### PR TITLE
fix(openova-mcp): hw256 defects — numeric runAsUser 65532 + primary-only slot 13d (0.1.1) — MERGE-HELD until hw256 cutoverComplete

### DIFF
--- a/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
+++ b/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
@@ -62,7 +62,20 @@ metadata:
   labels:
     catalyst.openova.io/slot: "13d"
     catalyst.openova.io/component: openova-mcp
+    catalyst.openova.io/region-role: primary
 spec:
+  # #5114 hw256 defect 2: PRIMARY-ONLY HR — the same G2 split (#2574) as
+  # its cohort's primary-side siblings (13 bp-catalyst-platform / 06a
+  # bp-self-sovereign-cutover / 62 bp-continuum). The facade's upstream
+  # (catalyst-api) and its dependsOn edge (bp-catalyst-platform) exist
+  # only on the primary — bp-catalyst-platform is suspended on secondary
+  # CPs by design, so on a secondary this HR could never leave
+  # `dependency 'flux-system/bp-catalyst-platform' is not ready`
+  # (permanently-False HR fan-out, hw256 region-b). SECONDARY_HR_SUSPEND
+  # renders "true" on every secondary CP's cloud-init
+  # (sovereign_region_role != "primary") and "false" on the primary,
+  # suspending this HR cluster-side without touching the chart catalog.
+  suspend: ${SECONDARY_HR_SUSPEND:=false}
   interval: 1m
   releaseName: openova-mcp
   # Lands in catalyst-system co-located with catalyst-api (its facade
@@ -78,12 +91,17 @@ spec:
   chart:
     spec:
       chart: bp-openova-mcp
+      # 0.1.1 (#5114 hw256 fixes): numeric runAsUser/runAsGroup 65532
+      # beside runAsNonRoot (image 0.2.0's string USER `nonroot` wedged
+      # the pod at CreateContainerConfigError on hw256) + appVersion
+      # 0.2.1 (numeric USER 65532:65532 in the Containerfile) + this
+      # slot goes primary-only via SECONDARY_HR_SUSPEND (defect 2).
       # 0.1.0 (#5114, Refs #3988): first release — Deployment (streamable-
       # HTTP transport) + ClusterIP Service + HTTPRoute mcp.<fqdn> +
       # zero-RBAC ServiceAccount + Cilium ingress/egress CNPs. Lockstep:
       # products/openova-mcp/chart/Chart.yaml + blueprint.yaml +
       # catalog-seed (blueprints.json).
-      version: 0.1.0
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-openova-mcp

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -3693,7 +3693,7 @@
         "pillar-4"
       ],
       "visibility": "unlisted",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "section": "pts-4-7-agentic-workspace",
       "depends": [],
       "shareable": false,

--- a/products/openova-mcp/Containerfile
+++ b/products/openova-mcp/Containerfile
@@ -31,7 +31,16 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" \
 # Static Go binary + CA bundle (the facade dials catalyst-api over HTTPS in
 # org mode) — distroless static, runs as nonroot (uid 65532). No shell, no
 # package manager: the server needs nothing but the binary and certs.
+#
+# USER must be NUMERIC (#5114 hw256 defect 1): a string USER (`nonroot`)
+# cannot be proven non-root by the kubelet when the pod spec sets
+# runAsNonRoot, and image 0.2.0 died on arrival with
+# `CreateContainerConfigError: container has runAsNonRoot and image has
+# non-numeric user (nonroot)`. 65532:65532 is the distroless nonroot
+# uid:gid — same identity, numerically stated; the chart's pod
+# securityContext pins the identical runAsUser/runAsGroup (belt and
+# braces — either surface alone now satisfies the runAsNonRoot check).
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /out/openova-mcp /usr/local/bin/openova-mcp
-USER nonroot
+USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/openova-mcp"]

--- a/products/openova-mcp/blueprint.yaml
+++ b/products/openova-mcp/blueprint.yaml
@@ -6,12 +6,17 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
+  # 0.1.1 (#5114 hw256 fixes): numeric runAsUser/runAsGroup 65532 beside
+  # runAsNonRoot (image 0.2.0's string USER `nonroot` wedged the hw256 pod
+  # at CreateContainerConfigError) + appVersion 0.2.1 (numeric USER in the
+  # Containerfile) + bootstrap-kit slot 13d goes primary-only
+  # (SECONDARY_HR_SUSPEND).
   # 0.1.0 (#5114, Refs #3988): first release — the Pillar-4 install path
   # for the OpenOva MCP server (Deployment + ClusterIP Service + Gateway-API
   # HTTPRoute + zero-RBAC ServiceAccount + Cilium CNPs). Lockstep with
-  # products/openova-mcp/chart/Chart.yaml 0.1.0 + bootstrap-kit slot 13d pin
+  # products/openova-mcp/chart/Chart.yaml 0.1.1 + bootstrap-kit slot 13d pin
   # + the catalog-seed (blueprints.json) entry.
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: OpenOva MCP
     summary: |

--- a/products/openova-mcp/chart/Chart.yaml
+++ b/products/openova-mcp/chart/Chart.yaml
@@ -13,6 +13,16 @@ description: |
   catalyst-api, whose own authz is the final word — the server holds NO
   privileged token and reads NOTHING from the Kubernetes API.
 type: application
+# 0.1.1 (#5114 hw256 live-proven fixes): pod securityContext gains NUMERIC
+# runAsUser/runAsGroup 65532 beside runAsNonRoot — image 0.2.0 declared
+# the STRING `USER nonroot`, which the kubelet cannot prove non-root, so
+# the hw256 pod died at `CreateContainerConfigError: container has
+# runAsNonRoot and image has non-numeric user (nonroot)`. appVersion
+# 0.2.1: the Containerfile states the same identity numerically
+# (USER 65532:65532 — belt and braces). Companion (same train, not a chart
+# change): bootstrap-kit slot 13d goes primary-only via
+# SECONDARY_HR_SUSPEND so secondaries stop fanning out a permanently-False
+# HR behind the suspended bp-catalyst-platform dependency.
 # 0.1.0 (#5114, Refs #3988): first release — the Pillar-4 install path.
 # Deployment (streamable-HTTP transport, OPENOVA_MCP_LISTEN) + ClusterIP
 # Service + Gateway-API HTTPRoute (mcp.<sovereign-fqdn>; never a Traefik
@@ -22,18 +32,20 @@ type: application
 # load-bearing DNS carve-out) + an optional values-gated chepherd-attach
 # ConfigMap (#3988 §4.4 deviation: no bp-chepherd exists in this kit, so
 # the dependency is an OPTIONAL seam and the chart is standalone-capable).
-# Lockstep: blueprint.yaml 0.1.0 + bootstrap-kit slot 13d pin 0.1.0 +
-# catalog-seed (blueprints.json) 0.1.0. Image = ghcr.io/openova-io/
+# Lockstep: blueprint.yaml 0.1.1 + bootstrap-kit slot 13d pin 0.1.1 +
+# catalog-seed (blueprints.json) 0.1.1. Image = ghcr.io/openova-io/
 # openova-mcp:<appVersion> (build-openova-mcp.yaml; plain image repo per
 # the #4706 chart-repo-collision lesson).
-version: 0.1.0
+version: 0.1.1
 # appVersion is the default image tag (openova-mcp.image in _helpers.tpl).
-# 0.2.0 is the FIRST image with the streamable-HTTP transport
+# 0.2.1 rebuilds 0.2.0 with a NUMERIC USER (65532:65532) — see the 0.1.1
+# note above; the binary is unchanged. 0.2.0 is the FIRST image with the
+# streamable-HTTP transport
 # (OPENOVA_MCP_LISTEN + /healthz + /readyz + Authorization-header bearer +
 # the OPENOVA_MCP_EXPECTED_ISSUER / OPENOVA_MCP_ORG_SCOPE instance pins) —
 # the 0.1.x binary was stdio-only (the agenity in-pod child, #4010/#4097)
 # and cannot back a Service.
-appVersion: "0.2.0"
+appVersion: "0.2.1"
 keywords:
   - mcp
   - agent

--- a/products/openova-mcp/chart/templates/deployment.yaml
+++ b/products/openova-mcp/chart/templates/deployment.yaml
@@ -36,6 +36,16 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        # NUMERIC uid/gid are REQUIRED next to runAsNonRoot (#5114 hw256
+        # defect 1): the image's USER is resolved by the kubelet at
+        # container-create, and a NON-numeric USER (the distroless
+        # `nonroot` string of image 0.2.0) cannot prove non-rootness →
+        # `CreateContainerConfigError: container has runAsNonRoot and
+        # image has non-numeric user (nonroot)` — pod dead on arrival.
+        # 65532 is the distroless static-debian12 nonroot uid/gid; the
+        # Containerfile pins the same numerically (USER 65532:65532).
+        runAsUser: 65532
+        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## What

Fixes the two live-proven bp-openova-mcp defects from the hw256 Wave-0 validation (#5114, comment 4983323898). **MERGE-HELD until hw256 cutoverComplete** — do not merge while the cutover chain is running (never merge during a Sovereign cutover; step-06 prewarm/pin drift).

### Defect 1 (P1) — pod dead on arrival: `CreateContainerConfigError`

`container has runAsNonRoot and image has non-numeric user (nonroot)` — the chart set `runAsNonRoot: true` with no numeric uid while image `openova-mcp:0.2.0` declared the STRING `USER nonroot`, which the kubelet cannot prove non-root.

- `products/openova-mcp/chart/templates/deployment.yaml` — pod securityContext gains `runAsUser: 65532` + `runAsGroup: 65532` (the distroless static-debian12 nonroot uid/gid).
- `products/openova-mcp/Containerfile` — `USER nonroot` → `USER 65532:65532` (belt and braces: image and chart now state the same numeric identity); appVersion 0.2.0 → 0.2.1. The pushed image tag derives from `Chart.AppVersion` in `.github/workflows/build-openova-mcp.yaml`, so tag and chart cannot drift; the post-merge main build publishes `:0.2.1` behind its /healthz smoke gate.

### Defect 2 — secondary-region HR permanently False

On secondaries the HR could never leave `dependency 'flux-system/bp-catalyst-platform' is not ready` — bp-catalyst-platform is suspend=true on secondary CPs by design. Slot 13d now takes the established G2 primary-only split (#2574), byte-identical mechanism to its cohort siblings `13-bp-catalyst-platform` / `06a-bp-self-sovereign-cutover` / `62-bp-continuum`:

- label `catalyst.openova.io/region-role: primary`
- `suspend: ${SECONDARY_HR_SUSPEND:=false}` — renders `true` on every secondary CP's cloud-init (`sovereign_region_role != "primary"`), `false` on the primary.

### Lockstep (4 surfaces, all 0.1.1)

- `products/openova-mcp/chart/Chart.yaml` — version 0.1.1, appVersion 0.2.1
- `products/openova-mcp/blueprint.yaml` — 0.1.1
- `clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml` — pin 0.1.1
- `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` — 0.1.1

## Gates (all run locally, all green)

- `helm lint` — 0 failed
- `helm template` default AND `mode=organization` — render clean; both render `runAsUser: 65532` / `runAsGroup: 65532` and `image: ghcr.io/openova-io/openova-mcp:0.2.1`
- `chart/tests/render-modes.sh` — PASS (sovereign + organization + fail-closed + chepherd seam, incl. the no-NodePort/no-Ingress assertions)
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (`bp-openova-mcp: chart=0.1.1 pin=0.1.1`)
- `python3 scripts/render-slot-placement.py check` — PASS (65 slots)
- `scripts/check-bootstrap-deps.sh` — PASS (0 cycles)
- `kubectl kustomize clusters/_template/bootstrap-kit` — builds
- `go build ./...` + `go test ./...` in `products/openova-mcp` — OK

No NodePort, no Ingress, no live-cluster access — chart/kit/catalog code only.

Refs #5114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>