### PR TITLE
fix(cutover): step-03 HARBOR_HOST explicit port — bare in-cluster dest black-holes token flow on ClusterIP:443

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -843,7 +843,13 @@ spec:
       # redirect (raw github.com/…) is a genuine deny-egress offender. Unblocks the ~40
       # harbor.openova.io/proxy-* chart-default refs step-07 doesn't textually pivot;
       # the deny-egress hold + completeness gate (authoritative proof) are UNCHANGED.
-      version: 0.1.126
+      # 0.1.127 (#5051 Refs #5037 #5036): step-03 HARBOR_HOST carries an EXPLICIT
+      # scheme-derived port (:80 http / :443 https). A bare in-cluster host made
+      # containers/image resolve the Harbor auth-token/blob-reuse endpoints
+      # https-first onto ClusterIP:443 — unexposed by the harbor-core Service —
+      # and unbacked ClusterIP ports black-hole (no RST): hw250 live step-03 ran
+      # 40+ min at 0/136 with per-blob token GETs timing out. Contract Case 54.
+      version: 0.1.127
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.126
+  version: 0.1.127
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2024,7 +2024,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.126
+version: 0.1.127
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -424,6 +424,20 @@ data:
             # dest_already_current), so this does not touch step-04/08. --dest-tls-verify
             # =false (default) drives skopeo's http fallback for the plain-HTTP Service.
             HARBOR_HOST=$(printf '%s' "${HARBOR_INTERNAL_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
+            # #5051: EXPLICIT PORT is mandatory. With a bare in-cluster host,
+            # containers/image resolves the auth-token/blob-reuse endpoints
+            # https-first onto ClusterIP:443 — a port the harbor-core Service
+            # does not expose — and an unbacked ClusterIP port BLACK-HOLES
+            # (no RST), so every copy burned its full timeout (hw250 live:
+            # 0/136 ok, cutover step-03 blocked). host:80 pins the entire
+            # registry+token flow to the plain-HTTP Service port.
+            case "${HARBOR_HOST}" in
+              *:*) : ;;
+              *) case "${HARBOR_INTERNAL_URL}" in
+                   https://*) HARBOR_HOST="${HARBOR_HOST}:443" ;;
+                   *)         HARBOR_HOST="${HARBOR_HOST}:80" ;;
+                 esac ;;
+            esac
 
             # Enumerate openova-io images cluster-wide.
             #

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2222,4 +2222,18 @@ grep -q 'RC=1' <<<"$_o" || { printf 'FAIL: #5036 — an un-covered github.com re
 grep -q 'UNCOVERED bad/badapp.*host:github.com' <<<"$_o" || { printf 'FAIL: #5036 — github.com offender not named UNCOVERED; output:\n%s\n' "$_o" >&2; exit 1; }
 echo "  PASS (#5036 contract: mothership redirect-covered ref sovereign; un-covered github.com ref is a named offender; ghcr.io documented as redirect-covered → not a FAIL example)"
 
+# ── Case 54 (#5051): step-03 HARBOR_HOST must carry an EXPLICIT PORT ─────────
+# A bare in-cluster host makes containers/image resolve the Harbor auth-token /
+# blob-reuse endpoints https-first onto ClusterIP:443 — a port the harbor-core
+# Service does not expose — and an unbacked ClusterIP port BLACK-HOLES (no
+# RST), so every copy burns its full timeout (hw250 live: 0/136 ok, cutover
+# blocked at step-03). The template must append :80/:443 (scheme-derived) when
+# HARBOR_INTERNAL_URL carries no port.
+echo "[cutover-contract] Case 54: step-03 HARBOR_HOST explicit port (#5051)"
+if ! grep -qF 'HARBOR_HOST="${HARBOR_HOST}:80"' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 does not append an explicit :80 to a port-less HARBOR_INTERNAL_URL — the skopeo token flow black-holes on ClusterIP:443 (#5051)" >&2
+  exit 1
+fi
+echo "  PASS (#5051 contract: HARBOR_HOST carries an explicit port — registry+token flow pinned to the plain-HTTP Service port)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.126"
+  version: "0.1.127"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.126"
+    version: "0.1.127"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Fixes the #5051 defect blocking hw250's live cutover at step-03 (full RCA + probe matrix on the issue).

**Root cause**: #5037 (`de1c06056`) pivoted the skopeo copy dest to the bare in-cluster host. containers/image resolves Harbor's auth-token/blob-reuse endpoints **https-first onto ClusterIP:443** — a port the `harbor-core` Service does not expose (`80→8080` http only) — and an unbacked ClusterIP port **black-holes instead of RSTing**, so every copy burned its full command-timeout. hw250 live: 40+ min at **0/136 ok**, every settled image failing on `dial tcp 10.96.213.73:443: i/o timeout`. Datapath and policy were exonerated live (cilium-health 12/12, zero drops on source+dest agents, VPC pod-CIDR routes in sync).

**Fix**: append an explicit scheme-derived port (`:80` http / `:443` https) to `HARBOR_HOST` when `HARBOR_INTERNAL_URL` carries none — the entire registry+token flow stays on the plain-HTTP Service port. Step-04/08 untouched (they target `LOCAL_REGISTRY_HOST`; the resolver's host-less paths strip the `HARBOR_HOST/` prefix regardless of port).

**Chart** `0.1.126 → 0.1.127`. **Contract Case 54** locks the invariant; full suite green locally (54/54 incl. Case 52's in-cluster-dial assertions, unbroken).

**Release-train**: hw250 stays converged — after publish + pin bump, its flux upgrade re-renders step-03 and the cutover re-fires via the runner-SA trigger. No fresh prov.

Refs #5051 #5037 #5036 #5046

🤖 Generated with [Claude Code](https://claude.com/claude-code)