### PR TITLE
fix(catalyst-api): Phase-1 watch progress-guard — never hard-fail a still-converging prov at the WatchTimeout wall-clock

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -118,6 +118,22 @@ const phase1ReachabilityBudgetEnv = "CATALYST_PHASE1_REACHABILITY_BUDGET"
 // silent. Default helmwatch.DefaultRecensusInterval (45s).
 const phase1RecensusIntervalEnv = "CATALYST_PHASE1_RECENSUS_INTERVAL"
 
+// phase1ProgressStallWindowEnv — env var override for the progress-guard
+// stall window (#5283). Past the soft WatchTimeout the watch concludes
+// OutcomeTimeout only once readyHRs has been flat for this long with no
+// failed HR; while readyHRs climbed within the window it defers instead
+// of stamping a still-converging prov failed (hw279: an intermittent
+// external xpkg.upbound.io 503 delayed the bp-crossplane →
+// bp-catalyst-platform chain past 120m while readyHRs kept climbing).
+// Empty/invalid falls back to helmwatch's WatchTimeout/4 default (30m).
+const phase1ProgressStallWindowEnv = "CATALYST_PHASE1_PROGRESS_STALL_WINDOW"
+
+// phase1ProgressGuardCeilingEnv — env var override for the absolute
+// wall-clock ceiling on the whole Phase-1 watch INCLUDING progress-guard
+// deferrals past WatchTimeout (#5283). Empty/invalid falls back to
+// helmwatch's WatchTimeout×2 default (240m).
+const phase1ProgressGuardCeilingEnv = "CATALYST_PHASE1_PROGRESS_GUARD_CEILING"
+
 // kubeconfigArrivalTimeoutEnv — how long runPhase1Watch waits for the
 // cloud-init PUT to land /var/lib/catalyst/kubeconfigs/<id>.yaml on
 // disk before giving up with OutcomeKubeconfigMissing. Cloud-init
@@ -450,6 +466,19 @@ func (h *Handler) phase1WatchConfigForDeployment(dep *Deployment, kubeconfig str
 		recensusInterval = helmwatch.CompileRecensusInterval(envOrEmpty(phase1RecensusIntervalEnv))
 	}
 
+	// #5283 — progress-guard knobs. Left zero unless an explicit env
+	// override is set, so helmwatch.applyDefaults derives both from the
+	// resolved WatchTimeout (stall window = /4, ceiling = ×2). Only a
+	// positive, parseable duration overrides.
+	var progressStallWindow time.Duration
+	if v, _ := time.ParseDuration(envOrEmpty(phase1ProgressStallWindowEnv)); v > 0 {
+		progressStallWindow = v
+	}
+	var progressGuardCeiling time.Duration
+	if v, _ := time.ParseDuration(envOrEmpty(phase1ProgressGuardCeilingEnv)); v > 0 {
+		progressGuardCeiling = v
+	}
+
 	// #4746 — the component whose terminal-install gates OutcomeReady.
 	// Base value is the Handler field (production New() sets it to
 	// catalyst-platform; tests leave it empty → gate off). An explicitly
@@ -464,6 +493,8 @@ func (h *Handler) phase1WatchConfigForDeployment(dep *Deployment, kubeconfig str
 	cfg := helmwatch.Config{
 		KubeconfigYAML:            kubeconfig,
 		WatchTimeout:              timeout,
+		ProgressStallWindow:       progressStallWindow,
+		ProgressGuardCeiling:      progressGuardCeiling,
 		MinBootstrapKitHRs:        minHRs,
 		FirstSeenTimeout:          firstSeen,
 		LatePollTimeout:           latePollTimeout,

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -255,6 +255,25 @@ const DefaultRecensusInterval = 45 * time.Second
 // degrades latency, never correctness.
 const staleInformerIntervals = 4
 
+// progressGuardStallDivisor — ProgressStallWindow defaults to
+// WatchTimeout / this when Config.ProgressStallWindow is unset (#5283).
+// At the 120m WatchTimeout default this yields a 30m stall window: past
+// the soft WatchTimeout the watch treats convergence as STALLED only
+// once readyHRs has been flat for a full window, which comfortably rides
+// out an intermittent external registry/image 503 (helm-controller keeps
+// retrying and lands the next HR within the window) while still
+// concluding promptly on a genuine no-progress stall.
+const progressGuardStallDivisor = 4
+
+// progressGuardCeilingMultiple — ProgressGuardCeiling defaults to
+// WatchTimeout × this when Config.ProgressGuardCeiling is unset (#5283).
+// This is the ABSOLUTE wall-clock cap on the whole watch INCLUDING any
+// progress-guard deferrals past WatchTimeout, so a pathological
+// never-converging prov still concludes. At the 120m default the cap is
+// 240m — well above observed healthy convergence (<120m) plus a full
+// WatchTimeout of external-delay margin.
+const progressGuardCeilingMultiple = 2
+
 // DefaultReachabilityProbeTimeout — per-attempt timeout for the
 // pre-flight apiserver reachability probe (issue #923). After a
 // catalyst-api Pod restart, the new Pod's TLS handshake to the
@@ -425,11 +444,40 @@ type Config struct {
 	// Empty string is invalid (Watch returns an error immediately).
 	KubeconfigYAML string
 
-	// WatchTimeout — overall budget for Phase 1. After this, the watch
-	// terminates regardless of HelmRelease state. Defaults to
+	// WatchTimeout — SOFT budget for Phase 1. Reaching it does NOT by
+	// itself conclude the watch: it is the first point at which the
+	// progress-guard (#5283) asks "is convergence still making forward
+	// progress?" — see ProgressStallWindow / ProgressGuardCeiling. The
+	// watch concludes at WatchTimeout only when convergence has genuinely
+	// stalled; while readyHRs is still climbing (and no HR has failed) the
+	// guard defers the conclusion, up to ProgressGuardCeiling. Defaults to
 	// DefaultWatchTimeout; the catalyst-api's main reads
 	// CATALYST_PHASE1_WATCH_TIMEOUT and passes the parsed Duration.
 	WatchTimeout time.Duration
+
+	// ProgressStallWindow — once WatchTimeout is reached, the watch treats
+	// convergence as STALLED (and concludes with OutcomeTimeout) only when
+	// readyHRs has NOT increased for at least this long AND no HR has
+	// failed. While readyHRs climbed within this window the watch defers
+	// its conclusion instead of hard-failing a still-progressing prov —
+	// the hw279 defect (#5283), where an intermittent external
+	// xpkg.upbound.io 503 delayed the bp-crossplane → bp-catalyst-platform
+	// chain and the 120m wall-clock stamped a recoverable, still-climbing
+	// (readyHRs 58/66, failedHRs 0) Sovereign as failed. Defaults to
+	// WatchTimeout / progressGuardStallDivisor (30m at the 120m default).
+	// Zero means "fall back to that default"; the catalyst-api wires
+	// CATALYST_PHASE1_PROGRESS_STALL_WINDOW into this.
+	ProgressStallWindow time.Duration
+
+	// ProgressGuardCeiling — absolute wall-clock cap for the whole watch
+	// INCLUDING any progress-guard deferrals past WatchTimeout (#5283). A
+	// pathological never-converging prov still concludes here. The
+	// informer runs at most this long. Defaults to
+	// WatchTimeout × progressGuardCeilingMultiple (240m at the 120m
+	// default); a value ≤ WatchTimeout is treated as unset and replaced by
+	// that default so the ceiling can never precede the soft deadline. The
+	// catalyst-api wires CATALYST_PHASE1_PROGRESS_GUARD_CEILING into this.
+	ProgressGuardCeiling time.Duration
 
 	// Now — clock injection point. Production passes time.Now; tests
 	// inject a fake clock so termination-on-timeout is deterministic.
@@ -628,6 +676,16 @@ func (c *Config) applyDefaults() {
 	if c.WatchTimeout <= 0 {
 		c.WatchTimeout = DefaultWatchTimeout
 	}
+	// Progress-guard defaults derive from the (now-resolved) WatchTimeout
+	// so short-budget tests scale their stall window down with it (#5283)
+	// — a static large window would make a 1.5s-budget test read "readyHRs
+	// increased recently" and defer past its deadline.
+	if c.ProgressStallWindow <= 0 {
+		c.ProgressStallWindow = c.WatchTimeout / progressGuardStallDivisor
+	}
+	if c.ProgressGuardCeiling <= c.WatchTimeout {
+		c.ProgressGuardCeiling = c.WatchTimeout * progressGuardCeilingMultiple
+	}
 	if c.Now == nil {
 		c.Now = time.Now
 	}
@@ -753,6 +811,20 @@ type Watcher struct {
 	// post-sync stabilisation tick that re-evaluates the gate cannot
 	// double-emit. Mutated under w.mu.
 	readyTransitionEmitted bool
+
+	// maxReadyCount — high-water-mark of the number of components observed
+	// in StateInstalled (#5283). Tracked as a high-water-mark, not the
+	// live count, so a single component flapping installed↔degraded cannot
+	// keep resetting the progress clock and thereby mask a genuine stall in
+	// the rest of the fleet. Mutated under w.mu.
+	maxReadyCount int
+
+	// lastReadyProgressAt — wall-clock instant maxReadyCount last increased
+	// (#5283). Zero until the first HR reaches installed. The progress-guard
+	// treats convergence as STALLED once this is older than
+	// ProgressStallWindow (with no failed HR), and as still-progressing
+	// otherwise. Mutated under w.mu.
+	lastReadyProgressAt time.Time
 
 	// lastInformerEventAt — wall-clock instant of the most recent
 	// informer-DELIVERED callback (Add/Update from the event handler,
@@ -950,10 +1022,15 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 		return nil, fmt.Errorf("helmwatch: build dynamic client: %w", err)
 	}
 
-	// Per-watch context with the configured timeout. We derive from
-	// the caller's ctx so the handler's parent context cancel
-	// (deployment delete, Pod shutdown) propagates.
-	watchCtx, cancel := context.WithTimeout(ctx, w.cfg.WatchTimeout)
+	// Per-watch context bound to the ABSOLUTE ProgressGuardCeiling, NOT
+	// the soft WatchTimeout (#5283). The informer/reachability/recensus
+	// all live for the ceiling; the WatchTimeout is enforced as a SOFT
+	// deadline inside the select loop, where the progress-guard can defer
+	// it while convergence is still climbing rather than tearing the
+	// informer down at a fixed wall-clock. We derive from the caller's ctx
+	// so the handler's parent context cancel (deployment delete, Pod
+	// shutdown) still propagates.
+	watchCtx, cancel := context.WithTimeout(ctx, w.cfg.ProgressGuardCeiling)
 	defer cancel()
 
 	// Pre-flight reachability probe — issue #923. Catalyst-api Pod
@@ -1157,6 +1234,24 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 	recensusTicker := time.NewTicker(w.cfg.RecensusInterval)
 	defer recensusTicker.Stop()
 
+	// Soft-deadline progress-guard timer (#5283). Its first fire is at the
+	// SOFT WatchTimeout; on each fire the loop concludes only if
+	// convergence has genuinely stalled and otherwise re-arms for one
+	// progressRecheck, deferring the conclusion while readyHRs is still
+	// climbing (bounded overall by ProgressGuardCeiling = watchCtx). The
+	// re-check cadence is a fraction of the stall window, clamped so
+	// production notices a stall promptly (≤30s) without busy-spinning on a
+	// tiny test budget.
+	progressRecheck := w.cfg.ProgressStallWindow / 4
+	if progressRecheck < 100*time.Millisecond {
+		progressRecheck = 100 * time.Millisecond
+	}
+	if progressRecheck > 30*time.Second {
+		progressRecheck = 30 * time.Second
+	}
+	progressTimer := time.NewTimer(w.cfg.WatchTimeout)
+	defer progressTimer.Stop()
+
 	// Wait for either all-terminal or context done.
 	for {
 		select {
@@ -1213,6 +1308,41 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 			// downstream handover fire exactly once regardless of
 			// whether an informer event or the ticker concluded.
 			w.runTickerRecensus(watchCtx, dyn, terminated, &closeOnce)
+
+		case <-progressTimer.C:
+			// #5283 — soft-deadline progress-guard. The SOFT WatchTimeout
+			// (or a subsequent re-check) has elapsed. Conclude only if
+			// convergence has genuinely stalled; while readyHRs is still
+			// climbing (no failed HR, last increase within
+			// ProgressStallWindow) defer by one re-check interval so a
+			// slow-but-healthy prov is not stamped failed at a fixed
+			// wall-clock (hw279 #5283). ProgressGuardCeiling (watchCtx)
+			// still caps the total runtime, so deferral cannot loop
+			// forever.
+			if w.convergenceProgressing(w.cfg.Now()) {
+				w.mu.Lock()
+				ready := w.maxReadyCount
+				observedN := len(w.observed)
+				w.mu.Unlock()
+				w.dispatch(provisioner.Event{
+					Time:  w.cfg.Now().UTC().Format(time.RFC3339),
+					Phase: PhaseComponent,
+					Level: "info",
+					Message: fmt.Sprintf(
+						"Phase-1 watch: soft budget %s reached but convergence is still progressing (%d of %d installed, no failures) — deferring the readiness conclusion up to the %s ceiling while readyHRs keeps climbing (#5283).",
+						w.cfg.WatchTimeout, ready, observedN, w.cfg.ProgressGuardCeiling,
+					),
+				})
+				progressTimer.Reset(progressRecheck)
+				continue
+			}
+			// Genuine stall (or a failed HR) at/after the soft deadline —
+			// conclude exactly as the wall-clock path does: cancel the
+			// watch context so the next loop iteration returns through the
+			// standard <-watchCtx.Done() branch (identical "terminated by
+			// context" warn + classifyOutcomeOnContextEnd verdict, i.e.
+			// OutcomeTimeout / OutcomeFluxNotReconciling).
+			cancel()
 		}
 	}
 }
@@ -1397,6 +1527,19 @@ func (w *Watcher) emitHeartbeat(hb Heartbeat) {
 			w.cfg.RecensusInterval,
 		),
 	})
+}
+
+// countInstalled returns the number of components sitting in
+// StateInstalled — the "readyHRs" the progress-guard (#5283) watches for
+// forward motion, and the census the heartbeat reports as ReadyHRs.
+func countInstalled(states map[string]string) int {
+	n := 0
+	for _, s := range states {
+		if s == StateInstalled {
+			n++
+		}
+	}
+	return n
 }
 
 // hasFailures returns true when at least one component in the state
@@ -1802,6 +1945,35 @@ func (w *Watcher) classifyOutcomeOnTerminate(final map[string]string) string {
 	return OutcomeReady
 }
 
+// convergenceProgressing reports whether Phase-1 convergence is still
+// making genuine forward progress at the soft WatchTimeout (#5283). It is
+// true only when NO observed HR has hard-FAILED and readyHRs increased
+// within ProgressStallWindow. When true, the Watch loop defers concluding
+// (up to ProgressGuardCeiling) instead of stamping a still-climbing prov
+// as OutcomeTimeout → failed — the hw279 defect where an intermittent
+// external xpkg.upbound.io 503 delayed the bp-crossplane →
+// bp-catalyst-platform chain past the 120m wall-clock while readyHRs kept
+// climbing (58/66, failedHRs 0).
+//
+// A failed HR falls through to the normal conclusion (existing behaviour:
+// the pre-terminal timeout classifies OutcomeTimeout, and the all-terminal
+// late-poll path owns genuine failures). readyHRs that never rose
+// (lastReadyProgressAt zero — everything stuck installing) is likewise NOT
+// progress. Reads the progress bookkeeping under w.mu.
+func (w *Watcher) convergenceProgressing(now time.Time) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, s := range w.states {
+		if s == StateFailed {
+			return false
+		}
+	}
+	if w.lastReadyProgressAt.IsZero() {
+		return false
+	}
+	return now.Sub(w.lastReadyProgressAt) < w.cfg.ProgressStallWindow
+}
+
 // classifyOutcomeOnContextEnd maps a context-cancelled exit into
 // OutcomeTimeout or OutcomeFluxNotReconciling depending on whether
 // any HelmRelease was ever observed. The handler reads this through
@@ -1952,6 +2124,18 @@ func (w *Watcher) processEvent(obj any, terminated chan struct{}, closeOnce *syn
 	w.observed[componentID] = struct{}{}
 	if w.firstSeenAt.IsZero() {
 		w.firstSeenAt = w.cfg.Now()
+	}
+
+	// Progress-guard bookkeeping (#5283): advance the readyHRs
+	// high-water-mark whenever the installed count climbs, stamping the
+	// wall-clock so the progress-guard can tell a still-converging prov
+	// (readyHRs rose within ProgressStallWindow) from a genuine stall
+	// (flat for a full window). Counting from w.states — which already
+	// reflects this event — keeps the informer and ticker-recensus drivers
+	// byte-identical here.
+	if ready := countInstalled(w.states); ready > w.maxReadyCount {
+		w.maxReadyCount = ready
+		w.lastReadyProgressAt = w.cfg.Now()
 	}
 
 	// The all-terminal check is gated on informerSynced — an event

--- a/products/catalyst/bootstrap/api/internal/helmwatch/progress_guard_5283_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/progress_guard_5283_test.go
@@ -1,0 +1,247 @@
+// Progress-guard coverage (#5283).
+//
+// hw279 (dep 059126bb, 2026-07-20): a fresh 2-region Sovereign was
+// converging HEALTHILY — the mothership phase1-watch heartbeat logged
+// observedHRs:66, readyHRs:58, failedHRs:0, sentinel:pending (genuine
+// forward progress, zero failed HelmReleases). An intermittent external
+// xpkg.upbound.io 503 merely DELAYED the bp-crossplane →
+// bp-crossplane-claims → bp-catalyst-platform chain. Yet the fixed 120m
+// WatchTimeout guillotine concluded OutcomeTimeout → finalStatus=failed,
+// which is terminal (#5253) and permanently suppressed the mesh/cutover
+// cascade — killing a recoverable, still-progressing prov.
+//
+// The fix adds a progress-guard: past the SOFT WatchTimeout the watch
+// concludes only on a genuine stall (readyHRs flat for ProgressStallWindow
+// with no failed HR) or the absolute ProgressGuardCeiling; while readyHRs
+// is still climbing it defers instead of hard-failing. These tests pin
+// both sides: still-progressing must NOT conclude failed; a true stall
+// still does.
+package helmwatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// TestConvergenceProgressing_5283 exercises the progress decision directly
+// (deterministic, no timers): forward progress within the window with no
+// failure is "progressing"; a flat window, a failed HR, or never-installed
+// are all "not progressing".
+func TestConvergenceProgressing_5283(t *testing.T) {
+	base := time.Date(2026, 7, 20, 2, 6, 0, 0, time.UTC)
+	newW := func(states map[string]string, lastProgress time.Time) *Watcher {
+		w, err := NewWatcher(Config{
+			KubeconfigYAML:      "fake",
+			ProgressStallWindow: 200 * time.Millisecond,
+		}, (&recorder{}).emit)
+		if err != nil {
+			t.Fatalf("NewWatcher: %v", err)
+		}
+		w.states = states
+		w.lastReadyProgressAt = lastProgress
+		return w
+	}
+
+	t.Run("climbing within window, no failure → progressing", func(t *testing.T) {
+		w := newW(map[string]string{"cilium": StateInstalled, "crossplane": StateInstalling}, base)
+		if !w.convergenceProgressing(base.Add(50 * time.Millisecond)) {
+			t.Fatal("readyHRs increased 50ms ago (< 200ms window) with no failure — must be progressing")
+		}
+	})
+
+	t.Run("flat beyond window → stalled", func(t *testing.T) {
+		w := newW(map[string]string{"cilium": StateInstalled, "crossplane": StateInstalling}, base)
+		if w.convergenceProgressing(base.Add(300 * time.Millisecond)) {
+			t.Fatal("readyHRs last rose 300ms ago (> 200ms window) — must be a stall, not progressing")
+		}
+	})
+
+	t.Run("a failed HR present → not progressing (falls through to normal conclusion)", func(t *testing.T) {
+		w := newW(map[string]string{"cilium": StateInstalled, "crossplane": StateFailed}, base)
+		if w.convergenceProgressing(base.Add(10 * time.Millisecond)) {
+			t.Fatal("a hard-FAILED HR is not clean forward progress — must not defer")
+		}
+	})
+
+	t.Run("readyHRs never rose (all stuck installing) → not progressing", func(t *testing.T) {
+		w := newW(map[string]string{"crossplane": StateInstalling}, time.Time{})
+		if w.convergenceProgressing(base.Add(10 * time.Millisecond)) {
+			t.Fatal("nothing ever reached installed — must not defer")
+		}
+	})
+}
+
+// TestApplyDefaults_ProgressGuard_5283 pins that both knobs derive from the
+// resolved WatchTimeout (so short-budget tests scale down with it), that an
+// explicit value wins, and that a ceiling ≤ WatchTimeout is rejected and
+// replaced by the safe default (the ceiling can never precede the soft
+// deadline).
+func TestApplyDefaults_ProgressGuard_5283(t *testing.T) {
+	t.Run("derived from WatchTimeout when unset", func(t *testing.T) {
+		c := Config{WatchTimeout: 120 * time.Minute}
+		c.applyDefaults()
+		if want := 30 * time.Minute; c.ProgressStallWindow != want {
+			t.Errorf("ProgressStallWindow = %v, want %v (WatchTimeout/%d)", c.ProgressStallWindow, want, progressGuardStallDivisor)
+		}
+		if want := 240 * time.Minute; c.ProgressGuardCeiling != want {
+			t.Errorf("ProgressGuardCeiling = %v, want %v (WatchTimeout×%d)", c.ProgressGuardCeiling, want, progressGuardCeilingMultiple)
+		}
+	})
+
+	t.Run("explicit values win", func(t *testing.T) {
+		c := Config{WatchTimeout: 120 * time.Minute, ProgressStallWindow: 5 * time.Minute, ProgressGuardCeiling: 300 * time.Minute}
+		c.applyDefaults()
+		if c.ProgressStallWindow != 5*time.Minute {
+			t.Errorf("explicit ProgressStallWindow overwritten: %v", c.ProgressStallWindow)
+		}
+		if c.ProgressGuardCeiling != 300*time.Minute {
+			t.Errorf("explicit ProgressGuardCeiling overwritten: %v", c.ProgressGuardCeiling)
+		}
+	})
+
+	t.Run("ceiling ≤ WatchTimeout is rejected (never precede the soft deadline)", func(t *testing.T) {
+		c := Config{WatchTimeout: 120 * time.Minute, ProgressGuardCeiling: 90 * time.Minute}
+		c.applyDefaults()
+		if want := 240 * time.Minute; c.ProgressGuardCeiling != want {
+			t.Errorf("ProgressGuardCeiling = %v, want %v (a ceiling below WatchTimeout must be replaced by the default)", c.ProgressGuardCeiling, want)
+		}
+	})
+}
+
+// TestWatch_ProgressingSlow_DefersPastWatchTimeout_5283 is the hw279 proof:
+// readyHRs keeps climbing PAST the soft WatchTimeout (three HRs remain
+// installing at the deadline and flip to installed only afterwards, with no
+// failure). Pre-fix the fixed WatchTimeout guillotine returned
+// OutcomeTimeout → failed at the deadline; the progress-guard must instead
+// defer while progress is active and conclude OutcomeReady once the fleet
+// genuinely converges. The watch MUST run past WatchTimeout (proving the
+// deferral) and MUST NOT report OutcomeTimeout.
+func TestWatch_ProgressingSlow_DefersPastWatchTimeout_5283(t *testing.T) {
+	scheme := newFakeScheme()
+	names := []string{"bp-c1", "bp-c2", "bp-c3", "bp-c4", "bp-c5", "bp-c6", "bp-c7", "bp-c8"}
+	seed := make([]runtime.Object, 0, len(names))
+	for _, n := range names {
+		seed = append(seed, makeInstallingHelmRelease(n))
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		seed...,
+	)
+
+	rec := &recorder{}
+	cfg := Config{
+		KubeconfigYAML: "fake",
+		// Soft budget 300ms, but readyHRs keeps rising until ~480ms. A
+		// generous stall window + ceiling keep the guard's decision on the
+		// PROGRESS signal, not on wall-clock jitter, so the test is not
+		// timing-flaky.
+		WatchTimeout:         300 * time.Millisecond,
+		ProgressStallWindow:  2 * time.Second,
+		ProgressGuardCeiling: 30 * time.Second,
+		FirstSeenTimeout:     30 * time.Second,
+		MinBootstrapKitHRs:   1,
+		DynamicFactory:       fakeFactory(client),
+		Resync:               0,
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	// Flip one HR installed → installed every 60ms, ending at ~480ms —
+	// well past the 300ms soft WatchTimeout. readyHRs climbs the whole
+	// time and nothing fails, so the guard must keep deferring.
+	go func() {
+		ready := []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue, Reason: "ReconciliationSucceeded", Message: "Helm install succeeded"}}
+		for _, n := range names {
+			time.Sleep(60 * time.Millisecond)
+			updateHR(t, client, n, ready)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	start := time.Now()
+	final, err := w.Watch(ctx)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got := w.Outcome(); got == OutcomeTimeout {
+		t.Fatalf("Outcome() = %q — a still-progressing prov (readyHRs climbing, failedHRs=0) must NOT be hard-failed at the WatchTimeout (#5283)", got)
+	}
+	if got, want := w.Outcome(), OutcomeReady; got != want {
+		t.Errorf("Outcome() = %q, want %q — the fleet genuinely converged after the soft deadline", got, want)
+	}
+	if elapsed <= cfg.WatchTimeout {
+		t.Errorf("watch concluded in %v (≤ WatchTimeout %v) — it must DEFER past the soft deadline while progress is active, not conclude at it", elapsed, cfg.WatchTimeout)
+	}
+	if elapsed >= cfg.ProgressGuardCeiling {
+		t.Errorf("watch ran %v (≥ ceiling %v) — should have concluded on convergence well before the hard ceiling", elapsed, cfg.ProgressGuardCeiling)
+	}
+	for _, n := range names {
+		id := ComponentIDFromHelmRelease(n)
+		if final[id] != StateInstalled {
+			t.Errorf("final[%q] = %q, want %q", id, final[id], StateInstalled)
+		}
+	}
+}
+
+// TestWatch_GenuineStall_ConcludesTimeout_5283 is the contrapositive:
+// readyHRs climbs to a plateau (3 installed) then goes FLAT while one HR
+// stays stuck installing and nothing further progresses. The progress-guard
+// must NOT keep a genuinely stalled prov alive — once readyHRs has been flat
+// for ProgressStallWindow the watch still concludes OutcomeTimeout (handler
+// → failed), near the soft WatchTimeout and well before the hard ceiling.
+func TestWatch_GenuineStall_ConcludesTimeout_5283(t *testing.T) {
+	scheme := newFakeScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		makeReadyHelmRelease("bp-c1"),
+		makeReadyHelmRelease("bp-c2"),
+		makeReadyHelmRelease("bp-c3"),
+		makeInstallingHelmRelease("bp-stuck"),
+	)
+
+	rec := &recorder{}
+	cfg := Config{
+		KubeconfigYAML:     "fake",
+		WatchTimeout:       400 * time.Millisecond, // stall window defaults to 100ms
+		FirstSeenTimeout:   30 * time.Second,
+		MinBootstrapKitHRs: 4, // bp-stuck never terminal → all-done gate cannot fire
+		DynamicFactory:     fakeFactory(client),
+		Resync:             0,
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	start := time.Now()
+	final, err := w.Watch(ctx)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got, want := w.Outcome(), OutcomeTimeout; got != want {
+		t.Errorf("Outcome() = %q, want %q — a genuinely stalled prov (readyHRs flat past the stall window) must still time out", got, want)
+	}
+	// Concludes near the soft budget, not deferred to the hard ceiling
+	// (WatchTimeout×2 = 800ms by default) — a stall must not be kept alive.
+	if elapsed >= 750*time.Millisecond {
+		t.Errorf("watch ran %v — a genuine stall must conclude near WatchTimeout (%v), not defer toward the ceiling", elapsed, cfg.WatchTimeout)
+	}
+	if final["c1"] != StateInstalled || final["stuck"] != StateInstalling {
+		t.Errorf("unexpected final states: %v", final)
+	}
+}


### PR DESCRIPTION
## Problem (live — hw279, dep 059126bb, 2026-07-20)

A fresh 2-region Sovereign fired at 02:06Z and was converging HEALTHILY. The mothership phase1-watch heartbeat (Refs #5269) logged `observedHRs:66, readyHRs:58, failedHRs:0, allTerminal:false, sentinel:pending` — genuine forward progress, zero failed HelmReleases. The `catalyst-platform` readiness sentinel was merely *delayed*: crossplane's core image pull hit an intermittent external `xpkg.upbound.io` 503 (addressed separately by #5282), stalling the `bp-crossplane → bp-crossplane-claims → bp-catalyst-platform` dependency chain.

After ~2 hours the phase1-watch nonetheless concluded `finalStatus=failed` with `outcome=null`. Per the #5253 forensics, `failed` is terminal — it permanently suppresses the mesh/cutover cascade (both heal gates exclude `failed`), so the whole prov died even though the cluster was recoverable and still progressing. The env already carried #5269 (heartbeat/recensus) and #5254 (decouple the cascade onto `OutcomeReady`), yet it STILL hard-failed while progress was active.

## Root cause

`helmwatch.Watcher.Watch()` bound the informer + select loop to `context.WithTimeout(ctx, WatchTimeout)` (default 120m). When that fixed wall-clock fired, the `<-watchCtx.Done()` branch unconditionally classified via `classifyOutcomeOnContextEnd()` → `OutcomeTimeout`, which the handler maps to `dep.Status = "failed"` (`phase1_watch.go` OutcomeTimeout case). It fired even with `failedHRs==0` and `readyHRs` still climbing — the wall-clock was a fixed guillotine with no notion of whether convergence was active.

`products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go` — `Watch()` `<-watchCtx.Done()` branch + `classifyOutcomeOnContextEnd`.

## Fix (added progress-guard, not a rewrite)

- The informer/reachability/recensus now live for an absolute `ProgressGuardCeiling`; `WatchTimeout` becomes a SOFT deadline enforced inside the select loop.
- At/after the soft deadline the watch concludes `OutcomeTimeout` only on a genuine terminal condition: a failed HR present, OR `readyHRs` flat for `ProgressStallWindow` (a true stall), OR the hard `ProgressGuardCeiling`. While `readyHRs` climbed within the window (and no HR failed) it defers, emitting an info heartbeat, so a slow-but-healthy prov is never stamped failed at a fixed wall-clock.
- A genuine stall still concludes verbatim through the existing `<-watchCtx.Done()` branch (identical "terminated by context" warn + classification), so the stall path is byte-identical to before.
- Defaults derive from `WatchTimeout` so short-budget tests scale down with it: stall window = `WatchTimeout/4` (30m at the 120m default), ceiling = `WatchTimeout×2` (240m). Both are env-overridable (`CATALYST_PHASE1_PROGRESS_STALL_WINDOW`, `CATALYST_PHASE1_PROGRESS_GUARD_CEILING`) per Inviolable Principle #4.
- Progress is tracked as a `readyHRs` high-water-mark stamped in `processEvent` (the single census/decision path shared by the informer and the #5269 ticker-recensus), so a flapping component cannot mask a fleet-wide stall.
- The #5269 heartbeat/recensus and #5254 `OutcomeReady` semantics are unchanged.

## Tests

`products/catalyst/bootstrap/api/internal/helmwatch/progress_guard_5283_test.go`:
- `TestConvergenceProgressing_5283` — the decision function: climbing-within-window+no-failure → progressing; flat-beyond-window / failed-HR-present / never-installed → not progressing.
- `TestApplyDefaults_ProgressGuard_5283` — defaults derive from `WatchTimeout`, explicit values win, a ceiling ≤ `WatchTimeout` is rejected.
- `TestWatch_ProgressingSlow_DefersPastWatchTimeout_5283` — readyHRs keeps climbing past the soft `WatchTimeout`; the watch defers (runs past the deadline) and concludes `OutcomeReady`, never `OutcomeTimeout`.
- `TestWatch_GenuineStall_ConcludesTimeout_5283` — readyHRs plateaus then goes flat; the watch still concludes `OutcomeTimeout` near `WatchTimeout`, well before the ceiling.

`go build ./... && go test ./...` green across the whole `products/catalyst/bootstrap/api` module (handler + helmwatch incl. `-race`).

Refs #5253 #5269