### PR TITLE
fix(pool-domain-manager): add explicit mcp A record to the canonical child-zone set

### DIFF
--- a/core/pool-domain-manager/internal/allocator/allocator.go
+++ b/core/pool-domain-manager/internal/allocator/allocator.go
@@ -26,12 +26,12 @@
 //     at the OpenOva NS endpoints. For BYO the operator's registrar handles
 //     delegation and PDM only owns the child zone — no parent touch.
 //
-//   - Each child zone publishes the canonical 8-record set: apex A,
-//     wildcard A, plus console/api/marketplace/gitea/harbor/registry A — all
-//     pointing at the regional Load Balancer IP (console/api/marketplace ride
-//     the dedicated console LB when one exists). Wildcard TLS is therefore scoped per
-//     Sovereign (`*.<sub>.<pool>`), satisfying the per-Sovereign isolation
-//     requirement in the issue body for #168.
+//   - Each child zone publishes the canonical 9-record set: apex A,
+//     wildcard A, plus console/api/marketplace/gitea/harbor/registry/mcp A —
+//     all pointing at the regional Load Balancer IP (console/api/marketplace
+//     ride the dedicated console LB when one exists). Wildcard TLS is therefore
+//     scoped per Sovereign (`*.<sub>.<pool>`), satisfying the per-Sovereign
+//     isolation requirement in the issue body for #168.
 //
 //   - DNSSEC is mandatory. Every child zone is signed with a fresh KSK+ZSK
 //     pair (algorithm 13, ECDSAP256SHA256). Per-Sovereign keys allow
@@ -66,7 +66,7 @@ type DNSWriter interface {
 	// AddARecord upserts a single A record inside a zone.
 	AddARecord(ctx context.Context, zone, name, ipv4 string, ttl int) error
 	// PatchRRSets is the lower-level batch primitive the allocator uses for
-	// the canonical 8-record set in a single round-trip.
+	// the canonical 9-record set in a single round-trip.
 	PatchRRSets(ctx context.Context, zone string, rrsets []pdns.RRSet) error
 	// AddNSDelegation upserts the NS delegation RRset inside the parent zone.
 	AddNSDelegation(ctx context.Context, parentZone, childName string, nameservers []string, ttl int) error
@@ -317,16 +317,16 @@ type CommitInput struct {
 	ConsoleLoadBalancerIP string
 }
 
-// Commit flips a reservation to ACTIVE and writes the canonical 8-record set
-// (apex, wildcard, console, api, marketplace, gitea, harbor, registry) into the
-// CHILD zone. All records point at the supplied LB IP and use TTL 300 for fast
-// failover.
+// Commit flips a reservation to ACTIVE and writes the canonical 9-record set
+// (apex, wildcard, console, api, marketplace, gitea, harbor, registry, mcp)
+// into the CHILD zone. All records point at the supplied LB IP and use TTL 300
+// for fast failover.
 //
 // Order of operations:
 //  1. Verify the row + reservation token (single row-locked Postgres tx).
 //  2. Update row to state='active' (same tx).
 //  3. Commit the tx.
-//  4. PATCH the 8 RRsets into the child zone in a single PowerDNS PATCH
+//  4. PATCH the 9 RRsets into the child zone in a single PowerDNS PATCH
 //     (atomic at the PowerDNS API layer).
 //
 // If step 4 fails we LEAVE the row in state='active' and surface the error
@@ -560,7 +560,7 @@ func childZoneName(poolDomain, subdomain string) string {
 	return strings.ToLower(strings.TrimSpace(subdomain)) + "." + strings.ToLower(strings.TrimSpace(poolDomain))
 }
 
-// canonicalRecordSet returns the 8-RRset payload PowerDNS PATCH expects to
+// canonicalRecordSet returns the 9-RRset payload PowerDNS PATCH expects to
 // publish a fresh Sovereign:
 //
 //	@            A   <lb>          (apex of the child zone)
@@ -571,6 +571,7 @@ func childZoneName(poolDomain, subdomain string) string {
 //	gitea        A   <lb>
 //	harbor       A   <lb>
 //	registry     A   <lb>          (#5225 — Harbor's primary host; shared gateway)
+//	mcp          A   <lb>          (#5206 — Sovereign-mode OpenOva MCP; shared gateway)
 //
 // #4053 — the console-gateway names point at consoleLBIP (the dedicated console
 // LB → cilium-gateway-console) so a poisoned SHARED-gateway CEC can never 404
@@ -592,7 +593,8 @@ func childZoneName(poolDomain, subdomain string) string {
 // dropped consoleLBIP entirely) console/api/marketplace ALL collapsed onto lbIP,
 // occluding the correct parent-zone records and failing the Phase-1 console
 // readiness gate so handover never fired. Every remaining name (apex, wildcard,
-// gitea, harbor, registry) always points at lbIP (the shared gateway) regardless.
+// gitea, harbor, registry, mcp) always points at lbIP (the shared gateway)
+// regardless.
 //
 // Per docs/PLATFORM-POWERDNS.md these names mirror the canonical-record
 // contract and use TTL 300 for fast failover.
@@ -630,6 +632,25 @@ func canonicalRecordSet(childZone, lbIP, consoleLBIP string) []pdns.RRSet {
 		// resolves the reachable VIP in BOTH regions. Mirrors the #5034 fix that
 		// added the then-missing marketplace record to this same set.
 		{"registry", lbIP},
+		// #5206 — mcp.<fqdn> is the Sovereign-mode OpenOva MCP server's public
+		// host (bp-openova-mcp, products/openova-mcp/chart/templates/
+		// httproute.yaml derives mcp.<sovereignFqdn> and parents the SHARED
+		// kube-system/cilium-gateway), the Pillar-4 Org→MCP front door. Exact
+		// #5225/#5243 defect class: without an EXPLICIT child-zone record it was
+		// covered only by the `*` wildcard, and on a 2-region Huawei Sovereign
+		// (§854 hostNetwork gateway — no LB VIP; gateway status = node addresses)
+		// external-dns (gateway-httproute source, policy=sync) SHADOWED that
+		// wildcard with a specific mcp.<fqdn> A pointing at a region-a
+		// control-plane node's INTERNAL VPC IP — unroutable cross-VPC/externally,
+		// so the MCP endpoint was unreachable to every Organization. An explicit
+		// record here — the reachable shared-gateway ELB EIP, identical to the
+		// wildcard + harbor + registry — is one external-dns will NOT overwrite
+		// (the TXT-registry own-only rule). Rides lbIP, NOT consoleLBIP: the
+		// route parents the shared gateway, and catalyst-api's authoritative
+		// lists agree (mcp ∈ CanonicalSovereignSubdomains, mcp ∉
+		// ConsoleGatewaySubdomains — sovereign_dns_records.go, the parent-zone
+		// writer this delegated child zone MUST mirror).
+		{"mcp", lbIP},
 	}
 	rrsets := make([]pdns.RRSet, 0, len(prefixes))
 	for _, p := range prefixes {

--- a/core/pool-domain-manager/internal/allocator/allocator_test.go
+++ b/core/pool-domain-manager/internal/allocator/allocator_test.go
@@ -176,8 +176,8 @@ func TestCanonicalRecordSet(t *testing.T) {
 	// #4053 — empty consoleLBIP = legacy single-LB behaviour: EVERY record
 	// (incl. console/api) points at lbIP, byte-identical to pre-#4053.
 	rrsets := canonicalRecordSet("acme.openova.io", "1.2.3.4", "")
-	if len(rrsets) != 8 {
-		t.Fatalf("expected 8 RRsets, got %d", len(rrsets))
+	if len(rrsets) != 9 {
+		t.Fatalf("expected 9 RRsets, got %d", len(rrsets))
 	}
 	wantNames := map[string]bool{
 		"acme.openova.io":             false,
@@ -188,6 +188,7 @@ func TestCanonicalRecordSet(t *testing.T) {
 		"harbor.acme.openova.io":      false,
 		"marketplace.acme.openova.io": false,
 		"registry.acme.openova.io":    false, // #5225
+		"mcp.acme.openova.io":         false, // #5206
 	}
 	for _, r := range rrsets {
 		if r.Type != "A" {
@@ -229,8 +230,8 @@ func TestCanonicalRecordSetConsoleSplit(t *testing.T) {
 	const sharedIP = "1.2.3.4"
 	const consoleIP = "9.9.9.9"
 	rrsets := canonicalRecordSet("acme.openova.io", sharedIP, consoleIP)
-	if len(rrsets) != 8 {
-		t.Fatalf("expected 8 RRsets, got %d", len(rrsets))
+	if len(rrsets) != 9 {
+		t.Fatalf("expected 9 RRsets, got %d", len(rrsets))
 	}
 	wantIP := map[string]string{
 		"acme.openova.io":             sharedIP,
@@ -243,6 +244,10 @@ func TestCanonicalRecordSetConsoleSplit(t *testing.T) {
 		// #5225 — registry rides the shared LB (Harbor's primary host), NOT the
 		// console LB, so it MUST stay on sharedIP even when a console LB exists.
 		"registry.acme.openova.io": sharedIP,
+		// #5206 — mcp rides the shared LB too (its HTTPRoute parents the shared
+		// cilium-gateway; mcp ∉ ConsoleGatewaySubdomains), so it MUST stay on
+		// sharedIP even when a console LB exists.
+		"mcp.acme.openova.io": sharedIP,
 	}
 	for _, r := range rrsets {
 		want, ok := wantIP[r.Name]
@@ -394,8 +399,8 @@ func TestCommitDNSShape(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := dns.rrsets["omantel.omani.works"]
-	if len(got) != 8 {
-		t.Fatalf("expected 8 RRsets recorded, got %d", len(got))
+	if len(got) != 9 {
+		t.Fatalf("expected 9 RRsets recorded, got %d", len(got))
 	}
 }
 

--- a/core/pool-domain-manager/internal/handler/handler.go
+++ b/core/pool-domain-manager/internal/handler/handler.go
@@ -272,7 +272,7 @@ func (h *Handler) Commit(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Allocator returns a wrapped "powerdns write" error AFTER the row
 		// was flipped to active. Surface 202 in that case so the caller
-		// knows the row is committed but the canonical 8-record set in the
+		// knows the row is committed but the canonical 9-record set in the
 		// child zone is pending — calling Commit again with the same body
 		// is idempotent (PowerDNS PATCH replaces existing RRsets in place).
 		if alloc != nil && strings.Contains(err.Error(), "powerdns write") {


### PR DESCRIPTION
Refs #5206

## Root cause

`mcp.<sovereign-fqdn>` — the Sovereign-mode OpenOva MCP front door (Pillar 4, Org→MCP north star) — had **no durable DNS record**. PDM's `canonicalRecordSet` (`core/pool-domain-manager/internal/allocator/allocator.go`) published only `@ * console api marketplace gitea harbor registry` into the delegated child zone, so `mcp` was covered by the `*` wildcard alone.

On the §854 hostNetwork gateway model (no LB VIP; the Gateway status carries node addresses), external-dns (gateway-httproute source, `policy=sync`) shadows that wildcard with a **specific** `mcp.<fqdn>` A record pointing at a region-a control-plane node **internal VPC IP** — unroutable cross-VPC and externally — so the per-Org MCP endpoint (`bp-openova-mcp`) was unreachable to every Organization. This is the exact defect class fixed for `registry.<fqdn>` in #5225/#5243.

## The fix

Add `{"mcp", lbIP}` to `canonicalRecordSet` — an explicit record external-dns will NOT overwrite (the TXT-registry own-only rule that already protects harbor/console/gitea/registry).

**Why `lbIP` (the reachable shared-gateway ELB EIP), not a node IP and not `consoleLBIP`:**
- The gateway is served DIRECT per §854 (shared-EIP / Local-ETP + hostPort on the hostNetwork cilium-envoy pods) — the record must target the reachable EIP, never a node-internal address, and never any nodePort wiring.
- `products/openova-mcp/chart/templates/httproute.yaml` renders the sovereign-mode host `mcp.<sovereignFqdn>` (helper `openova-mcp.hostname`) parenting the **shared** `kube-system/cilium-gateway` — proving the record is genuinely needed and that it rides the shared LB, not the console LB.
- catalyst-api's authoritative parent-zone writer agrees: `mcp` is already in `CanonicalSovereignSubdomains` (added under #5206, hw270 evidence in `products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go`) and is NOT in `ConsoleGatewaySubdomains`. The two DNS writers MUST agree (the #5225 fix doc rule) — this PR closes the PDM half of that agreement; **no catalyst-api change was needed**.

Wildcard TLS (`*.<fqdn>`) already covers the host — no cert/SAN change. Go control-plane change only — no Helm chart / lockstep pins.

## Also updated
- Record-count test assertions 8 → 9 (`TestCanonicalRecordSet`, `TestCanonicalRecordSetConsoleSplit` — asserts `mcp` stays on sharedIP when a console LB exists — and `TestCommitDNSShape`).
- Stale "8-record set" doc comments in `allocator.go` + `handler.go`.

## Follow-up (a separate follow-up, per #5243 scope note)
Other canonical hosts remain wildcard-only in PDM's child zone and are exposed to the same shadowing class: `auth bao grafana hubble pdns pdns-admin openova-flow newapi guacamole sandbox`. They are each the same one-liner, but this PR fixes ONLY `mcp` (minimal scope matching #5206); batching the rest should be a deliberate follow-up since several may warrant per-host gateway-membership review (as `marketplace` did in #5034).

## Gates
`go build ./...` / `go vet ./...` / `go test ./...` green across `core/pool-domain-manager`.

## Validation
Validates on a fresh-prov MCP reachability walk (`dig mcp.<fqdn>` returns the shared-gateway EIP in both regions + an Organization completes an MCP `tools/list` against `https://mcp.<fqdn>/mcp`). Not live-validated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)