### PR TITLE
fix(cutover): step-08 excludes oauth2-proxy sidecars from forced roll (#5059)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -856,7 +856,11 @@ spec:
       # flow. skopeo dest reverts to HARBOR_PUBLIC_URL (registry.<fqdn>) with a
       # bounded 40x15s readiness probe covering the #5037 pre-pivot DNS flake;
       # Harbor REST API dials stay on HARBOR_INTERNAL_URL. Cases 52/54 amended.
-      version: 0.1.128
+      # 0.1.130 (#5059): step-08 excludes oauth2-proxy sidecars from the forced
+      # fresh-pull roll — their blocking OIDC discovery to the public issuer
+      # CrashLoops under the hold and blows the 600s roll budget, restarting the
+      # whole sweep (hw250 looped ~5x/3h). Durable OIDC-hairpin fix in #5059.
+      version: 0.1.130
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.128
+  version: 0.1.130
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2024,7 +2024,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.128
+version: 0.1.130
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1960,7 +1960,7 @@ echo "[cutover-contract] Case 49: Step-08 roll-set NEVER includes the registry-p
 # fresh pulls are being proven on that node, and its readiness gate
 # (first-reconcile-pass) was already asserted by the step-04
 # daemonset-wait + per-node v2 ACKs.
-if ! grep -A1 'name: FRESH_PULL_EXCLUDE_WORKLOADS' "$TMP/render.yaml" | grep -q 'value: "catalyst/registry-pivot"'; then
+if ! grep -A1 'name: FRESH_PULL_EXCLUDE_WORKLOADS' "$TMP/render.yaml" | grep -qE 'value: "[^"]*\bcatalyst/registry-pivot\b'; then
   echo "FAIL: FRESH_PULL_EXCLUDE_WORKLOADS default must carry catalyst/registry-pivot (#5022)" >&2
   exit 1
 fi
@@ -2243,5 +2243,18 @@ if ! grep -qF 'never became ready after 40 probes' "$TMP/s03.yaml"; then
   exit 1
 fi
 echo "  PASS (#5051 contract: skopeo dest is the public host; readiness probe bounded + fail-loud; in-cluster dest derivation gone)"
+
+# ── Case 56 (#5059): step-08 excludes oauth2-proxy sidecars from the roll ─────
+# oauth2-proxy does a blocking OIDC discovery to the PUBLIC issuer at boot; under
+# the deny-egress hold that hairpin intermittently exceeds its 30s timeout ->
+# CrashLoop -> a freshly-rolled pod blows step-08's 600s roll budget -> the whole
+# sweep restarts (hw250 looped ~5x/3h). Rolling it proves nothing about mirror
+# completeness (image already pulled + HEAD'd), so it is excluded by ns/name.
+echo "[cutover-contract] Case 56: step-08 excludes oauth2-proxy from the forced roll (#5059)"
+if ! grep -A1 'name: FRESH_PULL_EXCLUDE_WORKLOADS' "$TMP/render.yaml" | grep -qE 'value: "[^"]*oauth2-proxy'; then
+  echo "FAIL: FRESH_PULL_EXCLUDE_WORKLOADS must exclude the oauth2-proxy sidecar — its OIDC-discovery CrashLoop blows the roll budget and restarts the sweep (#5059)" >&2
+  exit 1
+fi
+echo "  PASS (#5059 contract: oauth2-proxy sidecar excluded from the step-08 forced-roll set)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1200,6 +1200,28 @@ egressTest:
     # proven by the step-04 daemonset-wait + per-node v2 ACK assertions.
     excludeWorkloads:
       - "catalyst/registry-pivot"
+      # #5059 — oauth2-proxy sidecars do a BLOCKING OIDC discovery against the
+      # PUBLIC issuer (auth.<fqdn>) at boot; under the hold that hairpin (pod ->
+      # gateway EIP -> keycloak) intermittently exceeds oauth2-proxy's 30s
+      # discovery timeout -> CrashLoopBackOff -> a freshly-rolled pod misses the
+      # 600s roll budget -> step-08 FAILS and restarts the WHOLE sweep (hw250
+      # looped ~5x/3h on this). A fresh-pull-roll of an oauth2-proxy proves
+      # NOTHING about offline-mirror completeness (its image already pulled +
+      # was completeness-HEAD'd); rolling it only re-triggers the slow OIDC
+      # boot. Exclude the known instances (the durable in-cluster-discovery
+      # fix for the OIDC hairpin is tracked separately in #5059).
+      - "kube-system/hubble-ui-oauth2-proxy"
+      # #5059 — oauth2-proxy sidecars do a BLOCKING OIDC discovery against the
+      # PUBLIC issuer (auth.<fqdn>) at boot; under the hold that hairpin (pod →
+      # gateway EIP → keycloak) intermittently exceeds oauth2-proxy's 30s
+      # discovery timeout → CrashLoopBackOff → a freshly-rolled pod misses the
+      # 600s roll budget → step-08 FAILS and restarts the WHOLE sweep (hw250
+      # looped ~5x/3h on this). A fresh-pull-roll of an oauth2-proxy proves
+      # NOTHING about offline-mirror completeness (its image already pulled +
+      # was completeness-HEAD'd); rolling it only re-triggers the slow OIDC
+      # boot. Exclude the known instances (the durable in-cluster-discovery
+      # fix for the OIDC hairpin is tracked separately in #5059).
+      - "kube-system/hubble-ui-oauth2-proxy"
   # #5026 — PRE-HOLD ref-host lint (treadmill-breaker). The completeness gate
   # above proves image CONTENT is in local Harbor; this lint proves every
   # rolled workload's pod-spec image REF HOST is the local registry

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.128"
+  version: "0.1.130"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.128"
+    version: "0.1.130"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
**This is the fix the LIVE hw250 cutover is currently looping on** — see #5059 for full RCA. Step-08 has restarted its ~130-workload sweep ~5 times over 3 hours because the forced fresh-pull roll bounces `hubble-ui-oauth2-proxy`, whose blocking OIDC discovery to the public issuer CrashLoops under the deny-egress hold and blows the 600s roll budget.

**Fix**: add `kube-system/hubble-ui-oauth2-proxy` to `FRESH_PULL_EXCLUDE_WORKLOADS` (the existing #5022 ns/name roll-exclusion seam). Rolling an oauth2-proxy proves nothing about offline-mirror completeness — its image already pulled and was completeness-HEAD'd. Chart 0.1.130, full 4-surface lockstep. Contract Case 49 generalized to a contains-check; Case 56 locks the exclusion; suite 56/56 green. Durable OIDC-hairpin fix (in-cluster discovery) tracked in #5059.

**🛑 MERGE-TIMING DECISION (operator/next-session):** unlike the other RT-11-held PRs, this one *unblocks* the wedged in-flight cutover — the RT-11 "don't publish past a healthy mirror" rationale is inverted here (the cutover can't progress at all). Two paths: **(a)** let the current sweep keep coin-flipping (it may hit a cycle where the oauth2-proxy roll clears discovery in time); **(b)** disposition the loop as blocked-on-#5059, merge+publish 0.1.130, let hw250's HR upgrade, delete the stale step-08 job + re-POST → the fixed step-08 excludes oauth2-proxy and completes. Recommend (b) if the loop persists past ~2 more cycles. Left as an explicit decision rather than a hasty mid-loop republish.

RT-11-HOLD: ACTIVE

Refs #5059 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)