### PR TITLE
docs(iac): retire stale nodePort wording — gateway ELB targets durable node:443/:80 (§854)

### DIFF
--- a/infra/providers/huawei/outputs.tf
+++ b/infra/providers/huawei/outputs.tf
@@ -9,7 +9,7 @@ output "control_plane_ip" {
 }
 
 output "load_balancer_ip" {
-  description = "Public EIP the wildcard *.<fqdn> + app DNS A-records point at. #4690 / #4686 foundation-fix — this is the RESTORED gateway ELB's OWN routable EIP (huaweicloud_vpc_eip.elb_primary). The ELB forwards public :443/:80 → the gateway LoadBalancer Service's auto-allocated nodePort (the Service TYPE stays LoadBalancer, #4682). It is DISTINCT from control_plane_ip above (the CP-node EIP, a Huawei 1:1 NAT that is externally unreachable — the #4687 option-B wrongly pointed DNS there, verified hw208). catalyst-api reconciles the ELB members to the live nodePort post-convergence (post_handover_gateway_elb.go)."
+  description = "Public EIP the wildcard *.<fqdn> + app DNS A-records point at. #4690 / #4686 foundation-fix — this is the RESTORED gateway ELB's OWN routable EIP (huaweicloud_vpc_eip.elb_primary). The ELB does TCP passthrough public :443/:80 → node:443/:80, the durable cilium-envoy hostNetwork host ports (§854 — NodePorts FORBIDDEN; the former ELB→nodePort shape of #4690/#4691 was retired by the cilium 1.19.3 bump). It is DISTINCT from control_plane_ip above (the CP-node EIP, a Huawei 1:1 NAT that is externally unreachable — the #4687 option-B wrongly pointed DNS there, verified hw208). tofu seeds correct members at Phase-0; catalyst-api only heals member-set drift from node churn post-convergence (post_handover_gateway_elb.go) — ports never change."
   value       = huaweicloud_vpc_eip.elb_primary.publicip.0.ip_address
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1163,16 +1163,18 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// object-model surface). See post_handover_spine_apps.go.
 		h.spawnPostHandoverHook(func() { h.runPostHandoverSpineApplications(dep) })
 
-		// #4690 / #4686: on the CCM-less Huawei provider, discover the Sovereign
-		// gateway LoadBalancer Service's live auto-allocated nodePort and
-		// reconcile the Huawei gateway ELB's pool members to it (public :443/:80
-		// → node:<nodePort>). Without this the restored gateway ELB members stay
-		// at the tofu placeholder port and the wildcard *.<fqdn> front door never
-		// serves. Background goroutine + internal retry budget: the gateway
-		// Service may still be settling at first OutcomeReady, so this must NOT
-		// block the terminate path. No-op on Hetzner (hcloud-ccm programs
-		// node:443 directly). Failures log + emit SSE warn but never fail the
-		// handover. See post_handover_gateway_elb.go.
+		// #4690 / #4686: on the CCM-less Huawei provider, reconcile the Huawei
+		// gateway ELB's pool MEMBER SET to the live cluster's node IPs at the
+		// durable ports (public :443/:80 → node:443/:80, the cilium-envoy
+		// hostNetwork host ports — §854, no nodePort anywhere; the former
+		// discover-nodePort shape of #4690/#4691 was retired by the cilium
+		// 1.19.3 bump). Without this, autoscaler-added nodes are missing from
+		// the pools and replaced/removed nodes leave stale members. Background
+		// goroutine + internal retry budget: the node set may still be settling
+		// at first OutcomeReady, so this must NOT block the terminate path.
+		// No-op on Hetzner (hcloud-ccm programs node:443 directly). Failures
+		// log + emit SSE warn but never fail the handover. See
+		// post_handover_gateway_elb.go.
 		h.spawnPostHandoverHook(func() { h.runPostHandoverGatewayELB(dep) })
 	} else if outcome == helmwatch.OutcomeTimeout && len(dep.Request.Regions) >= 2 {
 		// #3285/hw130 (2026-06-12): a Phase-1 TIMEOUT is the


### PR DESCRIPTION
Two doc-drift sites still described the retired #4690/#4691 ELB→auto-allocated-nodePort shape as **current** behavior — on the exact surface of the founder's hard rule (NodePorts absolutely forbidden, §854):

- `infra/providers/huawei/outputs.tf` `load_balancer_ip` description claimed "ELB forwards :443/:80 → the gateway Service's auto-allocated nodePort" and "catalyst-api reconciles ELB members to the live nodePort".
- `phase1_watch.go` hook comment claimed the post-handover hook "discovers the live auto-allocated nodePort and reconciles pool members to it".

Reality (per `post_handover_gateway_elb.go` + `providers/huawei/gateway_elb.go`, retired by the cilium 1.19.3 bump): the ELB does TCP passthrough to the **durable cilium-envoy hostNetwork host ports `node:443/:80`**, tofu seeds correct members at Phase-0, and the hook only heals member-set drift from node churn. Comments/descriptions updated to match; zero behavior change (`go build ./internal/handler/` clean).

Part of the #5046 doc/system 100%-alignment sweep. `gateway_elb.go`'s own header was already correctly phrased as history — untouched.

Refs #5046

🤖 Generated with [Claude Code](https://claude.com/claude-code)