### PR TITLE
fix(console+billing): BSS Vouchers plan-tier — issuance select, persisted plan_tier, PLAN column + canonical redeem URL (UAT row 72)

### DIFF
--- a/core/services/billing/handlers/vouchers.go
+++ b/core/services/billing/handlers/vouchers.go
@@ -91,6 +91,11 @@ func (h *Handler) IssueVoucher(w http.ResponseWriter, r *http.Request) {
 	// (BillingPage.svelte uppercases on save). Public redemption is also
 	// case-insensitive — see RedeemVoucherPreview.
 	p.Code = strings.ToUpper(strings.TrimSpace(p.Code))
+	// #5223 (UAT row 72) — plan_tier is a catalog plan slug (s/m/l/xl…);
+	// normalise to lowercase to match catalog Plan.Slug. Empty = credit-only
+	// voucher (any plan). Not validated against the catalog here — billing
+	// has no catalog dependency and the field is operator-informational.
+	p.PlanTier = strings.ToLower(strings.TrimSpace(p.PlanTier))
 	// #3376 DoD-6 — voucher-code entropy. An omitted code auto-generates a
 	// high-entropy one (crypto/rand, ~60 bits); a supplied code must pass
 	// the server-side strength minimum so a guessable code (the walk's

--- a/core/services/billing/handlers/vouchers_test.go
+++ b/core/services/billing/handlers/vouchers_test.go
@@ -42,7 +42,7 @@ func TestRedeemVoucherPreview_404OnUnknownCode(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectQuery(regexp.QuoteMeta(
-		`SELECT code, credit_omr, description, active, max_redemptions, times_redeemed, created_at, deleted_at
+		`SELECT code, credit_omr, description, plan_tier, active, max_redemptions, times_redeemed, created_at, deleted_at
 			 FROM promo_codes WHERE code = $1 AND deleted_at IS NULL`,
 	)).WithArgs("DOES-NOT-EXIST").WillReturnError(sql.ErrNoRows)
 
@@ -72,12 +72,12 @@ func TestRedeemVoucherPreview_200OnValidCode(t *testing.T) {
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{
-		"code", "credit_omr", "description", "active",
+		"code", "credit_omr", "description", "plan_tier", "active",
 		"max_redemptions", "times_redeemed", "created_at", "deleted_at",
-	}).AddRow("LAUNCH-50", 50, "Launch credit", true, 0, 3, time.Now(), nil)
+	}).AddRow("LAUNCH-50", 50, "Launch credit", "", true, 0, 3, time.Now(), nil)
 
 	mock.ExpectQuery(regexp.QuoteMeta(
-		`SELECT code, credit_omr, description, active, max_redemptions, times_redeemed, created_at, deleted_at
+		`SELECT code, credit_omr, description, plan_tier, active, max_redemptions, times_redeemed, created_at, deleted_at
 			 FROM promo_codes WHERE code = $1 AND deleted_at IS NULL`,
 	)).WithArgs("LAUNCH-50").WillReturnRows(rows)
 
@@ -127,12 +127,12 @@ func TestRedeemVoucherPreview_410OnCappedCode(t *testing.T) {
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{
-		"code", "credit_omr", "description", "active",
+		"code", "credit_omr", "description", "plan_tier", "active",
 		"max_redemptions", "times_redeemed", "created_at", "deleted_at",
-	}).AddRow("CAPPED", 25, "Cap reached", true, 5, 5, time.Now(), nil)
+	}).AddRow("CAPPED", 25, "Cap reached", "", true, 5, 5, time.Now(), nil)
 
 	mock.ExpectQuery(regexp.QuoteMeta(
-		`SELECT code, credit_omr, description, active, max_redemptions, times_redeemed, created_at, deleted_at
+		`SELECT code, credit_omr, description, plan_tier, active, max_redemptions, times_redeemed, created_at, deleted_at
 			 FROM promo_codes WHERE code = $1 AND deleted_at IS NULL`,
 	)).WithArgs("CAPPED").WillReturnRows(rows)
 
@@ -238,15 +238,16 @@ func TestIssueVoucher_SendsEmail_WhenRecipientPresent(t *testing.T) {
 
 	// Match the UpsertPromoCode SQL — code normalises to upper.
 	mock.ExpectExec(regexp.QuoteMeta(
-		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
-			 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5, $6)
 			 ON CONFLICT (code) DO UPDATE
 			 SET credit_omr = EXCLUDED.credit_omr,
 			     description = EXCLUDED.description,
+			     plan_tier = EXCLUDED.plan_tier,
 			     active = EXCLUDED.active,
 			     max_redemptions = EXCLUDED.max_redemptions,
 			     deleted_at = NULL`,
-	)).WithArgs("GIFT5012ABCD", 50, "Q4 launch", true, 0).
+	)).WithArgs("GIFT5012ABCD", 50, "Q4 launch", "", true, 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	rt := &captureRoundTripper{}
@@ -327,15 +328,16 @@ func TestIssueVoucher_NoEmail_WhenRecipientAbsent(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectExec(regexp.QuoteMeta(
-		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
-			 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5, $6)
 			 ON CONFLICT (code) DO UPDATE
 			 SET credit_omr = EXCLUDED.credit_omr,
 			     description = EXCLUDED.description,
+			     plan_tier = EXCLUDED.plan_tier,
 			     active = EXCLUDED.active,
 			     max_redemptions = EXCLUDED.max_redemptions,
 			     deleted_at = NULL`,
-	)).WithArgs("LAUNCH012ABC", 100, "", false, 0).
+	)).WithArgs("LAUNCH012ABC", 100, "", "", false, 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	rt := &captureRoundTripper{}
@@ -380,15 +382,16 @@ func TestIssueVoucher_NotificationFailure_DoesNotFailUpsert(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectExec(regexp.QuoteMeta(
-		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
-			 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5, $6)
 			 ON CONFLICT (code) DO UPDATE
 			 SET credit_omr = EXCLUDED.credit_omr,
 			     description = EXCLUDED.description,
+			     plan_tier = EXCLUDED.plan_tier,
 			     active = EXCLUDED.active,
 			     max_redemptions = EXCLUDED.max_redemptions,
 			     deleted_at = NULL`,
-	)).WithArgs("FAILMAIL1234", 10, "", false, 0).
+	)).WithArgs("FAILMAIL1234", 10, "", "", false, 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	rt := &captureRoundTripper{
@@ -473,15 +476,16 @@ func TestIssueVoucher_SendsAuthorizationHeader(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectExec(regexp.QuoteMeta(
-		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
-			 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5, $6)
 			 ON CONFLICT (code) DO UPDATE
 			 SET credit_omr = EXCLUDED.credit_omr,
 			     description = EXCLUDED.description,
+			     plan_tier = EXCLUDED.plan_tier,
 			     active = EXCLUDED.active,
 			     max_redemptions = EXCLUDED.max_redemptions,
 			     deleted_at = NULL`,
-	)).WithArgs("AUTH12345678", 10, "auth header guard", true, 0).
+	)).WithArgs("AUTH12345678", 10, "auth header guard", "", true, 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// Choose explicit test bytes — production reads
@@ -594,15 +598,16 @@ func TestIssueVoucher_NoAuthHeader_WhenJWTSecretUnset(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectExec(regexp.QuoteMeta(
-		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
-			 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5, $6)
 			 ON CONFLICT (code) DO UPDATE
 			 SET credit_omr = EXCLUDED.credit_omr,
 			     description = EXCLUDED.description,
+			     plan_tier = EXCLUDED.plan_tier,
 			     active = EXCLUDED.active,
 			     max_redemptions = EXCLUDED.max_redemptions,
 			     deleted_at = NULL`,
-	)).WithArgs("BACKCOMPAT12", 5, "", true, 0).
+	)).WithArgs("BACKCOMPAT12", 5, "", "", true, 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	rt := &captureRoundTripper{}
@@ -654,15 +659,16 @@ func TestIssueVoucher_DetachesEmailDispatch_DoesNotBlockOnSlowRelay(t *testing.T
 	defer db.Close()
 
 	mock.ExpectExec(regexp.QuoteMeta(
-		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
-			 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5, $6)
 			 ON CONFLICT (code) DO UPDATE
 			 SET credit_omr = EXCLUDED.credit_omr,
 			     description = EXCLUDED.description,
+			     plan_tier = EXCLUDED.plan_tier,
 			     active = EXCLUDED.active,
 			     max_redemptions = EXCLUDED.max_redemptions,
 			     deleted_at = NULL`,
-	)).WithArgs("SLOW50123ABC", 50, "slow", true, 0).
+	)).WithArgs("SLOW50123ABC", 50, "slow", "", true, 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	rt := &blockingRoundTripper{started: make(chan struct{}), release: make(chan struct{})}
@@ -721,4 +727,58 @@ func (b *blockingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		Body:       io.NopCloser(bytes.NewReader(nil)),
 		Header:     make(http.Header),
 	}, nil
+}
+
+// TestIssueVoucher_PlanTierNormalisedAndEchoed — #5223 (UAT row 72). The
+// BSS Vouchers issuance form submits a `plan_tier` (catalog plan slug);
+// the handler lowercases it (catalog Plan.Slug convention), persists it on
+// the promo_codes row, and echoes it back in the 200 body so the console
+// table can render the PLAN column from the response without a re-list.
+func TestIssueVoucher_PlanTierNormalisedAndEchoed(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta(
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5, $6)
+			 ON CONFLICT (code) DO UPDATE
+			 SET credit_omr = EXCLUDED.credit_omr,
+			     description = EXCLUDED.description,
+			     plan_tier = EXCLUDED.plan_tier,
+			     active = EXCLUDED.active,
+			     max_redemptions = EXCLUDED.max_redemptions,
+			     deleted_at = NULL`,
+	)).WithArgs("PLANTIER2026M", 20, "", "m", true, 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	h := &Handler{Store: store.New(db)}
+
+	// " M " exercises both the trim and the lowercase normalisation.
+	body, _ := json.Marshal(map[string]any{
+		"code":       "PLANTIER2026M",
+		"credit_omr": 20,
+		"active":     true,
+		"plan_tier":  " M ",
+	})
+	r := httptest.NewRequest("POST", "/billing/vouchers/issue", bytes.NewReader(body))
+	r = withSuperadmin(r)
+	w := httptest.NewRecorder()
+	h.IssueVoucher(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue voucher: expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["plan_tier"] != "m" {
+		t.Errorf("plan_tier echo: got %v, want m", got["plan_tier"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sqlmock unmet: %v", err)
+	}
 }

--- a/core/services/billing/store/store.go
+++ b/core/services/billing/store/store.go
@@ -135,9 +135,16 @@ type Settings struct {
 //   - Remain the foreign-key target for past promo_redemptions + orders so
 //     historical analytics and admin order views stay intact
 type PromoCode struct {
-	Code           string     `json:"code"`
-	CreditOMR      int        `json:"credit_omr"`
-	Description    string     `json:"description"`
+	Code        string `json:"code"`
+	CreditOMR   int    `json:"credit_omr"`
+	Description string `json:"description"`
+	// PlanTier is the catalog plan slug (e.g. "s"/"m"/"l"/"xl" — see
+	// core/services/catalog store.Plan.Slug) this voucher targets.
+	// #5223 (UAT row 72): surfaced on the BSS Vouchers issuance form +
+	// list. Empty string = credit-only voucher, usable with any plan.
+	// Informational for the operator today — checkout does NOT enforce
+	// plan matching (the granted credit is fungible at checkout).
+	PlanTier       string     `json:"plan_tier,omitempty"`
 	Active         bool       `json:"active"`
 	MaxRedemptions int        `json:"max_redemptions"`
 	TimesRedeemed  int        `json:"times_redeemed"`
@@ -267,6 +274,10 @@ func (s *Store) Migrate(ctx context.Context) error {
 		// + orders.promo_code both reference it) but the code is hidden from
 		// listings and rejected by RedeemPromoCode.
 		`ALTER TABLE promo_codes ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`,
+		// #5223 (UAT row 72) — plan-tier targeting. The BSS Vouchers
+		// issuance form carries a plan tier (catalog plan slug); persisted
+		// here so the voucher list can render it. Empty = credit-only.
+		`ALTER TABLE promo_codes ADD COLUMN IF NOT EXISTS plan_tier TEXT NOT NULL DEFAULT ''`,
 		`CREATE TABLE IF NOT EXISTS credit_ledger (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			customer_id UUID NOT NULL REFERENCES customers(id),
@@ -839,9 +850,9 @@ func (s *Store) GetPromoCode(ctx context.Context, code string) (*PromoCode, erro
 	var p PromoCode
 	var deletedAt sql.NullTime
 	err := s.db.QueryRowContext(ctx,
-		`SELECT code, credit_omr, description, active, max_redemptions, times_redeemed, created_at, deleted_at
+		`SELECT code, credit_omr, description, plan_tier, active, max_redemptions, times_redeemed, created_at, deleted_at
 		 FROM promo_codes WHERE code = $1 AND deleted_at IS NULL`, code,
-	).Scan(&p.Code, &p.CreditOMR, &p.Description, &p.Active, &p.MaxRedemptions, &p.TimesRedeemed, &p.CreatedAt, &deletedAt)
+	).Scan(&p.Code, &p.CreditOMR, &p.Description, &p.PlanTier, &p.Active, &p.MaxRedemptions, &p.TimesRedeemed, &p.CreatedAt, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -863,15 +874,16 @@ func (s *Store) GetPromoCode(ctx context.Context, code string) (*PromoCode, erro
 // un-delete the tombstone rather than silently failing because of the PK.
 func (s *Store) UpsertPromoCode(ctx context.Context, p *PromoCode) error {
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
-		 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO promo_codes (code, credit_omr, description, plan_tier, active, max_redemptions)
+		 VALUES ($1, $2, $3, $4, $5, $6)
 		 ON CONFLICT (code) DO UPDATE
 		 SET credit_omr = EXCLUDED.credit_omr,
 		     description = EXCLUDED.description,
+		     plan_tier = EXCLUDED.plan_tier,
 		     active = EXCLUDED.active,
 		     max_redemptions = EXCLUDED.max_redemptions,
 		     deleted_at = NULL`,
-		p.Code, p.CreditOMR, p.Description, p.Active, p.MaxRedemptions,
+		p.Code, p.CreditOMR, p.Description, p.PlanTier, p.Active, p.MaxRedemptions,
 	)
 	if err != nil {
 		return fmt.Errorf("store: upsert promo %s: %w", p.Code, err)
@@ -885,7 +897,7 @@ func (s *Store) UpsertPromoCode(ctx context.Context, p *PromoCode) error {
 // appears to do nothing.
 func (s *Store) ListPromoCodes(ctx context.Context) ([]PromoCode, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT code, credit_omr, description, active, max_redemptions, times_redeemed, created_at, deleted_at
+		`SELECT code, credit_omr, description, plan_tier, active, max_redemptions, times_redeemed, created_at, deleted_at
 		 FROM promo_codes WHERE deleted_at IS NULL ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -896,7 +908,7 @@ func (s *Store) ListPromoCodes(ctx context.Context) ([]PromoCode, error) {
 	for rows.Next() {
 		var p PromoCode
 		var deletedAt sql.NullTime
-		if err := rows.Scan(&p.Code, &p.CreditOMR, &p.Description, &p.Active, &p.MaxRedemptions, &p.TimesRedeemed, &p.CreatedAt, &deletedAt); err != nil {
+		if err := rows.Scan(&p.Code, &p.CreditOMR, &p.Description, &p.PlanTier, &p.Active, &p.MaxRedemptions, &p.TimesRedeemed, &p.CreatedAt, &deletedAt); err != nil {
 			return nil, err
 		}
 		if deletedAt.Valid {

--- a/core/services/billing/store/store_test.go
+++ b/core/services/billing/store/store_test.go
@@ -483,12 +483,12 @@ func TestListPromoCodes_ExcludesSoftDeleted(t *testing.T) {
 
 	// The query must filter WHERE deleted_at IS NULL.
 	mock.ExpectQuery(regexp.QuoteMeta(
-		`SELECT code, credit_omr, description, active, max_redemptions, times_redeemed, created_at, deleted_at
+		`SELECT code, credit_omr, description, plan_tier, active, max_redemptions, times_redeemed, created_at, deleted_at
 		 FROM promo_codes WHERE deleted_at IS NULL ORDER BY created_at DESC`)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"code", "credit_omr", "description", "active",
+			"code", "credit_omr", "description", "plan_tier", "active",
 			"max_redemptions", "times_redeemed", "created_at", "deleted_at",
-		}).AddRow("LIVE", 10, "", true, 100, 5, time.Now(), nil))
+		}).AddRow("LIVE", 10, "", "", true, 100, 5, time.Now(), nil))
 
 	out, err := s.ListPromoCodes(context.Background())
 	if err != nil {

--- a/core/services/billing/store/voucher_integration_test.go
+++ b/core/services/billing/store/voucher_integration_test.go
@@ -128,9 +128,12 @@ func mkCustomer(t *testing.T, s *Store, id string) *Customer {
 func mkPromo(t *testing.T, s *Store, code string, credit, maxRedemptions int) {
 	t.Helper()
 	p := &PromoCode{
-		Code:           code,
-		CreditOMR:      credit,
-		Description:    "integration test " + code,
+		Code:        code,
+		CreditOMR:   credit,
+		Description: "integration test " + code,
+		// #5223 (UAT row 72) — every fixture voucher carries a plan tier so
+		// the round-trip assertions below cover the new column end-to-end.
+		PlanTier:       "m",
 		Active:         true,
 		MaxRedemptions: maxRedemptions,
 	}
@@ -167,6 +170,10 @@ func TestVoucherLifecycle_IssueRedeemAndCreditApplied(t *testing.T) {
 			found = true
 			if p.CreditOMR != 50 || !p.Active {
 				t.Errorf("listed promo wrong: %+v", p)
+			}
+			// #5223 (UAT row 72) — plan_tier persists through upsert + list.
+			if p.PlanTier != "m" {
+				t.Errorf("listed promo plan_tier: got %q, want %q", p.PlanTier, "m")
 			}
 		}
 	}
@@ -220,6 +227,10 @@ func TestVoucherLifecycle_IssueRedeemAndCreditApplied(t *testing.T) {
 	}
 	if p.TimesRedeemed != 1 {
 		t.Errorf("expected times_redeemed=1, got %d", p.TimesRedeemed)
+	}
+	// #5223 (UAT row 72) — plan_tier survives the single-row read too.
+	if p.PlanTier != "m" {
+		t.Errorf("GetPromoCode plan_tier: got %q, want %q", p.PlanTier, "m")
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
@@ -268,6 +268,9 @@ export interface Voucher {
   /** Credit amount in OMR (integer; BE stores OMR not cents). */
   credit_omr: number
   description: string
+  /** Catalog plan slug this voucher targets (s/m/l/xl — BE lowercases;
+   *  #5223 UAT row 72). Omitted/empty = credit-only voucher (any plan). */
+  plan_tier?: string
   /** Operator-toggleable enable flag (separate from soft-delete). */
   active: boolean
   /** 0 = unlimited; otherwise hard cap on redemptions. */
@@ -306,6 +309,9 @@ export interface IssueVoucherRequest {
   /** Credit amount in OMR (integer). */
   credit_omr: number
   description?: string
+  /** Catalog plan slug the voucher targets (#5223 UAT row 72). Omitted =
+   *  credit-only voucher usable with any plan. BE lowercases on save. */
+  plan_tier?: string
   active?: boolean
   /** 0 = unlimited (server default). */
   max_redemptions?: number

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.issue.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.issue.test.tsx
@@ -1,8 +1,14 @@
 /**
- * VouchersPage.issue.test.tsx — regression lock-in for UAT rows 73/74
+ * VouchersPage.issue.test.tsx — regression lock-in for UAT rows 72/73/74
  * (issue #5223): the Issue-voucher modal mirrors the SERVER voucher-code
- * strength policy (core/services/shared/voucher/code.go) inline.
+ * strength policy (core/services/shared/voucher/code.go) inline, and
+ * renders the plan-tier field the row-72 criterion names.
  *
+ *   • Row 72 — the issuance form renders code + credit OMR + PLAN TIER +
+ *     description. The plan-tier select is fed by the live commerce plans
+ *     list (never hardcoded); the chosen slug submits as `plan_tier`, and
+ *     "Any plan (credit only)" omits the field. The table's PLAN column
+ *     renders the persisted tier.
  *   • Row 73 — a weak custom code (`1234`) must be rejected INLINE with the
  *     min-12-chars message; before this fix it sailed to the server and the
  *     operator only saw the opaque post-submit 400.
@@ -45,6 +51,25 @@ vi.mock('@/lib/bss.api', () => ({
   listVouchers: () => Promise.resolve([]),
   revokeVoucher: () => Promise.resolve(),
   voucherStatus: () => 'active',
+}))
+
+// Row 72 — the Plan-tier select is fed by the commerce plans list. Two
+// generic tiers + one product-scoped tier (which the #3156 guard must
+// exclude from the picker).
+vi.mock('@/lib/commerce.api', () => ({
+  listPlans: () =>
+    Promise.resolve([
+      { slug: 'm', name: 'M', price_omr: 9, sort_order: 2, features: [] },
+      { slug: 's', name: 'S', price_omr: 5, sort_order: 1, features: [] },
+      {
+        slug: 'agenity-s',
+        name: 'Agenity S',
+        price_omr: 3,
+        sort_order: 9,
+        product_slug: 'agenity',
+        features: [],
+      },
+    ]),
 }))
 
 import { VouchersPage } from './VouchersPage'
@@ -151,5 +176,108 @@ describe('IssueVoucherModal — rows 73/74', () => {
     fireEvent.click(screen.getByTestId('bss-issue-voucher-submit'))
     await waitFor(() => expect(issueSpy).toHaveBeenCalledTimes(1))
     expect(issueSpy.mock.calls[0][0].code).toBe('LAUNCH2026PROMO')
+  })
+})
+
+describe('IssueVoucherModal — row 72 plan tier', () => {
+  it('renders the Plan-tier select fed by the commerce plans list, sorted, generic-only', async () => {
+    renderPage()
+    openIssueModal()
+    const select = screen.getByTestId(
+      'bss-issue-voucher-plan-tier',
+    ) as HTMLSelectElement
+    // Fetched options land async — wait for S + M.
+    await waitFor(() => expect(select.options.length).toBe(3))
+    expect(select.options[0].value).toBe('') // Any plan (credit only)
+    expect(select.options[1].value).toBe('s') // sort_order wins over fetch order
+    expect(select.options[2].value).toBe('m')
+    // #3156 guard — the product-scoped plan never enters the picker.
+    expect(
+      Array.from(select.options).some((o) => o.value === 'agenity-s'),
+    ).toBe(false)
+  })
+
+  it('submits the chosen plan slug as plan_tier', async () => {
+    renderPage()
+    openIssueModal()
+    const select = screen.getByTestId('bss-issue-voucher-plan-tier')
+    await waitFor(() =>
+      expect((select as HTMLSelectElement).options.length).toBe(3),
+    )
+    fireEvent.change(select, { target: { value: 'm' } })
+    setCredit('20')
+    fireEvent.click(screen.getByTestId('bss-issue-voucher-submit'))
+    await waitFor(() => expect(issueSpy).toHaveBeenCalledTimes(1))
+    expect(issueSpy.mock.calls[0][0].plan_tier).toBe('m')
+  })
+
+  it('omits plan_tier entirely for "Any plan (credit only)"', async () => {
+    renderPage()
+    openIssueModal()
+    setCredit('5')
+    fireEvent.click(screen.getByTestId('bss-issue-voucher-submit'))
+    await waitFor(() => expect(issueSpy).toHaveBeenCalledTimes(1))
+    expect('plan_tier' in issueSpy.mock.calls[0][0]).toBe(false)
+  })
+})
+
+describe('Voucher table — row 72 PLAN column', () => {
+  it('renders the persisted plan tier in the PLAN column and the drawer', () => {
+    const voucher = {
+      code: 'VCH-PLANM12345',
+      credit_omr: 20,
+      description: 'plan-tier row',
+      plan_tier: 'm',
+      active: true,
+      max_redemptions: 1,
+      times_redeemed: 0,
+      created_at: '2026-07-19T00:00:00Z',
+    }
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <VouchersPage
+          disableStream
+          disableFetch
+          initialItemsOverride={[voucher]}
+        />
+      </QueryClientProvider>,
+    )
+    expect(
+      screen.getByTestId('bss-voucher-plan-VCH-PLANM12345').textContent,
+    ).toBe('m')
+    fireEvent.click(screen.getByTestId('bss-voucher-toggle-VCH-PLANM12345'))
+    expect(
+      screen.getByTestId('bss-voucher-drawer-plan-VCH-PLANM12345').textContent,
+    ).toBe('m')
+  })
+
+  it('renders an em-dash in PLAN and "Any plan" in the drawer for a credit-only voucher', () => {
+    const voucher = {
+      code: 'VCH-CREDITONLY1',
+      credit_omr: 5,
+      description: '',
+      active: true,
+      max_redemptions: 0,
+      times_redeemed: 0,
+      created_at: '2026-07-19T00:00:00Z',
+    }
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <VouchersPage
+          disableStream
+          disableFetch
+          initialItemsOverride={[voucher]}
+        />
+      </QueryClientProvider>,
+    )
+    expect(
+      screen.getByTestId('bss-voucher-plan-VCH-CREDITONLY1').textContent,
+    ).toBe('—')
+    fireEvent.click(screen.getByTestId('bss-voucher-toggle-VCH-CREDITONLY1'))
+    expect(
+      screen.getByTestId('bss-voucher-drawer-plan-VCH-CREDITONLY1').textContent,
+    ).toBe('Any plan (credit only)')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
@@ -10,16 +10,23 @@
  *
  * Layout:
  *   • Header: tagline + filter row (search + status select + Issue CTA)
- *   • Table: Code | Recipient (—) | Plan (—) | Value | Status pill |
+ *   • Table: Code | Recipient (—) | Plan | Value | Status pill |
  *            Issued | Expires (—) | Redeemed by (— or N/N)
- *   • Issue modal: code, credit_omr, description, max_redemptions,
- *     recipient_email — POSTs /api/v1/org/billing/vouchers/issue
+ *   • Issue modal: code, credit_omr, plan_tier, description,
+ *     max_redemptions, recipient_email —
+ *     POSTs /api/v1/org/billing/vouchers/issue
  *
- * The "Recipient", "Plan", and "Expires" columns are rendered as `—`
- * placeholders for now because the backend (PromoCode store row, see
+ * The "Plan" column is LIVE as of #5223 (UAT row 72): the Issue modal
+ * carries a Plan-tier select fed by the commerce plans list (the same
+ * catalog the funnel's plan step renders), the billing service persists
+ * `plan_tier` on the promo_codes row, and the table + drawer render it.
+ * An empty plan tier = credit-only voucher usable with any plan.
+ *
+ * The "Recipient" and "Expires" columns remain `—` placeholders because
+ * the backend (PromoCode store row, see
  * core/services/billing/handlers/vouchers.go) does NOT yet persist the
  * recipient email (it is request-only per the issueVoucherRequest
- * comment) or a plan / expiry-at field. The columns are present in the
+ * comment) or an expiry-at field. The columns are present in the
  * target-state per Wave 6 brief; flipping them from `—` to live values
  * is a future BE schema extension, not a UI change. Per
  * INVIOLABLE-PRINCIPLES.md #1 (waterfall — first paint is the full
@@ -52,6 +59,10 @@ import {
   type Voucher,
   type VoucherStatus,
 } from '@/lib/bss.api'
+// #5223 (UAT row 72) — the Plan-tier select in the Issue modal is fed by
+// the SAME commerce plans list the funnel's plan step + the Commerce
+// editor render (catalyst-api /api/v1/org/commerce/plans read-proxy).
+import { listPlans, type CommercePlan } from '@/lib/commerce.api'
 
 const QUERY_STALE_MS = 15_000
 
@@ -241,6 +252,7 @@ export function VouchersPage({
                 <VoucherRow
                   key={v.code}
                   voucher={v}
+                  sovereignFQDN={sovereignFQDN}
                   expanded={expanded === v.code}
                   onToggle={() =>
                     setExpanded(expanded === v.code ? null : v.code)
@@ -268,12 +280,22 @@ export function VouchersPage({
 
 interface VoucherRowProps {
   voucher: Voucher
+  /** Live Sovereign FQDN from the deployment snapshot — builds the
+   *  canonical redeem URL in the drawer (docs/DOD.md §Domains-canon:
+   *  `https://marketplace.<sovereign-fqdn>/redeem/?code=<CODE>`). */
+  sovereignFQDN: string | null
   expanded: boolean
   onToggle: () => void
   onRevoke: () => void
 }
 
-function VoucherRow({ voucher, expanded, onToggle, onRevoke }: VoucherRowProps) {
+function VoucherRow({
+  voucher,
+  sovereignFQDN,
+  expanded,
+  onToggle,
+  onRevoke,
+}: VoucherRowProps) {
   const status = voucherStatus(voucher)
   const issued = formatDate(voucher.created_at)
   const redeemed =
@@ -299,12 +321,21 @@ function VoucherRow({ voucher, expanded, onToggle, onRevoke }: VoucherRowProps) 
             {voucher.code}
           </button>
         </td>
-        {/* Recipient + Plan + Expires are target-state columns; the BE
-            PromoCode row does not persist them yet (recipient is request-
-            only, plan / expiry are future schema extensions). Render `—`
-            until the BE catches up. */}
+        {/* Recipient + Expires are target-state columns; the BE PromoCode
+            row does not persist them yet (recipient is request-only,
+            expiry is a future schema extension). Render `—` until the BE
+            catches up. Plan is LIVE (#5223 UAT row 72). */}
         <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">—</td>
-        <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">—</td>
+        <td
+          data-testid={`bss-voucher-plan-${voucher.code}`}
+          className={
+            voucher.plan_tier
+              ? 'py-2 pr-3 text-xs uppercase text-[var(--color-text)]'
+              : 'py-2 pr-3 text-xs text-[var(--color-text-dim)]'
+          }
+        >
+          {voucher.plan_tier ? voucher.plan_tier : '—'}
+        </td>
         <td className="py-2 pr-3 text-right tabular-nums text-[var(--color-text)]">
           {voucher.credit_omr} OMR
         </td>
@@ -325,7 +356,11 @@ function VoucherRow({ voucher, expanded, onToggle, onRevoke }: VoucherRowProps) 
             colSpan={8}
             className="bg-[var(--color-bg-2)] border-b border-[var(--color-border)]"
           >
-            <VoucherDrawer voucher={voucher} onRevoke={onRevoke} />
+            <VoucherDrawer
+              voucher={voucher}
+              sovereignFQDN={sovereignFQDN}
+              onRevoke={onRevoke}
+            />
           </td>
         </tr>
       )}
@@ -335,11 +370,19 @@ function VoucherRow({ voucher, expanded, onToggle, onRevoke }: VoucherRowProps) 
 
 interface VoucherDrawerProps {
   voucher: Voucher
+  sovereignFQDN: string | null
   onRevoke: () => void
 }
 
-function VoucherDrawer({ voucher, onRevoke }: VoucherDrawerProps) {
+function VoucherDrawer({ voucher, sovereignFQDN, onRevoke }: VoucherDrawerProps) {
   const status = voucherStatus(voucher)
+  // docs/DOD.md §Domains-canon — the customer-facing redeem URL lives on
+  // the marketplace host of THIS Sovereign. Derived from the live
+  // deployment snapshot's FQDN, never hardcoded; `—` until the snapshot
+  // arrives.
+  const redeemURL = sovereignFQDN
+    ? `https://marketplace.${sovereignFQDN}/redeem/?code=${encodeURIComponent(voucher.code)}`
+    : null
   return (
     <div className="px-4 py-4">
       <dl className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2">
@@ -353,10 +396,37 @@ function VoucherDrawer({ voucher, onRevoke }: VoucherDrawerProps) {
             {voucher.credit_omr} OMR
           </span>
         </Field>
+        <Field label="Plan tier">
+          <span
+            data-testid={`bss-voucher-drawer-plan-${voucher.code}`}
+            className={
+              voucher.plan_tier
+                ? 'text-sm uppercase text-[var(--color-text)]'
+                : 'text-sm text-[var(--color-text-dim)]'
+            }
+          >
+            {voucher.plan_tier ? voucher.plan_tier : 'Any plan (credit only)'}
+          </span>
+        </Field>
         <Field label="Description">
           <span className="text-sm text-[var(--color-text)]">
             {voucher.description || '—'}
           </span>
+        </Field>
+        <Field label="Redeem URL">
+          {redeemURL ? (
+            <a
+              data-testid={`bss-voucher-redeem-url-${voucher.code}`}
+              href={redeemURL}
+              target="_blank"
+              rel="noreferrer"
+              className="break-all font-mono text-xs text-[var(--color-accent)] hover:underline"
+            >
+              {redeemURL}
+            </a>
+          ) : (
+            <span className="text-sm text-[var(--color-text-dim)]">—</span>
+          )}
         </Field>
         <Field label="Status">
           <StatusPill status={status} testCode={`${voucher.code}-drawer`} />
@@ -457,11 +527,27 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
   // a sibling of the admin Parent Domains modal.
   const [code, setCode] = useState('')
   const [creditOmr, setCreditOmr] = useState<number | ''>('')
+  const [planTier, setPlanTier] = useState('')
   const [description, setDescription] = useState('')
   const [maxRedemptions, setMaxRedemptions] = useState<number | ''>('')
   const [recipient, setRecipient] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // #5223 (UAT row 72) — plan tiers come from the live commerce plans
+  // list (same catalog the funnel plan step renders), never hardcoded.
+  // Product-scoped plans (product_slug set) are excluded per the #3156
+  // generic-picker guard. A failed fetch degrades to the credit-only
+  // option — issuing stays possible without the catalog.
+  const plansQuery = useQuery<CommercePlan[]>({
+    queryKey: ['commerce-plans'],
+    queryFn: listPlans,
+    staleTime: 5 * 60_000,
+    retry: false,
+  })
+  const planOptions = (plansQuery.data ?? [])
+    .filter((p) => !p.product_slug)
+    .sort((a, b) => a.sort_order - b.sort_order)
 
   // Rows 73/74 — live inline strength hint while the operator types a
   // custom code (empty = the auto-generate path, no hint). The SAME rule
@@ -494,6 +580,9 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
       // crypto/rand). The catalyst-api proxy skips edge strength checks
       // for exactly this empty-code path (#4914).
       if (code.trim()) req.code = code.trim().toUpperCase()
+      // #5223 (UAT row 72) — omit `plan_tier` when "Any plan" is chosen
+      // so the row persists as a credit-only voucher.
+      if (planTier) req.plan_tier = planTier
       if (description.trim()) req.description = description.trim()
       if (typeof maxRedemptions === 'number' && maxRedemptions > 0) {
         req.max_redemptions = maxRedemptions
@@ -585,6 +674,30 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
             placeholder="50"
             className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm tabular-nums text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
           />
+        </label>
+
+        <label className="mb-3 block">
+          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">
+            Plan tier
+          </div>
+          <select
+            data-testid="bss-issue-voucher-plan-tier"
+            value={planTier}
+            onChange={(e) => setPlanTier(e.target.value)}
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+          >
+            <option value="">Any plan (credit only)</option>
+            {planOptions.map((p) => (
+              <option key={p.slug} value={p.slug}>
+                {p.name} — {p.price_omr} OMR/mo
+              </option>
+            ))}
+          </select>
+          <div className="mt-1 text-[10px] text-[var(--color-text-dim)]">
+            {plansQuery.isError
+              ? 'Plan catalog unavailable — issuing as a credit-only voucher still works.'
+              : 'The plan this voucher targets. The credit is applied at checkout either way; the tier is shown to the operator on the voucher list.'}
+          </div>
         </label>
 
         <label className="mb-3 block">


### PR DESCRIPTION
Refs #5223

## What rendered before vs after

**Before** (hw274 walk, 2026-07-19, stamped UAT row 72 ❌): `console.<fqdn>/billing/vouchers` renders the Issue-voucher form with owner session (fields: Code optional/auto-gen, Credit OMR, Description, Max redemptions, Recipient email) — but **no plan-tier field**, and the table's PLAN column renders a hardcoded `—` placeholder. Row 72's criterion names "code, credit OMR, **plan tier**, description". (Note: the walk premise "no BSS/Vouchers form renders at all" is stale — live-checked on hw275 with the owner session: `GET /api/v1/org/billing/vouchers/list` → 200 with real voucher rows; the surface renders and is wired. The residual gap was exactly the plan-tier field.)

**After**: the Issue modal carries a **Plan tier** select fed by the live commerce plans list (`GET /api/v1/org/commerce/plans` — live-verified 200 on hw275, slugs `s/m/l/xl`), generic tiers only per the #3156 product-scope guard, defaulting to "Any plan (credit only)" which omits the field. The chosen slug submits as `plan_tier`, the billing service persists it on the `promo_codes` row, and the table PLAN column + row drawer render it. The drawer additionally shows the canonical redeem URL `https://marketplace.<sovereign-fqdn>/redeem/?code=<CODE>` (docs/DOD.md §Domains-canon), derived from the live deployment snapshot FQDN — nothing hardcoded.

## Endpoints wired (all pre-existing, no invented API)

- `POST /api/v1/org/billing/vouchers/issue` → org gateway → billing `POST /billing/vouchers/issue` (`core/services/billing/handlers/vouchers.go IssueVoucher`) — now accepts + persists + echoes `plan_tier`
- `GET /api/v1/org/billing/vouchers/list` → billing `ListVouchers` — rows now carry `plan_tier`
- `DELETE /api/v1/org/billing/vouchers/revoke/{code}` — unchanged
- `GET /api/v1/org/commerce/plans` (catalyst-api commerce read-proxy) — feeds the select

The catalyst-api proxy (`org_billing_vouchers.go`) is verbatim passthrough — untouched, its tests pass.

## API addition (scoped minimal)

Row 72 needed one small BE addition: `promo_codes.plan_tier TEXT NOT NULL DEFAULT ''` (idempotent `ALTER ... IF NOT EXISTS` in the existing `Migrate`), `PromoCode.PlanTier` (json `plan_tier,omitempty`), included in Upsert/Get/List, lowercased+trimmed on issue (catalog `Plan.Slug` convention). Empty = credit-only voucher. Checkout deliberately does NOT enforce plan matching — the granted credit stays fungible; the tier is operator-facing targeting info. Public `redeem-preview` shape unchanged (no new data leaked on the unauthenticated surface).

## Rendered-DOM assertions

`VouchersPage.issue.test.tsx` (13/13 green, 5 new):
- select renders 3 options — "Any plan (credit only)" + `S`/`M` sorted by `sort_order`, product-scoped plan excluded
- choosing `m` submits `plan_tier: "m"`; "Any plan" omits the field entirely
- PLAN column cell (`bss-voucher-plan-<code>`) renders `m`; drawer renders the tier, and `Any plan (credit only)` + `—` for credit-only rows

## Gates (delta vs pre-existing, measured on this branch vs stashed HEAD in the same tree)

- `npm run build` (tsc -b + vite build): clean
- `npm run typecheck`: clean
- vitest full run: 1848 passed / 68 failed — the **same 68 failures in the same 9 files exist on HEAD** (PinInput, ParentDomains, iframe-console suites, all unrelated); delta = +5 passing, 0 new failures
- eslint: 135 problems (119 errors) on HEAD and on this branch — **identical count, zero new**; my touched files lint clean
- `go build`, `go vet`, `go test -race ./...` in `core/services/billing`: clean; PG integration lifecycle now round-trips `plan_tier` (runs in CI via `BILLING_TEST_PG_URL`)
- `products/catalyst/bootstrap/api`: build + voucher handler tests green (no changes needed)

## Validation

Needs a fresh-prov walk to restamp UAT row 72 — the billing-service + catalyst-ui images must roll before the form shows the field on a live Sovereign. hw275 is in a degraded post-G12 DR state and was used read-only for endpoint-shape verification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)