### PR TITLE
fix(auth): Date header on the funnel customer's login-code mail — the third composer #5116 missed (#5104 facet C)

### DIFF
--- a/core/services/auth/handlers/handlers.go
+++ b/core/services/auth/handlers/handlers.go
@@ -632,9 +632,15 @@ func generateCode() (string, error) {
 // and authenticates with PLAIN when SMTP_USER/SMTP_PASS are configured.
 func (h *Handler) sendCodeEmail(to, code string) error {
 	addr := h.SMTPHost + ":" + h.SMTPPort
+	// RFC 5322 §3.6.1: Date is a REQUIRED originator field; Stalwart relays
+	// as-composed. #5116 stamped the other two composers (billing Mailer +
+	// catalyst-api PIN mail) but missed this one — the mail every funnel
+	// customer receives arrived with no Date header (hw256 walk:
+	// msg.get('Date')==None on 2/2 samples), breaking client sorting and
+	// feeding spam scoring.
 	msg := fmt.Sprintf(
-		"From: %s\r\nTo: %s\r\nSubject: Your login code\r\n\r\nYour login code: %s\r\n",
-		h.FromEmail, to, code,
+		"Date: %s\r\nFrom: %s\r\nTo: %s\r\nSubject: Your login code\r\n\r\nYour login code: %s\r\n",
+		time.Now().Format(time.RFC1123Z), h.FromEmail, to, code,
 	)
 
 	conn, err := smtp.Dial(addr)


### PR DESCRIPTION
hw256 funnel walk verdict V5: the customer 'Your login code' mail (auth-service `sendCodeEmail`, `handlers.go:634`) still lacks the RFC 5322 Date header — #5116 fixed the other two composers only; the walk's positive control (owner PIN mail) carried Date correctly, isolating this composer. Gates: go build/vet clean (module has no test files — pre-existing gap; composer has no injection seam without refactor scope). Validates on the next funnel walk's IMAP fetch. Refs #5104

🤖 Generated with [Claude Code](https://claude.com/claude-code)