### PR TITLE
fix(catalyst): serve api/console/marketplace on region-b via ClusterMesh global-service proxy (Refs #5289)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1264,7 +1264,12 @@ spec:
       #   cutover-rolled) before that Secret was reflected rolls when it
       #   lands and wires the /oidc/* provider routes — killing the cold
       #   catalyst-pin broker 404 (hw278 SSO). Lockstep w/ Chart.yaml.
-      version: 1.4.1189
+      # 1.4.1190 — #5289: multiRegion.enabled gates the ClusterMesh global
+      #   annotations on the control-plane backend Services so region-b's
+      #   bp-catalyst-edge-routes (slot 13b) can proxy api./console./
+      #   marketplace. to region-a's singletons. Set below from
+      #   ${SOVEREIGN_ENABLE_HOT_STANDBY}. Lockstep w/ Chart.yaml.
+      version: 1.4.1190
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform
@@ -1440,6 +1445,19 @@ spec:
       cluster:
         enabled: ${SOVEREIGN_ORG_PG_OWN_CLUSTER:=true}
         instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
+    # ─── Multi-region control-plane edge (#5289) ─────────────────────────
+    # On a 2-region Sovereign, publish the control-plane backend Services
+    # (catalyst-api / catalyst-ui / catalyst-catalog + org-services gateway/
+    # admin/marketplace) as Cilium ClusterMesh global Services so region-b's
+    # bp-catalyst-secondary-edge (slot 13b) proxies api./console./marketplace.
+    # to these region-a singletons — killing the steady-state 200↔404 flap
+    # where region-b's #5246-console-ELB envoy had no control-plane HTTPRoute.
+    # Sourced from ${SOVEREIGN_ENABLE_HOT_STANDBY} (the same cloud-init var
+    # that flips the active-hot-standby CNPG pair): "true" on a 2-region
+    # Sovereign, "false" on single-region → the chart's Service annotations
+    # render byte-identically to today on every single-region prov.
+    multiRegion:
+      enabled: ${SOVEREIGN_ENABLE_HOT_STANDBY:-false}
     global:
       sovereignFQDN: ${SOVEREIGN_FQDN}
       # sovereignLBIP — Sovereign's load-balancer public IPv4. Issue #900:

--- a/clusters/_template/bootstrap-kit/13e-bp-catalyst-secondary-edge-routes.yaml
+++ b/clusters/_template/bootstrap-kit/13e-bp-catalyst-secondary-edge-routes.yaml
@@ -1,0 +1,107 @@
+# bp-catalyst-secondary-edge — Catalyst Blueprint slot 13e (#5289).
+#
+# The region-b (secondary-CP) control-plane EDGE for a 2-region Sovereign.
+#
+# On a 2-region Sovereign the umbrella bp-catalyst-platform (slot 13) is
+# suspended on every secondary CP (G2 #2574 — catalyst-api is a single-writer
+# singleton on a zone-scoped RWO EVS PVC; a second writer would multi-attach +
+# split-brain, #5267). So the secondary CP serves NO api./console./
+# marketplace. HTTPRoute. But the #5246 both-region console ELB deliberately
+# targets BOTH regions' cilium-envoy pods, so ~half of those requests land on
+# region-b's envoy → TLS terminates → no route → 404 (the steady-state
+# 200↔404 flap #5289 root-caused).
+#
+# This slot un-suspends ONLY on the secondary CP (SECONDARY_EDGE_SUSPEND — the
+# symmetric inverse of SECONDARY_HR_SUSPEND) and installs bp-catalyst-edge-
+# routes, which renders — into catalyst-system + org-services — ONLY Cilium
+# ClusterMesh global-Service stubs + the api/console/marketplace HTTPRoutes
+# that proxy to region-a's singleton pods over the mesh. NO Deployment, NO
+# PVC. On the primary CP + on single-region provs the HR stays suspended
+# (inert), so those render paths are unchanged.
+#
+# Wrapper chart: platform/catalyst-edge-routes/chart/
+# Same both-regions-need-it rationale as slot 12a-bp-sovereign-tls-vars.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-catalyst-edge-routes
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-catalyst-secondary-edge
+  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  labels:
+    catalyst.openova.io/slot: "13e"
+    catalyst.openova.io/component: catalyst-secondary-edge
+    # region-role=secondary: this HR is the INVERSE of the slot-13 umbrella —
+    # active on secondary CPs, suspended on the primary (the umbrella serves
+    # the routes there locally).
+    catalyst.openova.io/region-role: secondary
+spec:
+  # #5289 — un-suspend ONLY on the secondary CP. SECONDARY_EDGE_SUSPEND renders
+  # "false" on secondary CPs (sovereign_region_role != "primary") and "true" on
+  # the primary CP + on any single-region prov (the only CP is "primary"),
+  # keeping this HR inert everywhere except region-b of a 2-region Sovereign.
+  suspend: ${SECONDARY_EDGE_SUSPEND:=true}
+  interval: 15m
+  releaseName: catalyst-secondary-edge
+  targetNamespace: catalyst-system
+  install:
+    # catalyst-system pre-exists (slot 13 raw Namespace, applied on all CPs);
+    # createNamespace is a harmless idempotent safety net.
+    createNamespace: true
+  dependsOn:
+    # gateway.networking.k8s.io CRDs (HTTPRoute + ReferenceGrant) must be
+    # registered before this chart's routes admit. Do NOT depend on
+    # bp-catalyst-platform — it is SUSPENDED on the secondary CP (never Ready),
+    # so a dep on it would deadlock this HR forever.
+    - name: bp-gateway-api
+      namespace: flux-system
+  chart:
+    spec:
+      chart: bp-catalyst-edge-routes
+      # 0.1.0 (#5289): initial region-b edge. Lockstep with
+      # platform/catalyst-edge-routes/chart/Chart.yaml.
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-catalyst-edge-routes
+        namespace: flux-system
+  values:
+    ingress:
+      gateway:
+        enabled: true
+        parentRef:
+          # The dedicated console Gateway (#4053) that fronts api./console./
+          # marketplace. — the SAME parentRef slot 13 hands the umbrella. On a
+          # single-EIP validation prov it resolves to the shared cilium-gateway.
+          name: ${SOVEREIGN_CONSOLE_GATEWAY:-cilium-gateway-console}
+          namespace: kube-system
+      hosts:
+        console:
+          host: console.${SOVEREIGN_FQDN}
+        api:
+          host: api.${SOVEREIGN_FQDN}
+        marketplace:
+          host: marketplace.${SOVEREIGN_FQDN}
+      # Mirror slot 13's marketplace gate so region-b proxies marketplace.<fqdn>
+      # (→ org-services gateway/admin/marketplace over the mesh) exactly when
+      # region-a serves it.
+      marketplace:
+        enabled: ${MARKETPLACE_ENABLED:-true}
+    services:
+      catalog:
+        # Mirrors bp-catalyst-platform's services.catalog.enabled (chart
+        # default true) so the catalyst-catalog stub + api.<fqdn>/api/v1/catalog
+        # route render on region-b whenever region-a serves the catalog.
+        enabled: true

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -86,6 +86,18 @@ resources:
   # (tombstone below). MUST be registered here or Flux never creates the
   # HR (the #3191 forgotten-slot wedge class).
   - 13d-bp-openova-mcp.yaml
+  # bp-catalyst-secondary-edge (slot 13e, #5289) — the region-b control-plane
+  # EDGE. On a 2-region Sovereign the umbrella bp-catalyst-platform (slot 13)
+  # is suspended on the secondary CP (G2 #2574), so region-b serves NO
+  # api./console./marketplace. HTTPRoute and 404s ~half the requests the
+  # #5246 both-region console ELB steers at its envoy (the #5289 flap). This
+  # slot's HR is un-suspended ONLY on the secondary CP (SECONDARY_EDGE_SUSPEND,
+  # the inverse of SECONDARY_HR_SUSPEND) and renders ClusterMesh global-Service
+  # stubs + those HTTPRoutes, proxying to region-a's singletons. Same
+  # both-regions-need-it rationale as 12a-bp-sovereign-tls-vars. MUST be
+  # registered here or Flux never creates the HR (the #3191 forgotten-slot
+  # wedge class); on single-region / primary CPs the HR is suspended (inert).
+  - 13e-bp-catalyst-secondary-edge-routes.yaml
   - 14-crossplane-claims.yaml
   - 15-external-secrets.yaml
   - 15a-external-secrets-stores.yaml

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -200,6 +200,15 @@ spec:
     - {file: 13-bp-catalyst-platform.yaml, hr: bp-catalyst-platform, vcluster: host, target: host,
        namespace: catalyst-system, extraNamespaces: [org-services, catalyst],
        justification: "#4291 DE-VCLUSTER §C — the §4 mgmt-vCluster target is retired (no platform-plane vClusters); host is now the canonical placement (Refs #4293)"}
+    # #5289 region-b control-plane edge — renders ClusterMesh global-Service
+    # stubs into catalyst-system + org-services + the api/console/marketplace
+    # HTTPRoutes that proxy to region-a's singletons. Host placement alongside
+    # the umbrella it mirrors; suspended on the primary CP + single-region
+    # (SECONDARY_EDGE_SUSPEND), active only on the secondary CP. Services +
+    # HTTPRoutes only — no Deployment/PVC (the region-a pods stay sole writers).
+    - {file: 13e-bp-catalyst-secondary-edge-routes.yaml, hr: bp-catalyst-secondary-edge, vcluster: host, target: host,
+       namespace: catalyst-system, extraNamespaces: [org-services],
+       justification: "#5289 — region-b (secondary-CP) edge; host ns catalyst-system alongside the umbrella it mirrors, org-services for the marketplace-host global-Service stubs; no vCluster (host is canonical, Refs #4293)"}
     # ── #4291 DE-VCLUSTER (Refs #4293 #3642 #3373) — gitea → native host ns ──
     # Inverse of the #3642 host-bridge: gitea runs natively in host ns `gitea`,
     # so its chart renders its OWN HTTPRoute (gitea.${SOVEREIGN_FQDN}), SSO

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -855,6 +855,21 @@ write_files:
             # can never render an empty or ephemeral class.
             SOVEREIGN_CNPG_STORAGE_CLASS: "${default_storage_class}"
             SECONDARY_HR_SUSPEND: "${sovereign_region_role == "primary" ? "false" : "true"}"
+            # #5289 — the symmetric INVERSE of SECONDARY_HR_SUSPEND for the
+            # region-b control-plane edge (bootstrap-kit slot 13b,
+            # bp-catalyst-secondary-edge). The umbrella bp-catalyst-platform
+            # is suspended on secondary CPs (G2 #2574), so those CPs serve NO
+            # api./console./marketplace. HTTPRoute and 404 ~half the requests
+            # that the #5246 both-region console ELB steers at their envoy.
+            # Slot 13b un-suspends there (suspend=false) to render the
+            # ClusterMesh global-Service stubs + HTTPRoutes that proxy those
+            # hosts back to region-a's singletons; on the PRIMARY CP the edge
+            # HR stays suspended (the umbrella already serves the routes
+            # locally). Renders "true" on the primary CP, "false" on every
+            # secondary CP — exactly opposite SECONDARY_HR_SUSPEND. On a
+            # single-region prov the only CP is "primary" → suspended → the
+            # slot-13b HR is inert and the render is unchanged from today.
+            SECONDARY_EDGE_SUSPEND: "${sovereign_region_role == "primary" ? "true" : "false"}"
             # #4765 — the ONE shared LB-IPAM CIDR for the sovereign-vip pool.
             # bp-cilium 1.4.9 renders a SINGLE CiliumLoadBalancerIPPool
             # `sovereign-vip` from cilium.lbIpam; the clustermesh-apiserver

--- a/platform/catalyst-edge-routes/README.md
+++ b/platform/catalyst-edge-routes/README.md
@@ -1,0 +1,75 @@
+# bp-catalyst-edge-routes
+
+Region-b (secondary control-plane) **edge** for a 2-region Catalyst Sovereign.
+
+## Role in Catalyst
+
+Control-plane plumbing — **not** a user-installable Application Blueprint. It is
+installed only on the **secondary** CP of a 2-region Sovereign, by bootstrap-kit
+slot `13b-catalyst-secondary-edge-routes.yaml`, and it renders **only** Cilium
+ClusterMesh global-Service stubs + Gateway-API HTTPRoutes/ReferenceGrant — never
+a Deployment, StatefulSet, PVC, or Job.
+
+## Why it exists (issue #5289)
+
+The Catalyst control plane (`catalyst-api` / `catalyst-ui` / `catalyst-catalog`
++ the Organization marketplace stack in `org-services`) is a **single-writer
+singleton pinned to region-a**: G2 (#2574) suspends `bp-catalyst-platform` on
+every secondary CP, and the api store is on a zone-scoped RWO EVS PVC — a second
+`catalyst-api` would multi-attach and split-brain (#5267).
+
+But the #5246 both-region **console ELB** deliberately targets *both* regions'
+`cilium-envoy` pods on `:443` so the console EIP survives a region-kill. In
+normal 2-region operation that means ~half of `api.` / `console.` /
+`marketplace.<fqdn>` requests land on **region-b's** envoy — which, with the
+umbrella HR suspended, serves **no** control-plane HTTPRoute and returns **404**.
+That is the steady-state `200↔404` flap #5289 root-caused (~6/10 requests 404 on
+hw280).
+
+## How it fixes it
+
+Region-b must **serve** those hosts by **proxying** to region-a's single pods
+over Cilium ClusterMesh **global Services** — the same idiom `bp-cnpg-pair` /
+`bp-openbao` use for cross-region delivery:
+
+1. **region-a** (`bp-catalyst-platform` ≥ 1.4.1190, gated on
+   `multiRegion.enabled`) annotates its real control-plane Services with
+   `service.cilium.io/global: "true"` + `.../shared: "true"`.
+2. **region-b** (this chart) renders same-name+namespace **stub** Services with
+   the same annotations and **zero local backends**. Cilium merges the two into
+   one global Service, so every region-b dial crosses the mesh to region-a's
+   singleton.
+3. **region-b** renders the `api.` / `console.` / `marketplace.` HTTPRoutes
+   (byte mirrors of the region-a routes) parented onto the same
+   `cilium-gateway-console` listener, backendRef'd at the stubs.
+
+No second `catalyst-api`/`catalyst-ui` Deployment, no PVC → the region-a pods
+stay the sole writers.
+
+## Configuration knobs
+
+All supplied per-Sovereign by bootstrap-kit slot 13b (defaults render nothing):
+
+| Value | Meaning |
+|---|---|
+| `ingress.gateway.enabled` | Master gate — no routes/services without it. |
+| `ingress.gateway.parentRef.{name,namespace,sectionName}` | The console Gateway (`cilium-gateway-console` in `kube-system`, or `cilium-gateway` on a single-EIP prov). |
+| `ingress.hosts.{console,api,marketplace}.host` | `console./api./marketplace.<fqdn>`. |
+| `ingress.marketplace.enabled` | Render the marketplace-host proxy (org-services stubs + route + grant). Mirrors slot 13's `MARKETPLACE_ENABLED`. |
+| `services.catalog.enabled` | Render the `catalyst-catalog` stub + `api.<fqdn>/api/v1/catalog` route. Mirrors `bp-catalyst-platform`'s `services.catalog.enabled`. |
+
+## Operational notes
+
+- **Region selection**: the slot-13b HelmRelease is un-suspended only on the
+  secondary CP via the `SECONDARY_EDGE_SUSPEND` cloud-init var (the symmetric
+  inverse of `SECONDARY_HR_SUSPEND`). On the primary CP and on any single-region
+  prov the HR is suspended and this chart is inert.
+- **Failover semantics**: during a region-a kill the stubs have no healthy mesh
+  backend, so region-b returns `503 no-healthy-upstream` for the control-plane
+  hosts — but `catalyst-api` is region-a-pinned and down during the kill anyway
+  (the data-plane gateway VIP still fails over per #5246). Steady-state (both
+  regions up) is `200` from either envoy, which is the #5289 contract.
+- **No NodePort** (§854): routing is Gateway-API + ClusterMesh only.
+
+Canonical model: see [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §10.7
+(control-plane DR posture) and [`docs/DOD.md`](../../docs/DOD.md) §6.

--- a/platform/catalyst-edge-routes/blueprint.yaml
+++ b/platform/catalyst-edge-routes/blueprint.yaml
@@ -1,0 +1,79 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-catalyst-edge-routes
+  labels:
+    catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
+    catalyst.openova.io/tier: catalyst-cp
+spec:
+  version: 0.1.0  # lockstep with chart/Chart.yaml (#5289)
+  card:
+    title: Catalyst control-plane edge (region-b)
+    summary: |
+      Secondary-CP edge for a 2-region Sovereign. Renders ClusterMesh
+      global-Service stubs + api/console/marketplace HTTPRoutes that proxy to
+      region-a's single control-plane pods, so the #5246 both-region console
+      ELB stops 404-ing on region-b's cilium-gateway-console envoy (#5289).
+      Services + HTTPRoutes only — never a Deployment, StatefulSet, PVC, or Job.
+    family: networking
+    documentation: ./README.md
+  visibility: unlisted  # mandatory infra, installed by bootstrap-kit slot 13b on secondary CPs only
+  owner:
+    team: platform
+    contact: platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      ingress:
+        type: object
+        description: |
+          Console-Gateway parentRef + per-Sovereign control-plane hostnames
+          (api./console./marketplace.<fqdn>) + marketplace-host toggle. Supplied
+          by bootstrap-kit slot 13b from the same cloud-init vars slot 13 uses.
+      services:
+        type: object
+        description: catalog.enabled mirrors bp-catalyst-platform's catalog gate.
+  placementSchema:
+    modes: [singleton, active-passive]
+    default: singleton
+    defaultOnMultiRegion: active-passive
+    minRegions: 1
+    maxRegions: 2
+  manifests:
+    chart: ./chart
+  depends:
+    # Cilium ClusterMesh must be up (the global-Service merge is what makes the
+    # stubs resolve to region-a) and the gateway.networking.k8s.io CRDs must be
+    # registered before the HTTPRoutes/ReferenceGrant admit.
+    - blueprint: bp-cilium
+      version: ^1
+    - blueprint: bp-gateway-api
+      version: ^1
+  upgrades:
+    from: ["0.x"]
+  topology:
+    # This edge exists only on the secondary CP of a 2-region Sovereign; the
+    # bootstrap-kit slot-13b HR (SECONDARY_EDGE_SUSPEND) selects the region.
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: passive   # region-a serves routes from the umbrella; edge is dormant here
+            mgmt-B: active     # region-b runs the edge (proxy to region-a)
+      singleton:
+        placement:
+          tier: ''
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton  # single-region: edge HR is suspended (inert)

--- a/platform/catalyst-edge-routes/blueprint.yaml
+++ b/platform/catalyst-edge-routes/blueprint.yaml
@@ -17,7 +17,7 @@ spec:
       Services + HTTPRoutes only — never a Deployment, StatefulSet, PVC, or Job.
     family: networking
     documentation: ./README.md
-  visibility: unlisted  # mandatory infra, installed by bootstrap-kit slot 13b on secondary CPs only
+  visibility: unlisted  # mandatory infra, installed by bootstrap-kit slot 13e on secondary CPs only
   owner:
     team: platform
     contact: platform@openova.io
@@ -29,7 +29,7 @@ spec:
         description: |
           Console-Gateway parentRef + per-Sovereign control-plane hostnames
           (api./console./marketplace.<fqdn>) + marketplace-host toggle. Supplied
-          by bootstrap-kit slot 13b from the same cloud-init vars slot 13 uses.
+          by bootstrap-kit slot 13e from the same cloud-init vars slot 13 uses.
       services:
         type: object
         description: catalog.enabled mirrors bp-catalyst-platform's catalog gate.
@@ -53,7 +53,7 @@ spec:
     from: ["0.x"]
   topology:
     # This edge exists only on the secondary CP of a 2-region Sovereign; the
-    # bootstrap-kit slot-13b HR (SECONDARY_EDGE_SUSPEND) selects the region.
+    # bootstrap-kit slot-13e HR (SECONDARY_EDGE_SUSPEND) selects the region.
     supported:
       - active-passive
       - singleton
@@ -63,17 +63,27 @@ spec:
     perTopology:
       active-passive:
         replication:
+          # Stateless routing proxy — no runtime data. Manifests are the only
+          # thing that "replicates", and they arrive via the GitOps loop.
           backend: flux-git
           mode: async
+        switchover:
+          # No data failover: on a region-a kill the ClusterMesh global-Service
+          # loses its only endpoints and the edge returns 503 (fail-fast);
+          # routes resume automatically when region-a recovers. Nothing to
+          # promote, so there is no switchover mechanism.
+          mechanism: none
+          rtoSeconds: 0
+          rpoSeconds: 0
         placement:
-          tier: ''
-          clusters: [mgmt-A, mgmt-B]
+          tier: rtz
+          clusters: [rtz-A, rtz-B]
           roles:
-            mgmt-A: passive   # region-a serves routes from the umbrella; edge is dormant here
-            mgmt-B: active     # region-b runs the edge (proxy to region-a)
+            rtz-A: passive   # region-a serves routes from the umbrella; edge is dormant here
+            rtz-B: active     # region-b runs the edge (proxy to region-a)
       singleton:
         placement:
-          tier: ''
-          clusters: [mgmt-A]
+          tier: rtz
+          clusters: [rtz-A]
           roles:
-            mgmt-A: singleton  # single-region: edge HR is suspended (inert)
+            rtz-A: singleton  # single-region: edge HR is suspended (inert)

--- a/platform/catalyst-edge-routes/chart/Chart.yaml
+++ b/platform/catalyst-edge-routes/chart/Chart.yaml
@@ -1,0 +1,63 @@
+apiVersion: v2
+name: bp-catalyst-edge-routes
+# 0.1.0 (#5289, 2026-07-20): region-b (secondary-CP) control-plane EDGE.
+#   On a 2-region Sovereign the Catalyst control plane is a single-writer
+#   singleton pinned to region-a (G2 #2574 suspends bp-catalyst-platform on
+#   every secondary CP; the api PVC is a zone-scoped RWO EVS volume — a
+#   second catalyst-api would multi-attach + split-brain, #5267). But the
+#   #5246 both-region console ELB targets BOTH regions' cilium-envoy pods,
+#   so ~half of api./console./marketplace. requests land on region-b's
+#   envoy, which — with the umbrella HR suspended — serves NO control-plane
+#   HTTPRoute and returns 404 (the steady-state 200↔404 flap, #5289).
+#
+#   This chart is the SECONDARY (region-b) half of the fix. Installed ONLY
+#   on secondary CPs (bootstrap-kit slot 13b, un-suspended via the
+#   SECONDARY_EDGE_SUSPEND cloud-init var), it renders — into catalyst-system
+#   and org-services — ONLY Services + HTTPRoutes (NO Deployments, NO
+#   StatefulSets, NO PVCs, NO Jobs):
+#     - global-Service stubs (service.cilium.io/global + /shared) named
+#       identically to region-a's control-plane Services (catalyst-api,
+#       catalyst-ui, catalyst-catalog, org-services/{gateway,admin,
+#       marketplace}). They carry ZERO local backends on region-b, so Cilium
+#       ClusterMesh merges them with region-a's same-named global Services and
+#       every dial crosses the mesh to region-a's singleton pods. This is the
+#       exact idiom bp-cnpg-pair / bp-openbao use for cross-region delivery.
+#     - the api./console./marketplace. HTTPRoutes, byte-for-byte mirrors of
+#       products/catalyst/chart/templates/{httproute,services/catalog/
+#       httproute,org-services/marketplace-routes}.yaml, parented onto the
+#       same cilium-gateway-console listener, backendRef'd at the stubs above.
+#
+#   Result: region-b's envoy now SERVES those hosts (proxying to region-a)
+#   instead of 404-ing → the flap ends, both regions up. The region-a
+#   half (the global annotations on the real Services) ships in
+#   bp-catalyst-platform 1.4.1190 gated on multiRegion.enabled. VALIDATES on
+#   the next fresh 2-region prov (hw281). Refs #5289.
+version: 0.1.0
+description: |
+  Region-b (secondary control-plane) edge for a 2-region Catalyst Sovereign.
+  Renders ClusterMesh global-Service stubs + api/console/marketplace
+  HTTPRoutes that proxy to region-a's single control-plane pods, so the
+  #5246 both-region console ELB stops 404-ing on region-b's envoy (#5289).
+  Services + HTTPRoutes only — never a Deployment, StatefulSet, PVC, or Job.
+type: application
+keywords: [catalyst, blueprint, multi-region, clustermesh, gateway-api, edge]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Annotations:
+#
+# - catalyst.openova.io/no-upstream: "true"
+#   Hollow-chart guard opt-out (Blueprint-Release workflow / issue #181):
+#   this chart legitimately ships only Catalyst-authored Services +
+#   gateway.networking.k8s.io HTTPRoutes/ReferenceGrant. It bundles NO
+#   upstream Helm subchart. Same shape as bp-network-policies / bp-continuum.
+#
+# - catalyst.openova.io/smoke-render-mode: default-off
+#   A default `helm template` (no hostnames, gateway/marketplace disabled)
+#   renders nothing — every resource is gated on the per-Sovereign hostnames
+#   + gateway parentRef supplied by bootstrap-kit slot 13b. The chart is a
+#   pure edge overlay; an empty default render is by design (GUARD 2).
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/smoke-render-mode: default-off

--- a/platform/catalyst-edge-routes/chart/templates/httproute.yaml
+++ b/platform/catalyst-edge-routes/chart/templates/httproute.yaml
@@ -1,0 +1,141 @@
+{{- /*
+Region-b control-plane HTTPRoutes (#5289).
+
+Byte-for-byte mirrors of the region-a routes in
+products/catalyst/chart/templates/httproute.yaml (catalyst-ui console-host +
+catalyst-api api-host) and templates/services/catalog/httproute.yaml
+(catalyst-catalog api-host /api/v1/catalog) — SAME hostnames, SAME path
+rules, SAME parentRef (the cilium-gateway-console listener region-b already
+advertises). The only difference is that backendRefs resolve to the local
+ClusterMesh global-Service stubs (services.yaml), which carry zero local
+backends on region-b and therefore proxy to region-a's singleton pods.
+
+Without these routes, region-b's cilium-gateway-console envoy — which the
+#5246 both-region console ELB targets — terminates the api./console. TLS and
+then has no matching route → 404 (~half of all requests, the #5289 flap).
+
+Gating identical to services.yaml: console Gateway enabled + both hostnames
+present. Default render is empty (smoke-render-mode:default-off).
+*/ -}}
+{{- if and .Values.ingress .Values.ingress.gateway .Values.ingress.gateway.enabled -}}
+{{- $consoleHost := (((.Values.ingress.hosts).console).host) }}
+{{- $apiHost := (((.Values.ingress.hosts).api).host) }}
+{{- if and $consoleHost $apiHost }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: catalyst-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: catalyst-ui
+spec:
+  parentRefs:
+    - name: {{ .Values.ingress.gateway.parentRef.name | default "cilium-gateway" | quote }}
+      namespace: {{ .Values.ingress.gateway.parentRef.namespace | default "kube-system" | quote }}
+      {{- with .Values.ingress.gateway.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    - {{ $consoleHost | quote }}
+  rules:
+    # /readyz + /healthz on the console hostname → catalyst-api (mirror of the
+    # region-a rule; without it the SPA catch-all shadows the probes).
+    - matches:
+        - path:
+            type: Exact
+            value: "/readyz"
+        - path:
+            type: Exact
+            value: "/healthz"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
+    # /auth/handover Exact → catalyst-api (Issue #879 Bug 5: MUST be Exact so
+    # /auth/callback and other client-side OIDC routes fall through to the SPA).
+    - matches:
+        - path:
+            type: Exact
+            value: "/auth/handover"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api/"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
+    # G117.2 #2741 — /catalyst/v1/* on the console hostname → catalyst-api.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/catalyst/"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
+    # Default — catalyst-ui (the React shell).
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      backendRefs:
+        - name: catalyst-ui
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: catalyst-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: catalyst-api
+spec:
+  parentRefs:
+    - name: {{ .Values.ingress.gateway.parentRef.name | default "cilium-gateway" | quote }}
+      namespace: {{ .Values.ingress.gateway.parentRef.namespace | default "kube-system" | quote }}
+      {{- with .Values.ingress.gateway.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    - {{ $apiHost | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
+{{- if .Values.services.catalog.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: catalyst-catalog
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: catalyst-catalog
+spec:
+  parentRefs:
+    - name: {{ .Values.ingress.gateway.parentRef.name | default "cilium-gateway" | quote }}
+      namespace: {{ .Values.ingress.gateway.parentRef.namespace | default "kube-system" | quote }}
+      {{- with .Values.ingress.gateway.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    - {{ $apiHost | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api/v1/catalog"
+      backendRefs:
+        - name: catalyst-catalog
+          port: 8080
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/catalyst-edge-routes/chart/templates/marketplace.yaml
+++ b/platform/catalyst-edge-routes/chart/templates/marketplace.yaml
@@ -1,0 +1,169 @@
+{{- /*
+Region-b marketplace-host edge (#5289).
+
+The marketplace.<fqdn> host on the #5246 both-region console ELB also lands
+~half its requests on region-b's envoy. Region-a serves it from the
+Organization BSS stack in the `org-services` namespace (gateway / admin /
+marketplace Pods), which — like the rest of the umbrella — does not run on a
+secondary CP. So region-b needs the same ClusterMesh global-Service stubs +
+the marketplace HTTPRoute (a byte mirror of
+products/catalyst/chart/templates/org-services/marketplace-routes.yaml, the
+platform-host route: /api/ → gateway, /back-office/ → admin, / → marketplace)
++ the cross-namespace ReferenceGrant.
+
+Rendered only when the marketplace host is served (ingress.marketplace.enabled
++ the marketplace hostname supplied by slot 13b). Per-tenant `<slug>.<fqdn>`
+routes are intentionally NOT mirrored here — they resolve to per-Org consoles
+that region-a's runtime organization-controller writes, and tenantSlugs
+defaults empty; the flap this fixes is the platform control-plane hosts.
+*/ -}}
+{{- if and .Values.ingress .Values.ingress.gateway .Values.ingress.gateway.enabled
+          .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- $marketplaceHost := (((.Values.ingress.hosts).marketplace).host) }}
+{{- if $marketplaceHost }}
+{{- $gwName := .Values.ingress.gateway.parentRef.name | default "cilium-gateway" }}
+{{- $gwNs := .Values.ingress.gateway.parentRef.namespace | default "kube-system" }}
+{{- $gwSection := .Values.ingress.gateway.parentRef.sectionName }}
+# org-services namespace — created by the umbrella chart on region-a, absent
+# on a suspended secondary CP, so the edge creates it (idempotent; keep policy
+# so an edge uninstall never cascades a live Organization workload elsewhere).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: org-services
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: catalyst-platform
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+  annotations:
+    helm.sh/resource-policy: keep
+    catalyst.openova.io/created-by: bp-catalyst-edge-routes
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: org-services
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: org-gateway
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: org-gateway
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: admin
+  namespace: org-services
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: org-admin
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: org-admin
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: marketplace
+  namespace: org-services
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: org-marketplace
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: org-marketplace
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+# Authorises the marketplace HTTPRoute (in {{ .Release.Namespace }}) to
+# cross-namespace backendRef the org-services stubs above — same grant shape
+# as products/catalyst/chart/templates/org-services/marketplace-reference-grant.yaml.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: marketplace-routes-to-org
+  namespace: org-services
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: marketplace-reference-grant
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: {{ .Release.Namespace }}
+  to:
+    - group: ""
+      kind: Service
+      name: marketplace
+    - group: ""
+      kind: Service
+      name: admin
+    - group: ""
+      kind: Service
+      name: gateway
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: marketplace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: marketplace
+spec:
+  parentRefs:
+    - name: {{ $gwName | quote }}
+      namespace: {{ $gwNs | quote }}
+      {{- with $gwSection }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    - {{ $marketplaceHost | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api/"
+      backendRefs:
+        - name: gateway
+          namespace: org-services
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/back-office/"
+      backendRefs:
+        - name: admin
+          namespace: org-services
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      backendRefs:
+        - name: marketplace
+          namespace: org-services
+          port: 8080
+{{- end }}
+{{- end }}

--- a/platform/catalyst-edge-routes/chart/templates/services.yaml
+++ b/platform/catalyst-edge-routes/chart/templates/services.yaml
@@ -1,0 +1,92 @@
+{{- /*
+Region-b ClusterMesh global-Service STUBS for the control plane (#5289).
+
+Each Service below is named + namespaced IDENTICALLY to the real region-a
+control-plane Service that bp-catalyst-platform 1.4.1190 annotates with
+`service.cilium.io/global: "true"` (gated on multiRegion.enabled). Cilium
+ClusterMesh merges two same-name+namespace global Services into one; on
+region-b these stubs select ZERO local Pods (there is no catalyst-api /
+catalyst-ui / catalyst-catalog Deployment on a secondary CP — the umbrella HR
+is suspended, G2 #2574), so every dial falls through the mesh to region-a's
+singleton. This is the exact idiom platform/openbao/templates/
+cross-region-mesh-service.yaml + platform/cnpg-pair use.
+
+NO Deployment, StatefulSet, or PVC is rendered — the region-a pods stay the
+sole writers of the RWO-EVS api store (#5267). The HTTPRoutes in
+httproute.yaml + marketplace.yaml backendRef these stubs.
+
+Gating: only when the console Gateway is enabled AND both the console + api
+hostnames are supplied by the slot-13b overlay. A default `helm template`
+renders nothing (smoke-render-mode:default-off).
+*/ -}}
+{{- if and .Values.ingress .Values.ingress.gateway .Values.ingress.gateway.enabled -}}
+{{- $consoleHost := (((.Values.ingress.hosts).console).host) }}
+{{- $apiHost := (((.Values.ingress.hosts).api).host) }}
+{{- if and $consoleHost $apiHost }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalyst-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: catalyst-api
+  annotations:
+    # Same annotation set as the region-a Service so the mesh merges them.
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  type: ClusterIP
+  selector:
+    # Zero local matches on region-b (no catalyst-api Pod here) → mesh routes
+    # to region-a's endpoints. Port MUST match region-a's (8080).
+    app.kubernetes.io/name: catalyst-api
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalyst-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: catalyst-ui
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: catalyst-ui
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+{{- if .Values.services.catalog.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalyst-catalog
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-edge-routes
+    catalyst.openova.io/component: catalyst-catalog
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: catalyst-catalog
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/catalyst-edge-routes/chart/values.yaml
+++ b/platform/catalyst-edge-routes/chart/values.yaml
@@ -1,7 +1,7 @@
 # bp-catalyst-edge-routes — region-b control-plane edge (#5289).
 #
-# All values are supplied per-Sovereign by bootstrap-kit slot 13b
-# (clusters/_template/bootstrap-kit/13b-catalyst-secondary-edge-routes.yaml),
+# All values are supplied per-Sovereign by bootstrap-kit slot 13e
+# (clusters/_template/bootstrap-kit/13e-bp-catalyst-secondary-edge-routes.yaml),
 # which threads the SAME hostnames + gateway parentRef that slot 13 hands the
 # umbrella bp-catalyst-platform chart. Defaults below leave every host empty
 # and both gateways off, so a bare `helm template` renders NOTHING (the
@@ -10,11 +10,11 @@
 
 ingress:
   gateway:
-    # Master gate: no HTTPRoutes/Services render unless true (slot 13b sets it).
+    # Master gate: no HTTPRoutes/Services render unless true (slot 13e sets it).
     enabled: false
     parentRef:
       # The dedicated console Gateway that fronts api./console./marketplace.
-      # (#4053 isolation). Slot 13b passes ${SOVEREIGN_CONSOLE_GATEWAY:-
+      # (#4053 isolation). Slot 13e passes ${SOVEREIGN_CONSOLE_GATEWAY:-
       # cilium-gateway-console}; on a single-EIP validation prov it resolves
       # to the shared cilium-gateway. Region-b advertises the same wildcard
       # listener, which is exactly why its envoy needs these routes.
@@ -22,15 +22,17 @@ ingress:
       namespace: kube-system
       # sectionName is optional — omitted by default (attach to all listeners).
       sectionName: ""
-    # The per-Sovereign control-plane hostnames (api./console./marketplace.
-    # <fqdn>). Empty defaults → no route renders.
-    hosts:
-      console:
-        host: ""
-      api:
-        host: ""
-      marketplace:
-        host: ""
+  # The per-Sovereign control-plane hostnames (api./console./marketplace.<fqdn>).
+  # Read by the templates as `.Values.ingress.hosts.*` — the SAME path slot 13e's
+  # HR fills (a sibling of `gateway`, NOT nested under it). Empty defaults → no
+  # route renders (smoke-render-mode:default-off).
+  hosts:
+    console:
+      host: ""
+    api:
+      host: ""
+    marketplace:
+      host: ""
   # Marketplace-host proxy (marketplace.<fqdn> → org-services gateway/admin/
   # marketplace over the mesh). Default OFF; slot 13b mirrors slot 13's
   # ${MARKETPLACE_ENABLED}. When off, the org-services stubs + marketplace

--- a/platform/catalyst-edge-routes/chart/values.yaml
+++ b/platform/catalyst-edge-routes/chart/values.yaml
@@ -1,0 +1,46 @@
+# bp-catalyst-edge-routes — region-b control-plane edge (#5289).
+#
+# All values are supplied per-Sovereign by bootstrap-kit slot 13b
+# (clusters/_template/bootstrap-kit/13b-catalyst-secondary-edge-routes.yaml),
+# which threads the SAME hostnames + gateway parentRef that slot 13 hands the
+# umbrella bp-catalyst-platform chart. Defaults below leave every host empty
+# and both gateways off, so a bare `helm template` renders NOTHING (the
+# smoke-render-mode:default-off contract) — the chart is a no-op until the
+# per-Sovereign overlay fills in the hosts.
+
+ingress:
+  gateway:
+    # Master gate: no HTTPRoutes/Services render unless true (slot 13b sets it).
+    enabled: false
+    parentRef:
+      # The dedicated console Gateway that fronts api./console./marketplace.
+      # (#4053 isolation). Slot 13b passes ${SOVEREIGN_CONSOLE_GATEWAY:-
+      # cilium-gateway-console}; on a single-EIP validation prov it resolves
+      # to the shared cilium-gateway. Region-b advertises the same wildcard
+      # listener, which is exactly why its envoy needs these routes.
+      name: cilium-gateway-console
+      namespace: kube-system
+      # sectionName is optional — omitted by default (attach to all listeners).
+      sectionName: ""
+    # The per-Sovereign control-plane hostnames (api./console./marketplace.
+    # <fqdn>). Empty defaults → no route renders.
+    hosts:
+      console:
+        host: ""
+      api:
+        host: ""
+      marketplace:
+        host: ""
+  # Marketplace-host proxy (marketplace.<fqdn> → org-services gateway/admin/
+  # marketplace over the mesh). Default OFF; slot 13b mirrors slot 13's
+  # ${MARKETPLACE_ENABLED}. When off, the org-services stubs + marketplace
+  # HTTPRoute + ReferenceGrant are not rendered.
+  marketplace:
+    enabled: false
+
+services:
+  catalog:
+    # catalyst-catalog global stub + api.<fqdn> /api/v1/catalog route.
+    # Mirrors bp-catalyst-platform's services.catalog.enabled so the edge
+    # renders the catalog proxy exactly when region-a serves it.
+    enabled: false

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,26 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1190 — #5289 (2-region api./console./marketplace. steady-state 200↔404
+#   flap): the PRIMARY (region-a) half of the ClusterMesh global-Service
+#   proxy fix. When the new `multiRegion.enabled` value is true, the
+#   control-plane backend Services — catalyst-api (api-service.yaml),
+#   catalyst-ui (ui-service.yaml), catalyst-catalog (services/catalog/
+#   service.yaml), and the Organization marketplace-host backends
+#   org-services/{gateway,admin,marketplace} — carry the Cilium ClusterMesh
+#   annotations `service.cilium.io/global: "true"` + `.../shared: "true"`, so
+#   region-b's new bp-catalyst-edge-routes stub Services (same name+namespace,
+#   zero local backends) resolve to THESE single region-a pods over the mesh.
+#   This lets region-b SERVE the api/console/catalog/marketplace HTTPRoutes
+#   (whose envoy is in the #5246 both-region console-ELB pool) instead of
+#   404-ing, WITHOUT running a second catalyst-api/console Deployment or
+#   binding the RWO-EVS api PVC (that would multi-attach + split-brain, #5267).
+#   `multiRegion.enabled` defaults false → single-region + primary-region
+#   render byte-identical to 1.4.1189 (proven via `helm template` diff). The
+#   region-b edge layer ships as the standalone bp-catalyst-edge-routes chart
+#   at bootstrap-kit slot 13b; slot 13 sets multiRegion.enabled from
+#   ${SOVEREIGN_ENABLE_HOT_STANDBY}. VALIDATES on the next fresh 2-region
+#   prov (hw281), not on live hw280 (region-b HR cannot be un-suspended live
+#   safely). Refs #5289.
 # 1.4.1180 — #5267 (Refs #5267 #5246 #4275, hw277 G12 region-kill: console
 #   404 during region-a outage): NO template change — adds the
 #   tests/api-single-writer-dr-contract.sh CI gate that makes the
@@ -3529,7 +3550,7 @@ name: bp-catalyst-platform
 #   while warm SSO works (hw278: harbor/openbao/guacamole/pdns-admin/hubble). Same
 #   self-heal idiom already used for handover-jwt-public + provisioning-github-token.
 #   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync gate).
-version: 1.4.1189
+version: 1.4.1190
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/api-service.yaml
+++ b/products/catalyst/chart/templates/api-service.yaml
@@ -2,6 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: catalyst-api
+  {{- if (((.Values.multiRegion).enabled)) }}
+  # #5289 multi-region: publish catalyst-api as a Cilium ClusterMesh global
+  # Service so region-b's bp-catalyst-edge-routes stub (same name+namespace,
+  # zero local backends) resolves to THIS single region-a pod over the mesh.
+  # Gated on multiRegion.enabled → single-region render is byte-unchanged.
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+  {{- end }}
 spec:
   selector:
     app.kubernetes.io/name: catalyst-api

--- a/products/catalyst/chart/templates/org-services/admin.yaml
+++ b/products/catalyst/chart/templates/org-services/admin.yaml
@@ -54,6 +54,14 @@ kind: Service
 metadata:
   name: admin
   namespace: org-services
+  {{- if (((.Values.multiRegion).enabled)) }}
+  # #5289 multi-region: publish the Organization back-office (BSS admin) as a
+  # Cilium ClusterMesh global Service so region-b's edge stub (marketplace.
+  # <fqdn> /back-office/*) resolves to this region-a pod. Gated → byte-unchanged.
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+  {{- end }}
 spec:
   selector:
     app: org-admin

--- a/products/catalyst/chart/templates/org-services/gateway.yaml
+++ b/products/catalyst/chart/templates/org-services/gateway.yaml
@@ -134,6 +134,14 @@ kind: Service
 metadata:
   name: gateway
   namespace: org-services
+  {{- if (((.Values.multiRegion).enabled)) }}
+  # #5289 multi-region: publish the Organization BSS gateway as a Cilium
+  # ClusterMesh global Service so region-b's edge stub (marketplace.<fqdn>
+  # /api/*) resolves to this region-a pod. Gated → single-region byte-unchanged.
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+  {{- end }}
 spec:
   selector:
     app: org-gateway

--- a/products/catalyst/chart/templates/org-services/marketplace.yaml
+++ b/products/catalyst/chart/templates/org-services/marketplace.yaml
@@ -60,6 +60,14 @@ kind: Service
 metadata:
   name: marketplace
   namespace: org-services
+  {{- if (((.Values.multiRegion).enabled)) }}
+  # #5289 multi-region: publish the marketplace storefront as a Cilium
+  # ClusterMesh global Service so region-b's edge stub (marketplace.<fqdn> /)
+  # resolves to this region-a pod. Gated → single-region byte-unchanged.
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+  {{- end }}
 spec:
   selector:
     app: org-marketplace

--- a/products/catalyst/chart/templates/services/catalog/service.yaml
+++ b/products/catalyst/chart/templates/services/catalog/service.yaml
@@ -6,6 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "catalog.labels" (dict "root" .) | nindent 4 }}
+  {{- if (((.Values.multiRegion).enabled)) }}
+  # #5289 multi-region: publish catalyst-catalog as a Cilium ClusterMesh
+  # global Service (api.<fqdn> /api/v1/catalog) so region-b's edge stub
+  # resolves to this region-a pod. Gated → single-region byte-unchanged.
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/products/catalyst/chart/templates/ui-service.yaml
+++ b/products/catalyst/chart/templates/ui-service.yaml
@@ -2,6 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: catalyst-ui
+  {{- if (((.Values.multiRegion).enabled)) }}
+  # #5289 multi-region: publish catalyst-ui as a Cilium ClusterMesh global
+  # Service so region-b's bp-catalyst-edge-routes stub resolves to this
+  # region-a pod over the mesh. Gated → single-region render byte-unchanged.
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+  {{- end }}
 spec:
   selector:
     app.kubernetes.io/name: catalyst-ui

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -64,6 +64,36 @@ global:
   # unchanged (NO-REGRESS).
   cloudProvider: ""
 
+# ─── Multi-region control-plane edge (issue #5289) ─────────────────────
+# On a 2-region Sovereign the control plane (catalyst-api / catalyst-ui /
+# catalyst-catalog + the Organization marketplace stack) is a single-writer
+# singleton pinned to region-a: G2 (#2574) suspends bp-catalyst-platform on
+# every secondary CP, and the api PVC is a zone-scoped RWO EVS volume (#5267)
+# — a second catalyst-api would multi-attach and split-brain. But the #5246
+# both-region console ELB deliberately targets BOTH regions' cilium-envoy
+# pods for region-kill failover, so ~half of api./console./marketplace.
+# requests land on region-b's envoy — which, with the umbrella HR suspended,
+# serves NO control-plane HTTPRoute and returns 404. That is the steady-state
+# 200↔404 flap #5289 root-caused.
+#
+# The fix makes region-b SERVE those hosts by proxying to region-a's single
+# pods over Cilium ClusterMesh global Services (the exact idiom bp-cnpg-pair /
+# bp-openbao use for cross-region delivery — a same name+namespace Service
+# carrying the two annotations below on BOTH sides makes the mesh merge them;
+# region-b has zero local backends so every dial crosses to region-a). No
+# second catalyst-api Deployment, no PVC — region-b renders only Services +
+# routes via the dedicated bp-catalyst-edge-routes chart (bootstrap-kit slot
+# 13b).
+#
+# This block is the PRIMARY (region-a) half: when `multiRegion.enabled=true`
+# the control-plane backend Services in this umbrella chart carry the global
+# ClusterMesh annotations so region-b's stubs can consume them. Default OFF —
+# single-region and pre-#5289 provs render byte-identically to today. The
+# bootstrap-kit slot 13 sets this from ${SOVEREIGN_ENABLE_HOT_STANDBY} (true
+# only on a 2-region / active-hot-standby Sovereign).
+multiRegion:
+  enabled: false
+
 # ─── Sovereign-side defaults (issue #901) ──────────────────────────────
 # Knobs that exclusively affect the franchised-Sovereign install path
 # and have no equivalent on Catalyst-Zero (contabo-mkt). Per-Sovereign

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -787,6 +787,17 @@ slots:
       - bp-catalyst-platform
       - bp-keycloak
     wave: present
+  - slot: "13e"
+    name: bp-catalyst-secondary-edge
+    # #5289: ClusterMesh global-Service edge routes, installed ONLY on the
+    # secondary CP (SECONDARY_EDGE_SUSPEND). Renders api/console/marketplace
+    # HTTPRoutes that proxy to region-a's single control-plane pods, killing
+    # the region-b cilium-gateway-console 200<->404 flap behind the #5246
+    # both-region ELB. Deliberately does NOT depend on bp-catalyst-platform
+    # (suspended on the secondary CP → a dep would deadlock this HR forever);
+    # it only needs the gateway.networking.k8s.io CRDs (bp-gateway-api).
+    depends_on: [bp-gateway-api]
+    wave: present
 
   # ---- Slot 62 — bp-continuum DR orchestrator (Pillar-3 unblock).
   # Issue #2065 (TBD-V14, 2026-05-20). Reconciles Continuum.dr.openova.io/v1


### PR DESCRIPTION
## What this fixes — `Refs #5289`

On a **2-region** Sovereign, `api.` / `console.` / `marketplace.<fqdn>` flap
**200↔404 in normal operation** (both regions healthy). Root cause (per the
#5289 RCA): the #5246 both-region **console ELB** targets BOTH regions'
`cilium-envoy` pods, but the umbrella `bp-catalyst-platform` HR is **suspended
on the secondary CP** (G2 #2574 — `catalyst-api` is a single-writer singleton
on a zone-scoped RWO EVS PVC), so region-b's envoy terminates the TLS and then
has **no control-plane HTTPRoute** → ~half of all requests 404.

## Design — ClusterMesh global-Service proxy (in-repo precedent)

Region-b **serves** those hosts by **proxying** to region-a's single pods over
Cilium ClusterMesh **global Services** — the exact idiom `bp-cnpg-pair` /
`bp-openbao` use for cross-region delivery. **No second `catalyst-api`/console
Deployment, no PVC** → region-a stays the sole writer (the #5267 single-writer
contract is untouched).

**Primary (region-a)** — `bp-catalyst-platform` `1.4.1189 → 1.4.1190`:
- new `multiRegion.enabled` value (**default false**) gates the annotations
  `service.cilium.io/global: "true"` + `.../shared: "true"` on the
  control-plane backend Services — `catalyst-api`, `catalyst-ui`,
  `catalyst-catalog`, and the marketplace-host backends
  `org-services/{gateway,admin,marketplace}`.
- bootstrap-kit slot 13 sets it from `${SOVEREIGN_ENABLE_HOT_STANDBY}`.

**Secondary (region-b)** — new `bp-catalyst-edge-routes` chart (`0.1.0`) at
**bootstrap-kit slot 13e** (`13b`–`13d` are taken):
- renders **only** same-name+namespace **global-Service stubs** (zero local
  backends → mesh resolves to region-a) + the `api`/`console`/`catalog`/
  `marketplace` HTTPRoutes (byte mirrors of the primary routes, parented onto
  `cilium-gateway-console`).
- un-suspended **only on secondary CPs** via the new `SECONDARY_EDGE_SUSPEND`
  cloud-init var (the symmetric inverse of `SECONDARY_HR_SUSPEND`); suspended +
  inert on the primary CP and on every single-region prov.
- registered in `kustomization.yaml` + `placement.yaml` (host, `catalyst-system`
  + `org-services`).

## Constraints honored
- **§854**: no NodePort anywhere — Gateway-API + ClusterMesh only.
- region-b renders **zero** Deployments/StatefulSets/PVCs/Jobs (proven below).
- single-region + primary render **byte-identical** to `1.4.1189` when the flag
  is off (proven below).

## `helm template` proof

**(i) `multiRegion.enabled=false` → 6 control-plane Services byte-identical to `origin/main`:**
```
IDENTICAL: templates/api-service.yaml
IDENTICAL: templates/ui-service.yaml
IDENTICAL: templates/services/catalog/service.yaml
IDENTICAL: templates/org-services/gateway.yaml
IDENTICAL: templates/org-services/admin.yaml
IDENTICAL: templates/org-services/marketplace.yaml
```
Chart default render: `service.cilium.io/global` count = **0**.
`multiRegion.enabled=true`: each of the 6 Services → `global=1 shared=1`.

**(ii) secondary-edge render — routes + global stubs, ZERO workloads:**
```
kinds:  4 HTTPRoute · 6 Service · 1 ReferenceGrant · 1 Namespace
Deployment=0 StatefulSet=0 PersistentVolumeClaim=0 Job=0 CronJob=0 DaemonSet=0 Pod=0
global=6 shared=6
routes → cilium-gateway-console/kube-system; hosts console./api./marketplace.<fqdn>
```
Default render (no overlay): **0 resources** (`smoke-render-mode: default-off`).

## Gates run locally (green)
- `render-slot-placement.py check` → PASS (67 slots)
- `check-bootstrap-kit-pin-sync.sh` → `bp-catalyst-edge-routes 0.1.0=0.1.0`, `bp-catalyst-platform 1.4.1190=1.4.1190`
- `check-chart-annotations.sh` → `bp-catalyst-edge-routes` passes GUARD 1 (no-upstream) + GUARD 2 (default-off)
- `helm lint platform/catalyst-edge-routes/chart` → 0 failed
- `api-single-writer-dr-contract.sh` (#5267) invariants untouched (api Deployment `replicas:1`/`Recreate`/RWO PVC + slot-13 `SECONDARY_HR_SUSPEND` gate all preserved)

## Validation
**VALIDATES on the next fresh 2-region prov (hw281)** — `for i in $(seq 30); do
curl https://api.<fqdn>/oidc/.well-known/openid-configuration; done` → 30/30 =
200 (zero 404), both regions up; same for `console.` and `marketplace.`. **Not**
exercised on live hw280 — region-b's HR cannot be un-suspended live safely.

## Note for ratification (outage signature)
During a region-a kill, region-b's stubs have no healthy mesh backend and return
**503 no-healthy-upstream** for the control-plane hosts (vs the #5267 `404`-with-
envoy signature). `catalyst-api` is region-a-pinned and down during the kill
either way, and the data-plane gateway VIP still fails over per #5246. Left the
CI-gated #5267 §6 contract doc/test **unchanged** (this PR does not touch the
invariants it guards) — flagging here so the outage-signature note in
`docs/DOD.md` §6 / `docs/ARCHITECTURE.md` §10.7 can be added if desired.

## Files
- `products/catalyst/chart/values.yaml` — new `multiRegion.enabled` (default false)
- `products/catalyst/chart/templates/{api-service,ui-service}.yaml`, `services/catalog/service.yaml`, `org-services/{gateway,admin,marketplace}.yaml` — gated global annotations
- `products/catalyst/chart/Chart.yaml` — `1.4.1189 → 1.4.1190` + changelog
- `platform/catalyst-edge-routes/` — new chart (`blueprint.yaml`, `chart/{Chart,values}.yaml`, `chart/templates/{services,httproute,marketplace}.yaml`, `README.md`)
- `clusters/_template/bootstrap-kit/13e-bp-catalyst-secondary-edge-routes.yaml` — new slot (HelmRepository + HelmRelease)
- `clusters/_template/bootstrap-kit/{kustomization,placement}.yaml` — register slot 13e
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — pin `1.4.1190` + `multiRegion.enabled` value
- `infra/providers/_shared/cloudinit-control-plane.tftpl` — emit `SECONDARY_EDGE_SUSPEND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
