### PR TITLE
fix(cloudinit): kubelet image-GC guard against the self-hosting image deadlock (Refs #4858)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1259,11 +1259,42 @@ runcmd:
   # deadlocks. A belt-and-braces Kyverno ENFORCE policy (bp-kyverno-policies
   # K23 forbid-local-path-storage) additionally DENIES any PVC/StorageClass/PV
   # that references local-path. (founder: "local path never ever ALLOWED".)
+  #
+  # #4858 kubelet image-GC guard — the self-hosting image deadlock. On the
+  # mothership (2026-07-08) DiskPressure pushed the node to the kubelet
+  # eviction wall (imagefs.available<15%), where the eviction manager purges
+  # EVERY unused image — including the locally-hosted Harbor's OWN component
+  # images — so all harbor.openova.io-prefixed workloads (Harbor itself +
+  # pdns-pg → PowerDNS → global sovereign DNS SERVFAIL) went ImagePullBackOff
+  # with nothing left to serve the re-pull. Post-cutover every Sovereign
+  # serves its workload images from its LOCAL Harbor (step 03 harbor-prewarm
+  # + step 04 registry-pivot), so every node here carries the same circular
+  # dependency. Guard, in the k3s kubelet leg (kubelet defaults in parens):
+  #   image-gc-high-threshold=70 (85) — periodic image-GC starts at 70% disk,
+  #     15 points BEFORE the eviction wall, so reclamation is early and
+  #     incremental (LRU order, stops at the low threshold) instead of a
+  #     pressure-driven mass purge. In-use images are never GC'd, and a
+  #     briefly-bouncing bootstrap-critical pod's image is at the BACK of the
+  #     LRU line — unlike eviction reclaim, which takes everything unused.
+  #   image-gc-low-threshold=60 (80) — reclaim down to 60%, real headroom for
+  #     the image-pull churn of a catalyst-api/platform roll (the #4858
+  #     DiskPressure source) instead of the default 5-point shave.
+  #   minimum-image-ttl-duration=2h (2m) — a JUST-PULLED image (age counted
+  #     from first detection) can't be reaped before its pod starts, so a
+  #     roll on a filling disk can't pull→GC→re-pull thrash. Long-resident
+  #     unused layers are past the TTL and stay reclaimable, so a genuinely
+  #     filling disk still frees space at the 70% trigger.
+  # Same guard on the worker templates (both providers) — Harbor/PowerDNS
+  # operands schedule on workers too. Refs #4849 (same disk-fill class).
+  # BYTE BUDGET: the 3-region Hetzner render sat 34 B under the 32512
+  # guardrail, so the ~123 B of kubelet args are paid for by shortening
+  # log-only strings (the two k3s FATAL echoes below + two prepull log
+  # lines) — exit codes 86/87 and every sentinel file are unchanged.
   - |
     NODE_EXTERNAL_IP=$(${node_external_ip_cmd})
-    [ -n "$${NODE_EXTERNAL_IP}" ] || { echo "[k3s] FATAL: could not determine node external IP" >&2; exit 87; }
+    [ -n "$${NODE_EXTERNAL_IP}" ] || { echo "[k3s] FATAL: no external IP" >&2; exit 87; }
     NODE_IP=$(${node_ip_cmd})
-    [ -n "$${NODE_IP}" ] || { echo "[k3s] FATAL: could not determine node private IP" >&2; exit 86; }
+    [ -n "$${NODE_IP}" ] || { echo "[k3s] FATAL: no private IP" >&2; exit 86; }
     # Substitute the runtime-detected private IP into the cilium values +
     # bootstrap-kit substitute map (the NODE_IP_PLACEHOLDER sentinel) so Cilium
     # reaches its OWN apiserver on a real address on every cloud.
@@ -1271,7 +1302,7 @@ runcmd:
     curl -sfL https://get.k3s.io | \
       INSTALL_K3S_VERSION=${k3s_version} \
       K3S_TOKEN=${k3s_token} \
-      INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --disable=local-storage --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=$${NODE_IP} --node-external-ip=$${NODE_EXTERNAL_IP} --advertise-address=$${NODE_IP} --kubelet-arg=max-pods=220 --tls-san=${sovereign_fqdn} --tls-san=$${NODE_IP} --tls-san=$${NODE_EXTERNAL_IP} --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} ${k3s_extra_args} --write-kubeconfig-mode=0644" \
+      INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --disable=local-storage --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=$${NODE_IP} --node-external-ip=$${NODE_EXTERNAL_IP} --advertise-address=$${NODE_IP} --kubelet-arg=max-pods=220 --kubelet-arg=image-gc-high-threshold=70 --kubelet-arg=image-gc-low-threshold=60 --kubelet-arg=minimum-image-ttl-duration=2h --tls-san=${sovereign_fqdn} --tls-san=$${NODE_IP} --tls-san=$${NODE_EXTERNAL_IP} --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} ${k3s_extra_args} --write-kubeconfig-mode=0644" \
       sh -
 
   # Wait for the API server to be reachable (Cilium comes up later, so we
@@ -1509,7 +1540,7 @@ runcmd:
   - |
     nohup sh -c '
       log=/var/lib/catalyst/prepull.log
-      echo "[prepull] $(date -u +%FT%TZ) starting background openova-io image pre-pull (#4049 fallback — warm path is primary)" >> "$log" 2>&1
+      echo "[prepull] $(date -u +%FT%TZ) background image pre-pull start (#4049)" >> "$log" 2>&1
       CRICTL="$(command -v crictl || echo /usr/local/bin/crictl)"
       HELM="$(command -v helm || echo /usr/local/bin/helm)"
       if [ ! -x "$CRICTL" ] || [ ! -x "$HELM" ]; then
@@ -1543,7 +1574,7 @@ runcmd:
           | sort -u)"
       fi
       if [ -z "$images" ]; then
-        echo "[prepull] no openova-io images resolved from chart render — nothing to pre-pull (kubelet pulls on demand)" >> "$log" 2>&1
+        echo "[prepull] no images resolved — skip (kubelet pulls on demand)" >> "$log" 2>&1
         rm -rf "$workdir" 2>/dev/null || true
         exit 0
       fi

--- a/infra/providers/hetzner/cloudinit-worker.tftpl
+++ b/infra/providers/hetzner/cloudinit-worker.tftpl
@@ -185,7 +185,14 @@ runcmd:
   # 45-HR install chain → Helm hooks → bp-* runtime pods). Caught on
   # prov #63 (cpx52 × 3): CP at 110/110 pods, bp-catalyst-platform's
   # catalyst-api pod stuck "Too many pods" → install hook timed out.
-  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_URL=https://${cp_private_ip}:6443 K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="agent --kubelet-arg=max-pods=220 --node-label catalyst.openova.io/role=worker" sh -'
+  #
+  # #4858 kubelet image-GC guard (image-gc 70/60 + image TTL 2h): start
+  # periodic image-GC 15 points before the DiskPressure eviction wall so the
+  # eviction manager's mass image-purge — which reaps the locally-hosted
+  # Harbor's OWN images and deadlocks every harbor-prefixed re-pull — can
+  # never fire. Post-cutover Harbor/PowerDNS operands schedule on workers
+  # too. Full rationale in _shared/cloudinit-control-plane.tftpl (k3s leg).
+  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_URL=https://${cp_private_ip}:6443 K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="agent --kubelet-arg=max-pods=220 --kubelet-arg=image-gc-high-threshold=70 --kubelet-arg=image-gc-low-threshold=60 --kubelet-arg=minimum-image-ttl-duration=2h --node-label catalyst.openova.io/role=worker" sh -'
   - mkdir -p /var/lib/catalyst
   - touch /var/lib/catalyst/cloud-init-complete
 final_message: "Catalyst worker bootstrap complete after $UPTIME seconds"

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -215,6 +215,8 @@ runcmd:
       echo "openova-k3s-agent-install: k3s-agent already active; nothing to do"
       exit 0
     fi
+    # #4858 image-GC guard flags (70/60 + TTL 2h) — rationale in
+    # _shared/cloudinit-control-plane.tftpl (k3s leg).
     # Install via canonical k3s installer (resolves get.k3s.io → fetches
     # binary → systemd unit). Each attempt exits 0 only if both curl|sh
     # and the post-install agent registration succeed.
@@ -222,7 +224,7 @@ runcmd:
       INSTALL_K3S_VERSION=${k3s_version} \
       K3S_TOKEN=${k3s_token} \
       K3S_URL=https://${cp_private_ip}:6443 \
-      INSTALL_K3S_EXEC="agent --node-label=catalyst.openova.io/provider=huawei --node-label=openova.io/region=hw-${region}-rtz-prod --node-label=topology.kubernetes.io/region=${region} --node-label=topology.kubernetes.io/zone=${region}" \
+      INSTALL_K3S_EXEC="agent --kubelet-arg=image-gc-high-threshold=70 --kubelet-arg=image-gc-low-threshold=60 --kubelet-arg=minimum-image-ttl-duration=2h --node-label=catalyst.openova.io/provider=huawei --node-label=openova.io/region=hw-${region}-rtz-prod --node-label=topology.kubernetes.io/region=${region} --node-label=topology.kubernetes.io/zone=${region}" \
       sh -; then
       echo "openova-k3s-agent-install: get.k3s.io install step failed; exiting nonzero for systemd retry"
       exit 1


### PR DESCRIPTION
Refs #4858 (item 3 — the DiskPressure headroom / GC guard). Refs #4849 (same disk-fill class).

## Problem

Mothership incident 2026-07-08: DiskPressure drove the node to the kubelet eviction wall (default `imagefs.available<15%`), where the eviction manager purges **every unused image** — including the locally-hosted Harbor's OWN component images — so every `harbor.openova.io`-prefixed workload (Harbor itself + `pdns-pg` → PowerDNS → **global sovereign DNS SERVFAIL**) went ImagePullBackOff with nothing left to serve the re-pull. Item 1 (upstream-pinning the mothership's bootstrap-critical images) landed in openova-private#842; item 2 (registries.yaml mirror-with-rewrite) was ruled out there. This PR is the remaining durable leg: kubelet image-GC tuning in the k3s config leg of cloud-init — and it protects **Sovereigns too**, since post-cutover every Sovereign self-hosts its images from its local Harbor (steps 03/04) and carries the identical circular dependency on every node.

## Fix — k3s kubelet leg (shared CP template + both providers' worker templates)

| kubelet arg | default | now | why |
|---|---|---|---|
| `image-gc-high-threshold` | 85 | **70** | periodic LRU image-GC starts 15 points BEFORE the eviction wall — early + incremental, never a pressure-driven mass purge (which is what reaps the self-hosted registry's own images) |
| `image-gc-low-threshold` | 80 | **60** | reclaim to 60% — real headroom for the image-pull churn of a catalyst-api/platform roll (the suspected #4858 DiskPressure source) |
| `minimum-image-ttl-duration` | 2m | **2h** | a just-pulled image (age from first detection) can't be reaped before its pod starts — no pull→GC→re-pull thrash mid-roll; long-resident unused layers stay reclaimable |

## Byte budget (Hetzner 3-region CP guardrail 32512)

Baseline main sat **34 B** under the guardrail; the ~123 B of kubelet args are paid for by shortening four **log-only** strings (two `[k3s] FATAL` echoes, two `[prepull]` log lines — exit codes 86/87 and every sentinel file unchanged). Net single-region CP render: 23840 → **23829 B (−11 vs main)**, so the 3-region render gains headroom.

## Coordination note (#5042)

Another agent is concurrently editing the **flux-install leg** of `infra/providers/_shared/cloudinit-control-plane.tftpl`. This PR touches only the **k3s install leg** (kubelet args + its comment block) and two `[prepull]` log strings in the pre-pull leg — no overlap with the flux-install/gateway-api legs, so any merge conflict is trivial.

## Gates (exact results)

- `tofu test` infra/providers/hetzner: **12 passed, 0 failed** (incl. `three_region_mgmt_fsn_hel` byte-guardrail precondition)
- `tofu test` infra/providers/huawei: **7 passed, 0 failed**
- `tofu test` infra/providers/_shared/tests: **2 passed, 0 failed**
- `scripts/cloudinit-size-check.sh both`: **6/6 surfaces PASS** (hetzner CP 23829/32256, worker 4885/30720; huawei CP 26939/32256, worker 6211/30720)
- `scripts/lint-cloudinit.sh both` (`dash -n`): **hetzner 26/26 + huawei 28/28 runcmd items PASS**

TRAIN: merge only as part of the assembled keystone train (founder release-train rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)