### PR TITLE
fix(cloudinit): repair #5082 build-failure — CP cloud-init byte-budget overflow (Refs #4858 #5082)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1574,11 +1574,11 @@ runcmd:
   - |
     nohup sh -c '
       log=/var/lib/catalyst/prepull.log
-      echo "[prepull] $(date -u +%FT%TZ) background image pre-pull start (#4049)" >> "$log" 2>&1
+      echo "[prepull] $(date -u +%FT%TZ) image pre-pull start (#4049)" >> "$log" 2>&1
       CRICTL="$(command -v crictl || echo /usr/local/bin/crictl)"
       HELM="$(command -v helm || echo /usr/local/bin/helm)"
       if [ ! -x "$CRICTL" ] || [ ! -x "$HELM" ]; then
-        echo "[prepull] crictl ($CRICTL) or helm ($HELM) not executable — skipping (kubelet pulls on demand)" >> "$log" 2>&1
+        echo "[prepull] crictl ($CRICTL)/helm ($HELM) not exec — skip" >> "$log" 2>&1
         exit 0
       fi
       workdir="$(mktemp -d /tmp/catalyst-prepull.XXXXXX 2>/dev/null || echo /tmp/catalyst-prepull)"
@@ -1608,7 +1608,7 @@ runcmd:
           | sort -u)"
       fi
       if [ -z "$images" ]; then
-        echo "[prepull] no images resolved — skip (kubelet pulls on demand)" >> "$log" 2>&1
+        echo "[prepull] no images resolved — skip" >> "$log" 2>&1
         rm -rf "$workdir" 2>/dev/null || true
         exit 0
       fi
@@ -1620,7 +1620,7 @@ runcmd:
           || echo "[prepull] WARN pull failed (non-fatal): $img" >> "$log" 2>&1
       done
       rm -rf "$workdir" 2>/dev/null || true
-      echo "[prepull] $(date -u +%FT%TZ) background pre-pull finished ($n image(s) attempted)" >> "$log" 2>&1
+      echo "[prepull] $(date -u +%FT%TZ) pre-pull done ($n img)" >> "$log" 2>&1
     ' >/dev/null 2>&1 &
 
 %{ if provider_id_cmd != "" ~}


### PR DESCRIPTION
## What & why

The **Build & Deploy Catalyst** run for the merged #5082 commit
(`364fe141a`, "kubelet image-GC guard against the self-hosting image
deadlock") **FAILED** — so the mothership never rolled to that image and
the #4858 fix is currently **inert**.

Failing job: `build-api` → **G36 — tofu test against tftpl fixtures**
([run 29366234969](https://github.com/openova-io/openova/actions/runs/29366234969)):

```
tests/multi_region.tftest.hcl... fail
  run "three_region_mgmt_fsn_hel"... fail
Rendered control-plane cloud-init is 32579 bytes, exceeds 32512
(256 B below the Hetzner 32768 hard cap) guardrail.
```

### Root cause (a REAL break, not flaky)

#5082's byte-budget accounting measured the **light** `cloudinit-size-check`
fixture (~23.8 KB, plenty of headroom — this is the "23840 → 23829 B"
number in the #5082 message) instead of the **binding** hetzner
`tofu test` **three_region** fixture, which injects production-representative
values. That render sat 34 B under the 32512 guardrail before #5082; the
~124 B of new kubelet args (net of #5082's own log trims) pushed it to
**32579 B — 67 B over**. The `_shared` render + size-check gates the author
ran locally all passed; the three_region `tofu test` gate is the one that
actually binds, and it was red on `main`.

### Fix

Reclaim **106 B** by shortening four **#4049 prepull-fallback** log-only
strings (the lowest-value logs in the file — "warm path is primary").
**No** change to exit codes, sentinel files, control flow, or the #5082
kubelet image-GC args. The guardrail itself is untouched (no relaxing).

Net three_region CP render: **32579 → 32473 B** (39 B under 32512, restoring headroom).

### Gates (run locally)

- `infra/providers/hetzner` **`tofu test` → 12 passed, 0 failed** (the exact gate that failed)
- `scripts/lint-cloudinit.sh both` → **dash -n PASS** (hetzner 26 runcmd items + huawei 29)
- `scripts/cloudinit-size-check.sh both` → **PASS** on all six surfaces
- Exact three_region size confirmed by guardrail bisection at 32472 (fails, prints `32473 bytes`)

TRAIN: follow-up to the hw252 keystone train.

Refs #4858 #5082

🤖 Generated with [Claude Code](https://claude.com/claude-code)