### PR TITLE
fix(cloud-init): collapse redundant reflector namespace list under existing catch-all — real render under the 32576B guardrail (unblocks catalyst-api build + mothership roll)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -228,9 +228,9 @@ write_files:
         namespace: flux-system
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]*"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,flux-system,org-.*,[a-z][a-z0-9-]*"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]*"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,org-.*,[a-z][a-z0-9-]*"
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: ${base64encode(jsonencode({


### PR DESCRIPTION
## What

The G36 `tofu test` guardrail (`length(local.control_plane_cloud_init) <= 32576`, main.tf:1039) was failing at **32677 bytes** — 101B over — wedging the `Build & Deploy Catalyst` job, which wedges the mothership catalyst-api roll to the 0.1.2 bp-openova-mcp slot pin, which wedges the hw259 keystone cycle.

## Root cause of the *measurement*

main.tf:987 wraps the templatefile in `replace(..., "/(?m)^[ ]*#( |$).*\\n/", "")` — it **strips every full-line comment before `length()` runs**. So culling comments cannot move the number (a prior attempt trimmed ~1KB of comments and the render stayed byte-identical at 32677). Only real *rendered* content counts.

## The fix

The `ghcr-pull` reflector annotations enumerated ~45 literal namespaces **and** already ended with the catch-all regexes `org-.*,[a-z][a-z0-9-]*`. reflector evaluates each comma-separated entry as literal-OR-regex with **union** semantics; `org-.*` is proven honored in production (per-Org apps pull ghcr images live), so the trailing `[a-z][a-z0-9-]*` already matches every enumerated literal. The enumeration was pure bloat.

Collapsed both annotation values to a critical core (`org-services,catalyst,catalyst-system,gitea,harbor[,flux-system]`) plus **both catch-alls** — preserving the exact matched-namespace set while cutting ~781 rendered bytes. Behavior-neutral; rich WHY comments restored (they cost 0 measured bytes).

## Evidence

```
tofu test tests/multi_region.tftest.hcl → Success! 12 passed, 0 failed   (was: 1 failed, 32677B > 32576B)
```

Diff is 2 lines. Margin is now ~680B under the guardrail (192B below the Hetzner 32768 hard cap), so routine future additions won't re-trip it.

Refs #5127, #5086, #5057, #5042, #966