### PR TITLE
fix(catalyst-api): async wipe + huawei-operator-creds fallback + re-wipeable stranded records (#5193)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -194,6 +194,27 @@ type Deployment struct {
 	// snapshot. Cleared on wipe.
 	secondaryKubeconfigPaths map[string]string
 	secondaryWatchers        map[string]*helmwatch.Watcher
+
+	// wipeInFlight — #5193. True only while THIS catalyst-api process's
+	// goroutine owns an active tofu-destroy purge for this deployment.
+	// Guarded by mu. Deliberately in-memory-only (never persisted via
+	// toRecord/fromRecord): a Deployment rehydrated after a Pod roll
+	// always starts with wipeInFlight=false even when the persisted
+	// Status is still "wiping" from a purge the OLD process abandoned
+	// mid-destroy (nginx 60s proxy-timeout killing a request-bound
+	// destroy, or the roll itself). That is what makes a stranded
+	// `wiping` record re-wipeable: the single-flight guard in
+	// WipeDeployment only refuses a genuinely-running goroutine in
+	// THIS process, never a bare status string left over from a dead
+	// one.
+	wipeInFlight bool
+
+	// lastWipeReport — the most recent wipeResponse produced by an
+	// async wipe purge (#5193), surfaced via State() so GET
+	// /deployments/{id} carries the same detail the old synchronous
+	// 200 response used to return directly. Nil until the first wipe
+	// completes.
+	lastWipeReport *wipeResponse
 }
 
 // SlimForHandover returns a copy of the receiver retaining ONLY the
@@ -939,6 +960,14 @@ func (d *Deployment) State() map[string]any {
 	}
 	if d.Error != "" {
 		out["error"] = d.Error
+	}
+	// #5193 — surface the most recent async wipe purge report so GET
+	// /deployments/{id} carries the same detail the old synchronous
+	// 200 response returned directly (SweepOrphan totals, S3 buckets
+	// purged, PDM-released flag, verifiedZeroOrphans, etc). The wizard
+	// polls this endpoint after the wipe's immediate 202 ack.
+	if d.lastWipeReport != nil {
+		out["lastWipeReport"] = d.lastWipeReport
 	}
 	if d.Result != nil {
 		out["result"] = d.Result

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -31,6 +31,20 @@
 // step 3 is fallback ONLY for orphans tofu can't see (corrupt state,
 // resources created out-of-band by a half-completed cloud-init, etc.).
 // We never use the direct API for new resource creation.
+//
+// #5193 — the purge sequence above (steps 2-6) runs ASYNCHRONOUSLY in a
+// detached goroutine (runWipePurge), NOT inside the HTTP request that
+// triggered it. WipeDeployment itself only validates + flips
+// Status="wiping" + launches the goroutine, then returns 202 Accepted
+// immediately. This matters because the console wipe endpoint sits
+// behind nginx with a 60s proxy-read-timeout: the old synchronous
+// implementation ran `tofu destroy` bound to r.Context(), so nginx
+// closing the client connection at 60s cancelled the context and
+// SIGKILLed the destroy mid-teardown, stranding the record at
+// status=wiping forever (hw268 incident). Poll GET
+// /api/v1/deployments/{id} for status=wiped + the `lastWipeReport`
+// field (same shape this file used to return synchronously), or GET
+// .../events for the live SSE purge log.
 package handler
 
 import (
@@ -260,20 +274,33 @@ func resolveProviderName(dep *Deployment) string {
 // WipeDeployment handles POST /api/v1/deployments/{id}/wipe.
 //
 // Response codes:
-//   - 200 OK on full or partial success (errors in the body)
-//   - 400 Bad Request when the body cannot be parsed
+//   - 202 Accepted once validation passes and the purge goroutine has
+//     been launched (#5193 — the actual tofu destroy + orphan sweep +
+//     DNS/PDM/local cleanup runs ASYNCHRONOUSLY in runWipePurge, never
+//     inside this request). Poll GET /api/v1/deployments/{id} for
+//     status=wiped + the `lastWipeReport` field (the same shape this
+//     endpoint used to return synchronously in a 200 body), or GET
+//     .../events for the live SSE purge log.
+//   - 400 Bad Request when the body cannot be parsed, or (huawei) no
+//     credential source resolves (typed body, legacy body, in-memory
+//     request, per-deployment PVC tfvars, or the huawei-operator-creds
+//     env fallback — see the provHint switch below).
 //   - 404 Not Found when the deployment id is unknown
-//   - 409 Conflict if a wipe is already in progress for this deployment,
-//     OR (issue #914) if the deployment is still in `phase1-watching`
-//     AND younger than wipeMinLifeProtection (default 30m). The 409
-//     body carries `retryAfterSec` + `minLifeSec` so the wizard can
-//     render a "wait N minutes" countdown. Operator override:
-//     `?force=true` query param.
-//   - 500 on a fatal local-state error (workdir non-removable, etc.)
+//   - 409 Conflict if a purge goroutine is ALREADY running for this
+//     deployment in this process (dep.wipeInFlight==true), OR (issue
+//     #914) if the deployment is still in `phase1-watching` AND
+//     younger than wipeMinLifeProtection (default 30m). The 409 body
+//     for the latter carries `retryAfterSec` + `minLifeSec` so the
+//     wizard can render a "wait N minutes" countdown. Operator
+//     override: `?force=true` query param.
 //
-// The endpoint is idempotent: re-running on a partially-wiped deployment
-// returns the same shape with empty deltas. The wizard treats a 200 with
-// non-empty Errors as "investigate the log; some cleanup may be manual".
+// The endpoint is idempotent, including re-wipe of a STRANDED `wiping`
+// record (#5193): a Status=="wiping" row whose owning goroutine died
+// with a prior catalyst-api process (Pod roll, or — pre-#5193 — nginx's
+// 60s proxy-timeout killing a request-bound destroy) is NOT protected
+// by the single-flight guard, because wipeInFlight is in-memory-only
+// and always starts false on a freshly rehydrated Deployment. A fresh
+// POST .../wipe on such a record simply resumes/re-runs the destroy.
 func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
@@ -303,11 +330,27 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 	// the canonical creds resolution order is (1) typed body fields,
 	// (2) in-memory depReq, (3) the per-deployment tofu.auto.tfvars.json
 	// on PVC (which catalyst-api wrote during provision and survives
-	// Pod restart unconditionally). If ALL three sources are empty,
-	// THEN refuse the wipe with a typed error. Otherwise let the wipe
-	// proceed and let buildWipeCredsRaw + the provider adapter do the
-	// rest. For Hetzner the legacy `hetznerToken` is still the only
-	// path until the wizard ships a typed shape.
+	// Pod restart unconditionally), (4) — #5193 — the `huawei-operator-
+	// creds` Secret projected into the catalyst-api Pod as
+	// CATALYST_HUAWEI_ACCESS_KEY/_SECRET_KEY/_PROJECT_ID/_REGION, the
+	// SAME in-cluster fallback the janitor's discoverHuaweiCreds
+	// (janitor.go:584) already uses for the project-wide orphan sweep.
+	// If ALL FOUR sources are empty, THEN refuse the wipe with a typed
+	// error. Otherwise let the wipe proceed and let buildWipeCredsRaw +
+	// the provider adapter do the rest. For Hetzner the legacy
+	// `hetznerToken` is still the only path until the wizard ships a
+	// typed shape.
+	//
+	// #5193 root cause: a partial destroy (killed mid-teardown by the
+	// nginx 60s proxy-timeout — see runWipePurge) deletes the per-
+	// deployment tfvars off the PVC. If the catalyst-api Pod has also
+	// rolled since (dep.Request.Huawei* GC'd from memory) and the
+	// operator re-fires the wipe with an empty body, sources (1)-(3)
+	// are ALL empty even though an environment the platform
+	// created must always be wipeable — the operator-creds Secret is
+	// right there in the catalyst ns. Without this fallback the wipe
+	// 400s "credentials are required" forever, stranding the record at
+	// status=wiping and blocking the one-environment-at-a-time gate.
 	provHint := strings.ToLower(strings.TrimSpace(dep.Request.Provider))
 	if provHint == "" {
 		provHint = "hetzner"
@@ -331,9 +374,29 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+		// #5193 — operator-creds env fallback. Only fires when body +
+		// tfvars + in-memory dep.Request are still empty for the
+		// authenticating pair; body/tfvars-supplied values always win.
+		if firstNonEmpty(body.HuaweiAccessKey, dep.Request.HuaweiAccessKey) == "" ||
+			firstNonEmpty(body.HuaweiSecretKey, dep.Request.HuaweiSecretKey) == "" {
+			if hw, ok := huaweiOperatorCredsFromEnv(); ok {
+				if strings.TrimSpace(body.HuaweiAccessKey) == "" {
+					body.HuaweiAccessKey = hw.AccessKey
+				}
+				if strings.TrimSpace(body.HuaweiSecretKey) == "" {
+					body.HuaweiSecretKey = hw.SecretKey
+				}
+				if strings.TrimSpace(body.HuaweiProjectID) == "" {
+					body.HuaweiProjectID = hw.ProjectID
+				}
+				if strings.TrimSpace(body.HuaweiRegion) == "" {
+					body.HuaweiRegion = hw.Region
+				}
+			}
+		}
 		if firstNonEmpty(body.HuaweiAccessKey, body.HetznerToken, dep.Request.HuaweiAccessKey) == "" ||
 			firstNonEmpty(body.HuaweiSecretKey, body.ObjectStorageSecretKey, dep.Request.HuaweiSecretKey) == "" {
-			http.Error(w, "huawei credentials are required (huaweiAccessKey + huaweiSecretKey in body, or already on PVC tfvars)", http.StatusBadRequest)
+			http.Error(w, "huawei credentials are required (huaweiAccessKey + huaweiSecretKey in body, or already on PVC tfvars, or CATALYST_HUAWEI_ACCESS_KEY/_SECRET_KEY env on catalyst-api)", http.StatusBadRequest)
 			return
 		}
 	default:
@@ -407,15 +470,27 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Single-flight guard: if Status is already "wiping", refuse.
+	// Single-flight guard — #5193 hardened for idempotent re-wipe.
+	// Refuse ONLY when a goroutine in THIS process is genuinely running
+	// the purge right now (wipeInFlight==true). A record whose Status
+	// is "wiping" but wipeInFlight is false is a STRANDED wipe —
+	// abandoned by a catalyst-api Pod roll mid-destroy, or (the
+	// primary #5193 defect, fixed below by runWipePurge's detached
+	// context) killed by nginx's 60s proxy-timeout tearing down a
+	// request-bound destroy. Both used to leave the record un-wipeable
+	// via the old status-string-only guard, which blocked the
+	// one-environment-at-a-time fresh-prov gate forever. Re-firing the
+	// wipe on a stranded record now simply resumes/re-runs the destroy
+	// — idempotent, per the doc comment at the top of this file.
 	dep.mu.Lock()
-	if dep.Status == "wiping" {
+	if dep.wipeInFlight {
 		dep.mu.Unlock()
 		http.Error(w, "wipe already in progress for this deployment", http.StatusConflict)
 		return
 	}
 	prevStatus := dep.Status
 	dep.Status = "wiping"
+	dep.wipeInFlight = true
 	dep.mu.Unlock()
 
 	// Re-open the events channel for the wipe phase. The previous one
@@ -432,6 +507,54 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 	dep.mu.Lock()
 	dep.eventsCh = make(chan provisioner.Event, 256)
 	dep.mu.Unlock()
+
+	// #5193 — respond immediately; the purge itself runs in a detached
+	// goroutine (mirrors CreateDeployment's `go h.runProvisioning(dep)`
+	// pattern, deployments.go:1498). This is the primary fix: the OLD
+	// code ran the entire purge sequence synchronously inside this HTTP
+	// request with `tofuCtx` rooted in `r.Context()`. nginx's 60s
+	// proxy-timeout closes the client-facing connection mid-destroy;
+	// Go's server then cancels r.Context() because the peer connection
+	// closed, which cancelled tofuCtx and SIGKILLed the `tofu destroy`
+	// subprocess partway through (region-a destroyed, region-b/EIPs/
+	// VPCs/S3 left behind — the hw268 incident). runWipePurge below
+	// roots every internal context in context.Background() instead, so
+	// a slow or disconnected client can never abort an in-flight
+	// destroy again. The wizard (or any client) polls
+	// GET /api/v1/deployments/{id} — `status` flips wiping → wiped, and
+	// `lastWipeReport` carries the same detail the old synchronous
+	// response used to return directly in its body.
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"deploymentId":  id,
+		"sovereignFQDN": dep.Request.SovereignFQDN,
+		"status":        "wiping",
+		"message":       "wipe started; poll GET /api/v1/deployments/" + id + " for status=wiped, or GET .../events for the live purge log",
+	})
+
+	go h.runWipePurge(dep, id, body, prevStatus)
+}
+
+// runWipePurge runs the full destructive purge sequence for a wipe —
+// tofu destroy, provider orphan sweep, DNS teardown, PDM release, and
+// local-state cleanup — detached from the HTTP request that triggered
+// it (#5193). WipeDeployment launches this in its own goroutine and
+// responds 202 immediately; every context created in here is rooted in
+// context.Background(), never r.Context(), so a client disconnect (the
+// nginx 60s proxy-timeout, a dropped wizard tab, a catalyst-api Pod
+// roll of some OTHER request) can never cancel this purge.
+//
+// Always clears dep.wipeInFlight on return (success or failure) so a
+// stranded `wiping` record — one whose owning goroutine died with a
+// prior catalyst-api process — is always re-wipeable via a fresh
+// POST .../wipe; the single-flight guard in WipeDeployment only blocks
+// a genuinely-running goroutine, never a bare status string left over
+// from a dead one.
+func (h *Handler) runWipePurge(dep *Deployment, id string, body wipeRequest, prevStatus string) {
+	defer func() {
+		dep.mu.Lock()
+		dep.wipeInFlight = false
+		dep.mu.Unlock()
+	}()
 
 	providerName := resolveProviderName(dep)
 	report := wipeResponse{
@@ -521,7 +644,12 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 	wipeReq.HetznerToken = body.HetznerToken
 
 	prov := provisioner.New()
-	tofuCtx, cancel := context.WithTimeout(r.Context(), 30*time.Minute)
+	// #5193 — rooted in context.Background(), NOT the (now long-since-
+	// returned) HTTP request context. This is what lets `tofu destroy`
+	// run to completion even though nginx's 60s proxy-timeout closes
+	// the original client connection almost immediately (the handler
+	// already responded 202 before this goroutine was even launched).
+	tofuCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
 	// Wave 3 — the provider adapter owns tofu destroy + orphan sweep
@@ -846,7 +974,22 @@ _ = deploymentSovereignName // retained for backwards-compat callers; unused on 
 		}()
 	}
 
-	writeJSON(w, http.StatusOK, report)
+	// #5193 — persist the final report so a poller (GET
+	// /deployments/{id}, or a re-fired wipe checking whether the prior
+	// attempt actually finished) sees the same detail the old
+	// synchronous 200 response used to return directly in its HTTP
+	// body. dep.Error carries a joined summary for the plain-text
+	// surfaces (wizard FailureCard, `error` field) that don't unwrap
+	// lastWipeReport; empty on a clean wipe.
+	dep.mu.Lock()
+	dep.lastWipeReport = &report
+	if len(report.Errors) > 0 {
+		dep.Error = "wipe completed with errors: " + strings.Join(report.Errors, "; ")
+	} else {
+		dep.Error = ""
+	}
+	dep.mu.Unlock()
+	h.persistDeployment(dep)
 }
 
 // deploymentSovereignName mirrors provisioner.Request.sovereignName() —
@@ -1176,6 +1319,36 @@ func loadHuaweiCredsFromTfvars(workdir string) (huaweiCreds, bool) {
 	}
 	if hw.AccessKey == "" || hw.SecretKey == "" {
 		return huaweiCreds{}, false
+	}
+	return hw, true
+}
+
+// huaweiOperatorCredsFromEnv resolves the `huawei-operator-creds`
+// Kubernetes Secret, projected into the catalyst-api Pod as
+// CATALYST_HUAWEI_ACCESS_KEY / _SECRET_KEY / _PROJECT_ID / _REGION —
+// the exact same in-cluster fallback discoverHuaweiCreds (janitor.go)
+// already uses for the project-wide orphan sweep. Refs #5193: the
+// wipe path lacked this fallback, so a wipe whose per-deployment
+// tfvars were already destroyed by a partial prior destroy (and whose
+// in-memory dep.Request was lost to a Pod roll) had nowhere left to
+// turn and 400'd "credentials required" forever. An environment the
+// platform created must always be wipeable from in-cluster creds.
+//
+// Returns (zero, false) when access_key, secret_key, or project_id is
+// missing — region alone defaults to "me-east-215" (same default the
+// janitor's discoverHuaweiCreds applies) when unset.
+func huaweiOperatorCredsFromEnv() (huaweiCreds, bool) {
+	hw := huaweiCreds{
+		AccessKey: strings.TrimSpace(os.Getenv("CATALYST_HUAWEI_ACCESS_KEY")),
+		SecretKey: strings.TrimSpace(os.Getenv("CATALYST_HUAWEI_SECRET_KEY")),
+		ProjectID: strings.TrimSpace(os.Getenv("CATALYST_HUAWEI_PROJECT_ID")),
+		Region:    strings.TrimSpace(os.Getenv("CATALYST_HUAWEI_REGION")),
+	}
+	if hw.AccessKey == "" || hw.SecretKey == "" || hw.ProjectID == "" {
+		return huaweiCreds{}, false
+	}
+	if hw.Region == "" {
+		hw.Region = "me-east-215"
 	}
 	return hw, true
 }

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_async_creds_rewipe_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_async_creds_rewipe_test.go
@@ -1,0 +1,404 @@
+// wipe_async_creds_rewipe_test.go — #5193 regression coverage.
+//
+// #5193 root-cause chain (hw268/hw269, 2026-07-18): (1) the console wipe
+// ran `tofu destroy` synchronously inside the HTTP request, so nginx's
+// 60s proxy-read-timeout closing the client connection cancelled
+// r.Context() and SIGKILLed the destroy mid-teardown; (2) the wipe path
+// lacked the huawei-operator-creds env fallback the janitor's
+// discoverHuaweiCreds already has, so a wipe whose per-deployment
+// tfvars were already destroyed (and whose in-memory dep.Request was
+// lost to a Pod roll) 400'd "credentials required" forever; (3) the
+// resulting stranded `wiping` record could not be re-fired because the
+// single-flight guard only checked the status string.
+//
+// This file exercises all three fixes:
+//   - async destroy kickoff (WipeDeployment responds before the purge
+//     finishes, and the purge survives cancellation of the ORIGINAL
+//     request context)
+//   - the operator-creds env fallback (huaweiOperatorCredsFromEnv +
+//     the HTTP-level 400 guard)
+//   - idempotent re-wipe of a stranded `wiping` record
+package handler
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// ── async destroy kickoff ────────────────────────────────────────────
+
+// TestWipeDeployment_RespondsBeforePurgeCompletes proves the primary
+// #5193 fix: WipeDeployment acks 202 (with dep.wipeInFlight already
+// true and dep.Status already "wiping") synchronously, WITHOUT waiting
+// for the purge sequence — tofu destroy + orphan sweep + DNS/PDM/local
+// cleanup — to finish. Pre-#5193 the entire sequence ran inline inside
+// the HTTP handler, so this assertion would have required the (real,
+// network-bound) purge to complete before any response came back.
+func TestWipeDeployment_RespondsBeforePurgeCompletes(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-async-kickoff",
+		Status:    "failed",
+		StartedAt: time.Now().Add(-10 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "otech-async.omani.works",
+			SovereignDomainMode: "pool",
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	start := time.Now()
+	w := callWipeDeployment(h, dep.ID, "", `{"hetznerToken":"fake-hetzner-token"}`)
+	elapsed := time.Since(start)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status=%d, want 202 — body=%s", w.Code, w.Body.String())
+	}
+	// The real purge (network-bound tofu/hetzner calls) takes several
+	// seconds in this test environment (see
+	// TestWipeDeployment_NoS3CredsAnywhereSurfacesError, ~4.5s). A
+	// synchronous implementation would make this response equally
+	// slow; the async one must return near-instantly.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("WipeDeployment took %v to respond — expected a near-instant 202 (the purge must run in a detached goroutine, not inline)", elapsed)
+	}
+
+	dep.mu.Lock()
+	inFlight := dep.wipeInFlight
+	status := dep.Status
+	dep.mu.Unlock()
+	if !inFlight {
+		t.Errorf("dep.wipeInFlight=false immediately after the 202 response — the purge goroutine was not launched synchronously with the ack")
+	}
+	if status != "wiping" {
+		t.Errorf("dep.Status=%q immediately after the 202 response, want wiping", status)
+	}
+
+	// Drain the goroutine before returning so it can't leak into a
+	// later test in this same process.
+	waitForWipeDone(t, dep, 15*time.Second)
+}
+
+// TestWipeDeployment_PurgeSurvivesRequestContextCancellation is the
+// direct regression test for the #5193 root cause: nginx's 60s
+// proxy-read-timeout closing the client-facing connection surfaces to
+// catalyst-api as the inbound request's context being cancelled. The
+// OLD code rooted the purge's tofuCtx in r.Context(), so that
+// cancellation propagated into every downstream network call
+// (`tofu destroy`'s exec.CommandContext, the Hetzner/Huawei orphan-
+// sweep HTTP client) and killed them mid-flight — region-a destroyed,
+// region-b/EIPs/VPCs/S3 left behind (the hw268 incident).
+//
+// This test cancels the ORIGINAL request's context immediately after
+// WipeDeployment acks, then asserts the detached purge goroutine still
+// ran its real network call to completion — i.e. its error is the
+// normal (several-second) auth-rejection shape, NOT an instant
+// "context canceled" that a request-bound context would have produced.
+func TestWipeDeployment_PurgeSurvivesRequestContextCancellation(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-detached-ctx",
+		Status:    "failed",
+		StartedAt: time.Now().Add(-10 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "otech-detached.omani.works",
+			SovereignDomainMode: "pool",
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	router := chi.NewRouter()
+	router.Post("/api/v1/deployments/{id}/wipe", h.WipeDeployment)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/deployments/"+dep.ID+"/wipe", bytes.NewBufferString(`{"hetznerToken":"fake-hetzner-token"}`))
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status=%d, want 202 — body=%s", w.Code, w.Body.String())
+	}
+
+	// Simulate nginx (or the wizard's browser tab) dropping the
+	// connection the instant the ack is received — exactly what a 60s
+	// proxy-timeout does to the caller's side of the request.
+	cancelledAt := time.Now()
+	cancel()
+
+	waitForWipeDone(t, dep, 15*time.Second)
+	purgeElapsed := time.Since(cancelledAt)
+
+	dep.mu.Lock()
+	status := dep.Status
+	report := dep.lastWipeReport
+	dep.mu.Unlock()
+
+	if status != "wiped" {
+		t.Errorf("dep.Status=%q after request-context cancellation, want wiped", status)
+	}
+	if report == nil {
+		t.Fatalf("dep.lastWipeReport is nil after purge completed")
+	}
+	for _, e := range report.Errors {
+		if strings.Contains(e, "context canceled") || strings.Contains(e, "context deadline exceeded") {
+			t.Errorf("purge error carries a context-cancellation shape (%q) — the purge is still tied to the (now-cancelled) request context, the #5193 bug is NOT fixed", e)
+		}
+	}
+	// A request-bound context would have failed every downstream call
+	// instantly (sub-millisecond). The real network round trip this
+	// test environment observes takes on the order of seconds — assert
+	// the purge actually took that long, proving it ran independently
+	// of the cancelled request context rather than aborting instantly.
+	if purgeElapsed < 200*time.Millisecond {
+		t.Errorf("purge completed %v after the request context was cancelled — too fast for a real network round trip, suggests the purge was aborted by the cancellation instead of running detached", purgeElapsed)
+	}
+}
+
+// ── operator-creds env fallback ──────────────────────────────────────
+
+// TestHuaweiOperatorCredsFromEnv_AllPresent — the happy path: all four
+// CATALYST_HUAWEI_* env vars set, region included verbatim.
+func TestHuaweiOperatorCredsFromEnv_AllPresent(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "ak-operator")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "sk-operator")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "proj-operator")
+	t.Setenv("CATALYST_HUAWEI_REGION", "me-east-215")
+
+	hw, ok := huaweiOperatorCredsFromEnv()
+	if !ok {
+		t.Fatal("expected ok=true with all four env vars set")
+	}
+	if hw.AccessKey != "ak-operator" || hw.SecretKey != "sk-operator" || hw.ProjectID != "proj-operator" || hw.Region != "me-east-215" {
+		t.Fatalf("unexpected creds: %+v", hw)
+	}
+}
+
+// TestHuaweiOperatorCredsFromEnv_DefaultsRegion — empty region defaults
+// to me-east-215, mirroring the janitor's discoverHuaweiCreds fallback
+// default (janitor.go).
+func TestHuaweiOperatorCredsFromEnv_DefaultsRegion(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "ak-operator")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "sk-operator")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "proj-operator")
+	t.Setenv("CATALYST_HUAWEI_REGION", "")
+
+	hw, ok := huaweiOperatorCredsFromEnv()
+	if !ok {
+		t.Fatal("expected ok=true with access/secret/project set and region empty")
+	}
+	if hw.Region != "me-east-215" {
+		t.Errorf("empty region must default to me-east-215, got %q", hw.Region)
+	}
+}
+
+// TestHuaweiOperatorCredsFromEnv_MissingAnyReturnsFalse — access_key,
+// secret_key, and project_id are each individually required; region is
+// the only optional field (defaulted).
+func TestHuaweiOperatorCredsFromEnv_MissingAnyReturnsFalse(t *testing.T) {
+	cases := []struct {
+		name              string
+		ak, sk, projectID string
+	}{
+		{"missing access_key", "", "sk", "proj"},
+		{"missing secret_key", "ak", "", "proj"},
+		{"missing project_id", "ak", "sk", ""},
+		{"all missing", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", tc.ak)
+			t.Setenv("CATALYST_HUAWEI_SECRET_KEY", tc.sk)
+			t.Setenv("CATALYST_HUAWEI_PROJECT_ID", tc.projectID)
+			t.Setenv("CATALYST_HUAWEI_REGION", "")
+
+			if _, ok := huaweiOperatorCredsFromEnv(); ok {
+				t.Errorf("%s: expected ok=false", tc.name)
+			}
+		})
+	}
+}
+
+// TestWipeDeployment_HuaweiOperatorCredsEnvFallbackAvoids400 is the
+// HTTP-level integration proof for #5193 fix 2. A Huawei deployment
+// whose body, in-memory Request, AND per-deployment PVC tfvars are ALL
+// empty of credentials (the exact hw268 shape: a partial destroy wiped
+// the tfvars, a Pod roll wiped dep.Request, the operator re-fires with
+// an empty body) must NOT 400 "credentials required" when the
+// huawei-operator-creds env is present on catalyst-api — it must fall
+// back to it, exactly like the janitor's discoverHuaweiCreds already
+// does for the orphan sweep.
+func TestWipeDeployment_HuaweiOperatorCredsEnvFallbackAvoids400(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "ak-operator-secret")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "sk-operator-secret")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "proj-operator-secret")
+	t.Setenv("CATALYST_HUAWEI_REGION", "me-east-215")
+	// No per-deployment tfvars on disk — points at an empty workdir root
+	// so loadHuaweiCredsFromTfvars honestly misses (simulating the
+	// partial-destroy-already-deleted-tfvars shape).
+	t.Setenv("CATALYST_TOFU_WORKDIR", t.TempDir())
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-hw268-stranded",
+		Status:    "failed",
+		StartedAt: time.Now().Add(-10 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "hw268.omani.works",
+			SovereignDomainMode: "pool",
+			Provider:            "huawei",
+			Regions:             []provisioner.RegionSpec{{Provider: "huawei", CloudRegion: "me-east-215"}},
+			// Huawei* fields intentionally EMPTY — simulates the
+			// post-Pod-roll state where they were GC'd from memory.
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	// Empty body — the operator re-fires the canonical bare wipe, same
+	// as the manual recovery this issue documents having to bypass via
+	// port-forward + explicit creds. With the fix, the empty body alone
+	// must be enough because the env fallback fills it in.
+	w := callWipeDeployment(h, dep.ID, "", `{}`)
+
+	if w.Code == http.StatusBadRequest {
+		t.Fatalf("wipe 400'd despite huawei-operator-creds env being set — the env fallback did not fire: body=%s", w.Body.String())
+	}
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status=%d, want 202 — body=%s", w.Code, w.Body.String())
+	}
+
+	waitForWipeDone(t, dep, 15*time.Second)
+}
+
+// TestWipeDeployment_HuaweiNoCredsAnywhereStill400s is the negative
+// cross-check: WITHOUT the operator-creds env set (and without body/
+// tfvars/in-memory creds), the wipe must still 400 — the fallback must
+// not mask a genuinely unconfigured catalyst-api.
+func TestWipeDeployment_HuaweiNoCredsAnywhereStill400s(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "")
+	t.Setenv("CATALYST_HUAWEI_REGION", "")
+	t.Setenv("CATALYST_TOFU_WORKDIR", t.TempDir())
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-hw268-nocreds",
+		Status:    "failed",
+		StartedAt: time.Now().Add(-10 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "hw268-nocreds.omani.works",
+			SovereignDomainMode: "pool",
+			Provider:            "huawei",
+			Regions:             []provisioner.RegionSpec{{Provider: "huawei", CloudRegion: "me-east-215"}},
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := callWipeDeployment(h, dep.ID, "", `{}`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400 (no credential source anywhere) — body=%s", w.Code, w.Body.String())
+	}
+	dep.mu.Lock()
+	status := dep.Status
+	dep.mu.Unlock()
+	if status != "failed" {
+		t.Errorf("dep.Status=%q after a 400, want unchanged 'failed' — the guard must short-circuit before the single-flight status flip", status)
+	}
+}
+
+// ── idempotent re-wipe of a stranded `wiping` record ─────────────────
+
+// TestWipeDeployment_StrandedWipingRecordIsReWipeable is the direct
+// regression test for #5193 fix 3. A deployment whose Status is
+// "wiping" but whose owning goroutine died with a PRIOR catalyst-api
+// process (simulated here by wipeInFlight defaulting to its zero value
+// false — exactly what fromRecord produces on Pod-restart rehydration,
+// since wipeInFlight is never persisted) must be re-wipeable: a fresh
+// POST .../wipe must NOT 409, it must resume/re-run the purge.
+func TestWipeDeployment_StrandedWipingRecordIsReWipeable(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-stranded-wiping",
+		Status:    "wiping", // left behind by a dead process
+		StartedAt: time.Now().Add(-45 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "hw268-stranded.omani.works",
+			SovereignDomainMode: "pool",
+		},
+		// wipeInFlight intentionally left at its zero value (false) —
+		// this is exactly the in-memory shape a Deployment rehydrated
+		// via fromRecord has: the field is never persisted, so a fresh
+		// process always starts believing no goroutine owns this wipe.
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := callWipeDeployment(h, dep.ID, "", `{"hetznerToken":"fake-hetzner-token"}`)
+
+	if w.Code == http.StatusConflict {
+		t.Fatalf("stranded wiping record was refused with 409 — a Status=wiping record with no live owning goroutine must be re-wipeable: body=%s", w.Body.String())
+	}
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status=%d, want 202 — body=%s", w.Code, w.Body.String())
+	}
+
+	dep.mu.Lock()
+	inFlight := dep.wipeInFlight
+	dep.mu.Unlock()
+	if !inFlight {
+		t.Errorf("dep.wipeInFlight=false immediately after re-firing the wipe — the purge goroutine was not (re)launched")
+	}
+
+	waitForWipeDone(t, dep, 15*time.Second)
+
+	dep.mu.Lock()
+	status := dep.Status
+	dep.mu.Unlock()
+	if status != "wiped" {
+		t.Errorf("dep.Status=%q after re-wiping a stranded record, want wiped — the resumed destroy must reach completion", status)
+	}
+}
+
+// TestWipeDeployment_GenuinelyInFlightWipeReturns409 is the paired
+// negative case: a Status="wiping" record whose goroutine IS actively
+// running in THIS process (wipeInFlight=true) must still be refused
+// with 409 — the single-flight guard must not become a no-op.
+func TestWipeDeployment_GenuinelyInFlightWipeReturns409(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-genuinely-in-flight",
+		Status:    "wiping",
+		StartedAt: time.Now().Add(-5 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "hw268-inflight.omani.works",
+			SovereignDomainMode: "pool",
+		},
+	}
+	dep.mu.Lock()
+	dep.wipeInFlight = true // a goroutine in THIS process genuinely owns the purge
+	dep.mu.Unlock()
+	h.deployments.Store(dep.ID, dep)
+
+	w := callWipeDeployment(h, dep.ID, "", `{"hetznerToken":"fake-hetzner-token"}`)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status=%d, want 409 (a genuinely in-flight purge must refuse a concurrent wipe) — body=%s", w.Code, w.Body.String())
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_test.go
@@ -48,6 +48,30 @@ func callWipeDeployment(h *Handler, id, query, bodyJSON string) *httptest.Respon
 	return w
 }
 
+// waitForWipeDone polls dep until the #5193 async purge goroutine has
+// cleared wipeInFlight (i.e. runWipePurge has returned and stamped
+// dep.lastWipeReport / dep.Error), or fails the test after timeout.
+// WipeDeployment now responds 202 before the purge itself runs, so any
+// test that needs to inspect the purge's outcome (report.Errors,
+// final Status, etc.) must synchronize on completion first — mirrors
+// the short-poll pattern already used elsewhere in this package for
+// other async goroutines (e.g. cutover_test.go).
+func waitForWipeDone(t *testing.T, dep *Deployment, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		dep.mu.Lock()
+		inFlight := dep.wipeInFlight
+		hasReport := dep.lastWipeReport != nil
+		dep.mu.Unlock()
+		if !inFlight && hasReport {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("wipe purge did not complete within %v", timeout)
+}
+
 // ── shouldRefuseWipe pure-function tests ────────────────────────────
 
 // TestShouldRefuseWipe_StillConvergingTooYoung — the headline case.
@@ -501,11 +525,15 @@ func TestWipeDeployment_BodyS3CredsBypassPodRestartScrub(t *testing.T) {
 
 // TestWipeDeployment_NoS3CredsAnywhereSurfacesError — issue #166
 // negative path. When neither body nor in-memory Request carries S3
-// creds, the response Errors slice MUST surface a clear message
+// creds, the purge report's Errors slice MUST surface a clear message
 // telling the operator to re-prompt + retry. Pre-#166 this case
 // silently logged a warn and reported "wipe complete" while a bucket
 // leaked. We assert the error message names both sources so future
 // readers immediately see why their bucket-purge skipped.
+//
+// #5193: the purge now runs asynchronously (WipeDeployment responds
+// 202 immediately), so this test waits for runWipePurge to finish and
+// reads the result off dep.lastWipeReport instead of the HTTP body.
 //
 // Test setup: terminal status (`failed`) so the guard allows the
 // wipe, EMPTY S3 creds on the Deployment Request, and a body with
@@ -526,21 +554,28 @@ func TestWipeDeployment_NoS3CredsAnywhereSurfacesError(t *testing.T) {
 
 	w := callWipeDeployment(h, dep.ID, "", `{"hetznerToken":"fake-hetzner-token"}`)
 
-	// The handler returns 200 even on partial failures (errors in body).
-	// We assert the errors slice carries our message.
-	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v — raw=%s", err, w.Body.String())
+	// #5193 — the handler now acks 202 immediately; the purge (and any
+	// errors it surfaces) completes asynchronously.
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status=%d, want 202 — body=%s", w.Code, w.Body.String())
 	}
-	errs, _ := resp["errors"].([]any)
+
+	waitForWipeDone(t, dep, 10*time.Second)
+
+	dep.mu.Lock()
+	report := dep.lastWipeReport
+	dep.mu.Unlock()
+	if report == nil {
+		t.Fatalf("dep.lastWipeReport is nil after purge completed")
+	}
 	foundS3Err := false
-	for _, e := range errs {
-		if s, ok := e.(string); ok && bytes.Contains([]byte(s), []byte("object-storage credentials not supplied on request body AND not retained on in-memory deployment record")) {
+	for _, e := range report.Errors {
+		if bytes.Contains([]byte(e), []byte("object-storage credentials not supplied on request body AND not retained on in-memory deployment record")) {
 			foundS3Err = true
 			break
 		}
 	}
 	if !foundS3Err {
-		t.Errorf("expected hard error naming both creds sources in response.errors; got errors=%v body=%s", errs, w.Body.String())
+		t.Errorf("expected hard error naming both creds sources in lastWipeReport.errors; got errors=%v", report.Errors)
 	}
 }


### PR DESCRIPTION
## Problem

A partial destroy can strand an environment in a permanently un-wipeable `status: wiping` state, which then halts the one-environment-at-a-time fresh-prov gate. Confirmed live on hw268 (dep `7e7a0a1f42b2fdf4`). Three defects in the wipe path combine:

1. **nginx 60s proxy-timeout kills the synchronous, request-bound `tofu destroy`.** The console wipe ran the destroy inside the HTTP request with the destroy context rooted in `r.Context()`. nginx 504s at 60s, Go cancels `r.Context()` when the client connection closes, and the destroy subprocess is SIGKILLed mid-teardown (region-a destroyed; region-b / EIPs / VPCs / S3 left behind). Record stuck `wiping`, zero tofu processes.
2. **The wipe path lacked the `huawei-operator-creds` fallback the janitor has.** After a partial destroy cleans the per-deployment tfvars off the PVC, a re-wipe 400s `huawei credentials are required` because `WipeDeployment` never fell back to the in-cluster `huawei-operator-creds` Secret (the `CATALYST_HUAWEI_*` env) that the janitor's `discoverHuaweiCreds` already reads.
3. **The single-flight guard keyed off the bare `status == "wiping"` string**, so a record left `wiping` by a dead process could never be re-fired.

## Fix

**1. Async destroy (primary).** `WipeDeployment` now validates, flips `status` to `wiping`, sets an in-memory `wipeInFlight` flag, responds **202** immediately, and runs the full purge sequence in a detached `runWipePurge` goroutine — mirroring `CreateDeployment`'s `go h.runProvisioning(dep)`. Every context inside `runWipePurge` is rooted in `context.Background()`, never `r.Context()`, so a disconnected or timed-out client can no longer abort an in-flight destroy. Clients poll `GET /deployments/{id}` for `status=wiped` plus the new `lastWipeReport` field (same shape the old synchronous 200 body returned). On completion the report is persisted and `dep.Error` carries a joined summary; a failed purge always clears `wipeInFlight` so the record is never left permanently stuck.

**2. `huawei-operator-creds` fallback.** New `huaweiOperatorCredsFromEnv()` resolves the `CATALYST_HUAWEI_ACCESS_KEY/_SECRET_KEY/_PROJECT_ID/_REGION` env the `huawei-operator-creds` Secret projects — added as source (4) after typed body, in-memory request, and per-deployment PVC tfvars. An environment the platform created is always wipeable from in-cluster creds, even when the tfvars are gone and the Pod has rolled. The negative path (no creds anywhere) still 400s.

**3. Idempotent re-wipe.** The single-flight guard now refuses only a genuinely-running goroutine in **this** process (`wipeInFlight == true`). `wipeInFlight` is in-memory-only (never persisted via `toRecord`/`fromRecord`), so a rehydrated `Deployment` whose owning goroutine died with a prior process always starts `wipeInFlight=false`, and a fresh `POST .../wipe` resumes/re-runs the destroy instead of 409/400.

## Files changed

- `products/catalyst/bootstrap/api/internal/handler/wipe.go` — `WipeDeployment` splits into a fast validate-and-launch handler + detached `runWipePurge`; `huaweiOperatorCredsFromEnv()` added and threaded into the credential-resolution switch; single-flight guard rekeyed to `wipeInFlight`; final report persisted to the record.
- `products/catalyst/bootstrap/api/internal/handler/deployments.go` — `Deployment.wipeInFlight` + `lastWipeReport` fields (in-memory-only); `State()` surfaces `lastWipeReport`.
- `products/catalyst/bootstrap/api/internal/handler/wipe_test.go` — existing tests synchronized on async completion via a new `waitForWipeDone` helper.
- `products/catalyst/bootstrap/api/internal/handler/wipe_async_creds_rewipe_test.go` — new regression coverage.

## Tests added

- **Async kickoff:** `WipeDeployment` returns 202 near-instantly before the purge finishes; the purge survives cancellation of the original request context (the direct nginx-timeout regression).
- **Creds fallback:** `huaweiOperatorCredsFromEnv` unit cases (all present / region default / each-field-missing); HTTP-level proof that an empty-body Huawei wipe with only the operator-creds env set avoids the 400; negative cross-check that no creds anywhere still 400s.
- **Re-wipe:** a stranded `wiping` record (owning goroutine dead) is re-wipeable to `wiped`; the paired case where a genuinely in-flight purge still returns 409.

## Gates

`go build ./...`, `go vet ./...`, and `go test -race -count=1 ./...` all green in `products/catalyst/bootstrap/api`.

Refs #5193