### PR TITLE
fix(catalyst-api): Edit-IaC seed served through the #5115 canonical Blueprint CR serializer

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
@@ -200,19 +200,57 @@ func iaCEditDurableReason(wroteBytes bool) string {
 	return "already up to date (no change)"
 }
 
+// catalogIaCSeedResponse is the GET /api/v1/catalog/{name}/iac envelope.
+// The FE reads only blueprintYaml (catalog.api.ts getCatalogBlueprintIaC);
+// path + source are diagnostic — source names which truth the seed came from
+// so a walk can tell a verbatim committed read from a re-canonicalized one.
+type catalogIaCSeedResponse struct {
+	BlueprintYaml string `json:"blueprintYaml"`
+	Path          string `json:"path"`
+	// Source is one of:
+	//   "committed"               — the committed file, already canonical, verbatim;
+	//   "committed-canonicalized" — a stale pre-#5115 committed file, re-served
+	//                               through the canonical CR serializer;
+	//   "live-cr"                 — nothing committed yet; the catalog-resolved
+	//                               CR through the same canonical serializer.
+	Source string `json:"source"`
+}
+
 // HandleGetCatalogBlueprintIaC — GET /api/v1/catalog/{name}/iac.
 //
-// Returns the CURRENTLY-COMMITTED catalog-sovereign/<repo>/blueprint.yaml — the
-// same file the PUT (HandleCatalogBlueprintIaCEdit) writes and the card-form save
-// commits, resolved via the same resolveCatalogEditRepo seam. #5124: the Edit-IaC
-// editor previously seeded from the store's stale CatalogItem.raw, so committing
-// from that seed silently reverted prior card-form edits (icon/title/summary) that
-// were already in the committed file. The FE seeds the editor from THIS endpoint
-// (the source of truth), falling back to its store raw only when nothing is
-// committed yet (404). Read-only.
+// Returns the Edit-IaC editor SEED: the CURRENTLY-COMMITTED
+// catalog-sovereign/<repo>/blueprint.yaml (the same file the PUT and the
+// card-form save write, resolved via the same resolveCatalogEditRepo seam),
+// always in the #5115 canonical Blueprint CR shape.
+//
+// #5124 (hw256 V6 walk, UAT row 130): the Edit-IaC editor originally seeded
+// from the store's stale CatalogItem.raw — the pre-#5115 shape (bare `alloy`
+// metadata.name, no spec.version, no Helm ownership labels, no card fields) —
+// so an IaC Commit from that seed silently reverted card-form edits already in
+// the committed file. Serving the committed file (first pass of this endpoint)
+// closed the main path, but two stale-seed legs remained, both closed here:
+//
+//  1. A committed file that PREDATES #5115 (bare name / server-side metadata
+//     junk / #4415-stripped spec.version) was returned VERBATIM — the editor
+//     opened the stale shape. It is now re-canonicalized on read through the
+//     SAME serializer every commit leg uses (stampBlueprintCRForFluxAggregator,
+//     #5113/#5115), with spec.version refilled from the catalog-resolved
+//     blueprint when the stale file lost it, so the served seed always passes
+//     the PUT's validateCatalogBlueprintYAML gate. An already-canonical file
+//     is returned verbatim (authored fidelity preserved).
+//  2. Nothing committed yet returned 404 and the FE fell back to the stale
+//     store raw — the exact defect signature. The endpoint now serves the
+//     catalog-resolved CR (chainedCatalogClient: Gitea seed → in-cluster live
+//     CR) through the same canonical serializer instead; 404 remains only
+//     when neither source resolves, so the FE's raw fallback is a last resort
+//     for a blueprint the whole platform cannot see.
+//
+// Read-only — this endpoint never writes; the canonical shape lands in Gitea
+// on the next commit (which re-canonicalizes the aggregator leg regardless).
 func (h *Handler) HandleGetCatalogBlueprintIaC(w http.ResponseWriter, r *http.Request) {
-	name := chi.URLParam(r, "name")
-	if name == "" {
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	bpName := catalogEditBlueprintName(name)
+	if bpName == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing-name"})
 		return
 	}
@@ -222,22 +260,155 @@ func (h *Handler) HandleGetCatalogBlueprintIaC(w http.ResponseWriter, r *http.Re
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
-	repo := h.resolveCatalogEditRepo(ctx, name)
+	repo := h.resolveCatalogEditRepo(ctx, bpName)
+	path := fmt.Sprintf("catalog-sovereign/%s/%s", repo, catalogEditBlueprintPath)
 	f, err := h.giteaClient.GetFile(ctx, catalogSovereignOrg, repo, catalogEditGitBranch, catalogEditBlueprintPath)
-	if err != nil {
-		// Not committed yet — the FE falls back to its store raw / live CR.
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not-committed", "detail": err.Error()})
+	if err == nil {
+		raw, derr := f.Decoded()
+		if derr != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "decode-failed", "detail": derr.Error()})
+			return
+		}
+		if catalogIaCSeedIsCanonical(raw, bpName) {
+			writeJSON(w, http.StatusOK, catalogIaCSeedResponse{
+				BlueprintYaml: string(raw),
+				Path:          path,
+				Source:        "committed",
+			})
+			return
+		}
+		// Stale pre-#5115 committed shape — re-canonicalize on read so the
+		// editor opens the current canonical CR, never the stale document.
+		if canonical := h.recanonicalizeCommittedIaCSeed(ctx, raw, bpName); len(canonical) > 0 {
+			writeJSON(w, http.StatusOK, catalogIaCSeedResponse{
+				BlueprintYaml: string(canonical),
+				Path:          path,
+				Source:        "committed-canonicalized",
+			})
+			return
+		}
+		// Un-parsable committed document (out-of-band push) — return it
+		// verbatim rather than fabricating a blank; the PUT's validation
+		// will name the parse failure if the admin commits it unchanged.
+		writeJSON(w, http.StatusOK, catalogIaCSeedResponse{
+			BlueprintYaml: string(raw),
+			Path:          path,
+			Source:        "committed",
+		})
 		return
 	}
-	raw, derr := f.Decoded()
-	if derr != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "decode-failed", "detail": derr.Error()})
+	// Nothing committed yet (or the read failed) — #5124: NEVER hand the FE
+	// back to its stale store raw when the blueprint resolves. Serve the
+	// catalog-resolved CR through the same canonical serializer.
+	if seed := h.canonicalIaCSeedFromCatalog(ctx, bpName); len(seed) > 0 {
+		writeJSON(w, http.StatusOK, catalogIaCSeedResponse{
+			BlueprintYaml: string(seed),
+			Path:          path,
+			Source:        "live-cr",
+		})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{
-		"blueprintYaml": string(raw),
-		"path":          fmt.Sprintf("catalog-sovereign/%s/%s", repo, catalogEditBlueprintPath),
-	})
+	writeJSON(w, http.StatusNotFound, map[string]string{"error": "not-committed", "detail": err.Error()})
+}
+
+// catalogIaCSeedIsCanonical reports whether a committed blueprint.yaml already
+// carries the #5115 canonical Blueprint CR shape: the canonical bp-<slug>
+// metadata.name, a non-empty spec.version, and none of the server-side fields
+// the canonical serializer scrubs (blueprintCRServerSideMetadataFields, status,
+// the last-applied annotation). A canonical file is served VERBATIM (authored
+// field order / comments preserved); anything else is the stale pre-#5115
+// shape and gets re-canonicalized on read.
+func catalogIaCSeedIsCanonical(raw []byte, bpName string) bool {
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil || doc == nil {
+		return false
+	}
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || asString(meta["name"]) != bpName {
+		return false
+	}
+	for _, k := range blueprintCRServerSideMetadataFields {
+		if _, present := meta[k]; present {
+			return false
+		}
+	}
+	if ann, ok := meta["annotations"].(map[string]interface{}); ok {
+		if _, present := ann["kubectl.kubernetes.io/last-applied-configuration"]; present {
+			return false
+		}
+	}
+	if _, present := doc["status"]; present {
+		return false
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	return spec != nil && strings.TrimSpace(asString(spec["version"])) != ""
+}
+
+// recanonicalizeCommittedIaCSeed re-serves a STALE pre-#5115 committed
+// blueprint.yaml through the canonical CR serializer (the same
+// stampBlueprintCRMapForFluxAggregator every commit leg uses): metadata.name
+// stamped to the canonical bp-<slug> identity, server-side metadata scrubbed,
+// Helm ownership labels preserved. When the stale file lost spec.version (the
+// pre-#5115 #4415 delivery-field strip), it is refilled from the
+// catalog-resolved blueprint so the served seed passes the PUT's
+// validateCatalogBlueprintYAML gate instead of 400ing the admin's commit.
+// Returns nil on an un-parsable document (the caller then serves the raw
+// bytes verbatim).
+func (h *Handler) recanonicalizeCommittedIaCSeed(ctx context.Context, raw []byte, bpName string) []byte {
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil || doc == nil {
+		return nil
+	}
+	if blueprintSpecVersionMissing(doc) && h.catalogClient != nil {
+		if bp, err := h.catalogClient.Get(ctx, bpName, ""); err == nil && bp != nil {
+			fillBlueprintSpecVersion(doc, bp.Version)
+		}
+	}
+	return stampBlueprintCRMapForFluxAggregator(doc, bpName)
+}
+
+// canonicalIaCSeedFromCatalog resolves the blueprint via the catalog client
+// (chainedCatalogClient: Gitea seed → in-cluster live CR — the same full-spec
+// source the card path's first-edit seed uses, #3668 §5A) and renders it
+// through the canonical CR serializer, refilling spec.version from the
+// resolved catalog version when the Raw document lacks it. Returns nil when
+// the client is unwired or the blueprint cannot be resolved — the caller then
+// 404s and the FE falls back to its store raw as a true last resort.
+func (h *Handler) canonicalIaCSeedFromCatalog(ctx context.Context, bpName string) []byte {
+	if h.catalogClient == nil {
+		return nil
+	}
+	bp, err := h.catalogClient.Get(ctx, bpName, "")
+	if err != nil || bp == nil || len(bp.Raw) == 0 {
+		return nil
+	}
+	doc := deepCopyYAMLMap(bp.Raw)
+	fillBlueprintSpecVersion(doc, bp.Version)
+	return stampBlueprintCRMapForFluxAggregator(doc, bpName)
+}
+
+// blueprintSpecVersionMissing reports whether a decoded Blueprint CR map lacks
+// a non-empty spec.version (the CRD-required field the pre-#5115 #4415 strip
+// removed from committed files).
+func blueprintSpecVersionMissing(doc map[string]interface{}) bool {
+	spec, _ := doc["spec"].(map[string]interface{})
+	return spec == nil || strings.TrimSpace(asString(spec["version"])) == ""
+}
+
+// fillBlueprintSpecVersion sets spec.version to the supplied version when the
+// document lacks one. Never overwrites an authored version — the admin owns
+// an explicit spec.version (DoD §9.7).
+func fillBlueprintSpecVersion(doc map[string]interface{}, version string) {
+	v := strings.TrimSpace(version)
+	if v == "" || !blueprintSpecVersionMissing(doc) {
+		return
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil {
+		spec = map[string]interface{}{}
+		doc["spec"] = spec
+	}
+	spec["version"] = v
 }
 
 // writeCatalogFullBlueprintToGit commits the FULL supplied blueprint.yaml to
@@ -337,6 +508,16 @@ func (h *Handler) resolveCatalogEditRepo(ctx context.Context, bpName string) str
 func stampBlueprintCRForFluxAggregator(raw []byte, bpName string) []byte {
 	var doc map[string]interface{}
 	if err := yamlv3.Unmarshal(raw, &doc); err != nil || doc == nil {
+		return nil
+	}
+	return stampBlueprintCRMapForFluxAggregator(doc, bpName)
+}
+
+// stampBlueprintCRMapForFluxAggregator is the map-level entry of the canonical
+// serializer above, shared with the #5124 Edit-IaC seed paths (which decode
+// first to refill a stripped spec.version before canonicalizing). MUTATES doc.
+func stampBlueprintCRMapForFluxAggregator(doc map[string]interface{}, bpName string) []byte {
+	if doc == nil {
 		return nil
 	}
 	if meta, ok := doc["metadata"].(map[string]interface{}); ok {

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit_test.go
@@ -425,7 +425,12 @@ func TestCatalogIaCEdit_MothershipSkipsAggregatorLeg(t *testing.T) {
 // edits (icon/title/summary) already present in the committed blueprint.yaml.
 // This GET returns the CURRENTLY-COMMITTED file — the same one the PUT writes,
 // resolved via the SAME resolveCatalogEditRepo seam — so the FE seeds the
-// editor from the source of truth (falling back to store raw only on 404).
+// editor from the source of truth. Two stale-seed legs are additionally pinned
+// below: a committed file that PREDATES #5115 (bare metadata.name, stripped
+// spec.version, server-side metadata junk) is re-canonicalized ON READ through
+// the same serializer every commit leg uses, and a not-yet-committed blueprint
+// is seeded from the catalog-resolved CR through that serializer instead of
+// 404ing the FE back onto its stale store raw (the exact hw256 defect).
 
 // callGetCatalogIaC drives GET /api/v1/catalog/{name}/iac through a chi router
 // so the {name} URL param resolves.
@@ -439,8 +444,9 @@ func callGetCatalogIaC(t *testing.T, h *Handler, name string) *httptest.Response
 	return rec
 }
 
-// TestGetCatalogIaC_ReturnsCommittedFile — the committed blueprint.yaml is
-// returned verbatim (the seed source of truth), NOT the stale store raw.
+// TestGetCatalogIaC_ReturnsCommittedFile — an already-CANONICAL committed
+// blueprint.yaml is returned verbatim (authored fidelity preserved), NOT the
+// stale store raw.
 func TestGetCatalogIaC_ReturnsCommittedFile(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	fg := newFakeGitea()
@@ -463,18 +469,22 @@ func TestGetCatalogIaC_ReturnsCommittedFile(t *testing.T) {
 	if resp["path"] != "catalog-sovereign/bp-alloy/blueprint.yaml" {
 		t.Errorf("path: got %q", resp["path"])
 	}
+	if resp["source"] != "committed" {
+		t.Errorf("a canonical committed file is served verbatim as source=committed; got %q", resp["source"])
+	}
 }
 
 // TestGetCatalogIaC_ResolvesBareRepo — when the committed file lives in the
 // BARE-named repo (the #4896/#4997 bare↔bp- divergence), the resolver finds it
-// and the GET returns it, exactly as the PUT read path does.
+// exactly as the PUT read path does. The bare-named document is a stale
+// pre-#5115 shape, so the served seed is the CANONICALIZED CR (name stamped
+// bp-alloy) — never the bare document the #5124 walk seeded from.
 func TestGetCatalogIaC_ResolvesBareRepo(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	fg := newFakeGitea()
 	h.SetGiteaClient(fg)
 
-	committed := bareAlloyBlueprintYAML("3.2.1")
-	fg.files[giteaKey(catalogSovereignOrg, "alloy", catalogEditGitBranch, catalogEditBlueprintPath)] = []byte(committed)
+	fg.files[giteaKey(catalogSovereignOrg, "alloy", catalogEditGitBranch, catalogEditBlueprintPath)] = []byte(bareAlloyBlueprintYAML("3.2.1"))
 
 	rec := callGetCatalogIaC(t, h, "bp-alloy")
 	if rec.Code != http.StatusOK {
@@ -482,16 +492,210 @@ func TestGetCatalogIaC_ResolvesBareRepo(t *testing.T) {
 	}
 	var resp map[string]string
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
-	if resp["blueprintYaml"] != committed {
-		t.Errorf("bare-repo committed file must be returned; got=%q", resp["blueprintYaml"])
-	}
 	if resp["path"] != "catalog-sovereign/alloy/blueprint.yaml" {
 		t.Errorf("path must reflect the resolved bare repo; got %q", resp["path"])
 	}
+	if resp["source"] != "committed-canonicalized" {
+		t.Errorf("a bare-named committed file is a stale shape ⇒ source=committed-canonicalized; got %q", resp["source"])
+	}
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal([]byte(resp["blueprintYaml"]), &doc); err != nil {
+		t.Fatalf("served seed did not parse: %v", err)
+	}
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || asString(meta["name"]) != "bp-alloy" {
+		t.Errorf("served seed must carry the canonical bp-alloy identity; metadata=%v", meta)
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil || asString(spec["version"]) != "3.2.1" {
+		t.Errorf("authored spec.version must survive canonicalization; spec=%v", spec)
+	}
+	if _, ok := spec["source"].(map[string]interface{}); !ok {
+		t.Errorf("full spec must survive canonicalization; spec=%v", spec)
+	}
 }
 
-// TestGetCatalogIaC_404WhenNotCommitted — nothing committed yet ⇒ 404 so the
-// FE knows to fall back to its store raw / live CR (never a fabricated blank).
+// staleAlloyPre5115CommittedYAML is the EXACT hw256 #5124 stale-seed
+// signature, as a committed pre-#5115 file: bare `alloy` metadata.name, NO
+// spec.version (the #4415 delivery-field strip), server-side metadata junk
+// (uid/resourceVersion/last-applied) + status, Helm ownership labels present,
+// and the card fields a prior card-form save committed. Opening the editor on
+// THIS document and committing is what reverted the walk's card edits.
+const staleAlloyPre5115CommittedYAML = `apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: alloy
+  uid: 8f0e2c1d-aaaa-bbbb-cccc-0123456789ab
+  resourceVersion: "123456"
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: catalyst-platform
+    kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"catalyst.openova.io/v1"}'
+spec:
+  card:
+    title: Grafana Alloy
+    summary: Walk-edited summary (prior card-form save)
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-alloy
+status:
+  phase: Ready
+`
+
+// TestGetCatalogIaC_RecanonicalizesStalePre5115Seed — the #5124 regression
+// guard: a committed file carrying the stale pre-#5115 raw shape is re-served
+// through the canonical CR serializer — name stamped bp-alloy, server junk
+// scrubbed, Helm ownership labels kept, the stripped spec.version refilled
+// from the catalog-resolved blueprint, and the prior card-form edits INTACT —
+// and the served seed then commits cleanly through the PUT (it passes
+// validateCatalogBlueprintYAML), so a commit from the editor seed can never
+// again regress card edits or 400 on a shape the read path itself produced.
+func TestGetCatalogIaC_RecanonicalizesStalePre5115Seed(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "") // mothership shape — isolates the seed/commit round-trip
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+	h.SetCatalogClient(newFakeCatalog(&CatalogBlueprint{Name: "bp-alloy", Version: "1.0.7"}))
+
+	perBP := giteaKey(catalogSovereignOrg, "bp-alloy", catalogEditGitBranch, catalogEditBlueprintPath)
+	fg.files[perBP] = []byte(staleAlloyPre5115CommittedYAML)
+
+	rec := callGetCatalogIaC(t, h, "bp-alloy")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp["source"] != "committed-canonicalized" {
+		t.Errorf("stale pre-#5115 file must be re-canonicalized on read; source=%q", resp["source"])
+	}
+	seed := resp["blueprintYaml"]
+
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal([]byte(seed), &doc); err != nil {
+		t.Fatalf("served seed did not parse: %v", err)
+	}
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || asString(meta["name"]) != "bp-alloy" {
+		t.Errorf("bare `alloy` must open as the canonical bp-alloy CR; metadata=%v", meta)
+	}
+	for _, k := range []string{"uid", "resourceVersion"} {
+		if _, present := meta[k]; present {
+			t.Errorf("server-side metadata.%s must be scrubbed from the seed; metadata=%v", k, meta)
+		}
+	}
+	if ann, _ := meta["annotations"].(map[string]interface{}); ann != nil {
+		if _, present := ann["kubectl.kubernetes.io/last-applied-configuration"]; present {
+			t.Errorf("last-applied annotation must be scrubbed from the seed; annotations=%v", ann)
+		}
+		if asString(ann["meta.helm.sh/release-name"]) != "catalyst-platform" {
+			t.Errorf("Helm ownership annotations must be PRESERVED (#5113 Facet E); annotations=%v", ann)
+		}
+	} else {
+		t.Errorf("Helm ownership annotations must survive canonicalization; metadata=%v", meta)
+	}
+	if lbl, _ := meta["labels"].(map[string]interface{}); lbl == nil || asString(lbl["app.kubernetes.io/managed-by"]) != "Helm" {
+		t.Errorf("Helm ownership labels must survive canonicalization; metadata=%v", meta)
+	}
+	if _, present := doc["status"]; present {
+		t.Errorf("status must be scrubbed from the seed")
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil || asString(spec["version"]) != "1.0.7" {
+		t.Errorf("the #4415-stripped spec.version must be refilled from the catalog-resolved blueprint; spec=%v", spec)
+	}
+	card, _ := spec["card"].(map[string]interface{})
+	if card == nil || asString(card["summary"]) != "Walk-edited summary (prior card-form save)" {
+		t.Errorf("prior card-form edits must be INTACT in the seed (the #5124 regression); card=%v", card)
+	}
+
+	// The served seed passes the PUT's validation gate…
+	if msg, ok := validateCatalogBlueprintYAML([]byte(seed), "bp-alloy"); !ok {
+		t.Fatalf("the served seed must pass validateCatalogBlueprintYAML; rejected: %s", msg)
+	}
+	// …and an UNMODIFIED commit of it round-trips without dropping the card
+	// fields — the exact silent-revert the hw256 walk hit.
+	put := callCatalogIaCEdit(t, h, "bp-alloy", `{"blueprintYaml":`+jsonQuote(seed)+`}`, adminClaims())
+	if put.Code != http.StatusOK {
+		t.Fatalf("committing the served seed must succeed; got %d body=%s", put.Code, put.Body.String())
+	}
+	var after map[string]interface{}
+	if err := yamlv3.Unmarshal(fg.files[perBP], &after); err != nil {
+		t.Fatalf("re-committed file did not parse: %v", err)
+	}
+	afterSpec, _ := after["spec"].(map[string]interface{})
+	afterCard, _ := afterSpec["card"].(map[string]interface{})
+	if afterCard == nil || asString(afterCard["summary"]) != "Walk-edited summary (prior card-form save)" {
+		t.Errorf("a commit from the editor seed must never regress card edits; committed card=%v", afterCard)
+	}
+}
+
+// TestGetCatalogIaC_SeedsFromLiveCRWhenNotCommitted — nothing committed yet:
+// instead of 404ing the FE back onto its stale store raw (the #5124 defect
+// signature), the endpoint serves the catalog-resolved CR through the SAME
+// canonical serializer — name stamped, server junk scrubbed, spec.version
+// filled from the resolved catalog version.
+func TestGetCatalogIaC_SeedsFromLiveCRWhenNotCommitted(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+	h.SetCatalogClient(newFakeCatalog(&CatalogBlueprint{
+		Name:    "bp-alloy",
+		Version: "1.0.2",
+		Raw: map[string]interface{}{
+			"apiVersion": "catalyst.openova.io/v1",
+			"kind":       "Blueprint",
+			"metadata": map[string]interface{}{
+				"name":            "alloy", // the stale bare shape the store raw carried
+				"uid":             "abc-123",
+				"resourceVersion": "42",
+			},
+			"spec": map[string]interface{}{
+				"card":   map[string]interface{}{"title": "Grafana Alloy", "summary": "Telemetry collector"},
+				"source": map[string]interface{}{"chart": "bp-alloy"},
+			},
+			"status": map[string]interface{}{"phase": "Ready"},
+		},
+	}))
+
+	rec := callGetCatalogIaC(t, h, "bp-alloy")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a resolvable blueprint must seed from the live CR, not 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp["source"] != "live-cr" {
+		t.Errorf("source: got %q want live-cr", resp["source"])
+	}
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal([]byte(resp["blueprintYaml"]), &doc); err != nil {
+		t.Fatalf("served seed did not parse: %v", err)
+	}
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || asString(meta["name"]) != "bp-alloy" {
+		t.Errorf("live-CR seed must carry the canonical bp-alloy identity; metadata=%v", meta)
+	}
+	if _, present := meta["uid"]; present {
+		t.Errorf("server-side metadata must be scrubbed from the live-CR seed; metadata=%v", meta)
+	}
+	if _, present := doc["status"]; present {
+		t.Errorf("status must be scrubbed from the live-CR seed")
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil || asString(spec["version"]) != "1.0.2" {
+		t.Errorf("spec.version must be filled from the resolved catalog version; spec=%v", spec)
+	}
+	if msg, ok := validateCatalogBlueprintYAML([]byte(resp["blueprintYaml"]), "bp-alloy"); !ok {
+		t.Errorf("the live-CR seed must pass validateCatalogBlueprintYAML; rejected: %s", msg)
+	}
+}
+
+// TestGetCatalogIaC_404WhenNotCommitted — nothing committed AND no catalog
+// client to resolve the CR ⇒ 404 so the FE knows to fall back to its store
+// raw as a true last resort (never a fabricated blank).
 func TestGetCatalogIaC_404WhenNotCommitted(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	fg := newFakeGitea()


### PR DESCRIPTION
## Root cause (#5124, hw256 V6 walk / UAT row 130)

The Edit-IaC editor seeded from the stale pre-#5115 `CatalogItem.raw` shape (bp-alloy opened as bare `alloy`, no `spec.version`, no Helm ownership labels), so an IaC Commit silently reverted prior card-form edits. The #5115 server serializer re-canonicalizes on commit, so no CR damage occurs — the defect is editor-seed staleness only. The first #5124 pass (PR #5164) added `GET /api/v1/catalog/{name}/iac` serving the committed file, but two stale-seed legs remained:

1. A committed file that PREDATES #5115 (bare name / server-side metadata junk / #4415-stripped `spec.version`) was returned VERBATIM — the editor still opened the stale shape.
2. Nothing-committed returned 404 and the FE fell back to the stale store raw — the exact defect signature.

## Fix — all in `products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go`

Every served seed now goes through the #5115 canonical Blueprint CR serializer:

- **Stale committed file → re-canonicalized on read** via the same `stampBlueprintCRMapForFluxAggregator` seam every commit leg uses (name stamped `bp-<slug>`, `uid`/`resourceVersion`/`status`/last-applied scrubbed, Helm ownership labels/annotations PRESERVED per #5113 Facet E), with the stripped `spec.version` refilled from the catalog-resolved blueprint so the seed always passes the PUT's `validateCatalogBlueprintYAML` gate.
- **Already-canonical committed file → verbatim** (authored fidelity preserved).
- **Not committed yet → catalog-resolved CR** (`chainedCatalogClient`: Gitea seed → in-cluster live CR) through the same serializer, instead of 404ing the FE onto its stale store raw. 404 remains only when neither source resolves — the FE raw fallback becomes a true last resort.
- Response gains a diagnostic `source` field (`committed` / `committed-canonicalized` / `live-cr`); the FE reads only `blueprintYaml`, so the wire contract is backward-compatible with the shipped console.

Read-only endpoint — the canonical shape lands in Gitea on the next commit (which re-canonicalizes the aggregator leg regardless), so no one-shot migration write is needed.

## Regression tests (`catalog_iac_edit_test.go`)

- `TestGetCatalogIaC_RecanonicalizesStalePre5115Seed` — the EXACT hw256 stale signature as a committed file (bare name, no `spec.version`, uid/resourceVersion/status/last-applied junk, Helm ownership labels, prior card-form edits) → served seed is canonical, version refilled, card fields INTACT; then an UNMODIFIED PUT of the served seed commits 200 and the card fields survive in the committed file — the silent-revert this issue is about.
- `TestGetCatalogIaC_SeedsFromLiveCRWhenNotCommitted` — resolvable blueprint with nothing committed serves the canonicalized live CR (source `live-cr`), never 404.
- `TestGetCatalogIaC_ResolvesBareRepo` — updated: a bare-named committed file (stale shape) now serves the canonicalized CR from the resolved bare repo.
- Existing verbatim/404/503 + PUT round-trip guards all still pass unchanged.

## Gates

- `go build ./...` + `go vet ./...` + `go test ./... -count=1` — all green on `products/catalyst/bootstrap/api`.
- Go-module-only change: no chart version bump, no pin moves required.

Refs #5124

🤖 Generated with [Claude Code](https://claude.com/claude-code)