### PR TITLE
fix(cutover): raise step-03 harbor-prewarm deadline for the #5095 DIRECT-fallback push (0.1.148)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -964,7 +964,7 @@ spec:
       # missing one and FATALing with the full missing list otherwise (knob
       # helmReadinessProbe.pinPresenceGate). Contract Case 68 runs the
       # extractor against this very slot corpus at PR time.
-      version: 0.1.147
+      version: 0.1.148
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.147
+  version: 0.1.148
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,26 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.148 (#5298, Refs #5095 #3379 — step-03 harbor-prewarm DIRECT-fallback
+# deadline. hw281 (2026-07-20) stamped step-03 failed while it was STILL
+# settling (log "Phase A progress: 100/140 settled (still copying)"): the
+# 90m (5400s) stepTimeouts.harborPrewarmSeconds ceiling was sized (#3379) for
+# the FAST bastion-proxy fan-out path and predates the #5095 DIRECT-source
+# fallback. When the mothership proxy path is unreachable each image is pushed
+# straight from its canonical upstream (~0.75 min/image DIRECT); a full
+# 140-image census ≈ 105 min + the #5095 exponential-backoff spacing (~15 min
+# inside a transit flap) + one catalyst-api re-poll blows past 90m. Because the
+# SAME per-step value stamps BOTH the K8s Job activeDeadlineSeconds (03-harbor-
+# prewarm-job.yaml embedded PodSpec) AND catalyst-api's watch-context deadline
+# (cutover.go cutoverStepDeadline → createCutoverJob / watchJobToCompletion),
+# both expired at 90m: failedStep=harbor-prewarm, lastError="watch Job … context
+# deadline exceeded". Raised stepTimeouts.harborPrewarmSeconds 5400 → 9600 (160m)
+# so the worst-case DIRECT-fallback push finishes inside budget. No step count /
+# RBAC / other-step deadline change. The step stays event-driven (a fast proxy-
+# path run returns in minutes, never waiting out the larger ceiling) and
+# resumable (prewarm.skipIfAlreadyPresent #4994 skips already-mirrored tags on a
+# re-fire via a manifest-digest HEAD, so a re-run resumes rather than restarting
+# from 0). Same remediation shape as egressBlockTestSeconds (900→1200→3600→7200,
+# #4723/#5065) and the earlier harborPrewarmSeconds 1800→5400 (#3379).
 # 0.1.147 (#5237 round 2, Refs #5007 #5265 — PIN-AWARE PREWARM + step-06 FULL
 # pin-presence gate: the durable close of the catalog-latest-vs-flux-pinned
 # drift class (hw274, dep d51a69f885872a81). The 0.1.145 union-warm (below) is
@@ -2533,7 +2554,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.147
+version: 0.1.148
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -117,8 +117,9 @@ data:
           # ERROR, never on a stuck-but-alive connection. With no command
           # timeout the copy never returns, the worker never drains, the parent
           # `wait` blocks forever, and the whole Job sits "active" until the
-          # 5400s activeDeadlineSeconds kills it — then catalyst-api auto-re-runs
-          # the DeadlineExceeded step (cutover.go) and the next 90-min hang
+          # step's activeDeadlineSeconds (9600s post-#5298) kills it — then
+          # catalyst-api auto-re-runs the DeadlineExceeded step (cutover.go) and
+          # the next full-deadline hang
           # begins. Back-to-back deadline cycles = the "step-03 active for hours,
           # never completing" symptom seen live on hw171 (dep 3963e9267c10a90d)
           # right after #3927 unstuck step-02. `--command-timeout` bounds each
@@ -1074,8 +1075,8 @@ data:
                       # base*2^(n-2) before attempt n → 30,60,120,240,480s =
                       # 930s (≥15 min) of spacing across the default 6-attempt
                       # budget, so a short transit flap toward the mothership
-                      # cannot exhaust it. Comfortably inside the 5400s step
-                      # deadline; a flap-failure is fast (reset/refused), not a
+                      # cannot exhaust it. Comfortably inside the 9600s step
+                      # deadline (#5298); a flap-failure is fast (reset/refused), not a
                       # stall, so the #3944 --command-timeout stays the stall
                       # bound.
                       _bo="${PREWARM_PROXY_BACKOFF_BASE_SECONDS}"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -567,8 +567,8 @@ prewarm:
   # PRIVATE openova-io image over throttled egress yet collapses an infinite
   # hang into a bounded, retryable failure. Operators on extremely slow links
   # may raise it via overlay; it must stay comfortably below
-  # stepTimeouts.harborPrewarmSeconds (5400s) so at least 2-3 copies can run
-  # serially within one Job's deadline even in the worst case.
+  # stepTimeouts.harborPrewarmSeconds (9600s, #5298) so at least 2-3 copies can
+  # run serially within one Job's deadline even in the worst case.
   skopeoCommandTimeout: "1200s"
   # #4529 (Refs #3379): TLS verification on the skopeo copy DESTINATION — the
   # IN-CLUSTER Harbor reached as `registry.<sov-fqdn>` (HARBOR_PUBLIC_URL →
@@ -669,7 +669,7 @@ prewarm:
   # therefore get:
   #   (a) their OWN attempts budget with EXPONENTIAL backoff — base doubling
   #       (30+60+120+240+480 = 930s ≥ 15 min of inter-attempt spacing at the
-  #       defaults, comfortably inside the 5400s step deadline) so a short
+  #       defaults, comfortably inside the 9600s step deadline #5298) so a short
   #       transit flap is ridden out instead of FATALing the step; and
   #   (b) a DIRECT-SOURCE fallback: on a proxy-source copy failure the SAME
   #       image is retried from its canonical upstream (docker.io/... etc.,
@@ -1808,7 +1808,28 @@ stepTimeouts:
   # now stamps the Job/watch deadline from THIS per-step value (cutover.go
   # createCutoverJob / watchJobToCompletion) rather than the old global
   # 15m cap that silently bounded every long step.
-  harborPrewarmSeconds: 5400
+  #
+  # #5298 (Refs #5095 #3379) — DIRECT-fallback push blows the 90m ceiling
+  # (hw281, 2026-07-20). The 5400s (90m) ceiling above was sized for the
+  # FAST path (bastion harbor-proxy fan-out). #5095 added a DIRECT-source
+  # fallback: when the mothership proxy path is unreachable, each image is
+  # pushed straight from its canonical upstream (ghcr.io / docker.io / …).
+  # That route is the SLOWEST — a full 140-image census at ~0.75 min/image
+  # DIRECT ≈ 105 min, plus the #5095 per-image exponential-backoff spacing
+  # (~15 min inside a transit flap) and one catalyst-api re-poll — legitimately
+  # past 90m. On hw281 the Job was still settling (log "Phase A progress:
+  # 100/140 settled (still copying)") when BOTH the K8s Job activeDeadlineSeconds
+  # AND catalyst-api's watch context (each stamped from this same value) expired
+  # at 90m: failedStep=harbor-prewarm, lastError="watch Job … context deadline
+  # exceeded" — a still-progressing prewarm killed as failed. Raised 5400 → 9600
+  # (160m) so the worst-case DIRECT-fallback push finishes inside budget. This
+  # single value flows to BOTH deadlines (K8s Job + catalyst-api watch), so the
+  # ceiling can never again undercut the DIRECT-fallback runtime. The step stays
+  # event-driven + resumable (prewarm.skipIfAlreadyPresent #4994 skips already-
+  # mirrored tags on a re-fire via a manifest-digest HEAD), so a fast proxy-path
+  # run returns in minutes and never waits out the larger ceiling, and a re-run
+  # resumes rather than re-transferring from 0. No other step's deadline changes.
+  harborPrewarmSeconds: 9600
   fluxGitRepositoryPatchSeconds: 600
   # Step 06 (helmrepository-patches) activeDeadlineSeconds. This step now
   # has FOUR potentially-slow waits inside one Job and the deadline must

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5044,7 +5044,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.147"
+  version: "0.1.148"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5061,7 +5061,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.147"
+    version: "0.1.148"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (live, hw281, 2026-07-20)

Cutover step **harbor-prewarm** (step 3/11, bp-self-sovereign-cutover@0.1.147) was stamped **failed** while it was still legitimately settling.

`self-sovereign-cutover-status` ConfigMap:
- `failedStep=harbor-prewarm`
- `lastError=watch Job catalyst/cutover-harbor-prewarm-<id>: context deadline exceeded`

Job log at the moment of failure:
```
Phase A progress: 100/140 settled (still copying)
done harbor.openova.io/proxy-ghcr/... (ok)
```

## Root cause

`stepTimeouts.harborPrewarmSeconds` was `5400` (90 min). That single value is the deadline in **two** places, both consuming it via the embedded PodSpec's `activeDeadlineSeconds`:

1. **K8s Job hard-kill** — `platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml:61` (`activeDeadlineSeconds: {{ .Values.stepTimeouts.harborPrewarmSeconds }}`).
2. **catalyst-api watch-context deadline** — `products/catalyst/bootstrap/api/internal/handler/cutover.go:428` (`cutoverStepDeadline`), stamped onto the created Job at `cutover.go:950` (`createCutoverJob`) and passed as the watch timeout at `cutover.go:1872` (`watchJobToCompletion(ctx, deps, jobOrDS, cutoverStepDeadline(step))`).

The 90-min ceiling was sized (#3379) for the FAST bastion harbor-proxy fan-out path. It predates the #5095 DIRECT-source fallback: when the mothership proxy path is unreachable, each image is pushed straight from its canonical upstream (~0.75 min/image DIRECT). A full 140-image census runs ≈ 105 min, plus the #5095 exponential-backoff spacing (~15 min inside a transit flap) and one catalyst-api re-poll — legitimately past 90 min. Both deadlines expired at 90 min and a still-progressing prewarm was killed as failed.

## Change

**Raise `stepTimeouts.harborPrewarmSeconds` `5400` → `9600` (160 min)** — covers the worst-case DIRECT-fallback push with headroom. The single chart value flows to both deadlines, so the ceiling can never again undercut the DIRECT-fallback runtime.

- **Exact line changed:** `platform/self-sovereign-cutover/chart/values.yaml:1811` (`harborPrewarmSeconds: 5400` → `9600`), with the rationale block above it and the two forward-reference invariant comments (`values.yaml:570`, `:672`) updated to the new value.
- **Before:** worst-case DIRECT-fallback push (~105 min + ~15 min backoff) exceeds the 90-min ceiling → K8s Job `activeDeadlineSeconds` + catalyst-api watch context both fire → still-progressing step killed as failed.
- **After:** 160-min ceiling covers a full 140-image DIRECT-fallback push + backoff + one re-poll. A fast proxy-path run stays event-driven and returns in minutes — it never waits out the larger ceiling.

**Resumability (already in place, confirmed):** `prewarm.skipIfAlreadyPresent: true` (#4994) makes a re-fired step-03 skip already-mirrored tags via a manifest-digest HEAD, so a retry resumes from where it left off rather than restarting from 0.

**No other step's deadline changes.** Same remediation shape already applied to `egressBlockTestSeconds` (900→1200→3600→7200, #4723/#5065) and to `harborPrewarmSeconds` itself (1800→5400, #3379).

## Version + pins

- `platform/self-sovereign-cutover/chart/Chart.yaml` `version` `0.1.147` → `0.1.148` + changelog.
- `platform/self-sovereign-cutover/blueprint.yaml` `0.1.147` → `0.1.148`.
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` both pins `0.1.147` → `0.1.148`.

## Validation

- `helm template` renders `activeDeadlineSeconds: 9600` for the harbor-prewarm step (single occurrence, no other step touched).
- `platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` — **All gates green** (Cases 1–68).
- Go: no source change; `cutoverStepDeadline`'s MAX-of-global-and-per-step behavior is already covered by `TestCutoverStepDeadline_HonorsPerStepPodSpecValue`, which proves the raised per-step value flows through to both the Job cap and the watch timeout.

Refs #5298 #5095 #3379
