### PR TITLE
fix(catalyst-api): enumerate region-b cluster when declared region slug diverges from kubeconfig-id code (#5274)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -262,14 +262,99 @@ func perRegionDynamicClient(in LoaderInput, rs provisioner.RegionSpec) dynamic.I
 		// Exact "<depID>-<region>" or suffixed "<depID>-<region>-N"
 		// (materialisation index, e.g. "...-me-east-215-b-1").
 		if cid == want || strings.HasPrefix(cid, want+"-") {
-			dc, err := in.K8sCache.DynamicClientFor(cid)
-			if err != nil || dc == nil {
-				return nil
-			}
-			return dc
+			return clientForCluster(in, cid)
+		}
+	}
+
+	// #5274 fallback — the declared CloudRegion can DIVERGE from the
+	// kubeconfig-id region token. The chroot's region list comes from
+	// SOVEREIGN_REGIONS_JSON (bare cloud code, e.g. "me-east-215-b" — the
+	// exact/prefix match above) OR, when that ConfigMap key isn't wired,
+	// from the SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION fallback
+	// (handler.chrootRegionsFromPrimaryReplicaEnv), which carries the FULL
+	// 4-segment cluster slug (e.g. "hw-me-east-215-b-rtz-prod", live hw101).
+	// The secondary kubeconfig is registered under the bare cloud code
+	// ("<depID>-me-east-215-b-1"), so "<depID>-hw-me-east-215-b-rtz-prod"
+	// never prefix-matches → region-b was rendered as buildAbsentRegion
+	// (Clusters: nil) → the Cloud graph showed "Region 2/2 · Cluster 1/1"
+	// on a fully-live 2-region Sovereign. Both strings still contain the
+	// same cloud-region code as a contiguous hyphen-delimited token run, so
+	// match on that. No fabrication: this only resolves a client for a
+	// secondary cluster that is GENUINELY registered in the k8sCache; a
+	// truly-absent region still matches nothing and stays buildAbsentRegion.
+	for _, cid := range in.K8sCache.Clusters() {
+		if cid == in.DeploymentID || !strings.HasPrefix(cid, in.DeploymentID+"-") {
+			continue // primary / chroot-self / a different deployment's cluster
+		}
+		idRegion := trimMaterialisationIndex(strings.TrimPrefix(cid, in.DeploymentID+"-"))
+		if regionTokensOverlap(region, idRegion) {
+			return clientForCluster(in, cid)
 		}
 	}
 	return nil
+}
+
+// clientForCluster fetches the k8sCache dynamic client for cid, returning
+// nil on error / absence so callers fall back to buildAbsentRegion (or the
+// primary client) rather than dereferencing a nil interface.
+func clientForCluster(in LoaderInput, cid string) dynamic.Interface {
+	dc, err := in.K8sCache.DynamicClientFor(cid)
+	if err != nil || dc == nil {
+		return nil
+	}
+	return dc
+}
+
+// trimMaterialisationIndex strips a trailing "-<digits>" materialisation
+// index off a region key ("me-east-215-b-1" → "me-east-215-b"). Keys with
+// no numeric tail are returned unchanged, so a bare "me-east-215-b" is a
+// no-op.
+func trimMaterialisationIndex(s string) string {
+	i := strings.LastIndex(s, "-")
+	if i <= 0 || i == len(s)-1 {
+		return s
+	}
+	for _, r := range s[i+1:] {
+		if r < '0' || r > '9' {
+			return s
+		}
+	}
+	return s[:i]
+}
+
+// regionTokensOverlap reports whether the hyphen-delimited token run of one
+// region string appears as a contiguous subsequence of the other's (either
+// direction). It lets a bare cloud code (me-east-215-b) match a full cluster
+// slug (hw-me-east-215-b-rtz-prod) that embeds it, WITHOUT the false
+// positives a raw substring test would allow ("me-east-215-b" vs
+// "me-east-215-ba" differ as tokens). Cloud-region codes are unique, so the
+// embedded code resolves each declared region to exactly one cluster.
+func regionTokensOverlap(a, b string) bool {
+	at := strings.Split(a, "-")
+	bt := strings.Split(b, "-")
+	return tokenSubsequence(at, bt) || tokenSubsequence(bt, at)
+}
+
+// tokenSubsequence reports whether needle appears as a contiguous run inside
+// haystack. Empty needle never matches (guards against an empty region
+// string pairing with everything).
+func tokenSubsequence(needle, haystack []string) bool {
+	if len(needle) == 0 || len(needle) > len(haystack) {
+		return false
+	}
+	for start := 0; start+len(needle) <= len(haystack); start++ {
+		match := true
+		for j := range needle {
+			if haystack[start+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }
 
 // nodeGVR — schema reference for core/v1 Node listing via dynamic client.

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
@@ -222,6 +222,119 @@ func TestLoad_SecondaryAbsentKubeconfigRendersDegraded(t *testing.T) {
 	}
 }
 
+// TestLoad_PerRegionFullSlugRegionMatchesBareCodeKubeconfig_5274 proves the
+// #5274 fix: on the chroot fallback path (SOVEREIGN_REGIONS_JSON unwired →
+// region list reconstructed from SOVEREIGN_PRIMARY_REGION /
+// SOVEREIGN_REPLICA_REGION), the declared CloudRegion is the FULL 4-segment
+// cluster slug (e.g. "hw-me-east-215-b-rtz-prod") while the secondary
+// kubeconfig is registered under the bare cloud code
+// ("<depID>-me-east-215-b-1"). The strict "<depID>-<CloudRegion>" prefix
+// match can't bridge that, so region-b was dropped to buildAbsentRegion and
+// the Cloud graph rendered "Region 2/2 · Cluster 1/1" on a fully-live
+// 2-region Sovereign (hw278, row 66). The loader must now resolve region-b's
+// OWN client via the shared cloud-region-code token and enumerate its
+// cluster — 2 clusters, region-b reading its own live vClusters.
+func TestLoad_PerRegionFullSlugRegionMatchesBareCodeKubeconfig_5274(t *testing.T) {
+	const depID = "hw278dep0000abcd"
+	primaryClient := vclusterRoleNamespaceClient(t, "primary-mgmt")
+	secondaryClient := vclusterRoleNamespaceClient(t, "secondary-mgmt")
+
+	// k8sCache ids follow the bare-cloud-code kubeconfig convention.
+	cache := &fakeK8sCache{clients: map[string]dynamic.Interface{
+		depID:                      primaryClient,   // bare-depID = primary / chroot-self
+		depID + "-me-east-215-b-1": secondaryClient, // materialised secondary (bare code)
+	}}
+
+	// Declared regions carry the FULL cluster slug (the chroot
+	// primary/replica-env reconstruction, jobs.go:chrootRegionsFromPrimaryReplicaEnv).
+	in := LoaderInput{
+		DeploymentID:  depID,
+		Status:        "ready",
+		SovereignFQDN: "hw278.omani.works",
+		Provider:      "huawei",
+		Region:        "hw-me-east-215-a-rtz-prod", // primary region (full slug)
+		Regions: []provisioner.RegionSpec{
+			{Provider: "huawei", CloudRegion: "hw-me-east-215-a-rtz-prod", WorkerCount: 5},
+			{Provider: "huawei", CloudRegion: "hw-me-east-215-b-rtz-prod", WorkerCount: 5},
+		},
+		DynamicClient: primaryClient,
+		K8sCache:      cache,
+	}
+
+	resp := Load(context.Background(), in)
+	regions := resp.Topology.Regions
+	if len(regions) != 2 {
+		t.Fatalf("expected 2 region rows, got %d", len(regions))
+	}
+
+	// Decisive census assertion: BOTH regions carry a live Cluster
+	// (Region 2/2 · Cluster 2/2), not one absent region → Cluster 1/1.
+	clusterCount := 0
+	var regB *Region
+	for i := range regions {
+		clusterCount += len(regions[i].Clusters)
+		if regions[i].Name == "hw-me-east-215-b-rtz-prod" {
+			regB = &regions[i]
+		}
+	}
+	if clusterCount != 2 {
+		t.Fatalf("expected 2 clusters across both regions (Cluster 2/2), got %d — region-b under-enumerated (#5274)", clusterCount)
+	}
+	if regB == nil {
+		t.Fatalf("missing region-b hw-me-east-215-b-rtz-prod; got %v", regionNames(regions))
+	}
+	if len(regB.Clusters) != 1 {
+		t.Fatalf("region-b should carry its live cluster, got %d clusters (buildAbsentRegion regression)", len(regB.Clusters))
+	}
+	// And it must read its OWN client, not mirror the primary.
+	secondaryVC := vclusterNames(*regB)
+	if !contains(secondaryVC, "secondary-mgmt") {
+		t.Errorf("region-b should read its own (secondary) client vClusters; got %v", secondaryVC)
+	}
+	if contains(secondaryVC, "primary-mgmt") {
+		t.Errorf("region-b leaked primary client vClusters %v — must resolve its OWN cluster", secondaryVC)
+	}
+}
+
+// TestRegionTokenMatchingHelpers locks the token-overlap semantics that
+// bridge the declared-region ↔ kubeconfig-id naming divergence without the
+// false positives a raw substring test would allow.
+func TestRegionTokenMatchingHelpers(t *testing.T) {
+	idxCases := []struct{ in, want string }{
+		{"me-east-215-b-1", "me-east-215-b"}, // strip materialisation index
+		{"me-east-215-b", "me-east-215-b"},   // bare code — no-op
+		{"nbg1-2", "nbg1"},
+		{"nbg1", "nbg1"},         // no numeric tail
+		{"region-b", "region-b"}, // non-numeric tail is not an index
+	}
+	for _, c := range idxCases {
+		if got := trimMaterialisationIndex(c.in); got != c.want {
+			t.Errorf("trimMaterialisationIndex(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	overlap := []struct {
+		a, b string
+		want bool
+	}{
+		// bare code embedded in the full slug (both directions) — the #5274 case.
+		{"hw-me-east-215-b-rtz-prod", "me-east-215-b", true},
+		{"me-east-215-b", "hw-me-east-215-b-rtz-prod", true},
+		{"me-east-215-b", "me-east-215-b", true},
+		// token-boundary safety: a longer trailing token must NOT match.
+		{"hw-me-east-215-ba-rtz-prod", "me-east-215-b", false},
+		// different region codes never match.
+		{"hw-me-east-215-a-rtz-prod", "me-east-215-b", false},
+		// empty needle never pairs.
+		{"", "me-east-215-b", false},
+	}
+	for _, c := range overlap {
+		if got := regionTokensOverlap(c.a, c.b); got != c.want {
+			t.Errorf("regionTokensOverlap(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
 func regionNames(rs []Region) []string {
 	out := make([]string, 0, len(rs))
 	for _, r := range rs {


### PR DESCRIPTION
## Problem (UAT hw278 row 66, cutoverComplete=true)

The Cloud `/cloud` graph's **Cluster chip read `1/1`** (only region-a: control-plane + worker-1..5, LB 1/1) across two stable clean renders post-cutover, while `kubectl` showed **2 live clusters** (region-a primary + region-b replica, both nodes Ready, ClusterMesh members). The **Region** layer rendered `2/2` correctly — only the **Cluster** layer under-counted, dropping region-b's cluster. A multi-region topology misrepresentation (Pillar 3 accuracy).

## Root cause

`products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go`

The Cloud graph's cluster-layer census is the declared topology tree from
`GET /api/v1/deployments/{id}/infrastructure/topology` → `infrastructure.Load` →
`buildTopology`. It emits **one Region per `Regions[*]`** and **one Cluster per
region** — *but only if that region's live client resolves*. A secondary region
whose own client can't be resolved is rendered by `buildAbsentRegion`
(`Clusters: nil`) → a Region node with **zero** Cluster nodes.

The per-region live client comes from `perRegionDynamicClient`, which matched
region-b's kubeconfig in the `k8sCache` **only** by the strict id convention
`<depID>-<CloudRegion>` (exact / `-N`-suffixed). On the chroot fallback path —
`SOVEREIGN_REGIONS_JSON` unwired, so the region list is reconstructed from
`SOVEREIGN_PRIMARY_REGION` / `SOVEREIGN_REPLICA_REGION`
(`handler.chrootRegionsFromPrimaryReplicaEnv`) — the declared `CloudRegion` is
the **full 4-segment cluster slug** (e.g. `hw-me-east-215-b-rtz-prod`, live
hw101), while region-b's secondary kubeconfig is registered under the **bare
cloud code** (`<depID>-me-east-215-b-1`). `<depID>-hw-me-east-215-b-rtz-prod`
never prefix-matches `<depID>-me-east-215-b-1`, so `perRegionDynamicClient`
returned nil → region-b dropped to `buildAbsentRegion` → **Region 2/2 ·
Cluster 1/1** on a fully-live 2-region Sovereign.

The cluster census cannot see region-b via ClusterMesh (a Cilium pod/service
datapath — it does not expose region-b's apiserver / Node list to region-a's
client). Region-b is enumerable **only** through its own kubeconfig registered
in the `k8sCache`; that record was present here, just not matched.

## Fix

After the exact/prefix match, `perRegionDynamicClient` now also matches the
**shared cloud-region code** as a contiguous hyphen-delimited **token run**
(either direction), so a bare code (`me-east-215-b`) resolves the region whose
declared slug embeds it (`hw-me-east-215-b-rtz-prod`). Token-boundary safe:
`me-east-215-b` never matches `me-east-215-ba`. Cloud-region codes are unique,
so each declared region resolves to exactly one cluster.

No fabrication: the fallback only resolves a client for a secondary cluster that
is **genuinely registered** in the `k8sCache`. A truly-absent region still
matches nothing and stays `buildAbsentRegion` — the #4811 / #4814 no-fabrication
guard is preserved (its test remains green).

## Tests

`products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go`

- `TestLoad_PerRegionFullSlugRegionMatchesBareCodeKubeconfig_5274` — reproduces
  the hw278 divergence (full-slug declared regions + bare-code kubeconfig ids)
  and asserts **Cluster 2/2** with region-b reading its own client. Verified to
  **fail** (Cluster 1/1) with the fallback neutralized.
- `TestRegionTokenMatchingHelpers` — locks the token-overlap semantics incl.
  the boundary-safety and empty-needle cases.
- Existing `TestLoad_PerRegionLiveClientFanOut` (bare-code happy path) and
  `TestLoad_SecondaryAbsentKubeconfigRendersDegraded` (genuinely-absent region
  stays cluster-less) both stay green.

`go build ./...` + `go vet ./internal/infrastructure/...` + `go test -count=1
./internal/infrastructure/` all pass. No chart touched (pure Go loader logic).

Refs #5274 #3987
