### PR TITLE
fix(catalyst-api): sandbox client re-resolves the backend after DR failover — recovers to 200 instead of permanent 503

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -50,6 +50,21 @@
 // neither path is available the handler returns 503 so the FE renders
 // its target-state "API pending" pill rather than a 5xx spinner.
 //
+// #5140 part B — primary-client re-resolution. The Path-1 Factory
+// client is constructed ONCE at AddCluster registration time and
+// cached in the Factory's cluster map; DynamicClientFor never
+// invalidates it. After a region-kill / DR failover the cached
+// client can keep dialing a dead or stale endpoint (or present a
+// token a peer apiserver rejects) — pre-fix, every request through
+// it failed identically and the surface returned 503 FOREVER, even
+// after the DR survivor was serving. sandboxCall fixes the recovery
+// gap: on a connection-level (backend-unavailable) failure from the
+// Path-1 client it re-resolves a FRESH client via sovereignDepsFor()
+// — the local host apiserver, where the Sandbox CRD + RBAC are
+// always valid (the remedy #5140 names) — and retries the operation
+// once, so the first request after the survivor takes over returns
+// 200 instead of a permanent 503.
+//
 // ── Org-scoping ─────────────────────────────────────────────────────
 //
 // Every endpoint reads `claims.Org` (populated by RequireSession from
@@ -400,16 +415,19 @@ func (h *Handler) HandleListSandboxSessions(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	client, ns, status, errResp := h.sandboxClient(r)
+	hc, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
 		writeJSON(w, status, errResp)
 		return
 	}
+	ns := hc.ns
 
-	ctx, cancel := context.WithTimeout(r.Context(), sandboxRequestBudget)
-	defer cancel()
-
-	listIface, err := client.Resource(SandboxGVR()).Namespace(ns).List(ctx, metav1.ListOptions{})
+	var listIface *unstructured.UnstructuredList
+	err := h.sandboxCall(r.Context(), hc, func(ctx context.Context, dyn dynamic.Interface) error {
+		var cerr error
+		listIface, cerr = dyn.Resource(SandboxGVR()).Namespace(ns).List(ctx, metav1.ListOptions{})
+		return cerr
+	})
 	if err != nil {
 		// CRD not installed → return empty list. The Sandbox CRD ships
 		// via the catalyst chart's crds/ directory but a fresh chroot
@@ -460,16 +478,19 @@ func (h *Handler) HandleGetSandboxSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	client, ns, status, errResp := h.sandboxClient(r)
+	hc, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
 		writeJSON(w, status, errResp)
 		return
 	}
+	ns := hc.ns
 
-	ctx, cancel := context.WithTimeout(r.Context(), sandboxRequestBudget)
-	defer cancel()
-
-	obj, err := client.Resource(SandboxGVR()).Namespace(ns).Get(ctx, id, metav1.GetOptions{})
+	var obj *unstructured.Unstructured
+	err := h.sandboxCall(r.Context(), hc, func(ctx context.Context, dyn dynamic.Interface) error {
+		var cerr error
+		obj, cerr = dyn.Resource(SandboxGVR()).Namespace(ns).Get(ctx, id, metav1.GetOptions{})
+		return cerr
+	})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			writeJSON(w, http.StatusNotFound, map[string]string{
@@ -539,11 +560,12 @@ func (h *Handler) HandleCreateSandboxSession(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	client, ns, status, errResp := h.sandboxClient(r)
+	hc, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
 		writeJSON(w, status, errResp)
 		return
 	}
+	ns := hc.ns
 
 	// Derive the CR name. Operator-supplied Name is preferred (lets
 	// the FE control the label); when empty we synthesise from the
@@ -558,10 +580,17 @@ func (h *Handler) HandleCreateSandboxSession(w http.ResponseWriter, r *http.Requ
 	orgSlug := sandboxOrgSlug(claims)
 	obj := buildSandboxUnstructured(crName, ns, displayName, agent, body.Repo, claims.Email, orgSlug)
 
-	ctx, cancel := context.WithTimeout(r.Context(), sandboxRequestBudget)
-	defer cancel()
-
-	created, err := client.Resource(SandboxGVR()).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
+	// Create retried through sandboxCall is safe: a first attempt that
+	// FAILED at the connection level (the only class sandboxCall
+	// retries) never reached the apiserver, so the retry cannot
+	// double-create; a duplicate racing through anyway surfaces as
+	// IsAlreadyExists and maps to 409 exactly like a double-click.
+	var created *unstructured.Unstructured
+	err := h.sandboxCall(r.Context(), hc, func(ctx context.Context, dyn dynamic.Interface) error {
+		var cerr error
+		created, cerr = dyn.Resource(SandboxGVR()).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
+		return cerr
+	})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			writeJSON(w, http.StatusConflict, map[string]string{
@@ -780,16 +809,16 @@ func (h *Handler) HandleDeleteSandboxSession(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	client, ns, status, errResp := h.sandboxClient(r)
+	hc, status, errResp := h.sandboxClient(r)
 	if errResp != nil {
 		writeJSON(w, status, errResp)
 		return
 	}
+	ns := hc.ns
 
-	ctx, cancel := context.WithTimeout(r.Context(), sandboxRequestBudget)
-	defer cancel()
-
-	err := client.Resource(SandboxGVR()).Namespace(ns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := h.sandboxCall(r.Context(), hc, func(ctx context.Context, dyn dynamic.Interface) error {
+		return dyn.Resource(SandboxGVR()).Namespace(ns).Delete(ctx, id, metav1.DeleteOptions{})
+	})
 	if err != nil && !apierrors.IsNotFound(err) {
 		if sandboxBackendUnavailable(err) {
 			h.log.Warn("sandbox: backend unavailable on delete", "id", id, "namespace", ns, "err", err)
@@ -813,16 +842,34 @@ func (h *Handler) HandleDeleteSandboxSession(w http.ResponseWriter, r *http.Requ
 
 // ── Internal helpers ────────────────────────────────────────────────
 
-// sandboxClient resolves the (dynamic.Interface, namespace) pair the
-// handlers operate on. Resolution order matches the package doc:
+// sandboxClientHandle bundles the resolved dynamic client with the
+// namespace it operates on plus the resolution path it came from.
+//
+// fromFactory marks a Path-1 (k8sCache Factory) client. That client is
+// a REGISTRATION-TIME construction cached in the Factory's cluster map
+// (k8scache.AddCluster builds it once from the kubeconfig on disk;
+// DynamicClientFor never invalidates it), so across a region-kill /
+// DR-failover window it can keep dialing a dead or stale endpoint —
+// #5140 part B. Only that path is eligible for sandboxCall's
+// re-resolve retry: Path-2 clients are already constructed fresh per
+// request (sovereignDepsFromEnv), so retrying the same construction
+// adds nothing but a duplicate call.
+type sandboxClientHandle struct {
+	dyn         dynamic.Interface
+	ns          string
+	fromFactory bool
+}
+
+// sandboxClient resolves the client handle the handlers operate on.
+// Resolution order matches the package doc:
 //
 //  1. k8sCache.Factory.DynamicClientFor(resolveChrootClusterID(""))
 //     — the canonical Catalyst-Zero / multi-Sovereign path.
 //  2. sovereignDepsFor() — chroot in-cluster fallback.
 //
-// Returns (..., status, errResp) with errResp non-nil on failure;
+// Returns (handle, status, errResp) with errResp non-nil on failure;
 // the caller writes the JSON envelope verbatim.
-func (h *Handler) sandboxClient(r *http.Request) (dynamic.Interface, string, int, map[string]string) {
+func (h *Handler) sandboxClient(r *http.Request) (*sandboxClientHandle, int, map[string]string) {
 	claims := auth.ClaimsFromContext(r.Context())
 	ns := sandboxNamespaceFor(claims)
 
@@ -834,7 +881,7 @@ func (h *Handler) sandboxClient(r *http.Request) (dynamic.Interface, string, int
 		clusterID := h.resolveChrootClusterID("")
 		if clusterID != "" {
 			if dyn, err := h.k8sCache.DynamicClientFor(clusterID); err == nil {
-				return dyn, ns, 0, nil
+				return &sandboxClientHandle{dyn: dyn, ns: ns, fromFactory: true}, 0, nil
 			}
 		}
 	}
@@ -844,18 +891,81 @@ func (h *Handler) sandboxClient(r *http.Request) (dynamic.Interface, string, int
 	// Tests inject a fake via SetSovereignDepsFactory.
 	deps, err := h.sovereignDepsFor()
 	if err != nil {
-		return nil, ns, http.StatusServiceUnavailable, map[string]string{
+		return nil, http.StatusServiceUnavailable, map[string]string{
 			"error":  "sandbox-cluster-unavailable",
 			"detail": err.Error(),
 		}
 	}
 	if deps == nil || deps.dyn == nil {
-		return nil, ns, http.StatusServiceUnavailable, map[string]string{
+		return nil, http.StatusServiceUnavailable, map[string]string{
 			"error":  "sandbox-cluster-unavailable",
 			"detail": "no dynamic client available",
 		}
 	}
-	return deps.dyn, ns, 0, nil
+	return &sandboxClientHandle{dyn: deps.dyn, ns: ns}, 0, nil
+}
+
+// sandboxCall runs op against the resolved client with the per-request
+// budget and — #5140 part B — re-resolves the backend on a
+// connection-level failure of the Path-1 (Factory-cached) client.
+//
+// Root cause of the recovery gap (hw261, post-region-kill): after the
+// DR failover flipped the primary region, the sandbox surface returned
+// 503 on EVERY request and never recovered, because the Factory's
+// dynamic client is built once at cluster registration and cached
+// forever — a dead endpoint, a token a peer apiserver rejects (401), or
+// a peer that does not serve the Sandbox CRD ("could not find the
+// requested resource") fails identically on every call, and
+// sandboxClient only falls through to Path 2 when Path 1 fails to
+// RESOLVE, never when its client fails at request time. Part A
+// (#5141/#5161/#5199) made those failures an honest retryable 503; this
+// closes the loop so a retry can actually succeed.
+//
+// Mechanics:
+//
+//   - The first attempt runs against hc.dyn under its own
+//     sandboxRequestBudget.
+//   - When the attempt fails with a backend-unavailable class error
+//     (sandboxBackendUnavailable — connection refused / dial / i-o
+//     timeout / 401 / 403 / discovery-404 / NoKindMatch) AND the client
+//     came from the Factory cache, a FRESH client is constructed via
+//     sovereignDepsFor() — rest.InClusterConfig, i.e. the LOCAL host
+//     apiserver where the Sandbox CRD + the cutover-driver RBAC are
+//     always valid (the exact remedy #5140 part B names) — and op is
+//     retried ONCE under a fresh budget. The fresh budget matters: a
+//     blackholed endpoint eats the full first budget, so reusing the
+//     original deadline would doom the retry to DeadlineExceeded.
+//   - A genuine object-level NotFound ("sandboxes \"x\" not found")
+//     is NOT in the backend-unavailable class, so ordinary 404s never
+//     pay a second call. A CRD-level miss retries and, when the CRD is
+//     genuinely absent locally too, returns the same error the caller
+//     already maps (List → 200 empty, Create → 503 crd-not-installed).
+//   - No sticky state: each request tries Path 1 first (it may have
+//     healed via a kubeconfig re-registration) and pays at most one
+//     extra call while the primary is stale. Worst case per request is
+//     2× sandboxRequestBudget, still bounded for the FE, and the
+//     response is a 200 from the survivor instead of a permanent 503.
+func (h *Handler) sandboxCall(rctx context.Context, hc *sandboxClientHandle, op func(ctx context.Context, dyn dynamic.Interface) error) error {
+	ctx, cancel := context.WithTimeout(rctx, sandboxRequestBudget)
+	err := op(ctx, hc.dyn)
+	cancel()
+	if err == nil || !hc.fromFactory || !sandboxBackendUnavailable(err) {
+		return err
+	}
+
+	deps, derr := h.sovereignDepsFor()
+	if derr != nil || deps == nil || deps.dyn == nil {
+		// No fresh local client available (mothership without in-cluster
+		// SA, CI without the seam wired) — surface the original, honest
+		// primary-path error; the caller degrades to 503 as before.
+		return err
+	}
+	h.log.Warn("sandbox: primary client backend-unavailable — re-resolved local in-cluster client, retrying once (#5140)",
+		"namespace", hc.ns, "err", err)
+
+	retryCtx, retryCancel := context.WithTimeout(rctx, sandboxRequestBudget)
+	defer retryCancel()
+	return op(retryCtx, deps.dyn)
 }
 
 // sandboxNamespaceFor returns the namespace the handler reads/writes.

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_reresolve_5140_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_reresolve_5140_test.go
@@ -1,0 +1,231 @@
+// Package handler — sandbox_sessions_reresolve_5140_test.go pins the
+// #5140 part-B recovery contract: after a region-kill / DR failover the
+// Path-1 (k8sCache Factory) sandbox client can keep dialing a dead or
+// stale endpoint forever — the Factory builds it once at AddCluster
+// registration and DynamicClientFor never invalidates it. Pre-fix the
+// handler degraded every such request to 503 and NEVER recovered, even
+// once the DR survivor was serving. sandboxCall now re-resolves a fresh
+// in-cluster client (sovereignDepsFor — the local host apiserver, where
+// the Sandbox CRD + RBAC are always valid) and retries once, so the
+// first request after the survivor takes over returns 200/201.
+//
+// Wiring mirrors production Path 1: a k8scache.Factory carrying one
+// registered cluster whose pre-built dynamic client fails with the
+// connection-level class observed live on hw261, resolved through
+// resolveChrootClusterID via SOVEREIGN_FQDN — while the re-resolve seam
+// (SetSovereignDepsFactory) serves the healthy survivor.
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+)
+
+// sandboxFakeDynamicClient builds a fake dynamic client with the
+// sandbox list-kind registered, seeded via the same Create-based path
+// newSandboxHandler uses (the tracker's objects-arg needs GVK
+// heuristics that don't align for the sandbox CRD).
+func sandboxFakeDynamicClient(t *testing.T, seed ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		SandboxGVR(): "SandboxList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+	for _, obj := range seed {
+		if _, err := dyn.Resource(SandboxGVR()).Namespace(obj.GetNamespace()).Create(
+			context.Background(), obj, metav1.CreateOptions{},
+		); err != nil {
+			t.Fatalf("seed Sandbox %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return dyn
+}
+
+// deadEndpointDynamicClient returns a fake dynamic client whose every
+// verb fails with the connection-level error a cached client dialing a
+// dead (post-region-kill) apiserver endpoint produces.
+func deadEndpointDynamicClient(t *testing.T) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	dyn := sandboxFakeDynamicClient(t)
+	dyn.PrependReactor("*", "*", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New(`Get "https://100.64.0.10:6443/apis/sandbox.openova.io/v1": dial tcp 100.64.0.10:6443: connect: connection refused`)
+	})
+	return dyn
+}
+
+// factoryWithPrimary registers exactly one cluster in a
+// k8scache.Factory backed by the supplied pre-built dynamic client —
+// the shape of a chroot whose registration-time primary client the
+// sandbox handler resolves via Path 1. The empty Registry keeps
+// AddCluster from spawning informers; Start is never called, matching
+// the handler-side contract that DynamicClientFor works regardless.
+func factoryWithPrimary(t *testing.T, clusterID string, dyn *dynamicfake.FakeDynamicClient) *k8scache.Factory {
+	t.Helper()
+	cfg := k8scache.Config{
+		Logger:   silentLogger(),
+		Registry: k8scache.NewRegistry(),
+		Clusters: []k8scache.ClusterRef{
+			{
+				ID:            clusterID,
+				DynamicClient: dyn,
+				CoreClient:    fakek8s.NewSimpleClientset(),
+			},
+		},
+	}
+	f, err := k8scache.NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(f.Stop)
+	return f
+}
+
+// TestSandboxReResolve_ListRecoversFromDeadPrimary — the part-B
+// contract itself: the Path-1 client dials the dead pre-failover
+// endpoint, the re-resolve retry lands on the survivor, and the FIRST
+// request after the failover returns 200 with the survivor's rows —
+// not the pre-fix permanent 503.
+func TestSandboxReResolve_ListRecoversFromDeadPrimary(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetK8sCache(factoryWithPrimary(t, "sovereign-t99-omani-works", deadEndpointDynamicClient(t)), k8scache.NewSARCache(), "")
+
+	// The survivor: a healthy apiserver already carrying one Sandbox.
+	survivor := sandboxFakeDynamicClient(t,
+		mkSandboxCR("sandbox-survivor", "acme", "claude-code", map[string]any{"phase": "Ready"}),
+	)
+	core := fakek8s.NewSimpleClientset()
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: core, dyn: survivor}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil)
+	req = withSandboxClaims(req, "user-sub-dr", "ops@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list after failover: status = %d, want 200 (re-resolved survivor); body = %s", rec.Code, rec.Body.String())
+	}
+	var resp sandboxListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Sandboxes) != 1 || resp.Sandboxes[0].ID != "sandbox-survivor" {
+		t.Fatalf("sandboxes = %+v, want the survivor's single row", resp.Sandboxes)
+	}
+	if resp.Sandboxes[0].Status != "running" {
+		t.Errorf("status = %q, want running (Ready phase projected)", resp.Sandboxes[0].Status)
+	}
+}
+
+// TestSandboxReResolve_CreateRecoversFromDeadPrimary — the mutating
+// path (the hw261 walk's failing click): POST against the dead primary
+// re-resolves and materialises the CR on the survivor, returning 201.
+func TestSandboxReResolve_CreateRecoversFromDeadPrimary(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetK8sCache(factoryWithPrimary(t, "sovereign-t99-omani-works", deadEndpointDynamicClient(t)), k8scache.NewSARCache(), "")
+
+	survivor := sandboxFakeDynamicClient(t)
+	core := fakek8s.NewSimpleClientset()
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: core, dyn: survivor}, nil
+	})
+
+	body, _ := json.Marshal(sandboxCreateRequest{Agent: "aider", Name: "post-failover"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSandboxClaims(req, "user-sub-dr", "ops@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create after failover: status = %d, want 201 (re-resolved survivor); body = %s", rec.Code, rec.Body.String())
+	}
+
+	// The CR must exist on the SURVIVOR's apiserver.
+	got, err := survivor.Resource(SandboxGVR()).Namespace("acme").Get(
+		context.Background(), "post-failover", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("survivor Get after create: %v", err)
+	}
+	if got.GetName() != "post-failover" {
+		t.Fatalf("survivor CR name = %q, want post-failover", got.GetName())
+	}
+}
+
+// TestSandboxReResolve_BothPathsDeadStays503 — when the re-resolved
+// client is ALSO unreachable (survivor not serving yet), the surface
+// keeps the honest part-A contract: 503 sandbox-backend-unavailable,
+// never a 500 and never a hang.
+func TestSandboxReResolve_BothPathsDeadStays503(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetK8sCache(factoryWithPrimary(t, "sovereign-t99-omani-works", deadEndpointDynamicClient(t)), k8scache.NewSARCache(), "")
+
+	core := fakek8s.NewSimpleClientset()
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: core, dyn: deadEndpointDynamicClient(t)}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil)
+	req = withSandboxClaims(req, "user-sub-dr", "ops@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("both paths dead: status = %d, want 503; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "sandbox-backend-unavailable" {
+		t.Errorf("error = %v, want sandbox-backend-unavailable", resp["error"])
+	}
+}
+
+// TestSandboxReResolve_NoRetryOnObjectNotFound — a genuine per-object
+// 404 from a HEALTHY primary maps straight to 404 without paying a
+// re-resolve call: the retry class is connection-level only, so
+// ordinary misses keep single-call latency.
+func TestSandboxReResolve_NoRetryOnObjectNotFound(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetK8sCache(factoryWithPrimary(t, "sovereign-t99-omani-works", sandboxFakeDynamicClient(t)), k8scache.NewSARCache(), "")
+
+	reResolves := 0
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		reResolves++
+		return &sovereignDeps{core: fakek8s.NewSimpleClientset(), dyn: sandboxFakeDynamicClient(t)}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions/no-such-sandbox", nil)
+	req = withSandboxClaims(req, "user-sub-dr", "ops@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("healthy-primary object miss: status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+	if reResolves != 0 {
+		t.Errorf("re-resolve invoked %d times on a genuine object 404, want 0", reResolves)
+	}
+}


### PR DESCRIPTION
Refs #5140 — part B, the primary-client re-resolution gap. Part A (transient failures map to an honest 503) is already merged via #5141/#5161/#5199, with Retry-After in flight on #5251; this PR closes the loop so the retry that 503 invites can actually SUCCEED once the DR survivor is serving.

## The recovery gap (root-caused in code)

`sandboxClient` (products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go) resolves in two paths:

1. **Path 1** — `h.k8sCache.DynamicClientFor(resolveChrootClusterID(""))`: the k8scache Factory's per-cluster dynamic client, built **once** at `AddCluster` registration time (internal/k8scache/factory.go) and cached in the Factory's cluster map. `DynamicClientFor` performs a pure map lookup — it never invalidates or rebuilds on failure.
2. **Path 2** — `sovereignDepsFor()`: a fresh `rest.InClusterConfig` client per call.

Path 2 is only reached when Path 1 fails to **resolve** (cluster not registered). When the Path-1 client fails at **request** time — dead endpoint after the region-kill flipped the primary, a token a peer apiserver rejects (401), a peer not serving the Sandbox CRD (the hw261 401/404 alternation from #5140) — every request repeats the identical dead dial and the Agenity surface returns 503 forever. Recovery required a catalyst-api restart, which the RWO-EVS constraint forbids (#5210).

The adjacent fixes do not cover this request path: #5132 materializes the chroot primary kubeconfig **only when the file is absent** (never refreshed on failover), #5210 fixed **token** staleness (refreshing `tokenFile`) not endpoint/client staleness, and #5137's re-resolution fix is chart-side (the cnpg-pair dr-promoter Deployment on the surviving region).

## The fix

New `sandboxCall` wraps every List/Get/Create/Delete apiserver call:

- First attempt runs against the resolved client under its own `sandboxRequestBudget`.
- On a **connection-level** failure (`sandboxBackendUnavailable` class: connection refused / dial / i-o timeout / 401 / 403 / discovery-404 / NoKindMatch) of a **Factory-cached** client, it re-resolves a **fresh** client via `sovereignDepsFor()` — `rest.InClusterConfig`, i.e. the **local host apiserver where the Sandbox CRD + cutover-driver RBAC are always valid**, the exact remedy #5140 part B names — and retries the operation once under a fresh budget (a blackholed endpoint eats the first budget whole; reusing the original deadline would doom the retry).
- Genuine object-level 404s (`sandboxes \"x\" not found`) are outside the retry class — ordinary misses never pay a second call.
- Path-2 clients are already constructed fresh per request, so they never retry.
- Both paths down → the honest part-A 503 contract is preserved (no 500, no hang; worst case 2× the 5s budget).
- No sticky state and no new connection framework: each request tries Path 1 first (it may have healed via kubeconfig re-registration), and the fallback construction is the handler's existing Path-2 idiom — the same upstream-then-cluster shape as `chainedCatalogClient` (catalog_client_cluster_fallback.go).

`sandboxClient` now returns a `sandboxClientHandle` carrying the resolution provenance (`fromFactory`) so only registration-time-cached clients are eligible for the retry.

## Tests (sandbox_sessions_reresolve_5140_test.go)

Wired the production Path-1 shape: a `k8scache.Factory` with one registered cluster whose pre-built dynamic client fails with the dead-endpoint dial error, resolved through `resolveChrootClusterID` via `SOVEREIGN_FQDN`, while `SetSovereignDepsFactory` serves the healthy survivor.

- `TestSandboxReResolve_ListRecoversFromDeadPrimary` — first request after failover returns **200** with the survivor's rows. **Verified red on pre-fix code** (fails with the permanent 503).
- `TestSandboxReResolve_CreateRecoversFromDeadPrimary` — the hw261 failing click: POST returns **201** and the CR is materialised on the survivor's apiserver.
- `TestSandboxReResolve_BothPathsDeadStays503` — survivor not serving yet → still 503 `sandbox-backend-unavailable`.
- `TestSandboxReResolve_NoRetryOnObjectNotFound` — genuine object 404 on a healthy primary pays zero re-resolve calls.

## Gates

`go build ./...` / `go vet ./...` / `go test ./... -count=1` green in `products/catalyst/bootstrap/api`. Runtime recovery validates on the next fresh-prov region-kill walk — not claimed live-validated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)