### PR TITLE
test(catalyst-api): guard markPhase1Done terminal-failed → QuarantineDeployment wiring (Refs #5285)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_quarantine_5285_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_quarantine_5285_test.go
@@ -1,0 +1,147 @@
+// phase1_watch_quarantine_5285_test.go — #5285 live-conclusion wiring guard.
+//
+// PR #5287 landed the k8scache reflector teardown+quarantine (factory.go
+// QuarantineDeployment) and two of its three call sites already carry
+// dedicated tests:
+//   - the factory method itself     → informer_teardown_5285_test.go
+//   - the restart re-derivation path → k8scache_quarantine_5285_test.go
+//     (SetK8sCache re-quarantines persisted Status=="failed" records)
+//
+// The THIRD call site — the live terminal conclusion in markPhase1Done
+// (phase1_watch.go: `if finalStatus == "failed" { QuarantineDeployment }`)
+// — had NO test. Deleting those lines broke nothing, so a future refactor
+// could silently drop the trigger and the hw279 flood (a failed env's
+// per-kind reflectors 404-flooding against its missing Catalyst CRDs, which
+// spike catalyst-api CPU and starve the /wipe + /deployments control
+// endpoints) would resume unnoticed.
+//
+// This test closes that gap. It proves the condition is load-bearing in
+// BOTH directions:
+//   - a deployment that concludes terminal-FAILED IS quarantined — every
+//     `<id>` primary AND `<id>-<region>` secondary reflector torn down, and
+//     re-registration (the lingering-kubeconfig rescan/POST vector)
+//     refused; and
+//   - a deployment that concludes READY is NOT quarantined — its reflectors
+//     stay live to power the console view.
+//
+// Anti-theater: removing the QuarantineDeployment call fails the failed-arm
+// assertions; widening the guard to quarantine unconditionally fails the
+// ready-arm assertion.
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestMarkPhase1Done_QuarantinesFailedDeploymentReflectors is the #5285
+// live-conclusion wiring guard for phase1_watch.go's terminal-failed branch.
+func TestMarkPhase1Done_QuarantinesFailedDeploymentReflectors(t *testing.T) {
+	// A factory with the failed deployment's primary + secondary clusters and
+	// an unrelated healthy deployment already registered (the state a running
+	// catalyst-api holds while Phase-1 is still watching). No Start() → the
+	// informers are built but never dial, so nothing touches the network.
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger:   quietLog(),
+		Registry: minimalRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	for _, id := range []string{"faildep", "faildep-b", "readydep"} {
+		if err := f.AddCluster(k8scache.ClusterRef{
+			ID:            id,
+			DynamicClient: fakeDynForQuarantineTest(),
+			CoreClient:    kfake.NewSimpleClientset(),
+		}); err != nil {
+			t.Fatalf("AddCluster(%s): %v", id, err)
+		}
+	}
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// suppressPostHandoverHooks keeps the READY branch's producer chain
+	// (mesh/spine/adoption/policy) from spawning — this test only exercises
+	// the quarantine wiring, not the handover fan-out.
+	h.suppressPostHandoverHooks = true
+	// A reachable console keeps the READY deployment genuinely "ready" (the
+	// #4706 gate never downgrades it), so the ready-arm assertion below is a
+	// clean discriminator for the `finalStatus == "failed"` condition.
+	h.consoleProbe = func(string) error { return nil }
+	h.k8sCache = f
+
+	mkDep := func(id string) *Deployment {
+		return &Deployment{
+			ID:        id,
+			Status:    "phase1-watching",
+			StartedAt: time.Now(),
+			eventsCh:  make(chan provisioner.Event, 256),
+			done:      make(chan struct{}),
+			Request: provisioner.Request{
+				SovereignFQDN: id + ".omani.works",
+				OrgEmail:      "operator@test.example.com",
+			},
+			Result:     &provisioner.Result{SovereignFQDN: id + ".omani.works"},
+			OwnerEmail: "operator@test.example.com",
+		}
+	}
+	failDep := mkDep("faildep")
+	readyDep := mkDep("readydep")
+	h.deployments.Store(failDep.ID, failDep)
+	h.deployments.Store(readyDep.ID, readyDep)
+
+	// --- Terminal-FAILED conclusion MUST quarantine (primary + secondary). ---
+	h.markPhase1Done(failDep, map[string]string{
+		"cilium":            helmwatch.StateInstalled,
+		"catalyst-platform": helmwatch.StateFailed,
+	}, helmwatch.OutcomeFailed)
+
+	failDep.mu.Lock()
+	failStatus := failDep.Status
+	failDep.mu.Unlock()
+	if failStatus != "failed" {
+		t.Fatalf("precondition: failed conclusion did not set Status=failed (got %q) — test would not reach the quarantine branch", failStatus)
+	}
+
+	if clustersContain(f.Clusters(), "faildep") {
+		t.Errorf("terminal-failed deployment primary 'faildep' NOT quarantined — the reflector 404-flood would resume (phase1_watch.go quarantine call removed?)")
+	}
+	if clustersContain(f.Clusters(), "faildep-b") {
+		t.Errorf("terminal-failed deployment SECONDARY 'faildep-b' NOT quarantined — secondary-region reflectors keep flooding")
+	}
+
+	// The quarantine must also REFUSE re-registration while the failed env's
+	// kubeconfig lingers on the PVC for the eventual wipe (the rescan/POST
+	// resurrection vector #5285 closes).
+	if err := f.AddCluster(k8scache.ClusterRef{
+		ID:            "faildep",
+		DynamicClient: fakeDynForQuarantineTest(),
+		CoreClient:    kfake.NewSimpleClientset(),
+	}); err != nil {
+		t.Fatalf("AddCluster(faildep) while quarantined returned error, want nil no-op: %v", err)
+	}
+	if clustersContain(f.Clusters(), "faildep") {
+		t.Errorf("quarantined 'faildep' was re-registered by a later rescan/AddCluster — the flood would resume")
+	}
+
+	// --- READY conclusion MUST NOT quarantine (reflectors power the view). ---
+	h.markPhase1Done(readyDep, map[string]string{
+		"cilium": helmwatch.StateInstalled,
+	}, helmwatch.OutcomeReady)
+
+	readyDep.mu.Lock()
+	readyStatus := readyDep.Status
+	readyDep.mu.Unlock()
+	if readyStatus != "ready" {
+		t.Fatalf("precondition: ready conclusion did not set Status=ready (got %q, err=%q)", readyStatus, readyDep.Error)
+	}
+	if !clustersContain(f.Clusters(), "readydep") {
+		t.Errorf("READY deployment 'readydep' was wrongly quarantined — its live reflectors (console view) went dark; the `finalStatus == \"failed\"` guard must gate the quarantine")
+	}
+}


### PR DESCRIPTION
## Summary

`Refs #5285` — the failed-deployment watch-informer flood that starved `/wipe` + `/deployments` (hw279 dep `059126bb`).

**The functional fix already landed via PR #5287** (merged 2026-07-20, ancestor of `main`): a terminal-FAILED deployment's k8scache reflectors are torn down and quarantined so they stop 404-flooding against the failed env's missing Catalyst CRDs. This PR is a **completeness audit + the one missing anti-theater guard** — it ships no behavior change, only a test that pins the last untested wiring point.

## Root cause (file:line)

A per-deployment k8scache cluster (keyed `<depID>` and `<depID>-<region>`) watches every `DefaultKind`, **including** the Catalyst CRDs `cnpgpairs` / `continuums` / `organizations` / `useraccesses`. When a deployment concluded terminal-FAILED, nothing tore its informer set down — `RemoveCluster` only ran on wipe, and the failed env's kubeconfig deliberately lingers on the PVC for the eventual wipe, so a bare removal was undone within one ≤30s rescan tick. The failed apiserver is up but its CRDs never installed, so the reflectors 404-flood (`reflector.go:227 "Failed to watch" … the server could not find the requested resource`), spike catalyst-api CPU (1206m on hw279), and starve the `/wipe` + `/deployments` handlers the operator needs to recover the env — a self-inflicted DoS with a chicken-and-egg on the wipe.

## Existing fix (PR #5287) — verified complete

| Concern | Code | Test |
|---|---|---|
| Stop + durably suppress reflectors on terminal-FAILED | `internal/k8scache/factory.go:857` `QuarantineDeployment` (+ `isQuarantinedLocked:804`, `AddCluster:561` refusal, `rescanOnce:1027`/`evictStaleQuarantine:1109` self-clear) | `internal/k8scache/informer_teardown_5285_test.go` |
| Tear down primary **and** `<id>-<region>` secondaries on wipe | `factory.go:837` `RemoveDeployment`; wired at `internal/handler/wipe.go:633-634` | `informer_teardown_5285_test.go` |
| Durable across catalyst-api restart (re-derive quarantine from persisted `Status=="failed"`) | `internal/handler/handler.go:878-892` `SetK8sCache` | `internal/handler/k8scache_quarantine_5285_test.go` |
| **Live terminal-FAILED conclusion → quarantine** | `internal/handler/phase1_watch.go:1457-1459` `if finalStatus == "failed" { QuarantineDeployment }` | **was untested → this PR** |

The k8scache reflectors are the exact subsystem in the hw279 log (those four CRDs are k8scache `DefaultKind`s). The provisioning-watch helmwatch `Watcher`s are torn down on the same conclusion via `stopSecondaries()` + the `liveWatcher` cancel, so both flood sources are covered.

## The gap this PR closes

The live-conclusion trigger at `phase1_watch.go:1457-1459` had **no test** — deleting those three lines broke nothing, so a refactor could silently drop the trigger and let the flood resume unnoticed (the "scaffold-only / missing-wiring" anti-pattern). This PR adds `TestMarkPhase1Done_QuarantinesFailedDeploymentReflectors`, load-bearing in both directions:

- a terminal-FAILED conclusion quarantines the `<id>` primary **and** its `<id>-<region>` secondaries, and refuses re-registration (the lingering-kubeconfig rescan/POST resurrection vector);
- a READY conclusion does **not** quarantine (its reflectors power the console live view).

## Anti-theater evidence (mutation testing)

- Comment out the `QuarantineDeployment` call → failed-arm assertions fail (`'faildep' NOT quarantined … the reflector 404-flood would resume`).
- Widen the guard to quarantine unconditionally (drop `finalStatus == "failed"`) → ready-arm assertion fails (`READY deployment 'readydep' was wrongly quarantined`).

## Green gates (`products/catalyst/bootstrap/api/`)

- `go build ./...` — OK
- `go vet ./internal/handler/ ./internal/k8scache/` — OK
- `go test ./...` — all packages pass (`internal/handler` 158s, `internal/k8scache` ok)

**Do not merge yet** — a fresh-prov fire cycle is in progress; this queues for the post-cycle release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)