### PR TITLE
fix(console): migrate operator console off deprecated /tenant/orgs alias to canonical /organizations (row 214)

### DIFF
--- a/core/console/src/lib/api.ts
+++ b/core/console/src/lib/api.ts
@@ -137,17 +137,16 @@ export const logoutAll = () =>
   request<{ message: string }>('/auth/logout-all', { method: 'POST' });
 
 // Organizations
-// Org CRUD rides the canonical `/organizations` routes (#3383 — served by
-// core/services/tenant routes.go via the gateway's /api/organizations).
-// The member / app / backing-service sub-resources below still live ONLY
-// under the legacy `/tenant/orgs/{id}/...` back-end paths — those URL
-// strings are the wire contract until the BE grows canonical aliases
-// (#3383 alias-removal checklist).
+// Org CRUD + the member / app / backing-service sub-resources all ride the
+// canonical `/organizations` routes (#3383 — served by core/services/tenant
+// routes.go via the gateway's /api/organizations). The tenant service keeps
+// the legacy `/tenant/orgs/{id}/...` paths as one-release deprecation aliases,
+// so nothing breaks during a rolling deploy.
 export const getMyOrgs = () => request<Org[]>('/organizations');
 export const getOrg = (id: string) => request<Org>(`/organizations/${id}`);
-export const getMembers = (orgId: string) => request<Member[]>(`/tenant/orgs/${orgId}/members`);
+export const getMembers = (orgId: string) => request<Member[]>(`/organizations/${orgId}/members`);
 export const inviteMember = (orgId: string, email: string, role: string) =>
-  request<Member>(`/tenant/orgs/${orgId}/members`, { method: 'POST', body: JSON.stringify({ email, role }) });
+  request<Member>(`/organizations/${orgId}/members`, { method: 'POST', body: JSON.stringify({ email, role }) });
 export const updateOrg = (orgId: string, patch: { name?: string }) =>
   request<Org>(`/organizations/${orgId}`, { method: 'PUT', body: JSON.stringify(patch) });
 export const deleteOrg = (orgId: string) =>
@@ -261,7 +260,7 @@ export const getJobs = (orgId: string) =>
 // Preview of what an uninstall will do to backing services. Used by the
 // confirm modal so the user sees purge vs retain before proceeding.
 export const getUninstallPreview = (orgId: string, slug: string) =>
-  request<UninstallPreview>(`/tenant/orgs/${orgId}/apps/${slug}/uninstall-preview`);
+  request<UninstallPreview>(`/organizations/${orgId}/apps/${slug}/uninstall-preview`);
 
 // Day-2 app management (backend: task #134 — returns 501 until shipped)
 // dep_choices maps dependency slug -> 'dedicated' | existing instance slug/id.
@@ -271,7 +270,7 @@ export const installApp = (
   depChoices?: Record<string, string>,
 ) =>
   request<{ status: string; message?: string; upgrade_suggestion?: string }>(
-    `/tenant/orgs/${orgId}/apps`,
+    `/organizations/${orgId}/apps`,
     {
       method: 'POST',
       body: JSON.stringify({
@@ -283,7 +282,7 @@ export const installApp = (
 
 export const uninstallApp = (orgId: string, slug: string) =>
   request<{ status: string }>(
-    `/tenant/orgs/${orgId}/apps/${slug}`,
+    `/organizations/${orgId}/apps/${slug}`,
     { method: 'DELETE' },
   );
 
@@ -337,7 +336,7 @@ export const getLaunchURL = async (
 // render name/version/endpoint + a Running/Pending/Failed pill in one call.
 export const getBackingServices = async (orgId: string): Promise<BackingService[]> => {
   const raw = await request<{ services: BackingService[] }>(
-    `/tenant/orgs/${orgId}/backing-services`,
+    `/organizations/${orgId}/backing-services`,
   );
   return raw.services || [];
 };

--- a/core/services/tenant/handlers/routes.go
+++ b/core/services/tenant/handlers/routes.go
@@ -47,22 +47,37 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("PUT /tenant/orgs/{id}", deprecatedAlias("/api/organizations/{id}", h.UpdateOrg))
 	mux.HandleFunc("DELETE /tenant/orgs/{id}", deprecatedAlias("/api/organizations/{id}", h.DeleteOrg))
 
-	// Authenticated — member management.
-	mux.HandleFunc("GET /tenant/orgs/{id}/members", h.ListMembers)
-	mux.HandleFunc("POST /tenant/orgs/{id}/members", h.InviteMember)
-	mux.HandleFunc("DELETE /tenant/orgs/{id}/members/{userId}", h.RemoveMember)
+	// Authenticated — member management (#3383: canonical `/organizations`).
+	mux.HandleFunc("GET /organizations/{id}/members", h.ListMembers)
+	mux.HandleFunc("POST /organizations/{id}/members", h.InviteMember)
+	mux.HandleFunc("DELETE /organizations/{id}/members/{userId}", h.RemoveMember)
 
 	// Authenticated — day-2 app install/uninstall.
-	mux.HandleFunc("POST /tenant/orgs/{id}/apps", h.InstallApp)
-	mux.HandleFunc("DELETE /tenant/orgs/{id}/apps/{slug}", h.UninstallApp)
+	mux.HandleFunc("POST /organizations/{id}/apps", h.InstallApp)
+	mux.HandleFunc("DELETE /organizations/{id}/apps/{slug}", h.UninstallApp)
 	// Preview: what data will be purged vs retained before an uninstall. Feeds
 	// the console's confirm modal so the user sees exactly what they're
 	// about to lose before clicking through.
-	mux.HandleFunc("GET /tenant/orgs/{id}/apps/{slug}/uninstall-preview", h.UninstallPreview)
+	mux.HandleFunc("GET /organizations/{id}/apps/{slug}/uninstall-preview", h.UninstallPreview)
 
-	// Authenticated — backing-service inventory per tenant (databases, caches).
-	// Metadata comes from the catalog; pod status is proxied from provisioning.
-	mux.HandleFunc("GET /tenant/orgs/{id}/backing-services", h.ListBackingServices)
+	// Authenticated — backing-service inventory per Organization (databases,
+	// caches). Metadata comes from the catalog; pod status is proxied from
+	// provisioning.
+	mux.HandleFunc("GET /organizations/{id}/backing-services", h.ListBackingServices)
+
+	// naming-guard: alias — legacy `/tenant/orgs/{id}/...` sub-resource paths,
+	// one-release deprecation. #3383 renamed the member / app / backing-service
+	// sub-resources to the canonical `/organizations/{id}/...` block above; the
+	// aliases stay for exactly one release so any consumer still pinned to the
+	// old path keeps working (each emits a Deprecation/Sunset header). Removal
+	// is a checklist row on #3383.
+	mux.HandleFunc("GET /tenant/orgs/{id}/members", deprecatedAlias("/api/organizations/{id}/members", h.ListMembers))
+	mux.HandleFunc("POST /tenant/orgs/{id}/members", deprecatedAlias("/api/organizations/{id}/members", h.InviteMember))
+	mux.HandleFunc("DELETE /tenant/orgs/{id}/members/{userId}", deprecatedAlias("/api/organizations/{id}/members/{userId}", h.RemoveMember))
+	mux.HandleFunc("POST /tenant/orgs/{id}/apps", deprecatedAlias("/api/organizations/{id}/apps", h.InstallApp))
+	mux.HandleFunc("DELETE /tenant/orgs/{id}/apps/{slug}", deprecatedAlias("/api/organizations/{id}/apps/{slug}", h.UninstallApp))
+	mux.HandleFunc("GET /tenant/orgs/{id}/apps/{slug}/uninstall-preview", deprecatedAlias("/api/organizations/{id}/apps/{slug}/uninstall-preview", h.UninstallPreview))
+	mux.HandleFunc("GET /tenant/orgs/{id}/backing-services", deprecatedAlias("/api/organizations/{id}/backing-services", h.ListBackingServices))
 
 	// Internal — unauthenticated service-to-service lookups. Expected to be
 	// reachable only via the in-cluster service IP (no gateway / ingress),

--- a/core/services/tenant/handlers/routes_canonical_organizations_5276_test.go
+++ b/core/services/tenant/handlers/routes_canonical_organizations_5276_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #5276 / row 214: the operator console migrated its member / app /
+// backing-service sub-resource calls off the deprecated `/tenant/orgs/{id}/...`
+// alias onto the canonical `/organizations/{id}/...` routes (banned-term
+// eradication — "tenant" → Organization). This test locks in that the tenant
+// service actually registers the canonical routes AND keeps the legacy aliases
+// resolving for one-release deprecation, so the console fix can never silently
+// regress to a 404.
+func TestOrganizationSubResourceRoutes_CanonicalAndLegacyAliases(t *testing.T) {
+	mux, ok := (&Handler{}).Routes().(*http.ServeMux)
+	if !ok {
+		t.Fatalf("Routes() concrete type is not *http.ServeMux")
+	}
+
+	cases := []struct {
+		name        string
+		method      string
+		path        string
+		wantPattern string
+	}{
+		// Canonical `/organizations/{id}/...` sub-resources (the console now
+		// calls these).
+		{"canonical list members", "GET", "/organizations/o1/members", "GET /organizations/{id}/members"},
+		{"canonical invite member", "POST", "/organizations/o1/members", "POST /organizations/{id}/members"},
+		{"canonical remove member", "DELETE", "/organizations/o1/members/u1", "DELETE /organizations/{id}/members/{userId}"},
+		{"canonical install app", "POST", "/organizations/o1/apps", "POST /organizations/{id}/apps"},
+		{"canonical uninstall app", "DELETE", "/organizations/o1/apps/wordpress", "DELETE /organizations/{id}/apps/{slug}"},
+		{"canonical uninstall preview", "GET", "/organizations/o1/apps/wordpress/uninstall-preview", "GET /organizations/{id}/apps/{slug}/uninstall-preview"},
+		{"canonical backing services", "GET", "/organizations/o1/backing-services", "GET /organizations/{id}/backing-services"},
+
+		// Legacy `/tenant/orgs/{id}/...` aliases still resolve (kept for one
+		// release so any pinned consumer keeps working during rolling deploy).
+		{"legacy list members", "GET", "/tenant/orgs/o1/members", "GET /tenant/orgs/{id}/members"},
+		{"legacy invite member", "POST", "/tenant/orgs/o1/members", "POST /tenant/orgs/{id}/members"},
+		{"legacy remove member", "DELETE", "/tenant/orgs/o1/members/u1", "DELETE /tenant/orgs/{id}/members/{userId}"},
+		{"legacy install app", "POST", "/tenant/orgs/o1/apps", "POST /tenant/orgs/{id}/apps"},
+		{"legacy uninstall app", "DELETE", "/tenant/orgs/o1/apps/wordpress", "DELETE /tenant/orgs/{id}/apps/{slug}"},
+		{"legacy uninstall preview", "GET", "/tenant/orgs/o1/apps/wordpress/uninstall-preview", "GET /tenant/orgs/{id}/apps/{slug}/uninstall-preview"},
+		{"legacy backing services", "GET", "/tenant/orgs/o1/backing-services", "GET /tenant/orgs/{id}/backing-services"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			_, pattern := mux.Handler(req)
+			if pattern != tc.wantPattern {
+				t.Errorf("%s %s resolved to pattern %q, want %q", tc.method, tc.path, pattern, tc.wantPattern)
+			}
+		})
+	}
+}
+
+// deprecatedAlias must carry the RFC-8594 Deprecation/Sunset signalling and a
+// successor-version Link pointing at the canonical `/organizations` path, so
+// consumers still on the legacy alias are told where to migrate.
+func TestDeprecatedAlias_EmitsRFC8594Headers(t *testing.T) {
+	called := false
+	h := deprecatedAlias("/api/organizations/{id}/members", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", "/tenant/orgs/o1/members", nil))
+
+	if !called {
+		t.Fatal("deprecatedAlias did not invoke the wrapped handler")
+	}
+	if got := rec.Header().Get("Deprecation"); got != "true" {
+		t.Errorf("Deprecation header = %q, want %q", got, "true")
+	}
+	if got := rec.Header().Get("Sunset"); got == "" {
+		t.Error("Sunset header missing")
+	}
+	if got := rec.Header().Get("Link"); got != `</api/organizations/{id}/members>; rel="successor-version"` {
+		t.Errorf("Link header = %q, want successor-version pointing at the canonical path", got)
+	}
+}


### PR DESCRIPTION
## Problem (UAT row 214, authed walk hw278)

The built operator-console bundle carries **0 'SME'** (the #3985/#5259 rename landed) but residual **'tenant'** tokens remain. `docs/GLOSSARY.md` §Banned-terms maps "tenant" → `Organization` for Catalyst surfaces.

Classifying every residual token in `core/console`:

| Token (bundle-surviving) | Kind | Disposition |
|---|---|---|
| `/tenant/orgs/{id}/members` (getMembers, inviteMember) | #3383-deprecated gateway **alias** to the tenant service | **Migrated → `/organizations/{id}/members`** |
| `/tenant/orgs/{id}/apps…` (installApp, uninstallApp, getUninstallPreview) | deprecated alias | **Migrated → `/organizations/{id}/apps…`** |
| `/tenant/orgs/{id}/backing-services` (getBackingServices) | deprecated alias | **Migrated → `/organizations/{id}/backing-services`** |
| `tenantId` store field | console-internal state / BroadcastChannel field | already `orgId` on main — no change needed |
| `/provisioning/tenant/{id}` + `?tenant_id=` (getProvisionStatus, getJobs) | **provisioning-service** path + query-param wire contract | **Grandfathered** (documented in-code) |
| `/domain/list?tenant_id=` (getDomains) | **domain-service** query-param wire contract | **Grandfathered** |
| `tenant_id` / `tenant_slug` JSON fields (Provision / Job) | backend struct JSON wire contract | **Grandfathered** |
| `org-checkout-tenant` / `org-tenant:` localStorage keys | client key **written by the marketplace SPA** (`core/marketplace`) | **Grandfathered** |

Note: `X-Tenant-Host` does **not** appear anywhere in `core/console` — it is the org-bootstrap SPA (`products/catalyst/bootstrap/ui`) + Go backend routing header, out of this bundle's scope, and a genuinely load-bearing wire header. The walk's mention of it against the console bundle was imprecise.

## Change

The tenant service already served canonical `/organizations` for org CRUD; the member/app/backing sub-resources were the only console calls left on the alias (the source comment even flagged them as waiting "until the BE grows canonical aliases"). This completes that migration in lockstep — **producer and consumer in one PR**:

- **`core/services/tenant/handlers/routes.go`** — register canonical `GET/POST/DELETE /organizations/{id}/members`, `POST/DELETE /organizations/{id}/apps…`, `GET /organizations/{id}/apps/{slug}/uninstall-preview`, `GET /organizations/{id}/backing-services`. The legacy `/tenant/orgs/{id}/...` paths stay as one-release deprecation aliases (`deprecatedAlias`, RFC-8594 `Deprecation`/`Sunset`/`Link`), so a rolling deploy never 404s a pinned consumer. Purely additive on the backend.
- **`core/console/src/lib/api.ts`** — point the six sub-resource calls at `/organizations/*`; refresh the surrounding comment.
- **`routes_canonical_organizations_5276_test.go`** — asserts canonical + legacy patterns both resolve (via `ServeMux.Handler`) and that `deprecatedAlias` emits the successor-version `Link`.

### Why the remaining tokens are grandfathered, not half-renamed

The provisioning/domain path + query-param + JSON-field names are owned by **other services'** Go structs and routing; renaming them means a lockstep change across `core/services/provisioning` and `core/services/domain` plus rolling-deploy ordering, which cannot be verified here. The localStorage keys are **written by the marketplace SPA and only cleared by the console** — renaming one side leaks stale keys. Correctness beats a token-count win, so those are left with an in-code note rather than a routing-breaking partial rename.

## Verification

- `cd core/services/tenant && go build ./... && go test ./...` → green (new route test passes: canonical + legacy patterns resolve, deprecation headers emitted).
- `cd core/console && npm install && npm run build` → clean build. Fresh bundle: **0 `/tenant/orgs`**, **0 `SME`**; the only residual `tenant` substrings are the four grandfathered wire contracts (`org-checkout-tenant`, `org-tenant:`, `/provisioning/tenant/`, `tenant_id`).

Refs #3985, Refs #3383, Refs #5276

🤖 Generated with [Claude Code](https://claude.com/claude-code)