### PR TITLE
fix(organization-controller): stop the reconcile hot-loop that made the per-Org repo a continuous writer starving the funnel cart-install (#5305)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -651,6 +652,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if _, _, err := r.GiteaClient.PutFile(ctx,
 			gOrg.Username, repoName, branch, path, data,
 			fmt.Sprintf("organization-controller: reconcile %s for %s", path, org.Spec.Slug)); err != nil {
+			// #5305 — a concurrent writer (the funnel cart-install, the
+			// authoritative read-modify-write owner of the shared
+			// `vcluster/apps/kustomization.yaml` index) landed a commit on the
+			// SAME branch HEAD between our read and our write, so this PutFile lost
+			// the compare-and-swap. That is the funnel CONVERGING — the desired end
+			// state — not a controller error. Failing the whole reconcile here
+			// re-ran the ENTIRE PutFile burst on the requeue, re-perturbing the
+			// branch HEAD and starving the funnel's finite compare-and-swap budget
+			// (the purchased app never landed — hw282). Soft-skip the lost CAS: the
+			// next reconcile re-verifies (by which point the funnel's index is
+			// visible and the merge is a byte-equal no-op). A genuine write failure
+			// (auth, malformed manifest, repo gone) still fails the reconcile.
+			if isConcurrentWriterCASLoss(err) {
+				log.Info("per-Org repo write lost the compare-and-swap to a concurrent funnel commit — soft-skipping so the funnel (the shared-index owner) converges instead of being re-bursted over (#5305)",
+					"organization", org.Spec.Slug, "path", path)
+				continue
+			}
 			return r.fail(ctx, &org, "GitopsWriteFailed",
 				fmt.Sprintf("write %s: %s", path, err))
 		}
@@ -1014,9 +1032,82 @@ func (r *Reconciler) fail(ctx context.Context, org *orgapi.Organization, reason,
 }
 
 func (r *Reconciler) patchStatus(ctx context.Context, org *orgapi.Organization, desired orgapi.OrganizationStatus) error {
+	// #5305 — CONVERGE-IDEMPOTENT status write (the root-cause fix). This
+	// reconciler watches the Organization with SetupWithManager's DEFAULT
+	// (all-events) filter, so a Status().Update re-enqueues THIS reconcile from
+	// its own output. The Ready condition stamped LastTransitionTime=now() on
+	// every pass, so `desired` ALWAYS differed from the live status → the
+	// reconciler wrote status → re-reconciled → wrote again, hot-looping
+	// sub-second the whole time the Org provisioned. Each pass re-ran step-3's
+	// per-Org `catalyst-tenant` repo PutFile burst (including the shared
+	// `vcluster/apps/kustomization.yaml` merge-write), turning the controller
+	// into a CONTINUOUS competing writer on the branch HEAD — one the funnel
+	// cart-install's finite compare-and-swap budget could never out-run, so the
+	// purchased app never landed (hw282). Carry forward each condition's
+	// LastTransitionTime when its (Status,Reason,Message) is unchanged, then SKIP
+	// the write entirely when the resulting status is byte-equal to the live one.
+	// The reconciler now re-fires only on a real state change or the explicit 30s
+	// provisioning requeue, so its per-Org repo writes collapse to a FINITE seed
+	// burst the funnel's retry budget straddles.
+	desired.Conditions = carryForwardConditionTimestamps(org.Status.Conditions, desired.Conditions)
+	if reflect.DeepEqual(org.Status, desired) {
+		return nil
+	}
 	updated := org.DeepCopyObject().(*orgapi.Organization)
 	updated.Status = desired
 	return r.Status().Update(ctx, updated)
+}
+
+// carryForwardConditionTimestamps returns `desired` with each condition's
+// LastTransitionTime replaced by the matching LIVE condition's timestamp when
+// the condition has NOT transitioned (same Status/Reason/Message). A genuine
+// transition keeps the freshly-stamped time. Without this the Ready condition's
+// unconditional now() stamp made every reconcile's status differ from the live
+// one, defeating the byte-equal skip in patchStatus and hot-looping the
+// controller into a continuous branch writer (#5305).
+func carryForwardConditionTimestamps(live, desired []orgapi.Condition) []orgapi.Condition {
+	byType := make(map[string]orgapi.Condition, len(live))
+	for _, c := range live {
+		byType[c.Type] = c
+	}
+	out := make([]orgapi.Condition, len(desired))
+	for i, d := range desired {
+		if prev, ok := byType[d.Type]; ok &&
+			prev.Status == d.Status && prev.Reason == d.Reason && prev.Message == d.Message {
+			d.LastTransitionTime = prev.LastTransitionTime
+		}
+		out[i] = d
+	}
+	return out
+}
+
+// isConcurrentWriterCASLoss reports whether a per-Org repo PutFile error is a
+// transient compare-and-swap loss to a concurrent writer on the same branch
+// HEAD (the funnel cart-install racing the controller's #5104 index merge-write)
+// rather than a permanent failure. Gitea surfaces the loss as a 409 (git
+// ref-lock / CAS) or a 422 whose body names the file-level precondition failure
+// ("sha does not match" on an update, "already exists" on a create). #5305.
+func isConcurrentWriterCASLoss(err error) bool {
+	if err == nil {
+		return false
+	}
+	var he *gitea.HTTPError
+	if errors.As(err, &he) {
+		if he.Status == http.StatusConflict {
+			return true
+		}
+		if he.Status == http.StatusUnprocessableEntity {
+			b := strings.ToLower(he.Body)
+			return strings.Contains(b, "exist") ||
+				strings.Contains(b, "does not match") ||
+				strings.Contains(b, "cannot lock ref")
+		}
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "sha does not match") ||
+		strings.Contains(s, "cannot lock ref") ||
+		strings.Contains(s, "repository file already exists")
 }
 
 // upsertUserAccess writes (or updates) a single-grant UserAccess CR

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -162,6 +162,12 @@ type giteaServer struct {
 	repos map[string]gitea.Repo // key: "{owner}/{name}"
 	files map[string]fileEntry  // key: "{owner}/{repo}/{path}"
 
+	// collideOnce injects a one-shot 409 git-ref-lock on the NEXT contents
+	// write (POST or PUT) to a given "{owner}/{repo}/{path}" key, modelling a
+	// concurrent writer (the funnel cart-install) winning the compare-and-swap
+	// on the shared branch HEAD. Consumed on first use. #5305.
+	collideOnce map[string]bool
+
 	// Counts of mutating calls — used by the idempotency test to
 	// assert zero post-steady-state writes.
 	createOrgs, createRepos, createFiles, updateFiles int
@@ -176,10 +182,11 @@ type fileEntry struct {
 
 func newGiteaServer(t *testing.T) *giteaServer {
 	gs := &giteaServer{
-		t:     t,
-		orgs:  map[string]gitea.Org{},
-		repos: map[string]gitea.Repo{},
-		files: map[string]fileEntry{},
+		t:           t,
+		orgs:        map[string]gitea.Org{},
+		repos:       map[string]gitea.Repo{},
+		files:       map[string]fileEntry{},
+		collideOnce: map[string]bool{},
 	}
 	gs.server = httptest.NewServer(http.HandlerFunc(gs.handle))
 	t.Cleanup(gs.server.Close)
@@ -337,6 +344,15 @@ func (g *giteaServer) handle(w http.ResponseWriter, r *http.Request) {
 			data, err := base64.StdEncoding.DecodeString(body.Content)
 			if err != nil {
 				http.Error(w, "bad b64", http.StatusBadRequest)
+				return
+			}
+			// #5305 — one-shot concurrent-writer CAS loss injection: model the
+			// funnel landing a commit on the same branch HEAD between the
+			// controller's read and its write. Gitea surfaces this as a 409
+			// git-ref-lock. Consume the flag so a retry/next-reconcile succeeds.
+			if g.collideOnce[key] {
+				delete(g.collideOnce, key)
+				http.Error(w, "cannot lock ref 'refs/heads/main': is at aaaa but expected bbbb", http.StatusConflict)
 				return
 			}
 			if r.Method == http.MethodPost {

--- a/core/controllers/organization/internal/controller/perorg_repo_hotloop_5305_test.go
+++ b/core/controllers/organization/internal/controller/perorg_repo_hotloop_5305_test.go
@@ -1,0 +1,152 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+)
+
+// #5305 (hw282) — a funnel customer's PURCHASED app never deployed: the funnel
+// cart-install's commit to the per-Org `<slug>/catalyst-tenant` repo lost the
+// compare-and-swap to the organization-controller on EVERY attempt, so the app
+// manifest never landed in `vcluster/apps/` and the Org boundary held only the
+// NP baseline.
+//
+// Root cause: the reconciler watches the Organization with the DEFAULT
+// (all-events) filter AND patchStatus wrote status unconditionally with a Ready
+// condition whose LastTransitionTime was stamped now() every pass. That status
+// write re-enqueued the reconcile from its own output — a sub-second HOT LOOP
+// the whole time the Org provisioned. Each pass re-ran step-3's per-Org repo
+// PutFile burst (incl. the shared `vcluster/apps/kustomization.yaml`
+// merge-write), turning the controller into a CONTINUOUS competing writer on the
+// branch HEAD that the funnel's finite retry budget could never out-run.
+//
+// The fix makes the status write CONVERGE-IDEMPOTENT (carry LastTransitionTime
+// forward when the condition is unchanged; skip the write when status is
+// byte-equal), so the controller re-fires only on a real state change or the
+// explicit 30s provisioning requeue — collapsing its per-Org repo writes to a
+// FINITE seed burst. These tests lock in that the controller is no longer a
+// continuous writer.
+
+// readyCondition returns the "Ready" condition of an Organization, or nil.
+func readyCondition(org *orgapi.Organization) *orgapi.Condition {
+	for i := range org.Status.Conditions {
+		if org.Status.Conditions[i].Type == "Ready" {
+			return &org.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// TestReconcile_ConvergeIdempotent_NoStatusChurn_NoReburst_5305 proves the
+// controller does NOT re-write status (the hot-loop trigger) NOR re-burst the
+// per-Org repo once its state matches desired. A steady-state reconcile must be
+// a genuine no-op: stable object resourceVersion (no self-triggering status
+// write), unchanged Ready-condition LastTransitionTime (no churn), and zero
+// additional Gitea file writes (no re-burst on the shared branch HEAD).
+func TestReconcile_ConvergeIdempotent_NoStatusChurn_NoReburst_5305(t *testing.T) {
+	org := sampleOrg()
+	r, gs, _ := makeReconciler(t, org)
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "acme"}}
+
+	// Two warmup reconciles to reach steady state (seed the repo, add the
+	// finalizer, settle status). The Org never goes Ready here (no vCluster HR
+	// is seeded), so it sits stably at Ready=False:VClusterProvisioning.
+	for i := 0; i < 2; i++ {
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("warmup reconcile %d: %v", i, err)
+		}
+	}
+
+	before := sampleOrg()
+	if err := r.Get(ctx, client.ObjectKey{Name: "acme"}, before); err != nil {
+		t.Fatalf("get before: %v", err)
+	}
+	rvBefore := before.ResourceVersion
+	rcBefore := readyCondition(before)
+	if rcBefore == nil {
+		t.Fatalf("no Ready condition after warmup: %+v", before.Status)
+	}
+	writesBefore := gs.createFiles + gs.updateFiles
+
+	// One more reconcile with NOTHING changed. Pre-#5305 this wrote status again
+	// (LastTransitionTime=now()), bumping resourceVersion and re-enqueueing the
+	// reconcile — the hot loop that made step-3 a continuous branch writer.
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("steady-state reconcile: %v", err)
+	}
+
+	after := sampleOrg()
+	if err := r.Get(ctx, client.ObjectKey{Name: "acme"}, after); err != nil {
+		t.Fatalf("get after: %v", err)
+	}
+	if after.ResourceVersion != rvBefore {
+		t.Errorf("#5305 regression: steady-state reconcile mutated the Organization (resourceVersion %s → %s) — the self-triggering status write hot-loops the reconciler into a continuous branch writer",
+			rvBefore, after.ResourceVersion)
+	}
+	rcAfter := readyCondition(after)
+	if rcAfter == nil {
+		t.Fatalf("no Ready condition after steady-state reconcile")
+	}
+	if !rcAfter.LastTransitionTime.Equal(&rcBefore.LastTransitionTime) {
+		t.Errorf("#5305 regression: Ready condition LastTransitionTime churned (%v → %v) with no state change — this is the now()-every-pass stamp that defeated the byte-equal status skip",
+			rcBefore.LastTransitionTime, rcAfter.LastTransitionTime)
+	}
+	if writesAfter := gs.createFiles + gs.updateFiles; writesAfter != writesBefore {
+		t.Errorf("#5305 regression: steady-state reconcile re-burst the per-Org repo (%d → %d writes) — the controller is a continuous writer again, starving the funnel's compare-and-swap",
+			writesBefore, writesAfter)
+	}
+}
+
+// TestReconcile_ConcurrentWriterCASLoss_SoftSkips_NoFail_5305 proves that when
+// the funnel (a concurrent writer) wins the compare-and-swap on the shared apps
+// index — modelled as a one-shot 409 git-ref-lock on that path's write — the
+// controller SOFT-SKIPS the lost CAS instead of failing the whole reconcile and
+// re-bursting the entire PutFile set (the amplification that starved the funnel
+// on hw282). The Org must not be parked at GitopsWriteFailed, and a subsequent
+// reconcile (collision consumed) must seed the index cleanly.
+func TestReconcile_ConcurrentWriterCASLoss_SoftSkips_NoFail_5305(t *testing.T) {
+	org := sampleOrg()
+	r, gs, _ := makeReconciler(t, org)
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "acme"}}
+
+	const appsIndexKey = "acme/catalyst-tenant/vcluster/apps/kustomization.yaml"
+	gs.collideOnce[appsIndexKey] = true
+
+	// The reconcile must NOT return an error and must NOT park the Org at
+	// GitopsWriteFailed — the lost CAS means the funnel converged, which is the
+	// desired end state, not a controller failure.
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("reconcile returned an error on a concurrent-writer CAS loss (should soft-skip): %v", err)
+	}
+	got := sampleOrg()
+	if err := r.Get(ctx, client.ObjectKey{Name: "acme"}, got); err != nil {
+		t.Fatalf("get org: %v", err)
+	}
+	for _, c := range got.Status.Conditions {
+		if c.Reason == "GitopsWriteFailed" {
+			t.Fatalf("#5305 regression: reconcile FAILED the Org on a concurrent-writer CAS loss instead of soft-skipping — this re-bursts the whole PutFile set and starves the funnel: %+v", c)
+		}
+	}
+	// The controller soft-skipped its own index write (the funnel owns it now).
+	if _, seeded := gs.files[appsIndexKey]; seeded {
+		t.Errorf("expected the controller to soft-skip the collided index write (leaving it to the funnel), but it wrote %s", appsIndexKey)
+	}
+
+	// A subsequent reconcile (collision consumed) seeds the index cleanly and
+	// still does not fail — the soft-skip self-heals on the next pass.
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("follow-up reconcile after soft-skip: %v", err)
+	}
+	if _, seeded := gs.files[appsIndexKey]; !seeded {
+		t.Errorf("index still absent after the collision was consumed — the controller did not re-seed it on the next reconcile")
+	}
+}

--- a/core/services/provisioning/github/client_hotloop_5305_test.go
+++ b/core/services/provisioning/github/client_hotloop_5305_test.go
@@ -1,0 +1,58 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+)
+
+// #5305 (hw282) — the funnel customer's PURCHASED app never deployed because the
+// organization-controller was a CONTINUOUS writer on the per-Org
+// `<slug>/catalyst-tenant` repo's `main` HEAD: an unconditional status write
+// (Ready condition stamped now() every pass) re-enqueued the reconcile from its
+// own output, hot-looping sub-second and re-firing its `vcluster/apps/`
+// PutFile burst forever. Against an UNBOUNDED writer the funnel's finite
+// compare-and-swap budget can never win — that is exactly what
+// TestCommitFiles_GiteaTarget_PermanentlyAdvancingRefExhausts_5234 pins
+// (advanceRemaining=-1 → exhausts). The #5305 fix removes the hot loop on the
+// controller side, so the controller's writes collapse to a FINITE seed burst.
+//
+// This test pins the OTHER half of the contract at the funnel client level: a
+// finite MULTI-COMMIT burst (a seed burst of several sequential controller
+// commits, each landing between the funnel's probe and its push) CONVERGES
+// within the widened attempt budget. It is the realistic post-#5305 shape —
+// several rapid controller commits at Org-create, then quiet — and proves the
+// funnel lands its purchased-app commit as soon as the controller stops.
+func TestCommitFiles_GiteaTarget_ConvergesOnFiniteSeedBurst_5305(t *testing.T) {
+	shrinkCommitRetryDelays(t)
+
+	// Six sequential competing commits (a full org-controller seed burst:
+	// namespace / HR / quota / limitrange / NP / index), then the branch goes
+	// quiet — well within commitAttemptsMax (10).
+	const burst = 6
+	fake := &casFakeGitea{t: t, fileSHA: 1, advanceRemaining: burst}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "hw282org", "catalyst-tenant", srv.URL)
+	err := c.CommitFiles(context.Background(), "main", "day-2: install wordpress", map[string]string{
+		casTrackedFile: "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - app-wordpress.yaml\n",
+	})
+	if err != nil {
+		t.Fatalf("CommitFiles must converge once the finite seed burst quiets (the #5305 post-fix shape), got: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	// One losing POST per competing commit, then one winning POST.
+	if fake.postCount != burst+1 {
+		t.Errorf("expected %d POSTs (%d CAS losses over the seed burst + 1 win), got %d", burst+1, burst, fake.postCount)
+	}
+	if fake.postCount > commitAttemptsMax {
+		t.Errorf("a %d-commit seed burst exhausted the %d-attempt budget — the funnel would drop the purchased app (#5305)", burst, commitAttemptsMax)
+	}
+	if want := fmt.Sprintf("filesha-%d", fake.fileSHA); fake.lastAcceptedSHA != want {
+		t.Errorf("winning batch carried sha %q, want the CURRENT head's %q — the retry did not rebuild against the advanced head", fake.lastAcceptedSHA, want)
+	}
+}


### PR DESCRIPTION
Refs #5305

## Symptom (live, hw282 2026-07-21)
A funnel customer's PURCHASED app never deployed into its Org vcluster:
`https://wordpress.<slug>.omani.homes/` → 404; the Org namespace held only
coredns + vcluster-0, and the `catalyst-tenant-<slug>-apps` Kustomization was
Ready=True but its inventory was just Namespace + NetworkPolicies — no app pod.
The funnel's commit of `app-wordpress.yaml` + its `vcluster/apps/kustomization.yaml`
entry to the per-Org `<slug>/catalyst-tenant` repo lost the compare-and-swap on
every attempt and was dropped.

## Root cause — the org-controller was a CONTINUOUS writer, not a bounded one
The per-Org repo has two writers on the same `main` HEAD: the funnel cart-install
(batch ChangeFiles with per-file SHA preconditions) and the organization-controller
(per-file `PutFile` burst in Reconcile step 3, including the shared #5104
`vcluster/apps/kustomization.yaml` merge-write).

`#5234`/`#5235` already made the funnel's commit a genuine per-attempt CAS
(re-read + re-merge every retry) and widened the budget 5→10 attempts with a 4s
backoff cap. That was necessary but not sufficient: **a bigger fixed retry window
still cannot out-run an *unbounded* competing writer.** And the org-controller was
unbounded:

- `SetupWithManager` `For()`s the Organization with the **default (all-events)
  event filter**, and `patchStatus` did an **unconditional `Status().Update`**
  whose Ready condition stamped `LastTransitionTime = now()` on every pass.
- So `desired != live` on every reconcile → the controller wrote status → the
  status write re-enqueued **this same reconcile** from its own output → a
  **sub-second hot loop** the entire time the Org provisioned.
- Each pass re-ran step-3's per-Org repo PutFile burst, continuously moving the
  branch HEAD and re-invalidating the funnel's in-flight per-file SHA on the
  shared index. The funnel's finite 10-attempt / ~18s budget was consumed and it
  returned `ref-race persisted after 10 attempts` — a terminal drop (not the
  parkable `#4404` "Gitea not ready" race).

The manifest render is deterministic (no `time.Now`/rand in `gitops.Render`), so
after the first seed the burst is otherwise byte-equal — the *hot loop*, not the
content, is what made the writer continuous.

## Fix — smallest change that removes the unbounded-loser condition
Chosen because the two writers are in **different processes** (an in-process
lease can't serialize them), a separate-subtree split still shares the ref lock
and needs a tree-layout migration, and the #5104 self-heal is guarded by existing
tests — so the cleanest lever is to make the **org-controller's writes bounded**,
i.e. converge-idempotent (option c).

1. **Converge-idempotent status write** (the root-cause fix). Carry each
   condition's `LastTransitionTime` forward when its `(Status,Reason,Message)` is
   unchanged, then **skip `Status().Update` when the status is byte-equal** to
   the live one. The controller re-fires only on a real state change or the
   explicit 30s provisioning requeue → its per-Org repo writes collapse to a
   **finite seed burst** the funnel's CAS budget straddles.
2. **Soft-skip a concurrent-writer CAS loss** on a per-Org repo write. A 409
   ref-lock / 422 sha-mismatch means the funnel — the authoritative shared-index
   owner — converged; that's the desired end state, not a controller error. Log +
   `continue` instead of failing the whole reconcile (which re-bursted the entire
   PutFile set on the requeue). A genuine write failure (auth / malformed
   manifest / repo gone) still fails the reconcile.

The #5104 merge-heal + never-clobber behavior is untouched; its tests
(`perorg_apps_kustomization_merge_5104_test.go` /
`perorg_hostapps_kustomization_merge_5104_test.go`) still pass.

## Tests
- `perorg_repo_hotloop_5305_test.go`
  - a steady-state reconcile is a genuine no-op: **stable object resourceVersion**
    (no self-triggering status write), unchanged Ready `LastTransitionTime` (no
    churn), and **zero additional Gitea file writes** (no re-burst);
  - a concurrent-writer CAS loss (injected one-shot 409) **soft-skips** — no
    `GitopsWriteFailed`, no error — and self-heals on the next reconcile.
  - Both **fail without the fix** (resourceVersion 1001→1002; Org parked at
    `GitopsWriteFailed`) and **pass with it** — verified by reverting each hunk.
- `github/client_hotloop_5305_test.go`: the funnel client **converges against a
  finite multi-commit seed burst** (the bounded post-#5305 shape) within the
  attempt budget — complements the existing `PermanentlyAdvancing…_5234` test
  that pins that an *unbounded* writer exhausts (the pre-fix hw282 condition).

`go test ./...` + `go build ./...` green in both touched modules
(`core/controllers/organization`, `core/services/provisioning`); `go vet` clean.

## Deploy / lockstep
No chart or microservice version bump: the org-controller image is SHA-pinned
(`REPLACE_WITH_SHA`), so CI tags the deploy image from this commit. The Blueprint
version-lockstep gate is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)