### PR TITLE
fix(cloud-init): #5042 prevention — flux-install gated on servable flux CRDs + fail-path cloudinit-log push

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -384,6 +384,40 @@ write_files:
       type: Opaque
       data:
         public.jwk: ${base64encode(handover_jwt_public_key)}
+%{ if provider == "huawei" ~}
+
+  # ── #5042(b): fail-loud sentinel + cloud-init-log push helper — CALLED on
+  # every post-PUT fail-loud runcmd exit (91/92/93/94/95) + once on success
+  # after the cloud-init-complete marker. Touches the named sentinel, echoes
+  # it into the log, then PUSHES /var/log/cloud-init-output.log to the
+  # mothership. kom4dc CPs have NO console-output API and no reachable sshd,
+  # so a runcmd leg that died AFTER the huawei prelude's ~50-min background-
+  # uploader window (main.tf provider_prelude_huawei, #3132/#5068) was
+  # forensic-blind — hw247: flux CRDs absent, GET cloudinit-log 404.
+  # The sentinel arg is echoed BEFORE the upload so the pushed log NAMES the
+  # dead leg; sleep 1 lets the runcmd tee flush that line into
+  # cloud-init-output.log before the upload reads the file. -4: the IPv4-only
+  # kom4dc VPC would otherwise dial the AAAA and the push dies silently
+  # (#5068). 0700 root-only — the body embeds the bearer token. Callers append
+  # `||true` so a helper failure can never mask the leg's own fail-loud exit
+  # code (no `|| true` inside — the caller guards). WHOLLY HUAWEI-GATED — a
+  # hard cloud dependency, same class as the prelude uploader: Hetzner keeps
+  # sshd + a console API for forensics AND its three_region CP render sits
+  # ~200 B under the 32512 guardrail — these bytes would tip it (the 32768
+  # hard cap bricks the prov, so cut, never raise). The fail sites below keep
+  # their plain `touch` sentinel on Hetzner. The pre-PUT exits (86/87, minute
+  # ~2) intentionally do NOT call mark: they always land inside the huawei
+  # background-uploader window, which starts BEFORE k3s and pushes every 30s.
+  - path: /var/lib/catalyst/mark
+    permissions: '0700'
+    content: |
+      touch "/var/lib/catalyst/$1"
+      echo "CLOUDINIT-SENTINEL: $1"
+%{ if deployment_id != "" && kubeconfig_bearer_token != "" && catalyst_api_url != "" ~}
+      sleep 1
+      curl -4 -sk -X PUT -H "Authorization: Bearer ${kubeconfig_bearer_token}" -H "Content-Type: text/plain" --data-binary @/var/log/cloud-init-output.log --max-time 20 "${catalyst_api_url}/api/v1/deployments/${deployment_id}/cloudinit-log" >/dev/null 2>&1
+%{ endif ~}
+%{ endif ~}
 
   # ── Cilium Helm values (one structured file; same on every cloud) ─────
   # kubeProxyReplacement + gateway-api + envoy + wireguard node-encryption.
@@ -1307,7 +1341,7 @@ runcmd:
   # ONE shell so KUBECONFIG is exported once — keeps the byte-tight Hetzner render.
   - |
     export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-    for i in 1 2 3 4 5; do kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml && break; [ "$i" = 5 ] && { touch /var/lib/catalyst/gwapi-apply-FAILED; exit 95; }; sleep 15; done
+    for i in 1 2 3 4 5; do kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml && break; [ "$i" = 5 ] && { %{ if provider == "huawei" }sh /var/lib/catalyst/mark gwapi-apply-FAILED||true%{ else }touch /var/lib/catalyst/gwapi-apply-FAILED%{ endif }; exit 95; }; sleep 15; done
     kubectl wait --for=condition=Established crd/tlsroutes.gateway.networking.k8s.io --timeout=60s
 
   # ── Cilium CNI: helm upgrade --install + retry/fail-fast (#4503) ───────
@@ -1333,7 +1367,7 @@ runcmd:
     rt helm repo add cilium https://helm.cilium.io/
     rt helm repo update
     rt helm upgrade --install cilium cilium/cilium --version 1.19.3 -n kube-system -f /var/lib/catalyst/cilium-values.yaml
-    rt kubectl -n kube-system rollout status ds/cilium --timeout=240s || { echo no-cni >/var/lib/catalyst/cilium-bootstrap-FAILED;exit 91;}
+    rt kubectl -n kube-system rollout status ds/cilium --timeout=240s || { %{ if provider == "huawei" }sh /var/lib/catalyst/mark cilium-bootstrap-FAILED||true;%{ else }echo no-cni >/var/lib/catalyst/cilium-bootstrap-FAILED;%{ endif }exit 91;}
 %{ if provider == "huawei" ~}
   # #4503 root cause (Huawei-gated note; the byte budget is Hetzner-only): on
   # the IPv4-only kom4dc path a single transient failure of get-helm-3 /
@@ -1564,7 +1598,16 @@ runcmd:
 %{ endif ~}
 
   # ── Flux install + the apiserver-side bootstrap secrets ───────────────
-  # #5042: flux legs retried+sentinel'd (were single-shot -> a CDN miss wedged bootstrap forensically-blind, hw247/hw249; mirrors #4503/#4513)
+  # #5042(a): the install leg is IDEMPOTENT and gated on the flux CRDs being
+  # SERVABLE (kubectl get crd helmreleases.helm.toolkit.fluxcd.io) — NOT on a
+  # single kubectl-apply exit 0. hw247 proved the wedge mode: cilium up, flux
+  # CRDs absent, phase1-watching forever. The apply retries with bounded
+  # linear backoff (10 tries, sleep n*10s ≈ 9m10s of sleep + curl --max-time 60
+  # per try, ~20m worst case) to ride out the #3232/#3829 github/ghcr
+  # transient-DNS class instead of the old 5x15s ~75s window; a re-run of
+  # cloud-init short-circuits on the first CRD probe. Exhaustion stays
+  # fail-loud (the mark helper touches the sentinel + exit 93) and now ALSO
+  # pushes the cloud-init log (#5042(b)) — never forensic-blind on kom4dc.
   # flux install creates deny-world NetworkPolicies that block source-controller
   # → github.com; delete them (bp-network-policies slot 30 provides the proper
   # zero-trust posture via CCNPs with flux-system allowlisted). ONE shell for the
@@ -1572,9 +1615,14 @@ runcmd:
   # under the 32256B cap; explicit exit 93/94 still halt runcmd fail-loud (#5042).
   - |
     export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-    for i in 1 2 3 4 5; do curl -fsSL https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml | kubectl apply -f - && break; [ "$i" = 5 ] && { touch /var/lib/catalyst/flux-install-FAILED; exit 93; }; sleep 15; done
+    n=0
+    until kubectl get crd helmreleases.helm.toolkit.fluxcd.io >/dev/null 2>&1; do
+     n=$((n+1)); [ "$n" -gt 10 ] && { %{ if provider == "huawei" }sh /var/lib/catalyst/mark flux-install-FAILED||true%{ else }touch /var/lib/catalyst/flux-install-FAILED%{ endif }; exit 93; }
+     curl -fsSL --max-time 60 https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml | kubectl apply -f - || true
+     sleep $((n*10))
+    done
     kubectl -n flux-system delete networkpolicy allow-egress allow-scraping allow-webhooks --ignore-not-found || true
-    for j in 1 2; do kubectl -n flux-system wait --for=condition=Available --timeout=300s deployment --all && break; [ "$j" = 2 ] && { touch /var/lib/catalyst/flux-wait-FAILED; exit 94; }; done
+    for j in 1 2; do kubectl -n flux-system wait --for=condition=Available --timeout=300s deployment --all && break; [ "$j" = 2 ] && { %{ if provider == "huawei" }sh /var/lib/catalyst/mark flux-wait-FAILED||true%{ else }touch /var/lib/catalyst/flux-wait-FAILED%{ endif }; exit 94; }; done
 
   # Apply the bootstrap secrets BEFORE Flux reconciles bootstrap-kit (each
   # is an idempotent `kubectl apply`; re-running cloud-init rewrites bytes).
@@ -1632,7 +1680,7 @@ runcmd:
 %{ if crossplane_provider_yaml != "" ~}
     kubectl apply -f /var/lib/catalyst/crossplane-provider.yaml || true
 %{ endif ~}
-    kubectl apply -f /var/lib/catalyst/flux-bootstrap.yaml || { touch /var/lib/catalyst/flux-bootstrap-FAILED; exit 92; }
+    kubectl apply -f /var/lib/catalyst/flux-bootstrap.yaml || { %{ if provider == "huawei" }sh /var/lib/catalyst/mark flux-bootstrap-FAILED||true%{ else }touch /var/lib/catalyst/flux-bootstrap-FAILED%{ endif }; exit 92; }
 %{ if crossplane_provider_yaml != "" ~}
     nohup bash -c "deadline=\$((SECONDS+1800)); while [ \$SECONDS -lt \$deadline ]; do kubectl apply -f /var/lib/catalyst/crossplane-provider.yaml >/dev/null 2>&1 && break; sleep 30; done" >/dev/null 2>&1 &
 %{ endif ~}
@@ -1640,5 +1688,13 @@ runcmd:
   # Marker for the catalyst-api provisioner to detect cloud-init is done.
   - mkdir -p /var/lib/catalyst
   - touch /var/lib/catalyst/cloud-init-complete
+%{ if provider == "huawei" ~}
+  # #5042(b): deterministic FINAL log push on the success path too — the huawei
+  # background uploader (main.tf provider_prelude_huawei) caps at ~50 min and
+  # can expire before a slow 2-region bootstrap finishes, leaving a truncated
+  # log with no completion line. The mark re-touch of cloud-init-complete is an
+  # idempotent no-op. Huawei-gated with the whole mark helper (see its header).
+  - sh /var/lib/catalyst/mark cloud-init-complete||true
+%{ endif ~}
 
 final_message: "Catalyst CP bootstrap done; Flux reconciling ${sovereign_fqdn}"


### PR DESCRIPTION
**TRAIN: merge only as part of the assembled keystone train (founder release-train rule).**

Prevention half of #5042 — the detection half (`OutcomeFluxCRDsAbsent`) merged in #5073. Built fresh off main: the pre-existing `fix/5042-cloudinit-rt-wrap` branch was read first and is already fully squash-merged as #5057 (`a0b0479`); its template content is byte-identical to main, so this builds ON TOP of that work rather than on the stale branch tip.

## (a) flux-install leg: idempotent + retried until the flux CRDs are SERVABLE

The #5057 leg retried the `curl | kubectl apply` 5×15s (~75s window) and broke on the first apply exit 0. hw247's mode — cilium up, **flux CRDs absent**, `phase1-watching` forever — needs the loop gated on the actual outcome, and ~75s does not ride out the #3232/#3829 github/ghcr transient-DNS class.

Now: `until kubectl get crd helmreleases.helm.toolkit.fluxcd.io` — the apply is idempotent, retried with bounded linear backoff (10 tries, `sleep n*10` ≈ 9m10s of sleep + `curl --max-time 60` per try, ~20m worst case), a cloud-init re-run short-circuits on the first CRD probe, and exhaustion stays fail-loud (`flux-install-FAILED` sentinel + exit 93). Shared verbatim across both providers (one-k8s-implementation directive).

## (b) log push fires ON the failure path (kom4dc never forensic-blind)

New `/var/lib/catalyst/mark` helper (write_files, 0700): touches the named sentinel, echoes `CLOUDINIT-SENTINEL: <leg>` into the log, then PUTs `/var/log/cloud-init-output.log` to `…/deployments/{id}/cloudinit-log` (curl `-4` per #5068). Called on **every post-PUT fail-loud exit** — 91 (cilium), 92 (flux-bootstrap), 93/94 (flux install/wait), 95 (gateway-api) — and **once on success** after the `cloud-init-complete` marker. This closes the exact hw247 hole: the prelude background uploader caps at ~50 min, so a leg dying after that window pushed nothing (`GET cloudinit-log` → 404). The pre-PUT exits (86/87, minute ~2) deliberately do not call mark — they always land inside the uploader window, which starts before k3s.

**Huawei-gated by design** (hard cloud dependency, same class as the prelude uploader): kom4dc has no console-output API and no reachable sshd; Hetzner keeps sshd + console forensics. The gating is also byte-load-bearing:

## Hetzner 32512 guardrail (three_region case) — measured, not estimated

Baseline three_region primary-CP render (comment-stripped, real provider blocks): **32306/32512** — only 206 B headroom. An ungated version of (b) rendered **32749** (19 B under the 32768 hard cap that bricks provs) — caught by the `hcloud_server.control_plane` precondition, and cut rather than raising the guardrail. Final shape: Hetzner render changes are the (a) leg ONLY (**+114 B → ~32420/32512**); every fail site keeps its exact baseline `touch`/`echo no-cni` sentinel text on Hetzner (render-diff-verified byte-identical outside the flux leg).

Sacred-cloud-init constraints held: no `{{ }}` anywhere, POSIX/dash-clean, docs as zero-byte stripped `# ` comments, thin.

## Gates (all green, run locally)

- `infra/providers/hetzner` `tofu test` — **12/12** (includes `three_region_mgmt_fsn_hel` exercising the 32512/32256 render preconditions)
- `infra/providers/huawei` `tofu test` — 7/7
- `infra/providers/_shared/tests` `tofu test` — 2/2 runs (all asserts incl. `rendered_bytes < 32256`)
- `scripts/cloudinit-size-check.sh both` — 6/6 surfaces within cap (hetzner CP 23954, huawei CP 27580 on the fixture renders)
- `scripts/lint-cloudinit.sh both` — the `dash -n cloud-init render` CI gate: 26 (hetzner) + 29 (huawei) runcmd items + concatenated scripts pass

Validation on a live fresh prov requires a mothership roll + kom4dc prov (RT-10) — deferred to the train keystone per protocol.

Refs #5042 #3232 #3829 #3132 #5068 #5073 #5057

🤖 Generated with [Claude Code](https://claude.com/claude-code)
