### PR TITLE
fix(cutover): steps 02/03 dial in-cluster Harbor Service, not external registry.<fqdn> — pre-pivot NXDOMAIN (Refs #5036)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -831,7 +831,11 @@ spec:
       # false-skipped an image step-08's completeness gate then 404'd (hw244
       # otel-operator; hw243 velero/cnpg). prewarm skip can no longer diverge from
       # the gate that judges it.
-      version: 0.1.124
+      # 0.1.125 (#5036 Refs #5007 #4688): steps 02/03 dial the IN-CLUSTER Harbor
+      # Service (harbor-core.harbor.svc, always CoreDNS-resolvable pre-pivot) for the
+      # control-plane API + skopeo push, not the external registry.<fqdn> — which
+      # NXDOMAIN'd pre-pivot on hw246 (powerdns-zone-bootstrap flake) → curl exit 6.
+      version: 0.1.125
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.124
+  version: 0.1.125
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,33 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.125 (#5036 Refs #5007 #4688 — hw246, dep c38c437f, omani.works: the PRE-pivot
+# steps 02 (harbor-projects) + 03 (harbor-prewarm) dialed the local Harbor at its
+# EXTERNAL host registry.<fqdn> (#4688). But those steps run BEFORE step-04 pins
+# registry.<fqdn> in the node /etc/hosts (#5007), and the external host resolves
+# in-cluster ONLY if the Sovereign's split-horizon PowerDNS authoritatively serves a
+# registry.<fqdn> record — NOT guaranteed: on hw246 the powerdns-zone-bootstrap Job
+# flaked ("Failed to connect to powerdns port 8081"), leaving the omani.works zone
+# with only NS+SOA and NO registry.<fqdn> → the harbor-projects Job NXDOMAIN'd with
+# curl exit 6 on the FIRST /registries POST (proxy-xpkg), 4 retry Pods identical,
+# cutover wedged. FIX (reverts #4688): steps 02/03 now dial the IN-CLUSTER Harbor
+# Service harbor-core.harbor.svc.cluster.local (HARBOR_INTERNAL_URL) for the Harbor
+# control-plane API (registry/project create), the artifact-API idempotency probe,
+# the /v2 HEAD, AND the skopeo push destination (HARBOR_HOST). The Service name
+# ALWAYS resolves via the CoreDNS kubernetes plugin — independent of PowerDNS zone
+# state and the step-04 pin — and 00-mgmt-isolation-carveout already opens the
+# catalyst -> harbor-core.harbor.svc path (step-01 gitea dials gitea-http.gitea.svc
+# the same way). #4688's "DMZ/RTZ multi-cluster segregation" premise does not hold
+# post-#4325 de-vcluster: harbor + catalyst are co-located host namespaces in ONE
+# cluster (verified live hw246: catalyst-ns Pod curls
+# http://harbor-core.harbor.svc.cluster.local/api/v2.0/ping → HTTP 200). Pushed
+# blobs land in the same Harbor project/repo (host-independent), so post-cutover
+# pulls via registry.<fqdn> (step-04 containerd + step-08 completeness HEAD, which
+# target LOCAL_REGISTRY_HOST, UNCHANGED) resolve the identical artifacts. The
+# artifact-API probe flips DOUBLE-encode (%252F, needed for envoy's one-layer decode
+# on the gateway path) to SINGLE-encode (%2F) for the direct Service path (#5030's
+# "Harbor must receive %2F" preserved); fail-closed either way. --dest-tls-verify
+# =false (default) drives skopeo's http fallback for the plain-HTTP Service on :80.
+# ── prior ──
 # 0.1.124 (#5030 Refs #3379 #4994 #4975 #5026 — hw244, dep b16a43ac: step-03
 # harbor-prewarm's #4994 dest_already_current() idempotency probe used
 # `skopeo inspect --raw` against the DESTINATION registry endpoint — a
@@ -1978,7 +2006,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.124
+version: 0.1.125
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
@@ -31,15 +31,30 @@ data:
         image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.curl.repository "tag" .Values.images.curl.tag "cutoverPhase" "pre" "Values" .Values) }}
         imagePullPolicy: IfNotPresent
         env:
+          # #5036 (Refs #5007; reverts #4688) — the Harbor CONTROL-PLANE API
+          # (registry + project creation) is dialed via the IN-CLUSTER Service
+          # harbor-core.harbor.svc.cluster.local (HARBOR_INTERNAL_URL), NOT the
+          # external host registry.<fqdn>. step-02 runs PRE-pivot, BEFORE step-04
+          # pins registry.<fqdn> in the node /etc/hosts. The external host resolves
+          # in-cluster ONLY if the Sovereign's split-horizon PowerDNS authoritatively
+          # serves a registry.<fqdn> record — NOT guaranteed pre-pivot: on hw246
+          # (dep c38c437f, omani.works) the powerdns-zone-bootstrap flaked
+          # ("Failed to connect to powerdns port 8081"), leaving the zone with only
+          # NS+SOA and no registry.<fqdn> → the harbor-projects Job NXDOMAIN'd with
+          # curl exit 6 on the FIRST /registries POST (4 retry Pods identical). The
+          # in-cluster Service ALWAYS resolves via the CoreDNS kubernetes plugin,
+          # independent of PowerDNS zone state AND the step-04 pin, and
+          # 00-mgmt-isolation-carveout already opens the catalyst -> harbor-core.harbor.svc
+          # path (step-01 gitea dials gitea-http.gitea.svc the same way). #4688's
+          # "DMZ/RTZ multi-cluster segregation" premise does not hold post-#4325
+          # de-vcluster: harbor + catalyst are co-located host namespaces in ONE
+          # cluster (verified live hw246: a Pod in the catalyst ns curls
+          # http://harbor-core.harbor.svc.cluster.local/api/v2.0/ping → HTTP 200).
+          # The external registry.<fqdn> host stays the target of step-04 (containerd)
+          # + step-06 (Flux) — those resolve via node /etc/hosts + public DNS.
           - name: HARBOR_INTERNAL_URL
             value: {{ .Values.sovereign.harborInternalURL | quote }}
-          # #4688 — reach the local Harbor via its EXTERNAL host registry.<fqdn>
-          # (NOT the internal svc name harbor-core.harbor.svc) so cutover steps work
-          # under DMZ/RTZ multi-cluster segregation, where an in-cluster ClusterIP
-          # does not route across clusters. In-cluster-reachable via the gateway
-          # hairpin (verified 401 from a harbor pod on hw208). The `-k` on the curls
-          # below tolerates the local Harbor's LE-STAGING wildcard on qaTest provs
-          # (in-cluster access to the LOCAL Harbor's own cert; not MITM-exposed).
+          # Retained for reference; step-02 now dials HARBOR_INTERNAL_URL above.
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
@@ -67,7 +82,7 @@ data:
           - |
             set -eu
             : "${HARBOR_USERNAME:=admin}"
-            base="${HARBOR_PUBLIC_URL}/api/v2.0"  # #4688 external host, not harbor-core.harbor.svc
+            base="${HARBOR_INTERNAL_URL}/api/v2.0"  # #5036 in-cluster Harbor Service — always CoreDNS-resolvable pre-pivot (external registry.<fqdn> NXDOMAIN'd on hw246 before the step-04 pin)
 
             # 1. Decode GHCR creds (used by proxy-ghcr registry, authMode=credential).
             if [ -n "${GHCR_DOCKERCONFIG:-}" ]; then

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -131,16 +131,19 @@ data:
           - name: PREWARM_SKOPEO_TIMEOUT
             value: {{ .Values.prewarm.skopeoCommandTimeout | default "1200s" | quote }}
           # #4529 (Refs #3379): TLS-verify on the skopeo copy DESTINATION (the
-          # in-cluster Harbor `registry.<sov-fqdn>` = HARBOR_HOST). DEFAULT
-          # false — the copy target is the Sovereign's OWN registry over the
-          # cluster pod network whose wildcard cert is LE-STAGING/untrusted on a
-          # fresh prov (and a Job-Pod skopeo has no node trust store even with
-          # production LE), so verifying the dest against the public CA x509-fails
-          # every push (live keystone 25aadcfc: push_ok=0 push_fail=30 → step-03 FATAL →
-          # cutover never reaches the deny-egress hold). Trust here is the
-          # cluster network, not a public CA — same rationale as
-          # registries.yaml v1's insecure_skip_verify for the bastion mirror.
-          # The SRC (ghcr.io) verification is ALWAYS true (external public host).
+          # in-cluster Harbor Service harbor-core.harbor.svc = HARBOR_HOST post-#5036).
+          # DEFAULT false — the copy target is the Sovereign's OWN registry over the
+          # cluster pod network. Pre-#5036 (HARBOR_HOST=registry.<fqdn>) the target's
+          # wildcard cert was LE-STAGING/untrusted on a fresh prov (and a Job-Pod
+          # skopeo has no node trust store even with production LE), so verifying the
+          # dest against the public CA x509-failed every push (live keystone
+          # 25aadcfc: push_ok=0 push_fail=30 → step-03 FATAL → cutover never reached
+          # the deny-egress hold). Post-#5036 the dest is the plain-HTTP in-cluster
+          # Service on :80; DEST_TLS_VERIFY=false ALSO drives skopeo's https->http
+          # ping fallback (containers/image retries http when InsecureSkipVerify is
+          # set), so the push lands over HTTP with no cert involved. Trust here is the
+          # cluster network, not a public CA. The SRC (ghcr.io) verification is
+          # ALWAYS true (external public host).
           - name: PREWARM_DEST_TLS_VERIFY
             value: {{ .Values.prewarm.destTLSVerify | default false | quote }}
           # #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
@@ -408,7 +411,19 @@ data:
               esac
             }
 
-            HARBOR_HOST=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
+            # #5036 (reverts #4688): the skopeo PUSH destination + the Harbor
+            # artifact-API existence check dial the IN-CLUSTER Harbor Service
+            # (harbor-core.harbor.svc, always CoreDNS-resolvable pre-pivot), NOT the
+            # external registry.<fqdn> (which NXDOMAINs pre-pivot on a Sovereign whose
+            # split-horizon PowerDNS lacks the record — hw246 dep c38c437f). The pushed
+            # blobs land in the SAME Harbor project/repo (Harbor stores by project/repo,
+            # host-independent), so post-cutover pulls via registry.<fqdn> — step-04
+            # containerd + step-08 completeness HEAD, which target LOCAL_REGISTRY_HOST,
+            # unchanged — resolve the identical artifacts. HARBOR_HOST is step-03-local
+            # (the resolver returns host-LESS paths; the prefix is stripped in
+            # dest_already_current), so this does not touch step-04/08. --dest-tls-verify
+            # =false (default) drives skopeo's http fallback for the plain-HTTP Service.
+            HARBOR_HOST=$(printf '%s' "${HARBOR_INTERNAL_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
 
             # Enumerate openova-io images cluster-wide.
             #
@@ -628,17 +643,21 @@ data:
               # No repository segment → cannot address an artifact → fail-closed (copy).
               [ -z "${_dc_repo}" ] && return 1
               # Harbor's artifact API needs the nested repo name's `/` encoded as
-              # %2F. The in-cluster gateway decodes ONE URL layer before Harbor, so
-              # DOUBLE-encode (`/` -> %252F) so Harbor receives %2F and routes the
-              # nested repository correctly (validated live hw244 #5030: single-
-              # encoded 404s the route; double-encoded 200s with the durable digest).
-              _dc_repo_enc=$(printf '%s' "${_dc_repo}" | sed 's#/#%252F#g')
-              # Durable DEST digest from Harbor CORE (never pull-through). -k: the
-              # local Harbor cert is LE-staging/untrusted on a fresh prov (same
-              # rationale as step-08's `curl -sk` completeness HEAD).
+              # %2F. #5036: this check now dials the Harbor CORE Service DIRECTLY
+              # (HARBOR_INTERNAL_URL) with NO gateway in the path, so SINGLE-encode
+              # (`/` -> %2F) — harbor-core receives %2F and routes the nested repo.
+              # (Under #4688's gateway path this was DOUBLE-encoded `%252F` to survive
+              # envoy's one-layer decode before Harbor; the direct Service path has no
+              # such decode, so #5030's "Harbor must receive exactly %2F" is met with a
+              # single encode here.) Fail-closed: a wrong-encoding 404 (or any miss)
+              # falls through to a full re-copy — never a false "already current" skip.
+              _dc_repo_enc=$(printf '%s' "${_dc_repo}" | sed 's#/#%2F#g')
+              # Durable DEST digest from Harbor CORE (never pull-through) via the
+              # in-cluster Service (#5036). -k is harmless over the plain-HTTP Service;
+              # retained so an https harborInternalURL override still works.
               _dc_d=$(curl -sk --max-time 30 \
                 -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                "${HARBOR_PUBLIC_URL}/api/v2.0/projects/${_dc_proj}/repositories/${_dc_repo_enc}/artifacts/${_dc_ref}" 2>/dev/null \
+                "${HARBOR_INTERNAL_URL}/api/v2.0/projects/${_dc_proj}/repositories/${_dc_repo_enc}/artifacts/${_dc_ref}" 2>/dev/null \
                 | jq -r '.digest // empty' 2>/dev/null)
               [ -n "${_dc_d}" ] && [ "${_dc_s}" = "${_dc_d}" ]
             }
@@ -1120,7 +1139,7 @@ data:
 
             # ─── Phase B (legacy): HEAD against proxy-cache for non-openova-io ─
             echo "[harbor-prewarm] Phase B: HEAD against proxy-cache for upstream images"
-            base="${HARBOR_PUBLIC_URL}/v2"  # #4688 external host, not harbor-core.harbor.svc
+            base="${HARBOR_INTERNAL_URL}/v2"  # #5036 in-cluster Harbor Service — always resolves pre-pivot; the /v2 registry API uses literal-slash repo names (no gateway-decode nuance)
             ok=0
             fail=0
             while IFS= read -r line; do

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2094,4 +2094,80 @@ if ! grep -q 'RC=0' <<<"$_lint_pass_out"; then
 fi
 echo "  PASS (lint fails loud listing offenders on a tether ref; passes when all-local; skips excluded/implicit-docker.io)"
 
+echo "[cutover-contract] Case 52: PRE-pivot steps 02/03 dial the local Harbor at the IN-CLUSTER Service (HARBOR_INTERNAL_URL = harbor-core.harbor.svc), NOT the external registry.<fqdn> (HARBOR_PUBLIC_URL) — the external host NXDOMAINs in-cluster before the step-04 pin (#5036, reverts #4688, Refs #5007)"
+# hw246 (dep c38c437f, omani.works): steps 02 (harbor-projects) + 03 (harbor-prewarm)
+# run PRE-pivot, BEFORE step-04 pins registry.<fqdn> in the node /etc/hosts (#5007).
+# #4688 pointed their Harbor dials at the EXTERNAL host registry.<fqdn>, which resolves
+# in-cluster ONLY if the Sovereign's split-horizon PowerDNS authoritatively serves a
+# registry.<fqdn> record. On hw246 the powerdns-zone-bootstrap flaked → NO record →
+# the harbor-projects Job NXDOMAIN'd (curl exit 6) on the FIRST /registries POST. The
+# in-cluster Service name ALWAYS resolves via the CoreDNS kubernetes plugin (the
+# 00-mgmt-isolation-carveout NetworkPolicy — Case 29 — already opens the path), so
+# every pre-pivot Harbor dial MUST target HARBOR_INTERNAL_URL, never HARBOR_PUBLIC_URL.
+# SCOPE: only the PRE-pivot steps 02 + 03. Steps 07/08 run AFTER step-04's pivot and
+# INTENTIONALLY dial the external registry.<fqdn> (step-08's completeness HEAD validates
+# the exact gateway serving path containerd uses post-cutover) — out of scope here. Slice
+# each step's ConfigMap block from its name to the next step's name (render order is
+# filename order: 02 < 03 < 04).
+awk '/name: cutover-step-02-harbor-projects/{c=1} /name: cutover-step-03-harbor-prewarm/{c=0} c' "$TMP/render.yaml" > "$TMP/s02.yaml"
+awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03.yaml"
+if [ ! -s "$TMP/s02.yaml" ] || [ ! -s "$TMP/s03.yaml" ]; then
+  echo "FAIL: could not slice the step-02/03 ConfigMap blocks from the render (#5036)" >&2
+  exit 1
+fi
+# (a) HARBOR_INTERNAL_URL default MUST be the in-cluster Service form on BOTH steps, so a
+#     stray external override is caught.
+for blk in s02 s03; do
+  if ! grep -q 'value: "http://harbor-core.harbor.svc.cluster.local"' "$TMP/$blk.yaml"; then
+    echo "FAIL: step-${blk#s} HARBOR_INTERNAL_URL does not default to the in-cluster Harbor Service http://harbor-core.harbor.svc.cluster.local — pre-pivot Harbor dials would depend on external DNS (#5036)" >&2
+    exit 1
+  fi
+done
+# (b) Step-02 harbor-projects: the Harbor control-plane API base MUST be the internal Service.
+if ! grep -qF 'base="${HARBOR_INTERNAL_URL}/api/v2.0"' "$TMP/s02.yaml"; then
+  echo "FAIL: step-02 harbor-projects does not dial the Harbor API via HARBOR_INTERNAL_URL — the external registry.<fqdn> NXDOMAINs pre-pivot (#5036)" >&2
+  exit 1
+fi
+# (c) Step-03 harbor-prewarm: the skopeo PUSH host, the artifact-API idempotency probe,
+#     and the /v2 HEAD base MUST all derive from the internal Service.
+if ! grep -qF 'HARBOR_HOST=$(printf '"'"'%s'"'"' "${HARBOR_INTERNAL_URL}"' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 harbor-prewarm skopeo push HARBOR_HOST is not derived from HARBOR_INTERNAL_URL — the push target NXDOMAINs pre-pivot on a PowerDNS-flaked prov (#5036)" >&2
+  exit 1
+fi
+if ! grep -qF '"${HARBOR_INTERNAL_URL}/api/v2.0/projects/' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 dest_already_current() artifact-API probe does not dial HARBOR_INTERNAL_URL (#5036)" >&2
+  exit 1
+fi
+if ! grep -qF 'base="${HARBOR_INTERNAL_URL}/v2"' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 Phase B /v2 HEAD base does not dial HARBOR_INTERNAL_URL (#5036)" >&2
+  exit 1
+fi
+# (d) The direct-Service artifact-API probe MUST SINGLE-encode the nested repo `/` as
+#     %2F (harbor-core receives it directly — no gateway one-layer decode). The #4688
+#     gateway-path DOUBLE-encode (%252F) MUST be gone (it would 404 the direct route).
+if ! grep -qF "sed 's#/#%2F#g'" "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 dest_already_current() does not SINGLE-encode the nested repo (%2F) for the direct harbor-core path (#5036, Refs #5030)" >&2
+  exit 1
+fi
+if grep -qF "sed 's#/#%252F#g'" "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 still DOUBLE-encodes the nested repo (%252F) — that survives envoy's decode on the gateway path but 404s the direct harbor-core Service path (#5036)" >&2
+  exit 1
+fi
+# (e) REGRESSION GUARD: no pre-pivot step-02/03 Harbor DIAL target may reference
+#     HARBOR_PUBLIC_URL (the #4688 external-host regression). HARBOR_PUBLIC_URL may
+#     still be PROJECTED as an env for reference, but never used as a curl/skopeo host.
+for blk in s02 s03; do
+  for bad in \
+    'base="${HARBOR_PUBLIC_URL}/api/v2.0"' \
+    'base="${HARBOR_PUBLIC_URL}/v2"' \
+    '"${HARBOR_PUBLIC_URL}/api/v2.0/projects/' \
+    'HARBOR_HOST=$(printf '"'"'%s'"'"' "${HARBOR_PUBLIC_URL}"' ; do
+    if grep -qF "$bad" "$TMP/$blk.yaml"; then
+      echo "FAIL: step-${blk#s} still targets the external HARBOR_PUBLIC_URL ('$bad') — reintroduces the #4688 pre-pivot NXDOMAIN (#5036)" >&2
+      exit 1
+    fi
+  done
+done
+echo "  PASS (steps 02/03 dial the in-cluster harbor-core.harbor.svc for API + skopeo push; single-encode %2F for the direct path; no HARBOR_PUBLIC_URL dial target remains; steps 07/08 external-host validation untouched)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.124"
+  version: "0.1.125"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.124"
+    version: "0.1.125"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Summary

Pre-pivot cutover steps **02 (harbor-projects)** and **03 (harbor-prewarm)** dialed the local Harbor at its **external** host `registry.<fqdn>` (#4688). Those steps run **before** step-04 pins `registry.<fqdn>` in the node `/etc/hosts` (#5007), and the external host resolves in-cluster **only** if the Sovereign's split-horizon PowerDNS authoritatively serves a `registry.<fqdn>` record — which is not guaranteed.

On **hw246** (dep `c38c437f`, `omani.works`) the `powerdns-zone-bootstrap` Job flaked mid-run (`Failed to connect to powerdns port 8081`), leaving the `omani.works` zone with only NS+SOA and **no** `registry.<fqdn>` record. The `harbor-projects` Job then NXDOMAIN'd with **curl exit 6** on the first `/registries` POST (the `proxy-xpkg` proxy-cache project) — deterministic, 4 retry Pods identical, cutover wedged.

## Root cause

Not TLD/pool-specific — a **general race the prov lost**. On a normal prov (e.g. hw242/`omantel.biz`) the zone-bootstrap succeeds and `registry.<fqdn>` resolves in-cluster via PowerDNS, so steps 02/03 reach Harbor through the gateway. hw246's zone-bootstrap flake left the authoritative zone incomplete → in-cluster NXDOMAIN before the step-04 pin. The deeper PowerDNS-bootstrap reliability gap is a separate concern; this change makes the cutover chart immune to it.

## Fix (reverts #4688 for the pre-pivot steps)

Steps 02/03 now dial the **in-cluster Harbor Service** `harbor-core.harbor.svc.cluster.local` (`HARBOR_INTERNAL_URL`) for:
- the Harbor control-plane API (registry + project create) — step 02;
- the artifact-API idempotency probe, the `/v2` HEAD, and the **skopeo push destination** (`HARBOR_HOST`) — step 03.

The Service name **always** resolves via the CoreDNS `kubernetes` plugin — independent of PowerDNS zone state and the step-04 pin — and `00-mgmt-isolation-carveout` already opens the `catalyst -> harbor-core.harbor.svc` path (step-01 gitea dials `gitea-http.gitea.svc` the same way). #4688's "DMZ/RTZ multi-cluster segregation" premise does not hold post-#4325 de-vcluster: harbor + catalyst are co-located host namespaces in **one** cluster.

### Why this is safe
- Pushed blobs land in the **same** Harbor project/repo (Harbor stores by project/repo, host-independent), so post-cutover pulls via `registry.<fqdn>` — step-04 containerd + step-08 completeness HEAD, which target `LOCAL_REGISTRY_HOST`, **unchanged** — resolve identical artifacts. `HARBOR_HOST` is step-03-local (the resolver returns host-less paths).
- The artifact-API probe flips **double-encode** (`%252F`, needed for envoy's one-layer decode on the gateway path) to **single-encode** (`%2F`) for the direct Service path (#5030's "Harbor must receive `%2F`" preserved); fail-closed either way (a wrong-encode 404 falls through to a full re-copy).
- `--dest-tls-verify=false` (already the default, #4529) drives skopeo's https→http ping fallback for the plain-HTTP Service on `:80`.
- Steps 07/08 keep the external host by design (post-pivot serving-path validation, esp. step-08's completeness gate) — this change does not touch them.

## Live evidence (hw246, catalyst ns Pod)
- `curl http://harbor-core.harbor.svc.cluster.local/api/v2.0/ping` → **HTTP 200**; `/api/v2.0/health` → all components healthy; `/v2/` → **HTTP 401** (auth-gated, reachable).
- `powerdns-zone-bootstrap-*` Error pod log: `curl: (7) Failed to connect to powerdns port 8081`; `pdnsutil list-zone omani.works` → NS+SOA only (SOA `a.misconfigured.dns.server.invalid`).

## Chart / lockstep
`bp-self-sovereign-cutover` **0.1.124 → 0.1.125** with lockstep pins: `blueprint.yaml`, bootstrap-kit slot-06a, catalog-seed `blueprints.yaml` (×2).

## Tests
- New `cutover-contract.sh` **Case 52** asserts steps 02/03 dial the in-cluster Service (API + skopeo push), single-encode `%2F`, and no `HARBOR_PUBLIC_URL` dial target remains (steps 07/08 external-host validation untouched).
- `cutover-contract.sh` (52 cases) + `image-registry-coverage.sh` green; `helm lint` clean.

Refs #5036 #5007 #4688 #5030 #4529
