### PR TITLE
fix(cloud): Networking lens chips read 0/0 — adapt Gateway/HTTPRoute/NetworkPolicy snapshot kinds into the graph (Refs #3987)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
@@ -337,6 +337,135 @@ describe('k8sToGraph', () => {
       }),
     )
   })
+
+  /* ── #3987 (UAT row 200) — Gateway-API + NetworkPolicy projection.
+   * The snapshot carried gateway:/httproute:/networkpolicy: keys but
+   * the adapter had no section for them, so the Networking lens chips
+   * rendered 0/0 against a cluster full of live routes. */
+
+  it('#3987: emits a Gateway node with Programmed-condition status + Namespace edge', () => {
+    const s = snap(
+      ['namespace:kube-system', { metadata: { name: 'kube-system' } }],
+      [
+        'gateway:kube-system/cilium-gateway',
+        {
+          apiVersion: 'gateway.networking.k8s.io/v1',
+          kind: 'Gateway',
+          metadata: { namespace: 'kube-system', name: 'cilium-gateway' },
+          spec: { gatewayClassName: 'cilium' },
+          status: { conditions: [{ type: 'Programmed', status: 'True' }] },
+        },
+      ],
+    )
+    const { nodes, edges } = k8sToGraph(s)
+    const gw = nodes.find((n) => n.id === 'Gateway:kube-system/cilium-gateway')
+    expect(gw).toBeDefined()
+    expect(gw?.type).toBe('Gateway')
+    expect(gw?.status).toBe('healthy')
+    expect(gw?.metadata?.['gatewayClassName']).toBe('cilium')
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        source: 'Gateway:kube-system/cilium-gateway',
+        target: 'Namespace:kube-system',
+        type: 'member-of',
+      }),
+    )
+  })
+
+  it('#3987: emits HTTPRoute node + flows-to Gateway (parentRefs) + routes-to Service (backendRefs)', () => {
+    const s = snap(
+      ['namespace:catalyst-system', { metadata: { name: 'catalyst-system' } }],
+      [
+        'gateway:kube-system/cilium-gateway',
+        {
+          apiVersion: 'gateway.networking.k8s.io/v1',
+          kind: 'Gateway',
+          metadata: { namespace: 'kube-system', name: 'cilium-gateway' },
+          spec: { gatewayClassName: 'cilium' },
+        },
+      ],
+      [
+        'httproute:catalyst-system/console',
+        {
+          apiVersion: 'gateway.networking.k8s.io/v1',
+          kind: 'HTTPRoute',
+          metadata: { namespace: 'catalyst-system', name: 'console' },
+          spec: {
+            hostnames: ['console.hw255.omani.works'],
+            parentRefs: [{ name: 'cilium-gateway', namespace: 'kube-system' }],
+            rules: [{ backendRefs: [{ name: 'catalyst-console', port: 80 }] }],
+          },
+          status: {
+            parents: [{ conditions: [{ type: 'Accepted', status: 'True' }] }],
+          },
+        },
+      ],
+    )
+    const { nodes, edges } = k8sToGraph(s)
+    const route = nodes.find((n) => n.id === 'HTTPRoute:catalyst-system/console')
+    expect(route).toBeDefined()
+    expect(route?.type).toBe('HTTPRoute')
+    expect(route?.status).toBe('healthy')
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        source: 'HTTPRoute:catalyst-system/console',
+        target: 'Gateway:kube-system/cilium-gateway',
+        type: 'flows-to',
+      }),
+    )
+    // backendRef without namespace defaults to the route's own ns.
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        source: 'HTTPRoute:catalyst-system/console',
+        target: 'Service:catalyst-system/catalyst-console',
+        type: 'routes-to',
+      }),
+    )
+  })
+
+  it('#3987: HTTPRoute with no accepted parent renders degraded', () => {
+    const s = snap([
+      'httproute:foo/r1',
+      {
+        apiVersion: 'gateway.networking.k8s.io/v1',
+        kind: 'HTTPRoute',
+        metadata: { namespace: 'foo', name: 'r1' },
+        spec: {},
+        status: {
+          parents: [{ conditions: [{ type: 'Accepted', status: 'False' }] }],
+        },
+      },
+    ])
+    const { nodes } = k8sToGraph(s)
+    expect(nodes.find((n) => n.id === 'HTTPRoute:foo/r1')?.status).toBe('degraded')
+  })
+
+  it('#3987: emits a NetworkPolicy node + Namespace edge', () => {
+    const s = snap(
+      ['namespace:catalyst-system', { metadata: { name: 'catalyst-system' } }],
+      [
+        'networkpolicy:catalyst-system/plane-isolation',
+        {
+          apiVersion: 'networking.k8s.io/v1',
+          kind: 'NetworkPolicy',
+          metadata: { namespace: 'catalyst-system', name: 'plane-isolation' },
+          spec: { podSelector: {} },
+        },
+      ],
+    )
+    const { nodes, edges } = k8sToGraph(s)
+    const np = nodes.find((n) => n.id === 'NetworkPolicy:catalyst-system/plane-isolation')
+    expect(np).toBeDefined()
+    expect(np?.type).toBe('NetworkPolicy')
+    expect(np?.status).toBe('healthy')
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        source: 'NetworkPolicy:catalyst-system/plane-isolation',
+        target: 'Namespace:catalyst-system',
+        type: 'member-of',
+      }),
+    )
+  })
 })
 
 describe('mergeGraphs', () => {

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
@@ -23,6 +23,9 @@
  *                                        membership when present)
  *     - Ingress → Service `flows-to`    via spec.rules[].http.paths[]
  *                                       .backend.service.name
+ *     - HTTPRoute → Gateway `flows-to`  via spec.parentRefs (#3987)
+ *     - HTTPRoute → Service `routes-to` via spec.rules[].backendRefs
+ *     - Gateway / NetworkPolicy → Namespace `member-of`
  *     - Pod → PVC         `attached-to` via spec.volumes[]
  *                                       .persistentVolumeClaim.claimName
  *     - PVC → Volume(.hcloud) `realizes` via PV csi.volumeAttributes
@@ -428,6 +431,120 @@ export function k8sToGraph(snapshot: K8sSnapshot): AdaptResult {
     }
   }
 
+  // 6b. Gateway-API Gateways (#3987 UAT row 200). The SSE snapshot
+  //     carries `gateway:` keys (CLOUD_PAGE_K8S_KINDS ∪ GRAPH_K8S_KINDS)
+  //     but no adapter section consumed them, so the Networking lens
+  //     chips read 0/0 while the cluster served real Gateways / routes.
+  //     Status from the Gateway's Programmed (fallback Accepted)
+  //     condition.
+  for (const [, gw] of iterByKind(snapshot, 'gateway')) {
+    const ns = gw.metadata?.namespace ?? ''
+    const name = gw.metadata?.name ?? ''
+    if (!ns || !name) continue
+    const id = compositeId('Gateway', ns, name)
+    addNode({
+      id,
+      type: 'Gateway',
+      label: name,
+      sublabel: ns,
+      status: gatewayStatus(gw),
+      metadata: {
+        namespace: ns,
+        gatewayClassName: (gw.spec?.['gatewayClassName'] as string | undefined) ?? '',
+      },
+    })
+    addEdge({
+      id: `e:${id}->Namespace:${ns}`,
+      source: id,
+      target: compositeId('Namespace', '', ns),
+      type: 'member-of',
+    })
+  }
+
+  // 6c. HTTPRoutes — status from status.parents[].conditions Accepted.
+  //     Edges: HTTPRoute → Gateway `flows-to` via spec.parentRefs
+  //     (parent namespace defaults to the route's own), and
+  //     HTTPRoute → Service `routes-to` via spec.rules[].backendRefs
+  //     (kind omitted = Service per the Gateway-API default).
+  for (const [, route] of iterByKind(snapshot, 'httproute')) {
+    const ns = route.metadata?.namespace ?? ''
+    const name = route.metadata?.name ?? ''
+    if (!ns || !name) continue
+    const id = compositeId('HTTPRoute', ns, name)
+    addNode({
+      id,
+      type: 'HTTPRoute',
+      label: name,
+      sublabel: ns,
+      status: httpRouteStatus(route),
+      metadata: {
+        namespace: ns,
+        hostnames: ((route.spec?.['hostnames'] as string[] | undefined) ?? []).join(', '),
+      },
+    })
+    addEdge({
+      id: `e:${id}->Namespace:${ns}`,
+      source: id,
+      target: compositeId('Namespace', '', ns),
+      type: 'member-of',
+    })
+    const parentRefs = (route.spec?.['parentRefs'] as Array<Record<string, unknown>> | undefined) ?? []
+    for (const p of parentRefs) {
+      const kind = (p['kind'] as string | undefined) ?? 'Gateway'
+      if (kind !== 'Gateway') continue
+      const pName = (p['name'] as string | undefined) ?? ''
+      if (!pName) continue
+      const pNs = (p['namespace'] as string | undefined) ?? ns
+      addEdge({
+        id: `e:${id}->Gateway:${pNs}/${pName}`,
+        source: id,
+        target: compositeId('Gateway', pNs, pName),
+        type: 'flows-to',
+      })
+    }
+    const routeRules = (route.spec?.['rules'] as Array<Record<string, unknown>> | undefined) ?? []
+    for (const rule of routeRules) {
+      const backends = (rule['backendRefs'] as Array<Record<string, unknown>> | undefined) ?? []
+      for (const b of backends) {
+        const kind = (b['kind'] as string | undefined) ?? 'Service'
+        if (kind !== 'Service') continue
+        const bName = (b['name'] as string | undefined) ?? ''
+        if (!bName) continue
+        const bNs = (b['namespace'] as string | undefined) ?? ns
+        addEdge({
+          id: `e:${id}->Service:${bNs}/${bName}`,
+          source: id,
+          target: compositeId('Service', bNs, bName),
+          type: 'routes-to',
+        })
+      }
+    }
+  }
+
+  // 6d. NetworkPolicies (networking.k8s.io) — no status subresource on
+  //     the API; an existing policy is an enforced policy, so presence
+  //     renders healthy. Edge: → Namespace.
+  for (const [, np] of iterByKind(snapshot, 'networkpolicy')) {
+    const ns = np.metadata?.namespace ?? ''
+    const name = np.metadata?.name ?? ''
+    if (!ns || !name) continue
+    const id = compositeId('NetworkPolicy', ns, name)
+    addNode({
+      id,
+      type: 'NetworkPolicy',
+      label: name,
+      sublabel: ns,
+      status: 'healthy',
+      metadata: { namespace: ns },
+    })
+    addEdge({
+      id: `e:${id}->Namespace:${ns}`,
+      source: id,
+      target: compositeId('Namespace', '', ns),
+      type: 'member-of',
+    })
+  }
+
   // 7. PVCs.
   for (const [, pvc] of iterByKind(snapshot, 'persistentvolumeclaim')) {
     const ns = pvc.metadata?.namespace ?? ''
@@ -499,6 +616,39 @@ function nodeStatus(o: K8sObject): ArchStatus {
     }
   }
   return 'unknown'
+}
+
+/**
+ * Gateway readiness — the Gateway-API status carries `Programmed`
+ * (the implementation wired dataplane config) with `Accepted` as the
+ * weaker fallback on older conditions sets.
+ */
+function gatewayStatus(o: K8sObject): ArchStatus {
+  const conds = (o.status?.['conditions'] as Array<{ type?: string; status?: string }> | undefined) ?? []
+  for (const want of ['Programmed', 'Accepted']) {
+    const c = conds.find((x) => x.type === want)
+    if (c) return c.status === 'True' ? 'healthy' : 'degraded'
+  }
+  return 'unknown'
+}
+
+/**
+ * HTTPRoute readiness — per-parent `Accepted` conditions under
+ * status.parents[]. Any accepted parent = the route is serving.
+ */
+function httpRouteStatus(o: K8sObject): ArchStatus {
+  const parents = (o.status?.['parents'] as Array<Record<string, unknown>> | undefined) ?? []
+  if (parents.length === 0) return 'unknown'
+  let sawAcceptedCondition = false
+  for (const p of parents) {
+    const conds = (p['conditions'] as Array<{ type?: string; status?: string }> | undefined) ?? []
+    const accepted = conds.find((c) => c.type === 'Accepted')
+    if (accepted) {
+      sawAcceptedCondition = true
+      if (accepted.status === 'True') return 'healthy'
+    }
+  }
+  return sawAcceptedCondition ? 'degraded' : 'unknown'
 }
 
 function kindToArchType(kind: 'deployment' | 'statefulset' | 'daemonset'): ArchNodeType {

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.ts
@@ -55,6 +55,15 @@ export const GRAPH_K8S_KINDS = [
   'persistentvolumeclaim',
   'configmap',
   'endpointslice',
+  // Gateway-API + NetworkPolicy (#3987 UAT row 200) — the graph draws
+  // Gateway / HTTPRoute / NetworkPolicy nodes (Networking lens), so the
+  // widget's self-sufficient fallback stream must watch them too. The
+  // CloudPage's shared subscription already covers them via
+  // CLOUD_PAGE_K8S_KINDS; without these the standalone graph rendered
+  // the Networking chips as 0/0 against a cluster full of routes.
+  'gateway',
+  'httproute',
+  'networkpolicy',
   // Crossplane bridge — the cloud-side counterpart to PV via volume.hcloud
   'server.hcloud',
   'volume.hcloud',


### PR DESCRIPTION
## Symptom (wave-2 walker, UAT row 200, hw255)
Cloud → Networking lens chips read **HTTPRoute 0/0, Gateway 0/0, NetworkPolicy 0/0** while the live cluster serves real objects. Other lenses render (Reconciliation: 89 nodes) — the gap is kind-selective.

## Root cause — FE adapter, not RBAC / registry / API
The backend is fully functional. Live hw255 evidence (authed console API, read-only GETs):

- `GET /api/v1/sovereigns/self/k8s/httproute` → **32 items**
- `GET /api/v1/sovereigns/self/k8s/gateway` → **3 items**
- `GET /api/v1/sovereigns/self/k8s/networkpolicy` → **51 items**
- `GET .../k8s/stream?kinds=httproute,gateway,networkpolicy&initialState=1` → `ready` frame + `ADDED` Gateway/HTTPRoute events streaming

The k8scache registry (`api/internal/k8scache/kinds.go:296-312`) registers all the GVRs and the cutover-driver ClusterRole carries the read verbs (`clusterrole-cutover-driver.yaml:184-188, 491-513`). The CloudPage SSE subscription covers the kinds via `CLOUD_PAGE_K8S_KINDS` (#3997/#3998), so the browser snapshot holds `gateway:`/`httproute:`/`networkpolicy:` keys.

The drop happens in **`k8sToGraph`** (`products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts`): it adapted only namespace/node/workloads/pod/service/ingress/PVC/configmap — no section consumed the three networking kinds, so `buildCloudGraph` never emitted a `Gateway`/`HTTPRoute`/`NetworkPolicy` node, and the graph chip strip's `typeTotals` (ArchitectureGraphPage.tsx:258) stayed 0 → every Networking-lens chip for those types rendered 0/0. (The list view's chips count from the snapshot directly, which is why #3987's earlier list fix looked complete while the graph lens stayed empty.)

## Fix
- `k8sAdapter.ts` — sections 6b/6c/6d:
  - **Gateway** node, status from the `Programmed` (fallback `Accepted`) condition; member-of Namespace edge.
  - **HTTPRoute** node, status from `status.parents[].Accepted`; `flows-to` parent Gateway via `spec.parentRefs` (ns defaults to the route's); `routes-to` backend Service via `spec.rules[].backendRefs` (kind omitted = Service).
  - **NetworkPolicy** node (no status subresource — presence renders healthy); member-of Namespace edge.
- `useK8sCacheStream.ts` — add the three kinds to `GRAPH_K8S_KINDS` so the widget's self-sufficient fallback stream watches them; the CloudPage shared subscription already did.
- `k8sAdapter.test.ts` — 4 new cases pin node shapes, both HTTPRoute edge sources, and the degraded no-accepted-parent path.

## Gates
- `vitest run` on the touched suites (k8sAdapter, cloudGraphData, unifiedGraph, useCloudLens, useK8sCacheStream, cloud-list/kinds): **83/83 pass**
- `tsc -b --noEmit`: clean; `eslint` on touched files: clean
- Full UI suite: 68 failures in 9 suites — **all pre-existing on main** (re-ran the same suites with the change stashed: same failures; none touch architecture-graph/cloud-list)
- `scripts/check-no-nodeports.sh`: exit 0
- No chart change (UI-only) — no lockstep surfaces touched

Refs #3987 #3998