### PR TITLE
fix(cutover): step-06 union-warm-on-drift for catalog-latest ahead of prewarm

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -932,7 +932,17 @@ spec:
       # via a v2 HEAD and verifies durability with a v2 digest GET; step-11
       # verify_local_pkg_artifact + the already-pivoted branch use the same v2
       # digest GET. Contract Case 65 re-locked.
-      version: 0.1.144
+      # 0.1.145 (#5237 Refs #5007): step-06 helmrepository-patches Phase-3a
+      # UNION-WARM-ON-DRIFT — when a sampled pivoted chart is absent from local
+      # Harbor because a mid-cutover deploy-bot bump drifted bp-catalyst-platform
+      # one concrete pin ahead of what step-03 prewarm mirrored (LIVE hw274:
+      # prewarm 1.4.1164, flux redeployed 1.4.1165 pre-step-06, step-06 404'd +
+      # stalled → cutover parked), top-up-warm it from the still-reachable
+      # upstream (step-06 runs BEFORE the step-08 deny-egress hold) into local
+      # Harbor, then re-probe. Self-healing (no hand-skopeo); a chart unpullable
+      # from BOTH local AND upstream still FATALs at the deadline. New knob
+      # helmReadinessProbe.unionWarmOnDrift (default true). Contract Case 66 added.
+      version: 0.1.145
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.144
+  version: 0.1.145
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.145 (#5237 Refs #5007 — step-06 helmrepository-patches UNION-WARM-ON-DRIFT.
+# Phase-3a samples the LIVE chart version off each pivoted HelmRelease (deployed
+# `.status.history[0].chartVersion` // desired `.spec.chart.spec.version`) and
+# refuses to strip mothership auth until each sampled chart is pullable from
+# local Harbor. If a `bp-catalyst-platform` release is published to ghcr AFTER
+# step-03 harbor-prewarm finishes (a mid-cutover merge's deploy-bot bump), flux
+# redeploys the umbrella to the newer CONCRETE pin BEFORE step-06 runs — so the
+# sampled tag is one bump ahead of what prewarm mirrored (catalog-latest drift;
+# neither the deployed NOR the desired tag was warmed → step-03 union-warm #5007
+# cannot cover it, the tag did not yet exist when prewarm ran). LIVE hw274 (dep
+# d51a69f885872a81): prewarm warmed through bp-catalyst-platform:1.4.1164;
+# 1.4.1165 published ~2 min later; step-06 sampled 1165, 404'd locally, stalled
+# stripReadinessSeconds → cutover parked at pct=45 → hand-heal (manual skopeo).
+# FIX: when a sampled chart is absent from local Harbor, TOP-UP-WARM it from the
+# still-reachable upstream (step-06 runs BEFORE the step-08 deny-egress hold) via
+# `helm pull` upstream + `helm push` local, then re-probe — self-healing the
+# drift, no hand-skopeo. Bounded per chart:ver (UNION_WARM_MAX_ATTEMPTS=3); a
+# chart genuinely unpullable from BOTH local AND upstream still FATALs at the
+# deadline (fail-loud preserved). New knob helmReadinessProbe.unionWarmOnDrift
+# (env UNION_WARM_ON_DRIFT, default true; false restores pure fail-loud). ghcr
+# creds come from the SAME ghcr-pull dockerconfig Phase-0 already reads (no new
+# secret); upstream ghcr.io keeps verify ON, only the in-cluster push carries
+# the existing LE-staging skip. No step-count / RBAC / deadline change (still 11
+# steps). Contract Case 66 asserts the union-warm helper + fail-branch call are
+# present in the rendered step-06 script.
+#
 # 0.1.144 (#5232 round 2 Refs #5204 — the xpkg digest verify + resolution
 # move to the REGISTRY V2 manifest API. Live hw274 (dep d51a69f885872a81,
 # 0.1.143 run): step-03 Phase A4 resolved the OCI-index digest correctly but
@@ -2439,7 +2465,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.144
+version: 0.1.145
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -173,6 +173,30 @@ data:
           # fast while still proving Harbor serves charts + auth works.
           - name: HELM_PROBE_SAMPLE_SIZE
             value: {{ .Values.helmReadinessProbe.sampleSize | quote }}
+          # #5237 (Refs #5007): union-warm-on-drift. Phase-3a samples the LIVE
+          # chart version off each pivoted HelmRelease (deployed
+          # `.status.history[0].chartVersion` // desired `.spec.chart.spec
+          # .version`). If a `bp-catalyst-platform` release is published to
+          # ghcr AFTER step-03 harbor-prewarm finishes (a mid-cutover merge's
+          # deploy-bot bump), flux redeploys the umbrella to the newer
+          # concrete pin BEFORE this step runs — so the sampled version is a
+          # tag prewarm never mirrored (catalog-latest drifted one bump ahead;
+          # neither the deployed NOR the desired tag was warmed). When true
+          # (default), a sampled chart that is absent from local Harbor is
+          # TOP-UP-WARMED from the still-reachable upstream (this step runs
+          # BEFORE the step-08 deny-egress hold) into local Harbor, then
+          # re-probed — self-healing the drift instead of stalling
+          # stripReadinessSeconds and parking the cutover. A genuinely-absent
+          # chart (unpullable from BOTH local Harbor AND upstream) still
+          # FATALs at the deadline (fail-loud preserved). Set false to restore
+          # pure fail-loud (no upstream top-up).
+          # NB: bare `| quote` (NOT `| default true`) — sprig `default` treats a
+          # literal `false` as empty and would flip an explicit disable back to
+          # true (feedback_rbac_create_no_resourcenames.md sprig_default_bool_unsafe).
+          # The values.yaml default (true) supplies the on-state; a nil renders
+          # "" and the script's `: "${UNION_WARM_ON_DRIFT:=true}"` restores true.
+          - name: UNION_WARM_ON_DRIFT
+            value: {{ .Values.helmReadinessProbe.unionWarmOnDrift | quote }}
           # #4557 (Refs #3379): TLS-verify on the Phase-3a helm-CLI probe
           # DESTINATION (the in-cluster Harbor `registry.<sov-fqdn>` =
           # harbor_host). DEFAULT false — the in-cluster Harbor serves an
@@ -180,9 +204,10 @@ data:
           # in a Job Pod has no node trust store. See
           # .Values.helmReadinessProbe.inClusterTLSVerify. When false, both
           # `helm registry login` and `helm pull` (in-cluster target) carry
-          # `--insecure-skip-tls-verify`; external ghcr/upstream calls are
-          # NOT made by this step, so verify is only ever skipped for the
-          # cluster's own registry.
+          # `--insecure-skip-tls-verify`. The ONLY external (ghcr/upstream)
+          # helm calls this step makes are the #5237 union-warm top-up pulls,
+          # which target the public-CA-signed ghcr.io and keep verify ON — the
+          # in-cluster skip is only ever applied to the cluster's own registry.
           - name: HELM_IN_CLUSTER_TLS_VERIFY
             value: {{ .Values.helmReadinessProbe.inClusterTLSVerify | default false | quote }}
           # Refs #3379 — source-controller TLS-trust for the pivoted
@@ -1243,6 +1268,89 @@ data:
               && echo "[helmrepository-patches] Phase-3a: helm registry login ${harbor_endpoint} OK" \
               || echo "[helmrepository-patches] Phase-3a WARN: helm registry login ${harbor_endpoint} returned non-zero (will retry inside the pull loop)"
 
+            # ---- #5237 union-warm-on-drift setup (Refs #5007) ----
+            # Derive the upstream (ghcr) host/project from the SAME value
+            # Phase-1 pivots FROM (oci://ghcr.io/openova-io). If a sampled chart
+            # drifted ahead of step-03 prewarm (a mid-cutover deploy-bot bump
+            # publishes bp-catalyst-platform:<N+1> AFTER prewarm mirrored :<N>
+            # and flux redeploys the umbrella to :<N+1> before THIS step), the
+            # local pull below 404s. This step runs BEFORE the step-08
+            # deny-egress hold, so the drifted tag is still pullable upstream —
+            # warm it into local Harbor on demand (helm pull upstream + helm
+            # push local), self-healing the catalog-latest-vs-prewarm race.
+            up_ref=$(printf '%s' "${UPSTREAM_PREFIX}" | sed -e 's,^oci://,,' -e 's,/*$,,')
+            up_host=${up_ref%%/*}
+            up_proj=${up_ref#*/}
+            : "${UNION_WARM_ON_DRIFT:=true}"
+            # Cap upstream top-up attempts per distinct chart:ver so a
+            # genuinely-absent tag cannot spin the upstream every 15s until the
+            # deadline (the stripReadinessSeconds deadline is the fail-loud
+            # guard); 3 attempts absorb a transient ghcr blip.
+            : "${UNION_WARM_MAX_ATTEMPTS:=3}"
+            if [ "${UNION_WARM_ON_DRIFT}" = "true" ]; then
+              # ghcr auth from the SAME ghcr-pull dockerconfig Phase-0 read
+              # (openova-io chart packages are PRIVATE); fall through to
+              # anonymous if absent. Upstream ghcr.io is public-CA-signed →
+              # verify stays ON for the upstream pull (no insecure flag).
+              up_auth_b64=$(printf '%s' "${existing_json:-}" | jq -r --arg h "${up_host}" '.auths[$h].auth // empty' 2>/dev/null || true)
+              if [ -n "${up_auth_b64}" ]; then
+                up_userpass=$(printf '%s' "${up_auth_b64}" | base64 -d 2>/dev/null || true)
+                up_user=${up_userpass%%:*}
+                up_pass=${up_userpass#*:}
+                if [ -n "${up_user}" ] && helm registry login "${up_host}" -u "${up_user}" -p "${up_pass}" >/dev/null 2>&1; then
+                  echo "[helmrepository-patches] Phase-3a: helm registry login ${up_host} OK (#5237 union-warm source)"
+                else
+                  echo "[helmrepository-patches] Phase-3a WARN: helm registry login ${up_host} non-zero — #5237 union-warm will try anonymous (public packages still pull)"
+                fi
+              else
+                echo "[helmrepository-patches] Phase-3a: no ${up_host} auth in ghcr-pull — #5237 union-warm pulls anonymously if the package is public"
+              fi
+            else
+              echo "[helmrepository-patches] Phase-3a: #5237 union-warm-on-drift DISABLED (UNION_WARM_ON_DRIFT=${UNION_WARM_ON_DRIFT}) — pure fail-loud on a drifted catalog-latest"
+            fi
+
+            # Top-up-warm ONE sampled chart:ver from the upstream into local
+            # Harbor. Called from the pull loop's fail branch; the next poll
+            # pass re-pulls it locally. Bounded per chart:ver; returns non-zero
+            # (no-op) when disabled, capped, or the warm fails — the deadline
+            # stays the fail-loud guard for a genuinely-absent chart.
+            warm_chart_from_upstream() {
+              w_chart="$1"; w_ver="$2"
+              [ "${UNION_WARM_ON_DRIFT}" = "true" ] || return 1
+              w_slug=$(printf '%s_%s' "${w_chart}" "${w_ver}" | tr -c 'A-Za-z0-9._-' '_')
+              w_marker="/tmp/.warm-${w_slug}.n"
+              w_n=0
+              [ -f "${w_marker}" ] && w_n=$(cat "${w_marker}" 2>/dev/null || echo 0)
+              if [ "${w_n}" -ge "${UNION_WARM_MAX_ATTEMPTS}" ]; then
+                return 1
+              fi
+              printf '%s' "$((w_n + 1))" > "${w_marker}"
+              echo "[helmrepository-patches] Phase-3a union-warm (#5237): ${w_chart}:${w_ver} absent from local Harbor — top-up-warming from ${up_host}/${up_proj} (egress still open, attempt $((w_n + 1))/${UNION_WARM_MAX_ATTEMPTS})"
+              rm -rf /tmp/warm-pull; mkdir -p /tmp/warm-pull
+              if ! helm pull "oci://${up_host}/${up_proj}/${w_chart}" --version "${w_ver}" \
+                   -d /tmp/warm-pull >/tmp/.warm-pull.log 2>&1; then
+                echo "[helmrepository-patches] Phase-3a union-warm WARN: upstream pull ${up_host}/${up_proj}/${w_chart}:${w_ver} failed (may be genuinely absent upstream — deadline stays fail-loud):" >&2
+                sed 's/^/    /' /tmp/.warm-pull.log 2>/dev/null | tail -4 >&2 || true
+                return 1
+              fi
+              w_tgz=$(ls /tmp/warm-pull/*.tgz 2>/dev/null | head -n1)
+              if [ -z "${w_tgz}" ]; then
+                echo "[helmrepository-patches] Phase-3a union-warm WARN: no chart tarball produced for ${w_chart}:${w_ver}" >&2
+                return 1
+              fi
+              # Push to the SAME openova-io path the probe pulls from; local
+              # Harbor is the in-cluster LE-staging target → carry the same
+              # in-cluster skip flag the local pull uses.
+              if helm push "${w_tgz}" "oci://${harbor_endpoint}/openova-io" ${HELM_PULL_INSECURE_FLAG} \
+                   >/tmp/.warm-push.log 2>&1; then
+                echo "[helmrepository-patches] Phase-3a union-warm OK (#5237): ${w_chart}:${w_ver} pushed to ${harbor_endpoint}/openova-io — local Harbor now serves the drifted catalog-latest; re-probing"
+                return 0
+              fi
+              echo "[helmrepository-patches] Phase-3a union-warm WARN: push ${w_chart}:${w_ver} -> ${harbor_endpoint} failed:" >&2
+              sed 's/^/    /' /tmp/.warm-push.log 2>/dev/null | tail -4 >&2 || true
+              return 1
+            }
+
             while [ "$(date +%s)" -lt "${strip_wait_deadline}" ]; do
               if [ "${sample_total}" -eq 0 ]; then
                 # No pivoted-chart HelmRelease found yet — Phase-1's URL pivot
@@ -1302,6 +1410,12 @@ data:
                 else
                   pull_fail=$((pull_fail+1))
                   pull_fail_names="${pull_fail_names}${p_chart}:${p_ver} "
+                  # #5237: the local pull 404'd — if this is a catalog-latest
+                  # drift (tag published AFTER step-03 prewarm), top-up-warm it
+                  # from the still-reachable upstream so the next poll pass finds
+                  # it locally. Bounded per chart:ver; no-op when disabled or at
+                  # the attempt cap. `|| true` keeps `set -e` happy.
+                  warm_chart_from_upstream "${p_chart}" "${p_ver}" || true
                 fi
               done < "${sample_file}"
               if [ "${pull_ok}" -gt 0 ] && [ "${pull_fail}" -eq 0 ]; then

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3122,4 +3122,61 @@ fi
 if [ "$c65_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5204 #5232: step-03 Phase A4 enumerates the Provider spec.package set, warms each xpkg ref DURABLY through the local proxy-xpkg endpoint [pull-through — Harbor rejects pushes into a proxy-cache project], resolves the tag->digest from a registry v2 HEAD [Docker-Content-Digest — the servable OCI index digest the artifact-management API never exposes; live hw274], asserts durability via a v2 digest GET [200], persists the map + FATALs on a v2 HEAD non-200 or a v2 digest GET non-200 [no artifact-management-API call in the xpkg leg]; step-11 pivots spec.package BY the minted digest with the SAME v2 digest-GET verify-before-pivot, re-verifies already-pivoted refs by digest, upgrades tag-form live pivots, pushes the digest form to Gitea, and FATALs loud on DIGEST-MISS naming the exact recovery; both toggles operator-wired; xpkg.upbound.io stays excluded from the generic push mirror)"
 
+# ── Case 66 (#5237 Refs #5007): step-06 Phase-3a UNION-WARM-ON-DRIFT ─────────
+# A `bp-catalyst-platform` release published to ghcr AFTER step-03 harbor-
+# prewarm finishes (a mid-cutover deploy-bot bump) drifts the umbrella one
+# CONCRETE pin ahead of what prewarm mirrored; flux redeploys it BEFORE step-06,
+# so Phase-3a samples a tag prewarm never warmed (the #5007 step-03 union-warm
+# cannot cover it — that tag did not exist when prewarm ran). LIVE hw274 (dep
+# d51a69f8): prewarm warmed 1.4.1164; 1.4.1165 published ~2 min later; step-06
+# sampled 1165, 404'd locally, stalled stripReadinessSeconds → cutover parked at
+# pct=45 → hand-heal (manual skopeo). FIX: a sampled chart absent from local
+# Harbor is top-up-warmed from the still-reachable upstream (step-06 runs BEFORE
+# the step-08 deny-egress hold) via helm pull upstream + helm push local, then
+# re-probed — self-healing, no hand-skopeo. A chart unpullable from BOTH local
+# AND upstream still FATALs at the deadline (fail-loud preserved).
+echo "[cutover-contract] Case 66: step-06 Phase-3a top-up-warms a catalog-latest chart that drifted ahead of step-03 prewarm from the still-reachable upstream, instead of stalling (#5237 Refs #5007)"
+c66_fail=0
+# (a) the gate env defaults to "true".
+if ! grep -A1 'name: UNION_WARM_ON_DRIFT' "$STEP06_F" | grep -q 'value: "true"'; then
+  echo "FAIL: step-06 UNION_WARM_ON_DRIFT does not default to \"true\" (helmReadinessProbe.unionWarmOnDrift) — a drifted catalog-latest would stall the strip-readiness gate (#5237)" >&2; c66_fail=1
+fi
+# (b) the warm helper exists AND is invoked from the local-pull fail branch —
+#     a helper that is never called cannot self-heal the drift.
+if ! grep -qF 'warm_chart_from_upstream()' "$STEP06_F"; then
+  echo "FAIL: step-06 lost the warm_chart_from_upstream helper — a sampled chart that drifted ahead of prewarm has no self-heal path and stalls the gate (#5237)" >&2; c66_fail=1
+fi
+if ! grep -qF 'warm_chart_from_upstream "${p_chart}" "${p_ver}"' "$STEP06_F"; then
+  echo "FAIL: step-06's Phase-3a local-pull fail branch never calls warm_chart_from_upstream — the helper exists but is never invoked, so the drift still stalls the gate (#5237)" >&2; c66_fail=1
+fi
+# (c) the warm PULLS from the upstream (ghcr) and PUSHES to local Harbor's
+#     openova-io — the exact path the probe pulls from.
+if ! grep -qF 'helm pull "oci://${up_host}/${up_proj}/${w_chart}"' "$STEP06_F"; then
+  echo "FAIL: step-06 union-warm does not helm-pull the drifted chart from the upstream host — the top-up has no source (#5237)" >&2; c66_fail=1
+fi
+if ! grep -qF 'helm push "${w_tgz}" "oci://${harbor_endpoint}/openova-io"' "$STEP06_F"; then
+  echo "FAIL: step-06 union-warm does not helm-push the warmed chart into local Harbor's openova-io project — the probe would still 404 the next pull (#5237)" >&2; c66_fail=1
+fi
+# (d) the upstream pull keeps TLS verify ON (public-CA-signed ghcr) — the
+#     in-cluster LE-staging skip flag must NOT be applied to the external pull.
+if grep -F 'helm pull "oci://${up_host}' "$STEP06_F" | grep -q 'HELM_PULL_INSECURE_FLAG'; then
+  echo "FAIL: step-06 union-warm applies the in-cluster TLS-skip flag to the EXTERNAL upstream pull — ghcr.io is public-CA-signed and MUST be verified (#5237)" >&2; c66_fail=1
+fi
+# (e) fail-loud preserved: a bounded attempt cap + the REFUSE-to-strip FATAL
+#     both survive — a chart unpullable from BOTH local and upstream still
+#     parks the cutover recoverably instead of silently stripping auth.
+if ! grep -qF 'UNION_WARM_MAX_ATTEMPTS' "$STEP06_F"; then
+  echo "FAIL: step-06 union-warm lost the per-chart:ver attempt cap — a genuinely-absent tag would spin the upstream every 15s until the deadline (#5237)" >&2; c66_fail=1
+fi
+if ! grep -qF 'REFUSING to strip' "$STEP06_F"; then
+  echo "FAIL: step-06 lost the strip-readiness FATAL/REFUSE path — the union-warm must NOT weaken the fail-loud guard for a chart unpullable from both local and upstream (#5237)" >&2; c66_fail=1
+fi
+# (f) the toggle is operator-wired: disabling it renders UNION_WARM_ON_DRIFT="false".
+helm template smoke-nounionwarm . --show-only templates/06-helmrepository-patches-job.yaml --set helmReadinessProbe.unionWarmOnDrift=false > "$TMP/r06_5237_off.yaml"
+if ! grep -A1 'name: UNION_WARM_ON_DRIFT' "$TMP/r06_5237_off.yaml" | grep -q 'value: "false"'; then
+  echo "FAIL: helmReadinessProbe.unionWarmOnDrift=false did not render UNION_WARM_ON_DRIFT=\"false\" — the operator override is not wired (#5237)" >&2; c66_fail=1
+fi
+if [ "$c66_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5237: step-06 Phase-3a top-up-warms a sampled chart absent from local Harbor [catalog-latest drifted ahead of step-03 prewarm] from the still-reachable upstream — helm pull upstream [verify ON] + helm push local openova-io — then re-probes; bounded per chart:ver; the REFUSE-to-strip FATAL still guards a chart unpullable from both local and upstream; operator-toggleable via helmReadinessProbe.unionWarmOnDrift)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1698,6 +1698,20 @@ helmReadinessProbe:
   # gate fast while remaining a genuine end-to-end pull. Operators may raise
   # this to probe more charts.
   sampleSize: 5
+  # #5237 (Refs #5007): union-warm-on-drift. Phase-3a samples the LIVE chart
+  # version off each pivoted HelmRelease. If a `bp-catalyst-platform` release
+  # is published to ghcr AFTER step-03 harbor-prewarm finishes (a mid-cutover
+  # merge's deploy-bot bump), flux redeploys the umbrella to the newer concrete
+  # pin BEFORE this step runs, so the sampled tag is one bump ahead of what
+  # prewarm mirrored (catalog-latest drift) → the local pull 404s → step-06
+  # stalls stripReadinessSeconds and the cutover parks (LIVE hw274, dep
+  # d51a69f8). When true (default), a sampled chart absent from local Harbor is
+  # top-up-warmed from the still-reachable upstream (this step runs BEFORE the
+  # step-08 deny-egress hold) into local Harbor, then re-probed — self-healing
+  # the drift with no hand-skopeo. A chart genuinely unpullable from BOTH local
+  # AND upstream still FATALs at the deadline (fail-loud preserved). Set false
+  # to restore pure fail-loud (no upstream top-up).
+  unionWarmOnDrift: true
   # #4557 (Refs #3379): TLS verification on the helm-CLI probe DESTINATION —
   # the IN-CLUSTER Harbor reached as `registry.<sov-fqdn>` (HARBOR_PUBLIC_URL
   # → harbor_host). DEFAULT false (skip verify for the in-cluster target).

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.144"
+  version: "0.1.145"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.144"
+    version: "0.1.145"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (recurring Pillar-5 cutover stall — LIVE hw274)

Cutover **step-06 (helmrepository-patches)** Phase-3a samples the LIVE chart
version off each pivoted HelmRelease (deployed `.status.history[0].chartVersion`
// desired `.spec.chart.spec.version`) and refuses to strip mothership auth
until every sampled chart is pullable from local Harbor.

If a `bp-catalyst-platform` release is published to ghcr **AFTER** step-03
harbor-prewarm finishes (a mid-cutover merge's deploy-bot bump), flux redeploys
the umbrella to the newer **concrete** pin **BEFORE** step-06 runs — so the
sampled tag is one bump ahead of what prewarm mirrored (catalog-latest drift).
The **#5007 step-03 union-warm cannot cover it**: that tag did not exist when
prewarm ran.

**hw274** (dep `d51a69f8`): prewarm warmed through `bp-catalyst-platform:1.4.1164`;
`1.4.1165` published ~2 min later; step-06 sampled `1165`, 404'd locally,
stalled `stripReadinessSeconds` → cutover parked at `pct=45` → had to hand-heal
with a manual skopeo-copy. That hand-heal should not be necessary.

## Which option + why

**Implemented issue option 1 — targeted union-warm top-up at step-06.**

Option 3 (sample the flux-HR-pinned version) was **rejected on the code**: the
`bp-catalyst-platform` HelmRelease is a **concrete** pin
(`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` → `version: 1.4.1165`),
and step-03 prewarm Phase A2 already warms the **union of deployed + desired**
(`03-harbor-prewarm-job.yaml`, #5007 round 3). On hw274 **both** the deployed
and the desired versions drifted forward to `1.4.1165` **after** prewarm covered
`1164` — so the sampled HR-pinned version **is the absent one**. No
version-resolution change removes the race; the tag simply did not exist locally.
Only a top-up warm from the still-reachable upstream heals it.

Step-06 runs **before** the step-08 deny-egress hold, so ghcr is reachable. When
a sampled chart is absent from local Harbor, the fail branch now top-up-warms it
(`helm pull` upstream + `helm push` local, reusing the `ghcr-pull` dockerconfig
Phase-0 already reads), then re-probes. Self-healing, no hand-skopeo. The
upstream ghcr.io pull keeps TLS verify **on**; only the in-cluster push carries
the existing LE-staging skip flag.

**Fail-loud preserved**: bounded per chart:ver (`UNION_WARM_MAX_ATTEMPTS=3`); a
chart unpullable from BOTH local AND upstream still FATALs at the deadline
(REFUSE-to-strip). New toggle `helmReadinessProbe.unionWarmOnDrift`
(env `UNION_WARM_ON_DRIFT`, default `true`; `false` restores pure fail-loud).
No step-count / RBAC / deadline change (still 11 steps).

### Phase-3a pull-loop fail branch (added)

```diff
                 else
                   pull_fail=$((pull_fail+1))
                   pull_fail_names="${pull_fail_names}${p_chart}:${p_ver} "
+                  # #5237: local pull 404'd — if a catalog-latest tag published
+                  # AFTER step-03 prewarm, top-up-warm it from the still-reachable
+                  # upstream so the next poll pass finds it locally.
+                  warm_chart_from_upstream "${p_chart}" "${p_ver}" || true
                 fi
```

The new `warm_chart_from_upstream()` helper: `helm pull "oci://${up_host}/${up_proj}/${w_chart}" --version "${w_ver}"`
(verify on) → `helm push "${w_tgz}" "oci://${harbor_endpoint}/openova-io" ${HELM_PULL_INSECURE_FLAG}`.

## Validation

- `helm lint` (cutover chart + catalyst chart) — pass
- `tests/cutover-contract.sh` — **66/66 cases green**, incl. new **Case 66**
  (asserts the union-warm helper + fail-branch call, upstream pull / local push,
  verify-on for the external pull, the `UNION_WARM_MAX_ATTEMPTS` cap + the
  REFUSE-to-strip FATAL survive, and the toggle wires `UNION_WARM_ON_DRIFT="false"`)
- `sh -n` (POSIX `/bin/sh`, the runtime shell) + `bash -n` on the rendered
  step-06 script — pass
- `scripts/check-catalog-seed-lockstep.sh` — pass (68 checked, 0 fail)
- `tests/image-registry-coverage.sh` — pass

Chart `0.1.144 → 0.1.145`; all lockstep pins moved (bootstrap-kit 06a slot,
`blueprint.yaml`, catalog-seed both version fields).

Refs #5237 #5007

🤖 Generated with [Claude Code](https://claude.com/claude-code)
