### PR TITLE
fix(catalyst-api): sandbox DELETE degrades to 503 on backend-unavailable (not 500)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -759,6 +759,14 @@ func canonicaliseForHash(in any) any {
 // inside the Org's vcluster. The handler returns 204 even when the CR
 // is already gone (idempotent — repeated DELETEs from the FE never
 // surface a 404 toast).
+//
+// #5140 follow-up: List/Get/Create already degrade a transient
+// backend-unavailable error (401/403/timeout/discovery-404/etc, see
+// sandboxBackendUnavailable) to 503 "API pending" instead of a raw
+// 500. Delete shared the exact same client + error surface but had
+// not been wired through the same classifier — fixed here so the
+// whole CRUD surface is consistent: transient ⇒ 503, genuine fault ⇒
+// 500.
 func (h *Handler) HandleDeleteSandboxSession(w http.ResponseWriter, r *http.Request) {
 	claims := auth.ClaimsFromContext(r.Context())
 	if claims == nil || claims.Sub == "" {
@@ -783,6 +791,14 @@ func (h *Handler) HandleDeleteSandboxSession(w http.ResponseWriter, r *http.Requ
 
 	err := client.Resource(SandboxGVR()).Namespace(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
+		if sandboxBackendUnavailable(err) {
+			h.log.Warn("sandbox: backend unavailable on delete", "id", id, "namespace", ns, "err", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error":  "sandbox-backend-unavailable",
+				"detail": "sandbox backend temporarily unavailable",
+			})
+			return
+		}
 		h.log.Warn("sandbox: delete failed", "id", id, "namespace", ns, "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error":  "delete-failed",

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_integration_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_integration_test.go
@@ -33,12 +33,14 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 )
@@ -456,6 +458,61 @@ func TestSandboxIntegration_ListThenDelete(t *testing.T) {
 	}
 	if len(listResp2.Sandboxes) != 2 {
 		t.Fatalf("LIST after delete count = %d, want 2", len(listResp2.Sandboxes))
+	}
+}
+
+// TestSandboxIntegration_DeleteBackendUnavailableDegradesTo503 — #5140
+// follow-up. List/Get/Create already degrade a transient
+// backend-unavailable error (401/403/timeout/discovery-race during a
+// cutover / region-kill recovery window — the hw261 symptom the issue
+// was filed against) to the honest 503 "API pending" instead of a raw
+// 500. Delete shares the exact same dynamic-client + error surface but
+// was not wired through the same sandboxBackendUnavailable classifier,
+// so the identical transient window still 500'd on the mutating
+// Start-session → Stop/Delete path. This pins the fix: a token-rejected
+// (Unauthorized) error on Delete now degrades to 503, matching the
+// other three verbs, while a genuine success (204, no error injected)
+// is unaffected — see TestSandboxIntegration_ListThenDelete.
+func TestSandboxIntegration_DeleteBackendUnavailableDegradesTo503(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		SandboxGVR(): "SandboxList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+	seed := mkSandboxCR("sandbox-flaky", "acme", "claude-code", nil)
+	if _, err := dyn.Resource(SandboxGVR()).Namespace("acme").Create(
+		context.Background(), seed, metav1.CreateOptions{},
+	); err != nil {
+		t.Fatalf("seed Sandbox: %v", err)
+	}
+
+	// Inject the exact transient class from the issue: a clustermesh
+	// peer apiserver rejecting the catalyst-api token during a
+	// region-kill recovery window surfaces as Unauthorized on the
+	// dynamic client call.
+	dyn.PrependReactor("delete", "sandboxes", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewUnauthorized("token rejected by peer apiserver")
+	})
+
+	core := fakek8s.NewSimpleClientset()
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: core, dyn: dyn}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/sandbox/sessions/sandbox-flaky", nil)
+	req = withSandboxClaims(req, "user-sub-flaky", "ops@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("DELETE on transient-unauthorized: status = %d, want 503 (sandbox-backend-unavailable); body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "sandbox-backend-unavailable" {
+		t.Errorf("error = %v, want sandbox-backend-unavailable", resp["error"])
 	}
 }
 


### PR DESCRIPTION
Refs #5140

## Problem

`#5140` was filed on the hw261 authenticated Agenity-workspace walk: `/api/v1/sandbox/sessions` (list) and `POST` (create) returned a raw **500** during a post-region-kill DR-failover recovery window, instead of the honest **503 "API pending"** the handler's own package doc promises for a transient backend-unavailable condition. The verified root cause (not RBAC) was a clustermesh peer apiserver intermittently rejecting the catalyst-api token (401) / not yet serving the CRD (404) while region-a re-converged after the region-kill.

That robustness gap for List/Get/Create was already fixed and merged in #5141 + #5161 (`sandboxBackendUnavailable()` classifies 401/403/503/timeout + untyped discovery/connection-refused/no-kind-match errors as retryable 503).

## Remaining gap fixed here

`HandleDeleteSandboxSession` (the `DELETE /api/v1/sandbox/sessions/{id}` verb — same CRUD family, same dynamic-client + error surface) was **not** wired through `sandboxBackendUnavailable()`. It only special-cased `IsNotFound`; every other error — including the exact 401/403/timeout class #5140 was filed against — still fell through to a raw 500. So the same transient recovery window that's now handled cleanly on List/Get/Create would still surface a bare 500 on a Stop/Delete-session action.

## Fix

Wires the same `sandboxBackendUnavailable(err)` check into `HandleDeleteSandboxSession`'s error path: a transient condition now returns 503 `sandbox-backend-unavailable` (matching List/Get/Create), a genuine fault stays a 500. Idempotent-delete semantics (`IsNotFound` → 204) are unchanged.

## Test

`TestSandboxIntegration_DeleteBackendUnavailableDegradesTo503` (new) injects an `Unauthorized` reactor on the fake dynamic client's `delete` verb — the exact transient class from the issue — and asserts 503 + the honest `sandbox-backend-unavailable` error body. The existing `TestSandboxIntegration_ListThenDelete` continues to pin the genuine 204 success path, so both the degrade path and the real-world-success path are covered.

`go build ./...` and `go test ./...` green for `products/catalyst/bootstrap/api` (all packages, including `internal/handler`).

## Scope note

The deeper cause of the hw261 symptom — whether catalyst-api's primary-referencing clients need explicit re-resolution after a region-kill DR failover flips the primary region — was scoped separately in #5140's thread and tied to #5137/#5132; that investigation needs a re-walk on a fresh non-region-killed Sovereign and is not part of this PR. This PR only closes the remaining handler-robustness gap (Delete) in the same class already fixed for List/Get/Create.