### PR TITLE
fix(cutover): warm Crossplane xpkg packages durably into local Harbor + step-11 verify-before-pivot (0.1.142)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -897,7 +897,17 @@ spec:
       # (prewarm.proxyBackoffBaseSeconds=30, doubling). FATAL-on-any-failure, the
       # #5030 dest-check skip, the #4975 pre-pass + multi-arch handling all
       # preserved. Contract Case 60.
-      version: 0.1.141
+      # 0.1.142 (#5204 Refs #5209): the local Harbor must DURABLY hold every
+      # Crossplane xpkg provider package BEFORE step-11 pivots onto it. #5209
+      # wired the package-pull auth, but nothing ever placed the xpkg artifact
+      # itself locally (proxy-xpkg is the ONE proxy-cache project — Harbor
+      # rejects pushes into it — and xpkg.upbound.io is excluded from the
+      # generic offline mirror). Step-03 Phase A4 now enumerates every
+      # Provider spec.package and warms it DURABLY through the local
+      # proxy-xpkg endpoint (full pull-through + artifact-API durable assert,
+      # FATAL on a miss); step-11 verifies the same durable presence before
+      # every spec.package rewrite (fail-loud). Contract Case 65.
+      version: 0.1.142
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.141
+  version: 0.1.142
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,53 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.142 (#5204 Refs #5209 #3379 — the local Harbor must DURABLY hold every
+# Crossplane xpkg provider package BEFORE step-11 pivots onto it. #5209
+# (0.1.139) wired the package-pull AUTH, but NOTHING ever placed the xpkg OCI
+# artifact ITSELF in the local Harbor: `proxy-xpkg` is the ONE local project
+# that stays a Harbor PROXY-CACHE (0.1.114; Harbor REJECTS pushes into a
+# proxy-cache project, so the Phase A skopeo-push route cannot serve it) and
+# xpkg.upbound.io is deliberately in offlineMirror.excludedHosts (the
+# Crossplane package manager bypasses containerd, so the generic mirror legs
+# are inert for it). On a COLD cache every post-severance package re-pull /
+# provider upgrade / inactive-revision reconcile needs the proxy leg to reach
+# xpkg.upbound.io — an upstream tether Principle #11 forbids: the fully-severed
+# Sovereign cannot resolve its own provider package descriptor from the local
+# registry (live hw270 dep b2f0a9b0585f6781: provider-opentofu
+# Installed=False). TWO coupled fixes:
+#   (1) step-03 Phase A4 (NEW, template 03 + values prewarm.xpkgPackages) —
+#       enumerate every providers.pkg.crossplane.io spec.package (the SAME set
+#       step-11 pivots; the upstream/mothership/registry-path literals come
+#       from the SAME crossplaneProviderPivot values, no second hand-list) and
+#       perform ONE FULL authenticated pull THROUGH the local proxy-xpkg
+#       endpoint per package (skopeo → dir: scratch, --multi-arch all, the
+#       #4955 tag@digest normalization, PREWARM_COPY_ATTEMPTS retry + #4994
+#       skip-if-already-durable idempotency). The pull-through makes Harbor
+#       fetch + DURABLY cache the manifest (list) + every blob, so the exact
+#       ref step-11 pivots to serves locally with no upstream leg (Harbor
+#       serves cached proxy-cache content when the upstream is unreachable).
+#       A bounded artifact-API poll (#5030 durable-probe discipline — Harbor
+#       CORE DB, never pull-through; proxy-cache records async) asserts each
+#       package landed; xpkg_fail>0 → FATAL naming the offender (the same
+#       fail-loud sovereignty contract as Phase A/A2). Skip-guards: the
+#       prewarm.xpkgPackages.enabled toggle + the same
+#       providers.pkg.crossplane.io-CRD-absent very-early-handover guard
+#       step-11 Phase 1 uses (both skip ⇒ nothing is ever pivoted onto a cold
+#       cache).
+#   (2) step-11 verify-before-pivot (template 11 + values
+#       crossplaneProviderPivot.verifyLocalArtifact) — each spec.package
+#       rewrite (AND each already-pivoted SKIP — the hw270 latent shape) is
+#       gated on the SAME artifact-API durable-presence probe (dialed via the
+#       in-cluster harborInternalURL, #5036); a miss records a sentinel and
+#       the step FATALs LOUD naming the package BEFORE the durable Gitea
+#       rewrite, so nothing is half-pivoted onto a ref the local registry
+#       cannot serve. NO RBAC change (providers get/list/watch + CRD get are
+#       already granted for step-11; step-03 runs under the same runner SA).
+#       NO step-count / job-mode / deadline change (still 11 steps). Contract
+#       Case 65 locks the warm + the verify gate + the toggles + the
+#       xpkg.upbound.io excludedHosts invariant. Slot-06a pin + blueprint.yaml
+#       + catalog-seed source.version + spec.version move to 0.1.142 in
+#       lockstep (Inviolable Principle #13).)
+# ── prior ──
 # 0.1.141 (#5215 Refs #4996 #5074 — step-07 must NOT roll the EVS/hcloud CSI
 # driver. Root-caused live on hw271 (cutoverComplete=true then re-fire wedge):
 # step-07 rolled the csi-evs-node DaemonSet via TWO vectors — (1) the
@@ -2316,7 +2364,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.141
+version: 0.1.142
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -243,6 +243,21 @@ data:
             value: {{ .Values.prewarm.proxyCopyAttempts | default 6 | quote }}
           - name: PREWARM_PROXY_BACKOFF_BASE_SECONDS
             value: {{ .Values.prewarm.proxyBackoffBaseSeconds | default 30 | quote }}
+          # #5204 (Refs #5209 #3379) — Phase A4 Crossplane xpkg package warm.
+          # The upstream/mothership/registry-path literals come from the SAME
+          # .Values.crossplaneProviderPivot block step-11 reads, so the warm
+          # set and the pivot target can never drift apart (no second
+          # hand-list — the #4975 single-source discipline).
+          - name: XPKG_PREWARM_ENABLED
+            value: {{ .Values.prewarm.xpkgPackages.enabled | quote }}
+          - name: SOVEREIGN_FQDN
+            value: {{ .Values.sovereign.fqdn | quote }}
+          - name: XPKG_UPSTREAM_HOST
+            value: {{ .Values.crossplaneProviderPivot.upstreamHost | quote }}
+          - name: XPKG_REGISTRY_PATH
+            value: {{ .Values.crossplaneProviderPivot.registryPath | quote }}
+          - name: XPKG_MOTHERSHIP_PROXY_PREFIX
+            value: {{ .Values.crossplaneProviderPivot.mothershipProxyPrefix | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -1469,6 +1484,197 @@ data:
             if [ "${chart_fail}" -gt 0 ]; then
               echo "[harbor-prewarm] FATAL: ${chart_fail} openova-io chart(s) failed to mirror (named above) — step-06 cannot strip ghcr.io safely (post-cutover chart (re)pulls would 404). #5007: this INCLUDES any pinned/desired chart version the union added — a pinned tag that cannot be pulled fails LOUD here (egress open, recoverable) instead of silently wedging step-06 under the deny-egress hold."
               exit 1
+            fi
+
+            # ─── Phase A4 (#5204): warm Crossplane xpkg provider packages ──────
+            #
+            # #5204 (Refs #5209 #3379). Step-11 (crossplane-provider-pivot)
+            # rewrites every Provider's spec.package to the local Harbor
+            # `proxy-xpkg` project and #5209 wired the package-pull AUTH — but
+            # NOTHING ever placed the xpkg OCI artifact ITSELF in the local
+            # Harbor. `proxy-xpkg` is the ONE local project that stays a Harbor
+            # PROXY-CACHE (0.1.114; Harbor REJECTS pushes into a proxy-cache
+            # project, so the Phase A skopeo-push route cannot serve it), and
+            # xpkg.upbound.io is deliberately in offlineMirror.excludedHosts
+            # (the Crossplane package manager bypasses containerd, so the
+            # generic mirror legs are inert for it). On a COLD cache every
+            # post-severance package re-pull / provider upgrade / inactive-
+            # revision reconcile needs the proxy leg to reach xpkg.upbound.io —
+            # an upstream tether Principle #11 forbids: the fully-severed
+            # Sovereign cannot resolve its own provider package descriptor
+            # from the local registry (live hw270 dep b2f0a9b0585f6781,
+            # provider-opentofu Installed=False).
+            #
+            # FIX: enumerate every providers.pkg.crossplane.io spec.package
+            # (the SAME set step-11 pivots) and perform ONE FULL authenticated
+            # pull THROUGH the local proxy-xpkg endpoint per package
+            # (`skopeo copy docker://${HARBOR_HOST}/proxy-xpkg/<path> dir:…`
+            # with --multi-arch all). The pull-through forces Harbor to fetch
+            # the manifest (list) + EVERY blob from upstream and cache them
+            # DURABLY in the project, so the exact ref step-11 pivots to
+            # serves locally with no upstream leg (Harbor serves cached
+            # proxy-cache content when the upstream is unreachable). A
+            # bounded durable-presence poll via the Harbor ARTIFACT API
+            # (#5030 discipline — Harbor CORE DB, never pull-through;
+            # proxy-cache records artifacts ASYNC, hence the poll) confirms
+            # each package landed; FATAL naming the offender otherwise — the
+            # same fail-loud sovereignty contract as Phase A/A2. Step-11's
+            # verify-before-pivot gate re-asserts this durable presence
+            # immediately before each spec.package rewrite.
+            xpkg_artifact_present() {
+              # $1 = local path project/repo[:tag|@digest]; 0 when the local
+              # Harbor DURABLY serves it (artifact API = Harbor CORE DB, never
+              # pull-through — the #5030 probe discipline). Non-zero on ANY
+              # miss/parse-fail/API error (fail-closed → the caller warms).
+              _xa_pp="$1"
+              _xa_ref="latest"
+              case "${_xa_pp}" in
+                *@*)
+                  _xa_ref="${_xa_pp##*@}"; _xa_pp="${_xa_pp%@*}"
+                  case "${_xa_pp##*/}" in *:*) _xa_pp="${_xa_pp%:*}" ;; esac ;;
+                *)
+                  case "${_xa_pp##*/}" in *:*) _xa_ref="${_xa_pp##*:}"; _xa_pp="${_xa_pp%:*}" ;; esac ;;
+              esac
+              case "${_xa_pp}" in
+                */*) _xa_proj="${_xa_pp%%/*}"; _xa_repo="${_xa_pp#*/}" ;;
+                *)   return 1 ;;
+              esac
+              # Single-encode nested repo `/` -> %2F for the direct harbor-core
+              # Service path (#5036 — no gateway decode layer in between).
+              _xa_repo_enc=$(printf '%s' "${_xa_repo}" | sed 's#/#%2F#g')
+              _xa_d=$(curl -sk --max-time 30 \
+                -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                "${HARBOR_INTERNAL_URL}/api/v2.0/projects/${_xa_proj}/repositories/${_xa_repo_enc}/artifacts/${_xa_ref}" 2>/dev/null \
+                | jq -r '.digest // empty' 2>/dev/null)
+              [ -n "${_xa_d}" ]
+            }
+
+            if [ "${XPKG_PREWARM_ENABLED:-true}" != "true" ]; then
+              echo "[harbor-prewarm] Phase A4 SKIP — prewarm.xpkgPackages.enabled=false (Crossplane package warm disabled; post-severance provider re-pulls stay dependent on proxy-cache upstream reachability)"
+            elif ! kubectl get crd providers.pkg.crossplane.io >/dev/null 2>&1; then
+              # Same very-early-handover guard step-11 Phase 1 uses: bp-crossplane
+              # not landed yet → no Provider CRs to warm, and step-11 skips the
+              # live pivot on the SAME probe, so no ref is ever pivoted onto a
+              # cold cache. A step re-run once crossplane lands warms the set.
+              echo "[harbor-prewarm] Phase A4 SKIP — providers.pkg.crossplane.io CRD not installed yet (bp-crossplane not landed); packages warm on a later step re-run"
+            else
+              echo "[harbor-prewarm] Phase A4: warm Crossplane xpkg provider packages through local ${XPKG_REGISTRY_PATH} (#5204)"
+              xpkg_target_host="harbor.${SOVEREIGN_FQDN}"
+              xpkg_tsv=$(kubectl get providers.pkg.crossplane.io \
+                -o 'jsonpath={range .items[*]}{.metadata.name}{"\t"}{.spec.package}{"\n"}{end}' 2>/dev/null || true)
+              xpkg_warm_dir=/tmp/xpkg-warm
+              rm -rf "${xpkg_warm_dir}"; mkdir -p "${xpkg_warm_dir}"
+              printf '%s\n' "${xpkg_tsv}" | while IFS="$(printf '\t')" read -r _xw_name _xw_pkg; do
+                [ -z "${_xw_name}" ] && continue
+                [ -z "${_xw_pkg}" ] && continue
+                # tag@digest → digest-only (skopeo rejects a ref carrying both;
+                # the digest is authoritative — the #4955 normalization).
+                _xw_pkg=$(offlinemirror_normalize_ref "${_xw_pkg}")
+                # Route the package to its local proxy-xpkg path. Handles every
+                # shape step-11 handles: the raw upstream host (Hetzner), the
+                # MOTHERSHIP proxy prefix (Huawei fresh-prov, #4488), and the
+                # already-pivoted local aliases (re-run idempotency).
+                _xw_lpath=""
+                case "${_xw_pkg}" in
+                  "${XPKG_UPSTREAM_HOST}/"*)
+                    _xw_lpath="${XPKG_REGISTRY_PATH}/${_xw_pkg#${XPKG_UPSTREAM_HOST}/}" ;;
+                  "${XPKG_MOTHERSHIP_PROXY_PREFIX}/"*)
+                    _xw_lpath="${XPKG_REGISTRY_PATH}/${_xw_pkg#${XPKG_MOTHERSHIP_PROXY_PREFIX}/}" ;;
+                  "${xpkg_target_host}/${XPKG_REGISTRY_PATH}/"*)
+                    _xw_lpath="${_xw_pkg#${xpkg_target_host}/}" ;;
+                  "${LOCAL_REGISTRY_HOST}/${XPKG_REGISTRY_PATH}/"*)
+                    _xw_lpath="${_xw_pkg#${LOCAL_REGISTRY_HOST}/}" ;;
+                  *)
+                    # Unmapped package host — the same fail-fast discipline as
+                    # the Phase A pre-pass (egress still open, offender named)
+                    # instead of a silent post-severance resolution failure.
+                    echo "[harbor-prewarm] Phase A4 UNMAPPED: Provider ${_xw_name} package '${_xw_pkg}' is from a host not covered by crossplaneProviderPivot (${XPKG_UPSTREAM_HOST} / ${XPKG_MOTHERSHIP_PROXY_PREFIX} / ${xpkg_target_host}/${XPKG_REGISTRY_PATH} / ${LOCAL_REGISTRY_HOST}/${XPKG_REGISTRY_PATH}) — extend the values and re-trigger"
+                    printf '%s %s (unmapped host)' "${_xw_name}" "${_xw_pkg}" > "${xpkg_warm_dir}/$(printf '%s' "${_xw_name}" | tr -c 'A-Za-z0-9._-' '_').fail"
+                    continue ;;
+                esac
+                _xw_slug=$(printf '%s' "${_xw_lpath}" | tr -c 'A-Za-z0-9._-' '_')
+                : >"${xpkg_warm_dir}/${_xw_slug}.log"
+                # Idempotency: skip when the artifact is ALREADY durably cached
+                # (re-run / prior warm). Fail-closed — any probe miss warms.
+                if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ] && xpkg_artifact_present "${_xw_lpath}"; then
+                  echo "[harbor-prewarm] Phase A4 skip ${_xw_pkg} -> ${_xw_lpath} (already durably cached)"
+                  printf '%s (present)' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.ok"
+                  continue
+                fi
+                echo "[harbor-prewarm] Phase A4 warm ${_xw_pkg} -> ${HARBOR_HOST}/${_xw_lpath} (full pull-through; manifest + all blobs cache durably)"
+                _xw_attempt=1
+                _xw_rc=1
+                while [ "${_xw_attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
+                  echo "[harbor-prewarm] Phase A4 warm ${_xw_lpath} attempt ${_xw_attempt}/${PREWARM_COPY_ATTEMPTS}" >>"${xpkg_warm_dir}/${_xw_slug}.log"
+                  rm -rf "${xpkg_warm_dir}/${_xw_slug}.dir"
+                  # SOURCE = the local proxy-xpkg endpoint (the exact ref
+                  # step-11 pivots to); admin src-creds satisfy Harbor's
+                  # authenticated proxy-cache pull (#5204/#5209). src-tls
+                  # follows PREWARM_DEST_TLS_VERIFY — it is the SAME in-cluster
+                  # registry.<fqdn> endpoint the Phase A pushes target (#4529
+                  # rationale: trust is the cluster network, not a public CA).
+                  # --multi-arch all pulls EVERY arch sub-manifest + blobs
+                  # through so the cached list is complete (#4975 rationale).
+                  if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
+                      --insecure-policy \
+                      --multi-arch all \
+                      --retry-times 5 \
+                      --src-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                      --src-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
+                      "docker://${HARBOR_HOST}/${_xw_lpath}" \
+                      "dir:${xpkg_warm_dir}/${_xw_slug}.dir" >>"${xpkg_warm_dir}/${_xw_slug}.log" 2>&1; then
+                    _xw_rc=0
+                    break
+                  else
+                    _xw_rc=$?
+                  fi
+                  echo "[harbor-prewarm] Phase A4 warm ${_xw_lpath} attempt ${_xw_attempt} failed (exit=${_xw_rc}); retrying after backoff" >>"${xpkg_warm_dir}/${_xw_slug}.log"
+                  _xw_attempt=$((_xw_attempt+1))
+                  [ "${_xw_attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
+                done
+                # The dir: copy is a scratch side-effect — the durable payload
+                # is what Harbor cached on the way through. Free the emptyDir.
+                rm -rf "${xpkg_warm_dir}/${_xw_slug}.dir"
+                if [ "${_xw_rc}" -ne 0 ]; then
+                  printf '%s exit=%s' "${_xw_lpath}" "${_xw_rc}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
+                  echo "[harbor-prewarm] Phase A4 done ${_xw_lpath} (FAIL exit=${_xw_rc})"
+                  continue
+                fi
+                # Durable-presence poll (Harbor records proxied artifacts
+                # ASYNC): bounded 12x10s before the fail-closed verdict.
+                _xw_present=0
+                for _xw_i in $(seq 1 12); do
+                  if xpkg_artifact_present "${_xw_lpath}"; then _xw_present=1; break; fi
+                  sleep 10
+                done
+                if [ "${_xw_present}" -eq 1 ]; then
+                  printf '%s' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.ok"
+                  echo "[harbor-prewarm] Phase A4 done ${_xw_lpath} (durably cached)"
+                else
+                  printf '%s (pulled through but never durably recorded)' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
+                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the Harbor artifact API never recorded the artifact durably (120s poll) — proxy-cache persistence failed"
+                fi
+              done
+              xpkg_ok=0
+              xpkg_fail=0
+              for f in "${xpkg_warm_dir}"/*.ok; do
+                [ -e "${f}" ] || continue
+                _xs=$(basename "${f}" .ok)
+                xpkg_ok=$((xpkg_ok+1))
+                echo "[harbor-prewarm] Phase A4 OK $(cat "${f}")"
+              done
+              for f in "${xpkg_warm_dir}"/*.fail; do
+                [ -e "${f}" ] || continue
+                _xs=$(basename "${f}" .fail)
+                sed 's/^/  /' "${xpkg_warm_dir}/${_xs}.log" 2>/dev/null || true
+                xpkg_fail=$((xpkg_fail+1))
+                echo "[harbor-prewarm] Phase A4 FAIL $(cat "${f}")"
+              done
+              echo "[harbor-prewarm] Phase A4 complete: xpkg_ok=${xpkg_ok} xpkg_fail=${xpkg_fail}"
+              if [ "${xpkg_fail}" -gt 0 ]; then
+                echo "[harbor-prewarm] FATAL: ${xpkg_fail} Crossplane xpkg package(s) failed to warm into local Harbor (named above) — step-11 would pivot Provider spec.package onto a ref the local registry cannot serve post-severance (#5204)"
+                exit 1
+              fi
             fi
 
             # ─── Phase B (legacy): HEAD against proxy-cache for non-openova-io ─

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -153,6 +153,13 @@ data:
           # spec.package carries.
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
+          # #5204 verify-before-pivot — the in-cluster Harbor Service URL for
+          # the artifact-API durable-presence probe (#5036 direct-Service
+          # path; single-encode %2F) + the operator toggle.
+          - name: HARBOR_INTERNAL_URL
+            value: {{ .Values.sovereign.harborInternalURL | quote }}
+          - name: VERIFY_LOCAL_ARTIFACT
+            value: {{ .Values.crossplaneProviderPivot.verifyLocalArtifact.enabled | quote }}
           - name: HARBOR_USERNAME
             valueFrom:
               secretKeyRef:
@@ -275,6 +282,57 @@ data:
               echo "[crossplane-provider-pivot]   OK ImageConfig ${IMAGE_CONFIG_NAME} (matchImages: ${target_host}/${REGISTRY_PATH}, ${registry_host}/${REGISTRY_PATH})"
             fi
 
+            # ---- Phase 0.5 (#5204): local-artifact verify gate ----
+            #
+            # Rewrite a Provider's spec.package onto the local Harbor ONLY
+            # after the Harbor ARTIFACT API (Harbor CORE DB — durable, never
+            # pull-through: the #5030 probe discipline) confirms the package
+            # artifact is durably present locally. Step-03 Phase A4 warms
+            # every Provider package through proxy-xpkg for exactly this;
+            # a miss here means the warm never ran / was skipped for this
+            # package (e.g. a Provider created mid-cutover after step-03
+            # enumerated), and pivoting anyway would point spec.package at a
+            # ref the local registry cannot serve post-severance. FAIL-LOUD:
+            # the offender is named and the step exits 1 so the operator
+            # re-triggers the cutover (step-03 re-warms, idempotent) instead
+            # of shipping a silently-dangling pivot.
+            verify_local_pkg_artifact() {
+              # $1 = local path project/repo[:tag|@digest]; 0 = durably
+              # present OR verification not applicable (disabled / no
+              # credential to probe with).
+              case "${VERIFY_LOCAL_ARTIFACT:-true}" in
+                true|True|TRUE|1|yes) : ;;
+                *) return 0 ;;
+              esac
+              if [ -z "${HARBOR_PASSWORD:-}" ]; then
+                echo "[crossplane-provider-pivot] WARN: HARBOR_PASSWORD empty — cannot probe the local artifact API; skipping the #5204 verify gate for $1"
+                return 0
+              fi
+              : "${HARBOR_USERNAME:=admin}"
+              _vp="$1"
+              _vref="latest"
+              case "${_vp}" in
+                *@*)
+                  _vref="${_vp##*@}"; _vp="${_vp%@*}"
+                  case "${_vp##*/}" in *:*) _vp="${_vp%:*}" ;; esac ;;
+                *)
+                  case "${_vp##*/}" in *:*) _vref="${_vp##*:}"; _vp="${_vp%:*}" ;; esac ;;
+              esac
+              case "${_vp}" in
+                */*) _vproj="${_vp%%/*}"; _vrepo="${_vp#*/}" ;;
+                *)   return 1 ;;
+              esac
+              _vrepo_enc=$(printf '%s' "${_vrepo}" | sed 's#/#%2F#g')
+              _vd=$(curl -sk --max-time 30 \
+                -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                "${HARBOR_INTERNAL_URL}/api/v2.0/projects/${_vproj}/repositories/${_vrepo_enc}/artifacts/${_vref}" 2>/dev/null \
+                | jq -r '.digest // empty' 2>/dev/null)
+              [ -n "${_vd}" ]
+            }
+            # Sentinel: the Phase-1 while-loop runs in a pipeline subshell, so
+            # a verify miss records here and the parent FATALs after the loop.
+            rm -f /tmp/xpkg-verify-failed
+
             # ---- Phase 1: live K8s patch on every Provider CR ----
             #
             # `kubectl get providers.pkg.crossplane.io` is cluster-scoped
@@ -331,6 +389,13 @@ data:
                       # host(+path) prefix with the Sovereign-local one.
                       pkg_suffix="${pkg#${matched_prefix}/}"
                       new_pkg="${target_prefix}/${pkg_suffix}"
+                      # #5204 verify-before-pivot: the local artifact MUST be
+                      # durably present BEFORE the rewrite (fail-loud).
+                      if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg_suffix}"; then
+                        echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: local Harbor does not durably serve ${REGISTRY_PATH}/${pkg_suffix} — refusing to pivot spec.package onto a ref the local registry cannot serve post-severance (#5204; step-03 Phase A4 should have warmed it — re-trigger the cutover)" >&2
+                        touch /tmp/xpkg-verify-failed
+                        continue
+                      fi
                       echo "[crossplane-provider-pivot] PATCH ${name} ${pkg} -> ${new_pkg}"
                       # Merge-patch only spec.package — preserves every
                       # other spec field (revisionActivationPolicy,
@@ -344,6 +409,14 @@ data:
                       fi
                       ;;
                     "${target_prefix}/"*)
+                      # #5204: an ALREADY-pivoted Provider must ALSO durably
+                      # resolve locally — this is exactly the hw270 latent
+                      # shape (pivoted ref, cold cache). Fail-loud too.
+                      if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg#${target_prefix}/}"; then
+                        echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: already pivoted to ${pkg} but the local Harbor does not durably serve ${REGISTRY_PATH}/${pkg#${target_prefix}/} (#5204; re-trigger the cutover so step-03 Phase A4 warms it)" >&2
+                        touch /tmp/xpkg-verify-failed
+                        continue
+                      fi
                       echo "[crossplane-provider-pivot] SKIP ${name} (already pivoted: ${pkg})"
                       ;;
                     *)
@@ -352,6 +425,15 @@ data:
                   esac
                 done
               fi
+            fi
+
+            # #5204 fail-loud: any verify miss recorded by the subshell loop
+            # fails the step BEFORE the durable Gitea rewrite, so nothing is
+            # half-pivoted onto a ref the local registry cannot serve. The
+            # live patches already applied are idempotent on the re-run.
+            if [ -e /tmp/xpkg-verify-failed ]; then
+              echo "[crossplane-provider-pivot] FATAL: one or more Provider packages are NOT durably served by the local Harbor (VERIFY-FAIL lines above) — re-trigger the cutover so step-03 Phase A4 warms them (#5204)" >&2
+              exit 1
             fi
 
             # ---- Phase 2: push YAML edit to local Gitea ----

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1560,12 +1560,15 @@ if ! grep -Eq '^[[:space:]]*--multi-arch all \\$' "$TMP/prewarm_ma_block.txt"; t
   echo "FAIL: Step-03 Phase A skopeo copy is missing --multi-arch all — a manifest-list image uploads only a single-arch manifest and Harbor rejects it 'digest invalid', fail-closing step-03 (#4975)" >&2
   exit 1
 fi
-# EXACTLY ONE copy carries it: the Phase A container-image copy. The Phase A2
-# chart-OCI copy (a single manifest, never a list) is left alone, so the flag-line
-# count is 1 — this also proves the flag did not get sprinkled onto the chart copy.
+# EXACTLY TWO copies carry it: the Phase A container-image copy AND the Phase A4
+# xpkg package warm (#5204 — upbound provider packages are multi-arch manifest
+# LISTS too; the warm must pull EVERY arch sub-manifest + blobs through so the
+# proxy-cache holds the complete list). The Phase A2 chart-OCI copy (a single
+# manifest, never a list) is left alone, so the flag-line count is exactly 2 —
+# this also proves the flag did not get sprinkled onto the chart copy.
 ma_lines=$(grep -Ec '^[[:space:]]*--multi-arch all \\$' "$TMP/prewarm_ma_block.txt" || true)
-if [ "${ma_lines}" -ne 1 ]; then
-  echo "FAIL: Step-03 has ${ma_lines} --multi-arch all flag line(s), expected exactly 1 (the container-image copy). The Phase A2 helm-chart-OCI copy must NOT carry it — chart artifacts are single manifests, not lists (#4975)" >&2
+if [ "${ma_lines}" -ne 2 ]; then
+  echo "FAIL: Step-03 has ${ma_lines} --multi-arch all flag line(s), expected exactly 2 (the Phase A container-image copy + the Phase A4 xpkg warm #5204). The Phase A2 helm-chart-OCI copy must NOT carry it — chart artifacts are single manifests, not lists (#4975)" >&2
   exit 1
 fi
 echo "  PASS (Step-03 Phase A container-image copy uses --multi-arch all; Phase A2 chart-OCI copy left single-manifest)"
@@ -2927,5 +2930,94 @@ else
 fi
 if [ "$c64_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5215: step-07 excludes the CSI driver from BOTH the additionalHRs HR pivot [excludeHelmReleases] AND the Phase 4 pod-spec sweep [podSpecSweep.excludeWorkloads]; the exclusion renders auditably and is deny-wins against an overlay re-add)"
+
+# ── Case 65 (#5204, Refs #5209 #3379): Crossplane xpkg provider packages are
+# DURABLY warmed into the local Harbor proxy-xpkg project by step-03 Phase A4,
+# and step-11 pivots spec.package ONLY after verifying the artifact serves
+# locally (fail-loud) ─────────────────────────────────────────────────────────
+# Root cause (live hw270 dep b2f0a9b0585f6781): step-11 pivots
+# Provider.spec.package to harbor.<fqdn>/proxy-xpkg/... and #5209 wired the
+# pull AUTH, but harbor-prewarm SKIPPED the xpkg packages entirely
+# (xpkg.upbound.io is in offlineMirror.excludedHosts, and `proxy-xpkg` is the
+# ONE project that stays a Harbor PROXY-CACHE — Harbor rejects pushes into a
+# proxy-cache project, so the Phase A skopeo-push route cannot serve it). On a
+# COLD cache the post-severance provider re-pull cannot resolve its package
+# descriptor from the local registry. This Case asserts the xpkg refs now
+# appear in the step-03 prewarm work (Phase A4 warm) + the step-11 gate.
+echo "[cutover-contract] Case 65: step-03 Phase A4 warms Crossplane xpkg provider packages into local proxy-xpkg + step-11 verifies durable local presence before each spec.package pivot (#5204)"
+[ -s "$TMP/s03pin.yaml" ] || awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml"
+c65_fail=0
+# (a) step-03 enumerates the Provider package refs — the SAME set step-11
+#     pivots — so xpkg refs land in the prewarm work list.
+if ! grep -qF 'kubectl get providers.pkg.crossplane.io' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 never enumerates providers.pkg.crossplane.io — xpkg provider packages are absent from the prewarm set and the local registry stays COLD for step-11's pivot target (#5204)" >&2; c65_fail=1
+fi
+# (b) the routing literals come from the SAME crossplaneProviderPivot values
+#     step-11 reads (no second hand-list that can drift).
+if ! grep -A1 'name: XPKG_REGISTRY_PATH' "$TMP/s03pin.yaml" | grep -q 'value: "proxy-xpkg"'; then
+  echo "FAIL: step-03 does not project XPKG_REGISTRY_PATH=proxy-xpkg from crossplaneProviderPivot.registryPath (#5204)" >&2; c65_fail=1
+fi
+if ! grep -A1 'name: XPKG_UPSTREAM_HOST' "$TMP/s03pin.yaml" | grep -q 'value: "xpkg.upbound.io"'; then
+  echo "FAIL: step-03 does not project XPKG_UPSTREAM_HOST from crossplaneProviderPivot.upstreamHost (#5204)" >&2; c65_fail=1
+fi
+if ! grep -A1 'name: XPKG_MOTHERSHIP_PROXY_PREFIX' "$TMP/s03pin.yaml" | grep -q 'value: "harbor.openova.io/proxy-xpkg"'; then
+  echo "FAIL: step-03 does not project XPKG_MOTHERSHIP_PROXY_PREFIX from crossplaneProviderPivot.mothershipProxyPrefix — the Huawei fresh-prov package shape (#4488) would go unwarmed (#5204)" >&2; c65_fail=1
+fi
+# (c) the warm is a FULL pull-THROUGH of the exact local ref step-11 pivots to
+#     (dir: scratch dest — Harbor rejects pushes into a proxy-cache project, so
+#     a push-mode copy cannot serve proxy-xpkg), multi-arch complete.
+if ! grep -qF 'docker://${HARBOR_HOST}/${_xw_lpath}' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 does not pull the package THROUGH the local proxy-xpkg endpoint — only a pull-through can populate a proxy-cache project (pushes are rejected) (#5204)" >&2; c65_fail=1
+fi
+if ! grep -qF 'dir:${xpkg_warm_dir}/${_xw_slug}.dir' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 lost the dir: scratch destination for the warm pull-through (#5204)" >&2; c65_fail=1
+fi
+# (d) durable presence is asserted via the Harbor ARTIFACT API (the #5030
+#     durable-probe discipline) and a warm failure FATALs the step.
+if ! grep -qF 'xpkg_artifact_present' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 lost the xpkg_artifact_present durable probe (Harbor artifact API — CORE DB, never pull-through) (#5204)" >&2; c65_fail=1
+fi
+if ! grep -qF 'Crossplane xpkg package(s) failed to warm' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 lost the xpkg_fail>0 FATAL — an unwarmed package would silently ship a cold cache into the step-11 pivot (#5204)" >&2; c65_fail=1
+fi
+# (e) xpkg.upbound.io STAYS excluded from the generic offline mirror — the
+#     Phase A push route targets push-mode projects and cannot serve the
+#     proxy-cache proxy-xpkg; Phase A4 is the dedicated leg.
+if ! grep -A1 'name: EXCLUDED_HOSTS' "$TMP/s03pin.yaml" | grep -q 'xpkg.upbound.io'; then
+  echo "FAIL: xpkg.upbound.io left offlineMirror.excludedHosts — the generic Phase A push would target the proxy-cache proxy-xpkg project, which Harbor rejects (#5204)" >&2; c65_fail=1
+fi
+# (f) the Phase A4 toggle + the very-early-handover CRD guard exist, and the
+#     toggle is operator-wired.
+if ! grep -A1 'name: XPKG_PREWARM_ENABLED' "$TMP/s03pin.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: XPKG_PREWARM_ENABLED does not default to \"true\" (prewarm.xpkgPackages.enabled) (#5204)" >&2; c65_fail=1
+fi
+helm template smoke-noxpkg . --show-only templates/03-harbor-prewarm-job.yaml --set prewarm.xpkgPackages.enabled=false > "$TMP/r03_5204_off.yaml"
+if ! grep -A1 'name: XPKG_PREWARM_ENABLED' "$TMP/r03_5204_off.yaml" | grep -q 'value: "false"'; then
+  echo "FAIL: prewarm.xpkgPackages.enabled=false did not render XPKG_PREWARM_ENABLED=\"false\" — the operator override is not wired (#5204)" >&2; c65_fail=1
+fi
+# (g) step-11: the verify gate exists, fires BEFORE the patch AND on the
+#     already-pivoted SKIP branch, and a miss FATALs via the sentinel.
+helm template smoke . --show-only templates/11-crossplane-provider-pivot-job.yaml > "$TMP/r11_5204.yaml"
+if ! grep -qF 'verify_local_pkg_artifact()' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 lost the verify_local_pkg_artifact gate — spec.package can be pivoted onto a ref the local registry never durably serves (#5204)" >&2; c65_fail=1
+fi
+if ! grep -qF 'verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg_suffix}"' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11's Phase-1 patch branch does not invoke the verify gate BEFORE the spec.package rewrite (#5204)" >&2; c65_fail=1
+fi
+if ! grep -qF 'verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg#${target_prefix}/}"' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 does not re-verify an ALREADY-pivoted Provider — the hw270 latent shape (pivoted ref, cold cache) would pass silently (#5204)" >&2; c65_fail=1
+fi
+if ! grep -qF '/tmp/xpkg-verify-failed' "$TMP/r11_5204.yaml" || ! grep -qF 'NOT durably served by the local Harbor' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 lost the fail-loud sentinel — a verify miss inside the pipeline-subshell loop must FATAL the step before the durable Gitea rewrite (#5204)" >&2; c65_fail=1
+fi
+if ! grep -A1 'name: VERIFY_LOCAL_ARTIFACT' "$TMP/r11_5204.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: VERIFY_LOCAL_ARTIFACT does not default to \"true\" (crossplaneProviderPivot.verifyLocalArtifact.enabled) (#5204)" >&2; c65_fail=1
+fi
+helm template smoke-noverify . --show-only templates/11-crossplane-provider-pivot-job.yaml --set crossplaneProviderPivot.verifyLocalArtifact.enabled=false > "$TMP/r11_5204_off.yaml"
+if ! grep -A1 'name: VERIFY_LOCAL_ARTIFACT' "$TMP/r11_5204_off.yaml" | grep -q 'value: "false"'; then
+  echo "FAIL: crossplaneProviderPivot.verifyLocalArtifact.enabled=false did not render VERIFY_LOCAL_ARTIFACT=\"false\" — the operator override is not wired (#5204)" >&2; c65_fail=1
+fi
+if [ "$c65_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5204: step-03 Phase A4 enumerates the Provider spec.package set and warms each xpkg ref DURABLY through the local proxy-xpkg endpoint [pull-through — Harbor rejects pushes into a proxy-cache project] with an artifact-API durable assert + FATAL; step-11 verifies the same durable presence before every pivot AND on already-pivoted refs, failing loud via the sentinel; both toggles operator-wired; xpkg.upbound.io stays excluded from the generic push mirror)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -653,6 +653,28 @@ prewarm:
   # existing 3×5s discipline (PREWARM_COPY_ATTEMPTS) unchanged.
   proxyCopyAttempts: 6
   proxyBackoffBaseSeconds: 30
+  # #5204 (Refs #5209 #3379) — Phase A4: warm every Crossplane provider
+  # package (providers.pkg.crossplane.io spec.package — the SAME set step-11
+  # pivots, read from the crossplaneProviderPivot values so the two can never
+  # drift) through the local Harbor `proxy-xpkg` project so the xpkg OCI
+  # artifact is DURABLY cached locally BEFORE step-11 rewrites spec.package
+  # onto it. `proxy-xpkg` is the ONE local project that stays a Harbor
+  # PROXY-CACHE (Harbor REJECTS pushes into a proxy-cache project, so the
+  # Phase A skopeo-push route cannot serve it, and xpkg.upbound.io is
+  # deliberately in offlineMirror.excludedHosts — the Crossplane package
+  # manager bypasses containerd, making the generic mirror legs inert for
+  # it). The warm is ONE FULL authenticated pull THROUGH the local endpoint
+  # per package (skopeo → dir: scratch, --multi-arch all), which makes Harbor
+  # fetch + durably cache the manifest (list) and every blob; a bounded
+  # Harbor-artifact-API poll (#5030 durable-probe discipline) then asserts
+  # presence, FATAL naming the offender otherwise. Without this the cache is
+  # COLD at pivot time and every post-severance package re-pull / provider
+  # upgrade needs the proxy leg to reach xpkg.upbound.io — an upstream tether
+  # Principle #11 forbids (live hw270 dep b2f0a9b0585f6781: provider-opentofu
+  # could not resolve its package from the local registry). Set false only on
+  # a Sovereign that intentionally keeps the xpkg upstream leg open.
+  xpkgPackages:
+    enabled: true
   # #4975 (Refs #3379 #3695) — RETIRED. This hand-maintained 11-image HEAD list
   # (the old Phase B "warm the proxy-cache" pass) was one of the three drifting
   # lists that caused the per-prov whack-a-mole: any upstream image a chart added
@@ -1893,6 +1915,20 @@ crossplaneProviderPivot:
     # ImageConfig (pkg.crossplane.io/v1beta1) name step 11 applies to bind the
     # matchImages prefixes to the pullSecretRef.
     imageConfigName: "cutover-harbor-xpkg"
+  # #5204 (Refs #5209) — verify-before-pivot gate. Step 11 rewrites a
+  # Provider's spec.package onto harbor.<sov-fqdn>/proxy-xpkg/<path> ONLY
+  # after the local Harbor ARTIFACT API (Harbor CORE DB — durable, never
+  # pull-through: the #5030 probe discipline, dialed via the in-cluster
+  # harborInternalURL per #5036) confirms the package artifact is durably
+  # present locally (step-03 Phase A4 / prewarm.xpkgPackages warms it).
+  # An ALREADY-pivoted Provider is re-verified too — that is exactly the
+  # hw270 latent shape (pivoted ref, cold cache). A miss FAILS the step
+  # LOUD naming the package (before the durable Gitea rewrite, so nothing
+  # is half-pivoted) instead of silently pointing spec.package at a ref the
+  # local registry cannot serve post-severance. Set false to restore the
+  # unverified pivot.
+  verifyLocalArtifact:
+    enabled: true
 
 # Step 09 (gitea-token-mint, TBD-C18) — bootstrap the Gitea API token
 # that the Organization provisioning service uses for tenant repo materialisation.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.141"
+  version: "0.1.142"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.141"
+    version: "0.1.142"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5204 (Refs #5209 #3379)

## Root cause

harbor-prewarm (step-03) skips the Crossplane xpkg provider packages entirely, so post-cutover the local registry cannot serve the provider package descriptor:

- `xpkg.upbound.io` is deliberately in `offlineMirror.excludedHosts` — the Crossplane package manager (`go-containerregistry remote.Image()`) bypasses node containerd, so the generic mirror legs are inert for it.
- `proxy-xpkg` is the ONE local Harbor project that stays a **proxy-cache** (Chart 0.1.114: "only proxy-xpkg stays proxy-cache for step-11"), and **Harbor rejects pushes into a proxy-cache project** — so the Phase A skopeo-push route cannot serve it either.
- Step-11 pivots `Provider.spec.package` onto `harbor.<fqdn>/proxy-xpkg/...` and #5209 (0.1.139) wired the package-pull auth — but the artifact itself was never placed locally. On a COLD cache, every post-severance package re-pull / provider upgrade / inactive-revision reconcile needs the proxy leg to reach `xpkg.upbound.io` — an upstream tether Principle #11 forbids (live hw270 dep b2f0a9b0585f6781: `provider-opentofu Installed=False`).

## Fix (chart 0.1.142) — and one stated deviation from the ticket direction

The dispatch direction said "skopeo-copy them like workload images into the local harbor project". That literal shape is impossible: **Harbor rejects pushes into a proxy-cache project**, and `proxy-xpkg` must stay proxy-cache (step-11 pivots against that literal project name; converting an existing env's project type is not idempotent). The mechanically equivalent copy is a **full authenticated pull-THROUGH of the exact local ref step-11 pivots to** — Harbor fetches and durably caches the manifest (list) + every blob, and then serves the cached content even when the upstream is unreachable. Both halves of the ticket's fix direction are implemented:

1. **step-03 Phase A4 (new)** — enumerates every `providers.pkg.crossplane.io` `spec.package` (the SAME set step-11 pivots; the upstream / mothership-proxy / registry-path literals are projected from the SAME `crossplaneProviderPivot` values — no second hand-list). Per package: route to `proxy-xpkg/<path>` (handles the Hetzner `xpkg.upbound.io/...` shape, the Huawei `harbor.openova.io/proxy-xpkg/...` #4488 shape, and both already-pivoted local aliases; an unmapped host FATALs naming the offender), then one full pull-through (`skopeo copy docker://<local>/proxy-xpkg/<path> dir:` scratch, `--multi-arch all`, #4955 tag@digest normalization, retry loop, #4994 skip-if-already-durable). A bounded Harbor-artifact-API poll (#5030 durable-probe discipline — Harbor CORE DB, never pull-through; proxy-cache records async) asserts durable presence; `xpkg_fail>0` FATALs. Toggle `prewarm.xpkgPackages.enabled` (default true) + the same CRD-absent very-early-handover skip guard step-11 uses.
2. **step-11 verify-before-pivot (fail-loud)** — every `spec.package` rewrite AND every already-pivoted SKIP (the hw270 latent shape) is gated on the same artifact-API durable-presence probe (via the in-cluster `harborInternalURL`, #5036). A miss records a sentinel (the Phase-1 loop is a pipeline subshell) and the step FATALs naming the package BEFORE the durable Gitea rewrite, so nothing is half-pivoted. Toggle `crossplaneProviderPivot.verifyLocalArtifact.enabled` (default true).

No RBAC change (`providers` get/list/watch + CRD get already granted; step-03 runs under the same runner SA). Still 11 steps, no job-mode/deadline change.

## Regression test

- New contract **Case 65**: asserts the step-03 render enumerates the Provider package set (xpkg refs in the prewarm work), routes via the shared `crossplaneProviderPivot` values, warms via pull-through + `dir:` scratch, asserts durable presence + FATAL, keeps `xpkg.upbound.io` in `EXCLUDED_HOSTS`, and asserts the step-11 verify gate fires on both the patch and SKIP branches with sentinel fail-loud; both toggles are proven operator-wired via `--set ...=false` renders.
- **Case 39** amended: exactly TWO `--multi-arch all` copies in step-03 (Phase A container images + Phase A4 xpkg warm — upbound provider packages are manifest lists); the Phase A2 chart-OCI copy still must not carry it.

## Validation

- `helm lint` PASS
- `tests/cutover-contract.sh` — all 65 cases PASS
- `tests/image-registry-coverage.sh` PASS
- `scripts/check-catalog-seed-lockstep.sh` PASS (68 checked, 0 fail)
- Rendered step-03 + step-11 scripts: `sh -n` + `bash -n` clean
- Phase A4 routing exercised against all 5 live package shapes (Hetzner upstream, Huawei mothership-proxy, both local aliases, tag@digest) + a negative unmapped-host case

## Lockstep (Inviolable Principle #13)

Chart 0.1.141 → 0.1.142 with pins moved in the same commit: `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`, `platform/self-sovereign-cutover/blueprint.yaml`, `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (spec.version + source.version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
