### PR TITLE
fix(#5269): phase1 watch re-censuses on a ticker + heartbeat — a quiesced informer can no longer strand a converged prov

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -191,6 +191,14 @@ type Handler struct {
 	phase1LatePollTimeout  time.Duration
 	phase1LatePollInterval time.Duration
 
+	// phase1RecensusInterval — test-only override for the informer-
+	// independent periodic re-census cadence (#5269). Zero means "fall
+	// back to env var → helmwatch.DefaultRecensusInterval (45s)";
+	// tests inject a tiny value (e.g. 50ms) so the ticker-driven
+	// conclusion path can be exercised in milliseconds. Production
+	// reads CATALYST_PHASE1_RECENSUS_INTERVAL on every Pod start.
+	phase1RecensusInterval time.Duration
+
 	// phase1Reachability — test-only override for the pre-flight
 	// apiserver reachability probe (issue #923). Production uses
 	// helmwatch.NewReachabilityProbeFromKubeconfig (discovery client

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -105,6 +105,19 @@ const phase1LatePollIntervalEnv = "CATALYST_PHASE1_LATE_POLL_INTERVAL"
 // reads this on every Pod start.
 const phase1ReachabilityBudgetEnv = "CATALYST_PHASE1_REACHABILITY_BUDGET"
 
+// phase1RecensusIntervalEnv — env var override for the cadence of the
+// informer-independent periodic re-census (#5269). Every interval the
+// Phase-1 watch Lists bp-* HelmReleases directly against the Sovereign
+// apiserver, re-runs the same sentinel-gated OutcomeReady decision the
+// informer path uses, and emits one structured heartbeat log line — so
+// a quiesced/hung informer event stream (the hw278 wedge: sentinel
+// Ready=True for 66min, watch never concluded, whole prov stranded at
+// phase1-watching ~80min with handover/mesh/cutover all gated behind
+// it) can no longer strand a converged prov, and a future wedge is
+// visible in the catalyst-api logs within one interval instead of
+// silent. Default helmwatch.DefaultRecensusInterval (45s).
+const phase1RecensusIntervalEnv = "CATALYST_PHASE1_RECENSUS_INTERVAL"
+
 // kubeconfigArrivalTimeoutEnv — how long runPhase1Watch waits for the
 // cloud-init PUT to land /var/lib/catalyst/kubeconfigs/<id>.yaml on
 // disk before giving up with OutcomeKubeconfigMissing. Cloud-init
@@ -430,6 +443,13 @@ func (h *Handler) phase1WatchConfigForDeployment(dep *Deployment, kubeconfig str
 		}
 	}
 
+	// #5269 — informer-independent re-census cadence. Same
+	// field-override-beats-env precedence as every other Phase-1 knob.
+	recensusInterval := h.phase1RecensusInterval
+	if recensusInterval == 0 {
+		recensusInterval = helmwatch.CompileRecensusInterval(envOrEmpty(phase1RecensusIntervalEnv))
+	}
+
 	// #4746 — the component whose terminal-install gates OutcomeReady.
 	// Base value is the Handler field (production New() sets it to
 	// catalyst-platform; tests leave it empty → gate off). An explicitly
@@ -450,6 +470,15 @@ func (h *Handler) phase1WatchConfigForDeployment(dep *Deployment, kubeconfig str
 		LatePollInterval:          latePollInterval,
 		ReachabilityOverallBudget: reachabilityBudget,
 		ReadySentinelComponent:    readySentinel,
+		RecensusInterval:          recensusInterval,
+		// OnHeartbeat — one structured log line per re-census
+		// evaluation cycle (#5269): dep id, HR ready count, sentinel
+		// state, all-terminal verdict, informer-event age. This is the
+		// forensic surface the hw278 wedge lacked — 80 minutes of
+		// silence between "informer synced" and the operator's manual
+		// rollout-restart. Secondary-region watchers re-wire this with
+		// a region tag in spawnSecondaryRegionWatchers.
+		OnHeartbeat: h.phase1HeartbeatLogger(dep, ""),
 		// OnSubstate — issue #923. The watcher fires this on every
 		// Phase-1 substate transition (reconnecting → watching). We
 		// stamp Result.Phase1Substate under dep.mu so a /deployments/
@@ -510,6 +539,45 @@ func (h *Handler) setPhase1Substate(dep *Deployment, substate string) {
 	dep.Result.Phase1Substate = substate
 	dep.mu.Unlock()
 	h.persistDeployment(dep)
+}
+
+// phase1HeartbeatLogger returns the helmwatch.Config.OnHeartbeat
+// callback for a deployment's Phase-1 watch (#5269): one structured
+// log line per re-census evaluation cycle so a wedged watch is visible
+// in the catalyst-api logs within one interval instead of silently
+// idling to WatchTimeout. region is empty for the primary watch and
+// the region key for secondary-region watchers (whose heartbeats carry
+// no sentinel — the gate is a primary-region concept, see
+// spawnSecondaryRegionWatchers).
+//
+// Level policy: Info for a healthy cycle; Warn when the cycle's direct
+// List failed (transient apiserver blip — no census update applied) or
+// when the informer event stream has gone stale (the hw278 signature —
+// the re-census is then the only thing driving the conclusion).
+func (h *Handler) phase1HeartbeatLogger(dep *Deployment, region string) func(helmwatch.Heartbeat) {
+	return func(hb helmwatch.Heartbeat) {
+		args := []any{
+			"id", dep.ID,
+			"observedHRs", hb.ObservedHRs,
+			"readyHRs", hb.ReadyHRs,
+			"failedHRs", hb.FailedHRs,
+			"sentinel", hb.SentinelState,
+			"allTerminal", hb.AllTerminal,
+			"informerEventAge", hb.InformerEventAge.Round(time.Second).String(),
+		}
+		if region != "" {
+			args = append(args, "region", region)
+		}
+		switch {
+		case hb.ListError != "":
+			args = append(args, "listErr", hb.ListError)
+			h.log.Warn("phase1 watch heartbeat: re-census List failed — no census update this cycle (#5269)", args...)
+		case hb.InformerStale:
+			h.log.Warn("phase1 watch heartbeat: informer event stream stale — ticker re-census is driving the readiness decision (#5269)", args...)
+		default:
+			h.log.Info("phase1 watch heartbeat (#5269)", args...)
+		}
+	}
 }
 
 // spawnSecondaryRegionWatchers reads `<kubeconfigsDir>/<id>-*.yaml`
@@ -628,6 +696,10 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 			// converged secondary self-terminate cleanly instead of idling until
 			// stopSecondaries cancels it.
 			cfg.ReadySentinelComponent = ""
+			// #5269 — region-tag the heartbeat so the per-region
+			// re-census lines are distinguishable from the primary's
+			// in the catalyst-api log stream.
+			cfg.OnHeartbeat = h.phase1HeartbeatLogger(dep, region)
 			watcher, err := helmwatch.NewWatcher(cfg, func(ev provisioner.Event) {
 				// Region-tag the component events so the SSE consumer
 				// can group them per region. Bare bp-* names from

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
@@ -1380,6 +1380,71 @@ func TestPhase1WatchConfig_ReachabilityFieldOverrideBeatsEnv(t *testing.T) {
 	}
 }
 
+// TestPhase1WatchConfig_RecensusIntervalEnvVarOverride proves the
+// CATALYST_PHASE1_RECENSUS_INTERVAL env var parses through
+// phase1WatchConfigForDeployment (issue #5269) — the operator's only
+// production knob for the informer-independent re-census cadence.
+func TestPhase1WatchConfig_RecensusIntervalEnvVarOverride(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	t.Setenv("CATALYST_PHASE1_RECENSUS_INTERVAL", "90s")
+
+	dep := makeDeploymentWithKubeconfig(t, h, "phase1-recensus-env", "fake-kubeconfig: yaml")
+	cfg := h.phase1WatchConfigForDeployment(dep, "fake-kubeconfig: yaml")
+
+	if cfg.RecensusInterval != 90*time.Second {
+		t.Errorf("RecensusInterval = %v, want 90s (from env)", cfg.RecensusInterval)
+	}
+}
+
+// TestPhase1WatchConfig_RecensusIntervalFieldOverrideBeatsEnv proves
+// the test-injection precedence for the re-census cadence (issue
+// #5269). Mirrors the FieldOverrideBeatsEnv contract for every other
+// Phase-1 knob.
+func TestPhase1WatchConfig_RecensusIntervalFieldOverrideBeatsEnv(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.phase1RecensusInterval = 50 * time.Millisecond
+	t.Setenv("CATALYST_PHASE1_RECENSUS_INTERVAL", "90s")
+
+	dep := makeDeploymentWithKubeconfig(t, h, "phase1-recensus-field", "fake-kubeconfig: yaml")
+	cfg := h.phase1WatchConfigForDeployment(dep, "fake-kubeconfig: yaml")
+
+	if cfg.RecensusInterval != 50*time.Millisecond {
+		t.Errorf("RecensusInterval = %v, want 50ms (handler field override)", cfg.RecensusInterval)
+	}
+}
+
+// TestPhase1WatchConfig_RecensusDefaultAndHeartbeatWired pins the
+// production wiring (#5269): with no env and no field override the
+// re-census cadence falls back to helmwatch.DefaultRecensusInterval,
+// and OnHeartbeat is non-nil — the structured per-cycle log line is
+// what makes a future watch wedge visible within one interval (the
+// hw278 forensic gap was 80 minutes of silence between "informer
+// synced" and the operator's manual rollout-restart). The callback is
+// invoked with a converged-but-stale sample and a List-failed sample
+// to prove both log branches execute without panicking.
+func TestPhase1WatchConfig_RecensusDefaultAndHeartbeatWired(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	t.Setenv("CATALYST_PHASE1_RECENSUS_INTERVAL", "")
+
+	dep := makeDeploymentWithKubeconfig(t, h, "phase1-recensus-default", "fake-kubeconfig: yaml")
+	cfg := h.phase1WatchConfigForDeployment(dep, "fake-kubeconfig: yaml")
+
+	if cfg.RecensusInterval != helmwatch.DefaultRecensusInterval {
+		t.Errorf("RecensusInterval = %v, want helmwatch.DefaultRecensusInterval (%v)", cfg.RecensusInterval, helmwatch.DefaultRecensusInterval)
+	}
+	if cfg.OnHeartbeat == nil {
+		t.Fatalf("OnHeartbeat is nil — the per-cycle heartbeat log line must be wired on the production path (#5269)")
+	}
+	cfg.OnHeartbeat(helmwatch.Heartbeat{
+		ObservedHRs:      66,
+		ReadyHRs:         63,
+		SentinelState:    helmwatch.StateInstalled,
+		InformerEventAge: 75 * time.Minute,
+		InformerStale:    true,
+	})
+	cfg.OnHeartbeat(helmwatch.Heartbeat{ListError: "connection refused"})
+}
+
 // TestRunPhase1Watch_OnSubstate_StampedOntoResult proves the wiring
 // from helmwatch.Watcher.OnSubstate → handler.setPhase1Substate →
 // dep.Result.Phase1Substate (issue #923).

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -218,6 +218,43 @@ const DefaultLatePollTimeout = 10 * time.Minute
 // Operator override: CATALYST_PHASE1_LATE_POLL_INTERVAL.
 const DefaultLatePollInterval = 30 * time.Second
 
+// DefaultRecensusInterval — cadence of the informer-independent
+// periodic re-census (#5269). Every interval the Watch loop performs a
+// direct List of bp-* HelmReleases against the Sovereign apiserver and
+// drives each result through the SAME processEvent census/decision path
+// an informer delta takes — so the terminate-on-all-done gate
+// (allObservedTerminal → OutcomeReady/OutcomeFailed) no longer depends
+// on a live informer event stream.
+//
+// hw278 (#5269, dep b27c7e204802ed7f, 2026-07-19): the per-deployment
+// phase1 watch established its informers ("informer synced helmrelease"
+// logged 20:05Z) then went silent — the sentinel bp-catalyst-platform
+// was Ready=True for 66 minutes, a fresh informer event (nudge) did NOT
+// re-trigger evaluation, and the deployment sat "phase1-watching" for
+// ~80min on a fully-converged region until a catalyst-api
+// rollout-restart re-launched a fresh watch that concluded in seconds.
+// The conclusion machinery was purely informer-event-driven, so a
+// quiesced/hung event stream silently stranded the prov: no handover,
+// no ClusterMesh, region-b wedged pre-mesh. The ticker re-census makes
+// the conclusion poll-robust; the informer remains the low-latency
+// steady-state path.
+//
+// 45s keeps worst-case added conclusion latency under a minute without
+// meaningfully loading the apiserver (one namespaced List per interval).
+// Operator override: CATALYST_PHASE1_RECENSUS_INTERVAL.
+const DefaultRecensusInterval = 45 * time.Second
+
+// staleInformerIntervals — number of re-census intervals without a
+// single informer-delivered event after which the heartbeat flags the
+// informer stale (#5269). A HEALTHY informer redelivers every cached
+// object at least once per Resync (30s default), so on the default
+// 45s re-census cadence 4 silent intervals (~3m) is a positive signal
+// the event stream has quiesced — not a quiet-but-alive cluster. The
+// staleness flag is observability-only: the ticker re-census already
+// drives the conclusion independent of the informer, so a stale stream
+// degrades latency, never correctness.
+const staleInformerIntervals = 4
+
 // DefaultReachabilityProbeTimeout — per-attempt timeout for the
 // pre-flight apiserver reachability probe (issue #923). After a
 // catalyst-api Pod restart, the new Pod's TLS handshake to the
@@ -527,6 +564,64 @@ type Config struct {
 	// notifications (the Watcher still runs the probe, just without
 	// surfacing the field on the deployment record).
 	OnSubstate func(substate string)
+
+	// RecensusInterval — cadence of the informer-independent periodic
+	// re-census (#5269). Every interval the Watch loop Lists bp-*
+	// HelmReleases directly against the apiserver and drives each
+	// result through processEvent, so a quiesced informer event stream
+	// cannot strand a converged prov at "phase1-watching". Defaults to
+	// DefaultRecensusInterval (45s); the catalyst-api wires
+	// CATALYST_PHASE1_RECENSUS_INTERVAL into this. Tests inject a tiny
+	// value (e.g. 50ms) to exercise the ticker path in milliseconds.
+	RecensusInterval time.Duration
+
+	// OnHeartbeat — fired once per re-census evaluation cycle (#5269)
+	// with the cycle's census summary. Production wires this to a
+	// structured h.log line carrying the deployment id, HR ready
+	// count, sentinel state and all-terminal verdict — so a future
+	// watch wedge is visible in the catalyst-api logs within one
+	// interval instead of silently idling to WatchTimeout. Optional;
+	// nil disables heartbeat notifications (the re-census still runs
+	// and still drives the conclusion).
+	OnHeartbeat func(hb Heartbeat)
+}
+
+// Heartbeat is the per-re-census-cycle summary handed to
+// Config.OnHeartbeat (#5269). One is produced per RecensusInterval tick
+// for the lifetime of the watch, BEFORE the cycle's List results are
+// driven through processEvent — so the heartbeat lands even if a
+// downstream emit subscriber wedges, and the log line pinpoints the
+// cycle at which a wedge began.
+type Heartbeat struct {
+	// ObservedHRs — count of distinct bp-* components in the union of
+	// the watcher's accumulated observed set and this cycle's fresh
+	// List.
+	ObservedHRs int
+	// ReadyHRs / FailedHRs — components in StateInstalled /
+	// StateFailed on the merged (accumulated ∪ fresh-List) view.
+	ReadyHRs  int
+	FailedHRs int
+	// SentinelState — the #4746 ready-sentinel's state on the merged
+	// view: a helmwatch State enum, "unobserved" when the sentinel is
+	// armed but not yet present, or "" when the gate is disabled.
+	SentinelState string
+	// AllTerminal — the allObservedTerminal verdict on the merged
+	// view: true means this cycle concludes the watch (OutcomeReady or
+	// OutcomeFailed via the standard classification downstream).
+	AllTerminal bool
+	// InformerEventAge — time since the informer last DELIVERED an
+	// event (initial-sync baseline when none has arrived since). A
+	// healthy informer redelivers at least every Resync (30s), so a
+	// growing age is the quiesced-stream signature.
+	InformerEventAge time.Duration
+	// InformerStale — true once InformerEventAge exceeds
+	// staleInformerIntervals × RecensusInterval. Observability-only:
+	// the ticker re-census drives the conclusion regardless.
+	InformerStale bool
+	// ListError — non-empty when this cycle's direct List failed
+	// (transient apiserver blip); counts then reflect only the
+	// accumulated informer view and no census update was applied.
+	ListError string
 }
 
 func (c *Config) applyDefaults() {
@@ -562,6 +657,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.ReachabilityOverallBudget <= 0 {
 		c.ReachabilityOverallBudget = DefaultReachabilityOverallBudget
+	}
+	if c.RecensusInterval <= 0 {
+		c.RecensusInterval = DefaultRecensusInterval
 	}
 	if c.Sleep == nil {
 		c.Sleep = sleepWithContext
@@ -655,6 +753,22 @@ type Watcher struct {
 	// post-sync stabilisation tick that re-evaluates the gate cannot
 	// double-emit. Mutated under w.mu.
 	readyTransitionEmitted bool
+
+	// lastInformerEventAt — wall-clock instant of the most recent
+	// informer-DELIVERED callback (Add/Update from the event handler,
+	// including Resync redeliveries), baselined at initial-sync time
+	// (#5269). The ticker re-census reads this to compute
+	// Heartbeat.InformerEventAge / InformerStale — a growing age with
+	// a live re-census is the quiesced-informer signature hw278
+	// exhibited. Mutated under w.mu.
+	lastInformerEventAt time.Time
+
+	// staleInformerWarnEmitted — set true once the loud stale-informer
+	// warn event has been dispatched for the CURRENT quiet stretch
+	// (#5269), so a wedged stream warns once instead of every tick.
+	// Reset whenever a non-stale cycle is observed so a later re-wedge
+	// warns again. Mutated under w.mu.
+	staleInformerWarnEmitted bool
 
 	// latePollActive — set true while the watcher is in the
 	// eventual-consistency late-poll mode (issue #910): the all-
@@ -918,9 +1032,11 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
+				w.noteInformerEvent()
 				w.processEvent(obj, terminated, &closeOnce)
 			},
 			UpdateFunc: func(_, obj any) {
+				w.noteInformerEvent()
 				w.processEvent(obj, terminated, &closeOnce)
 			},
 			// DeleteFunc — a HelmRelease being deleted mid-bootstrap
@@ -981,6 +1097,12 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 	// enter the cache. We park the all-terminal check until here.
 	w.mu.Lock()
 	w.informerSynced = true
+	// Baseline the informer-event clock at sync time (#5269) so the
+	// stale-informer detector measures quiet time from a defined
+	// instant — the initial-List Adds fired before this point and a
+	// quiet-but-converged cluster must not trip the stale flag on the
+	// first tick.
+	w.lastInformerEventAt = w.cfg.Now()
 	allTerminalAtSync := allObservedTerminal(w.states, w.observed, w.cfg.MinBootstrapKitHRs, w.firstSeenAt, true, w.cfg.ReadySentinelComponent)
 	w.mu.Unlock()
 
@@ -1023,6 +1145,17 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 	}
 	firstSeenTicker := time.NewTicker(firstSeenCheckInterval)
 	defer firstSeenTicker.Stop()
+
+	// Periodic re-census ticker (#5269) — the informer-independent
+	// conclusion driver. Every RecensusInterval the loop Lists bp-*
+	// HelmReleases directly against the apiserver and drives each
+	// result through the SAME processEvent census/decision path an
+	// informer delta takes, so a quiesced/hung informer event stream
+	// can no longer strand a converged prov: the sentinel-gated
+	// allObservedTerminal decision (#4746 semantics unchanged) is
+	// re-evaluated on the wall clock, not only on event callbacks.
+	recensusTicker := time.NewTicker(w.cfg.RecensusInterval)
+	defer recensusTicker.Stop()
 
 	// Wait for either all-terminal or context done.
 	for {
@@ -1069,8 +1202,201 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 			w.maybeEmitFirstSeenWarn(firstSeenStart)
 			// Loop and keep waiting — first-seen timeout does NOT
 			// terminate the watch.
+
+		case <-recensusTicker.C:
+			// #5269 — informer-independent re-census. Emits the
+			// heartbeat, then feeds the fresh List through
+			// processEvent, which closes `terminated` (via the shared
+			// closeOnce) when the census concludes; the next select
+			// iteration then returns through the standard
+			// <-terminated branch, so classification and the
+			// downstream handover fire exactly once regardless of
+			// whether an informer event or the ticker concluded.
+			w.runTickerRecensus(watchCtx, dyn, terminated, &closeOnce)
 		}
 	}
+}
+
+// noteInformerEvent stamps the informer-event clock (#5269). Called
+// from the informer's Add/Update handlers — including Resync
+// redeliveries — so the ticker re-census can distinguish a healthy
+// quiet cluster (resync keeps the age under Resync) from a quiesced
+// event stream (age grows without bound).
+func (w *Watcher) noteInformerEvent() {
+	w.mu.Lock()
+	w.lastInformerEventAt = w.cfg.Now()
+	w.mu.Unlock()
+}
+
+// runTickerRecensus performs one informer-independent evaluation cycle
+// (#5269): a direct namespaced List of bp-* HelmReleases against the
+// Sovereign apiserver, a heartbeat emit summarising the fresh census,
+// then each listed HR driven through processEvent — the SAME
+// census/decision path an informer delta takes. processEvent dedupes
+// emissions (first-observation / transition only), updates
+// w.states/w.observed, and closes `terminated` when allObservedTerminal
+// is satisfied, so the #4746 sentinel gate and the #5254/#5253
+// downstream semantics are byte-identical between the two drivers.
+//
+// The heartbeat is emitted BEFORE the processEvent feed so the log line
+// lands even if a downstream emit subscriber wedges — the cycle at
+// which a wedge began is then visible in the catalyst-api logs.
+//
+// A List failure (transient apiserver blip) emits a heartbeat carrying
+// the error and applies no census update — the informer path and the
+// next tick are unaffected; a flake can never invent a conclusion.
+func (w *Watcher) runTickerRecensus(watchCtx context.Context, dyn dynamic.Interface, terminated chan struct{}, closeOnce *sync.Once) {
+	// Bound the List so a hung apiserver costs at most one interval,
+	// never stalls the watch loop indefinitely (the production REST
+	// config carries DefaultRESTConfigTimeout too; this is the
+	// belt-and-braces bound for injected clients).
+	listBudget := w.cfg.RecensusInterval
+	if listBudget > DefaultRESTConfigTimeout {
+		listBudget = DefaultRESTConfigTimeout
+	}
+	listCtx, cancel := context.WithTimeout(watchCtx, listBudget)
+	list, err := dyn.Resource(HelmReleaseGVR).Namespace(FluxNamespace).List(listCtx, metav1.ListOptions{})
+	cancel()
+
+	if err != nil {
+		w.emitHeartbeat(w.buildHeartbeat(nil, err))
+		return
+	}
+
+	w.emitHeartbeat(w.buildHeartbeat(list, nil))
+
+	for i := range list.Items {
+		u := &list.Items[i]
+		if !strings.HasPrefix(u.GetName(), "bp-") {
+			continue
+		}
+		w.processEvent(u, terminated, closeOnce)
+	}
+}
+
+// buildHeartbeat computes the per-cycle census summary (#5269) from the
+// fresh List (nil on List failure) merged over the watcher's
+// accumulated state, WITHOUT mutating any watcher state — the real
+// census update happens in the processEvent feed that follows. The
+// merged view means the heartbeat's AllTerminal verdict matches exactly
+// what the processEvent feed is about to decide (the observed set is
+// append-only, so merging fresh states over accumulated ones reproduces
+// the post-feed decision inputs).
+func (w *Watcher) buildHeartbeat(list *unstructured.UnstructuredList, listErr error) Heartbeat {
+	fresh := map[string]string{}
+	if list != nil {
+		for i := range list.Items {
+			u := &list.Items[i]
+			name := u.GetName()
+			if !strings.HasPrefix(name, "bp-") {
+				continue
+			}
+			conds, _ := extractConditions(u)
+			state := DeriveState(conds)
+			// Wave 5.103 (#2447) parity with processEvent: suspended
+			// HRs count as installed.
+			if suspended, ok, _ := unstructured.NestedBool(u.Object, "spec", "suspend"); ok && suspended {
+				state = StateInstalled
+			}
+			fresh[ComponentIDFromHelmRelease(name)] = state
+		}
+	}
+
+	w.mu.Lock()
+	merged := make(map[string]string, len(w.states)+len(fresh))
+	observed := make(map[string]struct{}, len(w.observed)+len(fresh))
+	for k, v := range w.states {
+		merged[k] = v
+	}
+	for k := range w.observed {
+		observed[k] = struct{}{}
+	}
+	for k, v := range fresh {
+		merged[k] = v
+		observed[k] = struct{}{}
+	}
+	firstSeen := w.firstSeenAt
+	if firstSeen.IsZero() && len(fresh) > 0 {
+		// The processEvent feed below is about to stamp firstSeenAt —
+		// mirror that so the verdict matches the imminent decision.
+		firstSeen = w.cfg.Now()
+	}
+	synced := w.informerSynced
+	lastEvent := w.lastInformerEventAt
+	w.mu.Unlock()
+
+	ready, failed := 0, 0
+	for _, s := range merged {
+		switch s {
+		case StateInstalled:
+			ready++
+		case StateFailed:
+			failed++
+		}
+	}
+	sentinelState := ""
+	if w.cfg.ReadySentinelComponent != "" {
+		sentinelState = merged[w.cfg.ReadySentinelComponent]
+		if sentinelState == "" {
+			sentinelState = "unobserved"
+		}
+	}
+	var age time.Duration
+	if !lastEvent.IsZero() {
+		age = w.cfg.Now().Sub(lastEvent)
+	}
+	hb := Heartbeat{
+		ObservedHRs:      len(observed),
+		ReadyHRs:         ready,
+		FailedHRs:        failed,
+		SentinelState:    sentinelState,
+		AllTerminal:      allObservedTerminal(merged, observed, w.cfg.MinBootstrapKitHRs, firstSeen, synced, w.cfg.ReadySentinelComponent),
+		InformerEventAge: age,
+		InformerStale:    !lastEvent.IsZero() && age > time.Duration(staleInformerIntervals)*w.cfg.RecensusInterval,
+	}
+	if listErr != nil {
+		hb.ListError = listErr.Error()
+	}
+	return hb
+}
+
+// emitHeartbeat routes the per-cycle summary to Config.OnHeartbeat and
+// manages the one-shot stale-informer warn (#5269). The warn is a
+// dispatch (SSE + subscribers) so the operator-facing wizard log pane
+// surfaces the quiesced stream, not only the catalyst-api Pod log; it
+// fires once per quiet stretch and re-arms when the stream recovers.
+// Best-effort re-establishment is deliberately NOT attempted here — the
+// ticker re-census already drives the conclusion without the informer,
+// so a rebuild would add teardown/rebuild races for zero correctness
+// gain.
+func (w *Watcher) emitHeartbeat(hb Heartbeat) {
+	if w.cfg.OnHeartbeat != nil {
+		w.cfg.OnHeartbeat(hb)
+	}
+
+	if !hb.InformerStale {
+		w.mu.Lock()
+		w.staleInformerWarnEmitted = false
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Lock()
+	already := w.staleInformerWarnEmitted
+	w.staleInformerWarnEmitted = true
+	w.mu.Unlock()
+	if already {
+		return
+	}
+	w.dispatch(provisioner.Event{
+		Time:  w.cfg.Now().UTC().Format(time.RFC3339),
+		Phase: PhaseComponent,
+		Level: "warn",
+		Message: fmt.Sprintf(
+			"Phase-1 watch: informer event stream has been quiet for %s — the periodic re-census (every %s) is driving the readiness decision, so the watch still concludes; investigate the catalyst-api ↔ Sovereign apiserver watch connection if this persists (#5269).",
+			hb.InformerEventAge.Round(time.Second),
+			w.cfg.RecensusInterval,
+		),
+	})
 }
 
 // hasFailures returns true when at least one component in the state
@@ -2055,6 +2381,21 @@ func CompileLatePollInterval(raw string) time.Duration {
 	d, err := time.ParseDuration(raw)
 	if err != nil || d <= 0 {
 		return DefaultLatePollInterval
+	}
+	return d
+}
+
+// CompileRecensusInterval — env-var parse helper for
+// CATALYST_PHASE1_RECENSUS_INTERVAL. Empty / unparseable /
+// non-positive input yields DefaultRecensusInterval. Issue #5269.
+func CompileRecensusInterval(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultRecensusInterval
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return DefaultRecensusInterval
 	}
 	return d
 }

--- a/products/catalyst/bootstrap/api/internal/helmwatch/recensus_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/recensus_test.go
@@ -1,0 +1,352 @@
+// Tests for the #5269 informer-independent periodic re-census.
+//
+// Root cause the ticker closes: the terminate-on-all-done machinery was
+// purely informer-event-driven — `terminated` is closed only from
+// processEvent, which only ran on informer callbacks. hw278 (dep
+// b27c7e204802ed7f, 2026-07-19) proved a quiesced/hung informer event
+// stream silently strands a converged prov: the sentinel
+// bp-catalyst-platform was Ready=True for 66 minutes, a fresh informer
+// event (nudge) did not re-trigger evaluation, and the deployment sat
+// "phase1-watching" ~80min until a catalyst-api rollout-restart
+// re-launched a fresh watch that concluded in seconds. The re-census
+// ticker drives the SAME processEvent census/decision path from the
+// wall clock via a direct List, so the conclusion no longer depends on
+// a live event stream.
+//
+// These tests prove the behaviours that matter:
+//
+//  1. quiesced informer + sentinel converging later: the ticker List
+//     observes the transition and concludes OutcomeReady — with exactly
+//     ONE "ready for handover" emit (no double-fire of the downstream
+//     handover chain, which keys off Watch returning once).
+//  2. quiesced informer + sentinel never appearing: the ticker must NOT
+//     invent a conclusion — #4746 sentinel semantics are unchanged, the
+//     watch runs to WatchTimeout → OutcomeTimeout; the stale-informer
+//     detector flags the dead stream via the heartbeat + a single loud
+//     warn event.
+//  3. healthy informer racing the ticker: both drivers observing the
+//     same transition dedupe to one emitted transition and one ready
+//     conclusion.
+//
+// The quiesced informer is modelled by prepending a watch reactor that
+// returns a watch.Interface which never delivers — the informer's
+// initial List syncs normally (the hw278 shape: "informer synced
+// helmrelease" logged, then silence), while tracker updates remain
+// visible to the re-census's direct List.
+package helmwatch
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// deadenWatch makes the fake client's WATCH channel permanently silent
+// while leaving LIST untouched: the informer establishes and syncs its
+// initial List, then never receives another event — the hw278 quiesced
+// event stream, reproduced deterministically.
+func deadenWatch(client *dynamicfake.FakeDynamicClient) {
+	client.PrependWatchReactor("*", func(_ clientgotesting.Action) (bool, watch.Interface, error) {
+		return true, watch.NewFake(), nil
+	})
+}
+
+// makeInstallingHelmRelease — Ready=Unknown maps to StateInstalling
+// (non-terminal), so a sentinel seeded with this blocks the census
+// until something observes it flip to Ready=True.
+func makeInstallingHelmRelease(name string) *unstructured.Unstructured {
+	return makeHelmRelease(name, []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionUnknown, Reason: "Progressing", Message: "Helm install in progress"},
+	})
+}
+
+// heartbeatRecorder collects every Heartbeat the watcher emits for
+// assertions, mirroring the event `recorder` idiom.
+type heartbeatRecorder struct {
+	mu  sync.Mutex
+	hbs []Heartbeat
+}
+
+func (h *heartbeatRecorder) record(hb Heartbeat) {
+	h.mu.Lock()
+	h.hbs = append(h.hbs, hb)
+	h.mu.Unlock()
+}
+
+func (h *heartbeatRecorder) snapshot() []Heartbeat {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]Heartbeat, len(h.hbs))
+	copy(out, h.hbs)
+	return out
+}
+
+// countReadyTransitions counts the "Sovereign ready for handover"
+// emits — the double-fire canary: the downstream handover auto-fire
+// keys off Watch returning (once), and the operator-visible ready
+// transition must appear exactly once no matter which driver (informer
+// or ticker) concluded.
+func countReadyTransitions(evs []provisioner.Event) int {
+	n := 0
+	for _, ev := range evs {
+		if strings.Contains(ev.Message, "ready for handover") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestWatch_TickerRecensus_QuiescedInformer_ConcludesReady is the #5269
+// fix proof: the sentinel flips Ready AFTER the informer event stream
+// has gone permanently silent — only the ticker re-census's direct List
+// can observe it. The watch must conclude OutcomeReady (well before
+// WatchTimeout), with the sentinel-gated census intact and exactly one
+// ready emit.
+func TestWatch_TickerRecensus_QuiescedInformer_ConcludesReady(t *testing.T) {
+	scheme := newFakeScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		makeReadyHelmRelease("bp-cilium"),
+		makeInstallingHelmRelease("bp-catalyst-platform"),
+	)
+	deadenWatch(client)
+
+	rec := &recorder{}
+	hbrec := &heartbeatRecorder{}
+	cfg := Config{
+		KubeconfigYAML:         "fake",
+		WatchTimeout:           30 * time.Second, // must NOT be hit — the ticker concludes
+		FirstSeenTimeout:       30 * time.Second,
+		MinBootstrapKitHRs:     2,
+		DynamicFactory:         fakeFactory(client),
+		ReadySentinelComponent: "catalyst-platform",
+		RecensusInterval:       50 * time.Millisecond,
+		OnHeartbeat:            hbrec.record,
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	// The sentinel converges 250ms after start. The informer never
+	// hears about it (dead watch channel) — only the re-census List
+	// can. Pre-#5269 this fixture idles to WatchTimeout.
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		updateHR(t, client, "bp-catalyst-platform", []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "ReconciliationSucceeded", Message: "Helm install succeeded"},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	final, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got, want := w.Outcome(), OutcomeReady; got != want {
+		t.Errorf("Outcome() = %q, want %q — the ticker re-census must conclude a converged prov even with a dead informer event stream (#5269)", got, want)
+	}
+	if final["catalyst-platform"] != StateInstalled {
+		t.Errorf("final[catalyst-platform] = %q, want %q", final["catalyst-platform"], StateInstalled)
+	}
+	if final["cilium"] != StateInstalled {
+		t.Errorf("final[cilium] = %q, want %q", final["cilium"], StateInstalled)
+	}
+	if got := countReadyTransitions(rec.snapshot()); got != 1 {
+		t.Errorf("ready-for-handover emits = %d, want exactly 1 (double-fire canary)", got)
+	}
+
+	// Heartbeats: at least one cycle ran, and the concluding cycle's
+	// summary reflects the fresh census (sentinel installed, 2 ready,
+	// all-terminal verdict true).
+	hbs := hbrec.snapshot()
+	if len(hbs) == 0 {
+		t.Fatalf("no heartbeats emitted — one structured line per evaluation cycle is the #5269 observability contract")
+	}
+	last := hbs[len(hbs)-1]
+	if !last.AllTerminal {
+		t.Errorf("last heartbeat AllTerminal = false, want true (concluding cycle); heartbeat = %+v", last)
+	}
+	if last.SentinelState != StateInstalled {
+		t.Errorf("last heartbeat SentinelState = %q, want %q", last.SentinelState, StateInstalled)
+	}
+	if last.ReadyHRs != 2 || last.ObservedHRs != 2 {
+		t.Errorf("last heartbeat ReadyHRs/ObservedHRs = %d/%d, want 2/2", last.ReadyHRs, last.ObservedHRs)
+	}
+}
+
+// TestWatch_TickerRecensus_SentinelNeverReady_NoFalseConcludeFlagsStale
+// is the contrapositive: a dead informer must NOT let the ticker invent
+// a conclusion. The #4746 sentinel gate is unchanged — with the
+// sentinel never appearing, the watch runs to WatchTimeout →
+// OutcomeTimeout (handler maps to failed). Meanwhile the
+// stale-informer detector must surface the dead stream: heartbeats
+// flag InformerStale once the quiet stretch exceeds the threshold, and
+// exactly ONE loud warn event is dispatched.
+func TestWatch_TickerRecensus_SentinelNeverReady_NoFalseConcludeFlagsStale(t *testing.T) {
+	scheme := newFakeScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		makeReadyHelmRelease("bp-cilium"),
+	)
+	deadenWatch(client)
+
+	rec := &recorder{}
+	hbrec := &heartbeatRecorder{}
+	cfg := Config{
+		KubeconfigYAML:         "fake",
+		WatchTimeout:           1 * time.Second, // sentinel never comes; time out fast
+		FirstSeenTimeout:       10 * time.Second,
+		MinBootstrapKitHRs:     1,
+		DynamicFactory:         fakeFactory(client),
+		ReadySentinelComponent: "catalyst-platform",
+		RecensusInterval:       30 * time.Millisecond, // stale threshold = 4×30ms = 120ms
+		OnHeartbeat:            hbrec.record,
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	if _, err := w.Watch(context.Background()); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got := w.Outcome(); got == OutcomeReady {
+		t.Fatalf("Outcome() = %q — the ticker re-census must NEVER conclude ready while the #4746 sentinel is unobserved", got)
+	}
+	if got, want := w.Outcome(), OutcomeTimeout; got != want {
+		t.Errorf("Outcome() = %q, want %q", got, want)
+	}
+
+	hbs := hbrec.snapshot()
+	if len(hbs) == 0 {
+		t.Fatalf("no heartbeats emitted during a 1s watch with a 30ms re-census interval")
+	}
+	sawStale, sawUnobservedSentinel := false, false
+	for _, hb := range hbs {
+		if hb.InformerStale {
+			sawStale = true
+		}
+		if hb.SentinelState == "unobserved" {
+			sawUnobservedSentinel = true
+		}
+		if hb.AllTerminal {
+			t.Errorf("heartbeat AllTerminal = true with the sentinel unobserved — verdict must mirror the sentinel-gated census; heartbeat = %+v", hb)
+		}
+	}
+	if !sawStale {
+		t.Errorf("no heartbeat flagged InformerStale — a dead event stream must be visible in the heartbeat within %d intervals", staleInformerIntervals)
+	}
+	if !sawUnobservedSentinel {
+		t.Errorf("no heartbeat carried SentinelState=unobserved — the sentinel state is the load-bearing forensic field")
+	}
+
+	staleWarns := 0
+	for _, ev := range rec.snapshot() {
+		if strings.Contains(ev.Message, "informer event stream has been quiet") {
+			staleWarns++
+		}
+	}
+	if staleWarns != 1 {
+		t.Errorf("stale-informer warn events = %d, want exactly 1 (one-shot per quiet stretch, no SSE flooding)", staleWarns)
+	}
+}
+
+// TestWatch_TickerRecensus_HealthyInformerRace_SingleTransitionEmit
+// proves the two drivers dedupe: with a LIVE informer and a hot
+// re-census ticker both observing the sentinel's install transition,
+// processEvent's under-lock prev/state check must emit the transition
+// once and the ready conclusion once.
+func TestWatch_TickerRecensus_HealthyInformerRace_SingleTransitionEmit(t *testing.T) {
+	scheme := newFakeScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		makeReadyHelmRelease("bp-cilium"),
+		makeInstallingHelmRelease("bp-catalyst-platform"),
+	)
+
+	rec := &recorder{}
+	cfg := Config{
+		KubeconfigYAML:         "fake",
+		WatchTimeout:           30 * time.Second,
+		FirstSeenTimeout:       30 * time.Second,
+		MinBootstrapKitHRs:     2,
+		DynamicFactory:         fakeFactory(client),
+		ReadySentinelComponent: "catalyst-platform",
+		RecensusInterval:       10 * time.Millisecond, // hot — maximise the race window
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		updateHR(t, client, "bp-catalyst-platform", []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "ReconciliationSucceeded", Message: "Helm install succeeded"},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := w.Watch(ctx); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got, want := w.Outcome(), OutcomeReady; got != want {
+		t.Errorf("Outcome() = %q, want %q", got, want)
+	}
+	if got := countReadyTransitions(rec.snapshot()); got != 1 {
+		t.Errorf("ready-for-handover emits = %d, want exactly 1 (informer + ticker must dedupe the conclusion)", got)
+	}
+	installedEmits := 0
+	for _, ev := range rec.componentStateEvents() {
+		if ev.Component == "catalyst-platform" && ev.State == StateInstalled {
+			installedEmits++
+		}
+	}
+	if installedEmits != 1 {
+		t.Errorf("catalyst-platform installed transitions emitted = %d, want exactly 1 (both drivers observed it; processEvent dedupes under w.mu)", installedEmits)
+	}
+}
+
+// TestCompileRecensusInterval pins the env-parse helper's contract:
+// empty / unparseable / non-positive input falls back to
+// DefaultRecensusInterval; a valid duration parses through. Mirrors
+// the CompileWatchTimeout coverage so a future rename or default
+// drift lands as a test failure.
+func TestCompileRecensusInterval(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", DefaultRecensusInterval},
+		{"garbage", DefaultRecensusInterval},
+		{"-30s", DefaultRecensusInterval},
+		{"0s", DefaultRecensusInterval},
+		{"90s", 90 * time.Second},
+		{"2m", 2 * time.Minute},
+	}
+	for _, c := range cases {
+		if got := CompileRecensusInterval(c.in); got != c.want {
+			t.Errorf("CompileRecensusInterval(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+	if DefaultRecensusInterval != 45*time.Second {
+		t.Errorf("DefaultRecensusInterval = %v, want 45s (#5269 — under-a-minute worst-case conclusion latency)", DefaultRecensusInterval)
+	}
+}


### PR DESCRIPTION
Refs #5269 #4746 #5254

## Root cause (hw278, dep b27c7e204802ed7f)

The Phase-1 watch's terminate-on-all-done machinery was **purely informer-event-driven**: the `terminated` channel is closed only from `processEvent`, which ran only on informer Add/Update callbacks (`internal/helmwatch/helmwatch.go` main select loop). When the informer's event stream quiesced after "informer synced helmrelease", nothing ever re-evaluated the census — the sentinel `bp-catalyst-platform` was Ready=True for 66 minutes, a fresh informer event (annotation nudge) did not re-trigger evaluation, and the dep sat `phase1-watching` ~80min with handover / ClusterMesh / region-b SSO tier / cutover all gated behind the un-fired conclusion. A catalyst-api rollout-restart re-launched a fresh watch that concluded in seconds — proving the cluster state was conclusive all along and only the event stream was dead.

## Fix

**1. Periodic re-census (the load-bearing change)** — `helmwatch.Watcher.Watch` now runs a `recensusTicker` (default 45s; `CATALYST_PHASE1_RECENSUS_INTERVAL` / `Config.RecensusInterval` / handler test field `phase1RecensusInterval`). Each tick, `runTickerRecensus` does a direct namespaced List of bp-* HelmReleases against the apiserver and drives every result through the **same `processEvent` census/decision path** an informer delta takes — so the sentinel-gated `allObservedTerminal` decision is re-evaluated on the wall clock, independent of informer delivery. `closeOnce` + `readyTransitionEmitted` + Watch-returns-once keep the conclusion, the ready emit, and the downstream handover fire **exactly-once** regardless of which driver (informer or ticker) concluded. A List failure emits a heartbeat carrying the error and applies no census update — a flake can never invent a conclusion.

**2. Heartbeat log** — `Config.OnHeartbeat` fires once per evaluation cycle with the census summary; the handler wires it (`phase1HeartbeatLogger`) to one structured log line: dep id, observed/ready/failed HR counts, sentinel state, all-terminal verdict, informer-event age (region-tagged for secondary watchers). Emitted **before** the census feed so the line lands even if a downstream emit subscriber wedges. The hw278 forensic gap (80 minutes of silence) becomes visible within one interval.

**3. Stale-informer detection (minimal, observability-only)** — `lastInformerEventAt` is stamped on every informer delivery (incl. 30s resync redeliveries, so a healthy-but-quiet cluster never trips it) and baselined at sync; after 4 quiet re-census intervals the heartbeat flags `InformerStale` and one loud warn event is dispatched per quiet stretch. No informer re-establish churn — the ticker re-census already drives the conclusion without the informer, so a rebuild would add teardown races for zero correctness gain.

## Semantics preserved

`OutcomeReady` REQUIRES nothing new. The #4746 sentinel gate (`allObservedTerminal` unchanged), the #5253/#5254 console-degraded + producer-chain decoupling, min-HR floor, first-seen warn, late-poll (#910), and reachability probe (#923) are all untouched — only the *evaluation cadence* is now robust to a dead event stream.

## Tests

- `internal/helmwatch/recensus_test.go` (new):
  - `TestWatch_TickerRecensus_QuiescedInformer_ConcludesReady` — dead watch reactor (informer syncs, then permanent silence) + sentinel flipping Ready afterwards → ticker List concludes `OutcomeReady`; exactly one "ready for handover" emit; heartbeats reflect the fresh census.
  - `TestWatch_TickerRecensus_SentinelNeverReady_NoFalseConcludeFlagsStale` — dead informer + sentinel absent → NO false conclude (`OutcomeTimeout`), `InformerStale` flagged, exactly one stale warn (no SSE flooding).
  - `TestWatch_TickerRecensus_HealthyInformerRace_SingleTransitionEmit` — live informer + 10ms ticker racing → single transition emit, single conclusion.
  - `TestCompileRecensusInterval` — env-parse contract + 45s default pin.
- `internal/handler/phase1_watch_test.go`: env override / field-beats-env / default + `OnHeartbeat` wired on the production path, both log branches exercised.

`go build ./...` and `go test ./...` green in `products/catalyst/bootstrap/api` (helmwatch suite additionally run with `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
