### PR TITLE
fix(openova-mcp): resolve session tokens via catalyst-api /whoami (Refs #5175)

### DIFF
--- a/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
+++ b/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
@@ -110,7 +110,7 @@ spec:
       # zero-RBAC ServiceAccount + Cilium ingress/egress CNPs. Lockstep:
       # products/openova-mcp/chart/Chart.yaml + blueprint.yaml +
       # catalog-seed (blueprints.json).
-      version: 0.1.3
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-openova-mcp

--- a/docs/sessions/2026-07-17/fire-readiness-hw265.md
+++ b/docs/sessions/2026-07-17/fire-readiness-hw265.md
@@ -1,0 +1,32 @@
+# Fire-readiness gate — next prov (hw265) — 2026-07-17
+
+Preflight (`scripts/prov-preflight.sh hw265.omani.works hw265-omani-works`, read-only):
+
+## Infra headroom — ✅ ALL GREEN (2-region fire fits)
+- VPC 3/5 used (≥2 free ✅) · EVS 268/400 (≥120 free ✅) · OBS 69/100 (≥3 free ✅)
+- catalyst-api rollout settled ✅ · no in-flight CI ✅
+
+## Wipe-before-fire gates — ❌ EXPECTED (hw264 still live)
+- 1 active deployment (hw264 `4585c8a9`) → COMPLETELY wipe first (one-env-at-a-time #5111).
+- 3 orphaned DOWN EIPs + 9 non-bastion EIPs allocated → after wipe, wait ~10-15min for
+  release or firing risks VPC.0532 'EIP pool sold out' (#5126 — the founder's EIP limit).
+- foreign live ECS = hw264's own nodes (same wipe-first).
+
+## Fire sequence (gated, janitor-disciplined)
+1. Board the full train: deploybot chart image-pin ≥ 6ea8bf1de (delivers #5123 catalyst-api);
+   #5137 Continuum DR auto-promotion merged (bonus passenger). Chart pins already on main:
+   cnpg-pair 0.2.12 (#5125-D1), openbao 1.2.63 (#5157), openova-mcp 0.1.3 (#5167).
+2. Wipe hw264 (autonomous — platform-created, non-bastion): capture cloud-init log first (#3132)
+   only if FAILED (it's ready, so straight wipe), then `POST /deployments/{id}/wipe`.
+3. Wait ~10-15min → EIP/ECS release to shared pool.
+4. Re-run preflight → MUST pass (0 active, EIPs released).
+5. `python3 scripts/reset-uat.py hw265` (flush predecessor evidence #3132).
+6. Fire: `POST /sovereign/api/v1/deployments` (hw265.omani.works, qaTest=false PROD certs,
+   fireCutoverOnHandover=true zero-touch).
+7. Zero-touch validate the WHOLE train (esp. MCP RS256 ACTIVE #5167, openbao Deployment #5157,
+   cnpg failover-via-HR #5125-D1) → cutoverComplete → region-kill G12 (auto-promote if #5137
+   landed) → full ~281-row authed UAT sweep to 100%.
+
+## Delivery-chain note (merged ≠ delivered)
+deploybot image pin is at 2e18085 (has #5124) — #5123 (6ea8bf1de) merged AFTER; the fresh
+prov's catalyst-api carries #5123 only once deploybot bumps past it. DO NOT fire before that.

--- a/products/openova-mcp/blueprint.yaml
+++ b/products/openova-mcp/blueprint.yaml
@@ -23,7 +23,7 @@ spec:
   # HTTPRoute + zero-RBAC ServiceAccount + Cilium CNPs). Lockstep with
   # products/openova-mcp/chart/Chart.yaml 0.1.2 + bootstrap-kit slot 13d pin
   # + the catalog-seed (blueprints.json) entry.
-  version: 0.1.3
+  version: 0.1.4
   card:
     title: OpenOva MCP
     summary: |

--- a/products/openova-mcp/chart/Chart.yaml
+++ b/products/openova-mcp/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-openova-mcp
+# 0.1.4 / appVersion 0.2.4 (#5175, north-star close): the MCP verifies bearers
+# against the mothership HANDOVER public key, but real callers present
+# post-handover SESSION tokens signed with a deployment-local key the MCP does
+# NOT hold — so local rs256 verify fails "signature invalid" for every real
+# owner/Org session and tools/call 401s. The 0.2.4 binary adds a fail-closed
+# facade-forward-identity fallback: when local verify fails AND a catalyst-api
+# client is configured, it delegates the verdict to catalyst-api's own
+# /api/v1/whoami (the session-token AUTHORITY) and maps mode→context /
+# tier→tier / org→scope. The per-Org context+org pins are re-applied on this
+# path so a whoami verdict can never widen a per-Org instance's surface. A
+# bad/expired/tampered token 401s upstream → the original verify error stands
+# (surface never widened on a catalyst-api hiccup). No new value/env is needed —
+# the existing catalyst-api URL wiring activates the path. #5167 rs256 fast-path
+# unchanged. Lockstep: blueprint.yaml + slot 13d → 0.1.4 (not in catalog-seed).
+#
 # 0.1.3 / appVersion 0.2.3 (#5167, north-star unblock): verify=rs256 now WORKS
 # on a fresh Sovereign. Root cause of the every-fresh-prov DEGRADED mode was a
 # two-fold mismatch, silent behind optional:true — (a) values referenced the
@@ -59,7 +74,7 @@ type: application
 # catalog-seed (blueprints.json) 0.1.1. Image = ghcr.io/openova-io/
 # openova-mcp:<appVersion> (build-openova-mcp.yaml; plain image repo per
 # the #4706 chart-repo-collision lesson).
-version: 0.1.3
+version: 0.1.4
 # appVersion is the default image tag (openova-mcp.image in _helpers.tpl).
 # 0.2.2 (#5114): buildResolver degrades instead of exiting when the rs256
 # verify pubkey (or the hs256 secret) is absent/unparseable — see the 0.1.2
@@ -71,7 +86,7 @@ version: 0.1.3
 # the OPENOVA_MCP_EXPECTED_ISSUER / OPENOVA_MCP_ORG_SCOPE instance pins) —
 # the 0.1.x binary was stdio-only (the agenity in-pod child, #4010/#4097)
 # and cannot back a Service.
-appVersion: "0.2.3"
+appVersion: "0.2.4"
 keywords:
   - mcp
   - agent

--- a/products/openova-mcp/cmd/openova-mcp/main.go
+++ b/products/openova-mcp/cmd/openova-mcp/main.go
@@ -63,6 +63,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
 	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
@@ -288,7 +289,52 @@ func (s *server) resolveBearer(bearer string) (*identity.Identity, error) {
 	if bearer == "" {
 		return nil, errors.New("no bearer (set _auth.token in arguments or OPENOVA_MCP_BEARER)")
 	}
-	return s.resolver.Resolve(bearer)
+	id, err := s.resolver.Resolve(bearer)
+	if err == nil {
+		return id, nil
+	}
+	// #5175 — the MCP is configured with the mothership HANDOVER public key,
+	// but real callers present catalyst-api SESSION tokens signed with a
+	// deployment-local key the MCP does not hold. When local verify fails and
+	// a catalyst-api client is configured, delegate the verdict to
+	// catalyst-api's /whoami — it is the session-token authority. Fail-closed:
+	// on any whoami error (401 / unreachable / not-verified) fall through to
+	// the ORIGINAL local-verify error so a catalyst-api hiccup can never widen
+	// the surface.
+	if wid, werr := s.whoamiFallback(bearer); werr == nil {
+		return wid, nil
+	}
+	return nil, err
+}
+
+// whoamiFallback resolves identity via catalyst-api's /whoami for tokens the
+// local resolver cannot verify (session tokens signed by the deployment-local
+// key — #5175). Returns an error (→ caller keeps the original verify failure)
+// when no catalyst-api client is wired, the endpoint rejects the token, or
+// the session is not verified.
+func (s *server) whoamiFallback(bearer string) (*identity.Identity, error) {
+	api := s.reg.API()
+	if api == nil {
+		return nil, errors.New("whoami fallback: no catalyst-api client configured")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	w, err := api.Whoami(ctx, bearer)
+	if err != nil {
+		return nil, err
+	}
+	if !w.Verified {
+		return nil, errors.New("whoami fallback: session not verified")
+	}
+	return s.resolver.FromWhoami(identity.WhoamiIdentity{
+		Email:         w.Email,
+		Mode:          w.Mode,
+		Tier:          w.Tier,
+		Org:           w.Org,
+		OrgScoped:     w.OrgScoped,
+		DeploymentID:  w.DeploymentID,
+		SovereignFQDN: w.SovereignFQDN,
+	}, bearer)
 }
 
 // ── bearer plumbing (mirrors the sandbox MCP _auth envelope) ─────────────

--- a/products/openova-mcp/cmd/openova-mcp/whoami_fallback_test.go
+++ b/products/openova-mcp/cmd/openova-mcp/whoami_fallback_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+	"github.com/openova-io/openova/products/openova-mcp/internal/tools"
+)
+
+// End-to-end #5175: a degraded resolver is the REAL deployment shape — the MCP
+// holds the mothership HANDOVER public key but callers present post-handover
+// SESSION tokens signed by a deployment-local key the MCP does not have, so
+// local verify fails for every real caller. resolveBearer must then fall back
+// to catalyst-api's /whoami (the session-token authority) and resolve there.
+func TestResolveBearer_WhoamiFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/whoami" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"email":"e@openova.io","verified":true,"mode":"sovereign","tier":"owner","deploymentId":"dep1"}`))
+	}))
+	defer ts.Close()
+
+	srv := &server{
+		reg:      tools.NewRegistry(catalystapi.New(ts.URL)),
+		resolver: identity.NewDegradedResolver("no session pubkey", ""),
+	}
+
+	id, err := srv.resolveBearer("sess.tok.session")
+	if err != nil {
+		t.Fatalf("resolveBearer fell through despite a valid whoami verdict: %v", err)
+	}
+	if id.Tier != identity.TierOwner || id.Context != identity.ContextSovereign {
+		t.Fatalf("resolved id tier=%v ctx=%s", id.Tier, id.Context)
+	}
+	if id.RawBearer != "sess.tok.session" {
+		t.Fatalf("rawBearer=%q not forwarded to the facade", id.RawBearer)
+	}
+}
+
+// Fail-closed: when catalyst-api itself rejects the token (401), resolveBearer
+// keeps the ORIGINAL local-verify error — a catalyst-api verdict never widens
+// the surface on a token catalyst-api refuses.
+func TestResolveBearer_WhoamiFallback_FailsClosed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	srv := &server{
+		reg:      tools.NewRegistry(catalystapi.New(ts.URL)),
+		resolver: identity.NewDegradedResolver("no session pubkey", ""),
+	}
+	if _, err := srv.resolveBearer("bad.tok"); err == nil {
+		t.Fatal("resolveBearer accepted a token catalyst-api rejected (surface widened)")
+	}
+}
+
+// No catalyst-api client wired → no fallback path → the original verify error
+// stands. Backend-less / stdio-only deployments are unaffected by the fix.
+func TestResolveBearer_NoAPIClient_NoFallback(t *testing.T) {
+	srv := &server{
+		reg:      tools.NewRegistry(nil),
+		resolver: identity.NewDegradedResolver("no session pubkey", ""),
+	}
+	if _, err := srv.resolveBearer("any.tok"); err == nil {
+		t.Fatal("resolveBearer resolved with no resolver key and no catalyst-api client")
+	}
+}

--- a/products/openova-mcp/internal/catalystapi/client.go
+++ b/products/openova-mcp/internal/catalystapi/client.go
@@ -241,6 +241,40 @@ func (c *Client) ListOrganizations(ctx context.Context, bearer string) (*Organiz
 	return &out, nil
 }
 
+// WhoamiResponse mirrors whoamiResponse in
+// products/catalyst/bootstrap/api/internal/handler/auth.go. It is the
+// authoritative identity verdict for a session token: catalyst-api verifies
+// the token with the SAME key it minted the session with, then reports the
+// resolved (mode, tier, org, deployment) triple.
+type WhoamiResponse struct {
+	Email         string `json:"email"`
+	Sub           string `json:"sub"`
+	Verified      bool   `json:"verified"`
+	DeploymentID  string `json:"deploymentId,omitempty"`
+	SovereignFQDN string `json:"sovereignFQDN,omitempty"`
+	Mode          string `json:"mode,omitempty"` // "sovereign" | "organization"
+	Tier          string `json:"tier,omitempty"` // "owner" | "admin" | "viewer" | …
+	OrgScoped     bool   `json:"orgScoped,omitempty"`
+	Org           string `json:"org,omitempty"` // Organization slug in Org context
+}
+
+// Whoami calls GET /api/v1/whoami — catalyst-api's own identity endpoint.
+// The MCP uses it as the authority for SESSION tokens it cannot verify
+// locally: the MCP is configured with the mothership HANDOVER public key,
+// but catalyst-api mints post-handover session tokens with a DIFFERENT
+// (deployment-local) key whose public half the MCP does not hold (#5175).
+// Rather than ship that key to every MCP, the facade delegates the verdict
+// to catalyst-api — which IS the session-token issuer/authority. A non-2xx
+// (e.g. 401 on a bad/expired/tampered token) returns *APIError so the caller
+// fails closed.
+func (c *Client) Whoami(ctx context.Context, bearer string) (*WhoamiResponse, error) {
+	var out WhoamiResponse
+	if err := c.get(ctx, "/api/v1/whoami", bearer, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // ── Write: create Application (POST .../applications) ────────────────────
 
 // ApplicationBlueprintRef mirrors `applicationBlueprintRef` in the

--- a/products/openova-mcp/internal/catalystapi/client_test.go
+++ b/products/openova-mcp/internal/catalystapi/client_test.go
@@ -1,0 +1,61 @@
+package catalystapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Whoami parses catalyst-api's identity verdict — the #5175 authority the MCP
+// falls back to when it cannot verify a session token's signature locally.
+func TestWhoami_ParsesVerdict(t *testing.T) {
+	var gotAuth, gotCookie string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/whoami" {
+			t.Errorf("path = %q, want /api/v1/whoami", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		gotCookie = r.Header.Get("Cookie")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"email":"emrah.baysal@openova.io","sub":"u1","verified":true,` +
+			`"deploymentId":"b85cb3b3a565893a","sovereignFQDN":"hw266.omani.works",` +
+			`"mode":"sovereign","tier":"owner"}`))
+	}))
+	defer ts.Close()
+
+	w, err := New(ts.URL).Whoami(context.Background(), "sess.tok.xyz")
+	if err != nil {
+		t.Fatalf("Whoami: %v", err)
+	}
+	if !w.Verified || w.Mode != "sovereign" || w.Tier != "owner" {
+		t.Fatalf("verdict = %+v", w)
+	}
+	if w.DeploymentID != "b85cb3b3a565893a" || w.SovereignFQDN != "hw266.omani.works" {
+		t.Fatalf("verdict deployment fields = %+v", w)
+	}
+	// The facade forwards the caller's token both ways (gateway + RequireSession).
+	if gotAuth != "Bearer sess.tok.xyz" || gotCookie != "catalyst_session=sess.tok.xyz" {
+		t.Fatalf("forwarded auth=%q cookie=%q", gotAuth, gotCookie)
+	}
+}
+
+// A bad/expired/tampered token 401s upstream → *APIError, so the MCP
+// whoami-fallback fails closed (the caller keeps the original verify error).
+func TestWhoami_Unauthorized_IsAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
+	}))
+	defer ts.Close()
+
+	_, err := New(ts.URL).Whoami(context.Background(), "bad.tok")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusUnauthorized {
+		t.Fatalf("err = %v, want *APIError status 401", err)
+	}
+}

--- a/products/openova-mcp/internal/identity/whoami.go
+++ b/products/openova-mcp/internal/identity/whoami.go
@@ -1,0 +1,92 @@
+package identity
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+)
+
+// WhoamiIdentity is catalyst-api's authoritative identity verdict for a
+// session token, reduced to the fields the MCP scopes tools on. It is the
+// plain (no HTTP-client import) input to (*Resolver).FromWhoami so the
+// identity package stays free of a dependency on internal/catalystapi.
+type WhoamiIdentity struct {
+	Email         string
+	Mode          string // "sovereign" | "organization"
+	Tier          string // "owner" | "admin" | "viewer" | …
+	Org           string // Organization slug (Org context)
+	OrgScoped     bool
+	DeploymentID  string
+	SovereignFQDN string
+}
+
+// FromWhoami builds a verified *Identity from catalyst-api's /whoami verdict
+// instead of a locally-verified token signature. This is the #5175 path: the
+// MCP is configured with the mothership HANDOVER public key, but callers
+// present post-handover SESSION tokens signed with a deployment-local key
+// whose public half the MCP does not hold. Rather than ship that key to every
+// MCP, the facade delegates the verdict to catalyst-api — the session-token
+// authority — and maps its answer here.
+//
+// The SAME instance-level trust boundaries that fromClaims enforces apply on
+// this path: the per-Org context pin and the org pin are re-applied so a
+// whoami verdict can NEVER widen a per-Org instance's surface beyond its
+// pinned Org (#3988 §4.3). rawBearer is retained so the thin-facade tool
+// handlers forward the caller's token verbatim to catalyst-api (which accepts
+// it — it minted it).
+//
+// Callers only reach this after a signature-verify miss AND a catalyst-api
+// 2xx /whoami (a bad/expired/tampered token 401s upstream and never gets
+// here), so the result is fail-closed: no catalyst-api acceptance, no
+// identity.
+func (r *Resolver) FromWhoami(w WhoamiIdentity, rawBearer string) (*Identity, error) {
+	raw := strings.TrimSpace(strings.TrimPrefix(rawBearer, "Bearer "))
+	if raw == "" {
+		return nil, errors.New("identity: whoami fallback requires a bearer")
+	}
+
+	// Context: catalyst-api's `mode` (or the orgScoped flag) is authoritative.
+	ctx := ContextSovereign
+	if strings.EqualFold(w.Mode, string(ContextOrganization)) || w.OrgScoped {
+		ctx = ContextOrganization
+	}
+
+	id := &Identity{
+		// bearerOf() short-circuits to "" on a nil Claims, so a non-nil
+		// Claims is required for the facade to forward the token. Populate
+		// it faithfully from the verdict so the whoami tool echoes what the
+		// server actually resolved.
+		Claims: &sharedauth.Claims{
+			Email:         w.Email,
+			OrgID:         w.Org,
+			Tier:          w.Tier,
+			SovereignFQDN: w.SovereignFQDN,
+			DeploymentID:  w.DeploymentID,
+		},
+		Context:       ctx,
+		Tier:          tierFromLabel(w.Tier),
+		OrgID:         w.Org,
+		DeploymentID:  w.DeploymentID,
+		SovereignFQDN: w.SovereignFQDN,
+		Email:         w.Email,
+		RawBearer:     raw,
+	}
+
+	// Instance-level pins — identical invariants to fromClaims so the whoami
+	// path cannot bypass the per-Org trust boundary.
+	if r.pinnedCtx != "" {
+		if r.pinnedCtx == ContextOrganization && id.OrgID == "" {
+			return nil, errors.New("identity: per-Org MCP requires an org-scoped session (no org in whoami)")
+		}
+		id.Context = r.pinnedCtx
+	}
+	if id.Context == ContextOrganization && id.OrgID == "" {
+		return nil, errors.New("identity: organization context requires an org scope")
+	}
+	if r.orgPin != "" && id.OrgID != r.orgPin {
+		return nil, fmt.Errorf("identity: session org scope %q does not match this instance's pinned org %q", id.OrgID, r.orgPin)
+	}
+	return id, nil
+}

--- a/products/openova-mcp/internal/identity/whoami_test.go
+++ b/products/openova-mcp/internal/identity/whoami_test.go
@@ -1,0 +1,109 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+)
+
+// FromWhoami maps catalyst-api's authoritative verdict to an Identity — the
+// #5175 path where a session token cannot be locally verified but
+// catalyst-api (its issuer) resolves it. A degraded resolver (the real
+// deployment shape: MCP holds the handover key, not the session key) still
+// yields a usable identity through this path.
+func TestFromWhoami_SovereignOwner(t *testing.T) {
+	r := NewDegradedResolver("no session pubkey", "")
+	id, err := r.FromWhoami(WhoamiIdentity{
+		Email:         "emrah.baysal@openova.io",
+		Mode:          "sovereign",
+		Tier:          "owner",
+		DeploymentID:  "b85cb3b3a565893a",
+		SovereignFQDN: "hw266.omani.works",
+	}, "Bearer sess.tok.abc")
+	if err != nil {
+		t.Fatalf("FromWhoami rejected a valid sovereign-owner verdict: %v", err)
+	}
+	if id.Context != ContextSovereign {
+		t.Fatalf("context = %q, want sovereign", id.Context)
+	}
+	if id.Tier != TierOwner {
+		t.Fatalf("tier = %v, want TierOwner", id.Tier)
+	}
+	if id.DeploymentID != "b85cb3b3a565893a" {
+		t.Fatalf("deploymentID = %q", id.DeploymentID)
+	}
+	// The facade forwards the caller's token verbatim (bearerOf reads
+	// RawBearer after asserting Claims != nil), so both must be populated —
+	// the "Bearer " prefix is stripped.
+	if id.RawBearer != "sess.tok.abc" {
+		t.Fatalf("rawBearer = %q, want stripped token", id.RawBearer)
+	}
+	if id.Claims == nil {
+		t.Fatal("Claims is nil — bearerOf() would short-circuit to empty and break the forward")
+	}
+}
+
+func TestFromWhoami_OrganizationAdmin(t *testing.T) {
+	r := NewDegradedResolver("no session pubkey", "")
+	id, err := r.FromWhoami(WhoamiIdentity{
+		Email: "u@acme.test",
+		Mode:  "organization",
+		Tier:  "admin",
+		Org:   "acme",
+	}, "sess.tok.org")
+	if err != nil {
+		t.Fatalf("FromWhoami rejected a valid org-admin verdict: %v", err)
+	}
+	if id.Context != ContextOrganization {
+		t.Fatalf("context = %q, want organization", id.Context)
+	}
+	if id.Tier != TierAdmin {
+		t.Fatalf("tier = %v, want TierAdmin", id.Tier)
+	}
+	if id.OrgID != "acme" {
+		t.Fatalf("orgID = %q, want acme", id.OrgID)
+	}
+}
+
+// orgScoped=true forces Org context even when Mode is unset — matching the
+// SPA's own reading of the whoami envelope.
+func TestFromWhoami_OrgScopedFlagForcesOrgContext(t *testing.T) {
+	id, err := NewDegradedResolver("x", "").FromWhoami(WhoamiIdentity{
+		Email: "u@acme.test", Tier: "viewer", Org: "acme", OrgScoped: true,
+	}, "t")
+	if err != nil {
+		t.Fatalf("rejected: %v", err)
+	}
+	if id.Context != ContextOrganization {
+		t.Fatalf("orgScoped verdict got context %q, want organization", id.Context)
+	}
+}
+
+// The per-Org instance pin is re-applied on the whoami path: a verdict for a
+// DIFFERENT Org is rejected, exactly as the signed-token path rejects a
+// cross-org token (#3988 §4.3). The whoami fallback must not be a bypass.
+func TestFromWhoami_OrgPinRejectsCrossOrg(t *testing.T) {
+	r := NewDegradedResolver("x", ContextOrganization).WithOrgPin("demo")
+
+	if _, err := r.FromWhoami(WhoamiIdentity{Mode: "organization", Org: "demo", Tier: "admin"}, "t"); err != nil {
+		t.Fatalf("own-org whoami verdict rejected: %v", err)
+	}
+	_, err := r.FromWhoami(WhoamiIdentity{Mode: "organization", Org: "other", Tier: "admin"}, "t")
+	if err == nil || !strings.Contains(err.Error(), "pinned org") {
+		t.Fatalf("cross-org whoami verdict accepted by org-pinned instance (err=%v)", err)
+	}
+}
+
+// A per-Org pin with no org in the verdict is rejected (can't widen to
+// Sovereign, can't run Org-context without a scope).
+func TestFromWhoami_OrgPinRequiresOrgScope(t *testing.T) {
+	r := NewDegradedResolver("x", ContextOrganization)
+	if _, err := r.FromWhoami(WhoamiIdentity{Mode: "sovereign", Tier: "owner"}, "t"); err == nil {
+		t.Fatal("org-pinned instance accepted a verdict with no org scope")
+	}
+}
+
+func TestFromWhoami_EmptyBearerRejected(t *testing.T) {
+	if _, err := NewDegradedResolver("x", "").FromWhoami(WhoamiIdentity{Mode: "sovereign", Tier: "owner"}, "  "); err == nil {
+		t.Fatal("empty bearer accepted")
+	}
+}

--- a/products/openova-mcp/internal/tools/registry.go
+++ b/products/openova-mcp/internal/tools/registry.go
@@ -78,6 +78,17 @@ func NewRegistry(api *catalystapi.Client) *Registry {
 	return r
 }
 
+// API exposes the wired catalyst-api client (nil in backend-less unit tests)
+// so the server's identity resolver can fall back to catalyst-api's /whoami
+// when a session token cannot be verified locally (#5175). Returns nil if the
+// registry was built with no backend.
+func (r *Registry) API() *catalystapi.Client {
+	if r == nil {
+		return nil
+	}
+	return r.api
+}
+
 // visible reports whether the tool is visible to the given identity under
 // layer-1 (and gate-checked identically under layer-2). A nil identity
 // sees nothing.


### PR DESCRIPTION
## Problem (Pillar-4 north-star — final gap)

`bp-openova-mcp` verifies caller bearers against the **mothership HANDOVER**
public key (`catalyst-handover-jwt-public` / `public.jwk`), but real callers
present **post-handover SESSION tokens** minted by catalyst-api with a
**deployment-local key** whose public half the MCP does not hold. Result:
local rs256 verify fails `signature invalid` for every owner/Org session, so
`tools/call` 401s. Observed live on hw266: an owner PIN session's token gets
`whoami` OK from catalyst-api but `list_applications` via the MCP is rejected
"signature invalid". This is the last gap on the north-star — Agenity /
privileged users provisioning Applications through the MCP from either
Organization (all RBAC tiers).

`#5167` fixed the *first* half (the MCP now loads the handover JWK and leaves
DEGRADED mode); this fixes the *second* half (the key it loads is the wrong
one for real session tokens).

## Root cause

The MCP holds key **M** (mothership handover pubkey). catalyst-api signs
session tokens with key **H** (`/var/lib/catalyst/handover-jwt-private.pem`,
deployment-local); **H**'s public half is never published to the MCP. Shipping
**H** to every MCP instance is both operationally fragile and a key-distribution
liability.

## Fix — fail-closed facade-forward-identity

catalyst-api is *itself* the session-token authority (it minted them and
`/api/v1/whoami` verifies them with **H**). So instead of duplicating **H**,
the thin facade **delegates the verdict**:

- `resolveBearer` tries the existing rs256 fast-path first (unchanged — #5167).
- On a verify miss **and** a configured catalyst-api client, it calls
  `GET /api/v1/whoami` and maps the verdict `mode→context`, `tier→tier`,
  `org→scope`, retaining the raw bearer so the data tools forward the caller's
  token verbatim (catalyst-api accepts it — it issued it).
- The **per-Org context + org pins are re-applied** on the whoami path, so a
  whoami verdict can **never** widen a per-Org instance's surface beyond its
  pinned Org (identical invariant to `fromClaims`, #3988 §4.3).
- **Fail-closed**: a bad/expired/tampered token 401s upstream → the whoami
  fallback errors → the *original* local-verify error stands. A catalyst-api
  hiccup or a backend-less (stdio-only) deployment never widens the surface.

No new value/env — the existing `OPENOVA_MCP_CATALYST_API_URL` wiring activates
the path.

## Changes

| File | Change |
|---|---|
| `internal/catalystapi/client.go` | `Whoami(ctx, bearer)` + `WhoamiResponse` (mirrors auth.go `whoamiResponse`) |
| `internal/identity/whoami.go` | `(*Resolver).FromWhoami` — maps the verdict + re-applies context/org pins |
| `internal/tools/registry.go` | `Registry.API()` accessor (nil-safe) |
| `cmd/openova-mcp/main.go` | `resolveBearer` whoami-fallback + `whoamiFallback` helper (10s timeout) |
| `chart/Chart.yaml` | version `0.1.4` / appVersion `0.2.4` + changelog |
| `blueprint.yaml`, bootstrap-kit slot `13d` | lockstep pin `0.1.4` (pin-sync guard PASS) |

## Tests (11 new, all green)

- `FromWhoami`: sovereign-owner + org-admin mapping, `orgScoped` forces Org
  context, **org-pin rejects cross-org verdict**, org-pin requires a scope,
  empty-bearer rejected.
- `Whoami`: parses the verdict + forwards Authorization/Cookie both ways;
  **401 → `*APIError`** (fail-closed).
- `resolveBearer` end-to-end: degraded resolver + httptest catalyst-api →
  resolves via fallback; **401 → keeps original error**; **no-api-client → no
  fallback** (stdio-only unaffected).

`go build ./...` ✓ `go vet ./...` ✓ `go test ./...` ✓ `gofmt` ✓
`helm template` ✓ `check-bootstrap-kit-pin-sync.sh` PASS.

## Validation gate

Deploys on the **next fresh prov** (hw266 already runs 0.1.3). Held per the
in-flight-prov merge discipline (no merges during the hw266 cutover). Once
merged + rolled: owner PIN session → MCP `list_applications` returns the
Org's apps; per-Org (SME) session → MCP scoped to that Org only. Flips UAT
rows 211–213 to ✅ under a real session token.

Refs #5175