### PR TITLE
fix(cutover): step-03 harbor-prewarm — direct-source fallback + flap-tolerant pacing for mothership-proxy copies (0.1.136)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -884,7 +884,20 @@ spec:
       # (freshPullProof.rwoEvsExclusion) BEFORE representative selection + Deployment
       # top-up; locality already proven by the #4975 completeness gate + #5026 ref-host
       # lint, so no image-proof value lost. Contract Case 59.
-      version: 0.1.135
+      # 0.1.136 (#5095 Refs #5093): step-03 harbor-prewarm — direct-source fallback
+      # + flap-tolerant pacing for MOTHERSHIP-PROXY-sourced copies. The hw255
+      # 2026-07-15 Omantel→Cogent per-prefix transit flap toward the mothership /24
+      # FAILed every harbor.openova.io/proxy-dockerhub/* copy exit=1 (ghcr.io fine)
+      # and the shared 3×5s per-image budget exhausted inside the 35-min window →
+      # push_fail=6 → FATAL → a full extra Job re-run. Proxy-sourced refs now (1)
+      # retry the SAME image from its canonical direct upstream (docker.io/...,
+      # derived mechanically from the proxy path via the #4975 coverage-map inverse)
+      # before an attempt counts as failed, and (2) get their own attempts budget
+      # (prewarm.proxyCopyAttempts=6) with exponential backoff spanning ≥15 min
+      # (prewarm.proxyBackoffBaseSeconds=30, doubling). FATAL-on-any-failure, the
+      # #5030 dest-check skip, the #4975 pre-pass + multi-arch handling all
+      # preserved. Contract Case 60.
+      version: 0.1.136
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.135
+  version: 0.1.136
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,52 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.136 (#5095 Refs #5093 #3379 — step-03 harbor-prewarm: direct-source
+# fallback + flap-tolerant pacing for MOTHERSHIP-PROXY-sourced copies).
+# Docker-Hub-sourced bootstrap images route through the mothership Harbor
+# proxy-cache (harbor.openova.io/proxy-dockerhub/...), so step-03 has a hard
+# PRE-cutover tether to mothership reachability from the Sovereign. During the
+# 2026-07-15 05:20–05:55Z Omantel→Cogent transit black-hole toward the
+# mothership /24 (hw255 dep 5762118f, cutover 0.1.135 — the server was healthy
+# worldwide, only the path was dead) EVERY harbor.openova.io/proxy-dockerhub
+# copy FAILed exit=1 (keycloak, alpine/k8s ×3, alpine:3.20, aws-cli + the
+# queued bitnamilegacy wave) while every ghcr.io copy was fine. The shared
+# per-image budget (PREWARM_COPY_ATTEMPTS=3, fixed 5s backoff ≈ 10s of spacing)
+# exhausted INSIDE the 35-min flap → Phase A push_fail=6 → FATAL → zero-touch
+# recovery only via a FULL extra Job re-run (~30-40 min on the keystone clock;
+# the #5030 dest-check made the re-run cheap but the wall-clock was still
+# burned). TWO surgical fixes, template 03 + values only:
+#   (1) DIRECT-SOURCE FALLBACK — copy_one derives the canonical upstream ref
+#       MECHANICALLY from the proxy path via an INVERSE #4975 coverage-map
+#       lookup (first HOST_PROJECT_MAP host whose project == the ref's
+#       proxy-<x> segment: proxy-dockerhub → docker.io, proxy-quay → quay.io,
+#       proxy-k8s → registry.k8s.io, proxy-gcr → gcr.io, proxy-ghcr → ghcr.io
+#       — no second hand-list). On a proxy-source copy failure the SAME image
+#       is retried from that direct upstream BEFORE the attempt counts as
+#       failed; the DEST path (host-swap, path preserved) is untouched so
+#       step-04/07/08 resolve the identical local artifact, and the log names
+#       which source ultimately succeeded. src-creds go through the SAME
+#       src_creds_for selector (ghcr.io → PAT; anonymous elsewhere); upstream
+#       rate-limit exposure is bounded (~10-20 images, only while the proxy
+#       path is failing).
+#   (2) FLAP-TOLERANT PACING — proxy-sourced refs get their OWN attempts knob
+#       (PREWARM_PROXY_COPY_ATTEMPTS, .Values.prewarm.proxyCopyAttempts,
+#       default 6) with EXPONENTIAL backoff (prewarm.proxyBackoffBaseSeconds,
+#       default 30, doubling: 30+60+120+240+480 = 930s ≥ 15 min of
+#       inter-attempt spacing, inside the 5400s step deadline) so a routine
+#       per-prefix transit flap can't exhaust the budget. Non-proxy sources
+#       keep the existing 3×5s discipline unchanged.
+# The Phase A skopeo invocation is factored into prewarm_skopeo_copy() so both
+# attempts share ONE flag set — #3944 --command-timeout, #4529
+# --dest-tls-verify=${PREWARM_DEST_TLS_VERIFY} (src stays true), #4975
+# --multi-arch all, and the #3379 real-exit-status capture all preserved
+# (contract Cases 27/30 still count ≥2 bound copies). NOT weakened:
+# FATAL-on-any-failure (Phase A push_fail>0 → exit 1, the sovereignty
+# guarantee), the #5030 durable dest-check skip, the #4975 coverage-map
+# pre-pass, the #4982 settled-roll pre-flight, the #5007 coredns pin. New
+# contract Case 60 locks the wiring. NO step-count / RBAC / job-mode change
+# (still 11 steps). Slot-06a pin + blueprint.yaml + catalog-seed
+# source.version move to 0.1.136 in lockstep (Inviolable Principle #13).
+# ── prior ──
 # 0.1.135 (#5091 Refs #5081 #4975 — step-08 minimal roll-set RULE C: never
 # force-roll a stateful RWO-EVS singleton). The #5081 minimal roll-set (rule a:
 # skip infra namespaces; rule b: skip infra-ns DaemonSets) correctly excludes the
@@ -2155,7 +2202,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.135
+version: 0.1.136
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -217,6 +217,32 @@ data:
           # positive durable src==dst match. Set false to force re-copy.
           - name: PREWARM_SKIP_IF_PRESENT
             value: {{ .Values.prewarm.skipIfAlreadyPresent | quote }}
+          # #5095 (Refs #5093 #3379) — flap-tolerant pacing for MOTHERSHIP-
+          # PROXY-sourced copies. Docker-Hub-sourced bootstrap images route
+          # through the mothership Harbor proxy-cache (harbor.openova.io/
+          # proxy-dockerhub/...), so step-03 has a hard PRE-cutover tether to
+          # mothership reachability from the Sovereign. During the 2026-07-15
+          # 05:20–05:55Z Omantel→Cogent transit black-hole toward the
+          # mothership /24 (hw255 dep 5762118f, #5093 — the server was healthy
+          # worldwide, only the path was dead) EVERY proxy-sourced copy FAILed
+          # exit=1 while the ghcr.io copies were fine, and the shared
+          # PREWARM_COPY_ATTEMPTS=3 / fixed-5s budget exhausted INSIDE the
+          # 35-min flap → Phase A push_fail=6 → FATAL → a full extra Job
+          # re-run (~30-40 min on the keystone clock). Proxy-sourced refs now
+          # get their OWN attempts budget (default 6) with EXPONENTIAL
+          # backoff (base 30s doubling: 30+60+120+240+480 = 930s ≥ 15 min of
+          # inter-attempt spacing) so a routine per-prefix transit flap is
+          # ridden out instead of FATALing the step; copy_one ALSO retries the
+          # SAME image from its canonical DIRECT upstream (derived
+          # mechanically from the proxy path via the #4975 coverage map)
+          # before an attempt counts as failed. Non-proxy sources keep the
+          # existing 3×5s discipline unchanged. FATAL-on-any-failure (the
+          # sovereignty guarantee) is PRESERVED — this only widens the
+          # transient window the step can survive.
+          - name: PREWARM_PROXY_COPY_ATTEMPTS
+            value: {{ .Values.prewarm.proxyCopyAttempts | default 6 | quote }}
+          - name: PREWARM_PROXY_BACKOFF_BASE_SECONDS
+            value: {{ .Values.prewarm.proxyBackoffBaseSeconds | default 30 | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -685,6 +711,11 @@ data:
             # made every fatal copy miscount as success.
             : "${PREWARM_PARALLELISM:=6}"
             : "${PREWARM_COPY_ATTEMPTS:=3}"
+            # #5095 — separate, wider budget for MOTHERSHIP-PROXY-sourced
+            # copies (exponential backoff spans ≥15 min at the defaults so a
+            # short transit flap toward the mothership can't exhaust it).
+            : "${PREWARM_PROXY_COPY_ATTEMPTS:=6}"
+            : "${PREWARM_PROXY_BACKOFF_BASE_SECONDS:=30}"
             cpdir="/tmp/prewarm-copies"
             rm -rf "${cpdir}"; mkdir -p "${cpdir}"
             echo "[harbor-prewarm] pushing ${count} image(s) with parallelism=${PREWARM_PARALLELISM}"
@@ -812,6 +843,43 @@ data:
               [ -n "${_dc_d}" ] && [ "${_dc_s}" = "${_dc_d}" ]
             }
 
+            # #5095 — ONE bounded skopeo image copy SRC → LREF with optional
+            # src creds; output appended to LOGFILE. Factored out of copy_one
+            # so the proxy-source attempt and the #5095 direct-upstream
+            # fallback attempt share ONE invocation. The function's exit
+            # status is skopeo's REAL status (the #3379 hw138 always-0 trap
+            # stays closed: callers branch on it inside an if/else, never a
+            # pipeline). All prior flags are preserved:
+            #   • #3944 --command-timeout (GLOBAL flag before `copy`) bounds a
+            #     stalled-but-alive connection so it FAILS FAST and the outer
+            #     per-image retry loop can self-heal.
+            #   • #4529 --dest-tls-verify=${PREWARM_DEST_TLS_VERIFY} (default
+            #     false — in-cluster/LE-staging Harbor dest); --src-tls-verify
+            #     stays true (external public-CA sources).
+            #   • #4975 --multi-arch all: skopeo's default `--multi-arch
+            #     system` copies ONLY the running platform's sub-image out of
+            #     a manifest LIST while the copy is ADDRESSED by the list's
+            #     digest — Harbor computes the single-arch digest ≠ list
+            #     digest → `digest invalid` (live hw239: all 8 multi-arch
+            #     images FAILED). containerd pulls BY the list digest, so the
+            #     FULL list + all arch sub-manifests + blobs must land.
+            #     Single-arch refs are unaffected.
+            prewarm_skopeo_copy() {
+              _pc_src="$1"; _pc_creds="$2"; _pc_lref="$3"; _pc_log="$4"
+              # Optional --src-creds via the function's OWN positional params
+              # (empty for anonymous upstreams).
+              if [ -n "${_pc_creds}" ]; then set -- --src-creds="${_pc_creds}"; else set --; fi
+              skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
+                --insecure-policy \
+                --multi-arch all \
+                --retry-times 5 \
+                "$@" \
+                --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
+                --src-tls-verify=true \
+                "docker://${_pc_src}" "docker://${_pc_lref}" >>"${_pc_log}" 2>&1
+            }
+
             # #4975 — copy ONE upstream image to ALL of its local Harbor
             # destination path(s) (usually one; TWO for a ghcr.io/openova-io/*
             # ref — the host-drop openova-io/… convention + proxy-ghcr/openova-io/…).
@@ -832,7 +900,49 @@ data:
               srchost="${up%%/*}"
               case "${srchost}" in *.*|*:*|localhost) : ;; *) srchost="docker.io" ;; esac
               sc=$(src_creds_for "${srchost}")
-              if [ -n "${sc}" ]; then set -- --src-creds="${sc}"; else set --; fi
+              # #5095 (Refs #5093) — direct-source fallback derivation for a
+              # MOTHERSHIP-PROXY-sourced ref. A `harbor.openova.io/proxy-<x>/
+              # <path>` source is a hard PRE-cutover tether to mothership
+              # reachability: a routine per-prefix transit flap (hw255
+              # 2026-07-15 05:20–05:55Z, #5093 — mothership healthy worldwide,
+              # only the path black-holed) FAILs every such copy while direct
+              # upstream copies stay fine. Derive the canonical upstream ref
+              # MECHANICALLY from the proxy path via an INVERSE coverage-map
+              # lookup — the FIRST HOST_PROJECT_MAP host whose project equals
+              # the ref's proxy-<x> segment (proxy-dockerhub → docker.io,
+              # proxy-quay → quay.io, proxy-k8s → registry.k8s.io, proxy-gcr →
+              # gcr.io, proxy-ghcr → ghcr.io) — so NO second hand-list exists.
+              # The fallback fires ONLY after the proxy-source copy fails
+              # inside an attempt; the DEST path (host-swap, path preserved)
+              # is untouched, so step-04/07/08 resolve the identical local
+              # artifact. Upstream rate-limit exposure is bounded: ~10-20
+              # images, and only while the proxy path is failing. src-creds
+              # for the fallback host go through the SAME src_creds_for
+              # selector (ghcr.io → PAT; anonymous elsewhere).
+              proxy_src=0
+              fb_up=""
+              fb_creds=""
+              if [ -n "${MOTHERSHIP_HOST:-}" ] && [ "${srchost}" = "${MOTHERSHIP_HOST}" ]; then
+                proxy_src=1
+                _fb_rest="${up#*/}"
+                case "${_fb_rest}" in
+                  */*)
+                    _fb_proj="${_fb_rest%%/*}"
+                    _fb_path="${_fb_rest#*/}"
+                    _fb_host=""
+                    for _fb_pair in ${HOST_PROJECT_MAP}; do
+                      _fb_h="${_fb_pair%%:*}"
+                      case "${_fb_pair}" in *:*) _fb_p="${_fb_pair#*:}" ;; *) _fb_p="" ;; esac
+                      if [ -n "${_fb_p}" ] && [ "${_fb_p}" = "${_fb_proj}" ]; then _fb_host="${_fb_h}"; break; fi
+                    done
+                    if [ -n "${_fb_host}" ]; then
+                      fb_up="${_fb_host}/${_fb_path}"
+                      fb_creds=$(src_creds_for "${_fb_host}")
+                      echo "[harbor-prewarm] mothership-proxy source ${up}: direct-source fallback available (${fb_up}; #5095)" >>"${cpdir}/${slug}.log"
+                    fi
+                    ;;
+                esac
+              fi
               all_ok=1
               last_rc=0
               for dpath in ${dests}; do
@@ -851,50 +961,79 @@ data:
                 # transient blob fetch inside ONE copy; a Harbor-side reset that
                 # closes the dest connection can still abort the whole copy
                 # (hw146 large-image FATAL), so re-attempt the full copy up to
-                # PREWARM_COPY_ATTEMPTS times. FATAL-on-any-failure preserved:
-                # the image is .fail unless every dest copy eventually succeeds.
+                # PREWARM_COPY_ATTEMPTS times — or, for a MOTHERSHIP-PROXY-
+                # sourced ref, PREWARM_PROXY_COPY_ATTEMPTS with EXPONENTIAL
+                # backoff (#5095: the fixed 3×5s budget exhausted inside the
+                # hw255 35-min transit flap). The skopeo invocation itself
+                # (with all the #3944/#4529/#4975 flags) lives in
+                # prewarm_skopeo_copy above; the caller branches on its REAL
+                # exit status (the #3379 hw138 always-0 trap stays closed).
+                # FATAL-on-any-failure preserved: the image is .fail unless
+                # every dest copy eventually succeeds from SOME source.
                 attempt=1
                 rc=1
-                while [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
-                  echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt}/${PREWARM_COPY_ATTEMPTS}" >>"${cpdir}/${slug}.log"
-                  # #3944 --command-timeout (GLOBAL flag before `copy`) bounds a
-                  # stalled connection. #4529 --dest-tls-verify=PREWARM_DEST_TLS_VERIFY
-                  # (default false: in-cluster LE-staging Harbor). --src-tls-verify
-                  # stays true (external public-CA source). "$@" is the optional
-                  # --src-creds selected by host (empty for anonymous upstreams).
-                  # #4975 --multi-arch all: WITHOUT it skopeo defaults to
-                  # `--multi-arch system`, copying ONLY the running platform's
-                  # sub-image out of a manifest LIST while the copy is ADDRESSED by
-                  # the list's digest (`@sha256:205b...`). Harbor computes the digest
-                  # of the single-arch manifest actually uploaded, which does NOT
-                  # equal the list digest → `digest invalid`, fail-closing step-03
-                  # (live hw239 Phase A: 129 single-arch images pushed OK, all 8
-                  # multi-arch manifest-list images FAILED — cilium/*, hubble-*,
-                  # policy-controller, operator-generic). containerd pulls these pod
-                  # images BY the list digest, so Harbor must serve the FULL manifest
-                  # list + ALL arch sub-manifests + blobs. `--multi-arch all` copies
-                  # the complete list so the dest is addressable by the exact list
-                  # digest (digest matches). Single-arch refs are unaffected.
-                  if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
-                    --insecure-policy \
-                    --multi-arch all \
-                    --retry-times 5 \
-                    "$@" \
-                    --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                    --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
-                    --src-tls-verify=true \
-                    "docker://${up}" "docker://${lref}" >>"${cpdir}/${slug}.log" 2>&1; then
+                src_used=""
+                if [ "${proxy_src}" -eq 1 ]; then
+                  max_attempts="${PREWARM_PROXY_COPY_ATTEMPTS}"
+                else
+                  max_attempts="${PREWARM_COPY_ATTEMPTS}"
+                fi
+                while [ "${attempt}" -le "${max_attempts}" ]; do
+                  echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt}/${max_attempts}" >>"${cpdir}/${slug}.log"
+                  if prewarm_skopeo_copy "${up}" "${sc}" "${lref}" "${cpdir}/${slug}.log"; then
                     rc=0
+                    src_used="${up}"
                     break
                   else
                     # Capture skopeo's REAL exit status INSIDE the else branch
                     # (the #3379 hw138 always-0 trap).
                     rc=$?
                   fi
+                  # #5095 — direct-source fallback: BEFORE counting this
+                  # attempt failed, retry the SAME image from its canonical
+                  # upstream (same dest ref, same attempt) when the failed
+                  # source was the mothership proxy. A per-prefix transit flap
+                  # toward the mothership leaves the direct upstream fully
+                  # reachable (proven hw255: ghcr.io copies all ok while every
+                  # harbor.openova.io copy FAILed exit=1).
+                  if [ -n "${fb_up}" ]; then
+                    echo "[harbor-prewarm] proxy source failed (exit=${rc}); direct-source fallback ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5095)" >>"${cpdir}/${slug}.log"
+                    if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" "${cpdir}/${slug}.log"; then
+                      rc=0
+                      src_used="${fb_up}"
+                      break
+                    else
+                      rc=$?
+                    fi
+                  fi
                   echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt} failed (exit=${rc}); retrying after backoff" >>"${cpdir}/${slug}.log"
                   attempt=$((attempt+1))
-                  [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
+                  if [ "${attempt}" -le "${max_attempts}" ]; then
+                    if [ "${proxy_src}" -eq 1 ]; then
+                      # #5095 flap-tolerant pacing: exponential backoff
+                      # base*2^(n-2) before attempt n → 30,60,120,240,480s =
+                      # 930s (≥15 min) of spacing across the default 6-attempt
+                      # budget, so a short transit flap toward the mothership
+                      # cannot exhaust it. Comfortably inside the 5400s step
+                      # deadline; a flap-failure is fast (reset/refused), not a
+                      # stall, so the #3944 --command-timeout stays the stall
+                      # bound.
+                      _bo="${PREWARM_PROXY_BACKOFF_BASE_SECONDS}"
+                      _bi=2
+                      while [ "${_bi}" -lt "${attempt}" ]; do _bo=$((_bo*2)); _bi=$((_bi+1)); done
+                      echo "[harbor-prewarm] proxy-source backoff ${_bo}s before attempt ${attempt}/${max_attempts} for ${up} (#5095 flap-tolerant pacing)" >>"${cpdir}/${slug}.log"
+                      sleep "${_bo}"
+                    else
+                      sleep 5
+                    fi
+                  fi
                 done
+                # #5095 — log which source ultimately succeeded (stdout, real
+                # time, next to the done/skip lines + the per-image log).
+                if [ "${rc}" -eq 0 ] && [ -n "${src_used}" ] && [ "${src_used}" != "${up}" ]; then
+                  echo "[harbor-prewarm] ${up} -> ${lref} succeeded via DIRECT upstream ${src_used} (mothership proxy path failing; #5095)"
+                  echo "  succeeded via direct upstream ${src_used} (mothership proxy path failing)" >>"${cpdir}/${slug}.log"
+                fi
                 [ "${rc}" -eq 0 ] || { all_ok=0; last_rc="${rc}"; }
               done
               if [ "${all_ok}" -eq 1 ]; then

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2640,4 +2640,71 @@ if ! grep -qF 'openova-io chart(s) failed to mirror' "$TMP/s03pin.yaml"; then
 fi
 echo "  PASS (#5007 Facet C: Phase A2 warms the deployed+desired union, reports drift, and keeps the fail-loud chart_fail FATAL so a pinned tag that can't be pulled fails at step-03 with egress open)"
 
+# ── Case 60 (#5095, Refs #5093): step-03 Phase A rides out a mothership-proxy
+# transit flap — direct-source fallback + flap-tolerant exponential pacing ─────
+# hw255 (dep 5762118f, 2026-07-15): during the 05:20–05:55Z Omantel→Cogent
+# per-prefix black-hole toward the mothership /24, EVERY
+# harbor.openova.io/proxy-dockerhub/* copy FAILed exit=1 while every ghcr.io
+# copy was fine — the mothership was healthy worldwide, only the path was dead.
+# The shared PREWARM_COPY_ATTEMPTS=3 / fixed-5s budget exhausted INSIDE the
+# 35-min flap → Phase A push_fail=6 → FATAL → a full extra Job re-run. Step-03
+# must (1) retry a proxy-sourced image from its canonical DIRECT upstream
+# (derived mechanically from the proxy path via the #4975 coverage-map inverse)
+# before an attempt counts as failed, and (2) pace proxy-sourced retries with a
+# WIDER exponential budget (default 6 attempts, base-30s doubling ≥ 15 min of
+# spacing) — while keeping FATAL-on-any-failure (the sovereignty guarantee).
+echo "[cutover-contract] Case 60: step-03 Phase A proxy-sourced copies get a direct-source fallback + exponential flap-tolerant pacing (#5095)"
+[ -s "$TMP/s03pin.yaml" ] || awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml"
+# (a) the separate proxy knobs are projected from values with the right defaults.
+if ! grep -qF 'name: PREWARM_PROXY_COPY_ATTEMPTS' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not project PREWARM_PROXY_COPY_ATTEMPTS (from .Values.prewarm.proxyCopyAttempts) — proxy-sourced copies share the narrow 3-attempt budget a 35-min transit flap exhausts (#5095)" >&2
+  exit 1
+fi
+if ! grep -A1 'name: PREWARM_PROXY_COPY_ATTEMPTS' "$TMP/s03pin.yaml" | grep -q 'value: "6"'; then
+  echo "FAIL: PREWARM_PROXY_COPY_ATTEMPTS does not default to \"6\" — the proxy budget cannot span a routine transit flap (#5095)" >&2
+  exit 1
+fi
+if ! grep -qF 'name: PREWARM_PROXY_BACKOFF_BASE_SECONDS' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not project PREWARM_PROXY_BACKOFF_BASE_SECONDS — proxy retries keep the fixed 5s spacing that burned all attempts in ~10s of flap (#5095)" >&2
+  exit 1
+fi
+# (b) the fallback ref is derived via the INVERSE coverage-map lookup (no second
+#     hand-list may exist) and fires only for the mothership source host.
+if ! grep -qF '"${srchost}" = "${MOTHERSHIP_HOST}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 copy_one does not gate the direct-source fallback on the MOTHERSHIP_HOST source — either it never fires or it fires for non-proxy sources (#5095)" >&2
+  exit 1
+fi
+if ! grep -qF '[ -n "${_fb_p}" ] && [ "${_fb_p}" = "${_fb_proj}" ]' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 copy_one does not derive the fallback host via the inverse HOST_PROJECT_MAP lookup — the canonical upstream would come from a second hand-list that drifts (#5095)" >&2
+  exit 1
+fi
+# (c) the fallback RE-COPIES the same image from the direct upstream inside the
+#     attempt loop (before the attempt counts as failed), and the winning source
+#     is named in the log.
+if ! grep -qF 'prewarm_skopeo_copy "${fb_up}" "${fb_creds}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 copy_one never invokes the direct-source fallback copy — a proxy flap still FATALs images whose upstream is fully reachable (#5095)" >&2
+  exit 1
+fi
+if ! grep -qF 'succeeded via DIRECT upstream' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not log which source ultimately succeeded — a silent fallback hides the mothership-path degradation from the operator (#5095)" >&2
+  exit 1
+fi
+# (d) exponential pacing for proxy-sourced refs (doubling backoff), while the
+#     non-proxy 5s discipline survives.
+if ! grep -qF '_bo=$((_bo*2))' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 proxy retries are not exponentially paced — a fixed backoff cannot span a >=15-min transit flap within any sane attempt count (#5095)" >&2
+  exit 1
+fi
+if ! grep -qF 'sleep 5' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 lost the non-proxy 5s retry backoff — ghcr.io-sourced copies must keep the existing tight pacing (#5095)" >&2
+  exit 1
+fi
+# (e) the sovereignty guarantee is untouched: Phase A still FATALs on any
+#     un-pushed image after both sources + all attempts are exhausted.
+if ! grep -qF 'failed to push — Sovereign cannot survive ghcr.io deny-egress post-cutover' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A lost the push_fail>0 FATAL — the flap tolerance must widen the transient window, never waive the completeness guarantee (#5095)" >&2
+  exit 1
+fi
+echo "  PASS (#5095 contract: proxy-sourced copies fall back to the mechanically-derived direct upstream before an attempt fails, pace retries exponentially over >=15 min via values-exposed knobs, name the winning source, and keep the Phase A FATAL)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -610,6 +610,34 @@ prewarm:
   # before the deny-egress hold) is preserved — a skip happens ONLY on a
   # positive src==dst digest match. Set false to force an unconditional re-copy.
   skipIfAlreadyPresent: true
+  # #5095 (Refs #5093 #3379) — flap-tolerant pacing for MOTHERSHIP-PROXY-sourced
+  # copies. Docker-Hub-sourced bootstrap images route through the mothership
+  # Harbor proxy-cache (harbor.openova.io/proxy-dockerhub/...), giving step-03 a
+  # hard PRE-cutover tether to mothership reachability from the Sovereign. A
+  # routine per-prefix transit flap (hw255 2026-07-15 05:20–05:55Z, #5093:
+  # Omantel→Cogent black-hole toward the mothership /24 — the server was healthy
+  # worldwide, only the path was dead) FAILed every proxy-sourced copy exit=1
+  # while the ghcr.io copies were fine; the shared 3-attempt / fixed-5s budget
+  # exhausted INSIDE the 35-min flap → Phase A push_fail=6 → FATAL → a full
+  # extra Job re-run (~30-40 min on the keystone clock). Proxy-sourced refs
+  # therefore get:
+  #   (a) their OWN attempts budget with EXPONENTIAL backoff — base doubling
+  #       (30+60+120+240+480 = 930s ≥ 15 min of inter-attempt spacing at the
+  #       defaults, comfortably inside the 5400s step deadline) so a short
+  #       transit flap is ridden out instead of FATALing the step; and
+  #   (b) a DIRECT-SOURCE fallback: on a proxy-source copy failure the SAME
+  #       image is retried from its canonical upstream (docker.io/... etc.,
+  #       derived MECHANICALLY from the proxy path via the offlineMirror
+  #       coverage map's inverse — no second hand-list) BEFORE the attempt
+  #       counts as failed. The dest path is untouched (host-swap, path
+  #       preserved), so step-04/07/08 resolve the identical local artifact;
+  #       upstream rate-limit exposure is bounded (~10-20 images, only while
+  #       the proxy path is failing).
+  # FATAL-on-any-failure (the sovereignty guarantee) is PRESERVED — these only
+  # widen the transient window the step can survive. Non-proxy sources keep the
+  # existing 3×5s discipline (PREWARM_COPY_ATTEMPTS) unchanged.
+  proxyCopyAttempts: 6
+  proxyBackoffBaseSeconds: 30
   # #4975 (Refs #3379 #3695) — RETIRED. This hand-maintained 11-image HEAD list
   # (the old Phase B "warm the proxy-cache" pass) was one of the three drifting
   # lists that caused the per-prov whack-a-mole: any upstream image a chart added

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.135"
+  version: "0.1.136"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.135"
+    version: "0.1.136"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5095 #5093

## Defect (live, hw255 dep 5762118f, cutover 0.1.135, 2026-07-15)

During the 05:20–05:55Z Omantel→Cogent per-prefix transit black-hole toward the mothership /24, cutover step-03 harbor-prewarm split cleanly by source: every `ghcr.io/openova-io/*` copy ok, every `harbor.openova.io/proxy-dockerhub/*` copy FAIL exit=1 (keycloak 26.3.3, alpine/k8s ×3, alpine:3.20, aws-cli 2.17.0 + the queued bitnamilegacy wave). The shared per-image budget (`PREWARM_COPY_ATTEMPTS=3`, fixed 5s backoff ≈ 10s of total spacing) exhausted INSIDE the 35-min flap → Phase A `push_fail=6` → FATAL → recovery only via a full extra Job re-run (~30-40 min on the keystone clock). Docker-Hub-sourced images route through the mothership Harbor proxy-cache, so step-03 had a hard PRE-cutover tether to mothership reachability — a routine transit flap (not a mothership failure) became a cutover-step failure.

## Fix (both #5095 mitigations, template 03 + values only)

1. **Direct-source fallback** — `copy_one` derives the canonical upstream ref MECHANICALLY from the proxy path via an INVERSE #4975 coverage-map lookup (first `HOST_PROJECT_MAP` host whose project == the ref's `proxy-<x>` segment: `proxy-dockerhub`→`docker.io`, `proxy-quay`→`quay.io`, `proxy-k8s`→`registry.k8s.io`, `proxy-gcr`→`gcr.io`, `proxy-ghcr`→`ghcr.io` — no second hand-list). On a proxy-source copy failure the SAME image is retried from that direct upstream BEFORE the attempt counts as failed; the DEST path (host-swap, path preserved) is untouched so step-04/07/08 resolve the identical local artifact; the log names which source ultimately succeeded (`succeeded via DIRECT upstream …`). src-creds go through the existing `src_creds_for` selector; upstream rate-limit exposure is bounded (~10-20 images, only while the proxy path fails).
2. **Flap-tolerant pacing** — proxy-sourced refs get their own values-exposed budget: `PREWARM_PROXY_COPY_ATTEMPTS` (`prewarm.proxyCopyAttempts`, default 6) with exponential backoff (`prewarm.proxyBackoffBaseSeconds`, default 30, doubling: 30+60+120+240+480 = **930s ≥ 15 min** of inter-attempt spacing, inside the 5400s step deadline). Non-proxy sources keep the existing 3×5s discipline unchanged.

The Phase A skopeo invocation is factored into `prewarm_skopeo_copy()` so the proxy attempt and the fallback attempt share ONE flag set — #3944 `--command-timeout`, #4529 `--dest-tls-verify=${PREWARM_DEST_TLS_VERIFY}` (src stays `true`), #4975 `--multi-arch all`, and the #3379 real-exit-status capture all preserved.

## Preserved (not weakened)

- FATAL-on-any-failure: Phase A `push_fail>0` → exit 1 (the sovereignty guarantee) — the fixes only widen the transient window the step can ride out.
- #5030 durable dest-check skip (Harbor artifact-API probe, fail-closed).
- #4975 coverage-map pre-pass (UNMAPPED fail-fast) + multi-arch handling.
- #4982 settled-roll pre-flight, #5007 coredns registry pin — untouched.

## Gates

- `helm template` renders clean with defaults; embedded step-03 script passes `sh -n` + `bash -n`.
- `bash scripts/check-no-nodeports.sh` → exit 0.
- `tests/cutover-contract.sh` → all 60 cases green, incl. **new Case 60** (proxy knobs projected with defaults; inverse-map fallback gated on `MOTHERSHIP_HOST`; fallback copy invoked + winning source logged; exponential pacing present while the non-proxy 5s path survives; Phase A FATAL intact). Cases 27/30 still count ≥2 bound / env-driven copies.
- `tests/image-registry-coverage.sh` → PASS (168 refs, 7 hosts).
- 4-surface lockstep to **0.1.136**: `chart/Chart.yaml` + `blueprint.yaml` + `clusters/_template/bootstrap-kit/06a` pin + catalog-seed `spec.version`/`source.version`; `TestBootstrapKit_BlueprintVersionLockstepSweep` → ok.

## Render proof (fallback logic in the rendered job)

```
$ helm template . | <extract step-03 podSpec args>
457:: "${PREWARM_PROXY_COPY_ATTEMPTS:=6}"
458:: "${PREWARM_PROXY_BACKOFF_BASE_SECONDS:=30}"
679:          fb_up="${_fb_host}/${_fb_path}"
741:        if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" ...
761:          _bo="${PREWARM_PROXY_BACKOFF_BASE_SECONDS}"   # 30,60,120,240,480 = 930s
774:      echo "... succeeded via DIRECT upstream ${src_used} (mothership proxy path failing; #5095)"
```

Derivation simulated over the live hw255 failure set: `harbor.openova.io/proxy-dockerhub/keycloak/keycloak:26.3.3` → `docker.io/keycloak/keycloak:26.3.3`; `proxy-quay/cilium/cilium` → `quay.io/...`; `proxy-xpkg/*` (unmapped/excluded) → no fallback; non-mothership sources untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)