### PR TITLE
fix(cutover): self-heal gitea-admin-secret at step execution time (Refs #5214)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -897,7 +897,7 @@ spec:
       # (prewarm.proxyBackoffBaseSeconds=30, doubling). FATAL-on-any-failure, the
       # #5030 dest-check skip, the #4975 pre-pass + multi-arch handling all
       # preserved. Contract Case 60.
-      version: 0.1.139
+      version: 0.1.140
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.139
+  version: 0.1.140
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,34 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.140 (#5214 Refs #4557 #4558 #4661 — DURABLE close of the recurring
+# `secret "gitea-admin-secret" not found` wedge. Every cutover step Job that
+# reads the Gitea admin credential (06-helmrepository-patches,
+# 07-catalyst-api-env-patch, 09-gitea-token-mint, 10-vcluster-registry-pivot,
+# 11-crossplane-provider-pivot, 11-mirror-resync) resolves it via a
+# secretKeyRef on `gitea-admin-secret`, which resolves ONLY in the Pod's OWN
+# namespace (`catalyst`). Two install-time mechanisms materialise that copy —
+# the render-time lookup+mirror (00-gitea-admin-secret-bridge) and the #4661
+# one-shot runtime Job (00-gitea-admin-secret-bridge-job) — but the step Jobs
+# run 45+ min after install (post harbor-prewarm), and on hw271 the copy was
+# DELETED from `catalyst` between install and step-06 by an unidentified reaper
+# (NOT helm-controller: release stayed in-sync so `keep` was never consulted;
+# NOT kustomize-controller: not in any inventory; NOT kyverno: no delete
+# policy) and nothing re-asserted it (the mirror only re-renders on a helm
+# upgrade; the #4661 Job is one-shot Complete) → CreateContainerConfigError →
+# chain wedged at step-06. FIX: a reusable `giteaSecretSelfHealInitContainer`
+# helper (_helpers.tpl) copies gitea/gitea-admin-secret ->
+# catalyst/gitea-admin-secret AT STEP-EXECUTION TIME as an initContainer on
+# each of the six consuming step templates, so the secret is re-materialised
+# immediately before the main container needs it regardless of who deleted it.
+# Same jq sanitize as the #4661 Job, idempotent `kubectl apply`, fail-loud on a
+# missing password key, and it STAMPS `helm.sh/resource-policy: keep` on the
+# applied copy so a later reconcile cannot prune it. Runs under the existing
+# cutover runner SA (secrets get cluster-wide + create in-namespace already
+# granted — no new RBAC). Defense-in-depth: the #4661 bridge Job's jq now also
+# stamps `helm.sh/resource-policy: keep` so its applied copy stops clobbering
+# the mirror's keep protection. No step-count / RBAC / deadline change (still
+# 11 steps).)
+#
 # 0.1.139 (#5204 Refs #3379 — step-11 crossplane-provider-pivot: wire
 # package-pull AUTHENTICATION for the Sovereign-local Harbor. Pivoting
 # Provider.spec.package to harbor.<fqdn>/proxy-xpkg was necessary but NOT
@@ -2265,7 +2294,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.139
+version: 0.1.140
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge-job.yaml
@@ -281,7 +281,8 @@ spec:
                         },
                         annotations: {
                           "catalyst.openova.io/mirrored-from": $src,
-                          "catalyst.openova.io/bridge": "gitea-admin-secret-cutover-ns-runtime-4660"
+                          "catalyst.openova.io/bridge": "gitea-admin-secret-cutover-ns-runtime-4660",
+                          "helm.sh/resource-policy": "keep"
                         }
                       },
                       data: (.data // {})}' \

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -60,6 +60,12 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.helmRepositoryPatchesSeconds }}
+    # #5214 — re-assert gitea-admin-secret in the release namespace at step
+    # execution time (durable close of the #4557/#4558/#4661 recurrence class:
+    # the install-time bridge copy was deleted between install and this step on
+    # hw271, wedging the secretKeyRef below). See _helpers.tpl.
+    initContainers:
+      {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
       - name: helmrepository-patches
         # alpine/k8s ships kubectl + git so we can both patch the live

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -76,6 +76,11 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.catalystAPIEnvPatchSeconds }}
+    # #5214 — re-assert gitea-admin-secret in the release namespace at step
+    # execution time (durable close of the #4557/#4558/#4661 recurrence class).
+    # See _helpers.tpl.
+    initContainers:
+      {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
       - name: catalyst-api-env-patch
         image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "post" "Values" .Values) }}

--- a/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
@@ -85,6 +85,11 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.giteaTokenMintSeconds | default 600 }}
+    # #5214 — re-assert gitea-admin-secret in the release namespace at step
+    # execution time (durable close of the #4557/#4558/#4661 recurrence class).
+    # See _helpers.tpl.
+    initContainers:
+      {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
       - name: gitea-token-mint
         image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "post" "Values" .Values) }}

--- a/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
@@ -135,6 +135,11 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.vclusterRegistryPivotSeconds }}
+    # #5214 — re-assert gitea-admin-secret in the release namespace at step
+    # execution time (durable close of the #4557/#4558/#4661 recurrence class).
+    # See _helpers.tpl.
+    initContainers:
+      {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
       - name: vcluster-registry-pivot
         # alpine/k8s ships both kubectl AND git so we can patch live

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -103,6 +103,11 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.crossplaneProviderPivotSeconds }}
+    # #5214 — re-assert gitea-admin-secret in the release namespace at step
+    # execution time (durable close of the #4557/#4558/#4661 recurrence class).
+    # See _helpers.tpl.
+    initContainers:
+      {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
       - name: crossplane-provider-pivot
         # alpine/k8s carries both kubectl AND git so we can patch live

--- a/platform/self-sovereign-cutover/chart/templates/11-mirror-resync-cronjob.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-mirror-resync-cronjob.yaml
@@ -133,6 +133,12 @@ spec:
         spec:
           serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
           restartPolicy: Never
+          # #5214 — re-assert gitea-admin-secret in the release namespace before
+          # each resync fire (durable close of the #4557/#4558/#4661 recurrence
+          # class; the secretKeyRef below resolves only in this Pod's namespace).
+          # See _helpers.tpl.
+          initContainers:
+            {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "pre") | nindent 12 }}
           containers:
             - name: gitea-mirror-resync
               image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.git.repository "tag" .Values.images.git.tag "cutoverPhase" "pre" "Values" .Values) }}

--- a/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
+++ b/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
@@ -132,6 +132,142 @@ containerd. Space-separated, env-safe.
 {{- end -}}
 
 {{/*
+── #5214 gitea-admin-secret STEP-EXECUTION self-heal initContainer ──────────
+The DURABLE close of the #4557→#4558→#4661 recurrence class.
+
+WHY (verified live hw271). Every cutover step Job that reads the Gitea admin
+credential (06-helmrepository-patches, 07-catalyst-api-env-patch,
+09-gitea-token-mint, 10-vcluster-registry-pivot, 11-crossplane-provider-pivot,
+11-mirror-resync) resolves it via a Kubernetes `secretKeyRef` on
+`gitea-admin-secret`, which resolves ONLY in the Pod's OWN namespace
+(`catalyst`). Two install-time mechanisms materialise that copy —
+00-gitea-admin-secret-bridge.yaml (render-time Helm lookup+mirror, keep-policy)
+and 00-gitea-admin-secret-bridge-job.yaml (#4661 one-shot runtime copy). But
+the step Jobs run 45+ min after install (after harbor-prewarm), and on hw271 the
+copy was DELETED from `catalyst` between install and step-06 by an as-yet
+unidentified reaper (NOT helm-controller — release stayed in-sync so keep was
+never consulted; NOT kustomize-controller — the secret is in no inventory; NOT
+kyverno — no delete policy). Nothing re-asserted it (the mirror only re-renders
+on a helm upgrade; the #4661 Job is one-shot Complete) →
+`CreateContainerConfigError: secret "gitea-admin-secret" not found` → wedge.
+
+THE FIX. Re-assert the secret AT STEP-EXECUTION TIME, immediately before the
+main container needs it, regardless of who deleted it and when. This
+initContainer copies
+  <sourceNamespace>/<sourceSecretName>  ->  <Release.Namespace>/<adminSecretRef.name>
+with the SAME jq sanitize the #4661 bridge Job uses (rebuild-from-scratch drops
+resourceVersion/uid/managedFields/creationTimestamp/ownerReferences/
+last-applied-configuration and any helm.sh/hook* annotations by construction),
+BUT stamps `helm.sh/resource-policy: keep` on the applied copy so a subsequent
+helm reconcile cannot prune it. `kubectl apply` create-or-updates (idempotent),
+and the copy is fail-loud: if the password key is absent post-copy it exits 1
+so the step surfaces the real fault instead of a downstream 401.
+
+It runs under the cutover runner SA (secrets get cluster-wide + secrets create
+in the release namespace are already granted in rbac.yaml — no new RBAC). The
+kubectl image is images.kubectl (alpine/k8s carries kubectl + jq, exactly as
+the #4661 bridge Job relies on); `harbor.openova.io/proxy-*` refs resolve to
+local Harbor post-pivot via the step-04 containerd rewrite. HOME=/tmp with a
+writable rootfs (matching the step containers) so kubectl's cache has a home;
+no extra Pod volume is needed, keeping the per-step edit to `initContainers:`.
+
+Inputs (dict): .ctx (root context) .phase ("pre"|"post" image phase for the
+step this init is attached to). Emit at the pod's initContainers list level via
+`include ... (dict "ctx" . "phase" "post") | nindent 6` (see each step template).
+*/}}
+{{- define "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" -}}
+{{- $ctx := .ctx -}}
+{{- $phase := .phase | default "post" -}}
+{{- $srcNs := $ctx.Values.giteaAdminSecretBridge.sourceNamespace | default "gitea" -}}
+{{- $srcName := $ctx.Values.giteaAdminSecretBridge.sourceSecretName | default "gitea-admin-secret" -}}
+{{- $destName := $ctx.Values.gitea.adminSecretRef.name -}}
+{{- $destNs := $ctx.Release.Namespace -}}
+- name: ensure-gitea-admin-secret
+  image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" $ctx.Values.images.kubectl.repository "tag" $ctx.Values.images.kubectl.tag "cutoverPhase" $phase "Values" $ctx.Values) }}
+  imagePullPolicy: IfNotPresent
+  env:
+    - name: HOME
+      value: /tmp
+    - name: SRC_NAMESPACE
+      value: {{ $srcNs | quote }}
+    - name: SRC_SECRET_NAME
+      value: {{ $srcName | quote }}
+    - name: DEST_NAMESPACE
+      value: {{ $destNs | quote }}
+    - name: DEST_SECRET_NAME
+      value: {{ $destName | quote }}
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      set -eu
+      echo "[ensure-gitea-admin-secret] source = ${SRC_NAMESPACE}/${SRC_SECRET_NAME}"
+      echo "[ensure-gitea-admin-secret] dest   = ${DEST_NAMESPACE}/${DEST_SECRET_NAME}"
+
+      # Fast path — if the destination already carries a usable password key we
+      # still re-copy from source (so a Gitea password rotation propagates), but
+      # if the source has vanished AND the dest is intact we leave it be.
+      if ! kubectl -n "${SRC_NAMESPACE}" get secret "${SRC_SECRET_NAME}" >/dev/null 2>&1; then
+        if kubectl -n "${DEST_NAMESPACE}" get secret "${DEST_SECRET_NAME}" -o jsonpath='{.data.password}' 2>/dev/null | grep -q .; then
+          echo "[ensure-gitea-admin-secret] source absent but destination already intact — leaving untouched"
+          exit 0
+        fi
+        echo "[ensure-gitea-admin-secret] FATAL: source ${SRC_NAMESPACE}/${SRC_SECRET_NAME} absent and no destination secret to fall back on" >&2
+        exit 1
+      fi
+
+      # Copy source -> destination. jq REBUILDS the object from scratch (drops
+      # resourceVersion/uid/managedFields/creationTimestamp/ownerReferences/
+      # last-applied + any helm.sh/hook* annotations by construction), re-targets
+      # name+namespace, keeps only provenance annotations, and stamps
+      # helm.sh/resource-policy: keep so nothing prunes the applied copy. The
+      # base64 password bytes flow kubectl->jq->kubectl and are NEVER printed.
+      kubectl -n "${SRC_NAMESPACE}" get secret "${SRC_SECRET_NAME}" -o json \
+        | jq \
+            --arg ns "${DEST_NAMESPACE}" \
+            --arg name "${DEST_SECRET_NAME}" \
+            --arg src "${SRC_NAMESPACE}/${SRC_SECRET_NAME}" \
+            '{apiVersion, kind, type,
+              metadata: {
+                name: $name,
+                namespace: $ns,
+                labels: {
+                  "catalyst.openova.io/blueprint": "bp-self-sovereign-cutover",
+                  "catalyst.openova.io/component": "gitea-admin-secret-bridge",
+                  "app.kubernetes.io/part-of": "catalyst",
+                  "app.kubernetes.io/managed-by": "Helm"
+                },
+                annotations: {
+                  "catalyst.openova.io/mirrored-from": $src,
+                  "catalyst.openova.io/bridge": "gitea-admin-secret-cutover-ns-selfheal-5214",
+                  "helm.sh/resource-policy": "keep"
+                }
+              },
+              data: (.data // {})}' \
+        | kubectl -n "${DEST_NAMESPACE}" apply -f - >/dev/null
+
+      # Fail loud: the step must not proceed on a keyless secret.
+      if ! kubectl -n "${DEST_NAMESPACE}" get secret "${DEST_SECRET_NAME}" \
+           -o jsonpath='{.data.password}' 2>/dev/null | grep -q .; then
+        echo "[ensure-gitea-admin-secret] FATAL: destination secret missing the password key after copy" >&2
+        exit 1
+      fi
+      echo "[ensure-gitea-admin-secret] ${DEST_NAMESPACE}/${DEST_SECRET_NAME} present with password key — step secretKeyRef will resolve"
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      memory: 64Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: ["ALL"]
+{{- end -}}
+
+{{/*
 Image-path substrings EXCLUDED from the offline mirror + the step-08 roll-set
 (rancher/k3s = per-Org vcluster distro, un-mirrorable on the host plane;
 loft-sh/vcluster = handled by step-10 vcluster-registry-pivot). Space-separated.

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -819,13 +819,17 @@ if ! grep -A20 'cutover-step-11-crossplane-provider-pivot' "$TMP/render.yaml" | 
 fi
 # Default upstream host must be xpkg.upbound.io (the Crossplane Provider
 # package upstream the cutover pivots OFF of).
-if ! grep -A60 'cutover-step-11-crossplane-provider-pivot' "$TMP/render.yaml" | grep -q 'value: "xpkg.upbound.io"'; then
+# NB (#5214): the window is -A160 (was -A60) because the gitea-admin-secret
+# self-heal initContainer prepended to this step's podSpec adds ~84 lines
+# before the main container's env; 160 still lands well inside the single
+# step-11 ConfigMap (~456 lines), so the scope stays step-11-only.
+if ! grep -A160 'cutover-step-11-crossplane-provider-pivot' "$TMP/render.yaml" | grep -q 'value: "xpkg.upbound.io"'; then
   echo "FAIL: Step-11 missing UPSTREAM_HOST=xpkg.upbound.io env (TBD-V24 MISS-3)" >&2
   exit 1
 fi
 # Default registry path must be proxy-xpkg (the Harbor proxy-cache
 # project that mirrors xpkg.upbound.io — created by Step 02).
-if ! grep -A60 'cutover-step-11-crossplane-provider-pivot' "$TMP/render.yaml" | grep -q 'value: "proxy-xpkg"'; then
+if ! grep -A160 'cutover-step-11-crossplane-provider-pivot' "$TMP/render.yaml" | grep -q 'value: "proxy-xpkg"'; then
   echo "FAIL: Step-11 missing REGISTRY_PATH=proxy-xpkg env (TBD-V24 MISS-3)" >&2
   exit 1
 fi
@@ -2816,5 +2820,58 @@ if ! grep -A2 'name: MIRROR_SELF_HEAL_ENABLED' "$TMP/render-noselfheal.yaml" | g
   exit 1
 fi
 echo "  PASS (#5194 contract: a completeness miss is auto-warmed via the shared step-03 skopeo proxy-copy mechanism + re-HEADed before failing; a still-missing manifest after the warm still FATALs the gate; the self-heal path is operator-toggleable via offlineMirror.selfHeal.enabled)"
+
+echo "[cutover-contract] Case 63: #5214 gitea-admin-secret self-heal initContainer on every consuming step, absent from non-consumers"
+# Every cutover step that reads gitea-admin-secret via a secretKeyRef resolves
+# it ONLY in the Pod's own namespace (catalyst). Two install-time bridges
+# materialise the copy, but on hw271 it was DELETED between install and step-06
+# and nothing re-asserted it -> CreateContainerConfigError -> chain wedged
+# (the #4557/#4558/#4661 recurrence). The durable close is a self-heal
+# initContainer that re-copies gitea/gitea-admin-secret -> catalyst/
+# gitea-admin-secret at STEP-EXECUTION time on each consuming step, stamping
+# helm.sh/resource-policy: keep so it cannot be pruned again. This Case guards
+# BOTH that the init is present on all six consumers AND that it is NOT applied
+# to steps that do not consume the secret (anti over-application / theater).
+# The 11-mirror-resync CronJob is severance-gated OFF by default, so render it
+# in with --set mirrorResync.enabled=true.
+helm template smoke-selfheal . --set mirrorResync.enabled=true > "$TMP/render-selfheal.yaml"
+sh_fail=0
+consumers="cutover-step-06-helmrepository-patches cutover-step-07-catalyst-api-env-patch cutover-step-09-gitea-token-mint cutover-step-10-vcluster-registry-pivot cutover-step-11-crossplane-provider-pivot"
+non_consumers="cutover-step-01-gitea-mirror cutover-step-02-harbor-projects cutover-step-03-harbor-prewarm cutover-step-05-flux-gitrepository-patch cutover-step-08-egress-block-test"
+if command -v yq >/dev/null 2>&1; then
+  # 5 job-mode consumers carry the init inside the .data.podSpec block scalar
+  # (parsed by catalyst-api); re-parse that string and assert the init exists.
+  for step in $consumers; do
+    if ! yq "select(.kind==\"ConfigMap\" and .metadata.name==\"$step\") | .data.podSpec" "$TMP/render-selfheal.yaml" \
+         | yq '[.initContainers[]?.name] | contains(["ensure-gitea-admin-secret"])' - | grep -qx true; then
+      echo "FAIL: consuming step $step missing the #5214 gitea-admin-secret self-heal initContainer" >&2; sh_fail=1
+    fi
+  done
+  # 6th consumer: the mirror-resync CronJob (a real resource).
+  if ! yq 'select(.kind=="CronJob" and .metadata.name=="gitea-mirror-resync") | [.spec.jobTemplate.spec.template.spec.initContainers[]?.name] | contains(["ensure-gitea-admin-secret"])' "$TMP/render-selfheal.yaml" | grep -qx true; then
+    echo "FAIL: mirror-resync CronJob missing the #5214 gitea-admin-secret self-heal initContainer" >&2; sh_fail=1
+  fi
+  # Anti over-application: steps that read harbor/ghcr (or no) secret must NOT
+  # carry the gitea self-heal init.
+  for step in $non_consumers; do
+    if yq "select(.kind==\"ConfigMap\" and .metadata.name==\"$step\") | .data.podSpec" "$TMP/render-selfheal.yaml" \
+         | yq '[.initContainers[]?.name] | contains(["ensure-gitea-admin-secret"])' - | grep -qx true; then
+      echo "FAIL: non-consuming step $step unexpectedly carries the gitea-admin-secret self-heal init (over-application)" >&2; sh_fail=1
+    fi
+  done
+else
+  # No yq: assert exactly 6 init entries render (one per consumer).
+  n=$(grep -cE '^[[:space:]]*- name: ensure-gitea-admin-secret[[:space:]]*$' "$TMP/render-selfheal.yaml")
+  if [ "$n" -ne 6 ]; then
+    echo "FAIL: expected 6 self-heal initContainers (one per gitea-admin-secret consumer), got $n" >&2; sh_fail=1
+  fi
+fi
+# The applied copy MUST carry the #5214 provenance annotation (paired with
+# helm.sh/resource-policy: keep in the jq) — the durability property.
+if ! grep -q 'gitea-admin-secret-cutover-ns-selfheal-5214' "$TMP/render-selfheal.yaml"; then
+  echo "FAIL: self-heal init missing the #5214 provenance annotation / resource-policy keep pairing" >&2; sh_fail=1
+fi
+if [ "$sh_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5214: self-heal init on all 6 gitea-admin-secret consumers, absent from the 5 non-consumers, applied copy stamped resource-policy: keep)"
 
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.139"
+  version: "0.1.140"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.139"
+    version: "0.1.140"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (Refs #5214) — 4th recurrence of the same class

The 11-step self-sovereign-cutover chain wedges at step-06 with
`CreateContainerConfigError: secret "gitea-admin-secret" not found` — the
same class as #4557 → #4558 → #4661, re-observed live on hw271.

Every cutover step Job that reads the Gitea admin credential
(`06-helmrepository-patches`, `07-catalyst-api-env-patch`,
`09-gitea-token-mint`, `10-vcluster-registry-pivot`,
`11-crossplane-provider-pivot`, `11-mirror-resync`) resolves it via a
Kubernetes `secretKeyRef` on `gitea-admin-secret`, which resolves **only in
the Pod's own namespace** (`catalyst`). Two install-time mechanisms
materialise that copy:

1. `templates/00-gitea-admin-secret-bridge.yaml` — render-time Helm
   lookup+mirror (`helm.sh/resource-policy: keep`), rendered only when the
   lookup is non-nil at render time.
2. `templates/00-gitea-admin-secret-bridge-job.yaml` (#4661) — a one-shot
   runtime Job.

But the step Jobs run **45+ min after install** (after the long
harbor-prewarm), and on hw271 the copy was **deleted** from `catalyst`
between install and step-06 by an as-yet unidentified reaper (**not**
helm-controller — the release stayed in-sync so `keep` was never consulted;
**not** kustomize-controller — the secret is in no inventory; **not**
kyverno — no delete policy) and **nothing re-asserted it** (the mirror only
re-renders on a helm upgrade; the #4661 Job is one-shot `Complete`). Chain
wedged.

## Fix — self-heal at step-execution time (robust regardless of the deleter)

A reusable `bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer`
helper (`templates/_helpers.tpl`) emits an **initContainer**
(`ensure-gitea-admin-secret`) that, before the main container runs, copies
`gitea/gitea-admin-secret` → `<release-ns>/gitea-admin-secret` using the
**exact jq sanitize** the #4661 bridge Job uses (rebuild-from-scratch drops
`resourceVersion`/`uid`/`managedFields`/`creationTimestamp`/
`ownerReferences`/last-applied + any `helm.sh/hook*` annotations by
construction), re-targets name+namespace, keeps only provenance
annotations, and **adds `helm.sh/resource-policy: keep`** so a later
reconcile cannot prune it. Idempotent (`kubectl apply` create-or-update),
fail-loud (exits 1 if the password key is absent post-copy), password bytes
stream kubectl→jq→kubectl and are never printed.

It is wired into **every** step template that consumes the secret via
`secretKeyRef` — the six real consumers: `06`, `07`, `09`, `10`,
`11-crossplane-provider-pivot`, `11-mirror-resync-cronjob`. (Steps `02`,
`03`, `08` consume the **harbor**/**ghcr** secret, not gitea — confirmed by
`grep .Values.gitea.adminSecretRef` and the `values.yaml` consumer comment —
so they are deliberately **not** touched; anti over-application.)

Runs under the existing cutover runner SA
(`bp-self-sovereign-cutover-runner`), which already has `secrets get`
cluster-wide + `secrets create` in-namespace (rbac.yaml) — **no new RBAC,
no SA change**. Uses `images.kubectl` (alpine/k8s carries kubectl + jq, as
the #4661 Job already relies on); `harbor.openova.io/proxy-*` resolves to
local Harbor post-pivot via the step-04 containerd rewrite.

**Defense-in-depth:** `00-gitea-admin-secret-bridge-job.yaml`'s jq now also
stamps `helm.sh/resource-policy: keep` so its applied copy stops clobbering
the mirror's keep protection.

## Validation

```
$ helm template . --set giteaAdminSecretBridge.enabled=true --set mirrorResync.enabled=true
helm exit=0   (no YAML errors)
$ ... | grep -c 'ensure-gitea-admin-secret'
42
$ ... | grep -cE '^\s*- name: ensure-gitea-admin-secret\s*$'
6   # one init per consuming step (06, 07, 09, 10, 11-crossplane, 11-mirror-resync)
```

- Every embedded `podSpec` block scalar re-parses as valid YAML with the
  init present and the main container intact (verified by parsing each
  ConfigMap's `.data.podSpec` + the CronJob).
- `helm lint` — 0 failed.
- `tests/cutover-contract.sh` — **all gates green** (EXIT 0), including the
  new **Case 63** (self-heal init on all 6 consumers, absent from the 5
  non-consumers, applied copy stamped `resource-policy: keep`) and **Case
  22** (step-11 grep windows widened `-A60`→`-A160` to account for the
  prepended init, still scoped inside the single ~456-line step-11
  ConfigMap).
- `tests/image-registry-coverage.sh` — PASS.

## Pins bumped in lockstep (0.1.139 → 0.1.140)

- `platform/self-sovereign-cutover/chart/Chart.yaml`
- `platform/self-sovereign-cutover/blueprint.yaml`
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`
  (`spec.version` + `source.version`)

The `check-bootstrap-kit-pin-sync` and `catalog-seed lockstep` gates were
read: on `pull_request` the pin-sync audit runs `--changed-only` **without**
`--check-ghcr`, and the seed lockstep checks topology/endpoints/sso (not
versions) — both pass with these changes.

No step-count / RBAC / deadline change (still 11 steps). No NodePort.

Refs #5214

🤖 Generated with [Claude Code](https://claude.com/claude-code)