### PR TITLE
fix(catalyst-api): catalog card-save commit leg — canonical Blueprint CR serializer + honest verdict (#5113 facets A-D)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/blueprints.go
+++ b/products/catalyst/bootstrap/api/internal/handler/blueprints.go
@@ -395,8 +395,9 @@ func (h *Handler) HandleBlueprintCurate(w http.ResponseWriter, r *http.Request) 
 
 	// #3668 — ALSO mirror the curated CR into the Flux-reconciled aggregator
 	// tree so curate (not just the console edit) reaches the LIVE in-cluster
-	// Blueprint CR and survives `helm upgrade`. Ownership-strip first so the
-	// committed source is helm-upgrade-immune (DoD §9.4). Best-effort: a
+	// Blueprint CR and survives `helm upgrade`. The bytes go through the
+	// canonical commit serializer (server-side metadata stripped, canonical
+	// bp- name stamped, spec.version kept — #5113). Best-effort: a
 	// failure is logged + swallowed — the per-Blueprint write above already
 	// succeeded for the read overlay.
 	if _, aggErr := h.writeCatalogSovereignAggregator(

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
@@ -106,12 +106,13 @@ func catalogSovereignAggPath(sovereignFQDN, bpName string) string {
 	return fmt.Sprintf("clusters/%s/catalog-sovereign/%s.yaml", sovereignFQDN, bpName)
 }
 
-// writeCatalogSovereignAggregator mirrors one Blueprint's full, ownership-
-// stripped CR bytes into the Flux-reconciled aggregator tree (#3668). It is
+// writeCatalogSovereignAggregator mirrors one Blueprint's full, canonical
+// CR bytes into the Flux-reconciled aggregator tree (#3668). It is
 // best-effort + additive, exactly like the per-Blueprint write: a failure is
-// returned for the caller to log + swallow (the UI round-trip already
+// returned for the caller to log or surface (the UI round-trip already
 // succeeded via the per-Blueprint repo; the aggregator is what makes the CR
-// reconcile, but its absence must never fail the edit/curate API call).
+// reconcile — the card-edit path now SURFACES a failure of this leg per
+// #5113 Facet D, mirroring the #5018 honesty fix on the full-CR leg).
 //
 // No-ops (returns committed=false, err=nil) when:
 //   - the Gitea client is unwired (chroot pre-cutover / CI), OR
@@ -124,23 +125,34 @@ func catalogSovereignAggPath(sovereignFQDN, bpName string) string {
 // (openova/openova) is auto-init'd by the Organization repo-bootstrap hook, so the
 // branch always has a base commit to write onto.
 func (h *Handler) writeCatalogSovereignAggregator(ctx context.Context, bpName string, merged []byte) (bool, error) {
-	if len(merged) == 0 {
+	// Same no-op contract as the Bytes trunk, checked BEFORE the canonical
+	// render so an unwired client / mothership never turns into an error.
+	if len(merged) == 0 || h.giteaClient == nil ||
+		strings.TrimSpace(envOr("SOVEREIGN_FQDN", "")) == "" {
 		return false, nil
 	}
-	// #4415 — the Flux aggregator file SSA-applies (force:true) to the LIVE
-	// Blueprint CR, so any field it carries becomes Flux-owned. Strip the
-	// chart-delivery fields spec.version + spec.source so they stay
-	// exclusively catalog-seed (Helm)-owned: a merged catalog-seed version
-	// bump then reaches the live CR zero-touch on the next `helm upgrade`,
-	// instead of being pinned forever at the value frozen when the operator
-	// last edited the card. The operator's curated card / visibility /
-	// topology stay in the file and remain Flux-owned + revert-immune.
+	// #5113 Facets A+B — the payload goes through the SAME canonical
+	// serializer as the full-CR IaC leg (stampBlueprintCRForFluxAggregator):
+	// metadata.name stamped to the canonical bp-<slug> live-CR identity and
+	// spec.version/spec.source KEPT.
 	//
-	// NOTE the #4415 strip applies to the IMPLICIT card-edit path only. The
-	// full-CR IaC editor (catalog_iac_edit.go) calls the Bytes variant below
-	// directly with the admin's verbatim document, because an EXPLICIT
-	// whole-CR commit legitimately edits spec.version (DoD §9.7; UAT row 154).
-	return h.writeCatalogSovereignAggregatorBytes(ctx, bpName, stripDeliveryFieldsForFluxAggregator(merged))
+	// This supersedes the former #4415 delivery-field strip: spec.version is
+	// CRD-required (chart/crds/blueprint.yaml `required: [version, card]`),
+	// so a version-less aggregator file is REJECTED by kustomize-controller's
+	// server-side dry-run whenever the named CR does not already exist (bare-
+	// name mismatch, post-prune, curate of a non-seed blueprint) — wedging the
+	// ENTIRE catalog-sovereign Kustomization (hw255 walk, gitea commits
+	// d030078f/552a556c: `Blueprint "alloy" is invalid: spec.version: Required
+	// value`). The #4415 zero-touch seed-bump property is traded away: a
+	// catalog-seed version bump on a card-edited blueprint is now pinned until
+	// the next card edit refreshes the file (noted on #5113).
+	stamped := stampBlueprintCRForFluxAggregator(merged, bpName)
+	if len(stamped) == 0 {
+		// An unparsable document must never land in the Flux tree — that is
+		// the same Kustomization-wide wedge class. Surface it instead.
+		return false, fmt.Errorf("render Flux aggregator payload for %s: document did not parse", bpName)
+	}
+	return h.writeCatalogSovereignAggregatorBytes(ctx, bpName, stamped)
 }
 
 // writeCatalogSovereignAggregatorBytes commits the SUPPLIED final bytes to the
@@ -170,42 +182,6 @@ func (h *Handler) writeCatalogSovereignAggregatorBytes(ctx context.Context, bpNa
 			catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch, path, err)
 	}
 	return committed, nil
-}
-
-// stripDeliveryFieldsForFluxAggregator removes the chart-delivery fields
-// (spec.version + spec.source) from a Blueprint CR's YAML bytes before they
-// are committed to the Flux-reconciled catalog-sovereign aggregator tree
-// (#4415). Those fields are owned exclusively by catalog-seed (Helm) so a
-// seed version bump reaches the live CR with no human kubectl patch; the
-// Flux Kustomization applies this file with force:true SSA, which would
-// otherwise steal version/source ownership and pin them at the operator's
-// last-edit value, fighting every catalog-seed bump in a per-reconcile
-// ping-pong.
-//
-// The resulting partial CR is only ever consumed by kustomize-controller
-// SSA against the same-named CR catalog-seed already seeded WITH a version,
-// so the merged in-cluster object still satisfies the CRD's required
-// spec.version — SSA owns only the fields the applied config carries.
-//
-// Best-effort: on any decode/encode failure the input bytes are returned
-// unchanged so the reconcile (which already round-trips the per-Blueprint
-// UI read source) is never blocked by a strip.
-func stripDeliveryFieldsForFluxAggregator(merged []byte) []byte {
-	var doc map[string]interface{}
-	if err := yamlv3.Unmarshal(merged, &doc); err != nil || doc == nil {
-		return merged
-	}
-	spec, ok := doc["spec"].(map[string]interface{})
-	if !ok {
-		return merged
-	}
-	delete(spec, "version")
-	delete(spec, "source")
-	out, err := yamlv3.Marshal(doc)
-	if err != nil || len(out) == 0 {
-		return merged
-	}
-	return out
 }
 
 // catalogEditCommitAuthor / Email stamp the commit so a sovereign-admin
@@ -309,22 +285,41 @@ func (h *Handler) writeCatalogEditToGit(ctx context.Context, edit catalogEdit) (
 		return false, fmt.Errorf("merge blueprint.yaml: %w", err)
 	}
 
+	// #5113 Facets B+C — canonicalize BEFORE committing, through the SAME
+	// serializer the full-CR IaC leg (#5041) uses: metadata.name stamped to
+	// the canonical bp-<slug> live-CR identity (a bare `name: wordpress` from
+	// a bare-named seed / legacy file made Flux swap its inventory entry and
+	// PRUNE the live bp-wordpress CR on hw255), and cluster-populated
+	// metadata scrubbed (uid/resourceVersion/… leaked via legacy Gitea files
+	// survived the read-modify-write and produced the stale-uid Conflict
+	// wedge, gitea commit 7516c865). Both the per-Blueprint read source and
+	// the Flux aggregator get the SAME canonical bytes.
+	canonical := stampBlueprintCRForFluxAggregator(merged, bpName)
+	if len(canonical) == 0 {
+		// Unreachable in practice — merged was just produced by yaml.Marshal —
+		// but never commit a document the canonical serializer cannot parse.
+		return false, fmt.Errorf("canonicalize blueprint.yaml for %s: document did not re-parse", bpName)
+	}
+
 	msg := fmt.Sprintf("catalog: edit %s card via catalyst-api (#3648)", bpName)
 	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignOrg, bpName,
-		catalogEditGitBranch, catalogEditBlueprintPath, merged, msg, catalogEditCommitAuthor())
+		catalogEditGitBranch, catalogEditBlueprintPath, canonical, msg, catalogEditCommitAuthor())
 	if err != nil {
 		return false, fmt.Errorf("put %s/%s/%s: %w", catalogSovereignOrg, bpName, catalogEditBlueprintPath, err)
 	}
 
-	// #3668 — ALSO mirror the SAME merged CR bytes into the Flux-reconciled
-	// aggregator tree so the edit reaches the LIVE in-cluster Blueprint CR
-	// (the per-Blueprint write above is only the UI read source). Best-
-	// effort + additive: an aggregator failure is logged + swallowed so the
-	// edit API call still reports the per-Blueprint commit result (the
-	// reconcile catches up on the next successful write / out-of-band push).
-	if _, aggErr := h.writeCatalogSovereignAggregator(ctx, bpName, merged); aggErr != nil {
-		h.log.Warn("catalog-edit-git: aggregator mirror failed (Blueprint CR will not reconcile until next write)",
-			"blueprint", bpName, "err", aggErr)
+	// #3668 — ALSO mirror the SAME canonical CR bytes into the Flux-
+	// reconciled aggregator tree so the edit reaches the LIVE in-cluster
+	// Blueprint CR (the per-Blueprint write above is only the UI read
+	// source). #5113 Facet D — a failure of this leg is SURFACED, not
+	// swallowed: the aggregator is what actually applies, so reporting
+	// committed=true while it failed is the silent store/IaC split-brain the
+	// hw255 walk caught (same class the #5018 fix closed on the full-CR leg).
+	// The genuine no-op cases (unwired client / mothership) still return
+	// (false, nil) and do not fail the edit.
+	if _, aggErr := h.writeCatalogSovereignAggregatorBytes(ctx, bpName, canonical); aggErr != nil {
+		return false, fmt.Errorf("IaC source committed to %s/%s but the Flux reconcile leg failed (the edit will not reach the live Blueprint CR): %w",
+			catalogSovereignOrg, bpName, aggErr)
 	}
 
 	return committed, nil
@@ -390,13 +385,13 @@ const catalogEditBlueprintPath = "blueprint.yaml"
 // edit from a lossy stub to a full CR when the source is available, and never
 // fails the edit when it isn't.
 //
-// Server-managed + ownership metadata is stripped so the committed file is a
-// clean, hand-authorable source of truth that a later `helm upgrade` will not
-// fight over: status, resourceVersion, uid, generation, creationTimestamp,
-// managedFields, and the Helm/Flux ownership labels+annotations
-// (`app.kubernetes.io/managed-by: Helm`, `helm.toolkit.fluxcd.io/*`, the
-// release-tracking annotations) — leaving apiVersion/kind/metadata.name + the
-// full spec that the Blueprint projector and validateBlueprintYAML accept.
+// Server-side metadata is stripped so the committed file is a clean,
+// hand-authorable source of truth: status, resourceVersion, uid, generation,
+// creationTimestamp, managedFields, last-applied — while the Helm ownership
+// labels+annotations are PRESERVED (#5113 Facet E; see
+// stripBlueprintCRMapForGit) — leaving apiVersion/kind/metadata (name,
+// labels, annotations) + the full spec that the Blueprint projector and
+// validateBlueprintYAML accept.
 func (h *Handler) seedBlueprintYAMLFromLiveCR(ctx context.Context, bpName string) []byte {
 	if h.catalogClient == nil {
 		return nil
@@ -408,16 +403,37 @@ func (h *Handler) seedBlueprintYAMLFromLiveCR(ctx context.Context, bpName string
 	return stripBlueprintCRMapForGit(deepCopyYAMLMap(bp.Raw), bpName)
 }
 
-// stripBlueprintCRMapForGit renders a decoded Blueprint CR map as the
-// ownership-clean YAML source committed to Gitea (the catalog-sovereign
-// per-Blueprint repo AND the Flux aggregator tree). It keeps apiVersion/
-// kind/metadata.name + the full spec, and DROPS every server-managed +
-// ownership field (status + all metadata except name — resourceVersion,
-// uid, generation, creationTimestamp, managedFields, and the Helm/Flux
-// ownership labels+annotations `app.kubernetes.io/managed-by: Helm`,
-// `helm.toolkit.fluxcd.io/*`) so a later `helm upgrade` cannot claim the
-// committed file and the Flux Kustomization can SSA-adopt the live CR
-// (DoD §9.4). Returns nil on a nil/un-marshalable map.
+// blueprintCRServerSideMetadataFields are the cluster-populated metadata
+// fields that must NEVER land in a committed Blueprint source file: they are
+// minted by the API server per live object, so pinning them in git either
+// wedges the next apply (a pruned-then-recreated CR makes the pinned uid a
+// `dry-run failed (Conflict): uid mismatch` — hw255 walk, #5113 Facet C) or
+// is plain noise (managedFields / generation / creationTimestamp / …).
+var blueprintCRServerSideMetadataFields = []string{
+	"uid", "resourceVersion", "generation", "creationTimestamp",
+	"managedFields", "selfLink", "finalizers", "ownerReferences",
+	// Blueprint is a CLUSTER-scoped CRD (chart/crds/blueprint.yaml
+	// scope: Cluster) — a namespace on the committed file is invalid.
+	"namespace",
+}
+
+// stripBlueprintCRMapForGit renders a decoded Blueprint CR map as the clean
+// YAML source committed to Gitea (the catalog-sovereign per-Blueprint repo
+// AND the Flux aggregator tree). It keeps apiVersion/kind + the full spec +
+// the user/ownership metadata (name, labels, annotations), and DROPS ONLY
+// the server-side fields: status, plus the cluster-populated metadata listed
+// in blueprintCRServerSideMetadataFields and the apply-bookkeeping
+// `kubectl.kubernetes.io/last-applied-configuration` annotation.
+//
+// #5113 Facet E (supersedes the former strip-all-metadata behavior): the
+// Helm ownership labels+annotations (`app.kubernetes.io/managed-by: Helm`,
+// `meta.helm.sh/*`) and the catalog-seed/alias labels are PRESERVED. When
+// Flux prunes-and-recreates a CR from a file that lost them, the recreated
+// CR carries no Helm ownership and the next `helm upgrade` of catalyst-
+// platform hits an ownership conflict with NO console repair path (hw255
+// repair needed direct gitea commits 956574c1/ba06d510). With them in the
+// file, a Flux-materialized CR stays helm-adoptable. Returns nil on a
+// nil/un-marshalable map.
 func stripBlueprintCRMapForGit(doc map[string]interface{}, bpName string) []byte {
 	if doc == nil {
 		return nil
@@ -428,16 +444,27 @@ func stripBlueprintCRMapForGit(doc map[string]interface{}, bpName string) []byte
 	setIfAbsent(doc, "apiVersion", "catalyst.openova.io/v1")
 	setIfAbsent(doc, "kind", "Blueprint")
 
-	// metadata: keep only name; drop server-managed + ownership fields.
-	if meta, ok := doc["metadata"].(map[string]interface{}); ok {
-		name := asString(meta["name"])
-		if strings.TrimSpace(name) == "" {
-			name = bpName
-		}
-		doc["metadata"] = map[string]interface{}{"name": name}
-	} else {
-		doc["metadata"] = map[string]interface{}{"name": bpName}
+	// metadata: keep name + labels + annotations; drop server-side fields.
+	meta, ok := doc["metadata"].(map[string]interface{})
+	if !ok {
+		meta = map[string]interface{}{}
 	}
+	if strings.TrimSpace(asString(meta["name"])) == "" {
+		meta["name"] = bpName
+	}
+	for _, k := range blueprintCRServerSideMetadataFields {
+		delete(meta, k)
+	}
+	if ann, ok := meta["annotations"].(map[string]interface{}); ok {
+		delete(ann, "kubectl.kubernetes.io/last-applied-configuration")
+		if len(ann) == 0 {
+			delete(meta, "annotations")
+		}
+	}
+	if lbl, ok := meta["labels"].(map[string]interface{}); ok && len(lbl) == 0 {
+		delete(meta, "labels")
+	}
+	doc["metadata"] = meta
 
 	// status is server-derived — never part of the source file.
 	delete(doc, "status")

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
@@ -497,11 +497,12 @@ func TestCommitCatalogAppEditToGit_ByteIdenticalIsDurable(t *testing.T) {
 // ALSO writes the merged CR into the Flux-reconciled aggregator tree
 // `openova/openova @ catalog-sovereign : clusters/<fqdn>/catalog-
 // sovereign/<bp>.yaml`, so the openova-catalog-sovereign Kustomization can
-// reconcile it into the LIVE in-cluster Blueprint CR. The per-Blueprint repo
-// write (the UI read source) carries the FULL merged CR; the Flux write
-// carries the same CURATION fields but — per #4415 — DROPS the chart-delivery
-// fields spec.version / spec.source so a catalog-seed version bump is never
-// pinned-over by Flux's force:true SSA.
+// reconcile it into the LIVE in-cluster Blueprint CR. Per #5113 Facet A the
+// Flux write carries the FULL canonical CR INCLUDING the CRD-required
+// spec.version — the former #4415 delivery-field strip made the file
+// rejected by kustomize-controller's dry-run whenever the named CR did not
+// already exist (`spec.version: Required value`), wedging the whole
+// catalog-sovereign Kustomization (hw255 walk).
 func TestWriteCatalogEditToGit_MirrorsToFluxAggregator(t *testing.T) {
 	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
 	h := NewWithPDM(silentLogger(), &fakePDM{})
@@ -556,19 +557,22 @@ func TestWriteCatalogEditToGit_MirrorsToFluxAggregator(t *testing.T) {
 	if aggSpec == nil {
 		t.Fatalf("aggregator CR has no spec; doc=%v", aggDoc)
 	}
-	// #4415 — the Flux file must NOT carry the chart-delivery fields, so
-	// catalog-seed (Helm) stays the sole owner of spec.version + spec.source
-	// and a merged seed bump reaches the live CR zero-touch.
-	if _, leaked := aggSpec["version"]; leaked {
-		t.Errorf("aggregator (Flux SSA) CR must NOT carry spec.version (#4415); spec=%v", aggSpec)
+	// #5113 Facet A — the Flux file MUST carry the CRD-required spec.version
+	// (chart/crds/blueprint.yaml `required: [version, card]`): a version-less
+	// file is rejected by the kustomize-controller dry-run whenever the named
+	// CR does not already exist, wedging the whole Kustomization.
+	if asString(aggSpec["version"]) != "1.2.3" {
+		t.Errorf("aggregator (Flux SSA) CR must carry the real spec.version (#5113 Facet A); got %v", aggSpec["version"])
 	}
-	if _, leaked := aggSpec["source"]; leaked {
-		t.Errorf("aggregator (Flux SSA) CR must NOT carry spec.source (#4415); spec=%v", aggSpec)
+	// #5113 Facet B — the aggregator CR is stamped to the canonical live-CR
+	// identity, never a bare name whose inventory swap prunes the live CR.
+	aggMeta, _ := aggDoc["metadata"].(map[string]interface{})
+	if aggMeta == nil || aggMeta["name"] != "bp-wordpress" {
+		t.Errorf("aggregator CR name must be the canonical bp-wordpress (#5113 Facet B); meta=%v", aggMeta)
 	}
-	// The curation fields the operator legitimately owns DO survive into the
-	// Flux file (it is the field set Flux owns + must keep revert-immune).
+	// Every other spec field survives too.
 	if _, ok := aggSpec["manifests"].(map[string]interface{}); !ok {
-		t.Errorf("aggregator CR must keep non-delivery spec fields (e.g. manifests); spec=%v", aggSpec)
+		t.Errorf("aggregator CR must keep the full spec (e.g. manifests); spec=%v", aggSpec)
 	}
 	if !strings.Contains(string(aggRaw), "RECONCILE-PROOF") {
 		t.Errorf("aggregator CR must carry the edited summary; got:\n%s", aggRaw)
@@ -622,79 +626,255 @@ func TestWriteCatalogSovereignAggregator_BestEffortGuards(t *testing.T) {
 		t.Errorf("no-FQDN must write nothing; keys=%v", fileKeys(fg))
 	}
 
-	// Wired + FQDN + erroring PutFile → err returned (caller logs+swallows).
+	// Wired + FQDN + erroring PutFile → err returned (caller logs/surfaces).
 	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
 	fgErr := newFakeGitea()
 	fgErr.putFileErr = errors.New("gitea: 500")
 	h.SetGiteaClient(fgErr)
-	if _, err := h.writeCatalogSovereignAggregator(context.Background(), "bp-alloy", []byte("x")); err == nil {
+	validCR := []byte("apiVersion: catalyst.openova.io/v1\nkind: Blueprint\nmetadata:\n  name: bp-alloy\nspec:\n  version: \"1.0.0\"\n")
+	if _, err := h.writeCatalogSovereignAggregator(context.Background(), "bp-alloy", validCR); err == nil {
 		t.Errorf("erroring PutFile must return a non-nil err for the caller to log")
+	}
+
+	// Wired + FQDN + UNPARSABLE payload → err surfaced, nothing committed —
+	// an unparsable file in the Flux tree is the Kustomization-wide wedge
+	// class (#5113), never a best-effort write.
+	fgOK := newFakeGitea()
+	h.SetGiteaClient(fgOK)
+	if _, err := h.writeCatalogSovereignAggregator(context.Background(), "bp-alloy", []byte("\t::not yaml::\t")); err == nil {
+		t.Errorf("an unparsable aggregator payload must surface an error, not commit")
+	}
+	if len(fgOK.files) != 0 {
+		t.Errorf("an unparsable aggregator payload must not be committed; keys=%v", fileKeys(fgOK))
 	}
 }
 
-// TestStripDeliveryFieldsForFluxAggregator — #4415 unit. The Flux aggregator
-// file must drop the chart-delivery fields spec.version + spec.source (both
-// the top-level spec.source AND its nested source.version) so catalog-seed
-// (Helm) stays their sole owner and a seed version bump reaches the live CR
-// zero-touch. Every OTHER spec field (card, visibility, topology, manifests)
-// is preserved — those are the curation fields Flux legitimately owns.
-func TestStripDeliveryFieldsForFluxAggregator(t *testing.T) {
+// TestStampBlueprintCRForFluxAggregator_RoundTripsLiveCRFaithfully — #5113
+// Facets A+B+C+E unit on the canonical commit serializer, fed the exact
+// hw255 failure shape: a live CR dump with a BARE metadata.name, the full
+// server-side metadata (uid / resourceVersion / generation /
+// creationTimestamp / managedFields / status / last-applied), AND the Helm
+// ownership + catalog-seed labels/annotations. The committed YAML must:
+//   - stamp the canonical bp-<slug> name (Facet B — bare `name: wordpress`
+//     made Flux prune the live bp-wordpress CR);
+//   - keep spec.version + every spec field (Facet A — a version-less file is
+//     CRD-rejected on create, wedging the Kustomization);
+//   - drop ONLY the server-side fields (Facet C — a pinned uid produced the
+//     stale-uid Conflict wedge);
+//   - PRESERVE the Helm ownership labels/annotations (Facet E — without them
+//     a prune-recreated CR breaks the next `helm upgrade` with no console
+//     repair path).
+func TestStampBlueprintCRForFluxAggregator_RoundTripsLiveCRFaithfully(t *testing.T) {
 	in := []byte(`apiVersion: catalyst.openova.io/v1
 kind: Blueprint
 metadata:
-  name: bp-openclaw
+  name: wordpress
+  uid: 6d1f7f2e-dead-beef-a5b0-3c1de1a2b3c4
+  resourceVersion: "123456"
+  generation: 7
+  creationTimestamp: "2026-07-10T08:00:00Z"
+  managedFields:
+    - manager: helm
+      operation: Update
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    catalyst.openova.io/catalog-seed: "true"
+  annotations:
+    meta.helm.sh/release-name: catalyst-platform
+    meta.helm.sh/release-namespace: catalyst
+    catalyst.openova.io/alias-of: wordpress
+    kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"catalyst.openova.io/v1"}'
 spec:
-  version: "0.2.11"
+  version: "0.4.12"
   visibility: listed
+  card:
+    title: WordPress Turnkey
+    summary: curated summary
   source:
     kind: HelmRepository
     type: oci
     url: oci://ghcr.io/openova-io
-    chart: bp-openclaw
-    version: 0.2.11
+    chart: bp-wordpress
+    version: 0.4.12
   manifests:
-    chart: bp-openclaw
-  card:
-    title: OpenClaw
-    summary: edited-by-operator
+    chart: bp-wordpress
+status:
+  observedGeneration: 7
 `)
-	out := stripDeliveryFieldsForFluxAggregator(in)
+	out := stampBlueprintCRForFluxAggregator(in, "bp-wordpress")
+	if len(out) == 0 {
+		t.Fatal("canonical serializer returned empty output for a valid CR")
+	}
 	var doc map[string]interface{}
 	if err := yamlv3.Unmarshal(out, &doc); err != nil {
-		t.Fatalf("unmarshal stripped: %v", err)
+		t.Fatalf("unmarshal canonical CR: %v", err)
 	}
+
+	// Facet B — canonical name.
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "bp-wordpress" {
+		t.Errorf("metadata.name must be stamped to bp-wordpress; meta=%v", meta)
+	}
+
+	// Facet C — server-side fields gone.
+	for _, k := range []string{"uid", "resourceVersion", "generation", "creationTimestamp", "managedFields"} {
+		if _, leaked := meta[k]; leaked {
+			t.Errorf("metadata.%s must be stripped from the committed source; meta=%v", k, meta)
+		}
+	}
+	if _, leaked := doc["status"]; leaked {
+		t.Errorf("status must be stripped from the committed source")
+	}
+
+	// Facet E — Helm ownership + catalog labels/annotations preserved.
+	lbl, _ := meta["labels"].(map[string]interface{})
+	if lbl == nil || lbl["app.kubernetes.io/managed-by"] != "Helm" || lbl["catalyst.openova.io/catalog-seed"] != "true" {
+		t.Errorf("Helm/catalog-seed labels must be preserved; labels=%v", lbl)
+	}
+	ann, _ := meta["annotations"].(map[string]interface{})
+	if ann == nil || ann["meta.helm.sh/release-name"] != "catalyst-platform" ||
+		ann["meta.helm.sh/release-namespace"] != "catalyst" ||
+		ann["catalyst.openova.io/alias-of"] != "wordpress" {
+		t.Errorf("Helm ownership + alias-of annotations must be preserved; annotations=%v", ann)
+	}
+	if _, leaked := ann["kubectl.kubernetes.io/last-applied-configuration"]; leaked {
+		t.Errorf("last-applied-configuration is apply bookkeeping and must be stripped; annotations=%v", ann)
+	}
+
+	// Facet A — spec round-trips in full, version included.
 	spec, _ := doc["spec"].(map[string]interface{})
 	if spec == nil {
-		t.Fatalf("stripped CR lost its spec; doc=%v", doc)
+		t.Fatalf("canonical CR lost its spec; doc=%v", doc)
 	}
-	if _, leaked := spec["version"]; leaked {
-		t.Errorf("spec.version must be stripped; spec=%v", spec)
+	if asString(spec["version"]) != "0.4.12" {
+		t.Errorf("spec.version (CRD-required) must survive; got %v", spec["version"])
 	}
-	if _, leaked := spec["source"]; leaked {
-		t.Errorf("spec.source must be stripped (incl. nested source.version); spec=%v", spec)
-	}
-	// Curation fields survive.
-	if asString(spec["visibility"]) != "listed" {
-		t.Errorf("spec.visibility must survive; got %v", spec["visibility"])
+	if _, ok := spec["source"].(map[string]interface{}); !ok {
+		t.Errorf("spec.source must survive; spec=%v", spec)
 	}
 	if _, ok := spec["manifests"].(map[string]interface{}); !ok {
 		t.Errorf("spec.manifests must survive; spec=%v", spec)
 	}
 	card, _ := spec["card"].(map[string]interface{})
-	if card == nil || card["summary"] != "edited-by-operator" {
-		t.Errorf("spec.card edit must survive; card=%v", card)
-	}
-	// metadata.name survives so the Kustomization keys the right CR.
-	meta, _ := doc["metadata"].(map[string]interface{})
-	if meta == nil || meta["name"] != "bp-openclaw" {
-		t.Errorf("metadata.name must survive; meta=%v", meta)
+	if card == nil || card["summary"] != "curated summary" {
+		t.Errorf("spec.card must survive; card=%v", card)
 	}
 
-	// Best-effort: un-parseable input is returned unchanged so a strip never
-	// blocks the reconcile.
-	garbage := []byte("\t::not yaml::\t")
-	if got := stripDeliveryFieldsForFluxAggregator(garbage); string(got) != string(garbage) {
-		t.Errorf("un-parseable input must be returned unchanged; got %q", got)
+	// Un-parseable input renders nil — the callers surface that instead of
+	// committing a wedge-class file.
+	if got := stampBlueprintCRForFluxAggregator([]byte("\t::not yaml::\t"), "bp-x"); got != nil {
+		t.Errorf("un-parseable input must render nil; got %q", got)
+	}
+}
+
+// TestWriteCatalogEditToGit_CanonicalizesLegacyServerMetadata — #5113 Facets
+// B+C on the card-save leg end-to-end: when the EXISTING per-Blueprint Gitea
+// file carries the legacy hw255 shape (bare name + uid + resourceVersion +
+// Helm annotations, committed by an older build), the next card edit must
+// commit BOTH files (per-Blueprint + Flux aggregator) with the canonical
+// bp- name, the server junk scrubbed, spec.version intact, and the Helm
+// ownership annotations preserved.
+func TestWriteCatalogEditToGit_CanonicalizesLegacyServerMetadata(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	// Seed the legacy per-Blueprint file exactly as an older build left it.
+	legacy := []byte(`apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: wordpress
+  uid: 6d1f7f2e-dead-beef-a5b0-3c1de1a2b3c4
+  resourceVersion: "123456"
+  creationTimestamp: "2026-07-10T08:00:00Z"
+  annotations:
+    meta.helm.sh/release-name: catalyst-platform
+spec:
+  version: "0.4.12"
+  visibility: listed
+  card:
+    title: WordPress Turnkey
+    summary: curated summary
+`)
+	perBPKey := giteaKey(catalogSovereignOrg, "bp-wordpress", catalogEditGitBranch, catalogEditBlueprintPath)
+	fg.files[perBPKey] = legacy
+	fg.repos[catalogSovereignOrg+"/bp-wordpress"] = true
+	fg.orgs[catalogSovereignOrg] = true
+
+	edit := catalogEdit{Slug: "wordpress", IconLight: "new-icon.svg"}
+	if _, err := h.writeCatalogEditToGit(context.Background(), edit); err != nil {
+		t.Fatalf("writeCatalogEditToGit: %v", err)
+	}
+
+	aggKey := giteaKey(catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch,
+		catalogSovereignAggPath("t99.omani.works", "bp-wordpress"))
+	for _, tc := range []struct{ leg, key string }{
+		{"per-Blueprint", perBPKey},
+		{"Flux aggregator", aggKey},
+	} {
+		raw, ok := fg.files[tc.key]
+		if !ok {
+			t.Fatalf("%s write missing at %s; keys=%v", tc.leg, tc.key, fileKeys(fg))
+		}
+		var doc map[string]interface{}
+		if err := yamlv3.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("%s: unmarshal committed CR: %v", tc.leg, err)
+		}
+		meta, _ := doc["metadata"].(map[string]interface{})
+		if meta == nil || meta["name"] != "bp-wordpress" {
+			t.Errorf("%s: name must be canonical bp-wordpress (Facet B); meta=%v", tc.leg, meta)
+		}
+		for _, k := range []string{"uid", "resourceVersion", "creationTimestamp"} {
+			if _, leaked := meta[k]; leaked {
+				t.Errorf("%s: metadata.%s must be scrubbed (Facet C); meta=%v", tc.leg, k, meta)
+			}
+		}
+		ann, _ := meta["annotations"].(map[string]interface{})
+		if ann == nil || ann["meta.helm.sh/release-name"] != "catalyst-platform" {
+			t.Errorf("%s: Helm ownership annotation must be preserved (Facet E); annotations=%v", tc.leg, ann)
+		}
+		spec, _ := doc["spec"].(map[string]interface{})
+		if spec == nil || asString(spec["version"]) != "0.4.12" {
+			t.Errorf("%s: spec.version must survive (Facet A); spec=%v", tc.leg, spec)
+		}
+		card, _ := spec["card"].(map[string]interface{})
+		if card == nil || card["iconLight"] != "new-icon.svg" {
+			t.Errorf("%s: the card edit must land; card=%v", tc.leg, card)
+		}
+		if card["summary"] != "curated summary" {
+			t.Errorf("%s: the untouched curated summary must survive; card=%v", tc.leg, card)
+		}
+	}
+}
+
+// TestCommitCatalogAppEditToGit_AggregatorFailureSurfaced — #5113 Facet D on
+// the card-save leg: when the per-Blueprint source write lands but the Flux
+// aggregator leg (the write that actually reaches the live CR) fails, the
+// verdict must be committed=false with a reason — never the silent
+// store/IaC split-brain `committed:true` the hw255 walk caught. Mirrors the
+// #5018 honesty fix already shipped on the full-CR /iac leg.
+func TestCommitCatalogAppEditToGit_AggregatorFailureSurfaced(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	// Fail ONLY the aggregator write (openova/openova @ catalog-sovereign);
+	// the per-Blueprint source write succeeds.
+	fg.putFileErrFor = func(org, repo, branch, _ string) error {
+		if org == catalogSovereignAggOrg && repo == catalogSovereignAggRepo && branch == catalogSovereignAggBranch {
+			return errors.New("gitea: 500 on aggregator")
+		}
+		return nil
+	}
+	h.SetGiteaClient(fg)
+
+	body := []byte(`{"slug":"wordpress","name":"WordPress","tagline":"edited"}`)
+	committed, reason := h.commitCatalogAppEditToGit(context.Background(), body)
+	if committed {
+		t.Fatalf("a failed Flux reconcile leg must report committed=false (the edit never reaches the live CR)")
+	}
+	if !strings.Contains(reason, "Flux reconcile leg failed") {
+		t.Errorf("the reason must name the failed reconcile leg; got %q", reason)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
@@ -271,21 +271,28 @@ func (h *Handler) resolveCatalogEditRepo(ctx context.Context, bpName string) str
 	return bpName
 }
 
-// stampBlueprintCRForFluxAggregator renders the admin's full-CR document as
-// the Flux aggregator payload (#4896/#5018): metadata.name is FORCED to the
-// canonical live-CR identity (bp-<slug>) so the catalog-sovereign
-// Kustomization's force:true SSA patches the existing Blueprint CR instead of
-// creating a bare-named duplicate — the same identity bridge the dry-run/apply
-// path applies via reconcileBlueprintBareName (#4898). Server-managed +
-// ownership metadata and status are dropped (stripBlueprintCRMapForGit);
-// spec.version/spec.source are deliberately KEPT — the #4415 strip covers the
-// implicit card-edit only, while an explicit whole-CR commit owns its
-// delivery fields (DoD §9.7; UAT row 154's version round-trip).
+// stampBlueprintCRForFluxAggregator is the CANONICAL Blueprint-CR commit
+// serializer, shared by ALL THREE catalog commit legs — the full-CR IaC
+// editor (this file), the card-form save (writeCatalogEditToGit), and the
+// curate mirror (writeCatalogSovereignAggregator) — per #5113's "card-save
+// must reuse the SAME canonical serializer as the Edit-IaC leg (#5041)".
 //
-// Returns nil on an unparsable document — unreachable in practice because the
-// caller validated the same bytes (validateCatalogBlueprintYAML); the
-// aggregator writer treats empty bytes as a no-op, and the caller surfaces
-// that as a skipped reconcile leg rather than committing a wrong-named CR.
+// It renders a Blueprint document as the committed payload (#4896/#5018):
+// metadata.name is FORCED to the canonical live-CR identity (bp-<slug>) so
+// the catalog-sovereign Kustomization's force:true SSA patches the existing
+// Blueprint CR instead of creating a bare-named duplicate whose inventory
+// swap PRUNES the live CR (#5113 Facet B — the hw255 bp-wordpress deletion);
+// the same identity bridge the dry-run/apply path applies via
+// reconcileBlueprintBareName (#4898). Server-side metadata and status are
+// dropped while Helm ownership labels/annotations are preserved
+// (stripBlueprintCRMapForGit); spec.version/spec.source are KEPT —
+// spec.version is CRD-required, so a version-less file wedges the whole
+// Kustomization whenever the CR doesn't already exist (#5113 Facet A), and
+// an explicit whole-CR commit owns its delivery fields anyway (DoD §9.7;
+// UAT row 154's version round-trip).
+//
+// Returns nil on an unparsable document — the callers surface that as a
+// failed render rather than committing a wrong-named/unparsable CR.
 func stampBlueprintCRForFluxAggregator(raw []byte, bpName string) []byte {
 	var doc map[string]interface{}
 	if err := yamlv3.Unmarshal(raw, &doc); err != nil || doc == nil {

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
@@ -248,7 +248,12 @@ export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride, on
           managed-by: <span className={flux ? 'text-emerald-300' : 'text-amber-300'}>{flux ? 'flux' : 'manual'}</span>
         </span>
         <span className="text-[var(--color-text-dim)]">
-          {dirty ? '• unsaved changes' : '• in sync'}
+          {/* #5113 Facet D — this is a LOCAL dirty-state indicator only. It
+              formerly read "• in sync", fabricating reconcile state: on hw255
+              it showed "in sync" while the catalog-sovereign Kustomization
+              was Ready=False on this exact file. Do not claim sync here
+              unless it is read from the Kustomization/apply status. */}
+          {dirty ? '• unsaved changes' : '• no unsaved edits'}
         </span>
         <button
           type="button"


### PR DESCRIPTION
## Problem

The hw255 catalog-edit mutation walk (2026-07-15, post-cutover dep 5762118f63abef96) proved the operator-console catalog **card-form Save's IaC commit leg** writes invalid/destructive Blueprint YAML — an innocuous icon/summary edit **DELETED the live bp-wordpress Blueprint CR** via Flux prune and wedged the catalog-sovereign Kustomization 3× (evidence: docs/sessions/2026-07-15/hw255-catalog-edit/ + gitea commits d030078f..ba06d510, all on #5113).

## Fix — all at the serializer seam (`products/catalyst/bootstrap/api/internal/handler/`)

**Facet A — spec.version dropped → Kustomization wedge.** The card/curate aggregator writes no longer apply the #4415 delivery-field strip. `spec.version` is CRD-required (`chart/crds/blueprint.yaml required: [version, card]`), so a version-less file is rejected by kustomize-controller's server-side dry-run whenever the named CR does not already exist (bare-name mismatch, post-prune, curate of a non-seed blueprint) — wedging ALL catalog IaC applies. The committed file now round-trips the full spec, version included. Trade-off vs #4415: a catalog-seed version bump on a card-edited blueprint stays pinned until the next card edit refreshes the file (checklist note below).

**Facet B — bare `metadata.name` → Flux inventory swap → prune.** The card-save leg now reuses the **same canonical serializer as the #5041 Edit-IaC leg** (`stampBlueprintCRForFluxAggregator`): `metadata.name` stamped to the canonical `bp-<slug>` live-CR identity on BOTH writes (per-Blueprint read source + Flux aggregator), so a bare-named seed/legacy file can never mint a duplicate whose inventory swap prunes the live CR.

**Facet C — server-side metadata leaked into IaC.** The merged document is canonicalized BEFORE commit: `uid`, `resourceVersion`, `generation`, `creationTimestamp`, `managedFields`, `selfLink`, `finalizers`, `ownerReferences`, `namespace` (Blueprint is Cluster-scoped), `status`, and the `kubectl.kubernetes.io/last-applied-configuration` annotation are scrubbed — including junk perpetuated by legacy Gitea files through the read-modify-write (the stale-uid Conflict wedge, commit 7516c865).

**Facet E (same seam, zero extra scope).** `stripBlueprintCRMapForGit` now strips ONLY the server-side fields above and **preserves** the Helm ownership labels/annotations (`meta.helm.sh/*`, `app.kubernetes.io/managed-by`, `catalyst.openova.io/alias-of`, catalog-seed labels). Without them a prune-recreated CR broke the next `helm upgrade` with no console repair path (hw255 repair required direct gitea commits 956574c1/ba06d510).

**Facet D — verdict honesty (minimal).**
- API: a Flux-aggregator-leg failure on the card path is now **surfaced** as `committed:false` + reason (previously logged + swallowed → the `committed:true` store/IaC split-brain), mirroring the #5018 fix on the /iac leg. `committed:true` means exactly "both git writes landed" — nothing more is fabricated.
- UI: the YamlEditor's `• in sync` label — a pure local dirty-state indicator that read as reconcile state while the Kustomization was Ready=False (screenshot row140-156) — is reworded to `• no unsaved edits`, with a guard comment banning sync claims not read from the Kustomization/apply status.

## Tests

- `TestStampBlueprintCRForFluxAggregator_RoundTripsLiveCRFaithfully` — the exact hw255 live-CR shape (bare name + uid/resourceVersion/managedFields/status/last-applied + helm ownership + version) → canonical name, version + full spec preserved, server junk gone, helm metadata kept.
- `TestWriteCatalogEditToGit_CanonicalizesLegacyServerMetadata` — end-to-end card edit over a legacy per-Blueprint file: BOTH committed files canonical.
- `TestCommitCatalogAppEditToGit_AggregatorFailureSurfaced` — aggregator-only PutFile failure → `committed:false` + reconcile-leg reason.
- Flipped the #4415 assertions (`TestWriteCatalogEditToGit_MirrorsToFluxAggregator`, aggregator guards) to the new canon.

## Gates

- `products/catalyst/bootstrap/api`: `go build ./...` + `go vet` + `go test ./... -count=1` green (one pre-existing timing-sensitive test, `TestExportSecondaryKubeconfigs_WaitsForLateKubeconfig`, flaked once under concurrent load; passes in isolation and in the clean full run).
- `products/catalyst/bootstrap/ui`: `tsc -b --noEmit` + `vite build` + YamlEditor tests 7/7 green (68 pre-existing vitest failures in unrelated files reproduce identically without this diff).

## Deferred (checklist on #5113 — kept out to avoid scope inflation)

- [ ] Card-form Save UI shows no commit verdict at all (silent close+refresh) — render the `{committed, reason}` envelope in the cif-* editors.
- [ ] A real sync indicator reading the catalog-sovereign Kustomization Ready/applied state per file.
- [ ] Server-side dry-run of the exact committed bytes before reporting `committed:true` (issue's suggested hardening).
- [ ] Store `tagline` overwrites CR `card.summary` on unrelated-field saves (552a556c shape) — card editors PUT the full store row; needs dirty-field-only payloads.
- [ ] #4415 follow-up: seed-version bump vs Flux-owned spec.version on card-edited blueprints (refresh version from the live CR on each card edit, or SSA-ownership split).

Refs #5113

🤖 Generated with [Claude Code](https://claude.com/claude-code)