### PR TITLE
fix(cnpg-pair): dr-promoter steady-state ARM gate + timeline-divergence surfacing (#5220)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -229,7 +229,21 @@ spec:
       # re-asserts spec.suspend every loop while promoted/diverged (self-heal),
       # with readback verification. No new substitute; all decision gates
       # unchanged.
-      version: 0.2.15
+      # 0.2.16 (#5220): dr-promoter FALSE-POSITIVE fix — on hw273 G12 the 0.2.15
+      # promoter false-promoted region-B during a transient region-A blip
+      # (primary restart-storm + WAL-stream flap during convergence) while
+      # region-A stayed ALIVE on TL1, and #5219's suspend latch cemented it
+      # (region-B TL2, walreceiver FATAL-loop forever). Every liveness signal
+      # rides the SAME region-B→region-A datapath, so a link flap is
+      # indistinguishable from a real death. (A) ARM GATE — the actor cannot
+      # promote until it has OBSERVED continuous streaming steady-state
+      # (steadyStateArmSeconds), so a never-converged pair can never promote and
+      # the latch can never cement a false positive. (B) TIMELINE-DIVERGENCE
+      # SURFACING — a standby that can never re-stream from a reachable region-A
+      # is recorded on the HR (dr-timeline-diverged-at); the re-clone stays the
+      # operator's RUNBOOKS §6.1 action (non-destructive). #5219 latch + 120s
+      # hold + pg_isready gate + sync fence unchanged. No new substitute.
+      version: 0.2.16
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1079,10 +1079,16 @@ The deterministic failover test for two independent CNPG clusters:
    region-A still reachable is a replication fault, never a region kill, and does
    NOT promote). It waits `autoPromote.primaryDownHoldSeconds` (120s, so an
    intra-region primary restart never triggers), respects a `startupGraceSeconds`
-   window (a fresh catching-up replica can never trip it), confirms the
-   failover-readiness probe is Ready (LSN apply==receive, #5133), then executes
-   the promote + LATCH below ITSELF — zero operator action, expected promotion
-   ~2–4 min after the kill. The controller-side Continuum orchestration cannot do
+   window (a fresh catching-up replica can never trip it), and — since
+   bp-cnpg-pair ≥ 0.2.16 (#5220) — is **ARMED** only after it has OBSERVED the
+   pair reach a stable STREAMING steady-state (walreceiver status=streaming held
+   continuously for `autoPromote.steadyStateArmSeconds`, 180s); a region-A-down
+   signal BEFORE the first stable stream is a convergence-time transient (a
+   primary restart-storm on a still-converging pair — hw273 G12) and NEVER
+   promotes, so #5219's suspend latch can never cement a false positive. It then
+   confirms the failover-readiness probe is Ready (LSN apply==receive, #5133) and
+   executes the promote + LATCH below ITSELF — zero operator action, expected
+   promotion ~2–4 min after the kill. The controller-side Continuum orchestration cannot do
    this: it lives on region-a and dies with it (#5137). Evidence lands as
    `catalyst.openova.io/dr-auto-promoted-at` + `…/dr-auto-promote-latched-at` on
    the region-B HR + the dr-promoter pod log. The manual command remains the
@@ -1118,6 +1124,15 @@ The deterministic failover test for two independent CNPG clusters:
    re-cloned onto the current timeline (#5125 Defect-2, still open — CNPG replica
    walreceivers crash-loop `timeline N behind recovery timeline N+1` until the
    stale side is deleted + re-basebackup'd).
+   🛑 **Timeline-divergence signal (#5220)**: when a side can no longer stream
+   from a REACHABLE peer (the `timeline N behind recovery timeline N+1` wedge),
+   the dr-promoter records `catalyst.openova.io/dr-timeline-diverged-at` on the
+   region-B HR and logs the re-clone action — that annotation is the operator's
+   cue to delete the diverged Cluster's PVCs + re-basebackup it from the live
+   side. The actor does this NON-destructively (annotation only): from a 2-node
+   vantage with no witness it cannot prove WHICH side is authoritative, so
+   auto-destroying PGDATA could lose a real survivor's committed writes — the
+   re-clone stays this operator step.
 
 Test harness lives at the D31 acceptance test (PR #2075).
 

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -32,7 +32,17 @@ spec:
   # suspends IN THE SAME TICK as the promote (once helm renders) and re-asserts
   # spec.suspend every loop while promoted/diverged (self-heal), with readback
   # verification. All decision gates unchanged.
-  version: 0.2.15
+  # 0.2.16 (#5220): dr-promoter FALSE-POSITIVE fix — on hw273 G12 the 0.2.15
+  # promoter false-promoted region-B during a transient region-A blip while
+  # region-A stayed ALIVE on TL1, and #5219's suspend latch cemented it (region-B
+  # TL2, walreceiver FATAL-loop forever). (A) an ARM GATE makes the actor
+  # ineligible to promote until it has OBSERVED continuous streaming steady-state
+  # (steadyStateArmSeconds) — a never-converged pair can never promote, so the
+  # latch never cements a false positive; (B) a persistent can't-re-stream wedge
+  # is SURFACED on the HR (dr-timeline-diverged-at), the re-clone staying the
+  # operator's RUNBOOKS §6.1 action (non-destructive). #5219 latch + 120s hold +
+  # pg_isready gate + sync fence unchanged.
+  version: 0.2.16
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,35 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.16 (#5220): dr-promoter FALSE-POSITIVE fix — steady-state ARM gate +
+# timeline-divergence surfacing. On hw273 G12 the 0.2.15 promoter FALSE-PROMOTED
+# region-B during a TRANSIENT region-A unreachability (primary restart-storm +
+# cross-region WAL-stream blip during convergence) while region-A stayed ALIVE on
+# timeline 1, and #5219's durable suspend latch then CEMENTED the false promotion
+# permanently (region-B TL2, walreceiver FATAL-loop forever, region-A sync-wedged
+# on the never-connecting standby). Root cause: every liveness signal the
+# region-B promoter has (the cnpg WAL stream, the pg_isready of `-primary-mesh`)
+# rides the SAME region-B→region-A datapath, so a link flap is indistinguishable
+# from a real death over that link — the #5178 pg_isready gate false-positived
+# identically, and the #5178 startup grace (a FIXED timer from pod start) had
+# already expired when the restart-storm hit minutes into the env's life. TWO
+# fixes: (A) ARM GATE — the actor is INELIGIBLE to promote until the signals
+# container has OBSERVED region-B's replica actively STREAMING from region-A
+# (walreceiver status=streaming) CONTINUOUSLY for steadyStateArmSeconds (180s). A
+# region-A-down signal BEFORE the first stable stream is a convergence-time
+# transient, never a real kill; a pair that never reached steady-state can never
+# promote, so #5219's latch can never cement a false positive (this kills the
+# hw273 class at the source). Once armed it stays armed for the pod's life — a
+# real region-A death AFTER steady-state promotes normally. (B)
+# TIMELINE-DIVERGENCE SURFACING — a standby that can NEVER re-stream from a
+# REACHABLE region-A for timelineDivergenceHoldSeconds (300s) is recorded ONCE on
+# the HR (dr-timeline-diverged-at) + logged loudly, so the wedge is DIAGNOSED +
+# monitored instead of a silent FATAL loop. The re-clone stays the operator's
+# RUNBOOKS §6.1 action (NON-destructive here): a 2-node actor cannot prove WHICH
+# side is authoritative, so auto-destroying region-B's PGDATA could lose a real
+# survivor's committed writes — a worse failure than the wedge. #5219's durable
+# suspend latch + the 120s primaryDownHold + the region-A pg_isready gate + the
+# sync-only fence are ALL unchanged. No resource-count or RBAC change (the signals
+# container gains 2 env vars; script logic only). Lockstep slot 16b pin → 0.2.16.
 # 0.2.15 (#5218): dr-promoter durable-suspend RACE fix — on hw271 G12 the promote
 # fired at T0+2m29s (region-B writable, TL2) but was RE-DEMOTED mid-outage (a
 # second "primary loss" re-detected ~T0+7m while region-A was still down), so the
@@ -116,7 +146,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.15
+version: 0.2.16
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -156,6 +186,70 @@ description: |
 
   Changelog
   ─────────
+  0.2.16 (2026-07-19, dr-promoter FALSE-POSITIVE fix — steady-state ARM gate + timeline-divergence surfacing, Refs #5220)
+    - FIX (Pillar-3 region-kill DR): on hw273 G12 the 0.2.15 promoter
+      FALSE-PROMOTED region-B during a transient region-A unreachability
+      (primary-pod restart-storm — 5× clean exit 0 — + cross-region WAL-stream
+      blip during convergence) while region-A stayed ALIVE on timeline 1, and
+      #5219's durable suspend latch CEMENTED the false promotion permanently:
+      region-B bumped to TL2, its walreceiver FATAL-loops forever ("highest
+      timeline 1 of the primary is behind recovery timeline 2"), and region-A is
+      sync-wedged waiting on the never-connecting standby. The region-B promoter
+      declared "region-A dead" from region-B's vantage only — WAL stream absent
+      + pg_isready of `-primary-mesh` unreachable — but BOTH signals traverse the
+      SAME region-B→region-A ClusterMesh/VPC datapath, so a link flap is
+      indistinguishable from a real region loss; the #5178 pg_isready gate
+      false-positived identically and the #5178 startup grace (a fixed timer)
+      had already expired when the storm hit.
+    - (A) STEADY-STATE ARM GATE: the signals container now tracks CONTINUOUS
+      streaming (walreceiver status=streaming) and writes /shared/armed only
+      after it has held for autoPromote.steadyStateArmSeconds (180s). The actor
+      REFUSES every promote while UNARMED — a region-A-down signal before the
+      first stable stream is a convergence-time transient, never a real kill. A
+      pair that never reached steady-state can never promote, so #5219's latch
+      can never cement a convergence-time false positive. Once armed it stays
+      armed for the pod's life (a real region-A death AFTER steady-state
+      promotes normally); a non-streaming blip only restarts the arm window,
+      never un-arms.
+    - (B) TIMELINE-DIVERGENCE SURFACING: a standby that cannot re-stream from a
+      REACHABLE region-A for autoPromote.timelineDivergenceHoldSeconds (300s) is
+      the divergence wedge; the signals container flags it (/shared/timeline-
+      diverged) and the actor records it ONCE on the HR
+      (catalyst.openova.io/dr-timeline-diverged-at) + logs the RUNBOOKS §6.1
+      re-clone action, so the wedge is DIAGNOSED + monitored instead of a silent
+      FATAL loop. NON-destructive: the re-clone stays the operator's confirmed
+      action — a 2-node actor cannot prove which side is authoritative, so
+      auto-destroying region-B's PGDATA could lose a real survivor's committed
+      writes. Uses the existing HR get/patch RBAC (annotation only); no PVC/pod
+      delete.
+    - PRESERVED (all UNCHANGED): #5219's same-tick durable suspend latch +
+      per-loop self-heal + readback-verify, the 120s primaryDownHold, the
+      positive region-A pg_isready liveness gate, the startup grace, the
+      anti-flap "never re-promote a diverged cluster" latch, and the sync-only
+      data fence.
+    - New values: autoPromote.steadyStateArmSeconds (180),
+      autoPromote.timelineDivergenceHoldSeconds (300). Render-gate Case 18
+      asserts: the arm gate PRECEDES the promote merge-patch (a never-armed pair
+      can never reach the HR patch), the divergence marker is surfaced on the
+      HR, and the actor issues NO destructive kubectl delete + the dr-promoter
+      Role gains no delete/create verbs (data-safety). No resource-count or RBAC
+      change; the signals container gains 2 env vars. Lockstep slot 16b pin →
+      0.2.16. Live validation is the next fresh prov's region-kill G12.
+  0.2.15 (2026-07-18, dr-promoter durable-suspend RACE fix — same-tick latch + self-heal, Refs #5218)
+    - FIX (Pillar-3 region-kill DR durability): on hw271 G12 the promote fired
+      (T0+2m29s, region-B writable TL2) but was RE-DEMOTED mid-outage — the
+      0.2.14 latch suspended the HR only on the NEXT actor tick (up to a full
+      intervalSeconds later), leaving a window for kustomize-controller's SSA
+      re-apply to reclaim the atomic spec.values, drop the nested `promoted`
+      key, and re-render replica.enabled=true → re-demote. The actor now
+      suspends IN THE SAME TICK as the promote (polls until helm renders
+      replica.enabled=false, bounded by promoteRenderWaitSeconds, then suspends
+      immediately), re-asserts spec.suspend every loop while promoted/diverged
+      (per-loop self-heal), and READBACK-VERIFIES every suspend (suspend_hr
+      helper logs RBAC/conflict failures). suspend is NEVER set before the
+      render (a suspended HR is not reconciled by helm). All decision gates
+      unchanged. New value: autoPromote.promoteRenderWaitSeconds (90). Lockstep
+      slot 16b pin → 0.2.15.
   0.2.14 (2026-07-17, dr-promoter regression fix — liveness gate + durable latch, Refs #5178)
     - FIX Defect-A (false-positive promote): the 0.2.13 signals container
       inferred "region-A dead" from the LOCAL walreceiver alone and promoted a

--- a/platform/cnpg-pair/chart/templates/dr-promoter.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-promoter.yaml
@@ -84,6 +84,40 @@ HOW IT DECIDES (region-B-local signals + a POSITIVE region-A probe)
    diverged (left the source timeline), and once promoted it latches
    (suspend) so it can neither re-demote nor re-promote (#5178).
 
+STEADY-STATE ARM GATE + TIMELINE-DIVERGENCE SURFACING (#5220)
+------------------------------------------------------------
+hw273 G12 exposed a FALSE-POSITIVE promotion: on a fresh, still-
+converging pair the primary restart-stormed (clean exit 0 ×5) and the
+cross-region WAL stream + region-b→region-a mesh reach both dropped for
+>120s while region-A stayed ALIVE on timeline 1. Every liveness signal
+the promoter has (the cnpg WAL stream, the pg_isready of `-primary-mesh`)
+rides the SAME region-b→region-a datapath, so a link flap is
+indistinguishable from a real death over that link — the pg_isready gate
+alone could not veto it. The #5178 startup grace (a fixed timer from pod
+start) did not help either: the restart-storm hit AFTER the grace window.
+
+(A) ARM GATE — the promoter is INELIGIBLE to promote until the signals
+    container has OBSERVED region-b's replica actively STREAMING from
+    region-A (walreceiver status=streaming) CONTINUOUSLY for
+    `steadyStateArmSeconds`. Until that steady-state is reached the actor
+    REFUSES every promote (a region-A-down signal before the first stable
+    stream is a convergence-time transient, never a real kill). Once
+    armed it STAYS armed for the pod's life — a real death AFTER
+    steady-state promotes normally. This kills the hw273 class at the
+    source: a pair that never streamed cannot promote.
+(B) TIMELINE-DIVERGENCE SURFACING — a standby that can NEVER re-stream
+    from a REACHABLE region-A (it left the source timeline in a prior
+    promotion: "highest timeline N of the primary is behind recovery
+    timeline N+1") is recorded ONCE on the HR (dr-timeline-diverged-at)
+    and logged loudly, so the wedge is DIAGNOSED + monitored instead of a
+    silent FATAL loop. The re-clone stays the operator's RUNBOOKS §6.1
+    action (NON-destructive here): a 2-node actor cannot prove WHICH side
+    is authoritative, so auto-destroying region-b's PGDATA could lose a
+    real survivor's committed writes — a worse failure than the wedge.
+    #5219's durable suspend latch is UNCHANGED — with (A) the promoter
+    only ever latches a promotion decided AFTER steady-state, so it can
+    no longer cement a convergence-time false positive.
+
 ANTI-SPLIT-BRAIN — why acting on a region-local signal is data-safe
 -------------------------------------------------------------------
 The pair runs synchronous replication (remote_apply + FIRST 1 pinned
@@ -123,6 +157,13 @@ tracked on #5137.)
 {{- $startupGrace := $ap.startupGraceSeconds | default 300 }}
 {{- $probeTimeout := $ap.livenessProbeTimeoutSeconds | default 5 }}
 {{- $renderWait := $ap.promoteRenderWaitSeconds | default 90 }}
+{{- /* #5220 (A) — the continuous-streaming steady-state the signals container
+       must OBSERVE before the actor is EVER eligible to promote (kills the
+       hw273 convergence-time false positive). #5220 (B) — how long a standby
+       must be unable to re-stream from a REACHABLE region-A before the wedge
+       is flagged as a timeline divergence. */ -}}
+{{- $armSeconds := $ap.steadyStateArmSeconds | default 180 }}
+{{- $tlDivergeHold := $ap.timelineDivergenceHoldSeconds | default 300 }}
 {{- $peerClusters := .Values.cnpgPair.networkPolicy.crossRegionPeerClusters | default list }}
 {{- /* #5178 — the region-A liveness gate is meaningful ONLY when the mesh
        egress to region-A can actually be wired: clusterMesh on AND at least
@@ -363,12 +404,46 @@ spec:
                 if [ -f /shared/primary-wal-down-since ]; then
                   echo "$(date -u +"%FT%TZ") [dr-promoter/signals] $1 — hold clock cleared"
                 fi
-                rm -f /shared/primary-wal-down-since
+                # Clears the promote clock AND (#5220 B) the replication-fault /
+                # timeline-divergence markers — any state that reaches a normal
+                # clock-clear (streaming/receiving/promoted/unknown/real-kill
+                # arming/grace) means the pair is NOT in the persistent
+                # can't-re-stream wedge, so a resolved wedge fully resets.
+                rm -f /shared/primary-wal-down-since /shared/replication-fault-since /shared/timeline-diverged /shared/timeline-diverged-recorded
               }
               while true; do
                 : > /shared/signals-alive
                 STATE=$(psql "${CONN}" -tAXc "${Q}" 2>/dev/null || echo "unknown")
                 NOW=$(date -u +%s)
+                # ── #5220 (A) — steady-state ARM gate ──────────────────────
+                # The promoter must OBSERVE the pair reach a stable STREAMING
+                # steady-state before ANY region-A-death is believable. A
+                # convergence-time transient — a primary restart-storm, or a
+                # replica that has not streamed even once (the hw273 #5220
+                # false positive) — must never arm the promoter → never
+                # promote. Once armed it STAYS armed for the pod's life (a real
+                # death AFTER steady-state promotes normally); a brief
+                # non-streaming blip only RESTARTS the arm window, never
+                # un-arms. Runs every tick, independent of the startup grace
+                # (streaming observed during the grace window still counts).
+                if [ "${STATE}" = "streaming" ]; then
+                  if [ ! -f /shared/armed ]; then
+                    if [ ! -f /shared/streaming-since ]; then
+                      echo "${NOW}" > /shared/streaming-since
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/signals] first stable stream observed — arm window ${STEADY_STATE_ARM_SECONDS}s started; promoter stays DISARMED until continuous streaming holds (#5220)"
+                    else
+                      SSINCE=$(cat /shared/streaming-since 2>/dev/null || echo "${NOW}")
+                      if [ "$((NOW - SSINCE))" -ge "${STEADY_STATE_ARM_SECONDS}" ]; then
+                        : > /shared/armed
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/signals] ARMED — streaming steady-state held $((NOW - SSINCE))s (>=${STEADY_STATE_ARM_SECONDS}s); region-A-death detection is now live (#5220)"
+                      fi
+                    fi
+                  fi
+                else
+                  # Any non-streaming state breaks the continuity requirement
+                  # → restart the arm window. NEVER un-arms once armed.
+                  rm -f /shared/streaming-since
+                fi
                 # STARTUP GRACE — a fresh replica still doing its first
                 # catchup must never arm the clock (#5178).
                 if [ "$((NOW - STARTED))" -lt "${STARTUP_GRACE_SECONDS}" ]; then
@@ -395,7 +470,27 @@ spec:
                     if [ "${PRIMARY_LIVENESS_ENABLED}" != "true" ]; then
                       clear_clock "state=noreceiver but NO region-A liveness path (clusterMesh off / crossRegionPeerClusters empty) — auto-promote inert, fail-safe"
                     elif pg_isready -h "${PRIMARY_MESH_HOST}" -p 5432 -t "${PROBE_TIMEOUT}" -q; then
-                      clear_clock "state=noreceiver but region-A REACHABLE (pg_isready ok @ ${PRIMARY_MESH_HOST}) — replication fault, NOT a region kill; holding (data safety)"
+                      # region-A REACHABLE + local WAL absent ⇒ replication
+                      # fault, NOT a region kill. Clear the PROMOTE clock, but
+                      # (#5220 B) TRACK how long this fault persists: a standby
+                      # that can NEVER re-stream from a reachable region-A is
+                      # the timeline-divergence wedge (region-B left the source
+                      # timeline in a prior promotion and can never stream from
+                      # the lower-TL source). Do NOT call clear_clock here — it
+                      # would wipe the fault clock we are trying to accrue.
+                      if [ -f /shared/primary-wal-down-since ]; then
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/signals] state=noreceiver but region-A REACHABLE — replication fault, NOT a region kill; hold clock cleared"
+                      fi
+                      rm -f /shared/primary-wal-down-since
+                      if [ ! -f /shared/replication-fault-since ]; then
+                        echo "${NOW}" > /shared/replication-fault-since
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/signals] state=noreceiver but region-A REACHABLE (pg_isready ok @ ${PRIMARY_MESH_HOST}) — replication fault (data safety: NOT promoting); tracking for timeline-divergence (#5220)"
+                      fi
+                      FSINCE=$(cat /shared/replication-fault-since 2>/dev/null || echo "${NOW}")
+                      if [ "$((NOW - FSINCE))" -ge "${TL_DIVERGENCE_HOLD_SECONDS}" ] && [ ! -f /shared/timeline-diverged ]; then
+                        : > /shared/timeline-diverged
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/signals] TIMELINE-DIVERGENCE WEDGE: region-B has been unable to stream from a REACHABLE region-A for $((NOW - FSINCE))s (>=${TL_DIVERGENCE_HOLD_SECONDS}s) — the replica has left the source timeline and can never re-stream from the lower-TL source. Region-B must be RE-CLONED from region-A (RUNBOOKS §6.1); the actor records it on the HR (#5220)"
+                      fi
                     else
                       RC=$?
                       if [ "${RC}" -eq 2 ]; then
@@ -427,6 +522,11 @@ spec:
               value: {{ $startupGrace | quote }}
             - name: INTERVAL_SECONDS
               value: {{ $interval | quote }}
+            # #5220 (A) steady-state arm window + (B) timeline-divergence hold.
+            - name: STEADY_STATE_ARM_SECONDS
+              value: {{ $armSeconds | quote }}
+            - name: TL_DIVERGENCE_HOLD_SECONDS
+              value: {{ $tlDivergeHold | quote }}
           livenessProbe:
             exec:
               command:
@@ -531,6 +631,29 @@ spec:
                   REPLICA_ENABLED=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}' 2>/dev/null || echo "")
                   DIVERGED=""; [ -f /shared/diverged ] && DIVERGED="true"
 
+                  # #5220 (B) — TIMELINE-DIVERGENCE surfacing (non-destructive).
+                  # The signals container sets /shared/timeline-diverged when a
+                  # standby has been unable to re-stream from a REACHABLE
+                  # region-A for TL_DIVERGENCE_HOLD_SECONDS (it left the source
+                  # timeline in a prior promotion: "highest timeline N of the
+                  # primary is behind recovery timeline N+1"). Record it ONCE on
+                  # the HR so the wedge is DIAGNOSED + monitored instead of a
+                  # silent FATAL loop. Re-clone stays the operator's RUNBOOKS
+                  # §6.1 action: a 2-node actor cannot prove WHICH side is
+                  # authoritative, so auto-destroying region-B's PGDATA could
+                  # lose a real survivor's committed writes. Runs regardless of
+                  # suspend/promote state (a latched false promotion IS the
+                  # wedge the operator must un-stick). Uses the existing HR
+                  # get/patch RBAC — no new privileges.
+                  if [ -f /shared/timeline-diverged ] && [ ! -f /shared/timeline-diverged-recorded ]; then
+                    if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-timeline-diverged-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-timeline-diverged-action\":\"re-clone region-B from region-A per RUNBOOKS 6.1 — the replica left the source timeline and cannot re-stream (#5220)\"}}}" >/dev/null 2>&1; then
+                      : > /shared/timeline-diverged-recorded
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/actor] TIMELINE-DIVERGENCE recorded on HR ${HR_NAMESPACE}/${HR_NAME} (dr-timeline-diverged-at) — region-B cannot re-stream from a reachable region-A; RE-CLONE region-B per RUNBOOKS 6.1 (#5220)"
+                    else
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/actor] WARN: could not annotate HR with timeline-divergence (RBAC/conflict?) — wedge still logged by signals; retrying next tick (#5220)"
+                    fi
+                  fi
+
                   # 1. SELF-HEAL LATCH — keep an already-rendered promotion
                   #    durable. Fires on the post-promote tick AND re-freezes
                   #    the HR if anything ever un-suspends it. Both arms require
@@ -555,6 +678,21 @@ spec:
                   fi
 
                   # 3. PROMOTE decision (not promoted, not suspended).
+                  # #5220 ARM GATE — never promote until the pair has OBSERVED a
+                  # stable streaming steady-state (the signals container sets
+                  # /shared/armed after STEADY_STATE_ARM_SECONDS of continuous
+                  # streaming). A region-A-down signal BEFORE the first stable
+                  # stream is a convergence-time transient (the hw273 false
+                  # positive: primary restart-storm before the pair ever
+                  # streamed), NEVER a real kill. This is the primary #5220 fix:
+                  # a pair that never reached steady-state can never promote, so
+                  # #5219's suspend latch can never cement a false positive.
+                  if [ ! -f /shared/armed ]; then
+                    if [ -f /shared/primary-wal-down-since ]; then
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/actor] REFUSING promote: region-A-down signal present but the DR pair never reached streaming steady-state (UNARMED) — convergence-time transient, not a real kill; holding (#5220)"
+                    fi
+                    exit 0
+                  fi
                   [ -f /shared/primary-wal-down-since ] || exit 0
                   DOWN_SINCE=$(cat /shared/primary-wal-down-since)
                   NOW=$(date -u +%s)

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -910,4 +910,94 @@ grep -q 'name: PROMOTE_RENDER_WAIT_SECONDS' "$TMP/replica.yaml" || {
   echo "FAIL: #5218 actor missing the PROMOTE_RENDER_WAIT_SECONDS env (same-tick render-wait ceiling)." >&2; exit 1; }
 echo "  PASS (valid POSIX shell · readback-verified suspend · same-tick latch · self-heal re-assert · promote never suspends pre-render)"
 
+# ── Case 18: #5220 dr-promoter FALSE-POSITIVE fix — steady-state ARM gate +
+#             timeline-divergence surfacing ───────────────────────────────
+# hw273 G12: on a fresh, still-converging pair the primary restart-stormed and
+# the cross-region WAL stream + region-b→region-a mesh reach both dropped >120s
+# while region-A stayed ALIVE on timeline 1. The #5178 pg_isready gate rides the
+# SAME flapping link, and the #5178 startup grace (a fixed timer) expired before
+# the storm — so the promoter FALSE-PROMOTED and #5219's suspend latch cemented
+# it (region-b TL2, walreceiver FATAL-loop forever). 0.2.16 (A) makes the
+# promoter INELIGIBLE until it has OBSERVED continuous streaming steady-state,
+# and (B) SURFACES a persistent can't-re-stream wedge on the HR (non-destructive
+# — the re-clone stays the operator's RUNBOOKS §6.1 action).
+echo "[render] Case 18: #5220 steady-state ARM gate (no promote before observed steady-state) + timeline-divergence surfacing"
+
+# Extract both container scripts from the default side=replica render.
+python3 - "$TMP/replica.yaml" > "$TMP/signals.sh" <<'PYEOF' || { echo "FAIL: #5220 could not extract the signals container script." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-promoter' in d['metadata']['name']][0]
+sig=[c for c in dep['spec']['template']['spec']['containers'] if c['name']=='signals'][0]
+sys.stdout.write(sig['args'][0])
+PYEOF
+# (a) both scripts remain valid POSIX shell after the #5220 additions.
+sh -n "$TMP/signals.sh" || { echo "FAIL: #5220 signals container script is not valid POSIX shell." >&2; exit 1; }
+sh -n "$TMP/actor.sh"   || { echo "FAIL: #5220 actor container script is not valid POSIX shell." >&2; exit 1; }
+
+# (b) the ARM window + divergence hold are templated (envs present, default
+#     values 180 / 300 from values.yaml).
+python3 - "$TMP/replica.yaml" <<'PYEOF' || { echo "FAIL: #5220 arm/divergence env assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-promoter' in d['metadata']['name']][0]
+sig=[c for c in dep['spec']['template']['spec']['containers'] if c['name']=='signals'][0]
+env={e['name']:e.get('value') for e in sig['env']}
+assert env.get('STEADY_STATE_ARM_SECONDS')=='180', f"STEADY_STATE_ARM_SECONDS must default 180, got {env.get('STEADY_STATE_ARM_SECONDS')!r}"
+assert env.get('TL_DIVERGENCE_HOLD_SECONDS')=='300', f"TL_DIVERGENCE_HOLD_SECONDS must default 300, got {env.get('TL_DIVERGENCE_HOLD_SECONDS')!r}"
+PYEOF
+
+# (c) ARM tracking: signals arms ONLY on continuous streaming, resets the window
+#     on any non-streaming state, and never un-arms once armed.
+grep -q '/shared/armed' "$TMP/signals.sh" || {
+  echo "FAIL: #5220 signals missing the /shared/armed steady-state marker." >&2; exit 1; }
+grep -q '/shared/streaming-since' "$TMP/signals.sh" || {
+  echo "FAIL: #5220 signals missing the /shared/streaming-since continuity tracker." >&2; exit 1; }
+grep -q 'ARMED — streaming steady-state held' "$TMP/signals.sh" || {
+  echo "FAIL: #5220 signals missing the ARMED log (steady-state observed)." >&2; exit 1; }
+
+# (d) the ACTOR refuses to promote while UNARMED, and the arm gate PRECEDES the
+#     promote merge-patch (so a false positive can never reach the HR patch).
+grep -q 'REFUSING promote' "$TMP/actor.sh" || {
+  echo "FAIL: #5220 actor missing the unarmed REFUSING-promote guard." >&2; exit 1; }
+grep -q 'UNARMED' "$TMP/actor.sh" || {
+  echo "FAIL: #5220 actor missing the UNARMED refuse reason." >&2; exit 1; }
+python3 - "$TMP/actor.sh" <<'PYEOF' || { echo "FAIL: #5220 arm-gate ordering assertion failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+gate=s.find('/shared/armed')
+patch=s.find('\\"promoted\\":true')
+assert gate!=-1, "actor has no /shared/armed gate"
+assert patch!=-1, "actor has no promote merge-patch"
+assert gate < patch, "the /shared/armed arm gate MUST precede the promote merge-patch (a never-armed pair must never reach the HR patch)"
+PYEOF
+
+# (e) timeline-divergence detection: a standby that cannot re-stream from a
+#     REACHABLE region-A for the hold window is flagged (signals) and recorded
+#     ONCE on the HR (actor) — the wedge is diagnosed, not silently cemented.
+grep -q 'TIMELINE-DIVERGENCE WEDGE' "$TMP/signals.sh" || {
+  echo "FAIL: #5220 signals missing the timeline-divergence wedge detection." >&2; exit 1; }
+grep -q '/shared/timeline-diverged' "$TMP/signals.sh" || {
+  echo "FAIL: #5220 signals missing the /shared/timeline-diverged marker." >&2; exit 1; }
+grep -q 'dr-timeline-diverged-at' "$TMP/actor.sh" || {
+  echo "FAIL: #5220 actor does not record timeline-divergence on the HR." >&2; exit 1; }
+
+# (f) DATA SAFETY — the surfacing is NON-destructive. The actor must NEVER
+#     delete a PVC or a pod (a 2-node actor cannot prove which side is
+#     authoritative, so auto-destroying PGDATA could lose a real survivor's
+#     writes). Assert no destructive verbs in the script AND no delete RBAC.
+if grep -qE 'kubectl[^|]*delete' "$TMP/actor.sh"; then
+  echo "FAIL: #5220 actor issues a destructive kubectl delete — the re-clone must stay the operator's RUNBOOKS §6.1 action (2-node data-safety)." >&2
+  grep -nE 'kubectl[^|]*delete' "$TMP/actor.sh" >&2; exit 1; fi
+python3 - "$TMP/replica.yaml" <<'PYEOF' || { echo "FAIL: #5220 dr-promoter RBAC must not gain destructive verbs." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+for r in [d for d in docs if d.get('kind')=='Role' and 'dr-promoter' in d['metadata']['name']]:
+    for rule in r.get('rules',[]):
+        verbs=set(rule.get('verbs',[])); res=rule.get('resources',[])
+        assert 'delete' not in verbs, f"dr-promoter Role granted delete on {res} — must never delete PVCs/pods/CRs (data-safety, #5220)"
+        assert 'create' not in verbs, f"dr-promoter Role granted create on {res} — surfacing is non-destructive (#5220)"
+PYEOF
+echo "  PASS (arm gate blocks promote before observed steady-state · divergence surfaced on HR · non-destructive, no delete verbs)"
+
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -182,6 +182,36 @@ cnpgPair:
       # the fast path, never a correctness dependency. Must exceed a normal
       # helm-controller reconcile of the promoted HR.
       promoteRenderWaitSeconds: 90
+      # #5220 (A) steady-state ARM gate — the promoter is INELIGIBLE to
+      # promote until the signals container has OBSERVED region-B's replica
+      # actively STREAMING from region-A (walreceiver status=streaming) held
+      # CONTINUOUSLY this long. A convergence-time transient — a primary
+      # restart-storm, or a replica that has not streamed even once (the
+      # hw273 #5220 false positive, which fired minutes into the env's life
+      # while region-A stayed ALIVE on timeline 1) — must never look like a
+      # region kill. Every liveness signal the promoter has (the cnpg WAL
+      # stream, the pg_isready of `-primary-mesh`) rides the SAME region-B→
+      # region-A datapath, so a link flap is indistinguishable from a real
+      # death over that link; requiring an OBSERVED stable stream first is
+      # what rules out the never-converged case. Once satisfied the promoter
+      # latches ARMED for the pod's life — a real region-A death AFTER
+      # steady-state promotes normally. Must exceed a couple of poll
+      # intervals so a momentary streaming blip during churn never arms.
+      steadyStateArmSeconds: 180
+      # #5220 (B) timeline-divergence detection hold — a standby that cannot
+      # re-stream from a REACHABLE region-A for this long is the
+      # timeline-divergence wedge (region-B left the source timeline in a
+      # prior promotion and can never stream from the lower-TL source:
+      # "highest timeline N of the primary is behind recovery timeline N+1").
+      # The signals container flags it and the actor records it ONCE on the
+      # HR (dr-timeline-diverged-at) so the wedge is DIAGNOSED + monitored
+      # instead of a silent FATAL loop. The re-clone stays the operator's
+      # RUNBOOKS §6.1 action (NON-destructive here): a 2-node actor cannot
+      # prove WHICH side is authoritative, so auto-destroying region-B's
+      # PGDATA could lose a real survivor's committed writes. Must FAR exceed
+      # a normal basebackup+catchup so a slow first stream is never
+      # mis-flagged as a divergence.
+      timelineDivergenceHoldSeconds: 300
       # The flux HelmRelease whose DESIRED state carries the promotion
       # (bootstrap-kit slot 16b defaults).
       hr:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.15"
+    version: "0.2.16"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## Pillar 3 — region-kill failover (dr-promoter FALSE-POSITIVE fix)

Refs #5220 #5219 #5218 #5178 #4656

### Root cause (verified live on hw273 G12)
On a fresh hw273 prov (dep `67e4dd881502f1a2`, cnpg-pair **0.2.15** carrying #5219) the dr-promoter **FALSE-PROMOTED region-B during a transient region-A unreachability** (primary-pod restart-storm — 5× clean exit 0 — + cross-region WAL-stream blip during convergence) while **region-A stayed ALIVE on timeline 1**, and **#5219's durable `spec.suspend` latch then CEMENTED the false promotion permanently**: region-B bumped to TL2, its walreceiver FATAL-loops forever (`highest timeline 1 of the primary is behind recovery timeline 2`), and region-A is sync-wedged on the never-connecting standby.

The fundamental problem: **every liveness signal the region-B promoter has** — the cnpg WAL stream and the `pg_isready` of `-primary-mesh` (the #5178 gate) — **rides the SAME region-B→region-A ClusterMesh/VPC datapath**, so a link flap is indistinguishable from a real region death over that link. The #5178 pg_isready gate false-positived identically, and the #5178 startup grace (a **fixed timer** from pod start) had already expired when the restart-storm hit minutes into the env's life. This is a **distinct defect from #5218/#5219** — the latch works exactly as designed; the fix is to only ever *decide* a promotion that is real.

### Fix
**(A) Steady-state ARM gate** — the signals container now tracks CONTINUOUS streaming (`walreceiver status=streaming`) and writes `/shared/armed` only after it has held for `autoPromote.steadyStateArmSeconds` (**180s**). The actor **REFUSES every promote while UNARMED**. A region-A-down signal *before the first stable stream* is a convergence-time transient (the hw273 case), never a real kill. **A pair that never reached steady-state can never promote, so #5219's latch can never cement a convergence-time false positive** — this kills the hw273 class at the source. Once armed it stays armed for the pod's life; a real region-A death *after* steady-state promotes normally (no RTO regression). A non-streaming blip only restarts the arm window, never un-arms.

**(B) Timeline-divergence surfacing** — a standby that cannot re-stream from a **REACHABLE** region-A for `autoPromote.timelineDivergenceHoldSeconds` (**300s**) is the divergence wedge; the signals container flags it (`/shared/timeline-diverged`) and the actor records it ONCE on the HR (`catalyst.openova.io/dr-timeline-diverged-at`) + logs the re-clone action, so the wedge is **DIAGNOSED + monitored instead of a silent FATAL loop**. **Non-destructive** — the re-clone stays the operator's RUNBOOKS §6.1 action: a 2-node actor cannot prove *which side is authoritative*, so auto-destroying region-B's PGDATA could lose a real survivor's committed writes (a worse failure than the wedge). Uses the existing HR get/patch RBAC only (annotation) — **no PVC/pod delete**.

### Preserved (decision gates untouched)
#5219's same-tick durable suspend latch + per-loop self-heal + readback-verify, the 120s `primaryDownHold`, the positive region-A `pg_isready` liveness gate, the startup grace, the anti-flap "never re-promote a diverged cluster" latch, and the sync-only data fence are ALL unchanged.

### Promotion trigger — before vs after
- **Before:** `region-A WAL stream absent AND region-A pg_isready unreachable ≥120s AND failover-readiness Ready` → promote (+ #5219 same-tick suspend latch).
- **After:** `armed (observed continuous streaming ≥180s) AND region-A WAL stream absent AND region-A pg_isready unreachable ≥120s AND NOT diverged AND failover-readiness Ready` → promote (+ #5219 latch, unchanged). Plus: a persistent can't-re-stream-from-reachable-region-A condition (≥300s) is recorded on the HR as `dr-timeline-diverged-at`.

### Which of (A)/(B)/(C)
- **(A) implemented in full** — highest-ICE, lowest-risk; the actual fix for the reported defect and what unblocks G12.
- **(B) implemented as precise detection + durable, non-destructive HR surfacing.** The destructive auto-reclone was deliberately **not** auto-executed: from a 2-node vantage with no witness the actor cannot safely distinguish "false-positive divergence (region-B re-clonable)" from "real-survivor divergence (region-B authoritative)" — auto-destroying PGDATA on a wrong gate is silent data loss. The wedge is now surfaced + actionable; (A) prevents it forming in the first place.
- **(C) hardened death signal** — delivered *by* (A) (a death is only believable after observed steady-state); the existing 120s hold + region-A pg_isready gate are kept. The hold was not further bumped to avoid RTO regression on real post-steady-state kills.

### Tests
- **Render-gate Case 18** (new) asserts: both container scripts remain valid POSIX shell; the arm/divergence envs are templated (180/300); the arm gate **PRECEDES** the promote merge-patch (a never-armed pair can never reach the HR patch); the divergence marker is surfaced on the HR; and — data-safety — the actor issues **no destructive `kubectl delete`** and the dr-promoter Role gains **no delete/create verbs**. Cases 1–17 unchanged and green.
- Behavioral simulation of the arm-gate + fault predicates (13 assertions, all pass): hw273 false positive → never armed → refused; healthy steady-state → armed → real kill → promotes; blip-before-arm resets the window; persistent reachable-region-A fault → divergence flagged; sub-hold transient → no false flag.

### Chart / pins
`bp-cnpg-pair` **0.2.15 → 0.2.16**; lockstep slot 16b + `blueprint.yaml` + catalog-seed pins moved together (`check-bootstrap-kit-pin-sync` green). No `appVersion`/image bump (inline shell actor). No resource-count or RBAC change (signals gains 2 env vars).

### Residual risk
The 2-node, no-witness limitation is unchanged: a link flap *after* steady-state could still look like a real death (the arm gate only rules out the never-converged / convergence-transient class, which is the hw273 defect). (B) makes any such wedge diagnosed + operator-recoverable rather than silently permanent. A third-site/mothership witness is the general fix (tracked on #5137).

**Not runtime-verified yet** — live validation is the next fresh prov's region-kill **G12 (UAT Pillar-3)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)