### PR TITLE
fix(openova-mcp): rs256 verify ACTIVE on fresh Sovereign — accept the seeded JWK mirror (Refs #5167)

### DIFF
--- a/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
+++ b/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
@@ -110,7 +110,7 @@ spec:
       # zero-RBAC ServiceAccount + Cilium ingress/egress CNPs. Lockstep:
       # products/openova-mcp/chart/Chart.yaml + blueprint.yaml +
       # catalog-seed (blueprints.json).
-      version: 0.1.2
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-openova-mcp

--- a/products/openova-mcp/blueprint.yaml
+++ b/products/openova-mcp/blueprint.yaml
@@ -23,7 +23,7 @@ spec:
   # HTTPRoute + zero-RBAC ServiceAccount + Cilium CNPs). Lockstep with
   # products/openova-mcp/chart/Chart.yaml 0.1.2 + bootstrap-kit slot 13d pin
   # + the catalog-seed (blueprints.json) entry.
-  version: 0.1.2
+  version: 0.1.3
   card:
     title: OpenOva MCP
     summary: |

--- a/products/openova-mcp/chart/Chart.yaml
+++ b/products/openova-mcp/chart/Chart.yaml
@@ -1,5 +1,15 @@
 apiVersion: v2
 name: bp-openova-mcp
+# 0.1.3 / appVersion 0.2.3 (#5167, north-star unblock): verify=rs256 now WORKS
+# on a fresh Sovereign. Root cause of the every-fresh-prov DEGRADED mode was a
+# two-fold mismatch, silent behind optional:true — (a) values referenced the
+# never-created PEM Secret `catalyst-handover-jwt` / `handover-jwt-public.pem`
+# while a Sovereign only seeds the JWK mirror `catalyst-handover-jwt-public` /
+# `public.jwk`; (b) the binary rejected JWKs outright. The 0.2.3 binary parses
+# RSA JWKs natively (PEM still supported) and the values default now targets
+# the seeded mirror. tools/call RBAC-gating (Agenity→MCP create_application)
+# activates out-of-the-box; the #5114 degrade-never-crash posture is unchanged.
+# Lockstep: blueprint.yaml + slot 13d → 0.1.3 (not in catalog-seed).
 description: |
   OpenOva MCP server — the RBAC-scoped-per-user thin facade that exposes
   the OpenOva product surface (Applications, Environments, Organizations)
@@ -49,7 +59,7 @@ type: application
 # catalog-seed (blueprints.json) 0.1.1. Image = ghcr.io/openova-io/
 # openova-mcp:<appVersion> (build-openova-mcp.yaml; plain image repo per
 # the #4706 chart-repo-collision lesson).
-version: 0.1.2
+version: 0.1.3
 # appVersion is the default image tag (openova-mcp.image in _helpers.tpl).
 # 0.2.2 (#5114): buildResolver degrades instead of exiting when the rs256
 # verify pubkey (or the hs256 secret) is absent/unparseable — see the 0.1.2
@@ -61,7 +71,7 @@ version: 0.1.2
 # the OPENOVA_MCP_EXPECTED_ISSUER / OPENOVA_MCP_ORG_SCOPE instance pins) —
 # the 0.1.x binary was stdio-only (the agenity in-pod child, #4010/#4097)
 # and cannot back a Service.
-appVersion: "0.2.2"
+appVersion: "0.2.3"
 keywords:
   - mcp
   - agent

--- a/products/openova-mcp/chart/tests/render-modes.sh
+++ b/products/openova-mcp/chart/tests/render-modes.sh
@@ -47,7 +47,12 @@ grep -q 'type: ClusterIP' <<<"$sov" || fail "sovereign: Service is not ClusterIP
 grep -q 'kind: Ingress' <<<"$sov" && fail "an Ingress rendered — product charts use HTTPRoute ONLY"
 grep -qi 'nodeport' <<<"$sov" && fail "NodePort rendered — §854 ABSOLUTE BAN"
 grep -q 'OPENOVA_MCP_RS256_PUBKEY_PEM' <<<"$sov" || fail "sovereign: rs256 pubkey env (OPENOVA_MCP_RS256_PUBKEY_PEM) not wired"
-grep -q 'name: catalyst-handover-jwt' <<<"$sov" || fail "sovereign: rs256 pubkey secretKeyRef source (catalyst-handover-jwt) missing"
+# #5167: the ref must target the JWK mirror a Sovereign ACTUALLY seeds —
+# `catalyst-handover-jwt-public` / key `public.jwk` — not the never-created
+# PEM Secret `catalyst-handover-jwt` (that mismatch silently DEGRADED rs256
+# verify on every fresh prov and 401'd all tools/call).
+grep -q 'name: catalyst-handover-jwt-public' <<<"$sov" || fail "sovereign: rs256 pubkey secretKeyRef source (catalyst-handover-jwt-public — the seeded JWK mirror, #5167) missing"
+grep -q 'key: public.jwk' <<<"$sov" || fail "sovereign: rs256 pubkey secretKeyRef key (public.jwk, #5167) missing"
 grep -q 'optional: true' <<<"$sov" || fail "sovereign: rs256 pubkey ref not optional (#4228)"
 grep -q 'automountServiceAccountToken: false' <<<"$sov" || fail "SA token mounted — zero-RBAC contract broken"
 grep -q 'kind: CiliumNetworkPolicy' <<<"$sov" || fail "sovereign: gateway-ingress CNP missing (#4180)"

--- a/products/openova-mcp/chart/values.yaml
+++ b/products/openova-mcp/chart/values.yaml
@@ -85,17 +85,22 @@ auth:
   # realm URL — pin whichever issuer mints the sessions this instance
   # serves. Per-realm JWKS resolution is the #3988 §4.2 follow-up.
   expectedIssuer: ""
-  # RS256 verify pubkey (PKIX PEM) — the public half of the Sovereign
-  # handover signer that MINTS catalyst-api session bearers (#4114). The
-  # default names the `catalyst-handover-jwt` Secret in the install
-  # namespace, which exists in catalyst-system (where the sovereign-mode
-  # slot lands). The ref is rendered optional:true so an install where the
-  # Secret is absent (e.g. an Org namespace) still schedules — the binary
-  # then falls back to its inherited process env. Never Helm-seed a
-  # placeholder value (reflector empty-seed trap).
+  # RS256 verify pubkey — the public half of the Sovereign handover signer
+  # that MINTS catalyst-api session bearers (#4114). #5167: the default now
+  # names the Secret a Sovereign ACTUALLY seeds — the JWK mirror
+  # `catalyst-handover-jwt-public` (key `public.jwk`, an RSA JWK the ≥0.2.3
+  # binary parses natively alongside PKIX/PKCS1 PEM). The old default
+  # (`catalyst-handover-jwt` / `handover-jwt-public.pem`) referenced a PEM
+  # Secret that is NEVER created on a Sovereign, so verify=rs256 silently
+  # started DEGRADED on every fresh prov (hw264 live) and tools/call 401'd
+  # for everyone — killing the Agenity→MCP north star. The ref stays
+  # optional:true so an install where the Secret is absent (e.g. an Org
+  # namespace) still schedules — the binary then falls back to its inherited
+  # process env. Never Helm-seed a placeholder value (reflector empty-seed
+  # trap).
   rs256PubkeySecret:
-    name: catalyst-handover-jwt
-    key: handover-jwt-public.pem
+    name: catalyst-handover-jwt-public
+    key: public.jwk
   # HS256 shared secret (verify=hs256 only).
   hs256Secret:
     name: ""

--- a/products/openova-mcp/cmd/openova-mcp/main.go
+++ b/products/openova-mcp/cmd/openova-mcp/main.go
@@ -50,12 +50,14 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
 	"log"
+	"math/big"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -375,8 +377,8 @@ func buildResolver() (*identity.Resolver, error) {
 		if pemStr == "" {
 			log.Printf("WARNING: verify=rs256 but OPENOVA_MCP_RS256_PUBKEY_PEM is empty/absent — starting in DEGRADED mode: /healthz + /readyz serve, tools/list is the empty unauthenticated surface, tools/call is rejected 401. Wire the Sovereign handover verify pubkey (PKIX PEM) into OPENOVA_MCP_RS256_PUBKEY_PEM to enable authenticated tools. A missing OPTIONAL verify Secret must never CrashLoop the pod — the cutover settle-gate needs Ready.")
 			r = identity.NewDegradedResolver("verify=rs256 but OPENOVA_MCP_RS256_PUBKEY_PEM is absent", pin)
-		} else if pub, perr := parseRSAPublicKeyPEM(pemStr); perr != nil {
-			log.Printf("WARNING: verify=rs256 pubkey present but unparseable (%v) — starting in DEGRADED mode (see the absent-key note). The value must be a PKIX/PKCS1 RSA public-key PEM, NOT a JWK (the `catalyst-handover-jwt-public` mirror holds a JWK — #4228).", perr)
+		} else if pub, perr := parseRSAPublicKey(pemStr); perr != nil {
+			log.Printf("WARNING: verify=rs256 pubkey present but unparseable (%v) — starting in DEGRADED mode (see the absent-key note). The value must be a PKIX/PKCS1 RSA public-key PEM or an RSA JWK ({\"kty\":\"RSA\",\"n\":…,\"e\":…} — the format of the `catalyst-handover-jwt-public` mirror, #5167).", perr)
 			r = identity.NewDegradedResolver("verify=rs256 pubkey present but unparseable", pin)
 		} else {
 			r = identity.NewRS256Resolver(pub, pin)
@@ -401,6 +403,59 @@ func buildResolver() (*identity.Resolver, error) {
 	// instance trusts + the Org scope a per-Org instance is confined to.
 	return r.WithExpectedIssuer(os.Getenv("OPENOVA_MCP_EXPECTED_ISSUER")).
 		WithOrgPin(os.Getenv("OPENOVA_MCP_ORG_SCOPE")), nil
+}
+
+// parseRSAPublicKey accepts EITHER a PKIX/PKCS1 RSA public-key PEM OR an RSA
+// JWK JSON document ({"kty":"RSA","n":…,"e":…}).
+//
+// #5167 (north-star unblock): the ONLY verify-pubkey Secret a fresh Sovereign
+// actually seeds is the JWK mirror `catalyst-handover-jwt-public` (key
+// `public.jwk`) — the PEM Secret `catalyst-handover-jwt` the chart used to
+// reference is never created, so verify=rs256 silently started DEGRADED on
+// every fresh prov (hw264 live) and tools/call 401'd for everyone, killing the
+// Agenity→MCP create_application north star. Accepting the JWK format the
+// platform already publishes closes that loop with zero seeder changes; PEM
+// stays supported for the per-Org seed / any future PEM source.
+func parseRSAPublicKey(s string) (*rsa.PublicKey, error) {
+	if strings.HasPrefix(strings.TrimSpace(s), "{") {
+		return parseRSAPublicKeyJWK(s)
+	}
+	return parseRSAPublicKeyPEM(s)
+}
+
+// parseRSAPublicKeyJWK parses an RSA JWK ({"kty":"RSA","n":…,"e":…}) into an
+// rsa.PublicKey. n and e are base64url-without-padding per RFC 7518 §6.3.
+func parseRSAPublicKeyJWK(s string) (*rsa.PublicKey, error) {
+	var jwk struct {
+		Kty string `json:"kty"`
+		N   string `json:"n"`
+		E   string `json:"e"`
+	}
+	if err := json.Unmarshal([]byte(s), &jwk); err != nil {
+		return nil, fmt.Errorf("RS256 pubkey: JWK parse: %w", err)
+	}
+	if jwk.Kty != "RSA" {
+		return nil, fmt.Errorf("RS256 pubkey: JWK kty=%q, want RSA", jwk.Kty)
+	}
+	if jwk.N == "" || jwk.E == "" {
+		return nil, errors.New("RS256 pubkey: JWK missing n/e")
+	}
+	nb, err := base64.RawURLEncoding.DecodeString(jwk.N)
+	if err != nil {
+		return nil, fmt.Errorf("RS256 pubkey: JWK n: %w", err)
+	}
+	eb, err := base64.RawURLEncoding.DecodeString(jwk.E)
+	if err != nil {
+		return nil, fmt.Errorf("RS256 pubkey: JWK e: %w", err)
+	}
+	e := 0
+	for _, b := range eb {
+		e = e<<8 | int(b)
+	}
+	if e <= 1 {
+		return nil, errors.New("RS256 pubkey: JWK exponent invalid")
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: e}, nil
 }
 
 func parseRSAPublicKeyPEM(pemStr string) (*rsa.PublicKey, error) {

--- a/products/openova-mcp/cmd/openova-mcp/resolver_test.go
+++ b/products/openova-mcp/cmd/openova-mcp/resolver_test.go
@@ -4,7 +4,10 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
+	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -42,23 +45,34 @@ func TestBuildResolver_DegradedWhenRS256PubkeyAbsent(t *testing.T) {
 	}
 }
 
-// TestBuildResolver_DegradedWhenRS256PubkeyUnparseable proves the JWK-vs-PEM trap
-// (#4228) also degrades instead of crashing: the only published catalyst-system
-// mirror (`catalyst-handover-jwt-public`) holds a JWK, which the PEM parser cannot
-// read — that must not CrashLoop the pod either.
+// TestBuildResolver_DegradedWhenRS256PubkeyUnparseable proves a genuinely
+// unparseable pubkey (non-RSA JWK / garbage) still degrades instead of
+// crashing (#5114 posture). NOTE (#5167): a VALID RSA JWK is no longer the
+// unparseable case — it is now the PRIMARY fresh-prov path (the
+// `catalyst-handover-jwt-public` mirror), pinned ACTIVE by
+// TestBuildResolver_RS256ActiveWithJWK below.
 func TestBuildResolver_DegradedWhenRS256PubkeyUnparseable(t *testing.T) {
-	t.Setenv("OPENOVA_MCP_VERIFY", "rs256")
-	t.Setenv("OPENOVA_MCP_RS256_PUBKEY_PEM", `{"kty":"RSA","n":"0vx7","e":"AQAB"}`) // a JWK, not a PEM
-	t.Setenv("OPENOVA_MCP_CONTEXT", "")
-	t.Setenv("OPENOVA_MCP_EXPECTED_ISSUER", "")
-	t.Setenv("OPENOVA_MCP_ORG_SCOPE", "")
+	for name, payload := range map[string]string{
+		"non-RSA JWK":    `{"kty":"EC","crv":"P-256","x":"a","y":"b"}`,
+		"garbage n":      `{"kty":"RSA","n":"%%%not-base64url%%%","e":"AQAB"}`,
+		"missing n/e":    `{"kty":"RSA"}`,
+		"not JSON / PEM": `this is neither a pem nor a jwk`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OPENOVA_MCP_VERIFY", "rs256")
+			t.Setenv("OPENOVA_MCP_RS256_PUBKEY_PEM", payload)
+			t.Setenv("OPENOVA_MCP_CONTEXT", "")
+			t.Setenv("OPENOVA_MCP_EXPECTED_ISSUER", "")
+			t.Setenv("OPENOVA_MCP_ORG_SCOPE", "")
 
-	r, err := buildResolver()
-	if err != nil {
-		t.Fatalf("buildResolver must DEGRADE (not exit) on an unparseable pubkey; got %v", err)
-	}
-	if degraded, _ := r.Degraded(); !degraded {
-		t.Fatal("resolver should be DEGRADED when the rs256 pubkey is unparseable")
+			r, err := buildResolver()
+			if err != nil {
+				t.Fatalf("buildResolver must DEGRADE (not exit) on an unparseable pubkey; got %v", err)
+			}
+			if degraded, _ := r.Degraded(); !degraded {
+				t.Fatal("resolver should be DEGRADED when the rs256 pubkey is unparseable")
+			}
+		})
 	}
 }
 
@@ -121,6 +135,67 @@ func TestBuildResolver_RS256ActiveWithPubkey(t *testing.T) {
 	}
 	if _, err := r.Resolve(badSigned); err == nil {
 		t.Fatal("a token signed by a NON-trusted key must be rejected (rs256 verify active)")
+	}
+}
+
+// TestBuildResolver_RS256ActiveWithJWK is the #5167 fresh-prov path: the ONLY
+// verify-pubkey Secret a Sovereign seeds is the JWK mirror
+// `catalyst-handover-jwt-public` (key `public.jwk`, an RSA JWK). Feeding that
+// JWK into OPENOVA_MCP_RS256_PUBKEY_PEM must make rs256 verify ACTIVE (not
+// DEGRADED): a token signed by the matching private key resolves, a token
+// signed by a different key is rejected.
+func TestBuildResolver_RS256ActiveWithJWK(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	// Build the RSA JWK exactly the way the platform's mirror does:
+	// base64url-without-padding n + e (RFC 7518 §6.3).
+	n := base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes())
+	jwk := fmt.Sprintf(`{"alg":"RS256","e":%q,"kty":"RSA","n":%q,"use":"sig"}`, e, n)
+
+	t.Setenv("OPENOVA_MCP_VERIFY", "rs256")
+	t.Setenv("OPENOVA_MCP_RS256_PUBKEY_PEM", jwk)
+	t.Setenv("OPENOVA_MCP_CONTEXT", "")
+	t.Setenv("OPENOVA_MCP_EXPECTED_ISSUER", "")
+	t.Setenv("OPENOVA_MCP_ORG_SCOPE", "")
+
+	r, err := buildResolver()
+	if err != nil {
+		t.Fatalf("buildResolver with a valid RSA JWK: %v", err)
+	}
+	if degraded, reason := r.Degraded(); degraded {
+		t.Fatalf("resolver must be ACTIVE with a valid RSA JWK (the catalyst-handover-jwt-public format, #5167); got DEGRADED %q", reason)
+	}
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"sub": "user-1", "org_id": "demo", "tier": "org-admin", "typ": "session",
+	})
+	signed, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	id, err := r.Resolve(signed)
+	if err != nil {
+		t.Fatalf("a valid RS256 token must resolve against the JWK-loaded key: %v", err)
+	}
+	if id.Context != identity.ContextOrganization || id.OrgID != "demo" {
+		t.Fatalf("unexpected identity: context=%s org=%s", id.Context, id.OrgID)
+	}
+
+	other, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen other key: %v", err)
+	}
+	badSigned, err := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"sub": "user-1", "org_id": "demo", "tier": "org-admin", "typ": "session",
+	}).SignedString(other)
+	if err != nil {
+		t.Fatalf("sign bad: %v", err)
+	}
+	if _, err := r.Resolve(badSigned); err == nil {
+		t.Fatal("a token signed by a NON-trusted key must be rejected (JWK-loaded rs256 verify active)")
 	}
 }
 


### PR DESCRIPTION
## North-star unblock (Pillar 4: Agenity → MCP `create_application` under RBAC)

**Live on hw264 (fresh prov):** `bp-openova-mcp` starts in **DEGRADED mode** — `verify=rs256` with an empty pubkey env → `tools/call` 401s for **everyone** (SME and privileged Orgs alike). The north star is dead on every fresh Sovereign.

## Root cause (two-fold, silent behind the correct `optional: true`)
1. Chart values referenced the **never-created** PEM Secret `catalyst-handover-jwt` / `handover-jwt-public.pem`; a Sovereign only seeds the **JWK mirror** `catalyst-handover-jwt-public` / `public.jwk` (confirmed live).
2. The binary **rejected JWKs** ("the MCP wants PKIX PEM" — `sovereign_mcp_bearer_seed.go:36` concedes the gap).

#5114 correctly made the pod degrade instead of CrashLooping the cutover settle-gate — but the loop was never closed to make verification actually work.

## Fix (root-cause, zero seeder changes, no regression)
- **Resolver**: `parseRSAPublicKey` accepts an **RSA JWK** (`{"kty":"RSA","n":…,"e":…}`, RFC 7518 base64url) alongside PKIX/PKCS1 PEM. The #5114 degrade-never-crash posture is unchanged — genuinely unparseable inputs (non-RSA JWK, garbage) still degrade (table-tested).
- **Chart values default** → `catalyst-handover-jwt-public` / `public.jwk` (still `optional: true`).
- **Tests**: `TestBuildResolver_RS256ActiveWithJWK` (JWK-loaded key: valid signed token resolves, wrong-key token rejected — signature genuinely checked); render-modes.sh pins the seeded secret name+key.
- **Lockstep**: chart **0.1.2 → 0.1.3**, appVersion **0.2.2 → 0.2.3** (`build-openova-mcp.yaml` publishes the new image on merge, chart tag defaults to appVersion), blueprint.yaml + slot 13d → 0.1.3 (not in catalog-seed). **pin-sync PASS.**

## Gates
`go build ./... && go test ./...` green (incl. 4-case unparseable table + JWK-active) · `render-modes.sh` PASS · pin-sync PASS.

## Acceptance (next fresh prov)
MCP log shows RS256 **ACTIVE** (no DEGRADED warning); a console-minted owner session resolves; `tools/call` RBAC-gates correctly.

`Refs #5167 #3988 #4111 #5114`

🤖 Generated with [Claude Code](https://claude.com/claude-code)