### PR TITLE
fix(#4901): Continuum surfaces standby-absent — health degrades instead of false-green

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -161,7 +161,18 @@ spec:
       # backoff, failing loud via a continuum-error audit + a False/
       # RejoinRepairBounded condition rather than looping forever. Pin
       # moves in lockstep (Inviolable Principle #13).
-      version: 0.1.11
+      # 0.1.12 (#4901 follow-up): standby-GONE detection + flap-grace —
+      # a replica Cluster CR deleted outright (cluster deleted / region
+      # wiped) previously read "no determination", preserving the prior
+      # StandbyAvailable=True condition forever (false-green). The
+      # controller now remembers the last-resolved replica (seeded from
+      # status.standbyReplicaCluster across restarts) and degrades with
+      # reason StandbyAbsent when it vanishes; present-but-not-Ready
+      # keeps StandbyUnreachable. Both are gated behind a continuous-
+      # unavailability grace window (spec.standbyGraceSeconds, default
+      # 30s) so a flapped probe never flips the CR; recovery surfaces
+      # immediately. Pin moves in lockstep (Inviolable Principle #13).
+      version: 0.1.12
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/core/controllers/continuum/internal/cnpg/status.go
+++ b/core/controllers/continuum/internal/cnpg/status.go
@@ -134,9 +134,17 @@ func StandbyAvailable(replica Status) bool {
 // resolvable, e.g. provisioning in flight); the controller then leaves
 // any prior StandbyAvailable condition untouched instead of
 // false-alarming.
+//
+// Gone distinguishes the two unavailable postures (#4901 follow-up):
+// false = the replica Cluster CR is PRESENT but not serving (not
+// Ready / zero ready instances — "standby temporarily unreachable");
+// true = a replica Cluster CR that WAS previously resolvable is no
+// longer resolvable at all (cluster deleted / region wiped — "standby
+// cluster gone"). Only meaningful when Known && !Available.
 type StandbyObservation struct {
 	Known          bool
 	Available      bool
+	Gone           bool
 	ReplicaCluster string
 }
 

--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -76,6 +76,14 @@ const (
 	DefaultLeaseTTLSeconds   = 30
 	DefaultLeaseRenewSeconds = 10
 	DefaultLagThresholdSecs  = 60
+
+	// DefaultStandbyGraceSeconds — #4901 follow-up: how long the
+	// required synchronous hot-standby must be CONTINUOUSLY
+	// unavailable/unresolvable before the CR degrades (3 renew ticks
+	// at the default 10s cadence). Overridable per-CR via
+	// spec.standbyGraceSeconds; explicit 0 degrades on the first
+	// unavailable observation.
+	DefaultStandbyGraceSeconds = 30
 )
 
 // Phase strings — mirrors the CRD enum.
@@ -187,6 +195,19 @@ type continuumGoroutine struct {
 	// during the very promote-flap incidents the re-assert heals (hw273
 	// 18:33:57Z), and a same-value re-apply has no consumer impact.
 	lastActingPrimary string
+
+	// standbyLastSeenReplica + standbyUnavailableSince — #4901
+	// follow-up cross-tick memory for resolveStandbyPosture (same
+	// session-scoped pattern as the fields above). lastSeenReplica is
+	// the replica Cluster CR name from the most recent tick that
+	// RESOLVED the pair (seeded lazily from status.standbyReplicaCluster
+	// after a controller restart) — non-empty means a later
+	// unresolvable pair is a GONE standby, not provisioning-in-flight.
+	// unavailableSince is the wall-clock start of the current
+	// continuous-unavailable episode (zero when available / no
+	// episode); the grace window is measured against it.
+	standbyLastSeenReplica  string
+	standbyUnavailableSince time.Time
 }
 
 // SetupWithManager wires the reconciler into the controller-runtime
@@ -370,21 +391,29 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 		leaseState = newState
 
 		// #4901 — resolve the required synchronous hot-standby's
-		// availability alongside lag. standby.Known stays false when the
-		// CR names no cnpg pair (dr-spine/raft continuums) or the pair's
-		// replica half is unresolvable (provisioning in flight) — the
-		// status patch then preserves any prior StandbyAvailable
-		// condition instead of false-alarming.
+		// availability alongside lag. The RAW observation stays
+		// Known=false when the pair's replica half is unresolvable this
+		// tick; resolveStandbyPosture below folds it through the per-CR
+		// cross-tick memory so a PREVIOUSLY-SEEN replica that vanished
+		// (cluster deleted / region wiped) still degrades the CR after
+		// the grace window, while a never-seen pair (provisioning in
+		// flight, dr-spine/raft continuums) keeps making no
+		// determination — the status patch then preserves any prior
+		// StandbyAvailable condition instead of false-alarming.
 		var primaryStatus, replicaStatus cnpg.Status
 		var standby cnpg.StandbyObservation
 		if reader := r.cnpgReader(); reader != nil && spec.CNPGNamespace != "" && spec.CNPGPair != "" {
+			var raw cnpg.StandbyObservation
+			resolveFailed := false
 			primary, replica, fErr := reader.FindPair(ctx, spec.CNPGNamespace, spec.CNPGPair)
 			if fErr == nil {
 				primaryStatus, _, _ = reader.Get(ctx, primary.GetNamespace(), primary.GetName())
 				var gErr error
 				replicaStatus, _, gErr = reader.Get(ctx, replica.GetNamespace(), replica.GetName())
-				if gErr == nil {
-					standby = cnpg.StandbyObservation{
+				if gErr != nil {
+					resolveFailed = true
+				} else {
+					raw = cnpg.StandbyObservation{
 						Known:          true,
 						Available:      cnpg.StandbyAvailable(replicaStatus),
 						ReplicaCluster: replica.GetName(),
@@ -407,7 +436,10 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 					// pair reads; role_reassert.go.
 					r.reassertRolesOnPrimaryTransition(ctx, nn, reader, spec.CNPGNamespace, primary.GetName(), primaryStatus, replica.GetName(), replicaStatus)
 				}
+			} else {
+				resolveFailed = true
 			}
+			standby = r.resolveStandbyPosture(nn, cr, spec, raw, resolveFailed)
 		}
 
 		switchoverRequested := isSwitchoverRequested(cr)
@@ -892,6 +924,105 @@ func (r *ContinuumReconciler) clearSwitchoverRequest(ctx context.Context, cr *un
 	return err
 }
 
+// resolveStandbyPosture folds one tick's RAW standby observation
+// through the per-CR goroutine's cross-tick memory (#4901 follow-up).
+// It closes three gaps left by the first #4901 fix (#5094):
+//
+//  1. GONE standby: when the replica Cluster CR is deleted outright
+//     (cluster deleted / region wiped) FindPair fails and the raw
+//     observation reads "no determination" — which preserved the
+//     prior StandbyAvailable=True condition FOREVER (false-green). A
+//     pair whose replica RESOLVED earlier (this controller lifetime,
+//     or per the CR's own stored status) and is now unresolvable is
+//     GONE, not provisioning: after the grace window it degrades with
+//     reason StandbyAbsent.
+//  2. Flap-grace: one failed probe (apiserver hiccup, replica rolling
+//     restart) must not flip the CR Degraded for a single tick.
+//     Unavailable observations only pass through once continuously
+//     unavailable for spec.standbyGraceSeconds; inside the window the
+//     pass makes no determination, preserving the prior condition.
+//     Recovery (available) passes through IMMEDIATELY and resets the
+//     episode clock.
+//  3. Restart amnesia: the memory is session-scoped, so it seeds
+//     lazily from status.standbyReplicaCluster — a controller that
+//     restarts mid-outage (region outages restart controllers) still
+//     recognizes the vanished replica as previously-seen. When the
+//     stored status already says standbyAvailable=false the grace is
+//     treated as already served: a restart never flips a degraded CR
+//     back green.
+func (r *ContinuumReconciler) resolveStandbyPosture(
+	nn types.NamespacedName,
+	cr *unstructured.Unstructured,
+	spec ContinuumSpec,
+	raw cnpg.StandbyObservation,
+	resolveFailed bool,
+) cnpg.StandbyObservation {
+	r.activeContinuumsMu.Lock()
+	defer r.activeContinuumsMu.Unlock()
+	g, ok := r.activeContinuums[nn.String()]
+	if !ok {
+		// No per-CR goroutine registered (race with stopGoroutine).
+		// Without memory there is nothing to grace with — pass the raw
+		// observation through unchanged: degrade-on-observation is the
+		// safe default, silence is not.
+		return raw
+	}
+	grace := time.Duration(spec.StandbyGraceSeconds) * time.Second
+	now := r.now()
+
+	// Seed the session-scoped memory from the CR's stored status once
+	// (controller restart mid-outage).
+	if g.standbyLastSeenReplica == "" && cr != nil {
+		if prev, _, _ := unstructured.NestedString(cr.Object, "status", "standbyReplicaCluster"); prev != "" {
+			g.standbyLastSeenReplica = prev
+			if avail, found, _ := unstructured.NestedBool(cr.Object, "status", "standbyAvailable"); found && !avail {
+				// Already degraded before the restart — the grace
+				// window was served by the previous incarnation.
+				g.standbyUnavailableSince = now.Add(-grace)
+			}
+		}
+	}
+
+	switch {
+	case raw.Known && raw.Available:
+		g.standbyLastSeenReplica = raw.ReplicaCluster
+		g.standbyUnavailableSince = time.Time{}
+		return raw
+	case raw.Known:
+		// Replica CR present but not serving (not Ready / zero ready
+		// instances) — "standby temporarily unreachable".
+		g.standbyLastSeenReplica = raw.ReplicaCluster
+		if g.standbyUnavailableSince.IsZero() {
+			g.standbyUnavailableSince = now
+		}
+		if now.Sub(g.standbyUnavailableSince) < grace {
+			return cnpg.StandbyObservation{}
+		}
+		return raw
+	case resolveFailed && g.standbyLastSeenReplica != "":
+		// A previously-seen replica is no longer resolvable — the
+		// standby cluster is GONE (deleted CR / wiped region), not
+		// provisioning-in-flight.
+		if g.standbyUnavailableSince.IsZero() {
+			g.standbyUnavailableSince = now
+		}
+		if now.Sub(g.standbyUnavailableSince) < grace {
+			return cnpg.StandbyObservation{}
+		}
+		return cnpg.StandbyObservation{
+			Known:          true,
+			Available:      false,
+			Gone:           true,
+			ReplicaCluster: g.standbyLastSeenReplica,
+		}
+	default:
+		// Never-seen pair (provisioning in flight) or a transient
+		// resolve failure before any sighting — genuinely no
+		// determination; never false-alarm.
+		return cnpg.StandbyObservation{}
+	}
+}
+
 // patchStatusFromCR — convenience wrapper for steady-state patches.
 func (r *ContinuumReconciler) patchStatusFromCR(
 	ctx context.Context,
@@ -932,6 +1063,7 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 	if standby.Known {
 		avail := standby.Available
 		su.StandbyAvailable = &avail
+		su.StandbyGone = standby.Gone
 		su.StandbyReplicaCluster = standby.ReplicaCluster
 	}
 	if !lease.ExpiresAt.IsZero() {
@@ -996,6 +1128,13 @@ type statusUpdate struct {
 	// the OBSERVED status agree.
 	StandbyAvailable      *bool
 	StandbyReplicaCluster string
+
+	// StandbyGone — #4901 follow-up: only meaningful when
+	// StandbyAvailable is non-nil false. True = the replica Cluster CR
+	// itself is no longer resolvable (cluster deleted / region wiped) —
+	// the condition reason becomes StandbyAbsent; false = the CR is
+	// present but not serving — reason StandbyUnreachable.
+	StandbyGone bool
 
 	// RejoinRepair — #5125 Defect-2 step-8 outcome. nil = this pass made
 	// no rejoin-repair determination (no divergence observed) — any
@@ -1158,6 +1297,13 @@ func (r *ContinuumReconciler) patchStatus(ctx context.Context, cr *unstructured.
 		if !*su.StandbyAvailable {
 			cond["reason"] = "StandbyUnreachable"
 			cond["message"] = fmt.Sprintf("required synchronous hot-standby (cnpg-pair replica cluster %q) is unreachable; synchronous replication has no standby to acknowledge commits so writes stall and RPO=0 durability is at risk", su.StandbyReplicaCluster)
+			if su.StandbyGone {
+				// #4901 follow-up — the replica Cluster CR itself is no
+				// longer resolvable (cluster deleted / region wiped), a
+				// strictly worse posture than present-but-not-Ready.
+				cond["reason"] = "StandbyAbsent"
+				cond["message"] = fmt.Sprintf("required synchronous hot-standby (cnpg-pair replica cluster %q) is GONE — its Cluster CR is no longer resolvable (cluster deleted or region lost); synchronous replication has no standby to acknowledge commits so writes stall and RPO=0 durability is at risk", su.StandbyReplicaCluster)
+			}
 		}
 		conds = append(conds, cond)
 	}

--- a/core/controllers/continuum/internal/controller/spec.go
+++ b/core/controllers/continuum/internal/controller/spec.go
@@ -58,6 +58,18 @@ type ContinuumSpec struct {
 	// operator.
 	AutoFailover bool
 
+	// StandbyGraceSeconds — #4901 follow-up: how long the required
+	// synchronous hot-standby must be CONTINUOUSLY unavailable (or its
+	// Cluster CR unresolvable after having been seen) before the
+	// controller degrades the CR and writes StandbyAvailable=False. A
+	// brief flap (one failed probe, apiserver hiccup, rolling restart)
+	// inside the window makes no determination — the prior condition
+	// is preserved. Recovery always surfaces immediately. Read from
+	// spec.standbyGraceSeconds (the CRD's spec preserves unknown
+	// fields); absent = DefaultStandbyGraceSeconds, explicit 0 =
+	// degrade on first observation.
+	StandbyGraceSeconds int
+
 	// Mechanism — the switchover state-promotion mechanism
 	// (`cnpg-pair` default | `raft-transition`). Read from
 	// spec.switchover.mechanism; mirrors the Blueprint topology
@@ -149,6 +161,13 @@ func parseSpec(cr *unstructured.Unstructured) (ContinuumSpec, error) {
 	}
 
 	out.AutoFailover, _, _ = unstructured.NestedBool(cr.Object, "spec", "autoFailover")
+
+	// #4901 follow-up — standby-absent grace window. Absent field =
+	// default; explicit 0 = degrade on first unavailable observation.
+	out.StandbyGraceSeconds = DefaultStandbyGraceSeconds
+	if v, ok, _ := unstructured.NestedInt64(cr.Object, "spec", "standbyGraceSeconds"); ok {
+		out.StandbyGraceSeconds = int(v)
+	}
 
 	out.CNPGPair, _, _ = unstructured.NestedString(cr.Object, "spec", "cnpgPair", "name")
 	out.CNPGNamespace, _, _ = unstructured.NestedString(cr.Object, "spec", "cnpgPair", "namespace")

--- a/core/controllers/continuum/internal/controller/standby_gone_grace_4901_test.go
+++ b/core/controllers/continuum/internal/controller/standby_gone_grace_4901_test.go
@@ -1,0 +1,343 @@
+// Tests for the #4901 follow-up — resolveStandbyPosture closes the
+// residual false-green the first #4901 fix (#5094) left open:
+//
+//   - GONE standby: replica Cluster CR deleted outright → FindPair
+//     fails → the raw observation read "no determination", so the
+//     prior StandbyAvailable=True condition was preserved FOREVER.
+//     A previously-seen replica that vanishes must degrade with
+//     reason StandbyAbsent (after the grace window).
+//   - Flap-grace: a single unavailable observation must NOT flip the
+//     CR Degraded; only continuous unavailability past
+//     spec.standbyGraceSeconds does. Recovery surfaces immediately.
+//   - Never-seen pair (provisioning in flight) still makes no
+//     determination — no false alarms.
+//   - Restart-seed: memory seeds from status.standbyReplicaCluster so
+//     a controller restart mid-outage neither forgets the vanished
+//     replica nor flips a degraded CR back green.
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+)
+
+// registerGoroutine registers an (idle) per-CR goroutine entry so
+// resolveStandbyPosture has cross-tick memory to work with, exactly as
+// runPerCR does. Returns the entry for direct memory assertions.
+func registerGoroutine(r *ContinuumReconciler, nn types.NamespacedName) *continuumGoroutine {
+	g := &continuumGoroutine{cancel: func() {}}
+	r.activeContinuumsMu.Lock()
+	r.activeContinuums[nn.String()] = g
+	r.activeContinuumsMu.Unlock()
+	return g
+}
+
+// fakeClock is a controllable r.Now for grace-window tests.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.t }
+func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func standbySpec(graceSeconds int) ContinuumSpec {
+	return ContinuumSpec{StandbyGraceSeconds: graceSeconds}
+}
+
+// TestResolveStandbyPosture_GoneAfterGrace — the residual #4901
+// false-green: replica seen once, then its Cluster CR vanishes
+// (resolveFailed). Within grace: no determination (prior condition
+// preserved). Past grace: Known/unavailable/GONE determination.
+func TestResolveStandbyPosture_GoneAfterGrace(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("cnpg", "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	r, _, _ := newReconciler(t, cr)
+	clock := &fakeClock{t: time.Now()}
+	r.Now = clock.Now
+	nn := types.NamespacedName{Namespace: "cnpg", Name: "dr"}
+	registerGoroutine(r, nn)
+	spec := standbySpec(30)
+
+	// Tick 1: replica resolved + available — passes through, seeds memory.
+	avail := cnpg.StandbyObservation{Known: true, Available: true, ReplicaCluster: "demo-replica"}
+	if got := r.resolveStandbyPosture(nn, cr, spec, avail, false); !got.Known || !got.Available {
+		t.Fatalf("available observation must pass through, got %+v", got)
+	}
+
+	// Tick 2: replica Cluster CR deleted → resolveFailed. Within grace
+	// → no determination.
+	clock.Advance(10 * time.Second)
+	if got := r.resolveStandbyPosture(nn, cr, spec, cnpg.StandbyObservation{}, true); got.Known {
+		t.Fatalf("gone-within-grace must make no determination, got %+v", got)
+	}
+
+	// Tick 3: still gone, grace elapsed → GONE determination carrying
+	// the remembered replica name.
+	clock.Advance(30 * time.Second)
+	got := r.resolveStandbyPosture(nn, cr, spec, cnpg.StandbyObservation{}, true)
+	if !got.Known || got.Available || !got.Gone {
+		t.Fatalf("gone-past-grace must determine Known/unavailable/Gone, got %+v", got)
+	}
+	if got.ReplicaCluster != "demo-replica" {
+		t.Errorf("gone determination must carry the last-seen replica name, got %q", got.ReplicaCluster)
+	}
+
+	// The determination lands on the CR as Degraded + StandbyAbsent.
+	parsed, err := parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	if err := r.patchStatusFromCR(context.Background(), cr, parsed, heldLease("hw-a"), cnpg.Status{}, cnpg.Status{}, got, false, ""); err != nil {
+		t.Fatalf("patchStatusFromCR: %v", err)
+	}
+	r.HoldingRegion = "hw-a"
+	phase, condStatus, condReason, availField, absentField := statusFields(t, r, "cnpg", "dr")
+	if phase != PhaseDegraded {
+		t.Errorf("phase = %q, want Degraded (gone standby must degrade)", phase)
+	}
+	if condStatus["StandbyAvailable"] != "False" {
+		t.Errorf("StandbyAvailable condition = %q, want False", condStatus["StandbyAvailable"])
+	}
+	if condReason["StandbyAvailable"] != "StandbyAbsent" {
+		t.Errorf("StandbyAvailable reason = %q, want StandbyAbsent (gone, not merely unreachable)", condReason["StandbyAvailable"])
+	}
+	if v, ok := availField.(bool); !ok || v {
+		t.Errorf("status.standbyAvailable = %v, want false", availField)
+	}
+	if v, ok := absentField.(bool); !ok || !v {
+		t.Errorf("status.hotStandbyAbsent = %v, want true", absentField)
+	}
+}
+
+// TestResolveStandbyPosture_FlapGrace — a single unavailable
+// observation (replica present but not Ready) makes no determination;
+// recovery passes through immediately and resets the episode; only a
+// CONTINUOUS unavailable episode past the grace window degrades.
+func TestResolveStandbyPosture_FlapGrace(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("cnpg", "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	r, _, _ := newReconciler(t, cr)
+	clock := &fakeClock{t: time.Now()}
+	r.Now = clock.Now
+	nn := types.NamespacedName{Namespace: "cnpg", Name: "dr"}
+	g := registerGoroutine(r, nn)
+	spec := standbySpec(30)
+
+	unavail := cnpg.StandbyObservation{Known: true, Available: false, ReplicaCluster: "demo-replica"}
+	avail := cnpg.StandbyObservation{Known: true, Available: true, ReplicaCluster: "demo-replica"}
+
+	// Flap: one unavailable tick → no determination (prior condition
+	// preserved — the CR does NOT flip Degraded).
+	if got := r.resolveStandbyPosture(nn, cr, spec, unavail, false); got.Known {
+		t.Fatalf("first unavailable tick within grace must make no determination, got %+v", got)
+	}
+	// Recovery 10s later → passes through immediately + resets episode.
+	clock.Advance(10 * time.Second)
+	if got := r.resolveStandbyPosture(nn, cr, spec, avail, false); !got.Known || !got.Available {
+		t.Fatalf("recovery must surface immediately, got %+v", got)
+	}
+	if !g.standbyUnavailableSince.IsZero() {
+		t.Errorf("recovery must reset the unavailable episode clock")
+	}
+
+	// Fresh episode: continuously unavailable past grace → degrades
+	// with the PRESENT-but-unreachable posture (not Gone).
+	clock.Advance(10 * time.Second)
+	if got := r.resolveStandbyPosture(nn, cr, spec, unavail, false); got.Known {
+		t.Fatalf("new episode within grace must make no determination, got %+v", got)
+	}
+	clock.Advance(31 * time.Second)
+	got := r.resolveStandbyPosture(nn, cr, spec, unavail, false)
+	if !got.Known || got.Available {
+		t.Fatalf("unavailable past grace must determine Known/unavailable, got %+v", got)
+	}
+	if got.Gone {
+		t.Errorf("present-but-not-Ready replica must NOT read Gone (reason stays StandbyUnreachable)")
+	}
+}
+
+// TestResolveStandbyPosture_ZeroGrace_DegradesImmediately — explicit
+// spec.standbyGraceSeconds=0 keeps the #5094 degrade-on-first-
+// observation behavior.
+func TestResolveStandbyPosture_ZeroGrace_DegradesImmediately(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("cnpg", "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	r, _, _ := newReconciler(t, cr)
+	nn := types.NamespacedName{Namespace: "cnpg", Name: "dr"}
+	registerGoroutine(r, nn)
+
+	unavail := cnpg.StandbyObservation{Known: true, Available: false, ReplicaCluster: "demo-replica"}
+	if got := r.resolveStandbyPosture(nn, cr, standbySpec(0), unavail, false); !got.Known || got.Available {
+		t.Fatalf("zero grace must pass the unavailable observation through immediately, got %+v", got)
+	}
+}
+
+// TestResolveStandbyPosture_NeverSeen_NoFalseAlarm — a pair that never
+// resolved (provisioning in flight) keeps making no determination even
+// when resolution fails past any window: absence of history is not
+// evidence of loss.
+func TestResolveStandbyPosture_NeverSeen_NoFalseAlarm(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("cnpg", "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	r, _, _ := newReconciler(t, cr)
+	clock := &fakeClock{t: time.Now()}
+	r.Now = clock.Now
+	nn := types.NamespacedName{Namespace: "cnpg", Name: "dr"}
+	registerGoroutine(r, nn)
+	spec := standbySpec(30)
+
+	for i := 0; i < 10; i++ {
+		if got := r.resolveStandbyPosture(nn, cr, spec, cnpg.StandbyObservation{}, true); got.Known {
+			t.Fatalf("never-seen pair must never produce a determination, got %+v on tick %d", got, i)
+		}
+		clock.Advance(10 * time.Second)
+	}
+}
+
+// TestResolveStandbyPosture_RestartSeedsFromStatus — after a
+// controller restart the fresh goroutine has no memory, but the CR's
+// stored status carries standbyReplicaCluster + standbyAvailable=false
+// from the previous incarnation: the vanished replica must be
+// recognized as previously-seen AND the grace treated as already
+// served — a restart never flips a degraded CR back green.
+func TestResolveStandbyPosture_RestartSeedsFromStatus(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("cnpg", "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	_ = unstructured.SetNestedField(cr.Object, "demo-replica", "status", "standbyReplicaCluster")
+	_ = unstructured.SetNestedField(cr.Object, false, "status", "standbyAvailable")
+	r, _, _ := newReconciler(t, cr)
+	nn := types.NamespacedName{Namespace: "cnpg", Name: "dr"}
+	registerGoroutine(r, nn)
+
+	got := r.resolveStandbyPosture(nn, cr, standbySpec(30), cnpg.StandbyObservation{}, true)
+	if !got.Known || got.Available || !got.Gone {
+		t.Fatalf("restart over a degraded CR with a vanished replica must immediately re-determine Gone, got %+v", got)
+	}
+	if got.ReplicaCluster != "demo-replica" {
+		t.Errorf("seeded determination must carry the stored replica name, got %q", got.ReplicaCluster)
+	}
+}
+
+// TestResolveStandbyPosture_RestartSeed_GreenStatusGetsFullGrace — the
+// counterpart seed case: the stored status says the standby WAS
+// available; after the restart a resolve failure starts a FRESH grace
+// window (no immediate degrade off stale knowledge).
+func TestResolveStandbyPosture_RestartSeed_GreenStatusGetsFullGrace(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("cnpg", "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	_ = unstructured.SetNestedField(cr.Object, "demo-replica", "status", "standbyReplicaCluster")
+	_ = unstructured.SetNestedField(cr.Object, true, "status", "standbyAvailable")
+	r, _, _ := newReconciler(t, cr)
+	clock := &fakeClock{t: time.Now()}
+	r.Now = clock.Now
+	nn := types.NamespacedName{Namespace: "cnpg", Name: "dr"}
+	registerGoroutine(r, nn)
+	spec := standbySpec(30)
+
+	if got := r.resolveStandbyPosture(nn, cr, spec, cnpg.StandbyObservation{}, true); got.Known {
+		t.Fatalf("first post-restart resolve failure over a green status must open a grace window, got %+v", got)
+	}
+	clock.Advance(31 * time.Second)
+	got := r.resolveStandbyPosture(nn, cr, spec, cnpg.StandbyObservation{}, true)
+	if !got.Known || !got.Gone {
+		t.Fatalf("persisting resolve failure past grace must determine Gone, got %+v", got)
+	}
+}
+
+// TestRunPerCRPath_ReplicaDeleted_FindPairFails_ThenGone exercises the
+// same wiring runPerCR uses against a REAL deleted replica: FindPair
+// on the fake dynamic client fails once the replica Cluster CR is
+// deleted, and resolveStandbyPosture turns that into the Gone
+// determination past grace.
+func TestRunPerCRPath_ReplicaDeleted_FindPairFails_ThenGone(t *testing.T) {
+	t.Parallel()
+	const ns, pair = "cnpg", "demo"
+	cr := newTestContinuumCR(ns, "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	objs := append([]runtime.Object{cr}, newTestClusterPair(ns, pair, 0)...)
+	r, _, _ := newReconciler(t, objs...)
+	clock := &fakeClock{t: time.Now()}
+	r.Now = clock.Now
+	nn := types.NamespacedName{Namespace: ns, Name: "dr"}
+	registerGoroutine(r, nn)
+	spec := standbySpec(30)
+	reader := r.cnpgReader()
+
+	// Make the replica available so the first tick seeds the memory.
+	_, replica, err := reader.FindPair(context.Background(), ns, pair)
+	if err != nil {
+		t.Fatalf("FindPair: %v", err)
+	}
+	_ = unstructured.SetNestedSlice(replica.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+	if _, err := r.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Update(context.Background(), replica, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update replica: %v", err)
+	}
+	replicaStatus, _, err := reader.Get(context.Background(), replica.GetNamespace(), replica.GetName())
+	if err != nil {
+		t.Fatalf("Get replica: %v", err)
+	}
+	raw := cnpg.StandbyObservation{Known: true, Available: cnpg.StandbyAvailable(replicaStatus), ReplicaCluster: replica.GetName()}
+	if got := r.resolveStandbyPosture(nn, cr, spec, raw, false); !got.Known || !got.Available {
+		t.Fatalf("seed tick must pass available through, got %+v", got)
+	}
+
+	// Delete the replica Cluster CR — the #4901 "standby cluster gone"
+	// scenario. FindPair must now FAIL (pair incomplete).
+	if err := r.Dyn.Resource(cnpg.ClusterGVR).Namespace(ns).Delete(context.Background(), replica.GetName(), metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete replica: %v", err)
+	}
+	if _, _, err := reader.FindPair(context.Background(), ns, pair); err == nil {
+		t.Fatal("FindPair must fail once the replica Cluster CR is deleted")
+	}
+
+	// Same fold runPerCR performs on a FindPair failure.
+	clock.Advance(10 * time.Second)
+	if got := r.resolveStandbyPosture(nn, cr, spec, cnpg.StandbyObservation{}, true); got.Known {
+		t.Fatalf("within grace: no determination, got %+v", got)
+	}
+	clock.Advance(31 * time.Second)
+	got := r.resolveStandbyPosture(nn, cr, spec, cnpg.StandbyObservation{}, true)
+	if !got.Known || got.Available || !got.Gone || got.ReplicaCluster != replica.GetName() {
+		t.Fatalf("deleted replica past grace must determine Gone for %q, got %+v", replica.GetName(), got)
+	}
+}
+
+// TestParseSpec_StandbyGraceSeconds — absent = default; explicit value
+// wins; explicit 0 sticks (degrade-on-first-observation).
+func TestParseSpec_StandbyGraceSeconds(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("cnpg", "dr", "hw-a", []string{"hw-b"}, "k8s-lease")
+	spec, err := parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	if spec.StandbyGraceSeconds != DefaultStandbyGraceSeconds {
+		t.Errorf("absent spec.standbyGraceSeconds = %d, want default %d", spec.StandbyGraceSeconds, DefaultStandbyGraceSeconds)
+	}
+
+	_ = unstructured.SetNestedField(cr.Object, int64(90), "spec", "standbyGraceSeconds")
+	spec, err = parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	if spec.StandbyGraceSeconds != 90 {
+		t.Errorf("spec.standbyGraceSeconds=90 parsed as %d", spec.StandbyGraceSeconds)
+	}
+
+	_ = unstructured.SetNestedField(cr.Object, int64(0), "spec", "standbyGraceSeconds")
+	spec, err = parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	if spec.StandbyGraceSeconds != 0 {
+		t.Errorf("explicit spec.standbyGraceSeconds=0 parsed as %d, want 0", spec.StandbyGraceSeconds)
+	}
+}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5368,7 +5368,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-continuum
-    version: "0.1.11"
+    version: "0.1.12"
   topology:
     supported:
       - active-hot-standby

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -112,7 +112,25 @@ type: application
 # Flux re-pull once the deploy-bot stamps the new image SHA (the 0.1.9
 # lesson). Slot-62 pin + blueprint.yaml version move to 0.1.11 in
 # lockstep (Inviolable Principle #13).
-version: 0.1.11
+#
+# 0.1.12 (#4901 follow-up): standby-GONE detection + flap-grace. The
+# 0.1.10 standby-absent fix covered a replica Cluster CR that is
+# present but not Ready; a replica CR DELETED outright (cluster
+# deleted / region wiped) made FindPair fail -> "no determination" ->
+# the prior StandbyAvailable=True condition was preserved forever
+# (false-green). The reconcile loop now remembers the last-resolved
+# replica (seeded from status.standbyReplicaCluster across controller
+# restarts): a previously-seen replica that becomes unresolvable
+# degrades the CR with reason StandbyAbsent, while present-but-not-
+# Ready keeps StandbyUnreachable. Both degrade paths are gated behind
+# a continuous-unavailability grace window (spec.standbyGraceSeconds,
+# default 30s) so one flapped probe never flips the CR; recovery
+# surfaces immediately. Chart templates unchanged (controller-image
+# change only); the version bump forces the Flux re-pull once the
+# deploy-bot stamps the new image SHA (the 0.1.9 lesson). Slot-62 pin
+# + blueprint.yaml version move to 0.1.12 in lockstep (Inviolable
+# Principle #13).
+version: 0.1.12
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.11
+  version: 0.1.12
   card:
     title: Continuum
     summary: |


### PR DESCRIPTION
Refs #4901

🛑 **RT-11 merge freeze — do NOT merge.** Prepared ready-to-merge; a catalyst-api/controller roll mid-fire abandons the in-flight Sovereign prov. Merge on the next roll-gate window.

## RCA — the residual false-green after #5094

The first #4901 fix (#5094) degrades the cnpg-pair Continuum CR only when the replica-role Cluster half is **present but not serving** (not Ready / `readyInstances=0`). The issue's other branch — **"standby cluster gone"** (replica Cluster CR deleted outright: region wiped, cluster deleted) — still read as green forever:

- `core/controllers/continuum/internal/controller/continuum_controller.go` `runPerCR` resolve leg: replica CR deleted → `FindPair` errors ("pair incomplete") → `standby.Known` stays **false** → no determination.
- `patchStatusFromCR`: the degrade branch is gated on `standby.Known` → phase stays **Healthy**.
- `patchStatus` tri-state preserve-unless-rewriting: with `su.StandbyAvailable == nil` the **prior `StandbyAvailable=True` condition is preserved on every subsequent pass** — the CR keeps reporting a reachable standby indefinitely while there is NO standby (lag also reads 0: nothing is following).

Additionally #5094 flips Degraded on the **first** unavailable observation (no grace), and cannot distinguish "temporarily unreachable" from "gone".

## Fix

New `resolveStandbyPosture` folds each tick's raw observation through per-CR cross-tick memory (`standbyLastSeenReplica` + `standbyUnavailableSince` on `continuumGoroutine` — same session-scoped pattern as `lastSpecFingerprint` / `rejoinState`):

- **GONE detection**: a replica that resolved earlier — this controller lifetime, or seeded from the CR's stored `status.standbyReplicaCluster` (controller restart mid-outage neither forgets the vanished replica nor flips a degraded CR back green) — and is now unresolvable degrades the CR with condition reason **`StandbyAbsent`**; present-but-not-Ready keeps **`StandbyUnreachable`**. Never-seen pairs (provisioning in flight, dr-spine/raft continuums) still make no determination — no false alarms.
- **Flap-grace**: both degrade paths gate behind a continuous-unavailability window (`spec.standbyGraceSeconds`, default 30s = 3 renew ticks; explicit `0` = degrade on first observation; the Continuum CRD's `spec` carries `x-kubernetes-preserve-unknown-fields: true` so no CRD change is needed). Inside the window a pass makes no determination (prior condition preserved); recovery surfaces immediately and resets the episode.
- `cnpg.StandbyObservation` gains `Gone`; `statusUpdate` gains `StandbyGone`; the `StandbyAvailable=False` condition message names the gone posture explicitly. Lease/primary tracking, lag, switchover paths, and all #5094 semantics for present-replica postures unchanged.

## Delivery lockstep

Chart bp-continuum **0.1.11 → 0.1.12** (templates unchanged — controller-image change only; the bump forces the Flux re-pull once the deploy-bot stamps the new image SHA, the 0.1.9 lesson): `products/continuum/chart/Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot-62 pin + catalog-seed `source.version` (Inviolable Principle #13).

## Gates

- `go build` + `go vet` + `go test -race ./...` in `core/controllers/continuum` — green (8 new tests: gone-after-grace incl. real deleted-replica FindPair wiring on the fake dynamic client, flap-grace + episode reset, zero-grace immediate degrade, never-seen no-false-alarm, both restart-seed postures, spec parse).
- `tests/e2e/bootstrap-kit` (incl. `TestBootstrapKit_BlueprintVersionLockstepSweep`) — green.
- `helm template` with `continuum.enabled=true` renders 6 resources.
- `scripts/check-no-nodeports.sh` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)