### PR TITLE
fix(bp-cnpg-pair): failover-readiness probe no longer false-negatives on a caught-up sync standby (Refs #5133)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -199,7 +199,11 @@ spec:
       # PRIMARY's walsender (not a cascaded local standby) → sync_state=sync.
       # 0.2.9 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock.
-      version: 0.2.10
+      # 0.2.11 (#5133): failover-readiness probe fix — authenticates as
+      # streaming_replica (postgres superuser disabled) and measures apply
+      # lag via LSN receive-vs-replay so a caught-up SYNCHRONOUS standby is
+      # correctly Ready/promotable. Unblocks region-kill DR promotion (P3).
+      version: 0.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -9,7 +9,12 @@ spec:
   # 0.2.9 (#4846): cross-region DR admission is an identity-based
   # CiliumNetworkPolicy (io.cilium.k8s.policy.cluster) — the 0.2.8 ipBlock was
   # inert for ClusterMesh remote endpoints. values crossRegionPeerClusters.
-  version: 0.2.10
+  # 0.2.11 (#5133): failover-readiness probe no longer false-negatives on a
+  # caught-up SYNCHRONOUS standby — authenticates as streaming_replica (the
+  # postgres superuser is disabled) and measures apply lag via LSN
+  # receive-vs-replay (idle- + region-kill-safe). Unblocks region-kill DR
+  # promotion (Pillar 3).
+  version: 0.2.11
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.11 (#5133): FIX the failover-readiness probe false-negative that
+# blocked region-kill DR promotion (Pillar 3). Two defects in one probe:
+# (a) AUTH — it connected as `user=postgres`, but both Cluster CRs set
+# `enableSuperuserAccess: false`, so the psql auth FAILED on every poll →
+# `|| echo 999999` → the probe reported `lag=999999 … NOT promotable` on a
+# byte-caught-up SYNCHRONOUS standby and stayed 0/1 Ready forever (live on
+# hw260). It now authenticates as `streaming_replica` via the CNPG-issued
+# client cert (pg_hba `hostssl postgres streaming_replica all cert`),
+# mounting this replica cluster's own `<replica>-replication` + `<replica>-ca`
+# Secrets. (b) LAG MEASURE — the old `now() - pg_last_xact_replay_timestamp()`
+# is a replay-recency clock that grows unbounded on an idle-but-caught-up
+# standby (false lag) and returns NULL when nothing has been replayed. It now
+# compares `pg_last_wal_replay_lsn()` vs `pg_last_wal_receive_lsn()`: applied
+# == received → 0 lag (idle-safe AND region-kill-safe — the receiver freezes
+# when region-A dies and replay catches up → promotable, no dead-primary dep).
+# Only a genuinely-behind async standby falls through to a seconds-based apply
+# lag the `targetLagSeconds` threshold still gates. Probe now targets the
+# replica cluster's `-rw` Service (designated primary). Lockstep slot 16b pin →
+# 0.2.11. No resource-count change (volumes added to the existing Deployment).
 # 0.2.7 (#3829, #3375): default the Continuum CR's lease witness to
 # `k8s-lease` (a native coordination.k8s.io/v1 Lease in the control
 # plane — zero external dependency, durable etcd CAS) and DROP the
@@ -28,7 +47,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.10
+version: 0.2.11
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -68,6 +87,46 @@ description: |
 
   Changelog
   ─────────
+  0.2.11 (2026-07-16, failover-readiness false-negative fix — region-kill DR promotion, Refs #5133)
+    - FIX (Pillar-3 region-kill DR): the failover-readiness probe reported
+      `lag=999999s ≥ threshold=30s — NOT promotable` on a region-b replica
+      that was a byte-caught-up SYNCHRONOUS standby (pg_stat_replication on
+      the primary: state=streaming, sync_state=sync, empty replay_lag), so it
+      sat 0/1 Ready and a region-kill of region-a would NOT have promoted
+      region-b even though the replica was genuinely promotable. Caught live
+      on hw260 (dep 1e42924ea1656aac, 2026-07-16). TWO defects:
+        • AUTH (the always-firing cause of the 999999 sentinel): the probe
+          connected as `user=postgres`, but both Cluster CRs set
+          `enableSuperuserAccess: false`, so that superuser can NEVER
+          authenticate over TCP — every poll failed auth → `|| echo 999999`.
+          The probe now authenticates as `streaming_replica` via the
+          CNPG-issued client cert (CNPG default pg_hba
+          `hostssl postgres streaming_replica all cert`), mounting THIS replica
+          cluster's own `<replica>-replication` (tls.crt/tls.key) Secret (0440,
+          root:26 — the perms libpq requires for an sslkey) with sslmode=require.
+          Same streaming_replica-cert pattern the externalCluster streaming
+          connection already uses.
+        • LAG MEASURE: `now() - pg_last_xact_replay_timestamp()` is a
+          replay-recency clock, NOT a replication-lag measure — on a
+          caught-up standby of an idle primary it grows unbounded (false lag)
+          and returns NULL when no xact has been replayed. Replaced with an
+          LSN comparison: `pg_last_wal_replay_lsn() >= pg_last_wal_receive_lsn()`
+          → the standby applied everything it received → 0 lag. This is
+          idle-safe AND region-kill-safe (when region-a dies the WAL receiver
+          freezes and replay catches up to it → 0 → promotable, with no
+          dependency on the dead primary). A genuinely-behind async standby
+          (received > replayed) still falls through to a seconds-based apply
+          lag the `targetLagSeconds` threshold gates.
+    - The probe now targets the replica cluster's `-rw` Service (the
+      designated primary CNPG would promote) instead of `-r` (round-robin).
+    - Render-gate test (chart/tests/cnpg-pair-render.sh) Case 13 asserts the
+      probe authenticates as streaming_replica (NOT the disabled postgres
+      superuser), uses the LSN receive-vs-replay caught-up check, and mounts
+      the replication cert + CA.
+    - Default-OFF contract UNCHANGED: cnpgPair.enabled=false renders ZERO
+      resources on BOTH sides. Resource COUNTS unchanged (one Secret volume
+      added to the existing failover-readiness Deployment).
+
   0.2.6 (2026-06-24, cross-region replica streams from PRIMARY not a standby — RPO=0 completion, Refs #3740 / #3375)
     - FIX (Pillar-3 zero-tx-loss, the missing half of the 0.2.5 fix): the
       ClusterMesh replication-source Service (`-primary-mesh`, consumed by

--- a/platform/cnpg-pair/chart/templates/failover-readiness.yaml
+++ b/platform/cnpg-pair/chart/templates/failover-readiness.yaml
@@ -1,11 +1,34 @@
 {{- /*
 Failover-readiness probe Pod.
 
-Polls the replica's CNPG `-r` Service for `pg_last_wal_replay_lsn`
-vs the primary's `pg_current_wal_lsn`; when the lag falls below
-`cnpgPair.walStreaming.targetLagSeconds` the Pod's Ready condition
-flips true and Continuum K-Cont-2's switchover sequencer treats the
-replica as promotable.
+Polls the replica cluster's designated primary (its CNPG `-rw`
+Service) for the WAL APPLY lag and, when that lag falls below
+`cnpgPair.walStreaming.targetLagSeconds`, flips the Pod's Ready
+condition true so Continuum K-Cont-2's switchover sequencer treats
+the replica as promotable.
+
+Lag measure (#5133): compare the standby's `pg_last_wal_replay_lsn()`
+against its `pg_last_wal_receive_lsn()`. When the standby has REPLAYED
+everything its WAL receiver has RECEIVED the apply lag is zero — this
+is idle-safe (a caught-up SYNCHRONOUS standby of an idle primary reads
+0, NOT an ever-growing `now() - pg_last_xact_replay_timestamp()` clock
+skew) AND region-kill-safe (during a region-A kill the receiver freezes
+and replay catches up to it → 0 → promotable, with no dependency on the
+dead primary being reachable). Only a genuinely-behind (async) standby —
+received WAL not yet applied — falls through to a seconds-based apply
+lag that the `targetLagSeconds` threshold gates.
+
+🛑 AUTH (#5133 root cause): the probe authenticates as the
+`streaming_replica` role via its CNPG-issued client cert (CNPG's default
+pg_hba admits `hostssl postgres streaming_replica all cert`). The old
+probe connected as `user=postgres`, but BOTH Cluster CRs set
+`enableSuperuserAccess: false`, so that superuser can NEVER authenticate
+over TCP — every poll failed auth → `|| echo 999999` → the probe emitted
+`lag=999999 … NOT promotable` on a byte-caught-up SYNCHRONOUS standby and
+stayed 0/1 Ready forever, blocking region-kill promotion (Pillar 3). The
+`streaming_replica` client cert lives in this replica cluster's own
+CNPG-generated `<replica>-replication` Secret (same pattern the
+externalCluster streaming connection uses).
 
 Implementation: a single-replica Deployment running a tiny shell
 loop with psql + a /tmp/ready file watched by an exec readiness
@@ -78,19 +101,45 @@ spec:
         - name: probe
           image: {{ include "cnpg-pair.imageRef" . | quote }}
           imagePullPolicy: {{ .Values.cnpgPair.image.pullPolicy | quote }}
-          # Loop: query lag every 10s, write /tmp/ready when below
-          # threshold, remove it when above. The exec readinessProbe
+          # Loop: query the apply lag every 10s, write /tmp/ready when
+          # below threshold, remove it when above. The exec readinessProbe
           # then surfaces the boolean to K8s and to Continuum via
           # `kubectl get pod ... -o jsonpath=.status.conditions`.
-          # The CNPG `-r` Service is the read-only endpoint of the
-          # local (replica) Cluster CR — it always exists once CNPG
-          # has reconciled at least one instance Pod.
+          # We target the replica cluster's `-rw` Service — the DESIGNATED
+          # primary (the instance CNPG would promote), whose WAL receiver
+          # reflects the true CROSS-REGION stream. It always exists once
+          # CNPG has reconciled the replica Cluster's designated primary.
           command: ["/bin/sh", "-c"]
           args:
             - |
               set -eu
-              REPLICA_HOST="{{ include "cnpg-pair.replicaName" . }}-r"
+              REPLICA_HOST="{{ include "cnpg-pair.replicaName" . }}-rw"
               THRESHOLD={{ .Values.cnpgPair.walStreaming.targetLagSeconds }}
+              # streaming_replica mutual-TLS (see the header rationale) —
+              # the postgres superuser is disabled on the Cluster CR, so
+              # the probe MUST authenticate with the streaming_replica
+              # client cert (CNPG pg_hba: `hostssl postgres streaming_replica
+              # all cert`). sslmode=require + the client cert is the canonical
+              # CNPG connection shape used elsewhere in the platform (the
+              # replica's own externalCluster streaming connection uses the
+              # exact same pattern); the SERVER-side `cert` method verifies
+              # this client cert against the cluster CA.
+              CONN="host=${REPLICA_HOST} port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              # Apply lag in seconds. CASE ladder (#5133):
+              #  1. NOT in recovery      → already promoted → 0 (ready).
+              #  2. replay_lsn caught up to receive_lsn → applied all
+              #     received WAL → 0 (idle-safe + region-kill-safe: no
+              #     `now()-last_xact_replay` clock skew, no dead-primary dep).
+              #  3. otherwise (genuinely behind) → seconds since the last
+              #     replayed xact, so `targetLagSeconds` gates async lag;
+              #     a fresh join that has replayed nothing → effectively
+              #     infinite (NOT promotable).
+              LAG_SQL="SELECT CASE
+                WHEN NOT pg_is_in_recovery() THEN 0
+                WHEN pg_last_wal_receive_lsn() IS NOT NULL
+                     AND pg_last_wal_replay_lsn() >= pg_last_wal_receive_lsn() THEN 0
+                ELSE COALESCE(GREATEST(0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::bigint), 2147483647)
+              END"
               while true; do
                 # Heartbeat first — the livenessProbe reads /tmp/alive's
                 # mtime to detect a WEDGED loop (a hung psql or a stalled
@@ -98,9 +147,13 @@ spec:
                 # is a SEPARATE signal (promotability), so the two probes
                 # answer different questions: alive vs promotable.
                 : > /tmp/alive
-                LAG=$(psql "host=${REPLICA_HOST} port=5432 user=postgres dbname=postgres sslmode=require" \
-                       -tAXc "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::int" 2>/dev/null \
-                       || echo "999999")
+                # 999999 is the CONNECTION/QUERY-FAILURE sentinel ONLY (psql
+                # non-zero, or an empty/non-numeric result). A caught-up
+                # standby now returns 0 from the CASE above — it can never
+                # collapse to this sentinel the way the old superuser-auth
+                # failure did.
+                LAG=$(psql "${CONN}" -tAXc "${LAG_SQL}" 2>/dev/null || echo "999999")
+                case "${LAG}" in ''|*[!0-9]*) LAG=999999 ;; esac
                 if [ "${LAG}" -lt "${THRESHOLD}" ]; then
                   date -u +"%FT%TZ replica lag=${LAG}s < threshold=${THRESHOLD}s — promotable" > /tmp/ready
                 else
@@ -151,7 +204,24 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            # streaming_replica client cert + key (CNPG-issued for THIS
+            # replica cluster) — mounted 0440 root:26 so libpq (uid 26)
+            # accepts the key (root-owned, group-read-only, no world).
+            - name: replication-cert
+              mountPath: /tls/client
+              readOnly: true
       volumes:
         - name: tmp
           emptyDir: {}
+        # CNPG generates the streaming_replica client cert for EVERY Cluster
+        # CR it reconciles — including this replica Cluster — so this Secret
+        # exists locally on cluster-B (no cross-cluster sync needed; unlike
+        # the primary's `-primary-replication` the replica streams FROM).
+        # defaultMode 0440 keeps the private key readable by the postgres
+        # group (fsGroup 26) yet inaccessible to world — the exact perms
+        # libpq requires for an sslkey.
+        - name: replication-cert
+          secret:
+            secretName: {{ include "cnpg-pair.replicaName" . }}-replication
+            defaultMode: 0440
 {{- end }}

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -605,4 +605,46 @@ if grep -q 'CiliumNetworkPolicy' "$TMP/replica.yaml"; then
   echo "FAIL: #4846 replica render WITHOUT crossRegionPeerClusters must emit ZERO CiliumNetworkPolicy." >&2; exit 1; fi
 echo "  PASS (1 CNP per side, identity In-list, no ipBlock; empty peers → zero CNP)"
 
+# ── Case 13: #5133 — failover-readiness probe auth + lag measure ─
+# The probe on hw260 reported `lag=999999 … NOT promotable` on a byte-caught-up
+# SYNCHRONOUS standby and stayed 0/1 Ready, which would block region-kill DR
+# promotion (Pillar 3). Root cause: it connected as the `postgres` superuser
+# (DISABLED by enableSuperuserAccess:false → auth fails → `|| echo 999999`
+# sentinel) and measured `now() - pg_last_xact_replay_timestamp()` (a
+# replay-recency clock that false-lags on an idle-but-caught-up standby). The
+# 0.2.11 probe authenticates as streaming_replica via the CNPG-issued client
+# cert and measures apply lag via LSN receive-vs-replay (idle- + region-kill-
+# safe). Assert the rendered side=replica probe on all four counts.
+echo "[render] Case 13: #5133 failover-readiness probe authenticates as streaming_replica + measures LSN apply-lag"
+# 1. Authenticates as streaming_replica — NEVER the disabled postgres superuser.
+grep -q 'user=streaming_replica' "$TMP/replica.yaml" || {
+  echo "FAIL: #5133 failover-readiness probe does not authenticate as streaming_replica." >&2
+  exit 1
+}
+if grep -q 'user=postgres' "$TMP/replica.yaml"; then
+  echo "FAIL: #5133 failover-readiness probe still connects as the postgres superuser — enableSuperuserAccess:false makes that auth fail on every poll (the 999999 sentinel root cause)." >&2
+  grep -nE 'user=postgres' "$TMP/replica.yaml" >&2
+  exit 1
+fi
+# 2. Idle-safe + region-kill-safe LSN apply-lag: replay_lsn caught up to
+#    receive_lsn → 0 (promotable), NOT the old clock-skew measure.
+grep -qF 'pg_last_wal_replay_lsn() >= pg_last_wal_receive_lsn()' "$TMP/replica.yaml" || {
+  echo "FAIL: #5133 failover-readiness probe missing the LSN receive-vs-replay caught-up check (a caught-up SYNCHRONOUS standby must read 0 lag → promotable)." >&2
+  grep -nE 'pg_last_wal' "$TMP/replica.yaml" >&2
+  exit 1
+}
+# 3. Mounts THIS replica cluster's own streaming_replica client cert Secret.
+grep -q 'secretName: smoke-cnpg-pair-bp-cnpg-pair-replica-replication' "$TMP/replica.yaml" || {
+  echo "FAIL: #5133 failover-readiness probe does not mount the <replica>-replication client cert Secret." >&2
+  exit 1
+}
+# 4. Targets the replica cluster's -rw Service (the designated primary CNPG
+#    would promote), not the round-robin -r endpoint.
+grep -q 'REPLICA_HOST="smoke-cnpg-pair-bp-cnpg-pair-replica-rw"' "$TMP/replica.yaml" || {
+  echo "FAIL: #5133 failover-readiness probe does not target the replica cluster's -rw (designated-primary) Service." >&2
+  grep -nE 'REPLICA_HOST=' "$TMP/replica.yaml" >&2
+  exit 1
+}
+echo "  PASS (streaming_replica cert auth, LSN apply-lag, -rw target)"
+
 echo "[render] All bp-cnpg-pair render gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.10"
+    version: "0.2.11"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## Refs #5133

Fixes the `cnpg-pair` failover-readiness probe reporting a false `lag=999999s ≥ threshold=30s — NOT promotable` on a region-b replica that is a healthy, byte-caught-up **synchronous** standby — which would block region-kill DR promotion (Pillar 3). Root-caused live on hw260.

## RCA — two defects in one probe

**1. AUTH (the always-firing cause of the `999999` sentinel).**
The probe connected as `user=postgres`:
```
psql "host=<replica>-r ... user=postgres ... sslmode=require" -tAXc "..." 2>/dev/null || echo "999999"
```
But **both** cnpg-pair Cluster CRs set `enableSuperuserAccess: false` (primary-cluster.yaml + replica-cluster.yaml). With the superuser disabled, a `user=postgres` TCP connection can **never** authenticate — so psql exited non-zero on *every* poll and the `|| echo "999999"` fallback fired permanently. The `999999` was never real lag; it was a connection/auth-failure sentinel, exactly as the issue describes. The probe therefore stayed `0/1 Ready` regardless of actual replication state.

**2. LAG MEASURE (latent, would false-lag even if auth worked).**
`now() - pg_last_xact_replay_timestamp()` is a *replay-recency clock*, not a replication-lag measure. On a caught-up standby of an idle/near-idle primary (the steady state of a fresh 2-region prov) it grows without bound with wall-clock idle time, and returns `NULL` when no transaction has been replayed — both push a genuinely-promotable standby over the 30s threshold.

## Fix

- **Auth:** authenticate as `streaming_replica` via the CNPG-issued client cert — CNPG's default `pg_hba` admits `hostssl postgres streaming_replica all cert`. The cert is mounted from this replica cluster's own CNPG-generated `<replica>-replication` Secret (`tls.crt`/`tls.key`), `defaultMode: 0440` (root:26 — the perms libpq requires for an sslkey). This is the identical streaming_replica-cert pattern the replica's `externalCluster` streaming connection and `products/sandbox/.../sandbox_db.go` already use.
- **Lag measure:** compare `pg_last_wal_replay_lsn()` vs `pg_last_wal_receive_lsn()`. When the standby has replayed everything it received, apply lag is `0` — **idle-safe** (a caught-up sync standby reads 0 even when the primary is idle) and **region-kill-safe** (when region-a dies the WAL receiver freezes and replay catches up to it → 0 → promotable, with **no dependency on the dead primary being reachable**). A genuinely-behind async standby (`received > replayed`) still falls through to a seconds-based apply lag that `targetLagSeconds` (30s) gates — threshold semantics preserved.
- Probe now targets the replica cluster's `-rw` Service (the designated primary CNPG would promote) instead of `-r` (round-robin).
- `999999` is now the connection/query-failure sentinel **only** (with a numeric guard) — a caught-up standby returns `0` from the SQL and can never collapse to the sentinel the way the superuser-auth failure did.

```sql
SELECT CASE
  WHEN NOT pg_is_in_recovery() THEN 0
  WHEN pg_last_wal_receive_lsn() IS NOT NULL
       AND pg_last_wal_replay_lsn() >= pg_last_wal_receive_lsn() THEN 0
  ELSE COALESCE(GREATEST(0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::bigint), 2147483647)
END
```

## Test

`chart/tests/cnpg-pair-render.sh` **Case 13** (new) asserts the rendered side=replica probe:
1. authenticates as `streaming_replica` and **not** the disabled `postgres` superuser,
2. uses the LSN `pg_last_wal_replay_lsn() >= pg_last_wal_receive_lsn()` caught-up check,
3. mounts the `<replica>-replication` client-cert Secret,
4. targets the `-rw` (designated-primary) Service.

## Version lockstep

Chart `0.2.10 → 0.2.11`; `blueprint.yaml` and bootstrap-kit slot `16b-bp-cnpg-pair.yaml` pins bumped in lockstep (Inviolable Principle #13). Resource **counts unchanged** (one Secret volume added to the existing Deployment); `cnpgPair.enabled=false` still renders **zero** resources on both sides.

## Build/test evidence

```
$ helm lint platform/cnpg-pair/chart
1 chart(s) linted, 0 chart(s) failed

$ bash platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
[render] Case 1 … Case 12 … PASS
[render] Case 13: #5133 failover-readiness probe authenticates as streaming_replica + measures LSN apply-lag
  PASS (streaming_replica cert auth, LSN apply-lag, -rw target)
[render] All bp-cnpg-pair render gates green.

$ sh -n / dash -n  (extracted probe shell)   → SHELL SYNTAX OK / DASH SYNTAX OK
$ helm template … side=replica               → 5 non-test resources (unchanged)
```

Pure chart/render fix — no live cluster touched, no Sovereign wiped/fired. Not a runtime walk; the region-kill promotion walk on a fresh 2-region prov remains the acceptance step before the issue is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)