### PR TITLE
fix(catalyst-api): replication-status reports verified standby state, never synthesized health

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -68,10 +68,19 @@ type continuumReplicationStatus struct {
 	StreamingState    string                  `json:"streamingState"`
 	SyncState         string                  `json:"syncState"`
 	LastHeartbeat     string                  `json:"lastHeartbeat"`
+	// StandbyAvailable is the TRI-STATE standby-leg verdict (#4923/#4901):
+	// true  — the standby half was verified reachable+following off the live
+	//         cnpg cluster-pair;
+	// false — the required hot-standby is ABSENT (region-kill / outage) —
+	//         the explicit honest condition, never masked by a green shape;
+	// nil (omitted) — no cnpg pair resolvable, so the standby leg cannot be
+	//         verified from live cluster state; reported as unknown, NOT as
+	//         a fabricated healthy.
+	StandbyAvailable *bool                   `json:"standbyAvailable,omitempty"`
 	Replicas          []continuumReplicaInfo  `json:"replicas"`
 	HealthGates       []continuumHealthGate   `json:"healthGates"`
 	ObservedAt        string                  `json:"observedAt"`
-	Source            string                  `json:"source"` // "live" | "synthesized"
+	Source            string                  `json:"source"` // "live" | "pending"
 }
 
 // continuumHealthGate — one row in the replication status health-gate list.
@@ -320,9 +329,89 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 	// 2-region pair resolves (e.g. openbao-raft spine continuums).
 	h.augmentReplicationSyncFromLivePair(
 		r.Context(), client, appNameFromContinuumName(cr.GetName()), cr.GetNamespace(), &resp)
+	// #4923/#4901 — VERIFY the standby leg off the live cnpg cluster-pair and
+	// surface the tri-state verdict (available / ABSENT / unverifiable). The
+	// continuum-controller's stored status stays green through a hot-standby
+	// outage (it derives phase from lease-held-ness alone), so the endpoint
+	// must cross-check the replica half itself — never relay a fabricated
+	// Healthy.
+	h.augmentReplicationStandbyStatus(r.Context(), client, cr, &resp)
 	resp.Source = "live"
 	resp.ObservedAt = h.continuumNow().UTC().Format(time.RFC3339)
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// augmentReplicationStandbyStatus cross-checks the LIVE standby leg for a
+// Continuum-CR-backed replication-status response and stamps the tri-state
+// standbyAvailable verdict + the standby-available health gate (#4923, the
+// replication-status sibling of #4901's augmentContinuumStandbyStatus):
+//
+//   - spec.cnpgPair present + replica half resolvable → verified verdict
+//     (cnpgPairStandbyForContinuum — the #4901 path).
+//   - otherwise, a cnpg pair resolvable for the APP (label-driven, tenant-
+//     isolation-safe findCNPGPairForApp) → verified verdict off its replica
+//     half.
+//   - no pair resolvable at all (dr-spine / openbao-raft continuums) → the
+//     verdict stays UNKNOWN (standbyAvailable omitted) and an explicit Warn
+//     gate says the standby leg is unverifiable — honest-unknown, NEVER a
+//     fabricated Pass.
+//
+// On an ABSENT standby the response is forced non-promotable and the
+// streaming state reads "interrupted" — a lost required standby must never
+// render as a promotable green pair (the #4901 outage shape).
+func (h *Handler) augmentReplicationStandbyStatus(
+	ctx context.Context,
+	client dynamic.Interface,
+	cr *unstructured.Unstructured,
+	resp *continuumReplicationStatus,
+) {
+	available := false
+	region := ""
+	determined := false
+	if st, ok := h.cnpgPairStandbyForContinuum(ctx, client, cr); ok {
+		available, region, determined = st.Available, st.ReplicaRegion, true
+	} else {
+		appName, _, _ := unstructured.NestedString(cr.Object, "spec", "applicationRef")
+		if strings.TrimSpace(appName) == "" {
+			appName = appNameFromContinuumName(cr.GetName())
+		}
+		if ps, err := h.findCNPGPairForApp(ctx, client, appName, cr.GetNamespace()); err == nil && ps != nil {
+			available, region, determined = ps.StandbyAvailable, ps.ReplicaRegion, true
+		}
+	}
+	if !determined {
+		upsertHealthGate(resp, continuumHealthGate{
+			Name: "standby-available", Status: "Warn", Severity: "warning",
+			Message: "standby leg not verifiable from live cluster state (no cnpg pair resolvable); reporting unknown, not healthy",
+		})
+		return
+	}
+	resp.StandbyAvailable = &available
+	if available {
+		upsertHealthGate(resp, continuumHealthGate{
+			Name: "standby-available", Status: "Pass", Severity: "info",
+			Message: fmt.Sprintf("hot-standby in %s is reachable", standbyRegionLabel(region)),
+		})
+		return
+	}
+	resp.ReplicaPromotable = false
+	resp.StreamingState = "interrupted"
+	upsertHealthGate(resp, continuumHealthGate{
+		Name: "standby-available", Status: "Fail", Severity: "critical",
+		Message: fmt.Sprintf("required hot-standby in %s is unreachable; replication has no standby leg and RPO=0 durability is at risk",
+			standbyRegionLabel(region)),
+	})
+}
+
+// upsertHealthGate replaces the gate of the same name or appends it.
+func upsertHealthGate(resp *continuumReplicationStatus, gate continuumHealthGate) {
+	for i := range resp.HealthGates {
+		if resp.HealthGates[i].Name == gate.Name {
+			resp.HealthGates[i] = gate
+			return
+		}
+	}
+	resp.HealthGates = append(resp.HealthGates, gate)
 }
 
 // HandleContinuumSwitchoverHistory — GET
@@ -599,6 +688,12 @@ func (h *Handler) HandleDRReplicationStatus(w http.ResponseWriter, r *http.Reque
 		ContinuumCount    int                          `json:"continuumCount"`
 		ReplicasHealthy   int                          `json:"replicasHealthy"`
 		ReplicasDegraded  int                          `json:"replicasDegraded"`
+		// ReplicasUnknown counts continuums whose standby leg could not be
+		// verified from live cluster state (no cnpg pair resolvable — e.g.
+		// dr-spine/raft continuums). Reported honestly as UNKNOWN instead of
+		// being folded into healthy (#4923 hw242 evidence: all four dr-spine-*
+		// read Healthy while region-B ran zero workloads).
+		ReplicasUnknown   int                          `json:"replicasUnknown"`
 		MaxWALLagSeconds  float64                      `json:"maxWalLagSeconds"`
 		Continuums        []continuumReplicationStatus `json:"continuums"`
 		ObservedAt        string                       `json:"observedAt"`
@@ -625,13 +720,20 @@ func (h *Handler) HandleDRReplicationStatus(w http.ResponseWriter, r *http.Reque
 	for i := range list.Items {
 		cr := &list.Items[i]
 		row := enrichReplicationStatus(cr)
+		// #4923 — verify the standby leg off the live cnpg pair per row (the
+		// stored CR status alone stays green through a standby outage). Rows
+		// whose standby cannot be verified count as UNKNOWN — never healthy.
+		h.augmentReplicationStandbyStatus(r.Context(), client, cr, &row)
 		row.Source = "live"
 		out.Continuums = append(out.Continuums, row)
 		out.ContinuumCount++
-		if row.ReplicaPromotable {
+		switch {
+		case row.StandbyAvailable != nil && *row.StandbyAvailable:
 			out.ReplicasHealthy++
-		} else {
+		case row.StandbyAvailable != nil:
 			out.ReplicasDegraded++
+		default:
+			out.ReplicasUnknown++
 		}
 		if row.WALLagSeconds > out.MaxWALLagSeconds {
 			out.MaxWALLagSeconds = row.WALLagSeconds
@@ -917,32 +1019,97 @@ func enrichReplicationStatus(cr *unstructured.Unstructured) continuumReplication
 		out.WALLagSeconds = readNumericNested(cr.Object, "status", "replicationLagSeconds")
 	}
 	out.WALLagBytes = int64(readNumericNested(cr.Object, "status", "walLagBytes"))
-	if streaming, _, _ := unstructured.NestedString(cr.Object, "status", "streamingState"); streaming != "" {
-		out.StreamingState = streaming
-	} else {
-		out.StreamingState = "streaming"
-	}
-	if sync, _, _ := unstructured.NestedString(cr.Object, "status", "syncState"); sync != "" {
-		out.SyncState = sync
-	} else {
-		out.SyncState = "async"
-	}
-	out.ReplicaPromotable = out.WALLagSeconds <= 30
+	// #4923 — NO fabricated defaults. The prior code defaulted streamingState
+	// to "streaming" and syncState to "async" when the CR omitted them —
+	// synthesized telemetry the operator could not distinguish from a live
+	// reading (and flatly wrong on a synchronous RPO=0 pair). Empty = the CR
+	// does not report it; the live cnpg-pair augmentation fills syncState when
+	// a real pair resolves, and the UI renders "—" otherwise.
+	out.StreamingState, _, _ = unstructured.NestedString(cr.Object, "status", "streamingState")
+	out.SyncState, _, _ = unstructured.NestedString(cr.Object, "status", "syncState")
+	// #4923 — replicaPromotable needs POSITIVE evidence that a standby exists
+	// and follows (status.replicationHealthy), not just "lag number is small":
+	// an ABSENT standby also reads lag=0 (#4901 — health/lag stayed green for
+	// the whole hot-standby outage), so the old `lag <= 30` marked a lost
+	// standby promotable. The live-pair standby augmentation upgrades this
+	// when it verifies the standby off the cnpg cluster-pair.
+	replHealthy, replHealthyFound, _ := unstructured.NestedBool(cr.Object, "status", "replicationHealthy")
+	out.ReplicaPromotable = replHealthyFound && replHealthy && out.WALLagSeconds <= 30
+	// #4923 — health gates DERIVED from the observed CR status, never a
+	// hardcoded all-Pass wall (the prior shape reported "streaming-replication
+	// Pass" during a proven standby outage).
+	phase, _, _ := unstructured.NestedString(cr.Object, "status", "phase")
+	leaseHolder, _, _ := unstructured.NestedString(cr.Object, "status", "leaseHolder")
 	out.HealthGates = []continuumHealthGate{
-		{Name: "streaming-replication", Status: "Pass", Severity: "info"},
-		{Name: "wal-lag-under-rpo", Status: "Pass", Severity: "info"},
-		{Name: "lease-witness-quorum", Status: "Pass", Severity: "info"},
+		replicationHealthGate(replHealthy, replHealthyFound, phase),
+		walLagHealthGate(cr.Object, out.WALLagSeconds),
+		leaseWitnessHealthGate(leaseHolder),
 	}
+	// The configured standby regions from spec — placement config, labelled as
+	// such via the honest lastHeartbeat handling: only a heartbeat the CR
+	// actually reports is surfaced, never a fabricated now() stamp.
+	hb, _, _ := unstructured.NestedString(cr.Object, "status", "lastHeartbeat")
+	out.LastHeartbeat = hb
 	standbys, _, _ := unstructured.NestedStringSlice(cr.Object, "spec", "hotStandbyRegions")
 	for _, region := range standbys {
 		out.Replicas = append(out.Replicas, continuumReplicaInfo{
 			Region:        region,
 			Role:          "replica",
 			LagSeconds:    out.WALLagSeconds,
-			LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
+			LastHeartbeat: hb,
 		})
 	}
 	return out
+}
+
+// replicationHealthGate derives the streaming-replication gate from the
+// observed status. Tri-state honest: Pass only on a positive
+// replicationHealthy=true reading; Fail on an explicit false or a
+// Degraded/FailedOver phase; Warn (unverified) when the CR reports neither —
+// NEVER a default Pass. #4923.
+func replicationHealthGate(healthy, found bool, phase string) continuumHealthGate {
+	switch {
+	case found && healthy:
+		return continuumHealthGate{Name: "streaming-replication", Status: "Pass", Severity: "info"}
+	case found && !healthy:
+		return continuumHealthGate{Name: "streaming-replication", Status: "Fail", Severity: "critical",
+			Message: "replication reported unhealthy on the Continuum CR"}
+	case phase == "Degraded" || phase == "FailedOver":
+		return continuumHealthGate{Name: "streaming-replication", Status: "Fail", Severity: "critical",
+			Message: fmt.Sprintf("Continuum phase is %s", phase)}
+	default:
+		return continuumHealthGate{Name: "streaming-replication", Status: "Warn", Severity: "warning",
+			Message: "replication health not reported by the Continuum CR; unverified"}
+	}
+}
+
+// walLagHealthGate derives the wal-lag gate: Pass only when the CR actually
+// REPORTS a lag reading under the 30s promotability threshold; Warn when the
+// reading is over threshold or absent entirely (absent lag is unknown, not a
+// healthy zero — #4901's outage kept lag pinned at 0). #4923.
+func walLagHealthGate(obj map[string]interface{}, lag float64) continuumHealthGate {
+	_, foundWAL, _ := unstructured.NestedFieldNoCopy(obj, "status", "walLagSeconds")
+	_, foundRepl, _ := unstructured.NestedFieldNoCopy(obj, "status", "replicationLagSeconds")
+	if !foundWAL && !foundRepl {
+		return continuumHealthGate{Name: "wal-lag-under-rpo", Status: "Warn", Severity: "warning",
+			Message: "replication lag not reported by the Continuum CR; unverified"}
+	}
+	if lag > 30 {
+		return continuumHealthGate{Name: "wal-lag-under-rpo", Status: "Warn", Severity: "warning",
+			Message: fmt.Sprintf("replication lag %.0fs exceeds the 30s promotability threshold", lag)}
+	}
+	return continuumHealthGate{Name: "wal-lag-under-rpo", Status: "Pass", Severity: "info"}
+}
+
+// leaseWitnessHealthGate derives the witness-lease gate from the observed
+// lease holder: Pass when a region holds the lease, Warn when no lease is
+// observed. #4923.
+func leaseWitnessHealthGate(leaseHolder string) continuumHealthGate {
+	if strings.TrimSpace(leaseHolder) != "" {
+		return continuumHealthGate{Name: "lease-witness-quorum", Status: "Pass", Severity: "info"}
+	}
+	return continuumHealthGate{Name: "lease-witness-quorum", Status: "Warn", Severity: "warning",
+		Message: "no witness-lease holder observed on the Continuum CR"}
 }
 
 // findContinuumCRByApplicationRef lists every Continuum CR cluster-wide
@@ -1005,7 +1172,22 @@ func (h *Handler) liveReplicationStatusFromCNPGPair(
 	if sr, _ := rec.Status["syncReplication"].(bool); sr {
 		syncState = "sync"
 	}
-	if !healthy {
+	// #4923/#4901 — the VERIFIED standby-leg availability off the live pair
+	// (replica half Ready + >=1 ready instance). standbyAvailable=false is the
+	// explicit standby-absent condition: streaming honestly reads
+	// "interrupted", the standby-available gate FAILS critical, and the
+	// replica is never marked promotable — a lost required-sync standby must
+	// never render as a healthy green pair.
+	standbyAvailable, _ := rec.Status["standbyAvailable"].(bool)
+	standbyGate := continuumHealthGate{Name: "standby-available", Status: "Pass", Severity: "info",
+		Message: fmt.Sprintf("hot-standby in %s is reachable", standbyRegionLabel(replicaRegion))}
+	switch {
+	case !standbyAvailable:
+		streaming = "interrupted"
+		standbyGate = continuumHealthGate{Name: "standby-available", Status: "Fail", Severity: "critical",
+			Message: fmt.Sprintf("required hot-standby in %s is unreachable; replication has no standby leg and RPO=0 durability is at risk",
+				standbyRegionLabel(replicaRegion))}
+	case !healthy:
 		streaming = "catching-up"
 	}
 	out := continuumReplicationStatus{
@@ -1014,17 +1196,17 @@ func (h *Handler) liveReplicationStatusFromCNPGPair(
 		PrimaryRegion:     primaryRegion,
 		CurrentPrimary:    currentPrimary,
 		WALLagSeconds:     lag,
-		ReplicaPromotable: healthy && lag <= 30,
+		ReplicaPromotable: standbyAvailable && healthy && lag <= 30,
 		StreamingState:    streaming,
 		SyncState:         syncState,
+		StandbyAvailable:  &standbyAvailable,
 		Replicas: []continuumReplicaInfo{
-			{Region: replicaRegion, Role: "replica", LagSeconds: lag,
-				LastHeartbeat: h.continuumNow().UTC().Format(time.RFC3339)},
+			{Region: replicaRegion, Role: "replica", LagSeconds: lag},
 		},
 		HealthGates: []continuumHealthGate{
 			{Name: "streaming-replication", Status: gatePass(healthy), Severity: "info"},
 			{Name: "wal-lag-under-rpo", Status: gatePass(lag <= 30), Severity: "info"},
-			{Name: "lease-witness-quorum", Status: "Pass", Severity: "info"},
+			standbyGate,
 		},
 		Source: "live",
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4923_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4923_test.go
@@ -1,0 +1,339 @@
+// continuum_dr_extras_4923_test.go — #4923 regression coverage (hw242 wave).
+//
+// The replication-status endpoint must report REAL replication state derived
+// from the live CNPG cluster-pair / Continuum CRs — never a synthesized
+// healthy shape. This file locks the four honest states:
+//
+//   pair-healthy    — standbyAvailable:true, standby-available gate Pass.
+//   standby-absent  — standbyAvailable:false, standby-available gate Fail
+//                     (critical), replicaPromotable forced false, streaming
+//                     "interrupted" (the #4901 region-kill shape — the stored
+//                     CR status stays green through the outage, so the
+//                     endpoint cross-checks the replica half itself).
+//   unverifiable    — standbyAvailable OMITTED + an explicit Warn gate for
+//                     continuums with no resolvable cnpg pair (dr-spine /
+//                     openbao-raft) — honest-unknown, never fabricated Pass.
+//   no-pair         — source:"pending" honest-empty (locked by the #4551 /
+//                     #4930 suites).
+//
+// It also locks that enrichReplicationStatus no longer fabricates
+// streamingState:"streaming" / syncState:"async" / an all-Pass health-gate
+// wall / a now() replica heartbeat on CRs that report none, and that the
+// sovereign-wide roll-up counts unverifiable rows as replicasUnknown instead
+// of healthy.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// setCNPGReplicaDown marks the replica half of a cnpg pair fixture as NOT
+// Ready with zero ready instances — the proven #4901 region-kill state
+// (region-b nodes cordoned, replica Pods deleted).
+func setCNPGReplicaDown(replica *unstructured.Unstructured) {
+	_ = unstructured.SetNestedSlice(replica.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "False"},
+	}, "status", "conditions")
+	_ = unstructured.SetNestedField(replica.Object, int64(0), "status", "readyInstances")
+}
+
+func gateByName(t *testing.T, resp continuumReplicationStatus, name string) continuumHealthGate {
+	t.Helper()
+	for _, g := range resp.HealthGates {
+		if g.Name == name {
+			return g
+		}
+	}
+	t.Fatalf("health gate %q missing; got %+v", name, resp.HealthGates)
+	return continuumHealthGate{}
+}
+
+// pair-healthy — a Continuum CR referencing a cnpg pair whose replica half is
+// Ready must report standbyAvailable:true with a Pass gate.
+func TestReplicationStatus_StandbyAvailableVerifiedFromReferencedPair(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"cnpg-pair-bp-cnpg-pair-continuum", "catalyst-system",
+		"catalyst-platform", "me-east-215-a", []string{"me-east-215-b"})
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"name":      "shared-pg",
+		"namespace": "catalyst-system",
+	}, "spec", "cnpgPair")
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-b")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	fixed := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-4923-standby-ok")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cnpg-pair-bp-cnpg-pair-continuum/replication-status?namespace=catalyst-system", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source != "live" {
+		t.Errorf("source: got %q want live", resp.Source)
+	}
+	if resp.StandbyAvailable == nil || !*resp.StandbyAvailable {
+		t.Errorf("standbyAvailable: got %v want true (replica half Ready)", resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Pass" {
+		t.Errorf("standby-available gate: got %q want Pass (msg=%q)", g.Status, g.Message)
+	}
+}
+
+// standby-absent — the replica half down (region-kill) must surface the
+// explicit honest condition: standbyAvailable:false, a critical Fail gate,
+// replicaPromotable forced false, streaming "interrupted". The stored CR
+// status says Healthy/lag=0 the whole time — the endpoint must NOT relay it.
+func TestReplicationStatus_StandbyAbsentIsExplicitNeverHealthy(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"cnpg-pair-bp-cnpg-pair-continuum", "catalyst-system",
+		"catalyst-platform", "me-east-215-a", []string{"me-east-215-b"})
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"name":      "shared-pg",
+		"namespace": "catalyst-system",
+	}, "spec", "cnpgPair")
+	// The controller-stored status stays green during the outage (#4901).
+	_ = unstructured.SetNestedField(cr.Object, "Healthy", "status", "phase")
+	_ = unstructured.SetNestedField(cr.Object, int64(0), "status", "replicationLagSeconds")
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-b")
+	setCNPGReplicaDown(replica)
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4923-standby-absent")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cnpg-pair-bp-cnpg-pair-continuum/replication-status?namespace=catalyst-system", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.StandbyAvailable == nil || *resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want false (replica half down)", resp.StandbyAvailable)
+	}
+	g := gateByName(t, resp, "standby-available")
+	if g.Status != "Fail" || g.Severity != "critical" {
+		t.Errorf("standby-available gate: got status=%q severity=%q want Fail/critical", g.Status, g.Severity)
+	}
+	if resp.ReplicaPromotable {
+		t.Errorf("replicaPromotable: got true want false — an absent standby is never promotable")
+	}
+	if resp.StreamingState != "interrupted" {
+		t.Errorf("streamingState: got %q want interrupted", resp.StreamingState)
+	}
+}
+
+// unverifiable — a spine Continuum with NO cnpg pair must report the verdict
+// as UNKNOWN (standbyAvailable omitted) with an explicit Warn gate, and the
+// enrich layer must not fabricate streaming/async/all-Pass shapes for it.
+func TestReplicationStatus_SpineWithoutPairReportsUnknownNotFabricatedGreen(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-spine-openbao", "openbao", "openbao",
+		"me-east-215-a", []string{"me-east-215-b"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4923-spine-unknown")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-spine-openbao/replication-status?namespace=openbao", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.StandbyAvailable != nil {
+		t.Errorf("standbyAvailable: got %v want omitted (nil) — no cnpg pair to verify against", *resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Warn" {
+		t.Errorf("standby-available gate: got %q want Warn (unverifiable, not fabricated Pass)", g.Status)
+	}
+	// The fabricated defaults are GONE: the CR reports neither streaming nor
+	// sync state, so both are empty — never "streaming"/"async".
+	if resp.StreamingState != "" {
+		t.Errorf("streamingState: got %q want empty (CR reports none)", resp.StreamingState)
+	}
+	if resp.SyncState != "" {
+		t.Errorf("syncState: got %q want empty (CR reports none — the old hardcoded async misled the operator)", resp.SyncState)
+	}
+	// replication health is unreported on the CR → the gate is Warn, and a
+	// small lag number alone must not mark the replica promotable.
+	if g := gateByName(t, resp, "streaming-replication"); g.Status != "Warn" {
+		t.Errorf("streaming-replication gate: got %q want Warn (health not reported)", g.Status)
+	}
+	if resp.ReplicaPromotable {
+		t.Errorf("replicaPromotable: got true want false — no positive replication evidence on the CR")
+	}
+	// No fabricated now() heartbeat on the configured standby rows.
+	for _, rep := range resp.Replicas {
+		if rep.LastHeartbeat != "" {
+			t.Errorf("replica %s: fabricated lastHeartbeat %q (CR reports none)", rep.Region, rep.LastHeartbeat)
+		}
+	}
+}
+
+// app-level fallback — a Continuum CR WITHOUT spec.cnpgPair whose app is
+// backed by a resolvable pair (label-driven, namespace-scoped) still gets a
+// verified verdict off that pair's replica half.
+func TestReplicationStatus_StandbyVerifiedViaAppPairFallback(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "catalyst-system", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-b")
+	setCNPGReplicaDown(replica)
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4923-app-fallback")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-shared-pg/replication-status?namespace=catalyst-system", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.StandbyAvailable == nil || *resp.StandbyAvailable {
+		t.Errorf("standbyAvailable: got %v want false (app pair replica down, resolved without spec.cnpgPair)", resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Fail" {
+		t.Errorf("standby-available gate: got %q want Fail", g.Status)
+	}
+}
+
+// derive path (no Continuum CR) — a live pair whose replica half is down must
+// report the standby-absent condition off the derived record too.
+func TestReplicationStatus_DerivedLivePairSurfacesStandbyAbsent(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-b")
+	setCNPGReplicaDown(replica)
+	factory, _ := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4923-derive-absent")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-shared-pg/replication-status?namespace=catalyst-system", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source != "live" {
+		t.Fatalf("source: got %q want live (derived off the real pair)", resp.Source)
+	}
+	if resp.StandbyAvailable == nil || *resp.StandbyAvailable {
+		t.Errorf("standbyAvailable: got %v want false", resp.StandbyAvailable)
+	}
+	if resp.ReplicaPromotable {
+		t.Errorf("replicaPromotable: got true want false")
+	}
+	if resp.StreamingState != "interrupted" {
+		t.Errorf("streamingState: got %q want interrupted", resp.StreamingState)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Fail" || g.Severity != "critical" {
+		t.Errorf("standby-available gate: got %q/%q want Fail/critical", g.Status, g.Severity)
+	}
+}
+
+// roll-up — the sovereign-wide aggregate must count a verified-absent standby
+// as degraded and an unverifiable spine as UNKNOWN, never healthy. The old
+// code counted every low-lag row healthy (lag=0 during an outage → all green).
+func TestDRReplicationStatusRollup_HonestHealthyDegradedUnknownCounters(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	pairCR := newContinuumUnstructured(
+		"cnpg-pair-bp-cnpg-pair-continuum", "catalyst-system",
+		"catalyst-platform", "me-east-215-a", []string{"me-east-215-b"})
+	_ = unstructured.SetNestedMap(pairCR.Object, map[string]interface{}{
+		"name":      "shared-pg",
+		"namespace": "catalyst-system",
+	}, "spec", "cnpgPair")
+	spineCR := newContinuumUnstructured(
+		"dr-spine-openbao", "openbao", "openbao",
+		"me-east-215-a", []string{"me-east-215-b"})
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-b")
+	setCNPGReplicaDown(replica)
+	factory, _ := fakeContinuumDynamicFactory(pairCR, spineCR, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4923-rollup")
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/dr/replication-status", h.HandleDRReplicationStatus)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/dr/replication-status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		ContinuumCount   int                          `json:"continuumCount"`
+		ReplicasHealthy  int                          `json:"replicasHealthy"`
+		ReplicasDegraded int                          `json:"replicasDegraded"`
+		ReplicasUnknown  int                          `json:"replicasUnknown"`
+		Continuums       []continuumReplicationStatus `json:"continuums"`
+		Source           string                       `json:"source"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ContinuumCount != 2 {
+		t.Fatalf("continuumCount: got %d want 2", resp.ContinuumCount)
+	}
+	if resp.ReplicasHealthy != 0 {
+		t.Errorf("replicasHealthy: got %d want 0 (standby down + spine unverifiable)", resp.ReplicasHealthy)
+	}
+	if resp.ReplicasDegraded != 1 {
+		t.Errorf("replicasDegraded: got %d want 1 (the verified-absent cnpg pair)", resp.ReplicasDegraded)
+	}
+	if resp.ReplicasUnknown != 1 {
+		t.Errorf("replicasUnknown: got %d want 1 (the unverifiable spine)", resp.ReplicasUnknown)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
@@ -143,6 +143,13 @@ type cnpgPairState struct {
 	// posture that makes CNPG render `synchronous_standby_names = FIRST N (...)`
 	// (sync_state=sync in pg_stat_replication). False for async/lab pairs. #4923.
 	SyncReplication bool
+
+	// StandbyAvailable is the cnpgStandbyAvailable verdict on the replica
+	// half: Ready=True AND (when reported) >=1 ready instance. Distinct from
+	// ReplicationHealthy — a promoted (post-switchover) standby is available
+	// but no longer following. False = the standby-absent condition the
+	// replication-status endpoint must surface explicitly (#4923/#4901).
+	StandbyAvailable bool
 }
 
 // findCNPGPairForApp discovers the cnpg cluster-pair backing an
@@ -269,6 +276,7 @@ func (h *Handler) findCNPGPairForApp(
 	st.ReplicaReady = cnpgClusterReady(hv.replica)
 	st.LagSeconds = cnpgClusterLag(hv.replica)
 	st.SyncReplication = cnpgClusterSynchronous(hv.primary)
+	st.StandbyAvailable = cnpgStandbyAvailable(hv.replica)
 	// Healthy = the standby half is Ready and still in replica mode
 	// (actively following WAL). If replica.enabled flipped to false the
 	// pair is mid/post-switchover — not "healthy steady-state".
@@ -615,7 +623,11 @@ func (h *Handler) deriveLiveContinuumRecord(
 			// the primary half's spec.postgresql.synchronous. Consumed by
 			// liveReplicationStatusFromCNPGPair to report syncState honestly.
 			"syncReplication": st.SyncReplication,
-			"observedAt":      h.continuumNow().UTC().Format(time.RFC3339),
+			// #4923/#4901 — the VERIFIED standby-leg availability (replica half
+			// Ready + >=1 ready instance). false = the explicit standby-absent
+			// condition; consumed by liveReplicationStatusFromCNPGPair.
+			"standbyAvailable": st.StandbyAvailable,
+			"observedAt":       h.continuumNow().UTC().Format(time.RFC3339),
 		},
 	}
 	return rec, true

--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -202,6 +202,18 @@ export interface ContinuumReplicaInfo {
  * returned a realistic-but-not-live shape. The UI MUST surface this so a
  * fallback is never passed off as live.
  */
+/**
+ * ContinuumHealthGate — one row of the DERIVED health-gate list (#4923).
+ * Never a hardcoded all-Pass wall: Pass requires positive evidence, Warn
+ * means unverified/over-threshold, Fail means a verified fault.
+ */
+export interface ContinuumHealthGate {
+  name: string
+  status: string // "Pass" | "Warn" | "Fail"
+  message?: string
+  severity?: string // "info" | "warning" | "critical"
+}
+
 export interface ContinuumReplicationStatus {
   continuum: string
   namespace: string
@@ -213,9 +225,18 @@ export interface ContinuumReplicationStatus {
   streamingState?: string
   syncState?: string
   lastHeartbeat?: string
+  /**
+   * Tri-state standby-leg verdict (#4923/#4901):
+   * true — verified reachable+following off the live cnpg cluster-pair;
+   * false — the required hot-standby is ABSENT (the explicit honest
+   * condition the DR panel must surface, never masked as healthy);
+   * undefined — unverifiable (no cnpg pair resolvable) — unknown, not green.
+   */
+  standbyAvailable?: boolean
+  healthGates?: ContinuumHealthGate[]
   replicas?: ContinuumReplicaInfo[]
   observedAt?: string
-  source: string // "live" | "synthesized"
+  source: string // "live" | "pending"
 }
 
 /* ── Endpoint helpers ────────────────────────────────────────────── */

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -457,6 +457,61 @@ describe('TopologyTab — DR / replication surface (#3375 rows 51/52/56/57)', ()
     expect(btn.disabled).toBe(false)
   })
 
+  it('#4923: a VERIFIED-absent standby renders the explicit standby-absent condition, never a calm follower card', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue(standbyPlacement)
+    // The backend verified the standby leg off the live cnpg-pair replica
+    // half and reports it ABSENT (the #4901 region-kill shape) — lag stays 0
+    // during the outage, so the UI must key off standbyAvailable, not lag.
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0,
+      streamingState: 'interrupted',
+      standbyAvailable: false,
+      replicas: [{ region: 'me-east-215-b', role: 'replica', lagSeconds: 0 }],
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    // The explicit honest condition banner renders.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-standby-absent').textContent).toContain('Standby absent')
+    })
+    // The standby card reads unreachable — NOT the calm 'hot replica' text.
+    const card = screen.getByTestId('topology-tab-dr-standby-me-east-215-b')
+    expect(card.textContent).toContain('standby unreachable')
+    expect(card.textContent).not.toContain('hot replica (follows WAL)')
+  })
+
+  it('#4923: an UNVERIFIABLE standby (standbyAvailable omitted) renders NO absent banner (unknown is not a fault claim)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue(standbyPlacement)
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0.4,
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('topology-tab-dr-standby-absent')).toBeNull()
+  })
+
   it('a SINGLETON app shows NO DR panel + NO Switchover (honestly hidden, row 58)', async () => {
     getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
     const initialApp = {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -311,6 +311,14 @@ export function TopologyTab({
   const hasLiveDR = drStatus?.source === 'live' && !!liveStandbyRegion
   const showDR = hasStandby || hasLiveDR
 
+  // #4923/#4901 — the EXPLICIT standby-absent condition. The backend verifies
+  // the standby leg off the live cnpg cluster-pair and reports the tri-state
+  // standbyAvailable verdict: false means the required hot-standby is
+  // unreachable (region-kill / outage) and MUST render as a fault — never as
+  // a calm "hot replica (follows WAL)" card. undefined = unverifiable
+  // (unknown), which renders the normal card without a false health claim.
+  const standbyAbsent = drStatus?.standbyAvailable === false
+
   // The switchover target — the standby region we would promote. Prefer the
   // placement Standby target, fall back to the live continuum standby region.
   const switchoverTarget = useMemo(
@@ -569,41 +577,80 @@ export function TopologyTab({
                   drStandbyRegions.map((region) => (
                     <div
                       key={region}
-                      className="min-w-[11rem] rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2"
+                      className={`min-w-[11rem] rounded-md border px-3 py-2 ${
+                        standbyAbsent
+                          ? 'border-red-500/40 bg-red-500/10'
+                          : 'border-yellow-500/40 bg-yellow-500/10'
+                      }`}
                       data-testid={`topology-tab-dr-standby-${region}`}
                     >
                       <div className="text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]">
                         Standby region
                       </div>
-                      <div className="mt-0.5 font-mono text-xs font-semibold text-yellow-400">
+                      <div
+                        className={`mt-0.5 font-mono text-xs font-semibold ${
+                          standbyAbsent ? 'text-red-400' : 'text-yellow-400'
+                        }`}
+                      >
                         {region}
                       </div>
-                      <div className="text-[10px] text-[var(--color-text-dim)]">
-                        {drStatus?.streamingState
-                          ? drStatus.streamingState
-                          : 'hot replica (follows WAL)'}
+                      <div
+                        className={`text-[10px] ${standbyAbsent ? 'text-red-400' : 'text-[var(--color-text-dim)]'}`}
+                      >
+                        {standbyAbsent
+                          ? 'standby unreachable — replication interrupted'
+                          : drStatus?.streamingState
+                            ? drStatus.streamingState
+                            : 'hot replica (follows WAL)'}
                       </div>
                     </div>
                   ))
                 ) : (
                   <div
-                    className="min-w-[11rem] rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2"
+                    className={`min-w-[11rem] rounded-md border px-3 py-2 ${
+                      standbyAbsent
+                        ? 'border-red-500/40 bg-red-500/10'
+                        : 'border-yellow-500/40 bg-yellow-500/10'
+                    }`}
                     data-testid="topology-tab-dr-standby"
                   >
                     <div className="text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]">
                       Standby region
                     </div>
-                    <div className="mt-0.5 font-mono text-xs font-semibold text-yellow-400">
+                    <div
+                      className={`mt-0.5 font-mono text-xs font-semibold ${
+                        standbyAbsent ? 'text-red-400' : 'text-yellow-400'
+                      }`}
+                    >
                       {liveStandbyRegion ||
                         drStatus?.replicas?.find((rep) => rep.role !== 'primary')?.region ||
                         '—'}
                     </div>
-                    <div className="text-[10px] text-[var(--color-text-dim)]">
-                      {drStatus?.streamingState || 'hot replica (follows WAL)'}
+                    <div
+                      className={`text-[10px] ${standbyAbsent ? 'text-red-400' : 'text-[var(--color-text-dim)]'}`}
+                    >
+                      {standbyAbsent
+                        ? 'standby unreachable — replication interrupted'
+                        : drStatus?.streamingState || 'hot replica (follows WAL)'}
                     </div>
                   </div>
                 )}
               </div>
+
+              {/* #4923/#4901 — the explicit honest standby-absent condition.
+                  Rendered ONLY on a VERIFIED absent standby (backend cross-
+                  checked the live cnpg-pair replica half); never inferred
+                  from a small lag number or a stored-green CR phase. */}
+              {standbyAbsent ? (
+                <div
+                  className="mt-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-400"
+                  data-testid="topology-tab-dr-standby-absent"
+                >
+                  Standby absent — the required hot-standby is unreachable.
+                  Replication has no standby leg to acknowledge commits; RPO=0
+                  durability is at risk until the standby recovers.
+                </div>
+              ) : null}
 
               {/* Live replication lag in seconds (row 56) — never a hardcoded —. */}
               <div className="mt-3 flex items-center gap-2 text-xs" data-testid="topology-tab-dr-lag">


### PR DESCRIPTION
## Problem

Refs #4923 (sibling of #4901). `GET /api/v1/sovereigns/{id}/continuum/{name}/replication-status` and the sovereign-wide `GET .../dr/replication-status` roll-up synthesized health the SovereignConsole DR panel rendered as real:

- `streamingState` defaulted to `"streaming"` and `syncState` to `"async"` whenever the Continuum CR reported neither — fabricated telemetry indistinguishable from a live reading (and flatly wrong on a synchronous RPO=0 pair).
- `healthGates` was a hardcoded all-Pass wall — `streaming-replication: Pass` even during the proven #4901 hot-standby outage.
- `replicaPromotable` keyed on nothing but `lag <= 30`. An ABSENT standby also reads `lag=0` (#4901: the stored CR status stayed `Healthy`/`lag=0` through the entire region-kill drill), so a lost standby rendered promotable and green.
- every configured standby row carried a fabricated `now()` heartbeat.
- the roll-up counted every low-lag row healthy — the hw242 evidence shape (all four `dr-spine-*` read healthy while region-B ran zero workloads).

## Fix — report only observed state, verify the standby leg, honest-unknown otherwise

`products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go` + `continuum_live.go`:

| state | wire result |
|---|---|
| pair-healthy | `standbyAvailable:true`, gate `standby-available: Pass`, `replicaPromotable` only with positive evidence (`status.replicationHealthy` / verified replica half) and lag under threshold |
| lagging | `wal-lag-under-rpo: Warn` with the actual reading when over the 30s threshold; a Ready-but-lagging standby never raises standby-absent |
| standby-absent | `standbyAvailable:false`, gate `standby-available: Fail` (severity `critical`), `replicaPromotable` forced `false`, `streamingState:"interrupted"` — verified off the live cnpg cluster-pair replica half (Ready condition + `readyInstances`), never off the stored CR phase |
| unverifiable (no cnpg pair, e.g. `dr-spine-*` / openbao-raft) | `standbyAvailable` OMITTED + explicit `standby-available: Warn` gate ("standby leg not verifiable from live cluster state; reporting unknown, not healthy") |
| no-pair / bootstrapping | unchanged honest `source:"pending"` empty shape (#4551/#4930) |

Mechanics:

- `augmentReplicationStandbyStatus` (new): cross-checks the live standby leg per response — `spec.cnpgPair`-referenced pair first (the #4901 `cnpgPairStandbyForContinuum` path), label-driven app-pair fallback second (Organization-isolation-safe `findCNPGPairForApp`), honest-unknown when neither resolves.
- `enrichReplicationStatus`: gates now DERIVED from the observed CR status (`replicationHealthy` tri-state, lag present vs absent, `leaseHolder`), no fabricated streaming/sync defaults, no fabricated heartbeat.
- `liveReplicationStatusFromCNPGPair` (derive path, no CR): same verdict from `cnpgStandbyAvailable` on the replica half.
- roll-up: runs the per-row verification and adds `replicasUnknown` — unverifiable rows are never folded into healthy.

UI (`products/catalyst/bootstrap/ui`): `TopologyTab` renders the verified-absent standby as an explicit red condition banner (`topology-tab-dr-standby-absent`) + an unreachable standby card, keyed on `standbyAvailable === false` — never inferred from the lag number. Unknown renders no false claim in either direction.

## Tests

- Go: `continuum_dr_extras_4923_test.go` — 6 new tests locking pair-healthy / standby-absent (CR-referenced + app-fallback + derive path) / unverifiable-spine (no fabricated streaming/async/all-Pass/heartbeat) / roll-up honest counters. Full `go test ./...` in `products/catalyst/bootstrap/api` green.
- UI: 2 new `TopologyTab` tests (verified-absent banner + card; unverifiable renders no banner). `tsc -b --noEmit` clean, `vitest run` green, eslint clean on touched files.

Unblocks re-walk of UAT rows 51/52/56/188/189 (DR panel truthfulness on the Multi-region/DR area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
