### PR TITLE
fix(preflight): gate on catalyst-api deployed==pinned (no roll pending mid-prov)

### DIFF
--- a/scripts/prov-preflight.sh
+++ b/scripts/prov-preflight.sh
@@ -220,6 +220,31 @@ if kubectl -n catalyst rollout status deploy/catalyst-api --timeout=8s >/dev/nul
   pass "4. catalyst-api rollout settled"
 else bad "4. catalyst-api mid-roll — wait (a roll mid-prov ABANDONS it)"; fi
 
+# 4b. mothership catalyst-api DEPLOYED image == origin/main PINNED tag (no roll
+#     PENDING). hw265 died because check-4 "settled" is POINT-IN-TIME: at fire
+#     time catalyst-api was 1/1 on the OLD image, then Flux reconciled the
+#     already-merged deploybot image-bump a few minutes later — MID-tofu-apply —
+#     and the restart abandoned the prov (reference_deploybot_catalyst_api_roll_
+#     mid_fire_abandons_prov). Gate on deployed==pinned so no roll can land during
+#     the prov: they diverge ONLY when a deploybot bump is merged but not yet
+#     reconciled onto the mothership.
+git fetch origin main --quiet 2>/dev/null || true
+_deployed_tag=$(kubectl -n catalyst get deploy catalyst-api \
+  -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null | sed 's/.*://')
+_pinned_tag=$(git show origin/main:products/catalyst/chart/values.yaml 2>/dev/null | python3 -c '
+import sys,yaml
+try:
+    print((yaml.safe_load(sys.stdin) or {}).get("images",{}).get("catalystApi",{}).get("tag",""))
+except Exception:
+    print("")' 2>/dev/null)
+if [ -z "$_deployed_tag" ] || [ -z "$_pinned_tag" ]; then
+  bad "4b. could not read catalyst-api deployed/pinned tag (deployed='${_deployed_tag}' pinned='${_pinned_tag}') — verify the mothership is on the pinned image before firing"
+elif [ "$_deployed_tag" = "$_pinned_tag" ]; then
+  pass "4b. catalyst-api on the pinned image (${_deployed_tag}) — NO roll pending mid-prov"
+else
+  bad "4b. catalyst-api DEPLOYED=${_deployed_tag} != PINNED=${_pinned_tag} — a deploybot roll is PENDING; it WILL reconcile mid-prov and ABANDON it (hw265). Wait for Flux to roll catalyst-api to the pinned image + settle, THEN fire."
+fi
+
 # 5. NO in-flight Build-&-Deploy / blueprint-release CI (a merge mid-prov rolls catalyst-api -> abandon)
 inflight=$(gh run list --repo openova-io/openova --limit 12 --json name,status -q '[.[]|select(.status!="completed")]|length' 2>/dev/null)
 [ "${inflight:-x}" = "0" ] && pass "5. no in-flight CI (and HOLD all merges until ready)" || bad "5. ${inflight:-unknown} CI run(s) in flight — wait + DO NOT MERGE until prov is ready"


### PR DESCRIPTION
## Root cause — hw265 abandoned mid-apply (2026-07-17)
Fired right after a deploybot catalyst-api image bump merged. Preflight check-4 ("rollout settled") passed — catalyst-api was 1/1 on the OLD image at that instant — then the mothership Flux reconciled the already-merged bump a few minutes later, **mid tofu-apply**, and the catalyst-api restart abandoned the prov: `catalyst-api restarted during provisioning — this deployment was abandoned mid-apply`.

## Fix — new check 4b (deployed == pinned)
Check-4 is point-in-time and can't see a **pending** roll. Check-4b compares the mothership's **deployed** catalyst-api tag vs the **origin/main pinned** tag (`images.catalystApi.tag` — what deploybot writes). They diverge only when a bump is merged but not yet reconciled → a roll is imminent → **FAIL** (wait). Fire only when deployed==pinned, so no roll can land during the prov.

Verified live: deployed=`febfcc9` == pinned=`febfcc9` → 4b PASS. `bash -n` clean.

Durable fix for the `never-merge-catalyst-api-right-before-firing` / `catalyst-api-roll-abandons-inflight-prov` trap.

`Refs #960`

🤖 Generated with [Claude Code](https://claude.com/claude-code)