### PR TITLE
fix(catalyst-api): Reloader-watch catalyst-pin-broker-credentials — stop cold OIDC broker SSO 404 (Refs #5277)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1259,7 +1259,12 @@ spec:
       #   the rejoin stream, preserve_pki before every bounded delete,
       #   ConsistentSystemID divergence escalation + episode-marker
       #   self-heal + post-re-clone watch. Lockstep w/ Chart.yaml.
-      version: 1.4.1184
+      # 1.4.1185 — #5277: catalyst-api secret.reloader now also watches
+      #   catalyst-pin-broker-credentials, so a Pod that booted (or was
+      #   cutover-rolled) before that Secret was reflected rolls when it
+      #   lands and wires the /oidc/* provider routes — killing the cold
+      #   catalyst-pin broker 404 (hw278 SSO). Lockstep w/ Chart.yaml.
+      version: 1.4.1185
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3519,7 +3519,17 @@ name: bp-catalyst-platform
 #   synced clientCASecret trust), ConsistentSystemID divergence escalation +
 #   episode-marker self-heal + post-re-clone convergence watch kill the
 #   silent-wedge class on the re-clone leg.
-version: 1.4.1184
+# 1.4.1185 — #5277: add catalyst-pin-broker-credentials to the catalyst-api
+#   secret.reloader watch. That reflector-mirrored Secret feeds
+#   CATALYST_PIN_BROKER_CLIENT_SECRET via an optional valueFrom; when catalyst-api
+#   starts (or is rolled by the cutover catalyst-api-env-patch step) before the
+#   Secret lands, the value resolves "" and main.go silently skips the /oidc/*
+#   provider routes for the Pod's lifetime → Keycloak's cold catalyst-pin broker
+#   roundtrip 404s ("Unexpected error when authenticating with identity provider")
+#   while warm SSO works (hw278: harbor/openbao/guacamole/pdns-admin/hubble). Same
+#   self-heal idiom already used for handover-jwt-public + provisioning-github-token.
+#   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync gate).
+version: 1.4.1185
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -89,8 +89,18 @@ metadata:
     # populates GITHUB_TOKEN only after the PAT mint (a later Flux reconcile), so the
     # Pod must restart then to pick up CATALYST_GITOPS_TOKEN, else Org-creation
     # (POST /sme/tenants) fails "gitops token unconfigured" (caught live hw104 2026-06-08).
+    # catalyst-pin-broker-credentials added (#5277): SAME race, cold-SSO edition.
+    # CATALYST_PIN_BROKER_CLIENT_SECRET reads that reflector-mirrored Secret via an
+    # optional valueFrom; when catalyst-api starts (or is rolled by the cutover
+    # catalyst-api-env-patch step) before the Secret lands, the value resolves ""
+    # and main.go silently skips the whole /oidc/* provider route set for the
+    # Pod's lifetime. Keycloak's cold catalyst-pin broker roundtrip then 404s
+    # ("Unexpected error when authenticating with identity provider"); warm SSO
+    # (an existing realm session, which skips the broker) is unaffected — the exact
+    # hw278 signature across harbor/openbao/guacamole/pdns-admin/hubble. Reloader
+    # rolls the Pod when the Secret is reflected, so the routes wire on the restart.
     configmap.reloader.stakater.com/reload: "sovereign-fqdn"
-    secret.reloader.stakater.com/reload: "handover-jwt-public,provisioning-github-token"
+    secret.reloader.stakater.com/reload: "handover-jwt-public,provisioning-github-token,catalyst-pin-broker-credentials"
 spec:
   replicas: 1
   # Recreate strategy is required because the deployments PVC is RWO

--- a/products/catalyst/chart/tests/oidc-broker-secret-reloader-contract.sh
+++ b/products/catalyst/chart/tests/oidc-broker-secret-reloader-contract.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — catalyst-api OIDC-broker-secret Reloader watch contract gate (#5277).
+#
+# Guards the cold-broker SSO 404 root cause diagnosed on hw278 (cutoverComplete=true):
+# ten UAT rows (harbor 32/111/181, openbao 33/113/183, guacamole 35/115,
+# pdns-admin 36, hubble 39) failed SSO identically — the cold catalyst-pin OIDC
+# broker roundtrip to api.<fqdn>/oidc/* returned HTTP 404, so Keycloak rendered
+# "Unexpected error when authenticating with identity provider". WARM SSO (an
+# existing realm session, which skips the broker) worked.
+#
+# Mechanism: catalyst-api wires CATALYST_PIN_BROKER_CLIENT_SECRET from the
+# reflector-mirrored `catalyst-pin-broker-credentials` Secret via an
+# `optional: true` valueFrom. main.go (cmd/api/main.go) registers the /oidc/*
+# provider routes ONLY when that secret env is non-empty at process start. When
+# catalyst-api boots — or is rolled by the cutover catalyst-api-env-patch step —
+# before the Secret is reflected into catalyst-system, the value resolves "" and
+# the routes are silently skipped for the Pod's lifetime, permanently 404-ing the
+# cold broker path.
+#
+# The self-heal is Stakater Reloader: the Pod-template `secret.reloader.stakater.com/reload`
+# annotation must list `catalyst-pin-broker-credentials` so the Deployment rolls
+# when the Secret lands (identical idiom already used for handover-jwt-public — the
+# SOVEREIGN_FQDN race, otech62 — and provisioning-github-token — #3122, hw104).
+# It was omitted; this gate makes any future drop of that watch (or of the env
+# wiring it protects) fail Blueprint Release publish BEFORE the OCI artifact
+# reaches a Sovereign.
+#
+# Test framework: pure `helm template` + grep on rendered YAML, matching the
+# established tests/sovereign-fqdn-lb-ip-contract.sh pattern. Picked up
+# automatically by .github/workflows/blueprint-release.yaml.
+#
+# Usage: bash tests/oidc-broker-secret-reloader-contract.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+API_TEMPLATE="templates/api-deployment.yaml"
+PIN_SECRET="catalyst-pin-broker-credentials"
+
+helm template smoke . \
+  --set global.sovereignFQDN=omantel.biz \
+  --show-only "${API_TEMPLATE}" > "$TMP/api.yaml"
+
+echo "[oidc-broker-reloader] Case 1: secret.reloader watch lists ${PIN_SECRET} (#5277)"
+RELOAD_LINE="$(grep -E '^[[:space:]]*secret\.reloader\.stakater\.com/reload:' "$TMP/api.yaml" | head -1)"
+if [ -z "${RELOAD_LINE}" ]; then
+  echo "FAIL: catalyst-api Pod template carries NO secret.reloader.stakater.com/reload annotation — the boot-race self-heal for optional valueFrom secrets is gone (#5277 / #3122)" >&2
+  exit 1
+fi
+if ! printf '%s' "${RELOAD_LINE}" | grep -q "${PIN_SECRET}"; then
+  echo "FAIL: secret.reloader watch omits ${PIN_SECRET} — catalyst-api that booted before the pin-broker Secret was reflected will NEVER roll, so /oidc/* stays unwired and Keycloak's cold catalyst-pin broker 404s (hw278 SSO)" >&2
+  echo "  rendered: ${RELOAD_LINE}" >&2
+  exit 1
+fi
+echo "  PASS (${RELOAD_LINE##*reload: })"
+
+echo "[oidc-broker-reloader] Case 2: the existing boot-race watches are NOT regressed by the additive fix"
+for SECRET in handover-jwt-public provisioning-github-token; do
+  if ! printf '%s' "${RELOAD_LINE}" | grep -q "${SECRET}"; then
+    echo "FAIL: secret.reloader watch dropped ${SECRET} — a pre-existing boot-race self-heal (SOVEREIGN_FQDN / gitops-token) regressed" >&2
+    echo "  rendered: ${RELOAD_LINE}" >&2
+    exit 1
+  fi
+done
+echo "  PASS (handover-jwt-public + provisioning-github-token still watched)"
+
+echo "[oidc-broker-reloader] Case 3: the watched Secret is the SAME one CATALYST_PIN_BROKER_CLIENT_SECRET sources from (lockstep — no drift)"
+if ! grep -q "CATALYST_PIN_BROKER_CLIENT_SECRET" "$TMP/api.yaml"; then
+  echo "FAIL: catalyst-api no longer wires CATALYST_PIN_BROKER_CLIENT_SECRET — the /oidc/* provider secret env is gone; the Reloader watch protects nothing" >&2
+  exit 1
+fi
+# The env's secretKeyRef.name must be the SAME secret the Reloader watches, or the
+# self-heal targets the wrong resource and the cold-broker 404 reappears silently.
+if ! awk '/CATALYST_PIN_BROKER_CLIENT_SECRET/,/key:/' "$TMP/api.yaml" | grep -q "name: ${PIN_SECRET}"; then
+  echo "FAIL: CATALYST_PIN_BROKER_CLIENT_SECRET does not source from ${PIN_SECRET} — env/Reloader-watch names drifted; the #5277 self-heal watches a Secret the Pod does not read" >&2
+  awk '/CATALYST_PIN_BROKER_CLIENT_SECRET/,/key:/' "$TMP/api.yaml" >&2 || true
+  exit 1
+fi
+echo "  PASS (CATALYST_PIN_BROKER_CLIENT_SECRET ← ${PIN_SECRET}, matches the Reloader watch)"
+
+echo "[oidc-broker-reloader] All gates green."


### PR DESCRIPTION
## Problem (hw278, cutoverComplete=true, authed browser walk)

Ten UAT rows fail SSO with one signature: the **cold** catalyst-pin OIDC broker roundtrip to `api.<sovereign-fqdn>/oidc/*` returns **HTTP 404**, so Keycloak renders *"Unexpected error when authenticating with identity provider"*. **Warm** SSO (an existing Keycloak realm session, which skips the broker roundtrip) works. Affected apps: harbor (rows 32/111/181), openbao (33/113/183), guacamole (35/115), pdns-admin (36), hubble (39).

## Root cause

`products/catalyst/bootstrap/api/cmd/api/main.go:738` wires the `/oidc/*` provider routes only when `signer != nil && issuerURL != "" && clientSecret != ""` — evaluated **once** at process start. `clientSecret` is `CATALYST_PIN_BROKER_CLIENT_SECRET`, sourced from the reflector-mirrored `catalyst-pin-broker-credentials` Secret via an `optional: true` `secretKeyRef` (`products/catalyst/chart/templates/api-deployment.yaml:836`).

The catalyst-api Pod already carries a Stakater Reloader watch for exactly this class of boot-race optional `valueFrom` value — `handover-jwt-public` (the SOVEREIGN_FQDN race, otech62) and `provisioning-github-token` (#3122, hw104) — but `catalyst-pin-broker-credentials` was omitted. When catalyst-api starts, or is rolled by the cutover `catalyst-api-env-patch` step, **before** that Secret is reflected into `catalyst-system`, the env resolves `""`, the `/oidc/*` routes are silently skipped for the Pod's whole life, and no Reloader event ever rolls the Pod once the Secret lands. Cold broker SSO then 404s permanently; warm SSO never touches the broker so it is unaffected.

## Fix

Add `catalyst-pin-broker-credentials` to the `secret.reloader.stakater.com/reload` annotation so the Deployment rolls when the Secret is reflected after boot and the `/oidc/*` routes wire on the restart. Smallest correct change — it reuses the proven self-heal idiom already in this same annotation, and the annotation-only class of race that #3122 fixed for the gitops token.

- `products/catalyst/chart/templates/api-deployment.yaml` — add the watch + document the same-class race.
- `products/catalyst/chart/Chart.yaml` — `1.4.1184` -> `1.4.1185`; bootstrap-kit slot-13 pin (`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`) bumped in lockstep.
- `products/catalyst/chart/tests/oidc-broker-secret-reloader-contract.sh` — new chart-render gate: fails Blueprint Release publish if the watch, its co-listed watches, or the `CATALYST_PIN_BROKER_CLIENT_SECRET` env wiring drift. Verified green with the fix and red when reverted (negative control).

`helm template` (125 docs) + `helm lint` clean.

Refs #5277 #3374 #2725