### PR TITLE
fix(cnpg-pair): DR failover through HR desired state (Refs #5125 Defect-1)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -203,7 +203,11 @@ spec:
       # streaming_replica (postgres superuser disabled) and measures apply
       # lag via LSN receive-vs-replay so a caught-up SYNCHRONOUS standby is
       # correctly Ready/promotable. Unblocks region-kill DR promotion (P3).
-      version: 0.2.11
+      # 0.2.12 (#5125 Defect-1): replica.enabled follows the
+      # cnpgPair.replica.promoted VALUE, so region-kill failover flips the
+      # region-B HR desired state (spec.values...promoted=true) instead of a
+      # live-object patch flux drift-correction reverted mid-outage (hw256 G12).
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1069,10 +1069,27 @@ For multi-region active-hotstandby Sovereigns and Applications (Pillar 3).
 The deterministic failover test for two independent CNPG clusters:
 
 1. Place a write into the primary CNPG cluster (synchronous replication, `remote_apply`, PR #2071)
-2. Kill the primary region (Hetzner API: detach LB, drop firewall, terminate CP node)
-3. Promote the replica via `Continuum` CR (PR #2072, #2074)
-4. Verify the write made it across — zero-tx-loss
-5. Reverse: promote original primary back when region recovers
+2. Kill the primary region (canonical driver: `scripts/region-kill-drill.sh kill --arm` — batch HARD os-stop of the region-a ECS via the HCS action API; bastion hard-excluded)
+3. **Promote the replica by flipping the region-B HelmRelease DESIRED state**, NOT the live Cluster CR:
+   ```bash
+   # DURABLE (#5125 Defect-1): patch the HR values so the failed-over state
+   # IS the desired state → flux drift-correction RE-AFFIRMS the promotion.
+   kubectl --kubeconfig <region-b> -n <ns> patch helmrelease bp-cnpg-pair \
+     --type merge -p '{"spec":{"values":{"cnpgPair":{"replica":{"promoted":true}}}}}'
+   # → chart re-renders the replica Cluster CR with replica.enabled:false → CNPG promotes it writable.
+   ```
+   🛑 Do **NOT** `kubectl patch` `spec.replica.enabled=false` on the live Cluster CR:
+   a drift-enabled HelmRelease owns it, so helm-controller's "correct cluster drift"
+   REVERTS the patch mid-outage and silently re-demotes the survivor (hw256 G12,
+   T0+2m07s). Route the change through the HR value (or the Continuum sequencer
+   patching HR values) so the promotion survives reconcile. (The `Continuum` CR
+   orchestration path is the automated equivalent — PR #2072/#2074.)
+4. Verify the write made it across — zero-tx-loss (RPO=0)
+5. Reverse: `scripts/region-kill-drill.sh recover --arm` os-starts region-a; then set
+   `replica.promoted:false` back on the region-B HR to resume replica mode once the
+   original primary is re-cloned onto the current timeline (#5125 Defect-2, still open —
+   CNPG replica walreceivers crash-loop `timeline N behind recovery timeline N+1` until
+   the stale side is deleted + re-basebackup'd).
 
 Test harness lives at the D31 acceptance test (PR #2075).
 

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -14,7 +14,7 @@ spec:
   # postgres superuser is disabled) and measures apply lag via LSN
   # receive-vs-replay (idle- + region-kill-safe). Unblocks region-kill DR
   # promotion (Pillar 3).
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.12 (#5125 Defect-1): DR-durability — the replica Cluster CR's
+# `replica.enabled` is now driven by the `cnpgPair.replica.promoted` VALUE
+# (default false → `enabled: true` normal replica; promoted:true →
+# `enabled: false` writable primary), NOT a hard-coded `true` a live-object
+# failover patch fought. Region-kill failover MUST flip the region-B
+# HelmRelease's DESIRED state (`spec.values.cnpgPair.replica.promoted: true`),
+# never `kubectl patch` the live Cluster CR: on hw256 G12 (2026-07-15,
+# T0+2m07s, region-a still SHUTOFF) helm-controller ran "correct cluster
+# drift" on bp-cnpg-pair and reverted `replica.enabled` back to `true`,
+# silently re-demoting the promoted survivor to read-only against a dead
+# source. Driving promotion through HR values makes the failed-over state the
+# DESIRED state → drift-correction RE-AFFIRMS it. Backward-safe (missing
+# value ⇒ replica). Lockstep slot 16b pin → 0.2.12; RUNBOOKS §6.1 updated.
+# (Defect-2, timeline-divergence auto-rejoin, remains open in #5125.)
 # 0.2.11 (#5133): FIX the failover-readiness probe false-negative that
 # blocked region-kill DR promotion (Pillar 3). Two defects in one probe:
 # (a) AUTH — it connected as `user=postgres`, but both Cluster CRs set
@@ -47,7 +61,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.11
+version: 0.2.12
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -87,6 +101,23 @@ description: |
 
   Changelog
   ─────────
+  0.2.12 (2026-07-17, DR-durability — failover through HR desired state, Refs #5125 Defect-1)
+    - FIX (Pillar-3 region-kill DR durability): the replica Cluster CR's
+      `replica.enabled` was hard-coded `true`, so the documented #4275 failover
+      (`replica.enabled: false` to promote the survivor) was a LIVE-OBJECT patch
+      on an object a drift-enabled HelmRelease owns. On hw256 G12 (2026-07-15,
+      T0+2m07s, region-a still SHUTOFF) region-b's helm-controller ran "correct
+      cluster drift" on bp-cnpg-pair and reset `replica.enabled` back to `true`,
+      silently RE-DEMOTING the promoted survivor to read-only against a dead
+      primary — the failover was non-durable without operator intervention.
+      `replica.enabled` is now `{{ not (.Values.cnpgPair.replica.promoted | default false) }}`,
+      so DR failover flips the region-B HR DESIRED state
+      (`spec.values.cnpgPair.replica.promoted: true`) and Flux drift-correction
+      RE-AFFIRMS the promotion instead of undoing it. Default/absent value ⇒
+      replica mode (backward-safe). Render Case 14 pins both states; the bootstrap
+      source is preserved across the promote. Lockstep slot 16b → 0.2.12,
+      RUNBOOKS §6.1 updated. (Defect-2 — post-resume timeline-divergence
+      auto-rejoin — stays open in #5125.)
   0.2.11 (2026-07-16, failover-readiness false-negative fix — region-kill DR promotion, Refs #5133)
     - FIX (Pillar-3 region-kill DR): the failover-readiness probe reported
       `lag=999999s ≥ threshold=30s — NOT promotable` on a region-b replica

--- a/platform/cnpg-pair/chart/templates/replica-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/replica-cluster.yaml
@@ -75,10 +75,23 @@ spec:
   # `replica.enabled: true` configures this Cluster as a CNPG replica
   # cluster: instances bootstrap via streaming replication from the
   # named externalCluster source. Continuum K-Cont-2's switchover
-  # path patches `replica.enabled: false` on this CR (and flips the
-  # primary CR to the inverse) to promote/demote atomically.
+  # path promotes this CR by flipping it to `replica.enabled: false`.
+  #
+  # #5125 Defect-1 (DR durability): `enabled` is DRIVEN BY THE
+  # `replica.promoted` VALUE, not a live-object patch. Region-kill
+  # failover must patch the region-B HelmRelease DESIRED state
+  # (`spec.values.cnpgPair.replica.promoted: true`), NOT `kubectl patch`
+  # this live Cluster CR. A live-object patch is REVERTED by flux
+  # drift-correction mid-outage — on hw256 G12 (2026-07-15, T0+2m07s,
+  # region-a still SHUTOFF) helm-controller ran "correct cluster drift"
+  # on bp-cnpg-pair and reset `replica.enabled` back to `true`, silently
+  # re-demoting the promoted survivor to read-only against a dead source.
+  # Driving promotion through the HR value makes the failed-over state the
+  # DESIRED state, so drift-correction RE-AFFIRMS the promotion instead of
+  # undoing it. Default `promoted: false` ⇒ `enabled: true` (normal
+  # replica); a missing value is also treated as replica (backward-safe).
   replica:
-    enabled: true
+    enabled: {{ not (.Values.cnpgPair.replica.promoted | default false) }}
     source: {{ include "cnpg-pair.fullname" . }}-primary
 
   # ── Bootstrap from primary ──────────────────────────────────────

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -647,4 +647,43 @@ grep -q 'REPLICA_HOST="smoke-cnpg-pair-bp-cnpg-pair-replica-rw"' "$TMP/replica.y
 }
 echo "  PASS (streaming_replica cert auth, LSN apply-lag, -rw target)"
 
+# ── Case 14: #5125 Defect-1 — replica.enabled is driven by the promoted VALUE ─
+# DR failover must flip the HelmRelease desired state (spec.values.cnpgPair.
+# replica.promoted=true), not a live-object patch flux drift-correction reverts.
+echo "[render] Case 14: #5125 replica.enabled follows the promoted value (default replica, promoted→primary)"
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --show-only templates/replica-cluster.yaml > "$TMP/replica-default.yaml" 2>"$TMP/replica-default.err" || {
+  echo "FAIL: #5125 default replica render errored:" >&2; cat "$TMP/replica-default.err" >&2; exit 1
+}
+# Default (promoted unset) → replica mode: replica.enabled: true.
+grep -qE '^  replica:' "$TMP/replica-default.yaml" && grep -A1 -E '^  replica:' "$TMP/replica-default.yaml" | grep -qE '^    enabled: true' || {
+  echo "FAIL: #5125 default (promoted unset) must render 'replica.enabled: true' (normal replica mode)." >&2
+  grep -nE '^  replica:|^    enabled:' "$TMP/replica-default.yaml" >&2; exit 1
+}
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.replica.promoted=true \
+  --show-only templates/replica-cluster.yaml > "$TMP/replica-promoted.yaml" 2>"$TMP/replica-promoted.err" || {
+  echo "FAIL: #5125 promoted replica render errored:" >&2; cat "$TMP/replica-promoted.err" >&2; exit 1
+}
+# Promoted → CNPG primary: replica.enabled: false (the failed-over desired state).
+grep -A1 -E '^  replica:' "$TMP/replica-promoted.yaml" | grep -qE '^    enabled: false' || {
+  echo "FAIL: #5125 promoted=true must render 'replica.enabled: false' (promote to writable primary) — this IS the failover desired state flux drift-correction re-affirms." >&2
+  grep -nE '^  replica:|^    enabled:' "$TMP/replica-promoted.yaml" >&2; exit 1
+}
+# The bootstrap source stanza is preserved either way (ignored post-bootstrap).
+grep -q 'source: smoke-cnpg-pair-bp-cnpg-pair-primary' "$TMP/replica-promoted.yaml" || {
+  echo "FAIL: #5125 promoted render dropped the replica source (CNPG needs it stable across the promote)." >&2; exit 1
+}
+echo "  PASS (promoted=false→enabled:true replica · promoted=true→enabled:false primary)"
+
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -86,6 +86,17 @@ cnpgPair:
   # so Cilium ClusterMesh publishes it across every connected peer.
   replica:
     region: ""
+    # ── DR failover promotion (#5125 Defect-1) ──────────────────────
+    # When true, the replica Cluster CR renders `replica.enabled: false`
+    # → CNPG promotes it to a writable primary. Region-kill failover
+    # MUST flip this on the region-B HelmRelease's DESIRED state
+    # (`spec.values.cnpgPair.replica.promoted: true`), never by
+    # `kubectl patch`-ing the live Cluster CR: a live-object patch is
+    # reverted by flux drift-correction mid-outage (hw256 G12), silently
+    # re-demoting the survivor. Driving it through HR values makes the
+    # failover the desired state so drift-correction re-affirms it.
+    # See RUNBOOKS.md §6.1 (region-kill failover) + replica-cluster.yaml.
+    promoted: false
     instances: 3
     storage:
       size: 100Gi

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.11"
+    version: "0.2.12"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +

--- a/scripts/region-kill-drill.sh
+++ b/scripts/region-kill-drill.sh
@@ -5,8 +5,11 @@
 #
 # Mechanics proven on hw256 (2026-07-15) + hw261 (2026-07-16):
 #   batch HARD os-stop ALL region-a ECS via HCS ECS action API → region-a
-#   apiserver dies (~4-5s) → promote region-b CNPG replicas
-#   (spec.replica.enabled=false) → RTO ~5.7s, RPO=0 (pre-kill sentinel survives)
+#   apiserver dies (~4-5s) → promote region-b CNPG replicas by flipping the
+#   region-B HelmRelease DESIRED state (spec.values.cnpgPair.replica.promoted=
+#   true → chart renders replica.enabled:false), NOT a live Cluster-CR patch
+#   flux drift-correction reverts mid-outage (#5125 Defect-1, bp-cnpg-pair
+#   ≥0.2.12; see RUNBOOKS §6.1) → RTO ~5.7s, RPO=0 (pre-kill sentinel survives)
 #   → post-kill write accepted → openbao auto-unseal via the */2 reconciler
 #   CronJob (bp-openbao ≥1.2.62) → os-start region-a to recover.
 #


### PR DESCRIPTION
## Defect (#5125 Defect-1, P1 — DR durability)
Found live on the **hw256 region-kill G12** (2026-07-15). The failover itself passed (RTO 5.7s / RPO 0), but was **non-durable**: the replica Cluster CR hard-coded `replica.enabled: true`, so the documented #4275 failover (`kubectl patch replica.enabled=false` to promote the survivor) was a **live-object patch on an object a drift-enabled HelmRelease owns**. At T0+2m07s (region-a still SHUTOFF) region-b's helm-controller ran *"correct cluster drift"* on `bp-cnpg-pair` and reset `enabled` back to `true` — **silently re-demoting the promoted survivor to read-only against a dead primary.**

## Fix — drive promotion through the HR desired state
`replica.enabled` is now `{{ not (.Values.cnpgPair.replica.promoted | default false) }}`:
- default / absent → `enabled: true` (normal replica; **backward-safe**)
- `cnpgPair.replica.promoted: true` → `enabled: false` (CNPG promotes to writable primary)

Region-kill failover flips the **region-B HelmRelease values** (`spec.values.cnpgPair.replica.promoted: true`), so the failed-over state IS the desired state → flux drift-correction **re-affirms** the promotion instead of undoing it. This is the "drive through HR values" remedy the issue itself recommends.

## Changes
- `chart/templates/replica-cluster.yaml` — value-gated `replica.enabled`
- `chart/values.yaml` — `cnpgPair.replica.promoted: false` (documented)
- `chart/tests/cnpg-pair-render.sh` — **Case 14** pins both states + source preserved (14/14 green)
- lockstep **0.2.11 → 0.2.12**: Chart.yaml + blueprint.yaml + slot `16b` pin (pin-sync PASS)
- `docs/RUNBOOKS.md §6.1` — failover step patches the HR value, not the live CR; `scripts/region-kill-drill.sh` header updated

## Validation
Chart render tests 14/14 green; pin-sync PASS. **Needs live validation on the next fresh-prov region-kill** (per the founder principle — prove on a real region-kill, not exec-sim; hw264's region-kill is already spent). **Defect-2** (post-resume timeline-divergence auto-rejoin) remains open in #5125.

`Refs #5125`

🤖 Generated with [Claude Code](https://claude.com/claude-code)