### PR TITLE
fix(provisioning): per-Org repo commit is a genuine per-attempt CAS; terminal exhaustion paints the funnel red step

### DIFF
--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -79,20 +79,37 @@ func (c *Client) WithRepo(owner, repo string) *Client {
 // rebuild (getRef → tree → commit → updateRef) when updateRef returns
 // "Update is not a fast forward". Concurrent day-2 installs race at the
 // branch-ref level; a clean rebuild against the new HEAD succeeds on the
-// next try. 5 attempts handles bursts of ~5 parallel commits.
-const commitAttemptsMax = 5
+// next try.
+//
+// #5234 (hw274): 5 attempts was sized for a burst of ~5 parallel one-shot
+// commits — but the org-controller's per-Org reconcile advances the SAME
+// `<slug>/catalyst-tenant@main` head with a BURST of sequential single-file
+// PutFile commits (~10+ per reconcile, re-fired on every requeue while the
+// funnel Org is converging). The funnel's cart-install batch commit kept
+// landing mid-burst and lost the compare-and-swap 5/5 times inside the old
+// ~1.5s retry window ("ref-race persisted after 5 attempts" → the purchased
+// app never deployed). 10 attempts paired with the widened backoff below
+// gives the loser a multi-second window that straddles a whole burst.
+const commitAttemptsMax = 10
 
 // Backoff bounds for the ref-race retry. Without a delay every concurrent
 // writer that lost the compare-and-swap retries simultaneously and re-loses
 // against the SAME winner — a thundering herd that can burn all
 // commitAttemptsMax attempts in milliseconds on the shared `org-tenants`
-// branch (Refs #3376). A short jittered exponential backoff staggers the
-// racers so each gets a clear shot at the moved HEAD. Bounds are small —
-// Gitea ref updates land in tens of ms — so the worst-case total added
-// latency across 4 backoffs stays well under a second.
-const (
+// branch (Refs #3376). A jittered exponential backoff staggers the racers so
+// each gets a clear shot at the moved HEAD.
+//
+// #5234: the cap was 750ms, sized for one-shot racers. Against the
+// org-controller's sequential PutFile bursts the whole 4-backoff window
+// (~1.5s worst case) fit INSIDE a single burst, so every attempt re-lost.
+// The 4s cap stretches the worst-case total window to ~18s across 9
+// backoffs (expected ~9s with full jitter) — longer than any observed
+// reconcile burst, while staying well inside the day-2 consumer's budget.
+// Vars (not consts) so tests can shrink the delays to keep the
+// exhaustion-path tests fast.
+var (
 	commitRetryBaseDelay = 50 * time.Millisecond
-	commitRetryMaxDelay  = 750 * time.Millisecond
+	commitRetryMaxDelay  = 4 * time.Second
 )
 
 // commitRetryBackoff returns the jittered backoff to wait before the given
@@ -609,6 +626,19 @@ func (c *Client) ensureBranchExists(ctx context.Context, branch string) error {
 //   - "is at <sha> but expected <sha>"                              (CAS mismatch)
 //   - "unable to create '...refs/heads/<branch>.lock': File exists" (lock-file race)
 //   - "failed to update ref"                                       (generic ref-update wrap)
+//
+// #5234 — two MORE CAS-loss shapes come from the per-file SHA preconditions
+// the batch ChangeFiles payload carries (the file-level compare-and-swap):
+//   - "repository file already exists [path: …]" — our `create` op raced a
+//     concurrent create of the same path (e.g. both the org-controller and
+//     the funnel seeding/merging `vcluster/apps/kustomization.yaml`);
+//   - "sha does not match [given: …, expected: …]" — our `update` op carried
+//     a per-file SHA that went stale because a concurrent writer changed the
+//     file after our tree/contents probe.
+// Both mean a concurrent writer won; a fresh re-probe on the next attempt
+// converts the op (create→update / stale-SHA→current-SHA) and succeeds.
+// Before this they fell through to the fatal `change files` branch and the
+// retry loop never engaged.
 func isGiteaRefRaceError(err error) bool {
 	if err == nil {
 		return false
@@ -625,7 +655,11 @@ func isGiteaRefRaceError(err error) bool {
 		strings.Contains(s, "cannot lock ref") ||
 		strings.Contains(s, "but expected") ||
 		(strings.Contains(s, "unable to create") && strings.Contains(s, ".lock")) ||
-		strings.Contains(s, "failed to update ref")
+		strings.Contains(s, "failed to update ref") ||
+		// file-level CAS losses from the ChangeFiles per-file SHA
+		// preconditions (#5234) — see doc comment above.
+		strings.Contains(s, "repository file already exists") ||
+		strings.Contains(s, "sha does not match")
 }
 
 // getContentSHA returns the blob SHA of `path` at `branch`, or "" if the

--- a/core/services/provisioning/github/client_cas_5234_test.go
+++ b/core/services/provisioning/github/client_cas_5234_test.go
@@ -1,0 +1,191 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// #5234 (hw274) — the funnel's purchased-app commit to the per-Org
+// `<slug>/catalyst-tenant` repo raced the org-controller's per-file PutFile
+// commit bursts and reported "ref-race persisted after 5 attempts": the
+// purchased WordPress never landed in the Org boundary. The durable fix makes
+// every retry a genuine compare-and-swap: re-read the remote head + per-file
+// SHAs on EVERY attempt, push with those fresh SHA preconditions, classify
+// the file-level CAS-loss rejections (422 "sha does not match" / "repository
+// file already exists") as retryable, and widen the attempt budget + jittered
+// backoff so the loser's window straddles a whole controller burst.
+//
+// The fake Gitea below simulates the concurrent writer PRECISELY: it advances
+// the tracked file's SHA right after serving each probe (the concurrent
+// writer lands between our read and our push), and accepts a batch ONLY when
+// the batch's update op carries the CURRENT SHA. A client that reused a stale
+// base would re-send the first SHA forever and exhaust; the CAS client
+// re-probes per attempt and lands on the first un-raced window.
+
+// casFakeGitea is a minimal contents-API server tracking one file whose SHA a
+// simulated concurrent writer keeps advancing.
+type casFakeGitea struct {
+	t *testing.T
+
+	mu sync.Mutex
+	// fileSHA is the CURRENT blob SHA of the tracked file.
+	fileSHA int
+	// advanceRemaining is how many more times the concurrent writer advances
+	// the file right after our probe reads it (-1 = advance forever, the
+	// permanently-hot-branch case).
+	advanceRemaining int
+	postCount        int
+	// lastAcceptedSHA records the sha the winning batch carried.
+	lastAcceptedSHA string
+}
+
+const casTrackedFile = "vcluster/apps/kustomization.yaml"
+
+func (f *casFakeGitea) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			f.mu.Lock()
+			head := fmt.Sprintf("headsha-%040d", f.fileSHA)
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `[{"object":{"sha":"%s"}}]`, head)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/"+casTrackedFile):
+			// Per-file SHA probe (getContentSHA). Serve the CURRENT SHA, then
+			// let the concurrent writer win the window between this read and
+			// the upcoming POST.
+			f.mu.Lock()
+			sha := fmt.Sprintf("filesha-%d", f.fileSHA)
+			if f.advanceRemaining != 0 {
+				f.fileSHA++
+				if f.advanceRemaining > 0 {
+					f.advanceRemaining--
+				}
+			}
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"sha":"%s","content":"","encoding":"base64"}`, sha)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			body, _ := io.ReadAll(r.Body)
+			var payload struct {
+				Files []struct {
+					Operation string `json:"operation"`
+					Path      string `json:"path"`
+					SHA       string `json:"sha"`
+				} `json:"files"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				f.t.Errorf("batch body not JSON: %v", err)
+				http.Error(w, "bad body", http.StatusBadRequest)
+				return
+			}
+			var got string
+			for _, file := range payload.Files {
+				if file.Path == casTrackedFile {
+					got = file.SHA
+				}
+			}
+			f.mu.Lock()
+			f.postCount++
+			want := fmt.Sprintf("filesha-%d", f.fileSHA)
+			stale := got != want
+			if !stale {
+				f.lastAcceptedSHA = got
+			}
+			f.mu.Unlock()
+			if stale {
+				// Gitea's file-level CAS rejection: 422 + the git-native
+				// wording (NOT a 409, so only the #5234 classifier shape
+				// makes the retry loop engage).
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				fmt.Fprintf(w, `{"message":"sha does not match [given: %s, expected: %s]"}`, got, want)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"newcommitsha00000000000000000000000000"}}`))
+		default:
+			f.t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}
+}
+
+// TestCommitFiles_GiteaTarget_RebasesOntoAdvancedHead_5234 drives the exact
+// hw274 race: a concurrent writer advances the tracked file between the
+// client's probe and its push, twice. The CAS retry must re-probe the moved
+// head on every attempt and land once the writer stops — with the CURRENT
+// per-file SHA, proving the push was rebuilt against the new head rather than
+// replaying the first attempt's stale base.
+func TestCommitFiles_GiteaTarget_RebasesOntoAdvancedHead_5234(t *testing.T) {
+	fake := &casFakeGitea{t: t, fileSHA: 1, advanceRemaining: 2}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "acme274", "catalyst-tenant", srv.URL)
+	err := c.CommitFiles(context.Background(), "main", "day-2: install wordpress", map[string]string{
+		casTrackedFile: "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - app-wordpress.yaml\n",
+	})
+	if err != nil {
+		t.Fatalf("CommitFiles should have re-probed the advanced head and succeeded, got: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.postCount != 3 {
+		t.Errorf("expected 3 POSTs (2 CAS losses + 1 win), got %d", fake.postCount)
+	}
+	want := fmt.Sprintf("filesha-%d", fake.fileSHA)
+	if fake.lastAcceptedSHA != want {
+		t.Errorf("winning batch carried sha %q, want the CURRENT head's %q — the retry did not rebuild against the advanced head", fake.lastAcceptedSHA, want)
+	}
+}
+
+// TestCommitFiles_GiteaTarget_PermanentlyAdvancingRefExhausts_5234 asserts the
+// bounded terminal outcome: when the concurrent writer NEVER stops advancing
+// the file, the client burns exactly commitAttemptsMax attempts and returns
+// the descriptive ref-race exhaustion error — a hard failure the caller MUST
+// surface (red step / failed Job), never a silent success.
+func TestCommitFiles_GiteaTarget_PermanentlyAdvancingRefExhausts_5234(t *testing.T) {
+	shrinkCommitRetryDelays(t)
+	fake := &casFakeGitea{t: t, fileSHA: 1, advanceRemaining: -1}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "acme274", "catalyst-tenant", srv.URL)
+	err := c.CommitFiles(context.Background(), "main", "day-2: install wordpress", map[string]string{
+		casTrackedFile: "resources: []\n",
+	})
+	if err == nil {
+		t.Fatalf("expected a terminal ref-race error on a permanently-advancing head, got nil (silent success)")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("ref-race persisted after %d attempts", commitAttemptsMax)) {
+		t.Errorf("error should report exhaustion after %d attempts, got: %v", commitAttemptsMax, err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.postCount != commitAttemptsMax {
+		t.Errorf("expected exactly %d POST attempts (commitAttemptsMax), got %d", commitAttemptsMax, fake.postCount)
+	}
+}
+
+// TestCommitAttemptsBudget_5234 pins the widened retry envelope: 10 attempts
+// against the org-controller's PutFile bursts (was 5 — exhausted inside a
+// single burst on hw274) and a 4s backoff cap so the jittered window
+// straddles a whole burst instead of fitting inside one.
+func TestCommitAttemptsBudget_5234(t *testing.T) {
+	if commitAttemptsMax < 10 {
+		t.Errorf("commitAttemptsMax = %d, want >= 10 (#5234 — 5 exhausted inside one org-controller commit burst)", commitAttemptsMax)
+	}
+	if commitRetryMaxDelay.Milliseconds() < 2000 {
+		t.Errorf("commitRetryMaxDelay = %s, want >= 2s (#5234 — 750ms window fit inside a single burst)", commitRetryMaxDelay)
+	}
+}

--- a/core/services/provisioning/github/client_reflock_test.go
+++ b/core/services/provisioning/github/client_reflock_test.go
@@ -78,12 +78,26 @@ func TestCommitFiles_GiteaTarget_RetriesOnRefLock(t *testing.T) {
 	}
 }
 
+// shrinkCommitRetryDelays drops the ref-race backoff bounds to near-zero for
+// the duration of a test so exhaustion-path tests (#5234: 10 attempts, 4s
+// cap) complete in milliseconds. Restores the production values on cleanup.
+func shrinkCommitRetryDelays(t *testing.T) {
+	t.Helper()
+	origBase, origMax := commitRetryBaseDelay, commitRetryMaxDelay
+	commitRetryBaseDelay = 1 * time.Millisecond
+	commitRetryMaxDelay = 5 * time.Millisecond
+	t.Cleanup(func() {
+		commitRetryBaseDelay, commitRetryMaxDelay = origBase, origMax
+	})
+}
+
 // TestCommitFiles_GiteaTarget_RefLockPersists asserts that when the ref-lock
 // race NEVER clears, the client exhausts commitAttemptsMax and returns a
 // descriptive ref-race error (rather than hanging or masking the failure).
 // This guards the bound on the retry so a pathological hot branch can't spin
 // forever.
 func TestCommitFiles_GiteaTarget_RefLockPersists(t *testing.T) {
+	shrinkCommitRetryDelays(t)
 	var (
 		mu        sync.Mutex
 		postCount int
@@ -186,6 +200,13 @@ func TestIsGiteaRefRaceError_RefLockShapes(t *testing.T) {
 		"stale base",
 		"ref has been updated by another request",
 		"Update is not a fast forward",
+		// #5234 — file-level CAS losses from the ChangeFiles per-file SHA
+		// preconditions. Gitea returns these as 422 (no " 409 " marker), so
+		// they MUST match on wording: a concurrent writer created the same
+		// path first (create raced) or changed the file after our probe
+		// (stale update SHA). Both resolve on a fresh re-probe + retry.
+		`GitHub API POST .../contents: 422 {"message":"repository file already exists [path: vcluster/apps/kustomization.yaml]"}`,
+		`GitHub API POST .../contents: 422 {"message":"sha does not match [given: aaaa, expected: bbbb]"}`,
 	}
 	for _, s := range retryable {
 		if !isGiteaRefRaceError(simpleErr(s)) {

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -217,6 +217,13 @@ func (h *Handler) runInstallJob(ctx context.Context, data appChangeData) error {
 			"action":     "install",
 			"error":      err.Error(),
 		})
+		// #5234 — a terminally-failed step-0 commit (e.g. a ref-race that
+		// persisted through every CAS retry) means the purchased app can NEVER
+		// deploy from this dispatch. Fail the Org's in-flight funnel provision
+		// NOW — red "Deploying <app>" step + provision.failed → customer
+		// status "failed" — instead of letting the timeline burn the full
+		// 10-minute pod wait before surfacing anything.
+		h.failActiveProvisionForCommitError(ctx, data, err)
 		return err
 	}
 	h.markJobStep(ctx, job, 0, "completed", "ok")
@@ -660,6 +667,18 @@ func (h *Handler) perOrgBranch() string {
 // an uninstall removes them) WITHOUT touching the org-controller's boundary
 // baseline (networkpolicy.yaml / ciliumnetworkpolicy.yaml), which is preserved
 // in the merged kustomization.
+//
+// #5234 — the commit is a genuine per-attempt compare-and-swap. The
+// org-controller writes the SAME repo concurrently (one PutFile commit per
+// rendered manifest, per reconcile), so the funnel's batch commit routinely
+// loses the ref CAS mid-burst. The file map — including the read-modify-write
+// merges of both kustomization indexes — used to be built ONCE before the
+// retry loop, so every retry re-pushed content based on a STALE base read
+// (the exact #1031 defect class, now against the org-controller's #5104
+// merge-writes). The build now runs inside a rebuild closure the client
+// invokes at the start of EVERY attempt: each retry re-reads the remote
+// head's kustomization indexes / tree listings / DB password and re-merges
+// onto them before re-pushing with fresh per-file SHA preconditions.
 func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeData, action, planSlug string, appSlugs []string, _ string) error {
 	slug := data.TenantSlug
 	repoClient := h.GitHubClient.WithRepo(slug, h.perOrgRepoName())
@@ -667,15 +686,6 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 	// on a Sovereign). Commit to the branch the org-controller's per-Org Flux
 	// GitRepository actually watches.
 	branch := h.perOrgBranch()
-
-	// Preserve the existing DB password if the per-Org repo already carries a
-	// db Secret (so a second cart install / day-2 change keeps the running DB
-	// password). Read from the SAME per-Org tree we write to.
-	dbPassword := readDBPasswordFromTree(ctx, repoClient, branch, gitops.PerOrgAppsDir)
-	if dbPassword == "" {
-		slog.Info("day-2: no existing DB password found in per-Org repo — generating fresh (first DB install)",
-			"tenant", slug, "action", action, "repo", slug+"/"+h.perOrgRepoName())
-	}
 
 	// #4999: render the per-Org app hosts under the Org's CHOSEN (served) pool
 	// zone — the SAME zone resolveOrgParentDomain stamps on the Org CR's
@@ -695,90 +705,116 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 		gen = &clone
 	}
 
-	appFiles, appDocs := gen.GeneratePerOrgAppsTree(slug, planSlug, appSlugs, dbPassword)
-	if len(appFiles) == 0 && action == "install" {
-		// No deployable Application payload on an INSTALL (e.g. the cart held
-		// only HR-overlay apps the generic generator can't emit, or an empty
-		// cart). Nothing to commit — not an error. On an UNINSTALL we still
-		// fall through to prune the stale file + rebuild the kustomization.
+	// buildPerOrgFiles assembles the COMPLETE per-Org commit payload from the
+	// remote head's CURRENT state. Called before the commit (for the
+	// empty-payload early return, via the returned payload count) and again on
+	// every ref-race retry (#5234) so a retry never replays a merge computed
+	// against a superseded head.
+	buildPerOrgFiles := func(ctx context.Context) (map[string]string, int, error) {
+		// Preserve the existing DB password if the per-Org repo already carries a
+		// db Secret (so a second cart install / day-2 change keeps the running DB
+		// password). Read from the SAME per-Org tree we write to — re-read per
+		// attempt so a concurrent install's freshly-minted password is honored.
+		dbPassword := readDBPasswordFromTree(ctx, repoClient, branch, gitops.PerOrgAppsDir)
+		if dbPassword == "" {
+			slog.Info("day-2: no existing DB password found in per-Org repo — generating fresh (first DB install)",
+				"tenant", slug, "action", action, "repo", slug+"/"+h.perOrgRepoName())
+		}
+
+		appFiles, appDocs := gen.GeneratePerOrgAppsTree(slug, planSlug, appSlugs, dbPassword)
+		payloadCount := len(appFiles)
+		if appFiles == nil {
+			appFiles = map[string]string{}
+		}
+
+		// Merge the new app docs into the org-controller's vcluster/apps
+		// kustomization (read-modify-write so the NP/CNP baseline + any prior
+		// cart apps survive). On uninstall, the rebuilt list reflects ONLY the
+		// surviving app docs (appDocs no longer lists the removed app) plus the
+		// baseline. Empty existing → MergePerOrgAppsKustomization seeds the
+		// baseline + the current docs.
+		//
+		// #5104 — the merge is plan-aware AND tree-derived: it force-includes the
+		// org-controller baseline for this plan (networkpolicy.yaml; plus the #4992
+		// vcluster target-ns namespace.yaml for the vcluster tier) and every
+		// baseline-shaped doc ACTUALLY committed under vcluster/apps/ (best-effort
+		// dir listing — nil on error, the plan-aware list still covers the known
+		// docs). Before this, the merge knew only networkpolicy.yaml, so the funnel
+		// index dropped namespace.yaml → the target ns never existed inside the
+		// vcluster → the apps Flux Kustomization wedged on `namespaces "<slug>"
+		// not found` and the purchased app never deployed (2/2 Orgs, hw255).
+		kustPath := gitops.PerOrgAppsDir + "/kustomization.yaml"
+		existingKust := ""
+		if content, err := repoClient.ReadFile(ctx, branch, kustPath); err == nil {
+			existingKust = content
+		}
+		appsTreeDocs, err := repoClient.ListDir(ctx, branch, gitops.PerOrgAppsDir)
+		if err != nil {
+			appsTreeDocs = nil // best-effort — plan-aware baseline still applies
+		}
+		if action == "uninstall" {
+			// Rebuild from the baseline + the SURVIVING app docs only, so the
+			// removed app is dropped from resources (a plain merge would preserve
+			// it because it's still listed in the existing kustomization).
+			appFiles[kustPath] = gitops.MergePerOrgAppsKustomization("", planSlug, appsTreeDocs, appDocs)
+		} else {
+			appFiles[kustPath] = gitops.MergePerOrgAppsKustomization(existingKust, planSlug, appsTreeDocs, appDocs)
+		}
+
+		// #4993 — for the VCLUSTER tier, also emit the HOST-NATIVE per-app HTTPRoutes
+		// into vcluster/host-apps/. The app's own HTTPRoute is co-located INSIDE the
+		// vcluster (apps tree, kubeConfig-targeted) but loft vcluster 0.33.4 registers
+		// no httproute reflecting controller, so it never reaches the host Cilium
+		// Gateway → 404 with pods Running. The host-native route binds the SYNCED
+		// Service (<app>-x-<slug>-x-vcluster) on the host `<slug>` ns directly — the
+		// same host-native model the per-Org console route uses. The org-controller
+		// SEEDS vcluster/host-apps/kustomization.yaml once and never clobbers it, so
+		// merge our route docs in (preserving the CNP + provisioning-rbac baseline),
+		// exactly as the apps kustomization above. Host-tier Orgs route via the
+		// co-located generateAppHTTPRoute (plain Service in the host ns), so
+		// GeneratePerOrgHostAppRoutes returns nothing and this block is a no-op.
+		if gitops.BoundaryIsVcluster(planSlug) {
+			hostRouteFiles, hostAppDocs := gen.GeneratePerOrgHostAppRoutes(slug, planSlug, appSlugs)
+			for p, c := range hostRouteFiles {
+				appFiles[p] = c
+			}
+			hostKustPath := gitops.PerOrgHostAppsDir + "/kustomization.yaml"
+			existingHostKust := ""
+			if content, err := repoClient.ReadFile(ctx, branch, hostKustPath); err == nil {
+				existingHostKust = content
+			}
+			// #5104 — same tree-derived baseline preservation as the apps merge
+			// above: any baseline-shaped doc the org-controller committed under
+			// vcluster/host-apps/ survives the merge even if this build predates it.
+			hostTreeDocs, err := repoClient.ListDir(ctx, branch, gitops.PerOrgHostAppsDir)
+			if err != nil {
+				hostTreeDocs = nil // best-effort
+			}
+			if action == "uninstall" {
+				// Rebuild from baseline + SURVIVING route docs only (drops the
+				// removed app's route from the index).
+				appFiles[hostKustPath] = gitops.MergePerOrgHostAppsKustomization("", hostTreeDocs, hostAppDocs)
+			} else {
+				appFiles[hostKustPath] = gitops.MergePerOrgHostAppsKustomization(existingHostKust, hostTreeDocs, hostAppDocs)
+			}
+		}
+		return appFiles, payloadCount, nil
+	}
+
+	// First build runs BEFORE the commit loop so the empty-payload install
+	// stays a clean no-commit no-op (e.g. the cart held only HR-overlay apps
+	// the generic generator can't emit, or an empty cart). On an UNINSTALL we
+	// still fall through to prune the stale file + rebuild the kustomization.
+	// The app payload is deterministic per (slug, plan, apps), so emptiness
+	// cannot change across retries — only the merge inputs can.
+	firstFiles, payloadCount, err := buildPerOrgFiles(ctx)
+	if err != nil {
+		return err
+	}
+	if payloadCount == 0 && action == "install" {
 		slog.Info("day-2 (per-Org): no deployable app payload to commit",
 			"tenant", slug, "action", action, "apps", len(appSlugs))
 		return nil
-	}
-	if appFiles == nil {
-		appFiles = map[string]string{}
-	}
-
-	// Merge the new app docs into the org-controller's vcluster/apps
-	// kustomization (read-modify-write so the NP/CNP baseline + any prior
-	// cart apps survive). On uninstall, the rebuilt list reflects ONLY the
-	// surviving app docs (appDocs no longer lists the removed app) plus the
-	// baseline. Empty existing → MergePerOrgAppsKustomization seeds the
-	// baseline + the current docs.
-	//
-	// #5104 — the merge is plan-aware AND tree-derived: it force-includes the
-	// org-controller baseline for this plan (networkpolicy.yaml; plus the #4992
-	// vcluster target-ns namespace.yaml for the vcluster tier) and every
-	// baseline-shaped doc ACTUALLY committed under vcluster/apps/ (best-effort
-	// dir listing — nil on error, the plan-aware list still covers the known
-	// docs). Before this, the merge knew only networkpolicy.yaml, so the funnel
-	// index dropped namespace.yaml → the target ns never existed inside the
-	// vcluster → the apps Flux Kustomization wedged on `namespaces "<slug>"
-	// not found` and the purchased app never deployed (2/2 Orgs, hw255).
-	kustPath := gitops.PerOrgAppsDir + "/kustomization.yaml"
-	existingKust := ""
-	if content, err := repoClient.ReadFile(ctx, branch, kustPath); err == nil {
-		existingKust = content
-	}
-	appsTreeDocs, err := repoClient.ListDir(ctx, branch, gitops.PerOrgAppsDir)
-	if err != nil {
-		appsTreeDocs = nil // best-effort — plan-aware baseline still applies
-	}
-	if action == "uninstall" {
-		// Rebuild from the baseline + the SURVIVING app docs only, so the
-		// removed app is dropped from resources (a plain merge would preserve
-		// it because it's still listed in the existing kustomization).
-		appFiles[kustPath] = gitops.MergePerOrgAppsKustomization("", planSlug, appsTreeDocs, appDocs)
-	} else {
-		appFiles[kustPath] = gitops.MergePerOrgAppsKustomization(existingKust, planSlug, appsTreeDocs, appDocs)
-	}
-
-	// #4993 — for the VCLUSTER tier, also emit the HOST-NATIVE per-app HTTPRoutes
-	// into vcluster/host-apps/. The app's own HTTPRoute is co-located INSIDE the
-	// vcluster (apps tree, kubeConfig-targeted) but loft vcluster 0.33.4 registers
-	// no httproute reflecting controller, so it never reaches the host Cilium
-	// Gateway → 404 with pods Running. The host-native route binds the SYNCED
-	// Service (<app>-x-<slug>-x-vcluster) on the host `<slug>` ns directly — the
-	// same host-native model the per-Org console route uses. The org-controller
-	// SEEDS vcluster/host-apps/kustomization.yaml once and never clobbers it, so
-	// merge our route docs in (preserving the CNP + provisioning-rbac baseline),
-	// exactly as the apps kustomization above. Host-tier Orgs route via the
-	// co-located generateAppHTTPRoute (plain Service in the host ns), so
-	// GeneratePerOrgHostAppRoutes returns nothing and this block is a no-op.
-	if gitops.BoundaryIsVcluster(planSlug) {
-		hostRouteFiles, hostAppDocs := gen.GeneratePerOrgHostAppRoutes(slug, planSlug, appSlugs)
-		for p, c := range hostRouteFiles {
-			appFiles[p] = c
-		}
-		hostKustPath := gitops.PerOrgHostAppsDir + "/kustomization.yaml"
-		existingHostKust := ""
-		if content, err := repoClient.ReadFile(ctx, branch, hostKustPath); err == nil {
-			existingHostKust = content
-		}
-		// #5104 — same tree-derived baseline preservation as the apps merge
-		// above: any baseline-shaped doc the org-controller committed under
-		// vcluster/host-apps/ survives the merge even if this build predates it.
-		hostTreeDocs, err := repoClient.ListDir(ctx, branch, gitops.PerOrgHostAppsDir)
-		if err != nil {
-			hostTreeDocs = nil // best-effort
-		}
-		if action == "uninstall" {
-			// Rebuild from baseline + SURVIVING route docs only (drops the
-			// removed app's route from the index).
-			appFiles[hostKustPath] = gitops.MergePerOrgHostAppsKustomization("", hostTreeDocs, hostAppDocs)
-		} else {
-			appFiles[hostKustPath] = gitops.MergePerOrgHostAppsKustomization(existingHostKust, hostTreeDocs, hostAppDocs)
-		}
 	}
 
 	// Prune scope: ONLY the funnel-owned app docs (so uninstalled apps are
@@ -797,14 +833,27 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 		gitops.PerOrgHostAppsDir + "/app-",
 	}
 
+	// Rebuild-per-attempt (#5234): attempt 1 reuses the map built above (no
+	// double remote read on the happy path); every RETRY re-runs the full
+	// build against the freshly-moved head before re-pushing.
+	firstAttempt := true
+	rebuild := func(ctx context.Context) (map[string]string, error) {
+		if firstAttempt {
+			firstAttempt = false
+			return firstFiles, nil
+		}
+		files, _, buildErr := buildPerOrgFiles(ctx)
+		return files, buildErr
+	}
+
 	commitMsg := fmt.Sprintf("day-2: %s %s on Org %s (apps: %d) → vcluster/apps",
 		action, data.AppSlug, slug, len(appSlugs))
-	if err := repoClient.CommitFilesWithPrune(ctx, branch, commitMsg, appFiles, prunePrefixes); err != nil {
+	if err := repoClient.CommitFilesWithPruneAndRebuild(ctx, branch, commitMsg, nil, prunePrefixes, rebuild); err != nil {
 		return fmt.Errorf("commit to per-Org repo %s/%s: %w", slug, h.perOrgRepoName(), err)
 	}
 	slog.Info("day-2 (per-Org): committed app manifests to per-Org repo",
 		"tenant", slug, "action", action, "apps", len(appSlugs),
-		"repo", slug+"/"+h.perOrgRepoName(), "branch", branch, "files", len(appFiles))
+		"repo", slug+"/"+h.perOrgRepoName(), "branch", branch)
 	return nil
 }
 

--- a/core/services/provisioning/handlers/pending_install_reconciler.go
+++ b/core/services/provisioning/handlers/pending_install_reconciler.go
@@ -89,6 +89,10 @@ func (h *Handler) reconcilePendingInstalls(ctx context.Context) {
 				"action":     "install",
 				"error":      msg,
 			})
+			// #5234 — the purchased app can never deploy from this dispatch;
+			// paint the funnel timeline red now instead of leaving the
+			// "Deploying <app>" step running.
+			h.failActiveProvisionForCommitError(ctx, data, fmt.Errorf("%s", msg))
 			continue
 		}
 
@@ -130,6 +134,10 @@ func (h *Handler) reconcilePendingInstalls(ctx context.Context) {
 			"action":     "install",
 			"error":      err.Error(),
 		})
+		// #5234 — same terminal-state propagation as the synchronous path:
+		// fail the in-flight funnel provision immediately (red step +
+		// provision.failed → customer status "failed").
+		h.failActiveProvisionForCommitError(ctx, data, err)
 	}
 	if committed > 0 {
 		slog.Info("pending-install reconciler: self-healed parked installs", "count", committed)

--- a/core/services/provisioning/handlers/perorg_commit_cas_5234_test.go
+++ b/core/services/provisioning/handlers/perorg_commit_cas_5234_test.go
@@ -1,0 +1,374 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
+	"github.com/openova-io/openova/core/services/provisioning/gitops"
+	"github.com/openova-io/openova/core/services/provisioning/store"
+	"github.com/openova-io/openova/core/services/shared/events"
+)
+
+// #5234 (hw274) — the funnel's purchased-app commit to the per-Org
+// `<slug>/catalyst-tenant` repo lost the ref compare-and-swap to the
+// org-controller's per-file PutFile commit bursts on every attempt ("ref-race
+// persisted after 5 attempts") and the purchased WordPress never deployed.
+// Root defect on the handler side: applyTenantChangePerOrg built its file map
+// — INCLUDING the read-modify-write merges of the kustomization indexes —
+// ONCE before the retry loop, so a retry re-pushed content computed against a
+// superseded head (the #1031 stale-base class, now against the
+// org-controller's #5104 merge-writes). The tests here prove:
+//
+//  1. the commit rebuilds its merge against the NEW head on every retry (the
+//     org-controller's mid-race index write survives into the winning batch);
+//  2. a terminally-exhausted ref-race error is NOT classified as the parkable
+//     #4404 "Gitea not ready" race — the caller must take the FAIL branch;
+//  3. the terminal failure paints the in-flight funnel provision red
+//     immediately (machine-readable step + provision.failed event), instead
+//     of leaving "Deploying <app>" running for the 10-minute pod wait.
+
+// giteaRebuildFake is a fake Gitea contents API whose vcluster/apps tree
+// gains an org-controller-authored baseline doc (resourcequota.yaml) right
+// after the first (rejected) batch POST — simulating the concurrent
+// controller merge-write landing mid-race.
+type giteaRebuildFake struct {
+	t *testing.T
+
+	mu        sync.Mutex
+	phase     int // 1 = pre-race tree, 2 = controller's write landed
+	postCount int
+	batches   [][]byte
+}
+
+func (f *giteaRebuildFake) kustContent() string {
+	base := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - networkpolicy.yaml\n"
+	if f.phase >= 2 {
+		base += "  - resourcequota.yaml\n"
+	}
+	return base
+}
+
+func (f *giteaRebuildFake) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		phase := f.phase
+		f.mu.Unlock()
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/plans"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"s","slug":"s"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/apps"):
+			// resolveAppSlugs id→slug lookup.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"wordpress","slug":"wordpress"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `[{"object":{"sha":"headsha-%036d"}}]`, phase)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/trees/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tree":[],"truncated":false}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps"):
+			// ListDir — the dir listing the #5104 tree-derived merge reads.
+			w.Header().Set("Content-Type", "application/json")
+			if phase >= 2 {
+				_, _ = w.Write([]byte(`[{"name":"networkpolicy.yaml","type":"file"},{"name":"resourcequota.yaml","type":"file"},{"name":"kustomization.yaml","type":"file"}]`))
+				return
+			}
+			_, _ = w.Write([]byte(`[{"name":"networkpolicy.yaml","type":"file"},{"name":"kustomization.yaml","type":"file"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps/kustomization.yaml"):
+			// Serves BOTH the merge's ReadFile and the commit's SHA probe.
+			f.mu.Lock()
+			content := base64.StdEncoding.EncodeToString([]byte(f.kustContent()))
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"sha":"kustsha-%d","content":"%s","encoding":"base64"}`, phase, content)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			// db-password reads + fresh app-file probes → not there yet.
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			body, _ := io.ReadAll(r.Body)
+			f.mu.Lock()
+			f.postCount++
+			f.batches = append(f.batches, body)
+			first := f.postCount == 1
+			if first {
+				// Reject the first batch at the ref CAS — and land the
+				// concurrent org-controller write while the funnel backs off.
+				f.phase = 2
+			}
+			f.mu.Unlock()
+			if first {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"message":"cannot lock ref 'refs/heads/main': is at aaaa but expected bbbb"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"newcommitsha00000000000000000000000000"}}`))
+		default:
+			f.t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}
+}
+
+// batchKustContent extracts the base64-decoded kustomization.yaml content
+// from a recorded ChangeFiles batch body ("" when the batch didn't carry it).
+func batchKustContent(t *testing.T, body []byte) string {
+	t.Helper()
+	var payload struct {
+		Files []struct {
+			Path    string `json:"path"`
+			Content string `json:"content"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("batch body not JSON: %v\n%s", err, body)
+	}
+	for _, f := range payload.Files {
+		if f.Path == "vcluster/apps/kustomization.yaml" {
+			dec, err := base64.StdEncoding.DecodeString(f.Content)
+			if err != nil {
+				t.Fatalf("kustomization content not base64: %v", err)
+			}
+			return string(dec)
+		}
+	}
+	return ""
+}
+
+// TestApplyTenantChangePerOrg_RebuildsMergeAgainstNewHeadOnRetry_5234 drives
+// the day-2 install while the org-controller lands an index merge-write
+// mid-race. The funnel's retry must re-read the head and re-merge: the
+// winning batch's kustomization.yaml carries the controller's
+// resourcequota.yaml entry the first (stale) batch could not know about. A
+// stale-base replay would clobber that entry — the #1031/#5104 regression
+// this closes.
+func TestApplyTenantChangePerOrg_RebuildsMergeAgainstNewHeadOnRetry_5234(t *testing.T) {
+	fake := &giteaRebuildFake{t: t, phase: 1}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	gen := gitops.NewManifestGenerator("clusters/sov/org-tenants")
+	gen.ParentDomain = "omani.homes"
+
+	h := &Handler{
+		Generator:    gen,
+		GitHubClient: ghclient.NewClientWithAPIURL("token", "openova", "openova", srv.URL),
+		GitBranch:    "main",
+		PerOrgGitops: true,
+		CatalogURL:   srv.URL,
+	}
+
+	err := h.applyTenantChange(context.Background(), appChangeData{
+		TenantSlug: "g274cas",
+		AppSlug:    "wordpress",
+		Apps:       []string{"wordpress"},
+		PlanID:     "s",
+	}, "install")
+	if err != nil {
+		t.Fatalf("applyTenantChange should have retried past the ref CAS and succeeded, got: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.postCount != 2 {
+		t.Fatalf("expected 2 batch POSTs (1 CAS loss + 1 win), got %d", fake.postCount)
+	}
+	firstKust := batchKustContent(t, fake.batches[0])
+	winKust := batchKustContent(t, fake.batches[1])
+	if firstKust == "" || winKust == "" {
+		t.Fatalf("both batches must carry vcluster/apps/kustomization.yaml (first=%q win=%q)", firstKust, winKust)
+	}
+	if strings.Contains(firstKust, "resourcequota.yaml") {
+		t.Errorf("first batch already lists resourcequota.yaml — the fake's mid-race write fired too early:\n%s", firstKust)
+	}
+	if !strings.Contains(winKust, "resourcequota.yaml") {
+		t.Errorf("winning batch does NOT list the org-controller's mid-race resourcequota.yaml — the retry replayed a stale base instead of re-merging against the new head (#5234):\n%s", winKust)
+	}
+	for _, keep := range []string{"networkpolicy.yaml", "app-wordpress.yaml"} {
+		if !strings.Contains(winKust, keep) {
+			t.Errorf("winning batch kustomization dropped %q:\n%s", keep, winKust)
+		}
+	}
+}
+
+// TestRefRaceExhaustionIsTerminal_NotParkable_5234 pins the branch selection
+// in runInstallJob: a ref-race that persisted through every CAS attempt is a
+// TERMINAL failure (fail the Job + paint the provision red), NOT the parkable
+// #4404 "per-Org Gitea repo not ready yet" race. If the exhausted error ever
+// matched isGiteaNotReadyError, the install would park forever with no
+// machine-readable failed state anywhere.
+func TestRefRaceExhaustionIsTerminal_NotParkable_5234(t *testing.T) {
+	exhausted := errors.New(`commit to per-Org repo acme274/catalyst-tenant: commit: ref-race persisted after 10 attempts: update ref: GitHub API POST http://gitea-http.gitea.svc:3000/api/v1/repos/acme274/catalyst-tenant/contents: 422 {"message":"sha does not match [given: aaaa, expected: bbbb]"}: not a fast forward (gitea contents API)`)
+	if isGiteaNotReadyError(exhausted) {
+		t.Fatalf("a terminally-exhausted ref-race must NOT be parkable as #4404 Gitea-not-ready — it would wait forever with no red step")
+	}
+	lockShape := errors.New(`commit to per-Org repo acme274/catalyst-tenant: commit: ref-race persisted after 10 attempts: update ref: GitHub API POST http://gitea/api/v1/repos/acme274/catalyst-tenant/contents: 409 {"message":"cannot lock ref 'refs/heads/main'"}: not a fast forward (gitea contents API)`)
+	if isGiteaNotReadyError(lockShape) {
+		t.Fatalf("the ref-lock exhaustion shape must NOT be parkable as #4404 Gitea-not-ready")
+	}
+}
+
+// --- terminal red-step propagation (#5234) ---
+
+// fakeCommitFailStore implements commitFailProvisionStore.
+type fakeCommitFailStore struct {
+	inFlight *store.Provision
+	getErr   error
+
+	updatedID string
+	updated   *store.Provision
+}
+
+func (f *fakeCommitFailStore) GetInFlightProvisionByTenant(_ context.Context, _ string) (*store.Provision, error) {
+	return f.inFlight, f.getErr
+}
+
+func (f *fakeCommitFailStore) UpdateProvision(_ context.Context, id string, p *store.Provision) error {
+	f.updatedID = id
+	f.updated = p
+	return nil
+}
+
+// capturingPublisher records every published event.
+type capturingPublisher struct {
+	mu     sync.Mutex
+	events []*events.Event
+}
+
+func (c *capturingPublisher) Publish(_ context.Context, _ string, e *events.Event) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+	return nil
+}
+
+func (c *capturingPublisher) Close() {}
+
+func funnelSteps() []store.ProvisionStep {
+	return []store.ProvisionStep{
+		{Name: "Creating tenant", Status: "completed"},
+		{Name: "Committing manifests to Git", Status: "completed"},
+		{Name: "Provisioning vCluster", Status: "completed"},
+		{Name: "Deploying WordPress", Status: "running"},
+		{Name: "Configuring TLS certificates", Status: "pending"},
+		{Name: "Running health checks", Status: "pending"},
+	}
+}
+
+// TestFailActiveProvisionOn_PaintsRedStepAndPublishes_5234 asserts the
+// terminal commit failure lands as machine-readable state IMMEDIATELY: the
+// matching "Deploying <app>" step goes failed with the commit error, the
+// provision goes failed, and provision.failed is published (the event the
+// downstream consumer turns into customer status "failed" — the state the
+// /launching interstitial and the marketplace re-visit gate read).
+func TestFailActiveProvisionOn_PaintsRedStepAndPublishes_5234(t *testing.T) {
+	st := &fakeCommitFailStore{
+		inFlight: &store.Provision{
+			ID:       "prov-1",
+			TenantID: "t-1",
+			Status:   "provisioning",
+			Steps:    funnelSteps(),
+		},
+	}
+	pub := &capturingPublisher{}
+	h := &Handler{Producer: pub}
+
+	commitErr := errors.New("commit to per-Org repo acme274/catalyst-tenant: commit: ref-race persisted after 10 attempts: update ref: ...")
+	h.failActiveProvisionOn(context.Background(), st, appChangeData{
+		TenantID:   "t-1",
+		TenantSlug: "acme274",
+		AppSlug:    "wordpress",
+	}, commitErr)
+
+	if st.updated == nil {
+		t.Fatalf("provision was not updated — no machine-readable failed state landed")
+	}
+	if st.updatedID != "prov-1" {
+		t.Errorf("updated provision id = %q, want prov-1", st.updatedID)
+	}
+	if st.updated.Status != "failed" {
+		t.Errorf("provision status = %q, want failed", st.updated.Status)
+	}
+	depIdx := 3 // "Deploying WordPress"
+	step := st.updated.Steps[depIdx]
+	if step.Status != "failed" {
+		t.Errorf("step %q status = %q, want failed (the red step)", step.Name, step.Status)
+	}
+	if !strings.Contains(step.Message, "ref-race persisted") {
+		t.Errorf("red step message should carry the commit error, got %q", step.Message)
+	}
+	if step.DoneAt.IsZero() {
+		t.Errorf("red step should be timestamped")
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	var sawFailed bool
+	for _, e := range pub.events {
+		if e.Type == "provision.failed" && e.TenantID == "t-1" {
+			sawFailed = true
+		}
+	}
+	if !sawFailed {
+		t.Errorf("provision.failed was not published — customer status never flips to failed")
+	}
+}
+
+// TestFailActiveProvisionOn_NoInFlightProvisionIsNoop_5234 — a plain day-2
+// install on an already-active Org has no in-flight funnel provision; the
+// helper must not fabricate one (the Job + provision.app_failed event carry
+// the state there).
+func TestFailActiveProvisionOn_NoInFlightProvisionIsNoop_5234(t *testing.T) {
+	st := &fakeCommitFailStore{inFlight: nil}
+	pub := &capturingPublisher{}
+	h := &Handler{Producer: pub}
+
+	h.failActiveProvisionOn(context.Background(), st, appChangeData{
+		TenantID: "t-2",
+		AppSlug:  "wordpress",
+	}, errors.New("boom"))
+
+	if st.updated != nil {
+		t.Errorf("no in-flight provision — nothing should have been updated")
+	}
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.events) != 0 {
+		t.Errorf("no in-flight provision — nothing should have been published, got %d events", len(pub.events))
+	}
+}
+
+// TestCommitFailureStepIndex_5234 pins the red-step selection.
+func TestCommitFailureStepIndex_5234(t *testing.T) {
+	steps := funnelSteps()
+	cases := []struct {
+		name    string
+		steps   []store.ProvisionStep
+		appSlug string
+		want    int
+	}{
+		{"matches the app's own Deploying step", steps, "wordpress", 3},
+		{"unknown slug falls back to first Deploying step", steps, "ghost", 3},
+		{"empty slug falls back to first Deploying step", steps, "", 3},
+		{"no Deploying step falls back to the commit step", steps[:3], "wordpress", 1},
+		{"no match at all falls back to step 0", steps[:1], "wordpress", 0},
+		{"empty steps default to 0", nil, "wordpress", 0},
+	}
+	for _, tc := range cases {
+		if got := commitFailureStepIndex(tc.steps, tc.appSlug); got != tc.want {
+			t.Errorf("%s: commitFailureStepIndex = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}

--- a/core/services/provisioning/handlers/provision_commit_fail.go
+++ b/core/services/provisioning/handlers/provision_commit_fail.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/openova-io/openova/core/services/provisioning/store"
+)
+
+// #5234 — terminal per-Org commit failures must surface as a machine-readable
+// red step IMMEDIATELY, not after the 10-minute pod wait.
+//
+// On hw274 the funnel's purchased-app commit to the per-Org
+// `<slug>/catalyst-tenant` repo exhausted its ref-race retries ("ref-race
+// persisted after 5 attempts"), but the only state that changed right away was
+// the day-2 Job + a provision.app_failed event. The funnel provision timeline
+// — the state the /launching interstitial and the marketplace re-visit gate
+// can render — kept "Deploying WordPress" running until the pod wait timed out
+// 10 minutes later, and the customer status stayed "provisioning" the whole
+// time (UAT rows 86/91). The helpers here close that gap: when the step-0
+// commit fails terminally, the in-flight provision for the Org is failed on
+// the matching "Deploying …" step at once, and the provision.failed event
+// flips the customer status to "failed" through the existing consumer chain.
+
+// commitFailProvisionStore is the narrow store surface the terminal
+// commit-failure wiring needs. *store.Store satisfies it in production; tests
+// inject a fake so the red-step propagation is provable without a live Mongo
+// (same idiom as provisionDedupStore, #3744).
+type commitFailProvisionStore interface {
+	GetInFlightProvisionByTenant(ctx context.Context, tenantID string) (*store.Provision, error)
+	UpdateProvision(ctx context.Context, id string, p *store.Provision) error
+}
+
+// commitFailureStepIndex picks the funnel-timeline step to paint red when the
+// per-Org git commit exhausts terminally: the app's own "Deploying <name>"
+// step when one matches the failed install's slug, else the first
+// "Deploying …" step, else the "Committing manifests to Git" step, else step
+// 0. Pure so the selection is unit-testable without a store.
+func commitFailureStepIndex(steps []store.ProvisionStep, appSlug string) int {
+	slugLower := strings.ToLower(strings.TrimSpace(appSlug))
+	firstDeploying := -1
+	committing := -1
+	for i, s := range steps {
+		n := strings.ToLower(s.Name)
+		if strings.HasPrefix(n, "deploying") {
+			if firstDeploying < 0 {
+				firstDeploying = i
+			}
+			if slugLower != "" && strings.Contains(n, slugLower) {
+				return i
+			}
+		}
+		if committing < 0 && strings.Contains(n, "committing manifests") {
+			committing = i
+		}
+	}
+	if firstDeploying >= 0 {
+		return firstDeploying
+	}
+	if committing >= 0 {
+		return committing
+	}
+	return 0
+}
+
+// failActiveProvisionForCommitError surfaces a terminally-failed per-Org git
+// commit on the Org's in-flight funnel provision (#5234). No-op when there is
+// no in-flight provision (a plain day-2 install on an already-active Org —
+// the Job + provision.app_failed event carry the state there) or when the
+// handler has no store wired.
+func (h *Handler) failActiveProvisionForCommitError(ctx context.Context, data appChangeData, commitErr error) {
+	if h.Store == nil || data.TenantID == "" {
+		return
+	}
+	h.failActiveProvisionOn(ctx, h.Store, data, commitErr)
+}
+
+// failActiveProvisionOn is failActiveProvisionForCommitError against the
+// narrow store surface (testable with a fake). It mirrors failProvision's
+// semantics — mark the chosen step failed, fail the provision, publish
+// provision.failed — but resolves the provision by the Org instead of by ID,
+// because the day-2 install path does not know the funnel's provision ID.
+func (h *Handler) failActiveProvisionOn(ctx context.Context, st commitFailProvisionStore, data appChangeData, commitErr error) {
+	p, err := st.GetInFlightProvisionByTenant(ctx, data.TenantID)
+	if err != nil {
+		slog.Error("terminal commit failure: could not resolve in-flight provision (#5234)",
+			"tenant_id", data.TenantID, "error", err)
+		return
+	}
+	if p == nil {
+		return
+	}
+
+	msg := fmt.Sprintf("git commit to per-Org repo failed: %s", commitErr)
+	idx := commitFailureStepIndex(p.Steps, data.AppSlug)
+	if idx < len(p.Steps) && p.Steps[idx].Status != "failed" {
+		p.Steps[idx].Status = "failed"
+		p.Steps[idx].Message = msg
+		p.Steps[idx].DoneAt = time.Now().UTC()
+	}
+	p.Status = "failed"
+	if err := st.UpdateProvision(ctx, p.ID, p); err != nil {
+		slog.Error("terminal commit failure: could not mark provision failed (#5234)",
+			"provision_id", p.ID, "tenant_id", data.TenantID, "error", err)
+		return
+	}
+
+	// provision.failed → the downstream consumer flips the customer status to
+	// "failed" (the same chain failProvision uses), so the marketplace re-visit
+	// gate and the per-Org console see the terminal state immediately.
+	h.publishEvent(ctx, "provision.failed", data.TenantID, map[string]string{
+		"provision_id": p.ID,
+		"error":        msg,
+	})
+
+	slog.Error("provision failed on terminal per-Org commit error (#5234)",
+		"provision_id", p.ID, "tenant_id", data.TenantID,
+		"app_slug", data.AppSlug, "step", idx, "error", commitErr.Error())
+}


### PR DESCRIPTION
## Live failure (hw274)

`commit to per-Org repo acme274/catalyst-tenant: ref-race persisted after 5 attempts` → the purchased WordPress never landed in the Org boundary; `Deploying-WordPress` errored only after the 10-minute pod wait; customer status stayed `provisioning` throughout; the /launching interstitial redirected with no red step (UAT rows 86/89/90/91/226).

## Racing writers identified

1. **org-controller** (`core/controllers/organization/internal/controller/organization_controller.go` step 3): commits ONE PutFile (= one head advance) PER rendered manifest, per reconcile — bursts of ~10+ sequential commits to `<slug>/catalyst-tenant@main`, re-fired on every requeue while the funnel Org converges.
2. **provisioning service cart install** (`applyTenantChangePerOrg`, `core/services/provisioning/handlers/consumer.go`): one batch ChangeFiles commit of the app payload + merged kustomization indexes.

## Defects → fixes

| # | Defect | Fix |
|---|--------|-----|
| 1 | File map (incl. read-modify-write index merges) built ONCE before the retry loop — retries re-pushed content computed against a superseded head (#1031 class, now clobbering the org-controller's #5104 merge-writes) | Build moved into a rebuild closure invoked on EVERY attempt (`CommitFilesWithPruneAndRebuild`): each retry re-reads the moved head's indexes / tree listings / DB password and re-merges before re-pushing with fresh per-file SHA preconditions |
| 2 | 5 attempts × 750ms-capped backoff = ~1.5s window, smaller than ONE controller burst → deterministic exhaustion | `commitAttemptsMax` 5→10, backoff cap 750ms→4s (jittered, ctx-honoring) — the retry window (~18s worst case) straddles a whole burst |
| 3 | Gitea's file-level CAS-loss 422s (`sha does not match`, `repository file already exists`) fell through as FATAL — retry loop never engaged for the probe→push window race | Both shapes added to `isGiteaRefRaceError` — a fresh re-probe converts the op (stale-SHA→current, create→update) and wins |
| 4 | On exhaustion only the day-2 Job failed; the funnel timeline burned the full 10-minute pod wait and customer status stayed `provisioning` | `runInstallJob` + the #4404 pending-install reconciler now call `failActiveProvisionForCommitError`: red `Deploying <app>` step at once + `provision.failed` → customer status `failed` through the existing consumer chain — the machine-readable state the /launching interstitial and the marketplace re-visit gate read |

No global lock, no writer serialization — per-attempt CAS only, per the #5234 direction.

## Regression tests

- `client_cas_5234_test.go` (github pkg): fake Gitea advances the tracked file's SHA between probe and push — asserts the retry re-probes and wins with the CURRENT SHA (3 POSTs: 2 CAS losses + 1 win); a permanently-advancing head exhausts into the descriptive `ref-race persisted after 10 attempts` error — never a silent success; budget/backoff envelope pinned.
- `client_reflock_test.go`: classifier table extended with the two 422 CAS shapes; exhaustion test adapted to the widened budget via delay-shrink helper.
- `perorg_commit_cas_5234_test.go` (handlers pkg): the winning batch's `vcluster/apps/kustomization.yaml` carries the org-controller's MID-RACE `resourcequota.yaml` entry the first (rejected) batch could not know — proving rebuild-per-attempt, not stale-base replay; exhausted ref-race is NOT classified as the parkable #4404 not-ready race; `failActiveProvisionOn` paints the matching `Deploying WordPress` step red + publishes `provision.failed` (fake store/publisher); step-picker fallbacks pinned.

## Validation

- `go build ./... && go vet ./...` clean on `core/services/provisioning`
- `go test ./...` green across the module (gitguard / github / gitops / handlers / store)
- No cross-module consumers of the touched packages (comment-only references elsewhere)

## Follow-up (noted, not in this PR)

The /launching FE red-step render: `core/marketplace/src/components/LaunchingStep.svelte` today only probes the per-Org console `/healthz` — it has no provision-timeline model at all. Rendering the red step there means adding an authenticated provision-status poll to the marketplace interstitial — a larger FE change than this PR's wiring; the machine-readable state it needs (failed step + failed provision + failed customer status, all immediate) is shipped here. Tracked on #5234.

Refs #5234 #5104 #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)