### PR TITLE
fix(catalyst-api): wipe falls back to huawei-operator-creds env — env never stranded un-wipeable (#5193 item 1)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -1216,10 +1216,23 @@ func buildWipeCredsRaw(providerName string, body wipeRequest, depReq provisioner
 		// atomic: no need for the operator to re-prompt creds after
 		// a Pod restart, because catalyst-api wrote them to disk
 		// during provision.
-		out["access_key"] = firstNonEmpty(body.HuaweiAccessKey, body.HetznerToken, depReq.HuaweiAccessKey)
-		out["secret_key"] = firstNonEmpty(body.HuaweiSecretKey, body.ObjectStorageSecretKey, depReq.HuaweiSecretKey)
-		out["project_id"] = firstNonEmpty(body.HuaweiProjectID, body.ObjectStorageAccessKey, depReq.HuaweiProjectID)
-		out["region"] = firstNonEmpty(body.HuaweiRegion, body.ObjectStorageRegion, depReq.HuaweiRegion)
+		// #5193 — FINAL fallback: the huawei-operator-creds Secret projected env
+		// (CATALYST_HUAWEI_*). Mirrors the janitor's fallback (janitor.go ~584) and
+		// is what keeps an env the platform created ALWAYS wipeable from in-cluster
+		// creds — even after a partial destroy deleted the per-deployment tfvars AND
+		// the pod rolled (no in-memory depReq) AND no body creds. Without it the wipe
+		// 400s "huawei credentials are required" and the record sticks at
+		// status=wiping, blocking the one-environment-at-a-time preflight gate.
+		out["access_key"] = firstNonEmpty(body.HuaweiAccessKey, body.HetznerToken, depReq.HuaweiAccessKey, os.Getenv("CATALYST_HUAWEI_ACCESS_KEY"))
+		out["secret_key"] = firstNonEmpty(body.HuaweiSecretKey, body.ObjectStorageSecretKey, depReq.HuaweiSecretKey, os.Getenv("CATALYST_HUAWEI_SECRET_KEY"))
+		out["project_id"] = firstNonEmpty(body.HuaweiProjectID, body.ObjectStorageAccessKey, depReq.HuaweiProjectID, os.Getenv("CATALYST_HUAWEI_PROJECT_ID"))
+		out["region"] = firstNonEmpty(body.HuaweiRegion, body.ObjectStorageRegion, depReq.HuaweiRegion, os.Getenv("CATALYST_HUAWEI_REGION"))
+		// Default region ONLY when the creds resolved (matches janitor.go) — keeps
+		// the empty-everything case truly empty so the EVS/orphan backstop still
+		// reads "no creds" rather than a bare region.
+		if out["region"] == "" && out["access_key"] != "" && out["secret_key"] != "" && out["project_id"] != "" {
+			out["region"] = "me-east-215"
+		}
 	default:
 		// hetzner (canonical) — same wire shape pre-Wave-3.
 		token := strings.TrimSpace(body.HetznerToken)

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_creds_env_fallback_5193_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_creds_env_fallback_5193_test.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// #5193 — an env the platform created must stay wipeable from the
+// huawei-operator-creds projected env (CATALYST_HUAWEI_*) even in the worst case
+// a partial destroy hit: the per-deployment tfvars are gone, the pod rolled (no
+// in-memory dep.Request creds), and the wipe body carries no creds. Without this
+// fallback buildWipeCredsRaw yields an empty bag → the wipe 400s "huawei
+// credentials are required" and the record strands at status=wiping, blocking the
+// one-environment-at-a-time preflight gate for the next fire.
+func TestBuildWipeCredsRaw_HuaweiOperatorCredsEnvFallback_5193(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "AK-FROM-SECRET")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "SK-FROM-SECRET")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "PID-FROM-SECRET")
+	t.Setenv("CATALYST_HUAWEI_REGION", "me-east-215")
+
+	// Worst case: no body creds, no in-memory dep.Request creds.
+	got := buildWipeCredsRaw("huawei", wipeRequest{}, provisioner.Request{})
+
+	for k, want := range map[string]string{
+		"access_key": "AK-FROM-SECRET",
+		"secret_key": "SK-FROM-SECRET",
+		"project_id": "PID-FROM-SECRET",
+		"region":     "me-east-215",
+	} {
+		if got[k] != want {
+			t.Fatalf("%s: want env fallback %q, got %q", k, want, got[k])
+		}
+	}
+}
+
+// Body-supplied creds still WIN over the env fallback (operator override intact).
+func TestBuildWipeCredsRaw_BodyWinsOverEnv_5193(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "AK-FROM-SECRET")
+	got := buildWipeCredsRaw("huawei", wipeRequest{HuaweiAccessKey: "AK-FROM-BODY"}, provisioner.Request{})
+	if got["access_key"] != "AK-FROM-BODY" {
+		t.Fatalf("access_key: body must win over env, got %q", got["access_key"])
+	}
+}
+
+// Region defaults to me-east-215 ONLY when AK/SK/PID resolved (matches janitor.go);
+// the truly-empty case stays empty so the EVS/orphan backstop reads "no creds".
+func TestBuildWipeCredsRaw_RegionDefaultOnlyWithCreds_5193(t *testing.T) {
+	// No env, no body, no depReq → everything empty, region NOT defaulted.
+	empty := buildWipeCredsRaw("huawei", wipeRequest{}, provisioner.Request{})
+	if empty["region"] != "" {
+		t.Fatalf("region: empty-everything case must stay empty, got %q", empty["region"])
+	}
+	// Creds present but region absent → default fills in.
+	got := buildWipeCredsRaw("huawei", wipeRequest{
+		HuaweiAccessKey: "ak", HuaweiSecretKey: "sk", HuaweiProjectID: "pid",
+	}, provisioner.Request{})
+	if got["region"] != "me-east-215" {
+		t.Fatalf("region: want default me-east-215 when creds present, got %q", got["region"])
+	}
+}


### PR DESCRIPTION
## Problem
A partial wipe (nginx 60s proxy-timeout kills the request-bound `tofu destroy`, or a catalyst-api roll mid-wipe) strands an env at `status: wiping`: the partial destroy cleaned the per-deployment tfvars off the PVC, the pod rolled (no in-memory `dep.Request` creds), and a retried wipe carries no body creds → `buildWipeCredsRaw` yields an empty bag → the wipe 400s `huawei credentials are required`. The record sticks at `wiping` and the **one-environment-at-a-time preflight gate counts it 'still live' and refuses the next fire** — halting the LAW #5111 cycle. (Hit live wiping hw268→hw269; manual recovery was a port-forward wipe with creds pulled from the `huawei-operator-creds` Secret.)

## Fix (item 1 — the primary, self-contained one)
Add the `huawei-operator-creds` Secret projected env (`CATALYST_HUAWEI_ACCESS_KEY/SECRET_KEY/PROJECT_ID/REGION`) as the **final `firstNonEmpty` fallback** in `buildWipeCredsRaw` (wipe.go), mirroring the janitor's fallback (`janitor.go ~584`). An env the platform created is now **always wipeable from in-cluster creds**, even after absent tfvars + a pod roll. Region defaults to `me-east-215` **only when AK/SK/PID resolved** (keeps the empty-everything case empty so the EVS/orphan backstop still reads 'no creds').

## Validation
`go build` clean; `go test ./internal/handler -run 'BuildWipeCredsRaw|EvsBackstop'` → ok (3 new #5193 tests: env fallback fills creds; body wins over env; region-default scoping — plus the existing backstop test unbroken).

## Follow-ups (tracked on #5193, larger)
Item 2 async/detached `tofu destroy` vs the nginx-60s timeout; item 3 defer tfvars cleanup until `verifiedZeroOrphans`; item 4 PDM non-managed-pool 422 → no-op.

Refs #5193