### PR TITLE
fix(catalyst-api): recover EVS-backstop creds from workdir tfvars on body-less wipe (Refs #5135)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -559,6 +559,27 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 
 		credsRaw := buildWipeCredsRaw(providerName, body, dep.Request)
+
+		// #5135 / #5028 — WORKDIR-CRED FALLBACK for the post-destroy EVS
+		// backstop. On the canonical body-less wipe (`{}`) AFTER a
+		// catalyst-api Pod roll, dep.Request's Huawei AK/SK are gone (secrets
+		// are GC'd from the in-memory Request post-writeTfvars and do not
+		// survive a restart), so buildWipeCredsRaw yields empty
+		// access_key/secret_key here even though providerName resolves to
+		// "huawei" from the per-region spec. tofu destroy still authenticates
+		// (the provider reads the workdir tfvars directly), but
+		// huaweiSweepCredsFromRaw would return ok=false below and the #5028
+		// EVS backstop would SILENTLY SKIP — stranding every CSI `pvc-*`
+		// volume as status=available toward the HCS quota (413
+		// VolumeLimitExceeded on the next fresh prov). Recover the creds from
+		// the durable per-deployment tofu.auto.tfvars.json on the
+		// catalyst-api-deployments PVC while the workdir still exists (tofu
+		// destroy may remove it below). Only empty keys are filled —
+		// body/request-provided values always win.
+		if applyWorkdirEVSCredsFallback(providerName, credsRaw, filepath.Join(h.tofuWorkDir(), id)) {
+			emit("wipe", "info", "huawei: #5028 EVS backstop creds recovered from workdir tofu.auto.tfvars.json (body/request creds empty after Pod roll) (#5135)")
+		}
+
 		wipeSpec := providers.WipeSpec{
 			DeploymentID:  dep.ID,
 			SovereignFQDN: dep.Request.SovereignFQDN,

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop.go
@@ -84,6 +84,47 @@ func (h *Handler) reapDeploymentEVSBackstop(ctx context.Context, reaper evsReape
 	return reaped
 }
 
+// applyWorkdirEVSCredsFallback fills the empty Huawei AK/SK/project_id/region
+// keys in the resolved wipe-creds map from the durable per-deployment
+// tofu.auto.tfvars.json — the #5135 fix. On the canonical body-less wipe after
+// a catalyst-api Pod roll, buildWipeCredsRaw yields empty access_key/secret_key
+// (dep.Request secrets don't survive a restart), which would make
+// huaweiSweepCredsFromRaw return ok=false and silently skip the #5028
+// post-destroy EVS backstop. This recovers the creds from disk (which tofu
+// destroy has not yet removed at call time) so the backstop still reaps this
+// dep's stranded CSI `pvc-*` volumes.
+//
+// Contract: no-op (returns false) for non-huawei providers, when AK+SK are
+// already present (body/request creds win — only empty keys are filled), or
+// when the workdir tfvars is missing/unparseable (honest skip, never a panic).
+// Returns true when at least one previously-empty key was filled, so the caller
+// can emit an observable progress line.
+func applyWorkdirEVSCredsFallback(providerName string, credsRaw map[string]string, workdir string) bool {
+	if credsRaw == nil || !strings.EqualFold(strings.TrimSpace(providerName), "huawei") {
+		return false
+	}
+	// Body/request already supplied the authenticating pair — nothing to fill.
+	if strings.TrimSpace(credsRaw["access_key"]) != "" && strings.TrimSpace(credsRaw["secret_key"]) != "" {
+		return false
+	}
+	hw, ok := loadHuaweiCredsFromTfvars(workdir)
+	if !ok {
+		return false
+	}
+	filled := false
+	fill := func(key, val string) {
+		if strings.TrimSpace(credsRaw[key]) == "" && strings.TrimSpace(val) != "" {
+			credsRaw[key] = val
+			filled = true
+		}
+	}
+	fill("access_key", hw.AccessKey)
+	fill("secret_key", hw.SecretKey)
+	fill("project_id", hw.ProjectID)
+	fill("region", hw.Region)
+	return filled
+}
+
 // huaweiSweepCredsFromRaw builds the sweep creds from the resolved wipe creds
 // map (buildWipeCredsRaw output). This is the reliable in-band source — the
 // per-deployment tfvars the janitor's discoverHuaweiCreds walks may already be

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_evs_backstop_test.go
@@ -4,8 +4,28 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
+
+// writeTfvars writes a tofu.auto.tfvars.json with the given Huawei creds into
+// dir and returns dir (the per-deployment workdir the fallback reads).
+func writeTfvars(t *testing.T, dir, ak, sk, projectID, region string) string {
+	t.Helper()
+	body := `{`
+	body += `"huawei_access_key":"` + ak + `",`
+	body += `"huawei_secret_key":"` + sk + `",`
+	body += `"huawei_project_id":"` + projectID + `",`
+	body += `"huawei_region":"` + region + `"`
+	body += `}`
+	if err := os.WriteFile(filepath.Join(dir, "tofu.auto.tfvars.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write tfvars: %v", err)
+	}
+	return dir
+}
 
 // recordingEVSReaper captures the arguments the wipe path passes to
 // SweepOrphanEVS so the wiring (right active set + destructive=true) is
@@ -79,6 +99,90 @@ func TestReapDeploymentEVSBackstop_NoOpOnMissingCredsOrReaper(t *testing.T) {
 	reaper := &recordingEVSReaper{ret: 3}
 	if n := h.reapDeploymentEVSBackstop(context.Background(), reaper, "id0", huaweiSweepCreds{AK: "ak"}, nil); n != 0 || reaper.called {
 		t.Fatalf("incomplete creds must no-op (reaped=%d called=%v)", n, reaper.called)
+	}
+}
+
+// TestApplyWorkdirEVSCredsFallback_BodylessWipeAfterPodRoll — #5135. On the
+// canonical body-less wipe after a catalyst-api Pod roll, buildWipeCredsRaw
+// yields an empty huawei creds map (dep.Request secrets are gone). Without the
+// fallback, huaweiSweepCredsFromRaw returns ok=false and the #5028 EVS backstop
+// silently skips — stranding CSI pvc-* volumes toward the HCS quota. The
+// fallback must recover AK/SK/project_id/region from the workdir tfvars so the
+// backstop is invoked with non-empty creds.
+func TestApplyWorkdirEVSCredsFallback_BodylessWipeAfterPodRoll(t *testing.T) {
+	workdir := writeTfvars(t, t.TempDir(), "ak-disk", "sk-disk", "proj-disk", "me-east-777")
+
+	// Body-less wipe + Pod-rolled dep.Request (no huawei secrets) → all empty.
+	credsRaw := buildWipeCredsRaw("huawei", wipeRequest{}, provisioner.Request{})
+
+	// PROVE THE WEDGE: before the fallback the backstop would skip.
+	if _, ok := huaweiSweepCredsFromRaw(credsRaw); ok {
+		t.Fatal("precondition wrong: creds resolved without the fallback — test would not exercise #5135")
+	}
+
+	if !applyWorkdirEVSCredsFallback("huawei", credsRaw, workdir) {
+		t.Fatal("fallback did NOT fire on empty creds with a valid workdir tfvars (#5135 — backstop would silently skip)")
+	}
+
+	sweep, ok := huaweiSweepCredsFromRaw(credsRaw)
+	if !ok {
+		t.Fatal("creds still incomplete after the workdir fallback — huaweiSweepCredsFromRaw ok=false")
+	}
+	if sweep.AK != "ak-disk" || sweep.SK != "sk-disk" || sweep.ProjectID != "proj-disk" || sweep.Region != "me-east-777" {
+		t.Fatalf("recovered creds wrong: %+v", sweep)
+	}
+
+	// End-to-end wiring: the recovered creds must actually drive the reaper.
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	reaper := &recordingEVSReaper{ret: 4}
+	if got := h.reapDeploymentEVSBackstop(context.Background(), reaper, "cccccccc55556666", sweep, nil); got != 4 {
+		t.Fatalf("reaped = %d, want 4", got)
+	}
+	if !reaper.called {
+		t.Fatal("EVS backstop reaper NOT invoked with the workdir-recovered creds (#5135)")
+	}
+	if reaper.gotRegion != "me-east-777" {
+		t.Fatalf("region = %q, want me-east-777", reaper.gotRegion)
+	}
+}
+
+// TestApplyWorkdirEVSCredsFallback_BodyCredsWin — a wipe whose body carries the
+// creds must NOT be overwritten by the workdir tfvars. Only empty keys fill.
+func TestApplyWorkdirEVSCredsFallback_BodyCredsWin(t *testing.T) {
+	workdir := writeTfvars(t, t.TempDir(), "ak-disk", "sk-disk", "proj-disk", "me-east-777")
+
+	credsRaw := buildWipeCredsRaw("huawei", wipeRequest{
+		HuaweiAccessKey: "ak-body", HuaweiSecretKey: "sk-body",
+		HuaweiProjectID: "proj-body", HuaweiRegion: "me-east-body",
+	}, provisioner.Request{})
+
+	if applyWorkdirEVSCredsFallback("huawei", credsRaw, workdir) {
+		t.Fatal("fallback fired even though body creds were complete — it must not overwrite operator-supplied values")
+	}
+	if credsRaw["access_key"] != "ak-body" || credsRaw["region"] != "me-east-body" {
+		t.Fatalf("body creds were clobbered: %+v", credsRaw)
+	}
+}
+
+// TestApplyWorkdirEVSCredsFallback_NonHuaweiAndMissingTfvars guards the honest
+// skips: a mothership/hetzner wipe and a huawei wipe whose workdir has no
+// tfvars must both no-op (no panic, no spurious backstop invocation).
+func TestApplyWorkdirEVSCredsFallback_NonHuaweiAndMissingTfvars(t *testing.T) {
+	// Non-huawei: even WITH a valid tfvars on disk, a hetzner wipe never fills.
+	workdir := writeTfvars(t, t.TempDir(), "ak-disk", "sk-disk", "proj-disk", "me-east-777")
+	hetznerCreds := buildWipeCredsRaw("hetzner", wipeRequest{}, provisioner.Request{})
+	if applyWorkdirEVSCredsFallback("hetzner", hetznerCreds, workdir) {
+		t.Fatal("hetzner wipe must not harvest huawei tfvars creds")
+	}
+
+	// Huawei but missing tfvars → honest skip; backstop stays un-invocable.
+	empty := t.TempDir() // no tofu.auto.tfvars.json written
+	huaweiCreds := buildWipeCredsRaw("huawei", wipeRequest{}, provisioner.Request{})
+	if applyWorkdirEVSCredsFallback("huawei", huaweiCreds, empty) {
+		t.Fatal("missing tfvars must yield a no-op, not a filled creds map")
+	}
+	if _, ok := huaweiSweepCredsFromRaw(huaweiCreds); ok {
+		t.Fatal("creds must stay incomplete when the workdir tfvars is absent — the backstop honestly skips")
 	}
 }
 


### PR DESCRIPTION
## Root cause (Refs #5135)

A fresh prov hit `413 VolumeLimitExceeded` because 304 orphaned CSI `pvc-*` EVS volumes had piled up at `status=available` — the exact #5028 wedge the post-destroy EVS backstop was built to prevent. The backstop was silently skipping on every canonical wipe after a catalyst-api Pod roll.

Flow in `products/catalyst/bootstrap/api/internal/handler/wipe.go`:

- `credsRaw := buildWipeCredsRaw(providerName, body, dep.Request)` sources the Huawei AK/SK **only** from `body.Huawei*` or `dep.Request.Huawei*`.
- The #5028 EVS backstop runs **only** when `huaweiSweepCredsFromRaw(credsRaw)` returns `ok=true` (AK+SK+project_id all present).

On the canonical body-less wipe (`POST /deployments/{id}/wipe` with `{}`) **after a catalyst-api Pod roll**, the body creds are empty and `dep.Request`'s Huawei secrets do **not** persist a restart (they are GC'd from the in-memory Request right after `writeTfvars`). So `credsRaw["access_key"]/["secret_key"]` are empty → `huaweiSweepCredsFromRaw` returns `ok=false` → the backstop never runs. `tofu destroy` itself still authenticates because the provider adapter reads the workdir tfvars directly — only the backstop's `credsRaw` is starved. The stranded `pvc-*` volumes (no dep identity, outside tofu state) accumulate every wipe toward the HCS 400-EVS quota.

The pre-existing tfvars fallback (wipe.go ~line 316) only fires on the `provHint` path, keyed on `dep.Request.Provider`; the backstop is keyed on `providerName = resolveProviderName(dep)`, which reads the per-region `Regions[].Provider`. When those disagree (the canonical wizard payload sets only the per-region provider), `provHint` defaults to `hetzner`, the existing fallback never runs, and `credsRaw` stays empty even though `providerName == "huawei"`.

## The fix

Immediately after `credsRaw := buildWipeCredsRaw(...)` and **before** `cp.Wipe` runs (so the workdir/tfvars still exist — `tofu destroy` may remove them), a new `applyWorkdirEVSCredsFallback(providerName, credsRaw, filepath.Join(h.tofuWorkDir(), id))` fills **only** the empty `access_key`/`secret_key`/`project_id`/`region` keys from the durable per-deployment `tofu.auto.tfvars.json` on the `catalyst-api-deployments` PVC (via the existing `loadHuaweiCredsFromTfvars`). Body/request-provided values always win. It no-ops for non-huawei providers, when AK+SK are already present, or when the tfvars is absent (honest skip). When it fills a value, an `emit` progress line makes the recovery observable on the SSE stream.

The workdir key is confirmed as `<tofuWorkDir>/<full-deployment-id>` — the exact join the existing huawei caller at wipe.go:319 uses.

## Test

Extended `wipe_evs_backstop_test.go` (same package, reuses the recording `evsReaper` fake):

- `TestApplyWorkdirEVSCredsFallback_BodylessWipeAfterPodRoll` — empty body + empty `dep.Request` huawei secrets + a valid `tofu.auto.tfvars.json` in the dep workdir. Asserts `huaweiSweepCredsFromRaw` is `ok=false` **before** the fallback (proving the wedge), then that the fallback recovers all four creds and the backstop reaper **is** invoked with them (region propagated).
- `TestApplyWorkdirEVSCredsFallback_BodyCredsWin` — operator-supplied body creds are never overwritten by disk.
- `TestApplyWorkdirEVSCredsFallback_NonHuaweiAndMissingTfvars` — a hetzner/mothership wipe and a huawei wipe with no tfvars both no-op (no panic, honest skip; the backstop stays un-invocable).

## Evidence

- `go build ./...` — clean (module `products/catalyst/bootstrap/api`).
- `go vet ./internal/handler/` — clean.
- `go test ./...` — all pass.

This is a catalyst-api code change (image-tag-injected to Sovereigns at provision time). No chart version bump / lockstep needed.

Refs #5135, #5028

🤖 Generated with [Claude Code](https://claude.com/claude-code)
