### PR TITLE
fix(cloud-init): harden the bootstrap layer — retry k3s install + bound the healthz wait (last two single-shot #5042 legs)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1336,20 +1336,12 @@ runcmd:
     # bootstrap-kit substitute map (the NODE_IP_PLACEHOLDER sentinel) so Cilium
     # reaches its OWN apiserver on a real address on every cloud.
     sed -i "s|NODE_IP_PLACEHOLDER|$${NODE_IP}|g" /var/lib/catalyst/cilium-values.yaml /var/lib/catalyst/flux-bootstrap.yaml
-    # #5042: k3s install is the bootstrap FOUNDATION. The old single-shot
-    # `curl https://get.k3s.io | ... sh -` silently no-ops on a transient
-    # DNS/CDN miss — the pipe masks curl's exit and an empty stdin makes
-    # `sh -` exit 0, so a failed download "succeeds", k3s never installs, the
-    # apiserver never comes up, and the healthz wait below spins forever (hw247
-    # class, forensic-blind). Fix: download the installer to a FILE first (so a
-    # failed fetch is VISIBLE, not masked by the pipe), then run it; retry the
-    # whole unit 5x with linear backoff (sleep i*10s) to ride out the
-    # #3232/#3829 github/ghcr transient-DNS class instead of a one-shot dice-
-    # roll. Exhaustion is fail-loud — the sentinel + exit 88 halts runcmd and,
-    # on Huawei, the mark helper pushes the cloud-init log so the foundation
-    # failure is diagnosable, never blind. Re-running the k3s installer is
-    # idempotent (rewrites the unit + restarts), so a retry after a partial
-    # install recovers cleanly.
+    # #5042: k3s is the bootstrap foundation. Old `curl get.k3s.io | ... sh -`
+    # silently no-ops on a transient DNS/CDN miss (pipe masks curl's exit; empty
+    # stdin → `sh -` exit 0 → k3s never installs → healthz spins forever, hw247
+    # forensic-blind). Fix: download-to-FILE (failure visible) then run; 5x
+    # linear backoff for the #3232/#3829 class; exhaustion fail-loud (sentinel +
+    # exit 88, huawei log-push). Re-run is idempotent.
     for i in 1 2 3 4 5; do
       curl -fsSL --max-time 60 https://get.k3s.io -o /var/lib/catalyst/k3s-install.sh \
         && INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} \
@@ -1362,12 +1354,9 @@ runcmd:
 
   # Wait for the API server to be reachable (Cilium comes up later, so we
   # wait specifically for the apiserver /healthz endpoint, not node-Ready).
-  # #5042: BOUNDED. This was an UNBOUNDED `until ...; do sleep 5; done` that
-  # hung forever AND silently if the apiserver never came healthy — the exact
-  # latent defect the RCA flagged (a dead apiserver masqueraded as a downstream
-  # flux wedge, forensic-blind). Now 120x5s = 10m budget, then fail-loud: FATAL
-  # + sentinel + exit 89 (halts runcmd) and, on Huawei, the mark helper pushes
-  # the cloud-init log so a dead apiserver is fast-and-diagnosable.
+  # #5042: BOUNDED (was unbounded `until ...; sleep 5` — a dead apiserver hung
+  # forever + silently, masquerading as a downstream flux wedge). 120x5s=10m
+  # then fail-loud (sentinel + exit 89, huawei log-push).
   - |
     n=0
     until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get --raw /healthz >/dev/null 2>&1; do

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1336,15 +1336,44 @@ runcmd:
     # bootstrap-kit substitute map (the NODE_IP_PLACEHOLDER sentinel) so Cilium
     # reaches its OWN apiserver on a real address on every cloud.
     sed -i "s|NODE_IP_PLACEHOLDER|$${NODE_IP}|g" /var/lib/catalyst/cilium-values.yaml /var/lib/catalyst/flux-bootstrap.yaml
-    curl -sfL https://get.k3s.io | \
-      INSTALL_K3S_VERSION=${k3s_version} \
-      K3S_TOKEN=${k3s_token} \
-      INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --disable=local-storage --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=$${NODE_IP} --node-external-ip=$${NODE_EXTERNAL_IP} --advertise-address=$${NODE_IP} --kubelet-arg=max-pods=220 --kubelet-arg=image-gc-high-threshold=70 --kubelet-arg=image-gc-low-threshold=60 --kubelet-arg=minimum-image-ttl-duration=2h --tls-san=${sovereign_fqdn} --tls-san=$${NODE_IP} --tls-san=$${NODE_EXTERNAL_IP} --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} ${k3s_extra_args} --write-kubeconfig-mode=0644" \
-      sh -
+    # #5042: k3s install is the bootstrap FOUNDATION. The old single-shot
+    # `curl https://get.k3s.io | ... sh -` silently no-ops on a transient
+    # DNS/CDN miss — the pipe masks curl's exit and an empty stdin makes
+    # `sh -` exit 0, so a failed download "succeeds", k3s never installs, the
+    # apiserver never comes up, and the healthz wait below spins forever (hw247
+    # class, forensic-blind). Fix: download the installer to a FILE first (so a
+    # failed fetch is VISIBLE, not masked by the pipe), then run it; retry the
+    # whole unit 5x with linear backoff (sleep i*10s) to ride out the
+    # #3232/#3829 github/ghcr transient-DNS class instead of a one-shot dice-
+    # roll. Exhaustion is fail-loud — the sentinel + exit 88 halts runcmd and,
+    # on Huawei, the mark helper pushes the cloud-init log so the foundation
+    # failure is diagnosable, never blind. Re-running the k3s installer is
+    # idempotent (rewrites the unit + restarts), so a retry after a partial
+    # install recovers cleanly.
+    for i in 1 2 3 4 5; do
+      curl -fsSL --max-time 60 https://get.k3s.io -o /var/lib/catalyst/k3s-install.sh \
+        && INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} \
+           INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --disable=local-storage --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=$${NODE_IP} --node-external-ip=$${NODE_EXTERNAL_IP} --advertise-address=$${NODE_IP} --kubelet-arg=max-pods=220 --kubelet-arg=image-gc-high-threshold=70 --kubelet-arg=image-gc-low-threshold=60 --kubelet-arg=minimum-image-ttl-duration=2h --tls-san=${sovereign_fqdn} --tls-san=$${NODE_IP} --tls-san=$${NODE_EXTERNAL_IP} --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} ${k3s_extra_args} --write-kubeconfig-mode=0644" \
+           sh /var/lib/catalyst/k3s-install.sh \
+        && break
+      [ "$i" = 5 ] && { echo "[k3s] FATAL: install failed after 5 attempts" >&2; %{ if provider == "huawei" }sh /var/lib/catalyst/mark k3s-install-FAILED||true%{ else }touch /var/lib/catalyst/k3s-install-FAILED%{ endif }; exit 88; }
+      sleep $((i*10))
+    done
 
   # Wait for the API server to be reachable (Cilium comes up later, so we
   # wait specifically for the apiserver /healthz endpoint, not node-Ready).
-  - 'until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get --raw /healthz; do sleep 5; done'
+  # #5042: BOUNDED. This was an UNBOUNDED `until ...; do sleep 5; done` that
+  # hung forever AND silently if the apiserver never came healthy — the exact
+  # latent defect the RCA flagged (a dead apiserver masqueraded as a downstream
+  # flux wedge, forensic-blind). Now 120x5s = 10m budget, then fail-loud: FATAL
+  # + sentinel + exit 89 (halts runcmd) and, on Huawei, the mark helper pushes
+  # the cloud-init log so a dead apiserver is fast-and-diagnosable.
+  - |
+    n=0
+    until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get --raw /healthz >/dev/null 2>&1; do
+      n=$((n+1)); [ "$n" -ge 120 ] && { echo "[healthz] FATAL: apiserver never healthy after 120 tries (10m)" >&2; %{ if provider == "huawei" }sh /var/lib/catalyst/mark apiserver-healthz-FAILED||true%{ else }touch /var/lib/catalyst/apiserver-healthz-FAILED%{ endif }; exit 89; }
+      sleep 5
+    done
 
   # #3971 — NO StorageClass is provisioned here. k3s ran with
   # `--disable=local-storage` (above) so the ephemeral local-path provisioner


### PR DESCRIPTION
## What

Closes the last two single-shot / unbounded legs in the SACRED cloud-init control-plane template that the #5042 RCA named but the class-fix PRs (#5057 / #5068 / #5073 / #5083 / #5107) did not cover. Both sit **upstream of the kubeconfig PUT**, so a failure there is the most forensic-blind of all — this hardens the bootstrap layer so a future fresh-prov dice-roll fails **loud and diagnosable** instead of wedging at `phase1-watching` forever.

## Root cause (from the issue's own evidence)

- **hw247 mode**: nodes Ready + cilium up, but k3s/flux never landed → forever wedge, no cloud-init log. The RCA traced this to single-shot network legs on the IPv4-only kom4dc VPC losing a transient-DNS/CDN dice-roll (#3232/#3829 class).
- #5057 hardened **flux-install (exit 93)**, **flux-wait (exit 94)** and **gateway-api (exit 95)**; #5068/#5083 added the fail-path cloud-init-log push; #5073/#5107 added the named `OutcomeFluxCRDsAbsent` terminal state + probe-budget fix. **The k3s install and the apiserver healthz wait were left un-hardened** — exactly the two legs comment 1 ("the k3s install … is single-shot") and comment 3 item 2 ("Bound the `until healthz` wait … finite + FATAL") flagged as remaining.

## Changes (`infra/providers/_shared/cloudinit-control-plane.tftpl`, one file)

1. **k3s install (~L1339)** — was `curl -sfL https://get.k3s.io | … sh -`. The pipe **masks curl's exit**: a failed download yields empty stdin and `sh -` exits 0, so the miss looks like success and k3s silently never installs. Now: download the installer to a **file** first (a failed fetch is visible, not masked), then run it; retry the whole unit **5× with linear backoff**. Exhaustion → `k3s-install-FAILED` sentinel + **exit 88** (halts runcmd); on Huawei the `mark` helper pushes the cloud-init log. Re-running the k3s installer is idempotent.
2. **apiserver healthz wait (~L1347)** — was an **unbounded** `until kubectl … get --raw /healthz; do sleep 5; done` that hung forever + silently if the apiserver never came healthy (a dead apiserver masqueraded as a downstream flux wedge). Now bounded **120×5s = 10m**, then fail-loud → `apiserver-healthz-FAILED` sentinel + **exit 89** (+ Huawei log push).

Both match the idioms already in the file (the gwapi `for i in 1..5; do <cmd> && break; …; sleep; done` and the flux-install bounded `until`), stay POSIX/dash-clean, and use previously-free exit codes 88/89 (86/87 = IP detection, 88 = k3s, 89 = healthz — a contiguous bootstrap-foundation sequence).

## Gates (green, code-only — no live cluster; validation lands on the next fresh prov per the #5057 precedent)

- `scripts/lint-cloudinit.sh both` → **PASS** — dash -n clean for all runcmd items (hetzner 26, huawei 29) + concatenated script; both providers render OK (confirms `${tf}` vs shell `$${var}` escaping is correct — no dollar-brace footgun).
- `scripts/cloudinit-size-check.sh both` → **PASS** — hetzner CP **24398 B** (7858 B headroom) / huawei CP **27994 B** (4262 B headroom), both well under the 32256 guardrail (Hetzner's 32768 hard cap). Rendered both provider branches and confirmed the `%{ if provider == "huawei" }` split resolves correctly (Hetzner `touch …-FAILED`; Huawei `sh /var/lib/catalyst/mark …-FAILED||true` — the log-pushing path).
- `tofu fmt` N/A — it rejects `.tftpl` by design; CI's `tofu fmt -check -recursive` only formats HCL.

Do **not** merge during an active Sovereign cutover (RT-11). No NodePorts, no live-cluster access.

Refs #5042

🤖 Generated with [Claude Code](https://claude.com/claude-code)