### PR TITLE
fix(cutover): step-04 registry-pivot verifies curl+jq and fails loud (#5191)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -897,7 +897,7 @@ spec:
       # (prewarm.proxyBackoffBaseSeconds=30, doubling). FATAL-on-any-failure, the
       # #5030 dest-check skip, the #4975 pre-pass + multi-arch handling all
       # preserved. Contract Case 60.
-      version: 0.1.136
+      version: 0.1.137
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.136
+  version: 0.1.137
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2202,7 +2202,20 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.136
+#
+# 0.1.137 — #5191 (2026-07-18): step-04 registry-pivot toolchain (curl+jq) is
+# no longer acquired via a silent `apk add ... || true`. It now retries apk 6×
+# with backoff, then VERIFIES `command -v jq && command -v curl`, and if either
+# is still absent EXITS 1 (fail-loud → visible CrashLoopBackOff that self-heals
+# when apk succeeds) instead of silently proceeding tool-less. Root cause: on
+# hw268 two rebooted nodes lost the apk toolchain with no egress to reinstall;
+# `|| true` let the pivot run jq-less, every per-node `registriesYaml=v2` ack
+# failed silently, the step-04 daemonset-wait never reached N/N, and the WHOLE
+# cutover wedged at 27% with failedStep="" (no signal). A cutover (egress-
+# severing) tool must never silently depend on public-CDN egress for its own
+# toolchain. No step-count / RBAC / deadline change (still 11 steps). New
+# contract Case 61 asserts the fail-loud guard replaced `|| true`.
+version: 0.1.137
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -292,7 +292,29 @@ data:
     # contract is unchanged.
     set -u
 
-    apk add --no-cache curl jq >/dev/null 2>&1 || true
+    # #5191 — the pivot toolchain (curl + jq) is load-bearing: Harbor CA
+    # extraction, dragonfly-CA/dfdaemon patch, LB-IP discovery, and the per-node
+    # `registriesYaml` acks (write_node_ack / cm_patch_status) all shell out to
+    # them. The former `apk add ... || true` SILENTLY proceeded tool-less on an
+    # egress miss, so every ack failed (`jq: not found`) and the node never
+    # acked v2 — the step-04 daemonset-wait then wedged the WHOLE cutover with
+    # NO failed-step flag (observed live: hw268 2 rebooted nodes lost the apk
+    # toolchain with no egress to reinstall). Retry, then verify, then FAIL
+    # LOUD: a still-missing tool crashes the Pod (a visible CrashLoopBackOff
+    # that self-heals the moment apk succeeds), never a silent tool-less
+    # proceed. Explicit exit — `set -u` here is deliberate (NOT errexit), so the
+    # guard cannot rely on a non-zero apk killing the shell.
+    i=0
+    while [ "${i}" -lt 6 ]; do
+      apk add --no-cache curl jq >/dev/null 2>&1 && break
+      i=$((i + 1))
+      echo "[registry-pivot] WARN apk add curl jq failed (attempt ${i}/6); retry in $((i * 5))s" >&2
+      sleep $((i * 5))
+    done
+    if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+      echo "[registry-pivot] FATAL toolchain unavailable after 6 attempts (jq=$(command -v jq || echo MISSING) curl=$(command -v curl || echo MISSING)); refusing to proceed tool-less — exiting so the Pod restarts and retries rather than silently wedging the step-04 ack-wait. See #5191." >&2
+      exit 1
+    fi
 
     api="https://kubernetes.default.svc"
     token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2707,4 +2707,24 @@ if ! grep -qF 'failed to push — Sovereign cannot survive ghcr.io deny-egress p
 fi
 echo "  PASS (#5095 contract: proxy-sourced copies fall back to the mechanically-derived direct upstream before an attempt fails, pace retries exponentially over >=15 min via values-exposed knobs, name the winning source, and keep the Phase A FATAL)"
 
+# ── Case 61 (#5191): step-04 registry-pivot toolchain (curl+jq) fail-loud ──
+# curl+jq are load-bearing in the pivot (Harbor CA extraction, dragonfly-CA/
+# dfdaemon patch, LB-IP discovery, per-node registriesYaml acks). The former
+# `apk add --no-cache curl jq >/dev/null 2>&1 || true` SILENTLY proceeded
+# tool-less on an egress miss, so every ack failed (`jq: not found`), the node
+# never acked v2, and the step-04 daemonset-wait wedged the WHOLE cutover with
+# NO failed-step flag (hw268: 2 rebooted nodes lost the toolchain, no egress to
+# reinstall). Assert the silent form is GONE and a verify-then-exit-1 fail-loud
+# guard replaced it (a visible CrashLoop that self-heals, never a silent wedge).
+echo "[cutover-contract] Case 61: step-04 registry-pivot verifies curl+jq and fails loud, never 'apk add ... || true' (#5191)"
+if grep -qE 'apk add --no-cache curl jq >/dev/null 2>&1 \|\| true' "$TMP/render.yaml"; then
+  echo "FAIL: step-04 still acquires curl+jq via a silent 'apk add ... || true' — an egress miss would run the pivot tool-less and wedge the step-04 ack-wait (#5191)" >&2
+  exit 1
+fi
+if ! grep -q 'command -v jq' "$TMP/render.yaml" || ! grep -q 'refusing to proceed tool-less' "$TMP/render.yaml"; then
+  echo "FAIL: step-04 lost the fail-loud toolchain guard (retry apk, verify command -v jq/curl, then exit 1) — a missing tool must crash the Pod visibly, never silently proceed (#5191)" >&2
+  exit 1
+fi
+echo "  PASS (#5191 contract: step-04 retries apk, verifies jq+curl present, and exits 1 fail-loud when absent — a visible self-healing CrashLoop replaces the silent tool-less wedge)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.136"
+  version: "0.1.137"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.136"
+    version: "0.1.137"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem
step-04 registry-pivot acquired its load-bearing toolchain (curl+jq — Harbor CA extraction, dragonfly-CA/dfdaemon patch, LB-IP discovery, per-node `registriesYaml` acks) via a silent `apk add --no-cache curl jq >/dev/null 2>&1 || true`. On an egress miss the `|| true` let the pivot run **tool-less**: every ack failed (`jq: not found` → `WARN failed to ack ... will retry next sweep`), the node never acked v2, the step-04 daemonset-wait never reached N/N, and the **whole cutover wedged with no failed-step flag**.

Root-caused live on hw268 (2026-07-18): after a region-a reboot, 2 nodes lost their apk toolchain (jq+libonig+curl) with no egress to reinstall → cutover stuck at step 3/27%, `failedStep=""`. A cutover (egress-severing) tool must never silently depend on public-CDN egress for its own toolchain.

## Fix
- Retry `apk add --no-cache curl jq` 6× with backoff, then **verify** `command -v jq && command -v curl`; if either is still absent → **`exit 1`** (a visible CrashLoopBackOff that self-heals the moment apk succeeds) instead of silently proceeding tool-less. `set -u`-safe (explicit guard, not errexit).
- Chart `0.1.136 → 0.1.137` lockstep: Chart.yaml + blueprint.yaml + catalog-seed ×2 + bootstrap-kit slot 06a (`check-bootstrap-kit-pin-sync.sh` PASS, 65 pairs).
- New `cutover-contract.sh` **Case 61** asserts the silent `|| true` form is gone and the verify+exit-1 guard is present.

## Gates (local, all green)
- `cutover-contract.sh`: all gates green incl. Case 61.
- `check-bootstrap-kit-pin-sync.sh`: PASS.
- `helm template`: renders; `bash -n` on the rendered pivot script: SYNTAX OK.

## Validation
Validates on the next clean fresh-prov cutover (correct order: converge → cutover→cutoverComplete=true). Follow-up option noted: bake curl+jq into a purpose-built pivot image for full egress-independence.

Refs #5191

🤖 Generated with [Claude Code](https://claude.com/claude-code)