### PR TITLE
fix(mcp): publish mcp.<sov-fqdn> DNS + reject Org-scoped tokens + per-Org install door (#5206)

### DIFF
--- a/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
+++ b/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
@@ -9,8 +9,11 @@
 # tool forwards the CALLER's bearer to the live catalyst-api, whose own
 # authz is the final word — the pod carries ZERO k8s RBAC and no token
 # mount. Per-Org (organization-mode) instances are NOT this slot: they
-# arrive via the org pipeline (follow-up on #5114); today the per-Org
-# path is the agenity-bundled stdio child (products/agenity).
+# install standalone via the SAME per-Org Application-CR door bp-agenity's
+# embedded stdio child already uses (POST /applications / the
+# create-instance seed path — products/catalyst/bootstrap/api/internal/
+# handler/application_parameters.go stampOpenovaMCPOrgParameters, #5206),
+# not an automatic Org-create-time trigger.
 #
 # Slot 13d — the catalyst-platform cohort (13 umbrella / 13b sso-bridge /
 # 13c oidc-gate): the facade is meaningless before catalyst-api exists,
@@ -91,6 +94,13 @@ spec:
   chart:
     spec:
       chart: bp-openova-mcp
+      # 0.1.5 (#5206): appVersion 0.2.5 — this Sovereign-mode instance's
+      # internal/identity resolver now REJECTS an Org-scoped caller instead
+      # of silently relabelling its context to Sovereign (the live hw270
+      # org-scoped-forbidden symptom — an Org-admin token had nowhere else
+      # to go before the #5206 per-Org install door existed). Values
+      # unchanged: mode=sovereign here still pins full Sovereign scope for
+      # genuine sovereign-admin bearers.
       # 0.1.2 (#5114 hw258 CHAIN-BLOCKER): appVersion 0.2.2 — the binary
       # degrades instead of CrashLooping when verify=rs256 but the OPTIONAL
       # pubkey Secret is absent/unparseable. On a Sovereign the PEM Secret
@@ -110,7 +120,7 @@ spec:
       # zero-RBAC ServiceAccount + Cilium ingress/egress CNPs. Lockstep:
       # products/openova-mcp/chart/Chart.yaml + blueprint.yaml +
       # catalog-seed (blueprints.json).
-      version: 0.1.4
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-openova-mcp

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
@@ -136,6 +136,15 @@ func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug, orgConsole
 		stampAgenityGateHost(out, orgConsoleHost)
 	}
 
+	// #5206 gap 2 — a standalone per-Org bp-openova-mcp install reuses this
+	// SAME per-Org Application-CR install door (POST /applications / the
+	// create-instance seed path) — the only per-Org provisioning pipeline
+	// that exists today (bp-agenity's embedded stdio child arrives the same
+	// way). See stampOpenovaMCPOrgParameters for the full rationale.
+	if isOpenovaMCPBlueprint(blueprint) {
+		stampOpenovaMCPOrgParameters(out, sovereignFQDN, orgSlug, orgConsoleHost)
+	}
+
 	if len(out) > 0 {
 		return out
 	}
@@ -306,6 +315,152 @@ func stampAgenityGateHost(params map[string]interface{}, orgConsoleHost string) 
 	params["httpRoute"] = hr
 }
 
+// openovaMCPOrgHTTPRouteParentRef is the console-facing Cilium Gateway a
+// per-Org bp-openova-mcp install must parent its HTTPRoute to (#4054 console
+// isolation) — the SAME gateway bp-agenity's own chart hardcodes as ITS
+// default (products/agenity/chart/values.yaml). bp-openova-mcp cannot bake
+// this into its own chart defaults because ONE chart serves both the
+// bootstrap-kit sovereign-mode slot 13d (kube-system/cilium-gateway is
+// correct there) and a per-Org install — so the org-mode gateway override
+// must come from this install-time stamp, not the chart.
+const openovaMCPOrgHTTPRouteParentRef = "cilium-gateway-console"
+
+// stampOpenovaMCPOrgParameters wires a per-Org bp-openova-mcp install
+// (#5206 gap 2 — the Pillar-4 north-star Org→MCP surface) through the SAME
+// per-Org Application-CR install door bp-agenity's embedded stdio child
+// already uses (POST /applications / the create-instance seed path) — today
+// the ONLY per-Org provisioning pipeline that exists (there is no separate
+// Org-create-time auto-provisioning trigger for either Blueprint). Mirrors
+// the proven stampAgenity* pattern field-for-field, adapted to
+// bp-openova-mcp's OWN values shape (products/openova-mcp/chart/values.yaml):
+//
+//   - mode: "organization" — pins the instance's realm context
+//     (internal/identity.Resolver.pinnedCtx) so THIS install can never widen
+//     to Sovereign scope no matter what bearer reaches it (the #5206 gap-3
+//     hardening in internal/identity/identity.go + whoami.go is what makes
+//     that pin safe: an org-scoped caller is confined to its own Org, never
+//     silently relabelled).
+//   - sovereignFqdn — so the chart's openova-mcp.catalystApiUrl helper
+//     derives https://console.<sovereignFqdn> (organization mode), giving
+//     the binary a catalyst-api client to delegate the #5175 whoami-fallback
+//     identity resolution to (internal/identity.Resolver.FromWhoami) even
+//     before any local verify key is wired.
+//   - organization.tenantHost — the Org's public console host, forwarded as
+//     X-Tenant-Host (#4116/#4610) exactly like the agenity stamp, so
+//     catalyst-api resolves the caller's OWN Org namespace on every
+//     forwarded tool call.
+//   - httpRoute.hostnames[0] = mcp.<slug>.<pool> + httpRoute.parentRef.name
+//     = cilium-gateway-console — the chart's OWN default
+//     (cilium-gateway/kube-system + mcp.<sovereignFqdn>) is the Sovereign
+//     slot-13d shape and is the WRONG gateway/host for a per-Org install
+//     (the exact #5206 gap-1 DNS-and-gateway mismatch class, applied here to
+//     the per-Org door before it ships the same bug a second time).
+//   - auth.rs256PubkeySecret — best-effort: points at the SAME in-namespace
+//     `agenity-mcp-bearer` Secret the agenity-embedded stdio child already
+//     consumes (fed by the existing per-Org OpenBao producer, seedMCPBearer
+//     / #4610 — no second producer/path needed). The chart's secretKeyRef is
+//     optional:true (products/openova-mcp/chart/templates/deployment.yaml),
+//     so an Org that has not (also) installed bp-agenity in this namespace
+//     still schedules Ready — the binary degrades to the #5175
+//     whoami-delegation path instead of crash-looping on an absent Secret.
+//
+// Deference (same as every stampAgenity* sibling): every field is set only
+// when the caller did not already pin a non-empty value; nothing here is
+// forced onto an explicit install request.
+func stampOpenovaMCPOrgParameters(params map[string]interface{}, sovereignFQDN, orgSlug, orgConsoleHost string) {
+	setIfAbsentString(params, "mode", "organization")
+	stampOpenovaMCPSovereignFqdn(params, sovereignFQDN)
+	stampOpenovaMCPTenantHost(params, orgConsoleHost)
+	stampOpenovaMCPGateHost(params, orgConsoleHost)
+	stampOpenovaMCPBearer(params, orgSlug)
+}
+
+// stampOpenovaMCPSovereignFqdn sets `parameters.sovereignFqdn` — see
+// stampOpenovaMCPOrgParameters. No-op when sovereignFQDN is empty (the
+// mothership case) so the chart's existing fail-closed default holds.
+func stampOpenovaMCPSovereignFqdn(params map[string]interface{}, sovereignFQDN string) {
+	fqdn := strings.TrimSpace(sovereignFQDN)
+	if fqdn == "" {
+		return
+	}
+	setIfAbsentString(params, "sovereignFqdn", fqdn)
+}
+
+// stampOpenovaMCPTenantHost sets `parameters.organization.tenantHost` to the
+// Org's public console host — see stampOpenovaMCPOrgParameters. No-op when
+// orgConsoleHost is empty (mothership / unregistered tenant — fail-closed).
+func stampOpenovaMCPTenantHost(params map[string]interface{}, orgConsoleHost string) {
+	host := strings.ToLower(strings.TrimSpace(orgConsoleHost))
+	if host == "" {
+		return
+	}
+	org, _ := params["organization"].(map[string]interface{})
+	if org == nil {
+		org = map[string]interface{}{}
+	}
+	setIfAbsentString(org, "tenantHost", host)
+	params["organization"] = org
+}
+
+// stampOpenovaMCPGateHost sets `parameters.httpRoute.hostnames[0]` to the
+// Org's public MCP host (mcp.<slug>.<pool>, the exact inverse derivation of
+// stampAgenityGateHost's agenity.<slug>.<pool>) and
+// `parameters.httpRoute.parentRef.name` to the console gateway — see
+// stampOpenovaMCPOrgParameters. The parentRef stamp is independent of the
+// hostnames deference: even a caller who pinned their own hostnames still
+// needs the console-gateway parentRef corrected (the chart default parents
+// the Sovereign-wide gateway, which has no listener path a per-Org install
+// can rely on being routed the same way). No-op (whole function) when
+// orgConsoleHost is empty (mothership / unregistered tenant — fail-closed,
+// chart defaults hold).
+func stampOpenovaMCPGateHost(params map[string]interface{}, orgConsoleHost string) {
+	host := strings.ToLower(strings.TrimSpace(orgConsoleHost))
+	if host == "" {
+		return
+	}
+	// console.<slug>.<pool> → <slug>.<pool>; require a dotted host so a bare
+	// label can't produce a zone-less "mcp." host.
+	parts := strings.SplitN(host, ".", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return
+	}
+	gateHost := "mcp." + parts[1]
+
+	hr, _ := params["httpRoute"].(map[string]interface{})
+	if hr == nil {
+		hr = map[string]interface{}{}
+	}
+	if existing, ok := hr["hostnames"].([]interface{}); !ok || len(existing) == 0 {
+		hr["hostnames"] = []interface{}{gateHost}
+	}
+	setIfAbsentMap(hr, "parentRef", map[string]interface{}{
+		"name": openovaMCPOrgHTTPRouteParentRef,
+	})
+	params["httpRoute"] = hr
+}
+
+// stampOpenovaMCPBearer wires `parameters.auth.rs256PubkeySecret` at the SAME
+// in-namespace Secret the agenity-embedded stdio child consumes — see
+// stampOpenovaMCPOrgParameters. No-op when orgSlug is empty (we can't scope
+// the OpenBao-fed Secret name any tighter than "the agenity convention", but
+// we at least require SOME Org identity) or the caller already pinned a
+// non-empty auth.rs256PubkeySecret.
+func stampOpenovaMCPBearer(params map[string]interface{}, orgSlug string) {
+	slug := leadingDNSLabel(orgSlug)
+	if slug == "" {
+		return
+	}
+	auth, _ := params["auth"].(map[string]interface{})
+	if auth == nil {
+		auth = map[string]interface{}{}
+	}
+	setIfAbsentMap(auth, "rs256PubkeySecret", map[string]interface{}{
+		"name": agenityMCPBearerSecretName,
+		"key":  "pubkeyPem",
+	})
+	params["auth"] = auth
+}
+
 // orgConsoleHostFor resolves the Org's public console host
 // (console.<slug>.<poolParentDomain>) for an Org ref from the tenant
 // registry — the SAME table the org-scoped install path resolves
@@ -380,6 +535,15 @@ func setIfAbsentMap(dst map[string]interface{}, key string, val map[string]inter
 	dst[key] = val
 }
 
+// setIfAbsentString sets key=val only when the destination has no non-empty
+// string value at key — the scalar-valued twin of setIfAbsentMap.
+func setIfAbsentString(dst map[string]interface{}, key, val string) {
+	if existing, ok := dst[key].(string); ok && strings.TrimSpace(existing) != "" {
+		return
+	}
+	dst[key] = val
+}
+
 // leadingDNSLabel returns the first DNS label (everything before the first
 // dot) of an Org ref, lower-cased + trimmed. "nstar2.omani.homes" → "nstar2";
 // "acme" → "acme"; "" → "". Matches the per-Org OpenBao path slug the
@@ -406,6 +570,14 @@ func isPostgresBlueprint(blueprint string) bool {
 	b := strings.TrimSpace(strings.ToLower(blueprint))
 	b = strings.TrimPrefix(b, "bp-")
 	return b == "postgres"
+}
+
+// isOpenovaMCPBlueprint reports whether the blueprint id refers to
+// bp-openova-mcp (with or without the `bp-` prefix) — #5206 gap 2.
+func isOpenovaMCPBlueprint(blueprint string) bool {
+	b := strings.TrimSpace(strings.ToLower(blueprint))
+	b = strings.TrimPrefix(b, "bp-")
+	return b == "openova-mcp"
 }
 
 // postgresConfigSchemaMode folds the canonical placement topology onto the

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
@@ -528,3 +528,159 @@ func TestDefaultedParameters_AgenityExplicitGateHostWins(t *testing.T) {
 		t.Fatalf("explicit gate host must win, got %#v", hosts)
 	}
 }
+
+// ── #5206 gap 2: a standalone per-Org bp-openova-mcp install rides the SAME
+//    Application-CR install door bp-agenity's embedded stdio child already
+//    uses. Mirrors the stampAgenity* test shape field-for-field. ──────────
+
+func TestDefaultedParameters_OpenovaMCPNoValues_StampsOrgMode(t *testing.T) {
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", nil)
+	if got["mode"] != "organization" {
+		t.Fatalf("openova-mcp org install must stamp mode=organization, got %#v", got["mode"])
+	}
+	if got["sovereignFqdn"] != "hw220.omani.works" {
+		t.Fatalf("openova-mcp org install must stamp sovereignFqdn, got %#v", got["sovereignFqdn"])
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPExplicitModeWins(t *testing.T) {
+	explicit := map[string]interface{}{"mode": "sovereign"}
+	got := defaultedParameters("openova-mcp", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", explicit)
+	if got["mode"] != "sovereign" {
+		t.Fatalf("a caller-pinned mode must NOT be overwritten, got %#v", got["mode"])
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPStampsOrgTenantHost(t *testing.T) {
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", nil)
+	org, ok := got["organization"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("openova-mcp parameters missing organization block: %#v", got)
+	}
+	if org["tenantHost"] != "console.nstar.omani.homes" {
+		t.Fatalf("organization.tenantHost = %v, want console.nstar.omani.homes (the ORG console host)", org["tenantHost"])
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPEmptyOrgConsoleHost_NoTenantHostStamp(t *testing.T) {
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar", "", nil)
+	if _, present := got["organization"]; present {
+		t.Fatalf("empty orgConsoleHost must NOT stamp organization.tenantHost, got %#v", got["organization"])
+	}
+	// mode + sovereignFqdn stamp independently of tenantHost resolution.
+	if got["mode"] != "organization" || got["sovereignFqdn"] != "hw220.omani.works" {
+		t.Fatalf("mode/sovereignFqdn must still stamp when orgConsoleHost is empty, got %#v", got)
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPStampsGateHostAndConsoleGateway(t *testing.T) {
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", nil)
+	hr, ok := got["httpRoute"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected httpRoute block, got %#v", got["httpRoute"])
+	}
+	hosts, ok := hr["hostnames"].([]interface{})
+	if !ok || len(hosts) != 1 || hosts[0] != "mcp.nstar.omani.homes" {
+		t.Fatalf("gate host = %#v, want [mcp.nstar.omani.homes] (the per-Org host, not mcp.hw220.omani.works)", hr["hostnames"])
+	}
+	parentRef, ok := hr["parentRef"].(map[string]interface{})
+	if !ok || parentRef["name"] != "cilium-gateway-console" {
+		t.Fatalf("httpRoute.parentRef.name = %v, want cilium-gateway-console (the chart default cilium-gateway is the Sovereign-wide gateway)", hr["parentRef"])
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPGateHostEmptyOrgConsole_NoStamp(t *testing.T) {
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar", "", nil)
+	if _, present := got["httpRoute"]; present {
+		t.Fatalf("no gate host/parentRef must be stamped when orgConsoleHost is empty, got %#v", got["httpRoute"])
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPExplicitHostnamesStillGetsParentRef(t *testing.T) {
+	// A caller-pinned hostnames list must be preserved verbatim, but the
+	// console-gateway parentRef correction still lands independently (the
+	// chart default parentRef is the Sovereign-wide gateway either way).
+	explicit := map[string]interface{}{
+		"httpRoute": map[string]interface{}{"hostnames": []interface{}{"mcp.custom.example"}},
+	}
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", explicit)
+	hr := got["httpRoute"].(map[string]interface{})
+	hosts := hr["hostnames"].([]interface{})
+	if hosts[0] != "mcp.custom.example" {
+		t.Fatalf("explicit gate host must win, got %#v", hosts)
+	}
+	parentRef := hr["parentRef"].(map[string]interface{})
+	if parentRef["name"] != "cilium-gateway-console" {
+		t.Fatalf("parentRef must still stamp even with an explicit hostnames list, got %#v", parentRef)
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPStampsRS256PubkeySecret(t *testing.T) {
+	// FQDN-form org ref must collapse to the leading DNS label, matching the
+	// SAME agenity-mcp-bearer Secret the embedded stdio child consumes.
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar.omani.homes", "console.nstar.omani.homes", nil)
+	auth, ok := got["auth"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("openova-mcp parameters missing auth block: %#v", got)
+	}
+	pk, ok := auth["rs256PubkeySecret"].(map[string]interface{})
+	if !ok || pk["name"] != agenityMCPBearerSecretName || pk["key"] != "pubkeyPem" {
+		t.Fatalf("auth.rs256PubkeySecret must point at %q/pubkeyPem, got %#v", agenityMCPBearerSecretName, auth["rs256PubkeySecret"])
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPEmptyOrgSlug_NoBearerStamp(t *testing.T) {
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "", "console.nstar.omani.homes", nil)
+	if _, ok := got["auth"]; ok {
+		t.Fatalf("empty org slug must NOT stamp auth.rs256PubkeySecret, got %#v", got["auth"])
+	}
+}
+
+func TestDefaultedParameters_OpenovaMCPExplicitPubkeySecretWins(t *testing.T) {
+	explicit := map[string]interface{}{
+		"auth": map[string]interface{}{"rs256PubkeySecret": map[string]interface{}{"name": "pinned-secret", "key": "pubkeyPem"}},
+	}
+	got := defaultedParameters("bp-openova-mcp", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", explicit)
+	auth := got["auth"].(map[string]interface{})
+	pk := auth["rs256PubkeySecret"].(map[string]interface{})
+	if pk["name"] != "pinned-secret" {
+		t.Fatalf("a caller-pinned auth.rs256PubkeySecret must NOT be overwritten, got %#v", pk)
+	}
+}
+
+func TestDefaultedParameters_NonOpenovaMCP_NoStamps(t *testing.T) {
+	got := defaultedParameters("bp-agenity", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", nil)
+	if got["mode"] != nil {
+		t.Fatalf("non-openova-mcp Blueprint must NOT get the mode stamp, got %#v", got["mode"])
+	}
+}
+
+func TestNewApplicationUnstructured_OpenovaMCP_StampsOrgParameters(t *testing.T) {
+	req := applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-openova-mcp", Version: "0.1.4"},
+		Name:            "openova-mcp",
+		OrganizationRef: "nstar.omani.homes",
+		EnvironmentRef:  "nstar-prod",
+		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"primary"}},
+	}
+	obj := newApplicationUnstructured(req, "hw220.omani.works", "console.nstar.omani.homes")
+	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
+	if !found || params == nil {
+		t.Fatalf("spec.parameters absent/nil for openova-mcp install")
+	}
+	if params["mode"] != "organization" {
+		t.Fatalf("openova-mcp Application CR must carry spec.parameters.mode=organization, got %#v", params)
+	}
+	if params["sovereignFqdn"] != "hw220.omani.works" {
+		t.Fatalf("openova-mcp Application CR must carry spec.parameters.sovereignFqdn, got %#v", params)
+	}
+	org := params["organization"].(map[string]interface{})
+	if org["tenantHost"] != "console.nstar.omani.homes" {
+		t.Fatalf("organization.tenantHost = %v, want console.nstar.omani.homes", org["tenantHost"])
+	}
+	hr := params["httpRoute"].(map[string]interface{})
+	hosts := hr["hostnames"].([]interface{})
+	if hosts[0] != "mcp.nstar.omani.homes" {
+		t.Fatalf("httpRoute.hostnames = %v, want [mcp.nstar.omani.homes]", hosts)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
@@ -25,7 +25,7 @@
 // What this writes:
 //   For every CanonicalSovereignSubdomain (console / auth / gitea /
 //   harbor / bao / grafana / hubble / pdns / pdns-admin / openova-flow /
-//   marketplace / api / registry / guacamole / newapi / sandbox) an A record
+//   marketplace / api / registry / guacamole / newapi / sandbox / mcp) an A record
 //     <sub>.<sovereign-fqdn>. → <primary-lb-ipv4>
 //   in the parent zone. PATCH REPLACE — idempotent re-runs are safe.
 
@@ -48,6 +48,8 @@ import (
 //   - platform/catalyst-platform/chart/templates/*.yaml
 //   - platform/bp-keycloak / bp-gitea / bp-harbor / bp-openbao / bp-grafana /
 //     bp-pdns / bp-openova-flow-server / bp-guacamole / bp-newapi (HTTPRoute hostnames)
+//   - products/openova-mcp/chart/templates/httproute.yaml (bp-openova-mcp,
+//     sovereign-mode host mcp.<sov-fqdn> — #5206)
 //
 // Operator-overridable via CATALYST_SOVEREIGN_SUBDOMAINS (comma-separated)
 // for the rare case where the Sovereign exposes a custom subset.
@@ -91,6 +93,19 @@ var CanonicalSovereignSubdomains = []string{
 	// reach the URL even though the Gateway listener + HTTPRoute exist).
 	// Matches the cilium-gateway-cert.yaml SAN list (sandbox.<sov-fqdn>).
 	"sandbox",
+	// mcp — public URL for the Sovereign-mode OpenOva MCP server
+	// (bp-openova-mcp, bootstrap-kit slot 13d, host mcp.${SOVEREIGN_FQDN}
+	// per clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml). The
+	// chart renders an Accepted=True HTTPRoute on the shared cilium-gateway
+	// (products/openova-mcp/chart/templates/httproute.yaml) but — same
+	// #3263/#3225 gap class — that alone never resolves publicly: only the
+	// prefixes in THIS allowlist get an A record in the parent zone. Caught
+	// live on hw270 (2026-07-18): `dig mcp.hw270.omantel.biz` returned empty
+	// for 3h+ while every sibling (registry/gitea/console) resolved, even
+	// though the HTTPRoute was Accepted and the backend healthy — blocking
+	// the entire Pillar-4 Org→MCP north star (#5206). Wildcard TLS
+	// (*.<fqdn>) already covers it; no cert/SAN change needed.
+	"mcp",
 }
 
 // ConsoleGatewaySubdomains — the subset of CanonicalSovereignSubdomains whose

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
@@ -52,6 +52,7 @@ func TestCanonicalSovereignSubdomainsCoversBrowserFacingApps(t *testing.T) {
 		"openova-flow", // bp-openova-flow-server
 		"newapi",       // bp-newapi (LLM gateway) — #3263 row 6
 		"sandbox",      // bp-sandbox per-Sandbox pty-server
+		"mcp",          // bp-openova-mcp sovereign-mode instance — #5206
 	}
 
 	for _, sub := range want {

--- a/products/openova-mcp/blueprint.yaml
+++ b/products/openova-mcp/blueprint.yaml
@@ -6,6 +6,12 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
+  # 0.1.5 (#5206): appVersion 0.2.5 — internal/identity (fromClaims +
+  # FromWhoami) now rejects an Org-scoped caller reaching a Sovereign-pinned
+  # instance instead of silently relabelling its context to Sovereign (the
+  # live hw270 org-scoped-forbidden symptom). Also adds the per-Org install
+  # door (application_parameters.go stampOpenovaMCPOrgParameters) — no chart
+  # template changes. Lockstep: chart/Chart.yaml + bootstrap-kit slot 13d.
   # 0.1.2 (#5114 hw258 CHAIN-BLOCKER): appVersion 0.2.2 — the binary degrades
   # instead of CrashLooping when verify=rs256 but the OPTIONAL pubkey Secret
   # is absent/unparseable (the sovereign-mode slot-13d case: the PEM Secret
@@ -23,7 +29,7 @@ spec:
   # HTTPRoute + zero-RBAC ServiceAccount + Cilium CNPs). Lockstep with
   # products/openova-mcp/chart/Chart.yaml 0.1.2 + bootstrap-kit slot 13d pin
   # + the catalog-seed (blueprints.json) entry.
-  version: 0.1.4
+  version: 0.1.5
   card:
     title: OpenOva MCP
     summary: |
@@ -39,9 +45,11 @@ spec:
     documentation: https://github.com/openova-io/openova
     license: MIT
   # unlisted — infrastructure component: the sovereign-mode instance is
-  # auto-installed by bootstrap-kit slot 13d; the per-Org instance arrives
-  # via the org pipeline (follow-up on #5114), not a marketplace card. The
-  # USER-facing Pillar-4 card is bp-agenity, which consumes this MCP.
+  # auto-installed by bootstrap-kit slot 13d; the per-Org instance installs
+  # standalone through the SAME Application-CR door bp-agenity's embedded
+  # stdio child already uses (POST /applications, #5206), not a marketplace
+  # card. The USER-facing Pillar-4 card is bp-agenity, which consumes this
+  # MCP.
   visibility: unlisted
   owner:
     team: ai-platform

--- a/products/openova-mcp/chart/Chart.yaml
+++ b/products/openova-mcp/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-openova-mcp
+# 0.1.5 / appVersion 0.2.5 (#5206, Org-usability gap-3 hardening): a
+# Sovereign-mode (mode=sovereign, pinnedCtx=Sovereign) instance used to
+# silently RELABEL any Org-scoped caller's context to Sovereign — harmless
+# for tool-visibility (Tier still gates it) but it misrouted every
+# downstream tool call at the Sovereign-WIDE catalyst-api seam
+# (requireDeployment + the deployment-addressed route table), which the
+# endpoint's own OrgScopeGuard then 403'd with an opaque
+# "org-scoped-forbidden" (live hw270 symptom: an Org-admin token hit the
+# only deployed instance — mode=sovereign, slot 13d — and list_applications
+# 403'd). internal/identity/identity.go (fromClaims) + whoami.go
+# (FromWhoami) now REJECT up front with a clear, actionable identity error
+# instead of misrouting. #5206 also adds the per-Org install door
+# (products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+# stampOpenovaMCPOrgParameters) — a chart-values-only change, no template
+# edits — and the parent-zone A-record fix for mcp.<sov-fqdn>
+# (sovereign_dns_records.go CanonicalSovereignSubdomains), neither of which
+# touch this chart. Lockstep: blueprint.yaml + slot 13d → 0.1.5 (not in
+# catalog-seed, matching the 0.1.3/0.1.4 precedent).
+#
 # 0.1.4 / appVersion 0.2.4 (#5175, north-star close): the MCP verifies bearers
 # against the mothership HANDOVER public key, but real callers present
 # post-handover SESSION tokens signed with a deployment-local key the MCP does
@@ -74,8 +93,11 @@ type: application
 # catalog-seed (blueprints.json) 0.1.1. Image = ghcr.io/openova-io/
 # openova-mcp:<appVersion> (build-openova-mcp.yaml; plain image repo per
 # the #4706 chart-repo-collision lesson).
-version: 0.1.4
+version: 0.1.5
 # appVersion is the default image tag (openova-mcp.image in _helpers.tpl).
+# 0.2.5 (#5206): see the version-0.1.5 note above — identity.go/whoami.go
+# reject an Org-scoped caller reaching a Sovereign-pinned instance instead
+# of silently relabelling it.
 # 0.2.2 (#5114): buildResolver degrades instead of exiting when the rs256
 # verify pubkey (or the hs256 secret) is absent/unparseable — see the 0.1.2
 # note above. 0.2.1 rebuilds 0.2.0 with a NUMERIC USER (65532:65532) — see
@@ -86,7 +108,7 @@ version: 0.1.4
 # the OPENOVA_MCP_EXPECTED_ISSUER / OPENOVA_MCP_ORG_SCOPE instance pins) —
 # the 0.1.x binary was stdio-only (the agenity in-pod child, #4010/#4097)
 # and cannot back a Service.
-appVersion: "0.2.4"
+appVersion: "0.2.5"
 keywords:
   - mcp
   - agent

--- a/products/openova-mcp/chart/DESIGN.md
+++ b/products/openova-mcp/chart/DESIGN.md
@@ -22,6 +22,21 @@ the tool surface is filtered per caller by the two-layer RBAC in
   do in the console. The Sandbox concept this replaces was removed by the
   founder 2026-06-30; bootstrap-kit slot 19a (bp-sandbox) is retired in the
   same change that adds this chart (#5114).
+- **Per-Org install door (#5206)**: a standalone `mode: organization`
+  instance installs through the SAME per-Org Application-CR door bp-agenity's
+  embedded stdio child already uses (`POST /applications` / the
+  create-instance seed path) — there is no separate Org-create-time
+  auto-provisioning trigger. `products/catalyst/bootstrap/api/internal/
+  handler/application_parameters.go`'s `stampOpenovaMCPOrgParameters` stamps
+  `mode=organization`, `sovereignFqdn`, `organization.tenantHost`,
+  `httpRoute.hostnames=[mcp.<slug>.<pool>]`,
+  `httpRoute.parentRef.name=cilium-gateway-console`, and (best-effort)
+  `auth.rs256PubkeySecret` at the same in-namespace `agenity-mcp-bearer`
+  Secret bp-agenity's stdio child consumes — mirroring the proven
+  `stampAgenity*` pattern field-for-field. An Org without bp-agenity (yet)
+  installed still gets a working instance: the optional pubkey secretKeyRef
+  resolves absent and the binary falls back to the #5175 whoami-delegation
+  identity path (see the pinnedCtx hardening note below).
 - **Thin facade (#3988 §3, load-bearing)**: every data tool forwards the
   caller's bearer to the LIVE catalyst-api; the endpoint's own authz is the
   final word. The chart enforces this architecturally: the ServiceAccount
@@ -78,9 +93,15 @@ so RBAC semantics cannot diverge per transport.
 
 ## Verify-key reality (sharp edge)
 
-`auth.rs256PubkeySecret` defaults to Secret `catalyst-handover-jwt`, key
-`handover-jwt-public.pem` — present in `catalyst-system` (where the
-sovereign-mode slot lands). The `catalyst-handover-jwt-public` mirror holds
-a **JWK, not PEM** (#4228) — do not point the chart at it. The secretKeyRef
-renders `optional: true` so an install where the Secret is absent still
-schedules and the binary falls back to inherited process env.
+`auth.rs256PubkeySecret` defaults to Secret `catalyst-handover-jwt-public`,
+key `public.jwk` (#5167) — the JWK mirror a Sovereign actually seeds in
+`catalyst-system` (where the sovereign-mode slot lands); the ≥0.2.3 binary
+parses an RSA JWK natively alongside PKIX/PKCS1 PEM. The aspirational PEM
+Secret `catalyst-handover-jwt` / key `handover-jwt-public.pem` referenced by
+pre-#5167 defaults is NEVER created on a Sovereign — do not point the chart
+back at it. The secretKeyRef renders `optional: true` so an install where
+the Secret is absent (e.g. a per-Org install whose namespace has not
+installed bp-agenity — see the #5206 per-Org install door above, which
+points this same field at the in-namespace `agenity-mcp-bearer` /
+`pubkeyPem` Secret instead) still schedules and the binary falls back to
+the #5175 whoami-delegation identity path.

--- a/products/openova-mcp/internal/identity/identity.go
+++ b/products/openova-mcp/internal/identity/identity.go
@@ -329,6 +329,19 @@ func (r *Resolver) fromClaims(claims *sharedauth.Claims) (*Identity, error) {
 		if r.pinnedCtx == ContextOrganization && id.OrgID == "" {
 			return nil, errors.New("identity: per-Org MCP requires an org-scoped token (no org_id claim)")
 		}
+		// #5206: the symmetric guard. A Sovereign-mode instance must NEVER
+		// silently relabel an Org-scoped token (derived ContextOrganization —
+		// i.e. NOT a sovereign-admin) as Sovereign. Doing so used to route
+		// every downstream tool call at the Sovereign-wide catalyst-api seam
+		// (requireDeployment + the deployment-addressed route table), which
+		// the endpoint's OWN OrgScopeGuard then 403s — an opaque
+		// "org-scoped-forbidden" surfacing far from its actual cause (the
+		// live hw270 symptom: an Org-admin token hit the only deployed
+		// instance, mode=sovereign, and list_applications 403'd). Reject up
+		// front with a clear, actionable identity error instead.
+		if r.pinnedCtx == ContextSovereign && id.Context == ContextOrganization {
+			return nil, fmt.Errorf("identity: this Sovereign-mode MCP instance requires a sovereign-admin session; the caller's token is scoped to organization %q — use that Organization's own MCP instance instead", id.OrgID)
+		}
 		id.Context = r.pinnedCtx
 	}
 

--- a/products/openova-mcp/internal/identity/identity_pins_test.go
+++ b/products/openova-mcp/internal/identity/identity_pins_test.go
@@ -66,3 +66,33 @@ func TestOrgScopePin(t *testing.T) {
 		t.Fatal("cross-org token accepted by org-pinned instance")
 	}
 }
+
+// #5206 — the symmetric guard: a Sovereign-pinned instance (mode=sovereign,
+// the ONLY instance deployed today — bootstrap-kit slot 13d) must REJECT an
+// Org-scoped token outright rather than silently relabelling its context to
+// Sovereign. The pre-fix behaviour let the token through as ContextSovereign,
+// which then misrouted every downstream tool call at the Sovereign-wide
+// catalyst-api seam and got an opaque "org-scoped-forbidden" 403 far from its
+// actual cause (the live hw270 symptom).
+func TestSovereignPinRejectsOrgScopedToken(t *testing.T) {
+	orgToken := mintNone(t, &sharedauth.Claims{Email: "u@acme.test", OrgID: "acme", Tier: "org-admin"})
+
+	r := NewInsecureResolver(ContextSovereign)
+	_, err := r.Resolve(orgToken)
+	if err == nil {
+		t.Fatal("Sovereign-pinned instance accepted an Org-scoped token instead of rejecting it")
+	}
+	if !strings.Contains(err.Error(), "sovereign-admin") || !strings.Contains(err.Error(), "acme") {
+		t.Fatalf("rejection error should name the sovereign-admin requirement + the caller's org, got: %v", err)
+	}
+
+	// A genuine sovereign-admin token still resolves fine on the same pin.
+	sovToken := mintNone(t, &sharedauth.Claims{Email: "e@openova.io", Role: "sovereign-admin"})
+	id, err := r.Resolve(sovToken)
+	if err != nil {
+		t.Fatalf("Sovereign-pinned instance rejected a genuine sovereign-admin token: %v", err)
+	}
+	if id.Context != ContextSovereign {
+		t.Fatalf("got context %q, want sovereign", id.Context)
+	}
+}

--- a/products/openova-mcp/internal/identity/whoami.go
+++ b/products/openova-mcp/internal/identity/whoami.go
@@ -80,6 +80,13 @@ func (r *Resolver) FromWhoami(w WhoamiIdentity, rawBearer string) (*Identity, er
 		if r.pinnedCtx == ContextOrganization && id.OrgID == "" {
 			return nil, errors.New("identity: per-Org MCP requires an org-scoped session (no org in whoami)")
 		}
+		// #5206: the symmetric guard (see fromClaims) — a Sovereign-mode
+		// instance must never relabel an org-scoped whoami verdict as
+		// Sovereign; that misroutes the caller at the Sovereign-wide
+		// catalyst-api seam instead of rejecting cleanly up front.
+		if r.pinnedCtx == ContextSovereign && id.Context == ContextOrganization {
+			return nil, fmt.Errorf("identity: this Sovereign-mode MCP instance requires a sovereign-admin whoami verdict; catalyst-api resolved the caller to organization %q — use that Organization's own MCP instance instead", id.OrgID)
+		}
 		id.Context = r.pinnedCtx
 	}
 	if id.Context == ContextOrganization && id.OrgID == "" {

--- a/products/openova-mcp/internal/identity/whoami_test.go
+++ b/products/openova-mcp/internal/identity/whoami_test.go
@@ -107,3 +107,31 @@ func TestFromWhoami_EmptyBearerRejected(t *testing.T) {
 		t.Fatal("empty bearer accepted")
 	}
 }
+
+// #5206 — the symmetric guard on the whoami-fallback path (mirrors
+// TestSovereignPinRejectsOrgScopedToken in identity_pins_test.go): a
+// Sovereign-pinned instance must reject an org-scoped whoami verdict instead
+// of silently relabelling it Sovereign — the exact hw270 misroute (an
+// Org-admin session hit the only deployed instance, mode=sovereign, and
+// list_applications 403'd org-scoped-forbidden downstream at catalyst-api).
+func TestFromWhoami_SovereignPinRejectsOrgScopedVerdict(t *testing.T) {
+	r := NewDegradedResolver("no session pubkey", ContextSovereign)
+	_, err := r.FromWhoami(WhoamiIdentity{
+		Email: "u@acme.test", Mode: "organization", Tier: "admin", Org: "acme",
+	}, "sess.tok.org")
+	if err == nil {
+		t.Fatal("Sovereign-pinned instance accepted an org-scoped whoami verdict instead of rejecting it")
+	}
+	if !strings.Contains(err.Error(), "sovereign-admin") || !strings.Contains(err.Error(), "acme") {
+		t.Fatalf("rejection error should name the sovereign-admin requirement + the caller's org, got: %v", err)
+	}
+
+	// A genuine sovereign verdict still resolves fine on the same pin.
+	id, err := r.FromWhoami(WhoamiIdentity{Email: "e@openova.io", Mode: "sovereign", Tier: "owner"}, "sess.tok.sov")
+	if err != nil {
+		t.Fatalf("Sovereign-pinned instance rejected a genuine sovereign verdict: %v", err)
+	}
+	if id.Context != ContextSovereign {
+		t.Fatalf("got context %q, want sovereign", id.Context)
+	}
+}


### PR DESCRIPTION
## Summary

Refs #5206 — live hw270 walk found the Pillar-4 MCP north star (an
Organization member reaching the OpenOva MCP surface) unreachable, despite
the MCP machinery itself genuinely working (`create_application` returns a
real 201 with a sovereign-admin token). Three compounding gaps, all
addressed:

1. **No DNS for `mcp.<sov-fqdn>`** — the HTTPRoute renders `Accepted=True`
   with a healthy backend, but (the same #3263/#3225 gap class) that alone
   never publishes a public A record: only the prefixes in catalyst-api's
   `CanonicalSovereignSubdomains` allowlist get one written into the parent
   PowerDNS zone. Added `"mcp"` to the allowlist in
   `products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go`.
   The wildcard TLS SAN (`*.<fqdn>`) already covers the host — no cert
   change needed. Regression test
   `TestCanonicalSovereignSubdomainsCoversBrowserFacingApps` updated.

2. **No per-Org MCP instance** — only the bootstrap-kit sovereign-mode slot
   13d existed; `mode=organization` had no install path. Wired a standalone
   per-Org install through the *same* per-Org Application-CR door
   `bp-agenity`'s embedded stdio child already uses (`POST /applications` /
   the create-instance seed path — there is no separate Org-create-time
   auto-provisioning trigger for either Blueprint today).
   `application_parameters.go`'s new `stampOpenovaMCPOrgParameters` mirrors
   the proven `stampAgenity*` pattern field-for-field:
   - `mode: organization` (pins the instance's realm context)
   - `sovereignFqdn` (so the chart derives `https://console.<sovereignFqdn>`, giving the binary a catalyst-api client for the #5175 whoami-delegation identity path)
   - `organization.tenantHost` (the Org's public console host, forwarded as `X-Tenant-Host`)
   - `httpRoute.hostnames=[mcp.<slug>.<pool>]` + `httpRoute.parentRef.name=cilium-gateway-console` (the chart's own default — `cilium-gateway`/`mcp.<sovereignFqdn>` — is the Sovereign slot-13d shape and is the wrong gateway/host for a per-Org install)
   - `auth.rs256PubkeySecret` (best-effort, points at the same in-namespace `agenity-mcp-bearer` Secret the agenity stdio child already consumes; the chart's `secretKeyRef` is `optional:true` so an Org without `bp-agenity` installed still schedules Ready and degrades to the whoami-fallback path)

   No chart template changes — this is entirely install-time values wiring.
   Verified by rendering the exact stamped values through the real chart
   (`helm template` with `mode=organization` + the stamped overrides) —
   correct `OPENOVA_MCP_CONTEXT`, `OPENOVA_MCP_CATALYST_API_URL`,
   `OPENOVA_MCP_TENANT_HOST`, and an `HTTPRoute` parented on
   `cilium-gateway-console` at `mcp.<slug>.<pool>`.

3. **Sovereign-context pin** — the deployed (and only) instance pins
   `OPENOVA_MCP_CONTEXT=sovereign`, and `internal/identity`'s pin logic
   *unconditionally* relabelled every caller's context to Sovereign
   regardless of the token's real scope. An Org-admin token reaching that
   instance got silently promoted to `ContextSovereign`, which routed
   `list_applications` at the Sovereign-**wide** catalyst-api seam instead
   of the Org-scoped one — and that endpoint's own `OrgScopeGuard` 403'd it
   as `org-scoped-forbidden`, an opaque failure far from its actual cause
   (exactly the live hw270 symptom). `internal/identity/identity.go`
   (`fromClaims`) and `whoami.go` (`FromWhoami`) now **reject up front**
   with a clear, actionable error — `"this Sovereign-mode MCP instance
   requires a sovereign-admin session; the caller's token is scoped to
   organization %q — use that Organization's own MCP instance instead"` —
   instead of misrouting. A genuine sovereign-admin session is unaffected.

Chart version bumped in lockstep (0.1.4→0.1.5 / appVersion 0.2.4→0.2.5) —
blueprint.yaml + bootstrap-kit slot 13d pin updated to match.

## What's NOT in this PR (scoped out, per the dispatch brief)

- **Automatic Org-create-time provisioning.** This PR makes bp-openova-mcp
  installable in `mode=organization` through the existing per-Org
  Application-CR install door — the same bar `bp-agenity` itself meets
  today (neither is auto-provisioned at Org-create; both are installed
  on-demand via `POST /applications`). A zero-click "every new Org
  automatically gets its own MCP instance the moment it's created" trigger
  is a materially larger provisioning-pipeline change (deciding the
  trigger point in `core/controllers/organization`, DNS story for the pool
  wildcard vs an explicit registration, etc.) and needs live-env validation
  I can't do from this worktree. Flagging it explicitly rather than
  guessing at the design.
- The `auth.rs256PubkeySecret` best-effort wiring in gap 2 assumes
  `bp-agenity` is (or will be) installed in the same Org namespace to
  produce the `agenity-mcp-bearer` Secret. This is safe (the ref is
  `optional:true`, degrades to the whoami-fallback path) but is worth a
  live-env walk to confirm the whoami-fallback path actually round-trips
  end-to-end against a real Sovereign's catalyst-api — I could only verify
  the identity-resolution logic and the chart-render shape from this
  sandboxed worktree, not a live cluster.

## Verification

- `go build ./... && go test ./...` green for both
  `products/openova-mcp` and `products/catalyst/bootstrap/api` (new tests
  included: `TestSovereignPinRejectsOrgScopedToken`,
  `TestFromWhoami_SovereignPinRejectsOrgScopedVerdict`, and the
  `TestDefaultedParameters_OpenovaMCP*` / `TestNewApplicationUnstructured_OpenovaMCP_StampsOrgParameters` table).
- `helm lint` + the chart's own `tests/render-modes.sh` gate pass
  unchanged (no chart template edits).
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (bp-openova-mcp chart=0.1.5 pin=0.1.5).
- `scripts/check-catalog-seed-lockstep.sh` — PASS.
- `scripts/check-no-nodeports.sh` — PASS (`OK: zero NodePorts across sources + rendered charts`). No NodePort anywhere in this diff (`git diff | grep -i nodeport` → empty); no chart Service/template was touched.
- No Hetzner/Huawei-provider-specific files touched — every change is in `clusters/_template/` (the shared template) or provider-agnostic Go source.

## Test plan

- [ ] Fresh-prov or live-Sovereign walk: confirm `dig mcp.<sov-fqdn>` resolves post-fix (gap 1)
- [ ] Install `bp-openova-mcp` with `mode=organization` via `POST /applications` in a live Org namespace; confirm the Deployment reaches Ready and the HTTPRoute serves `mcp.<slug>.<pool>` on the console gateway (gap 2)
- [ ] From that Org's session token, confirm `whoami`/`list_applications` resolve the caller's own Org (not 403) — both via the new per-Org instance and, as a regression check, confirm an Org-scoped token against the *existing* Sovereign-mode instance now gets the new clear rejection instead of a 403 (gap 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)