### PR TITLE
fix(billing): price the BCP topology surcharge at checkout (#5104 facet B)

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -12,7 +12,15 @@
   const selectedAddons = $derived(addons.filter(a => cart.addons.includes(a.id)));
   const planCost = $derived(selectedPlan?.monthly_price ?? 0);
   const addonCost = $derived(selectedAddons.reduce((sum, a) => sum + a.monthly_price, 0));
-  const totalCost = $derived(planCost + addonCost);
+  // #5104 facet B — the BCP step stores the choice at
+  // cart.appConfigs.postgres.active_hot_standby; it must be a priced line
+  // item HERE too, or the checkout total silently under-states what /review
+  // showed and (before the billing fix) under-billed the order. 5000 baisa
+  // mirrors billing's activeHotStandbyPriceOMR — the server remains the
+  // authority; this is display only.
+  const hotStandby = $derived(Boolean((cart.appConfigs ?? {})['postgres']?.['active_hot_standby']));
+  const topologyCost = $derived(hotStandby ? 5000 : 0);
+  const totalCost = $derived(planCost + addonCost + topologyCost);
 
   $effect(() => {
     getPlans().then(p => { plans = p; }).catch(() => {});
@@ -369,6 +377,10 @@
         plan_id: cart.plan || '',
         apps: cart.apps,
         addons: cart.addons,
+        // #5104 facet B — the topology must reach billing explicitly; it
+        // used to travel only inside the tenant-create app_configs, so the
+        // order billed the plan alone while the Org got hot-standby free.
+        topology: hotStandby ? 'active-hot-standby' : 'single-region',
         tenant_id: tenant.id,
         promo_code: trimmedPromo || undefined,
       });
@@ -699,6 +711,12 @@
                 <span class="text-[var(--color-text)]">{formatOMR(a.monthly_price)}</span>
               </div>
             {/each}
+            {#if hotStandby}
+              <div class="flex justify-between">
+                <span class="text-[var(--color-text-dim)]">+ Active hot-standby (BCP)</span>
+                <span class="text-[var(--color-text)]">{formatOMR(topologyCost)}</span>
+              </div>
+            {/if}
             <div class="mt-1 flex justify-between border-t border-dashed border-[var(--color-border)] pt-2 font-semibold">
               <span class="text-[var(--color-text-strong)]">Total (monthly)</span>
               <span class="text-[var(--color-text-strong)]">{formatOMR(totalCost)}</span>

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -549,6 +549,10 @@ export interface CheckoutRequest {
   addons: string[];
   tenant_id: string;
   promo_code?: string;
+  // #5104 facet B — BCP topology chosen on /bcp, canonical vocabulary
+  // ('single-region' | 'active-hot-standby'). Billing prices the
+  // hot-standby surcharge server-side; omitting it bills single-region.
+  topology?: string;
 }
 
 export interface CheckoutResponse {

--- a/core/services/billing/handlers/checkout_test.go
+++ b/core/services/billing/handlers/checkout_test.go
@@ -13,6 +13,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -436,5 +437,57 @@ func TestCheckoutRateLimiter_2941(t *testing.T) {
 	// Empty userID — should pass (auth middleware handles 401).
 	if !rl.Allow("") {
 		t.Errorf("empty userID should pass through (handled by auth layer)")
+	}
+}
+
+// TestComputeOrderTotal_TopologySurcharge guards #5104 facet B: the hw255
+// funnel walk proved a plan-M + active-hot-standby cart showed OMR 14 on
+// /review but billed OMR 9 — the topology never reached the pricing seam.
+// The surcharge must be priced server-side, and an unknown topology value
+// must fail closed (a typo can never grant an unbilled paid topology).
+func TestComputeOrderTotal_TopologySurcharge(t *testing.T) {
+	catalog := fakeCatalogServer(t, "plan-m", 9)
+	defer catalog.Close()
+	h := &Handler{CatalogURL: catalog.URL}
+
+	got, err := h.computeOrderTotal(context.Background(), "plan-m", nil, nil, topologyActiveHotStandby)
+	if err != nil {
+		t.Fatalf("computeOrderTotal(active-hot-standby): %v", err)
+	}
+	if want := 9 + activeHotStandbyPriceOMR; got != want {
+		t.Errorf("total = %d, want %d (plan 9 + hot-standby surcharge %d)", got, want, activeHotStandbyPriceOMR)
+	}
+
+	got, err = h.computeOrderTotal(context.Background(), "plan-m", nil, nil, topologySingleRegion)
+	if err != nil {
+		t.Fatalf("computeOrderTotal(single-region): %v", err)
+	}
+	if got != 9 {
+		t.Errorf("single-region total = %d, want 9 (no surcharge)", got)
+	}
+}
+
+// TestNormalizeTopology covers the canonical vocabulary + fail-closed default.
+func TestNormalizeTopology(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+		wantErr  bool
+	}{
+		{"", topologySingleRegion, false},
+		{topologySingleRegion, topologySingleRegion, false},
+		{topologyActiveHotStandby, topologyActiveHotStandby, false},
+		{"active_hot_standby", "", true}, // wrong dialect must NOT pass silently
+		{"multi-region", "", true},
+	} {
+		got, err := normalizeTopology(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("normalizeTopology(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil || got != tc.want {
+			t.Errorf("normalizeTopology(%q) = %q,%v want %q", tc.in, got, err, tc.want)
+		}
 	}
 }

--- a/core/services/billing/handlers/handlers.go
+++ b/core/services/billing/handlers/handlers.go
@@ -155,6 +155,13 @@ type checkoutRequest struct {
 	Addons    []string `json:"addons"`
 	TenantID  string   `json:"tenant_id"`
 	PromoCode string   `json:"promo_code"`
+	// Topology is the BCP topology chosen on the marketplace /bcp step, in
+	// the canonical vocabulary ("single-region" | "active-hot-standby").
+	// Empty = single-region. Priced server-side in computeOrderTotal —
+	// #5104 facet B: the choice used to travel ONLY via the tenant-create
+	// app_configs, so the review page showed plan+surcharge while the order
+	// billed the plan alone and the customer received hot-standby unbilled.
+	Topology string `json:"topology"`
 }
 
 type checkoutResponse struct {
@@ -226,7 +233,13 @@ func (h *Handler) Checkout(w http.ResponseWriter, r *http.Request) {
 	// New order: compute total → validate → then redeem. If catalog fails,
 	// the promo stays untouched. The admin's redemption cap accounting
 	// matches the number of orders that actually exist.
-	totalOMR, err := h.computeOrderTotal(ctx, req.PlanID, req.Apps, req.Addons)
+	topology, err := normalizeTopology(req.Topology)
+	if err != nil {
+		slog.Error("checkout: invalid topology", "error", err, "topology", req.Topology)
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	totalOMR, err := h.computeOrderTotal(ctx, req.PlanID, req.Apps, req.Addons, topology)
 	if err != nil {
 		slog.Error("checkout: compute total", "error", err)
 		respond.Error(w, http.StatusBadRequest, "failed to compute order total: "+err.Error())
@@ -303,7 +316,7 @@ func (h *Handler) Checkout(w http.ResponseWriter, r *http.Request) {
 	if remainingOMR <= 0 {
 		order := &store.Order{
 			CustomerID: cust.ID, TenantID: req.TenantID, PlanID: req.PlanID,
-			Apps: appsJSON, Addons: addonsJSON,
+			Apps: appsJSON, Addons: addonsJSON, Topology: topology,
 			AmountOMR: totalOMR, Status: "completed",
 			PromoCode: req.PromoCode,
 		}
@@ -354,7 +367,7 @@ func (h *Handler) Checkout(w http.ResponseWriter, r *http.Request) {
 	// Pending order for Stripe.
 	order := &store.Order{
 		CustomerID: cust.ID, TenantID: req.TenantID, PlanID: req.PlanID,
-		Apps: appsJSON, Addons: addonsJSON,
+		Apps: appsJSON, Addons: addonsJSON, Topology: topology,
 		AmountOMR: totalOMR, Status: "pending",
 		PromoCode: req.PromoCode,
 	}
@@ -1066,7 +1079,32 @@ type catalogAddon struct {
 	PriceOMR int    `json:"price_omr"`
 }
 
-func (h *Handler) computeOrderTotal(ctx context.Context, planID string, apps, addons []string) (int, error) {
+// Canonical BCP topology vocabulary (docs/GLOSSARY + catalog store.go #3648)
+// and the billing-side price authority for the topology surcharge. The
+// marketplace BCPStep.svelte "+OMR 5.000 / mo" label MUST match this value;
+// moving the price into the catalog service (so FE + billing read one source)
+// is the follow-up tracked on #5104.
+const (
+	topologySingleRegion     = "single-region"
+	topologyActiveHotStandby = "active-hot-standby"
+	activeHotStandbyPriceOMR = 5
+)
+
+// normalizeTopology maps the request field to the canonical vocabulary,
+// fail-closed: empty means single-region (free), anything unrecognized is an
+// error — a typo must never grant an unbilled paid topology (#5104 facet B).
+func normalizeTopology(t string) (string, error) {
+	switch t {
+	case "", topologySingleRegion:
+		return topologySingleRegion, nil
+	case topologyActiveHotStandby:
+		return topologyActiveHotStandby, nil
+	default:
+		return "", fmt.Errorf("unknown topology %q (want %q or %q)", t, topologySingleRegion, topologyActiveHotStandby)
+	}
+}
+
+func (h *Handler) computeOrderTotal(ctx context.Context, planID string, apps, addons []string, topology string) (int, error) {
 	if h.CatalogURL == "" {
 		return 0, fmt.Errorf("catalog URL not configured")
 	}
@@ -1102,7 +1140,14 @@ func (h *Handler) computeOrderTotal(ctx context.Context, planID string, apps, ad
 	}
 	// Apps are free for now (catalog app records have no price field).
 	_ = apps
-	return planPrice + addonTotal, nil
+
+	// BCP topology surcharge (#5104 facet B) — priced here, the server
+	// authority, never trusted from the client-side review total.
+	topologyTotal := 0
+	if topology == topologyActiveHotStandby {
+		topologyTotal = activeHotStandbyPriceOMR
+	}
+	return planPrice + addonTotal + topologyTotal, nil
 }
 
 func (h *Handler) resolvePlanStripePriceID(ctx context.Context, planID string) (string, error) {
@@ -1171,6 +1216,7 @@ func (h *Handler) dispatchOrderPlaced(tenantID string, order *store.Order) {
 		"plan_id":          order.PlanID,
 		"apps":             order.Apps,
 		"addons":           order.Addons,
+		"topology":         order.Topology,
 		"amount_omr":       order.AmountOMR,
 		"amount_baisa":     order.AmountBaisa,
 		"status":           order.Status,

--- a/core/services/billing/store/store.go
+++ b/core/services/billing/store/store.go
@@ -53,6 +53,10 @@ type Order struct {
 	PlanID          string          `json:"plan_id"`
 	Apps            json.RawMessage `json:"apps"`
 	Addons          json.RawMessage `json:"addons"`
+	// Topology is the billed BCP topology ("single-region" |
+	// "active-hot-standby") — a priced order dimension, persisted so
+	// invoices/BSS views show what the surcharge bought (#5104 facet B).
+	Topology        string          `json:"topology"`
 	AmountOMR       int             `json:"amount_omr"`
 	AmountBaisa     int64           `json:"amount_baisa"`
 	Status          string          `json:"status"`
@@ -209,6 +213,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 		// the admin order list can show it even after the promo is retired.
 		// The column is nullable because most orders have no promo.
 		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS promo_code TEXT`,
+		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS topology TEXT NOT NULL DEFAULT 'single-region'`,
 		`CREATE TABLE IF NOT EXISTS invoices (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			customer_id UUID NOT NULL REFERENCES customers(id),
@@ -402,10 +407,10 @@ func (s *Store) CreateOrder(ctx context.Context, o *Order) error {
 		o.AmountBaisa = OMRToBaisa(o.AmountOMR)
 	}
 	err := s.db.QueryRowContext(ctx,
-		`INSERT INTO orders (customer_id, tenant_id, plan_id, apps, addons, amount_omr, amount_baisa, status, stripe_session_id, promo_code)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		`INSERT INTO orders (customer_id, tenant_id, plan_id, apps, addons, topology, amount_omr, amount_baisa, status, stripe_session_id, promo_code)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		 RETURNING id, created_at`,
-		o.CustomerID, o.TenantID, o.PlanID, o.Apps, o.Addons, o.AmountOMR, o.AmountBaisa, o.Status, nilIfEmpty(o.StripeSessionID), nilIfEmpty(o.PromoCode),
+		o.CustomerID, o.TenantID, o.PlanID, o.Apps, o.Addons, orderTopology(o.Topology), o.AmountOMR, o.AmountBaisa, o.Status, nilIfEmpty(o.StripeSessionID), nilIfEmpty(o.PromoCode),
 	).Scan(&o.ID, &o.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("store: create order: %w", err)
@@ -424,13 +429,13 @@ func (s *Store) GetOrder(ctx context.Context, id string) (*Order, error) {
 	var promoCode sql.NullString
 	var promoDeletedAt sql.NullTime
 	err := s.db.QueryRowContext(ctx,
-		`SELECT o.id, o.customer_id, o.tenant_id, o.plan_id, o.apps, o.addons,
+		`SELECT o.id, o.customer_id, o.tenant_id, o.plan_id, o.apps, o.addons, o.topology,
 		        o.amount_omr, o.amount_baisa, o.status, o.stripe_session_id, o.created_at,
 		        o.promo_code, pc.deleted_at
 		   FROM orders o
 		   LEFT JOIN promo_codes pc ON pc.code = o.promo_code
 		  WHERE o.id = $1`, id,
-	).Scan(&o.ID, &o.CustomerID, &o.TenantID, &o.PlanID, &o.Apps, &o.Addons,
+	).Scan(&o.ID, &o.CustomerID, &o.TenantID, &o.PlanID, &o.Apps, &o.Addons, &o.Topology,
 		&o.AmountOMR, &o.AmountBaisa, &o.Status, &sessionID, &o.CreatedAt,
 		&promoCode, &promoDeletedAt)
 	if err == sql.ErrNoRows {
@@ -467,7 +472,7 @@ func (s *Store) UpdateOrderStatus(ctx context.Context, id, status, stripeSession
 // whether it has been soft-deleted, without a per-row extra query.
 func (s *Store) ListRecentOrders(ctx context.Context) ([]Order, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT o.id, o.customer_id, o.tenant_id, o.plan_id, o.apps, o.addons,
+		`SELECT o.id, o.customer_id, o.tenant_id, o.plan_id, o.apps, o.addons, o.topology,
 		        o.amount_omr, o.amount_baisa, o.status, o.stripe_session_id, o.created_at,
 		        o.promo_code, pc.deleted_at
 		   FROM orders o
@@ -485,7 +490,7 @@ func (s *Store) ListRecentOrders(ctx context.Context) ([]Order, error) {
 		var sessionID sql.NullString
 		var promoCode sql.NullString
 		var promoDeletedAt sql.NullTime
-		if err := rows.Scan(&o.ID, &o.CustomerID, &o.TenantID, &o.PlanID, &o.Apps, &o.Addons,
+		if err := rows.Scan(&o.ID, &o.CustomerID, &o.TenantID, &o.PlanID, &o.Apps, &o.Addons, &o.Topology,
 			&o.AmountOMR, &o.AmountBaisa, &o.Status, &sessionID, &o.CreatedAt,
 			&promoCode, &promoDeletedAt); err != nil {
 			return nil, fmt.Errorf("store: scan order: %w", err)
@@ -1349,11 +1354,11 @@ func (s *Store) CreditOnlyCheckout(ctx context.Context, order *Order, sub *Subsc
 
 	// 1. Persist the order.
 	if err := tx.QueryRowContext(ctx,
-		`INSERT INTO orders (customer_id, tenant_id, plan_id, apps, addons, amount_omr, amount_baisa, status, stripe_session_id, promo_code)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		`INSERT INTO orders (customer_id, tenant_id, plan_id, apps, addons, topology, amount_omr, amount_baisa, status, stripe_session_id, promo_code)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		 RETURNING id, created_at`,
 		order.CustomerID, order.TenantID, order.PlanID, order.Apps, order.Addons,
-		order.AmountOMR, order.AmountBaisa, order.Status,
+		orderTopology(order.Topology), order.AmountOMR, order.AmountBaisa, order.Status,
 		nilIfEmpty(order.StripeSessionID), nilIfEmpty(order.PromoCode),
 	).Scan(&order.ID, &order.CreatedAt); err != nil {
 		return fmt.Errorf("store: credit-only create order: %w", err)
@@ -1446,6 +1451,15 @@ func (s *Store) DeleteWebhookEvent(ctx context.Context, eventID string) error {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// orderTopology defends the orders.topology NOT NULL invariant: an empty
+// struct field persists as the canonical default, never as ''.
+func orderTopology(t string) string {
+	if t == "" {
+		return "single-region"
+	}
+	return t
+}
 
 func nilIfEmpty(s string) *string {
 	if s == "" {

--- a/core/services/billing/store/store_test.go
+++ b/core/services/billing/store/store_test.go
@@ -241,8 +241,9 @@ func TestCreateOrder_DerivesBaisaFromOMR(t *testing.T) {
 		WithArgs(
 			"cust", "tenant", "plan",
 			sqlmock.AnyArg(), sqlmock.AnyArg(),
-			42,           // amount_omr
-			int64(42000), // amount_baisa
+			"single-region", // topology (default when unset)
+			42,              // amount_omr
+			int64(42000),    // amount_baisa
 			"pending",
 			sqlmock.AnyArg(), // stripe_session_id
 			sqlmock.AnyArg(), // promo_code (#91)
@@ -375,6 +376,7 @@ func TestCreditOnlyCheckout_CommitsAllThreeWrites(t *testing.T) {
 		WithArgs(
 			"cust", "tenant", "plan",
 			sqlmock.AnyArg(), sqlmock.AnyArg(), // apps, addons
+			sqlmock.AnyArg(), // topology
 			9, int64(9000), // amount_omr, amount_baisa
 			"completed",
 			sqlmock.AnyArg(), sqlmock.AnyArg(), // stripe_session_id (nil), promo_code (nil)


### PR DESCRIPTION
## What

Makes the BCP topology a first-class, server-priced checkout dimension:

- **billing**: `checkoutRequest.topology` (canonical `single-region` | `active-hot-standby`, fail-closed — unknown values 400 so a typo can never grant an unbilled paid topology); `computeOrderTotal` adds the `activeHotStandbyPriceOMR=5` surcharge server-side; `orders.topology` column (ALTER IF NOT EXISTS, default `single-region`) persisted through both insert paths and projected into the `order.placed` event.
- **marketplace**: `CheckoutStep` derives the choice from `cart.appConfigs.postgres.active_hot_standby`, sends `topology` explicitly to `/billing/checkout`, and renders the surcharge line item so the checkout ORDER SUMMARY equals the billed total.

## Why

#5104 facet B, proven live on the hw255 funnel walk and reproduced on two orders (`9d529d1c`, `dd494c63`): /review showed **OMR 14.000** (plan-M 9 + Active-hot-standby 5) but checkout billed **9** — the topology only traveled inside the tenant-create `app_configs`, so the customer received the paid hot-standby topology un-billed while the feature itself provisioned correctly.

## Gates

`go build && go vet && go test ./...` green in `core/services/billing` (new `TestComputeOrderTotal_TopologySurcharge` + `TestNormalizeTopology`; sqlmock insert expectations updated). Marketplace `npm run build` green incl. the domain-hygiene postbuild gate.

Follow-up (checklist on #5104): move the surcharge price into the catalog service so FE + billing read one source instead of a matched constant.

Refs #5104

🤖 Generated with [Claude Code](https://claude.com/claude-code)