### PR TITLE
fix(cutover): step-03 prewarm proxy-DOWN direct-first routing, deadline preserved (0.1.149)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -964,7 +964,7 @@ spec:
       # missing one and FATALing with the full missing list otherwise (knob
       # helmReadinessProbe.pinPresenceGate). Contract Case 68 runs the
       # extractor against this very slot corpus at PR time.
-      version: 0.1.148
+      version: 0.1.149
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.148
+  version: 0.1.149
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,27 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.149 (#5095 round 2, Refs #5093 #5298 — step-03 harbor-prewarm proxy-DOWN
+# DIRECT-FIRST routing. The 0.1.136 direct-source fallback (below) fires only
+# AFTER the mothership-proxy `skopeo copy` returns non-zero, and that proxy copy
+# is bounded ONLY by the #3944 --command-timeout (skopeoCommandTimeout, 1200s).
+# When the mothership Harbor proxy is unreachable for the WHOLE step (a
+# sustained transit hole toward the mothership /24, not a brief flap), EVERY
+# proxy-sourced image independently burns that timeout probing the dead proxy
+# BEFORE the fast direct upstream is tried — the per-image "proxy timeout tax"
+# that dragged the direct-fallback wave to ~100 min for 140 images and tripped
+# the step deadline (raised separately in #5298/#5299). Round 2 adds a ONE-TIME
+# cheap HTTP reachability probe of the mothership proxy at the top of the copy
+# wave (only when the wave has proxy-sourced refs); on an unreachable proxy the
+# step latches proxy-DOWN and copy_one tries the DIRECT upstream FIRST for
+# proxy-sourced refs (proxy kept as the secondary), so the wave runs at full
+# parallel speed with no timeout tax. The latch also trips adaptively the moment
+# a proxy leg fails while its direct sibling succeeds (the hw255 "proxy bad,
+# direct good" signature), catching a proxy that dies mid-wave after the probe
+# passed. Source selection ONLY — the DEST path (host-swap, path preserved) is
+# untouched, so step-04/07/08 resolve the identical LOCAL artifact and the
+# sovereignty guarantee (every image in local Harbor before the deny-egress
+# hold) is intact; FATAL-on-any-failure is preserved. Template 03 + values
+# prewarm.proxyDownDirectFirst (enabled/probeTimeoutSeconds/probeAttempts).
 # 0.1.148 (#5298, Refs #5095 #3379 — step-03 harbor-prewarm DIRECT-fallback
 # deadline. hw281 (2026-07-20) stamped step-03 failed while it was STILL
 # settling (log "Phase A progress: 100/140 settled (still copying)"): the
@@ -2554,7 +2576,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.148
+version: 0.1.149
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -244,6 +244,34 @@ data:
             value: {{ .Values.prewarm.proxyCopyAttempts | default 6 | quote }}
           - name: PREWARM_PROXY_BACKOFF_BASE_SECONDS
             value: {{ .Values.prewarm.proxyBackoffBaseSeconds | default 30 | quote }}
+          # #5095 round 2 (Refs #5093 #5298) — proxy-DOWN direct-first routing.
+          # The 0.1.136 direct-source fallback fires only AFTER the proxy-source
+          # `skopeo copy` returns non-zero, and that proxy copy is bounded ONLY by
+          # the #3944 --command-timeout (PREWARM_SKOPEO_TIMEOUT, 1200s). When the
+          # mothership Harbor proxy is unreachable for the WHOLE step (a sustained
+          # transit hole toward the mothership /24, not a brief flap — hw281 dep
+          # observed the proxy dead for the full prewarm), EVERY proxy-sourced
+          # image independently burns that timeout on the dead proxy BEFORE the
+          # fast direct upstream is even tried — the per-image "proxy timeout tax"
+          # that dragged the direct-fallback wave to ~100 min for 140 images and
+          # tripped the step deadline (raised separately in #5298/#5299). This
+          # env drives a ONE-TIME cheap HTTP reachability probe of the mothership
+          # proxy at the top of the copy wave; on an unreachable proxy the step
+          # latches proxy-DOWN and copy_one tries the DIRECT upstream FIRST for
+          # proxy-sourced refs (proxy kept as the secondary), so the wave runs at
+          # full parallel speed with no per-image timeout tax. The latch also
+          # trips adaptively the moment any in-flight proxy leg fails, catching a
+          # proxy that dies mid-wave (after the probe passed). Source selection
+          # only — the DEST path (host-swap, path preserved) is untouched, so
+          # step-04/07/08 resolve the identical LOCAL artifact and the
+          # sovereignty guarantee (every image in local Harbor before deny-egress)
+          # is intact. Default true; set false to keep strict proxy-first.
+          - name: PROXY_DIRECT_FIRST_ENABLED
+            value: {{ .Values.prewarm.proxyDownDirectFirst.enabled | quote }}
+          - name: PROXY_PROBE_TIMEOUT_SECONDS
+            value: {{ .Values.prewarm.proxyDownDirectFirst.probeTimeoutSeconds | default 8 | quote }}
+          - name: PROXY_PROBE_ATTEMPTS
+            value: {{ .Values.prewarm.proxyDownDirectFirst.probeAttempts | default 3 | quote }}
           # #5204 (Refs #5209 #3379) — Phase A4 Crossplane xpkg package warm.
           # The upstream/mothership/registry-path literals come from the SAME
           # .Values.crossplaneProviderPivot block step-11 reads, so the warm
@@ -777,6 +805,10 @@ data:
             # short transit flap toward the mothership can't exhaust it).
             : "${PREWARM_PROXY_COPY_ATTEMPTS:=6}"
             : "${PREWARM_PROXY_BACKOFF_BASE_SECONDS:=30}"
+            # #5095 round 2 — proxy-DOWN direct-first routing defaults.
+            : "${PROXY_DIRECT_FIRST_ENABLED:=true}"
+            : "${PROXY_PROBE_TIMEOUT_SECONDS:=8}"
+            : "${PROXY_PROBE_ATTEMPTS:=3}"
             cpdir="/tmp/prewarm-copies"
             rm -rf "${cpdir}"; mkdir -p "${cpdir}"
             echo "[harbor-prewarm] pushing ${count} image(s) with parallelism=${PREWARM_PARALLELISM}"
@@ -1040,6 +1072,32 @@ data:
                   max_attempts="${PREWARM_COPY_ATTEMPTS}"
                 fi
                 while [ "${attempt}" -le "${max_attempts}" ]; do
+                  # #5095 round 2 — proxy-DOWN DIRECT-FIRST short-circuit. When the
+                  # ref is mothership-proxy-sourced, HAS a mechanically-derived
+                  # direct upstream, AND the proxy is latched DOWN for this step
+                  # (the upfront probe found it unreachable, or a proxy leg earlier
+                  # this wave failed while its direct sibling succeeded), try the
+                  # DIRECT upstream FIRST and skip the dead proxy entirely on
+                  # success — so no image burns the 1200s --command-timeout probing
+                  # the dead proxy before the fast direct path is even tried (round
+                  # 1 shipped the fallback but always AFTER the timed-out proxy
+                  # leg — the per-image "proxy timeout tax" that dragged the wave to
+                  # ~100 min for 140 images). Re-checked every attempt so a latch
+                  # flipped by another worker reorders THIS image's remaining
+                  # attempts too. The DEST ref is identical (host-swap, path
+                  # preserved), so step-04/07/08 resolve the same LOCAL artifact.
+                  # On a direct-first MISS we fall straight through to the round-1
+                  # proxy-first path below (the proxy might have just recovered).
+                  if [ -n "${fb_up}" ] && [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ] && [ -f "${cpdir}/.proxy_down" ]; then
+                    echo "[harbor-prewarm] proxy latched DOWN; direct-first ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5095 round 2)" >>"${cpdir}/${slug}.log"
+                    if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" "${cpdir}/${slug}.log"; then
+                      rc=0
+                      src_used="${fb_up}"
+                      break
+                    else
+                      rc=$?
+                    fi
+                  fi
                   echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt}/${max_attempts}" >>"${cpdir}/${slug}.log"
                   if prewarm_skopeo_copy "${up}" "${sc}" "${lref}" "${cpdir}/${slug}.log"; then
                     rc=0
@@ -1062,6 +1120,16 @@ data:
                     if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" "${cpdir}/${slug}.log"; then
                       rc=0
                       src_used="${fb_up}"
+                      # #5095 round 2 — the proxy leg failed but its direct sibling
+                      # SUCCEEDED: a precise "proxy bad, direct good" signal (the
+                      # hw255 signature). Latch the proxy DOWN so the rest of the
+                      # wave skips proxy-first via the short-circuit above and pays
+                      # no further timeout tax. Fires ONLY when the proxy was tried
+                      # (proxy_src=1), never on a broad outage where direct also
+                      # fails. Idempotent touch, safe under the parallel fan-out.
+                      if [ "${proxy_src}" -eq 1 ] && [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ]; then
+                        touch "${cpdir}/.proxy_down" 2>/dev/null || true
+                      fi
                       break
                     else
                       rc=$?
@@ -1109,6 +1177,39 @@ data:
               fi
             }
 
+            # #5095 round 2 — ONE-TIME mothership-proxy reachability probe.
+            # A cheap anonymous `GET https://${MOTHERSHIP_HOST}/v2/` (Harbor's
+            # registry API returns 401 for anonymous, 200/403 for public proxy
+            # projects — ANY of those proves the path is alive). A transit hole
+            # toward the mothership /24 yields curl exit!=0 / HTTP 000. On an
+            # unreachable proxy the step latches `${cpdir}/.proxy_down`, which
+            # flips copy_one to DIRECT-FIRST for proxy-sourced refs so no image
+            # burns the 1200s --command-timeout on the dead proxy before the
+            # fast direct upstream is tried (#5095 round 1 shipped that fallback
+            # but always AFTER the timed-out proxy leg). The probe is bounded
+            # (PROXY_PROBE_ATTEMPTS × PROXY_PROBE_TIMEOUT_SECONDS, default
+            # 3 × 8s = 24s worst case — negligible against a multi-image wave)
+            # and NEVER fatal: a down proxy must not fail the step, the direct
+            # path covers it. Re-probes each Job run (cpdir is wiped above).
+            probe_mothership_proxy() {
+              [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ] || { echo "[harbor-prewarm] proxy-DOWN direct-first routing DISABLED (PROXY_DIRECT_FIRST_ENABLED=${PROXY_DIRECT_FIRST_ENABLED:-}); strict proxy-first ordering (#5095)"; return 0; }
+              [ -n "${MOTHERSHIP_HOST:-}" ] || return 0
+              _mp_code=""
+              _mp_i=1
+              while [ "${_mp_i}" -le "${PROXY_PROBE_ATTEMPTS}" ]; do
+                _mp_code=$(curl -sk -o /dev/null -w '%{http_code}' -m "${PROXY_PROBE_TIMEOUT_SECONDS}" "https://${MOTHERSHIP_HOST}/v2/" 2>/dev/null || true)
+                case "${_mp_code}" in
+                  200|401|403)
+                    rm -f "${cpdir}/.proxy_down" 2>/dev/null || true
+                    echo "[harbor-prewarm] mothership proxy ${MOTHERSHIP_HOST} reachable (HTTP ${_mp_code}, probe ${_mp_i}/${PROXY_PROBE_ATTEMPTS}) — proxy-first ordering (#5095)"
+                    return 0 ;;
+                esac
+                _mp_i=$((_mp_i+1))
+              done
+              touch "${cpdir}/.proxy_down"
+              echo "[harbor-prewarm] mothership proxy ${MOTHERSHIP_HOST} UNREACHABLE after ${PROXY_PROBE_ATTEMPTS} probes (last HTTP ${_mp_code:-none}) — DIRECT-FIRST for proxy-sourced images this step; no per-image proxy timeout tax (#5095). Images still land in LOCAL Harbor via the direct upstream; sovereignty guarantee intact."
+            }
+
             # #4975 PRE-PASS — resolve every enumerated image through the shared
             # coverage map BEFORE the parallel fan-out. Excluded images (xpkg /
             # rancher-k3s / loft-sh-vcluster) are dropped; an image from a
@@ -1141,6 +1242,13 @@ data:
             fi
             count=$(printf '%s\n' ${mirror_work} | grep -c . || true)
             echo "[harbor-prewarm] ${count} mapped image(s) to mirror after resolver filter (parallelism=${PREWARM_PARALLELISM})"
+
+            # #5095 round 2 — probe the mothership proxy ONCE before the fan-out,
+            # but only when this wave actually has mothership-proxy-sourced refs
+            # (all-ghcr provs never dial the proxy, so skip the probe entirely).
+            if [ -n "${MOTHERSHIP_HOST:-}" ] && printf '%s\n' ${mirror_work} | grep -q "^${MOTHERSHIP_HOST}/"; then
+              probe_mothership_proxy
+            fi
 
             # #4994 — real-time progress heartbeat. A bounded, self-stopping
             # background loop prints "N/M settled" every 30s while the fan-out

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3383,4 +3383,75 @@ fi
 if [ "$c68_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5237 round 2: step-03 Phase A2-pins unions the FROZEN local-Gitea bootstrap-kit pins into the chart mirror [fail-loud, toggleable]; step-06 Phase 3a-pin asserts EVERY frozen pin durably present via the in-cluster artifact API before the irreversible strip [top-up-warm, FATAL with full missing list, deadline re-armed]; ONE shared 03b extractor for both + the #5265 Day-2 seam; ${corpus_note})"
 
+# ── Case 69 (#5095 round 2, Refs #5093 #5298): step-03 harbor-prewarm rides out
+# a mothership-proxy that is DOWN for the WHOLE step without paying a per-image
+# "proxy timeout tax" ────────────────────────────────────────────────────────
+# hw281: the mothership Harbor proxy was unreachable for the entire prewarm
+# wave. Round 1 (#5095, Case 60) added a direct-source fallback — but it fires
+# only AFTER the proxy-source `skopeo copy` returns non-zero, and that proxy
+# copy is bounded ONLY by the #3944 --command-timeout (skopeoCommandTimeout,
+# 1200s). So EVERY proxy-sourced image independently burned that timeout probing
+# the dead proxy before the fast direct upstream was tried → the direct-fallback
+# wave crawled to ~100 min for 140 images and tripped the step deadline (raised
+# separately in #5298/#5299). Round 2 must (1) probe the mothership proxy ONCE
+# up front and latch it DOWN when unreachable, (2) then try the DIRECT upstream
+# FIRST for proxy-sourced refs so the dead proxy is never probed per-image, and
+# (3) latch adaptively the moment a proxy leg fails while its direct sibling
+# succeeds (a proxy that dies mid-wave) — all NEVER-fatal (a down proxy must not
+# fail the step; the direct path covers it) and source-selection-ONLY (the local
+# DEST + the sovereignty guarantee are untouched).
+echo "[cutover-contract] Case 69: step-03 proxy-DOWN direct-first routing eliminates the per-image proxy timeout tax when the mothership proxy is unreachable (#5095 round 2)"
+[ -s "$TMP/s03pin.yaml" ] || awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml"
+# (a) the toggle + probe knobs project from values with the right defaults.
+if ! grep -A1 'name: PROXY_DIRECT_FIRST_ENABLED' "$TMP/s03pin.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: step-03 does not project PROXY_DIRECT_FIRST_ENABLED default \"true\" (prewarm.proxyDownDirectFirst.enabled) — the proxy-DOWN direct-first routing is off by default (#5095 round 2)" >&2
+  exit 1
+fi
+if ! grep -qF 'name: PROXY_PROBE_TIMEOUT_SECONDS' "$TMP/s03pin.yaml" || ! grep -qF 'name: PROXY_PROBE_ATTEMPTS' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not project the bounded-probe knobs PROXY_PROBE_TIMEOUT_SECONDS + PROXY_PROBE_ATTEMPTS — the reachability probe is unbounded/unconfigurable (#5095 round 2)" >&2
+  exit 1
+fi
+# (b) a one-time reachability probe of the mothership proxy that latches
+#     .proxy_down when unreachable, and is NEVER fatal (no exit 1 on the down
+#     path — a down proxy must not fail the step).
+if ! grep -qF 'probe_mothership_proxy()' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 has no probe_mothership_proxy function — nothing detects a proxy that is down for the whole step, so every image pays the 1200s timeout tax (#5095 round 2)" >&2
+  exit 1
+fi
+if ! grep -qF 'touch "${cpdir}/.proxy_down"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 never latches .proxy_down — the probe/adaptive signal cannot flip copy_one to direct-first (#5095 round 2)" >&2
+  exit 1
+fi
+# The probe curls the mothership /v2/ and treats a live reply as reachable.
+if ! grep -qF 'https://${MOTHERSHIP_HOST}/v2/' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 probe does not GET https://\${MOTHERSHIP_HOST}/v2/ — it cannot distinguish a reachable proxy from a transit hole (#5095 round 2)" >&2
+  exit 1
+fi
+# (c) copy_one tries the DIRECT upstream FIRST when the proxy is latched down,
+#     gated on the toggle + the .proxy_down latch.
+if ! grep -qF 'proxy latched DOWN; direct-first' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 copy_one has no proxy-DOWN direct-first short-circuit — a dead proxy is still probed per-image before the direct upstream, keeping the timeout tax (#5095 round 2)" >&2
+  exit 1
+fi
+if ! grep -qF '[ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ] && [ -f "${cpdir}/.proxy_down" ]' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 direct-first short-circuit is not gated on BOTH the toggle AND the .proxy_down latch — it would reorder even when the proxy is healthy (rate-limit exposure) or when disabled (#5095 round 2)" >&2
+  exit 1
+fi
+# (d) the probe is invoked only when the wave actually has proxy-sourced refs.
+if ! grep -qF 'grep -q "^${MOTHERSHIP_HOST}/"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 runs the proxy probe unconditionally — an all-ghcr wave that never dials the proxy should skip the probe entirely (#5095 round 2)" >&2
+  exit 1
+fi
+# (e) the round-1 guarantees survive: the direct fallback (Case 60) + the Phase A
+#     FATAL-on-any-failure are both still present (round 2 only reorders sources).
+if ! grep -qF 'prewarm_skopeo_copy "${fb_up}" "${fb_creds}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 lost the round-1 direct-source fallback invocation — round 2 must ADD direct-first, never remove the after-failure fallback (#5095 round 2)" >&2
+  exit 1
+fi
+if ! grep -qF 'failed to push — Sovereign cannot survive ghcr.io deny-egress post-cutover' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A lost the push_fail>0 FATAL — direct-first routing must never waive the completeness guarantee (#5095 round 2)" >&2
+  exit 1
+fi
+echo "  PASS (#5095 round 2: step-03 probes the mothership proxy once [bounded, values-knobbed, never fatal], latches .proxy_down when unreachable, then tries the DIRECT upstream first for proxy-sourced refs — gated on the toggle + latch, probe skipped on an all-ghcr wave, adaptive latch on the proxy-bad/direct-good signal — eliminating the per-image proxy timeout tax while keeping the round-1 after-failure fallback + the Phase A FATAL intact)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -684,6 +684,38 @@ prewarm:
   # existing 3×5s discipline (PREWARM_COPY_ATTEMPTS) unchanged.
   proxyCopyAttempts: 6
   proxyBackoffBaseSeconds: 30
+  # #5095 round 2 (Refs #5093 #5298) — proxy-DOWN direct-first routing. The
+  # 0.1.136 direct-source fallback (proxyCopyAttempts + the mechanical upstream
+  # derivation above) fires only AFTER the proxy-source `skopeo copy` returns
+  # non-zero, and that proxy copy is bounded ONLY by the #3944 --command-timeout
+  # (skopeoCommandTimeout, 1200s). When the mothership Harbor proxy is
+  # unreachable for the WHOLE step — a sustained transit hole toward the
+  # mothership /24, not a brief flap — EVERY proxy-sourced image independently
+  # burns that timeout probing the dead proxy BEFORE the fast direct upstream is
+  # tried. That per-image "proxy timeout tax" dragged the direct-fallback wave to
+  # ~100 min for 140 images and tripped the step deadline (raised separately in
+  # #5298/#5299). This block adds a ONE-TIME, cheap HTTP reachability probe of
+  # the mothership proxy at the top of the copy wave (only when the wave actually
+  # has proxy-sourced refs); on an unreachable proxy the step latches proxy-DOWN
+  # and copy_one tries the DIRECT upstream FIRST for proxy-sourced refs (proxy
+  # kept as the secondary), so the wave runs at full parallel speed with no
+  # timeout tax. The latch also trips adaptively the moment a proxy leg fails
+  # while its direct sibling succeeds (the "proxy bad, direct good" hw255
+  # signature), catching a proxy that dies mid-wave after the probe passed.
+  # Source selection ONLY — the DEST path (host-swap, path preserved) is
+  # untouched, so step-04/07/08 resolve the identical LOCAL artifact and the
+  # sovereignty guarantee (every image in local Harbor before the deny-egress
+  # hold) is intact; FATAL-on-any-failure is preserved (both sources must fail
+  # for an image to be .fail). The probe is NEVER fatal — a down proxy must not
+  # fail the step, the direct path covers it. Default true; set enabled=false to
+  # keep strict proxy-first ordering.
+  proxyDownDirectFirst:
+    enabled: true
+    # Per-probe curl timeout (seconds) and probe attempt count. Worst case
+    # probeAttempts × probeTimeoutSeconds (default 3 × 8s = 24s) — negligible
+    # against a multi-image wave, and only paid when proxy-sourced refs exist.
+    probeTimeoutSeconds: 8
+    probeAttempts: 3
   # #5204 (Refs #5209 #3379) — Phase A4: warm every Crossplane provider
   # package (providers.pkg.crossplane.io spec.package — the SAME set step-11
   # pivots, read from the crossplaneProviderPivot values so the two can never
@@ -1829,6 +1861,10 @@ stepTimeouts:
   # mirrored tags on a re-fire via a manifest-digest HEAD), so a fast proxy-path
   # run returns in minutes and never waits out the larger ceiling, and a re-run
   # resumes rather than re-transferring from 0. No other step's deadline changes.
+  # #5095 round 2 keeps this 9600s ceiling: proxy-DOWN direct-first routing only
+  # removes the per-image proxy timeout tax on top of the DIRECT wave; the DIRECT
+  # census itself is still the ~105-min slow path this ceiling was sized for, and
+  # a slow-but-reachable-egress run needs the same headroom regardless.
   harborPrewarmSeconds: 9600
   fluxGitRepositoryPatchSeconds: 600
   # Step 06 (helmrepository-patches) activeDeadlineSeconds. This step now

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5050,7 +5050,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.148"
+  version: "0.1.149"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5067,7 +5067,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.148"
+    version: "0.1.149"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5095 #5093 #5298 #5299

## Root cause (file:line)

`platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml`, `copy_one`:

- the mothership-proxy source leg is `prewarm_skopeo_copy "${up}" "${sc}"` (job template L1044), bounded ONLY by `--command-timeout "${PREWARM_SKOPEO_TIMEOUT}"` (`prewarm_skopeo_copy` L933, value `skopeoCommandTimeout: "1200s"`);
- the round-1 direct-source fallback (`prewarm_skopeo_copy "${fb_up}" "${fb_creds}"`, L1062) fires ONLY AFTER that proxy copy returns non-zero.

So when the mothership Harbor proxy (`harbor.openova.io/proxy-*`) is unreachable for the WHOLE step — a sustained transit hole toward the mothership /24, not a brief flap — EVERY proxy-sourced image independently burns up to the 1200s `--command-timeout` probing the dead proxy BEFORE the fast direct upstream is even tried. On hw281 (2026-07-20) that per-image "proxy timeout tax" dragged the direct-fallback wave to ~100 min for 140 images. #5095 round 1 (0.1.136) added the direct-source fallback + flap-tolerant pacing, but always *after* the timed-out proxy leg.

Nothing in the cutover severs the proxy mid-step — it is simply unreachable over the network for the whole wave — so the durable fix is to stop paying the per-image timeout tax and route direct.

## Fix (chart 0.1.149) — source selection only

The local DEST path (host-swap, path preserved) is untouched, so step-04/07/08 resolve the identical LOCAL artifact and the sovereignty guarantee (every image in local Harbor before the deny-egress hold) is intact.

1. **One-time reachability probe** `probe_mothership_proxy` (job template L1179+): a bounded `GET https://${MOTHERSHIP_HOST}/v2/` (`PROXY_PROBE_ATTEMPTS` x `PROXY_PROBE_TIMEOUT_SECONDS`, default 3x8s), run only when the wave has proxy-sourced refs. On an unreachable proxy it latches `${cpdir}/.proxy_down`. NEVER fatal — a down proxy must not fail the step, the direct path covers it.
2. **Direct-first short-circuit** in `copy_one` (L1074+): when the latch is set (gated on `PROXY_DIRECT_FIRST_ENABLED` + the `.proxy_down` latch), try the mechanically-derived DIRECT upstream FIRST for proxy-sourced refs, so no image burns the 1200s timeout on the dead proxy. Proxy stays the secondary when believed up (avoids the upstream's anonymous rate limits).
3. **Adaptive latch** (L1122+): trips the moment a proxy leg fails while its direct sibling succeeds (the hw255 "proxy bad, direct good" signature), catching a proxy that dies mid-wave after the probe passed.

Round-1 after-failure fallback + the Phase A `push_fail>0` FATAL + #4994 skip-if-present idempotency/resumability are all preserved.

New values (`prewarm.proxyDownDirectFirst`): `enabled: true`, `probeTimeoutSeconds: 8`, `probeAttempts: 3` (all overridable; `enabled: false` restores strict proxy-first).

## Before / after pull source

| Scenario | main (0.1.148) | this PR (0.1.149) |
|---|---|---|
| Proxy reachable | proxy-first (fast) | proxy-first (unchanged) |
| Proxy down whole step | proxy leg times out (up to 1200s/image) THEN direct fallback — ~100 min tax for 140 images | probe latches down → **direct upstream FIRST**, no per-image timeout tax |
| Proxy dies mid-wave | each remaining image pays the timeout | adaptive latch flips remaining images to direct-first |

The mothership proxy is now at most an OPTIONAL fast-path; the direct upstream (ghcr.io / docker.io / quay.io / registry.k8s.io, derived mechanically from the proxy path via the #4975 coverage map) is the guaranteed path when the proxy is absent.

## Deadline preserved (correction vs the parked PR #5300)

`stepTimeouts.harborPrewarmSeconds` stays at the #5298/#5299 value **9600s**. Direct-first only removes the per-image proxy timeout tax on top of the DIRECT wave; the DIRECT census itself is still the ~105-min slow path that ceiling was sized for, and a slow-but-reachable-egress run needs the same headroom regardless. The earlier parked 0.1.149 attempt (PR #5300, closed) silently reverted `9600 -> 5400` in a rebase over #5299 and omitted the `catalog-seed/blueprints.yaml` pin bump — both corrected here.

## Lockstep 0.1.148 -> 0.1.149 (all five pins)

`Chart.yaml`, `blueprint.yaml`, `catalog-seed/blueprints.yaml` (spec.version + source.version), `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`.

## Validation

- `helm template` + `helm lint`: clean
- rendered step-03 prewarm script: `sh -n` + `bash -n` clean
- `tests/cutover-contract.sh`: green incl. new Case 69 (asserts probe, latch, direct-first gating, all-ghcr-skip, and the preserved round-1 fallback + FATAL). Case 34 (`19-harbor.yaml disableRedirect`) is a pre-existing #5303 test-lag on `main`, unrelated to this change.
- `tests/image-registry-coverage.sh`: green
- `tests/e2e/bootstrap-kit` version-lockstep sweep: green

No live Sovereign/mothership touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)