### PR TITLE
fix(catalyst-api): sovereign-admin fleet visibility on /sovereign/deployments list (Refs #4683)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1533,6 +1533,17 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 //     only filter and an empty ?owner= returns every deployment —
 //     same passthrough policy as checkOwnership() to keep existing
 //     tests working unchanged.
+//  4. Issue #4683 — a session that holds the catalyst-owner realm
+//     role (or the flattened tier=owner claim) is a sovereign-admin
+//     with FLEET-WIDE visibility: the session-email boundary of
+//     rule 2 does not apply. Owner-scoping is a marketplace-CUSTOMER
+//     concern; the operator console must show every deployment
+//     (including legacy rows with empty OwnerEmail) or the page
+//     renders empty the moment a prov was fired under a different
+//     operator identity — caught live on hw206 (console.openova.io
+//     /sovereign/deployments rendered empty for the operator). For
+//     such a session ?owner= becomes a genuine filter over ANY
+//     owner instead of a self-assertion.
 //
 // Adopted deployments (AdoptedAt != nil) are EXCLUDED from the list —
 // post-handover the customer's Sovereign is operationally self-
@@ -1551,13 +1562,18 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 	// claims first (auth.RequireSession injects them), falling back to
 	// X-User-Email so existing tests that build a Handler{} directly
 	// continue to exercise the session-bound filter without rewiring.
+	claims := auth.ClaimsFromContext(r.Context())
 	sessionEmail := ""
-	if c := auth.ClaimsFromContext(r.Context()); c != nil {
-		sessionEmail = strings.TrimSpace(strings.ToLower(c.Email))
+	if claims != nil {
+		sessionEmail = strings.TrimSpace(strings.ToLower(claims.Email))
 	}
 	if sessionEmail == "" {
 		sessionEmail = strings.TrimSpace(strings.ToLower(r.Header.Get("X-User-Email")))
 	}
+
+	// Issue #4683 — sovereign-admin fleet visibility. A catalyst-owner
+	// session is not owner-scoped: rule 4 of the filtering table above.
+	fleetVisible := deploymentsListFleetVisible(claims)
 
 	// Issue #748 — when a session is present AND a ?owner= query param
 	// is also supplied AND ?owner != session.email, return an empty list
@@ -1567,8 +1583,9 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 	// makes the boundary explicit without leaking existence (we don't
 	// emit 403 — the response shape MUST NOT differentiate "exists but
 	// not yours" from "doesn't exist", same posture as the issue #689
-	// 404-not-403 rule on /deployments/{id}).
-	if sessionEmail != "" && ownerFilter != "" && ownerFilter != sessionEmail {
+	// 404-not-403 rule on /deployments/{id}). Does not apply to a
+	// fleet-visible session (#4683) — there ?owner= is a real filter.
+	if !fleetVisible && sessionEmail != "" && ownerFilter != "" && ownerFilter != sessionEmail {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"deployments": []any{},
 		})
@@ -1578,9 +1595,11 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 	// Effective owner filter — when the session is set (production behind
 	// RequireSession), it always defines the boundary so the ?owner=
 	// query is at most a redundant assertion. In tests / CI without the
-	// middleware, fall back to whatever the caller passed.
+	// middleware, fall back to whatever the caller passed. A fleet-
+	// visible session (#4683) has no session boundary: the ?owner=
+	// query alone decides (empty ?owner= → every deployment).
 	effectiveOwner := sessionEmail
-	if effectiveOwner == "" {
+	if fleetVisible || effectiveOwner == "" {
 		effectiveOwner = ownerFilter
 	}
 
@@ -1670,6 +1689,37 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"deployments": out,
 	})
+}
+
+// deploymentsListFleetVisible reports whether the authenticated session
+// may list EVERY deployment regardless of OwnerEmail (issue #4683).
+//
+// True for the sovereign-admin/operator tier only: the catalyst-owner
+// realm role (canonical, stamped by Keycloak realm config or the G97
+// operator enrichment in auth.RequireSession) OR the flattened
+// tier=owner claim. Both signals project the SAME owner tier — the
+// dual check absorbs the documented session-shape drift where some
+// mint paths carry only one of the two (hw86 2026-06-01: OIDC session
+// with empty realm_access.roles; PIN sessions carry tier only).
+//
+// An Org-scoped customer session (tier=org-admin, #4110) is NEVER
+// fleet-visible — checked first so realm-config drift that leaks a
+// privileged role onto a customer token cannot widen their view.
+//
+// nil claims (middleware bypassed: CI / tests / catalyst-api without
+// CATALYST_KC_ADDR) → false, preserving the legacy ?owner= passthrough
+// semantics unchanged.
+func deploymentsListFleetVisible(claims *auth.Claims) bool {
+	if claims == nil {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(claims.Tier), orgScopedTier) {
+		return false
+	}
+	if claims.HasRealmRole("catalyst-owner") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(claims.Tier), "owner")
 }
 
 // GetDeployment returns the current state of a deployment for polling.

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_list_fleet_4683_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_list_fleet_4683_test.go
@@ -1,0 +1,178 @@
+// Tests for the sovereign-admin fleet visibility on the deployments
+// list endpoint (issue #4683).
+//
+// Contract: a session holding the catalyst-owner realm role (or the
+// flattened tier=owner claim) lists EVERY deployment regardless of
+// OwnerEmail — including legacy rows with empty OwnerEmail — and may
+// use ?owner= as a genuine filter over any owner. Owner-scoping stays
+// the boundary for every other session shape (issues #747/#748
+// unchanged), and an Org-scoped customer session (tier=org-admin,
+// #4110) is never fleet-visible even when realm-config drift leaks a
+// privileged role onto its token.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// fleetListRequest builds a GET /api/v1/deployments request with the
+// given Claims injected the same way auth.RequireSession does (context
+// + X-User-Email header).
+func fleetListRequest(claims *auth.Claims, query string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/deployments"+query, nil)
+	if claims != nil {
+		r = r.WithContext(context.WithValue(r.Context(), auth.ClaimsKey, claims))
+		if claims.Email != "" {
+			r.Header.Set("X-User-Email", claims.Email)
+		}
+	}
+	return r
+}
+
+// fleetListRows runs ListDeployments and decodes the row set keyed by id.
+func fleetListRows(t *testing.T, h *Handler, r *http.Request) map[string]map[string]any {
+	t.Helper()
+	w := httptest.NewRecorder()
+	h.ListDeployments(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200; got %d body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Deployments []map[string]any `json:"deployments"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	rows := make(map[string]map[string]any, len(body.Deployments))
+	for _, d := range body.Deployments {
+		id, _ := d["id"].(string)
+		rows[id] = d
+	}
+	return rows
+}
+
+// newFleetTestHandler seeds three owners plus one legacy (empty
+// OwnerEmail) row — the hw206 shape where the live prov was owned by a
+// different identity than the signed-in operator.
+func newFleetTestHandler() *Handler {
+	h := &Handler{log: slog.Default()}
+	newDepListEntry(h, "dep-alice", "alice@example.com", "ready", false)
+	newDepListEntry(h, "dep-bob", "bob@example.com", "phase1-watching", false)
+	newDepListEntry(h, "dep-legacy", "", "ready", false)
+	return h
+}
+
+// TestListDeployments_CatalystOwnerRoleSeesAll proves the #4683 fix:
+// a catalyst-owner session whose email owns NONE of the deployments
+// still lists all of them (fleet visibility is role-driven, not
+// email-driven), legacy empty-owner rows included.
+func TestListDeployments_CatalystOwnerRoleSeesAll(t *testing.T) {
+	h := newFleetTestHandler()
+	claims := &auth.Claims{
+		Email:       "operator@example.com",
+		RealmAccess: auth.RealmAccess{Roles: []string{"catalyst-owner"}},
+	}
+
+	rows := fleetListRows(t, h, fleetListRequest(claims, ""))
+	if len(rows) != 3 {
+		t.Fatalf("catalyst-owner must see all 3 deployments; got %d (%+v)", len(rows), rows)
+	}
+	for _, id := range []string{"dep-alice", "dep-bob", "dep-legacy"} {
+		if _, ok := rows[id]; !ok {
+			t.Fatalf("catalyst-owner list missing %s; got %+v", id, rows)
+		}
+	}
+}
+
+// TestListDeployments_OwnerTierSeesAll proves the flattened tier=owner
+// claim alone grants fleet visibility — some session mint paths carry
+// the tier without the realm role (hw86 2026-06-01 session shape).
+func TestListDeployments_OwnerTierSeesAll(t *testing.T) {
+	h := newFleetTestHandler()
+	claims := &auth.Claims{Email: "operator@example.com", Tier: "owner"}
+
+	rows := fleetListRows(t, h, fleetListRequest(claims, ""))
+	if len(rows) != 3 {
+		t.Fatalf("tier=owner must see all 3 deployments; got %d (%+v)", len(rows), rows)
+	}
+}
+
+// TestListDeployments_FleetVisibleOwnerFilter proves ?owner= acts as a
+// genuine filter for a fleet-visible session instead of the #748
+// cross-tenant empty-list guard: filtering by bob returns bob's row.
+func TestListDeployments_FleetVisibleOwnerFilter(t *testing.T) {
+	h := newFleetTestHandler()
+	claims := &auth.Claims{
+		Email:       "operator@example.com",
+		RealmAccess: auth.RealmAccess{Roles: []string{"catalyst-owner"}},
+	}
+
+	rows := fleetListRows(t, h, fleetListRequest(claims, "?owner=bob@example.com"))
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly bob's row; got %d (%+v)", len(rows), rows)
+	}
+	if _, ok := rows["dep-bob"]; !ok {
+		t.Fatalf("expected dep-bob; got %+v", rows)
+	}
+}
+
+// TestListDeployments_OrgScopedTierNeverFleetVisible proves the #4110
+// guard: an Org-scoped customer session stays confined to its own email
+// scope even when realm-config drift leaks catalyst-owner onto the
+// token. alice's org-admin session sees only alice's row.
+func TestListDeployments_OrgScopedTierNeverFleetVisible(t *testing.T) {
+	h := newFleetTestHandler()
+	claims := &auth.Claims{
+		Email:       "alice@example.com",
+		Tier:        auth.OrgScopedTier,
+		RealmAccess: auth.RealmAccess{Roles: []string{"catalyst-owner"}},
+	}
+
+	rows := fleetListRows(t, h, fleetListRequest(claims, ""))
+	if len(rows) != 1 {
+		t.Fatalf("org-scoped session must stay email-scoped; got %d (%+v)", len(rows), rows)
+	}
+	if _, ok := rows["dep-alice"]; !ok {
+		t.Fatalf("expected only dep-alice; got %+v", rows)
+	}
+}
+
+// TestListDeployments_PlainClaimsSessionStillScoped is the regression
+// guard for #747/#748: a claims-bearing session WITHOUT the owner role
+// or tier remains scoped to its own email — the fleet seam must not
+// widen the default boundary.
+func TestListDeployments_PlainClaimsSessionStillScoped(t *testing.T) {
+	h := newFleetTestHandler()
+	claims := &auth.Claims{Email: "alice@example.com", Tier: "developer"}
+
+	rows := fleetListRows(t, h, fleetListRequest(claims, ""))
+	if len(rows) != 1 {
+		t.Fatalf("plain session must see only its own row; got %d (%+v)", len(rows), rows)
+	}
+	if _, ok := rows["dep-alice"]; !ok {
+		t.Fatalf("expected only dep-alice; got %+v", rows)
+	}
+
+	// And the #748 cross-tenant ?owner= guard still returns 200 + empty.
+	w := httptest.NewRecorder()
+	h.ListDeployments(w, fleetListRequest(claims, "?owner=bob@example.com"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200; got %d body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Deployments []map[string]any `json:"deployments"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(body.Deployments) != 0 {
+		t.Fatalf("cross-tenant ?owner= must stay empty for a plain session; got %+v", body.Deployments)
+	}
+}


### PR DESCRIPTION
## Problem

Refs #4683 — the operator console `/sovereign/deployments` rendered **empty** for the sovereign-admin whenever a live deployment was owned by a different operator identity. `ListDeployments` (`products/catalyst/bootstrap/api/internal/handler/deployments.go`) scoped every row to the session email (#747/#748). Owner-scoping is a marketplace-customer boundary; the operator console needs fleet-wide visibility (caught live on hw206: the page was empty while the prov existed, worked around by re-owning the record + minting the cookie as the owning identity).

## Fix (role-based, per the issue's option a)

- New seam `deploymentsListFleetVisible(claims)`: a session holding the **catalyst-owner** realm role OR the flattened **tier=owner** claim lists EVERY deployment — legacy empty-`OwnerEmail` rows included. The dual role/tier check absorbs the documented session-shape drift (hw86 2026-06-01: OIDC session with empty `realm_access.roles`; PIN sessions carry tier only).
- For a fleet-visible session, `?owner=` becomes a genuine filter over any owner instead of the #748 self-assertion (cross-tenant `?owner=` no longer collapses to 200+empty for the admin).

## Boundaries preserved

- Org-scoped customer sessions (`tier=org-admin`, #4110) are **never** fleet-visible — guarded first, so realm-config drift leaking a privileged role onto a customer token cannot widen their view.
- Plain sessions stay email-scoped; #748 cross-tenant `?owner=` 200+empty posture unchanged (regression test included).
- nil-claims passthrough (CI / tests / catalyst-api without `CATALYST_KC_ADDR`) unchanged.

## Tests

5 new tests in `deployments_list_fleet_4683_test.go` (role-sees-all, tier-sees-all, admin `?owner=` filter, org-scoped never fleet-visible, plain-session regression guard). Full `products/catalyst/bootstrap/api` suite: `go build ./... && go test ./...` green.

No chart surfaces touched (Go handler + test only). Do not merge while the hw255 cutover is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)