### PR TITLE
fix(#5245): dr-failback targets a peer host resolvable from the recovered region — unwedge failback re-clone

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -269,7 +269,15 @@ spec:
       # side=primary dr-failback actor demotes + re-clones region-A onto
       # region-B's promoted line (pg_basebackup over the new `-replica-mesh`
       # global Service; shared client CA so region-A's own cert authenticates).
-      version: 0.2.18
+      # 0.2.19 (#5245): dr-failback TL-EQUALITY deadlock + fail-loud peer
+      # probe. hw277 G12: region-A's os-start HA failover bumped its timeline
+      # to the SAME number as region-B's promote (TL2==TL2) — the strict
+      # TL_peer>TL_local gate was structurally unsatisfiable → 57-minute
+      # split-brain until region-B's TL-ahead re-promote broke the tie. TL
+      # gate now `>=` (the sync fence is the authority proof) + every peer-
+      # probe failure reason (NXDOMAIN/unreachable/in-recovery/TL-behind)
+      # logs loudly. Script-only; substitutes unchanged.
+      version: 0.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1137,8 +1137,12 @@ The deterministic failover test for two independent CNPG clusters:
      holds every acknowledged commit (the lower-TL side is write-fenced by
      its unsatisfiable `FIRST 1`), so re-promoting it is data-safe.
    - **dr-failback** (region-A, side=primary): on POSITIVE proof — local
-     writable on TL n, the pinned sync standby ABSENT, peer WRITABLE on a
-     HIGHER timeline over the `-replica-mesh` global Service, held 120s —
+     writable on TL n, the pinned sync standby ABSENT, peer WRITABLE on an
+     EQUAL-or-higher timeline over the `-replica-mesh` global Service
+     (chart 0.2.19 #5245: equality included — on hw277 region-A's os-start
+     HA failover matched the survivor's TL and the strict gate deadlocked
+     in split-brain; the sync fence is the authority proof, and every
+     peer-probe failure reason now logs fail-loud), held 120s —
      region-A demotes via `SOVEREIGN_CNPG_PAIR_DEMOTED="true"` (the primary
      Cluster CR re-renders as a pg_basebackup replica cluster of region-B)
      and the stale Cluster CR is deleted so helm re-creates it and the

--- a/platform/cnpg-pair/DESIGN.md
+++ b/platform/cnpg-pair/DESIGN.md
@@ -367,12 +367,22 @@ line.** `side=primary` renders a `<fullname>-dr-failback` Deployment
 action, so nothing renders). Signals: local cluster WRITABLE on TL n +
 the pinned sync standby ABSENT from `pg_stat_replication` (walsender
 rows run AS `streaming_replica` — same-user rows are fully visible) +
-the peer REACHABLE, WRITABLE and on a strictly HIGHER timeline over
+the peer REACHABLE, WRITABLE and on an EQUAL-OR-HIGHER timeline over
 the new `-replica-mesh` global Service (the reverse mirror of
 `-primary-mesh`: a CNPG-managed `rw` additional Service on the replica
-Cluster + a zero-backend stub on cluster-A). `TL_peer > TL_local` is
-antisymmetric — only the stale side can ever see peer-ahead, so the
-two regions' actors can never both act. After the proof holds
+Cluster + a zero-backend stub on cluster-A). `TL_peer >= TL_local`,
+never strict (chart 0.2.19, #5245 hw277): region-A's os-start recovery
+can run a LOCAL HA failover that bumps its timeline to the SAME number
+as region-B's promote (TL2 == TL2 live-observed — a 57-minute
+split-brain under the earlier strict gate). Timeline numbers on two
+independently-promoted lines are not ordered lineage, so equality
+carries no authority signal; the sync fence is the authority proof,
+and the single-actor asymmetry rests on side gating (only cluster-A
+renders a dr-failback actor) plus the dr-promoter's anti-flap. A peer
+TL strictly BEHIND local is refused loudly (fail-safe, RUNBOOKS §6.1),
+and every peer-probe failure reason (NXDOMAIN / unreachable /
+in-recovery / TL-unreadable / TL-behind) logs on its transition with a
+~5-minute heartbeat while it persists. After the proof holds
 `peerAheadHoldSeconds`, the actor flips
 `SOVEREIGN_CNPG_PAIR_DEMOTED="true"`, waits for kustomize to render
 the demoted shape into the HR (primary Cluster CR as a replica cluster

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -68,7 +68,21 @@ spec:
   # destruction, sync-fence data-safety (region-B ⊇ every acked commit).
   # Shared client CA on the replica Cluster (clientCASecret=-primary-ca) lets
   # region-A's own cert authenticate the rejoin stream.
-  version: 0.2.18
+  # 0.2.19 (#5245): dr-failback TL-EQUALITY deadlock + fail-loud peer probe.
+  # hw277 G12 live-proved the 0.2.18 failback wedge is NOT DNS (the
+  # `-replica-mesh` stub existed on cluster-A since install and the bare name
+  # resolves from the actor pod — the same proven form the WAL path uses):
+  # region-A's os-start HA failover bumped its timeline to the SAME number as
+  # region-B's promote (TL2==TL2), so the strict TL_peer>TL_local gate was
+  # structurally unsatisfiable → 57-minute split-brain until region-B's
+  # independent TL-ahead re-promote broke the tie; the chain then converged
+  # end-to-end. Fixes: (1) TL gate `>` → `>=` — the sync fence, not the TL
+  # number, is the authority proof (side gating + promoter anti-flap carry
+  # the single-actor asymmetry; peer-BEHIND stays fail-safe + loud);
+  # (2) fail-loud peer probe: NXDOMAIN / unreachable / in-recovery /
+  # TL-unreadable / TL-behind each log on transition + ~5-min heartbeat —
+  # no more silent wedge. Script-only; no schema/RBAC/resource delta.
+  version: 0.2.19
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,37 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.19 (#5245): dr-failback TL-EQUALITY deadlock + fail-loud peer probe.
+# hw277 G12 (dep 1708c340ffc0e3f2, 2026-07-19) live-proved the 0.2.18 failback
+# wedge root cause is NOT DNS: the `-replica-mesh` stub Service existed on
+# cluster-A since install (helm-created 14:56:30Z, pre-kill) and the bare name
+# resolves fine from the actor pod (same-namespace search path — the same
+# proven form the WAL externalCluster uses for `-primary-mesh`; the NXDOMAIN
+# read in the 17:48Z walk was a NODE-vantage resolver artifact,
+# `.openstacklocal` search). The REAL wedge: region-A's os-start recovery ran
+# a LOCAL HA failover that bumped its timeline to the SAME number as
+# region-B's promote (TL2 == TL2), so the DETECT gate's strict
+# `TL_peer > TL_local` was STRUCTURALLY unsatisfiable — both regions served
+# writes for 57 minutes (persistent split-brain, divergence-probe-proven)
+# until region-B's independent TL-ahead re-promote (TL3, 18:33:55Z) happened
+# to break the tie; the demote → wedge-escalation → re-clone chain then ran
+# clean end-to-end (re-clone 18:46:31Z, pg_basebackup streaming). TWO fixes:
+# (1) TL gate `>` → `>=`. Equality is safe: a WRITABLE peer behind
+#     `-replica-mesh` (selectorType rw of the REPLICA Cluster) proves
+#     region-B promoted, the local pinned-sync-standby ABSENCE proves the
+#     fork, and the sync fence (FIRST 1 + dataDurability:required — a render
+#     precondition) proves region-A acked nothing since. TL numbers on two
+#     independently-promoted lines are not ordered lineage; the fence is the
+#     authority proof. Single-actor asymmetry rests on side gating (only
+#     cluster-A renders dr-failback) + the promoter's anti-flap, never on TL
+#     strictness. Peer TL strictly BEHIND local stays fail-safe (loud log,
+#     no action, RUNBOOKS §6.1).
+# (2) FAIL-LOUD peer probe: every probe-failure reason — host NOT RESOLVABLE
+#     (getent, NXDOMAIN by name) / unreachable / in-recovery / TL-unreadable /
+#     TL-behind — logs on its transition + re-logs every 30 ticks (~5 min)
+#     while it persists. hw277 sat 57 min with zero output after 'loop
+#     started'; a silent probe loop made the TL deadlock indistinguishable
+#     from a DNS wedge. Script-only change: no resource-count, RBAC, env or
+#     values-schema delta. Lockstep slot 16b pin → 0.2.19.
 # 0.2.18 (#5245): region-kill FAILBACK — the DR chain gains its missing return
 # leg. hw275 G12 (dep 7886def2e61c63aa, 2026-07-19): after a CLEAN forward
 # promote (region-B writable TL2, latched), recovering region-A did NOT
@@ -251,7 +283,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.18
+version: 0.2.19
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -291,6 +323,41 @@ description: |
 
   Changelog
   ─────────
+  0.2.19 (2026-07-19, dr-failback TL-equality deadlock + fail-loud peer probe, Refs #5245 #5248 #5218)
+    - FIX (Pillar-3 region-kill failback): hw277 G12 (dep 1708c340ffc0e3f2)
+      live-proved the 0.2.18 failback wedge is NOT DNS. The `-replica-mesh`
+      stub Service existed on cluster-A since install (helm-created
+      14:56:30Z, pre-kill) and the bare name resolves from the actor pod
+      (same-namespace search path — the identical proven-reachable form the
+      WAL externalCluster uses for `-primary-mesh`; the walk's NXDOMAIN
+      observation was a NODE-vantage resolver artifact, `.openstacklocal`
+      search). The REAL wedge: region-A's os-start recovery ran a LOCAL HA
+      failover that bumped its timeline to the SAME number as region-B's
+      promote (TL2 == TL2), so the DETECT gate's strict `TL_peer > TL_local`
+      was structurally unsatisfiable — both regions served writes for 57
+      minutes (persistent split-brain, divergence-probe-proven) until
+      region-B's independent TL-ahead re-promote (TL3, 18:33:55Z) broke the
+      tie by luck; the demote → wedge-escalation → re-clone chain then ran
+      clean end-to-end (re-clone 18:46:31Z, pg_basebackup streaming).
+    - TL gate `>` → `>=`: a WRITABLE peer behind `-replica-mesh`
+      (selectorType rw of the REPLICA Cluster) proves region-B promoted, the
+      local pinned-sync-standby ABSENCE proves the fork, and the sync fence
+      (FIRST 1 + dataDurability:required — a render precondition) proves
+      region-A acked nothing since. TL numbers on two independently-promoted
+      lines are not ordered lineage; the fence is the authority proof.
+      Single-actor asymmetry rests on side gating + the promoter anti-flap,
+      never on TL strictness. Peer TL strictly BEHIND local stays fail-safe
+      (loud log, no action — RUNBOOKS §6.1).
+    - FAIL-LOUD peer probe: every probe-failure reason — host NOT RESOLVABLE
+      (getent, NXDOMAIN named explicitly) / unreachable / in-recovery /
+      TL-unreadable / TL-behind — logs on its transition and re-logs every
+      30 ticks (~5 min) while it persists. hw277 sat 57 min with zero output
+      after 'loop started'; a silent probe loop made the TL deadlock
+      indistinguishable from a DNS wedge from the outside.
+    - Script-only change: no resource-count, RBAC, env or values-schema
+      delta. Render Case 19 now pins the `>=` gate, the loud TL-behind
+      refusal, and the fail-loud reason ladder. Lockstep slot 16b pin →
+      0.2.19.
   0.2.18 (2026-07-19, region-kill FAILBACK — demote+re-clone region-A onto the promoted line, durable handoff, TL-ahead re-promote, Refs #5245)
     - FIX (Pillar-3 region-kill DR, the missing return leg): on hw275 G12 the
       forward promote was CLEAN (region-B TL2, armed, latched) but recovering

--- a/platform/cnpg-pair/chart/templates/dr-failback.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-failback.yaml
@@ -43,13 +43,33 @@ fence IS the authority proof.
      on timeline N, the pinned sync standby ABSENT from
      pg_stat_replication (walsender rows run AS streaming_replica, so
      the probe role sees its own rows — no #5239 privilege trap), AND
-     the peer REACHABLE + WRITABLE + on a HIGHER timeline over the
-     `-replica-mesh` global Service. Timelines come from IDENTIFY_SYSTEM
-     over a replication-protocol connection — the one surface
-     streaming_replica is guaranteed to have (pg_hba `hostssl
+     the peer REACHABLE + WRITABLE + on an EQUAL-OR-HIGHER timeline
+     over the `-replica-mesh` global Service. Timelines come from
+     IDENTIFY_SYSTEM over a replication-protocol connection — the one
+     surface streaming_replica is guaranteed to have (pg_hba `hostssl
      replication streaming_replica all cert`), no pg_control privileges
-     involved. TL_peer > TL_local is antisymmetric: only the stale side
-     can ever see peer-ahead, so two actors can never both act.
+     involved.
+     TL_peer >= TL_local, NOT strictly greater (chart 0.2.19, #5245
+     hw277 live-proof, dep 1708c340ffc0e3f2 2026-07-19): region-A's
+     os-start recovery ran a LOCAL HA failover that bumped its own
+     timeline to the SAME number as region-B's promote (TL2 == TL2), so
+     the 0.2.18 strict `>` gate was STRUCTURALLY unsatisfiable — both
+     regions served writes for 57 minutes (persistent split-brain,
+     divergence-probe-proven) until region-B's independent TL-ahead
+     re-promote (TL3) happened to break the tie at 18:33:57Z, after
+     which the whole demote → wedge-escalation → re-clone chain ran
+     clean. Equality is safe to act on: a WRITABLE peer behind
+     `-replica-mesh` (selectorType rw of the REPLICA Cluster CR) proves
+     region-B promoted, the local pinned-sync-standby ABSENCE proves
+     the fork, and the sync fence (FIRST 1 + dataDurability:required —
+     a render precondition of this actor) proves region-A has acked
+     nothing since. Timeline numbers on two INDEPENDENTLY-promoted
+     lines are not ordered lineage — equality carries no authority
+     signal either way; the fence does. Single-actor asymmetry never
+     rested on the TL compare: only cluster-A renders a dr-failback
+     actor (side gating) and the dr-promoter never demotes (anti-flap).
+     A peer TL strictly BEHIND local stays fail-safe: loud log, no
+     action (RUNBOOKS §6.1).
   2. DECIDE (actor container): the peer-ahead evidence must hold
      CONTINUOUSLY for failback.peerAheadHoldSeconds (120s), never
      during the startup grace.
@@ -115,12 +135,28 @@ Same delivery contract as the dr-promoter: a region-local DR actor is
 a continuous Deployment loop; a CronJob's scheduler is the regional
 control plane and does not reliably resume around region churn.
 
+FAIL-LOUD PEER PROBE (#5245, chart 0.2.19)
+------------------------------------------
+Every peer-probe failure REASON — host NOT RESOLVABLE (NXDOMAIN) /
+unreachable / in recovery / timeline unreadable / TL behind — is
+logged on its transition and re-logged every 30 ticks (~5 min) while
+it persists. On hw277 the loop emitted NOTHING for 57 minutes after
+'loop started' while the probe failed every tick on TL equality; from
+the outside that silence was indistinguishable from a DNS wedge (the
+17:48Z walk verdict blamed an NXDOMAIN on the bare `-replica-mesh`
+name — in fact the peer-mesh-service.yaml stub had existed on
+cluster-A since install, 14:56:30Z, and the probe reached the peer
+over that exact bare name the moment the TL relation admitted it;
+the `.openstacklocal` fall-through observed was a NODE-vantage
+resolver artifact, not the pod's). A silent probe loop is a defect:
+every wedge must name itself in the logs immediately.
+
 WHAT IT NEVER DOES
 ------------------
 Never patches a live Cluster CR (#5125-D1 — drift-correction reverts
 it). Never deletes PVCs directly (owner-GC only), never any object but
 the one resourceNames-pinned Cluster CR. Never acts when the peer is
-unreachable, in recovery, or on an equal/lower timeline — a mere mesh
+unreachable, in recovery, or on a LOWER timeline — a mere mesh
 partition, a healthy pair, or the pre-promote outage window all read
 as "no peer-ahead proof" and clear the hold clock. Never re-promotes
 region-B (that is the dr-promoter's TL-ahead re-promote, on
@@ -378,18 +414,68 @@ spec:
                 rm -f /shared/peer-ahead-since
               }
               clear_wedge() { rm -f /shared/wedge-since; }
-              # probe_peer_ahead <tl_local> — verifies peer REACHABLE +
-              # WRITABLE + TL strictly higher; on success touches the
-              # freshness marker the actor re-checks before EVERY
-              # destructive step. Any failure → non-zero (caller clears).
+              # peer_report <key> <message> — #5245 FAIL-LOUD probe
+              # diagnostics (chart 0.2.19). hw277: the loop sat 57 min
+              # after 'loop started' with ZERO output while the peer
+              # probe failed every tick (TL2==TL2 under the then-strict
+              # -gt gate) — a silent wedge indistinguishable from an
+              # NXDOMAIN from outside. Every probe REASON now logs on
+              # its transition and re-logs every 30 ticks (~5 min at
+              # the 10s interval) while a non-ok reason persists.
+              peer_report() {
+                _k="$1"; _m="$2"
+                _prev=$(cat /shared/peer-probe-reason 2>/dev/null || echo "")
+                if [ "${_k}" != "${_prev}" ]; then
+                  echo "${_k}" > /shared/peer-probe-reason
+                  echo 0 > /shared/peer-probe-ticks
+                  echo "$(date -u +"%FT%TZ") [dr-failback/signals] peer probe: ${_m}"
+                elif [ "${_k}" != "ok" ]; then
+                  _n=$(($(cat /shared/peer-probe-ticks 2>/dev/null || echo 0) + 1))
+                  if [ "${_n}" -ge 30 ]; then
+                    _n=0
+                    echo "$(date -u +"%FT%TZ") [dr-failback/signals] peer probe STILL: ${_m}"
+                  fi
+                  echo "${_n}" > /shared/peer-probe-ticks
+                fi
+              }
+              # probe_peer_ahead <tl_local> — verifies peer RESOLVABLE +
+              # REACHABLE + WRITABLE + TL equal-or-higher (>= — see the
+              # DETECT rationale: the hw277 TL2==TL2 deadlock; the sync
+              # fence, not the TL number, is the authority proof). On
+              # success touches the freshness marker the actor re-checks
+              # before EVERY destructive step. Any failure → non-zero
+              # (caller clears) with its reason fail-loud via
+              # peer_report.
               probe_peer_ahead() {
                 _tl_local="$1"
-                pg_isready -h "${PEER_MESH_HOST}" -p 5432 -t "${PROBE_TIMEOUT}" -q || return 1
+                # DNS first, separately from reachability: a structural
+                # NXDOMAIN (missing local -replica-mesh stub Service /
+                # broken kube-dns) must surface BY NAME, immediately
+                # (#5245). getent-less images fall through to
+                # pg_isready, which still covers reachability.
+                if command -v getent >/dev/null 2>&1 && ! getent hosts "${PEER_MESH_HOST}" >/dev/null 2>&1; then
+                  peer_report nxdomain "peer host ${PEER_MESH_HOST} NOT RESOLVABLE from this pod (NXDOMAIN) — the like-named local -replica-mesh stub Service (peer-mesh-service.yaml) or kube-dns is missing/broken; failback cannot observe the peer (#5245)"
+                  return 1
+                fi
+                if ! pg_isready -h "${PEER_MESH_HOST}" -p 5432 -t "${PROBE_TIMEOUT}" -q; then
+                  peer_report unreachable "peer ${PEER_MESH_HOST} resolves but is UNREACHABLE (pg_isready failed — region-B down, mesh partition, or CNP block)"
+                  return 1
+                fi
                 _rec=$(psql "${PEER_CONN}" -tAXc "SELECT pg_is_in_recovery()" 2>/dev/null || echo "err")
-                [ "${_rec}" = "f" ] || return 1
+                if [ "${_rec}" != "f" ]; then
+                  peer_report in-recovery "peer ${PEER_MESH_HOST} reachable but NOT WRITABLE (in_recovery=${_rec}) — region-B not promoted (healthy pair / pre-promote window): no failback"
+                  return 1
+                fi
                 _tl_peer=$(tl_of "${PEER_REPL}")
-                is_int "${_tl_peer}" || return 1
-                [ "${_tl_peer}" -gt "${_tl_local}" ] || return 1
+                if ! is_int "${_tl_peer}"; then
+                  peer_report tl-unreadable "peer ${PEER_MESH_HOST} writable but its timeline is unreadable over the replication protocol — fail-safe"
+                  return 1
+                fi
+                if ! [ "${_tl_peer}" -ge "${_tl_local}" ]; then
+                  peer_report tl-behind "SPLIT-BRAIN with peer TL BEHIND local (peer TL=${_tl_peer} < local TL=${_tl_local}): both sides writable but the recovered region out-promoted the survivor — automatic failback REFUSES this geometry (fail-safe); sovereign-admin action per RUNBOOKS §6.1 (#5245)"
+                  return 1
+                fi
+                peer_report ok "peer ${PEER_MESH_HOST} WRITABLE on TL=${_tl_peer} >= local TL=${_tl_local} — peer-ahead proof available (#5245)"
                 echo "${_tl_peer}" > /shared/tl-peer
                 : > /shared/peer-ahead-fresh
                 return 0
@@ -423,10 +509,10 @@ spec:
                     if probe_peer_ahead "${TL_LOCAL}"; then
                       if [ ! -f /shared/peer-ahead-since ]; then
                         echo "${NOW}" > /shared/peer-ahead-since
-                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] POST-FAILOVER GEOMETRY: local writable TL=${TL_LOCAL}, sync standby ABSENT, peer WRITABLE on TL=$(cat /shared/tl-peer) (> local) — peer-ahead hold clock started (#5245)"
+                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] POST-FAILOVER GEOMETRY: local writable TL=${TL_LOCAL}, sync standby ABSENT, peer WRITABLE on TL=$(cat /shared/tl-peer) (>= local) — peer-ahead hold clock started (#5245)"
                       fi
                     else
-                      clear_hold "peer not provably writable+ahead (unreachable / in recovery / TL<=local)"
+                      clear_hold "peer not provably writable+equal-or-ahead (reason in the fail-loud peer-probe line above)"
                     fi
                     ;;
                   streaming)
@@ -446,7 +532,7 @@ spec:
                     if is_int "${TL_LOCAL}" && probe_peer_ahead "${TL_LOCAL}"; then
                       if [ ! -f /shared/wedge-since ]; then
                         echo "${NOW}" > /shared/wedge-since
-                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] local standby cannot stream (state=${STATE}) while peer is writable+ahead — wedge clock started (#5245 escalation)"
+                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] local standby cannot stream (state=${STATE}) while peer is writable+equal-or-ahead — wedge clock started (#5245 escalation)"
                       fi
                     else
                       clear_wedge
@@ -575,7 +661,7 @@ spec:
                       exit 0
                     fi
                     peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] hold expired but peer proof is stale — re-verifying next tick (fail-safe)"; exit 0; }
-                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] DEMOTING region-A: peer writable on TL=$(cat /shared/tl-peer 2>/dev/null || echo '?') > local TL=$(cat /shared/tl-local 2>/dev/null || echo '?') held ${HELD}s — patching Kustomization substitute SOVEREIGN_CNPG_PAIR_DEMOTED=true (durable source seam, #5245)"
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] DEMOTING region-A: peer writable on TL=$(cat /shared/tl-peer 2>/dev/null || echo '?') >= local TL=$(cat /shared/tl-local 2>/dev/null || echo '?') held ${HELD}s — patching Kustomization substitute SOVEREIGN_CNPG_PAIR_DEMOTED=true (durable source seam, #5245)"
                     kubectl -n "${KS_NAMESPACE}" patch kustomization "${KS_NAME}" --type merge ${FM} -p '{"spec":{"postBuild":{"substitute":{"SOVEREIGN_CNPG_PAIR_DEMOTED":"true"}}}}'
                     kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-started-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-failback-reason\":\"region-A resumed stale TL$(cat /shared/tl-local 2>/dev/null || echo '?') primary while region-B is writable on TL$(cat /shared/tl-peer 2>/dev/null || echo '?'); demoting + re-cloning region-A onto region-B's line (#5245)\"}}}" >/dev/null 2>&1 || true
                     nudge kustomization "${KS_NAMESPACE}" "${KS_NAME}" nudged-ks

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -1104,8 +1104,30 @@ grep -q 'pg_stat_replication' "$TMP/fb-signals.sh" || {
   echo "FAIL: #5245 signals must check the pinned sync standby's presence in pg_stat_replication." >&2; exit 1; }
 grep -qE 'value: "[a-z0-9-]+-replica-mesh"' "$TMP/cnp-primary.yaml" || {
   echo "FAIL: #5245 PEER_MESH_HOST must be the templated -replica-mesh alias, not hardcoded." >&2; exit 1; }
-grep -q '"${_tl_peer}" -gt "${_tl_local}"' "$TMP/fb-signals.sh" || {
-  echo "FAIL: #5245 signals must require TL_peer STRICTLY greater than TL_local (the antisymmetric authority proof)." >&2; exit 1; }
+# 0.2.19 (#5245 hw277): the TL gate is EQUAL-OR-GREATER, never strict.
+# region-A's os-start HA failover bumped it to the SAME TL as region-B's
+# promote (TL2==TL2) and the strict -gt gate sat in a silent 57-minute
+# split-brain; the sync fence (a render precondition), not the TL number,
+# is the authority proof — side gating carries the single-actor asymmetry.
+grep -q '"${_tl_peer}" -ge "${_tl_local}"' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must accept TL_peer EQUAL-OR-GREATER than TL_local (hw277: strict > deadlocks when the recovered region's local failover matches the survivor's TL)." >&2; exit 1; }
+if grep -q '"${_tl_peer}" -gt "${_tl_local}"' "$TMP/fb-signals.sh"; then
+  echo "FAIL: #5245 signals must NOT gate the peer-ahead proof on a STRICT TL comparison (the hw277 TL-equality deadlock)." >&2; exit 1; fi
+grep -q 'tl-behind' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must explicitly detect the peer-TL-BEHIND geometry and refuse it loudly (fail-safe, RUNBOOKS §6.1)." >&2; exit 1; }
+# 0.2.19 (#5245): the peer probe must FAIL LOUD — every failure reason
+# (NXDOMAIN by name, unreachable, in-recovery, TL-unreadable, TL-behind)
+# logs on its transition + a periodic heartbeat. hw277: 57 minutes of
+# total silence after 'loop started' made a TL deadlock indistinguishable
+# from a DNS wedge.
+grep -q 'peer_report' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must carry the fail-loud peer-probe reason ladder (peer_report)." >&2; exit 1; }
+grep -q 'NOT RESOLVABLE' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must log a loud NXDOMAIN diagnostic naming the unresolvable peer host." >&2; exit 1; }
+grep -q 'getent hosts' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must resolve the peer host explicitly (getent) so NXDOMAIN surfaces separately from unreachability." >&2; exit 1; }
+grep -q 'peer probe STILL' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 signals must re-log a persisting probe-failure reason (heartbeat) — a wedge must never go silent." >&2; exit 1; }
 
 # (e) DURABLE SEAM: the actor demotes through the Kustomization substitute
 #     (SOVEREIGN_CNPG_PAIR_DEMOTED) with a CUSTOM field manager — never a raw

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -85,20 +85,28 @@ cnpgPair:
     # dead. failback ships a region-A-local actor (side=primary only)
     # that detects the post-failover geometry from POSITIVE signals
     # (local writable on TL n; the pinned sync standby absent; the peer
-    # REACHABLE + WRITABLE + on a HIGHER timeline over the
-    # `-replica-mesh` global Service) and then demotes + RE-CLONES
-    # region-A onto region-B's line via the SOVEREIGN_CNPG_PAIR_DEMOTED
-    # substitute seam. The one destructive act (deleting the local
-    # stale Cluster CR so helm re-creates it as a pg_basebackup replica
-    # of region-B) is gated on the peer being PROVABLY writable + ahead
-    # at that exact tick — the timeline order is the authority proof.
+    # REACHABLE + WRITABLE + on an EQUAL-OR-HIGHER timeline over the
+    # `-replica-mesh` global Service — 0.2.19 #5245 hw277: region-A's
+    # os-start HA failover bumped it to the SAME TL as region-B's
+    # promote, so the 0.2.18 strictly-higher gate deadlocked in a
+    # 57-minute split-brain) and then demotes + RE-CLONES region-A onto
+    # region-B's line via the SOVEREIGN_CNPG_PAIR_DEMOTED substitute
+    # seam. The one destructive act (deleting the local stale Cluster
+    # CR so helm re-creates it as a pg_basebackup replica of region-B)
+    # is gated on the peer being PROVABLY writable + equal-or-ahead at
+    # that exact tick — the sync fence (FIRST 1 + dataDurability:
+    # required), not the bare TL number, is the authority proof; the TL
+    # bound only refuses the anomalous peer-BEHIND geometry.
     failback:
       enabled: true
       intervalSeconds: 10
       # The peer-ahead evidence (local primary + sync standby absent +
-      # peer writable on a higher TL) must hold CONTINUOUSLY this long
-      # before the actor flips the demotion substitute. A transient
-      # mesh blip or a replica restart clears the clock.
+      # peer writable on an EQUAL-or-higher TL — hw277 #5245: a
+      # strictly-higher gate is structurally unsatisfiable when the
+      # recovered region's local failover matched the survivor's TL)
+      # must hold CONTINUOUSLY this long before the actor flips the
+      # demotion substitute. A transient mesh blip or a replica restart
+      # clears the clock.
       peerAheadHoldSeconds: 120
       # A freshly-(re)started signals container must never act on a
       # half-observed geometry.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -441,7 +441,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.18"
+    version: "0.2.19"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## What hw277 actually proved (live forensics, dep 1708c340ffc0e3f2)

The CRITICAL-FIRST-STEP question — how does the WAL cross-region replication resolve — answers the whole issue:

- The WAL externalCluster resolves `-primary-mesh` as a **bare, namespace-local Service name**: a like-named local Service object in `cnpg` (the side-local stub / CNPG-managed additional Service) + `service.cilium.io/global` merge carries the traffic across the mesh. That is the proven-reachable form.
- The dr-failback peer target `-replica-mesh` **already uses the exact same form** (0.2.18 shipped `peer-mesh-service.yaml`, the cluster-A zero-backend stub). Live proof: the stub existed on hw277 region-a **since install** (helm-created `14:56:30Z`, creationTimestamp pre-kill, labels `helm.sh/chart: bp-cnpg-pair-0.2.18`), and the actor pod probed the peer successfully over that bare name at `18:33:57Z`. The walk's NXDOMAIN observation was a **node-vantage resolver artifact** (`.openstacklocal` is the node's resolv.conf search domain — pods in `cnpg` resolve the name via `cnpg.svc.cluster.local` first).

**The real wedge** (signals-container logs, region-a): region-A's os-start recovery ran a **local HA failover that bumped its timeline to TL2 — the same number as region-B's promote**. The DETECT gate required `TL_peer > TL_local` strictly, which is structurally unsatisfiable at TL2==TL2, and the probe loop is silent on failure → 57 minutes of divergence-probe-proven split-brain, broken only when region-B's independent TL-ahead re-promote (TL3, `18:33:55Z`) made the strict compare pass. From there the 0.2.18 chain ran clean end-to-end: hold 120s → demote substitute `18:36:06Z` → in-place-demote wedge → escalation `18:46:20Z` → re-clone `18:46:31Z` → pg_basebackup streaming (verified live).

## Fix — chart 0.2.19 (script-only)

1. **TL gate `>` → `>=`** (`dr-failback.yaml` signals `probe_peer_ahead`): equality is safe — a WRITABLE peer behind `-replica-mesh` (selectorType `rw` of the REPLICA Cluster) proves region-B promoted; the local pinned-sync-standby ABSENCE proves the fork; the sync fence (`FIRST 1` + `dataDurability: required`, a render precondition of this actor) proves region-A acked nothing since. TL numbers on two independently-promoted lines are not ordered lineage — the fence is the authority proof; single-actor asymmetry rests on side gating (only cluster-A renders dr-failback) + the promoter's anti-flap, never on TL strictness. Peer TL strictly BEHIND local stays fail-safe (loud refusal, RUNBOOKS §6.1).
2. **Fail-loud peer probe** (the future-NXDOMAIN requirement): every probe-failure reason — host **NOT RESOLVABLE** (explicit `getent` check, so NXDOMAIN surfaces by name, separately from unreachability) / unreachable / in-recovery / TL-unreadable / TL-behind — logs on its transition and re-logs every 30 ticks (~5 min) while it persists. No more silent wedge.

No resource-count, RBAC, env or values-schema delta.

## Validation

- `chart/tests/cnpg-pair-render.sh`: Case 19 now pins the `>=` gate (a strict `>` FAILS the gate), the loud TL-behind refusal, the `getent` NXDOMAIN diagnostic, the `peer_report` reason ladder + `STILL` heartbeat — **all 19 cases green** (incl. POSIX `sh -n` of both extracted scripts).
- Probe ladder exercised against 7 mocked scenarios (extracted rendered script + pg_isready/psql/getent mocks): NXDOMAIN loud-once + heartbeat-at-30, TL2==TL2 → rc=0 + freshness marker, TL3>2 → rc=0, TL1<2 → loud refuse rc=1, in-recovery rc=1, unreachable rc=1, ok-transition re-log.
- Lockstep: `blueprint.yaml` + bootstrap-kit slot 16b + catalog-seed → 0.2.19; `TestBootstrapKit_BlueprintVersionLockstepSweep` PASS locally.

Live validation rides the next fresh 2-region prov's G12 kill+recover walk (the TL-equality geometry reproduces whenever os-start triggers a local failover).

Refs #5245 #5248 #5218

🤖 Generated with [Claude Code](https://claude.com/claude-code)