### PR TITLE
fix(cnpg-pair): dr-promoter durable-suspend race — same-tick latch + per-loop self-heal (#5218)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -221,7 +221,15 @@ spec:
       # startup grace, and (B) a durable SUSPEND latch + anti-flap guard. The
       # existing SOVEREIGN_PEER_CLUSTERMESH_NAMES wiring (below) is what arms
       # the liveness gate — no new substitute.
-      version: 0.2.14
+      # 0.2.15 (#5218): dr-promoter durable-suspend RACE fix — on hw271 G12 the
+      # promote fired but was re-demoted mid-outage because the 0.2.14 latch
+      # suspended the HR only on the NEXT tick, leaving a window for kustomize
+      # to revert spec.values and re-render replica.enabled=true. The actor now
+      # suspends IN THE SAME TICK as the promote (once helm renders) and
+      # re-asserts spec.suspend every loop while promoted/diverged (self-heal),
+      # with readback verification. No new substitute; all decision gates
+      # unchanged.
+      version: 0.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -25,7 +25,14 @@ spec:
   # so the actor no longer false-promotes a healthy replica against a live
   # region-A, and (B) a durable SUSPEND latch + anti-flap divergence guard so a
   # real promotion sticks instead of flapping the timeline away (hw266 G12).
-  version: 0.2.14
+  # 0.2.15 (#5218): dr-promoter durable-suspend RACE fix — on hw271 G12 the
+  # promote fired but was re-demoted mid-outage because the 0.2.14 latch only
+  # suspended the HR on the NEXT actor tick, leaving a window for kustomize to
+  # revert spec.values and re-render replica.enabled=true. The actor now
+  # suspends IN THE SAME TICK as the promote (once helm renders) and re-asserts
+  # spec.suspend every loop while promoted/diverged (self-heal), with readback
+  # verification. All decision gates unchanged.
+  version: 0.2.15
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.15 (#5218): dr-promoter durable-suspend RACE fix — on hw271 G12 the promote
+# fired at T0+2m29s (region-B writable, TL2) but was RE-DEMOTED mid-outage (a
+# second "primary loss" re-detected ~T0+7m while region-A was still down), so the
+# survivor latched as a diverged TL2 standby and the failover effectively failed.
+# The 0.2.14 latch suspended the HR only on the NEXT actor tick (up to a full
+# intervalSeconds after the promote), leaving a window in which kustomize-
+# controller's SSA re-apply reclaimed the atomic spec.values, dropped the nested
+# `promoted` key, and helm re-rendered replica.enabled=true → re-demote. Fix: the
+# actor now stays IN THE SAME TICK after flipping promoted=true — it polls until
+# helm renders replica.enabled=false (bounded by promoteRenderWaitSeconds) and
+# suspends IMMEDIATELY, collapsing the promote→suspend window to seconds; a
+# per-tick SELF-HEAL latch re-asserts spec.suspend on every loop while the cluster
+# is promoted/diverged (idempotent — re-freezes if anything un-suspends the HR);
+# and a suspend_hr helper READBACK-VERIFIES every suspend and logs RBAC/conflict
+# failures. The suspend is NEVER set before the render (a suspended HR is not
+# reconciled by helm, so the promotion would never land). All 0.2.14 decision
+# gates unchanged (120s hold, positive region-A pg_isready gate, sync-only render,
+# startup grace, anti-flap divergence latch). No RBAC change (the flux-system Role
+# already grants get+patch on the one HR). No resource-count change. Lockstep slot
+# 16b → 0.2.15.
 # 0.2.14 (#5178): dr-promoter regression fix — the 0.2.13 promoter FALSE-PROMOTED
 # a healthy replica against a LIVE region-A and its promotion was NON-DURABLE, so
 # on hw266 G12 it ran the region-B Postgres timeline away (TL2→TL25) and
@@ -96,7 +116,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.14
+version: 0.2.15
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/dr-promoter.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-promoter.yaml
@@ -122,6 +122,7 @@ tracked on #5137.)
 {{- $hold := $ap.primaryDownHoldSeconds | default 120 }}
 {{- $startupGrace := $ap.startupGraceSeconds | default 300 }}
 {{- $probeTimeout := $ap.livenessProbeTimeoutSeconds | default 5 }}
+{{- $renderWait := $ap.promoteRenderWaitSeconds | default 90 }}
 {{- $peerClusters := .Values.cnpgPair.networkPolicy.crossRegionPeerClusters | default list }}
 {{- /* #5178 — the region-A liveness gate is meaningful ONLY when the mesh
        egress to region-A can actually be wired: clusterMesh on AND at least
@@ -464,30 +465,63 @@ spec:
             - name: replication-cert
               mountPath: /tls/client
               readOnly: true
-        # ── actor — the PROMOTER + durable LATCH (#5178 Defect-B) ────
+        # ── actor — the PROMOTER + durable SUSPEND LATCH (#5178 / #5218) ─
         # Each tick runs in a subshell (a persistent fault retries next
-        # tick instead of crashing the pod — #5157 shape). Ordering:
-        #   1. LATCH — if we drove a promotion (HR promoted=true) that has
-        #      RENDERED (local Cluster replica.enabled=false) but the HR is
-        #      not yet suspended, set spec.suspend=true. This makes the
-        #      promotion durable: kustomize-controller does NOT own
-        #      spec.suspend, and a suspended HR freezes helm so the reverted
-        #      atomic spec.values can no longer re-demote the survivor. Runs
-        #      independent of the hold clock (which signals clears the moment
-        #      the cluster leaves recovery).
-        #   2. ANTI-FLAP — already suspended (latched) OR promote in flight
-        #      ⇒ never touch again.
+        # tick instead of crashing the pod — #5157 shape). A shell helper
+        # `suspend_hr` sets spec.suspend=true, READBACK-VERIFIES it landed,
+        # and logs loudly (RBAC/conflict) on failure so a stuck latch is
+        # diagnosable in the actor-container log. Ordering:
+        #   1. SELF-HEAL LATCH (every tick, independent of the hold clock) —
+        #      if the promotion is DRIVEN + RENDERED (HR promoted=true AND
+        #      local Cluster replica.enabled=false) OR the local cluster has
+        #      already left recovery (/shared/diverged), and the HR is NOT
+        #      suspended, RE-ASSERT spec.suspend=true. Idempotent: it latches
+        #      the promoted release AND re-freezes within one interval if
+        #      anything ever un-suspends the HR. Both arms require POSITIVE
+        #      render evidence, so it can never freeze a pre-render HR and
+        #      strand an un-rendered promotion.
+        #   2. ANTI-FLAP — already suspended (latched) ⇒ done. HR promoted
+        #      but not yet rendered ⇒ WAIT for the render (do NOT suspend a
+        #      pre-render HR — a suspended HR is not reconciled by helm, so
+        #      the promotion would never land).
         #   3. PROMOTE — hold expired → NOT already diverged → local Cluster
-        #      still a replica → failover-readiness Ready (#5133). Then ONE
-        #      merge-patch of the HR desired state (the RUNBOOKS §6.1 seam);
-        #      the LATCH fires on the next tick once helm renders it.
+        #      still a replica → failover-readiness Ready (#5133). Flip the HR
+        #      desired state (the RUNBOOKS §6.1 seam), then STAY IN THE SAME
+        #      TICK (#5218): poll until helm renders replica.enabled=false and
+        #      suspend IMMEDIATELY. This shrinks the promote→suspend window
+        #      from a full interval (the 0.2.14 next-tick latch, which let
+        #      kustomize revert spec.values and re-demote mid-outage on hw271)
+        #      to seconds; the step-1 self-heal is the backstop.
         - name: actor
           image: {{ printf "%s:%s" $krepo $ktag | quote }}
           imagePullPolicy: {{ $kpull | quote }}
           command: ["/bin/sh", "-c"]
           args:
             - |
-              echo "[dr-promoter/actor] loop started (hold=${HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME})"
+              # suspend_hr <reason> — patch spec.suspend=true (+ latched-at
+              # annotation), then READBACK-VERIFY it landed. spec.suspend is a
+              # field flux's Kustomization (slot 16b) does NOT own, so its SSA
+              # drift-correction cannot remove it; a suspended HR freezes
+              # helm-controller so the reverted atomic spec.values can no
+              # longer re-render replica.enabled=true and re-demote the
+              # survivor (#5178 Defect-B / #5218). Returns non-zero (logged)
+              # if the patch or the readback fails — the caller re-asserts next
+              # tick, so an RBAC/conflict fault is self-healing AND diagnosable.
+              suspend_hr() {
+                _reason="$1"
+                if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-latched-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":true}}" >/dev/null 2>&1; then
+                  _v=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
+                  if [ "${_v}" = "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] LATCHED (${_reason}): HR ${HR_NAMESPACE}/${HR_NAME} spec.suspend=true VERIFIED — promotion durable; flux drift-correction can no longer revert spec.values and re-demote the survivor (#5178 Defect-B / #5218)"
+                    return 0
+                  fi
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] ERROR (${_reason}): spec.suspend patch accepted but readback='${_v}' (expected true) — HR NOT frozen; re-asserting next tick (#5218)"
+                  return 1
+                fi
+                echo "$(date -u +"%FT%TZ") [dr-promoter/actor] ERROR (${_reason}): spec.suspend patch FAILED (RBAC/conflict?) — HR NOT frozen; re-asserting next tick (#5218)"
+                return 1
+              }
+              echo "[dr-promoter/actor] loop started (hold=${HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s renderWait=${PROMOTE_RENDER_WAIT_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME})"
               while true; do
                 : > /shared/actor-alive
                 (
@@ -495,18 +529,28 @@ spec:
                   SUSPENDED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
                   HR_PROMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.cnpgPair.replica.promoted}' 2>/dev/null || echo "")
                   REPLICA_ENABLED=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}' 2>/dev/null || echo "")
+                  DIVERGED=""; [ -f /shared/diverged ] && DIVERGED="true"
 
-                  # 1. LATCH — make an already-rendered promotion durable.
-                  if [ "${SUSPENDED}" != "true" ] && [ "${HR_PROMOTED}" = "true" ] && [ "${REPLICA_ENABLED}" = "false" ]; then
-                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-latched-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":true}}"
-                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] LATCHED: HR ${HR_NAMESPACE}/${HR_NAME} spec.suspend=true — promotion durable; flux drift-correction can no longer revert spec.values and re-demote the survivor (#5178 Defect-B)"
+                  # 1. SELF-HEAL LATCH — keep an already-rendered promotion
+                  #    durable. Fires on the post-promote tick AND re-freezes
+                  #    the HR if anything ever un-suspends it. Both arms require
+                  #    POSITIVE render evidence (replica.enabled=false OR the
+                  #    cluster already left recovery) so it can never freeze a
+                  #    pre-render HR and strand the promotion.
+                  if [ "${SUSPENDED}" != "true" ] && { { [ "${HR_PROMOTED}" = "true" ] && [ "${REPLICA_ENABLED}" = "false" ]; } || [ "${DIVERGED}" = "true" ]; }; then
+                    suspend_hr "self-heal" || true
                     exit 0
                   fi
-                  # 2. ANTI-FLAP — latched, or a promote is mid-render.
+                  # 2. ANTI-FLAP — latched ⇒ done.
                   if [ "${SUSPENDED}" = "true" ]; then
                     exit 0
                   fi
+                  # Promote driven but not yet rendered (replica.enabled still
+                  # true, not diverged) — WAIT for helm; never suspend now (a
+                  # suspended HR is not reconciled, the promote would never
+                  # land) and never re-promote.
                   if [ "${HR_PROMOTED}" = "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] HR promoted=true but not yet rendered (replica.enabled='${REPLICA_ENABLED}') — waiting for helm-controller; self-heal latch suspends the instant it renders (#5218)"
                     exit 0
                   fi
 
@@ -536,7 +580,28 @@ spec:
                   fi
                   echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTING: region-A WAL stream absent AND region-A unreachable ${DOWN_FOR}s >= ${HOLD_SECONDS}s AND failover-readiness Ready — patching HR desired state (#5125-D1 seam)"
                   kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-auto-promote-reason\":\"region-A WAL stream absent and region-A unreachable ${DOWN_FOR}s; failover-readiness Ready (#5137/#5178)\"}},\"spec\":{\"values\":{\"cnpgPair\":{\"replica\":{\"promoted\":true}}}}}"
-                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTED (step 1/2): HR ${HR_NAMESPACE}/${HR_NAME} spec.values.cnpgPair.replica.promoted=true — helm-controller renders replica.enabled:false → CNPG promotes; the suspend LATCH fires next tick once it renders (#5178)"
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTED (step 1/2): HR ${HR_NAMESPACE}/${HR_NAME} spec.values.cnpgPair.replica.promoted=true — helm-controller renders replica.enabled:false → CNPG promotes"
+                  # 3b. SAME-TICK DURABLE LATCH (#5218) — do NOT wait for the
+                  #     next tick. Poll until helm renders replica.enabled=false
+                  #     (the promotion has LANDED), then suspend IMMEDIATELY so
+                  #     kustomize cannot reclaim the atomic spec.values and
+                  #     re-demote in the gap. Bounded; the step-1 self-heal is
+                  #     the backstop if the render outlasts the ceiling.
+                  RE=""
+                  i=0
+                  while [ "${i}" -lt "${PROMOTE_RENDER_WAIT_SECONDS}" ]; do
+                    RE=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}' 2>/dev/null || echo "")
+                    if [ "${RE}" = "false" ]; then
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTION RENDERED (step 2/2): replica.enabled=false after ${i}s — suspending HR now (#5218)"
+                      suspend_hr "post-promote same-tick" || true
+                      break
+                    fi
+                    i=$((i + 1))
+                    sleep 1
+                  done
+                  if [ "${RE}" != "false" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] NOTE: helm has not rendered replica.enabled=false within ${PROMOTE_RENDER_WAIT_SECONDS}s of the promote patch (replica.enabled='${RE}') — the per-tick self-heal latch will suspend the instant it renders (#5218)"
+                  fi
                 ) || echo "[dr-promoter/actor] tick returned non-zero — retry in ${INTERVAL_SECONDS}s"
                 sleep "${INTERVAL_SECONDS}"
               done
@@ -553,6 +618,10 @@ spec:
               value: {{ $hold | quote }}
             - name: INTERVAL_SECONDS
               value: {{ $interval | quote }}
+            # #5218 — ceiling on the same-tick post-promote poll that waits
+            # for helm to render replica.enabled=false before suspending.
+            - name: PROMOTE_RENDER_WAIT_SECONDS
+              value: {{ $renderWait | quote }}
             - name: REPLICA_CLUSTER
               value: {{ include "cnpg-pair.replicaName" . | quote }}
             - name: READY_SELECTOR

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -862,4 +862,52 @@ if [ "$(grep -cE '^kind: CiliumNetworkPolicy' "$TMP/replica-peer.yaml")" -ne 2 ]
   grep -nE '^kind: CiliumNetworkPolicy' "$TMP/replica-peer.yaml" >&2; exit 1; fi
 echo "  PASS (fail-safe observe-only without a peer; liveness gate + startup grace + suspend latch + anti-flap with a peer)"
 
+# ── Case 17: #5218 dr-promoter durable-suspend RACE fix ──────────────
+# hw271 G12: the promote fired (T0+2m29s) but was RE-DEMOTED mid-outage —
+# the 0.2.14 latch suspended the HR only on the NEXT actor tick (up to a
+# full intervalSeconds later), leaving a window for kustomize-controller to
+# reclaim the atomic spec.values, drop the nested `promoted` key, and let
+# helm re-render replica.enabled=true → re-demote. 0.2.15: suspend IN THE
+# SAME TICK as the promote (once helm renders), re-assert every loop while
+# promoted/diverged (self-heal), and readback-verify every suspend.
+echo "[render] Case 17: #5218 same-tick durable suspend + self-heal re-assert + readback-verify"
+# (a) the actor container script must be valid POSIX shell — helm renders the
+#     YAML but never parses the embedded shell, so a syntax error would ship.
+python3 - "$TMP/replica.yaml" <<'PYEOF' > "$TMP/actor.sh" || { echo "FAIL: #5218 could not extract the actor container script." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-promoter' in d['metadata']['name']][0]
+act=[c for c in dep['spec']['template']['spec']['containers'] if c['name']=='actor'][0]
+sys.stdout.write(act['args'][0])
+PYEOF
+sh -n "$TMP/actor.sh" || { echo "FAIL: #5218 actor container script is not valid POSIX shell." >&2; exit 1; }
+# (b) suspend_hr helper exists and READBACK-VERIFIES the suspend landed.
+grep -q 'suspend_hr()' "$TMP/actor.sh" || {
+  echo "FAIL: #5218 actor missing the suspend_hr helper." >&2; exit 1; }
+grep -q 'spec.suspend}' "$TMP/actor.sh" && grep -q 'VERIFIED' "$TMP/actor.sh" || {
+  echo "FAIL: #5218 suspend_hr must READBACK-VERIFY spec.suspend after patching." >&2; exit 1; }
+# (c) same-tick latch: after the promote patch the actor polls for the render
+#     and suspends in the SAME tick (step 2/2), not the next tick.
+grep -q 'PROMOTION RENDERED (step 2/2)' "$TMP/actor.sh" || {
+  echo "FAIL: #5218 actor must suspend in the SAME tick after helm renders (step 2/2), not the next tick." >&2; exit 1; }
+grep -q 'suspend_hr "post-promote same-tick"' "$TMP/actor.sh" || {
+  echo "FAIL: #5218 actor missing the same-tick post-promote suspend call." >&2; exit 1; }
+# (d) self-heal: suspend is re-asserted on every loop while promoted/diverged.
+grep -q 'suspend_hr "self-heal"' "$TMP/actor.sh" || {
+  echo "FAIL: #5218 actor missing the per-loop self-heal suspend re-assert." >&2; exit 1; }
+# (e) suspend must NEVER ride into the promote patch — a suspended HR is not
+#     reconciled by helm, so the promotion would never render/land. The
+#     promote merge-patch (promoted=true) must NOT also carry suspend=true.
+python3 - "$TMP/actor.sh" <<'PYEOF' || { echo "FAIL: #5218 promote/suspend ordering assertion failed." >&2; exit 1; }
+import sys
+lines=[l for l in open(sys.argv[1]).read().splitlines() if 'kubectl' in l and '\\"promoted\\":true' in l]
+assert lines, "no promote merge-patch line (promoted=true) found in the actor script"
+for l in lines:
+    assert '\\"suspend\\":true' not in l, "the promote patch must NOT also set spec.suspend — a suspended HR is not reconciled by helm, so the promotion would never render"
+PYEOF
+# (f) the same-tick render-wait ceiling is templated (env present).
+grep -q 'name: PROMOTE_RENDER_WAIT_SECONDS' "$TMP/replica.yaml" || {
+  echo "FAIL: #5218 actor missing the PROMOTE_RENDER_WAIT_SECONDS env (same-tick render-wait ceiling)." >&2; exit 1; }
+echo "  PASS (valid POSIX shell · readback-verified suspend · same-tick latch · self-heal re-assert · promote never suspends pre-render)"
+
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -169,6 +169,19 @@ cnpgPair:
       # response) counts as unreachable, every other result fail-safes to
       # "region-A alive" (do NOT promote).
       livenessProbeTimeoutSeconds: 5
+      # #5218 same-tick durable latch — after the actor flips the HR
+      # DESIRED state (promoted=true) it stays IN THE SAME tick, polling the
+      # local Cluster CR until helm has rendered replica.enabled=false, then
+      # IMMEDIATELY suspends the HR. This collapses the promote→suspend gap
+      # from a full intervalSeconds (the 0.2.14 next-tick latch) to seconds,
+      # so kustomize-controller's SSA re-apply of the atomic spec.values
+      # cannot reclaim the nested `promoted` key and re-demote the survivor
+      # in the window. Bounds how long that in-tick poll waits for the render
+      # (a slow helm-controller); if it is exceeded the per-tick self-heal
+      # latch suspends the instant the render lands, so this is a ceiling on
+      # the fast path, never a correctness dependency. Must exceed a normal
+      # helm-controller reconcile of the promoted HR.
+      promoteRenderWaitSeconds: 90
       # The flux HelmRelease whose DESIRED state carries the promotion
       # (bootstrap-kit slot 16b defaults).
       hr:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.14"
+    version: "0.2.15"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## Pillar 3 — region-kill failover (dr-promoter durability)

Refs #5218

### Root cause (verified live on hw271 G12)
The region-B promote fired at **T0+2m29s** (region-B writable, TL2) but was **re-demoted mid-outage** while region-A was still down, latching the survivor as a diverged TL2 standby — the failover effectively failed.

The 0.2.14 durable latch suspended the HR only on the **next** actor tick (up to a full `intervalSeconds` after the promote). In that window kustomize-controller's SSA re-apply of the ATOMIC `spec.values` RawExtension reclaimed the field, dropped the nested `promoted` key, and helm re-rendered `replica.enabled:true` → CNPG re-demoted. `spec.suspend` never held long enough to freeze helm before the revert.

### Fix — make the existing suspend mechanism win the race
The promotion mechanism is unchanged (helm renders `replica.enabled:false` from `spec.values.cnpgPair.replica.promoted:true`, then a suspended HR freezes helm so kustomize can no longer re-render a demotion). What changed is **how fast the suspend lands and how it stays landed**:

- **Same-tick durable latch** — after flipping `promoted=true` the actor stays in the same tick, polls the Cluster CR until helm renders `replica.enabled=false` (the promotion has LANDED), then suspends **immediately**. This collapses the promote→suspend window from a full interval to seconds. `suspend` is deliberately **not** ridden into the promote patch: a suspended HR is not reconciled by helm-controller, so a suspend-before-render would freeze the HR and the promotion would never land.
- **Per-loop self-heal** — every actor loop re-asserts `spec.suspend=true` while the cluster is promoted/diverged (idempotent). If anything ever un-suspends the HR, the next loop (≤`intervalSeconds`) re-freezes it before a re-render can demote.
- **Readback-verified `suspend_hr` helper** — every suspend patch is followed by a `spec.suspend` readback; RBAC/conflict failures log loudly so a stuck latch is diagnosable in the actor-container log.

### Preserved (decision gates untouched)
120s primary-down hold, the positive region-A `pg_isready` liveness gate, sync-replication-only rendering, the startup grace, and the anti-flap "never re-promote a diverged cluster" latch are all unchanged. This change is only about making a *decided* promotion durable.

### RBAC
No change — the `flux-system` Role already grants `get` + `patch` on the single `bp-cnpg-pair` HelmRelease (`resourceNames`-pinned). The new suspend re-assert uses the same verb on the same object.

### Validation (local)
- `helm lint platform/cnpg-pair/chart` → 0 failed.
- `helm template … --set cnpgPair.side=replica …` → exit 0; actor container script passes `sh -n` (valid POSIX shell); `PROMOTE_RENDER_WAIT_SECONDS` env renders (default 90).
- `bash tests/cnpg-pair-render.sh` → all 17 cases PASS, incl. new **Case 17** (`sh -n` validity, readback-verify, same-tick latch, self-heal re-assert, promote-never-suspends-pre-render).
- `scripts/check-bootstrap-kit-pin-sync.sh` → `bp-cnpg-pair: chart=0.2.15 pin=0.2.15` OK (exit 0).
- `scripts/check-catalog-seed-lockstep.sh` → fail: 0 (exit 0).
- `go test tests/e2e/bootstrap-kit` `TestBootstrapKit_BlueprintVersionLockstepSweep` → ok.

### Chart bump + lockstep
`platform/cnpg-pair/chart/Chart.yaml` 0.2.14 → **0.2.15**; `platform/cnpg-pair/blueprint.yaml` `spec.version`, bootstrap-kit slot **16b** pin, and catalog-seed **`source.version`** updated in lockstep.

### Runtime verification status
Not runtime-verified. Live proof requires a region-kill (G12) re-test on the next fresh fire (hw272) with full actor-container log capture across the promote window — the mechanism cannot be exercised without an actual region outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)