### PR TITLE
fix(harbor): alias host 301-redirects to canonical instead of co-serving (#5015)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -226,7 +226,7 @@ spec:
       #   DNS/cert change. externalURL + OIDC redirect_uri stay on registry.<fqdn>.
       # 1.2.42: updateStrategy Recreate — single-replica RWO jobservice
       # deadlocked cutover step-08's forced roll on Multi-Attach (#5022).
-      version: 1.2.42
+      version: 1.2.43
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.42  # lockstep with chart/Chart.yaml (#5022 updateStrategy Recreate — jobservice RWO single-replica roll deadlock)
+  version: 1.2.43  # lockstep with chart/Chart.yaml (#5022 updateStrategy Recreate — jobservice RWO single-replica roll deadlock)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -170,7 +170,7 @@ type: application
 #   sign-in->/c/oidc/login redirect keeps its canonical hostname), so entry via
 #   harbor.<fqdn> lands on the canonical host with no loop. Also adds
 #   gateway.extraHosts (arbitrary aliases) + tests/httproute-render.sh Case 6.
-version: 1.2.42
+version: 1.2.43
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/httproute.yaml
+++ b/platform/harbor/chart/templates/httproute.yaml
@@ -53,9 +53,13 @@ self-links on registry.<fqdn>, so an entry via harbor.<fqdn> lands on the
 canonical host after login (no redirect loop). Disable via
 gateway.aliasHarborHost=false; add arbitrary aliases via gateway.extraHosts.
 */}}
-{{- if and .Values.gateway.aliasHarborHost (hasPrefix "registry." .Values.gateway.host) }}
-    - {{ printf "harbor.%s" (trimPrefix "registry." .Values.gateway.host) | quote }}
-{{- end }}
+{{- /* #5015: harbor.<fqdn> is NO LONGER co-served on this route. Co-serving
+   started the OIDC flow on the alias origin (state/nonce cookie set on
+   harbor.<fqdn>) but Harbor's redirect_uri/externalURL is registry.<fqdn>, so
+   the callback landed cross-host with no state cookie → HTTP 400 (hw242 live).
+   When gateway.aliasHarborHost is true, a SEPARATE redirect-only HTTPRoute
+   below 301s harbor.<fqdn>/* → registry.<fqdn>/* so the ENTIRE flow is
+   single-origin — keeping #4913's no-bare-404 discoverability. */}}
 {{- range $h := .Values.gateway.extraHosts }}
 {{- if and $h (ne $h $.Values.gateway.host) }}
     - {{ $h | quote }}
@@ -128,5 +132,36 @@ port (e.g. 30443) into Location, which nothing serves externally (the
       backendRefs:
         - name: {{ .Values.gateway.backendService | default (printf "%s-core" (ternary .Release.Name (printf "%s-harbor" .Release.Name) (contains "harbor" .Release.Name))) | quote }}
           port: {{ .Values.gateway.backendPort | default 80 }}
+{{- end }}
+---
+{{- /* #5015 — dedicated redirect-only HTTPRoute: harbor.<fqdn> → 301 →
+   registry.<fqdn>, path preserved. Fires BEFORE any OIDC flow starts, so the
+   whole auth flow is single-origin on the canonical host (no cross-host state
+   cookie 400). Only when aliasHarborHost=true AND gateway.host is a registry.*
+   host (so the harbor.* alias is derivable). Set aliasHarborHost=false to serve
+   ONLY gateway.host with no alias at all. */}}
+{{- if and .Values.gateway.host .Values.gateway.aliasHarborHost (hasPrefix "registry." .Values.gateway.host) }}
+{{- $aliasHost := printf "harbor.%s" (trimPrefix "registry." .Values.gateway.host) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "bp-harbor.fullname" . }}-alias-redirect
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.gateway.name | default "cilium-gateway" }}
+      namespace: {{ .Values.gateway.namespace | default "kube-system" }}
+      sectionName: {{ .Values.gateway.sectionName | default "https" | quote }}
+  hostnames:
+    - {{ $aliasHost | quote }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: {{ .Values.gateway.host | quote }}
+            port: 443
+            statusCode: 301
 {{- end }}
 {{- end }}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3306,7 +3306,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.42"
+  version: "1.2.43"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3330,7 +3330,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.42"
+    version: "1.2.43"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
**Defect** (hw242 live SSO walk, browser evidence on #5015): entering `harbor.<fqdn>` mid-login → OIDC state/nonce cookie set on the alias origin, but Harbor's `redirect_uri`/`externalURL` is the canonical `registry.<fqdn>`, so the callback lands cross-host with no state cookie → **HTTP 400**. Root cause: #4913 added `harbor.<fqdn>` as a co-serving second hostname on the main HTTPRoute (to kill a bare-envoy 404), which inadvertently made the alias a login-initiating origin.

**Fix**: replace the co-serve hostname with a **dedicated redirect-only HTTPRoute** — `harbor.<fqdn>/*` → **301** → `registry.<fqdn>` (path preserved), firing before any OIDC flow starts, so the whole auth flow is single-origin. Keeps #4913's discoverability goal (no bare 404); `gateway.host` stays canonical; `aliasHarborHost=false` still serves only the canonical host.

**Verified deterministically (no live env needed for correctness)**: `helm template` shows the main route's hostnames are now `[registry.<fqdn>]` only, and a new `harbor-alias-redirect` HTTPRoute does the 301. Chart 1.2.43 + full 4-surface lockstep; pin-sync + lockstep Go tests green. Live SSO-landing walk (UAT row per #5015) queued for the hw250 post-cutover sweep.

RT-11-HOLD: ACTIVE

Refs #5015 #4913 #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)