### PR TITLE
fix(catalyst): unbreak mothership raw-kustomize (#5290 global-Service annotations unconditional)

### DIFF
--- a/products/catalyst/chart/templates/api-service.yaml
+++ b/products/catalyst/chart/templates/api-service.yaml
@@ -2,15 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: catalyst-api
-  {{- if (((.Values.multiRegion).enabled)) }}
   # #5289 multi-region: publish catalyst-api as a Cilium ClusterMesh global
   # Service so region-b's bp-catalyst-edge-routes stub (same name+namespace,
   # zero local backends) resolves to THIS single region-a pod over the mesh.
-  # Gated on multiRegion.enabled → single-region render is byte-unchanged.
+  # UNCONDITIONAL plain YAML — this file is ALSO consumed raw by the mothership
+  # catalyst-platform kustomization (path=.../chart/templates), which cannot
+  # parse Helm {{ }}. The annotation is an inert no-op without a clustermesh
+  # (single-region Sovereign / Catalyst-Zero mothership) and only takes effect
+  # where a mesh exists (2-region Sovereign) — so it is safe to always emit.
   annotations:
     service.cilium.io/global: "true"
     service.cilium.io/shared: "true"
-  {{- end }}
 spec:
   selector:
     app.kubernetes.io/name: catalyst-api

--- a/products/catalyst/chart/templates/ui-service.yaml
+++ b/products/catalyst/chart/templates/ui-service.yaml
@@ -2,14 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: catalyst-ui
-  {{- if (((.Values.multiRegion).enabled)) }}
   # #5289 multi-region: publish catalyst-ui as a Cilium ClusterMesh global
   # Service so region-b's bp-catalyst-edge-routes stub resolves to this
-  # region-a pod over the mesh. Gated → single-region render byte-unchanged.
+  # region-a pod over the mesh. UNCONDITIONAL plain YAML — this file is ALSO
+  # consumed raw by the mothership catalyst-platform kustomization, which cannot
+  # parse Helm {{ }}. The annotation is an inert no-op without a clustermesh
+  # (single-region / mothership) and only takes effect where a mesh exists.
   annotations:
     service.cilium.io/global: "true"
     service.cilium.io/shared: "true"
-  {{- end }}
 spec:
   selector:
     app.kubernetes.io/name: catalyst-ui


### PR DESCRIPTION
**P0 hotfix.** #5290 added Helm `{{- if }}` conditionals to `api-service.yaml` + `ui-service.yaml`, which are ALSO consumed raw by the mothership `catalyst-platform` Flux Kustomization (`path=./products/catalyst/chart/templates`). Kustomize can't parse `{{ }}` → `MalformedYAMLError line 5` → the kustomization wedged at the pre-#5290 revision, blocking the catalyst-api roll + all catalyst-platform reconciles on the mothership.

Fix: make the global-Service annotations unconditional plain YAML — inert no-op without a clustermesh (single-region / mothership), active on 2-region Sovereigns, so #5289 behavior is preserved and both consumers (Helm + raw-kustomize) parse cleanly.

Verified: `kubectl kustomize ./products/catalyst/chart/templates` succeeds (15 resources, both Services carry the annotation).

Refs #5289