### PR TITLE
fix(scripts): region-kill-drill discover echo ran kill via backtick (#960)

### DIFF
--- a/docs/sessions/2026-07-17/hw263-region-kill-G12-validation-runbook.md
+++ b/docs/sessions/2026-07-17/hw263-region-kill-G12-validation-runbook.md
@@ -1,0 +1,80 @@
+# hw263 — region-kill G12 DR-recovery validation on the FIXED train (task #960)
+
+**Goal:** prove — on a clean prov of the *now-fixed* train — that a region-kill
+auto-recovers the full DR surface with **zero operator action**:
+1. **openbao auto-unseal** via the `openbao-unseal-reconciler` CronJob
+   (`bp-openbao 1.2.62`). hw262 ran the **buggy 1.2.61** whose reconciler
+   mis-captured `bao status`' rc (`if ! bao status; then RC=$?` → the `!`
+   negation clobbers `$?` to 0 → guard `[ $RC != 2 ]` true → **permanent
+   no-op**), so openbao stayed SEALED 6+ min post-kill. 1.2.62 fixes it
+   (`RC=0; bao status || RC=$?`) — this prov is where the fix is proven
+   end-to-end by the *real CronJob* (hw262 only proved it via exec-simulation).
+2. **CNPG failover** region-a→region-b (RTO ~sec, RPO=0), as on hw256.
+3. **sso-bridge healthy** — hw262 hit `#5150` ImagePullBackOff (alpine/k8s
+   tag `1.30.0` unresolvable via `proxy-dockerhub`); `bp-sso-bridge 0.2.25`
+   pins `1.31.4`. Expect sso-bridge Running (no ImagePullBackOff) on hw263.
+
+## Preconditions
+- hw262 (dep `9e8f4383e79bc943`) **fully wiped** — record GONE + live Huawei
+  ground-truth ZERO remnants (verify before fire; one-env gate). ⏳ (in flight)
+- Train 4-surface lockstep PASS + GHCR-published:
+  - `bp-openbao 1.2.62` ✅ (ghcr + bootstrap-kit slot 08 + catalog-seed)
+  - `bp-sso-bridge 0.2.25` ✅ (ghcr + bootstrap-kit slot 13b + catalog-seed)
+- Reconciler chart verified on main: corrected `RC=0; bao status || RC=$?`
+  (unseal-reconciler.yaml L110-111), buggy pattern gone from executable code,
+  CronJob schedule `*/2 * * * *`, `reconcile.enabled: true`. ✅
+- Do NOT merge any catalyst-api PR while hw263 is in-flight (roll abandons prov).
+
+## Fire (match hw262's PROVEN sizing — it fully converged AND cut over)
+```bash
+export CATALYST_MOTHERSHIP_KEY=/tmp/hw-priv.pem
+CP_SIZE=m7n.xlarge.8 WORKER_SIZE=m7n.2xlarge.8 WORKER_COUNT=3 \
+  QATEST=false FIRECUT=true \
+  scripts/sovereign-lifecycle.sh fire hw263 omani.works
+# fire() = prov-preflight (fail-closed, one-env gate) → reset-uat → POST.
+# If preflight flags m7n.2xlarge.8 pool exhausted, fall back to the script
+# default WORKER_SIZE=m7n.xlarge.8 WORKER_COUNT=5 (verified-ACTIVE flavor).
+```
+
+## Converge (zero-touch — NO hand-patching; that IS the proof)
+- dep status → `ready`; ~60 component HRs installed.
+- Handover auto-fires → (FIRECUT=true) 11-step auto-cutover chain runs → watch
+  `self-sovereign-cutover-status` cm to `cutoverComplete=true`.
+- openbao reaches unsealed/Ready on first convergence (init-Job path);
+  sso-bridge Running (validates #5151 on a fresh prov).
+
+## Region-kill G12 + the openbao-reconciler proof
+Mechanics proven hw256 (`docs/sessions/2026-07-15/hw256-region-kill/`): batch
+HARD os-stop of all region-a ECS via HCS API → region-b promote. Known
+CNPG-orthogonal defects to expect (heal, don't abort):
+- **Defect-1:** region-b helm-controller "correct cluster drift" reverts the
+  cnpg promote patch mid-kill; re-patch if it re-demotes the survivor.
+- **Defect-2:** rejoin walreceiver crash-loop (timeline N behind N+1). Heal =
+  delete region-b replica Cluster CR + re-apply → pg_basebackup (~2m/cluster).
+
+Steps:
+1. Pre-kill: `bao status` → Sealed=false; sso-bridge Running; seed g12_marker
+   (shared-pg) + d31_counter (cnpg-pair); verify region-b RPO=0.
+2. Region-kill: batch os-stop region-a ECS (NOT delete) via HCS API; promote
+   region-b replicas.
+3. **THE openbao PROOF (what hw262's 1.2.61 could NOT do):** openbao pods
+   restart SEALED (shamir) → within ~2 min the `openbao-unseal-reconciler`
+   CronJob fires, reads persisted `openbao-unseal-keys`, runs `bao operator
+   unseal` → **Sealed=false with ZERO hand-intervention.** Capture:
+   - `kubectl get cronjob openbao-unseal-reconciler` (schedule */2)
+   - the reconciler Job logs showing the unseal (rc=2 → PROCEED → unsealed)
+   - `bao status` Sealed=false after the reconciler run
+   - SSO/funnel/per-Org rows that openbao-gates now walk green
+4. Recover region-a → confirm re-join, no split-brain.
+
+## UAT
+- reset-uat ran on fire (flushes hw262 evidence).
+- Stamp: region-kill G12, openbao-DR auto-unseal, CNPG RPO=0 failover, the
+  sso-bridge #5151 row, + the openbao-confounded SSO/funnel/per-Org rows.
+- Run `scripts/uat-drift-guard.py` — no hw262/hw255 tokens on ✅ rows.
+
+## Guards
+- ONE env at a time — hw262 fully wiped before fire; nothing coexists.
+- No live-patching during convergence (zero-touch is the proof).
+- bastion `bastion-openova` / EIP 212.72.24.20 — NEVER touch.
+- NodePorts ABSOLUTELY FORBIDDEN (§854) — gateway served DIRECT.

--- a/docs/sessions/2026-07-17/prov-diagnostics/9e8f4383e79bc943-cloudinit.log
+++ b/docs/sessions/2026-07-17/prov-diagnostics/9e8f4383e79bc943-cloudinit.log
@@ -1,0 +1,434 @@
+Cloud-init v. 19.1 running 'init-local' at Thu, 16 Jul 2026 16:53:47 +0000. Up 10.59 seconds.
+Cloud-init v. 19.1 running 'init' at Thu, 16 Jul 2026 16:53:49 +0000. Up 11.92 seconds.
+ci-info: +++++++++++++++++++++++++++++++++++++++Net device info+++++++++++++++++++++++++++++++++++++++
+ci-info: +--------+------+------------------------------+---------------+--------+-------------------+
+ci-info: | Device |  Up  |           Address            |      Mask     | Scope  |     Hw-Address    |
+ci-info: +--------+------+------------------------------+---------------+--------+-------------------+
+ci-info: |  eth0  | True |         10.81.1.204          | 255.255.255.0 | global | fa:16:3e:fe:ae:79 |
+ci-info: |  eth0  | True | fe80::f816:3eff:fefe:ae79/64 |       .       |  link  | fa:16:3e:fe:ae:79 |
+ci-info: |   lo   | True |          127.0.0.1           |   255.0.0.0   |  host  |         .         |
+ci-info: |   lo   | True |           ::1/128            |       .       |  host  |         .         |
+ci-info: +--------+------+------------------------------+---------------+--------+-------------------+
+ci-info: +++++++++++++++++++++++++++++++Route IPv4 info+++++++++++++++++++++++++++++++
+ci-info: +-------+-----------------+-----------+-----------------+-----------+-------+
+ci-info: | Route |   Destination   |  Gateway  |     Genmask     | Interface | Flags |
+ci-info: +-------+-----------------+-----------+-----------------+-----------+-------+
+ci-info: |   0   |     0.0.0.0     | 10.81.1.1 |     0.0.0.0     |    eth0   |   UG  |
+ci-info: |   1   |    10.81.1.0    |  0.0.0.0  |  255.255.255.0  |    eth0   |   U   |
+ci-info: |   2   | 169.254.169.254 | 10.81.1.1 | 255.255.255.255 |    eth0   |  UGH  |
+ci-info: +-------+-----------------+-----------+-----------------+-----------+-------+
+ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
+ci-info: +-------+-------------+---------+-----------+-------+
+ci-info: | Route | Destination | Gateway | Interface | Flags |
+ci-info: +-------+-------------+---------+-----------+-------+
+ci-info: |   1   |  fe80::/64  |    ::   |    eth0   |   U   |
+ci-info: |   3   |  multicast  |    ::   |    eth0   |   U   |
+ci-info: +-------+-------------+---------+-----------+-------+
+Generating public/private rsa key pair.
+Your identification has been saved in /etc/ssh/ssh_host_rsa_key
+Your public key has been saved in /etc/ssh/ssh_host_rsa_key.pub
+The key fingerprint is:
+SHA256:21JEP/XHeC0/4VwojwUhfQ+/lPxSLORKsz9R9zKrPlQ root@catalyst-hw262-omani-works-9e8f4383-me-east-215-b-cp1-d6a9fc
+The key's randomart image is:
++---[RSA 3072]----+
+|          o.o..  |
+|         . o.o+=.|
+|          . ++**O|
+|         .  o*EB@|
+|        S ...=oB*|
+|         +  + =.+|
+|        o .. . * |
+|         .  . +  |
+|           .oo . |
++----[SHA256]-----+
+Generating public/private dsa key pair.
+Your identification has been saved in /etc/ssh/ssh_host_dsa_key
+Your public key has been saved in /etc/ssh/ssh_host_dsa_key.pub
+The key fingerprint is:
+SHA256:os5BcsJBVHq0lcbQwtExok4soh43ZAnI1NPUD12pfIY root@catalyst-hw262-omani-works-9e8f4383-me-east-215-b-cp1-d6a9fc
+The key's randomart image is:
++---[DSA 1024]----+
+|+++oOB=o. ...    |
+|.+.*+=*+ . .     |
+|o *++o  + o      |
+|o=oo     E o     |
+|..=oo . S o      |
+|. o=.. .         |
+| .  o            |
+|   o .           |
+|    o            |
++----[SHA256]-----+
+Generating public/private ecdsa key pair.
+Your identification has been saved in /etc/ssh/ssh_host_ecdsa_key
+Your public key has been saved in /etc/ssh/ssh_host_ecdsa_key.pub
+The key fingerprint is:
+SHA256:qsdlqU9VOMksEaCFGU4T2K2z0jiAC46MSguBdAEjXiE root@catalyst-hw262-omani-works-9e8f4383-me-east-215-b-cp1-d6a9fc
+The key's randomart image is:
++---[ECDSA 256]---+
+|.E.*B*o.o.       |
+|o.=+++.  + o     |
+|+.. o.  . * .    |
+|*   o    . o     |
+|*+ o o  S..      |
+|=++ o  .+.       |
+|+ .o ..+.        |
+|..   .+.         |
+|    .. ..        |
++----[SHA256]-----+
+Generating public/private ed25519 key pair.
+Your identification has been saved in /etc/ssh/ssh_host_ed25519_key
+Your public key has been saved in /etc/ssh/ssh_host_ed25519_key.pub
+The key fingerprint is:
+SHA256:gSUPDrwuo/pYMwqmbp1LT2lvCsrJn8k2V9drRF48gYs root@catalyst-hw262-omani-works-9e8f4383-me-east-215-b-cp1-d6a9fc
+The key's randomart image is:
++--[ED25519 256]--+
+|   .. o .   .    |
+|    .o *   . .   |
+|     .o o . o .  |
+|    .    E o +   |
+|   .    S + . .  |
+|  o . .. . +     |
+|.o==.+. . . .    |
+|B==BB...   o     |
+|OB+*+oo.  .      |
++----[SHA256]-----+
+Cloud-init v. 19.1 running 'modules:config' at Thu, 16 Jul 2026 16:53:53 +0000. Up 16.22 seconds.
+Cloud-init v. 19.1 running 'modules:final' at Thu, 16 Jul 2026 16:54:00 +0000. Up 23.75 seconds.
+Hit:1 http://repo.huaweicloud.com/ubuntu jammy InRelease
+Get:2 http://repo.huaweicloud.com/ubuntu jammy-updates InRelease [128 kB]
+Get:3 http://repo.huaweicloud.com/ubuntu jammy-backports InRelease [127 kB]
+Get:4 http://repo.huaweicloud.com/ubuntu jammy-security InRelease [129 kB]
+Get:5 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 Packages [3,632 kB]
+Get:6 http://repo.huaweicloud.com/ubuntu jammy-updates/main Translation-en [544 kB]
+Get:7 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 c-n-f Metadata [20.1 kB]
+Get:8 http://repo.huaweicloud.com/ubuntu jammy-updates/restricted amd64 Packages [6,221 kB]
+Get:9 http://repo.huaweicloud.com/ubuntu jammy-updates/restricted Translation-en [1,189 kB]
+Get:10 http://repo.huaweicloud.com/ubuntu jammy-updates/restricted amd64 c-n-f Metadata [584 B]
+Get:11 http://repo.huaweicloud.com/ubuntu jammy-updates/universe amd64 Packages [1,278 kB]
+Get:12 http://repo.huaweicloud.com/ubuntu jammy-updates/universe Translation-en [321 kB]
+Get:13 http://repo.huaweicloud.com/ubuntu jammy-updates/universe amd64 c-n-f Metadata [30.8 kB]
+Get:14 http://repo.huaweicloud.com/ubuntu jammy-updates/multiverse amd64 Packages [71.6 kB]
+Get:15 http://repo.huaweicloud.com/ubuntu jammy-updates/multiverse Translation-en [15.5 kB]
+Get:16 http://repo.huaweicloud.com/ubuntu jammy-updates/multiverse amd64 c-n-f Metadata [756 B]
+Get:17 http://repo.huaweicloud.com/ubuntu jammy-backports/main amd64 Packages [70.2 kB]
+Get:18 http://repo.huaweicloud.com/ubuntu jammy-backports/main Translation-en [11.4 kB]
+Get:19 http://repo.huaweicloud.com/ubuntu jammy-backports/main amd64 c-n-f Metadata [412 B]
+Get:20 http://repo.huaweicloud.com/ubuntu jammy-backports/universe amd64 Packages [30.8 kB]
+Get:21 http://repo.huaweicloud.com/ubuntu jammy-backports/universe Translation-en [16.9 kB]
+Get:22 http://repo.huaweicloud.com/ubuntu jammy-backports/universe amd64 c-n-f Metadata [676 B]
+Get:23 http://repo.huaweicloud.com/ubuntu jammy-security/main amd64 Packages [3,360 kB]
+Get:24 http://repo.huaweicloud.com/ubuntu jammy-security/main Translation-en [475 kB]
+Get:25 http://repo.huaweicloud.com/ubuntu jammy-security/main amd64 c-n-f Metadata [14.7 kB]
+Get:26 http://repo.huaweicloud.com/ubuntu jammy-security/restricted amd64 Packages [5,988 kB]
+Get:27 http://repo.huaweicloud.com/ubuntu jammy-security/restricted Translation-en [1,146 kB]
+Get:28 http://repo.huaweicloud.com/ubuntu jammy-security/restricted amd64 c-n-f Metadata [600 B]
+Get:29 http://repo.huaweicloud.com/ubuntu jammy-security/universe amd64 Packages [1,044 kB]
+Get:30 http://repo.huaweicloud.com/ubuntu jammy-security/universe Translation-en [233 kB]
+Get:31 http://repo.huaweicloud.com/ubuntu jammy-security/universe amd64 c-n-f Metadata [23.2 kB]
+Get:32 http://repo.huaweicloud.com/ubuntu jammy-security/multiverse amd64 Packages [64.3 kB]
+Get:33 http://repo.huaweicloud.com/ubuntu jammy-security/multiverse Translation-en [12.6 kB]
+Get:34 http://repo.huaweicloud.com/ubuntu jammy-security/multiverse amd64 c-n-f Metadata [544 B]
+Fetched 26.2 MB in 5s (4,978 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+unattended-upgrades is already the newest version (2.8ubuntu1).
+The following packages were automatically installed and are no longer required:
+  eatmydata libeatmydata1 libflashrom1 libftdi1-2 python-babel-localedata
+  python3-babel python3-certifi python3-jinja2 python3-json-pointer
+  python3-jsonpatch python3-jsonschema python3-markupsafe python3-pyrsistent
+  python3-requests python3-tz python3-urllib3
+Use 'apt autoremove' to remove them.
+The following additional packages will be installed:
+  libcurl4 libip4tc2 libip6tc2 libjq1 libonig5 libxtables12 python3-pyinotify
+  whois
+Suggested packages:
+  default-mta | mail-transport-agent www-browser x-terminal-emulator mailx
+  monit sqlite3 git-daemon-run | git-daemon-sysvinit git-doc git-email git-gui
+  gitk gitweb git-cvs git-mediawiki git-svn firewalld python-pyinotify-doc
+The following NEW packages will be installed:
+  apt-listchanges fail2ban jq libjq1 libonig5 python3-pyinotify whois
+The following packages will be upgraded:
+  ca-certificates curl git iptables libcurl4 libip4tc2 libip6tc2 libxtables12
+8 upgraded, 7 newly installed, 0 to remove and 332 not upgraded.
+Need to get 5,243 kB of archives.
+After this operation, 3,974 kB of additional disk space will be used.
+Get:1 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 ca-certificates all 20260601~22.04.1 [141 kB]
+Get:2 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 iptables amd64 1.8.7-1ubuntu5.2 [455 kB]
+Get:3 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libxtables12 amd64 1.8.7-1ubuntu5.2 [31.3 kB]
+Get:4 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libip6tc2 amd64 1.8.7-1ubuntu5.2 [20.3 kB]
+Get:5 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libip4tc2 amd64 1.8.7-1ubuntu5.2 [19.9 kB]
+Get:6 http://repo.huaweicloud.com/ubuntu jammy/main amd64 apt-listchanges all 3.24 [85.3 kB]
+Get:7 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 curl amd64 7.81.0-1ubuntu1.25 [194 kB]
+Get:8 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libcurl4 amd64 7.81.0-1ubuntu1.25 [291 kB]
+Get:9 http://repo.huaweicloud.com/ubuntu jammy/universe amd64 fail2ban all 0.11.2-6 [394 kB]
+Get:10 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 git amd64 1:2.34.1-1ubuntu1.17 [3,174 kB]
+Get:11 http://repo.huaweicloud.com/ubuntu jammy/main amd64 libonig5 amd64 6.9.7.1-2build1 [172 kB]
+Get:12 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libjq1 amd64 1.6-2.1ubuntu3.2 [135 kB]
+Get:13 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 jq amd64 1.6-2.1ubuntu3.2 [52.5 kB]
+Get:14 http://repo.huaweicloud.com/ubuntu jammy/main amd64 python3-pyinotify all 0.9.6-1.3 [24.8 kB]
+Get:15 http://repo.huaweicloud.com/ubuntu jammy/main amd64 whois amd64 5.5.13 [53.4 kB]
+Preconfiguring packages ...
+Fetched 5,243 kB in 1s (6,644 kB/s)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 80859 files and directories currently installed.)
+Preparing to unpack .../00-ca-certificates_20260601~22.04.1_all.deb ...
+Unpacking ca-certificates (20260601~22.04.1) over (20230311ubuntu0.22.04.1) ...
+Preparing to unpack .../01-iptables_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking iptables (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Preparing to unpack .../02-libxtables12_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking libxtables12:amd64 (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Preparing to unpack .../03-libip6tc2_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking libip6tc2:amd64 (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Preparing to unpack .../04-libip4tc2_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking libip4tc2:amd64 (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Selecting previously unselected package apt-listchanges.
+Preparing to unpack .../05-apt-listchanges_3.24_all.deb ...
+Unpacking apt-listchanges (3.24) ...
+Preparing to unpack .../06-curl_7.81.0-1ubuntu1.25_amd64.deb ...
+Unpacking curl (7.81.0-1ubuntu1.25) over (7.81.0-1ubuntu1.10) ...
+Preparing to unpack .../07-libcurl4_7.81.0-1ubuntu1.25_amd64.deb ...
+Unpacking libcurl4:amd64 (7.81.0-1ubuntu1.25) over (7.81.0-1ubuntu1.10) ...
+Selecting previously unselected package fail2ban.
+Preparing to unpack .../08-fail2ban_0.11.2-6_all.deb ...
+Unpacking fail2ban (0.11.2-6) ...
+Preparing to unpack .../09-git_1%3a2.34.1-1ubuntu1.17_amd64.deb ...
+Unpacking git (1:2.34.1-1ubuntu1.17) over (1:2.34.1-1ubuntu1.9) ...
+Selecting previously unselected package libonig5:amd64.
+Preparing to unpack .../10-libonig5_6.9.7.1-2build1_amd64.deb ...
+Unpacking libonig5:amd64 (6.9.7.1-2build1) ...
+Selecting previously unselected package libjq1:amd64.
+Preparing to unpack .../11-libjq1_1.6-2.1ubuntu3.2_amd64.deb ...
+Unpacking libjq1:amd64 (1.6-2.1ubuntu3.2) ...
+Selecting previously unselected package jq.
+Preparing to unpack .../12-jq_1.6-2.1ubuntu3.2_amd64.deb ...
+Unpacking jq (1.6-2.1ubuntu3.2) ...
+Selecting previously unselected package python3-pyinotify.
+Preparing to unpack .../13-python3-pyinotify_0.9.6-1.3_all.deb ...
+Unpacking python3-pyinotify (0.9.6-1.3) ...
+Selecting previously unselected package whois.
+Preparing to unpack .../14-whois_5.5.13_amd64.deb ...
+Unpacking whois (5.5.13) ...
+Setting up libip4tc2:amd64 (1.8.7-1ubuntu5.2) ...
+Setting up whois (5.5.13) ...
+Setting up libip6tc2:amd64 (1.8.7-1ubuntu5.2) ...
+Setting up fail2ban (0.11.2-6) ...
+Setting up python3-pyinotify (0.9.6-1.3) ...
+Setting up ca-certificates (20260601~22.04.1) ...
+Updating certificates in /etc/ssl/certs...
+rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
+24 added, 40 removed; done.
+Setting up git (1:2.34.1-1ubuntu1.17) ...
+Setting up libxtables12:amd64 (1.8.7-1ubuntu5.2) ...
+Setting up libcurl4:amd64 (7.81.0-1ubuntu1.25) ...
+Setting up curl (7.81.0-1ubuntu1.25) ...
+Setting up apt-listchanges (3.24) ...
+
+Creating config file /etc/apt/listchanges.conf with new version
+Setting up libonig5:amd64 (6.9.7.1-2build1) ...
+Setting up libjq1:amd64 (1.6-2.1ubuntu3.2) ...
+Setting up iptables (1.8.7-1ubuntu5.2) ...
+Setting up jq (1.6-2.1ubuntu3.2) ...
+Processing triggers for man-db (2.10.2-1) ...
+Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
+Processing triggers for ca-certificates (20260601~22.04.1) ...
+Updating certificates in /etc/ssl/certs...
+0 added, 0 removed; done.
+Running hooks in /etc/ca-certificates/update.d...
+done.
+NEEDRESTART-VER: 3.5
+NEEDRESTART-KCUR: 5.15.0-76-generic
+NEEDRESTART-KEXP: 5.15.0-76-generic
+NEEDRESTART-KSTA: 1
+NEEDRESTART-SVC: systemd-journald.service
+NEEDRESTART-SVC: systemd-logind.service
+NEEDRESTART-SVC: systemd-manager
+NEEDRESTART-SVC: systemd-resolved.service
+update-alternatives: using /usr/sbin/iptables-legacy to provide /usr/sbin/iptables (iptables) in manual mode
+update-alternatives: using /usr/sbin/ip6tables-legacy to provide /usr/sbin/ip6tables (ip6tables) in manual mode
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.ipv6.conf.lo.disable_ipv6 = 1
+* Applying /etc/sysctl.d/10-console-messages.conf ...
+kernel.printk = 4 4 1 7
+* Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
+net.ipv6.conf.all.use_tempaddr = 2
+net.ipv6.conf.default.use_tempaddr = 2
+* Applying /etc/sysctl.d/10-kernel-hardening.conf ...
+kernel.kptr_restrict = 1
+* Applying /etc/sysctl.d/10-magic-sysrq.conf ...
+kernel.sysrq = 176
+* Applying /etc/sysctl.d/10-network-security.conf ...
+net.ipv4.conf.default.rp_filter = 2
+net.ipv4.conf.all.rp_filter = 2
+* Applying /etc/sysctl.d/10-ptrace.conf ...
+kernel.yama.ptrace_scope = 1
+* Applying /etc/sysctl.d/10-zeropage.conf ...
+vm.mmap_min_addr = 65536
+* Applying /usr/lib/sysctl.d/50-default.conf ...
+kernel.core_uses_pid = 1
+net.ipv4.conf.default.rp_filter = 2
+net.ipv4.conf.default.accept_source_route = 0
+sysctl: setting key "net.ipv4.conf.all.accept_source_route": Invalid argument
+net.ipv4.conf.default.promote_secondaries = 1
+sysctl: setting key "net.ipv4.conf.all.promote_secondaries": Invalid argument
+net.ipv4.ping_group_range = 0 2147483647
+net.core.default_qdisc = fq_codel
+fs.protected_hardlinks = 1
+fs.protected_symlinks = 1
+fs.protected_regular = 1
+fs.protected_fifos = 1
+* Applying /usr/lib/sysctl.d/50-pid-max.conf ...
+kernel.pid_max = 4194304
+* Applying /etc/sysctl.d/99-catalyst-disable-ipv6.conf ...
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.ipv6.conf.lo.disable_ipv6 = 1
+* Applying /etc/sysctl.d/99-catalyst-inotify.conf ...
+fs.inotify.max_user_instances = 8192
+fs.inotify.max_user_watches = 1048576
+fs.inotify.max_queued_events = 16384
+* Applying /usr/lib/sysctl.d/99-protect-links.conf ...
+fs.protected_fifos = 1
+fs.protected_hardlinks = 1
+fs.protected_regular = 2
+fs.protected_symlinks = 1
+* Applying /etc/sysctl.d/99-sysctl.conf ...
+vm.swappiness = 0
+net.core.somaxconn = 1024
+net.ipv4.tcp_max_tw_buckets = 5000
+net.ipv4.tcp_max_syn_backlog = 1024
+* Applying /etc/sysctl.conf ...
+vm.swappiness = 0
+net.core.somaxconn = 1024
+net.ipv4.tcp_max_tw_buckets = 5000
+net.ipv4.tcp_max_syn_backlog = 1024
+Synchronizing state of fail2ban.service with SysV service script with /lib/systemd/systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable fail2ban
+Created symlink /etc/systemd/system/multi-user.target.wants/fail2ban.service → /lib/systemd/system/fail2ban.service.
+Synchronizing state of unattended-upgrades.service with SysV service script with /lib/systemd/systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable unattended-upgrades
+[INFO]  Using v1.31.4+k3s1 as release
+[INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/sha256sum-amd64.txt
+[INFO]  Downloading binary https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s
+[INFO]  Verifying binary download
+[INFO]  Installing k3s to /usr/local/bin/k3s
+[INFO]  Skipping installation of SELinux RPM
+[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
+[INFO]  Creating /usr/local/bin/crictl symlink to k3s
+[INFO]  Creating /usr/local/bin/ctr symlink to k3s
+[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
+[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
+[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
+[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
+[INFO]  systemd: Enabling k3s unit
+Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
+[INFO]  systemd: Starting k3s
+secondary kubeconfig PUT-back attempt 1 -> HTTP 201
+customresourcedefinition.apiextensions.k8s.io/backendlbpolicies.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/backendtlspolicies.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/referencegrants.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/tcproutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/tlsroutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/udproutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/tlsroutes.gateway.networking.k8s.io condition met
+Downloading https://get.helm.sh/helm-v3.21.3-linux-amd64.tar.gz
+Verifying checksum... Done.
+Preparing to install helm into /usr/local/bin
+helm installed into /usr/local/bin/helm
+"cilium" has been added to your repositories
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "cilium" chart repository
+Update Complete. ⎈Happy Helming!⎈
+Release "cilium" does not exist. Installing it now.
+NAME: cilium
+LAST DEPLOYED: Fri Jul 17 00:55:10 2026
+NAMESPACE: kube-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+You have successfully installed Cilium with Hubble.
+
+Your release version is 1.19.3.
+
+For any further help, visit https://docs.cilium.io/en/v1.19/gettinghelp
+Waiting for daemon set "cilium" rollout to finish: 0 of 1 updated pods are available...
+Waiting for daemon set "cilium" rollout to finish: 1 out of 2 new pods have been updated...
+Waiting for daemon set "cilium" rollout to finish: 0 of 2 updated pods are available...
+Waiting for daemon set "cilium" rollout to finish: 1 of 2 updated pods are available...
+Waiting for daemon set "cilium" rollout to finish: 2 out of 3 new pods have been updated...
+Waiting for daemon set "cilium" rollout to finish: 1 of 3 updated pods are available...
+Waiting for daemon set "cilium" rollout to finish: 3 out of 4 new pods have been updated...
+Waiting for daemon set "cilium" rollout to finish: 1 of 4 updated pods are available...
+Waiting for daemon set "cilium" rollout to finish: 2 of 4 updated pods are available...
+Waiting for daemon set "cilium" rollout to finish: 3 of 4 updated pods are available...
+error: timed out waiting for the condition
+Waiting for daemon set "cilium" rollout to finish: 3 of 4 updated pods are available...
+daemon set "cilium" successfully rolled out
+configmap/coredns-custom created
+namespace/flux-system created
+resourcequota/critical-pods created
+customresourcedefinition.apiextensions.k8s.io/alerts.notification.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/buckets.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/gitrepositories.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/helmcharts.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/helmreleases.helm.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/helmrepositories.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/imagepolicies.image.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/imagerepositories.image.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/imageupdateautomations.image.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/kustomizations.kustomize.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/ocirepositories.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/providers.notification.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/receivers.notification.toolkit.fluxcd.io created
+serviceaccount/helm-controller created
+serviceaccount/image-automation-controller created
+serviceaccount/image-reflector-controller created
+serviceaccount/kustomize-controller created
+serviceaccount/notification-controller created
+serviceaccount/source-controller created
+clusterrole.rbac.authorization.k8s.io/crd-controller created
+clusterrole.rbac.authorization.k8s.io/flux-edit created
+clusterrole.rbac.authorization.k8s.io/flux-view created
+clusterrolebinding.rbac.authorization.k8s.io/cluster-reconciler created
+clusterrolebinding.rbac.authorization.k8s.io/crd-controller created
+service/notification-controller created
+service/source-controller created
+service/webhook-receiver created
+deployment.apps/helm-controller created
+deployment.apps/image-automation-controller created
+deployment.apps/image-reflector-controller created
+deployment.apps/kustomize-controller created
+deployment.apps/notification-controller created
+deployment.apps/source-controller created
+networkpolicy.networking.k8s.io/allow-egress created
+networkpolicy.networking.k8s.io/allow-scraping created
+networkpolicy.networking.k8s.io/allow-webhooks created
+networkpolicy.networking.k8s.io "allow-egress" deleted
+networkpolicy.networking.k8s.io "allow-scraping" deleted
+networkpolicy.networking.k8s.io "allow-webhooks" deleted
+deployment.apps/helm-controller condition met
+deployment.apps/image-automation-controller condition met
+deployment.apps/image-reflector-controller condition met
+deployment.apps/kustomize-controller condition met
+deployment.apps/notification-controller condition met
+deployment.apps/source-controller condition met
+namespace/catalyst-system created
+namespace/openbao created
+secret/ghcr-pull created
+secret/harbor-robot-token created
+secret/pdm-basicauth created
+secret/catalyst-handover-jwt-public created
+secret/object-storage created
+secret/cloud-credentials created
+secret/openbao-recovery-seed created
+gitrepository.source.toolkit.fluxcd.io/openova created
+kustomization.kustomize.toolkit.fluxcd.io/bootstrap-kit created
+kustomization.kustomize.toolkit.fluxcd.io/sovereign-tls created
+kustomization.kustomize.toolkit.fluxcd.io/bootstrap-kit-crs created
+CLOUDINIT-SENTINEL: cloud-init-complete

--- a/docs/sessions/2026-07-17/prov-diagnostics/fe9eb3995b594b79-cloudinit.log
+++ b/docs/sessions/2026-07-17/prov-diagnostics/fe9eb3995b594b79-cloudinit.log
@@ -1,0 +1,423 @@
+Cloud-init v. 19.1 running 'init-local' at Thu, 16 Jul 2026 06:10:11 +0000. Up 11.04 seconds.
+Cloud-init v. 19.1 running 'init' at Thu, 16 Jul 2026 06:10:12 +0000. Up 12.22 seconds.
+ci-info: +++++++++++++++++++++++++++++++++++++++Net device info+++++++++++++++++++++++++++++++++++++++
+ci-info: +--------+------+------------------------------+---------------+--------+-------------------+
+ci-info: | Device |  Up  |           Address            |      Mask     | Scope  |     Hw-Address    |
+ci-info: +--------+------+------------------------------+---------------+--------+-------------------+
+ci-info: |  eth0  | True |         10.171.1.29          | 255.255.255.0 | global | fa:16:3e:a4:fa:16 |
+ci-info: |  eth0  | True | fe80::f816:3eff:fea4:fa16/64 |       .       |  link  | fa:16:3e:a4:fa:16 |
+ci-info: |   lo   | True |          127.0.0.1           |   255.0.0.0   |  host  |         .         |
+ci-info: |   lo   | True |           ::1/128            |       .       |  host  |         .         |
+ci-info: +--------+------+------------------------------+---------------+--------+-------------------+
+ci-info: +++++++++++++++++++++++++++++++Route IPv4 info++++++++++++++++++++++++++++++++
+ci-info: +-------+-----------------+------------+-----------------+-----------+-------+
+ci-info: | Route |   Destination   |  Gateway   |     Genmask     | Interface | Flags |
+ci-info: +-------+-----------------+------------+-----------------+-----------+-------+
+ci-info: |   0   |     0.0.0.0     | 10.171.1.1 |     0.0.0.0     |    eth0   |   UG  |
+ci-info: |   1   |    10.171.1.0   |  0.0.0.0   |  255.255.255.0  |    eth0   |   U   |
+ci-info: |   2   | 169.254.169.254 | 10.171.1.1 | 255.255.255.255 |    eth0   |  UGH  |
+ci-info: +-------+-----------------+------------+-----------------+-----------+-------+
+ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
+ci-info: +-------+-------------+---------+-----------+-------+
+ci-info: | Route | Destination | Gateway | Interface | Flags |
+ci-info: +-------+-------------+---------+-----------+-------+
+ci-info: |   1   |  fe80::/64  |    ::   |    eth0   |   U   |
+ci-info: |   3   |  multicast  |    ::   |    eth0   |   U   |
+ci-info: +-------+-------------+---------+-----------+-------+
+Generating public/private rsa key pair.
+Your identification has been saved in /etc/ssh/ssh_host_rsa_key
+Your public key has been saved in /etc/ssh/ssh_host_rsa_key.pub
+The key fingerprint is:
+SHA256:RiPhmcpP6uXxwRy1VWmfXuaPXXiVfCzE6bkodU5O/ys root@catalyst-hw261-omani-works-fe9eb399-me-east-215-b-cp1-7211b4
+The key's randomart image is:
++---[RSA 3072]----+
+|      .      ..o |
+|     . +     .*  |
+|      = o . .+.+o|
+|   . . o o o. B+B|
+|    o . S .. B.B+|
+|     + + .. . =.=|
+|    . + +  .   ++|
+|   . o o .   E. +|
+|    . . .     ...|
++----[SHA256]-----+
+Generating public/private dsa key pair.
+Your identification has been saved in /etc/ssh/ssh_host_dsa_key
+Your public key has been saved in /etc/ssh/ssh_host_dsa_key.pub
+The key fingerprint is:
+SHA256:Y4xFa2Tx+ME0ZjcCOip3K58vQm3Ik2ZTstKDlATw/xk root@catalyst-hw261-omani-works-fe9eb399-me-east-215-b-cp1-7211b4
+The key's randomart image is:
++---[DSA 1024]----+
+|+.      *o* o    |
+| ..    = O + .   |
+| ...  o = +      |
+|  o....* . .     |
+| ..++BE S .      |
+|  oo&oo= .       |
+|   =.=+          |
+|    .o..         |
+|     .oo.        |
++----[SHA256]-----+
+Generating public/private ecdsa key pair.
+Your identification has been saved in /etc/ssh/ssh_host_ecdsa_key
+Your public key has been saved in /etc/ssh/ssh_host_ecdsa_key.pub
+The key fingerprint is:
+SHA256:nS7n8QdeCb+GEDY5kwA2blv9Npwrmfi0Q/SCFx6s3c0 root@catalyst-hw261-omani-works-fe9eb399-me-east-215-b-cp1-7211b4
+The key's randomart image is:
++---[ECDSA 256]---+
+|      +.         |
+|     o ...       |
+|      o .o.o     |
+|     . o .&+..   |
+|      . SBoX*= . |
+|        ooB++oE  |
+|        ooO+.+ . |
+|         *.=o +  |
+|          +..o   |
++----[SHA256]-----+
+Generating public/private ed25519 key pair.
+Your identification has been saved in /etc/ssh/ssh_host_ed25519_key
+Your public key has been saved in /etc/ssh/ssh_host_ed25519_key.pub
+The key fingerprint is:
+SHA256:dNIwYettj1Ogj51Esf3VEPPf0oBr/v4U3a+zuTZGWG0 root@catalyst-hw261-omani-works-fe9eb399-me-east-215-b-cp1-7211b4
+The key's randomart image is:
++--[ED25519 256]--+
+|        =..   +. |
+|       . = + . +.|
+|        + * o ..+|
+|       o * . o.+E|
+|        S + +ooo*|
+|         * B. ..o|
+|        . * o.  o|
+|           . .=+ |
+|             +B*.|
++----[SHA256]-----+
+Cloud-init v. 19.1 running 'modules:config' at Thu, 16 Jul 2026 06:10:17 +0000. Up 17.25 seconds.
+Cloud-init v. 19.1 running 'modules:final' at Thu, 16 Jul 2026 06:10:25 +0000. Up 24.98 seconds.
+Hit:1 http://repo.huaweicloud.com/ubuntu jammy InRelease
+Get:2 http://repo.huaweicloud.com/ubuntu jammy-updates InRelease [128 kB]
+Get:3 http://repo.huaweicloud.com/ubuntu jammy-backports InRelease [127 kB]
+Get:4 http://repo.huaweicloud.com/ubuntu jammy-security InRelease [129 kB]
+Get:5 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 Packages [3,632 kB]
+Get:6 http://repo.huaweicloud.com/ubuntu jammy-updates/main Translation-en [544 kB]
+Get:7 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 c-n-f Metadata [20.1 kB]
+Get:8 http://repo.huaweicloud.com/ubuntu jammy-updates/restricted amd64 Packages [6,221 kB]
+Get:9 http://repo.huaweicloud.com/ubuntu jammy-updates/restricted Translation-en [1,189 kB]
+Get:10 http://repo.huaweicloud.com/ubuntu jammy-updates/restricted amd64 c-n-f Metadata [584 B]
+Get:11 http://repo.huaweicloud.com/ubuntu jammy-updates/universe amd64 Packages [1,278 kB]
+Get:12 http://repo.huaweicloud.com/ubuntu jammy-updates/universe Translation-en [321 kB]
+Get:13 http://repo.huaweicloud.com/ubuntu jammy-updates/universe amd64 c-n-f Metadata [30.8 kB]
+Get:14 http://repo.huaweicloud.com/ubuntu jammy-updates/multiverse amd64 Packages [71.6 kB]
+Get:15 http://repo.huaweicloud.com/ubuntu jammy-updates/multiverse Translation-en [15.5 kB]
+Get:16 http://repo.huaweicloud.com/ubuntu jammy-updates/multiverse amd64 c-n-f Metadata [756 B]
+Get:17 http://repo.huaweicloud.com/ubuntu jammy-backports/main amd64 Packages [70.2 kB]
+Get:18 http://repo.huaweicloud.com/ubuntu jammy-backports/main Translation-en [11.4 kB]
+Get:19 http://repo.huaweicloud.com/ubuntu jammy-backports/main amd64 c-n-f Metadata [412 B]
+Get:20 http://repo.huaweicloud.com/ubuntu jammy-backports/universe amd64 Packages [30.8 kB]
+Get:21 http://repo.huaweicloud.com/ubuntu jammy-backports/universe Translation-en [16.9 kB]
+Get:22 http://repo.huaweicloud.com/ubuntu jammy-backports/universe amd64 c-n-f Metadata [676 B]
+Get:23 http://repo.huaweicloud.com/ubuntu jammy-security/main amd64 Packages [3,360 kB]
+Get:24 http://repo.huaweicloud.com/ubuntu jammy-security/main Translation-en [475 kB]
+Get:25 http://repo.huaweicloud.com/ubuntu jammy-security/main amd64 c-n-f Metadata [14.7 kB]
+Get:26 http://repo.huaweicloud.com/ubuntu jammy-security/restricted amd64 Packages [5,988 kB]
+Get:27 http://repo.huaweicloud.com/ubuntu jammy-security/restricted Translation-en [1,146 kB]
+Get:28 http://repo.huaweicloud.com/ubuntu jammy-security/restricted amd64 c-n-f Metadata [600 B]
+Get:29 http://repo.huaweicloud.com/ubuntu jammy-security/universe amd64 Packages [1,044 kB]
+Get:30 http://repo.huaweicloud.com/ubuntu jammy-security/universe Translation-en [233 kB]
+Get:31 http://repo.huaweicloud.com/ubuntu jammy-security/universe amd64 c-n-f Metadata [23.2 kB]
+Get:32 http://repo.huaweicloud.com/ubuntu jammy-security/multiverse amd64 Packages [64.3 kB]
+Get:33 http://repo.huaweicloud.com/ubuntu jammy-security/multiverse Translation-en [12.6 kB]
+Get:34 http://repo.huaweicloud.com/ubuntu jammy-security/multiverse amd64 c-n-f Metadata [544 B]
+Fetched 26.2 MB in 5s (5,710 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+unattended-upgrades is already the newest version (2.8ubuntu1).
+The following packages were automatically installed and are no longer required:
+  eatmydata libeatmydata1 libflashrom1 libftdi1-2 python-babel-localedata
+  python3-babel python3-certifi python3-jinja2 python3-json-pointer
+  python3-jsonpatch python3-jsonschema python3-markupsafe python3-pyrsistent
+  python3-requests python3-tz python3-urllib3
+Use 'apt autoremove' to remove them.
+The following additional packages will be installed:
+  libcurl4 libip4tc2 libip6tc2 libjq1 libonig5 libxtables12 python3-pyinotify
+  whois
+Suggested packages:
+  default-mta | mail-transport-agent www-browser x-terminal-emulator mailx
+  monit sqlite3 git-daemon-run | git-daemon-sysvinit git-doc git-email git-gui
+  gitk gitweb git-cvs git-mediawiki git-svn firewalld python-pyinotify-doc
+The following NEW packages will be installed:
+  apt-listchanges fail2ban jq libjq1 libonig5 python3-pyinotify whois
+The following packages will be upgraded:
+  ca-certificates curl git iptables libcurl4 libip4tc2 libip6tc2 libxtables12
+8 upgraded, 7 newly installed, 0 to remove and 332 not upgraded.
+Need to get 5,243 kB of archives.
+After this operation, 3,974 kB of additional disk space will be used.
+Get:1 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 ca-certificates all 20260601~22.04.1 [141 kB]
+Get:2 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 iptables amd64 1.8.7-1ubuntu5.2 [455 kB]
+Get:3 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libxtables12 amd64 1.8.7-1ubuntu5.2 [31.3 kB]
+Get:4 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libip6tc2 amd64 1.8.7-1ubuntu5.2 [20.3 kB]
+Get:5 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libip4tc2 amd64 1.8.7-1ubuntu5.2 [19.9 kB]
+Get:6 http://repo.huaweicloud.com/ubuntu jammy/main amd64 apt-listchanges all 3.24 [85.3 kB]
+Get:7 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 curl amd64 7.81.0-1ubuntu1.25 [194 kB]
+Get:8 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libcurl4 amd64 7.81.0-1ubuntu1.25 [291 kB]
+Get:9 http://repo.huaweicloud.com/ubuntu jammy/universe amd64 fail2ban all 0.11.2-6 [394 kB]
+Get:10 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 git amd64 1:2.34.1-1ubuntu1.17 [3,174 kB]
+Get:11 http://repo.huaweicloud.com/ubuntu jammy/main amd64 libonig5 amd64 6.9.7.1-2build1 [172 kB]
+Get:12 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 libjq1 amd64 1.6-2.1ubuntu3.2 [135 kB]
+Get:13 http://repo.huaweicloud.com/ubuntu jammy-updates/main amd64 jq amd64 1.6-2.1ubuntu3.2 [52.5 kB]
+Get:14 http://repo.huaweicloud.com/ubuntu jammy/main amd64 python3-pyinotify all 0.9.6-1.3 [24.8 kB]
+Get:15 http://repo.huaweicloud.com/ubuntu jammy/main amd64 whois amd64 5.5.13 [53.4 kB]
+Preconfiguring packages ...
+Fetched 5,243 kB in 1s (7,634 kB/s)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 80859 files and directories currently installed.)
+Preparing to unpack .../00-ca-certificates_20260601~22.04.1_all.deb ...
+Unpacking ca-certificates (20260601~22.04.1) over (20230311ubuntu0.22.04.1) ...
+Preparing to unpack .../01-iptables_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking iptables (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Preparing to unpack .../02-libxtables12_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking libxtables12:amd64 (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Preparing to unpack .../03-libip6tc2_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking libip6tc2:amd64 (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Preparing to unpack .../04-libip4tc2_1.8.7-1ubuntu5.2_amd64.deb ...
+Unpacking libip4tc2:amd64 (1.8.7-1ubuntu5.2) over (1.8.7-1ubuntu5.1) ...
+Selecting previously unselected package apt-listchanges.
+Preparing to unpack .../05-apt-listchanges_3.24_all.deb ...
+Unpacking apt-listchanges (3.24) ...
+Preparing to unpack .../06-curl_7.81.0-1ubuntu1.25_amd64.deb ...
+Unpacking curl (7.81.0-1ubuntu1.25) over (7.81.0-1ubuntu1.10) ...
+Preparing to unpack .../07-libcurl4_7.81.0-1ubuntu1.25_amd64.deb ...
+Unpacking libcurl4:amd64 (7.81.0-1ubuntu1.25) over (7.81.0-1ubuntu1.10) ...
+Selecting previously unselected package fail2ban.
+Preparing to unpack .../08-fail2ban_0.11.2-6_all.deb ...
+Unpacking fail2ban (0.11.2-6) ...
+Preparing to unpack .../09-git_1%3a2.34.1-1ubuntu1.17_amd64.deb ...
+Unpacking git (1:2.34.1-1ubuntu1.17) over (1:2.34.1-1ubuntu1.9) ...
+Selecting previously unselected package libonig5:amd64.
+Preparing to unpack .../10-libonig5_6.9.7.1-2build1_amd64.deb ...
+Unpacking libonig5:amd64 (6.9.7.1-2build1) ...
+Selecting previously unselected package libjq1:amd64.
+Preparing to unpack .../11-libjq1_1.6-2.1ubuntu3.2_amd64.deb ...
+Unpacking libjq1:amd64 (1.6-2.1ubuntu3.2) ...
+Selecting previously unselected package jq.
+Preparing to unpack .../12-jq_1.6-2.1ubuntu3.2_amd64.deb ...
+Unpacking jq (1.6-2.1ubuntu3.2) ...
+Selecting previously unselected package python3-pyinotify.
+Preparing to unpack .../13-python3-pyinotify_0.9.6-1.3_all.deb ...
+Unpacking python3-pyinotify (0.9.6-1.3) ...
+Selecting previously unselected package whois.
+Preparing to unpack .../14-whois_5.5.13_amd64.deb ...
+Unpacking whois (5.5.13) ...
+Setting up libip4tc2:amd64 (1.8.7-1ubuntu5.2) ...
+Setting up whois (5.5.13) ...
+Setting up libip6tc2:amd64 (1.8.7-1ubuntu5.2) ...
+Setting up fail2ban (0.11.2-6) ...
+Setting up python3-pyinotify (0.9.6-1.3) ...
+Setting up ca-certificates (20260601~22.04.1) ...
+Updating certificates in /etc/ssl/certs...
+rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
+24 added, 40 removed; done.
+Setting up git (1:2.34.1-1ubuntu1.17) ...
+Setting up libxtables12:amd64 (1.8.7-1ubuntu5.2) ...
+Setting up libcurl4:amd64 (7.81.0-1ubuntu1.25) ...
+Setting up curl (7.81.0-1ubuntu1.25) ...
+Setting up apt-listchanges (3.24) ...
+
+Creating config file /etc/apt/listchanges.conf with new version
+Setting up libonig5:amd64 (6.9.7.1-2build1) ...
+Setting up libjq1:amd64 (1.6-2.1ubuntu3.2) ...
+Setting up iptables (1.8.7-1ubuntu5.2) ...
+Setting up jq (1.6-2.1ubuntu3.2) ...
+Processing triggers for man-db (2.10.2-1) ...
+Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
+Processing triggers for ca-certificates (20260601~22.04.1) ...
+Updating certificates in /etc/ssl/certs...
+0 added, 0 removed; done.
+Running hooks in /etc/ca-certificates/update.d...
+done.
+NEEDRESTART-VER: 3.5
+NEEDRESTART-KCUR: 5.15.0-76-generic
+NEEDRESTART-KEXP: 5.15.0-76-generic
+NEEDRESTART-KSTA: 1
+NEEDRESTART-SVC: systemd-journald.service
+NEEDRESTART-SVC: systemd-logind.service
+NEEDRESTART-SVC: systemd-manager
+NEEDRESTART-SVC: systemd-resolved.service
+update-alternatives: using /usr/sbin/iptables-legacy to provide /usr/sbin/iptables (iptables) in manual mode
+update-alternatives: using /usr/sbin/ip6tables-legacy to provide /usr/sbin/ip6tables (ip6tables) in manual mode
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.ipv6.conf.lo.disable_ipv6 = 1
+* Applying /etc/sysctl.d/10-console-messages.conf ...
+kernel.printk = 4 4 1 7
+* Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
+net.ipv6.conf.all.use_tempaddr = 2
+net.ipv6.conf.default.use_tempaddr = 2
+* Applying /etc/sysctl.d/10-kernel-hardening.conf ...
+kernel.kptr_restrict = 1
+* Applying /etc/sysctl.d/10-magic-sysrq.conf ...
+kernel.sysrq = 176
+* Applying /etc/sysctl.d/10-network-security.conf ...
+net.ipv4.conf.default.rp_filter = 2
+net.ipv4.conf.all.rp_filter = 2
+* Applying /etc/sysctl.d/10-ptrace.conf ...
+kernel.yama.ptrace_scope = 1
+* Applying /etc/sysctl.d/10-zeropage.conf ...
+vm.mmap_min_addr = 65536
+* Applying /usr/lib/sysctl.d/50-default.conf ...
+kernel.core_uses_pid = 1
+net.ipv4.conf.default.rp_filter = 2
+net.ipv4.conf.default.accept_source_route = 0
+sysctl: setting key "net.ipv4.conf.all.accept_source_route": Invalid argument
+net.ipv4.conf.default.promote_secondaries = 1
+sysctl: setting key "net.ipv4.conf.all.promote_secondaries": Invalid argument
+net.ipv4.ping_group_range = 0 2147483647
+net.core.default_qdisc = fq_codel
+fs.protected_hardlinks = 1
+fs.protected_symlinks = 1
+fs.protected_regular = 1
+fs.protected_fifos = 1
+* Applying /usr/lib/sysctl.d/50-pid-max.conf ...
+kernel.pid_max = 4194304
+* Applying /etc/sysctl.d/99-catalyst-disable-ipv6.conf ...
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.ipv6.conf.lo.disable_ipv6 = 1
+* Applying /etc/sysctl.d/99-catalyst-inotify.conf ...
+fs.inotify.max_user_instances = 8192
+fs.inotify.max_user_watches = 1048576
+fs.inotify.max_queued_events = 16384
+* Applying /usr/lib/sysctl.d/99-protect-links.conf ...
+fs.protected_fifos = 1
+fs.protected_hardlinks = 1
+fs.protected_regular = 2
+fs.protected_symlinks = 1
+* Applying /etc/sysctl.d/99-sysctl.conf ...
+vm.swappiness = 0
+net.core.somaxconn = 1024
+net.ipv4.tcp_max_tw_buckets = 5000
+net.ipv4.tcp_max_syn_backlog = 1024
+* Applying /etc/sysctl.conf ...
+vm.swappiness = 0
+net.core.somaxconn = 1024
+net.ipv4.tcp_max_tw_buckets = 5000
+net.ipv4.tcp_max_syn_backlog = 1024
+Synchronizing state of fail2ban.service with SysV service script with /lib/systemd/systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable fail2ban
+Created symlink /etc/systemd/system/multi-user.target.wants/fail2ban.service → /lib/systemd/system/fail2ban.service.
+Synchronizing state of unattended-upgrades.service with SysV service script with /lib/systemd/systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable unattended-upgrades
+[INFO]  Using v1.31.4+k3s1 as release
+[INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/sha256sum-amd64.txt
+[INFO]  Downloading binary https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s
+[INFO]  Verifying binary download
+[INFO]  Installing k3s to /usr/local/bin/k3s
+[INFO]  Skipping installation of SELinux RPM
+[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
+[INFO]  Creating /usr/local/bin/crictl symlink to k3s
+[INFO]  Creating /usr/local/bin/ctr symlink to k3s
+[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
+[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
+[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
+[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
+[INFO]  systemd: Enabling k3s unit
+Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
+[INFO]  systemd: Starting k3s
+secondary kubeconfig PUT-back attempt 1 -> HTTP 201
+customresourcedefinition.apiextensions.k8s.io/backendlbpolicies.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/backendtlspolicies.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/referencegrants.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/tcproutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/tlsroutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/udproutes.gateway.networking.k8s.io created
+customresourcedefinition.apiextensions.k8s.io/tlsroutes.gateway.networking.k8s.io condition met
+Downloading https://get.helm.sh/helm-v3.21.3-linux-amd64.tar.gz
+Verifying checksum... Done.
+Preparing to install helm into /usr/local/bin
+helm installed into /usr/local/bin/helm
+"cilium" has been added to your repositories
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "cilium" chart repository
+Update Complete. ⎈Happy Helming!⎈
+Release "cilium" does not exist. Installing it now.
+NAME: cilium
+LAST DEPLOYED: Thu Jul 16 14:11:33 2026
+NAMESPACE: kube-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+You have successfully installed Cilium with Hubble.
+
+Your release version is 1.19.3.
+
+For any further help, visit https://docs.cilium.io/en/v1.19/gettinghelp
+Waiting for daemon set "cilium" rollout to finish: 0 of 1 updated pods are available...
+daemon set "cilium" successfully rolled out
+configmap/coredns-custom created
+namespace/flux-system created
+resourcequota/critical-pods created
+customresourcedefinition.apiextensions.k8s.io/alerts.notification.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/buckets.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/gitrepositories.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/helmcharts.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/helmreleases.helm.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/helmrepositories.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/imagepolicies.image.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/imagerepositories.image.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/imageupdateautomations.image.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/kustomizations.kustomize.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/ocirepositories.source.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/providers.notification.toolkit.fluxcd.io created
+customresourcedefinition.apiextensions.k8s.io/receivers.notification.toolkit.fluxcd.io created
+serviceaccount/helm-controller created
+serviceaccount/image-automation-controller created
+serviceaccount/image-reflector-controller created
+serviceaccount/kustomize-controller created
+serviceaccount/notification-controller created
+serviceaccount/source-controller created
+clusterrole.rbac.authorization.k8s.io/crd-controller created
+clusterrole.rbac.authorization.k8s.io/flux-edit created
+clusterrole.rbac.authorization.k8s.io/flux-view created
+clusterrolebinding.rbac.authorization.k8s.io/cluster-reconciler created
+clusterrolebinding.rbac.authorization.k8s.io/crd-controller created
+service/notification-controller created
+service/source-controller created
+service/webhook-receiver created
+deployment.apps/helm-controller created
+deployment.apps/image-automation-controller created
+deployment.apps/image-reflector-controller created
+deployment.apps/kustomize-controller created
+deployment.apps/notification-controller created
+deployment.apps/source-controller created
+networkpolicy.networking.k8s.io/allow-egress created
+networkpolicy.networking.k8s.io/allow-scraping created
+networkpolicy.networking.k8s.io/allow-webhooks created
+networkpolicy.networking.k8s.io "allow-egress" deleted
+networkpolicy.networking.k8s.io "allow-scraping" deleted
+networkpolicy.networking.k8s.io "allow-webhooks" deleted
+deployment.apps/helm-controller condition met
+deployment.apps/image-automation-controller condition met
+deployment.apps/image-reflector-controller condition met
+deployment.apps/kustomize-controller condition met
+deployment.apps/notification-controller condition met
+deployment.apps/source-controller condition met
+namespace/catalyst-system created
+namespace/openbao created
+secret/ghcr-pull created
+secret/harbor-robot-token created
+secret/pdm-basicauth created
+secret/catalyst-handover-jwt-public created
+secret/object-storage created
+secret/cloud-credentials created
+secret/openbao-recovery-seed created
+gitrepository.source.toolkit.fluxcd.io/openova created
+kustomization.kustomize.toolkit.fluxcd.io/bootstrap-kit created
+kustomization.kustomize.toolkit.fluxcd.io/sovereign-tls created
+kustomization.kustomize.toolkit.fluxcd.io/bootstrap-kit-crs created
+CLOUDINIT-SENTINEL: cloud-init-complete

--- a/scripts/region-kill-drill.sh
+++ b/scripts/region-kill-drill.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# region-kill-drill.sh — canonical, reusable Region-Kill (G12 / DoD Pillar-3)
+# DR-failover drill for a live 2-region Huawei kom4dc Sovereign.
+#
+# Mechanics proven on hw256 (2026-07-15) + hw261 (2026-07-16):
+#   batch HARD os-stop ALL region-a ECS via HCS ECS action API → region-a
+#   apiserver dies (~4-5s) → promote region-b CNPG replicas
+#   (spec.replica.enabled=false) → RTO ~5.7s, RPO=0 (pre-kill sentinel survives)
+#   → post-kill write accepted → openbao auto-unseal via the */2 reconciler
+#   CronJob (bp-openbao ≥1.2.62) → os-start region-a to recover.
+#
+# 🛑 SAFETY (fail-closed, layered):
+#   * DRY-RUN by default. The destructive os-stop fires ONLY with --arm.
+#   * The kill set is RESTRICTED to ECS whose name contains the region-a token
+#     (default `-me-east-215-a-`). Servers without it are NEVER touched.
+#   * The bastion is hard-excluded by name-prefix `bastion`, by EIP
+#     212.72.24.20, AND by explicit id-prefix guard. NEVER stopped. (founder:
+#     bastion-openova is the ONE protected Huawei resource.)
+#   * If discovery finds 0 region-a ECS, or if any target matches a guard, the
+#     script ABORTS rather than proceed.
+#
+# Usage:
+#   KUBECONFIG=/tmp/hwNNN.kubeconfig HW_TFVARS=/tmp/preflight-tfvars.json \
+#     scripts/region-kill-drill.sh discover                 # list kill-set (safe)
+#   ... region-kill-drill.sh kill --arm                     # os-stop region-a
+#   ... region-kill-drill.sh recover                        # os-start region-a
+#
+# Env:
+#   KUBECONFIG   — the Sovereign kubeconfig (region-a control-plane).
+#   HW_TFVARS    — tfvars json with huawei_access_key/secret_key/project_id/region.
+#   REGION_A_TOKEN (default "-me-east-215-a-") — substring identifying region-a ECS.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+HW_TFVARS="${HW_TFVARS:-/tmp/preflight-tfvars.json}"
+REGION_A_TOKEN="${REGION_A_TOKEN:--me-east-215-a-}"
+BASTION_EIP="212.72.24.20"
+CMD="${1:-discover}"; ARM=""; [ "${2:-}" = "--arm" ] && ARM="1"
+K(){ timeout 25 kubectl --request-timeout=20s "$@"; }
+
+[ -f "$HW_TFVARS" ] || { echo "!! HW_TFVARS not found: $HW_TFVARS"; exit 2; }
+
+# discover_region_a — print JSON array [{id,name,status}] of region-a ECS,
+# with the bastion + non-region-a servers filtered OUT. Fails closed.
+discover_region_a() {
+  python3 - "$HW_TFVARS" "$REGION_A_TOKEN" "$BASTION_EIP" <<'PY'
+import sys,json,hashlib,hmac,datetime,ssl,urllib.request
+tf=json.load(open(sys.argv[1])); tok=sys.argv[2]; beip=sys.argv[3]
+ak=tf.get("huawei_access_key") or tf.get("huawei_ak")
+sk=tf.get("huawei_secret_key") or tf.get("huawei_sk")
+proj=tf.get("huawei_project_id"); region=tf.get("huawei_region")
+host=f"ecs.{region}.kom4dc.nationalcloud.om"; uri=f"/v1/{proj}/cloudservers/detail"
+now=datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+sh="host;x-sdk-date"; ch=f"host:{host}\nx-sdk-date:{now}\n"
+cr=f"GET\n{uri}/\n\n{ch}\n{sh}\n"+hashlib.sha256(b'').hexdigest()
+sts=f"SDK-HMAC-SHA256\n{now}\n"+hashlib.sha256(cr.encode()).hexdigest()
+sig=hmac.new(sk.encode(),sts.encode(),hashlib.sha256).hexdigest()
+ctx=ssl.create_default_context(); ctx.check_hostname=False; ctx.verify_mode=ssl.CERT_NONE
+req=urllib.request.Request(f"https://{host}{uri}",headers={"X-Sdk-Date":now,"Authorization":f"SDK-HMAC-SHA256 Access={ak}, SignedHeaders={sh}, Signature={sig}","host":host})
+servers=json.load(urllib.request.urlopen(req,timeout=25,context=ctx)).get("servers",[])
+out=[]
+for s in servers:
+    name=s.get("name",""); sid=s.get("id","")
+    # LAYER 1: must be a region-a ECS (token present)
+    if tok not in name: continue
+    # LAYER 2: bastion hard-guard (name prefix)
+    if name.startswith("bastion"): continue
+    # LAYER 3: bastion hard-guard (EIP attached)
+    addrs=s.get("addresses",{}) or {}
+    eips=[a.get("addr") for grp in addrs.values() for a in grp if a.get("OS-EXT-IPS:type")=="floating"]
+    if beip in eips: continue
+    out.append({"id":sid,"name":name,"status":s.get("status")})
+print(json.dumps(out))
+PY
+}
+
+# ecs_action <json-action-body> — POST signed action to the ECS action API.
+ecs_action() {
+  python3 - "$HW_TFVARS" "$1" <<'PY'
+import sys,json,hashlib,hmac,datetime,ssl,urllib.request
+tf=json.load(open(sys.argv[1])); body=sys.argv[2].encode()
+ak=tf.get("huawei_access_key") or tf.get("huawei_ak")
+sk=tf.get("huawei_secret_key") or tf.get("huawei_sk")
+proj=tf.get("huawei_project_id"); region=tf.get("huawei_region")
+host=f"ecs.{region}.kom4dc.nationalcloud.om"; uri=f"/v1/{proj}/cloudservers/action"
+now=datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+sh="content-type;host;x-sdk-date"; ch=f"content-type:application/json\nhost:{host}\nx-sdk-date:{now}\n"
+cr=f"POST\n{uri}/\n\n{ch}\n{sh}\n"+hashlib.sha256(body).hexdigest()
+sts=f"SDK-HMAC-SHA256\n{now}\n"+hashlib.sha256(cr.encode()).hexdigest()
+sig=hmac.new(sk.encode(),sts.encode(),hashlib.sha256).hexdigest()
+ctx=ssl.create_default_context(); ctx.check_hostname=False; ctx.verify_mode=ssl.CERT_NONE
+req=urllib.request.Request(f"https://{host}{uri}",data=body,method="POST",headers={"Content-Type":"application/json","X-Sdk-Date":now,"Authorization":f"SDK-HMAC-SHA256 Access={ak}, SignedHeaders={sh}, Signature={sig}","host":host})
+try:
+    r=urllib.request.urlopen(req,timeout=25,context=ctx); print("HTTP",r.status,r.read().decode()[:200])
+except urllib.error.HTTPError as e: print("HTTP",e.code,e.read().decode()[:300])
+PY
+}
+
+targets_or_die() {
+  local js; js=$(discover_region_a) || { echo "!! discovery failed"; exit 3; }
+  local n; n=$(printf '%s' "$js" | python3 -c 'import sys,json;print(len(json.load(sys.stdin)))')
+  [ "$n" -ge 1 ] || { echo "!! 0 region-a ECS discovered (token=$REGION_A_TOKEN) — ABORT (nothing to kill / wrong env)"; exit 3; }
+  echo "$js"
+}
+
+case "$CMD" in
+  discover)
+    echo "== region-a kill-set (token=$REGION_A_TOKEN; bastion $BASTION_EIP hard-excluded) =="
+    targets_or_die | python3 -c 'import sys,json;[print("  ",x["id"],x["name"],x["status"]) for x in json.load(sys.stdin)]'
+    echo "(dry-run — no action taken; run `kill --arm` to os-stop)"
+    ;;
+  kill)
+    js=$(targets_or_die)
+    echo "== KILL region-a (HARD os-stop) =="
+    printf '%s' "$js" | python3 -c 'import sys,json;[print("  target:",x["id"],x["name"],x["status"]) for x in json.load(sys.stdin)]'
+    ids=$(printf '%s' "$js" | python3 -c 'import sys,json;print(",".join(x["id"] for x in json.load(sys.stdin)))')
+    body=$(printf '%s' "$js" | python3 -c 'import sys,json;s=json.load(sys.stdin);print(json.dumps({"os-stop":{"type":"HARD","servers":[{"id":x["id"]} for x in s]}}))')
+    if [ -z "$ARM" ]; then echo "DRY-RUN (no --arm): would POST os-stop for [$ids]"; echo "$body"; exit 0; fi
+    echo "T0=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ) — issuing HARD os-stop"
+    ecs_action "$body"
+    echo "-- polling region-a apiserver death --"
+    for i in $(seq 1 30); do
+      if ! K get --raw='/readyz' >/dev/null 2>&1; then echo "region-a apiserver DEAD at poll $i ($(date -u +%H:%M:%S.%3NZ))"; break; fi
+      sleep 2
+    done
+    ;;
+  recover)
+    js=$(targets_or_die)
+    body=$(printf '%s' "$js" | python3 -c 'import sys,json;s=json.load(sys.stdin);print(json.dumps({"os-start":{"servers":[{"id":x["id"]} for x in s]}}))')
+    echo "== RECOVER region-a (os-start) =="
+    if [ -z "$ARM" ]; then echo "DRY-RUN (no --arm): would POST os-start"; echo "$body"; exit 0; fi
+    ecs_action "$body"
+    ;;
+  *) echo "usage: $0 {discover | kill --arm | recover --arm}"; exit 2 ;;
+esac

--- a/scripts/region-kill-drill.sh
+++ b/scripts/region-kill-drill.sh
@@ -108,7 +108,7 @@ case "$CMD" in
   discover)
     echo "== region-a kill-set (token=$REGION_A_TOKEN; bastion $BASTION_EIP hard-excluded) =="
     targets_or_die | python3 -c 'import sys,json;[print("  ",x["id"],x["name"],x["status"]) for x in json.load(sys.stdin)]'
-    echo "(dry-run — no action taken; run `kill --arm` to os-stop)"
+    echo "(dry-run — no action taken; run 'kill --arm' to os-stop)"
     ;;
   kill)
     js=$(targets_or_die)


### PR DESCRIPTION
One-char fix: the discover hint used backticks around kill --arm, which bash executed as a command substitution. Single-quoted the literal. Validated live against hw263 Huawei ECS — discover correctly lists the 4 region-a nodes with bastion excluded. Scripts-only, convergence-safe. Refs #960