### PR TITLE
fix(cutover): step-08 egress deadline 3600→7200 + exclude falco's slow rules-pull roll (DeadlineExceeded ×2 on hw250)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -856,7 +856,7 @@ spec:
       # flow. skopeo dest reverts to HARBOR_PUBLIC_URL (registry.<fqdn>) with a
       # bounded 40x15s readiness probe covering the #5037 pre-pivot DNS flake;
       # Harbor REST API dials stay on HARBOR_INTERNAL_URL. Cases 52/54 amended.
-      version: 0.1.128
+      version: 0.1.131
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.128
+  version: 0.1.131
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2024,7 +2024,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.128
+version: 0.1.131
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1200,6 +1200,14 @@ egressTest:
     # proven by the step-04 daemonset-wait + per-node v2 ACK assertions.
     excludeWorkloads:
       - "catalyst/registry-pivot"
+      # falco/falco (#5065, live hw250): the falcoctl-artifact-install init pulls
+      # the rules OCI artifact per-pod, so a 6-node DaemonSet roll takes ~9min
+      # under deny-egress — it blows the step deadline for ZERO added sovereignty
+      # (the completeness HEAD gate + ref-host lint already prove falco's image is
+      # in local Harbor). Skip the synthetic roll; #5063 keeps falco genuinely
+      # recreatable (Kyverno resource-requests exempt) for real node-replace /
+      # region-kill. Same class as kube-system/hubble-ui-oauth2-proxy (#5059).
+      - "falco/falco"
   # #5026 — PRE-HOLD ref-host lint (treadmill-breaker). The completeness gate
   # above proves image CONTENT is in local Harbor; this lint proves every
   # rolled workload's pod-spec image REF HOST is the local registry
@@ -1554,7 +1562,12 @@ stepTimeouts:
   # DeadlineExceeded at exactly +1200s mid-proof (NOT an egress failure)
   # and the engine looped 20-minute failures. 3600s gives the proof room;
   # the deny-egress window itself stays 600s.
-  egressBlockTestSeconds: 3600
+  # #5065 (2026-07-14, live hw250): 3600s ALSO too short on a larger 2-region
+  # prov — full ~130-workload roll (~45min) + 600s hold + one engine sweep-
+  # restart > 60min → DeadlineExceeded ×2 (NOT an egress failure). 7200s covers
+  # roll+hold+one restart; paired with the falco excludeWorkloads entry (its
+  # per-pod falcoctl rules-pull roll alone ate ~9min).
+  egressBlockTestSeconds: 7200
   # Step 09 (gitea-token-mint, TBD-C18) — short-lived: a single
   # Gitea API mint + validate + Secret patch + best-effort rollout.
   # 600s leaves generous headroom for the provisioning Deployment

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.128"
+    version: "0.1.131"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (LIVE hw250, step-08)
After healing the falco Kyverno block + trivy OOM (#5063), step-08 (egress-block-test) still failed **twice** with `DeadlineExceeded` — **not** an egress/workload failure (0 FAILs). The engine restarted its sweep at ~43min, and the 3600s deadline was hit before the restarted roll + 600s hold finished.

**Roots:**
1. **3600s too short** for a large 2-region cluster: full ~130-workload rolling fresh-pull (~45min) + 600s hold + one sweep-restart > 60min. (Already bumped 1200→3600 once in #4723 — recurs bigger.)
2. **falco roll is ~9min** — falcoctl-artifact-install pulls the rules OCI artifact per-pod across 6 nodes, for ZERO added sovereignty (the pre-hold completeness HEAD gate + ref-host lint already prove its image is in local Harbor).

## Fix
- `stepTimeouts.egressBlockTestSeconds` 3600 → **7200** (full roll + hold + one restart).
- `excludeWorkloads` += `falco/falco` — skip the synthetic 9-min roll; #5063 keeps falco genuinely recreatable (Kyverno exempt) for real node-replace/region-kill. Same class as `kube-system/hubble-ui-oauth2-proxy` (#5059).
- chart+blueprint+bootstrap-kit+catalog-seed lockstep → **0.1.131**. helm lint + drift test green.

## Context — 4th step-08 defect this cycle (the #5046 treadmill)
oauth2-proxy hairpin (#5059) → falco Kyverno block (#5063) → trivy OOM (#5063) → **deadline/falco-roll (this)**. Each surfaced only after the prior was healed on hw250 — the one-defect-per-prov treadmill the retrospective named the #1 root cause. **Merge-order:** touches `excludeWorkloads`, which #5060 (oauth2-proxy) also edits — serialize/rebase the two at merge. Path to green: consolidate-merge all 4 step-08 fixes + a **clean re-prov** on the hardened train (not more hand-healing on the now-dirty hw250).

RT-11-HOLD: ACTIVE

Refs #5065