### PR TITLE
fix(powerdns): Hetzner DNS front door via dnsdist hostPort:53 DaemonSet

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -150,7 +150,12 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve powerdns (no more "no Application CR").
-      version: 1.2.20
+      # 1.2.21 (#5086, Refs #4765): dnsdist.hostPortMode — on Hetzner (only)
+      # dnsdist becomes a DaemonSet binding hostPort:53 on every node so the
+      # tofu dns LB :53->node:53 forward reaches a real listener (the LB-IPAM
+      # anycast VIP path is dead on Hetzner). §854-clean: hostPort, NEVER a
+      # NodePort. Driven below by ${POWERDNS_DNSDIST_HOSTPORT} (Hetzner-only).
+      version: 1.2.21
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns
@@ -215,6 +220,16 @@ spec:
       uiRedirectHost: pdns-admin.${SOVEREIGN_FQDN}
       gateway:
         enabled: true
+    # ── Hetzner DNS front door (#5086, Refs #4765) ─────────────────────────
+    # On Hetzner the Cilium LB-IPAM sovereign-vip pool is gated OFF and
+    # hcloud-ccm cannot materialise the anycast Service, so node:53 never binds
+    # via the VIP path (below) and the tofu `dns` LB :53->node:53 forward is
+    # inert. hostPortMode flips dnsdist to a hostPort:53 DaemonSet that binds
+    # node:53 directly (§854-clean — hostPort, NEVER a NodePort). The Hetzner
+    # cloud-init sets POWERDNS_DNSDIST_HOSTPORT=true; on Huawei/kom4dc the var
+    # is UNSET → default false → the LB-IPAM anycast path stays UNTOUCHED.
+    dnsdist:
+      hostPortMode: ${POWERDNS_DNSDIST_HOSTPORT:=false}
     # DNS-01 wildcard cert: expose PowerDNS :53 as a Cilium LB-IPAM
     # LoadBalancer VIP sharing the Sovereign EIP (§854 DIRECT,
     # lbipam.cilium.io/sharing-key). This is the NS-delegated endpoint

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -790,6 +790,9 @@ write_files:
             # variable validation rejects "" and "local-path", so this substitute
             # can never render an empty or ephemeral class.
             SOVEREIGN_CNPG_STORAGE_CLASS: "${default_storage_class}"
+            # #5086 Hetzner DNS front door: dnsdist hostPort:53 DaemonSet binds
+            # node:53 (LB-IPAM anycast VIP dead here). hostPort, NEVER nodePort.
+            POWERDNS_DNSDIST_HOSTPORT: "true"
 %{ endif ~}
 %{ if provider == "huawei" ~}
             # Huawei: no cloud CCM. Cilium LB-IPAM assigns the ExternalIP

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -191,14 +191,13 @@ resource "hcloud_firewall" "main" {
   # forwards :53 → node:53 on the standard port — §854 / #4765: the
   # powerdns-anycast Service is type=LoadBalancer with
   # allocateLoadBalancerNodePorts:false (bp-powerdns ≥1.2.18 fails render on
-  # NodePort), so no node:3xxxx hop exists to forward to. ⚠️ node:53 does NOT
-  # yet BIND on Hetzner (#5086): the anycast Service takes its ingress from the
-  # Cilium LB-IPAM sovereign-vip VIP, which is gated OFF on Hetzner (hcloud-ccm
-  # path), and hcloud-ccm cannot materialise the anycast Service either (no
-  # nodePort target, no location annotation). So this rule + the dns LB forward
-  # are §854-clean but INERT until #5086 restores a node:53 listener on
-  # Hetzner. Not a regression — node:30053 was equally dead since the
-  # bp-powerdns 1.2.18 §854 flip.
+  # NodePort), so no node:3xxxx hop exists to forward to. The node:53 LISTENER
+  # on Hetzner is the bp-powerdns ≥1.2.21 dnsdist DaemonSet (hostPortMode, gated
+  # ON via the Hetzner cloud-init POWERDNS_DNSDIST_HOSTPORT substitute): it binds
+  # hostPort:53 on every node (§854 hostPort, NEVER a nodePort). The Cilium
+  # LB-IPAM sovereign-vip anycast VIP stays dead on Hetzner (gated OFF; no
+  # hcloud-ccm fallback) — hostPort is the front door. LIVE-GATED (#5086):
+  # unproven until a real Hetzner prov confirms `dig @<node> <fqdn>` resolves.
   rule {
     direction  = "in"
     protocol   = "tcp"
@@ -1028,16 +1027,23 @@ resource "hcloud_server" "control_plane" {
   # behavior-risky config trims, so the guardrail is raised to 32512 — still
   # 256 B below the 32768 hard cap. Prefer cutting; only raise for #5042-class
   # fail-loud features that must not be silently truncated.
+  # #5086 (2026-07-15): +1 substitute var POWERDNS_DNSDIST_HOSTPORT (~46 B) —
+  # the Hetzner DNS-front-door gate (flips dnsdist to a hostPort:53 DaemonSet).
+  # It's a config value that must NOT be silently truncated (else node:53 never
+  # binds and Sovereign DNS stays dead). Comments are stripped pre-measure (the
+  # replace() regex above), so no comment cull can offset it AND the render is
+  # already at its documented floor — guardrail raised 32512 → 32576, still
+  # 192 B below the 32768 hard cap.
   lifecycle {
     precondition {
-      condition = length(local.control_plane_cloud_init) <= 32512
+      condition = length(local.control_plane_cloud_init) <= 32576
       # G107 #2702 (2026-06-01): wrap length() with nonsensitive() so the
       # byte count shows in the error_message. Without it tofu redacts the
       # entire message because the local references hcloud_token / ssh_key
       # marked sensitive. Operators iterating on cloud-init slim-downs
       # cannot target their cuts without knowing the actual overshoot;
       # nonsensitive() leaks only the integer length, not any token bytes.
-      error_message = "Rendered control-plane cloud-init is ${nonsensitive(length(local.control_plane_cloud_init))} bytes, exceeds 32512 (256 B below the Hetzner 32768 hard cap) guardrail. Cull comments / move bloat out of cloudinit-control-plane.tftpl. See issues #966 / #1981 / #5057 / #5042."
+      error_message = "Rendered control-plane cloud-init is ${nonsensitive(length(local.control_plane_cloud_init))} bytes, exceeds 32576 (192 B below the Hetzner 32768 hard cap) guardrail. Cull comments / move bloat out of cloudinit-control-plane.tftpl. See issues #966 / #1981 / #5057 / #5042 / #5086."
     }
     precondition {
       condition     = length(local.worker_cloud_init) <= 30720
@@ -1185,16 +1191,15 @@ resource "hcloud_load_balancer_service" "dns" {
   # anycast-endpoint ServiceType=NodePort overlay that #4766 eradicated from
   # 11-powerdns.yaml (now type=LoadBalancer + lbipam.cilium.io/sharing-key,
   # allocateLoadBalancerNodePorts:false — bp-powerdns ≥1.2.18 hard-fails on
-  # NodePort), so node:30053 can never be bound again. §854-clean, BUT ⚠️ INERT
-  # on Hetzner today (#5086): unlike the http/https legs above — whose Cilium
-  # Gateway Service IS materialised by hcloud-ccm (its own hcloud LB), so those
-  # legs limp along — the anycast Service has NO hcloud-ccm fallback (no
-  # location annotation, no nodePort) AND Cilium LB-IPAM is gated OFF on
-  # Hetzner, so nothing binds node:53. This forward resolves Sovereign DNS only
-  # after #5086 restores a node:53 listener on Hetzner (enable the Cilium
-  # LB-IPAM sovereign-vip pool as on Huawei, or hostPort:53 on dnsdist). Not a
-  # regression — node:30053 has been equally dead since the bp-powerdns 1.2.18
-  # §854 flip. Do NOT read this as "DNS works on Hetzner".
+  # NodePort), so node:30053 can never be bound again. §854-clean.
+  # #5086: the node:53 LISTENER on Hetzner is now the bp-powerdns ≥1.2.21
+  # dnsdist DaemonSet (hostPortMode, gated ON via the Hetzner cloud-init
+  # POWERDNS_DNSDIST_HOSTPORT substitute) — it binds hostPort:53 on every node
+  # (§854 hostPort, NEVER a nodePort), so this LB forward reaches a real
+  # listener. (The Cilium LB-IPAM sovereign-vip anycast VIP path stays dead on
+  # Hetzner: no hcloud-ccm fallback, LB-IPAM gated OFF — hostPort is the front
+  # door here.) LIVE-GATED: unproven until a real Hetzner prov confirms
+  # `dig @<node> <fqdn>` resolves; no Hetzner env is currently up.
   # lb11 supports TCP only; UDP :53 is handled via the Hetzner Firewall
   # opening UDP/53 directly to the node's public IP. The LB TCP path handles
   # zone transfers and ACME challenge TXT queries; UDP is used for regular

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.20
+  version: 1.2.21
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -56,7 +56,15 @@ name: bp-powerdns
 #   Service as the forbidden NodePort.
 # 1.2.20 (#4765): hook-Job labels spelled out so managed-by=flux actually
 #   renders — the 1.2.19 duplicate-key override was inert (first key wins).
-version: 1.2.20
+# 1.2.21 (#5086, Refs #4765): Hetzner DNS front door. New dnsdist.hostPortMode
+#   (default false — Huawei/kom4dc anycast-VIP path UNCHANGED). When true (set
+#   ONLY by the Hetzner cloud-init substitute), dnsdist becomes a DaemonSet
+#   whose container binds hostPort:53 on every node so the tofu `dns` LB
+#   :53->node:53 forward has a real listener. §854-clean: hostPort ONLY, NEVER
+#   a NodePort. No hostNetwork (pod-netns :53 bind dodges the Ubuntu-24.04
+#   systemd-resolved 127.0.0.53:53 stub). Live-gated: proven on a real Hetzner
+#   prov (dig @<node> <fqdn>), no Hetzner env currently up.
+version: 1.2.21
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/dnsdist.yaml
+++ b/platform/powerdns/chart/templates/dnsdist.yaml
@@ -21,15 +21,33 @@ data:
   dnsdist.conf: |
     {{- tpl .Values.dnsdist.config . | nindent 4 }}
 ---
+{{- /*
+Workload kind is Hetzner-gated (#5086, Refs #4765). DEFAULT
+(Huawei / kom4dc / contabo): a Deployment fronted by the Cilium LB-IPAM
+anycast VIP (anycast-endpoint.yaml) — this path is UNCHANGED. On Hetzner the
+LB-IPAM `sovereign-vip` pool is gated OFF and hcloud-ccm cannot materialise the
+anycast Service (no location annotation, no nodePort), so node:53 never binds
+via the VIP path and the tofu `dns` LB :53 -> node:53 forward is inert.
+`dnsdist.hostPortMode: true` (set ONLY by the Hetzner cloud-init substitute)
+flips dnsdist to a DaemonSet whose container claims hostPort:53 on EVERY node
+(the Hetzner DNS LB targets all nodes — CP + workers), giving that forward a
+real listener. §854-clean: hostPort ONLY, NEVER a NodePort (#4765). Deliberately
+NO hostNetwork — dnsdist binds :53 inside the pod netns (Cilium
+kube-proxy-replacement DNATs node:53 -> pod), so it never collides with the
+Ubuntu-24.04 systemd-resolved stub already holding 127.0.0.53:53 on the host.
+*/}}
+{{- $hostPort := .Values.dnsdist.hostPortMode | default false }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ if $hostPort }}DaemonSet{{ else }}Deployment{{ end }}
 metadata:
   name: dnsdist
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bp-powerdns.dnsdistLabels" . | nindent 4 }}
 spec:
+  {{- if not $hostPort }}
   replicas: {{ .Values.dnsdist.replicaCount | default 1 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: dnsdist
@@ -40,10 +58,17 @@ spec:
         {{- include "bp-powerdns.dnsdistLabels" . | nindent 8 }}
       annotations:
         # Hash the rendered dnsdist.conf (post-tpl) so a values change rolls
-        # the Deployment automatically. Avoid `include "<this file>"` —
+        # the workload automatically. Avoid `include "<this file>"` —
         # that's a recursive template self-reference and Helm rejects it.
         checksum/config: {{ tpl .Values.dnsdist.config . | sha256sum }}
     spec:
+      {{- if $hostPort }}
+      # DNS front door on EVERY node the Hetzner LB targets (CP + workers).
+      # Tolerate all taints so the CP node (an LB :53 target) is covered too —
+      # mirrors bp-cilium's every-node clustermesh-proxy host-socket DaemonSet.
+      tolerations:
+        - operator: Exists
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 953
@@ -61,9 +86,15 @@ spec:
           ports:
             - name: dns-udp
               containerPort: 53
+              {{- if $hostPort }}
+              hostPort: 53          # §854 node:53 direct bind — NEVER a NodePort (#4765)
+              {{- end }}
               protocol: UDP
             - name: dns-tcp
               containerPort: 53
+              {{- if $hostPort }}
+              hostPort: 53          # §854 node:53 direct bind — NEVER a NodePort (#4765)
+              {{- end }}
               protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -333,6 +333,20 @@ postgres:
 # PowerDNS replica. Defaults: 100 qps per source IP, configurable.
 dnsdist:
   enabled: true
+  # ─── Hetzner DNS front door (#5086, Refs #4765) ─────────────────────────
+  # DEFAULT false ⇒ dnsdist is a Deployment fronted by the Cilium LB-IPAM
+  # anycast VIP (the working path on Huawei / kom4dc / contabo — UNTOUCHED).
+  # On Hetzner the LB-IPAM `sovereign-vip` pool is gated OFF and hcloud-ccm
+  # cannot materialise the anycast Service (no location annotation, no
+  # nodePort), so node:53 never binds via the VIP path and the tofu `dns`
+  # LB :53->node:53 forward is inert. Set true (ONLY by the Hetzner
+  # cloud-init substitute POWERDNS_DNSDIST_HOSTPORT) to make dnsdist a
+  # DaemonSet whose container claims hostPort:53 on every node — a
+  # §854-clean node:53 listener (hostPort ONLY, NEVER a NodePort). No
+  # hostNetwork: dnsdist binds :53 in the pod netns (Cilium
+  # kube-proxy-replacement DNATs node:53->pod) so it never collides with the
+  # Ubuntu-24.04 systemd-resolved stub on 127.0.0.53:53.
+  hostPortMode: false
   image:
     # Official dnsdist image. Repo `powerdns/dnsdist-19` carries the 1.9.x
     # line (matches Authoritative 5.0.x release cadence). Pin a concrete

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4771,7 +4771,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-powerdns
-    version: "1.2.20"
+    version: "1.2.21"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Facet-A of #5086 — Hetzner Sovereign DNS front door

**Root cause (repo-confirmed, no live cluster touched):** on Hetzner the Cilium LB-IPAM `sovereign-vip` pool is gated OFF and hcloud-ccm cannot materialise the powerdns `anycast` Service (no `load-balancer.hetzner.cloud/location` annotation, no nodePort target) → `EXTERNAL-IP <pending>` → the tofu `dns` LB `:53 -> node:53` forward has no listener → Sovereign DNS has had no front door since the bp-powerdns 1.2.18 §854 flip. Not a #5080 regression; the §854 literal-eradication half (#5080) already merged.

**Decided path (per the #5086 decision comment): `hostPort:53` on dnsdist, Hetzner-gated.**

### What this does
- New `dnsdist.hostPortMode` (default **false**). Default renders the existing **Deployment** behind the LB-IPAM anycast VIP — the **Huawei / kom4dc / contabo path is UNCHANGED** (verified: the default render is byte-identical apart from one comment word).
- When **true**, `platform/powerdns/chart/templates/dnsdist.yaml` renders dnsdist as a **DaemonSet** whose container claims `hostPort: 53` (TCP+UDP) so the pod binds `node:53` directly.

### DaemonSet, not CP-pinned — why
The Hetzner main LB (`hcloud_load_balancer.main`) targets **CP + every worker** for `:53` (`hcloud_load_balancer_target.control_plane` + `.workers`, `main.tf`), round-robining the `:53` forward across all of them. A CP-pinned single pod would leave every worker's `:53` health-check dead. A DaemonSet (with `tolerations: operator: Exists`, mirroring bp-cilium's every-node clustermesh-proxy host-socket DaemonSet) gives every LB target a real listener.

### Plain hostPort, NOT hostNetwork — why
Hetzner nodes run **ubuntu-24.04**, which ships systemd-resolved with a stub on **127.0.0.53:53**, and cloud-init does not disable it. A `hostNetwork` pod binding host `0.0.0.0:53` would overlap that stub → `EADDRINUSE` → CrashLoop → DNS still dead. Plain `hostPort` binds `:53` inside the pod netns (Cilium `kubeProxyReplacement: true` DNATs `node:53 -> pod`), avoiding the collision while staying §854-clean. No live Kyverno policy blocks hostPort (the `disallow-host-ports` policy is Audit-only + QA-fixture-gated; bp-cilium's clustermesh-proxy already runs `hostPort:12379` live).

### §854 compliance
`hostPort` only, **NEVER a NodePort**. The chart's `fail`-on-`serviceType=NodePort` guard is untouched; the full-chart render in both modes greps clean of any nodePort literal (only the pre-existing `allocateLoadBalancerNodePorts: false` suppressor + `NEVER a NodePort` comments remain).

### Gating
`clusters/_template/bootstrap-kit/11-powerdns.yaml` sets `dnsdist.hostPortMode: ${POWERDNS_DNSDIST_HOSTPORT:=false}`. Only the `provider == "hetzner"` block of `infra/providers/_shared/cloudinit-control-plane.tftpl` sets `POWERDNS_DNSDIST_HOSTPORT: "true"`; Huawei leaves it unset -> default false -> its working LB-IPAM anycast VIP path is untouched.

### Gates run
- `helm lint platform/powerdns/chart` -> 0 failed.
- Rendered `dnsdist.yaml`, both modes: default = Deployment + replicas, no hostPort/hostNetwork; Hetzner = DaemonSet, no replicas, `tolerations`, `hostPort: 53` x2. No nodePort/hostNetwork literal in either mode.
- `cd infra/providers/hetzner && tofu test` -> **12 passed, 0 failed** (`tofu fmt` clean). The realistic three-region render is 32519 B; cloud-init comments are stripped pre-measure (the `replace()` regex), so the ~46 B substitute var cannot be offset by comment culling and the render is at its documented floor — the CP guardrail is raised 32512 -> 32576 (still 192 B below the 32768 Hetzner hard cap) per the in-file "raise for a config value that must not be silently truncated" policy.
- `scripts/cloudinit-size-check.sh both` -> every surface within cap.
- Chart `1.2.20 -> 1.2.21`; overlay pin bumped in lockstep.

### Live-gated (not yet proven)
No Hetzner env is currently up, so `node:53` binding cannot be shown live. This needs a real Hetzner prov to confirm `dig @<node> <fqdn>` resolves — in particular that Cilium's hostPort DNAT reaches the pod for UDP `:53` on the LB-targeted node IPs.

**Do not merge** — the RT-11 keystone cutover is in flight; this stays held.

Refs #5086 #4765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
