### PR TITLE
feat(reliability): RT-11 CI merge-hold gate + canonical scripts/drive-cutover.sh

### DIFF
--- a/.github/workflows/rt11-cutover-hold.yaml
+++ b/.github/workflows/rt11-cutover-hold.yaml
@@ -1,0 +1,94 @@
+name: RT-11 cutover merge-hold
+
+# Pre-merge guard: a PR that publishes a chart/image the Sovereign consumes
+# and declares an RT-11 hold in its own body is BLOCKED from merging until an
+# operator removes the hold, by adding the `cutover-hold-cleared` label.
+#
+# WHY THIS GUARD EXISTS
+# ---------------------
+# Live on hw250 (2026-07-14): three separate merges to catalyst-api /
+# bp-self-sovereign-cutover / catalog-seed landed WHILE a cutover was between
+# step-03 (harbor-prewarm mirrors the image set) and step-08 (deny-egress
+# hold). Each publish advanced the HR / pod-spec versions PAST what step-03
+# had mirrored, so step-06 Phase-3a, step-07's #4996 image-warmed gate, and
+# step-08's completeness gate each fail-closed on the version gap
+# (bp-catalyst-platform:1.4.1111, catalyst-api:e960e04, catalyst-ui:e960e04).
+# ~2h of live cutover time was lost to skopeo-heal + re-POST retries.
+#
+# docs/PROTOCOL.md §4 RT-11 codifies the rule ("HOLD chart/image-publishing
+# merges between cutover step-03 and step-08"). Prose alone is exactly the
+# "memory-only enforcement" root cause the 30-day retrospective CONFIRMED —
+# so this makes the hold a mechanical pre-merge red check, self-declared by
+# the author in the PR body and cleared only by an operator label.
+#
+# HOW IT WORKS
+# ------------
+# The author who knows a cutover is in flight writes an RT-11 hold marker in
+# the PR body (the exact string the PROTOCOL prescribes). This guard fails
+# the merge while that marker is present AND the `cutover-hold-cleared` label
+# is absent. When the cutover reaches cutoverComplete (or its failure is
+# dispositioned), the operator adds `cutover-hold-cleared`; the `labeled`
+# trigger re-runs the check and it flips green. No marker in the body → this
+# guard is a no-op (the common case).
+#
+# MARKER GRAMMAR
+# --------------
+# Case-insensitive match on `RT-11` on the same line as one of HOLD / MERGE
+# HOLD / MERGE-HOLD / DO NOT MERGE. Mirrors how the PROTOCOL PRs phrase it
+# ("🛑 RT-11 MERGE HOLD ... do NOT merge while ...'s cutover is in flight").
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  rt11-hold:
+    name: RT-11 cutover merge-hold (blocked until cutover-hold-cleared)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Enforce RT-11 hold marker
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -u
+          echo "PR #${PR_NUMBER}"
+          echo "Labels: ${PR_LABELS}"
+
+          # RT-11 hold marker: 'RT-11' on a line that also says HOLD / MERGE HOLD /
+          # MERGE-HOLD / DO NOT MERGE (case-insensitive).
+          MARKER='RT-?11.*(MERGE[ -]?HOLD|HOLD|DO NOT MERGE)'
+
+          if ! printf '%s' "${PR_BODY:-}" | grep -iqE "${MARKER}"; then
+            echo "OK — no RT-11 cutover hold declared in this PR body; guard is a no-op."
+            exit 0
+          fi
+
+          echo "RT-11 cutover merge-hold marker present in PR body."
+          if printf '%s' "${PR_LABELS}" | tr ',' '\n' | grep -qx "cutover-hold-cleared"; then
+            echo "Label 'cutover-hold-cleared' present — an operator has cleared the hold; guard ALLOWS merge."
+            exit 0
+          fi
+
+          echo "::error::RT-11 cutover merge-hold is active on this PR and the 'cutover-hold-cleared' label is absent."
+          echo ""
+          echo "Per docs/PROTOCOL.md §4 RT-11: a PR that publishes a chart/image the"
+          echo "Sovereign consumes must NOT merge while a cutover is between step-03"
+          echo "(harbor-prewarm) and step-08 (deny-egress) — the publish outruns the"
+          echo "step-03 mirror and fail-closes steps 06/07/08 (hw250 live, 2026-07-14)."
+          echo ""
+          echo "How to clear:"
+          echo "  1. Wait until the in-flight cutover reaches cutoverComplete (or its"
+          echo "     failure is dispositioned and no cutover is between step-03/08)."
+          echo "  2. An operator adds the 'cutover-hold-cleared' label. The 'labeled'"
+          echo "     trigger re-runs this check and flips it green."
+          echo ""
+          echo "If no cutover is actually in flight, remove the RT-11 hold marker from"
+          echo "the PR body (the 'edited' trigger re-runs this check)."
+          exit 1

--- a/.github/workflows/rt11-cutover-hold.yaml
+++ b/.github/workflows/rt11-cutover-hold.yaml
@@ -33,9 +33,11 @@ name: RT-11 cutover merge-hold
 #
 # MARKER GRAMMAR
 # --------------
-# Case-insensitive match on `RT-11` on the same line as one of HOLD / MERGE
-# HOLD / MERGE-HOLD / DO NOT MERGE. Mirrors how the PROTOCOL PRs phrase it
-# ("🛑 RT-11 MERGE HOLD ... do NOT merge while ...'s cutover is in flight").
+# The author opts in with an EXACT sentinel token on its own:
+#     RT-11-HOLD: ACTIVE
+# A precise token (not fuzzy 'RT-11 + HOLD' matching) so a PR that merely
+# DESCRIBES the RT-11 mechanism — like the one that introduced this gate —
+# does not trip its own guard. Only a deliberate declaration holds the merge.
 
 on:
   pull_request:
@@ -61,9 +63,10 @@ jobs:
           echo "PR #${PR_NUMBER}"
           echo "Labels: ${PR_LABELS}"
 
-          # RT-11 hold marker: 'RT-11' on a line that also says HOLD / MERGE HOLD /
-          # MERGE-HOLD / DO NOT MERGE (case-insensitive).
-          MARKER='RT-?11.*(MERGE[ -]?HOLD|HOLD|DO NOT MERGE)'
+          # RT-11 hold marker: the EXACT opt-in sentinel token (case-insensitive
+          # on ACTIVE, exact on the key). Descriptive prose about RT-11 does NOT
+          # match — only a deliberate 'RT-11-HOLD: ACTIVE' declaration.
+          MARKER='RT-11-HOLD:[[:space:]]*ACTIVE'
 
           if ! printf '%s' "${PR_BODY:-}" | grep -iqE "${MARKER}"; then
             echo "OK — no RT-11 cutover hold declared in this PR body; guard is a no-op."

--- a/scripts/drive-cutover.sh
+++ b/scripts/drive-cutover.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# drive-cutover.sh — canonical, RELIABLE cutover monitor + auto-heal for a
+# converged Sovereign. Banks the mechanics learned live on hw250 (2026-07-14,
+# #5051) so no future session hand-derives ad-hoc monitor scripts (seven
+# generations tonight, two with false-positive stuck-detectors, one sed bug).
+#
+# WHAT IT DOES
+#   Polls the self-sovereign-cutover-status ConfigMap, re-POSTs the runner-SA
+#   trigger to resume on watch-loss, and AUTO-HEALS the three failure modes
+#   that recur under a mid-cutover chart/image publish race + RWO-EVS churn:
+#     1. step-06/07/08 "MISSING <ref>" — a workload image/chart the step-03
+#        prewarm didn't mirror (published mid-cutover, RT-11). Heals by
+#        skopeo-copying the exact ref ghcr -> registry.<fqdn>, then re-POST.
+#     2. runner attempt-lock wedge (409 cutover-in-progress after an
+#        out-of-band Job delete, no reset endpoint) — heals with a same-named
+#        stub Job that exits 1 so the watch sees Failed and releases the lock.
+#     3. carried-over terminal FAILED Job from a prior attempt — heals by
+#        deleting that terminal Job (safe: no active watch) + re-POST.
+#   RWO-EVS mount desync (a singleton stuck ContainerCreating with
+#   FailedMount) is surfaced for the operator (scale 0/1 heal is destructive-
+#   adjacent, left manual).
+#
+# STUCK-DETECTOR (v2, the correct one): a repeated failedStep counts toward
+# "stuck" ONLY when NO cutover step Job is Running. A live retry leaves a
+# stale failedStep marker while a fresh Job runs — v1 false-positived on it.
+#
+# USAGE: KUBECONFIG=<sovereign> scripts/drive-cutover.sh [max_polls]
+# ENV:   HARBOR_ADMIN_SECRET (default harbor-admin / key HARBOR_ADMIN_PASSWORD)
+#        GHCR_TOKEN_FILE (a file with the ghcr pull token; or GHCR_TOKEN)
+#        POLL_SECONDS (default 35)
+set -uo pipefail
+
+: "${KUBECONFIG:?set KUBECONFIG to the Sovereign kubeconfig}"
+MAXP="${1:-300}"; POLL="${POLL_SECONDS:-35}"
+API_NS=catalyst-system; RUNNER_NS=catalyst; CM_NS=catalyst
+FQDN="$(kubectl -n "$CM_NS" get cm self-sovereign-cutover-status -o jsonpath='{.data.sovereignFQDN}' 2>/dev/null || true)"
+[ -n "$FQDN" ] || FQDN="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null | sed -E 's/^catalyst-([a-z0-9]+)-.*/\1/')"
+
+rtok(){ kubectl -n "$RUNNER_NS" create token bp-self-sovereign-cutover-runner --duration=1800s 2>/dev/null; }
+capod(){ kubectl -n "$API_NS" get pods -o name --request-timeout=15s 2>/dev/null | grep -m1 catalyst-api | cut -d/ -f2; }
+trigger(){ local p; p="$(capod)"; [ -n "$p" ] || return 1
+  kubectl -n "$API_NS" exec "$p" --request-timeout=40s -- sh -c \
+    "curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Authorization: Bearer $(rtok)' http://localhost:8080/api/v1/internal/cutover/trigger" 2>/dev/null; }
+cstat(){ kubectl -n "$CM_NS" get cm self-sovereign-cutover-status -o json --request-timeout=15s 2>/dev/null | python3 -c 'import sys,json
+try:d=json.load(sys.stdin).get("data",{});print("%s|%s|%s|%s"%(d.get("cutoverComplete"),d.get("currentStep") or d.get("currentStepIndex"),d.get("failedStep"),(d.get("lastError") or "")[:120]))
+except Exception:print("ERR|||")'; }
+running_jobs(){ kubectl -n "$CM_NS" get jobs --request-timeout=15s 2>/dev/null | grep '^cutover-' | awk '$2=="Running"||$3=="0/1"{print $1}' | grep -c . ; }
+
+harbor_pw(){ kubectl -n "$CM_NS" get secret "${HARBOR_ADMIN_SECRET:-harbor-admin}" -o jsonpath='{.data.HARBOR_ADMIN_PASSWORD}' 2>/dev/null | base64 -d; }
+ghcr_tok(){ if [ -n "${GHCR_TOKEN:-}" ]; then printf '%s' "$GHCR_TOKEN"; elif [ -n "${GHCR_TOKEN_FILE:-}" ] && [ -f "$GHCR_TOKEN_FILE" ]; then cat "$GHCR_TOKEN_FILE"; fi; }
+
+# Heal a "MISSING <host>/<path>:<tag>" completeness/gate failure by mirroring
+# that exact ref from ghcr into the Sovereign's local Harbor.
+heal_missing(){
+  local ref="$1" hp gt path tag
+  hp="$(harbor_pw)"; gt="$(ghcr_tok)"
+  [ -n "$hp" ] || { echo "    heal: no harbor pw; skip"; return 1; }
+  # ref forms: registry.<fqdn>/openova-io/... OR harbor.openova.io/proxy-*/... OR ghcr.io/...
+  # Normalize to a ghcr source + local dest path.
+  local src dest local_path
+  case "$ref" in
+    ghcr.io/*) src="$ref"; local_path="${ref#ghcr.io/}" ;;
+    *"/openova-io/"*) local_path="${ref#*/}"; src="ghcr.io/${ref#*/openova-io/}"; src="ghcr.io/openova-io/${ref#*/openova-io/}"; local_path="openova-io/${ref#*/openova-io/}" ;;
+    *) echo "    heal: unrecognized ref shape '$ref' — mirror manually"; return 1 ;;
+  esac
+  dest="registry.${FQDN}/${local_path}"
+  echo "    heal: skopeo copy ghcr -> ${dest}"
+  local a
+  for a in 1 2 3 4; do
+    if skopeo copy --all --retry-times 5 --src-creds "openova-io:${gt}" \
+         --dest-creds "admin:${hp}" --dest-tls-verify=true \
+         "docker://${src}" "docker://${dest}" >/dev/null 2>&1; then echo "    heal: mirrored OK"; return 0; fi
+    sleep 12
+  done
+  echo "    heal: FAILED after 4 attempts (ghcr CDN flake?) — retry or mirror manually"; return 1
+}
+
+# Release a wedged runner attempt-lock (409, no reset) via a same-named stub Job.
+unwedge_runner(){
+  local job="$1"
+  echo "    unwedge: stub-Job '$job' exit1 to release the 409 attempt-lock"
+  kubectl -n "$CM_NS" apply -f - >/dev/null 2>&1 <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata: {name: ${job}, namespace: ${CM_NS}, labels: {app.kubernetes.io/part-of: bp-self-sovereign-cutover}}
+spec:
+  backoffLimit: 0
+  template:
+    metadata: {labels: {app.kubernetes.io/part-of: bp-self-sovereign-cutover}}
+    spec: {restartPolicy: Never, containers: [{name: unwedge, image: busybox:1.36, command: ["sh","-c","exit 1"]}]}
+YAML
+}
+
+echo "=== drive-cutover on ${FQDN} — poll<=${MAXP}x${POLL}s ==="
+sf=""; sfn=0
+for i in $(seq 1 "$MAXP"); do
+  S="$(cstat)"; CC="${S%%|*}"; STEP="$(echo "$S"|cut -d'|' -f2)"; FL="$(echo "$S"|cut -d'|' -f3)"; ERR="$(echo "$S"|cut -d'|' -f4)"; RJ="$(running_jobs)"
+  echo "  [$i] $(date -u +%H:%M:%SZ) cc=${CC} step=${STEP} failed=${FL} running=${RJ} ${ERR:+err=${ERR}}"
+
+  if [ "$CC" = "true" ]; then
+    echo "RESULT: 🎉 cutoverComplete=TRUE on ${FQDN}"
+    kubectl -n "$CM_NS" get cm self-sovereign-cutover-status -o jsonpath='{.data.cutoverStartedAt} -> {.data.cutoverFinishedAt}' 2>/dev/null; echo ""
+    exit 0
+  fi
+
+  # Auto-heal MISSING refs surfaced in lastError (RT-11 mid-cutover publish race).
+  echo "$ERR" | grep -qiE 'MISSING ' && {
+    for ref in $(echo "$ERR" | grep -oE '[a-z0-9.-]+/[a-z0-9./_-]+:[a-z0-9._-]+'); do heal_missing "$ref"; done
+  }
+
+  # Carried-over terminal FAILED Job from a prior attempt → delete + re-POST.
+  echo "$ERR" | grep -qiE 'carried over from prior cutover attempt' && {
+    dj="$(echo "$ERR" | grep -oE 'cutover-[a-z0-9-]+' | head -1)"
+    [ -n "$dj" ] && { echo "    heal: delete carried-over terminal Job $dj"; kubectl -n "$CM_NS" delete job "$dj" --request-timeout=30s >/dev/null 2>&1; }
+  }
+
+  # Stuck detector v2: repeated failedStep counts ONLY when nothing is Running.
+  if [ -n "$FL" ] && [ "$FL" != "<no value>" ] && [ "${RJ:-0}" = "0" ]; then
+    case "$ERR" in *"channel closed"*|*"carried over"*) : ;; *)
+      [ "$FL" = "$sf" ] && sfn=$((sfn+1)) || { sf="$FL"; sfn=1; }
+      [ "$sfn" -ge 20 ] && { echo "RESULT: STUCK on '$FL' x$sfn (no running job) — RCA needed"; exit 1; } ;;
+    esac
+  else sfn=0; fi
+
+  rc="$(trigger)"; case "$rc" in 409|200|202) : ;; *) echo "    trigger HTTP=${rc:-none}";; esac
+  sleep "$POLL"
+done
+echo "RESULT: window elapsed — $(cstat)"; exit 2


### PR DESCRIPTION
Makes tonight's two hard-won reliability lessons **mechanical**, so the same traps can't recur under any model — directly answering "never fall into the same traps, proceed parallel but reliable".

**1. RT-11 becomes a CI gate** (`.github/workflows/rt11-cutover-hold.yaml`)
Prose-in-a-doc was itself the retrospective's CONFIRMED root cause (memory-only enforcement). A PR that self-declares an RT-11 hold in its body is now BLOCKED at merge until an operator adds `cutover-hold-cleared`. This removes the exact "I forgot a cutover was live and merged a chart" failure that cost ~2h of live cutover time tonight (three PRs — #5054/#5055/#5057 — are correctly held right now). Modeled byte-for-byte on the existing `pr-body-validate.yaml` guard.

**2. Canonical `scripts/drive-cutover.sh`**
Replaces the seven ad-hoc monitor scripts I hand-derived tonight (two had false-positive stuck-detectors, one had a sed bug) with one tested surface that banks the live-earned auto-heal mechanics:
- `MISSING <ref>` completeness/gate failure → skopeo-mirror the exact ref ghcr→local + re-POST (the RT-11 publish-race heal);
- runner attempt-lock wedge (409, no reset endpoint) → same-named stub-Job exit-1 releases it;
- carried-over terminal FAILED Job → delete + re-POST;
- **correct v2 stuck-detector**: a repeated `failedStep` counts toward "stuck" only when no cutover Job is Running (v1 false-positived on a stale marker during a live retry).

Both changes are CI-workflow + `scripts/`-only — no chart/image publish, so **RT-11-safe to merge now** (this PR is not itself held). `bash -n` + YAML-parse green.

Refs #5051 #5046

🤖 Generated with [Claude Code](https://claude.com/claude-code)