### PR TITLE
fix(console): voucher-code inline policy + autogen path, reconciler-node drill, card-save IaC verdict toast, create-Org isolation copy

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
@@ -297,8 +297,12 @@ export function voucherStatus(v: Voucher): VoucherStatus {
 }
 
 export interface IssueVoucherRequest {
-  /** Voucher code (uppercased server-side on save). */
-  code: string
+  /** Voucher code (uppercased server-side on save). OPTIONAL — when
+   *  omitted/blank the billing service auto-generates a high-entropy
+   *  `VCH-XXXXXXXXXXXX` code (core/services/shared/voucher GenerateCode,
+   *  ~60 bits; UAT row 74). A supplied code must clear the server's
+   *  strength minimum (>=12 chars, >=6 distinct — row 73). */
+  code?: string
   /** Credit amount in OMR (integer). */
   credit_omr: number
   description?: string

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.envelope.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.envelope.test.ts
@@ -1,0 +1,44 @@
+/**
+ * commerce.api.envelope.test.ts — unit lock-in for parseCatalogEditEnvelope
+ * (#5113 facet-a / UAT row 132, issue #5223): folding the catalyst-api
+ * {stored, committed, reason} card-save envelope onto CatalogSaveVerdict.
+ * A legacy raw-row body must yield committed:null (verdict UNKNOWN), never
+ * a fabricated committed:true.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseCatalogEditEnvelope } from './commerce.api'
+
+describe('parseCatalogEditEnvelope', () => {
+  it('reads the honest envelope verbatim', () => {
+    expect(
+      parseCatalogEditEnvelope(
+        { stored: true, committed: true, store: { slug: 'wordpress' } },
+        'wordpress',
+      ),
+    ).toEqual({ slug: 'wordpress', stored: true, committed: true, reason: undefined })
+  })
+
+  it('carries the failure reason on committed:false', () => {
+    expect(
+      parseCatalogEditEnvelope(
+        { stored: true, committed: false, reason: 'flux dry-run rejected' },
+        'alloy',
+      ),
+    ).toEqual({
+      slug: 'alloy',
+      stored: true,
+      committed: false,
+      reason: 'flux dry-run rejected',
+    })
+  })
+
+  it('legacy raw store row (no envelope) → committed:null, not a fabricated green', () => {
+    expect(parseCatalogEditEnvelope({ slug: 'wordpress', name: 'WordPress' }, 'wordpress')).toEqual({
+      slug: 'wordpress',
+      stored: true,
+      committed: null,
+    })
+    expect(parseCatalogEditEnvelope(null, 'x')).toEqual({ slug: 'x', stored: true, committed: null })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
@@ -182,6 +182,42 @@ export interface CatalogEntryEdit {
 }
 
 /**
+ * CatalogSaveVerdict — the #3668/#5113 dual-write verdict for one catalog
+ * card-save. The catalyst-api `apps` create/update proxy wraps the upstream
+ * store row in a `{stored, committed, reason}` envelope
+ * (writeCatalogEditEnvelope in handler/org_commerce.go, honest since #5115):
+ *   • stored    — the commerce store (the cache) accepted the edit.
+ *   • committed — the IaC source-of-truth git commit (catalog-sovereign
+ *     Gitea) durably landed AND its Flux reconcile leg is armed. `null`
+ *     when the server relayed a legacy (pre-envelope) body — the UI then
+ *     reports the verdict as unavailable rather than fabricating a green.
+ *   • reason    — the server's why, when the commit leg failed.
+ */
+export interface CatalogSaveVerdict {
+  slug: string
+  stored: boolean
+  committed: boolean | null
+  reason?: string
+}
+
+/** parseCatalogEditEnvelope — fold a commerce `apps` write response body
+ *  onto the CatalogSaveVerdict. Tolerates the legacy raw-row shape (no
+ *  envelope) by returning committed:null — verdict unknown, never a
+ *  fabricated `committed:true`. */
+export function parseCatalogEditEnvelope(body: unknown, slug: string): CatalogSaveVerdict {
+  if (body && typeof body === 'object' && typeof (body as { committed?: unknown }).committed === 'boolean') {
+    const env = body as { stored?: unknown; committed: boolean; reason?: unknown }
+    return {
+      slug,
+      stored: env.stored !== false,
+      committed: env.committed,
+      reason: typeof env.reason === 'string' && env.reason ? env.reason : undefined,
+    }
+  }
+  return { slug, stored: true, committed: null }
+}
+
+/**
  * saveCatalogEdit persists an admin's catalog-entry edit to the Organization
  * commerce catalog store.
  *
@@ -200,9 +236,14 @@ export interface CatalogEntryEdit {
  *      never had), POST a new minimal row (slug + the edited fields) so the
  *      edit still persists and overlays the seed on the next catalog read.
  *
- * Returns the slug it wrote, for the caller's optimistic cache update.
+ * Returns the CatalogSaveVerdict (#5113 facet-a / UAT row 132): the caller
+ * surfaces "Saved to IaC ✓" vs "Saved to store — IaC commit failed: …"
+ * instead of closing silently.
  */
-export async function saveCatalogEdit(slug: string, edit: CatalogEntryEdit): Promise<string> {
+export async function saveCatalogEdit(
+  slug: string,
+  edit: CatalogEntryEdit,
+): Promise<CatalogSaveVerdict> {
   const bare = slug.replace(/^bp-/, '')
   const apps = await listApps()
   const existing = apps.find((a) => (a.slug ?? '').replace(/^bp-/, '') === bare)
@@ -221,16 +262,16 @@ export async function saveCatalogEdit(slug: string, edit: CatalogEntryEdit): Pro
     // Merge onto the full runtime row so untouched columns survive the
     // full-$set UpdateApp.
     const merged = { ...existing, ...patch }
-    await updateCommerce('apps', existing.id, merged)
-    return bare
+    const body = await updateCommerce('apps', existing.id, merged)
+    return parseCatalogEditEnvelope(body, bare)
   }
 
   // No store row yet — create one carrying the edit. slug is required by
   // the store; name falls back to the slug when the admin left it blank.
-  await createCommerce<CommerceApp>('apps', {
+  const body = await createCommerce<CommerceApp>('apps', {
     slug: bare,
     name: edit.name || bare,
     ...patch,
   })
-  return bare
+  return parseCatalogEditEnvelope(body, bare)
 }

--- a/products/catalyst/bootstrap/ui/src/pages/org/CreateTenantPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/CreateTenantPage.tsx
@@ -197,7 +197,7 @@ export function CreateTenantPage({
           <p className="text-sm text-[var(--color-text-dim)]">
             {isInternal
               ? 'An internal department — a people, app, and cost boundary on this Sovereign. No marketplace voucher; consumption attributes to the org via showback.'
-              : 'A customer organization — provisions its own vCluster, blueprint charts, DNS, certs, Keycloak realm, and registry entry. Choose a free subdomain under one of this Sovereign’s parent domains or bring an org-owned apex.'}
+              : 'A customer organization — provisions its own isolated runtime (per the isolation shown under Defaults, validated server-side at provision time), blueprint charts, DNS, certs, Keycloak realm, and registry entry. Choose a free subdomain under one of this Sovereign’s parent domains or bring an org-owned apex.'}
           </p>
         </div>
       </div>
@@ -243,7 +243,7 @@ export function CreateTenantPage({
                   <span className="block text-xs text-[var(--color-text-dim)]">
                     {k === 'internal'
                       ? 'Department — people/app/cost boundary'
-                      : 'Customer — its own Kubernetes universe'}
+                      : 'Customer — externally billed, own isolated runtime'}
                   </span>
                 </button>
               )
@@ -328,8 +328,8 @@ export function CreateTenantPage({
             className="rounded-md border border-[var(--color-border)] bg-[var(--color-input)] px-3 py-2 text-sm"
           />
           <span className="text-xs text-[var(--color-text-dim)]">
-            Used in resource names (vCluster, namespace) and the URL when
-            the organization picks free-subdomain mode.
+            Used in resource names (namespace and per-Org resources) and the
+            URL when the organization picks free-subdomain mode.
           </span>
         </label>
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.tsx
@@ -26,6 +26,15 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { saveCatalogEdit, type CatalogEntryEdit } from '@/lib/commerce.api'
 
+/** How long the save-verdict toast stays visible (#5113 facet-a). */
+export const TOAST_MS = 6_000
+
+/** One save-verdict toast: green committed-to-IaC vs amber store-only. */
+interface SaveNotice {
+  tone: 'ok' | 'warn'
+  text: string
+}
+
 export interface CatalogInlineFieldProps<T> {
   /** Catalog entry id (may be `bp-`-prefixed) — keyed to the store slug. */
   blueprintId: string
@@ -69,7 +78,29 @@ export function CatalogInlineField<T>({
   const [draft, setDraft] = useState<T>(initialDraft)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // #5113 facet-a / UAT row 132 — the save verdict TOAST. The editor used
+  // to close silently on save; now the {stored, committed} envelope the
+  // server returns (honest since #5115) is surfaced next to the field:
+  //   committed:true  → green  "Saved to IaC ✓"
+  //   committed:false → amber  "Saved to store — IaC commit failed: …"
+  //   committed:null  → amber  "Saved to store — no IaC verdict reported"
+  // Auto-dismisses after TOAST_MS; never blocks the next edit.
+  const [notice, setNotice] = useState<SaveNotice | null>(null)
   const editorRef = useRef<HTMLDivElement>(null)
+  const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Clear any pending toast timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (noticeTimerRef.current) clearTimeout(noticeTimerRef.current)
+    }
+  }, [])
+
+  const showNotice = (n: SaveNotice) => {
+    if (noticeTimerRef.current) clearTimeout(noticeTimerRef.current)
+    setNotice(n)
+    noticeTimerRef.current = setTimeout(() => setNotice(null), TOAST_MS)
+  }
 
   // Re-seed the draft from the latest current value each time the editor opens,
   // so re-opening after an external refetch starts from the live value.
@@ -99,10 +130,24 @@ export function CatalogInlineField<T>({
     // surgical — every sibling field round-trips unchanged.
     const edit: CatalogEntryEdit = { ...current, ...toPatch(draft) }
     try {
-      const slug = await saveCatalogEdit(blueprintId, edit)
-      void slug
+      const verdict = await saveCatalogEdit(blueprintId, edit)
       setSaving(false)
       setEditing(false)
+      // Row 132 — surface the dual-write verdict instead of closing
+      // silently. committed:false/null NEVER reads as a durable green.
+      if (verdict.committed === true) {
+        showNotice({ tone: 'ok', text: 'Saved to IaC ✓' })
+      } else if (verdict.committed === false) {
+        showNotice({
+          tone: 'warn',
+          text: `Saved to store — IaC commit failed${verdict.reason ? `: ${verdict.reason}` : ''}`,
+        })
+      } else {
+        showNotice({
+          tone: 'warn',
+          text: 'Saved to store — no IaC verdict reported by the server',
+        })
+      }
       onSaved(edit)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -150,6 +195,16 @@ export function CatalogInlineField<T>({
             </svg>
           </span>
         </button>
+        {notice ? (
+          <span
+            role="status"
+            className={`cif-toast cif-toast-${notice.tone}`}
+            data-testid={`cif-${fieldKey}-save-verdict`}
+            data-tone={notice.tone}
+          >
+            {notice.text}
+          </span>
+        ) : null}
       </div>
     )
   }
@@ -233,6 +288,20 @@ const CATALOG_INLINE_FIELD_CSS = `
 .cif-topo-summary { font-size: 0.85rem; color: var(--color-text); font-weight: 400; }
 
 .cif-error { margin: 0; color: var(--color-danger); font-size: 0.78rem; }
+
+/* #5113 facet-a — the per-field save-verdict toast (UAT row 132). */
+.cif-toast {
+  display: inline-block; margin-top: 0.3rem; padding: 0.2rem 0.6rem;
+  border-radius: 999px; font-size: 0.72rem; font-weight: 600;
+}
+.cif-toast-ok {
+  background: color-mix(in srgb, var(--color-success, #16a34a) 16%, transparent);
+  color: var(--color-success, #16a34a);
+}
+.cif-toast-warn {
+  background: color-mix(in srgb, #f59e0b 16%, transparent);
+  color: #d97706;
+}
 .cif-actions { display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 0.1rem; }
 .cif-btn {
   padding: 0.4rem 0.95rem; border-radius: 8px; border: 1px solid transparent;

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.verdict.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.verdict.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * CatalogInlineField.verdict.test.tsx — regression lock-in for UAT row 132
+ * (#5113 facet-a, issue #5223): the catalog card-save must NEVER close
+ * silently. The {stored, committed, reason} envelope the catalyst-api
+ * returns (honest since #5115) is surfaced as an in-UI toast:
+ *
+ *   committed:true  → green "Saved to IaC ✓"
+ *   committed:false → amber "Saved to store — IaC commit failed: <reason>"
+ *   legacy body     → amber "no IaC verdict reported" (never a fabricated green)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import type { CatalogSaveVerdict } from '@/lib/commerce.api'
+
+const verdictHolder: { value: CatalogSaveVerdict } = {
+  value: { slug: 'wordpress', stored: true, committed: true },
+}
+const saveSpy = vi.fn(() => Promise.resolve(verdictHolder.value))
+vi.mock('@/lib/commerce.api', () => ({
+  saveCatalogEdit: () => saveSpy(),
+}))
+
+import { CatalogInlineField } from './CatalogInlineField'
+
+const CURRENT = {
+  name: 'WordPress',
+  tagline: 'Blog engine',
+  supported_topologies: ['singleton'],
+  icon_light: '',
+  icon_dark: '',
+}
+
+function renderField() {
+  return render(
+    <CatalogInlineField<string>
+      blueprintId="bp-wordpress"
+      fieldKey="name"
+      label="Display name"
+      current={CURRENT}
+      editable
+      initialDraft={CURRENT.name}
+      renderDisplay={() => <span>WordPress</span>}
+      renderEditor={(draft, setDraft) => (
+        <input
+          data-testid="verdict-test-input"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+        />
+      )}
+      toPatch={(draft) => ({ name: draft })}
+      onSaved={() => {}}
+    />,
+  )
+}
+
+async function editAndSave() {
+  fireEvent.click(screen.getByTestId('cif-name-edit'))
+  fireEvent.change(screen.getByTestId('verdict-test-input'), {
+    target: { value: 'WordPress Turnkey' },
+  })
+  fireEvent.click(screen.getByTestId('cif-name-save'))
+  await waitFor(() => expect(saveSpy).toHaveBeenCalled())
+}
+
+beforeEach(() => {
+  saveSpy.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CatalogInlineField — save-verdict toast (row 132)', () => {
+  it('committed:true → green "Saved to IaC ✓" (no more silent close)', async () => {
+    verdictHolder.value = { slug: 'wordpress', stored: true, committed: true }
+    renderField()
+    await editAndSave()
+    const toast = await screen.findByTestId('cif-name-save-verdict')
+    expect(toast.textContent).toBe('Saved to IaC ✓')
+    expect(toast.getAttribute('data-tone')).toBe('ok')
+  })
+
+  it('committed:false → amber store-only verdict carrying the server reason', async () => {
+    verdictHolder.value = {
+      slug: 'wordpress',
+      stored: true,
+      committed: false,
+      reason: 'gitea commit rejected',
+    }
+    renderField()
+    await editAndSave()
+    const toast = await screen.findByTestId('cif-name-save-verdict')
+    expect(toast.textContent).toContain('IaC commit failed')
+    expect(toast.textContent).toContain('gitea commit rejected')
+    expect(toast.getAttribute('data-tone')).toBe('warn')
+  })
+
+  it('legacy body (no envelope) → amber "no IaC verdict", never a fabricated green', async () => {
+    verdictHolder.value = { slug: 'wordpress', stored: true, committed: null }
+    renderField()
+    await editAndSave()
+    const toast = await screen.findByTestId('cif-name-save-verdict')
+    expect(toast.textContent).toContain('no IaC verdict')
+    expect(toast.getAttribute('data-tone')).toBe('warn')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.issue.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.issue.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * VouchersPage.issue.test.tsx — regression lock-in for UAT rows 73/74
+ * (issue #5223): the Issue-voucher modal mirrors the SERVER voucher-code
+ * strength policy (core/services/shared/voucher/code.go) inline.
+ *
+ *   • Row 73 — a weak custom code (`1234`) must be rejected INLINE with the
+ *     min-12-chars message; before this fix it sailed to the server and the
+ *     operator only saw the opaque post-submit 400.
+ *   • Row 74 — a BLANK code is the server's auto-generate path
+ *     (`VCH-XXXXXXXXXXXX`, ~60 bits); before this fix the client-side
+ *     "Voucher code is required." block made that path UI-unreachable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── Mocks (declared before importing the page) ─────────────────────────
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: 'dep-test-1', loading: false }),
+}))
+
+vi.mock('../useDeploymentEvents', () => ({
+  useDeploymentEvents: () => ({ snapshot: null }),
+}))
+
+vi.mock('../PortalShell', () => ({
+  PortalShell: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="portal-shell-stub">{children}</div>
+  ),
+}))
+
+const issueSpy = vi.fn((req: Record<string, unknown>) =>
+  Promise.resolve({
+    code: (req.code as string) ?? 'VCH-AUTOGEN12345',
+    credit_omr: req.credit_omr as number,
+    active: true,
+    times_redeemed: 0,
+    max_redemptions: 0,
+    created_at: '2026-07-19T00:00:00Z',
+  }),
+)
+vi.mock('@/lib/bss.api', () => ({
+  issueVoucher: (req: Record<string, unknown>) => issueSpy(req),
+  listVouchers: () => Promise.resolve([]),
+  revokeVoucher: () => Promise.resolve(),
+  voucherStatus: () => 'active',
+}))
+
+import { VouchersPage } from './VouchersPage'
+import {
+  validateVoucherCodeStrength,
+  VOUCHER_CODE_MIN_LEN,
+  VOUCHER_CODE_MIN_DISTINCT,
+} from './voucherCodePolicy'
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <VouchersPage disableStream disableFetch initialItemsOverride={[]} />
+    </QueryClientProvider>,
+  )
+}
+
+function openIssueModal() {
+  fireEvent.click(screen.getByTestId('bss-vouchers-issue-cta'))
+  expect(screen.getByTestId('bss-issue-voucher-modal')).toBeTruthy()
+}
+
+function setCredit(value: string) {
+  fireEvent.change(screen.getByTestId('bss-issue-voucher-credit'), {
+    target: { value },
+  })
+}
+
+beforeEach(() => {
+  issueSpy.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('validateVoucherCodeStrength — the inline mirror of the server policy', () => {
+  it('accepts empty (the auto-generate path)', () => {
+    expect(validateVoucherCodeStrength('')).toBeNull()
+    expect(validateVoucherCodeStrength('   ')).toBeNull()
+  })
+
+  it('rejects a short code with the min-length message (row 73)', () => {
+    const msg = validateVoucherCodeStrength('1234')
+    expect(msg).toContain(`at least ${VOUCHER_CODE_MIN_LEN} characters`)
+  })
+
+  it('measures the hyphen-stripped body, matching the server', () => {
+    // 11 body chars split by hyphens — still too short.
+    expect(validateVoucherCodeStrength('ABC-DEF-2026')).not.toBeNull()
+    // 12 body chars with >= 6 distinct — acceptable.
+    expect(validateVoucherCodeStrength('LAUNCH-2026X-Y')).toBeNull()
+  })
+
+  it('rejects a low-distinct-chars code (ABABABABABAB shape)', () => {
+    const msg = validateVoucherCodeStrength('ABABABABABAB')
+    expect(msg).toContain(`${VOUCHER_CODE_MIN_DISTINCT} distinct`)
+  })
+
+  it('accepts a strong custom code', () => {
+    expect(validateVoucherCodeStrength('LAUNCH2026PROMO')).toBeNull()
+  })
+})
+
+describe('IssueVoucherModal — rows 73/74', () => {
+  it('row 73: a weak code gets an INLINE min-12-char rejection and never reaches the API', async () => {
+    renderPage()
+    openIssueModal()
+    fireEvent.change(screen.getByTestId('bss-issue-voucher-code'), {
+      target: { value: '1234' },
+    })
+    setCredit('5')
+    // The live hint appears while typing…
+    expect(
+      screen.getByTestId('bss-issue-voucher-code-hint').textContent,
+    ).toContain(`at least ${VOUCHER_CODE_MIN_LEN} characters`)
+    // …and the same rule gates submit.
+    fireEvent.click(screen.getByTestId('bss-issue-voucher-submit'))
+    expect(
+      screen.getByTestId('bss-issue-voucher-error').textContent,
+    ).toContain(`at least ${VOUCHER_CODE_MIN_LEN} characters`)
+    expect(issueSpy).not.toHaveBeenCalled()
+  })
+
+  it('row 74: a BLANK code submits (auto-generate path) with the code field omitted', async () => {
+    renderPage()
+    openIssueModal()
+    setCredit('10')
+    fireEvent.click(screen.getByTestId('bss-issue-voucher-submit'))
+    await waitFor(() => expect(issueSpy).toHaveBeenCalledTimes(1))
+    const req = issueSpy.mock.calls[0][0]
+    expect('code' in req).toBe(false)
+    expect(req.credit_omr).toBe(10)
+  })
+
+  it('a strong custom code still submits uppercased', async () => {
+    renderPage()
+    openIssueModal()
+    fireEvent.change(screen.getByTestId('bss-issue-voucher-code'), {
+      target: { value: 'launch2026promo' },
+    })
+    setCredit('7')
+    fireEvent.click(screen.getByTestId('bss-issue-voucher-submit'))
+    await waitFor(() => expect(issueSpy).toHaveBeenCalledTimes(1))
+    expect(issueSpy.mock.calls[0][0].code).toBe('LAUNCH2026PROMO')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
@@ -36,6 +36,13 @@ import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { PortalShell } from '../PortalShell'
 import { BillingSectionNav } from './BillingSectionNav'
 import { useDeploymentEvents } from '../useDeploymentEvents'
+// Rows 73/74 (issue #5223) — the inline mirror of the server voucher-code
+// strength policy (core/services/shared/voucher/code.go).
+import {
+  validateVoucherCodeStrength,
+  VOUCHER_CODE_MIN_DISTINCT,
+  VOUCHER_CODE_MIN_LEN,
+} from './voucherCodePolicy'
 import {
   issueVoucher,
   listVouchers,
@@ -437,6 +444,7 @@ function formatDate(iso: string): string {
   return d.toLocaleDateString()
 }
 
+
 interface IssueVoucherModalProps {
   onClose: () => void
   onIssued: (voucher: Voucher) => void
@@ -455,10 +463,19 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Rows 73/74 — live inline strength hint while the operator types a
+  // custom code (empty = the auto-generate path, no hint). The SAME rule
+  // gates submit, so the hint is never advisory-only.
+  const liveCodeHint = validateVoucherCodeStrength(code)
+
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!code.trim()) {
-      setError('Voucher code is required.')
+    // Rows 73/74 — mirror the server strength policy inline. An EMPTY
+    // code is VALID (the server auto-generates a high-entropy one); a
+    // supplied code must clear the min-length + distinct-chars minimum.
+    const codeError = validateVoucherCodeStrength(code)
+    if (codeError) {
+      setError(codeError)
       return
     }
     if (typeof creditOmr !== 'number' || creditOmr <= 0) {
@@ -469,10 +486,14 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
     setError(null)
     try {
       const req: IssueVoucherRequest = {
-        code: code.trim().toUpperCase(),
         credit_omr: creditOmr,
         active: true,
       }
+      // Omit `code` entirely when blank — the billing service's
+      // IssueVoucher then auto-generates `VCH-XXXXXXXXXXXX` (~60 bits,
+      // crypto/rand). The catalyst-api proxy skips edge strength checks
+      // for exactly this empty-code path (#4914).
+      if (code.trim()) req.code = code.trim().toUpperCase()
       if (description.trim()) req.description = description.trim()
       if (typeof maxRedemptions === 'number' && maxRedemptions > 0) {
         req.max_redemptions = maxRedemptions
@@ -520,18 +541,32 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
 
         <label className="mb-3 block">
           <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">
-            Code
+            Code (optional — leave blank to auto-generate)
           </div>
           <input
             data-testid="bss-issue-voucher-code"
             type="text"
             value={code}
             onChange={(e) => setCode(e.target.value)}
-            placeholder="LAUNCH2026"
+            placeholder="Blank auto-generates VCH-…"
             className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm font-mono uppercase text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
             autoFocus
             autoComplete="off"
           />
+          {liveCodeHint ? (
+            <div
+              data-testid="bss-issue-voucher-code-hint"
+              className="mt-1 text-[10px] text-amber-300"
+            >
+              {liveCodeHint}
+            </div>
+          ) : (
+            <div className="mt-1 text-[10px] text-[var(--color-text-dim)]">
+              A custom code needs ≥ {VOUCHER_CODE_MIN_LEN} characters with ≥{' '}
+              {VOUCHER_CODE_MIN_DISTINCT} distinct characters. Blank issues a
+              high-entropy VCH-… code.
+            </div>
+          )}
         </label>
 
         <label className="mb-3 block">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/voucherCodePolicy.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/voucherCodePolicy.ts
@@ -1,0 +1,40 @@
+/**
+ * voucherCodePolicy.ts — client-side mirror of the SERVER voucher-code
+ * strength policy (UAT rows 73/74, issue #5223).
+ *
+ * Source of truth: core/services/shared/voucher/code.go (#3376 DoD-6,
+ * edge-enforced by catalyst-api #4914):
+ *   • code OMITTED → the server auto-generates a high-entropy
+ *     `VCH-XXXXXXXXXXXX` (~60 bits) — an EMPTY field is VALID (row 74: the
+ *     old client-side "Voucher code is required." block made the
+ *     auto-generate path UI-unreachable).
+ *   • code SUPPLIED → hyphen-stripped body must be >= VOUCHER_CODE_MIN_LEN
+ *     chars AND carry >= VOUCHER_CODE_MIN_DISTINCT distinct characters
+ *     (row 73: a weak `1234` previously reached the server with no inline
+ *     rejection).
+ * The server remains the authority — this is the same rule surfaced early,
+ * with the same remediation hint (leave blank to auto-generate).
+ */
+
+/** Server-side minimum length for an operator-supplied voucher code
+ *  (voucher.MinCodeLen). */
+export const VOUCHER_CODE_MIN_LEN = 12
+
+/** Server-side minimum DISTINCT characters (voucher.MinDistinctChars). */
+export const VOUCHER_CODE_MIN_DISTINCT = 6
+
+/** validateVoucherCodeStrength — null when acceptable (or empty =
+ *  auto-generate); otherwise the operator-actionable inline message. */
+export function validateVoucherCodeStrength(raw: string): string | null {
+  const code = raw.trim().toUpperCase()
+  if (code === '') return null // auto-generate path — valid
+  const body = code.replace(/-/g, '')
+  if (body.length < VOUCHER_CODE_MIN_LEN) {
+    return `Voucher code must be at least ${VOUCHER_CODE_MIN_LEN} characters — or leave it blank to auto-generate a strong code.`
+  }
+  const distinct = new Set(body.split(''))
+  if (distinct.size < VOUCHER_CODE_MIN_DISTINCT) {
+    return `Voucher code is too predictable (needs at least ${VOUCHER_CODE_MIN_DISTINCT} distinct characters) — leave it blank to auto-generate a strong code.`
+  }
+  return null
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.recon-drill.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.recon-drill.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * ArchitectureGraphPage.recon-drill.test.tsx — the row-193 (issue #5223)
+ * integration lock-in: on the unified Cloud graph, CLICKING a reconciler
+ * node opens the ReconcilerDrillPanel (the #3996 drill re-wired), not the
+ * generic infrastructure DetailPanel and not nothing.
+ *
+ * This is the exact regression the hw255 walk caught: the Reconciliation
+ * lens rendered its nodes but a click produced NO drill-in.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// The drill panel resolves coordinates + logs through the #3996 client —
+// mock the wire, keep everything else real.
+const listSpy = vi.fn(() =>
+  Promise.resolve({
+    reconcilers: [
+      {
+        kind: 'HelmRelease',
+        name: 'bp-keycloak',
+        namespace: 'flux-system',
+        state: 'Reconciled' as const,
+        message: 'Helm install succeeded',
+        revision: '1.2.3',
+        suspended: false,
+        lastReconcile: '2026-07-19T00:00:00Z',
+        controller: 'helm-controller',
+      },
+    ],
+    reconciled: 1,
+    total: 1,
+  }),
+)
+const logsSpy = vi.fn(() =>
+  Promise.resolve({
+    controller: 'helm-controller',
+    object: 'flux-system/bp-keycloak',
+    lines: [{ lineNumber: 1, message: 'reconciling flux-system/bp-keycloak' }],
+    total: 1,
+  }),
+)
+vi.mock('@/lib/reconciler-manage.api', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@/lib/reconciler-manage.api')>()
+  return {
+    ...orig,
+    fetchReconcilers: () => listSpy(),
+    fetchReconcilerLogs: () => logsSpy(),
+  }
+})
+
+import { ArchitectureGraphPage } from './ArchitectureGraphPage'
+import type { ReconciliationNode } from '@/lib/reconciliation.api'
+
+const RECONCILERS: ReconciliationNode[] = [
+  {
+    id: 'bp-keycloak',
+    label: 'bp-keycloak',
+    kind: 'HelmRelease',
+    state: 'Reconciled',
+  },
+]
+
+function renderGraphWithReconciler() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ArchitectureGraphPage
+        deploymentId="dep-test-1"
+        data={null}
+        isLoading={false}
+        isError={false}
+        onRefetch={() => {}}
+        k8sSnapshot={new Map()}
+        k8sRevision={0}
+        reconcilers={RECONCILERS}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  listSpy.mockClear()
+  logsSpy.mockClear()
+})
+
+describe('ArchitectureGraphPage — reconciler-node drill (row 193)', () => {
+  it('clicking a reconciler node opens the ReconcilerDrillPanel wired to the logs endpoint', async () => {
+    renderGraphWithReconciler()
+
+    // Switch to the Reconciliation lens so the control-category chip set
+    // (incl. HelmRelease) is active.
+    fireEvent.change(screen.getByTestId('cloud-architecture-lens'), {
+      target: { value: 'reconciliation' },
+    })
+
+    const node = await screen.findByTestId('arch-graph-node-HelmRelease-recon:bp-keycloak')
+    expect(screen.queryByTestId('reconciler-drill-panel')).toBeNull()
+
+    fireEvent.click(node)
+
+    // The drill panel opens (NOT the generic infrastructure panel)…
+    expect(screen.getByTestId('reconciler-drill-panel')).toBeTruthy()
+    expect(screen.queryByTestId('infrastructure-detail-panel')).toBeNull()
+
+    // …and the logs drill actually fires against the #3996 endpoint.
+    await waitFor(() => expect(logsSpy).toHaveBeenCalled())
+    const line = await screen.findByTestId('reconciler-drill-log-line-1')
+    expect(line.textContent).toContain('reconciling flux-system/bp-keycloak')
+
+    // Close restores the no-panel state.
+    fireEvent.click(screen.getByTestId('reconciler-drill-close'))
+    expect(screen.queryByTestId('reconciler-drill-panel')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
@@ -64,6 +64,8 @@ import type {
   VolumeItem,
 } from '@/lib/infrastructure.types'
 import { GraphCanvas, type GraphCanvasHandle } from './GraphCanvas'
+import { ReconcilerDrillPanel } from './ReconcilerDrillPanel'
+import { isReconcilerNode } from './reconcilerDrill'
 import { buildCloudGraph } from './cloudGraphData'
 import { useK8sCacheStream, type K8sSnapshot } from './useK8sCacheStream'
 import type { ReconciliationNode } from '@/lib/reconciliation.api'
@@ -664,8 +666,21 @@ export function ArchitectureGraphPage({
        *  canvas) which the canvas renders via showLegend + edgeTypeCounts.
        *  No separate bottom button. */}
 
+      {/* Reconciler drill-in (UAT row 193 / #5223) — a reconciler-side
+          node opens the #3996 drill (status + owning-controller logs +
+          reconcile/suspend/resume) instead of the generic infrastructure
+          panel, re-wiring the drill that lived on the deleted
+          /reconciliation page onto the unified Cloud graph. */}
+      {selectedNode && isReconcilerNode(selectedNode) && (
+        <ReconcilerDrillPanel
+          deploymentId={deploymentId}
+          node={selectedNode}
+          onClose={() => setSelectedId(null)}
+        />
+      )}
+
       {/* Detail panel — slides in from the right on node click. */}
-      {selectedNode && (
+      {selectedNode && !isReconcilerNode(selectedNode) && (
         <DetailPanel
           node={selectedNode}
           neighbors={neighborList}

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ReconcilerDrillPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ReconcilerDrillPanel.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * ReconcilerDrillPanel.test.tsx — regression lock-in for UAT row 193
+ * (issue #5223): clicking a reconciler node on the unified Cloud graph
+ * must open a DRILL-IN wired to the #3996 reconciler-management surface
+ * (GET .../reconcilers + GET .../reconcilers/{kind}/{ns}/{name}/logs).
+ *
+ * Before this fix the Reconciliation lens rendered 89 reconciler nodes but
+ * a click opened only the generic infrastructure panel — the drill+logs
+ * shipped on the since-deleted /reconciliation page and was never re-wired.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── Mock the management API (list + logs + action) ────────────────────
+const listSpy = vi.fn((...listArgs: unknown[]) => {
+  void listArgs
+  return Promise.resolve({
+    reconcilers: [
+      {
+        kind: 'HelmRelease',
+        name: 'bp-keycloak',
+        namespace: 'flux-system',
+        state: 'Reconciled' as const,
+        message: 'Helm install succeeded',
+        revision: '1.2.3',
+        suspended: false,
+        lastReconcile: '2026-07-19T00:00:00Z',
+        controller: 'helm-controller',
+      },
+    ],
+    reconciled: 1,
+    total: 1,
+  })
+})
+const logsSpy = vi.fn((...logsArgs: unknown[]) => {
+  void logsArgs
+  return Promise.resolve({
+    controller: 'helm-controller',
+    object: 'flux-system/bp-keycloak',
+    lines: [
+      { lineNumber: 1, message: 'reconciling HelmRelease flux-system/bp-keycloak' },
+      { lineNumber: 2, message: 'release bp-keycloak upgraded' },
+    ],
+    total: 2,
+  })
+})
+const actionSpy = vi.fn((...actionArgs: unknown[]) => {
+  void actionArgs
+  return Promise.resolve({
+    kind: 'HelmRelease',
+    namespace: 'flux-system',
+    name: 'bp-keycloak',
+    action: 'reconcile' as const,
+    requestedAt: '2026-07-19T01:00:00Z',
+    requestedBy: 'operator@test',
+  })
+})
+vi.mock('@/lib/reconciler-manage.api', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@/lib/reconciler-manage.api')>()
+  return {
+    ...orig,
+    fetchReconcilers: (...args: unknown[]) => listSpy(...args),
+    fetchReconcilerLogs: (...args: unknown[]) => logsSpy(...args),
+    triggerReconcilerAction: (...args: unknown[]) => actionSpy(...args),
+  }
+})
+
+import { ReconcilerDrillPanel } from './ReconcilerDrillPanel'
+import { isReconcilerNode, reconcilerCoordsForNode } from './reconcilerDrill'
+import type { GraphNode } from './types'
+
+const HR_NODE: GraphNode = {
+  id: 'recon:bp-keycloak',
+  type: 'HelmRelease',
+  label: 'bp-keycloak',
+  sublabel: 'HelmRelease · Reconciled',
+  status: 'healthy',
+  metadata: { kind: 'HelmRelease', state: 'Reconciled' },
+}
+
+const CERT_NODE: GraphNode = {
+  id: 'recon:certificate/cert-ns/wildcard-cert',
+  type: 'Certificate',
+  label: 'wildcard-cert',
+  sublabel: 'Certificate · Reconciled',
+  status: 'healthy',
+  metadata: { kind: 'Certificate', state: 'Reconciled' },
+}
+
+function renderPanel(node: GraphNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ReconcilerDrillPanel deploymentId="dep-test-1" node={node} onClose={() => {}} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  listSpy.mockClear()
+  logsSpy.mockClear()
+  actionSpy.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('reconcilerCoordsForNode — the three DAG id dialects', () => {
+  it('HelmRelease: bare bp-<app> id', () => {
+    expect(reconcilerCoordsForNode(HR_NODE)).toEqual({
+      kind: 'HelmRelease',
+      namespace: null,
+      name: 'bp-keycloak',
+    })
+  })
+
+  it('Kustomization: kustomization/<tier> id', () => {
+    expect(
+      reconcilerCoordsForNode({
+        id: 'recon:kustomization/bootstrap-kit',
+        type: 'Kustomization',
+        label: 'bootstrap-kit',
+        metadata: { kind: 'Kustomization', state: 'Reconciled' },
+      }),
+    ).toEqual({ kind: 'Kustomization', namespace: null, name: 'bootstrap-kit' })
+  })
+
+  it('declarative: <kindlower>/<ns>/<name> id (empty ns for cluster-scoped)', () => {
+    expect(reconcilerCoordsForNode(CERT_NODE)).toEqual({
+      kind: 'Certificate',
+      namespace: 'cert-ns',
+      name: 'wildcard-cert',
+    })
+    expect(
+      reconcilerCoordsForNode({
+        id: 'recon:organization//acme',
+        type: 'Organization',
+        label: 'acme',
+        metadata: { kind: 'Organization', state: 'Reconciled' },
+      }),
+    ).toEqual({ kind: 'Organization', namespace: null, name: 'acme' })
+  })
+})
+
+describe('isReconcilerNode', () => {
+  it('true for recon:-namespaced ids, false otherwise', () => {
+    expect(isReconcilerNode(HR_NODE)).toBe(true)
+    expect(isReconcilerNode({ id: 'Cluster:hw270' })).toBe(false)
+  })
+})
+
+describe('ReconcilerDrillPanel — row 193 drill + logs', () => {
+  it('a Flux reconciler node drills into the owning-controller logs', async () => {
+    renderPanel(HR_NODE)
+    expect(screen.getByTestId('reconciler-drill-panel')).toBeTruthy()
+    expect(screen.getByTestId('reconciler-drill-name').textContent).toBe('bp-keycloak')
+
+    // Coordinates resolve via the reconcilers LIST (kind+name → namespace)…
+    await waitFor(() => expect(listSpy).toHaveBeenCalled())
+    // …and the logs drill fires against the resolved coordinate.
+    await waitFor(() => expect(logsSpy).toHaveBeenCalled())
+    expect(logsSpy.mock.calls[0]).toEqual([
+      'dep-test-1',
+      'HelmRelease',
+      'flux-system',
+      'bp-keycloak',
+      200,
+    ])
+
+    const line1 = await screen.findByTestId('reconciler-drill-log-line-1')
+    expect(line1.textContent).toContain('reconciling HelmRelease flux-system/bp-keycloak')
+    expect(screen.getByTestId('reconciler-drill-log-line-2').textContent).toContain(
+      'release bp-keycloak upgraded',
+    )
+    // The status strip surfaces the resolved object coordinate.
+    expect(screen.getByTestId('reconciler-drill-object').textContent).toBe(
+      'flux-system/bp-keycloak',
+    )
+  })
+
+  it('Reconcile-now fires the #3996 action against the resolved coordinate', async () => {
+    renderPanel(HR_NODE)
+    await waitFor(() => expect(listSpy).toHaveBeenCalled())
+    fireEvent.click(screen.getByTestId('reconciler-drill-action-reconcile'))
+    await waitFor(() => expect(actionSpy).toHaveBeenCalled())
+    expect(actionSpy.mock.calls[0]).toEqual([
+      'dep-test-1',
+      'HelmRelease',
+      'flux-system',
+      'bp-keycloak',
+      'reconcile',
+    ])
+    expect((await screen.findByTestId('reconciler-drill-action-ok')).textContent).toContain(
+      'reconcile requested',
+    )
+  })
+
+  it('a non-Flux declarative reconciler states the no-controller-logs truth (no fabricated log view)', () => {
+    renderPanel(CERT_NODE)
+    expect(screen.getByTestId('reconciler-drill-panel')).toBeTruthy()
+    expect(screen.getByTestId('reconciler-drill-nonflux')).toBeTruthy()
+    expect(screen.queryByTestId('reconciler-drill-logs')).toBeNull()
+    expect(logsSpy).not.toHaveBeenCalled()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ReconcilerDrillPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ReconcilerDrillPanel.tsx
@@ -1,0 +1,306 @@
+/**
+ * ReconcilerDrillPanel — the reconciler-node drill-in for the unified
+ * Cloud graph's Reconciliation lens (UAT row 193, issue #5223).
+ *
+ * The #3996 ArgoCD-like drill (status + owning-controller LOGS +
+ * reconcile/suspend/resume) shipped on the per-kind cloud-list
+ * ResourceDetailPage, but when #3958 folded the reconcilers into the ONE
+ * Cloud graph and deleted the standalone /reconciliation page, clicking a
+ * reconciler NODE on the canvas opened only the generic infrastructure
+ * DetailPanel — no drill, no logs. This panel re-wires the graph click to
+ * the SAME backend surface the ReconcileTab uses
+ * (lib/reconciler-manage.api.ts):
+ *
+ *   GET  /api/v1/deployments/{id}/reconcilers                     — coords + rich row
+ *   GET  /api/v1/deployments/{id}/reconcilers/{kind}/{ns}/{name}/logs
+ *   POST /api/v1/deployments/{id}/reconcilers/{kind}/{ns}/{name}/{action}
+ *
+ * Coordinate resolution: the reconciliation-DAG feed the graph ingests
+ * (lib/reconciliation.api.ts) does NOT carry a namespace, so the panel
+ * resolves the exact `{kind, ns, name}` from the reconcilers LIST (which
+ * carries both coordinates), falling back to the canonical `flux-system`
+ * namespace for the Flux kinds when the list row is absent (the backend's
+ * log filter also matches the bare object name, so the fallback still
+ * scopes correctly on a normal Sovereign).
+ *
+ * Non-Flux declarative reconcilers (Certificate / CNPG Cluster /
+ * ExternalSecret / the Catalyst CRs) have no owning Flux controller, so
+ * the panel states that honestly instead of fabricating a log view.
+ */
+
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  fetchReconcilerLogs,
+  fetchReconcilers,
+  isManageableKind,
+  triggerReconcilerAction,
+  type ManagedReconciler,
+  type ReconcilerActionKind,
+} from '@/lib/reconciler-manage.api'
+import { reconcilerCoordsForNode } from './reconcilerDrill'
+import type { GraphNode } from './types'
+
+/** The canonical Flux namespace on every Catalyst Sovereign (bootstrap-kit
+ *  installs the controllers + the bp-* HelmReleases there); used only as
+ *  the fallback when the reconcilers list did not return the object. */
+const FLUX_NS_FALLBACK = 'flux-system'
+
+/** How many controller-log lines the drill tails per fetch. */
+const LOG_TAIL_LINES = 200
+
+export interface ReconcilerDrillPanelProps {
+  deploymentId: string
+  node: GraphNode
+  onClose: () => void
+}
+
+export function ReconcilerDrillPanel({ deploymentId, node, onClose }: ReconcilerDrillPanelProps) {
+  const coords = useMemo(() => reconcilerCoordsForNode(node), [node])
+  const manageable = isManageableKind(coords.kind)
+
+  // Resolve the exact coordinates (esp. namespace) from the reconcilers
+  // list — the same feed the #3996 management list reads. Shared query key
+  // so switching nodes reuses one list fetch.
+  const listQuery = useQuery({
+    queryKey: ['reconcilers-manage', deploymentId],
+    queryFn: () => fetchReconcilers(deploymentId),
+    enabled: !!deploymentId && manageable,
+    staleTime: 15_000,
+    retry: 1,
+  })
+
+  const listRow: ManagedReconciler | null = useMemo(() => {
+    const rows = listQuery.data?.reconcilers ?? []
+    return (
+      rows.find((r) => r.kind === coords.kind && r.name === coords.name) ??
+      // HelmRelease DAG ids are `bp-<app>` while some feeds name the HR
+      // without the prefix — tolerate either spelling before giving up.
+      rows.find(
+        (r) =>
+          r.kind === coords.kind &&
+          (r.name === coords.name.replace(/^bp-/, '') || `bp-${r.name}` === coords.name),
+      ) ??
+      null
+    )
+  }, [listQuery.data, coords])
+
+  const logNamespace = listRow?.namespace ?? coords.namespace ?? FLUX_NS_FALLBACK
+  const logName = listRow?.name ?? coords.name
+
+  const logsQuery = useQuery({
+    queryKey: ['reconciler-logs', deploymentId, coords.kind, logNamespace, logName],
+    queryFn: () => fetchReconcilerLogs(deploymentId, coords.kind, logNamespace, logName, LOG_TAIL_LINES),
+    // Wait for the list resolution (or its failure) before tailing so the
+    // first fetch already uses the exact namespace.
+    enabled: !!deploymentId && manageable && (listQuery.isSuccess || listQuery.isError),
+    retry: 1,
+  })
+
+  const [actionBusy, setActionBusy] = useState<ReconcilerActionKind | null>(null)
+  const [actionMsg, setActionMsg] = useState<string | null>(null)
+  const [actionErr, setActionErr] = useState<string | null>(null)
+
+  async function fireAction(action: ReconcilerActionKind) {
+    setActionBusy(action)
+    setActionErr(null)
+    setActionMsg(null)
+    try {
+      const res = await triggerReconcilerAction(deploymentId, coords.kind, logNamespace, logName, action)
+      setActionMsg(`${res.action} requested at ${res.requestedAt}`)
+      void listQuery.refetch()
+      void logsQuery.refetch()
+    } catch (e) {
+      setActionErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setActionBusy(null)
+    }
+  }
+
+  const state = listRow?.state ?? node.metadata?.state ?? ''
+  const message = listRow?.message ?? node.metadata?.message ?? ''
+
+  return (
+    <aside
+      role="dialog"
+      aria-label={`${node.label} reconciler drill-in`}
+      data-testid="reconciler-drill-panel"
+      className="fixed right-0 top-14 z-30 flex h-[calc(100vh-3.5rem)] w-[28rem] flex-col gap-3 border-l border-[var(--color-border)] bg-[var(--color-bg-2)] p-4 shadow-xl"
+    >
+      <header className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p
+            data-testid="reconciler-drill-name"
+            className="truncate text-base font-semibold text-[var(--color-text-strong)]"
+          >
+            {node.label}
+          </p>
+          <p
+            data-testid="reconciler-drill-kind"
+            className="text-xs uppercase tracking-wide text-[var(--color-text-dim)]"
+          >
+            {coords.kind}
+            {state ? ` · ${state}` : ''}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          data-testid="reconciler-drill-close"
+          className="rounded-md border border-[var(--color-border)] bg-transparent px-2 py-1 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+          aria-label="Close reconciler drill-in"
+        >
+          ×
+        </button>
+      </header>
+
+      {/* Status strip — coordinates + revision + last reconcile. */}
+      <section className="flex flex-col gap-1.5" data-testid="reconciler-drill-status">
+        <h3 className="text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-[var(--color-text-dim)]">
+          Status
+        </h3>
+        <dl className="grid grid-cols-3 gap-x-2 gap-y-1.5 text-xs">
+          <dt className="text-[var(--color-text-dim)]">Object</dt>
+          <dd className="col-span-2 truncate font-mono text-[var(--color-text)]" data-testid="reconciler-drill-object">
+            {logNamespace ? `${logNamespace}/` : ''}
+            {logName}
+          </dd>
+          {listRow?.revision ? (
+            <>
+              <dt className="text-[var(--color-text-dim)]">Revision</dt>
+              <dd className="col-span-2 truncate font-mono text-[var(--color-text)]">{listRow.revision}</dd>
+            </>
+          ) : null}
+          {listRow?.lastReconcile ? (
+            <>
+              <dt className="text-[var(--color-text-dim)]">Last reconcile</dt>
+              <dd className="col-span-2 truncate text-[var(--color-text)]">{listRow.lastReconcile}</dd>
+            </>
+          ) : null}
+          {listRow?.controller ? (
+            <>
+              <dt className="text-[var(--color-text-dim)]">Controller</dt>
+              <dd className="col-span-2 truncate font-mono text-[var(--color-text)]">{listRow.controller}</dd>
+            </>
+          ) : null}
+        </dl>
+        {message ? (
+          <p
+            data-testid="reconciler-drill-message"
+            className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1.5 text-xs text-[var(--color-text)]"
+          >
+            {message}
+          </p>
+        ) : null}
+      </section>
+
+      {manageable ? (
+        <>
+          {/* Actions — the #3996 Flux-native triad. */}
+          <section className="flex flex-col gap-1.5" data-testid="reconciler-drill-actions">
+            <h3 className="text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-[var(--color-text-dim)]">
+              Actions
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                data-testid="reconciler-drill-action-reconcile"
+                disabled={actionBusy !== null}
+                onClick={() => void fireAction('reconcile')}
+                className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)] disabled:opacity-50"
+              >
+                {actionBusy === 'reconcile' ? 'Reconciling…' : 'Reconcile now'}
+              </button>
+              {listRow?.suspended ? (
+                <button
+                  type="button"
+                  data-testid="reconciler-drill-action-resume"
+                  disabled={actionBusy !== null}
+                  onClick={() => void fireAction('resume')}
+                  className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)] disabled:opacity-50"
+                >
+                  {actionBusy === 'resume' ? 'Resuming…' : 'Resume'}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  data-testid="reconciler-drill-action-suspend"
+                  disabled={actionBusy !== null}
+                  onClick={() => void fireAction('suspend')}
+                  className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)] disabled:opacity-50"
+                >
+                  {actionBusy === 'suspend' ? 'Suspending…' : 'Suspend'}
+                </button>
+              )}
+            </div>
+            {actionMsg ? (
+              <p role="status" className="text-xs text-[var(--color-success,#16a34a)]" data-testid="reconciler-drill-action-ok">
+                {actionMsg}
+              </p>
+            ) : null}
+            {actionErr ? (
+              <p role="alert" className="text-xs text-[var(--color-danger)]" data-testid="reconciler-drill-action-error">
+                {actionErr}
+              </p>
+            ) : null}
+          </section>
+
+          {/* Controller logs — the row-193 drill. */}
+          <section className="flex min-h-0 flex-1 flex-col gap-1.5" data-testid="reconciler-drill-logs">
+            <div className="flex items-center justify-between">
+              <h3 className="text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-[var(--color-text-dim)]">
+                Controller logs{logsQuery.data ? ` (${logsQuery.data.total})` : ''}
+              </h3>
+              <button
+                type="button"
+                data-testid="reconciler-drill-logs-refresh"
+                onClick={() => void logsQuery.refetch()}
+                className="rounded-md border border-[var(--color-border)] px-2 py-0.5 text-[10px] text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+              >
+                Refresh
+              </button>
+            </div>
+            {logsQuery.isLoading || (!logsQuery.data && !logsQuery.isError) ? (
+              <p className="text-xs text-[var(--color-text-dim)]" data-testid="reconciler-drill-logs-loading">
+                Tailing {logNamespace}/{logName} from the owning controller…
+              </p>
+            ) : logsQuery.isError ? (
+              <p className="text-xs text-[var(--color-danger)]" data-testid="reconciler-drill-logs-error">
+                {(logsQuery.error as Error | undefined)?.message ?? 'Controller logs unavailable'}
+              </p>
+            ) : logsQuery.data && logsQuery.data.lines.length === 0 ? (
+              <p className="text-xs text-[var(--color-text-dim)]" data-testid="reconciler-drill-logs-empty">
+                No recent {logsQuery.data.controller} log lines mention {logNamespace}/{logName}.
+              </p>
+            ) : (
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-2">
+                <ol className="flex flex-col gap-0.5">
+                  {logsQuery.data!.lines.map((l) => (
+                    <li
+                      key={l.lineNumber}
+                      data-testid={`reconciler-drill-log-line-${l.lineNumber}`}
+                      className="whitespace-pre-wrap break-all font-mono text-[10px] leading-relaxed text-[var(--color-text)]"
+                    >
+                      {l.message}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )}
+          </section>
+        </>
+      ) : (
+        // Non-Flux declarative reconciler — no owning Flux controller to
+        // tail; say so honestly instead of fabricating a log view.
+        <section className="flex flex-col gap-1.5" data-testid="reconciler-drill-nonflux">
+          <p className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1.5 text-xs text-[var(--color-text-dim)]">
+            Controller-log drill applies to the Flux reconciler kinds
+            (HelmRelease / Kustomization / sources). {coords.kind} is a
+            declarative reconciler — its live state and message above are the
+            drill surface.
+          </p>
+        </section>
+      )}
+    </aside>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/reconcilerDrill.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/reconcilerDrill.ts
@@ -1,0 +1,49 @@
+/**
+ * reconcilerDrill.ts — coordinate helpers for the reconciler-node drill-in
+ * (UAT row 193, issue #5223). Split from ReconcilerDrillPanel.tsx so the
+ * component file only exports components (react-refresh rule).
+ */
+
+import type { GraphNode } from './types'
+
+/** Node-id namespace the reconciler adapter stamps (reconcilerAdapter.ts). */
+export const RECON_NODE_PREFIX = 'recon:'
+
+/** isReconcilerNode — true when a graph node came from the reconciler set. */
+export function isReconcilerNode(node: Pick<GraphNode, 'id'>): boolean {
+  return node.id.startsWith(RECON_NODE_PREFIX)
+}
+
+export interface ReconcilerCoords {
+  kind: string
+  namespace: string | null
+  name: string
+}
+
+/**
+ * reconcilerCoordsForNode — derive the `{kind, ns, name}` coordinate from a
+ * reconciler graph node. The DAG feed's id dialects
+ * (handler/reconciliation_dag.go):
+ *   • HelmRelease    — `bp-<app>`                      (no ns on the wire)
+ *   • Kustomization  — `kustomization/<tier>`          (no ns on the wire)
+ *   • declarative    — `<kindlower>/<ns>/<name>`       (ns inline; empty for
+ *                       cluster-scoped kinds, e.g. `organization//acme`)
+ * The REAL Kind casing rides in node.metadata.kind (reconcilerAdapter).
+ */
+export function reconcilerCoordsForNode(node: GraphNode): ReconcilerCoords {
+  const rawId = node.id.slice(RECON_NODE_PREFIX.length)
+  const kind = node.metadata?.kind ?? ''
+  if (rawId.startsWith('kustomization/')) {
+    return {
+      kind: kind || 'Kustomization',
+      namespace: null,
+      name: rawId.slice('kustomization/'.length),
+    }
+  }
+  const parts = rawId.split('/')
+  if (parts.length === 3) {
+    // Declarative `<kindlower>/<ns>/<name>` — ns may be empty (cluster-scoped).
+    return { kind: kind || parts[0], namespace: parts[1] || null, name: parts[2] }
+  }
+  return { kind: kind || 'HelmRelease', namespace: null, name: rawId }
+}


### PR DESCRIPTION
## What

One catalyst-ui PR fixing the four verified console-SPA gaps from the hw240/hw255/hw256/hw270 UAT walks (rows 73/74/132/193 + row-12 residual). Component scope: `products/catalyst/bootstrap/ui` only (plus its tests). No chart version touched — flips on the next rolled catalyst-ui image + authed walk.

### Row 73 + 74 — BSS voucher issue modal (`bss/VouchersPage.tsx`)
- **Before:** validated only empty-code + credit-positive-int. A weak code (`1234`) got NO inline min-12-char rejection (row 73), and the client-side `Voucher code is required.` block made the server's `voucher.GenerateCode` auto-generate path UI-unreachable (row 74).
- **After:** new `bss/voucherCodePolicy.ts` mirrors the server policy (`core/services/shared/voucher/code.go`: hyphen-stripped body >= 12 chars AND >= 6 distinct chars; empty = auto-generate) as a live inline hint AND the submit gate. A blank code now submits with `code` OMITTED (`IssueVoucherRequest.code` is optional) — the catalyst-api proxy explicitly passes the empty-code path through for auto-generation (#4914). Field copy: "Code (optional — leave blank to auto-generate)".

### Row 132 — catalog card-save verdict (#5113 facet-a; server half shipped in #5115)
- **Before:** the per-field card editors (`CatalogInlineField`) closed silently on Save; the `{stored, committed, reason}` envelope existed only on the wire.
- **After:** `saveCatalogEdit` parses the envelope into a `CatalogSaveVerdict`; `CatalogInlineField` shows a transient toast next to the saved field: green `Saved to IaC ✓` on `committed:true`, amber `Saved to store — IaC commit failed: <reason>` on `committed:false`, amber `no IaC verdict reported` for a legacy body — never a fabricated green.

### Row 193 — Cloud → Reconciliation lens drill-in
- **Before:** the lens rendered 89 reconciler nodes but clicking opened NO drill: the #3996 drill+logs shipped on the since-deleted `/reconciliation` page's sibling surface and was never re-wired to `ArchitectureGraphPage`/`GraphCanvas` (backend logs endpoint 200s per row 195).
- **After:** new `ReconcilerDrillPanel` (widgets/architecture-graph) opens on any `recon:`-namespaced node click, resolving exact `{kind, ns, name}` via `GET .../reconcilers`, tailing the owning-controller logs via `GET .../reconcilers/{kind}/{ns}/{name}/logs`, and exposing the #3996 reconcile/suspend/resume triad — all through the pre-existing `lib/reconciler-manage.api.ts` client. Non-Flux declarative reconcilers (Certificate/CNPG/ESO/Catalyst CRs) state honestly that controller-log drill applies to Flux kinds only.

### Row-12 residual — create-Org form isolation copy
- **Before:** copy advertised "provisions its own vCluster" + "resource names (vCluster, namespace)" while hw270's live Org detail reports `isolation=namespace` (#4325 de-vcluster re-baseline).
- **After:** copy defers to the Defaults isolation value ("validated server-side at provision time"); the customer kind sub-caption reads "externally billed, own isolated runtime". The `kindDefaults('customer')` MODEL default is intentionally NOT flipped in this console-only PR — that is an Organizations-model decision (the backend re-derives + validates); flagged on #5223.

## Regression tests (would have caught each defect)
- `bss/VouchersPage.issue.test.tsx` — weak `1234` inline-rejected + API never called; blank code submits WITHOUT `code`; strong code uppercased. Policy unit tests incl. the `ABABABABABAB` distinct-chars shape.
- `CatalogInlineField.verdict.test.tsx` + `lib/commerce.api.envelope.test.ts` — the three envelope shapes → the three toasts; legacy body never reads green.
- `widgets/architecture-graph/ReconcilerDrillPanel.test.tsx` — the three DAG id dialects → coordinates; logs drill against the resolved `{kind,ns,name}`; action wiring; non-Flux honesty (no fabricated log view).
- `widgets/architecture-graph/ArchitectureGraphPage.recon-drill.test.tsx` — the exact row-193 repro: switch to the Reconciliation lens, CLICK the reconciler node, the drill panel opens (not the generic panel, not nothing) and the logs endpoint fires.

## Gates
- `tsc -b --noEmit` clean; `npm run build` (tsc + vite) green.
- `eslint` clean on every changed file (remaining findings in `CreateTenantPage`/`VouchersPage` are byte-identical on clean main — verified via stash-baseline).
- `vitest`: 63/63 across all touched suites; full-suite failures (68, in 9 untouched files: PinInput6/ParentDomainsPage/etc.) are byte-identical on clean main with this diff stashed — pre-existing, unrelated.

## Verification plan (post-merge)
Next rolled catalyst-ui image + authed walk on the live env: (1) BSS → Vouchers → Issue with `1234` → inline rejection; Issue with blank code → `VCH-…` row appears; (2) Catalog → edit summary → `Saved to IaC ✓` toast; (3) Cloud → Reconciliation lens → click a HelmRelease node → drill panel + controller logs; (4) Organizations → Create → copy no longer claims vCluster backing.

Refs #5223 #5113 #3376 #3996 #3958 #4325 #4914

🤖 Generated with [Claude Code](https://claude.com/claude-code)