### PR TITLE
fix(cutover): step-03 prewarm durable Harbor artifact-API dest probe (Refs #5030)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -825,7 +825,13 @@ spec:
       # offline-mirror coverage map + NEW step-08 pre-hold ref-host lint that
       # fails loud on ANY residual tether ref (velero-hcs/cnpg on hw243) —
       # surfaces the whole un-pivoted set in one prov (treadmill-breaker).
-      version: 0.1.123
+      # 0.1.124 (#5030): step-03 harbor-prewarm dest_already_current() now probes
+      # the DEST via the Harbor artifact API (durable, never pull-through) instead
+      # of `skopeo inspect --raw` — which pull-throughs on a proxy-cache dest and
+      # false-skipped an image step-08's completeness gate then 404'd (hw244
+      # otel-operator; hw243 velero/cnpg). prewarm skip can no longer diverge from
+      # the gate that judges it.
+      version: 0.1.124
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.123
+  version: 0.1.124
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.124 (#5030 Refs #3379 #4994 #4975 #5026 — hw244, dep b16a43ac: step-03
+# harbor-prewarm's #4994 dest_already_current() idempotency probe used
+# `skopeo inspect --raw` against the DESTINATION registry endpoint — a
+# registry-protocol read that PULL-THROUGHS on a proxy-cache-reachable dest while
+# egress is still up during prewarm. It saw a byte-identical (pulled-through)
+# manifest for an image NEVER durably pushed, false-"current"-SKIPPED the real
+# `skopeo copy`, and logged (ok); after step-08's deny-egress hold the image 404'd
+# and the pre-hold completeness gate FAILED → cutoverComplete never reached (live
+# hw244 opentelemetry-operator:0.101.0; same class as hw243 velero/cnpg — #5026
+# fixed only the host-pivot leg). FIX: dest_already_current now probes the DEST
+# via the Harbor ARTIFACT API (GET /api/v2.0/projects/<proj>/repositories/<repo>/
+# artifacts/<ref>) — served by Harbor CORE against its DB, so it reflects ONLY
+# durably-stored artifacts and CANNOT pull through at any cutover phase — the SAME
+# durable presence step-08's gate asserts, so a prewarm skip can never diverge
+# from the gate. Src digest still from `skopeo inspect --raw` on the SOURCE; skip
+# ONLY on a real durable digest match; fail-CLOSED (404/absent/error → real copy).
+# Nested repo names double-encode `/`->%252F (in-cluster gateway decodes one URL
+# layer). Validated live hw244: artifact-API digest == registry-v2 == source for a
+# present image; 404 for the missing otel-operator.)
 # 0.1.123 (#5026 Refs #5010 #4977 #3379 — hw243, the FIRST run to reach step-08:
 # the pre-hold completeness gate correctly FAILED because velero-hcs + cnpg
 # pod-specs still referenced harbor.openova.io/proxy-* (the MOTHERSHIP Harbor, a
@@ -1959,7 +1978,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.123
+version: 0.1.124
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -170,19 +170,24 @@ data:
           # disable override. The key is always present in values.yaml.
           - name: SETTLED_ROLL_PREFLIGHT
             value: {{ .Values.prewarm.settledRollPreflight.enabled | quote }}
-          # #4994 (Refs #3379) — content-digest idempotency. When true (default)
-          # each skopeo copy first compares the SOURCE vs DEST manifest digest
-          # (`skopeo inspect --raw | sha256sum` — the sha256 of the exact manifest
-          # bytes IS the digest, for single-arch AND multi-arch LISTS, fetched
-          # WITHOUT pulling a single blob) and SKIPS the copy when local Harbor
-          # already serves byte-identical content. A prewarm RE-RUN (catalyst-api
-          # re-fires the step after a DeadlineExceeded) or an already-mirrored
-          # image then costs a cheap manifest HEAD instead of re-transferring
-          # every multi-hundred-MB blob from the mothership (the hw240 #4994
-          # "step-03 Running 0/1 for 68m" symptom). Fail-OPEN: any inspect miss
-          # (source or dest unreachable/absent/partial) FALLS THROUGH to the full
-          # copy, so the fail-closed completeness contract is preserved — a skip
-          # happens ONLY on a positive src==dst match. Set false to force re-copy.
+          # #4994 (Refs #3379), #5030 — content-digest idempotency. When true
+          # (default) each skopeo copy first compares the SOURCE manifest digest
+          # (`skopeo inspect --raw | sha256sum` on the SOURCE — the sha256 of the
+          # exact manifest bytes IS the digest, single-arch AND multi-arch LISTS,
+          # no blob pulled) against the DEST's DURABLE digest and SKIPS the copy
+          # only on a real match. #5030: the DEST digest now comes from the Harbor
+          # ARTIFACT API (GET /api/v2.0/.../artifacts/<ref>, served by Harbor CORE
+          # against its DB — NEVER pull-through), NOT `skopeo inspect --raw` on the
+          # dest registry endpoint, which pull-throughs on a proxy-cache-reachable
+          # dest and false-"current"-skipped an image the step-08 gate then 404'd
+          # (hw244 otel-operator; hw243 velero/cnpg). A prewarm RE-RUN (catalyst-api
+          # re-fires the step after a DeadlineExceeded) or an already-mirrored image
+          # then costs a cheap API GET instead of re-transferring every
+          # multi-hundred-MB blob from the mothership (the hw240 #4994 "step-03
+          # Running 0/1 for 68m" symptom). Fail-CLOSED: any miss (source
+          # unreachable, dest 404/absent/partial, API error, empty/mismatched dest
+          # digest) FALLS THROUGH to the full copy — a skip happens ONLY on a
+          # positive durable src==dst match. Set false to force re-copy.
           - name: PREWARM_SKIP_IF_PRESENT
             value: {{ .Values.prewarm.skipIfAlreadyPresent | quote }}
         volumeMounts:
@@ -550,22 +555,49 @@ data:
               esac
             }
 
-            # #4994 (Refs #3379) — content-digest idempotency probe. Returns 0
-            # (SKIP the copy) only when the local Harbor DEST already serves
-            # byte-identical manifest content as the SOURCE. `skopeo inspect --raw`
-            # streams the exact manifest (or manifest LIST) bytes the registry
-            # serves; their sha256 IS the manifest digest — correct for single-arch
-            # AND multi-arch, and it pulls NO blob. Comparing the two inspect-raw
-            # shas to each other (not to a precomputed digest) is robust to any
-            # consistent skopeo formatting. Fail-CLOSED to a full copy on ANY miss:
-            # an empty source sha (upstream unreachable) or a mismatched/empty dest
-            # sha (absent / partial / single-arch leftover from the pre-#4975 bug)
-            # both return non-zero → the caller does the real copy. So the
-            # fail-closed completeness contract is untouched; this only elides a
-            # redundant re-transfer.
+            # #5030 (Refs #3379 #4994 #4975) — DURABLE dest-presence idempotency
+            # probe. Returns 0 (SKIP the copy) ONLY when the local Harbor DEST
+            # already serves the SAME manifest DURABLY (pushed into Harbor's own
+            # store), never on a transient pull-through.
+            #
+            # WHY the #4994 shape was WRONG: it proved dest presence with
+            # `skopeo inspect --raw` on the DESTINATION registry endpoint — a
+            # REGISTRY-PROTOCOL read that returns whatever registry.<fqdn> serves
+            # for the ref AT THAT MOMENT. During prewarm (step-03) egress is still
+            # up and the dest ref resolves through a pull-through-reachable path
+            # (a Harbor proxy-cache leg / an upstream still auth'd), so that
+            # inspect PULLS THE MANIFEST THROUGH from upstream and returns
+            # byte-identical bytes for an image that was NEVER durably pushed →
+            # src==dst → false "current" → the real `skopeo copy` is SKIPPED and
+            # the image logs (ok). The pull-through persists only the manifest, no
+            # blobs; after step-08's deny-egress hold the image 404s and step-08's
+            # completeness gate FAILS → cutoverComplete is never reached. Live
+            # hw244: proxy-ghcr/open-telemetry/opentelemetry-operator:0.101.0
+            # (durable Harbor artifact API returned NOT_FOUND while the dest
+            # inspect pull-throughs). Same class killed hw243 (velero/cnpg; #5026
+            # fixed only the host-pivot leg).
+            #
+            # FIX: probe the DEST via the Harbor ARTIFACT API
+            # (GET /api/v2.0/projects/<proj>/repositories/<repo>/artifacts/<ref>) —
+            # served by Harbor CORE against its DATABASE, so it reflects ONLY
+            # durably-stored artifacts and CANNOT pull through at ANY cutover phase.
+            # This is the SAME durable-presence assertion step-08's completeness
+            # gate makes, so a step-03 skip can NEVER diverge from the gate that
+            # then judges it. The SOURCE digest still comes from `skopeo inspect
+            # --raw` on the SOURCE (source pull-through is irrelevant — that IS the
+            # manifest we mirror FROM; its sha256 IS the manifest/-list digest, no
+            # blob pulled, correct for single-arch AND multi-arch). Skip ONLY on a
+            # real durable digest MATCH. Fail-CLOSED on ANY ambiguity: empty source
+            # sha (upstream unreachable), 404/absent/partial dest, curl/API error,
+            # or empty/mismatched dest digest all return non-zero → the caller does
+            # the real copy. So the fail-closed completeness contract is UNTOUCHED;
+            # this only elides a genuinely-redundant re-transfer.
             dest_already_current() {
-              # $1 upstream ref  $2 local dest ref  $3 src creds (may be empty)
-              _dc_up="$1"; _dc_lref="$2"; _dc_sc="$3"
+              # $1 upstream ref  $2 local dest ref (either the resolver PATH
+              #    project/repo[:tag|@digest] OR a HARBOR_HOST-prefixed lref)
+              #    $3 src creds (may be empty)
+              _dc_up="$1"; _dc_dref="$2"; _dc_sc="$3"
+              # SOURCE manifest digest (sha256 of the raw manifest/-list bytes).
               if [ -n "${_dc_sc}" ]; then
                 _dc_s=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
                   --creds="${_dc_sc}" --tls-verify=true "docker://${_dc_up}" 2>/dev/null \
@@ -576,10 +608,38 @@ data:
                   | sha256sum 2>/dev/null | awk '{print $1}')
               fi
               [ -z "${_dc_s}" ] && return 1
-              _dc_d=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
-                --creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                --tls-verify="${PREWARM_DEST_TLS_VERIFY}" "docker://${_dc_lref}" 2>/dev/null \
-                | sha256sum 2>/dev/null | awk '{print $1}')
+              _dc_s="sha256:${_dc_s}"
+              # Accept either a bare resolver path or a HARBOR_HOST-prefixed lref.
+              _dc_pp="${_dc_dref#${HARBOR_HOST}/}"
+              # Split the local path into project / repository / reference.
+              _dc_ref="latest"
+              case "${_dc_pp}" in
+                *@*)
+                  _dc_ref="${_dc_pp##*@}"; _dc_pp="${_dc_pp%@*}"
+                  case "${_dc_pp##*/}" in *:*) _dc_pp="${_dc_pp%:*}" ;; esac ;;
+                *)
+                  case "${_dc_pp##*/}" in *:*) _dc_ref="${_dc_pp##*:}"; _dc_pp="${_dc_pp%:*}" ;; esac ;;
+              esac
+              # project = first path segment; repository = the (possibly nested) rest.
+              case "${_dc_pp}" in
+                */*) _dc_proj="${_dc_pp%%/*}"; _dc_repo="${_dc_pp#*/}" ;;
+                *)   _dc_proj="${_dc_pp}";     _dc_repo="" ;;
+              esac
+              # No repository segment → cannot address an artifact → fail-closed (copy).
+              [ -z "${_dc_repo}" ] && return 1
+              # Harbor's artifact API needs the nested repo name's `/` encoded as
+              # %2F. The in-cluster gateway decodes ONE URL layer before Harbor, so
+              # DOUBLE-encode (`/` -> %252F) so Harbor receives %2F and routes the
+              # nested repository correctly (validated live hw244 #5030: single-
+              # encoded 404s the route; double-encoded 200s with the durable digest).
+              _dc_repo_enc=$(printf '%s' "${_dc_repo}" | sed 's#/#%252F#g')
+              # Durable DEST digest from Harbor CORE (never pull-through). -k: the
+              # local Harbor cert is LE-staging/untrusted on a fresh prov (same
+              # rationale as step-08's `curl -sk` completeness HEAD).
+              _dc_d=$(curl -sk --max-time 30 \
+                -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                "${HARBOR_PUBLIC_URL}/api/v2.0/projects/${_dc_proj}/repositories/${_dc_repo_enc}/artifacts/${_dc_ref}" 2>/dev/null \
+                | jq -r '.digest // empty' 2>/dev/null)
               [ -n "${_dc_d}" ] && [ "${_dc_s}" = "${_dc_d}" ]
             }
 
@@ -961,9 +1021,12 @@ data:
               # as the Phase-B PREWARM_COPY_ATTEMPTS image path) turns a
               # transient dest 504 into a bounded retry instead of a cutover-
               # killing FATAL.
-              # #4994 idempotency: skip when local Harbor already serves this exact
-              # chart artifact (re-run / already-mirrored). The chart OCI is a single
-              # manifest; compare src vs dst raw-manifest sha (no blob pull).
+              # #4994 idempotency (#5030 durable): skip when local Harbor already
+              # serves this exact chart artifact (re-run / already-mirrored). The
+              # chart OCI is a single manifest; dest_already_current compares the
+              # SOURCE raw-manifest sha against the DEST's Harbor artifact-API digest
+              # (durable, never pull-through) — the HARBOR_HOST prefix is stripped
+              # inside the function, so the openova-io/<chart>:<ver> path resolves.
               if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ] \
                  && dest_already_current "${up_chart_prefix}/${cchart}:${cver}" "${HARBOR_HOST}/openova-io/${cchart}:${cver}" "${ghcr_user}:${ghcr_pat}"; then
                 echo "[harbor-prewarm] skip chart ${cchart}:${cver} (dest already current)"

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1604,7 +1604,7 @@ if ! grep -A1 'name: SETTLED_ROLL_PREFLIGHT' "$TMP/prewarm_a0_block.txt" | grep 
 fi
 echo "  PASS (Step-03 Phase A0 settled-roll pre-flight fail-closes on a mid-roll env before the mirror is built; default enabled)"
 
-echo "[cutover-contract] Case 42: Step-03 harbor-prewarm is idempotent (skip-if-already-present) + streams real-time progress so it can't silently hang (#4994, Refs #3379)"
+echo "[cutover-contract] Case 42: Step-03 harbor-prewarm is idempotent (skip-if-already-present, #5030 DURABLE dest probe) + streams real-time progress so it can't silently hang (#4994, Refs #3379)"
 # hw240 (#4994): step-03 sat Running 0/1 for 68m re-pushing ~121 proxy-* images
 # from the mothership, logging ONLY `queue` lines — the per-image copy logs were
 # file-buffered and only surfaced after the whole `wait`, so a slow-but-working
@@ -1626,7 +1626,19 @@ if ! grep -q 'dest_already_current()' "$TMP/prewarm_4994.txt"; then
   exit 1
 fi
 if ! grep -q 'inspect --raw' "$TMP/prewarm_4994.txt"; then
-  echo "FAIL: Step-03 idempotency does not use 'skopeo inspect --raw' (the no-blob-pull manifest-digest compare) (#4994)" >&2
+  echo "FAIL: Step-03 idempotency does not use 'skopeo inspect --raw' (the no-blob-pull SOURCE manifest-digest compare) (#4994)" >&2
+  exit 1
+fi
+# #5030 — the DEST-side presence check MUST be the Harbor artifact API (served by
+# Harbor CORE against its DB — durable, NEVER pull-through), NOT `skopeo inspect
+# --raw` on the dest registry endpoint (which pull-throughs on a proxy-cache-
+# reachable dest while egress is still up during prewarm, sees a byte-identical
+# manifest for an image NEVER durably pushed, and false-"current"-SKIPs the real
+# copy → step-08's completeness gate then 404s it under the deny-egress hold →
+# cutoverComplete never reached; hw244 otel-operator, hw243 velero/cnpg). Lock the
+# durable probe in so a refactor can't silently revert to the pull-through inspect.
+if ! grep -Eq 'api/v2\.0/projects/.*/repositories/.*/artifacts/' "$TMP/prewarm_4994.txt"; then
+  echo "FAIL: Step-03 dest_already_current() does not probe the DEST via the durable Harbor artifact API (GET /api/v2.0/projects/<proj>/repositories/<repo>/artifacts/<ref>) — a proxy-cache pull-through can false-skip a copy the step-08 gate then 404s (#5030)" >&2
   exit 1
 fi
 if ! grep -q 'progress_heartbeat' "$TMP/prewarm_4994.txt"; then

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.123"
+  version: "0.1.124"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.123"
+    version: "0.1.124"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

Cutover **step-03 harbor-prewarm** can report an image `(ok)` **without durably mirroring it**. Its `dest_already_current()` idempotency probe (`03-harbor-prewarm-job.yaml`, #4994) proved dest presence with `skopeo inspect --raw` against the **destination registry endpoint** — a registry-protocol read that **PULL-THROUGHS** on a proxy-cache-reachable dest while egress is still up during prewarm. It saw a byte-identical (pulled-through) manifest for an image **never durably pushed**, `dest_already_current` returned 0 → the real `skopeo copy` was **SKIPPED**. After step-08's deny-egress hold the image 404s → **step-08 offline-mirror completeness gate FAILS** → `cutoverComplete` never reached (Pillar 5 keystone gate failure).

Regression class, not a one-off: live **hw244** `opentelemetry-operator:0.101.0`; same shape as **hw243** velero-hcs/cnpg (#5026 fixed only the *host-pivot* leg — this dest-check leg is the remaining root).

## Fix

Make prewarm's dest-presence probe **identical in durability to step-08's completeness gate** so a prewarm skip can never diverge from the gate that then judges it:

- `dest_already_current()` now probes the DEST via the **Harbor artifact API** `GET /api/v2.0/projects/<proj>/repositories/<repo>/artifacts/<ref>` — served by Harbor CORE against its DB, so it reflects **only durably-stored artifacts** and **cannot pull through at any cutover phase**.
- The **source** digest still comes from `skopeo inspect --raw` on the SOURCE (source pull-through is irrelevant — that IS the manifest we mirror from). Skip **only** on a real durable digest match.
- **Fail-CLOSED** on any ambiguity (404 / absent / partial / API error / empty-or-mismatched digest) → do the real copy. `--multi-arch all` (#4975) + all retry/timeout logic preserved.
- Nested repo names **double-encode** `/`→`%252F` (the in-cluster gateway decodes one URL layer before Harbor). The `${HARBOR_HOST}/` prefix is stripped inside the function so both callers (Phase-A image copy + Phase-A2 chart copy) work unchanged.

## Live root-cause confirmation (hw244, dep b16a43ac)

| probe | missing `otel-operator:0.101.0` | present `stakater/reloader:v1.4.16` |
|---|---|---|
| Harbor artifact API (durable, new dest probe) | **404 NOT_FOUND** | **200**, `digest sha256:4e0d…` |
| registry v2 manifest HEAD (step-08's probe) | 404 | 200, same digest |
| source `skopeo inspect --raw` | — | `sha256:4e0d…` (matches) |

End-to-end test of the **new function** on live hw244:
- missing otel-operator → artifact API 404 → **`return 1` COPY** (bug fixed; step-08 gate will pass)
- present reloader → durable digest match → **`return 0` SKIP** (#4994 idempotency preserved)

## Tests

- `helm template` renders clean (8153 lines); the durable probe renders in the step-03 CM.
- `tests/cutover-contract.sh` — **all gates green**, incl. Case 42 which gains a **#5030 regression guard** asserting the dest probe uses the durable artifact API (`/api/v2.0/projects/.../repositories/.../artifacts/`).
- `tests/image-registry-coverage.sh` — PASS.
- Path-parsing unit-tested across 6 ref shapes (tag / digest / nested / single-segment / HARBOR_HOST-prefixed) under both `dash` and `busybox ash`.

## Chart

`0.1.123` → **`0.1.124`**; lockstep pins bumped in `bootstrap-kit/06a`, `blueprint.yaml`, `catalog-seed/blueprints.yaml`.

Refs #5030 #3379 #4994 #4975 #5026

🤖 Generated with [Claude Code](https://claude.com/claude-code)
