### PR TITLE
fix(catalyst-api): stop freezing a healthy secondary at 0/0 degraded when flux lands after the CRD-probe budget

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -1260,7 +1260,7 @@ locals {
                 --max-time 15 \
                 "${var.catalyst_api_url}/api/v1/deployments/${var.deployment_id}/kubeconfig" || echo "000")
               echo "primary kubeconfig PUT-back attempt $${attempt} -> HTTP $${HTTP_CODE}"
-              if [ "$${HTTP_CODE}" = "204" ] || [ "$${HTTP_CODE}" = "200" ]; then break; fi
+              case "$${HTTP_CODE}" in 2*) break;; esac
               sleep 30
             done
           fi
@@ -1289,7 +1289,11 @@ locals {
                 --max-time 15 \
                 "${var.catalyst_api_url}/api/v1/sovereign/secondary-kubeconfig" || echo "000")
               echo "secondary kubeconfig PUT-back attempt $${attempt} -> HTTP $${HTTP_CODE}"
-              if [ "$${HTTP_CODE}" = "204" ] || [ "$${HTTP_CODE}" = "200" ]; then break; fi
+              # #5012 hw255: the secondary endpoint answers 201 Created — the old
+              # 204|200-only check never broke, so every healthy secondary burned
+              # 12 attempts x sleep 30 (~6 min) HERE, pushing flux-install past the
+              # mothership's flux-CRD probe budget. Accept ANY 2xx.
+              case "$${HTTP_CODE}" in 2*) break;; esac
               sleep 30
             done
             rm -f /tmp/secondary-kubeconfig-body.json

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -161,15 +161,27 @@ const fluxCRDProbeBudgetEnv = "CATALYST_PHASE1_FLUX_CRD_PROBE_BUDGET"
 const fluxCRDProbePollIntervalEnv = "CATALYST_PHASE1_FLUX_CRD_PROBE_POLL_INTERVAL"
 
 // DefaultFluxCRDProbeBudget — production default for the Flux-CRD-
-// presence probe budget (#5042). 5 minutes is generous headroom: on a
-// HEALTHY prov the flux-install manifest lands seconds after the k3s
-// apiserver is up (well before the kubeconfig is even PUT back), so a
-// CRD still absent 5 minutes after the kubeconfig arrives is a
-// high-confidence signal that cloud-init's flux-install stage failed.
+// presence probe budget (#5042).
+//
+// 15 minutes, NOT less — the original 5m default rested on an inverted
+// premise ("flux lands before the kubeconfig is even PUT back"). Since the
+// #3129 PUT-early invariant (cloudinit-control-plane.tftpl header), the
+// kubeconfig PUT-back runs RIGHT AFTER the k3s apiserver is healthy, and
+// flux-install only runs AFTER gateway-api CRDs + the helm binary download +
+// the cilium helm install + the FULL cilium DaemonSet rollout across every
+// node in the region. On a healthy Huawei 6-node region that is ~6-9 minutes
+// of legitimate bootstrap AFTER the kubeconfig arrives. hw255 (#5012
+// recurrence, dep 5762118f63abef96, 2026-07-15): region-b PUT ~04:13 UTC,
+// flux CRDs landed ~04:21 UTC — a healthy 8-minute gap that the 5m budget
+// classified as a positive flux-CRD-absent, permanently freezing the region's
+// census at 0/0 degraded while it actually converged to 58/65 HRs Ready.
+// 15 minutes still terminates a genuine #5042 wedge ~8x faster than the 120m
+// WatchTimeout it exists to shortcut.
+//
 // The probe is CONSERVATIVE — it only classifies OutcomeFluxCRDsAbsent
 // on a POSITIVE "CRD absent + apiserver answered" observation at
 // budget end, never on a transient probe error (see probeFluxCRDAbsent).
-const DefaultFluxCRDProbeBudget = 5 * time.Minute
+const DefaultFluxCRDProbeBudget = 15 * time.Minute
 
 // DefaultFluxCRDProbePollInterval — production default for the Flux-
 // CRD-presence probe poll cadence (#5042).
@@ -582,11 +594,28 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 			// fail/hang the whole prov (surface-not-gate discipline), so a
 			// positive absent verdict records a NAMED, greppable degraded signal
 			// (recordSecondaryFluxCRDAbsent: a loud region-tagged warn +
-			// Result.SecondaryFluxCRDAbsentRegions + a nil census slot) and
-			// skips spinning the doomed watcher. The slot stays reserved.
+			// Result.SecondaryFluxCRDAbsentRegions + a nil census slot). The
+			// slot stays reserved.
+			//
+			// hw255 recurrence (#5012, dep 5762118f63abef96): the verdict must
+			// be a SURFACE, not a terminal — the #3129 PUT-early invariant puts
+			// the kubeconfig on the mothership minutes BEFORE the secondary's
+			// cloud-init reaches flux-install (gateway-api CRDs + helm download
+			// + full cilium DaemonSet rollout sit in between), so flux can land
+			// AFTER the probe budget on a perfectly healthy region. Keep
+			// waiting (bounded only by this watcher's ctx — phase-1 lifetime);
+			// when the CRD lands, clear the degraded record and fall through to
+			// spin the real watcher so the #3611 census reports the region's
+			// true HR counts instead of a frozen 0/0. A region whose flux never
+			// lands keeps the recorded signal and spins no watcher, as before.
 			if h.probeFluxCRDAbsentForRegion(wctx, dep, region, string(raw)) {
 				h.recordSecondaryFluxCRDAbsent(dep, region)
-				return
+				if !h.waitFluxCRDServableForRegion(wctx, dep, region, string(raw)) {
+					// Phase-1 ended (ctx cancelled) with the CRD still absent —
+					// the recorded degraded signal stands.
+					return
+				}
+				h.clearSecondaryFluxCRDAbsent(dep, region)
 			}
 
 			cfg := h.phase1WatchConfigForDeployment(dep, string(raw))
@@ -2518,6 +2547,83 @@ func (h *Handler) recordSecondaryFluxCRDAbsent(dep *Deployment, region string) {
 		Message: fmt.Sprintf("Phase-1 watch [region %s]: the Flux HelmRelease CRD (helmreleases.helm.toolkit.fluxcd.io) was still ABSENT after the probe budget — this SECONDARY region's cloud-init flux-install stage did not land. Recording it DEGRADED (secondary-flux-crds-absent) and skipping its doomed no-CRD watcher; the PRIMARY region is unaffected and the deployment is NOT failed on account of this secondary (surface-not-gate). Operator: SSH region %s's control-plane and inspect /var/log/cloud-init-output.log for the flux-install step. Refs #5012 #5042.", region, region),
 	})
 	h.log.Warn("secondary region flux HelmRelease CRD absent after probe budget — recording degraded, skipping doomed watcher (non-fatal, surface-not-gate)",
+		"id", dep.ID, "region", region)
+}
+
+// waitFluxCRDServableForRegion keeps polling a SECONDARY region's apiserver for
+// the Flux HelmRelease CRD AFTER probeFluxCRDAbsentForRegion classified it
+// absent-at-budget (#5012, hw255 recurrence). Under the #3129 PUT-early
+// invariant a healthy secondary legitimately installs flux minutes after its
+// kubeconfig lands on the mothership (gateway-api CRDs + helm download + the
+// full cilium DaemonSet rollout run in between), so an absent-at-budget verdict
+// must not permanently freeze the region's census at 0/0. Bounded only by ctx
+// (the region watcher's context — phase-1 lifetime): returns true the moment a
+// List against HelmReleaseGVR succeeds (flux landed; caller clears the degraded
+// record and spins the real watcher), false when ctx is cancelled first (the
+// recorded degraded signal stands). Any error — absent or transient — just
+// keeps polling; this waiter never invents a verdict of its own.
+func (h *Handler) waitFluxCRDServableForRegion(ctx context.Context, dep *Deployment, region, kubeconfig string) bool {
+	_, pollEvery := h.fluxCRDProbeBudgets()
+
+	dyn, err := h.buildFluxProbeDynamicClient(kubeconfig)
+	if err != nil || dyn == nil {
+		h.log.Warn("secondary flux-crd late-landing wait: could not build dynamic client; leaving region recorded degraded",
+			"id", dep.ID, "region", region, "err", err)
+		return false
+	}
+
+	for {
+		getCtx, cancelGet := context.WithTimeout(ctx, pollEvery)
+		_, listErr := dyn.Resource(helmwatch.HelmReleaseGVR).
+			Namespace(helmwatch.FluxNamespace).
+			List(getCtx, metav1.ListOptions{Limit: 1})
+		cancelGet()
+		if listErr == nil {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(pollEvery):
+		}
+	}
+}
+
+// clearSecondaryFluxCRDAbsent reverses recordSecondaryFluxCRDAbsent for a
+// SECONDARY region whose Flux CRD landed after the probe budget (#5012, hw255
+// recurrence): removes the region from Result.SecondaryFluxCRDAbsentRegions,
+// releases the nil census slot (the caller registers the REAL watcher next, so
+// the #3611 census reports true HR counts instead of a frozen 0/0), and emits
+// an info event so the wizard log shows the recovery next to the earlier warn.
+func (h *Handler) clearSecondaryFluxCRDAbsent(dep *Deployment, region string) {
+	dep.mu.Lock()
+	if dep.Result != nil && len(dep.Result.SecondaryFluxCRDAbsentRegions) > 0 {
+		kept := dep.Result.SecondaryFluxCRDAbsentRegions[:0]
+		for _, r := range dep.Result.SecondaryFluxCRDAbsentRegions {
+			if r != region {
+				kept = append(kept, r)
+			}
+		}
+		if len(kept) == 0 {
+			dep.Result.SecondaryFluxCRDAbsentRegions = nil
+		} else {
+			dep.Result.SecondaryFluxCRDAbsentRegions = kept
+		}
+	}
+	// Only release the slot recordSecondaryFluxCRDAbsent registered (nil); a
+	// real watcher registered concurrently must never be dropped.
+	if w, ok := dep.secondaryWatchers[region]; ok && w == nil {
+		delete(dep.secondaryWatchers, region)
+	}
+	dep.mu.Unlock()
+
+	h.emitWatchEvent(dep, provisioner.Event{
+		Time:    time.Now().UTC().Format(time.RFC3339),
+		Phase:   helmwatch.PhaseComponent,
+		Level:   "info",
+		Message: fmt.Sprintf("Phase-1 watch [region %s]: the Flux HelmRelease CRD landed AFTER the probe budget — this secondary's flux-install was slow, not missing. Clearing the degraded (secondary-flux-crds-absent) record and starting its per-component watch. Refs #5012.", region),
+	})
+	h.log.Info("secondary region flux HelmRelease CRD landed after probe budget — clearing degraded record, starting watcher",
 		"id", dep.ID, "region", region)
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_secondary_flux_crd_absent_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_secondary_flux_crd_absent_test.go
@@ -23,6 +23,14 @@
 //     watcher, and NEVER fails the deployment (Status stays phase1-watching).
 //  3. spawnSecondaryRegionWatchers against a present-CRD secondary spins a
 //     normal real watcher and records nothing absent — no regression.
+//  4. hw255 recurrence (#5012, dep 5762118f63abef96): an absent-at-budget
+//     verdict is a SURFACE, not a terminal. Under the #3129 PUT-early
+//     invariant a healthy secondary installs flux MINUTES after its
+//     kubeconfig lands (gateway-api CRDs + helm download + the full cilium
+//     DaemonSet rollout run in between), so when the CRD lands AFTER the
+//     probe budget the spawn must clear Result.SecondaryFluxCRDAbsentRegions,
+//     release the nil census slot, and spin the REAL watcher — instead of
+//     freezing the region's census at 0/0 degraded for the whole prov.
 package handler
 
 import (
@@ -31,9 +39,44 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 )
+
+// fakeDynamicFactoryHRListErrorUntil — closure that returns fake dynamic
+// clients whose List against the HelmRelease GVR fails with listErr for the
+// first `failCalls` List invocations ACROSS ALL clients it builds, then
+// succeeds (empty list). Simulates the hw255 #5012 shape: the CRD is cleanly
+// absent while the probe runs (cloud-init is still mid cilium-rollout), then
+// flux-install lands and the CRD becomes servable. The counter is shared
+// across client builds because the probe, the late-landing waiter, and the
+// real watcher each build their own client through the same factory.
+func fakeDynamicFactoryHRListErrorUntil(listErr error, failCalls int64) func(string) (dynamic.Interface, error) {
+	var calls atomic.Int64
+	return func(_ string) (dynamic.Interface, error) {
+		scheme := newFakeSchemeForHandler()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme,
+			map[schema.GroupVersionResource]string{helmwatch.HelmReleaseGVR: "HelmReleaseList"},
+		)
+		client.PrependReactor("list", "helmreleases", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			if calls.Add(1) <= failCalls {
+				return true, nil, listErr
+			}
+			return false, nil, nil // fall through to the default (empty-list) reactor
+		})
+		return client, nil
+	}
+}
 
 // TestProbeFluxCRDAbsentForRegion covers the secondary probe verdicts in
 // isolation, exactly mirroring TestProbeFluxCRDAbsent for the primary.
@@ -213,6 +256,74 @@ func TestSpawnSecondaryRegionWatchers_FluxCRDPresent(t *testing.T) {
 	defer dep.mu.Unlock()
 	if containsStr(dep.Result.SecondaryFluxCRDAbsentRegions, region) {
 		t.Errorf("region %q recorded flux-crd-absent on a CRD-PRESENT prov — the probe false-positived", region)
+	}
+}
+
+// TestSpawnSecondaryRegionWatchers_FluxCRDLandsLate drives the hw255 #5012
+// recurrence end-to-end: the secondary's CRD is cleanly absent PAST the probe
+// budget (probe classifies absent → region recorded degraded), then flux lands
+// (the #3129 PUT-early gap closing). The spawn must then CLEAR the recorded
+// degraded signal and register a REAL watcher so the census reports true HR
+// counts — the region must not stay frozen at 0/0 degraded.
+func TestSpawnSecondaryRegionWatchers_FluxCRDLandsLate(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// The probe polls ~6 times inside its 150ms budget; 30 failing List calls
+	// comfortably outlast the budget (positive absent verdict) and then keep
+	// the late-landing waiter polling for a few more rounds before the CRD
+	// becomes servable.
+	h.dynamicFactory = fakeDynamicFactoryHRListErrorUntil(hrCRDNotFound(), 30)
+	h.fluxCRDProbeBudget = 150 * time.Millisecond
+	h.fluxCRDProbePollInterval = 10 * time.Millisecond
+	h.phase1WatchTimeout = 5 * time.Second
+
+	kcDir := t.TempDir()
+	h.kubeconfigsDir = kcDir
+	depID := "sec-flux-lands-late"
+	region := "me-east-215-b-1"
+
+	dep := makeDeploymentWithKubeconfig(t, h, depID, "primary-kubeconfig: yaml")
+	if err := os.WriteFile(filepath.Join(kcDir, depID+"-"+region+".yaml"), []byte("secondary-kubeconfig: yaml"), 0o600); err != nil {
+		t.Fatalf("write secondary kubeconfig: %v", err)
+	}
+
+	stop := h.spawnSecondaryRegionWatchers(dep)
+	defer stop()
+
+	// Phase A — the probe must first classify absent and record the region
+	// degraded (the surface fires while flux genuinely isn't there yet).
+	if !waitUntil(2*time.Second, func() bool {
+		dep.mu.Lock()
+		recorded := containsStr(dep.Result.SecondaryFluxCRDAbsentRegions, region)
+		dep.mu.Unlock()
+		return recorded
+	}) {
+		t.Fatalf("timed out waiting for region %q to first be recorded flux-crd-absent", region)
+	}
+
+	// Phase B — once the CRD lands, the record must clear and a REAL watcher
+	// must be registered.
+	if !waitUntil(3*time.Second, func() bool {
+		dep.mu.Lock()
+		cleared := !containsStr(dep.Result.SecondaryFluxCRDAbsentRegions, region)
+		sw, exists := dep.secondaryWatchers[region]
+		dep.mu.Unlock()
+		return cleared && exists && sw != nil
+	}) {
+		dep.mu.Lock()
+		gotAbsent := append([]string(nil), dep.Result.SecondaryFluxCRDAbsentRegions...)
+		sw, exists := dep.secondaryWatchers[region]
+		dep.mu.Unlock()
+		t.Fatalf("timed out waiting for late-landing recovery: SecondaryFluxCRDAbsentRegions=%v, watcherSlot(exists=%v,nil=%v) — the region stayed frozen degraded", gotAbsent, exists, sw == nil)
+	}
+
+	// The recovery must never have flipped the deployment terminal.
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Status == "failed" {
+		t.Errorf("Status = %q — a late-landing secondary must never fail the prov", dep.Status)
+	}
+	if dep.Result.Phase1Outcome != "" {
+		t.Errorf("Phase1Outcome = %q — the secondary path must not touch the primary's terminal outcome", dep.Result.Phase1Outcome)
 	}
 }
 


### PR DESCRIPTION
Refs #5012 #5042

## What broke on hw255 (dep `5762118f63abef96`, live keystone, post-cutoverComplete)

Region-b's Flux plane is NOT empty — it converged to **65 HRs, 58 Ready** (the exact hw235 healthy-secondary shape: 7 non-Ready are the by-design suspended/DR set). Yet the deployment record froze at `hrReady 0/0`, `degraded=true`, `secondaryDegraded=true`, `secondaryFluxCRDAbsentRegions=["me-east-215-b-1"]`.

## RCA — three compounding defects

**Timeline (region-b cloud-init log, pushed to the mothership PVC):**
- 04:11:38Z boot; k3s starts ~04:13Z.
- kubeconfig PUT-back fires immediately (the #3129 PUT-early invariant) — **12 attempts, every one HTTP 201**.
- gateway-api CRDs → helm download → cilium helm install (completes 04:19:18Z) → full 6-node cilium DS rollout → **flux-system + CRDs land ~04:21Z**.
- `phase1FinishedAt` 05:01:45Z with region-b fully populating.

1. **PR #5084's per-secondary flux-CRD probe (merged 03:08Z, first live on this prov) treats absent-at-budget as TERMINAL** (`phase1_watch.go` — spawn path skipped the "doomed" watcher and kept the slot reserved forever). Flux landed ~2-3 min after the 5m deadline, so the census could never observe the 58/65 recovery: nil slot → 0/0 → degraded, frozen into the record at `markPhase1Done`.
2. **`DefaultFluxCRDProbeBudget`'s 5m premise is inverted.** Its comment assumed "flux lands before the kubeconfig is even PUT back" — but #3129 deliberately PUTs the kubeconfig right after k3s, and flux-install follows gateway-api + helm + the full cilium rollout (~6-9 min on healthy Huawei regions). The same race can false-fail the PRIMARY (`OutcomeFluxCRDsAbsent` fails the whole prov), since `PutKubeconfig` kicks the watch on the PUT itself.
3. **The huawei secondary PUT-back loop never breaks**: it accepts only 204/200 but `/api/v1/sovereign/secondary-kubeconfig` answers **201 Created** (`sovereign_secondary_kubeconfig.go:307`). All 12 attempts fire with `sleep 30` between = ~6 wasted minutes that pushed flux-install even further past the probe budget. (Hetzner uses plain `curl -fsSL`, unaffected; the primary PUT answers 204 and broke on attempt 1.)

## Fix (durable, no live mutation of hw255)

- `phase1_watch.go`: a secondary absent-at-budget verdict is now a **surface that self-heals** — record the loud degraded signal as before, then keep waiting for the CRD (bounded by the phase-1 watcher ctx); when it lands, clear `SecondaryFluxCRDAbsentRegions`, release the nil census slot, and spin the real watcher. A region whose flux never lands keeps the named signal and spins no watcher, unchanged.
- `DefaultFluxCRDProbeBudget` 5m → **15m** with the corrected premise documented — still ~8x faster than the 120m WatchTimeout for a genuine #5042 wedge, and it removes the primary-probe false-fail window too.
- `infra/providers/huawei/main.tf`: both PUT-back loops break on **any 2xx**.

## Verification

- New `TestSpawnSecondaryRegionWatchers_FluxCRDLandsLate` drives the hw255 shape end-to-end: absent past budget → recorded degraded → CRD lands → record cleared + REAL watcher registered, deployment never failed.
- Existing absent/present/ctx-cancel tests pass unchanged (genuinely-dead-region behavior preserved).
- Full `products/catalyst/bootstrap/api` module: `go vet` + `go test ./...` green.
- `infra/providers/huawei`: `tofu init -backend=false` + `tofu validate` green (real providers, not a simulation).
- Next fresh 2-region prov validates live: expect the record's `regions[me-east-215-b-*]` to report real HR counts (~58/65) with `secondaryDegraded=false`, and the secondary PUT-back log to show a single 201 attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)