### PR TITLE
fix(cutover): exclude CSI driver from step-08 fresh-pull sweep (#5074)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -861,7 +861,7 @@ spec:
       # as ClusterIP (no VIP ever), so the pin deferred FOREVER on every
       # ELB-direct prov (hw250 all night); ClusterIP now pins HOST_IP like the
       # absent-Service hostNetwork branch. LoadBalancer semantics unchanged.
-      version: 0.1.131
+      version: 0.1.132
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.131
+  version: 0.1.132
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,26 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.132 (#5074 Refs #5014 #3379 — step-08 fresh-pull sweep rolled the EVS CSI
+# DRIVER itself and self-defeated the hold; caught live hw251): freshPullProof
+# (step-08's deny-egress fresh-pull sweep) rolled the Huawei EVS CSI driver
+# (csi-evs-node DaemonSet + csi-evs-controller). Restarting the csi-evs-node
+# plugin mid-hold desyncs NodeStage/NodePublish, so every OTHER stateful EVS-PVC
+# workload rolled in the SAME sweep (gitea, grafana, …) gets NodePublishVolume
+# against a `globalmount` the restarted plugin never re-staged → `mount: special
+# device .../globalmount does not exist` (exit 32) → blows the 600s roll budget →
+# step-08 FAILs. Same recursive/self-defeating class already excluded for
+# catalyst/registry-pivot (#5022), kube-system/hubble-ui-oauth2-proxy (#5059) and
+# falco/falco (#5065): never bounce the mechanism every other stateful mount
+# depends on. FIX (values-only): append csi-evs-node/csi-evs-controller (+ the
+# Hetzner hcloud-csi provider-parity names, harmless no-op when absent) to
+# freshPullProof.excludeWorkloads. CSI image-locality is ALREADY proven (running
+# from local post-pivot + the step-08 completeness HEAD gate + the ref-host lint),
+# so skipping the synthetic roll removes no sovereignty proof. Case 49 is a
+# contains-check (#5069), so the grown exclude list passes unchanged. NO
+# step-count / job-mode / RBAC change (still 11 steps). Slot-06a pin +
+# blueprint.yaml + catalog-seed source.version + spec.version move to 0.1.132 in
+# lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag the chart).
+# ── prior ──
 # 0.1.126 (#5036 Refs #5026 #5027 #4975 — hw246, dep c38c437f, omani.works): the
 # step-08 PRE-HOLD ref-host lint (run_podspec_refhost_lint, added #5026/#5027) is now
 # REDIRECT-AWARE. It failed BEFORE the deny-egress hold on the ~40 workloads whose
@@ -2024,7 +2045,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.131
+version: 0.1.132
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1215,6 +1215,19 @@ egressTest:
       # recreatable (Kyverno resource-requests exempt) for real node-replace /
       # region-kill.
       - "falco/falco"
+      # CSI drivers (#5074): rolling the CSI DRIVER mid-hold is self-defeating —
+      # the csi-evs-node DaemonSet restart desyncs NodeStage/NodePublish, so every
+      # OTHER stateful EVS/PV-backed workload rolled in the same sweep (gitea,
+      # grafana, …) gets NodePublishVolume against a globalmount the restarted
+      # plugin never re-staged → `special device .../globalmount does not exist`
+      # (exit 32) → blows the roll budget → step-08 FAILs. Recursive, exactly like
+      # registry-pivot: never bounce the mechanism every other stateful mount
+      # depends on. CSI image-locality is already proven (running from local
+      # post-pivot + the completeness HEAD gate). Caught live hw251 step-08.
+      - "huawei-evs-csi/csi-evs-node"
+      - "huawei-evs-csi/csi-evs-controller"
+      - "kube-system/hcloud-csi-node"
+      - "kube-system/hcloud-csi-controller"
   # #5026 — PRE-HOLD ref-host lint (treadmill-breaker). The completeness gate
   # above proves image CONTENT is in local Harbor; this lint proves every
   # rolled workload's pod-spec image REF HOST is the local registry

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.131"
+    version: "0.1.132"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (verified live hw251 step-08)

step-08's fresh-pull sweep (`freshPullProof`) rolled the Huawei EVS **CSI driver itself** — the `csi-evs-node` DaemonSet + `csi-evs-controller`. Restarting the `csi-evs-node` plugin mid-hold desyncs `NodeStage`/`NodePublish`, so every **other** stateful EVS-PVC workload rolled in the same sweep (gitea, grafana, …) gets `NodePublishVolume` against a `globalmount` the restarted plugin never re-staged:

```
mount: special device .../globalmount does not exist   (exit 32)
```

That blows the 600s roll budget → **step-08 FAILs** → `cutoverComplete` never set. This is the exact recursive/self-defeating class already handled for `catalyst/registry-pivot` (#5022), `kube-system/hubble-ui-oauth2-proxy` (#5059), and `falco/falco` (#5065): never bounce the mechanism every other stateful mount depends on.

## Fix (values-only, +4-surface version lockstep)

Append the CSI driver workloads to `freshPullProof.excludeWorkloads` in `platform/self-sovereign-cutover/chart/values.yaml`:

- `huawei-evs-csi/csi-evs-node`
- `huawei-evs-csi/csi-evs-controller`
- `kube-system/hcloud-csi-node`  (Hetzner provider-parity; harmless no-op when absent)
- `kube-system/hcloud-csi-controller`  (same)

CSI image-locality is **already proven** independently — the driver runs from the local registry post-pivot, and the step-08 completeness HEAD gate + ref-host lint assert its image is in local Harbor — so skipping the synthetic roll removes **no** sovereignty proof.

4-surface version lockstep (Inviolable Principle #13) → **0.1.132**:
| Surface | File | Line |
|---|---|---|
| Chart | `platform/self-sovereign-cutover/chart/Chart.yaml` | `version: 0.1.132` |
| Blueprint | `platform/self-sovereign-cutover/blueprint.yaml` | `spec.version: 0.1.132` |
| Slot 06a pin | `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` | `version: 0.1.132` |
| Catalog seed | `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` | `source.version: "0.1.132"` |

## Gates (all green)

- `bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` → **exit 0** (all 55 cases green; Case 49 is a contains-check per #5069 so the grown exclude list passes unchanged).
- `helm lint platform/self-sovereign-cutover/chart` → **0 charts failed**.
- `go test -run TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` → **ok** (seed pin not behind chart).
- Rendered `FRESH_PULL_EXCLUDE_WORKLOADS` env confirmed to carry all four new entries.

> Note (RT-11): this cutover chart may be under a merge-hold — do **not** force-merge. A red `RT-11 cutover merge-hold` check is expected. Chart-only change; no live cluster touched.

Refs #5074 #5014

🤖 Generated with [Claude Code](https://claude.com/claude-code)