### PR TITLE
fix(catalyst-api): sync shared-pg consumer hub secrets pre-mesh, not behind the full-mesh flip

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -506,7 +506,9 @@ type sharedPGConsumerWorkload struct {
 //
 // THE BUG: on a 2-region prov, region-B's keycloak/gitea/harbor boot during the
 // pre-ClusterMesh-flip SINGLETON phase against a region-LOCAL, randomly-minted
-// shared-pg password. After the flip, syncSharedPGConsumerHubSecrets overwrites
+// shared-pg password. Once region-A's hubs are authoritative (`-mesh-rw` —
+// since #5230 already in the pre-mesh phase; before #5230 only after the
+// full-mesh flip), syncSharedPGConsumerHubSecrets overwrites
 // region-B's divergent hub Secret with region-A's AUTHORITATIVE password (and
 // the DB role replicates onto the follower), but the already-running pod stays
 // pinned to the stale password it cached at boot → endless
@@ -932,6 +934,32 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 		h.emitClusterMeshProgress(dep, "warn",
 			fmt.Sprintf("ClusterMesh: region %q (cluster %q) unreachable before fan-out (%v) — peers will be marked disconnected", s.key, s.clusterName, s.err))
 	}
+
+	// ── #5230: EARLY shared-pg consumer-hub Secret sync (pre-mesh) ──────
+	// Hoisted OUT of enableCNPGPairAfterFullMesh (where it sat behind the
+	// countFullyMeshedRegions full-mesh gate): the #3629 consumer hub
+	// Secrets (harbor-database-secret + siblings) are plain data copies
+	// whose only real prerequisites are (a) region-A's authoritative hub
+	// Secrets carrying the topology-aware `-mesh-rw` host and (b) the
+	// replica region's apiserver being reachable — the mesh itself is NOT
+	// required (the `-mesh-rw` host resolves on the replica from first
+	// render via the replica-side stub Service). Keeping the sync behind
+	// the flip left region-B's harbor-core in CreateContainerConfigError
+	// (`secret "harbor-database-secret" not found`) for the whole
+	// mesh-establishment window — ≈22m37s on hw274, recurring on every
+	// fresh 2-region prov. Firing it here, BEFORE the up-to-5-min-per-
+	// region LB polling below, lands the hubs as early as the reconcile
+	// tick allows. Level-triggered + BEST-EFFORT like every #3629-family
+	// sync: it skips quietly when a source hub is absent (shared-pg
+	// disabled / consumer unconfigured / not yet minted), DEFERS any hub
+	// whose host is not yet `-mesh-rw`, and tolerates a nil replica
+	// clientset — so calling it on every pass (including passes where the
+	// mesh cannot establish) is safe and the re-run converges whatever
+	// this pass skipped. The flip-coupled replica-auth syncs
+	// (syncCNPGPairReplicaAuthSecrets / syncSharedPGReplicaAuthSecrets)
+	// deliberately stay inside enableCNPGPairAfterFullMesh — the replica
+	// Cluster CRs they feed exist only post-flip.
+	h.syncSharedPGConsumerHubSecrets(ctx, dep, slots)
 
 	// Step 1: per-region LB IP discovery (poll up to 5 min each).
 	for i := range slots {
@@ -1598,17 +1626,16 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 				patched++
 			}
 		}
-		// #3629 (best-effort, never blocks): once the flip has landed, region-A
-		// reconciles crossRegion=true and its bp-postgres hubs gain the
-		// topology-aware `-mesh-rw` host. Copy those hubs (correct password +
-		// host) primary → replica so the cross-region consumers (grafana,
-		// powerdns-admin, …) stop reading the divergent region-local hub each
-		// region minted in its singleton phase. The readiness gate inside the
-		// call defers any hub whose host is not yet `-mesh-rw`, so a first pass
-		// (before region-A's slot upgrade lands) is a harmless no-op and the
-		// #3241/#3583 level-trigger re-run converges it. NEVER gates the flip.
+		// #3629 → #5230: the consumer-hub Secret sync
+		// (syncSharedPGConsumerHubSecrets) is NO LONGER invoked here — it is
+		// hoisted into the early per-slot phase of autoEstablishClusterMesh
+		// (which precedes EVERY invocation of this function in the same
+		// reconcile pass), so the hubs land on the replica as soon as
+		// region-A's authoritative `-mesh-rw` Secrets + the replica clientset
+		// exist instead of waiting out the full-mesh flip (the ~22-min
+		// region-B harbor CreateContainerConfigError window on every fresh
+		// 2-region prov, hw274).
 		if sharedPGOn {
-			h.syncSharedPGConsumerHubSecrets(ctx, dep, slots)
 			// #4158 (best-effort, never blocks): one layer above the #3629
 			// consumer-hub DB secrets — region-B's keycloak boots against the
 			// cross-region-replicated shared-pg catalog (so its admin password
@@ -1871,6 +1898,17 @@ func (h *Handler) syncSharedPGReplicaAuthSecrets(ctx context.Context, dep *Deplo
 // failure is logged and SKIPPED, and the #3241/#3583 level-trigger re-run
 // converges it on a later pass. It returns nothing (the caller ignores the
 // outcome) precisely so it can never wedge convergence.
+//
+// CALL SITE (#5230): invoked from the EARLY per-slot phase of
+// autoEstablishClusterMesh — BEFORE LB discovery, on every level-trigger pass
+// — NOT from enableCNPGPairAfterFullMesh. The hubs need neither the mesh nor
+// the flip (plain data copies; the `-mesh-rw` host resolves on the replica
+// from first render via the stub Service), and gating them on the full-mesh
+// flip cost region-B's harbor-core a ≈22-min CreateContainerConfigError
+// window on every fresh 2-region prov (hw274). The internal skips above make
+// arbitrarily-early invocation safe: a pass before region-A minted its hubs
+// (or on a shared-pg-disabled Sovereign, where they never exist) skips every
+// name quietly.
 //
 // READINESS GATE: a hub Secret is propagated ONLY once its `host` key carries
 // the `-mesh-rw` marker — i.e. region-A has reconciled crossRegion=true and its

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -2838,6 +2838,73 @@ func TestSyncSharedPGConsumerHubSecrets(t *testing.T) {
 	})
 }
 
+// TestAutoEstablishClusterMesh_ConsumerHubSecretsSyncPreMesh locks in #5230:
+// the #3629 consumer-hub Secret sync must fire from the EARLY per-slot phase of
+// autoEstablishClusterMesh — clustermesh NOT required — not from behind the
+// countFullyMeshedRegions full-mesh gate inside enableCNPGPairAfterFullMesh.
+// Region B deliberately has NO LB ingress, so the mesh can NEVER fully
+// establish and the cnpg-pair flip path is never reached; under the pre-#5230
+// wiring the replica's hub Secret therefore stayed divergent for the whole
+// mesh-establishment window (hw274: region-B harbor-core sat in
+// CreateContainerConfigError `secret "harbor-database-secret" not found` for
+// ≈22m37s on every fresh 2-region prov). The only prerequisites the sync
+// genuinely has: region-A's authoritative `-mesh-rw` hub Secret + a reachable
+// replica clientset — both present here.
+func TestAutoEstablishClusterMesh_ConsumerHubSecretsSyncPreMesh(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", ""})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+	// Shrink the LB lookup timeout so region B's absent LB fails fast.
+	setClusterMeshLBOverrides(t, 200*time.Millisecond, 25*time.Millisecond)
+
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
+	// Region-A's hub is AUTHORITATIVE from first render on a fresh prov
+	// (topology-aware -mesh-rw host — the hw274 21:15:53 state).
+	seedHubSecret(t, primaryCS, "harbor-database-secret",
+		"shared-pg-mesh-rw.shared-data.svc.cluster.local", "region-A-authoritative-pw")
+	// Region-B carries its divergent singleton-phase copy (the defect state
+	// the sync must overwrite without waiting for the mesh).
+	seedHubSecret(t, replicaCS, "harbor-database-secret",
+		"shared-pg-rw.shared-data.svc.cluster.local", "region-B-divergent-pw")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+
+	// Sanity: the mesh must NOT be fully established (region B has no LB) —
+	// this is exactly the window in which the pre-#5230 wiring never synced.
+	if fullyMeshed := countFullyMeshedRegions(statuses); fullyMeshed == len(statuses) {
+		t.Fatalf("fixture invalid: mesh fully established (%d/%d) — the pre-mesh window this test locks in did not occur", fullyMeshed, len(statuses))
+	}
+	// Sanity: the cnpg-pair flip must not have landed either (the old call
+	// site's gate) — proves the sync observed below ran OUTSIDE the flip.
+	ks := getBootstrapKitKustomization(t, fx.dynClients[fx.secondaryKubeconfigPath])
+	substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if substitute[clusterMeshCNPGPairSubstituteKey] == "true" {
+		t.Fatalf("fixture invalid: SOVEREIGN_ENABLE_CNPG_PAIR flipped ON despite the mesh never establishing")
+	}
+
+	// THE #5230 ASSERTION: region-B's hub Secret already carries region-A's
+	// authoritative host + password — synced pre-mesh, on the very first pass.
+	got, ok := getSharedDataSecret(t, replicaCS, "harbor-database-secret")
+	if !ok {
+		t.Fatalf("replica hub Secret missing — pre-mesh consumer-hub sync did not run (#5230 regression: sync still gated behind the full-mesh flip)")
+	}
+	if h := string(got.Data["host"]); h != "shared-pg-mesh-rw.shared-data.svc.cluster.local" {
+		t.Errorf("replica host = %q, want the -mesh-rw host synced PRE-mesh (#5230)", h)
+	}
+	if p := string(got.Data["password"]); p != "region-A-authoritative-pw" {
+		t.Errorf("replica password = %q, want region-A's authoritative password synced PRE-mesh (#5230) — harbor-core would sit in CreateContainerConfigError until the full-mesh flip otherwise", p)
+	}
+}
+
 // TestReconcileSharedPGConsumerRestart locks in the #4878 RESIDUAL fix
 // (live-verified on hw232): the consumer rollout-restart must NOT fire the
 // instant the shared-data hub Secret changes — it must wait until the corrected


### PR DESCRIPTION
## Problem (hw274 RCA)

On every fresh 2-region prov, region-b's `harbor-database-secret` (and sibling shared-pg consumer hub Secrets) only materialized AFTER the full-mesh flip: `syncSharedPGConsumerHubSecrets` was nested inside `enableCNPGPairAfterFullMesh`, which `countFullyMeshedRegions` gates on every region fully meshed. hw274: region-b bp-harbor rendered 21:10:50 → harbor-core sat in `CreateContainerConfigError: secret "harbor-database-secret" not found` until the flip @21:31:17 → sync @21:32:21 → healthy @21:33:27. **~22m37s region-b harbor outage, recurring on every fresh prov.**

The gate is unnecessary for this leg: the hubs are plain data copies needing only (a) region-a's authoritative `-mesh-rw` hub Secrets and (b) a reachable region-b apiserver — clustermesh NOT required (the `-mesh-rw` host resolves on the replica from first render via the stub Service).

## Fix

- **Hoist** the `syncSharedPGConsumerHubSecrets(ctx, dep, slots)` call into the early per-slot phase of `autoEstablishClusterMesh` — right after `buildRegionSlots` + pre-fan-out error surfacing, BEFORE the up-to-5-min-per-region LB polling — so it fires on every level-trigger pass regardless of mesh state.
- **Remove** the nested call from `enableCNPGPairAfterFullMesh`: its single caller is `autoEstablishClusterMesh`, so every prior invocation path is still covered (earlier) in the same reconcile pass — no idempotence assumption is broken; keeping it would be pure double-invocation.
- The sync's existing internal guards make arbitrarily-early invocation safe: skips quietly on missing source Secrets (shared-pg disabled / not yet minted), defers non-`-mesh-rw` hosts, tolerates nil replica clientsets, and `copySecretAcrossClusters` is Get+compare (writes only on drift) — level-triggered and no-thrash per #3241/#3583.

**Unchanged by design** (per the RCA): `syncSharedPGReplicaAuthSecrets` stays flip-coupled (replica Cluster CRs exist only post-flip); `reconcileSharedPGConsumerRestart` / `rolloutRestartConsumerWorkload` stay as-is (#4878 fingerprint-idempotent, consistency-gated — hoisting the sync just lets the restart converge earlier).

## Test

New `TestAutoEstablishClusterMesh_ConsumerHubSecretsSyncPreMesh` (full fixture, mirrors neighboring `TestAutoEstablishClusterMesh_*` tests): region-b deliberately has NO LB so the mesh can never establish and the flip path is never reached, yet the replica must still receive region-a's authoritative `-mesh-rw` hub Secret, overwriting its divergent singleton-phase copy. Sanity guards assert the mesh did not converge and `SOVEREIGN_ENABLE_CNPG_PAIR` did not flip — proving the sync ran outside the flip.

**Verified regression lock**: the test was run against the pre-hoist wiring (fix stashed) and FAILS there (`replica password = "region-B-divergent-pw"`), passes with the hoist.

```
go build ./... && go vet ./...   # clean
go test ./internal/handler/...   # ok (158s, full suite)
```

Refs #5230 #5228

🤖 Generated with [Claude Code](https://claude.com/claude-code)