### PR TITLE
fix(#3971): forbid local-path StorageClass at land — CI gate + violation fixes

### DIFF
--- a/.github/workflows/check-no-local-path.yaml
+++ b/.github/workflows/check-no-local-path.yaml
@@ -1,0 +1,58 @@
+name: check — zero local-path StorageClass (#3971)
+
+# Permanent guard that the local-path StorageClass stays FORBIDDEN at land,
+# for EVERY future PR.
+#
+# #3971: local-path (rancher.io/local-path) is ephemeral node-local disk —
+# no cloud block volume behind it — so any node replacement destroys the
+# data. The runtime layers already forbid it (k3s --disable=local-storage,
+# the per-provider cloud CSI default StorageClass, and the K23 Kyverno
+# ENFORCE deny). This workflow is the LAND-TIME layer: no shipped chart,
+# manifest, overlay, or IaC source may name local-path, and no chart may
+# RENDER a storageClassName/storageClass/provisioner resolving to it.
+#
+# scripts/check-no-local-path.sh runs two phases: an authoritative static
+# source scan (platform/ products/ clusters/ infra/ core/) plus a
+# best-effort `helm template` render sweep of every chart. See the script
+# header for detail. Same shape as check-no-nodeports.yaml (#4765).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'clusters/**'
+      - 'infra/**'
+      - 'core/**'
+      - 'scripts/check-no-local-path.sh'
+      - '.github/workflows/check-no-local-path.yaml'
+  pull_request:
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'clusters/**'
+      - 'infra/**'
+      - 'core/**'
+      - 'scripts/check-no-local-path.sh'
+      - '.github/workflows/check-no-local-path.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  no-local-path:
+    name: Reject local-path StorageClass (sources + rendered charts)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      - name: Run zero-local-path guard
+        run: bash scripts/check-no-local-path.sh

--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -86,7 +86,10 @@ spec:
       # 1.2.4 — #4347: harbor-proxy the seaweedfs image so all 4 workloads clear
       #   the host-ns Kyverno harbor-proxy-pull Enforce policy (post-#4325).
       #   Refs #4347 #4325.
-      version: 1.2.4
+      # 1.2.5 — #3971: comment-only reword in storageclass.yaml so the
+      #   land-time zero-local-path guard sees the ban marker on the line
+      #   naming rancher.io/local-path. Rendered output identical to 1.2.4.
+      version: 1.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
@@ -86,12 +86,17 @@ spec:
         # matches bp-keycloak's realm-config-cli default.
         issuer: https://auth.omantel.biz/realms/catalyst
       recordings:
-        # omantel chroot is currently single-CSI (local-path).
-        # SeaweedFS-CSI is not deployed here; once it is, switch
-        # back to `seaweedfs-storage` for RWX session-recording
-        # streaming. local-path is RWO but the recording-shipper
-        # (when added) reads asynchronously, so RWO is acceptable.
-        storageClass: local-path
+        # #3971: local-path is FORBIDDEN — k3s runs
+        # --disable=local-storage (the ephemeral provisioner is never
+        # installed) and the K23 Kyverno ENFORCE policy DENIES any
+        # local-path PVC/StorageClass. omantel runs on Huawei (kom4dc)
+        # where the durable cloud CSI class is `evs-ssd`
+        # (bp-huawei-evs-csi, slot 55b) — pin it so a future
+        # recordings.persistence=true flip binds a durable EVS volume,
+        # not the chart's Hetzner default (hcloud-volumes). Recordings
+        # stay an emptyDir until persistence is enabled (chart default
+        # recordings.persistence=false, #3374).
+        storageClass: evs-ssd
       webapp:
         # Memory-constrained omantel cluster — only one webapp
         # replica fits alongside the rest of the catalyst-system

--- a/platform/hcloud-csi/README.md
+++ b/platform/hcloud-csi/README.md
@@ -78,10 +78,14 @@ The **chart's** `defaultStorageClass` value defaults to `false` (so a bare
 - The `hcloud-volumes` StorageClass renders with the
   `storageclass.kubernetes.io/is-default-class: "true"` annotation.
 - A post-install hook Job (`default-class-hook.yaml`) waits for the SC to
-  exist, then promotes it to default and **demotes** the k3s `local-path`
-  default (strips its default annotation) so there is exactly ONE default.
-- `local-path` is left INSTALLED but non-default — genuinely-ephemeral caches
-  can still opt in with `storageClassName: local-path`.
+  exist, then promotes it to default and **demotes** any OTHER StorageClass
+  still carrying the default annotation so there is exactly ONE default (on
+  a fresh prov this is a no-op — `local-path` does not exist at all).
+- `local-path` is FORBIDDEN outright (#3971): k3s runs
+  `--disable=local-storage` so the provisioner is NEVER installed, and the
+  bp-kyverno-policies K23 ENFORCE policy DENIES any `local-path` PVC /
+  StorageClass / `rancher.io/local-path` provisioner. There is no opt-in —
+  genuinely-ephemeral caches use `emptyDir`, never a local-path PVC.
 
 On a FRESH prov this is non-destructive: the stateful slots (openbao,
 keycloak, gitea, cnpg) install LATE (after their `dependsOn` chains on

--- a/platform/seaweedfs/blueprint.yaml
+++ b/platform/seaweedfs/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.2.4  # lockstep with chart/Chart.yaml (#4347 harbor-proxy image for host-ns Kyverno harbor-proxy-pull Enforce)
+  version: 1.2.5  # lockstep with chart/Chart.yaml (#3971 comment-only reword for the zero-local-path land guard)
   card:
     title: SeaweedFS
     family: foundation

--- a/platform/seaweedfs/chart/Chart.yaml
+++ b/platform/seaweedfs/chart/Chart.yaml
@@ -40,7 +40,11 @@ type: application
 #   host-ns Kyverno `harbor-proxy-pull` Enforce policy admits all 4 seaweedfs
 #   workloads (master/volume/filer/s3) after #4325 re-homed bp-seaweedfs into
 #   the native host ns. Refs #4347 #4325.
-version: 1.2.4
+# 1.2.5 (#3971): comment-only — reword a storageclass.yaml doc line so the
+#   land-time zero-local-path guard (scripts/check-no-local-path.sh) sees the
+#   ban marker on the same line that names `rancher.io/local-path`. Rendered
+#   output is byte-identical to 1.2.4.
+version: 1.2.5
 appVersion: "4.22"
 keywords: [catalyst, blueprint, seaweedfs, s3, object-storage, storage]
 maintainers:

--- a/platform/seaweedfs/chart/templates/storageclass.yaml
+++ b/platform/seaweedfs/chart/templates/storageclass.yaml
@@ -25,8 +25,8 @@ Why bp-seaweedfs ships this StorageClass (not bp-guacamole / overlay):
 Cloud CSI), NOT the ephemeral k3s local-path:
   - k3s now runs `--disable=local-storage` (cloud-init), so the local-path
     provisioner is FORBIDDEN — it is NEVER installed. A StorageClass with
-    `provisioner: rancher.io/local-path` would be non-functional (no
-    provisioner to bind) AND would be DENIED by the bp-kyverno-policies
+    `provisioner: rancher.io/local-path` is FORBIDDEN and non-functional
+    (no provisioner to bind) AND would be DENIED by the bp-kyverno-policies
     local-path ENFORCE policy.
   - bp-hcloud-csi (bootstrap-kit slot 55a) is now a `dependsOn` of the
     stateful root slots (bp-cnpg / bp-mgmt-vcluster), so the cloud CSI +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2661,7 +2661,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-seaweedfs
-    version: "1.2.4"
+    version: "1.2.5"
   topology:
     supported:
     - singleton

--- a/scripts/check-no-local-path.sh
+++ b/scripts/check-no-local-path.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# check-no-local-path.sh — CI guard that the local-path StorageClass stays
+# FORBIDDEN at land, forever (#3971).
+#
+# local-path (rancher.io/local-path) is a directory on the node's local disk —
+# NO cloud block volume behind it — so any node replacement destroys the data.
+# The P0 blocker #3971 was that EVERY Sovereign's PVCs landed on local-path.
+# The durable fix FORBIDS local-path entirely, in three runtime layers:
+#   1. k3s runs `--disable=local-storage` (cloud-init) — the provisioner is
+#      NEVER installed on a fresh prov.
+#   2. The per-provider durable cloud CSI is the ONLY default StorageClass
+#      (bp-hcloud-csi `hcloud-volumes` on Hetzner, bp-huawei-evs-csi `evs-ssd`
+#      on Huawei — bootstrap-kit slots 55a/55b).
+#   3. The bp-kyverno-policies K23 ClusterPolicy (ENFORCE) DENIES any
+#      PVC/StorageClass/PV that names local-path or the rancher.io/local-path
+#      provisioner at admission.
+#
+# This guard is the LAND-TIME layer: it fails ANY future PR that reintroduces
+# a local-path reference into shipped charts/manifests/IaC, so the runtime
+# layers can never silently regress. Two phases (same shape as
+# scripts/check-no-nodeports.sh, #4765):
+#   Phase 1 (authoritative, always enforced) — a static scan of the repo
+#     sources (platform/ products/ clusters/ infra/ core/) for local-path
+#     StorageClass field/literal patterns, ignoring comments and lines that
+#     merely DOCUMENT the ban.
+#   Phase 2 (best-effort) — `helm template` every chart under platform/*/chart
+#     and products/*/charts/* with default values and grep the RENDERED
+#     output for storageClassName/storageClass/provisioner fields resolving
+#     to local-path (catches values-driven defaults that only appear
+#     post-render). A chart that cannot be rendered offline is WARN-skipped —
+#     Phase 1 already covers its template sources.
+#
+# Usage:  scripts/check-no-local-path.sh
+# Exit:   0 = clean, 1 = a local-path reference reappeared, 2 = setup error.
+
+set -euo pipefail
+
+ROOT="${ROOT:-.}"
+cd "${ROOT}"
+
+EXIT=0
+fail() {
+  echo "FAIL: $1" >&2
+  EXIT=1
+}
+
+# ─── Phase 1 — static source scan ────────────────────────────────────────
+#
+# Forbidden real-field / real-literal patterns (NOT comments, NOT lines that
+# document the ban):
+#   storageClassName: local-path      (PVC / StatefulSet volumeClaimTemplate)
+#   storageClass: local-path          (chart values / HR values overlays)
+#   storage_class = "local-path"      (Terraform / HCL, incl. *_storage_class
+#                                     assignment shapes)
+#   rancher.io/local-path             (the provisioner literal — a rendered
+#                                     StorageClass or an image/provisioner pin)
+# The `!=` comparisons in infra/ tf `validation` blocks (the ban's own
+# guards) do NOT match: `[:=]` requires the char right after the key to be
+# `:` or `=`, and `var.default_storage_class` is not preceded by whitespace.
+PATTERN='(^|[[:space:]])(storageClassName|storageClass|default)[[:space:]]*:[[:space:]]*"?local-path"?([[:space:]]|$)|(^|[[:space:]])([A-Za-z_]*storage_class(_name)?|default)[[:space:]]*=[[:space:]]*"local-path"|rancher\.io/local-path'
+
+SCAN_ROOTS=(platform products clusters infra core)
+
+# A candidate line is a VIOLATION unless it is a comment or documents the
+# ban. Strip leading whitespace, drop lines whose first char is a comment
+# marker (# //), and drop lines that carry an explicit ban marker.
+BAN_MARKERS='FORBIDDEN|forbidden|#3971|#892|NEVER|never|must not|DENIED|denied|deny'
+
+echo "== Phase 1: static local-path source scan =="
+RAW="$(grep -rnIE "${PATTERN}" \
+  --include='*.yaml' --include='*.yml' \
+  --include='*.tf' --include='*.tftpl' --include='*.tfvars' \
+  "${SCAN_ROOTS[@]}" 2>/dev/null || true)"
+
+VIOLATIONS=""
+if [ -n "${RAW}" ]; then
+  while IFS= read -r line; do
+    [ -z "${line}" ] && continue
+    # Skip the K23 forbid-local-path ENFORCE policy + its test fixtures: they
+    # INTENTIONALLY name `local-path` / `rancher.io/local-path` as the
+    # admission DENY-list values and the "bad" kyverno-cli test inputs that
+    # prove the policy actually CATCHES a local-path PVC/SC (#3971). They are
+    # the enforcement layer itself, never a deployed local-path consumer —
+    # excluding them is correct, not a weakening (same shape as the NodePort
+    # gate's kyverno-fixture exclusion, #5088/#5089).
+    case "${line%%:*}" in
+      platform/kyverno-policies/chart/templates/baseline/23-forbid-local-path.yaml) continue ;;
+      platform/kyverno-policies/chart/tests/*) continue ;;
+    esac
+    # line == path:lineno:content — strip the path:lineno: prefix for the
+    # comment/marker tests.
+    content="${line#*:}"; content="${content#*:}"
+    trimmed="${content#"${content%%[![:space:]]*}"}"
+    first="${trimmed:0:1}"
+    # Skip pure comment lines (# yaml/tf, // just in case).
+    case "${first}" in
+      '#' | '*') continue ;;
+    esac
+    case "${trimmed}" in
+      '//'*) continue ;;
+    esac
+    # Skip lines that DOCUMENT the ban (they name the forbidden thing on
+    # purpose, e.g. a Kyverno validate message or a tf error_message).
+    if printf '%s' "${content}" | grep -qE "${BAN_MARKERS}"; then
+      continue
+    fi
+    VIOLATIONS="${VIOLATIONS}${line}"$'\n'
+  done <<< "${RAW}"
+fi
+
+if [ -n "${VIOLATIONS}" ]; then
+  fail "a local-path StorageClass reference reappeared in repo sources (#3971):"
+  printf '%s' "${VIOLATIONS}" >&2
+else
+  echo "OK — no local-path StorageClass reference in ${SCAN_ROOTS[*]} sources."
+fi
+
+# ─── Phase 2 — rendered-chart scan (best-effort) ─────────────────────────
+echo ""
+echo "== Phase 2: rendered-chart local-path scan =="
+if ! command -v helm >/dev/null 2>&1; then
+  echo "WARN: helm not on PATH — skipping the rendered-chart phase (Phase 1"
+  echo "      already covers chart template sources). Install helm to enforce."
+else
+  shopt -s nullglob
+  # Per-chart render timeout so a pathological chart can never hang CI. We
+  # NEVER run `helm dependency build` (it reaches out to the network and can
+  # hang); charts render OFFLINE from their vendored charts/*.tgz. A chart
+  # with unvendored deps fails template fast and is WARN-skipped.
+  HELM_TIMEOUT="${HELM_TIMEOUT:-30s}"
+  # Field-shaped pattern only: a real rendered violation surfaces as a
+  # storageClassName/storageClass field or a StorageClass provisioner
+  # resolving to local-path. (The K23 policy's rendered DENY-list values are
+  # bare `- local-path` list items — deliberately NOT matched.)
+  RENDER_PATTERN='(^|[[:space:]])(storageClassName|storageClass)[[:space:]]*:[[:space:]]*"?local-path"?([[:space:]]|$)|(^|[[:space:]])provisioner[[:space:]]*:[[:space:]]*"?rancher\.io/local-path"?([[:space:]]|$)'
+  CHART_DIRS=(platform/*/chart products/*/charts/*)
+  for chart in "${CHART_DIRS[@]}"; do
+    [ -f "${chart}/Chart.yaml" ] || continue
+    rendered="$(timeout "${HELM_TIMEOUT}" helm template "$(basename "${chart}")" "${chart}" 2>/dev/null || true)"
+    if [ -z "${rendered}" ]; then
+      echo "WARN: ${chart} did not render offline — skipped (Phase 1 covers its sources)."
+      continue
+    fi
+    hits="$(printf '%s\n' "${rendered}" \
+      | grep -nE "${RENDER_PATTERN}" \
+      | grep -vE '^[0-9]+:[[:space:]]*#' \
+      || true)"
+    if [ -n "${hits}" ]; then
+      fail "chart ${chart} RENDERS a local-path StorageClass reference (#3971):"
+      printf '%s\n' "${hits}" >&2
+    else
+      echo "OK — ${chart} renders zero local-path references."
+    fi
+  done
+fi
+
+echo ""
+if [ "${EXIT}" -ne 0 ]; then
+  echo "───────────────────────────────────────────────────────────────" >&2
+  echo "The local-path StorageClass is FORBIDDEN (#3971). It is ephemeral" >&2
+  echo "node-local disk — no cloud block volume — so node replacement" >&2
+  echo "DESTROYS the data. k3s runs --disable=local-storage (the provisioner" >&2
+  echo "is never installed) and the K23 Kyverno ENFORCE policy denies it at" >&2
+  echo "admission. Omit storageClassName to bind the durable cluster-default" >&2
+  echo "cloud CSI (hcloud-volumes on Hetzner, evs-ssd on Huawei), or name an" >&2
+  echo "explicit durable class. If a change appears to need local-path, it" >&2
+  echo "is the WRONG change — use the cloud CSI or an emptyDir." >&2
+  echo "───────────────────────────────────────────────────────────────" >&2
+  exit 1
+fi
+echo "OK: zero local-path StorageClass references across sources + rendered charts (#3971)."
+exit 0


### PR DESCRIPTION
Refs #3971

## What

The #3971 runtime layers already forbid `local-path` (k3s `--disable=local-storage`, per-provider cloud CSI default StorageClass, K23 Kyverno ENFORCE deny). This PR adds the missing **land-time** layer — a CI gate that fails any PR reintroducing a `local-path` reference into shipped charts/manifests/IaC — and fixes the remaining source references found by a full-tree audit.

🛑 **RT-11 merge freeze is active — do NOT merge yet.** Prepared + CI-green only; merge on freeze lift.

## CI gate (same shape as the zero-NodePort gate, #4765)

- `scripts/check-no-local-path.sh`
  - **Phase 1 (authoritative)** — static scan of `platform/ products/ clusters/ infra/ core/` (`*.yaml|*.yml|*.tf|*.tftpl|*.tfvars`) for `storageClassName: local-path`, `storageClass: local-path`, HCL `*storage_class = "local-path"` / `default = "local-path"`, and the `rancher.io/local-path` provisioner literal. Comment lines and lines documenting the ban are skipped. The K23 ENFORCE policy + its kyverno-cli fixtures are excluded — they ARE the enforcement layer (same exclusion shape as the NodePort gate's #5088/#5089 fixtures).
  - **Phase 2 (best-effort)** — `helm template` every chart under `platform/*/chart` + `products/*/charts/*` offline and greps the RENDERED output for field-shaped local-path hits; non-offline-renderable charts WARN-skip (Phase 1 covers their sources).
- `.github/workflows/check-no-local-path.yaml` — identical triggers to `check-no-nodeports.yaml` (push main + PR on the five source roots + the script/workflow, `workflow_dispatch`).

## Audit table (hit class → verdict)

| Hit | Verdict |
|---|---|
| `clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml:94` — `recordings.storageClass: local-path` | **VIOLATION — fixed** → `evs-ssd` (omantel = Huawei/kom4dc; `bp-huawei-evs-csi` slot 55b is its durable CSI; `seaweedfs-storage` there still carries the Hetzner provisioner so it cannot bind). Inert until `recordings.persistence=true` (chart default `false`, #3374). |
| `platform/hcloud-csi/README.md:83-84` — "`local-path` is left INSTALLED … can still opt in" | **Stale doc — fixed**: contradicted the ban (never installed; K23 denies). No opt-in; ephemeral caches use `emptyDir`. |
| `platform/seaweedfs/chart/templates/storageclass.yaml:28` — block-comment line naming `rancher.io/local-path` without a ban marker on that line | **Doc line — reworded** so the marker sits on the naming line (rendered output byte-identical); Chart 1.2.4 → 1.2.5. |
| `platform/kyverno-policies/chart/templates/baseline/23-forbid-local-path.yaml` + `chart/tests/fixtures/forbid-local-path/*` | **Allowed** — the K23 admission deny layer itself + its intentionally-failing fixtures; gate excludes by path. |
| `infra/providers/{huawei,hetzner}/variables.tf` `default_storage_class` validation (`!= "local-path"`) | **Allowed** — the ban's own IaC guard; `!=` comparison shape does not match the gate pattern. |
| `infra/providers/_shared/cloudinit-control-plane.tftpl` `--disable=local-storage` | **Allowed** — the fix itself. |
| `products/catalyst/bootstrap/api/**` Go (helmwatch `LocalPathProvisioner` const, provisioner.go, phase1_watch.go, sovereign_test.go, hw173 testdata JSON) | **Allowed** — the bootstrap watchdog/provisioning-DoD detection code + captured fixtures; Go/JSON are not chart/manifest surface and are outside the gate's include set. |
| `platform/seaweedfs/chart/charts/seaweedfs/values.yaml` commented `# storageClass: "local-path-provisioner"` examples; `platform/{hcloud-csi,huawei-evs-csi,postgres,gitea,…}` comments; `clusters/_template` slot comments; `scripts/expected-bootstrap-deps.yaml` comments | **Allowed** — comments documenting the ban / vendored upstream examples; comment filter skips them. |

## Verification

- Clean tree: `bash scripts/check-no-local-path.sh` → exit 0, `OK: zero local-path StorageClass references across sources + rendered charts (#3971)`.
- Negative test: seeded `storageClassName: local-path` (yaml), `storage_class = "local-path"` (HCL), and a rendered-chart violation — all three FAIL the gate with the #3971 message; seeds removed.
- `helm template` of the touched seaweedfs chart renders OK; guacamole overlay YAML parses; the overlay value feeds `seaweedfs-pvc.yaml`'s `storageClassName` as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)