### PR TITLE
fix(catalyst-api): tear down + quarantine k8scache reflectors on terminal-failed deployment (#5285)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -863,6 +863,33 @@ func (h *Handler) SetK8sCache(f *k8scache.Factory, sar *k8scache.SARCache, userH
 	h.k8sCache = f
 	h.sarCache = sar
 	h.k8sUserHeader = userHeader
+
+	// #5285 — make the terminal-failed quarantine DURABLE across a
+	// catalyst-api restart. The QuarantineDeployment call on terminal
+	// conclusion is in-memory only; a Pod restart re-scans every lingering
+	// kubeconfig on the PVC (a failed env's kubeconfig is kept for the
+	// eventual wipe) and would re-establish the 404-flood the running Pod
+	// had stopped. Re-derive the quarantine from the persisted
+	// Status=="failed" records that restoreFromStore() loaded in New()
+	// (which runs before main.go calls SetK8sCache), so a restarted Pod
+	// does not resurrect the reflector flood. Only fully-"failed" records
+	// quarantine — a "partial-failure" primary's CRDs exist (no flood) and
+	// its reflectors power the console view.
+	if f != nil {
+		h.deployments.Range(func(_, val any) bool {
+			dep, ok := val.(*Deployment)
+			if !ok || dep == nil {
+				return true
+			}
+			dep.mu.Lock()
+			id, failed := dep.ID, dep.Status == "failed"
+			dep.mu.Unlock()
+			if failed {
+				f.QuarantineDeployment(id)
+			}
+			return true
+		})
+	}
 }
 
 // K8sCache exposes the wired Factory so /healthz can read its synced

--- a/products/catalyst/bootstrap/api/internal/handler/k8scache_quarantine_5285_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8scache_quarantine_5285_test.go
@@ -1,0 +1,97 @@
+// k8scache_quarantine_5285_test.go — #5285 durable-restart guard.
+//
+// The terminal-conclusion QuarantineDeployment call (phase1_watch.go) is
+// in-memory only. On a catalyst-api Pod restart, restoreFromStore() reloads
+// every deployment record and the k8scache rescan loop re-registers every
+// lingering kubeconfig on the PVC — including a failed env's kubeconfig,
+// which is deliberately kept for the eventual wipe. Without re-deriving the
+// quarantine from the persisted Status=="failed" records, the restarted Pod
+// would resurrect the 404-flood against the failed env's missing CRDs.
+//
+// This test proves SetK8sCache re-quarantines exactly the failed
+// deployments (primary + secondary) and leaves healthy ones registered.
+package handler
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func fakeDynForQuarantineTest() *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "PodList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, &unstructured.Unstructured{})
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{{Version: "v1", Resource: "pods"}: "PodList"})
+}
+
+func clustersContain(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSetK8sCache_QuarantinesFailedDeploymentsAcrossRestart(t *testing.T) {
+	// A restarted Pod's k8scache has re-registered every lingering
+	// kubeconfig: a fully-failed env (primary + secondary) and a healthy
+	// (ready) env. No Start() → informers built but never dial.
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger:   quietLog(),
+		Registry: minimalRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	for _, id := range []string{"faileddep", "faileddep-b", "readydep"} {
+		if err := f.AddCluster(k8scache.ClusterRef{
+			ID:            id,
+			DynamicClient: fakeDynForQuarantineTest(),
+			CoreClient:    kfake.NewSimpleClientset(),
+		}); err != nil {
+			t.Fatalf("AddCluster(%s): %v", id, err)
+		}
+	}
+
+	// A Handler restored from the store: one failed record, one ready.
+	h := &Handler{}
+	h.deployments.Store("faileddep", &Deployment{ID: "faileddep", Status: "failed"})
+	h.deployments.Store("readydep", &Deployment{ID: "readydep", Status: "ready"})
+
+	// main.go calls this at boot, after restoreFromStore populated
+	// h.deployments.
+	h.SetK8sCache(f, nil, "X-Forwarded-User")
+
+	if clustersContain(f.Clusters(), "faileddep") {
+		t.Errorf("failed deployment primary was not re-quarantined across restart (still registered) — the flood would resume")
+	}
+	if clustersContain(f.Clusters(), "faileddep-b") {
+		t.Errorf("failed deployment SECONDARY was not re-quarantined across restart (still registered)")
+	}
+	if !clustersContain(f.Clusters(), "readydep") {
+		t.Errorf("healthy 'ready' deployment was wrongly quarantined on restart — console live view would go dark")
+	}
+
+	// The quarantine must also block a subsequent rescan re-register of the
+	// failed env while its kubeconfig lingers.
+	if err := f.AddCluster(k8scache.ClusterRef{
+		ID:            "faileddep",
+		DynamicClient: fakeDynForQuarantineTest(),
+		CoreClient:    kfake.NewSimpleClientset(),
+	}); err != nil {
+		t.Fatalf("AddCluster(faileddep) while quarantined: %v", err)
+	}
+	if clustersContain(f.Clusters(), "faileddep") {
+		t.Errorf("quarantined failed deployment was re-registered by a later rescan/AddCluster")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1404,6 +1404,29 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		)
 	}
 
+	// #5285 — on a terminal-FAILED conclusion, tear down + quarantine this
+	// deployment's k8scache watch reflectors. A failed env's apiserver is
+	// often still UP but its Catalyst CRDs (cnpgpairs / continuums /
+	// organizations / useraccesses) never installed, so the per-kind
+	// reflectors 404-flood ("the server could not find the requested
+	// resource"), spike catalyst-api CPU, and starve the /wipe +
+	// /deployments control endpoints the operator needs to recover the env
+	// — a self-inflicted DoS with a chicken-and-egg on the wipe (hw279 dep
+	// 059126bb). QuarantineDeployment stops every `<id>` / `<id>-<region>`
+	// reflector AND suppresses the rescan loop from re-registering the
+	// lingering (kept-for-wipe) kubeconfig; the quarantine self-clears once
+	// the eventual wipe removes the kubeconfig. This is the failed-branch
+	// counterpart to the ready-branch handover below. Symmetric with the
+	// primary/secondary helmwatch.Watcher teardown already done in
+	// stopSecondaries() + the liveWatcher clear. Nil-tolerant: production
+	// wires h.k8sCache from main.go; tests building Handler{} leave it nil.
+	// NOTE: only the FAILED branch quarantines — a "ready"/handed-off
+	// Sovereign's CRDs DO exist (no flood) and its reflectors power the
+	// console live view, so those must stay running.
+	if finalStatus == "failed" && h.k8sCache != nil {
+		h.k8sCache.QuarantineDeployment(dep.ID)
+	}
+
 	// Issues #764 + #768 — auto-fire the handover JWT mint immediately
 	// after Phase-1 reaches OutcomeReady. Until this landed, the
 	// operator was stranded on the wizard's provision page after a

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -621,8 +621,17 @@ func (h *Handler) runWipePurge(dep *Deployment, id string, body wipeRequest, pre
 	// stop the goroutines BEFORE Hetzner cleanup makes the IP a
 	// sinkhole. Idempotent + nil-tolerant — production wires k8sCache
 	// via main.go; tests building Handler{} directly leave it nil.
+	//
+	// #5285 — use RemoveDeployment (not RemoveCluster) so BOTH the bare
+	// `<id>` primary AND every `<id>-<region>` secondary reflector set is
+	// torn down. The bare-id RemoveCluster missed the secondary-region
+	// clusters, which then kept 404/x509-flooding against their destroyed
+	// apiservers. Then clear any terminal-failed quarantine for this id
+	// (the kubeconfig files are removed later in this wipe, so nothing will
+	// resurrect it) to keep the quarantine set bounded.
 	if h.k8sCache != nil {
-		h.k8sCache.RemoveCluster(id)
+		h.k8sCache.RemoveDeployment(id)
+		h.k8sCache.UnquarantineDeployment(id)
 		emit("wipe", "info", "k8scache informer set removed for "+id)
 	}
 

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -228,6 +228,26 @@ type Factory struct {
 	mu       sync.RWMutex
 	clusters map[string]*clusterState
 
+	// terminated — the set of DEPLOYMENT ids whose watch reflectors were
+	// torn down at a terminal-FAILED conclusion and must NOT be
+	// re-registered by the kubeconfigs rescan loop (#5285). Keyed by the
+	// bare deployment id; a cluster id is quarantined when it is exactly
+	// a terminated id OR is one of its `<depID>-<region>` secondaries.
+	//
+	// Why this is needed ON TOP OF RemoveCluster: a FAILED deployment's
+	// kubeconfig is deliberately KEPT on the PVC (the eventual wipe reads
+	// it for the pre-destroy EVS drain), so a bare RemoveCluster is undone
+	// by the next rescan tick (≤30s), which re-registers any kubeconfig
+	// file still present in the dir. The apiserver of a failed env is
+	// often UP but its Catalyst CRDs (cnpgpairs / continuums /
+	// organizations / useraccesses) never installed, so the re-registered
+	// reflectors 404-flood ("the server could not find the requested
+	// resource"), burn CPU, and starve the very /wipe + /deployments
+	// endpoints needed to recover — a self-inflicted control-plane DoS.
+	// Quarantine is the durable stop; entries self-evict in rescanOnce
+	// once the kubeconfig(s) vanish (post-wipe). Guarded by mu.
+	terminated map[string]struct{}
+
 	// subscribers — fan-out registry for SSE clients. Keyed by an
 	// opaque subscriber id; value is a buffered channel the SSE
 	// handler reads. Mutated under subMu (separate from mu so a
@@ -508,6 +528,7 @@ func NewFactory(cfg Config) (*Factory, error) {
 		log:         cfg.Logger,
 		registry:    cfg.Registry,
 		clusters:    map[string]*clusterState{},
+		terminated:  map[string]struct{}{},
 		subscribers: map[int64]*subscriber{},
 		stop:        make(chan struct{}),
 	}
@@ -527,6 +548,22 @@ func NewFactory(cfg Config) (*Factory, error) {
 func (f *Factory) AddCluster(c ClusterRef) error {
 	if c.ID == "" {
 		return errors.New("k8scache: ClusterRef.ID is required")
+	}
+
+	// #5285 — refuse to (re)register a cluster belonging to a deployment
+	// that concluded terminal-FAILED. Its reflectors were torn down at
+	// conclusion; the lingering kubeconfig on the PVC must not resurrect
+	// the 404-flood via ANY registration path (rescan loop, secondary-
+	// kubeconfig POST, chroot self-register). Authoritative choke point —
+	// every registration funnels through here. The quarantine self-clears
+	// in rescanOnce once the kubeconfig is gone (post-wipe).
+	f.mu.RLock()
+	quarantined := f.isQuarantinedLocked(c.ID)
+	f.mu.RUnlock()
+	if quarantined {
+		f.log.Info("k8scache: skipping registration of quarantined (terminally-failed) deployment cluster",
+			"cluster", c.ID)
+		return nil
 	}
 
 	dyn := c.DynamicClient
@@ -659,6 +696,17 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 	}
 
 	f.mu.Lock()
+	// #5285 — re-check quarantine UNDER the write lock (the top-of-func
+	// RLock check was released while the informers were built). Closes the
+	// TOCTOU where a deployment concluded terminal-FAILED mid-AddCluster:
+	// abort the insert so the just-built informers are never started (they
+	// GC unstarted) and the 404-flood cannot re-establish.
+	if f.isQuarantinedLocked(c.ID) {
+		f.mu.Unlock()
+		f.log.Info("k8scache: aborting registration — deployment quarantined mid-build (terminal failure)",
+			"cluster", c.ID)
+		return nil
+	}
 	// If a cluster with the same id was already registered, close its
 	// stop channel so its informer goroutines exit before we overwrite
 	// the map entry. Without this the previous reflectors would leak —
@@ -746,6 +794,96 @@ func (f *Factory) RemoveCluster(id string) {
 	}
 	f.log.Info("k8scache: cluster removed",
 		"cluster", id, "kinds", len(cs.informers))
+}
+
+// isQuarantinedLocked reports whether clusterID belongs to a
+// terminally-failed deployment. Caller MUST hold f.mu (R or W). A
+// clusterID matches when it is exactly a quarantined bare deployment id
+// OR carries the `<depID>-` prefix of one (its secondary-region cluster).
+// #5285.
+func (f *Factory) isQuarantinedLocked(clusterID string) bool {
+	if _, ok := f.terminated[clusterID]; ok {
+		return true
+	}
+	for dep := range f.terminated {
+		if strings.HasPrefix(clusterID, dep+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+// deploymentClusterIDsLocked returns every registered cluster id that
+// belongs to deployment depID — the bare `<depID>` primary and every
+// `<depID>-<region>` secondary. Caller MUST hold f.mu (R or W). #5285.
+func (f *Factory) deploymentClusterIDsLocked(depID string) []string {
+	prefix := depID + "-"
+	var ids []string
+	for id := range f.clusters {
+		if id == depID || strings.HasPrefix(id, prefix) {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// RemoveDeployment tears down the k8scache informer set for EVERY cluster
+// of deployment depID — the bare `<depID>` primary AND all
+// `<depID>-<region>` secondaries. RemoveCluster alone (as the wipe path
+// historically called it with the bare id) missed the secondary-region
+// reflectors, which then kept retrying against the destroyed apiserver.
+// Idempotent + safe from any goroutine. Used by the wipe path (which then
+// deletes the kubeconfig files, so no quarantine is needed there). #5285.
+func (f *Factory) RemoveDeployment(depID string) {
+	if depID == "" {
+		return
+	}
+	f.mu.RLock()
+	ids := f.deploymentClusterIDsLocked(depID)
+	f.mu.RUnlock()
+	for _, id := range ids {
+		f.RemoveCluster(id)
+	}
+}
+
+// QuarantineDeployment stops AND durably suppresses the watch reflectors
+// for a deployment that concluded terminal-FAILED. It marks depID
+// terminated (so the rescan loop / AddCluster refuse to re-register it
+// while its kubeconfig lingers on the PVC for the eventual wipe) and
+// tears down every currently-registered `<depID>` / `<depID>-<region>`
+// cluster. Without this, a failed env's per-kind reflectors 404-flood
+// against its missing Catalyst CRDs and starve the /wipe + /deployments
+// control endpoints needed to recover it (#5285). Idempotent.
+func (f *Factory) QuarantineDeployment(depID string) {
+	if depID == "" {
+		return
+	}
+	f.mu.Lock()
+	if f.terminated == nil {
+		f.terminated = map[string]struct{}{}
+	}
+	f.terminated[depID] = struct{}{}
+	ids := f.deploymentClusterIDsLocked(depID)
+	f.mu.Unlock()
+	for _, id := range ids {
+		f.RemoveCluster(id)
+	}
+	f.log.Info("k8scache: deployment quarantined (terminal failure) — reflectors stopped, rescan re-registration suppressed",
+		"deployment", depID, "clustersRemoved", len(ids))
+}
+
+// UnquarantineDeployment clears a deployment's terminal-failed quarantine
+// so a same-id re-register can proceed again. Rarely needed directly (the
+// rescan loop auto-clears once the kubeconfig(s) vanish), but the wipe
+// path calls it as belt-and-suspenders after the deployment's kubeconfig
+// files are removed. Idempotent. #5285.
+func (f *Factory) UnquarantineDeployment(depID string) {
+	if depID == "" {
+		return
+	}
+	f.mu.Lock()
+	delete(f.terminated, depID)
+	f.mu.Unlock()
 }
 
 // Start kicks off every informer + the snapshot loop. Safe to call
@@ -883,8 +1021,12 @@ func (f *Factory) rescanOnce(ctx context.Context) {
 		for _, ref := range refs {
 			f.mu.RLock()
 			_, already := f.clusters[ref.ID]
+			// #5285 — a terminally-failed deployment's kubeconfig lingers
+			// on the PVC for the eventual wipe; do NOT resurrect its
+			// 404-flooding reflectors here.
+			quarantined := f.isQuarantinedLocked(ref.ID)
 			f.mu.RUnlock()
-			if already {
+			if already || quarantined {
 				continue
 			}
 			if err := f.AddCluster(ref); err != nil {
@@ -894,6 +1036,16 @@ func (f *Factory) rescanOnce(ctx context.Context) {
 			}
 			f.log.Info("k8scache: rescan — registered new cluster",
 				"id", ref.ID, "kubeconfig", ref.KubeconfigPath)
+		}
+
+		// #5285 — self-evict quarantine entries for deployments whose
+		// kubeconfig(s) have all vanished (post-wipe), so the set stays
+		// bounded and cannot block a same-id re-register. Guarded on a
+		// SUCCESSFUL dir read (err == nil): an unreadable dir returns an
+		// empty ref list, and clearing on that would drop live quarantines
+		// and let the next good rescan resurrect the flood.
+		if err == nil {
+			f.evictStaleQuarantine(refs)
 		}
 
 		// #3987 — prune file-backed clusters whose kubeconfig vanished from
@@ -944,6 +1096,36 @@ func (f *Factory) rescanOnce(ctx context.Context) {
 	}
 	f.log.Info("k8scache: rescan — chroot self-registered from ConfigMap",
 		"id", ref.ID, "sovereignFQDN", fqdn)
+}
+
+// evictStaleQuarantine drops #5285 quarantine entries whose kubeconfig
+// file(s) are no longer present in the rescanned dir — i.e. the failed
+// deployment has since been wiped, so there is nothing left to resurrect
+// and the entry is safe (and desirable) to forget, keeping the set
+// bounded. `present` is the full ref list from a SUCCESSFUL
+// LoadClustersFromDir pass (the caller guards on err == nil). A
+// quarantined deployment id `dep` is considered still present when any
+// ref is exactly `dep` or carries the `dep-` secondary prefix.
+func (f *Factory) evictStaleQuarantine(present []ClusterRef) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.terminated) == 0 {
+		return
+	}
+	for dep := range f.terminated {
+		stillPresent := false
+		for _, ref := range present {
+			if ref.ID == dep || strings.HasPrefix(ref.ID, dep+"-") {
+				stillPresent = true
+				break
+			}
+		}
+		if !stillPresent {
+			delete(f.terminated, dep)
+			f.log.Info("k8scache: quarantine cleared — deployment kubeconfig gone (post-wipe)",
+				"deployment", dep)
+		}
+	}
 }
 
 // clustersToPrune returns the ids of file-backed clusters whose

--- a/products/catalyst/bootstrap/api/internal/k8scache/informer_teardown_5285_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/informer_teardown_5285_test.go
@@ -1,0 +1,225 @@
+// informer_teardown_5285_test.go — #5285 regression guard.
+//
+// Root cause: a per-deployment k8scache cluster (keyed `<depID>` and
+// `<depID>-<region>`) watches every DefaultKind, INCLUDING the Catalyst
+// CRDs cnpgpairs / continuums / organizations / useraccesses. When a
+// deployment concluded terminal-FAILED, nothing tore its informer set
+// down — RemoveCluster only ran on wipe. Worse, the failed env's
+// kubeconfig deliberately lingers on the PVC for the eventual wipe, so a
+// bare RemoveCluster would be undone within one rescan tick (≤30s), which
+// re-registers any kubeconfig still on disk. The failed apiserver is up
+// but its CRDs never installed, so the reflectors 404-flood ("the server
+// could not find the requested resource"), spike catalyst-api CPU, and
+// starve the /wipe + /deployments control endpoints needed to recover the
+// env (hw279, dep 059126bb).
+//
+// The fix: on terminal-FAILED conclusion the handler calls
+// QuarantineDeployment(depID) — it tears down every `<depID>` /
+// `<depID>-<region>` reflector set AND suppresses re-registration by the
+// rescan loop / AddCluster while the kubeconfig lingers, self-clearing
+// once the eventual wipe removes the kubeconfig.
+package k8scache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeMinimalKubeconfig writes a valid token-auth kubeconfig for cluster
+// id `id` into `dir/<id>.yaml` (the shape LoadClustersFromDir + AddCluster
+// both accept). The server IP is a black hole — the informers built off it
+// are never Start()ed in these tests, so nothing dials it.
+func writeMinimalKubeconfig(t *testing.T, dir, id string) {
+	t.Helper()
+	kc := "apiVersion: v1\n" +
+		"kind: Config\n" +
+		"clusters:\n" +
+		"- cluster:\n" +
+		"    server: https://10.255.0.1:6443\n" +
+		"    insecure-skip-tls-verify: true\n" +
+		"  name: c\n" +
+		"contexts:\n" +
+		"- context:\n" +
+		"    cluster: c\n" +
+		"    user: u\n" +
+		"  name: c\n" +
+		"current-context: c\n" +
+		"users:\n" +
+		"- name: u\n" +
+		"  user:\n" +
+		"    token: test-token\n"
+	if err := os.WriteFile(filepath.Join(dir, id+".yaml"), []byte(kc), 0o600); err != nil {
+		t.Fatalf("write kubeconfig %s: %v", id, err)
+	}
+}
+
+// TestQuarantineDeployment_StopsAndSuppressesReflectors is the hermetic
+// method-level guard: QuarantineDeployment removes every cluster of a
+// deployment (primary + secondary), AddCluster then REFUSES to re-register
+// them (any resurrection path), and UnquarantineDeployment restores the
+// ability to register again. Unrelated deployments are untouched.
+func TestQuarantineDeployment_StopsAndSuppressesReflectors(t *testing.T) {
+	f, err := NewFactory(Config{Logger: quietLogger()})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	// Register a failed deployment's primary + secondary + an unrelated
+	// healthy deployment. No Start() → informers are built but never dial.
+	addCluster := func(id string) {
+		dyn, core := fakeClients()
+		if err := f.AddCluster(ClusterRef{ID: id, DynamicClient: dyn, CoreClient: core}); err != nil {
+			t.Fatalf("AddCluster(%s): %v", id, err)
+		}
+	}
+	addCluster("dep1")
+	addCluster("dep1-b")
+	addCluster("other")
+
+	for _, id := range []string{"dep1", "dep1-b", "other"} {
+		if !containsClusterID(f.Clusters(), id) {
+			t.Fatalf("precondition: Clusters()=%v missing %q", f.Clusters(), id)
+		}
+	}
+
+	// Conclude dep1 as terminal-FAILED.
+	f.QuarantineDeployment("dep1")
+
+	if containsClusterID(f.Clusters(), "dep1") {
+		t.Errorf("after QuarantineDeployment: primary dep1 still registered — reflectors not torn down")
+	}
+	if containsClusterID(f.Clusters(), "dep1-b") {
+		t.Errorf("after QuarantineDeployment: secondary dep1-b still registered — secondary reflectors not torn down")
+	}
+	if !containsClusterID(f.Clusters(), "other") {
+		t.Errorf("after QuarantineDeployment: unrelated deployment 'other' was wrongly removed")
+	}
+
+	// The crux of #5285: re-registration (the rescan/POST resurrection
+	// vector while the kubeconfig lingers) must be REFUSED for both the
+	// primary and the secondary. AddCluster returns nil (no-op) but the
+	// cluster must NOT reappear.
+	for _, id := range []string{"dep1", "dep1-b"} {
+		dyn, core := fakeClients()
+		if err := f.AddCluster(ClusterRef{ID: id, DynamicClient: dyn, CoreClient: core}); err != nil {
+			t.Fatalf("AddCluster(%s) while quarantined returned error, want nil no-op: %v", id, err)
+		}
+		if containsClusterID(f.Clusters(), id) {
+			t.Errorf("quarantined %q was re-registered by AddCluster — the 404-flood would resume", id)
+		}
+	}
+
+	// Wipe path clears the quarantine (kubeconfig removed) → registration
+	// works again.
+	f.UnquarantineDeployment("dep1")
+	dyn, core := fakeClients()
+	if err := f.AddCluster(ClusterRef{ID: "dep1", DynamicClient: dyn, CoreClient: core}); err != nil {
+		t.Fatalf("AddCluster(dep1) after Unquarantine: %v", err)
+	}
+	if !containsClusterID(f.Clusters(), "dep1") {
+		t.Errorf("after UnquarantineDeployment, dep1 failed to re-register")
+	}
+}
+
+// TestRemoveDeployment_TearsDownPrimaryAndSecondaries proves the wipe-path
+// helper removes BOTH the bare `<depID>` primary and every
+// `<depID>-<region>` secondary (the bare-id RemoveCluster missed the
+// secondaries), without quarantining — so a subsequent AddCluster of the
+// same id can proceed (wipe deletes the kubeconfig, no resurrection risk).
+func TestRemoveDeployment_TearsDownPrimaryAndSecondaries(t *testing.T) {
+	f, err := NewFactory(Config{Logger: quietLogger()})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	for _, id := range []string{"dep2", "dep2-a", "dep2-b", "other"} {
+		dyn, core := fakeClients()
+		if err := f.AddCluster(ClusterRef{ID: id, DynamicClient: dyn, CoreClient: core}); err != nil {
+			t.Fatalf("AddCluster(%s): %v", id, err)
+		}
+	}
+
+	f.RemoveDeployment("dep2")
+
+	for _, id := range []string{"dep2", "dep2-a", "dep2-b"} {
+		if containsClusterID(f.Clusters(), id) {
+			t.Errorf("RemoveDeployment left %q registered", id)
+		}
+	}
+	if !containsClusterID(f.Clusters(), "other") {
+		t.Errorf("RemoveDeployment wrongly removed unrelated 'other'")
+	}
+
+	// RemoveDeployment must NOT quarantine — a same-id re-register works.
+	dyn, core := fakeClients()
+	if err := f.AddCluster(ClusterRef{ID: "dep2", DynamicClient: dyn, CoreClient: core}); err != nil {
+		t.Fatalf("AddCluster(dep2) after RemoveDeployment: %v", err)
+	}
+	if !containsClusterID(f.Clusters(), "dep2") {
+		t.Errorf("RemoveDeployment wrongly quarantined dep2 (re-register refused)")
+	}
+}
+
+// TestFailedDeployment_RescanDoesNotResurrectReflectors is the end-to-end
+// guard against the real defect: the kubeconfigs rescan loop must NOT
+// re-register a terminally-failed deployment whose kubeconfig still lingers
+// on disk (kept for the eventual wipe), and the quarantine must self-clear
+// once that kubeconfig is finally removed.
+func TestFailedDeployment_RescanDoesNotResurrectReflectors(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalKubeconfig(t, dir, "dep1")   // primary
+	writeMinimalKubeconfig(t, dir, "dep1-b") // secondary region
+
+	f, err := NewFactory(Config{Logger: quietLogger(), KubeconfigsDir: dir})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	ctx := context.Background()
+
+	// First rescan registers both clusters from disk (informers built, not
+	// started — the factory was never Start()ed).
+	f.rescanOnce(ctx)
+	for _, id := range []string{"dep1", "dep1-b"} {
+		if !containsClusterID(f.Clusters(), id) {
+			t.Fatalf("precondition: rescan did not register %q (Clusters=%v)", id, f.Clusters())
+		}
+	}
+
+	// Deployment concludes terminal-FAILED.
+	f.QuarantineDeployment("dep1")
+	if containsClusterID(f.Clusters(), "dep1") || containsClusterID(f.Clusters(), "dep1-b") {
+		t.Fatalf("QuarantineDeployment left a cluster registered: %v", f.Clusters())
+	}
+
+	// The kubeconfig files STILL exist on disk (kept for wipe). A rescan
+	// MUST NOT resurrect the 404-flooding reflectors.
+	f.rescanOnce(ctx)
+	for _, id := range []string{"dep1", "dep1-b"} {
+		if containsClusterID(f.Clusters(), id) {
+			t.Fatalf("rescan RESURRECTED quarantined %q — the reflector flood would resume (the #5285 defect)", id)
+		}
+	}
+
+	// The eventual wipe removes the kubeconfig files. The next rescan
+	// self-clears the quarantine (bounded set), and a genuinely new
+	// kubeconfig with the same id may register again.
+	if err := os.Remove(filepath.Join(dir, "dep1.yaml")); err != nil {
+		t.Fatalf("remove dep1.yaml: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, "dep1-b.yaml")); err != nil {
+		t.Fatalf("remove dep1-b.yaml: %v", err)
+	}
+	f.rescanOnce(ctx) // sees the files gone → evictStaleQuarantine clears dep1
+
+	writeMinimalKubeconfig(t, dir, "dep1")
+	f.rescanOnce(ctx)
+	if !containsClusterID(f.Clusters(), "dep1") {
+		t.Errorf("after wipe removed the kubeconfig, quarantine did not self-clear — a fresh same-id kubeconfig failed to register")
+	}
+}


### PR DESCRIPTION
## Problem (live, hw279 dep 059126bb, 2026-07-20)

After a deployment concludes `finalStatus=failed`, its per-deployment k8scache watch-informers keep retry-flooding the mothership catalyst-api against the failed cluster's **missing Catalyst CRDs**:

```
E reflector.go:227 "Failed to watch" err="failed to list dr.openova.io/v1, Resource=cnpgpairs: the server could not find the requested resource"
E ... Resource=continuums / organizations / useraccesses ...
```

The catalyst-api ran hot (1206m CPU) and its deployment-management endpoints hung — `POST /deployments/{id}/wipe` and `GET /deployments` returned empty/timeout for ~16 min, so the failed env's wipe could not even start. That is a self-inflicted control-plane DoS plus a chicken-and-egg on the wipe (you need `/wipe` to clear the flood, but the flood blocks `/wipe`). Heal was a manual `kubectl rollout restart` — not acceptable as steady state.

## Root cause (file:line)

Two informer layers exist; only one is the flood source:

- **`internal/helmwatch/helmwatch.go`** — the per-deployment `helmwatch.Watcher` watches **only** HelmReleases (`helmwatch.go:77`), and is already torn down on conclusion (`phase1_watch.go` `stopSecondaries()` + the `liveWatcher` clear). Not the flood.
- **`internal/k8scache/factory.go`** — the per-cluster `dynamicinformer` reflector set watches **every** `DefaultKind`, including the four CRDs in the flood: `internal/k8scache/kinds.go` `useraccesses` (:197), `organizations`, `continuums` (:243), `cnpgpairs` (:248). This layer had **no teardown on a terminal-`failed` conclusion** — `RemoveCluster` only ran on wipe (`wipe.go`), janitor eject, and the disk rescan-prune. A deployment's cluster is registered from its kubeconfig (`<depID>.yaml` / `<depID>-<region>.yaml`) on the catalyst-api PVC by the rescan loop (`factory.go` `rescanOnce`) / secondary-kubeconfig POST.

Why a bare `RemoveCluster` on conclusion is insufficient: a failed env's kubeconfig is deliberately **kept** on the PVC for the eventual wipe's pre-destroy EVS drain, so the rescan loop re-registers it within one tick (≤30s) and the reflectors resume. The failed apiserver is UP but its CRDs never installed, so every re-registered reflector 404s ("the server could not find the requested resource") and burns CPU.

## Fix

`internal/k8scache/factory.go` — a per-deployment **quarantine** set (`terminated`) keyed by bare deployment id:
- `QuarantineDeployment(depID)` — tears down every `<depID>` primary + `<depID>-<region>` secondary reflector set AND records the deployment so `AddCluster` (the single registration choke point, guarded top-of-func and re-checked under the write lock to close a mid-build TOCTOU) and the rescan loop refuse to re-register it while the kubeconfig lingers.
- `RemoveDeployment(depID)` — tears down primary + all secondaries without quarantine (used by the wipe path, which then deletes the kubeconfig).
- `UnquarantineDeployment(depID)` + `evictStaleQuarantine` — the quarantine self-clears (bounded set) once the kubeconfig(s) vanish post-wipe (guarded on a successful dir read so an unreadable dir never drops a live quarantine).

`internal/handler/phase1_watch.go` — on terminal `finalStatus == "failed"`, call `QuarantineDeployment(dep.ID)`. This is the failed-branch counterpart to the ready-branch handover. **Only** `failed` quarantines — a `ready`/handed-off Sovereign's CRDs exist (no flood) and its reflectors power the console live view, so those stay running.

`internal/handler/wipe.go` — `RemoveCluster(id)` → `RemoveDeployment(id)` + `UnquarantineDeployment(id)`. This also fixes a pre-existing gap: the bare-id `RemoveCluster` missed the `<id>-<region>` secondary reflectors, which kept retrying against their destroyed apiservers.

`internal/handler/handler.go` — `SetK8sCache` re-derives the quarantine from the persisted `Status=="failed"` records `restoreFromStore()` loaded in `New()`, making the quarantine **durable across a catalyst-api Pod restart** (a restart re-scans the lingering kubeconfigs and would otherwise resurrect the flood).

Net effect: a concluded-`failed` deployment can no longer keep reflectors alive, so it cannot saturate CPU or starve `/wipe` + `/deployments` — regardless of how many deployments have failed or whether the Pod restarted.

## Tests

`internal/k8scache/informer_teardown_5285_test.go`:
- `TestQuarantineDeployment_StopsAndSuppressesReflectors` — quarantine tears down primary + secondary, `AddCluster` then refuses re-registration (both paths), `Unquarantine` restores it; unrelated deployments untouched.
- `TestRemoveDeployment_TearsDownPrimaryAndSecondaries` — wipe-path helper removes primary + all secondaries, keeps unrelated, and does not quarantine.
- `TestFailedDeployment_RescanDoesNotResurrectReflectors` — end-to-end with a real kubeconfigs dir: `rescanOnce` registers, quarantine removes, a later `rescanOnce` with the kubeconfig still present does **not** resurrect, and the quarantine self-clears once the kubeconfig is removed.

`internal/handler/k8scache_quarantine_5285_test.go`:
- `TestSetK8sCache_QuarantinesFailedDeploymentsAcrossRestart` — a restarted Pod re-quarantines the failed primary + secondary and leaves the healthy `ready` env registered.

`go build ./... && go test ./...` (non-race) green in `products/catalyst/bootstrap/api`; the four new tests + every touched package (`internal/k8scache`, `internal/handler`) are green under `-race`.

Note on one `-race` flake: `TestWipeDeployment_NoS3CredsAnywhereSurfacesError` (a pre-existing async-purge test with a fixed 10s budget) can time out under `-race` on a network-constrained runner — its fake-Hetzner-token purge does real API retries whose latency tracks external network responsiveness. It fails identically on this branch's base commit **without this diff**, and never touches this change's code path (`NewWithPDM` leaves `h.k8sCache` nil, so the wipe-path `if h.k8sCache != nil` block and `SetK8sCache` are not executed). Same class as the known wipe-async timing flake noted on #5254.

## Coordination

Lands alongside **#5284** (issue #5283 — the `WatchTimeout` progress-guard in `helmwatch.go`). This change is a distinct aspect (informer teardown on terminal conclusion vs. the timeout wall-clock) and is kept separable — branched off `origin/main`, which does not yet carry #5284.

Refs #5285 #5253
