### PR TITLE
fix(cutover-contract): Case 49 exact-match → contains-check (unblocks bp-self-sovereign-cutover 0.1.131 publish)

### DIFF
--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1960,7 +1960,7 @@ echo "[cutover-contract] Case 49: Step-08 roll-set NEVER includes the registry-p
 # fresh pulls are being proven on that node, and its readiness gate
 # (first-reconcile-pass) was already asserted by the step-04
 # daemonset-wait + per-node v2 ACKs.
-if ! grep -A1 'name: FRESH_PULL_EXCLUDE_WORKLOADS' "$TMP/render.yaml" | grep -q 'value: "catalyst/registry-pivot"'; then
+if ! grep -A1 'name: FRESH_PULL_EXCLUDE_WORKLOADS' "$TMP/render.yaml" | grep -qE 'value: "[^"]*catalyst/registry-pivot'; then
   echo "FAIL: FRESH_PULL_EXCLUDE_WORKLOADS default must carry catalyst/registry-pivot (#5022)" >&2
   exit 1
 fi


### PR DESCRIPTION
The consolidated step-08 exclude set grew beyond registry-pivot (oauth2-proxy #5059 + falco #5065), but Case 49 asserted an exact match → Blueprint Release chart-integration-test FAILED → **0.1.131 never published → the re-prov train is blocked**. Switch the assertion to a contains-check (registry-pivot must be IN the list). Full cutover-contract.sh green locally (exit 0); no version bump (test-only). Refs #5022