### PR TITLE
fix(catalyst-api): materialize chroot primary kubeconfig so multi-region clustermesh reconcile arms cutover (#5131)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -3282,8 +3282,8 @@ func countFullyMeshedRegions(statuses []ClusterMeshStatus) int {
 // rehydrated record before PutKubeconfig stamped it — but the kubeconfig
 // FILE itself always survives on the PVC at `<kubeconfigsDir>/<id>.yaml`.
 //
-// Returns the resolved, stat-readable path and true. READ-ONLY by
-// design: it must NOT stamp the resolved path back onto
+// Returns the resolved, stat-readable path and true. READ-ONLY with respect
+// to dep.Result by design: it must NOT stamp the resolved path back onto
 // dep.Result.KubeconfigPath. Deployment.State() hands the *Result
 // pointer to writeJSON, which marshals it OUTSIDE dep.mu — a write
 // here from the mesh-reconcile goroutine (markPhase1Done →
@@ -3296,6 +3296,18 @@ func countFullyMeshedRegions(statuses []ClusterMeshStatus) int {
 // (PVC unmount / wipe race) or whose kubeconfigsDir is unset returns
 // ("", false) so the caller can warn-and-skip rather than spin a retry
 // budget against a phantom path.
+//
+// #5131 — chroot self-materialize. On the in-cluster (chroot) Sovereign the
+// mothership never posts the PRIMARY (local region-a) kubeconfig — only
+// SECONDARY kubeconfigs arrive via POST /api/v1/sovereign/secondary-kubeconfig
+// at handover — so the conventional file is absent and the os.Stat above
+// missed forever, permanently skipping the ClusterMesh startup reconcile on a
+// perfectly healthy 2-region Sovereign. When the primary file is absent AND
+// we are the chroot that owns dep, materialize it from the in-cluster
+// ServiceAccount (a NO-NETWORK build — see materializeChrootPrimaryKubeconfig)
+// and re-stat. This is still dep.Result-write-free (it writes a FILE, not the
+// record), so the -race contract above holds. Best-effort: a materialize
+// failure keeps the honest ("", false) miss.
 func (h *Handler) resolvePrimaryKubeconfigPath(dep *Deployment) (string, bool) {
 	dep.mu.Lock()
 	kubeconfigPath := ""
@@ -3303,16 +3315,30 @@ func (h *Handler) resolvePrimaryKubeconfigPath(dep *Deployment) (string, bool) {
 		kubeconfigPath = dep.Result.KubeconfigPath
 	}
 	dep.mu.Unlock()
-	if kubeconfigPath == "" && h.kubeconfigsDir != "" {
-		kubeconfigPath = filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
+	// The conventional PVC path is the deterministic materialize target: the
+	// mothership's PutKubeconfig stamps this exact string, so on a chroot the
+	// recorded field (when present) already equals it.
+	conventional := ""
+	if h.kubeconfigsDir != "" {
+		conventional = filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
+	}
+	if kubeconfigPath == "" {
+		kubeconfigPath = conventional
 	}
 	if kubeconfigPath == "" {
 		return "", false
 	}
-	if _, err := os.Stat(kubeconfigPath); err != nil {
-		return "", false
+	if _, err := os.Stat(kubeconfigPath); err == nil {
+		return kubeconfigPath, true
 	}
-	return kubeconfigPath, true
+	// Primary file absent. On the chroot that owns dep, synthesize the local
+	// cluster's kubeconfig from the in-cluster ServiceAccount and re-stat.
+	if conventional != "" && h.materializeChrootPrimaryKubeconfig(dep, conventional) {
+		if _, err := os.Stat(conventional); err == nil {
+			return conventional, true
+		}
+	}
+	return "", false
 }
 
 // shouldStartupClusterMeshReconcile reports whether a rehydrated
@@ -3400,10 +3426,18 @@ func (h *Handler) clusterMeshReconcileStatusGate(dep *Deployment) bool {
 // clusterMeshStartupRetryInterval and launches runAutoEstablishClusterMesh the
 // FIRST time it passes, then returns (the establish loop owns convergence +
 // steady-state from there; its own clusterMeshLoopActive guard makes any
-// double-start a no-op). It stops early when the deployment leaves the
+// double-start a no-op). It stops when the deployment leaves the
 // ready/rescuable-timeout status gate (a wipe landed mid-wait — the kubeconfigs
-// are gone) and gives up after clusterMeshStartupRetryBudget so a genuinely-lost
-// kubeconfig (PVC unmount / wipe race) does NOT spin forever.
+// are gone).
+//
+// #5131 — the retry is LEVEL-triggered: it no longer gives up after a fixed
+// budget with "next trigger is a catalyst-api restart". A ready multi-region
+// Sovereign whose primary kubeconfig is momentarily unresolved (the #4811
+// dir-load race) OR structurally unresolved until materialized (the #5131
+// chroot case, where the mothership never posts the local region's kubeconfig)
+// keeps re-checking until it resolves and self-heals without a pod restart. The
+// only terminal edges are "resolved → launch establish" and "no longer a mesh
+// candidate → stop"; the budget field is repurposed as a heartbeat-log cadence.
 func (h *Handler) retryStartupClusterMeshReconcile(dep *Deployment) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -3418,20 +3452,34 @@ func (h *Handler) retryStartupClusterMeshReconcile(dep *Deployment) {
 	if interval <= 0 {
 		interval = clusterMeshStartupRetryIntervalDefault
 	}
-	budget := h.clusterMeshStartupRetryBudget
-	if budget <= 0 {
-		budget = clusterMeshStartupRetryBudgetDefault
+	// #5131 — the retry is LEVEL-triggered, not a one-shot budget. It
+	// re-evaluates the gate every `interval` and returns ONLY on a terminal
+	// edge: the deployment leaving the ready/rescuable-timeout candidate set (a
+	// wipe removed the kubeconfigs → nothing left to mesh), or the establish
+	// loop launching. It NEVER gives up "until a catalyst-api restart" — a
+	// transient miss (or, the #5131 chroot case, a primary kubeconfig that must
+	// first be materialized from the in-cluster ServiceAccount) self-heals
+	// without a pod restart. `clusterMeshStartupRetryBudget` is repurposed as
+	// the heartbeat cadence: how often an unresolved-but-still-candidate
+	// deployment re-logs that it is still waiting, so the level-triggered spin
+	// stays observable without logging on every interval.
+	heartbeat := h.clusterMeshStartupRetryBudget
+	if heartbeat <= 0 {
+		heartbeat = clusterMeshStartupRetryBudgetDefault
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), budget)
-	defer cancel()
+	// A background context: sleepCtx here only paces the loop by `interval`.
+	// The stop condition is the candidate gate below, never a deadline — that
+	// is what makes the retry level-triggered rather than restart-gated.
+	ctx := context.Background()
 
-	h.log.Info("clustermesh: startup reconcile deferred — primary kubeconfig unresolved at restore; retrying until it lands on the PVC",
+	h.log.Info("clustermesh: startup reconcile deferred — primary kubeconfig unresolved at restore; retrying (level-triggered) until it resolves or the deployment leaves the mesh-candidate set",
 		"id", dep.ID,
 		"interval", interval,
-		"budget", budget,
+		"heartbeat", heartbeat,
 	)
 
+	lastHeartbeat := time.Now()
 	for attempt := 1; ; attempt++ {
 		// Stop the moment the deployment stops being a mesh candidate — a wipe
 		// mid-wait removes the kubeconfigs, so there is nothing left to mesh.
@@ -3450,14 +3498,14 @@ func (h *Handler) retryStartupClusterMeshReconcile(dep *Deployment) {
 			go h.runAutoEstablishClusterMesh(dep)
 			return
 		}
-		if sleepErr := sleepCtx(ctx, interval); sleepErr != nil {
-			h.log.Warn("clustermesh: startup reconcile retry budget exhausted — primary kubeconfig never resolved; next trigger is a catalyst-api restart",
+		if time.Since(lastHeartbeat) >= heartbeat {
+			h.log.Warn("clustermesh: startup reconcile still waiting — primary kubeconfig unresolved; retrying on a level basis (no restart required)",
 				"id", dep.ID,
 				"attempts", attempt,
-				"err", sleepErr,
 			)
-			return
+			lastHeartbeat = time.Now()
 		}
+		_ = sleepCtx(ctx, interval)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig.go
@@ -1,0 +1,151 @@
+// clustermesh_primary_kubeconfig.go — #5131 primary (local) kubeconfig
+// self-materialization for the in-cluster (chroot) Sovereign.
+//
+// Root cause (#5131, root-caused live on hw259, a healthy fresh 2-region
+// Huawei Sovereign):
+//
+//	The mothership writes each provisioned Sovereign's PRIMARY (region-a)
+//	kubeconfig to its OWN PVC at <kubeconfigsDir>/<id>.yaml during Phase 0,
+//	and forwards only the SECONDARY region kubeconfigs to the chroot via
+//	POST /api/v1/sovereign/secondary-kubeconfig at handover. The chroot —
+//	the in-cluster Sovereign catalyst-api — therefore has the SECONDARY
+//	kubeconfig on disk (resolves fine) but NEVER receives the PRIMARY: the
+//	local region-a cluster is the one the chroot itself runs on, reachable
+//	via the mounted ServiceAccount, so no file was ever posted for it.
+//
+//	resolvePrimaryKubeconfigPath insists on a stat-readable FILE at
+//	<kubeconfigsDir>/<id>.yaml (or dep.Result.KubeconfigPath). On a chroot
+//	that file is absent, so os.Stat missed forever, shouldStartupCluster-
+//	MeshReconcile returned false on every attempt, and the retry loop
+//	exhausted its budget with "primary kubeconfig unresolved — next trigger
+//	is a catalyst-api restart". The ClusterMesh establish never ran, so the
+//	slot-16b SOVEREIGN_ENABLE_CNPG_PAIR flip + the multi-region convergence
+//	that arms self-sovereign-cutover never fired: the keystone stalled on a
+//	perfectly healthy 2-region mesh.
+//
+// Fix: on the chroot, MATERIALIZE the primary (local) kubeconfig from the
+// in-cluster ServiceAccount — NO network round-trip — and write it to the
+// canonical <kubeconfigsDir>/<id>.yaml path so every existing file-based
+// consumer (buildRegionSlots, clusterMeshDynamicClient, the jobs informer)
+// resolves the local cluster exactly as it does on the mothership.
+
+package handler
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// inClusterConfigForMaterialize is the seam the production path wires to
+// rest.InClusterConfig. Tests override it to inject a synthetic rest.Config
+// (or a forced error) without needing a real ServiceAccount mount.
+var inClusterConfigForMaterialize = rest.InClusterConfig
+
+// chrootServesDeployment reports whether THIS catalyst-api is the in-cluster
+// (chroot) Sovereign that OWNS dep — i.e. SOVEREIGN_FQDN is set on the process
+// AND equals dep.Request.SovereignFQDN. Mirrors sovereignDynamicClient /
+// tryDynamicClientLocked exactly so the primary-kubeconfig materialization uses
+// the identical discriminator: a chroot only ever self-materializes for the
+// single deployment it runs on, and the mothership (SOVEREIGN_FQDN unset) never
+// materializes at all.
+func (h *Handler) chrootServesDeployment(dep *Deployment) bool {
+	selfFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	if selfFQDN == "" {
+		return false
+	}
+	dep.mu.Lock()
+	depFQDN := strings.TrimSpace(dep.Request.SovereignFQDN)
+	dep.mu.Unlock()
+	return depFQDN != "" && depFQDN == selfFQDN
+}
+
+// inClusterKubeconfigYAML serializes the in-cluster rest.Config into a
+// kubeconfig YAML pointing at the LOCAL apiserver with the mounted
+// ServiceAccount bearer token + CA. This is a NO-NETWORK resolution of the
+// local cluster: rest.InClusterConfig reads only the KUBERNETES_SERVICE_*
+// env and the mounted token/CA files — it never dials the apiserver.
+func inClusterKubeconfigYAML() (string, error) {
+	cfg, err := inClusterConfigForMaterialize()
+	if err != nil {
+		return "", fmt.Errorf("in-cluster config: %w", err)
+	}
+	if strings.TrimSpace(cfg.Host) == "" {
+		return "", fmt.Errorf("in-cluster config has empty host")
+	}
+
+	caData := cfg.TLSClientConfig.CAData
+	if len(caData) == 0 && cfg.TLSClientConfig.CAFile != "" {
+		if b, rerr := os.ReadFile(cfg.TLSClientConfig.CAFile); rerr == nil {
+			caData = b
+		}
+	}
+	token := cfg.BearerToken
+	if token == "" && cfg.BearerTokenFile != "" {
+		if b, rerr := os.ReadFile(cfg.BearerTokenFile); rerr == nil {
+			token = strings.TrimSpace(string(b))
+		}
+	}
+
+	const name = "in-cluster"
+	apiCfg := clientcmdapi.NewConfig()
+	cluster := &clientcmdapi.Cluster{Server: cfg.Host}
+	if len(caData) > 0 {
+		cluster.CertificateAuthorityData = caData
+	} else {
+		// No CA available (unusual) — the helmwatch client path forces
+		// TLS-insecure anyway (issue #923), but a serialized kubeconfig
+		// must be self-consistent, so mark it insecure explicitly.
+		cluster.InsecureSkipTLSVerify = true
+	}
+	apiCfg.Clusters[name] = cluster
+	apiCfg.AuthInfos[name] = &clientcmdapi.AuthInfo{Token: token}
+	apiCfg.Contexts[name] = &clientcmdapi.Context{Cluster: name, AuthInfo: name}
+	apiCfg.CurrentContext = name
+
+	out, err := clientcmd.Write(*apiCfg)
+	if err != nil {
+		return "", fmt.Errorf("serialize in-cluster kubeconfig: %w", err)
+	}
+	return string(out), nil
+}
+
+// materializeChrootPrimaryKubeconfig writes the in-cluster (local, region-a)
+// kubeconfig for a chroot's OWN deployment to the canonical primary path when
+// that file is absent, and reports whether the file is now present. See the
+// package-doc (#5131) for the root cause. Best-effort + idempotent: a failure
+// (not a chroot, in-cluster config unavailable, write error) returns false and
+// the caller keeps its honest "primary unresolved" warn-and-skip, so a
+// genuinely-lost MOTHERSHIP kubeconfig is never masked.
+func (h *Handler) materializeChrootPrimaryKubeconfig(dep *Deployment, path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	if !h.chrootServesDeployment(dep) {
+		return false
+	}
+	raw, err := inClusterKubeconfigYAML()
+	if err != nil {
+		h.log.Warn("clustermesh: chroot primary kubeconfig materialize skipped — in-cluster config unavailable (#5131)",
+			"id", dep.ID, "err", err)
+		return false
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		h.log.Warn("clustermesh: chroot primary kubeconfig mkdir failed (#5131)",
+			"id", dep.ID, "dir", filepath.Dir(path), "err", err)
+		return false
+	}
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		h.log.Warn("clustermesh: chroot primary kubeconfig write failed (#5131)",
+			"id", dep.ID, "path", path, "err", err)
+		return false
+	}
+	h.log.Info("clustermesh: materialized chroot primary (local) kubeconfig from in-cluster ServiceAccount (#5131)",
+		"id", dep.ID, "path", path)
+	return true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig_test.go
@@ -1,0 +1,159 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// stubInClusterConfig temporarily points the materialize seam at a synthetic
+// rest.Config (or a forced error) so the test never needs a real
+// ServiceAccount mount. Restores the production hook on cleanup.
+func stubInClusterConfig(t *testing.T, cfg *rest.Config, err error) {
+	t.Helper()
+	prev := inClusterConfigForMaterialize
+	inClusterConfigForMaterialize = func() (*rest.Config, error) { return cfg, err }
+	t.Cleanup(func() { inClusterConfigForMaterialize = prev })
+}
+
+// TestResolvePrimaryKubeconfig_ChrootMaterializesInClusterPrimary is the #5131
+// reproduction: a healthy fresh 2-region Sovereign (hw259 shape) where the
+// SECONDARY (region-b) kubeconfig resolves fine but the PRIMARY (local
+// region-a) kubeconfig FILE is absent, because the mothership only ever posts
+// SECONDARY kubeconfigs to the chroot. Before the fix, resolvePrimaryKubeconfig-
+// Path's os.Stat missed forever, shouldStartupClusterMeshReconcile returned
+// false on every attempt, and the retry exhausted its budget with "primary
+// kubeconfig unresolved — next trigger is a catalyst-api restart", so the mesh
+// establish (and the multi-region convergence that arms self-sovereign-cutover)
+// never ran. The fix materializes the primary from the in-cluster
+// ServiceAccount (no network) so the startup reconcile PROCEEDS.
+func TestResolvePrimaryKubeconfig_ChrootMaterializesInClusterPrimary(t *testing.T) {
+	const (
+		depID      = "97917f0298eb14eb"
+		sovFQDN    = "tcm.example.io"
+		inClusHost = "https://10.0.0.1:6443"
+		saToken    = "sa-bearer-token-xyz"
+	)
+	twoRegions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+
+	newDep := func() *Deployment {
+		return &Deployment{
+			ID:     depID,
+			Status: "ready",
+			Request: provisioner.Request{
+				Regions:       twoRegions,
+				SovereignFQDN: sovFQDN,
+			},
+			// Result nil mimics the omitempty KubeconfigPath lost on a PVC restore.
+		}
+	}
+
+	t.Run("chroot-materializes-primary-and-reconcile-proceeds", func(t *testing.T) {
+		dir := t.TempDir()
+		h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+
+		// The SECONDARY (region-b) kubeconfig is present on the chroot's PVC —
+		// it was POSTed at handover — proving the asymmetry the bug hinges on.
+		secondaryPath := filepath.Join(dir, depID+"-me-east-215-b-1.yaml")
+		if err := os.WriteFile(secondaryPath, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+			t.Fatalf("seed secondary kubeconfig: %v", err)
+		}
+		primaryPath := filepath.Join(dir, depID+".yaml")
+		if _, err := os.Stat(primaryPath); err == nil {
+			t.Fatalf("precondition: primary kubeconfig must be ABSENT to reproduce #5131")
+		}
+
+		// Chroot mode: SOVEREIGN_FQDN matches the deployment's FQDN, and the
+		// in-cluster config resolves (no network — synthetic here).
+		t.Setenv("SOVEREIGN_FQDN", sovFQDN)
+		stubInClusterConfig(t, &rest.Config{
+			Host:        inClusHost,
+			BearerToken: saToken,
+			TLSClientConfig: rest.TLSClientConfig{
+				CAData: []byte("-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"),
+			},
+		}, nil)
+
+		dep := newDep()
+
+		// The startup reconcile must PROCEED (not skip) on the ready 2-region
+		// Sovereign: the primary is materialized from the in-cluster SA.
+		if !h.shouldStartupClusterMeshReconcile(dep) {
+			t.Fatalf("startup reconcile skipped — #5131 regression: chroot primary kubeconfig was not materialized")
+		}
+
+		// READ-ONLY(dep.Result) contract: materialization writes a FILE, never
+		// stamps the record (the State() -race guard, #3241).
+		if dep.Result != nil {
+			t.Errorf("gate mutated dep.Result: %+v — must stay nil", dep.Result)
+		}
+
+		// The primary file now exists at the canonical path…
+		raw, err := os.ReadFile(primaryPath)
+		if err != nil {
+			t.Fatalf("primary kubeconfig not materialized at %s: %v", primaryPath, err)
+		}
+		// …and it is a valid, buildable kubeconfig pointing at the local
+		// apiserver with the SA bearer token (this is what buildRegionSlots'
+		// NewKubernetesClientFromKubeconfig consumes for the primary slot).
+		restCfg, err := clientcmd.RESTConfigFromKubeConfig(raw)
+		if err != nil {
+			t.Fatalf("materialized primary kubeconfig does not parse: %v", err)
+		}
+		if restCfg.Host != inClusHost {
+			t.Errorf("materialized primary host = %q, want %q", restCfg.Host, inClusHost)
+		}
+		if restCfg.BearerToken != saToken {
+			t.Errorf("materialized primary token = %q, want %q", restCfg.BearerToken, saToken)
+		}
+
+		// resolvePrimaryKubeconfigPath resolves to the canonical path now.
+		got, ok := h.resolvePrimaryKubeconfigPath(dep)
+		if !ok || got != primaryPath {
+			t.Errorf("resolvePrimaryKubeconfigPath = (%q, %v), want (%q, true)", got, ok, primaryPath)
+		}
+	})
+
+	t.Run("mothership-does-not-materialize", func(t *testing.T) {
+		dir := t.TempDir()
+		h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+		// Mothership: SOVEREIGN_FQDN unset. Even if in-cluster config were
+		// resolvable, the chroot discriminator must gate materialization off so
+		// a genuinely-missing mothership primary still warn-and-skips.
+		t.Setenv("SOVEREIGN_FQDN", "")
+		stubInClusterConfig(t, &rest.Config{Host: inClusHost, BearerToken: saToken}, nil)
+
+		dep := newDep()
+		if h.shouldStartupClusterMeshReconcile(dep) {
+			t.Fatalf("mothership must NOT materialize a self-kubeconfig — reconcile should skip when the primary file is genuinely absent")
+		}
+		if _, err := os.Stat(filepath.Join(dir, depID+".yaml")); err == nil {
+			t.Errorf("mothership wrote a primary kubeconfig it must never synthesize")
+		}
+	})
+
+	t.Run("chroot-inclusterconfig-unavailable-skips", func(t *testing.T) {
+		dir := t.TempDir()
+		h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+		t.Setenv("SOVEREIGN_FQDN", sovFQDN)
+		// In-cluster config unavailable (off-cluster dev / CI) → best-effort
+		// no-op, honest skip, no file written.
+		stubInClusterConfig(t, nil, os.ErrNotExist)
+
+		dep := newDep()
+		if h.shouldStartupClusterMeshReconcile(dep) {
+			t.Fatalf("reconcile must skip when in-cluster config is unavailable")
+		}
+		if _, err := os.Stat(filepath.Join(dir, depID+".yaml")); err == nil {
+			t.Errorf("primary kubeconfig written despite in-cluster config being unavailable")
+		}
+	})
+}


### PR DESCRIPTION
## Root cause (#5131, root-caused live on hw259 — healthy fresh 2-region Huawei Sovereign)

The Sovereign catalyst-api's ClusterMesh **startup reconcile** was permanently skipped because it could not resolve the **PRIMARY (local, region-a) kubeconfig**, while the **SECONDARY (region-b)** resolved fine:

```
WARN clustermesh: startup reconcile skipped — primary kubeconfig unresolved on ready multi-region deployment  id=97917f0298eb14eb regions=2
INFO secondary-kubeconfig: registered  region=me-east-215-b-1 clusterID=97917f0298eb14eb-me-east-215-b-1
WARN clustermesh: startup reconcile retry budget exhausted — primary kubeconfig never resolved; next trigger is a catalyst-api restart  attempts=36 err="context deadline exceeded"
```

The asymmetry is structural, not a race:

- The **mothership** writes each Sovereign's PRIMARY kubeconfig to its OWN PVC at `<kubeconfigsDir>/<id>.yaml` during Phase 0, and forwards only the **SECONDARY** region kubeconfigs to the chroot via `POST /api/v1/sovereign/secondary-kubeconfig` at handover.
- The **chroot** (the in-cluster Sovereign catalyst-api) therefore has the secondary on disk (`<id>-<region>.yaml`) but **never receives the primary** — the local region-a cluster is the one the chroot itself runs on, reachable via its mounted ServiceAccount, so no file is ever posted for it.
- `resolvePrimaryKubeconfigPath` insisted on a stat-readable FILE at the canonical path, so `os.Stat` missed forever → `shouldStartupClusterMeshReconcile` returned false every attempt → the `#4811` retry exhausted its budget and declared "next trigger is a catalyst-api restart".

`err="context deadline exceeded"` is the retry budget's own `context.WithTimeout` firing — **not** a network dial. There was no round-trip; the primary file simply never existed on the chroot.

**Consequence:** `runAutoEstablishClusterMesh` never ran, so the slot-16b `SOVEREIGN_ENABLE_CNPG_PAIR` flip and the multi-region convergence that arms `self-sovereign-cutover` never fired — the multi-region keystone stalled on a perfectly healthy mesh (both regions Ready, clustermesh formed 1/1).

## Fix

**1. Materialize the chroot's primary (local) kubeconfig — no network.** When the primary file is absent AND this catalyst-api is the chroot that owns the deployment (same `SOVEREIGN_FQDN == dep.Request.SovereignFQDN` discriminator as `sovereignDynamicClient`/`tryDynamicClientLocked`), synthesize the kubeconfig from `rest.InClusterConfig()` (reads only the mounted SA token + CA + `KUBERNETES_SERVICE_*` env — no apiserver dial) and write it to the canonical `<kubeconfigsDir>/<id>.yaml`. Every existing file-based consumer (`buildRegionSlots`, `clusterMeshDynamicClient`, the jobs informer) then resolves the local cluster exactly as on the mothership. `dep.Result` is never mutated — a FILE is written, not the record — so the `State()` `-race` contract (#3241) holds. New file `clustermesh_primary_kubeconfig.go`; `resolvePrimaryKubeconfigPath` gains the materialize fallback.

**2. Level-triggered retry.** `retryStartupClusterMeshReconcile` no longer gives up after a fixed budget with "next trigger is a catalyst-api restart". It re-checks the gate until the primary resolves (self-heal) or the deployment leaves the mesh-candidate set (a wipe). The former budget field is repurposed as a heartbeat-log cadence so the level-triggered spin stays observable. A transient miss now self-heals without a pod restart.

## Test

`TestResolvePrimaryKubeconfig_ChrootMaterializesInClusterPrimary` reproduces the hw259 shape — **secondary present, primary absent, chroot mode** — via a `rest.Config` seam (`inClusterConfigForMaterialize`) so no real SA mount is needed. It asserts:

- the startup reconcile **PROCEEDS** (not skipped) on the ready 2-region Sovereign,
- the materialized kubeconfig parses and carries the in-cluster host + SA bearer token (what `buildRegionSlots` consumes),
- `dep.Result` stays nil (read-only contract),
- the **mothership** path never self-materializes, and an unavailable in-cluster config honestly skips.

## Gate

```
go build ./...      # exit 0
go vet ./internal/handler/   # exit 0
go test ./...       # all packages ok, 0 failures (handler 152.9s)
go test -race ./internal/handler/ -run 'ResolvePrimaryKubeconfig|ClusterMesh|StartupClusterMesh|GetDeploymentEvents_ReturnsComponentEvents'   # ok, race-clean
```

Refs #5131

🤖 Generated with [Claude Code](https://claude.com/claude-code)