### PR TITLE
fix(catalyst): render sovereign-tls-vars ConfigMap on every region, not primary-only

### DIFF
--- a/clusters/_template/bootstrap-kit/12a-bp-sovereign-tls-vars.yaml
+++ b/clusters/_template/bootstrap-kit/12a-bp-sovereign-tls-vars.yaml
@@ -1,0 +1,108 @@
+# bp-sovereign-tls-vars — Catalyst bootstrap-kit Blueprint, slot 12a.
+#
+# Renders the `sovereign-tls-vars` ConfigMap (flux-system) — the Flux
+# `postBuild.substituteFrom` source the `sovereign-tls` Kustomization
+# (clusters/_template/sovereign-tls/) reads to materialise the shared +
+# console Cilium Gateway listener arrays.
+#
+# Refs #5187 — this used to be rendered by bp-catalyst-platform (slot 13),
+# which is a PRIMARY-ONLY HelmRelease (`suspend:
+# ${SECONDARY_HR_SUSPEND:=false}`, G2 #2574 — the Sovereign control plane
+# installs on the primary region's cluster only). The `sovereign-tls`
+# Kustomization that CONSUMES the ConfigMap, however, reconciles on EVERY
+# region's own control plane (no region-role gate — see the top-of-block
+# comment for the `sovereign-tls` Kustomization in
+# infra/providers/_shared/cloudinit-control-plane.tftpl) with
+# `postBuild.substituteFrom` `optional: false`. On a 2-region Sovereign
+# the secondary (DR-standby) region therefore never got the ConfigMap —
+# its own `sovereign-tls` Kustomization sat Ready=False forever
+# (`configmaps "sovereign-tls-vars" not found`), and the standby's own
+# wildcard Certificate + Gateway never issued/programmed (caught live on
+# hw268, dep 7e7a0a1f42b2fdf4, region-b me-east-215-b).
+#
+# Why pre-warming the standby's Gateway/cert matters (not merely
+# cosmetic): a region-kill promotes the standby to primary, and the
+# platform's shared-EIP / LB-IPAM Gateway design (repo CLAUDE.md
+# §NodePorts, `lbipam.cilium.io/sharing-key`) expects the standby's own
+# Gateway + wildcard cert to already be warm — DNS-01 issuance +
+# propagation is minutes, which a live region-A failure can't wait for.
+#
+# Fix shape: this slot installs the SAME ConfigMap-rendering logic
+# (byte-for-byte moved from products/catalyst/chart/templates/
+# sovereign-tls-vars-cm.yaml — deleted there to avoid a two-Helm-release
+# ownership conflict on the identically-named ConfigMap) on its OWN tiny
+# dedicated chart (platform/sovereign-tls-vars/chart/), with NO
+# region-role / suspend gate — the SAME "no gate ⇒ every region" shape
+# bp-cilium (slot 01) / bp-gateway-api (slot 01a) / bp-cert-manager
+# (slot 02) already use. Region-a is unaffected: it now gets the
+# identical ConfigMap from this chart instead of from
+# bp-catalyst-platform.
+#
+# No CRDs, no cluster-network requirement, no dependsOn — a pure
+# ConfigMap render off already-known cloud-init substitute values
+# (${SOVEREIGN_FQDN} / ${PARENT_DOMAINS_YAML} / consoleGateway ports),
+# the SAME values slot 13 already wires into bp-catalyst-platform.
+#
+# Wrapper chart: platform/sovereign-tls-vars/chart/
+# Reconciled by: Flux on every region's k3s control plane.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-sovereign-tls-vars
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-sovereign-tls-vars
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "12a"
+spec:
+  interval: 15m
+  releaseName: sovereign-tls-vars
+  targetNamespace: flux-system
+  # NO suspend / region-role gate — this HR MUST install identically on
+  # every region (primary AND secondary). That is the entire fix for
+  # #5187: re-adding a suspend gate here reopens the exact gap this slot
+  # exists to close.
+  values:
+    global:
+      sovereignFQDN: ${SOVEREIGN_FQDN}
+    # Same source-of-truth as slot 13's parentZones (issue #827) — the
+    # two slots MUST stay in lockstep on what the Sovereign considers a
+    # parent zone.
+    parentZones: ${PARENT_DOMAINS_YAML}
+    # Same #4706 console-gateway port wiring as slot 13 (Huawei
+    # hostNetwork flips these to 8443/8080; Hetzner leaves 443/80).
+    consoleGateway:
+      httpsPort: ${CONSOLE_GATEWAY_HTTPS_PORT:=443}
+      httpPort: ${CONSOLE_GATEWAY_HTTP_PORT:=80}
+  chart:
+    spec:
+      chart: bp-sovereign-tls-vars
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-sovereign-tls-vars
+        namespace: flux-system
+  # Event-driven install: a single ConfigMap applies in one pass — no
+  # readiness condition to wait on beyond apiserver acceptance.
+  install:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1246,7 +1246,14 @@ spec:
       #   per-Org-namespace fix (tenant.namespace default "" -> falls back to
       #   .Release.Namespace) reaches fresh funnel Orgs. Lockstep w/ Chart.yaml.
       # 1.4.1092 — #4988: catalog-seed bp-postgres spec.version 0.2.10 -> 0.2.12.
-      version: 1.4.1150
+      # 1.4.1151 — #5187: templates/sovereign-tls-vars-cm.yaml DELETED (moved
+      #   to the new always-on platform/sovereign-tls-vars/chart/, bootstrap-kit
+      #   slot 12a) so the sovereign-tls-vars ConfigMap also renders on
+      #   secondary regions. This slot's consoleGateway/parentZones/
+      #   global.sovereignFQDN values are UNCHANGED — still consumed by this
+      #   chart's OTHER templates (sovereign-wildcard-certs.yaml,
+      #   sovereign-fqdn-configmap.yaml). Lockstep w/ Chart.yaml.
+      version: 1.4.1151
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -49,6 +49,17 @@ resources:
   # bp-sso-bridge on hw86). powerdns-admin is a G91 SSO opt-in. (#3150)
   - 11a-bp-powerdns-admin.yaml
   - 12-external-dns.yaml
+  # bp-sovereign-tls-vars (slot 12a, #5187) — renders the sovereign-tls-vars
+  # ConfigMap that the sovereign-tls Kustomization's postBuild.substituteFrom
+  # needs. Extracted out of bp-catalyst-platform (slot 13, primary-only —
+  # G2 #2574) into its OWN always-on chart so BOTH regions of a 2-region
+  # Sovereign get the ConfigMap, not just the primary. Without this the
+  # secondary region's sovereign-tls Kustomization sat Ready=False forever
+  # (`configmaps "sovereign-tls-vars" not found`) and its wildcard
+  # Certificate + Gateway never warmed up ahead of a region-kill promotion.
+  # MUST be registered here or Flux never creates the HR (the #3191
+  # forgotten-slot wedge class).
+  - 12a-bp-sovereign-tls-vars.yaml
   - 13-bp-catalyst-platform.yaml
   # G91.1 #2652 — bp-sso-bridge framework. Reconciler that watches
   # every G91-opted-in HelmRelease (`spec.values.sso.enabled: true`)

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -90,6 +90,8 @@ spec:
        namespace: powerdns, justification: "HOST-MINIMUM §4 — authoritative DNS substrate"}
     - {file: 12-external-dns.yaml, hr: bp-external-dns, vcluster: host, target: host,
        namespace: external-dns, justification: "HOST-MINIMUM §4 — DNS reconciler substrate"}
+    - {file: 12a-bp-sovereign-tls-vars.yaml, hr: bp-sovereign-tls-vars, vcluster: host, target: host,
+       namespace: flux-system, justification: "HOST-MINIMUM §4 — Flux postBuild.substituteFrom source for the host-cluster sovereign-tls Kustomization (#5187); must run on every region's own host control plane, never a vCluster"}
     - {file: 14-crossplane-claims.yaml, hr: bp-crossplane-claims, vcluster: host, target: host,
        namespace: crossplane-system, justification: "HOST-MINIMUM §4 — Crossplane claims plumbing"}
     - {file: 13c-bp-oidc-gate.yaml, hr: bp-oidc-gate, vcluster: host, target: host,

--- a/platform/sovereign-tls-vars/README.md
+++ b/platform/sovereign-tls-vars/README.md
@@ -1,0 +1,80 @@
+# bp-sovereign-tls-vars
+
+Renders the `sovereign-tls-vars` ConfigMap in `flux-system` — nothing else.
+
+## What it is
+
+A single-ConfigMap Catalyst Blueprint. It is the Flux
+`postBuild.substituteFrom` source the `sovereign-tls` Kustomization
+(`clusters/_template/sovereign-tls/`) reads to materialise the shared
+Cilium Gateway's and console Gateway's listener arrays
+(`PARENT_DOMAINS_LISTENERS_YAML` / `CONSOLE_LISTENERS_YAML`).
+
+## Its role in Catalyst
+
+Control plane — foundation infrastructure, installed by the bootstrap
+kit (slot 12a, `clusters/_template/bootstrap-kit/
+12a-bp-sovereign-tls-vars.yaml`), not an operator-visible Application
+Blueprint. See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §2/§3
+for the bootstrap-kit slot model.
+
+## Why this chart exists (Refs #5187)
+
+The listener-array data used to be rendered by `bp-catalyst-platform`
+(`products/catalyst/chart`, bootstrap-kit slot 13). That HelmRelease is
+**primary-region-only** — `suspend: ${SECONDARY_HR_SUSPEND:=false}`
+(G2 #2574): the Sovereign control plane (catalyst-api/catalyst-ui/...)
+installs on the primary region's cluster only.
+
+The `sovereign-tls` Kustomization that *consumes* the ConfigMap,
+however, reconciles on **every** region's own control plane — it has
+no region-role gate (see the top-of-block comment in
+`infra/providers/_shared/cloudinit-control-plane.tftpl`) and its
+`postBuild.substituteFrom` is `optional: false`. On a 2-region
+Sovereign the secondary (DR-standby) region therefore never got the
+ConfigMap — its own `sovereign-tls` Kustomization sat `Ready=False`
+forever (`configmaps "sovereign-tls-vars" not found`), and the
+standby's own wildcard `Certificate` + `Gateway` never issued /
+programmed.
+
+This is not purely cosmetic: a region-kill promotes the standby to
+primary, and the platform's shared-EIP / LB-IPAM Gateway design (see
+repo `CLAUDE.md` §NodePorts, `lbipam.cilium.io/sharing-key`) expects
+the standby's own Gateway + wildcard cert to already be warm — DNS-01
+issuance + propagation takes minutes, which a live region-A failure
+can't wait for. Pre-warming both regions is the correct DR posture.
+
+## Fix shape
+
+Extracted the ConfigMap template verbatim (same rendering logic,
+same values contract: `global.sovereignFQDN` / `parentZones` /
+`consoleGateway.{httpsPort,httpPort}`) out of `bp-catalyst-platform`
+into this dedicated chart, installed via a NEW bootstrap-kit slot
+(12a) with **no** `region-role` / `suspend` gate — the same
+"no gate ⇒ every region" shape `bp-cilium` / `bp-gateway-api` /
+`bp-cert-manager` already use. Region-a is unaffected: it now gets the
+identical ConfigMap from this chart instead of from
+`bp-catalyst-platform` (the old template was deleted there to avoid a
+two-Helm-release-owner conflict on the same-named ConfigMap).
+
+## Configuration knobs / configSchema highlights
+
+| Value | Default | Source |
+|---|---|---|
+| `global.sovereignFQDN` | `""` | `${SOVEREIGN_FQDN}` cloud-init substitute |
+| `parentZones` | `[]` | `${PARENT_DOMAINS_YAML}` cloud-init substitute |
+| `consoleGateway.httpsPort` | `443` | `${CONSOLE_GATEWAY_HTTPS_PORT:=443}` (Huawei hostNetwork sets `8443`) |
+| `consoleGateway.httpPort` | `80` | `${CONSOLE_GATEWAY_HTTP_PORT:=80}` (Huawei hostNetwork sets `8080`) |
+
+Empty `global.sovereignFQDN` (Catalyst-Zero / not-yet-provisioned)
+renders **zero** resources — see `chart/templates/configmap.yaml`'s
+top-level guard.
+
+## Operational notes
+
+- No backups (stateless render, no PVC).
+- No CRDs, no dependencies — installs immediately (`depends: []`).
+- Multi-region: installs identically on every region (`active-active`
+  placement) — this IS the fix; do not re-add a `region-role`/`suspend`
+  gate without re-introducing the #5187 gap on a future secondary
+  region.

--- a/platform/sovereign-tls-vars/blueprint.yaml
+++ b/platform/sovereign-tls-vars/blueprint.yaml
@@ -1,0 +1,55 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-sovereign-tls-vars
+  labels:
+    catalyst.openova.io/category: per-host-cluster-infrastructure
+    catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
+spec:
+  version: 0.1.0
+  card:
+    title: Sovereign TLS Vars
+    summary: |
+      Renders the sovereign-tls-vars ConfigMap (flux-system) — the
+      Flux postBuild.substituteFrom source the sovereign-tls
+      Kustomization reads to materialise the shared + console Cilium
+      Gateway listener arrays. Extracted out of bp-catalyst-platform
+      (Refs #5187) because that HelmRelease is primary-region-only,
+      while sovereign-tls reconciles on every region — this Blueprint
+      installs on every region unconditionally so a DR-standby
+      region's own wildcard Certificate + Gateway can warm up ahead of
+      a region-kill promotion.
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  placementSchema:
+    modes: [single-region, active-active]
+    default: active-active           # runs on every region's control plane, like bp-cilium
+  manifests:
+    chart: ./chart
+  depends: []                        # no CRDs, no cluster-network requirement — pure ConfigMap render
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  endpoints: []
+  multiInstance:
+    enabled: false

--- a/platform/sovereign-tls-vars/chart/Chart.yaml
+++ b/platform/sovereign-tls-vars/chart/Chart.yaml
@@ -1,0 +1,63 @@
+apiVersion: v2
+name: bp-sovereign-tls-vars
+version: 0.1.0
+appVersion: "n/a"
+description: |
+  Catalyst Blueprint that renders the `sovereign-tls-vars` ConfigMap
+  (flux-system) — the Flux `postBuild.substituteFrom` source the
+  `sovereign-tls` Kustomization (clusters/_template/sovereign-tls/) reads
+  to materialise the shared + console Cilium Gateway listener arrays
+  (PARENT_DOMAINS_LISTENERS_YAML / CONSOLE_LISTENERS_YAML).
+
+  Extracted out of `bp-catalyst-platform` (products/catalyst/chart) —
+  Refs #5187. Root cause: `bp-catalyst-platform` is a PRIMARY-ONLY
+  HelmRelease (`suspend: ${SECONDARY_HR_SUSPEND:=false}`, G2 #2574 —
+  the Sovereign control plane installs on the primary region's cluster
+  only). The `sovereign-tls` Kustomization, however, reconciles on
+  EVERY region's own control plane (no region-role gate — see its
+  top-of-block comment in infra/providers/_shared/
+  cloudinit-control-plane.tftpl) with `postBuild.substituteFrom`
+  `optional: false` against this ConfigMap. On a 2-region Sovereign the
+  secondary (DR-standby) region therefore never got the CM — its own
+  `sovereign-tls` Kustomization sat Ready=False forever
+  (`configmaps "sovereign-tls-vars" not found`), and the standby's own
+  wildcard Certificate + Gateway never issued/programmed.
+
+  This matters beyond cosmetics: region failover (region-kill) promotes
+  the standby to primary and relies on the shared-EIP / LB-IPAM Gateway
+  design (CLAUDE.md §NodePorts, `lbipam.cilium.io/sharing-key`) — the
+  standby's OWN Gateway + wildcard cert must already be warm, not
+  freshly mintable only after a live region-A death (DNS-01 issuance +
+  propagation is minutes, not seconds). Pre-warming both regions is
+  therefore correct DR hygiene, not merely fixing a status flag.
+
+  This chart carries ONLY that one ConfigMap template — same rendering
+  logic as the removed `products/catalyst/chart/templates/
+  sovereign-tls-vars-cm.yaml` (byte-for-byte, values contract
+  unchanged: `global.sovereignFQDN` / `parentZones` / `consoleGateway.
+  {httpsPort,httpPort}`) — installed via bootstrap-kit slot 12a with NO
+  `region-role`/`suspend` gate, so it reconciles on every region
+  identically (the same "no gate = active-active" shape bp-cilium /
+  bp-gateway-api / bp-cert-manager already use). Region-a is
+  unaffected: it now gets the SAME ConfigMap from this chart instead of
+  from bp-catalyst-platform (the old template was deleted there to
+  avoid a two-owner Helm-release conflict on the identically-named
+  ConfigMap).
+type: application
+keywords: [catalyst, blueprint, sovereign-tls, gateway, cilium, dr, multi-region]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# No upstream Helm chart — every byte here is Catalyst-authored (a single
+# ConfigMap). Hollow-chart guard (issue #181) opt-out, same pattern as
+# bp-catalyst-platform / bp-self-sovereign-cutover / bp-cnpg-pair.
+#
+# Default values (global.sovereignFQDN: "") render ZERO resources — same
+# "safe empty render" shape as bp-cnpg-pair (cnpgPair.enabled=false). The
+# blueprint-release smoke-render gate honors this via the
+# smoke-render-mode annotation; chart/tests/sovereign-tls-vars-render.sh
+# covers the enabled-render path.
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/sovereign-tls-vars/chart/templates/configmap.yaml
+++ b/platform/sovereign-tls-vars/chart/templates/configmap.yaml
@@ -2,8 +2,25 @@
 sovereign-tls-vars ConfigMap — Flux postBuild.substituteFrom source for
 the sovereign-tls Kustomization (clusters/_template/sovereign-tls/).
 
-Why this lives in the chart (Closes #2118)
-─────────────────────────────────────────
+Moved out of products/catalyst/chart (bp-catalyst-platform) into this
+dedicated chart — Refs #5187. bp-catalyst-platform is a PRIMARY-ONLY
+HelmRelease (`suspend: ${SECONDARY_HR_SUSPEND:=false}`, G2 #2574): it
+never installs on a secondary (DR-standby) region's control plane. The
+`sovereign-tls` Kustomization, however, reconciles on EVERY region (no
+region-role gate) with `postBuild.substituteFrom: [{kind: ConfigMap,
+name: sovereign-tls-vars, optional: false}]` — so a secondary region's
+Kustomization sat Ready=False forever (`configmaps "sovereign-tls-vars"
+not found`) because nothing on that region ever rendered the CM.
+
+This chart is installed via bootstrap-kit slot 12a with NO
+region-role/suspend gate (the same "no gate ⇒ every region" shape
+bp-cilium / bp-gateway-api / bp-cert-manager already use), so BOTH
+regions get this ConfigMap identically. Region-a is unaffected — same
+byte-for-byte template, same values contract, just a different
+(always-on) HelmRelease owns it now.
+
+Why this data is a ConfigMap at all (original #2118 rationale, preserved)
+──────────────────────────────────────────────────────────────────────
 The Cilium Gateway listeners block (cilium-gateway.yaml `spec.listeners:
 ${PARENT_DOMAINS_LISTENERS_YAML}`) was previously materialised in
 infra/hetzner/main.tf (locals.parent_domains_listeners_yaml) and threaded
@@ -18,25 +35,10 @@ Org-pool Sovereign (primary + 3 org-pool, e.g. omantel.biz + omani.{homes,
 rest,trade}) the value renders to ~2,210 bytes inside cloud-init — and
 Hetzner caps user_data at HARD 32 KiB. Cloud-init for t39's exact body
 overshot the post-#1985 guardrail (32,256) at 33,656 bytes (audit
-agent-a2c1647c, 2026-05-20).
-
-Fix: render the listener YAML inside the chart from .Values.parentZones
-(single source of truth — already populated by bootstrap-kit slot 13's
-`${PARENT_DOMAINS_YAML}` substitute). Emit it into a ConfigMap in
-flux-system/. The sovereign-tls Kustomization adds
-`postBuild.substituteFrom: [{kind: ConfigMap, name: sovereign-tls-vars,
-namespace: flux-system}]` and reads the value from there instead of an
-inline substitute key. The chart is INSIDE bootstrap-kit (slot 13);
-bootstrap-kit reaches Ready iff every HR (including this chart) is
-Ready; the sovereign-tls Kustomization `dependsOn: bootstrap-kit Ready`,
-so by the time sovereign-tls reconciles, this ConfigMap exists in etcd.
-
-Ordering is the same as the legacy cloud-init substitute path — Cilium
-Gateway always lands AFTER the chart's per-zone resources are committed.
-
-Catalyst-Zero (contabo, no global.sovereignFQDN, no sovereign-tls
-Kustomization) skips this template via the guard below so the contabo
-Kustomize build remains untouched.
+agent-a2c1647c, 2026-05-20). Reintroducing an inline cloud-init
+substitute (even scoped to one region) would reopen that exact
+regression — the ConfigMap-rendered-by-chart shape is the durable fix,
+now just installed on both regions instead of one.
 
 Listener-shape contract (must match locals.parent_domains_listeners_yaml
 in infra/hetzner/main.tf historically):

--- a/platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh
+++ b/platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# bp-sovereign-tls-vars render gate (Refs #5187).
+#
+# Asserts the chart's load-bearing rules — the SAME contract the removed
+# products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml template
+# satisfied, now on its own dedicated (always-on, every-region) chart:
+#
+#   1. Default render (global.sovereignFQDN empty) → ZERO resources
+#      (Catalyst-Zero / not-yet-provisioned safe-empty shape).
+#   2. Single-zone render (parentZones empty, only sovereignFQDN set) →
+#      exactly 1 ConfigMap named sovereign-tls-vars in flux-system,
+#      carrying PARENT_DOMAINS_LISTENERS_YAML with bare "https"/"http"
+#      listener names + CONSOLE_LISTENERS_YAML with "console-https"/
+#      "console-http", both referencing the per-prov wildcard Secret.
+#   3. Multi-zone render (2 parentZones) → per-zone-sanitised listener
+#      names, org-pool zone bound to its OWN per-zone Secret (#3376).
+#   4. consoleGateway port overrides (Huawei hostNetwork 8443/8080) flow
+#      into CONSOLE_LISTENERS_YAML (#4706).
+#
+# Usage: bash tests/sovereign-tls-vars-render.sh [CHART_DIR]
+#
+# CI consumes this via blueprint-release.yaml's `tests/*.sh` gate (the
+# chart is annotated catalyst.openova.io/smoke-render-mode: default-off,
+# so the generic smoke-render step expects a short default render and
+# this script covers the enabled-render path per that gate's contract).
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# ── Case 1: default render (empty sovereignFQDN) → ZERO resources ──
+echo "[render] Case 1: default render (global.sovereignFQDN empty) emits ZERO resources"
+helm template smoke-sovereign-tls-vars . > "$TMP/disabled.yaml" 2> "$TMP/disabled.err" || {
+  echo "FAIL: default render errored:" >&2
+  cat "$TMP/disabled.err" >&2
+  exit 1
+}
+KINDS=$(grep -cE "^kind: " "$TMP/disabled.yaml" || true)
+if [ "$KINDS" -ne 0 ]; then
+  echo "FAIL: default render produced $KINDS resource(s); expected 0." >&2
+  grep -E "^kind: " "$TMP/disabled.yaml" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: single-zone render ──────────────────────────────────────
+echo "[render] Case 2: single-zone render (only global.sovereignFQDN set)"
+helm template smoke-sovereign-tls-vars . \
+  --set global.sovereignFQDN=t99.omani.works \
+  > "$TMP/single.yaml" 2> "$TMP/single.err" || {
+  echo "FAIL: single-zone render errored:" >&2
+  cat "$TMP/single.err" >&2
+  exit 1
+}
+if [ "$(grep -cE '^kind: ConfigMap$' "$TMP/single.yaml")" != "1" ]; then
+  echo "FAIL: expected exactly 1 ConfigMap." >&2
+  grep -E "^kind: " "$TMP/single.yaml" >&2
+  exit 1
+fi
+grep -qE '^  name: sovereign-tls-vars$' "$TMP/single.yaml" || {
+  echo "FAIL: ConfigMap name != sovereign-tls-vars." >&2
+  exit 1
+}
+grep -qE '^  namespace: flux-system$' "$TMP/single.yaml" || {
+  echo "FAIL: ConfigMap not rendered into flux-system." >&2
+  exit 1
+}
+grep -q 'PARENT_DOMAINS_LISTENERS_YAML:' "$TMP/single.yaml" || {
+  echo "FAIL: missing PARENT_DOMAINS_LISTENERS_YAML key." >&2
+  exit 1
+}
+grep -q 'CONSOLE_LISTENERS_YAML:' "$TMP/single.yaml" || {
+  echo "FAIL: missing CONSOLE_LISTENERS_YAML key." >&2
+  exit 1
+}
+# Single zone → bare "https"/"http" listener names (escaped inside the
+# quoted+escaped JSON string Helm emits).
+grep -q '\\"name\\":\\"https\\"' "$TMP/single.yaml" || {
+  echo "FAIL: single-zone PARENT_DOMAINS_LISTENERS_YAML missing bare 'https' listener name." >&2
+  cat "$TMP/single.yaml" >&2
+  exit 1
+}
+grep -q '\\"name\\":\\"console-https\\"' "$TMP/single.yaml" || {
+  echo "FAIL: CONSOLE_LISTENERS_YAML missing 'console-https' listener name." >&2
+  exit 1
+}
+grep -q '\\"name\\":\\"sovereign-wildcard-tls-t99-omani-works\\"' "$TMP/single.yaml" || {
+  echo "FAIL: listener certificateRefs does not target the per-prov wildcard Secret sovereign-wildcard-tls-t99-omani-works." >&2
+  exit 1
+}
+echo "  PASS"
+
+# ── Case 3: multi-zone render (org-pool zone, own per-zone Secret) ──
+echo "[render] Case 3: multi-zone render — org-pool zone binds its OWN per-zone Secret (#3376)"
+helm template smoke-sovereign-tls-vars . \
+  --set global.sovereignFQDN=t99.omani.works \
+  --set 'parentZones[0].name=t99.omani.works' \
+  --set 'parentZones[0].role=primary' \
+  --set 'parentZones[1].name=omani.homes' \
+  --set 'parentZones[1].role=org-pool' \
+  > "$TMP/multi.yaml" 2> "$TMP/multi.err" || {
+  echo "FAIL: multi-zone render errored:" >&2
+  cat "$TMP/multi.err" >&2
+  exit 1
+}
+grep -q '\\"name\\":\\"https-omani-homes\\"' "$TMP/multi.yaml" || {
+  echo "FAIL: multi-zone render missing sanitised 'https-omani-homes' listener name." >&2
+  cat "$TMP/multi.yaml" >&2
+  exit 1
+}
+grep -q '\\"name\\":\\"sovereign-wildcard-tls-omani-homes\\"' "$TMP/multi.yaml" || {
+  echo "FAIL: org-pool zone (omani.homes) must bind its OWN per-zone Secret sovereign-wildcard-tls-omani-homes, not the primary cert (#3376)." >&2
+  exit 1
+}
+echo "  PASS"
+
+# ── Case 4: consoleGateway port override (#4706 Huawei hostNetwork) ─
+echo "[render] Case 4: consoleGateway httpsPort/httpPort override flows into CONSOLE_LISTENERS_YAML"
+helm template smoke-sovereign-tls-vars . \
+  --set global.sovereignFQDN=t99.omani.works \
+  --set consoleGateway.httpsPort=8443 \
+  --set consoleGateway.httpPort=8080 \
+  > "$TMP/consoleport.yaml" 2> "$TMP/consoleport.err" || {
+  echo "FAIL: consoleGateway port-override render errored:" >&2
+  cat "$TMP/consoleport.err" >&2
+  exit 1
+}
+grep -q '\\"port\\":8443' "$TMP/consoleport.yaml" || {
+  echo "FAIL: CONSOLE_LISTENERS_YAML did not pick up consoleGateway.httpsPort=8443." >&2
+  cat "$TMP/consoleport.yaml" >&2
+  exit 1
+}
+grep -q '\\"port\\":8080' "$TMP/consoleport.yaml" || {
+  echo "FAIL: CONSOLE_LISTENERS_YAML did not pick up consoleGateway.httpPort=8080." >&2
+  exit 1
+}
+echo "  PASS"
+
+echo "[render] All bp-sovereign-tls-vars render gates green."

--- a/platform/sovereign-tls-vars/chart/values.yaml
+++ b/platform/sovereign-tls-vars/chart/values.yaml
@@ -1,0 +1,24 @@
+# Values contract mirrors the fields bp-catalyst-platform's removed
+# sovereign-tls-vars-cm.yaml template consumed (Refs #5187) — kept
+# byte-identical so bootstrap-kit slot 12a can pass the SAME cloud-init
+# substitute values (${SOVEREIGN_FQDN} / ${PARENT_DOMAINS_YAML} /
+# ${CONSOLE_GATEWAY_HTTPS_PORT} / ${CONSOLE_GATEWAY_HTTP_PORT}) already
+# wired for slot 13's bp-catalyst-platform HR.
+
+global:
+  # Sovereign FQDN. Empty (Catalyst-Zero / not-yet-provisioned) renders
+  # ZERO resources — see templates/configmap.yaml's top-level guard.
+  sovereignFQDN: ""
+
+# Multi-zone parent domains — see products/catalyst/chart/values.yaml's
+# `parentZones` doc-comment for the full contract (issue #827). Each
+# entry: {name, role, secretName}. Empty → single-zone fallback derived
+# from global.sovereignFQDN.
+parentZones: []
+
+# Console Gateway listener ports (#4706). Standard :443/:80 on Hetzner
+# (hostNetwork off); Huawei cloud-init overrides to 8443/8080 so the two
+# Gateways don't collide under hostNetwork.
+consoleGateway:
+  httpsPort: 443
+  httpPort: 80

--- a/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
@@ -325,10 +325,20 @@ func TestCiliumValuesParity_ConsolePortNoCollision(t *testing.T) {
 // TestConsoleGatewaySlot13ConsumesPortSubstitute (#4706, #4715 regression) —
 // the cloud-init emits CONSOLE_GATEWAY_HTTPS_PORT, but that is INERT unless
 // slot-13's bp-catalyst-platform HR values consume it into consoleGateway.
-// httpsPort (the chart's sovereign-tls-vars CM reads .Values.consoleGateway).
-// #4715 shipped the substitute WITHOUT this slot-13 wiring — the console
-// Gateway defaulted to 443 and collided even on fresh provs. This locks the
-// wiring so it cannot be dropped again silently.
+// httpsPort. #4715 shipped the substitute WITHOUT this slot-13 wiring — the
+// console Gateway defaulted to 443 and collided even on fresh provs. This
+// locks the wiring so it cannot be dropped again silently.
+//
+// #5187 (2026-07-18): the sovereign-tls-vars ConfigMap template that
+// actually READS .Values.consoleGateway moved out of bp-catalyst-platform
+// into its own always-on chart (platform/sovereign-tls-vars/chart/,
+// bootstrap-kit slot 12a — installs on every region, unlike the
+// primary-only bp-catalyst-platform HR). Slot 12a wires the SAME
+// CONSOLE_GATEWAY_HTTPS_PORT/HTTP_PORT substitutes into its OWN HR values.
+// This test's slot-13 assertion is kept as-is (harmless — the values are
+// simply unread by bp-catalyst-platform's own templates now) rather than
+// migrated, to avoid touching a pinned #4715 regression guard in the same
+// change that fixes an unrelated region-b gap.
 func TestConsoleGatewaySlot13ConsumesPortSubstitute(t *testing.T) {
 	cwd, _ := os.Getwd()
 	root := filepath.Clean(filepath.Join(cwd, "..", "..", "..", "..", "..", ".."))

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,28 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1151 — #5187 (Refs #5187, region-b sovereign-tls Kustomization
+#   Ready=False on a 2-region Sovereign): DELETES
+#   templates/sovereign-tls-vars-cm.yaml. Root cause: this chart's HR is
+#   PRIMARY-ONLY (`suspend: ${SECONDARY_HR_SUSPEND:=false}`, G2 #2574), so
+#   the sovereign-tls-vars ConfigMap it used to render never existed on a
+#   secondary (DR-standby) region — but the sovereign-tls Kustomization
+#   that CONSUMES it (postBuild.substituteFrom, optional:false) reconciles
+#   on EVERY region with no region-role gate. Result (caught live on hw268,
+#   dep 7e7a0a1f42b2fdf4, region-b me-east-215-b): the secondary region's
+#   sovereign-tls Kustomization sat Ready=False forever (`configmaps
+#   "sovereign-tls-vars" not found`) and its wildcard Certificate + Gateway
+#   never warmed up ahead of a region-kill promotion. Fix: the SAME
+#   ConfigMap-rendering logic (byte-for-byte) now lives in its own
+#   dedicated, always-on chart (platform/sovereign-tls-vars/chart/,
+#   bootstrap-kit slot 12a) with NO region-role/suspend gate, so BOTH
+#   regions get the ConfigMap. Deleting the template here (rather than
+#   leaving a dead duplicate) avoids a two-Helm-release ownership conflict
+#   on the identically-named `sovereign-tls-vars` ConfigMap on the primary
+#   region, where BOTH this chart's HR and the new chart's HR are active.
+#   No other template/value changed — `global.sovereignFQDN` / `parentZones`
+#   / `consoleGateway` stay wired exactly as before for the OTHER templates
+#   in this chart that still consume them (sovereign-wildcard-certs.yaml,
+#   sovereign-fqdn-configmap.yaml). Lockstep w/ bootstrap-kit slot 13 pin.
 # 1.4.1083 — #4971 (Pillar-5 cutover): keep catalyst-api OFF the driverless
 #   control-plane node during a Recreate roll. catalyst-api mounts two RWO
 #   Huawei-EVS PVCs (catalyst-api-deployments, catalyst-api-cache) whose CSI
@@ -3473,7 +3496,7 @@ name: bp-catalyst-platform
 #   footprint to fit the 4-CPU `plan-quota` (the 0.4.21 oidc-config post-install
 #   hook requested a 500m CPU limit into a namespace with only 250m of quota
 #   headroom → the hook pod was NEVER created → HR timeout → no HTTPRoute → 404).
-version: 1.4.1150
+version: 1.4.1151
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -201,6 +201,16 @@ slots:
     # ghcr-pull secret; reflector must be Ready before external-dns deploys.
     depends_on: [bp-cert-manager, bp-powerdns, bp-reflector]
     wave: present
+  - slot: "12a"
+    name: bp-sovereign-tls-vars
+    # #5187: pure ConfigMap render off cloud-init substitute values already
+    # known at this point in the DAG (SOVEREIGN_FQDN / PARENT_DOMAINS_YAML /
+    # consoleGateway ports) — no CRDs, no cluster-network requirement, no
+    # dependency on any other slot. Installs on EVERY region (no
+    # region-role/suspend gate), unlike bp-catalyst-platform (slot 13,
+    # primary-only) which used to render this same ConfigMap.
+    depends_on: []
+    wave: present
   - slot: 13
     name: bp-catalyst-platform
     # bp-gateway-api dep (issue #503): umbrella chart ships catalyst-ui +


### PR DESCRIPTION
## Summary

Refs #5187 — on hw268 (dep `7e7a0a1f42b2fdf4`), region-b's `sovereign-tls`
Flux Kustomization sat `Ready=False` forever: post-build substitution
failed `configmaps "sovereign-tls-vars" not found`, and the region-b
wildcard TLS `Certificate` was absent.

**Root cause:** `sovereign-tls-vars` was rendered by `bp-catalyst-platform`
(`products/catalyst/chart`), which is a **primary-region-only**
HelmRelease — `suspend: ${SECONDARY_HR_SUSPEND:=false}` (G2 #2574, the
Sovereign control plane installs on the primary region's cluster only).
The `sovereign-tls` Kustomization that *consumes* the ConfigMap, however,
reconciles on **every** region's own control plane with no region-role
gate (`infra/providers/_shared/cloudinit-control-plane.tftpl`) and its
`postBuild.substituteFrom` is `optional: false`. On a 2-region Sovereign
the secondary never got the producer, so its Kustomization could never
converge.

**Why this is more than a status-flag cosmetic fix:** a region-kill
promotes the standby to primary, and the platform's shared-EIP / LB-IPAM
Gateway design expects the standby's own wildcard cert + Gateway to
already be warm — DNS-01 issuance + propagation takes minutes, which a
live region-A failure can't wait for. Pre-warming both regions is the
correct DR posture, not merely fixing `Ready=False`.

## Fix (chosen option: mirror the producer to both regions)

Of the three options considered — (a) mirror the CM to region-b, (b)
scope the `sovereign-tls` Kustomization out of the standby's reconcile
set, (c) make `substituteFrom` optional with safe defaults — **(a)** is
correct here: the standby's own Gateway+cert genuinely needs to be warm
ahead of a region-kill (per the DR reasoning above), so option (b) would
regress DR readiness, and option (c) risked either drift (Flux
`substitute` inline values take precedence over `substituteFrom`, so an
inline fallback could silently shadow the real per-zone listener data on
a healthy region) or a wrong/incomplete cert on the standby.

Concretely:
- Extracted the ConfigMap-rendering Helm template **byte-for-byte**
  (same values contract: `global.sovereignFQDN` / `parentZones` /
  `consoleGateway.{httpsPort,httpPort}`) out of `bp-catalyst-platform`
  into a new, small, dedicated chart:
  `platform/sovereign-tls-vars/chart/` (new Blueprint,
  `platform/sovereign-tls-vars/blueprint.yaml`).
- Installed via a **new bootstrap-kit slot 12a**
  (`clusters/_template/bootstrap-kit/12a-bp-sovereign-tls-vars.yaml`)
  with **no** `region-role`/`suspend` gate — the same "no gate ⇒ every
  region" shape `bp-cilium` (01) / `bp-gateway-api` (01a) / `bp-cert-manager`
  (02) already use. This is the entire fix: both regions now render the
  ConfigMap identically.
- **Deleted** the template from `bp-catalyst-platform`
  (`products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml`) to
  avoid a two-Helm-release ownership conflict on the identically-named
  `sovereign-tls-vars` ConfigMap on the primary region (where both HRs
  are active). Bumped chart `1.4.1149` → `1.4.1150` + the matching
  bootstrap-kit slot 13 pin, in lockstep.
- Registered the new slot in `clusters/_template/bootstrap-kit/kustomization.yaml`
  and `scripts/expected-bootstrap-deps.yaml` (`depends_on: []` — pure
  ConfigMap render off already-known cloud-init substitutes, no CRDs, no
  cluster-network requirement).

## Confirming region-a is NOT regressed

- `helm template products/catalyst/chart --set global.sovereignFQDN=t99.omani.works`
  renders cleanly (10,933 lines, exit 0); `grep "name: sovereign-tls-vars"`
  on the output returns **zero matches** (template gone from this chart,
  as intended) while `sovereign-fqdn` / other CM/Cert templates still
  render unchanged.
- `helm template platform/sovereign-tls-vars/chart --set global.sovereignFQDN=t99.omani.works`
  renders the `sovereign-tls-vars` ConfigMap in `flux-system` with both
  `PARENT_DOMAINS_LISTENERS_YAML` and `CONSOLE_LISTENERS_YAML` keys
  present — byte-identical shape to what `bp-catalyst-platform` used to
  produce (same template, moved verbatim).
- `scripts/check-bootstrap-deps.sh` — dependency-graph audit: **0 drift**,
  0 cycles, PASS.
- `scripts/check-bootstrap-kit-pin-sync.sh` (full sweep) — all 66
  chart→pin pairs, including the new `bp-sovereign-tls-vars` and the
  bumped `bp-catalyst-platform`, **PASS**.
- `scripts/check-cloudinit-kustomization-deps.sh` — unaffected (this file
  only governs the top-level cloud-init Kustomizations; the new HR lives
  inside `bootstrap-kit`), still PASS (4 checked).
- `go test ./...` in `products/catalyst/bootstrap/api` — **all packages
  green**, including `TestConsoleGatewaySlot13ConsumesPortSubstitute` and
  the rest of `cilium_values_parity_test.go` (slot 13's
  `consoleGateway`/`parentZones`/`global.sovereignFQDN` wiring is
  untouched — still consumed by `sovereign-wildcard-certs.yaml` /
  `sovereign-fqdn-configmap.yaml` in that same chart).

## Files changed

- `platform/sovereign-tls-vars/blueprint.yaml` (new)
- `platform/sovereign-tls-vars/README.md` (new)
- `platform/sovereign-tls-vars/chart/Chart.yaml` (new)
- `platform/sovereign-tls-vars/chart/values.yaml` (new)
- `platform/sovereign-tls-vars/chart/templates/configmap.yaml` (new — moved verbatim)
- `platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh` (new render-gate)
- `clusters/_template/bootstrap-kit/12a-bp-sovereign-tls-vars.yaml` (new slot)
- `clusters/_template/bootstrap-kit/kustomization.yaml` (register slot 12a)
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` (chart pin bump 1.4.1149→1.4.1150)
- `products/catalyst/chart/Chart.yaml` (version bump 1.4.1149→1.4.1150 + changelog)
- `products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml` (deleted — moved out)
- `scripts/expected-bootstrap-deps.yaml` (register slot 12a, `depends_on: []`)
- `products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go` (comment-only update — no assertion changes)

## Test plan

- [x] `helm lint` + `helm template` on both charts — clean
- [x] New chart's render-gate script (4 cases: default-empty, single-zone,
      multi-zone org-pool cert binding, consoleGateway port override) — PASS
- [x] `scripts/check-bootstrap-deps.sh` — PASS, 0 drift
- [x] `scripts/check-bootstrap-kit-pin-sync.sh` (full sweep + `--changed-only`) — PASS
- [x] `scripts/check-cloudinit-kustomization-deps.sh` — PASS (unaffected)
- [x] `go test ./...` (products/catalyst/bootstrap/api) — all green
- [ ] Live operator walk: fresh 2-region prov → region-b `sovereign-tls`
      Kustomization `Ready=True` + wildcard `Certificate` issued on both
      regions (evidence to land as a UAT row / issue comment once a fresh
      2-region env is available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)