### PR TITLE
fix(console): purge rendered tenant-term copy; refute rows 196/197 with bundle evidence

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/CrudModals/formFields/WorkerNodeFormFields.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/CrudModals/formFields/WorkerNodeFormFields.tsx
@@ -106,11 +106,11 @@ export function WorkerNodeFormFields({
           />
         )}
       </FormRow>
-      <FormRow label="Taints" hint="Comma-separated key=value:effect — e.g. tenant=dmz:NoSchedule.">
+      <FormRow label="Taints" hint="Comma-separated key=value:effect — e.g. org=dmz:NoSchedule.">
         <TextInput
           value={values.taints}
           onChange={(v) => onChange({ ...values, taints: v })}
-          placeholder="tenant=dmz:NoSchedule"
+          placeholder="org=dmz:NoSchedule"
           testId="worker-node-form-taints"
         />
       </FormRow>

--- a/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
@@ -253,7 +253,7 @@ export async function createOrgTenant(
   })
   if (!res.ok && res.status !== 202) {
     const detail = await res.text().catch(() => '')
-    throw new Error(`create org tenant: HTTP ${res.status} ${detail}`)
+    throw new Error(`create organization: HTTP ${res.status} ${detail}`)
   }
   return (await res.json()) as OrgTenant
 }
@@ -265,7 +265,7 @@ export async function listOrgTenants(): Promise<OrgTenant[]> {
     headers: { Accept: 'application/json' },
   })
   if (!res.ok) {
-    throw new Error(`list org tenants: HTTP ${res.status}`)
+    throw new Error(`list organizations: HTTP ${res.status}`)
   }
   const body = (await res.json()) as { items?: OrgTenant[] }
   return body.items ?? []


### PR DESCRIPTION
Refs #5100 #3996

## Triage of the three hw255 deployed-bundle gaps (bundle /assets/index-DqSJ9fgF.js, catalyst-ui:2b05348)

### Gap 1 — Reconcile control "absent" (row 196): FALSE POSITIVE, no code change needed
The walk grepped the SPA bundle for `reconcile.fluxcd.io` — that token lives only in the Go handlers (`products/catalyst/bootstrap/api/internal/handler/reconcilers*.go`, `jobs_retry.go`), never in the frontend. The UI calls `POST /api/v1/deployments/{id}/reconcilers/{kind}/{ns}/{name}/reconcile` and the annotation is stamped server-side. Direct evidence from the SAME deployed hw255 bundle (fetched read-only from https://console.hw255.omani.works/assets/index-DqSJ9fgF.js):

- `Reconcile now` — 1 hit (ReconcileTab button label)
- `/reconcilers` — 2 hits (API path builder)
- `reconcile-kv-suspended` — 1 hit (ReconcileTab testid)
- `managing a reconciler requires operator tier or higher` — 1 hit (403 copy)

The #3996 surface (`ReconcileTab.tsx`, `reconciler-manage.api.ts`, landed 684e538c5 / PR #3999 on 2026-06-20) is an ancestor of image commit 2b05348 and IS in the shipped bundle. No pin-lag, no regression.

### Gap 2 — Suspend/Resume control "absent" (row 197): FALSE POSITIVE, no code change needed
Same methodology error: `spec.suspend` is a server-side merge-patch built in the Go handler. The deployed bundle contains `children:\`Suspend\`` and `children:\`Resume\`` (the ReconcileTab toggle buttons). The control shipped.

**Rows 196/197 need a UAT re-walk with UI-side tokens (`Reconcile now`, `reconcile-kv-suspended`, `/reconcilers`) or an authenticated click-walk — not a source fix.**

### Gap 3 — tenant-string residue (row 214): REAL, fixed here
Of the 76 bundle hits, the rendered user-visible subset (matching the row-214 walk nuance) is exactly three strings, all fixed per docs/GLOSSARY.md:

- `WorkerNodeFormFields.tsx` — Taints hint `e.g. tenant=dmz:NoSchedule.` → `e.g. org=dmz:NoSchedule.` and placeholder likewise (no live chart uses a `tenant=` taint key — the example is illustrative copy only)
- `org.api.ts` — `create org tenant: HTTP …` → `create organization: HTTP …` (renders in the create-Organization submit-error panel)
- `org.api.ts` — `list org tenants: HTTP …` → `list organizations: HTTP …`

Untouched by design: `X-Tenant-Host` header, `org_tenant_id`/`tenantOrg` wire fields, `data-testid=\"org-create-tenant-*\"`/`sov-console-tenant-*` testids, `bp-*-tenant` chart slugs, legacy `/bss/tenants` redirect paths — protocol/identifier level, not user-visible copy.

## Gates
- `npm run build` (tsc -b && vite build): clean, ✓ built
- `npx vitest run src/pages/org src/components/CrudModals`: 3 files, 17 tests passed
- Fresh dist bundle: `tenant=dmz` / `create org tenant` / `list org tenants` = 0 hits; `org=dmz:NoSchedule` present; total tenant hits 76 → 73 (remaining are protocol/testid/slug)

hw255 was touched read-only (single unauthenticated GET of the static bundle asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)