### PR TITLE
fix(pdm): route marketplace.<fqdn> at the console LB in the delegated child zone (Refs #5034)

### DIFF
--- a/core/pool-domain-manager/internal/allocator/allocator.go
+++ b/core/pool-domain-manager/internal/allocator/allocator.go
@@ -565,17 +565,31 @@ func childZoneName(poolDomain, subdomain string) string {
 //	*            A   <lb>          (wildcard for ad-hoc subdomains)
 //	console      A   <consoleLB>   (#4053 — isolated console gateway)
 //	api          A   <consoleLB>   (#4053 — isolated console gateway)
+//	marketplace  A   <consoleLB>   (#4053/#5034 — isolated console gateway)
 //	gitea        A   <lb>
 //	harbor       A   <lb>
-//	marketplace  A   <lb>
 //
-// #4053 — the `console` and `api` names point at consoleLBIP (the dedicated
-// console LB → cilium-gateway-console) so a poisoned SHARED-gateway CEC can
-// never 404 the console. When consoleLBIP is empty (a provisioner or a
-// deployment record that pre-dates #4053), it falls back to lbIP for those two
-// names too — making the record set byte-identical to the legacy single-LB
-// payload. Every other name (apex, wildcard, gitea, harbor, marketplace) always
-// points at lbIP (the shared gateway) regardless.
+// #4053 — the console-gateway names point at consoleLBIP (the dedicated console
+// LB → cilium-gateway-console) so a poisoned SHARED-gateway CEC can never 404
+// the console front doors. When consoleLBIP is empty (a provisioner or a
+// deployment record that pre-dates #4053), they fall back to lbIP too — making
+// the record set byte-identical to the legacy single-LB payload.
+//
+// #5034 — the console-gateway set is console + api + MARKETPLACE. Marketplace's
+// HTTPRoute parents cilium-gateway-console (products/catalyst/chart/templates/
+// org-services/marketplace-routes.yaml inherits the console-gateway parentRef
+// default) exactly like console/api, so its A-record MUST ride consoleLBIP too.
+// This mirrors catalyst-api's authoritative ConsoleGatewaySubdomains =
+// {console, api, marketplace} in sovereign_dns_records.go — the two DNS writers
+// (catalyst-api's parent-zone upsert + PDM's delegated child zone) MUST agree,
+// and for a pool Sovereign the delegated child zone is the AUTHORITATIVE answer
+// (it occludes the parent-zone records below the zone cut). Before this, PDM
+// left marketplace on lbIP → marketplace.<fqdn> resolved the SHARED gateway and
+// 404'd on every console-isolated prov, and (with the pre-#4054 image that
+// dropped consoleLBIP entirely) console/api/marketplace ALL collapsed onto lbIP,
+// occluding the correct parent-zone records and failing the Phase-1 console
+// readiness gate so handover never fired. Every remaining name (apex, wildcard,
+// gitea, harbor) always points at lbIP (the shared gateway) regardless.
 //
 // Per docs/PLATFORM-POWERDNS.md these names mirror the canonical-record
 // contract and use TTL 300 for fast failover.
@@ -583,8 +597,8 @@ func canonicalRecordSet(childZone, lbIP, consoleLBIP string) []pdns.RRSet {
 	if consoleLBIP == "" {
 		consoleLBIP = lbIP
 	}
-	// Per-prefix target: the two console-control-plane names ride the console
-	// LB; everything else rides the shared LB.
+	// Per-prefix target: the console-gateway front-door names (console/api/
+	// marketplace) ride the console LB; everything else rides the shared LB.
 	prefixes := []struct {
 		name string
 		ip   string
@@ -593,9 +607,9 @@ func canonicalRecordSet(childZone, lbIP, consoleLBIP string) []pdns.RRSet {
 		{"*", lbIP},
 		{"console", consoleLBIP},
 		{"api", consoleLBIP},
+		{"marketplace", consoleLBIP},
 		{"gitea", lbIP},
 		{"harbor", lbIP},
-		{"marketplace", lbIP},
 	}
 	rrsets := make([]pdns.RRSet, 0, len(prefixes))
 	for _, p := range prefixes {

--- a/core/pool-domain-manager/internal/allocator/allocator_test.go
+++ b/core/pool-domain-manager/internal/allocator/allocator_test.go
@@ -214,11 +214,16 @@ func TestCanonicalRecordSet(t *testing.T) {
 	}
 }
 
-// TestCanonicalRecordSetConsoleSplit — #4053. When a console LB IP is supplied,
-// ONLY console + api ride it; every other name keeps the shared LB IP. This is
-// the DNS half of the poison-proof gateway isolation: console./api.<fqdn> reach
-// the dedicated cilium-gateway-console while *.<fqdn> (every volatile app) keeps
-// reaching the shared cilium-gateway.
+// TestCanonicalRecordSetConsoleSplit — #4053/#5034. When a console LB IP is
+// supplied, the console-gateway front doors (console + api + marketplace) ride
+// it; every other name keeps the shared LB IP. This is the DNS half of the
+// poison-proof gateway isolation: console./api./marketplace.<fqdn> reach the
+// dedicated cilium-gateway-console while *.<fqdn> (every volatile app) keeps
+// reaching the shared cilium-gateway. The console-gateway set MUST match
+// catalyst-api's ConsoleGatewaySubdomains = {console, api, marketplace}
+// (sovereign_dns_records.go) — for a pool Sovereign this delegated child zone
+// is the authoritative answer, so a marketplace record left on the shared LB
+// 404'd marketplace.<fqdn> on every console-isolated prov (#5034).
 func TestCanonicalRecordSetConsoleSplit(t *testing.T) {
 	const sharedIP = "1.2.3.4"
 	const consoleIP = "9.9.9.9"
@@ -231,9 +236,9 @@ func TestCanonicalRecordSetConsoleSplit(t *testing.T) {
 		"*.acme.openova.io":           sharedIP,
 		"console.acme.openova.io":     consoleIP,
 		"api.acme.openova.io":         consoleIP,
+		"marketplace.acme.openova.io": consoleIP,
 		"gitea.acme.openova.io":       sharedIP,
 		"harbor.acme.openova.io":      sharedIP,
-		"marketplace.acme.openova.io": sharedIP,
 	}
 	for _, r := range rrsets {
 		want, ok := wantIP[r.Name]


### PR DESCRIPTION
## What

Route `marketplace.<fqdn>` at the console load-balancer IP (the dedicated `cilium-gateway-console`) inside the delegated per-Sovereign **child zone** that pool-domain-manager (PDM) publishes, aligning PDM's console-gateway set with catalyst-api's authoritative `ConsoleGatewaySubdomains = {console, api, marketplace}`.

`Refs #5034`

## Root cause

For a pool Sovereign, DNS for `console/api/marketplace.<fqdn>` is served by a **delegated child zone** `<sub>.<pool>` (own SOA + NS), created and populated by PDM's `allocator.Commit` → `canonicalRecordSet`. Because that child zone is a zone cut below the parent pool zone, it is the **authoritative** answer — it occludes the same-name records catalyst-api's `sovereign_dns_records.go` writes into the parent pool zone. Whatever PDM publishes is what the world resolves.

`canonicalRecordSet` routed `console` + `api` at `consoleLBIP` but left `marketplace` on the shared `lbIP`. Marketplace's HTTPRoute parents `cilium-gateway-console` exactly like console/api, so on every console-isolated prov `marketplace.<fqdn>` resolved the shared gateway (which carries no console route) and returned 404. The shared LB IP also has no bearing on the console front doors, so the two DNS writers disagreed on the same three names.

## Live evidence (hw245, dep 7e337ed1185ac288, omani.works)

- Delegated child zone `hw245.omani.works` served `console/api/marketplace` → `212.72.24.49` (shared EIP), while the correct console EIP `212.72.24.36` sat **occluded** in the parent `omani.works` zone. This is the "pg-says-.36 / NS-serves-.49" split, and `pdns_control purge` was a no-op because it is a wrong-zone problem, not a cache one.
- Confirmed the child zone is authoritative: editing the child-zone `console` record to `.36` immediately flipped the answer from `ns1/ns2/ns3.openova.io`, and `console.hw245.omani.works` then returned **HTTP 200** end-to-end.
- The mothership PDM pod additionally runs a pre-#4054 image (`pool-domain-manager:43487f1`, 2026-06-02) whose `canonicalRecordSet` predates console-LB targeting entirely and collapses all front doors onto `lbIP`; a mothership PDM roll to the built image from this change is required for the fix to take effect on a fresh prov.

## Scope

- General across all managed pool TLDs (`omani.works`, `omantel.biz`, `openova.io`); not TLD-specific. Manifests only when console isolation is enabled (a dedicated console LB IP exists).
- No behavior change when `consoleLBIP` is empty (console isolation off): every record still falls back to `lbIP`, byte-identical to before.

## Tests

`go test ./...` green for `core/pool-domain-manager`. `TestCanonicalRecordSetConsoleSplit` updated to assert `marketplace` rides the console LB alongside `console`/`api`.
