### PR TITLE
fix(#5245): dr-failback re-clones the diverged demoted region so it converges to streaming

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1253,7 +1253,13 @@ spec:
       #   global.sovereignFQDN values are UNCHANGED — still consumed by this
       #   chart's OTHER templates (sovereign-wildcard-certs.yaml,
       #   sovereign-fqdn-configmap.yaml). Lockstep w/ Chart.yaml.
-      version: 1.4.1182
+      # 1.4.1183 — #5245: catalog-seed bp-cnpg-pair pin 0.2.19 -> 0.2.20
+      #   (+ spec.version display label, #4988 precedent) — dr-failback
+      #   re-clone convergence (hw278 residual): no wrong-CA sslRootCert on
+      #   the rejoin stream, preserve_pki before every bounded delete,
+      #   ConsistentSystemID divergence escalation + episode-marker
+      #   self-heal + post-re-clone watch. Lockstep w/ Chart.yaml.
+      version: 1.4.1183
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -277,7 +277,23 @@ spec:
       # gate now `>=` (the sync fence is the authority proof) + every peer-
       # probe failure reason (NXDOMAIN/unreachable/in-recovery/TL-behind)
       # logs loudly. Script-only; substitutes unchanged.
-      version: 0.2.19
+      # 0.2.20 (#5245): dr-failback RE-CLONE CONVERGENCE (hw278 residual).
+      # hw278 G12: the 0.2.19 chain fired clean (demote at 122s held, wedge
+      # escalation + bounded delete at +10min) but the re-clone itself
+      # wedged silently for 5+ hours — the pgbasebackup bootstrap
+      # FATAL-looped on x509 (the demoted externalCluster pinned sslRootCert
+      # to region-A's own -primary-ca while the dialed server is region-B's
+      # replica Cluster, signed by region-B's own -replica-ca;
+      # require+rootcert = verify-ca semantics in libpq/pgx) and the
+      # Cluster-CR delete GC'd the CNPG PKI Secrets, re-issuing a fresh CA
+      # that region-B's one-shot synced clientCASecret copy can't trust.
+      # Fixes: no root cert on the rejoin stream (forward pin kept),
+      # preserve_pki ownerReference strip before every delete (+pinned
+      # secrets get/patch RBAC), ConsistentSystemID divergence escalation
+      # (grace 180s, pre-episode-bounded), episode-marker self-heal,
+      # post-re-clone convergence watch + psql-dark writable probe.
+      # Substitutes unchanged.
+      version: 0.2.20
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/DESIGN.md
+++ b/platform/cnpg-pair/DESIGN.md
@@ -410,7 +410,9 @@ and NEVER a Cluster created after the failback episode began — an
 in-place-demoted stale standby (if the webhook admits the shape change
 on the live CR) is re-cloned only via the wedge escalation
 (`wedgeHoldSeconds` unable to stream, `creationTimestamp` predating
-`dr-failback-started-at`); a fresh clone is never deleted.
+`dr-failback-started-at`) or, since 0.2.20, the ConsistentSystemID
+divergence escalation (same pre-episode bound, see below); a fresh
+clone is never deleted.
 
 *Auth*: the rejoin stream and the peer probe present region-A's own
 `-primary-replication` client cert. Region-B accepts it because the
@@ -419,6 +421,29 @@ replica Cluster pins `certificates.clientCASecret` to the shared
 — live-verified hw275; CNPG generates `<replica>-replication` from a
 BYO client CA when `replicationTLSSecret` is unset, so every existing
 consumer keeps its mounts).
+
+*Re-clone convergence (chart 0.2.20, the hw278 residual)*: hw278 G12
+live-proved the chain above fires clean and the re-clone ITSELF can
+still wedge, silently. Three hardenings: (1) the rejoin stream carries
+**no `sslRootCert`** — the dialed server is region-B's replica
+Cluster, signed by region-B's own `-replica-ca` which cluster-A does
+not hold, and libpq/pgx upgrade `sslmode=require` to verify-ca
+semantics whenever a root cert IS supplied (hw278: pgbasebackup
+FATAL-looped 5+ hours on x509; the forward stream keeps its pin —
+there the CA matches); (2) **`preserve_pki`** strips the Cluster
+ownerReferences from the CNPG-issued `-ca`/`-replication`/`-server`
+Secrets before every bounded delete — otherwise the delete GC's the CA
+and CNPG re-issues a fresh one that region-B's one-shot synced
+`clientCASecret` copy can never trust; (3) the actor gains a
+**ConsistentSystemID divergence escalation** (CNPG's own
+cannot-consistently-follow condition held False for
+`failback.divergenceGraceSeconds`, pre-episode-bounded, fresh
+writable-peer-guarded — no dependence on a 600 s-contiguous psql wedge
+clock that resets on every psql-dark tick), an **episode-marker
+self-heal** (a lost `dr-failback-started-at` write silently disabled
+every escalation), and a **post-re-clone convergence watch** (phase +
+ConsistentSystemID logged every ~30 ticks until streaming) — a wedged
+re-clone names itself.
 
 End state after a kill+recover cycle: region-B primary, region-A
 streaming replica, both HRs unsuspended, the failed-over topology

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -82,7 +82,24 @@ spec:
   # (2) fail-loud peer probe: NXDOMAIN / unreachable / in-recovery /
   # TL-unreadable / TL-behind each log on transition + ~5-min heartbeat —
   # no more silent wedge. Script-only; no schema/RBAC/resource delta.
-  version: 0.2.19
+  # 0.2.20 (#5245): dr-failback RE-CLONE CONVERGENCE — the hw278 residual.
+  # hw278 G12 live-proved the 0.2.19 chain fires clean (demote at 122s held
+  # on the -ge gate, wedge escalation + bounded delete at +10min) and the
+  # RE-CLONE ITSELF then wedged silently for 5+ hours: the pgbasebackup
+  # bootstrap FATAL-looped on `x509: certificate signed by unknown
+  # authority` (the demoted externalCluster pinned sslRootCert to region-A's
+  # OWN -primary-ca while the dialed server is region-B's replica Cluster,
+  # signed by region-B's own -replica-ca — libpq/pgx upgrade sslmode=require
+  # to verify-ca whenever a root cert IS supplied), and the Cluster-CR
+  # delete had GC'd the CNPG-issued PKI Secrets so a FRESH CA orphaned
+  # region-B's synced clientCASecret trust. Fixes: (1) no sslRootCert on the
+  # rejoin stream (forward pin kept); (2) preserve_pki strips the Secret
+  # ownerReferences before every delete (RBAC +secrets get/patch, pinned);
+  # (3) ConsistentSystemID divergence escalation (divergenceGraceSeconds,
+  # default 180, pre-episode-bounded) + episode-marker self-heal +
+  # post-re-clone convergence watch + psql-dark writable probe — a wedged
+  # re-clone can never be silent again.
+  version: 0.2.20
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,41 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.20 (#5245): dr-failback RE-CLONE CONVERGENCE — the hw278 residual.
+# hw278 G12 (2026-07-19/20) live-proved the 0.2.19 chain fires clean (demote
+# 23:10:36Z on the -ge gate at 122s held; wedge escalation + bounded delete
+# 23:20:50Z) and the RE-CLONE ITSELF then wedged, silently, for 5+ hours:
+# (1) WRONG-CA ROOT PIN: the demoted externalCluster pinned sslRootCert to
+#     region-A's OWN -primary-ca while the server it dials is region-B's
+#     replica Cluster, whose server chain is signed by region-B's own
+#     -replica-ca (a Secret cluster-A does not hold). libpq/pgx upgrade
+#     sslmode=require to verify-ca semantics whenever a root cert IS
+#     supplied → the pgbasebackup bootstrap Job FATAL-looped every 5s on
+#     `x509: certificate signed by unknown authority`. The demoted shape now
+#     omits sslRootCert (require = encrypted, no chain verification — the
+#     forward stream KEEPS its pin: there -primary-ca signs the dialed
+#     server). Authenticity rides the client-cert requirement + the mesh
+#     identity path.
+# (2) PKI GARBAGE-COLLECTION: the Cluster-CR delete GC'd the CNPG-issued
+#     -ca/-replication/-server Secrets (controller ownerReference,
+#     live-verified) and CNPG re-issued a FRESH CA on re-create — region-B's
+#     one-shot post-mesh-flip synced clientCASecret copy could never trust
+#     the re-cloned cluster's new client leaf. preserve_pki now strips the
+#     ownerReferences (field-manager dr-failback) before EVERY delete; CNPG
+#     adopts the surviving Secrets (BYO path) and the trusted CA lineage is
+#     unbroken. RBAC: +secrets get/patch, resourceNames-pinned to the three.
+# (3) SILENT POST-DELETE ACTOR: (a) ConsistentSystemID DIVERGENCE escalation
+#     — a PRE-episode demoted CR holding CNPG's own cannot-consistently-
+#     follow condition False for failback.divergenceGraceSeconds (default
+#     180) with a fresh writable-peer proof escalates to the re-clone
+#     without a 600s-contiguous psql wedge clock (which resets on every
+#     'unknown' tick while the demoted standby restarts through the
+#     in-place switch); (b) the dr-failback-started-at episode marker
+#     self-heals (a lost one-shot write silently disabled EVERY
+#     escalation); (c) a post-re-clone convergence watch logs phase +
+#     ConsistentSystemID every ~30 ticks until streaming — a wedged
+#     re-clone names itself. Signals: probe_peer_writable keeps the
+#     writable proof fresh in the psql-dark 'unknown' arm. Render Case 20
+#     pins all of it. Lockstep slot 16b pin → 0.2.20.
 # 0.2.19 (#5245): dr-failback TL-EQUALITY deadlock + fail-loud peer probe.
 # hw277 G12 (dep 1708c340ffc0e3f2, 2026-07-19) live-proved the 0.2.18 failback
 # wedge root cause is NOT DNS: the `-replica-mesh` stub Service existed on
@@ -283,7 +319,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.19
+version: 0.2.20
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -323,6 +359,60 @@ description: |
 
   Changelog
   ─────────
+  0.2.20 (2026-07-20, dr-failback re-clone convergence — the hw278 residual, Refs #5245 #5268 #5248)
+    - FIX (Pillar-3 region-kill failback, re-clone leg): hw278 G12
+      live-proved the 0.2.19 chain fires clean end-to-end (demote 23:10:36Z
+      at 122s held on the `-ge` gate — the hw277 57-minute TL-equality
+      split-brain is dead; wedge escalation + bounded delete 23:20:50Z) and
+      the RE-CLONE ITSELF then wedged, silently, for 5+ hours: the fresh
+      Cluster sat at phase 'Setting up primary' with
+      ConsistentSystemID=False(NotFound) and wal_receiver empty while its
+      pgbasebackup bootstrap Job FATAL-looped every 5s on `x509:
+      certificate signed by unknown authority` against `-replica-mesh`.
+    - NO sslRootCert ON THE REJOIN STREAM: the demoted externalCluster
+      pinned sslRootCert to region-A's OWN `-primary-ca`, but the dialed
+      server is region-B's replica Cluster — server chain signed by
+      region-B's own `-replica-ca`, which cluster-A does not hold.
+      libpq/pgx upgrade sslmode=require to verify-ca semantics whenever a
+      root cert IS supplied, so this leg could never connect. The demoted
+      shape now omits sslRootCert; authenticity rides the client-cert
+      requirement (region-B verifies region-A's leaf against the shared
+      client CA) + the Cilium ClusterMesh identity path. The FORWARD
+      stream keeps its root pin (there the CA matches the dialed server).
+    - preserve_pki BEFORE EVERY DELETE: the bounded Cluster-CR delete GC'd
+      the CNPG-issued `-ca`/`-replication`/`-server` Secrets (controller
+      ownerReference, live-verified) and CNPG re-issued a FRESH CA on
+      re-create — region-B's one-shot post-mesh-flip synced clientCASecret
+      copy (hw278: 3h58m old vs cluster-A's re-issued 117m) could never
+      trust the re-cloned cluster's new client leaf. The actor now strips
+      the ownerReferences from the three PKI Secrets (--field-manager=
+      dr-failback) before every delete; CNPG adopts the surviving Secrets
+      on re-create (BYO path). A failed strip aborts the delete for that
+      tick. RBAC: +secrets get/patch, resourceNames-pinned to the three.
+    - ConsistentSystemID DIVERGENCE ESCALATION: a PRE-episode (in-place-
+      demoted) CR holding CNPG's own cannot-consistently-follow condition
+      False for failback.divergenceGraceSeconds (default 180) with a
+      <60s-fresh writable-peer proof escalates to the re-clone directly —
+      no dependence on the 600s-contiguous psql wedge clock, which resets
+      on every 'unknown' tick while the demoted standby restarts through
+      the in-place switch. A fresh clone (postdates the episode) is NEVER
+      deleted — bounded destruction unchanged.
+    - EPISODE-MARKER SELF-HEAL: dr-failback-started-at was a one-shot,
+      best-effort write in the D0 tick; if lost, ts_lt() never passed and
+      EVERY escalation was structurally disabled — silently. Now re-written
+      loudly whenever the demotion is rendered but the marker is absent.
+    - POST-RE-CLONE CONVERGENCE WATCH: until streaming is observed the
+      actor logs the live Cluster phase + ConsistentSystemID status/reason
+      every ~30 ticks — a wedged re-clone names itself in the logs.
+    - Signals: probe_peer_writable (split writable-only probe) keeps the
+      peer proof fresh in the psql-dark 'unknown' arm; fail-safe clears
+      unchanged (healthy pair stays a strict no-op).
+    - Render Case 20 pins: no root cert on the rejoin stream + forward pin
+      kept; preserve_pki ordering before every delete + pinned RBAC;
+      divergence escalation graced + pre-episode-bounded + writable-proof-
+      guarded; self-heal; watch; dark-window probe; healthy no-op.
+      values-schema delta: +failback.divergenceGraceSeconds. Lockstep slot
+      16b pin → 0.2.20.
   0.2.19 (2026-07-19, dr-failback TL-equality deadlock + fail-loud peer probe, Refs #5245 #5248 #5218)
     - FIX (Pillar-3 region-kill failback): hw277 G12 (dep 1708c340ffc0e3f2)
       live-proved the 0.2.18 failback wedge is NOT DNS. The `-replica-mesh`

--- a/platform/cnpg-pair/chart/templates/dr-failback.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-failback.yaml
@@ -151,6 +151,65 @@ the `.openstacklocal` fall-through observed was a NODE-vantage
 resolver artifact, not the pod's). A silent probe loop is a defect:
 every wedge must name itself in the logs immediately.
 
+RE-CLONE CONVERGENCE (#5245, chart 0.2.20 — the hw278 residual)
+---------------------------------------------------------------
+hw278 G12 (2026-07-19/20) proved the 0.2.19 chain fires clean — demote
+23:10:36Z (122s held on the `-ge` gate), wedge escalation + bounded
+delete 23:20:50Z — and then the RE-CLONE ITSELF wedged, silently, for
+5+ hours (live-read this session, kubeconfig /tmp/hw278-a.kubeconfig):
+
+  1. WRONG-CA ROOT PIN (structural): the re-created Cluster's
+     pgbasebackup bootstrap Job FATAL-looped every 5s on `x509:
+     certificate signed by unknown authority` against `-replica-mesh`.
+     The demoted externalCluster pinned sslRootCert to region-A's OWN
+     `-primary-ca`, but the server it dials is region-B's replica
+     Cluster, whose SERVER chain is signed by region-B's own
+     `-replica-ca` — a Secret cluster-A does not hold. libpq/pgx
+     upgrade sslmode=require to verify-ca semantics whenever a root
+     cert IS supplied, so this leg could never connect. The demoted
+     shape now omits sslRootCert (primary-cluster.yaml #5245 0.2.20);
+     the forward leg keeps its root pin (there the CA matches).
+  2. PKI GARBAGE-COLLECTION (trust break): the Cluster-CR delete GC'd
+     the CNPG-issued PKI Secrets (`-primary-ca`/`-replication`/
+     `-server` carry a controller ownerReference to the Cluster —
+     live-verified) and CNPG re-issued a FRESH CA on re-create.
+     Region-B's clientCASecret is the one-shot post-mesh-flip SYNCED
+     COPY of the OLD `-primary-ca` (hw278: cluster-A copy 117m old vs
+     cluster-B copy 3h58m old), so the re-cloned cluster's new client
+     leaf could never authenticate even after fix 1. preserve_pki now
+     strips the ownerReferences from the three PKI Secrets
+     (--field-manager=dr-failback) before EVERY delete; CNPG adopts
+     the surviving Secrets on re-create (BYO path) and the CA lineage
+     region-B trusts stays unbroken.
+  3. SILENT POST-DELETE ACTOR: the re-created CR is in the demoted
+     shape and postdates the episode, so every actor tick fell through
+     to a silent exit while the bootstrap looped — the exact
+     silent-wedge defect class the 0.2.19 probe ladder killed on the
+     signals side. Three escalation/observability fixes:
+       a. DIVERGENCE escalation: a PRE-episode demoted CR whose
+          ConsistentSystemID condition stays False for
+          failback.divergenceGraceSeconds with the peer verified
+          writable escalates to the re-clone directly. The condition
+          is CNPG's own cannot-consistently-follow signal and needs NO
+          contiguous psql observability — the 600s wedge clock resets
+          on every 'unknown' tick, and the demoted standby restarts
+          through the in-place switch, which is how hw278 crawled to
+          its escalation.
+       b. EPISODE-MARKER self-heal: dr-failback-started-at was written
+          once, best-effort, in the same tick as the substitute patch;
+          if that single write is lost, ts_lt() never passes and every
+          escalation is structurally disabled — silently. The actor
+          now re-writes it (loudly) whenever the demotion is rendered
+          but the marker is absent.
+       c. POST-RE-CLONE convergence watch: until streaming is
+          observed, the actor logs the live Cluster phase +
+          ConsistentSystemID status/reason every ~30 ticks — a wedged
+          re-clone names itself in the logs instead of sitting dark.
+     The signals container also keeps the peer-writable proof fresh
+     while the local cluster is psql-dark (probe_peer_writable in the
+     'unknown' branch): the destructive escalations need a live
+     writable peer precisely when local observability is gone.
+
 WHAT IT NEVER DOES
 ------------------
 Never patches a live Cluster CR (#5125-D1 — drift-correction reverts
@@ -179,6 +238,7 @@ cluster-B).
 {{- $startupGrace := $fb.startupGraceSeconds | default 300 }}
 {{- $probeTimeout := $fb.livenessProbeTimeoutSeconds | default 5 }}
 {{- $wedgeHold := $fb.wedgeHoldSeconds | default 600 }}
+{{- $divergenceGrace := $fb.divergenceGraceSeconds | default 180 }}
 {{- $peerClusters := .Values.cnpgPair.networkPolicy.crossRegionPeerClusters | default list }}
 ---
 apiVersion: v1
@@ -205,6 +265,20 @@ rules:
     resources: [clusters]
     verbs: [get, delete]
     resourceNames: [{{ include "cnpg-pair.primaryName" . }}]
+  # #5245 0.2.20 preserve_pki: strip the controller ownerReferences from
+  # the CNPG-issued PKI Secrets before the bounded Cluster-CR delete so
+  # the CA lineage survives (hw278: the delete GC'd -ca/-replication/
+  # -server, CNPG re-issued a FRESH CA, and region-B's one-shot synced
+  # clientCASecret copy could never trust the re-cloned cluster's new
+  # client leaf). get+patch only, resourceNames-pinned to the three
+  # Secrets — no list, no read of any other Secret.
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [get, patch]
+    resourceNames:
+      - {{ include "cnpg-pair.primaryName" . }}-ca
+      - {{ include "cnpg-pair.primaryName" . }}-replication
+      - {{ include "cnpg-pair.primaryName" . }}-server
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -438,16 +512,22 @@ spec:
                   echo "${_n}" > /shared/peer-probe-ticks
                 fi
               }
-              # probe_peer_ahead <tl_local> — verifies peer RESOLVABLE +
-              # REACHABLE + WRITABLE + TL equal-or-higher (>= — see the
-              # DETECT rationale: the hw277 TL2==TL2 deadlock; the sync
-              # fence, not the TL number, is the authority proof). On
-              # success touches the freshness marker the actor re-checks
-              # before EVERY destructive step. Any failure → non-zero
-              # (caller clears) with its reason fail-loud via
-              # peer_report.
-              probe_peer_ahead() {
-                _tl_local="$1"
+              # probe_peer_writable — peer RESOLVABLE + REACHABLE +
+              # WRITABLE. The first three rungs of the probe ladder,
+              # split out (0.2.20, #5245 hw278) so the post-demote
+              # escalations can keep a LIVE writable-peer proof while
+              # the LOCAL cluster is psql-dark (mid-demote restarts, a
+              # bootstrap-looping re-clone) — once the demotion is
+              # durably rendered the authority question is settled and
+              # what a destructive step still needs is a fresh writable
+              # peer, not a re-run of the TL arithmetic. Touches
+              # /shared/peer-writable-fresh on success. Failure reasons
+              # stay fail-loud via peer_report; success reporting is
+              # the CALLER's job (probe_peer_ahead reports 'ok' with
+              # the TL numbers; probe_peer_writable_report reports the
+              # dark-window transition) so alternating call sites never
+              # spam per-tick transitions.
+              probe_peer_writable() {
                 # DNS first, separately from reachability: a structural
                 # NXDOMAIN (missing local -replica-mesh stub Service /
                 # broken kube-dns) must surface BY NAME, immediately
@@ -466,6 +546,31 @@ spec:
                   peer_report in-recovery "peer ${PEER_MESH_HOST} reachable but NOT WRITABLE (in_recovery=${_rec}) — region-B not promoted (healthy pair / pre-promote window): no failback"
                   return 1
                 fi
+                : > /shared/peer-writable-fresh
+                return 0
+              }
+              # probe_peer_writable_report — standalone form for ticks
+              # where the TL arithmetic cannot run (local psql dark):
+              # logs the writable-proof transition once, never per-tick.
+              probe_peer_writable_report() {
+                if probe_peer_writable; then
+                  _prev=$(cat /shared/peer-probe-reason 2>/dev/null || echo "")
+                  case "${_prev}" in
+                    ok|writable-ok) : ;;
+                    *) peer_report writable-ok "peer ${PEER_MESH_HOST} WRITABLE (in_recovery=f) — peer-writable proof held while the local cluster is psql-dark (#5245 hw278)" ;;
+                  esac
+                fi
+              }
+              # probe_peer_ahead <tl_local> — probe_peer_writable + TL
+              # equal-or-higher (>= — see the DETECT rationale: the
+              # hw277 TL2==TL2 deadlock; the sync fence, not the TL
+              # number, is the authority proof). On success touches the
+              # freshness marker the actor re-checks before EVERY
+              # destructive step. Any failure → non-zero (caller
+              # clears) with its reason fail-loud via peer_report.
+              probe_peer_ahead() {
+                _tl_local="$1"
+                probe_peer_writable || return 1
                 _tl_peer=$(tl_of "${PEER_REPL}")
                 if ! is_int "${_tl_peer}"; then
                   peer_report tl-unreadable "peer ${PEER_MESH_HOST} writable but its timeline is unreadable over the replication protocol — fail-safe"
@@ -535,15 +640,26 @@ spec:
                         echo "$(date -u +"%FT%TZ") [dr-failback/signals] local standby cannot stream (state=${STATE}) while peer is writable+equal-or-ahead — wedge clock started (#5245 escalation)"
                       fi
                     else
+                      # 0.2.20 (#5245 hw278): a standby whose own TL is
+                      # unreadable still needs the writable-peer proof
+                      # kept fresh for the divergence escalation.
+                      is_int "${TL_LOCAL}" || probe_peer_writable_report
                       clear_wedge
                     fi
                     ;;
                   unknown|*)
                     # Local probe failed — mid-re-clone (no endpoints) or an
                     # unhealthy local cluster. Fail-safe: no evidence accrues.
+                    # 0.2.20 (#5245 hw278): STILL probe the peer's
+                    # writability — the divergence escalation and the
+                    # post-re-clone watch need a fresh peer proof precisely
+                    # while the local cluster is psql-dark (the demoted
+                    # standby restarts through the in-place switch; a
+                    # bootstrap-looping re-clone has no endpoints at all).
                     clear_hold "local state unknown (probe failed — fail-safe)"
                     clear_wedge
                     rm -f /shared/converged-streaming
+                    probe_peer_writable_report
                     ;;
                 esac
                 sleep "${INTERVAL_SECONDS}"
@@ -610,7 +726,7 @@ spec:
           args:
             - |
               FM="--field-manager=dr-failback"
-              echo "[dr-failback/actor] loop started (hold=${HOLD_SECONDS}s wedgeHold=${WEDGE_HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME} kustomization=${KS_NAMESPACE}/${KS_NAME})"
+              echo "[dr-failback/actor] loop started (hold=${HOLD_SECONDS}s wedgeHold=${WEDGE_HOLD_SECONDS}s divergenceGrace=${DIVERGENCE_GRACE_SECONDS}s interval=${INTERVAL_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME} kustomization=${KS_NAMESPACE}/${KS_NAME})"
               # nudge <kind> <ns> <name> <marker> — rate-limited flux
               # reconcile request (reconcile.fluxcd.io/requestedAt).
               nudge() {
@@ -627,6 +743,39 @@ spec:
               peer_fresh() {
                 [ -f /shared/peer-ahead-fresh ] && [ -z "$(find /shared/peer-ahead-fresh -mmin +1 2>/dev/null)" ]
               }
+              # peer_fresh_writable — the signals container verified the
+              # peer WRITABLE within the last 60s (0.2.20, #5245 hw278).
+              # The divergence escalation runs while the LOCAL cluster is
+              # psql-dark, so the full TL-arithmetic proof (peer_fresh)
+              # may be structurally unavailable — but the demotion is
+              # already durably rendered by then, so a live writable peer
+              # is the guard that still matters before destruction.
+              peer_fresh_writable() {
+                [ -f /shared/peer-writable-fresh ] && [ -z "$(find /shared/peer-writable-fresh -mmin +1 2>/dev/null)" ]
+              }
+              # preserve_pki — strip the controller ownerReferences from
+              # the CNPG-issued PKI Secrets so the bounded Cluster-CR
+              # delete does NOT garbage-collect the CA lineage (0.2.20,
+              # #5245 hw278: the delete GC'd -ca/-replication/-server,
+              # CNPG re-issued a FRESH CA on re-create, and region-B's
+              # one-shot post-mesh-flip synced clientCASecret copy could
+              # never trust the re-cloned cluster's new client leaf —
+              # auth dead even after the sslRootCert fix). CNPG adopts
+              # the surviving Secrets on re-create (BYO path). A failed
+              # strip ABORTS the delete for this tick — deleting anyway
+              # would reproduce the trust break.
+              preserve_pki() {
+                _rc=0
+                for _s in "${PRIMARY_CLUSTER}-ca" "${PRIMARY_CLUSTER}-replication" "${PRIMARY_CLUSTER}-server"; do
+                  if kubectl -n "${NAMESPACE}" get secret "${_s}" >/dev/null 2>&1; then
+                    if ! kubectl -n "${NAMESPACE}" patch secret "${_s}" --type merge ${FM} -p '{"metadata":{"ownerReferences":[]}}' >/dev/null 2>&1; then
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] PKI-PRESERVE FAILED on Secret ${_s} — NOT deleting the Cluster this tick (#5245 hw278: a delete now would GC the CA and orphan region-B's synced client-CA trust); retrying next tick"
+                      _rc=1
+                    fi
+                  fi
+                done
+                return ${_rc}
+              }
               # ts_lt <a> <b> — RFC3339-UTC lexicographic a < b (POSIX;
               # no `[ \< ]` bashism).
               ts_lt() {
@@ -638,7 +787,12 @@ spec:
                   set -eu
                   SUB=$(kubectl -n "${KS_NAMESPACE}" get kustomization "${KS_NAME}" -o jsonpath='{.spec.postBuild.substitute.SOVEREIGN_CNPG_PAIR_DEMOTED}' 2>/dev/null || echo "")
                   VALS_DEMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.cnpgPair.primary.demoted}' 2>/dev/null || echo "")
-                  CR_JSON=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" -o jsonpath='{.spec.replica.enabled}|{.metadata.creationTimestamp}|{.metadata.deletionTimestamp}' 2>/dev/null || echo "__absent__")
+                  # 0.2.20 (#5245 hw278): also read the ConsistentSystemID
+                  # condition (CNPG's own cannot-consistently-follow-the-
+                  # source signal — live shape on hw278:
+                  # status=False reason=NotFound) + the phase, for the
+                  # divergence escalation and the post-re-clone watch.
+                  CR_JSON=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" -o jsonpath="{.spec.replica.enabled}|{.metadata.creationTimestamp}|{.metadata.deletionTimestamp}|{.status.conditions[?(@.type=='ConsistentSystemID')].status}|{.status.conditions[?(@.type=='ConsistentSystemID')].reason}|{.status.phase}" 2>/dev/null || echo "__absent__")
                   STARTED_AT=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.metadata.annotations.catalyst\.openova\.io/dr-failback-started-at}' 2>/dev/null || echo "")
 
                   # ── CONVERGED — record once, then idle ────────────────
@@ -675,6 +829,22 @@ spec:
                     exit 0
                   fi
 
+                  # ── D1.5: EPISODE-MARKER self-heal (0.2.20, #5245 hw278) ─
+                  # dr-failback-started-at was written once, best-effort, in
+                  # the same D0 tick as the substitute patch. If that single
+                  # write was lost (patch failure, actor crash between the
+                  # two patches), ts_lt() below never passes and EVERY
+                  # escalation is structurally disabled — silently. Re-write
+                  # it loudly whenever the demotion is rendered but the
+                  # marker is absent. (A late marker is safe: it only makes
+                  # the pre-existing in-place-demoted CR read as
+                  # pre-episode, which it is.)
+                  if [ -z "${STARTED_AT}" ]; then
+                    STARTED_AT="$(date -u +"%FT%TZ")"
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] dr-failback-started-at annotation MISSING while the demotion is rendered — self-healing the episode marker to ${STARTED_AT} (#5245 hw278: without it the divergence/wedge escalations are dead, silently)"
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-started-at\":\"${STARTED_AT}\"}}}" >/dev/null 2>&1 || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] episode-marker self-heal patch FAILED — retrying next tick"; exit 0; }
+                  fi
+
                   # ── D2: RE-CLONE — the one bounded destructive act ────
                   if [ "${CR_JSON}" = "__absent__" ]; then
                     # Deleted (by us) or not yet re-created — nudge helm to
@@ -685,36 +855,95 @@ spec:
                   CR_REPLICA=$(echo "${CR_JSON}" | cut -d'|' -f1)
                   CR_CREATED=$(echo "${CR_JSON}" | cut -d'|' -f2)
                   CR_DELETING=$(echo "${CR_JSON}" | cut -d'|' -f3)
+                  CR_SYSID_OK=$(echo "${CR_JSON}" | cut -d'|' -f4)
+                  CR_SYSID_REASON=$(echo "${CR_JSON}" | cut -d'|' -f5)
+                  CR_PHASE=$(echo "${CR_JSON}" | cut -d'|' -f6)
                   if [ -n "${CR_DELETING}" ]; then
                     exit 0   # teardown in progress — wait
                   fi
                   if [ "${CR_REPLICA}" != "true" ]; then
                     # Still the OLD primary shape with the stale timeline.
                     peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] demotion rendered but peer proof stale — NOT deleting (fail-safe)"; exit 0; }
-                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONING: deleting stale Cluster ${PRIMARY_CLUSTER} (old primary shape, TL=$(cat /shared/tl-local 2>/dev/null || echo '?')) — helm re-creates it as a pg_basebackup replica of region-B; PVCs are CNPG-owned and garbage-collect (#5245)"
+                    preserve_pki || exit 0
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONING: deleting stale Cluster ${PRIMARY_CLUSTER} (old primary shape, TL=$(cat /shared/tl-local 2>/dev/null || echo '?')) — helm re-creates it as a pg_basebackup replica of region-B; PVCs are CNPG-owned and garbage-collect, PKI Secrets preserved (#5245)"
                     kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
                     kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
                     exit 0
                   fi
                   # Demoted shape exists. A CR created BEFORE the failback
-                  # episode is an IN-PLACE demote keeping stale PGDATA — if it
-                  # cannot stream for wedgeHold while the peer stays provably
-                  # writable+ahead, escalate to the re-clone. A CR created
-                  # AFTER (a fresh clone) is NEVER deleted — bounded
-                  # destruction.
-                  if [ -n "${STARTED_AT}" ] && ts_lt "${CR_CREATED}" "${STARTED_AT}" && [ -f /shared/wedge-since ]; then
-                    WSINCE=$(cat /shared/wedge-since)
-                    NOW=$(date -u +%s)
-                    if [ "$((NOW - WSINCE))" -ge "${WEDGE_HOLD_SECONDS}" ]; then
-                      peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] wedge hold expired but peer proof stale — NOT deleting (fail-safe)"; exit 0; }
-                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] WEDGE ESCALATION: in-place-demoted Cluster (created ${CR_CREATED} < failback start ${STARTED_AT}) unable to stream $((NOW - WSINCE))s >= ${WEDGE_HOLD_SECONDS}s with peer writable+ahead — deleting for a clean re-clone (#5245)"
-                      kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
-                      kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
-                      exit 0
+                  # episode is an IN-PLACE demote keeping stale PGDATA — it
+                  # escalates to the bounded re-clone on EITHER detector
+                  # below. A CR created AFTER (a fresh clone) is NEVER
+                  # deleted — bounded destruction, at most one re-clone per
+                  # divergence detection.
+                  if [ -n "${STARTED_AT}" ] && ts_lt "${CR_CREATED}" "${STARTED_AT}"; then
+                    # ── D2a: DIVERGENCE escalation (0.2.20, #5245 hw278) ──
+                    # CNPG's own signal: ConsistentSystemID stays False on
+                    # the in-place-demoted CR. Unlike the wedge clock below
+                    # this needs NO contiguous psql observability — the
+                    # demoted standby restarts through the in-place switch
+                    # and every 'unknown' tick resets the wedge clock (how
+                    # hw278 crawled to its escalation). One clock, cleared
+                    # whenever the condition leaves False; the delete still
+                    # requires a fresh writable-peer proof.
+                    if [ "${CR_SYSID_OK}" = "False" ] && [ ! -f /shared/converged-streaming ]; then
+                      if [ ! -f /shared/diverged-since ]; then
+                        date -u +%s > /shared/diverged-since
+                        echo "$(date -u +"%FT%TZ") [dr-failback/actor] DIVERGENCE DETECTED: in-place-demoted Cluster (created ${CR_CREATED} < episode ${STARTED_AT}) reports ConsistentSystemID=False (reason=${CR_SYSID_REASON:-?}, phase='${CR_PHASE:-?}') — the stale-PGDATA line cannot consistently follow region-B; divergence clock started (grace ${DIVERGENCE_GRACE_SECONDS}s) (#5245 hw278)"
+                      fi
+                      DSINCE=$(cat /shared/diverged-since)
+                      NOW=$(date -u +%s)
+                      if [ "$((NOW - DSINCE))" -ge "${DIVERGENCE_GRACE_SECONDS}" ]; then
+                        if peer_fresh_writable; then
+                          preserve_pki || exit 0
+                          echo "$(date -u +"%FT%TZ") [dr-failback/actor] DIVERGENCE ESCALATION: ConsistentSystemID=False held $((NOW - DSINCE))s >= ${DIVERGENCE_GRACE_SECONDS}s on the pre-episode demoted Cluster with peer verified writable — deleting for a clean pg_basebackup re-clone (PKI preserved) (#5245 hw278)"
+                          kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
+                          rm -f /shared/diverged-since
+                          kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
+                          exit 0
+                        fi
+                        echo "$(date -u +"%FT%TZ") [dr-failback/actor] divergence grace expired but no fresh peer-writable proof — NOT deleting (fail-safe)"
+                        exit 0
+                      fi
+                    else
+                      rm -f /shared/diverged-since
                     fi
+                    # ── D2b: WEDGE escalation (the psql-observed path) ──
+                    if [ -f /shared/wedge-since ]; then
+                      WSINCE=$(cat /shared/wedge-since)
+                      NOW=$(date -u +%s)
+                      if [ "$((NOW - WSINCE))" -ge "${WEDGE_HOLD_SECONDS}" ]; then
+                        peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] wedge hold expired but peer proof stale — NOT deleting (fail-safe)"; exit 0; }
+                        preserve_pki || exit 0
+                        echo "$(date -u +"%FT%TZ") [dr-failback/actor] WEDGE ESCALATION: in-place-demoted Cluster (created ${CR_CREATED} < failback start ${STARTED_AT}) unable to stream $((NOW - WSINCE))s >= ${WEDGE_HOLD_SECONDS}s with peer writable+ahead — deleting for a clean re-clone (PKI preserved) (#5245)"
+                        kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
+                        kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
+                        exit 0
+                      fi
+                    fi
+                    # Pre-episode CR, clocks still accruing (or following
+                    # cleanly) — wait.
+                    exit 0
                   fi
-                  # Fresh clone converging (or in-place demote following
-                  # cleanly) — let it stream; the CONVERGED block closes out.
+                  # ── D3: POST-RE-CLONE convergence watch (0.2.20) ──────
+                  # The CR postdates the episode: the fresh clone. NEVER
+                  # deleted (bounded destruction). hw278: the fresh clone's
+                  # pgbasebackup Job FATAL-looped on x509 for 5+ hours with
+                  # the actor totally silent — a wedged re-clone must name
+                  # itself. Log the live phase + ConsistentSystemID every
+                  # 30 ticks (~5 min) until streaming converges.
+                  if [ ! -f /shared/converged-streaming ]; then
+                    _n=$(($(cat /shared/postclone-ticks 2>/dev/null || echo 0) + 1))
+                    if [ "${_n}" -ge 30 ]; then
+                      _n=0
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONE NOT YET STREAMING: Cluster phase='${CR_PHASE:-?}', ConsistentSystemID=${CR_SYSID_OK:-?}(${CR_SYSID_REASON:-?}), local state=$(cat /shared/local-state 2>/dev/null || echo '?') — the pg_basebackup bootstrap has not converged; check the ${PRIMARY_CLUSTER}-1-pgbasebackup Job logs (hw278 wedge shape: x509 unknown-authority = a root cert pinned against the wrong CA) (#5245)"
+                    fi
+                    echo "${_n}" > /shared/postclone-ticks
+                  else
+                    rm -f /shared/postclone-ticks
+                  fi
+                  # Fresh clone converging (or converged) — the CONVERGED
+                  # block closes out on the streaming signal.
                   exit 0
                 ) || echo "[dr-failback/actor] tick returned non-zero — retry in ${INTERVAL_SECONDS}s"
                 sleep "${INTERVAL_SECONDS}"
@@ -736,6 +965,8 @@ spec:
               value: {{ $hold | quote }}
             - name: WEDGE_HOLD_SECONDS
               value: {{ $wedgeHold | quote }}
+            - name: DIVERGENCE_GRACE_SECONDS
+              value: {{ $divergenceGrace | quote }}
             - name: INTERVAL_SECONDS
               value: {{ $interval | quote }}
             - name: PRIMARY_CLUSTER

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -109,15 +109,30 @@ spec:
       # pinned to this same `-primary-ca` (shared client CA, #5245).
       # Both Secrets exist natively on cluster-A (CNPG issued them for
       # this Cluster).
+      #
+      # 🛑 NO sslRootCert HERE (0.2.20, #5245 hw278 live-proof): the
+      # SERVER this connection dials is region-B's replica Cluster,
+      # whose server chain is signed by region-B's OWN `-replica-ca` —
+      # a Secret cluster-A does not hold. 0.2.18/0.2.19 pinned
+      # sslRootCert to region-A's own `-primary-ca`, and because
+      # libpq/pgx upgrade sslmode=require to verify-ca semantics
+      # whenever a root cert IS supplied, the re-clone's pgbasebackup
+      # bootstrap FATAL-looped every 5s on `x509: certificate signed by
+      # unknown authority` for 5+ hours (hw278, Job
+      # <primary>-1-pgbasebackup). With no root cert, sslmode=require
+      # is encrypted without server-chain verification — the same
+      # posture as every other in-mesh streaming hop; peer authenticity
+      # rides the client-cert requirement (region-B verifies THIS cert
+      # against the shared client CA) + the Cilium ClusterMesh identity
+      # path. The forward direction (replica-cluster.yaml) KEEPS its
+      # root pin — there `-primary-ca` genuinely signs the server it
+      # dials.
       sslKey:
         name: {{ include "cnpg-pair.fullname" . }}-primary-replication
         key: tls.key
       sslCert:
         name: {{ include "cnpg-pair.fullname" . }}-primary-replication
         key: tls.crt
-      sslRootCert:
-        name: {{ include "cnpg-pair.fullname" . }}-primary-ca
-        key: ca.crt
 {{- else }}
   bootstrap:
     initdb:

--- a/platform/cnpg-pair/chart/templates/replica-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/replica-cluster.yaml
@@ -74,8 +74,15 @@ spec:
   # That reverse-direction auth is what the #5245 failback rides:
   # the demoted region-A streams FROM this cluster (post-promote)
   # presenting the only client cert cluster-A natively holds. Server
-  # certs are untouched (sslmode=require skips server-chain
-  # verification on every streaming path in this chart).
+  # certs are untouched — but NOTE (0.2.20, hw278 live-proof):
+  # sslmode=require skips server-chain verification ONLY when no
+  # sslRootCert is supplied; libpq/pgx upgrade `require` to verify-ca
+  # semantics the moment a root cert IS provided. The forward stream
+  # below carries sslRootCert=-primary-ca and verifies fine (that CA
+  # signs region-A's server leafs); the failback stream
+  # (primary-cluster.yaml demoted shape) carries NO root cert, because
+  # THIS cluster's server chain is signed by its own `-replica-ca`,
+  # which cluster-A does not hold.
   certificates:
     clientCASecret: {{ include "cnpg-pair.fullname" . }}-primary-ca
 

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -1147,10 +1147,22 @@ python3 - "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5245 delete-guard order
 import sys
 s=open(sys.argv[1]).read()
 import re
-for m in re.finditer(r'delete clusters', s):
-    head = s[:m.start()]
-    assert 'peer_fresh' in head.rsplit('exit 0',1)[-1] or 'peer_fresh ||' in s[max(0,m.start()-600):m.start()], \
-        "every kubectl delete of the Cluster CR must be immediately preceded by a peer_fresh guard"
+deletes=list(re.finditer(r'delete clusters', s))
+assert deletes, "actor must carry the bounded Cluster-CR delete"
+for m in deletes:
+    win = s[max(0,m.start()-900):m.start()]
+    # 0.2.20 (#5245 hw278): the peer proof may be the full TL-arithmetic
+    # form (peer_fresh) or, on the divergence path where the local line is
+    # psql-dark, the writable-only form (peer_fresh_writable) — both carry
+    # the 'peer_fresh' prefix.
+    assert 'peer_fresh' in win, \
+        "every kubectl delete of the Cluster CR must be guarded by a fresh peer proof (peer_fresh / peer_fresh_writable)"
+    # 0.2.20 (#5245 hw278): the delete GC'd the CNPG-issued PKI Secrets
+    # (-ca/-replication/-server are Cluster-owned), CNPG re-issued a FRESH
+    # CA, and region-B's one-shot synced clientCASecret copy could never
+    # trust the re-cloned cluster's new client leaf again.
+    assert 'preserve_pki' in win, \
+        "every kubectl delete of the Cluster CR must be immediately preceded by preserve_pki (the hw278 CA-GC trust break)"
 PYEOF
 python3 - "$TMP/cnp-primary.yaml" <<'PYEOF' || { echo "FAIL: #5245 dr-failback RBAC assertions failed." >&2; exit 1; }
 import sys, yaml
@@ -1246,5 +1258,148 @@ sh -n "$TMP/actor.sh"   || { echo "FAIL: #5245 dr-promoter actor script is not v
 sh -n "$TMP/signals.sh" || { echo "FAIL: #5245 dr-promoter signals script is not valid POSIX shell." >&2; exit 1; }
 
 echo "  PASS (peers-gated dr-failback · demoted pg_basebackup rejoin shape · shared client CA + -replica-mesh · durable substitute seams + latch lift · TL-ahead re-promote · bounded resourceNames-pinned destruction)"
+
+# ── Case 20: #5245 hw278 residual — the re-clone must CONVERGE to streaming ─
+# hw278 G12 live-proof: the 0.2.19 chain fired clean (demote 23:10:36Z,
+# wedge escalation + bounded delete 23:20:50Z) and the RE-CLONE ITSELF then
+# wedged silently for 5+ hours — (1) the demoted externalCluster pinned
+# sslRootCert to region-A's OWN -primary-ca while the server it dials is
+# region-B's replica Cluster (server chain signed by region-B's own
+# -replica-ca): libpq/pgx upgrade sslmode=require to verify-ca semantics
+# whenever a root cert IS supplied → pgbasebackup FATAL-looped on `x509:
+# certificate signed by unknown authority`; (2) the delete GC'd the
+# Cluster-owned PKI Secrets and CNPG re-issued a FRESH CA, orphaning
+# region-B's one-shot synced clientCASecret trust; (3) the actor fell
+# through to a silent exit on every tick post-delete.
+echo "[render] Case 20: #5245 hw278 — no wrong-CA sslRootCert on the rejoin stream + preserve_pki + ConsistentSystemID divergence escalation + episode-marker self-heal + post-re-clone watch"
+
+# (a) REJOIN STREAM TLS: the demoted externalCluster must NOT pin a root
+#     cert (cluster-A does not hold region-B's -replica-ca; any root pin
+#     upgrades require→verify-ca and is structurally unsatisfiable). The
+#     FORWARD stream keeps its root pin — there -primary-ca genuinely signs
+#     the dialed server.
+python3 - "$TMP/demoted.yaml" <<'PYEOF' || { echo "FAIL: #5245 hw278 demoted externalCluster TLS assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+c=[d for d in docs if d.get('kind')=='Cluster'][0]
+ext=c['spec']['externalClusters'][0]
+assert 'sslRootCert' not in ext, \
+    "demoted externalCluster must NOT carry sslRootCert (region-B's server chain is signed by region-B's own -replica-ca, which cluster-A does not hold; a root pin upgrades sslmode=require to verify-ca → the hw278 x509 FATAL loop)"
+assert ext['connectionParameters'].get('sslmode')=='require', "rejoin stream must keep sslmode=require (encrypted)"
+assert ext['sslCert']['name'].endswith('-primary-replication'), "rejoin stream must keep region-A's own client cert (region-B verifies it against the shared client CA)"
+PYEOF
+python3 - "$TMP/replica.yaml" <<'PYEOF' || { echo "FAIL: #5245 hw278 forward externalCluster root-pin regression." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+c=[d for d in docs if d.get('kind')=='Cluster'][0]
+ext=c['spec']['externalClusters'][0]
+assert ext.get('sslRootCert',{}).get('name','').endswith('-primary-ca'), \
+    "FORWARD externalCluster must KEEP sslRootCert=-primary-ca (that CA genuinely signs region-A's server leafs — verify-ca there is correct and must not be weakened)"
+PYEOF
+
+# (b) PKI PRESERVATION: preserve_pki strips the Cluster ownerReferences from
+#     the three CNPG-issued PKI Secrets before EVERY delete (the per-delete
+#     ordering is pinned in Case 19's delete-guard assertion); RBAC grants
+#     get+patch ONLY, resourceNames-pinned to exactly those Secrets.
+grep -q 'preserve_pki' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 actor missing preserve_pki (the CA-GC trust break: delete GC'd -ca/-replication/-server, CNPG re-issued a fresh CA, region-B's synced clientCASecret copy orphaned)." >&2; exit 1; }
+grep -q 'ownerReferences' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 preserve_pki must strip the ownerReferences (merge-patch to []) so the Secrets survive the Cluster delete." >&2; exit 1; }
+python3 - "$TMP/cnp-primary.yaml" <<'PYEOF' || { echo "FAIL: #5245 hw278 PKI-Secret RBAC assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+roles=[d for d in docs if d.get('kind')=='Role' and 'dr-failback' in d['metadata']['name'] and d['metadata'].get('namespace') is None]
+assert roles, "local-namespace dr-failback Role not found"
+secr=[r for role in roles for r in role.get('rules',[]) if 'secrets' in r.get('resources',[])]
+assert len(secr)==1, f"expected exactly ONE secrets rule, got {len(secr)}"
+rule=secr[0]
+assert sorted(rule['verbs'])==['get','patch'], f"secrets verbs must be exactly get+patch, got {rule['verbs']}"
+names=rule.get('resourceNames',[])
+assert len(names)==3 and all(n.endswith(('-ca','-replication','-server')) for n in names), \
+    f"secrets rule must be resourceNames-pinned to the three PKI Secrets, got {names}"
+PYEOF
+
+# (c) DIVERGENCE ESCALATION: the actor reads CNPG's ConsistentSystemID
+#     condition and escalates a PRE-episode demoted CR that holds False past
+#     the grace window — no dependence on a 600s-contiguous psql wedge clock.
+#     The delete is guarded by the writable-peer freshness proof and the
+#     ts_lt pre-episode bound (a fresh clone is NEVER deleted).
+grep -q 'ConsistentSystemID' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 actor must read the ConsistentSystemID condition (CNPG's own cannot-consistently-follow signal — the psql-independent divergence detector)." >&2; exit 1; }
+grep -q 'DIVERGENCE DETECTED' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 actor must log the divergence detection loudly (divergence clock start)." >&2; exit 1; }
+grep -q 'DIVERGENCE ESCALATION' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 actor missing the divergence escalation (re-clone trigger)." >&2; exit 1; }
+grep -q 'peer_fresh_writable' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 the divergence delete must require a fresh writable-peer proof (peer_fresh_writable) — the local line is psql-dark there, so the TL-arithmetic proof is structurally unavailable." >&2; exit 1; }
+python3 - "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5245 hw278 divergence-escalation bounds assertions failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+i=s.find('DIVERGENCE ESCALATION')
+assert i!=-1
+# The escalation lives INSIDE the pre-episode branch: the ts_lt CR-predates-
+# episode guard must open before it (bounded destruction — a fresh clone,
+# which postdates the episode, can never reach this delete).
+guard=s.rfind('ts_lt "${CR_CREATED}" "${STARTED_AT}"', 0, i)
+assert guard!=-1, "divergence escalation must sit inside the ts_lt pre-episode guard"
+blk=s[guard:i]
+assert 'DIVERGENCE_GRACE_SECONDS' in blk, "escalation must hold for the divergenceGraceSeconds window (no thrash on a transient False)"
+assert 'diverged-since' in blk, "escalation must accrue a divergence clock, not fire on a single observation"
+# NOTHING deletes the Cluster after the post-re-clone watch begins (the
+# postdates-episode branch): the fresh clone is observation-only.
+w=s.find('POST-RE-CLONE convergence watch')
+assert w!=-1, "actor missing the post-re-clone convergence watch"
+assert 'delete clusters' not in s[w:], "the postdates-episode branch must NEVER delete (bounded destruction)"
+PYEOF
+# Grace window default is 180s (values → env).
+python3 - "$TMP/cnp-primary.yaml" <<'PYEOF' || { echo "FAIL: #5245 hw278 DIVERGENCE_GRACE_SECONDS env assertion failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-failback' in d['metadata']['name']][0]
+actor=[c for c in dep['spec']['template']['spec']['containers'] if c['name']=='actor'][0]
+env={e['name']:e.get('value') for e in actor.get('env',[])}
+assert env.get('DIVERGENCE_GRACE_SECONDS')=='180', f"DIVERGENCE_GRACE_SECONDS must default 180, got {env.get('DIVERGENCE_GRACE_SECONDS')!r}"
+PYEOF
+
+# (d) EPISODE-MARKER SELF-HEAL: a lost dr-failback-started-at annotation
+#     write silently disabled EVERY escalation (fail-silent one-shot). The
+#     actor must re-write it, loudly, whenever the demotion is rendered but
+#     the marker is absent.
+grep -q 'self-healing the episode marker' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 actor missing the episode-marker (dr-failback-started-at) self-heal." >&2; exit 1; }
+
+# (e) POST-RE-CLONE WATCH: a wedged re-clone must name itself — phase +
+#     ConsistentSystemID logged periodically until streaming converges.
+grep -q 'RE-CLONE NOT YET STREAMING' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 actor missing the post-re-clone convergence heartbeat (the 5h-silent wedge)." >&2; exit 1; }
+
+# (f) DARK-WINDOW PEER PROOF: the signals container must keep the
+#     writable-peer proof fresh while the local cluster is psql-dark — the
+#     'unknown' arm probes writability instead of dropping all evidence.
+grep -q 'probe_peer_writable' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 hw278 signals missing probe_peer_writable (the split writable-only probe)." >&2; exit 1; }
+python3 - "$TMP/fb-signals.sh" <<'PYEOF' || { echo "FAIL: #5245 hw278 unknown-arm peer-probe assertion failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+i=s.find('unknown|*)')
+assert i!=-1, "signals ladder lost its unknown arm"
+arm=s[i:s.find('esac',i)]
+assert 'probe_peer_writable' in arm, "the unknown arm must probe peer writability (the divergence escalation needs a fresh proof precisely while local psql is dark)"
+assert 'clear_hold' in arm and 'clear_wedge' in arm, "the unknown arm must KEEP its fail-safe clears (healthy no-op: no promote/wedge evidence accrues from darkness)"
+PYEOF
+# HEALTHY-PAIR NO-OP: a local primary with its pinned sync standby PRESENT
+# clears the hold clock (no failback evidence), and a streaming standby
+# clears the wedge clock (converged) — the actor's destructive paths all sit
+# behind demote-rendered + pre-episode + hold/grace + fresh-peer guards.
+grep -q 'local primary with sync standby' "$TMP/fb-signals.sh" || {
+  echo "FAIL: #5245 healthy-pair no-op regression: a local primary with its sync standby present must clear the hold clock." >&2; exit 1; }
+awk '/streaming\)/{f=1} f&&/clear_wedge/{print "OK"; exit}' "$TMP/fb-signals.sh" | grep -q OK || {
+  echo "FAIL: #5245 converged no-op regression: the streaming state must clear the wedge clock." >&2; exit 1; }
+
+# (g) Scripts still valid POSIX shell with the 0.2.20 additions.
+sh -n "$TMP/fb-signals.sh" || { echo "FAIL: #5245 hw278 signals script is not valid POSIX shell." >&2; exit 1; }
+sh -n "$TMP/fb-actor.sh"   || { echo "FAIL: #5245 hw278 actor script is not valid POSIX shell." >&2; exit 1; }
+
+echo "  PASS (no wrong-CA root pin on the rejoin stream + forward pin kept · preserve_pki before every delete + pinned get/patch RBAC · ConsistentSystemID divergence escalation, graced + pre-episode-bounded + writable-proof-guarded · episode-marker self-heal · post-re-clone watch · dark-window peer probe · healthy-pair no-op)"
 
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -120,6 +120,18 @@ cnpgPair:
       # created AFTER the failback started is NEVER deleted (bounded
       # destruction: at most one re-clone per failback episode).
       wedgeHoldSeconds: 600
+      # 0.2.20 (#5245 hw278): how long the in-place-demoted Cluster's
+      # ConsistentSystemID condition (CNPG's own cannot-consistently-
+      # follow-the-source signal) must stay False before the actor
+      # escalates to the re-clone. Unlike the wedge clock this detector
+      # needs NO contiguous psql observability — the demoted standby
+      # restarts through the in-place switch and every 'unknown' tick
+      # resets the 600s wedge clock, which is how hw278 crawled to its
+      # escalation. Applies ONLY to a Cluster CR that predates the
+      # failback episode; a fresh clone reporting False mid-bootstrap
+      # is never deleted (bounded destruction), and the delete still
+      # requires a <60s-fresh writable-peer proof.
+      divergenceGraceSeconds: 180
       # The flux Kustomization whose postBuild.substitute map carries
       # the durable SOVEREIGN_CNPG_PAIR_DEMOTED flip (the catalyst-api
       # enableCNPGPairAfterFullMesh precedent — a custom field manager

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3509,7 +3509,17 @@ name: bp-catalyst-platform
 #   footprint to fit the 4-CPU `plan-quota` (the 0.4.21 oidc-config post-install
 #   hook requested a 500m CPU limit into a namespace with only 250m of quota
 #   headroom → the hook pod was NEVER created → HR timeout → no HTTPRoute → 404).
-version: 1.4.1182
+# 1.4.1183 — #5245: catalog-seed bp-cnpg-pair pin 0.2.19 -> 0.2.20 (spec.version
+#   display-label lockstepped too, #4988 precedent; lockstep w/ platform/
+#   cnpg-pair chart + blueprint.yaml + bootstrap-kit slot 16b). dr-failback
+#   RE-CLONE CONVERGENCE (hw278 residual): the demoted externalCluster drops
+#   the wrong-CA sslRootCert (require+rootcert = verify-ca in libpq/pgx → the
+#   pgbasebackup x509 FATAL loop), preserve_pki strips the Secret
+#   ownerReferences before every bounded delete (a GC'd CA orphaned region-B's
+#   synced clientCASecret trust), ConsistentSystemID divergence escalation +
+#   episode-marker self-heal + post-re-clone convergence watch kill the
+#   silent-wedge class on the re-clone leg.
+version: 1.4.1183
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -411,7 +411,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.13"
+  # 0.2.20 (#5245): dr-failback re-clone convergence (hw278 residual) —
+  # keep this display-version in lockstep with delivery source.version +
+  # blueprint.yaml (the #4988 precedent).
+  version: "0.2.20"
   visibility: listed
   card:
     title: "CNPG Cluster-Pair (Active-Hotstandby DR)"
@@ -441,7 +444,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.19"
+    version: "0.2.20"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
Refs #5245 #5268 #5248

## The residual gap (hw278 live forensics, read this session)

#5268 (0.2.19) fixed the primary #5245 defect — the \`-ge\` DETECT gate demoted region-A cleanly at 122s with no split-brain. This PR fixes the residual leg: **the demoted region never converged to streaming**. Live on hw278 (kubeconfig \`/tmp/hw278-a.kubeconfig\`):

- actor log: demote 23:10:36Z → wedge escalation + bounded delete **23:20:50Z** (the 0.2.18/0.2.19 machinery worked) → **then silence for 5+ hours**
- the re-created Cluster (creationTimestamp 23:21:00Z) sat at phase \`Setting up primary\`, \`ConsistentSystemID=False(NotFound)\`, \`wal_receiver\` empty
- its \`-1-pgbasebackup\` Job FATAL-looped every 5s: \`x509: certificate signed by unknown authority\` against \`-replica-mesh\`
- cluster-A's \`-primary-ca\`/\`-replication\`/\`-server\` Secrets were re-issued 117m ago (GC'd with the deleted CR — controller ownerReference live-verified) while cluster-B still holds the 3h58m-old synced \`-primary-ca\` copy its \`clientCASecret\` pins

## Fixes (bp-cnpg-pair 0.2.20 — CNPG-idiomatic re-clone = delete the CR, helm re-creates the demoted shape, CNPG \`bootstrap.pg_basebackup\` clones region-B; this PR makes that bootstrap actually able to connect, authenticate, and be observed)

1. **No \`sslRootCert\` on the rejoin stream** (\`primary-cluster.yaml\` demoted externalCluster): the dialed server is region-B's replica Cluster, signed by region-B's own \`-replica-ca\` — a Secret cluster-A does not hold. libpq/pgx upgrade \`sslmode=require\` to verify-ca semantics whenever a root cert IS supplied, so this leg was structurally unconnectable. Forward stream keeps its pin (there \`-primary-ca\` genuinely signs the dialed server).
2. **\`preserve_pki\` before every bounded delete** (\`dr-failback.yaml\` actor): strips the Cluster ownerReferences from the three CNPG-issued PKI Secrets (\`--field-manager=dr-failback\`) so the CA lineage survives the delete; CNPG adopts the surviving Secrets on re-create (BYO path) and region-B's synced client-CA trust stays unbroken. Failed strip = no delete that tick. RBAC: +\`secrets\` get/patch, resourceNames-pinned to exactly the three.
3. **Fail-loud escalation + observability** (\`dr-failback.yaml\`):
   - **ConsistentSystemID divergence escalation**: a PRE-episode (in-place-demoted) CR holding CNPG's own condition False for \`failback.divergenceGraceSeconds\` (default 180) with a <60s-fresh writable-peer proof escalates to the re-clone — no dependence on the 600s-contiguous psql wedge clock (which resets on every psql-dark tick while the demoted standby restarts through the switch). Fresh clones are NEVER deleted — bounded destruction unchanged, one re-clone per divergence detection, wedgeHold path retained.
   - **Episode-marker self-heal**: a lost one-shot \`dr-failback-started-at\` write silently disabled EVERY escalation (\`ts_lt\` never passes). Re-written loudly whenever the demotion is rendered but the marker is absent.
   - **Post-re-clone convergence watch**: phase + ConsistentSystemID status/reason logged every ~30 ticks until streaming — divergence detected → re-clone triggered → streaming / still-not-streaming are all named in the logs.
   - **Signals**: \`probe_peer_writable\` (split writable-only probe) keeps the peer proof fresh in the psql-dark \`unknown\` arm; healthy pair stays a strict no-op (hold cleared on sync-standby-present, wedge cleared on streaming).

## Tests

- \`platform/cnpg-pair/chart/tests/cnpg-pair-render.sh\`: **all 20 cases green** — new Case 20 pins the no-root-pin rejoin stream (+ forward-pin regression), preserve_pki ordering before every delete + pinned RBAC, the graced/pre-episode-bounded/writable-proof-guarded divergence escalation, the self-heal, the watch, the dark-window probe, and the healthy no-op; Case 19's delete-guard assertion strengthened (every delete now also requires \`preserve_pki\`).
- Actor's ConsistentSystemID jsonpath validated **verbatim against live hw278**: \`true|2026-07-19T23:21:00Z||False|NotFound|Setting up primary\`.
- Lockstep (four-surface): chart 0.2.20 + \`blueprint.yaml\` + bootstrap-kit slot 16b + catalog-seed (delivery pin AND \`spec.version\` display label, #4988 precedent); \`bp-catalyst-platform\` 1.4.1182 → 1.4.1183. \`TestBootstrapKit_BlueprintVersionLockstepSweep\` + \`TestCatalogSeed_DeliveryPinsNotBehindComponentCharts\` **PASS locally**.

Live validation rides the next fresh 2-region G12 kill+recover walk: after the demote, region-a must reach \`pg_stat_wal_receiver\` non-empty against region-b with \`ConsistentSystemID=True\` — no hand-heals on hw278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)