### PR TITLE
fix(console): CiliumNetworkPolicy as distinct graph node, not folded into NetworkPolicy (#5129)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/icons.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/icons.ts
@@ -80,5 +80,6 @@ export const NODE_ICON: Record<ArchNodeType, Icon> = {
   Gateway: IconRouteAltLeft,
   HTTPRoute: IconRouteAltLeft,
   NetworkPolicy: IconShieldLock,
+  CiliumNetworkPolicy: IconShieldLock,
   Database: IconDatabase,
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
@@ -466,6 +466,58 @@ describe('k8sToGraph', () => {
       }),
     )
   })
+
+  it('#5129: emits CiliumNetworkPolicy as a DISTINCT node type (not folded into NetworkPolicy)', () => {
+    const s = snap(
+      ['namespace:gitea', { metadata: { name: 'gitea' } }],
+      [
+        'networkpolicy:gitea/vanilla-np',
+        {
+          apiVersion: 'networking.k8s.io/v1',
+          kind: 'NetworkPolicy',
+          metadata: { namespace: 'gitea', name: 'vanilla-np' },
+          spec: { podSelector: {} },
+        },
+      ],
+      [
+        'ciliumnetworkpolicy:gitea/gitea-egress',
+        {
+          apiVersion: 'cilium.io/v2',
+          kind: 'CiliumNetworkPolicy',
+          metadata: { namespace: 'gitea', name: 'gitea-egress' },
+          spec: { endpointSelector: {} },
+        },
+      ],
+      [
+        'ciliumclusterwidenetworkpolicy:/baseline-deny',
+        {
+          apiVersion: 'cilium.io/v2',
+          kind: 'CiliumClusterwideNetworkPolicy',
+          metadata: { name: 'baseline-deny' },
+          spec: { endpointSelector: {} },
+        },
+      ],
+    )
+    const { nodes, edges } = k8sToGraph(s)
+    // The vanilla NP is still its own type…
+    expect(nodes.find((n) => n.id === 'NetworkPolicy:gitea/vanilla-np')?.type).toBe('NetworkPolicy')
+    // …and the CiliumNetworkPolicy is a SEPARATE node type, not folded in.
+    const cnp = nodes.find((n) => n.id === 'CiliumNetworkPolicy:gitea/gitea-egress')
+    expect(cnp).toBeDefined()
+    expect(cnp?.type).toBe('CiliumNetworkPolicy')
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        source: 'CiliumNetworkPolicy:gitea/gitea-egress',
+        target: 'Namespace:gitea',
+        type: 'member-of',
+      }),
+    )
+    // Clusterwide CNP renders (no namespace → id has no ns segment, no member-of edge).
+    const ccnp = nodes.find((n) => n.id === 'CiliumNetworkPolicy:baseline-deny')
+    expect(ccnp?.type).toBe('CiliumNetworkPolicy')
+    // No NetworkPolicy node was created for the Cilium policies (no fold).
+    expect(nodes.filter((n) => n.type === 'NetworkPolicy')).toHaveLength(1)
+  })
 })
 
 describe('mergeGraphs', () => {

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
@@ -545,6 +545,34 @@ export function k8sToGraph(snapshot: K8sSnapshot): AdaptResult {
     })
   }
 
+  // 6e. CiliumNetworkPolicies (cilium.io/v2) — L3-L7 micro-segmentation,
+  //     rendered as a DISTINCT node type so the Networking lens no longer
+  //     folds them into the vanilla NetworkPolicy count (#5129). Edge: → Namespace.
+  for (const cnpKind of ['ciliumnetworkpolicy', 'ciliumclusterwidenetworkpolicy'] as const) {
+    for (const [, cnp] of iterByKind(snapshot, cnpKind)) {
+      const ns = cnp.metadata?.namespace ?? ''
+      const name = cnp.metadata?.name ?? ''
+      if (!name) continue
+      const id = compositeId('CiliumNetworkPolicy', ns, name)
+      addNode({
+        id,
+        type: 'CiliumNetworkPolicy',
+        label: name,
+        sublabel: ns || 'cluster-wide',
+        status: 'healthy',
+        metadata: { namespace: ns },
+      })
+      if (ns) {
+        addEdge({
+          id: `e:${id}->Namespace:${ns}`,
+          source: id,
+          target: compositeId('Namespace', '', ns),
+          type: 'member-of',
+        })
+      }
+    }
+  }
+
   // 7. PVCs.
   for (const [, pvc] of iterByKind(snapshot, 'persistentvolumeclaim')) {
     const ns = pvc.metadata?.namespace ?? ''

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/types.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/types.ts
@@ -73,6 +73,7 @@ export type ArchNodeType =
   | 'Gateway'
   | 'HTTPRoute'
   | 'NetworkPolicy'
+  | 'CiliumNetworkPolicy'
   | 'Database'
 
 /**
@@ -117,6 +118,7 @@ export const ALL_NODE_TYPES: ArchNodeType[] = [
   'Gateway',
   'HTTPRoute',
   'NetworkPolicy',
+  'CiliumNetworkPolicy',
   'Database',
 ]
 
@@ -287,6 +289,7 @@ export const NODE_CATEGORY: Record<ArchNodeType, NodeCategory> = {
   HTTPRoute: 'network',
   Network: 'network',
   NetworkPolicy: 'network',
+  CiliumNetworkPolicy: 'network',
   // ◆ Config / Identity / Secret
   ConfigMap: 'config',
   Secret: 'config',
@@ -379,6 +382,7 @@ export const NODE_FAMILY: Record<ArchNodeType, NodeFamily> = {
   // Cilium / networking
   Network: 'cilium',
   NetworkPolicy: 'cilium',
+  CiliumNetworkPolicy: 'cilium',
   Gateway: 'cilium',
   HTTPRoute: 'cilium',
   // Catalyst control-plane CRs (*.openova.io)
@@ -551,6 +555,7 @@ export const NODE_FILL: Record<ArchNodeType, string> = {
   Gateway: '#0891b2', // cyan — networking
   HTTPRoute: '#1098ad', // teal-cyan — networking
   NetworkPolicy: '#15aabf', // bright cyan — networking
+  CiliumNetworkPolicy: '#0c8599', // deep cyan — Cilium L3-L7 micro-seg (#5129)
   Database: '#4338ca', // indigo — CNPG
 }
 


### PR DESCRIPTION
Cloud-view architecture-graph Networking lens folded CNP into a single NetworkPolicy chip. Added CiliumNetworkPolicy as a first-class graph node type (union+category+family+colour+icon) + adapter §6e iterating ciliumnetworkpolicy/ciliumclusterwidenetworkpolicy → distinct nodes. tsc clean + 23/23 adapter tests green. Console FE only. **Hold merge until hw264 prov is past cutover** (console baked into catalyst-api image). Refs #5129