### PR TITLE
fix: gateway + console ELB backend pools span ALL regions — region-kill EIP failover (Refs #5244)

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -1510,7 +1510,15 @@ resource "huaweicloud_elb_loadbalancer" "primary" {
   ipv4_subnet_id    = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
   ipv4_eip_id       = huaweicloud_vpc_eip.elb_primary.id
   availability_zone = [var.huawei_az]
-  description       = "Catalyst Sovereign ${var.sovereign_fqdn} — #4690 gateway ELB, public 443/80 → gateway LoadBalancer Service nodePort (type=LoadBalancer, #4682)"
+  description       = "Catalyst Sovereign ${var.sovereign_fqdn} — #4690 gateway ELB, public 443/80 → node:443/:80 (cilium-envoy hostNetwork host ports, §854 — no nodePort)"
+
+  # #5244 — IP-as-backend so PEER-REGION nodes can be pool members. The ELB
+  # lives in the primary region's VPC; region-b nodes sit in region-b's VPC,
+  # reachable only over the mesh VPC peering. Huawei ELB only accepts members
+  # outside its own VPC as IP-type members with cross-VPC backend enabled.
+  # Multi-region only: single-region provs keep the pre-#5244 shape (all
+  # members are same-VPC, the flag stays provider-default).
+  cross_vpc_backend = length(local.region_keys) > 1 ? true : null
 
   # Immutable-field churn guards (same as the console ELB): the huaweicloud
   # provider sends null/empty for l4_flavor_id/l7_flavor_id/vpc_id/ipv4_eip_id
@@ -1563,22 +1571,40 @@ resource "huaweicloud_elb_listener" "http" {
   description     = "TCP passthrough — ACME HTTP-01 + .well-known + HTTP→HTTPS redirect at the gateway"
 }
 
-# Primary-region node private IPs — consumed by BOTH the gateway ELB
-# (elb_primary) members here and the CONSOLE ELB (elb_console) members below.
-# cilium-envoy (hostNetwork DaemonSet, gateway-api hostNetwork mode #4706)
-# binds node:443/:80 on every node, so every node is a valid member.
+# MESH-WIDE node private IPs — consumed by BOTH the gateway ELB (elb_primary)
+# members here and the CONSOLE ELB (elb_console) members below. cilium-envoy
+# (hostNetwork DaemonSet, gateway-api hostNetwork mode #4706) binds
+# node:443/:80 on EVERY node in EVERY region, so every node is a valid member.
+#
+# #5244 region-kill failover: members were previously PRIMARY-REGION-ONLY, so
+# on a region-a kill the ELB health monitors drained every member and the
+# public EIP black-holed — externally unreachable for the whole outage — even
+# though region-b's cilium-envoy was Running and serving node:443 (proven live
+# on hw275 G12, dep 7886def2: all pool members 10.208.1.x/region-a, zero
+# 10.218.1.x/region-b, ip_target_enable=false). The fix spans the member set
+# across ALL regions' nodes: peer-region nodes are CROSS-VPC (IP-as-backend)
+# members reaching the peer VPC over the existing mesh peering + routes
+# (huaweicloud_vpc_peering_connection.mesh, ~L224 — the same path the pod
+# datapath and the ELB health probes ride). The per-pool TCP health monitors
+# (below, unchanged) drain the dead region's members within
+# interval×max_retries (~30s) and the survivors carry the EIP. Ports stay the
+# durable gateway host ports (443/80 gateway, 8443/8080 console) — hostNetwork
+# cilium-envoy host ports, never a nodePort (§854).
 locals {
   # CPs are `count`-based — index by tofu's list-indexed array.
   # Workers are `for_each`-based on local.worker_map (key=<region>-<index>).
-  primary_lb_node_ips = concat(
-    [for idx, n in local.cp_nodes :
-      huaweicloud_compute_instance.control_plane[idx].access_ip_v4
-      if n.region == local.region_keys[0]
-    ],
-    [for w in local.worker_nodes :
-      huaweicloud_compute_instance.worker["${w.region}-${w.index}"].access_ip_v4
-      if w.region == local.region_keys[0]
-    ],
+  # `primary` marks nodes in the ELB's own VPC (region_keys[0]) — they carry
+  # the primary subnet_id; peer-region nodes are IP-type members (no subnet,
+  # requires cross_vpc_backend on the LB).
+  gateway_lb_members = concat(
+    [for idx, n in local.cp_nodes : {
+      ip      = huaweicloud_compute_instance.control_plane[idx].access_ip_v4
+      primary = n.region == local.region_keys[0]
+    }],
+    [for w in local.worker_nodes : {
+      ip      = huaweicloud_compute_instance.worker["${w.region}-${w.index}"].access_ip_v4
+      primary = w.region == local.region_keys[0]
+    }],
   )
 
   # #4053 console-isolation gate (Refs #4431 #4212). When "true" (default) the
@@ -1587,30 +1613,33 @@ locals {
   # node, so their count is the node count multiplied by the gate (0 → no
   # members when isolation is off).
   console_isolation_on = var.console_isolation_enabled == "true"
-  console_member_count = local.console_isolation_on ? length(local.primary_lb_node_ips) : 0
+  console_member_count = local.console_isolation_on ? length(local.gateway_lb_members) : 0
 }
 
-# Gateway ELB members: primary-region nodes (CPs + workers). With cilium
+# Gateway ELB members: ALL regions' nodes (CPs + workers). With cilium
 # 1.19.3's gateway-api hostNetwork mode (#4706), cilium-envoy (a hostNetwork
 # DaemonSet) binds node:443/:80 on EVERY node, so every node is a valid member
 # at the DURABLE host ports — correct from Phase-0 apply, no placeholder, no
 # post-convergence nodePort discovery, no nodePort anywhere (§854).
+# #5244: peer-region nodes are cross-VPC IP-type members (subnet_id omitted —
+# the ELB reaches them over the mesh VPC peering), so a region-a kill leaves
+# the health-checked region-b members serving the EIP.
 # catalyst-api (post_handover_gateway_elb.go) only heals member-SET drift
 # (node churn from the autoscaler) at these same ports.
 resource "huaweicloud_elb_member" "https" {
-  count         = length(local.primary_lb_node_ips)
+  count         = length(local.gateway_lb_members)
   pool_id       = huaweicloud_elb_pool.https.id
-  address       = local.primary_lb_node_ips[count.index]
+  address       = local.gateway_lb_members[count.index].ip
   protocol_port = var.gateway_member_port_https
-  subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
+  subnet_id     = local.gateway_lb_members[count.index].primary ? huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id : null
 }
 
 resource "huaweicloud_elb_member" "http" {
-  count         = length(local.primary_lb_node_ips)
+  count         = length(local.gateway_lb_members)
   pool_id       = huaweicloud_elb_pool.http.id
-  address       = local.primary_lb_node_ips[count.index]
+  address       = local.gateway_lb_members[count.index].ip
   protocol_port = var.gateway_member_port_http
-  subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
+  subnet_id     = local.gateway_lb_members[count.index].primary ? huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id : null
 }
 
 resource "huaweicloud_elb_monitor" "https" {
@@ -1681,7 +1710,11 @@ resource "huaweicloud_elb_loadbalancer" "console" {
   ipv4_subnet_id    = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
   ipv4_eip_id       = huaweicloud_vpc_eip.elb_console[0].id
   availability_zone = [var.huawei_az]
-  description       = "Catalyst Sovereign ${var.sovereign_fqdn} — #4053 dedicated CONSOLE gateway 443→443 + 80→80 passthrough (#4682)"
+  description       = "Catalyst Sovereign ${var.sovereign_fqdn} — #4053 dedicated CONSOLE gateway 443→8443 + 80→8080 passthrough (#4682/#4715)"
+
+  # #5244 — same cross-VPC backend rationale as elb_primary above: the console
+  # EIP must keep serving from peer-region nodes when the primary region dies.
+  cross_vpc_backend = length(local.region_keys) > 1 ? true : null
 
   # Immutable-field churn guards: the huaweicloud provider sends null/empty for
   # l4_flavor_id/l7_flavor_id/vpc_id/ipv4_eip_id on subsequent plans (HCS auto-
@@ -1737,23 +1770,25 @@ resource "huaweicloud_elb_listener" "console_http" {
   description     = "TCP passthrough — console HTTP→HTTPS redirect"
 }
 
-# Console ELB members: the SAME primary-region nodes as the primary ELB.
-# The console gateway owns its own Service type=LoadBalancer on :443/:80
-# (hostNetwork off, no NodePort; #4682), reachable on every node.
+# Console ELB members: the SAME mesh-wide node set as the primary ELB
+# (#5244 — the console EIP black-holed on region-kill for the same
+# region-a-only-membership root cause). The console gateway binds
+# node:8443/:8080 (host ports, NOT nodePorts — #4715) on every node in every
+# region; peer-region nodes are cross-VPC IP-type members like the gateway's.
 resource "huaweicloud_elb_member" "console_https" {
   count         = local.console_member_count
   pool_id       = huaweicloud_elb_pool.console_https[0].id
-  address       = local.primary_lb_node_ips[count.index]
+  address       = local.gateway_lb_members[count.index].ip
   protocol_port = 8443
-  subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
+  subnet_id     = local.gateway_lb_members[count.index].primary ? huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id : null
 }
 
 resource "huaweicloud_elb_member" "console_http" {
   count         = local.console_member_count
   pool_id       = huaweicloud_elb_pool.console_http[0].id
-  address       = local.primary_lb_node_ips[count.index]
+  address       = local.gateway_lb_members[count.index].ip
   protocol_port = 8080
-  subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
+  subnet_id     = local.gateway_lb_members[count.index].primary ? huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id : null
 }
 
 resource "huaweicloud_elb_monitor" "console_https" {

--- a/infra/providers/huawei/tests/multi_region.tftest.hcl
+++ b/infra/providers/huawei/tests/multi_region.tftest.hcl
@@ -158,6 +158,36 @@ run "tier_b_two_regions_poc" {
     condition     = huaweicloud_obs_bucket.main.bucket == "catalyst-t99-omani-works-deadbeef"
     error_message = "OBS bucket name must match the operator-supplied obs_bucket_name."
   }
+
+  # #5244 — gateway ELB members span ALL regions' nodes (2 CP + 4 workers =
+  # 6), not just the primary's. Primary-region-only membership black-holed
+  # the gateway EIP for the whole region-a outage on hw275 G12: the health
+  # monitors drained every member and nothing was left to serve.
+  assert {
+    condition     = length(huaweicloud_elb_member.https) == 6 && length(huaweicloud_elb_member.http) == 6
+    error_message = "Gateway ELB pools must contain EVERY region's nodes (6 for 2×(1 CP + 2 workers)) so a region kill leaves the peer region serving the EIP (#5244)."
+  }
+  assert {
+    condition     = length([for m in local.gateway_lb_members : m if !m.primary]) == 3
+    error_message = "3 of the 6 gateway ELB members must be peer-region (region-b) nodes (#5244)."
+  }
+  # Peer-region members are cross-VPC IP-type members: subnet_id omitted.
+  assert {
+    condition     = length([for i, m in local.gateway_lb_members : i if !m.primary && huaweicloud_elb_member.https[i].subnet_id != null]) == 0
+    error_message = "Peer-region gateway members must OMIT subnet_id (cross-VPC IP-type member — the peer node's IP is outside the ELB's VPC, #5244)."
+  }
+  # Cross-VPC (IP-as-backend) must be on for a multi-region prov, or the
+  # peer-region member creates are rejected by the ELB API.
+  assert {
+    condition     = huaweicloud_elb_loadbalancer.primary.cross_vpc_backend == true
+    error_message = "Multi-region provs must enable cross_vpc_backend on the gateway ELB (#5244)."
+  }
+  # §854 — the member ports stay the durable cilium-envoy hostNetwork host
+  # ports; the k8s NodePort range must never appear.
+  assert {
+    condition     = length([for m in huaweicloud_elb_member.https : m if m.protocol_port >= 30000]) == 0 && length([for m in huaweicloud_elb_member.http : m if m.protocol_port >= 30000]) == 0
+    error_message = "Gateway ELB member ports must stay below the k8s NodePort range — nodePorts are forbidden (§854)."
+  }
 }
 
 # Scenario 2 — single-region shape (1 CP region, no secondary). Verifies
@@ -194,6 +224,12 @@ run "single_region" {
   assert {
     condition     = length(huaweicloud_compute_instance.worker) == 2
     error_message = "Single-region must create 2 worker ECS."
+  }
+  # #5244 — single-region keeps the pre-#5244 member shape: all members are
+  # same-VPC (subnet_id set), and cross_vpc_backend stays provider-default.
+  assert {
+    condition     = length(huaweicloud_elb_member.https) == 3 && length([for m in local.gateway_lb_members : m if !m.primary]) == 0
+    error_message = "Single-region gateway ELB members must be exactly the region's own 3 nodes, all primary (no cross-VPC members, #5244)."
   }
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_gateway_elb.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_gateway_elb.go
@@ -13,6 +13,17 @@
 // replaced/removed nodes leaving stale members — the job hcloud-ccm does
 // continuously on Hetzner, done explicitly here because Huawei has no CCM.
 //
+// #5244 — the member set spans EVERY region's nodes, not just the primary's.
+// Both the tofu seed and this hook were primary-region-only, so a region-a
+// kill drained every (health-checked) member and the gateway + console EIPs
+// black-holed for the whole outage even though region-b's cilium-envoy was
+// serving node:443 (hw275 G12). This hook now enumerates ALL regions'
+// clusters (primary kubeconfig + every secondary kubeconfig) and converges
+// the ELB member set to the UNION; peer-region nodes become cross-VPC
+// IP-type members (see providers/huawei/gateway_elb.go). When a secondary
+// cluster cannot be enumerated (possibly mid-outage) the reconcile is
+// ADDS-ONLY — it never sweeps members belonging to a region it cannot see.
+//
 // History: on cilium 1.16.5 (hostNetwork bind bug) this hook discovered the
 // gateway Service's auto-allocated nodePort and repointed member PORTS
 // (#4690/#4691). That shape is retired by the 1.19.3 bump.
@@ -26,6 +37,7 @@ package handler
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -89,20 +101,9 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 		h.log.Warn("gateway-elb: no kubeconfig for deployment; skipping ELB reconcile", "id", dep.ID)
 		return
 	}
-	kcRaw, err := os.ReadFile(kcPath)
+	cs, err := h.clientsetFromKubeconfigPath(kcPath)
 	if err != nil {
-		h.log.Warn("gateway-elb: read kubeconfig failed; skipping", "id", dep.ID, "path", kcPath, "err", err)
-		return
-	}
-	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kcRaw)
-	if err != nil {
-		h.log.Warn("gateway-elb: parse kubeconfig failed", "id", dep.ID, "err", err)
-		return
-	}
-	restCfg.Timeout = 20 * time.Second
-	cs, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		h.log.Warn("gateway-elb: build clientset failed", "id", dep.ID, "err", err)
+		h.log.Warn("gateway-elb: primary clientset build failed; skipping", "id", dep.ID, "path", kcPath, "err", err)
 		return
 	}
 
@@ -117,15 +118,27 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 
 	// Poll for the primary cluster's node InternalIPs (the primary kubeconfig
 	// scopes this to primary-region nodes — each region is its own cluster),
-	// then converge the ELB member set to them at the gateway host ports.
+	// then converge the ELB member set to the MESH-WIDE node union (#5244):
+	// primary nodes + every secondary region's nodes, at the gateway host
+	// ports.
 	deadline := time.Now().Add(gatewayELBReconcileMaxWait)
 	for {
 		nodeIPs, perr := h.discoverNodeInternalIPs(cs)
 		if perr == nil && len(nodeIPs) > 0 {
+			// #5244 — enumerate every SECONDARY region's cluster too. When any
+			// of them cannot be listed (kubeconfig missing / cluster
+			// unreachable — possibly mid region outage), the reconcile is
+			// ADDS-ONLY (sweepStale=false): stale members are kept rather
+			// than risk draining the region currently carrying the EIP.
+			peerIPs, allPeersEnumerated := h.discoverSecondaryNodeInternalIPs(dep)
+			sweepStale := allPeersEnumerated
+			if !sweepStale {
+				h.log.Warn("gateway-elb: secondary region enumeration incomplete — reconciling adds-only (no stale-member sweep)", "id", dep.ID)
+			}
 			changed, rerr := hp.ReconcileGatewayELBMembers(
 				context.Background(),
 				dep.Request.HuaweiAccessKey, dep.Request.HuaweiSecretKey, dep.Request.HuaweiProjectID,
-				region, fqdn, nodeIPs, gatewayHostPortHTTPS, gatewayHostPortHTTP,
+				region, fqdn, nodeIPs, peerIPs, gatewayHostPortHTTPS, gatewayHostPortHTTP, sweepStale,
 				func(msg string) { h.log.Info("gateway-elb: " + msg) },
 			)
 			if rerr != nil {
@@ -139,25 +152,27 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 				return
 			}
 			h.log.Info("gateway-elb: reconcile complete",
-				"id", dep.ID, "nodes", len(nodeIPs), "membersChanged", changed)
+				"id", dep.ID, "primaryNodes", len(nodeIPs), "peerNodes", len(peerIPs), "membersChanged", changed)
 			dep.recordEvent(provisioner.Event{
 				Time:    time.Now().UTC().Format(time.RFC3339),
 				Phase:   "post-handover",
 				Level:   "info",
-				Message: "Gateway ELB member set converged to " + strconv.Itoa(len(nodeIPs)) + " live nodes at node:" + strconv.Itoa(gatewayHostPortHTTPS) + "/:" + strconv.Itoa(gatewayHostPortHTTP) + " (" + strconv.Itoa(changed) + " changed); public :443/:80 front door is wired.",
+				Message: "Gateway ELB member set converged to " + strconv.Itoa(len(nodeIPs)) + " primary + " + strconv.Itoa(len(peerIPs)) + " peer-region live nodes at node:" + strconv.Itoa(gatewayHostPortHTTPS) + "/:" + strconv.Itoa(gatewayHostPortHTTP) + " (" + strconv.Itoa(changed) + " changed); public :443/:80 front door is wired for cross-region failover.",
 			})
 
 			// Also converge the dedicated CONSOLE ELB (console_isolation provs)
-			// to the same live nodes at the console gateway host ports (8443/8080).
-			// Best-effort + soft-skip: a console_isolation=false prov has no
-			// console ELB → clean no-op. Without this the console ELB kept its
-			// tofu-seeded boot members forever and lost its backends after an
-			// autoscaler node roll → Console 000 (#4706). Its failure must NOT
-			// mask the primary success above, so it is logged, not returned.
+			// to the same mesh-wide nodes at the console gateway host ports
+			// (8443/8080). Best-effort + soft-skip: a console_isolation=false
+			// prov has no console ELB → clean no-op. Without this the console
+			// ELB kept its tofu-seeded boot members forever and lost its
+			// backends after an autoscaler node roll → Console 000 (#4706) —
+			// and stayed region-a-only on region-kill → console EIP black-hole
+			// (#5244). Its failure must NOT mask the primary success above, so
+			// it is logged, not returned.
 			if cChanged, cErr := hp.ReconcileConsoleELBMembers(
 				context.Background(),
 				dep.Request.HuaweiAccessKey, dep.Request.HuaweiSecretKey, dep.Request.HuaweiProjectID,
-				region, fqdn, nodeIPs, consoleHostPortHTTPS, consoleHostPortHTTP,
+				region, fqdn, nodeIPs, peerIPs, consoleHostPortHTTPS, consoleHostPortHTTP, sweepStale,
 				func(msg string) { h.log.Info("console-elb: " + msg) },
 			); cErr != nil {
 				h.log.Warn("console-elb: member reconcile failed (non-fatal; primary front door is up)", "id", dep.ID, "err", cErr)
@@ -181,6 +196,21 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 	}
 }
 
+// clientsetFromKubeconfigPath reads + parses a kubeconfig file into a
+// short-timeout clientset (20s — node list only).
+func (h *Handler) clientsetFromKubeconfigPath(path string) (kubernetes.Interface, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(raw)
+	if err != nil {
+		return nil, err
+	}
+	restCfg.Timeout = 20 * time.Second
+	return kubernetes.NewForConfig(restCfg)
+}
+
 // discoverNodeInternalIPs lists the cluster's nodes and returns their
 // InternalIP addresses — the gateway ELB pool member addresses. Every node
 // runs cilium-envoy (hostNetwork DaemonSet) with the gateway listeners bound
@@ -201,4 +231,63 @@ func (h *Handler) discoverNodeInternalIPs(cs kubernetes.Interface) ([]string, er
 		}
 	}
 	return ips, nil
+}
+
+// discoverSecondaryNodeInternalIPs (#5244) lists every SECONDARY region
+// cluster's node InternalIPs — the peer-region gateway ELB members. Each
+// region is its own cluster; the secondary kubeconfigs are the union of the
+// in-memory dep.secondaryKubeconfigPaths map and the on-disk
+// `<depID>-<regionKey>.yaml` files (onDiskSecondaryKubeconfigKeys — the
+// authoritative set, immune to in-memory loss across catalyst-api restarts,
+// #4000).
+//
+// Returns (peerIPs, complete). complete=false when the deployment spec
+// expects more secondary regions than were successfully enumerated (missing
+// kubeconfig, or a cluster that cannot be listed — possibly mid region
+// outage). Callers must then reconcile ADDS-ONLY: never sweep members of a
+// region that cannot currently be seen.
+func (h *Handler) discoverSecondaryNodeInternalIPs(dep *Deployment) ([]string, bool) {
+	dep.mu.Lock()
+	expectedSecondaries := 0
+	if len(dep.Request.Regions) > 1 {
+		expectedSecondaries = len(dep.Request.Regions) - 1
+	}
+	paths := make(map[string]string, len(dep.secondaryKubeconfigPaths))
+	for k, v := range dep.secondaryKubeconfigPaths {
+		paths[k] = v
+	}
+	depID := dep.ID
+	dep.mu.Unlock()
+
+	// Union with the files actually on disk (keyed by whatever regionKey the
+	// secondary CP's cloud-init deposited).
+	dir := secondaryKubeconfigsDir()
+	for _, key := range onDiskSecondaryKubeconfigKeys(dir, depID) {
+		if _, ok := paths[key]; !ok {
+			paths[key] = filepath.Join(dir, depID+"-"+key+".yaml")
+		}
+	}
+
+	if expectedSecondaries == 0 {
+		// Single-region deployment: vacuously complete, no peers.
+		return nil, true
+	}
+
+	var peerIPs []string
+	enumerated := 0
+	for key, path := range paths {
+		cs, err := h.clientsetFromKubeconfigPath(path)
+		if err != nil {
+			h.log.Warn("gateway-elb: secondary clientset build failed", "id", depID, "region", key, "path", path, "err", err)
+			continue
+		}
+		ips, err := h.discoverNodeInternalIPs(cs)
+		if err != nil || len(ips) == 0 {
+			h.log.Warn("gateway-elb: secondary node list failed or empty", "id", depID, "region", key, "err", err)
+			continue
+		}
+		peerIPs = append(peerIPs, ips...)
+		enumerated++
+	}
+	return peerIPs, enumerated >= expectedSecondaries
 }

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb.go
@@ -17,6 +17,18 @@
 // hcloud-ccm does continuously on Hetzner, done explicitly here because
 // Huawei has no CCM.
 //
+// #5244 — the member set spans ALL regions, not just the primary. Members
+// were primary-region-only (both the tofu seed and this reconciler), so on a
+// region-a kill the ELB health monitors drained every member and the public
+// EIP black-holed for the whole outage even though region-b's cilium-envoy
+// was Running and bound on node:443 (proven live on hw275 G12, dep 7886def2:
+// every pool member 10.208.1.x/region-a, zero 10.218.1.x/region-b,
+// ip_target_enable=false). Peer-region nodes live in a DIFFERENT VPC than
+// the ELB, so they are added as cross-VPC IP-type members (no
+// subnet_cidr_id; requires the LB's ip_target_enable, which this reconciler
+// flips on when needed) reachable over the existing mesh VPC peering. The
+// ports stay the identical hostNetwork host ports — never a nodePort (§854).
+//
 // History: on cilium 1.16.5 (hostNetwork bind bug) the gateway was an
 // ELB→node:<auto-allocated nodePort> forward and this file repointed member
 // PORTS post-convergence (#4690/#4691). That shape — and its failure mode
@@ -64,50 +76,86 @@ const (
 )
 
 // ReconcileGatewayELBMembers converges the gateway ELB's HTTPS/HTTP pool
-// member sets to nodeIPs at the fixed gateway host ports, and points each
-// pool's health monitor at the same port.
+// member sets to the union of primaryIPs + peerIPs at the fixed gateway host
+// ports, and points each pool's health monitor at the same port.
 //
 // It is an exported method on *Provider (mirrors SweepOrphanEIPs) so the
-// handler reaches it via h.huaweiProvider("gateway-elb"). nodeIPs are the
-// live cluster's node InternalIPs (primary region — each region is its own
-// cluster); httpsPort/httpPort are the durable gateway host ports (443/80),
-// bound on every node by cilium-envoy's gateway-api hostNetwork mode.
+// handler reaches it via h.huaweiProvider("gateway-elb").
+//
+//   - primaryIPs are the PRIMARY region cluster's node InternalIPs — nodes in
+//     the ELB's own VPC, added as classic subnet members.
+//   - peerIPs are every OTHER region cluster's node InternalIPs (#5244) —
+//     nodes in peer VPCs, added as cross-VPC IP-type members (no
+//     subnet_cidr_id; the reconciler enables the LB's ip_target_enable when
+//     peer members are needed and it is off).
+//   - sweepStale gates DELETION of members outside the union. Pass false when
+//     region enumeration was INCOMPLETE (e.g. a peer cluster unreachable —
+//     possibly mid region outage): the reconcile then only ADDS missing
+//     members, so a temporarily unlistable region's members — the exact
+//     members carrying the EIP through the outage — are never drained by a
+//     blind sweep.
+//   - httpsPort/httpPort are the durable gateway host ports (443/80), bound on
+//     every node in every region by cilium-envoy's gateway-api hostNetwork
+//     mode.
 //
 // Returns the number of members changed (adds + removals; 0 == already
 // converged) and an error only on a hard API failure. Per-member failures are
 // logged via progress and do NOT abort the whole reconcile (best-effort, like
 // the day-2 post-handover hooks).
-func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN string, nodeIPs []string, httpsPort, httpPort int, progress func(msg string)) (int, error) {
+func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN string, primaryIPs, peerIPs []string, httpsPort, httpPort int, sweepStale bool, progress func(msg string)) (int, error) {
 	return p.reconcileELBMembers(ctx, ak, sk, projectID, region, sovereignFQDN,
 		gatewayELBNameSuffix, gatewayPoolHTTPSSuffix, gatewayPoolHTTPSuffix,
-		nodeIPs, httpsPort, httpPort, false /*softSkipMissing*/, progress)
+		primaryIPs, peerIPs, httpsPort, httpPort, sweepStale, false /*softSkipMissing*/, progress)
 }
 
 // ReconcileConsoleELBMembers converges the dedicated CONSOLE ELB's member set
-// to nodeIPs at the console gateway host ports (8443/8080 on huawei). Identical
-// convergence to the primary gateway, targeting the "-elb-console" ELB. It is
-// softSkipMissing: a console_isolation_enabled=false prov has no console ELB, so
-// "ELB not found" is a clean no-op (0, nil), not an error. Without this, primary
-// self-heals node churn (post_handover) but the console ELB kept its tofu-seeded
-// boot member set forever → after an autoscaler node roll the console front door
-// lost its live backends → Console 000. Companion to ReconcileGatewayELBMembers.
-func (p *Provider) ReconcileConsoleELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN string, nodeIPs []string, httpsPort, httpPort int, progress func(msg string)) (int, error) {
+// to the same mesh-wide node union at the console gateway host ports
+// (8443/8080 on huawei — #5244: the console EIP black-holed on region-kill for
+// the same primary-region-only-membership root cause as the gateway ELB).
+// Identical convergence to the primary gateway, targeting the "-elb-console"
+// ELB. It is softSkipMissing: a console_isolation_enabled=false prov has no
+// console ELB, so "ELB not found" is a clean no-op (0, nil), not an error.
+// Without this, primary self-heals node churn (post_handover) but the console
+// ELB kept its tofu-seeded boot member set forever → after an autoscaler node
+// roll the console front door lost its live backends → Console 000. Companion
+// to ReconcileGatewayELBMembers.
+func (p *Provider) ReconcileConsoleELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN string, primaryIPs, peerIPs []string, httpsPort, httpPort int, sweepStale bool, progress func(msg string)) (int, error) {
 	return p.reconcileELBMembers(ctx, ak, sk, projectID, region, sovereignFQDN,
 		consoleELBNameSuffix, consolePoolHTTPSSuffix, consolePoolHTTPSuffix,
-		nodeIPs, httpsPort, httpPort, true /*softSkipMissing*/, progress)
+		primaryIPs, peerIPs, httpsPort, httpPort, sweepStale, true /*softSkipMissing*/, progress)
 }
 
-func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN, elbSuffix, poolHTTPSSuffix, poolHTTPSuffix string, nodeIPs []string, httpsPort, httpPort int, softSkipMissing bool, progress func(msg string)) (int, error) {
+// elbMember is one pool member as returned by the ELB v3 members-list
+// endpoint.
+type elbMember struct {
+	ID           string `json:"id"`
+	Address      string `json:"address"`
+	ProtocolPort int    `json:"protocol_port"`
+	SubnetID     string `json:"subnet_cidr_id"`
+}
+
+func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN, elbSuffix, poolHTTPSSuffix, poolHTTPSuffix string, primaryIPs, peerIPs []string, httpsPort, httpPort int, sweepStale, softSkipMissing bool, progress func(msg string)) (int, error) {
 	if progress == nil {
 		progress = func(string) {}
 	}
 	if httpsPort <= 0 && httpPort <= 0 {
 		return 0, fmt.Errorf("gateway-elb: no valid gateway host port supplied (https=%d http=%d)", httpsPort, httpPort)
 	}
-	desiredIPs := make(map[string]bool, len(nodeIPs))
-	for _, ip := range nodeIPs {
+	// desiredIPs = the full member union; crossVPC marks the peer-region
+	// subset that must be created WITHOUT a subnet_cidr_id (IP-type member).
+	// A duplicate IP in both lists classifies as primary.
+	desiredIPs := make(map[string]bool, len(primaryIPs)+len(peerIPs))
+	crossVPC := make(map[string]bool, len(peerIPs))
+	for _, ip := range peerIPs {
 		if ip = strings.TrimSpace(ip); ip != "" {
 			desiredIPs[ip] = true
+			crossVPC[ip] = true
+		}
+	}
+	for _, ip := range primaryIPs {
+		if ip = strings.TrimSpace(ip); ip != "" {
+			desiredIPs[ip] = true
+			delete(crossVPC, ip)
 		}
 	}
 	if len(desiredIPs) == 0 {
@@ -140,8 +188,9 @@ func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, r
 	}
 
 	// 2. Resolve the ELB's pools + its VIP subnet (the fallback subnet for
-	//    member creates when a pool has no existing member to inherit from —
-	//    nodes and the ELB share the region subnet by construction).
+	//    same-VPC member creates when a pool has no existing member to inherit
+	//    from — primary-region nodes and the ELB share the region subnet by
+	//    construction) + ip_target_enable (#5244 — cross-VPC members need it).
 	lbResp, status, err := doSignedRequest(client, hw, http.MethodGet, base+"/loadbalancers/"+gwELBID, nil)
 	if err != nil {
 		return 0, fmt.Errorf("gateway-elb: get LB %s: %w", gwELBID, err)
@@ -152,6 +201,7 @@ func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, r
 	var lb struct {
 		LoadBalancer struct {
 			VipSubnetCidrID string `json:"vip_subnet_cidr_id"`
+			IPTargetEnable  bool   `json:"ip_target_enable"`
 			Pools           []struct {
 				ID string `json:"id"`
 			} `json:"pools"`
@@ -161,9 +211,32 @@ func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, r
 		return 0, fmt.Errorf("gateway-elb: decode LB %s: %w", gwELBID, err)
 	}
 
+	// 2b. #5244 — peer-region members are cross-VPC IP-type members; the LB
+	// must have ip_target_enable on before their create is accepted. tofu sets
+	// cross_vpc_backend at Phase-0 on multi-region provs; this heals drift
+	// (pre-#5244 provs, or an HCS build that dropped the create-time flag).
+	// On PUT failure: log + skip ADDING cross-VPC members this cycle (their
+	// creates would be rejected anyway) — but keep them in desiredIPs so an
+	// existing peer member is never swept as stale.
+	if len(crossVPC) > 0 && !lb.LoadBalancer.IPTargetEnable {
+		putBody := []byte(`{"loadbalancer":{"ip_target_enable":true}}`)
+		pResp, pStat, pErr := doSignedRequest(client, hw, http.MethodPut, base+"/loadbalancers/"+gwELBID, putBody)
+		if pErr != nil || pStat >= 400 {
+			progress(fmt.Sprintf("gateway-elb: enable ip_target_enable on LB %s failed (status %d): %s — peer-region member adds skipped this cycle", gwELBID, pStat, snippet(pResp, 200)))
+			for ip := range crossVPC {
+				crossVPC[ip] = false // marker: known peer IP, but not addable now
+			}
+		} else {
+			progress(fmt.Sprintf("gateway-elb: LB %s ip_target_enable → true (cross-VPC members permitted)", gwELBID))
+		}
+	}
+
 	changed := 0
 	for _, pl := range lb.LoadBalancer.Pools {
-		// Fetch pool detail (name + members + healthmonitor_id).
+		// Fetch pool detail (name + healthmonitor_id). NOTE: the pool GET's
+		// inline `members` are ID-only STUBS on HCS (proven live on hw275 —
+		// address/protocol_port come back empty), so the member set is read
+		// from the dedicated members-list endpoint below.
 		pResp, pStat, perr := doSignedRequest(client, hw, http.MethodGet, base+"/pools/"+pl.ID, nil)
 		if perr != nil || pStat >= 400 {
 			progress(fmt.Sprintf("gateway-elb: get pool %s failed (status %d): %v", pl.ID, pStat, perr))
@@ -171,13 +244,7 @@ func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, r
 		}
 		var pool struct {
 			Pool struct {
-				Name    string `json:"name"`
-				Members []struct {
-					ID           string `json:"id"`
-					Address      string `json:"address"`
-					ProtocolPort int    `json:"protocol_port"`
-					SubnetID     string `json:"subnet_cidr_id"`
-				} `json:"members"`
+				Name            string `json:"name"`
 				HealthMonitorID string `json:"healthmonitor_id"`
 			} `json:"pool"`
 		}
@@ -201,17 +268,37 @@ func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, r
 			continue
 		}
 
-		// 3. Converge the member set: keep members already at (nodeIP, desired),
-		//    delete everything else (stale nodes, wrong ports, empty addresses),
-		//    then add the missing nodes. Track a subnet to inherit for creates.
+		// Fetch the pool's full member objects (address + port + subnet).
+		mResp, mStat, merr := doSignedRequest(client, hw, http.MethodGet, base+"/pools/"+pl.ID+"/members", nil)
+		if merr != nil || mStat >= 400 {
+			progress(fmt.Sprintf("gateway-elb: list members of pool %s failed (status %d): %v", pl.ID, mStat, merr))
+			continue
+		}
+		var members struct {
+			Members []elbMember `json:"members"`
+		}
+		if err := json.Unmarshal(mResp, &members); err != nil {
+			progress(fmt.Sprintf("gateway-elb: decode members of pool %s failed: %v", pl.ID, err))
+			continue
+		}
+
+		// 3. Converge the member set: keep members already at (nodeIP, desired);
+		//    delete everything else (stale nodes, wrong ports, empty addresses)
+		//    — but ONLY when sweepStale (a partial region enumeration must
+		//    never drain the unreachable region's members, #5244) — then add
+		//    the missing nodes. Track a subnet to inherit for same-VPC creates.
 		subnetForCreate := lb.LoadBalancer.VipSubnetCidrID
-		present := make(map[string]bool, len(pool.Pool.Members))
-		for _, m := range pool.Pool.Members {
+		present := make(map[string]bool, len(members.Members))
+		for _, m := range members.Members {
 			if m.SubnetID != "" {
 				subnetForCreate = m.SubnetID
 			}
 			if desiredIPs[m.Address] && m.ProtocolPort == desired {
 				present[m.Address] = true
+				continue
+			}
+			if !sweepStale {
+				progress(fmt.Sprintf("gateway-elb: pool %s: member %q:%d not in the enumerated node set, but region enumeration was incomplete — keeping (adds-only cycle)", pool.Pool.Name, m.Address, m.ProtocolPort))
 				continue
 			}
 			// Stale member (node gone, wrong port, or empty address).
@@ -227,18 +314,35 @@ func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, r
 			if present[ip] {
 				continue
 			}
-			body := gatewayMemberCreateBody(ip, desired, subnetForCreate)
+			isCross, isKnownPeer := crossVPC[ip]
+			if isKnownPeer && !isCross {
+				// Peer IP whose cross-VPC enable failed above — skip the add.
+				continue
+			}
+			subnet := subnetForCreate
+			if isCross {
+				// #5244 cross-VPC IP-type member: subnet_cidr_id MUST be
+				// omitted — the peer node's IP is outside every subnet of the
+				// ELB's VPC; the ELB reaches it over the mesh VPC peering.
+				subnet = ""
+			}
+			body := gatewayMemberCreateBody(ip, desired, subnet)
 			cResp, cStat, cErr := doSignedRequest(client, hw, http.MethodPost, base+"/pools/"+pl.ID+"/members", body)
 			if cErr != nil || cStat >= 400 {
 				progress(fmt.Sprintf("gateway-elb: pool %s: add member %s:%d failed (status %d): %s", pool.Pool.Name, ip, desired, cStat, snippet(cResp, 200)))
 				continue
 			}
-			progress(fmt.Sprintf("gateway-elb: pool %s: member %s:%d added", pool.Pool.Name, ip, desired))
+			kind := "member"
+			if isCross {
+				kind = "cross-VPC member"
+			}
+			progress(fmt.Sprintf("gateway-elb: pool %s: %s %s:%d added", pool.Pool.Name, kind, ip, desired))
 			changed++
 		}
 
 		// 4. Point the pool's health monitor at the gateway host port, so the
-		//    ELB marks the members healthy against the port it actually forwards.
+		//    ELB marks the members healthy against the port it actually forwards
+		//    — and drains a dead region's members on region-kill (#5244).
 		if pool.Pool.HealthMonitorID != "" {
 			hmBody := []byte(fmt.Sprintf(`{"healthmonitor":{"monitor_port":%d}}`, desired))
 			hResp, hStat, hErr := doSignedRequest(client, hw, http.MethodPut, base+"/healthmonitors/"+pool.Pool.HealthMonitorID, hmBody)
@@ -255,9 +359,10 @@ func (p *Provider) reconcileELBMembers(ctx context.Context, ak, sk, projectID, r
 
 // gatewayMemberCreateBody builds the ELB v3 member-create payload. subnet_cidr_id
 // is the member's IPv4 subnet (inherited from an existing member, or the ELB's
-// own VIP subnet — nodes and the ELB share the region subnet by construction).
-// When empty it is omitted (cross-VPC member — not our case, but keep the
-// encoder honest).
+// own VIP subnet — primary-region nodes and the ELB share the region subnet by
+// construction). When empty it is omitted — the cross-VPC IP-type member shape
+// (#5244): peer-region nodes live outside the ELB's VPC, and the members API
+// rejects a subnet_cidr_id that does not contain the address.
 func gatewayMemberCreateBody(address string, port int, subnetCIDRID string) []byte {
 	member := map[string]any{
 		"address":       address,

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb_test.go
@@ -12,18 +12,22 @@ import (
 
 // memberOp records a member create (POST) or delete for assertions.
 type memberOp struct {
-	verb    string // "POST" | "DELETE"
-	poolID  string
-	address string
-	port    int
-	id      string // for DELETE
+	verb      string // "POST" | "DELETE"
+	poolID    string
+	address   string
+	port      int
+	id        string // for DELETE
+	subnet    string // for POST: the subnet_cidr_id sent ("" == omitted)
+	hasSubnet bool   // for POST: whether subnet_cidr_id was present at all
 }
 
 // fakeHCSGatewayELB mimics the ELB v3 endpoints ReconcileGatewayELBMembers
-// walks: list LBs, get LB (pools + vip subnet), get pool (members +
-// healthmonitor), member POST/DELETE, and healthmonitor PUT. It records every
-// member op + monitor PUT port so the test asserts the reconcile converged the
-// member SET correctly.
+// walks: list LBs, get LB (pools + vip subnet + ip_target_enable), get pool
+// (name + healthmonitor — with ID-ONLY member stubs, the live HCS shape
+// proven on hw275), list pool members (the full member objects), member
+// POST/DELETE, LB PUT (ip_target_enable), and healthmonitor PUT. It records
+// every member op + LB PUT + monitor PUT port so the test asserts the
+// reconcile converged the member SET correctly.
 //
 // Fixture shape (#4706 contract):
 //   - live nodes: 10.42.0.10 / .11 / .12 (passed by the test)
@@ -34,7 +38,7 @@ type memberOp struct {
 //     and .10 are missing at :443 → added.
 //   - http pool: one stale member (.10:31080 → delete); all 3 nodes added at :80.
 //   - a console ELB that must never be touched.
-func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func() {
+func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int, lbPuts *[]string) func() {
 	t.Helper()
 	var mu sync.Mutex
 
@@ -42,19 +46,23 @@ func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func(
 	  {"id":"lb-gw","name":"catalyst-hw9-omani-works-5b413990-elb-primary"},
 	  {"id":"lb-console","name":"catalyst-hw9-omani-works-5b413990-elb-console"}
 	]}`
-	const lbGetGW = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","pools":[{"id":"pool-https"},{"id":"pool-http"}]}}`
+	const lbGetGW = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","ip_target_enable":false,"pools":[{"id":"pool-https"},{"id":"pool-http"}]}}`
+	// Pool GET carries ID-ONLY member stubs — the live HCS shape (hw275): the
+	// reconciler MUST read the members-list endpoint, not these.
 	const poolHTTPS = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-https",
 	  "healthmonitor_id":"hm-https",
-	  "members":[
+	  "members":[{"id":"m-https-1"},{"id":"m-https-empty"},{"id":"m-https-ok"}]}}`
+	const poolHTTP = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-http",
+	  "healthmonitor_id":"hm-http",
+	  "members":[{"id":"m-http-1"}]}}`
+	const membersHTTPS = `{"members":[
 	    {"id":"m-https-1","address":"10.42.0.10","protocol_port":31443,"subnet_cidr_id":"subnet-1"},
 	    {"id":"m-https-empty","address":"","protocol_port":443,"subnet_cidr_id":""},
 	    {"id":"m-https-ok","address":"10.42.0.12","protocol_port":443,"subnet_cidr_id":"subnet-1"}
-	  ]}}`
-	const poolHTTP = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-http",
-	  "healthmonitor_id":"hm-http",
-	  "members":[
+	  ]}`
+	const membersHTTP = `{"members":[
 	    {"id":"m-http-1","address":"10.42.0.10","protocol_port":31080,"subnet_cidr_id":"subnet-1"}
-	  ]}}`
+	  ]}`
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := r.URL.Path
@@ -63,6 +71,20 @@ func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func(
 			_, _ = w.Write([]byte(lbList))
 		case r.Method == http.MethodGet && strings.HasSuffix(p, "/loadbalancers/lb-gw"):
 			_, _ = w.Write([]byte(lbGetGW))
+		case r.Method == http.MethodPut && strings.HasSuffix(p, "/loadbalancers/lb-gw"):
+			var body struct {
+				LoadBalancer map[string]any `json:"loadbalancer"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			b, _ := json.Marshal(body.LoadBalancer)
+			mu.Lock()
+			*lbPuts = append(*lbPuts, string(b))
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-https/members"):
+			_, _ = w.Write([]byte(membersHTTPS))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-http/members"):
+			_, _ = w.Write([]byte(membersHTTP))
 		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-https"):
 			_, _ = w.Write([]byte(poolHTTPS))
 		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-http"):
@@ -76,17 +98,16 @@ func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func(
 			w.WriteHeader(http.StatusNoContent)
 		case r.Method == http.MethodPost && strings.HasSuffix(p, "/members"):
 			var body struct {
-				Member struct {
-					Address      string `json:"address"`
-					ProtocolPort int    `json:"protocol_port"`
-					SubnetCidrID string `json:"subnet_cidr_id"`
-				} `json:"member"`
+				Member map[string]any `json:"member"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
+			addr, _ := body.Member["address"].(string)
+			portF, _ := body.Member["protocol_port"].(float64)
+			subnet, hasSubnet := body.Member["subnet_cidr_id"].(string)
 			mu.Lock()
 			parts := strings.Split(strings.TrimRight(p, "/"), "/")
 			poolID := parts[len(parts)-2]
-			*ops = append(*ops, memberOp{verb: "POST", poolID: poolID, address: body.Member.Address, port: body.Member.ProtocolPort})
+			*ops = append(*ops, memberOp{verb: "POST", poolID: poolID, address: addr, port: int(portF), subnet: subnet, hasSubnet: hasSubnet})
 			mu.Unlock()
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"member":{"id":"m-new"}}`))
@@ -121,18 +142,21 @@ func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func(
 // gateway host ports (443/80); stale members (wrong port, gone node, EMPTY
 // address — the hw217 memberless-pool bug shape) are removed; a member
 // already correct is untouched; the console ELB is never touched; both
-// pools' health monitors point at the gateway host port.
+// pools' health monitors point at the gateway host port. Member state is
+// read from the members-list endpoint (the pool GET's inline stubs carry no
+// addresses on HCS — hw275).
 func TestReconcileGatewayELBMembers_ConvergesSetAtHostPorts(t *testing.T) {
 	var ops []memberOp
 	var monitorPorts []int
-	restore := fakeHCSGatewayELB(t, &ops, &monitorPorts)
+	var lbPuts []string
+	restore := fakeHCSGatewayELB(t, &ops, &monitorPorts, &lbPuts)
 	defer restore()
 
 	nodes := []string{"10.42.0.10", "10.42.0.11", "10.42.0.12"}
 	p := New()
 	changed, err := p.ReconcileGatewayELBMembers(context.Background(),
 		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
-		nodes, 443, 80, nil)
+		nodes, nil, 443, 80, true, nil)
 	if err != nil {
 		t.Fatalf("ReconcileGatewayELBMembers: %v", err)
 	}
@@ -175,9 +199,16 @@ func TestReconcileGatewayELBMembers_ConvergesSetAtHostPorts(t *testing.T) {
 		if po.port >= 30000 {
 			t.Fatalf("POSTed member port %d is in the NodePort range — nodePorts are FORBIDDEN (§854)", po.port)
 		}
+		if !po.hasSubnet || po.subnet == "" {
+			t.Fatalf("primary-region POST for %s must carry a subnet_cidr_id, got %+v", po.address, po)
+		}
 	}
 	if changed != len(posts)+len(deletes) {
 		t.Fatalf("changed = %d, want %d (adds + removals)", changed, len(posts)+len(deletes))
+	}
+	// No peer IPs were supplied → the cross-VPC enable PUT must NOT fire.
+	if len(lbPuts) != 0 {
+		t.Fatalf("LB PUTs = %v, want none (no peer members requested)", lbPuts)
 	}
 	// Both health monitors point at the gateway host ports.
 	if len(monitorPorts) != 2 {
@@ -197,6 +228,192 @@ func TestReconcileGatewayELBMembers_ConvergesSetAtHostPorts(t *testing.T) {
 	}
 }
 
+// TestReconcileGatewayELBMembers_CrossRegionMembers (#5244) — peer-region
+// node IPs become cross-VPC IP-type members: the LB's ip_target_enable is
+// flipped on first (it was false), and every peer member create OMITS
+// subnet_cidr_id. Existing correct members (primary and peer) are untouched.
+func TestReconcileGatewayELBMembers_CrossRegionMembers(t *testing.T) {
+	var mu sync.Mutex
+	var ops []memberOp
+	var lbPuts []string
+	const lbList = `{"loadbalancers":[{"id":"lb-gw","name":"catalyst-hw9-omani-works-5b413990-elb-primary"}]}`
+	const lbGet = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","ip_target_enable":false,"pools":[{"id":"pool-https"}]}}`
+	const poolHTTPS = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-https",
+	  "healthmonitor_id":"","members":[{"id":"m1"}]}}`
+	// Primary member .10 already correct; peer members 10.43.0.20/.21 missing.
+	const membersHTTPS = `{"members":[{"id":"m1","address":"10.42.0.10","protocol_port":443,"subnet_cidr_id":"subnet-1"}]}`
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/elb/loadbalancers"):
+			_, _ = w.Write([]byte(lbList))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/loadbalancers/lb-gw"):
+			_, _ = w.Write([]byte(lbGet))
+		case r.Method == http.MethodPut && strings.HasSuffix(p, "/loadbalancers/lb-gw"):
+			var body struct {
+				LoadBalancer map[string]any `json:"loadbalancer"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			b, _ := json.Marshal(body.LoadBalancer)
+			mu.Lock()
+			lbPuts = append(lbPuts, string(b))
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-https/members"):
+			_, _ = w.Write([]byte(membersHTTPS))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-https"):
+			_, _ = w.Write([]byte(poolHTTPS))
+		case r.Method == http.MethodPost && strings.HasSuffix(p, "/members"):
+			var body struct {
+				Member map[string]any `json:"member"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			addr, _ := body.Member["address"].(string)
+			portF, _ := body.Member["protocol_port"].(float64)
+			subnet, hasSubnet := body.Member["subnet_cidr_id"].(string)
+			mu.Lock()
+			ops = append(ops, memberOp{verb: "POST", address: addr, port: int(portF), subnet: subnet, hasSubnet: hasSubnet})
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"member":{"id":"m-new"}}`))
+		case r.Method == http.MethodDelete && strings.Contains(p, "/members/"):
+			mu.Lock()
+			ops = append(ops, memberOp{verb: "DELETE"})
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "https://")
+	orig := endpointFor
+	endpointFor = func(service, region string) string { return "https://" + host }
+	defer func() { endpointFor = orig }()
+
+	p := New()
+	changed, err := p.ReconcileGatewayELBMembers(context.Background(),
+		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
+		[]string{"10.42.0.10"}, []string{"10.43.0.20", "10.43.0.21"}, 443, 80, true, nil)
+	if err != nil {
+		t.Fatalf("ReconcileGatewayELBMembers: %v", err)
+	}
+
+	// ip_target_enable must be flipped on exactly once, before member adds.
+	if len(lbPuts) != 1 || !strings.Contains(lbPuts[0], `"ip_target_enable":true`) {
+		t.Fatalf("LB PUTs = %v, want exactly one enabling ip_target_enable", lbPuts)
+	}
+	var posts, deletes []memberOp
+	for _, o := range ops {
+		if o.verb == "POST" {
+			posts = append(posts, o)
+		} else {
+			deletes = append(deletes, o)
+		}
+	}
+	if len(deletes) != 0 {
+		t.Fatalf("DELETEs = %d, want 0 (nothing stale)", len(deletes))
+	}
+	if len(posts) != 2 {
+		t.Fatalf("POSTs = %d (%v), want 2 (both peer nodes)", len(posts), posts)
+	}
+	for _, po := range posts {
+		if !strings.HasPrefix(po.address, "10.43.0.") {
+			t.Fatalf("unexpected POST address %q — the primary member was already present", po.address)
+		}
+		if po.port != 443 {
+			t.Fatalf("peer POST for %s got port %d, want 443 (the durable host port — NEVER a nodePort, §854)", po.address, po.port)
+		}
+		if po.hasSubnet {
+			t.Fatalf("peer-region POST for %s must OMIT subnet_cidr_id (cross-VPC IP-type member), got subnet %q", po.address, po.subnet)
+		}
+	}
+	if changed != 2 {
+		t.Fatalf("changed = %d, want 2", changed)
+	}
+}
+
+// TestReconcileGatewayELBMembers_AddsOnlyWhenEnumerationIncomplete (#5244) —
+// with sweepStale=false (a secondary region could not be enumerated —
+// possibly mid region outage) the reconcile must NOT delete any member, even
+// ones outside the supplied node set: the unlistable region's members may be
+// the only ones carrying the EIP. Missing members are still added.
+func TestReconcileGatewayELBMembers_AddsOnlyWhenEnumerationIncomplete(t *testing.T) {
+	var mu sync.Mutex
+	var ops []memberOp
+	const lbList = `{"loadbalancers":[{"id":"lb-gw","name":"catalyst-hw9-omani-works-5b413990-elb-primary"}]}`
+	// ip_target_enable already true (peer members were added by a prior cycle).
+	const lbGet = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","ip_target_enable":true,"pools":[{"id":"pool-https"}]}}`
+	const poolHTTPS = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-https",
+	  "healthmonitor_id":"","members":[{"id":"m-peer"}]}}`
+	// A peer-region member from the unlistable region — must survive.
+	const membersHTTPS = `{"members":[{"id":"m-peer","address":"10.43.0.20","protocol_port":443,"subnet_cidr_id":""}]}`
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/elb/loadbalancers"):
+			_, _ = w.Write([]byte(lbList))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/loadbalancers/lb-gw"):
+			_, _ = w.Write([]byte(lbGet))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-https/members"):
+			_, _ = w.Write([]byte(membersHTTPS))
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/pools/pool-https"):
+			_, _ = w.Write([]byte(poolHTTPS))
+		case r.Method == http.MethodPost && strings.HasSuffix(p, "/members"):
+			var body struct {
+				Member map[string]any `json:"member"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			addr, _ := body.Member["address"].(string)
+			mu.Lock()
+			ops = append(ops, memberOp{verb: "POST", address: addr})
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"member":{"id":"m-new"}}`))
+		case r.Method == http.MethodDelete && strings.Contains(p, "/members/"):
+			mu.Lock()
+			ops = append(ops, memberOp{verb: "DELETE"})
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "https://")
+	orig := endpointFor
+	endpointFor = func(service, region string) string { return "https://" + host }
+	defer func() { endpointFor = orig }()
+
+	p := New()
+	// Only the primary region was enumerable — sweepStale=false, no peer IPs.
+	changed, err := p.ReconcileGatewayELBMembers(context.Background(),
+		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
+		[]string{"10.42.0.10"}, nil, 443, 80, false, nil)
+	if err != nil {
+		t.Fatalf("ReconcileGatewayELBMembers: %v", err)
+	}
+	for _, o := range ops {
+		if o.verb == "DELETE" {
+			t.Fatalf("issued a DELETE with sweepStale=false — the unlistable region's member 10.43.0.20 would have been drained mid-outage")
+		}
+	}
+	var posts []memberOp
+	for _, o := range ops {
+		if o.verb == "POST" {
+			posts = append(posts, o)
+		}
+	}
+	if len(posts) != 1 || posts[0].address != "10.42.0.10" {
+		t.Fatalf("POSTs = %v, want exactly the missing primary member 10.42.0.10", posts)
+	}
+	if changed != 1 {
+		t.Fatalf("changed = %d, want 1 (one add, zero removals)", changed)
+	}
+}
+
 // TestReconcileGatewayELBMembers_Idempotent — a re-run when the member set
 // already equals the live nodes at the host port is a no-op (0 changes,
 // 0 DELETE/POST).
@@ -204,16 +421,18 @@ func TestReconcileGatewayELBMembers_Idempotent(t *testing.T) {
 	var mu sync.Mutex
 	var ops []memberOp
 	const lbList = `{"loadbalancers":[{"id":"lb-gw","name":"catalyst-hw9-omani-works-5b413990-elb-primary"}]}`
-	const lbGet = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","pools":[{"id":"pool-https"}]}}`
+	const lbGet = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","ip_target_enable":false,"pools":[{"id":"pool-https"}]}}`
 	const poolHTTPS = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-https",
-	  "healthmonitor_id":"hm-https",
-	  "members":[{"id":"m1","address":"10.42.0.10","protocol_port":443,"subnet_cidr_id":"subnet-1"}]}}`
+	  "healthmonitor_id":"hm-https","members":[{"id":"m1"}]}}`
+	const membersHTTPS = `{"members":[{"id":"m1","address":"10.42.0.10","protocol_port":443,"subnet_cidr_id":"subnet-1"}]}`
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/elb/loadbalancers"):
 			_, _ = w.Write([]byte(lbList))
 		case strings.HasSuffix(r.URL.Path, "/loadbalancers/lb-gw"):
 			_, _ = w.Write([]byte(lbGet))
+		case strings.HasSuffix(r.URL.Path, "/pools/pool-https/members"):
+			_, _ = w.Write([]byte(membersHTTPS))
 		case strings.HasSuffix(r.URL.Path, "/pools/pool-https"):
 			_, _ = w.Write([]byte(poolHTTPS))
 		case r.Method == http.MethodDelete || r.Method == http.MethodPost:
@@ -235,7 +454,7 @@ func TestReconcileGatewayELBMembers_Idempotent(t *testing.T) {
 	p := New()
 	changed, err := p.ReconcileGatewayELBMembers(context.Background(),
 		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
-		[]string{"10.42.0.10"}, 443, 80, nil)
+		[]string{"10.42.0.10"}, nil, 443, 80, true, nil)
 	if err != nil {
 		t.Fatalf("ReconcileGatewayELBMembers: %v", err)
 	}
@@ -265,7 +484,7 @@ func TestReconcileGatewayELBMembers_NoGatewayELB(t *testing.T) {
 	p := New()
 	_, err := p.ReconcileGatewayELBMembers(context.Background(),
 		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
-		[]string{"10.42.0.10"}, 443, 80, nil)
+		[]string{"10.42.0.10"}, nil, 443, 80, true, nil)
 	if err == nil {
 		t.Fatalf("expected an error when no -elb-primary ELB exists, got nil")
 	}
@@ -274,14 +493,14 @@ func TestReconcileGatewayELBMembers_NoGatewayELB(t *testing.T) {
 	}
 }
 
-// TestReconcileGatewayELBMembers_RefusesEmptyNodeSet — an empty node list must
-// error out, never empty the pools (an empty pool = console 000, the exact
-// hw217 failure).
+// TestReconcileGatewayELBMembers_RefusesEmptyNodeSet — an empty node union
+// (no primary AND no peer IPs) must error out, never empty the pools (an
+// empty pool = console 000, the exact hw217 failure).
 func TestReconcileGatewayELBMembers_RefusesEmptyNodeSet(t *testing.T) {
 	p := New()
 	_, err := p.ReconcileGatewayELBMembers(context.Background(),
 		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
-		nil, 443, 80, nil)
+		nil, nil, 443, 80, true, nil)
 	if err == nil {
 		t.Fatalf("expected an error on an empty node set, got nil")
 	}


### PR DESCRIPTION
Refs #5244

## Root cause — confirmed live (hw275 G12, dep `7886def2e61c63aa`, 2026-07-19, ELB v3 API read)

Both public front-door ELBs had backend pools anchored to **primary-region (region-a) nodes only**:

| ELB | EIP | Pool members (live dump) | ip_target_enable |
|---|---|---|---|
| `…-elb-primary` (gateway) | 212.72.24.14 | 10.208.1.{120,218,172,163,212} at :443/:80 — **all region-a** | `false` |
| `…-elb-console` | 212.72.24.49 | same 5 region-a IPs at :8443/:8080 | `false` |

Zero region-b (10.218.1.x) members in any pool. The per-pool TCP health monitors exist (delay 10s, timeout 5s, max_retries 3) and did their job on the kill — they drained the dead region-a members. But with no region-b members the pools went **empty** and both EIPs black-holed for the entire ~4-min outage, even though `cilium-envoy` (hostNetwork DaemonSet) was Running on all 5 region-b nodes with the gateway listeners bound on `node:443/:80`, and DNS had failed over cleanly.

Two code paths pinned the membership to region-a:

1. **tofu seed** — `infra/providers/huawei/main.tf` `local.primary_lb_node_ips` filtered nodes to `region_keys[0]` for both ELBs' members.
2. **day-2 reconciler** — `post_handover_gateway_elb.go` enumerated only the PRIMARY kubeconfig's nodes, and `gateway_elb.go`'s stale-member sweep would have **deleted** any region-b member as "stale" on its next run — so even a hand-seeded cross-region pool could not survive.

A third latent defect surfaced during the live read: on HCS the **pool GET returns ID-only member stubs** (no address/port), so the reconciler's inline-member parse saw every member as "empty address = stale" — delete + re-add churn every cycle.

## The fix — mechanism and why it is §854-safe

**ELB backend pools span BOTH regions' nodes, with the existing health monitors draining the dead region.** Peer-region nodes live in a different VPC than the ELB, so they are added as **cross-VPC IP-type members** (`subnet_cidr_id` omitted, `cross_vpc_backend`/`ip_target_enable` on) reached over the **existing** mesh VPC peering + routes (`huaweicloud_vpc_peering_connection.mesh` + node-CIDR/pod-CIDR routes; SG ingress on 443/80/8443/8080 is already 0.0.0.0/0 — no new network surface). On a region-a kill the monitors mark region-a members OFFLINE within ~interval×max_retries (~30s) and the region-b members keep serving the same EIP.

**§854 compliance**: every member — primary or peer — targets the durable hostNetwork host ports only: `node:443/:80` (cilium-envoy gateway) and `node:8443/:8080` (console gateway host ports, #4715). No `Service type=NodePort`, no auto-allocated nodePort, no ELB member in the 30000–32767 range — the tofu variable validation and a new tftest assertion reject the NodePort range outright, and `scripts/check-no-nodeports.sh` passes locally on this diff.

**Alternatives weighed (and why not):**
- *Cilium LB-IPAM VIP re-homing / shared-EIP `lbipam.cilium.io/sharing-key` to region-b*: the option-B shape was proven broken on this provider (hw208) — the CP EIPs are 1:1 NAT, externally unreachable as gateway VIPs (#4687→#4690 restored the dedicated ELB for exactly this reason). Re-homing the EIP binding itself would need out-of-band Huawei API automation during the very outage window, with a dead region's control plane in the loop — strictly worse than a health-checked static member spread.
- *BGP/gratuitous-ARP announce from the alive region*: no BGP peering surface on the kom4dc ELB/EIP path; the EIP is bound to the ELB, not to a node.
- *A second standby ELB in region-b + DNS switch*: burns an EIP from the tight quota and re-introduces DNS-TTL-bound RTO; the ELB is a managed service that survives the node-kill, so member-spanning gives failover with zero extra EIPs and no DNS dependency.

## Changes

- `infra/providers/huawei/main.tf` — `local.primary_lb_node_ips` → `local.gateway_lb_members` (ALL regions' CPs + workers, with a per-node `primary` flag); gateway + console member resources fan out over it, peer nodes get `subnet_id = null` (IP-type member); `cross_vpc_backend = true` on both LBs for multi-region provs (single-region provs keep the exact pre-#5244 shape). Cloud-init untouched (SACRED/thin).
- `products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb.go` — reconcile signature takes `primaryIPs, peerIPs, sweepStale`; converges the UNION; creates peer members without `subnet_cidr_id`; flips `ip_target_enable` on when peer members are needed and it is off (heals pre-#5244 provs); reads member state from the members-list endpoint (HCS pool GET carries ID-only stubs — hw275); `sweepStale=false` makes the cycle ADDS-ONLY so a region that cannot currently be enumerated (possibly mid-outage — the exact region carrying the EIP) is never drained by a blind sweep.
- `products/catalyst/bootstrap/api/internal/handler/post_handover_gateway_elb.go` — enumerates every secondary region's cluster (in-memory `secondaryKubeconfigPaths` ∪ on-disk `<depID>-<region>.yaml`, the #4000 pattern) and feeds peer IPs + the completeness bit into both the gateway and console reconciles.
- Tests: 3 new unit tests (cross-VPC member create omits `subnet_cidr_id` + `ip_target_enable` PUT fires exactly once; adds-only when enumeration incomplete; NodePort-range guard on every POSTed member) + fixtures moved to the live HCS members-list shape; 6 new tftest assertions (2-region: 6 members/pool, 3 peer members subnet-less, `cross_vpc_backend=true`; single-region: unchanged shape; §854 port ceiling).

## Validation

- `go test -race ./...` green across `products/catalyst/bootstrap/api` (incl. the 164s handler suite).
- `tofu init/fmt/validate/test` green on `infra/providers/huawei` (7/7 runs, incl. the new #5244 assertions).
- `bash scripts/check-no-nodeports.sh` → `OK: zero NodePorts across sources + rendered charts`.
- Live hw275 read-only API dump above is the root-cause evidence. **Not claimed**: the fix is NOT live-validated — the DoD gate on #5244 is a fresh-prov region-kill walk (kill region-a, `curl` the console + a gateway-fronted app URL through the drain window, evidence to `docs/sessions/` + UAT stamp).

## Risk notes

- `cross_vpc_backend` maps to ELB `ip_target_enable`; the hw275 LB GET already returns the field on this HCS build (value `false`), so the API surface exists. If a given HCS build rejected the create-time flag, the day-2 reconciler's enable-on-demand PUT is the fallback path; the fresh-prov walk proves it end-to-end.
- Member-resource indices reorder vs the old primary-only list; provs are create-only through catalyst-api (wipe + re-prov lifecycle), so no in-place `tofu apply` churn concern.

Do NOT merge — awaiting review + fresh-prov region-kill validation per the #5244 DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)