### PR TITLE
fix(cutover): step-07 must not roll the EVS/hcloud CSI driver (#5215)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -897,7 +897,7 @@ spec:
       # (prewarm.proxyBackoffBaseSeconds=30, doubling). FATAL-on-any-failure, the
       # #5030 dest-check skip, the #4975 pre-pass + multi-arch handling all
       # preserved. Contract Case 60.
-      version: 0.1.140
+      version: 0.1.141
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.140
+  version: 0.1.141
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,27 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.141 (#5215 Refs #4996 #5074 — step-07 must NOT roll the EVS/hcloud CSI
+# driver. Root-caused live on hw271 (cutoverComplete=true then re-fire wedge):
+# step-07 rolled the csi-evs-node DaemonSet via TWO vectors — (1) the
+# imageRegistryPivot.additionalHRs HR-pivot loop, which carried bp-huawei-evs-csi
+# (added #4892), so patching its spec.values.global.imageRegistry made Flux
+# Helm-upgrade the chart and roll the node plugin; (2) the Phase 4 pod-spec sweep
+# (sweep_workload_podspec_images), which discovers EVERY DaemonSet and rewrote
+# the csi-evs-node sidecar images, rolling it too. The rolled node plugin loses
+# the node-side NodeStage `globalmount` for already-attached EVS volumes, so any
+# EVS-backed pod that remounts on that node fails `MountVolume.SetUp ...
+# globalmount does not exist ... exit status 32`. catalyst-api (Recreate, 2
+# RWO-EVS PVCs) rolls in the SAME step-07 window → stuck ContainerCreating → the
+# #4996 rollout-wait errors → cutover wedges. step-04's registry-pivot DaemonSet
+# ALREADY rewrites node containerd certs.d so the CSI images resolve to the local
+# registry WITHOUT a roll, so both pivots are redundant AND harmful. FIX: two
+# values-driven exclude lists — imageRegistryPivot.excludeHelmReleases (default
+# [bp-huawei-evs-csi]) filters the additionalHRs loop; imageRegistryPivot.
+# podSpecSweep.excludeWorkloads (default the EVS + hcloud CSI driver/controller
+# "<ns>/<name>" set) filters the Phase 4 sweep. This is the step-07 twin of
+# step-08's CSI exclusion (#5074/#5081). No step-count / RBAC / deadline change
+# (still 11 steps). Contract Case 64 guards both vectors.)
+#
 # 0.1.140 (#5214 Refs #4557 #4558 #4661 — DURABLE close of the recurring
 # `secret "gitea-admin-secret" not found` wedge. Every cutover step Job that
 # reads the Gitea admin credential (06-helmrepository-patches,
@@ -2294,7 +2316,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.140
+version: 0.1.141
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -45,6 +45,18 @@ offline-mirror resolver step-03/04/08 share — no per-chart-helper /
 per-image allowlist to drift. Idempotent, presence-gated, fail-open,
 reversible (records pre-sweep images in a pod-template annotation).
 
+#5215 (Refs #4996 #5074): storage/CSI-driver workloads are the ONE class
+this step must NOT roll. Both the HR global.imageRegistry pivot loop
+(imageRegistryPivot.excludeHelmReleases) AND the Phase 4 pod-spec sweep
+(imageRegistryPivot.podSpecSweep.excludeWorkloads) now EXCLUDE the EVS/
+hcloud CSI drivers. Rolling csi-evs-node drops the node-side NodeStage
+`globalmount` for already-attached EVS volumes → catalyst-api (2 RWO-EVS
+PVCs, also rolling here) wedges ContainerCreating → the #4996 rollout
+wait errors → cutover wedges (live hw271). step-04's containerd certs.d
+rewrite already resolves the CSI images to local WITHOUT a roll, so the
+pivot is redundant AND harmful — step-08 excludes the same drivers for
+the identical reason (#5074).
+
 Phase 2 (pre-G61): kubectl set env CATALYST_GITOPS_REPO_URL pointing
 catalyst-api at the local Gitea mirror. Triggers another rolling
 restart (likely already in-flight from Phase 1's HR upgrade, but
@@ -170,6 +182,11 @@ data:
             value: {{ eq (toString .Values.imageRegistryPivot.podSpecSweep.enabled) "true" | quote }}
           - name: PODSPEC_SWEEP_EXCLUDE
             value: {{ .Values.imageRegistryPivot.podSpecSweep.excludeWorkloadSubstring | default "catalyst-api" | quote }}
+          # #5215 — "<ns>/<name>" storage/CSI-driver workloads the sweep MUST NOT
+          # roll (rolling csi-evs-node drops NodeStage globalmount for in-use EVS
+          # PVCs → catalyst-api wedges; step-04 containerd rewrite covers the pull).
+          - name: PODSPEC_SWEEP_EXCLUDE_WORKLOADS
+            value: {{ .Values.imageRegistryPivot.podSpecSweep.excludeWorkloads | default (list) | join " " | quote }}
           - name: PODSPEC_SWEEP_PRESENCE_GATE
             value: {{ eq (toString .Values.imageRegistryPivot.podSpecSweep.presenceGate) "true" | quote }}
           - name: LOCAL_REGISTRY_HOST
@@ -346,6 +363,23 @@ data:
                     # the bp-catalyst-platform HR + env roll below).
                     if [ -n "${PODSPEC_SWEEP_EXCLUDE:-}" ]; then
                       case "${_sw_name}" in *"${PODSPEC_SWEEP_EXCLUDE}"*) continue ;; esac
+                    fi
+                    # #5215 — never sweep a storage/CSI-driver workload. Rewriting
+                    # its pod-spec image rolls the driver Pod (csi-evs-node
+                    # DaemonSet), which drops the node-side NodeStage globalmount for
+                    # already-attached EVS volumes → every EVS-backed pod that
+                    # remounts on that node fails `globalmount does not exist` (exit
+                    # 32) and catalyst-api (RWO-EVS, also rolling in step-07) wedges.
+                    # step-04's containerd certs.d rewrite already resolves the CSI
+                    # images to local WITHOUT a roll; step-08 excludes the same
+                    # drivers (#5074). Exact "<ns>/<name>" match.
+                    _sw_skip=0
+                    for _sw_x in ${PODSPEC_SWEEP_EXCLUDE_WORKLOADS:-}; do
+                      if [ "${_sw_ns}/${_sw_name}" = "${_sw_x}" ]; then _sw_skip=1; break; fi
+                    done
+                    if [ "${_sw_skip}" = "1" ]; then
+                      echo "[catalyst-api-env-patch]     SKIP ${_sw_k} ${_sw_ns}/${_sw_name} (#5215 storage/CSI driver — a pod-spec-image roll drops NodeStage globalmount for in-use EVS volumes; step-04 containerd rewrite covers its pull)"
+                      continue
                     fi
                     sweep_one_workload "${_sw_k}" "${_sw_ns}" "${_sw_name}" || true
                   done
@@ -796,8 +830,17 @@ data:
                 "reconcile.fluxcd.io/requestedAt=$(date +%s)" \
                 --overwrite || true
             }
+            # #5215 — storage/CSI-driver HelmReleases NEVER pivoted here (rolling a
+            # CSI driver rolls its csi-evs-node DaemonSet → drops NodeStage globalmount
+            # for in-use EVS PVCs → catalyst-api wedges; step-04 containerd rewrite
+            # covers their pull; step-08 excludes the same drivers #5074): {{ .Values.imageRegistryPivot.excludeHelmReleases | default (list) | join " " }}
+{{- $excludeHR := .Values.imageRegistryPivot.excludeHelmReleases | default (list) }}
 {{- range .Values.imageRegistryPivot.additionalHRs }}
+{{- if has .name $excludeHR }}
+            # #5215 SKIP HR pivot {{ .name }} (storage/CSI driver in imageRegistryPivot.excludeHelmReleases — rolling it breaks NodeStage globalmount)
+{{- else }}
             pivot_extra_hr {{ .name | quote }} {{ .namespace | quote }} {{ .slotFile | quote }}
+{{- end }}
 {{- end }}
 
             # G61 Phase 2 (was Step 07 pre-G61): set env on the

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2874,4 +2874,58 @@ fi
 if [ "$sh_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5214: self-heal init on all 6 gitea-admin-secret consumers, absent from the 5 non-consumers, applied copy stamped resource-policy: keep)"
 
+echo "[cutover-contract] Case 64: #5215 step-07 NEVER rolls the EVS/hcloud CSI driver — both the additionalHRs HR-pivot loop AND the Phase 4 pod-spec sweep exclude it (rolling csi-evs-node drops NodeStage globalmount for in-use EVS PVCs → catalyst-api wedges; step-04 containerd rewrite covers the pull; step-08 excludes the same driver #5074)"
+# Root-caused live hw271: step-07 rolled the csi-evs-node DaemonSet via TWO
+# vectors — (1) imageRegistryPivot.additionalHRs carried bp-huawei-evs-csi (added
+# #4892), so patching its HR global.imageRegistry Helm-upgraded the chart and
+# rolled the node plugin; (2) the Phase 4 sweep discovers EVERY DaemonSet and
+# rewrote csi-evs-node's sidecar images, rolling it too. The rolled plugin loses
+# the node-side NodeStage `globalmount` for already-attached EVS volumes → any
+# EVS-backed pod that remounts fails `globalmount does not exist` (exit 32) and
+# catalyst-api (2 RWO-EVS PVCs, also rolling here) wedges ContainerCreating → the
+# #4996 rollout-wait errors → cutover wedges. This Case guards BOTH exclusion
+# vectors + the overlay-resistant guard.
+helm template smoke . --show-only templates/07-catalyst-api-env-patch-job.yaml > "$TMP/r07_5215.yaml"
+c64_fail=0
+# (1) HR-pivot loop MUST NOT target the CSI driver.
+if grep -q 'pivot_extra_hr "bp-huawei-evs-csi"' "$TMP/r07_5215.yaml"; then
+  echo "FAIL: step-07 additionalHRs loop still pivots bp-huawei-evs-csi — rolling its HR rolls csi-evs-node and breaks NodeStage globalmount (#5215)" >&2; c64_fail=1
+fi
+# ...but the exclude guard MUST render bp-huawei-evs-csi (the exclusion is
+# auditable in the rendered manifest, not just absent).
+if ! grep -q 'NEVER pivoted here' "$TMP/r07_5215.yaml" \
+   || ! grep -A3 'NEVER pivoted here' "$TMP/r07_5215.yaml" | grep -q 'bp-huawei-evs-csi'; then
+  echo "FAIL: step-07 excludeHelmReleases guard comment does not render bp-huawei-evs-csi (#5215)" >&2; c64_fail=1
+fi
+# (2) Phase 4 pod-spec sweep env MUST carry the CSI driver "<ns>/<name>" set.
+if ! grep -A1 'name: PODSPEC_SWEEP_EXCLUDE_WORKLOADS$' "$TMP/r07_5215.yaml" \
+     | grep -q 'huawei-evs-csi/csi-evs-node'; then
+  echo "FAIL: step-07 PODSPEC_SWEEP_EXCLUDE_WORKLOADS env missing huawei-evs-csi/csi-evs-node (#5215)" >&2; c64_fail=1
+fi
+for _csi in huawei-evs-csi/csi-evs-controller kube-system/hcloud-csi-node kube-system/hcloud-csi-controller; do
+  if ! grep -A1 'name: PODSPEC_SWEEP_EXCLUDE_WORKLOADS$' "$TMP/r07_5215.yaml" | grep -q "$_csi"; then
+    echo "FAIL: step-07 PODSPEC_SWEEP_EXCLUDE_WORKLOADS env missing $_csi (#5215)" >&2; c64_fail=1
+  fi
+done
+# (2b) the sweep loop MUST consume that env with an exact "<ns>/<name>" match.
+if ! grep -q 'for _sw_x in ${PODSPEC_SWEEP_EXCLUDE_WORKLOADS' "$TMP/r07_5215.yaml"; then
+  echo "FAIL: step-07 pod-spec sweep does not honour PODSPEC_SWEEP_EXCLUDE_WORKLOADS (#5215)" >&2; c64_fail=1
+fi
+# (3) OVERLAY-RESISTANT: even if an overlay RE-ADDS bp-huawei-evs-csi to
+# additionalHRs, excludeHelmReleases (deny wins over allow) MUST still skip it.
+if helm template smoke . --show-only templates/07-catalyst-api-env-patch-job.yaml \
+     --set-json 'imageRegistryPivot.additionalHRs=[{"name":"bp-huawei-evs-csi","namespace":"flux-system","slotFile":"clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml"}]' \
+     > "$TMP/r07_5215_overlay.yaml" 2>/dev/null; then
+  if grep -q 'pivot_extra_hr "bp-huawei-evs-csi"' "$TMP/r07_5215_overlay.yaml"; then
+    echo "FAIL: an overlay that re-adds bp-huawei-evs-csi to additionalHRs is NOT neutralised by excludeHelmReleases — the guard is not deny-wins (#5215)" >&2; c64_fail=1
+  fi
+  if ! grep -q '#5215 SKIP HR pivot bp-huawei-evs-csi' "$TMP/r07_5215_overlay.yaml"; then
+    echo "FAIL: overlay re-add of bp-huawei-evs-csi did not render the excludeHelmReleases SKIP guard (#5215)" >&2; c64_fail=1
+  fi
+else
+  echo "FAIL: helm --set-json overlay render failed (#5215)" >&2; c64_fail=1
+fi
+if [ "$c64_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5215: step-07 excludes the CSI driver from BOTH the additionalHRs HR pivot [excludeHelmReleases] AND the Phase 4 pod-spec sweep [podSpecSweep.excludeWorkloads]; the exclusion renders auditably and is deny-wins against an overlay re-add)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -940,16 +940,22 @@ imageRegistryPivot:
     - name: bp-continuum
       namespace: flux-system
       slotFile: clusters/_template/bootstrap-kit/62-bp-continuum.yaml
-    # #4892 (Refs #4885): the four charts formerly excluded above now honour
+    # #4892 (Refs #4885): the charts formerly excluded above now honour
     # global.imageRegistry, so their HRs pivot cleanly (no longer silent no-ops).
     # Each metadata.name matches the live HelmRelease the cutover patches, and
     # each slotFile carries the 6-space `global.imageRegistry: ''` seam.
+    # #5215: bp-huawei-evs-csi is DELIBERATELY NOT in this pivot list — pivoting
+    # its HR imageRegistry rolls the csi-evs-node DaemonSet, which drops the
+    # node-side NodeStage globalmount for already-attached EVS volumes → every
+    # EVS-backed pod that remounts hits `globalmount does not exist` (exit 32)
+    # and catalyst-api (2 RWO-EVS PVCs, also rolling in step-07) wedges
+    # ContainerCreating → the #4996 rollout-wait errors → cutover wedges. step-04's
+    # containerd certs.d rewrite ALREADY pivots its images to local WITHOUT a roll,
+    # so the pivot is redundant AND harmful. Enforced by excludeHelmReleases below
+    # (step-08 excludes the same driver for the identical reason — #5074).
     - name: bp-guacamole
       namespace: flux-system
       slotFile: clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
-    - name: bp-huawei-evs-csi
-      namespace: flux-system
-      slotFile: clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
     - name: bp-newapi
       namespace: flux-system
       slotFile: clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -971,6 +977,24 @@ imageRegistryPivot:
     - name: bp-k8s-ws-proxy
       namespace: flux-system
       slotFile: clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+
+  # #5215 — storage/CSI-driver HelmReleases that step-07 MUST NEVER pivot, even
+  # if an overlay (or a future edit) re-adds one to additionalHRs above. Deny
+  # wins over allow: the additionalHRs loop skips any HR whose name is listed
+  # here. Patching a CSI driver's global.imageRegistry rolls its node plugin
+  # (csi-evs-node DaemonSet); the rolled plugin loses the node-side NodeStage
+  # `globalmount` for already-attached EVS volumes, so any EVS-backed pod that
+  # remounts on that node fails `MountVolume.SetUp ... globalmount does not
+  # exist ... exit status 32`. catalyst-api (Recreate, 2 RWO-EVS PVCs) rolls in
+  # the SAME step-07 window and wedges ContainerCreating → the #4996 rollout
+  # wait errors → cutover wedges (live hw271, cutoverComplete never re-set after
+  # a re-fire). step-04's registry-pivot DaemonSet ALREADY rewrites the node
+  # containerd certs.d so the CSI images resolve to the local registry WITHOUT a
+  # roll, so the HR pivot is redundant AND harmful. This is the step-07 twin of
+  # step-08's CSI exclusion (#5074: never bounce the mechanism every stateful
+  # mount depends on). Auditable + overlay-extensible.
+  excludeHelmReleases:
+    - bp-huawei-evs-csi
 
   # #4973 #4975 #4961 — COMPREHENSIVE pod-spec image sweep (step-07 Phase 4).
   #
@@ -1002,6 +1026,24 @@ imageRegistryPivot:
     # Never sweep the cutover engine's own catalyst-api (step-07 pivots it via the
     # bp-catalyst-platform HR + env roll above). Substring match on workload name.
     excludeWorkloadSubstring: "catalyst-api"
+    # #5215 — storage/CSI-driver workloads ("<namespace>/<name>") the sweep MUST
+    # NEVER touch. Rewriting a CSI driver's pod-spec image rolls its node plugin
+    # (csi-evs-node DaemonSet), which drops the node-side NodeStage `globalmount`
+    # for already-attached EVS volumes → every EVS-backed pod that remounts on
+    # that node fails `globalmount does not exist` (exit 32) and catalyst-api (2
+    # RWO-EVS PVCs) wedges ContainerCreating → the #4996 rollout wait errors →
+    # cutover wedges (live hw271). This is the second step-07 vector that rolls
+    # the driver (the additionalHRs HR pivot is the first — see
+    # excludeHelmReleases above); both are closed for the same root cause. step-04's
+    # containerd certs.d rewrite already resolves the CSI images to local WITHOUT a
+    # roll, and step-08 excludes the same drivers by name (#5074) + never rolls a
+    # DaemonSet in an infra namespace (#5081 rule b). Covers Huawei EVS + Hetzner
+    # hcloud CSI (driver + controller); auditable + overlay-extensible.
+    excludeWorkloads:
+      - "huawei-evs-csi/csi-evs-node"
+      - "huawei-evs-csi/csi-evs-controller"
+      - "kube-system/hcloud-csi-node"
+      - "kube-system/hcloud-csi-controller"
     # Refuse to pivot a pod-spec image onto a ref the local Harbor does not yet
     # serve — leave it as-is so step-08's completeness gate names the REAL offender
     # instead of a sweep-induced ImagePullBackOff. Keep ON.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.140"
+  version: "0.1.141"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.140"
+    version: "0.1.141"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (root-caused live on hw271)

Cutover **step-07** rolled the `csi-evs-node` DaemonSet (ns `huawei-evs-csi`). The rolled node plugin loses the node-side NodeStage `globalmount` for already-attached EVS volumes, so any EVS-backed pod that (re)mounts on that node fails `MountVolume.SetUp ... globalmount does not exist ... exit status 32`. **catalyst-api** (Recreate strategy, 2 RWO-EVS PVCs) also rolls in the same step-07 window → stuck `ContainerCreating` → step-07's `#4996` rollout-wait errors → the cutover chain wedges.

Two independent step-07 vectors rolled the driver:

1. **HR-pivot loop** — `imageRegistryPivot.additionalHRs` carried `bp-huawei-evs-csi` (added in #4892). Patching its `spec.values.global.imageRegistry` makes Flux Helm-upgrade the chart → rolls the node plugin.
2. **Phase 4 pod-spec sweep** (`sweep_workload_podspec_images`) — discovers **every** DaemonSet and rewrote `csi-evs-node`'s sidecar image refs to the local registry → rolls it too. It previously excluded only workloads whose name contains `catalyst-api`.

step-04's registry-pivot DaemonSet **already** rewrites node containerd `certs.d` so the CSI images resolve to the local registry **without** a roll — so both pivots are redundant **and** harmful. This is the step-07 twin of **step-08**'s CSI exclusion (#5074 / #5081), which already refuses to roll the same driver for the identical globalmount reason.

## Fix — two values-driven, auditable exclude lists

- `imageRegistryPivot.excludeHelmReleases` (default `[bp-huawei-evs-csi]`) filters the `additionalHRs` HR-pivot loop. **Deny wins over allow** — an overlay that re-adds the driver to `additionalHRs` is still neutralised (the loop renders a `#5215 SKIP HR pivot` comment instead of the `pivot_extra_hr` call).
- `imageRegistryPivot.podSpecSweep.excludeWorkloads` (default the EVS + hcloud CSI driver/controller `"<ns>/<name>"` set) filters the Phase 4 pod-spec sweep by exact `<ns>/<name>` match.

No step-count / RBAC / activeDeadline change (still 11 steps). Lockstep pins bumped `0.1.140 → 0.1.141`: Chart.yaml (version + changelog), `blueprint.yaml`, bootstrap-kit slot 06a, catalog-seed `spec.version` + `source.version`.

## Validation (all local, EXIT 0)

- `helm template . | grep -i bp-huawei-evs-csi` — the step-07 HR sweep no longer emits `pivot_extra_hr "bp-huawei-evs-csi"`; the `excludeHelmReleases` guard comment renders the excluded driver (exclusion is auditable in the manifest).
- `tests/cutover-contract.sh` — **EXIT 0**; new **Case 64** guards both vectors + the deny-wins overlay re-add.
- `helm lint` — **0 charts failed**.
- `scripts/check-bootstrap-kit-pin-sync.sh` — `chart=0.1.141 pin=0.1.141 OK`.
- `scripts/check-catalog-seed-lockstep.sh` — `fail: 0`.
- `tests/image-registry-coverage.sh` — PASS (no new image hosts).

Refs #5215 #4996 #5074

🤖 Generated with [Claude Code](https://claude.com/claude-code)