### PR TITLE
fix(cnpg-pair): dr-promoter arm gate reads a streaming signal the probe role can actually see (#5239)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -243,7 +243,17 @@ spec:
       # is recorded on the HR (dr-timeline-diverged-at); the re-clone stays the
       # operator's RUNBOOKS §6.1 action (non-destructive). #5219 latch + 120s
       # hold + pg_isready gate + sync fence unchanged. No new substitute.
-      version: 0.2.16
+      # 0.2.17 (#5239): the #5220 arm gate NEVER armed — it read "streaming" from
+      # pg_stat_wal_receiver.status, but the signals probe authenticates as
+      # streaming_replica, which lacks pg_read_all_stats so status is ALWAYS NULL
+      # (live-confirmed hw274) → status='streaming' never true → /shared/armed
+      # never written → actor REFUSED every promote (DR failover dead). Fix:
+      # detect streaming from PUBLIC-readable signals — a live pg_stat_wal_receiver
+      # ROW (EXISTS/pid is visible to all) AND pg_last_wal_receive_lsn() non-null.
+      # A GRANT was not viable (streaming_replica is a CNPG reserved role and does
+      # not exist at postInitSQL time → GRANT would wedge bootstrap). All #5220/
+      # #5219/#5178 gates unchanged; script-only. No new substitute.
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -42,7 +42,15 @@ spec:
   # is SURFACED on the HR (dr-timeline-diverged-at), the re-clone staying the
   # operator's RUNBOOKS §6.1 action (non-destructive). #5219 latch + 120s hold +
   # pg_isready gate + sync fence unchanged.
-  version: 0.2.16
+  # 0.2.17 (#5239): the #5220 arm gate NEVER armed — it read "streaming" from
+  # pg_stat_wal_receiver.status, unreadable to the streaming_replica probe role
+  # (no pg_read_all_stats → status ALWAYS NULL, live-confirmed hw274), so the pair
+  # never armed and the actor refused every promote (DR failover dead). Fix:
+  # detect streaming from PUBLIC-readable signals — a live pg_stat_wal_receiver
+  # ROW (EXISTS visible to all) AND pg_last_wal_receive_lsn() non-null. A GRANT
+  # was not viable (streaming_replica is CNPG-reserved and absent at postInitSQL
+  # time). All #5220/#5219/#5178 gates unchanged; script-only.
+  version: 0.2.17
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.17 (#5239): dr-promoter ARM GATE never armed — the #5220 steady-state arm
+# gate detected "streaming" via `pg_stat_wal_receiver WHERE status = 'streaming'`,
+# but the signals container authenticates as `streaming_replica` (client cert),
+# which lacks pg_read_all_stats/pg_monitor, so PostgreSQL NULLs the privileged
+# columns of pg_stat_wal_receiver for it — `status` is ALWAYS NULL (live-confirmed
+# hw274: pg_has_role('streaming_replica','pg_read_all_stats','MEMBER')=f;
+# SELECT status FROM pg_stat_wal_receiver → NULL). The `status = 'streaming'`
+# predicate was therefore NEVER true → the pair NEVER armed → /shared/armed never
+# written → #5220's actor REFUSED every promote → a real region-kill would NOT
+# fail over (DR failover dead on every env, worse than the #5220 false-promote it
+# replaced). A GRANT is NOT a clean fix: `streaming_replica` is a CNPG RESERVED
+# role (barred from spec.managed.roles) AND does not yet exist at initdb
+# postInitSQL time (ConfigureNewInstance runs postInitSQL BEFORE the operator
+# creates streaming_replica), so a GRANT would fail and wedge the whole primary
+# bootstrap of the platform's shared-pg. Fix: detect "streaming" with objects
+# EVERY role can read on a standby — a live pg_stat_wal_receiver ROW (its `pid`,
+# hence EXISTS, is visible to all; only the detail columns are NULLed) AND
+# pg_last_wal_receive_lsn() IS NOT NULL (both PUBLIC-executable). The row-EXISTS
+# guard neutralises the one hazard of pg_last_wal_receive_lsn() (its value
+# persists after a receiver stops): the view holds a row ONLY while a walreceiver
+# process is live, so requiring BOTH is a true "streaming right now" signal that
+# resets the instant the receiver dies. Everything else in #5220/#5219/#5178 is
+# UNCHANGED (the arm window, the same-tick suspend latch, the refuse-while-unarmed
+# guard, the timeline-divergence surfacing) — only the streaming signal is made
+# readable by the probe role. No resource-count/RBAC/env change (script only).
+# Lockstep slot 16b pin → 0.2.17.
 # 0.2.16 (#5220): dr-promoter FALSE-POSITIVE fix — steady-state ARM gate +
 # timeline-divergence surfacing. On hw273 G12 the 0.2.15 promoter FALSE-PROMOTED
 # region-B during a TRANSIENT region-A unreachability (primary restart-storm +
@@ -146,7 +172,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.16
+version: 0.2.17
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/dr-promoter.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-promoter.yaml
@@ -98,8 +98,10 @@ start) did not help either: the restart-storm hit AFTER the grace window.
 
 (A) ARM GATE — the promoter is INELIGIBLE to promote until the signals
     container has OBSERVED region-b's replica actively STREAMING from
-    region-A (walreceiver status=streaming) CONTINUOUSLY for
-    `steadyStateArmSeconds`. Until that steady-state is reached the actor
+    region-A (a live walreceiver row + a set receive-LSN — the #5239
+    non-privileged streaming signal, since `streaming_replica` cannot
+    read the privileged pg_stat_wal_receiver.status column) CONTINUOUSLY
+    for `steadyStateArmSeconds`. Until that steady-state is reached the actor
     REFUSES every promote (a region-A-down signal before the first stable
     stream is a convergence-time transient, never a real kill). Once
     armed it STAYS armed for the pod's life — a real death AFTER
@@ -387,14 +389,45 @@ spec:
               CONN="host={{ include "cnpg-pair.replicaName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
               # 'promoted'   — NOT in recovery: the local cluster is writable
               #                (already promoted / diverged off the source TL).
-              # 'streaming'  — WAL receiver actively streaming.
-              # 'receiving'  — a WAL receiver row EXISTS but is not (yet)
-              #                streaming (starting/waiting/restarting/catchup)
+              # 'streaming'  — WAL receiver process ALIVE and it has received WAL
+              #                over the stream (receive-LSN set) — the pair is
+              #                genuinely streaming right now.
+              # 'receiving'  — a WAL receiver row EXISTS but no WAL has been
+              #                received yet (the brief connect/handshake window)
               #                — region-A is delivering WAL, ALIVE, not dead.
               # 'noreceiver' — no WAL receiver row at all → POTENTIAL loss.
+              #
+              # #5239 — the arm gate MUST decide "streaming" from signals the
+              # probe role can actually READ. The signals psql authenticates as
+              # `streaming_replica` (client cert), which lacks pg_read_all_stats
+              # / pg_monitor, so PostgreSQL NULLs the privileged columns of
+              # pg_stat_wal_receiver for it — `status` is ALWAYS NULL
+              # (live-confirmed hw274). The former `status = 'streaming'`
+              # predicate was therefore NEVER true → the pair NEVER armed → a
+              # real region-kill would refuse to promote (DR failover dead on
+              # every env). A privilege GRANT is not a clean fix here:
+              # `streaming_replica` is a CNPG RESERVED role (barred from
+              # spec.managed.roles), and it does not yet exist at initdb
+              # postInitSQL time (ConfigureNewInstance runs postInitSQL before
+              # the operator creates streaming_replica), so a GRANT would fail
+              # and wedge the whole primary bootstrap. Instead detect streaming
+              # with objects EVERY role can read on a standby:
+              #   - pg_is_in_recovery()       — PUBLIC-executable
+              #   - the pg_stat_wal_receiver ROW — its `pid` (hence EXISTS) is
+              #                                    visible to all; only the
+              #                                    detail columns are NULLed
+              #   - pg_last_wal_receive_lsn() — PUBLIC-executable
+              # The ROW-EXISTS guard is what makes pg_last_wal_receive_lsn() safe
+              # here: that function's value PERSISTS after a receiver stops, so
+              # ALONE it is not proof of CURRENT streaming — but the view holds a
+              # row ONLY while a walreceiver process is live, so requiring BOTH
+              # (row present AND receive-LSN set) is a true "streaming right now"
+              # signal that resets the instant the receiver dies (row vanishes →
+              # STATE becomes 'noreceiver'). Everything else in the #5220/#5178
+              # arm gate + latch is unchanged; only this signal is made readable.
               Q="SELECT CASE
                 WHEN NOT pg_is_in_recovery() THEN 'promoted'
-                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver WHERE status = 'streaming') THEN 'streaming'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) AND pg_last_wal_receive_lsn() IS NOT NULL THEN 'streaming'
                 WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'
                 ELSE 'noreceiver'
               END"

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -998,6 +998,32 @@ for r in [d for d in docs if d.get('kind')=='Role' and 'dr-promoter' in d['metad
         assert 'delete' not in verbs, f"dr-promoter Role granted delete on {res} — must never delete PVCs/pods/CRs (data-safety, #5220)"
         assert 'create' not in verbs, f"dr-promoter Role granted create on {res} — surfacing is non-destructive (#5220)"
 PYEOF
-echo "  PASS (arm gate blocks promote before observed steady-state · divergence surfaced on HR · non-destructive, no delete verbs)"
+
+# (g) #5239 — the arm gate's "streaming" signal must be READABLE by the probe
+#     role. The signals psql authenticates as streaming_replica (client cert),
+#     which lacks pg_read_all_stats/pg_monitor, so PostgreSQL NULLs the
+#     privileged columns of pg_stat_wal_receiver for it — `status` is ALWAYS NULL
+#     (live-confirmed hw274). The former `pg_stat_wal_receiver WHERE status =
+#     'streaming'` predicate could therefore NEVER be true → /shared/armed never
+#     written → the actor REFUSED every promote → a real region-kill would not
+#     fail over (DR failover DEAD). Assert the privileged status column is GONE
+#     from the streaming detector, and that "streaming" is now decided from
+#     PUBLIC-readable signals only.
+if grep -qF "pg_stat_wal_receiver WHERE status" "$TMP/signals.sh"; then
+  echo "FAIL: #5239 signals still gate 'streaming' on the privileged pg_stat_wal_receiver.status column — NULL for the unprivileged streaming_replica probe role, so the pair never arms and DR failover is dead." >&2
+  grep -nF "pg_stat_wal_receiver WHERE status" "$TMP/signals.sh" >&2; exit 1; fi
+# "streaming" must require BOTH a live pg_stat_wal_receiver ROW (its pid/EXISTS is
+# visible to every role; the view holds a row ONLY while a walreceiver is alive)
+# AND a set pg_last_wal_receive_lsn() (PUBLIC-executable). The ROW-EXISTS guard is
+# what makes the receive-LSN a "streaming NOW" proof — the LSN value persists
+# after a receiver stops, so alone it is not current-streaming evidence.
+grep -qF "EXISTS (SELECT 1 FROM pg_stat_wal_receiver) AND pg_last_wal_receive_lsn() IS NOT NULL THEN 'streaming'" "$TMP/signals.sh" || {
+  echo "FAIL: #5239 'streaming' must be detected from PUBLIC-readable signals — a live pg_stat_wal_receiver ROW AND pg_last_wal_receive_lsn() IS NOT NULL (both readable by streaming_replica)." >&2; exit 1; }
+# The arm gate keys off STATE='streaming', so the detector rewrite must keep that
+# exact token feeding /shared/armed (regression guard for the whole #5220 chain).
+grep -qF 'if [ "${STATE}" = "streaming" ]' "$TMP/signals.sh" || {
+  echo "FAIL: #5239 arm window must still key off STATE='streaming' (the #5220 continuity tracker)." >&2; exit 1; }
+
+echo "  PASS (arm gate blocks promote before observed steady-state · divergence surfaced on HR · non-destructive, no delete verbs · #5239 streaming signal readable by streaming_replica)"
 
 echo "[render] All bp-cnpg-pair render gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.16"
+    version: "0.2.17"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## Problem (live-proven, hw274)

The #5222 dr-promoter steady-state ARM gate never armed. The signals container detects "streaming" via:

```sql
WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver WHERE status = 'streaming') THEN 'streaming'
```

but the signals `psql` authenticates as `streaming_replica` (client cert), which lacks `pg_read_all_stats`/`pg_monitor`. PostgreSQL therefore NULLs the privileged columns of `pg_stat_wal_receiver` for it — `status` is **always NULL**. Live on hw274:

- `pg_has_role('streaming_replica','pg_read_all_stats','MEMBER')` → **f**
- `SELECT status FROM pg_stat_wal_receiver` → **NULL** (the row EXISTS; only the detail columns are NULLed)

So `status = 'streaming'` is never true → the CASE returns `'receiving'` → `/shared/armed` is never written → #5222's actor **refuses every promote**. A real region-kill would not fail over — DR failover dead on every env, worse than the #5220 false-promote it replaced. Gates region-kill G12.

## Why not a privilege GRANT (Option 1)

Investigated and ruled out with hard evidence:

- **`managed.roles`**: `streaming_replica` is a CNPG **reserved** role — CNPG bars it from `spec.managed.roles` (per CNPG docs).
- **`postInitSQL` GRANT**: the CNPG source (`ConfigureNewInstance` in `pkg/management/postgres/initdb.go`) runs `postInitSQL` **before** the operator creates `streaming_replica`. A `GRANT pg_monitor TO streaming_replica` there would hit a non-existent role and — per the CNPG bootstrap doc — *"interrupt the bootstrap phase, leaving the cluster incomplete"*, wedging the whole primary bootstrap of the platform's shared-pg.

Option 2 (probe as a stats-capable role) would add a new managed role + password Secret + a cross-cluster reflection dependency — more surface, not less.

## Fix (Option 3 — hardened, self-contained)

Detect "streaming" from objects **every** role can read on a standby:

```sql
WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) AND pg_last_wal_receive_lsn() IS NOT NULL THEN 'streaming'
WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'
```

- `pg_is_in_recovery()`, `pg_last_wal_receive_lsn()` — **PUBLIC-executable** (PostgreSQL 16 recovery-info functions, no restriction).
- the `pg_stat_wal_receiver` **row** — its `pid` (hence `EXISTS`) is visible to all; only detail columns are NULLed (live-confirmed on hw274: the CASE already reached the `'receiving'` branch, so `EXISTS` was true for `streaming_replica`).

The task's caution — `pg_last_wal_receive_lsn()` **persists after a receiver stops**, so alone it is not proof of *current* streaming — is neutralised by the **row-EXISTS guard**: the view holds a row **only while a walreceiver process is live**, so requiring **both** is a true "streaming right now" signal that resets the instant the receiver dies (row vanishes → `'noreceiver'`).

Everything else in #5220/#5219/#5178 is unchanged: the arm window + continuity tracker (`STATE='streaming'` still feeds `/shared/streaming-since` → `/shared/armed`), the same-tick suspend latch, the refuse-while-unarmed guard, and the timeline-divergence surfacing. Only the streaming signal is made readable by the probe role.

## Validation

- `helm lint` clean; `helm template` renders the new predicate (streaming detector rewritten, `'receiving'` branch preserved, `STATE='streaming'` arm continuity intact).
- Render-gate suite `platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` — **all 18 cases green**, including a new Case-18 (g) that (1) fails if the privileged `pg_stat_wal_receiver WHERE status` predicate returns, and (2) asserts the row-guarded `pg_last_wal_receive_lsn() IS NOT NULL` streaming detector.
- Behavioral proof grounded in the issue's own hw274 data: on the genuinely-streaming pair the old predicate returned `'receiving'` (never armed); the new predicate returns `'streaming'` (`EXISTS(row)` true + receive-LSN non-null) → arms after `steadyStateArmSeconds`.

Chart `0.2.16 → 0.2.17` + lockstep pins (`clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml`, `platform/cnpg-pair/blueprint.yaml`, `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`).

### Security note
No privilege change is made. (Had Option 1 been taken, `pg_monitor` is a read-only monitoring role — no write/DDL rights — so it would have been safe; but this PR grants nothing.)

Refs #5239 #5222

🤖 Generated with [Claude Code](https://claude.com/claude-code)