### PR TITLE
fix(cutover): verify + resolve xpkg digest via the registry v2 API, not the artifact-management API (0.1.144)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -921,7 +921,18 @@ spec:
       # + the already-pivoted branch + the Gitea YAML rewrite all
       # digest-based; tag-form live pivots upgraded; DIGEST-MISS FATALs with
       # the exact recovery). Contract Case 65 re-locked.
-      version: 0.1.143
+      # 0.1.144 (#5232 round 2 Refs #5204): the xpkg digest verify + tag->digest
+      # resolution move to the REGISTRY V2 manifest API. Live hw274 (0.1.143
+      # run): the digest was resolved correctly but verified via the Harbor
+      # artifact-management API, which for a multi-arch package records only
+      # per-arch child manifests and never exposes the top-level OCI index by
+      # its own digest → the resolved index 404s → step-03 still FATAL'd. The
+      # v2 API serves it (HEAD tag → Docker-Content-Digest; GET digest → 200),
+      # exactly containerd/Crossplane's pull path. Step-03 Phase A4 now resolves
+      # via a v2 HEAD and verifies durability with a v2 digest GET; step-11
+      # verify_local_pkg_artifact + the already-pivoted branch use the same v2
+      # digest GET. Contract Case 65 re-locked.
+      version: 0.1.144
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.143
+  version: 0.1.144
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,27 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.144 (#5232 round 2 Refs #5204 — the xpkg digest verify + resolution
+# move to the REGISTRY V2 manifest API. Live hw274 (dep d51a69f885872a81,
+# 0.1.143 run): step-03 Phase A4 resolved the OCI-index digest correctly but
+# verified durability via the Harbor artifact-management API
+# (GET /api/v2.0/projects/proxy-xpkg/repositories/<repo>/artifacts/<digest>).
+# For a MULTI-ARCH package Harbor's proxy-cache records ONLY the per-arch
+# CHILD manifests there (live: sha256:f344ef2c / fbe8adf8 / 238c1393, all
+# type=IMAGE) and NEVER exposes the top-level OCI index by its own digest, so
+# GET artifacts/sha256:4aeddb70… (the resolved index) 404s → FATAL `pulled
+# through but never durably recorded`, despite every blob being durable. The
+# registry v2 API serves it correctly and is EXACTLY containerd/Crossplane's
+# pull path: HEAD /v2/proxy-xpkg/upbound/provider-opentofu/manifests/v1.1.3 →
+# 200 + Docker-Content-Digest: sha256:4aeddb70… (Content-Type
+# oci.image.index), and GET /v2/.../manifests/sha256:4aeddb70… → 200. TWO
+# coupled changes: (1) step-03 Phase A4 resolves the tag->digest from a v2
+# HEAD (Docker-Content-Digest) and verifies durability with a v2 digest GET
+# (200) — the artifact-management-API probe is dropped from the xpkg leg
+# entirely; FATAL only on a v2 HEAD non-200 or a v2 digest GET non-200.
+# (2) step-11 verify_local_pkg_artifact + the already-pivoted SKIP branch use
+# the same v2 digest GET (200). Single-arch packages HEAD to a manifest.v2
+# digest, equally servable — the Accept header covers index + list + single
+# manifest, no special-casing. Contract Case 65 re-locked.
 # 0.1.143 (#5232 Refs #5226 #5204 — the xpkg leg moves to DIGEST refs
 # end-to-end. Live hw274 (dep d51a69f885872a81, first 0.1.142 run): step-03
 # Phase A4 FATAL'd `pulled through but never durably recorded` on
@@ -2417,7 +2439,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.143
+version: 0.1.144
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -1543,37 +1543,56 @@ data:
             # — deterministic, not async lag), so the 0.1.142 tag-based
             # artifact probe could never pass and a tag-based step-11 pivot
             # ref would genuinely 404 post-severance. The artifact IS cached
-            # and queryable BY DIGEST. Phase A4 therefore resolves each
-            # package's tag->digest at warm time (sha256 of the exact
-            # pulled-through manifest bytes in the dir: scratch), verifies
-            # durability BY DIGEST, and persists the map in the
-            # XPKG_DIGEST_CM ConfigMap for step-11's digest pivot.
-            xpkg_artifact_present() {
-              # $1 = local path project/repo[:tag|@digest]; 0 when the local
-              # Harbor DURABLY serves it (artifact API = Harbor CORE DB, never
-              # pull-through — the #5030 probe discipline). Non-zero on ANY
-              # miss/parse-fail/API error (fail-closed → the caller warms).
-              _xa_pp="$1"
-              _xa_ref="latest"
-              case "${_xa_pp}" in
-                *@*)
-                  _xa_ref="${_xa_pp##*@}"; _xa_pp="${_xa_pp%@*}"
-                  case "${_xa_pp##*/}" in *:*) _xa_pp="${_xa_pp%:*}" ;; esac ;;
-                *)
-                  case "${_xa_pp##*/}" in *:*) _xa_ref="${_xa_pp##*:}"; _xa_pp="${_xa_pp%:*}" ;; esac ;;
-              esac
-              case "${_xa_pp}" in
-                */*) _xa_proj="${_xa_pp%%/*}"; _xa_repo="${_xa_pp#*/}" ;;
-                *)   return 1 ;;
-              esac
-              # Single-encode nested repo `/` -> %2F for the direct harbor-core
-              # Service path (#5036 — no gateway decode layer in between).
-              _xa_repo_enc=$(printf '%s' "${_xa_repo}" | sed 's#/#%2F#g')
-              _xa_d=$(curl -sk --max-time 30 \
+            # and queryable BY DIGEST — but ONLY via the registry v2 API, not
+            # the artifact-management API (#5232 round 2, live hw274: for a
+            # MULTI-ARCH package the artifact API records only the per-arch
+            # CHILD manifests, never the top-level OCI index by its own digest
+            # → GET artifacts/sha256:<index> 404s there even though every blob
+            # is durable). Phase A4 therefore resolves each package's
+            # tag->digest from a registry v2 HEAD (the Docker-Content-Digest
+            # response header — the exact digest containerd/Crossplane resolve
+            # at pull time), verifies durability with a v2 digest GET (200),
+            # and persists the map in the XPKG_DIGEST_CM ConfigMap for
+            # step-11's digest pivot.
+            #
+            # The two helpers below use the registry v2 manifest API
+            # (${HARBOR_INTERNAL_URL}/v2/<repo>/manifests/<ref>, the SAME
+            # in-cluster Harbor Service Phase B dials) with LITERAL-slash repo
+            # paths (no %2F encode — the /v2 API takes the nested repo name
+            # verbatim). The Accept header covers OCI index + docker manifest
+            # list + single manifest so a single-arch package (whose HEAD
+            # returns a manifest.v2 digest, equally servable) needs no
+            # special-casing.
+            XPKG_V2_ACCEPT='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+            xpkg_v2_resolve_digest() {
+              # $1 = repo-path (literal slashes, incl. project), $2 = tag.
+              # Echoes the servable manifest/index digest (Docker-Content-Digest
+              # from a v2 HEAD) when the HEAD is 200 + carries the header, else
+              # nothing. This is the durable digest step-11 pivots spec.package
+              # to. Empty tag → nothing (an in-ref digest is authoritative and
+              # never needs resolving).
+              _xr_repo="$1"; _xr_tag="$2"
+              [ -n "${_xr_tag}" ] || return 0
+              curl -sSIk --max-time 30 \
                 -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                "${HARBOR_INTERNAL_URL}/api/v2.0/projects/${_xa_proj}/repositories/${_xa_repo_enc}/artifacts/${_xa_ref}" 2>/dev/null \
-                | jq -r '.digest // empty' 2>/dev/null)
-              [ -n "${_xa_d}" ]
+                -H "Accept: ${XPKG_V2_ACCEPT}" \
+                "${HARBOR_INTERNAL_URL}/v2/${_xr_repo}/manifests/${_xr_tag}" 2>/dev/null \
+                | tr -d '\r' | grep -i '^docker-content-digest:' | tail -1 | awk '{print $2}'
+            }
+            xpkg_v2_digest_present() {
+              # $1 = repo-path (literal slashes, incl. project), $2 = sha256
+              # digest. 0 iff the registry v2 API serves that digest (200) —
+              # Harbor CORE serving the durably-cached index/manifest, the
+              # multi-arch-aware durability signal that supersedes the
+              # artifact-management-API probe for xpkg (#5232). Non-zero on ANY
+              # miss → fail-closed (the caller warms / FATALs).
+              _xp_repo="$1"; _xp_dig="$2"
+              [ -n "${_xp_dig}" ] || return 1
+              _xp_code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
+                -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                -H "Accept: ${XPKG_V2_ACCEPT}" \
+                "${HARBOR_INTERNAL_URL}/v2/${_xp_repo}/manifests/${_xp_dig}" 2>/dev/null)
+              [ "${_xp_code}" = "200" ]
             }
 
             if [ "${XPKG_PREWARM_ENABLED:-true}" != "true" ]; then
@@ -1630,17 +1649,20 @@ data:
                 esac
                 _xw_slug=$(printf '%s' "${_xw_lpath}" | tr -c 'A-Za-z0-9._-' '_')
                 : >"${xpkg_warm_dir}/${_xw_slug}.log"
-                # #5232 — split the local path into repo-path + ref. A source
-                # ref that already carries a digest (#4955 normalized
-                # tag@digest -> digest-only) IS the authoritative digest.
+                # #5232 — split the local path into repo-path + tag + ref. A
+                # source ref that already carries a digest (#4955 normalized
+                # tag@digest -> digest-only) IS the authoritative digest; the
+                # tag drives the registry v2 HEAD that resolves the servable
+                # digest for a tag-only ref.
                 _xw_repo_path="${_xw_lpath}"
                 _xw_digest=""
+                _xw_tag=""
                 case "${_xw_lpath}" in
                   *@sha256:*)
                     _xw_digest="${_xw_lpath##*@}"; _xw_repo_path="${_xw_lpath%@*}"
-                    case "${_xw_repo_path##*/}" in *:*) _xw_repo_path="${_xw_repo_path%:*}" ;; esac ;;
+                    case "${_xw_repo_path##*/}" in *:*) _xw_tag="${_xw_repo_path##*:}"; _xw_repo_path="${_xw_repo_path%:*}" ;; esac ;;
                   *)
-                    case "${_xw_lpath##*/}" in *:*) _xw_repo_path="${_xw_lpath%:*}" ;; esac ;;
+                    case "${_xw_lpath##*/}" in *:*) _xw_tag="${_xw_lpath##*:}"; _xw_repo_path="${_xw_lpath%:*}" ;; esac ;;
                 esac
                 # Idempotency (#4994/#5232): skip ONLY when a digest is
                 # already authoritative (in-ref, or minted by a PRIOR
@@ -1654,7 +1676,7 @@ data:
                   if [ -z "${_xw_skip_digest}" ]; then
                     _xw_skip_digest=$(printf '%s' "${xpkg_digest_map_json}" | jq -r --arg k "${_xw_slug}" '.data[$k] // empty' 2>/dev/null) || _xw_skip_digest=""
                   fi
-                  if [ -n "${_xw_skip_digest}" ] && xpkg_artifact_present "${_xw_repo_path}@${_xw_skip_digest}"; then
+                  if [ -n "${_xw_skip_digest}" ] && xpkg_v2_digest_present "${_xw_repo_path}" "${_xw_skip_digest}"; then
                     echo "[harbor-prewarm] Phase A4 skip ${_xw_pkg} -> ${_xw_repo_path}@${_xw_skip_digest} (already durably cached by digest)"
                     printf '%s' "${_xw_skip_digest}" > "${xpkg_warm_dir}/${_xw_slug}.digest"
                     printf '%s@%s (present)' "${_xw_repo_path}" "${_xw_skip_digest}" > "${xpkg_warm_dir}/${_xw_slug}.ok"
@@ -1692,15 +1714,19 @@ data:
                   _xw_attempt=$((_xw_attempt+1))
                   [ "${_xw_attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
                 done
-                # #5232 — resolve the tag->digest from the pulled-through
-                # scratch BEFORE freeing it: the dir: transport's top-level
-                # manifest.json is the EXACT manifest(-list) bytes the proxy
-                # served, so its sha256 IS the digest Harbor records for the
-                # cached artifact (the same sha256-of-raw-bytes identity
-                # dest_already_current relies on, single-arch AND lists).
+                # #5232 (round 2) — resolve the tag->digest from the REGISTRY
+                # V2 API, not the pulled-through scratch: HEAD the tag and read
+                # the `Docker-Content-Digest` response header. That is the
+                # EXACT digest Harbor serves for the tag (and containerd/
+                # Crossplane resolve at pull time) — for a multi-arch package
+                # the top-level OCI INDEX digest, which the artifact-management
+                # API never exposes by its own digest (live hw274: only per-
+                # arch child manifests, so the resolved index 404s there). The
+                # full pull-through above already cached the manifest + every
+                # blob durably, so this HEAD is served from cache. In-ref
+                # digests (#4955) are authoritative and skip the resolve.
                 if [ "${_xw_rc}" -eq 0 ] && [ -z "${_xw_digest}" ]; then
-                  _xw_digest_hex=$(sha256sum "${xpkg_warm_dir}/${_xw_slug}.dir/manifest.json" 2>/dev/null | awk '{print $1}') || _xw_digest_hex=""
-                  if [ -n "${_xw_digest_hex}" ]; then _xw_digest="sha256:${_xw_digest_hex}"; fi
+                  _xw_digest=$(xpkg_v2_resolve_digest "${_xw_repo_path}" "${_xw_tag}")
                 fi
                 # The dir: copy is a scratch side-effect — the durable payload
                 # is what Harbor cached on the way through. Free the emptyDir.
@@ -1715,15 +1741,16 @@ data:
                   # tag ref 404s post-severance — Harbor never records tags on
                   # proxy projects, #5232) — fail LOUD while egress is open.
                   printf '%s (pulled through but tag->digest resolution failed)' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
-                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the scratch manifest.json digest could not be computed — no digest to record for the step-11 pivot (#5232)"
+                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the registry v2 HEAD returned no Docker-Content-Digest for tag '${_xw_tag}' (HEAD non-200 or header absent) — no digest to record for the step-11 pivot (#5232)"
                   continue
                 fi
-                # Durable-presence poll BY DIGEST (#5232 — Harbor records
-                # proxied artifacts ASYNC and never records their tags):
-                # bounded 12x10s before the fail-closed verdict.
+                # Durable-presence poll BY DIGEST via the registry v2 API
+                # (#5232 round 2 — the multi-arch-aware durability signal;
+                # Harbor records proxied artifacts ASYNC): GET the digest must
+                # be 200, bounded 12x10s before the fail-closed verdict.
                 _xw_present=0
                 for _xw_i in $(seq 1 12); do
-                  if xpkg_artifact_present "${_xw_repo_path}@${_xw_digest}"; then _xw_present=1; break; fi
+                  if xpkg_v2_digest_present "${_xw_repo_path}" "${_xw_digest}"; then _xw_present=1; break; fi
                   sleep 10
                 done
                 if [ "${_xw_present}" -eq 1 ]; then
@@ -1732,7 +1759,7 @@ data:
                   echo "[harbor-prewarm] Phase A4 done ${_xw_repo_path}@${_xw_digest} (durably cached by digest)"
                 else
                   printf '%s@%s (pulled through but never durably recorded)' "${_xw_repo_path}" "${_xw_digest}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
-                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the Harbor artifact API never recorded ${_xw_digest} durably (120s poll) — proxy-cache persistence failed"
+                  echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the registry v2 API never served ${_xw_digest} (GET non-200, 120s poll) — proxy-cache persistence failed"
                 fi
               done
               xpkg_ok=0

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -301,27 +301,33 @@ data:
             # ---- Phase 0.5 (#5204): local-artifact verify gate ----
             #
             # Rewrite a Provider's spec.package onto the local Harbor ONLY
-            # after the Harbor ARTIFACT API (Harbor CORE DB — durable, never
-            # pull-through: the #5030 probe discipline) confirms the package
-            # artifact is durably present locally. Step-03 Phase A4 warms
-            # every Provider package through proxy-xpkg for exactly this;
-            # a miss here means the warm never ran / was skipped for this
-            # package (e.g. a Provider created mid-cutover after step-03
-            # enumerated), and pivoting anyway would point spec.package at a
-            # ref the local registry cannot serve post-severance. FAIL-LOUD:
-            # the offender is named and the step exits 1 so the operator
-            # re-triggers the cutover (step-03 re-warms, idempotent) instead
-            # of shipping a silently-dangling pivot.
+            # after the registry v2 manifest API confirms the package's digest
+            # is durably served locally (#5232 round 2, live hw274 — the
+            # multi-arch-aware durability signal; the Harbor artifact-
+            # management API records only the per-arch CHILD manifests for a
+            # multi-arch package and never exposes the top-level OCI index by
+            # its own digest, so a digest-addressed artifact-API probe 404s
+            # even when the index IS durable + servable via /v2, exactly
+            # containerd/Crossplane's pull path). Step-03 Phase A4 warms every
+            # Provider package through proxy-xpkg for exactly this; a miss here
+            # means the warm never ran / was skipped for this package (e.g. a
+            # Provider created mid-cutover after step-03 enumerated), and
+            # pivoting anyway would point spec.package at a ref the local
+            # registry cannot serve post-severance. FAIL-LOUD: the offender is
+            # named and the step exits 1 so the operator re-triggers the
+            # cutover (step-03 re-warms, idempotent) instead of shipping a
+            # silently-dangling pivot.
             verify_local_pkg_artifact() {
-              # $1 = local path project/repo[:tag|@digest]; 0 = durably
-              # present OR verification not applicable (disabled / no
+              # $1 = local path project/repo@sha256:<digest> (step-11 always
+              # verifies BY DIGEST). 0 = the registry v2 API durably serves
+              # that digest (200) OR verification not applicable (disabled / no
               # credential to probe with).
               case "${VERIFY_LOCAL_ARTIFACT:-true}" in
                 true|True|TRUE|1|yes) : ;;
                 *) return 0 ;;
               esac
               if [ -z "${HARBOR_PASSWORD:-}" ]; then
-                echo "[crossplane-provider-pivot] WARN: HARBOR_PASSWORD empty — cannot probe the local artifact API; skipping the #5204 verify gate for $1"
+                echo "[crossplane-provider-pivot] WARN: HARBOR_PASSWORD empty — cannot probe the local registry v2 API; skipping the #5204 verify gate for $1"
                 return 0
               fi
               : "${HARBOR_USERNAME:=admin}"
@@ -335,15 +341,20 @@ data:
                   case "${_vp##*/}" in *:*) _vref="${_vp##*:}"; _vp="${_vp%:*}" ;; esac ;;
               esac
               case "${_vp}" in
-                */*) _vproj="${_vp%%/*}"; _vrepo="${_vp#*/}" ;;
+                */*) : ;;
                 *)   return 1 ;;
               esac
-              _vrepo_enc=$(printf '%s' "${_vrepo}" | sed 's#/#%2F#g')
-              _vd=$(curl -sk --max-time 30 \
+              # Registry v2 manifest API: LITERAL-slash repo path (no %2F
+              # encode — the /v2 API takes the nested repo name verbatim), the
+              # digest as the reference, must serve 200. Accept covers OCI
+              # index + docker manifest list + single manifest so a single-arch
+              # package (manifest.v2 digest, equally servable) needs no
+              # special-casing.
+              _vcode=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
                 -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                "${HARBOR_INTERNAL_URL}/api/v2.0/projects/${_vproj}/repositories/${_vrepo_enc}/artifacts/${_vref}" 2>/dev/null \
-                | jq -r '.digest // empty' 2>/dev/null)
-              [ -n "${_vd}" ]
+                -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+                "${HARBOR_INTERNAL_URL}/v2/${_vp}/manifests/${_vref}" 2>/dev/null)
+              [ "${_vcode}" = "200" ]
             }
             # Sentinel: the Phase-1 while-loop runs in a pipeline subshell, so
             # a verify miss records here and the parent FATALs after the loop.

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -2950,9 +2950,18 @@ echo "  PASS (#5215: step-07 excludes the CSI driver from BOTH the additionalHRs
 # tag — deterministic), so the #5204 tag-based durable-verify could never pass
 # (step-03 FATAL'd at pct=18) and a tag-based step-11 pivot ref would
 # genuinely 404 post-severance. The artifact IS cached + queryable BY DIGEST.
-# This Case asserts the warm + the digest resolution + the digest-addressed
-# durable verify + the digest-addressed pivot end-to-end.
-echo "[cutover-contract] Case 65: step-03 Phase A4 warms Crossplane xpkg provider packages into local proxy-xpkg with tag->digest resolution + step-11 pivots spec.package BY DIGEST after a digest-addressed durable verify (#5204 #5232)"
+# Root cause #5232 round 2 (same env, 0.1.143 run): the digest was resolved
+# correctly but verified via the Harbor artifact-MANAGEMENT API
+# (/api/v2.0/.../artifacts/<digest>). For a MULTI-ARCH package that API records
+# ONLY the per-arch CHILD manifests and NEVER exposes the top-level OCI index
+# by its own digest → GET artifacts/<index-digest> 404s → step-03 STILL FATAL'd
+# despite every blob being durable. The registry v2 manifest API serves the
+# index correctly (HEAD tag → 200 + Docker-Content-Digest; GET digest → 200) —
+# exactly containerd/Crossplane's pull path. This Case asserts the warm + the
+# v2-HEAD digest resolution + the v2 digest-GET durable verify (with NO
+# artifact-management-API call in the xpkg leg) + the digest-addressed pivot
+# end-to-end.
+echo "[cutover-contract] Case 65: step-03 Phase A4 warms Crossplane xpkg provider packages into local proxy-xpkg, resolves the tag->digest via a registry v2 HEAD + durable-verifies via a v2 digest GET (no artifact-management API), and step-11 pivots spec.package BY DIGEST after the same v2 durable verify (#5204 #5232)"
 [ -s "$TMP/s03pin.yaml" ] || awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml"
 c65_fail=0
 # (a) step-03 enumerates the Provider package refs — the SAME set step-11
@@ -2980,37 +2989,59 @@ fi
 if ! grep -qF 'dir:${xpkg_warm_dir}/${_xw_slug}.dir' "$TMP/s03pin.yaml"; then
   echo "FAIL: step-03 Phase A4 lost the dir: scratch destination for the warm pull-through (#5204)" >&2; c65_fail=1
 fi
-# (d) durable presence is asserted via the Harbor ARTIFACT API (the #5030
-#     durable-probe discipline) and a warm failure FATALs the step.
-if ! grep -qF 'xpkg_artifact_present' "$TMP/s03pin.yaml"; then
-  echo "FAIL: step-03 Phase A4 lost the xpkg_artifact_present durable probe (Harbor artifact API — CORE DB, never pull-through) (#5204)" >&2; c65_fail=1
+# (d) durable presence is asserted via the REGISTRY V2 manifest API (#5232
+#     round 2 — the multi-arch-aware durability signal; the artifact-
+#     management API never exposes a multi-arch OCI index by its own digest,
+#     live hw274) and a warm failure FATALs the step.
+if ! grep -qF 'xpkg_v2_digest_present' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 lost the xpkg_v2_digest_present durable probe (registry v2 digest GET — the multi-arch-aware durability signal) (#5232)" >&2; c65_fail=1
 fi
 if ! grep -qF 'Crossplane xpkg package(s) failed to warm' "$TMP/s03pin.yaml"; then
   echo "FAIL: step-03 Phase A4 lost the xpkg_fail>0 FATAL — an unwarmed package would silently ship a cold cache into the step-11 pivot (#5204)" >&2; c65_fail=1
 fi
-# (d2) #5232: the tag->digest is resolved from the pulled-through dir: scratch
-#     (sha256 of the exact top-level manifest bytes IS the digest Harbor
-#     records), the durable poll probes BY DIGEST (tags are never recorded on
-#     proxy projects — hw274), a failed resolution FATALs, and the map is
-#     persisted to the XPKG_DIGEST_CM ConfigMap for step-11.
-if ! grep -qF 'sha256sum "${xpkg_warm_dir}/${_xw_slug}.dir/manifest.json"' "$TMP/s03pin.yaml"; then
-  echo "FAIL: step-03 Phase A4 does not resolve the tag->digest from the pulled-through scratch manifest.json — step-11 has no digest to pivot by and a tag ref 404s post-severance (#5232)" >&2; c65_fail=1
+# (d2) #5232 round 2: the tag->digest is resolved from a REGISTRY V2 HEAD
+#     (the Docker-Content-Digest response header — the exact digest
+#     containerd/Crossplane resolve; for a multi-arch package the top-level
+#     OCI index digest, which the artifact-management API never exposes by its
+#     own digest — live hw274), the durable poll probes BY DIGEST via a v2
+#     digest GET (200), a v2 HEAD non-200 AND a v2 digest GET non-200 both
+#     FATAL, and the map is persisted to the XPKG_DIGEST_CM ConfigMap.
+if ! grep -qF 'xpkg_v2_resolve_digest "${_xw_repo_path}" "${_xw_tag}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 does not resolve the tag->digest from a registry v2 HEAD (xpkg_v2_resolve_digest) — the artifact-management API 404s on a multi-arch OCI index by digest (live hw274) (#5232)" >&2; c65_fail=1
 fi
-if ! grep -qF 'xpkg_artifact_present "${_xw_repo_path}@${_xw_digest}"' "$TMP/s03pin.yaml"; then
-  echo "FAIL: step-03 Phase A4 durable-presence poll is not DIGEST-addressed — a tag-based probe deterministically fails on proxy-cache artifacts (Harbor records no tags; live hw274) (#5232)" >&2; c65_fail=1
+if ! grep -qF "grep -i '^docker-content-digest:'" "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4's v2 digest resolve does not parse the Docker-Content-Digest response header — the servable index digest is the durability signal (#5232)" >&2; c65_fail=1
 fi
-if ! grep -qF 'tag->digest resolution failed' "$TMP/s03pin.yaml"; then
-  echo "FAIL: step-03 Phase A4 lost the FATAL on a failed tag->digest resolution — step-11 would have nothing valid to pivot to (#5232)" >&2; c65_fail=1
+if ! grep -qF 'xpkg_v2_digest_present "${_xw_repo_path}" "${_xw_digest}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 durable-presence poll is not a registry v2 digest GET — the artifact-management API deterministically 404s on a multi-arch OCI index (live hw274) (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'no Docker-Content-Digest for tag' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 lost the FATAL on a v2 HEAD that returns no Docker-Content-Digest (HEAD non-200 / header absent) — step-11 would have nothing valid to pivot to (#5232)" >&2; c65_fail=1
+fi
+if ! grep -qF 'the registry v2 API never served' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 lost the FATAL on a v2 digest GET non-200 durable-verify miss (#5232)" >&2; c65_fail=1
 fi
 if ! grep -qF 'kubectl create configmap "${XPKG_DIGEST_CM}"' "$TMP/s03pin.yaml"; then
   echo "FAIL: step-03 Phase A4 does not persist the tag->digest map to the XPKG_DIGEST_CM ConfigMap — step-11 cannot construct digest pivot refs (#5232)" >&2; c65_fail=1
 fi
 # (d3) #5232: the skip-if-present branch keys ONLY on a digest a PRIOR
-#     successful warm minted (or an in-ref #4955 digest) — never on a fresh
-#     tag resolve through the proxy, which could record a manifest with COLD
-#     blobs (a durability hole).
-if ! grep -qF 'xpkg_artifact_present "${_xw_repo_path}@${_xw_skip_digest}"' "$TMP/s03pin.yaml"; then
-  echo "FAIL: step-03 Phase A4 skip-if-present is not keyed on a prior-minted digest — a tag-based (or fresh-resolve) skip either never fires or can false-skip on a cold-blob manifest record (#5232)" >&2; c65_fail=1
+#     successful warm minted (or an in-ref #4955 digest) and durable-verifies
+#     it with the SAME registry v2 digest GET — never on a fresh tag resolve
+#     through the proxy, which could record a manifest with COLD blobs.
+if ! grep -qF 'xpkg_v2_digest_present "${_xw_repo_path}" "${_xw_skip_digest}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A4 skip-if-present is not keyed on a prior-minted digest verified via the registry v2 digest GET — a tag-based (or fresh-resolve) skip either never fires or can false-skip on a cold-blob manifest record (#5232)" >&2; c65_fail=1
+fi
+# (d3b) #5232 round 2: the xpkg leg (Phase A4) makes NO artifact-management-API
+#     call — for a multi-arch package that API 404s on the OCI index by its
+#     own digest (live hw274). The registry v2 manifest API is the sole xpkg
+#     durability probe. (The container-image Phase A dest_already_current
+#     keeps the artifact API per #5030 — a DIFFERENT leg; this scopes to A4.)
+awk '/─── Phase A4/{c=1} /─── Phase B/{c=0} c' "$TMP/s03pin.yaml" > "$TMP/s03_a4.yaml"
+if [ ! -s "$TMP/s03_a4.yaml" ]; then
+  echo "FAIL: could not isolate the step-03 Phase A4 block for the artifact-API-absence assertion (#5232)" >&2; c65_fail=1
+fi
+if grep -Eq 'api/v2\.0/projects/.*/artifacts/' "$TMP/s03_a4.yaml"; then
+  echo "FAIL: step-03 Phase A4 still calls the Harbor artifact-management API (/api/v2.0/.../artifacts/) — it 404s on a multi-arch OCI index by digest; the xpkg leg must verify via the registry v2 manifest API only (#5232)" >&2; c65_fail=1
 fi
 # (d4) #5232: both steps project the SAME values-driven digest-map CM name.
 if ! grep -A1 'name: XPKG_DIGEST_CM' "$TMP/s03pin.yaml" | grep -q 'value: "self-sovereign-cutover-xpkg-digests"'; then
@@ -3038,6 +3069,16 @@ fi
 helm template smoke . --show-only templates/11-crossplane-provider-pivot-job.yaml > "$TMP/r11_5204.yaml"
 if ! grep -qF 'verify_local_pkg_artifact()' "$TMP/r11_5204.yaml"; then
   echo "FAIL: step-11 lost the verify_local_pkg_artifact gate — spec.package can be pivoted onto a ref the local registry never durably serves (#5204)" >&2; c65_fail=1
+fi
+# #5232 round 2: step-11's verify probes the REGISTRY V2 manifest API BY
+# DIGEST (200), NOT the Harbor artifact-management API — the same multi-arch-
+# aware durability signal step-03 uses (the artifact API 404s on a multi-arch
+# OCI index by its own digest; live hw274).
+if ! grep -qF '${HARBOR_INTERNAL_URL}/v2/${_vp}/manifests/${_vref}' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 verify_local_pkg_artifact does not probe the registry v2 manifest API BY DIGEST — the artifact-management API 404s on a multi-arch OCI index (live hw274) (#5232)" >&2; c65_fail=1
+fi
+if grep -Eq 'api/v2\.0/projects/.*/artifacts/' "$TMP/r11_5204.yaml"; then
+  echo "FAIL: step-11 still calls the Harbor artifact-management API (/api/v2.0/.../artifacts/) — the xpkg verify must go through the registry v2 manifest API only (#5232)" >&2; c65_fail=1
 fi
 if ! grep -qF 'lookup_pkg_digest' "$TMP/r11_5204.yaml"; then
   echo "FAIL: step-11 lost the lookup into the step-03 tag->digest map — without it every pivot ref stays tag-form and 404s post-severance (#5232)" >&2; c65_fail=1
@@ -3079,6 +3120,6 @@ if ! grep -A1 'name: VERIFY_LOCAL_ARTIFACT' "$TMP/r11_5204_off.yaml" | grep -q '
   echo "FAIL: crossplaneProviderPivot.verifyLocalArtifact.enabled=false did not render VERIFY_LOCAL_ARTIFACT=\"false\" — the operator override is not wired (#5204)" >&2; c65_fail=1
 fi
 if [ "$c65_fail" -ne 0 ]; then exit 1; fi
-echo "  PASS (#5204 #5232: step-03 Phase A4 enumerates the Provider spec.package set, warms each xpkg ref DURABLY through the local proxy-xpkg endpoint [pull-through — Harbor rejects pushes into a proxy-cache project], resolves the tag->digest from the pulled-through scratch manifest, asserts durability BY DIGEST via the artifact API [tags are never recorded on proxy projects — hw274], persists the map + FATALs on any miss; step-11 pivots spec.package BY the minted digest with digest-addressed verify-before-pivot, re-verifies already-pivoted refs by digest, upgrades tag-form live pivots, pushes the digest form to Gitea, and FATALs loud on DIGEST-MISS naming the exact recovery; both toggles operator-wired; xpkg.upbound.io stays excluded from the generic push mirror)"
+echo "  PASS (#5204 #5232: step-03 Phase A4 enumerates the Provider spec.package set, warms each xpkg ref DURABLY through the local proxy-xpkg endpoint [pull-through — Harbor rejects pushes into a proxy-cache project], resolves the tag->digest from a registry v2 HEAD [Docker-Content-Digest — the servable OCI index digest the artifact-management API never exposes; live hw274], asserts durability via a v2 digest GET [200], persists the map + FATALs on a v2 HEAD non-200 or a v2 digest GET non-200 [no artifact-management-API call in the xpkg leg]; step-11 pivots spec.package BY the minted digest with the SAME v2 digest-GET verify-before-pivot, re-verifies already-pivoted refs by digest, upgrades tag-form live pivots, pushes the digest form to Gitea, and FATALs loud on DIGEST-MISS naming the exact recovery; both toggles operator-wired; xpkg.upbound.io stays excluded from the generic push mirror)"
 
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.143"
+  version: "0.1.144"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.143"
+    version: "0.1.144"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (live hw274, dep d51a69f885872a81, cutover chart 0.1.143 run)

PR #5233 (0.1.143) moved the Crossplane xpkg leg to DIGEST refs and resolves the digest correctly, but verifies durability against the **wrong Harbor API** — so step-03 Phase A4 **still FATALs**:

- #5233 verifies via the Harbor **artifact-management API** `GET /api/v2.0/projects/proxy-xpkg/repositories/<repo>/artifacts/<digest>`. For a **multi-arch** package Harbor's proxy-cache records ONLY the per-arch child manifests there (live: `sha256:f344ef2c` / `fbe8adf8` / `238c1393`, all `type=IMAGE`) and **never** exposes the top-level OCI **index** by its own digest → `GET artifacts/sha256:4aeddb70…` (the resolved index) **404s** → `Phase A4 FAIL … pulled through but never durably recorded`, despite every blob being durable.
- The **registry v2 API** serves it correctly and is exactly containerd/Crossplane's pull path:
  - `HEAD /v2/proxy-xpkg/upbound/provider-opentofu/manifests/v1.1.3` → `200`, `Content-Type: application/vnd.oci.image.index.v1+json`, `Docker-Content-Digest: sha256:4aeddb70…`
  - `GET /v2/.../manifests/sha256:4aeddb70…` → `200`

## Fix (chart `platform/self-sovereign-cutover` 0.1.143 → 0.1.144)

**step-03 Phase A4** (`03-harbor-prewarm-job.yaml`): after the full pull-through, resolve the tag→digest from a registry **v2 HEAD** (parse the `Docker-Content-Digest` response header) and durable-verify with a **v2 digest GET** (`200`). FATAL **only** on a v2 HEAD non-200 (no digest header) **or** a v2 digest GET non-200. The artifact-management-API probe is removed from the xpkg leg entirely (the container-image Phase A `dest_already_current` keeps it per #5030 — a different leg). Skip-if-present keys on a prior-minted digest verified via the same v2 digest GET.

**step-11** (`11-crossplane-provider-pivot-job.yaml`): `verify_local_pkg_artifact` and the already-pivoted SKIP branch use the same v2 digest GET. The digest-addressed `spec.package` pivot is unchanged.

The `Accept` header covers OCI index + docker manifest list + single manifest, so a **single-arch** package (whose HEAD returns a `manifest.v2` digest, equally servable) needs no special-casing.

### Before / after (the verify snippet)

```diff
-# step-03 xpkg_artifact_present() / step-11 verify_local_pkg_artifact()
-_xa_d=$(curl -sk -u "$U:$P" \
-  "$HARBOR_INTERNAL_URL/api/v2.0/projects/$proj/repositories/$repo_enc/artifacts/$ref" \
-  | jq -r '.digest // empty')
-[ -n "$_xa_d" ]                       # 404s on a multi-arch OCI index -> FATAL
+# resolve: v2 HEAD -> Docker-Content-Digest
+curl -sSIk -u "$U:$P" -H "Accept: <index,list,manifest,manifest.v2>" \
+  "$HARBOR_INTERNAL_URL/v2/$repo/manifests/$tag" \
+  | tr -d '\r' | grep -i '^docker-content-digest:' | tail -1 | awk '{print $2}'
+# verify: v2 GET digest must be 200
+code=$(curl -sk -o /dev/null -w '%{http_code}' -u "$U:$P" -H "Accept: <…>" \
+  "$HARBOR_INTERNAL_URL/v2/$repo/manifests/$digest")
+[ "$code" = 200 ]
```

## Validation

- `helm lint` clean.
- `tests/cutover-contract.sh` full suite **green** (67 cases; Case 65 re-locked to assert the v2 HEAD digest-parse, the v2 digest GET 200 durability check, the FATAL on a v2 HEAD/GET non-200, and **no artifact-management-API call in the xpkg leg** for both steps).
- `sh -n` / `bash -n` clean on the rendered step-03 + step-11 scripts.
- Stub-driven simulation of the rendered helpers proves: multi-arch HEAD resolves the exact hw274 index `sha256:4aeddb70…` + v2 GET 200; the old artifact-API 404s on that same index digest; **single-arch** HEAD resolves a `manifest.v2` digest + v2 GET 200 (handled, no special-casing); v2 HEAD non-200 → empty digest → resolution FATAL; v2 digest GET non-200 → durable-verify FATAL.
- `scripts/check-catalog-seed-lockstep.sh` 68/0.
- All lockstep pins moved to 0.1.144: chart `Chart.yaml`, `blueprint.yaml`, bootstrap-kit slot `06a`, catalog-seed both version fields.

No NodePort. Merge + hw274 re-roll sequenced by the orchestrator.

Refs #5232 #5204

🤖 Generated with [Claude Code](https://claude.com/claude-code)