### PR TITLE
fix(pool-domain-manager): registry.<fqdn> resolves the reachable gateway VIP in both regions (Refs #5225)

### DIFF
--- a/core/pool-domain-manager/internal/allocator/allocator.go
+++ b/core/pool-domain-manager/internal/allocator/allocator.go
@@ -26,9 +26,10 @@
 //     at the OpenOva NS endpoints. For BYO the operator's registrar handles
 //     delegation and PDM only owns the child zone — no parent touch.
 //
-//   - Each child zone publishes the canonical 6-record set: apex A,
-//     wildcard A, plus console/api/gitea/harbor A — all pointing at the
-//     regional Load Balancer IP. Wildcard TLS is therefore scoped per
+//   - Each child zone publishes the canonical 8-record set: apex A,
+//     wildcard A, plus console/api/marketplace/gitea/harbor/registry A — all
+//     pointing at the regional Load Balancer IP (console/api/marketplace ride
+//     the dedicated console LB when one exists). Wildcard TLS is therefore scoped per
 //     Sovereign (`*.<sub>.<pool>`), satisfying the per-Sovereign isolation
 //     requirement in the issue body for #168.
 //
@@ -65,7 +66,7 @@ type DNSWriter interface {
 	// AddARecord upserts a single A record inside a zone.
 	AddARecord(ctx context.Context, zone, name, ipv4 string, ttl int) error
 	// PatchRRSets is the lower-level batch primitive the allocator uses for
-	// the canonical 6-record set in a single round-trip.
+	// the canonical 8-record set in a single round-trip.
 	PatchRRSets(ctx context.Context, zone string, rrsets []pdns.RRSet) error
 	// AddNSDelegation upserts the NS delegation RRset inside the parent zone.
 	AddNSDelegation(ctx context.Context, parentZone, childName string, nameservers []string, ttl int) error
@@ -316,15 +317,16 @@ type CommitInput struct {
 	ConsoleLoadBalancerIP string
 }
 
-// Commit flips a reservation to ACTIVE and writes the canonical 6-record set
-// (apex, wildcard, console, api, gitea, harbor) into the CHILD zone. All
-// records point at the supplied LB IP and use TTL 300 for fast failover.
+// Commit flips a reservation to ACTIVE and writes the canonical 8-record set
+// (apex, wildcard, console, api, marketplace, gitea, harbor, registry) into the
+// CHILD zone. All records point at the supplied LB IP and use TTL 300 for fast
+// failover.
 //
 // Order of operations:
 //  1. Verify the row + reservation token (single row-locked Postgres tx).
 //  2. Update row to state='active' (same tx).
 //  3. Commit the tx.
-//  4. PATCH the 6 RRsets into the child zone in a single PowerDNS PATCH
+//  4. PATCH the 8 RRsets into the child zone in a single PowerDNS PATCH
 //     (atomic at the PowerDNS API layer).
 //
 // If step 4 fails we LEAVE the row in state='active' and surface the error
@@ -558,7 +560,7 @@ func childZoneName(poolDomain, subdomain string) string {
 	return strings.ToLower(strings.TrimSpace(subdomain)) + "." + strings.ToLower(strings.TrimSpace(poolDomain))
 }
 
-// canonicalRecordSet returns the 7-RRset payload PowerDNS PATCH expects to
+// canonicalRecordSet returns the 8-RRset payload PowerDNS PATCH expects to
 // publish a fresh Sovereign:
 //
 //	@            A   <lb>          (apex of the child zone)
@@ -568,6 +570,7 @@ func childZoneName(poolDomain, subdomain string) string {
 //	marketplace  A   <consoleLB>   (#4053/#5034 — isolated console gateway)
 //	gitea        A   <lb>
 //	harbor       A   <lb>
+//	registry     A   <lb>          (#5225 — Harbor's primary host; shared gateway)
 //
 // #4053 — the console-gateway names point at consoleLBIP (the dedicated console
 // LB → cilium-gateway-console) so a poisoned SHARED-gateway CEC can never 404
@@ -589,7 +592,7 @@ func childZoneName(poolDomain, subdomain string) string {
 // dropped consoleLBIP entirely) console/api/marketplace ALL collapsed onto lbIP,
 // occluding the correct parent-zone records and failing the Phase-1 console
 // readiness gate so handover never fired. Every remaining name (apex, wildcard,
-// gitea, harbor) always points at lbIP (the shared gateway) regardless.
+// gitea, harbor, registry) always points at lbIP (the shared gateway) regardless.
 //
 // Per docs/PLATFORM-POWERDNS.md these names mirror the canonical-record
 // contract and use TTL 300 for fast failover.
@@ -610,6 +613,23 @@ func canonicalRecordSet(childZone, lbIP, consoleLBIP string) []pdns.RRSet {
 		{"marketplace", consoleLBIP},
 		{"gitea", lbIP},
 		{"harbor", lbIP},
+		// #5225 — registry.<fqdn> is Harbor's PRIMARY host (externalURL, OIDC
+		// redirect_uri, the /v2 OCI registry API all live here; harbor.<fqdn> is
+		// only a redirect alias). Its HTTPRoute parents the SHARED cilium-gateway
+		// exactly like harbor's, so it rides lbIP too. Without an EXPLICIT child-
+		// zone record it was covered only by the `*` wildcard, and on a 2-region
+		// Huawei Sovereign external-dns (gateway-httproute source, policy=sync)
+		// SHADOWED that wildcard with a specific registry.<fqdn> A pointing at the
+		// shared gateway's hostNetwork status address — a region-a control-plane
+		// node INTERNAL VPC IP (e.g. 10.150.1.228), unroutable cross-VPC → region-b
+		// image pulls ImagePullBackOff (that node-IP record also propagated into
+		// the region-b node's /etc/hosts r4() boot pin). An explicit record here —
+		// the reachable gateway ELB EIP, identical to the wildcard + harbor — is a
+		// record external-dns will NOT overwrite (the TXT-registry own-only rule
+		// that already keeps harbor/console/gitea reachable), so registry.<fqdn>
+		// resolves the reachable VIP in BOTH regions. Mirrors the #5034 fix that
+		// added the then-missing marketplace record to this same set.
+		{"registry", lbIP},
 	}
 	rrsets := make([]pdns.RRSet, 0, len(prefixes))
 	for _, p := range prefixes {

--- a/core/pool-domain-manager/internal/allocator/allocator_test.go
+++ b/core/pool-domain-manager/internal/allocator/allocator_test.go
@@ -176,8 +176,8 @@ func TestCanonicalRecordSet(t *testing.T) {
 	// #4053 — empty consoleLBIP = legacy single-LB behaviour: EVERY record
 	// (incl. console/api) points at lbIP, byte-identical to pre-#4053.
 	rrsets := canonicalRecordSet("acme.openova.io", "1.2.3.4", "")
-	if len(rrsets) != 7 {
-		t.Fatalf("expected 7 RRsets, got %d", len(rrsets))
+	if len(rrsets) != 8 {
+		t.Fatalf("expected 8 RRsets, got %d", len(rrsets))
 	}
 	wantNames := map[string]bool{
 		"acme.openova.io":             false,
@@ -187,6 +187,7 @@ func TestCanonicalRecordSet(t *testing.T) {
 		"gitea.acme.openova.io":       false,
 		"harbor.acme.openova.io":      false,
 		"marketplace.acme.openova.io": false,
+		"registry.acme.openova.io":    false, // #5225
 	}
 	for _, r := range rrsets {
 		if r.Type != "A" {
@@ -228,8 +229,8 @@ func TestCanonicalRecordSetConsoleSplit(t *testing.T) {
 	const sharedIP = "1.2.3.4"
 	const consoleIP = "9.9.9.9"
 	rrsets := canonicalRecordSet("acme.openova.io", sharedIP, consoleIP)
-	if len(rrsets) != 7 {
-		t.Fatalf("expected 7 RRsets, got %d", len(rrsets))
+	if len(rrsets) != 8 {
+		t.Fatalf("expected 8 RRsets, got %d", len(rrsets))
 	}
 	wantIP := map[string]string{
 		"acme.openova.io":             sharedIP,
@@ -239,6 +240,9 @@ func TestCanonicalRecordSetConsoleSplit(t *testing.T) {
 		"marketplace.acme.openova.io": consoleIP,
 		"gitea.acme.openova.io":       sharedIP,
 		"harbor.acme.openova.io":      sharedIP,
+		// #5225 — registry rides the shared LB (Harbor's primary host), NOT the
+		// console LB, so it MUST stay on sharedIP even when a console LB exists.
+		"registry.acme.openova.io": sharedIP,
 	}
 	for _, r := range rrsets {
 		want, ok := wantIP[r.Name]
@@ -390,8 +394,8 @@ func TestCommitDNSShape(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := dns.rrsets["omantel.omani.works"]
-	if len(got) != 7 {
-		t.Fatalf("expected 7 RRsets recorded, got %d", len(got))
+	if len(got) != 8 {
+		t.Fatalf("expected 8 RRsets recorded, got %d", len(got))
 	}
 }
 

--- a/core/pool-domain-manager/internal/handler/handler.go
+++ b/core/pool-domain-manager/internal/handler/handler.go
@@ -272,7 +272,7 @@ func (h *Handler) Commit(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Allocator returns a wrapped "powerdns write" error AFTER the row
 		// was flipped to active. Surface 202 in that case so the caller
-		// knows the row is committed but the canonical 6-record set in the
+		// knows the row is committed but the canonical 8-record set in the
 		// child zone is pending — calling Commit again with the same body
 		// is idempotent (PowerDNS PATCH replaces existing RRsets in place).
 		if alloc != nil && strings.Contains(err.Error(), "powerdns write") {


### PR DESCRIPTION
## Problem (Refs #5225 — observed on hw273, 2-region Huawei Sovereign)

`registry.<sovereign-fqdn>` resolved to `10.150.1.228` — a region-a control-plane node's **INTERNAL VPC IP**, unroutable cross-VPC from region-b. Region-b `org-services` marketplace pods hit ImagePullBackOff even with Harbor healthy, because the node-IP record also propagated into the region-b node's `/etc/hosts` r4() boot pin. The registry FQDN must resolve to a **reachable VIP/gateway** from every region (§854).

## Root cause — an omission in the authoritative child-zone record set

For a **pool-allocated** Sovereign FQDN (e.g. `hw273.omani.works` from the `omani.works` pool) the delegated **child zone is the authoritative answer** (it occludes the parent-zone records below the zone cut). `pool-domain-manager`'s `canonicalRecordSet` — the writer of that child zone — published:

```
@  *  console  api  marketplace  gitea  harbor
```

…but **omitted `registry`**. `registry.<fqdn>` is Harbor's **primary** host (its `externalURL`, OIDC `redirect_uri`, and the `/v2` OCI registry API all live there; `harbor.<fqdn>` is only a redirect alias). With no explicit child-zone record, `registry` was covered solely by the `*` wildcard.

On the Huawei hostNetwork gateway model (§854 / #4706) the shared `cilium-gateway` has no LoadBalancer VIP — its `.status.addresses` are node **internal** VPC IPs. `external-dns` (gateway-httproute source, `policy: sync`, no target override) therefore **shadowed the wildcard** with a specific `registry.<fqdn>` A record pointing at that node internal IP. Its sibling `harbor.<fqdn>` stayed reachable precisely because it **has an explicit record** `external-dns` will not overwrite (the TXT-registry own-only rule that also protects console/api/gitea).

catalyst-api's `CanonicalSovereignSubdomains` already includes `registry`, but PDM's child-zone set did not — and the function's own doc says *"the two DNS writers MUST agree."* This is the exact class as #5034 (marketplace was omitted from this same set and had to be added).

## Fix

Add `registry -> lbIP` to `canonicalRecordSet` (`core/pool-domain-manager/internal/allocator/allocator.go`). `lbIP` is the reachable shared-gateway ELB EIP — identical to what the wildcard and `harbor` already use — so:

- `external-dns` sees an existing explicit record and leaves it alone (same mechanism keeping harbor/console/gitea reachable),
- `registry.<fqdn>` resolves the **reachable gateway VIP in BOTH regions**, never a node internal IP,
- the region-b node's r4() boot pin then caches the reachable EIP → region-b pulls succeed.

`registry` rides the **shared** gateway (like `harbor`), so it stays on `lbIP`, not the console LB — verified by an explicit assertion in `TestCanonicalRecordSetConsoleSplit`.

**No NodePort** (§854) — the reachable target is the gateway ELB EIP the wildcard already publishes. No Helm chart touched (Go control-plane change), so no lockstep pins.

## Tests

- `go build ./...`, `go vet ./...` — clean.
- `go test ./...` (all 13 packages) — pass. Updated the three `canonicalRecordSet` assertions (7→8 records) + added `registry.acme.openova.io` name/IP expectations.
- Doc comments in `allocator.go` / `handler.go` updated to the 8-record set.

## Scope notes

- The prose docs (GLOSSARY/ARCHITECTURE/RUNBOOKS) still say "6-record set" — they were already stale before this change (code had 7 after #5034); reconciling that prose is left as separate housekeeping to keep this PR focused.
- The `dynadot.go` registrar path is a different code path (Dynadot-hosted zones, not external-dns-managed); its own wildcard already covers registry there, so it needs no change.

Refs #5225
Refs #5034
Refs #5007

🤖 Generated with [Claude Code](https://claude.com/claude-code)