### PR TITLE
fix(catalyst): per-Org Apps grid lists funnel-purchased apps (Refs #5123)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications.go
@@ -59,6 +59,27 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/catalog"
 )
 
+// perOrgAppRouteComponents — the `catalyst.openova.io/component` label values
+// the funnel stamps on the HOST-visible per-app HTTPRoute of a
+// Deployment-shaped purchased app (core/services/provisioning/gitops):
+//   - `per-org-app-route`     — host tier (free/S): generateAppHTTPRoute
+//     co-locates the route with the Deployment+Service in the host `<slug>` ns.
+//   - `per-org-app-hostroute` — vcluster tier (paid M+): #4993
+//     generateHostNativeAppRoute lands the route host-side in the `<slug>` ns
+//     (the Deployment itself lives INSIDE the Org vcluster, invisible to the
+//     host client).
+//
+// #5123 — these routes are the ONLY host-visible per-app artifact of a funnel
+// purchase: the purchase deploys NO Application CR and NO HelmRelease (the
+// provisioning consumer commits raw Deployment-shaped manifests into the
+// per-Org repo's `vcluster/apps` tree, reconciled by the org-controller's
+// `catalyst-tenant-<slug>-apps` Flux Kustomization). The Org-scoped Apps
+// projection joins on this label to surface each purchase as its own card.
+var perOrgAppRouteComponents = map[string]bool{
+	"per-org-app-route":     true,
+	"per-org-app-hostroute": true,
+}
+
 // HandleOrgApplicationInstall — POST /api/v1/org/applications.
 //
 // Installs an Application into the CALLER'S OWN Organization. The target
@@ -220,6 +241,14 @@ func (h *Handler) HandleOrgApplications(w http.ResponseWriter, r *http.Request) 
 	// index BOTH so the release→route join below resolves whichever key the
 	// chart used.
 	urlByKey := map[string]string{}
+	// funnelApps — app slug → open URL for every funnel-purchased
+	// Deployment-shaped app, joined from its per-org-app HTTPRoute (#5123, the
+	// only host-visible per-app artifact of a funnel purchase — see
+	// perOrgAppRouteComponents). funnelTenantSlug is the Org slug the funnel
+	// stamped on those routes (`openova.io/tenant`), used to resolve the
+	// purchase-delivering `catalyst-tenant-<slug>-apps` Kustomization.
+	funnelApps := map[string]string{}
+	funnelTenantSlug := ""
 	if rts, err := deps.dyn.Resource(httpRouteGVR).Namespace(orgNS).List(ctx, metav1.ListOptions{}); err == nil {
 		for _, rt := range rts.Items {
 			hosts, _, _ := unstructured.NestedStringSlice(rt.Object, "spec", "hostnames")
@@ -228,6 +257,22 @@ func (h *Handler) HandleOrgApplications(w http.ResponseWriter, r *http.Request) 
 			}
 			url := "https://" + hosts[0]
 			urlByKey[rt.GetName()] = url
+			if labels := rt.GetLabels(); perOrgAppRouteComponents[labels["catalyst.openova.io/component"]] {
+				slug := strings.TrimSpace(labels["app"])
+				if slug == "" {
+					// Route names are `app-<slug>` (host tier) or
+					// `app-<slug>-hostroute` (vcluster tier).
+					slug = strings.TrimSuffix(strings.TrimPrefix(rt.GetName(), "app-"), "-hostroute")
+				}
+				if slug != "" {
+					if _, exists := funnelApps[slug]; !exists {
+						funnelApps[slug] = url
+					}
+					if funnelTenantSlug == "" {
+						funnelTenantSlug = strings.TrimSpace(labels["openova.io/tenant"])
+					}
+				}
+			}
 			rules, _, _ := unstructured.NestedSlice(rt.Object, "spec", "rules")
 			for _, rl := range rules {
 				rm, isMap := rl.(map[string]interface{})
@@ -371,6 +416,57 @@ func (h *Handler) HandleOrgApplications(w http.ResponseWriter, r *http.Request) 
 			Instance:    true,
 			Blueprint:   bpFull,
 		})
+	}
+
+	// Funnel-purchase pass (#5123) — every per-org-app HTTPRoute in the Org
+	// namespace is one purchased Application (see perOrgAppRouteComponents: a
+	// funnel purchase deploys NO Application CR and NO HelmRelease, so neither
+	// pass above can see it — hw256 acme256 rendered "0 apps" while the
+	// purchased WordPress served 200 at its route host). Status is read from
+	// the org-controller's `catalyst-tenant-<slug>-apps` Flux Kustomization
+	// (flux-system) — the delivery unit that reconciles the purchase's
+	// manifests into the Org boundary: Ready=True → installed, anything else
+	// (including not-yet-created) → installing, never fabricated. Cards
+	// already projected via an Application CR or HelmRelease of the same id
+	// are skipped — this pass only surfaces what the others cannot see.
+	if len(funnelApps) > 0 {
+		seen := map[string]bool{}
+		for i := range rows {
+			seen[rows[i].ID] = true
+		}
+		if funnelTenantSlug == "" {
+			// Funnel Orgs register OrganizationNamespace = the boundary slug
+			// namespace (tenantRegistrationFromOrgCR), so orgNS is the slug.
+			funnelTenantSlug = orgNS
+		}
+		status := "installing"
+		appsKSName := "catalyst-tenant-" + funnelTenantSlug + "-apps"
+		if ks, err := deps.dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
+			Get(ctx, appsKSName, metav1.GetOptions{}); err == nil && helmReleaseReady(ks) {
+			// helmReleaseReady is a generic status.conditions[type=Ready]
+			// reader — it works on any Flux object, Kustomizations included.
+			status = "installed"
+		}
+		slugs := make([]string, 0, len(funnelApps))
+		for slug := range funnelApps {
+			slugs = append(slugs, slug)
+		}
+		sort.Strings(slugs)
+		for _, slug := range slugs {
+			if seen[slug] {
+				continue
+			}
+			rows = append(rows, sovereignAppItem{
+				ID:          slug,
+				Slug:        slug,
+				Title:       slug,
+				Status:      status,
+				Environment: defaultSovereignEnvironment,
+				ExternalURL: funnelApps[slug],
+				Instance:    true,
+				Blueprint:   "bp-" + slug,
+			})
+		}
 	}
 
 	resp.Apps = rows

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications_funnel_5123_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications_funnel_5123_test.go
@@ -1,0 +1,253 @@
+// org_applications_funnel_5123_test.go — #5123 Facet A: the per-Org console
+// never listed funnel-purchased apps.
+//
+// A funnel purchase deploys NO Application CR and NO HelmRelease: the
+// provisioning consumer commits Deployment-shaped workloads into the per-Org
+// `<slug>/catalyst-tenant` repo (`vcluster/apps`, #4384), which the
+// org-controller's Flux Kustomization `catalyst-tenant-<slug>-apps` reconciles
+// into the Org boundary. The ONLY host-visible per-app artifact in the Org
+// namespace is the funnel-labeled HTTPRoute (`per-org-app-route` for the host
+// tier, `per-org-app-hostroute` for the vcluster tier, #4993). The projection
+// used those routes solely as a URL index — never as a card source — so a
+// customer who purchased WordPress saw "0 apps" (hw256 acme256, UAT row 89:
+// GET /api/v1/org/applications returned only the `vcluster` HR card while
+// https://wordpress.acme256.omani.homes served 200).
+//
+// These tests mirror the hw256 estate byte-for-byte and pin the funnel pass:
+// route-labeled purchases are projected as instance cards, status honest from
+// the `catalyst-tenant-<slug>-apps` Kustomization Ready condition, deduped
+// against Application-CR/HR cards, own-Org-scoped only.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// funnelOrgAppsRec drives GET /api/v1/org/applications as an acme256
+// Org-scoped session against a handler seeded with the supplied dynamic
+// objects, returning the raw recorder.
+func funnelOrgAppsRec(t *testing.T, dynObjs []runtime.Object) *httptest.ResponseRecorder {
+	t.Helper()
+	t.Setenv("SOVEREIGN_FQDN", "hw256.omani.works")
+	h := newSovereignHandler(t, nil, dynObjs)
+	h.SetTenantRegistry(funnelOrgTestRegistry(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/org/applications", nil)
+	req.Header.Set("X-Tenant-Host", "console.acme256.omani.homes")
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "acme256"}
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, claims))
+	rec := httptest.NewRecorder()
+	h.HandleOrgApplications(rec, req)
+	return rec
+}
+
+// funnelOrgTestRegistry registers a funnel-minted Org shaped exactly like the
+// hw256 walk's acme256: the tenant-registry reconciler
+// (tenantRegistrationFromOrgCR) sets OrganizationNamespace to the SLUG
+// namespace — the org-controller boundary ns the apps Kustomization targets —
+// not an `org-<uuid>` namespace.
+func funnelOrgTestRegistry(t *testing.T) *store.TenantRegistry {
+	t.Helper()
+	reg, err := store.NewTenantRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:                  "console.acme256.omani.homes",
+		TenantID:              "acme256-tenant-uuid",
+		TenantKind:            store.TenantKindOrg,
+		KeycloakRealmURL:      "https://keycloak.acme256.omani.homes/realms/org-acme256",
+		KeycloakClientID:      "catalyst-ui",
+		OrganizationNamespace: "acme256",
+		OrgKeycloakRealmName:  "org-acme256",
+	}); err != nil {
+		t.Fatalf("put acme256: %v", err)
+	}
+	return reg
+}
+
+// makeFunnelAppRoute builds the per-app HTTPRoute the funnel commits for a
+// Deployment-shaped purchased app: `app-<slug>-hostroute` (vcluster tier,
+// generateHostNativeAppRoute #4993) or `app-<slug>` (host tier,
+// generateAppHTTPRoute), labeled app=<slug> + openova.io/tenant=<org-slug> +
+// catalyst.openova.io/component=<component>.
+func makeFunnelAppRoute(name, ns, appSlug, orgSlug, component, host, backendSvc string) *unstructured.Unstructured {
+	u := makeHTTPRouteWithBackend(name, ns, []string{host}, backendSvc)
+	u.SetLabels(map[string]string{
+		"app":                           appSlug,
+		"openova.io/tenant":             orgSlug,
+		"catalyst.openova.io/component": component,
+	})
+	return u
+}
+
+// makeAppsKustomization builds the org-controller's per-Org apps Flux
+// Kustomization (`catalyst-tenant-<slug>-apps` in flux-system) with the given
+// Ready condition status — the delivery unit of every funnel purchase.
+func makeAppsKustomization(orgSlug, ready string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kustomize.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    "Kustomization",
+	})
+	u.SetName("catalyst-tenant-" + orgSlug + "-apps")
+	u.SetNamespace("flux-system")
+	conds := []interface{}{
+		map[string]interface{}{
+			"type":   "Ready",
+			"status": ready,
+			"reason": "ReconciliationSucceeded",
+		},
+	}
+	_ = unstructured.SetNestedSlice(u.Object, conds, "status", "conditions")
+	return u
+}
+
+// funnelOrgAppsGet drives GET /api/v1/org/applications for the acme256 funnel
+// Org and decodes the card list into an id-keyed map.
+func funnelOrgAppsGet(t *testing.T, dynObjs []runtime.Object) map[string]struct {
+	slug, bp, status, url string
+	instance              bool
+} {
+	t.Helper()
+	rec := funnelOrgAppsRec(t, dynObjs)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Apps []struct {
+			ID          string `json:"id"`
+			Slug        string `json:"slug"`
+			Blueprint   string `json:"blueprint"`
+			Status      string `json:"status"`
+			ExternalURL string `json:"externalURL"`
+			Instance    bool   `json:"instance"`
+		} `json:"apps"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]struct {
+		slug, bp, status, url string
+		instance              bool
+	}{}
+	for _, a := range resp.Apps {
+		byID[a.ID] = struct {
+			slug, bp, status, url string
+			instance              bool
+		}{a.Slug, a.Blueprint, a.Status, a.ExternalURL, a.Instance}
+	}
+	return byID
+}
+
+// TestOrgApplications_FunnelPurchasedAppListed_5123 — the hw256 acme256
+// estate: the Org's vcluster HR + the funnel-purchased WordPress delivered as
+// a Deployment inside the vcluster with its #4993 host-native route in the
+// Org namespace, apps Kustomization Ready=True. The projection MUST list the
+// purchase as an installed card with its working Open URL — pre-fix it
+// returned only the vcluster HR card ("0 apps" grid, UAT row 89 ❌).
+func TestOrgApplications_FunnelPurchasedAppListed_5123(t *testing.T) {
+	dynObjs := []runtime.Object{
+		makeHRWithRelease("vcluster", "acme256", "True", "vcluster", ""),
+		makeFunnelAppRoute("app-wordpress-hostroute", "acme256",
+			"wordpress", "acme256", "per-org-app-hostroute",
+			"wordpress.acme256.omani.homes", "wordpress-x-acme256-x-vcluster"),
+		makeAppsKustomization("acme256", "True"),
+		// FOREIGN funnel purchase in a sibling Org's namespace — must not leak.
+		makeFunnelAppRoute("app-ghost-hostroute", "beta256",
+			"ghost", "beta256", "per-org-app-hostroute",
+			"ghost.beta256.omani.homes", "ghost-x-beta256-x-vcluster"),
+	}
+	byID := funnelOrgAppsGet(t, dynObjs)
+
+	wp, ok := byID["wordpress"]
+	if !ok {
+		t.Fatalf("funnel-purchased wordpress missing from org projection (the #5123 bug); got %v", byID)
+	}
+	if wp.status != "installed" {
+		t.Errorf("wordpress status = %q, want installed (apps Kustomization Ready=True)", wp.status)
+	}
+	if wp.url != "https://wordpress.acme256.omani.homes" {
+		t.Errorf("wordpress externalURL = %q, want https://wordpress.acme256.omani.homes", wp.url)
+	}
+	if wp.bp != "bp-wordpress" {
+		t.Errorf("wordpress blueprint = %q, want bp-wordpress", wp.bp)
+	}
+	if !wp.instance {
+		t.Errorf("wordpress card must be an instance row")
+	}
+	if _, ok := byID["vcluster"]; !ok {
+		t.Errorf("vcluster HR card regressed out of the projection; got %v", byID)
+	}
+	if _, leaked := byID["ghost"]; leaked {
+		t.Errorf("FOREIGN funnel purchase leaked into acme256 projection: %v", byID)
+	}
+}
+
+// TestOrgApplications_FunnelAppInstalling_KustomizationNotReady_5123 — the
+// host-tier route shape (`app-<slug>`, per-org-app-route) with the apps
+// Kustomization not (yet) Ready projects the purchase honestly as installing,
+// never a fabricated installed.
+func TestOrgApplications_FunnelAppInstalling_KustomizationNotReady_5123(t *testing.T) {
+	dynObjs := []runtime.Object{
+		makeFunnelAppRoute("app-wordpress", "acme256",
+			"wordpress", "acme256", "per-org-app-route",
+			"wordpress.acme256.omani.homes", "wordpress"),
+		makeAppsKustomization("acme256", "False"),
+	}
+	byID := funnelOrgAppsGet(t, dynObjs)
+	wp, ok := byID["wordpress"]
+	if !ok {
+		t.Fatalf("host-tier funnel wordpress missing from org projection; got %v", byID)
+	}
+	if wp.status != "installing" {
+		t.Errorf("wordpress status = %q, want installing (apps Kustomization Ready=False)", wp.status)
+	}
+}
+
+// TestOrgApplications_FunnelRouteDedupedAgainstApplicationCR_5123 — when an
+// Application CR already projects the same id (e.g. a console-installed app
+// that also carries a funnel-shaped route), the funnel pass must not emit a
+// duplicate card.
+func TestOrgApplications_FunnelRouteDedupedAgainstApplicationCR_5123(t *testing.T) {
+	dynObjs := []runtime.Object{
+		makeApplicationFull("wordpress", "acme256", "bp-wordpress", "Ready"),
+		makeFunnelAppRoute("app-wordpress", "acme256",
+			"wordpress", "acme256", "per-org-app-route",
+			"wordpress.acme256.omani.homes", "wordpress"),
+		makeAppsKustomization("acme256", "True"),
+	}
+	rec := funnelOrgAppsRec(t, dynObjs)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Apps []struct {
+			ID string `json:"id"`
+		} `json:"apps"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	count := 0
+	for _, a := range resp.Apps {
+		if a.ID == "wordpress" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("wordpress projected %d times, want exactly 1 (CR card, no funnel duplicate)", count)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
@@ -8,10 +8,10 @@
 //     Warning-level Events as Job rows, sorted started-DESC.
 //  3. /api/v1/sovereign/apps — joins the embedded blueprint catalog
 //     with HelmRelease state on the cluster:
-//       - HR present + Ready=True       → "installed"
-//       - HR present + Ready=False/none → "installing"
-//       - listed catalog, no HR         → "available"
-//       - bootstrap-kit                 → "bootstrap"
+//     - HR present + Ready=True       → "installed"
+//     - HR present + Ready=False/none → "installing"
+//     - listed catalog, no HR         → "available"
+//     - bootstrap-kit                 → "bootstrap"
 //  4. /api/v1/sovereign/cloud — emits nodes / namespaces / ingresses /
 //     LoadBalancer-services / storage classes / PVCs from the in-cluster
 //     client, with HTTPRoutes coming via dynamic client.
@@ -48,9 +48,10 @@ func newSovereignHandler(t *testing.T, coreObjs []runtime.Object, dynObjs []runt
 
 	scheme := runtime.NewScheme()
 	gvrToList := map[schema.GroupVersionResource]string{
-		helmReleaseGVR: "HelmReleaseList",
-		httpRouteGVR:   "HTTPRouteList",
-		applicationGVR: "ApplicationList",
+		helmReleaseGVR:       "HelmReleaseList",
+		httpRouteGVR:         "HTTPRouteList",
+		applicationGVR:       "ApplicationList",
+		fluxKustomizationGVR: "KustomizationList",
 		{Group: "cert-manager.io", Version: "v1", Resource: "certificates"}: "CertificateList",
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, dynObjs...)


### PR DESCRIPTION
Refs #5123 (Facet A — the projection half; Facet B member-session 403 noise is NOT touched here)

## Root cause (verified, not the symptom)

A funnel purchase deploys **no Application CR and no HelmRelease**: the provisioning consumer commits Deployment-shaped workloads into the per-Org `<slug>/catalyst-tenant` repo's `vcluster/apps` tree (#4384), which the org-controller's `catalyst-tenant-<slug>-apps` Flux Kustomization reconciles into the Org boundary (into the Org vcluster for paid tiers). `GET /api/v1/org/applications` (`HandleOrgApplications`) projected **only** Application CRs + HelmReleases in the Org namespace — so every funnel purchase was structurally invisible. hw256 walk evidence (issue body): purchased WordPress deployed and served 200 at `wordpress.acme256.omani.homes`, yet the endpoint returned only the `vcluster` HR card → "0 apps" grid, UAT row 89 ❌.

The only host-visible per-app artifact of a purchase is the funnel's per-app HTTPRoute in the Org namespace — `catalyst.openova.io/component=per-org-app-route` (host tier, `generateAppHTTPRoute`) / `=per-org-app-hostroute` (vcluster tier, #4993 `generateHostNativeAppRoute`). The handler already listed those routes but used them solely as a URL index, never as a card source.

## Fix (handler-only, wire shape unchanged)

Third projection pass in `HandleOrgApplications`:

- joins the funnel-labeled HTTPRoutes already listed in the caller's OWN resolved Org namespace (RBAC unchanged — the #4110 own-org binding via `resolveOrganization` still gates everything; a foreign Org's routes are never listed),
- one instance card per purchased app: slug from the route's `app` label, Open URL from the route hostname, `blueprint: bp-<slug>`,
- status read honestly from the purchase-delivering `catalyst-tenant-<slug>-apps` Kustomization Ready condition (`installed` on Ready=True, else `installing` — never fabricated),
- deduped against cards already projected from an Application CR or HelmRelease of the same id.

`sovereignAppsResponse` shape untouched → the per-Org console AppsPage renders the new cards with zero FE changes.

## Reproduction + test

New `org_applications_funnel_5123_test.go` mirrors the hw256 acme256 estate (funnel Org with `OrganizationNamespace = slug`, vcluster HR, #4993 hostroute, apps Kustomization). On the pre-fix handler it fails with the exact live symptom:

```
--- FAIL: TestOrgApplications_FunnelPurchasedAppListed_5123
    funnel-purchased wordpress missing from org projection (the #5123 bug);
    got map[vcluster:{vcluster bp-vcluster installed  true}]
```

Post-fix: all 3 new tests + all pre-existing OrgApplications tests green; full `products/catalyst/bootstrap/api` module `go build ./... && go test ./...` green.

## Regression risk

Low: additive pass gated on the funnel-only `catalyst.openova.io/component` label values; Orgs without funnel purchases take the exact pre-fix path (proven by the untouched #4113/#4897 tests). No chart bump needed (Go handler only; ships with the next catalyst-api image roll).
