### PR TITLE
test(console): lock in #5129 full-cluster NetworkPolicy/CiliumNetworkPolicy separation

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/networking/NetworkingPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/networking/NetworkingPage.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   RouterProvider,
@@ -156,6 +156,47 @@ describe('NetworkingPage', () => {
     expect(screen.getAllByText(/CiliumNetworkPolicy/).length).toBeGreaterThan(0)
     expect(screen.getByText(/default-deny/)).toBeTruthy()
     expect(screen.queryByText(/pending live data/)).toBeNull()
+  })
+
+  // #5129 — the Cloud Networking lens must never fold NetworkPolicy and
+  // CiliumNetworkPolicy into a single chip. Seed all three policy kinds
+  // with DISTINCT counts (30 / 40 / 4 — the hw258 UAT-201/202 reference
+  // scale) and assert each renders its OWN per-kind stat card with its
+  // OWN count, never a merged/summed total.
+  it('Policies tab renders NetworkPolicy + CiliumNetworkPolicy as SEPARATE per-kind cards with independent counts', async () => {
+    setFetchHandler(() => ({
+      items: [],
+      counts_by_kind: {
+        NetworkPolicy: 30,
+        CiliumNetworkPolicy: 40,
+        CiliumClusterwideNetworkPolicy: 4,
+      },
+      counts_by_namespace: {},
+      total: 74,
+    }))
+    renderAtSlug('policies')
+    await waitFor(() => screen.getByTestId('policies-tab'))
+
+    const npCard = screen.getByTestId('policy-kind-NetworkPolicy')
+    const cnpCard = screen.getByTestId('policy-kind-CiliumNetworkPolicy')
+    const ccnpCard = screen.getByTestId('policy-kind-CiliumClusterwideNetworkPolicy')
+
+    // Three DISTINCT cards, not one folded chip.
+    expect(npCard).toBeTruthy()
+    expect(cnpCard).toBeTruthy()
+    expect(ccnpCard).toBeTruthy()
+
+    // Each card carries its OWN exact full-cluster count — EXACT text
+    // match (not substring) so a "40" rendered where "4" is expected
+    // (or vice versa) fails this assertion, and never the summed total
+    // (74) nor the historical folded-and-wrong "35".
+    expect(within(npCard).getByText('30', { exact: true })).toBeTruthy()
+    expect(within(cnpCard).getByText('40', { exact: true })).toBeTruthy()
+    expect(within(ccnpCard).getByText('4', { exact: true })).toBeTruthy()
+    expect(within(npCard).queryByText('35', { exact: true })).toBeNull()
+    expect(within(cnpCard).queryByText('35', { exact: true })).toBeNull()
+    expect(within(npCard).queryByText('74', { exact: true })).toBeNull()
+    expect(within(ccnpCard).queryByText('40', { exact: true })).toBeNull()
   })
 
   it('ClusterMesh tab renders fsn + hel peers', async () => {

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
@@ -518,6 +518,81 @@ describe('k8sToGraph', () => {
     // No NetworkPolicy node was created for the Cilium policies (no fold).
     expect(nodes.filter((n) => n.type === 'NetworkPolicy')).toHaveLength(1)
   })
+
+  it('#5129: NetworkPolicy/CiliumNetworkPolicy totals are FULL-CLUSTER, not a graph-scoped subset', () => {
+    // Reproduces the hw258 UAT-201/202 reference scale: 30 vanilla
+    // NetworkPolicies + 44 Cilium(Clusterwide)NetworkPolicies (74 total).
+    // The pre-#5163 defect folded these into a single mislabeled chip
+    // whose count (35) matched neither 30, 44, nor 74 — the symptom of a
+    // graph-scoped subset (only policies whose Namespace also happened to
+    // be rendered). This test seeds MORE policies (across MANY namespaces)
+    // than Namespace nodes present in the snapshot, so a regression that
+    // silently drops/skips policies lacking a rendered Namespace peer would
+    // fail this test even though it would pass the single-object test above.
+    const entries: Array<[string, K8sObject]> = [
+      // Only 3 Namespace nodes are actually present in the snapshot —
+      // deliberately fewer than the namespaces the policies below span,
+      // so a namespace-gated adapter would under-count.
+      ['namespace:ns-0', { metadata: { name: 'ns-0' } }],
+      ['namespace:ns-1', { metadata: { name: 'ns-1' } }],
+      ['namespace:ns-2', { metadata: { name: 'ns-2' } }],
+    ]
+    const NP_TOTAL = 30
+    const CNP_TOTAL = 40
+    const CCNP_TOTAL = 4 // cluster-scoped; combines with CNP_TOTAL -> 44
+    for (let i = 0; i < NP_TOTAL; i++) {
+      const ns = `ns-${i % 10}` // spans 10 namespaces, only 3 of which have a Namespace node
+      entries.push([
+        `networkpolicy:${ns}/np-${i}`,
+        {
+          apiVersion: 'networking.k8s.io/v1',
+          kind: 'NetworkPolicy',
+          metadata: { namespace: ns, name: `np-${i}` },
+          spec: { podSelector: {} },
+        },
+      ])
+    }
+    for (let i = 0; i < CNP_TOTAL; i++) {
+      const ns = `ns-${i % 10}`
+      entries.push([
+        `ciliumnetworkpolicy:${ns}/cnp-${i}`,
+        {
+          apiVersion: 'cilium.io/v2',
+          kind: 'CiliumNetworkPolicy',
+          metadata: { namespace: ns, name: `cnp-${i}` },
+          spec: { endpointSelector: {} },
+        },
+      ])
+    }
+    for (let i = 0; i < CCNP_TOTAL; i++) {
+      entries.push([
+        `ciliumclusterwidenetworkpolicy:/ccnp-${i}`,
+        {
+          apiVersion: 'cilium.io/v2',
+          kind: 'CiliumClusterwideNetworkPolicy',
+          metadata: { name: `ccnp-${i}` },
+          spec: { endpointSelector: {} },
+        },
+      ])
+    }
+    const s = snap(...entries)
+    const { nodes } = k8sToGraph(s)
+
+    const npNodes = nodes.filter((n) => n.type === 'NetworkPolicy')
+    const cnpNodes = nodes.filter((n) => n.type === 'CiliumNetworkPolicy')
+
+    // Full-cluster counts — every policy became a node, not just the
+    // ones whose namespace happened to also be a rendered Namespace node.
+    expect(npNodes).toHaveLength(NP_TOTAL)
+    expect(cnpNodes).toHaveLength(CNP_TOTAL + CCNP_TOTAL)
+    expect(cnpNodes).toHaveLength(44)
+
+    // The two kinds never collide into one type, and neither total
+    // reproduces the historical folded-and-wrong "35" chip.
+    expect(npNodes.length).not.toBe(35)
+    expect(cnpNodes.length).not.toBe(35)
+    expect(npNodes.length + cnpNodes.length).toBe(74)
+  })
 })
 
 describe('mergeGraphs', () => {


### PR DESCRIPTION
## Summary

The primary defect in #5129 (Cloud Networking lens folding `NetworkPolicy` and `CiliumNetworkPolicy` into one wrong-count chip) was already durably fixed by the merged PR #5163 (`k8sAdapter.ts` §6e renders `CiliumNetworkPolicy` as a distinct graph node type, sourced unconditionally from the full k8s-cache snapshot). Verified this before touching anything further — see investigation notes below.

That prior fix only carried a single-object adapter test and only covered the architecture-graph layer. This PR:

- Extends `k8sAdapter.test.ts` with a full-cluster-scale case (30 `NetworkPolicy` + 40 `CiliumNetworkPolicy` + 4 `CiliumClusterwideNetworkPolicy`, deliberately spanning more namespaces than have a rendered `Namespace` node) proving the per-type totals are sourced from the full snapshot — not a graph-scoped subset that only counts policies attached to already-rendered nodes.
- Extends `NetworkingPage.test.tsx` (Sovereign Console → Networking → Policies tab — a separate surface `#5163` never touched) proving `NetworkPolicy` / `CiliumNetworkPolicy` / `CiliumClusterwideNetworkPolicy` render as three independent per-kind cards with exact (not substring) counts, never folded or summed.

Also verified — no change needed — the third Networking-lens surface: the Cloud **list view**'s `CloudKindChips` (backed by `CloudPage.tsx`'s `kindCounts`, derived directly from the live k8s snapshot) was already correct pre-#5129 via the `#3987`/`#3998` per-kind model.

## Investigation (why no production code changed)

- `products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts` §6d/§6e: iterates the **entire** snapshot per kind unconditionally — no node is dropped for lacking a rendered `Namespace` peer, no cap. Full-cluster by construction.
- `products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.ts`: the SSE stream ships `initialState=1` — the full k8s-cache informer snapshot, cluster-wide, not scoped to rendered nodes.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx` `kindCounts`: counts every snapshot key matching a kind's registry name — also full-cluster, independent of the graph.
- `products/catalyst/bootstrap/api/internal/handler/networking.go` `HandleNetworkingPolicies`: joins `networkpolicy` + `ciliumnetworkpolicy` + `ciliumclusterwidenetworkpolicy` via `k8sCache.List` (full cluster list) and buckets by `humanKindName` — already per-kind, already merged in a much earlier change.

All three surfaces a Sovereign-console operator could call "the Networking lens" now independently prove out; this PR adds the missing regression coverage so a future change can't silently re-introduce the fold.

## Test plan
- [x] `npm run build` (`tsc -b && vite build`) — clean, no errors
- [x] `npx eslint` on both changed files — clean
- [x] `npx vitest run` on both changed files — 38/38 passing
- [x] Full `npm test` — 1821 passed / 68 pre-existing failures across 9 unrelated files (`StepComponents.test.tsx` wizard-cascade drift, `CloudComputePage.test.tsx` fixture-count drift), reproduced identically on the base commit before this change (confirmed via `git stash`)

Refs #5129

🤖 Generated with [Claude Code](https://claude.com/claude-code)