### PR TITLE
test(console): lock row-214 tenant-string fix as a regression guard

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/CrudModals/formFields/WorkerNodeFormFields.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/CrudModals/formFields/WorkerNodeFormFields.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * WorkerNodeFormFields.test.tsx — regression guard for UAT row 214
+ * (issue #5100 / PR #5102).
+ *
+ * The Taints hint + placeholder used to read `tenant=dmz:NoSchedule`
+ * (a purely illustrative example — no shipped chart uses a `tenant=`
+ * taint key). PR #5102 rewrote both to `org=dmz:NoSchedule` per
+ * docs/GLOSSARY.md ("tenant" → Organization). This test locks the
+ * rendered copy so it can't silently regress back to the banned term.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { WorkerNodeFormFields } from './WorkerNodeFormFields'
+
+afterEach(() => cleanup())
+
+const baseValues = {
+  name: 'worker-eu-3',
+  sku: '',
+  role: 'worker' as const,
+  taints: '',
+  labels: '',
+}
+
+describe('WorkerNodeFormFields — Taints hint (row 214)', () => {
+  it('renders the org=dmz example, not tenant=dmz', () => {
+    render(
+      <WorkerNodeFormFields values={baseValues} onChange={vi.fn()} provider="hetzner" />,
+    )
+    expect(screen.getByText(/org=dmz:NoSchedule/)).toBeTruthy()
+    expect(screen.queryByText(/tenant=dmz/i)).toBeNull()
+  })
+
+  it('the taints input placeholder is org=dmz:NoSchedule, not tenant=dmz:NoSchedule', () => {
+    render(
+      <WorkerNodeFormFields values={baseValues} onChange={vi.fn()} provider="hetzner" />,
+    )
+    const taints = screen.getByTestId('worker-node-form-taints') as HTMLInputElement
+    expect(taints.placeholder).toBe('org=dmz:NoSchedule')
+  })
+
+  it('no rendered text on the form contains the banned "tenant" term', () => {
+    const { container } = render(
+      <WorkerNodeFormFields values={baseValues} onChange={vi.fn()} provider="hetzner" />,
+    )
+    expect(container.textContent?.toLowerCase()).not.toContain('tenant')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/org/CreateTenantPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/CreateTenantPage.test.tsx
@@ -8,12 +8,20 @@
  *   • Console URL preview updates as fields change (free-subdomain)
  *   • Switching to BYO mode hides the dropdown + shows the BYO field
  *   • Empty pool surfaces the "no parents available" placeholder
+ *   • Submit-failure panel renders "create organization:" with no
+ *     tenant-string residue (UAT row 214, issue #5100 / PR #5102)
  */
 
-import { afterEach, describe, expect, it } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { CreateTenantPage } from './CreateTenantPage'
 import type { SovereignParentDomain } from './org.api'
+
+vi.mock('./org.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./org.api')>()
+  return { ...actual, createOrgTenant: vi.fn() }
+})
+import { createOrgTenant } from './org.api'
 
 afterEach(() => cleanup())
 
@@ -140,5 +148,34 @@ describe('CreateTenantPage', () => {
     ) as HTMLSelectElement
     expect(select.disabled).toBe(true)
     expect(select.textContent).toContain('No pool parents available')
+  })
+
+  /* ── Row 214 regression guard (issue #5100 / PR #5102) ──
+     createOrgTenant's rejection message is rendered VERBATIM in the
+     submit-error panel — it used to read "create org tenant: …",
+     now "create organization: …". Lock the rendered copy so it can't
+     silently regress back to the banned "tenant" term. */
+  it('submit failure renders "create organization:" with no tenant-string residue', async () => {
+    vi.mocked(createOrgTenant).mockRejectedValueOnce(
+      new Error('create organization: HTTP 500 upstream failure'),
+    )
+    render(<CreateTenantPage initialParentDomains={POOL} disableFetch />)
+
+    fireEvent.change(screen.getByTestId('org-create-tenant-subdomain'), {
+      target: { value: 'acme' },
+    })
+    fireEvent.change(screen.getByTestId('org-create-tenant-email'), {
+      target: { value: 'admin@acme.com' },
+    })
+    fireEvent.click(screen.getByTestId('org-create-tenant-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('org-create-tenant-submit-error').textContent).toContain(
+        'create organization: HTTP 500',
+      )
+    })
+    expect(
+      screen.getByTestId('org-create-tenant-submit-error').textContent?.toLowerCase(),
+    ).not.toContain('tenant')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/org/org.api.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/org/org.api.test.ts
@@ -1,0 +1,75 @@
+/**
+ * org.api.test.ts — regression guard for UAT row 214 (issue #5100).
+ *
+ * PR #5102 purged the two rendered "tenant" strings that leaked out of
+ * `createOrgTenant` / `listOrgTenants` error messages (`create org
+ * tenant: …` / `list org tenants: …` → `create organization: …` /
+ * `list organizations: …`). These messages are rendered verbatim in
+ * `CreateTenantPage`'s submit-error panel (`err.message`), so a
+ * regression here is a user-visible tenant-string leak, not just an
+ * internal rename.
+ *
+ * This file locks the wording so it can't silently regress. It does
+ * NOT touch the wire contract: the request path (`/v1/organizations`),
+ * the `X-Tenant-Host` header, or any `tenant*` JSON field name are
+ * untouched by design — only the human-facing Error.message text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createOrgTenant, listOrgTenants } from './org.api'
+
+beforeEach(() => {
+  global.fetch = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('org.api — create/list organization error copy (row 214)', () => {
+  it('createOrgTenant failure message reads "create organization:" with no tenant residue', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('boom', { status: 500 }),
+    )
+    await expect(
+      createOrgTenant({
+        subdomain: 'acme',
+        admin_email: 'admin@acme.com',
+        company_name: 'Acme Corp',
+        domain_mode: 'free-subdomain',
+        parent_domain: 'omani.works',
+        kind: 'customer',
+        billing_mode: 'real',
+        isolation: 'vcluster',
+      }),
+    ).rejects.toThrow(/^create organization: HTTP 500/)
+  })
+
+  it('listOrgTenants failure message reads "list organizations:" with no tenant residue', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('boom', { status: 503 }),
+    )
+    await expect(listOrgTenants()).rejects.toThrow(/^list organizations: HTTP 503/)
+  })
+
+  it('neither error message contains the banned "tenant" term (docs/GLOSSARY.md)', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+
+    const createErr = await createOrgTenant({
+      subdomain: 'acme',
+      admin_email: 'admin@acme.com',
+      company_name: 'Acme Corp',
+      domain_mode: 'free-subdomain',
+      parent_domain: 'omani.works',
+      kind: 'customer',
+      billing_mode: 'real',
+      isolation: 'vcluster',
+    }).catch((e) => e as Error)
+    const listErr = await listOrgTenants().catch((e) => e as Error)
+
+    expect((createErr as Error).message.toLowerCase()).not.toContain('tenant')
+    expect((listErr as Error).message.toLowerCase()).not.toContain('tenant')
+  })
+})


### PR DESCRIPTION
Refs #5100

## Context

UAT row 214 (issue #5100) flagged tenant-string residue in the deployed console bundle. PR #5102 already fixed the three real user-visible leaks it identified and merged (ancestor of this branch):

- `WorkerNodeFormFields.tsx` — Taints hint/placeholder `tenant=dmz:NoSchedule` → `org=dmz:NoSchedule`
- `org.api.ts` — `create org tenant: HTTP …` → `create organization: HTTP …`
- `org.api.ts` — `list org tenants: HTTP …` → `list organizations: HTTP …`

The most recent walk (hw269, 2026-07-17/18) reported the tenant-residue facet as "largely resolved" with only 1 remaining user-visible hit out of ~74 total bundle hits. I re-audited from scratch to find and fix that remaining hit.

## What I found

A full source-level grep + a fresh `npm run build` bundle grep (54 `tenant`-matching hits in the current dist, reproducing the walk's methodology) across **both** console apps — `products/catalyst/bootstrap/ui` (the confirmed `catalyst-ui` image per the Containerfile + PR #5102's file set) and `core/console` (Astro+Svelte operator console) — turned up **zero further genuine user-visible tenant/SME copy**. Every remaining hit is one of:

- wire/protocol fields (`X-Tenant-Host`, `tenantId`, `org_tenant_id`, `tenant_id`/`tenant_kind` from `/api/v1/tenant/discover`)
- `data-testid` attributes
- code comments
- legacy redirect paths (`/bss/tenants` → `/organizations`)
- catalog chart slugs (`bp-stalwart-tenant`, `bp-wordpress-tenant` — real Blueprint slugs, not copy)

All rendered headings/labels already read "Organization"/"Organizations" (`sov-section-tenant` → `<h2>Organization</h2>`, BSS `Top organization` KPI, `Organizations` column header, etc.). The currently pinned `catalystUi` image tag in `products/catalyst/chart/values.yaml` (`5033950` / commit `503395044`) is confirmed to be a descendant of PR #5102's fix commit, so the fix is live in the current pin — the hw269 finding most likely reflects that specific environment's older deployed image, not a source-level gap.

## What this PR does

Since there's no further string to change, this PR hardens the already-shipped fix against regression with real component-level tests (not source-grep theater):

- `src/components/CrudModals/formFields/WorkerNodeFormFields.test.tsx` (new) — renders the component and asserts the Taints hint text and input placeholder read `org=dmz:NoSchedule`, and that no rendered text contains "tenant".
- `src/pages/org/org.api.test.ts` (new) — mocks `fetch` to fail and asserts `createOrgTenant`/`listOrgTenants` throw `create organization: HTTP …` / `list organizations: HTTP …`, with no "tenant" in the message.
- `src/pages/org/CreateTenantPage.test.tsx` (extended) — end-to-end: mocks `createOrgTenant` to reject and asserts the rendered submit-error panel shows the organization-scoped message with no tenant residue.

**Untouched by design** (wire contract, not copy): `X-Tenant-Host` header, `tenantId`/`org_tenant_id`/`tenant_id`/`tenant_kind` JSON fields, `data-testid="org-create-tenant-*"` / `sov-console-tenant-*` testids, `bp-*-tenant` chart slugs, the `/bss/tenants` legacy redirect path.

## Gates

- `npm run build` (`tsc -b && vite build`): clean.
- `npx vitest run src/pages/org src/components/CrudModals`: 5 files / 24 tests passed.
- `npm test` (full suite): 184 files / 1826 tests passed; 9 files / 68 tests fail — all pre-existing and unrelated (PinInput6, ProvisionPage SSE, JobsPage, SettingsPage, ExecPanel, ParentDomainsPage, UserAccessEditPage, StepComponents catalog cascade, CloudComputePage fixture-count mismatch). Verified these same failures reproduce on unmodified `main` via `git stash`.
- `npm run lint`: 119 pre-existing errors across unrelated files (none in the files this PR touches); not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)