### PR TITLE
fix(cnpg-pair): region-kill FAILBACK — demote+re-clone region-A onto the promoted line, durable substitute seams, TL-ahead re-promote (0.2.18)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -253,7 +253,23 @@ spec:
       # A GRANT was not viable (streaming_replica is a CNPG reserved role and does
       # not exist at postInitSQL time → GRANT would wedge bootstrap). All #5220/
       # #5219/#5178 gates unchanged; script-only. No new substitute.
-      version: 0.2.17
+      # 0.2.18 (#5245): region-kill FAILBACK. hw275 G12: after a clean forward
+      # promote, recovered region-A resumed its stale TL1 primary while promoted
+      # region-B FATAL-looped as a TL2 standby — replication permanently dead.
+      # (1) every actor write uses a custom --field-manager (kustomize-controller
+      # strips kubectl-managed fields on every reconcile of THIS slot — the
+      # live-observed mid-recovery re-demote of the promoted survivor); (2) the
+      # promotion/demotion desired state now rides TWO NEW substitutes below
+      # (SOVEREIGN_CNPG_PAIR_PROMOTED / SOVEREIGN_CNPG_PAIR_DEMOTED) that the
+      # DR actors patch onto THIS Kustomization's postBuild.substitute with
+      # their own field managers (the catalyst-api SOVEREIGN_ENABLE_CNPG_PAIR
+      # precedent) — kustomize then renders the failed-over topology as its own
+      # desired state and the suspend latch is LIFTED; (3) a TL-ahead standby
+      # (own timeline > reachable source's) re-promotes automatically; (4) NEW
+      # side=primary dr-failback actor demotes + re-clones region-A onto
+      # region-B's promoted line (pg_basebackup over the new `-replica-mesh`
+      # global Service; shared client CA so region-A's own cert authenticates).
+      version: 0.2.18
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair
@@ -331,8 +347,29 @@ spec:
       primary:
         # Canonical region label (matches openova.io/region node label).
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
+        # ── #5245 DR FAILBACK seam — cluster-local runtime flip ───────
+        # NOT a provisioner substitute: default false on every prov. The
+        # side=primary dr-failback actor patches SOVEREIGN_CNPG_PAIR_
+        # DEMOTED="true" onto THIS Kustomization's postBuild.substitute
+        # (custom field manager `dr-failback`) when a recovered region-A
+        # must rejoin region-B's promoted line — kustomize then renders
+        # the demotion (primary Cluster CR as a pg_basebackup replica of
+        # region-B) as its OWN desired state, so drift-correction
+        # re-affirms it. The sovereign-admin's controlled switchback
+        # resets it to "false" (RUNBOOKS §6.1).
+        demoted: ${SOVEREIGN_CNPG_PAIR_DEMOTED:-false}
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+        # ── #5245 DR PROMOTION seam — cluster-local runtime flip ──────
+        # NOT a provisioner substitute: default false on every prov. The
+        # side=replica dr-promoter's DURABLE HANDOFF patches SOVEREIGN_
+        # CNPG_PAIR_PROMOTED="true" onto THIS Kustomization once a
+        # promotion is latched+rendered (and the TL-ahead re-promote
+        # writes it directly) — the promotion becomes the SOURCE-rendered
+        # desired state and the #5219 suspend latch is LIFTED, so flux
+        # keeps reconciling the promoted survivor instead of freezing
+        # forever. Reset to "false" at the controlled switchback.
+        promoted: ${SOVEREIGN_CNPG_PAIR_PROMOTED:-false}
       networkPolicy:
         # crossRegionPeerClusters (#4846) — admit the PEER region's Pods to the
         # pair's 5432 by CLUSTER IDENTITY. A k8s `ipBlock` (the reverted #4846

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1118,21 +1118,49 @@ The deterministic failover test for two independent CNPG clusters:
    survivor (hw256 G12, T0+2m07s). (The `Continuum` CR orchestration path is the
    automated equivalent — PR #2072/#2074.)
 4. Verify the write made it across — zero-tx-loss (RPO=0)
-5. Reverse: `scripts/region-kill-drill.sh recover --arm` os-starts region-a; then
-   **un-suspend** the region-B HR (`{"spec":{"suspend":false}}`) and set
-   `replica.promoted:false` to resume replica mode once the original primary is
-   re-cloned onto the current timeline (#5125 Defect-2, still open — CNPG replica
-   walreceivers crash-loop `timeline N behind recovery timeline N+1` until the
-   stale side is deleted + re-basebackup'd).
-   🛑 **Timeline-divergence signal (#5220)**: when a side can no longer stream
-   from a REACHABLE peer (the `timeline N behind recovery timeline N+1` wedge),
-   the dr-promoter records `catalyst.openova.io/dr-timeline-diverged-at` on the
-   region-B HR and logs the re-clone action — that annotation is the operator's
-   cue to delete the diverged Cluster's PVCs + re-basebackup it from the live
-   side. The actor does this NON-destructively (annotation only): from a 2-node
-   vantage with no witness it cannot prove WHICH side is authoritative, so
-   auto-destroying PGDATA could lose a real survivor's committed writes — the
-   re-clone stays this operator step.
+5. Reverse: `scripts/region-kill-drill.sh recover --arm` os-starts region-a.
+   **AUTOMATIC (bp-cnpg-pair ≥ 0.2.18, #5245)** — the failback now converges
+   with zero operator action, in three coordinated moves:
+   - **Durable handoff + latch lift** (region-B dr-promoter): once the
+     promotion is latched+rendered, the actor writes it into the SOURCE —
+     `SOVEREIGN_CNPG_PAIR_PROMOTED="true"` on the bootstrap-kit
+     Kustomization's `postBuild.substitute` (slot 16b renders
+     `replica.promoted` from it) — verifies the HR renders promoted=true,
+     then **un-suspends** the HR itself. Flux thereafter RE-AFFIRMS the
+     failed-over topology; no forever-frozen HR. (Every actor write uses a
+     custom `--field-manager` — kustomize's cleanup strips `kubectl*`-managed
+     fields on each reconcile, the hw275 mid-recovery re-demote root cause.)
+   - **TL-ahead re-promote** (region-B dr-promoter): a standby whose own
+     timeline exceeds its REACHABLE source's (`IDENTIFY_SYSTEM` arithmetic —
+     the hw275 `timeline 1 of the primary is behind recovery timeline 2`
+     wedge, #5220-B) is re-promoted through the substitute seam: that line
+     holds every acknowledged commit (the lower-TL side is write-fenced by
+     its unsatisfiable `FIRST 1`), so re-promoting it is data-safe.
+   - **dr-failback** (region-A, side=primary): on POSITIVE proof — local
+     writable on TL n, the pinned sync standby ABSENT, peer WRITABLE on a
+     HIGHER timeline over the `-replica-mesh` global Service, held 120s —
+     region-A demotes via `SOVEREIGN_CNPG_PAIR_DEMOTED="true"` (the primary
+     Cluster CR re-renders as a pg_basebackup replica cluster of region-B)
+     and the stale Cluster CR is deleted so helm re-creates it and the
+     basebackup clones region-B's line. Discarded: only region-A's
+     never-acked WAL tail (the RPO=0 contract). Evidence:
+     `dr-failback-started-at` / `-recloned-at` / `-converged-at` annotations
+     on the region-A HR + both actors' pod logs.
+   **End state**: region-B primary, region-A streaming replica, both HRs
+   unsuspended, topology rendered from source. The **controlled switchback**
+   to original roles stays a sovereign-admin action: demote region-B and
+   restore region-A by resetting BOTH substitutes
+   (`SOVEREIGN_CNPG_PAIR_PROMOTED`/`_DEMOTED` → `"false"` on each region's
+   bootstrap-kit Kustomization) during a maintenance window — automate via
+   the CNPG demotion-token handshake is follow-up on #5245.
+   🛑 **Timeline-divergence signal (#5220/#5245)**: the dr-promoter still
+   records `catalyst.openova.io/dr-timeline-diverged-at` on the region-B HR
+   when a side cannot stream from a REACHABLE peer — on ≥ 0.2.18 the wedge
+   then AUTO-RESOLVES via the TL-ahead re-promote + failback above; the
+   annotation remains the audit trail (plus `dr-tl-ahead-repromoted-at` when
+   the re-promote fired). On < 0.2.18 the re-clone stays this manual step:
+   un-suspend the region-B HR, set `replica.promoted:false`, delete the
+   diverged Cluster's PVCs + re-basebackup from the live side.
 
 Test harness lives at the D31 acceptance test (PR #2075).
 

--- a/platform/cnpg-pair/DESIGN.md
+++ b/platform/cnpg-pair/DESIGN.md
@@ -300,6 +300,123 @@ region-kill. A third-site witness generalizing this (and letting the
 full Continuum sequencer — DNS flip, HTTPRoute drain — run from the
 survivor) is follow-up on #5137.
 
+### 10. Region-A automatic DR failback — the dr-failback + durable seams (chart 0.2.18, #5245)
+
+hw275 G12 (2026-07-19) proved the DR chain had a forward leg only.
+After a clean promote (region-B writable, TL2, latched), `recover
+--arm` os-started region-A and nothing converged: region-A resumed its
+OLD TL1 primary role (it never knew it was killed), region-B could
+never re-stream — a TL2 line cannot follow a TL1 source (walreceiver
+`FATAL 55000 "highest timeline 1 of the primary is behind recovery
+timeline 2"`, every 5 s, forever) — and the promote latch froze the HR
+with no owner for the return leg. Chart 0.2.18 closes it with four
+pieces:
+
+**(a) Latch durability — custom field managers.** The observed
+mid-recovery re-demote had a precise mechanism: kustomize-controller's
+server-side-apply cleanup replaces every field manager matching the
+`kubectl` prefix with itself on EACH reconcile of the applying
+Kustomization and drops the claimed fields absent from its manifest
+(its documented "undo kubectl drift" behavior). The #5219 suspend
+latch was written with the default `kubectl-patch` manager, so every
+bootstrap-kit reconcile stripped it: on hw275, kustomize Apply
+06:55:20 → helm redeployed the reverted values 06:55:23 (release v4 —
+the re-demote that manufactured the FATAL-loop state) → the self-heal
+re-latched 06:55:27, nineteen times in 30 minutes. Every DR-actor
+write now carries `--field-manager=dr-promoter` / `dr-failback` —
+managers the cleanup list does not match (live precedent: the
+catalyst-api substitute flips persist under manager `catalyst-api`).
+
+**(b) Durable handoff + latch lift — the substitute seam.** The
+suspend latch remains the mid-outage mechanism (helm-only; works from
+the cached chart artifact with zero kustomize/source dependency), but
+it is no longer the end state. Slot 16b now renders
+`replica.promoted: ${SOVEREIGN_CNPG_PAIR_PROMOTED:-false}` and
+`primary.demoted: ${SOVEREIGN_CNPG_PAIR_DEMOTED:-false}`; once a
+promotion is latched+rendered, the promoter patches
+`SOVEREIGN_CNPG_PAIR_PROMOTED="true"` onto the bootstrap-kit
+Kustomization's `postBuild.substitute` (the catalyst-api
+`SOVEREIGN_ENABLE_CNPG_PAIR` precedent — the Kustomization CR is
+applied once by cloud-init and never re-applied, so a custom-manager
+patch persists), verifies the HR renders `promoted: true` from source,
+then UNSUSPENDS. Drift-correction thereafter re-affirms the failed-over
+topology; flux is fully reconciled (chart bumps flow again). If the
+substitute is ever lost, the per-tick self-heal re-latches.
+
+**(c) TL-ahead re-promote — the #5220-B wedge made actionable.** A
+standby whose OWN timeline is strictly higher than its REACHABLE
+source's holds a line the source can never supersede: before the
+divergence it was the mandatory `remote_apply` sync target (so it had
+every acked commit), and after it the lower-TL side is write-fenced by
+its unsatisfiable `FIRST 1`. The promoter reads both timelines via
+`IDENTIFY_SYSTEM` on replication-protocol connections (the one surface
+`streaming_replica` is guaranteed — no `pg_read_all_stats`, the #5239
+lesson) and, once the #5220 divergence wedge has held, re-promotes the
+TL-ahead standby through the substitute seam. This deliberately
+bypasses the #5220 arm gate (a TL-ahead standby can never stream, so
+it could never arm) — sound because the timeline arithmetic is a
+strictly stronger proof than the streaming heuristic: no link flap or
+never-converged pair can manufacture `own-TL > source-TL`. Guards: max
+once per pod lifetime, never after `/shared/diverged` (the hw266
+runaway guard), wedge must have held `timelineDivergenceHoldSeconds`.
+
+**(d) dr-failback — demote + re-clone region-A onto the promoted
+line.** `side=primary` renders a `<fullname>-dr-failback` Deployment
+(same #5157 two-container shape) gated on sync mode AND
+`crossRegionPeerClusters` (without the peer probe there is no safe
+action, so nothing renders). Signals: local cluster WRITABLE on TL n +
+the pinned sync standby ABSENT from `pg_stat_replication` (walsender
+rows run AS `streaming_replica` — same-user rows are fully visible) +
+the peer REACHABLE, WRITABLE and on a strictly HIGHER timeline over
+the new `-replica-mesh` global Service (the reverse mirror of
+`-primary-mesh`: a CNPG-managed `rw` additional Service on the replica
+Cluster + a zero-backend stub on cluster-A). `TL_peer > TL_local` is
+antisymmetric — only the stale side can ever see peer-ahead, so the
+two regions' actors can never both act. After the proof holds
+`peerAheadHoldSeconds`, the actor flips
+`SOVEREIGN_CNPG_PAIR_DEMOTED="true"`, waits for kustomize to render
+the demoted shape into the HR (primary Cluster CR as a replica cluster
+of region-B: `replica.enabled: true` + `bootstrap.pg_basebackup` from
+the `-replica` externalCluster, synchronous block omitted), and then
+performs the ONE destructive act: it deletes the stale Cluster CR so
+helm re-creates it fresh and `pg_basebackup` clones region-B's current
+timeline (PVCs are CNPG-owned and garbage-collect).
+
+*Why this direction, and why it is data-safe*: the same sync fence
+that authorizes the forward promote proves region-B's line ⊇ every
+ACKED commit region-A ever made — before the kill B was the mandatory
+sync target; the dead window adds nothing; post-recovery A is
+write-fenced by its unsatisfiable `FIRST 1`. Discarding A's line loses
+only never-acked local WAL, which the RPO=0 contract already
+discards. The reverse re-clone (B from A) would destroy acknowledged
+post-promote writes and is never automatic. *Why not `pg_rewind`*:
+CNPG has no cross-cluster rewind trigger, and rewind's fork-point
+arithmetic depends on WAL-tail geometry the actor cannot verify; the
+basebackup re-clone is deterministic for every geometry (cost: a full
+copy — acceptable on the recovery leg, disclosed here). *Bounded
+destruction*: delete only the resourceNames-pinned Cluster CR, only
+with a <60 s-fresh peer-writable-and-ahead proof at that exact tick,
+and NEVER a Cluster created after the failback episode began — an
+in-place-demoted stale standby (if the webhook admits the shape change
+on the live CR) is re-cloned only via the wedge escalation
+(`wedgeHoldSeconds` unable to stream, `creationTimestamp` predating
+`dr-failback-started-at`); a fresh clone is never deleted.
+
+*Auth*: the rejoin stream and the peer probe present region-A's own
+`-primary-replication` client cert. Region-B accepts it because the
+replica Cluster pins `certificates.clientCASecret` to the shared
+`-primary-ca` (already synced A→B with `ca.key` at the post-mesh flip
+— live-verified hw275; CNPG generates `<replica>-replication` from a
+BYO client CA when `replicationTLSSecret` is unset, so every existing
+consumer keeps its mounts).
+
+End state after a kill+recover cycle: region-B primary, region-A
+streaming replica, both HRs unsuspended, the failed-over topology
+rendered from source. The controlled switchback to the original roles
+(demote B, restore A as primary — flip both substitutes back) stays a
+sovereign-admin action per RUNBOOKS §6.1; automating it needs the
+CNPG demotion-token handshake and is follow-up on #5245.
+
 ---
 
 ## C-DB-3 acceptance test — implementer brief (HARNESS SHIPPED, awaits operator walk)

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -50,7 +50,25 @@ spec:
   # ROW (EXISTS visible to all) AND pg_last_wal_receive_lsn() non-null. A GRANT
   # was not viable (streaming_replica is CNPG-reserved and absent at postInitSQL
   # time). All #5220/#5219/#5178 gates unchanged; script-only.
-  version: 0.2.17
+  # 0.2.18 (#5245): region-kill FAILBACK — the missing return leg. hw275 G12:
+  # after a clean forward promote, recovered region-A resumed its stale TL1
+  # primary role while promoted region-B FATAL-looped as a TL2 standby —
+  # replication permanently dead. (1) latch durability: every actor write uses
+  # a custom --field-manager (kustomize's managed-fields cleanup strips
+  # kubectl-managed fields each reconcile — the observed mid-recovery
+  # re-demote); (2) durable handoff: the promotion moves into the
+  # bootstrap-kit Kustomization substitute SOVEREIGN_CNPG_PAIR_PROMOTED and
+  # the suspend latch is LIFTED once source-rendered; (3) TL-ahead
+  # re-promote: a standby provably ahead of its reachable source
+  # (IDENTIFY_SYSTEM arithmetic) re-promotes through the substitute seam;
+  # (4) NEW side=primary dr-failback actor: on a held peer-writable-and-ahead
+  # proof it demotes region-A (SOVEREIGN_CNPG_PAIR_DEMOTED → the primary
+  # Cluster renders as a pg_basebackup replica of region-B over the new
+  # `-replica-mesh` global Service) and re-clones the stale line — bounded
+  # destruction, sync-fence data-safety (region-B ⊇ every acked commit).
+  # Shared client CA on the replica Cluster (clientCASecret=-primary-ca) lets
+  # region-A's own cert authenticate the rejoin stream.
+  version: 0.2.18
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,84 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.18 (#5245): region-kill FAILBACK — the DR chain gains its missing return
+# leg. hw275 G12 (dep 7886def2e61c63aa, 2026-07-19): after a CLEAN forward
+# promote (region-B writable TL2, latched), recovering region-A did NOT
+# converge — region-A resumed its OLD TL1 primary role (it never knew it was
+# killed), region-B could never re-stream ("highest timeline 1 of the primary
+# is behind recovery timeline 2" walreceiver FATAL every 5s, forever), and the
+# HR stayed suspend-latched: cross-region replication permanently dead, no
+# actor anywhere owned the failback. FOUR pieces:
+# (1) LATCH DURABILITY (root cause of the observed re-demote): every actor
+#     write now uses a CUSTOM --field-manager (dr-promoter / dr-failback).
+#     kustomize-controller's managed-fields cleanup REPLACES kubectl-prefixed
+#     managers with itself on EVERY reconcile and drops the claimed fields
+#     absent from its manifest — hw275 live-proof: kustomize Apply 06:55:20
+#     stripped spec.suspend → helm redeployed reverted values 06:55:23 (the
+#     mid-recovery RE-DEMOTE, release v4) → self-heal re-latched 06:55:27; 19
+#     re-latches in 30 min; the HR's dr-auto-promoted-at annotation was
+#     stripped the same way. Custom managers are not in the cleanup list
+#     (live precedent: catalyst-api's substitute flips persist).
+# (2) DURABLE HANDOFF + LATCH LIFT: the suspend latch stays the mid-outage
+#     mechanism (helm-only, no source dependency), but once the promotion is
+#     latched+rendered the actor writes it into the SOURCE — bootstrap-kit
+#     Kustomization postBuild.substitute SOVEREIGN_CNPG_PAIR_PROMOTED="true"
+#     (slot 16b renders `promoted: ${SOVEREIGN_CNPG_PAIR_PROMOTED:-false}`) —
+#     verifies the HR renders promoted=true, then UNSUSPENDS. Drift-correction
+#     now RE-AFFIRMS the promotion and flux is fully reconciled again (no
+#     forever-frozen HR). Self-heal re-latches if the substitute is ever lost.
+# (3) TL-AHEAD RE-PROMOTE (state-X recovery, the #5220-B wedge made
+#     actionable): a standby whose OWN timeline is strictly HIGHER than its
+#     reachable source's (IDENTIFY_SYSTEM arithmetic — readable by
+#     streaming_replica via the replication protocol, no pg_control privileges)
+#     holds every acknowledged commit (pre-divergence it was the mandatory
+#     remote_apply sync target; post-divergence the lower-TL side is
+#     write-fenced by its unsatisfiable FIRST 1). The promoter re-promotes it
+#     through the substitute seam — bypassing the #5220 arm gate (a TL-ahead
+#     standby can never stream, so it could never arm; the TL arithmetic is a
+#     strictly stronger proof no link flap can manufacture), max once per pod
+#     lifetime, never after /shared/diverged (the hw266 runaway guard holds).
+# (4) dr-failback ACTOR (side=primary, NEW): detects the post-failover
+#     geometry from region-A — local writable on TL n + the pinned sync
+#     standby ABSENT + the peer REACHABLE, WRITABLE and on a HIGHER timeline
+#     over the NEW `-replica-mesh` global Service (reverse mirror of
+#     `-primary-mesh`: CNPG-managed rw Service on the replica Cluster + a
+#     zero-backend stub on cluster-A) — then demotes + RE-CLONES region-A onto
+#     region-B's line: flips substitute SOVEREIGN_CNPG_PAIR_DEMOTED="true"
+#     (slot 16b → `primary.demoted`), waits for kustomize to render, and
+#     deletes the stale Cluster CR so helm re-creates it as a pg_basebackup
+#     replica of region-B (primary-cluster.yaml demoted shape: replica cluster
+#     + externalCluster over `-replica-mesh`, synchronous block omitted).
+#     Direction is fixed by the data: sync remote_apply + FIRST 1 pinned +
+#     dataDurability:required means region-B ⊇ every acked commit region-A
+#     ever made (post-recovery region-A is write-fenced by the same
+#     unsatisfiable FIRST 1) — only never-acked WAL is discarded, which RPO=0
+#     already discards; re-cloning region-B from region-A would destroy acked
+#     post-promote writes and is never automatic. pg_rewind is deliberately
+#     not used (no CNPG cross-cluster trigger; basebackup is deterministic for
+#     every WAL-tail geometry). Destruction is bounded: delete only the
+#     resourceNames-pinned Cluster CR (PVCs owner-GC), only with a <60s-fresh
+#     peer-writable-and-ahead proof, and a fresh clone is NEVER deleted (wedge
+#     escalation only re-clones a CR predating the failback episode). AUTH:
+#     the rejoin stream + peer probe present region-A's own
+#     `-primary-replication` cert, accepted by region-B because the replica
+#     Cluster now pins certificates.clientCASecret to the SHARED `-primary-ca`
+#     (already synced A→B with ca.key at the post-mesh flip, live-verified
+#     hw275; CNPG generates `<replica>-replication` from a BYO client CA when
+#     replicationTLSSecret is unset — cluster_pki.go — so every existing
+#     consumer keeps its mounts).
+# End state after a kill+recover cycle: region-B primary / region-A streaming
+# replica, both HRs unsuspended, desired state at the source. The controlled
+# switchback to original roles stays a sovereign-admin action (RUNBOOKS §6.1).
+# Forward-path gates ALL unchanged: #5220 arm gate, #5239 readable signals,
+# #5218 same-tick latch, 120s hold, pg_isready gate, startup grace, sync-only
+# fence. New values: primary.demoted, primary.failback.{enabled,intervalSeconds,
+# peerAheadHoldSeconds,startupGraceSeconds,livenessProbeTimeoutSeconds,
+# wedgeHoldSeconds,kustomization,hr,kubectlImage},
+# replica.autoPromote.kustomization. Side=primary gains the `-replica-mesh`
+# stub Service always (+1) and the dr-failback stack when peers are wired
+# (+7). Validation REQUIRES a fresh 2-region prov kill+recover G12 (the
+# failback only reproduces via a real kill + os-start recovery). Lockstep slot
+# 16b pin → 0.2.18.
 # 0.2.17 (#5239): dr-promoter ARM GATE never armed — the #5220 steady-state arm
 # gate detected "streaming" via `pg_stat_wal_receiver WHERE status = 'streaming'`,
 # but the signals container authenticates as `streaming_replica` (client cert),
@@ -172,7 +251,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.17
+version: 0.2.18
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -212,6 +291,61 @@ description: |
 
   Changelog
   ─────────
+  0.2.18 (2026-07-19, region-kill FAILBACK — demote+re-clone region-A onto the promoted line, durable handoff, TL-ahead re-promote, Refs #5245)
+    - FIX (Pillar-3 region-kill DR, the missing return leg): on hw275 G12 the
+      forward promote was CLEAN (region-B TL2, armed, latched) but recovering
+      region-A did not converge: region-A resumed its old TL1 primary role,
+      region-B FATAL-looped ("highest timeline 1 of the primary is behind
+      recovery timeline 2"), the HR stayed suspend-latched — cross-region
+      replication permanently dead with no owner.
+    - LATCH DURABILITY (observed root cause of the mid-recovery re-demote):
+      every actor write now carries a CUSTOM --field-manager. kustomize-
+      controller's managed-fields cleanup claims kubectl-prefixed managers on
+      every reconcile and strips their fields (hw275: suspend stripped
+      06:55:20 → helm re-demoted 06:55:23 → re-latch 06:55:27, ×19) — custom
+      managers survive it (catalyst-api substitute-flip precedent).
+    - DURABLE HANDOFF + LATCH LIFT: once the promotion is latched+rendered the
+      promoter writes SOVEREIGN_CNPG_PAIR_PROMOTED="true" into the
+      bootstrap-kit Kustomization postBuild.substitute, verifies the HR
+      renders promoted=true from source, then UNSUSPENDS — flux reconciles
+      again, drift-correction re-affirms the promotion. Self-heal re-latches
+      if the substitute is ever lost.
+    - TL-AHEAD RE-PROMOTE: the #5220-B divergence wedge is now actionable —
+      a standby whose own timeline exceeds its reachable source's
+      (IDENTIFY_SYSTEM arithmetic, streaming_replica-readable) is re-promoted
+      through the substitute seam (bypasses the arm gate: a TL-ahead standby
+      can never stream; the arithmetic is a stronger proof than the streaming
+      heuristic). Max once per pod lifetime; the /shared/diverged runaway
+      guard holds.
+    - NEW dr-failback actor (side=primary, sync-mode + peers-wired only):
+      detects local-writable-TL-n + pinned-sync-standby-absent + peer
+      writable on a HIGHER timeline over the new `-replica-mesh` global
+      Service, holds the proof 120s, flips SOVEREIGN_CNPG_PAIR_DEMOTED=
+      "true", waits for the source-rendered demotion, then deletes the stale
+      Cluster CR so helm re-creates it as a pg_basebackup replica of
+      region-B. Bounded destruction: one resourceNames-pinned Cluster CR,
+      <60s-fresh peer proof required at the delete tick, fresh clones never
+      deleted (wedge escalation only re-clones a CR predating the episode).
+      Data direction fixed by the sync fence: region-B ⊇ every acked commit
+      region-A ever made — only never-acked WAL is discarded (the RPO=0
+      contract); the reverse re-clone would lose acked writes, never
+      automatic.
+    - Shared client CA: the replica Cluster pins certificates.clientCASecret
+      to `-primary-ca` (synced A→B with ca.key at the post-mesh flip), so
+      region-A's own `-primary-replication` cert authenticates against
+      region-B (CNPG keeps generating `<replica>-replication` from the BYO
+      CA — existing consumers unchanged). Reverse-direction mesh path: the
+      replica Cluster publishes `-replica-mesh` (managed additional Service,
+      selectorType rw) + a zero-backend stub on side=primary.
+    - PRESERVED: #5220 arm gate, #5239 readable signals, #5218 same-tick
+      latch + self-heal, 120s primaryDownHold, pg_isready liveness gate,
+      startup grace, sync-only fence, #5125-D1 no-live-CR-patch doctrine.
+    - Resource deltas: side=primary +1 always (`-replica-mesh` stub Service),
+      +7 when crossRegionPeerClusters wired (dr-failback SA/2×Role/2×RB/CNP/
+      Deployment). side=replica unchanged. Render Case 19 pins the gating,
+      the demoted shape, the substitute seams, the field managers, and the
+      no-PVC-verb RBAC. Lockstep slot 16b pin → 0.2.18. Live validation
+      REQUIRES a fresh 2-region prov kill+recover G12.
   0.2.16 (2026-07-19, dr-promoter FALSE-POSITIVE fix — steady-state ARM gate + timeline-divergence surfacing, Refs #5220)
     - FIX (Pillar-3 region-kill DR): on hw273 G12 the 0.2.15 promoter
       FALSE-PROMOTED region-B during a transient region-A unreachability

--- a/platform/cnpg-pair/chart/templates/_helpers.tpl
+++ b/platform/cnpg-pair/chart/templates/_helpers.tpl
@@ -161,3 +161,54 @@ directly to the right object) rather than as a standalone template.
 {{- define "cnpg-pair.replicationServiceName" -}}
 {{- printf "%s-primary-mesh" (include "cnpg-pair.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end }}
+
+{{/*
+Peer replication Service name (#5245) — the REVERSE-direction mesh
+alias: region-A reaches region-B's writable (promoted) primary through
+`<fullname>-replica-mesh`. Declared via the replica Cluster CR's
+`spec.managed.services.additional` (selectorType rw — B's designated
+primary) on side=replica, plus a zero-backend local stub on
+side=primary (Cilium merges global services by name+namespace; without
+the stub the name is NXDOMAIN on cluster-A). Consumed by the
+dr-failback actor's peer probe and by the demoted primary Cluster's
+externalCluster (the region-A rejoin stream).
+*/}}
+{{- define "cnpg-pair.peerReplicationServiceName" -}}
+{{- printf "%s-replica-mesh" (include "cnpg-pair.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Region-A automatic DR FAILBACK — active? (chart 0.2.18, #5245)
+
+TRUE only when ALL of:
+  - cnpgPair.enabled
+  - side=primary                 (the failback actor runs ON cluster-A —
+                                  by definition it only matters once
+                                  region-A is back)
+  - primary.failback.enabled     (operator gate; default TRUE, hasKey-
+                                  guarded like autoPromote)
+  - replication.mode == sync     (the SAME data fence that makes the
+                                  forward promote safe is what PROVES
+                                  region-B's line ⊇ region-A's acked
+                                  history — without it, discarding
+                                  region-A's timeline could lose
+                                  acknowledged commits)
+  - clusterMesh.enabled AND crossRegionPeerClusters non-empty
+                                 (the peer probe — psql of region-B over
+                                  `-replica-mesh` — is a HARD
+                                  requirement: without a positive
+                                  peer-writable-and-ahead proof the
+                                  actor has no safe action at all, so
+                                  it does not render. This mirrors the
+                                  dr-promoter's #5178 fail-safe, but
+                                  stricter: the promoter can observe
+                                  without peers; the failback cannot
+                                  even observe.)
+*/}}
+{{- define "cnpg-pair.failbackActive" -}}
+{{- $fb := .Values.cnpgPair.primary.failback | default dict -}}
+{{- $fbEnabled := true -}}
+{{- if hasKey $fb "enabled" }}{{- $fbEnabled = $fb.enabled -}}{{- end -}}
+{{- $peers := .Values.cnpgPair.networkPolicy.crossRegionPeerClusters | default list -}}
+{{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isPrimarySide" .) $fbEnabled (eq (.Values.cnpgPair.replication.mode | default "sync") "sync") .Values.cnpgPair.clusterMesh.enabled (gt (len $peers) 0) -}}true{{- end -}}
+{{- end }}

--- a/platform/cnpg-pair/chart/templates/dr-failback.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-failback.yaml
@@ -1,0 +1,708 @@
+{{- /*
+Region-A DR auto-FAILBACK (#5245 — chart 0.2.18).
+
+WHY THIS EXISTS
+---------------
+hw275 G12 (2026-07-19, dep 7886def2e61c63aa) proved the DR chain had a
+forward leg only. After a clean region-kill promote (region-B writable
+on TL2, latched), the recovery of region-A did NOT converge:
+
+  - region-A's primary Cluster resumed its OLD role — pg_is_in_recovery
+    =false, timeline 1. It never knew it was killed.
+  - region-B could never re-stream from it: a TL2 line cannot follow a
+    TL1 source — walreceiver FATAL 55000 "highest timeline 1 of the
+    primary is behind recovery timeline 2", every 5 seconds, forever.
+  - Nothing anywhere demoted region-A, re-cloned anyone, or lifted the
+    promote latch. Cross-region replication was permanently dead.
+
+This Deployment is the region-A actor that closes the loop. It renders
+ONLY on side=primary (it acts on cluster-A, which by definition exists
+again exactly when failback matters) and ONLY when the cross-region
+peer probe can be wired (clusterMesh + crossRegionPeerClusters — see
+cnpg-pair.failbackActive; without a positive peer proof there is no
+safe action, so the actor does not render at all).
+
+WHAT IT DOES — demote + re-clone region-A onto region-B's line
+--------------------------------------------------------------
+The correct failback direction is fixed by the data, not by preference:
+region-B's promoted line ⊇ every ACKNOWLEDGED commit region-A ever
+made. Structurally: sync remote_apply + FIRST 1 pinned to the
+cross-region replica + dataDurability:required means (a) before the
+kill, no commit was acked on A that B had not already applied; (b) the
+dead window adds nothing; (c) post-recovery region-A is write-fenced by
+the same unsatisfiable FIRST 1 (its only allowed sync standby has left
+the timeline), so it acks nothing new. Discarding region-A's line loses
+only never-acked local WAL — exactly what the RPO=0 contract already
+discards. The reverse direction (re-cloning region-B from region-A)
+would destroy the acknowledged post-promote writes and is therefore
+never automatic. This is why the actor renders only in sync mode: the
+fence IS the authority proof.
+
+  1. DETECT (signals container, psql as streaming_replica with this
+     cluster's own client cert): local cluster WRITABLE (in_recovery=f)
+     on timeline N, the pinned sync standby ABSENT from
+     pg_stat_replication (walsender rows run AS streaming_replica, so
+     the probe role sees its own rows — no #5239 privilege trap), AND
+     the peer REACHABLE + WRITABLE + on a HIGHER timeline over the
+     `-replica-mesh` global Service. Timelines come from IDENTIFY_SYSTEM
+     over a replication-protocol connection — the one surface
+     streaming_replica is guaranteed to have (pg_hba `hostssl
+     replication streaming_replica all cert`), no pg_control privileges
+     involved. TL_peer > TL_local is antisymmetric: only the stale side
+     can ever see peer-ahead, so two actors can never both act.
+  2. DECIDE (actor container): the peer-ahead evidence must hold
+     CONTINUOUSLY for failback.peerAheadHoldSeconds (120s), never
+     during the startup grace.
+  3. DEMOTE — durable, through the SOURCE: patch the bootstrap-kit
+     Kustomization's postBuild.substitute SOVEREIGN_CNPG_PAIR_DEMOTED=
+     "true" (custom field manager `dr-failback`; see LATCH-DURABILITY
+     below) and wait for kustomize to render `primary.demoted: true`
+     into the HR desired state. From that moment flux itself re-affirms
+     the demotion — no suspend latch is needed on this side, and the
+     hazard window of the b-side promote path (values revert → wrong
+     shape re-render) cannot exist here.
+  4. RE-CLONE — the ONE destructive act: delete the local Cluster CR
+     (PVCs are CNPG-owned and garbage-collect with it) so helm
+     re-creates it in the demoted shape and pg_basebackup clones
+     region-B's current timeline. Guarded per-tick: desired state
+     RENDERED + peer verified writable-and-ahead within the last probe
+     window + the CR still in its OLD primary shape. A Cluster CR
+     already in the demoted shape is deleted ONLY via the wedge
+     escalation (below) and ONLY when it predates this failback episode
+     — a fresh clone is NEVER deleted, so destruction is bounded to one
+     re-clone per episode.
+  5. CONVERGE: the re-cloned cluster streams from region-B
+     (walreceiver row + receive-LSN — the #5239-readable signal); the
+     actor records dr-failback-converged-at on the HR and goes idle.
+
+WEDGE ESCALATION (in-place demote left a stale standby)
+-------------------------------------------------------
+If the CNPG webhook admits the shape change on the LIVE Cluster before
+the delete lands, CNPG demotes it in place, keeping the stale TL-N
+PGDATA. If that standby's WAL tail is past the fork point it can never
+follow region-B (the mirrored FATAL wedge). The actor escalates to the
+re-clone when a demoted-shape CR that PREDATES the failback episode
+(creationTimestamp < dr-failback-started-at) has been unable to stream
+from a verified writable+ahead peer for failback.wedgeHoldSeconds. If
+the tail happened to be exactly at the fork, the in-place demote
+follows cleanly instead and no re-clone happens at all — cheapest path
+wins automatically.
+
+LATCH-DURABILITY (#5245 root-cause, shared with dr-promoter)
+------------------------------------------------------------
+kustomize-controller's server-side-apply cleanup REPLACES every field
+manager matching the `kubectl` prefix (kubectl-patch, kubectl-edit, …)
+with itself on EVERY reconcile of the applying Kustomization, then
+drops the claimed fields absent from its manifest (fluxcd
+kustomization_controller.go managed-fields cleanup — its documented
+"undo kubectl drift" behavior). hw275 live-proved this is what
+re-demoted the promoted survivor mid-recovery: kustomize Apply
+06:55:20 stripped the #5219 suspend latch, helm redeployed the
+reverted values 06:55:23 (release v4 — the re-demote), the promoter's
+self-heal re-latched 06:55:27, and the war repeated every reconcile
+(19 re-latches in 30 min; the HR's foreign annotations were stripped
+the same way). Custom field managers (`dr-failback`, `dr-promoter`)
+are NOT in that cleanup list, and the Kustomization CR itself is
+applied once by cloud-init (kubectl-client-side-apply, never
+re-applied) — the catalyst-api substitute flip
+(SOVEREIGN_ENABLE_CNPG_PAIR, manager `catalyst-api`) is the live-
+proven precedent that such patches persist. Every write this actor
+makes uses --field-manager=dr-failback.
+
+WHY A DEPLOYMENT, NOT A CronJob (#5157)
+---------------------------------------
+Same delivery contract as the dr-promoter: a region-local DR actor is
+a continuous Deployment loop; a CronJob's scheduler is the regional
+control plane and does not reliably resume around region churn.
+
+WHAT IT NEVER DOES
+------------------
+Never patches a live Cluster CR (#5125-D1 — drift-correction reverts
+it). Never deletes PVCs directly (owner-GC only), never any object but
+the one resourceNames-pinned Cluster CR. Never acts when the peer is
+unreachable, in recovery, or on an equal/lower timeline — a mere mesh
+partition, a healthy pair, or the pre-promote outage window all read
+as "no peer-ahead proof" and clear the hold clock. Never re-promotes
+region-B (that is the dr-promoter's TL-ahead re-promote, on
+cluster-B).
+*/ -}}
+{{- if (include "cnpg-pair.failbackActive" .) }}
+{{- $fb := .Values.cnpgPair.primary.failback }}
+{{- $hr := $fb.hr | default dict }}
+{{- $hrName := $hr.name | default "bp-cnpg-pair" }}
+{{- $hrNamespace := $hr.namespace | default "flux-system" }}
+{{- $ks := $fb.kustomization | default dict }}
+{{- $ksName := $ks.name | default "bootstrap-kit" }}
+{{- $ksNamespace := $ks.namespace | default "flux-system" }}
+{{- $kimg := $fb.kubectlImage | default dict }}
+{{- $krepo := $kimg.repository | default "harbor.openova.io/proxy-dockerhub/alpine/k8s" }}
+{{- $ktag := $kimg.tag | default "1.30.0" }}
+{{- $kpull := $kimg.pullPolicy | default "IfNotPresent" }}
+{{- $interval := $fb.intervalSeconds | default 10 }}
+{{- $hold := $fb.peerAheadHoldSeconds | default 120 }}
+{{- $startupGrace := $fb.startupGraceSeconds | default 300 }}
+{{- $probeTimeout := $fb.livenessProbeTimeoutSeconds | default 5 }}
+{{- $wedgeHold := $fb.wedgeHoldSeconds | default 600 }}
+{{- $peerClusters := .Values.cnpgPair.networkPolicy.crossRegionPeerClusters | default list }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+    catalyst.openova.io/role: dr-failback
+---
+# Local-namespace surface: get + delete on EXACTLY the primary Cluster
+# CR (the bounded re-clone). No patch (live-CR patches are the #5125-D1
+# anti-pattern), no PVC verbs (owner-GC does the storage), no list.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+rules:
+  - apiGroups: [postgresql.cnpg.io]
+    resources: [clusters]
+    verbs: [get, delete]
+    resourceNames: [{{ include "cnpg-pair.primaryName" . }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+    namespace: {{ .Release.Namespace }}
+---
+# flux-system surface: the HR (annotations + reconcile nudges) and the
+# Kustomization (the durable SOVEREIGN_CNPG_PAIR_DEMOTED substitute) —
+# both resourceNames-pinned, get+patch only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+rules:
+  - apiGroups: [helm.toolkit.fluxcd.io]
+    resources: [helmreleases]
+    verbs: [get, patch]
+    resourceNames: [{{ $hrName }}]
+  - apiGroups: [kustomize.toolkit.fluxcd.io]
+    resources: [kustomizations]
+    verbs: [get, patch]
+    resourceNames: [{{ $ksName }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+    namespace: {{ .Release.Namespace }}
+---
+# Egress allow-list (one CNP, #4428 idiom): apiserver (kubectl) +
+# kube-dns + the local primary cluster's 5432 (signals psql) + the
+# peer replica cluster's 5432 across the ClusterMesh (the peer probe —
+# same #4846 identity-scoped shape as the dr-promoter's region-A leg).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback-egress
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      catalyst.openova.io/role: dr-failback
+      catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "cnpg-pair.primaryName" . }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Peer probe path — region-B's replica Cluster Pods over the mesh.
+    # Cross-region ClusterMesh endpoints carry their OWN pod identity;
+    # a plain toEndpoints is implicitly ANDed with the LOCAL cluster
+    # (#4846), so admit the peer cluster(s) explicitly.
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "cnpg-pair.replicaName" . }}
+          matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-dr-failback
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+    catalyst.openova.io/role: dr-failback
+  annotations:
+    catalyst.openova.io/blueprint: bp-cnpg-pair
+spec:
+  replicas: 1
+  # Single actor; never two failback loops at once (#5157 shape).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "cnpg-pair.selectorLabels" . | nindent 6 }}
+      catalyst.openova.io/role: dr-failback
+  template:
+    metadata:
+      labels:
+        {{- include "cnpg-pair.selectorLabels" . | nindent 8 }}
+        catalyst.openova.io/role: dr-failback
+        catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+        # kyverno cilium-l7-mtls (Enforce) — required on the Pod
+        # template or the Deployment is DENIED at admission (#3238).
+        policy.cilium.io/enforced: "true"
+    spec:
+      # The actor runs in the primary region — the half being rejoined.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: openova.io/region
+                    operator: In
+                    values: [{{ .Values.cnpgPair.primary.region | quote }}]
+      serviceAccountName: {{ include "cnpg-pair.fullname" . }}-dr-failback
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 26
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        # ── signals — post-failover-geometry detector ─────────────────
+        # psql (streaming_replica client cert — this cluster's own
+        # `-primary-replication`, the #5133 auth pattern) against the
+        # LOCAL `-rw` plus the PEER probe over `-replica-mesh`. The
+        # peer psql presents the SAME local cert: region-B accepts it
+        # because its client CA is pinned to the shared `-primary-ca`
+        # (replica-cluster.yaml #5245). Timelines via IDENTIFY_SYSTEM
+        # on replication-protocol connections (pg_hba `hostssl
+        # replication streaming_replica all cert` — no pg_control /
+        # pg_read_all_stats privileges involved, #5239 lesson).
+        - name: signals
+          image: {{ include "cnpg-pair.imageRef" . | quote }}
+          imagePullPolicy: {{ .Values.cnpgPair.image.pullPolicy | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              LOCAL_CONN="host={{ include "cnpg-pair.primaryName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              PEER_CONN="host=${PEER_MESH_HOST} port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              # Replication-protocol conninfo for IDENTIFY_SYSTEM (the
+              # timeline read every streaming_replica can perform).
+              LOCAL_REPL="host={{ include "cnpg-pair.primaryName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key replication=true"
+              PEER_REPL="host=${PEER_MESH_HOST} port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key replication=true"
+              # LOCAL state ladder — mirrors the dr-promoter's #5239-readable
+              # signals: 'primary' (writable), 'streaming' (standby with a live
+              # walreceiver row + a set receive-LSN), 'receiving' (row, no WAL
+              # yet), 'noreceiver' (standby, no stream), 'unknown' (probe
+              # failed — fail-safe).
+              LQ="SELECT CASE
+                WHEN NOT pg_is_in_recovery() THEN 'primary'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) AND pg_last_wal_receive_lsn() IS NOT NULL THEN 'streaming'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'
+                ELSE 'noreceiver'
+              END"
+              # Pinned sync standby present? The walsender rows run AS
+              # streaming_replica, so this probe role sees its own rows in
+              # full (no #5239 NULLing for same-user rows) — and row
+              # ABSENCE, the signal that matters, is visible to everyone.
+              SQ="SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_stat_replication WHERE application_name = '{{ include "cnpg-pair.replicaName" . }}') THEN 'present' ELSE 'absent' END"
+              # IDENTIFY_SYSTEM row: systemid | timeline | xlogpos | dbname
+              tl_of() {
+                psql "$1" -tAXc "IDENTIFY_SYSTEM" 2>/dev/null | head -1 | cut -d'|' -f2
+              }
+              is_int() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+              STARTED=$(date -u +%s)
+              echo "[dr-failback/signals] loop started (interval=${INTERVAL_SECONDS}s startupGrace=${STARTUP_GRACE_SECONDS}s peerMeshHost=${PEER_MESH_HOST})"
+              clear_hold() {
+                if [ -f /shared/peer-ahead-since ]; then
+                  echo "$(date -u +"%FT%TZ") [dr-failback/signals] $1 — peer-ahead hold clock cleared"
+                fi
+                rm -f /shared/peer-ahead-since
+              }
+              clear_wedge() { rm -f /shared/wedge-since; }
+              # probe_peer_ahead <tl_local> — verifies peer REACHABLE +
+              # WRITABLE + TL strictly higher; on success touches the
+              # freshness marker the actor re-checks before EVERY
+              # destructive step. Any failure → non-zero (caller clears).
+              probe_peer_ahead() {
+                _tl_local="$1"
+                pg_isready -h "${PEER_MESH_HOST}" -p 5432 -t "${PROBE_TIMEOUT}" -q || return 1
+                _rec=$(psql "${PEER_CONN}" -tAXc "SELECT pg_is_in_recovery()" 2>/dev/null || echo "err")
+                [ "${_rec}" = "f" ] || return 1
+                _tl_peer=$(tl_of "${PEER_REPL}")
+                is_int "${_tl_peer}" || return 1
+                [ "${_tl_peer}" -gt "${_tl_local}" ] || return 1
+                echo "${_tl_peer}" > /shared/tl-peer
+                : > /shared/peer-ahead-fresh
+                return 0
+              }
+              while true; do
+                : > /shared/signals-alive
+                STATE=$(psql "${LOCAL_CONN}" -tAXc "${LQ}" 2>/dev/null || echo "unknown")
+                NOW=$(date -u +%s)
+                echo "${STATE}" > /shared/local-state
+                if [ "$((NOW - STARTED))" -lt "${STARTUP_GRACE_SECONDS}" ]; then
+                  clear_hold "startup grace ($((NOW - STARTED))s<${STARTUP_GRACE_SECONDS}s, state=${STATE})"
+                  clear_wedge
+                  sleep "${INTERVAL_SECONDS}"; continue
+                fi
+                case "${STATE}" in
+                  primary)
+                    clear_wedge
+                    SYNC=$(psql "${LOCAL_CONN}" -tAXc "${SQ}" 2>/dev/null || echo "err")
+                    if [ "${SYNC}" != "absent" ]; then
+                      # Standby streaming from us (or probe failed) — the pair
+                      # is healthy (or unknowable): fail-safe, no failback.
+                      clear_hold "local primary with sync standby ${SYNC}"
+                      sleep "${INTERVAL_SECONDS}"; continue
+                    fi
+                    TL_LOCAL=$(tl_of "${LOCAL_REPL}")
+                    if ! is_int "${TL_LOCAL}"; then
+                      clear_hold "local timeline unreadable — fail-safe"
+                      sleep "${INTERVAL_SECONDS}"; continue
+                    fi
+                    echo "${TL_LOCAL}" > /shared/tl-local
+                    if probe_peer_ahead "${TL_LOCAL}"; then
+                      if [ ! -f /shared/peer-ahead-since ]; then
+                        echo "${NOW}" > /shared/peer-ahead-since
+                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] POST-FAILOVER GEOMETRY: local writable TL=${TL_LOCAL}, sync standby ABSENT, peer WRITABLE on TL=$(cat /shared/tl-peer) (> local) — peer-ahead hold clock started (#5245)"
+                      fi
+                    else
+                      clear_hold "peer not provably writable+ahead (unreachable / in recovery / TL<=local)"
+                    fi
+                    ;;
+                  streaming)
+                    # Demoted + streaming from region-B — converged.
+                    clear_hold "local standby streaming (converged)"
+                    clear_wedge
+                    : > /shared/converged-streaming
+                    ;;
+                  receiving|noreceiver)
+                    # A local standby that is NOT streaming. If the peer is
+                    # provably writable+ahead this is the in-place-demote
+                    # wedge candidate (stale TL-N PGDATA that cannot follow) —
+                    # accrue the wedge clock for the actor's escalation.
+                    clear_hold "local standby state=${STATE}"
+                    rm -f /shared/converged-streaming
+                    TL_LOCAL=$(tl_of "${LOCAL_REPL}")
+                    if is_int "${TL_LOCAL}" && probe_peer_ahead "${TL_LOCAL}"; then
+                      if [ ! -f /shared/wedge-since ]; then
+                        echo "${NOW}" > /shared/wedge-since
+                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] local standby cannot stream (state=${STATE}) while peer is writable+ahead — wedge clock started (#5245 escalation)"
+                      fi
+                    else
+                      clear_wedge
+                    fi
+                    ;;
+                  unknown|*)
+                    # Local probe failed — mid-re-clone (no endpoints) or an
+                    # unhealthy local cluster. Fail-safe: no evidence accrues.
+                    clear_hold "local state unknown (probe failed — fail-safe)"
+                    clear_wedge
+                    rm -f /shared/converged-streaming
+                    ;;
+                esac
+                sleep "${INTERVAL_SECONDS}"
+              done
+          env:
+            - name: PGCONNECT_TIMEOUT
+              value: "5"
+            - name: PEER_MESH_HOST
+              value: {{ include "cnpg-pair.peerReplicationServiceName" . | quote }}
+            - name: PROBE_TIMEOUT
+              value: {{ $probeTimeout | quote }}
+            - name: STARTUP_GRACE_SECONDS
+              value: {{ $startupGrace | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/signals-alive && test -z \"$(find /shared/signals-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/signals-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsUser: 26   # postgres in upstream cnpg image
+            runAsGroup: 26
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+            - name: replication-cert
+              mountPath: /tls/client
+              readOnly: true
+        # ── actor — demote (substitute) + bounded re-clone ────────────
+        # Every write carries --field-manager=dr-failback (survives the
+        # kustomize kubectl-manager cleanup — the #5245 root cause).
+        # Each tick runs in a subshell; every step is guarded by
+        # live-observed state, so the loop is idempotent and resumes
+        # from any crash point.
+        - name: actor
+          image: {{ printf "%s:%s" $krepo $ktag | quote }}
+          imagePullPolicy: {{ $kpull | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              FM="--field-manager=dr-failback"
+              echo "[dr-failback/actor] loop started (hold=${HOLD_SECONDS}s wedgeHold=${WEDGE_HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME} kustomization=${KS_NAMESPACE}/${KS_NAME})"
+              # nudge <kind> <ns> <name> <marker> — rate-limited flux
+              # reconcile request (reconcile.fluxcd.io/requestedAt).
+              nudge() {
+                if [ ! -f "/shared/$4" ] || [ -n "$(find "/shared/$4" -mmin +1)" ]; then
+                  kubectl -n "$2" annotate "$1" "$3" "reconcile.fluxcd.io/requestedAt=$(date -u +%s)" --overwrite ${FM} >/dev/null 2>&1 || true
+                  : > "/shared/$4"
+                fi
+              }
+              # peer_fresh — the signals container re-verified the peer
+              # writable+ahead within the last 60s (it re-probes every
+              # tick, ~10s). Required before EVERY destructive step (a
+              # stale proof is no proof). POSIX find only (-mmin integer:
+              # busybox-safe).
+              peer_fresh() {
+                [ -f /shared/peer-ahead-fresh ] && [ -z "$(find /shared/peer-ahead-fresh -mmin +1 2>/dev/null)" ]
+              }
+              # ts_lt <a> <b> — RFC3339-UTC lexicographic a < b (POSIX;
+              # no `[ \< ]` bashism).
+              ts_lt() {
+                [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort | head -1)" = "$1" ]
+              }
+              while true; do
+                : > /shared/actor-alive
+                (
+                  set -eu
+                  SUB=$(kubectl -n "${KS_NAMESPACE}" get kustomization "${KS_NAME}" -o jsonpath='{.spec.postBuild.substitute.SOVEREIGN_CNPG_PAIR_DEMOTED}' 2>/dev/null || echo "")
+                  VALS_DEMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.cnpgPair.primary.demoted}' 2>/dev/null || echo "")
+                  CR_JSON=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" -o jsonpath='{.spec.replica.enabled}|{.metadata.creationTimestamp}|{.metadata.deletionTimestamp}' 2>/dev/null || echo "__absent__")
+                  STARTED_AT=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.metadata.annotations.catalyst\.openova\.io/dr-failback-started-at}' 2>/dev/null || echo "")
+
+                  # ── CONVERGED — record once, then idle ────────────────
+                  if [ -f /shared/converged-streaming ] && [ "${VALS_DEMOTED}" = "true" ] && [ ! -f /shared/converged-recorded ]; then
+                    if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-converged-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1; then
+                      : > /shared/converged-recorded
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] CONVERGED: region-A re-cloned and streaming from region-B — recorded dr-failback-converged-at on HR ${HR_NAMESPACE}/${HR_NAME}. Cross-region replication restored, roles swapped; the controlled switchback (demote region-B, restore region-A primary) is the sovereign-admin's RUNBOOKS §6.1 action (#5245)"
+                    fi
+                    exit 0
+                  fi
+
+                  # ── D0: DECIDE — flip the durable demotion substitute ─
+                  if [ "${SUB}" != "true" ]; then
+                    [ -f /shared/peer-ahead-since ] || exit 0
+                    SINCE=$(cat /shared/peer-ahead-since)
+                    NOW=$(date -u +%s)
+                    HELD=$((NOW - SINCE))
+                    if [ "${HELD}" -lt "${HOLD_SECONDS}" ]; then
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] peer writable+ahead held ${HELD}s < ${HOLD_SECONDS}s — waiting"
+                      exit 0
+                    fi
+                    peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] hold expired but peer proof is stale — re-verifying next tick (fail-safe)"; exit 0; }
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] DEMOTING region-A: peer writable on TL=$(cat /shared/tl-peer 2>/dev/null || echo '?') > local TL=$(cat /shared/tl-local 2>/dev/null || echo '?') held ${HELD}s — patching Kustomization substitute SOVEREIGN_CNPG_PAIR_DEMOTED=true (durable source seam, #5245)"
+                    kubectl -n "${KS_NAMESPACE}" patch kustomization "${KS_NAME}" --type merge ${FM} -p '{"spec":{"postBuild":{"substitute":{"SOVEREIGN_CNPG_PAIR_DEMOTED":"true"}}}}'
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-started-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-failback-reason\":\"region-A resumed stale TL$(cat /shared/tl-local 2>/dev/null || echo '?') primary while region-B is writable on TL$(cat /shared/tl-peer 2>/dev/null || echo '?'); demoting + re-cloning region-A onto region-B's line (#5245)\"}}}" >/dev/null 2>&1 || true
+                    nudge kustomization "${KS_NAMESPACE}" "${KS_NAME}" nudged-ks
+                    exit 0
+                  fi
+
+                  # ── D1: WAIT for kustomize to render the demotion ─────
+                  if [ "${VALS_DEMOTED}" != "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] substitute set but HR values not yet rendered (demoted='${VALS_DEMOTED}') — waiting for kustomize-controller"
+                    nudge kustomization "${KS_NAMESPACE}" "${KS_NAME}" nudged-ks
+                    exit 0
+                  fi
+
+                  # ── D2: RE-CLONE — the one bounded destructive act ────
+                  if [ "${CR_JSON}" = "__absent__" ]; then
+                    # Deleted (by us) or not yet re-created — nudge helm to
+                    # render the demoted shape promptly.
+                    nudge helmrelease "${HR_NAMESPACE}" "${HR_NAME}" nudged-hr
+                    exit 0
+                  fi
+                  CR_REPLICA=$(echo "${CR_JSON}" | cut -d'|' -f1)
+                  CR_CREATED=$(echo "${CR_JSON}" | cut -d'|' -f2)
+                  CR_DELETING=$(echo "${CR_JSON}" | cut -d'|' -f3)
+                  if [ -n "${CR_DELETING}" ]; then
+                    exit 0   # teardown in progress — wait
+                  fi
+                  if [ "${CR_REPLICA}" != "true" ]; then
+                    # Still the OLD primary shape with the stale timeline.
+                    peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] demotion rendered but peer proof stale — NOT deleting (fail-safe)"; exit 0; }
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONING: deleting stale Cluster ${PRIMARY_CLUSTER} (old primary shape, TL=$(cat /shared/tl-local 2>/dev/null || echo '?')) — helm re-creates it as a pg_basebackup replica of region-B; PVCs are CNPG-owned and garbage-collect (#5245)"
+                    kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
+                    exit 0
+                  fi
+                  # Demoted shape exists. A CR created BEFORE the failback
+                  # episode is an IN-PLACE demote keeping stale PGDATA — if it
+                  # cannot stream for wedgeHold while the peer stays provably
+                  # writable+ahead, escalate to the re-clone. A CR created
+                  # AFTER (a fresh clone) is NEVER deleted — bounded
+                  # destruction.
+                  if [ -n "${STARTED_AT}" ] && ts_lt "${CR_CREATED}" "${STARTED_AT}" && [ -f /shared/wedge-since ]; then
+                    WSINCE=$(cat /shared/wedge-since)
+                    NOW=$(date -u +%s)
+                    if [ "$((NOW - WSINCE))" -ge "${WEDGE_HOLD_SECONDS}" ]; then
+                      peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] wedge hold expired but peer proof stale — NOT deleting (fail-safe)"; exit 0; }
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] WEDGE ESCALATION: in-place-demoted Cluster (created ${CR_CREATED} < failback start ${STARTED_AT}) unable to stream $((NOW - WSINCE))s >= ${WEDGE_HOLD_SECONDS}s with peer writable+ahead — deleting for a clean re-clone (#5245)"
+                      kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
+                      kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
+                      exit 0
+                    fi
+                  fi
+                  # Fresh clone converging (or in-place demote following
+                  # cleanly) — let it stream; the CONVERGED block closes out.
+                  exit 0
+                ) || echo "[dr-failback/actor] tick returned non-zero — retry in ${INTERVAL_SECONDS}s"
+                sleep "${INTERVAL_SECONDS}"
+              done
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HR_NAME
+              value: {{ $hrName | quote }}
+            - name: HR_NAMESPACE
+              value: {{ $hrNamespace | quote }}
+            - name: KS_NAME
+              value: {{ $ksName | quote }}
+            - name: KS_NAMESPACE
+              value: {{ $ksNamespace | quote }}
+            - name: HOLD_SECONDS
+              value: {{ $hold | quote }}
+            - name: WEDGE_HOLD_SECONDS
+              value: {{ $wedgeHold | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+            - name: PRIMARY_CLUSTER
+              value: {{ include "cnpg-pair.primaryName" . | quote }}
+            # kubectl writes its discovery/http cache under $HOME.
+            - name: HOME
+              value: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/actor-alive && test -z \"$(find /shared/actor-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/actor-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: shared
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        # THIS primary cluster's own CNPG-issued streaming_replica client
+        # cert — 0440 root:26, the perms libpq requires for an sslkey
+        # (#5133). The SAME cert authenticates against region-B thanks to
+        # the shared client CA (replica-cluster.yaml #5245).
+        - name: replication-cert
+          secret:
+            secretName: {{ include "cnpg-pair.primaryName" . }}-replication
+            defaultMode: 0440
+{{- end }}

--- a/platform/cnpg-pair/chart/templates/dr-promoter.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-promoter.yaml
@@ -794,13 +794,20 @@ spec:
                       nudge_ks
                     fi
                   else
-                    if [ "${SUSPENDED}" = "true" ] && [ "${HR_PROMOTED}" = "true" ]; then
-                      if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-handoff-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":false}}" >/dev/null 2>&1; then
-                        echo "$(date -u +"%FT%TZ") [dr-promoter/actor] DURABLE HANDOFF (step 2/2): substitute in place and HR promoted=true — suspend latch LIFTED; flux reconciles the promoted desired state from source (#5245)"
-                      else
-                        echo "$(date -u +"%FT%TZ") [dr-promoter/actor] WARN: latch-lift patch failed — retrying next tick (#5245)"
+                    if [ "${SUSPENDED}" = "true" ]; then
+                      if [ "${HR_PROMOTED}" = "true" ]; then
+                        if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-handoff-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":false}}" >/dev/null 2>&1; then
+                          echo "$(date -u +"%FT%TZ") [dr-promoter/actor] DURABLE HANDOFF (step 2/2): substitute in place and HR promoted=true — suspend latch LIFTED; flux reconciles the promoted desired state from source (#5245)"
+                        else
+                          echo "$(date -u +"%FT%TZ") [dr-promoter/actor] WARN: latch-lift patch failed — retrying next tick (#5245)"
+                        fi
+                        exit 0
                       fi
-                      exit 0
+                      # Substitute set but the HR does not yet render
+                      # promoted=true — keep nudging kustomize (rate-limited)
+                      # so the handoff / TL-ahead re-promote converges within
+                      # the poll cadence instead of a full kustomize interval.
+                      nudge_ks
                     fi
                   fi
                   # 1. SELF-HEAL LATCH — keep an already-rendered promotion

--- a/platform/cnpg-pair/chart/templates/dr-promoter.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-promoter.yaml
@@ -54,8 +54,18 @@ So the actor makes the promotion durable by SUSPENDING the HR
 is NOT in slot 16b's manifest, so kustomize-controller does not own it and
 its drift-correction cannot remove it; a suspended HR freezes helm-
 controller, so even after kustomize reverts the atomic `spec.values` the
-promoted release is NOT re-rendered and the survivor stays writable. The
-operator un-suspends after re-cloning the stale side (RUNBOOKS §6.1).
+promoted release is NOT re-rendered and the survivor stays writable.
+#5245 CAVEATS on the 0.2.15–0.2.17 latch, both fixed here: (a) the latch
+was written with the default `kubectl-patch` field manager, which
+kustomize-controller's managed-fields cleanup CLAIMS AND STRIPS on every
+reconcile of the applying Kustomization (hw275: suspend stripped 06:55:20
+→ helm re-demoted the survivor 06:55:23 → self-heal re-latched 06:55:27,
+×19) — every write now uses `--field-manager=dr-promoter`, which the
+cleanup list does not match; (b) nothing ever LIFTED the latch — the
+DURABLE HANDOFF below moves the promotion into the bootstrap-kit
+Kustomization's postBuild.substitute (SOVEREIGN_CNPG_PAIR_PROMOTED) and
+then un-suspends, so the end state is a fully reconciled flux, not a
+frozen HR (RUNBOOKS §6.1).
 
 HOW IT DECIDES (region-B-local signals + a POSITIVE region-A probe)
 -------------------------------------------------------------------
@@ -150,6 +160,9 @@ tracked on #5137.)
 {{- $hr := $ap.hr | default dict }}
 {{- $hrName := $hr.name | default "bp-cnpg-pair" }}
 {{- $hrNamespace := $hr.namespace | default "flux-system" }}
+{{- $ks := $ap.kustomization | default dict }}
+{{- $ksName := $ks.name | default "bootstrap-kit" }}
+{{- $ksNamespace := $ks.namespace | default "flux-system" }}
 {{- $kimg := $ap.kubectlImage | default dict }}
 {{- $krepo := $kimg.repository | default "harbor.openova.io/proxy-dockerhub/alpine/k8s" }}
 {{- $ktag := $kimg.tag | default "1.30.0" }}
@@ -220,7 +233,11 @@ subjects:
 # The promotion surface: get (idempotence + suspend-state read) + patch
 # (merge-patch of spec.values.cnpgPair.replica.promoted AND, for the #5178
 # durable latch, spec.suspend) on EXACTLY the bp-cnpg-pair HelmRelease —
-# resourceNames-pinned, no list/create/delete.
+# resourceNames-pinned, no list/create/delete. #5245 adds the applying
+# Kustomization (get + patch, resourceNames-pinned): the DURABLE HANDOFF
+# writes the promotion into postBuild.substitute
+# SOVEREIGN_CNPG_PAIR_PROMOTED so kustomize itself renders the promoted
+# desired state, after which the suspend latch is LIFTED.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -234,6 +251,10 @@ rules:
     resources: [helmreleases]
     verbs: [get, patch]
     resourceNames: [{{ $hrName }}]
+  - apiGroups: [kustomize.toolkit.fluxcd.io]
+    resources: [kustomizations]
+    verbs: [get, patch]
+    resourceNames: [{{ $ksName }}]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -431,6 +452,21 @@ spec:
                 WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'
                 ELSE 'noreceiver'
               END"
+              # #5245 — timeline reads for the TL-ahead re-promote proof.
+              # IDENTIFY_SYSTEM over a replication-protocol connection is
+              # the one surface streaming_replica is GUARANTEED to have
+              # (pg_hba `hostssl replication streaming_replica all cert`) —
+              # no pg_control / pg_read_all_stats privileges involved (the
+              # #5239 lesson). The SOURCE read authenticates with THIS
+              # cluster's `-replication` cert, which region-A accepts
+              # because chart ≥0.2.18 issues it from the SHARED client CA
+              # (`-primary-ca`, replica-cluster.yaml).
+              LOCAL_REPL="host={{ include "cnpg-pair.replicaName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key replication=true"
+              SOURCE_REPL="host=${PRIMARY_MESH_HOST} port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key replication=true"
+              tl_of() {
+                psql "$1" -tAXc "IDENTIFY_SYSTEM" 2>/dev/null | head -1 | cut -d'|' -f2
+              }
+              is_int() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
               STARTED=$(date -u +%s)
               echo "[dr-promoter/signals] loop started (interval=${INTERVAL_SECONDS}s startupGrace=${STARTUP_GRACE_SECONDS}s primaryLiveness=${PRIMARY_LIVENESS_ENABLED} primaryMeshHost=${PRIMARY_MESH_HOST})"
               clear_clock() {
@@ -438,11 +474,12 @@ spec:
                   echo "$(date -u +"%FT%TZ") [dr-promoter/signals] $1 — hold clock cleared"
                 fi
                 # Clears the promote clock AND (#5220 B) the replication-fault /
-                # timeline-divergence markers — any state that reaches a normal
-                # clock-clear (streaming/receiving/promoted/unknown/real-kill
-                # arming/grace) means the pair is NOT in the persistent
-                # can't-re-stream wedge, so a resolved wedge fully resets.
-                rm -f /shared/primary-wal-down-since /shared/replication-fault-since /shared/timeline-diverged /shared/timeline-diverged-recorded
+                # timeline-divergence markers (+ the #5245 TL-ahead proof) —
+                # any state that reaches a normal clock-clear (streaming/
+                # receiving/promoted/unknown/real-kill arming/grace) means the
+                # pair is NOT in the persistent can't-re-stream wedge, so a
+                # resolved wedge fully resets.
+                rm -f /shared/primary-wal-down-since /shared/replication-fault-since /shared/timeline-diverged /shared/timeline-diverged-recorded /shared/tl-ahead
               }
               while true; do
                 : > /shared/signals-alive
@@ -522,7 +559,28 @@ spec:
                       FSINCE=$(cat /shared/replication-fault-since 2>/dev/null || echo "${NOW}")
                       if [ "$((NOW - FSINCE))" -ge "${TL_DIVERGENCE_HOLD_SECONDS}" ] && [ ! -f /shared/timeline-diverged ]; then
                         : > /shared/timeline-diverged
-                        echo "$(date -u +"%FT%TZ") [dr-promoter/signals] TIMELINE-DIVERGENCE WEDGE: region-B has been unable to stream from a REACHABLE region-A for $((NOW - FSINCE))s (>=${TL_DIVERGENCE_HOLD_SECONDS}s) — the replica has left the source timeline and can never re-stream from the lower-TL source. Region-B must be RE-CLONED from region-A (RUNBOOKS §6.1); the actor records it on the HR (#5220)"
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/signals] TIMELINE-DIVERGENCE WEDGE: region-B has been unable to stream from a REACHABLE region-A for $((NOW - FSINCE))s (>=${TL_DIVERGENCE_HOLD_SECONDS}s) — the replica has left the source timeline and can never re-stream from the lower-TL source. The actor records it on the HR (#5220) and, when the TL-ahead proof below holds, RE-PROMOTES this line (#5245)"
+                      fi
+                      # #5245 — once the wedge holds, PROVE the direction with
+                      # timeline arithmetic: own TL strictly higher than the
+                      # reachable source's ⇒ this standby's line supersedes the
+                      # source's acknowledged history (state-X shape: the hw275
+                      # TL2-standby-vs-TL1-primary FATAL loop). The proof is
+                      # re-taken every tick and torn down by clear_clock the
+                      # moment the wedge resolves.
+                      if [ -f /shared/timeline-diverged ]; then
+                        TL_OWN=$(tl_of "${LOCAL_REPL}")
+                        TL_SRC=$(tl_of "${SOURCE_REPL}")
+                        if is_int "${TL_OWN}" && is_int "${TL_SRC}" && [ "${TL_OWN}" -gt "${TL_SRC}" ]; then
+                          echo "${TL_OWN}" > /shared/tl-own
+                          echo "${TL_SRC}" > /shared/tl-source
+                          if [ ! -f /shared/tl-ahead ]; then
+                            : > /shared/tl-ahead
+                            echo "$(date -u +"%FT%TZ") [dr-promoter/signals] TL-AHEAD PROOF: own timeline ${TL_OWN} > reachable source timeline ${TL_SRC} — this standby's line holds every acknowledged commit; the actor may re-promote it (#5245)"
+                          fi
+                        else
+                          rm -f /shared/tl-ahead
+                        fi
                       fi
                     else
                       RC=$?
@@ -631,6 +689,23 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              # #5245 — EVERY write uses a CUSTOM field manager. hw275 G12
+              # live-proved the #5219 latch was NOT durable under the default
+              # `kubectl-patch` manager: kustomize-controller's managed-fields
+              # cleanup REPLACES every manager matching the `kubectl` prefix
+              # with itself on EACH reconcile of the applying Kustomization
+              # and then drops the claimed fields absent from its manifest
+              # (fluxcd kustomization_controller.go — the documented "undo
+              # kubectl drift" behavior). On hw275 that stripped spec.suspend
+              # + the DR annotations every bootstrap-kit reconcile: kustomize
+              # Apply 06:55:20 → helm redeployed the reverted values 06:55:23
+              # (the mid-recovery RE-DEMOTE that produced the #5245 FATAL-loop
+              # state) → self-heal re-latched 06:55:27 — a war repeating every
+              # reconcile (19 re-latches in 30 min). A custom manager is NOT
+              # in that cleanup list, so the latch + annotations now survive
+              # (live precedent: the catalyst-api substitute flips persist
+              # under manager `catalyst-api`).
+              FM="--field-manager=dr-promoter"
               # suspend_hr <reason> — patch spec.suspend=true (+ latched-at
               # annotation), then READBACK-VERIFY it landed. spec.suspend is a
               # field flux's Kustomization (slot 16b) does NOT own, so its SSA
@@ -642,7 +717,7 @@ spec:
               # tick, so an RBAC/conflict fault is self-healing AND diagnosable.
               suspend_hr() {
                 _reason="$1"
-                if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-latched-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":true}}" >/dev/null 2>&1; then
+                if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-latched-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":true}}" >/dev/null 2>&1; then
                   _v=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
                   if [ "${_v}" = "true" ]; then
                     echo "$(date -u +"%FT%TZ") [dr-promoter/actor] LATCHED (${_reason}): HR ${HR_NAMESPACE}/${HR_NAME} spec.suspend=true VERIFIED — promotion durable; flux drift-correction can no longer revert spec.values and re-demote the survivor (#5178 Defect-B / #5218)"
@@ -654,7 +729,15 @@ spec:
                 echo "$(date -u +"%FT%TZ") [dr-promoter/actor] ERROR (${_reason}): spec.suspend patch FAILED (RBAC/conflict?) — HR NOT frozen; re-asserting next tick (#5218)"
                 return 1
               }
-              echo "[dr-promoter/actor] loop started (hold=${HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s renderWait=${PROMOTE_RENDER_WAIT_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME})"
+              # nudge_ks — rate-limited kustomize reconcile request so a
+              # substitute flip renders without waiting a full interval.
+              nudge_ks() {
+                if [ ! -f /shared/nudged-ks ] || [ -n "$(find /shared/nudged-ks -mmin +1 2>/dev/null)" ]; then
+                  kubectl -n "${KS_NAMESPACE}" annotate kustomization "${KS_NAME}" "reconcile.fluxcd.io/requestedAt=$(date -u +%s)" --overwrite ${FM} >/dev/null 2>&1 || true
+                  : > /shared/nudged-ks
+                fi
+              }
+              echo "[dr-promoter/actor] loop started (hold=${HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s renderWait=${PROMOTE_RENDER_WAIT_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME} kustomization=${KS_NAMESPACE}/${KS_NAME})"
               while true; do
                 : > /shared/actor-alive
                 (
@@ -662,6 +745,7 @@ spec:
                   SUSPENDED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
                   HR_PROMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.cnpgPair.replica.promoted}' 2>/dev/null || echo "")
                   REPLICA_ENABLED=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}' 2>/dev/null || echo "")
+                  SUB=$(kubectl -n "${KS_NAMESPACE}" get kustomization "${KS_NAME}" -o jsonpath='{.spec.postBuild.substitute.SOVEREIGN_CNPG_PAIR_PROMOTED}' 2>/dev/null || echo "")
                   DIVERGED=""; [ -f /shared/diverged ] && DIVERGED="true"
 
                   # #5220 (B) — TIMELINE-DIVERGENCE surfacing (non-destructive).
@@ -679,7 +763,7 @@ spec:
                   # wedge the operator must un-stick). Uses the existing HR
                   # get/patch RBAC — no new privileges.
                   if [ -f /shared/timeline-diverged ] && [ ! -f /shared/timeline-diverged-recorded ]; then
-                    if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-timeline-diverged-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-timeline-diverged-action\":\"re-clone region-B from region-A per RUNBOOKS 6.1 — the replica left the source timeline and cannot re-stream (#5220)\"}}}" >/dev/null 2>&1; then
+                    if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-timeline-diverged-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-timeline-diverged-action\":\"re-clone region-B from region-A per RUNBOOKS 6.1 — the replica left the source timeline and cannot re-stream (#5220)\"}}}" >/dev/null 2>&1; then
                       : > /shared/timeline-diverged-recorded
                       echo "$(date -u +"%FT%TZ") [dr-promoter/actor] TIMELINE-DIVERGENCE recorded on HR ${HR_NAMESPACE}/${HR_NAME} (dr-timeline-diverged-at) — region-B cannot re-stream from a reachable region-A; RE-CLONE region-B per RUNBOOKS 6.1 (#5220)"
                     else
@@ -687,14 +771,86 @@ spec:
                     fi
                   fi
 
+                  # ── #5245 DURABLE HANDOFF + LATCH LIFT ────────────────
+                  # The suspend latch is the MID-OUTAGE mechanism (helm-only,
+                  # works from the source-controller's cached chart with no
+                  # kustomize/source dependency). It is NOT the end state: a
+                  # latched HR freezes flux forever and, pre-#5245, nothing
+                  # ever lifted it. Once the promotion is real, hand the
+                  # desired state to the SOURCE: set the Kustomization's
+                  # postBuild.substitute SOVEREIGN_CNPG_PAIR_PROMOTED="true"
+                  # (slot 16b renders `promoted: ${SOVEREIGN_CNPG_PAIR_
+                  # PROMOTED:-false}`), and once the HR carries promoted=true
+                  # with the substitute in place, UNSUSPEND — kustomize now
+                  # renders the promotion as its OWN desired state, so
+                  # drift-correction RE-AFFIRMS it and flux is fully
+                  # reconciled again (chart bumps flow, no frozen HR). If the
+                  # substitute is ever lost, the step-1 self-heal latch
+                  # below re-freezes within one tick (belt and braces).
+                  if [ "${SUB}" != "true" ]; then
+                    if [ "${SUSPENDED}" = "true" ] && { { [ "${HR_PROMOTED}" = "true" ] && [ "${REPLICA_ENABLED}" = "false" ]; } || [ "${DIVERGED}" = "true" ]; }; then
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/actor] DURABLE HANDOFF (step 1/2): promotion is latched+rendered — patching Kustomization ${KS_NAMESPACE}/${KS_NAME} substitute SOVEREIGN_CNPG_PAIR_PROMOTED=true so the promotion becomes the SOURCE-rendered desired state (#5245)"
+                      kubectl -n "${KS_NAMESPACE}" patch kustomization "${KS_NAME}" --type merge ${FM} -p '{"spec":{"postBuild":{"substitute":{"SOVEREIGN_CNPG_PAIR_PROMOTED":"true"}}}}' >/dev/null 2>&1 || echo "$(date -u +"%FT%TZ") [dr-promoter/actor] WARN: substitute patch failed (RBAC/conflict?) — retrying next tick (#5245)"
+                      nudge_ks
+                    fi
+                  else
+                    if [ "${SUSPENDED}" = "true" ] && [ "${HR_PROMOTED}" = "true" ]; then
+                      if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-handoff-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":false}}" >/dev/null 2>&1; then
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/actor] DURABLE HANDOFF (step 2/2): substitute in place and HR promoted=true — suspend latch LIFTED; flux reconciles the promoted desired state from source (#5245)"
+                      else
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/actor] WARN: latch-lift patch failed — retrying next tick (#5245)"
+                      fi
+                      exit 0
+                    fi
+                  fi
                   # 1. SELF-HEAL LATCH — keep an already-rendered promotion
                   #    durable. Fires on the post-promote tick AND re-freezes
                   #    the HR if anything ever un-suspends it. Both arms require
                   #    POSITIVE render evidence (replica.enabled=false OR the
                   #    cluster already left recovery) so it can never freeze a
-                  #    pre-render HR and strand the promotion.
-                  if [ "${SUSPENDED}" != "true" ] && { { [ "${HR_PROMOTED}" = "true" ] && [ "${REPLICA_ENABLED}" = "false" ]; } || [ "${DIVERGED}" = "true" ]; }; then
+                  #    pre-render HR and strand the promotion. #5245: SKIPPED
+                  #    once the durable handoff holds (substitute set AND the
+                  #    HR rendering promoted=true from source) — the promotion
+                  #    no longer needs the freeze; if the substitute is ever
+                  #    reverted this guard re-arms automatically.
+                  if [ "${SUSPENDED}" != "true" ] && ! { [ "${SUB}" = "true" ] && [ "${HR_PROMOTED}" = "true" ]; } && { { [ "${HR_PROMOTED}" = "true" ] && [ "${REPLICA_ENABLED}" = "false" ]; } || [ "${DIVERGED}" = "true" ]; }; then
                     suspend_hr "self-heal" || true
+                    exit 0
+                  fi
+                  # ── #5245 TL-AHEAD RE-PROMOTE — the state-X recovery ──
+                  # The wedge the #5220-B surfacing only DIAGNOSED is now
+                  # actionable: a standby whose OWN timeline is STRICTLY
+                  # HIGHER than its reachable source's (IDENTIFY_SYSTEM
+                  # arithmetic, written by the signals container as
+                  # /shared/tl-ahead) holds a line the source can never have
+                  # — every acknowledged commit lives on the higher line
+                  # (before divergence B was the mandatory remote_apply sync
+                  # target; after it, the lower-TL side is write-fenced by
+                  # its unsatisfiable FIRST 1). Re-promoting it is therefore
+                  # data-safe, and it is the ONLY way out of the hw275 state
+                  # (region-B re-demoted to a TL2 standby FATAL-looping at a
+                  # TL1 region-A): region-B must be writable again before
+                  # region-A's failback actor can re-clone region-A onto its
+                  # line. DELIBERATELY BYPASSES the #5220 arm gate (a
+                  # TL-ahead standby can never stream, so it could never
+                  # arm) and the failover-readiness gate (there is no lag
+                  # against a lower-TL source — the standby's own line IS
+                  # the payload): the TL arithmetic is a STRONGER proof than
+                  # either heuristic — a link flap or a never-converged pair
+                  # can never manufacture own-TL > source-TL. Guards: the
+                  # divergence wedge must have HELD (timelineDivergenceHold),
+                  # at most ONE TL-ahead promote per pod lifetime, and never
+                  # after this pod has already seen the cluster promoted
+                  # (/shared/diverged — the hw266 runaway guard). Rides the
+                  # DURABLE SUBSTITUTE seam (not the raw HR patch): once the
+                  # substitute renders promoted=true, the handoff block above
+                  # lifts any suspend and helm renders the promotion.
+                  if [ -f /shared/timeline-diverged ] && [ -f /shared/tl-ahead ] && [ ! -f /shared/diverged ] && [ ! -f /shared/tl-ahead-promoted ] && [ "${REPLICA_ENABLED}" = "true" ] && [ "${SUB}" != "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] TL-AHEAD RE-PROMOTE: local standby TL=$(cat /shared/tl-own 2>/dev/null || echo '?') > reachable source TL=$(cat /shared/tl-source 2>/dev/null || echo '?') and the wedge held ${TL_DIVERGENCE_HOLD_SECONDS}s — this line holds every acknowledged commit; re-promoting via the durable substitute seam (#5245)"
+                    kubectl -n "${KS_NAMESPACE}" patch kustomization "${KS_NAME}" --type merge ${FM} -p '{"spec":{"postBuild":{"substitute":{"SOVEREIGN_CNPG_PAIR_PROMOTED":"true"}}}}'
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-tl-ahead-repromoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-tl-ahead-repromote-reason\":\"standby timeline ahead of reachable source (state-X wedge); re-promoted so the acknowledged line serves writes and region-A can fail back onto it (#5245)\"}}}" >/dev/null 2>&1 || true
+                    : > /shared/tl-ahead-promoted
+                    nudge_ks
                     exit 0
                   fi
                   # 2. ANTI-FLAP — latched ⇒ done.
@@ -750,7 +906,7 @@ spec:
                     exit 0
                   fi
                   echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTING: region-A WAL stream absent AND region-A unreachable ${DOWN_FOR}s >= ${HOLD_SECONDS}s AND failover-readiness Ready — patching HR desired state (#5125-D1 seam)"
-                  kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-auto-promote-reason\":\"region-A WAL stream absent and region-A unreachable ${DOWN_FOR}s; failover-readiness Ready (#5137/#5178)\"}},\"spec\":{\"values\":{\"cnpgPair\":{\"replica\":{\"promoted\":true}}}}}"
+                  kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-auto-promote-reason\":\"region-A WAL stream absent and region-A unreachable ${DOWN_FOR}s; failover-readiness Ready (#5137/#5178)\"}},\"spec\":{\"values\":{\"cnpgPair\":{\"replica\":{\"promoted\":true}}}}}"
                   echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTED (step 1/2): HR ${HR_NAMESPACE}/${HR_NAME} spec.values.cnpgPair.replica.promoted=true — helm-controller renders replica.enabled:false → CNPG promotes"
                   # 3b. SAME-TICK DURABLE LATCH (#5218) — do NOT wait for the
                   #     next tick. Poll until helm renders replica.enabled=false
@@ -785,6 +941,12 @@ spec:
               value: {{ $hrName | quote }}
             - name: HR_NAMESPACE
               value: {{ $hrNamespace | quote }}
+            # #5245 durable-handoff target — the Kustomization applying
+            # slot 16b (its postBuild.substitute carries the promotion).
+            - name: KS_NAME
+              value: {{ $ksName | quote }}
+            - name: KS_NAMESPACE
+              value: {{ $ksNamespace | quote }}
             - name: HOLD_SECONDS
               value: {{ $hold | quote }}
             - name: INTERVAL_SECONDS
@@ -793,6 +955,11 @@ spec:
             # for helm to render replica.enabled=false before suspending.
             - name: PROMOTE_RENDER_WAIT_SECONDS
               value: {{ $renderWait | quote }}
+            # #5245 — referenced by the TL-ahead re-promote log line (the
+            # wedge must have held this long before the signals container
+            # ever sets /shared/timeline-diverged + /shared/tl-ahead).
+            - name: TL_DIVERGENCE_HOLD_SECONDS
+              value: {{ $tlDivergeHold | quote }}
             - name: REPLICA_CLUSTER
               value: {{ include "cnpg-pair.replicaName" . | quote }}
             - name: READY_SELECTOR

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -89,6 +89,20 @@ spec:
           protocol: TCP
         - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+{{- if (include "cnpg-pair.failbackActive" .) }}
+    # #5245 dr-failback signals container — polls the primary's -rw for
+    # the post-failover geometry (local recovery/timeline state + the
+    # pinned sync standby's presence). Same intra-cluster 5432 path as
+    # the replica side's dr-promoter rule.
+    - from:
+        - podSelector:
+            matchLabels:
+              catalyst.openova.io/role: dr-failback
+              catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+{{- end }}
 {{- if gt (len .Values.cnpgPair.networkPolicy.crossRegionPeerClusters) 0 }}
 ---
 # CROSS-REGION DR (#4846): the REPLICA region's Pods (streaming + pg_basebackup)

--- a/platform/cnpg-pair/chart/templates/peer-mesh-service.yaml
+++ b/platform/cnpg-pair/chart/templates/peer-mesh-service.yaml
@@ -1,0 +1,51 @@
+{{- /*
+Primary-side ClusterMesh global Service stub for `-replica-mesh`
+(#5245, chart 0.2.18) — the exact mirror of replica-mesh-service.yaml.
+
+Cilium ClusterMesh global services merge BY NAME+NAMESPACE: a Service
+participates only if an object with the same name + namespace exists in
+EVERY consuming cluster, each annotated `service.cilium.io/global`.
+The replica side's `-replica-mesh` Service is CNPG-managed on
+cluster-B (replica Cluster CR `spec.managed.services.additional`) —
+but cluster-A has no replica Cluster CR, so without this stub the name
+is NXDOMAIN on cluster-A and neither the dr-failback peer probe nor
+the demoted (rejoin) primary Cluster's externalCluster could ever
+resolve region-B's writable endpoint.
+
+The selector (`cnpg.io/cluster: <fullname>-replica`) matches ZERO Pods
+on cluster-A by construction, so every connection routes across the
+mesh to region-B's backends (the `affinity: local` hint falls through
+to remote when no local backend exists). No CNPG ownership collision:
+the local CNPG operator on cluster-A manages only the primary
+Cluster's Services, never this name.
+
+Rendered whenever the pair + mesh are on (not failback-gated): the
+stub is a passive DNS anchor with zero backends, and having it present
+from day 0 means the failback path needs no render-ordering dance when
+peers are wired later.
+*/ -}}
+{{- if and .Values.cnpgPair.enabled .Values.cnpgPair.clusterMesh.enabled (include "cnpg-pair.isPrimarySide" .) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cnpg-pair.peerReplicationServiceName" . }}
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+    catalyst.openova.io/role: failback-source
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/affinity: {{ .Values.cnpgPair.clusterMesh.affinity | quote }}
+    catalyst.openova.io/blueprint: bp-cnpg-pair
+spec:
+  type: ClusterIP
+  selector:
+    # CNPG selector shape for the REPLICA Cluster — matches zero Pods
+    # on the primary cluster by construction.
+    cnpg.io/cluster: {{ include "cnpg-pair.replicaName" . }}
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+{{- end }}

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -16,9 +16,37 @@ Side-gating (chart 0.2.0): this CR renders ONLY on side=primary —
 the primary and replica halves of the pair live on SEPARATE clusters
 (ClusterMesh-joined), so cluster-B must never receive the primary
 Cluster CR (its region-A node-affinity could never schedule there).
+
+DEMOTED shape (#5245, chart 0.2.18): when `cnpgPair.primary.demoted`
+is true this CR renders as a REPLICA CLUSTER of region-B — the
+region-A rejoin after a region-kill promote. hw275 G12 proved the
+failback leg was missing: recovered region-A resumed its OLD TL1
+primary role while promoted region-B held TL2, and a TL2 line can
+never stream from a TL1 source ("highest timeline 1 of the primary is
+behind recovery timeline 2" FATAL loop) — cross-region replication
+permanently dead. The rejoin DISCARDS region-A's stale timeline and
+re-clones from region-B (bootstrap.pg_basebackup over the
+`-replica-mesh` global Service): with sync remote_apply + FIRST 1
+pinned to the cross-region replica + dataDurability:required, region-B
+holds EVERY acknowledged commit region-A ever made (before the kill it
+was the mandatory sync target; after recovery region-A is write-fenced
+by the same unsatisfiable FIRST 1), so nothing acknowledged is lost —
+only region-A's never-acked local WAL tail, which the RPO=0 contract
+already discards. pg_rewind is deliberately NOT used: CNPG has no
+cross-cluster rewind trigger and a rewind's fork-point arithmetic
+depends on WAL-tail geometry the actor cannot verify; the basebackup
+re-clone is deterministic for every geometry. The demoted shape omits
+the synchronous block (a standby carries no sync fence); flipping
+`demoted` back to false (the sovereign-admin's controlled switchback,
+after region-B has been demoted in turn) restores the full primary
+shape. AUTH: the rejoin stream presents region-A's OWN
+`-primary-replication` client cert — accepted by region-B because the
+replica Cluster pins its client CA to the shared `-primary-ca`
+(replica-cluster.yaml, #5245).
 */ -}}
 {{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isPrimarySide" .) }}
 {{- include "cnpg-pair.validateRegions" . }}
+{{- $demoted := .Values.cnpgPair.primary.demoted | default false }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -46,10 +74,56 @@ spec:
   resources:
     {{- toYaml .Values.cnpgPair.primary.resources | nindent 4 }}
 
+{{- if $demoted }}
+  # ── #5245 REJOIN shape — replica cluster of region-B ──────────────
+  # `replica.enabled: true` + pg_basebackup from the `-replica`
+  # externalCluster (region-B's promoted primary over `-replica-mesh`).
+  # bootstrap runs only at Cluster creation — the dr-failback actor
+  # deletes the stale Cluster CR once this desired state is rendered,
+  # so helm re-creates it fresh and the basebackup clones region-B's
+  # current timeline.
+  replica:
+    enabled: true
+    source: {{ include "cnpg-pair.fullname" . }}-replica
+  bootstrap:
+    pg_basebackup:
+      source: {{ include "cnpg-pair.fullname" . }}-replica
+      database: {{ .Values.cnpgPair.primary.bootstrap.database | quote }}
+      owner:    {{ .Values.cnpgPair.primary.bootstrap.owner | quote }}
+  externalClusters:
+    - name: {{ include "cnpg-pair.fullname" . }}-replica
+      connectionParameters:
+        # Reverse-direction ClusterMesh global alias: region-B's
+        # replica Cluster publishes its `rw` (designated/promoted
+        # primary) as `<fullname>-replica-mesh` (managed additional
+        # Service, replica-cluster.yaml); the side=primary local stub
+        # (peer-mesh-service.yaml) makes the name resolve here with
+        # zero local backends → traffic crosses the mesh.
+        host: {{ include "cnpg-pair.peerReplicationServiceName" . }}
+        port: "5432"
+        user: streaming_replica
+        sslmode: require
+        dbname: {{ .Values.cnpgPair.primary.bootstrap.database | quote }}
+      # Region-A's OWN CNPG-issued streaming_replica client cert —
+      # accepted by region-B because the replica Cluster's client CA is
+      # pinned to this same `-primary-ca` (shared client CA, #5245).
+      # Both Secrets exist natively on cluster-A (CNPG issued them for
+      # this Cluster).
+      sslKey:
+        name: {{ include "cnpg-pair.fullname" . }}-primary-replication
+        key: tls.key
+      sslCert:
+        name: {{ include "cnpg-pair.fullname" . }}-primary-replication
+        key: tls.crt
+      sslRootCert:
+        name: {{ include "cnpg-pair.fullname" . }}-primary-ca
+        key: ca.crt
+{{- else }}
   bootstrap:
     initdb:
       database: {{ .Values.cnpgPair.primary.bootstrap.database | quote }}
       owner:    {{ .Values.cnpgPair.primary.bootstrap.owner | quote }}
+{{- end }}
 
   # Region pinning — node-affinity is the operator's idiomatic seam
   # for region selection (Cluster CR Pods land on nodes whose
@@ -128,11 +202,15 @@ spec:
       manifest then omits both the parameter AND the synchronous block,
       falling back to the PostgreSQL default (synchronous_commit=on,
       no standbys forced).
+
+      #5245: the DEMOTED (rejoin) shape also omits both — a standby of
+      region-B must not pin a sync fence; the fence returns with the
+      primary shape on the controlled switchback (demoted:false).
       */ -}}
-      {{- if eq (default "sync" .Values.cnpgPair.replication.mode) "sync" }}
+      {{- if and (not $demoted) (eq (default "sync" .Values.cnpgPair.replication.mode) "sync") }}
       synchronous_commit: {{ default "remote_apply" .Values.cnpgPair.replication.sync.commit | quote }}
       {{- end }}
-    {{- if eq (default "sync" .Values.cnpgPair.replication.mode) "sync" }}
+    {{- if and (not $demoted) (eq (default "sync" .Values.cnpgPair.replication.mode) "sync") }}
     # ── Synchronous replication — CNPG-native (NOT a raw parameter) ────
     # method=first + number=N + standbyNamesPre:[<replica>] +
     # maxStandbyNamesFromCluster:0 renders

--- a/platform/cnpg-pair/chart/templates/replica-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/replica-cluster.yaml
@@ -61,6 +61,24 @@ spec:
   resources:
     {{- toYaml .Values.cnpgPair.replica.resources | nindent 4 }}
 
+  # ── Shared client CA (#5245) ──────────────────────────────────────
+  # Pin this cluster's CLIENT CA to the primary cluster's CA Secret
+  # (already synced cluster-A → cluster-B at the post-mesh flip, with
+  # ca.crt + ca.key — live-verified hw275). CNPG then issues THIS
+  # cluster's `<replica>-replication` streaming_replica leaf from that
+  # CA (cluster_pki.go: a BYO clientCASecret carrying ca.key generates
+  # the replication leaf when replicationTLSSecret is unset), so every
+  # local consumer (failover-readiness + the promoter signals) keeps
+  # mounting `<replica>-replication` unchanged — AND region-A's own
+  # `-primary-replication` cert (same CA) now authenticates here too.
+  # That reverse-direction auth is what the #5245 failback rides:
+  # the demoted region-A streams FROM this cluster (post-promote)
+  # presenting the only client cert cluster-A natively holds. Server
+  # certs are untouched (sslmode=require skips server-chain
+  # verification on every streaming path in this chart).
+  certificates:
+    clientCASecret: {{ include "cnpg-pair.fullname" . }}-primary-ca
+
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -146,6 +164,43 @@ spec:
       sslRootCert:
         name: {{ include "cnpg-pair.fullname" . }}-primary-ca
         key: ca.crt
+
+  # ── Reverse-direction replication Service (#5245) ─────────────────
+  # Publish THIS cluster's writable endpoint across the mesh as
+  # `<fullname>-replica-mesh` — the exact mirror of the primary side's
+  # `-primary-mesh` (CNPG-managed additional Service, selectorType rw,
+  # Cilium-global). Pre-promote this tracks the designated primary (a
+  # standby — no consumers); POST-PROMOTE it is the writable survivor
+  # region-A's failback rides: the failback actor's peer probe and the
+  # demoted region-A's externalCluster both resolve this name (the
+  # side=primary local stub in peer-mesh-service.yaml completes the
+  # by-name global-service merge). CNPG re-points `rw` at whatever
+  # instance is current, so the alias tracks promotion/demotion with
+  # no chart change (#3740 idiom).
+  {{- if .Values.cnpgPair.clusterMesh.enabled }}
+  managed:
+    services:
+      additional:
+        - selectorType: rw
+          serviceTemplate:
+            metadata:
+              name: {{ include "cnpg-pair.peerReplicationServiceName" . }}
+              labels:
+                {{- include "cnpg-pair.labels" . | nindent 16 }}
+                catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+                catalyst.openova.io/role: failback-source
+              annotations:
+                service.cilium.io/global: "true"
+                service.cilium.io/affinity: {{ .Values.cnpgPair.clusterMesh.affinity | quote }}
+                catalyst.openova.io/blueprint: bp-cnpg-pair
+            spec:
+              type: ClusterIP
+              ports:
+                - name: postgres
+                  port: 5432
+                  targetPort: 5432
+                  protocol: TCP
+  {{- end }}
 
   # `hot_standby` is intentionally OMITTED — see primary-cluster.yaml
   # for the rationale. PostgreSQL 16 hard-pins it to `on` for any

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -5,13 +5,14 @@
 #   1. Default render (cnpgPair.enabled=false) → ZERO resources, on
 #      BOTH sides (side=primary and side=replica) — byte-identical
 #      empty renders.
-#   2. Enabled side=primary render → 3 non-test resources (primary
+#   2. Enabled side=primary render → 4 non-test resources (primary
 #      Cluster CR + audit-config ConfigMap + replication-ingress
-#      NetworkPolicy) + 4 helm-test resources. NO replica Cluster, NO
-#      failover-readiness Deployment (those live on cluster-B — chart
-#      0.2.0: a 2-region Sovereign is two SEPARATE clusters joined by
-#      ClusterMesh; region-B-pinned workloads can never schedule on
-#      cluster-A, hw126 FailedScheduling).
+#      NetworkPolicy + the #5245 `-replica-mesh` Service stub) + 4
+#      helm-test resources. NO replica Cluster, NO failover-readiness
+#      Deployment (those live on cluster-B — chart 0.2.0: a 2-region
+#      Sovereign is two SEPARATE clusters joined by ClusterMesh;
+#      region-B-pinned workloads can never schedule on cluster-A,
+#      hw126 FailedScheduling).
 #   3. Enabled side=replica render → 5 non-test resources (replica
 #      Cluster CR + `-primary-mesh` global Service stub + failover-
 #      readiness Deployment + 2 probe NetworkPolicies) + 0 helm-test.
@@ -93,10 +94,12 @@ helm template smoke-cnpg-pair . \
 }
 
 # Expect 1×Cluster (primary) + 1×ConfigMap (audit) + 1×NetworkPolicy
-# (replication ingress) = 3 non-test kinds; helm-test Pod + SA + Role
-# + RoleBinding = 4 test kinds. The replication Service is CNPG-
-# managed via the primary Cluster's spec.managed.services.additional,
-# so it is NOT a kind in the rendered manifest.
+# (replication ingress) + 1×Service (#5245 `-replica-mesh` stub — the
+# zero-backend local anchor for the reverse-direction global-service
+# merge) = 4 non-test kinds; helm-test Pod + SA + Role + RoleBinding =
+# 4 test kinds. The replication Service is CNPG-managed via the
+# primary Cluster's spec.managed.services.additional, so it is NOT a
+# kind in the rendered manifest.
 count_resources() {
   python3 - "$1" <<'PYEOF'
 import sys, yaml
@@ -114,8 +117,8 @@ count_resources "$TMP/primary.yaml" > "$TMP/primary-counts" || {
 }
 NONTEST=$(grep -E '^NONTEST=' "$TMP/primary-counts" | cut -d= -f2)
 TEST=$(grep -E '^TEST=' "$TMP/primary-counts" | cut -d= -f2)
-if [ "$NONTEST" -ne 3 ] || [ "$TEST" -ne 4 ]; then
-  echo "FAIL: side=primary expected 3 non-test + 4 test resources, got $NONTEST + $TEST." >&2
+if [ "$NONTEST" -ne 4 ] || [ "$TEST" -ne 4 ]; then
+  echo "FAIL: side=primary expected 4 non-test + 4 test resources, got $NONTEST + $TEST." >&2
   grep -E "^kind: " "$TMP/primary.yaml" >&2
   exit 1
 fi
@@ -216,7 +219,7 @@ grep -qE '^\s+- port: 9187' "$TMP/primary.yaml" || {
   echo "FAIL: primary-side NetworkPolicy missing the operator metrics port (9187)." >&2
   exit 1
 }
-echo "  PASS (3 non-test + 4 test resources)"
+echo "  PASS (4 non-test + 4 test resources)"
 
 # ── Case 3: side=replica enabled render ──────────────────────────
 echo "[render] Case 3: enabled side=replica render emits the replica half only"
@@ -565,8 +568,11 @@ helm template smoke-cnpg-pair . \
   --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={hw228-me-east-b}' \
   > "$TMP/cnp-primary.yaml" 2> "$TMP/cnp-primary.err" || {
   echo "FAIL: #4846 side=primary CNP render errored:" >&2; cat "$TMP/cnp-primary.err" >&2; exit 1; }
-if [ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-primary.yaml")" != "1" ]; then
-  echo "FAIL: #4846 side=primary expected exactly 1 CiliumNetworkPolicy." >&2; exit 1; fi
+# 0.2.18: side=primary carries 2 CNPs when peers are set — the #4846
+# crossregion-dr-primary ingress admit + the #5245 dr-failback-egress
+# (the failback actor renders only when peers are wired).
+if [ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-primary.yaml")" != "2" ]; then
+  echo "FAIL: #4846/#5245 side=primary expected exactly 2 CiliumNetworkPolicies (crossregion-dr-primary + dr-failback-egress)." >&2; exit 1; fi
 grep -qE '^  name: smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-primary$' "$TMP/cnp-primary.yaml" || {
   echo "FAIL: #4846 primary CNP name != smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-primary." >&2; exit 1; }
 grep -qE '^      cnpg.io/cluster: smoke-cnpg-pair-bp-cnpg-pair-primary$' "$TMP/cnp-primary.yaml" || {
@@ -1025,5 +1031,198 @@ grep -qF 'if [ "${STATE}" = "streaming" ]' "$TMP/signals.sh" || {
   echo "FAIL: #5239 arm window must still key off STATE='streaming' (the #5220 continuity tracker)." >&2; exit 1; }
 
 echo "  PASS (arm gate blocks promote before observed steady-state · divergence surfaced on HR · non-destructive, no delete verbs · #5239 streaming signal readable by streaming_replica)"
+
+# ── Case 19: #5245 region-kill FAILBACK — dr-failback actor, demoted shape,
+#             durable substitute seams, field managers, bounded destruction ─
+# hw275 G12: after a clean forward promote, recovered region-A resumed its
+# stale TL1 primary role while promoted region-B FATAL-looped as a TL2
+# standby — cross-region replication permanently dead, no failback owner.
+echo "[render] Case 19: #5245 failback — dr-failback gating + demoted rejoin shape + durable seams + latch lift + TL-ahead re-promote"
+
+# (a) GATING: no dr-failback without crossRegionPeerClusters (no peer probe ⇒
+#     no safe action ⇒ nothing renders); never on side=replica; the
+#     `-replica-mesh` stub Service IS on the default primary render (passive
+#     DNS anchor, mesh-gated only).
+if grep -q 'dr-failback' "$TMP/primary.yaml"; then
+  echo "FAIL: #5245 side=primary WITHOUT crossRegionPeerClusters must render ZERO dr-failback resources (no peer probe → no safe action)." >&2; exit 1; fi
+grep -qE '^  name: smoke-cnpg-pair-bp-cnpg-pair-replica-mesh$' "$TMP/primary.yaml" || {
+  echo "FAIL: #5245 side=primary missing the -replica-mesh stub Service (reverse-direction global-service merge anchor)." >&2; exit 1; }
+if grep -q 'dr-failback' "$TMP/replica.yaml"; then
+  echo "FAIL: #5245 side=replica rendered dr-failback resources — the failback actor runs ONLY on cluster-A." >&2; exit 1; fi
+# failback disabled / async mode ⇒ no dr-failback even with peers.
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={hw228-me-east-b}' \
+  --set cnpgPair.primary.failback.enabled=false \
+  > "$TMP/nofailback.yaml" 2>/dev/null || { echo "FAIL: #5245 failback-disabled render errored." >&2; exit 1; }
+if grep -q 'dr-failback' "$TMP/nofailback.yaml"; then
+  echo "FAIL: #5245 primary.failback.enabled=false must render ZERO dr-failback resources." >&2; exit 1; fi
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={hw228-me-east-b}' \
+  --set cnpgPair.replication.mode=async \
+  > "$TMP/asyncfailback.yaml" 2>/dev/null || { echo "FAIL: #5245 async-mode primary render errored." >&2; exit 1; }
+if grep -q 'dr-failback' "$TMP/asyncfailback.yaml"; then
+  echo "FAIL: #5245 replication.mode=async must render ZERO dr-failback resources — the sync fence is the data-safety proof for discarding region-A's line." >&2; exit 1; fi
+
+# (b) DELIVERY SHAPE on the peers-wired render (Case 12 output): a Recreate
+#     Deployment (#5157 — never a CronJob) with signals + actor containers.
+awk '/^kind: Deployment$/{d=1} d&&/name: .*-dr-failback$/{f=1} f&&/type: Recreate/{print "RECREATE"; exit}' "$TMP/cnp-primary.yaml" | grep -q RECREATE || {
+  echo "FAIL: #5245 dr-failback must be a Deployment with strategy Recreate (single actor, #5157 shape)." >&2; exit 1; }
+
+# (c) SCRIPTS are valid POSIX shell.
+python3 - "$TMP/cnp-primary.yaml" signals > "$TMP/fb-signals.sh" <<'PYEOF' || { echo "FAIL: #5245 could not extract the dr-failback signals script." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-failback' in d['metadata']['name']][0]
+c=[c for c in dep['spec']['template']['spec']['containers'] if c['name']==sys.argv[2]][0]
+sys.stdout.write(c['args'][0])
+PYEOF
+python3 - "$TMP/cnp-primary.yaml" actor > "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5245 could not extract the dr-failback actor script." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-failback' in d['metadata']['name']][0]
+c=[c for c in dep['spec']['template']['spec']['containers'] if c['name']==sys.argv[2]][0]
+sys.stdout.write(c['args'][0])
+PYEOF
+sh -n "$TMP/fb-signals.sh" || { echo "FAIL: #5245 dr-failback signals script is not valid POSIX shell." >&2; exit 1; }
+sh -n "$TMP/fb-actor.sh"   || { echo "FAIL: #5245 dr-failback actor script is not valid POSIX shell." >&2; exit 1; }
+
+# (d) POSITIVE-PROOF signals: peer probe = pg_isready + pg_is_in_recovery +
+#     IDENTIFY_SYSTEM timeline arithmetic (streaming_replica-readable, #5239
+#     lesson) over the -replica-mesh alias; sync-standby presence read from
+#     pg_stat_replication (walsender rows run AS streaming_replica).
+grep -q 'IDENTIFY_SYSTEM' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must read timelines via IDENTIFY_SYSTEM (the streaming_replica-readable surface)." >&2; exit 1; }
+grep -q 'pg_stat_replication' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must check the pinned sync standby's presence in pg_stat_replication." >&2; exit 1; }
+grep -qE 'value: "[a-z0-9-]+-replica-mesh"' "$TMP/cnp-primary.yaml" || {
+  echo "FAIL: #5245 PEER_MESH_HOST must be the templated -replica-mesh alias, not hardcoded." >&2; exit 1; }
+grep -q '"${_tl_peer}" -gt "${_tl_local}"' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must require TL_peer STRICTLY greater than TL_local (the antisymmetric authority proof)." >&2; exit 1; }
+
+# (e) DURABLE SEAM: the actor demotes through the Kustomization substitute
+#     (SOVEREIGN_CNPG_PAIR_DEMOTED) with a CUSTOM field manager — never a raw
+#     HR-values-only patch, never a live Cluster-CR patch.
+grep -qF 'SOVEREIGN_CNPG_PAIR_DEMOTED' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 actor must flip the SOVEREIGN_CNPG_PAIR_DEMOTED substitute (the durable source seam)." >&2; exit 1; }
+grep -qF -- '--field-manager=dr-failback' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 actor writes must use --field-manager=dr-failback (kustomize's cleanup strips kubectl-managed fields — the hw275 re-demote root cause)." >&2; exit 1; }
+if grep -q 'patch clusters' "$TMP/fb-actor.sh"; then
+  echo "FAIL: #5245 actor patches a live Cluster CR — drift-correction reverts that (#5125-D1)." >&2; exit 1; fi
+
+# (f) BOUNDED DESTRUCTION: delete only via a fresh peer proof; RBAC delete is
+#     resourceNames-pinned to the ONE primary Cluster CR; no PVC/pod verbs.
+grep -q 'peer_fresh' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 actor must re-verify the peer writable+ahead proof (peer_fresh) before every delete." >&2; exit 1; }
+python3 - "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5245 delete-guard ordering assertion failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+import re
+for m in re.finditer(r'delete clusters', s):
+    head = s[:m.start()]
+    assert 'peer_fresh' in head.rsplit('exit 0',1)[-1] or 'peer_fresh ||' in s[max(0,m.start()-600):m.start()], \
+        "every kubectl delete of the Cluster CR must be immediately preceded by a peer_fresh guard"
+PYEOF
+python3 - "$TMP/cnp-primary.yaml" <<'PYEOF' || { echo "FAIL: #5245 dr-failback RBAC assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+roles=[d for d in docs if d.get('kind')=='Role' and 'dr-failback' in d['metadata']['name']]
+assert len(roles)==2, f"expected 2 dr-failback Roles (local ns + flux-system), got {len(roles)}"
+for r in roles:
+    for rule in r.get('rules',[]):
+        res=rule.get('resources',[]); verbs=set(rule.get('verbs',[]))
+        assert 'persistentvolumeclaims' not in res, "dr-failback must never hold PVC verbs (storage goes via owner-GC only)"
+        assert 'pods' not in res, "dr-failback needs no pod verbs"
+        if 'delete' in verbs:
+            assert res==['clusters'], f"delete verb only on the Cluster CR, got {res}"
+            assert rule.get('resourceNames'), "the delete rule must be resourceNames-pinned"
+PYEOF
+
+# (g) DEMOTED REJOIN SHAPE: primary.demoted=true renders the primary Cluster
+#     as a pg_basebackup replica of region-B (no sync fence); the default
+#     render keeps initdb + the full synchronous block.
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.primary.demoted=true \
+  > "$TMP/demoted.yaml" 2> "$TMP/demoted.err" || {
+  echo "FAIL: #5245 demoted render errored:" >&2; cat "$TMP/demoted.err" >&2; exit 1; }
+python3 - "$TMP/demoted.yaml" <<'PYEOF' || { echo "FAIL: #5245 demoted-shape assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+c=[d for d in docs if d.get('kind')=='Cluster'][0]
+spec=c['spec']
+assert spec.get('replica',{}).get('enabled') is True, "demoted primary must render replica.enabled=true"
+assert 'pg_basebackup' in spec.get('bootstrap',{}), "demoted primary must bootstrap via pg_basebackup (the re-clone)"
+ext=spec.get('externalClusters',[])
+assert ext and ext[0]['connectionParameters']['host'].endswith('-replica-mesh'), "demoted primary must stream from the -replica-mesh alias"
+assert ext[0]['sslCert']['name'].endswith('-primary-replication'), "the rejoin stream must present region-A's OWN client cert (shared client CA)"
+assert 'synchronous' not in spec.get('postgresql',{}), "demoted primary must NOT carry the synchronous block (a standby holds no sync fence)"
+assert 'synchronous_commit' not in spec.get('postgresql',{}).get('parameters',{}), "demoted primary must NOT set synchronous_commit"
+PYEOF
+python3 - "$TMP/primary.yaml" <<'PYEOF' || { echo "FAIL: #5245 default primary shape regression." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+c=[d for d in docs if d.get('kind')=='Cluster'][0]
+assert 'initdb' in c['spec'].get('bootstrap',{}), "default primary must keep bootstrap.initdb"
+assert 'synchronous' in c['spec'].get('postgresql',{}), "default primary must keep the synchronous block"
+PYEOF
+
+# (h) SHARED CLIENT CA + reverse mesh Service on side=replica: the replica
+#     Cluster pins clientCASecret to -primary-ca (so region-A's own cert
+#     authenticates the rejoin stream) and publishes -replica-mesh via
+#     managed.services.additional (selectorType rw, Cilium-global).
+python3 - "$TMP/replica.yaml" <<'PYEOF' || { echo "FAIL: #5245 replica-side shared-CA / -replica-mesh assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+c=[d for d in docs if d.get('kind')=='Cluster'][0]
+assert c['spec'].get('certificates',{}).get('clientCASecret','').endswith('-primary-ca'), \
+    "replica Cluster must pin certificates.clientCASecret to the shared -primary-ca (region-A's cert must authenticate the failback stream)"
+svcs=c['spec'].get('managed',{}).get('services',{}).get('additional',[])
+mesh=[s for s in svcs if s['serviceTemplate']['metadata']['name'].endswith('-replica-mesh')]
+assert mesh, "replica Cluster must publish the -replica-mesh managed additional Service"
+assert mesh[0]['selectorType']=='rw', "the -replica-mesh Service must use selectorType rw (tracks the writable/promoted instance)"
+assert mesh[0]['serviceTemplate']['metadata']['annotations'].get('service.cilium.io/global')=='true', \
+    "the -replica-mesh Service must be Cilium-global"
+PYEOF
+
+# (i) PROMOTER-SIDE #5245 pieces (default replica render): custom field
+#     manager on every write, the durable handoff (substitute + latch lift),
+#     and the TL-ahead re-promote riding the substitute seam with the
+#     divergence-wedge + runaway guards.
+grep -qF -- '--field-manager=dr-promoter' "$TMP/actor.sh" || {
+  echo "FAIL: #5245 dr-promoter writes must use --field-manager=dr-promoter (the hw275 latch-strip root cause)." >&2; exit 1; }
+grep -qF 'SOVEREIGN_CNPG_PAIR_PROMOTED' "$TMP/actor.sh" || {
+  echo "FAIL: #5245 dr-promoter missing the durable-handoff substitute patch (SOVEREIGN_CNPG_PAIR_PROMOTED)." >&2; exit 1; }
+grep -qF '\"suspend\":false' "$TMP/actor.sh" || {
+  echo "FAIL: #5245 dr-promoter must LIFT the suspend latch once the promotion is source-rendered (the reconciled-topology end state)." >&2; exit 1; }
+grep -q 'TL-AHEAD RE-PROMOTE' "$TMP/actor.sh" || {
+  echo "FAIL: #5245 dr-promoter missing the TL-ahead re-promote (the state-X recovery)." >&2; exit 1; }
+python3 - "$TMP/actor.sh" <<'PYEOF' || { echo "FAIL: #5245 TL-ahead guard assertions failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+i=s.find('TL-AHEAD RE-PROMOTE')
+blk=s[i:i+2500]
+assert '/shared/timeline-diverged' in blk, "TL-ahead re-promote must require the held divergence wedge"
+assert '/shared/tl-ahead' in blk, "TL-ahead re-promote must require the positive TL arithmetic proof"
+assert '! -f /shared/diverged' in blk, "TL-ahead re-promote must keep the /shared/diverged runaway guard (hw266)"
+assert '/shared/tl-ahead-promoted' in blk, "TL-ahead re-promote must be once-per-pod-lifetime"
+PYEOF
+grep -q 'TL-AHEAD PROOF' "$TMP/signals.sh" || {
+  echo "FAIL: #5245 dr-promoter signals missing the TL-ahead arithmetic proof (IDENTIFY_SYSTEM own-vs-source)." >&2; exit 1; }
+# Scripts still valid POSIX shell after the #5245 additions.
+sh -n "$TMP/actor.sh"   || { echo "FAIL: #5245 dr-promoter actor script is not valid POSIX shell." >&2; exit 1; }
+sh -n "$TMP/signals.sh" || { echo "FAIL: #5245 dr-promoter signals script is not valid POSIX shell." >&2; exit 1; }
+
+echo "  PASS (peers-gated dr-failback · demoted pg_basebackup rejoin shape · shared client CA + -replica-mesh · durable substitute seams + latch lift · TL-ahead re-promote · bounded resourceNames-pinned destruction)"
 
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -53,6 +53,83 @@ cnpgPair:
     # via configSchema. Empty string with enabled=true triggers a
     # template-time `required` error.
     region: ""
+    # ── DR FAILBACK demotion (#5245) — mirror of replica.promoted ────
+    # When true, the side=primary Cluster CR renders as a REPLICA
+    # CLUSTER of region-B (replica.enabled:true + bootstrap.pg_basebackup
+    # + externalClusters streaming region-B's promoted primary over the
+    # `-replica-mesh` global Service), and the synchronous block is
+    # OMITTED (a standby carries no sync fence). This is the region-A
+    # rejoin shape after a region-kill promote: the recovered region-A
+    # must DISCARD its stale timeline and re-clone onto region-B's
+    # promoted line — never the reverse (region-B's line ⊇ every
+    # ACKNOWLEDGED commit, structurally: sync remote_apply + FIRST 1
+    # pinned to the cross-region replica + dataDurability:required means
+    # region-A could never ack a commit region-B lacked, before OR after
+    # the kill — post-recovery region-A is write-fenced by the same
+    # unsatisfiable FIRST 1).
+    #
+    # The durable channel for this flag is the bootstrap-kit
+    # Kustomization postBuild substitute SOVEREIGN_CNPG_PAIR_DEMOTED
+    # (slot 16b renders `demoted: ${SOVEREIGN_CNPG_PAIR_DEMOTED:-false}`),
+    # patched by the dr-failback actor with its own field manager —
+    # kustomize-controller then renders the demotion as ITS OWN desired
+    # state, so drift-correction RE-AFFIRMS it (no suspend latch needed
+    # on this side; see the #5245 latch-durability note in dr-promoter).
+    demoted: false
+    # ── Region-A automatic DR FAILBACK (#5245) ───────────────────────
+    # hw275 G12 proved the failback leg was missing: after a clean
+    # forward promote (region-B TL2) and a region-A recovery, region-A
+    # resumed its OLD TL1 primary role and region-B could never
+    # re-stream ("highest timeline 1 of the primary is behind recovery
+    # timeline 2" FATAL loop) — cross-region replication permanently
+    # dead. failback ships a region-A-local actor (side=primary only)
+    # that detects the post-failover geometry from POSITIVE signals
+    # (local writable on TL n; the pinned sync standby absent; the peer
+    # REACHABLE + WRITABLE + on a HIGHER timeline over the
+    # `-replica-mesh` global Service) and then demotes + RE-CLONES
+    # region-A onto region-B's line via the SOVEREIGN_CNPG_PAIR_DEMOTED
+    # substitute seam. The one destructive act (deleting the local
+    # stale Cluster CR so helm re-creates it as a pg_basebackup replica
+    # of region-B) is gated on the peer being PROVABLY writable + ahead
+    # at that exact tick — the timeline order is the authority proof.
+    failback:
+      enabled: true
+      intervalSeconds: 10
+      # The peer-ahead evidence (local primary + sync standby absent +
+      # peer writable on a higher TL) must hold CONTINUOUSLY this long
+      # before the actor flips the demotion substitute. A transient
+      # mesh blip or a replica restart clears the clock.
+      peerAheadHoldSeconds: 120
+      # A freshly-(re)started signals container must never act on a
+      # half-observed geometry.
+      startupGraceSeconds: 300
+      # pg_isready timeout for the peer probe.
+      livenessProbeTimeoutSeconds: 5
+      # How long an in-place-demoted standby (a Cluster CR that CNPG
+      # demoted in place, keeping its stale TL-n PGDATA) may sit unable
+      # to stream from a writable+ahead peer before the actor escalates
+      # to the re-clone (delete + fresh pg_basebackup). A fresh clone
+      # created AFTER the failback started is NEVER deleted (bounded
+      # destruction: at most one re-clone per failback episode).
+      wedgeHoldSeconds: 600
+      # The flux Kustomization whose postBuild.substitute map carries
+      # the durable SOVEREIGN_CNPG_PAIR_DEMOTED flip (the catalyst-api
+      # enableCNPGPairAfterFullMesh precedent — a custom field manager
+      # on the Kustomization spec survives every reconcile).
+      kustomization:
+        name: bootstrap-kit
+        namespace: flux-system
+      # The region-A HelmRelease (annotations + reconcile nudges only —
+      # the desired state itself rides the substitute).
+      hr:
+        name: bp-cnpg-pair
+        namespace: flux-system
+      # kubectl-bearing image for the actor container (same
+      # harbor-proxy-pull-compliant prefix as the dr-promoter's).
+      kubectlImage:
+        repository: harbor.openova.io/proxy-dockerhub/alpine/k8s
+        tag: "1.30.0"
+        pullPolicy: IfNotPresent
     instances: 3
     storage:
       size: 100Gi
@@ -216,6 +293,30 @@ cnpgPair:
       # (bootstrap-kit slot 16b defaults).
       hr:
         name: bp-cnpg-pair
+        namespace: flux-system
+      # ── #5245 durable-promotion handoff target ──────────────────────
+      # The flux Kustomization that applies slot 16b. hw275 G12 proved
+      # the #5219 suspend latch is NOT durable: kustomize-controller's
+      # managed-fields cleanup claims every `kubectl*`-managed field on
+      # each reconcile (fluxcd kustomization_controller.go — managers
+      # matching the `kubectl` prefix are replaced and their fields,
+      # absent from the manifest, are REMOVED), so `spec.suspend` +
+      # the DR annotations were stripped every bootstrap-kit reconcile
+      # and helm re-demoted the promoted survivor in the seconds before
+      # the self-heal re-latched (hw275: kustomize Apply 06:55:20 →
+      # helm re-demote 06:55:23 → re-latch 06:55:27). Two fixes ride
+      # this value: (a) every actor patch now uses a CUSTOM field
+      # manager (`dr-promoter`), which the cleanup list does not match,
+      # so the latch survives; (b) once the promotion is rendered the
+      # actor performs a DURABLE HANDOFF — it patches this
+      # Kustomization's postBuild.substitute
+      # SOVEREIGN_CNPG_PAIR_PROMOTED="true" so kustomize itself renders
+      # `replica.promoted: true` into the HR desired state, verifies the
+      # render, then LIFTS the suspend latch (the reconciled-topology
+      # end state: flux fully unfrozen, drift-correction re-affirming
+      # the promotion).
+      kustomization:
+        name: bootstrap-kit
         namespace: flux-system
       # kubectl-bearing image for the actor container. Same
       # harbor-proxy-pull-compliant (`*/proxy-*/*`) prefix as the

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.17"
+    version: "0.2.18"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
Refs #5245

## Defect (hw275 G12, dep `7886def2e61c63aa`, 2026-07-19)

After a clean forward region-kill promote (region-B writable TL2, arm-gated, latched), recovering region-A did **not** converge:

- region-A `cnpg-pair-bp-cnpg-pair-primary-1`: `pg_is_in_recovery()=f`, TL=1 — resumed its old primary role (it never knew it was killed).
- region-B `cnpg-pair-bp-cnpg-pair-replica-1`: `pg_is_in_recovery()=t`, TL=2, `spec.replica.enabled=true` — demoted back to a standby whose walreceiver FATAL-loops every 5 s: `FATAL 55000 "highest timeline 1 of the primary is behind recovery timeline 2"`.
- HR `flux-system/bp-cnpg-pair`: `spec.suspend=true`, values `promoted` gone.

Cross-region replication permanently dead; no actor anywhere owned the return leg.

## Root cause — two distinct gaps

**1. The suspend latch was never durable (this is what manufactured the observed state).** Live forensics on hw275: helm deployed release **v4 at 06:55:23** — 2.5 min *after* the latch landed (06:52:54) — re-rendering `replica.enabled=true` and re-demoting the promoted survivor mid-recovery. Mechanism, confirmed against the flux source: kustomize-controller's server-side-apply cleanup **replaces every field manager matching the `kubectl` prefix** with itself on each reconcile of the applying Kustomization and drops the claimed fields absent from its manifest (`kustomization_controller.go`, `fieldManagers` list: `kubectl` Apply+Update, `before-first-apply`). The latch was written with the default `kubectl-patch` manager → every bootstrap-kit reconcile stripped `spec.suspend` + the DR annotations → helm re-demoted in the seconds before the self-heal re-latched (19 re-latches in 30 min on hw275; the `dr-auto-promoted-at` / `dr-timeline-diverged-at` annotations were stripped the same way — both absent from the live HR).

**2. No failback path existed at all.** Nothing detected region-A's return, decided authority, demoted+re-cloned the stale side, or lifted the latch — the #5220-B timeline-divergence surfacing diagnosed the wedge but nothing acted on it.

## Design (chart `bp-cnpg-pair` 0.2.17 → **0.2.18**)

Four coordinated pieces; the forward-path gates (#5220 arm gate, #5239 readable signals, #5218 same-tick latch, 120 s hold, pg_isready gate, sync-only fence) are all preserved.

### (a) Latch durability — custom field managers
Every DR-actor write now carries `--field-manager=dr-promoter` / `--field-manager=dr-failback`. Custom managers are not in flux's cleanup list, so the latch and annotations survive every reconcile (live precedent on hw275: the catalyst-api substitute flips persist under manager `catalyst-api`).

### (b) Durable handoff + latch lift — the substitute seam
The suspend latch stays the **mid-outage** mechanism (helm-only; works from the cached chart artifact with zero kustomize/source dependency — proven mid-outage on hw275, render 1 s after the promote patch). It is no longer the end state: slot 16b now renders `replica.promoted: ${SOVEREIGN_CNPG_PAIR_PROMOTED:-false}` and `primary.demoted: ${SOVEREIGN_CNPG_PAIR_DEMOTED:-false}`, and once a promotion is latched+rendered the promoter patches `SOVEREIGN_CNPG_PAIR_PROMOTED="true"` onto the bootstrap-kit Kustomization's `postBuild.substitute` (the catalyst-api `SOVEREIGN_ENABLE_CNPG_PAIR` precedent — live-verified durable: the Kustomization CR is applied once by cloud-init and never re-applied), verifies the HR renders `promoted: true` from source, then **un-suspends**. Drift-correction thereafter re-affirms the failed-over topology; flux is fully reconciled again. If the substitute is ever lost, the per-tick self-heal re-latches (belt and braces).

### (c) TL-ahead re-promote — the state-X recovery
A standby whose **own timeline is strictly higher than its reachable source's** holds a line the source can never supersede: pre-divergence it was the mandatory `remote_apply` sync target (so it had every acked commit); post-divergence the lower-TL side is write-fenced by its unsatisfiable `FIRST 1`. The promoter reads both timelines via `IDENTIFY_SYSTEM` on replication-protocol connections (the one surface `streaming_replica` is guaranteed — the #5239 lesson) and, once the #5220 divergence wedge has held 300 s, re-promotes through the substitute seam. This deliberately bypasses the #5220 arm gate — sound because a TL-ahead standby can never stream (so it could never arm) and the timeline arithmetic is a strictly stronger proof than the streaming heuristic: no link flap or never-converged pair can manufacture `own-TL > source-TL`. Guards: once per pod lifetime, never after `/shared/diverged` (the hw266 runaway guard stands). This is what un-wedges the exact state hw275 is in now.

### (d) `dr-failback` actor — demote + re-clone region-A onto the promoted line
New side=primary Deployment (#5157 two-container shape), rendered only in sync mode with `crossRegionPeerClusters` wired (no peer probe ⇒ no safe action ⇒ nothing renders). Signals: local writable on TL n + pinned sync standby ABSENT from `pg_stat_replication` (walsender rows run as `streaming_replica` — same-user rows fully visible) + peer REACHABLE, WRITABLE, and on a strictly HIGHER timeline over the new **`-replica-mesh`** global Service (reverse mirror of `-primary-mesh`: CNPG-managed `rw` additional Service on the replica Cluster + zero-backend stub on cluster-A). `TL_peer > TL_local` is antisymmetric — the two regions' actors can never both act. After 120 s of held proof: flip `SOVEREIGN_CNPG_PAIR_DEMOTED="true"` → kustomize renders the demoted shape (primary Cluster CR as a replica cluster of region-B: `replica.enabled: true` + `bootstrap.pg_basebackup`, synchronous block omitted) → delete the stale Cluster CR so helm re-creates it fresh and the basebackup clones region-B's current timeline (PVCs owner-GC).

**Why this direction / why data-safe**: the same sync fence that authorizes the forward promote proves region-B ⊇ every ACKED commit region-A ever made (pre-kill it was the mandatory sync target; post-recovery region-A is write-fenced by its unsatisfiable `FIRST 1`). Discarding region-A's line loses only never-acked local WAL — what the RPO=0 contract already discards. The reverse re-clone (B from A) would destroy acknowledged post-promote writes and is never automatic.

**Why not `pg_rewind`**: CNPG has no cross-cluster rewind trigger, and rewind's fork-point arithmetic depends on WAL-tail geometry the actor cannot verify; the basebackup re-clone is deterministic for every geometry (cost: one full copy on the recovery leg — disclosed in DESIGN.md §10).

**Bounded destruction**: delete only the resourceNames-pinned Cluster CR, only with a <60 s-fresh peer-writable-and-ahead proof at that tick, and never a Cluster created after the failback episode began — an in-place-demoted stale standby (if the CNPG webhook admits the shape change on the live CR) is re-cloned only via the wedge escalation (600 s unable to stream, `creationTimestamp` predating `dr-failback-started-at`); a fresh clone is never deleted. No PVC/pod verbs anywhere; no live Cluster-CR patches (#5125-D1 doctrine).

**Auth — shared client CA**: the rejoin stream + peer probe present region-A's own `-primary-replication` cert; region-B accepts it because the replica Cluster now pins `certificates.clientCASecret` to the shared `-primary-ca` (already synced A→B **with `ca.key`** at the post-mesh flip — live-verified hw275; CNPG generates `<replica>-replication` from a BYO client CA when `replicationTLSSecret` is unset, per `cluster_pki.go`, so every existing consumer keeps its mounts).

**End state after kill+recover**: region-B primary, region-A streaming replica, both HRs unsuspended, topology rendered from source. The controlled switchback to original roles (flip both substitutes back) stays a sovereign-admin action per RUNBOOKS §6.1; automating it needs the CNPG demotion-token handshake — follow-up tracked on #5245.

## Files
- `platform/cnpg-pair/chart/templates/dr-failback.yaml` — NEW: the region-A actor (SA, 2×Role, 2×RB, egress CNP, Deployment).
- `platform/cnpg-pair/chart/templates/peer-mesh-service.yaml` — NEW: side=primary `-replica-mesh` stub.
- `platform/cnpg-pair/chart/templates/dr-promoter.yaml` — field managers, durable handoff + latch lift, TL-ahead re-promote, Kustomization RBAC.
- `platform/cnpg-pair/chart/templates/primary-cluster.yaml` — demoted (rejoin) shape.
- `platform/cnpg-pair/chart/templates/replica-cluster.yaml` — shared client CA + `-replica-mesh` managed Service.
- `platform/cnpg-pair/chart/templates/networkpolicy.yaml` — failback signals ingress carve-out.
- `platform/cnpg-pair/chart/values.yaml`, `_helpers.tpl` — `primary.demoted`, `primary.failback.*`, `autoPromote.kustomization`, `failbackActive` / `peerReplicationServiceName` helpers.
- `platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` — new Case 19 + updated Cases 2/12; **all 19 cases green** (`helm template` clean on every permutation).
- Lockstep pins: `clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml` → 0.2.18 (+ the two substitutes), `platform/cnpg-pair/blueprint.yaml` → 0.2.18, `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` delivery pin → 0.2.18 (drift guard green).
- Docs: `platform/cnpg-pair/DESIGN.md` §10, `docs/RUNBOOKS.md` §6.1 step 5.

## Validation status
Render-gate + `helm template` verified on every permutation (default-off byte-identical; side=primary 4+4; side=replica 12 unchanged; peers-wired +7 failback stack). **Not live-validated**: the failback only reproduces via a real kill + os-start recovery, so the proof is the next fresh 2-region prov's kill+recover G12 (region-kill-drill `kill --arm` → promote evidence → `recover --arm` → `dr-failback-converged-at` + streaming pair + both HRs unsuspended). The live hw275 env still carries the pre-0.2.18 wedge; its convergence path after this ships is the TL-ahead re-promote + failback chain on a fresh prov, not a hand-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

