### PR TITLE
fix(#5267): document + gate the control-plane DR contract (404-during-outage is deliberate)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1253,7 +1253,7 @@ spec:
       #   global.sovereignFQDN values are UNCHANGED — still consumed by this
       #   chart's OTHER templates (sovereign-wildcard-certs.yaml,
       #   sovereign-fqdn-configmap.yaml). Lockstep w/ Chart.yaml.
-      version: 1.4.1179
+      version: 1.4.1180
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1620,6 +1620,8 @@ Application-page topology UI: editor (`single-region` | `active-active` | `activ
 
 **Acceptance**: 3-region cluster up (1 mgt + 2 data planes). Demo Application with `active-hotstandby` runs primary in fsn, hot-standby in hel; CNPG replication healthy. Switchover from Application page completes in <60s with <5s write disruption. Resolver clients within 30–90s observe new primary (lua-record TTL window). Reverse failback once original primary recovers.
 
+**Control-plane DR posture (#5267, deliberate)**: the Catalyst control plane (catalyst-api serving console / api / marketplace) is **primary-region-only** — G2 (#2574) suspends `bp-catalyst-platform` on secondary CPs (`SECONDARY_HR_SUSPEND`), and catalyst-api is single-replica `strategy: Recreate` on RWO zone-scoped EVS PVCs (single-writer flat-file deployment store, no leader election). During a primary-region kill the gateway VIP fails over to the surviving region's envoy (#5246) and the console returns **HTTP 404 `server: envoy`** for the outage window, then 200 on failback — that 404 signature is the expected PASS state, gated by `products/catalyst/chart/tests/api-single-writer-dr-contract.sh` and specified in [`DOD.md`](DOD.md) §6 "Service-plane contract during the kill". Data-plane failover (CNPG + customer workloads + gateway) is the Pillar-3 contract; control-plane HA needs a persistence redesign (DB-backed store + leader election) and is deferred with that reason.
+
 ### §10.8 State-of-the-art patterns applied
 
 | Pattern | Where it lives |

--- a/docs/DOD.md
+++ b/docs/DOD.md
@@ -759,6 +759,57 @@ region kill. Any gap, replay, or skipped value = failed gate.
   **only acceptable evidence**. Operator-walk screenshots alone do not
   satisfy D31.
 
+### Service-plane contract during the kill — control-plane availability (deliberate, #5267)
+
+Pillar 3's DR contract is **data-plane** continuity: CNPG promotion, customer
+workloads, and the gateway VIP in the surviving region. The **Catalyst
+control plane** (catalyst-api serving console / api / marketplace in
+`catalyst-system`) is **primary-region-only by design** and is NOT part of
+the failover contract. This was decided twice, independently:
+
+- **G2 (#2574)**: `bp-catalyst-platform` installs only where
+  `sovereign_region_role == "primary"` — bootstrap-kit slot 13 renders
+  `suspend: true` on every secondary CP (`SECONDARY_HR_SUSPEND`).
+- **Chart design**: catalyst-api is single-replica with
+  `strategy: Recreate`, persisting the deployment store (tofu workdirs,
+  flat-file JSON deployment records) and the k8scache snapshots on two
+  **RWO EVS PVCs** whose PVs carry zone-scoped nodeAffinity — the volume
+  cannot attach in the other region, so a region-b replica cannot mount the
+  store. The store is single-writer flat-file with no leader election; a
+  region-b replica with its own PVC would fork the deployment/tofu state
+  (split-brain over infrastructure truth — double-provision / mis-wipe
+  hazards), and catalyst-api's in-process singleton loops (phase-1 watch,
+  deploy reconciler, cutover driver) would run twice.
+
+**Expected observable behavior during a primary-region kill** (live-confirmed
+hw277 G12, 2026-07-19 — #5267):
+
+| Surface | During outage | On failback | Meaning |
+|---|---|---|---|
+| Gateway VIP (`https://console.<sovereign-fqdn>/`) | **HTTP 404 with `server: envoy`** | HTTP 200 | TLS terminates on the surviving region's envoy (#5246 both-region ELB pool); the 404 proves the gateway is alive and the control-plane backend is deliberately absent |
+| Customer data plane (tenant Applications, CNPG) | Serving from the surviving region | Serving | The actual Pillar-3 contract |
+| Console / api / marketplace (control plane) | Unreachable — the 404 above | Returns automatically, no manual action | Control plane restarts with the primary region |
+
+A whole-outage connection **timeout / black-hole** on the gateway VIP is a
+**FAIL** (#5244 shape — ELB pool was primary-region-only). The
+404-with-`server: envoy` signature is the **PASS** signature for the
+service-plane check: it distinguishes "gateway failed over, control plane
+deliberately absent" from "gateway dead".
+
+During the outage the sovereign-admin observes/drives via `kubectl` against
+the surviving region's cluster; D31 itself needs no console — the failover
+is machine-driven (`failover-controller` + counter writer, per the hard
+requirements above).
+
+Control-plane HA is **deferred with reason**: it requires a persistence
+redesign (deployment store moved off RWO-EVS flat files onto a DR-replicated
+database, plus leader election for the singleton loops) — not a
+replica-count bump. The contract is CI-gated by
+`products/catalyst/chart/tests/api-single-writer-dr-contract.sh`, which
+fails any chart change that raises catalyst-api replicas, drops
+`strategy: Recreate`, or widens the PVC access mode without revisiting this
+section.
+
 ---
 
 ## §7 — Pillar 5 sovereignty cutover

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1180 — #5267 (Refs #5267 #5246 #4275, hw277 G12 region-kill: console
+#   404 during region-a outage): NO template change — adds the
+#   tests/api-single-writer-dr-contract.sh CI gate that makes the
+#   control-plane DR posture a deliberate, tested contract. catalyst-api is
+#   primary-region-only by design (G2 #2574 SECONDARY_HR_SUSPEND; RWO
+#   zone-scoped EVS PVCs backing the single-writer flat-file deployment
+#   store; no leader election), so during a primary-region kill the gateway
+#   fails over (#5246, envoy answers) and console/api/marketplace return
+#   404-with-`server: envoy` until failback — documented in docs/DOD.md §6
+#   "Service-plane contract during the kill" + docs/ARCHITECTURE.md §10.7.
+#   The gate fails any future replicas>1 / strategy!=Recreate / RWX-widening
+#   change that skips the persistence redesign (DB-backed store + leader
+#   election). Lockstep w/ bootstrap-kit slot 13 pin.
 # 1.4.1151 — #5187 (Refs #5187, region-b sovereign-tls Kustomization
 #   Ready=False on a 2-region Sovereign): DELETES
 #   templates/sovereign-tls-vars-cm.yaml. Root cause: this chart's HR is
@@ -3496,7 +3509,7 @@ name: bp-catalyst-platform
 #   footprint to fit the 4-CPU `plan-quota` (the 0.4.21 oidc-config post-install
 #   hook requested a 500m CPU limit into a namespace with only 250m of quota
 #   headroom → the hook pod was NEVER created → HR timeout → no HTTPRoute → 404).
-version: 1.4.1179
+version: 1.4.1180
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/tests/api-single-writer-dr-contract.sh
+++ b/products/catalyst/chart/tests/api-single-writer-dr-contract.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — catalyst-api single-writer / control-plane DR
+# contract gate (#5267).
+#
+# WHAT THIS ENCODES
+# -----------------
+# During a primary-region kill on a 2-region Sovereign, the gateway VIP
+# fails over to the surviving region's envoy (#5246 both-region ELB pool)
+# but the operator console / api / marketplace answer **HTTP 404 with
+# `server: envoy`** until failback. That 404-during-outage → 200-on-failback
+# behavior is a DELIBERATE, documented decision (docs/DOD.md §6 "Service-
+# plane contract during the kill", docs/ARCHITECTURE.md §10.7), NOT an
+# accident: the Catalyst control plane is primary-region-only by design.
+#
+# WHY (the load-bearing constraints this gate protects)
+# -----------------------------------------------------
+#   1. catalyst-api persists the deployment store (tofu workdirs, flat-file
+#      JSON deployment records) + k8scache snapshots on two RWO EVS PVCs.
+#      The EVS PV nodeAffinity is zone-scoped — the volume physically cannot
+#      attach in the other region, so a region-b replica cannot mount it.
+#   2. The store is single-writer flat-file with NO leader election. A second
+#      replica with its own PVC forks the deployment/tofu state — split-brain
+#      over infrastructure truth (double-provision / mis-wipe hazards).
+#   3. catalyst-api runs in-process singleton loops (phase-1 watch, deploy
+#      reconciler, cutover driver) that assume exactly one instance.
+#   4. G2 (#2574): bootstrap-kit slot 13 suspends bp-catalyst-platform on
+#      every secondary CP (SECONDARY_HR_SUSPEND) — the control plane lives
+#      with the primary region.
+#
+# Therefore: replicas MUST stay 1, strategy MUST stay Recreate, and both
+# PVCs MUST stay ReadWriteOnce — until control-plane HA is done PROPERLY
+# (deployment store moved to a DR-replicated database + leader election).
+# If your change trips this gate, you are either (a) doing that redesign —
+# then update docs/DOD.md §6 + docs/ARCHITECTURE.md §10.7 + this test in the
+# same PR, or (b) about to ship a split-brain — revert.
+#
+# Test framework: pure `helm template` + grep on rendered YAML, matching the
+# established tests/sovereign-fqdn-lb-ip-contract.sh pattern. Picked up
+# automatically by .github/workflows/blueprint-release.yaml ("Run chart
+# integration tests (chart/tests/*.sh)").
+#
+# Usage: bash tests/api-single-writer-dr-contract.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+DOC_REF="docs/DOD.md §6 'Service-plane contract during the kill' (#5267)"
+
+echo "[api-single-writer-dr] Case 1: catalyst-api Deployment renders replicas: 1 (single-writer store — no HA without persistence redesign)"
+helm template smoke . \
+  --show-only templates/api-deployment.yaml > "$TMP/api.yaml"
+
+# Deployment-level spec.replicas — top-level two-space indent in rendered YAML.
+REPLICAS_LINE="$(grep -E '^[[:space:]]{2}replicas:' "$TMP/api.yaml" | head -1 || true)"
+if [ -z "$REPLICAS_LINE" ]; then
+  echo "FAIL: catalyst-api Deployment no longer renders an explicit 'replicas:' — the single-writer contract must stay explicit, see ${DOC_REF}" >&2
+  exit 1
+fi
+if ! echo "$REPLICAS_LINE" | grep -qE 'replicas:[[:space:]]*1$'; then
+  echo "FAIL: catalyst-api Deployment replicas != 1 (got: '${REPLICAS_LINE// /}')." >&2
+  echo "      catalyst-api persists the tofu/deployment store on a zone-scoped RWO EVS PVC" >&2
+  echo "      with no leader election — a second replica is a split-brain over infrastructure" >&2
+  echo "      truth, and a cross-region replica cannot attach the volume at all." >&2
+  echo "      Control-plane HA requires the persistence redesign in ${DOC_REF};" >&2
+  echo "      update that section + this gate in the same PR if that is what you are shipping." >&2
+  exit 1
+fi
+echo "  PASS (replicas: 1)"
+
+echo "[api-single-writer-dr] Case 2: strategy is Recreate (RWO PVC — a rolling update would MultiAttachError)"
+if ! grep -qE '^[[:space:]]*type:[[:space:]]*Recreate' "$TMP/api.yaml"; then
+  echo "FAIL: catalyst-api Deployment strategy is no longer Recreate — with RWO PVCs a" >&2
+  echo "      RollingUpdate schedules a second Pod against the same single-attach volume" >&2
+  echo "      (MultiAttachError). See ${DOC_REF}." >&2
+  exit 1
+fi
+echo "  PASS (strategy.type: Recreate)"
+
+echo "[api-single-writer-dr] Case 3: both catalyst-api PVCs stay ReadWriteOnce (access-mode widening = HA redesign, not a values tweak)"
+for tpl in templates/api-deployments-pvc.yaml templates/api-cache-pvc.yaml; do
+  helm template smoke . --show-only "$tpl" > "$TMP/pvc.yaml"
+  if ! grep -qE '^[[:space:]]*-[[:space:]]*ReadWriteOnce' "$TMP/pvc.yaml"; then
+    echo "FAIL: ${tpl} accessModes is no longer ReadWriteOnce." >&2
+    echo "      Widening to RWX (or adding modes) implies a multi-writer filesystem that the" >&2
+    echo "      flat-file store + EVS CSI do not provide; cross-region HA additionally needs a" >&2
+    echo "      DR-replicated store + leader election. See ${DOC_REF} — update it + this gate" >&2
+    echo "      in the same PR if you are doing the redesign." >&2
+    exit 1
+  fi
+done
+echo "  PASS (api-deployments-pvc + api-cache-pvc both RWO)"
+
+echo "[api-single-writer-dr] Case 4: kustomize sibling (contabo/mothership path, .helmignore'd) keeps replicas: 1"
+# api-deployment-kustomize.yaml is applied via raw Kustomize on contabo — it is
+# not helm-rendered, so assert at source level.
+KUSTOMIZE_SIBLING="templates/api-deployment-kustomize.yaml"
+if [ -f "$KUSTOMIZE_SIBLING" ]; then
+  if ! grep -qE '^[[:space:]]{2}replicas:[[:space:]]*1$' "$KUSTOMIZE_SIBLING"; then
+    echo "FAIL: ${KUSTOMIZE_SIBLING} replicas != 1 — the mothership catalyst-api has the same" >&2
+    echo "      single-writer store constraints. See ${DOC_REF}." >&2
+    exit 1
+  fi
+  echo "  PASS (kustomize sibling replicas: 1)"
+else
+  echo "  SKIP (kustomize sibling not present — Helm-rendered Deployment already gated above)"
+fi
+
+echo "[api-single-writer-dr] Case 5: bootstrap-kit slot 13 keeps the G2 (#2574) secondary-CP suspend gate"
+# The primary-region-only decision has a second leg: bp-catalyst-platform must
+# not install on secondary CPs. Assert the SECONDARY_HR_SUSPEND substitution is
+# still wired in the bootstrap-kit slot (repo-relative; skip when the test runs
+# from a packaged chart where the kit is out of tree).
+KIT_SLOT="$(cd "$CHART_DIR" && git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$KIT_SLOT" ] && [ -f "$KIT_SLOT/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml" ]; then
+  if ! grep -qE 'suspend:[[:space:]]*\$\{SECONDARY_HR_SUSPEND' "$KIT_SLOT/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml"; then
+    echo "FAIL: bootstrap-kit slot 13 lost the SECONDARY_HR_SUSPEND suspend gate (G2 #2574) —" >&2
+    echo "      bp-catalyst-platform would install a second full control plane on the secondary" >&2
+    echo "      CP (duplicate singleton loops + forked store). See ${DOC_REF}." >&2
+    exit 1
+  fi
+  echo "  PASS (slot 13 suspend: \${SECONDARY_HR_SUSPEND} present)"
+else
+  echo "  SKIP (bootstrap-kit not in tree — packaged-chart run)"
+fi
+
+echo "[api-single-writer-dr] ALL PASS — control-plane DR contract intact (404-during-outage → 200-on-failback is deliberate, ${DOC_REF})"


### PR DESCRIPTION
## Decision: document + gate the control-plane DR contract (HA deferred with reason)

Live-confirmed on hw277 G12 (2026-07-19, dep 1708c340ffc0e3f2): during a region-a kill the gateway/ELB fails over correctly (#5246 — region-b envoy answers, `HTTP 404` with `server: envoy`), but console/api/marketplace are down for the outage window because catalyst-api is primary-region-only.

### Why not an HA replica (investigated first)

The single-region pin is a **deliberate design decided twice, independently**:

1. **G2 (#2574)** — bootstrap-kit slot 13 (`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`) renders `suspend: ${SECONDARY_HR_SUSPEND}` = `true` on every secondary CP: the Sovereign control plane belongs to the primary region.
2. **Chart design** — `products/catalyst/chart/templates/api-deployment.yaml` pins `replicas: 1` + `strategy: Recreate` because both PVCs (`catalyst-api-deployments`, `catalyst-api-cache`) are **RWO EVS** volumes whose PVs carry zone-scoped nodeAffinity (`topology.evs.csi.huaweicloud.com/zone`).

A region-b warm replica is not a replica-count bump:
- the RWO EVS volume **cannot attach cross-region** (zone-scoped PV nodeAffinity), so a region-b pod can never mount the deployment store;
- an independent region-b PVC would **fork the flat-file deployment/tofu store** — split-brain over infrastructure truth (double-provision / mis-wipe hazards) with no leader election anywhere in `internal/store`;
- catalyst-api runs in-process singleton loops (phase-1 watch, deploy reconciler, cutover driver) that assume exactly one instance.

Proper HA = persistence redesign (deployment store onto a DR-replicated database + leader election for the singleton loops). Deferred with that reason; this PR encodes today's behavior as a deliberate, tested contract instead.

### What shipped

- **docs/DOD.md §6** — new "Service-plane contract during the kill — control-plane availability" section: `404`-with-`server: envoy` during outage → `200` on failback is the **PASS** signature; whole-outage timeout/black-hole = **FAIL** (#5244 shape). D31 needs no console (failover is machine-driven); sovereign-admin observes via kubectl against the surviving region.
- **docs/ARCHITECTURE.md §10.7** — control-plane DR posture paragraph.
- **`products/catalyst/chart/tests/api-single-writer-dr-contract.sh`** — CI gate (picked up by blueprint-release "Run chart integration tests"): asserts rendered `replicas: 1`, `strategy: Recreate`, both PVCs RWO, kustomize sibling `replicas: 1`, and the G2 `SECONDARY_HR_SUSPEND` gate on slot 13. Verified to FAIL on `replicas: 2` and RWX mutations; all 5 cases PASS on HEAD.
- **bp-catalyst-platform `1.4.1179` → `1.4.1180`** + bootstrap-kit slot-13 pin lockstep (no template change — test + changelog only).

### Verification

- `bash tests/api-single-writer-dr-contract.sh` — 5/5 PASS; mutation tests (replicas=2, RWX) both exit 1.
- All 6 `products/catalyst/chart/tests/*.sh` PASS; `helm lint` clean.
- `scripts/check-bootstrap-kit-pin-sync.sh` PASS (66 pairs); `scripts/check-catalog-seed-lockstep.sh` PASS (68 checked).

Refs #5267 #5246 #4275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
