### PR TITLE
fix(catalyst-api): materialize local kubeconfig with refreshing tokenFile (#5210)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig.go
@@ -67,9 +67,36 @@ func (h *Handler) chrootServesDeployment(dep *Deployment) bool {
 
 // inClusterKubeconfigYAML serializes the in-cluster rest.Config into a
 // kubeconfig YAML pointing at the LOCAL apiserver with the mounted
-// ServiceAccount bearer token + CA. This is a NO-NETWORK resolution of the
-// local cluster: rest.InClusterConfig reads only the KUBERNETES_SERVICE_*
-// env and the mounted token/CA files — it never dials the apiserver.
+// ServiceAccount CA + a REFRESHING token reference. This is a NO-NETWORK
+// resolution of the local cluster: rest.InClusterConfig reads only the
+// KUBERNETES_SERVICE_* env and the mounted token/CA files — it never dials
+// the apiserver.
+//
+// #5210 — token refresh, NOT a one-shot bake. The projected ServiceAccount
+// token this pod mounts is bound (expirationSeconds ~3607 on the Sovereign
+// chart) and kubelet ROTATES it on disk before expiry. Earlier this function
+// baked the token's CURRENT string value inline (`user.token:`), so the
+// materialized <kubeconfigsDir>/<id>.yaml — which the k8scache informer
+// Factory, buildRegionSlots, clusterMeshDynamicClient and the jobs informer
+// all load — produced a rest.Config with BearerToken set but BearerTokenFile
+// EMPTY. client-go's NewBearerAuthWithRefreshRoundTripper builds a
+// NON-refreshing round-tripper when the token file is empty, so every one of
+// those long-lived reflectors kept presenting the ORIGINAL token forever.
+// Once the bound token rotated (~1h post-cutover, after the step-08 deny-egress
+// hold / step-04 node rolls tore down the watch streams), every watch + every
+// resource-GET on the local region-a client flooded 401 Unauthorized and the
+// console went DEGRADED — even though a freshly-read token authenticates 200.
+//
+// Fix: emit `user.tokenFile:` pointing at the mounted projected-token path
+// instead of an inline `user.token:`. clientcmd maps tokenFile ->
+// rest.Config.BearerTokenFile, which selects the REFRESHING round-tripper
+// (a CachedFileTokenSource re-reads the file ~every minute), so kubelet's
+// rotation is picked up with no pod restart — critical because the local
+// catalyst-api Pod mounts RWO Huawei-EVS PVCs and MUST NOT be restarted to
+// "clear" a wedged reflector (#5210 constraint). The inline `token:` path
+// survives ONLY as a fallback for a synthetic/off-cluster config that carries
+// a token string but no file (dev/CI); production InClusterConfig always sets
+// BearerTokenFile.
 func inClusterKubeconfigYAML() (string, error) {
 	cfg, err := inClusterConfigForMaterialize()
 	if err != nil {
@@ -85,12 +112,6 @@ func inClusterKubeconfigYAML() (string, error) {
 			caData = b
 		}
 	}
-	token := cfg.BearerToken
-	if token == "" && cfg.BearerTokenFile != "" {
-		if b, rerr := os.ReadFile(cfg.BearerTokenFile); rerr == nil {
-			token = strings.TrimSpace(string(b))
-		}
-	}
 
 	const name = "in-cluster"
 	apiCfg := clientcmdapi.NewConfig()
@@ -103,8 +124,24 @@ func inClusterKubeconfigYAML() (string, error) {
 		// must be self-consistent, so mark it insecure explicitly.
 		cluster.InsecureSkipTLSVerify = true
 	}
+
+	// Prefer a REFRESHING tokenFile reference (#5210). Every downstream
+	// consumer parses this YAML through clientcmd, which sets BearerTokenFile
+	// from `user.tokenFile` and thus builds the auto-refreshing round-tripper.
+	authInfo := &clientcmdapi.AuthInfo{}
+	if tf := strings.TrimSpace(cfg.BearerTokenFile); tf != "" {
+		authInfo.TokenFile = tf
+	} else if strings.TrimSpace(cfg.BearerToken) != "" {
+		// Fallback: a token-only config (no mounted file) — dev/CI/off-cluster.
+		// This path is NON-refreshing, which is acceptable only because such a
+		// config has no rotating file to track in the first place.
+		authInfo.Token = cfg.BearerToken
+	} else {
+		return "", fmt.Errorf("in-cluster config has neither a bearer token file nor an inline token")
+	}
+
 	apiCfg.Clusters[name] = cluster
-	apiCfg.AuthInfos[name] = &clientcmdapi.AuthInfo{Token: token}
+	apiCfg.AuthInfos[name] = authInfo
 	apiCfg.Contexts[name] = &clientcmdapi.Context{Cluster: name, AuthInfo: name}
 	apiCfg.CurrentContext = name
 

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/client-go/rest"
@@ -72,11 +73,19 @@ func TestResolvePrimaryKubeconfig_ChrootMaterializesInClusterPrimary(t *testing.
 		}
 
 		// Chroot mode: SOVEREIGN_FQDN matches the deployment's FQDN, and the
-		// in-cluster config resolves (no network — synthetic here).
+		// in-cluster config resolves (no network — synthetic here). Real
+		// rest.InClusterConfig ALWAYS sets BearerTokenFile (the mounted
+		// projected-token path) as well as the read-once BearerToken string;
+		// mirror that here so the #5210 refreshing-token path is exercised.
 		t.Setenv("SOVEREIGN_FQDN", sovFQDN)
+		tokFile := filepath.Join(t.TempDir(), "token")
+		if err := os.WriteFile(tokFile, []byte(saToken), 0o600); err != nil {
+			t.Fatalf("seed projected token file: %v", err)
+		}
 		stubInClusterConfig(t, &rest.Config{
-			Host:        inClusHost,
-			BearerToken: saToken,
+			Host:            inClusHost,
+			BearerToken:     saToken,
+			BearerTokenFile: tokFile,
 			TLSClientConfig: rest.TLSClientConfig{
 				CAData: []byte("-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"),
 			},
@@ -111,8 +120,22 @@ func TestResolvePrimaryKubeconfig_ChrootMaterializesInClusterPrimary(t *testing.
 		if restCfg.Host != inClusHost {
 			t.Errorf("materialized primary host = %q, want %q", restCfg.Host, inClusHost)
 		}
-		if restCfg.BearerToken != saToken {
-			t.Errorf("materialized primary token = %q, want %q", restCfg.BearerToken, saToken)
+		// #5210 — the materialized kubeconfig MUST carry a refreshing tokenFile
+		// reference, NOT a one-shot inline token. clientcmd maps user.tokenFile
+		// -> rest.Config.BearerTokenFile, which selects client-go's
+		// auto-refreshing bearer round-tripper (re-reads the mounted token every
+		// ~minute). Without BearerTokenFile set, every reflector built from this
+		// kubeconfig freezes on the original bound token and floods 401
+		// Unauthorized once kubelet rotates it (~1h post-cutover).
+		if restCfg.BearerTokenFile != tokFile {
+			t.Errorf("materialized primary BearerTokenFile = %q, want %q (refreshing token reference — #5210)", restCfg.BearerTokenFile, tokFile)
+		}
+		// The serialized YAML must reference the file, never bake the literal.
+		if strings.Contains(string(raw), "token: "+saToken) {
+			t.Errorf("materialized primary kubeconfig baked a one-shot inline token — #5210 regression:\n%s", raw)
+		}
+		if !strings.Contains(string(raw), "tokenFile: "+tokFile) {
+			t.Errorf("materialized primary kubeconfig missing tokenFile reference — #5210:\n%s", raw)
 		}
 
 		// resolvePrimaryKubeconfigPath resolves to the canonical path now.

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -564,12 +564,28 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 		restCfg.TLSClientConfig.Insecure = true
 		restCfg.TLSClientConfig.CAData = nil
 		restCfg.TLSClientConfig.CAFile = ""
-		dyn, err = dynamic.NewForConfig(restCfg)
+		// #5210 — a kubeconfig that references a projected-token FILE
+		// (user.tokenFile:, which clientcmd maps to BearerTokenFile) belongs to
+		// the LOCAL chroot cluster: the materialized primary kubeconfig
+		// (clustermesh_primary_kubeconfig.go) now emits tokenFile instead of a
+		// one-shot inline token. This is the file-backed twin of the chroot
+		// self-register path, and on a chroot it is the client that ACTUALLY
+		// serves the local region (self-register is de-duped away once
+		// <id>.yaml exists). Give its long-lived informer/reflector clients the
+		// same force-refresh-on-401 transport the self-register path already
+		// uses. Applied to a COPY so the captured restCfg — reused by the exec
+		// SPDY dialer (RestConfigFor) — keeps its plain BearerTokenFile auth
+		// untouched. The helper is a no-op when BearerTokenFile is empty, so
+		// every REMOTE Sovereign/secondary kubeconfig (static embedded token, no
+		// file to re-read) builds exactly as before.
+		informerCfg := rest.CopyConfig(restCfg)
+		wrapInClusterTokenRefreshOn401(informerCfg)
+		dyn, err = dynamic.NewForConfig(informerCfg)
 		if err != nil {
 			return fmt.Errorf("dynamic client: %w", err)
 		}
 		if core == nil {
-			core, err = kubernetes.NewForConfig(restCfg)
+			core, err = kubernetes.NewForConfig(informerCfg)
 			if err != nil {
 				return fmt.Errorf("typed client: %w", err)
 			}

--- a/products/catalyst/bootstrap/api/internal/k8scache/token_refresh_addcluster_5210_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/token_refresh_addcluster_5210_test.go
@@ -1,0 +1,89 @@
+// token_refresh_addcluster_5210_test.go — #5210 file-backed path regression.
+//
+// On a chroot the LOCAL region informer client is NOT the InClusterConfig
+// self-register (that is de-duped away once <kubeconfigsDir>/<id>.yaml exists);
+// it is the FILE-backed AddCluster path loading the materialized primary
+// kubeconfig. clustermesh_primary_kubeconfig.go now materializes that kubeconfig
+// with a `user.tokenFile:` reference (not a one-shot inline `token:`), which
+// clientcmd maps to rest.Config.BearerTokenFile. AddCluster must (a) keep that
+// BearerTokenFile on the captured exec config so the projected token keeps
+// refreshing, and (b) route the informer clients through the same
+// force-refresh-on-401 transport the self-register path uses. Before the #5210
+// fix the materialized kubeconfig baked a static token (empty BearerTokenFile)
+// and every reflector 401-looped forever once kubelet rotated the bound token.
+package k8scache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTokenFileKubeconfig writes a projected-token file plus a kubeconfig that
+// references it via user.tokenFile (the shape clustermesh_primary_kubeconfig.go
+// now materializes). Returns the kubeconfig path and the token-file path.
+func writeTokenFileKubeconfig(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("bound-sa-token-A"), 0o600); err != nil {
+		t.Fatalf("seed token file: %v", err)
+	}
+	kc := "apiVersion: v1\n" +
+		"kind: Config\n" +
+		"clusters:\n" +
+		"- cluster:\n" +
+		"    server: https://10.255.0.1:6443\n" +
+		"    insecure-skip-tls-verify: true\n" +
+		"  name: local\n" +
+		"contexts:\n" +
+		"- context:\n" +
+		"    cluster: local\n" +
+		"    user: local\n" +
+		"  name: local\n" +
+		"current-context: local\n" +
+		"users:\n" +
+		"- name: local\n" +
+		"  user:\n" +
+		"    tokenFile: " + tokenFile + "\n"
+	kcPath := filepath.Join(dir, "local.yaml")
+	if err := os.WriteFile(kcPath, []byte(kc), 0o600); err != nil {
+		t.Fatalf("seed kubeconfig: %v", err)
+	}
+	return kcPath, tokenFile
+}
+
+// TestAddCluster_TokenFileKubeconfig_StaysRefreshing proves the file-backed
+// local-cluster path preserves the refreshing token reference. NewFactory calls
+// AddCluster during construction (before Start), so the informers are built but
+// never dial — the assertion inspects the captured rest.Config only.
+func TestAddCluster_TokenFileKubeconfig_StaysRefreshing(t *testing.T) {
+	kcPath, tokenFile := writeTokenFileKubeconfig(t)
+
+	f, err := NewFactory(Config{
+		Logger:   quietLogger(),
+		Clusters: []ClusterRef{{ID: "local", KubeconfigPath: kcPath}},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	// The cluster must have registered (a parse failure would have made
+	// NewFactory skip it — e.g. if BearerTokenFile had been dropped and the
+	// tokenFile could not be resolved).
+	if !containsClusterID(f.Clusters(), "local") {
+		t.Fatalf("Clusters() = %v, want to contain \"local\" — tokenFile kubeconfig failed to register", f.Clusters())
+	}
+
+	// The captured exec rest.Config (RestConfigFor, consumed by the SPDY exec
+	// dialer) MUST retain BearerTokenFile so its auth also refreshes with the
+	// rotated projected token instead of freezing on a one-shot value.
+	rc, err := f.RestConfigFor("local")
+	if err != nil {
+		t.Fatalf("RestConfigFor(local): %v", err)
+	}
+	if rc.BearerTokenFile != tokenFile {
+		t.Errorf("captured exec BearerTokenFile = %q, want %q — a tokenFile kubeconfig must stay refreshing (#5210)", rc.BearerTokenFile, tokenFile)
+	}
+}


### PR DESCRIPTION
## Problem (live, hw270 post-cutover, #5210)

The Sovereign-side catalyst-api local-region reflectors flood `reflector "Failed to watch" err="... Unauthorized"` (1741/2000 recent log lines) and the k9s resource-GET returns `500 {"detail":"Unauthorized"}`, flipping the operator console to **DEGRADED** — even though `kubectl auth can-i` passes for all kinds and a **freshly-read** projected token authenticates 200. Classic stale-token-held-on-a-non-refreshing-client signature.

## Root cause

The `#5131` chroot primary-kubeconfig materialization (`inClusterKubeconfigYAML`) baked the bound ServiceAccount token's **current string value inline** (`user.token:`) into `<kubeconfigsDir>/<id>.yaml`. On a chroot the k8scache informer Factory loads **that file** as the local-region client — the InClusterConfig self-register is de-duped away once `<id>.yaml` exists — and `clientcmd` parses an inline token into `rest.Config.BearerToken` with an **empty `BearerTokenFile`**. client-go's `NewBearerAuthWithRefreshRoundTripper` builds a **non-refreshing** round-tripper when the token file is empty (verified in `client-go@v0.36.0/transport/round_trippers.go`: `if len(tokenFile) == 0 { return &bearerAuthRoundTripper{bearer, nil, rt} }`). So every reflector kept presenting the **original** bound token forever; once it rotated (~1h post-cutover, after the step-08 deny-egress hold / step-04 node rolls tore down the watch streams) every watch + resource-GET `401`'d with no recovery.

The already-merged `wrapInClusterTokenRefreshOn401` covered only the **InClusterConfig self-register** path — which is **not** the client that serves the local region on a chroot — so the flood persisted.

## Fix

- **`inClusterKubeconfigYAML`** now emits `user.tokenFile:` (the mounted projected-token path) instead of a one-shot inline `user.token:`. `clientcmd` maps `tokenFile` → `rest.Config.BearerTokenFile`, which selects the **refreshing** round-tripper (a `CachedFileTokenSource` re-reads the file ~every minute) so kubelet's rotation is honoured with **no pod restart** — the local Pod's RWO Huawei-EVS PVCs make a restart risky (#5210 constraint). Inline `token:` survives only as a fallback for a token-only dev/CI config with no mounted file.
- **`k8scache.AddCluster`** routes the file-backed local-region informer clients through the existing `wrapInClusterTokenRefreshOn401` (force-refresh on 401), applied to a **copy** so the exec SPDY config (`RestConfigFor`) keeps its plain `BearerTokenFile` auth untouched. No-op for remote Sovereign/secondary kubeconfigs (static embedded token, no file to re-read).

## Tests

- `clustermesh_primary_kubeconfig_test.go`: the materialized kubeconfig references `tokenFile:` (never a baked inline token) and round-trips to a `BearerTokenFile`-set `rest.Config`.
- `token_refresh_addcluster_5210_test.go`: a `tokenFile` kubeconfig loaded via `AddCluster` registers and keeps its refreshing `BearerTokenFile`.
- `go build ./...`, `go vet ./...`, `go test ./internal/k8scache/...` and `./internal/handler/...` all green.

## Deploy

`catalyst-build.yaml` triggers on `products/catalyst/bootstrap/**` and auto-bumps `catalystApi.tag` + the kustomize literal + `CATALYST_BUILD_SHA` to the merge SHA on merge — no manual pin bump (the #5207 pattern).

## Validation status

Code + unit tests green. **Not yet runtime-verified** — the live proof is the next fresh prov's post-cutover console: the informer 401 flood gone and Cloud / Topology / resource drill-in rendering.

Refs #5210

🤖 Generated with [Claude Code](https://claude.com/claude-code)