### PR TITLE
fix(openbao): unseal-reconciler no-op'd on SEALED vault — capture bao's real rc (#5146)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -156,7 +156,12 @@ spec:
       # 1.2.61 — #5142: continuous unseal reconciler CronJob so OpenBao
       #   re-unseals automatically after a region-kill restart (the one-shot
       #   init Job never re-runs, so post-region-kill the vault stayed SEALED).
-      version: 1.2.61
+      # 1.2.62 — #5146 hotfix: the 1.2.61 reconciler no-op'd on a SEALED vault —
+      #   `if ! bao status; then RC=$?` captured the `!`-negated exit code (0),
+      #   not bao's real rc=2, so the "reachable-but-sealed" branch never ran.
+      #   Caught by the live region-kill DR proof on hw262 (openbao-0 restarted
+      #   sealed, reconciler no-op'd every tick). Now captures rc directly.
+      version: 1.2.62
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.61  # lockstep with chart/Chart.yaml (#4879 snapshot-fetch: NoSuchBucket → graceful skip, not hard Job failure)
+  version: 1.2.62  # lockstep with chart/Chart.yaml (#4879 snapshot-fetch: NoSuchBucket → graceful skip, not hard Job failure)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -228,7 +228,7 @@ name: bp-openbao
 #   entity joined the sovereign-admins external group (direct_group_ids). Only
 #   the sso-configure reconcile.sh ROLE_PAYLOAD changes (+ the chart bump that
 #   rolls the Deployment per the #3374 checksum); no other template moves.
-version: 1.2.61
+version: 1.2.62
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/unseal-reconciler.yaml
+++ b/platform/openbao/chart/templates/unseal-reconciler.yaml
@@ -99,17 +99,19 @@ spec:
                   TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
                   APISERVER="https://kubernetes.default.svc"
 
-                  # Reachability: if openbao isn't answering at all, exit 0 —
-                  # a reconciler must not fail-spam while the Pod is still
-                  # starting; the next tick will catch it.
-                  if ! bao status >/dev/null 2>&1; then
-                    RC=$?
-                    # rc 2 = reachable-but-sealed (proceed); anything else =
-                    # not reachable yet → best-effort no-op.
-                    if [ "$RC" != "2" ]; then
-                      echo "[unseal-reconciler] openbao not reachable at $BAO_ADDR (rc=$RC) — no-op this tick"
-                      exit 0
-                    fi
+                  # Reachability: capture bao status' REAL exit code.
+                  #   0 = reachable + unsealed · 2 = reachable + SEALED · other = not reachable.
+                  # MUST NOT wrap in `if ! bao status; then RC=$?` — the `!` negation
+                  # clobbers $? to 0, so a SEALED vault (rc=2) is misread as rc=0 and the
+                  # guard below no-ops FOREVER (never unseals). This exact bug shipped in
+                  # 1.2.61 and was caught by the live region-kill DR proof on hw262 (#5146):
+                  # openbao-0 restarted sealed and the reconciler no-op'd every tick.
+                  # `|| RC=$?` is set -e safe (bao returns non-zero when sealed/unreachable).
+                  RC=0
+                  bao status >/dev/null 2>&1 || RC=$?
+                  if [ "$RC" != "0" ] && [ "$RC" != "2" ]; then
+                    echo "[unseal-reconciler] openbao not reachable at $BAO_ADDR (rc=$RC) — no-op this tick"
+                    exit 0
                   fi
 
                   SEALED=$(bao status -format=json 2>/dev/null | grep -E '"sealed"' | head -1 | sed -E 's/.*"sealed"[[:space:]]*:[[:space:]]*(true|false).*/\1/')

--- a/platform/openbao/chart/tests/auto-unseal-toggle.sh
+++ b/platform/openbao/chart/tests/auto-unseal-toggle.sh
@@ -147,4 +147,30 @@ if grep -qE "openbao-unseal-reconciler" "$TMP/recoff.yaml"; then
 fi
 echo "  PASS"
 
+echo "[auto-unseal-toggle] Case 6: #5146 reconciler captures bao's REAL rc (sealed=2 → proceed), not the !-negated 0"
+# The 1.2.61 bug: `if ! bao status; then RC=$?` clobbers $? to 0 via the `!`
+# negation, so a SEALED vault (rc=2) reads as rc=0 → the reachability guard
+# no-ops forever and never unseals. Caught live on the hw262 region-kill DR
+# proof (openbao-0 restarted sealed, reconciler no-op'd every tick). Guard the
+# regression on BOTH the rendered script (static) and the idiom (behavioral).
+REC="$TMP/autounseal.yaml"
+# 6a — the buggy `if ! bao status` wrapper must be ABSENT from executable code
+# (strip comment lines — the fix's own doc-comment names the antipattern).
+if grep -vE '^[[:space:]]*#' "$REC" | grep -qE 'if ! bao status'; then
+  echo "FAIL: reconciler wraps 'bao status' in 'if !' — the negation clobbers \$? (1.2.61 bug)." >&2
+  exit 1
+fi
+# 6b — the correct direct rc-capture must be PRESENT.
+if ! grep -qE 'bao status >/dev/null 2>&1 \|\| RC=\$\?' "$REC"; then
+  echo "FAIL: reconciler missing direct 'bao status ... || RC=\$?' rc-capture." >&2
+  exit 1
+fi
+# 6c — behavioral: the corrected idiom must PROCEED on sealed (rc=2), not no-op.
+res=$(sh -c 'set -eu; RC=0; (exit 2) >/dev/null 2>&1 || RC=$?; if [ "$RC" != "0" ] && [ "$RC" != "2" ]; then echo NOOP; else echo PROCEED; fi')
+if [ "$res" != "PROCEED" ]; then
+  echo "FAIL: corrected rc-capture idiom did not PROCEED on sealed(rc=2): got $res" >&2
+  exit 1
+fi
+echo "  PASS"
+
 echo "[auto-unseal-toggle] All bp-openbao auto-unseal-toggle gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3417,7 +3417,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.61"
+  version: "1.2.62"
   visibility: unlisted
   card:
     title: "OpenBao"
@@ -3442,7 +3442,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openbao
-    version: "1.2.61"
+    version: "1.2.62"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## Problem — the #5146 fix didn't actually work at runtime

bp-openbao 1.2.61 (#5142/#5146) added a continuous unseal-reconciler CronJob so OpenBao re-unseals after a region-kill restart. **It never unsealed a sealed vault.** Its reachability guard was:

```sh
if ! bao status >/dev/null 2>&1; then
  RC=$?                       # ← the exit code of the !-NEGATED test = 0, not bao's rc=2
  if [ "$RC" != "2" ]; then   # sealed vault: RC reads 0 → 0≠2 true → no-op
    echo "... not reachable ... no-op this tick"; exit 0
  fi
fi
```

`bao status` exits **2** when sealed, but `! bao status` inverts that to **0**, so inside the `then` block `$?` is **0** — the "reachable-but-sealed → proceed" branch is unreachable. The reconciler no-op'd every tick, forever; the vault stayed SEALED after any restart.

## How it was caught — live region-kill DR proof (hw262)

On a fresh 2-region Sovereign (dep `9e8f4383e79bc943`), with the reconciler deployed + openbao unsealed, I deleted `openbao-0` (a faithful proxy for a region-kill restart). It came up **sealed** and the reconciler no-op'd for **6+ minutes** — manual recovery required. Unit tests passed because they mock `bao status`; only a live sealed vault exposes the `!`-negation `$?` bug. This is exactly why the fresh-prov proof is mandated over unit tests alone.

## Fix

Capture `bao status`'s real exit code directly (set -e safe):
```sh
RC=0
bao status >/dev/null 2>&1 || RC=$?
if [ "$RC" != "0" ] && [ "$RC" != "2" ]; then ... no-op ; fi   # 0=unsealed 2=sealed → proceed
```

- `unseal-reconciler.yaml`: correct rc capture + regression doc-comment
- `tests/auto-unseal-toggle.sh`: **Case 6** — static (no `if ! bao status` in executable code) + behavioral (sealed rc=2 → PROCEED) regression guard. All 6 cases green.
- bp-openbao **1.2.61 → 1.2.62** across all 4 lockstep surfaces (chart / blueprint / bootstrap-kit slot 08 / catalog-seed). `pin-sync-audit` green, `helm lint` clean.

Refs #5146, #5142, #960