### PR TITLE
fix(marketplace): render live provisioning-stage timeline in the funnel launch interstitial (row 86)

### DIFF
--- a/core/marketplace/playwright/customer-journey.spec.ts
+++ b/core/marketplace/playwright/customer-journey.spec.ts
@@ -897,4 +897,119 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     await expect(page.getByRole('heading', { name: /Something went wrong/i }))
       .toBeVisible({ timeout: 5_000 })
   })
+
+  // #3860 / UAT row 86 — the interstitial must render a LIVE provisioning
+  // timeline that advances through the backend's named stages, not an
+  // indefinite generic spinner. The stage names + states come verbatim from
+  // GET /api/provisioning/tenant/<id> (store.Provision.Steps): Creating tenant
+  // → Committing manifests to Git → Provisioning vCluster → Deploying <app> →
+  // Configuring TLS certificates → Running health checks.
+  test('21 launching interstitial renders the named provisioning-stage timeline (row 86)', async ({ page }) => {
+    // Host stays unreachable so the interstitial does NOT forward — we hold on
+    // the page and observe the timeline the status poll paints.
+    await page.route('**/api/provisioning/console-ready**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ready: false }) }),
+    )
+    // Per-stage status: three stages done, the vCluster stage running, the rest
+    // pending — exactly the shape the workflow emits mid-provision.
+    await page.route('**/api/provisioning/tenant/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'prov-1',
+          tenant_id: 'tenant-1',
+          status: 'provisioning',
+          progress: 33,
+          steps: [
+            { name: 'Creating tenant', status: 'completed' },
+            { name: 'Committing manifests to Git', status: 'completed' },
+            { name: 'Provisioning vCluster', status: 'running' },
+            { name: 'Deploying WordPress', status: 'pending' },
+            { name: 'Configuring TLS certificates', status: 'pending' },
+            { name: 'Running health checks', status: 'pending' },
+          ],
+        }),
+      }),
+    )
+
+    const params = new URLSearchParams({
+      host: 'https://console.demo.omani.works',
+      token: 'mock-session-jwt',
+      next: '/jobs',
+      tenant: 'tenant-1',
+    })
+    await page.goto('/launching?' + params.toString())
+
+    // The timeline renders — with each backend-named stage present.
+    const timeline = page.locator('[data-testid="provisioning-timeline"]')
+    await expect(timeline).toBeVisible({ timeout: 8_000 })
+    for (const name of [
+      'Creating tenant',
+      'Committing manifests to Git',
+      'Provisioning vCluster',
+      'Deploying WordPress',
+      'Configuring TLS certificates',
+      'Running health checks',
+    ]) {
+      await expect(timeline.getByText(name, { exact: true })).toBeVisible()
+    }
+    // Honest per-stage state: completed stages carry data-status=completed, the
+    // active one is running, later ones are still pending (no premature green).
+    await expect(page.locator('[data-testid="provisioning-stage"][data-status="completed"]')).toHaveCount(2)
+    await expect(page.locator('[data-testid="provisioning-stage"][data-status="running"]')).toContainText('Provisioning vCluster')
+    await expect(page.locator('[data-testid="provisioning-stage"][data-status="pending"]')).toHaveCount(3)
+    // Host not ready → we have NOT forwarded off the marketplace origin.
+    expect(page.url(), 'stays on the marketplace-origin /launching page').toContain('/launching')
+  })
+
+  test('22 launching interstitial surfaces WHICH stage failed on a terminal backend failure (honest, no infinite spinner)', async ({ page }) => {
+    // Host stays unreachable — a spinner-forever bug would ride out the full
+    // timeout here. The honest behaviour is to STOP the instant the backend
+    // reports a terminal failure and name the stage that broke.
+    await page.route('**/api/provisioning/console-ready**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ready: false }) }),
+    )
+    await page.route('**/api/provisioning/tenant/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'prov-1',
+          tenant_id: 'tenant-1',
+          status: 'failed',
+          steps: [
+            { name: 'Creating tenant', status: 'completed' },
+            { name: 'Committing manifests to Git', status: 'completed' },
+            { name: 'Provisioning vCluster', status: 'completed' },
+            { name: 'Deploying WordPress', status: 'failed', message: 'HelmRelease wordpress not ready: install retries exhausted' },
+            { name: 'Configuring TLS certificates', status: 'pending' },
+            { name: 'Running health checks', status: 'pending' },
+          ],
+        }),
+      }),
+    )
+
+    const params = new URLSearchParams({
+      host: 'https://console.demo.omani.works',
+      token: 'mock-session-jwt',
+      next: '/jobs',
+      tenant: 'tenant-1',
+    })
+    await page.goto('/launching?' + params.toString())
+
+    // Terminal failure surfaces an honest heading — not a perpetual spinner.
+    await expect(page.getByRole('heading', { name: /Provisioning didn't finish/i }))
+      .toBeVisible({ timeout: 8_000 })
+    // The failed stage renders red (data-status=failed) and names itself.
+    const failed = page.locator('[data-testid="provisioning-stage"][data-status="failed"]')
+    await expect(failed).toHaveCount(1)
+    await expect(failed).toContainText('Deploying WordPress')
+    await expect(failed).toContainText(/install retries exhausted/i)
+    // No premature success: the completed-before-failure stages stayed
+    // completed, but nothing claims the whole provision succeeded, and we did
+    // NOT forward to the console.
+    await expect(page.getByRole('heading', { name: /Your Organization is ready/i })).toHaveCount(0)
+    expect(page.url(), 'stays on the marketplace-origin /launching page').toContain('/launching')
+  })
 })

--- a/core/marketplace/src/components/LaunchingStep.svelte
+++ b/core/marketplace/src/components/LaunchingStep.svelte
@@ -38,10 +38,33 @@
   // restriction in the way at all.
 
   import { API_BASE } from '../lib/config';
+  import ProvisioningTimeline from './ProvisioningTimeline.svelte';
+  import type { ProvisionStep } from '../lib/api';
 
-  type Phase = 'provisioning' | 'forwarding' | 'timeout' | 'error';
+  type Phase = 'provisioning' | 'forwarding' | 'timeout' | 'error' | 'failed';
   let phase = $state<Phase>('provisioning');
   let elapsedMs = $state(0);
+
+  // #3860 / UAT row 86 — live provisioning-stage timeline.
+  //
+  // While this interstitial waits for the per-Org console HOST to become
+  // reachable (the console-ready probe below), it ALSO polls the provisioning
+  // service for the backend workflow's per-stage status and renders it, so the
+  // customer watches named stages advance (Creating tenant → Committing
+  // manifests → Provisioning vCluster → Deploying <app> → TLS → Health)
+  // instead of a bare, indefinite spinner. Host-readiness stays the forward
+  // trigger (the host's async DNS/TLS/HTTPRoute can still be landing after the
+  // workflow itself completes — #4273/#5205); the timeline is the honest
+  // progress surface during that wait. A TERMINAL backend failure short-
+  // circuits the wait and shows WHICH stage failed rather than spinning out
+  // the full timeout.
+  let stages = $state<ProvisionStep[]>([]);
+  let provisionStatus = $state<string>('');
+  const STATUS_POLL_MS = 2000;
+  let statusTimer: ReturnType<typeof setTimeout> | null = null;
+  let orgId: string | null = null;
+
+  const failedStage = $derived(stages.find((s) => s.status === 'failed') ?? null);
 
   // Polling schedule — fast at first (route often lands inside ~20-40s) then
   // backs off. Bounded by TIMEOUT_MS so a genuinely stuck provision surfaces a
@@ -57,6 +80,13 @@
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
   let tickTimer: ReturnType<typeof setInterval> | null = null;
   let cancelled = false;
+  // Terminal-failure flag. Kept as a PLAIN (non-reactive) let — NOT $state —
+  // deliberately: the poll guards below run synchronously inside start(),
+  // which the mount $effect invokes. Reading a $state (e.g. `phase`) there
+  // would make the effect re-subscribe and re-run whenever that state changed,
+  // resetting the whole interstitial in a loop. `terminated` mirrors
+  // `cancelled` (also plain) so the guards never re-trigger the effect.
+  let terminated = false;
 
   interface LaunchParams {
     host: string;   // full origin, e.g. https://console.abc.omani.trade
@@ -98,6 +128,23 @@
 
   let params = $state<LaunchParams | null>(null);
 
+  // Resolve the Org id (tenant_id) to poll provisioning status for. Prefer the
+  // `tenant` query param the funnel threads through consoleLaunchHref /
+  // Layout's inline launch; fall back to the id setActiveOrg persisted in
+  // localStorage before this redirect. Absent → no timeline (the interstitial
+  // degrades to spinner + host-readiness wait, never worse than before).
+  function resolveOrgId(): string | null {
+    if (typeof window === 'undefined') return null;
+    const fromQuery = (new URLSearchParams(window.location.search).get('tenant') || '').trim();
+    if (fromQuery) return fromQuery;
+    try {
+      const stored = (localStorage.getItem('org-active-org') || '').trim();
+      return stored || null;
+    } catch {
+      return null;
+    }
+  }
+
   // Probe the per-Org console's readiness via the marketplace's OWN
   // same-origin proxy (#5205). Unlike the retired cross-origin
   // `fetch(console.<slug>/healthz, {mode:'no-cors'})` — whose opaque Response
@@ -127,6 +174,42 @@
     }
   }
 
+  // Poll the provisioning service for the backend workflow's per-stage status
+  // (#3860). Tolerant like probeReady: a 404 (the provision row not created
+  // yet) or any network/parse error is swallowed and retried — we keep the
+  // last-known stages and keep polling. Contract (store.Provision):
+  //   status ∈ pending | provisioning | completed | failed
+  //   steps[].status ∈ pending | running | completed | failed
+  // A terminal `failed` stops the wait and surfaces which stage broke;
+  // `completed` does NOT forward here — the console host's DNS/TLS/HTTPRoute
+  // can still be landing, so forwarding stays gated on the readiness probe.
+  async function pollStatusOnce(id: string) {
+    if (cancelled || terminated) return;
+    try {
+      const res = await fetch(
+        `${API_BASE}/provisioning/tenant/${encodeURIComponent(id)}`,
+        { method: 'GET', cache: 'no-store' },
+      );
+      if (res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | { status?: string; steps?: ProvisionStep[] }
+          | null;
+        if (data && Array.isArray(data.steps)) stages = data.steps;
+        if (data && typeof data.status === 'string') provisionStatus = data.status;
+        if (data?.status === 'failed') {
+          terminated = true;
+          phase = 'failed';
+          cleanup();
+          return;
+        }
+      }
+    } catch {
+      // Swallow — keep last-known stages and retry on the next tick.
+    }
+    if (cancelled || terminated) return;
+    statusTimer = setTimeout(() => pollStatusOnce(id), STATUS_POLL_MS);
+  }
+
   function forward(p: LaunchParams) {
     phase = 'forwarding';
     cleanup();
@@ -139,14 +222,16 @@
   }
 
   async function pollOnce(p: LaunchParams) {
-    if (cancelled) return;
+    if (cancelled || terminated) return;
     if (Date.now() - startedAt >= TIMEOUT_MS) {
       phase = 'timeout';
       cleanup();
       return;
     }
     const ready = await probeReady(p.host);
-    if (cancelled) return;
+    // A terminal provisioning failure (surfaced by pollStatusOnce) wins over a
+    // late host-ready — never forward into a dead provision.
+    if (cancelled || terminated) return;
     if (ready) {
       forward(p);
       return;
@@ -160,6 +245,7 @@
   function cleanup() {
     if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
     if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+    if (statusTimer) { clearTimeout(statusTimer); statusTimer = null; }
   }
 
   function start() {
@@ -167,11 +253,18 @@
     params = p;
     if (!p) { phase = 'error'; return; }
     cancelled = false;
+    terminated = false;
     phase = 'provisioning';
     startedAt = Date.now();
     elapsedMs = 0;
+    stages = [];
+    provisionStatus = '';
+    orgId = resolveOrgId();
     tickTimer = setInterval(() => { elapsedMs = Date.now() - startedAt; }, 1000);
     pollOnce(p);
+    // Kick off the provisioning-stage timeline poll in parallel with the
+    // host-readiness probe. Only when we know which Org to poll.
+    if (orgId) pollStatusOnce(orgId);
   }
 
   function retry() {
@@ -200,7 +293,12 @@
 <div class="mx-auto max-w-lg py-12">
   <div class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 text-center">
     {#if phase === 'provisioning' || phase === 'forwarding'}
-      <div class="mx-auto mb-5 h-14 w-14 animate-spin rounded-full border-4 border-[var(--color-accent)] border-t-transparent"></div>
+      <!-- Bare spinner only until the first stage payload lands; once we have
+           named stages the timeline (with its own per-stage running spinner)
+           is the progress surface. -->
+      {#if stages.length === 0}
+        <div class="mx-auto mb-5 h-14 w-14 animate-spin rounded-full border-4 border-[var(--color-accent)] border-t-transparent"></div>
+      {/if}
       <h1 class="text-xl font-bold text-[var(--color-text-strong)]">
         {phase === 'forwarding' ? 'Opening your console…' : 'Setting up your console…'}
       </h1>
@@ -208,11 +306,56 @@
         We're provisioning your Organization's secure address. This usually
         takes under a minute — you'll be redirected automatically.
       </p>
+      {#if stages.length > 0}
+        <div class="mt-6 text-left">
+          <ProvisioningTimeline steps={stages} status={provisionStatus} />
+        </div>
+      {/if}
       {#if phase === 'provisioning' && elapsedMs >= 5000}
         <p class="mt-4 text-xs text-[var(--color-text-dimmer)]">
           Still working… ({elapsedLabel})
         </p>
       {/if}
+    {:else if phase === 'failed'}
+      <!-- Terminal backend failure (#3860). Show WHICH stage failed and STOP —
+           never a premature success, never an indefinite spinner on a dead
+           provision. Forwarding is suppressed (pollOnce/pollStatusOnce bail on
+           phase==='failed'). -->
+      <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--color-danger)]/15">
+        <svg class="h-7 w-7 text-[var(--color-danger)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/>
+        </svg>
+      </div>
+      <h1 class="text-xl font-bold text-[var(--color-text-strong)]">Provisioning didn't finish</h1>
+      <p class="mt-2 text-sm text-[var(--color-text-dim)]">
+        {#if failedStage}
+          Something went wrong at the <span class="font-semibold text-[var(--color-text)]">{failedStage.name}</span> stage.
+        {:else}
+          Something went wrong while setting up your Organization.
+        {/if}
+        Our team has been notified — you can try again or contact support.
+      </p>
+      {#if stages.length > 0}
+        <div class="mt-6 text-left">
+          <ProvisioningTimeline steps={stages} status={provisionStatus} />
+        </div>
+      {/if}
+      <div class="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-center">
+        <button
+          type="button"
+          onclick={retry}
+          data-testid="launching-retry"
+          class="inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--color-accent)] px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-accent-hover)]"
+        >
+          Try again
+        </button>
+        <a
+          href="/checkout"
+          class="inline-flex items-center justify-center gap-2 rounded-xl border border-[var(--color-border)] px-5 py-2.5 text-sm font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-hover)] no-underline"
+        >
+          Back to checkout
+        </a>
+      </div>
     {:else if phase === 'timeout'}
       <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--color-warn)]/15">
         <svg class="h-7 w-7 text-[var(--color-warn)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">

--- a/core/marketplace/src/components/ProvisioningTimeline.svelte
+++ b/core/marketplace/src/components/ProvisioningTimeline.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  // #3860 / UAT row 86 — live provisioning-stage timeline.
+  //
+  // Renders the ordered stages the provisioning service emits for a funnel
+  // Org (core/services/provisioning/handlers/consumer.go): Creating tenant →
+  // Committing manifests to Git → Provisioning vCluster → Installing <dep>
+  // (dependency) → Deploying <app> → Configuring TLS certificates → Running
+  // health checks. Stage NAMES are rendered verbatim from the backend
+  // payload — this component invents none, so dependency/app rows scale with
+  // the real order and the labels always match what the workflow actually
+  // did.
+  //
+  // HONEST STATES ONLY. Each stage renders its real backend status:
+  //   completed → green check      running → accent spinner
+  //   failed    → red cross + why  pending → neutral ring
+  // Nothing shows green until the backend reports `completed`, and a failed
+  // stage renders red and names itself (never a premature success, never an
+  // indefinite spinner on a dead provision).
+  import type { ProvisionStep } from '../lib/api';
+
+  let { steps = [], status = '' }: { steps?: ProvisionStep[]; status?: string } = $props();
+</script>
+
+<ol class="flex flex-col gap-3" data-testid="provisioning-timeline" aria-label="Provisioning progress">
+  {#each steps as step}
+    <li class="flex items-start gap-3" data-testid="provisioning-stage" data-status={step.status}>
+      {#if step.status === 'completed'}
+        <div class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--color-success)]">
+          <svg class="h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+      {:else if step.status === 'failed'}
+        <div class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--color-danger)]">
+          <svg class="h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+      {:else if step.status === 'running'}
+        <div class="mt-0.5 h-6 w-6 shrink-0 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent" aria-hidden="true"></div>
+      {:else}
+        <div class="mt-0.5 h-6 w-6 shrink-0 rounded-full border border-[var(--color-border)]" aria-hidden="true"></div>
+      {/if}
+      <div class="min-w-0">
+        <span
+          class="block text-sm {step.status === 'failed'
+            ? 'font-medium text-[var(--color-danger)]'
+            : step.status === 'running'
+              ? 'font-medium text-[var(--color-accent)]'
+              : step.status === 'completed'
+                ? 'text-[var(--color-text)]'
+                : 'text-[var(--color-text-dimmer)]'}"
+        >{step.name}</span>
+        {#if step.status === 'failed' && step.message && step.message !== 'ok'}
+          <span class="mt-0.5 block break-words text-xs text-[var(--color-danger)]">{step.message}</span>
+        {/if}
+      </div>
+    </li>
+  {/each}
+</ol>

--- a/core/marketplace/src/layouts/Layout.astro
+++ b/core/marketplace/src/layouts/Layout.astro
@@ -221,6 +221,15 @@ const { title, step = 0 } = Astro.props;
             token: token,
             next: '/jobs',
           });
+          // #3860 / UAT row 86 — pass the active Org id (tenant_id) so the
+          // /launching interstitial can render the live provisioning-stage
+          // timeline (mirrors src/lib/config.ts::consoleLaunchHref). Best-
+          // effort: absent it, the interstitial keeps its spinner + host-
+          // readiness wait.
+          try {
+            var activeOrgId = (localStorage.getItem('org-active-org') || '').trim();
+            if (activeOrgId) launchQs.set('tenant', activeOrgId);
+          } catch (_) {}
           // The marketplace is served at the site root (no Astro `base:`
           // configured), so `/launching` is the interstitial page route. This
           // is an `is:inline` script — NOT processed by Vite — so we use a

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -565,13 +565,25 @@ export interface CheckoutResponse {
 export interface Provision {
   id: string;
   tenant_id: string;
+  // pending | provisioning | completed | failed (store.Provision.Status).
   status: string;
   steps: ProvisionStep[];
+  // 0-100 rollup the provisioning service stamps as steps complete
+  // (store.Provision.Progress). Optional so older payloads still decode.
+  progress?: number;
 }
 
 export interface ProvisionStep {
   name: string;
+  // pending | running | completed | failed (store.ProvisionStep.Status).
   status: string;
+  // Human-readable detail the workflow attaches on completion/failure
+  // (store.ProvisionStep.Message) — e.g. the reason a stage failed.
+  message?: string;
   started_at?: string;
-  completed_at?: string;
+  // Wire field is `done_at` (store.ProvisionStep.DoneAt) — NOT completed_at.
+  // The operator console (core/console) already decodes done_at; the
+  // marketplace type was drifted and is corrected here so the launch
+  // interstitial reads the real field.
+  done_at?: string;
 }

--- a/core/marketplace/src/lib/config.ts
+++ b/core/marketplace/src/lib/config.ts
@@ -98,6 +98,26 @@ function readActiveConsoleHost(): string | null {
 }
 
 /**
+ * localStorage key for the active Org's id (the tenant_id the provisioning
+ * service keys on). `setActiveOrg` (api.ts) stamps this right after
+ * `createTenant` / on Stripe return — BEFORE the launch redirect fires — so
+ * the `/launching` interstitial can poll `GET /api/provisioning/tenant/<id>`
+ * to render the live provisioning-stage timeline (#3860 / UAT row 86).
+ */
+export const ACTIVE_ORG_ID_KEY = 'org-active-org';
+
+/** Read the persisted active-Org id (tenant_id). Null in SSR or when unset. */
+function readActiveOrgId(): string | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const id = localStorage.getItem(ACTIVE_ORG_ID_KEY);
+    return id && id.trim() ? id.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Derive the customer console URL from the current marketplace host AND the
  * active tenant slug (if known).
  *
@@ -311,11 +331,14 @@ export const consoleHandoffHref = (
  * placed in any URL — it stays in client storage.
  *
  * Pass `opts.slug` to override the active-org-slug read from localStorage.
+ * Pass `opts.tenant` to override the active-Org id (tenant_id) the
+ * interstitial polls for the provisioning-stage timeline; when omitted it
+ * falls back to the id `setActiveOrg` stamped before this redirect (#3860).
  */
 export const consoleLaunchHref = (
   token: string,
   refreshToken?: string | null,
-  opts?: { slug?: string | null; next?: string },
+  opts?: { slug?: string | null; next?: string; tenant?: string | null },
 ): string => {
   const base = opts && opts.slug !== undefined
     ? deriveConsoleURL(opts.slug)
@@ -328,6 +351,16 @@ export const consoleLaunchHref = (
   // Sovereign per-Org (or operator) console — route through the marketplace-
   // origin interstitial that waits for the host to be reachable.
   const params = new URLSearchParams({ host: base, token, next });
+  // #3860 / UAT row 86 — thread the Org id (tenant_id) so the interstitial
+  // can poll GET /api/provisioning/tenant/<id> and render the live
+  // Creating tenant → Committing manifests → Provisioning vCluster →
+  // Deploying <app> → TLS → Health stage timeline instead of a bare spinner.
+  // Prefer the caller-supplied id, else the one setActiveOrg persisted before
+  // this redirect. Absent (e.g. a returning user whose id was cleared) the
+  // interstitial degrades to the spinner + host-readiness wait — never worse
+  // than today.
+  const tenant = (opts && opts.tenant) || readActiveOrgId();
+  if (tenant) params.set('tenant', tenant);
   return `${BASE}launching?${params.toString()}`;
 };
 


### PR DESCRIPTION
## Problem (UAT row 86 / live-confirmed hw282)

After a customer clicks Launch/redeem in the marketplace funnel, the post-Launch
interstitial (`core/marketplace/src/components/LaunchingStep.svelte`) showed only
a generic spinner — "Setting up your console… Still working… (Ns)" — with **zero
stage/timeline rendering** while the Organization provisioned. The acceptance
walk requires the progress timeline to advance through named stages to Done.

The **backend already exposes the per-stage data** — this was purely a
frontend gap. Verified end-to-end before writing any FE code.

## Backend stage contract rendered against

`core/services/provisioning`:

- Endpoint: `GET /api/provisioning/tenant/<id>` — gateway public route
  (`core/services/gateway/main.go`) → provisioning-service handler
  `GetByTenant` → returns `store.Provision` JSON.
- `Provision`: `{ id, tenant_id, status, steps[], progress }` where overall
  `status ∈ { pending, provisioning, completed, failed }`.
- `steps[]` (`store.ProvisionStep`): `{ name, status, message, started_at,
  done_at }` where step `status ∈ { pending, running, completed, failed }`.
- Ordered stage names the workflow emits (`handlers/consumer.go`):
  **Creating tenant → Committing manifests to Git → Provisioning vCluster →
  Installing `<dep>` (dependency) → Deploying `<app>` → Configuring TLS
  certificates → Running health checks**, then overall `completed` at 100%.

Stage **names are rendered verbatim from the payload** — none are invented — so
dependency/app rows scale with the real order and always match what the workflow
actually did. This maps 1:1 onto the row-86 walk (Creating Org → Committing
manifests → Provisioning vCluster → Deploying WordPress → TLS → Health → Done).

## What changed (frontend only)

- **New `ProvisioningTimeline.svelte`** — renders each stage with its real
  state: completed = green check, running = accent spinner, failed = red cross
  **+ the failure reason**, pending = neutral ring. Reuses the existing console
  design-system CSS vars and the `CheckoutStep` status-pill vocabulary (no new
  visual primitives).
- **`LaunchingStep.svelte`** polls the status endpoint in parallel with the
  existing #5205 console-ready host probe and renders the timeline. Host
  readiness stays the **forward trigger** (the per-Org host's DNS/TLS/HTTPRoute
  land asynchronously after the workflow itself completes — #4273/#5205); the
  timeline is the honest progress surface during that wait.
- **Honest-failure rendering (included):** on a terminal `Provision.status =
  failed` the interstitial **stops and names WHICH stage failed** (red, with the
  step message) — never a premature green, never an indefinite spinner on a dead
  provision. Forwarding is suppressed on terminal failure.
- The Org id (`tenant_id`) is threaded to `/launching` via `consoleLaunchHref`
  and Layout's inline launch, falling back to the `setActiveOrg`-stamped
  localStorage id. Absent it, the interstitial degrades to the prior spinner +
  host-readiness wait (never worse than today).
- Corrected the marketplace `ProvisionStep` type to the real wire fields
  (`message`, `done_at`) — it had drifted to a non-existent `completed_at`;
  the operator console (`core/console`) already decodes `done_at`.
- Poll guards use plain (non-reactive) `let` flags: reading the `$state` `phase`
  in a guard executed synchronously inside the mount `$effect` made the effect
  re-subscribe to `phase` and reset the interstitial in a loop whenever `phase`
  changed (caught by the failed-state test).

## Gates

- `cd core/marketplace && npm install && npm run build` — green (incl. the
  `check-served-domain-hygiene` postbuild gate).
- `customer-journey.spec.ts` extended (tests 21/22): the named-stage timeline
  renders + advances (completed/running/pending honest), and a terminal failure
  surfaces the failed stage honestly without forwarding. Full spec: **22 passed**.
  The 1 remaining failure (`05b` redeem owner-redirect) is **pre-existing** —
  reproduced identically on the pristine baseline, and this PR does not touch
  `redeem.astro`.

Refs #3860

🤖 Generated with [Claude Code](https://claude.com/claude-code)