### PR TITLE
fix(cutover): step-08 rule c — never roll stateful RWO-EVS singletons (#5091)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -861,7 +861,7 @@ spec:
       # as ClusterIP (no VIP ever), so the pin deferred FOREVER on every
       # ELB-direct prov (hw250 all night); ClusterIP now pins HOST_IP like the
       # absent-Service hostNetwork branch. LoadBalancer semantics unchanged.
-      version: 0.1.133
+      version: 0.1.134
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.133
+  version: 0.1.134
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,40 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.134 (#5091 Refs #5081 #4975 — step-08 minimal roll-set RULE C: never
+# force-roll a stateful RWO-EVS singleton). The #5081 minimal roll-set (rule a:
+# skip infra namespaces; rule b: skip infra-ns DaemonSets) correctly excludes the
+# CSI driver / cilium / hubble, but it STILL selected deployment/gitea — a
+# REPRESENTATIVE-namespace (gitea) stateful RWO-EVS singleton (gitea-shared-storage
+# evs-ssd 20Gi, Recreate strategy) — as a fresh-pull representative and force-rolled
+# it under the deny-egress hold. That roll's NodeUnstage removed the CSI globalmount
+# while the VolumeAttachment persisted unchanged, so the EVS CSI node driver never
+# re-fired NodeStage → NodePublish failed `special device .../globalmount does not
+# exist` (exit 32) → the replacement pod hung Init:0/3 past the 600s roll budget →
+# ROLL_FAIL deployment/gitea → step-08 FRESH-PULL proof FAILED → cutoverComplete
+# stayed false forever (proven LIVE on hw253, dep 8a0f810a, 2026-07-15). The CSI
+# driver is healthy — this is a NodeStage-not-retriggered-when-VA-persists desync
+# with no zero-touch recovery. FIX (template 08 + values + rbac): add RULE C to the
+# minimal roll-set filter — skip any Deployment/StatefulSet whose pod template mounts
+# an RWO PVC backed by EVS (storageClass in
+# freshPullProof.rwoEvsExclusion.storageClasses [evs-ssd] OR bound-PV CSI driver in
+# rwoEvsExclusion.csiDrivers [evs.csi.huaweicloud.com]). Their image locality is
+# ALREADY proven by the #4975 pre-hold completeness HEAD gate + the #5026 ref-host
+# lint (both prove locality WITHOUT rolling), so the synthetic roll adds NO
+# image-proof value — the fresh-pull ROLL proof rolls STATELESS representative
+# workloads only. Rule c filters the candidate universe BEFORE both the
+# representative-namespace selection AND the Deployment top-up, so the
+# minRepresentativesPerRegion (12) floor is still met from the STATELESS pool (a real
+# Sovereign has dozens of stateless non-infra Deployments). New step-08 envs
+# FRESH_PULL_RWO_EVS_EXCLUDE / _STORAGECLASSES / _CSIDRIVERS + a workload_rwo_evs_reason()
+# detector; RBAC adds persistentvolumes {get,list} (the bound-PV CSI-driver leg;
+# persistentvolumeclaims get/list already present from #4996). NOT weakened: rule a/b,
+# the #4975 completeness gate, the 600s deny-egress hold, the curl-000 call-home proof
+# — rule c ONLY narrows the ROLL set. New cutover-contract Case 57 proves an
+# RWO-EVS-mounting workload is skipped (rule c) while a stateless one still rolls. NO
+# step-count / job-mode change (still 11 steps). Slot-06a pin + blueprint.yaml +
+# catalog-seed source.version + spec.version move to 0.1.134 in lockstep (Inviolable
+# Principle #13; catalog-seed pin must NOT lag the chart).
+# ── prior ──
 # 0.1.133 (#5074 #5065 #5059 Refs #3379 — step-08 ROLL-SET MINIMIZATION, the
 # root treadmill-breaker): the per-workload freshPullProof.excludeWorkloads list
 # was whack-a-mole — each prov surfaced ONE more infra workload broken by the
@@ -2077,7 +2112,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.133
+version: 0.1.134
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -186,6 +186,28 @@ data:
             value: {{ .Values.egressTest.freshPullProof.minRepresentativesPerRegion | default 12 | quote }}
           - name: FRESH_PULL_REPRESENTATIVE_NAMESPACES
             value: {{ .Values.egressTest.freshPullProof.representativeNamespaces | default (list "flux-system" "gitea" "harbor" "keycloak" "grafana") | join " " | quote }}
+          # #5091 — MINIMAL-mode rule c: NEVER force-roll a stateful RWO-EVS
+          # singleton (gitea, keycloak-postgresql, harbor-database/redis, cnpg,
+          # …). Its image locality is ALREADY proven by the #4975 pre-hold
+          # completeness HEAD gate + the #5026 ref-host lint (both prove locality
+          # WITHOUT rolling); the synthetic roll adds NO image-proof value and
+          # triggers the UNRECOVERABLE CSI NodeStage/VolumeAttachment desync — a
+          # Recreate roll's NodeUnstage removes the CSI globalmount, the
+          # VolumeAttachment persists unchanged, so NodeStage never re-fires and
+          # NodePublish then fails on the missing globalmount → the replacement
+          # pod hangs Init:0/3 past the roll budget → ROLL_FAIL → step-08 fails
+          # forever (proven live hw253 gitea, #5091). Detection = an RWO PVC whose
+          # storageClass is in rwoEvsExclusion.storageClasses OR whose bound-PV
+          # CSI driver is in rwoEvsExclusion.csiDrivers. This ONLY narrows the
+          # ROLL set — rule a/b, the #4975 completeness gate, the #5026 ref-host
+          # lint, the 600s deny-egress hold + the curl call-home proof are all
+          # untouched.
+          - name: FRESH_PULL_RWO_EVS_EXCLUDE
+            value: {{ eq (toString .Values.egressTest.freshPullProof.rwoEvsExclusion.enabled) "true" | quote }}
+          - name: FRESH_PULL_RWO_EVS_STORAGECLASSES
+            value: {{ .Values.egressTest.freshPullProof.rwoEvsExclusion.storageClasses | default (list "evs-ssd") | join " " | quote }}
+          - name: FRESH_PULL_RWO_EVS_CSIDRIVERS
+            value: {{ .Values.egressTest.freshPullProof.rwoEvsExclusion.csiDrivers | default (list "evs.csi.huaweicloud.com") | join " " | quote }}
         volumeMounts:
           # #3379 (hw139, 2026-06-15): WRITABLE emptyDir at /work. The
           # container runs readOnlyRootFilesystem:true (securityContext
@@ -862,6 +884,56 @@ data:
               return 1
             }
 
+            # ── #5091 rule-c detection: is a workload a stateful RWO-EVS singleton? ─
+            # Echoes a human reason "<claim> sc=<sc> driver=<driver> modes=<modes>"
+            # for the FIRST pod-template volume whose PVC is ReadWriteOnce AND
+            # backed by EVS (storageClass in FRESH_PULL_RWO_EVS_STORAGECLASSES OR
+            # the BOUND-PV CSI driver in FRESH_PULL_RWO_EVS_CSIDRIVERS); empty
+            # output = NOT an RWO-EVS stateful singleton → safe to roll. Only
+            # single-writer (RWO) volumes hit the NodeStage/VolumeAttachment desync
+            # (#5091) — a RWX shared-fs volume has no per-node globalmount hand-off
+            # to lose, so it is never matched. FAIL-OPEN: any kubectl/jq gap yields
+            # empty (the workload STAYS a roll candidate — its image locality is
+            # still HARD-proven by the #4975 completeness HEAD gate either way, so a
+            # missing RBAC/tooling read can never silently weaken the sovereignty
+            # proof, only over-roll).
+            workload_rwo_evs_reason() {
+              _wek="$1"; _wens="$2"; _wenm="$3"
+              _we_scs="${FRESH_PULL_RWO_EVS_STORAGECLASSES:-evs-ssd}"
+              _we_drivers="${FRESH_PULL_RWO_EVS_CSIDRIVERS:-evs.csi.huaweicloud.com}"
+              _we_claims=$(kubectl get "${_wek}" "${_wenm}" -n "${_wens}" \
+                -o jsonpath='{range .spec.template.spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{end}' 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | sort -u || true)
+              [ -z "${_we_claims}" ] && return 0
+              for _we_c in ${_we_claims}; do
+                _we_pvc=$(kubectl get pvc "${_we_c}" -n "${_wens}" -o json 2>/dev/null || true)
+                [ -z "${_we_pvc}" ] && continue
+                _we_modes=$(printf '%s' "${_we_pvc}" | jq -r '.spec.accessModes // [] | join(",")' 2>/dev/null || echo "")
+                case ",${_we_modes}," in
+                  *,ReadWriteOnce,*) : ;;
+                  *) continue ;;
+                esac
+                _we_sc=$(printf '%s' "${_we_pvc}" | jq -r '.spec.storageClassName // ""' 2>/dev/null || echo "")
+                _we_pv=$(printf '%s' "${_we_pvc}" | jq -r '.spec.volumeName // ""' 2>/dev/null || echo "")
+                _we_driver=""
+                [ -n "${_we_pv}" ] && _we_driver=$(kubectl get pv "${_we_pv}" -o jsonpath='{.spec.csi.driver}' 2>/dev/null || echo "")
+                _we_hit=0
+                for _we_want in ${_we_scs}; do
+                  [ "${_we_sc}" = "${_we_want}" ] && { _we_hit=1; break; }
+                done
+                if [ "${_we_hit}" != "1" ]; then
+                  for _we_want in ${_we_drivers}; do
+                    [ "${_we_driver}" = "${_we_want}" ] && { _we_hit=1; break; }
+                  done
+                fi
+                if [ "${_we_hit}" = "1" ]; then
+                  printf '%s sc=%s driver=%s modes=%s' "${_we_c}" "${_we_sc:-<none>}" "${_we_driver:-<none>}" "${_we_modes}"
+                  return 0
+                fi
+              done
+              return 0
+            }
+
             run_fresh_pull_all() {
               echo "[egress-block-test] #3695: fresh-pull roll under deny-egress (roll-set mode: ${FRESH_PULL_ROLL_SET_MODE:-minimal})"
               # Enumerate Deployments/DaemonSets/StatefulSets whose container
@@ -962,6 +1034,28 @@ data:
                     done
                     if [ "${_allow}" != "1" ]; then
                       echo "  skip (rule a: infra namespace, not allowlisted) ${_rkind} ${_rns}/${_rname}"
+                      continue
+                    fi
+                  fi
+                  # ── #5091 rule c: skip stateful RWO-EVS singletons ──────────
+                  # A Deployment/StatefulSet whose pod template mounts an RWO PVC
+                  # backed by EVS is a stateful singleton whose forced roll under
+                  # the deny-egress hold triggers the UNRECOVERABLE NodeStage/
+                  # VolumeAttachment desync (globalmount removed on NodeUnstage,
+                  # the VA persists, NodeStage never re-fires → NodePublish fails
+                  # on the missing globalmount → the replacement pod hangs
+                  # Init:0/3 → ROLL_FAIL → step-08 fails forever; live hw253
+                  # gitea, #5091). Its image locality is ALREADY HEAD-proven by
+                  # the #4975 pre-hold completeness gate, so the synthetic roll
+                  # adds NO image-proof value — the fresh-pull ROLL proof rolls
+                  # STATELESS representative workloads only. Applied to
+                  # deployment/statefulset (a DaemonSet cannot mount an RWO PVC
+                  # across nodes; rule b already covers infra-ns DaemonSets).
+                  if [ "${FRESH_PULL_RWO_EVS_EXCLUDE:-true}" = "true" ] \
+                     && { [ "${_rkind}" = "deployment" ] || [ "${_rkind}" = "statefulset" ]; }; then
+                    _rwo_reason=$(workload_rwo_evs_reason "${_rkind}" "${_rns}" "${_rname}")
+                    if [ -n "${_rwo_reason}" ]; then
+                      echo "  skip (rule c: RWO-EVS stateful singleton — image locality is HEAD-proven, roll triggers NodeStage/VA desync) ${_rkind} ${_rns}/${_rname} [${_rwo_reason}]"
                       continue
                     fi
                   fi

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -130,7 +130,10 @@ rules:
     resources: ["nodes"]   # registry-pivot DaemonSet reports node status into the status ConfigMap; step 07 (#4996) reads node EVS zone labels to spot a broken-CSI node
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]   # step 07 (#4996) maps catalyst-api's PVCs -> PV names to scope the EVS detach-gate to catalyst-api's OWN volumes
+    resources: ["persistentvolumeclaims"]   # step 07 (#4996) maps catalyst-api's PVCs -> PV names to scope the EVS detach-gate to catalyst-api's OWN volumes; step 08 (#5091) rule-c reads each roll candidate's PVC accessModes + storageClassName to skip RWO-EVS stateful singletons
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]   # step 08 (#5091) rule-c resolves a candidate PVC's BOUND PV to read .spec.csi.driver (the storageClass-independent EVS-detection leg, so a PVC with an empty storageClassName is still caught)
     verbs: ["get", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]   # step 07 (#4996) enumerates VolumeAttachments to find + clear the STALE RWO-EVS attachment that Multi-Attach-deadlocks a Recreate roll (#4972)

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2309,8 +2309,17 @@ done
 _c56="$TMP/rollset56"; mkdir -p "$_c56/bin" "$_c56/work"
 helm template smoke . --show-only templates/08-egress-block-test-job.yaml > "$TMP/r08c56.yaml"
 _slice_fn "$TMP/r08c56.yaml" run_fresh_pull_all | sed 's#/work/#'"$_c56"'/work/#g' > "$_c56/sweep.sh"
+# run_fresh_pull_all now calls the #5091 rule-c detector — slice + source it too
+# so the real (both-functions-present) environment is reproduced. The Case-56
+# mock kubectl returns no PVCs for these fixtures, so rule c finds nothing to
+# skip and the roll-set behaviour asserted below is unchanged (Case 57 exercises
+# rule c's skip path against RWO-EVS fixtures).
+_slice_fn "$TMP/r08c56.yaml" workload_rwo_evs_reason > "$_c56/rwo.sh"
 if ! grep -q 'run_fresh_pull_all() {' "$_c56/sweep.sh"; then
   echo "FAIL: could not slice run_fresh_pull_all from step-08 (#5074)" >&2; exit 1
+fi
+if ! grep -q 'workload_rwo_evs_reason() {' "$_c56/rwo.sh"; then
+  echo "FAIL: could not slice workload_rwo_evs_reason from step-08 (#5074 / #5091)" >&2; exit 1
 fi
 cat > "$_c56/bin/kubectl" <<'MOCK'
 #!/bin/sh
@@ -2355,6 +2364,7 @@ _run56() { # $1 = FRESH_PULL_ROLL_SET_MODE
     export FRESH_PULL_INFRA_ALLOWLIST=""
     export FRESH_PULL_MIN_REPS_PER_REGION="12"
     export FRESH_PULL_REPRESENTATIVE_NAMESPACES="flux-system gitea harbor keycloak grafana"
+    . "$_c56/rwo.sh"
     . "$_c56/sweep.sh"
     roll_and_check_workload() { echo "ROLLED $1 $2/$3"; return 0; }
     : > "$_c56/work/roll_failures.txt"
@@ -2382,5 +2392,153 @@ done
 grep -qF 'ROLLED deployment flux-system/source-controller' <<<"$_full_out" \
   && { printf 'FAIL: full (legacy) mode rolled a LOCAL-registry-ref workload — legacy external-only selection changed; output:\n%s\n' "$_full_out" >&2; exit 1; }
 echo "  PASS (minimal: infra-ns DaemonSets + non-allowlisted infra workloads excluded by rule, representative sample rolled incl. Deployment top-up; full: legacy external-registry sweep byte-identical)"
+
+# ── Case 57 (#5091 Refs #5081 #4975): step-08 roll-set RULE C ───────────────
+# The #5081 minimal roll-set (rule a/b) still selected deployment/gitea — a
+# REPRESENTATIVE-namespace stateful RWO-EVS singleton — and force-rolled it under
+# the deny-egress hold, tripping the unrecoverable CSI NodeStage/VolumeAttachment
+# desync (globalmount missing) → ROLL_FAIL → step-08 fails forever (live hw253).
+# rule c must SKIP any Deployment/StatefulSet mounting an RWO PVC backed by EVS
+# (storageClass in rwoEvsExclusion.storageClasses OR bound-PV CSI driver in
+# rwoEvsExclusion.csiDrivers) while STILL rolling stateless representatives. The
+# ≥minRepresentativesPerRegion floor stays met from the stateless pool (rule c
+# filters candidates BEFORE the representative selection AND the Deployment
+# top-up, so the top-up draws only stateless workloads).
+echo "[cutover-contract] Case 57: step-08 rule c — a stateful RWO-EVS singleton (gitea evs-ssd / keycloak-postgresql evs.csi driver) is SKIPPED; stateless representatives still roll; floor met from the stateless pool (#5091 Refs #5081 #4975)"
+# Static: the rule-c knobs must reach the Job env with the new defaults.
+if ! grep -A1 'name: FRESH_PULL_RWO_EVS_EXCLUDE' "$TMP/render.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: freshPullProof.rwoEvsExclusion.enabled default must be true (#5091)" >&2
+  exit 1
+fi
+if ! grep -A1 'name: FRESH_PULL_RWO_EVS_STORAGECLASSES' "$TMP/render.yaml" | grep -q 'evs-ssd'; then
+  echo "FAIL: FRESH_PULL_RWO_EVS_STORAGECLASSES default must carry evs-ssd (#5091)" >&2
+  exit 1
+fi
+if ! grep -A1 'name: FRESH_PULL_RWO_EVS_CSIDRIVERS' "$TMP/render.yaml" | grep -q 'evs.csi.huaweicloud.com'; then
+  echo "FAIL: FRESH_PULL_RWO_EVS_CSIDRIVERS default must carry evs.csi.huaweicloud.com (#5091)" >&2
+  exit 1
+fi
+# RBAC: rule c reads PVCs (accessModes/storageClass) + bound PVs (csi.driver).
+if ! grep -q 'resources: \["persistentvolumes"\]' "$TMP/render.yaml"; then
+  echo "FAIL: rule c needs persistentvolumes get/list in the runner ClusterRole (#5091)" >&2
+  exit 1
+fi
+# Behavioral: slice run_fresh_pull_all + the rule-c detector, stub
+# roll_and_check_workload, mock kubectl (enumeration + per-candidate PVC/PV
+# lookups). Fixture: representative-ns workloads gitea (RWO evs-ssd → skip via
+# storageClass leg) + keycloak-postgresql (RWO, empty SC, bound-PV driver
+# evs.csi.huaweicloud.com → skip via driver leg); stateless source-controller /
+# harbor-core (representative ns, no PVC → roll) + orgapp/web (top-up → roll).
+_c57="$TMP/rollset57"; mkdir -p "$_c57/bin" "$_c57/work"
+helm template smoke . --show-only templates/08-egress-block-test-job.yaml > "$TMP/r08c57.yaml"
+_slice_fn "$TMP/r08c57.yaml" run_fresh_pull_all | sed 's#/work/#'"$_c57"'/work/#g' > "$_c57/sweep.sh"
+_slice_fn "$TMP/r08c57.yaml" workload_rwo_evs_reason > "$_c57/rwo.sh"
+if ! grep -q 'run_fresh_pull_all() {' "$_c57/sweep.sh"; then
+  echo "FAIL: could not slice run_fresh_pull_all from step-08 (#5091)" >&2; exit 1
+fi
+if ! grep -q 'workload_rwo_evs_reason() {' "$_c57/rwo.sh"; then
+  echo "FAIL: could not slice workload_rwo_evs_reason from step-08 (#5091)" >&2; exit 1
+fi
+cat > "$_c57/bin/kubectl" <<'MOCK'
+#!/bin/sh
+# $1 is always "get".
+case "$2" in nodes) printf 'af-north-1\n'; exit 0 ;; esac
+if [ "$3" = "-A" ]; then
+  case "$2" in
+    deployments)
+      printf 'deployment gitea gitea=registry.t99.omani.works/proxy-ghcr/go-gitea/gitea:1.22 \n'
+      printf 'deployment flux-system source-controller=registry.t99.omani.works/proxy-ghcr/fluxcd/source-controller:v1.3 \n'
+      printf 'deployment harbor harbor-core=registry.t99.omani.works/proxy-dockerhub/goharbor/harbor-core:v2.11 \n'
+      printf 'deployment orgapp web=registry.t99.omani.works/proxy-dockerhub/library/nginx:1.27 \n'
+      ;;
+    statefulsets)
+      printf 'statefulset keycloak keycloak-postgresql=registry.t99.omani.works/proxy-dockerhub/bitnami/postgresql:16 \n'
+      ;;
+    daemonsets) : ;;
+  esac
+  exit 0
+fi
+# rule-c per-candidate lookups.
+case "$2" in
+  deployment|statefulset)
+    # get <kind> <name> -n <ns> -o jsonpath=...volumes... → claimName lines.
+    _name="$3"; _ns="$5"
+    case "${_ns}/${_name}" in
+      gitea/gitea)                     printf 'gitea-shared-storage\n' ;;
+      keycloak/keycloak-postgresql)    printf 'data-keycloak-postgresql\n' ;;
+      *) : ;;  # stateless — no PVC-backed volumes
+    esac
+    exit 0 ;;
+  pvc)
+    _name="$3"
+    case "${_name}" in
+      gitea-shared-storage)            printf '{"spec":{"accessModes":["ReadWriteOnce"],"storageClassName":"evs-ssd","volumeName":"pv-gitea"}}\n' ;;
+      data-keycloak-postgresql)        printf '{"spec":{"accessModes":["ReadWriteOnce"],"storageClassName":"","volumeName":"pv-kc-pg"}}\n' ;;
+      *) : ;;
+    esac
+    exit 0 ;;
+  pv)
+    _name="$3"
+    case "${_name}" in
+      pv-gitea|pv-kc-pg)               printf 'evs.csi.huaweicloud.com' ;;
+      *) : ;;
+    esac
+    exit 0 ;;
+esac
+exit 0
+MOCK
+chmod +x "$_c57/bin/kubectl"
+_run57() { # $1 = FRESH_PULL_RWO_EVS_EXCLUDE
+  ( set +e; set -u
+    export PATH="$_c57/bin:$PATH"
+    export FRESH_PULL_ROLL_SET_MODE="minimal"
+    export FRESH_PULL_RWO_EVS_EXCLUDE="$1"
+    export FRESH_PULL_RWO_EVS_STORAGECLASSES="evs-ssd"
+    export FRESH_PULL_RWO_EVS_CSIDRIVERS="evs.csi.huaweicloud.com"
+    export LOCAL_REGISTRY_SUBSTR="registry.t99.omani.works"
+    export FRESH_PULL_EXCLUDE="catalyst-api"
+    export EXCLUDED_HOSTS="xpkg.upbound.io"
+    export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
+    export FRESH_PULL_EXCLUDE_WORKLOADS="catalyst/registry-pivot"
+    export FRESH_PULL_INFRA_NAMESPACES="kube-system huawei-evs-csi catalyst"
+    export FRESH_PULL_INFRA_ALLOWLIST=""
+    export FRESH_PULL_MIN_REPS_PER_REGION="12"
+    export FRESH_PULL_REPRESENTATIVE_NAMESPACES="flux-system gitea harbor keycloak grafana"
+    . "$_c57/rwo.sh"
+    . "$_c57/sweep.sh"
+    roll_and_check_workload() { echo "ROLLED $1 $2/$3"; return 0; }
+    : > "$_c57/work/roll_failures.txt"
+    run_fresh_pull_all; echo "RC=$?" )
+}
+# (i) exclusion ON (the fix) — RWO-EVS singletons skipped, stateless rolled.
+_on_out=$(_run57 true)
+grep -q 'RC=0' <<<"$_on_out" || { printf 'FAIL: rule-c sweep did not PASS; output:\n%s\n' "$_on_out" >&2; exit 1; }
+# gitea (storageClass leg) + keycloak-postgresql (bound-PV driver leg) SKIPPED by rule c.
+grep 'skip (rule c: RWO-EVS stateful singleton' <<<"$_on_out" | grep -q 'deployment gitea/gitea' \
+  || { printf 'FAIL: rule c did not skip the RWO-EVS gitea Deployment (storageClass leg); output:\n%s\n' "$_on_out" >&2; exit 1; }
+grep 'skip (rule c: RWO-EVS stateful singleton' <<<"$_on_out" | grep -q 'statefulset keycloak/keycloak-postgresql' \
+  || { printf 'FAIL: rule c did not skip the RWO-EVS keycloak-postgresql StatefulSet (bound-PV driver leg); output:\n%s\n' "$_on_out" >&2; exit 1; }
+grep -q 'gitea-shared-storage sc=evs-ssd' <<<"$_on_out" \
+  || { printf 'FAIL: rule-c skip line did not name the offending claim/storageClass; output:\n%s\n' "$_on_out" >&2; exit 1; }
+grep -q 'data-keycloak-postgresql sc=<none> driver=evs.csi.huaweicloud.com' <<<"$_on_out" \
+  || { printf 'FAIL: rule-c skip line did not name the bound-PV CSI driver; output:\n%s\n' "$_on_out" >&2; exit 1; }
+# The RWO-EVS singletons must NEVER be rolled.
+for _never in 'ROLLED deployment gitea/gitea' 'ROLLED statefulset keycloak/keycloak-postgresql'; do
+  grep -qF "$_never" <<<"$_on_out" && { printf 'FAIL: rule c let an RWO-EVS stateful singleton roll (%s) — the #5091 desync would re-fire; output:\n%s\n' "$_never" "$_on_out" >&2; exit 1; }
+done
+# Stateless representatives + the Deployment top-up STILL roll (floor met from the
+# stateless pool — the RWO-EVS singletons were removed from the candidate universe
+# BEFORE selection/top-up, never re-added).
+for _want in 'ROLLED deployment flux-system/source-controller' 'ROLLED deployment harbor/harbor-core' 'ROLLED deployment orgapp/web'; do
+  grep -qF "$_want" <<<"$_on_out" || { printf 'FAIL: rule c dropped a STATELESS representative that must still roll (%s); output:\n%s\n' "$_want" "$_on_out" >&2; exit 1; }
+done
+# (ii) exclusion OFF — the toggle reverts to the pre-#5091 behaviour: the RWO-EVS
+# gitea is force-rolled again (proves rule c is exactly what skips it).
+_off_out=$(_run57 false)
+grep -qF 'ROLLED deployment gitea/gitea' <<<"$_off_out" \
+  || { printf 'FAIL: with rwoEvsExclusion off, gitea should roll (pre-#5091 behaviour) — the toggle is inert; output:\n%s\n' "$_off_out" >&2; exit 1; }
+grep -q 'skip (rule c' <<<"$_off_out" \
+  && { printf 'FAIL: rule c fired while FRESH_PULL_RWO_EVS_EXCLUDE=false — the switch does not gate it; output:\n%s\n' "$_off_out" >&2; exit 1; }
+echo "  PASS (rule c skips gitea [evs-ssd] + keycloak-postgresql [evs.csi driver], names the offending claim; stateless source-controller/harbor-core/web still roll; toggle-off reverts to force-roll)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1284,6 +1284,46 @@ egressTest:
       - "harbor"
       - "keycloak"
       - "grafana"
+    # ── #5091 rule c: exclude stateful RWO-EVS singletons from the ROLL set ─
+    # The #5081 minimal roll-set (rules a/b) correctly excludes the infra
+    # namespaces + infra DaemonSets, but a REPRESENTATIVE-namespace stateful
+    # singleton — gitea (RWO evs-ssd 20Gi, Recreate strategy), keycloak-
+    # postgresql, harbor-database/redis, cnpg, … — is still selected and
+    # force-rolled. Rolling such a workload under the deny-egress hold triggers
+    # the UNRECOVERABLE CSI NodeStage/VolumeAttachment desync: the Recreate
+    # roll's NodeUnstage removes the EVS globalmount, the VolumeAttachment
+    # persists unchanged, so the CSI node driver never re-fires NodeStage and
+    # NodePublish then fails `special device .../globalmount does not exist`
+    # (exit 32) → the replacement pod hangs Init:0/3 past the roll budget →
+    # ROLL_FAIL → step-08 fails forever (proven LIVE on hw253 gitea, #5091).
+    # The image locality of every such workload is ALREADY proven by the #4975
+    # pre-hold completeness HEAD gate + the #5026 ref-host lint (both prove
+    # locality WITHOUT rolling), so the synthetic roll adds ZERO image-proof
+    # value. rule c therefore SKIPS any Deployment/StatefulSet mounting an RWO
+    # PVC whose storageClass is in storageClasses OR whose bound-PV CSI driver
+    # is in csiDrivers. This ONLY narrows the ROLL set — the fresh-pull ROLL
+    # proof rolls STATELESS representative workloads only; rule a/b, the
+    # completeness gate, the ref-host lint, the 600s deny-egress hold and the
+    # curl call-home proof are all untouched. The ≥minRepresentativesPerRegion
+    # floor is still met from the STATELESS pool: rule c filters the candidate
+    # universe BEFORE both the representative selection AND the Deployment
+    # top-up, so the top-up naturally draws only stateless workloads (a real
+    # Sovereign has dozens of stateless non-infra Deployments — far above the
+    # 12/region floor).
+    rwoEvsExclusion:
+      # Master switch (default true — the keystone cc=true path needs it).
+      enabled: true
+      # StorageClass names treated as EVS-backed RWO block storage. Huawei EVS
+      # by default; add hcloud-volumes (Hetzner) or another block CSI's class
+      # via overlay for provider parity (matches the excludeWorkloads pattern
+      # that carries hcloud-csi names as a harmless no-op when absent).
+      storageClasses:
+        - "evs-ssd"
+      # Bound-PV CSI driver names treated as EVS-backed RWO block storage —
+      # the second, storageClass-independent detection leg (a PVC with an empty
+      # storageClassName but a bound PV on this driver is still caught).
+      csiDrivers:
+        - "evs.csi.huaweicloud.com"
   # #5026 — PRE-HOLD ref-host lint (treadmill-breaker). The completeness gate
   # above proves image CONTENT is in local Harbor; this lint proves every
   # rolled workload's pod-spec image REF HOST is the local registry

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.133"
+    version: "0.1.134"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Defect (proven LIVE on hw253 step-08, dep 8a0f810a, 2026-07-15)

The #5081 minimal roll-set works — rule a (skip infra namespaces) + rule b (skip
infra-ns DaemonSets) correctly exclude the CSI driver / cilium / hubble. But it
still selected `deployment/gitea` — a representative-namespace **stateful RWO-EVS
singleton** (`gitea-shared-storage` evs-ssd 20Gi, Recreate strategy) — as a
fresh-pull representative and force-rolled it under the deny-egress hold:

```
FAIL — workload(s) failed to roll under deny-egress:  ROLL_FAIL deployment/gitea
FailedMount: mount failed: exit status 32 — special device .../evs.csi.huaweicloud.com/<h>/globalmount does not exist
```

The Recreate roll's `NodeUnstage` removed the CSI globalmount while the
`VolumeAttachment` persisted unchanged, so the EVS CSI node driver never re-fired
`NodeStage` → `NodePublish` failed on the missing globalmount → the replacement
pod hung `Init:0/3` past the 600s roll budget → `ROLL_FAIL` → step-08's fresh-pull
proof FAILED → `cutoverComplete` stayed false. The CSI driver is healthy; this is
a NodeStage-not-retriggered-when-VA-persists desync with no zero-touch recovery.

## Fix — rule c

Extend the minimal roll-set exclusion: **skip any Deployment/StatefulSet whose pod
template mounts an RWO PVC backed by EVS** — storageClass in
`freshPullProof.rwoEvsExclusion.storageClasses` (`evs-ssd`) OR bound-PV CSI driver
in `rwoEvsExclusion.csiDrivers` (`evs.csi.huaweicloud.com`). Detection resolves each
candidate's `.spec.template.spec.volumes[].persistentVolumeClaim.claimName`, then the
PVC's `accessModes`+`storageClassName` and (storageClass-independent leg) the bound
PV's `.spec.csi.driver`.

Their image locality is **already** proven by the #4975 pre-hold completeness HEAD
gate + the #5026 ref-host lint (both prove locality WITHOUT rolling), so the
synthetic roll adds no image-proof value. The fresh-pull ROLL proof now rolls
stateless representative workloads only.

**≥12-reps floor still holds from the stateless pool:** rule c filters the candidate
universe BEFORE both the representative-namespace selection AND the Deployment
top-up, so the top-up inherently draws only stateless workloads. A real Sovereign
carries dozens of stateless non-infra Deployments — far above the
`minRepresentativesPerRegion` (12) x regions floor. No namespace widening and no
silent floor lowering; if a pathological Sovereign had fewer than the floor of
stateless candidates the roll set is simply smaller (locality of everything is still
hard-proven by the HEAD gate + lint).

**Not weakened:** rule a/b, the #4975 completeness gate, the 600s deny-egress hold,
and the curl-000 call-home proof. Rule c only narrows the ROLL set.

## Changes

- `templates/08-egress-block-test-job.yaml`: `workload_rwo_evs_reason()` detector +
  rule c in the candidate filter loop + `FRESH_PULL_RWO_EVS_EXCLUDE` /
  `_STORAGECLASSES` / `_CSIDRIVERS` envs (fail-open on any kubectl/jq gap).
- `values.yaml`: `freshPullProof.rwoEvsExclusion.{enabled,storageClasses,csiDrivers}`.
- `templates/rbac.yaml`: add `persistentvolumes {get,list}` (the bound-PV CSI-driver
  leg; `persistentvolumeclaims` get/list already granted by #4996).
- `tests/cutover-contract.sh`: new **Case 57** — an RWO-EVS workload is skipped via
  both the storageClass leg (gitea/evs-ssd) and the bound-PV-driver leg
  (keycloak-postgresql/evs.csi.huaweicloud.com), stateless representatives still roll,
  and the toggle-off reverts to force-roll. Case 56 sources the new detector so it
  reproduces the real both-functions-present script.
- 4-surface lockstep bump to **0.1.134**: `Chart.yaml` + `blueprint.yaml` + slot-06a
  pin + catalog-seed `source.version`.

## Gates

- `helm lint` clean.
- `tests/cutover-contract.sh` all green (Cases 1–57) + `tests/image-registry-coverage.sh` PASS.
- Rendered step-03 + step-08 scripts parse clean under `dash -n` AND `busybox sh -n`
  (the container's actual shell).

Held — not for merge until after the pending keystone re-fire.

Refs #5091 #5081 #4975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
