### PR TITLE
fix(cnpg-pair): region-B dr-promoter — automatic RPO=0 region-kill failover survives the loss of region-A (Refs #5137)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -207,7 +207,13 @@ spec:
       # cnpgPair.replica.promoted VALUE, so region-kill failover flips the
       # region-B HR desired state (spec.values...promoted=true) instead of a
       # live-object patch flux drift-correction reverted mid-outage (hw256 G12).
-      version: 0.2.12
+      # 0.2.13 (#5137): region-B AUTOMATIC DR promotion — side=replica adds a
+      # dr-promoter Deployment (Deployment NOT CronJob, #5157) that patches
+      # THIS HR's desired state (spec.values.cnpgPair.replica.promoted=true,
+      # the #5125-D1 seam) when the primary's WAL stream has been dead ≥120s
+      # AND failover-readiness is Ready — automatic RPO=0 region-kill
+      # failover with zero operator action. sync-mode-only (data fence).
+      version: 0.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1070,7 +1070,20 @@ The deterministic failover test for two independent CNPG clusters:
 
 1. Place a write into the primary CNPG cluster (synchronous replication, `remote_apply`, PR #2071)
 2. Kill the primary region (canonical driver: `scripts/region-kill-drill.sh kill --arm` — batch HARD os-stop of the region-a ECS via the HCS action API; bastion hard-excluded)
-3. **Promote the replica by flipping the region-B HelmRelease DESIRED state**, NOT the live Cluster CR:
+3. **AUTOMATIC (bp-cnpg-pair ≥ 0.2.13, #5137)**: region-B's `<pair>-dr-promoter`
+   Deployment (side=replica; a Deployment NOT a CronJob per #5157 — it survives
+   the region-kill because it runs in the surviving region) detects the dead WAL
+   stream via the LOCAL replica's `pg_stat_wal_receiver`, waits
+   `autoPromote.primaryDownHoldSeconds` (120s, so an intra-region primary
+   restart never triggers), confirms the failover-readiness probe is Ready
+   (LSN apply==receive, #5133), and then executes the HR patch below ITSELF —
+   zero operator action, expected promotion ~2–4 min after the kill. The
+   controller-side Continuum orchestration cannot do this: it lives on region-a
+   and dies with it (#5137). Evidence lands as
+   `catalyst.openova.io/dr-auto-promoted-at` on the region-B HR + the
+   dr-promoter pod log. The manual command remains the fallback (and is exactly
+   what the actor runs). **Promote the replica by flipping the region-B
+   HelmRelease DESIRED state**, NOT the live Cluster CR:
    ```bash
    # DURABLE (#5125 Defect-1): patch the HR values so the failed-over state
    # IS the desired state → flux drift-correction RE-AFFIRMS the promotion.

--- a/platform/cnpg-pair/DESIGN.md
+++ b/platform/cnpg-pair/DESIGN.md
@@ -254,6 +254,52 @@ replica's streaming auth mounts the primary's `-replication` / `-ca`
 Secrets, which must be synced cluster-A → cluster-B (ESO/reflector
 per the per-Sovereign overlay).
 
+### 9. Region-B automatic DR promotion — the dr-promoter (chart 0.2.13, #5137)
+
+hw261 region-kill G12 (2026-07-16) exposed the last Pillar-3 gap: the
+DR *orchestrator* was single-region. The Continuum controller and its
+`dr.openova.io/v1` CR live on region-A (bp-continuum slot 62 is
+SECONDARY_HR_SUSPEND'ed on secondaries, and the Continuum CRD ships in
+bp-catalyst-platform slot 13, also suspended), so a real region-kill
+takes the orchestrator down WITH the region it exists to fail away
+from. failover-readiness correctly said "promotable" (#5133); nothing
+acted; the operator promoted by hand.
+
+`side=replica` therefore renders a `<fullname>-dr-promoter`
+**Deployment** (never a CronJob — #5157: the CronJob scheduler is the
+regional control plane and does not reliably resume) with two
+containers sharing an emptyDir:
+
+- **signals** (cnpg postgres image, `streaming_replica` client-cert
+  auth — the #5133 pattern): polls the LOCAL replica `-rw`. While in
+  recovery, a non-`streaming` `pg_stat_wal_receiver` means the WAL
+  stream from region-A is dead; the hold clock starts on the
+  streaming→down transition and clears on resume/promotion/psql
+  failure (fail-safe).
+- **actor** (alpine/k8s, kubectl): promotes only when the stream has
+  been dead continuously ≥ `autoPromote.primaryDownHoldSeconds` (120s)
+  AND failover-readiness is Ready AND the local Cluster CR is still a
+  replica AND the HR value is not already promoted. The promotion is
+  ONE merge-patch of the region-B HelmRelease DESIRED state
+  (`spec.values.cnpgPair.replica.promoted: true` — the #5125-D1 seam,
+  byte-identical to the RUNBOOKS §6.1 operator command), never a live
+  Cluster-CR patch (hw256 G12: drift-correction reverts those).
+
+**Why acting on a region-local signal is split-brain-safe** (and why
+the promoter renders only when `replication.mode=sync`): with
+`synchronous_commit=remote_apply` + `FIRST 1` pinned to the
+cross-region replica + `dataDurability: required` (#3740), the old
+primary CANNOT COMMIT while its sync standby is unreachable — during
+the outage/partition nothing committed exists on A that B lacks
+(RPO=0), and after recovery the stale primary stays write-fenced (its
+walsender is rejected on the diverged timeline) until re-cloned
+(#5125 Defect-2). A `k8s-lease` witness cannot arbitrate two SEPARATE
+clusters (each side would hold "its own" lease in its own apiserver);
+the sync-rep fence is the arbiter that actually holds through a
+region-kill. A third-site witness generalizing this (and letting the
+full Continuum sequencer — DNS flip, HTTPRoute drain — run from the
+survivor) is follow-up on #5137.
+
 ---
 
 ## C-DB-3 acceptance test — implementer brief (HARNESS SHIPPED, awaits operator walk)

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -14,7 +14,13 @@ spec:
   # postgres superuser is disabled) and measures apply lag via LSN
   # receive-vs-replay (idle- + region-kill-safe). Unblocks region-kill DR
   # promotion (Pillar 3).
-  version: 0.2.12
+  # 0.2.13 (#5137): region-B AUTOMATIC DR promotion — side=replica renders a
+  # dr-promoter Deployment (#5157 shape) that survives region-A loss: when the
+  # WAL stream is dead ≥ hold AND failover-readiness is Ready, it patches the
+  # region-B HR desired state (replica.promoted=true, the #5125-D1 seam) so
+  # CNPG promotes the survivor with ZERO operator action. sync-mode-only
+  # (the remote_apply/dataDurability fence is the anti-split-brain arbiter).
+  version: 0.2.13
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,26 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.13 (#5137): region-B AUTOMATIC DR promotion — the DR orchestration now
+# SURVIVES the loss of the primary region. hw261 G12 proved the Continuum
+# controller + dr CR are single-region (region-A; bp-continuum slot 62 and the
+# Continuum CRD's bp-catalyst-platform slot 13 are both SECONDARY_HR_SUSPEND'ed),
+# so a real region-kill takes the orchestrator down WITH the region it must fail
+# away from — failover-readiness said promotable, no actor acted, the operator
+# promoted by hand. New side=replica-gated `<fullname>-dr-promoter` Deployment
+# (Deployment NOT CronJob — #5157, a CronJob's scheduler dies with the region):
+# signals container (psql, streaming_replica cert #5133) watches the LOCAL
+# replica's pg_stat_wal_receiver; when the WAL stream is dead CONTINUOUSLY for
+# autoPromote.primaryDownHoldSeconds (120s) AND failover-readiness is Ready
+# (LSN apply==receive) the actor container merge-patches the region-B HR
+# DESIRED state `spec.values.cnpgPair.replica.promoted: true` (the #5125-D1
+# seam / exact RUNBOOKS §6.1 command) — flux renders replica.enabled:false and
+# CNPG promotes the survivor, RPO=0, zero operator action. Data fence: only
+# rendered when replication.mode=sync (remote_apply + FIRST 1 + dataDurability:
+# required means the old primary cannot COMMIT while its sync standby is
+# unreachable or diverged — no committed-data split-brain, partition or kill).
+# Default-ON via autoPromote.enabled (side=replica + pair enabled only);
+# operator-manual HR patch unchanged (actor no-ops when already promoted).
+# Lockstep slot 16b pin → 0.2.13.
 # 0.2.12 (#5125 Defect-1): DR-durability — the replica Cluster CR's
 # `replica.enabled` is now driven by the `cnpgPair.replica.promoted` VALUE
 # (default false → `enabled: true` normal replica; promoted:true →
@@ -61,7 +82,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.12
+version: 0.2.13
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -101,6 +122,73 @@ description: |
 
   Changelog
   ─────────
+  0.2.13 (2026-07-17, region-B AUTOMATIC DR promotion — orchestration survives region-kill, Refs #5137)
+    - NEW (Pillar-3 region-kill DR): side=replica now renders a
+      `<fullname>-dr-promoter` Deployment — the region-B actor that makes
+      failover AUTOMATIC. hw261 G12 (2026-07-16) proved the DR orchestrator
+      is single-region: the Continuum controller + `dr` CR live on region-A
+      (bp-continuum slot 62 + the Continuum CRD's bp-catalyst-platform slot
+      13 are both suspended on secondaries), so a real region-kill takes the
+      orchestrator down WITH the region it must fail away from.
+      failover-readiness correctly reported promotable (#5133) but no actor
+      acted — the operator promoted by hand.
+    - Delivery wrapper is a Deployment with a continuous loop, NEVER a
+      CronJob (#5157, proven hw263→hw264: the CronJob scheduler dies with
+      the region and does not resume). replicas:1 + strategy Recreate — a
+      single actor, never two promotion loops.
+    - Two region-B-local signals, both independent of region-A:
+        signals container (cnpg postgres image, streaming_replica client
+        cert — the #5133 auth pattern) polls the LOCAL replica `-rw`:
+        while in recovery, a non-streaming `pg_stat_wal_receiver` means the
+        primary's WAL stream is dead. The hold clock starts on the
+        streaming→down transition and clears on resume / promotion / psql
+        failure (fail-safe: an unhealthy local replica never looks like a
+        dead primary).
+        actor container (alpine/k8s, kubectl) promotes ONLY when the stream
+        has been dead continuously ≥ autoPromote.primaryDownHoldSeconds
+        (120s — an intra-region primary restart/switchover reconnects in
+        seconds and never triggers) AND the failover-readiness probe is
+        Ready (LSN apply==receive → promotable) AND the local Cluster CR is
+        still a replica AND the HR value is not already promoted.
+    - The promotion is ONE merge-patch of the region-B HelmRelease DESIRED
+      state (`spec.values.cnpgPair.replica.promoted: true` + audit
+      annotations) — the exact RUNBOOKS §6.1 operator command and the
+      #5125-D1 seam, so flux drift-correction RE-AFFIRMS the failover
+      instead of reverting it. NEVER a live Cluster-CR patch (hw256 G12).
+      The operator-manual path keeps working: the actor no-ops when the
+      value is already true.
+    - ANTI-SPLIT-BRAIN data fence: the promoter renders ONLY when
+      replication.mode=sync. With synchronous_commit=remote_apply +
+      FIRST 1 pinned to the cross-region replica + dataDurability:required
+      (#3740), the old primary cannot COMMIT while its sync standby is
+      unreachable — so nothing committed exists on A that B lacks (RPO=0),
+      a mere partition cannot fork committed data, and after recovery the
+      stale primary stays write-fenced (walsender rejected on the diverged
+      timeline) until the operator re-clones it (#5125 Defect-2). A
+      k8s-lease witness cannot arbitrate two SEPARATE clusters; the
+      sync-rep fence is the arbiter that actually holds during a
+      region-kill. async mode (forensic/lab) renders NO promoter.
+    - RBAC is minimal + resourceNames-pinned: pods get/list + the replica
+      Cluster CR get (release ns); helmreleases get/patch on EXACTLY the
+      configured HR (flux-system). Egress is one CiliumNetworkPolicy:
+      kube-apiserver entity (#4428 idiom) + kube-dns + replica 5432.
+      The replica-side ingress policy admits the signals container to 5432
+      (same path as failover-readiness).
+    - kyverno-Enforce compliant: policy.cilium.io/enforced label, both
+      probes on both containers, both images under the single
+      `*/proxy-*/*` glob (postgres via proxy-ghcr, alpine/k8s via
+      proxy-dockerhub), pinned tags.
+    - New values: cnpgPair.replica.autoPromote.{enabled(true),
+      intervalSeconds(10), primaryDownHoldSeconds(120),
+      hr.name(bp-cnpg-pair), hr.namespace(flux-system),
+      kubectlImage.{repository,tag,pullPolicy}}.
+    - Default-OFF contract UNCHANGED: cnpgPair.enabled=false renders ZERO
+      resources on BOTH sides; side=primary is byte-identical to 0.2.12;
+      autoPromote.enabled=false or replication.mode=async renders the
+      0.2.12 replica set. Replica-side non-test resource count 5 → 12
+      (Deployment + SA + 2 Role + 2 RoleBinding + egress CNP). Render
+      Case 15 pins the gating, the HR merge-patch body, the #5157
+      Deployment shape, and the sync-mode fence.
   0.2.12 (2026-07-17, DR-durability — failover through HR desired state, Refs #5125 Defect-1)
     - FIX (Pillar-3 region-kill DR durability): the replica Cluster CR's
       `replica.enabled` was hard-coded `true`, so the documented #4275 failover

--- a/platform/cnpg-pair/chart/templates/_helpers.tpl
+++ b/platform/cnpg-pair/chart/templates/_helpers.tpl
@@ -104,6 +104,35 @@ rendering the primary half). Any other value fails the render.
 {{- end }}
 
 {{/*
+Region-B automatic DR promotion — active? (chart 0.2.13, #5137)
+
+TRUE only when ALL of:
+  - cnpgPair.enabled            (multi-region pair is on)
+  - side=replica                (the actor runs ON cluster-B, the half
+                                 that survives a region-A kill)
+  - replica.autoPromote.enabled (operator gate; default TRUE — absent
+                                 key ⇒ enabled, hasKey-guarded because
+                                 sprig `default` swallows a literal
+                                 `false`)
+  - replication.mode == sync    (the anti-split-brain DATA FENCE: with
+                                 synchronous_commit=remote_apply +
+                                 dataDurability=required pinned to the
+                                 cross-region replica, the old primary
+                                 CANNOT durably commit while its sync
+                                 standby is unreachable or diverged —
+                                 so an automatic promotion can never
+                                 lose or fork committed data. async
+                                 mode has NO such fence; the promoter
+                                 fail-safes to NOT render there.)
+*/}}
+{{- define "cnpg-pair.autoPromoteActive" -}}
+{{- $ap := .Values.cnpgPair.replica.autoPromote | default dict -}}
+{{- $apEnabled := true -}}
+{{- if hasKey $ap "enabled" }}{{- $apEnabled = $ap.enabled -}}{{- end -}}
+{{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isReplicaSide" .) $apEnabled (eq (.Values.cnpgPair.replication.mode | default "sync") "sync") -}}true{{- end -}}
+{{- end }}
+
+{{/*
 Canonical CR names — derived from fullname so Continuum + the
 ClusterMesh global Service can compute them deterministically.
 */}}

--- a/platform/cnpg-pair/chart/templates/dr-promoter.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-promoter.yaml
@@ -1,0 +1,457 @@
+{{- /*
+Region-B DR auto-promoter (#5137 — chart 0.2.13).
+
+WHY THIS EXISTS
+---------------
+hw261 region-kill G12 (2026-07-16) proved the DR ORCHESTRATOR was
+single-region: the Continuum controller + its `dr` CR live on region-A
+(bp-continuum slot 62 is SECONDARY_HR_SUSPEND'ed; the Continuum CRD
+ships in bp-catalyst-platform slot 13, ALSO suspended on secondaries),
+so a real region-kill takes the orchestrator down WITH the region it
+must fail away from. failover-readiness correctly said "promotable"
+(1/1, #5133) but NO ACTOR acted on it — the operator promoted by hand.
+
+This Deployment is the region-B actor that survives the loss of
+region-A. It is rendered ONLY on side=replica (the same split-side
+gating as failover-readiness), so it runs ON cluster-B with zero
+dependency on anything in region-A.
+
+WHY A DEPLOYMENT, NOT A CronJob (#5157 — proven hw263→hw264)
+------------------------------------------------------------
+A region-local actor that must run DURING a region outage is a
+continuous Deployment loop: a CronJob's scheduler is the (regional)
+control plane and does not reliably resume after recovery (openbao
+stayed SEALED 40+ min on hw263). Same delivery wrapper as the
+openbao-unseal-reconciler.
+
+WHY IT PATCHES THE HELMRELEASE, NEVER THE LIVE Cluster CR (#5125-D1)
+--------------------------------------------------------------------
+On hw256 G12 a live `kubectl patch spec.replica.enabled=false` was
+REVERTED by flux drift-correction at T0+2m07s, silently re-demoting
+the promoted survivor mid-outage. bp-cnpg-pair ≥0.2.12 drives
+`replica.enabled` from the `cnpgPair.replica.promoted` VALUE, so the
+promoter flips the region-B HelmRelease DESIRED state
+(`spec.values.cnpgPair.replica.promoted: true`) — drift-correction
+then RE-AFFIRMS the promotion. This is byte-identical to the
+RUNBOOKS §6.1 operator command; the operator-manual path keeps
+working (the actor no-ops when the value is already true).
+
+Durability of the HR patch: the flux Kustomization's SSA re-apply of
+the bootstrap-kit slot 16b manifest does NOT remove the key — slot 16b
+never sets `replica.promoted`, so the promoter's field-manager keeps
+ownership of a field git never claims.
+
+HOW IT DECIDES (two independent signals, both region-B-local)
+-------------------------------------------------------------
+1. PRIMARY LOSS — `signals` container (postgres image, the same
+   streaming_replica client-cert auth as failover-readiness #5133)
+   polls the LOCAL replica's `-rw`: while in recovery, an EMPTY /
+   non-streaming `pg_stat_wal_receiver` means the WAL stream from
+   region-A is dead. The condition must hold CONTINUOUSLY for
+   `autoPromote.primaryDownHoldSeconds` (default 120s) so an
+   intra-region primary restart / instance switchover (receiver
+   reconnects in seconds) never triggers a cross-region promotion.
+2. PROMOTABILITY — the failover-readiness Pod's Ready condition
+   (the #5133 LSN apply==receive signal): the standby has APPLIED
+   everything it RECEIVED.
+
+ANTI-SPLIT-BRAIN — why acting on a region-local signal is data-safe
+-------------------------------------------------------------------
+The pair runs synchronous replication (remote_apply + FIRST 1 pinned
+to the cross-region replica + dataDurability:required — #3740). That
+gives a structural data fence with NO third-site witness:
+  - During the outage/partition, the region-A primary CANNOT COMMIT
+    (its only synchronous standby is unreachable) — so there is
+    nothing committed on A that B does not already have (RPO=0), and
+    a mere partition (A alive, mesh dead) cannot diverge committed
+    data either.
+  - After region-A recovers, its old primary still cannot durably
+    commit: the promoted region-B replica has left the timeline, the
+    walsender connection is rejected, and FIRST 1 stays unsatisfied —
+    the stale side is write-fenced until the operator re-clones it
+    (RUNBOOKS §6.1 step 5 / #5125 Defect-2).
+For this reason the promoter renders ONLY when replication.mode=sync
+(see cnpg-pair.autoPromoteActive) — async mode has no fence.
+
+The k8s-lease witness cannot arbitrate here: a coordination.k8s.io
+Lease lives in ONE cluster's apiserver, and a 2-region Sovereign is
+two SEPARATE clusters — each side would trivially hold "its own"
+lease. The sync-rep data fence is the arbiter that actually holds
+during a region-kill. (A future 3rd-site witness generalizes this;
+tracked on #5137.)
+*/ -}}
+{{- if (include "cnpg-pair.autoPromoteActive" .) }}
+{{- $ap := .Values.cnpgPair.replica.autoPromote }}
+{{- $hr := $ap.hr | default dict }}
+{{- $hrName := $hr.name | default "bp-cnpg-pair" }}
+{{- $hrNamespace := $hr.namespace | default "flux-system" }}
+{{- $kimg := $ap.kubectlImage | default dict }}
+{{- $krepo := $kimg.repository | default "harbor.openova.io/proxy-dockerhub/alpine/k8s" }}
+{{- $ktag := $kimg.tag | default "1.30.0" }}
+{{- $kpull := $kimg.pullPolicy | default "IfNotPresent" }}
+{{- $interval := $ap.intervalSeconds | default 10 }}
+{{- $hold := $ap.primaryDownHoldSeconds | default 120 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+    catalyst.openova.io/role: dr-promoter
+---
+# Local-namespace reads: failover-readiness Pod Ready condition + the
+# replica Cluster CR's replica.enabled state.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+rules:
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  - apiGroups: [postgresql.cnpg.io]
+    resources: [clusters]
+    verbs: [get]
+    resourceNames: [{{ include "cnpg-pair.replicaName" . }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+    namespace: {{ .Release.Namespace }}
+---
+# The promotion surface: get (idempotence read) + patch (merge-patch of
+# spec.values.cnpgPair.replica.promoted) on EXACTLY the bp-cnpg-pair
+# HelmRelease — resourceNames-pinned, no list/create/delete.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+rules:
+  - apiGroups: [helm.toolkit.fluxcd.io]
+    resources: [helmreleases]
+    verbs: [get, patch]
+    resourceNames: [{{ $hrName }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+    namespace: {{ .Release.Namespace }}
+---
+# Egress for the promoter Pod. The kube-apiserver is a reserved Cilium
+# entity a vanilla k8s NetworkPolicy cannot express (#4428 idiom — under
+# kube-proxy-replacement the apiserver VIP resolves to the reserved
+# `kube-apiserver` identity, which is neither a pod nor `world`), so the
+# whole egress allow-list lives in ONE CiliumNetworkPolicy: apiserver
+# (kubectl) + kube-dns (service-name resolution) + the replica cluster's
+# 5432 (the signals psql). Everything else stays denied.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter-egress
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      catalyst.openova.io/role: dr-promoter
+      catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "cnpg-pair.replicaName" . }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+    catalyst.openova.io/role: dr-promoter
+  annotations:
+    catalyst.openova.io/blueprint: bp-cnpg-pair
+spec:
+  replicas: 1
+  # Single actor; never two promotion loops at once (#5157 shape).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "cnpg-pair.selectorLabels" . | nindent 6 }}
+      catalyst.openova.io/role: dr-promoter
+  template:
+    metadata:
+      labels:
+        {{- include "cnpg-pair.selectorLabels" . | nindent 8 }}
+        catalyst.openova.io/role: dr-promoter
+        catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+        # kyverno cilium-l7-mtls (Enforce) — required on the Pod
+        # template or the Deployment is DENIED at admission (#3238).
+        policy.cilium.io/enforced: "true"
+    spec:
+      # The actor runs in the replica region — the half that survives a
+      # region-A kill (same pin as failover-readiness).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: openova.io/region
+                    operator: In
+                    values: [{{ .Values.cnpgPair.replica.region | quote }}]
+      serviceAccountName: {{ include "cnpg-pair.fullname" . }}-dr-promoter
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 26
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        # ── signals — PRIMARY-LOSS detector ──────────────────────────
+        # psql (streaming_replica client cert, the #5133 auth pattern)
+        # against the LOCAL replica `-rw`. While the replica is in
+        # recovery, a non-streaming pg_stat_wal_receiver == the WAL
+        # stream from region-A is dead; the hold clock (file mtime-free,
+        # epoch-in-file) starts on the streaming→down transition and is
+        # CLEARED the moment streaming resumes, the replica leaves
+        # recovery (already promoted), or psql itself fails (fail-safe:
+        # an unhealthy local replica must never look like a dead
+        # primary).
+        - name: signals
+          image: {{ include "cnpg-pair.imageRef" . | quote }}
+          imagePullPolicy: {{ .Values.cnpgPair.image.pullPolicy | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              CONN="host={{ include "cnpg-pair.replicaName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              Q="SELECT CASE
+                WHEN NOT pg_is_in_recovery() THEN 'promoted'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver WHERE status = 'streaming') THEN 'streaming'
+                ELSE 'down'
+              END"
+              echo "[dr-promoter/signals] loop started (interval={{ $interval }}s)"
+              while true; do
+                : > /shared/signals-alive
+                STATE=$(psql "${CONN}" -tAXc "${Q}" 2>/dev/null || echo "unknown")
+                case "${STATE}" in
+                  down)
+                    if [ ! -f /shared/primary-wal-down-since ]; then
+                      date -u +%s > /shared/primary-wal-down-since
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/signals] WAL receiver DOWN — primary stream dead; hold clock started"
+                    fi
+                    ;;
+                  *)
+                    if [ -f /shared/primary-wal-down-since ]; then
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/signals] state=${STATE} — hold clock cleared"
+                    fi
+                    rm -f /shared/primary-wal-down-since
+                    ;;
+                esac
+                sleep {{ $interval }}
+              done
+          env:
+            - name: PGCONNECT_TIMEOUT
+              value: "5"
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/signals-alive && test -z \"$(find /shared/signals-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/signals-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsUser: 26   # postgres in upstream cnpg image
+            runAsGroup: 26
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+            - name: replication-cert
+              mountPath: /tls/client
+              readOnly: true
+        # ── actor — the PROMOTER ─────────────────────────────────────
+        # Each tick runs in a subshell (a persistent fault retries next
+        # tick instead of crashing the pod — #5157 shape). Gates, in
+        # order: hold expired → HR not already promoted (idempotence +
+        # operator-manual compatibility) → local Cluster CR still a
+        # replica → failover-readiness Ready (promotable, #5133). Then
+        # ONE merge-patch of the HR desired state — the exact RUNBOOKS
+        # §6.1 command — plus audit annotations.
+        - name: actor
+          image: {{ printf "%s:%s" $krepo $ktag | quote }}
+          imagePullPolicy: {{ $kpull | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "[dr-promoter/actor] loop started (hold=${HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME})"
+              while true; do
+                : > /shared/actor-alive
+                (
+                  set -eu
+                  [ -f /shared/primary-wal-down-since ] || exit 0
+                  DOWN_SINCE=$(cat /shared/primary-wal-down-since)
+                  NOW=$(date -u +%s)
+                  DOWN_FOR=$((NOW - DOWN_SINCE))
+                  if [ "${DOWN_FOR}" -lt "${HOLD_SECONDS}" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] primary WAL stream down ${DOWN_FOR}s < hold ${HOLD_SECONDS}s — waiting"
+                    exit 0
+                  fi
+                  PROMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.cnpgPair.replica.promoted}')
+                  if [ "${PROMOTED}" = "true" ]; then
+                    exit 0
+                  fi
+                  REPLICA_ENABLED=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}')
+                  if [ "${REPLICA_ENABLED}" != "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] local Cluster CR replica.enabled=${REPLICA_ENABLED} — not a replica; nothing to promote"
+                    exit 0
+                  fi
+                  READY=$(kubectl -n "${NAMESPACE}" get pod -l "${READY_SELECTOR}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}')
+                  if ! echo "${READY}" | grep -qw True; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] failover-readiness NOT Ready (got: '${READY}') — standby not promotable; holding (data safety over RTO)"
+                    exit 0
+                  fi
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTING: WAL stream down ${DOWN_FOR}s >= ${HOLD_SECONDS}s AND failover-readiness Ready — patching HR desired state (#5125-D1 seam)"
+                  kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-auto-promote-reason\":\"primary WAL stream down ${DOWN_FOR}s; failover-readiness Ready (#5137)\"}},\"spec\":{\"values\":{\"cnpgPair\":{\"replica\":{\"promoted\":true}}}}}"
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTED: HR ${HR_NAMESPACE}/${HR_NAME} spec.values.cnpgPair.replica.promoted=true — helm-controller renders replica.enabled:false → CNPG promotes the survivor writable"
+                ) || echo "[dr-promoter/actor] tick returned non-zero — retry in ${INTERVAL_SECONDS}s"
+                sleep "${INTERVAL_SECONDS}"
+              done
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HR_NAME
+              value: {{ $hrName | quote }}
+            - name: HR_NAMESPACE
+              value: {{ $hrNamespace | quote }}
+            - name: HOLD_SECONDS
+              value: {{ $hold | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+            - name: REPLICA_CLUSTER
+              value: {{ include "cnpg-pair.replicaName" . | quote }}
+            - name: READY_SELECTOR
+              value: "catalyst.openova.io/role=failover-readiness-probe,catalyst.openova.io/cnpg-pair={{ include "cnpg-pair.fullname" . }}"
+            # kubectl writes its discovery/http cache under $HOME.
+            - name: HOME
+              value: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/actor-alive && test -z \"$(find /shared/actor-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/actor-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: shared
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        # THIS replica cluster's own CNPG-issued streaming_replica client
+        # cert (exists locally on cluster-B, no cross-cluster sync) —
+        # 0440 root:26, the perms libpq requires for an sslkey (#5133).
+        - name: replication-cert
+          secret:
+            secretName: {{ include "cnpg-pair.replicaName" . }}-replication
+            defaultMode: 0440
+{{- end }}

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -163,6 +163,19 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+{{- if (include "cnpg-pair.autoPromoteActive" .) }}
+    # #5137 dr-promoter signals container — polls the replica's -rw for
+    # pg_stat_wal_receiver (primary-loss detection). Same intra-cluster
+    # 5432 path as the failover-readiness probe.
+    - from:
+        - podSelector:
+            matchLabels:
+              catalyst.openova.io/role: dr-promoter
+              catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+{{- end }}
     # #3322 OWN-CLUSTER carve-out: the replica Cluster's instance-2 joins
     # instance-1 via the replica's -rw Service on 5432. This netpol selects
     # the replica Pods, so without an explicit allow for the replica's OWN

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -238,9 +238,12 @@ count_resources "$TMP/replica.yaml" > "$TMP/replica-counts" || {
 NONTEST=$(grep -E '^NONTEST=' "$TMP/replica-counts" | cut -d= -f2)
 TEST=$(grep -E '^TEST=' "$TMP/replica-counts" | cut -d= -f2)
 # 1×Cluster (replica) + 1×Service (mesh stub) + 1×Deployment (probe)
-# + 2×NetworkPolicy = 5 non-test; helm-test renders on primary only.
-if [ "$NONTEST" -ne 5 ] || [ "$TEST" -ne 0 ]; then
-  echo "FAIL: side=replica expected 5 non-test + 0 test resources, got $NONTEST + $TEST." >&2
+# + 2×NetworkPolicy = 5, plus the #5137 dr-promoter set (default-ON on
+# side=replica): 1×Deployment + 1×ServiceAccount + 2×Role +
+# 2×RoleBinding + 1×CiliumNetworkPolicy (egress) = 7 → 12 non-test;
+# helm-test renders on primary only.
+if [ "$NONTEST" -ne 12 ] || [ "$TEST" -ne 0 ]; then
+  echo "FAIL: side=replica expected 12 non-test + 0 test resources, got $NONTEST + $TEST." >&2
   grep -E "^kind: " "$TMP/replica.yaml" >&2
   exit 1
 fi
@@ -309,7 +312,7 @@ grep -qE '^\s+- port: 9187' "$TMP/replica.yaml" || {
   echo "FAIL: replica-side NetworkPolicy missing the operator metrics port (9187)." >&2
   exit 1
 }
-echo "  PASS (5 non-test resources)"
+echo "  PASS (12 non-test resources — 5 replica-half + 7 dr-promoter)"
 
 # ── Case 4: side normalization + invalid side fail-fast ──────────
 echo "[render] Case 4: side=secondary aliases replica; invalid side fails fast"
@@ -588,8 +591,11 @@ helm template smoke-cnpg-pair . \
   --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={hw228-mesh}' \
   > "$TMP/cnp-replica.yaml" 2> "$TMP/cnp-replica.err" || {
   echo "FAIL: #4846 side=replica CNP render errored:" >&2; cat "$TMP/cnp-replica.err" >&2; exit 1; }
-if [ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-replica.yaml")" != "1" ]; then
-  echo "FAIL: #4846 side=replica expected exactly 1 CiliumNetworkPolicy." >&2; exit 1; fi
+# 0.2.13: side=replica carries 2 CNPs when peers are set — the #4846
+# crossregion-dr-replica ingress admit + the always-on #5137
+# dr-promoter-egress.
+if [ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-replica.yaml")" != "2" ]; then
+  echo "FAIL: #4846/#5137 side=replica expected exactly 2 CiliumNetworkPolicies (crossregion-dr-replica + dr-promoter-egress)." >&2; exit 1; fi
 grep -qE '^  name: smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-replica$' "$TMP/cnp-replica.yaml" || {
   echo "FAIL: #4846 replica CNP name != smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-replica." >&2; exit 1; }
 grep -qE '^      cnpg.io/cluster: smoke-cnpg-pair-bp-cnpg-pair-replica$' "$TMP/cnp-replica.yaml" || {
@@ -598,12 +604,14 @@ grep -q '"hw228-mesh"' "$TMP/cnp-replica.yaml" || {
   echo "FAIL: #4846 replica CNP missing the primary mesh name in the In-list." >&2; exit 1; }
 if grep -qE '^[[:space:]]*-?[[:space:]]*ipBlock:' "$TMP/cnp-replica.yaml"; then
   echo "FAIL: #4846 replica render leaked an ipBlock rule." >&2; exit 1; fi
-# Empty crossRegionPeerClusters (Case 2 default primary render) → ZERO CNP.
+# Empty crossRegionPeerClusters (Case 2 default primary render) → ZERO
+# crossregion-dr CNP. (0.2.13: the replica side ALWAYS carries the #5137
+# dr-promoter-egress CNP — assert by NAME, not by kind.)
 if grep -q 'CiliumNetworkPolicy' "$TMP/primary.yaml"; then
   echo "FAIL: #4846 primary render WITHOUT crossRegionPeerClusters must emit ZERO CiliumNetworkPolicy." >&2; exit 1; fi
-if grep -q 'CiliumNetworkPolicy' "$TMP/replica.yaml"; then
-  echo "FAIL: #4846 replica render WITHOUT crossRegionPeerClusters must emit ZERO CiliumNetworkPolicy." >&2; exit 1; fi
-echo "  PASS (1 CNP per side, identity In-list, no ipBlock; empty peers → zero CNP)"
+if grep -q 'crossregion-dr' "$TMP/replica.yaml"; then
+  echo "FAIL: #4846 replica render WITHOUT crossRegionPeerClusters must emit ZERO crossregion-dr CiliumNetworkPolicy." >&2; exit 1; fi
+echo "  PASS (1 CNP per side, identity In-list, no ipBlock; empty peers → zero crossregion CNP)"
 
 # ── Case 13: #5133 — failover-readiness probe auth + lag measure ─
 # The probe on hw260 reported `lag=999999 … NOT promotable` on a byte-caught-up
@@ -685,5 +693,87 @@ grep -q 'source: smoke-cnpg-pair-bp-cnpg-pair-primary' "$TMP/replica-promoted.ya
   echo "FAIL: #5125 promoted render dropped the replica source (CNPG needs it stable across the promote)." >&2; exit 1
 }
 echo "  PASS (promoted=false→enabled:true replica · promoted=true→enabled:false primary)"
+
+# ── Case 15: #5137 — region-B automatic DR promotion (dr-promoter) ─
+# The DR orchestration must survive the loss of region-A (hw261 G12: the
+# Continuum controller + dr CR died WITH the killed region; nobody acted
+# on a promotable standby). side=replica renders a dr-promoter Deployment
+# that (a) detects primary loss via the LOCAL replica's
+# pg_stat_wal_receiver, (b) gates on the failover-readiness Ready signal,
+# and (c) promotes by merge-patching the region-B HelmRelease DESIRED
+# state (spec.values.cnpgPair.replica.promoted=true — the #5125-D1 seam),
+# NEVER the live Cluster CR.
+echo "[render] Case 15: #5137 dr-promoter — side-gating, #5157 Deployment shape, HR-desired-state promotion, sync-only fence"
+# 1. Present on the default side=replica render (Case 3 output).
+grep -q 'catalyst.openova.io/role: dr-promoter' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 side=replica default render missing the dr-promoter." >&2; exit 1; }
+# 2. NEVER on side=primary (the actor must live in the surviving region).
+if grep -q 'dr-promoter' "$TMP/primary.yaml"; then
+  echo "FAIL: #5137 side=primary rendered dr-promoter resources — the actor must run ONLY on cluster-B (it must survive a region-A kill)." >&2; exit 1; fi
+# 3. Deployment (NOT CronJob — #5157: a CronJob's scheduler dies with the
+#    region) with a single Recreate replica (never two promotion loops).
+awk '/^kind: Deployment$/{d=1} d&&/name: .*-dr-promoter$/{f=1} f&&/type: Recreate/{print "RECREATE"; exit}' "$TMP/replica.yaml" | grep -q RECREATE || {
+  echo "FAIL: #5137 dr-promoter must be a Deployment with strategy Recreate (single actor, #5157 shape)." >&2; exit 1; }
+if grep -q '^kind: CronJob' "$TMP/replica.yaml"; then
+  echo "FAIL: #5137 rendered a CronJob — a region-local DR actor must be a Deployment (#5157: the CronJob scheduler dies with the region)." >&2; exit 1; fi
+# 4. Promotion drives the HR DESIRED state — the exact #5125-D1 merge-patch
+#    body — never a live Cluster-CR patch.
+grep -q 'patch helmrelease' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 actor does not patch the HelmRelease." >&2; exit 1; }
+grep -qF '\"spec\":{\"values\":{\"cnpgPair\":{\"replica\":{\"promoted\":true}}}}' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 actor must merge-patch spec.values.cnpgPair.replica.promoted=true (the #5125-D1 seam / RUNBOOKS §6.1 command)." >&2; exit 1; }
+if grep -q 'patch clusters' "$TMP/replica.yaml"; then
+  echo "FAIL: #5137 actor patches a live Cluster CR — flux drift-correction reverts that mid-outage (hw256 G12)." >&2; exit 1; fi
+# 5. Primary-loss detection via the LOCAL replica's WAL receiver, with the
+#    #5133 streaming_replica-cert auth (never the disabled superuser).
+grep -q 'pg_stat_wal_receiver' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 signals container missing the pg_stat_wal_receiver primary-loss detector." >&2; exit 1; }
+# 6. Promotability gate reads the failover-readiness probe's Ready signal.
+grep -q 'catalyst.openova.io/role=failover-readiness-probe' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 actor does not gate on the failover-readiness Ready condition (#5133 promotability signal)." >&2; exit 1; }
+# 7. RBAC is resourceNames-pinned to the configured HR in flux-system.
+grep -qE '^  namespace: flux-system$' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 missing the flux-system Role/RoleBinding (HR patch surface)." >&2; exit 1; }
+grep -qE 'resourceNames: \[bp-cnpg-pair\]' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 flux-system Role must be resourceNames-pinned to the bp-cnpg-pair HR." >&2; exit 1; }
+# 8. Egress CNP admits the kube-apiserver reserved entity (#4428 idiom).
+grep -q 'kube-apiserver' "$TMP/replica.yaml" || {
+  echo "FAIL: #5137 dr-promoter-egress CNP missing the kube-apiserver entity — kubectl egress would be default-denied." >&2; exit 1; }
+# 9. The replica ingress policy admits the signals container to 5432.
+#    (grep WITHOUT -q: under `set -o pipefail` a -q early-exit SIGPIPEs
+#    the upstream awk and fails the pipeline even on a match.)
+awk '/allow-probe-to-replica/{f=1} f' "$TMP/replica.yaml" | grep 'catalyst.openova.io/role: dr-promoter' >/dev/null || {
+  echo "FAIL: #5137 allow-probe-to-replica must admit the dr-promoter signals container to 5432." >&2; exit 1; }
+# 10. autoPromote.enabled=false → the 0.2.12 replica set (5 non-test), no promoter.
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.replica.autoPromote.enabled=false \
+  > "$TMP/nopromoter.yaml" 2> "$TMP/nopromoter.err" || {
+  echo "FAIL: #5137 autoPromote-disabled render errored:" >&2; cat "$TMP/nopromoter.err" >&2; exit 1; }
+if grep -q 'dr-promoter' "$TMP/nopromoter.yaml"; then
+  echo "FAIL: #5137 autoPromote.enabled=false must render ZERO dr-promoter resources." >&2; exit 1; fi
+if [ "$(grep -cE '^kind: ' "$TMP/nopromoter.yaml")" -ne 5 ]; then
+  echo "FAIL: #5137 autoPromote.enabled=false replica render must match the 0.2.12 set (5 non-test)." >&2
+  grep -E '^kind: ' "$TMP/nopromoter.yaml" >&2; exit 1; fi
+# 11. replication.mode=async → NO promoter (the sync-rep remote_apply +
+#     dataDurability:required fence is what makes automatic promotion
+#     split-brain-safe; async has no fence, so the actor must fail-safe
+#     to absent).
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.replication.mode=async \
+  > "$TMP/asyncpromoter.yaml" 2> "$TMP/asyncpromoter.err" || {
+  echo "FAIL: #5137 async-mode replica render errored:" >&2; cat "$TMP/asyncpromoter.err" >&2; exit 1; }
+if grep -q 'dr-promoter' "$TMP/asyncpromoter.yaml"; then
+  echo "FAIL: #5137 replication.mode=async must render ZERO dr-promoter resources (no sync-rep data fence → automatic promotion is not split-brain-safe)." >&2; exit 1; fi
+echo "  PASS (replica-only actor, Recreate Deployment, HR-desired-state patch, resourceNames-pinned RBAC, sync-only)"
 
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -97,6 +97,58 @@ cnpgPair:
     # failover the desired state so drift-correction re-affirms it.
     # See RUNBOOKS.md §6.1 (region-kill failover) + replica-cluster.yaml.
     promoted: false
+    # ── Region-B AUTOMATIC DR promotion (#5137) ─────────────────────
+    # hw261 G12 proved the DR orchestrator (Continuum controller + dr
+    # CR) is single-region: it dies WITH the killed primary region, so
+    # nothing acted on a promotable standby — the operator promoted by
+    # hand. autoPromote ships a region-B-local actor (side=replica
+    # only, like failover-readiness) that survives region-A loss:
+    #   Deployment `<fullname>-dr-promoter` — a continuous loop
+    #   (Deployment NOT CronJob, #5157: a CronJob's scheduler dies
+    #   with the region) with two containers:
+    #     signals — psql (streaming_replica cert, #5133 auth) against
+    #       the LOCAL replica -rw: non-streaming pg_stat_wal_receiver
+    #       while in recovery == the primary's WAL stream is dead.
+    #     actor  — when the stream has been dead CONTINUOUSLY for
+    #       primaryDownHoldSeconds AND the failover-readiness probe is
+    #       Ready (LSN apply==receive, promotable) AND the local
+    #       Cluster CR is still a replica AND the HR value is not
+    #       already promoted, it merge-patches the region-B
+    #       HelmRelease DESIRED state
+    #       (spec.values.cnpgPair.replica.promoted: true — the exact
+    #       RUNBOOKS §6.1 command / #5125-D1 seam). Flux then renders
+    #       replica.enabled:false and CNPG promotes the survivor.
+    # DATA SAFETY: only rendered when replication.mode=sync — with
+    # remote_apply + FIRST 1 pinned to the cross-region replica +
+    # dataDurability:required, the old primary cannot COMMIT while its
+    # sync standby is unreachable or diverged, so automatic promotion
+    # can never lose or fork committed data (RPO=0), partition or
+    # kill alike. The operator-manual HR patch keeps working; the
+    # actor no-ops when the value is already true.
+    autoPromote:
+      enabled: true
+      # Poll cadence for both containers.
+      intervalSeconds: 10
+      # The WAL stream must be down CONTINUOUSLY this long before the
+      # actor promotes. An intra-region primary restart / instance
+      # switchover reconnects the receiver in seconds and clears the
+      # hold clock — 120s keeps those events from triggering a
+      # cross-region promotion while still auto-recovering a real
+      # region kill in ~2-4 min end-to-end.
+      primaryDownHoldSeconds: 120
+      # The flux HelmRelease whose DESIRED state carries the promotion
+      # (bootstrap-kit slot 16b defaults).
+      hr:
+        name: bp-cnpg-pair
+        namespace: flux-system
+      # kubectl-bearing image for the actor container. Same
+      # harbor-proxy-pull-compliant (`*/proxy-*/*`) prefix as the
+      # signals/postgres image so the whole Pod matches ONE kyverno
+      # anyPattern glob (the #3195 single-source constraint).
+      kubectlImage:
+        repository: harbor.openova.io/proxy-dockerhub/alpine/k8s
+        tag: "1.30.0"
+        pullPolicy: IfNotPresent
     instances: 3
     storage:
       size: 100Gi

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -411,7 +411,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.9"
+  version: "0.2.13"
   visibility: listed
   card:
     title: "CNPG Cluster-Pair (Active-Hotstandby DR)"
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.12"
+    version: "0.2.13"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
Refs #5137

## Root cause

hw261 region-kill G12 (2026-07-16) passed zero-tx-loss **only via operator action**, because the DR orchestrator is single-region:

- The Continuum controller (bp-continuum slot 62) is `SECONDARY_HR_SUSPEND`'ed on secondary control planes — it runs only on region-a.
- The `dr.openova.io/v1` CR renders only on `side=primary` (`platform/cnpg-pair/chart/templates/continuum.yaml`), and the Continuum **CRD** ships in bp-catalyst-platform (slot 13), which is *also* suspended on secondaries — region-b has no CRD, no CR, no controller.
- A real region-kill (os-stop all region-a ECS) therefore takes the orchestrator down **with the region it must fail away from**. `failover-readiness` correctly reported promotable (#5134/#5133); no actor acted.

## Design chosen — and why not "run the controller on region-B"

The dispatch's preferred shape (Continuum controller instance on region-B, k8s-lease leader-election, dr CR mirror) was validated against the code and is **not implementable today without a much larger change**:

1. The Continuum CRD lives in bp-catalyst-platform (suspended on secondaries); `products/continuum/chart/crds/README.md` explicitly forbids duplicating it into bp-continuum (helm/kustomize ownership flap). No CRD on region-b ⇒ no CR mirror, no controller watch.
2. The controller's 7-step sequencer hard-depends on PDM, NATS, and `catalyst-system` — all region-a residents that are DOWN during the exact event.
3. Its `cnpgPromoter` still promotes via **live Cluster-CR patches** (`SetReplicaEnabled`) — the precise anti-pattern hw256 G12 proved flux drift-correction reverts mid-outage (#5125-D1).
4. A `coordination.k8s.io/v1` Lease lives in ONE cluster's apiserver; a 2-region Sovereign is two SEPARATE clusters, so the "existing k8s-lease witness" cannot arbitrate across them — each side would trivially hold its own lease.

**Shipped instead (highest-ICE, root-cause):** the region-B DR actor lives in **bp-cnpg-pair** — the only chart already applied on BOTH control planes with split-side gating (0.2.0), and the chart that owns the #5125-D1 `replica.promoted` seam. New `<pair>-dr-promoter` **Deployment** on `side=replica` only:

- **Deployment, never a CronJob** (#5157 hard rule, proven hw263→hw264) — replicas:1 + `Recreate` (single actor).
- **signals** container (cnpg postgres image, `streaming_replica` client-cert auth — the #5133 pattern): polls the LOCAL replica `-rw`; while in recovery, a non-`streaming` `pg_stat_wal_receiver` = the primary's WAL stream is dead. Hold clock starts on streaming→down; clears on resume / promotion / psql failure (fail-safe: an unhealthy local replica never looks like a dead primary).
- **actor** container (alpine/k8s, kubectl): promotes only when the stream has been dead continuously ≥ `autoPromote.primaryDownHoldSeconds` (**120s** — an intra-region primary restart/instance switchover reconnects in seconds and never triggers) AND the failover-readiness Pod is Ready (LSN apply==receive → promotable) AND the local Cluster CR is still a replica AND the HR value is not already promoted.
- The promotion is **one merge-patch of the region-B HelmRelease DESIRED state** — `spec.values.cnpgPair.replica.promoted: true` + `catalyst.openova.io/dr-auto-promoted-at`/`-reason` audit annotations — byte-identical to the RUNBOOKS §6.1 operator command. Never a live Cluster-CR patch. The bootstrap-kit slot never sets `replica.promoted`, so the flux Kustomization's SSA re-apply cannot strip the promoter's field. Operator-manual path unchanged (actor no-ops when already true).

### Anti-split-brain — why a region-local decision is data-safe

The promoter renders **only when `replication.mode=sync`** (new `cnpg-pair.autoPromoteActive` helper): with `synchronous_commit=remote_apply` + `FIRST 1` pinned to the cross-region replica + `dataDurability: required` (#3740), the old primary **cannot COMMIT** while its sync standby is unreachable — so nothing committed exists on A that B lacks (RPO=0), a mere partition cannot fork committed data, and after recovery the stale primary stays write-fenced (walsender rejected on the diverged timeline) until re-cloned (#5125 Defect-2). The sync-rep fence is the arbiter that actually holds during a region-kill; `async` (forensic/lab) renders NO promoter. A third-site witness generalizing this (and letting the full sequencer — DNS flip, HTTPRoute drain — run from the survivor) is documented as follow-up on #5137.

### Non-regression

- Single-region: `cnpgPair.enabled=false` still renders ZERO resources both sides (Case 1).
- `side=primary` byte-identical to 0.2.12 (Case 15.2); the #5094/#4901 standby-absent status path on the primary-side Continuum CR is untouched (no Go changes).
- `autoPromote.enabled=false` / `replication.mode=async` → exactly the 0.2.12 replica set (Case 15.10/15.11).
- Operator-manual HR patch keeps working; the actor is idempotent against it.
- RBAC minimal + resourceNames-pinned; egress is one CNP (kube-apiserver entity per the #4428 idiom + kube-dns + replica 5432); kyverno-Enforce compliant (enforced label, both probes on both containers, single `*/proxy-*/*` image glob, pinned tags). No NodePorts anywhere.

## Evidence (this PR)

- `bash platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` — **all 15 cases green**, incl. new Case 15 (side-gating, #5157 Deployment shape, exact HR merge-patch body, failover-readiness gate, resourceNames pin, sync-only fence) and updated Case 3 (replica non-test 5→12) / Case 12 (2 CNPs with peers set).
- `helm lint` clean; both container scripts `sh -n` clean; merge-patch body JSON-validated; full replica render YAML-parses (12 docs).
- `bash scripts/check-bootstrap-kit-pin-sync.sh` — PASS (65 pairs).
- `cd tests/e2e/bootstrap-kit && go test ./...` — PASS (incl. TestCatalogSeed).
- Lockstep 0.2.13: `Chart.yaml` + `blueprint.yaml` + slot 16b pin + catalog-seed `spec.version` **and** `source.version`.

## What validates on the next region-kill (live)

On the next fresh-prov G12 (`scripts/region-kill-drill.sh kill --arm`):
1. region-b `kubectl -n cnpg logs deploy/cnpg-pair-bp-cnpg-pair-dr-promoter -c signals` shows the hold clock starting at T0+~10s;
2. at T0+~130s the actor logs `PROMOTING …` and the region-b HR gains `catalyst.openova.io/dr-auto-promoted-at` + `spec.values.cnpgPair.replica.promoted: true`;
3. helm-controller renders `replica.enabled: false`, CNPG promotes, the pre-kill sync-committed sentinel row survives → **RPO=0 with ZERO operator action**;
4. drift-correction re-affirms (no hw256-style revert);
5. negative check: an intra-region primary pod restart must NOT trigger (hold clock clears on reconnect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)