### PR TITLE
fix(catalog-seed): sync 14 stale catalog card versions + guard spec.version drift (Refs #4432)

### DIFF
--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -204,7 +204,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.4.12"
+  version: "0.4.22"
   visibility: listed
   card:
     title: "WordPress"
@@ -870,7 +870,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.0"
+  version: "1.0.3"
   visibility: listed
   card:
     title: "Loki"
@@ -1724,7 +1724,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.3"
+  version: "0.2.29"
   visibility: listed
   card:
     title: "Apache Guacamole"
@@ -2320,7 +2320,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.137"
+  version: "1.4.140"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2645,7 +2645,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.4"
+  version: "1.2.5"
   visibility: unlisted
   card:
     title: "SeaweedFS"
@@ -3559,7 +3559,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.539"
+  # #4432: this catalog-seed template renders INSIDE the bp-catalyst-platform
+  # umbrella chart, whose version auto-increments on EVERY deploy commit
+  # (products/catalyst/chart/Chart.yaml). A hard-pinned display version can
+  # therefore never stay in lockstep — it re-drifts the moment the next deploy
+  # bumps the umbrella. Rendering .Chart.Version makes the card ALWAYS report
+  # the exact shipping umbrella version, self-maintaining by construction.
+  version: {{ .Chart.Version | quote }}
   visibility: unlisted
   card:
     title: "Catalyst Platform"
@@ -3577,7 +3583,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-catalyst-platform
-    version: "1.4.539"
+    version: {{ .Chart.Version | quote }}
   topology:
     supported:
       - active-hot-standby
@@ -3793,7 +3799,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.13"
+  version: "1.4.16"
   visibility: unlisted
   card:
     title: "Cilium"
@@ -4480,7 +4486,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.14"
+  version: "0.1.16"
   visibility: unlisted
   card:
     title: "k8s-ws-proxy"
@@ -4594,7 +4600,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.46"
+  version: "1.0.48"
   visibility: unlisted
   card:
     title: "Kyverno Policy Library"
@@ -4757,7 +4763,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.20"
+  version: "1.2.21"
   visibility: unlisted
   card:
     title: "PowerDNS"
@@ -5350,7 +5356,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.4"
+  version: "0.1.12"
   visibility: unlisted
   card:
     title: "Continuum"
@@ -5522,7 +5528,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.6"
+  version: "0.2.29"
   visibility: unlisted
   card:
     title: "Management vCluster"
@@ -5568,7 +5574,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.5"
+  version: "0.2.9"
   visibility: unlisted
   card:
     title: "DMZ vCluster"
@@ -5614,7 +5620,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.6"
+  version: "0.2.14"
   visibility: unlisted
   card:
     title: "RTZ vCluster"

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -1512,6 +1512,184 @@ func TestCatalogSeed_DeliveryPinsNotBehindComponentCharts(t *testing.T) {
 	t.Logf("catalog-seed drift guard: compared %d in-repo delivery pins against component chart versions; none behind", checked)
 }
 
+// ── #4432 recurrence guard — catalog-seed DISPLAY versions (spec.version)
+//    must not lag the delivery pin / component chart ─────────────────────
+//
+// Root cause of #4432 (UAT row R21): the #4415/#4864 guard above
+// (TestCatalogSeed_DeliveryPinsNotBehindComponentCharts) checks ONLY the
+// `source.version` delivery pin. The card the operator console renders reads
+// `spec.version` — a SECOND, unchecked version field on the same CR. When a
+// component chart is bumped, syncing `source.version` (which CI enforced) but
+// forgetting `spec.version` left the catalog CARD advertising a stale version
+// while the chart actually shipped a newer one. 14 of 79 seed entries had
+// drifted this way on hw282 (e.g. bp-guacamole card 0.2.3 while the chart
+// shipped 0.2.29; bp-continuum 0.1.4 vs 0.1.12) — the card LIED about the
+// shipping version. This guard makes both invariants a hard CI failure:
+//
+//	(1) spec.version is NOT behind the component chart/Chart.yaml, and
+//	(2) spec.version EQUALS source.version (the card advertises exactly what
+//	    the delivery pin installs).
+//
+// Same in-repo-only, semver-aware, skip-external rules as the #4415 guard.
+// Entries whose version is a Helm template (e.g. bp-catalyst-platform pins
+// `{{ .Chart.Version }}` — the umbrella whose version auto-increments on every
+// deploy, so a hard pin can never stay in lockstep) render numerically at
+// install time and are skipped by the numeric-parse gate here, exactly as the
+// #4415 guard skips them.
+
+type seedEntry struct {
+	name          string
+	specVersion   string
+	specLine      int
+	sourceChart   string
+	sourceVersion string
+	sourceLine    int
+}
+
+var reSeedKind = regexp.MustCompile(`^kind:\s*Blueprint\s*$`)
+var reSeedName = regexp.MustCompile(`^  name:\s*"?(bp-[A-Za-z0-9._-]+)"?\s*$`)
+var reSeedSpecVersion = regexp.MustCompile(`^  version:\s*"?([0-9][0-9A-Za-z._+-]*)"?\s*$`)
+
+// catalogSeedEntries walks the catalog-seed template by `kind: Blueprint`
+// boundaries and captures, per Blueprint CR, the metadata.name, the
+// spec.version (the card DISPLAY version — the first 2-space `version:` that
+// precedes the `source:` block) and the source.chart + source.version delivery
+// pin. The file is a Helm template so a plain YAML unmarshal is impossible; the
+// fields we read are static YAML, so a scoped line scan is sufficient.
+func catalogSeedEntries(t *testing.T, root string) []seedEntry {
+	t.Helper()
+	f := filepath.Join(root, "products", "catalyst", "chart", "templates", "catalog-seed", "blueprints.yaml")
+	raw, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("read catalog-seed: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+	var entries []seedEntry
+	var cur *seedEntry
+	inSource := false
+	flush := func() {
+		if cur != nil {
+			entries = append(entries, *cur)
+		}
+		cur = nil
+		inSource = false
+	}
+	for i, ln := range lines {
+		if reSeedKind.MatchString(ln) {
+			flush()
+			cur = &seedEntry{}
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		if cur.name == "" {
+			if m := reSeedName.FindStringSubmatch(ln); m != nil {
+				cur.name = m[1]
+			}
+		}
+		if reSeedSource.MatchString(ln) {
+			inSource = true
+			continue
+		}
+		if inSource {
+			// A non-blank line indented <=2 spaces ends the source block.
+			if strings.TrimSpace(ln) != "" && !strings.HasPrefix(ln, "    ") {
+				inSource = false
+			} else {
+				if m := reSeedChart.FindStringSubmatch(ln); m != nil {
+					cur.sourceChart = m[1]
+				}
+				if m := reSeedVersion.FindStringSubmatch(ln); m != nil && cur.sourceVersion == "" {
+					cur.sourceVersion = m[1]
+					cur.sourceLine = i + 1
+				}
+				continue
+			}
+		}
+		// Outside a source block: the first 2-space `version:` is spec.version.
+		if cur.specVersion == "" {
+			if m := reSeedSpecVersion.FindStringSubmatch(ln); m != nil {
+				cur.specVersion = m[1]
+				cur.specLine = i + 1
+			}
+		}
+	}
+	flush()
+	return entries
+}
+
+func TestCatalogSeed_DisplayVersionNotBehindDeliveryPin(t *testing.T) {
+	root := repoRoot(t)
+
+	comp := componentChartVersions(t, root)
+	if len(comp) == 0 {
+		t.Fatal("discovered zero component charts under platform/ + products/ — guard is inert (glob/parse broken)")
+	}
+	entries := catalogSeedEntries(t, root)
+	if len(entries) == 0 {
+		t.Fatal("parsed zero catalog-seed Blueprint entries — the line parser is broken (expected dozens)")
+	}
+
+	checkedChart := 0
+	checkedPair := 0
+	for _, e := range entries {
+		if e.specVersion == "" {
+			// Templated (e.g. {{ .Chart.Version }}) or absent — nothing to
+			// compare statically; rendered at install time. Skip.
+			continue
+		}
+		chart := e.sourceChart
+		if chart == "" {
+			chart = e.name
+		}
+
+		// (1) DISPLAY version must not lag the component chart source-of-truth.
+		if cv, ok := comp[chart]; ok {
+			if less, comparable := semverLess(e.specVersion, cv); comparable {
+				checkedChart++
+				if less {
+					t.Errorf("CATALOG-SEED DISPLAY DRIFT (#4432 / R21):\n"+
+						"  Blueprint %q card spec.version is BEHIND its component chart:\n"+
+						"    catalog-seed spec.version   = %q  (blueprints.yaml line %d)\n"+
+						"    component chart/Chart.yaml  = %q\n"+
+						"  → the operator-console catalog CARD advertises a STALE version.\n"+
+						"  Sync the card: set spec.version to %q for %q in\n"+
+						"  products/catalyst/chart/templates/catalog-seed/blueprints.yaml",
+						e.name, e.specVersion, e.specLine, cv, cv, e.name)
+				}
+			}
+		}
+
+		// (2) DISPLAY version must EQUAL the delivery pin — the card must
+		// advertise exactly the chart the source block installs.
+		if e.sourceVersion != "" {
+			_, specNum := parseSemverNumeric(e.specVersion)
+			_, srcNum := parseSemverNumeric(e.sourceVersion)
+			if specNum && srcNum {
+				checkedPair++
+				if e.specVersion != e.sourceVersion {
+					t.Errorf("CATALOG-SEED CARD/DELIVERY MISMATCH (#4432 / R21):\n"+
+						"  Blueprint %q advertises one version but delivers another:\n"+
+						"    spec.version   = %q  (blueprints.yaml line %d)\n"+
+						"    source.version = %q  (blueprints.yaml line %d)\n"+
+						"  → the catalog card must advertise exactly the chart it installs.\n"+
+						"  Align both to the component chart version for %q in\n"+
+						"  products/catalyst/chart/templates/catalog-seed/blueprints.yaml",
+						e.name, e.specVersion, e.specLine, e.sourceVersion, e.sourceLine, e.name)
+				}
+			}
+		}
+	}
+	if checkedChart == 0 {
+		t.Fatal("zero catalog-seed spec.versions were comparable against component charts — the chart-name mapping is broken (guard would never catch display drift)")
+	}
+	if checkedPair == 0 {
+		t.Fatal("zero catalog-seed spec/source version pairs were comparable — the parser is broken (guard would never catch card/delivery mismatch)")
+	}
+	t.Logf("catalog-seed display-version guard: %d card versions checked against component charts, %d card-vs-delivery pairs checked; all aligned", checkedChart, checkedPair)
+}
+
 // TestBootstrapKit_LbIpamSharingCrossNamespace guards the #4765 residue
 // fixed in bp-cilium 1.4.16 (live-proven hw255, 2026-07-15): Cilium
 // LB-IPAM (≥1.16) only lets two LoadBalancer Services share one VIP


### PR DESCRIPTION
## Problem (UAT row R21, Refs #4432)

The operator-console catalog card renders a Blueprint CR's **`spec.version`**. The existing recurrence guard from #4415/#4864 — `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` — only checks the *other* version field on the same CR: **`source.version`** (the Flux delivery pin). `spec.version` was checked by nothing.

Result: when a component chart was bumped, whoever synced the seed updated `source.version` (CI enforced it) but not `spec.version`. **14 of 79 seed cards** ended up advertising a stale version while the chart actually shipped a newer one — the card lied about the shipping version. Live-confirmed on hw282 (2026-07-21).

Note on the `keep`-annotation theory in the ticket: the seed CRs carry **no** `helm.sh/resource-policy: keep` annotation (verified). The inert-bump mechanism here is simply that `spec.version` had no CI guard — a later `source.version`-only sweep never touched the card version.

## Fix — bring every lagging `spec.version` into lockstep

Source of truth = each component `chart/Chart.yaml` (which the existing `TestBootstrapKit_BlueprintVersionLockstepSweep` already keeps equal to `blueprint.yaml` `spec.version`). For 13 entries the delivery `source.version` was already correct, so only the card `spec.version` was bumped to match:

| Blueprint | seed spec.version (old) | in-repo current |
|---|---|---|
| bp-wordpress | 0.4.12 | **0.4.22** |
| bp-loki | 1.0.0 | **1.0.3** |
| bp-guacamole | 0.2.3 | **0.2.29** |
| bp-newapi | 1.4.137 | **1.4.140** |
| bp-seaweedfs | 1.2.4 | **1.2.5** |
| bp-cilium | 1.4.13 | **1.4.16** |
| bp-k8s-ws-proxy | 0.1.14 | **0.1.16** |
| bp-kyverno-policies | 1.0.46 | **1.0.48** |
| bp-powerdns | 1.2.20 | **1.2.21** |
| bp-continuum | 0.1.4 | **0.1.12** |
| bp-mgmt-vcluster | 0.2.6 | **0.2.29** |
| bp-dmz-vcluster | 0.2.5 | **0.2.9** |
| bp-rtz-vcluster | 0.2.6 | **0.2.14** |

### bp-catalyst-platform — the self-referential umbrella (no `keep` dropped)

`bp-catalyst-platform` had **both** `spec.version` and `source.version` pinned at `1.4.539` while the actual umbrella `Chart.yaml` is `1.4.1195` (~656 deploy commits ahead). This catalog-seed template renders **inside** that umbrella chart, whose version auto-increments on every `deploy:` commit — so any hard pin re-drifts the instant the next deploy lands (the chicken-and-egg the #4415 guard documents by excluding it). Rather than hard-pin `1.4.1195` (which would immediately re-lag), **both fields now render `{{ .Chart.Version }}`**, so the card always reports the exact shipping umbrella version — self-maintaining by construction. No `helm.sh/resource-policy: keep` annotation existed to drop.

## New guard — closes the `spec.version` coverage gap

`TestCatalogSeed_DisplayVersionNotBehindDeliveryPin` (in `tests/e2e/bootstrap-kit/main_test.go`), modelled on the existing `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` + `semverLess`/`componentChartVersions` helpers. For every seed entry it asserts:

1. `spec.version` is **not behind** its component `chart/Chart.yaml` (the R21 defect), and
2. `spec.version` **equals** `source.version` (the card advertises exactly what it delivers).

Same in-repo-only, semver-aware, skip-external rules as the #4415 guard. Templated versions (the `{{ .Chart.Version }}` umbrella) render numerically at install time and are skipped by the numeric-parse gate.

**Proof the guard catches drift** (bp-guacamole reverted to 0.2.3):
```
--- FAIL: TestCatalogSeed_DisplayVersionNotBehindDeliveryPin
    CATALOG-SEED DISPLAY DRIFT (#4432 / R21):
      Blueprint "bp-guacamole" card spec.version is BEHIND its component chart:
        catalog-seed spec.version   = "0.2.3"  (blueprints.yaml line 1727)
      Sync the card: set spec.version to "0.2.29" for "bp-guacamole"
    CATALOG-SEED CARD/DELIVERY MISMATCH (#4432 / R21):
        spec.version   = "0.2.3"   source.version = "0.2.29"
```
Once synced: `PASS ... 74 card versions checked, 79 card-vs-delivery pairs checked; all aligned`.

## Green gates
- `go build ./...` + `go vet ./...` + `go test ./...` in `tests/e2e/bootstrap-kit` — **PASS**
- `go build ./...` + catalog/seed/blueprint tests in `products/catalyst/bootstrap/api` — **PASS**
- `helm template` the catalyst chart's catalog-seed — renders (exit 0); umbrella card resolves to `1.4.1195`
- Existing `scripts/check-catalog-seed-lockstep.sh` (topology/endpoints/sso) — **PASS** (68 checked, 0 fail)
- Existing `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` (source.version) — **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)