### PR TITLE
fix(#5261): mesh cascade force-reconciles replica-region HRs stalled before hub-secret delivery

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -272,6 +272,13 @@ const (
 	// deadlock) keys the patch ordering off it.
 	clusterMeshRegionRoleSubstituteKey = "SOVEREIGN_REGION_ROLE"
 	fluxReconcileRequestedAtAnnotation = "reconcile.fluxcd.io/requestedAt"
+	// fluxReconcileForceAtAnnotation (#5261) — paired with requestedAt (same
+	// token value), this is what makes helm-controller retry a HelmRelease whose
+	// install/upgrade remediation retries are EXHAUSTED (Stalled=True). A bare
+	// requestedAt bump only re-queues the object; the reconciler sees the
+	// exhausted remediation budget and returns without acting. `flux reconcile
+	// helmrelease --force` stamps exactly this pair.
+	fluxReconcileForceAtAnnotation = "reconcile.fluxcd.io/forceAt"
 
 	// clusterMeshPeerClusterMeshNamesSubstituteKey (#4846, Refs #4656 #4275)
 	// carries the Cilium ClusterMesh cluster.name(s) of the OTHER region(s)
@@ -1916,6 +1923,13 @@ func (h *Handler) syncSharedPGReplicaAuthSecrets(ctx context.Context, dep *Deplo
 // source still carries the region-LOCAL `<instance>-rw` (which NXDOMAINs on the
 // replica), so pushing it would make things WORSE; skipping waits for the next
 // pass. Single-region (len(slots)<2) is a no-op.
+//
+// #5261 COMPLETION STEP: a replica pass that actually DELIVERED hub bytes
+// (copySecretAcrossClusters changed=true — the moment the missing input
+// arrives) closes its own loop by force-reconciling that replica's
+// flux-system HelmReleases which wedged BEFORE the delivery
+// (forceReconcileStalledReplicaHelmReleases). Steady-state passes (no byte
+// change) never kick, so the #3241/#3583 no-thrash contract holds.
 func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deployment, slots []regionSlot) {
 	if len(slots) < 2 {
 		return // single-region — no replica to sync to
@@ -1926,6 +1940,14 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 			"id", dep.ID)
 		return
 	}
+
+	// #5261 — captured BEFORE any copy lands: only HR failures whose
+	// lastTransitionTime predates this instant can have been caused by the
+	// hub Secrets missing, so only those are force-reconcile candidates.
+	syncStartedAt := time.Now().UTC()
+	// deliveredToReplica[i] — slot index i actually received changed hub
+	// bytes on THIS pass (the delivery moment, not a steady-state re-check).
+	deliveredToReplica := make(map[int]bool, len(slots)-1)
 
 	synced := make([]string, 0, len(sharedPGConsumerHubSecrets))
 	for _, name := range sharedPGConsumerHubSecrets {
@@ -1955,11 +1977,17 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 				copied = false
 				continue
 			}
-			if _, err := h.copySecretAcrossClusters(ctx, src, replica.clientset, sharedPGNamespace); err != nil {
+			changed, err := h.copySecretAcrossClusters(ctx, src, replica.clientset, sharedPGNamespace)
+			if err != nil {
 				h.log.Warn("clustermesh: shared-pg consumer-hub sync: copy to replica failed — skipping this Secret/region (best-effort, re-run converges)",
 					"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name, "err", err)
 				copied = false
 				continue
+			}
+			if changed {
+				// #5261 — this pass DELIVERED hub bytes to this replica (create
+				// or heal), so its pre-delivery stalled HRs get kicked below.
+				deliveredToReplica[i] = true
 			}
 			// #4878 (+ residual, live hw232): after we OVERWRITE the replica's
 			// divergent shared-data hub Secret with region-A's authoritative one,
@@ -1995,6 +2023,145 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 			fmt.Sprintf("ClusterMesh: synced %d shared-pg consumer-hub Secret(s) (%s) primary → %d replica region(s) — cross-region consumer DB host/password (#3629)",
 				len(synced), strings.Join(synced, ", "), len(slots)-1))
 	}
+
+	// #5261 — the cascade closes its own loop: every replica that received
+	// changed hub bytes THIS pass gets its pre-delivery stalled flux-system
+	// HelmReleases force-reconciled. Best-effort: a kick failure never fails
+	// the sync (matching the #4878 consumer-restart idiom above).
+	for i := 1; i < len(slots); i++ {
+		if !deliveredToReplica[i] {
+			continue
+		}
+		h.forceReconcileStalledReplicaHelmReleases(ctx, dep, &slots[i], syncStartedAt)
+	}
+}
+
+// forceReconcileStalledReplicaHelmReleases (#5261) — the mesh cascade's
+// close-the-loop step for the hw277 wedge: on a 2-region Sovereign the
+// replica-region SSO-tier HelmReleases (bp-keycloak + its 7 dependents) fire
+// at boot, ~107min BEFORE the post-Phase-1 cascade delivers the consumer-hub
+// Secrets (keycloak-database-secret et al., fire 13:26Z → secret 15:13Z on
+// hw277) — so bp-keycloak exhausts its install remediation retries
+// (Stalled=True `Failed to install after 2 attempt(s)`) while its DB Secret
+// simply does not exist yet. Flux NEVER retries a Stalled HelmRelease on its
+// own, so even after the workload self-heals (the pod picks up the delivered
+// Secret) the release object stays Failed and every `dependsOn` dependent
+// sits at 'dependency not ready' indefinitely.
+//
+// Called ONLY from syncSharedPGConsumerHubSecrets, and only for a replica
+// that received CHANGED hub bytes on this pass (the delivery moment). It
+// lists the replica's flux-system HelmReleases and force-reconciles —
+// stamping BOTH reconcile.fluxcd.io/requestedAt AND …/forceAt with the same
+// token; the forceAt half is what makes helm-controller retry an EXHAUSTED
+// install — every HR that is wedged (Ready=False and/or Stalled=True) with a
+// lastTransitionTime PREDATING the sync. The predates-the-sync guard is the
+// anti-thrash contract: a failure stamped AFTER the hub Secrets landed is a
+// genuine defect (not a missing-input strand) and must keep surfacing, not
+// be masked by an endless force-retry treadmill. Kicked HRs transition
+// (Reconciling) immediately, so they can never match a later delivery pass
+// either — each strand is kicked at most once per delivery.
+//
+// BEST-EFFORT like the #4878 consumer rollout-restart step: a missing
+// kubeconfig, client-build failure, List failure, or per-HR Patch failure is
+// logged (with the #5261 ref) and skipped — NEVER fatal to the orchestrator;
+// the same 'kick after the missing input arrives' idiom as the #5254 heal
+// paths (rescuableConsoleDowngrade / runConvergedLateRescue).
+func (h *Handler) forceReconcileStalledReplicaHelmReleases(ctx context.Context, dep *Deployment, slot *regionSlot, syncedAt time.Time) {
+	if slot == nil {
+		return
+	}
+	regionLabel := slot.key
+	if regionLabel == "" {
+		regionLabel = "replica"
+	}
+	if slot.kubeconfigPath == "" {
+		h.log.Warn("clustermesh: #5261 stalled-HR force-reconcile: region kubeconfig path empty — skipping (best-effort)",
+			"id", dep.ID, "region", regionLabel)
+		return
+	}
+	dyn, err := h.clusterMeshDynamicClient(slot.kubeconfigPath)
+	if err != nil {
+		h.log.Warn("clustermesh: #5261 stalled-HR force-reconcile: dynamic client build failed — skipping (best-effort)",
+			"id", dep.ID, "region", regionLabel, "err", err)
+		return
+	}
+	listCtx, cancelList := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	list, err := dyn.Resource(helmReleaseGVR).Namespace(fluxSystemNamespace).List(listCtx, metav1.ListOptions{})
+	cancelList()
+	if err != nil {
+		h.log.Warn("clustermesh: #5261 stalled-HR force-reconcile: list flux-system HelmReleases failed — skipping (best-effort)",
+			"id", dep.ID, "region", regionLabel, "err", err)
+		return
+	}
+
+	kicked := make([]string, 0, 4)
+	for i := range list.Items {
+		hr := &list.Items[i]
+		wedged, failedAt := helmReleaseWedgedSince(hr)
+		if !wedged {
+			continue // healthy / progressing — never touched
+		}
+		if failedAt.IsZero() || !failedAt.Before(syncedAt) {
+			// The failure does not (provably) predate the hub-secret delivery —
+			// a post-delivery failure is a genuine defect, not a missing-input
+			// strand. Leave it to surface on its own merits (#5261 anti-thrash).
+			h.log.Info("clustermesh: #5261 stalled-HR force-reconcile: HelmRelease failure does not predate the hub-secret delivery — leaving untouched",
+				"id", dep.ID, "region", regionLabel, "helmrelease", hr.GetName(),
+				"failedAt", failedAt.UTC().Format(time.RFC3339), "hubSecretsDeliveredAt", syncedAt.Format(time.RFC3339))
+			continue
+		}
+		token := time.Now().UTC().Format(time.RFC3339Nano)
+		patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q,%q:%q}}}`,
+			fluxReconcileRequestedAtAnnotation, token, fluxReconcileForceAtAnnotation, token))
+		patchCtx, cancelPatch := context.WithTimeout(ctx, clusterMeshCallTimeout)
+		_, patchErr := dyn.Resource(helmReleaseGVR).Namespace(fluxSystemNamespace).
+			Patch(patchCtx, hr.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+		cancelPatch()
+		if patchErr != nil {
+			h.log.Warn("clustermesh: #5261 stalled-HR force-reconcile: annotation patch failed — continuing (best-effort; kick never fails the orchestrator)",
+				"id", dep.ID, "region", regionLabel, "helmrelease", hr.GetName(), "err", patchErr)
+			continue
+		}
+		h.log.Info("clustermesh: #5261 force-reconciled stalled HelmRelease — its install retries exhausted BEFORE the mesh cascade delivered the hub Secrets, and Flux never retries a Stalled release on its own",
+			"id", dep.ID, "region", regionLabel, "helmrelease", hr.GetName(),
+			"failedAt", failedAt.UTC().Format(time.RFC3339), "hubSecretsDeliveredAt", syncedAt.Format(time.RFC3339))
+		kicked = append(kicked, hr.GetName())
+	}
+	if len(kicked) > 0 {
+		h.emitClusterMeshProgress(dep, "info",
+			fmt.Sprintf("ClusterMesh: force-reconciled %d stalled HelmRelease(s) (%s) in region %q whose install retries exhausted before the hub-secret delivery (#5261 — requestedAt+forceAt makes helm-controller retry the exhausted install)",
+				len(kicked), strings.Join(kicked, ", "), regionLabel))
+	}
+}
+
+// helmReleaseWedgedSince reports whether a HelmRelease is wedged —
+// Ready=False and/or Stalled=True — and the LATEST lastTransitionTime among
+// its wedged conditions (zero when none parse). Using the latest matching
+// transition means an HR is only treated as pre-delivery-stranded (#5261)
+// when EVERY piece of its failure evidence predates the hub-secret sync; any
+// post-delivery transition disqualifies it. Pure helper, no I/O.
+func helmReleaseWedgedSince(hr *unstructured.Unstructured) (bool, time.Time) {
+	conds, _, _ := unstructured.NestedSlice(hr.Object, "status", "conditions")
+	wedged := false
+	var latest time.Time
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		typ, _ := cm["type"].(string)
+		status, _ := cm["status"].(string)
+		if !((typ == "Ready" && status == "False") || (typ == "Stalled" && status == "True")) {
+			continue
+		}
+		wedged = true
+		if lt, _ := cm["lastTransitionTime"].(string); lt != "" {
+			if ts, err := time.Parse(time.RFC3339, lt); err == nil && ts.After(latest) {
+				latest = ts
+			}
+		}
+	}
+	return wedged, latest
 }
 
 // patchSecondaryCrossRegionPGHosts re-stamps the cross-region shared-pg WRITE

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -486,7 +486,10 @@ func defaultBootstrapKitSubstitute() map[string]any {
 }
 
 // newFakeKustomizationDynClient builds a fake dynamic client that knows
-// the Flux Kustomization GVR, seeded with the given objects.
+// the Flux Kustomization GVR — plus the HelmRelease GVR, so the #5261
+// post-delivery stalled-HR scan can List flux-system HelmReleases against
+// the same fake (an unregistered list GVR panics the dynamic fake) —
+// seeded with the given objects.
 func newFakeKustomizationDynClient(t *testing.T, objs ...runtime.Object) dynamic.Interface {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -496,8 +499,17 @@ func newFakeKustomizationDynClient(t *testing.T, objs ...runtime.Object) dynamic
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
 		Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "KustomizationList",
 	}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: helmReleaseGVR.Group, Version: helmReleaseGVR.Version, Kind: "HelmRelease",
+	}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: helmReleaseGVR.Group, Version: helmReleaseGVR.Version, Kind: "HelmReleaseList",
+	}, &unstructured.UnstructuredList{})
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
-		map[schema.GroupVersionResource]string{fluxKustomizationGVR: "KustomizationList"},
+		map[schema.GroupVersionResource]string{
+			fluxKustomizationGVR: "KustomizationList",
+			helmReleaseGVR:       "HelmReleaseList",
+		},
 		objs...)
 }
 
@@ -2836,6 +2848,220 @@ func TestSyncSharedPGConsumerHubSecrets(t *testing.T) {
 			}
 		}
 	})
+}
+
+// ── #5261 — cascade force-reconciles replica HRs stalled pre-delivery ──
+
+// buildTestHelmRelease returns a flux-system HelmRelease (the unstructured
+// shape the #5261 stalled-HR scan reads) carrying the given status conditions.
+func buildTestHelmRelease(name string, conds ...map[string]any) *unstructured.Unstructured {
+	condList := make([]any, 0, len(conds))
+	for _, c := range conds {
+		condList = append(condList, c)
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": helmReleaseGVR.Group + "/" + helmReleaseGVR.Version,
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": fluxSystemNamespace,
+		},
+		"status": map[string]any{"conditions": condList},
+	}}
+}
+
+// hrCondition builds one status condition; a zero lastTransition omits the
+// lastTransitionTime key entirely (the unprovable-age shape).
+func hrCondition(typ, status, reason string, lastTransition time.Time) map[string]any {
+	c := map[string]any{"type": typ, "status": status, "reason": reason}
+	if !lastTransition.IsZero() {
+		c["lastTransitionTime"] = lastTransition.UTC().Format(time.RFC3339)
+	}
+	return c
+}
+
+// getFluxSystemHelmRelease re-reads a flux-system HR from the fake dynamic
+// client so assertions observe post-patch state.
+func getFluxSystemHelmRelease(t *testing.T, dyn dynamic.Interface, name string) *unstructured.Unstructured {
+	t.Helper()
+	hr, err := dyn.Resource(helmReleaseGVR).Namespace(fluxSystemNamespace).
+		Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get HelmRelease %s: %v", name, err)
+	}
+	return hr
+}
+
+// TestForceReconcileStalledReplicaHelmReleases covers the #5261 close-the-loop
+// step (hw277 live evidence): replica-region SSO HRs exhaust their install
+// retries BEFORE the post-Phase-1 mesh cascade delivers the hub Secrets
+// (bp-keycloak Stalled=True at 13:26Z+2 attempts, keycloak-database-secret
+// only at 15:13Z), and Flux never retries a Stalled HR on its own — so after
+// the hub-secret delivery the cascade must force-reconcile exactly the HRs
+// whose failure PREDATES the delivery: (1) a pre-delivery stalled HR is
+// kicked with matching requestedAt+forceAt tokens (forceAt is what makes
+// helm-controller retry an exhausted install); (2) a healthy HR is untouched;
+// (3) an HR that failed AFTER the delivery is untouched (a genuine defect,
+// not a missing-input strand — kicking it would mask it and thrash retries);
+// (4) a wedged HR whose age cannot be proven is untouched; (5) a per-HR kick
+// failure is non-fatal and the scan continues to the next HR.
+func TestForceReconcileStalledReplicaHelmReleases(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dep := &Deployment{ID: "dep-5261"}
+	syncRef := time.Now().UTC()
+	const kcPath = "kc-replica-5261"
+	slot := &regionSlot{key: "secondary", kubeconfigPath: kcPath}
+
+	install := func(t *testing.T, dyn dynamic.Interface) {
+		t.Helper()
+		restore := installClusterMeshDynamicClientFactory(map[string]dynamic.Interface{kcPath: dyn})
+		t.Cleanup(restore)
+	}
+	annotationsOf := func(t *testing.T, dyn dynamic.Interface, name string) map[string]string {
+		t.Helper()
+		return getFluxSystemHelmRelease(t, dyn, name).GetAnnotations()
+	}
+
+	t.Run("stalled-HR-predating-sync-gets-kicked", func(t *testing.T) {
+		// The exact hw277 shape: install retries exhausted (`Failed to install
+		// after 2 attempt(s)`) ~107min before the cascade delivered the secret.
+		dyn := newFakeKustomizationDynClient(t, buildTestHelmRelease("bp-keycloak",
+			hrCondition("Ready", "False", "InstallFailed", syncRef.Add(-107*time.Minute)),
+			hrCondition("Stalled", "True", "RetriesExceeded", syncRef.Add(-107*time.Minute)),
+		))
+		install(t, dyn)
+		h.forceReconcileStalledReplicaHelmReleases(context.Background(), dep, slot, syncRef)
+		ann := annotationsOf(t, dyn, "bp-keycloak")
+		req, force := ann[fluxReconcileRequestedAtAnnotation], ann[fluxReconcileForceAtAnnotation]
+		if req == "" || force == "" {
+			t.Fatalf("pre-delivery stalled HR was not kicked (requestedAt=%q forceAt=%q) — Flux never retries a Stalled HR on its own, so the region-b SSO tier stays wedged (#5261)", req, force)
+		}
+		if req != force {
+			t.Errorf("requestedAt=%q != forceAt=%q — helm-controller only force-retries an exhausted install when both tokens MATCH", req, force)
+		}
+	})
+
+	t.Run("healthy-HR-untouched", func(t *testing.T) {
+		dyn := newFakeKustomizationDynClient(t, buildTestHelmRelease("bp-grafana",
+			hrCondition("Ready", "True", "InstallSucceeded", syncRef.Add(-3*time.Hour)),
+		))
+		install(t, dyn)
+		h.forceReconcileStalledReplicaHelmReleases(context.Background(), dep, slot, syncRef)
+		if ann := annotationsOf(t, dyn, "bp-grafana"); len(ann) != 0 {
+			t.Errorf("healthy HR gained annotations %v — a Ready release must never be force-reconciled", ann)
+		}
+	})
+
+	t.Run("HR-failing-after-sync-untouched", func(t *testing.T) {
+		// Failure stamped AFTER the hub-secret delivery — a genuine defect, not
+		// a missing-input strand. Kicking it would mask the defect and put the
+		// release on an endless force-retry treadmill.
+		dyn := newFakeKustomizationDynClient(t, buildTestHelmRelease("bp-newapi",
+			hrCondition("Ready", "False", "UpgradeFailed", syncRef.Add(10*time.Minute)),
+		))
+		install(t, dyn)
+		h.forceReconcileStalledReplicaHelmReleases(context.Background(), dep, slot, syncRef)
+		if ann := annotationsOf(t, dyn, "bp-newapi"); len(ann) != 0 {
+			t.Errorf("post-delivery failing HR gained annotations %v — only failures PREDATING the sync are missing-input strands (#5261)", ann)
+		}
+	})
+
+	t.Run("wedged-HR-without-transition-time-untouched", func(t *testing.T) {
+		// No parseable lastTransitionTime → the failure cannot be proven to
+		// predate the delivery → conservative skip.
+		dyn := newFakeKustomizationDynClient(t, buildTestHelmRelease("bp-oidc-gate",
+			hrCondition("Stalled", "True", "RetriesExceeded", time.Time{}),
+		))
+		install(t, dyn)
+		h.forceReconcileStalledReplicaHelmReleases(context.Background(), dep, slot, syncRef)
+		if ann := annotationsOf(t, dyn, "bp-oidc-gate"); len(ann) != 0 {
+			t.Errorf("wedged HR with unprovable failure age gained annotations %v — must be skipped conservatively", ann)
+		}
+	})
+
+	t.Run("kick-error-non-fatal-and-continues", func(t *testing.T) {
+		dyn := newFakeKustomizationDynClient(t,
+			buildTestHelmRelease("bp-keycloak",
+				hrCondition("Ready", "False", "InstallFailed", syncRef.Add(-time.Hour)),
+				hrCondition("Stalled", "True", "RetriesExceeded", syncRef.Add(-time.Hour)),
+			),
+			buildTestHelmRelease("bp-gitea",
+				hrCondition("Ready", "False", "DependencyNotReady", syncRef.Add(-time.Hour)),
+			),
+		)
+		fd := dyn.(*dynamicfake.FakeDynamicClient)
+		fd.PrependReactor("patch", "helmreleases", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if pa, ok := action.(ktesting.PatchAction); ok && pa.GetName() == "bp-keycloak" {
+				return true, nil, fmt.Errorf("injected patch failure")
+			}
+			return false, nil, nil
+		})
+		install(t, dyn)
+		// Must neither panic nor abort — the failed kick is logged (best-effort,
+		// matching the #4878 consumer rollout-restart idiom) and the scan
+		// continues to the remaining HRs.
+		h.forceReconcileStalledReplicaHelmReleases(context.Background(), dep, slot, syncRef)
+		if ann := annotationsOf(t, dyn, "bp-gitea"); ann[fluxReconcileRequestedAtAnnotation] == "" {
+			t.Errorf("kick failure on bp-keycloak stopped the scan — bp-gitea was never kicked (best-effort continue broke)")
+		}
+	})
+}
+
+// TestSyncSharedPGConsumerHubSecrets_KicksStalledHRsOnDeliveryPassOnly wires
+// the #5261 step through its real caller: the force-reconcile fires on the
+// pass that actually DELIVERS hub bytes to the replica (copy changed=true)
+// and NOT on a steady-state re-check pass (bytes already match) — the
+// #3241/#3583 no-thrash contract for the ~2-min level-trigger re-runs.
+func TestSyncSharedPGConsumerHubSecrets_KicksStalledHRsOnDeliveryPassOnly(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dep := &Deployment{ID: "dep-5261-sync"}
+	const kcPath = "kc-replica-5261-sync"
+
+	primaryCS := kfake.NewSimpleClientset()
+	replicaCS := kfake.NewSimpleClientset()
+	// Region-A's authoritative hub (topology-aware -mesh-rw host) — the
+	// replica has NO copy yet, so pass 1 is the delivery pass.
+	seedHubSecret(t, primaryCS, "keycloak-database-secret",
+		"shared-pg-mesh-rw.shared-data.svc.cluster.local", "region-A-pw")
+
+	// bp-keycloak stalled long before the delivery (the hw277 wedge).
+	stalledSince := time.Now().UTC().Add(-2 * time.Hour)
+	dyn := newFakeKustomizationDynClient(t, buildTestHelmRelease("bp-keycloak",
+		hrCondition("Ready", "False", "InstallFailed", stalledSince),
+		hrCondition("Stalled", "True", "RetriesExceeded", stalledSince),
+	))
+	restore := installClusterMeshDynamicClientFactory(map[string]dynamic.Interface{kcPath: dyn})
+	defer restore()
+
+	slots := []regionSlot{
+		{key: "", clientset: primaryCS},
+		{key: "secondary", clientset: replicaCS, kubeconfigPath: kcPath},
+	}
+
+	// Pass 1 — DELIVERY: the replica gains the hub Secret → the pre-delivery
+	// stalled HR must be force-reconciled in the same pass.
+	h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+	ann := getFluxSystemHelmRelease(t, dyn, "bp-keycloak").GetAnnotations()
+	if ann[fluxReconcileRequestedAtAnnotation] == "" || ann[fluxReconcileForceAtAnnotation] == "" {
+		t.Fatalf("delivery pass did not kick the pre-delivery stalled HR (annotations=%v) — the hw277 wedge would persist (#5261)", ann)
+	}
+
+	// Simulate helm-controller consuming the kick: wipe the annotations.
+	hr := getFluxSystemHelmRelease(t, dyn, "bp-keycloak")
+	unstructured.RemoveNestedField(hr.Object, "metadata", "annotations")
+	if _, err := dyn.Resource(helmReleaseGVR).Namespace(fluxSystemNamespace).
+		Update(context.Background(), hr, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("reset HR annotations: %v", err)
+	}
+
+	// Pass 2 — STEADY STATE: replica bytes already match → no delivery → no
+	// kick, even though the HR still reads as stalled-before-now. Without the
+	// delivery gate this would re-kick on every ~2-min pass (retry treadmill).
+	h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+	ann = getFluxSystemHelmRelease(t, dyn, "bp-keycloak").GetAnnotations()
+	if ann[fluxReconcileRequestedAtAnnotation] != "" || ann[fluxReconcileForceAtAnnotation] != "" {
+		t.Errorf("steady-state pass (no byte change) re-kicked the HR (annotations=%v) — the #5261 anti-thrash gate broke", ann)
+	}
 }
 
 // TestAutoEstablishClusterMesh_ConsumerHubSecretsSyncPreMesh locks in #5230:


### PR DESCRIPTION
## Problem (hw277, dep 1708c340ffc0e3f2)

On a 2-region Sovereign the replica-region SSO-tier HelmReleases fire at boot, ~107min before the post-Phase-1 mesh cascade delivers the consumer-hub Secrets (fire 13:26Z, keycloak-database-secret 15:13Z). bp-keycloak exhausts its install remediation retries in that window (Stalled=True, 'Failed to install after 2 attempt(s)'), and Flux never retries a Stalled HelmRelease on its own — so even after the pod self-heals against the delivered Secret, the release object stays Failed and its 7 dependsOn dependents (gitea/grafana/guacamole/newapi/oidc-gate/powerdns-admin/sso-bridge) sit at 'dependency not ready' indefinitely. Region-b wedged at 51/66.

## Fix — the cascade closes its own loop

`products/catalyst/bootstrap/api/internal/handler/clustermesh.go`:

- **`syncSharedPGConsumerHubSecrets`** now tracks, per replica, whether this pass actually DELIVERED changed hub bytes (`copySecretAcrossClusters` changed=true — the moment the missing input arrives), and captures `syncStartedAt` before any copy lands.
- **New `forceReconcileStalledReplicaHelmReleases`** (#5261): for each replica that received a delivery this pass, lists that region's `flux-system` HelmReleases and stamps BOTH `reconcile.fluxcd.io/requestedAt` AND `reconcile.fluxcd.io/forceAt` (matching tokens — the forceAt half is what makes helm-controller retry an EXHAUSTED install, same as `flux reconcile hr --force`) on every HR that is wedged (Ready=False and/or Stalled=True) with a lastTransitionTime PREDATING the sync.
- **Anti-thrash guards**: post-delivery failures and unprovable-age failures are left untouched (genuine defects must surface, not be masked by a force-retry treadmill), and steady-state passes (no byte change) never kick — the #3241/#3583 no-thrash contract holds. Kicked HRs transition immediately, so each strand is kicked at most once per delivery.
- **Best-effort** end to end, matching the #4878 consumer rollout-restart idiom and the #5254 'kick after the missing input arrives' heal paths: missing kubeconfig / client-build / List / per-HR Patch failures are logged with the #5261 ref and never fail the orchestrator.

## Tests

- `TestForceReconcileStalledReplicaHelmReleases`: pre-delivery stalled HR kicked with matching requestedAt+forceAt tokens; healthy HR untouched; HR failing AFTER the sync untouched; wedged HR with unprovable age untouched; per-HR kick error non-fatal + scan continues.
- `TestSyncSharedPGConsumerHubSecrets_KicksStalledHRsOnDeliveryPassOnly`: kick fires on the delivery pass through the real caller, and NOT on a steady-state re-check pass.
- `go build ./...` + `go test ./... -count=1` green across the whole bootstrap/api module (handler suite 158s).

Refs #5261 #5253 #5254

🤖 Generated with [Claude Code](https://claude.com/claude-code)