### PR TITLE
fix(scripts): wire MANDATORY prov-preflight gate into fire() — fail-closed

### DIFF
--- a/scripts/prov-preflight.sh
+++ b/scripts/prov-preflight.sh
@@ -7,8 +7,11 @@
 # Usage: scripts/prov-preflight.sh <FQDN> <BUCKET> [<qaTestEnabled>] [<fireCutoverOnHandover>]
 #   FQDN must be a NEW incremented env (hw<NNN>.<tld>) — never reuse a failed number.
 #
-# Requires: COOK (catalyst_session cookie) + HW_TFVARS (path to tofu.auto.tfvars.json
-# with Huawei AK/SK) in the environment.
+# Requires: COOK (catalyst_session cookie) OR BEARER (owner RS256 JWT) for the
+# deployments check, + HW_TFVARS (path to tofu.auto.tfvars.json with Huawei
+# AK/SK). PREFLIGHT_PROTECTED (comma-separated env stems, default hw240) names
+# Sovereigns that legitimately coexist — never counted against capacity and
+# NEVER to be wiped to make room (docs/PROTOCOL.md §5.0 protect-list).
 set -uo pipefail
 FQDN="${1:?need FQDN}"; BUCKET="${2:?need BUCKET}"
 QATEST="${3:-false}"; FIRECUT="${4:-true}"
@@ -22,12 +25,21 @@ echo "═══ PROV PRE-FLIGHT for ${FQDN} ═══"
 case "$FQDN" in hw[0-9]*) pass "1. FQDN is hw-numbered: $FQDN (caller must confirm it is a NEW number, never a failed one)";;
   *) bad "1. FQDN '$FQDN' is not hw<NNN>.<tld> — increment the env number";; esac
 
-# 2. zero other active deployments (kom4dc fits ONE prov: VPC+EIP quota)
-act=$(curl -s -H "Cookie: catalyst_session=${COOK}" "${CONSOLE}/deployments" 2>/dev/null | python3 -c '
-import sys,json
+# 2. zero other active deployments beyond the protect-list (kom4dc fits ONE
+#    working prov alongside the protected production Sovereign: VPC quota 5,
+#    2 VPCs per 2-region prov). Auth: BEARER (owner JWT) preferred, else COOK —
+#    the list is owner-scoped either way (mint as emrah.baysal@openova.io).
+if [ -n "${BEARER:-}" ]; then AUTH_HDR="Authorization: Bearer ${BEARER}"; else AUTH_HDR="Cookie: catalyst_session=${COOK:-}"; fi
+act=$(curl -s -H "$AUTH_HDR" "${CONSOLE}/deployments" 2>/dev/null | PROT="${PREFLIGHT_PROTECTED:-hw240}" python3 -c '
+import sys,json,os
+prot=[p.strip() for p in os.environ.get("PROT","").split(",") if p.strip()]
 d=json.load(sys.stdin); deps=d if isinstance(d,list) else d.get("deployments",d.get("items",[]))
-print(len([x for x in deps if x.get("status") not in ("wiped","deleted","failed","gone",None)]))' 2>/dev/null)
-[ "$act" = "0" ] && pass "2. 0 active deployments (capacity free)" || bad "2. ${act} active deployment(s) — wipe first (sequential)"
+live=[x for x in deps if x.get("status") not in ("wiped","deleted","failed","gone",None)]
+def protected(x):
+    f=str(x.get("sovereignFQDN") or x.get("fqdn") or x.get("sovereignSubdomain") or "")
+    return any(f.startswith(p) for p in prot)
+print(len([x for x in live if not protected(x)]))' 2>/dev/null)
+[ "${act:-x}" = "0" ] && pass "2. 0 active non-protected deployments (capacity free; protect-list: ${PREFLIGHT_PROTECTED:-hw240})" || bad "2. ${act:-unknown} active non-protected deployment(s) — wipe first (sequential; NEVER wipe protect-list envs to make room)"
 
 # 3. EIP headroom: only the bastion may remain; no DOWN/unbound orphans
 if [ -n "${HW_TFVARS:-}" ] && [ -s "${HW_TFVARS}" ]; then
@@ -56,9 +68,10 @@ PY
   #     Huawei ECS in the target project and FAIL if ANY node's name prefix is NOT this
   #     FQDN and NOT bastion-*. A foreign live Sovereign in the project = DO NOT FIRE.
   stem=$(printf '%s' "$FQDN" | tr '.' '-')
-  foreign=$(python3 - "$HW_TFVARS" "$stem" <<'PY' 2>/dev/null
+  foreign=$(python3 - "$HW_TFVARS" "$stem" "${PREFLIGHT_PROTECTED:-hw240}" <<'PY' 2>/dev/null
 import sys,json,hashlib,hmac,datetime,urllib.request,ssl
 t=json.load(open(sys.argv[1])); stem=sys.argv[2]
+prot=[p.strip() for p in sys.argv[3].split(",") if p.strip()]
 ak=t.get('huawei_access_key') or t.get('access_key') or t.get('huawei_ak'); sk=t.get('huawei_secret_key') or t.get('secret_key') or t.get('huawei_sk')
 proj=t.get('huawei_project_id') or t.get('project_id'); region=t.get('huawei_region') or 'me-east-215'
 host=f"ecs.{region}.kom4dc.nationalcloud.om"; uri=f"/v1/{proj}/cloudservers/detail"
@@ -68,14 +81,36 @@ sig=hmac.new(sk.encode(),sts.encode(),hashlib.sha256).hexdigest()
 ctx=ssl.create_default_context(); ctx.check_hostname=False; ctx.verify_mode=ssl.CERT_NONE
 req=urllib.request.Request(f"https://{host}{uri}",headers={"X-Sdk-Date":now,"Authorization":f"SDK-HMAC-SHA256 Access={ak}, SignedHeaders={sh}, Signature={sig}","host":host})
 servers=json.load(urllib.request.urlopen(req,timeout=25,context=ctx)).get("servers",[])
-# foreign = any ECS not part of THIS prov's stem and not the bastion
-foreign=[s.get('name','') for s in servers if stem not in s.get('name','') and not s.get('name','').startswith('bastion')]
+# foreign = any ECS not part of THIS prov's stem, not the bastion, and not a
+# protect-listed Sovereign (which legitimately coexists — never wipe it).
+foreign=[s.get('name','') for s in servers if stem not in s.get('name','') and not s.get('name','').startswith('bastion') and not any(s.get('name','').startswith(p) for p in prot)]
 print("\n".join(foreign) if foreign else "0")
 PY
 )
-  if [ "${foreign:-x}" = "0" ]; then pass "3b. no foreign Sovereign in project (live Huawei ECS ground-truth)"
+  if [ "${foreign:-x}" = "0" ]; then pass "3b. no foreign Sovereign in project (live Huawei ECS ground-truth; protect-list excluded)"
   else bad "3b. FOREIGN live ECS in target project (a live Sovereign shares it — firing WILL risk #4614 VPC-reclaim): $(printf '%s' "$foreign" | tr '\n' ' ' | cut -c1-160)"; fi
-else bad "3. HW_TFVARS unset — cannot verify EIP headroom"; fi
+
+  # 3c. VPC headroom (the ACTUAL #4614 reclaim trigger): a 2-region prov
+  #     consumes 2 VPCs; kom4dc quota is 5. Require >=2 free so tofu-init
+  #     never quota-reclaims a live VPC. Override quota via PREFLIGHT_VPC_QUOTA.
+  vused=$(python3 - "$HW_TFVARS" <<'PY' 2>/dev/null
+import sys,json,hashlib,hmac,datetime,urllib.request,ssl
+t=json.load(open(sys.argv[1]))
+ak=t.get('huawei_access_key') or t.get('access_key') or t.get('huawei_ak'); sk=t.get('huawei_secret_key') or t.get('secret_key') or t.get('huawei_sk')
+proj=t.get('huawei_project_id') or t.get('project_id'); region=t.get('huawei_region') or 'me-east-215'
+host=f"vpc.{region}.kom4dc.nationalcloud.om"; uri=f"/v1/{proj}/vpcs"
+now=datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ'); ch=f"host:{host}\nx-sdk-date:{now}\n"; sh="host;x-sdk-date"
+cr=f"GET\n{uri}/\n\n{ch}\n{sh}\n"+hashlib.sha256(b'').hexdigest(); sts=f"SDK-HMAC-SHA256\n{now}\n"+hashlib.sha256(cr.encode()).hexdigest()
+sig=hmac.new(sk.encode(),sts.encode(),hashlib.sha256).hexdigest()
+ctx=ssl.create_default_context(); ctx.check_hostname=False; ctx.verify_mode=ssl.CERT_NONE
+req=urllib.request.Request(f"https://{host}{uri}",headers={"X-Sdk-Date":now,"Authorization":f"SDK-HMAC-SHA256 Access={ak}, SignedHeaders={sh}, Signature={sig}","host":host})
+print(len(json.load(urllib.request.urlopen(req,timeout=20,context=ctx)).get("vpcs",[])))
+PY
+)
+  vq="${PREFLIGHT_VPC_QUOTA:-5}"
+  if [ -n "${vused:-}" ] && [ "$vused" -le $((vq-2)) ] 2>/dev/null; then pass "3c. VPC headroom: ${vused}/${vq} used (>=2 free for a 2-region fire)"
+  else bad "3c. VPC headroom insufficient: used=${vused:-unknown}/${vq} — need >=2 free (wipe stale envs + wait ~15min release lag; NEVER reclaim live VPCs)"; fi
+else bad "3. HW_TFVARS unset — cannot verify EIP/VPC headroom or foreign-Sovereign ground truth"; fi
 
 # 4. mothership catalyst-api rollout settled
 if kubectl -n catalyst rollout status deploy/catalyst-api --timeout=8s >/dev/null 2>&1; then
@@ -84,7 +119,7 @@ else bad "4. catalyst-api mid-roll — wait (a roll mid-prov ABANDONS it)"; fi
 
 # 5. NO in-flight Build-&-Deploy / blueprint-release CI (a merge mid-prov rolls catalyst-api -> abandon)
 inflight=$(gh run list --repo openova-io/openova --limit 12 --json name,status -q '[.[]|select(.status!="completed")]|length' 2>/dev/null)
-[ "${inflight:-x}" = "0" ] && pass "5. no in-flight CI (and HOLD all merges until ready)" || bad "5. ${inflight} CI run(s) in flight — wait + DO NOT MERGE until prov is ready"
+[ "${inflight:-x}" = "0" ] && pass "5. no in-flight CI (and HOLD all merges until ready)" || bad "5. ${inflight:-unknown} CI run(s) in flight — wait + DO NOT MERGE until prov is ready"
 
 # 6. fresh bucket (caller asserts uniqueness)
 pass "6. bucket: ${BUCKET} (caller must confirm it is fresh/unused)"

--- a/scripts/sovereign-lifecycle.sh
+++ b/scripts/sovereign-lifecycle.sh
@@ -2,7 +2,8 @@
 # Canonical Sovereign prov lifecycle — MECHANICAL enforcement of the two founder
 # rules (2026-06-08). NEVER call POST /deployments or POST /wipe directly; go
 # through this so the wrong order is impossible:
-#   * fire  -> runs scripts/reset-uat.py FIRST, then POST /deployments
+#   * fire  -> runs the MANDATORY scripts/prov-preflight.sh gate (fail-closed,
+#             docs/PROTOCOL.md §5), then scripts/reset-uat.py, then POST /deployments
 #   * wipe  -> CAPTURES the cloud-init log FIRST (GET /cloudinit-log, #3132),
 #             then POST /wipe   <-- debug-before-wipe
 # The capture relies on the control-plane self-uploading its log (#3132); on
@@ -48,6 +49,25 @@ wipe() {
 # fire <subdomain> [pool] — RESET-UAT-ON-FIRE: reset first, ALWAYS, then fire.
 fire() {
   local sub="$1" pool="${2:-omani.works}" pub body
+  # MANDATORY pre-flight gate (docs/PROTOCOL.md §5; founder mandate 2026-06-30:
+  # never fire blind). Fail-closed, no bypass. Runs BEFORE reset_uat so a
+  # refused fire never flushes ledger evidence. HW_TFVARS auto-fetched from the
+  # mothership catalyst-api PVC when unset (the only durable cred cache — L1).
+  if [ -z "${HW_TFVARS:-}" ]; then
+    local apod tfsrc
+    apod=$(kubectl -n catalyst get pods -o name 2>/dev/null | grep -m1 catalyst-api | cut -d/ -f2)
+    if [ -n "$apod" ]; then
+      tfsrc=$(kubectl -n catalyst exec "$apod" --request-timeout=25s -- sh -c 'ls -t /var/lib/catalyst/tofu/*/tofu.auto.tfvars.json /deps/tofu/*/tofu.auto.tfvars.json 2>/dev/null | head -1' 2>/dev/null)
+      if [ -n "$tfsrc" ]; then
+        kubectl -n catalyst exec "$apod" --request-timeout=25s -- cat "$tfsrc" > /tmp/preflight-tfvars.json 2>/dev/null
+        export HW_TFVARS=/tmp/preflight-tfvars.json
+      fi
+    fi
+  fi
+  echo "== MANDATORY prov-preflight gate (docs/PROTOCOL.md §5) =="
+  if ! BEARER="$(_tok)" bash "${REPO_ROOT}/scripts/prov-preflight.sh" "${sub}.${pool}" "auto-${sub}" "false" "true"; then
+    echo "!! PRE-FLIGHT FAIL — fire ABORTED (fix the ❌ items; never fire blind, never wipe protect-list envs to make room)"; return 1
+  fi
   echo "== reset-UAT-on-fire (founder rule 2026-06-08) =="; reset_uat "$sub"
   pub=$(cat /home/openova/.ssh/*.pub 2>/dev/null | grep -E "^ssh-" | head -1)
   # SHARED_PG=true opts the prov into the ADR-0010 reusable shared-Postgres


### PR DESCRIPTION
Retrospective cause 4 (**CONFIRMED**, #5046): `scripts/prov-preflight.sh` self-declares the MANDATORY pre-flight gate (founder mandate 2026-06-30) yet had **zero callers** — `sovereign-lifecycle.sh fire()` POSTed after only a UAT reset. Production was deleted twice (#4614, #4675) by exactly the class this gate exists to prevent.

**Wiring** (`sovereign-lifecycle.sh`):
- `fire()` runs the gate **before** `reset_uat` — a refused fire never flushes ledger evidence — and aborts fail-closed, no bypass.
- `HW_TFVARS` auto-fetched from the catalyst-api PVC when unset (`/var/lib/catalyst/tofu/*/tofu.auto.tfvars.json` in-pod, `/deps` debug-pod fallback).

**Gate fixes** (`prov-preflight.sh`) so it actually works in the fire path:
- `BEARER` (owner RS256 JWT) auth for the owner-scoped deployments check — `fire()` mints JWTs, not cookies.
- `PREFLIGHT_PROTECTED` protect-list (default `hw240`): the coexisting production Sovereign is never counted against capacity nor flagged foreign. Without this the gate chronically fails and pressures a future session toward the catastrophic wipe-to-make-room move it exists to prevent (docs/PROTOCOL.md §5.0).
- **NEW check 3c — VPC headroom**: requires ≥2 of the 5-quota VPCs free (a 2-region prov consumes 2) — the actual #4614 quota-reclaim trigger, previously unchecked.

**Live validation** (anti-theater): run against current reality with hw250 mid-cutover → `rc=1` with four true positives — 1 active non-protected deployment (hw250), 5 orphaned/unbound EIPs, hw250 ECS correctly flagged foreign to a hypothetical hw999, 2 CI runs in flight — and check 3c reads real quota (3/5 used). Checks 1/3c/4/6/7 pass. Full output on #5046.

Side-finding for the janitor backlog: **5 orphaned/unbound EIPs** currently in the project (excluding bastion) — cleanup candidate once hw250 concludes.

Refs #5046 #4675 #4614

🤖 Generated with [Claude Code](https://claude.com/claude-code)