### PR TITLE
fix: same-origin console-ready proxy replaces no-cors funnel poll

### DIFF
--- a/core/marketplace/playwright/customer-journey.spec.ts
+++ b/core/marketplace/playwright/customer-journey.spec.ts
@@ -799,24 +799,28 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
 
   // ──────────────────────────────────────────────────────────────────────
   // #4273 — provisioning interstitial (redirect-before-ready race fix).
+  // #5205 — readiness probe moved off a cross-origin no-cors browser fetch
+  // (whose opaque Response the browser could never read a real status from,
+  // per the live hw270 walk) onto the marketplace's own same-origin
+  // `/api/provisioning/console-ready` proxy.
   //
   // The funnel no longer hard-bounces to the per-Org console host the instant
   // checkout succeeds (its DNS/TLS/HTTPRoute are still provisioning → the
   // first click hit NXDOMAIN). It now lands on `/launching` — served from the
-  // marketplace origin, which always resolves — which polls the per-Org
-  // console `/healthz` and only forwards to `/auth/org-handover` once the host
-  // serves a response. These tests are hermetic: the `/healthz` probe is
-  // intercepted so no real per-Org host is needed.
+  // marketplace origin, which always resolves — which polls the same-origin
+  // readiness proxy and only forwards to `/auth/org-handover` once it reports
+  // ready:true. These tests are hermetic: `/api/provisioning/console-ready`
+  // is intercepted so no real per-Org host or backend is needed.
   // ──────────────────────────────────────────────────────────────────────
   test('18 launching interstitial shows immediately, then forwards once the per-Org host is ready', async ({ page }) => {
     const consoleHost = 'https://console.abc.omani.trade'
-    // The per-Org host's /healthz: fail (abort = NXDOMAIN/conn-refused shape)
-    // for the first 2 probes, then resolve — emulating DNS/TLS/route landing.
+    // The same-origin readiness proxy: ready:false (still provisioning) for
+    // the first 2 probes, then ready:true — emulating DNS/TLS/route landing.
     let probes = 0
-    await page.route('**/console.abc.omani.trade/healthz**', (route) => {
+    await page.route('**/api/provisioning/console-ready**', (route) => {
       probes += 1
-      if (probes <= 2) return route.abort('namenotresolved')
-      return route.fulfill({ status: 200, body: 'ok' })
+      const ready = probes > 2
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ready }) })
     })
     // Stop the real cross-host /auth/org-handover navigation (no live host) —
     // intercept so the forward lands on an interceptable response and the test
@@ -839,14 +843,16 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     const url = page.url()
     expect(url, 'forwarded to /auth/org-handover on the per-Org host').toContain('/auth/org-handover')
     expect(url, 'session token carried through to the handover').toContain('token=mock-session-jwt')
-    expect(probes, 'polled /healthz until ready (tolerated early NXDOMAIN)').toBeGreaterThanOrEqual(3)
+    expect(probes, 'polled console-ready until ready (tolerated early ready:false)').toBeGreaterThanOrEqual(3)
   })
 
   test('19 launching interstitial keeps a friendly waiting state while the host stays unreachable (no raw NXDOMAIN)', async ({ page }) => {
     // Probe never succeeds — the host is still provisioning. The customer must
     // see the on-brand "Setting up…" spinner (and an elapsed hint), NEVER a
     // dead browser error page, and must remain ON the marketplace origin.
-    await page.route('**/console.def.omani.rest/healthz**', (route) => route.abort('namenotresolved'))
+    await page.route('**/api/provisioning/console-ready**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ready: false }) }),
+    )
 
     const params = new URLSearchParams({ host: 'https://console.def.omani.rest', token: 'mock-session-jwt', next: '/jobs' })
     await page.goto('/launching?' + params.toString())
@@ -855,6 +861,21 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
       .toBeVisible({ timeout: 5_000 })
     // After a few seconds of failing probes it still shows the waiting state
     // (and the elapsed-time hint) — we have NOT navigated away to a dead host.
+    await expect(page.getByText(/Still working/i)).toBeVisible({ timeout: 12_000 })
+    expect(page.url(), 'stays on the marketplace-origin /launching page').toContain('/launching')
+  })
+
+  test('19b launching interstitial tolerates the readiness proxy itself being unreachable (network error, not ready:false)', async ({ page }) => {
+    // The console-ready endpoint call itself fails at the transport level
+    // (e.g. a transient gateway blip) — this must be swallowed exactly like
+    // an upstream ready:false, never surfaced as a hard error.
+    await page.route('**/api/provisioning/console-ready**', (route) => route.abort('failed'))
+
+    const params = new URLSearchParams({ host: 'https://console.ghi.omani.homes', token: 'mock-session-jwt', next: '/jobs' })
+    await page.goto('/launching?' + params.toString())
+
+    await expect(page.getByRole('heading', { name: /Setting up your console/i }))
+      .toBeVisible({ timeout: 5_000 })
     await expect(page.getByText(/Still working/i)).toBeVisible({ timeout: 12_000 })
     expect(page.url(), 'stays on the marketplace-origin /launching page').toContain('/launching')
   })

--- a/core/marketplace/src/components/LaunchingStep.svelte
+++ b/core/marketplace/src/components/LaunchingStep.svelte
@@ -13,14 +13,31 @@
   //
   // This page is served from the marketplace origin (`marketplace.<sov>`),
   // which ALWAYS resolves. It shows a branded "Setting up your console…"
-  // state, polls the per-Org console `/healthz` (mapped to catalyst-api by the
-  // per-Org HTTPRoute — a 200 means DNS + TLS + route are all live), and only
-  // then forwards to the existing secure `/auth/org-handover` endpoint. The
-  // handover token is carried THROUGH unchanged and handed to the server at the
-  // end of the wait, preserving the #4182/#4186 contract (token → HttpOnly
-  // cookie server-side; never logged; refresh token never in a URL). On
-  // timeout the customer sees an honest "still provisioning" state with a
-  // manual retry — never a raw browser DNS error.
+  // state, polls the per-Org console readiness, and only then forwards to the
+  // existing secure `/auth/org-handover` endpoint. The handover token is
+  // carried THROUGH unchanged and handed to the server at the end of the
+  // wait, preserving the #4182/#4186 contract (token → HttpOnly cookie
+  // server-side; never logged; refresh token never in a URL). On timeout the
+  // customer sees an honest "still provisioning" state with a manual retry —
+  // never a raw browser DNS error.
+  //
+  // #5205 — the readiness probe used to `fetch(console.<slug>.<sov>/healthz,
+  // {mode:'no-cors'})` DIRECTLY from the browser. A no-cors cross-origin
+  // fetch always returns an OPAQUE Response — its status is unreadable by
+  // design — so the only signal available was "did the fetch promise resolve
+  // at all", which a live hw270 funnel walk proved unreliable: a real signup
+  // had the backend (Org+cert+DNS+WordPress) Ready in ~35s, but the opaque
+  // probe never observed success and the interstitial rode out the full
+  // 5-minute timeout, stranding the customer on a manual "Open console
+  // anyway" click even though a direct curl/browser-nav to the same host
+  // returned 200 within seconds. The fix routes the probe through the
+  // marketplace's OWN same-origin `/api/provisioning/console-ready` endpoint
+  // (core/services/provisioning/handlers/console_ready.go) — a plain,
+  // fully-readable JSON `{ready: boolean}` computed by a server-side GET
+  // /healthz against the per-Org host, with no browser CORS/opaque-response
+  // restriction in the way at all.
+
+  import { API_BASE } from '../lib/config';
 
   type Phase = 'provisioning' | 'forwarding' | 'timeout' | 'error';
   let phase = $state<Phase>('provisioning');
@@ -81,27 +98,28 @@
 
   let params = $state<LaunchParams | null>(null);
 
-  // Probe the per-Org console /healthz. ANY failure (DNS / TLS / connection /
-  // non-2xx) is treated as "still provisioning" and swallowed — we keep
-  // polling until ready or timeout. `no-cors` keeps the probe a simple request
-  // (no preflight) and tolerates the opaque cross-origin response; a resolved
-  // fetch (opaque or ok) means the host is up and serving, a rejection means
-  // it is not reachable yet.
+  // Probe the per-Org console's readiness via the marketplace's OWN
+  // same-origin proxy (#5205). Unlike the retired cross-origin
+  // `fetch(console.<slug>/healthz, {mode:'no-cors'})` — whose opaque Response
+  // gave the browser no readable status at all — this is a plain same-origin
+  // fetch to `${API_BASE}/provisioning/console-ready`, so `res.ok` and the
+  // JSON body are both fully readable. The provisioning-service handler does
+  // the actual cross-host GET /healthz server-side and reports back a REAL
+  // `{ready: boolean}`. ANY failure (this request's own network error, a
+  // non-OK response, or an upstream ready:false) is treated as "still
+  // provisioning" and swallowed — we keep polling until ready or timeout,
+  // preserving the original probe's tolerant contract.
   async function probeReady(host: string): Promise<boolean> {
     const ctrl = new AbortController();
     const t = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
     try {
-      await fetch(`${host}/healthz`, {
-        method: 'GET',
-        mode: 'no-cors',
-        cache: 'no-store',
-        redirect: 'follow',
-        signal: ctrl.signal,
-      });
-      // A non-throwing fetch (even an opaque no-cors response) means DNS
-      // resolved, the TLS handshake completed, and the server answered — the
-      // host is reachable. NXDOMAIN / refused / TLS-fail all REJECT instead.
-      return true;
+      const res = await fetch(
+        `${API_BASE}/provisioning/console-ready?host=${encodeURIComponent(host)}`,
+        { method: 'GET', cache: 'no-store', signal: ctrl.signal },
+      );
+      if (!res.ok) return false;
+      const data = (await res.json().catch(() => null)) as { ready?: boolean } | null;
+      return data?.ready === true;
     } catch {
       return false;
     } finally {

--- a/core/services/gateway/main.go
+++ b/core/services/gateway/main.go
@@ -76,6 +76,12 @@ func main() {
 		// Provisioning — status polling is public, admin/start require auth.
 		{PathPrefix: "/api/provisioning/status/", Upstream: provisioningURL, StripPrefix: "/api", Public: true},
 		{PathPrefix: "/api/provisioning/tenant/", Upstream: provisioningURL, StripPrefix: "/api", Public: true},
+		// #5205 — same-origin readiness proxy the funnel completion
+		// interstitial polls instead of a cross-origin no-cors fetch straight
+		// at the per-Org console host (whose opaque Response the browser can
+		// never read the status of). Public: polled before the customer has
+		// any session, from the marketplace's own origin.
+		{PathPrefix: "/api/provisioning/console-ready", Upstream: provisioningURL, StripPrefix: "/api", Public: true},
 		{PathPrefix: "/api/provisioning/", Upstream: provisioningURL, StripPrefix: "/api", Public: false},
 		// Billing (mixed — public list of plans/addons/redeem-preview for
 		// the marketplace landing + /redeem flow; webhook for Stripe;

--- a/core/services/provisioning/handlers/console_ready.go
+++ b/core/services/provisioning/handlers/console_ready.go
@@ -1,0 +1,151 @@
+// console_ready.go — #5205 same-origin readiness proxy for the funnel
+// completion interstitial (marketplace's LaunchingStep.svelte).
+//
+// The per-Org console host (console.<slug>.<parentDomain>) is provisioned
+// ASYNCHRONOUSLY (DNS A-record, TLS cert, HTTPRoute — see tenant_route.go)
+// after the Org CR is created. The interstitial used to poll that host's
+// /healthz DIRECTLY from the browser with `fetch(..., {mode:'no-cors'})`.
+// Live hw270 funnel walk (#5205, 2026-07-18): a real signup completed with
+// backend Org+cert+DNS+WordPress all Ready in ~35s, but the cross-origin
+// no-cors probe NEVER observed success — the interstitial hit its 5-min
+// timeout every time, stranding every real customer on "Setting up your
+// console…" and requiring a manual "Open console anyway" click. A direct
+// curl/browser-nav to the SAME host returned 200 within seconds. The
+// no-cors opaque Response is the root cause: a cross-origin opaque
+// response's status is unreadable, so the browser-side probe was guessing
+// blind.
+//
+// Fix: the marketplace gateway (marketplace.<sov-fqdn>/api/*, PUBLIC,
+// SAME-ORIGIN as the /launching page) exposes this readiness proxy. The
+// frontend polls it same-origin — a plain JSON {"ready": bool} is fully
+// readable, no opaque response involved — and THIS handler does the actual
+// cross-host GET /healthz server-side, where no browser CORS/opaque-response
+// restriction applies at all.
+package handlers
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/openova-io/openova/core/services/shared/respond"
+)
+
+// consoleReadyProbeTimeout bounds the outbound GET /healthz this handler
+// issues. Kept short because the frontend polls on a backoff schedule (as
+// low as every 1.5s) — a single slow probe must fail fast rather than pile
+// up concurrent outbound requests.
+const consoleReadyProbeTimeout = 4 * time.Second
+
+// consoleReadyHTTPClient is dedicated to the outbound per-Org console probe.
+// Standard TLS verification is intentional: this hits a public-internet host
+// (the same cert chain a real browser nav to /auth/org-handover will
+// validate), so skipping verification here would let this endpoint report
+// "ready" against a host whose cert the eventual browser nav then rejects.
+var consoleReadyHTTPClient = &http.Client{
+	Timeout: consoleReadyProbeTimeout,
+	CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+		if len(via) >= 5 {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	},
+}
+
+// isConsoleHost mirrors the marketplace frontend's own guard
+// (LaunchingStep.svelte parseParams): the target must be an https `console`
+// or `console.*` host. This is the SSRF guard for this endpoint — without
+// it, the `host` query param would let any caller make this service issue
+// an arbitrary outbound GET.
+func isConsoleHost(u *url.URL) bool {
+	if u == nil || u.Scheme != "https" {
+		return false
+	}
+	h := strings.ToLower(u.Hostname())
+	return h == "console" || strings.HasPrefix(h, "console.")
+}
+
+// ipsArePublic reports whether every address in ips is a real, publicly
+// routable unicast address (not private/loopback/link-local/unspecified).
+// Every per-Org console host on this platform is a real public-internet
+// endpoint (a pool-domain A-record + LE cert, per docs/DOD.md domains
+// canon) — resolving to anything else means either DNS-rebinding abuse of
+// the `host` param or a caller error, and either way this handler should
+// fail closed to "not ready" rather than let this service's outbound
+// network access be used to probe internal infrastructure.
+func ipsArePublic(ips []net.IP) bool {
+	if len(ips) == 0 {
+		return false
+	}
+	for _, ip := range ips {
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			return false
+		}
+	}
+	return true
+}
+
+// resolvesToPublicIP resolves host and applies the ipsArePublic guard.
+var resolvesToPublicIP = func(host string) bool {
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return false
+	}
+	return ipsArePublic(ips)
+}
+
+// probeConsoleHealthz issues the actual GET <origin>/healthz and reports
+// whether it answered with a 2xx. Any transport failure (DNS, TLS,
+// connection refused, timeout) or non-2xx status is "not ready" — the exact
+// semantics the original no-cors probe intended (NXDOMAIN / TLS-handshake /
+// connection-refused all tolerated as "still provisioning") but, unlike an
+// opaque no-cors Response, this ACTUALLY reads the status instead of
+// guessing from fetch-resolved-vs-rejected.
+func probeConsoleHealthz(ctx context.Context, origin string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+"/healthz", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := consoleReadyHTTPClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// ConsoleReady probes a per-Org console host's /healthz server-side and
+// reports whether it is reachable + answering. Always responds 200 with
+// {"ready": bool} for a validly-shaped host param — network/TLS/DNS
+// failures and non-2xx upstream responses all fold into ready:false,
+// matching the original probe's "swallow and keep polling" contract. A
+// missing or non-console host param 400s instead: that is a caller bug,
+// never "still provisioning".
+func (h *Handler) ConsoleReady(w http.ResponseWriter, r *http.Request) {
+	raw := strings.TrimSpace(r.URL.Query().Get("host"))
+	if raw == "" {
+		respond.Error(w, http.StatusBadRequest, "host query param is required")
+		return
+	}
+	target, err := url.Parse(raw)
+	if err != nil || !isConsoleHost(target) {
+		respond.Error(w, http.StatusBadRequest, "host must be an https console.* origin")
+		return
+	}
+	if !resolvesToPublicIP(target.Hostname()) {
+		respond.OK(w, map[string]bool{"ready": false})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), consoleReadyProbeTimeout)
+	defer cancel()
+	// Reconstruct the origin ourselves (scheme + host only) rather than
+	// trusting any path/query the caller appended — the probe path is
+	// always literally /healthz.
+	origin := (&url.URL{Scheme: target.Scheme, Host: target.Host}).String()
+	respond.OK(w, map[string]bool{"ready": probeConsoleHealthz(ctx, origin)})
+}

--- a/core/services/provisioning/handlers/console_ready_5205_test.go
+++ b/core/services/provisioning/handlers/console_ready_5205_test.go
@@ -1,0 +1,184 @@
+package handlers
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// #5205 — the funnel completion interstitial used to poll the per-Org
+// console host DIRECTLY from the browser with `fetch(..., {mode:'no-cors'})`.
+// A live hw270 walk showed that probe NEVER observed success even though a
+// direct curl/browser-nav to the same host returned 200 within seconds — the
+// opaque cross-origin Response gave the browser no readable status. These
+// tests lock the readable, same-origin replacement: isConsoleHost (the SSRF/
+// open-redirect guard), ipsArePublic (the DNS-rebinding guard), and
+// probeConsoleHealthz (the part that actually reads the upstream status,
+// unlike the old opaque-response guess).
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
+}
+
+func TestIsConsoleHost(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"bare console https", "https://console.acme.omani.works", true},
+		{"exact console host", "https://console", true},
+		{"console with port", "https://console.acme.omani.works:8443", true},
+		{"case-insensitive host", "https://CONSOLE.acme.omani.works", true},
+		{"http rejected — must be https", "http://console.acme.omani.works", false},
+		{"non-console host rejected — open-redirect guard", "https://evil.example.com", false},
+		{"consoleish-but-not-dot-prefixed host rejected", "https://consolefoo.example.com", false},
+		{"marketplace host rejected", "https://marketplace.acme.omani.works", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := mustParseURL(t, tc.raw)
+			if got := isConsoleHost(u); got != tc.want {
+				t.Errorf("isConsoleHost(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIpsArePublic(t *testing.T) {
+	cases := []struct {
+		name string
+		ips  []net.IP
+		want bool
+	}{
+		{"empty resolution rejected", nil, false},
+		{"public IPv4", []net.IP{net.ParseIP("203.0.113.10")}, true},
+		{"private RFC1918 rejected", []net.IP{net.ParseIP("10.0.0.1")}, false},
+		{"private RFC1918 192.168 rejected", []net.IP{net.ParseIP("192.168.1.1")}, false},
+		{"loopback rejected", []net.IP{net.ParseIP("127.0.0.1")}, false},
+		{"link-local rejected", []net.IP{net.ParseIP("169.254.1.1")}, false},
+		{"unspecified rejected", []net.IP{net.ParseIP("0.0.0.0")}, false},
+		{"mixed public+private rejected (fail closed on ANY private answer)",
+			[]net.IP{net.ParseIP("203.0.113.10"), net.ParseIP("10.0.0.1")}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ipsArePublic(tc.ips); got != tc.want {
+				t.Errorf("ipsArePublic(%v) = %v, want %v", tc.ips, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProbeConsoleHealthz_ReadsRealStatus is the heart of the #5205 fix: unlike
+// the browser's opaque no-cors Response (which resolves the same way whether
+// the upstream answered 200 or 500), this probe reads the ACTUAL status code.
+func TestProbeConsoleHealthz_ReadsRealStatus(t *testing.T) {
+	t.Run("2xx is ready", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/healthz" {
+				t.Errorf("expected probe path /healthz, got %q", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer srv.Close()
+
+		if !probeConsoleHealthz(context.Background(), srv.URL) {
+			t.Error("probeConsoleHealthz() = false, want true for a 200 upstream")
+		}
+	})
+
+	t.Run("non-2xx is not ready — the opaque probe could never see this", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		if probeConsoleHealthz(context.Background(), srv.URL) {
+			t.Error("probeConsoleHealthz() = true, want false for a 503 upstream")
+		}
+	})
+
+	t.Run("connection refused (host torn down) is not ready", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		srv.Close() // closed before use — guarantees connection-refused
+
+		if probeConsoleHealthz(context.Background(), srv.URL) {
+			t.Error("probeConsoleHealthz() = true, want false against a closed listener")
+		}
+	})
+
+	t.Run("context deadline exceeded is not ready", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(200 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		if probeConsoleHealthz(ctx, srv.URL) {
+			t.Error("probeConsoleHealthz() = true, want false when the context deadline is exceeded")
+		}
+	})
+}
+
+// TestConsoleReady_HandlerRejectsInvalidHost exercises the HTTP handler's
+// input-validation path (no network call is reachable for these cases — a bad
+// host must never even attempt an outbound probe).
+func TestConsoleReady_HandlerRejectsInvalidHost(t *testing.T) {
+	h := &Handler{}
+
+	cases := []struct {
+		name       string
+		query      string
+		wantStatus int
+	}{
+		{"missing host param", "", http.StatusBadRequest},
+		{"non-console host (open-redirect/SSRF attempt)", "?host=" + url.QueryEscape("https://evil.example.com"), http.StatusBadRequest},
+		{"http scheme rejected", "?host=" + url.QueryEscape("http://console.acme.omani.works"), http.StatusBadRequest},
+		{"unparseable host", "?host=" + url.QueryEscape("://not-a-url"), http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/provisioning/console-ready"+tc.query, nil)
+			rec := httptest.NewRecorder()
+			h.ConsoleReady(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestConsoleReady_HandlerFailsClosedOnPrivateResolution locks the
+// DNS-rebinding guard end-to-end through the handler: a host that resolves
+// only to private/loopback addresses must report ready:false (200), not
+// attempt the outbound probe against internal infrastructure.
+func TestConsoleReady_HandlerFailsClosedOnPrivateResolution(t *testing.T) {
+	orig := resolvesToPublicIP
+	resolvesToPublicIP = func(host string) bool { return false }
+	t.Cleanup(func() { resolvesToPublicIP = orig })
+
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/provisioning/console-ready?host="+url.QueryEscape("https://console.acme.omani.works"), nil)
+	rec := httptest.NewRecorder()
+	h.ConsoleReady(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (fail-closed to ready:false, not an error)", rec.Code)
+	}
+	if body := rec.Body.String(); body != `{"ready":false}`+"\n" {
+		t.Errorf("body = %q, want ready:false", body)
+	}
+}

--- a/core/services/provisioning/handlers/routes.go
+++ b/core/services/provisioning/handlers/routes.go
@@ -9,6 +9,12 @@ func (h *Handler) Routes() http.Handler {
 	// Public — provision status polling.
 	mux.HandleFunc("GET /provisioning/status/{id}", h.GetStatus)
 	mux.HandleFunc("GET /provisioning/tenant/{tenantId}", h.GetByTenant)
+	// Public — #5205 same-origin readiness proxy for the marketplace funnel
+	// completion interstitial (LaunchingStep.svelte). Must be public: it is
+	// polled before the customer has any session, from the SAME marketplace
+	// origin, replacing the old cross-origin no-cors browser probe that could
+	// never read the per-Org console's actual readiness.
+	mux.HandleFunc("GET /provisioning/console-ready", h.ConsoleReady)
 
 	// Admin — manual provisioning and listing.
 	mux.HandleFunc("POST /provisioning/start", h.Start)


### PR DESCRIPTION
## Summary

- The funnel completion interstitial (`LaunchingStep.svelte`) polled the per-Org console's `/healthz` directly from the browser with `fetch(..., {mode:'no-cors'})`. A no-cors cross-origin fetch always returns an opaque Response whose status is unreadable, so the probe could only observe "did the fetch promise resolve" — a live hw270 funnel walk showed that signal never firing for a real signup even though the backend (Org+cert+DNS+WordPress) was Ready in ~35s and a direct curl/browser-nav to the same host returned 200 within seconds. Every real customer rode out the full 5-minute timeout and had to click "Open console anyway".
- Adds a same-origin readiness proxy — `GET /provisioning/console-ready` (`core/services/provisioning/handlers/console_ready.go`), exposed at `marketplace.<sov>/api/provisioning/console-ready` via the gateway's public route table (`core/services/gateway/main.go`) — that does the actual `GET /healthz` against the per-Org host server-side and returns a plain, fully-readable `{"ready": bool}`. Guards: https-only + `console`/`console.*` hostname (mirrors the frontend's own open-redirect guard) and a public-IP-only DNS check (fails closed against DNS-rebinding SSRF).
- `LaunchingStep.svelte`'s `probeReady` now polls this same-origin endpoint instead of the opaque cross-origin fetch, so it can tell "still provisioning" from "definitely up" instead of guessing. Timeout + manual "Open console anyway" fallback are unchanged (genuine last resort).

## Approach chosen

Same-origin catalyst-side readiness proxy (option b in the ticket), implemented on the existing public marketplace gateway (`marketplace.<sov>/api/provisioning/*`, already reached same-origin by `/launching`) rather than adding CORS headers to the org console's own `/healthz` (option a) — this avoids touching a widely-shared health endpoint and keeps the blast radius to the funnel path only.

## Test plan

- [x] `cd core/services/provisioning && go build ./... && go vet ./... && go test ./...` — green, incl. new `console_ready_5205_test.go` (validates `isConsoleHost`, `ipsArePublic`, `probeConsoleHealthz` against an `httptest` server returning 200/503/connection-refused/timeout, and the handler's 400/200 contract)
- [x] `cd core/services/gateway && go build ./... && go vet ./... && go test ./...` — green
- [x] `cd core/marketplace && npm ci && npm run build` — clean, `postbuild` domain-hygiene check passes
- [x] `npx playwright test --config=./playwright.config.ts` — 20/21 pass; the 4 launching-interstitial tests (18/19/19b/20, updated to intercept `**/api/provisioning/console-ready**` instead of the retired cross-origin `console.*/healthz` probe) all pass; the 1 pre-existing failure (`05b`, unrelated `/redeem` owner-guard test) reproduces identically against unmodified `main` — not a regression from this change

Refs #5205