### PR TITLE
fix(cutover): step-08 roll-set minimization — rollSetMode minimal excludes infra by rule (0.1.133)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -861,7 +861,7 @@ spec:
       # as ClusterIP (no VIP ever), so the pin deferred FOREVER on every
       # ELB-direct prov (hw250 all night); ClusterIP now pins HOST_IP like the
       # absent-Service hostNetwork branch. LoadBalancer semantics unchanged.
-      version: 0.1.132
+      version: 0.1.133
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.132
+  version: 0.1.133
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,37 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.133 (#5074 #5065 #5059 Refs #3379 — step-08 ROLL-SET MINIMIZATION, the
+# root treadmill-breaker): the per-workload freshPullProof.excludeWorkloads list
+# was whack-a-mole — each prov surfaced ONE more infra workload broken by the
+# forced fresh-pull roll under the deny-egress hold (oauth2-proxy #5059 → falco
+# #5065 → the EVS CSI driver #5074). NEW: freshPullProof.rollSetMode="minimal"
+# (default; "full" keeps the legacy roll-everything sweep byte-for-byte).
+# Minimal mode excludes by RULE, not by name: (a) any workload in
+# freshPullProof.infraNamespaces (kube-system / huawei-evs-csi / catalyst)
+# unless explicitly named in infraRepresentativeAllowlist; (b) UNCONDITIONALLY
+# every DaemonSet in an infra namespace (its restart risks the hold's own
+# machinery: CSI mounts, CNI, the registry pivot — even an allowlist entry
+# cannot re-include one). It then rolls a REPRESENTATIVE SAMPLE instead of all
+# ~130 workloads: every candidate in representativeNamespaces (flux-system /
+# gitea / harbor / keycloak / grafana — one per registry-dependent workload
+# class: gitops, stateful-PVC git, the registry itself, auth, observability;
+# local-registry refs are candidates too, post-step-07 they are the pivoted
+# ordinary-app set) topped up with other candidate Deployments to at least
+# minRepresentativesPerRegion (default 12) x <node-region-count>. Image
+# locality for everything NOT rolled remains HARD-gated by the #4975 pre-hold
+# completeness HEAD gate + the #5026 pre-hold ref-host lint — both prove
+# locality WITHOUT rolling. The deny-egress curl call-home proof (github.com /
+# ghcr.io / harbor.openova.io / console must be 000) is UNTOUCHED in both
+# modes — that IS the sovereignty proof. The name-based excludeWorkloads list
+# stays honoured in BOTH modes for back-compat. New contract Case 56 locks the
+# behaviour (minimal excludes infra-ns DaemonSets + rolls the representative
+# set; full mode unchanged). NO step-count / job-mode / RBAC change (still 11
+# steps). NOTE #4982 Finding A (step-CMs resource-policy keep) was ALREADY
+# fixed in 0.1.117 (step/resolver CMs never carried keep; Case 40 guards it;
+# only the status CM self-sovereign-cutover-status keeps) — no change here.
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version
+# move to 0.1.133 in lockstep (Inviolable Principle #13).
+# ── prior ──
 # 0.1.132 (#5074 Refs #5014 #3379 — step-08 fresh-pull sweep rolled the EVS CSI
 # DRIVER itself and self-defeated the hold; caught live hw251): freshPullProof
 # (step-08's deny-egress fresh-pull sweep) rolled the Huawei EVS CSI driver
@@ -2045,7 +2077,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.132
+version: 0.1.133
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -171,6 +171,21 @@ data:
           # registry-pivot DS is the pivot mechanism itself — recursive).
           - name: FRESH_PULL_EXCLUDE_WORKLOADS
             value: {{ .Values.egressTest.freshPullProof.excludeWorkloads | default (list "catalyst/registry-pivot") | join " " | quote }}
+          # #5074/#5065/#5059 — principled roll-set. "minimal" (default) rolls
+          # a representative sample of ORDINARY APP workloads and excludes
+          # infra by RULE (namespaces + DaemonSets-in-infra-ns) instead of the
+          # name-by-name whack-a-mole; "full" keeps the legacy roll-everything
+          # sweep. See values.yaml egressTest.freshPullProof.rollSetMode.
+          - name: FRESH_PULL_ROLL_SET_MODE
+            value: {{ .Values.egressTest.freshPullProof.rollSetMode | default "minimal" | quote }}
+          - name: FRESH_PULL_INFRA_NAMESPACES
+            value: {{ .Values.egressTest.freshPullProof.infraNamespaces | default (list "kube-system" "huawei-evs-csi" "catalyst") | join " " | quote }}
+          - name: FRESH_PULL_INFRA_ALLOWLIST
+            value: {{ .Values.egressTest.freshPullProof.infraRepresentativeAllowlist | default (list) | join " " | quote }}
+          - name: FRESH_PULL_MIN_REPS_PER_REGION
+            value: {{ .Values.egressTest.freshPullProof.minRepresentativesPerRegion | default 12 | quote }}
+          - name: FRESH_PULL_REPRESENTATIVE_NAMESPACES
+            value: {{ .Values.egressTest.freshPullProof.representativeNamespaces | default (list "flux-system" "gitea" "harbor" "keycloak" "grafana") | join " " | quote }}
         volumeMounts:
           # #3379 (hw139, 2026-06-15): WRITABLE emptyDir at /work. The
           # container runs readOnlyRootFilesystem:true (securityContext
@@ -848,29 +863,44 @@ data:
             }
 
             run_fresh_pull_all() {
-              echo "[egress-block-test] #3695: rolling EVERY external-registry workload under deny-egress"
+              echo "[egress-block-test] #3695: fresh-pull roll under deny-egress (roll-set mode: ${FRESH_PULL_ROLL_SET_MODE:-minimal})"
               # Enumerate Deployments/DaemonSets/StatefulSets whose container
-              # images reference a host that is NOT the local registry. The
-              # local registry is identified by LOCAL_REGISTRY_SUBSTR
-              # (harbor.<fqdn>). We also exclude the cutover runner's own
-              # catalyst-api (FRESH_PULL_EXCLUDE) so the engine is never bounced
-              # mid-hold. Rows look like "kind ns name=img1,img2".
+              # images reference a dotted registry host. We also exclude the
+              # cutover runner's own catalyst-api (FRESH_PULL_EXCLUDE) so the
+              # engine is never bounced mid-hold. Rows look like
+              # "kind ns name=img1,img2".
               workloads=$(
                 for kind in deployments daemonsets statefulsets; do
                   kubectl get "${kind}" -A \
                     -o jsonpath="{range .items[*]}${kind%s} {.metadata.namespace} {.metadata.name}={.spec.template.spec.containers[*].image} {.spec.template.spec.initContainers[*].image}{\"\n\"}{end}" 2>/dev/null
                 done
               )
-              # Keep rows whose image list contains a NON-local registry host.
-              # A bare image (docker-library short form) or a localhost/local
-              # Harbor ref is NOT a tether. We treat any image containing a
-              # dotted host (registry) that does NOT include LOCAL_REGISTRY_SUBSTR
-              # as external.
-              targets=$(printf '%s\n' "${workloads}" \
-                | grep -E '=[^ ]*[a-z0-9.-]+\.[a-z]+/' \
-                | grep -vE "[=, ]${LOCAL_REGISTRY_SUBSTR}" \
-                | { [ -n "${FRESH_PULL_EXCLUDE}" ] && grep -vE " ${FRESH_PULL_EXCLUDE}[^ ]*=" || cat; } \
-                || true)
+              if [ "${FRESH_PULL_ROLL_SET_MODE:-minimal}" = "full" ]; then
+                # LEGACY full mode — unchanged behaviour: keep rows whose image
+                # list contains a NON-local registry host. A bare image
+                # (docker-library short form) or a localhost/local Harbor ref is
+                # NOT a tether. We treat any image containing a dotted host
+                # (registry) that does NOT include LOCAL_REGISTRY_SUBSTR as
+                # external, and roll ALL of them.
+                targets=$(printf '%s\n' "${workloads}" \
+                  | grep -E '=[^ ]*[a-z0-9.-]+\.[a-z]+/' \
+                  | grep -vE "[=, ]${LOCAL_REGISTRY_SUBSTR}" \
+                  | { [ -n "${FRESH_PULL_EXCLUDE}" ] && grep -vE " ${FRESH_PULL_EXCLUDE}[^ ]*=" || cat; } \
+                  || true)
+              else
+                # #5074/#5065/#5059 MINIMAL mode (default) — candidates are ALL
+                # image-registry-dependent workloads (dotted-host refs), local-
+                # registry refs INCLUDED: post-step-07 the ordinary-app refs are
+                # pivoted to registry.<fqdn> and rolling THOSE is exactly the
+                # fresh-pull-from-local-Harbor witness; redirect-covered external
+                # refs stay candidates too (they pull locally via the step-04
+                # containerd redirect). Rule-based infra exclusion + the
+                # representative sampling below then cut this to the minimal set.
+                targets=$(printf '%s\n' "${workloads}" \
+                  | grep -E '=[^ ]*[a-z0-9.-]+\.[a-z]+/' \
+                  | { [ -n "${FRESH_PULL_EXCLUDE}" ] && grep -vE " ${FRESH_PULL_EXCLUDE}[^ ]*=" || cat; } \
+                  || true)
+              fi
               # #4975 — never roll a workload the offline mirror deliberately
               # does NOT cover: xpkg.upbound.io (step-11 crossplane), rancher/k3s
               # (per-Org vcluster distro), loft-sh/vcluster (step-10). Rolling
@@ -890,11 +920,88 @@ data:
                 _wns="${_w%%/*}"; _wname="${_w##*/}"
                 targets=$(printf '%s\n' "${targets}" | grep -vE "^[a-z]+ ${_wns} ${_wname}=" || true)
               done
+              # ── #5074/#5065/#5059 MINIMAL ROLL-SET SELECTION ────────────
+              # Excludes infra by RULE instead of the per-workload
+              # excludeWorkloads whack-a-mole (each prov surfaced ONE more
+              # infra workload broken by the forced roll: oauth2-proxy #5059,
+              # falco #5065, the EVS CSI driver #5074):
+              #   (a) any workload in FRESH_PULL_INFRA_NAMESPACES is skipped
+              #       unless "<ns>/<name>" is in FRESH_PULL_INFRA_ALLOWLIST;
+              #   (b) a DaemonSet in an infra namespace is NEVER rolled —
+              #       even an allowlist entry cannot re-include one (its
+              #       restart risks the hold's own machinery: CSI mounts,
+              #       CNI, the registry pivot).
+              # Then a REPRESENTATIVE SAMPLE rolls instead of all ~130
+              # workloads: every candidate in the representative namespaces
+              # (stateful-PVC/gitops/auth/registry/observability classes) plus
+              # a top-up of other candidate Deployments to at least
+              # FRESH_PULL_MIN_REPS_PER_REGION x <node-region-count>. Image
+              # locality for everything NOT rolled remains HARD-gated by the
+              # #4975 pre-hold completeness HEAD gate + the #5026 ref-host
+              # lint (both ran above, both prove locality without rolling);
+              # the deny-egress call-home proof is untouched.
+              if [ "${FRESH_PULL_ROLL_SET_MODE:-minimal}" != "full" ]; then
+                : > /work/rollset_candidates.txt
+                printf '%s\n' "${targets}" | while IFS= read -r _row; do
+                  [ -z "${_row}" ] && continue
+                  _rkind=$(printf '%s' "${_row}" | awk '{print $1}')
+                  _rns=$(printf '%s' "${_row}" | awk '{print $2}')
+                  _rname=$(printf '%s' "${_row}" | awk '{print $3}' | cut -d= -f1)
+                  _infra=0
+                  for _in in ${FRESH_PULL_INFRA_NAMESPACES}; do
+                    [ "${_rns}" = "${_in}" ] && { _infra=1; break; }
+                  done
+                  if [ "${_infra}" = "1" ]; then
+                    if [ "${_rkind}" = "daemonset" ]; then
+                      echo "  skip (rule b: DaemonSet in infra namespace) ${_rkind} ${_rns}/${_rname}"
+                      continue
+                    fi
+                    _allow=0
+                    for _aw in ${FRESH_PULL_INFRA_ALLOWLIST}; do
+                      [ "${_rns}/${_rname}" = "${_aw}" ] && { _allow=1; break; }
+                    done
+                    if [ "${_allow}" != "1" ]; then
+                      echo "  skip (rule a: infra namespace, not allowlisted) ${_rkind} ${_rns}/${_rname}"
+                      continue
+                    fi
+                  fi
+                  printf '%s\n' "${_row}" >> /work/rollset_candidates.txt
+                done
+                # Region-aware sample floor: N per region (node
+                # topology.kubernetes.io/region labels; 1 when unlabeled).
+                _regions=$(kubectl get nodes \
+                  -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io/region}{"\n"}{end}' 2>/dev/null \
+                  | sort -u | grep -c . || true)
+                [ "${_regions:-0}" -ge 1 ] || _regions=1
+                _min_total=$(( ${FRESH_PULL_MIN_REPS_PER_REGION:-12} * _regions ))
+                # Every candidate in the representative namespaces rolls.
+                : > /work/rollset.txt
+                for _rns in ${FRESH_PULL_REPRESENTATIVE_NAMESPACES}; do
+                  awk -v ns="${_rns}" '$2 == ns' /work/rollset_candidates.txt >> /work/rollset.txt
+                done
+                _picked=$(grep -c . /work/rollset.txt || true)
+                if [ "${_picked}" -lt "${_min_total}" ]; then
+                  # Top up with other (non-representative-ns) candidate
+                  # Deployments, stable-sorted, to the floor. An empty
+                  # rollset.txt pattern file makes grep -v pass ALL candidate
+                  # rows (documented busybox/GNU behaviour used by the #3634
+                  # baseline diff above).
+                  grep -vxF -f /work/rollset.txt /work/rollset_candidates.txt 2>/dev/null \
+                    | awk '$1 == "deployment"' | sort \
+                    | head -n $(( _min_total - _picked )) >> /work/rollset.txt || true
+                fi
+                targets=$(cat /work/rollset.txt 2>/dev/null || true)
+                echo "  minimal roll-set selected: ${_picked} representative-namespace workload(s), floor ${_min_total} (regions=${_regions}); locality of every non-rolled workload is proven by the #4975 completeness HEAD gate + #5026 ref-host lint"
+              fi
               if [ -z "${targets}" ]; then
-                echo "  no external-registry workloads found — every workload already pulls from the local registry (PASS)"
+                if [ "${FRESH_PULL_ROLL_SET_MODE:-minimal}" = "full" ]; then
+                  echo "  no external-registry workloads found — every workload already pulls from the local registry (PASS)"
+                else
+                  echo "  minimal roll-set is EMPTY (no ordinary-app registry-dependent candidates) — locality already proven by the pre-hold completeness HEAD gate + ref-host lint (PASS)"
+                fi
                 return 0
               fi
-              echo "  external-registry workloads to roll:"
+              echo "  workloads to roll:"
               printf '%s\n' "${targets}" | sed 's/^/    /'
               rc=0
               # Roll each; collect the first failure but attempt all so the log
@@ -907,11 +1014,11 @@ data:
                 roll_and_check_workload "${kind}" "${ns}" "${name}" || echo "ROLL_FAIL ${kind}/${name}" >> /work/roll_failures.txt
               done
               if [ -s /work/roll_failures.txt ]; then
-                echo "  FAIL — external-registry workload(s) failed to roll under deny-egress:"
+                echo "  FAIL — workload(s) failed to roll under deny-egress:"
                 sed 's/^/    /' /work/roll_failures.txt
                 rc=1
               else
-                echo "  PASS — every external-registry workload rolled to Running pulling from the local registry under deny-egress (#3695)"
+                echo "  PASS — every rolled workload reached Running pulling from the local registry under deny-egress (#3695; roll-set mode ${FRESH_PULL_ROLL_SET_MODE:-minimal})"
               fi
               return "${rc}"
             }

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2264,4 +2264,123 @@ if ! grep -qF '"${svc_type}" = "LoadBalancer"' "$TMP/s04.yaml"; then
 fi
 echo "  PASS (#5007 contract: 200-branch splits on .spec.type — LB uses VIP-or-defer, non-LB pins HOST_IP like the hostNetwork branch)"
 
+# ── Case 56 (#5074 #5065 #5059): step-08 roll-set minimization ─────────────
+# The per-workload excludeWorkloads list was whack-a-mole (oauth2-proxy #5059
+# → falco #5065 → CSI drivers #5074). rollSetMode=minimal (NEW DEFAULT) must
+# exclude infra by RULE: (a) infra namespaces (kube-system/huawei-evs-csi/
+# catalyst) skip unless allowlisted, (b) DaemonSets in infra namespaces are
+# NEVER rolled — even when NOT in the name-based exclude list. It rolls a
+# representative sample (representativeNamespaces + Deployment top-up to the
+# per-region floor). rollSetMode=full must keep the LEGACY sweep unchanged:
+# every non-local-registry workload rolls, including infra DaemonSets.
+echo "[cutover-contract] Case 56: step-08 roll-set mode — minimal excludes infra-ns DaemonSets by RULE + rolls the representative sample; full mode legacy-unchanged (#5074 #5065 #5059)"
+# Static: the mode + rule knobs must reach the Job env with the new defaults.
+if ! grep -A1 'name: FRESH_PULL_ROLL_SET_MODE' "$TMP/render.yaml" | grep -q 'value: "minimal"'; then
+  echo "FAIL: freshPullProof.rollSetMode default must be \"minimal\" (#5074 #5065 #5059)" >&2
+  exit 1
+fi
+_infra_env=$(grep -A1 'name: FRESH_PULL_INFRA_NAMESPACES' "$TMP/render.yaml" | tail -1)
+for _ns in kube-system huawei-evs-csi catalyst; do
+  if ! grep -q "$_ns" <<<"$_infra_env"; then
+    echo "FAIL: FRESH_PULL_INFRA_NAMESPACES default must carry $_ns (#5074)" >&2
+    exit 1
+  fi
+done
+if ! grep -A1 'name: FRESH_PULL_MIN_REPS_PER_REGION' "$TMP/render.yaml" | grep -q 'value: "12"'; then
+  echo "FAIL: freshPullProof.minRepresentativesPerRegion default must be 12 (#5065)" >&2
+  exit 1
+fi
+_reps_env=$(grep -A1 'name: FRESH_PULL_REPRESENTATIVE_NAMESPACES' "$TMP/render.yaml" | tail -1)
+for _ns in flux-system gitea harbor keycloak grafana; do
+  if ! grep -q "$_ns" <<<"$_reps_env"; then
+    echo "FAIL: FRESH_PULL_REPRESENTATIVE_NAMESPACES default must span $_ns (#5065)" >&2
+    exit 1
+  fi
+done
+# Behavioral: slice run_fresh_pull_all, stub roll_and_check_workload, mock
+# kubectl enumeration. Fixture (all classes): local-ref ordinary apps in the
+# representative namespaces (gitea/flux-system/harbor/keycloak) + a non-rep
+# local-ref Deployment (orgapp/web, the top-up) + infra-namespace workloads
+# that are NOT name-excluded (the whole point: the RULE must catch them) —
+# huawei-evs-csi/csi-evs-node DS, kube-system/hcloud-csi-node DS,
+# kube-system/hubble-ui-oauth2-proxy Deploy, catalyst/some-operator Deploy —
+# + a non-infra DaemonSet (falco/falco) that minimal's Deployment-only top-up
+# must not add.
+_c56="$TMP/rollset56"; mkdir -p "$_c56/bin" "$_c56/work"
+helm template smoke . --show-only templates/08-egress-block-test-job.yaml > "$TMP/r08c56.yaml"
+_slice_fn "$TMP/r08c56.yaml" run_fresh_pull_all | sed 's#/work/#'"$_c56"'/work/#g' > "$_c56/sweep.sh"
+if ! grep -q 'run_fresh_pull_all() {' "$_c56/sweep.sh"; then
+  echo "FAIL: could not slice run_fresh_pull_all from step-08 (#5074)" >&2; exit 1
+fi
+cat > "$_c56/bin/kubectl" <<'MOCK'
+#!/bin/sh
+if [ "$2" = "nodes" ]; then printf 'af-north-1\naf-north-1\n'; exit 0; fi
+if [ "$3" = "-A" ]; then
+  case "$2" in
+    deployments)
+      printf 'deployment gitea gitea=registry.t99.omani.works/proxy-ghcr/go-gitea/gitea:1.22 \n'
+      printf 'deployment flux-system source-controller=registry.t99.omani.works/proxy-ghcr/fluxcd/source-controller:v1.3 \n'
+      printf 'deployment harbor harbor-core=registry.t99.omani.works/proxy-dockerhub/goharbor/harbor-core:v2.11 \n'
+      printf 'deployment kube-system hubble-ui-oauth2-proxy=quay.io/oauth2_proxy/oauth2-proxy:v7.6 \n'
+      printf 'deployment catalyst some-operator=registry.t99.omani.works/openova-io/op:1.0 \n'
+      printf 'deployment orgapp web=registry.t99.omani.works/proxy-dockerhub/library/nginx:1.27 \n'
+      ;;
+    daemonsets)
+      printf 'daemonset huawei-evs-csi csi-evs-node=harbor.openova.io/proxy-swr/csi-evs:v2.1 \n'
+      printf 'daemonset kube-system hcloud-csi-node=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9 \n'
+      printf 'daemonset falco falco=registry.t99.omani.works/proxy-dockerhub/falcosecurity/falco:0.38 \n'
+      ;;
+    statefulsets)
+      printf 'statefulset keycloak keycloak=registry.t99.omani.works/proxy-quay/keycloak/keycloak:26.0 \n'
+      ;;
+  esac
+  exit 0
+fi
+exit 0
+MOCK
+chmod +x "$_c56/bin/kubectl"
+_run56() { # $1 = FRESH_PULL_ROLL_SET_MODE
+  ( set +e; set -u
+    export PATH="$_c56/bin:$PATH"
+    export FRESH_PULL_ROLL_SET_MODE="$1"
+    export LOCAL_REGISTRY_SUBSTR="registry.t99.omani.works"
+    export FRESH_PULL_EXCLUDE="catalyst-api"
+    export EXCLUDED_HOSTS="xpkg.upbound.io"
+    export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
+    # Deliberately ONLY the historic default — the infra CSI/oauth2-proxy
+    # fixtures are NOT name-excluded, so only the minimal-mode RULE can skip
+    # them (the whole Case).
+    export FRESH_PULL_EXCLUDE_WORKLOADS="catalyst/registry-pivot"
+    export FRESH_PULL_INFRA_NAMESPACES="kube-system huawei-evs-csi catalyst"
+    export FRESH_PULL_INFRA_ALLOWLIST=""
+    export FRESH_PULL_MIN_REPS_PER_REGION="12"
+    export FRESH_PULL_REPRESENTATIVE_NAMESPACES="flux-system gitea harbor keycloak grafana"
+    . "$_c56/sweep.sh"
+    roll_and_check_workload() { echo "ROLLED $1 $2/$3"; return 0; }
+    : > "$_c56/work/roll_failures.txt"
+    run_fresh_pull_all; echo "RC=$?" )
+}
+# (i) minimal mode — infra excluded by RULE, representative sample rolled.
+_min_out=$(_run56 minimal)
+grep -q 'RC=0' <<<"$_min_out" || { printf 'FAIL: minimal-mode sweep did not PASS; output:\n%s\n' "$_min_out" >&2; exit 1; }
+for _want in 'ROLLED deployment gitea/gitea' 'ROLLED deployment flux-system/source-controller' 'ROLLED deployment harbor/harbor-core' 'ROLLED statefulset keycloak/keycloak' 'ROLLED deployment orgapp/web'; do
+  grep -qF "$_want" <<<"$_min_out" || { printf 'FAIL: minimal mode did not roll the representative workload (%s); output:\n%s\n' "$_want" "$_min_out" >&2; exit 1; }
+done
+for _never in 'ROLLED daemonset huawei-evs-csi/csi-evs-node' 'ROLLED daemonset kube-system/hcloud-csi-node' 'ROLLED deployment kube-system/hubble-ui-oauth2-proxy' 'ROLLED deployment catalyst/some-operator' 'ROLLED daemonset falco/falco'; do
+  grep -qF "$_never" <<<"$_min_out" && { printf 'FAIL: minimal mode rolled an infra/non-representative workload it must exclude by RULE (%s) (#5074 #5065 #5059); output:\n%s\n' "$_never" "$_min_out" >&2; exit 1; }
+done
+grep -q 'skip (rule b: DaemonSet in infra namespace) daemonset huawei-evs-csi/csi-evs-node' <<<"$_min_out" \
+  || { printf 'FAIL: minimal mode did not name the rule-b skip for the infra-ns CSI DaemonSet; output:\n%s\n' "$_min_out" >&2; exit 1; }
+# (ii) full mode — LEGACY unchanged: every non-local-registry workload rolls
+# (including the infra DaemonSets the minimal rule excludes); local-registry
+# refs are NOT rolled.
+_full_out=$(_run56 full)
+grep -q 'RC=0' <<<"$_full_out" || { printf 'FAIL: full-mode sweep did not PASS; output:\n%s\n' "$_full_out" >&2; exit 1; }
+for _want in 'ROLLED daemonset huawei-evs-csi/csi-evs-node' 'ROLLED daemonset kube-system/hcloud-csi-node' 'ROLLED deployment kube-system/hubble-ui-oauth2-proxy'; do
+  grep -qF "$_want" <<<"$_full_out" || { printf 'FAIL: full (legacy) mode no longer rolls every external-registry workload (%s missing — legacy behaviour changed); output:\n%s\n' "$_want" "$_full_out" >&2; exit 1; }
+done
+grep -qF 'ROLLED deployment flux-system/source-controller' <<<"$_full_out" \
+  && { printf 'FAIL: full (legacy) mode rolled a LOCAL-registry-ref workload — legacy external-only selection changed; output:\n%s\n' "$_full_out" >&2; exit 1; }
+echo "  PASS (minimal: infra-ns DaemonSets + non-allowlisted infra workloads excluded by rule, representative sample rolled incl. Deployment top-up; full: legacy external-registry sweep byte-identical)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1228,6 +1228,62 @@ egressTest:
       - "huawei-evs-csi/csi-evs-controller"
       - "kube-system/hcloud-csi-node"
       - "kube-system/hcloud-csi-controller"
+    # ── #5074/#5065/#5059 ROLL-SET MODE (the treadmill-breaker) ──────────
+    # The per-workload excludeWorkloads list above is whack-a-mole: each prov
+    # surfaced ONE more infra workload that breaks when force-rolled under the
+    # deny-egress hold (oauth2-proxy #5059 → falco #5065 → CSI drivers #5074).
+    # "minimal" (the new default) replaces name-by-name exclusion with a RULE:
+    # the forced fresh-pull roll targets only ORDINARY APP workloads —
+    #   (a) nothing in infraNamespaces (kube-system / huawei-evs-csi /
+    #       catalyst) unless explicitly named in infraRepresentativeAllowlist;
+    #   (b) NEVER a DaemonSet in an infra namespace (its restart risks the
+    #       hold's own machinery: CSI mounts, CNI, the registry pivot) — rule
+    #       (b) is unconditional, an allowlist entry cannot re-include one;
+    # and rolls a REPRESENTATIVE SAMPLE rather than all ~130 workloads: every
+    # candidate in representativeNamespaces (the stateful-PVC / gitops / auth /
+    # registry / observability classes: flux-system, gitea, harbor, keycloak,
+    # grafana) plus a top-up of other candidate Deployments to at least
+    # minRepresentativesPerRegion x <node-region-count>. Image locality for
+    # everything NOT rolled stays HARD-gated by the #4975 pre-hold completeness
+    # HEAD gate (every workload image HEADed against local Harbor) + the #5026
+    # pre-hold ref-host lint (every pod-spec ref host local or step-04
+    # redirect-covered) — both prove locality WITHOUT rolling. The deny-egress
+    # curl call-home proof (github/ghcr/harbor.openova.io/console must be
+    # unreachable) is UNTOUCHED in both modes — that is the sovereignty proof.
+    # "full" keeps the legacy behaviour byte-for-byte: roll EVERY workload
+    # whose pod-spec references a non-local registry host, minus the
+    # name-based excludeWorkloads above (which stay honoured in BOTH modes
+    # for back-compat).
+    rollSetMode: "minimal"
+    # Namespaces treated as INFRA by minimal mode's rule (a)/(b). These host
+    # the hold's own machinery (CNI/CSI/oauth2-proxy sidecars in kube-system,
+    # the EVS CSI driver, the cutover engine + registry-pivot in catalyst).
+    infraNamespaces:
+      - "kube-system"
+      - "huawei-evs-csi"
+      - "catalyst"
+    # Explicit "<ns>/<name>" workloads inside infraNamespaces that minimal
+    # mode MAY still roll (a representative infra Deployment, if an operator
+    # wants one proven by roll). Empty by default. DaemonSets in infra
+    # namespaces are excluded UNCONDITIONALLY (rule b) even if listed here.
+    infraRepresentativeAllowlist: []
+    # Floor of the representative sample, PER REGION (node
+    # topology.kubernetes.io/region labels; 1 when unlabeled). If the
+    # representativeNamespaces candidates number fewer than
+    # minRepresentativesPerRegion x regions, minimal mode tops the roll set
+    # up with other (non-infra) candidate Deployments to the floor.
+    minRepresentativesPerRegion: 12
+    # Namespaces whose candidate workloads are ALWAYS in the minimal roll
+    # set — one per image-registry-dependent workload class: gitops engine
+    # (flux-system), stateful-PVC git (gitea), the registry itself (harbor),
+    # auth (keycloak), observability (grafana — the bootstrap-kit slot-25
+    # targetNamespace; the task-name "grafana-stack" class).
+    representativeNamespaces:
+      - "flux-system"
+      - "gitea"
+      - "harbor"
+      - "keycloak"
+      - "grafana"
   # #5026 — PRE-HOLD ref-host lint (treadmill-breaker). The completeness gate
   # above proves image CONTENT is in local Harbor; this lint proves every
   # rolled workload's pod-spec image REF HOST is the local registry

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.132"
+    version: "0.1.133"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Summary

**bp-self-sovereign-cutover 0.1.132 → 0.1.133 — step-08 roll-set minimization (the root treadmill-breaker).**

The step-08 fresh-pull sweep's per-workload `freshPullProof.excludeWorkloads` list was whack-a-mole: each prov surfaced ONE more infra workload breaking when force-rolled under the deny-egress hold — `kube-system/hubble-ui-oauth2-proxy` (#5059), `falco/falco` (#5065), the EVS CSI driver (#5074, live hw251: NodeStage desync → every stateful EVS-PVC workload failed mount). This PR replaces name-by-name exclusion with a principled, rule-based roll-set.

## What changed

New values knob `egressTest.freshPullProof.rollSetMode`:

- **`"minimal"` (new default)** — excludes infra by RULE, not by name:
  - **(a)** any workload in `infraNamespaces` (`kube-system`, `huawei-evs-csi`, `catalyst`) is skipped unless explicitly named in `infraRepresentativeAllowlist` (empty by default);
  - **(b)** **UNCONDITIONALLY** every DaemonSet in an infra namespace — its restart risks the hold's own machinery (CSI mounts, CNI, the registry pivot); even an allowlist entry cannot re-include one.

  Rolls a **representative sample** instead of all ~130 workloads: every candidate in `representativeNamespaces` (`flux-system`/`gitea`/`harbor`/`keycloak`/`grafana` — one per registry-dependent workload class: gitops engine, stateful-PVC git, the registry itself, auth, observability; NB the deployed grafana-stack namespace is `grafana` per bootstrap-kit slot 25), topped up with other candidate Deployments to at least `minRepresentativesPerRegion` (default 12) × node-region-count. Local-registry refs are candidates too — post-step-07 they ARE the pivoted ordinary-app set, and rolling them is exactly the fresh-pull-from-local-Harbor witness.

- **`"full"`** — the legacy roll-every-external-registry-workload sweep, byte-for-byte unchanged.

**Unchanged hard gates (both modes):** the #4975 pre-hold completeness HEAD gate (every workload image HEADed against local Harbor) + the #5026 pre-hold ref-host lint (every pod-spec ref host local or step-04 redirect-covered) keep proving image locality for everything NOT rolled — without rolling. The deny-egress curl call-home proof (github.com / ghcr.io / harbor.openova.io / console must be 000) is UNTOUCHED — that IS the sovereignty proof. The name-based `excludeWorkloads` list stays honoured in BOTH modes for back-compat.

## #4982 — already fixed on main (no change shipped)

The dispatch also named #4982 Finding A (step-CMs `helm.sh/resource-policy: keep` making chart-fix bumps inert mid-cutover). **Verified already fixed on main in chart 0.1.117** — commit `df0d135f6` (PR #4983): the per-step + resolver ConfigMaps never carried `keep` (the hw239 0.1.114 stickiness was the unsettled-env symptom, Finding B, fixed by the same PR's step-03 settled-roll pre-flight); contract **Case 40** guards the invariant; only the status CM `self-sovereign-cutover-status` keeps its `keep` (it is state, not re-renderable config — dropping it would lose mid-cutover progress). Runner consumption is by label selector (`bp.openova.io/cutover-order`), so CM-name versioning would have broken step discovery — the shipped drop-keep option was the correct least-invasive one. No re-fix needed; evidence above.

## Contract coverage

New **Case 56** (mocked-kubectl behavioral test on the sliced `run_fresh_pull_all`):
1. `rollSetMode=minimal` excludes infra-ns DaemonSets (`huawei-evs-csi/csi-evs-node`, `kube-system/hcloud-csi-node`) + non-allowlisted infra workloads (`kube-system/hubble-ui-oauth2-proxy`, `catalyst/some-operator`) **even when NOT in the name-based exclude list**, and rolls the representative sample (gitea/flux-system/harbor/keycloak + Deployment top-up).
2. Legacy `full` mode unchanged: still rolls every external-registry workload (including infra DaemonSets), never a local-ref one.

## 4-surface lockstep → 0.1.133

- `platform/self-sovereign-cutover/chart/Chart.yaml`
- `platform/self-sovereign-cutover/blueprint.yaml`
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`

Repo-wide grep for `0.1.132` confirms no remaining pin outside docs/ledger history.

## Gates (all green)

- `bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` → exit 0, `[cutover-contract] All gates green.` (56 cases incl. new Case 56)
- `helm lint platform/self-sovereign-cutover/chart` → `1 chart(s) linted, 0 chart(s) failed`
- `go test ./...` in `tests/e2e/bootstrap-kit` → `ok` (incl. `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts`: 75 pins compared, none behind; and `TestBootstrapKit_BlueprintVersionLockstepSweep`)

NO step-count / job-mode / RBAC change (still 11 steps, step 04 daemonset-wait).

**TRAIN: merge only as part of the assembled keystone train (founder release-train rule).**

Refs #5074
Refs #5065
Refs #5059
Refs #4982
Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
