### PR TITLE
fix(cutover): step-08 ref-host lint is redirect-aware — HOST_PROJECT_MAP hosts are sovereign via the step-04 containerd redirect (Refs #5036)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -835,7 +835,15 @@ spec:
       # Service (harbor-core.harbor.svc, always CoreDNS-resolvable pre-pivot) for the
       # control-plane API + skopeo push, not the external registry.<fqdn> — which
       # NXDOMAIN'd pre-pivot on hw246 (powerdns-zone-bootstrap flake) → curl exit 6.
-      version: 0.1.125
+      # 0.1.126 (#5036 Refs #5026 #5027 #4975): step-08 pre-hold ref-host lint is now
+      # REDIRECT-AWARE — a workload ref on a HOST_PROJECT_MAP host (harbor.openova.io
+      # host-swap + ghcr.io/docker.io/… proxy-cache) is exempt because step-04 writes a
+      # containerd certs.d redirect for it to registry.<fqdn>, so it pulls locally and
+      # never dials the mothership (already sovereign; live hw246). Only a host with NO
+      # redirect (raw github.com/…) is a genuine deny-egress offender. Unblocks the ~40
+      # harbor.openova.io/proxy-* chart-default refs step-07 doesn't textually pivot;
+      # the deny-egress hold + completeness gate (authoritative proof) are UNCHANGED.
+      version: 0.1.126
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.125
+  version: 0.1.126
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.126 (#5036 Refs #5026 #5027 #4975 — hw246, dep c38c437f, omani.works): the
+# step-08 PRE-HOLD ref-host lint (run_podspec_refhost_lint, added #5026/#5027) is now
+# REDIRECT-AWARE. It failed BEFORE the deny-egress hold on the ~40 workloads whose
+# chart-default image ref is harbor.openova.io/proxy-* — but step-04's registry-pivot
+# writes a containerd certs.d/<host>/hosts.toml redirect to registry.<fqdn> for EVERY
+# host in HOST_PROJECT_MAP (the mothership harbor.openova.io host-swap AND ghcr.io/
+# docker.io/quay.io/… proxy-cache pull-through), so those refs pull from the LOCAL
+# Harbor via the redirect and NEVER dial the mothership — already sovereign (verified
+# live hw246: certs.d/harbor.openova.io/hosts.toml → server="https://harbor.openova.io",
+# host."https://registry.hw246.omani.works"). The lint now exempts a host if it is
+# LOCAL_REGISTRY_HOST OR appears in HOST_PROJECT_MAP (the SAME single-source env step-04
+# reads — no fresh hardcoded literal); a GENUINE offender is a host with NO redirect
+# (e.g. a raw github.com/… ref) that deny-egress would actually block. The deny-egress
+# hold + the offline-mirror completeness gate are UNCHANGED and remain the authoritative
+# sovereignty proof (a redirect-covered ref that could NOT pull would still fail the
+# hold), so relaxing the pre-hold lint removes only a false positive, never a real
+# tether. Option B (make step-07 TEXTUALLY rewrite all such refs, belt-and-suspenders)
+# is deferred as backlog per the founder-pending sovereignty-posture decision.
+# ── prior ──
 # 0.1.125 (#5036 Refs #5007 #4688 — hw246, dep c38c437f, omani.works: the PRE-pivot
 # steps 02 (harbor-projects) + 03 (harbor-prewarm) dialed the local Harbor at its
 # EXTERNAL host registry.<fqdn> (#4688). But those steps run BEFORE step-04 pins
@@ -27,7 +46,6 @@ name: bp-self-sovereign-cutover
 # on the gateway path) to SINGLE-encode (%2F) for the direct Service path (#5030's
 # "Harbor must receive %2F" preserved); fail-closed either way. --dest-tls-verify
 # =false (default) drives skopeo's http fallback for the plain-HTTP Service on :80.
-# ── prior ──
 # 0.1.124 (#5030 Refs #3379 #4994 #4975 #5026 — hw244, dep b16a43ac: step-03
 # harbor-prewarm's #4994 dest_already_current() idempotency probe used
 # `skopeo inspect --raw` against the DESTINATION registry endpoint — a
@@ -2006,7 +2024,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.125
+version: 0.1.126
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -398,14 +398,35 @@ data:
 
             # #5026 — PRE-HOLD REF-HOST LINT (treadmill-breaker). Complements the
             # content-completeness gate above: that proves the IMAGE is in local
-            # Harbor; this proves the pod-spec REF POINTS AT local Harbor. A ref
-            # still on a tether host (harbor.openova.io mothership, ghcr.io, …)
-            # that step-07's sweep missed is a latent deny-egress ImagePullBackOff
-            # AND was historically found one-host-per-prov. This lists EVERY
-            # offender at once and fails BEFORE the hold so the whole un-pivoted
-            # set surfaces in a single prov.
+            # Harbor; this proves the pod-spec REF RESOLVES to local Harbor. A ref
+            # on a host that is NEITHER the local registry NOR a step-04 redirect-
+            # covered host is a genuine deny-egress tether (a raw github.com/… ref
+            # with NO containerd redirect) → latent ImagePullBackOff under the hold.
+            # This lists EVERY such offender at once and fails BEFORE the hold so
+            # the whole un-covered set surfaces in a single prov.
+            #
+            # #5036 (Refs #5026 #5027 #4975 — hw246) — REDIRECT-AWARE. The premise
+            # is NOT "the ref host must be registry.<fqdn>". Step-04 (04-registry-
+            # pivot-daemonset.yaml, which PASSED before this step) writes a
+            # containerd certs.d/<host>/hosts.toml redirect to registry.<fqdn> for
+            # EVERY host in HOST_PROJECT_MAP — the mothership harbor.openova.io
+            # host-swap AND ghcr.io/docker.io/quay.io/registry.k8s.io/… (proxy-cache
+            # pull-through). So a pod-spec ref like harbor.openova.io/proxy-<x>/PATH
+            # pulls from the LOCAL Harbor via that redirect and NEVER dials the
+            # mothership — it is already sovereign (verified live hw246:
+            # certs.d/harbor.openova.io/hosts.toml → server="https://harbor.openova.io",
+            # host."https://registry.<fqdn>"). Requiring step-07 to TEXTUALLY rewrite
+            # those ~40 chart-default refs (Option B, deferred backlog) is
+            # belt-and-suspenders, not a sovereignty requirement. This lint therefore
+            # exempts a host if it is the local registry OR appears in HOST_PROJECT_MAP
+            # (the SAME single-source env step-04 reads — no fresh hardcoded literal).
+            # SOUNDNESS: the deny-egress hold below is the authoritative proof; a
+            # redirect-covered ref that could NOT actually pull locally would still
+            # ImagePullBackOff during the hold and fail the proof, so exempting it
+            # here removes only a false positive on an already-local ref, never a
+            # real tether. The completeness gate above independently proves content.
             run_podspec_refhost_lint() {
-              echo "[egress-block-test] #5026: PRE-HOLD ref-host lint — every rolled workload pod-spec image host must be ${LOCAL_REGISTRY_HOST} (tether refs must be pivoted by step-07)"
+              echo "[egress-block-test] #5026/#5036: PRE-HOLD ref-host lint — every rolled workload pod-spec image host must be ${LOCAL_REGISTRY_HOST} OR a step-04 redirect-covered host (HOST_PROJECT_MAP: harbor.openova.io/ghcr.io/…); genuine offenders are hosts with NO containerd redirect that deny-egress would block"
               _lint_off="/work/refhost-offenders.$$"; : > "${_lint_off}"
               for _lk in deployments daemonsets statefulsets; do
                 kubectl get "${_lk}" -A \
@@ -446,20 +467,32 @@ data:
                           [ "${_lh}" = "${_eh}" ] && { _sk=1; break; }
                         done
                         [ "${_sk}" = "1" ] && continue
-                        # The local registry host is the ONLY acceptable explicit host.
+                        # The local registry host is sovereign.
                         [ "${_lh}" = "${LOCAL_REGISTRY_HOST}" ] && continue
+                        # #5036 — a host that step-04's containerd registries redirect
+                        # maps to the local registry is ALSO sovereign. HOST_PROJECT_MAP
+                        # is the SAME space-separated `host:project` env step-04 loops
+                        # over to write each certs.d/<host>/hosts.toml redirect to
+                        # registry.<fqdn> (harbor.openova.io host-swap + ghcr.io/docker.io/
+                        # … proxy-cache), so a ref on any of those hosts pulls locally via
+                        # the redirect and never dials the mothership → not an offender.
+                        _redir=0
+                        for _rp in ${HOST_PROJECT_MAP:-}; do
+                          [ "${_lh}" = "${_rp%%:*}" ] && { _redir=1; break; }
+                        done
+                        [ "${_redir}" = "1" ] && continue
                         printf '%s/%s [%s] %s (host:%s)\n' "${_lns}" "${_lname}" "${_lcn}" "${_limg}" "${_lh}" >> "${_lint_off}"
                       done
                   done
               done
               if [ -s "${_lint_off}" ]; then
-                echo "  FAIL — these rolled workload pod-spec image(s) STILL reference a NON-LOCAL registry host after step-07's sweep (each is a deny-egress tether; fix = step-07 sweep coverage / the chart's default image host so it renders registry.<fqdn> or a proxy-* host the sweep pivots):"
-                sort -u "${_lint_off}" | while IFS= read -r _o; do echo "    UNPIVOTED ${_o}"; done
+                echo "  FAIL — these rolled workload pod-spec image(s) reference a registry host that is NEITHER the local registry NOR step-04 redirect-covered (each is a genuine deny-egress tether with NO containerd redirect; fix = add the host to offlineMirror.hostProjects so step-04 redirects it, OR pivot the chart's default image host to registry.<fqdn> / a HOST_PROJECT_MAP host):"
+                sort -u "${_lint_off}" | while IFS= read -r _o; do echo "    UNCOVERED ${_o}"; done
                 rm -f "${_lint_off}"
                 return 1
               fi
               rm -f "${_lint_off}"
-              echo "  PASS — every rolled workload pod-spec references the local registry ${LOCAL_REGISTRY_HOST} (or implicit docker.io / excluded) — no residual tether refs (#5026)"
+              echo "  PASS — every rolled workload pod-spec references the local registry ${LOCAL_REGISTRY_HOST}, a step-04 redirect-covered host (HOST_PROJECT_MAP: harbor.openova.io/ghcr.io/…), implicit docker.io, or an excluded host — no un-covered tether refs (#5026 #5036)"
               return 0
             }
             if [ "${PODSPEC_REFHOST_LINT}" = "true" ]; then

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2010,7 +2010,7 @@ if ! grep -A1 'name: HOST_PROJECT_MAP' "$TMP/render.yaml" | grep -q 'harbor.open
 fi
 echo "  PASS (mothership harbor.openova.io/proxy-* pivots to registry.<fqdn>/proxy-*; coverage map guarantees the host)"
 
-echo "[cutover-contract] Case 51: step-08 pre-hold ref-host lint FAILS loud on a residual tether ref + PASSES when all-local (#5026 treadmill-breaker)"
+echo "[cutover-contract] Case 51: step-08 pre-hold ref-host lint is REDIRECT-AWARE — FAILS loud on an un-covered tether host, PASSES step-04 redirect-covered hosts (harbor.openova.io + ghcr.io) and the local registry (#5026 #5036 treadmill-breaker)"
 helm template smoke . --show-only templates/08-egress-block-test-job.yaml > "$TMP/r08.yaml"
 _slice_fn "$TMP/r08.yaml" run_podspec_refhost_lint > "$TMP/c_lint.sh"
 if ! grep -q 'run_podspec_refhost_lint() {' "$TMP/c_lint.sh"; then
@@ -2020,22 +2020,37 @@ fi
 if ! grep -q 'ref-host lint FAILED before the hold' "$TMP/render.yaml"; then
   echo "FAIL: run_podspec_refhost_lint is not invoked as a hard pre-hold gate (#5026)" >&2; exit 1
 fi
+# #5036 — the lint must derive its redirect-covered exemption set from HOST_PROJECT_MAP
+# (the SAME env step-04 loops over to write each certs.d/<host> redirect), NOT a
+# hardcoded literal. Assert the loop is present so a future refactor can't silently
+# drop redirect-awareness and reintroduce the harbor.openova.io false positive.
+if ! grep -qF 'for _rp in ${HOST_PROJECT_MAP' "$TMP/c_lint.sh"; then
+  echo "FAIL: ref-host lint is not redirect-aware — it does not exempt HOST_PROJECT_MAP hosts (#5036)" >&2; exit 1
+fi
 # Behavioral test with a mock kubectl. Local work dir so /work redirect is safe.
 _lintdir="$TMP/lint"; mkdir -p "$_lintdir/bin" "$_lintdir/work"
-# FAIL fixture: velero still on harbor.openova.io; reloader local; registry-pivot
-# excluded; nginx implicit-docker.io; rancher/k3s excluded substring.
+# HOST_PROJECT_MAP mirrors offlineMirror.hostProjects (values.yaml): every upstream
+# registry host is redirect-covered by step-04; github.com is deliberately ABSENT
+# (no containerd redirect → a genuine deny-egress tether).
+_HPM="ghcr.io:proxy-ghcr docker.io:proxy-dockerhub registry-1.docker.io:proxy-dockerhub quay.io:proxy-quay registry.k8s.io:proxy-k8s gcr.io:proxy-gcr harbor.openova.io:"
+# FAIL fixture: badapp on github.com (NO step-04 redirect → genuine tether → offender);
+# velero on harbor.openova.io + cnpg on ghcr.io (BOTH redirect-covered → sovereign, must
+# NOT flag — the #5036 core); reloader already-local; registry-pivot excluded workload;
+# nginx implicit-docker.io; rancher/k3s excluded substring.
 cat > "$_lintdir/bin/kubectl" <<'MOCK'
 #!/bin/sh
 kind="$2"
 if [ "$3" = "-A" ]; then
   case "$kind" in
-    deployments) printf 'velero velero\nreloader reloader-reloader\ncatalyst registry-pivot\norgns myapp\n' ;;
+    deployments) printf 'bad badapp\nvelero velero\ncnpg cnpg-controller\nreloader reloader-reloader\ncatalyst registry-pivot\norgns myapp\n' ;;
     daemonsets) printf '' ;; statefulsets) printf '' ;;
   esac
 else
   key="$kind/$5/$3"
   case "$key" in
+    deployments/bad/badapp) printf 'c=github.com/acme/tool:v1\n' ;;
     deployments/velero/velero) printf 'velero=harbor.openova.io/proxy-dockerhub/velero/velero:v1.18.0\n' ;;
+    deployments/cnpg/cnpg-controller) printf 'c=ghcr.io/cloudnative-pg/postgresql:16.4\n' ;;
     deployments/reloader/reloader-reloader) printf 'r=registry.t99.omani.works/proxy-ghcr/stakater/reloader:v1.4.16\n' ;;
     deployments/orgns/myapp) printf 'a=nginx:1.27\ns=rancher/k3s:v1\n' ;;
     deployments/catalyst/registry-pivot) printf 'p=harbor.openova.io/proxy-ghcr/x/y:z\n' ;;
@@ -2049,32 +2064,34 @@ _lint_fail_out=$(
   set +e; set -u
   export PATH="$_lintdir/bin:$PATH"
   export LOCAL_REGISTRY_HOST="registry.t99.omani.works"
+  export HOST_PROJECT_MAP="$_HPM"
   export EXCLUDED_HOSTS="xpkg.upbound.io"; export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
   export FRESH_PULL_EXCLUDE_WORKLOADS="catalyst/registry-pivot"
   . "$_lintdir/lint.sh"; run_podspec_refhost_lint; echo "RC=$?"
 )
 if ! grep -q 'RC=1' <<<"$_lint_fail_out"; then
-  echo "FAIL: ref-host lint did not FAIL on a residual harbor.openova.io ref; output:\n$_lint_fail_out" >&2; exit 1
+  echo "FAIL: ref-host lint did not FAIL on an un-covered github.com ref; output:\n$_lint_fail_out" >&2; exit 1
 fi
-if ! grep -q 'UNPIVOTED velero/velero.*host:harbor.openova.io' <<<"$_lint_fail_out"; then
-  echo "FAIL: ref-host lint did not name the velero offender (#5026); output:\n$_lint_fail_out" >&2; exit 1
+if ! grep -q 'UNCOVERED bad/badapp.*host:github.com' <<<"$_lint_fail_out"; then
+  echo "FAIL: ref-host lint did not name the github.com offender (#5036); output:\n$_lint_fail_out" >&2; exit 1
 fi
-# The excluded workload (registry-pivot), the implicit-docker.io ref (nginx), the
-# excluded substring (rancher/k3s), and the already-local ref (reloader) must NOT
-# be flagged.
-if grep -qE 'UNPIVOTED (catalyst/registry-pivot|orgns/myapp|reloader/)' <<<"$_lint_fail_out"; then
-  echo "FAIL: ref-host lint flagged an excluded / implicit-docker.io / already-local ref (false positive) (#5026); output:\n$_lint_fail_out" >&2; exit 1
+# #5036 CORE: the redirect-covered mothership (harbor.openova.io) + proxy-cache (ghcr.io)
+# refs, the excluded workload, the implicit-docker.io ref, the excluded substring, and
+# the already-local ref must NOT be flagged.
+if grep -qE 'UNCOVERED (velero/velero|cnpg/cnpg-controller|catalyst/registry-pivot|orgns/myapp|reloader/)' <<<"$_lint_fail_out"; then
+  echo "FAIL: ref-host lint flagged a redirect-covered / excluded / implicit-docker.io / already-local ref (false positive) (#5036); output:\n$_lint_fail_out" >&2; exit 1
 fi
-# PASS fixture: velero pivoted to local.
+# PASS fixture: every ref is the local registry OR redirect-covered.
 cat > "$_lintdir/bin/kubectl" <<'MOCK'
 #!/bin/sh
 kind="$2"
 if [ "$3" = "-A" ]; then
-  case "$kind" in deployments) printf 'velero velero\norgns myapp\n' ;; daemonsets) printf '' ;; statefulsets) printf '' ;; esac
+  case "$kind" in deployments) printf 'velero velero\ncnpg cnpg-controller\norgns myapp\n' ;; daemonsets) printf '' ;; statefulsets) printf '' ;; esac
 else
   key="$kind/$5/$3"
   case "$key" in
-    deployments/velero/velero) printf 'velero=registry.t99.omani.works/proxy-dockerhub/velero/velero:v1.18.0\n' ;;
+    deployments/velero/velero) printf 'velero=harbor.openova.io/proxy-dockerhub/velero/velero:v1.18.0\n' ;;
+    deployments/cnpg/cnpg-controller) printf 'c=registry.t99.omani.works/proxy-ghcr/cloudnative-pg/postgresql:16.4\n' ;;
     deployments/orgns/myapp) printf 'a=nginx:1.27\n' ;;
     *) printf '' ;;
   esac
@@ -2085,14 +2102,15 @@ _lint_pass_out=$(
   set +e; set -u
   export PATH="$_lintdir/bin:$PATH"
   export LOCAL_REGISTRY_HOST="registry.t99.omani.works"
+  export HOST_PROJECT_MAP="$_HPM"
   export EXCLUDED_HOSTS="xpkg.upbound.io"; export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
   export FRESH_PULL_EXCLUDE_WORKLOADS="catalyst/registry-pivot"
   . "$_lintdir/lint.sh"; run_podspec_refhost_lint; echo "RC=$?"
 )
 if ! grep -q 'RC=0' <<<"$_lint_pass_out"; then
-  echo "FAIL: ref-host lint did not PASS when every ref is local; output:\n$_lint_pass_out" >&2; exit 1
+  echo "FAIL: ref-host lint did not PASS when every ref is local or redirect-covered; output:\n$_lint_pass_out" >&2; exit 1
 fi
-echo "  PASS (lint fails loud listing offenders on a tether ref; passes when all-local; skips excluded/implicit-docker.io)"
+echo "  PASS (lint fails loud on an un-covered github.com tether; exempts redirect-covered harbor.openova.io + ghcr.io; skips excluded/implicit-docker.io/local)"
 
 echo "[cutover-contract] Case 52: PRE-pivot steps 02/03 dial the local Harbor at the IN-CLUSTER Service (HARBOR_INTERNAL_URL = harbor-core.harbor.svc), NOT the external registry.<fqdn> (HARBOR_PUBLIC_URL) — the external host NXDOMAINs in-cluster before the step-04 pin (#5036, reverts #4688, Refs #5007)"
 # hw246 (dep c38c437f, omani.works): steps 02 (harbor-projects) + 03 (harbor-prewarm)
@@ -2169,5 +2187,39 @@ for blk in s02 s03; do
   done
 done
 echo "  PASS (steps 02/03 dial the in-cluster harbor-core.harbor.svc for API + skopeo push; single-encode %2F for the direct path; no HARBOR_PUBLIC_URL dial target remains; steps 07/08 external-host validation untouched)"
+
+echo "[cutover-contract] Case 53: step-08 ref-host lint #5036 CONTRACT — a redirect-covered mothership ref (harbor.openova.io/proxy-*) is SOVEREIGN (PASS); an un-covered external ref (github.com/*) is an offender (FAIL). NB: ghcr.io is NOT a valid FAIL example — step-04 redirect-covers it (proxy-ghcr; verified live hw246), so it PASSES too."
+_c53="$TMP/lint53"; mkdir -p "$_c53/bin" "$_c53/work"
+_slice_fn "$TMP/r08.yaml" run_podspec_refhost_lint | sed 's#/work/#'"$_c53"'/work/#g' > "$_c53/lint.sh"
+_run53() { # $1 = mock kubectl body
+  cp "$1" "$_c53/bin/kubectl"; chmod +x "$_c53/bin/kubectl"
+  ( set +e; set -u
+    export PATH="$_c53/bin:$PATH"
+    export LOCAL_REGISTRY_HOST="registry.t99.omani.works"
+    export HOST_PROJECT_MAP="ghcr.io:proxy-ghcr harbor.openova.io:"
+    export EXCLUDED_HOSTS="xpkg.upbound.io"; export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
+    export FRESH_PULL_EXCLUDE_WORKLOADS="catalyst/registry-pivot"
+    . "$_c53/lint.sh"; run_podspec_refhost_lint; echo "RC=$?" )
+}
+# (a) redirect-covered mothership ref → SOVEREIGN → PASS (the exact ~40-workload case)
+cat > "$_c53/moth.sh" <<'MOCK'
+#!/bin/sh
+[ "$3" = "-A" ] && { [ "$2" = deployments ] && printf 'velero velero\n'; exit 0; }
+[ "$2/$5/$3" = "deployments/velero/velero" ] && printf 'v=harbor.openova.io/proxy-dockerhub/velero/velero:v1.18.0\n'
+exit 0
+MOCK
+_o=$(_run53 "$_c53/moth.sh")
+grep -q 'RC=0' <<<"$_o" || { printf 'FAIL: #5036 — a redirect-covered harbor.openova.io/proxy-* ref was NOT treated as sovereign; output:\n%s\n' "$_o" >&2; exit 1; }
+# (b) un-covered github.com ref → offender → FAIL, named UNCOVERED
+cat > "$_c53/gh.sh" <<'MOCK'
+#!/bin/sh
+[ "$3" = "-A" ] && { [ "$2" = deployments ] && printf 'bad badapp\n'; exit 0; }
+[ "$2/$5/$3" = "deployments/bad/badapp" ] && printf 'c=github.com/acme/tool:v1\n'
+exit 0
+MOCK
+_o=$(_run53 "$_c53/gh.sh")
+grep -q 'RC=1' <<<"$_o" || { printf 'FAIL: #5036 — an un-covered github.com ref did NOT fail the lint; output:\n%s\n' "$_o" >&2; exit 1; }
+grep -q 'UNCOVERED bad/badapp.*host:github.com' <<<"$_o" || { printf 'FAIL: #5036 — github.com offender not named UNCOVERED; output:\n%s\n' "$_o" >&2; exit 1; }
+echo "  PASS (#5036 contract: mothership redirect-covered ref sovereign; un-covered github.com ref is a named offender; ghcr.io documented as redirect-covered → not a FAIL example)"
 
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.125"
+  version: "0.1.126"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.125"
+    version: "0.1.126"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Summary

Option A for #5036: make the step-08 pre-hold **ref-host lint** (`run_podspec_refhost_lint`, added #5026/#5027) **redirect-aware** so it no longer fails on the ~40 workloads whose chart-default image ref is `harbor.openova.io/proxy-*`.

`Refs #5036 #5026 #5027 #4975`

## Root cause

The lint's premise was "every rolled workload pod-spec image host must be `registry.<fqdn>`", so it flagged `harbor.openova.io/proxy-*` refs as tethers and exited **before** the deny-egress hold. But `harbor.openova.io` is **redirect-covered**: step-04's `registry-pivot` DaemonSet writes a containerd `certs.d/<host>/hosts.toml` redirect to `registry.<fqdn>` for **every** host in `HOST_PROJECT_MAP` — the mothership `harbor.openova.io` host-swap **and** `ghcr.io` / `docker.io` / `quay.io` / `registry.k8s.io` / … proxy-cache. A pod-spec ref on one of those hosts pulls from the **local** Harbor via the redirect and never dials the mothership — it is already sovereign.

### Live evidence (hw246, dep `c38c437f`, `omani.works` — reached step-08)

```
# certs.d/harbor.openova.io/hosts.toml on a hw246 node (step-04 wrote it):
server = "https://harbor.openova.io"
[host."https://registry.hw246.omani.works"]
  capabilities = ["pull", "resolve"]
  skip_verify = true
```

`ghcr.io` → `registry.hw246.omani.works/v2/proxy-ghcr`, `docker.io` → `.../proxy-dockerhub`, etc. are all present too.

## The fix

`run_podspec_refhost_lint` now treats a workload image host as sovereign when it is **either** `LOCAL_REGISTRY_HOST` (registry.<fqdn>) **or** a host that appears in `HOST_PROJECT_MAP` — the **same** single-source env step-04 loops over to write its redirects (no fresh hardcoded literal). A **genuine offender** is a host with **no** redirect (e.g. a raw `github.com/…` ref) that deny-egress would actually block.

> Note: `ghcr.io`/`docker.io` are NOT valid "offender" examples — step-04 redirect-covers them (`proxy-ghcr`/`proxy-dockerhub`), so they pull locally and correctly PASS. The only genuine pre-hold offender is a host absent from `HOST_PROJECT_MAP` (e.g. `github.com`).

### Why this does not weaken the sovereignty guarantee

The **deny-egress hold** and the **offline-mirror completeness gate** are **UNCHANGED** and remain the authoritative proof. A redirect-covered ref that could not actually pull locally would still `ImagePullBackOff` **during** the hold and fail the proof, so relaxing the pre-hold lint removes only a false positive on an already-local ref — never a real tether. The hold, the completeness gate, and the call-home assertion are byte-identical.

## Tests

- Rewrote `cutover-contract` **Case 51** to be redirect-aware: FAILS loud on an un-covered `github.com` host; PASSES redirect-covered `harbor.openova.io` + `ghcr.io`, the local registry, implicit-docker.io, excluded hosts/substrings, and excluded workloads. Also asserts the lint derives its exemption set from `HOST_PROJECT_MAP` (regression-proofs redirect-awareness).
- Added **Case 53** — the crisp #5036 contract: a redirect-covered mothership ref (`harbor.openova.io/proxy-*`) is sovereign (PASS); an un-covered external ref (`github.com/*`) is a named offender (FAIL); documents in-code why `ghcr.io` is redirect-covered and thus not a valid FAIL example.
- `bash tests/cutover-contract.sh` → all 53 gates green; `bash tests/image-registry-coverage.sh` → green; `helm lint` clean.

## Versioning

Chart `0.1.125` → `0.1.126` + lockstep pins: `blueprint.yaml`, bootstrap-kit slot `06a-bp-self-sovereign-cutover.yaml`, catalog-seed `blueprints.yaml` (×2).

## Deferred (backlog)

**Option B** — a comprehensive step-07 sweep that *textually* rewrites all `harbor.openova.io/proxy-*` (and other redirect-covered) refs to `registry.<fqdn>` (belt-and-suspenders) — is deferred pending the founder sovereignty-posture decision. It is not required for the sovereignty proof: redirect-coverage + the deny-egress hold already guarantee no mothership dial.

## Pillar

Pillar 5 (sovereign independence post-`bp-self-sovereign-cutover`), step-08 egress-block-test — the final gate to `cutoverComplete` on a fully-fixed prov. Not verified on a fresh prov yet; the orchestrator drives that walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
