### PR TITLE
feat(kyverno-policies): §854 NodePort audit guard

### DIFF
--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,21 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.48 (#5088): NEW baseline policy `forbid-nodeport-service` (24) — the
+#   systemic §854 AUDIT guard. §854 was enforced ONLY at chart-render time
+#   (per-chart `fail` guards); nothing caught a runtime / non-chart NodePort
+#   applied straight to a live cluster. A live §854 walk (#5088) found 4
+#   pre-existing NodePort Services on the mothership. This ClusterPolicy flags
+#   every `type=NodePort` Service AND every `type=LoadBalancer` Service that does
+#   not set `allocateLoadBalancerNodePorts:false` (unset silently allocates
+#   nodePorts), cluster-wide, at admission + background scans. Ships action=Audit
+#   (report-only) deliberately — 4 live violations exist + cert-manager's HTTP-01
+#   solver auto-creates NodePort Services; Enforce is the deliberate follow-up
+#   once the violations clear and the Audit report shows zero false positives.
+#   cert-manager `cm-acme-http-solver-*` solver Services (label
+#   acme.cert-manager.io/http01-solver) are carved out. New
+#   `kyverno test tests/forbid-nodeport-service/` (12/12 pass): NodePort DENIED,
+#   leaky LoadBalancer DENIED, ClusterIP + disabled-nodePort LoadBalancer +
+#   both solver Services ADMITTED. Template + values only. Refs #5088 #4765.
 # 1.0.46 (#5017 / #4973 family — harbor-proxy-pull learns mixed-source
 # pods: each anyPattern entry requires EVERY container to match ONE glob,
 # so a pod mixing proxy-cache sidecars with a native-push openova-io
@@ -310,7 +326,7 @@ type: application
 #   (helm.sh/hook annotation) — hooks get no Flux labels + Helm force-stamps
 #   managed-by:Helm, so a legit hook Job (bp-powerdns zone-bootstrap) was
 #   Enforce-denied on live upgrade, stranding the powerdns anycast NodePort.
-version: 1.0.47
+version: 1.0.48
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/24-forbid-nodeport-service.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/24-forbid-nodeport-service.yaml
@@ -1,0 +1,163 @@
+{{/*
+K24 — §854 NodePort AUDIT guard (#5088).
+
+THE MANDATE
+===========
+Founder, verbatim (§854, 2026-07-03): "YOU CAN NEVER EVER USE NODEPORT EVEN FOR
+TESTING PURPOSE!!! ... FUCK THE NODEPORTS!!!" — the #1 ABSOLUTE ban. The gateway
+is served DIRECT (cilium LB-IPAM VIP / shared-EIP, or Local-ETP + hostPort on the
+hostNetwork cilium-envoy pods → node:443/:80), never a nodePort. A `type=NodePort`
+Service — and a `type=LoadBalancer` Service that SILENTLY allocates nodePorts
+(the `allocateLoadBalancerNodePorts` default is true) — both violate §854.
+
+WHY THIS POLICY EXISTS
+======================
+§854 was enforced ONLY at chart-render time (per-chart `fail` guards in Helm
+templates). Nothing caught a runtime / non-chart NodePort applied straight to a
+live cluster. A live §854 walk (#5088, 2026-07-15) found 4 pre-existing NodePort
+Services on the mothership that the render-time guards never saw. This Kyverno
+ClusterPolicy closes that gap: it flags every `type=NodePort` Service, and every
+`type=LoadBalancer` Service that does not explicitly set
+`allocateLoadBalancerNodePorts: false`, cluster-wide, at admission AND in
+background scans (PolicyReport rows → Compliance Dashboard).
+
+WHY action IS Audit (NOT Enforce) TO START
+===========================================
+This ships in Audit mode DELIBERATELY. Two reasons:
+  1. Four §854 violations already exist live (#5088). Flipping straight to
+     Enforce would not retro-block them (admission is create/update-time) but
+     WOULD risk fail-closing a legitimate ephemeral Service class before the
+     known violations are triaged and the carve-outs are proven correct.
+  2. cert-manager's default HTTP-01 solver auto-creates `type=NodePort` solver
+     Services (`cm-acme-http-solver-*`). Those are carved out below, but Audit
+     first lets us confirm the signal is actionable (only the 4 real violations,
+     zero solver noise) on a live PolicyReport before we harden.
+Enforce is the DELIBERATE FOLLOW-UP once (a) the 4 live violations in #5088 are
+cleared and (b) the Audit PolicyReport confirms zero false positives. Flip via
+`--set compliancePolicies.forbidNodePortService.action=Enforce` (post-handover,
+after bootstrapMode has been flipped to false). See #5088.
+
+CARVE-OUT — cert-manager ACME HTTP-01 solver Services
+=====================================================
+cert-manager's built-in HTTP-01 solver creates a short-lived `type=NodePort`
+Service per in-flight ACME challenge, labelled
+`acme.cert-manager.io/http01-solver: "true"` and named
+`cm-acme-http-solver-<rand>`. They GC automatically when the challenge
+completes. They are a KNOWN-ACCEPTED transient class — excluded here so the
+policy's signal stays actionable, not drowned in solver churn. The §854-clean
+long-term fix is to switch issuers to the DNS-01 / gateway-API HTTP-01 solver so
+NO NodePort solver is ever created; until every issuer is migrated, this
+carve-out keeps the guard's report meaningful. (A leaked/stuck solver — e.g. a
+challenge pending for weeks — is a cert-manager problem to resolve at the root,
+not a signal this policy should raise; #5088 tracks the iogrid stuck challenge
+separately.)
+
+Operator override: `--set compliancePolicies.forbidNodePortService.enabled=false`
+disables it entirely; `.excludeNamespaces` adds per-namespace escapes (default
+empty — NodePorts are forbidden EVERYWHERE, including kube-system, per §854).
+*/}}
+{{- if .Values.compliancePolicies.forbidNodePortService.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: forbid-nodeport-service
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: network-exposure
+  annotations:
+    policies.kyverno.io/title: Forbid NodePort Services (§854)
+    policies.kyverno.io/category: catalyst-network-exposure
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      §854 (founder #1 ABSOLUTE ban): a Service must never be type=NodePort, and
+      a type=LoadBalancer Service must set allocateLoadBalancerNodePorts=false so
+      it does not silently allocate nodePorts. The gateway is served DIRECT
+      (cilium LB-IPAM VIP / shared-EIP, or Local-ETP + hostPort), never a
+      nodePort. Ships Audit; Enforce is the deliberate follow-up (#5088).
+      cert-manager HTTP-01 solver Services are carved out.
+spec:
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.forbidNodePortService.action) }}
+  background: true
+  rules:
+    # ── Rule 1: no Service may be type=NodePort ───────────────────────────
+    - name: service-type-not-nodeport
+      match:
+        any:
+          - resources:
+              kinds:
+                - Service
+      exclude:
+        any:
+          # cert-manager ACME HTTP-01 solver — auto-created type=NodePort,
+          # GCs on challenge completion. Carved out by BOTH the upstream
+          # solver label and the name pattern (belt-and-braces; the label
+          # is the durable contract, the name pattern a fallback).
+          - resources:
+              selector:
+                matchLabels:
+                  acme.cert-manager.io/http01-solver: "true"
+          - resources:
+              names:
+                - "cm-acme-http-solver-*"
+          {{- with .Values.compliancePolicies.forbidNodePortService.excludeNamespaces }}
+          - resources:
+              namespaces:
+                {{- range . }}
+                - {{ . }}
+                {{- end }}
+          {{- end }}
+      validate:
+        message: >-
+          Service {{ `{{request.object.metadata.namespace}}/{{request.object.metadata.name}}` }}
+          is type=NodePort — FORBIDDEN by §854 (founder #1 ABSOLUTE ban). Never
+          use a NodePort, not even for testing. Expose it DIRECT instead: a
+          ClusterIP Service fronted by a gateway HTTPRoute/TCPRoute, or the
+          cilium LB-IPAM VIP / shared-EIP (lbipam.cilium.io/sharing-key). See
+          #5088.
+        deny:
+          conditions:
+            all:
+              - key: {{ `"{{ request.object.spec.type || '' }}"` }}
+                operator: Equals
+                value: NodePort
+    # ── Rule 2: a LoadBalancer Service must NOT allocate nodePorts ─────────
+    #    allocateLoadBalancerNodePorts defaults to true — an unset value
+    #    silently allocates a nodePort per port. §854-clean LoadBalancer
+    #    Services must set it to false explicitly. to_string() coerces the
+    #    (possibly-absent) bool to a string so the deny condition is nil-safe
+    #    and dodges the JMESPath `false || default` falsy trap.
+    - name: loadbalancer-must-disable-nodeport-allocation
+      match:
+        any:
+          - resources:
+              kinds:
+                - Service
+      {{- with .Values.compliancePolicies.forbidNodePortService.excludeNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range . }}
+                - {{ . }}
+                {{- end }}
+      {{- end }}
+      validate:
+        message: >-
+          Service {{ `{{request.object.metadata.namespace}}/{{request.object.metadata.name}}` }}
+          is type=LoadBalancer without allocateLoadBalancerNodePorts=false — it
+          silently allocates a nodePort per port, violating §854. Set
+          `spec.allocateLoadBalancerNodePorts: false` so no nodePort is opened.
+          See #5088.
+        deny:
+          conditions:
+            all:
+              - key: {{ `"{{ request.object.spec.type || '' }}"` }}
+                operator: Equals
+                value: LoadBalancer
+              - key: {{ `"{{ to_string(request.object.spec.allocateLoadBalancerNodePorts) }}"` }}
+                operator: NotEquals
+                value: "false"
+{{- end -}}

--- a/platform/kyverno-policies/chart/tests/forbid-nodeport-service/kyverno-test.yaml
+++ b/platform/kyverno-policies/chart/tests/forbid-nodeport-service/kyverno-test.yaml
@@ -1,0 +1,80 @@
+# #5088 — Kyverno conformance test for the §854 forbid-nodeport-service policy.
+#
+# Run with the Kyverno CLI:
+#   cd platform/kyverno-policies/chart
+#   # re-render the policy if the template/values changed:
+#   helm template . --set compliancePolicies.bootstrapMode=false \
+#     --set compliancePolicies.forbidNodePortService.action=Enforce \
+#     --show-only templates/baseline/24-forbid-nodeport-service.yaml \
+#     | grep -v '^# Source:' | sed '/^---$/d' \
+#     > tests/forbid-nodeport-service/policy.yaml
+#   kyverno test tests/forbid-nodeport-service/
+#
+# `policy.yaml` is the rendered ClusterPolicy at action=Enforce (committed so the
+# test is self-contained + CI-runnable without a Helm pass in the test step —
+# Enforce so the deny rules produce fail/pass verdicts the CLI can assert).
+#
+# SIX fixtures prove both rules + the cert-manager carve-out:
+#   Rule 1 (service-type-not-nodeport):
+#     - powerdns-api-ext (type=NodePort)                → DENIED  (the #5088 shape)
+#     - powerdns-api (type=ClusterIP)                   → admitted
+#     - gateway-lb-leaky / gateway-lb-clean (LB)        → admitted (not NodePort)
+#     - cm-acme-http-solver-by-label (NodePort+label)   → SKIPPED (carve-out)
+#     - cm-acme-http-solver-9xk2p (NodePort, name only) → SKIPPED (carve-out)
+#   Rule 2 (loadbalancer-must-disable-nodeport-allocation):
+#     - gateway-lb-leaky (LB, no allocateLoadBalancerNodePorts) → DENIED (§854 subtlety)
+#     - gateway-lb-clean (LB, allocateLoadBalancerNodePorts:false) → admitted
+#     - every non-LoadBalancer Service                          → admitted
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: forbid-nodeport-service-test
+policies:
+  - policy.yaml
+resources:
+  - resource-services.yaml
+results:
+  # ── Rule 1: service-type-not-nodeport ──────────────────────────────────
+  # NodePort Service → DENIED (§854).
+  - policy: forbid-nodeport-service
+    rule: service-type-not-nodeport
+    resources:
+      - openova-system/powerdns-api-ext
+    kind: Service
+    result: fail
+  # ClusterIP / LoadBalancer Services → not NodePort → admitted by rule 1.
+  - policy: forbid-nodeport-service
+    rule: service-type-not-nodeport
+    resources:
+      - openova-system/powerdns-api
+      - cilium-gateway/gateway-lb-leaky
+      - cilium-gateway/gateway-lb-clean
+    kind: Service
+    result: pass
+  # cert-manager HTTP-01 solver Services (type=NodePort) → EXCLUDED → skipped.
+  - policy: forbid-nodeport-service
+    rule: service-type-not-nodeport
+    resources:
+      - iogrid/cm-acme-http-solver-by-label
+      - iogrid/cm-acme-http-solver-9xk2p
+    kind: Service
+    result: skip
+  # ── Rule 2: loadbalancer-must-disable-nodeport-allocation ──────────────
+  # LoadBalancer WITHOUT allocateLoadBalancerNodePorts:false → DENIED (§854 subtlety).
+  - policy: forbid-nodeport-service
+    rule: loadbalancer-must-disable-nodeport-allocation
+    resources:
+      - cilium-gateway/gateway-lb-leaky
+    kind: Service
+    result: fail
+  # Non-LoadBalancer Services + the explicitly-disabled LoadBalancer → admitted.
+  - policy: forbid-nodeport-service
+    rule: loadbalancer-must-disable-nodeport-allocation
+    resources:
+      - openova-system/powerdns-api-ext
+      - openova-system/powerdns-api
+      - cilium-gateway/gateway-lb-clean
+      - iogrid/cm-acme-http-solver-by-label
+      - iogrid/cm-acme-http-solver-9xk2p
+    kind: Service
+    result: pass

--- a/platform/kyverno-policies/chart/tests/forbid-nodeport-service/policy.yaml
+++ b/platform/kyverno-policies/chart/tests/forbid-nodeport-service/policy.yaml
@@ -1,0 +1,87 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: forbid-nodeport-service
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: network-exposure
+  annotations:
+    policies.kyverno.io/title: Forbid NodePort Services (§854)
+    policies.kyverno.io/category: catalyst-network-exposure
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      §854 (founder #1 ABSOLUTE ban): a Service must never be type=NodePort, and
+      a type=LoadBalancer Service must set allocateLoadBalancerNodePorts=false so
+      it does not silently allocate nodePorts. The gateway is served DIRECT
+      (cilium LB-IPAM VIP / shared-EIP, or Local-ETP + hostPort), never a
+      nodePort. Ships Audit; Enforce is the deliberate follow-up (#5088).
+      cert-manager HTTP-01 solver Services are carved out.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    # ── Rule 1: no Service may be type=NodePort ───────────────────────────
+    - name: service-type-not-nodeport
+      match:
+        any:
+          - resources:
+              kinds:
+                - Service
+      exclude:
+        any:
+          # cert-manager ACME HTTP-01 solver — auto-created type=NodePort,
+          # GCs on challenge completion. Carved out by BOTH the upstream
+          # solver label and the name pattern (belt-and-braces; the label
+          # is the durable contract, the name pattern a fallback).
+          - resources:
+              selector:
+                matchLabels:
+                  acme.cert-manager.io/http01-solver: "true"
+          - resources:
+              names:
+                - "cm-acme-http-solver-*"
+      validate:
+        message: >-
+          Service {{request.object.metadata.namespace}}/{{request.object.metadata.name}}
+          is type=NodePort — FORBIDDEN by §854 (founder #1 ABSOLUTE ban). Never
+          use a NodePort, not even for testing. Expose it DIRECT instead: a
+          ClusterIP Service fronted by a gateway HTTPRoute/TCPRoute, or the
+          cilium LB-IPAM VIP / shared-EIP (lbipam.cilium.io/sharing-key). See
+          #5088.
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.type || '' }}"
+                operator: Equals
+                value: NodePort
+    # ── Rule 2: a LoadBalancer Service must NOT allocate nodePorts ─────────
+    #    allocateLoadBalancerNodePorts defaults to true — an unset value
+    #    silently allocates a nodePort per port. §854-clean LoadBalancer
+    #    Services must set it to false explicitly. to_string() coerces the
+    #    (possibly-absent) bool to a string so the deny condition is nil-safe
+    #    and dodges the JMESPath `false || default` falsy trap.
+    - name: loadbalancer-must-disable-nodeport-allocation
+      match:
+        any:
+          - resources:
+              kinds:
+                - Service
+      validate:
+        message: >-
+          Service {{request.object.metadata.namespace}}/{{request.object.metadata.name}}
+          is type=LoadBalancer without allocateLoadBalancerNodePorts=false — it
+          silently allocates a nodePort per port, violating §854. Set
+          `spec.allocateLoadBalancerNodePorts: false` so no nodePort is opened.
+          See #5088.
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.type || '' }}"
+                operator: Equals
+                value: LoadBalancer
+              - key: "{{ to_string(request.object.spec.allocateLoadBalancerNodePorts) }}"
+                operator: NotEquals
+                value: "false"

--- a/platform/kyverno-policies/chart/tests/forbid-nodeport-service/resource-services.yaml
+++ b/platform/kyverno-policies/chart/tests/forbid-nodeport-service/resource-services.yaml
@@ -1,0 +1,79 @@
+# #5088 — INPUT fixtures for the §854 forbid-nodeport-service (Enforce) policy.
+# Six Services exercise both rules + the cert-manager solver carve-out.
+
+# 1. VIOLATION: a plain type=NodePort Service → DENIED by rule 1 (§854).
+apiVersion: v1
+kind: Service
+metadata:
+  name: powerdns-api-ext
+  namespace: openova-system
+spec:
+  type: NodePort
+  ports:
+    - port: 8081
+      nodePort: 30853
+---
+# 2. CLEAN: a ClusterIP Service → ADMITTED (neither rule fires).
+apiVersion: v1
+kind: Service
+metadata:
+  name: powerdns-api
+  namespace: openova-system
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8081
+---
+# 3. VIOLATION: a type=LoadBalancer Service that does NOT set
+#    allocateLoadBalancerNodePorts:false → silently allocates nodePorts →
+#    DENIED by rule 2 (§854 subtlety).
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-lb-leaky
+  namespace: cilium-gateway
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 443
+---
+# 4. CLEAN: a type=LoadBalancer Service that explicitly disables nodePort
+#    allocation → ADMITTED (the §854-compliant LoadBalancer shape).
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-lb-clean
+  namespace: cilium-gateway
+spec:
+  type: LoadBalancer
+  allocateLoadBalancerNodePorts: false
+  ports:
+    - port: 443
+---
+# 5. CARVE-OUT (by label): cert-manager HTTP-01 solver Service — type=NodePort
+#    but labelled acme.cert-manager.io/http01-solver → EXCLUDED from rule 1.
+apiVersion: v1
+kind: Service
+metadata:
+  name: cm-acme-http-solver-by-label
+  namespace: iogrid
+  labels:
+    acme.cert-manager.io/http01-solver: "true"
+spec:
+  type: NodePort
+  ports:
+    - port: 8089
+      nodePort: 30633
+---
+# 6. CARVE-OUT (by name): cert-manager HTTP-01 solver Service — type=NodePort,
+#    no solver label but name matches cm-acme-http-solver-* → EXCLUDED from rule 1.
+apiVersion: v1
+kind: Service
+metadata:
+  name: cm-acme-http-solver-9xk2p
+  namespace: iogrid
+spec:
+  type: NodePort
+  ports:
+    - port: 8089
+      nodePort: 30634

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -483,6 +483,39 @@ compliancePolicies:
     # default — local-path is forbidden EVERYWHERE, including kube-system).
     excludeNamespaces: []
 
+  # #5088 — §854 NodePort AUDIT guard. §854 (founder #1 ABSOLUTE ban) forbids
+  # NodePort Services everywhere: "YOU CAN NEVER EVER USE NODEPORT EVEN FOR
+  # TESTING PURPOSE!!!" The gateway is served DIRECT (cilium LB-IPAM VIP /
+  # shared-EIP, or Local-ETP + hostPort), never a nodePort. Previously §854 was
+  # only enforced at chart-render time (per-chart `fail` guards) — nothing caught
+  # a runtime / non-chart NodePort applied straight to a live cluster. A live
+  # §854 walk (#5088) found 4 pre-existing NodePort Services on the mothership.
+  # This policy flags every `type=NodePort` Service AND every `type=LoadBalancer`
+  # Service that does not explicitly set `allocateLoadBalancerNodePorts: false`
+  # (an unset value silently allocates nodePorts), cluster-wide, at admission +
+  # in background scans.
+  #
+  # action DEFAULTS to Audit (report-only, not fail-closed) deliberately: four
+  # §854 violations already exist live (#5088), and cert-manager's HTTP-01 solver
+  # auto-creates `type=NodePort` Services — Audit-first confirms the signal is
+  # actionable (only the real violations, with the solver carve-out below) before
+  # any Enforce flip. Enforce is the DELIBERATE FOLLOW-UP once the 4 live
+  # violations are cleared and the Audit PolicyReport shows zero false positives:
+  # `--set compliancePolicies.forbidNodePortService.action=Enforce`. (The
+  # bootstrapMode helper still forces Audit during Phase-1 regardless.)
+  #
+  # cert-manager ACME HTTP-01 solver Services (`cm-acme-http-solver-*`, label
+  # `acme.cert-manager.io/http01-solver: "true"`) are carved out in the template
+  # — they are auto-created type=NodePort by cert-manager's default solver and GC
+  # on challenge completion (a known-accepted transient class).
+  forbidNodePortService:
+    enabled: true
+    action: Audit
+    # NodePorts are forbidden EVERYWHERE (including kube-system) per §854 —
+    # default empty. Operators add per-namespace escapes here only for a
+    # deliberate, documented exception.
+    excludeNamespaces: []
+
   # G98 (Refs #2644, 2026-06-01) — MUTATE policy that auto-stamps
   # `catalyst.openova.io/application` label on Pods cluster-wide.
   # Without this label, the Compliance scorecard's per-Application


### PR DESCRIPTION
## What

Adds a systemic §854 guardrail: a Kyverno `ClusterPolicy` (`forbid-nodeport-service`, baseline `24`) that flags NodePort Services **cluster-wide** — at admission **and** in background scans — so a runtime / non-chart NodePort can no longer slip past the render-time `fail` guards.

**Refs #5088 #4765** — held (a keystone cutover is in flight; do not merge).

## Why

§854 (founder #1 ABSOLUTE ban) was enforced **only at chart-render time** (per-chart `{{ fail }}` guards in Helm templates). Nothing caught a NodePort applied straight to a live cluster. The live §854 walk in #5088 found 4 pre-existing NodePort Services on the mothership that the render-time guards never saw. This closes that gap at the admission layer.

## The policy

Two rules in one `ClusterPolicy`:

1. `service-type-not-nodeport` — denies any `Service` with `spec.type == NodePort`.
2. `loadbalancer-must-disable-nodeport-allocation` — denies any `type=LoadBalancer` Service that does **not** set `allocateLoadBalancerNodePorts: false` (an unset value silently allocates a nodePort per port — the §854 subtlety the issue calls out).

Both run `background: true`, resolve their action through the existing `bp-kyverno-policies.action` helper, and default to **Audit**.

### Why Audit, not Enforce (deliberate)

- Four §854 violations already exist live (#5088). Enforce is admission-time (create/update) so it would not retro-block them, but it **would** risk fail-closing a legitimate ephemeral Service class before the known violations are triaged.
- cert-manager's default HTTP-01 solver auto-creates `type=NodePort` solver Services. Audit-first confirms the signal is actionable (only the real violations, with the solver carve-out below) on a live `PolicyReport` before any hardening.

**Enforce is the deliberate follow-up** once (a) the 4 live violations in #5088 are cleared and (b) the Audit report shows zero false positives — flip with `--set compliancePolicies.forbidNodePortService.action=Enforce` (post-handover, after `bootstrapMode=false`).

### cert-manager carve-out

cert-manager's built-in HTTP-01 solver creates a short-lived `type=NodePort` Service per in-flight ACME challenge (`cm-acme-http-solver-<rand>`, label `acme.cert-manager.io/http01-solver: "true"`), GC'd on completion. Rule 1 excludes them by **both** the upstream solver label and the name pattern, so the policy's report stays actionable and is not drowned in solver churn. The §854-clean long-term path is migrating issuers to the DNS-01 / gateway-API solver so no NodePort solver is ever created.

## Where it lives

`platform/kyverno-policies/chart` (the `bp-kyverno-policies` chart — same library as the existing `forbid-local-path`, `flux-managed`, etc. baseline policies):

- `templates/baseline/24-forbid-nodeport-service.yaml` — the ClusterPolicy.
- `values.yaml` — `compliancePolicies.forbidNodePortService` (`enabled`, `action`, `excludeNamespaces`; NodePorts forbidden everywhere → default empty excludes).
- `tests/forbid-nodeport-service/` — a `kyverno test` harness (rendered Enforce policy + 6 Service fixtures).
- `Chart.yaml` — version 1.0.47 → 1.0.48 + changelog.

## Gate results

- `helm lint` — clean (only the standard "icon is recommended" INFO).
- `helm template` — full chart renders 24 ClusterPolicies, no errors; disable gate verified (`enabled=false` → empty).
- `kyverno test tests/forbid-nodeport-service/` — **12/12 pass**: NodePort DENIED, leaky LoadBalancer DENIED, ClusterIP + disabled-nodePort LoadBalancer + both solver Services ADMITTED (`Reason: Excluded`).
- All 4 policy test dirs re-run green (12 / 2 / 5 / 3).

## Secondary finding — `openova-system/powerdns-api-ext` (8081:30853)

Investigated per #5088. This Service is **not defined in this public repo** — it is a manual / mothership-hand-applied Service (the `-ext` suffix + `openova-system` namespace are not emitted by any chart here; likely a legacy hand-exposure predating the §854-compliant path). It is therefore **not fixable from this repo**.

The §854-compliant replacement **already exists** in `platform/powerdns/chart`:
- `templates/api-httproute.yaml` exposes the powerdns API via a Gateway-API `HTTPRoute` → ClusterIP `powerdns` backend on 8081.
- `templates/anycast-endpoint.yaml` already `fail`s render on `serviceType=NodePort` and emits `allocateLoadBalancerNodePorts: false` for LoadBalancer (#4765, chart v1.2.18).

**Recommendation for the founder:** delete the manual `openova-system/powerdns-api-ext` NodePort Service and rely on the chart's existing HTTPRoute for API exposure. No chart edit is shipped here because the chart is already §854-clean.

The other 3 live NodePort Services from #5088 are report-only (no code): `cinova/catalog-svc` is protected SME never-touch; `iogrid/proxy-gateway-socks5` is app-owned; `iogrid/cm-acme-http-solver-*` is a stuck 41-day ACME challenge (cert-manager root-cause, auto-GCs on resolution — and is the exact class this policy carves out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)