### PR TITLE
fix(mail): RFC 5322 Date header on PIN + notification mails (#5104 facet C)

### DIFF
--- a/core/services/notification/handlers/smtp.go
+++ b/core/services/notification/handlers/smtp.go
@@ -248,6 +248,10 @@ func (m *Mailer) Send(to, subject, htmlBody string) error {
 	headers := []string{
 		"MIME-Version: 1.0",
 		"Content-Type: text/html; charset=UTF-8",
+		// RFC 5322 §3.6.1: Date is a REQUIRED originator field. Stalwart
+		// relays the message as-is, so without it clients sort/thread the
+		// mail badly and some spam filters score on the absence (#5104 C).
+		fmt.Sprintf("Date: %s", time.Now().Format(time.RFC1123Z)),
 		fmt.Sprintf("From: OpenOva <%s>", m.From),
 		fmt.Sprintf("To: %s", to),
 		fmt.Sprintf("Subject: %s", subject),

--- a/core/services/notification/handlers/smtp_test.go
+++ b/core/services/notification/handlers/smtp_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"bytes"
 	"errors"
+	"net/mail"
 	"net/smtp"
 	"net/textproto"
 	"strings"
@@ -14,14 +16,16 @@ import (
 // the i-th call (saturating to the last entry if calls > len(errs)),
 // and records every invocation under the mutex.
 type fakeSendMail struct {
-	mu    sync.Mutex
-	calls int
-	errs  []error
+	mu      sync.Mutex
+	calls   int
+	errs    []error
+	lastMsg []byte
 }
 
 func (f *fakeSendMail) send(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.lastMsg = append([]byte(nil), msg...)
 	i := f.calls
 	f.calls++
 	if i >= len(f.errs) {
@@ -413,4 +417,25 @@ func TestBuildAuth(t *testing.T) {
 	t.Run("user-only", func(t *testing.T) { withEnv(t, "u", "", false) })
 	t.Run("pass-only", func(t *testing.T) { withEnv(t, "", "p", false) })
 	t.Run("both", func(t *testing.T) { withEnv(t, "u", "p", true) })
+}
+
+// TestMailerSend_IncludesRFC5322DateHeader guards #5104 facet C: Stalwart
+// relays messages as-composed, so Send must stamp the mandatory RFC 5322
+// Date originator field itself — its absence breaks client sorting and
+// feeds spam scoring.
+func TestMailerSend_IncludesRFC5322DateHeader(t *testing.T) {
+	fs := &fakeSendMail{errs: []error{nil}}
+	now, _, _ := fixedNow()
+	m := newTestMailer(fs, &recordingSleep{}, now)
+
+	if err := m.Send("to@example.com", "subject", "<p>hi</p>"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	parsed, err := mail.ReadMessage(bytes.NewReader(fs.lastMsg))
+	if err != nil {
+		t.Fatalf("composed message does not parse as RFC 5322: %v", err)
+	}
+	if _, err := parsed.Header.Date(); err != nil {
+		t.Errorf("Date header missing or unparseable: %v (got %q)", err, parsed.Header.Get("Date"))
+	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -615,6 +615,40 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 // via Stalwart per smtpAddr().
 var sendPinEmail = sendPinEmailDefault
 
+// pinEmailMessage assembles the full RFC 5322 message (headers + RFC
+// 2046 multipart/alternative body) for a sign-in-code mail. Factored
+// out of sendPinEmailDefault so tests can assert on the wire format
+// without an SMTP dial.
+func pinEmailMessage(from, to, subject, plain, html, boundary string) string {
+	headers := strings.Join([]string{
+		// RFC 5322 §3.6.1: Date is a REQUIRED originator field; Stalwart
+		// relays as-is, so its absence breaks client sorting/threading
+		// and feeds spam scoring (#5104 facet C).
+		"Date: " + time.Now().Format(time.RFC1123Z),
+		"From: OpenOva Platform <" + from + ">",
+		"To: " + to,
+		"Subject: " + subject,
+		"MIME-Version: 1.0",
+		"Content-Type: multipart/alternative; boundary=\"" + boundary + "\"",
+	}, "\r\n")
+	body := strings.Join([]string{
+		"",
+		"--" + boundary,
+		"Content-Type: text/plain; charset=utf-8",
+		"Content-Transfer-Encoding: 7bit",
+		"",
+		plain,
+		"--" + boundary,
+		"Content-Type: text/html; charset=utf-8",
+		"Content-Transfer-Encoding: 7bit",
+		"",
+		html,
+		"--" + boundary + "--",
+		"",
+	}, "\r\n")
+	return headers + "\r\n" + body
+}
+
 // sendPinEmailDefault sends a multipart MIME email (text + HTML) with
 // the 6-digit code rendered as a polished one-time-code card. iCloud /
 // Stripe parity — large monospaced digit groups, brand mark, expiration
@@ -640,29 +674,7 @@ func sendPinEmailDefault(to, pin string) error {
 	// support it, fall back to plain otherwise. Boundary is a UUID so it
 	// can never collide with body content.
 	boundary := strings.ReplaceAll(uuid.NewString(), "-", "")
-	headers := strings.Join([]string{
-		"From: OpenOva Platform <" + from + ">",
-		"To: " + to,
-		"Subject: " + subject,
-		"MIME-Version: 1.0",
-		"Content-Type: multipart/alternative; boundary=\"" + boundary + "\"",
-	}, "\r\n")
-	body := strings.Join([]string{
-		"",
-		"--" + boundary,
-		"Content-Type: text/plain; charset=utf-8",
-		"Content-Transfer-Encoding: 7bit",
-		"",
-		plain,
-		"--" + boundary,
-		"Content-Type: text/html; charset=utf-8",
-		"Content-Transfer-Encoding: 7bit",
-		"",
-		html,
-		"--" + boundary + "--",
-		"",
-	}, "\r\n")
-	msg := headers + "\r\n" + body
+	msg := pinEmailMessage(from, to, subject, plain, html, boundary)
 
 	smtpUser := os.Getenv("CATALYST_SMTP_USER")
 	smtpPass := os.Getenv("CATALYST_SMTP_PASS")

--- a/products/catalyst/bootstrap/api/internal/handler/auth_pin_email_msg_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_pin_email_msg_test.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"net/mail"
+	"strings"
+	"testing"
+)
+
+// TestPinEmailMessage_HasRFC5322DateHeader guards #5104 facet C: the
+// live hw255 funnel walk proved sign-in-code mails arrive with NO Date
+// header (msg.get('Date') == None on IMAP fetch) — Stalwart relays the
+// message as-composed, so the composer must stamp the mandatory RFC
+// 5322 Date originator field itself.
+func TestPinEmailMessage_HasRFC5322DateHeader(t *testing.T) {
+	msg := pinEmailMessage(
+		"noreply@openova.io", "user@example.com",
+		"Your OpenOva sign-in code: 123456",
+		"plain body", "<p>html body</p>", "deadbeefboundary",
+	)
+
+	parsed, err := mail.ReadMessage(strings.NewReader(msg))
+	if err != nil {
+		t.Fatalf("composed message does not parse as RFC 5322: %v", err)
+	}
+	if _, err := parsed.Header.Date(); err != nil {
+		t.Errorf("Date header missing or unparseable: %v (got %q)", err, parsed.Header.Get("Date"))
+	}
+	// The multipart contract must survive the refactor.
+	if ct := parsed.Header.Get("Content-Type"); !strings.Contains(ct, "multipart/alternative") || !strings.Contains(ct, "deadbeefboundary") {
+		t.Errorf("Content-Type lost multipart contract: %q", ct)
+	}
+}


### PR DESCRIPTION
## What

Stamps the mandatory RFC 5322 `Date:` originator field in both mail composers:
- `products/catalyst/bootstrap/api/internal/handler/auth.go` — PIN sign-in-code mails (assembly factored into `pinEmailMessage` so the wire format is unit-testable without an SMTP dial)
- `core/services/notification/handlers/smtp.go` — notification-service `Mailer.Send`

Regression tests parse the composed message with `net/mail` and assert `Header.Date()` succeeds (+ multipart contract preserved on the PIN path).

## Why

#5104 facet C, proven live on the hw255 funnel walk: login-code mails land with `msg.get('Date') == None` on IMAP fetch. Stalwart relays as-composed — clients sort/thread the mail badly and some spam filters score on the absent Date.

Gates: `go build ./... && go test` green in both modules (`core/services/notification`, `products/catalyst/bootstrap/api`).

Refs #5104

🤖 Generated with [Claude Code](https://claude.com/claude-code)