### PR TITLE
fix(cutover): step-03 skopeo dest = HARBOR_PUBLIC_URL behind fail-loud probe (#5051 round 2)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -849,7 +849,14 @@ spec:
       # https-first onto ClusterIP:443 — unexposed by the harbor-core Service —
       # and unbacked ClusterIP ports black-hole (no RST): hw250 live step-03 ran
       # 40+ min at 0/136 with per-blob token GETs timing out. Contract Case 54.
-      version: 0.1.127
+      # 0.1.128 (#5051 round 2): the :80 attempt was PARTIAL — Harbor's bearer
+      # realm is https://<request-host>/service/token (host echoed, scheme
+      # HARD-https, probed live on hw250 across core/nginx/public) and nothing
+      # in-cluster terminates TLS, so NO in-cluster dest can complete the token
+      # flow. skopeo dest reverts to HARBOR_PUBLIC_URL (registry.<fqdn>) with a
+      # bounded 40x15s readiness probe covering the #5037 pre-pivot DNS flake;
+      # Harbor REST API dials stay on HARBOR_INTERNAL_URL. Cases 52/54 amended.
+      version: 0.1.128
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.127
+  version: 0.1.128
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2024,7 +2024,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.127
+version: 0.1.128
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -131,9 +131,10 @@ data:
           - name: PREWARM_SKOPEO_TIMEOUT
             value: {{ .Values.prewarm.skopeoCommandTimeout | default "1200s" | quote }}
           # #4529 (Refs #3379): TLS-verify on the skopeo copy DESTINATION (the
-          # in-cluster Harbor Service harbor-core.harbor.svc = HARBOR_HOST post-#5036).
-          # DEFAULT false — the copy target is the Sovereign's OWN registry over the
-          # cluster pod network. Pre-#5036 (HARBOR_HOST=registry.<fqdn>) the target's
+          # PUBLIC registry.<fqdn> = HARBOR_HOST — restored by #5051 round 2; the
+          # #5036/#5037 in-cluster dest is unusable for pushes because Harbor's
+          # bearer-token realm is hard-https on the echoed host and nothing
+          # in-cluster terminates TLS). DEFAULT false — the target's
           # wildcard cert was LE-STAGING/untrusted on a fresh prov (and a Job-Pod
           # skopeo has no node trust store even with production LE), so verifying the
           # dest against the public CA x509-failed every push (live keystone
@@ -421,23 +422,40 @@ data:
             # containerd + step-08 completeness HEAD, which target LOCAL_REGISTRY_HOST,
             # unchanged — resolve the identical artifacts. HARBOR_HOST is step-03-local
             # (the resolver returns host-LESS paths; the prefix is stripped in
-            # dest_already_current), so this does not touch step-04/08. --dest-tls-verify
-            # =false (default) drives skopeo's http fallback for the plain-HTTP Service.
-            HARBOR_HOST=$(printf '%s' "${HARBOR_INTERNAL_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
-            # #5051: EXPLICIT PORT is mandatory. With a bare in-cluster host,
-            # containers/image resolves the auth-token/blob-reuse endpoints
-            # https-first onto ClusterIP:443 — a port the harbor-core Service
-            # does not expose — and an unbacked ClusterIP port BLACK-HOLES
-            # (no RST), so every copy burned its full timeout (hw250 live:
-            # 0/136 ok, cutover step-03 blocked). host:80 pins the entire
-            # registry+token flow to the plain-HTTP Service port.
-            case "${HARBOR_HOST}" in
-              *:*) : ;;
-              *) case "${HARBOR_INTERNAL_URL}" in
-                   https://*) HARBOR_HOST="${HARBOR_HOST}:443" ;;
-                   *)         HARBOR_HOST="${HARBOR_HOST}:80" ;;
-                 esac ;;
-            esac
+            # dest_already_current), so this does not touch step-04/08.
+            #
+            # #5051 (round 2 — supersedes the 0.1.127 :80 attempt): the skopeo
+            # PUSH DEST must be the PUBLIC host. Harbor builds its bearer-token
+            # realm as https://<request-host>/service/token — request host
+            # echoed, scheme HARD-https (probed empirically on hw250 across
+            # harbor-core:80, nginx harbor:80, and the public URL) — and NO
+            # in-cluster harbor Service terminates TLS (all http/80; TLS ends
+            # at the gateway). An in-cluster dest therefore can NEVER complete
+            # the token flow: hw250 went 0/136 twice (bare host → :443
+            # black-hole; :80 host → https-on-plaintext). Only the public host
+            # yields a realm that is actually reachable (gateway + cert). The
+            # #5037 motivation (hw246 pre-pivot NXDOMAIN flake) is handled by
+            # the bounded readiness probe below, NOT by a dest pivot. Harbor
+            # REST API dials (projects, artifact idempotency probe, Phase B
+            # /v2 HEAD — basic auth, no token dance) STAY on
+            # HARBOR_INTERNAL_URL, which step-02 proved works in-cluster.
+            HARBOR_HOST=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
+            echo "[harbor-prewarm] public-dest readiness probe: https://${HARBOR_HOST}/v2/ (want 401/200)"
+            _pr_ok=0
+            for _pr_i in $(seq 1 40); do
+              _pr_code=$(curl -sk -o /dev/null -w '%{http_code}' -m 10 "https://${HARBOR_HOST}/v2/" 2>/dev/null)
+              if [ "${_pr_code}" = "401" ] || [ "${_pr_code}" = "200" ]; then
+                _pr_ok=1
+                echo "[harbor-prewarm] public dest ready (HTTP ${_pr_code}, probe ${_pr_i})"
+                break
+              fi
+              echo "[harbor-prewarm] public dest not ready (HTTP ${_pr_code:-none}, probe ${_pr_i}/40) — pre-pivot DNS/gateway may still be settling (#5037 hw246 flake); retry in 15s"
+              sleep 15
+            done
+            if [ "${_pr_ok}" != "1" ]; then
+              echo "[harbor-prewarm] FATAL: public dest https://${HARBOR_HOST}/v2/ never became ready after 40 probes — cannot push. The in-cluster fallback is NOT usable (Harbor token realm is hard-https on the echoed host; #5051). Fix DNS/gateway, then re-trigger."
+              exit 1
+            fi
 
             # Enumerate openova-io images cluster-wide.
             #

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2112,7 +2112,7 @@ if ! grep -q 'RC=0' <<<"$_lint_pass_out"; then
 fi
 echo "  PASS (lint fails loud on an un-covered github.com tether; exempts redirect-covered harbor.openova.io + ghcr.io; skips excluded/implicit-docker.io/local)"
 
-echo "[cutover-contract] Case 52: PRE-pivot steps 02/03 dial the local Harbor at the IN-CLUSTER Service (HARBOR_INTERNAL_URL = harbor-core.harbor.svc), NOT the external registry.<fqdn> (HARBOR_PUBLIC_URL) — the external host NXDOMAINs in-cluster before the step-04 pin (#5036, reverts #4688, Refs #5007)"
+echo "[cutover-contract] Case 52: PRE-pivot steps 02/03 Harbor REST API dials use the IN-CLUSTER Service (HARBOR_INTERNAL_URL); the step-03 skopeo PUSH DEST uses HARBOR_PUBLIC_URL behind a readiness probe — Harbor bearer realm is hard-https on the echoed host, so no in-cluster dest can complete the token flow (#5036 amended by #5051)"
 # hw246 (dep c38c437f, omani.works): steps 02 (harbor-projects) + 03 (harbor-prewarm)
 # run PRE-pivot, BEFORE step-04 pins registry.<fqdn> in the node /etc/hosts (#5007).
 # #4688 pointed their Harbor dials at the EXTERNAL host registry.<fqdn>, which resolves
@@ -2148,8 +2148,12 @@ if ! grep -qF 'base="${HARBOR_INTERNAL_URL}/api/v2.0"' "$TMP/s02.yaml"; then
 fi
 # (c) Step-03 harbor-prewarm: the skopeo PUSH host, the artifact-API idempotency probe,
 #     and the /v2 HEAD base MUST all derive from the internal Service.
-if ! grep -qF 'HARBOR_HOST=$(printf '"'"'%s'"'"' "${HARBOR_INTERNAL_URL}"' "$TMP/s03.yaml"; then
-  echo "FAIL: step-03 harbor-prewarm skopeo push HARBOR_HOST is not derived from HARBOR_INTERNAL_URL — the push target NXDOMAINs pre-pivot on a PowerDNS-flaked prov (#5036)" >&2
+if ! grep -qF 'HARBOR_HOST=$(printf '"'"'%s'"'"' "${HARBOR_PUBLIC_URL}"' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 harbor-prewarm skopeo push HARBOR_HOST is not derived from HARBOR_PUBLIC_URL — Harbor advertises its bearer-token realm as https://<request-host>/service/token and nothing in-cluster terminates TLS, so an in-cluster push dest can NEVER complete the token flow (hw250 0/136 twice; #5051)" >&2
+  exit 1
+fi
+if ! grep -qF 'public-dest readiness probe' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 lacks the bounded public-dest readiness probe — without it a pre-pivot DNS flake (hw246 #5037) fails copies blind instead of waiting/failing loud (#5051)" >&2
   exit 1
 fi
 if ! grep -qF '"${HARBOR_INTERNAL_URL}/api/v2.0/projects/' "$TMP/s03.yaml"; then
@@ -2178,15 +2182,14 @@ for blk in s02 s03; do
   for bad in \
     'base="${HARBOR_PUBLIC_URL}/api/v2.0"' \
     'base="${HARBOR_PUBLIC_URL}/v2"' \
-    '"${HARBOR_PUBLIC_URL}/api/v2.0/projects/' \
-    'HARBOR_HOST=$(printf '"'"'%s'"'"' "${HARBOR_PUBLIC_URL}"' ; do
+    '"${HARBOR_PUBLIC_URL}/api/v2.0/projects/' ; do
     if grep -qF "$bad" "$TMP/$blk.yaml"; then
       echo "FAIL: step-${blk#s} still targets the external HARBOR_PUBLIC_URL ('$bad') — reintroduces the #4688 pre-pivot NXDOMAIN (#5036)" >&2
       exit 1
     fi
   done
 done
-echo "  PASS (steps 02/03 dial the in-cluster harbor-core.harbor.svc for API + skopeo push; single-encode %2F for the direct path; no HARBOR_PUBLIC_URL dial target remains; steps 07/08 external-host validation untouched)"
+echo "  PASS (steps 02/03 REST API dials stay in-cluster; step-03 skopeo dest is HARBOR_PUBLIC_URL behind a readiness probe per the #5051 realm invariant; single-encode %2F for the direct API path; steps 07/08 external-host validation untouched)"
 
 echo "[cutover-contract] Case 53: step-08 ref-host lint #5036 CONTRACT — a redirect-covered mothership ref (harbor.openova.io/proxy-*) is SOVEREIGN (PASS); an un-covered external ref (github.com/*) is an offender (FAIL). NB: ghcr.io is NOT a valid FAIL example — step-04 redirect-covers it (proxy-ghcr; verified live hw246), so it PASSES too."
 _c53="$TMP/lint53"; mkdir -p "$_c53/bin" "$_c53/work"
@@ -2222,18 +2225,23 @@ grep -q 'RC=1' <<<"$_o" || { printf 'FAIL: #5036 — an un-covered github.com re
 grep -q 'UNCOVERED bad/badapp.*host:github.com' <<<"$_o" || { printf 'FAIL: #5036 — github.com offender not named UNCOVERED; output:\n%s\n' "$_o" >&2; exit 1; }
 echo "  PASS (#5036 contract: mothership redirect-covered ref sovereign; un-covered github.com ref is a named offender; ghcr.io documented as redirect-covered → not a FAIL example)"
 
-# ── Case 54 (#5051): step-03 HARBOR_HOST must carry an EXPLICIT PORT ─────────
-# A bare in-cluster host makes containers/image resolve the Harbor auth-token /
-# blob-reuse endpoints https-first onto ClusterIP:443 — a port the harbor-core
-# Service does not expose — and an unbacked ClusterIP port BLACK-HOLES (no
-# RST), so every copy burns its full timeout (hw250 live: 0/136 ok, cutover
-# blocked at step-03). The template must append :80/:443 (scheme-derived) when
-# HARBOR_INTERNAL_URL carries no port.
-echo "[cutover-contract] Case 54: step-03 HARBOR_HOST explicit port (#5051)"
-if ! grep -qF 'HARBOR_HOST="${HARBOR_HOST}:80"' "$TMP/s03.yaml"; then
-  echo "FAIL: step-03 does not append an explicit :80 to a port-less HARBOR_INTERNAL_URL — the skopeo token flow black-holes on ClusterIP:443 (#5051)" >&2
+# ── Case 54 (#5051 round 2): step-03 push dest = PUBLIC host + fail-loud probe ─
+# Harbor builds its bearer-token realm as https://<request-host>/service/token
+# (host echoed, scheme HARD-https — probed live on hw250 across harbor-core:80,
+# nginx harbor:80, and the public URL) and NO in-cluster harbor Service
+# terminates TLS. An in-cluster skopeo dest therefore can NEVER complete the
+# token flow (0/136 twice on hw250: bare host → :443 black-hole; :80 host →
+# https-on-plaintext). The dest MUST be the public host; the pre-pivot DNS
+# flake (#5037/hw246) is covered by a bounded readiness probe that fails LOUD.
+echo "[cutover-contract] Case 54: step-03 push dest is PUBLIC + probe fails loud (#5051)"
+if grep -qF 'HARBOR_HOST=$(printf '"'"'%s'"'"' "${HARBOR_INTERNAL_URL}"' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 derives the skopeo push HARBOR_HOST from HARBOR_INTERNAL_URL — the in-cluster token flow is structurally broken (#5051)" >&2
   exit 1
 fi
-echo "  PASS (#5051 contract: HARBOR_HOST carries an explicit port — registry+token flow pinned to the plain-HTTP Service port)"
+if ! grep -qF 'never became ready after 40 probes' "$TMP/s03.yaml"; then
+  echo "FAIL: step-03 public-dest probe does not fail loud after its bounded window (#5051)" >&2
+  exit 1
+fi
+echo "  PASS (#5051 contract: skopeo dest is the public host; readiness probe bounded + fail-loud; in-cluster dest derivation gone)"
 
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.127"
+  version: "0.1.128"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.127"
+    version: "0.1.128"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Round 2 for #5051 — the 0.1.127 `:80` fix was PARTIAL. Empirical `WWW-Authenticate` probe from the live hw250 prewarm pod (table on the issue): Harbor advertises `Bearer realm="https://<request-host>/service/token"` — request host echoed, scheme **hard-https** — on every path, and no in-cluster harbor Service terminates TLS (all http/80). An in-cluster skopeo dest can therefore **never** complete the bearer-token flow: hw250 went 0/136 twice (bare host → ClusterIP:443 black-hole; `:80` host → https-on-plaintext).

**Fix (chart 0.1.128)**
- skopeo push dest reverts to `HARBOR_PUBLIC_URL` (`registry.<fqdn>`) — its advertised realm is the reachable gateway URL, proven end-to-end from the live pod (the 401 probe is a completed HTTPS round trip).
- Bounded **readiness probe** (40×15s, fail-loud with transcript) covers the #5037 motivation — hw246's pre-pivot DNS flake — without the structurally broken dest pivot.
- Harbor REST API dials (step-02 projects, step-03 artifact idempotency + Phase B `/v2` HEAD — basic auth, no token dance) **stay on `HARBOR_INTERNAL_URL`**, proven in-cluster.
- Contract **Case 52 amended** (API=internal, push dest=public+probe; regression bads updated), **Case 54 rewritten** to encode the realm invariant. Suite 54/54 green locally; lockstep Go tests + pin-sync green; full pin lockstep included (06a, blueprint.yaml, catalog-seed).

**Release-train**: hw250 stays converged; flux pulls the pin automatically post-publish and the cutover re-fires on the live env.

Refs #5051 #5037 #5036

🤖 Generated with [Claude Code](https://claude.com/claude-code)