### PR TITLE
fix(jobs): surface the 65 bootstrap-kit install rows on /jobs with the typed install kind

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_inventory_full_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_inventory_full_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
 )
 
-// TestHandler_ListJobs_InventoryFull pins the #4731 amendment: the default
-// /jobs view stays the #3996 FINITE list (continuous install / reconcile /
-// reconciler leaves dropped), but ?inventory=full returns the COMPLETE
-// platform inventory the Dashboard treemap needs so a converged Sovereign
-// renders every HelmRelease install, Flux Kustomization, and reconciler
-// Deployment — not just the ~14 finite rows the founder saw.
+// TestHandler_ListJobs_InventoryFull pins the #4731 amendment as amended
+// by #5019: the default /jobs view drops the open-ended reconcile /
+// reconciler leaves but KEEPS the bootstrap-kit install leaves (#5019
+// install lens), while ?inventory=full returns the COMPLETE platform
+// inventory the Dashboard treemap needs so a converged Sovereign renders
+// every HelmRelease install, Flux Kustomization, and reconciler
+// Deployment.
 func TestHandler_ListJobs_InventoryFull(t *testing.T) {
 	r, st, _ := newJobsAPIRouter(t)
 	depID := "dep-inventory"
@@ -65,16 +66,23 @@ func TestHandler_ListJobs_InventoryFull(t *testing.T) {
 		return out
 	}
 
-	// Default (finite) view: continuous install/reconcile/reconciler leaves
-	// are gone; only the finite cutover step + cron survive.
+	// Default view: open-ended reconcile/reconciler leaves are gone; the
+	// install leaves (#5019), the finite cutover step, and the cron survive.
 	finite := names("/api/v1/deployments/" + depID + "/jobs")
-	for _, dropped := range []string{"install-cilium", "install-keycloak", "reconcile-flux-system", "reconciler-pool-domain-manager"} {
+	for _, dropped := range []string{"reconcile-flux-system", "reconciler-pool-domain-manager"} {
 		if _, ok := finite[dropped]; ok {
-			t.Errorf("finite /jobs leaked continuous reconciler %q", dropped)
+			t.Errorf("default /jobs leaked continuous reconciler %q", dropped)
+		}
+	}
+	for _, kept := range []string{"install-cilium", "install-keycloak"} {
+		if got, ok := finite[kept]; !ok {
+			t.Errorf("default /jobs dropped install row %q (#5019)", kept)
+		} else if got != jobs.KindInstall {
+			t.Errorf("default /jobs %q kind = %q, want %q", kept, got, jobs.KindInstall)
 		}
 	}
 	if _, ok := finite["cutover-step-01-gitea"]; !ok {
-		t.Errorf("finite /jobs dropped the finite cutover step")
+		t.Errorf("default /jobs dropped the finite cutover step")
 	}
 
 	// Full inventory: every leaf present — the 2 installs, the Kustomization,
@@ -94,9 +102,9 @@ func TestHandler_ListJobs_InventoryFull(t *testing.T) {
 			t.Errorf("inventory=full %q kind = %q, want %q", want.name, got, want.kind)
 		}
 	}
-	// The install leaves that the finite view dropped now outnumber it —
-	// full inventory is strictly a superset.
+	// Full inventory is strictly a superset — it carries the open-ended
+	// reconcile/reconciler leaves the default view drops.
 	if len(full) <= len(finite) {
-		t.Errorf("inventory=full (%d leaves) should exceed finite (%d)", len(full), len(finite))
+		t.Errorf("inventory=full (%d leaves) should exceed default (%d)", len(full), len(finite))
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_test.go
@@ -72,26 +72,30 @@ func TestHandler_ListJobs_Empty(t *testing.T) {
 	}
 }
 
-// TestHandler_ListJobs_Populated asserts the FINITE-work view (#3996
-// follow-up): the continuous-reconciler install leaves (KindInstall) are
-// dropped from /jobs and surface only on the Cloud Reconciliation lens,
-// while genuinely finite work (provision steps, batch Jobs, CronJob runs,
-// Day-2 mutations) still renders. A finite-work group with surviving
-// children keeps its rolled-up status + ChildIDs; the bootstrap-kit group,
-// left with only install leaves, is pruned entirely.
+// TestHandler_ListJobs_Populated asserts the /jobs view selector (#3996
+// follow-up + #5019 install lens): the open-ended reconciler leaves
+// (KindReconcile / KindReconciler) are dropped from /jobs and surface only
+// on the Cloud Reconciliation lens, while the bootstrap-kit HelmRelease
+// install leaves (KindInstall, issue #5019) AND genuinely finite work
+// (provision steps, batch Jobs, CronJob runs, Day-2 mutations) render.
+// Groups with surviving children keep their rolled-up status + ChildIDs;
+// the reconcilers group, left with only reconcile/reconciler leaves, is
+// pruned entirely.
 func TestHandler_ListJobs_Populated(t *testing.T) {
 	r, st, _ := newJobsAPIRouter(t)
 	depID := "dep-populated"
 
 	t0 := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
-	// bootstrap-kit group holds ONLY install leaves (continuous Flux
-	// HelmReleases) — it must be pruned from /jobs after filtering.
+	// bootstrap-kit group holds install leaves — kept on /jobs (#5019).
 	bkParent := jobs.JobID(depID, jobs.GroupBootstrapKit)
-	// reconcilers group holds finite work (provisioner steps, a batch
+	// provisioner group holds finite work (provisioner steps, a batch
 	// task) that MUST still render on /jobs.
 	finiteParent := jobs.JobID(depID, jobs.GroupProvisioner)
+	// reconcilers group holds ONLY open-ended reconcile/reconciler leaves
+	// — it must be pruned from /jobs after filtering.
+	reconParent := jobs.JobID(depID, jobs.GroupReconcilers)
 	jobsToSeed := []jobs.Job{
-		// bootstrap-kit group + its continuous install leaves → all dropped.
+		// bootstrap-kit group + its install leaves → all kept (#5019).
 		{DeploymentID: depID, JobName: jobs.GroupBootstrapKit, DisplayName: jobs.GroupBootstrapKitDisplay, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
 		{DeploymentID: depID, JobName: "install-cilium", AppID: "cilium", Kind: jobs.KindInstall, Type: jobs.JobTypeInstall, ParentID: bkParent, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: ptrTime(t0.Add(20 * time.Second))},
 		{DeploymentID: depID, JobName: "install-flux", AppID: "flux", Kind: jobs.KindInstall, Type: jobs.JobTypeInstall, ParentID: bkParent, Status: jobs.StatusRunning, StartedAt: ptrTime(t0.Add(time.Minute))},
@@ -100,6 +104,10 @@ func TestHandler_ListJobs_Populated(t *testing.T) {
 		{DeploymentID: depID, JobName: jobs.GroupProvisioner, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
 		{DeploymentID: depID, JobName: "provisioner-step-tofu-init", Kind: jobs.KindStep, Type: jobs.JobTypeInstall, ParentID: finiteParent, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: ptrTime(t0.Add(10 * time.Second))},
 		{DeploymentID: depID, JobName: "task-snapshot-once", Kind: jobs.KindTask, Type: jobs.JobTypeInstall, ParentID: finiteParent, Status: jobs.StatusRunning, StartedAt: ptrTime(t0.Add(time.Minute))},
+		// Reconcilers group + its open-ended leaves → all dropped.
+		{DeploymentID: depID, JobName: jobs.GroupReconcilers, DisplayName: jobs.GroupReconcilersDisplay, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
+		{DeploymentID: depID, JobName: "reconcile-apps", Kind: jobs.KindReconcile, Type: jobs.JobTypeInstall, ParentID: reconParent, Status: jobs.StatusRunning},
+		{DeploymentID: depID, JobName: "reconciler-sso-bridge", Kind: jobs.KindReconciler, Type: jobs.JobTypeInstall, ParentID: reconParent, Status: jobs.StatusHealthy},
 	}
 	for _, j := range jobsToSeed {
 		if err := st.UpsertJob(j); err != nil {
@@ -117,32 +125,50 @@ func TestHandler_ListJobs_Populated(t *testing.T) {
 	}
 	decodeJSON(t, rec.Body, &resp)
 
-	// Expect the finite group + its 2 finite leaves; bootstrap-kit + the 2
-	// install leaves are gone.
-	if len(resp.Jobs) != 3 {
-		t.Fatalf("expected 3 jobs (finite group + 2 finite leaves), got %d: %+v", len(resp.Jobs), resp.Jobs)
+	// Expect bootstrap-kit group + 2 install leaves + finite group + its 2
+	// finite leaves = 6; the reconcilers group + its 2 open-ended leaves
+	// are gone.
+	if len(resp.Jobs) != 6 {
+		t.Fatalf("expected 6 jobs (bk group + 2 installs + finite group + 2 finite leaves), got %d: %+v", len(resp.Jobs), resp.Jobs)
 	}
-	for _, j := range resp.Jobs {
+	byName := map[string]*jobs.Job{}
+	for i := range resp.Jobs {
+		j := &resp.Jobs[i]
 		if jobs.IsContinuousReconciler(j.Kind) {
 			t.Errorf("continuous reconciler leaked into /jobs: %q (kind=%q)", j.JobName, j.Kind)
 		}
-		if j.JobName == jobs.GroupBootstrapKit {
-			t.Errorf("empty bootstrap-kit group should have been pruned, still present")
+		if j.JobName == jobs.GroupReconcilers {
+			t.Errorf("empty reconcilers group should have been pruned, still present")
 		}
+		byName[j.JobName] = j
+	}
+	// #5019 — the install rows render on /jobs with the typed install Kind
+	// so the JobsTable Kind filter offers the install lens.
+	for _, want := range []string{"install-cilium", "install-flux"} {
+		ij := byName[want]
+		if ij == nil {
+			t.Fatalf("install row %q missing from /jobs (#5019): %+v", want, resp.Jobs)
+		}
+		if ij.Kind != jobs.KindInstall {
+			t.Errorf("install row %q Kind: want %q, got %q", want, jobs.KindInstall, ij.Kind)
+		}
+	}
+	// The bootstrap-kit group survives with both install children and a
+	// running rollup (succeeded + running → running).
+	bk := byName[jobs.GroupBootstrapKit]
+	if bk == nil {
+		t.Fatalf("bootstrap-kit group missing in response (#5019): %+v", resp.Jobs)
+	}
+	if len(bk.ChildIDs) != 2 {
+		t.Errorf("bootstrap-kit ChildIDs: want 2, got %d (%v)", len(bk.ChildIDs), bk.ChildIDs)
+	}
+	if bk.Status != jobs.StatusRunning {
+		t.Errorf("bootstrap-kit rolled-up Status: want running, got %q", bk.Status)
 	}
 	// The finite group survives with both finite children + a running rollup.
-	var group *jobs.Job
-	for i := range resp.Jobs {
-		if resp.Jobs[i].Type == jobs.JobTypeGroup {
-			group = &resp.Jobs[i]
-			break
-		}
-	}
+	group := byName[jobs.GroupProvisioner]
 	if group == nil {
 		t.Fatalf("finite group job missing in response: %+v", resp.Jobs)
-	}
-	if group.JobName != jobs.GroupProvisioner {
-		t.Errorf("surviving group: want %q, got %q", jobs.GroupProvisioner, group.JobName)
 	}
 	// Children: succeeded step + running task → rolled-up running.
 	if group.Status != jobs.StatusRunning {

--- a/products/catalyst/bootstrap/api/internal/jobs/filter.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/filter.go
@@ -1,27 +1,42 @@
 package jobs
 
-// filter.go — the `/jobs` view selector (issue #3996 follow-up).
+// filter.go — the `/jobs` view selector (issue #3996 follow-up, install
+// lens restored per issue #5019).
 //
-// # Why /jobs is FINITE-only
+// # What /jobs shows
 //
-// The Jobs page is a list of FINITE work — things that start, run, and
-// end: provision steps, cutover steps, batch Jobs, CronJob runs, and the
-// one-shot Day-2 mutations. The CONTINUOUS reconcilers — the Flux
-// HelmRelease installs that never stop reconciling, the Flux
-// Kustomization reconcile leaves, and the long-running reconciler
-// Deployments — are NOT finite work. They run forever by design, so
-// listing them on /jobs drowns the finite rows in an ever-growing wall of
-// "running" reconcilers (the exact symptom the founder sees on
-// console.<sov>/jobs).
+// The Jobs page lists work with a completion semantics — things that
+// start, run, and reach a result: provision steps, cutover steps, batch
+// Jobs, CronJob runs, one-shot Day-2 mutations, AND the bootstrap-kit
+// HelmRelease installs. The truly OPEN-ENDED reconcilers — the Flux
+// Kustomization reconcile leaves and the long-running reconciler
+// Deployments — are NOT such work. They run forever by design, so listing
+// them on /jobs drowns the result-bearing rows in an ever-growing wall of
+// "running" reconcilers (the exact symptom the founder saw on
+// console.<sov>/jobs, #3996).
 //
-// Those continuous reconcilers now have their OWN home: the Cloud surface
+// Those open-ended reconcilers have their OWN home: the Cloud surface
 // Reconciliation lens + the lightweight ArgoCD-like reconciler-management
 // surface (#3996), which reads them LIVE from the cluster (independent of
-// this jobs store). So removing them from /jobs loses nothing — it moves
-// them to the surface that's actually built for "always-on" objects.
+// this jobs store).
+//
+// # Why installs are back (issue #5019)
+//
+// The original #3996 filter also dropped KindInstall, on the reasoning
+// that a HelmRelease reconciles forever. That erased ALL ~65 bootstrap-kit
+// install rows from /jobs — the Kind filter had no "install" option and
+// class assertions like "install-openbao green" became unwalkable (UAT
+// row 170). Unlike a Kustomization reconcile, an install leaf carries a
+// real per-attempt result (chart applied → Ready condition), the set is
+// BOUNDED by the bootstrap-kit catalog (it never grows unattended), and
+// the operator's primary question — "did every install land?" — is a
+// /jobs question. So KindInstall is a first-class /jobs kind again; only
+// KindReconcile + KindReconciler stay on the recon lens exclusively.
 //
 // # What stays
 //
+//   - KindInstall   — a HelmRelease install leaf ("install-<chart>",
+//                     bounded bootstrap-kit set; status = Ready result).
 //   - KindStep      — provision / cutover / DR-switchover steps (finite).
 //   - KindTask      — standalone / owned batch Jobs (finite).
 //   - KindCron      — recurring CronJob runs (each run is a finite
@@ -31,8 +46,6 @@ package jobs
 //
 // # What's removed
 //
-//   - KindInstall    — a Flux HelmRelease install leaf. Flux reconciles it
-//                      forever; it never "finishes". CONTINUOUS.
 //   - KindReconcile  — a Flux Kustomization reconcile leaf. CONTINUOUS.
 //   - KindReconciler — a long-running reconciler Deployment. CONTINUOUS.
 //
@@ -40,17 +53,17 @@ package jobs
 //
 // Removing the continuous leaves can leave a synthesised group Job with no
 // remaining children (e.g. the `reconcilers` group when every member was a
-// Kustomization/reconciler, or `bootstrap-kit` when it only ever held
-// install leaves). An empty group is noise, so we drop any group that has
-// no surviving descendant after the leaf filter and re-derive the tree
-// view so ChildIDs / rollups stay honest.
+// Kustomization/reconciler). An empty group is noise, so we drop any group
+// that has no surviving descendant after the leaf filter and re-derive the
+// tree view so ChildIDs / rollups stay honest.
 
 // continuousReconcilerKinds is the set of Job kinds that represent
-// always-on reconcilers rather than finite work. They are surfaced on the
-// Cloud Reconciliation lens / reconciler-management surface (#3996), never
-// on /jobs.
+// open-ended, always-on reconcilers rather than result-bearing work. They
+// are surfaced on the Cloud Reconciliation lens / reconciler-management
+// surface (#3996), never on /jobs. KindInstall is deliberately NOT here —
+// the bounded bootstrap-kit install rows are first-class /jobs rows
+// (issue #5019).
 var continuousReconcilerKinds = map[string]bool{
-	KindInstall:    true,
 	KindReconcile:  true,
 	KindReconciler: true,
 }
@@ -63,12 +76,13 @@ func IsContinuousReconciler(kind string) bool {
 	return continuousReconcilerKinds[kind]
 }
 
-// FilterFiniteJobs returns the subset of `in` that represents FINITE work
-// for the /jobs list: continuous-reconciler leaves (HelmRelease installs,
-// Flux Kustomization reconciles, reconciler Deployments) are dropped, and
-// any group Job left with no surviving descendant is pruned. The returned
-// slice is re-run through deriveTreeView so ChildIDs and group rollups
-// reflect only the surviving rows.
+// FilterFiniteJobs returns the subset of `in` that the /jobs list shows:
+// open-ended continuous-reconciler leaves (Flux Kustomization reconciles,
+// reconciler Deployments) are dropped — HelmRelease install leaves are
+// KEPT (issue #5019) — and any group Job left with no surviving
+// descendant is pruned. The returned slice is re-run through
+// deriveTreeView so ChildIDs and group rollups reflect only the surviving
+// rows.
 //
 // The input is expected to be a deriveTreeView-shaped slice (the output of
 // Store.ListJobs): leaf rows + synthesised group rows, ParentID linking

--- a/products/catalyst/bootstrap/api/internal/jobs/filter_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/filter_test.go
@@ -5,12 +5,14 @@ import (
 	"time"
 )
 
-// TestFilterFiniteJobs_DropsContinuousKeepsFinite asserts the /jobs
-// FINITE-work view (#3996 follow-up): the continuous reconcilers (install /
-// reconcile / reconciler leaves) are dropped, finite kinds (step / task /
-// cron / mutation / lifecycle) are kept, and a group left with no surviving
-// descendant is pruned while a group with a surviving finite child stays
-// with a correct rollup.
+// TestFilterFiniteJobs_DropsContinuousKeepsFinite asserts the /jobs view
+// selector (#3996 follow-up + #5019 install lens): the open-ended
+// reconciler leaves (reconcile / reconciler) are dropped, install leaves
+// are KEPT along with their bootstrap-kit group (issue #5019 — the ~65
+// bootstrap-kit install rows must be walkable on /jobs), finite kinds
+// (step / task / cron / mutation / lifecycle) are kept, and a group left
+// with no surviving descendant is pruned while a group with surviving
+// children stays with a correct rollup.
 func TestFilterFiniteJobs_DropsContinuousKeepsFinite(t *testing.T) {
 	dep := "dep-x"
 	t0 := time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC)
@@ -19,7 +21,7 @@ func TestFilterFiniteJobs_DropsContinuousKeepsFinite(t *testing.T) {
 	prov := JobID(dep, GroupProvisioner)
 
 	in := []Job{
-		// bootstrap-kit holds only continuous install leaves → group pruned.
+		// bootstrap-kit holds install leaves → group + leaves KEPT (#5019).
 		{ID: bk, DeploymentID: dep, JobName: GroupBootstrapKit, Type: JobTypeGroup, Kind: KindGroup},
 		{ID: JobID(dep, "install-cilium"), DeploymentID: dep, JobName: "install-cilium", Kind: KindInstall, Type: JobTypeInstall, ParentID: bk, Status: StatusSucceeded},
 		{ID: JobID(dep, "install-flux"), DeploymentID: dep, JobName: "install-flux", Kind: KindInstall, Type: JobTypeInstall, ParentID: bk, Status: StatusRunning},
@@ -40,26 +42,40 @@ func TestFilterFiniteJobs_DropsContinuousKeepsFinite(t *testing.T) {
 
 	out := FilterFiniteJobs(in)
 
-	// Survivors: provisioner group + 4 finite leaves = 5.
-	if len(out) != 5 {
-		t.Fatalf("want 5 survivors (group + 4 finite leaves), got %d: %+v", len(out), names(out))
+	// Survivors: bootstrap-kit group + 2 install leaves + provisioner
+	// group + 4 finite leaves = 8.
+	if len(out) != 8 {
+		t.Fatalf("want 8 survivors (bk group + 2 installs + prov group + 4 finite leaves), got %d: %+v", len(out), names(out))
 	}
-	for _, j := range out {
-		if IsContinuousReconciler(j.Kind) {
-			t.Errorf("continuous reconciler survived: %q (kind=%q)", j.JobName, j.Kind)
-		}
-		if j.JobName == GroupBootstrapKit || j.JobName == GroupReconcilers {
-			t.Errorf("empty group %q should be pruned", j.JobName)
-		}
-	}
-	var g *Job
+	byName := map[string]*Job{}
 	for i := range out {
-		if out[i].Type == JobTypeGroup {
-			g = &out[i]
+		if IsContinuousReconciler(out[i].Kind) {
+			t.Errorf("continuous reconciler survived: %q (kind=%q)", out[i].JobName, out[i].Kind)
+		}
+		if out[i].JobName == GroupReconcilers {
+			t.Errorf("empty group %q should be pruned", out[i].JobName)
+		}
+		byName[out[i].JobName] = &out[i]
+	}
+	// #5019 — the install lens: install leaves + their group survive.
+	for _, want := range []string{GroupBootstrapKit, "install-cilium", "install-flux"} {
+		if byName[want] == nil {
+			t.Errorf("install row %q missing from /jobs view (#5019)", want)
 		}
 	}
-	if g == nil || g.JobName != GroupProvisioner {
-		t.Fatalf("provisioner group missing/wrong: %+v", out)
+	bkGroup := byName[GroupBootstrapKit]
+	if bkGroup != nil {
+		if len(bkGroup.ChildIDs) != 2 {
+			t.Errorf("bootstrap-kit ChildIDs: want 2, got %d (%v)", len(bkGroup.ChildIDs), bkGroup.ChildIDs)
+		}
+		// succeeded + running → running rollup.
+		if bkGroup.Status != StatusRunning {
+			t.Errorf("bootstrap-kit rollup status: want running, got %q", bkGroup.Status)
+		}
+	}
+	g := byName[GroupProvisioner]
+	if g == nil {
+		t.Fatalf("provisioner group missing: %+v", names(out))
 	}
 	if len(g.ChildIDs) != 4 {
 		t.Errorf("provisioner ChildIDs: want 4, got %d (%v)", len(g.ChildIDs), g.ChildIDs)
@@ -71,29 +87,38 @@ func TestFilterFiniteJobs_DropsContinuousKeepsFinite(t *testing.T) {
 }
 
 // TestFilterFiniteJobs_LegacyKindBackfill asserts a row persisted before
-// the Kind field existed (Kind == "") is classified by JobName so an
-// "install-*" legacy leaf is still recognised as continuous and dropped,
-// while a "task-*" legacy leaf survives.
+// the Kind field existed (Kind == "") is classified by JobName: an
+// "install-*" legacy leaf survives (installs are /jobs rows per #5019), a
+// "reconcile-*" legacy leaf is recognised as continuous and dropped, and a
+// "task-*" legacy leaf survives.
 func TestFilterFiniteJobs_LegacyKindBackfill(t *testing.T) {
 	dep := "dep-legacy"
 	in := []Job{
 		{ID: JobID(dep, "install-legacy"), DeploymentID: dep, JobName: "install-legacy", Type: JobTypeInstall, Status: StatusSucceeded},
+		{ID: JobID(dep, "reconcile-legacy"), DeploymentID: dep, JobName: "reconcile-legacy", Type: JobTypeInstall, Status: StatusRunning},
 		{ID: JobID(dep, "task-legacy"), DeploymentID: dep, JobName: "task-legacy", Type: JobTypeInstall, Status: StatusSucceeded},
 	}
 	out := FilterFiniteJobs(in)
-	if len(out) != 1 || out[0].JobName != "task-legacy" {
-		t.Fatalf("legacy backfill: want only task-legacy, got %v", names(out))
+	got := map[string]bool{}
+	for _, j := range out {
+		got[j.JobName] = true
+	}
+	if len(out) != 2 || !got["install-legacy"] || !got["task-legacy"] {
+		t.Fatalf("legacy backfill: want install-legacy + task-legacy, got %v", names(out))
+	}
+	if got["reconcile-legacy"] {
+		t.Fatalf("legacy reconcile leaf must be dropped, got %v", names(out))
 	}
 }
 
 // TestFilterFiniteJobs_AllContinuousYieldsEmpty asserts a deployment whose
-// /jobs store is nothing but continuous reconcilers returns an empty list
+// /jobs store is nothing but open-ended reconcilers returns an empty list
 // (never nil — the handler marshals []).
 func TestFilterFiniteJobs_AllContinuousYieldsEmpty(t *testing.T) {
 	dep := "dep-all-recon"
 	in := []Job{
-		{ID: JobID(dep, "install-a"), DeploymentID: dep, JobName: "install-a", Kind: KindInstall, Type: JobTypeInstall},
 		{ID: JobID(dep, "reconcile-b"), DeploymentID: dep, JobName: "reconcile-b", Kind: KindReconcile, Type: JobTypeInstall},
+		{ID: JobID(dep, "reconciler-c"), DeploymentID: dep, JobName: "reconciler-c", Kind: KindReconciler, Type: JobTypeInstall},
 	}
 	out := FilterFiniteJobs(in)
 	if len(out) != 0 {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -5,18 +5,21 @@
  *   • Header: <h1>Jobs</h1> + tagline + back-to-apps link.
  *   • <JobsTable /> — table view with search/sort/filter + per-row Retry.
  *
- * # FINITE work only (#3996 follow-up)
+ * # Which rows render here (#3996 follow-up, install lens per #5019)
  *
- * /jobs is the list of FINITE work — things that start, run, and END:
- * provision steps, cutover steps, batch Jobs, CronJob runs, and one-shot
- * Day-2 mutations. The CONTINUOUS reconcilers — Flux HelmRelease installs,
- * Flux Kustomization reconciles, and long-running reconciler Deployments —
- * are NOT finite work; they run forever by design. They are now EXCLUDED
- * from `/jobs` by the catalyst-api `ListJobs` handler
- * (`jobs.FilterFiniteJobs`) and surface ONLY on the Cloud surface's
- * Reconciliation lens + the ArgoCD-like reconciler-management surface
- * (#3996), which reads them LIVE from the cluster. So this page no longer
- * drowns its finite rows in an ever-growing wall of "running" reconcilers.
+ * /jobs lists work with a completion semantics — things that start, run,
+ * and reach a result: provision steps, cutover steps, batch Jobs, CronJob
+ * runs, one-shot Day-2 mutations, AND the bootstrap-kit HelmRelease
+ * install rows (issue #5019 — the ~65 `install-*` leaves are a BOUNDED
+ * catalog set with a real Ready result, so "install-openbao green" is
+ * walkable here; the Kind filter offers the `install` lens). The truly
+ * OPEN-ENDED reconcilers — Flux Kustomization reconciles and long-running
+ * reconciler Deployments — run forever by design and stay EXCLUDED from
+ * `/jobs` by the catalyst-api `ListJobs` handler (`jobs.FilterFiniteJobs`);
+ * they surface ONLY on the Cloud surface's Reconciliation lens + the
+ * ArgoCD-like reconciler-management surface (#3996), which reads them LIVE
+ * from the cluster. So this page still never drowns in an ever-growing
+ * wall of "running" reconcilers.
  *
  * # One honest list — no client-side mashup (issue #3646)
  *

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -1127,6 +1127,7 @@ const JOBS_TABLE_CSS = `
   border: 1px solid rgba(148,163,184,0.25);
 }
 .jobs-kind-cron       { color: #C084FC; border-color: rgba(192,132,252,0.35); background: rgba(192,132,252,0.08); }
+.jobs-kind-install    { color: #818CF8; border-color: rgba(129,140,248,0.35); background: rgba(129,140,248,0.08); }
 .jobs-kind-reconcile  { color: #38BDF8; border-color: rgba(56,189,248,0.35);  background: rgba(56,189,248,0.08); }
 .jobs-kind-reconciler { color: #2DD4BF; border-color: rgba(45,212,191,0.35);  background: rgba(45,212,191,0.08); }
 .jobs-kind-step       { color: #FBBF24; border-color: rgba(251,191,36,0.35);  background: rgba(251,191,36,0.08); }


### PR DESCRIPTION
## Problem (Refs #5019, part 1 — the install lens)

Found live on hw242 and re-verified on hw255 (dep `5762118f63abef96`): the `/jobs` table shows **zero** of the ~65 bootstrap-kit `install-*` rows and its Kind filter has no `install` option, so class assertions like "install-openbao green" (UAT row 170) cannot be walked. Meanwhile the Dashboard treemap's `?inventory=full` path carries all 65 entries — the two surfaces contradict each other.

**Root cause**: the #3996 follow-up filter `jobs.FilterFiniteJobs` (`products/catalyst/bootstrap/api/internal/jobs/filter.go`) put `KindInstall` in `continuousReconcilerKinds`, dropping every install leaf (and the then-empty `bootstrap-kit` group) from the default `/jobs` read. The ingestion itself was never the gap — the chroot seed writes all 65 install rows into the jobs store (hw255 catalyst-api log: `chroot seed: secondary region jobs.Store populated ... helmReleases=65 jobsWritten=65`); the read filtered them back out.

## Fix

- `internal/jobs/filter.go` — remove `KindInstall` from `continuousReconcilerKinds`. The install set is **bounded** by the bootstrap-kit catalog (it never grows unattended) and each leaf carries a real per-attempt result (HelmRelease Ready), unlike the open-ended `KindReconcile` / `KindReconciler` leaves, which stay excluded and keep living on the Cloud Reconciliation lens (#3996 intent preserved — no ever-growing wall of running reconcilers).
- `JobsTable.tsx` — add the `install` kind-chip style; the Kind filter dropdown needs no change (it renders the kinds actually present, so the `install` lens appears generically per the #3646 typed-Kind model).
- `JobsPage.tsx` — header doc updated to the amended contract.
- Tests updated/extended: `filter_test.go`, `handler/jobs_test.go`, `handler/jobs_inventory_full_test.go` now pin installs-present + reconcile/reconciler-absent on the default view, and `?inventory=full` remains a strict superset (#4731 contract intact).

## Live evidence (hw255, read-only)

- `KUBECONFIG=/tmp/hw255.kubeconfig kubectl get helmreleases -A --no-headers | wc -l` → **65**
- catalyst-api (`catalyst-system/catalyst-api-65fc8896f8-6b6wm`) log 2026-07-15T05:19:50Z: `chroot seed: secondary region jobs.Store populated ... helmReleases=65 jobsWritten=65 executionsSeeded=65`
- `origin/main` `filter.go` still lists `KindInstall: true` in `continuousReconcilerKinds` (last touched by #3999).

## Gates

- `go build ./... && go test ./...` in `products/catalyst/bootstrap/api` — green (incl. full handler suite).
- `go vet` on touched packages — clean.
- UI: `npm run build` green; jobs-related suites (`JobsTable.test.tsx`, `JobsPage.degraft.test.tsx`, `useLiveJobsBackfill.test.tsx`) 71/71 pass. (Pre-existing, unrelated failures in `PinInput6.test.tsx` / `ProvisionPage.sse-url.test.tsx` / `JobsPage.test.tsx` Show-as-Flow reproduce identically on a clean checkout of `main` — not introduced here.)
- `bash scripts/check-no-nodeports.sh` — exit 0.
- No chart changes → no 4-surface lockstep bump required (Go/TSX only; ships with the next catalyst-api image roll).

Scope note: #5019 part 2 (recon drill-panel empty Actions, rows 195-197) is a separate surface (#3996 residue) and is not touched here.

Refs #5019

🤖 Generated with [Claude Code](https://claude.com/claude-code)