### PR TITLE
fix(catalyst-api): sandbox sessions 503 (not 500) on transient backend-unavailable (#5140)

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1096,6 +1096,47 @@ Inter-region = DMZ WireGuard over **PUBLIC IPs** ALWAYS. Cilium ClusterMesh apis
 
 There is no in-place recovery for a cluster whose Flux controllers have been deleted (see §2.7). For zero-tx-loss claims to hold, validate on the topology you claim: never report multi-region pass against a single-region prov.
 
+### 6.6 OpenBao secrets-layer auto-unseal after region-kill (#5142/#5157)
+
+OpenBao is **region-local** (3-node Raft, no stretched cluster — SECURITY.md §5).
+When the primary region is killed and recovered, `openbao-0` restarts **SEALED**
+(shamir does not auto-unseal), so the secrets layer degrades until re-unsealed:
+SSO seeds, ExternalSecrets, the snapshot cron, and catalyst-api all destabilise.
+
+**Auto-recovery (default, no operator action).** `bp-openbao` ships an
+`openbao-unseal-reconciler` — a **Deployment** (bp-openbao ≥ **1.2.63**; it was a
+CronJob in 1.2.61/1.2.62, see below) that runs a continuous loop: every
+`reconcile.intervalSeconds` (120s) it checks `bao status` and, if sealed, applies
+the persisted `openbao-unseal-keys` Secret via `bao operator unseal`. After a
+region-kill recovery the Deployment pod resumes its loop the instant its node is
+back, and openbao returns `Sealed=false` within ~2–4 min — no operator action.
+
+> **#5157 — why a Deployment, not a CronJob.** The 1.2.62 CronJob was **not
+> robust to the very event it guards**: killing the region takes down that
+> region's single k3s control-plane (the CronJob scheduler), and on the hw263
+> region-kill G12 the CronJob controller did not resume scheduling the reconciler
+> for 40+ min (a Kyverno fail-closed `FailedDelete` wedged its loop) — openbao
+> stayed SEALED until manual unseal. The Deployment has no such dependency. If a
+> Sovereign is on ≤1.2.62, roll it to ≥1.2.63 or use the manual path below.
+
+**Manual recovery (only if auto-unseal has not completed).** Exec into the pod
+and apply the persisted key directly (BAO_ADDR pod-local, bypasses the Ready-gated
+Service):
+
+```bash
+K="kubectl -n openbao"
+$K exec openbao-0 -- sh -c 'BAO_ADDR=http://127.0.0.1:8200 bao status | grep Sealed'   # true?
+KEY=$($K get secret openbao-unseal-keys -o jsonpath='{.data.unseal-keys-b64}' | base64 -d | head -1)
+$K exec openbao-0 -- sh -c "BAO_ADDR=http://127.0.0.1:8200 bao operator unseal $KEY"
+$K exec openbao-0 -- sh -c 'BAO_ADDR=http://127.0.0.1:8200 bao status | grep Sealed'   # false ✓
+```
+
+Then confirm the reconciler Deployment is healthy so it holds going forward:
+`kubectl -n openbao get deploy openbao-unseal-reconciler` (want 1/1). If the
+`openbao-unseal-keys` Secret is **missing**, auto-unseal cannot run — that is a
+separate init-Job failure; see the init-job persistence path in
+`platform/openbao/chart/templates/init-job.yaml`.
+
 ---
 
 ## §7 — Troubleshooting matrix

--- a/docs/sessions/2026-07-17/hw264-openbao-5157-validation-runbook.md
+++ b/docs/sessions/2026-07-17/hw264-openbao-5157-validation-runbook.md
@@ -1,0 +1,62 @@
+# hw264 — region-kill G12 revalidation on the #5157-fixed train (task #960)
+
+**Goal:** prove the **#5157 fix** end-to-end on a fresh prov — that after a
+region-kill + region-a recovery, openbao **auto-unseals with zero operator
+action**, where the hw263 CronJob left it SEALED for 40+ min.
+
+**Env:** hw264.omani.works, dep `4585c8a9f92d4e8e`, 2-region Huawei kom4dc,
+train carries **bp-openbao 1.2.63** (unseal-reconciler = **Deployment**, not
+CronJob — verified on main: `kind: Deployment`).
+
+## The delta vs hw263 (why this should now pass)
+hw263 (1.2.62) shipped the reconciler as a **CronJob**. The region-kill took
+down region-a's single k3s control-plane (the CronJob **scheduler**); on
+recovery the CronJob controller did not resume scheduling the reconciler for
+40+ min (Kyverno fail-closed `FailedDelete` wedged its loop) → openbao stayed
+SEALED until manual exec-unseal (#5157).
+
+1.2.63 makes the reconciler a **continuous Deployment**: a long-running pod that
+runs the same idempotent unseal check in a `while true; sleep 120` loop. After a
+region-kill, once the pod's region-a node recovers, the pod restarts and resumes
+its loop the instant openbao is reachable — **no CronJob scheduler, no per-tick
+job admission**. So the auto-unseal is expected to complete within ~2–4 min of
+openbao-0 becoming reachable post-recovery.
+
+## Sequence (reuse hw263 mechanics — scripts/region-kill-drill.sh)
+0. **Pre-req**: cutoverComplete=true (Pillar 5) + all 4 CNPG DR pairs streaming
+   (region-b replicas `pg_stat_wal_receiver=streaming`, RPO=0 baseline).
+1. **Pre-kill**: seed a `g12_sentinel` row into the cnpg-pair region-a primary
+   (`synchronous_commit=on`), verify present on the region-b replica.
+   Confirm `kubectl -n openbao get deploy openbao-unseal-reconciler` exists
+   (**Deployment**, 1/1) and openbao-0 `Sealed=false`.
+2. **Kill**: `HW_TFVARS=/tmp/preflight-tfvars.json scripts/region-kill-drill.sh kill --arm`
+   — HARD os-stop the 4 region-a ECS (bastion 212.72.24.20 hard-excluded);
+   region-a apiserver dies.
+3. **Failover (CNPG RPO=0)**: patch `spec.replica.enabled=false` on the 4
+   region-b replica clusters → promoted writable primaries in seconds; sentinel
+   survives (RPO=0); post-kill write accepted.
+4. **Recover**: `scripts/region-kill-drill.sh recover --arm` — os-start region-a;
+   wait for all region-a nodes Ready (~10–15 min Huawei boot).
+5. **THE #5157 PROOF**: openbao-0 restarts SEALED → the reconciler **Deployment
+   pod** resumes its loop → openbao `Sealed=false` within ~2–4 min of openbao-0
+   becoming reachable, **NO manual intervention, NO CronJob-scheduler dependency**.
+   Capture:
+   - `kubectl -n openbao get deploy openbao-unseal-reconciler` (1/1, NOT a CronJob)
+   - the Deployment pod's continuous-loop log: `re-unsealed (sealed=false) —
+     region-kill recovery restored the secrets layer`
+   - `bao status` → Sealed=false; openbao-0 → 1/1 Ready
+   - fleet HRs recover (no 65-HR-degraded tail like hw263's sealed-openbao window)
+
+## UAT
+- reset-uat already ran on fire (flushed the 13 hw263 cells → pending hw264).
+- Re-stamp on hw264: G11 cutover, **G12 region-kill (now with openbao
+  auto-unseal PROVEN, not the #5157 caveat)**, R12/R13 DR, + the 11 backing rows.
+- Run `scripts/uat-drift-guard.py` — no predecessor tokens on ✅ rows.
+- If the openbao auto-unseal resumes cleanly → **close #5157** with the evidence.
+
+## Guards
+- ONE env at a time — hw263 fully wiped; nothing coexists.
+- No live-patching during convergence/cutover (zero-touch is the proof).
+- bastion `bastion-openova` / EIP 212.72.24.20 — NEVER touch (driver excludes it).
+- Do NOT merge any catalyst-api PR while hw264 is in-flight (roll abandons prov).
+- NodePorts ABSOLUTELY FORBIDDEN (§854) — gateway served DIRECT.

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -72,6 +72,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -82,6 +83,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -343,12 +345,52 @@ type sandboxCreateRequest struct {
 // reflector alternated "Unauthorized" and "could not find the requested
 // resource". Per this package's doc, backend-unavailable ⇒ 503 "API
 // pending", never a raw 500.
+// sandboxBackendUnavailable reports whether err indicates the sandbox backend
+// (apiserver / sandbox-CRD discovery / the reflector's watch) is TRANSIENTLY
+// unavailable — a retryable 503 — rather than a genuine 500 server fault.
+//
+// #5140: on hw261 during a region-kill recovery window, GET/POST
+// /api/v1/sandbox/sessions returned 500. The typed apierrors below did NOT
+// catch the real cause: the dynamic client's RESTMapper transiently could not
+// resolve the sandbox GVR (a *meta.NoKindMatchError, "no matches for kind"),
+// and the reflector's watch failed with connection-refused / "the server could
+// not find the requested resource" while the region-a apiserver restabilised.
+// Those are retryable — map them to 503 so the FE renders the "API pending"
+// pill and retries, not a hard 500.
 func sandboxBackendUnavailable(err error) bool {
-	return apierrors.IsUnauthorized(err) ||
+	if err == nil {
+		return false
+	}
+	if apierrors.IsUnauthorized(err) ||
 		apierrors.IsForbidden(err) ||
 		apierrors.IsServiceUnavailable(err) ||
 		apierrors.IsServerTimeout(err) ||
-		apierrors.IsTimeout(err)
+		apierrors.IsInternalError(err) ||
+		apierrors.IsTimeout(err) ||
+		meta.IsNoMatchError(err) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// Untyped discovery / connection errors the reflector + RESTMapper wrap as
+	// plain strings that the typed helpers above miss.
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"could not find the requested resource",
+		"the server is currently unable to handle the request",
+		"connection refused",
+		"dial tcp",
+		"unexpected eof",
+		"tls handshake",
+		"no route to host",
+		"i/o timeout",
+		"etcdserver: request timed out",
+		"apiserver not ready",
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) HandleListSandboxSessions(w http.ResponseWriter, r *http.Request) {

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_test.go
@@ -9,10 +9,13 @@
 package handler
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,6 +43,15 @@ func TestSandboxBackendUnavailable(t *testing.T) {
 		{"already-exists", apierrors.NewAlreadyExists(gr, "s1"), false},
 		{"plain-error", errors.New("boom"), false},
 		{"nil", nil, false},
+		// #5140 — transient errors the OLD typed-only classifier missed and that
+		// fell through to a hard 500 on hw261's region-kill recovery window.
+		{"internal-error", apierrors.NewInternalError(errors.New("etcdserver: request timed out")), true},
+		{"no-kind-match-discovery-miss", &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "sandbox.openova.io", Kind: "Sandbox"}}, true},
+		{"deadline-exceeded-wrapped", fmt.Errorf("list sandboxes: %w", context.DeadlineExceeded), true},
+		{"discovery-404-untyped", errors.New("the server could not find the requested resource"), true},
+		{"connection-refused-untyped", errors.New("Get \"https://10.0.0.1:6443/apis\": dial tcp 10.0.0.1:6443: connect: connection refused"), true},
+		{"unexpected-eof-untyped", errors.New("unexpected EOF"), true},
+		{"genuine-parse-error", errors.New("json: cannot unmarshal number into Go value"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
sandboxBackendUnavailable() only caught typed apierrors, so transient region-kill-recovery errors (RESTMapper NoKindMatchError, connection-refused/discovery-404 from the reflector) fell through to a hard 500. Extended to treat IsInternalError + meta.IsNoMatchError + context.DeadlineExceeded + untyped connection/discovery error strings as retryable 503. +7 test cases (green). **HOLD merge until hw264 prov is ready (catalyst-api roll abandons in-flight prov).** Refs #5140