### PR TITLE
fix(cutover): consolidate step-08 hardening (oauth2-proxy+falco exclude + deadline 7200) → 0.1.131

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -861,7 +861,7 @@ spec:
       # as ClusterIP (no VIP ever), so the pin deferred FOREVER on every
       # ELB-direct prov (hw250 all night); ClusterIP now pins HOST_IP like the
       # absent-Service hostNetwork branch. LoadBalancer semantics unchanged.
-      version: 0.1.129
+      version: 0.1.131
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.129
+  version: 0.1.131
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2024,7 +2024,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.129
+version: 0.1.131
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1200,6 +1200,21 @@ egressTest:
     # proven by the step-04 daemonset-wait + per-node v2 ACK assertions.
     excludeWorkloads:
       - "catalyst/registry-pivot"
+      # kube-system/hubble-ui-oauth2-proxy (#5059): oauth2-proxy does a BLOCKING
+      # OIDC discovery to the PUBLIC issuer at boot; under the deny-egress hold
+      # that hairpin (pod→gateway EIP→keycloak) intermittently exceeds its 30s
+      # timeout → CrashLoop → a freshly-rolled pod blows the roll budget → the
+      # whole sweep restarts (hw250 looped ~5x/3h). Rolling it proves nothing
+      # about mirror completeness (image already HEAD'd); exclude it by ns/name.
+      - "kube-system/hubble-ui-oauth2-proxy"
+      # falco/falco (#5065): the falcoctl-artifact-install init pulls the rules
+      # OCI artifact per-pod, so a 6-node DaemonSet roll takes ~9min under
+      # deny-egress — it blows the step deadline for ZERO added sovereignty (the
+      # completeness HEAD gate + ref-host lint already prove falco's image is in
+      # local Harbor). Skip the synthetic roll; #5063 keeps falco genuinely
+      # recreatable (Kyverno resource-requests exempt) for real node-replace /
+      # region-kill.
+      - "falco/falco"
   # #5026 — PRE-HOLD ref-host lint (treadmill-breaker). The completeness gate
   # above proves image CONTENT is in local Harbor; this lint proves every
   # rolled workload's pod-spec image REF HOST is the local registry
@@ -1554,7 +1569,11 @@ stepTimeouts:
   # DeadlineExceeded at exactly +1200s mid-proof (NOT an egress failure)
   # and the engine looped 20-minute failures. 3600s gives the proof room;
   # the deny-egress window itself stays 600s.
-  egressBlockTestSeconds: 3600
+  # #5065 (2026-07-14, live hw250): 3600s ALSO too short on a larger 2-region
+  # prov — full ~130-workload roll (~45min) + 600s hold + one engine sweep-
+  # restart > 60min → DeadlineExceeded ×2 (NOT an egress failure). 7200s covers
+  # roll+hold+one restart; paired with the oauth2-proxy + falco excludeWorkloads.
+  egressBlockTestSeconds: 7200
   # Step 09 (gitea-token-mint, TBD-C18) — short-lived: a single
   # Gitea API mint + validate + Secret patch + best-effort rollout.
   # 600s leaves generous headroom for the provisioning Deployment

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.129"
+    version: "0.1.131"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Consolidates **#5060** (#5059 oauth2-proxy exclude) + **#5066** (#5065 falco exclude + deadline) into one cutover-chart bump, avoiding a 3-way version collision with the already-merged #5055 (0.1.129).

## Step-08 hardening (the last 2 of the 4-defect chain)
- `excludeWorkloads` += `kube-system/hubble-ui-oauth2-proxy` (blocking OIDC-discovery hairpin blows the roll budget → sweep restart) + `falco/falco` (~9min per-pod rules-pull roll for zero added sovereignty — image already HEAD-proven local). Both stay genuinely recreatable via #5062 / #5063/#5064.
- `stepTimeouts.egressBlockTestSeconds` 3600 → **7200** (full ~130-workload roll + 600s hold + one sweep-restart > 60min → DeadlineExceeded ×2 on hw250).
- chart+blueprint+bootstrap-kit+catalog-seed lockstep → **0.1.131**.

Renders verified (all 3 excludes + `activeDeadlineSeconds: 7200`); helm lint + catalog-seed drift green. **Supersedes #5060 + #5066.**

RT-11-HOLD: ACTIVE

Refs #5059 #5065