### PR TITLE
fix(cnpg-pair): dr-promoter region-A liveness gate + durable suspend latch (Refs #5178)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -213,7 +213,15 @@ spec:
       # the #5125-D1 seam) when the primary's WAL stream has been dead ≥120s
       # AND failover-readiness is Ready — automatic RPO=0 region-kill
       # failover with zero operator action. sync-mode-only (data fence).
-      version: 0.2.13
+      # 0.2.14 (#5178): dr-promoter regression fix — the 0.2.13 promoter
+      # false-promoted a healthy replica against a live region-A and its
+      # promote was non-durable, running the region-B timeline away on hw266
+      # G12 (TL2→TL25). Adds (A) a POSITIVE region-A liveness gate (pg_isready
+      # of `-primary-mesh` over the mesh, gated on crossRegionPeerClusters) +
+      # startup grace, and (B) a durable SUSPEND latch + anti-flap guard. The
+      # existing SOVEREIGN_PEER_CLUSTERMESH_NAMES wiring (below) is what arms
+      # the liveness gate — no new substitute.
+      version: 0.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1070,39 +1070,54 @@ The deterministic failover test for two independent CNPG clusters:
 
 1. Place a write into the primary CNPG cluster (synchronous replication, `remote_apply`, PR #2071)
 2. Kill the primary region (canonical driver: `scripts/region-kill-drill.sh kill --arm` — batch HARD os-stop of the region-a ECS via the HCS action API; bastion hard-excluded)
-3. **AUTOMATIC (bp-cnpg-pair ≥ 0.2.13, #5137)**: region-B's `<pair>-dr-promoter`
+3. **AUTOMATIC (bp-cnpg-pair ≥ 0.2.14, #5137 + #5178)**: region-B's `<pair>-dr-promoter`
    Deployment (side=replica; a Deployment NOT a CronJob per #5157 — it survives
-   the region-kill because it runs in the surviving region) detects the dead WAL
-   stream via the LOCAL replica's `pg_stat_wal_receiver`, waits
-   `autoPromote.primaryDownHoldSeconds` (120s, so an intra-region primary
-   restart never triggers), confirms the failover-readiness probe is Ready
-   (LSN apply==receive, #5133), and then executes the HR patch below ITSELF —
-   zero operator action, expected promotion ~2–4 min after the kill. The
-   controller-side Continuum orchestration cannot do this: it lives on region-a
-   and dies with it (#5137). Evidence lands as
-   `catalyst.openova.io/dr-auto-promoted-at` on the region-B HR + the
-   dr-promoter pod log. The manual command remains the fallback (and is exactly
-   what the actor runs). **Promote the replica by flipping the region-B
-   HelmRelease DESIRED state**, NOT the live Cluster CR:
+   the region-kill because it runs in the surviving region) detects loss via TWO
+   signals: the LOCAL replica's `pg_stat_wal_receiver` is ABSENT **AND** a direct
+   `pg_isready` of the region-A `-primary-mesh` endpoint over the ClusterMesh is
+   UNREACHABLE (the #5178 positive-liveness gate — a stalled local stream with
+   region-A still reachable is a replication fault, never a region kill, and does
+   NOT promote). It waits `autoPromote.primaryDownHoldSeconds` (120s, so an
+   intra-region primary restart never triggers), respects a `startupGraceSeconds`
+   window (a fresh catching-up replica can never trip it), confirms the
+   failover-readiness probe is Ready (LSN apply==receive, #5133), then executes
+   the promote + LATCH below ITSELF — zero operator action, expected promotion
+   ~2–4 min after the kill. The controller-side Continuum orchestration cannot do
+   this: it lives on region-a and dies with it (#5137). Evidence lands as
+   `catalyst.openova.io/dr-auto-promoted-at` + `…/dr-auto-promote-latched-at` on
+   the region-B HR + the dr-promoter pod log. The manual command remains the
+   fallback (and is exactly what the actor runs). **Promote the replica by
+   flipping the region-B HelmRelease DESIRED state, then SUSPEND the HR to latch
+   it** — NOT the live Cluster CR:
    ```bash
-   # DURABLE (#5125 Defect-1): patch the HR values so the failed-over state
-   # IS the desired state → flux drift-correction RE-AFFIRMS the promotion.
+   # STEP 1 — drive the failed-over DESIRED state (#5125 Defect-1):
    kubectl --kubeconfig <region-b> -n <ns> patch helmrelease bp-cnpg-pair \
      --type merge -p '{"spec":{"values":{"cnpgPair":{"replica":{"promoted":true}}}}}'
    # → chart re-renders the replica Cluster CR with replica.enabled:false → CNPG promotes it writable.
+   # STEP 2 — LATCH it durable (#5178 Defect-B): once replica.enabled:false has
+   # rendered, suspend the HR so flux can no longer revert it.
+   kubectl --kubeconfig <region-b> -n <ns> patch helmrelease bp-cnpg-pair \
+     --type merge -p '{"spec":{"suspend":true}}'
    ```
-   🛑 Do **NOT** `kubectl patch` `spec.replica.enabled=false` on the live Cluster CR:
-   a drift-enabled HelmRelease owns it, so helm-controller's "correct cluster drift"
-   REVERTS the patch mid-outage and silently re-demotes the survivor (hw256 G12,
-   T0+2m07s). Route the change through the HR value (or the Continuum sequencer
-   patching HR values) so the promotion survives reconcile. (The `Continuum` CR
-   orchestration path is the automated equivalent — PR #2072/#2074.)
+   🛑 The HR-value patch ALONE is NOT durable (hw266 G12, #5178): `spec.values` is
+   an ATOMIC RawExtension wholly owned by the flux Kustomization, so its next SSA
+   re-apply DROPS the nested `promoted` key and helm re-demotes the survivor →
+   promote/demote timeline-divergence flap (TL2→TL25). `spec.suspend` is a field
+   the Kustomization does NOT own, so it survives drift-correction and freezes
+   helm on the promoted release. (The actor sets both automatically; do STEP 2 by
+   hand only when `autoPromote.enabled=false`.)
+   🛑 Also do **NOT** `kubectl patch` `spec.replica.enabled=false` on the live
+   Cluster CR: a drift-enabled HelmRelease owns it, so helm-controller's "correct
+   cluster drift" REVERTS the patch mid-outage and silently re-demotes the
+   survivor (hw256 G12, T0+2m07s). (The `Continuum` CR orchestration path is the
+   automated equivalent — PR #2072/#2074.)
 4. Verify the write made it across — zero-tx-loss (RPO=0)
-5. Reverse: `scripts/region-kill-drill.sh recover --arm` os-starts region-a; then set
-   `replica.promoted:false` back on the region-B HR to resume replica mode once the
-   original primary is re-cloned onto the current timeline (#5125 Defect-2, still open —
-   CNPG replica walreceivers crash-loop `timeline N behind recovery timeline N+1` until
-   the stale side is deleted + re-basebackup'd).
+5. Reverse: `scripts/region-kill-drill.sh recover --arm` os-starts region-a; then
+   **un-suspend** the region-B HR (`{"spec":{"suspend":false}}`) and set
+   `replica.promoted:false` to resume replica mode once the original primary is
+   re-cloned onto the current timeline (#5125 Defect-2, still open — CNPG replica
+   walreceivers crash-loop `timeline N behind recovery timeline N+1` until the
+   stale side is deleted + re-basebackup'd).
 
 Test harness lives at the D31 acceptance test (PR #2075).
 

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -20,7 +20,12 @@ spec:
   # region-B HR desired state (replica.promoted=true, the #5125-D1 seam) so
   # CNPG promotes the survivor with ZERO operator action. sync-mode-only
   # (the remote_apply/dataDurability fence is the anti-split-brain arbiter).
-  version: 0.2.13
+  # 0.2.14 (#5178): dr-promoter regression fix — (A) a POSITIVE region-A
+  # liveness gate (pg_isready of `-primary-mesh` over the mesh) + startup grace
+  # so the actor no longer false-promotes a healthy replica against a live
+  # region-A, and (B) a durable SUSPEND latch + anti-flap divergence guard so a
+  # real promotion sticks instead of flapping the timeline away (hw266 G12).
+  version: 0.2.14
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.14 (#5178): dr-promoter regression fix — the 0.2.13 promoter FALSE-PROMOTED
+# a healthy replica against a LIVE region-A and its promotion was NON-DURABLE, so
+# on hw266 G12 it ran the region-B Postgres timeline away (TL2→TL25) and
+# permanently broke cross-region replication. Two fixes: (A) POSITIVE region-A
+# liveness gate — the signals container arms the promote clock ONLY when the LOCAL
+# WAL receiver is ABSENT (catchup/starting/waiting count as ALIVE) AND a direct
+# pg_isready of the `-primary-mesh` endpoint over the mesh is UNREACHABLE, plus a
+# startupGraceSeconds window; region-A reachable + local stall ⇒ replication
+# fault, DO NOT promote; no liveness path wired ⇒ observe-only (fail-safe). (B)
+# durable + latched promotion — after helm renders the promote the actor SUSPENDS
+# the HR (spec.suspend, a field flux's Kustomization does not own → survives
+# drift-correction), and it NEVER re-promotes an already-diverged cluster
+# (anti-flap). Adds one region-A egress rule to the dr-promoter-egress CNP (gated
+# on crossRegionPeerClusters). No resource-count change. Lockstep slot 16b → 0.2.14.
 # 0.2.13 (#5137): region-B AUTOMATIC DR promotion — the DR orchestration now
 # SURVIVES the loss of the primary region. hw261 G12 proved the Continuum
 # controller + dr CR are single-region (region-A; bp-continuum slot 62 and the
@@ -82,7 +96,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.13
+version: 0.2.14
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -122,6 +136,32 @@ description: |
 
   Changelog
   ─────────
+  0.2.14 (2026-07-17, dr-promoter regression fix — liveness gate + durable latch, Refs #5178)
+    - FIX Defect-A (false-positive promote): the 0.2.13 signals container
+      inferred "region-A dead" from the LOCAL walreceiver alone and promoted a
+      healthy replica against a live region-A (hw266 G12, 16s after a verified
+      healthy stream). The container now arms the promote clock ONLY when the
+      LOCAL WAL receiver row is ABSENT (a present-but-not-streaming receiver —
+      catchup/starting/waiting/restarting — counts as ALIVE) AND a DIRECT
+      pg_isready of the region-A `-primary-mesh` endpoint over the ClusterMesh
+      returns "no response" (rc=2). region-A reachable + local stall ⇒
+      replication fault, log + do NOT promote. New startupGraceSeconds (300s)
+      holds the clock clear while a fresh replica finishes its first catchup.
+      If no cross-region liveness path is wired (clusterMesh off or
+      crossRegionPeerClusters empty) the actor observes but NEVER promotes.
+    - FIX Defect-B (non-durable, non-latched promote): the HR-value patch was
+      reverted by flux (spec.values is an atomic RawExtension owned by the
+      Kustomization) → a promote/demote timeline-divergence flap (TL2→TL25). The
+      actor now LATCHES a rendered promotion durable by suspending the HR
+      (spec.suspend — a field the Kustomization does not own → survives
+      drift-correction, freezes helm on the promoted release), and it NEVER
+      re-promotes an already-diverged cluster (anti-flap /shared/diverged guard).
+    - NetworkPolicy: one region-A egress rule added to the dr-promoter-egress
+      CNP (identity-scoped by crossRegionPeerClusters, #4846 idiom) for the
+      liveness probe. Empty peer list → no rule (byte-identical, observe-only).
+    - No resource-count change (still 12 non-test on side=replica). Lockstep
+      slot 16b pin → 0.2.14; RUNBOOKS §6.1 promote command updated (adds the
+      suspend latch + un-suspend on recovery).
   0.2.13 (2026-07-17, region-B AUTOMATIC DR promotion — orchestration survives region-kill, Refs #5137)
     - NEW (Pillar-3 region-kill DR): side=replica now renders a
       `<fullname>-dr-promoter` Deployment — the region-B actor that makes

--- a/platform/cnpg-pair/chart/templates/dr-promoter.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-promoter.yaml
@@ -31,29 +31,58 @@ REVERTED by flux drift-correction at T0+2m07s, silently re-demoting
 the promoted survivor mid-outage. bp-cnpg-pair ≥0.2.12 drives
 `replica.enabled` from the `cnpgPair.replica.promoted` VALUE, so the
 promoter flips the region-B HelmRelease DESIRED state
-(`spec.values.cnpgPair.replica.promoted: true`) — drift-correction
-then RE-AFFIRMS the promotion. This is byte-identical to the
-RUNBOOKS §6.1 operator command; the operator-manual path keeps
-working (the actor no-ops when the value is already true).
+(`spec.values.cnpgPair.replica.promoted: true`) — helm-controller then
+renders `replica.enabled:false` and CNPG promotes. This is
+byte-identical to the RUNBOOKS §6.1 operator command; the
+operator-manual path keeps working (the actor no-ops when already
+promoted).
 
-Durability of the HR patch: the flux Kustomization's SSA re-apply of
-the bootstrap-kit slot 16b manifest does NOT remove the key — slot 16b
-never sets `replica.promoted`, so the promoter's field-manager keeps
-ownership of a field git never claims.
+DURABILITY — the SUSPEND latch (#5178 Defect-B)
+-----------------------------------------------
+The 0.2.13 header CLAIMED the HR-value patch was durable ("field-manager
+keeps ownership of a field git never claims"). hw266 G12 DISPROVED it:
+`spec.values` on a HelmRelease is an ATOMIC RawExtension, wholly owned by
+the flux Kustomization (kustomize-controller) that applies slot 16b. Its
+next SSA re-apply reclaims `spec.values` and DROPS the promoter's nested
+`promoted` key → helm re-renders `replica.enabled:true` → CNPG re-demotes.
+The demoted survivor then fails to re-stream (its timeline has advanced),
+the promoter sees "receiver down" again and re-promotes → the timeline
+runs away (hw266: TL2→TL25), permanently breaking replication.
 
-HOW IT DECIDES (two independent signals, both region-B-local)
--------------------------------------------------------------
+So the actor makes the promotion durable by SUSPENDING the HR
+(`spec.suspend: true`) once helm has rendered the promotion. `spec.suspend`
+is NOT in slot 16b's manifest, so kustomize-controller does not own it and
+its drift-correction cannot remove it; a suspended HR freezes helm-
+controller, so even after kustomize reverts the atomic `spec.values` the
+promoted release is NOT re-rendered and the survivor stays writable. The
+operator un-suspends after re-cloning the stale side (RUNBOOKS §6.1).
+
+HOW IT DECIDES (region-B-local signals + a POSITIVE region-A probe)
+-------------------------------------------------------------------
 1. PRIMARY LOSS — `signals` container (postgres image, the same
-   streaming_replica client-cert auth as failover-readiness #5133)
-   polls the LOCAL replica's `-rw`: while in recovery, an EMPTY /
-   non-streaming `pg_stat_wal_receiver` means the WAL stream from
-   region-A is dead. The condition must hold CONTINUOUSLY for
-   `autoPromote.primaryDownHoldSeconds` (default 120s) so an
-   intra-region primary restart / instance switchover (receiver
-   reconnects in seconds) never triggers a cross-region promotion.
+   streaming_replica client-cert auth as failover-readiness #5133).
+   #5178 Defect-A: a stalled LOCAL `pg_stat_wal_receiver` is NOT proof
+   region-A died — a healthy replica is legitimately non-`streaming` for
+   long stretches during catchup / receiver `starting`/`waiting`/restart /
+   a cross-region blip. So the container arms the promote clock ONLY when
+   BOTH hold: (a) the LOCAL WAL receiver is ABSENT (no row at all — the
+   `catchup`/`starting`/`waiting` alive states do NOT count as down), AND
+   (b) a DIRECT pg_isready of the region-A primary over the ClusterMesh
+   (`-primary-mesh`:5432 — the exact endpoint the replica streams from)
+   returns "no response". region-A REACHABLE + local stream stalled ⇒
+   replication fault ⇒ log + DO NOT promote. A STARTUP GRACE
+   (`startupGraceSeconds`) additionally holds the clock clear while a
+   fresh replica finishes its first catchup. The clock must then hold
+   CONTINUOUSLY for `autoPromote.primaryDownHoldSeconds` (120s).
+   FAIL-SAFE: if no cross-region liveness path is wired (clusterMesh off
+   or crossRegionPeerClusters empty) the actor observes but NEVER
+   promotes — there is no way to positively prove region-A is gone.
 2. PROMOTABILITY — the failover-readiness Pod's Ready condition
    (the #5133 LSN apply==receive signal): the standby has APPLIED
    everything it RECEIVED.
+3. ANTI-FLAP — the actor never re-promotes a cluster that has ALREADY
+   diverged (left the source timeline), and once promoted it latches
+   (suspend) so it can neither re-demote nor re-promote (#5178).
 
 ANTI-SPLIT-BRAIN — why acting on a region-local signal is data-safe
 -------------------------------------------------------------------
@@ -91,6 +120,15 @@ tracked on #5137.)
 {{- $kpull := $kimg.pullPolicy | default "IfNotPresent" }}
 {{- $interval := $ap.intervalSeconds | default 10 }}
 {{- $hold := $ap.primaryDownHoldSeconds | default 120 }}
+{{- $startupGrace := $ap.startupGraceSeconds | default 300 }}
+{{- $probeTimeout := $ap.livenessProbeTimeoutSeconds | default 5 }}
+{{- $peerClusters := .Values.cnpgPair.networkPolicy.crossRegionPeerClusters | default list }}
+{{- /* #5178 — the region-A liveness gate is meaningful ONLY when the mesh
+       egress to region-A can actually be wired: clusterMesh on AND at least
+       one peer ClusterMesh name. Without it the actor observes but NEVER
+       promotes (fail-safe), because it has no way to POSITIVELY prove
+       region-A is gone. */ -}}
+{{- $livenessEnabled := and .Values.cnpgPair.clusterMesh.enabled (gt (len $peerClusters) 0) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -135,9 +173,10 @@ subjects:
     name: {{ include "cnpg-pair.fullname" . }}-dr-promoter
     namespace: {{ .Release.Namespace }}
 ---
-# The promotion surface: get (idempotence read) + patch (merge-patch of
-# spec.values.cnpgPair.replica.promoted) on EXACTLY the bp-cnpg-pair
-# HelmRelease — resourceNames-pinned, no list/create/delete.
+# The promotion surface: get (idempotence + suspend-state read) + patch
+# (merge-patch of spec.values.cnpgPair.replica.promoted AND, for the #5178
+# durable latch, spec.suspend) on EXACTLY the bp-cnpg-pair HelmRelease —
+# resourceNames-pinned, no list/create/delete.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -175,7 +214,9 @@ subjects:
 # `kube-apiserver` identity, which is neither a pod nor `world`), so the
 # whole egress allow-list lives in ONE CiliumNetworkPolicy: apiserver
 # (kubectl) + kube-dns (service-name resolution) + the replica cluster's
-# 5432 (the signals psql). Everything else stays denied.
+# 5432 (the signals psql) + (#5178) the region-A primary's 5432 across the
+# ClusterMesh (the signals pg_isready liveness probe). Everything else
+# stays denied.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -208,6 +249,32 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
+{{- if $livenessEnabled }}
+    # #5178 region-A liveness probe path — the signals container pg_isready's
+    # the region-A primary over the mesh (the SAME `-primary-mesh`:5432 the
+    # replica streams from) to POSITIVELY confirm region-A is gone before
+    # arming the promote clock. Cross-region ClusterMesh endpoints carry
+    # their OWN pod identity; a plain local `toEndpoints` is implicitly ANDed
+    # with the LOCAL cluster (Cilium `io.cilium.k8s.policy.cluster=<local>`)
+    # and never matches the remote primary (#4846), so admit the peer
+    # cluster(s) by identity. EMPTY crossRegionPeerClusters (or clusterMesh
+    # off) → this rule is absent AND $livenessEnabled=false → the actor
+    # fail-safes to observe-only (never promotes).
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "cnpg-pair.primaryName" . }}
+          matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -256,16 +323,18 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-        # ── signals — PRIMARY-LOSS detector ──────────────────────────
+        # ── signals — PRIMARY-LOSS detector (#5178 liveness-gated) ────
         # psql (streaming_replica client cert, the #5133 auth pattern)
-        # against the LOCAL replica `-rw`. While the replica is in
-        # recovery, a non-streaming pg_stat_wal_receiver == the WAL
-        # stream from region-A is dead; the hold clock (file mtime-free,
-        # epoch-in-file) starts on the streaming→down transition and is
-        # CLEARED the moment streaming resumes, the replica leaves
-        # recovery (already promoted), or psql itself fails (fail-safe:
-        # an unhealthy local replica must never look like a dead
-        # primary).
+        # against the LOCAL replica `-rw` for pg_stat_wal_receiver state,
+        # PLUS a POSITIVE region-A liveness probe (pg_isready of the
+        # `-primary-mesh` endpoint over the ClusterMesh). The promote
+        # clock (epoch-in-file) is armed ONLY when the LOCAL WAL receiver
+        # is ABSENT (`catchup`/`starting`/`waiting`/streaming all count as
+        # ALIVE) AND region-A is genuinely UNREACHABLE, and never during
+        # the startup grace. It is CLEARED the moment the receiver returns,
+        # region-A answers, the replica leaves recovery (already promoted),
+        # psql itself fails (fail-safe: an unhealthy local replica must
+        # never look like a dead primary), or no liveness path is wired.
         - name: signals
           image: {{ include "cnpg-pair.imageRef" . | quote }}
           imagePullPolicy: {{ .Values.cnpgPair.image.pullPolicy | quote }}
@@ -274,34 +343,89 @@ spec:
             - |
               set -eu
               CONN="host={{ include "cnpg-pair.replicaName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              # 'promoted'   — NOT in recovery: the local cluster is writable
+              #                (already promoted / diverged off the source TL).
+              # 'streaming'  — WAL receiver actively streaming.
+              # 'receiving'  — a WAL receiver row EXISTS but is not (yet)
+              #                streaming (starting/waiting/restarting/catchup)
+              #                — region-A is delivering WAL, ALIVE, not dead.
+              # 'noreceiver' — no WAL receiver row at all → POTENTIAL loss.
               Q="SELECT CASE
                 WHEN NOT pg_is_in_recovery() THEN 'promoted'
                 WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver WHERE status = 'streaming') THEN 'streaming'
-                ELSE 'down'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'
+                ELSE 'noreceiver'
               END"
-              echo "[dr-promoter/signals] loop started (interval={{ $interval }}s)"
+              STARTED=$(date -u +%s)
+              echo "[dr-promoter/signals] loop started (interval=${INTERVAL_SECONDS}s startupGrace=${STARTUP_GRACE_SECONDS}s primaryLiveness=${PRIMARY_LIVENESS_ENABLED} primaryMeshHost=${PRIMARY_MESH_HOST})"
+              clear_clock() {
+                if [ -f /shared/primary-wal-down-since ]; then
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/signals] $1 — hold clock cleared"
+                fi
+                rm -f /shared/primary-wal-down-since
+              }
               while true; do
                 : > /shared/signals-alive
                 STATE=$(psql "${CONN}" -tAXc "${Q}" 2>/dev/null || echo "unknown")
+                NOW=$(date -u +%s)
+                # STARTUP GRACE — a fresh replica still doing its first
+                # catchup must never arm the clock (#5178).
+                if [ "$((NOW - STARTED))" -lt "${STARTUP_GRACE_SECONDS}" ]; then
+                  clear_clock "startup grace ($((NOW - STARTED))s<${STARTUP_GRACE_SECONDS}s, state=${STATE})"
+                  sleep "${INTERVAL_SECONDS}"; continue
+                fi
                 case "${STATE}" in
-                  down)
-                    if [ ! -f /shared/primary-wal-down-since ]; then
-                      date -u +%s > /shared/primary-wal-down-since
-                      echo "$(date -u +"%FT%TZ") [dr-promoter/signals] WAL receiver DOWN — primary stream dead; hold clock started"
-                    fi
+                  promoted)
+                    # Left recovery → already promoted/diverged. Mark it so
+                    # the actor never re-promotes (anti-flap #5178).
+                    : > /shared/diverged
+                    clear_clock "state=promoted (local cluster writable)"
                     ;;
-                  *)
-                    if [ -f /shared/primary-wal-down-since ]; then
-                      echo "$(date -u +"%FT%TZ") [dr-promoter/signals] state=${STATE} — hold clock cleared"
+                  streaming|receiving)
+                    clear_clock "state=${STATE} (WAL receiver alive)"
+                    ;;
+                  unknown)
+                    clear_clock "state=unknown (local replica probe failed — fail-safe)"
+                    ;;
+                  noreceiver)
+                    # LOCAL WAL stream absent — the 0.2.13 bug promoted here on
+                    # the LOCAL signal alone (hw266). #5178: require a POSITIVE
+                    # region-A-unreachable proof first.
+                    if [ "${PRIMARY_LIVENESS_ENABLED}" != "true" ]; then
+                      clear_clock "state=noreceiver but NO region-A liveness path (clusterMesh off / crossRegionPeerClusters empty) — auto-promote inert, fail-safe"
+                    elif pg_isready -h "${PRIMARY_MESH_HOST}" -p 5432 -t "${PROBE_TIMEOUT}" -q; then
+                      clear_clock "state=noreceiver but region-A REACHABLE (pg_isready ok @ ${PRIMARY_MESH_HOST}) — replication fault, NOT a region kill; holding (data safety)"
+                    else
+                      RC=$?
+                      if [ "${RC}" -eq 2 ]; then
+                        if [ ! -f /shared/primary-wal-down-since ]; then
+                          echo "${NOW}" > /shared/primary-wal-down-since
+                          echo "$(date -u +"%FT%TZ") [dr-promoter/signals] WAL receiver ABSENT and region-A UNREACHABLE (pg_isready rc=2 @ ${PRIMARY_MESH_HOST}) — primary loss; hold clock started"
+                        fi
+                      else
+                        clear_clock "state=noreceiver, region-A probe ambiguous (pg_isready rc=${RC}) — fail-safe, NOT arming"
+                      fi
                     fi
-                    rm -f /shared/primary-wal-down-since
                     ;;
                 esac
-                sleep {{ $interval }}
+                sleep "${INTERVAL_SECONDS}"
               done
           env:
             - name: PGCONNECT_TIMEOUT
               value: "5"
+            # #5178 region-A liveness probe target — the SAME ClusterMesh
+            # `-primary-mesh` endpoint the replica streams from (templated
+            # from the replicationServiceName helper, never hardcoded).
+            - name: PRIMARY_MESH_HOST
+              value: {{ include "cnpg-pair.replicationServiceName" . | quote }}
+            - name: PRIMARY_LIVENESS_ENABLED
+              value: {{ if $livenessEnabled }}"true"{{ else }}"false"{{ end }}
+            - name: PROBE_TIMEOUT
+              value: {{ $probeTimeout | quote }}
+            - name: STARTUP_GRACE_SECONDS
+              value: {{ $startupGrace | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
           livenessProbe:
             exec:
               command:
@@ -340,14 +464,23 @@ spec:
             - name: replication-cert
               mountPath: /tls/client
               readOnly: true
-        # ── actor — the PROMOTER ─────────────────────────────────────
+        # ── actor — the PROMOTER + durable LATCH (#5178 Defect-B) ────
         # Each tick runs in a subshell (a persistent fault retries next
-        # tick instead of crashing the pod — #5157 shape). Gates, in
-        # order: hold expired → HR not already promoted (idempotence +
-        # operator-manual compatibility) → local Cluster CR still a
-        # replica → failover-readiness Ready (promotable, #5133). Then
-        # ONE merge-patch of the HR desired state — the exact RUNBOOKS
-        # §6.1 command — plus audit annotations.
+        # tick instead of crashing the pod — #5157 shape). Ordering:
+        #   1. LATCH — if we drove a promotion (HR promoted=true) that has
+        #      RENDERED (local Cluster replica.enabled=false) but the HR is
+        #      not yet suspended, set spec.suspend=true. This makes the
+        #      promotion durable: kustomize-controller does NOT own
+        #      spec.suspend, and a suspended HR freezes helm so the reverted
+        #      atomic spec.values can no longer re-demote the survivor. Runs
+        #      independent of the hold clock (which signals clears the moment
+        #      the cluster leaves recovery).
+        #   2. ANTI-FLAP — already suspended (latched) OR promote in flight
+        #      ⇒ never touch again.
+        #   3. PROMOTE — hold expired → NOT already diverged → local Cluster
+        #      still a replica → failover-readiness Ready (#5133). Then ONE
+        #      merge-patch of the HR desired state (the RUNBOOKS §6.1 seam);
+        #      the LATCH fires on the next tick once helm renders it.
         - name: actor
           image: {{ printf "%s:%s" $krepo $ktag | quote }}
           imagePullPolicy: {{ $kpull | quote }}
@@ -359,19 +492,39 @@ spec:
                 : > /shared/actor-alive
                 (
                   set -eu
+                  SUSPENDED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
+                  HR_PROMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.cnpgPair.replica.promoted}' 2>/dev/null || echo "")
+                  REPLICA_ENABLED=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}' 2>/dev/null || echo "")
+
+                  # 1. LATCH — make an already-rendered promotion durable.
+                  if [ "${SUSPENDED}" != "true" ] && [ "${HR_PROMOTED}" = "true" ] && [ "${REPLICA_ENABLED}" = "false" ]; then
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-latched-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":true}}"
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] LATCHED: HR ${HR_NAMESPACE}/${HR_NAME} spec.suspend=true — promotion durable; flux drift-correction can no longer revert spec.values and re-demote the survivor (#5178 Defect-B)"
+                    exit 0
+                  fi
+                  # 2. ANTI-FLAP — latched, or a promote is mid-render.
+                  if [ "${SUSPENDED}" = "true" ]; then
+                    exit 0
+                  fi
+                  if [ "${HR_PROMOTED}" = "true" ]; then
+                    exit 0
+                  fi
+
+                  # 3. PROMOTE decision (not promoted, not suspended).
                   [ -f /shared/primary-wal-down-since ] || exit 0
                   DOWN_SINCE=$(cat /shared/primary-wal-down-since)
                   NOW=$(date -u +%s)
                   DOWN_FOR=$((NOW - DOWN_SINCE))
                   if [ "${DOWN_FOR}" -lt "${HOLD_SECONDS}" ]; then
-                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] primary WAL stream down ${DOWN_FOR}s < hold ${HOLD_SECONDS}s — waiting"
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] region-A unreachable ${DOWN_FOR}s < hold ${HOLD_SECONDS}s — waiting"
                     exit 0
                   fi
-                  PROMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.cnpgPair.replica.promoted}')
-                  if [ "${PROMOTED}" = "true" ]; then
+                  # ANTI-FLAP: never re-promote a cluster that already left the
+                  # source timeline — that IS the runaway (hw266 TL2→TL25).
+                  if [ -f /shared/diverged ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] REFUSING promote: local cluster already diverged (left the source timeline) — re-clone required, NOT re-promote (RUNBOOKS §6.1 / #5178 anti-flap)"
                     exit 0
                   fi
-                  REPLICA_ENABLED=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}')
                   if [ "${REPLICA_ENABLED}" != "true" ]; then
                     echo "$(date -u +"%FT%TZ") [dr-promoter/actor] local Cluster CR replica.enabled=${REPLICA_ENABLED} — not a replica; nothing to promote"
                     exit 0
@@ -381,9 +534,9 @@ spec:
                     echo "$(date -u +"%FT%TZ") [dr-promoter/actor] failover-readiness NOT Ready (got: '${READY}') — standby not promotable; holding (data safety over RTO)"
                     exit 0
                   fi
-                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTING: WAL stream down ${DOWN_FOR}s >= ${HOLD_SECONDS}s AND failover-readiness Ready — patching HR desired state (#5125-D1 seam)"
-                  kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-auto-promote-reason\":\"primary WAL stream down ${DOWN_FOR}s; failover-readiness Ready (#5137)\"}},\"spec\":{\"values\":{\"cnpgPair\":{\"replica\":{\"promoted\":true}}}}}"
-                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTED: HR ${HR_NAMESPACE}/${HR_NAME} spec.values.cnpgPair.replica.promoted=true — helm-controller renders replica.enabled:false → CNPG promotes the survivor writable"
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTING: region-A WAL stream absent AND region-A unreachable ${DOWN_FOR}s >= ${HOLD_SECONDS}s AND failover-readiness Ready — patching HR desired state (#5125-D1 seam)"
+                  kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-auto-promote-reason\":\"region-A WAL stream absent and region-A unreachable ${DOWN_FOR}s; failover-readiness Ready (#5137/#5178)\"}},\"spec\":{\"values\":{\"cnpgPair\":{\"replica\":{\"promoted\":true}}}}}"
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTED (step 1/2): HR ${HR_NAMESPACE}/${HR_NAME} spec.values.cnpgPair.replica.promoted=true — helm-controller renders replica.enabled:false → CNPG promotes; the suspend LATCH fires next tick once it renders (#5178)"
                 ) || echo "[dr-promoter/actor] tick returned non-zero — retry in ${INTERVAL_SECONDS}s"
                 sleep "${INTERVAL_SECONDS}"
               done

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -776,4 +776,90 @@ if grep -q 'dr-promoter' "$TMP/asyncpromoter.yaml"; then
   echo "FAIL: #5137 replication.mode=async must render ZERO dr-promoter resources (no sync-rep data fence → automatic promotion is not split-brain-safe)." >&2; exit 1; fi
 echo "  PASS (replica-only actor, Recreate Deployment, HR-desired-state patch, resourceNames-pinned RBAC, sync-only)"
 
+# ── Case 16: #5178 dr-promoter regression fix — liveness gate + durable latch ─
+# hw266 G12: the 0.2.13 promoter false-promoted a HEALTHY replica against a LIVE
+# region-A (inferred "primary dead" from the LOCAL walreceiver alone) and the
+# HR-value promote was non-durable, so a promote/demote flap ran the region-B
+# timeline away (TL2→TL25). 0.2.14 adds (A) a POSITIVE region-A liveness gate +
+# startup grace, and (B) a durable suspend latch + anti-flap divergence guard.
+echo "[render] Case 16: #5178 region-A liveness gate + startup grace + durable suspend latch + anti-flap"
+
+# (a) FAIL-SAFE default (Case 3 render, no crossRegionPeerClusters): the promoter
+#     still renders, but the liveness gate is OFF (observe-only) and NO region-A
+#     egress rule is emitted — a promoter with no way to POSITIVELY prove
+#     region-A is gone must never promote.
+grep -q 'name: PRIMARY_LIVENESS_ENABLED' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 signals container missing the PRIMARY_LIVENESS_ENABLED env." >&2; exit 1; }
+python3 - "$TMP/replica.yaml" <<'PYEOF' || { echo "FAIL: #5178 fail-safe default assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-promoter' in d['metadata']['name']][0]
+sig=[c for c in dep['spec']['template']['spec']['containers'] if c['name']=='signals'][0]
+env={e['name']:e.get('value') for e in sig['env']}
+assert env.get('PRIMARY_LIVENESS_ENABLED')=='false', f"liveness must be OFF (fail-safe) without a peer, got {env.get('PRIMARY_LIVENESS_ENABLED')!r}"
+cnp=[d for d in docs if d.get('kind')=='CiliumNetworkPolicy' and 'dr-promoter-egress' in d['metadata']['name']][0]
+prim=[r for r in cnp['spec']['egress'] for s in r.get('toEndpoints',[]) if '-primary' in s.get('matchLabels',{}).get('cnpg.io/cluster','')]
+assert not prim, "region-A egress rule must be ABSENT without crossRegionPeerClusters (fail-safe)"
+PYEOF
+
+# region-A liveness probe (pg_isready of the -primary-mesh endpoint — the SAME
+# source the replica streams from, templated not hardcoded).
+grep -q 'pg_isready -h "${PRIMARY_MESH_HOST}"' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 signals container missing the pg_isready region-A liveness probe." >&2; exit 1; }
+grep -qE 'value: "[a-z0-9-]+-primary-mesh"' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 PRIMARY_MESH_HOST must be the -primary-mesh endpoint (region-A stream source), not hardcoded." >&2; exit 1; }
+# region-A REACHABLE + local stall ⇒ replication fault, NOT a promote.
+grep -q 'replication fault, NOT a region kill' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 signals must treat region-A-reachable + local WAL stall as a replication fault (no promote)." >&2; exit 1; }
+# A present-but-not-streaming receiver (catchup/starting/waiting) counts as ALIVE.
+grep -qF "WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'" "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 signals must treat a present (non-streaming) WAL receiver as ALIVE, not down." >&2; exit 1; }
+
+# (b) startup grace — a fresh, still-catching-up replica can never trip the clock.
+grep -q 'name: STARTUP_GRACE_SECONDS' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 missing the STARTUP_GRACE_SECONDS env." >&2; exit 1; }
+grep -q 'startup grace' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 signals missing the startup-grace clock-clear." >&2; exit 1; }
+
+# (c) durable latch + anti-flap: the actor suspends the HR to latch the promote,
+#     and never re-promotes an already-diverged cluster.
+grep -qF '\"spec\":{\"suspend\":true}' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 actor missing the durable suspend LATCH (spec.suspend=true) — the HR-value patch alone is reverted by flux." >&2; exit 1; }
+grep -q '/shared/diverged' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 missing the anti-flap divergence marker (/shared/diverged)." >&2; exit 1; }
+grep -q 'REFUSING promote' "$TMP/replica.yaml" || {
+  echo "FAIL: #5178 actor must REFUSE to re-promote an already-diverged cluster (anti-flap latch)." >&2; exit 1; }
+
+# (d) crossRegionPeerClusters wired ⇒ liveness ON + a region-A egress RULE inside
+#     the existing dr-promoter-egress CNP (not a new CNP — count stays 2).
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={hw228-mesh}' \
+  > "$TMP/replica-peer.yaml" 2> "$TMP/replica-peer.err" || {
+  echo "FAIL: #5178 crossRegionPeerClusters replica render errored:" >&2; cat "$TMP/replica-peer.err" >&2; exit 1; }
+python3 - "$TMP/replica-peer.yaml" <<'PYEOF' || { echo "FAIL: #5178 liveness-ON assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-promoter' in d['metadata']['name']][0]
+sig=[c for c in dep['spec']['template']['spec']['containers'] if c['name']=='signals'][0]
+env={e['name']:e.get('value') for e in sig['env']}
+assert env.get('PRIMARY_LIVENESS_ENABLED')=='true', f"liveness must be ON with a peer, got {env.get('PRIMARY_LIVENESS_ENABLED')!r}"
+cnp=[d for d in docs if d.get('kind')=='CiliumNetworkPolicy' and 'dr-promoter-egress' in d['metadata']['name']][0]
+ok=False
+for r in cnp['spec']['egress']:
+    for s in r.get('toEndpoints',[]):
+        lbl='-primary' in s.get('matchLabels',{}).get('cnpg.io/cluster','')
+        idn=any(m.get('key')=='io.cilium.k8s.policy.cluster' and 'hw228-mesh' in (m.get('values') or []) for m in s.get('matchExpressions',[]))
+        ok=ok or (lbl and idn)
+assert ok, "region-A egress rule (primary cluster + io.cilium.k8s.policy.cluster In [peer]) must render when crossRegionPeerClusters set"
+PYEOF
+if [ "$(grep -cE '^kind: CiliumNetworkPolicy' "$TMP/replica-peer.yaml")" -ne 2 ]; then
+  echo "FAIL: #5178 region-A egress must be a RULE inside dr-promoter-egress, not a new CiliumNetworkPolicy (expected 2 CNPs on the replica side)." >&2
+  grep -nE '^kind: CiliumNetworkPolicy' "$TMP/replica-peer.yaml" >&2; exit 1; fi
+echo "  PASS (fail-safe observe-only without a peer; liveness gate + startup grace + suspend latch + anti-flap with a peer)"
+
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -107,17 +107,28 @@ cnpgPair:
     #   (Deployment NOT CronJob, #5157: a CronJob's scheduler dies
     #   with the region) with two containers:
     #     signals — psql (streaming_replica cert, #5133 auth) against
-    #       the LOCAL replica -rw: non-streaming pg_stat_wal_receiver
-    #       while in recovery == the primary's WAL stream is dead.
-    #     actor  — when the stream has been dead CONTINUOUSLY for
+    #       the LOCAL replica -rw for pg_stat_wal_receiver state, PLUS
+    #       (#5178) a POSITIVE region-A liveness probe: a direct
+    #       pg_isready of the `-primary-mesh` endpoint over the
+    #       ClusterMesh (the SAME source the replica streams from). It
+    #       arms the promote clock ONLY when the local WAL stream is
+    #       absent AND region-A is genuinely unreachable — a local
+    #       stream stall with region-A still reachable is a REPLICATION
+    #       fault, never a region kill, so it does NOT promote.
+    #     actor  — when the region-A-loss clock has held for
     #       primaryDownHoldSeconds AND the failover-readiness probe is
     #       Ready (LSN apply==receive, promotable) AND the local
     #       Cluster CR is still a replica AND the HR value is not
-    #       already promoted, it merge-patches the region-B
+    #       already promoted AND the cluster has NOT already diverged, it
+    #       merge-patches the region-B
     #       HelmRelease DESIRED state
     #       (spec.values.cnpgPair.replica.promoted: true — the exact
     #       RUNBOOKS §6.1 command / #5125-D1 seam). Flux then renders
-    #       replica.enabled:false and CNPG promotes the survivor.
+    #       replica.enabled:false and CNPG promotes the survivor. The
+    #       actor then LATCHES the promotion durable by suspending the HR
+    #       (#5178 Defect-B — spec.suspend is a field flux's Kustomization
+    #       does NOT own, so drift-correction can no longer revert the
+    #       promoted release and flap the timeline away).
     # DATA SAFETY: only rendered when replication.mode=sync — with
     # remote_apply + FIRST 1 pinned to the cross-region replica +
     # dataDurability:required, the old primary cannot COMMIT while its
@@ -125,17 +136,39 @@ cnpgPair:
     # can never lose or fork committed data (RPO=0), partition or
     # kill alike. The operator-manual HR patch keeps working; the
     # actor no-ops when the value is already true.
+    #
+    # #5178 REGRESSION FIX (hw266 G12): the 0.2.13 promoter inferred
+    # "region-A dead" from the LOCAL WAL receiver alone and false-promoted
+    # a healthy replica against a live region-A, and the HR-value promote
+    # was reverted by flux → a promote/demote TIMELINE-DIVERGENCE flap
+    # (TL2→TL25). 0.2.14 adds (A) the positive region-A liveness gate +
+    # startupGraceSeconds + treating catchup/starting/waiting receiver
+    # states as alive, and (B) the durable suspend latch + anti-flap
+    # divergence guard.
     autoPromote:
       enabled: true
       # Poll cadence for both containers.
       intervalSeconds: 10
-      # The WAL stream must be down CONTINUOUSLY this long before the
-      # actor promotes. An intra-region primary restart / instance
-      # switchover reconnects the receiver in seconds and clears the
-      # hold clock — 120s keeps those events from triggering a
-      # cross-region promotion while still auto-recovering a real
-      # region kill in ~2-4 min end-to-end.
+      # The region-A-loss clock (local WAL stream absent AND region-A
+      # unreachable) must hold CONTINUOUSLY this long before the actor
+      # promotes. An intra-region primary restart / instance switchover
+      # reconnects the receiver in seconds and clears the clock — 120s
+      # keeps those events from triggering a cross-region promotion while
+      # still auto-recovering a real region kill in ~2-4 min end-to-end.
       primaryDownHoldSeconds: 120
+      # #5178 startup grace — a freshly-(re)started replica still
+      # completing its first catchup (walreceiver absent/`starting`) must
+      # NEVER trip the promote clock. For the whole grace window from
+      # signals-container start the clock is held clear regardless of
+      # receiver state. Must exceed a normal basebackup+catchup; 300s is
+      # conservative for the C-DB-3 100Gi seed.
+      startupGraceSeconds: 300
+      # #5178 region-A liveness probe timeout (seconds) — the pg_isready
+      # of the `-primary-mesh` endpoint. Kept short so a genuine region
+      # kill is detected within the poll cadence; only a rc=2 (no
+      # response) counts as unreachable, every other result fail-safes to
+      # "region-A alive" (do NOT promote).
+      livenessProbeTimeoutSeconds: 5
       # The flux HelmRelease whose DESIRED state carries the promotion
       # (bootstrap-kit slot 16b defaults).
       hr:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.13"
+    version: "0.2.14"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## What & why

The #5137 region-B `dr-promoter` (0.2.13, PR #5171) **false-promoted a healthy replica against a live region-A** and its promotion was **not durable**, producing a promote/demote flap that ran region-B's Postgres timeline away (TL2→TL25) on hw266 G12 and **permanently broke cross-region replication** — the Pillar-3 region-kill G12 proof could not run. This is data-safety-critical DR code; the fix is conservative and preserves the side=replica + `replication.mode=sync` gating and the sync-rep anti-split-brain fence.

Full root-cause + live evidence: `docs/sessions/2026-07-17/hw266-region-kill-G12/RESULT.md` and Refs #5178.

## Fix A — positive region-A liveness gate (false-positive trigger)

The `signals` container inferred "region-A dead" purely from the LOCAL replica's `pg_stat_wal_receiver` not being `streaming` — a healthy replica is legitimately non-streaming for long stretches (catchup, receiver `starting`/`waiting`/restart, a cross-region blip), so any sustained local stall promoted even with region-A alive.

Now the promote clock arms **only** when BOTH hold:
- the local WAL receiver row is **ABSENT** (a present-but-not-streaming receiver — `catchup`/`starting`/`waiting`/`restarting` — now counts as **ALIVE**), AND
- a **direct `pg_isready`** of the region-A `-primary-mesh` endpoint over the ClusterMesh (the exact source the replica streams from — discovered from the same `replicationServiceName` helper the replica Cluster's `externalClusters` host uses, never hardcoded) returns **no response (rc=2)**.

region-A **reachable** + local stall ⇒ replication fault: log and **do not promote**. A `startupGraceSeconds` window holds the clock clear while a fresh replica finishes its first catchup. **Fail-safe**: when no cross-region liveness path is wired (`clusterMesh` off or `crossRegionPeerClusters` empty) the actor observes but **never promotes** — there is no way to positively prove region-A is gone. One identity-scoped region-A egress rule is added to the `dr-promoter-egress` CiliumNetworkPolicy (the #4846 `io.cilium.k8s.policy.cluster` idiom; empty peer list ⇒ no rule, byte-identical).

## Fix B — durable + latched promotion (non-durable / timeline flap)

The actor patched the HR `spec.values.cnpgPair.replica.promoted=true`, but `spec.values` is an **atomic RawExtension** wholly owned by the flux Kustomization — its next SSA re-apply drops the nested key and helm re-demotes the survivor, and the re-demoted cluster (timeline advanced) can't re-stream, so the promoter re-promotes → the timeline runs away.

The actor now, once helm has **rendered** the promotion (local Cluster `replica.enabled:false`), **LATCHES it durable by suspending the HR** (`spec.suspend: true`). `spec.suspend` is **not** in the slot-16b manifest, so kustomize-controller does not own it and drift-correction cannot revert it; a suspended HR freezes helm, so even after the atomic `spec.values` reverts, the promoted release is not re-rendered and the survivor stays writable. The actor also **never re-promotes an already-diverged cluster** (an anti-flap `/shared/diverged` guard set the moment the local cluster leaves recovery). The operator-manual path stays compatible (idempotent when already promoted/suspended); RUNBOOKS §6.1 is updated with the suspend latch (STEP 2) and the un-suspend-on-recovery step.

## Gates
- `helm template` both modes: side=primary renders **zero** promoter; side=replica+sync renders it — no errors. `helm lint` clean.
- Render tests extended (`tests/cnpg-pair-render.sh` **Case 16**): (a) region-A-reachable ⇒ no-promote + fail-safe observe-only default, (b) startup-grace, (c) latch-once-promoted + anti-flap on a diverged timeline, plus the liveness-ON + region-A egress rule with a peer wired. All 16 cases green.
- Lockstep bump 0.2.13 → **0.2.14**: `Chart.yaml` (+ changelog), `blueprint.yaml`, slot `16b-bp-cnpg-pair.yaml` pin, catalog-seed `spec.version`. `bash scripts/check-bootstrap-kit-pin-sync.sh` → **PASS**.
- Generated `signals` + `actor` shell scripts pass `sh -n` and `dash -n`.

## Note
Validates on the **next** fresh 2-region prov — this does **not** repair hw266 in place (region-b is orphaned on an advanced timeline and gets re-cloned on the next prov). **Do not merge** ahead of the live prov cadence; leave for review.

Refs #5178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
