### PR TITLE
fix(bp-harbor): disable S3 blob-redirect via the correct lowercase key — #4573 F2 was inert (camelCase typo) → region-restart cold-pull TLS-fail (#5302)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -226,7 +226,9 @@ spec:
       #   DNS/cert change. externalURL + OIDC redirect_uri stay on registry.<fqdn>.
       # 1.2.42: updateStrategy Recreate — single-replica RWO jobservice
       # deadlocked cutover step-08's forced roll on Multi-Attach (#5022).
-      version: 1.2.43
+      # 1.2.44: #5302 — fix the disableredirect key casing (was silently-dropped
+      # camelCase; the s3 overlay above now sets the correct lowercase key).
+      version: 1.2.44
       sourceRef:
         kind: HelmRepository
         name: bp-harbor
@@ -401,11 +403,15 @@ spec:
           # *.obs... not registry.<fqdn>` (live c39f0cd4455b7a46, #4573 F2).
           # That x509 wedges the step-08 fresh-pull proof (containerd blob
           # GET) and any in-cluster blob fetch under the deny-egress hold.
-          # `disableRedirect: true` makes harbor-registry stream the blob
+          # `disableredirect: true` makes harbor-registry stream the blob
           # bytes itself over the already-trusted registry host — the OBS
           # backend is still the durable store (Harbor reads/writes it
           # server-side); only the CLIENT-facing 302 is suppressed.
-          disableRedirect: true
+          # #5302: the key is ALL-LOWERCASE `disableredirect` — upstream Harbor
+          # reads exactly that (registry-cm renders `disable: {{ $storage.
+          # disableredirect }}`). The camelCase `disableRedirect` #4575 shipped
+          # was silently dropped by Helm (case-sensitive), leaving redirect ON.
+          disableredirect: true
           type: s3
           s3:
             existingSecret: harbor-objectstorage-credentials

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.43  # lockstep with chart/Chart.yaml (#5022 updateStrategy Recreate — jobservice RWO single-replica roll deadlock)
+  version: 1.2.44  # lockstep with chart/Chart.yaml (#5302 disableredirect key casing — see Chart.yaml changelog)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -170,7 +170,18 @@ type: application
 #   sign-in->/c/oidc/login redirect keeps its canonical hostname), so entry via
 #   harbor.<fqdn> lands on the canonical host with no loop. Also adds
 #   gateway.extraHosts (arbitrary aliases) + tests/httproute-render.sh Case 6.
-version: 1.2.43
+# 1.2.44 (#5302): fix the S3 blob-redirect key casing. Upstream Harbor reads the
+#   ALL-LOWERCASE `persistence.imageChartStorage.disableredirect` (registry-cm
+#   renders `redirect.disable: {{ $storage.disableredirect }}`). The camelCase
+#   `disableRedirect` that #4573 F2 / #4575 shipped was silently dropped by Helm
+#   (values are case-sensitive), so the OBS 302 redirect stayed ENABLED and every
+#   COLD chart pull (e.g. after a region hard-restart) TLS-failed with `x509:
+#   certificate valid for *.obs... not registry.<fqdn>`, wedging post-cutover
+#   Flux self-heal. Default is now `disableredirect: true` — the self-contained
+#   sovereign registry streams blobs over its own trusted host, never redirects
+#   to a differently-certed Object Storage backend. tests/registry-disableredirect.sh
+#   guards the wiring so the casing typo cannot recur.
+version: 1.2.44
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/tests/registry-disableredirect.sh
+++ b/platform/harbor/chart/tests/registry-disableredirect.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# bp-harbor — registry S3 blob-redirect wiring guard (#5302).
+#
+# The self-contained sovereign registry MUST serve blob bytes over its own
+# trusted host (registry.<fqdn>) and NEVER 302-redirect a client to the
+# differently-certed Object Storage backend (obs.<region>.<sov>.nationalcloud.om
+# / S3). If it redirects, every in-cluster TLS-pinned client (source-controller
+# OCI pulls, containerd, skopeo) fails on a COLD blob fetch with
+#   x509: certificate is valid for *.obs... not registry.<fqdn>
+# which wedges post-cutover Flux self-heal after any cache-evicting restart
+# (region-kill G12 face-6 on hw281, dep 6db2745323dff4aa).
+#
+# The control is `persistence.imageChartStorage.disableredirect` — note the key
+# is ALL-LOWERCASE. Upstream Harbor's registry-cm renders
+#   redirect: { disable: {{ $storage.disableredirect }} }
+# Helm values are case-sensitive, so the camelCase `disableRedirect` that
+# #4573 F2 / #4575 shipped was silently dropped and the redirect stayed ENABLED
+# for the fix's entire life (masked because cutover prewarm keeps blobs in
+# Harbor's local cache — only a cold pull after eviction hits the redirect).
+#
+# Cases:
+#   1. Sovereign overlay (type=s3, lowercase disableredirect=true) → disable: true
+#   2. Lowercase key genuinely controls it (disableredirect=false → disable: false)
+#   3. GUARD: chart default renders disable: true (redirect off by default)
+#   4. GUARD: a camelCase `disableRedirect` override is INERT — it cannot flip
+#      the redirect back on (the exact #4575 typo must never silently regress)
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+cm="charts/harbor/templates/registry/registry-cm.yaml"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# Extract the `disable:` value from the registry config's storage.redirect block.
+redirect_disable() {
+  # Render only the registry configmap, then read the `redirect: { disable: X }`
+  # line inside the embedded config.yml.
+  "$helm" template smoke "$chart_dir" "$@" --show-only "$cm" 2>&1 \
+    | awk '/redirect:/{f=1;next} f&&/disable:/{print $2;exit}'
+}
+
+# ── Case 1: sovereign overlay → redirect disabled ─────────────────────
+echo "[bp-harbor] Case 1: type=s3 + disableredirect=true → registry redirect DISABLED"
+v=$(redirect_disable \
+      --set harbor.persistence.imageChartStorage.type=s3 \
+      --set harbor.persistence.imageChartStorage.disableredirect=true)
+if [ "$v" != "true" ]; then
+  echo "FAIL: expected redirect.disable=true, got '$v'"
+  echo "(cold chart pulls would 302 to OBS and x509-fail → post-cutover self-heal wedged)"
+  exit 1
+fi
+echo "[bp-harbor] Case 1: PASS"
+
+# ── Case 2: lowercase key genuinely controls the value ────────────────
+echo "[bp-harbor] Case 2: lowercase disableredirect=false → redirect ENABLED (key is live)"
+v=$(redirect_disable \
+      --set harbor.persistence.imageChartStorage.type=s3 \
+      --set harbor.persistence.imageChartStorage.disableredirect=false)
+if [ "$v" != "false" ]; then
+  echo "FAIL: lowercase disableredirect=false did not reach registry-cm (got '$v')"
+  exit 1
+fi
+echo "[bp-harbor] Case 2: PASS"
+
+# ── Case 3: chart default keeps redirect OFF ──────────────────────────
+echo "[bp-harbor] Case 3: chart default → redirect DISABLED (safe sovereign default)"
+v=$(redirect_disable)
+if [ "$v" != "true" ]; then
+  echo "FAIL: #5302 REGRESSION — chart default no longer disables the S3 blob redirect (got '$v')"
+  exit 1
+fi
+echo "[bp-harbor] Case 3: PASS"
+
+# ── Case 4: camelCase override is INERT (the #4575 typo cannot regress) ─
+echo "[bp-harbor] Case 4: GUARD — camelCase disableRedirect cannot flip redirect back on"
+v=$(redirect_disable \
+      --set harbor.persistence.imageChartStorage.type=s3 \
+      --set harbor.persistence.imageChartStorage.disableRedirect=false)
+if [ "$v" != "true" ]; then
+  echo "FAIL: a camelCase 'disableRedirect' override changed the rendered redirect —"
+  echo "either the upstream key changed or the default was reverted (got '$v')."
+  echo "The wired key is lowercase 'disableredirect'; camelCase must be inert."
+  exit 1
+fi
+echo "[bp-harbor] Case 4: PASS"
+
+echo "[bp-harbor] All registry disableredirect wiring cases PASS"

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -139,7 +139,14 @@ harbor:
         accessMode: ReadWriteOnce
         size: 5Gi
     imageChartStorage:
-      disableRedirect: false
+      # #5302: upstream Harbor's key is all-lowercase `disableredirect` (Helm
+      # values are case-sensitive — camelCase `disableRedirect` is silently
+      # ignored, which is why #4573 F2 was inert its entire life and a
+      # region-restart cold chart-pull TLS-failed against the OBS redirect).
+      # Default `true`: a self-contained sovereign registry must stream blobs
+      # over its own trusted registry host, never 302-redirect to a
+      # differently-certed Object Storage backend. Inert for `type: filesystem`.
+      disableredirect: true
       # Default `filesystem` so contabo dev/test renders cleanly with
       # no S3 endpoint configured. Per-Sovereign overlay flips this to
       # `s3` and supplies bucket/region/regionendpoint/existingSecret

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3309,7 +3309,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.43"
+  version: "1.2.44"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3333,7 +3333,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.43"
+    version: "1.2.44"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## What

Fixes a Helm key-casing typo that made Harbor's S3 blob-redirect suppression **inert its entire life**, so a Sovereign could not re-pull charts from its own local Harbor after any cache-evicting restart.

## Root cause (proven)

Upstream Harbor (`harbor-1.18.3`) reads the **all-lowercase** `persistence.imageChartStorage.disableredirect`; its `registry-cm` renders `redirect: disable: {{ $storage.disableredirect }}`. But #4573 F2 / #4575 shipped the **camelCase** `disableRedirect`. Helm values are case-sensitive → the camelCase key was silently dropped → the subchart defaulted to `false` → the OBS 302 redirect stayed **enabled**.

Local render of the pinned chart:

| value | rendered registry-cm |
|---|---|
| `disableRedirect: true` (camelCase — what #4575 set) | `redirect: disable: false` ❌ |
| `disableredirect: true` (lowercase — this PR) | `redirect: disable: true` ✓ |

## Why it stayed hidden until a region-kill

During cutover, `harbor-prewarm` pushes every chart into Harbor immediately before source-controller pulls it, so blobs are in Harbor's **local cache** and served directly (no 302). Only a **cold pull after cache eviction** — exactly what a region hard-restart forces — hits the OBS redirect and the TLS mismatch:

```
oci://registry.hw281.omani.works/openova-io/bp-newapi:1.4.140
→ 302 → obs.me-east-215.kom4dc.nationalcloud.om
→ x509: certificate is valid for *.obs.me-east-215...om, NOT registry.hw281.omani.works
```

Surfaced live on the region-kill G12 walk (hw281, dep `6db2745323dff4aa`): after region-a was hard-restarted, all 67 region-a HelmReleases stayed `0/67` because every cold chart pull TLS-failed — blocking the DR failback re-clone (Pillar 3) and post-cutover self-heal (Pillar 5).

## Change

- `clusters/_template/bootstrap-kit/19-harbor.yaml:408` — overlay key `disableRedirect` → `disableredirect` (the live source of the HR value)
- `platform/harbor/chart/values.yaml:142` — chart default → `disableredirect: true` (a self-contained sovereign registry streams blobs over its own trusted host; inert for `type: filesystem`)
- bp-harbor `1.2.43` → `1.2.44` + catalog-seed `spec.version` / `source.version` lockstep
- `tests/registry-disableredirect.sh` — 4-case render guard, including **Case 4: a camelCase override is inert** so the exact typo cannot silently regress

All 4 test cases pass; `helm template` renders clean on both the s3 overlay and default paths; the s3-overlay render now emits `redirect: disable: true`.

## Verification

Clean 6/6 region-kill G12 on the next fresh prov: after a region hard-restart, source-controller cold-pulls succeed, region-a re-converges, cnpg re-clones as a streaming replica.

Refs #5302 #4573 #4275 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
