### PR TITLE
fix(sso-bridge): align alpine/k8s to cutover-standard 1.31.4 — post-cutover ImagePullBackOff (#5150)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -170,7 +170,7 @@ spec:
       #   policy-dropped → `no OpenBao token` every tick → grafana/hubble 503,
       #   gitea 500. Fix: CNP egress now also names kube-dns + keycloak + openbao.
       #   #4449 fixed the INGRESS side; this is the EGRESS side. Refs #4458 #4449.
-      version: 0.2.24
+      version: 0.2.25
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.24
+  version: 0.2.25
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.24
+version: 0.2.25
 # 0.2.24 (#4458, 2026-06-26): EGRESS half of the #4448/#4449 sso-bridge↔openbao
 # netpol gap. THE CILIUM TRAP: the `sso-bridge-reconciler-apiserver`
 # CiliumNetworkPolicy attaches an egress rule to the reconciler endpoint, which

--- a/platform/sso-bridge/chart/values.yaml
+++ b/platform/sso-bridge/chart/values.yaml
@@ -50,7 +50,15 @@ enabled: true
 # segment) — but the canonical shape going forward is host-less here.
 image:
   repository: proxy-dockerhub/alpine/k8s
-  tag: "1.30.0"
+  # 1.31.4 aligns with the platform-standard alpine/k8s tag used by the
+  # self-sovereign-cutover chart's own Jobs (platform/self-sovereign-cutover/
+  # chart/values.yaml images.kubectl.tag). Those Jobs run through the cutover,
+  # so 1.31.4 is warmed into the Sovereign's local Harbor proxy-cache; the
+  # divergent 1.30.0 was NOT cached and the reconciler ImagePullBackOff'd
+  # post-cutover on a self-sovereign env (proxy-cache can only serve pre-cached
+  # dockerhub images; the prewarm is ghcr-only by design). Live-caught on hw262
+  # (#5150). One alpine/k8s tag across the platform = one thing to warm.
+  tag: "1.31.4"
   pullPolicy: IfNotPresent
 
 # Reconcile cadence. 60s is the natural ceiling for "operator pushed a new

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5146,7 +5146,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.24"
+  version: "0.2.25"
   visibility: unlisted
   card:
     title: "SSO Bridge"
@@ -5163,7 +5163,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-sso-bridge
-    version: "0.2.24"
+    version: "0.2.25"
   topology:
     supported:
       - active-passive


### PR DESCRIPTION
Live-caught on hw262 (cutoverComplete=true): `sso-bridge-reconciler` ImagePullBackOff on `proxy-dockerhub/alpine/k8s:1.30.0`. Post-cutover the local Harbor proxy-cache serves only pre-cached dockerhub images (prewarm is ghcr-only). The cutover chart's own Jobs use **1.31.4** and run through the cutover, so 1.31.4 is warmed; sso-bridge's divergent **1.30.0** was never cached. Fix: align sso-bridge to **1.31.4** (one tag across the platform). bp-sso-bridge 0.2.24→0.2.25, 4-surface lockstep, pin-sync green, helm-lint clean. Verify on next fresh prov. Refs #5150, #960