### PR TITLE
fix(cutover): step-03 prewarm — in-cluster CoreDNS pin for registry.<fqdn> + warm deployed∪desired chart versions (0.1.134)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -861,7 +861,21 @@ spec:
       # as ClusterIP (no VIP ever), so the pin deferred FOREVER on every
       # ELB-direct prov (hw250 all night); ClusterIP now pins HOST_IP like the
       # absent-Service hostNetwork branch. LoadBalancer semantics unchanged.
-      version: 0.1.133
+      # 0.1.134 (#5007 round 3): TWO step-03 harbor-prewarm durability fixes.
+      # (A/DNS) the skopeo push to registry.<fqdn> (dest MUST stay the public host
+      # for Harbor's hard-https bearer realm, #5051) was still resolved via PUBLIC
+      # DNS behind only a readiness probe — broken by a stale `*.<pool>` wildcard
+      # shadow (hw241) or a mid-push NXDOMAIN flap (hw252 push_ok=131/fail=7). The
+      # hardened non-root pod can't write /etc/hosts, so it installs a kube-system
+      # coredns-custom `.server` override (registry.<fqdn> -> gateway ClusterIP,
+      # merge-patched, NOT .override) before the probe so CoreDNS answers in-cluster;
+      # fail-loud if the ClusterIP can't be resolved.
+      # (C/version-drift) Phase A2 warms the UNION of deployed + desired chart
+      # versions so a PR re-publishing a chart mid-cutover can't leave prewarm's
+      # warmed version (deployed 1.4.1121) diverged from the flux pin step-06
+      # checks (1.4.1120) → step-06 wedge; chart_fail>0 stays the fail-loud guard.
+      # Cases 57/58. Facet B (step-04 ELB-direct node pin) was closed in 0.1.129.
+      version: 0.1.134
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.133
+  version: 0.1.134
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,48 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.134 (#5007 round 3 Refs #5051 #5036 #4652 #4682 #4870 #3379 — TWO step-03
+# harbor-prewarm durability fixes). FACET A (DNS): #5051 round 2 (0.1.128) correctly
+# forced the skopeo push DEST back to the PUBLIC host registry.<fqdn> — only the
+# TLS-terminating gateway serves Harbor's hard-https bearer realm https://registry.
+# <fqdn>/service/token, so no in-cluster :80 Service can complete the token flow — but
+# that dest was left resolving via public DNS, behind only a bounded readiness probe.
+# A readiness probe cannot cover (a) a persistent dead-`*.<pool>`-wildcard shadow
+# (hw241: registry.<fqdn> → dead 49.12.16.160 → probe connection-refused → 10-min
+# FATAL) nor (b) a mid-push NXDOMAIN flap (hw252: `lookup registry.<fqdn> on
+# 10.96.0.10:53: no such host` → push_ok=131 push_fail=7). FIX (template 03 + the
+# existing localRegistryHostPin values): harbor-prewarm now installs a kube-system
+# `coredns-custom` `.server` override (registry.<fqdn> → the cilium-gateway Service
+# ClusterIP) BEFORE the readiness probe, so CoreDNS answers registry.<fqdn> IN-CLUSTER
+# — the push + bearer-token flow no longer depend on public DNS. CoreDNS (not the pod
+# /etc/hosts) because harbor-prewarm runs runAsNonRoot(1000) + readOnlyRootFilesystem
+# + drop-ALL and CANNOT write its own root-owned /etc/hosts, and pod hostAliases can't
+# take a runtime IP. The gateway Service ClusterIP is ALWAYS allocated — even
+# TYPE=ClusterIP with no VIP on the §854 ELB-direct model (#5007 round 2) — and
+# ClusterIP:443 terminates the wildcard TLS + serves the /service/token realm (proven
+# #4637). Host/SNI stay registry.<fqdn> so the realm + HTTPRoute + cert still match. A
+# dedicated `.server` block (NOT `.override` — two `hosts` plugins in `.:53` crash
+# CoreDNS, the #3804 trap), MERGE-patched so a co-resident github-ipv4 pin survives,
+# ONLY on the primary cluster's CoreDNS + ONLY for the registry name (a narrow, fail-
+# loud reversal of #4682's public-DNS assumption for the pre-pivot prewarm; the NODE/
+# containerd path is untouched). The existing readiness probe is the CoreDNS-reload
+# sync-confirm. FAIL-LOUD if the gateway ClusterIP can't be resolved. FACET C
+# (version-drift): step-03 Phase A2 warmed the DEPLOYED chart version
+# (.status.history[0].chartVersion, #4870) — but a PR re-publishing a chart DURING the
+# cutover rolls the live HR to the just-published tag (hw252: deployed 1.4.1121) while
+# the flux/bootstrap-kit pin step-06 settles on is 1.4.1120 → prewarm warmed 1.4.1121,
+# step-06 waited FOREVER for 1.4.1120. FIX: Phase A2 warms the UNION of deployed +
+# desired versions (a strict superset satisfying both #4870 and this), reports drift,
+# and the chart_fail>0 FATAL stays the fail-loud guard for a pinned tag that can't be
+# pulled. New step-03 envs LOCAL_REGISTRY_PIN_ENABLED / GATEWAY_LB_SVC_NAME /
+# GATEWAY_LB_SVC_NAMESPACE (reuse PR #5008 values); the kube-system configmaps
+# create/get/patch RBAC the runner SA already holds cluster-wide covers the CoreDNS
+# patch — NO RBAC change. cutover-contract Cases 57/58 lock it. NO step-count /
+# job-mode change (still 11 steps). Facet B (the step-04 NODE pin on the §854
+# ELB-direct model) was ALREADY closed in 0.1.129 (#5007 round 2, Case 55). Slot-06a
+# pin + blueprint.yaml + catalog-seed source.version + spec.version move to 0.1.134 in
+# lockstep (Inviolable Principle #13; catalog-seed spec.version had lagged at 0.1.129
+# — realigned here).
+# ── prior ──
 # 0.1.133 (#5074 #5065 #5059 Refs #3379 — step-08 ROLL-SET MINIMIZATION, the
 # root treadmill-breaker): the per-workload freshPullProof.excludeWorkloads list
 # was whack-a-mole — each prov surfaced ONE more infra workload broken by the
@@ -2077,7 +2120,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.133
+version: 0.1.134
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -162,6 +162,29 @@ data:
             value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
           - name: MOTHERSHIP_HOST
             value: {{ include "bp-self-sovereign-cutover.mothershipHost" . | quote }}
+          # #5007 (Refs #5051 #5036 #4652 #4682) — in-cluster CoreDNS pin of the
+          # local registry host for the PRE-pivot prewarm phase. #5051 round 2
+          # settled that the skopeo push DEST must be the PUBLIC host registry.<fqdn>
+          # (only the TLS-terminating gateway serves Harbor's hard-https bearer
+          # realm), but it was left resolving via PUBLIC DNS → still breaks on a
+          # stale `*.<pool>` wildcard shadow (hw241 dead 49.12.16.160) or a mid-push
+          # NXDOMAIN flap (hw252). harbor-prewarm runs runAsNonRoot(1000) +
+          # readOnlyRootFilesystem + drop-ALL, so it CANNOT write its own /etc/hosts;
+          # instead it installs a kube-system `coredns-custom` `.server` override
+          # (registry.<fqdn> -> the cilium-gateway Service ClusterIP) so CoreDNS —
+          # which every pod already queries — answers registry.<fqdn> in-cluster,
+          # independent of the Sovereign zone / public wildcard. The ClusterIP is
+          # ALWAYS allocated (even TYPE=ClusterIP with no VIP on the §854 ELB-direct
+          # model, #5007 round 2 / 0.1.129) and ClusterIP:443 terminates the wildcard
+          # TLS + serves the /service/token realm (proven #4637). Reuses the SAME
+          # gateway-Service values PR #5008 added for the step-04 node pin + the
+          # configmaps create/get/patch RBAC the runner SA already holds cluster-wide.
+          - name: LOCAL_REGISTRY_PIN_ENABLED
+            value: {{ .Values.registryPivot.localRegistryHostPin.enabled | quote }}
+          - name: GATEWAY_LB_SVC_NAME
+            value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceName | quote }}
+          - name: GATEWAY_LB_SVC_NAMESPACE
+            value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceNamespace | quote }}
           # #4982 (Refs #3379) — settled-roll pre-flight toggle. When true
           # (default) Phase A0 REFUSES to build the mirror while any HelmRelease
           # or Deployment/StatefulSet on the host cluster is mid-roll, so the
@@ -440,7 +463,102 @@ data:
             # /v2 HEAD — basic auth, no token dance) STAY on
             # HARBOR_INTERNAL_URL, which step-02 proved works in-cluster.
             HARBOR_HOST=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
-            echo "[harbor-prewarm] public-dest readiness probe: https://${HARBOR_HOST}/v2/ (want 401/200)"
+
+            # ── #5007 (Refs #5051 #5036 #4652 #4682) — install a kube-system
+            # `coredns-custom` override so registry.<fqdn> resolves IN-CLUSTER to the
+            # cilium-gateway Service ClusterIP, BEFORE the readiness probe + every
+            # skopeo push, making the local-registry datapath INDEPENDENT of public
+            # DNS. #5051 round 2 correctly forced the push DEST back to the PUBLIC host
+            # (only the TLS-terminating gateway serves Harbor's hard-https bearer realm
+            # https://registry.<fqdn>/service/token — no in-cluster :80 Service can
+            # complete the token flow), but that dest was left resolving via PUBLIC
+            # DNS, so it still breaks when the Sovereign zone flakes or a wiped-env
+            # `*.<pool>` wildcard shadows the specific record: hw241's dead
+            # `*.omantel.biz` 49.12.16.160 → readiness probe connection-refused →
+            # 10-min FATAL; hw252's intermittent NXDOMAIN (`lookup registry.hw252.
+            # omani.works on 10.96.0.10:53: no such host`) flapped MID-PUSH →
+            # push_ok=131 push_fail=7 (survived only on a backoffLimit retry).
+            #
+            # WHY CoreDNS, not /etc/hosts: harbor-prewarm runs runAsNonRoot(uid 1000)
+            # + readOnlyRootFilesystem + drop-ALL, so it CANNOT write its own (root-
+            # owned) /etc/hosts, and a pod `hostAliases` can't take a runtime IP. It
+            # instead patches the k3s-native `coredns-custom` ConfigMap — the same
+            # extension point cloud-init uses for the github-ipv4 pin — with a
+            # SEPARATE `.server` block (registry.<fqdn> -> the gateway ClusterIP), so
+            # CoreDNS (which every pod already queries at 10.96.0.10) answers
+            # registry.<fqdn> authoritatively in-cluster. The ClusterIP is ALWAYS
+            # allocated (even TYPE=ClusterIP with no VIP on the §854 ELB-direct model,
+            # #5007 round 2 / 0.1.129); ClusterIP:443 terminates the wildcard TLS and
+            # serves BOTH the /v2 challenge AND the /service/token realm (proven
+            # #4637). Request host / SNI stay registry.<fqdn> so the bearer realm +
+            # gateway HTTPRoute + wildcard cert all still match — ONLY resolution is
+            # pinned. This reverses #4682's public-DNS assumption ONLY for the primary
+            # cluster's CoreDNS + ONLY for the local registry name (a dedicated
+            # `.server` block, never a `.override` — two `hosts` plugins in one block
+            # crash CoreDNS, the #3804 trap); the NODE/containerd path is untouched
+            # (step-04's /etc/hosts pin). FAIL-LOUD: if the pin is enabled but the
+            # gateway ClusterIP can't be resolved, EXIT NON-ZERO rather than silently
+            # push over the flaky public path. The existing readiness probe below is
+            # the sync-confirm — it blocks until CoreDNS actually serves the override.
+            install_coredns_registry_pin() {
+              case "${LOCAL_REGISTRY_PIN_ENABLED:-true}" in
+                true|True|TRUE|1|yes) : ;;
+                *) echo "[harbor-prewarm] local-registry CoreDNS pin DISABLED (LOCAL_REGISTRY_PIN_ENABLED=${LOCAL_REGISTRY_PIN_ENABLED:-}) — ${HARBOR_HOST} resolves via cluster DNS (public path)"; return 0 ;;
+              esac
+              [ -n "${HARBOR_HOST}" ] || { echo "[harbor-prewarm] FATAL: HARBOR_PUBLIC_URL yielded an empty registry host — cannot pin (#5007)"; exit 1; }
+              _cip=""
+              if [ -n "${GATEWAY_LB_SVC_NAME:-}" ]; then
+                _pin_attempt=1
+                while [ "${_pin_attempt}" -le 5 ]; do
+                  # ClusterIP is allocated the moment the gateway Service exists (well
+                  # before step-03) in BOTH the LB and the §854 ELB-direct (TYPE=
+                  # ClusterIP) gateway models. `services get` RBAC is already granted.
+                  _c=$(kubectl get svc "${GATEWAY_LB_SVC_NAME}" -n "${GATEWAY_LB_SVC_NAMESPACE}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
+                  case "${_c}" in
+                    ""|None) : ;;
+                    *) _cip="${_c}"; break ;;
+                  esac
+                  echo "[harbor-prewarm] gateway Service ${GATEWAY_LB_SVC_NAMESPACE}/${GATEWAY_LB_SVC_NAME} ClusterIP not resolved yet (attempt ${_pin_attempt}/5); retry in 3s"
+                  _pin_attempt=$((_pin_attempt+1))
+                  sleep 3
+                done
+              fi
+              if [ -z "${_cip}" ]; then
+                echo "[harbor-prewarm] FATAL: could not resolve the cilium-gateway Service ClusterIP (${GATEWAY_LB_SVC_NAMESPACE:-}/${GATEWAY_LB_SVC_NAME:-<unset>}). Refusing to push over the flaky public DNS path (#5007). Fix/name the gateway Service (registryPivot.localRegistryHostPin.gatewayServiceName), then re-trigger."
+                exit 1
+              fi
+              # A SEPARATE `.server` block (NEVER `.override`): a single `hosts` plugin
+              # scoped to the registry zone, mirroring cloud-init's github-ipv4 pin.
+              _cdns_key="cutover-registry-pin.server"
+              _cdns_block=$(printf '%s {\n    hosts {\n        %s %s\n        fallthrough\n    }\n    forward . /etc/resolv.conf\n}\n' "${HARBOR_HOST}" "${_cip}" "${HARBOR_HOST}")
+              # Idempotent: if kube-system/coredns-custom already carries our key with
+              # THIS ClusterIP, nothing to do (avoids a needless CoreDNS reload on a
+              # step re-run).
+              _cdns_cur=$(kubectl get cm coredns-custom -n kube-system -o json 2>/dev/null | jq -r --arg k "${_cdns_key}" '.data[$k] // ""' 2>/dev/null || true)
+              case "${_cdns_cur}" in
+                *"${_cip} ${HARBOR_HOST}"*)
+                  echo "[harbor-prewarm] coredns-custom already pins ${HARBOR_HOST} -> ${_cip} (#5007)"
+                  return 0 ;;
+              esac
+              _cdns_patch=$(jq -cn --arg k "${_cdns_key}" --arg v "${_cdns_block}" '{data: {($k): $v}}')
+              # MERGE-patch (never replace) so a co-resident github-ipv4.server key is
+              # preserved; create the CM if it does not exist yet (Hetzner renders no
+              # coredns-custom at boot); re-patch on a create race.
+              if kubectl patch configmap coredns-custom -n kube-system --type merge -p "${_cdns_patch}" >/dev/null 2>&1; then
+                :
+              elif kubectl create configmap coredns-custom -n kube-system --from-literal="${_cdns_key}=${_cdns_block}" >/dev/null 2>&1; then
+                :
+              elif kubectl patch configmap coredns-custom -n kube-system --type merge -p "${_cdns_patch}" >/dev/null 2>&1; then
+                :
+              else
+                echo "[harbor-prewarm] FATAL: could not install the coredns-custom ${HARBOR_HOST} -> ${_cip} override (kube-system/coredns-custom patch+create both failed). Refusing to push over the flaky public DNS path (#5007)."
+                exit 1
+              fi
+              echo "[harbor-prewarm] installed coredns-custom pin ${HARBOR_HOST} -> ${_cip} (in-cluster; step-03 pushes + bearer-token flow bypass public DNS; #5007). Waiting for CoreDNS reload via the readiness probe below."
+            }
+            install_coredns_registry_pin
+
+            echo "[harbor-prewarm] public-dest readiness probe: https://${HARBOR_HOST}/v2/ (want 401/200; registry.<fqdn> resolves via the in-cluster CoreDNS gateway-ClusterIP pin once CoreDNS reloads, #5007)"
             _pr_ok=0
             for _pr_i in $(seq 1 40); do
               _pr_code=$(curl -sk -o /dev/null -w '%{http_code}' -m 10 "https://${HARBOR_HOST}/v2/" 2>/dev/null)
@@ -453,7 +571,7 @@ data:
               sleep 15
             done
             if [ "${_pr_ok}" != "1" ]; then
-              echo "[harbor-prewarm] FATAL: public dest https://${HARBOR_HOST}/v2/ never became ready after 40 probes — cannot push. The in-cluster fallback is NOT usable (Harbor token realm is hard-https on the echoed host; #5051). Fix DNS/gateway, then re-trigger."
+              echo "[harbor-prewarm] FATAL: https://${HARBOR_HOST}/v2/ never became ready after 40 probes (10 min) — cannot push. With the #5007 coredns-custom pin, registry.<fqdn> resolves to the in-cluster gateway ClusterIP once CoreDNS reloads; a persistent failure means either CoreDNS did not pick up the override (check kube-system/coredns-custom + the coredns Pod logs) OR the gateway is not serving the registry (Harbor down / HTTPRoute not Programmed / wildcard TLS not issued) — NOT a public-DNS flake. (If the pin is disabled via LOCAL_REGISTRY_PIN_ENABLED=false, also check the Sovereign DNS zone for registry.<fqdn>.)"
               exit 1
             fi
 
@@ -1007,23 +1125,58 @@ data:
             # Enumerate (chart, version, sourceRef.kind, sourceRef.name) from
             # every HelmRelease cluster-wide. Tab-separated; a HR with no
             # explicit chart.spec is skipped (empty fields).
-            # #4870-followup: mirror the DEPLOYED chart version
-            # (.status.history[0].chartVersion), NOT the mutable desired
-            # .spec.chart.spec.version. During a cutover the gitea-mirror step
-            # can pull a deploybot-bumped catalog pin into the env, so
-            # .spec.chart.spec.version can transiently oscillate (e.g. an env
-            # DEPLOYED on 1.4.1038 briefly shows spec 1.4.1039 then settles
-            # back). If prewarm mirrors the transient desired (1.4.1039) but
-            # step-06 later checks the settled deployed (1.4.1038), the pivot
-            # wedges forever ("chart not yet pullable"). The deployed version
-            # is immutable for the running release — mirror THAT so the release
-            # keeps reconciling from local Harbor post-pivot.
+            #
+            # #5007 round 3 (Refs #4870 #4982) — mirror the UNION of the DEPLOYED
+            # and the DESIRED chart versions per HR. Two OPPOSITE drifts wedge
+            # step-06 (helmrepository-patches Phase-3a), which reads the SAME
+            # `.status.history[0].chartVersion // .spec.chart.spec.version`
+            # resolution (06-…-job.yaml L1199-1207) — but at a LATER instant:
+            #   • #4870: mirroring ONLY the desired (`.spec.chart.spec.version`)
+            #     breaks when a deploybot catalog bump transiently oscillates the
+            #     desired ahead of the settled deployed → prewarm mirrors 1.4.1039,
+            #     step-06 checks the settled deployed 1.4.1038 → wedge.
+            #   • #5007 round 3 (hw252): mirroring ONLY the deployed
+            #     (`.status.history[0].chartVersion`) breaks when a PR merges +
+            #     re-publishes a chart DURING the cutover — the live HR briefly
+            #     DEPLOYS the just-published 1.4.1121 (so history[0]=1.4.1121),
+            #     while the flux/bootstrap-kit PIN the Sovereign settles back to
+            #     post-step-05 is 1.4.1120 (`.spec.chart.spec.version`). prewarm
+            #     warmed 1.4.1121, step-06 waited FOREVER for the pinned 1.4.1120.
+            # Mirroring the UNION warms BOTH the pinned/desired AND the deployed
+            # tag, so step-06 finds its version locally regardless of which the HR
+            # settles on between the two steps. The union is a strict SUPERSET (an
+            # extra skopeo copy is idempotent + #4994 skip-if-present makes it
+            # cheap), never narrows the set, and the Phase A2 chart_fail>0 FATAL
+            # below is the FAIL-LOUD guard: a PINNED version whose OCI artifact
+            # cannot be pulled fails the cutover HERE (egress still open, named)
+            # instead of silently wedging step-06 under the deny-egress hold.
             chart_tuples=$(kubectl get helmreleases -A -o json | \
               jq -r '.items[]
                 | .spec.chart.spec as $cs
                 | select($cs.chart != null and $cs.sourceRef != null)
-                | [ $cs.chart, ((.status.history[0].chartVersion) // $cs.version // ""), ($cs.sourceRef.kind // ""), ($cs.sourceRef.name // "") ]
+                | ( [ (.status.history[0].chartVersion), $cs.version ]
+                    | map(select(. != null and . != "")) | unique ) as $vers
+                | ( if ($vers | length) == 0 then [""] else $vers end )[]
+                | . as $v
+                | [ $cs.chart, $v, ($cs.sourceRef.kind // ""), ($cs.sourceRef.name // "") ]
                 | @tsv' 2>/dev/null | sort -u || true)
+
+            # #5007 round 3 — informational DRIFT report: name every pivot-set HR
+            # whose DEPLOYED (history[0]) and DESIRED (spec) chart versions differ.
+            # Both are warmed by the union above, so this NEVER wedges — it makes a
+            # mid-cutover publish visible in the step-03 log instead of surfacing as
+            # an opaque step-06 "chart not yet pullable" hang.
+            chart_drift=$(kubectl get helmreleases -A -o json 2>/dev/null | \
+              jq -r '.items[]
+                | .spec.chart.spec as $cs
+                | select($cs.chart != null and $cs.sourceRef != null)
+                | select((.status.history[0].chartVersion) != null and $cs.version != null
+                         and (.status.history[0].chartVersion) != $cs.version)
+                | "\($cs.chart): deployed=\(.status.history[0].chartVersion) desired=\($cs.version)"' 2>/dev/null | sort -u || true)
+            if [ -n "${chart_drift}" ]; then
+              echo "[harbor-prewarm] Phase A2 DRIFT (#5007): HelmRelease(s) with deployed != desired chart version — warming BOTH so step-06 finds its pinned version regardless:"
+              printf '%s\n' "${chart_drift}" | sed 's/^/  drift: /'
+            fi
 
             # Resolve the UPSTREAM chart-OCI host/project prefix from the same
             # value step-06 pivots FROM (oci://ghcr.io/openova-io → host
@@ -1041,6 +1194,16 @@ data:
                 echo "[harbor-prewarm] Phase A2 WARN: HelmRelease chart ${c_chart} (source ${c_name}) has no pinned version — skipping (cannot mirror a floating tag deterministically)"
                 continue
               fi
+              # #5007 round 3 — the union may surface a DESIRED spec.version that is
+              # a semver RANGE (a `<`, `>`, `~`, `^`, `|`, `*` or space) rather than a
+              # concrete OCI tag; a range can't be skopeo-copied deterministically, so
+              # skip it with a clear WARN instead of FATALing on an invalid tag. The
+              # concrete deployed/desired tag(s) for the same chart still mirror.
+              case "${c_ver}" in
+                *[\<\>~^\|\ ]*|*'*'*)
+                  echo "[harbor-prewarm] Phase A2 WARN: HelmRelease chart ${c_chart} (source ${c_name}) version '${c_ver}' is a semver range, not a concrete tag — skipping (cannot mirror deterministically)"
+                  continue ;;
+              esac
               printf '%s\t%s\n' "${c_chart}" "${c_ver}" >> "${chart_work}"
             done
             sort -u "${chart_work}" -o "${chart_work}"
@@ -1165,7 +1328,7 @@ data:
             done
             echo "[harbor-prewarm] Phase A2 complete: chart_ok=${chart_ok} chart_fail=${chart_fail}"
             if [ "${chart_fail}" -gt 0 ]; then
-              echo "[harbor-prewarm] FATAL: ${chart_fail} openova-io chart(s) failed to mirror — step-06 cannot strip ghcr.io safely (post-cutover chart (re)pulls would 404)"
+              echo "[harbor-prewarm] FATAL: ${chart_fail} openova-io chart(s) failed to mirror (named above) — step-06 cannot strip ghcr.io safely (post-cutover chart (re)pulls would 404). #5007: this INCLUDES any pinned/desired chart version the union added — a pinned tag that cannot be pulled fails LOUD here (egress open, recoverable) instead of silently wedging step-06 under the deny-egress hold."
               exit 1
             fi
 

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2383,4 +2383,103 @@ grep -qF 'ROLLED deployment flux-system/source-controller' <<<"$_full_out" \
   && { printf 'FAIL: full (legacy) mode rolled a LOCAL-registry-ref workload — legacy external-only selection changed; output:\n%s\n' "$_full_out" >&2; exit 1; }
 echo "  PASS (minimal: infra-ns DaemonSets + non-allowlisted infra workloads excluded by rule, representative sample rolled incl. Deployment top-up; full: legacy external-registry sweep byte-identical)"
 
+# ── Case 57 (#5007 round 3): step-03 pins registry.<fqdn> to the gateway ClusterIP
+# via a coredns-custom override (the hardened non-root pod can't write /etc/hosts) ─
+# #5051 round 2 (Case 54) correctly forced the step-03 skopeo push DEST back to the
+# PUBLIC host registry.<fqdn> (only the TLS-terminating gateway serves Harbor's
+# hard-https bearer realm), but left it resolving via PUBLIC DNS — still broken by a
+# stale `*.<pool>` wildcard shadow (hw241 dead 49.12.16.160) or a mid-push NXDOMAIN
+# flap (hw252: push_ok=131 push_fail=7). harbor-prewarm runs runAsNonRoot + readOnly-
+# RootFilesystem + drop-ALL, so it can't write its own /etc/hosts; it instead installs
+# a kube-system coredns-custom `.server` override (registry.<fqdn> -> the gateway
+# Service ClusterIP, always allocated incl. the §854 ELB-direct TYPE=ClusterIP model)
+# BEFORE the readiness probe, and FAILS LOUD (never silently push over the flaky
+# public path) if the ClusterIP can't be resolved. Request host / SNI stay
+# registry.<fqdn> (bearer realm + HTTPRoute + wildcard cert still match) — only
+# resolution is pinned. A `.server` block (NOT `.override`, which would put two
+# `hosts` plugins in `.:53` and crash CoreDNS — the #3804 trap).
+echo "[cutover-contract] Case 57: step-03 pins registry.<fqdn> to the gateway ClusterIP via coredns-custom before pushing — DNS-independent + fail-loud (#5007)"
+awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml" || true
+[ -s "$TMP/s03pin.yaml" ] || cp "$TMP/render.yaml" "$TMP/s03pin.yaml"
+# (a) the pin toggle + gateway-Service envs are wired from the SAME values PR #5008
+#     added for the step-04 node pin.
+if ! grep -qF 'name: LOCAL_REGISTRY_PIN_ENABLED' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not carry LOCAL_REGISTRY_PIN_ENABLED — the local-registry CoreDNS pin is not wired (#5007)" >&2
+  exit 1
+fi
+if ! grep -qF 'name: GATEWAY_LB_SVC_NAME' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not carry GATEWAY_LB_SVC_NAME — the pin cannot resolve the gateway Service (#5007)" >&2
+  exit 1
+fi
+# (b) the pin resolves the gateway Service CLUSTERIP (not the LB VIP) — the robust
+#     in-cluster target present in BOTH the LB and the ELB-direct gateway models.
+if ! grep -qF "jsonpath='{.spec.clusterIP}'" "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 pin does not read the gateway Service .spec.clusterIP — the CoreDNS override must point at the ClusterIP (always allocated, incl. ELB-direct), not the LB VIP (#5007)" >&2
+  exit 1
+fi
+# (c) the pin installs a kube-system coredns-custom `.server` override (NOT .override,
+#     which crashes CoreDNS) and MERGE-patches so a co-resident github-ipv4 key survives.
+if ! grep -qF 'configmap coredns-custom -n kube-system --type merge' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 pin does not MERGE-patch kube-system/coredns-custom — registry.<fqdn> is not pinned in-cluster (or a replace would clobber the github-ipv4 override) (#5007)" >&2
+  exit 1
+fi
+if ! grep -qF 'cutover-registry-pin.server' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 pin does not use a dedicated .server key — a .override merges into .:53 (two hosts plugins) and crashes CoreDNS (#3804 trap) (#5007)" >&2
+  exit 1
+fi
+if grep -qF 'cutover-registry-pin.override' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 pin uses a .override key — it would add a second hosts plugin to .:53 and crash CoreDNS cluster-wide (#3804) (#5007)" >&2
+  exit 1
+fi
+# (c2) the pin is invoked BEFORE the public-dest readiness probe (the probe is the
+#      CoreDNS-reload sync-confirm; a push must never race an unpinned registry.<fqdn>).
+_pin_ln=$(grep -n '            install_coredns_registry_pin$' "$TMP/s03pin.yaml" | tail -1 | cut -d: -f1)
+_probe_ln=$(grep -n 'public-dest readiness probe' "$TMP/s03pin.yaml" | head -1 | cut -d: -f1)
+if [ -z "$_pin_ln" ] || [ -z "$_probe_ln" ] || [ "$_pin_ln" -ge "$_probe_ln" ]; then
+  echo "FAIL: step-03 install_coredns_registry_pin is not invoked BEFORE the public-dest readiness probe (pin@${_pin_ln:-none} probe@${_probe_ln:-none}) — a push could race an unpinned registry.<fqdn> (#5007)" >&2
+  exit 1
+fi
+# (d) FAIL-LOUD: an enabled pin that cannot resolve the gateway ClusterIP exits
+#     non-zero instead of silently pushing over the flaky public path.
+if ! grep -qF 'Refusing to push over the flaky public DNS path' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 pin does not fail loud when the gateway ClusterIP can't be resolved — it could silently fall back to public DNS (#5007)" >&2
+  exit 1
+fi
+echo "  PASS (#5007 contract: step-03 installs a coredns-custom .server pin registry.<fqdn> -> gateway ClusterIP before the readiness probe; merge-patch preserves github-ipv4; fail-loud; skopeo dest host unchanged so the bearer realm still matches)"
+
+# ── Case 58 (#5007 round 3 / Facet C): Phase A2 mirrors the UNION of deployed +
+# desired chart versions, so a mid-cutover publish drift can't wedge step-06 ─────
+# step-06 (helmrepository-patches Phase-3a) reads the SAME
+# `.status.history[0].chartVersion // .spec.chart.spec.version` resolution as
+# step-03, but at a LATER instant. Two OPPOSITE drifts each wedge it: mirroring
+# only the DESIRED breaks on a deploybot oscillation (#4870); mirroring only the
+# DEPLOYED breaks when a PR re-publishes a chart mid-cutover (hw252: prewarm warmed
+# the just-published 1.4.1121 while the flux pin settled back to 1.4.1120). Phase A2
+# must warm BOTH (the union), and the existing chart_fail>0 FATAL is the fail-loud
+# guard for a pinned tag that can't be pulled.
+echo "[cutover-contract] Case 58: step-03 Phase A2 warms the UNION of deployed + desired chart versions + reports drift (#5007 Facet C)"
+[ -s "$TMP/s03pin.yaml" ] || awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml"
+# (a) the tuple jq enumerates BOTH history[0].chartVersion AND spec.version into a
+#     unique-d set (not a single `history // spec` pick).
+if ! grep -qF '[ (.status.history[0].chartVersion), $cs.version ]' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A2 does not build the {deployed, desired} chart-version set — a mid-cutover publish drift (deployed ahead of the flux pin) wedges step-06 (#5007 Facet C)" >&2
+  exit 1
+fi
+if ! grep -qF '| map(select(. != null and . != "")) | unique ) as $vers' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A2 does not unique the deployed+desired versions before emitting one row each — the union is not warmed (#5007 Facet C)" >&2
+  exit 1
+fi
+# (b) the informational drift report is present (deployed != desired named, not silent).
+if ! grep -qF 'Phase A2 DRIFT (#5007)' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A2 does not report deployed!=desired chart-version drift — a mid-cutover publish is invisible until step-06 hangs (#5007 Facet C)" >&2
+  exit 1
+fi
+# (c) the FATAL guard still fires on any un-mirrorable chart (the fail-loud contract:
+#     a pinned tag that can't be pulled fails step-03, not step-06's deny-egress hold).
+if ! grep -qF 'openova-io chart(s) failed to mirror' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A2 lost the chart_fail>0 FATAL — an un-mirrorable pinned chart would silently wedge step-06 (#5007 Facet C)" >&2
+  exit 1
+fi
+echo "  PASS (#5007 Facet C: Phase A2 warms the deployed+desired union, reports drift, and keeps the fail-loud chart_fail FATAL so a pinned tag that can't be pulled fails at step-03 with egress open)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.129"
+  version: "0.1.134"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.133"
+    version: "0.1.134"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5007 #5051 #5036 #4652 #4682 #4870

Two step-03 `harbor-prewarm` durability fixes, chart `0.1.133 → 0.1.134`. **RT-11-held — do NOT merge until a clean 0-cutover window.**

## Facet A (DNS) — the skopeo push no longer depends on public DNS

`#5051` round 2 (0.1.128) correctly forced the step-03 skopeo push DEST back to the **public host** `registry.<fqdn>` — only the TLS-terminating gateway serves Harbor's hard-https bearer realm `https://registry.<fqdn>/service/token`, so no in-cluster `:80` Service can complete the token flow. But that dest was left resolving via **public DNS**, behind only a bounded readiness probe. A readiness probe cannot cover:

- a **persistent** dead-`*.<pool>`-wildcard shadow — `hw241`: `registry.<fqdn>` → dead `49.12.16.160` → probe connection-refused → 10-min FATAL;
- a **mid-push** NXDOMAIN flap — `hw252`: `lookup registry.<fqdn> on 10.96.0.10:53: no such host` → `push_ok=131 push_fail=7` (survived only on a backoffLimit retry that re-resolved on luck).

**Why not a pod `/etc/hosts` pin:** `harbor-prewarm` runs `runAsNonRoot(1000)` + `readOnlyRootFilesystem` + `drop: ["ALL"]`, so it **cannot write its own root-owned `/etc/hosts`**, and a pod `hostAliases` can't take a runtime IP.

**Fix:** before the readiness probe, `harbor-prewarm` installs a kube-system `coredns-custom` `.server` override (`registry.<fqdn>` → the cilium-gateway Service **ClusterIP**), so CoreDNS — which every pod already queries at `10.96.0.10` — answers `registry.<fqdn>` **in-cluster**, independent of the Sovereign zone / public wildcard.

- The gateway Service ClusterIP is **always allocated** — even `type=ClusterIP` with no VIP on the §854 ELB-direct model (`#5007` round 2 / 0.1.129); `ClusterIP:443` terminates the wildcard TLS and serves both the `/v2` challenge and the `/service/token` realm (proven `#4637`).
- Host / SNI stay `registry.<fqdn>` so the bearer realm + HTTPRoute + wildcard cert still match — only resolution is pinned.
- A dedicated `.server` block (**not** `.override` — two `hosts` plugins in `.:53` crash CoreDNS, the `#3804` trap), **merge-patched** so a co-resident `github-ipv4` pin survives, on the **primary cluster's** CoreDNS only, for the registry name only. The node/containerd path is untouched (step-04's `/etc/hosts` pin).
- The existing readiness probe is the **CoreDNS-reload sync-confirm** — it blocks until CoreDNS actually serves the override. **Fail-loud** if the gateway ClusterIP can't be resolved.
- This is a narrow reversal of `#4682`'s public-DNS assumption **for the pre-pivot prewarm only** — flagging for reviewer awareness.

## Facet C (version-drift) — warm the deployed∪desired chart versions

Phase A2 warmed only the **deployed** chart version (`.status.history[0].chartVersion`, `#4870`). A PR re-publishing a chart **during** the cutover rolls the live HR to the just-published tag (`hw252`: deployed `1.4.1121`) while the flux/bootstrap-kit pin step-06 settles on is `1.4.1120` — so prewarm warmed `1.4.1121`, step-06 waited forever for `1.4.1120`. step-06 (`helmrepository-patches` Phase-3a) uses the identical `.status.history[0] // .spec.chart.spec.version` resolution, but reads it at a **later** instant.

**Fix:** Phase A2 warms the **union** of `{deployed, desired}` versions — a strict superset satisfying both `#4870` (deployed) and this (pinned/desired), so step-06 finds its version regardless of which the HR settles on. A drift report names any `deployed != desired` HR; the `chart_fail>0` FATAL stays the fail-loud guard (a pinned tag that can't be pulled fails at step-03 with egress open, not at step-08's deny-egress hold). A range-guard skips a semver-range desired (mirrors the concrete deployed tag instead).

## Facet B

The step-04 **node** pin on the §854 ELB-direct model was already closed in 0.1.129 (`#5007` round 2, Case 55) — no change here.

## Lockstep + gates

- 4-surface version lockstep to `0.1.134`: `Chart.yaml` + `blueprint.yaml` + slot-06a pin + catalog-seed `source.version` **and** `spec.version` (the catalog-seed `spec.version` had lagged at `0.1.129` — realigned).
- No RBAC / step-count / job-mode change (the runner SA already holds cluster-wide `configmaps` create/get/patch; still 11 steps). Reuses the `registryPivot.localRegistryHostPin.*` values `#5008` added.
- `cutover-contract` Cases 57 (CoreDNS pin: `.server` not `.override`, merge-patch, ClusterIP, pre-probe order, fail-loud) + 58 (deployed∪desired union + drift + fail-loud guard) added.
- Gates green: `helm lint`; all 58 `cutover-contract` cases; `image-registry-coverage` + self-tests. Rendered step-03 script `sh -n` clean; CoreDNS `.server` block + jq merge-patch validated.

Live cutover-walk proof deferred to the next re-fire (PR merge ≠ pillar shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)