### PR TITLE
fix(catalyst-api): decouple the Phase-1 producer chain from the #4706 console downgrade (converged primary stays armed)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -3432,6 +3432,21 @@ func (h *Handler) shouldStartupClusterMeshReconcile(dep *Deployment) bool {
 // converging under Flux — abandoning its mesh forever contradicted the
 // never-wipe-a-timeout doctrine. Hard failures (OutcomeFailed /
 // flux-not-reconciling) stay excluded.
+//
+// #5253 also accepts failed+OutcomeReady — the pre-#5253 console-downgrade
+// signature (hw276): the PRIMARY fully converged (OutcomeReady is granted only
+// when every primary HelmRelease installed — the primary-converged proof) but
+// the #4706 console-reachability gate latched the record "failed", which
+// structurally excluded it from every mesh path, leaving the cross-region
+// topology permanently inert (no mesh → no CNPG-pair flip → hub secrets never
+// sync). Under the current markPhase1Done a console-degraded record stays
+// "ready" (surface-not-gate), so this arm matches only records PERSISTED by
+// older builds — a catalyst-api restart now re-establishes their mesh instead
+// of abandoning it. The establish loop is idempotent, so an already-meshed
+// record's first attempt confirms + exits. Genuine failures still can't slip
+// in: every other failed shape carries a non-OutcomeReady Phase1Outcome
+// (kubeconfig-missing, flux-not-reconciling, OutcomeFailed, timeout, the
+// #3971 storage downgrade stamps ReasonDefaultStorageClassEphemeral).
 func (h *Handler) clusterMeshReconcileStatusGate(dep *Deployment) bool {
 	dep.mu.Lock()
 	status := dep.Status
@@ -3442,7 +3457,8 @@ func (h *Handler) clusterMeshReconcileStatusGate(dep *Deployment) bool {
 	}
 	dep.mu.Unlock()
 	rescuableTimeout := status == "failed" && outcome == helmwatch.OutcomeTimeout
-	if (status != "ready" && !rescuableTimeout) || regionCount < 2 {
+	rescuableConsoleDowngrade := status == "failed" && outcome == helmwatch.OutcomeReady
+	if (status != "ready" && !rescuableTimeout && !rescuableConsoleDowngrade) || regionCount < 2 {
 		return false
 	}
 	return true

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -3446,3 +3446,51 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 		h.patchSecondaryCrossRegionPGHosts(context.Background(), dep, []regionSlot{{key: "", kubeconfigPath: primaryPath}})
 	})
 }
+
+// TestClusterMeshReconcileStatusGate_ConsoleDowngradedRecord pins the #5253
+// heal arm: a failed record whose Phase1Outcome is "ready" — the signature a
+// pre-#5253 build persisted when the #4706 console gate downgraded a fully
+// converged primary (hw276) — must be a mesh candidate, so a catalyst-api
+// restart re-establishes ClusterMesh instead of leaving the cross-region
+// topology inert forever. Genuine failures (any non-OutcomeReady,
+// non-OutcomeTimeout Phase1Outcome) and single-region records stay excluded,
+// and the existing ready + failed-by-TIMEOUT (#3317) arms are unchanged.
+func TestClusterMeshReconcileStatusGate_ConsoleDowngradedRecord(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	regions := func(n int) []provisioner.RegionSpec {
+		out := make([]provisioner.RegionSpec, n)
+		for i := range out {
+			out[i] = provisioner.RegionSpec{Provider: "huawei"}
+		}
+		return out
+	}
+	mk := func(status, outcome string, regionCount int) *Deployment {
+		return &Deployment{
+			ID:      "gate-5253",
+			Status:  status,
+			Request: provisioner.Request{Regions: regions(regionCount)},
+			Result:  &provisioner.Result{Phase1Outcome: outcome},
+		}
+	}
+
+	cases := []struct {
+		name    string
+		status  string
+		outcome string
+		regions int
+		want    bool
+	}{
+		{"ready multi-region (baseline)", "ready", helmwatch.OutcomeReady, 2, true},
+		{"failed+timeout multi-region (#3317 arm intact)", "failed", helmwatch.OutcomeTimeout, 2, true},
+		{"failed+OutcomeReady multi-region (#5253 hw276 pre-fix shape)", "failed", helmwatch.OutcomeReady, 2, true},
+		{"failed+OutcomeReady single-region", "failed", helmwatch.OutcomeReady, 1, false},
+		{"failed+OutcomeFailed (genuine hard failure)", "failed", helmwatch.OutcomeFailed, 2, false},
+		{"failed+flux-not-reconciling (genuine hard failure)", "failed", helmwatch.OutcomeFluxNotReconciling, 2, false},
+		{"failed+storage-downgrade (#3971 replaces the outcome)", "failed", provisioner.ReasonDefaultStorageClassEphemeral, 2, false},
+	}
+	for _, c := range cases {
+		if got := h.clusterMeshReconcileStatusGate(mk(c.status, c.outcome, c.regions)); got != c.want {
+			t.Errorf("%s: gate=%v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
@@ -1,64 +1,113 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
 
-// TestMarkPhase1DoneConsoleGate locks in #4706: a Phase-1 OutcomeReady is
-// promoted to Status="ready" ONLY when the external console-reachability probe
-// succeeds. A converged-but-unreachable console (the console-000 symptom that
-// killed hw217 while the mothership still claimed "ready") must be classified
-// "failed" — never a false-green "ready" that redirects the operator to a dead
-// URL. The consoleProbe seam lets us assert both arms without a network.
+// TestMarkPhase1DoneConsoleGate locks in the #5253 contract for the #4706
+// console-reachability signal (family #4486):
+//
+//   - A converged PRIMARY (OutcomeReady) whose console probe FAILS stays
+//     Status="ready" and STILL fires the producer chain (fireHandover +
+//     the mesh/spine/adoption/policy hooks) — the console condition rides
+//     the NON-FATAL ConsoleDegraded surface instead of latching the whole
+//     cross-region topology inert (the hw276 defect: failed+OutcomeReady
+//     matched no terminal block and no heal path, so region-b never meshed).
+//   - A genuinely-failed primary (outcome != OutcomeReady) stays "failed",
+//     fires NO handover, and never runs the console probe — the honest
+//     failure detection #4706/#3018 pinned is untouched.
 func TestMarkPhase1DoneConsoleGate(t *testing.T) {
+	twoRegions := []provisioner.RegionSpec{{Provider: "huawei"}, {Provider: "huawei"}}
 	mkDep := func() *Deployment {
 		return &Deployment{
-			ID:     "console-gate",
-			Status: "phase1-watching",
+			ID:        "console-gate",
+			Status:    "phase1-watching",
+			StartedAt: time.Now(),
+			eventsCh:  make(chan provisioner.Event, 256),
+			done:      make(chan struct{}),
 			Request: provisioner.Request{
 				SovereignFQDN: "hw999.omani.works",
-				Regions:       []provisioner.RegionSpec{{Provider: "huawei"}},
+				OrgEmail:      "operator@test.example.com",
+				Regions:       twoRegions,
 			},
-			Result: &provisioner.Result{},
+			Result:     &provisioner.Result{},
+			OwnerEmail: "operator@test.example.com",
 		}
 	}
 	finalStates := map[string]string{"cilium": helmwatch.StateInstalled}
 
-	t.Run("console reachable -> ready", func(t *testing.T) {
+	t.Run("console reachable -> ready, no degraded surface", func(t *testing.T) {
 		h := NewWithPDM(silentLogger(), &fakePDM{})
+		h.suppressPostHandoverHooks = true
 		h.consoleProbe = func(fqdn string) error { return nil }
 		dep := mkDep()
 		h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
 		if dep.Status != "ready" {
 			t.Fatalf("reachable console must flip ready: got Status=%q (err=%q)", dep.Status, dep.Error)
 		}
+		if dep.Result.ConsoleDegraded || dep.Result.ConsoleDegradedDetail != "" {
+			t.Fatalf("reachable console must not surface ConsoleDegraded: got %v / %q",
+				dep.Result.ConsoleDegraded, dep.Result.ConsoleDegradedDetail)
+		}
 	})
 
-	t.Run("console unreachable -> failed, not false-ready", func(t *testing.T) {
+	// #5253 — the hw276 shape: converged primary + console probe failure.
+	// The producer chain must STILL fire and the record must stay a mesh
+	// candidate; the console signal surfaces non-fatally.
+	t.Run("console unreachable + converged primary -> ready, chain fires, ConsoleDegraded surfaced", func(t *testing.T) {
 		h := NewWithPDM(silentLogger(), &fakePDM{})
-		h.consoleProbe = func(fqdn string) error { return fmt.Errorf("connection refused") }
+		h.suppressPostHandoverHooks = true
+		h.SetHandoverSigner(loadTestSigner(t))
+		h.consoleProbe = func(fqdn string) error { return fmt.Errorf("https://console.%s/ returned HTTP 404", fqdn) }
 		dep := mkDep()
 		h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
-		if dep.Status == "ready" {
-			t.Fatalf("unreachable console must NOT flip ready (false-green) — got Status=ready")
+
+		if dep.Status != "ready" {
+			t.Fatalf("converged primary must stay ready despite console probe failure (#5253): got Status=%q (err=%q)", dep.Status, dep.Error)
 		}
-		if dep.Status != "failed" {
-			t.Fatalf("unreachable console: got Status=%q, want failed", dep.Status)
+		if dep.Error != "" {
+			t.Fatalf("console condition must NOT ride dep.Error (FailureCard renders it as a hard failure): got %q", dep.Error)
 		}
-		if !strings.Contains(dep.Error, "externally reachable") {
-			t.Fatalf("failed error must explain the console is unreachable, got %q", dep.Error)
+		if !dep.Result.ConsoleDegraded {
+			t.Fatalf("ConsoleDegraded surface must be set for an unconfirmed console")
+		}
+		if !strings.Contains(dep.Result.ConsoleDegradedDetail, "HTTP 404") {
+			t.Fatalf("ConsoleDegradedDetail must carry the probe diagnostic, got %q", dep.Result.ConsoleDegradedDetail)
+		}
+		if dep.Result.Phase1Outcome != helmwatch.OutcomeReady {
+			t.Fatalf("Phase1Outcome must stay %q, got %q", helmwatch.OutcomeReady, dep.Result.Phase1Outcome)
+		}
+		// The producer chain fired: fireHandover ran inline in the
+		// OutcomeReady terminal block — the same block that spawns
+		// runAutoEstablishClusterMesh + the spine/adoption/policy hooks.
+		if dep.Result.HandoverFiredAt == nil {
+			t.Fatalf("handover must auto-fire for a converged primary despite the console downgrade (#5253)")
+		}
+		if !strings.HasPrefix(dep.Result.HandoverURL, "https://console.hw999.omani.works/auth/handover?token=") {
+			t.Fatalf("HandoverURL has unexpected shape: %q", dep.Result.HandoverURL)
+		}
+		// And the record remains a mesh candidate for the level-triggered
+		// startup heal paths.
+		if !h.clusterMeshReconcileStatusGate(dep) {
+			t.Fatalf("a ready 2-region console-degraded record must pass the mesh status gate")
 		}
 	})
 
 	// The probe is skipped for non-Ready outcomes — a genuine hard failure
-	// upstream must stay failed regardless of console state.
-	t.Run("non-ready outcome is untouched by the gate", func(t *testing.T) {
+	// upstream must stay failed regardless of console state, and must NOT
+	// fire the producer chain (the fire condition is OutcomeReady, i.e.
+	// every primary HR installed).
+	t.Run("genuinely-failed primary: stays failed, no fire, probe not run", func(t *testing.T) {
 		h := NewWithPDM(silentLogger(), &fakePDM{})
+		h.suppressPostHandoverHooks = true
+		h.SetHandoverSigner(loadTestSigner(t))
 		called := false
 		h.consoleProbe = func(fqdn string) error { called = true; return nil }
 		dep := mkDep()
@@ -68,6 +117,96 @@ func TestMarkPhase1DoneConsoleGate(t *testing.T) {
 		}
 		if dep.Status != "failed" {
 			t.Fatalf("OutcomeFluxNotReconciling must stay failed, got %q", dep.Status)
+		}
+		if dep.Result.HandoverFiredAt != nil || dep.Result.HandoverURL != "" {
+			t.Fatalf("a genuinely-failed primary must NOT fire handover: firedAt=%v url=%q",
+				dep.Result.HandoverFiredAt, dep.Result.HandoverURL)
+		}
+		if dep.Result.ConsoleDegraded {
+			t.Fatalf("ConsoleDegraded must not be set on a genuine failure")
+		}
+	})
+
+	t.Run("hard-failed component: stays failed, no fire, not a mesh candidate", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		h.suppressPostHandoverHooks = true
+		h.SetHandoverSigner(loadTestSigner(t))
+		h.consoleProbe = func(fqdn string) error { return nil }
+		dep := mkDep()
+		h.markPhase1Done(dep, map[string]string{"cilium": helmwatch.StateFailed}, helmwatch.OutcomeFailed)
+		if dep.Status != "failed" {
+			t.Fatalf("hard-failed component must stay failed, got %q", dep.Status)
+		}
+		if dep.Result.HandoverFiredAt != nil {
+			t.Fatalf("hard failure must NOT fire handover")
+		}
+		// failed + OutcomeFailed is excluded from the #5253 heal arms too —
+		// only the failed+OutcomeReady console-downgrade signature (records
+		// persisted by pre-#5253 builds) is rescuable.
+		if h.clusterMeshReconcileStatusGate(dep) {
+			t.Fatalf("failed+OutcomeFailed must NOT pass the mesh status gate")
+		}
+	})
+}
+
+// TestConsoleReachabilityReprobe pins the #5253 background re-probe: it
+// clears the non-fatal ConsoleDegraded surface the moment the front door
+// answers, refreshes the surfaced diagnostic while it does not, and gives up
+// (surface intact) after its bounded attempts.
+func TestConsoleReachabilityReprobe(t *testing.T) {
+	mkDegraded := func() *Deployment {
+		return &Deployment{
+			ID:     "console-reprobe",
+			Status: "ready",
+			Request: provisioner.Request{
+				SovereignFQDN: "hw999.omani.works",
+			},
+			Result: &provisioner.Result{
+				Phase1Outcome:         helmwatch.OutcomeReady,
+				ConsoleDegraded:       true,
+				ConsoleDegradedDetail: "https://console.hw999.omani.works/ returned HTTP 404",
+			},
+		}
+	}
+
+	t.Run("clears the surface once the console answers", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		calls := 0
+		h.consoleProbe = func(fqdn string) error {
+			calls++
+			if calls < 2 {
+				return errors.New("still HTTP 404")
+			}
+			return nil
+		}
+		dep := mkDegraded()
+		h.runConsoleReachabilityReprobe(dep)
+		if calls != 2 {
+			t.Fatalf("re-probe must retry until reachable: got %d calls, want 2", calls)
+		}
+		if dep.Result.ConsoleDegraded || dep.Result.ConsoleDegradedDetail != "" {
+			t.Fatalf("surface must clear once the console answers: got %v / %q",
+				dep.Result.ConsoleDegraded, dep.Result.ConsoleDegradedDetail)
+		}
+	})
+
+	t.Run("bounded give-up keeps the surface + freshest diagnostic", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		calls := 0
+		h.consoleProbe = func(fqdn string) error {
+			calls++
+			return fmt.Errorf("attempt-%d: connection refused", calls)
+		}
+		dep := mkDegraded()
+		h.runConsoleReachabilityReprobe(dep)
+		if calls != consoleReprobeAttempts {
+			t.Fatalf("re-probe must stop after %d attempts, got %d", consoleReprobeAttempts, calls)
+		}
+		if !dep.Result.ConsoleDegraded {
+			t.Fatalf("surface must stay set while the console never answers")
+		}
+		if !strings.Contains(dep.Result.ConsoleDegradedDetail, fmt.Sprintf("attempt-%d", consoleReprobeAttempts)) {
+			t.Fatalf("detail must carry the freshest diagnostic, got %q", dep.Result.ConsoleDegradedDetail)
 		}
 	})
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_reachable_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_reachable_test.go
@@ -45,3 +45,64 @@ func TestDefaultConsoleReachable_EmptyFQDN(t *testing.T) {
 		t.Fatalf("empty FQDN must error, got %v", err)
 	}
 }
+
+// TestDefaultConsoleReachable_RootSPA404HandoverFallback pins the #5253
+// false-negative fix (hw276): a HEALTHY console whose bare SPA root answers
+// 404 must still count reachable because the catalyst-api-registered
+// /auth/handover route answers (302 to the SPA error page → 200 after
+// redirect-following). The hw218 no-vhost envoy shape — 404 on EVERY path —
+// stays unreachable (pinned by the status-bar table above), so the #4706
+// false-green bar is intact.
+func TestDefaultConsoleReachable_RootSPA404HandoverFallback(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/handover", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/auth/handover-error?reason=missing_token", http.StatusFound)
+	})
+	mux.HandleFunc("/auth/handover-error", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // the hw276 SPA root
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+	if err := probeReachableForTest(srv.URL); err != nil {
+		t.Fatalf("healthy console with a 404 SPA root must be reachable via the /auth/handover fallback (#5253), got %v", err)
+	}
+}
+
+// TestDefaultConsoleReachable_RedirectFinalStatusDecides pins the #5253
+// redirect contract: the reachability decision is made on the FINAL status of
+// the redirect chain — a 2xx-after-redirect is a healthy silent-SSO front
+// door; a redirect landing on a 4xx is not.
+func TestDefaultConsoleReachable_RedirectFinalStatusDecides(t *testing.T) {
+	t.Run("2xx after redirect -> reachable", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/landed", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/landed", http.StatusFound)
+		})
+		srv := httptest.NewTLSServer(mux)
+		defer srv.Close()
+		if err := probeReachableForTest(srv.URL); err != nil {
+			t.Fatalf("302 -> 200 must be reachable, got %v", err)
+		}
+	})
+
+	t.Run("4xx after redirect on every path -> unreachable", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/dead", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/dead", http.StatusFound)
+		})
+		srv := httptest.NewTLSServer(mux)
+		defer srv.Close()
+		if err := probeReachableForTest(srv.URL); err == nil {
+			t.Fatalf("a redirect chain terminating on 404 for every probed path must stay unreachable")
+		}
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late.go
@@ -31,6 +31,19 @@ import (
 // of Ready HelmReleases, so a half-dead cluster never rescues. Every
 // downstream step (fireHandover, job sweep, policy flip) is idempotent
 // and self-guarding.
+//
+// #5253 extends the same rescue to failed+OutcomeReady — the pre-#5253
+// console-downgrade signature (hw276): the primary fully converged
+// (every primary HR installed) but the #4706 console-reachability gate
+// latched the record "failed", skipping the whole producer chain with
+// no heal path (`failed && OutcomeReady` matched neither this gate nor
+// the mesh status gate). markPhase1Done no longer produces that shape
+// (a console-degraded record stays "ready" with the non-fatal
+// ConsoleDegraded surface), so this arm heals records PERSISTED by
+// older builds on the next catalyst-api restart. The live census below
+// is the primary-converged proof either way, and the stale #4706
+// console error is re-homed onto the ConsoleDegraded surface so the
+// rescued record is not ready-with-FailureCard.
 
 // convergedLateMinReady is the absolute floor of Ready HelmReleases —
 // just under the canonical bootstrap-kit size so a kit-trim doesn't
@@ -48,7 +61,13 @@ func (h *Handler) shouldConvergedLateRescue(dep *Deployment) bool {
 		fired = dep.Result.HandoverFiredAt != nil
 	}
 	dep.mu.Unlock()
-	if status != "failed" || outcome != helmwatch.OutcomeTimeout || fired {
+	if status != "failed" || fired {
+		return false
+	}
+	// TIMEOUT (#3319, the original converged-late shape) or OutcomeReady
+	// (#5253, the pre-fix console-downgrade shape) qualify; every other
+	// outcome is a hard failure and never rescues.
+	if outcome != helmwatch.OutcomeTimeout && outcome != helmwatch.OutcomeReady {
 		return false
 	}
 	if _, ok := h.resolvePrimaryKubeconfigPath(dep); !ok {
@@ -87,8 +106,23 @@ func (h *Handler) runConvergedLateRescue(dep *Deployment) {
 		return
 	}
 	dep.Status = "ready"
-	if dep.Result != nil && dep.Result.Phase1FinishedAt == nil {
-		dep.Result.Phase1FinishedAt = &now
+	if dep.Result != nil {
+		if dep.Result.Phase1FinishedAt == nil {
+			dep.Result.Phase1FinishedAt = &now
+		}
+		// #5253 — a pre-fix console-downgrade record (failed +
+		// Phase1Outcome=="ready") carries the #4706 "console is NOT
+		// externally reachable" text on dep.Error. Re-home it onto the
+		// non-fatal ConsoleDegraded surface: the rescued record must not
+		// read ready-with-FailureCard (/deployments/{id} renders a
+		// non-empty Error as a hard failure), and the console signal
+		// stays surfaced instead of being deleted. Timeout records keep
+		// their existing Error handling untouched.
+		if dep.Result.Phase1Outcome == helmwatch.OutcomeReady && dep.Error != "" {
+			dep.Result.ConsoleDegraded = true
+			dep.Result.ConsoleDegradedDetail = dep.Error
+			dep.Error = ""
+		}
 	}
 	dep.mu.Unlock()
 	h.persistDeployment(dep)

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late_test.go
@@ -44,4 +44,61 @@ func TestShouldConvergedLateRescue(t *testing.T) {
 	if h.shouldConvergedLateRescue(mk("ready", helmwatch.OutcomeReady, false)) {
 		t.Errorf("ready records are not rescue candidates")
 	}
+	// #5253 — the pre-fix console-downgrade signature (hw276): the primary
+	// converged (OutcomeReady) but the #4706 console gate latched the record
+	// failed. Such PERSISTED records must qualify so a catalyst-api restart
+	// fires their producer chain; an already-fired one must not re-fire.
+	if !h.shouldConvergedLateRescue(mk("failed", helmwatch.OutcomeReady, false)) {
+		t.Errorf("failed+OutcomeReady+unfired must qualify (#5253, the hw276 pre-fix console-downgrade shape)")
+	}
+	if h.shouldConvergedLateRescue(mk("failed", helmwatch.OutcomeReady, true)) {
+		t.Errorf("already-fired handover must not re-fire for the #5253 shape")
+	}
+}
+
+// TestRunConvergedLateRescue_ConsoleDowngradeRecord proves the #5253 rescue
+// end-to-end for a pre-fix persisted record (failed + Phase1Outcome=="ready" +
+// the #4706 console error on dep.Error): once the live census confirms the
+// converged primary, the record flips ready and the stale console error is
+// re-homed onto the non-fatal ConsoleDegraded surface (the rescued record must
+// not read ready-with-FailureCard).
+func TestRunConvergedLateRescue_ConsoleDowngradeRecord(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	const depID = "hw276rescue"
+	if err := os.WriteFile(filepath.Join(dir, depID+".yaml"), []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	origCensus := censusHelmReleases
+	censusHelmReleases = func(kubeconfigPath string) (int, int, error) { return 66, 66, nil }
+	defer func() { censusHelmReleases = origCensus }()
+
+	consoleErr := "Phase 1 converged (all HelmReleases installed) but the console is NOT externally reachable: HTTP 404"
+	dep := &Deployment{
+		ID:     depID,
+		Status: "failed",
+		Error:  consoleErr,
+		Request: provisioner.Request{
+			Regions: []provisioner.RegionSpec{{Provider: "huawei"}, {Provider: "huawei"}},
+		},
+		Result: &provisioner.Result{Phase1Outcome: helmwatch.OutcomeReady},
+	}
+
+	h.runConvergedLateRescue(dep)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Status != "ready" {
+		t.Fatalf("census-confirmed console-downgrade record must flip ready, got %q", dep.Status)
+	}
+	if dep.Error != "" {
+		t.Fatalf("rescued record must not keep the #4706 error on dep.Error (FailureCard), got %q", dep.Error)
+	}
+	if !dep.Result.ConsoleDegraded || dep.Result.ConsoleDegradedDetail != consoleErr {
+		t.Fatalf("console signal must be re-homed onto ConsoleDegraded/Detail, got %v / %q",
+			dep.Result.ConsoleDegraded, dep.Result.ConsoleDegradedDetail)
+	}
+	if dep.Result.Phase1FinishedAt == nil {
+		t.Fatalf("rescue must stamp Phase1FinishedAt")
+	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -802,56 +802,170 @@ const (
 	consoleProbeInterval = 15 * time.Second
 )
 
-// defaultConsoleReachable is the production external-reachability probe for
-// #4706: it repeatedly GETs https://console.<fqdn>/ until it gets an HTTP
-// response with status < 400 (the console front door actually SERVES) or the
-// budget expires. It returns nil on reachable, a descriptive error otherwise.
+// consoleProbePaths are the paths each probe pass tries IN ORDER against
+// https://console.<fqdn>; the front door counts as SERVING when ANY of them
+// answers < 400 after redirect-following (#5253).
 //
-// TLS verification is skipped on purpose — this proves the gateway ANSWERS
-// (TCP + TLS + HTTP), not that the cert chains to a public root (a fresh
-// Sovereign may still be on an LE-staging/in-cluster wildcard).
+//   - "/" — the operator's entry point (silent-SSO: 200 SSR landing or 302 to
+//     the Keycloak login on a healthy console).
+//   - "/auth/handover" — the catalyst-api-registered handover route every
+//     Sovereign console serves (auth_handover.go): a browser-shaped GET
+//     without a token answers 302 to the SPA error page. This is the #5253
+//     false-negative killer — hw276's healthy console answered 404 at its
+//     bare SPA root, and the single-path probe misread the whole front door
+//     as dead, tipping a fully-converged Sovereign to "failed". A route the
+//     console BACKEND owns still answers < 400 in that shape, while the
+//     hw218 no-vhost envoy 404 (#4715 — envoy up, NO route to the console
+//     backend) keeps failing on EVERY path, so the false-green bar #4706
+//     exists for is unchanged.
+var consoleProbePaths = []string{"/", "/auth/handover"}
+
+// newConsoleProbeClient builds the probe's HTTP client. TLS verification is
+// skipped on purpose — the probe proves the gateway ANSWERS (TCP + TLS +
+// HTTP), not that the cert chains to a public root (a fresh Sovereign may
+// still be on an LE-staging/in-cluster wildcard). Redirect-following is
+// EXPLICIT and load-bearing (#5253): the reachability decision is made on the
+// FINAL status of the redirect chain (a 2xx-after-redirect is a healthy
+// silent-SSO front door; a redirect landing on a 4xx/5xx is not). Go's
+// default client already follows up to 10 hops — pinned here so a future
+// client change can't silently turn the probe into a single-hop reader.
+func newConsoleProbeClient() *http.Client {
+	return &http.Client{
+		Timeout:   8 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, // reachability, not trust
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			return nil
+		},
+	}
+}
+
+// consoleProbeAttempt runs ONE probe pass against base (scheme://host, no
+// trailing slash): each consoleProbePaths entry is GET'd browser-shaped
+// (Accept: text/html — the gate proves the OPERATOR's browser can open the
+// console) with redirect-following. Returns nil when any path's final status
+// is < 400; otherwise the last error/status observed.
+func consoleProbeAttempt(ctx context.Context, client *http.Client, base string) error {
+	var last error
+	for _, p := range consoleProbePaths {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+p, nil)
+		if err != nil {
+			last = err
+			continue
+		}
+		req.Header.Set("Accept", "text/html")
+		resp, err := client.Do(req)
+		if err != nil {
+			last = err
+			continue
+		}
+		code := resp.StatusCode
+		resp.Body.Close()
+		if code < 400 {
+			return nil
+		}
+		last = fmt.Errorf("%s returned HTTP %d", base+p, code)
+	}
+	return last
+}
+
+// defaultConsoleReachable is the production external-reachability probe for
+// #4706: it repeatedly probes https://console.<fqdn> (see consoleProbePaths)
+// until a pass observes an HTTP response with FINAL status < 400 after
+// redirect-following (the console front door actually SERVES) or the budget
+// expires. It returns nil on reachable, a descriptive error otherwise.
 //
 // STATUS BAR < 400 (tightened from the original < 500 — hw218 evidence, #4706):
-// the catalyst console is silent-SSO — its bare root returns 200 (SSR landing,
-// signed-in) or 302 (redirect to the Keycloak login), NEVER a 4xx. hw218
+// the catalyst console is silent-SSO — its entry routes answer 200 or 302,
+// never a 4xx, when the front door routes to the console backend. hw218
 // (2026-07-03) exposed the hole in the old < 500 bar: its console gateway
 // answered HTTP 404 (envoy up, but NO vhost/route to the console backend — the
 // #4715 listener collision), and the < 500 gate mislabelled that broken front
-// door "ready" — the exact false-green this probe exists to kill. A 4xx (404
-// no-route / 401 / 403 misconfigured front door) or 5xx or a transport error
-// (connection refused / timeout / NXDOMAIN) now correctly counts as down.
+// door "ready" — the exact false-green this probe exists to kill. A 4xx on
+// EVERY probed path or 5xx or a transport error (connection refused / timeout
+// / NXDOMAIN) counts as down. #5253 widened a pass to the multi-path +
+// redirect-following decision above so a healthy console whose bare SPA root
+// answers 404 (hw276) is no longer misread as a dead front door.
 func defaultConsoleReachable(fqdn string) error {
 	fqdn = strings.TrimSpace(fqdn)
 	if fqdn == "" {
 		return fmt.Errorf("empty sovereign FQDN — cannot probe console reachability")
 	}
-	target := "https://console." + fqdn + "/"
-	client := &http.Client{
-		Timeout:   8 * time.Second,
-		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, // reachability, not trust
-	}
+	base := "https://console." + fqdn
+	client := newConsoleProbeClient()
 	ctx, cancel := context.WithTimeout(context.Background(), consoleProbeBudget)
 	defer cancel()
 	var last error
 	for {
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
-		resp, err := client.Do(req)
-		if err == nil {
-			code := resp.StatusCode
-			resp.Body.Close()
-			if code < 400 {
-				return nil
-			}
-			last = fmt.Errorf("%s returned HTTP %d", target, code)
+		if err := consoleProbeAttempt(ctx, client, base); err == nil {
+			return nil
 		} else {
 			last = err
 		}
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("console %s not externally reachable within %s: %v", target, consoleProbeBudget, last)
+			return fmt.Errorf("console %s/ not externally reachable within %s: %v", base, consoleProbeBudget, last)
 		case <-time.After(consoleProbeInterval):
 		}
 	}
+}
+
+// consoleReprobeAttempts bounds the #5253 background re-probe that runs after
+// a ready-but-ConsoleDegraded Phase-1 termination. Each attempt is a full
+// consoleProbeBudget pass of h.consoleProbe, so 4 attempts extend the grace
+// window well past any realistic gateway/LB/cert settling lag without leaving
+// an unbounded goroutine behind.
+const consoleReprobeAttempts = 4
+
+// runConsoleReachabilityReprobe re-runs the console-reachability probe for a
+// deployment that terminated Phase-1 ready with the non-fatal ConsoleDegraded
+// surface set (#5253). On the first successful pass it clears the surface and
+// persists; failed passes refresh ConsoleDegradedDetail so the operator sees
+// the CURRENT diagnostic, not the stale termination-time one. This is
+// observability-only — the producer chain (handover/mesh/spine/policy) fired
+// at termination and is never gated on this loop. Runs on a
+// spawnPostHandoverHook goroutine; the h.consoleProbe seam keeps tests off
+// the network.
+func (h *Handler) runConsoleReachabilityReprobe(dep *Deployment) {
+	if h.consoleProbe == nil {
+		return
+	}
+	// dep.Request is immutable after creation — lock-free read is safe
+	// (same contract markPhase1Done relies on).
+	fqdn := dep.Request.SovereignFQDN
+	for attempt := 1; attempt <= consoleReprobeAttempts; attempt++ {
+		err := h.consoleProbe(fqdn)
+		dep.mu.Lock()
+		if dep.Result == nil {
+			dep.mu.Unlock()
+			return
+		}
+		if err == nil {
+			dep.Result.ConsoleDegraded = false
+			dep.Result.ConsoleDegradedDetail = ""
+			dep.mu.Unlock()
+			h.persistDeployment(dep)
+			h.log.Info("console re-probe: front door now serving — ConsoleDegraded cleared (#5253)",
+				"id", dep.ID,
+				"attempt", attempt,
+			)
+			return
+		}
+		dep.Result.ConsoleDegradedDetail = err.Error()
+		dep.mu.Unlock()
+		h.persistDeployment(dep)
+		h.log.Warn("console re-probe: front door still not confirmed reachable (#5253)",
+			"id", dep.ID,
+			"attempt", attempt,
+			"err", err,
+		)
+	}
+	h.log.Warn("console re-probe attempts exhausted — ConsoleDegraded stays surfaced; investigate the gateway / load-balancer wiring (#4706). The producer chain (handover/mesh/spine/policy) already fired at Phase-1 termination and is NOT gated on this (#5253)",
+		"id", dep.ID,
+		"attempts", consoleReprobeAttempts,
+	)
 }
 
 // EnableConsoleReachabilityGate wires the production external console-
@@ -1018,13 +1132,44 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		dep.Error = fmt.Sprintf("Phase 1 watch timed out before convergence: %d component(s) observed, none hard-failed, but not all reached installed within the watch budget. The Sovereign's Flux keeps retrying cluster-side; re-attach the watch (retry) to re-evaluate. The deployment is NOT ready until every component is installed.", len(finalStates))
 	case outcome == helmwatch.OutcomeReady:
 		if consoleReachErr != nil {
-			// #4706 — Flux converged (every HelmRelease installed) but the
-			// operator-facing console is NOT externally reachable. A "ready"
-			// pill here redirects the operator to a dead URL — the exact
-			// false-green the readiness gate must refuse. Classify honestly.
-			dep.Status = "failed"
-			dep.Error = fmt.Sprintf("Phase 1 converged (all HelmReleases installed) but the console is NOT externally reachable: %v. The Sovereign's internals are up, but its gateway is not serving the public console URL, so the operator cannot use it — this is NOT ready. Investigate the gateway / load-balancer wiring (#4706) then retry.", consoleReachErr)
-			break
+			// #5253 (family #4486/#4706, root-caused live on hw276) — Flux
+			// converged (every PRIMARY HelmRelease installed) but the #4706
+			// external console probe did not observe https://console.<fqdn>/
+			// serving within its budget. The former handling latched
+			// Status="failed" here, which re-introduced for the console cause
+			// the EXACT architectural fault the #4486 comment below documents
+			// for the absent-secondary cause: finalStatus=="failed" makes the
+			// OutcomeReady terminal block skip fireHandover +
+			// runAutoEstablishClusterMesh + the spine/adoption/policy hooks,
+			// and BOTH heal paths (clusterMeshReconcileStatusGate,
+			// shouldConvergedLateRescue) structurally excluded the
+			// failed+OutcomeReady shape — so a fully-converged primary never
+			// meshed, region-b never converged (no mesh → no CNPG-pair flip →
+			// hub secrets never sync → keycloak + the SSO charts wedge). On
+			// hw276 the trigger was additionally a FALSE NEGATIVE: the
+			// console stack was healthy, its SPA root just answered 404 while
+			// the front door served fine one redirect later.
+			//
+			// The honest, self-healing outcome mirrors #4486: STAY "ready"
+			// (OutcomeReady is granted only when every primary HR installed —
+			// that is the producer-chain fire condition), fire the chain, and
+			// carry the console condition on the NON-FATAL ConsoleDegraded
+			// surface (the #3611 surface-not-gate idiom) with a background
+			// re-probe (see the OutcomeReady terminal block below) that
+			// clears it the moment the front door answers. dep.Error stays
+			// empty on purpose — /deployments/{id} renders a non-empty Error
+			// as a hard FailureCard (the #4486 NB below). A genuinely-dead
+			// console stays loudly visible via ConsoleDegraded + this warn +
+			// the re-probe's terminal warn; it no longer latches the
+			// cross-region topology inert. A genuinely-unconverged primary
+			// never reaches this arm at all (outcome != OutcomeReady) and
+			// stays failed with no handover.
+			dep.Result.ConsoleDegraded = true
+			dep.Result.ConsoleDegradedDetail = consoleReachErr.Error()
+			h.log.Warn("phase 1 converged on the PRIMARY but the console front door was not confirmed externally reachable — staying ready + firing the producer chain; surfaced as ConsoleDegraded with a background re-probe (#5253, family #4486/#4706)",
+				"id", dep.ID,
+				"consoleReachErr", consoleReachErr,
+			)
 		}
 		dep.Status = "ready"
 	default:
@@ -1324,6 +1469,16 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// log + emit SSE warn but never fail the handover. See
 		// post_handover_gateway_elb.go.
 		h.spawnPostHandoverHook(func() { h.runPostHandoverGatewayELB(dep) })
+
+		// #5253 — when the #4706 console probe did NOT confirm reachability,
+		// the record is ready with the non-fatal ConsoleDegraded surface set
+		// (see the OutcomeReady case above). Keep re-probing in the
+		// background and clear the surface the moment the front door
+		// answers — the producer chain above already fired and is NOT gated
+		// on this. Failures only refresh the surfaced diagnostic.
+		if consoleReachErr != nil {
+			h.spawnPostHandoverHook(func() { h.runConsoleReachabilityReprobe(dep) })
+		}
 	} else if outcome == helmwatch.OutcomeTimeout && len(dep.Request.Regions) >= 2 {
 		// #3285/hw130 (2026-06-12): a Phase-1 TIMEOUT is the
 		// recoverable classification ("components observed, none
@@ -2850,23 +3005,12 @@ func certificateReady(u *unstructured.Unstructured) (bool, string, error) {
 	return false, "<missing-ready>", nil
 }
 
-// probeReachableForTest mirrors defaultConsoleReachable's status-bar decision
-// against an explicit URL (no console.<fqdn> construction, single attempt) so
-// the < 400 contract is unit-testable without DNS or the 90s budget. Kept in
-// non-test code because httptest servers need the same *http.Client TLS-skip.
+// probeReachableForTest runs defaultConsoleReachable's real status-bar
+// decision (consoleProbeAttempt: multi-path + redirect-following + < 400
+// final status, #4706/#5253) against an explicit base URL (no console.<fqdn>
+// construction, single pass) so the contract is unit-testable without DNS or
+// the probe budget. Kept in non-test code because httptest servers need the
+// same *http.Client TLS-skip.
 func probeReachableForTest(target string) error {
-	client := &http.Client{
-		Timeout:   8 * time.Second,
-		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
-	}
-	resp, err := client.Get(target)
-	if err != nil {
-		return err
-	}
-	code := resp.StatusCode
-	resp.Body.Close()
-	if code < 400 {
-		return nil
-	}
-	return fmt.Errorf("%s returned HTTP %d", target, code)
+	return consoleProbeAttempt(context.Background(), newConsoleProbeClient(), strings.TrimSuffix(target, "/"))
 }

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1474,6 +1474,30 @@ type Result struct {
 	// the #3611 Regions census as a 0/0 degraded secondary because the probe
 	// registers a nil watcher slot for it (skipping the doomed real watcher).
 	SecondaryFluxCRDAbsentRegions []string `json:"secondaryFluxCRDAbsentRegions,omitempty"`
+
+	// ConsoleDegraded — surface-only flag (#5253, family #4486/#4706): the
+	// PRIMARY region fully converged (Phase1Outcome=="ready" — every primary
+	// HelmRelease installed) but the #4706 external console-reachability
+	// probe did not observe https://console.<fqdn>/ serving within its budget
+	// at Phase-1 termination. Like SecondaryDegraded this is intentionally
+	// NOT a gate — markPhase1Done keeps Status="ready" and fires the full
+	// producer chain (handover, ClusterMesh establish, spine/adoption/policy
+	// hooks) off the converged primary, because latching Status="failed" here
+	// left the ENTIRE cross-region topology permanently inert (hw276: no
+	// mesh → no CNPG-pair flip → hub secrets never sync → keycloak + the SSO
+	// charts wedge on region-b). A background re-probe clears the flag the
+	// moment the front door answers; the operator console can badge a
+	// "ready" deployment as console-degraded off this field meanwhile.
+	ConsoleDegraded bool `json:"consoleDegraded,omitempty"`
+
+	// ConsoleDegradedDetail — the human diagnostic behind ConsoleDegraded
+	// (the last probe error, e.g. "https://console.<fqdn>/ returned HTTP
+	// 404"). Updated by each background re-probe attempt; cleared together
+	// with ConsoleDegraded when the console answers. Deliberately NOT
+	// stamped on the deployment's top-level Error field — /deployments/{id}
+	// renders a non-empty Error as a hard failure (the #4486 NB), and this
+	// condition is non-fatal by design.
+	ConsoleDegradedDetail string `json:"consoleDegradedDetail,omitempty"`
 }
 
 // PartialRegionMaterialisationError is returned by Provision when


### PR DESCRIPTION
Refs #5253 (family #4486 / #4706)

## The gate defect (root-caused live on hw276)

`markPhase1Done` (`products/catalyst/bootstrap/api/internal/handler/phase1_watch.go`):

- The #4706 arm inside `case outcome == helmwatch.OutcomeReady` downgraded a fully-converged primary to `Status="failed"` when the external console probe did not confirm `https://console.<fqdn>/` within its budget.
- The OutcomeReady terminal block is gated `outcome == OutcomeReady && finalStatus == "ready"` — with the downgrade it was SKIPPED, so `fireHandover` + `spawnPostHandoverHook(runAutoEstablishClusterMesh)` + the spine/adoption/policy/gateway hooks never ran; the `OutcomeTimeout` else-arm was also skipped (outcome was `ready`).
- Both heal paths structurally excluded the resulting record: `clusterMeshReconcileStatusGate` required `ready` OR `failed && OutcomeTimeout`; `shouldConvergedLateRescue` required `failed && OutcomeTimeout && !fired`. hw276 was `failed && OutcomeReady` → permanently inert: no ClusterMesh → region-b never converged → no CNPG-pair flip → hub secrets never synced → keycloak + the SSO charts wedged.
- This is the same producer-chain fault #4486 removed for the ABSENT-SECONDARY cause of `finalStatus=failed`, re-introduced by the console-reachability cause. Compounding it, the hw276 probe result was a FALSE NEGATIVE — the console stack was healthy; its SPA root answered 404 while the front door served fine one redirect later.

## The 3-part fix

1. **Producer chain decoupled (mirrors #4486, surface-not-gate).** A converged primary (`outcome == OutcomeReady`) stays `Status="ready"` and fires the full chain. The console condition rides a new NON-FATAL surface — `Result.ConsoleDegraded` + `Result.ConsoleDegradedDetail` (the #3611 idiom; `dep.Error` stays empty so `/deployments/{id}` does not render a hard FailureCard) — plus a bounded background re-probe (`runConsoleReachabilityReprobe`, 4 × full probe budget) that clears the surface the moment the front door answers and refreshes the diagnostic while it does not. The #4706 signal is kept, loudly: the termination-time warn, the surfaced condition, and the re-probe's terminal warn.
2. **Heal paths accept the pre-fix persisted signature** `failed && Phase1Outcome=="ready"` (`clustermesh.go::clusterMeshReconcileStatusGate`, `phase1_converged_late.go::shouldConvergedLateRescue`): a catalyst-api restart now re-establishes the mesh and fires the converged-late rescue for an hw276-shaped record instead of abandoning it. The rescue is census-verified (>=45 Ready HRs AND >=90% — the primary-converged proof) and re-homes the stale #4706 error text onto the ConsoleDegraded surface so the rescued record is not ready-with-FailureCard. Under the fixed `markPhase1Done` this signature is no longer produced, so the arms match only records persisted by older builds.
3. **Probe hardened** (`defaultConsoleReachable` → `consoleProbeAttempt`): each pass now tries `/` AND `/auth/handover` (the catalyst-api-registered handover route every Sovereign console serves — a browser-shaped tokenless GET answers 302 to the SPA error page), browser-shaped (`Accept: text/html`), with EXPLICIT redirect-following and the decision made on the FINAL status of the chain (< 400). A healthy console whose SPA root answers 404 is recognized; the hw218 no-vhost envoy 404 still fails on EVERY path, so the false-green bar #4706 exists for is unchanged.

## Why this does not re-break #4486 or fire on a genuine failure

- #4486's absent-secondary decoupling is untouched — its `dep.Status == "ready"` re-evaluation block still runs (a console-degraded record is now `ready`, so the DR-integrity + #3971 storage gates run on it too, which the old downgrade path skipped).
- The fire condition is exactly `outcome == OutcomeReady` (every primary HR installed). A genuinely-unconverged primary (kubeconfig-missing, flux-not-reconciling, flux-CRDs-absent, hard-failed component, timeout) never enters the OutcomeReady arm: it stays `failed`, fires NO handover, and cannot enter the new heal arms because every such shape carries a non-OutcomeReady `Phase1Outcome` (the #3971 storage downgrade REPLACES the outcome with `default-storageclass-ephemeral`, so a storage-blocked record is excluded as well — and it still blocks the chain at `finalStatus`).
- No NodePort anywhere (§854) — this is status/producer-chain logic plus an HTTP probe.

## Tests (all green: `go build`, `go vet`, `go test ./...` in `products/catalyst/bootstrap/api`)

- `TestMarkPhase1DoneConsoleGate` (rewritten to the #5253 contract): converged primary + console-404 → `ready`, `HandoverFiredAt` set + `HandoverURL` minted (the producer chain fired), `ConsoleDegraded` + detail surfaced, `dep.Error` empty, and the record passes the mesh status gate; genuinely-failed primary (`OutcomeFluxNotReconciling`, hard-failed component) → stays `failed`, probe not run, NO handover, NOT a mesh candidate.
- `TestConsoleReachabilityReprobe`: clears the surface when the console answers; bounded give-up keeps the surface with the freshest diagnostic.
- `TestClusterMeshReconcileStatusGate_ConsoleDowngradedRecord`: `failed+OutcomeReady` multi-region passes; single-region, `OutcomeFailed`, `flux-not-reconciling`, and the #3971 storage signature stay excluded; the ready + #3317 timeout arms are unchanged.
- `TestShouldConvergedLateRescue` (extended) + `TestRunConvergedLateRescue_ConsoleDowngradeRecord`: the hw276 shape qualifies (fired records do not), flips ready on a passing census, and re-homes the #4706 error onto the non-fatal surface.
- `TestDefaultConsoleReachable_RootSPA404HandoverFallback` + `TestDefaultConsoleReachable_RedirectFinalStatusDecides`: the hw276 false-negative shape is reachable; a redirect chain terminating on 4xx for every path — and the hw218 all-paths-404 table — stay unreachable.

Validates on the next fresh 2-region prov: region-b reaching ~63/66 with ClusterMesh established. Not claimed live-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)