### PR TITLE
fix(catalyst-api): reap orphaned CSI/EVS volumes on wipe with 429-throttle (#5028)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/janitor.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor.go
@@ -750,7 +750,13 @@ func (h *Handler) cleanOrphanEVSHuawei(tofuWorkDir string, activeIDs map[string]
 	if hp == nil {
 		return 0
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	// #5028 — the destructive reap now throttles deletes ≥~0.9s apart (the
+	// HCS EVS API rate-limits HARD → un-throttled bulk deletes 429 wholesale).
+	// A one-time backlog near the 400-volume quota therefore needs real
+	// wall-clock to drain, so widen the budget from 3m to 10m (≈600 deletes)
+	// — enough to clear a full backlog in a single pass. The next pass (5m
+	// later) continues anything still outstanding.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	activePrefixes := h.buildActivePrefixes()
 	deleted, err := hp.SweepOrphanEVS(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, activePrefixes, janitorDestructive(), func(msg string) {

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -583,6 +583,29 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 				report.Errors = append(report.Errors, wipeRes.Errors...)
 			}
 		}
+
+		// #5028 — POST-DESTROY EVS BACKSTOP. tofu destroy + the provider
+		// orphan-purge remove IaC-declared infra, but NOT the CSI-provisioned
+		// `pvc-*` EVS volumes (no dep name → invisible to the name-prefix
+		// purge). The #4677 drain releases them only when the cluster was
+		// still reachable; on an already-dead env it no-ops and the volumes
+		// strand as status=available, filling the HCS 400-volume quota after
+		// ~3 wipes and hard-blocking the next fresh prov's PVCs (413
+		// VolumeLimitExceeded). This is the "post-destroy cloud-GC backstop"
+		// wipe_drain.go promised: reap THIS dep's detached `pvc-*` volumes
+		// (throttled + 429-backoff), protecting every OTHER live dep.
+		if strings.EqualFold(providerName, "huawei") {
+			if hp := h.huaweiProvider("post-wipe-EVS"); hp != nil {
+				if creds, ok := huaweiSweepCredsFromRaw(credsRaw); ok {
+					reaped := h.reapDeploymentEVSBackstop(tofuCtx, hp, id, creds, func(msg string) {
+						emit("wipe", "info", "huawei: post-destroy EVS backstop: "+msg)
+					})
+					if reaped > 0 {
+						emit("wipe", "info", "huawei: post-destroy EVS backstop reaped "+itoa(reaped)+" detached CSI volume(s) tofu destroy left orphaned (#5028)")
+					}
+				}
+			}
+		}
 	}
 
 	if providerPurgeTotal(report.ProviderPurge) > 0 {

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop.go
@@ -1,0 +1,106 @@
+package handler
+
+// wipe_evs_backstop.go — #5028 post-destroy EVS backstop.
+//
+// THE LEAK this closes
+// ────────────────────
+// The canonical wipe runs `tofu destroy`, which removes only the
+// Terraform-declared infra (nodes, IaC disks, VPC/EIP/NAT/…). The CSI driver
+// (huawei-evs-csi) provisions ONE cloud EVS volume per PVC at RUNTIME, named
+// `pvc-<uuid>` with NO deployment identity — outside tofu state. `tofu
+// destroy` tears down the nodes before the in-cluster CSI controller can
+// delete those volumes, so every wipe strands them as status=available.
+//
+// #4677 (wipe_drain.go) drains the PVCs BEFORE tofu destroy so CSI releases
+// the volumes — but ONLY while the cluster's apiserver is still reachable. On
+// an already-dead env (or when CSI can't finish before the drain deadline)
+// the drain no-ops and its own comment promises "the post-destroy cloud-GC
+// (swept by detached-status, not name) is the backstop for that case." That
+// backstop was never wired into the wipe path: the ONLY caller of
+// SweepOrphanEVS was the periodic janitor, which is log-only unless
+// CATALYST_JANITOR_DESTRUCTIVE=true. So the stranded `pvc-*` volumes piled up
+// as available — 332 of the 400-volume HCS kom4dc quota after ~3 wipes,
+// hard-blocking the next fresh prov's PVCs (413 VolumeLimitExceeded) → no DB
+// → keycloak CrashLoop → convergence wedged (live on hw244, 2026-07-12).
+//
+// THE FIX
+// ───────
+// After tofu destroy, reap this deployment's now-detached `pvc-*` volumes
+// (SweepOrphanEVS, throttled + 429-backoff per #5028) while hard-protecting
+// EVERY OTHER live deployment: run buildActivePrefixes() (protect-by-default,
+// the #4454 fail-safe denylist) and remove ONLY the id being wiped so its
+// volumes become reclaimable. A volume of any OTHER live env — even one
+// momentarily detached mid-roll — stays protected. Because buildActivePrefixes
+// protects only NON-wiped records, this same pass also reaps any available
+// `pvc-*` left behind by a PRIOR partially-failed wipe, so quota cannot fill
+// across provs. `available` + zero-attachment + `pvc-` prefix is enforced in
+// isReclaimableOrphanEVS, so an in-use volume or the bastion is never touched.
+
+import (
+	"context"
+	"strings"
+)
+
+// evsReaper is the subset of the huawei provider the post-wipe EVS backstop
+// needs. *huawei.Provider satisfies it in production; tests supply a recording
+// fake so the wiring (right active set + destructive=true) is asserted without
+// an HCS endpoint.
+type evsReaper interface {
+	SweepOrphanEVS(ctx context.Context, ak, sk, projectID, region string,
+		activeDepIDPrefixes map[string]struct{}, destructive bool, progress func(msg string)) (int, error)
+}
+
+// activePrefixesForWipeBackstop returns the protect-by-default active-prefix
+// set with ONLY the deployment being wiped removed. Every other non-`wiped`
+// record stays protected (fail-safe), so the backstop reaps this dep's
+// detached volumes (and any orphaned-available `pvc-*` from previously-wiped
+// deps) but never a live neighbour's.
+func (h *Handler) activePrefixesForWipeBackstop(id string) map[string]struct{} {
+	active := h.buildActivePrefixes()
+	if len(id) >= 8 {
+		delete(active, id[:8])
+	}
+	return active
+}
+
+// reapDeploymentEVSBackstop runs the post-destroy EVS reap for the wiped
+// deployment. destructive is ALWAYS true here — the operator explicitly
+// invoked a wipe, so (unlike the background janitor's log-only default) the
+// backstop acts, exactly as VPCReclaimPreflight does for the in-band VPC
+// reclaim. Best-effort: an error is logged, never surfaced as a wipe failure.
+// Returns the number of volumes reaped.
+func (h *Handler) reapDeploymentEVSBackstop(ctx context.Context, reaper evsReaper, id string, creds huaweiSweepCreds, progress func(msg string)) int {
+	if reaper == nil || strings.TrimSpace(creds.AK) == "" || strings.TrimSpace(creds.SK) == "" || strings.TrimSpace(creds.ProjectID) == "" {
+		return 0
+	}
+	if progress == nil {
+		progress = func(string) {}
+	}
+	active := h.activePrefixesForWipeBackstop(id)
+	reaped, err := reaper.SweepOrphanEVS(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, active, true /*destructive — operator asked to wipe*/, progress)
+	if err != nil {
+		h.log.Warn("[WIPE] post-destroy EVS backstop error (#5028)", "err", err.Error(), "id", id)
+	}
+	return reaped
+}
+
+// huaweiSweepCredsFromRaw builds the sweep creds from the resolved wipe creds
+// map (buildWipeCredsRaw output). This is the reliable in-band source — the
+// per-deployment tfvars the janitor's discoverHuaweiCreds walks may already be
+// gone once tofu destroy has run. Returns ok=false when the triple is
+// incomplete (a non-huawei wipe, or missing creds).
+func huaweiSweepCredsFromRaw(raw map[string]string) (huaweiSweepCreds, bool) {
+	c := huaweiSweepCreds{
+		AK:        strings.TrimSpace(raw["access_key"]),
+		SK:        strings.TrimSpace(raw["secret_key"]),
+		ProjectID: strings.TrimSpace(raw["project_id"]),
+		Region:    strings.TrimSpace(raw["region"]),
+	}
+	if c.AK == "" || c.SK == "" || c.ProjectID == "" {
+		return huaweiSweepCreds{}, false
+	}
+	if c.Region == "" {
+		c.Region = "me-east-215"
+	}
+	return c, true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop_test.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// recordingEVSReaper captures the arguments the wipe path passes to
+// SweepOrphanEVS so the wiring (right active set + destructive=true) is
+// asserted without an HCS endpoint.
+type recordingEVSReaper struct {
+	called         bool
+	gotActive      map[string]struct{}
+	gotDestructive bool
+	gotRegion      string
+	ret            int
+}
+
+func (r *recordingEVSReaper) SweepOrphanEVS(_ context.Context, ak, sk, projectID, region string,
+	active map[string]struct{}, destructive bool, _ func(string)) (int, error) {
+	r.called = true
+	r.gotActive = active
+	r.gotDestructive = destructive
+	r.gotRegion = region
+	return r.ret, nil
+}
+
+// TestReapDeploymentEVSBackstop_UnprotectsWipedDepProtectsNeighbors — #5028.
+// The post-destroy backstop must reap the wiped deployment's now-detached
+// volumes (its prefix removed from the protected set) while every OTHER live
+// deployment stays protected — the fail-safe that stops it eating a live
+// neighbour's momentarily-detached PVCs (the b9f9590b self-destruct class).
+func TestReapDeploymentEVSBackstop_UnprotectsWipedDepProtectsNeighbors(t *testing.T) {
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	const wipedID = "aaaaaaaa11112222" // the dep being wiped
+	const neighborID = "bbbbbbbb33334444"
+	h.deployments.Store(wipedID, &Deployment{ID: wipedID, Status: "wiping"})
+	h.deployments.Store(neighborID, &Deployment{ID: neighborID, Status: "ready"})
+
+	reaper := &recordingEVSReaper{ret: 7}
+	creds := huaweiSweepCreds{AK: "ak", SK: "sk", ProjectID: "proj", Region: "me-east-215"}
+
+	got := h.reapDeploymentEVSBackstop(context.Background(), reaper, wipedID, creds, nil)
+
+	if !reaper.called {
+		t.Fatal("wipe path did NOT invoke the EVS backstop reap (#5028 — orphaned pvc-* volumes never reaped)")
+	}
+	if !reaper.gotDestructive {
+		t.Fatal("backstop must run destructive=true — the operator explicitly asked to wipe")
+	}
+	if got != 7 {
+		t.Fatalf("reaped count = %d, want 7 (return value not propagated)", got)
+	}
+	if _, protected := reaper.gotActive[neighborID[:8]]; !protected {
+		t.Fatalf("neighbour dep %q was NOT protected — the backstop could reap a live env's detached PVCs", neighborID[:8])
+	}
+	if _, stillProtected := reaper.gotActive[wipedID[:8]]; stillProtected {
+		t.Fatalf("wiped dep %q is STILL protected — its orphaned volumes would never be reaped (the #5028 leak)", wipedID[:8])
+	}
+	if reaper.gotRegion != "me-east-215" {
+		t.Fatalf("region = %q, want me-east-215", reaper.gotRegion)
+	}
+}
+
+// TestReapDeploymentEVSBackstop_NoOpOnMissingCredsOrReaper guards the
+// best-effort contract: a nil reaper or incomplete creds must no-op (never
+// panic, never a spurious reap).
+func TestReapDeploymentEVSBackstop_NoOpOnMissingCredsOrReaper(t *testing.T) {
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	full := huaweiSweepCreds{AK: "ak", SK: "sk", ProjectID: "proj", Region: "r"}
+
+	if n := h.reapDeploymentEVSBackstop(context.Background(), nil, "id0", full, nil); n != 0 {
+		t.Fatalf("nil reaper must no-op, reaped %d", n)
+	}
+
+	reaper := &recordingEVSReaper{ret: 3}
+	if n := h.reapDeploymentEVSBackstop(context.Background(), reaper, "id0", huaweiSweepCreds{AK: "ak"}, nil); n != 0 || reaper.called {
+		t.Fatalf("incomplete creds must no-op (reaped=%d called=%v)", n, reaper.called)
+	}
+}
+
+// TestHuaweiSweepCredsFromRaw locks the in-band cred source the backstop uses
+// (buildWipeCredsRaw output) + the region default.
+func TestHuaweiSweepCredsFromRaw(t *testing.T) {
+	// Complete triple + explicit region.
+	if c, ok := huaweiSweepCredsFromRaw(map[string]string{
+		"access_key": "ak", "secret_key": "sk", "project_id": "proj", "region": "me-east-999",
+	}); !ok || c.AK != "ak" || c.SK != "sk" || c.ProjectID != "proj" || c.Region != "me-east-999" {
+		t.Fatalf("complete creds mis-parsed: %+v ok=%v", c, ok)
+	}
+	// Missing region → default.
+	if c, ok := huaweiSweepCredsFromRaw(map[string]string{
+		"access_key": "ak", "secret_key": "sk", "project_id": "proj",
+	}); !ok || c.Region != "me-east-215" {
+		t.Fatalf("region default not applied: %+v ok=%v", c, ok)
+	}
+	// Incomplete triple → not ok (a non-huawei wipe's creds map).
+	if _, ok := huaweiSweepCredsFromRaw(map[string]string{"hcloud_token": "x"}); ok {
+		t.Fatal("hetzner creds map must not yield huawei sweep creds")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -2188,6 +2188,55 @@ func isReclaimableOrphanEVS(name, status string, attachmentCount int, metadata m
 	return true
 }
 
+// evsDeleteSpacing throttles consecutive EVS DELETE calls in the orphan
+// sweep. The HCS EVS API rate-limits HARD — deletes fired faster than
+// ~0.8s apart trip 429 ("too many 429 error responses") and a large backlog
+// (the 332-volume hw244 heal, #5028) fails wholesale. 900ms leaves margin
+// over the observed ~0.8s floor. Package var so tests run instantly.
+var evsDeleteSpacing = 900 * time.Millisecond
+
+// evsDelete429MaxRetries / evsDelete429BaseBackoff bound the per-volume
+// retry when a single DELETE still 429s despite the inter-call spacing (a
+// burst from a concurrent janitor pass, say). Exponential, ctx-interruptible.
+// Package vars so tests run instantly.
+var (
+	evsDelete429MaxRetries  = 5
+	evsDelete429BaseBackoff = 1 * time.Second
+)
+
+// deleteEVSVolume issues DELETE /v2/{project}/cloudvolumes/{id} with
+// retry-with-backoff on HTTP 429 (the HCS EVS hard rate-limit, #5028).
+// Returns the final HTTP status. A transport error aborts immediately; a
+// non-429 status (incl. 404 already-gone) returns straight away. Honours ctx
+// cancellation between retries so a wipe/janitor deadline is respected.
+func deleteEVSVolume(ctx context.Context, client *http.Client, hw hwCreds, region, projectID, volID string) (int, error) {
+	delURL := fmt.Sprintf("%s/v2/%s/cloudvolumes/%s", endpointFor("evs", region), projectID, volID)
+	backoff := evsDelete429BaseBackoff
+	var status int
+	var err error
+	for attempt := 0; ; attempt++ {
+		_, status, err = doSignedRequest(client, hw, http.MethodDelete, delURL, nil)
+		if err != nil {
+			return status, err
+		}
+		if status != http.StatusTooManyRequests {
+			return status, nil
+		}
+		// 429 — the rate-limit the un-throttled bulk reap tripped. Back off
+		// (exponential) and retry, unless we've exhausted the budget (the
+		// caller logs the residual 429; the periodic janitor retries later).
+		if attempt >= evsDelete429MaxRetries {
+			return status, nil
+		}
+		select {
+		case <-ctx.Done():
+			return status, ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+}
+
 // SweepOrphanEVS lists every EVS volume in the HCS project and reclaims
 // detached CSI `pvc-*` volumes that belong to no in-flight deployment
 // (#4466). It is the volume-tier sibling of SweepOrphanEIPs / Keypairs /
@@ -2238,10 +2287,24 @@ func (p *Provider) SweepOrphanEVS(ctx context.Context, ak, sk, projectID, region
 			deleted++
 			continue
 		}
-		delURL := fmt.Sprintf("%s/v2/%s/cloudvolumes/%s", endpointFor("evs", region), projectID, v.ID)
-		_, dstatus, derr := doSignedRequest(client, hw, http.MethodDelete, delURL, nil)
+		// #5028 — THROTTLE. The HCS EVS API rate-limits HARD: firing DELETEs
+		// back-to-back on a large backlog trips 429 ("too many 429 error
+		// responses") and the reap fails wholesale (live: the 332-volume
+		// hw244 heal could not run un-throttled). Space consecutive deletes
+		// ≥evsDeleteSpacing apart, ctx-interruptible so a wipe/janitor
+		// deadline still bounds the pass.
+		select {
+		case <-ctx.Done():
+			return deleted, ctx.Err()
+		case <-time.After(evsDeleteSpacing):
+		}
+		dstatus, derr := deleteEVSVolume(ctx, client, hw, region, projectID, v.ID)
 		if derr != nil {
 			progress(fmt.Sprintf("sweep orphan EVS %s: DELETE failed: %v", v.Name, derr))
+			continue
+		}
+		if dstatus == http.StatusTooManyRequests {
+			progress(fmt.Sprintf("sweep orphan EVS %s: still 429 after %d backoff retries — leaving for the next pass", v.Name, evsDelete429MaxRetries))
 			continue
 		}
 		if dstatus >= 400 && dstatus != http.StatusNotFound {

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/sweep_orphan_evs_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/sweep_orphan_evs_test.go
@@ -7,8 +7,28 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/providers"
 )
+
+// neutralizeEVSThrottle zeroes the inter-delete spacing + backoff so the
+// destructive-path tests run instantly. #5028 added a ≥~0.9s spacing and a
+// 1s-base 429 backoff to protect against the HCS EVS hard rate-limit; tests
+// exercise the LOGIC, not the wall-clock, so we drive both to ~0 and restore.
+func neutralizeEVSThrottle(t *testing.T) {
+	t.Helper()
+	origSpacing, origBackoff, origRetries := evsDeleteSpacing, evsDelete429BaseBackoff, evsDelete429MaxRetries
+	evsDeleteSpacing = 0
+	evsDelete429BaseBackoff = 0
+	t.Cleanup(func() {
+		evsDeleteSpacing = origSpacing
+		evsDelete429BaseBackoff = origBackoff
+		evsDelete429MaxRetries = origRetries
+	})
+}
 
 // fakeHCSEVS stands up a httptest server that mimics the EVS detail-list +
 // per-volume DELETE endpoints, overrides the package `endpointFor` to route
@@ -76,6 +96,7 @@ func TestSweepOrphanEVS_LogOnlyReapsNothing(t *testing.T) {
 // sweep deletes ONLY the genuine orphan; the in-use + bastion volumes are
 // never touched.
 func TestSweepOrphanEVS_DestructiveReapsOrphanOnly(t *testing.T) {
+	neutralizeEVSThrottle(t)
 	var deleted []string
 	restore := fakeHCSEVS(t, evsListFixture, &deleted)
 	defer restore()
@@ -95,6 +116,7 @@ func TestSweepOrphanEVS_DestructiveReapsOrphanOnly(t *testing.T) {
 // metadata carries an in-flight deployment-ID prefix is protected EVEN with
 // the destructive flag set.
 func TestSweepOrphanEVS_ActiveDepNeverReaped(t *testing.T) {
+	neutralizeEVSThrottle(t)
 	listBody := fmt.Sprintf(`{"volumes":[
 	  {"id":"vol-live-1","name":"pvc-live","status":"available","attachments":[],"metadata":{"cluster_id":"catalyst-x-%s-cluster"}}
 	]}`, "5b413990")
@@ -241,5 +263,148 @@ func TestIsReclaimableOrphanEVS_NoActiveProvs(t *testing.T) {
 	}
 	if isReclaimableOrphanEVS("bastion-openova-root", "available", 0, nil, empty) {
 		t.Fatal("a bastion disk must stay protected even with an empty active set")
+	}
+}
+
+// fakeHCS429EVS stands up an EVS DELETE endpoint that returns HTTP 429 for the
+// first `fail429` DELETE calls (any volume), then 202. Records the attempt
+// count so a test can assert the #5028 backoff retried the right number of
+// times. Returns a restore func.
+func fakeHCS429EVS(t *testing.T, fail429 int, attempts *int32) func() {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/cloudvolumes/") {
+			n := atomic.AddInt32(attempts, 1)
+			if int(n) <= fail429 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	host := strings.TrimPrefix(srv.URL, "https://")
+	orig := endpointFor
+	endpointFor = func(service, region string) string { return "https://" + host }
+	return func() {
+		endpointFor = orig
+		srv.Close()
+	}
+}
+
+// TestDeleteEVSVolume_429Backoff — #5028 core: the HCS EVS API rate-limits
+// HARD (429). deleteEVSVolume MUST retry-with-backoff on 429 up to the budget
+// and give up gracefully (returning the residual 429) rather than treating the
+// first 429 as a fatal failure. Table-tests the attempt accounting with the
+// wall-clock backoff neutralised.
+func TestDeleteEVSVolume_429Backoff(t *testing.T) {
+	cases := []struct {
+		name         string
+		fail429      int
+		maxRetries   int
+		wantAttempts int32
+		wantStatus   int
+	}{
+		{"succeeds on first try", 0, 5, 1, http.StatusAccepted},
+		{"429 twice then 202 (retries succeed)", 2, 5, 3, http.StatusAccepted},
+		{"429 forever exhausts the budget", 99, 3, 4 /*1 initial + 3 retries*/, http.StatusTooManyRequests},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origBackoff, origRetries := evsDelete429BaseBackoff, evsDelete429MaxRetries
+			evsDelete429BaseBackoff = 0 // no wall-clock in tests
+			evsDelete429MaxRetries = tc.maxRetries
+			defer func() {
+				evsDelete429BaseBackoff = origBackoff
+				evsDelete429MaxRetries = origRetries
+			}()
+
+			var attempts int32
+			restore := fakeHCS429EVS(t, tc.fail429, &attempts)
+			defer restore()
+
+			client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": "me-east-215"}})
+			status, err := deleteEVSVolume(context.Background(), client,
+				hwCreds{AccessKey: "ak", SecretKey: "sk", ProjectID: "proj"}, "me-east-215", "proj", "vol-x")
+			if err != nil {
+				t.Fatalf("deleteEVSVolume: %v", err)
+			}
+			if status != tc.wantStatus {
+				t.Fatalf("final status = %d, want %d", status, tc.wantStatus)
+			}
+			if got := atomic.LoadInt32(&attempts); got != tc.wantAttempts {
+				t.Fatalf("DELETE attempts = %d, want %d (429-retry budget not honoured)", got, tc.wantAttempts)
+			}
+		})
+	}
+}
+
+// TestSweepOrphanEVS_ThrottlesConsecutiveDeletes proves the #5028 throttle is
+// actually applied on the destructive path: two genuine orphans reaped with a
+// 50ms spacing must take at least one spacing interval (un-throttled the two
+// DELETEs are sub-millisecond). Without the throttle a 332-volume backlog
+// 429s wholesale — this is the regression guard for that.
+func TestSweepOrphanEVS_ThrottlesConsecutiveDeletes(t *testing.T) {
+	origSpacing, origBackoff := evsDeleteSpacing, evsDelete429BaseBackoff
+	evsDeleteSpacing = 50 * time.Millisecond
+	evsDelete429BaseBackoff = 0
+	defer func() {
+		evsDeleteSpacing = origSpacing
+		evsDelete429BaseBackoff = origBackoff
+	}()
+
+	listBody := `{"volumes":[
+	  {"id":"vol-o1","name":"pvc-o1","status":"available","attachments":[],"metadata":{}},
+	  {"id":"vol-o2","name":"pvc-o2","status":"available","attachments":[],"metadata":{}}
+	]}`
+	var deleted []string
+	restore := fakeHCSEVS(t, listBody, &deleted)
+	defer restore()
+
+	p := New()
+	start := time.Now()
+	n, err := p.SweepOrphanEVS(context.Background(), "ak", "sk", "proj", "me-east-215",
+		map[string]struct{}{}, true /*destructive*/, nil)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("SweepOrphanEVS: %v", err)
+	}
+	if n != 2 || len(deleted) != 2 {
+		t.Fatalf("reaped n=%d deleted=%v, want exactly 2", n, deleted)
+	}
+	if elapsed < evsDeleteSpacing {
+		t.Fatalf("2-delete sweep took %s — the #5028 throttle was not applied (want ≥ %s)", elapsed, evsDeleteSpacing)
+	}
+}
+
+// TestSweepOrphanEVS_ThrottleRespectsContext proves the throttle honours the
+// wipe/janitor deadline: with a long spacing and an already-cancelled context,
+// the sweep returns ctx.Err() immediately without deleting anything (rather
+// than blocking the whole spacing interval).
+func TestSweepOrphanEVS_ThrottleRespectsContext(t *testing.T) {
+	origSpacing := evsDeleteSpacing
+	evsDeleteSpacing = time.Hour // would block forever if the ctx weren't honoured
+	defer func() { evsDeleteSpacing = origSpacing }()
+
+	listBody := `{"volumes":[
+	  {"id":"vol-o1","name":"pvc-o1","status":"available","attachments":[],"metadata":{}}
+	]}`
+	var deleted []string
+	restore := fakeHCSEVS(t, listBody, &deleted)
+	defer restore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	p := New()
+	_, err := p.SweepOrphanEVS(ctx, "ak", "sk", "proj", "me-east-215",
+		map[string]struct{}{}, true /*destructive*/, nil)
+	if err == nil {
+		t.Fatal("expected ctx.Err() from the throttle wait, got nil")
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("cancelled sweep deleted %v — must stop before the DELETE", deleted)
 	}
 }


### PR DESCRIPTION
## Problem (Refs #5028)

The canonical wipe (`POST /deployments/{id}/wipe` → `tofu destroy`) removes only IaC-declared resources. The evs-csi driver provisions one dynamically-provisioned `pvc-*` EVS volume per PVC (CNPG/harbor/openbao/…) at **runtime**, outside tofu state and with **no deployment identity in the name**. `tofu destroy` tears down the nodes before the in-cluster CSI controller can delete those volumes, so every wipe strands them as `status=available`.

The #4677 drain-before-destroy releases them **only while the cluster is still reachable**; on an already-dead env it no-ops and its comment promised a *"post-destroy cloud-GC backstop (swept by detached-status, not name)"* — **which was never wired into the wipe path.** The only caller of `SweepOrphanEVS` was the periodic janitor, which is **log-only** unless `CATALYST_JANITOR_DESTRUCTIVE=true`.

**Live proof (hw244, 2026-07-12):** after hw241/242/243 wipes, **332 of 400** volumes were orphaned `available` → hw244's new PVCs got **413 VolumeLimitExceeded** → no DB → keycloak CrashLoop → convergence wedged.

## Root-cause mechanism

Combination of **(a)** and **(c)** from the issue:
- **(a)** `SweepOrphanEVS` is **not invoked on the wipe path** — the provider `Wipe()`/`purgeHuaweiResources` sweeps ECS/ELB/NAT/EIP/SG/VPC/keypair but has no EVS-volume sweep; the promised backstop was a phantom.
- **(c)** `SweepOrphanEVS`'s delete loop was **un-throttled** — the HCS EVS API rate-limits HARD (429; the live 332-volume heal hit *"too many 429 error responses"* at ~0.8s spacing), so even the janitor-armed path would 429-fail on a large backlog.

## Changes

- **`provider.go`** — throttle `SweepOrphanEVS` deletes ≥~0.9s apart + per-volume **retry-with-exponential-backoff on 429** (`deleteEVSVolume`), ctx-interruptible so wipe/janitor deadlines are honoured. Only `status=available` + zero-attachment + `pvc-` volumes are ever eligible (existing `isReclaimableOrphanEVS`).
- **`wipe.go` + `wipe_evs_backstop.go`** — wire the **post-destroy EVS backstop**: after tofu destroy, reap **this dep's** detached `pvc-*` volumes (destructive — the operator asked to wipe) while protecting **every other live dep** via `buildActivePrefixes()` minus the wiped dep (the #4454 fail-safe). Because only non-`wiped` records are protected, the same pass also reaps leftovers from prior partially-failed wipes → **quota can't fill across provs**. In-use volumes and the bastion are never touched.
- **`janitor.go`** — the standing periodic EVS sweep already exists (`cleanOrphanEVSHuawei`); budget widened 3m→10m so a one-time near-quota backlog clears in a single throttled pass.

## Tests (`go build ./...` + `go test ./internal/providers/huawei/...` + `./internal/handler/...` green)

- `TestDeleteEVSVolume_429Backoff` — table-test: succeed-first-try / 429-twice-then-succeed / 429-forever-exhausts-budget (attempt accounting).
- `TestSweepOrphanEVS_ThrottlesConsecutiveDeletes` + `_ThrottleRespectsContext` — throttle applied + deadline honoured.
- `TestReapDeploymentEVSBackstop_*` + `TestHuaweiSweepCredsFromRaw` — wipe path invokes the reap `destructive=true`, un-protects the wiped dep, protects neighbours.
- Existing available-only / active-dep-protected EVS tests retained (throttle neutralised for speed).

**This is a catalyst-api Go change → needs a mothership roll to take effect.** Do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)