### PR TITLE
fix(#5099): fire script defaults SHARED_PG=true — explicit enableSharedPostgres:false no longer hollows the shared-pg trio

### DIFF
--- a/scripts/sovereign-lifecycle.sh
+++ b/scripts/sovereign-lifecycle.sh
@@ -70,8 +70,21 @@ fire() {
   fi
   echo "== reset-UAT-on-fire (founder rule 2026-06-08) =="; reset_uat "$sub"
   pub=$(cat /home/openova/.ssh/*.pub 2>/dev/null | grep -E "^ssh-" | head -1)
-  # SHARED_PG=true opts the prov into the ADR-0010 reusable shared-Postgres
-  # model (#3188 -> SOVEREIGN_ENABLE_SHARED_PG, fire-body wired in #3275). Off by default.
+  # SHARED_PG drives the ADR-0010 reusable shared-Postgres model (#3188 ->
+  # SOVEREIGN_ENABLE_SHARED_PG, fire-body wired in #3275). Default TRUE (#5099):
+  # the platform canon is default-true everywhere else — provisioner Request
+  # (deployments.go CreateDeployment pre-decode default, Refs #3370) and tofu
+  # var enable_shared_pg (variables.tf default "true") — because the shared
+  # trio (slots 16a/16c/16d) is founder North-Star-2 AND the only path that
+  # self-registers the 3 shared-pg Application CRs on a fresh prov. This script
+  # used to default SHARED_PG=false and stamp an EXPLICIT
+  # `"enableSharedPostgres": false` into the POST body, which (by the
+  # pointer-bool-emulation contract) OVERRIDES the server's default-true — on
+  # hw255 that cascaded to SOVEREIGN_ENABLE_SHARED_PG="false" -> the slot-16a/
+  # 16c/16d master gate off -> 3 HRs Ready over ZERO rendered resources (no
+  # shared-pg Cluster, no Application CRs, ns shared-data empty; 5 Application
+  # CRs where prior envs had 8). Set SHARED_PG=false explicitly for the
+  # dedicated-per-consumer-cluster path.
   #
   # Node sizing is overridable per-fire (#3952 capacity verdict, 2026-06-20): the
   # default m7n.xlarge.8 x3 worker tier runs ~99% CPU once the full #3642 vc-mgmt
@@ -83,10 +96,10 @@ fire() {
   # RCA 2026-05-27 — s7n.large.4 exhausted -> Ecs.0219 No-valid-host, 11 wasted debug
   # waves). Only m7n.large.8 (CP) and m7n.xlarge.8 (worker) are verified-ACTIVE; verify
   # any other flavor via direct HCS API (sub_jobs[0].error_code) BEFORE firing.
-  body=$(SUB="$sub" POOL="$pool" PUB="$pub" SHARED_PG="${SHARED_PG:-false}" \
+  body=$(SUB="$sub" POOL="$pool" PUB="$pub" SHARED_PG="${SHARED_PG:-true}" \
     CP_SIZE="${CP_SIZE:-m7n.large.8}" WORKER_SIZE="${WORKER_SIZE:-m7n.xlarge.8}" WORKER_COUNT="${WORKER_COUNT:-3}" \
     python3 -c 'import json,os;s=os.environ["SUB"];p=os.environ["POOL"];c=os.environ["CP_SIZE"];w=os.environ["WORKER_SIZE"];wc=int(os.environ["WORKER_COUNT"]);print(json.dumps({"orgName":"Omantel","orgEmail":"emrah.baysal@openova.io","provider":"huawei","sovereignDomainMode":"pool","sovereignPoolDomain":p,"sovereignSubdomain":s,"sovereignFQDN":s+"."+p,"sshPublicKey":os.environ["PUB"],"enableSharedPostgres":os.environ.get("SHARED_PG")=="true","regions":[{"provider":"huawei","cloudRegion":"me-east-215-a","controlPlaneSize":c,"workerSize":w,"workerCount":wc},{"provider":"huawei","cloudRegion":"me-east-215-b","controlPlaneSize":c,"workerSize":w,"workerCount":wc}]}))')
-  echo "== firing ${sub}.${pool} (CP=${CP_SIZE:-m7n.large.8} worker=${WORKER_SIZE:-m7n.xlarge.8}x${WORKER_COUNT:-3}/region) =="
+  echo "== firing ${sub}.${pool} (CP=${CP_SIZE:-m7n.large.8} worker=${WORKER_SIZE:-m7n.xlarge.8}x${WORKER_COUNT:-3}/region sharedPG=${SHARED_PG:-true}) =="
   curl -sk -X POST -H "Authorization: Bearer $(_tok)" -H "Content-Type: application/json" -d "$body" "${API}"; echo
 }
 


### PR DESCRIPTION
Refs #5099

## Root cause

The shared-pg trio's HR-Ready-over-zero-resources on hw255 is the bp-postgres 0.1.1 master gate working as designed — the defect is one layer up, in the canonical fire path:

- `scripts/sovereign-lifecycle.sh` line 86 defaulted `SHARED_PG=${SHARED_PG:-false}`, and the body builder (line 88, `os.environ.get("SHARED_PG")=="true"`) therefore stamped an **EXPLICIT** `"enableSharedPostgres": false` into every POST /deployments body fired without `SHARED_PG=true` exported.
- Per the CreateDeployment pre-decode default-true contract (`products/catalyst/bootstrap/api/internal/handler/deployments.go:1103`, Refs #3370) an explicit false in the body WINS over the server default — so the platform's default-true canon (handler default + `infra/providers/huawei/variables.tf` `enable_shared_pg` default `"true"`) was silently defeated.
- Cascade on hw255: body `false` → tfvars `enable_shared_pg="false"` → cloud-init `SOVEREIGN_ENABLE_SHARED_PG="false"` (confirmed live in the bootstrap-kit Kustomization postBuild.substitute) → slots 16a/16c/16d pass `values.enabled: false` (confirmed live in `hr/bp-postgres-shared` spec.values) → chart renders zero resources → 3 Ready HRs over an empty `shared-data` namespace, no shared-pg CNPG Cluster, no Application CRs (5 CRs where prior envs had 8).

## Repro (exact live hw255 values, bp-postgres@0.2.12)

| render | resources |
|---|---|
| `helm template` with the live HR spec.values (`enabled: false`) | **0** |
| same values with `enabled: true` | **16** (1 CNPG Cluster `shared-pg` + 1 Application CR + 3 Database CRs + 9 Secrets + NetworkPolicy + CiliumNetworkPolicy) |

## Fix

Smallest durable fix, fire-side only (no chart change, so no 4-surface lockstep needed):

- `SHARED_PG` now defaults to `true` in the fire body, matching the founder North-Star-2 default-true canon at the API + tofu layers. `SHARED_PG=false` remains available for the dedicated-per-consumer-cluster path.
- The fire log line now echoes `sharedPG=<value>` so the gate state is visible at fire time instead of failing silent.
- Comment block documents the explicit-false-overrides-server-default trap so the next reader doesn't reintroduce it.

## Verification

- `bash -n` clean; body simulation: unset → `enableSharedPostgres: true`, `SHARED_PG=false` → `false`, `SHARED_PG=true` → `true`.
- `bash scripts/check-no-nodeports.sh` → exit 0.
- hw255 was inspected READ-ONLY (get/describe only); no live mutation.

DO NOT auto-close — verification is a fresh prov walking slots 16a/16c/16d to 3 rendered engines + 8 Application CRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)