### PR TITLE
fix(catalyst-api): refresh in-cluster SA token on 401 so post-cutover reflectors recover

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -60,6 +60,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/transport"
 )
 
 // EventType mirrors cache.DeltaType / watch.EventType. Wire-compatible
@@ -1474,6 +1475,12 @@ func buildChrootClusterRef(log *slog.Logger, sovereignFQDN string) (ClusterRef, 
 	}
 	cfg.QPS = 50
 	cfg.Burst = 100
+	// #5210 — force the in-cluster informer/client transport to re-read the
+	// rotated projected SA token on a 401 instead of pinning a cached/expired
+	// one. Without this the reflector LIST/WATCH + the resource-GET client
+	// 401-loop after a cutover disruption rotates the bound token (see the
+	// helper godoc for the full client-go transport analysis).
+	wrapInClusterTokenRefreshOn401(cfg)
 	dyn, err := dynamic.NewForConfig(cfg)
 	if err != nil {
 		log.Warn("k8scache: chroot dynamic client build failed", "err", err)
@@ -1489,6 +1496,47 @@ func buildChrootClusterRef(log *slog.Logger, sovereignFQDN string) (ClusterRef, 
 		DynamicClient: dyn,
 		CoreClient:    core,
 	}, true
+}
+
+// wrapInClusterTokenRefreshOn401 upgrades an in-cluster *rest.Config so its
+// HTTP transport force-refreshes the projected ServiceAccount token whenever
+// the apiserver answers 401 Unauthorized.
+//
+// Root cause (#5210, hw270 post-cutover): rest.InClusterConfig() returns a
+// config carrying BearerToken (the token file read ONCE at process start) plus
+// BearerTokenFile (the projected-token path). client-go's HasTokenAuth() branch
+// wraps that with a bearerAuthRoundTripper, which re-reads the token file on a
+// ~1-minute timer but NEVER resets its cache in response to a 401 — unlike the
+// tokenSourceTransport client-go installs for a ResettableTokenSource, which
+// calls ResetTokenOlderThan on every 401. After a cutover disruption (the
+// step-08 10-minute deny-egress hold and/or the step-04 registry-pivot node
+// rolls) interrupts the long-lived watch streams and the bound token rotates,
+// the reflector LIST/WATCH goroutines and the DynamicClientFor resource-GET can
+// pin a cached/expired token and 401-loop against the local apiserver even
+// though a fresh read of the projected token file authenticates fine.
+//
+// Swapping to transport.ResettableTokenSourceWrapTransport makes the very next
+// request after a 401 re-read the rotated projected token instead of waiting on
+// the timer — the recovery path the plain bearer transport lacks. BearerToken /
+// BearerTokenFile are cleared so client-go does NOT also install a
+// bearerAuthRoundTripper: that wrapper pre-sets the Authorization header, and
+// tokenSourceTransport skips (no reset) any request whose Authorization is
+// already set, which would defeat the fix.
+//
+// No-op when BearerTokenFile is empty (off-cluster dev via a kubeconfig — that
+// path carries a static embedded token with no file to re-read).
+func wrapInClusterTokenRefreshOn401(cfg *rest.Config) {
+	tokenFile := cfg.BearerTokenFile
+	if tokenFile == "" {
+		return
+	}
+	ts := transport.NewCachedFileTokenSource(tokenFile)
+	cfg.WrapTransport = transport.Wrappers(
+		cfg.WrapTransport,
+		transport.ResettableTokenSourceWrapTransport(ts),
+	)
+	cfg.BearerToken = ""
+	cfg.BearerTokenFile = ""
 }
 
 // scanStoreForDeploymentID walks the deployment store dir for a

--- a/products/catalyst/bootstrap/api/internal/k8scache/token_refresh_5210_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/token_refresh_5210_test.go
@@ -1,0 +1,139 @@
+// token_refresh_5210_test.go — regression coverage for #5210.
+//
+// The Sovereign-side (chroot) catalyst-api builds its informer + resource-GET
+// kube clients from rest.InClusterConfig(). The plain BearerToken/BearerTokenFile
+// transport client-go installs for that config refreshes the projected token on
+// a timer but does NOT reset its cache on a 401, so after a cutover disruption
+// rotated the bound token the reflectors 401-looped on a stale/expired token
+// even though a fresh read of the projected token file authenticated fine.
+//
+// wrapInClusterTokenRefreshOn401 swaps in a transport.ResettableTokenSource so
+// the transport re-reads the rotated token file the instant it sees a 401.
+package k8scache
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// seqRT is a fake http.RoundTripper that records the Authorization header it
+// received on each call and returns a scripted status code sequence.
+type seqRT struct {
+	authSeen []string
+	codes    []int
+	i        int
+}
+
+func (r *seqRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.authSeen = append(r.authSeen, req.Header.Get("Authorization"))
+	code := http.StatusOK
+	if r.i < len(r.codes) {
+		code = r.codes[r.i]
+	}
+	r.i++
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// TestWrapInClusterTokenRefresh_ClearsStaticCredsAndWires proves the config
+// mutation: the static bearer creds are cleared (so client-go does not ALSO
+// install the non-resetting bearerAuthRoundTripper) and a WrapTransport is
+// wired. Env-independent — no in-cluster env required.
+func TestWrapInClusterTokenRefresh_ClearsStaticCredsAndWires(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("token-A"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &rest.Config{BearerToken: "token-A", BearerTokenFile: tokenFile}
+	wrapInClusterTokenRefreshOn401(cfg)
+
+	if cfg.BearerToken != "" {
+		t.Errorf("BearerToken not cleared: %q — client-go would install a non-resetting bearerAuthRoundTripper", cfg.BearerToken)
+	}
+	if cfg.BearerTokenFile != "" {
+		t.Errorf("BearerTokenFile not cleared: %q", cfg.BearerTokenFile)
+	}
+	if cfg.WrapTransport == nil {
+		t.Fatal("WrapTransport not wired — token would never reset on 401")
+	}
+}
+
+// TestWrapInClusterTokenRefresh_NoOpWithoutTokenFile proves the off-cluster /
+// dev path (kubeconfig-embedded static token, no BearerTokenFile) is left
+// untouched.
+func TestWrapInClusterTokenRefresh_NoOpWithoutTokenFile(t *testing.T) {
+	cfg := &rest.Config{BearerToken: "static-kubeconfig-token"}
+	wrapInClusterTokenRefreshOn401(cfg)
+	if cfg.BearerToken != "static-kubeconfig-token" {
+		t.Errorf("static token unexpectedly mutated: %q", cfg.BearerToken)
+	}
+	if cfg.WrapTransport != nil {
+		t.Error("WrapTransport wired for a config with no BearerTokenFile — should be a no-op")
+	}
+}
+
+// TestWrapInClusterTokenRefresh_RereadsFileOn401 is the behavioural regression:
+// a cached token that starts returning 401 (the post-rotation stale-token case)
+// forces an immediate re-read of the rotated projected token file on the next
+// request — the recovery the plain bearer transport lacked.
+func TestWrapInClusterTokenRefresh_RereadsFileOn401(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("token-A"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &rest.Config{BearerToken: "token-A", BearerTokenFile: tokenFile}
+	wrapInClusterTokenRefreshOn401(cfg)
+
+	base := &seqRT{codes: []int{http.StatusOK, http.StatusUnauthorized, http.StatusOK}}
+	rt := cfg.WrapTransport(base)
+
+	do := func() {
+		req, err := http.NewRequest(http.MethodGet, "https://apiserver.local/api", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("roundtrip: %v", err)
+		}
+		_ = resp.Body.Close()
+	}
+
+	// 1) prime the token cache with token-A (200).
+	do()
+	// kubelet rotates the projected token on disk.
+	if err := os.WriteFile(tokenFile, []byte("token-B"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// 2) cached token-A is still within its 1-minute cache window → the apiserver
+	//    rejects it with 401 → the transport resets the token cache.
+	do()
+	// 3) next request must re-read the file and present the rotated token-B.
+	do()
+
+	if len(base.authSeen) != 3 {
+		t.Fatalf("expected 3 upstream requests, got %d (%v)", len(base.authSeen), base.authSeen)
+	}
+	if base.authSeen[0] != "Bearer token-A" {
+		t.Errorf("req1 Authorization = %q, want %q", base.authSeen[0], "Bearer token-A")
+	}
+	if base.authSeen[1] != "Bearer token-A" {
+		t.Errorf("req2 Authorization = %q, want %q (cached, pre-401)", base.authSeen[1], "Bearer token-A")
+	}
+	if base.authSeen[2] != "Bearer token-B" {
+		t.Errorf("req3 Authorization = %q, want %q (re-read after 401) — token did NOT refresh on 401 (#5210 regression)", base.authSeen[2], "Bearer token-B")
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.degrade5210.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.degrade5210.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * ResourceDetailPage.degrade5210.test.tsx — #5210 graceful-degrade lock-in.
+ *
+ * When the parent resource-GET (the k9s lens `/k8s/{kind}/{ns}/{name}`)
+ * fails on a Sovereign — e.g. a transient apiserver auth blip after cutover
+ * returns 500 Unauthorized — the ResourceDetailPage previously hid the WHOLE
+ * tab body behind the parent-GET error, which also hid the Flux reconciler's
+ * own working management surface (logs + reconcile / suspend / resume). This
+ * asserts the reconcile tab still renders (degraded, obj=null) alongside the
+ * error banner so the operator can still drive the reconciler (UAT 193/195).
+ */
+
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getResource = vi.fn()
+const getResourceTree = vi.fn()
+
+vi.mock('./resource.api', async () => {
+  const actual = await vi.importActual<typeof import('./resource.api')>('./resource.api')
+  return {
+    ...actual,
+    getResource: (...a: unknown[]) => getResource(...a),
+    getResourceTree: (...a: unknown[]) => getResourceTree(...a),
+  }
+})
+
+const fetchReconcilerLogs = vi.fn()
+
+vi.mock('@/lib/reconciler-manage.api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/reconciler-manage.api')>(
+    '@/lib/reconciler-manage.api',
+  )
+  return {
+    ...actual,
+    fetchReconcilerLogs: (...a: unknown[]) => fetchReconcilerLogs(...a),
+  }
+})
+
+import { ResourceDetailPage } from './ResourceDetailPage'
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  getResource.mockReset()
+  getResourceTree.mockReset()
+  fetchReconcilerLogs.mockReset()
+  // The lens parent-GET fails the way the Sovereign reported it (#5210).
+  getResource.mockRejectedValue(new Error('Unauthorized'))
+  getResourceTree.mockResolvedValue({ kind: 'HelmRelease', name: 'bp-keycloak', children: [] })
+  fetchReconcilerLogs.mockResolvedValue({
+    controller: 'helm-controller',
+    object: 'flux-system/bp-keycloak',
+    lines: [{ lineNumber: 1, message: 'reconciling' }],
+    total: 1,
+  })
+})
+
+function renderPage(tab: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ResourceDetailPage
+        deploymentId="dep-1"
+        basePath="/cloud"
+        kind="helmrelease"
+        ns="flux-system"
+        name="bp-keycloak"
+        tab={tab as never}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ResourceDetailPage — #5210 degrade', () => {
+  it('keeps the reconcile management surface when the parent resource-GET fails', async () => {
+    renderPage('reconcile')
+
+    // The error banner surfaces (operator sees the lens GET failed) …
+    await waitFor(() => expect(screen.getByTestId('resource-detail-error')).toBeTruthy())
+    // … AND the reconcile tab body still renders (degraded, obj=null) so
+    // reconcile / suspend / resume + logs remain usable.
+    expect(screen.getByTestId('resource-detail-tab-content-reconcile')).toBeTruthy()
+    expect(screen.getByTestId('reconcile-tab')).toBeTruthy()
+  })
+
+  it('still hides non-reconciler tab bodies on a failed parent-GET', async () => {
+    renderPage('overview')
+
+    await waitFor(() => expect(screen.getByTestId('resource-detail-error')).toBeTruthy())
+    // Overview has no independent endpoint — it stays gated behind the error.
+    expect(screen.queryByTestId('resource-detail-tab-content-overview')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
@@ -292,6 +292,29 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
         </div>
       )}
 
+      {/* #5210 — graceful degrade. The parent resource-GET (the k9s lens
+          `/k8s/{kind}/{ns}/{name}`) can fail on a Sovereign — e.g. a
+          transient apiserver auth blip after cutover — while the Flux
+          reconciler's OWN endpoints (logs + reconcile / suspend / resume)
+          stay reachable. Keep that management surface usable instead of
+          hiding the whole tab body behind the parent-GET error. `obj` is
+          null here; ReconcileTab reads every obj field defensively
+          (obj?.…) and drives its actions from deploymentId/apiKind/ns/name,
+          so it renders + operates without the parent object. Unblocks the
+          reconcile drill-in when the lens GET degrades (UAT rows 193/195). */}
+      {!isLoading && objErr && tab === 'reconcile' && isReconcilerManageable(apiKind) && (
+        <div data-testid={`resource-detail-tab-content-${tab}`}>
+          <ReconcileTab
+            deploymentId={deploymentId}
+            apiKind={apiKind}
+            ns={ns}
+            name={name}
+            obj={null}
+            isTierAdmin={isTierAdmin}
+          />
+        </div>
+      )}
+
       {!isLoading && !objErr && (
         <div data-testid={`resource-detail-tab-content-${tab}`}>
           {tab === 'overview' && (


### PR DESCRIPTION
## Problem
On a Sovereign post-cutover (hw270, dep `b2f0a9b0585f6781`, `cutoverComplete=true`), the chroot catalyst-api pod (SA `catalyst-api-cutover-driver`) floods its log with reflector watch failures and the console shows a **DEGRADED** badge:

```
reflector "Failed to watch" err="failed to list /v1, Resource=nodes: Unauthorized"
  ... cilium.io/v2alpha1 ciliumendpointslices / dr.openova.io/v1 cnpgpairs: Unauthorized
spine-apps: list HelmReleases failed; will retry err="Unauthorized"
```

The bound ClusterRole **does** grant those kinds, and a **fresh** read of the projected token file authenticates `200` — yet the long-lived informer/watch client keeps presenting a stale token. The k9s-lens resource-GET (`/api/v1/sovereigns/{id}/k8s/...`) likewise returns `500 {"detail":"Unauthorized"}`, which hid the whole `ResourceDetailPage` tab body.

## Root cause
`buildChrootClusterRef` (`products/catalyst/bootstrap/api/internal/k8scache/factory.go`, `rest.InClusterConfig()` ~L1471) builds the in-cluster informer + resource-GET clients. `InClusterConfig()` sets `BearerToken` (read **once** at startup) + `BearerTokenFile`. client-go routes that through the `HasTokenAuth()` branch → a **`bearerAuthRoundTripper`** (`transport/round_trippers.go`) that re-reads the token file on a ~1-minute timer but **never resets its cache in response to a 401** — unlike the `tokenSourceTransport` client-go installs for a `ResettableTokenSource`, which calls `ResetTokenOlderThan` on every 401.

After a cutover disruption (the step-08 10-minute deny-egress hold and/or the step-04 registry-pivot node rolls) interrupts the watch streams and the bound token rotates, the reflector LIST/WATCH goroutines + the `DynamicClientFor` resource-GET pin a cached/expired token and 401-loop against the local apiserver — even though the projected token file on disk is valid. RBAC is already correct; this is purely a token-refresh gap.

## Fix
New `wrapInClusterTokenRefreshOn401(cfg)` in `factory.go` rebuilds the chroot config to authenticate via `transport.ResettableTokenSourceWrapTransport` over a `transport.NewCachedFileTokenSource(BearerTokenFile)`, and clears `BearerToken`/`BearerTokenFile` so client-go does **not** also install the non-resetting bearer wrapper (which would pre-set the `Authorization` header and make the resettable source a no-op). The transport now re-reads the rotated projected token the instant it sees a 401 — the recovery path the plain bearer transport lacked. This restores **both** the reflector watches and the resource-GET. Scoped to the in-cluster chroot path; the mother's kubeconfig-file clients carry a static embedded token (no file to re-read) and are untouched.

**404 watches (organizations/applications):** investigated — the registered GVKs `apps.openova.io/v1` + `orgs.openova.io/v1` already match the shipped CRDs (`products/catalyst/chart/crds/{application,organization}.yaml`, both `served+storage: v1`, scopes aligned) and every Go GVR constant. There is **no code-level GVK mismatch**, so the 404 on hw270 is environment drift (older-chart CRD / not-yet-Established), not a code change. Changing the GVK would regress the correct alignment.

**FE graceful-degrade:** `ResourceDetailPage` no longer hides the entire tab body behind a failed parent resource-GET. For a Flux reconciler kind it renders the `ReconcileTab` in degraded mode (`obj={null}`; every field is read defensively `obj?.…`, actions drive off `deploymentId/apiKind/ns/name`), keeping reconcile/suspend/resume + logs usable when the lens GET degrades (UAT rows 193/195).

## Validation
- `go build ./...` (bootstrap/api): **OK**
- `go test ./internal/k8scache/`: **ok** — incl. new `TestWrapInClusterTokenRefresh_*`, whose behavioural case drives a cached token → 401 → and asserts the very next request presents the **re-read rotated token** (`Bearer token-B`).
- `go vet ./internal/k8scache/`: clean
- UI: `tsc -b --noEmit` clean; `vitest` cloud-list **93 passed** incl. new `ResourceDetailPage.degrade5210` tests.

## Residual risk / follow-up
- Needs verification on the next fresh-prov post-cutover that the reflectors + resource-GET stay authorized across a bound-token rotation (the failure only manifests after real token rotation + a watch-stream disruption).
- The organizations/applications 404 should be re-confirmed on a fresh prov; if it recurs with the shipped-CRD versions it points to a live CRD-version drift to chase in the env, not this client.

Refs #5210
Refs #3996

🤖 Generated with [Claude Code](https://claude.com/claude-code)