### PR TITLE
fix(catalyst-api): stamp Retry-After on sandbox 503 degrades — complete the #5140 retryable contract

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -208,6 +208,28 @@ var sandboxNameSanitize = regexp.MustCompile(`[^a-z0-9-]+`)
 // rendering the "API pending" pill (see sandbox.api.ts:EMPTY_SANDBOXES).
 const sandboxRequestBudget = 5 * time.Second
 
+// sandboxRetryAfterSeconds — the Retry-After hint stamped on every
+// sandbox 503 response (#5140). The transient windows the 503 covers
+// (clustermesh peer-apiserver token rejection during a cutover /
+// chart-roll / region-kill recovery, discovery races, apiserver
+// restabilising) typically clear within a few minutes, so a 30s pace
+// keeps retrying clients honest without hammering the degraded
+// backend. Same convention as organization_provisioning.go's
+// NS-flip-pending 503 (which uses 300s for its slower DNS window).
+const sandboxRetryAfterSeconds = "30"
+
+// writeSandboxJSON writes the JSON envelope for the sandbox handlers'
+// error paths. When the status is 503 Service Unavailable it first
+// stamps the Retry-After back-off hint so clients treat the degrade as
+// retryable-with-pacing (#5140); genuine faults (500) and the
+// object-level 404/409 keep their envelope untouched.
+func writeSandboxJSON(w http.ResponseWriter, status int, body map[string]string) {
+	if status == http.StatusServiceUnavailable {
+		w.Header().Set("Retry-After", sandboxRetryAfterSeconds)
+	}
+	writeJSON(w, status, body)
+}
+
 // sandboxDefaultNamespaceEnv — operator override for the namespace the
 // handler reads/writes when claims.Org is empty (single-tenant chroot
 // case). Defaults to `catalyst-system` so a fresh Sovereign with the
@@ -402,7 +424,7 @@ func (h *Handler) HandleListSandboxSessions(w http.ResponseWriter, r *http.Reque
 
 	client, ns, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
-		writeJSON(w, status, errResp)
+		writeSandboxJSON(w, status, errResp)
 		return
 	}
 
@@ -421,7 +443,7 @@ func (h *Handler) HandleListSandboxSessions(w http.ResponseWriter, r *http.Reque
 		}
 		if sandboxBackendUnavailable(err) {
 			h.log.Warn("sandbox: backend unavailable on list", "namespace", ns, "err", err)
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			writeSandboxJSON(w, http.StatusServiceUnavailable, map[string]string{
 				"error":  "sandbox-backend-unavailable",
 				"detail": "sandbox backend temporarily unavailable",
 			})
@@ -462,7 +484,7 @@ func (h *Handler) HandleGetSandboxSession(w http.ResponseWriter, r *http.Request
 
 	client, ns, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
-		writeJSON(w, status, errResp)
+		writeSandboxJSON(w, status, errResp)
 		return
 	}
 
@@ -480,7 +502,7 @@ func (h *Handler) HandleGetSandboxSession(w http.ResponseWriter, r *http.Request
 		}
 		if sandboxBackendUnavailable(err) {
 			h.log.Warn("sandbox: backend unavailable on get", "id", id, "namespace", ns, "err", err)
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			writeSandboxJSON(w, http.StatusServiceUnavailable, map[string]string{
 				"error":  "sandbox-backend-unavailable",
 				"detail": "sandbox backend temporarily unavailable",
 			})
@@ -541,7 +563,7 @@ func (h *Handler) HandleCreateSandboxSession(w http.ResponseWriter, r *http.Requ
 
 	client, ns, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
-		writeJSON(w, status, errResp)
+		writeSandboxJSON(w, status, errResp)
 		return
 	}
 
@@ -575,7 +597,7 @@ func (h *Handler) HandleCreateSandboxSession(w http.ResponseWriter, r *http.Requ
 			// the sandboxes.sandbox.openova.io CRD on this
 			// cluster yet. Surface 503 so the FE renders the
 			// "API pending" pill rather than a generic 500.
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			writeSandboxJSON(w, http.StatusServiceUnavailable, map[string]string{
 				"error":  "sandbox-crd-not-installed",
 				"detail": "sandboxes.sandbox.openova.io CRD missing on this cluster",
 			})
@@ -583,7 +605,7 @@ func (h *Handler) HandleCreateSandboxSession(w http.ResponseWriter, r *http.Requ
 		}
 		if sandboxBackendUnavailable(err) {
 			h.log.Warn("sandbox: backend unavailable on create", "name", crName, "namespace", ns, "err", err)
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			writeSandboxJSON(w, http.StatusServiceUnavailable, map[string]string{
 				"error":  "sandbox-backend-unavailable",
 				"detail": "sandbox backend temporarily unavailable",
 			})
@@ -782,7 +804,7 @@ func (h *Handler) HandleDeleteSandboxSession(w http.ResponseWriter, r *http.Requ
 
 	client, ns, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
-		writeJSON(w, status, errResp)
+		writeSandboxJSON(w, status, errResp)
 		return
 	}
 
@@ -793,7 +815,7 @@ func (h *Handler) HandleDeleteSandboxSession(w http.ResponseWriter, r *http.Requ
 	if err != nil && !apierrors.IsNotFound(err) {
 		if sandboxBackendUnavailable(err) {
 			h.log.Warn("sandbox: backend unavailable on delete", "id", id, "namespace", ns, "err", err)
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			writeSandboxJSON(w, http.StatusServiceUnavailable, map[string]string{
 				"error":  "sandbox-backend-unavailable",
 				"detail": "sandbox backend temporarily unavailable",
 			})

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_integration_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -513,6 +514,83 @@ func TestSandboxIntegration_DeleteBackendUnavailableDegradesTo503(t *testing.T) 
 	}
 	if resp["error"] != "sandbox-backend-unavailable" {
 		t.Errorf("error = %v, want sandbox-backend-unavailable", resp["error"])
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Errorf("Retry-After header missing on sandbox 503 (#5140 retryable contract)")
+	}
+}
+
+// TestSandboxIntegration_ListTransient503VsGenuine500 — #5140. Pins the
+// full HTTP contract on the primary GET /api/v1/sandbox/sessions route:
+//
+//   - a TRANSIENT backend error (peer-apiserver token rejection during a
+//     cutover / region-kill recovery window) → 503 with the Retry-After
+//     back-off hint, so clients treat the hiccup as retryable;
+//   - a GENUINE internal error (a fault the classifier does not
+//     recognise as backend-unavailable) → 500 with NO Retry-After, so a
+//     real server fault is never dressed up as a transient one.
+func TestSandboxIntegration_ListTransient503VsGenuine500(t *testing.T) {
+	cases := []struct {
+		name          string
+		injected      error
+		wantCode      int
+		wantError     string
+		wantRetryHint bool
+	}{
+		{
+			name:          "transient-unauthorized-degrades-503",
+			injected:      apierrors.NewUnauthorized("token rejected by peer apiserver"),
+			wantCode:      http.StatusServiceUnavailable,
+			wantError:     "sandbox-backend-unavailable",
+			wantRetryHint: true,
+		},
+		{
+			name:          "genuine-fault-stays-500",
+			injected:      errors.New("json: cannot unmarshal number into Go value"),
+			wantCode:      http.StatusInternalServerError,
+			wantError:     "list-failed",
+			wantRetryHint: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			gvrToList := map[schema.GroupVersionResource]string{
+				SandboxGVR(): "SandboxList",
+			}
+			dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+			dyn.PrependReactor("list", "sandboxes", func(clienttesting.Action) (bool, runtime.Object, error) {
+				return true, nil, tc.injected
+			})
+
+			core := fakek8s.NewSimpleClientset()
+			h := NewWithPDM(silentLogger(), &fakePDM{})
+			h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+				return &sovereignDeps{core: core, dyn: dyn}, nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil)
+			req = withSandboxClaims(req, "user-sub-list", "ops@acme.com", "acme")
+			rec := callSandbox(t, h, req)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("LIST status = %d, want %d; body = %s", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			var resp map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp["error"] != tc.wantError {
+				t.Errorf("error = %v, want %s", resp["error"], tc.wantError)
+			}
+			got := rec.Header().Get("Retry-After")
+			if tc.wantRetryHint && got == "" {
+				t.Errorf("Retry-After header missing on sandbox 503 (#5140 retryable contract)")
+			}
+			if !tc.wantRetryHint && got != "" {
+				t.Errorf("Retry-After = %q on a genuine 500 — a real fault must not advertise retryability", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Root cause

Re-verified #5140 on HEAD before changing anything: the transient-vs-genuine status-code mapping is **already merged** — `sandboxBackendUnavailable` (typed apierrors 401/403/503/timeout/internal + `meta.NoKindMatchError` + `context.DeadlineExceeded` + untyped connection-refused / dial-tcp / i/o-timeout / discovery-404 strings) routes List/Get/Create/Delete to 503, shipped across PR #5141, PR #5161, PR #5199.

What was still missing from the retryable contract: **none of the sandbox 503 responses carried a `Retry-After` header**, although this codebase already has that convention on 503 — `organization_provisioning.go` stamps `Retry-After: 300` on its NS-flip-pending 503 (with a test asserting the header), and `auth.go` stamps it on 429. A client honoring "503 = retryable" had no pacing signal, so honest retry loops hammer a degraded apiserver during exactly the cutover / region-kill recovery windows the 503 exists for.

## Before / after status-code mapping

| Condition | Before | After |
|---|---|---|
| Transient backend-unavailable (peer-apiserver 401/403, timeout, discovery race, connection refused) | 503, no `Retry-After` | 503 + `Retry-After: 30` |
| Sandbox CRD not installed yet (create) | 503, no `Retry-After` | 503 + `Retry-After: 30` |
| No dynamic client / cluster unavailable (`sandboxClient`) | 503, no `Retry-After` | 503 + `Retry-After: 30` |
| Genuine internal fault (unclassified error) | 500 | 500 (unchanged, and asserted to carry **no** `Retry-After`) |
| Object-level 404 / 409 / 400 | unchanged | unchanged |

JSON error body shape is preserved everywhere — the change is header-only, via one helper (`writeSandboxJSON`) that stamps the header iff the status is 503.

## Test added

- `TestSandboxIntegration_ListTransient503VsGenuine500` — drives `GET /api/v1/sandbox/sessions` through the chi router against the fake dynamic client: injected transient error (peer-apiserver `Unauthorized`, the live hw261 symptom) → **503** + `sandbox-backend-unavailable` + `Retry-After` present; injected genuine fault → **500** + `list-failed` + `Retry-After` absent.
- `TestSandboxIntegration_DeleteBackendUnavailableDegradesTo503` extended to assert the header on the Delete 503.

## Gates

`go build ./...` + `go vet ./...` + `go test ./...` all green in `products/catalyst/bootstrap/api` (full handler suite incl. the 14 pre-existing Sandbox tests).

Refs #5140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
