### PR TITLE
fix: Continuum sequencer step-8 re-clone-on-divergence (#5125 Defect-2)

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -149,7 +149,19 @@ spec:
       # Healthy/lag=0 through the whole outage). Naming mirrors the
       # catalyst-api DR-panel projection (#4905). Pin moves in lockstep
       # (Inviolable Principle #13).
-      version: 0.1.10
+      # 0.1.11 (#5125 Defect-2): step-8 re-clone-on-divergence — on
+      # region-a resume the returning cnpg-pair half's walreceiver can
+      # crash-loop with "highest timeline N of the primary is behind
+      # recovery timeline N+1"; the per-CR reconcile loop now detects
+      # that exact divergence signature (standby un-Ready + TimelineID
+      # strictly ahead of the acting primary — never on a healthy
+      # rejoin or ordinary catch-up lag) and drives the proven manual
+      # heal (delete + re-create the diverged Cluster CR to force a
+      # pg_basebackup re-clone), bounded to 3 attempts with linear
+      # backoff, failing loud via a continuum-error audit + a False/
+      # RejoinRepairBounded condition rather than looping forever. Pin
+      # moves in lockstep (Inviolable Principle #13).
+      version: 0.1.11
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/core/controllers/continuum/internal/cnpg/status.go
+++ b/core/controllers/continuum/internal/cnpg/status.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,6 +91,21 @@ type Status struct {
 	// status is too old/partial to judge on this axis.
 	ReadyInstances    int
 	HasReadyInstances bool
+
+	// TimelineID is status.timelineID — the PostgreSQL timeline this
+	// Cluster is currently on. CNPG bumps it on every promotion
+	// (intra-Cluster failover, or a replica-cluster leaving recovery).
+	// Used by #5125 Defect-2 divergence detection (DetectDivergence):
+	// a standby (spec.replica.enabled=true) reporting a TimelineID
+	// STRICTLY GREATER than the CR currently acting as primary means
+	// its own recovery history has advanced past what the primary can
+	// serve — the structured form of the CNPG walreceiver crash-loop
+	// "highest timeline N of the primary is behind recovery timeline
+	// N+1". Zero/absent (HasTimelineID=false) means the field hasn't
+	// been populated yet (fresh CR, or a CNPG version/phase that
+	// hasn't surfaced it) — callers must never guess on absent data.
+	TimelineID    int
+	HasTimelineID bool
 }
 
 // StandbyAvailable reports whether the replica (standby) half of a
@@ -253,6 +269,55 @@ func (r *Reader) SetReplicaEnabled(ctx context.Context, namespace, name string, 
 	return nil
 }
 
+// RecloneCluster deletes then re-creates a CNPG Cluster CR from its own
+// captured spec/labels/annotations, forcing the CNPG operator to
+// re-bootstrap it from scratch (pg_basebackup) instead of trying to
+// resume streaming replication.
+//
+// This is the structured form of the #5125 Defect-2 proven manual heal
+// for a walreceiver stuck in timeline-divergence ("highest timeline N
+// of the primary is behind recovery timeline N+1"): "delete replica
+// Cluster CR + re-apply". Only spec + labels + annotations survive;
+// server-set metadata (resourceVersion, uid, creationTimestamp,
+// generation, managedFields, status) is stripped so the Create call is
+// accepted as a genuinely fresh object — CNPG then re-runs its normal
+// bootstrap reconcile, which re-clones via pg_basebackup.
+//
+// Idempotent: if the CR is already absent (e.g. a prior attempt's
+// Delete succeeded but the process crashed before Create), the missing
+// Get simply errors and the caller (Sequencer.CheckRejoin) surfaces it
+// as this attempt's failure — bounded-attempts + backoff (rejoin.go)
+// retries on the next cooldown window rather than looping tightly.
+func (r *Reader) RecloneCluster(ctx context.Context, namespace, name string) error {
+	if r == nil || r.Dyn == nil {
+		return errors.New("cnpg: nil Reader")
+	}
+	cr, err := r.Dyn.Resource(ClusterGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cnpg: get for reclone: %w", err)
+	}
+
+	fresh := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	fresh.SetGroupVersionKind(cr.GroupVersionKind())
+	fresh.SetName(cr.GetName())
+	fresh.SetNamespace(cr.GetNamespace())
+	fresh.SetLabels(cr.GetLabels())
+	fresh.SetAnnotations(cr.GetAnnotations())
+	if spec, found, _ := unstructured.NestedMap(cr.Object, "spec"); found {
+		if err := unstructured.SetNestedMap(fresh.Object, spec, "spec"); err != nil {
+			return fmt.Errorf("cnpg: reclone: copy spec: %w", err)
+		}
+	}
+
+	if err := r.Dyn.Resource(ClusterGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("cnpg: delete for reclone: %w", err)
+	}
+	if _, err := r.Dyn.Resource(ClusterGVR).Namespace(namespace).Create(ctx, fresh, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("cnpg: recreate for reclone: %w", err)
+	}
+	return nil
+}
+
 // MaxLagSeconds returns the maximum lag observed across the listed
 // Clusters' Status. Clusters that aren't replicas (lag=0) are skipped
 // per the CNPG semantics.
@@ -297,6 +362,19 @@ func parseStatus(cr *unstructured.Unstructured) Status {
 			s.ReadyInstances, s.HasReadyInstances = n, true
 		case float64:
 			s.ReadyInstances, s.HasReadyInstances = int(n), true
+		}
+	}
+
+	// timelineID (#5125 Defect-2) — same tolerant int64/int/float64
+	// decoding as readyInstances above.
+	if v, found, _ := unstructured.NestedFieldNoCopy(cr.Object, "status", "timelineID"); found {
+		switch n := v.(type) {
+		case int64:
+			s.TimelineID, s.HasTimelineID = int(n), true
+		case int:
+			s.TimelineID, s.HasTimelineID = n, true
+		case float64:
+			s.TimelineID, s.HasTimelineID = int(n), true
 		}
 	}
 

--- a/core/controllers/continuum/internal/cnpg/status_test.go
+++ b/core/controllers/continuum/internal/cnpg/status_test.go
@@ -192,6 +192,86 @@ func TestReader_SetReplicaEnabled(t *testing.T) {
 	}
 }
 
+// TestParseStatus_TimelineID — #5125 Defect-2: status.timelineID must
+// decode (tolerating the int64/int/float64 encodings the dynamic
+// client + fakes produce, same as readyInstances), and be absent
+// (HasTimelineID=false) when the field simply isn't present yet.
+func TestParseStatus_TimelineID(t *testing.T) {
+	t.Parallel()
+	cr := newCluster("ns", "p", nil, map[string]interface{}{
+		"timelineID": int64(3),
+	}, false)
+	s := parseStatus(cr)
+	if !s.HasTimelineID || s.TimelineID != 3 {
+		t.Errorf("TimelineID = %d HasTimelineID=%v, want 3/true", s.TimelineID, s.HasTimelineID)
+	}
+
+	cr2 := newCluster("ns", "p2", nil, map[string]interface{}{}, false)
+	s2 := parseStatus(cr2)
+	if s2.HasTimelineID {
+		t.Errorf("expected HasTimelineID=false for a Cluster CR with no timelineID field, got TimelineID=%d", s2.TimelineID)
+	}
+}
+
+// TestReader_RecloneCluster — #5125 Defect-2: RecloneCluster deletes
+// then re-creates the Cluster CR, preserving spec/labels/annotations
+// but stripping status/resourceVersion so CNPG treats it as a fresh
+// object (re-bootstrap via pg_basebackup).
+func TestReader_RecloneCluster(t *testing.T) {
+	t.Parallel()
+	cr := newCluster("ns", "demo-replica", map[string]string{
+		PairLabel:     "demo",
+		PairRoleLabel: RoleReplica,
+	}, map[string]interface{}{
+		"timelineID": int64(3),
+		"phase":      "Cluster in healthy state",
+	}, true)
+	cr.SetAnnotations(map[string]string{"some-annotation": "keep-me"})
+
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMap(), cr)
+	r := NewReader(dyn)
+
+	if err := r.RecloneCluster(context.Background(), "ns", "demo-replica"); err != nil {
+		t.Fatalf("RecloneCluster: %v", err)
+	}
+
+	got, err := dyn.Resource(ClusterGVR).Namespace("ns").Get(context.Background(), "demo-replica", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get post-reclone: %v", err)
+	}
+	// spec.replica.enabled=true must survive the reclone.
+	en, _, _ := unstructured.NestedBool(got.Object, "spec", "replica", "enabled")
+	if !en {
+		t.Fatalf("expected spec.replica.enabled=true preserved, got %v", en)
+	}
+	// Labels + annotations must survive.
+	if got.GetLabels()[PairLabel] != "demo" {
+		t.Fatalf("pair label not preserved: %v", got.GetLabels())
+	}
+	if got.GetAnnotations()["some-annotation"] != "keep-me" {
+		t.Fatalf("annotation not preserved: %v", got.GetAnnotations())
+	}
+	// status must be wiped — the whole point is a fresh bootstrap.
+	if _, found, _ := unstructured.NestedFieldNoCopy(got.Object, "status", "timelineID"); found {
+		t.Fatalf("expected status.timelineID wiped after reclone, still present")
+	}
+}
+
+// TestReader_RecloneCluster_MissingCluster — RecloneCluster on a
+// nonexistent Cluster CR errors rather than panicking (bounded
+// attempts in rejoin.go treat this as a failed attempt, retried next
+// cooldown).
+func TestReader_RecloneCluster_MissingCluster(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMap())
+	r := NewReader(dyn)
+	if err := r.RecloneCluster(context.Background(), "ns", "nope"); err == nil {
+		t.Fatal("expected error re-cloning a nonexistent Cluster CR")
+	}
+}
+
 func TestMaxLagSeconds(t *testing.T) {
 	t.Parallel()
 	if MaxLagSeconds() != 0 {

--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -143,6 +143,12 @@ type ContinuumReconciler struct {
 	// 30s per design doc §9.5; tests override to 0.
 	HealthDelay time.Duration
 
+	// RejoinOptions configures step-8 (#5125 Defect-2 re-clone-on-
+	// divergence): max attempts + backoff cooldown. Zero-value is
+	// filled by switchover.RejoinOptions.Defaults() (3 attempts, 3m
+	// cooldown) on every call.
+	RejoinOptions switchover.RejoinOptions
+
 	// activeContinuums tracks per-CR goroutines keyed by
 	// NamespacedName.String() (e.g. "demo/cr1").
 	activeContinuums   map[string]*continuumGoroutine
@@ -164,6 +170,13 @@ type continuumGoroutine struct {
 	// loop iteration sees a different value, we emit
 	// `continuum-config-changed` (slice F-1).
 	lastSpecFingerprint string
+
+	// rejoinState is step-8's (#5125 Defect-2) cross-tick bookkeeping —
+	// attempt count + backoff clock + bounded-fail-loud latch for the
+	// current re-clone-on-divergence episode. Session-scoped, same
+	// pattern as lastSpecFingerprint above (a controller restart starts
+	// a fresh episode rather than persisting across restarts).
+	rejoinState switchover.RejoinState
 }
 
 // SetupWithManager wires the reconciler into the controller-runtime
@@ -366,6 +379,14 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 						Available:      cnpg.StandbyAvailable(replicaStatus),
 						ReplicaCluster: replica.GetName(),
 					}
+					// #5125 Defect-2 — step-8 rejoin-repair check. Reuses
+					// the SAME FindPair + Get calls above; no extra CNPG
+					// API traffic. Runs every tick regardless of
+					// switchover-requested/lag-breach below — its own
+					// gate (DetectDivergence) is narrow enough to be a
+					// safe no-op outside the region-a-resume-with-
+					// divergence scenario (rejoin.go).
+					r.checkRejoin(ctx, nn, reader, spec.CNPGNamespace, primary.GetName(), primaryStatus, replica.GetName(), replicaStatus)
 				}
 			}
 		}
@@ -537,6 +558,89 @@ func (r *ContinuumReconciler) runPostSwitchoverHealth(plan switchover.Switchover
 		LastSwitchoverHealthy:       condStatus,
 		LastSwitchoverHealthyDetail: detail,
 		Reason:                      "PostSwitchoverHealth",
+	})
+}
+
+// checkRejoin runs step-8 (#5125 Defect-2 — re-clone-on-divergence)
+// for this reconcile tick. It reuses the primary/replica CNPG status
+// the caller (runPerCR) already fetched for the #4901 standby check —
+// no extra API traffic.
+//
+// State is carried in the per-CR goroutine's in-memory RejoinState
+// (same session-scoped pattern as lastSpecFingerprint) so attempts +
+// backoff survive across ticks within one controller lifetime. The
+// outcome is mirrored onto the CR status + an audit event ONLY when
+// switchover.CheckRejoin reports a determination (a divergence was
+// observed this tick) — a healthy/no-divergence tick is a pure no-op,
+// exactly like the #4901 StandbyAvailable tri-state contract.
+func (r *ContinuumReconciler) checkRejoin(
+	ctx context.Context,
+	nn types.NamespacedName,
+	reader *cnpg.Reader,
+	namespace string,
+	primaryName string, primaryStatus cnpg.Status,
+	replicaName string, replicaStatus cnpg.Status,
+) {
+	key := nn.String()
+	r.activeContinuumsMu.Lock()
+	g, ok := r.activeContinuums[key]
+	var prior switchover.RejoinState
+	if ok {
+		prior = g.rejoinState
+	}
+	r.activeContinuumsMu.Unlock()
+	if !ok {
+		// No per-CR goroutine registered (shouldn't happen — checkRejoin
+		// is only called FROM that goroutine — but never guess/panic).
+		return
+	}
+
+	seq := &switchover.Sequencer{CNPG: reader, Now: r.Now}
+	next, result := seq.CheckRejoin(ctx, namespace, primaryName, primaryStatus, replicaName, replicaStatus, prior, r.RejoinOptions)
+
+	r.activeContinuumsMu.Lock()
+	if g2, ok2 := r.activeContinuums[key]; ok2 {
+		g2.rejoinState = next
+	}
+	r.activeContinuumsMu.Unlock()
+
+	if !result.Diverged {
+		return
+	}
+
+	cr, err := r.fetchCR(ctx, nn)
+	if err == nil {
+		_ = r.patchStatus(ctx, cr, statusUpdate{
+			Reason:  "RejoinRepair",
+			Message: result.Message,
+			RejoinRepair: &rejoinRepairUpdate{
+				Target:   result.Target,
+				Attempts: next.Attempts,
+				Bounded:  next.Bounded,
+				Message:  result.Message,
+			},
+		})
+	}
+
+	if r.Audit == nil {
+		return
+	}
+	// TypeRejoinRepair for an observed/attempted episode; TypeError once
+	// Bounded — the same "operator must act" audit-type the sequencer's
+	// step-N failures use (emitError in sequence.go), because a bounded
+	// rejoin-repair IS an unresolved failure, not routine progress.
+	evType := events.TypeRejoinRepair
+	reason := "rejoin-divergence"
+	if result.Bounded {
+		evType = events.TypeError
+		reason = "rejoin-repair-bounded"
+	}
+	_ = r.Audit.Publish(ctx, events.Event{
+		Type:          evType,
+		ContinuumName: key,
+		Reason:        reason,
+		Message:       result.Message,
+		InitiatedBy:   "controller",
 	})
 }
 
@@ -874,7 +978,28 @@ type statusUpdate struct {
 	StandbyAvailable      *bool
 	StandbyReplicaCluster string
 
+	// RejoinRepair — #5125 Defect-2 step-8 outcome. nil = this pass made
+	// no rejoin-repair determination (no divergence observed) — any
+	// prior RejoinRepair condition/status is preserved. Non-nil = write
+	// status.rejoinRepair + upsert the RejoinRepair condition, mirroring
+	// the StandbyAvailable tri-state pattern above.
+	RejoinRepair *rejoinRepairUpdate
+
 	Reason  string
+	Message string
+}
+
+// rejoinRepairUpdate is the #5125 Defect-2 step-8 status projection.
+type rejoinRepairUpdate struct {
+	// Target is the Cluster CR name step-8 is (re-)cloning.
+	Target string
+	// Attempts is the re-clone attempt count issued so far for the
+	// current divergence episode.
+	Attempts int
+	// Bounded — true once MaxAttempts is exhausted without converging;
+	// fail-loud, awaiting operator intervention.
+	Bounded bool
+	// Message is the human-readable detail surfaced on the condition.
 	Message string
 }
 
@@ -958,6 +1083,11 @@ func (r *ContinuumReconciler) patchStatus(ctx context.Context, cr *unstructured.
 			if t == "StandbyAvailable" && su.StandbyAvailable != nil {
 				continue
 			}
+			// #5125 Defect-2: same preserve-unless-rewriting contract for
+			// the RejoinRepair condition.
+			if t == "RejoinRepair" && su.RejoinRepair != nil {
+				continue
+			}
 			conds = append(conds, c)
 		}
 	}
@@ -1011,6 +1141,37 @@ func (r *ContinuumReconciler) patchStatus(ctx context.Context, cr *unstructured.
 			cond["message"] = fmt.Sprintf("required synchronous hot-standby (cnpg-pair replica cluster %q) is unreachable; synchronous replication has no standby to acknowledge commits so writes stall and RPO=0 durability is at risk", su.StandbyReplicaCluster)
 		}
 		conds = append(conds, cond)
+	}
+	// #5125 Defect-2 — surface step-8's re-clone-on-divergence outcome.
+	// Only written when this pass made a determination (a divergence was
+	// observed); a healthy/no-divergence pass leaves any prior condition
+	// untouched (preserve-unless-rewriting, same contract as
+	// StandbyAvailable above).
+	if su.RejoinRepair != nil {
+		rr := su.RejoinRepair
+		status["rejoinRepair"] = map[string]interface{}{
+			"target":   rr.Target,
+			"attempts": int64(rr.Attempts),
+			"bounded":  rr.Bounded,
+			"message":  rr.Message,
+			"at":       r.now().UTC().Format(time.RFC3339),
+		}
+		// Unknown while an attempt is in flight / converging (neither
+		// proven-healthy nor proven-failed yet); False only once Bounded
+		// (definitively did not converge — operator intervention needed).
+		condStatus := "Unknown"
+		reason := "RejoinRepairAttempted"
+		if rr.Bounded {
+			condStatus = "False"
+			reason = "RejoinRepairBounded"
+		}
+		conds = append(conds, map[string]interface{}{
+			"type":               "RejoinRepair",
+			"status":             condStatus,
+			"reason":             reason,
+			"message":            rr.Message,
+			"lastTransitionTime": r.now().UTC().Format(time.RFC3339),
+		})
 	}
 	status["conditions"] = conds
 	latest.Object["status"] = status

--- a/core/controllers/continuum/internal/controller/rejoin_5125_test.go
+++ b/core/controllers/continuum/internal/controller/rejoin_5125_test.go
@@ -1,0 +1,201 @@
+// Tests for #5125 Defect-2 — step-8 re-clone-on-divergence wiring at
+// the controller level: checkRejoin must patch the CR status +
+// (for a bounded/failed episode) emit a continuum-error audit event,
+// and must be a complete no-op on a healthy rejoin.
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/events"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/switchover"
+)
+
+func clusterGVKForTest() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"}
+}
+
+// newDivergedPair builds a cnpg-pair where the replica half is
+// un-Ready and reports a TimelineID strictly ahead of the (Ready)
+// primary — the #5125 Defect-2 divergence shape.
+func newDivergedPair(ns, pair string, replicaTimeline, primaryTimeline int) (*unstructured.Unstructured, *unstructured.Unstructured) {
+	primary := &unstructured.Unstructured{}
+	primary.SetGroupVersionKind(clusterGVKForTest())
+	primary.SetNamespace(ns)
+	primary.SetName(pair + "-primary")
+	primary.SetLabels(map[string]string{cnpg.PairLabel: pair, cnpg.PairRoleLabel: cnpg.RolePrimary})
+	_ = unstructured.SetNestedField(primary.Object, int64(primaryTimeline), "status", "timelineID")
+	_ = unstructured.SetNestedSlice(primary.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+
+	replica := &unstructured.Unstructured{}
+	replica.SetGroupVersionKind(clusterGVKForTest())
+	replica.SetNamespace(ns)
+	replica.SetName(pair + "-replica")
+	replica.SetLabels(map[string]string{cnpg.PairLabel: pair, cnpg.PairRoleLabel: cnpg.RoleReplica})
+	_ = unstructured.SetNestedField(replica.Object, true, "spec", "replica", "enabled")
+	_ = unstructured.SetNestedField(replica.Object, int64(replicaTimeline), "status", "timelineID")
+	// No Ready condition — un-Ready (crash-looping walreceiver).
+
+	return primary, replica
+}
+
+// TestCheckRejoin_ControllerWiring_PatchesStatusAndAudits confirms the
+// controller-level plumbing: on a diverged pair, checkRejoin patches
+// status.rejoinRepair + the RejoinRepair condition, and (since a
+// single low MaxAttempts bounds almost immediately) eventually emits a
+// continuum-error audit once bounded.
+func TestCheckRejoin_ControllerWiring_PatchesStatusAndAudits(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "cnpg", "demo"
+	cr := newTestContinuumCR(ns, "dr", "hw-a", []string{"hw-b"}, "in-memory")
+	primary, replicaObj := newDivergedPair(ns, pair, 3, 2)
+	r, rec, _ := newReconciler(t, cr, primary, replicaObj)
+	r.RejoinOptions = switchover.RejoinOptions{MaxAttempts: 1, Cooldown: time.Minute}
+	// Controllable clock so we can deterministically cross the (single
+	// attempt's) backoff window between tick 1 and tick 2 without a
+	// real sleep.
+	clock := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	r.Now = func() time.Time { return clock }
+
+	nn := types.NamespacedName{Namespace: ns, Name: "dr"}
+	key := nn.String()
+	r.activeContinuumsMu.Lock()
+	r.activeContinuums[key] = &continuumGoroutine{}
+	r.activeContinuumsMu.Unlock()
+
+	reader := r.cnpgReader()
+	primaryStatus, _, err := reader.Get(context.Background(), ns, pair+"-primary")
+	if err != nil {
+		t.Fatalf("Get primary: %v", err)
+	}
+	replicaStatus, _, err := reader.Get(context.Background(), ns, pair+"-replica")
+	if err != nil {
+		t.Fatalf("Get replica: %v", err)
+	}
+
+	// Tick 1 — issues the (only, MaxAttempts=1) reclone attempt.
+	r.checkRejoin(context.Background(), nn, reader, ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus)
+
+	got, err := r.Dyn.Resource(ContinuumGVR).Namespace(ns).Get(context.Background(), "dr", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR: %v", err)
+	}
+	target, _, _ := unstructured.NestedString(got.Object, "status", "rejoinRepair", "target")
+	if target != pair+"-replica" {
+		t.Errorf("status.rejoinRepair.target = %q, want %q", target, pair+"-replica")
+	}
+	attempts, _, _ := unstructured.NestedInt64(got.Object, "status", "rejoinRepair", "attempts")
+	if attempts != 1 {
+		t.Errorf("status.rejoinRepair.attempts = %d, want 1", attempts)
+	}
+
+	// Tick 2 — the reclone wiped the replica's status, so a plain
+	// re-Get would show no divergence. Simulate the persistent-failure
+	// case (reclone didn't fix it) by re-injecting the same divergence,
+	// which with MaxAttempts=1 must now bound + fail loud.
+	replicaAfter, err := r.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Get(context.Background(), pair+"-replica", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get replica post-reclone: %v", err)
+	}
+	_ = unstructured.SetNestedField(replicaAfter.Object, int64(3), "status", "timelineID")
+	if _, err := r.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Update(context.Background(), replicaAfter, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update replica: %v", err)
+	}
+	replicaStatus, _, err = reader.Get(context.Background(), ns, pair+"-replica")
+	if err != nil {
+		t.Fatalf("re-Get replica: %v", err)
+	}
+
+	// Advance the clock past the (single attempt's) backoff window
+	// before the second tick, so the MaxAttempts cap — not the cooldown
+	// gate — is what fires this time.
+	clock = clock.Add(2 * time.Minute)
+
+	r.checkRejoin(context.Background(), nn, reader, ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus)
+
+	got, err = r.Dyn.Resource(ContinuumGVR).Namespace(ns).Get(context.Background(), "dr", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR (2): %v", err)
+	}
+	bounded, _, _ := unstructured.NestedBool(got.Object, "status", "rejoinRepair", "bounded")
+	if !bounded {
+		t.Errorf("status.rejoinRepair.bounded = %v, want true after MaxAttempts=1 exhausted", bounded)
+	}
+	conds, _, _ := unstructured.NestedSlice(got.Object, "status", "conditions")
+	foundBoundedCond := false
+	for _, c := range conds {
+		cm, _ := c.(map[string]interface{})
+		if cm["type"] == "RejoinRepair" {
+			if cm["status"] != "False" || cm["reason"] != "RejoinRepairBounded" {
+				t.Errorf("RejoinRepair condition = %+v, want status=False reason=RejoinRepairBounded", cm)
+			}
+			foundBoundedCond = true
+		}
+	}
+	if !foundBoundedCond {
+		t.Errorf("expected a RejoinRepair condition on the CR, got conditions=%v", conds)
+	}
+
+	// A bounded episode must audit as continuum-error (operator must
+	// act), not the routine continuum-rejoin-repair type.
+	errEvents := rec.EventsByType(events.TypeError)
+	if len(errEvents) == 0 {
+		t.Errorf("expected at least one continuum-error audit event on bounded rejoin-repair")
+	}
+}
+
+// TestCheckRejoin_ControllerWiring_HealthyRejoin_NoStatusChange confirms
+// a healthy (Ready) standby never touches the CR status/conditions nor
+// emits any audit event.
+func TestCheckRejoin_ControllerWiring_HealthyRejoin_NoStatusChange(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "cnpg", "demo"
+	cr := newTestContinuumCR(ns, "dr", "hw-a", []string{"hw-b"}, "in-memory")
+	primary, replicaObj := newDivergedPair(ns, pair, 3, 2)
+	// Flip the replica to Ready — a healthy rejoin, despite the (now
+	// irrelevant) timeline gap.
+	_ = unstructured.SetNestedSlice(replicaObj.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+	r, rec, _ := newReconciler(t, cr, primary, replicaObj)
+
+	nn := types.NamespacedName{Namespace: ns, Name: "dr"}
+	key := nn.String()
+	r.activeContinuumsMu.Lock()
+	r.activeContinuums[key] = &continuumGoroutine{}
+	r.activeContinuumsMu.Unlock()
+
+	reader := r.cnpgReader()
+	primaryStatus, _, _ := reader.Get(context.Background(), ns, pair+"-primary")
+	replicaStatus, _, _ := reader.Get(context.Background(), ns, pair+"-replica")
+
+	before, err := r.Dyn.Resource(ContinuumGVR).Namespace(ns).Get(context.Background(), "dr", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR: %v", err)
+	}
+	beforeRV := before.GetResourceVersion()
+
+	r.checkRejoin(context.Background(), nn, reader, ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus)
+
+	after, err := r.Dyn.Resource(ContinuumGVR).Namespace(ns).Get(context.Background(), "dr", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR after: %v", err)
+	}
+	if after.GetResourceVersion() != beforeRV {
+		t.Errorf("CR mutated on a healthy rejoin — resourceVersion changed %q -> %q", beforeRV, after.GetResourceVersion())
+	}
+	if len(rec.EventsByType(events.TypeRejoinRepair)) != 0 || len(rec.EventsByType(events.TypeError)) != 0 {
+		t.Errorf("expected NO rejoin-repair or error audit events on a healthy rejoin")
+	}
+}

--- a/core/controllers/continuum/internal/events/events.go
+++ b/core/controllers/continuum/internal/events/events.go
@@ -45,6 +45,9 @@ const Subject = "catalyst.audit"
 //
 // Schemas for the new types are documented in
 // products/continuum/DESIGN.md §"Slice F audit-type schemas".
+//
+// #5125 Defect-2 adds one more: TypeRejoinRepair — step-8's
+// re-clone-on-divergence outcome (attempted / bounded-fail-loud).
 const (
 	TypeSwitchover        = "continuum-switchover"
 	TypeFailbackPending   = "continuum-failback-pending"
@@ -60,6 +63,9 @@ const (
 	TypeCRCreated      = "continuum-cr-created"
 	TypeConfigChanged  = "continuum-config-changed"
 	TypeLeaseCollision = "continuum-lease-collision"
+
+	// #5125 Defect-2 addition — step-8 rejoin-repair outcome.
+	TypeRejoinRepair = "continuum-rejoin-repair"
 )
 
 // AuditTypes is the canonical list — used by tests + by U-DR-1's
@@ -80,6 +86,7 @@ var AuditTypes = []string{
 	TypeCRCreated,
 	TypeConfigChanged,
 	TypeLeaseCollision,
+	TypeRejoinRepair,
 }
 
 // IsValidType reports whether `t` is one of the 9 reserved values.

--- a/core/controllers/continuum/internal/events/events_test.go
+++ b/core/controllers/continuum/internal/events/events_test.go
@@ -14,9 +14,10 @@ func jsonUnmarshal(b []byte, v any) error { return json.Unmarshal(b, v) }
 
 func TestAuditTypes_Coverage(t *testing.T) {
 	t.Parallel()
-	// K-Cont-2 reserved 9; slice F (#1101 F-1) added 3 more = 12.
-	if len(AuditTypes) != 12 {
-		t.Fatalf("expected 12 audit types, got %d", len(AuditTypes))
+	// K-Cont-2 reserved 9; slice F (#1101 F-1) added 3 more; #5125
+	// Defect-2 added 1 more (TypeRejoinRepair) = 13.
+	if len(AuditTypes) != 13 {
+		t.Fatalf("expected 13 audit types, got %d", len(AuditTypes))
 	}
 	for _, want := range []string{
 		TypeSwitchover, TypeFailbackPending, TypeFailbackCompleted,
@@ -24,6 +25,8 @@ func TestAuditTypes_Coverage(t *testing.T) {
 		TypeCNPGPromotable, TypeError, TypeReconcileSuccess,
 		// F-1 additions
 		TypeCRCreated, TypeConfigChanged, TypeLeaseCollision,
+		// #5125 Defect-2 addition
+		TypeRejoinRepair,
 	} {
 		if !IsValidType(want) {
 			t.Errorf("expected %q to be valid", want)
@@ -89,6 +92,41 @@ func TestSliceFAuditTypes_Roundtrip(t *testing.T) {
 				t.Errorf("ContinuumName drift: got %q want %q", got.ContinuumName, e.ContinuumName)
 			}
 		})
+	}
+}
+
+// TestRejoinRepairAuditType_StringValueAndRoundtrip — #5125 Defect-2:
+// pin the wire string value + confirm the Event JSON round-trips, same
+// coverage the F-1 additions got above.
+func TestRejoinRepairAuditType_StringValueAndRoundtrip(t *testing.T) {
+	t.Parallel()
+	if TypeRejoinRepair != "continuum-rejoin-repair" {
+		t.Fatalf("audit-type constant drift: want %q got %q", "continuum-rejoin-repair", TypeRejoinRepair)
+	}
+	e := Event{
+		Type:            TypeRejoinRepair,
+		ContinuumName:   "demo/cr1",
+		ApplicationName: "demo/app1",
+		FromPrimary:     "fsn",
+		ToPrimary:       "hel",
+		Reason:          "rejoin-divergence",
+		Message:         "re-clone attempt 1/3 issued",
+		InitiatedBy:     "controller",
+		Timestamp:       "2026-07-18T01:02:03Z",
+	}
+	b, err := MarshalEvent(e)
+	if err != nil {
+		t.Fatalf("MarshalEvent: %v", err)
+	}
+	if !strings.Contains(string(b), `"type":"`+TypeRejoinRepair+`"`) {
+		t.Errorf("missing %q in JSON: %s", TypeRejoinRepair, b)
+	}
+	var got Event
+	if err := jsonUnmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Type != TypeRejoinRepair || got.ContinuumName != e.ContinuumName {
+		t.Errorf("roundtrip drift: got %+v", got)
 	}
 }
 

--- a/core/controllers/continuum/internal/switchover/rejoin.go
+++ b/core/controllers/continuum/internal/switchover/rejoin.go
@@ -1,0 +1,290 @@
+// Step-8 — re-clone-on-divergence (#5125 Defect-2).
+//
+// The 7-step Sequencer (sequence.go) drives a NEW switchover
+// (validate-lease → cordon → drain → dns → swap-lease → promote →
+// audit). It has no opinion about what happens LATER, when a region
+// that was down resumes and its cnpg-pair half tries to rejoin as the
+// standby of whichever half was promoted during the outage.
+//
+// The hw256 G12 region-kill walk (2026-07-15) proved that rejoin can
+// wedge: on region-a resume, its cnpg-pair Cluster CR (now flipped to
+// spec.replica.enabled=true by the switchover's promote step) tries to
+// stream from the newly-promoted primary, and CNPG's walreceiver
+// crash-loops with `highest timeline N of the primary is behind
+// recovery timeline N+1` — the standby's own recovery history has
+// advanced past what the primary can serve (typically because the
+// standby itself was briefly promoted, or did its own local crash
+// recovery, while the primary was unreachable). A plain reconnect can
+// never resolve this; CNPG requires a full re-bootstrap. The proven
+// manual heal is "delete the replica Cluster CR + re-apply" (~2-3
+// min/cluster to pg_basebackup back to a consistent state).
+//
+// CheckRejoin is that heal, automated + bounded. It is NOT part of
+// Execute()'s atomic step chain — it is invoked once per reconcile
+// tick (continuum_controller.go's runPerCR, alongside the existing
+// #4901 standby-availability check, reusing the SAME FindPair + Get
+// calls) so it naturally only becomes live once region-a's own
+// cnpg-pair Cluster CR status is observable again post-resume.
+package switchover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+)
+
+// DefaultRejoinMaxAttempts + DefaultRejoinCooldown — see RejoinOptions.
+const (
+	DefaultRejoinMaxAttempts = 3
+	DefaultRejoinCooldown    = 3 * time.Minute
+)
+
+// RejoinOptions configures step-8. Zero-value is filled by Defaults().
+type RejoinOptions struct {
+	// MaxAttempts caps how many re-clone attempts step-8 will issue for
+	// a single divergence episode before giving up and failing loud
+	// (RejoinResult.Bounded=true). Default 3.
+	MaxAttempts int
+
+	// Cooldown is the minimum wait between attempts, scaled linearly by
+	// the attempt number (attempt 1 fires immediately on detection;
+	// attempt 2 waits ≥1×Cooldown after attempt 1; attempt 3 waits
+	// ≥2×Cooldown after attempt 2; …) — simple backoff so a re-clone
+	// that takes the proven ~2-3 min to converge is never interrupted
+	// by another delete+recreate on the very next reconcile tick.
+	// Default 3 minutes.
+	Cooldown time.Duration
+}
+
+// Defaults applies missing-field defaults. Returns a copy.
+func (o RejoinOptions) Defaults() RejoinOptions {
+	out := o
+	if out.MaxAttempts <= 0 {
+		out.MaxAttempts = DefaultRejoinMaxAttempts
+	}
+	if out.Cooldown <= 0 {
+		out.Cooldown = DefaultRejoinCooldown
+	}
+	return out
+}
+
+// RejoinState is the bookkeeping CheckRejoin carries ACROSS reconcile
+// ticks for one Continuum CR. The caller (continuum_controller.go)
+// keeps this in the per-CR goroutine's in-memory state (the same
+// session-scoped pattern already used for the F-1 spec-fingerprint
+// drift check) and mirrors it onto the CR's status for operator
+// visibility.
+type RejoinState struct {
+	// Attempts is the number of re-clone attempts issued so far for the
+	// CURRENT divergence episode. Reset to 0 the moment the standby
+	// stops reporting divergence (healthy rejoin, or a fresh re-clone
+	// wiped its status).
+	Attempts int
+
+	// LastAttemptAt is the wall-clock time of the most recent attempt.
+	// Zero means no attempt has been issued yet.
+	LastAttemptAt time.Time
+
+	// Bounded is true once Attempts has exhausted MaxAttempts without
+	// the standby converging. Once true, CheckRejoin stops issuing new
+	// attempts automatically — it fails loud (RejoinResult.Err set)
+	// every subsequent tick until an operator intervenes and the
+	// standby's status changes (which naturally clears Bounded, since a
+	// fresh RejoinState is returned once DetectDivergence stops firing).
+	Bounded bool
+
+	// Target is the Cluster CR name step-8 last (re-)cloned. Surfaced
+	// on the CR status for observability.
+	Target string
+}
+
+// RejoinResult is what CheckRejoin returns for THIS tick — the caller
+// uses it to decide whether to patch status / emit an audit event.
+type RejoinResult struct {
+	// Diverged reports whether DetectDivergence fired this tick (even
+	// if no new attempt was issued because we're inside the cooldown
+	// window, or already Bounded).
+	Diverged bool
+
+	// Attempted is true iff this tick actually issued a
+	// CNPG.RecloneCluster call.
+	Attempted bool
+
+	// Bounded is true iff MaxAttempts is now exhausted — fail-loud,
+	// operator intervention required.
+	Bounded bool
+
+	// Target is the Cluster CR name involved (standby side).
+	Target string
+
+	// Message is a human-readable summary for the audit/status message.
+	Message string
+
+	// Err is non-nil when an attempted re-clone failed, OR when Bounded
+	// just became true. Never set for the plain "no divergence" /
+	// "within cooldown" cases — those are healthy no-ops, not errors.
+	Err error
+}
+
+// DetectDivergence decides whether the CR CURRENTLY ACTING AS STANDBY
+// of a cnpg-pair (the CR reporting spec.replica.enabled=true, i.e.
+// Status.IsReplicaCluster) has left the timeline history the CR
+// CURRENTLY ACTING AS PRIMARY (IsReplicaCluster=false) can serve.
+//
+// Deliberately narrow gate — this must NEVER fire on an ordinary
+// transient reconnect blip or ordinary lag:
+//
+//  1. Exactly one of the two inputs must be acting as standby right
+//     now (the other must be acting as primary). Both-standby /
+//     both-primary / unresolved states are a mid-switchover or
+//     malformed pair — never guess; report no divergence.
+//  2. The standby must be un-Ready. A Ready standby is, by definition,
+//     successfully streaming — that IS a healthy rejoin, regardless of
+//     what its timeline history says.
+//  3. Both sides must have reported a TimelineID (CNPG populates this
+//     once it has enough status to say; a fresh/absent value means
+//     "insufficient data", not "healthy" and not "diverged" — never
+//     guess on absent data).
+//  4. The standby's TimelineID must be STRICTLY GREATER than the
+//     primary's. This is the literal structured form of "highest
+//     timeline of the primary is behind the standby's recovery
+//     timeline" and is exactly what separates a genuine re-clone-
+//     needed divergence from an ordinary catch-up-in-progress standby
+//     (whose timeline is behind or equal, and which will heal itself
+//     once it catches up).
+//
+// `aName`/`bName` identify which of the two STATUS inputs the caller
+// should re-clone if this reports diverged=true — the caller only
+// knows them by their STATIC pair-label role ("primary-labeled" /
+// "replica-labeled" per cnpg.PairRoleLabel), which does NOT necessarily
+// match which one is playing which CNPG role after a failover, so the
+// live spec.replica.enabled flag (not the label) decides.
+func DetectDivergence(aName string, aStatus cnpg.Status, bName string, bStatus cnpg.Status) (target string, diverged bool, reason string) {
+	switch {
+	case aStatus.IsReplicaCluster && !bStatus.IsReplicaCluster:
+		return evalDivergence(aName, aStatus, bName, bStatus)
+	case bStatus.IsReplicaCluster && !aStatus.IsReplicaCluster:
+		return evalDivergence(bName, bStatus, aName, aStatus)
+	default:
+		// Both replica, both primary, or some other ambiguous
+		// combination (mid-switchover in-flight, malformed pair). Never
+		// guess — no-op.
+		return "", false, ""
+	}
+}
+
+func evalDivergence(standbyName string, standby cnpg.Status, primaryName string, primary cnpg.Status) (string, bool, string) {
+	if standby.Ready {
+		// Healthy rejoin — the standby is successfully streaming.
+		return "", false, ""
+	}
+	if !standby.HasTimelineID || !primary.HasTimelineID {
+		// Insufficient data to judge — could be a fresh/bootstrapping
+		// CR that hasn't populated status.timelineID yet. Never guess.
+		return "", false, ""
+	}
+	if standby.TimelineID <= primary.TimelineID {
+		// Un-Ready but NOT ahead of the primary's timeline — an
+		// ordinary transient reconnect / catch-up-in-progress standby,
+		// not a divergence. Must NOT trigger a re-clone.
+		return "", false, ""
+	}
+	reason := fmt.Sprintf(
+		"standby %q not Ready with TimelineID=%d strictly ahead of primary %q TimelineID=%d — walreceiver timeline-divergence (highest timeline of the primary is behind the standby's recovery timeline); re-clone required",
+		standbyName, standby.TimelineID, primaryName, primary.TimelineID,
+	)
+	return standbyName, true, reason
+}
+
+// CheckRejoin is step-8. Call it once per reconcile tick with the
+// freshest (primaryName, primaryStatus, replicaName, replicaStatus) —
+// the SAME values continuum_controller.go's runPerCR already computes
+// for the #4901 standby-availability check, so no extra CNPG API calls
+// are needed.
+//
+// Returns the updated RejoinState (the caller persists it for the next
+// tick) and a RejoinResult describing what happened this tick.
+//
+// Bounded + backoff: an already-Bounded prior state short-circuits to
+// fail-loud without touching the cluster again. A fresh (non-Bounded)
+// divergence outside the cooldown window issues ONE RecloneCluster
+// call; a divergence still inside the cooldown window is a no-op this
+// tick (waiting for the in-flight re-clone to converge). The state
+// resets to zero the instant DetectDivergence stops firing (healthy
+// rejoin, OR the re-clone's freshly-recreated CR has wiped its own
+// status so there's nothing to judge yet).
+func (s *Sequencer) CheckRejoin(ctx context.Context, namespace string, primaryName string, primaryStatus cnpg.Status, replicaName string, replicaStatus cnpg.Status, prior RejoinState, opts RejoinOptions) (RejoinState, RejoinResult) {
+	opts = opts.Defaults()
+	result := RejoinResult{}
+
+	target, diverged, reason := DetectDivergence(primaryName, primaryStatus, replicaName, replicaStatus)
+	if !diverged {
+		// No divergence this tick — reset any prior episode state
+		// (including a prior Bounded fail-loud latch: the standby
+		// converged, or a fresh re-clone reset its status).
+		return RejoinState{}, result
+	}
+
+	result.Diverged = true
+	result.Target = target
+	result.Message = reason
+
+	if prior.Bounded && prior.Target == target {
+		result.Bounded = true
+		result.Err = fmt.Errorf("rejoin re-clone of %q did not converge after %d attempts: %s", target, opts.MaxAttempts, reason)
+		result.Message = result.Err.Error()
+		return prior, result
+	}
+
+	// A divergence on a DIFFERENT target than the prior episode is a
+	// fresh episode — never carry over another CR's bounded/attempt
+	// state.
+	state := prior
+	if prior.Target != target {
+		state = RejoinState{Target: target}
+	}
+
+	now := s.now()
+	if !state.LastAttemptAt.IsZero() {
+		backoff := time.Duration(state.Attempts) * opts.Cooldown
+		if now.Sub(state.LastAttemptAt) < backoff {
+			result.Message = fmt.Sprintf("%s (within backoff window, attempt %d/%d already issued at %s)", reason, state.Attempts, opts.MaxAttempts, state.LastAttemptAt.UTC().Format(time.RFC3339))
+			return state, result
+		}
+	}
+
+	nextAttempt := state.Attempts + 1
+	if nextAttempt > opts.MaxAttempts {
+		state.Bounded = true
+		result.Bounded = true
+		result.Err = fmt.Errorf("rejoin re-clone of %q did not converge after %d attempts: %s", target, opts.MaxAttempts, reason)
+		result.Message = result.Err.Error()
+		return state, result
+	}
+
+	if s.CNPG == nil {
+		result.Err = errors.New("rejoin re-clone: CNPG reader is required")
+		result.Message = result.Err.Error()
+		return state, result
+	}
+
+	if err := s.CNPG.RecloneCluster(ctx, namespace, target); err != nil {
+		// The attempt still counts (bounded backoff must advance even
+		// on failure, or a persistently-erroring cluster would retry
+		// every tick forever).
+		state.Attempts = nextAttempt
+		state.LastAttemptAt = now
+		result.Err = fmt.Errorf("re-clone attempt %d/%d of %q failed: %w", nextAttempt, opts.MaxAttempts, target, err)
+		result.Message = result.Err.Error()
+		return state, result
+	}
+
+	state.Attempts = nextAttempt
+	state.LastAttemptAt = now
+	result.Attempted = true
+	result.Message = fmt.Sprintf("re-clone attempt %d/%d issued for %q (delete+recreate Cluster CR to force pg_basebackup): %s", nextAttempt, opts.MaxAttempts, target, reason)
+	return state, result
+}

--- a/core/controllers/continuum/internal/switchover/rejoin_test.go
+++ b/core/controllers/continuum/internal/switchover/rejoin_test.go
@@ -1,0 +1,417 @@
+// Tests for #5125 Defect-2 — step-8 re-clone-on-divergence.
+
+package switchover
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+)
+
+// readyStatus + notReadyStatus are small builders keeping the table
+// tests below readable.
+func readyStatus(replica bool, timeline int) cnpg.Status {
+	return cnpg.Status{Ready: true, IsReplicaCluster: replica, TimelineID: timeline, HasTimelineID: timeline > 0}
+}
+
+func notReadyStatus(replica bool, timeline int) cnpg.Status {
+	return cnpg.Status{Ready: false, IsReplicaCluster: replica, TimelineID: timeline, HasTimelineID: true}
+}
+
+func TestDetectDivergence(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		a            cnpg.Status
+		b            cnpg.Status
+		wantDiverged bool
+		wantTarget   string
+	}{
+		{
+			name:         "healthy steady state — standby Ready streaming",
+			a:            cnpg.Status{IsReplicaCluster: false, Ready: true, HasTimelineID: true, TimelineID: 2},
+			b:            readyStatus(true, 2),
+			wantDiverged: false,
+		},
+		{
+			name:         "clean initial failover — standby behind, not yet Ready",
+			a:            notReadyStatus(true, 1), // old primary, now standby, stale TL1
+			b:            cnpg.Status{IsReplicaCluster: false, Ready: true, HasTimelineID: true, TimelineID: 2},
+			wantDiverged: false,
+		},
+		{
+			name:         "ordinary catch-up — standby not ready, timeline EQUAL",
+			a:            notReadyStatus(true, 2),
+			b:            cnpg.Status{IsReplicaCluster: false, Ready: true, HasTimelineID: true, TimelineID: 2},
+			wantDiverged: false,
+		},
+		{
+			name:         "#5125 Defect-2 — standby not ready, timeline STRICTLY AHEAD of primary",
+			a:            notReadyStatus(true, 3), // returning region-a, recovery TL3
+			b:            cnpg.Status{IsReplicaCluster: false, Ready: true, HasTimelineID: true, TimelineID: 2},
+			wantDiverged: true,
+			wantTarget:   "a",
+		},
+		{
+			name:         "divergence on the OTHER physical side (role flip)",
+			a:            cnpg.Status{IsReplicaCluster: false, Ready: true, HasTimelineID: true, TimelineID: 2},
+			b:            notReadyStatus(true, 3),
+			wantDiverged: true,
+			wantTarget:   "b",
+		},
+		{
+			name:         "both acting as standby (mid-switchover/malformed) — never guess",
+			a:            notReadyStatus(true, 3),
+			b:            notReadyStatus(true, 1),
+			wantDiverged: false,
+		},
+		{
+			name:         "both acting as primary — never guess",
+			a:            readyStatus(false, 2),
+			b:            readyStatus(false, 2),
+			wantDiverged: false,
+		},
+		{
+			name:         "missing TimelineID data — never guess",
+			a:            cnpg.Status{IsReplicaCluster: true, Ready: false},
+			b:            cnpg.Status{IsReplicaCluster: false, Ready: true},
+			wantDiverged: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			target, diverged, reason := DetectDivergence("a", tc.a, "b", tc.b)
+			if diverged != tc.wantDiverged {
+				t.Fatalf("diverged = %v, want %v (reason=%q)", diverged, tc.wantDiverged, reason)
+			}
+			if diverged && target != tc.wantTarget {
+				t.Errorf("target = %q, want %q", target, tc.wantTarget)
+			}
+			if diverged && reason == "" {
+				t.Errorf("expected non-empty reason when diverged")
+			}
+		})
+	}
+}
+
+// newCheckRejoinSequencer builds a minimal Sequencer wired to a fake
+// CNPG dynamic client containing one cluster-pair — enough for
+// CheckRejoin, which only touches s.CNPG + s.Now.
+func newCheckRejoinSequencer(t *testing.T, objs ...runtime.Object) (*Sequencer, *cnpg.Reader) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMap(), objs...)
+	reader := cnpg.NewReader(dyn)
+	now := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	seq := &Sequencer{
+		CNPG: reader,
+		Now:  func() time.Time { return now },
+	}
+	return seq, reader
+}
+
+// newDivergedReplicaCluster builds a cnpg-pair replica Cluster CR that
+// is un-Ready and reports a TimelineID strictly ahead of the primary —
+// the #5125 Defect-2 divergence shape.
+func newDivergedReplicaCluster(ns, pair string, timeline int) *unstructured.Unstructured {
+	replica := &unstructured.Unstructured{}
+	replica.SetGroupVersionKind(schema.GroupVersionKind{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"})
+	replica.SetNamespace(ns)
+	replica.SetName(pair + "-replica")
+	replica.SetLabels(map[string]string{cnpg.PairLabel: pair, cnpg.PairRoleLabel: cnpg.RoleReplica})
+	_ = unstructured.SetNestedField(replica.Object, true, "spec", "replica", "enabled")
+	_ = unstructured.SetNestedField(replica.Object, int64(timeline), "status", "timelineID")
+	// No Ready condition — un-Ready.
+	return replica
+}
+
+func newHealthyPrimaryCluster(ns, pair string, timeline int) *unstructured.Unstructured {
+	primary := &unstructured.Unstructured{}
+	primary.SetGroupVersionKind(schema.GroupVersionKind{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"})
+	primary.SetNamespace(ns)
+	primary.SetName(pair + "-primary")
+	primary.SetLabels(map[string]string{cnpg.PairLabel: pair, cnpg.PairRoleLabel: cnpg.RolePrimary})
+	_ = unstructured.SetNestedField(primary.Object, int64(timeline), "status", "timelineID")
+	_ = unstructured.SetNestedSlice(primary.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+	return primary
+}
+
+// TestCheckRejoin_DivergenceDetected_IssuesReclone — case (a) from the
+// dispatch: divergence detected on the FIRST tick issues an immediate
+// re-clone attempt (RecloneCluster called, Attempts=1).
+func TestCheckRejoin_DivergenceDetected_IssuesReclone(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "ns", "demo"
+	replica := newDivergedReplicaCluster(ns, pair, 3)
+	primary := newHealthyPrimaryCluster(ns, pair, 2)
+	seq, reader := newCheckRejoinSequencer(t, primary, replica)
+
+	primaryStatus, _, err := reader.Get(context.Background(), ns, pair+"-primary")
+	if err != nil {
+		t.Fatalf("Get primary: %v", err)
+	}
+	replicaStatus, _, err := reader.Get(context.Background(), ns, pair+"-replica")
+	if err != nil {
+		t.Fatalf("Get replica: %v", err)
+	}
+
+	next, result := seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, RejoinState{}, RejoinOptions{})
+
+	if !result.Diverged {
+		t.Fatalf("expected Diverged=true, got result=%+v", result)
+	}
+	if !result.Attempted {
+		t.Fatalf("expected Attempted=true (re-clone issued on first detection), got result=%+v", result)
+	}
+	if result.Bounded {
+		t.Fatalf("expected Bounded=false on first attempt, got result=%+v", result)
+	}
+	if next.Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1", next.Attempts)
+	}
+	if next.Target != pair+"-replica" {
+		t.Errorf("Target = %q, want %q", next.Target, pair+"-replica")
+	}
+
+	// Confirm the reclone actually happened — the Cluster CR's status
+	// should be wiped (fresh object).
+	got, err := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Get(context.Background(), pair+"-replica", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get post-reclone: %v", err)
+	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(got.Object, "status", "timelineID"); found {
+		t.Errorf("expected status wiped by reclone, still present: %v", got.Object["status"])
+	}
+	// spec.replica.enabled must survive (still meant to be the standby).
+	en, _, _ := unstructured.NestedBool(got.Object, "spec", "replica", "enabled")
+	if !en {
+		t.Errorf("expected spec.replica.enabled=true preserved across reclone")
+	}
+}
+
+// TestCheckRejoin_HealthyRejoin_NoOp — case (b): a Ready standby (even
+// with the SAME or a divergent-looking timeline) must NEVER trigger a
+// reclone. Confirms the Cluster CR is untouched.
+func TestCheckRejoin_HealthyRejoin_NoOp(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "ns", "demo"
+	replica := &unstructured.Unstructured{}
+	replica.SetGroupVersionKind(schema.GroupVersionKind{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"})
+	replica.SetNamespace(ns)
+	replica.SetName(pair + "-replica")
+	replica.SetLabels(map[string]string{cnpg.PairLabel: pair, cnpg.PairRoleLabel: cnpg.RoleReplica})
+	_ = unstructured.SetNestedField(replica.Object, true, "spec", "replica", "enabled")
+	_ = unstructured.SetNestedField(replica.Object, int64(3), "status", "timelineID")
+	_ = unstructured.SetNestedSlice(replica.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+	primary := newHealthyPrimaryCluster(ns, pair, 2)
+
+	seq, reader := newCheckRejoinSequencer(t, primary, replica)
+	primaryStatus, _, _ := reader.Get(context.Background(), ns, pair+"-primary")
+	replicaStatus, _, _ := reader.Get(context.Background(), ns, pair+"-replica")
+
+	next, result := seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, RejoinState{}, RejoinOptions{})
+
+	if result.Diverged {
+		t.Fatalf("expected Diverged=false for a Ready (healthy) standby, got result=%+v", result)
+	}
+	if result.Attempted {
+		t.Fatalf("expected no reclone attempt on a healthy rejoin, got result=%+v", result)
+	}
+	if next != (RejoinState{}) {
+		t.Errorf("expected zero-value RejoinState on no-divergence, got %+v", next)
+	}
+
+	// Cluster CR must be completely untouched — same resourceVersion.
+	got, err := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Get(context.Background(), pair+"-replica", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetResourceVersion() != replica.GetResourceVersion() {
+		t.Errorf("Cluster CR resourceVersion changed (%q -> %q) — must be untouched on healthy rejoin", replica.GetResourceVersion(), got.GetResourceVersion())
+	}
+}
+
+// TestCheckRejoin_OrdinaryLag_NoOp — an un-Ready standby whose timeline
+// is BEHIND or EQUAL to the primary (ordinary catch-up / transient
+// reconnect) must not trigger a reclone either.
+func TestCheckRejoin_OrdinaryLag_NoOp(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "ns", "demo"
+	replica := newDivergedReplicaCluster(ns, pair, 2) // NOT ahead — equal to primary
+	primary := newHealthyPrimaryCluster(ns, pair, 2)
+	seq, reader := newCheckRejoinSequencer(t, primary, replica)
+	primaryStatus, _, _ := reader.Get(context.Background(), ns, pair+"-primary")
+	replicaStatus, _, _ := reader.Get(context.Background(), ns, pair+"-replica")
+
+	_, result := seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, RejoinState{}, RejoinOptions{})
+	if result.Diverged || result.Attempted {
+		t.Fatalf("expected no-op for a standby whose timeline is not AHEAD of the primary, got result=%+v", result)
+	}
+}
+
+// TestCheckRejoin_Bounded_CapsAttemptsAndFailsLoud — case (c): a
+// standby that NEVER converges (still diverging after every reclone —
+// e.g. re-clone succeeds but the underlying cause persists and status
+// somehow keeps re-reporting the SAME divergence, or simply the
+// operator hasn't fixed the root cause) must be capped at MaxAttempts
+// and then fail loud (Bounded=true, Err set) WITHOUT issuing more
+// reclone calls.
+func TestCheckRejoin_Bounded_CapsAttemptsAndFailsLoud(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "ns", "demo"
+	opts := RejoinOptions{MaxAttempts: 2, Cooldown: time.Minute}
+
+	replica := newDivergedReplicaCluster(ns, pair, 5)
+	primary := newHealthyPrimaryCluster(ns, pair, 2)
+	seq, reader := newCheckRejoinSequencer(t, primary, replica)
+	primaryStatus, _, _ := reader.Get(context.Background(), ns, pair+"-primary")
+	replicaStatus, _, _ := reader.Get(context.Background(), ns, pair+"-replica")
+
+	// Attempt 1 — immediate.
+	state, result := seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, RejoinState{}, opts)
+	if !result.Attempted || state.Attempts != 1 {
+		t.Fatalf("attempt 1: expected Attempted=true Attempts=1, got result=%+v state=%+v", result, state)
+	}
+
+	// Simulate the reclone not having fixed anything: re-populate the
+	// SAME divergence signature directly (in reality a fresh clone's
+	// status would reset; here we force the persistent-failure path).
+	if err := unstructured.SetNestedField(replica.Object, int64(5), "status", "timelineID"); err != nil {
+		t.Fatalf("re-set timelineID: %v", err)
+	}
+	if _, err := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Update(context.Background(), replica, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update replica: %v", err)
+	}
+	replicaStatus, _, _ = reader.Get(context.Background(), ns, pair+"-replica")
+
+	// Advance the clock past the attempt-1 backoff window.
+	seq.Now = func() time.Time { return time.Date(2026, 7, 18, 0, 5, 0, 0, time.UTC) }
+
+	// Attempt 2 — still within MaxAttempts.
+	state, result = seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, state, opts)
+	if !result.Attempted || state.Attempts != 2 {
+		t.Fatalf("attempt 2: expected Attempted=true Attempts=2, got result=%+v state=%+v", result, state)
+	}
+
+	if err := unstructured.SetNestedField(replica.Object, int64(5), "status", "timelineID"); err != nil {
+		t.Fatalf("re-set timelineID: %v", err)
+	}
+	if _, err := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Update(context.Background(), replica, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update replica: %v", err)
+	}
+	replicaStatus, _, _ = reader.Get(context.Background(), ns, pair+"-replica")
+	seq.Now = func() time.Time { return time.Date(2026, 7, 18, 0, 10, 0, 0, time.UTC) }
+
+	// Attempt 3 would exceed MaxAttempts=2 — must bound + fail loud,
+	// WITHOUT issuing another reclone call. Capture the resourceVersion
+	// via a fresh Get (not the stale local `replica` var) so the
+	// post-check comparison is against the ACTUAL current state.
+	preBoundCR, _ := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Get(context.Background(), pair+"-replica", metav1.GetOptions{})
+	beforeRV := preBoundCR.GetResourceVersion()
+	state, result = seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, state, opts)
+	if !state.Bounded || !result.Bounded {
+		t.Fatalf("expected Bounded=true after exceeding MaxAttempts, got state=%+v result=%+v", state, result)
+	}
+	if result.Err == nil {
+		t.Errorf("expected non-nil Err on bounded fail-loud")
+	}
+	if result.Attempted {
+		t.Errorf("expected NO reclone attempt once bounded")
+	}
+	got, _ := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Get(context.Background(), pair+"-replica", metav1.GetOptions{})
+	if got.GetResourceVersion() != beforeRV {
+		t.Errorf("Cluster CR mutated after bounding — resourceVersion changed %q -> %q", beforeRV, got.GetResourceVersion())
+	}
+
+	// A SUBSEQUENT tick (still diverged) must keep reporting bounded
+	// fail-loud without ever touching the cluster again.
+	_, result = seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, state, opts)
+	if !result.Bounded || result.Attempted {
+		t.Fatalf("expected persistent bounded fail-loud on later ticks, got result=%+v", result)
+	}
+}
+
+// TestCheckRejoin_WithinCooldown_NoOp — a divergence detected again
+// before the backoff window elapses must not issue a second reclone.
+func TestCheckRejoin_WithinCooldown_NoOp(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "ns", "demo"
+	opts := RejoinOptions{MaxAttempts: 3, Cooldown: 10 * time.Minute}
+	replica := newDivergedReplicaCluster(ns, pair, 5)
+	primary := newHealthyPrimaryCluster(ns, pair, 2)
+	seq, reader := newCheckRejoinSequencer(t, primary, replica)
+	primaryStatus, _, _ := reader.Get(context.Background(), ns, pair+"-primary")
+	replicaStatus, _, _ := reader.Get(context.Background(), ns, pair+"-replica")
+
+	state, result := seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, RejoinState{}, opts)
+	if !result.Attempted {
+		t.Fatalf("attempt 1 should fire immediately, got %+v", result)
+	}
+
+	// Re-fetch the (now reset/recreated) replica status and advance the
+	// clock by only 1 minute — well within the 10-minute cooldown.
+	replicaStatus, _, _ = reader.Get(context.Background(), ns, pair+"-replica")
+	// Force the divergence signature back (simulating the recreate not
+	// yet having converged, still un-Ready + ahead).
+	got, _ := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Get(context.Background(), pair+"-replica", metav1.GetOptions{})
+	_ = unstructured.SetNestedField(got.Object, int64(5), "status", "timelineID")
+	if _, err := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Update(context.Background(), got, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	replicaStatus, _, _ = reader.Get(context.Background(), ns, pair+"-replica")
+
+	seq.Now = func() time.Time { return time.Date(2026, 7, 18, 0, 1, 0, 0, time.UTC) }
+	rvBefore := got.GetResourceVersion()
+
+	_, result2 := seq.CheckRejoin(context.Background(), ns, pair+"-primary", primaryStatus, pair+"-replica", replicaStatus, state, opts)
+	if result2.Attempted {
+		t.Fatalf("expected no second attempt within the cooldown window, got %+v", result2)
+	}
+	if !result2.Diverged {
+		t.Errorf("expected Diverged=true to still be reported within cooldown (informational)")
+	}
+
+	afterCR, _ := reader.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Get(context.Background(), pair+"-replica", metav1.GetOptions{})
+	if afterCR.GetResourceVersion() != rvBefore {
+		t.Errorf("Cluster CR mutated within the cooldown window — resourceVersion changed %q -> %q", rvBefore, afterCR.GetResourceVersion())
+	}
+}
+
+// TestCheckRejoin_NilCNPGReader_ErrorsGracefully — a Sequencer with no
+// CNPG reader wired must return a clear error rather than panic.
+func TestCheckRejoin_NilCNPGReader_ErrorsGracefully(t *testing.T) {
+	t.Parallel()
+	seq := &Sequencer{Now: time.Now}
+	standby := notReadyStatus(true, 3)
+	primary := cnpg.Status{IsReplicaCluster: false, Ready: true, HasTimelineID: true, TimelineID: 2}
+	_, result := seq.CheckRejoin(context.Background(), "ns", "demo-primary", primary, "demo-replica", standby, RejoinState{}, RejoinOptions{})
+	if result.Err == nil {
+		t.Fatal("expected error when Sequencer.CNPG is nil")
+	}
+}
+
+// TestRejoinOptions_Defaults confirms the documented defaults.
+func TestRejoinOptions_Defaults(t *testing.T) {
+	t.Parallel()
+	got := RejoinOptions{}.Defaults()
+	if got.MaxAttempts != DefaultRejoinMaxAttempts {
+		t.Errorf("MaxAttempts = %d want %d", got.MaxAttempts, DefaultRejoinMaxAttempts)
+	}
+	if got.Cooldown != DefaultRejoinCooldown {
+		t.Errorf("Cooldown = %v want %v", got.Cooldown, DefaultRejoinCooldown)
+	}
+}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5368,7 +5368,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-continuum
-    version: "0.1.10"
+    version: "0.1.11"
   topology:
     supported:
       - active-hot-standby

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -94,7 +94,25 @@ type: application
 # once the deploy-bot stamps the new image SHA (the 0.1.9 lesson).
 # Slot-62 pin + catalog-seed source.version move to 0.1.10 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.10
+#
+# 0.1.11 (#5125 Defect-2): step-8 re-clone-on-divergence. On region-a
+# resume post-region-kill, the returning cnpg-pair half's walreceiver
+# can crash-loop with "highest timeline N of the primary is behind
+# recovery timeline N+1" (its own recovery history advanced past what
+# the new primary can serve — no plain reconnect can fix this). The
+# controller's per-CR reconcile loop now detects this exact signature
+# (standby un-Ready + TimelineID strictly ahead of the acting primary —
+# never on a healthy rejoin or ordinary catch-up lag) and drives the
+# proven manual heal (delete + re-create the diverged Cluster CR to
+# force a pg_basebackup re-clone), bounded to 3 attempts with linear
+# backoff and failing loud (continuum-error audit + a False/
+# RejoinRepairBounded condition) rather than looping forever. Surfaced
+# on status.rejoinRepair + condition type RejoinRepair. Chart templates
+# unchanged (controller-image change only); the version bump forces the
+# Flux re-pull once the deploy-bot stamps the new image SHA (the 0.1.9
+# lesson). Slot-62 pin + blueprint.yaml version move to 0.1.11 in
+# lockstep (Inviolable Principle #13).
+version: 0.1.11
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.10
+  version: 0.1.11
   card:
     title: Continuum
     summary: |


### PR DESCRIPTION
## Summary

- Refs #5125 Defect-2 only (Defect 1 — flux drift reverting the failover patch — is already covered by #5178's dr-promoter suspend-latch and is untouched here).
- On region-a resume after a region-kill, the returning cnpg-pair half's walreceiver can crash-loop forever with `highest timeline N of the primary is behind recovery timeline N+1` — its own recovery history advanced past what the newly-promoted primary can serve, and neither CNPG nor the Continuum sequencer had a re-clone step. This adds that step-8 to the per-CR reconcile loop: it reuses the same CNPG status the existing #4901 standby-availability check already fetches, detects the exact divergence signature, and drives the proven manual heal (delete + re-create the diverged Cluster CR to force a `pg_basebackup` re-clone) — bounded to a capped attempt count with linear backoff, failing loud via a `continuum-error` audit event + a `False/RejoinRepairBounded` status condition once exhausted rather than looping forever.
- Divergence gate is intentionally narrow so it never fires outside the exact resume-with-divergence scenario: the CR currently acting as standby (`spec.replica.enabled=true`) must be un-Ready AND report a `status.timelineID` strictly ahead of the CR currently acting as primary. A healthy rejoin (standby Ready) or an ordinary catch-up-lagging standby (timeline behind/equal) is always a no-op.
- `bp-continuum` chart 0.1.10 → 0.1.11 (controller-image-only change; no template edits) + `blueprint.yaml` + bootstrap-kit slot-62 pin moved in lockstep.

## Where step-8 lives

- `core/controllers/continuum/internal/cnpg/status.go` — new `Status.TimelineID`/`HasTimelineID` fields (parsed from `status.timelineID`) + `Reader.RecloneCluster` (delete + re-create a Cluster CR from its own captured spec/labels/annotations).
- `core/controllers/continuum/internal/switchover/rejoin.go` (new) — `DetectDivergence` (pure decision function) + `Sequencer.CheckRejoin` (the bounded, backed-off, fail-loud step-8 entry point).
- `core/controllers/continuum/internal/controller/continuum_controller.go` — wires `checkRejoin` into the per-CR reconcile loop's existing FindPair/Get block (no extra CNPG API calls), carries `RejoinState` in the per-CR goroutine (same session-scoped pattern as the existing spec-fingerprint drift check), and surfaces the outcome on `status.rejoinRepair` + a new `RejoinRepair` condition.
- `core/controllers/continuum/internal/events/events.go` — new `TypeRejoinRepair` audit-type (13th reserved type).

## Test plan

- [x] `go build ./...` — clean (core/controllers module)
- [x] `go vet ./...` — clean
- [x] `go test ./continuum/... -race` — all packages green, no regressions
- [x] New unit tests (switchover package): divergence-detected → re-clone issued, healthy rejoin → no-op, ordinary catch-up lag → no-op, bounded attempts → fail loud without further mutation, within-cooldown → no-op, nil CNPG reader → error
- [x] New unit tests (cnpg package): `TimelineID` parsing (present/absent), `RecloneCluster` (spec/labels/annotations preserved, status wiped, missing-cluster error)
- [x] New controller-level wiring tests: `checkRejoin` patches `status.rejoinRepair` + condition and emits a `continuum-error` audit once bounded; a healthy rejoin leaves the CR completely untouched (no status/audit side effects)
- [x] `scripts/check-bootstrap-kit-pin-sync.sh` — PASS
- [x] `scripts/check-catalog-seed-lockstep.sh` — PASS (bp-continuum has no platform/ source, unaffected)
- [x] `helm lint` + `helm template` on `products/continuum/chart` — clean render

🤖 Generated with [Claude Code](https://claude.com/claude-code)