### PR TITLE
fix(#5237): pin-aware prewarm + step-06 version-presence gate — catalog drift cannot wedge cutover

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -951,7 +951,20 @@ spec:
       # The #5214 self-heal initContainer is removed from these two steps
       # (no longer gitea-admin-secret consumers). Companion bp-gitea 1.2.48
       # makes the admin password itself vanish-proof. Contract Case 67 added.
-      version: 0.1.146
+      # 0.1.147 (#5237 round 2, Refs #5007 #5265): PIN-AWARE PREWARM + step-06
+      # FULL pin-presence gate — the durable close of the catalog-latest-vs-
+      # flux-pinned drift class. New shared 03b extractor ConfigMap
+      # (cutover-bootstrap-kit-pins, zero-dep sh+awk, one parser for step-03 +
+      # step-06 + the #5265 Day-2 reconciler); step-03 Phase A2-pins unions the
+      # FROZEN local-Gitea-mirror bootstrap-kit pins (the commit flux consumes
+      # post-step-05) into the chart-mirror set (fail-loud on an unprovable pin
+      # set; knob prewarm.bootstrapKitPins.enabled); step-06 Phase 3a-pin
+      # asserts EVERY frozen pin durably present in local Harbor (in-cluster
+      # artifact API) before the irreversible auth strip, top-up-warming a
+      # missing one and FATALing with the full missing list otherwise (knob
+      # helmReadinessProbe.pinPresenceGate). Contract Case 68 runs the
+      # extractor against this very slot corpus at PR time.
+      version: 0.1.147
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.146
+  version: 0.1.147
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,48 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.147 (#5237 round 2, Refs #5007 #5265 — PIN-AWARE PREWARM + step-06 FULL
+# pin-presence gate: the durable close of the catalog-latest-vs-flux-pinned
+# drift class (hw274, dep d51a69f885872a81). The 0.1.145 union-warm (below) is
+# the mid-flight NET; this round removes the drift class at the ROOT: the
+# post-cutover pin ground truth is the bootstrap-kit slot files in the LOCAL
+# GITEA MIRROR (the commit step-01 mirrored = the commit flux consumes once
+# step-05 pivots the GitRepository), immune to anything a mid-cutover merge
+# publishes upstream.
+# (1) NEW shared ConfigMap cutover-bootstrap-kit-pins (03b) — a zero-dep
+#     POSIX sh+awk extractor `bootstrapkit_pins DIR UP_PREFIX LOCAL_PREFIX`
+#     emitting the (chart, version) pin set off clusters/_template/
+#     bootstrap-kit/[0-9]*.yaml; ONE parser sourced by step-03 AND step-06
+#     (and the documented reuse seam for the #5265 Day-2 mirror-resync
+#     reconciler), same single-source discipline as the 03a resolver. awk
+#     (not kubectl --dry-run=client: that resolves kinds via discovery and
+#     breaks when a slot CRD apiVersion stops being served; not yq: not in
+#     alpine/k8s, apk-add is a mid-cutover network dep — the G69 lesson).
+#     Contract Case 68 runs THIS extractor against the in-repo slot corpus,
+#     so slot-format drift fails CI at PR time, never on a Sovereign.
+# (2) Step-03 Phase A2-pins: fetch the slot files from the local Gitea
+#     (contents+raw API, catalyst-gitea-token PAT — the step-01/05 read
+#     path) and UNION the frozen pins into the Phase A2 chart-mirror set.
+#     The live deployed∪desired union (#5007 r3) tracks the CLUSTER, which a
+#     pin-bump merged between step-01's mirror and step-05's pivot rolls
+#     AWAY from the frozen pins (GitRepository still on GitHub) — prewarm
+#     then mirrors the transient tag while the version flux settles back to
+#     was never warmed → post-strip 404 under the deny-egress hold. The pin
+#     union closes that direction for good; PIN-ONLY entries are logged as
+#     the drift report. FAIL-LOUD: unreadable PAT / unlistable mirror /
+#     zero-pin parse exits 1 while egress is open. Knob
+#     prewarm.bootstrapKitPins.enabled (default true).
+# (3) Step-06 Phase 3a-pin (belt-and-braces): BEFORE the sampled pull-probe
+#     and the irreversible Phase-3b auth strip, assert EVERY frozen pin is
+#     durably present in local Harbor (artifact API on the in-cluster
+#     Service — the #5030 never-pull-through probe; ~65 GETs, seconds); a
+#     missing version is top-up-warmed via the 0.1.145 warm helper, and
+#     anything still missing FATALs with the FULL missing list, ghcr auth
+#     intact (recoverable) — a clear step-06 failure instead of wedged HRs.
+#     The sample-probe deadline re-arms after the gate. Knob
+#     helmReadinessProbe.pinPresenceGate (default true). New step-06 envs
+#     PIN_PRESENCE_GATE + HARBOR_INTERNAL_URL; step-03 gains the Gitea/PAT
+#     envs. No step-count / RBAC change (secrets get is already granted
+#     cluster-wide; still 11 steps).
 # 0.1.146 (#5262 Refs #5214 #3379 — steps 10/11 git-persist authenticates with
 # the step-09 minted PAT, never the gitea admin password. LIVE hw277 (dep
 # 1708c340ffc0e3f2, 2026-07-19): step-10 vcluster-registry-pivot failed
@@ -2490,7 +2533,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.146
+version: 0.1.147
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -271,6 +271,35 @@ data:
             value: {{ .Values.prewarm.xpkgPackages.digestMapConfigMapName | quote }}
           - name: RELEASE_NAMESPACE
             value: {{ .Release.Namespace | quote }}
+          # #5237 round 2 (Refs #5007) — Phase A2-pins: union the chart-mirror
+          # set with the EXACT versions the bootstrap-kit slot pins in the
+          # LOCAL GITEA MIRROR reference — the frozen commit flux consumes
+          # once step-05 pivots the GitRepository, immune to anything a
+          # mid-cutover merge publishes upstream. The slot files are fetched
+          # from the local Gitea (step-01 mirrored them) via the SAME
+          # catalyst-gitea-token PAT steps 01/05 read, and parsed by the
+          # shared cutover-bootstrap-kit-pins extractor (03b — one parser for
+          # step-03, step-06 and the #5265 Day-2 reconciler).
+          # NB: bare `| quote` (NOT `| default true`) — sprig `default`
+          # treats a literal false as empty and would flip an explicit
+          # disable back to true (sprig_default_bool_unsafe); the script's
+          # `: "${VAR:=true}"` restores the on-state for a nil render.
+          - name: PREWARM_BOOTSTRAP_KIT_PINS
+            value: {{ .Values.prewarm.bootstrapKitPins.enabled | quote }}
+          - name: GITEA_INTERNAL_URL
+            value: {{ .Values.sovereign.giteaInternalURL | quote }}
+          - name: GITEA_ORG
+            value: {{ .Values.gitea.org | quote }}
+          - name: GITEA_REPO
+            value: {{ .Values.gitea.repo | quote }}
+          - name: UPSTREAM_BRANCH
+            value: {{ .Values.upstream.branch | quote }}
+          - name: PAT_SOURCE_NAMESPACE
+            value: {{ .Values.gitRepositorySecretRef.patSourceNamespace | quote }}
+          - name: PAT_SOURCE_SECRET_NAME
+            value: {{ .Values.gitRepositorySecretRef.patSourceSecretName | quote }}
+          - name: PAT_SOURCE_KEY
+            value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -280,6 +309,9 @@ data:
             readOnly: true
           - name: offline-mirror-resolver
             mountPath: /resolver
+            readOnly: true
+          - name: bootstrap-kit-pins
+            mountPath: /pin-extractor
             readOnly: true
           - name: tmp
             mountPath: /tmp
@@ -1373,6 +1405,107 @@ data:
               esac
               printf '%s\t%s\n' "${c_chart}" "${c_ver}" >> "${chart_work}"
             done
+
+            # ── Phase A2-pins (#5237 round 2, Refs #5007): union the FROZEN
+            # bootstrap-kit pins from the LOCAL GITEA MIRROR into the chart-
+            # mirror set. The live deployed∪desired union above tracks the
+            # CLUSTER — which a mid-cutover catalog merge can roll AWAY from
+            # the pins flux settles back to post-step-05 (the GitRepository
+            # still tracks GitHub until then, so a pin-bump commit landing
+            # between step-01's mirror and step-05's pivot rolls the live HR
+            # to a version the FROZEN mirror never pins; prewarm mirrors the
+            # transient tag, the frozen pin is never warmed, and the first
+            # post-strip (re)pull 404s under the deny-egress hold — the hw274
+            # class, dep d51a69f885872a81). The bootstrap-kit slot files in
+            # the local Gitea mirror ARE the post-cutover pin ground truth,
+            # immune to anything published upstream after step-01 mirrored:
+            # enumerate them (shared extractor 03b — the SAME parser step-06's
+            # Phase 3a-pin gate and the #5265 Day-2 reconciler use) and union
+            # the result in. Strict superset — every entry is still copied
+            # idempotently (#4994 skip-if-present makes an already-mirrored
+            # pin a cheap API GET), and the Phase A2 chart_fail>0 FATAL below
+            # stays the fail-loud guard for a pinned tag that cannot be
+            # pulled. FAIL-LOUD on enumeration failure: an unreadable PAT /
+            # unreachable mirror / zero-pin parse exits 1 HERE (egress open,
+            # recoverable) rather than silently narrowing the mirror.
+            : "${PREWARM_BOOTSTRAP_KIT_PINS:=true}"
+            if [ "${PREWARM_BOOTSTRAP_KIT_PINS}" = "true" ]; then
+              echo "[harbor-prewarm] Phase A2-pins (#5237): enumerating bootstrap-kit chart pins from the local Gitea mirror (the frozen commit flux consumes post-step-05)"
+              # The catalyst-gitea-token PAT — same coordinates + bounded wait
+              # as steps 01/05 (BasicAuth would hang ~130s then 401 while
+              # Keycloak converges; a PAT is a direct local lookup). Never
+              # echoed; sent only via the Authorization header.
+              bk_pat=""
+              for i in $(seq 1 12); do
+                bk_pat=$(kubectl -n "${PAT_SOURCE_NAMESPACE}" get secret "${PAT_SOURCE_SECRET_NAME}" \
+                  -o "jsonpath={.data.${PAT_SOURCE_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+                [ -n "${bk_pat}" ] && break
+                echo "[harbor-prewarm] Phase A2-pins: PAT not yet populated in ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME} (attempt ${i}/12) — sleeping 5s"
+                sleep 5
+              done
+              if [ -z "${bk_pat}" ]; then
+                echo "[harbor-prewarm] FATAL: ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY} empty after 60s — cannot read the local Gitea mirror's bootstrap-kit pins, so the mirror set cannot be proven to cover the frozen flux pin set (#5237). Emergency override: prewarm.bootstrapKitPins.enabled=false."
+                exit 1
+              fi
+              bk_dir=/tmp/bootstrap-kit-pins
+              rm -rf "${bk_dir}"; mkdir -p "${bk_dir}"
+              bk_api="${GITEA_INTERNAL_URL%/}/api/v1/repos/${GITEA_ORG}/${GITEA_REPO}"
+              bk_path="clusters/_template/bootstrap-kit"
+              # Directory listing via the Gitea contents API, then each slot
+              # file raw — ~70 small text fetches against the in-cluster
+              # Gitea Service (step-01 already proved it reachable), far
+              # lighter than a full monorepo clone.
+              bk_list=$(curl -fsS --retry 3 --retry-delay 5 \
+                -H "Authorization: token ${bk_pat}" \
+                "${bk_api}/contents/${bk_path}?ref=${UPSTREAM_BRANCH}" 2>/dev/null \
+                | jq -r '.[] | select(.type=="file") | .name | select(test("^[0-9].*\\.ya?ml$"))' 2>/dev/null || true)
+              if [ -z "${bk_list}" ]; then
+                echo "[harbor-prewarm] FATAL: could not list ${bk_path} in the local Gitea mirror (${GITEA_ORG}/${GITEA_REPO}@${UPSTREAM_BRANCH}) — step-01 gitea-mirror must have completed before step-03; without the frozen pin set the mirror cannot be proven complete (#5237). Emergency override: prewarm.bootstrapKitPins.enabled=false."
+                exit 1
+              fi
+              bk_fetch_fail=0
+              for bk_f in ${bk_list}; do
+                if ! curl -fsS --retry 3 --retry-delay 5 \
+                    -H "Authorization: token ${bk_pat}" \
+                    -o "${bk_dir}/${bk_f}" \
+                    "${bk_api}/raw/${bk_path}/${bk_f}?ref=${UPSTREAM_BRANCH}" 2>/dev/null; then
+                  echo "[harbor-prewarm] Phase A2-pins: fetch FAILED for ${bk_path}/${bk_f}"
+                  bk_fetch_fail=$((bk_fetch_fail+1))
+                fi
+              done
+              if [ "${bk_fetch_fail}" -gt 0 ]; then
+                echo "[harbor-prewarm] FATAL: ${bk_fetch_fail} bootstrap-kit slot file(s) failed to fetch from the local Gitea mirror (named above) — a partial pin set could silently miss the exact version a mid-cutover merge makes load-bearing (#5237). Emergency override: prewarm.bootstrapKitPins.enabled=false."
+                exit 1
+              fi
+              # Shared extractor (03b): one parser for step-03 + step-06 +
+              # the #5265 Day-2 reconciler. Accepts BOTH the upstream and the
+              # already-pivoted local prefix so a post-step-06 re-run (mirror
+              # already rewritten to local Harbor) still enumerates.
+              . /pin-extractor/extract-pins.sh
+              bk_pins=/tmp/.bootstrap-kit-pins.tsv
+              bootstrapkit_pins "${bk_dir}" "${UPSTREAM_PREFIX}" "oci://${HARBOR_HOST}/openova-io" > "${bk_pins}"
+              bk_count=$(grep -c . "${bk_pins}" || true)
+              if [ "${bk_count}" -eq 0 ]; then
+                echo "[harbor-prewarm] FATAL: zero pinned openova-io charts parsed from ${bk_path} ($(printf '%s\n' ${bk_list} | grep -c .) slot files fetched) — the bootstrap-kit ALWAYS pins its charts, so an empty parse means the mirror or the slot format drifted; refusing to build a mirror that cannot be proven to cover the frozen flux pin set (#5237). Emergency override: prewarm.bootstrapKitPins.enabled=false."
+                exit 1
+              fi
+              # Drift visibility: pins NOT already in the live union are
+              # exactly the entries a mid-cutover roll would have lost.
+              sort -u "${chart_work}" -o "${chart_work}"
+              bk_pin_only=0
+              while IFS="$(printf '\t')" read -r bk_c bk_v; do
+                [ -z "${bk_c}" ] && continue
+                if ! grep -Fxq "$(printf '%s\t%s' "${bk_c}" "${bk_v}")" "${chart_work}"; then
+                  echo "[harbor-prewarm] Phase A2-pins PIN-ONLY (#5237): ${bk_c}:${bk_v} pinned by the frozen bootstrap-kit but absent from the live deployed∪desired union — the live cluster drifted; warming the pin so post-pivot flux converges"
+                  bk_pin_only=$((bk_pin_only+1))
+                fi
+                printf '%s\t%s\n' "${bk_c}" "${bk_v}" >> "${chart_work}"
+              done < "${bk_pins}"
+              echo "[harbor-prewarm] Phase A2-pins: ${bk_count} frozen bootstrap-kit pin(s) unioned into the mirror set (${bk_pin_only} pin-only, i.e. not covered by the live union)"
+            else
+              echo "[harbor-prewarm] Phase A2-pins DISABLED (prewarm.bootstrapKitPins.enabled=false) — mirroring the live deployed∪desired union only; the frozen flux pin set is NOT guaranteed locally (#5237)"
+            fi
+
             sort -u "${chart_work}" -o "${chart_work}"
             chart_count=$(grep -c . "${chart_work}" || true)
             echo "[harbor-prewarm] Phase A2: ${chart_count} unique openova-io chart(s) to mirror"
@@ -1870,5 +2003,11 @@ data:
           items:
             - key: resolver.sh
               path: resolver.sh
+      - name: bootstrap-kit-pins
+        configMap:
+          name: cutover-bootstrap-kit-pins
+          items:
+            - key: extract-pins.sh
+              path: extract-pins.sh
       - name: tmp
         emptyDir: {}

--- a/platform/self-sovereign-cutover/chart/templates/03b-bootstrap-kit-pins.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03b-bootstrap-kit-pins.yaml
@@ -1,0 +1,137 @@
+{{- /*
+#5237 (Refs #5007 #3379) — the BOOTSTRAP-KIT PIN EXTRACTOR.
+
+This ConfigMap carries ONE shell library, sourced by BOTH step-03
+(harbor-prewarm Phase A2-pins: mirror EXACTLY the chart versions the frozen
+local-Gitea bootstrap-kit pins reference) AND step-06 (helmrepository-patches
+Phase 3a-pin: assert every pinned chart version is present in local Harbor
+BEFORE the mothership-auth strip). Two consumers, ONE parser — the same
+single-source discipline as the #4975 offline-mirror resolver next door
+(03a): neither consumer forks the logic, so the mirror set and the gate can
+never disagree about what "the pins" are.
+
+WHY the pins, not the live cluster: the live HelmRelease deployed∪desired
+union (step-03 Phase A2, #5007 round 3) tracks the CLUSTER's current state —
+which a mid-cutover catalog merge can roll AWAY from the pins the Sovereign
+settles back to once step-05 freezes Flux onto the local Gitea mirror commit.
+The bootstrap-kit slot files in that MIRROR are the ground truth of what flux
+will pin post-cutover, immune to anything published upstream after step-01
+mirrored. Enumerating them kills the catalog-latest-vs-flux-pinned drift
+class at the root (hw274, dep d51a69f885872a81).
+
+WHY awk, not kubectl/yq: a `kubectl create --dry-run=client` parse resolves
+each doc's kind through discovery, so it breaks the moment a slot file's CRD
+apiVersion (e.g. source.toolkit.fluxcd.io/v1beta2) stops being served — a
+flux-lifecycle coupling this enumeration must not have. yq is not in the
+alpine/k8s image and an `apk add` mid-cutover is a network dependency (the
+G69 skopeo lesson). Plain awk over the repo-controlled slot corpus has ZERO
+runtime deps, and tests/cutover-contract.sh runs THIS exact library against
+clusters/_template/bootstrap-kit at PR time — any slot-format drift fails CI
+before it can ever reach a Sovereign.
+
+REUSE CONTRACT (#5265 Day-2 leg): the same drift class re-opens POST-cutover
+when the local Gitea mirror re-syncs upstream pin bumps whose chart versions
+local Harbor lacks. A Day-2 reconciler closes that by calling THIS function
+over the freshly-synced mirror commit and warming any missing version — the
+callable seam is deliberately runtime-agnostic:
+
+    . /pin-extractor/extract-pins.sh
+    bootstrapkit_pins <slot-dir> <upstream-oci-prefix> <local-oci-prefix>
+      stdout : "<chart>\t<version>" per pinned openova-io-sourced HelmRelease
+      stderr : WARN/skip diagnostics (never mixed into stdout)
+      exit   : always 0 — the CALLER owns the fail-loud policy (count check)
+
+NOT a cutover-step ConfigMap: no bp.openova.io/cutover-order label, so it
+does not count toward the 11-step contract (tests/cutover-contract.sh Case
+2/4).
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-bootstrap-kit-pins
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-bootstrap-kit-pins
+data:
+  extract-pins.sh: |
+    # POSIX sh + awk. No runtime deps. Pure function — no side effects.
+    #
+    # bootstrapkit_pins DIR UPSTREAM_PREFIX LOCAL_PREFIX
+    #   Emits one "<chart>\t<version>" line (sorted, deduped) per HelmRelease
+    #   in DIR/[0-9]*.yaml whose chart.spec pins a CONCRETE version AND whose
+    #   sourceRef names a HelmRepository (declared anywhere in DIR) whose url
+    #   starts with UPSTREAM_PREFIX (pre-pivot: oci://ghcr.io/openova-io) or
+    #   LOCAL_PREFIX (a post-step-06 re-run reads the already-pivoted mirror:
+    #   oci://registry.<fqdn>/openova-io). Non-openova sources (e.g. the loft
+    #   charts.loft.sh HelmRepository, slot 60) and semver-range pins are
+    #   skipped with a stderr WARN. Exit 0 always — the caller owns the
+    #   fail-loud policy via a count check on stdout.
+    bootstrapkit_pins() {
+      _bk_dir="$1"; _bk_up="$2"; _bk_lp="${3:-}"
+      [ -d "${_bk_dir}" ] || { echo "[bootstrapkit-pins] WARN: ${_bk_dir} is not a directory" >&2; return 0; }
+      # Slot files are the numbered bootstrap-kit entries; kustomization.yaml
+      # + placement.yaml are not slot manifests.
+      _bk_files=$(ls "${_bk_dir}"/[0-9]*.yaml 2>/dev/null || true)
+      [ -n "${_bk_files}" ] || { echo "[bootstrapkit-pins] WARN: no [0-9]*.yaml slot files in ${_bk_dir}" >&2; return 0; }
+
+      # Pass A — the openova-io pivot set: HelmRepository metadata.name for
+      # every repo whose spec.url starts with the upstream OR the already-
+      # pivoted local prefix. Slot docs order apiVersion/kind/metadata/spec
+      # with metadata.name at 2-space and spec.url at 2-space; secretRef.name
+      # sits at 4-space, so the exact-indent anchors cannot cross-match.
+      _bk_pivot=$(awk -v up="${_bk_up}" -v lp="${_bk_lp}" '
+        FNR==1 { kind=""; rname="" }
+        /^---/ { kind=""; rname=""; next }
+        /^[[:space:]]*#/ { next }
+        /^kind:[[:space:]]*/ { kind=$2; rname=""; next }
+        kind=="HelmRepository" && rname=="" && /^  name:[[:space:]]*[^[:space:]]/ { rname=$2; next }
+        kind=="HelmRepository" && rname!="" && /^  url:[[:space:]]*[^[:space:]]/ {
+          url=$2; gsub(/"/,"",url)
+          if (index(url, up)==1 || (lp!="" && index(url, lp)==1)) print rname
+          else printf "[bootstrapkit-pins] skip repo %s (non-openova url %s)\n", rname, url > "/dev/stderr"
+          kind=""; rname=""
+        }
+      ' ${_bk_files} | sort -u)
+
+      # Pass B — (chart, version, sourceRef.name) off every HelmRelease
+      # chart.spec: the 6-space `chart:` scalar, the FIRST following 6-space
+      # `version:`, and the 8-space `name:` under the 6-space `sourceRef:`.
+      # Comments are stripped first, so the multi-hundred-line version-history
+      # comment blocks between `chart:` and `version:` (slot 13 carries >1000)
+      # never confuse the pairing; the c!=""/v=="" guards keep any 6-space
+      # key inside a spec.values block from being mis-captured.
+      awk '
+        FNR==1 { kind=""; c=""; v=""; insrc=0 }
+        /^---/ { kind=""; c=""; v=""; insrc=0; next }
+        /^[[:space:]]*#/ { next }
+        /^kind:[[:space:]]*/ { kind=$2; c=""; v=""; insrc=0; next }
+        kind=="HelmRelease" && /^      chart:[[:space:]]*[^[:space:]]/ { c=$2; gsub(/"/,"",c); v=""; insrc=0; next }
+        kind=="HelmRelease" && c!="" && v=="" && /^      version:[[:space:]]*[^[:space:]]/ { v=$2; gsub(/"/,"",v); next }
+        kind=="HelmRelease" && c!="" && /^      sourceRef:[[:space:]]*$/ { insrc=1; next }
+        insrc==1 && /^        name:[[:space:]]*[^[:space:]]/ {
+          s=$2; gsub(/"/,"",s)
+          printf "%s\t%s\t%s\n", c, v, s
+          insrc=0; c=""; v=""
+        }
+      ' ${_bk_files} | sort -u | while IFS="$(printf '\t')" read -r _bk_c _bk_v _bk_s; do
+        [ -z "${_bk_c}" ] && continue
+        if ! printf '%s\n' "${_bk_pivot}" | grep -Fxq "${_bk_s}"; then
+          echo "[bootstrapkit-pins] skip ${_bk_c} (sourceRef ${_bk_s} not an openova-io HelmRepository)" >&2
+          continue
+        fi
+        if [ -z "${_bk_v}" ]; then
+          echo "[bootstrapkit-pins] WARN: ${_bk_c} (source ${_bk_s}) has no pinned version — skipping (cannot mirror a floating tag deterministically)" >&2
+          continue
+        fi
+        # Same range guard as step-03 Phase A2 (#5007 round 3): a semver
+        # range is not a concrete OCI tag.
+        case "${_bk_v}" in
+          *[\<\>~^\|\ ]*|*'*'*)
+            echo "[bootstrapkit-pins] WARN: ${_bk_c} version '${_bk_v}' is a semver range — skipping (cannot mirror deterministically)" >&2
+            continue ;;
+        esac
+        printf '%s\t%s\n' "${_bk_c}" "${_bk_v}"
+      done | sort -u
+      return 0
+    }

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -197,6 +197,23 @@ data:
           # "" and the script's `: "${UNION_WARM_ON_DRIFT:=true}"` restores true.
           - name: UNION_WARM_ON_DRIFT
             value: {{ .Values.helmReadinessProbe.unionWarmOnDrift | quote }}
+          # #5237 round 2 (Refs #5007): Phase 3a-pin — before the sampled
+          # pull-probe (and the irreversible Phase-3b strip), assert EVERY
+          # bootstrap-kit-pinned chart version from the Phase-2 clone of the
+          # local Gitea mirror (the frozen commit flux consumes post-pivot)
+          # is durably present in local Harbor; top-up-warm a missing one
+          # from the still-reachable upstream, and FATAL with the full
+          # missing list otherwise (auth intact — recoverable). Same bare
+          # `| quote` sprig-bool discipline as UNION_WARM_ON_DRIFT above.
+          - name: PIN_PRESENCE_GATE
+            value: {{ .Values.helmReadinessProbe.pinPresenceGate | quote }}
+          # #5237 round 2 — the in-cluster Harbor Service URL for the
+          # Phase 3a-pin durable-presence probe (artifact API served by
+          # Harbor CORE against its DB — never pull-through, the #5030
+          # discipline; the SAME endpoint step-03's dest_already_current
+          # dials).
+          - name: HARBOR_INTERNAL_URL
+            value: {{ .Values.sovereign.harborInternalURL | quote }}
           # #4557 (Refs #3379): TLS-verify on the Phase-3a helm-CLI probe
           # DESTINATION (the in-cluster Harbor `registry.<sov-fqdn>` =
           # harbor_host). DEFAULT false — the in-cluster Harbor serves an
@@ -229,6 +246,9 @@ data:
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
+            readOnly: true
+          - name: bootstrap-kit-pins
+            mountPath: /pin-extractor
             readOnly: true
           - name: tmp
             mountPath: /tmp
@@ -1351,6 +1371,92 @@ data:
               return 1
             }
 
+            # ---- Phase 3a-pin (#5237 round 2, Refs #5007): FULL pin-presence gate ----
+            #
+            # The Phase-3a loop below proves a SAMPLE of pivoted charts pulls.
+            # This gate proves the WHOLE frozen pin set exists: every chart
+            # version the bootstrap-kit slots pin in the Phase-2 clone at
+            # /tmp/repo — the EXACT local-Gitea-mirror commit flux consumes
+            # post-step-05, immune to anything a mid-cutover merge published
+            # upstream — must be durably present in local Harbor BEFORE the
+            # irreversible Phase-3b mothership-auth strip. Enumeration is the
+            # shared cutover-bootstrap-kit-pins extractor (03b) — the SAME
+            # parser step-03 Phase A2-pins mirrors from (and the #5265 Day-2
+            # reconciler reuses), so the mirror and this gate can never
+            # disagree about what "the pins" are. Presence is the Harbor
+            # ARTIFACT API on the in-cluster Service (Harbor CORE against its
+            # DB — never pull-through, the #5030 discipline): ~65 cheap GETs,
+            # seconds. A missing version is first top-up-warmed from the
+            # still-reachable upstream (warm_chart_from_upstream above —
+            # egress is open until step-08); anything STILL missing FATALs
+            # with the FULL missing list and the ghcr.io auth intact — a
+            # clear, recoverable step-06 failure (re-run; a step-03 re-run
+            # with Phase A2-pins also heals) instead of HelmReleases wedging
+            # on `does not have an artifact` after the strip (the hw274
+            # class, dep d51a69f885872a81).
+            : "${PIN_PRESENCE_GATE:=true}"
+            if [ "${PIN_PRESENCE_GATE}" = "true" ]; then
+              pin_src_dir=/tmp/repo/clusters/_template/bootstrap-kit
+              if [ ! -d "${pin_src_dir}" ]; then
+                echo "[helmrepository-patches] FATAL: ${pin_src_dir} absent — the Phase-2 clone of the local Gitea mirror did not materialise the bootstrap-kit tree, so the frozen pin set cannot be asserted before the strip (#5237). Emergency override: helmReadinessProbe.pinPresenceGate=false." >&2
+                exit 1
+              fi
+              . /pin-extractor/extract-pins.sh
+              pin_file=/tmp/.bootstrap-kit-pins.tsv
+              bootstrapkit_pins "${pin_src_dir}" "${UPSTREAM_PREFIX}" "${local_prefix}" > "${pin_file}"
+              pin_total=$(grep -c . "${pin_file}" || true)
+              if [ "${pin_total}" -eq 0 ]; then
+                echo "[helmrepository-patches] FATAL: zero pinned openova-io charts parsed from ${pin_src_dir} — the bootstrap-kit ALWAYS pins its charts, so an empty parse means the mirror or the slot format drifted; refusing to strip mothership auth on an unprovable pin set (#5237). Emergency override: helmReadinessProbe.pinPresenceGate=false." >&2
+                exit 1
+              fi
+              echo "[helmrepository-patches] Phase 3a-pin (#5237): asserting all ${pin_total} frozen bootstrap-kit pin(s) are durably present in local Harbor (artifact API, in-cluster) before the strip"
+              # Durable-presence probe: 200 from the artifact API = the chart
+              # OCI artifact is in Harbor's own store. Chart repos are single-
+              # segment under openova-io, so no %2F encoding is needed.
+              pin_present() {
+                _pp_code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
+                  -u "${HARBOR_USERNAME:-admin}:${HARBOR_PASSWORD}" \
+                  "${HARBOR_INTERNAL_URL}/api/v2.0/projects/openova-io/repositories/$1/artifacts/$2" 2>/dev/null)
+                [ "${_pp_code}" = "200" ]
+              }
+              pin_missing=""
+              pin_ok=0
+              pin_warmed=0
+              while IFS="$(printf '\t')" read -r pg_chart pg_ver; do
+                [ -z "${pg_chart}" ] && continue
+                if pin_present "${pg_chart}" "${pg_ver}"; then
+                  pin_ok=$((pin_ok+1))
+                  continue
+                fi
+                echo "[helmrepository-patches] Phase 3a-pin: ${pg_chart}:${pg_ver} pinned by the frozen bootstrap-kit but ABSENT from local Harbor — top-up-warming from the still-reachable upstream (#5237)"
+                warm_chart_from_upstream "${pg_chart}" "${pg_ver}" || true
+                # Bounded re-probe: a direct helm push records via the
+                # registry hook near-synchronously; allow a short settle.
+                pg_found=0
+                for pg_i in $(seq 1 6); do
+                  if pin_present "${pg_chart}" "${pg_ver}"; then pg_found=1; break; fi
+                  sleep 5
+                done
+                if [ "${pg_found}" -eq 1 ]; then
+                  pin_ok=$((pin_ok+1))
+                  pin_warmed=$((pin_warmed+1))
+                else
+                  pin_missing="${pin_missing}${pg_chart}:${pg_ver} "
+                fi
+              done < "${pin_file}"
+              if [ -n "${pin_missing}" ]; then
+                echo "[helmrepository-patches] FATAL: $(printf '%s' "${pin_missing}" | wc -w | tr -d ' ') bootstrap-kit-pinned chart version(s) are NOT in local Harbor and could not be top-up-warmed from the upstream: ${pin_missing}— REFUSING to strip mothership auth (the post-pivot flux pin set would 404 under the deny-egress hold). ghcr.io auth is intact; this step is recoverable on re-run, and a step-03 re-run (Phase A2-pins) also heals the mirror (#5237)." >&2
+                exit 1
+              fi
+              echo "[helmrepository-patches] Phase 3a-pin OK: all ${pin_total} frozen bootstrap-kit pin(s) durably present in local Harbor (${pin_warmed} top-up-warmed) — proceeding to the sampled pull-probe"
+            else
+              echo "[helmrepository-patches] Phase 3a-pin DISABLED (helmReadinessProbe.pinPresenceGate=false) — the strip is gated on the sampled pull-probe only; the full frozen pin set is NOT asserted (#5237)"
+            fi
+
+            # Re-arm the sample-probe deadline so a warm-heavy Phase 3a-pin
+            # pass cannot eat the pull-probe's stripReadinessSeconds budget.
+            strip_wait_deadline=$(( $(date +%s) + STRIP_READINESS_TIMEOUT_SECONDS ))
+
             while [ "$(date +%s)" -lt "${strip_wait_deadline}" ]; do
               if [ "${sample_total}" -eq 0 ]; then
                 # No pivoted-chart HelmRelease found yet — Phase-1's URL pivot
@@ -1523,6 +1629,12 @@ data:
           items:
             - key: helmrepository-names.txt
               path: helmrepository-names.txt
+      - name: bootstrap-kit-pins
+        configMap:
+          name: cutover-bootstrap-kit-pins
+          items:
+            - key: extract-pins.sh
+              path: extract-pins.sh
       - name: tmp
         emptyDir: {}
 # re-publish 0.1.145 (Blueprint Release for #5238 failed transiently — #5237 union-warm fix)

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3236,4 +3236,151 @@ done
 if [ "$c67_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5262: steps 10/11 clone/push with the step-09 minted catalyst-gitea-token PAT — runtime read, fail-loud on empty, PAT-embedded remote URL, zero GITEA_PASSWORD residue)"
 
+# ── Case 68 (#5237 round 2, Refs #5007 #5265): PIN-AWARE PREWARM + step-06 pin gate ──
+# The durable close of the catalog-latest-vs-flux-pinned drift class (hw274):
+# the post-cutover pin ground truth is the bootstrap-kit slot set in the LOCAL
+# GITEA MIRROR (the commit flux consumes post-step-05). Step-03 Phase A2-pins
+# unions those FROZEN pins into the chart-mirror set; step-06 Phase 3a-pin
+# asserts EVERY frozen pin durably present in local Harbor before the
+# irreversible Phase-3b auth strip. Both consume the ONE shared extractor
+# (cutover-bootstrap-kit-pins, 03b) — and THIS case runs that exact extractor
+# against the in-repo slot corpus, so slot-format drift fails CI at PR time
+# instead of silently narrowing a Sovereign's mirror.
+echo "[cutover-contract] Case 68: pin-aware prewarm (step-03 Phase A2-pins) + step-06 full pin-presence gate share the 03b extractor; the extractor parses the live slot corpus (#5237 round 2)"
+c68_fail=0
+helm template smoke . --show-only templates/03-harbor-prewarm-job.yaml > "$TMP/r03_5237.yaml"
+helm template smoke . --show-only templates/06-helmrepository-patches-job.yaml > "$TMP/r06_5237.yaml"
+helm template smoke . --show-only templates/03b-bootstrap-kit-pins.yaml > "$TMP/r03b_5237.yaml"
+
+# (a) the shared extractor ConfigMap renders, carries the library, and is NOT
+#     a cutover step (no order label — the 11-step contract must not grow).
+if ! grep -q 'name: cutover-bootstrap-kit-pins' "$TMP/r03b_5237.yaml"; then
+  echo "FAIL: cutover-bootstrap-kit-pins ConfigMap does not render — no shared pin extractor for step-03/step-06/#5265 (#5237)" >&2; c68_fail=1
+fi
+if ! grep -q 'bootstrapkit_pins()' "$TMP/r03b_5237.yaml"; then
+  echo "FAIL: the 03b ConfigMap lost the bootstrapkit_pins() library function (#5237)" >&2; c68_fail=1
+fi
+if grep -q 'bp.openova.io/cutover-order' "$TMP/r03b_5237.yaml"; then
+  echo "FAIL: cutover-bootstrap-kit-pins must NOT carry bp.openova.io/cutover-order — it is a shared library, not a 12th step (#5237)" >&2; c68_fail=1
+fi
+
+# (b) BOTH consumers mount the SAME ConfigMap (single-source discipline —
+#     neither step may fork its own parser).
+for rf in "$TMP/r03_5237.yaml" "$TMP/r06_5237.yaml"; do
+  if ! grep -q 'name: cutover-bootstrap-kit-pins' "$rf"; then
+    echo "FAIL: $(basename "$rf") does not mount the cutover-bootstrap-kit-pins ConfigMap — the pin set would fork between mirror and gate (#5237)" >&2; c68_fail=1
+  fi
+  if ! grep -qF '. /pin-extractor/extract-pins.sh' "$rf"; then
+    echo "FAIL: $(basename "$rf") never sources /pin-extractor/extract-pins.sh — the shared extractor is mounted but unused (#5237)" >&2; c68_fail=1
+  fi
+done
+
+# (c) step-03 Phase A2-pins: defaults ON, fetches the FROZEN slot files from
+#     the LOCAL Gitea mirror (contents + raw API with the PAT read path steps
+#     01/05 use), unions the pins into the chart-mirror work list, and is
+#     FAIL-LOUD on an unprovable pin set.
+if ! grep -A1 'name: PREWARM_BOOTSTRAP_KIT_PINS' "$TMP/r03_5237.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: step-03 PREWARM_BOOTSTRAP_KIT_PINS does not default to \"true\" (prewarm.bootstrapKitPins.enabled) — the frozen pin union is off by default (#5237)" >&2; c68_fail=1
+fi
+if ! grep -qF '/contents/${bk_path}?ref=${UPSTREAM_BRANCH}' "$TMP/r03_5237.yaml"; then
+  echo "FAIL: step-03 never lists clusters/_template/bootstrap-kit via the local Gitea contents API — the pins are not read from the FROZEN mirror commit (#5237)" >&2; c68_fail=1
+fi
+if ! grep -qF '/raw/${bk_path}/${bk_f}?ref=${UPSTREAM_BRANCH}' "$TMP/r03_5237.yaml"; then
+  echo "FAIL: step-03 never fetches the slot files raw from the local Gitea mirror (#5237)" >&2; c68_fail=1
+fi
+if ! grep -qF 'bootstrapkit_pins "${bk_dir}" "${UPSTREAM_PREFIX}" "oci://${HARBOR_HOST}/openova-io"' "$TMP/r03_5237.yaml"; then
+  echo "FAIL: step-03 never calls bootstrapkit_pins over the fetched slot files (accepting both the upstream and the already-pivoted local prefix) (#5237)" >&2; c68_fail=1
+fi
+if ! grep -qF '>> "${chart_work}"' "$TMP/r03_5237.yaml" || ! grep -q 'Phase A2-pins' "$TMP/r03_5237.yaml"; then
+  echo "FAIL: step-03 Phase A2-pins never unions the frozen pins into the chart-mirror work list (#5237)" >&2; c68_fail=1
+fi
+if ! grep -q 'PIN-ONLY' "$TMP/r03_5237.yaml"; then
+  echo "FAIL: step-03 lost the PIN-ONLY drift report — a mid-cutover roll away from the frozen pins would be invisible in the step log (#5237)" >&2; c68_fail=1
+fi
+c68_fatal_ok=1
+grep -q 'FATAL: zero pinned openova-io charts parsed' "$TMP/r03_5237.yaml" || c68_fatal_ok=0
+grep -q 'bootstrap-kit slot file(s) failed to fetch' "$TMP/r03_5237.yaml" || c68_fatal_ok=0
+grep -q 'could not list ${bk_path}' "$TMP/r03_5237.yaml" || c68_fatal_ok=0
+if [ "$c68_fatal_ok" -ne 1 ]; then
+  echo "FAIL: step-03 Phase A2-pins lost one of its FAIL-LOUD exits (PAT/list/fetch/zero-pins) — an enumeration failure would silently narrow the mirror (#5237)" >&2; c68_fail=1
+fi
+helm template smoke-nopins . --show-only templates/03-harbor-prewarm-job.yaml --set prewarm.bootstrapKitPins.enabled=false > "$TMP/r03_5237_off.yaml"
+if ! grep -A1 'name: PREWARM_BOOTSTRAP_KIT_PINS' "$TMP/r03_5237_off.yaml" | grep -q 'value: "false"'; then
+  echo "FAIL: prewarm.bootstrapKitPins.enabled=false did not render PREWARM_BOOTSTRAP_KIT_PINS=\"false\" — the emergency override is not wired (#5237)" >&2; c68_fail=1
+fi
+
+# (d) step-06 Phase 3a-pin: defaults ON, reads the FROZEN Phase-2 clone,
+#     probes EVERY pin via the in-cluster Harbor artifact API (the #5030
+#     never-pull-through probe), top-up-warms a missing pin via the #5237
+#     union-warm helper, FATALs with the full missing list BEFORE the strip,
+#     and re-arms the sample-probe deadline.
+if ! grep -A1 'name: PIN_PRESENCE_GATE' "$TMP/r06_5237.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: step-06 PIN_PRESENCE_GATE does not default to \"true\" (helmReadinessProbe.pinPresenceGate) (#5237)" >&2; c68_fail=1
+fi
+if ! grep -qF 'pin_src_dir=/tmp/repo/clusters/_template/bootstrap-kit' "$TMP/r06_5237.yaml"; then
+  echo "FAIL: step-06's pin gate does not read the Phase-2 clone of the local Gitea mirror — any other source is not the frozen commit flux consumes (#5237)" >&2; c68_fail=1
+fi
+if ! grep -qF '/api/v2.0/projects/openova-io/repositories/$1/artifacts/$2' "$TMP/r06_5237.yaml"; then
+  echo "FAIL: step-06's pin gate does not probe durable presence via the Harbor artifact API — a pull-through probe would false-pass a cold artifact (#5030 discipline) (#5237)" >&2; c68_fail=1
+fi
+if ! grep -A1 'name: HARBOR_INTERNAL_URL' "$TMP/r06_5237.yaml" | grep -q 'value:'; then
+  echo "FAIL: step-06 lost the HARBOR_INTERNAL_URL env — the artifact-API probe has no in-cluster endpoint (#5237)" >&2; c68_fail=1
+fi
+if ! grep -qF 'warm_chart_from_upstream "${pg_chart}" "${pg_ver}"' "$TMP/r06_5237.yaml"; then
+  echo "FAIL: step-06's pin gate never top-up-warms a missing pin via warm_chart_from_upstream — a frozen pin absent locally has no self-heal before the FATAL (#5237)" >&2; c68_fail=1
+fi
+if ! grep -q 'REFUSING to strip mothership auth (the post-pivot flux pin set' "$TMP/r06_5237.yaml"; then
+  echo "FAIL: step-06's pin gate lost its FATAL-with-missing-list REFUSE path — a missing frozen pin must park the step recoverably, never proceed to the strip (#5237)" >&2; c68_fail=1
+fi
+if ! grep -q 'Re-arm the sample-probe deadline' "$TMP/r06_5237.yaml"; then
+  echo "FAIL: step-06 no longer re-arms strip_wait_deadline after the pin gate — a warm-heavy gate pass would eat the sampled pull-probe's budget (#5237)" >&2; c68_fail=1
+fi
+helm template smoke-nopingate . --show-only templates/06-helmrepository-patches-job.yaml --set helmReadinessProbe.pinPresenceGate=false > "$TMP/r06_5237_off.yaml"
+if ! grep -A1 'name: PIN_PRESENCE_GATE' "$TMP/r06_5237_off.yaml" | grep -q 'value: "false"'; then
+  echo "FAIL: helmReadinessProbe.pinPresenceGate=false did not render PIN_PRESENCE_GATE=\"false\" — the emergency override is not wired (#5237)" >&2; c68_fail=1
+fi
+
+# (e) THE PARSER-VS-CORPUS LOCK: extract the rendered extractor and run it
+#     against this repo's actual clusters/_template/bootstrap-kit. The
+#     extractor and the corpus live in the same repo — a slot-format change
+#     that the awk cannot parse fails HERE, at PR time, never on a Sovereign.
+#     Skipped (with a loud note) only when the chart is tested outside the
+#     monorepo (no corpus dir) — blueprint-release CI runs from the monorepo.
+# (the suite already `cd "$CHART_DIR"`-ed at the top, so the monorepo root is ../../..)
+CORPUS_DIR="$(cd ../../.. && pwd)/clusters/_template/bootstrap-kit"
+if [ -d "$CORPUS_DIR" ]; then
+  awk '/^  extract-pins.sh: \|/{f=1;next} f && !/^    / && !/^$/{exit} f{sub(/^    /,"");print}' \
+    "$TMP/r03b_5237.yaml" > "$TMP/extract-pins.sh"
+  if ! sh -n "$TMP/extract-pins.sh"; then
+    echo "FAIL: the rendered extract-pins.sh does not parse as POSIX sh (#5237)" >&2; c68_fail=1
+  fi
+  UP="oci://ghcr.io/openova-io"
+  sh -c ". '$TMP/extract-pins.sh'; bootstrapkit_pins '$CORPUS_DIR' '$UP' ''" \
+    > "$TMP/corpus-pins.tsv" 2> "$TMP/corpus-pins.warn"
+  pins_n=$(grep -c . "$TMP/corpus-pins.tsv" || true)
+  if [ "$pins_n" -lt 40 ]; then
+    echo "FAIL: the extractor parsed only ${pins_n} pins from the live slot corpus (expected the full bootstrap-kit set, ≥40) — the slot format drifted from the awk anchors; fix the extractor in 03b BEFORE this merges, or every future cutover under-mirrors (#5237)" >&2
+    sed 's/^/    /' "$TMP/corpus-pins.warn" >&2 || true
+    c68_fail=1
+  fi
+  # Cross-parser check: the keystone umbrella pin must round-trip exactly.
+  kp_ver=$(grep -E '^      version: [0-9]' "$CORPUS_DIR/13-bp-catalyst-platform.yaml" | awk '{print $2}' | head -1)
+  if [ -n "$kp_ver" ] && ! grep -qF "$(printf 'bp-catalyst-platform\t%s' "$kp_ver")" "$TMP/corpus-pins.tsv"; then
+    echo "FAIL: the extractor did not recover bp-catalyst-platform:${kp_ver} from slot 13 — the chart/version pairing broke (#5237)" >&2; c68_fail=1
+  fi
+  # Purity: every emitted line is exactly "<chart>\t<concrete-version>".
+  if grep -vE "^[A-Za-z0-9._-]+$(printf '\t')[0-9][A-Za-z0-9._+-]*$" "$TMP/corpus-pins.tsv" | grep -q .; then
+    echo "FAIL: the extractor emitted a malformed pin line (must be chart<TAB>concrete-version):" >&2
+    grep -vE "^[A-Za-z0-9._-]+$(printf '\t')[0-9][A-Za-z0-9._+-]*$" "$TMP/corpus-pins.tsv" | sed 's/^/    /' >&2
+    c68_fail=1
+  fi
+  corpus_note="corpus lock: ${pins_n} pins recovered from the live slot set, bp-catalyst-platform:${kp_ver} round-tripped"
+else
+  echo "  NOTE: monorepo slot corpus not found at ${CORPUS_DIR} — skipping the parser-vs-corpus lock (runs in blueprint-release CI from the monorepo)"
+  corpus_note="corpus lock SKIPPED (chart tested outside the monorepo)"
+fi
+
+if [ "$c68_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5237 round 2: step-03 Phase A2-pins unions the FROZEN local-Gitea bootstrap-kit pins into the chart mirror [fail-loud, toggleable]; step-06 Phase 3a-pin asserts EVERY frozen pin durably present via the in-cluster artifact API before the irreversible strip [top-up-warm, FATAL with full missing list, deadline re-armed]; ONE shared 03b extractor for both + the #5265 Day-2 seam; ${corpus_note})"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -619,6 +619,28 @@ prewarm:
   # settled.
   settledRollPreflight:
     enabled: true
+  # #5237 round 2 (Refs #5007 #3379) — PIN-AWARE prewarm: union the chart-
+  # mirror set with the EXACT versions the bootstrap-kit slot pins in the
+  # LOCAL GITEA MIRROR reference (clusters/_template/bootstrap-kit/*.yaml at
+  # the commit step-01 mirrored — the SAME commit flux consumes once step-05
+  # pivots the GitRepository). The live deployed∪desired union (#5007 round 3)
+  # tracks the CLUSTER, which a mid-cutover catalog merge can roll AWAY from
+  # the frozen pins before step-03 runs (the GitRepository still tracks GitHub
+  # until step-05): prewarm then mirrors the transient tag while the version
+  # flux settles back to post-pivot was never warmed → step-06 wedges /
+  # post-strip chart (re)pulls 404 under the deny-egress hold. Enumerating the
+  # FROZEN pins directly (via the shared cutover-bootstrap-kit-pins extractor
+  # — ONE parser for step-03, step-06 and the #5265 Day-2 reconciler)
+  # guarantees the post-cutover pin set is in local Harbor REGARDLESS of what
+  # merges upstream mid-cutover — the durable close of the hw274
+  # catalog-latest-vs-flux-pinned drift class (dep d51a69f885872a81).
+  # FAIL-LOUD: an unreadable PAT / unreachable Gitea mirror / zero-pin parse
+  # FATALs step-03 while egress is still open, never a silently narrower
+  # mirror. Set false ONLY as an emergency override on an env whose local
+  # Gitea mirror is manually confirmed unusable (the live-union mirror set +
+  # the step-06 union-warm top-up then remain the only nets).
+  bootstrapKitPins:
+    enabled: true
   # #4994 (Refs #3379) — content-digest idempotency for the step-03 skopeo
   # mirror. When true (default) each container-image copy (Phase A) + chart-OCI
   # copy (Phase A2) first compares the SOURCE vs local-Harbor DEST manifest
@@ -1721,6 +1743,22 @@ helmReadinessProbe:
   # AND upstream still FATALs at the deadline (fail-loud preserved). Set false
   # to restore pure fail-loud (no upstream top-up).
   unionWarmOnDrift: true
+  # #5237 round 2 (Refs #5007) — step-06 Phase 3a-pin: BEFORE the sampled
+  # pull-probe (and therefore before the irreversible Phase-3b mothership-auth
+  # strip), assert EVERY bootstrap-kit-pinned chart version — enumerated from
+  # the step-06 Phase-2 clone of the local Gitea mirror (the frozen commit
+  # flux consumes post-pivot) via the SAME cutover-bootstrap-kit-pins
+  # extractor step-03 mirrors from — is durably present in local Harbor
+  # (artifact-API probe on the in-cluster Harbor Service, the #5030
+  # never-pull-through discipline). A missing version is first top-up-warmed
+  # from the still-reachable upstream (the #5237 union-warm helper; egress is
+  # open until step-08); anything STILL missing FATALs with the full missing
+  # list and the ghcr.io auth intact — a clear, recoverable step-06 failure
+  # instead of HelmReleases wedging on `does not have an artifact` after the
+  # strip. The Phase-3a sample probe only proves a SAMPLE pulls; this gate
+  # proves the WHOLE frozen pin set exists. Set false only to restore the
+  # pre-#5237-round-2 sample-only gating.
+  pinPresenceGate: true
   # #4557 (Refs #3379): TLS verification on the helm-CLI probe DESTINATION —
   # the IN-CLUSTER Harbor reached as `registry.<sov-fqdn>` (HARBOR_PUBLIC_URL
   # → harbor_host). DEFAULT false (skip verify for the in-cluster target).

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.146"
+  version: "0.1.147"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.146"
+    version: "0.1.147"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5237 #3379 #5007 #5265

## Problem — the catalog-latest-vs-flux-pinned drift class (killed hw274)

A `bp-catalyst-platform` release published to ghcr AFTER step-03 harbor-prewarm finishes (a mid-cutover merge's deploy-bot bump) makes the live cluster drift away from the pin set the Sovereign settles back to once step-05 freezes Flux onto the local Gitea mirror commit. Step-03's live deployed∪desired union (#5007 r3) tracks the CLUSTER, not the FROZEN pins — so the version flux converges to post-pivot can be a version prewarm never mirrored, and step-06 / post-strip chart (re)pulls 404 under the deny-egress hold. The #5238 union-warm is the mid-flight net; the operational rule so far was a human-enforced merge freeze during cutover. This PR makes the guarantee mechanical.

## Mechanism

**Ground truth**: the bootstrap-kit slot files in the LOCAL GITEA MIRROR (`clusters/_template/bootstrap-kit/*.yaml` at the commit step-01 mirrored — the exact commit flux consumes post-step-05), immune to anything published upstream mid-cutover.

1. **Shared extractor `cutover-bootstrap-kit-pins` (new template 03b)** — a zero-dependency POSIX sh+awk library, `bootstrapkit_pins DIR UP_PREFIX LOCAL_PREFIX` → `chart\tversion` pin set (openova-io-sourced HelmReleases only; semver ranges and community repos like charts.loft.sh skipped with WARNs). ONE parser sourced by step-03 AND step-06 — and the **documented reuse seam for the #5265 Day-2 mirror-resync reconciler** (the same drift class re-opens post-cutover when the mirror re-syncs pin bumps local Harbor lacks; the Day-2 caller sources this same ConfigMap over the freshly-synced commit). awk, not `kubectl create --dry-run=client` (RESTMapper couples the enumeration to served CRD versions — empirically breaks) and not yq (not in alpine/k8s; `apk add` is a mid-cutover network dependency, the G69 lesson).
2. **Step-03 Phase A2-pins (pin-aware prewarm)** — fetches the slot files from the local Gitea (contents+raw API, `catalyst-gitea-token` PAT — the step-01/05 read path) and UNIONS the frozen pins into the Phase A2 chart-mirror set. PIN-ONLY entries (frozen pin not covered by the live union = exactly what a mid-cutover roll would have lost) are logged as a drift report. FAIL-LOUD while egress is open: unreadable PAT / unlistable mirror / partial fetch / zero-pin parse each exit 1 naming the recovery. Knob `prewarm.bootstrapKitPins.enabled` (default true, sprig-bool-safe wiring).
3. **Step-06 Phase 3a-pin (belt-and-braces presence gate)** — BEFORE the sampled pull-probe and the irreversible Phase-3b mothership-auth strip: enumerates the same pins from the Phase-2 clone at `/tmp/repo` (the frozen commit), asserts EVERY pin durably present in local Harbor via the artifact API on the in-cluster Service (the #5030 never-pull-through probe; ~65 GETs, seconds), top-up-warms a missing pin via the #5238 `warm_chart_from_upstream` helper (egress still open), and FATALs with the FULL missing list otherwise — ghcr auth intact, recoverable on re-run. The sample-probe deadline re-arms after the gate so a warm-heavy pass cannot eat its budget. Knob `helmReadinessProbe.pinPresenceGate` (default true).

Result: whatever merges upstream mid-cutover, the post-pivot flux pin set is guaranteed present in local Harbor (step-03), and the strip can never fire against an unproven pin set (step-06). No merge freeze needed.

## Tests

- `tests/cutover-contract.sh` **Case 68**: renders + asserts every load-bearing token of (1)/(2)/(3) incl. both toggles' off-wiring, and runs the **parser-vs-corpus lock** — the rendered extractor executes against this repo's actual `clusters/_template/bootstrap-kit` (64 pins recovered; `bp-catalyst-platform:1.4.1177` round-tripped; purity/format asserts), so slot-format drift fails CI at PR time, never on a Sovereign. Full suite green (68/68).
- Rendered step-03 (1646 lines) + step-06 (1357 lines) podSpec scripts pass `sh -n` under dash AND busybox ash.
- Lockstep: chart `0.1.147` + `blueprint.yaml` + bootstrap-kit slot 06a pin + catalog-seed (2 spots) — `tests/e2e/bootstrap-kit` full package green incl. `TestBootstrapKit_BlueprintVersionLockstepSweep` + `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` (0.1.146 was claimed by #5262 mid-flight; rebased + serialized per canon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
