### PR TITLE
fix(console): silent-SSO handoff — stop cancelling the prompt=none Keycloak navigation (UAT row 29, hw255)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -310,9 +310,30 @@ async function rootBeforeLoad({ location }: { location: { pathname: string } }) 
   // ping-ponging console → KC → console → KC. The guard is cleared by
   // AuthCallbackPage on a successful exchange.
   if (await attemptSilentSovereignSSO()) {
-    // Navigation is being handed to Keycloak via window.location.replace
-    // inside initiateLogin — block this route resolution.
-    throw redirect({ to: canonical as never, replace: true })
+    // Navigation has been handed to Keycloak via window.location.replace
+    // inside initiateLogin. Do NOT throw a router redirect here: TanStack
+    // would commit a same-document history navigation, and Chromium
+    // cancels any in-flight provisional document navigation the moment
+    // the renderer commits a same-document one — the KC round-trip died
+    // with net::ERR_ABORTED before ever leaving the page, the gate
+    // re-ran, saw the one-shot guard, and dumped even LIVE-session
+    // visitors on /login?next=… (#3374 row 29 — reproduced live on hw255,
+    // wire trace: whoami 401 → authorize?prompt=none issued → same-doc
+    // NAV → authorize ERR_ABORTED → /login). Instead, PARK this route
+    // resolution while the document unloads to Keycloak. Safety net: if
+    // the KC navigation somehow fails to commit (auth host unreachable),
+    // fall back to /login after a grace period rather than hanging a
+    // blank tab forever.
+    await new Promise((resolve) => setTimeout(resolve, SILENT_SSO_NAV_GRACE_MS))
+    // Still executing → the document navigation to Keycloak never
+    // committed, so no KC round-trip actually happened. Clear the
+    // one-shot guard to re-arm a later silent attempt, then fall through
+    // to the explicit /login redirect below.
+    try {
+      sessionStorage.removeItem(SILENT_SSO_GUARD_KEY)
+    } catch {
+      /* private browsing may throw */
+    }
   }
   // Silent SSO not possible (already attempted this cycle, or no FQDN) —
   // fall back to the explicit /login. Sanitize the `next` so we can never
@@ -348,6 +369,17 @@ async function rootBeforeLoad({ location }: { location: { pathname: string } }) 
  * successful token exchange (so a later genuine expiry re-arms silent SSO).
  */
 export const SILENT_SSO_GUARD_KEY = 'catalyst:silent-sso-attempted'
+
+/**
+ * How long rootBeforeLoad stays parked after handing navigation to
+ * Keycloak before concluding the document navigation failed to commit
+ * (e.g. auth host unreachable) and falling back to /login. In the happy
+ * path the page unloads to Keycloak within a few hundred ms and this
+ * timer never fires. Generous on purpose: a premature fallback would
+ * commit a same-document navigation, which cancels the in-flight KC
+ * navigation (the exact #3374 row-29 defect this guards against).
+ */
+export const SILENT_SSO_NAV_GRACE_MS = 8000
 
 async function attemptSilentSovereignSSO(): Promise<boolean> {
   if (typeof window === 'undefined') return false


### PR DESCRIPTION
## Problem — UAT row 29: silent-SSO front door does not engage on hw255

Wave-2 walker evidence (ledger `a98147dfc`): with a **live** Keycloak SSO session in the browser (proven — `auth.hw255.omani.works/admin/sovereign/console/`, grafana, harbor all silently authed in the same context), a bare hit to `https://console.hw255.omani.works/` still lands on `/login?next=%2Fdashboard` with the PIN form.

### Shipped-vs-deployed verdict

The #4985 mechanism (`prompt=none` builder, all four recoverable OIDC error codes, silent-SSO guard) **IS present in the deployed hw255 bundle** (`index-DqSJ9fgF.js`) — this is not pin-lag. The shipped fix itself has a runtime defect that its hw239-era gates (typecheck/vitest/build) could not catch: it is a browser navigation-cancellation race.

### Root cause — reproduced live on hw255, wire-traced

`rootBeforeLoad` (`products/catalyst/bootstrap/ui/src/app/router.tsx`), after `attemptSilentSovereignSSO()` calls `window.location.replace(<KC authorize?prompt=none>)`, threw `redirect({ to: canonical })` to "block route resolution". TanStack commits that as a **same-document history navigation**, and Chromium **cancels the in-flight provisional document navigation to Keycloak**. Pristine-context trace against the deployed bundle:

```
530ms  RES 401  /api/v1/whoami
533ms  REQ GET  auth.hw255…/realms/sovereign/protocol/openid-connect/auth?…prompt=none   ← silent attempt fires
541ms  NAV      /dashboard                          ← TanStack same-document commit
547ms  FAIL     auth.hw255…/auth?…  err=net::ERR_ABORTED   ← KC navigation cancelled
551ms  NAV      /login?next=%2Fdashboard            ← gate re-ran, one-shot guard '1' → fallback
```

The KC round-trip never leaves the page — **with or without a live session** — so even signed-in-at-KC visitors get the PIN wall. The stuck guard (`catalyst:silent-sso-attempted=1`, only cleared by `AuthCallbackPage` which is never reached) also disarms all later attempts in the tab. The walker's methodology was sound; the URL shape they captured (`/login?next=%2Fdashboard`, which only the pre-round-trip fallback produces — the callback fallback lands on bare `/login`) matches this trace exactly.

## Fix

`router.tsx` — after the silent handoff, do **not** throw a router redirect. Park the route resolution on a grace timer (`SILENT_SSO_NAV_GRACE_MS`, 8s) while the document unloads to Keycloak. Safety net: if the KC navigation never commits (auth host unreachable), clear the one-shot guard (no round-trip actually happened) and fall through to the explicit `/login` redirect — no blank-tab hang, no redirect loop (`/login` is public).

## Runtime verification (read-only against the real hw255 Keycloak)

Fixed local build served under `console.hw255.omani.works` via Playwright interception, whoami stubbed 401, KC real, pristine context:

```
537ms  RES 302  KC authorize?prompt=none → /auth/callback?error=login_required&state=…   ← round-trip COMMITS
552ms  NAV      /auth/callback?error=login_required…
1087ms NAV      /login          ← AuthCallbackPage clean fallback, PIN form rendered
guard: null (re-armed)          ← was stuck '1' before the fix
```

The live-session complement (auth-cookie → code) is realm-side: the sovereign realm browser flow runs `auth-cookie` (priority 10) before the `catalyst-pin` redirector (priority 25), and the walker independently proved realm-session reuse works on hw255 (silent auth into the KC admin console). The FE now actually delivers the browser to that flow.

## Gates
- `tsc -b --noEmit`: clean
- `vitest` — auth-gate + oidc + organizationsRedirects suites: 99 passed
- `vite build`: clean

Refs #4985
Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
