### PR TITLE
fix(bootstrap): flux-crds-absent Phase-1 terminal state (Refs #5042)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -223,6 +223,20 @@ type Handler struct {
 	kubeconfigArrivalTimeout      time.Duration
 	kubeconfigArrivalPollInterval time.Duration
 
+	// fluxCRDProbeBudget / fluxCRDProbePollInterval — runtime knobs for
+	// the bounded Flux-CRD-presence probe runPhase1Watch runs AFTER the
+	// kubeconfig lands and BEFORE the helmwatch informer is built (#5042).
+	// The probe classifies OutcomeFluxCRDsAbsent when the new Sovereign is
+	// healthy (kubeconfig PUT, CNI up) but cloud-init's flux-install stage
+	// never installed the helmreleases.helm.toolkit.fluxcd.io CRD — so the
+	// deployment fails fast with an actionable diagnostic instead of idling
+	// "phase1-watching" to the 120m WatchTimeout. Zero falls back to the
+	// env var → DefaultFluxCRDProbeBudget / DefaultFluxCRDProbePollInterval.
+	// Tests inject tiny values (e.g. 200ms / 50ms) plus a fake dynamic
+	// client so the probe path is exercised in milliseconds.
+	fluxCRDProbeBudget       time.Duration
+	fluxCRDProbePollInterval time.Duration
+
 	// phase1StorageGate — test-only override for the #3971 default-
 	// StorageClass durability gate run at the end of markPhase1Done.
 	// Production uses helmwatch.DefaultStorageClassFromKubeconfig

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -40,6 +40,8 @@ import (
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -133,6 +135,45 @@ const DefaultKubeconfigArrivalTimeout = 15 * time.Minute
 // DefaultKubeconfigArrivalPollInterval — production default for the
 // kubeconfig-arrival poll cadence. Issue #538.
 const DefaultKubeconfigArrivalPollInterval = 15 * time.Second
+
+// fluxCRDProbeBudgetEnv — env var override for the overall budget of
+// the bounded Flux-CRD-presence probe (#5042). AFTER the kubeconfig
+// lands and BEFORE the helmwatch informer is built, runPhase1Watch
+// probes whether the Flux HelmRelease CRD
+// (helmreleases.helm.toolkit.fluxcd.io) is servable on the new
+// Sovereign. On an intermittent bootstrap wedge the cluster is
+// HEALTHY (nodes Ready, CNI up, kubeconfig PUT) but cloud-init's
+// flux-install stage never landed, so the CRD is ABSENT — without this
+// probe the deployment idles "phase1-watching" for the full
+// WatchTimeout (120m) with no fast, named diagnostic. The probe polls
+// until the CRD becomes servable (→ proceed to the watcher) or the
+// budget elapses with the CRD still positively absent (→
+// OutcomeFluxCRDsAbsent, a fast actionable failure). Per
+// docs/INVIOLABLE-PRINCIPLES.md #4 this is runtime-configurable; tests
+// inject a sub-second value via Handler.fluxCRDProbeBudget.
+const fluxCRDProbeBudgetEnv = "CATALYST_PHASE1_FLUX_CRD_PROBE_BUDGET"
+
+// fluxCRDProbePollIntervalEnv — env var override for the cadence at
+// which the Flux-CRD-presence probe re-checks the CRD (#5042). 15s
+// keeps the wizard log pane responsive without hammering the new
+// Sovereign's apiserver. Tests inject a sub-second value via
+// Handler.fluxCRDProbePollInterval.
+const fluxCRDProbePollIntervalEnv = "CATALYST_PHASE1_FLUX_CRD_PROBE_POLL_INTERVAL"
+
+// DefaultFluxCRDProbeBudget — production default for the Flux-CRD-
+// presence probe budget (#5042). 5 minutes is generous headroom: on a
+// HEALTHY prov the flux-install manifest lands seconds after the k3s
+// apiserver is up (well before the kubeconfig is even PUT back), so a
+// CRD still absent 5 minutes after the kubeconfig arrives is a
+// high-confidence signal that cloud-init's flux-install stage failed.
+// The probe is CONSERVATIVE — it only classifies OutcomeFluxCRDsAbsent
+// on a POSITIVE "CRD absent + apiserver answered" observation at
+// budget end, never on a transient probe error (see probeFluxCRDAbsent).
+const DefaultFluxCRDProbeBudget = 5 * time.Minute
+
+// DefaultFluxCRDProbePollInterval — production default for the Flux-
+// CRD-presence probe poll cadence (#5042).
+const DefaultFluxCRDProbePollInterval = 15 * time.Second
 
 // handoverCertWaitTimeoutEnv — env var override for how long the
 // handover auto-fire waits for the new Sovereign's wildcard TLS
@@ -228,6 +269,25 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 		// The warn event was emitted by waitForKubeconfig at the
 		// final tick.
 		h.markPhase1Done(dep, nil, helmwatch.OutcomeKubeconfigMissing)
+		return
+	}
+
+	// #5042 — bounded Flux-CRD-presence probe. On an intermittent
+	// fresh-prov bootstrap wedge the new Sovereign is HEALTHY (kubeconfig
+	// PUT, nodes Ready, CNI up) but cloud-init's flux-install stage never
+	// landed, so the Flux HelmRelease CRD
+	// (helmreleases.helm.toolkit.fluxcd.io) is ABSENT. Without this probe
+	// the helmwatch informer below would attach and simply observe zero
+	// HelmReleases until the 120m WatchTimeout — the deployment idles
+	// "phase1-watching" for hours with no fast, named diagnostic (the
+	// #5042 forensic gap). probeFluxCRDAbsent polls until the CRD becomes
+	// servable (→ proceed to the watcher as normal) or its budget elapses
+	// with the CRD still POSITIVELY absent (→ OutcomeFluxCRDsAbsent, a
+	// fast actionable failure). It is CONSERVATIVE: a transient probe
+	// error (apiserver blip, client-build failure) falls through to the
+	// watcher so a flake never invents a failure.
+	if h.probeFluxCRDAbsent(dep, kubeconfig) {
+		h.markPhase1Done(dep, nil, helmwatch.OutcomeFluxCRDsAbsent)
 		return
 	}
 
@@ -844,6 +904,19 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// flux-system before any retry.
 		dep.Status = "failed"
 		dep.Error = "Phase 1 watch saw zero HelmReleases — the bootstrap-kit Kustomization on the new Sovereign is not reconciling. Operator: inspect `flux get kustomization -n flux-system` and `kubectl describe kustomization -n flux-system` on the new cluster (see docs/RUNBOOK-PROVISIONING.md §\"Phase 1 watch shows 0 HelmReleases\")."
+	case outcome == helmwatch.OutcomeFluxCRDsAbsent:
+		// #5042 — the new Sovereign PUT its kubeconfig and its CNI is
+		// healthy (the pre-flight probe reached the apiserver), but the
+		// Flux HelmRelease CRD (helmreleases.helm.toolkit.fluxcd.io) was
+		// never installed — cloud-init's flux-install stage did not land.
+		// Distinct from OutcomeFluxNotReconciling (CRD present, Flux
+		// installed, but zero HelmReleases reconciled): here Flux itself
+		// is absent, so the corrective action is on cloud-init's install
+		// stage, not the bootstrap-kit Kustomization. Surfaced as a fast,
+		// named failure instead of idling "phase1-watching" to the 120m
+		// WatchTimeout (the #5042 forensic gap).
+		dep.Status = "failed"
+		dep.Error = "Phase 1 could not start: the new Sovereign has its kubeconfig and a healthy CNI, but Flux (helmreleases.helm.toolkit.fluxcd.io CRD) was never installed — cloud-init's flux-install stage did not land. Operator: SSH the control-plane and inspect `/var/log/cloud-init-output.log` for the flux-install step + `ls /var/lib/rancher/k3s/server/manifests/` for the flux manifest (see docs/RUNBOOK-PROVISIONING.md). Refs #5042."
 	case failed > 0:
 		dep.Status = "failed"
 		dep.Error = fmt.Sprintf("Phase 1 finished with %d failed component(s); see ComponentStates for the per-component breakdown", failed)
@@ -2080,6 +2153,149 @@ func (h *Handler) waitForKubeconfig(dep *Deployment) (string, bool) {
 				Message: fmt.Sprintf("Phase-1 watch: timed out after %s waiting for cloud-init kubeconfig postback. The new Sovereign's cloud-init never PUT its kubeconfig to /api/v1/deployments/{id}/kubeconfig — either Phase 0 failed, the LB never routed to the cloud-init endpoint, or cloud-init crashed. Operator can fetch the kubeconfig via SSH (see docs/RUNBOOK-PROVISIONING.md §Fetch kubeconfig via SSH) and re-run the deployment.", timeout),
 			})
 			return "", false
+		}
+
+		time.Sleep(pollEvery)
+	}
+}
+
+// probeFluxCRDAbsent runs the #5042 bounded Flux-CRD-presence probe.
+// It is called AFTER waitForKubeconfig succeeds and BEFORE the
+// helmwatch informer is built. It returns true ONLY on a POSITIVE
+// "the Flux HelmRelease CRD (helmreleases.helm.toolkit.fluxcd.io) is
+// absent AND the apiserver answered" observation that persists to the
+// end of the probe budget — the signal that cloud-init's flux-install
+// stage never landed on an otherwise-healthy fresh Sovereign. In every
+// other case (CRD servable, or the probe never got a clean absent
+// answer) it returns false so runPhase1Watch proceeds to the watcher
+// exactly as before.
+//
+// Conservatism (surface-not-gate discipline, mirrors the #3971 storage
+// gate and the #4706 console probe): the probe classifies "absent" ONLY
+// on a clean NotFound / no-resource-match from a reachable apiserver.
+// A dynamic-client build failure, a connection error, a timeout, or any
+// other ambiguous/transient error is NEVER treated as a positive absent
+// observation — it falls through (returns false) so a flake cannot
+// invent a failure. When the CRD really is absent, the dynamic client's
+// List against HelmReleaseGVR gets an HTTP 404 the apiserver returns for
+// an unserved resource path (apierrors.IsNotFound); a discovery-mapped
+// path would surface meta.IsNoMatchError — both count as a positive
+// "reachable apiserver says the resource type does not exist".
+//
+// Budget + poll cadence are runtime-configurable per
+// docs/INVIOLABLE-PRINCIPLES.md #4 — see fluxCRDProbeBudgetEnv /
+// fluxCRDProbePollIntervalEnv. Tests inject sub-second values via
+// Handler.fluxCRDProbeBudget / Handler.fluxCRDProbePollInterval and a
+// fake dynamic client (via Handler.dynamicFactory) whose List reactor
+// returns the desired error.
+func (h *Handler) probeFluxCRDAbsent(dep *Deployment, kubeconfig string) bool {
+	budget := h.fluxCRDProbeBudget
+	if budget == 0 {
+		if v, _ := time.ParseDuration(envOrEmpty(fluxCRDProbeBudgetEnv)); v > 0 {
+			budget = v
+		} else {
+			budget = DefaultFluxCRDProbeBudget
+		}
+	}
+	pollEvery := h.fluxCRDProbePollInterval
+	if pollEvery == 0 {
+		if v, _ := time.ParseDuration(envOrEmpty(fluxCRDProbePollIntervalEnv)); v > 0 {
+			pollEvery = v
+		} else {
+			pollEvery = DefaultFluxCRDProbePollInterval
+		}
+	}
+
+	// Build the dynamic client the same way the cert-wait path does:
+	// the test-only h.dynamicFactory when wired, else the production
+	// kubeconfig→dynamic.Interface factory. A build error is NOT a
+	// positive absent observation — fall through so NewWatcher (which
+	// runs next in runPhase1Watch) surfaces OutcomeWatcherStartFailed
+	// with its own diagnostic. Never invent OutcomeFluxCRDsAbsent from a
+	// client-construction failure.
+	var (
+		dyn dynamic.Interface
+		err error
+	)
+	if h.dynamicFactory != nil {
+		dyn, err = h.dynamicFactory(kubeconfig)
+	} else {
+		dyn, err = helmwatch.NewDynamicClientFromKubeconfig(kubeconfig)
+	}
+	if err != nil || dyn == nil {
+		h.log.Warn("flux-crd probe: could not build dynamic client; skipping probe (falling through to watcher)",
+			"id", dep.ID,
+			"err", err,
+		)
+		return false
+	}
+
+	h.emitWatchEvent(dep, provisioner.Event{
+		Time:    time.Now().UTC().Format(time.RFC3339),
+		Phase:   helmwatch.PhaseComponent,
+		Level:   "info",
+		Message: fmt.Sprintf("Phase-1 watch: probing for the Flux HelmRelease CRD (helmreleases.helm.toolkit.fluxcd.io) before starting the per-component watch (budget %s, polling every %s). Issue #5042.", budget, pollEvery),
+	})
+
+	deadline := time.Now().Add(budget)
+	// lastAbsent records whether the MOST RECENT probe was a clean
+	// "CRD absent + apiserver reachable" answer. It gates the terminal
+	// classification: at deadline we return true only if the last
+	// observation was a positive absent — an ambiguous/transient error
+	// at deadline leaves lastAbsent false → fall through (fail-open).
+	lastAbsent := false
+	for {
+		getCtx, cancelGet := context.WithTimeout(context.Background(), pollEvery)
+		_, listErr := dyn.Resource(helmwatch.HelmReleaseGVR).
+			Namespace(helmwatch.FluxNamespace).
+			List(getCtx, metav1.ListOptions{Limit: 1})
+		cancelGet()
+
+		switch {
+		case listErr == nil:
+			// The CRD is servable — Flux is installed. Proceed to the
+			// watcher exactly as before.
+			h.emitWatchEvent(dep, provisioner.Event{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   helmwatch.PhaseComponent,
+				Level:   "info",
+				Message: "Phase-1 watch: Flux HelmRelease CRD is present; starting the per-component HelmRelease watch.",
+			})
+			return false
+		case apierrors.IsNotFound(listErr) || meta.IsNoMatchError(listErr):
+			// POSITIVE absent observation: the apiserver answered that
+			// the resource type does not exist. Keep polling — the
+			// flux-install manifest may still land within the budget.
+			lastAbsent = true
+		default:
+			// Ambiguous/transient (connection refused, TLS flap, timeout,
+			// forbidden, …). Do NOT let this drive a false absent
+			// classification. If the budget elapses while the last
+			// observation is ambiguous we fall through (fail-open).
+			lastAbsent = false
+		}
+
+		if time.Now().After(deadline) {
+			if lastAbsent {
+				h.emitWatchEvent(dep, provisioner.Event{
+					Time:    time.Now().UTC().Format(time.RFC3339),
+					Phase:   helmwatch.PhaseComponent,
+					Level:   "warn",
+					Message: fmt.Sprintf("Phase-1 watch: the Flux HelmRelease CRD (helmreleases.helm.toolkit.fluxcd.io) was still absent after %s — cloud-init's flux-install stage did not land. Classifying flux-crds-absent. Issue #5042.", budget),
+				})
+				return true
+			}
+			// Ambiguous at deadline — fail-open: proceed to the watcher
+			// so a transient apiserver blip never invents a failure. The
+			// watcher's own reachability probe + WatchTimeout path will
+			// classify honestly if the cluster is genuinely unreachable.
+			h.emitWatchEvent(dep, provisioner.Event{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   helmwatch.PhaseComponent,
+				Level:   "info",
+				Message: fmt.Sprintf("Phase-1 watch: Flux HelmRelease CRD probe inconclusive after %s (last observation was a transient error, not a clean absent) — proceeding to the per-component watch. Issue #5042.", budget),
+			})
+			return false
 		}
 
 		time.Sleep(pollEvery)

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_flux_crd_absent_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_flux_crd_absent_test.go
@@ -1,0 +1,243 @@
+// Tests for the #5042 bounded Flux-CRD-presence probe.
+//
+// Background (verified live on hw247 dep 5360c909c6b61472): on an
+// intermittent fresh-prov bootstrap wedge the new Sovereign is HEALTHY
+// — nodes Ready, CNI up, kubeconfig PUT succeeds — but cloud-init's
+// flux-install stage silently didn't land, so the Flux HelmRelease CRD
+// (helmreleases.helm.toolkit.fluxcd.io) is ABSENT. Before this fix the
+// helmwatch informer would attach and observe zero HelmReleases until
+// the 120m WatchTimeout, leaving the deployment "phase1-watching" for
+// hours with no fast, named diagnostic — the #5042 forensic gap.
+//
+// What this file proves:
+//
+//  1. probeFluxCRDAbsent returns false (proceed to the watcher) the
+//     instant the CRD is servable — a List against HelmReleaseGVR that
+//     succeeds means Flux is installed.
+//  2. probeFluxCRDAbsent returns true when the CRD stays absent
+//     (apiserver answers NotFound for the resource path) for the whole
+//     probe budget — the positive "flux-install never landed" signal.
+//  3. probeFluxCRDAbsent is CONSERVATIVE / fail-open: a transient probe
+//     error (connection blip, timeout) is NEVER classified absent — it
+//     falls through to the watcher so a flake can't invent a failure.
+//  4. runPhase1Watch, driven end-to-end against an absent-CRD cluster,
+//     terminates with Status="failed", Phase1Outcome=OutcomeFluxCRDsAbsent
+//     and an operator-actionable diagnostic naming cloud-init's
+//     flux-install stage (Refs #5042).
+//  5. runPhase1Watch against a present-CRD cluster proceeds past the
+//     probe and reaches OutcomeReady — the probe never false-positives
+//     on a healthy prov.
+package handler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+)
+
+// fakeDynamicFactoryWithHRListError — closure that returns a fake
+// dynamic client whose List against the HelmRelease GVR always fails
+// with listErr. Used to simulate the two apiserver responses the probe
+// must distinguish: a NotFound (CRD absent, positive observation) vs a
+// generic transient error (ambiguous, fail-open). A PrependReactor for
+// verb "list" / resource "helmreleases" short-circuits the default
+// object reactor so the injected error is what the probe's List sees.
+func fakeDynamicFactoryWithHRListError(listErr error) func(string) (dynamic.Interface, error) {
+	return func(_ string) (dynamic.Interface, error) {
+		scheme := newFakeSchemeForHandler()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme,
+			map[schema.GroupVersionResource]string{helmwatch.HelmReleaseGVR: "HelmReleaseList"},
+		)
+		client.PrependReactor("list", "helmreleases", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, listErr
+		})
+		return client, nil
+	}
+}
+
+// hrCRDNotFound — the error a real apiserver returns for a dynamic-client
+// List against a resource path whose CRD is not installed (HTTP 404 →
+// apierrors.IsNotFound == true).
+func hrCRDNotFound() error {
+	return apierrors.NewNotFound(
+		schema.GroupResource{Group: "helm.toolkit.fluxcd.io", Resource: "helmreleases"},
+		"",
+	)
+}
+
+// TestProbeFluxCRDAbsent covers the three probe verdicts in isolation:
+// present → proceed (false), absent-past-budget → classify (true),
+// transient error → fail-open (false).
+func TestProbeFluxCRDAbsent(t *testing.T) {
+	t.Run("CRDPresentProceeds", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		// No injected error: List against the seeded fake client
+		// succeeds (empty list, no error) → CRD servable.
+		h.dynamicFactory = fakeDynamicFactoryFromObjects()
+		h.fluxCRDProbeBudget = 2 * time.Second
+		h.fluxCRDProbePollInterval = 20 * time.Millisecond
+
+		dep := makeDeploymentWithKubeconfig(t, h, "flux-crd-present-probe", "fake-kubeconfig: yaml")
+
+		if got := h.probeFluxCRDAbsent(dep, "fake-kubeconfig: yaml"); got {
+			t.Errorf("probeFluxCRDAbsent = true, want false (CRD is servable → proceed to watcher)")
+		}
+	})
+
+	t.Run("CRDAbsentPastBudgetClassifies", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		h.dynamicFactory = fakeDynamicFactoryWithHRListError(hrCRDNotFound())
+		h.fluxCRDProbeBudget = 150 * time.Millisecond
+		h.fluxCRDProbePollInterval = 25 * time.Millisecond
+
+		dep := makeDeploymentWithKubeconfig(t, h, "flux-crd-absent-probe", "fake-kubeconfig: yaml")
+
+		start := time.Now()
+		got := h.probeFluxCRDAbsent(dep, "fake-kubeconfig: yaml")
+		elapsed := time.Since(start)
+
+		if !got {
+			t.Errorf("probeFluxCRDAbsent = false, want true (CRD absent past budget → classify flux-crds-absent)")
+		}
+		// The probe must exhaust the budget before classifying — it must
+		// NOT trip on the first absent observation (the manifest may still
+		// land within the budget).
+		if elapsed < 150*time.Millisecond {
+			t.Errorf("probe returned after %v — it classified before the %s budget elapsed", elapsed, 150*time.Millisecond)
+		}
+	})
+
+	t.Run("TransientErrorFailsOpen", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		// A generic (non-NotFound, non-NoMatch) error models a transient
+		// apiserver blip — the conservative probe must NEVER classify
+		// this as absent.
+		h.dynamicFactory = fakeDynamicFactoryWithHRListError(errors.New("connection refused: dial tcp 10.0.0.1:6443"))
+		h.fluxCRDProbeBudget = 150 * time.Millisecond
+		h.fluxCRDProbePollInterval = 25 * time.Millisecond
+
+		dep := makeDeploymentWithKubeconfig(t, h, "flux-crd-transient-probe", "fake-kubeconfig: yaml")
+
+		if got := h.probeFluxCRDAbsent(dep, "fake-kubeconfig: yaml"); got {
+			t.Errorf("probeFluxCRDAbsent = true, want false (transient error must fail-open, never invent flux-crds-absent)")
+		}
+	})
+
+	t.Run("ClientBuildErrorFailsOpen", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		// A dynamic-client construction failure is NOT a positive absent
+		// observation — the probe falls through so NewWatcher can surface
+		// OutcomeWatcherStartFailed with its own diagnostic.
+		h.dynamicFactory = func(string) (dynamic.Interface, error) {
+			return nil, errors.New("malformed kubeconfig")
+		}
+		h.fluxCRDProbeBudget = 150 * time.Millisecond
+		h.fluxCRDProbePollInterval = 25 * time.Millisecond
+
+		dep := makeDeploymentWithKubeconfig(t, h, "flux-crd-buildfail-probe", "fake-kubeconfig: yaml")
+
+		if got := h.probeFluxCRDAbsent(dep, "fake-kubeconfig: yaml"); got {
+			t.Errorf("probeFluxCRDAbsent = true, want false (client build error must fail-open)")
+		}
+	})
+}
+
+// TestRunPhase1Watch_FluxCRDsAbsentTerminalState drives the full
+// runPhase1Watch entry point against a healthy-but-Flux-less Sovereign:
+// the kubeconfig is on disk, the apiserver answers, but the HelmRelease
+// CRD is absent. The watch must terminate FAST with Status="failed",
+// Phase1Outcome=OutcomeFluxCRDsAbsent and an operator-actionable
+// diagnostic — never idle "phase1-watching" to the WatchTimeout. #5042.
+func TestRunPhase1Watch_FluxCRDsAbsentTerminalState(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = fakeDynamicFactoryWithHRListError(hrCRDNotFound())
+	h.fluxCRDProbeBudget = 150 * time.Millisecond
+	h.fluxCRDProbePollInterval = 25 * time.Millisecond
+	// Belt-and-braces: if the probe ever mis-classified present and fell
+	// through to the watcher, a tiny watch timeout keeps the test bounded.
+	h.phase1WatchTimeout = 2 * time.Second
+	h.suppressPostHandoverHooks = true
+
+	dep := makeDeploymentWithKubeconfig(t, h, "phase1-flux-crds-absent", "fake-kubeconfig: yaml")
+
+	start := time.Now()
+	h.runPhase1Watch(dep)
+	elapsed := time.Since(start)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "failed" {
+		t.Errorf("Status = %q, want %q (flux-crds-absent is a hard failure)", dep.Status, "failed")
+	}
+	if dep.Result == nil {
+		t.Fatalf("Result is nil")
+	}
+	if dep.Result.Phase1Outcome != helmwatch.OutcomeFluxCRDsAbsent {
+		t.Errorf("Phase1Outcome = %q, want %q", dep.Result.Phase1Outcome, helmwatch.OutcomeFluxCRDsAbsent)
+	}
+	if dep.Result.Phase1FinishedAt == nil {
+		t.Errorf("Phase1FinishedAt should be set on the terminal flux-crds-absent path")
+	}
+	// The diagnostic must point the operator at cloud-init's flux-install
+	// stage — the actual root cause — and reference #5042.
+	for _, want := range []string{"Flux", "flux-install", "cloud-init", "#5042"} {
+		if !strings.Contains(dep.Error, want) {
+			t.Errorf("Error missing %q; got: %q", want, dep.Error)
+		}
+	}
+	// The whole point of #5042 is a FAST diagnostic — the probe budget is
+	// 150ms, so the watch must terminate in well under the (belt-and-braces)
+	// 2s watch timeout, and nowhere near the 120m production WatchTimeout.
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("runPhase1Watch took %v — flux-crds-absent should terminate at the probe budget, not hang", elapsed)
+	}
+}
+
+// TestRunPhase1Watch_FluxCRDsPresentProceeds proves the probe does NOT
+// false-positive on a healthy prov: with the Flux CRD present and every
+// bp-* HelmRelease Ready, runPhase1Watch sails past the probe and reaches
+// OutcomeReady — the classic happy path is unchanged. #5042.
+func TestRunPhase1Watch_FluxCRDsPresentProceeds(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = fakeDynamicFactoryFromObjects(
+		makeReadyHR("bp-cilium"),
+		makeReadyHR("bp-cert-manager"),
+		makeReadyHR("bp-flux"),
+	)
+	h.fluxCRDProbeBudget = 2 * time.Second
+	h.fluxCRDProbePollInterval = 20 * time.Millisecond
+	h.phase1WatchTimeout = 5 * time.Second
+	h.suppressPostHandoverHooks = true
+
+	dep := makeDeploymentWithKubeconfig(t, h, "phase1-flux-crds-present", "fake-kubeconfig: yaml")
+
+	h.runPhase1Watch(dep)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Result == nil {
+		t.Fatalf("Result is nil")
+	}
+	if dep.Result.Phase1Outcome == helmwatch.OutcomeFluxCRDsAbsent {
+		t.Errorf("Phase1Outcome = %q — the probe false-positived on a healthy CRD-present prov", dep.Result.Phase1Outcome)
+	}
+	if dep.Status != "ready" {
+		t.Errorf("Status = %q, want %q (CRD present + all HRs installed → ready)", dep.Status, "ready")
+	}
+	if dep.Result.Phase1Outcome != helmwatch.OutcomeReady {
+		t.Errorf("Phase1Outcome = %q, want %q", dep.Result.Phase1Outcome, helmwatch.OutcomeReady)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -306,6 +306,23 @@ const (
 	// same reason as OutcomeKubeconfigMissing — without an informer,
 	// no per-component state can be observed.
 	OutcomeWatcherStartFailed = "watcher-start-failed"
+
+	// OutcomeFluxCRDsAbsent — the new Sovereign PUT its kubeconfig and
+	// its CNI is healthy (apiserver reachable, nodes Ready), but the
+	// Flux HelmRelease CRD (helmreleases.helm.toolkit.fluxcd.io) was
+	// never installed: cloud-init's flux-install stage did not land.
+	// Without that CRD there is nothing for the Phase-1 watcher to
+	// observe — the deployment would otherwise idle "phase1-watching"
+	// for the full WatchTimeout with no fast, named diagnostic. The
+	// handler's bounded Flux-CRD-presence probe (runPhase1Watch, before
+	// NewWatcher) classifies this on a POSITIVE "CRD absent + cluster
+	// reachable" observation after its budget elapses, so the operator
+	// gets an immediate, actionable failure instead of a multi-hour
+	// hang. Issue #5042. Operator playbook: SSH the control-plane and
+	// inspect /var/log/cloud-init-output.log for the flux-install step
+	// + ls /var/lib/rancher/k3s/server/manifests/ for the flux
+	// manifest (docs/RUNBOOK-PROVISIONING.md).
+	OutcomeFluxCRDsAbsent = "flux-crds-absent"
 )
 
 // State enums — kept as constants so callers (handler, tests) compare


### PR DESCRIPTION
## Problem (Refs #5042)

On an intermittent fresh-prov bootstrap wedge (verified live on hw247 dep `5360c909c6b61472`), the new Sovereign cluster is **HEALTHY** — nodes Ready, cilium up, kubeconfig PUT succeeds — but cloud-init's **flux-install stage silently doesn't land**, so the Flux HelmRelease CRD (`helmreleases.helm.toolkit.fluxcd.io`) is **ABSENT** (cloud-init died after CNI, before/at flux-install).

`runPhase1Watch` already handled kubeconfig-missing (`OutcomeKubeconfigMissing`) and zero-HRs-observed (`OutcomeFluxNotReconciling`), but the **"kubeconfig present + cluster reachable + Flux CRD never installed"** case fell through to watching until the 120m `WatchTimeout` (or reconnect-loops) → the deployment sat `phase1-watching` for hours with **no fast, named, actionable diagnostic**. That is the #5042 forensic gap.

## Fix

Add a **bounded Flux-CRD-presence probe** as a new distinct terminal outcome:

1. **helmwatch** — new constant `OutcomeFluxCRDsAbsent = "flux-crds-absent"`.
2. **handler** — `probeFluxCRDAbsent` runs AFTER `waitForKubeconfig` succeeds and BEFORE `helmwatch.NewWatcher`. It polls a `List` against `HelmReleaseGVR` in `flux-system` with a bounded budget:
   - `CATALYST_PHASE1_FLUX_CRD_PROBE_BUDGET` (default **5m**)
   - `CATALYST_PHASE1_FLUX_CRD_PROBE_POLL_INTERVAL` (default **15s**)
   - CRD becomes servable → proceed to the watcher exactly as before.
   - budget elapses with the CRD still positively absent → `markPhase1Done(dep, nil, OutcomeFluxCRDsAbsent)`.
3. **markPhase1Done** — new `case outcome == OutcomeFluxCRDsAbsent` sets `Status="failed"` with an operator-actionable diagnostic pointing at cloud-init's flux-install stage (`/var/log/cloud-init-output.log` + `ls /var/lib/rancher/k3s/server/manifests/`).

### Conservative / fail-open (non-negotiable reliability)

Mirrors the surface-not-gate discipline of the #3971 storage gate and #4706 console probe: the probe classifies absent **ONLY** on a clean `NotFound` / `NoResourceMatch` from a **reachable** apiserver. A dynamic-client build failure, connection error, timeout, or any ambiguous/transient error **falls through to the watcher** — a flake can never invent a failure. It also requires the absent observation to persist to the **end of the budget** (the flux manifest may still land mid-window).

### Env-knob discipline (INVIOLABLE-PRINCIPLES #4)

Budget + poll cadence are env-overridable with sensible defaults and test-only `Handler` field overrides (`fluxCRDProbeBudget` / `fluxCRDProbePollInterval`), mirroring the existing kubeconfig-arrival knobs.

## Tests (`phase1_watch_flux_crd_absent_test.go`)

- `TestProbeFluxCRDAbsent`: present→proceed (false), absent-past-budget→classify (true), transient-error→fail-open (false), client-build-error→fail-open (false).
- `TestRunPhase1Watch_FluxCRDsAbsentTerminalState`: end-to-end absent → `Status="failed"` + `Phase1Outcome=OutcomeFluxCRDsAbsent` + diagnostic naming `Flux`/`flux-install`/`cloud-init`/`#5042`, terminating at the probe budget (not the WatchTimeout).
- `TestRunPhase1Watch_FluxCRDsPresentProceeds`: end-to-end present → `OutcomeReady` (no false positive on a healthy prov).

## Verification

- `go build ./...` green.
- `go vet ./...` clean.
- `go test ./internal/handler/... ./internal/helmwatch/...` green (both suites), plus `-race` on the new tests.
- Scope: Go-only change in the bootstrap api handler + helmwatch. No cloud-init, infra `*.tf`, or chart touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)