### PR TITLE
fix(#4765): cross-namespace grant for the sovereign-vip VIP share — powerdns-anycast no longer starves (bp-cilium 1.4.16)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -141,7 +141,7 @@ spec:
       # 1370 → 1420 (WG-only). Layers on the 1.4.9/1.4.10 zero-nodeport +
       # authMode=legacy work. Cross-region ClusterMesh pod path needs a fresh
       # 2-region prov to verify (datapath change). Refs #4656.
-      version: 1.4.15
+      version: 1.4.16
       sourceRef:
         kind: HelmRepository
         name: bp-cilium
@@ -420,6 +420,17 @@ spec:
               # Load-bearing on no-CCM Huawei; inert on Hetzner (LB-IPAM
               # disabled → hcloud-ccm reads its own annotations below).
               lbipam.cilium.io/sharing-key: sovereign-vip
+              # #4765 residue (live-proven hw255, 2026-07-15): the sharing-key
+              # alone is NOT sufficient across namespaces — Cilium LB-IPAM
+              # (≥1.16) only co-locates two Services on one VIP when BOTH carry
+              # `lbipam.cilium.io/sharing-cross-namespace` allowing the peer's
+              # namespace (docs.cilium.io lb-ipam). Without this, THIS Service
+              # (kube-system) takes the single sovereign-vip /32 and
+              # powerdns-anycast (ns powerdns, :53) starves forever:
+              # IPAMRequestSatisfied=False reason=out_of_ips, EXTERNAL-IP
+              # <pending>. Explicit peer namespace, never "*", so tenant/Org
+              # LB Services can never hijack the sovereign EIP by annotation.
+              lbipam.cilium.io/sharing-cross-namespace: "powerdns"
               load-balancer.hetzner.cloud/location: "${HCLOUD_LB_LOCATION}"
               load-balancer.hetzner.cloud/type: "lb11"
               # use-private-ip: false — LB→backend connection transits

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -230,6 +230,17 @@ spec:
       serviceType: LoadBalancer
       annotations:
         lbipam.cilium.io/sharing-key: sovereign-vip
+        # #4765 residue (live-proven hw255, 2026-07-15): the sharing-key
+        # alone is NOT sufficient — Cilium LB-IPAM only shares a VIP
+        # across namespaces when BOTH Services carry
+        # `lbipam.cilium.io/sharing-cross-namespace` allowing the peer's
+        # namespace (docs.cilium.io lb-ipam, Cilium ≥1.16). Without it
+        # the clustermesh-apiserver (kube-system) takes the single /32
+        # and this Service starves: IPAMRequestSatisfied=False
+        # reason=out_of_ips, EXTERNAL-IP=<pending> forever. Explicit
+        # namespace (never "*") so tenant/Org LB Services can never
+        # co-locate onto the sovereign EIP by annotation hijack.
+        lbipam.cilium.io/sharing-cross-namespace: "kube-system"
       ports:
         - name: dns-udp
           port: 53

--- a/clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -116,6 +116,14 @@ spec:
       serviceType: LoadBalancer
       annotations:
         lbipam.cilium.io/sharing-key: sovereign-vip
+        # #4765 residue (live-proven hw255, 2026-07-15): Cilium LB-IPAM
+        # only shares a VIP across namespaces when BOTH Services carry
+        # `lbipam.cilium.io/sharing-cross-namespace` allowing the peer's
+        # namespace (Cilium >=1.16). Without it the clustermesh-apiserver
+        # (kube-system) takes the single /32 and this Service starves
+        # (out_of_ips, EXTERNAL-IP <pending>). Explicit namespace, never
+        # "*". Mirrors clusters/_template/bootstrap-kit/11-powerdns.yaml.
+        lbipam.cilium.io/sharing-cross-namespace: "kube-system"
       ports:
         - name: dns-udp
           port: 53

--- a/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -116,6 +116,14 @@ spec:
       serviceType: LoadBalancer
       annotations:
         lbipam.cilium.io/sharing-key: sovereign-vip
+        # #4765 residue (live-proven hw255, 2026-07-15): Cilium LB-IPAM
+        # only shares a VIP across namespaces when BOTH Services carry
+        # `lbipam.cilium.io/sharing-cross-namespace` allowing the peer's
+        # namespace (Cilium >=1.16). Without it the clustermesh-apiserver
+        # (kube-system) takes the single /32 and this Service starves
+        # (out_of_ips, EXTERNAL-IP <pending>). Explicit namespace, never
+        # "*". Mirrors clusters/_template/bootstrap-kit/11-powerdns.yaml.
+        lbipam.cilium.io/sharing-cross-namespace: "kube-system"
       ports:
         - name: dns-udp
           port: 53

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.15
+  version: 1.4.16
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-cilium
+# 1.4.16 (#4765 residue, 2026-07-15): cross-namespace VIP sharing on the
+# sovereign-vip pool actually works now. 1.4.9 put `lbipam.cilium.io/
+# sharing-key: sovereign-vip` on both riders (clustermesh-apiserver :2379,
+# powerdns-anycast :53) but Cilium LB-IPAM (≥1.16) only shares a VIP
+# ACROSS namespaces when BOTH Services also carry `lbipam.cilium.io/
+# sharing-cross-namespace` allowing the peer's namespace — the riders live
+# in kube-system vs powerdns, so the share was silently refused: the
+# clustermesh-apiserver took the single /32 and powerdns-anycast starved
+# forever (IPAMRequestSatisfied=False reason=out_of_ips, EXTERNAL-IP
+# <pending> — live-proven hw255 dep 5762118f63abef96, 2026-07-15; upstream
+# semantics: docs.cilium.io lb-ipam "The annotation must be present on
+# both services"). Fix: values-clustermesh.yaml adds
+# sharing-cross-namespace: "powerdns" on the clustermesh-apiserver Service
+# annotations; the powerdns side (bootstrap-kit 11-powerdns.yaml overlays,
+# all 3 copies) adds sharing-cross-namespace: "kube-system". Explicit peer
+# namespaces, never "*", so tenant/Org LB Services can never co-locate
+# onto the sovereign EIP by annotation hijack. Zero NodePorts throughout
+# (§854; allocateLoadBalancerNodePorts stays false). Inert on Hetzner
+# (LB-IPAM disabled → hcloud-ccm). Lockstep: blueprint.yaml 1.4.16 +
+# 01-cilium.yaml slot pin 1.4.16 + catalog-seed 1.4.16. Refs #4765.
 # 1.4.13 (#4656 #4854, 2026-07-09): vpc-podcidr-route-reconciler — per-node
 # pod-CIDR VPC routes on no-CCM Huawei. #4807's whole-/16 pod-CIDR peering
 # routes only carry native-routed pod traffic INTO the peer VPC; each VPC's
@@ -279,7 +299,7 @@ name: bp-cilium
 #   Layers ON TOP of the 1.4.9/1.4.10 zero-nodeport + authMode=legacy work.
 #   Needs a fresh 2-region prov to verify the cross-region ClusterMesh pod
 #   path end-to-end (datapath change, not CI-provable). Refs #4656.
-version: 1.4.15
+version: 1.4.16
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/templates/sovereign-vip-lb-ipam-pool.yaml
+++ b/platform/cilium/chart/templates/sovereign-vip-lb-ipam-pool.yaml
@@ -38,6 +38,18 @@ CANONICAL FIX — one pool, one CIDR, no conflict:
   IP and leave the rest Pending — pool exhausted; the sharing-key is what
   lets them coexist on the one address.)
 
+  🛑 CROSS-NAMESPACE REQUIREMENT (#4765 residue, live-proven hw255
+  2026-07-15): the sharing-key alone only shares WITHIN one namespace.
+  Cilium LB-IPAM (≥1.16) refuses a cross-namespace share unless BOTH
+  Services also carry `lbipam.cilium.io/sharing-cross-namespace` listing
+  the peer's namespace (docs.cilium.io lb-ipam). The riders live in
+  different namespaces (clustermesh-apiserver → kube-system,
+  powerdns-anycast → powerdns), so each must allow the other explicitly
+  — never "*", or any tenant/Org LB Service could hijack a port on the
+  sovereign EIP. Symptom when missing: the first-created Service takes
+  the /32 and every later rider reports IPAMRequestSatisfied=False
+  reason=out_of_ips with EXTERNAL-IP <pending> forever.
+
 OPERATOR GATE:
   Enabled per-provider via the HelmRelease overlay substitute
   CILIUM_LB_IPAM_ENABLED (true on no-CCM Huawei, unset on Hetzner where

--- a/platform/cilium/chart/values-clustermesh.yaml
+++ b/platform/cilium/chart/values-clustermesh.yaml
@@ -91,6 +91,19 @@ cilium:
           # (:2379) makes the share with powerdns :53 / gateway :443/:80
           # collision-free. Inert on Hetzner (LB-IPAM disabled → hcloud-ccm).
           lbipam.cilium.io/sharing-key: sovereign-vip
+          # #4765 residue (live-proven hw255, 2026-07-15): the sharing-key
+          # alone does NOT share a VIP across namespaces — Cilium LB-IPAM
+          # (≥1.16) additionally requires BOTH Services to carry
+          # `lbipam.cilium.io/sharing-cross-namespace` allowing the peer's
+          # namespace. Without it this Service (kube-system) takes the
+          # single sovereign-vip /32 and powerdns-anycast (ns powerdns)
+          # starves: out_of_ips, EXTERNAL-IP <pending>. Explicit peer
+          # namespace, never "*" (annotation-hijack guard). Must stay in
+          # lockstep with the slot-01 overlay
+          # (clusters/_template/bootstrap-kit/01-cilium.yaml) and the
+          # powerdns side (bootstrap-kit 11-powerdns.yaml
+          # anycast.annotations → sharing-cross-namespace: kube-system).
+          lbipam.cilium.io/sharing-cross-namespace: "powerdns"
       tls:
         # Mutual cert auth between Cilium peers — every peer's
         # clustermesh-apiserver verifies the other's cert against the

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3807,7 +3807,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cilium
-    version: "1.4.15"
+    version: "1.4.16"
   topology:
     supported:
       - singleton

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -1506,3 +1506,81 @@ func TestCatalogSeed_DeliveryPinsNotBehindComponentCharts(t *testing.T) {
 	}
 	t.Logf("catalog-seed drift guard: compared %d in-repo delivery pins against component chart versions; none behind", checked)
 }
+
+// TestBootstrapKit_LbIpamSharingCrossNamespace guards the #4765 residue
+// fixed in bp-cilium 1.4.16 (live-proven hw255, 2026-07-15): Cilium
+// LB-IPAM (≥1.16) only lets two LoadBalancer Services share one VIP
+// ACROSS namespaces when BOTH carry
+// `lbipam.cilium.io/sharing-cross-namespace` allowing the peer's
+// namespace — the `lbipam.cilium.io/sharing-key` alone is same-namespace
+// only (docs.cilium.io lb-ipam: "The annotation must be present on both
+// services"). The sovereign-vip riders live in kube-system
+// (clustermesh-apiserver :2379) and powerdns (powerdns-anycast :53), so
+// any annotation block that opts into the shared EIP via the sharing-key
+// MUST also carry the cross-namespace grant, or the first-created rider
+// takes the single /32 and every later rider starves forever
+// (IPAMRequestSatisfied=False reason=out_of_ips, EXTERNAL-IP <pending>).
+// The grant must be an explicit namespace list — never "*", which would
+// let ANY tenant/Org LoadBalancer Service co-locate onto the sovereign
+// EIP by annotation hijack.
+func TestBootstrapKit_LbIpamSharingCrossNamespace(t *testing.T) {
+	root := repoRoot(t)
+
+	// Every file that participates in the sovereign-vip sharing contract.
+	// filepath.Glob over clusters/*/bootstrap-kit/*.yaml covers _template
+	// plus every per-Sovereign copy; values-clustermesh.yaml is the
+	// chart-side reference for the clustermesh Service annotations.
+	var files []string
+	for _, pat := range []string{
+		filepath.Join(root, "clusters", "*", "bootstrap-kit", "*.yaml"),
+		filepath.Join(root, "platform", "cilium", "chart", "values-clustermesh.yaml"),
+	} {
+		matches, err := filepath.Glob(pat)
+		if err != nil {
+			t.Fatalf("glob %s: %v", pat, err)
+		}
+		files = append(files, matches...)
+	}
+
+	const (
+		keyAnno   = "lbipam.cilium.io/sharing-key:"
+		crossAnno = "lbipam.cilium.io/sharing-cross-namespace:"
+	)
+
+	checked := 0
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		var keys, crosses, wildcards int
+		for i, line := range strings.Split(string(raw), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "#") {
+				continue // prose about the annotation, not the annotation
+			}
+			switch {
+			case strings.HasPrefix(trimmed, keyAnno):
+				keys++
+			case strings.HasPrefix(trimmed, crossAnno):
+				crosses++
+				val := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, crossAnno)), `"'`)
+				if val == "*" {
+					wildcards++
+					t.Errorf("%s:%d: lbipam.cilium.io/sharing-cross-namespace is %q — the wildcard grant lets ANY namespace's LB Service co-locate onto the sovereign EIP (annotation hijack); list the peer namespace explicitly", f, i+1, "*")
+				}
+			}
+		}
+		if keys > 0 {
+			checked++
+			if crosses < keys {
+				t.Errorf("%s: %d `%s sovereign-vip` annotation(s) but only %d `%s` grant(s) — without the cross-namespace grant on BOTH riders Cilium refuses the share and the later Service starves (out_of_ips, EXTERNAL-IP <pending>; #4765 residue, hw255 2026-07-15). Add `%s \"<peer-namespace>\"` next to each sharing-key.",
+					f, keys, keyAnno, crosses, crossAnno, crossAnno)
+			}
+		}
+	}
+	if checked < 4 {
+		t.Fatalf("only %d files carry the sovereign-vip sharing-key — expected ≥4 (template 01-cilium + template 11-powerdns + per-Sovereign copies + values-clustermesh.yaml); the guard's file enumeration is broken", checked)
+	}
+	t.Logf("sovereign-vip sharing contract: %d files checked, every sharing-key has its cross-namespace grant, zero wildcard grants", checked)
+}


### PR DESCRIPTION
## What / why

**Live defect (hw255, dep `5762118f63abef96`, 2026-07-15):** `powerdns/powerdns-anycast` (type=LoadBalancer, `allocateLoadBalancerNodePorts: false`, sharing-key `sovereign-vip`) never gets its VIP:

```
status.conditions: IPAMRequestSatisfied=False reason=out_of_ips
  "All enabled CiliumLoadBalancerIPPools that match this service ran out of allocatable IPs"
kubectl get svc -n powerdns powerdns-anycast → EXTERNAL-IP <pending>  (70m and counting)
```

while `kube-system/clustermesh-apiserver` (same sharing-key) holds the pool's single /32 (`212.72.24.36`, `ipMode: VIP`, satisfied).

**Root cause:** the #4765 design (bp-cilium 1.4.9) relies on `lbipam.cilium.io/sharing-key: sovereign-vip` to co-locate the riders on the one shared Sovereign EIP — but Cilium LB-IPAM (>=1.16; hw255 runs 1.19.3) only shares a VIP **across namespaces** when **both** Services also carry `lbipam.cilium.io/sharing-cross-namespace` allowing the peer's namespace (docs.cilium.io lb-ipam: *"The annotation must be present on both services"*). The riders live in `kube-system` vs `powerdns`, so the share was silently refused and the second rider starves forever.

## Fix (smallest durable, section-854-clean)

Add the missing grant next to every `sharing-key`:

- clustermesh-apiserver side → `lbipam.cilium.io/sharing-cross-namespace: "powerdns"` (`clusters/_template/bootstrap-kit/01-cilium.yaml` slot overlay + `platform/cilium/chart/values-clustermesh.yaml` reference)
- powerdns-anycast side → `lbipam.cilium.io/sharing-cross-namespace: "kube-system"` (`clusters/{_template,otech.omani.works,omantel.omani.works}/bootstrap-kit/11-powerdns.yaml`)

Explicit peer namespaces, **never `"*"`** — a wildcard would let any tenant/Org LB Service co-locate onto the sovereign EIP by annotation hijack. No NodePort anywhere; `allocateLoadBalancerNodePorts` stays `false`; distinct L4 ports (2379 vs 53) keep the share collision-free. Pool-template header documents the requirement.

**Guard:** `TestBootstrapKit_LbIpamSharingCrossNamespace` — every `sharing-key: sovereign-vip` must pair with a cross-namespace grant, wildcard grants are rejected. Negative-verified: the test FAILS on the pre-fix shape.

**Lockstep bp-cilium 1.4.15 → 1.4.16:** `Chart.yaml` + `blueprint.yaml` + slot-01 pin + catalog-seed `source.version` (same file-set shape as the 1.4.15 bump f96cd32a5).

## Verification state of the parent issues (read-only walk on hw255)

- #4682 (`:30443` gateway) — **already fixed** on main (bp-cilium 1.4.8/#4706 + cutover chart): live Gateway listeners are `https=443 http=80` (hostNetwork `cilium-envoy` DaemonSet 6/6, gateway Svc ClusterIP, zero NodePort); `scripts/check-no-nodeports.sh` exit 0; cutover-contract tests actively forbid `:30443` regressions.
- #4765 — NodePort eradication itself is **already fixed** live: `kubectl get svc -A` shows ZERO `type=NodePort` Services; powerdns-anycast is LB with `allocateLoadBalancerNodePorts: false` and no allocated nodePorts; clustermesh dial is `https://hw255-me-east-b.mesh.cilium.io:12379` (hostNetwork clustermesh-proxy socat, #4784) — not a node:3xxxx. **This PR fixes the one residual live defect in that design** (the starved VIP).
- Residual (documented, not in this PR): external `dig @EIP :53` on Huawei still depends on the 1:1-NAT reachability question (hw208 class) + there is no `:53` SG rule in `infra/providers/huawei` — the post-handover DNS self-sufficiency path (ADR-0001 section 9.4) needs its own wiring pass once the VIP materialises on a fresh prov.

## Gates

- `tests/e2e/bootstrap-kit`: `go build ./... && go vet ./... && go test ./...` → ok (incl. `TestBootstrapKit_BlueprintVersionLockstepSweep`, `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts`)
- `bash scripts/check-no-nodeports.sh` → exit 0
- YAML parse of all 6 edited manifests → ok (chart offline-render skipped: upstream cilium subchart not vendored, same as CI Phase-2 behavior)

DO NOT MERGE while the hw255 cutover is in flight (merge train held per RT-11).

Refs #4765 #4682

🤖 Generated with [Claude Code](https://claude.com/claude-code)