### PR TITLE
fix(cutover): re-check Job state on watch-channel loss instead of failing the step (Refs #5014)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -142,6 +142,16 @@ const (
 	// public openova repo). 15 minutes is a generous worst case.
 	defaultCutoverStepTimeout = 15 * time.Minute
 
+	// #5014: on a Job-watch channel close (or watch-establish failure) the
+	// engine re-checks the Job's ACTUAL state and re-establishes the watch
+	// rather than failing the step — a closed watch is NORMAL k8s behaviour
+	// (watch expiry, apiserver churn) and the catalyst-api Pod itself ROLLS
+	// mid-cutover at step-07, which closes the engine's watch on a Job that
+	// may already be Complete. These bound that re-watch loop so a Job that
+	// genuinely never terminates cannot spin forever.
+	defaultCutoverJobWatchRewatchMax     = 10
+	defaultCutoverJobWatchRewatchBackoff = 2 * time.Second
+
 	// DaemonSet ready-wait timeout. registry-pivot rolls in seconds on
 	// a small Sovereign and a few minutes on a large one.
 	defaultDaemonSetReadyTimeout = 10 * time.Minute
@@ -190,6 +200,11 @@ const (
 	envCutoverStatusCM      = "CATALYST_CUTOVER_STATUS_CONFIGMAP"
 	envCutoverStepTimeout   = "CATALYST_CUTOVER_STEP_TIMEOUT"
 	envCutoverDaemonSetWait = "CATALYST_CUTOVER_DAEMONSET_TIMEOUT"
+	// #5014 re-watch tuning: max number of times watchJobToCompletion
+	// re-establishes a Job watch after a transient channel-close /
+	// establish-error before it gives up, and the backoff between attempts.
+	envCutoverJobWatchRewatchMax     = "CATALYST_CUTOVER_JOBWATCH_REWATCH_MAX"
+	envCutoverJobWatchRewatchBackoff = "CATALYST_CUTOVER_JOBWATCH_REWATCH_BACKOFF"
 )
 
 // ── In-process state ────────────────────────────────────────────────────────
@@ -356,6 +371,33 @@ func cutoverStepTimeout() time.Duration {
 		return v
 	}
 	return defaultCutoverStepTimeout
+}
+
+// cutoverJobWatchRewatchMax is the #5014 re-watch budget: the maximum number
+// of times watchJobToCompletion re-establishes a Job watch after a transient
+// channel-close / watch-establish failure before it gives up. The overall
+// step deadline (wctx) still caps wall-clock time; this bound additionally
+// guards against a tight re-close loop (a chronically flaky apiserver, or a
+// fake in a unit test) spinning forever without ever making progress.
+// Runtime-overridable per Inviolable-Principle #4; malformed / non-positive
+// values fall back to the default.
+func cutoverJobWatchRewatchMax() int {
+	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(envCutoverJobWatchRewatchMax))); err == nil && v > 0 {
+		return v
+	}
+	return defaultCutoverJobWatchRewatchMax
+}
+
+// cutoverJobWatchRewatchBackoff is the pause between re-watch attempts. A
+// small delay keeps a synchronous re-close (e.g. an apiserver returning an
+// immediately-closed watch, or a fake clientset in tests) from busy-spinning
+// the CPU. Bounded by wctx so the overall step deadline still wins. Non-
+// positive / malformed → default.
+func cutoverJobWatchRewatchBackoff() time.Duration {
+	if v, _ := time.ParseDuration(strings.TrimSpace(os.Getenv(envCutoverJobWatchRewatchBackoff))); v > 0 {
+		return v
+	}
+	return defaultCutoverJobWatchRewatchBackoff
 }
 
 // cutoverStepDeadline returns the wall-clock budget for a single step's
@@ -958,9 +1000,29 @@ func createCutoverJob(ctx context.Context, deps *cutoverDeps, step cutoverStep, 
 
 // watchJobToCompletion blocks until the Job reports a terminal
 // condition (Complete or Failed). Returns the terminal condition type
-// or an error on watch / context failure. Uses a single Watch call
-// against the Job by name so we get an event-driven completion signal
-// rather than polling.
+// or an error on genuine failure / context end. It watches the Job by
+// name for an event-driven completion signal, but the step outcome is a
+// function of the Job's ACTUAL state — never the watch channel's
+// liveness.
+//
+// #5014 (hw242 step-03 harbor-prewarm, hw251 egress-block-test): a watch
+// channel CLOSE is normal k8s behaviour — server-side watches expire /
+// time out periodically, AND the catalyst-api Pod (which hosts this
+// engine) ROLLS mid-cutover at step-07 (catalyst-api-env-patch), which
+// restarts the engine and closes its Job watch. The Job itself may have
+// already SUCCEEDED or may still be Running. The pre-fix code failed the
+// STEP on any channel close whose immediate one-shot Get didn't yet show
+// a terminal condition — a false-negative that halted a cutover which
+// would otherwise reach cutoverComplete (harbor-prewarm ran ~80 min and
+// its watch churned; the manual recovery was a single re-POST of the
+// internal trigger that simply re-read the already-Complete Job).
+//
+// Post-fix: on a channel close OR a watch-establish error we RE-POLL the
+// Job's real condition via Get and, if it is not yet terminal, RE-WATCH.
+// This loops until the Job is genuinely terminal, the context ends
+// (deadline / cancel), or the bounded re-watch budget is exhausted —
+// only then does the step fail. A real JobFailed still fails the step; a
+// cancelled/expired ctx still returns ctx.Err().
 func watchJobToCompletion(ctx context.Context, deps *cutoverDeps, jobName string, timeout time.Duration) (batchv1.JobConditionType, error) {
 	if timeout <= 0 {
 		timeout = cutoverStepTimeout()
@@ -968,50 +1030,108 @@ func watchJobToCompletion(ctx context.Context, deps *cutoverDeps, jobName string
 	wctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Sanity-check the current state up front so a Job that completed
-	// between Create and Watch (rare but possible on a small cluster)
-	// is recognised without waiting for the next event.
-	if existing, err := deps.core.BatchV1().Jobs(deps.ns).Get(wctx, jobName, metav1.GetOptions{}); err == nil {
-		if t, ok := terminalJobCondition(existing); ok {
-			return t, nil
+	rewatchBudget := cutoverJobWatchRewatchMax()
+	rewatches := 0
+
+	for {
+		// (Re-)poll the Job's ACTUAL state before (re-)establishing the
+		// watch. Recognises a Job that completed between Create and Watch
+		// (small clusters) OR during a watch gap after the channel closed
+		// (the #5014 case) without waiting for a fresh event.
+		if existing, err := deps.core.BatchV1().Jobs(deps.ns).Get(wctx, jobName, metav1.GetOptions{}); err == nil {
+			if t, ok := terminalJobCondition(existing); ok {
+				return t, nil
+			}
+		}
+
+		w, err := deps.core.BatchV1().Jobs(deps.ns).Watch(wctx, metav1.ListOptions{
+			FieldSelector: "metadata.name=" + jobName,
+		})
+		if err != nil {
+			// #5014: a watch-establish failure is transient (apiserver
+			// flake, or the catalyst-api Pod restarting mid-cutover). The
+			// Job's real state was just polled above; retry establishing
+			// the watch within budget instead of failing the step.
+			retry, rerr := cutoverJobWatchRewatch(wctx, &rewatches, rewatchBudget, deps.ns, jobName,
+				fmt.Errorf("establish watch: %w", err))
+			if !retry {
+				return "", rerr
+			}
+			continue
+		}
+
+		cond, closed, loopErr := awaitTerminalJobEvent(wctx, w, deps.ns, jobName)
+		switch {
+		case loopErr != nil:
+			// ctx end (deadline/cancel) or a genuine watch.Error event.
+			return "", loopErr
+		case cond != "":
+			// Terminal condition observed on the wire (Complete or Failed).
+			return cond, nil
+		case closed:
+			// #5014: transient channel close. Loop back to re-Get + re-watch,
+			// bounded by the re-watch budget.
+			retry, rerr := cutoverJobWatchRewatch(wctx, &rewatches, rewatchBudget, deps.ns, jobName,
+				fmt.Errorf("watch channel closed before terminal condition"))
+			if !retry {
+				return "", rerr
+			}
+			continue
 		}
 	}
+}
 
-	w, err := deps.core.BatchV1().Jobs(deps.ns).Watch(wctx, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + jobName,
-	})
-	if err != nil {
-		return "", fmt.Errorf("watch Job %s/%s: %w", deps.ns, jobName, err)
-	}
+// awaitTerminalJobEvent drains a single Job watch until it observes a
+// terminal condition, the channel closes, the context ends, or a
+// watch.Error event arrives. It Stops the watcher before returning.
+//
+// Returns exactly one of:
+//   - (cond, false, nil)  — the Job reached a terminal condition (Complete|Failed)
+//   - ("",   true,  nil)  — the watch channel closed (caller re-watches per #5014)
+//   - ("",   false, err)  — the context ended, or a genuine watch.Error event
+func awaitTerminalJobEvent(wctx context.Context, w watch.Interface, ns, jobName string) (batchv1.JobConditionType, bool, error) {
 	defer w.Stop()
-
 	for {
 		select {
 		case <-wctx.Done():
-			return "", fmt.Errorf("watch Job %s/%s: %w", deps.ns, jobName, wctx.Err())
+			return "", false, fmt.Errorf("watch Job %s/%s: %w", ns, jobName, wctx.Err())
 		case ev, ok := <-w.ResultChan():
 			if !ok {
-				// Watch closed (resource version expired, server
-				// flake). Fall back to a one-shot Get + retry the
-				// watch up to the deadline.
-				if existing, err := deps.core.BatchV1().Jobs(deps.ns).Get(wctx, jobName, metav1.GetOptions{}); err == nil {
-					if t, ok := terminalJobCondition(existing); ok {
-						return t, nil
-					}
-				}
-				return "", fmt.Errorf("watch Job %s/%s: channel closed before terminal condition", deps.ns, jobName)
+				return "", true, nil
 			}
 			if ev.Type == watch.Error {
-				return "", fmt.Errorf("watch Job %s/%s: error event: %#v", deps.ns, jobName, ev.Object)
+				return "", false, fmt.Errorf("watch Job %s/%s: error event: %#v", ns, jobName, ev.Object)
 			}
 			job, ok := ev.Object.(*batchv1.Job)
 			if !ok {
 				continue
 			}
 			if t, ok := terminalJobCondition(job); ok {
-				return t, nil
+				return t, false, nil
 			}
 		}
+	}
+}
+
+// cutoverJobWatchRewatch decides whether watchJobToCompletion should
+// re-establish its Job watch after a transient failure (#5014). It
+// increments the re-watch counter, enforces the budget, and applies a
+// bounded backoff. Returns (true, nil) to signal "retry the watch"; on
+// budget exhaustion or context end it returns (false, err) with a clear,
+// operator-legible message that names the transient cause.
+func cutoverJobWatchRewatch(wctx context.Context, rewatches *int, budget int, ns, jobName string, cause error) (bool, error) {
+	if *rewatches >= budget {
+		return false, fmt.Errorf(
+			"watch Job %s/%s: %v; re-watch budget of %d exhausted without a terminal Job condition",
+			ns, jobName, cause, budget)
+	}
+	*rewatches++
+	select {
+	case <-wctx.Done():
+		// Overall step deadline / cancel wins over a re-watch attempt.
+		return false, fmt.Errorf("watch Job %s/%s: %w", ns, jobName, wctx.Err())
+	case <-time.After(cutoverJobWatchRewatchBackoff()):
+		return true, nil
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_jobwatch_rewatch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_jobwatch_rewatch_test.go
@@ -1,0 +1,368 @@
+// #5014 — cutover driver Job-watch re-watch tests.
+//
+// Live defect (hw242 step-03 harbor-prewarm 2026-07-12, hw251
+// egress-block-test): the step-runner treated loss of its Job watch
+// channel as a STEP FAILURE. It did a single one-shot Get on close and,
+// if the Job had not YET flipped terminal, returned
+// "channel closed before terminal condition" — halting the whole cutover
+// chain on a step whose Job actually SUCCEEDED moments later (a
+// false-negative). A watch close is normal k8s behaviour (server-side
+// watch expiry) and is guaranteed on the mid-cutover catalyst-api Pod
+// roll at step-07.
+//
+// Post-fix watchJobToCompletion makes the step outcome a function of the
+// Job's ACTUAL state: on a channel close (or a watch-establish error) it
+// re-Gets the Job and re-establishes the watch, bounded by a re-watch
+// budget + the overall step deadline. These tests pin every branch:
+//
+//	(a) channel closes, Job then Complete (via re-Get)      → step succeeds
+//	(b) channel closes, Job still running, re-watch delivers Complete event → succeeds
+//	(c) genuine JobFailed (direct event)                    → returns Failed (step fails)
+//	(c2) genuine JobFailed surfaced through a channel close → returns Failed (not masked)
+//	(d) re-watch budget exhausted, Job never terminal       → clear budget error
+//	(e) watch-establish error is transient, then Complete   → succeeds
+//	(f) ctx cancelled mid-watch                             → returns ctx.Err()
+//	(g) overall deadline elapses with Job not terminal      → returns DeadlineExceeded
+//	(h) end-to-end: a step whose first watch closes still advances the chain
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const jobwatchTestJob = "cutover-egress-block-test-1783798334"
+
+func jobWith(name, ns string, cond batchv1.JobConditionType) *batchv1.Job {
+	j := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	if cond != "" {
+		j.Status.Conditions = []batchv1.JobCondition{{
+			Type:   cond,
+			Status: corev1.ConditionTrue,
+			Reason: "Test",
+		}}
+	}
+	return j
+}
+
+// newClosedJobWatch returns a watcher whose ResultChan is already closed —
+// modelling a server-side watch expiry / the catalyst-api Pod roll closing
+// the engine's watch. The consumer observes (_, ok=false).
+func newClosedJobWatch() watch.Interface {
+	fw := watch.NewFake()
+	fw.Stop()
+	return fw
+}
+
+// newJobEventWatch returns an open watcher pre-loaded with a single Modify
+// event carrying job, so the consumer observes a terminal condition on the
+// wire (buffered so the reactor doesn't block).
+func newJobEventWatch(job *batchv1.Job) watch.Interface {
+	fw := watch.NewFakeWithChanSize(1, false)
+	fw.Modify(job)
+	return fw
+}
+
+// scriptedGet installs a get/jobs reactor returning conds[i] on the i-th Get,
+// holding the last entry for any further calls (so a two-phase running→terminal
+// transition is deterministic without racing an UpdateStatus goroutine).
+func scriptedGet(client *fakek8s.Clientset, ns, name string, conds ...batchv1.JobConditionType) {
+	var calls int32
+	client.PrependReactor("get", "jobs", func(clienttesting.Action) (bool, k8sruntime.Object, error) {
+		i := int(atomic.AddInt32(&calls, 1)) - 1
+		if i >= len(conds) {
+			i = len(conds) - 1
+		}
+		return true, jobWith(name, ns, conds[i]), nil
+	})
+}
+
+func newJobwatchDeps(objs ...k8sruntime.Object) (*cutoverDeps, *fakek8s.Clientset) {
+	client := fakek8s.NewSimpleClientset(objs...)
+	return &cutoverDeps{core: client, ns: cutoverTestNS}, client
+}
+
+// ── (a) channel close, then Job Complete via re-Get ─────────────────────────
+
+func TestWatchJobToCompletion_ChannelCloseThenComplete_Succeeds(t *testing.T) {
+	t.Setenv(envCutoverJobWatchRewatchBackoff, "1ms")
+	deps, client := newJobwatchDeps()
+	// First Get (before the watch) sees Running; after the close, the re-Get
+	// sees Complete — exactly the hw242 timeline (Job Complete 1/1 while the
+	// driver's watch channel churned).
+	scriptedGet(client, deps.ns, jobwatchTestJob, "", batchv1.JobComplete)
+	var watches int32
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		if atomic.AddInt32(&watches, 1) == 1 {
+			return true, newClosedJobWatch(), nil
+		}
+		t.Errorf("unexpected watch #%d: re-Get should observe Complete without a second watch", watches)
+		return true, newClosedJobWatch(), nil
+	})
+
+	cond, err := watchJobToCompletion(context.Background(), deps, jobwatchTestJob, 5*time.Second)
+	if err != nil {
+		t.Fatalf("watchJobToCompletion errored on a Complete Job after channel close (the #5014 false-negative): %v", err)
+	}
+	if cond != batchv1.JobComplete {
+		t.Fatalf("cond = %q, want %q", cond, batchv1.JobComplete)
+	}
+}
+
+// ── (b) channel close, Job still running, re-watch delivers the terminal ────
+
+func TestWatchJobToCompletion_ChannelCloseThenRewatchDeliversComplete(t *testing.T) {
+	t.Setenv(envCutoverJobWatchRewatchBackoff, "1ms")
+	deps, client := newJobwatchDeps()
+	// Get ALWAYS reports Running — the terminal signal must come from the
+	// RE-ESTABLISHED watch's event, proving the re-watch (not just re-Get) path.
+	scriptedGet(client, deps.ns, jobwatchTestJob, "")
+	var watches int32
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		if atomic.AddInt32(&watches, 1) == 1 {
+			return true, newClosedJobWatch(), nil
+		}
+		return true, newJobEventWatch(jobWith(jobwatchTestJob, deps.ns, batchv1.JobComplete)), nil
+	})
+
+	cond, err := watchJobToCompletion(context.Background(), deps, jobwatchTestJob, 5*time.Second)
+	if err != nil {
+		t.Fatalf("watchJobToCompletion errored; re-watch should have observed the terminal event: %v", err)
+	}
+	if cond != batchv1.JobComplete {
+		t.Fatalf("cond = %q, want %q", cond, batchv1.JobComplete)
+	}
+	if watches < 2 {
+		t.Fatalf("expected the watch to be re-established (>=2 calls); got %d", watches)
+	}
+}
+
+// ── (c) genuine JobFailed via a direct event still fails the step ───────────
+
+func TestWatchJobToCompletion_GenuineFailedEvent_ReturnsFailed(t *testing.T) {
+	deps, client := newJobwatchDeps()
+	scriptedGet(client, deps.ns, jobwatchTestJob, "") // Running at the up-front Get
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		return true, newJobEventWatch(jobWith(jobwatchTestJob, deps.ns, batchv1.JobFailed)), nil
+	})
+
+	cond, err := watchJobToCompletion(context.Background(), deps, jobwatchTestJob, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cond != batchv1.JobFailed {
+		t.Fatalf("cond = %q, want %q (a genuine failure must still surface so the caller fails the step)", cond, batchv1.JobFailed)
+	}
+}
+
+// ── (c2) a genuine failure surfaced THROUGH a channel close is not masked ───
+
+func TestWatchJobToCompletion_ChannelCloseThenFailed_ReturnsFailed(t *testing.T) {
+	t.Setenv(envCutoverJobWatchRewatchBackoff, "1ms")
+	deps, client := newJobwatchDeps()
+	scriptedGet(client, deps.ns, jobwatchTestJob, "", batchv1.JobFailed)
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		return true, newClosedJobWatch(), nil
+	})
+
+	cond, err := watchJobToCompletion(context.Background(), deps, jobwatchTestJob, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cond != batchv1.JobFailed {
+		t.Fatalf("cond = %q, want %q (re-Get must surface a real Failed, not re-watch forever)", cond, batchv1.JobFailed)
+	}
+}
+
+// ── (d) re-watch budget exhausted with a never-terminal Job ─────────────────
+
+func TestWatchJobToCompletion_RewatchBudgetExhausted_FailsWithBudgetError(t *testing.T) {
+	t.Setenv(envCutoverJobWatchRewatchBackoff, "1ms")
+	t.Setenv(envCutoverJobWatchRewatchMax, "3")
+	deps, client := newJobwatchDeps()
+	scriptedGet(client, deps.ns, jobwatchTestJob, "") // never terminal
+	var watches int32
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		atomic.AddInt32(&watches, 1)
+		return true, newClosedJobWatch(), nil // always closes
+	})
+
+	cond, err := watchJobToCompletion(context.Background(), deps, jobwatchTestJob, 5*time.Second)
+	if err == nil {
+		t.Fatalf("expected a budget-exhausted error; got cond=%q err=nil", cond)
+	}
+	if cond != "" {
+		t.Fatalf("cond = %q, want empty on failure", cond)
+	}
+	if !strings.Contains(err.Error(), "re-watch budget of 3 exhausted") {
+		t.Fatalf("error %q must name the exhausted re-watch budget", err.Error())
+	}
+	// budget=3 → 3 successful re-watches, then the 4th close fails.
+	if got := atomic.LoadInt32(&watches); got != 4 {
+		t.Fatalf("watch established %d times, want 4 (budget 3 + the final failing close)", got)
+	}
+}
+
+// ── (e) transient watch-establish error is retried, then Complete ───────────
+
+func TestWatchJobToCompletion_EstablishErrorThenRewatchSucceeds(t *testing.T) {
+	t.Setenv(envCutoverJobWatchRewatchBackoff, "1ms")
+	deps, client := newJobwatchDeps()
+	scriptedGet(client, deps.ns, jobwatchTestJob, "")
+	var watches int32
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		if atomic.AddInt32(&watches, 1) == 1 {
+			return true, nil, errors.New("etcdserver: request timed out") // transient establish failure
+		}
+		return true, newJobEventWatch(jobWith(jobwatchTestJob, deps.ns, batchv1.JobComplete)), nil
+	})
+
+	cond, err := watchJobToCompletion(context.Background(), deps, jobwatchTestJob, 5*time.Second)
+	if err != nil {
+		t.Fatalf("a transient watch-establish error should be retried, not fail the step: %v", err)
+	}
+	if cond != batchv1.JobComplete {
+		t.Fatalf("cond = %q, want %q", cond, batchv1.JobComplete)
+	}
+}
+
+// ── (f) ctx cancel preserves ctx.Err() semantics ───────────────────────────
+
+func TestWatchJobToCompletion_ContextCancel_ReturnsCtxErr(t *testing.T) {
+	deps, client := newJobwatchDeps()
+	scriptedGet(client, deps.ns, jobwatchTestJob, "")
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		return true, watch.NewFake(), nil // open, never delivers
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	cond, err := watchJobToCompletion(ctx, deps, jobwatchTestJob, 5*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want it to wrap context.Canceled", err)
+	}
+	if cond != "" {
+		t.Fatalf("cond = %q, want empty on cancel", cond)
+	}
+}
+
+// ── (g) overall deadline elapses with the Job not terminal ──────────────────
+
+func TestWatchJobToCompletion_DeadlineExceeded_ReturnsDeadlineErr(t *testing.T) {
+	deps, client := newJobwatchDeps()
+	scriptedGet(client, deps.ns, jobwatchTestJob, "")
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		return true, watch.NewFake(), nil // open, never delivers
+	})
+
+	cond, err := watchJobToCompletion(context.Background(), deps, jobwatchTestJob, 40*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want it to wrap context.DeadlineExceeded", err)
+	}
+	if cond != "" {
+		t.Fatalf("cond = %q, want empty on deadline", cond)
+	}
+}
+
+// ── (h) end-to-end: a mid-step watch close does NOT halt the chain ──────────
+
+// TestHandleCutoverStart_AdvancesChainDespiteWatchClose is the #5014
+// regression at the engine level: the FIRST Job watch of the run closes
+// mid-step (as it did live on hw242), yet the created Job completes and the
+// engine must advance through every step to cutoverComplete=true instead of
+// recording failedStep + halting.
+func TestHandleCutoverStart_AdvancesChainDespiteWatchClose(t *testing.T) {
+	// Backoff long enough that the installJobReactor's ~20ms UpdateStatus has
+	// landed before the post-close re-Get, so the re-Get sees Complete on the
+	// first retry (well within the default budget of 10).
+	t.Setenv(envCutoverJobWatchRewatchBackoff, "60ms")
+
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-harbor-prewarm", cutoverStepHarborPrewarm, 2, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-03-registry-pivot", "registry-pivot", 3, cutoverModeDaemonSetWait, "", "registry-pivot"),
+		makeReadyDaemonSet("registry-pivot"),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+			Data: map[string]string{
+				"cutoverComplete":              "false",
+				"node.cp-1.registriesYaml":     "v2",
+				"node.worker-1.registriesYaml": "v2",
+				"node.worker-2.registriesYaml": "v2",
+			},
+		},
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+
+	// Close ONLY the first Job watch of the run; every later watch falls
+	// through to the tracker-backed default so the remaining steps behave
+	// normally.
+	var firstWatch int32
+	client.PrependWatchReactor("jobs", func(clienttesting.Action) (bool, watch.Interface, error) {
+		if atomic.AddInt32(&firstWatch, 1) == 1 {
+			return true, newClosedJobWatch(), nil
+		}
+		return false, nil, nil // delegate to the default tracker watch
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/cutover/start", nil)
+	h.HandleCutoverStart(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandleCutoverStart: status %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		bus := h.cutoverBusFor()
+		bus.mu.Lock()
+		running := bus.running
+		bus.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(), cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status ConfigMap: %v", err)
+	}
+	if got := cm.Data["cutoverComplete"]; got != "true" {
+		t.Fatalf("cutoverComplete = %q, want true (chain must advance despite the mid-step watch close); failedStep=%q lastError=%q",
+			got, cm.Data["failedStep"], cm.Data["lastError"])
+	}
+	if fs := cm.Data["failedStep"]; fs != "" {
+		t.Fatalf("failedStep = %q, want empty — a watch close must not be recorded as a step failure", fs)
+	}
+	if got := cm.Data["step.gitea-mirror.result"]; got != "success" {
+		t.Fatalf("step.gitea-mirror.result = %q, want success", got)
+	}
+	// The close path is definitively pinned by the direct watchJobToCompletion
+	// unit tests above (b/d/e); here we only assert the chain still completes.
+	// The watch normally fires (a Job is Running at its up-front Get), but we
+	// don't make that a hard assertion to avoid coupling to CREATE→Get timing.
+	if atomic.LoadInt32(&firstWatch) < 1 {
+		t.Logf("note: no Job watch was established this run (both step Jobs completed before their up-front Get) — chain-completion still verified")
+	}
+}


### PR DESCRIPTION
## Problem

`Refs #5014`

The cutover driver's per-step Job watcher (`watchJobToCompletion` in
`products/catalyst/bootstrap/api/internal/handler/cutover.go`) treated **loss of
its Job watch channel** as a **step failure**. On a channel close it did a single
one-shot `Get`; if that Get had not *yet* observed a terminal condition it
returned `watch Job <ns>/<job>: channel closed before terminal condition`, which
propagated up and marked the cutover **step failed** and **halted the whole
chain**.

But a watch-channel close is **normal** k8s behaviour:

- server-side watches expire / time out periodically, and
- the `catalyst-api` Pod that hosts the cutover engine **rolls mid-cutover** at
  step-07 (`catalyst-api-env-patch`) — the engine restarts and its Job watch
  closes on a Job that may already be **Complete** or still **Running**.

**Live evidence:**
- hw242 step-03 `harbor-prewarm` (2026-07-12 ~21:22Z): Job reached `Complete 1/1`
  (134/134 images, zero errors) yet the status CM recorded
  `failedStep=harbor-prewarm, lastError="…channel closed before terminal
  condition"` and halted ~30 min — a **false failure on a succeeded step**.
- hw251 `egress-block-test`: `lastError=…channel closed before terminal
  condition` recorded while the Job was still `Running`.

The proven live recovery was a single re-POST of the internal trigger, which just
re-read the already-Complete Job. This PR builds that re-check into the driver so
the halt never happens.

## Fix

Make the step outcome a function of the **Job's ACTUAL state**, not the watch
channel's liveness. `watchJobToCompletion` now loops:

1. **(Re-)poll** the Job via `Get`; a terminal `JobComplete`/`JobFailed`
   condition returns immediately.
2. Establish the watch. On a **watch-establish error** → re-poll + re-watch
   (transient).
3. Drain the watch (`awaitTerminalJobEvent`): a terminal condition on the wire
   returns; a **channel close** re-polls + re-watches; ctx-end / a genuine
   `watch.Error` event returns the error.
4. Re-watching is bounded by a **re-watch budget** (`cutoverJobWatchRewatch`) +
   the overall step deadline (`wctx`), so a Job that genuinely never terminates
   can't loop forever.

Semantics preserved: a real `JobFailed` still fails the step; a cancelled /
deadline-exceeded ctx still returns `ctx.Err()`. Only the transient
channel-close / establish-error paths changed from "fail the step" to "re-check
the Job's real state and re-watch."

### New runtime knobs (Inviolable-Principle #4, env-overridable)
- `CATALYST_CUTOVER_JOBWATCH_REWATCH_MAX` — max re-watch attempts (default 10)
- `CATALYST_CUTOVER_JOBWATCH_REWATCH_BACKOFF` — pause between attempts (default 2s)

## Tests

New `cutover_jobwatch_rewatch_test.go` (9 tests) pins every branch:

- channel close → Job Complete via re-Get → **step succeeds** (not failed)
- channel close → Job still running → **re-watch delivers** the terminal event
- genuine `JobFailed` (direct event) → returns Failed (step fails)
- genuine `JobFailed` surfaced through a channel close → returns Failed (not masked)
- re-watch budget exhausted, Job never terminal → clear budget error
- transient watch-establish error → retried → succeeds
- ctx cancel → returns `ctx.Err()`
- overall deadline elapses, Job not terminal → returns `DeadlineExceeded`
- **engine-level**: a step whose first watch closes mid-run still advances the
  chain to `cutoverComplete=true` with `failedStep` empty

`go build ./...`, `go vet ./...`, and `go test ./internal/handler/...` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
