### PR TITLE
fix(ci): cutover-contract Case 22 here-strings — unhalt the bp-self-sovereign-cutover:0.1.145 release

### DIFF
--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -873,30 +873,30 @@ fi
 #
 # (a) The auth-config env must render on the step-11 ConfigMap.
 step11_body="$(awk '/cutover-step-11-crossplane-provider-pivot/{f=1} f{print} /^---$/{if(f)exit}' "$TMP/render.yaml")"
-if ! printf '%s' "${step11_body}" | grep -q 'name: PACKAGE_PULL_AUTH_ENABLED'; then
+if ! grep -q 'name: PACKAGE_PULL_AUTH_ENABLED' <<<"${step11_body}"; then
   echo "FAIL: Step-11 missing PACKAGE_PULL_AUTH_ENABLED env (#5204)" >&2
   exit 1
 fi
-if ! printf '%s' "${step11_body}" | grep -q 'name: CROSSPLANE_NAMESPACE'; then
+if ! grep -q 'name: CROSSPLANE_NAMESPACE' <<<"${step11_body}"; then
   echo "FAIL: Step-11 missing CROSSPLANE_NAMESPACE env (#5204)" >&2
   exit 1
 fi
-if ! printf '%s' "${step11_body}" | grep -q 'name: HARBOR_PASSWORD'; then
+if ! grep -q 'name: HARBOR_PASSWORD' <<<"${step11_body}"; then
   echo "FAIL: Step-11 missing HARBOR_PASSWORD env — cannot derive local-Harbor pull credential (#5204)" >&2
   exit 1
 fi
 # (b) The script body must apply an ImageConfig (pkg.crossplane.io/v1beta1)
 # whose registry.authentication.pullSecretRef binds the local-Harbor pull
 # Secret — the Crossplane 1.18 native package-pull-auth mechanism.
-if ! printf '%s' "${step11_body}" | grep -q 'kind: ImageConfig'; then
+if ! grep -q 'kind: ImageConfig' <<<"${step11_body}"; then
   echo "FAIL: Step-11 missing ImageConfig apply — package pull would 401 against the local Harbor proxy-cache (#5204)" >&2
   exit 1
 fi
-if ! printf '%s' "${step11_body}" | grep -q 'pullSecretRef'; then
+if ! grep -q 'pullSecretRef' <<<"${step11_body}"; then
   echo "FAIL: Step-11 ImageConfig missing registry.authentication.pullSecretRef (#5204)" >&2
   exit 1
 fi
-if ! printf '%s' "${step11_body}" | grep -q 'type: kubernetes.io/dockerconfigjson'; then
+if ! grep -q 'type: kubernetes.io/dockerconfigjson' <<<"${step11_body}"; then
   echo "FAIL: Step-11 missing the dockerconfigjson pull Secret the ImageConfig references (#5204)" >&2
   exit 1
 fi


### PR DESCRIPTION
## What

Converts the 6 `printf '%s' "${step11_body}" | grep -q '…'` assertions in Case 22 of `platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` to here-strings `grep -q '…' <<<"${step11_body}"`.

## Why

The `Blueprint Release` build for `bp-self-sovereign-cutover:0.1.145` failed persistently ~25s in (runs 29669676668, 29670123527). The real error:

```
line 880: printf: write error: Broken pipe
FAIL: Step-11 missing CROSSPLANE_NAMESPACE env (#5204)
```

The 0.1.145 chart is fine — the step-11 template renders `CROSSPLANE_NAMESPACE` correctly and the case PASSES when run locally against the identical render. The failure is a **SIGPIPE false-failure under `set -euo pipefail`**: `grep -q` closes the pipe on first match → `printf` takes SIGPIPE (141) → pipefail flips a PASS into a FALSE FAIL. This is the exact anti-pattern #5033 eradicated for 7 other assertions; #5204 (merged after) reintroduced 6. Timing-dependent — passes locally, loses the race on the CI runner.

## Verification

`bash tests/cutover-contract.sh` against the 0.1.145 render: exit 0, 66 gates PASS, `All gates green.`, zero Broken-pipe lines. Diff is exactly 6 lines (here-string swap); no chart-template or values change, so 0.1.145 bytes are untouched. Merge re-fires the path-triggered release and publishes 0.1.145, matching the catalog-seed + bootstrap-kit pins.

Refs #5241 #5204 #5033 #5238

🤖 Generated with [Claude Code](https://claude.com/claude-code)