### PR TITLE
fix(cutover): pivot the Crossplane xpkg leg to DIGEST refs end-to-end (0.1.143)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -907,7 +907,21 @@ spec:
       # proxy-xpkg endpoint (full pull-through + artifact-API durable assert,
       # FATAL on a miss); step-11 verifies the same durable presence before
       # every spec.package rewrite (fail-loud). Contract Case 65.
-      version: 0.1.142
+      # 0.1.143 (#5232 Refs #5226 #5204): the xpkg leg moves to DIGEST refs
+      # end-to-end. Live hw274: Harbor proxy-cache never records TAGS for
+      # pulled-through xpkg artifacts (tag-create 401s on proxy projects; a
+      # tag manifest GET records nothing either), so the 0.1.142 tag-based
+      # Phase A4 durable-verify deterministically FATAL'd at step-03 and a
+      # tag-based step-11 pivot ref would 404 post-severance. Step-03 now
+      # resolves each package's tag->digest from the pulled-through scratch
+      # manifest, verifies durability BY DIGEST via the artifact API, and
+      # persists the map in the self-sovereign-cutover-xpkg-digests
+      # ConfigMap; step-11 pivots spec.package to
+      # harbor.<fqdn>/proxy-xpkg/<path>@sha256:<digest> (verify-before-pivot
+      # + the already-pivoted branch + the Gitea YAML rewrite all
+      # digest-based; tag-form live pivots upgraded; DIGEST-MISS FATALs with
+      # the exact recovery). Contract Case 65 re-locked.
+      version: 0.1.143
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.142
+  version: 0.1.143
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,58 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.143 (#5232 Refs #5226 #5204 — the xpkg leg moves to DIGEST refs
+# end-to-end. Live hw274 (dep d51a69f885872a81, first 0.1.142 run): step-03
+# Phase A4 FATAL'd `pulled through but never durably recorded` on
+# proxy-xpkg/upbound/provider-opentofu:v1.1.3 — the pull-through SUCCEEDED
+# and the artifact IS durably cached + queryable BY DIGEST
+# (sha256:d953d019..., media manifest.list.v2), but Harbor proxy-cache NEVER
+# records TAGS for pulled-through xpkg artifacts: manual tag-create 401s on
+# proxy projects, and a fresh tag manifest GET serves the OCI index without
+# recording the tag either (deterministic, not async lag). So (a) #5226's
+# tag-based Phase A4 durable-verify could never pass — the cutover halts at
+# step-03 pct=18 by design, and (b) step-11's tag-based spec.package pivot
+# ref would genuinely 404 post-severance. THREE coupled changes:
+#   (1) step-03 Phase A4 (template 03) — after the full pull-through, the
+#       tag->digest is resolved from the dir: scratch's top-level
+#       manifest.json (sha256 of the exact pulled-through manifest bytes IS
+#       the digest Harbor records — the #4994/#5030 sha256-of-raw-bytes
+#       identity, single-arch AND lists), the durable-presence poll probes
+#       the artifact API BY DIGEST (works today — hw274 evidence), and the
+#       map is persisted to the prewarm.xpkgPackages.digestMapConfigMapName
+#       ConfigMap (create-or-replace, release namespace) for step-11. The
+#       skip-if-present branch keys ONLY on a digest a PRIOR successful warm
+#       minted (in-ref #4955 digests aside) — never on a fresh tag resolve,
+#       which would itself pull the manifest through and could record the
+#       digest with COLD blobs. FATAL when the resolution or the CM persist
+#       fails (egress still open, recoverable).
+#   (2) step-11 (template 11) — every spec.package pivot ref is
+#       DIGEST-addressed: `harbor.<fqdn>/proxy-xpkg/<path>@sha256:<digest>`
+#       (Crossplane accepts digest package refs: spec.package is an
+#       unrestricted string [v1.18.0 cluster/crds/pkg.crossplane.io_
+#       providers.yaml] parsed via go-containerregistry name.ParseReference
+#       [internal/controller/pkg/manager/revisioner.go], and the xpkg naming
+#       layer treats ":@" as the identifier delimiter set [internal/xpkg/
+#       name.go]). Phase 1 rewrites BY the minted digest with the
+#       verify-before-pivot probe now digest-based; an ALREADY digest-pivoted
+#       Provider re-verifies by its own digest; a pre-#5232 TAG-form local
+#       pivot is UPGRADED to the digest form; a missing digest FATALs LOUD
+#       (DIGEST-MISS) naming the exact recovery (clear
+#       step.harbor-prewarm.result + re-trigger — the runCutover resume
+#       skips result=success steps, so a bare re-trigger alone would NOT
+#       re-run step-03). Phase 2's Gitea rewrite pushes the SAME digest form
+#       (all three source shapes: upstream host, #4488 mothership proxy
+#       prefix, tag-form local) so the bootstrap-kit reconcile re-asserts —
+#       never reverts — the live digest patch; refs with no minted digest
+#       (foreign-Sovereign/_template overlays, very-early-handover) keep the
+#       host-swap and upgrade on a later re-run. NO RBAC change (configmaps
+#       create/get/update/patch already granted cluster-wide). NO step-count
+#       / job-mode / deadline change (still 11 steps). Contract Case 65
+#       re-locks the digest resolution + digest verify + digest pivot-ref
+#       shape + the DIGEST-MISS FATAL; Case 39 unchanged (still exactly 2
+#       --multi-arch all copies). Slot-06a pin + blueprint.yaml +
+#       catalog-seed source.version + spec.version move to 0.1.143 in
+#       lockstep (Inviolable Principle #13).)
+# ── prior ──
 # 0.1.142 (#5204 Refs #5209 #3379 — the local Harbor must DURABLY hold every
 # Crossplane xpkg provider package BEFORE step-11 pivots onto it. #5209
 # (0.1.139) wired the package-pull AUTH, but NOTHING ever placed the xpkg OCI
@@ -47,7 +100,7 @@ name: bp-self-sovereign-cutover
 #       xpkg.upbound.io excludedHosts invariant. Slot-06a pin + blueprint.yaml
 #       + catalog-seed source.version + spec.version move to 0.1.142 in
 #       lockstep (Inviolable Principle #13).)
-# ── prior ──
+#
 # 0.1.141 (#5215 Refs #4996 #5074 — step-07 must NOT roll the EVS/hcloud CSI
 # driver. Root-caused live on hw271 (cutoverComplete=true then re-fire wedge):
 # step-07 rolled the csi-evs-node DaemonSet via TWO vectors — (1) the
@@ -2364,7 +2417,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.142
+version: 0.1.143
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -258,6 +258,19 @@ data:
             value: {{ .Values.crossplaneProviderPivot.registryPath | quote }}
           - name: XPKG_MOTHERSHIP_PROXY_PREFIX
             value: {{ .Values.crossplaneProviderPivot.mothershipProxyPrefix | quote }}
+          # #5232 (Refs #5226 #5204) — the tag->digest map Phase A4 records
+          # for step-11. Harbor proxy-cache NEVER records TAGS for
+          # pulled-through xpkg artifacts (manual tag-create 401s on proxy
+          # projects; a tag manifest GET serves the index but does not record
+          # the tag either — live hw274 dep d51a69f885872a81), so the step-11
+          # pivot ref must be DIGEST-addressed. Phase A4 resolves each
+          # package's digest at warm time (sha256 of the exact pulled-through
+          # manifest bytes) and persists it here; step-11 reads the SAME
+          # values-driven ConfigMap name (no drift).
+          - name: XPKG_DIGEST_CM
+            value: {{ .Values.prewarm.xpkgPackages.digestMapConfigMapName | quote }}
+          - name: RELEASE_NAMESPACE
+            value: {{ .Release.Namespace | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -1521,6 +1534,20 @@ data:
             # same fail-loud sovereignty contract as Phase A/A2. Step-11's
             # verify-before-pivot gate re-asserts this durable presence
             # immediately before each spec.package rewrite.
+            #
+            # #5232 (Refs #5226) — the durable verify + the step-11 pivot are
+            # DIGEST-addressed end-to-end. Live hw274 (dep d51a69f885872a81):
+            # Harbor proxy-cache NEVER records TAGS for pulled-through xpkg
+            # artifacts (manual tag-create 401s on proxy projects; a fresh
+            # tag manifest GET serves the OCI index but still records no tag
+            # — deterministic, not async lag), so the 0.1.142 tag-based
+            # artifact probe could never pass and a tag-based step-11 pivot
+            # ref would genuinely 404 post-severance. The artifact IS cached
+            # and queryable BY DIGEST. Phase A4 therefore resolves each
+            # package's tag->digest at warm time (sha256 of the exact
+            # pulled-through manifest bytes in the dir: scratch), verifies
+            # durability BY DIGEST, and persists the map in the
+            # XPKG_DIGEST_CM ConfigMap for step-11's digest pivot.
             xpkg_artifact_present() {
               # $1 = local path project/repo[:tag|@digest]; 0 when the local
               # Harbor DURABLY serves it (artifact API = Harbor CORE DB, never
@@ -1558,12 +1585,21 @@ data:
               # cold cache. A step re-run once crossplane lands warms the set.
               echo "[harbor-prewarm] Phase A4 SKIP — providers.pkg.crossplane.io CRD not installed yet (bp-crossplane not landed); packages warm on a later step re-run"
             else
-              echo "[harbor-prewarm] Phase A4: warm Crossplane xpkg provider packages through local ${XPKG_REGISTRY_PATH} (#5204)"
+              echo "[harbor-prewarm] Phase A4: warm Crossplane xpkg provider packages through local ${XPKG_REGISTRY_PATH} (#5204; digest-addressed durable verify #5232)"
               xpkg_target_host="harbor.${SOVEREIGN_FQDN}"
               xpkg_tsv=$(kubectl get providers.pkg.crossplane.io \
                 -o 'jsonpath={range .items[*]}{.metadata.name}{"\t"}{.spec.package}{"\n"}{end}' 2>/dev/null || true)
               xpkg_warm_dir=/tmp/xpkg-warm
               rm -rf "${xpkg_warm_dir}"; mkdir -p "${xpkg_warm_dir}"
+              # #5232 — the prior-run digest map (also the create-or-replace
+              # target below). A skip-if-present decision may ONLY key on a
+              # digest a PRIOR successful warm minted (full pull-through +
+              # durable verify): resolving a tag via a fresh manifest GET
+              # through the proxy would itself pull the manifest through and
+              # could record the artifact digest with COLD blobs — a
+              # durability hole. No prior digest -> full warm. Fail-closed.
+              xpkg_digest_map_json=$(kubectl get configmap "${XPKG_DIGEST_CM}" -n "${RELEASE_NAMESPACE}" -o json 2>/dev/null) || xpkg_digest_map_json='{}'
+              [ -n "${xpkg_digest_map_json}" ] || xpkg_digest_map_json='{}'
               printf '%s\n' "${xpkg_tsv}" | while IFS="$(printf '\t')" read -r _xw_name _xw_pkg; do
                 [ -z "${_xw_name}" ] && continue
                 [ -z "${_xw_pkg}" ] && continue
@@ -1594,12 +1630,36 @@ data:
                 esac
                 _xw_slug=$(printf '%s' "${_xw_lpath}" | tr -c 'A-Za-z0-9._-' '_')
                 : >"${xpkg_warm_dir}/${_xw_slug}.log"
-                # Idempotency: skip when the artifact is ALREADY durably cached
-                # (re-run / prior warm). Fail-closed — any probe miss warms.
-                if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ] && xpkg_artifact_present "${_xw_lpath}"; then
-                  echo "[harbor-prewarm] Phase A4 skip ${_xw_pkg} -> ${_xw_lpath} (already durably cached)"
-                  printf '%s (present)' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.ok"
-                  continue
+                # #5232 — split the local path into repo-path + ref. A source
+                # ref that already carries a digest (#4955 normalized
+                # tag@digest -> digest-only) IS the authoritative digest.
+                _xw_repo_path="${_xw_lpath}"
+                _xw_digest=""
+                case "${_xw_lpath}" in
+                  *@sha256:*)
+                    _xw_digest="${_xw_lpath##*@}"; _xw_repo_path="${_xw_lpath%@*}"
+                    case "${_xw_repo_path##*/}" in *:*) _xw_repo_path="${_xw_repo_path%:*}" ;; esac ;;
+                  *)
+                    case "${_xw_lpath##*/}" in *:*) _xw_repo_path="${_xw_lpath%:*}" ;; esac ;;
+                esac
+                # Idempotency (#4994/#5232): skip ONLY when a digest is
+                # already authoritative (in-ref, or minted by a PRIOR
+                # successful warm) AND that digest is durably present. A TAG
+                # can never be probed: Harbor proxy-cache NEVER records tags
+                # for pulled-through xpkg artifacts (live hw274 — manual
+                # tag-create 401s on proxy projects; a tag manifest GET does
+                # not record either). Fail-closed — any miss warms.
+                if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ]; then
+                  _xw_skip_digest="${_xw_digest}"
+                  if [ -z "${_xw_skip_digest}" ]; then
+                    _xw_skip_digest=$(printf '%s' "${xpkg_digest_map_json}" | jq -r --arg k "${_xw_slug}" '.data[$k] // empty' 2>/dev/null) || _xw_skip_digest=""
+                  fi
+                  if [ -n "${_xw_skip_digest}" ] && xpkg_artifact_present "${_xw_repo_path}@${_xw_skip_digest}"; then
+                    echo "[harbor-prewarm] Phase A4 skip ${_xw_pkg} -> ${_xw_repo_path}@${_xw_skip_digest} (already durably cached by digest)"
+                    printf '%s' "${_xw_skip_digest}" > "${xpkg_warm_dir}/${_xw_slug}.digest"
+                    printf '%s@%s (present)' "${_xw_repo_path}" "${_xw_skip_digest}" > "${xpkg_warm_dir}/${_xw_slug}.ok"
+                    continue
+                  fi
                 fi
                 echo "[harbor-prewarm] Phase A4 warm ${_xw_pkg} -> ${HARBOR_HOST}/${_xw_lpath} (full pull-through; manifest + all blobs cache durably)"
                 _xw_attempt=1
@@ -1632,6 +1692,16 @@ data:
                   _xw_attempt=$((_xw_attempt+1))
                   [ "${_xw_attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
                 done
+                # #5232 — resolve the tag->digest from the pulled-through
+                # scratch BEFORE freeing it: the dir: transport's top-level
+                # manifest.json is the EXACT manifest(-list) bytes the proxy
+                # served, so its sha256 IS the digest Harbor records for the
+                # cached artifact (the same sha256-of-raw-bytes identity
+                # dest_already_current relies on, single-arch AND lists).
+                if [ "${_xw_rc}" -eq 0 ] && [ -z "${_xw_digest}" ]; then
+                  _xw_digest_hex=$(sha256sum "${xpkg_warm_dir}/${_xw_slug}.dir/manifest.json" 2>/dev/null | awk '{print $1}') || _xw_digest_hex=""
+                  if [ -n "${_xw_digest_hex}" ]; then _xw_digest="sha256:${_xw_digest_hex}"; fi
+                fi
                 # The dir: copy is a scratch side-effect — the durable payload
                 # is what Harbor cached on the way through. Free the emptyDir.
                 rm -rf "${xpkg_warm_dir}/${_xw_slug}.dir"
@@ -1640,19 +1710,29 @@ data:
                   echo "[harbor-prewarm] Phase A4 done ${_xw_lpath} (FAIL exit=${_xw_rc})"
                   continue
                 fi
-                # Durable-presence poll (Harbor records proxied artifacts
-                # ASYNC): bounded 12x10s before the fail-closed verdict.
+                if [ -z "${_xw_digest}" ]; then
+                  # Without a digest step-11 has NOTHING valid to pivot to (a
+                  # tag ref 404s post-severance — Harbor never records tags on
+                  # proxy projects, #5232) — fail LOUD while egress is open.
+                  printf '%s (pulled through but tag->digest resolution failed)' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
+                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the scratch manifest.json digest could not be computed — no digest to record for the step-11 pivot (#5232)"
+                  continue
+                fi
+                # Durable-presence poll BY DIGEST (#5232 — Harbor records
+                # proxied artifacts ASYNC and never records their tags):
+                # bounded 12x10s before the fail-closed verdict.
                 _xw_present=0
                 for _xw_i in $(seq 1 12); do
-                  if xpkg_artifact_present "${_xw_lpath}"; then _xw_present=1; break; fi
+                  if xpkg_artifact_present "${_xw_repo_path}@${_xw_digest}"; then _xw_present=1; break; fi
                   sleep 10
                 done
                 if [ "${_xw_present}" -eq 1 ]; then
-                  printf '%s' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.ok"
-                  echo "[harbor-prewarm] Phase A4 done ${_xw_lpath} (durably cached)"
+                  printf '%s' "${_xw_digest}" > "${xpkg_warm_dir}/${_xw_slug}.digest"
+                  printf '%s@%s' "${_xw_repo_path}" "${_xw_digest}" > "${xpkg_warm_dir}/${_xw_slug}.ok"
+                  echo "[harbor-prewarm] Phase A4 done ${_xw_repo_path}@${_xw_digest} (durably cached by digest)"
                 else
-                  printf '%s (pulled through but never durably recorded)' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
-                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the Harbor artifact API never recorded the artifact durably (120s poll) — proxy-cache persistence failed"
+                  printf '%s@%s (pulled through but never durably recorded)' "${_xw_repo_path}" "${_xw_digest}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
+                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the Harbor artifact API never recorded ${_xw_digest} durably (120s poll) — proxy-cache persistence failed"
                 fi
               done
               xpkg_ok=0
@@ -1671,6 +1751,28 @@ data:
                 echo "[harbor-prewarm] Phase A4 FAIL $(cat "${f}")"
               done
               echo "[harbor-prewarm] Phase A4 complete: xpkg_ok=${xpkg_ok} xpkg_fail=${xpkg_fail}"
+              # #5232 — persist the tag->digest map for step-11 BEFORE the
+              # fail gate so partial progress is durable across a re-run.
+              # Create-or-replace: the enumerated live set fully re-emits
+              # every run (kubectl apply prunes keys absent from the render).
+              _xd_literals=""
+              _xd_count=0
+              for f in "${xpkg_warm_dir}"/*.digest; do
+                [ -e "${f}" ] || continue
+                _xd_literals="${_xd_literals} --from-literal=$(basename "${f}" .digest)=$(cat "${f}")"
+                _xd_count=$((_xd_count+1))
+              done
+              if [ "${_xd_count}" -gt 0 ]; then
+                if kubectl create configmap "${XPKG_DIGEST_CM}" -n "${RELEASE_NAMESPACE}" ${_xd_literals} \
+                    --dry-run=client -o json \
+                  | jq '.metadata.labels={"app.kubernetes.io/managed-by":"self-sovereign-cutover","bp.openova.io/cutover-step":"harbor-prewarm"}' \
+                  | kubectl apply -f - >/dev/null; then
+                  echo "[harbor-prewarm] Phase A4 recorded ${_xd_count} tag->digest entries in ConfigMap ${RELEASE_NAMESPACE}/${XPKG_DIGEST_CM} for the step-11 digest pivot (#5232)"
+                else
+                  echo "[harbor-prewarm] FATAL: failed to persist the xpkg tag->digest map to ConfigMap ${RELEASE_NAMESPACE}/${XPKG_DIGEST_CM} — step-11 cannot construct digest pivot refs without it (#5232)"
+                  exit 1
+                fi
+              fi
               if [ "${xpkg_fail}" -gt 0 ]; then
                 echo "[harbor-prewarm] FATAL: ${xpkg_fail} Crossplane xpkg package(s) failed to warm into local Harbor (named above) — step-11 would pivot Provider spec.package onto a ref the local registry cannot serve post-severance (#5204)"
                 exit 1

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -52,14 +52,18 @@ Phase inventory
            for every Provider CR (cluster-scoped). Computes the new
            package literal by replacing the `xpkg.upbound.io` prefix
            with `harbor.<SOVEREIGN_FQDN>/proxy-xpkg` while preserving
-           the path + tag. Triggers an immediate Crossplane revision
-           reconcile so the new package is fetched within seconds.
-  Phase 2  Push YAML edit to local Gitea — sed-in-place every
-           `clusters/<sov>/infrastructure/provider-<name>.yaml` carrying the
-           literal `xpkg.upbound.io/...`. Without this phase, the
-           bootstrap-kit Kustomization reconcile (every ~1 min from
+           the path, and (#5232) replacing the TAG with the
+           `@sha256:<digest>` step-03 Phase A4 minted — Harbor
+           proxy-cache never records tags for pulled-through xpkg
+           artifacts, so only a digest ref serves post-severance.
+           Triggers an immediate Crossplane revision reconcile so the
+           new package is fetched within seconds.
+  Phase 2  Push YAML edit to local Gitea — rewrite every
+           `clusters/<sov>/infrastructure/provider-<name>.yaml` package
+           literal to the SAME digest form (#5232). Without this phase,
+           the bootstrap-kit Kustomization reconcile (every ~1 min from
            local Gitea) would silently revert Phase 1 back to the
-           upstream URL within minutes.
+           upstream URL (or a dead tag-form ref) within minutes.
 
 Idempotency
 ───────────
@@ -179,6 +183,18 @@ data:
             value: {{ .Values.crossplaneProviderPivot.packagePullAuth.pullSecretName | quote }}
           - name: IMAGE_CONFIG_NAME
             value: {{ .Values.crossplaneProviderPivot.packagePullAuth.imageConfigName | quote }}
+          # #5232 (Refs #5226 #5204) — the tag->digest map step-03 Phase A4
+          # minted (Harbor proxy-cache never records TAGS for pulled-through
+          # xpkg artifacts, so every pivot ref below is digest-addressed).
+          # SAME values-driven ConfigMap name as step-03 — no drift.
+          - name: XPKG_DIGEST_CM
+            value: {{ .Values.prewarm.xpkgPackages.digestMapConfigMapName | quote }}
+          - name: RELEASE_NAMESPACE
+            value: {{ .Release.Namespace | quote }}
+          # The cutover status ConfigMap — named in the DIGEST-MISS recovery
+          # message (clearing step.harbor-prewarm.result forces the re-warm).
+          - name: STATUS_CM
+            value: {{ .Values.status.configMapName | quote }}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
@@ -333,6 +349,47 @@ data:
             # a verify miss records here and the parent FATALs after the loop.
             rm -f /tmp/xpkg-verify-failed
 
+            # ---- #5232: digest-addressed pivot refs ----
+            #
+            # Harbor proxy-cache NEVER records TAGS for pulled-through xpkg
+            # artifacts (live hw274 dep d51a69f885872a81: manual tag-create
+            # 401s on proxy projects; a fresh tag manifest GET serves the OCI
+            # index but still records no tag — deterministic), so a tag-form
+            # local ref genuinely 404s post-severance. Every spec.package
+            # pivot below is therefore DIGEST-addressed:
+            #   registry-path preserved, tag replaced by @sha256:<digest>.
+            # Crossplane's package manager accepts digest refs: spec.package
+            # is an unrestricted string (pkg.crossplane.io_providers.yaml CRD)
+            # parsed by go-containerregistry name.ParseReference (crossplane
+            # v1.18.0 internal/controller/pkg/manager/revisioner.go), and the
+            # xpkg naming layer treats ":@" as the identifier delimiter set
+            # (internal/xpkg/name.go) — digest identifiers are first-class.
+            # The ONLY digest mint is step-03 Phase A4's full pull-through +
+            # durable verify; there is NO live re-resolve here (a fresh tag
+            # GET through the proxy could record a manifest with COLD blobs).
+            xpkg_digest_map_json=$(kubectl get configmap "${XPKG_DIGEST_CM}" -n "${RELEASE_NAMESPACE}" -o json 2>/dev/null) || xpkg_digest_map_json='{}'
+            [ -n "${xpkg_digest_map_json}" ] || xpkg_digest_map_json='{}'
+            lookup_pkg_digest() {
+              # $1 = local path project/repo[:tag]; echoes the sha256:<hex>
+              # step-03 Phase A4 minted for this exact ref, or empty on miss.
+              # SAME slug idiom as step-03 (tr -c 'A-Za-z0-9._-' '_').
+              _ld_slug=$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_')
+              printf '%s' "${xpkg_digest_map_json}" | jq -r --arg k "${_ld_slug}" '.data[$k] // empty' 2>/dev/null || true
+            }
+            # split_pkg_ref REF -> sets _sp_repo (path with no ref) and
+            # _sp_digest (sha256:<hex> when REF carries one, else empty).
+            # Handles tag, digest, and the #4955 tag@digest shapes.
+            split_pkg_ref() {
+              _sp_repo="$1"; _sp_digest=""
+              case "${_sp_repo}" in
+                *@sha256:*)
+                  _sp_digest="${_sp_repo##*@}"; _sp_repo="${_sp_repo%@*}"
+                  case "${_sp_repo##*/}" in *:*) _sp_repo="${_sp_repo%:*}" ;; esac ;;
+                *)
+                  case "${_sp_repo##*/}" in *:*) _sp_repo="${_sp_repo%:*}" ;; esac ;;
+              esac
+            }
+
             # ---- Phase 1: live K8s patch on every Provider CR ----
             #
             # `kubectl get providers.pkg.crossplane.io` is cluster-scoped
@@ -385,17 +442,32 @@ data:
 
                   case "${pkg}" in
                     "${upstream_prefix}/"* | "${MOTHERSHIP_PROXY_PREFIX}/"*)
-                      # Compute new spec.package by replacing the matched
-                      # host(+path) prefix with the Sovereign-local one.
+                      # Compute the DIGEST pivot ref (#5232): registry path
+                      # from the matched suffix + the digest step-03 minted
+                      # (or the digest the source ref itself carries, the
+                      # #4955 shape). A tag-form pivot ref is FORBIDDEN — it
+                      # 404s post-severance (Harbor records no tags on proxy
+                      # projects).
                       pkg_suffix="${pkg#${matched_prefix}/}"
-                      new_pkg="${target_prefix}/${pkg_suffix}"
-                      # #5204 verify-before-pivot: the local artifact MUST be
-                      # durably present BEFORE the rewrite (fail-loud).
-                      if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg_suffix}"; then
-                        echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: local Harbor does not durably serve ${REGISTRY_PATH}/${pkg_suffix} — refusing to pivot spec.package onto a ref the local registry cannot serve post-severance (#5204; step-03 Phase A4 should have warmed it — re-trigger the cutover)" >&2
+                      split_pkg_ref "${pkg_suffix}"
+                      pkg_repo="${_sp_repo}"
+                      pkg_digest="${_sp_digest}"
+                      if [ -z "${pkg_digest}" ]; then
+                        pkg_digest=$(lookup_pkg_digest "${REGISTRY_PATH}/${pkg_suffix}")
+                      fi
+                      if [ -z "${pkg_digest}" ]; then
+                        echo "[crossplane-provider-pivot] DIGEST-MISS ${name}: no recorded tag->digest for ${REGISTRY_PATH}/${pkg_suffix} in ConfigMap ${RELEASE_NAMESPACE}/${XPKG_DIGEST_CM} — a tag-form pivot ref 404s post-severance (#5232). Force step-03 to re-warm+record: kubectl -n ${RELEASE_NAMESPACE} patch configmap ${STATUS_CM} --type merge -p '{\"data\":{\"step.harbor-prewarm.result\":\"\"}}' then re-trigger the cutover" >&2
                         touch /tmp/xpkg-verify-failed
                         continue
                       fi
+                      # #5204/#5232 verify-before-pivot BY DIGEST: the exact
+                      # artifact MUST be durably present BEFORE the rewrite.
+                      if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg_repo}@${pkg_digest}"; then
+                        echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: local Harbor does not durably serve ${REGISTRY_PATH}/${pkg_repo}@${pkg_digest} — refusing to pivot spec.package onto a ref the local registry cannot serve post-severance (#5204 #5232; step-03 Phase A4 should have warmed it)" >&2
+                        touch /tmp/xpkg-verify-failed
+                        continue
+                      fi
+                      new_pkg="${target_prefix}/${pkg_repo}@${pkg_digest}"
                       echo "[crossplane-provider-pivot] PATCH ${name} ${pkg} -> ${new_pkg}"
                       # Merge-patch only spec.package — preserves every
                       # other spec field (revisionActivationPolicy,
@@ -409,15 +481,45 @@ data:
                       fi
                       ;;
                     "${target_prefix}/"*)
-                      # #5204: an ALREADY-pivoted Provider must ALSO durably
-                      # resolve locally — this is exactly the hw270 latent
-                      # shape (pivoted ref, cold cache). Fail-loud too.
-                      if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg#${target_prefix}/}"; then
-                        echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: already pivoted to ${pkg} but the local Harbor does not durably serve ${REGISTRY_PATH}/${pkg#${target_prefix}/} (#5204; re-trigger the cutover so step-03 Phase A4 warms it)" >&2
-                        touch /tmp/xpkg-verify-failed
-                        continue
+                      piv_suffix="${pkg#${target_prefix}/}"
+                      split_pkg_ref "${piv_suffix}"
+                      piv_repo="${_sp_repo}"
+                      piv_digest="${_sp_digest}"
+                      if [ -n "${piv_digest}" ]; then
+                        # #5204/#5232: an ALREADY digest-pivoted Provider must
+                        # ALSO durably resolve locally — the hw270 latent
+                        # shape (pivoted ref, cold cache). Verify BY DIGEST.
+                        if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${piv_repo}@${piv_digest}"; then
+                          echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: already pivoted to ${pkg} but the local Harbor does not durably serve ${REGISTRY_PATH}/${piv_repo}@${piv_digest} (#5204 #5232; re-warm via step-03 Phase A4)" >&2
+                          touch /tmp/xpkg-verify-failed
+                          continue
+                        fi
+                        echo "[crossplane-provider-pivot] SKIP ${name} (already digest-pivoted: ${pkg})"
+                      else
+                        # A TAG-form local pivot (the pre-#5232 0.1.142 shape)
+                        # genuinely 404s post-severance — UPGRADE it to the
+                        # digest form step-03 minted.
+                        piv_digest=$(lookup_pkg_digest "${REGISTRY_PATH}/${piv_suffix}")
+                        if [ -z "${piv_digest}" ]; then
+                          echo "[crossplane-provider-pivot] DIGEST-MISS ${name}: already pivoted to TAG-form ${pkg} but no recorded tag->digest for ${REGISTRY_PATH}/${piv_suffix} in ConfigMap ${RELEASE_NAMESPACE}/${XPKG_DIGEST_CM} (#5232). Force step-03 to re-warm+record: kubectl -n ${RELEASE_NAMESPACE} patch configmap ${STATUS_CM} --type merge -p '{\"data\":{\"step.harbor-prewarm.result\":\"\"}}' then re-trigger the cutover" >&2
+                          touch /tmp/xpkg-verify-failed
+                          continue
+                        fi
+                        if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${piv_repo}@${piv_digest}"; then
+                          echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: local Harbor does not durably serve ${REGISTRY_PATH}/${piv_repo}@${piv_digest} — refusing the tag->digest upgrade (#5232)" >&2
+                          touch /tmp/xpkg-verify-failed
+                          continue
+                        fi
+                        new_pkg="${target_prefix}/${piv_repo}@${piv_digest}"
+                        echo "[crossplane-provider-pivot] PATCH ${name} ${pkg} -> ${new_pkg} (tag->digest upgrade, #5232)"
+                        patch_json=$(printf '{"spec":{"package":"%s"}}' "${new_pkg}")
+                        if kubectl patch provider.pkg.crossplane.io "${name}" \
+                            --type=merge --patch "${patch_json}" >/dev/null 2>&1; then
+                          echo "[crossplane-provider-pivot]   OK ${name}"
+                        else
+                          echo "[crossplane-provider-pivot]   FAIL ${name}" >&2
+                        fi
                       fi
-                      echo "[crossplane-provider-pivot] SKIP ${name} (already pivoted: ${pkg})"
                       ;;
                     *)
                       echo "[crossplane-provider-pivot] SKIP ${name} (package prefix not ${upstream_prefix}, ${MOTHERSHIP_PROXY_PREFIX}, or ${target_prefix}: ${pkg})"
@@ -432,7 +534,7 @@ data:
             # half-pivoted onto a ref the local registry cannot serve. The
             # live patches already applied are idempotent on the re-run.
             if [ -e /tmp/xpkg-verify-failed ]; then
-              echo "[crossplane-provider-pivot] FATAL: one or more Provider packages are NOT durably served by the local Harbor (VERIFY-FAIL lines above) — re-trigger the cutover so step-03 Phase A4 warms them (#5204)" >&2
+              echo "[crossplane-provider-pivot] FATAL: one or more Provider packages are NOT durably served by the local Harbor by digest (DIGEST-MISS / VERIFY-FAIL lines above) — nothing was durably rewritten. Recovery: clear the step-03 success marker so the re-trigger re-warms + re-records digests (kubectl -n ${RELEASE_NAMESPACE} patch configmap ${STATUS_CM} --type merge -p '{\"data\":{\"step.harbor-prewarm.result\":\"\"}}'), then re-trigger the cutover (#5204 #5232)" >&2
               exit 1
             fi
 
@@ -481,22 +583,58 @@ data:
             if [ -z "${matches}" ]; then
               echo "[crossplane-provider-pivot] no clusters/*/infrastructure/**/provider-*.yaml present in mirror"
             else
-              # Iterate, sed each file in-place. We escape `/` in the
-              # upstream/target prefixes so they don't terminate sed's
-              # delimiter; using `,` as delimiter is the simpler workaround
-              # (the prefixes never contain commas).
+              # #5232 — rewrite each file's `package:` literal to the DIGEST
+              # form so the bootstrap-kit reconcile from local Gitea
+              # re-asserts the SAME digest ref Phase 1 patched live (a
+              # tag-form YAML would revert the live patch on the next
+              # reconcile AND 404 post-severance). Handles all three source
+              # shapes Phase 1 handles: the raw upstream host, the mothership
+              # proxy prefix (#4488 Huawei), and a pre-#5232 tag-form local
+              # pivot. A ref with NO minted digest (a foreign-Sovereign /
+              # _template overlay whose Provider never ran on THIS cluster,
+              # or the very-early-handover path where step-03 skipped on the
+              # absent CRD) keeps the pre-#5232 host-swap so no upstream-host
+              # literal survives; the eventual step re-run upgrades it to the
+              # digest form. `,` sed delimiter — the refs never contain
+              # commas; the OLD literal has its `.` escaped for -E.
               for file in ${matches}; do
-                if grep -q "package: ${upstream_prefix}/" "${file}" 2>/dev/null; then
-                  if sed -i -E "s,(package:[[:space:]]+)${upstream_prefix}/,\1${target_prefix}/," "${file}"; then
-                    echo "[crossplane-provider-pivot] rewrote ${file}"
-                    edited=$((edited+1))
+                _f_changed=0
+                _f_pkgs=$(sed -n -E 's/^[[:space:]]*package:[[:space:]]+//p' "${file}" | sort -u)
+                for _f_pkg in ${_f_pkgs}; do
+                  _f_prefix=""
+                  case "${_f_pkg}" in
+                    "${upstream_prefix}/"*)         _f_prefix="${upstream_prefix}" ;;
+                    "${MOTHERSHIP_PROXY_PREFIX}/"*) _f_prefix="${MOTHERSHIP_PROXY_PREFIX}" ;;
+                    "${target_prefix}/"*@sha256:*)  continue ;;
+                    "${target_prefix}/"*)           _f_prefix="${target_prefix}" ;;
+                    *)                              continue ;;
+                  esac
+                  _f_suffix="${_f_pkg#${_f_prefix}/}"
+                  split_pkg_ref "${_f_suffix}"
+                  _f_repo="${_sp_repo}"
+                  _f_digest="${_sp_digest}"
+                  if [ -z "${_f_digest}" ]; then
+                    _f_digest=$(lookup_pkg_digest "${REGISTRY_PATH}/${_f_suffix}")
+                  fi
+                  if [ -n "${_f_digest}" ]; then
+                    _f_new="${target_prefix}/${_f_repo}@${_f_digest}"
+                  else
+                    _f_new="${target_prefix}/${_f_suffix}"
+                  fi
+                  if [ "${_f_pkg}" = "${_f_new}" ]; then
+                    echo "[crossplane-provider-pivot] SKIP ${file}: ${_f_pkg} (no digest recorded; already host-swapped — upgraded on a later step re-run)"
+                    continue
+                  fi
+                  _f_esc=$(printf '%s' "${_f_pkg}" | sed 's/\./\\./g')
+                  if sed -i -E "s,(package:[[:space:]]+)${_f_esc}([[:space:]]*)\$,\1${_f_new}\2," "${file}"; then
+                    echo "[crossplane-provider-pivot] rewrote ${file}: ${_f_pkg} -> ${_f_new}"
+                    _f_changed=1
                   else
                     echo "[crossplane-provider-pivot] WARN sed failed on ${file}" >&2
                   fi
-                elif grep -q "package: ${target_prefix}/" "${file}" 2>/dev/null; then
-                  echo "[crossplane-provider-pivot] SKIP ${file} (already pivoted)"
-                else
-                  echo "[crossplane-provider-pivot] SKIP ${file} (no upstream package literal found)"
+                done
+                if [ "${_f_changed}" -eq 1 ]; then
+                  edited=$((edited+1))
                 fi
               done
             fi
@@ -512,7 +650,7 @@ data:
               echo "[crossplane-provider-pivot] git diff empty after sed — nothing to commit"
               exit 0
             fi
-            git commit -m "cutover: pivot Crossplane Provider spec.package to harbor.${SOVEREIGN_FQDN}/${REGISTRY_PATH}" >/dev/null
+            git commit -m "cutover: pivot Crossplane Provider spec.package to harbor.${SOVEREIGN_FQDN}/${REGISTRY_PATH} by digest (#5232)" >/dev/null
             push_err=$(git push origin main 2>&1) || {
               echo "[crossplane-provider-pivot] FATAL: git push failed" >&2
               printf '%s\n' "$push_err" >&2

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2931,20 +2931,28 @@ fi
 if [ "$c64_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5215: step-07 excludes the CSI driver from BOTH the additionalHRs HR pivot [excludeHelmReleases] AND the Phase 4 pod-spec sweep [podSpecSweep.excludeWorkloads]; the exclusion renders auditably and is deny-wins against an overlay re-add)"
 
-# ── Case 65 (#5204, Refs #5209 #3379): Crossplane xpkg provider packages are
-# DURABLY warmed into the local Harbor proxy-xpkg project by step-03 Phase A4,
-# and step-11 pivots spec.package ONLY after verifying the artifact serves
+# ── Case 65 (#5204 + #5232, Refs #5209 #5226 #3379): Crossplane xpkg provider
+# packages are DURABLY warmed into the local Harbor proxy-xpkg project by
+# step-03 Phase A4 WITH a tag->digest resolution, and step-11 pivots
+# spec.package BY DIGEST only after verifying the digest artifact serves
 # locally (fail-loud) ─────────────────────────────────────────────────────────
-# Root cause (live hw270 dep b2f0a9b0585f6781): step-11 pivots
+# Root cause #5204 (live hw270 dep b2f0a9b0585f6781): step-11 pivots
 # Provider.spec.package to harbor.<fqdn>/proxy-xpkg/... and #5209 wired the
 # pull AUTH, but harbor-prewarm SKIPPED the xpkg packages entirely
 # (xpkg.upbound.io is in offlineMirror.excludedHosts, and `proxy-xpkg` is the
 # ONE project that stays a Harbor PROXY-CACHE — Harbor rejects pushes into a
 # proxy-cache project, so the Phase A skopeo-push route cannot serve it). On a
 # COLD cache the post-severance provider re-pull cannot resolve its package
-# descriptor from the local registry. This Case asserts the xpkg refs now
-# appear in the step-03 prewarm work (Phase A4 warm) + the step-11 gate.
-echo "[cutover-contract] Case 65: step-03 Phase A4 warms Crossplane xpkg provider packages into local proxy-xpkg + step-11 verifies durable local presence before each spec.package pivot (#5204)"
+# descriptor from the local registry.
+# Root cause #5232 (live hw274 dep d51a69f885872a81): Harbor proxy-cache NEVER
+# records TAGS for pulled-through xpkg artifacts (manual tag-create 401s on
+# proxy projects; a fresh tag manifest GET serves the OCI index but records no
+# tag — deterministic), so the #5204 tag-based durable-verify could never pass
+# (step-03 FATAL'd at pct=18) and a tag-based step-11 pivot ref would
+# genuinely 404 post-severance. The artifact IS cached + queryable BY DIGEST.
+# This Case asserts the warm + the digest resolution + the digest-addressed
+# durable verify + the digest-addressed pivot end-to-end.
+echo "[cutover-contract] Case 65: step-03 Phase A4 warms Crossplane xpkg provider packages into local proxy-xpkg with tag->digest resolution + step-11 pivots spec.package BY DIGEST after a digest-addressed durable verify (#5204 #5232)"
 [ -s "$TMP/s03pin.yaml" ] || awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml"
 c65_fail=0
 # (a) step-03 enumerates the Provider package refs — the SAME set step-11
@@ -2980,6 +2988,34 @@ fi
 if ! grep -qF 'Crossplane xpkg package(s) failed to warm' "$TMP/s03pin.yaml"; then
   echo "FAIL: step-03 Phase A4 lost the xpkg_fail>0 FATAL — an unwarmed package would silently ship a cold cache into the step-11 pivot (#5204)" >&2; c65_fail=1
 fi
+# (d2) #5232: the tag->digest is resolved from the pulled-through dir: scratch
+#     (sha256 of the exact top-level manifest bytes IS the digest Harbor
+#     records), the durable poll probes BY DIGEST (tags are never recorded on
+#     proxy projects — hw274), a failed resolution FATALs, and the map is
+#     persisted to the XPKG_DIGEST_CM ConfigMap for step-11.
+if ! grep -qF 'sha256sum "${xpkg_warm_dir}/${_xw_slug}.dir/manifest.json"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 does not resolve the tag->digest from the pulled-through scratch manifest.json — step-11 has no digest to pivot by and a tag ref 404s post-severance (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'xpkg_artifact_present "${_xw_repo_path}@${_xw_digest}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 durable-presence poll is not DIGEST-addressed — a tag-based probe deterministically fails on proxy-cache artifacts (Harbor records no tags; live hw274) (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'tag->digest resolution failed' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 lost the FATAL on a failed tag->digest resolution — step-11 would have nothing valid to pivot to (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'kubectl create configmap "${XPKG_DIGEST_CM}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 does not persist the tag->digest map to the XPKG_DIGEST_CM ConfigMap — step-11 cannot construct digest pivot refs (#5232)" >&2; c65_fail=1
+fi
+# (d3) #5232: the skip-if-present branch keys ONLY on a digest a PRIOR
+#     successful warm minted (or an in-ref #4955 digest) — never on a fresh
+#     tag resolve through the proxy, which could record a manifest with COLD
+#     blobs (a durability hole).
+if ! grep -qF 'xpkg_artifact_present "${_xw_repo_path}@${_xw_skip_digest}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 skip-if-present is not keyed on a prior-minted digest — a tag-based (or fresh-resolve) skip either never fires or can false-skip on a cold-blob manifest record (#5232)" >&2; c65_fail=1
+fi
+# (d4) #5232: both steps project the SAME values-driven digest-map CM name.
+if ! grep -A1 'name: XPKG_DIGEST_CM' "$TMP/s03pin.yaml" | grep -q 'value: "self-sovereign-cutover-xpkg-digests"'; then
+  echo "FAIL: step-03 does not project XPKG_DIGEST_CM from prewarm.xpkgPackages.digestMapConfigMapName (#5232)" >&2; c65_fail=1
+fi
 # (e) xpkg.upbound.io STAYS excluded from the generic offline mirror — the
 #     Phase A push route targets push-mode projects and cannot serve the
 #     proxy-cache proxy-xpkg; Phase A4 is the dedicated leg.
@@ -2995,20 +3031,45 @@ helm template smoke-noxpkg . --show-only templates/03-harbor-prewarm-job.yaml --
 if ! grep -A1 'name: XPKG_PREWARM_ENABLED' "$TMP/r03_5204_off.yaml" | grep -q 'value: "false"'; then
   echo "FAIL: prewarm.xpkgPackages.enabled=false did not render XPKG_PREWARM_ENABLED=\"false\" — the operator override is not wired (#5204)" >&2; c65_fail=1
 fi
-# (g) step-11: the verify gate exists, fires BEFORE the patch AND on the
-#     already-pivoted SKIP branch, and a miss FATALs via the sentinel.
+# (g) step-11: the verify gate exists, is DIGEST-addressed, fires BEFORE the
+#     patch AND on the already-pivoted branch, the pivot ref itself is the
+#     digest form, a pre-#5232 tag-form local pivot is UPGRADED, and a
+#     missing digest / verify miss FATALs via the sentinel.
 helm template smoke . --show-only templates/11-crossplane-provider-pivot-job.yaml > "$TMP/r11_5204.yaml"
 if ! grep -qF 'verify_local_pkg_artifact()' "$TMP/r11_5204.yaml"; then
   echo "FAIL: step-11 lost the verify_local_pkg_artifact gate — spec.package can be pivoted onto a ref the local registry never durably serves (#5204)" >&2; c65_fail=1
 fi
-if ! grep -qF 'verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg_suffix}"' "$TMP/r11_5204.yaml"; then
-  echo "FAIL: step-11's Phase-1 patch branch does not invoke the verify gate BEFORE the spec.package rewrite (#5204)" >&2; c65_fail=1
+if ! grep -qF 'lookup_pkg_digest' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 lost the lookup into the step-03 tag->digest map — without it every pivot ref stays tag-form and 404s post-severance (#5232)" >&2; c65_fail=1
 fi
-if ! grep -qF 'verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg#${target_prefix}/}"' "$TMP/r11_5204.yaml"; then
-  echo "FAIL: step-11 does not re-verify an ALREADY-pivoted Provider — the hw270 latent shape (pivoted ref, cold cache) would pass silently (#5204)" >&2; c65_fail=1
+if ! grep -A1 'name: XPKG_DIGEST_CM' "$TMP/r11_5204.yaml" | grep -q 'value: "self-sovereign-cutover-xpkg-digests"'; then
+  echo "FAIL: step-11 does not project XPKG_DIGEST_CM from prewarm.xpkgPackages.digestMapConfigMapName — the two steps can drift onto different maps (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg_repo}@${pkg_digest}"' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11's Phase-1 patch branch does not verify BY DIGEST before the spec.package rewrite (#5204 #5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'new_pkg="${target_prefix}/${pkg_repo}@${pkg_digest}"' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11's pivot ref is not the digest form <target>/<path>@sha256:<digest> — a tag-form ref genuinely 404s post-severance (Harbor records no tags on proxy projects; live hw274) (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'verify_local_pkg_artifact "${REGISTRY_PATH}/${piv_repo}@${piv_digest}"' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 does not re-verify an ALREADY-pivoted Provider BY DIGEST — the hw270 latent shape (pivoted ref, cold cache) would pass silently (#5204 #5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'tag->digest upgrade' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 does not UPGRADE a pre-#5232 tag-form local pivot to the digest form — the 0.1.142-era live shape would keep a dead tag ref (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'DIGEST-MISS' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 lost the DIGEST-MISS fail-loud path — a missing tag->digest entry must FATAL naming the recovery, never silently pivot a tag ref (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'step.harbor-prewarm.result' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11's DIGEST-MISS recovery does not name the step-03 success-marker clear — the runCutover resume skips result=success steps, so a bare re-trigger alone would NOT re-run step-03 (#5232)" >&2; c65_fail=1
 fi
 if ! grep -qF '/tmp/xpkg-verify-failed' "$TMP/r11_5204.yaml" || ! grep -qF 'NOT durably served by the local Harbor' "$TMP/r11_5204.yaml"; then
   echo "FAIL: step-11 lost the fail-loud sentinel — a verify miss inside the pipeline-subshell loop must FATAL the step before the durable Gitea rewrite (#5204)" >&2; c65_fail=1
+fi
+# (g2) #5232: Phase 2's Gitea rewrite pushes the SAME digest form so the
+#     bootstrap-kit reconcile re-asserts (never reverts) the live patch.
+if ! grep -qF '_f_new="${target_prefix}/${_f_repo}@${_f_digest}"' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 Phase 2 does not rewrite the Gitea YAML package literal to the digest form — the bootstrap-kit reconcile would revert the live digest patch to a tag ref within minutes (#5232)" >&2; c65_fail=1
 fi
 if ! grep -A1 'name: VERIFY_LOCAL_ARTIFACT' "$TMP/r11_5204.yaml" | grep -q 'value: "true"'; then
   echo "FAIL: VERIFY_LOCAL_ARTIFACT does not default to \"true\" (crossplaneProviderPivot.verifyLocalArtifact.enabled) (#5204)" >&2; c65_fail=1
@@ -3018,6 +3079,6 @@ if ! grep -A1 'name: VERIFY_LOCAL_ARTIFACT' "$TMP/r11_5204_off.yaml" | grep -q '
   echo "FAIL: crossplaneProviderPivot.verifyLocalArtifact.enabled=false did not render VERIFY_LOCAL_ARTIFACT=\"false\" — the operator override is not wired (#5204)" >&2; c65_fail=1
 fi
 if [ "$c65_fail" -ne 0 ]; then exit 1; fi
-echo "  PASS (#5204: step-03 Phase A4 enumerates the Provider spec.package set and warms each xpkg ref DURABLY through the local proxy-xpkg endpoint [pull-through — Harbor rejects pushes into a proxy-cache project] with an artifact-API durable assert + FATAL; step-11 verifies the same durable presence before every pivot AND on already-pivoted refs, failing loud via the sentinel; both toggles operator-wired; xpkg.upbound.io stays excluded from the generic push mirror)"
+echo "  PASS (#5204 #5232: step-03 Phase A4 enumerates the Provider spec.package set, warms each xpkg ref DURABLY through the local proxy-xpkg endpoint [pull-through — Harbor rejects pushes into a proxy-cache project], resolves the tag->digest from the pulled-through scratch manifest, asserts durability BY DIGEST via the artifact API [tags are never recorded on proxy projects — hw274], persists the map + FATALs on any miss; step-11 pivots spec.package BY the minted digest with digest-addressed verify-before-pivot, re-verifies already-pivoted refs by digest, upgrades tag-form live pivots, pushes the digest form to Gitea, and FATALs loud on DIGEST-MISS naming the exact recovery; both toggles operator-wired; xpkg.upbound.io stays excluded from the generic push mirror)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -675,6 +675,15 @@ prewarm:
   # a Sovereign that intentionally keeps the xpkg upstream leg open.
   xpkgPackages:
     enabled: true
+    # #5232 (Refs #5226 #5204) — the release-namespace ConfigMap where Phase
+    # A4 records each warmed package's tag->digest resolution. Harbor
+    # proxy-cache NEVER records TAGS for pulled-through xpkg artifacts
+    # (manual tag-create 401s on proxy projects; a tag manifest GET serves
+    # the index but does not record the tag either — live hw274 dep
+    # d51a69f885872a81), so step-11 pivots Provider.spec.package BY DIGEST
+    # using this map; a tag-form pivot ref would 404 post-severance. The
+    # SAME value is read by BOTH step templates (no drift).
+    digestMapConfigMapName: "self-sovereign-cutover-xpkg-digests"
   # #4975 (Refs #3379 #3695) — RETIRED. This hand-maintained 11-image HEAD list
   # (the old Phase B "warm the proxy-cache" pass) was one of the three drifting
   # lists that caused the per-prov whack-a-mole: any upstream image a chart added

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.142"
+  version: "0.1.143"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.142"
+    version: "0.1.143"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

Chart `bp-self-sovereign-cutover` 0.1.142 → **0.1.143**: the Crossplane xpkg leg moves to **digest refs end-to-end** — step-03 Phase A4 resolves + records each package's tag→digest at warm time, and step-11 pivots `Provider.spec.package` to `registry-path@sha256:<digest>`.

## Why (live hw274, dep `d51a69f885872a81`, first 0.1.142 run)

Harbor proxy-cache **never records TAGS** for pulled-through xpkg artifacts:
- manual tag-create → **401** (Harbor forbids writes incl. tag-create on proxy projects),
- a fresh tag-based manifest GET → 200 (serves the OCI index) but the tag is **still not recorded** — deterministic, not async lag.

So #5226's tag-based Phase A4 durable-verify could never pass (`Phase A4 FAIL proxy-xpkg/upbound/provider-opentofu:v1.1.3 (pulled through but never durably recorded)` → FATAL, cutover halted at pct=18, failedStep=harbor-prewarm), and step-11's tag-based pivot ref would genuinely **404 post-severance**. The artifact IS durably cached and queryable **by digest** (`sha256:d953d019...`, media `manifest.list.v2`).

## Digest flow — before / after

| Leg | 0.1.142 (tag-based) | 0.1.143 (digest-based) |
|---|---|---|
| A4 durable verify | `GET /artifacts/v1.1.3` → never recorded → deterministic FATAL | tag→digest resolved from the pulled-through `dir:` scratch `manifest.json` (sha256 of the exact manifest bytes IS the digest — the #4994/#5030 identity); `GET /artifacts/sha256:<digest>` → works today |
| A4 skip-if-present | tag probe (never fires for tag refs) | keys ONLY on a digest a **prior successful warm** minted (or an in-ref #4955 digest) — a fresh tag resolve through the proxy could record a cold-blob manifest (durability hole), so it is never used |
| cross-step handoff | none | `self-sovereign-cutover-xpkg-digests` ConfigMap (release ns, `prewarm.xpkgPackages.digestMapConfigMapName`, create-or-replace, kubectl idiom already RBAC'd) |
| step-11 Phase 1 | `<target>/<path>:<tag>` + tag verify | `<target>/<path>@sha256:<digest>` + digest verify; already-digest-pivoted refs re-verify by digest; pre-0.1.143 **tag-form live pivots are UPGRADED** to digest form; missing digest → **DIGEST-MISS FATAL** naming the exact recovery (`kubectl -n <ns> patch configmap self-sovereign-cutover-status --type merge -p '{"data":{"step.harbor-prewarm.result":""}}'` + re-trigger — the runCutover resume skips `result=success` steps, so a bare re-trigger alone would NOT re-run step-03) |
| step-11 Phase 2 (Gitea) | host-swap, tag preserved → would revert the live digest patch on the next bootstrap-kit reconcile | digest form for all three source shapes (upstream host, #4488 mothership proxy prefix, tag-form local); refs with no minted digest (foreign-Sovereign/_template overlays, very-early-handover) keep the host-swap and upgrade on a later re-run |

## Proof Crossplane accepts digest package refs (v1.18.0, the pinned upstream)

- `cluster/crds/pkg.crossplane.io_providers.yaml`: `spec.package` is an **unrestricted string** — no pattern/format validation.
- `internal/controller/pkg/manager/revisioner.go`: `name.ParseReference(p.GetSource(), name.WithDefaultRegistry(r.registry))` — go-containerregistry parses `repo@sha256:...` natively as `name.Digest`; the revision ID derives from `fetcher.Head(ctx, ref).Digest.Hex`.
- `internal/xpkg/name.go`: `identifierDelimeters = ":@"` — digest identifiers are first-class in the xpkg naming layer.
- This chart's own #4955 normalization + the `_xa_pp` @-parsers already handled digest-carrying `spec.package` values.

## Validation

- `helm lint` → 1 chart linted, 0 failed.
- `tests/cutover-contract.sh` → **All gates green** (Case 65 re-locked on: scratch-manifest digest resolution, digest-addressed durable probe, prior-minted-digest-only skip, map persist, digest pivot-ref shape, already-pivoted digest verify, tag→digest upgrade, DIGEST-MISS FATAL + recovery naming, Phase-2 digest rewrite, shared CM-name env on both steps; Case 39 unchanged — still exactly 2 `--multi-arch all` copies).
- `bash -n` + `sh -n` on the rendered step-03 (1519 lines) and step-11 (465 lines) scripts → clean.
- **Runtime simulation** of the rendered scripts with stubbed kubectl/skopeo/curl/git: step-11 pivots `xpkg.upbound.io/upbound/provider-opentofu:v1.1.3 → harbor.<fqdn>/proxy-xpkg/upbound/provider-opentofu@sha256:d953d019...`, upgrades a tag-form local pivot, digest-SKIPs a digest-form ref, rewrites the Gitea YAML to the digest form, and exits 1 on DIGEST-MISS with zero patches applied; step-03 A4 resolves the digest from the scratch manifest, publishes the map with the step-11-compatible slug key, FATALs fail-closed when the durable record never appears (the exact hw274 shape), and skips without any skopeo copy on a re-run with a prior-minted digest.
- `scripts/check-catalog-seed-lockstep.sh` → checked 68, fail 0.
- Lockstep pins moved to 0.1.143: `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`, `platform/self-sovereign-cutover/blueprint.yaml`, `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (source.version + spec.version).

No RBAC change (configmaps create/get/update/patch already cluster-wide). No step-count / job-mode / deadline change (still 11 steps). No NodePort.

Refs #5232 #5204

🤖 Generated with [Claude Code](https://claude.com/claude-code)