### PR TITLE
fix(catalyst-api): Agenity sandbox sessions degrade to 503 on backend-unavailable (not 500)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -333,6 +333,24 @@ type sandboxCreateRequest struct {
 // with `{sandboxes: []}` even when the CRD isn't installed yet — the
 // FE renders the empty state plus its "API pending" pill in either
 // case, and a 5xx would just churn the page state with a spinner.
+// sandboxBackendUnavailable reports whether err indicates the Sandbox
+// backend is temporarily unreachable (as opposed to a genuine
+// object-not-found, which each handler maps to its own 200/404/503).
+// 401/403 arise when the catalyst-api dynamic client hits a clustermesh
+// peer apiserver that rejects its token during a cutover / chart-roll /
+// region-kill recovery window — observed live on hw261 after the
+// region-kill DR failover flipped the primary region and the sandbox
+// reflector alternated "Unauthorized" and "could not find the requested
+// resource". Per this package's doc, backend-unavailable ⇒ 503 "API
+// pending", never a raw 500.
+func sandboxBackendUnavailable(err error) bool {
+	return apierrors.IsUnauthorized(err) ||
+		apierrors.IsForbidden(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTimeout(err)
+}
+
 func (h *Handler) HandleListSandboxSessions(w http.ResponseWriter, r *http.Request) {
 	claims := auth.ClaimsFromContext(r.Context())
 	if claims == nil || claims.Sub == "" {
@@ -357,6 +375,14 @@ func (h *Handler) HandleListSandboxSessions(w http.ResponseWriter, r *http.Reque
 		// renders the empty state in either case.
 		if apierrors.IsNotFound(err) {
 			writeJSON(w, http.StatusOK, sandboxListResponse{Sandboxes: []sandboxItem{}})
+			return
+		}
+		if sandboxBackendUnavailable(err) {
+			h.log.Warn("sandbox: backend unavailable on list", "namespace", ns, "err", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error":  "sandbox-backend-unavailable",
+				"detail": "sandbox backend temporarily unavailable",
+			})
 			return
 		}
 		h.log.Warn("sandbox: list failed", "namespace", ns, "err", err)
@@ -407,6 +433,14 @@ func (h *Handler) HandleGetSandboxSession(w http.ResponseWriter, r *http.Request
 			writeJSON(w, http.StatusNotFound, map[string]string{
 				"error":  "sandbox-not-found",
 				"detail": fmt.Sprintf("sandbox %q not found in namespace %q", id, ns),
+			})
+			return
+		}
+		if sandboxBackendUnavailable(err) {
+			h.log.Warn("sandbox: backend unavailable on get", "id", id, "namespace", ns, "err", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error":  "sandbox-backend-unavailable",
+				"detail": "sandbox backend temporarily unavailable",
 			})
 			return
 		}
@@ -502,6 +536,14 @@ func (h *Handler) HandleCreateSandboxSession(w http.ResponseWriter, r *http.Requ
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
 				"error":  "sandbox-crd-not-installed",
 				"detail": "sandboxes.sandbox.openova.io CRD missing on this cluster",
+			})
+			return
+		}
+		if sandboxBackendUnavailable(err) {
+			h.log.Warn("sandbox: backend unavailable on create", "name", crName, "namespace", ns, "err", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error":  "sandbox-backend-unavailable",
+				"detail": "sandbox backend temporarily unavailable",
 			})
 			return
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_test.go
@@ -9,11 +9,46 @@
 package handler
 
 import (
+	"errors"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// TestSandboxBackendUnavailable pins the degrade classifier: transient
+// backend-unreachable errors (401/403/503/timeout — e.g. the sandbox
+// reflector hitting a clustermesh peer apiserver that rejects its token
+// during a cutover/roll/region-kill recovery window, observed live on
+// hw261) MUST degrade to the honest 503 "API pending", while a genuine
+// object-not-found or already-exists MUST NOT (those keep each handler's
+// own 200/404/409 semantics).
+func TestSandboxBackendUnavailable(t *testing.T) {
+	gr := schema.GroupResource{Group: "sandbox.openova.io", Resource: "sandboxes"}
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"unauthorized-401", apierrors.NewUnauthorized("token rejected by peer apiserver"), true},
+		{"forbidden-403", apierrors.NewForbidden(gr, "s1", errors.New("no")), true},
+		{"service-unavailable-503", apierrors.NewServiceUnavailable("apiserver draining"), true},
+		{"server-timeout", apierrors.NewServerTimeout(gr, "list", 1), true},
+		{"not-found-object", apierrors.NewNotFound(gr, "s1"), false},
+		{"already-exists", apierrors.NewAlreadyExists(gr, "s1"), false},
+		{"plain-error", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sandboxBackendUnavailable(tc.err); got != tc.want {
+				t.Fatalf("sandboxBackendUnavailable(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestUnstructuredToSandboxItem_StatusReflection(t *testing.T) {
 	creationTime := metav1.Now()


### PR DESCRIPTION
Closes the robustness half of #5140 (found live on the hw261 authenticated Pillar-4 walk).

## Problem
`/api/v1/sandbox/sessions` (list + create) returned **500** on hw261 post-region-kill. Root cause is **not** RBAC (verified: the `catalyst-api-cutover-driver` SA can list/create sandboxes, CRD present). The catalyst-api sandbox reflector hit a clustermesh **peer apiserver rejecting its token** during the DR-failover recovery window (log: alternating `Unauthorized` / `could not find the requested resource`). The handlers only degraded on `IsNotFound`, so a 401/403 fell through to a generic 500 — the console logged 500s and Start-session failed, instead of the honest "API pending" pill the UI already renders.

## Fix
`sandboxBackendUnavailable(err)` = `IsUnauthorized || IsForbidden || IsServiceUnavailable || IsServerTimeout || IsTimeout`, wired into `HandleList/Get/CreateSandboxSession` → **503 `sandbox-backend-unavailable`**. This matches the package doc's stated contract ("backend-unavailable ⇒ 503 'API pending', never a 5xx"). `IsNotFound` semantics unchanged (list→empty 200, get→404, create→503 CRD-missing).

## Test
`TestSandboxBackendUnavailable` pins the classifier: 401/403/503/timeout ⇒ true; not-found/already-exists/plain/nil ⇒ false. `go test`/`go vet` green.

## Scope
Robustness only — turns a raw 500 into the honest degrade. The **deeper cause** (post-failover the primary region flipped but catalyst-api's primary-referencing clients didn't re-resolve) stays open in **#5140** and is tied to **#5137** (Continuum-HA) / **#5132** (chroot primary-kubeconfig materialization). Lands for the next prov (catalyst-api image).

Refs #5140, #5137, #960
🤖 Generated with [Claude Code](https://claude.com/claude-code)