### PR TITLE
fix(#5270): adoption endpoints use the real HCS region, not the VPC-mimic pseudo-region

### DIFF
--- a/.github/workflows/check-adoption-endpoint-region.yaml
+++ b/.github/workflows/check-adoption-endpoint-region.yaml
@@ -1,0 +1,56 @@
+name: check — adoption endpoints use the real HCS region (#5270)
+
+# Permanent guard that the Crossplane cloudadoption module composes its
+# Huawei API endpoint hosts from the REAL HCS region, never the kom4dc
+# 2-VPC-mimic pseudo-region (me-east-215-a / -b).
+#
+# The mimic pseudo-region is the correct Kubernetes-side identity
+# (placement/labels/region-affinity) but has NO API DNS — the -a/-b
+# endpoint hosts are NXDOMAIN while the real region resolves. When the
+# adoption Workspaces inherited the claim's pseudo-region into their
+# endpoint URLs, 16/24 adoptions could never Observe (live-proven hw278,
+# 2026-07-19, UAT rows 206/207/239). Chart 1.3.4 maps mimic->real via
+# `local.hw_api_region`; scripts/check-adoption-endpoint-region.sh
+# asserts the mapping three ways: structural (rendered endpoints use
+# hw_api_region), hermetic (the shipped expression evaluated with the
+# real tofu runtime across mimic/real/default inputs), and a full-module
+# `tofu validate` (kills the #4739 single-line-block syntax class).
+#
+# Per docs/PRINCIPLES.md #4a, this workflow renders + evaluates templates
+# locally — it does not deploy anything or call cloud APIs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/crossplane-claims/**'
+      - 'scripts/check-adoption-endpoint-region.sh'
+      - '.github/workflows/check-adoption-endpoint-region.yaml'
+  pull_request:
+    paths:
+      - 'platform/crossplane-claims/**'
+      - 'scripts/check-adoption-endpoint-region.sh'
+      - '.github/workflows/check-adoption-endpoint-region.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  adoption-endpoint-region:
+    name: Reject mimic pseudo-region in adoption endpoint hosts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run adoption endpoint-region guard
+        run: bash scripts/check-adoption-endpoint-region.sh

--- a/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
+++ b/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
@@ -70,7 +70,11 @@ spec:
       # is replaced by a plain namespaced CRD reconciled by the
       # catalyst-useraccess-controller. Removes the retired legacy
       # Composition + the `userAccess.compositionEnabled` toggle.
-      version: 1.3.3
+      # 1.3.4 (#5270): cloudadoption Huawei endpoint hosts use the real HCS
+      # region — the kom4dc 2-VPC-mimic pseudo-region suffix (-a/-b) is
+      # stripped for the API host only (the me-east-215-a/-b hosts are
+      # NXDOMAIN; 16/24 adoptions never Observed on hw278).
+      version: 1.3.4
       sourceRef:
         kind: HelmRepository
         name: bp-crossplane-claims

--- a/platform/crossplane-claims/blueprint.yaml
+++ b/platform/crossplane-claims/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.3.3
+  version: 1.3.4
   card:
     title: crossplane-claims
     summary: |

--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -23,7 +23,14 @@ name: bp-crossplane-claims
 # CloudAdoption CRs at Ready=False. The `userAccess.compositionEnabled`
 # value is removed (no Composition remains to enable).
 # 1.3.1 (#4739): cloudadoption Composition Workspace GVK tf.upbound.io -> opentofu.upbound.io (matches the installed provider-opentofu; tf.upbound.io is the terraform provider group, unregistered here). Fixes CloudAdoption never-Ready + empty `kubectl get managed` (UAT 206/207/239).
-version: 1.3.3
+# 1.3.4 (#5270): cloudadoption module Huawei endpoint hosts use the REAL
+# HCS region — new local hw_api_region strips the kom4dc 2-VPC-mimic
+# pseudo-region suffix (me-east-215-a/-b -> me-east-215). The mimic hosts
+# have no API DNS (NXDOMAIN), so 16/24 adoptions never Observed on hw278.
+# Claim region (placement/labels) is untouched; a real non-mimic region
+# passes through unchanged. New module output hw_api_region feeds the
+# hermetic CI evaluation (scripts/check-adoption-endpoint-region.sh).
+version: 1.3.4
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -175,6 +175,12 @@ spec:
               # / HW_PROJECT_ID natively. region falls back to HW_REGION_NAME
               # for the var-empty path, but the endpoints below need the
               # literal region string, so we coalesce it locally.
+              # #5270: the endpoint HOSTS use local.hw_api_region — the REAL
+              # HCS region — never local.hw_region (the claim's region, which
+              # on a kom4dc 2-VPC mimic is the pseudo-region me-east-215-a /
+              # -b with NO API DNS; see the locals block). `region` keeps the
+              # claim's value: the endpoints map covers every service this
+              # module dials, so no host is ever derived from `region`.
               provider "huaweicloud" {
                 region     = local.hw_region
                 access_key = var.huawei_access_key != "" ? var.huawei_access_key : null
@@ -182,10 +188,10 @@ spec:
                 project_id = var.huawei_project_id != "" ? var.huawei_project_id : null
                 insecure   = tobool(var.huawei_insecure)
                 endpoints = {
-                  iam = "https://iam.${local.hw_region}.kom4dc.nationalcloud.om"
-                  ecs = "https://ecs.${local.hw_region}.kom4dc.nationalcloud.om"
-                  vpc = "https://vpc.${local.hw_region}.kom4dc.nationalcloud.om"
-                  elb = "https://elb.${local.hw_region}.kom4dc.nationalcloud.om"
+                  iam = "https://iam.${local.hw_api_region}.kom4dc.nationalcloud.om"
+                  ecs = "https://ecs.${local.hw_api_region}.kom4dc.nationalcloud.om"
+                  vpc = "https://vpc.${local.hw_api_region}.kom4dc.nationalcloud.om"
+                  elb = "https://elb.${local.hw_api_region}.kom4dc.nationalcloud.om"
                 }
               }
 
@@ -233,6 +239,19 @@ spec:
                 # for the var-empty path, but endpoints are string-built so
                 # they always use this local.
                 hw_region = var.huawei_region != "" ? var.huawei_region : "me-east-215"
+                # #5270: kom4dc single-region 2-VPC mimic — the claim carries
+                # the PSEUDO-region (me-east-215-a / -b), correct for
+                # placement/labels/region-affinity, but HCS publishes API DNS
+                # ONLY for the real region: ecs.me-east-215.kom4dc.
+                # nationalcloud.om resolves (212.72.2.97) while the -a/-b
+                # hosts are NXDOMAIN (live-proven hw278: 16/24 adoptions
+                # never Observed, UAT rows 206/207/239). Map mimic -> real
+                # for the ENDPOINT host only: strip a trailing -a/-b when it
+                # follows a digit-ending base (the mimic shape
+                # "<real-region>-a|b"). Every real HCS/Huawei region id ends
+                # in a digit (me-east-215, ae-ad-1), so a real region never
+                # matches and passes through unchanged.
+                hw_api_region = try(regex("^(.+\\d)-[ab]$", local.hw_region)[0], local.hw_region)
                 observed_id = coalesce(
                   try(data.huaweicloud_elb_loadbalancers.hw[0].loadbalancers[0].id, ""),
                   try(data.huaweicloud_compute_instance.hw[0].id, ""),
@@ -273,6 +292,10 @@ spec:
               output "observed_id"      { value = local.observed_id }
               output "observed_address" { value = local.observed_address }
               output "adopted"          { value = local.observed_id == var.resource_id }
+              # #5270: surfaced for debuggability (status.atProvider.outputs)
+              # + the hermetic CI evaluation of the mimic->real mapping
+              # (scripts/check-adoption-endpoint-region.sh).
+              output "hw_api_region"    { value = local.hw_api_region }
       patches:
         # ── identity / external-name binding ─────────────────────────
         - fromFieldPath: spec.parameters.resourceId

--- a/products/catalyst/bootstrap/api/internal/provisioner/adoption_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/adoption_test.go
@@ -143,6 +143,32 @@ func TestGenerateAdoptionClaims_hw173_RealELB(t *testing.T) {
 	}
 }
 
+// #5270 seam contract: on a kom4dc 2-VPC mimic the claim's region IS the
+// pseudo-region (me-east-215-a / -b) — that value is the Kubernetes-side
+// placement/label/region-affinity identity and the seeder must pass it
+// through VERBATIM. The mimic->real mapping (me-east-215-a -> me-east-215)
+// happens ONLY where the API endpoint host is composed: the cloudadoption
+// module's hw_api_region local (platform/crossplane-claims chart 1.3.4,
+// guarded by scripts/check-adoption-endpoint-region.sh). Stripping the
+// suffix HERE would erase the claim's placement identity — this test pins
+// the seam so #5270 is never "re-fixed" on the wrong side.
+func TestGenerateAdoptionClaims_MimicRegionKeptOnClaim(t *testing.T) {
+	out, err := GenerateAdoptionClaims([]byte(hw173StateFixture), "hw278.omani.works", "huawei", "me-east-215-a")
+	if err != nil {
+		t.Fatalf("GenerateAdoptionClaims: %v", err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, "region: me-east-215-a") {
+		t.Errorf("claim must keep the mimic pseudo-region verbatim (placement/labels contract); got:\n%s", got)
+	}
+	// Every claim carries the mimic region — none may be silently mapped
+	// to the real region by the seeder.
+	if strings.Contains(got, "region: me-east-215\n") {
+		t.Errorf("seeder must NOT strip the mimic -a suffix — endpoint mapping lives in the cloudadoption module, not the claim")
+	}
+}
+
 func TestGenerateAdoptionClaims_Deterministic(t *testing.T) {
 	a, _ := GenerateAdoptionClaims([]byte(hw173StateFixture), "hw173.omani.works", "huawei", "me-east-215")
 	b, _ := GenerateAdoptionClaims([]byte(hw173StateFixture), "hw173.omani.works", "huawei", "me-east-215")

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3986,7 +3986,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.3.3"
+  version: "1.3.4"
   visibility: unlisted
   card:
     title: "Crossplane Claims"
@@ -4003,7 +4003,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-crossplane-claims
-    version: "1.3.3"
+    version: "1.3.4"
   topology:
     supported:
       - singleton

--- a/scripts/check-adoption-endpoint-region.sh
+++ b/scripts/check-adoption-endpoint-region.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# check-adoption-endpoint-region.sh — CI guard that the Crossplane
+# cloudadoption module composes its Huawei API endpoint hosts from the
+# REAL HCS region, never the kom4dc 2-VPC-mimic pseudo-region.
+#
+# History (#5270, the class this guard kills): kom4dc (single-region HCS)
+# mimics a 2-region topology with two isolated VPCs whose Kubernetes-side
+# region identity is the PSEUDO-region `me-east-215-a` / `me-east-215-b`.
+# That value is correct for placement/labels/region-affinity — but HCS
+# publishes API DNS ONLY for the real region:
+#   {iam,ecs,vpc,elb}.me-east-215.kom4dc.nationalcloud.om   -> 212.72.2.97
+#   {iam,ecs,vpc,elb}.me-east-215-a.kom4dc.nationalcloud.om -> NXDOMAIN
+# The adoption Workspaces inherited the claim's pseudo-region into their
+# endpoint URLs, so 16/24 adoptions could never Observe (live-proven
+# hw278, 2026-07-19, UAT rows 206/207/239). Chart 1.3.4 maps mimic->real
+# via `local.hw_api_region` (strip a trailing -a/-b after a digit-ending
+# base) and builds every endpoint host from it.
+#
+# Phase 1 (structural) — render the chart, extract the inline OpenTofu
+#   module from the cloudadoption Composition, assert every huaweicloud
+#   endpoint host is built from `local.hw_api_region` (and none from
+#   `local.hw_region`), and that the hw_api_region local + output exist.
+# Phase 2 (hermetic evaluation) — lift the EXACT hw_region/hw_api_region
+#   expressions out of the rendered module into a minimal provider-less
+#   OpenTofu config and evaluate them with the real tofu runtime, offline:
+#     me-east-215-a -> me-east-215     (mimic zone a)
+#     me-east-215-b -> me-east-215     (mimic zone b)
+#     me-east-215   -> me-east-215     (real region — unchanged)
+#     ae-ad-1       -> ae-ad-1         (real non-mimic region — unchanged)
+#     ""            -> me-east-215     (var-empty default path)
+#   This evaluates the shipped expression itself, not a copy — if the
+#   locals are renamed/moved the extraction fails loudly (exit 2).
+# Phase 3 (full-module validate, network) — `tofu init` + `tofu validate`
+#   the complete extracted module (downloads the huaweicloud + hcloud
+#   providers). Kills the #4739 class (OpenTofu rejecting single-line
+#   multi-argument blocks) that a YAML-only lint can never see.
+#   Skippable for offline runs: OFFLINE=1 ./scripts/check-adoption-endpoint-region.sh
+#
+# Usage:  scripts/check-adoption-endpoint-region.sh
+# Needs:  helm, yq (v4), tofu
+# Exit:   0 = clean, 1 = a regression, 2 = setup/extraction error.
+
+set -euo pipefail
+
+ROOT="${ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CHART="${ROOT}/platform/crossplane-claims/chart"
+COMPOSITION="opentofu-cloud-adoption.compose.openova.io"
+
+for tool in helm yq tofu; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "ERROR: ${tool} not installed" >&2; exit 2; }
+done
+[ -d "${CHART}" ] || { echo "ERROR: chart not found at ${CHART}" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+EXIT=0
+fail() {
+  echo "FAIL: $1" >&2
+  EXIT=1
+}
+
+# ─── Phase 1 — render + structural assertions ────────────────────────────
+echo "== Phase 1: render chart + extract the cloudadoption inline module =="
+helm template adoption-region-check "${CHART}" > "${WORK}/rendered.yaml"
+
+yq ea "select(.kind == \"Composition\" and .metadata.name == \"${COMPOSITION}\") \
+  | .spec.resources[] | select(.name == \"adoption-workspace\") \
+  | .base.spec.forProvider.module" "${WORK}/rendered.yaml" > "${WORK}/module.tf"
+
+if [ ! -s "${WORK}/module.tf" ] || [ "$(head -c4 "${WORK}/module.tf")" = "null" ]; then
+  echo "ERROR: could not extract the inline module from Composition ${COMPOSITION}" >&2
+  exit 2
+fi
+
+for svc in iam ecs vpc elb; do
+  if ! grep -Eq "${svc} = \"https://${svc}\.\\\$\{local\.hw_api_region\}\.kom4dc\.nationalcloud\.om\"" "${WORK}/module.tf"; then
+    fail "endpoint host for '${svc}' is not built from local.hw_api_region (#5270 regression)"
+  fi
+done
+if grep -E '\.\$\{local\.hw_region\}\.' "${WORK}/module.tf" | grep -q .; then
+  fail "an endpoint host is built from local.hw_region (the claim/mimic region) — must use local.hw_api_region"
+fi
+grep -Eq '^\s*hw_api_region\s+=' "${WORK}/module.tf" \
+  || fail "module no longer defines the hw_api_region local"
+grep -Eq '^output "hw_api_region"' "${WORK}/module.tf" \
+  || fail "module no longer exposes the hw_api_region output (Phase-2 hook + live debuggability)"
+
+# ─── Phase 2 — hermetic evaluation of the shipped expressions ────────────
+echo "== Phase 2: evaluate the mimic->real region mapping with tofu (offline) =="
+mkdir -p "${WORK}/eval"
+HW_REGION_LINE="$(grep -E '^\s*hw_region\s+=' "${WORK}/module.tf" || true)"
+HW_API_REGION_LINE="$(grep -E '^\s*hw_api_region\s+=' "${WORK}/module.tf" || true)"
+if [ -z "${HW_REGION_LINE}" ] || [ -z "${HW_API_REGION_LINE}" ]; then
+  echo "ERROR: could not extract the hw_region/hw_api_region locals from the rendered module" >&2
+  exit 2
+fi
+{
+  echo 'variable "huawei_region" { type = string }'
+  echo 'locals {'
+  echo "${HW_REGION_LINE}"
+  echo "${HW_API_REGION_LINE}"
+  echo '}'
+  echo 'output "hw_api_region" { value = local.hw_api_region }'
+} > "${WORK}/eval/main.tf"
+
+( cd "${WORK}/eval" && tofu init -backend=false -input=false >/dev/null )
+
+check_case() {
+  local input="$1" want="$2" got
+  ( cd "${WORK}/eval" && tofu apply -auto-approve -input=false -var "huawei_region=${input}" >/dev/null )
+  got="$(cd "${WORK}/eval" && tofu output -raw hw_api_region)"
+  if [ "${got}" = "${want}" ]; then
+    echo "  PASS  huawei_region='${input}' -> '${got}'"
+  else
+    fail "huawei_region='${input}' -> '${got}' (want '${want}')"
+  fi
+}
+
+check_case "me-east-215-a" "me-east-215"   # kom4dc mimic zone a
+check_case "me-east-215-b" "me-east-215"   # kom4dc mimic zone b
+check_case "me-east-215"   "me-east-215"   # real region — pass-through
+check_case "ae-ad-1"       "ae-ad-1"       # real non-mimic region — pass-through
+check_case ""              "me-east-215"   # var-empty default path
+
+# ─── Phase 3 — full-module validate (needs provider downloads) ───────────
+if [ "${OFFLINE:-0}" = "1" ]; then
+  echo "== Phase 3: SKIPPED (OFFLINE=1) =="
+else
+  echo "== Phase 3: tofu validate the complete inline module =="
+  mkdir -p "${WORK}/full"
+  cp "${WORK}/module.tf" "${WORK}/full/main.tf"
+  ( cd "${WORK}/full" && tofu init -backend=false -input=false >/dev/null && tofu validate ) \
+    || fail "full-module tofu validate failed (#4739 class: module syntax broken)"
+fi
+
+if [ "${EXIT}" -eq 0 ]; then
+  echo "OK: adoption endpoints are composed from the real HCS region (mimic -a/-b stripped, real regions untouched)."
+fi
+exit "${EXIT}"


### PR DESCRIPTION
Refs #5270 #3987

## Root cause (live-proven hw278, dep b27c7e204802ed7f, 2026-07-19)

The cloudadoption Composition's inline OpenTofu module built every Huawei API endpoint host from `local.hw_region` — the claim's `spec.parameters.region`, which on a kom4dc single-region 2-VPC mimic is the PSEUDO-region `me-east-215-a` / `-b`. HCS publishes API DNS only for the real region: `{iam,ecs,vpc,elb}.me-east-215.kom4dc.nationalcloud.om` resolve (212.72.2.97) while the `-a`/`-b` hosts are NXDOMAIN. Result: 16/24 adopt-* Workspaces (all server/loadbalancer/network kinds) hard-failed at `dial tcp: lookup {ecs,elb,vpc}.me-east-215-a...: no such host` and never Observed (UAT rows 206/207/239). The provisioner itself already dials the real region (`products/catalyst/bootstrap/api/internal/providers/huawei/provider.go:129`); only the adoption endpoint composition carried the mimic suffix.

## Fix — `platform/crossplane-claims` chart 1.3.4

- New module local (the region-mapping helper), applied at endpoint composition only:
  ```hcl
  hw_api_region = try(regex("^(.+\\d)-[ab]$", local.hw_region)[0], local.hw_region)
  ```
  Strips a trailing `-a`/`-b` ONLY when it follows a digit-ending base — exactly the kom4dc mimic shape `<real-region>-a|b`. Every real HCS/Huawei region id ends in a digit (`me-east-215`, `ae-ad-1`), so on a REAL multi-region HCS the region passes through unchanged.
- All four `endpoints` hosts (`iam`/`ecs`/`vpc`/`elb`) now use `local.hw_api_region`.
- The claim's region, the Workspace `huawei_region` var, and the provider `region` argument keep the mimic value — placement/labels/region-affinity are untouched (the endpoints map covers every service the module dials, so no host is ever derived from `region`).
- New `output "hw_api_region"` for live debuggability (`status.atProvider.outputs`) and the CI evaluation below.
- Lockstep bump: `chart/Chart.yaml` + `blueprint.yaml` + `clusters/_template/bootstrap-kit/14-crossplane-claims.yaml` → 1.3.4 (`scripts/check-bootstrap-kit-pin-sync.sh` PASS, 66 pairs).

## Seam contract pinned in Go

`TestGenerateAdoptionClaims_MimicRegionKeptOnClaim` (bootstrap api `internal/provisioner`) asserts the seeder passes the mimic region through VERBATIM into `spec.parameters.region` — the mapping lives ONLY at endpoint composition, so #5270 can never be "re-fixed" on the wrong side (which would erase the claim's placement identity).

## New CI guard — `scripts/check-adoption-endpoint-region.sh` (+ workflow)

- **Phase 1 (structural)**: `helm template` → extract the inline module from the rendered Composition → assert every endpoint host is built from `local.hw_api_region` and none from `local.hw_region`.
- **Phase 2 (hermetic evaluation)**: lifts the EXACT shipped `hw_region`/`hw_api_region` expressions into a provider-less OpenTofu config and evaluates them with the real `tofu` runtime, offline:
  - `me-east-215-a` → `me-east-215` PASS
  - `me-east-215-b` → `me-east-215` PASS
  - `me-east-215` → `me-east-215` PASS (real region unchanged)
  - `ae-ad-1` → `ae-ad-1` PASS (real non-mimic region unchanged)
  - `""` → `me-east-215` PASS (var-empty default)
- **Phase 3**: full-module `tofu init` + `tofu validate` (kills the #4739 single-line-block class that YAML lint can't see). `Success! The configuration is valid.`
- Negative-tested: the guard run against the pre-fix chart fails with 7 explicit FAILs.

## Verification run locally

- `bash scripts/check-adoption-endpoint-region.sh` → all phases green (output above).
- `go build ./...` + `go test ./... -count=1` in `products/catalyst/bootstrap/api` → rc=0, zero failures.
- `scripts/check-bootstrap-kit-pin-sync.sh` PASS, `scripts/check-crossplane-gvk.sh` PASS, `scripts/check-no-banned-words.sh` PASS.
- GHCR: latest published tag is 1.3.3 → 1.3.4 free, no version collision.

Not in this PR (per #5270 secondary observations): the P2 hollow eip/subnet adoptions (no real data sources) and the P3 `adoption-placeholder` GC — noted on the issue for the follow-up wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
