### PR TITLE
fix(cloud): render Volume nodes from live volume.hcloud managed resources (Refs #3987)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
@@ -338,6 +338,81 @@ describe('k8sToGraph', () => {
     )
   })
 
+  it('renders Volume nodes from live volume.hcloud managed resources (#3987)', () => {
+    const s = snap([
+      'volume.hcloud:9001',
+      {
+        apiVersion: 'hcloud.crossplane.io/v1alpha1',
+        kind: 'Volume',
+        metadata: {
+          name: 'pvc-data-0',
+          annotations: { 'crossplane.io/external-name': '9001' },
+        },
+        spec: { forProvider: { name: 'data-vol', size: 10, location: 'fsn1' } },
+        status: { conditions: [{ type: 'Ready', status: 'True' }] },
+      },
+    ])
+    const { nodes } = k8sToGraph(s)
+    expect(nodes).toContainEqual(
+      expect.objectContaining({
+        id: 'Volume:9001',
+        type: 'Volume',
+        label: 'data-vol',
+        status: 'healthy',
+        metadata: expect.objectContaining({ capacity: '10 GB', region: 'fsn1', hcloudID: '9001' }),
+      }),
+    )
+  })
+
+  it('resolves the PVC→Volume `realizes` edge once the volume.hcloud node exists (#3987)', () => {
+    const s = snap(
+      ['namespace:foo', { metadata: { name: 'foo' } }],
+      [
+        'persistentvolumeclaim:foo/data-0',
+        {
+          apiVersion: 'v1',
+          kind: 'PersistentVolumeClaim',
+          metadata: { namespace: 'foo', name: 'data-0' },
+          spec: { volumeName: 'pv-1', resources: { requests: { storage: '10Gi' } } },
+          status: { phase: 'Bound' },
+        },
+      ],
+      [
+        'persistentvolume:pv-1',
+        {
+          apiVersion: 'v1',
+          kind: 'PersistentVolume',
+          metadata: { name: 'pv-1' },
+          spec: { csi: { volumeHandle: '9001' } },
+        },
+      ],
+      [
+        'volume.hcloud:9001',
+        {
+          apiVersion: 'hcloud.crossplane.io/v1alpha1',
+          kind: 'Volume',
+          metadata: { name: 'pvc-data-0', annotations: { 'crossplane.io/external-name': '9001' } },
+          spec: { forProvider: { size: 10, location: 'fsn1' } },
+          status: { conditions: [{ type: 'Ready', status: 'True' }] },
+        },
+      ],
+    )
+    // mergeGraphs's final endpoint filter DROPS any edge whose target node
+    // is absent. Before the Volume node existed the `realizes` edge always
+    // dangled; asserting it survives the merge proves the bridge is whole.
+    const merged = mergeGraphs({ nodes: [], edges: [] }, k8sToGraph(s))
+    expect(merged.nodes).toContainEqual(
+      expect.objectContaining({ id: 'Volume:9001', type: 'Volume' }),
+    )
+    expect(merged.edges).toContainEqual(
+      expect.objectContaining({
+        source: 'PVC:foo/data-0',
+        target: 'Volume:9001',
+        type: 'realizes',
+      }),
+    )
+  })
+
   /* ── #3987 (UAT row 200) — Gateway-API + NetworkPolicy projection.
    * The snapshot carried gateway:/httproute:/networkpolicy: keys but
    * the adapter had no section for them, so the Networking lens chips

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
@@ -610,6 +610,40 @@ export function k8sToGraph(snapshot: K8sSnapshot): AdaptResult {
     }
   }
 
+  // 7b. Volume — Crossplane `volume.hcloud` managed resource (#3987).
+  //     The SSE snapshot carries `volume.hcloud:` keys (they are in both
+  //     GRAPH_K8S_KINDS and the CloudPage CLOUD_PAGE_K8S_KINDS union; the
+  //     kind is registered in api/internal/k8scache/kinds.go), and
+  //     section 7 already emits a PVC → `Volume:${hcloudID}` `realizes`
+  //     edge — but NO adapter ever created the Volume node. So the whole
+  //     PVC→Volume.hcloud bridge that kinds.go / GRAPH_K8S_KINDS / the
+  //     cloud-side adapter all scaffold rendered nothing: the Volume chip
+  //     read empty on an hcloud Sovereign even with live volumes, and
+  //     every `realizes` edge dangled (its target node absent → dropped
+  //     by mergeGraphs's endpoint filter). Adapt the managed resource
+  //     into a Volume node keyed by its hcloud id (the Crossplane
+  //     external-name, which equals the CSI volumeHandle the edge keys
+  //     on) so the chip populates from the live source AND the existing
+  //     PVC→Volume edges resolve. A cluster with no volume.hcloud objects
+  //     (e.g. a non-hcloud provider) still renders empty — no fabrication.
+  for (const [, vol] of iterByKind(snapshot, 'volume.hcloud')) {
+    const hcloudID = crossplaneExternalID(vol)
+    if (!hcloudID) continue
+    const forProvider = (vol.spec?.['forProvider'] as Record<string, unknown> | undefined) ?? {}
+    const size = forProvider['size']
+    const capacity = size != null && `${size}` !== '' ? `${size} GB` : ''
+    const region = (forProvider['location'] as string | undefined) ?? ''
+    const label = (forProvider['name'] as string | undefined) || vol.metadata?.name || hcloudID
+    addNode({
+      id: compositeId('Volume', '', hcloudID),
+      type: 'Volume',
+      label,
+      sublabel: capacity || region,
+      status: nodeStatus(vol),
+      metadata: { capacity, region, hcloudID },
+    })
+  }
+
   // 8. ConfigMaps — opt-in chip; rendered only when the operator
   //    enables the type. Edge: ConfigMap → Namespace.
   for (const [, cm] of iterByKind(snapshot, 'configmap')) {
@@ -644,6 +678,23 @@ function nodeStatus(o: K8sObject): ArchStatus {
     }
   }
   return 'unknown'
+}
+
+/**
+ * crossplaneExternalID resolves a Crossplane managed resource's stable
+ * cloud-side id — the `crossplane.io/external-name` annotation, which
+ * provider-hcloud sets to the numeric hcloud id (the SAME value the
+ * hcloud-csi PV carries as its volumeHandle, so a Volume node keyed on
+ * it matches the PVC→Volume `realizes` edge target). Falls back to
+ * status.atProvider.id, then metadata.name. Empty string when none
+ * resolve (the node is skipped rather than keyed on a blank id).
+ */
+function crossplaneExternalID(o: K8sObject): string {
+  const ext = o.metadata?.annotations?.['crossplane.io/external-name']
+  if (ext) return ext
+  const atProvider = o.status?.['atProvider'] as { id?: unknown } | undefined
+  if (atProvider?.id != null && `${atProvider.id}` !== '') return `${atProvider.id}`
+  return o.metadata?.name ?? ''
 }
 
 /**


### PR DESCRIPTION
## Problem

Audit of the cloud-graph's **per-kind empty-data** class (GOV #897 / issue #3987) found one genuine gap remaining after the prior fixes (#3997 subscribed every registry kind; #5108/#5129 added the networking graph adapters; #3998 infra; #5280 clusters).

The **PVC → Volume.hcloud bridge is fully scaffolded but never completes**:

- `volume.hcloud` is a registered kind (`api/internal/k8scache/kinds.go:113`), listed in both `GRAPH_K8S_KINDS` (`useK8sCacheStream.ts:69`) and the CloudPage `CLOUD_PAGE_K8S_KINDS` union, and streamed over SSE.
- `k8sAdapter.ts` section 7 already emits a `PVC → Volume:${hcloudID}` `realizes` edge (`k8sAdapter.ts:602-609`).
- The cloud-side adapter renders `Volume` nodes from `tree.storage.volumes` (`adapter.ts`), and `Volume` is a first-class `ArchNodeType`.

…but **no adapter ever creates the Volume node from the live `volume.hcloud` objects** (the topology loader's `buildStorage` returns `[]Volume{}`). Net effect on an hcloud Sovereign:

1. The **Volume chip renders empty** despite live volumes.
2. Every `PVC → Volume` `realizes` edge **dangles** — its target node is absent, so `mergeGraphs`'s endpoint filter (`k8sAdapter.ts:839`) silently drops it.

This is the exact "adapter returns `[]` on a present-but-unqueried source" class named in the audit scope.

## Fix

Add a `k8sToGraph` section (`7b`) that adapts each `volume.hcloud` managed resource into a `Volume` node, keyed by its hcloud id — the Crossplane `crossplane.io/external-name` annotation, which equals the hcloud-csi PV `volumeHandle` the existing `realizes` edge keys on. So the chip populates from the live source **and** the PVC→Volume edges resolve.

Pure, read-only render surface — **no fabrication**: a cluster with no `volume.hcloud` objects (e.g. a non-hcloud provider) still renders empty.

## Tests

`k8sAdapter.test.ts`: (1) a live `volume.hcloud` MR yields a `Volume` node with the right id/label/capacity/region/status; (2) the `PVC→Volume` `realizes` edge **survives `mergeGraphs`'s endpoint filter** now that the node exists (before this change it was always dropped).

- `vitest run architecture-graph/` — 99 passed
- `vitest run CloudPage.test.tsx` — 6 passed
- `tsc -b --noEmit` — clean

Tertiary operator-debugger surface; change is tight and additive (no behavior change to any other kind).

Refs #3987

🤖 Generated with [Claude Code](https://claude.com/claude-code)