### PR TITLE
fix(cloud-init): force IPv4 on Huawei log-self-upload → mid-run bootstrap deaths become diagnosable (#5042)

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -977,8 +977,14 @@ locals {
       if [ -n "${var.deployment_id}" ] && [ -n "${var.kubeconfig_bearer_token}" ] && [ -n "${var.catalyst_api_url}" ]; then
         nohup sh -c '
           n=0
-          while [ "$${n}" -lt 40 ]; do
-            curl -sk -X PUT \
+          # #5042: -4 forces IPv4. This loop runs in the prelude BEFORE the
+          # IPv4-pin step, so on the IPv4-only kom4dc VPC curl otherwise resolves
+          # catalyst_api_url to AAAA, tries IPv6 first -> "network unreachable" ->
+          # every push fails silently (|| true) -> a mid-run cloud-init death is
+          # forensic-blind (hw247 GET cloudinit-log 404). 60 iters (~50min) covers
+          # a slow 2-region bootstrap.
+          while [ "$${n}" -lt 60 ]; do
+            curl -4 -sk -X PUT \
               -H "Authorization: Bearer ${var.kubeconfig_bearer_token}" \
               -H "Content-Type: text/plain" \
               --data-binary @/var/log/cloud-init-output.log \


### PR DESCRIPTION
## Root cause (located live on hw247, #5042)
Fresh-prov bootstrap can die mid-cloud-init with **zero forensic surface** on kom4dc (no ECS console-output API, no sshd → `/var/log/cloud-init-output.log` can only be PUSHED). The console-less log self-upload loop runs in the `provider_prelude` **before** the IPv4-pin step, so on the IPv4-only kom4dc VPC `curl` resolves `catalyst_api_url` to an **AAAA** record, tries IPv6 first → `network unreachable` → every PUT fails silently (`|| true`) → `GET /deployments/{id}/cloudinit-log` returns **404** (the exact hw247 wedge). hetzner is unaffected (dual-stack).

## Fix
- `curl -4` — force IPv4 so the forensic push works before DNS is pinned.
- loop `40 → 60` iters (~50min) to cover a slow 2-region bootstrap.

dash -n + tofu fmt clean. Directly de-risks the diagnosability of every future kom4dc prov — including the imminent hardened-train re-prov (so a Phase-1 wedge is no longer forensic-blind).

Refs #5042