### PR TITLE
fix(#4896): Edit-IaC commit writes the repo the read path resolves + the Flux reconcile leg

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/blueprints_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/blueprints_test.go
@@ -38,6 +38,13 @@ type fakeGiteaClient struct {
 	// unchanged behaviour for every existing caller.
 	putFileSleep time.Duration // when >0, PutFile blocks this long (honours ctx cancel)
 	putFileErr   error         // when non-nil, PutFile returns this error
+
+	// putFileErrFor — #4896 additive TARGETED injection: when non-nil it is
+	// consulted per PutFile target and a non-nil return fails ONLY that
+	// write. Lets the dual-write tests fail the Flux aggregator leg while
+	// the per-Blueprint source write succeeds. Default nil → unchanged
+	// behaviour for every existing caller.
+	putFileErrFor func(org, repo, branch, path string) error
 }
 
 func newFakeGitea() *fakeGiteaClient {
@@ -77,6 +84,7 @@ func (f *fakeGiteaClient) PutFile(ctx context.Context, org, repo, branch, path s
 	f.mu.Lock()
 	sleep := f.putFileSleep
 	putErr := f.putFileErr
+	errFor := f.putFileErrFor
 	f.mu.Unlock()
 	if sleep > 0 {
 		select {
@@ -87,6 +95,11 @@ func (f *fakeGiteaClient) PutFile(ctx context.Context, org, repo, branch, path s
 	}
 	if putErr != nil {
 		return gitea.File{}, false, putErr
+	}
+	if errFor != nil {
+		if e := errFor(org, repo, branch, path); e != nil {
+			return gitea.File{}, false, e
+		}
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
@@ -124,14 +124,7 @@ func catalogSovereignAggPath(sovereignFQDN, bpName string) string {
 // (openova/openova) is auto-init'd by the Organization repo-bootstrap hook, so the
 // branch always has a base commit to write onto.
 func (h *Handler) writeCatalogSovereignAggregator(ctx context.Context, bpName string, merged []byte) (bool, error) {
-	if h.giteaClient == nil {
-		return false, nil // unwired — best-effort no-op (pre-cutover / CI)
-	}
-	sovereignFQDN := strings.TrimSpace(envOr("SOVEREIGN_FQDN", ""))
-	if sovereignFQDN == "" {
-		return false, nil // Catalyst-Zero mothership — no local catalog Flux
-	}
-	if strings.TrimSpace(bpName) == "" || len(merged) == 0 {
+	if len(merged) == 0 {
 		return false, nil
 	}
 	// #4415 — the Flux aggregator file SSA-applies (force:true) to the LIVE
@@ -142,7 +135,32 @@ func (h *Handler) writeCatalogSovereignAggregator(ctx context.Context, bpName st
 	// instead of being pinned forever at the value frozen when the operator
 	// last edited the card. The operator's curated card / visibility /
 	// topology stay in the file and remain Flux-owned + revert-immune.
-	fluxBytes := stripDeliveryFieldsForFluxAggregator(merged)
+	//
+	// NOTE the #4415 strip applies to the IMPLICIT card-edit path only. The
+	// full-CR IaC editor (catalog_iac_edit.go) calls the Bytes variant below
+	// directly with the admin's verbatim document, because an EXPLICIT
+	// whole-CR commit legitimately edits spec.version (DoD §9.7; UAT row 154).
+	return h.writeCatalogSovereignAggregatorBytes(ctx, bpName, stripDeliveryFieldsForFluxAggregator(merged))
+}
+
+// writeCatalogSovereignAggregatorBytes commits the SUPPLIED final bytes to the
+// Flux-reconciled aggregator tree — the shared trunk of the card-edit path
+// (which pre-strips the #4415 chart-delivery fields) and the full-CR IaC edit
+// path (#4896/#5018 — which commits the admin's whole document verbatim, name
+// stamped to the live CR identity). Same no-op contract as the wrapper above:
+// (false, nil) when the Gitea client is unwired or SOVEREIGN_FQDN is empty
+// (Catalyst-Zero mothership — no local catalog Flux reconcile exists).
+func (h *Handler) writeCatalogSovereignAggregatorBytes(ctx context.Context, bpName string, fluxBytes []byte) (bool, error) {
+	if h.giteaClient == nil {
+		return false, nil // unwired — best-effort no-op (pre-cutover / CI)
+	}
+	sovereignFQDN := strings.TrimSpace(envOr("SOVEREIGN_FQDN", ""))
+	if sovereignFQDN == "" {
+		return false, nil // Catalyst-Zero mothership — no local catalog Flux
+	}
+	if strings.TrimSpace(bpName) == "" || len(fluxBytes) == 0 {
+		return false, nil
+	}
 	path := catalogSovereignAggPath(sovereignFQDN, bpName)
 	msg := fmt.Sprintf("catalog: reconcile %s into Blueprint CR via Flux (#3668)", bpName)
 	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignAggOrg, catalogSovereignAggRepo,

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
@@ -13,8 +13,25 @@
 // the admin supplies directly to catalog-sovereign/<bp>/blueprint.yaml —
 // validated as a Blueprint CR first (reusing validateBlueprintYAML), under
 // the dedicated catalogEditGitBudget (NOT the commerce probe budget), with
-// the git verdict surfaced (committed / reason). It is the IaC source write;
-// Flux reconciles that file into the in-cluster Blueprint CR.
+// the git verdict surfaced (committed / reason).
+//
+// #4896 / #5018 — the commit is a DUAL write, exactly like the card path:
+//
+//  1. catalog-sovereign/<repo>/blueprint.yaml — the UI read source. <repo> is
+//     the repo the READ path actually resolves (resolveCatalogEditRepo —
+//     mirrors the catalyst-catalog resolver's bare↔bp- toggle, #4990/#4997),
+//     so a resource loaded by the read path always commits back to the SAME
+//     file it was loaded from, never a divergent freshly-minted twin repo.
+//  2. openova/openova @ catalog-sovereign :
+//     clusters/<fqdn>/catalog-sovereign/<bp>.yaml — the Flux-reconciled
+//     aggregator leg (writeCatalogSovereignAggregatorBytes). This is what
+//     actually reaches the LIVE in-cluster Blueprint CR; without it the
+//     commit is silently inert (the exact hw242 #5018 finding — UAT rows
+//     148/154). Unlike the card path there is NO #4415 delivery-field strip:
+//     an explicit whole-CR commit legitimately edits spec.version (DoD §9.7).
+//     A failure of this leg is SURFACED (502 committed:false), never
+//     swallowed — "Committed ✓" on an unreconciled edit is the false-green
+//     #5018 called out.
 //
 // Auth: the same tier-admin gate the existing /blueprints/edit-pr uses
 // (applicationInstallCallerAuthorized) — this ticket adds no new
@@ -119,7 +136,7 @@ func (h *Handler) HandleCatalogBlueprintIaCEdit(w http.ResponseWriter, r *http.R
 	ctx, cancel := context.WithTimeout(r.Context(), catalogEditGitBudgetDuration())
 	defer cancel()
 
-	committed, err := h.writeCatalogFullBlueprintToGit(ctx, bpName, yamlBytes)
+	repo, committed, err := h.writeCatalogFullBlueprintToGit(ctx, bpName, yamlBytes)
 	if err != nil {
 		if h.log != nil {
 			h.log.Warn("catalog-iac-edit: commit to catalog-sovereign failed",
@@ -127,18 +144,49 @@ func (h *Handler) HandleCatalogBlueprintIaCEdit(w http.ResponseWriter, r *http.R
 		}
 		writeJSON(w, http.StatusBadGateway, catalogIaCEditResponse{
 			Slug:      normalizeCatalogKey(bpName),
-			Path:      catalogSovereignOrg + "/" + bpName + "/" + catalogEditBlueprintPath,
+			Path:      catalogSovereignOrg + "/" + repo + "/" + catalogEditBlueprintPath,
 			Committed: false,
 			Reason:    "IaC commit failed: " + err.Error(),
 		})
 		return
 	}
 
+	// #4896 / #5018 — leg 2: mirror the committed document into the Flux-
+	// reconciled aggregator tree so the edit actually reaches the LIVE
+	// in-cluster Blueprint CR. metadata.name is stamped to the canonical CR
+	// identity (bp-<slug> — the same bridge reconcileBlueprintBareName applies
+	// on the dry-run path, #4898) so Flux SSA-patches the existing CR instead
+	// of minting a bare-named duplicate; no #4415 delivery-field strip — the
+	// admin's explicit full-CR edit owns spec.version/spec.source (DoD §9.7).
+	var aggCommitted bool
+	var aggErr error
+	if aggBytes := stampBlueprintCRForFluxAggregator(yamlBytes, bpName); len(aggBytes) == 0 {
+		// Unreachable after validateCatalogBlueprintYAML parsed these same
+		// bytes — but never silently skip the reconcile leg on a render miss.
+		aggErr = fmt.Errorf("render Flux aggregator payload for %s: document did not re-parse", bpName)
+	} else {
+		aggCommitted, aggErr = h.writeCatalogSovereignAggregatorBytes(ctx, bpName, aggBytes)
+	}
+	if aggErr != nil {
+		if h.log != nil {
+			h.log.Warn("catalog-iac-edit: Flux aggregator mirror failed — edit committed to source but will NOT reach the live Blueprint CR",
+				"blueprint", bpName, "repo", repo, "err", aggErr)
+		}
+		writeJSON(w, http.StatusBadGateway, catalogIaCEditResponse{
+			Slug:      normalizeCatalogKey(bpName),
+			Path:      catalogSovereignOrg + "/" + repo + "/" + catalogEditBlueprintPath,
+			Committed: false,
+			Reason: "IaC source committed to " + catalogSovereignOrg + "/" + repo +
+				" but the Flux reconcile leg failed (the edit will not reach the live Blueprint CR): " + aggErr.Error(),
+		})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, catalogIaCEditResponse{
 		Slug:      normalizeCatalogKey(bpName),
-		Path:      catalogSovereignOrg + "/" + bpName + "/" + catalogEditBlueprintPath,
+		Path:      catalogSovereignOrg + "/" + repo + "/" + catalogEditBlueprintPath,
 		Committed: true,
-		Reason:    iaCEditDurableReason(committed),
+		Reason:    iaCEditDurableReason(committed || aggCommitted),
 	})
 }
 
@@ -152,35 +200,103 @@ func iaCEditDurableReason(wroteBytes bool) string {
 }
 
 // writeCatalogFullBlueprintToGit commits the FULL supplied blueprint.yaml to
-// catalog-sovereign/<bpName>/blueprint.yaml — the same file + repo the
-// card-edit path (writeCatalogEditToGit) writes, so both editors drive the
-// SAME Gitea source of truth (§6). Unlike the card path this is NOT a card
+// catalog-sovereign/<repo>/blueprint.yaml — the same file + repo the read
+// path resolves (resolveCatalogEditRepo), so both editors drive the SAME
+// Gitea source of truth (§6). Unlike the card path this is NOT a card
 // merge: the admin owns the whole document, so it is committed verbatim
 // (after the caller's validateBlueprintYAML).
 //
-// Returns (wroteBytes, err): wroteBytes=false + err=nil when PutFile's
-// byte-equal short-circuit fired (the file already carried these exact bytes
-// — still durable). A non-nil err is a genuine transport/API failure.
-func (h *Handler) writeCatalogFullBlueprintToGit(ctx context.Context, bpName string, blueprintYAML []byte) (bool, error) {
+// Returns (repo, wroteBytes, err): repo is the per-Blueprint repo actually
+// written (bare or bp-prefixed — whichever the read path resolves);
+// wroteBytes=false + err=nil when PutFile's byte-equal short-circuit fired
+// (the file already carried these exact bytes — still durable). A non-nil
+// err is a genuine transport/API failure.
+func (h *Handler) writeCatalogFullBlueprintToGit(ctx context.Context, bpName string, blueprintYAML []byte) (string, bool, error) {
 	if h.giteaClient == nil {
-		return false, fmt.Errorf("gitea client unwired")
+		return bpName, false, fmt.Errorf("gitea client unwired")
 	}
 	if _, err := h.giteaClient.EnsureOrg(ctx, catalogSovereignOrg,
 		"Sovereign-curated catalog",
 		"Curated Blueprints visible to every Org", "public"); err != nil {
-		return false, fmt.Errorf("ensure org %q: %w", catalogSovereignOrg, err)
+		return bpName, false, fmt.Errorf("ensure org %q: %w", catalogSovereignOrg, err)
 	}
-	if _, err := h.giteaClient.EnsureRepo(ctx, catalogSovereignOrg, bpName,
+	repo := h.resolveCatalogEditRepo(ctx, bpName)
+	if _, err := h.giteaClient.EnsureRepo(ctx, catalogSovereignOrg, repo,
 		"Sovereign-curated Blueprint", false); err != nil {
-		return false, fmt.Errorf("ensure repo %s/%s: %w", catalogSovereignOrg, bpName, err)
+		return repo, false, fmt.Errorf("ensure repo %s/%s: %w", catalogSovereignOrg, repo, err)
 	}
 	msg := fmt.Sprintf("catalog: edit %s full IaC via catalyst-api (#3668)", bpName)
-	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignOrg, bpName,
+	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignOrg, repo,
 		catalogEditGitBranch, catalogEditBlueprintPath, blueprintYAML, msg, catalogEditCommitAuthor())
 	if err != nil {
-		return false, fmt.Errorf("put %s/%s/%s: %w", catalogSovereignOrg, bpName, catalogEditBlueprintPath, err)
+		return repo, false, fmt.Errorf("put %s/%s/%s: %w", catalogSovereignOrg, repo, catalogEditBlueprintPath, err)
 	}
-	return committed, nil
+	return repo, committed, nil
+}
+
+// resolveCatalogEditRepo returns the catalog-sovereign per-Blueprint repo the
+// READ path resolves for this blueprint, so the full-CR write lands in the
+// SAME file the editor loaded (#4896 — single naming source of truth shared
+// by read+write).
+//
+// The catalyst-catalog resolver (core/services/catalyst-catalog/internal/
+// source, fetchBlueprintYAML/altBPName — #4990/#4997) serves the UI's GET
+// with a bare↔bp- prefix toggle: the frontend strips a leading `bp-`
+// (CatalogDetail.tsx), so the resolver tries the BARE repo first (deployed
+// Blueprints live in bare-named repos, e.g. `agenity`) and falls back to the
+// `bp-` form (catalog-seed-only entries keep the raw `bp-<x>` repo name,
+// e.g. `bp-alloy`). That package is module-internal, so the convention is
+// MIRRORED here — probe in the resolver's order and write to the first repo
+// whose blueprint.yaml exists:
+//
+//  1. bare  <slug>    — matches a deployed Blueprint's repo (read hit #1);
+//  2. bp-<slug>       — matches a seed-only / curated repo (read hit #2);
+//  3. neither exists  — default to the canonical bp-<slug> (fresh curate,
+//     same repo the card-edit path mints).
+//
+// Before this resolution the write unconditionally minted `bp-<slug>`, so a
+// commit against a bare-repo blueprint created a divergent twin the read
+// path never consults — half of the #5018 "commit is inert" split-brain.
+func (h *Handler) resolveCatalogEditRepo(ctx context.Context, bpName string) string {
+	bare := strings.TrimPrefix(bpName, "bp-")
+	for _, repo := range []string{bare, bpName} {
+		if repo == "" {
+			continue
+		}
+		if _, err := h.giteaClient.GetFile(ctx, catalogSovereignOrg, repo,
+			catalogEditGitBranch, catalogEditBlueprintPath); err == nil {
+			return repo
+		}
+	}
+	return bpName
+}
+
+// stampBlueprintCRForFluxAggregator renders the admin's full-CR document as
+// the Flux aggregator payload (#4896/#5018): metadata.name is FORCED to the
+// canonical live-CR identity (bp-<slug>) so the catalog-sovereign
+// Kustomization's force:true SSA patches the existing Blueprint CR instead of
+// creating a bare-named duplicate — the same identity bridge the dry-run/apply
+// path applies via reconcileBlueprintBareName (#4898). Server-managed +
+// ownership metadata and status are dropped (stripBlueprintCRMapForGit);
+// spec.version/spec.source are deliberately KEPT — the #4415 strip covers the
+// implicit card-edit only, while an explicit whole-CR commit owns its
+// delivery fields (DoD §9.7; UAT row 154's version round-trip).
+//
+// Returns nil on an unparsable document — unreachable in practice because the
+// caller validated the same bytes (validateCatalogBlueprintYAML); the
+// aggregator writer treats empty bytes as a no-op, and the caller surfaces
+// that as a skipped reconcile leg rather than committing a wrong-named CR.
+func stampBlueprintCRForFluxAggregator(raw []byte, bpName string) []byte {
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil || doc == nil {
+		return nil
+	}
+	if meta, ok := doc["metadata"].(map[string]interface{}); ok {
+		meta["name"] = bpName
+	} else {
+		doc["metadata"] = map[string]interface{}{"name": bpName}
+	}
+	return stripBlueprintCRMapForGit(doc, bpName)
 }
 
 // validateCatalogBlueprintYAML enforces the structural Blueprint invariants

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit_test.go
@@ -13,6 +13,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -169,4 +170,250 @@ func TestCatalogIaCEdit_503WhenGiteaUnwired(t *testing.T) {
 func jsonQuote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
+}
+
+// ── #4896 / #5018 — read → edit → commit round-trip regression guards ──────
+//
+// hw242 live walk (UAT rows 148/154, #3668): the full-CR Edit-IaC commit
+// "succeeded" (200 committed:true) but was silently INERT — it wrote only the
+// unwatched per-Blueprint repo, never the Flux-watched aggregator leg the
+// card path dual-writes, and always minted the `bp-` repo even when the read
+// path (#4990/#4997 bare↔bp- toggle) resolves the bare-named one. These pin
+// the durable contract: whatever the read path loads, the commit lands back
+// in the SAME per-Blueprint file AND reaches the Flux aggregator tree that
+// reconciles it into the live Blueprint CR.
+
+// fullWordpressBlueprintYAML is the UAT row-148 resource shape: a deployed,
+// structurally-different blueprint whose spec.manifests the editor edits in
+// place. metadata.name carries the canonical bp- form (the shape the live CR
+// / dry-run path uses).
+func fullWordpressBlueprintYAML(manifestsNS string) string {
+	return `apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-wordpress
+spec:
+  version: "6.5.0"
+  visibility: listed
+  card:
+    title: WordPress
+    summary: CMS
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-wordpress
+    version: "6.5.0"
+  manifests:
+    chart: bp-wordpress
+    namespace: ` + manifestsNS + `
+`
+}
+
+// bareAlloyBlueprintYAML is the UAT row-154 resource shape: the AUTHORED
+// seed blueprint.yaml whose metadata.name is the BARE slug (`alloy`) while
+// the repo/URL/CR use `bp-alloy` — the exact #4896 name divergence. The
+// editor loads this document verbatim, so the commit path must accept it
+// (never a defensive 400 on a name the read path itself produced).
+func bareAlloyBlueprintYAML(version string) string {
+	return strings.Replace(fullAlloyBlueprintYAML(version), "name: bp-alloy", "name: alloy", 1)
+}
+
+// TestCatalogIaCEdit_RoundTrip_ManifestsEditReachesFluxLeg — row 148: the
+// editor loads bp-wordpress (seed-only bp- repo), edits spec.manifests, and
+// commits. The commit must (a) land back in the SAME repo the read resolved,
+// and (b) mirror into the Flux aggregator tree with the manifests edit so the
+// live Blueprint CR reconciles — the leg whose absence made hw242's commit
+// inert.
+func TestCatalogIaCEdit_RoundTrip_ManifestsEditReachesFluxLeg(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	// READ SOURCE: the seed-only per-BP repo the resolver serves (#4997).
+	perBP := giteaKey(catalogSovereignOrg, "bp-wordpress", catalogEditGitBranch, catalogEditBlueprintPath)
+	fg.files[perBP] = []byte(fullWordpressBlueprintYAML("wordpress"))
+
+	// EDIT + COMMIT: the loaded document with spec.manifests.namespace changed.
+	edited := fullWordpressBlueprintYAML("wordpress-uatproof")
+	rec := callCatalogIaCEdit(t, h, "bp-wordpress", `{"blueprintYaml":`+jsonQuote(edited)+`}`, adminClaims())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// (a) The per-BP read source carries the edit (read→edit→commit→read).
+	if got := string(fg.files[perBP]); got != edited {
+		t.Errorf("per-BP read source must round-trip the committed document;\ngot:\n%s\nwant:\n%s", got, edited)
+	}
+
+	// (b) The Flux aggregator leg landed with the manifests edit.
+	aggKey := giteaKey(catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch,
+		"clusters/t99.omani.works/catalog-sovereign/bp-wordpress.yaml")
+	aggRaw, ok := fg.files[aggKey]
+	if !ok {
+		t.Fatalf("Flux aggregator write missing at %s (the #5018 inert-commit regression); keys=%v", aggKey, fileKeys(fg))
+	}
+	var aggDoc map[string]interface{}
+	if err := yamlv3.Unmarshal(aggRaw, &aggDoc); err != nil {
+		t.Fatalf("unmarshal aggregator CR: %v", err)
+	}
+	aggSpec, _ := aggDoc["spec"].(map[string]interface{})
+	man, _ := aggSpec["manifests"].(map[string]interface{})
+	if man == nil || asString(man["namespace"]) != "wordpress-uatproof" {
+		t.Errorf("the spec.manifests edit must reach the Flux leg; got manifests=%v", aggSpec["manifests"])
+	}
+	meta, _ := aggDoc["metadata"].(map[string]interface{})
+	if meta == nil || asString(meta["name"]) != "bp-wordpress" {
+		t.Errorf("aggregator CR must target the live CR identity bp-wordpress; metadata=%v", meta)
+	}
+}
+
+// TestCatalogIaCEdit_RoundTrip_VersionPersistsInFluxLeg_BareName — row 154 +
+// the #4896 headline in one: the editor loads the authored seed document
+// (metadata.name = bare `alloy`), bumps spec.version 1.0.2→1.0.3, and
+// commits against URL bp-alloy. The commit must be ACCEPTED (no 400 on the
+// name shape the read path itself produced) and the version bump must reach
+// the Flux leg — NOT #4415-stripped: an explicit whole-CR commit owns
+// spec.version (DoD §9.7), which is exactly the edit hw242 proved inert.
+func TestCatalogIaCEdit_RoundTrip_VersionPersistsInFluxLeg_BareName(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	// READ SOURCE: seed-only bp-alloy repo carrying the bare-named document.
+	perBP := giteaKey(catalogSovereignOrg, "bp-alloy", catalogEditGitBranch, catalogEditBlueprintPath)
+	fg.files[perBP] = []byte(bareAlloyBlueprintYAML("1.0.2"))
+
+	edited := bareAlloyBlueprintYAML("1.0.3")
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", `{"blueprintYaml":`+jsonQuote(edited)+`}`, adminClaims())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a bare metadata.name the read path produced must commit (got %d, the #4896 400-shape); body=%s",
+			rec.Code, rec.Body.String())
+	}
+
+	// The per-BP read source round-trips verbatim (bare name preserved —
+	// the admin owns the document).
+	if got := string(fg.files[perBP]); got != edited {
+		t.Errorf("per-BP read source must round-trip verbatim;\ngot:\n%s\nwant:\n%s", got, edited)
+	}
+
+	aggKey := giteaKey(catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch,
+		"clusters/t99.omani.works/catalog-sovereign/bp-alloy.yaml")
+	aggRaw, ok := fg.files[aggKey]
+	if !ok {
+		t.Fatalf("Flux aggregator write missing at %s; keys=%v", aggKey, fileKeys(fg))
+	}
+	var aggDoc map[string]interface{}
+	if err := yamlv3.Unmarshal(aggRaw, &aggDoc); err != nil {
+		t.Fatalf("unmarshal aggregator CR: %v", err)
+	}
+	meta, _ := aggDoc["metadata"].(map[string]interface{})
+	if meta == nil || asString(meta["name"]) != "bp-alloy" {
+		t.Errorf("aggregator CR name must be stamped to the live CR identity bp-alloy (was bare `alloy`); metadata=%v", meta)
+	}
+	aggSpec, _ := aggDoc["spec"].(map[string]interface{})
+	if aggSpec == nil || asString(aggSpec["version"]) != "1.0.3" {
+		t.Errorf("row 154: the explicit spec.version edit must reach the Flux leg un-stripped; got version=%v",
+			aggSpec["version"])
+	}
+	if _, ok := aggSpec["source"].(map[string]interface{}); !ok {
+		t.Errorf("an explicit full-CR commit keeps spec.source in the Flux leg (no #4415 card-strip); spec=%v", aggSpec)
+	}
+}
+
+// TestCatalogIaCEdit_WritesRepoTheReadPathResolves — the split-brain half of
+// #5018: a DEPLOYED blueprint lives in a bare-named repo (`wordpress`), which
+// is what the read path resolves (#4997 tries the bare form first). The
+// commit must land THERE — not mint a divergent `bp-wordpress` twin the read
+// never consults.
+func TestCatalogIaCEdit_WritesRepoTheReadPathResolves(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "") // mothership shape — isolates the repo-resolution assert
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	// READ SOURCE: deployed bare-named repo only.
+	bareKey := giteaKey(catalogSovereignOrg, "wordpress", catalogEditGitBranch, catalogEditBlueprintPath)
+	fg.files[bareKey] = []byte(fullWordpressBlueprintYAML("wordpress"))
+
+	edited := fullWordpressBlueprintYAML("wordpress-moved")
+	rec := callCatalogIaCEdit(t, h, "bp-wordpress", `{"blueprintYaml":`+jsonQuote(edited)+`}`, adminClaims())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	if got := string(fg.files[bareKey]); got != edited {
+		t.Errorf("commit must land in the bare repo the read path resolves;\ngot:\n%s\nwant:\n%s", got, edited)
+	}
+	twinKey := giteaKey(catalogSovereignOrg, "bp-wordpress", catalogEditGitBranch, catalogEditBlueprintPath)
+	if _, ok := fg.files[twinKey]; ok {
+		t.Errorf("commit must NOT mint a divergent bp- twin repo the read never consults; keys=%v", fileKeys(fg))
+	}
+
+	// The response path names the repo actually written.
+	var resp catalogIaCEditResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Path != catalogSovereignOrg+"/wordpress/"+catalogEditBlueprintPath {
+		t.Errorf("response path must name the repo written; got %q", resp.Path)
+	}
+}
+
+// TestCatalogIaCEdit_AggregatorFailureSurfaced — a commit whose Flux
+// reconcile leg fails must NOT report success: "Committed ✓" on an edit that
+// never reaches the live Blueprint CR is the exact hw242 false-green (#5018).
+func TestCatalogIaCEdit_AggregatorFailureSurfaced(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	// Fail ONLY the aggregator-repo write; the per-BP source write succeeds.
+	fg.putFileErrFor = func(org, repo, _, _ string) error {
+		if org == catalogSovereignAggOrg && repo == catalogSovereignAggRepo {
+			return fmt.Errorf("aggregator repo unreachable (injected)")
+		}
+		return nil
+	}
+	h.SetGiteaClient(fg)
+
+	body := `{"blueprintYaml":` + jsonQuote(fullAlloyBlueprintYAML("1.0.3")) + `}`
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", body, adminClaims())
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("a failed reconcile leg must surface 502, never a false success; got %d body=%s",
+			rec.Code, rec.Body.String())
+	}
+	var resp catalogIaCEditResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Committed {
+		t.Errorf("committed must be false when the edit cannot reach the live Blueprint CR")
+	}
+	if !strings.Contains(resp.Reason, "Flux reconcile leg failed") {
+		t.Errorf("reason must name the failed reconcile leg; got %q", resp.Reason)
+	}
+}
+
+// TestCatalogIaCEdit_MothershipSkipsAggregatorLeg — on the Catalyst-Zero
+// mothership (SOVEREIGN_FQDN empty) there is no local catalog Flux reconcile
+// by design: the commit succeeds on the per-BP source alone and no aggregator
+// key is written.
+func TestCatalogIaCEdit_MothershipSkipsAggregatorLeg(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	body := `{"blueprintYaml":` + jsonQuote(fullAlloyBlueprintYAML("1.0.2")) + `}`
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", body, adminClaims())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	for k := range fg.files {
+		if strings.HasPrefix(k, catalogSovereignAggOrg+"/"+catalogSovereignAggRepo+"/") {
+			t.Errorf("mothership must not write an aggregator leg; found %s", k)
+		}
+	}
 }


### PR DESCRIPTION
## Problem
The console catalog **Edit-IaC "Commit" never durably lands** (hw242 live walk, UAT rows 148/154 ❌, consolidated in #5018). The original #4896 dry-run 400 was resolved by #4898, and #4997 made the catalog READ path `bp-`prefix-tolerant — but the WRITE path (`PUT /api/v1/catalog/{name}/iac`) still diverged from the read path in two ways, so a commit "succeeded" (200 `committed:true`) while being **silently inert**:

1. **Naming split-brain** — `writeCatalogFullBlueprintToGit` unconditionally minted/targeted the `bp-<slug>` repo, while the read path (`fetchBlueprintYAML`/`altBPName`, #4990/#4997) resolves whichever repo form EXISTS (bare for deployed Blueprints, `bp-` for catalog-seed-only). For a bare-repo Blueprint the commit created a divergent twin repo the read never consults — the editor re-opened without the edit.
2. **Missing reconcile leg** — the card-edit path dual-writes the per-Blueprint repo AND the Flux-watched aggregator (`openova/openova@catalog-sovereign` → `clusters/<fqdn>/catalog-sovereign/<bp>.yaml`); the full-CR IaC path wrote only the unwatched per-Blueprint repo, so no commit ever reached the live Blueprint CR (verified live: commits `efd0760ff4`/`856bcf567a` on hw242 reconciled into nothing).

## Fix (`products/catalyst/bootstrap/api/internal/handler/`)
- **Single naming source of truth shared by read+write**: new `resolveCatalogEditRepo` mirrors the catalyst-catalog resolver's probe order (bare first, then `bp-`, default canonical `bp-` for a fresh curate) — the commit now lands in the SAME `blueprint.yaml` the editor loaded, and the response `path` names the repo actually written. (The resolver package is module-internal, so the convention is mirrored with a cross-referencing contract comment on both semantics.)
- **Reconcile leg**: the commit now ALSO writes the Flux aggregator file via the new shared trunk `writeCatalogSovereignAggregatorBytes` (the card path's `writeCatalogSovereignAggregator` becomes a thin #4415-stripping wrapper over it). The aggregator payload stamps `metadata.name` to the live-CR identity `bp-<slug>` (the same bridge `reconcileBlueprintBareName` applies on the dry-run path, #4898) and drops status/ownership metadata — so Flux SSA patches the existing CR instead of minting a bare-named duplicate.
- **No #4415 delivery-field strip on this path**: an explicit whole-CR commit legitimately edits `spec.version` (DoD §9.7 — UAT row 154 is exactly "a non-card `version` edit persists"). The #4415 strip stays intact for the implicit card-edit path.
- **No silent inertness**: a failed reconcile leg surfaces **502 `committed:false`** with a reason naming both leg outcomes — never the hw242 false "Committed ✓". Mothership (`SOVEREIGN_FQDN` empty) keeps its by-design no-op (no local catalog Flux exists there). No name the read path itself produces can 400: bare and `bp-` `metadata.name` both address the Blueprint (`catalogEditBlueprintName` normalization, unchanged), pinned by the new bare-name round-trip test.

## Tests (round-trip read → edit → commit, the exact row-148/154 shapes)
- `TestCatalogIaCEdit_RoundTrip_ManifestsEditReachesFluxLeg` — row 148: `bp-wordpress` `spec.manifests` edit lands back in the repo the read resolved AND in the aggregator with the edit + correct CR name.
- `TestCatalogIaCEdit_RoundTrip_VersionPersistsInFluxLeg_BareName` — row 154 + the #4896 headline: bare `metadata.name: alloy` (the authored seed shape the read path serves) commits with 200 against URL `bp-alloy`; the `1.0.2→1.0.3` version bump reaches the Flux leg un-stripped; the aggregator CR name is stamped `bp-alloy`.
- `TestCatalogIaCEdit_WritesRepoTheReadPathResolves` — deployed bare-repo shape: no divergent `bp-` twin is minted; response path names the real repo.
- `TestCatalogIaCEdit_AggregatorFailureSurfaced` — failed reconcile leg → 502 `committed:false` + explicit reason (targeted PutFile fault injection added to the test fake, additive).
- `TestCatalogIaCEdit_MothershipSkipsAggregatorLeg` — mothership contract pinned.

**Verified as genuine regression guards**: the four core tests FAIL on the pre-fix implementation with the exact #5018 symptoms (aggregator write missing, divergent twin repo, false success) and PASS with the fix. `go build ./... && go vet ./... && go test ./...` green across the whole bootstrap/api module. No UI change needed — `saveCatalogBlueprintIaC` already surfaces non-2xx bodies as the apply error. No chart change — the `openova-catalog-sovereign` GitRepository/Kustomization already watch the aggregator branch.

Remaining #5018 symptoms (detail-API overlay merge on read, "in sync" computed against the reconciled CR) are read-path/UI scope and stay tracked there.

Refs #4896
Refs #5018
Refs #3668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
