### PR TITLE
fix(bp-postgres,continuum): single-source pair role passwords + CNPG managed-roles re-assert on primary transition (Refs #5224)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -155,7 +155,11 @@ spec:
       # (#4442). Lockstep with 16c/16d.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16c/16d.
-      version: 0.2.12
+      # 0.2.13 (#5224, Refs #5220 #4915): role-secrets side-gate — a region
+      # stamped side=secondary NEVER mints role/hub Secrets (incl. the #4460
+      # pre-flip window); the pair's password set is single-sourced from
+      # region-A. Lockstep with the other 16* bp-postgres slots.
+      version: 0.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -93,7 +93,11 @@ spec:
       # moment the mesh peers. Lockstep with 16a/16d.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16d.
-      version: 0.2.12
+      # 0.2.13 (#5224, Refs #5220 #4915): role-secrets side-gate — a region
+      # stamped side=secondary NEVER mints role/hub Secrets (incl. the #4460
+      # pre-flip window); the pair's password set is single-sourced from
+      # region-A. Lockstep with the other 16* bp-postgres slots.
+      version: 0.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -81,7 +81,11 @@ spec:
       # openova-flow hosts resolve the moment the mesh peers. Lockstep 16a/16c.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16c.
-      version: 0.2.12
+      # 0.2.13 (#5224, Refs #5220 #4915): role-secrets side-gate — a region
+      # stamped side=secondary NEVER mints role/hub Secrets (incl. the #4460
+      # pre-flip window); the pair's password set is single-sourced from
+      # region-A. Lockstep with the other 16* bp-postgres slots.
+      version: 0.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/core/controllers/continuum/internal/cnpg/roles.go
+++ b/core/controllers/continuum/internal/cnpg/roles.go
@@ -1,0 +1,136 @@
+// Managed-role password re-assert through CNPG's OWN contract (#5224,
+// Refs #5220 #4915 — the hw273 harbor 28P01 lockout).
+//
+// CNPG reconciles a managed role's password FROM the Secret named by
+// `spec.managed.roles[].passwordSecret`, and it detects drift ONLY via
+// that Secret's resourceVersion (status.managedRolesStatus records the
+// rv it last applied). An OUT-OF-BAND `ALTER ROLE` on the database —
+// the hw273 G12 promote-flap casualty, where the shared primary's
+// `harbor` role was asserted with the replica region's divergent
+// locally-minted password — is therefore INVISIBLE to CNPG: the status
+// stays "reconciled" at the old rv while the database rejects the very
+// password that Secret carries, and every consumer's NEW connection
+// fails with SQLSTATE 28P01 until an operator touches the Secret by
+// hand.
+//
+// ReassertManagedRoles is the structured form of that manual heal: a
+// metadata-only annotation bump on each referenced passwordSecret
+// changes its resourceVersion WITHOUT changing the credential bytes,
+// which forces CNPG's role reconciler to re-apply the canonical
+// password (its own ALTER ROLE, on the cluster it manages). This is
+// the ONLY sanctioned role-password assertion path for the DR
+// promote/failback machinery — Continuum/dr actors must NEVER issue
+// direct SQL against the shared write endpoint (they cannot know which
+// region's Secret set is authoritative mid-flap; CNPG + the primary
+// region's Secret always are).
+package cnpg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SecretGVR — core-v1 Secrets via the same dynamic client the Reader
+// already holds (ADR-0001 §2.7 forbids typed CNPG bindings; staying
+// dynamic-only here keeps the package's client surface uniform).
+var SecretGVR = schema.GroupVersionResource{Version: "v1", Resource: "secrets"}
+
+// RoleReassertAnnotation is stamped (with the touch timestamp) on each
+// managed-role passwordSecret ReassertManagedRoles touches. The VALUE
+// changing is what bumps the Secret's resourceVersion; the key doubles
+// as the operator-visible audit trail of when the DR machinery last
+// forced a canonical re-apply.
+const RoleReassertAnnotation = "catalyst.openova.io/dr-role-reassert-at"
+
+// ManagedRolePasswordSecrets returns the DEDUPED list of Secret names
+// referenced by `spec.managed.roles[].passwordSecret.name` on a CNPG
+// Cluster CR, in spec order. Nil/absent spec.managed.roles → nil (a
+// replica-half CR carries no managed roles — bp-postgres
+// replica-cluster.yaml — and must yield a clean no-op).
+func ManagedRolePasswordSecrets(cr *unstructured.Unstructured) []string {
+	if cr == nil {
+		return nil
+	}
+	roles, found, err := unstructured.NestedSlice(cr.Object, "spec", "managed", "roles")
+	if !found || err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, ri := range roles {
+		rm, ok := ri.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(rm, "passwordSecret", "name")
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+// ReassertManagedRoles touches every managed-role passwordSecret the
+// named Cluster CR references (RoleReassertAnnotation = `at`, in the
+// CR's namespace — CNPG requires passwordSecrets co-located with the
+// Cluster) so each Secret's resourceVersion changes and CNPG re-applies
+// the canonical password on the cluster it manages.
+//
+// Semantics:
+//   - Idempotent + credential-preserving: only annotation metadata
+//     changes; the password bytes are untouched, so a re-assert against
+//     an already-canonical role is a harmless same-value ALTER.
+//   - A MISSING referenced Secret is SKIPPED, not an error: a
+//     replica-role region never mints role Secrets (bp-postgres ≥0.2.13
+//     side-gate, the #4915-class single-sourcing), so dangling refs on
+//     a pre-flip placeholder CR are an expected shape.
+//   - Per-Secret API failures are aggregated (errors.Join) and the
+//     remaining Secrets still processed — the caller retries on its
+//     next tick, so a transient conflict self-heals.
+//
+// Returns the names actually touched.
+func (r *Reader) ReassertManagedRoles(ctx context.Context, namespace, name string, at time.Time) ([]string, error) {
+	if r == nil || r.Dyn == nil {
+		return nil, errors.New("cnpg: nil Reader")
+	}
+	cr, err := r.Dyn.Resource(ClusterGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("cnpg: get cluster for role re-assert %s/%s: %w", namespace, name, err)
+	}
+	stamp := at.UTC().Format(time.RFC3339)
+	var touched []string
+	var errs []error
+	for _, secretName := range ManagedRolePasswordSecrets(cr) {
+		sec, gErr := r.Dyn.Resource(SecretGVR).Namespace(namespace).Get(ctx, secretName, metav1.GetOptions{})
+		if apierrors.IsNotFound(gErr) {
+			// Replica-role regions carry no local role Secrets by design
+			// (single-sourced from the primary region) — skip, no error.
+			continue
+		}
+		if gErr != nil {
+			errs = append(errs, fmt.Errorf("cnpg: get passwordSecret %s/%s: %w", namespace, secretName, gErr))
+			continue
+		}
+		ann := sec.GetAnnotations()
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		ann[RoleReassertAnnotation] = stamp
+		sec.SetAnnotations(ann)
+		if _, uErr := r.Dyn.Resource(SecretGVR).Namespace(namespace).Update(ctx, sec, metav1.UpdateOptions{}); uErr != nil {
+			errs = append(errs, fmt.Errorf("cnpg: touch passwordSecret %s/%s: %w", namespace, secretName, uErr))
+			continue
+		}
+		touched = append(touched, secretName)
+	}
+	return touched, errors.Join(errs...)
+}

--- a/core/controllers/continuum/internal/cnpg/roles_test.go
+++ b/core/controllers/continuum/internal/cnpg/roles_test.go
@@ -1,0 +1,174 @@
+// Tests for #5224 — managed-role password re-assert through CNPG's
+// passwordSecret-resourceVersion contract (the hw273 harbor 28P01
+// lockout heal, structured).
+
+package cnpg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func gvrListMapWithSecrets() map[schema.GroupVersionResource]string {
+	m := gvrListMap()
+	m[SecretGVR] = "SecretList"
+	return m
+}
+
+// newClusterWithManagedRoles builds a CNPG Cluster CR carrying
+// spec.managed.roles entries — the bp-postgres cluster.yaml shape
+// (one role per unique owner, passwordSecret per role).
+func newClusterWithManagedRoles(ns, name string, roleToSecret map[string]string) *unstructured.Unstructured {
+	c := newCluster(ns, name, nil, nil, false)
+	roles := []interface{}{}
+	for role, secret := range roleToSecret {
+		entry := map[string]interface{}{
+			"name":   role,
+			"ensure": "present",
+			"login":  true,
+		}
+		if secret != "" {
+			entry["passwordSecret"] = map[string]interface{}{"name": secret}
+		}
+		roles = append(roles, entry)
+	}
+	_ = unstructured.SetNestedSlice(c.Object, roles, "spec", "managed", "roles")
+	return c
+}
+
+func newRoleSecret(ns, name string) *unstructured.Unstructured {
+	s := &unstructured.Unstructured{}
+	s.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Secret"})
+	s.SetNamespace(ns)
+	s.SetName(name)
+	_ = unstructured.SetNestedStringMap(s.Object, map[string]string{
+		"username": "harbor",
+		"password": "canonical-password",
+	}, "stringData")
+	return s
+}
+
+func TestManagedRolePasswordSecrets_ParsesAndDedupes(t *testing.T) {
+	t.Parallel()
+	c := newCluster("shared-data", "shared-pg", nil, nil, false)
+	_ = unstructured.SetNestedSlice(c.Object, []interface{}{
+		map[string]interface{}{"name": "harbor", "passwordSecret": map[string]interface{}{"name": "shared-pg-harbor"}},
+		map[string]interface{}{"name": "gitea", "passwordSecret": map[string]interface{}{"name": "shared-pg-gitea"}},
+		// Duplicate secret ref (two roles sharing one Secret) — deduped.
+		map[string]interface{}{"name": "gitea_ro", "passwordSecret": map[string]interface{}{"name": "shared-pg-gitea"}},
+		// No passwordSecret at all — skipped.
+		map[string]interface{}{"name": "nopass"},
+	}, "spec", "managed", "roles")
+
+	got := ManagedRolePasswordSecrets(c)
+	want := []string{"shared-pg-harbor", "shared-pg-gitea"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+}
+
+func TestManagedRolePasswordSecrets_NoManagedRoles(t *testing.T) {
+	t.Parallel()
+	// The bp-postgres replica-half CR carries NO managed.roles — must be
+	// a clean nil (no-op re-assert), never a guess.
+	c := newCluster("shared-data", "shared-pg-replica", nil, nil, true)
+	if got := ManagedRolePasswordSecrets(c); got != nil {
+		t.Fatalf("replica-half CR: got %v want nil", got)
+	}
+	if got := ManagedRolePasswordSecrets(nil); got != nil {
+		t.Fatalf("nil CR: got %v want nil", got)
+	}
+}
+
+func TestReassertManagedRoles_TouchesSecretRV(t *testing.T) {
+	t.Parallel()
+	const ns = "shared-data"
+	cluster := newClusterWithManagedRoles(ns, "shared-pg", map[string]string{"harbor": "shared-pg-harbor"})
+	secret := newRoleSecret(ns, "shared-pg-harbor")
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMapWithSecrets(), cluster, secret)
+	r := NewReader(dyn)
+
+	at := time.Date(2026, 7, 18, 18, 35, 9, 0, time.UTC)
+	touched, err := r.ReassertManagedRoles(context.Background(), ns, "shared-pg", at)
+	if err != nil {
+		t.Fatalf("ReassertManagedRoles: %v", err)
+	}
+	if len(touched) != 1 || touched[0] != "shared-pg-harbor" {
+		t.Fatalf("touched = %v want [shared-pg-harbor]", touched)
+	}
+
+	got, gErr := dyn.Resource(SecretGVR).Namespace(ns).Get(context.Background(), "shared-pg-harbor", metav1.GetOptions{})
+	if gErr != nil {
+		t.Fatalf("readback: %v", gErr)
+	}
+	ann := got.GetAnnotations()
+	if ann[RoleReassertAnnotation] != "2026-07-18T18:35:09Z" {
+		t.Fatalf("annotation = %q want the RFC3339 touch stamp", ann[RoleReassertAnnotation])
+	}
+	// The credential bytes must be UNTOUCHED — the re-assert is a
+	// metadata-only rv bump, never a rotation.
+	pw, _, _ := unstructured.NestedString(got.Object, "stringData", "password")
+	if pw != "canonical-password" {
+		t.Fatalf("password bytes changed: %q — the re-assert must never rotate the credential", pw)
+	}
+}
+
+func TestReassertManagedRoles_MissingSecretSkipped(t *testing.T) {
+	t.Parallel()
+	const ns = "shared-data"
+	// The pre-flip placeholder shape: the CR references role Secrets a
+	// replica-role region never mints (bp-postgres >=0.2.13 side-gate).
+	// Missing Secrets are SKIPPED — no error, no touch.
+	cluster := newClusterWithManagedRoles(ns, "shared-pg", map[string]string{"harbor": "shared-pg-harbor"})
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMapWithSecrets(), cluster)
+	r := NewReader(dyn)
+
+	touched, err := r.ReassertManagedRoles(context.Background(), ns, "shared-pg", time.Now())
+	if err != nil {
+		t.Fatalf("missing Secret must be skipped, got error: %v", err)
+	}
+	if len(touched) != 0 {
+		t.Fatalf("touched = %v want none", touched)
+	}
+}
+
+func TestReassertManagedRoles_NoManagedRolesIsNoOp(t *testing.T) {
+	t.Parallel()
+	const ns = "shared-data"
+	cluster := newCluster(ns, "shared-pg-replica", nil, nil, true)
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMapWithSecrets(), cluster)
+	r := NewReader(dyn)
+
+	touched, err := r.ReassertManagedRoles(context.Background(), ns, "shared-pg-replica", time.Now())
+	if err != nil {
+		t.Fatalf("no managed roles must be a clean no-op, got: %v", err)
+	}
+	if len(touched) != 0 {
+		t.Fatalf("touched = %v want none", touched)
+	}
+}
+
+func TestReassertManagedRoles_ClusterAbsentErrors(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMapWithSecrets())
+	r := NewReader(dyn)
+	if _, err := r.ReassertManagedRoles(context.Background(), "ns", "absent", time.Now()); err == nil {
+		t.Fatal("absent Cluster CR must surface an error (caller retries next tick)")
+	}
+}

--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -177,6 +177,16 @@ type continuumGoroutine struct {
 	// pattern as lastSpecFingerprint above (a controller restart starts
 	// a fresh episode rather than persisting across restarts).
 	rejoinState switchover.RejoinState
+
+	// lastActingPrimary is the Cluster CR name this goroutine last
+	// observed ACTING as the pair's primary (live spec.replica.enabled,
+	// not the static pair-role label) AND successfully re-asserted
+	// managed-role passwords on (#5224, role_reassert.go). Empty on a
+	// fresh goroutine, so the first settled observation always fires one
+	// idempotent re-assert — deliberate: the per-CR goroutines restart
+	// during the very promote-flap incidents the re-assert heals (hw273
+	// 18:33:57Z), and a same-value re-apply has no consumer impact.
+	lastActingPrimary string
 }
 
 // SetupWithManager wires the reconciler into the controller-runtime
@@ -387,6 +397,15 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 					// safe no-op outside the region-a-resume-with-
 					// divergence scenario (rejoin.go).
 					r.checkRejoin(ctx, nn, reader, spec.CNPGNamespace, primary.GetName(), primaryStatus, replica.GetName(), replicaStatus)
+					// #5224 — canonical role-password re-assert on
+					// acting-primary transition (promote / failback /
+					// goroutine restart mid-flap). Touches the acting
+					// primary's managed-role passwordSecrets so CNPG
+					// re-applies the canonical passwords, healing any
+					// out-of-band role clobber (the hw273 harbor 28P01
+					// lockout) CNPG itself cannot detect. Same reused
+					// pair reads; role_reassert.go.
+					r.reassertRolesOnPrimaryTransition(ctx, nn, reader, spec.CNPGNamespace, primary.GetName(), primaryStatus, replica.GetName(), replicaStatus)
 				}
 			}
 		}

--- a/core/controllers/continuum/internal/controller/continuum_controller_test.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller_test.go
@@ -33,6 +33,7 @@ func gvrListKinds() map[schema.GroupVersionResource]string {
 	return map[schema.GroupVersionResource]string{
 		ContinuumGVR:            "ContinuumList",
 		cnpg.ClusterGVR:         "ClusterList",
+		cnpg.SecretGVR:          "SecretList",
 		switchover.HTTPRouteGVR: "HTTPRouteList",
 	}
 }

--- a/core/controllers/continuum/internal/controller/role_reassert.go
+++ b/core/controllers/continuum/internal/controller/role_reassert.go
@@ -1,0 +1,121 @@
+// #5224 — canonical role-password re-assert on acting-primary
+// transition (the hw273 harbor 28P01 lockout, a #5220 G12 promote-flap
+// casualty).
+//
+// THE DEFECT: during the hw273 G12 exercise the shared-pg pair's
+// promote/failback machinery flipped which side acts as primary
+// (region-b shared-pg-replica CR flipped 18:33:33Z; the dr-shared-pg
+// per-CR goroutines restarted 18:33:57Z), and the shared primary's
+// `harbor` role ended up asserted with the replica region's DIVERGENT
+// locally-minted password (the bp-postgres pre-flip mint, fixed by the
+// 0.2.13 side-gate in the same PR). CNPG could not self-heal: it
+// detects password drift ONLY via the passwordSecret resourceVersion
+// (managedRolesStatus stayed "reconciled" at rv 28321), so the
+// out-of-band value stood and every NEW consumer connection failed
+// with SQLSTATE 28P01 — 4,319 rejections in 80 minutes — until a
+// manual Secret touch.
+//
+// THE RULE this file encodes: after ANY change of which pair half is
+// ACTING primary — a promote, a failback, or a controller restart
+// mid-flap (first observation) — the DR machinery re-asserts the
+// canonical role passwords THROUGH CNPG's managed-roles contract
+// (cnpg.ReassertManagedRoles: a metadata-only rv bump on each
+// spec.managed.roles[].passwordSecret, which makes CNPG re-apply the
+// password it owns). NEVER direct SQL against the write endpoint: a
+// DR actor cannot know mid-flap which region's Secret set is
+// authoritative, and an out-of-band ALTER is exactly the invisible
+// clobber CNPG cannot detect.
+//
+// Firing on FIRST observation (per goroutine lifetime) is deliberate:
+// the per-CR goroutines restart during the very incidents this heals
+// (18:33:57Z), and the touch is idempotent — an already-canonical role
+// gets a same-value re-apply, no consumer impact.
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+)
+
+// actingPrimaryName resolves which half of a cnpg-pair is CURRENTLY
+// acting as primary from the live spec.replica.enabled flags
+// (cnpg.Status.IsReplicaCluster) — the STATIC pair-role labels do NOT
+// track post-failover reality (the rejoin.go lesson). Exactly one half
+// must be acting primary and the other acting replica; every other
+// combination (both / neither — a mid-switchover or malformed pair)
+// returns "" so the caller never guesses.
+func actingPrimaryName(primaryName string, primaryStatus cnpg.Status, replicaName string, replicaStatus cnpg.Status) string {
+	switch {
+	case !primaryStatus.IsReplicaCluster && replicaStatus.IsReplicaCluster:
+		return primaryName
+	case !replicaStatus.IsReplicaCluster && primaryStatus.IsReplicaCluster:
+		return replicaName
+	default:
+		return ""
+	}
+}
+
+// reassertRolesOnPrimaryTransition runs once per runPerCR tick, on the
+// SAME FindPair/Get results the #4901 standby check already fetched (no
+// extra CNPG API traffic on the read side). When the acting primary
+// differs from the one this goroutine last handled — a promote, a
+// failback, or the goroutine's first tick — it touches the acting
+// primary's managed-role passwordSecrets (cnpg.ReassertManagedRoles) so
+// CNPG re-applies the canonical passwords, healing any out-of-band role
+// clobber accrued while the pair was in flux.
+//
+// The per-goroutine watermark (continuumGoroutine.lastActingPrimary) is
+// advanced ONLY on a successful re-assert, so a transient API failure
+// retries on the next tick instead of being lost.
+func (r *ContinuumReconciler) reassertRolesOnPrimaryTransition(
+	ctx context.Context,
+	nn types.NamespacedName,
+	reader *cnpg.Reader,
+	namespace string,
+	primaryName string, primaryStatus cnpg.Status,
+	replicaName string, replicaStatus cnpg.Status,
+) {
+	log := ctrl.LoggerFrom(ctx).WithValues("name", nn.Name, "namespace", nn.Namespace)
+	acting := actingPrimaryName(primaryName, primaryStatus, replicaName, replicaStatus)
+	if acting == "" {
+		// Ambiguous pair state (mid-switchover) — never guess; the
+		// transition fires once the pair settles.
+		return
+	}
+
+	key := nn.String()
+	r.activeContinuumsMu.Lock()
+	g, ok := r.activeContinuums[key]
+	last := ""
+	if ok {
+		last = g.lastActingPrimary
+	}
+	r.activeContinuumsMu.Unlock()
+	if !ok || last == acting {
+		return
+	}
+
+	touched, err := reader.ReassertManagedRoles(ctx, namespace, acting, r.now())
+	if err != nil {
+		// Watermark NOT advanced — retried next tick (self-healing on
+		// transient conflicts / partial touches).
+		log.Error(err, "role re-assert on acting-primary transition failed; retrying next tick (#5224)",
+			"actingPrimary", acting, "touched", touched)
+		return
+	}
+
+	r.activeContinuumsMu.Lock()
+	if g, ok := r.activeContinuums[key]; ok {
+		g.lastActingPrimary = acting
+	}
+	r.activeContinuumsMu.Unlock()
+
+	if len(touched) > 0 {
+		log.Info("re-asserted canonical role passwords via CNPG managed-roles contract (passwordSecret rv touch) on acting-primary transition (#5224)",
+			"actingPrimary", acting, "previous", last, "touchedSecrets", touched)
+	}
+}

--- a/core/controllers/continuum/internal/controller/role_reassert_5224_test.go
+++ b/core/controllers/continuum/internal/controller/role_reassert_5224_test.go
@@ -1,0 +1,207 @@
+// Tests for #5224 — canonical role-password re-assert on
+// acting-primary transition (the hw273 harbor 28P01 lockout shape).
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+)
+
+// newManagedRolesPair builds the shared-pg pair shape: the
+// primary-labeled CR carries managed.roles (bp-postgres cluster.yaml);
+// the replica-labeled CR carries none (replica-cluster.yaml).
+// actingPrimaryIsLabelPrimary controls the LIVE spec.replica.enabled
+// flags (the post-failover reality the static labels do not track).
+func newManagedRolesPair(ns, pair, roleSecret string, actingPrimaryIsLabelPrimary bool) (*unstructured.Unstructured, *unstructured.Unstructured) {
+	primary := &unstructured.Unstructured{}
+	primary.SetGroupVersionKind(clusterGVKForTest())
+	primary.SetNamespace(ns)
+	primary.SetName(pair)
+	primary.SetLabels(map[string]string{cnpg.PairLabel: pair, cnpg.PairRoleLabel: cnpg.RolePrimary})
+	_ = unstructured.SetNestedSlice(primary.Object, []interface{}{
+		map[string]interface{}{
+			"name":           "harbor",
+			"ensure":         "present",
+			"login":          true,
+			"passwordSecret": map[string]interface{}{"name": roleSecret},
+		},
+	}, "spec", "managed", "roles")
+
+	replica := &unstructured.Unstructured{}
+	replica.SetGroupVersionKind(clusterGVKForTest())
+	replica.SetNamespace(ns)
+	replica.SetName(pair + "-replica")
+	replica.SetLabels(map[string]string{cnpg.PairLabel: pair, cnpg.PairRoleLabel: cnpg.RoleReplica})
+
+	_ = unstructured.SetNestedField(primary.Object, !actingPrimaryIsLabelPrimary, "spec", "replica", "enabled")
+	_ = unstructured.SetNestedField(replica.Object, actingPrimaryIsLabelPrimary, "spec", "replica", "enabled")
+	return primary, replica
+}
+
+func newRoleSecretObj(ns, name string) *unstructured.Unstructured {
+	s := &unstructured.Unstructured{}
+	s.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Secret"})
+	s.SetNamespace(ns)
+	s.SetName(name)
+	return s
+}
+
+func secretAnnotation(t *testing.T, r *ContinuumReconciler, ns, name string) string {
+	t.Helper()
+	got, err := r.Dyn.Resource(cnpg.SecretGVR).Namespace(ns).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("readback secret %s/%s: %v", ns, name, err)
+	}
+	return got.GetAnnotations()[cnpg.RoleReassertAnnotation]
+}
+
+func statusesFor(t *testing.T, r *ContinuumReconciler, ns, primaryName, replicaName string) (cnpg.Status, cnpg.Status) {
+	t.Helper()
+	reader := r.cnpgReader()
+	ps, _, err := reader.Get(context.Background(), ns, primaryName)
+	if err != nil {
+		t.Fatalf("Get %s: %v", primaryName, err)
+	}
+	rs, _, err := reader.Get(context.Background(), ns, replicaName)
+	if err != nil {
+		t.Fatalf("Get %s: %v", replicaName, err)
+	}
+	return ps, rs
+}
+
+func TestActingPrimaryName(t *testing.T) {
+	t.Parallel()
+	p := cnpg.Status{IsReplicaCluster: false}
+	s := cnpg.Status{IsReplicaCluster: true}
+	if got := actingPrimaryName("a", p, "b", s); got != "a" {
+		t.Fatalf("label-primary acting: got %q want a", got)
+	}
+	if got := actingPrimaryName("a", s, "b", p); got != "b" {
+		t.Fatalf("label-replica acting (post-failover): got %q want b", got)
+	}
+	// Ambiguous shapes must NEVER guess.
+	if got := actingPrimaryName("a", p, "b", p); got != "" {
+		t.Fatalf("both-primary: got %q want empty", got)
+	}
+	if got := actingPrimaryName("a", s, "b", s); got != "" {
+		t.Fatalf("both-replica: got %q want empty", got)
+	}
+}
+
+// TestReassertRoles_FirstObservationTouchesActingPrimary — the hw273
+// restart shape: the per-CR goroutine restarts mid-flap (18:33:57Z),
+// first settled observation must fire ONE re-assert on the acting
+// primary's managed-role passwordSecrets (rv touch → CNPG re-applies
+// the canonical password, healing the out-of-band clobber).
+func TestReassertRoles_FirstObservationTouchesActingPrimary(t *testing.T) {
+	t.Parallel()
+	const ns, pair, roleSecret = "shared-data", "shared-pg", "shared-pg-harbor"
+	cr := newTestContinuumCR(ns, "dr-shared-pg", "region-a", []string{"region-b"}, "in-memory")
+	primaryObj, replicaObj := newManagedRolesPair(ns, pair, roleSecret, true)
+	r, _, _ := newReconciler(t, cr, primaryObj, replicaObj, newRoleSecretObj(ns, roleSecret))
+	clock := time.Date(2026, 7, 18, 18, 34, 0, 0, time.UTC)
+	r.Now = func() time.Time { return clock }
+
+	nn := types.NamespacedName{Namespace: ns, Name: "dr-shared-pg"}
+	r.activeContinuumsMu.Lock()
+	r.activeContinuums[nn.String()] = &continuumGoroutine{}
+	r.activeContinuumsMu.Unlock()
+
+	ps, rs := statusesFor(t, r, ns, pair, pair+"-replica")
+	r.reassertRolesOnPrimaryTransition(context.Background(), nn, r.cnpgReader(), ns, pair, ps, pair+"-replica", rs)
+
+	if got := secretAnnotation(t, r, ns, roleSecret); got != "2026-07-18T18:34:00Z" {
+		t.Fatalf("first observation must touch the acting primary's role Secret; annotation = %q", got)
+	}
+	r.activeContinuumsMu.Lock()
+	last := r.activeContinuums[nn.String()].lastActingPrimary
+	r.activeContinuumsMu.Unlock()
+	if last != pair {
+		t.Fatalf("watermark = %q want %q", last, pair)
+	}
+
+	// Second tick with NO transition — must NOT touch again (the
+	// no-thrash contract: the annotation stamp stays put).
+	clock = clock.Add(time.Minute)
+	r.reassertRolesOnPrimaryTransition(context.Background(), nn, r.cnpgReader(), ns, pair, ps, pair+"-replica", rs)
+	if got := secretAnnotation(t, r, ns, roleSecret); got != "2026-07-18T18:34:00Z" {
+		t.Fatalf("steady-state tick must not re-touch; annotation = %q", got)
+	}
+}
+
+// TestReassertRoles_TransitionOnFailbackRetouches — a promote then a
+// failback each constitute an acting-primary CHANGE and each must
+// re-assert (the failback leg is exactly the hw273 heal: region-a
+// resumes as acting primary with possibly-clobbered roles).
+func TestReassertRoles_TransitionOnFailbackRetouches(t *testing.T) {
+	t.Parallel()
+	const ns, pair, roleSecret = "shared-data", "shared-pg", "shared-pg-harbor"
+	cr := newTestContinuumCR(ns, "dr-shared-pg", "region-a", []string{"region-b"}, "in-memory")
+	primaryObj, replicaObj := newManagedRolesPair(ns, pair, roleSecret, true)
+	r, _, _ := newReconciler(t, cr, primaryObj, replicaObj, newRoleSecretObj(ns, roleSecret))
+	clock := time.Date(2026, 7, 18, 18, 34, 0, 0, time.UTC)
+	r.Now = func() time.Time { return clock }
+
+	nn := types.NamespacedName{Namespace: ns, Name: "dr-shared-pg"}
+	// Watermark pre-seeded at the label-primary (steady state observed).
+	r.activeContinuumsMu.Lock()
+	r.activeContinuums[nn.String()] = &continuumGoroutine{lastActingPrimary: pair}
+	r.activeContinuumsMu.Unlock()
+
+	// PROMOTE: the replica-labeled half becomes acting primary. It has
+	// NO managed roles (replica-cluster.yaml) → transition recorded,
+	// zero touches — and critically NOTHING asserts the replica
+	// region's local secret set against the pair.
+	promoted := cnpg.Status{IsReplicaCluster: false}
+	demoted := cnpg.Status{IsReplicaCluster: true}
+	r.reassertRolesOnPrimaryTransition(context.Background(), nn, r.cnpgReader(), ns, pair, demoted, pair+"-replica", promoted)
+	if got := secretAnnotation(t, r, ns, roleSecret); got != "" {
+		t.Fatalf("promote to the roles-less replica half must not touch the primary's Secret; annotation = %q", got)
+	}
+
+	// FAILBACK: the label-primary is acting primary again — must fire a
+	// fresh re-assert (its DB may carry an out-of-band role clobber
+	// accrued during the flap; CNPG cannot detect it without the rv
+	// bump).
+	clock = time.Date(2026, 7, 18, 19, 0, 0, 0, time.UTC)
+	r.reassertRolesOnPrimaryTransition(context.Background(), nn, r.cnpgReader(), ns, pair, promoted, pair+"-replica", demoted)
+	if got := secretAnnotation(t, r, ns, roleSecret); got != "2026-07-18T19:00:00Z" {
+		t.Fatalf("failback must re-touch the canonical role Secret; annotation = %q", got)
+	}
+}
+
+// TestReassertRoles_AmbiguousPairNeverTouches — mid-switchover shapes
+// (both halves claiming primary, or both replica) must never fire.
+func TestReassertRoles_AmbiguousPairNeverTouches(t *testing.T) {
+	t.Parallel()
+	const ns, pair, roleSecret = "shared-data", "shared-pg", "shared-pg-harbor"
+	cr := newTestContinuumCR(ns, "dr-shared-pg", "region-a", []string{"region-b"}, "in-memory")
+	primaryObj, replicaObj := newManagedRolesPair(ns, pair, roleSecret, true)
+	r, _, _ := newReconciler(t, cr, primaryObj, replicaObj, newRoleSecretObj(ns, roleSecret))
+
+	nn := types.NamespacedName{Namespace: ns, Name: "dr-shared-pg"}
+	r.activeContinuumsMu.Lock()
+	r.activeContinuums[nn.String()] = &continuumGoroutine{}
+	r.activeContinuumsMu.Unlock()
+
+	both := cnpg.Status{IsReplicaCluster: false}
+	r.reassertRolesOnPrimaryTransition(context.Background(), nn, r.cnpgReader(), ns, pair, both, pair+"-replica", both)
+	if got := secretAnnotation(t, r, ns, roleSecret); got != "" {
+		t.Fatalf("ambiguous pair must never touch; annotation = %q", got)
+	}
+	r.activeContinuumsMu.Lock()
+	last := r.activeContinuums[nn.String()].lastActingPrimary
+	r.activeContinuumsMu.Unlock()
+	if last != "" {
+		t.Fatalf("ambiguous pair must not advance the watermark; got %q", last)
+	}
+}

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -11,7 +11,10 @@ spec:
   # 0.2.10 (#4846): cross-region DR admission is an identity-based
   # CiliumNetworkPolicy (io.cilium.k8s.policy.cluster) — the 0.2.9 ipBlock was
   # inert for ClusterMesh remote endpoints. values crossRegionPeerClusters.
-  version: 0.2.12
+  # 0.2.13 (#5224): role-secrets side-gate — a replica-role region never mints
+  # role/hub Secrets (incl. the pre-flip window); password set single-sourced
+  # from the primary region (#4915 remedy class).
+  version: 0.2.13
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,29 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.13 — #5224 (Refs #5220 #4915 #4878; the hw273 harbor 28P01 lockout):
+#   role-secrets.yaml gate `not renderReplicaHalf` → `not isReplicaSide`, so a
+#   region stamped side=secondary (SOVEREIGN_REGION_ROLE, present from the
+#   FIRST render) NEVER mints role-password/hub Secrets — including the #4460
+#   PRE-FLIP window where crossRegion (SOVEREIGN_ENABLE_CNPG_PAIR) is still
+#   false and the old gate let the secondary mint its own randAlphaNum
+#   passwords, frozen forever by `helm.sh/resource-policy: keep` (hw273:
+#   region-b shared-pg-harbor sha 59fd1fef… vs region-a 26f87b29…; gitea/
+#   keycloak likewise). Those divergent local Secrets are the ammunition for
+#   the #5220 G12 promote-flap casualty: a role password asserted from the
+#   replica region's local set against the shared `-mesh-rw` write endpoint
+#   clobbers the primary's canonical password, and CNPG cannot self-heal (it
+#   detects drift ONLY via passwordSecret resourceVersion — managedRolesStatus
+#   stayed "reconciled" at rv 28321 while the DB rejected that very password).
+#   The replica region consumes region-A's authoritative hub Secrets via the
+#   existing catalyst-api cross-mesh sync (#4915/#4918 remedy class + #4878
+#   restarts), so the pair's password set is single-sourced by construction.
+#   Companion (same PR): continuum-controller re-asserts role passwords
+#   through CNPG's managed-roles contract (passwordSecret rv touch) on every
+#   acting-primary transition. Primary/singleton render byte-identical; the
+#   ONLY delta is the pre-flip secondary, which now renders ZERO Secrets.
+#   tests/postgres-render.sh Case 4g added (pre-flip secondary → ZERO
+#   Secrets). Lockstep: 16a/16c/16d HR pins + blueprint.yaml + catalog-seed
+#   → 0.2.13.
 # 0.2.4 — #3878 (companion to #3876, the cycle-1 vc-mgmt DB-secret deadlock):
 #   add the optional `reflect.mangledTarget` knob. When a binding declares it,
 #   the chart emits a SECOND hub connection Secret named with the vCluster
@@ -167,7 +191,7 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.12
+version: 0.2.13
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -40,15 +40,37 @@ Stability: password = lookup(live role Secret) || lookup(live hub
 Secret) || randAlphaNum — upgrades never rotate under a running
 consumer; resource-policy keep guards release replaces.
 
-Split-side (#3375 / #3571): the role-password + hub connection Secrets are
-PRIMARY-side only. CNPG's managed.roles[].passwordSecret is consumed by the
-PRIMARY Cluster; the replica follower has no managed roles of its own (it
-streams the primary's catalog), and the consumer-facing hub Secrets reflect
-out of the primary region's shared-data. The renderReplicaHalf gate skips
-this whole template on side=replica so the replica cluster never mints a
-second, divergent password set.
+Split-side (#3375 / #3571, tightened by #5224): the role-password + hub
+connection Secrets are PRIMARY-side only. CNPG's managed.roles[].passwordSecret
+is consumed by the PRIMARY Cluster; the replica follower has no managed roles
+of its own (it streams the primary's catalog), and the consumer-facing hub
+Secrets reflect out of the primary region's shared-data.
+
+Gate = isReplicaSide, NOT renderReplicaHalf (#5224 — the hw273 harbor 28P01
+lockout). renderReplicaHalf is `activeHotStandby AND side=replica`, and
+activeHotStandby rides topology.crossRegion = SOVEREIGN_ENABLE_CNPG_PAIR,
+which flips LATE (post-mesh-convergence, the #4460 pre-flip window). side,
+by contrast, is stamped from SOVEREIGN_REGION_ROLE at cloud-init — present
+from the very FIRST render. Under the old renderReplicaHalf gate the
+secondary region's pre-flip renders (side=secondary, crossRegion=false)
+passed the gate and MINTED their own random role passwords (`lookup` finds
+nothing locally → randAlphaNum), which `helm.sh/resource-policy: keep` then
+preserved forever — a permanently DIVERGENT per-region password set (hw273:
+region-b shared-pg-harbor sha 59fd1fef… vs region-a 26f87b29…). Any DR
+promote/failback actor that asserts a role password from those local
+Secrets against the shared write endpoint then clobbers the primary's
+canonical password (the #5220 G12 flap casualty). Gating on the region ROLE
+alone means a replica-side region NEVER mints role/hub Secrets — including
+the pre-flip singleton window — and instead consumes the primary region's
+authoritative values via the catalyst-api cross-mesh hub-secret sync
+(the #4915/#4918 keycloak single-sourcing remedy class + #4878), so the
+pair's password set is single-sourced by construction. The pre-flip
+placeholder singleton Cluster still renders on the secondary (deliberate,
+#4460); its managed.roles reference Secrets that do not exist there, which
+CNPG surfaces as a pending role reconcile on the throwaway placeholder —
+strictly better than a divergent credential that outlives the placeholder.
 */ -}}
-{{- if and (ne (toString .Values.enabled) "false") (not (include "bp-postgres.renderReplicaHalf" .)) }}
+{{- if and (ne (toString .Values.enabled) "false") (not (include "bp-postgres.isReplicaSide" .)) }}
 {{- $ctx := . }}
 {{- $ns := .Release.Namespace }}
 {{- $instance := include "bp-postgres.instanceName" . }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -332,6 +332,42 @@ if grep -qE '^      additional:$' "$TMP/preflip-secondary.yaml"; then
 fi
 grep -q 'cnpg.io/instanceRole: primary' "$TMP/preflip-secondary.yaml" || fail "#4460 pre-flip secondary -mesh-rw stub missing primary-role selector"
 
+# ── Case 4g: #5224 — PRE-FLIP SECONDARY must mint ZERO Secrets ────────────────
+# The hw273 harbor 28P01 lockout regression. role-secrets.yaml used to be gated
+# on renderReplicaHalf (= activeHotStandby AND side=replica); activeHotStandby
+# rides crossRegion (SOVEREIGN_ENABLE_CNPG_PAIR), which flips LATE — so the
+# secondary region's PRE-FLIP renders (side=secondary, crossRegion=false, the
+# exact Case-4d secondary shape above) passed the gate and MINTED their own
+# randAlphaNum role passwords, frozen forever by `helm.sh/resource-policy:
+# keep` → a permanently DIVERGENT per-region password set (region-b
+# shared-pg-harbor sha 59fd1fef… vs region-a 26f87b29…). A DR promote/failback
+# actor asserting a role password from the replica region's local set against
+# the shared `-mesh-rw` write endpoint then clobbers the primary's canonical
+# password, and CNPG cannot self-heal (drift is detected ONLY via the
+# passwordSecret resourceVersion). The gate is now the region ROLE alone
+# (isReplicaSide): a side=secondary/replica region NEVER mints role or hub
+# Secrets — pre-flip OR post-flip — and consumes region-A's authoritative
+# values via the catalyst-api cross-mesh hub-secret sync (#4915/#4918 class).
+echo "[render] Case 4g: #5224 pre-flip SECONDARY (side=secondary, crossRegion=false) → ZERO Secrets (no divergent mint)"
+if grep -qE '^kind: Secret$' "$TMP/preflip-secondary.yaml"; then
+  fail "#5224: pre-flip SECONDARY minted a Secret — the divergent role/hub password mint is back (hw273 harbor 28P01 lockout shape)"
+fi
+if grep -q 'harbor-database-secret' "$TMP/preflip-secondary.yaml"; then
+  fail "#5224: pre-flip SECONDARY rendered the hub connection Secret (must be primary-side only)"
+fi
+# The pre-flip PRIMARY must still mint the full set (the authoritative source).
+grep -qE '^type: kubernetes.io/basic-auth$' "$TMP/preflip-primary.yaml" \
+  || fail "#5224: pre-flip PRIMARY lost its role-password Secret (the gate must only exclude the replica side)"
+grep -q 'name: "harbor-database-secret"' "$TMP/preflip-primary.yaml" \
+  || fail "#5224: pre-flip PRIMARY lost its hub connection Secret"
+# And the replica-spelling alias must behave identically to `secondary`.
+helm template shared-pg . -f "$TMP/preflip.values.yaml" --namespace shared-data \
+  --set topology.side=replica \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/preflip-replica-alias.yaml" 2>&1 || fail "#5224 pre-flip side=replica render errored"
+if grep -qE '^kind: Secret$' "$TMP/preflip-replica-alias.yaml"; then
+  fail "#5224: pre-flip side=replica minted a Secret (alias must match side=secondary)"
+fi
+
 # ── Case 4e: #4846 — crossRegionPeerClusters → identity-based CNP, NO ipBlock ─
 # The cross-region DR admission is an identity-based CiliumNetworkPolicy that
 # selects the peer cluster(s) by io.cilium.k8s.policy.cluster. A k8s-netpol

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5726,7 +5726,9 @@ spec:
   # cnpg-pair flip (region-B cross-region consumer DB host NXDOMAIN fix).
   # 0.2.12 (#4987/#4988): continuum.yaml mints dr-<instance> for AHS DR panel;
   # keep this display-version in lockstep with delivery source.version + blueprint.yaml.
-  version: "0.2.12"
+  # 0.2.13 (#5224): role-secrets side-gate — replica-role region never mints
+  # role/hub Secrets; pair password set single-sourced from the primary region.
+  version: "0.2.13"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5824,7 +5826,8 @@ spec:
     # DB hosts resolve the moment the mesh peers; region-B NXDOMAIN fix).
     # 0.2.12 (#4986): active-hot-standby emits the dr-<instance> Continuum CR so
     # the per-app Topology DR panel renders (shared-pg #3375 rows 51/52/56/57/64).
-    version: "0.2.12"
+    # 0.2.13 (#5224): role-secrets side-gate (replica-role region mints nothing).
+    version: "0.2.13"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## What this fixes

The hw273 harbor SQLSTATE 28P01 lockout (2026-07-18 18:35:09Z, during the G12 exercise validating #5219): the `harbor` role password on the SHARED region-a primary (`shared-pg`, reached via ClusterMesh `shared-pg-mesh-rw`) was rotated out-of-band to a value matching neither region's `harbor-database-secret` — 4,319 auth rejections in 80 minutes, region-b harbor-core/jobservice crashloop, region-a harbor surviving only on pooled connections. CNPG could not self-heal: it detects password drift ONLY via the passwordSecret resourceVersion, and `managedRolesStatus` sat at "reconciled" rv 28321 while the DB rejected that very password.

Two coupled root causes, two legs:

## Leg (a) — bp-postgres 0.2.13: replica-role region never mints role/hub Secrets

`role-secrets.yaml` was gated on `not renderReplicaHalf` (= `activeHotStandby AND side=replica`). `activeHotStandby` rides `topology.crossRegion` = `SOVEREIGN_ENABLE_CNPG_PAIR`, which flips LATE (the #4460 pre-flip window) — but `topology.side` = `SOVEREIGN_REGION_ROLE` is stamped at cloud-init, present from the FIRST render. So region-b's pre-flip renders (side=secondary, crossRegion=false) passed the gate and minted their own `randAlphaNum` role passwords, frozen forever by `helm.sh/resource-policy: keep` — a permanently divergent per-region password set (hw273: region-b `shared-pg-harbor` sha `59fd1fef…` vs region-a `26f87b29…`; gitea/keycloak likewise). Those divergent local Secrets are the ammunition for the #5220 flap casualty: any role assert from the replica region's local set against the shared write endpoint clobbers the primary's canonical password.

**Fix**: gate = `not isReplicaSide` (the region role alone). A side=secondary/replica region NEVER mints role-password or hub Secrets — pre-flip or post-flip — and consumes region-A's authoritative values via the existing catalyst-api cross-mesh hub-secret sync (the #4915/#4918 keycloak single-sourcing remedy class + #4878 consumer restarts). The pair's password set is single-sourced by construction, so a role assert with "local" secrets is a no-op (values identical or absent). Primary/singleton renders are byte-identical; the only delta is the pre-flip secondary, which now renders ZERO Secrets (its placeholder Cluster's managed.roles reference Secrets that do not exist there — an expected pending state on a throwaway placeholder, strictly better than a divergent credential that outlives it).

**Regression test**: `tests/postgres-render.sh` Case 4g — pre-flip secondary (`side=secondary, crossRegion=false`, the exact hw273 shape) and the `side=replica` alias must render ZERO Secrets, while the pre-flip primary keeps the full role+hub set. This case FAILS on 0.2.12 and passes on 0.2.13.

**Lockstep pins moved in the same commit**: `clusters/_template/bootstrap-kit/16{a,c,d}-bp-postgres-shared*.yaml` HR pins, `platform/postgres/blueprint.yaml`, `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (display + delivery) → 0.2.13.

## Leg (b) — continuum-controller: canonical role re-assert through CNPG's managed-roles contract

During the flap, the DR machinery flipped which half acts as primary (region-b `shared-pg-replica` CR flipped 18:33:33Z by field-manager "manager"; dr-shared-pg per-CR goroutines restarted 18:33:57Z) and the shared primary's role ended up carrying an out-of-band value CNPG cannot see. Nothing in the promote/failback path re-asserted the canonical passwords.

**Fix**: new `cnpg.ReassertManagedRoles` — a metadata-only annotation bump (`catalyst.openova.io/dr-role-reassert-at`) on each `spec.managed.roles[].passwordSecret`, which changes the Secret's resourceVersion and makes CNPG re-apply the canonical password via its own role reconciler (the structured form of the proven manual heal). Wired into `runPerCR` (`role_reassert.go`): fires on every acting-primary transition — promote, failback, or goroutine first-observation after a restart (deliberate: the goroutines restart during the very incidents this heals; the touch is idempotent, a same-value re-apply). The per-goroutine watermark advances only on success (transient API failures retry next tick); ambiguous mid-switchover pair states never fire (the rejoin.go never-guess posture). Direct SQL against the shared write endpoint remains forbidden — a DR actor cannot know mid-flap which region's secret set is authoritative; CNPG + the primary region's Secret always are.

**Validation-vs-direction note (deviation with evidence)**: the fix direction named the `platform/cnpg-pair` dr-promoter actor as a co-fix-site. Audit of the actual code shows the dr-promoter contains NO SQL role assertion — it only patches the HelmRelease desired state (`promoted`/`suspend`) — so there is nothing to remove there, and the (b) leg lands at the continuum-controller seam, the only DR actor with a pair-wide view. The cnpg-pair chart is untouched.

**Regression tests**: `cnpg/roles_test.go` (parse+dedupe, rv-touch with credential bytes untouched, missing-Secret skip = the replica-side shape, no-managed-roles no-op, absent-CR error) + `controller/role_reassert_5224_test.go` (first-observation touch + no-thrash steady state, promote-then-failback re-touch — the exact hw273 heal, ambiguous-pair never fires).

## Gates run

- `helm lint` PASS; `tests/postgres-render.sh` all cases including new 4g PASS
- `scripts/check-catalog-seed-lockstep.sh` PASS (68 checked, 0 fail)
- `scripts/check-bootstrap-deps.sh`, `scripts/check-cloudinit-kustomization-deps.sh`, `scripts/render-slot-placement.py check` PASS
- `core/controllers`: `go build ./...`, `go vet ./...` PASS; `go test ./continuum/...` PASS (all packages, incl. the 10 new tests)

## Live-heal for any surviving env

Touch/rotate region-a's `shared-pg-harbor` Secret (changing rv) so CNPG re-applies the canonical password — harbor-core-b recovers on next restart, jobservice follows. (Leg (b) automates exactly this on the next acting-primary transition.)

## Secondary defect filed separately

`registry.<sovereign-fqdn>` resolving to region-a cp1 INTERNAL-IP (10.150.1.228, cross-VPC, :443 refused) breaks region-b pulls even with harbor up — filed as #5225 (registry exposure must be a reachable VIP/gateway per §854; no NodePort anywhere in this PR or ever).

Refs #5224
Refs #5220
Refs #4915
Refs #4878
Refs #5225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
