### PR TITLE
fix(openbao): continuous unseal reconciler — survive region-kill (#5142)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -153,7 +153,10 @@ spec:
       #   a NoSuchBucket (local seaweedfs `openbao-snapshots` bucket not yet
       #   created) aborted the Job every tick. Now a missing bucket is treated
       #   like the empty-bucket case: WARN + exit 0 (skipped tick, not failure).
-      version: 1.2.60
+      # 1.2.61 — #5142: continuous unseal reconciler CronJob so OpenBao
+      #   re-unseals automatically after a region-kill restart (the one-shot
+      #   init Job never re-runs, so post-region-kill the vault stayed SEALED).
+      version: 1.2.61
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.60  # lockstep with chart/Chart.yaml (#4879 snapshot-fetch: NoSuchBucket → graceful skip, not hard Job failure)
+  version: 1.2.61  # lockstep with chart/Chart.yaml (#4879 snapshot-fetch: NoSuchBucket → graceful skip, not hard Job failure)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -228,7 +228,7 @@ name: bp-openbao
 #   entity joined the sovereign-admins external group (direct_group_ids). Only
 #   the sso-configure reconcile.sh ROLE_PAYLOAD changes (+ the chart bump that
 #   rolls the Deployment per the #3374 checksum); no other template moves.
-version: 1.2.60
+version: 1.2.61
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/unseal-reconciler.yaml
+++ b/platform/openbao/chart/templates/unseal-reconciler.yaml
@@ -1,0 +1,169 @@
+{{- /*
+Catalyst openbao unseal reconciler — bp-openbao (#5142).
+
+WHY THIS EXISTS
+---------------
+`init-job.yaml` initialises OpenBao with a shamir seal and PERSISTS the
+unseal keys into the `openbao-unseal-keys` Secret, then (Step 2a) re-applies
+them via `bao operator unseal` when the vault is sealed. But that init Job is
+a ONE-SHOT Helm post-install/upgrade hook: it runs at install/roll and then
+completes. When `openbao-0`'s node/region is later killed and recovered — the
+core Pillar-3 region-kill event — the Pod restarts SEALED (shamir does not
+auto-unseal), and nothing re-runs the init Job, so the secrets layer stays
+degraded (SSO seeds fail, snapshot cron fails, catalyst-api destabilises).
+Observed live on hw261 after region-kill G12 (#5142).
+
+This CronJob closes that gap: on a short schedule it checks `bao status`, and
+if the vault is SEALED it fetches the persisted `openbao-unseal-keys` Secret
+and applies the keys — the exact idempotent path from init-job.yaml Step 2a,
+minus the init/seed/marker/trace machinery. On the happy path (already
+unsealed) it exits 0 and does nothing. It only exits non-zero when the vault
+is genuinely sealed AND cannot be unsealed (keys missing), so a persistent
+problem surfaces as a Failed reconcile row rather than silent degradation.
+
+Skip-render (per #402 — never `{{ fail }}`): rendered ONLY when
+`autoUnseal.enabled=true` AND `autoUnseal.reconcile.enabled=true` (default
+true when auto-unseal is on). Reuses the openbao-auto-unseal SA + RBAC
+(auto-unseal-rbac.yaml) which already grants read on the unseal-keys Secret.
+*/}}
+{{- $au := .Values.autoUnseal | default dict -}}
+{{- $rec := $au.reconcile | default dict -}}
+{{- $recEnabled := true -}}
+{{- if hasKey $rec "enabled" }}{{- $recEnabled = $rec.enabled -}}{{- end -}}
+{{- if and $au.enabled $recEnabled -}}
+{{- $img := $au.image | default dict -}}
+{{- $repo := $img.repository | default "quay.io/openbao/openbao" -}}
+{{- $registry := .Values.global.imageRegistry | default "" -}}
+{{- if $registry }}{{- $repo = printf "%s/%s" $registry $repo -}}{{- end -}}
+{{- $tag := $img.tag | default "2.1.0" -}}
+{{- $pullPolicy := $img.pullPolicy | default "IfNotPresent" -}}
+{{- $baoAddr := $au.baoAddress | default (printf "http://%s-openbao:8200" .Release.Name) -}}
+{{- $schedule := $rec.schedule | default "*/2 * * * *" -}}
+{{- $deadline := $rec.activeDeadlineSeconds | default 120 -}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: openbao-unseal-reconciler
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-unseal-reconciler
+    app.kubernetes.io/managed-by: flux
+spec:
+  schedule: {{ $schedule | quote }}
+  # Never overlap runs, and don't fire a backlog of missed runs after a
+  # long node/region outage — one fresh attempt on recovery is enough.
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    metadata:
+      labels:
+        catalyst.openova.io/blueprint: bp-openbao
+        catalyst.openova.io/component: openbao-unseal-reconciler
+    spec:
+      activeDeadlineSeconds: {{ $deadline }}
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 300
+      template:
+        metadata:
+          labels:
+            catalyst.openova.io/blueprint: bp-openbao
+            catalyst.openova.io/component: openbao-unseal-reconciler
+        spec:
+          serviceAccountName: openbao-auto-unseal
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 100
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - name: unseal
+              image: {{ printf "%s:%s" $repo $tag | quote }}
+              imagePullPolicy: {{ $pullPolicy | quote }}
+              env:
+                - name: BAO_ADDR
+                  value: {{ $baoAddr | quote }}
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  UNSEAL_SECRET_NAME="openbao-unseal-keys"
+                  TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                  APISERVER="https://kubernetes.default.svc"
+
+                  # Reachability: if openbao isn't answering at all, exit 0 —
+                  # a reconciler must not fail-spam while the Pod is still
+                  # starting; the next tick will catch it.
+                  if ! bao status >/dev/null 2>&1; then
+                    RC=$?
+                    # rc 2 = reachable-but-sealed (proceed); anything else =
+                    # not reachable yet → best-effort no-op.
+                    if [ "$RC" != "2" ]; then
+                      echo "[unseal-reconciler] openbao not reachable at $BAO_ADDR (rc=$RC) — no-op this tick"
+                      exit 0
+                    fi
+                  fi
+
+                  SEALED=$(bao status -format=json 2>/dev/null | grep -E '"sealed"' | head -1 | sed -E 's/.*"sealed"[[:space:]]*:[[:space:]]*(true|false).*/\1/')
+                  if [ "$SEALED" != "true" ]; then
+                    echo "[unseal-reconciler] vault unsealed — nothing to do"
+                    exit 0
+                  fi
+
+                  echo "[unseal-reconciler] vault is SEALED — fetching persisted unseal keys from $UNSEAL_SECRET_NAME"
+                  UNSEAL_RESPONSE=$(wget -qO- --no-check-certificate \
+                    --header="Authorization: Bearer $TOKEN" \
+                    "$APISERVER/api/v1/namespaces/$NAMESPACE/secrets/$UNSEAL_SECRET_NAME") || {
+                      echo "[unseal-reconciler] FATAL: vault sealed but cannot fetch $UNSEAL_SECRET_NAME (missing?) — manual recovery: docs/RUNBOOKS.md openbao-auto-unseal"
+                      exit 1
+                    }
+                  KEYS_B64_FIELD=$(echo "$UNSEAL_RESPONSE" | tr -d '\n' | sed -E 's/.*"unseal-keys-b64"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+                  THRESHOLD_FIELD=$(echo "$UNSEAL_RESPONSE" | tr -d '\n' | sed -E 's/.*"unseal-threshold"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+                  if [ -z "$KEYS_B64_FIELD" ] || [ "$KEYS_B64_FIELD" = "$UNSEAL_RESPONSE" ]; then
+                    echo "[unseal-reconciler] FATAL: $UNSEAL_SECRET_NAME has no unseal-keys-b64 field"
+                    exit 1
+                  fi
+                  echo "$KEYS_B64_FIELD" | base64 -d > /tmp/.unseal-keys
+                  if [ -z "$THRESHOLD_FIELD" ] || [ "$THRESHOLD_FIELD" = "$UNSEAL_RESPONSE" ]; then
+                    UNSEAL_THRESHOLD=1
+                  else
+                    UNSEAL_THRESHOLD=$(echo "$THRESHOLD_FIELD" | base64 -d)
+                  fi
+                  if [ -z "$UNSEAL_THRESHOLD" ] || [ "$UNSEAL_THRESHOLD" -lt 1 ] 2>/dev/null; then
+                    UNSEAL_THRESHOLD=1
+                  fi
+                  # grep -c . counts NON-EMPTY lines (matches init-job Step 3;
+                  # base64 -d of a single key has no terminal newline so wc -l
+                  # would undercount — #2295).
+                  KEY_COUNT=$(grep -c . /tmp/.unseal-keys 2>/dev/null || echo 0)
+                  if [ "$KEY_COUNT" -lt "$UNSEAL_THRESHOLD" ]; then
+                    echo "[unseal-reconciler] FATAL: persisted $KEY_COUNT key(s) but threshold=$UNSEAL_THRESHOLD"
+                    exit 1
+                  fi
+                  echo "[unseal-reconciler] applying $UNSEAL_THRESHOLD unseal key(s)"
+                  I=0
+                  while [ "$I" -lt "$UNSEAL_THRESHOLD" ]; do
+                    I=$((I+1))
+                    KEY=$(sed -n "${I}p" /tmp/.unseal-keys)
+                    if [ -z "$KEY" ]; then
+                      echo "[unseal-reconciler] FATAL: empty key at slot $I"
+                      exit 1
+                    fi
+                    bao operator unseal "$KEY" >/dev/null
+                  done
+                  rm -f /tmp/.unseal-keys
+                  SEALED_AFTER=$(bao status -format=json 2>/dev/null | grep -E '"sealed"' | head -1 | sed -E 's/.*"sealed"[[:space:]]*:[[:space:]]*(true|false).*/\1/')
+                  if [ "$SEALED_AFTER" != "false" ]; then
+                    echo "[unseal-reconciler] FATAL: still sealed after applying $UNSEAL_THRESHOLD key(s) — sealed=$SEALED_AFTER"
+                    exit 1
+                  fi
+                  echo "[unseal-reconciler] re-unsealed (sealed=false) — region-kill recovery restored the secrets layer"
+{{- end -}}

--- a/platform/openbao/chart/tests/auto-unseal-toggle.sh
+++ b/platform/openbao/chart/tests/auto-unseal-toggle.sh
@@ -119,4 +119,32 @@ if [ "$JOB_BEFORE_HOOK" -lt 2 ]; then
 fi
 echo "  PASS"
 
+echo "[auto-unseal-toggle] Case 5: #5142 unseal reconciler — CronJob renders when autoUnseal on (default reconcile), suppressed by reconcile.enabled=false"
+# The one-shot init Job unseals at install but never re-runs; the reconciler
+# CronJob (templates/unseal-reconciler.yaml) re-applies the persisted unseal
+# keys after a region-kill restart. Gated on autoUnseal.enabled AND
+# autoUnseal.reconcile.enabled (default true when auto-unseal is on).
+if ! grep -qE "^  name: openbao-unseal-reconciler$" "$TMP/autounseal.yaml"; then
+  echo "FAIL: openbao-unseal-reconciler CronJob not rendered when autoUnseal.enabled=true (default reconcile)." >&2
+  exit 1
+fi
+if ! grep -qE "^kind: CronJob$" "$TMP/autounseal.yaml"; then
+  echo "FAIL: reconciler did not render as a CronJob." >&2
+  exit 1
+fi
+helm template smoke-bao . \
+  --set autoUnseal.enabled=true \
+  --set autoUnseal.reconcile.enabled=false \
+  --set gateway.host=bao.test.example.com \
+  > "$TMP/recoff.yaml" 2> "$TMP/recoff.err" || {
+    echo "FAIL: autoUnseal.enabled=true + reconcile.enabled=false render failed:" >&2
+    cat "$TMP/recoff.err" >&2
+    exit 1
+  }
+if grep -qE "openbao-unseal-reconciler" "$TMP/recoff.yaml"; then
+  echo "FAIL: reconciler CronJob rendered despite reconcile.enabled=false — skip-render broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
 echo "[auto-unseal-toggle] All bp-openbao auto-unseal-toggle gates green."

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -195,6 +195,23 @@ autoUnseal:
   # leave the Job pending indefinitely.
   activeDeadlineSeconds: 600
   backoffLimit: 6
+  # ─── #5142 continuous unseal reconciler ───────────────────────────────
+  # The init Job above is a one-shot Helm post-install/upgrade hook: it
+  # unseals at install/roll but never re-runs. After a region-kill
+  # kills + recovers openbao-0's node, the Pod restarts SEALED (shamir
+  # does not auto-unseal) and stays sealed — the secrets layer degrades
+  # (SSO seeds, snapshot cron, catalyst-api). Observed live on hw261 after
+  # region-kill G12. This CronJob (templates/unseal-reconciler.yaml)
+  # re-applies the persisted openbao-unseal-keys on a short schedule so a
+  # region-kill recovery restores the secrets layer without operator
+  # action (Pillar-3 DR recovery). Rendered only when autoUnseal.enabled
+  # AND reconcile.enabled are both true.
+  reconcile:
+    enabled: true
+    # Seal-status check cadence. Every 2 min bounds post-region-kill
+    # sealed-time to ~2 min while staying cheap (no long-running Pod).
+    schedule: "*/2 * * * *"
+    activeDeadlineSeconds: 120
   # ─── #3888 (Refs #3847) prov-time openbao KV-seed ─────────────────────
   # The MISSING mechanism #3890 flagged: there is no way to land a
   # per-deployment cred into openbao KV at provision time, because the

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3417,7 +3417,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.60"
+  version: "1.2.61"
   visibility: unlisted
   card:
     title: "OpenBao"
@@ -3442,7 +3442,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openbao
-    version: "1.2.60"
+    version: "1.2.61"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
Fixes the Pillar-3 DR-recovery gap found live on the hw261 region-kill G12 walk (#5142). Clean re-cut off latest main (the prior #5143/#5145 branch got a corrupted Actions trigger state after close/reopen churn; same 2 commits, cherry-picked clean).

**Problem:** OpenBao's unseal is a one-shot init Job that never re-runs, so after a region-kill kills+recovers openbao-0's node the vault restarts **SEALED** (observed live: failed `openbao-snapshot-save` cron + catalyst-api `openbao: token is required` seed-reconcile failures + jobs-retry 502).

**Fix:** `templates/unseal-reconciler.yaml` — a CronJob (default `*/2 * * * *`) that re-applies the persisted `openbao-unseal-keys` when the vault is sealed (reuses the init Job's idempotent unseal path). Gated on `autoUnseal.enabled` + `autoUnseal.reconcile.enabled`.

**Lockstep + tests:** chart 1.2.60→1.2.61 across **all 4 surfaces** (Chart.yaml + blueprint.yaml + catalog-seed ×2 + bootstrap-kit slot 08); new test Case 5. Verified locally: `helm lint` clean, all 5 auto-unseal-toggle cases green, pin-sync-audit passes.

Refs #5142, #5137, #960
🤖 Generated with [Claude Code](https://claude.com/claude-code)