### PR TITLE
fix(continuum): cnpg-pair Continuum CR surfaces standby-absent condition (0.1.10)

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -140,7 +140,16 @@ spec:
       # 0.1.9 (#4257): pure version bump (image still 9c91a7e) to force
       # Flux to re-pull — the 0.1.8 deploy-bot image-tag overwrite did not
       # change the version so the #4254 k8s-lease controller never rolled.
-      version: 0.1.9
+      # 0.1.10 (#4901): controller surfaces a lost REQUIRED synchronous
+      # hot-standby on the cnpg-pair Continuum CR status it owns — phase
+      # Healthy->Degraded + standbyAvailable/hotStandbyAbsent fields + a
+      # StandbyAvailable=False/StandbyUnreachable condition when the
+      # pair's replica-role Cluster half is not Ready or readyInstances=0
+      # (the G12 region-kill drill posture; before this the CR stayed
+      # Healthy/lag=0 through the whole outage). Naming mirrors the
+      # catalyst-api DR-panel projection (#4905). Pin moves in lockstep
+      # (Inviolable Principle #13).
+      version: 0.1.10
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/core/controllers/continuum/internal/cnpg/status.go
+++ b/core/controllers/continuum/internal/cnpg/status.go
@@ -81,6 +81,47 @@ type Status struct {
 	// Ready reports whether the Cluster is operationally Ready as
 	// surfaced by the conditions array (type=Ready, status=True).
 	Ready bool
+
+	// ReadyInstances is status.readyInstances — the count of the
+	// Cluster's Pods currently Ready. CNPG drops it to 0 when every
+	// instance is down (the #4901 region-kill state: nodes cordoned,
+	// replica Pods deleted). HasReadyInstances reports whether the
+	// field was present at all — an absent field means the Cluster
+	// status is too old/partial to judge on this axis.
+	ReadyInstances    int
+	HasReadyInstances bool
+}
+
+// StandbyAvailable reports whether the replica (standby) half of a
+// cnpg cluster-pair is genuinely serving as a hot-standby: its Cluster
+// reports Ready=True AND (when the field is present) at least one
+// instance is Ready (#4901).
+//
+// A Ready-but-LAGGING standby is still AVAILABLE — replication lag is
+// a separate axis (status.replicationLagSeconds) and must NEVER raise
+// a standby-absent alarm. Only an unreachable / down standby (not
+// Ready, or zero ready instances) counts as absent.
+func StandbyAvailable(replica Status) bool {
+	if !replica.Ready {
+		return false
+	}
+	if replica.HasReadyInstances {
+		return replica.ReadyInstances >= 1
+	}
+	return true
+}
+
+// StandbyObservation is one reconcile pass's determination of the
+// required synchronous hot-standby's availability (#4901). Known=false
+// means no determination could be made this pass (the CR names no
+// cnpg pair — dr-spine/raft continuums — or the replica half was not
+// resolvable, e.g. provisioning in flight); the controller then leaves
+// any prior StandbyAvailable condition untouched instead of
+// false-alarming.
+type StandbyObservation struct {
+	Known          bool
+	Available      bool
+	ReplicaCluster string
 }
 
 // Reader reads + writes CNPG Cluster CRs via the dynamic client.
@@ -244,6 +285,19 @@ func parseStatus(cr *unstructured.Unstructured) Status {
 		s.LagSeconds = int(lag)
 	} else if lag, found, _ := unstructured.NestedInt64(cr.Object, "status", "replication", "lagSeconds"); found {
 		s.LagSeconds = int(lag)
+	}
+
+	// readyInstances — tolerate the int64/int/float64 encodings the
+	// dynamic client + fakes produce (#4901).
+	if v, found, _ := unstructured.NestedFieldNoCopy(cr.Object, "status", "readyInstances"); found {
+		switch n := v.(type) {
+		case int64:
+			s.ReadyInstances, s.HasReadyInstances = int(n), true
+		case int:
+			s.ReadyInstances, s.HasReadyInstances = n, true
+		case float64:
+			s.ReadyInstances, s.HasReadyInstances = int(n), true
+		}
 	}
 
 	conds, _, _ := unstructured.NestedSlice(cr.Object, "status", "conditions")

--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -336,7 +336,7 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 				} else {
 					log.Info("lease lost; new holder in charge", "err", err)
 				}
-				_ = r.patchStatusFromCR(ctx, cr, spec, witness.State{}, cnpg.Status{}, cnpg.Status{}, false, "")
+				_ = r.patchStatusFromCR(ctx, cr, spec, witness.State{}, cnpg.Status{}, cnpg.Status{}, cnpg.StandbyObservation{}, false, "")
 				continue
 			}
 			_ = r.publishLeaseAcquired(ctx, nn, spec, newState)
@@ -346,12 +346,27 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 		}
 		leaseState = newState
 
+		// #4901 — resolve the required synchronous hot-standby's
+		// availability alongside lag. standby.Known stays false when the
+		// CR names no cnpg pair (dr-spine/raft continuums) or the pair's
+		// replica half is unresolvable (provisioning in flight) — the
+		// status patch then preserves any prior StandbyAvailable
+		// condition instead of false-alarming.
 		var primaryStatus, replicaStatus cnpg.Status
-		if cr := r.cnpgReader(); cr != nil && spec.CNPGNamespace != "" && spec.CNPGPair != "" {
-			primary, replica, fErr := cr.FindPair(ctx, spec.CNPGNamespace, spec.CNPGPair)
+		var standby cnpg.StandbyObservation
+		if reader := r.cnpgReader(); reader != nil && spec.CNPGNamespace != "" && spec.CNPGPair != "" {
+			primary, replica, fErr := reader.FindPair(ctx, spec.CNPGNamespace, spec.CNPGPair)
 			if fErr == nil {
-				primaryStatus, _, _ = cr.Get(ctx, primary.GetNamespace(), primary.GetName())
-				replicaStatus, _, _ = cr.Get(ctx, replica.GetNamespace(), replica.GetName())
+				primaryStatus, _, _ = reader.Get(ctx, primary.GetNamespace(), primary.GetName())
+				var gErr error
+				replicaStatus, _, gErr = reader.Get(ctx, replica.GetNamespace(), replica.GetName())
+				if gErr == nil {
+					standby = cnpg.StandbyObservation{
+						Known:          true,
+						Available:      cnpg.StandbyAvailable(replicaStatus),
+						ReplicaCluster: replica.GetName(),
+					}
+				}
 			}
 		}
 
@@ -369,7 +384,7 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 			_ = r.publishLagBreach(ctx, nn, spec, maxLag)
 			r.runSwitchover(ctx, cr, spec, toRegion, "lag-breach", maxLag, w)
 		default:
-			_ = r.patchStatusFromCR(ctx, cr, spec, leaseState, primaryStatus, replicaStatus, false, "")
+			_ = r.patchStatusFromCR(ctx, cr, spec, leaseState, primaryStatus, replicaStatus, standby, false, "")
 			_ = r.publishReconcileSuccess(ctx, nn, spec, maxLag)
 		}
 	}
@@ -761,6 +776,7 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 	spec ContinuumSpec,
 	lease witness.State,
 	primaryStatus, replicaStatus cnpg.Status,
+	standby cnpg.StandbyObservation,
 	switchoverInProgress bool,
 	stepLabel string,
 ) error {
@@ -772,6 +788,15 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 	if !heldByUs {
 		phase = PhaseDegraded
 	}
+	// #4901 — a lost REQUIRED synchronous hot-standby degrades the
+	// Continuum even while the lease is held correctly: an absent
+	// standby also reads lag=0 (nothing is following), so without this
+	// branch the CR stays phase=Healthy / replicationLagSeconds=0 for
+	// the whole outage while writes stall on SyncRep (proven in the
+	// G12 region-kill drill on hw232).
+	if standby.Known && !standby.Available && phase == PhaseHealthy {
+		phase = PhaseDegraded
+	}
 	su := statusUpdate{
 		Phase:                 phase,
 		PrimaryRegion:         spec.PrimaryRegion,
@@ -780,6 +805,11 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 		ReplicationLagSeconds: maxLag,
 		SwitchoverInProgress:  switchoverInProgress,
 		Step:                  stepLabel,
+	}
+	if standby.Known {
+		avail := standby.Available
+		su.StandbyAvailable = &avail
+		su.StandbyReplicaCluster = standby.ReplicaCluster
 	}
 	if !lease.ExpiresAt.IsZero() {
 		su.LeaseExpiresAt = lease.ExpiresAt.Format(time.RFC3339)
@@ -831,6 +861,18 @@ type statusUpdate struct {
 	// observed transition time, not the request time.
 	LastLuaRecord   map[string]interface{}
 	LastLuaRecordAt string
+
+	// StandbyAvailable — tri-state (#4901). nil = no determination this
+	// pass (non-cnpg-pair CRs, or replica half unresolvable): any prior
+	// StandbyAvailable condition is preserved and the standbyAvailable /
+	// hotStandbyAbsent status fields are left untouched. Non-nil = write
+	// status.standbyAvailable + status.hotStandbyAbsent and upsert the
+	// StandbyAvailable condition (True/StandbyReachable or
+	// False/StandbyUnreachable). Field + condition naming matches the
+	// catalyst-api DR-panel projection (#4905) so the stored status and
+	// the OBSERVED status agree.
+	StandbyAvailable      *bool
+	StandbyReplicaCluster string
 
 	Reason  string
 	Message string
@@ -909,6 +951,13 @@ func (r *ContinuumReconciler) patchStatus(ctx context.Context, cr *unstructured.
 			if t == "LastSwitchoverHealthy" && su.LastSwitchoverHealthy != "" {
 				continue
 			}
+			// #4901: same preserve-unless-rewriting contract for the
+			// StandbyAvailable condition — a pass with no determination
+			// (lease-lost patches, switchover step patches) keeps the
+			// last observed standby posture visible.
+			if t == "StandbyAvailable" && su.StandbyAvailable != nil {
+				continue
+			}
 			conds = append(conds, c)
 		}
 	}
@@ -942,6 +991,26 @@ func (r *ContinuumReconciler) patchStatus(ctx context.Context, cr *unstructured.
 			"message":            firstNonEmpty(su.LastSwitchoverHealthyDetail, su.Message),
 			"lastTransitionTime": r.now().UTC().Format(time.RFC3339),
 		})
+	}
+	// #4901 — surface the required synchronous hot-standby's
+	// availability on the CR the controller owns, mirroring the
+	// catalyst-api DR-panel projection's naming (#4905) so the two
+	// surfaces agree. Only written when this pass made a determination.
+	if su.StandbyAvailable != nil {
+		status["standbyAvailable"] = *su.StandbyAvailable
+		status["hotStandbyAbsent"] = !*su.StandbyAvailable
+		cond := map[string]interface{}{
+			"type":               "StandbyAvailable",
+			"status":             boolToCondStatus(*su.StandbyAvailable),
+			"reason":             "StandbyReachable",
+			"message":            fmt.Sprintf("required synchronous hot-standby (cnpg-pair replica cluster %q) is reachable and following the primary", su.StandbyReplicaCluster),
+			"lastTransitionTime": r.now().UTC().Format(time.RFC3339),
+		}
+		if !*su.StandbyAvailable {
+			cond["reason"] = "StandbyUnreachable"
+			cond["message"] = fmt.Sprintf("required synchronous hot-standby (cnpg-pair replica cluster %q) is unreachable; synchronous replication has no standby to acknowledge commits so writes stall and RPO=0 durability is at risk", su.StandbyReplicaCluster)
+		}
+		conds = append(conds, cond)
 	}
 	status["conditions"] = conds
 	latest.Object["status"] = status

--- a/core/controllers/continuum/internal/controller/continuum_controller_test.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller_test.go
@@ -416,7 +416,7 @@ func TestPatchStatusFromCR_HealthyWhenHolderMatchesPrimary_NoEnv(t *testing.T) {
 		Holder:    primary,
 		ExpiresAt: now.Add(30 * time.Second),
 	}
-	if err := r.patchStatusFromCR(context.Background(), cr, spec, lease, cnpg.Status{}, cnpg.Status{}, false, ""); err != nil {
+	if err := r.patchStatusFromCR(context.Background(), cr, spec, lease, cnpg.Status{}, cnpg.Status{}, cnpg.StandbyObservation{}, false, ""); err != nil {
 		t.Fatalf("patchStatusFromCR: %v", err)
 	}
 

--- a/core/controllers/continuum/internal/controller/standby_absent_4901_test.go
+++ b/core/controllers/continuum/internal/controller/standby_absent_4901_test.go
@@ -1,0 +1,254 @@
+// Tests for #4901 — the cnpg-pair Continuum CR must surface a
+// standby-absent condition instead of staying phase=Healthy /
+// replicationLagSeconds=0 while its REQUIRED synchronous hot-standby
+// is unreachable (the G12 region-kill drill on hw232 proved the
+// controller was blind to this: lease/primary tracking was correct
+// but a lost standby also reads lag=0, so RPO=0 durability risk was
+// invisible on the CR the controller owns).
+//
+// Semantics under test (mirrors the catalyst-api projection #4905 so
+// the stored + observed statuses agree):
+//   - replica half not Ready, or Ready with readyInstances==0
+//     → phase Degraded, standbyAvailable=false, hotStandbyAbsent=true,
+//     condition StandbyAvailable=False/StandbyUnreachable.
+//   - replica Ready (+ readyInstances>=1 when present)
+//     → phase stays Healthy, condition True/StandbyReachable.
+//   - Ready-but-LAGGING standby is NOT flagged — lag rides its own field.
+//   - no determination (lease-lost patch) preserves the prior condition.
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness"
+)
+
+// heldLease returns a witness lease held by the given region, unexpired.
+func heldLease(holder string) witness.State {
+	return witness.State{Holder: holder, ExpiresAt: time.Now().Add(30 * time.Second)}
+}
+
+// statusFields reads back phase + conditions + the #4901 fields.
+func statusFields(t *testing.T, r *ContinuumReconciler, ns, name string) (phase string, condStatus, condReason map[string]string, standbyAvailable, hotStandbyAbsent interface{}) {
+	t.Helper()
+	got, err := r.Dyn.Resource(ContinuumGVR).Namespace(ns).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR: %v", err)
+	}
+	phase, _, _ = unstructured.NestedString(got.Object, "status", "phase")
+	condStatus = map[string]string{}
+	condReason = map[string]string{}
+	conds, _, _ := unstructured.NestedSlice(got.Object, "status", "conditions")
+	for _, c := range conds {
+		cm, _ := c.(map[string]interface{})
+		typ, _ := cm["type"].(string)
+		st, _ := cm["status"].(string)
+		rs, _ := cm["reason"].(string)
+		condStatus[typ] = st
+		condReason[typ] = rs
+	}
+	standbyAvailable, _, _ = unstructured.NestedFieldNoCopy(got.Object, "status", "standbyAvailable")
+	hotStandbyAbsent, _, _ = unstructured.NestedFieldNoCopy(got.Object, "status", "hotStandbyAbsent")
+	return phase, condStatus, condReason, standbyAvailable, hotStandbyAbsent
+}
+
+// TestPatchStatusFromCR_StandbyAbsent_SurfacesDegraded — the proven
+// region-kill posture: lease held correctly by the primary, lag=0
+// (nothing following), replica half NOT Ready. The CR must go
+// Degraded with the explicit StandbyAvailable=False condition.
+func TestPatchStatusFromCR_StandbyAbsent_SurfacesDegraded(t *testing.T) {
+	t.Parallel()
+	const primary = "hw-me-east-215-a-rtz-prod"
+	cr := newTestContinuumCR("cnpg", "dr", primary, []string{"hw-me-east-215-b-rtz-prod"}, "k8s-lease")
+	r, _, _ := newReconciler(t, cr)
+	r.HoldingRegion = ""
+
+	spec, err := parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	standby := cnpg.StandbyObservation{Known: true, Available: false, ReplicaCluster: "demo-replica"}
+	if err := r.patchStatusFromCR(context.Background(), cr, spec, heldLease(primary), cnpg.Status{}, cnpg.Status{}, standby, false, ""); err != nil {
+		t.Fatalf("patchStatusFromCR: %v", err)
+	}
+
+	phase, condStatus, condReason, avail, absent := statusFields(t, r, "cnpg", "dr")
+	if phase != PhaseDegraded {
+		t.Errorf("phase = %q, want Degraded (standby absent must degrade even with the lease held)", phase)
+	}
+	if condStatus["StandbyAvailable"] != "False" {
+		t.Errorf("StandbyAvailable condition = %q, want False", condStatus["StandbyAvailable"])
+	}
+	if condReason["StandbyAvailable"] != "StandbyUnreachable" {
+		t.Errorf("StandbyAvailable reason = %q, want StandbyUnreachable", condReason["StandbyAvailable"])
+	}
+	if v, ok := avail.(bool); !ok || v {
+		t.Errorf("status.standbyAvailable = %v, want false", avail)
+	}
+	if v, ok := absent.(bool); !ok || !v {
+		t.Errorf("status.hotStandbyAbsent = %v, want true", absent)
+	}
+	// Lease tracking stays correct — the degradation is standby-driven.
+	if condStatus["LeaseHeld"] != "True" {
+		t.Errorf("LeaseHeld = %q, want True (lease tracking must be preserved verbatim)", condStatus["LeaseHeld"])
+	}
+	if condStatus["Ready"] != "False" {
+		t.Errorf("Ready = %q, want False when Degraded", condStatus["Ready"])
+	}
+}
+
+// TestPatchStatusFromCR_StandbyPresent_StaysHealthy — a reachable
+// standby keeps phase Healthy and writes the True condition.
+func TestPatchStatusFromCR_StandbyPresent_StaysHealthy(t *testing.T) {
+	t.Parallel()
+	const primary = "hw-me-east-215-a-rtz-prod"
+	cr := newTestContinuumCR("cnpg", "dr", primary, []string{"hw-me-east-215-b-rtz-prod"}, "k8s-lease")
+	r, _, _ := newReconciler(t, cr)
+	r.HoldingRegion = ""
+
+	spec, err := parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	standby := cnpg.StandbyObservation{Known: true, Available: true, ReplicaCluster: "demo-replica"}
+	if err := r.patchStatusFromCR(context.Background(), cr, spec, heldLease(primary), cnpg.Status{}, cnpg.Status{}, standby, false, ""); err != nil {
+		t.Fatalf("patchStatusFromCR: %v", err)
+	}
+
+	phase, condStatus, condReason, avail, absent := statusFields(t, r, "cnpg", "dr")
+	if phase != PhaseHealthy {
+		t.Errorf("phase = %q, want Healthy", phase)
+	}
+	if condStatus["StandbyAvailable"] != "True" {
+		t.Errorf("StandbyAvailable condition = %q, want True", condStatus["StandbyAvailable"])
+	}
+	if condReason["StandbyAvailable"] != "StandbyReachable" {
+		t.Errorf("StandbyAvailable reason = %q, want StandbyReachable", condReason["StandbyAvailable"])
+	}
+	if v, ok := avail.(bool); !ok || !v {
+		t.Errorf("status.standbyAvailable = %v, want true", avail)
+	}
+	if v, ok := absent.(bool); !ok || v {
+		t.Errorf("status.hotStandbyAbsent = %v, want false", absent)
+	}
+}
+
+// TestPatchStatusFromCR_NoDetermination_LeavesStandbyUntouched — a
+// pass with no determination (dr-spine/raft continuums, or replica
+// unresolvable) must not write the fields nor the condition, and a
+// later no-determination pass must PRESERVE a previously-written one.
+func TestPatchStatusFromCR_NoDetermination_LeavesStandbyUntouched(t *testing.T) {
+	t.Parallel()
+	const primary = "hw-me-east-215-a-rtz-prod"
+	cr := newTestContinuumCR("cnpg", "dr", primary, []string{"hw-me-east-215-b-rtz-prod"}, "k8s-lease")
+	r, _, _ := newReconciler(t, cr)
+	r.HoldingRegion = ""
+
+	spec, err := parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	// Pass 1: no determination at all — nothing standby-related lands.
+	if err := r.patchStatusFromCR(context.Background(), cr, spec, heldLease(primary), cnpg.Status{}, cnpg.Status{}, cnpg.StandbyObservation{}, false, ""); err != nil {
+		t.Fatalf("patchStatusFromCR: %v", err)
+	}
+	phase, condStatus, _, avail, absent := statusFields(t, r, "cnpg", "dr")
+	if phase != PhaseHealthy {
+		t.Errorf("phase = %q, want Healthy", phase)
+	}
+	if _, present := condStatus["StandbyAvailable"]; present {
+		t.Errorf("StandbyAvailable condition written with no determination — must be absent")
+	}
+	if avail != nil || absent != nil {
+		t.Errorf("standbyAvailable/hotStandbyAbsent written with no determination: %v / %v", avail, absent)
+	}
+
+	// Pass 2: standby-absent determination lands the condition.
+	standby := cnpg.StandbyObservation{Known: true, Available: false, ReplicaCluster: "demo-replica"}
+	if err := r.patchStatusFromCR(context.Background(), cr, spec, heldLease(primary), cnpg.Status{}, cnpg.Status{}, standby, false, ""); err != nil {
+		t.Fatalf("patchStatusFromCR: %v", err)
+	}
+	// Pass 3: lease-lost-style no-determination patch must preserve it.
+	if err := r.patchStatusFromCR(context.Background(), cr, spec, witness.State{}, cnpg.Status{}, cnpg.Status{}, cnpg.StandbyObservation{}, false, ""); err != nil {
+		t.Fatalf("patchStatusFromCR: %v", err)
+	}
+	_, condStatus, condReason, _, _ := statusFields(t, r, "cnpg", "dr")
+	if condStatus["StandbyAvailable"] != "False" || condReason["StandbyAvailable"] != "StandbyUnreachable" {
+		t.Errorf("prior StandbyAvailable condition not preserved across a no-determination pass: status=%q reason=%q",
+			condStatus["StandbyAvailable"], condReason["StandbyAvailable"])
+	}
+}
+
+// TestStandbyAvailable_Semantics — the pure availability rule: Ready
+// gates first; readyInstances==0 (present) is absent; an absent
+// readyInstances field falls back to Ready alone; LAG NEVER flags.
+func TestStandbyAvailable_Semantics(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		st   cnpg.Status
+		want bool
+	}{
+		{"not ready", cnpg.Status{Ready: false}, false},
+		{"ready, no readyInstances field", cnpg.Status{Ready: true}, true},
+		{"ready, readyInstances=0 (region-kill)", cnpg.Status{Ready: true, HasReadyInstances: true, ReadyInstances: 0}, false},
+		{"ready, readyInstances=1", cnpg.Status{Ready: true, HasReadyInstances: true, ReadyInstances: 1}, true},
+		{"ready but LAGGING — lag rides its own field, never flags", cnpg.Status{Ready: true, HasReadyInstances: true, ReadyInstances: 1, LagSeconds: 900}, true},
+		{"not ready and lagging", cnpg.Status{Ready: false, LagSeconds: 900}, false},
+	}
+	for _, tc := range cases {
+		if got := cnpg.StandbyAvailable(tc.st); got != tc.want {
+			t.Errorf("%s: StandbyAvailable = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRunPerCRPath_StandbyObservation_FromClusterPair exercises the
+// same wiring runPerCR uses: FindPair + Get → StandbyObservation. The
+// replica half present-but-not-Ready is exactly the proven #4901
+// region-kill state and must produce Known=true / Available=false.
+func TestRunPerCRPath_StandbyObservation_FromClusterPair(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "cnpg", "demo"
+	objs := newTestClusterPair(ns, pair, 0) // replica has NO Ready condition → not Ready
+	r, _, _ := newReconciler(t, objs...)
+
+	reader := r.cnpgReader()
+	primary, replica, err := reader.FindPair(context.Background(), ns, pair)
+	if err != nil {
+		t.Fatalf("FindPair: %v", err)
+	}
+	if primary == nil || replica == nil {
+		t.Fatal("pair halves missing")
+	}
+	replicaStatus, _, err := reader.Get(context.Background(), replica.GetNamespace(), replica.GetName())
+	if err != nil {
+		t.Fatalf("Get replica: %v", err)
+	}
+	if cnpg.StandbyAvailable(replicaStatus) {
+		t.Error("replica without Ready condition must read standby-absent")
+	}
+
+	// Flip the replica Ready + readyInstances=1 → available.
+	_ = unstructured.SetNestedSlice(replica.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+	_ = unstructured.SetNestedField(replica.Object, int64(1), "status", "readyInstances")
+	if _, err := r.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Update(context.Background(), replica, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update replica: %v", err)
+	}
+	replicaStatus, _, err = reader.Get(context.Background(), replica.GetNamespace(), replica.GetName())
+	if err != nil {
+		t.Fatalf("re-Get replica: %v", err)
+	}
+	if !cnpg.StandbyAvailable(replicaStatus) {
+		t.Error("Ready replica with readyInstances=1 must read standby-available")
+	}
+}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5368,7 +5368,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-continuum
-    version: "0.1.9"
+    version: "0.1.10"
   topology:
     supported:
       - active-hot-standby

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -77,7 +77,24 @@ type: application
 # Degraded/leaseHolder-empty -> Topology DR undeliverable. Bumping to
 # 0.1.9 (image still 9c91a7e) forces the re-pull. Slot-62 pin moves to
 # 0.1.9 in lockstep (Inviolable Principle #13).
-version: 0.1.9
+# 0.1.10 (#4901): the continuum-controller now surfaces a lost REQUIRED
+# synchronous hot-standby on the cnpg-pair Continuum CR status it owns:
+# phase Healthy->Degraded, status.standbyAvailable=false,
+# status.hotStandbyAbsent=true, and a StandbyAvailable=False /
+# StandbyUnreachable condition when the pair's replica-role Cluster
+# half is not Ready (or reports readyInstances=0 — the proven G12
+# region-kill state on hw232 where the CR sat phase=Healthy /
+# replicationLagSeconds=0 for the whole outage while writes stalled on
+# SyncRep). Field + condition naming matches the catalyst-api DR-panel
+# projection (#4905) so the stored and observed statuses agree. A
+# Ready-but-lagging standby is NEVER flagged (lag rides its own field);
+# dr-spine/raft continuums (no spec.cnpgPair) and unresolvable pairs
+# are left untouched — no false alarms. Chart templates unchanged
+# (controller-image change); the version bump forces the Flux re-pull
+# once the deploy-bot stamps the new image SHA (the 0.1.9 lesson).
+# Slot-62 pin + catalog-seed source.version move to 0.1.10 in lockstep
+# (Inviolable Principle #13).
+version: 0.1.10
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.9
+  version: 0.1.10
   card:
     title: Continuum
     summary: |


### PR DESCRIPTION
Refs #4901

## Defect

The G12 region-kill drill on hw232 proved the cnpg-pair Continuum CR (`cnpg-pair-bp-cnpg-pair-continuum`) stayed **phase=Healthy, replicationLagSeconds=0, switchoverInProgress=false** for the entire hot-standby outage. The controller derives phase purely from witness-lease-held-ness (`patchStatusFromCR`), and an ABSENT standby also reads lag=0 (nothing is following) — so RPO=0 durability risk was invisible on the CR the controller owns while writes stalled on SyncRep.

PR #4905 fixed only the catalyst-api **read projection** (`HandleContinuumGet` augment). The **stored CR status** — what `kubectl get continuum` and every other consumer reads, and what DR UAT rows 51/52/56 walk — kept lying. Verified live on hw255 (2026-07-15, read-only): the cnpg-pair Continuum CR carries only `LeaseHeld` + `Ready` conditions, no standby surface at all.

## Fix (controller-side, the CR status owner)

`core/controllers/continuum` — the reconcile loop now resolves the required synchronous hot-standby's availability off the same cnpg cluster-pair it already reads for lag: the replica-role Cluster half must be `Ready=True` AND (when the field is present) report `readyInstances >= 1`. On standby-absent the controller writes onto the CR status:

- `phase` Healthy → **Degraded** (lease/primary tracking preserved verbatim; `Ready` condition goes False; SwitchingOver/FailedOver never clobbered)
- `status.standbyAvailable=false` + `status.hotStandbyAbsent=true`
- condition **`StandbyAvailable=False / StandbyUnreachable`**

Naming mirrors the catalyst-api projection (#4905) so stored + observed statuses agree.

Guard rails (no false alarms):
- a Ready-but-**lagging** standby is NEVER flagged — lag rides its own field
- dr-spine / raft continuums (no `spec.cnpgPair`) and unresolvable pairs produce **no determination**: fields untouched, prior condition preserved across lease-lost / switchover-step patches

`cnpg.Status` gains `ReadyInstances`/`HasReadyInstances` (`status.readyInstances`, tolerant of int64/int/float64) + the `StandbyAvailable` rule + `StandbyObservation` carrier. The Continuum CRD status schema already carries `x-kubernetes-preserve-unknown-fields: true` — no CRD change needed.

## Chart lockstep (bp-continuum 0.1.9 → 0.1.10)

Templates unchanged (controller-image change); the version bump forces the Flux re-pull once the deploy-bot stamps the new controller image SHA (the 0.1.9 lesson — same-version digest overwrites are never re-pulled). All four surfaces move together (Inviolable Principle #13):
- `products/continuum/chart/Chart.yaml`
- `products/continuum/chart/blueprint.yaml`
- `clusters/_template/bootstrap-kit/62-bp-continuum.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`

## Tests + gates

- New `standby_absent_4901_test.go`: standby-absent → Degraded + False condition + fields; standby-present → Healthy + True condition; readyInstances=0 (present) → absent; Ready-but-lagging → available; no-determination passes preserve the prior condition; FindPair→Get wiring off a fake cluster-pair.
- `go build && go vet && go test ./continuum/...` — green
- `tests/e2e/bootstrap-kit` full suite incl. `TestBootstrapKit_BlueprintVersionLockstepSweep` — green
- `helm template products/continuum/chart --set continuum.enabled=true --set continuum.image.tag=<sha>` renders 6 resources
- `bash scripts/check-no-nodeports.sh` — exit 0

## Live evidence of the defect (hw255, read-only)

```
$ kubectl get continuum -n cnpg cnpg-pair-bp-cnpg-pair-continuum -o yaml
status:
  conditions: [LeaseHeld=True, Ready=True]   # no StandbyAvailable surface
  phase: Healthy
  replicationLagSeconds: 0
```

DO NOT MERGE while the hw255 cutover is in flight (merge train held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)