### PR TITLE
fix(cutover): exempt falco from Kyverno resource-requests Enforce + raise trivy-operator memory (step-08 wedge)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -154,7 +154,7 @@ spec:
       # mixed-source pods (proxy-cache sidecars + openova-io plugin) —
       # un-wedges huawei-evs-csi + its 24-HR dependency cascade (#5017,
       # #4973 family).
-      version: 1.0.46
+      version: 1.0.47
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/clusters/_template/bootstrap-kit/30-trivy.yaml
+++ b/clusters/_template/bootstrap-kit/30-trivy.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-trivy
-      version: 1.0.3
+      version: 1.0.4
       sourceRef:
         kind: HelmRepository
         name: bp-trivy

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.46
+  version: 1.0.47
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -310,7 +310,7 @@ type: application
 #   (helm.sh/hook annotation) — hooks get no Flux labels + Helm force-stamps
 #   managed-by:Helm, so a legit hook Job (bp-powerdns zone-bootstrap) was
 #   Enforce-denied on live upgrade, stranding the powerdns anycast NodePort.
-version: 1.0.46
+version: 1.0.47
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -135,6 +135,17 @@ compliancePolicies:
       # per-workload annotation. Code-reviewer agent surfaced this gap
       # 2026-06-01T13:35Z (G109 review verdict PASS-with-caveats).
       - sso-bridge
+      # falco (#5063, hw250 2026-07-14): host-eBPF runtime-security DaemonSet.
+      # Its falcoctl sidecars carry no resources.requests and the main container
+      # legitimately needs host root + a writable rootfs (kernel/eBPF access), so
+      # it CANNOT satisfy resource-requests / runAsNonRoot / readOnlyRootFilesystem.
+      # Original pods admit at prov time, but the self-sovereign-cutover deny-egress
+      # fresh-pull proof ROLLS the DaemonSet → the recycled pod is DENIED by the
+      # resource-requests Enforce policy → DS stuck 5/6 → egress-block-test FAIL
+      # (step-08 wedged, exactly the #4640 dragonfly shape one tier up). A node
+      # replacement / region-kill hits the identical block → general robustness,
+      # not cutover-only. Same privileged trust tier as cilium/dragonfly: exempt.
+      - falco
 
   pdb:
     enabled: true

--- a/platform/trivy/blueprint.yaml
+++ b/platform/trivy/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.3
+  version: 1.0.4
   card:
     title: Trivy
     family: guardian

--- a/platform/trivy/chart/Chart.yaml
+++ b/platform/trivy/chart/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   secrets, infra assessments. Target namespaces follow the `bp-*` prefix
   convention so scan results align with Blueprint installation units.
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "0.30.1"
 keywords: [catalyst, blueprint, trivy, security, scanner, vulnerability]
 maintainers:

--- a/platform/trivy/chart/values.yaml
+++ b/platform/trivy/chart/values.yaml
@@ -108,14 +108,19 @@ trivy-operator:
   # Resources for the operator pod itself.
   # 256Mi was too tight — operator manages scan jobs across 80+ pods and
   # each watch cache grows with cluster size. OOMKilled (exit 137) on otech22.
-  # 512Mi is the stable floor for a 38-HR Sovereign per handover testing.
+  # 512Mi held for a 38-HR Sovereign, but OOMKilled again (exit 137, restarts=10)
+  # on the larger hw250 2-region prov (#5063): under the self-sovereign-cutover
+  # deny-egress fresh-pull roll the recreated operator never reached Ready within
+  # the 600s budget → step-08 egress-block-test FAIL. 1Gi is the stable floor for
+  # a 60+ HR multi-region Sovereign; a node replacement / region-kill hits the
+  # same recreate, so this is general robustness, not cutover-only.
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi
 
   # ServiceMonitor — DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2
   # (Catalyst provides bp-grafana / kube-prometheus-stack separately).

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4608,7 +4608,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-kyverno-policies
-    version: "1.0.46"
+    version: "1.0.47"
   topology:
     supported:
       - singleton
@@ -5272,7 +5272,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-trivy
-    version: "1.0.3"
+    version: "1.0.4"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (found LIVE on hw250, sovereignty-cutover step-08)
The deny-egress fresh-pull proof rolls every DaemonSet/Deployment. Two Day-2 security-tier workloads fail the roll for **non-image** reasons → step-08 `egress-block-test` DeadlineExceeded → cutover parked at 63%:

1. **falco** (host-eBPF runtime security DaemonSet) — the recycled pod is DENIED at admission by the `resource-requests` **Enforce** policy (falcoctl sidecars declare no `resources.requests`; the main container needs host root + writable rootfs so it also can't meet runAsNonRoot/readOnlyRootFilesystem). Original pods admit at prov time, but **any** recreate — cutover roll, node replacement, region-kill — is blocked → DS stuck 5/6. `falco` was missing from the `complianceDefaultExcludes` anchor that already exempts cilium/dragonfly/cert-manager. Identical shape to #4640 (dragonfly, one tier up).
2. **trivy-operator** — chronic OOMKilled/137 (restarts=10) at 512Mi on the larger 2-region cluster → never Ready within the 600s roll budget.

## Fix (durable)
- `bp-kyverno-policies`: add `falco` to the shared `complianceDefaultExcludes` anchor. Verified via `helm template`: falco now excluded in all 3 resource-requests rules.
- `bp-trivy`: raise operator limit 512Mi→1Gi, requests 128Mi→256Mi.
- Chart + blueprint + bootstrap-kit pins bumped in lockstep (bp-kyverno-policies 1.0.47, bp-trivy 1.0.4). `helm lint` clean.

## Live-heal parity
hw250 was live-healed (HRs suspended: added falco+trivy-system to the enforce ClusterPolicy exclusions, bumped trivy to 1Gi). Post-heal: falco rolls 6/6 (falcoctl pulls rules from local Harbor OK), trivy stable at 1Gi. Cutover re-triggered — step-08 re-running clean. This PR makes the heal durable so the post-cutover HR un-suspend + every fresh prov carries it.

RT-11-HOLD: ACTIVE

Refs #5063