### PR TITLE
fix(cutover): step-04 registry-pin VIP derivation splits on Service type — ClusterIP gateway pins HOST_IP (#5007 round 2)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -856,7 +856,12 @@ spec:
       # flow. skopeo dest reverts to HARBOR_PUBLIC_URL (registry.<fqdn>) with a
       # bounded 40x15s readiness probe covering the #5037 pre-pivot DNS flake;
       # Harbor REST API dials stay on HARBOR_INTERNAL_URL. Cases 52/54 amended.
-      version: 0.1.128
+      # 0.1.129 (#5007 round 2): step-04 registry-pin VIP derivation splits on
+      # Service .spec.type — the §854 ELB-direct model keeps the gateway Service
+      # as ClusterIP (no VIP ever), so the pin deferred FOREVER on every
+      # ELB-direct prov (hw250 all night); ClusterIP now pins HOST_IP like the
+      # absent-Service hostNetwork branch. LoadBalancer semantics unchanged.
+      version: 0.1.129
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.128
+  version: 0.1.129
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2024,7 +2024,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.128
+version: 0.1.129
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -442,10 +442,22 @@ data:
       json=$(printf '%s' "${resp}" | sed '$d')
       case "${code}" in
         200)
-          # Service present: use its ingress VIP (or spec.loadBalancerIP). Empty when
-          # the VIP is still pending → caller defers this sweep (do NOT fall back to
-          # HOST_IP here: in the LB model node:443 is NOT served by envoy).
-          printf '%s' "$(printf '%s' "${json}" | jq -r '.status.loadBalancer.ingress[0].ip // .spec.loadBalancerIP // empty' 2>/dev/null || true)"
+          # Service present. Split on .spec.type (#5007 round 2, hw250 live):
+          # - LoadBalancer: use its ingress VIP (or spec.loadBalancerIP); empty =
+          #   VIP pending → caller defers (do NOT fall back to HOST_IP: in the LB
+          #   model node:443 is NOT served by envoy).
+          # - ClusterIP (the §854 ELB-direct model keeps the gateway Service but
+          #   cilium assigns NO VIP EVER): hostNetwork envoy serves node:443 —
+          #   identical serving shape to the 404/absent branch — so pin HOST_IP.
+          #   Without this split the pin DEFERRED FOREVER on every ELB-direct
+          #   prov (hw250: 'LB VIP pending / API miss' on all sweeps all night),
+          #   leaving nodes exposed to the #5007 stale-wildcard defect.
+          svc_type=$(printf '%s' "${json}" | jq -r '.spec.type // empty' 2>/dev/null || true)
+          if [ "${svc_type}" = "LoadBalancer" ]; then
+            printf '%s' "$(printf '%s' "${json}" | jq -r '.status.loadBalancer.ingress[0].ip // .spec.loadBalancerIP // empty' 2>/dev/null || true)"
+          else
+            printf '%s' "${HOST_IP:-}"
+          fi
           ;;
         404)
           # Service absent → hostNetwork gateway model: cilium-envoy binds node:443.

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2244,4 +2244,24 @@ if ! grep -qF 'never became ready after 40 probes' "$TMP/s03.yaml"; then
 fi
 echo "  PASS (#5051 contract: skopeo dest is the public host; readiness probe bounded + fail-loud; in-cluster dest derivation gone)"
 
+# ── Case 55 (#5007 round 2): step-04 pin derivation handles ClusterIP gateway ─
+# The §854 ELB-direct model keeps the gateway Service present as type=ClusterIP
+# (cilium assigns NO VIP ever) while hostNetwork envoy serves node:443. The
+# resolve_gateway_vip 200-branch must split on .spec.type and pin HOST_IP for
+# non-LoadBalancer Services — else the /etc/hosts registry pin defers forever
+# (hw250 live: 'LB VIP pending / API miss' on every sweep) and nodes stay
+# exposed to the #5007 stale-wildcard defect.
+echo "[cutover-contract] Case 55: step-04 pin derivation splits on Service type (#5007)"
+awk '/name: cutover-step-04-registry-pivot/{c=1} /name: cutover-step-05/{c=0} c' "$TMP/render.yaml" > "$TMP/s04.yaml" || true
+[ -s "$TMP/s04.yaml" ] || cp "$TMP/render.yaml" "$TMP/s04.yaml"
+if ! grep -qF 'svc_type=$(printf' "$TMP/s04.yaml"; then
+  echo "FAIL: step-04 resolve_gateway_vip does not inspect Service .spec.type — ClusterIP gateway (ELB-direct §854) defers the registry pin forever (#5007)" >&2
+  exit 1
+fi
+if ! grep -qF '"${svc_type}" = "LoadBalancer"' "$TMP/s04.yaml"; then
+  echo "FAIL: step-04 pin derivation lacks the LoadBalancer/ClusterIP split (#5007)" >&2
+  exit 1
+fi
+echo "  PASS (#5007 contract: 200-branch splits on .spec.type — LB uses VIP-or-defer, non-LB pins HOST_IP like the hostNetwork branch)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.128"
+  version: "0.1.129"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.128"
+    version: "0.1.129"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
**🛑 RT-11 MERGE HOLD (docs/PROTOCOL.md §4): do NOT merge while hw250's cutover is between step-03 and step-08.** This bumps the cutover chart (0.1.129) — merging mid-cutover would publish past the live mirror, the exact race that hit three times tonight. Merge after `cutoverComplete` (or on failure disposition).

**Defect (live negative finding on #5007, hw250 all night):** the §854 ELB-direct model keeps the gateway Service present as `type=ClusterIP` — cilium assigns no VIP ever — while hostNetwork envoy serves `node:443`. `resolve_gateway_vip`'s 200-branch only extracted LoadBalancer VIPs, so the `/etc/hosts` registry pin **deferred forever** (`WARN could not derive gateway VIP ... DEFERRING` on every sweep), leaving nodes exposed to the exact stale-wildcard defect (#5007/hw241) the pin exists to prevent. The merged #5007 fix was INERT on ELB-direct provs.

**Fix:** the 200-branch splits on `.spec.type` — `LoadBalancer` keeps VIP-or-defer semantics byte-identical; anything else pins `HOST_IP`, matching the 404/absent hostNetwork branch (identical serving shape: envoy binds node:443 either way). Contract **Case 55** locks the split (suite 55/55 green locally); full 4-surface pin lockstep included; pin-sync + lockstep Go tests green.

Refs #5007 #5051

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**RT-11-HOLD: ACTIVE** — held until hw250 cutover reaches cutoverComplete; an operator clears via the `cutover-hold-cleared` label.
