### PR TITLE
fix(cutover): authenticate the Crossplane package pull against the Sovereign-local Harbor (step-11)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -897,7 +897,7 @@ spec:
       # (prewarm.proxyBackoffBaseSeconds=30, doubling). FATAL-on-any-failure, the
       # #5030 dest-check skip, the #4975 pre-pass + multi-arch handling all
       # preserved. Contract Case 60.
-      version: 0.1.138
+      version: 0.1.139
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.138
+  version: 0.1.139
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,29 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.139 (#5204 Refs #3379 — step-11 crossplane-provider-pivot: wire
+# package-pull AUTHENTICATION for the Sovereign-local Harbor. Pivoting
+# Provider.spec.package to harbor.<fqdn>/proxy-xpkg was necessary but NOT
+# sufficient: proxy-xpkg is a Harbor PROXY-CACHE project and Harbor requires an
+# authenticated pull from a proxy-cache project even when it is public, and the
+# Crossplane package manager (go-containerregistry remote.Image()) uses its OWN
+# registry-auth path — NOT the node containerd certs.d (step 04) nor the
+# ghcr-pull dockerconfigjson (step 06, wired for Flux source-controller). So
+# every post-cutover Provider package re-pull / version upgrade / inactive-
+# revision reconcile 401s (live hw270 dep b2f0a9b0585f6781: provider-opentofu
+# Installed=False, UnpackingPackage, 401 Unauthorized — the existing revision
+# keeps running, so live adoption is unaffected TODAY, but the Sovereign can
+# never upgrade its own Crossplane providers post-severance → a Pillar-5
+# durability gap). Step 11 Phase 0 now creates a dockerconfigjson Secret in
+# crossplane-system carrying the SAME admin:<HARBOR password> step 02/03/06 use
+# and an ImageConfig (pkg.crossplane.io/v1beta1, native in Crossplane 1.18)
+# whose matchImages cover harbor.<fqdn>/proxy-xpkg + registry.<fqdn>/proxy-xpkg
+# and whose spec.registry.authentication.pullSecretRef points at that Secret —
+# so the package manager authenticates the pull. Runs BEFORE the Phase-1 patch
+# so the re-pull it triggers already has auth; idempotent (kubectl apply);
+# fail-loud (FATAL on empty HARBOR_PASSWORD or apply failure); skip-if-CRD-
+# absent in the very-early-handover window. RBAC gains pkg.crossplane.io/
+# imageconfigs create/get/list/watch/update/patch.)
+#
 # 0.1.136 (#5095 Refs #5093 #3379 — step-03 harbor-prewarm: direct-source
 # fallback + flap-tolerant pacing for MOTHERSHIP-PROXY-sourced copies).
 # Docker-Hub-sourced bootstrap images route through the mothership Harbor
@@ -2241,7 +2265,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.138
+version: 0.1.139
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -139,6 +139,34 @@ data:
           # survives the cutover (Principle #11).
           - name: MOTHERSHIP_PROXY_PREFIX
             value: {{ .Values.crossplaneProviderPivot.mothershipProxyPrefix | quote }}
+          # #5204 — package-pull AUTH for the Sovereign-local Harbor. The
+          # canonical public registry host (registry.<sov-fqdn>) is derived
+          # from HARBOR_PUBLIC_URL exactly the way step 03/06 do; the pivot
+          # host (harbor.<sov-fqdn>) is computed from SOVEREIGN_FQDN below.
+          # Both are covered by the pull Secret + ImageConfig so the Crossplane
+          # package manager authenticates against whichever alias a Provider's
+          # spec.package carries.
+          - name: HARBOR_PUBLIC_URL
+            value: {{ .Values.sovereign.harborPublicURL | quote }}
+          - name: HARBOR_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.usernameKey }}
+                optional: true
+          - name: HARBOR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.passwordKey }}
+          - name: PACKAGE_PULL_AUTH_ENABLED
+            value: {{ .Values.crossplaneProviderPivot.packagePullAuth.enabled | quote }}
+          - name: CROSSPLANE_NAMESPACE
+            value: {{ .Values.crossplaneProviderPivot.packagePullAuth.crossplaneNamespace | quote }}
+          - name: PULL_SECRET_NAME
+            value: {{ .Values.crossplaneProviderPivot.packagePullAuth.pullSecretName | quote }}
+          - name: IMAGE_CONFIG_NAME
+            value: {{ .Values.crossplaneProviderPivot.packagePullAuth.imageConfigName | quote }}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
@@ -159,6 +187,88 @@ data:
             echo "[crossplane-provider-pivot] target host:   ${target_host}"
             echo "[crossplane-provider-pivot] upstream:      ${upstream_prefix}"
             echo "[crossplane-provider-pivot] target prefix: ${target_prefix}"
+
+            # ---- Phase 0: wire package-pull AUTH (ImageConfig + Secret) ----
+            #
+            # #5204 (Refs #3379). Pivoting spec.package to the local Harbor's
+            # `proxy-xpkg` project is NOT sufficient: `proxy-xpkg` is a Harbor
+            # PROXY-CACHE project, and Harbor requires an AUTHENTICATED pull
+            # from a proxy-cache project even when the project is public
+            # (unlike the push-mode offline-mirror projects step 02 creates
+            # public:true for anonymous pull). The Crossplane package manager
+            # (go-containerregistry remote.Image()) uses its OWN registry-auth
+            # path — NOT the node containerd certs.d (step 04) nor the
+            # flux-system/ghcr-pull dockerconfigjson (step 06, wired for Flux
+            # source-controller). With no credential wired it pulls anonymously
+            # and 401s (live hw270: provider-opentofu Installed=False,
+            # UnpackingPackage, 401 Unauthorized) — a latent Pillar-5 gap: the
+            # existing revision keeps running, but the Sovereign can never
+            # upgrade its own Crossplane providers post-severance.
+            #
+            # FIX (Crossplane 1.18 native): create a dockerconfigjson Secret in
+            # the Crossplane namespace carrying the SAME admin:<HARBOR password>
+            # credential step 02/03/06 use, and an ImageConfig
+            # (pkg.crossplane.io/v1beta1) whose matchImages prefixes cover the
+            # pivot host `harbor.<fqdn>/proxy-xpkg` AND the canonical
+            # `registry.<fqdn>/proxy-xpkg` alias, with
+            # spec.registry.authentication.pullSecretRef -> that Secret. The
+            # package manager then authenticates every package pull against the
+            # local Harbor. Runs BEFORE Phase 1 so the spec.package patch's
+            # immediate re-pull already has auth. Idempotent (kubectl apply).
+            registry_host="$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/.*$,,')"
+
+            if [ "${PACKAGE_PULL_AUTH_ENABLED}" != "true" ]; then
+              echo "[crossplane-provider-pivot] Phase 0 SKIP — packagePullAuth.enabled=false"
+            elif ! kubectl get crd imageconfigs.pkg.crossplane.io >/dev/null 2>&1; then
+              # Same very-early-handover guard Phase 1 uses: bp-crossplane not
+              # installed yet (no ImageConfig CRD, no crossplane-system ns).
+              # Phase 2 still rewrites Gitea so the eventual install pulls the
+              # pivoted URL; a step re-run once crossplane lands wires the auth.
+              echo "[crossplane-provider-pivot] Phase 0 SKIP — imageconfigs.pkg.crossplane.io CRD not installed yet (bp-crossplane not landed); auth wired on a later step re-run"
+            else
+              if [ -z "${HARBOR_PASSWORD:-}" ]; then
+                echo "[crossplane-provider-pivot] FATAL: HARBOR_PASSWORD env empty — cannot wire package-pull auth for ${target_host}" >&2
+                exit 1
+              fi
+              : "${HARBOR_USERNAME:=admin}"
+              echo "[crossplane-provider-pivot] Phase 0: wiring package-pull auth in ns ${CROSSPLANE_NAMESPACE} for ${target_host} + ${registry_host}"
+
+              harbor_auth="$(printf '%s:%s' "${HARBOR_USERNAME}" "${HARBOR_PASSWORD}" | base64 | tr -d '\n')"
+              # Auth keyed on BOTH aliases (exact host[:port] match by
+              # go-containerregistry). --arg keeps the password a literal
+              # (never re-parsed by the shell).
+              dockercfg="$(jq -cn \
+                --arg th "${target_host}" \
+                --arg rh "${registry_host}" \
+                --arg user "${HARBOR_USERNAME}" \
+                --arg auth "${harbor_auth}" \
+                '{auths: {($th): {username: $user, auth: $auth}, ($rh): {username: $user, auth: $auth}}}')"
+              dockercfg_b64="$(printf '%s' "${dockercfg}" | base64 | tr -d '\n')"
+
+              # dockerconfigjson pull Secret — kubectl apply is idempotent
+              # (re-run rotates the password bytes cleanly). Built with printf
+              # and piped: a plain heredoc terminator cannot sit at column 0
+              # inside this YAML block scalar, so printf is the robust idiom.
+              # Nothing is written to disk (readOnlyRootFilesystem honoured).
+              secret_manifest="$(printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: crossplane-provider-pivot\ntype: kubernetes.io/dockerconfigjson\ndata:\n  .dockerconfigjson: %s\n' \
+                "${PULL_SECRET_NAME}" "${CROSSPLANE_NAMESPACE}" "${dockercfg_b64}")"
+              if ! printf '%s' "${secret_manifest}" | kubectl apply -f - >/dev/null; then
+                echo "[crossplane-provider-pivot] FATAL: failed to apply pull Secret ${CROSSPLANE_NAMESPACE}/${PULL_SECRET_NAME}" >&2
+                exit 1
+              fi
+              echo "[crossplane-provider-pivot]   OK Secret ${CROSSPLANE_NAMESPACE}/${PULL_SECRET_NAME}"
+
+              # ImageConfig binds the matchImages prefixes to the pull Secret.
+              # pullSecretRef resolves in the Crossplane install namespace.
+              # Same printf-piped idiom (no column-0 heredoc terminator).
+              imageconfig_manifest="$(printf 'apiVersion: pkg.crossplane.io/v1beta1\nkind: ImageConfig\nmetadata:\n  name: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: crossplane-provider-pivot\nspec:\n  matchImages:\n    - prefix: %s/%s\n    - prefix: %s/%s\n  registry:\n    authentication:\n      pullSecretRef:\n        name: %s\n' \
+                "${IMAGE_CONFIG_NAME}" "${target_host}" "${REGISTRY_PATH}" "${registry_host}" "${REGISTRY_PATH}" "${PULL_SECRET_NAME}")"
+              if ! printf '%s' "${imageconfig_manifest}" | kubectl apply -f - >/dev/null; then
+                echo "[crossplane-provider-pivot] FATAL: failed to apply ImageConfig ${IMAGE_CONFIG_NAME}" >&2
+                exit 1
+              fi
+              echo "[crossplane-provider-pivot]   OK ImageConfig ${IMAGE_CONFIG_NAME} (matchImages: ${target_host}/${REGISTRY_PATH}, ${registry_host}/${REGISTRY_PATH})"
+            fi
 
             # ---- Phase 1: live K8s patch on every Provider CR ----
             #

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -92,6 +92,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]   # #4652 (Refs #4641): registry-pivot DaemonSet execs `grep` in the Running CoreDNS pod to confirm the coredns-custom CM-volume sync completed BEFORE trusting the registry.<fqdn>->ClusterIP override (the patch-then-sync sequencing — restart races the stale mount)
     verbs: ["create", "get"]
+  - apiGroups: ["pkg.crossplane.io"]
+    resources: ["imageconfigs"]   # step 11 (#5204) creates the ImageConfig that binds the pivoted matchImages prefixes to the local-Harbor package-pull Secret so the Crossplane package manager authenticates post-cutover
+    verbs: ["create"]
 
   # ───────────────────────────────────────────────────────────────
   # READ verbs — namespace-spanning per the step inventory above.
@@ -145,7 +148,7 @@ rules:
     resources: ["gateways"]   # step 06 Phase -1 (#1871, chart 0.1.32): wait for cilium-gateway Programmed=True before URL rewrite
     verbs: ["get", "list", "watch"]
   - apiGroups: ["pkg.crossplane.io"]
-    resources: ["providers"]   # step 11 (TBD-V24 MISS-3, chart 0.1.37): pivot Provider.spec.package off xpkg.upbound.io
+    resources: ["providers", "imageconfigs"]   # step 11 (TBD-V24 MISS-3, chart 0.1.37): pivot Provider.spec.package off xpkg.upbound.io; #5204 reads/applies the ImageConfig that authenticates the local-Harbor package pull
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]   # step 11 probes for providers.pkg.crossplane.io CRD presence before patching
@@ -188,8 +191,8 @@ rules:
     resources: ["kustomizations"]
     verbs: ["update", "patch"]   # step 08 (#3526) force-reconciles the bootstrap-kit Kustomization so Step-06's durable git-push lands before the pivot assertion (the annotate reconcile.fluxcd.io/requestedAt patch)
   - apiGroups: ["pkg.crossplane.io"]
-    resources: ["providers"]
-    verbs: ["update", "patch"]   # step 11 crossplane-provider-pivot (TBD-V24 MISS-3)
+    resources: ["providers", "imageconfigs"]
+    verbs: ["update", "patch"]   # step 11 crossplane-provider-pivot (TBD-V24 MISS-3); #5204 patches the ImageConfig on re-run (kubectl apply)
   - apiGroups: ["cilium.io"]
     resources: ["ciliumnetworkpolicies"]
     verbs: ["delete", "patch", "update"]   # step 08 removes the policy at end-of-test

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -859,7 +859,56 @@ if ! grep -q '"xpkg.upbound.io"' "$TMP/render.yaml"; then
   echo "FAIL: xpkg.upbound.io not present in chart values (mothershipAuthsToStrip / blockedDomains) (TBD-V24 MISS-3)" >&2
   exit 1
 fi
-echo "  PASS (Step-11 wired to pivot Provider CRs to local Harbor proxy-xpkg)"
+# #5204: Step-11 must ALSO wire package-pull AUTHENTICATION. Pivoting the
+# spec.package host is necessary but not sufficient — proxy-xpkg is a Harbor
+# proxy-cache project that requires an authenticated pull even when public, and
+# the Crossplane package manager uses its own registry-auth path (not the node
+# certs.d nor the ghcr-pull dockerconfigjson). Without this the post-cutover
+# Provider re-pull 401s (live hw270). Guard the auth wiring is present so a
+# future edit can't silently drop it back to the anonymous-401 shape.
+#
+# (a) The auth-config env must render on the step-11 ConfigMap.
+step11_body="$(awk '/cutover-step-11-crossplane-provider-pivot/{f=1} f{print} /^---$/{if(f)exit}' "$TMP/render.yaml")"
+if ! printf '%s' "${step11_body}" | grep -q 'name: PACKAGE_PULL_AUTH_ENABLED'; then
+  echo "FAIL: Step-11 missing PACKAGE_PULL_AUTH_ENABLED env (#5204)" >&2
+  exit 1
+fi
+if ! printf '%s' "${step11_body}" | grep -q 'name: CROSSPLANE_NAMESPACE'; then
+  echo "FAIL: Step-11 missing CROSSPLANE_NAMESPACE env (#5204)" >&2
+  exit 1
+fi
+if ! printf '%s' "${step11_body}" | grep -q 'name: HARBOR_PASSWORD'; then
+  echo "FAIL: Step-11 missing HARBOR_PASSWORD env — cannot derive local-Harbor pull credential (#5204)" >&2
+  exit 1
+fi
+# (b) The script body must apply an ImageConfig (pkg.crossplane.io/v1beta1)
+# whose registry.authentication.pullSecretRef binds the local-Harbor pull
+# Secret — the Crossplane 1.18 native package-pull-auth mechanism.
+if ! printf '%s' "${step11_body}" | grep -q 'kind: ImageConfig'; then
+  echo "FAIL: Step-11 missing ImageConfig apply — package pull would 401 against the local Harbor proxy-cache (#5204)" >&2
+  exit 1
+fi
+if ! printf '%s' "${step11_body}" | grep -q 'pullSecretRef'; then
+  echo "FAIL: Step-11 ImageConfig missing registry.authentication.pullSecretRef (#5204)" >&2
+  exit 1
+fi
+if ! printf '%s' "${step11_body}" | grep -q 'type: kubernetes.io/dockerconfigjson'; then
+  echo "FAIL: Step-11 missing the dockerconfigjson pull Secret the ImageConfig references (#5204)" >&2
+  exit 1
+fi
+# (c) RBAC: ClusterRole must permit create + patch on
+# pkg.crossplane.io.imageconfigs (kubectl apply = get-then-create-or-patch).
+if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" \
+     | grep -B1 -A3 '"imageconfigs"' | grep -E 'verbs:.*"create"' >/dev/null; then
+  echo "FAIL: ClusterRole missing pkg.crossplane.io.imageconfigs create verb (#5204)" >&2
+  exit 1
+fi
+if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" \
+     | grep -B1 -A3 '"imageconfigs"' | grep -E 'verbs:.*"patch"|verbs:.*"update"' >/dev/null; then
+  echo "FAIL: ClusterRole missing pkg.crossplane.io.imageconfigs [update|patch] verb (#5204)" >&2
+  exit 1
+fi
+echo "  PASS (Step-11 wired to pivot Provider CRs to local Harbor proxy-xpkg + authenticate the package pull)"
 
 
 echo "[cutover-contract] Case 23: Step-07 Phase 3 pivots catalyst-api issuer envs + runtime-config URLs (#2940)"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1804,6 +1804,53 @@ crossplaneProviderPivot:
   # host + "/" + registryPath. Hetzner Sovereigns ship the upstream host
   # so this prefix simply never matches there (harmless).
   mothershipProxyPrefix: "harbor.openova.io/proxy-xpkg"
+  # #5204 (Refs #3379) — package-pull AUTHENTICATION for the Sovereign-local
+  # Harbor. Pivoting spec.package to `harbor.<sov-fqdn>/proxy-xpkg` is NOT
+  # sufficient on its own: `proxy-xpkg` is a Harbor PROXY-CACHE project, and
+  # Harbor requires an AUTHENTICATED pull from a proxy-cache project even when
+  # the project is public (unlike the push-mode offline-mirror projects
+  # proxy-ghcr/proxy-dockerhub/… which serve anonymous pulls). The Crossplane
+  # package manager fetches packages with go-containerregistry's remote.Image()
+  # and its OWN registry-auth path — it does NOT read the node containerd
+  # certs.d (step 04) NOR the flux-system/ghcr-pull dockerconfigjson
+  # (step 06 wired that for source-controller, not for Crossplane). With no
+  # credential wired for the package manager, EVERY post-cutover Provider
+  # package re-pull / version upgrade / inactive-revision reconcile 401s
+  # against the local Harbor (live hw270 dep b2f0a9b0585f6781: provider-opentofu
+  # Installed=False, reason UnpackingPackage, `401 Unauthorized` — the existing
+  # revision keeps running so live adoption is unaffected TODAY, but the
+  # Sovereign can never upgrade its own providers post-severance → a Pillar-5
+  # durability gap).
+  #
+  # THE FIX (Crossplane 1.18 native mechanism). Step 11 wires an
+  # `ImageConfig` (pkg.crossplane.io/v1beta1) whose spec.matchImages prefixes
+  # cover the pivoted host(s) and whose spec.registry.authentication.pullSecretRef
+  # points at a dockerconfigjson Secret it also creates in the Crossplane
+  # install namespace. The package manager then authenticates package pulls
+  # against the local Harbor with the SAME `admin:<HARBOR_ADMIN_PASSWORD>`
+  # credential step 02/03/06 use (read from harbor.adminSecretRef). The auth
+  # entry is keyed on BOTH `harbor.<sov-fqdn>` (the spec.package pivot host)
+  # AND the canonical `registry.<sov-fqdn>` (sovereign.harborPublicURL host,
+  # the gateway.aliasHarborHost alias) — go-containerregistry auth lookup is an
+  # exact host[:port] match, so covering both aliases is robust regardless of
+  # which literal a Provider carries.
+  packagePullAuth:
+    # Master switch. Default true — the fix is active on every cutover. Flip
+    # false ONLY on a Sovereign whose local Harbor serves proxy-xpkg with
+    # anonymous pull already permitted (then the Provider re-pull needs no
+    # credential). Per docs/INVIOLABLE-PRINCIPLES.md #4 (operator-tunable).
+    enabled: true
+    # Namespace where Crossplane's package manager runs — the pullSecretRef +
+    # ImageConfig both resolve here (bootstrap-kit slot 04 installs bp-crossplane
+    # into crossplane-system). Override per-Sovereign if a future topology moves
+    # the Crossplane control plane.
+    crossplaneNamespace: "crossplane-system"
+    # dockerconfigjson Secret step 11 creates in crossplaneNamespace, carrying
+    # the local-Harbor pull credential the ImageConfig references.
+    pullSecretName: "cutover-harbor-xpkg-pull"
+    # ImageConfig (pkg.crossplane.io/v1beta1) name step 11 applies to bind the
+    # matchImages prefixes to the pullSecretRef.
+    imageConfigName: "cutover-harbor-xpkg"
 
 # Step 09 (gitea-token-mint, TBD-C18) — bootstrap the Gitea API token
 # that the Organization provisioning service uses for tenant repo materialisation.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.138"
+  version: "0.1.139"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.138"
+    version: "0.1.139"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem
Post-cutover, every Crossplane Provider package re-pull / version upgrade / inactive-revision reconcile **401s** against the Sovereign-local Harbor.

Live on **hw270** (dep `b2f0a9b0585f6781`, all 11 cutover steps success, 2026-07-18):
```
kubectl get provider.pkg.crossplane.io provider-opentofu
  Installed=False  reason=UnpackingPackage  message="401 Unauthorized" (pulling from registry.hw270.omantel.biz)
  Healthy=True
```
`Healthy=True` — the existing provider revision keeps running, so **live adoption is unaffected today**. This is a latent Pillar-5 (Sovereign independence) durability gap: a fully self-sovereign Sovereign must be able to upgrade its own Crossplane providers, and today any provider re-pull/upgrade post-severance fails.

## Root cause
Step-11 pivots `Provider.spec.package` from `xpkg.upbound.io` to `harbor.<sov-fqdn>/proxy-xpkg`, but:
- `proxy-xpkg` is a Harbor **proxy-cache** project, and Harbor requires an **authenticated pull from a proxy-cache project even when the project is public** — unlike the push-mode offline-mirror projects (`proxy-ghcr`/`proxy-dockerhub`/…) that step-02 creates `public:true` for anonymous pull.
- The Crossplane package manager fetches packages with go-containerregistry's `remote.Image()` and its **own** registry-auth path — it does **not** read the node containerd `certs.d` (step-04) nor the `flux-system/ghcr-pull` dockerconfigjson (step-06, wired for Flux source-controller).

No credential was ever wired for the package manager → the pivoted pull is anonymous → 401.

## Fix
Step-11 **Phase-0** (runs **before** the Phase-1 `spec.package` patch, so the re-pull the patch triggers already has auth) wires the **Crossplane 1.18 native** mechanism (the repo pins `crossplane/crossplane` `1.18.0`):

1. A `kubernetes.io/dockerconfigjson` **Secret** in `crossplane-system` carrying the **same** `admin:<HARBOR_ADMIN_PASSWORD>` credential steps 02/03/06 use (from `harbor.adminSecretRef`), keyed on **both** `harbor.<sov-fqdn>` (the `spec.package` pivot host) and the canonical `registry.<sov-fqdn>` alias (`sovereign.harborPublicURL` host, routed to the same Harbor via `gateway.aliasHarborHost`) — go-containerregistry auth lookup is an exact `host[:port]` match, so covering both aliases is robust.
2. An **`ImageConfig`** (`pkg.crossplane.io/v1beta1`) whose `spec.matchImages` cover `{harbor,registry}.<sov-fqdn>/proxy-xpkg` and whose `spec.registry.authentication.pullSecretRef` points at that Secret.

Properties:
- **Idempotent** — `kubectl apply` (re-run rotates the credential cleanly).
- **Fail-loud** — FATAL (`exit 1`) on empty `HARBOR_PASSWORD` or on any apply failure; no silent-pass, consistent with the other steps.
- **Skip-if-CRD-absent** — in the very-early-handover window (bp-crossplane not yet installed), Phase-0 skips exactly like Phase-1; Phase-2's Gitea rewrite still lands the pivoted URL and a step re-run wires the auth once crossplane installs.
- **No hardcoded FQDN** — templated on `sovereign.fqdn` / `sovereign.harborPublicURL` / `harbor.adminSecretRef`, the same templating the other 10 steps use.

**Why step-11 and not the bp-crossplane chart:** the pull Secret's content (per-Sovereign FQDN host key + Harbor admin password) is only known at cutover time (post-Harbor-up); bp-crossplane installs at slot-04, long before Harbor exists. Co-locating both the Secret and the ImageConfig in step-11 — both templated on values already available to the cutover chart, both created exactly when the pivot happens — is the smallest self-contained change and matches every other step's live-kubectl idiom.

RBAC gains `pkg.crossplane.io/imageconfigs` `create` + `get/list/watch` + `update/patch` (the ImageConfig CRD-presence probe reuses the existing `customresourcedefinitions` read grant).

Chart `0.1.138 -> 0.1.139`.

## Validation
- `helm lint` — 0 charts failed.
- `helm template` — renders; the step-11 script's Phase-0 passes `bash -n` **and** POSIX `sh -n` (the container runs `/bin/sh`); the rendered Secret + ImageConfig manifests parse as valid YAML with the expected structure (dockerconfigjson type; matchImages for both hosts; pullSecretRef).
- `bash tests/cutover-contract.sh` — **All gates green**. Case 22 now additionally asserts the auth wiring (`PACKAGE_PULL_AUTH_ENABLED` / `CROSSPLANE_NAMESPACE` / `HARBOR_PASSWORD` env, `kind: ImageConfig` + `pullSecretRef`, the dockerconfigjson Secret, and `imageconfigs` create/patch RBAC).
- `bash tests/image-registry-coverage.sh` — PASS (no new image introduced; step-11 reuses the existing alpine/k8s image).
- No NodePort introduced (§854).

## Residual risk / follow-up
- Needs verification on the next fresh-prov cutover that `provider-opentofu` reaches `Installed=True` (the fix is chart-only; not exercised against a live cluster in this PR).
- TLS trust is untouched: the observed failure was a `401` (auth), which means the TLS handshake already succeeded on hw270 — so this is purely the auth gap. On a Sovereign still serving the in-cluster Harbor with an LE-staging (node-untrusted) wildcard at the time of the package pull, a separate `x509` trust path may be needed; not in evidence here.

Refs #5204
Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)