### PR TITLE
test(catalyst-api): raise wipe_async_creds_rewipe waitForWipeDone ceiling 15s -> 60s (Refs #5255)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe_async_creds_rewipe_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_async_creds_rewipe_test.go
@@ -85,8 +85,12 @@ func TestWipeDeployment_RespondsBeforePurgeCompletes(t *testing.T) {
 	}
 
 	// Drain the goroutine before returning so it can't leak into a
-	// later test in this same process.
-	waitForWipeDone(t, dep, 15*time.Second)
+	// later test in this same process. 60s ceiling (#5255): a loaded
+	// shared CI runner finished the purge at ~15.01s, tripping the old
+	// 15s deadline. waitForWipeDone polls every 10ms and returns the
+	// moment the purge lands, so the generous ceiling costs nothing on
+	// healthy runs.
+	waitForWipeDone(t, dep, 60*time.Second)
 }
 
 // TestWipeDeployment_PurgeSurvivesRequestContextCancellation is the
@@ -138,7 +142,7 @@ func TestWipeDeployment_PurgeSurvivesRequestContextCancellation(t *testing.T) {
 	cancelledAt := time.Now()
 	cancel()
 
-	waitForWipeDone(t, dep, 15*time.Second)
+	waitForWipeDone(t, dep, 60*time.Second)
 	purgeElapsed := time.Since(cancelledAt)
 
 	dep.mu.Lock()
@@ -280,7 +284,7 @@ func TestWipeDeployment_HuaweiOperatorCredsEnvFallbackAvoids400(t *testing.T) {
 		t.Fatalf("status=%d, want 202 — body=%s", w.Code, w.Body.String())
 	}
 
-	waitForWipeDone(t, dep, 15*time.Second)
+	waitForWipeDone(t, dep, 60*time.Second)
 }
 
 // TestWipeDeployment_HuaweiNoCredsAnywhereStill400s is the negative
@@ -365,7 +369,7 @@ func TestWipeDeployment_StrandedWipingRecordIsReWipeable(t *testing.T) {
 		t.Errorf("dep.wipeInFlight=false immediately after re-firing the wipe — the purge goroutine was not (re)launched")
 	}
 
-	waitForWipeDone(t, dep, 15*time.Second)
+	waitForWipeDone(t, dep, 60*time.Second)
 
 	dep.mu.Lock()
 	status := dep.Status


### PR DESCRIPTION
## Problem

`wipe_async_creds_rewipe_test.go` gates four tests on `waitForWipeDone(t, dep, 15*time.Second)`. On a loaded shared CI runner the async wipe purge completed at ~15.01s, tripping the deadline at line 283 (`wipe purge did not complete within 15s`) and failing the #5254 merge train's run; the rerun was green with no code change. A test that fails on runner-timing variance alone keeps recurring as a merge-train delay across unrelated PRs.

## Fix (test-only)

Raise the ceiling at all four call sites to `60*time.Second`, with an inline rationale at the first site so nobody re-tightens it. `waitForWipeDone` (`wipe_test.go:59`) already polls every 10ms and returns the moment `wipeInFlight` clears and `lastWipeReport` lands, so the generous ceiling costs zero wall-time on healthy runs — and 60s still surfaces a genuinely hung purge far inside the 10m package deadline as this test's named failure. No non-test file touched; every assertion from the #5193 regression lock (PR #5200) preserved unchanged.

## Validation

- `go build ./...` clean in `products/catalyst/bootstrap/api`.
- `go test ./...` green across the module (handler package 156.6s total, zero failures).
- `go test ./internal/handler -run TestWipeDeployment -v`: all 12 pass; the four async-wipe tests complete in ~4s each — the poll returns early, wall-time unchanged.

Refs #5255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
