### PR TITLE
ci(catalyst): guard mothership raw-kustomize build against bare Helm braces (prevent #5290 regression)

### DIFF
--- a/.github/workflows/mothership-kustomize-guard.yaml
+++ b/.github/workflows/mothership-kustomize-guard.yaml
@@ -1,0 +1,38 @@
+name: mothership-kustomize-guard
+# Regression guard (#5290 → #5292, 2026-07-20). The mothership `catalyst-platform`
+# Flux Kustomization raw-kustomize-builds `products/catalyst/chart/templates` via that
+# directory's kustomization.yaml `resources:` list. A bare Helm {{ }} directive in one
+# of those raw-consumed files makes `kustomize build` fail (MalformedYAMLError) → the
+# mothership kustomization wedges → the catalyst-api image roll stalls → fresh-prov
+# preflight 4b never clears → no prov can fire. This gate runs the exact build the
+# mothership runs, on any change to those templates, so the regression can't merge.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-mothership-kustomize-plain-yaml.sh'
+      - '.github/workflows/mothership-kustomize-guard.yaml'
+  pull_request:
+    paths:
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-mothership-kustomize-plain-yaml.sh'
+      - '.github/workflows/mothership-kustomize-guard.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: mothership raw-kustomize build must succeed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install kustomize
+        run: |
+          curl -sfL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/kustomize
+          kustomize version
+      - name: Guard — no bare Helm {{ }} in mothership-consumed templates (#5290/#5292)
+        run: bash scripts/check-mothership-kustomize-plain-yaml.sh

--- a/scripts/check-mothership-kustomize-plain-yaml.sh
+++ b/scripts/check-mothership-kustomize-plain-yaml.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# §-guard (regression #5290 → #5292, 2026-07-20): the mothership `catalyst-platform`
+# Flux Kustomization raw-kustomize-builds `products/catalyst/chart/templates` via that
+# directory's kustomization.yaml `resources:` list. A **bare** Helm `{{ }}` directive
+# (an unquoted structural `{{- if }}` / `{{- end }}` etc., not one inside a comment or
+# a quoted string) in a resources[] file makes `kustomize build` fail with
+# `MalformedYAMLError` → the mothership kustomization wedges at the last-good revision →
+# the catalyst-api image roll stalls → fresh-prov preflight 4b (DEPLOYED != PINNED)
+# never clears → NO prov can fire.
+#
+# Ground truth = the exact build the mothership runs. If it succeeds, the raw-consumed
+# templates are kustomize-parseable; if it fails, a resources[] file broke it.
+#
+# Fix when it fails: keep the offending template plain YAML, or move the Helm-templated
+# content to a separate plain `*-kustomize.yaml` variant (like ui-deployment-kustomize.yaml)
+# and leave the Helm file OUT of the resources[] list.
+set -euo pipefail
+DIR="products/catalyst/chart/templates"
+[ -f "$DIR/kustomization.yaml" ] || { echo "SKIP: $DIR/kustomization.yaml not found (run from repo root)"; exit 0; }
+BIN=""
+if command -v kustomize >/dev/null 2>&1; then BIN="kustomize build"; fi
+if command -v kubectl   >/dev/null 2>&1; then BIN="kubectl kustomize"; fi
+[ -n "$BIN" ] || { echo "SKIP: neither kustomize nor kubectl available"; exit 0; }
+if $BIN "$DIR" >/dev/null 2>/tmp/mk-kustomize.err; then
+  echo "PASS: mothership raw-kustomize build of $DIR succeeds — no resources[] template carries a bare Helm {{ }} that would wedge the mothership GitOps (#5290/#5292)."
+  exit 0
+fi
+echo "FAIL: '$BIN $DIR' errored — a resources[] template likely contains a bare Helm {{ }} directive kustomize cannot parse (regression class #5290/#5292):"
+sed 's/^/  /' /tmp/mk-kustomize.err | head -6
+echo "Fix: keep the mothership-consumed template plain YAML, or move Helm-templated content to a plain *-kustomize.yaml variant that is in resources[] while the Helm file is not."
+exit 1


### PR DESCRIPTION
Prevents recurrence of the #5290→#5292 regression that wedged the mothership GitOps + blocked all fresh provs today. The mothership `catalyst-platform` Flux Kustomization raw-kustomize-builds `products/catalyst/chart/templates` (its kustomization.yaml `resources[]`); a bare Helm `{{ }}` directive in one of those files fails `kustomize build` (MalformedYAMLError) → mothership wedges → catalyst-api roll stalls → preflight 4b never clears → no prov fires.

`scripts/check-mothership-kustomize-plain-yaml.sh` runs the exact build the mothership runs. Tested: PASS on current main; FAIL reproducing the line-5 MalformedYAMLError when a bare conditional is reintroduced; PASS on restore. Comment / quoted-string braces are correctly NOT flagged (the build is ground truth, not a naive grep).

Refs #5289