### PR TITLE
fix(catalyst-api): converge partial wipes — retain tfstate until verified + PDM 422 no-op (Refs #5193)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -5,22 +5,22 @@
 // banner exposes a "Cancel & Wipe" button that POSTs here. This handler
 // runs the canonical purge sequence:
 //
-//   1. Cancel any in-flight context (helmwatch informer, current Phase-0
-//      runner) for this deployment.
-//   2. Run `tofu destroy -auto-approve` against the per-deployment
-//      workdir. Idempotent — re-runs on partial state are safe.
-//   3. Run a Hetzner force-purge of any resources tagged with
-//      `catalyst.openova.io/sovereign=<fqdn>` so anything tofu missed (or
-//      anything created out-of-band) is removed. Belt + braces; tofu
-//      destroy is the primary path, Hetzner API the safety net.
-//   4. Release the PDM allocation row (pool subdomain only). Best-effort:
-//      a PDM outage doesn't block local cleanup, the pool-domain-manager
-//      operator can force-release later via `pdm-cli` (#319).
-//   5. Delete the on-disk record + kubeconfig + tofu workdir.
-//   6. Mark the in-memory Deployment Status="wiped" so subsequent GETs
-//      return 410 Gone (per the founder's minimum-retention principle —
-//      Catalyst-Zero retains nothing operational about a wiped
-//      deployment).
+//  1. Cancel any in-flight context (helmwatch informer, current Phase-0
+//     runner) for this deployment.
+//  2. Run `tofu destroy -auto-approve` against the per-deployment
+//     workdir. Idempotent — re-runs on partial state are safe.
+//  3. Run a Hetzner force-purge of any resources tagged with
+//     `catalyst.openova.io/sovereign=<fqdn>` so anything tofu missed (or
+//     anything created out-of-band) is removed. Belt + braces; tofu
+//     destroy is the primary path, Hetzner API the safety net.
+//  4. Release the PDM allocation row (pool subdomain only). Best-effort:
+//     a PDM outage doesn't block local cleanup, the pool-domain-manager
+//     operator can force-release later via `pdm-cli` (#319).
+//  5. Delete the on-disk record + kubeconfig + tofu workdir.
+//  6. Mark the in-memory Deployment Status="wiped" so subsequent GETs
+//     return 410 Gone (per the founder's minimum-retention principle —
+//     Catalyst-Zero retains nothing operational about a wiped
+//     deployment).
 //
 // All progress streams as SSE events on the same channel as the original
 // provisioning + Phase-1 watch, so the wizard's banner can render the
@@ -205,7 +205,6 @@ type wipeRequest struct {
 	HuaweiProjectID string `json:"huaweiProjectId,omitempty"`
 	HuaweiRegion    string `json:"huaweiRegion,omitempty"`
 }
-
 
 // wipeResponse summarises what was actually purged. The wizard renders
 // the counts in a "Wipe complete — N servers, M load balancers, …
@@ -906,13 +905,33 @@ func (h *Handler) runWipePurge(dep *Deployment, id string, body wipeRequest, pre
 	}
 
 	// Key the workdir by the deployment ID — the provisioner does the same
-// (provisioner.go:workdirKey()), so this matches what was actually
-// created at provision time. FQDN-keyed lookups would miss when two
-// reprovs of the same FQDN existed in sequence.
-tofuWorkDir := filepath.Join(prov.WorkDir, id)
-_ = deploymentSovereignName // retained for backwards-compat callers; unused on the wipe path now
-	if err := os.RemoveAll(tofuWorkDir); err != nil {
-		report.Errors = append(report.Errors, "remove tofu workdir: "+err.Error())
+	// (provisioner.go:workdirKey()), so this matches what was actually
+	// created at provision time. FQDN-keyed lookups would miss when two
+	// reprovs of the same FQDN existed in sequence.
+	tofuWorkDir := filepath.Join(prov.WorkDir, id)
+	_ = deploymentSovereignName // retained for backwards-compat callers; unused on the wipe path now
+	// Refs #5193 (item 3) — RETAIN the per-deployment tofu workdir (tfvars +
+	// terraform.tfstate) unless the wipe is VERIFIED complete. Removing it
+	// unconditionally here clobbered the exact state a retried wipe
+	// re-destroys against after a PARTIAL destroy (the hw268 shape: region-a
+	// tore down but region-b/EIPs/VPCs/OBS survived), leaving the env
+	// un-wipeable via the clean tofu path — the retry then fell back to the
+	// name-prefix orphan sweep only. provisioner.Destroy already PRESERVES the
+	// workdir when `tofu destroy` errors (provisioner.go:2433 "operator may
+	// want to inspect") and removes it itself on a clean destroy (2438); this
+	// epilogue removal used to negate that preservation. Only reclaim the
+	// workdir once BOTH convergence signals agree the wipe converged: tofu
+	// destroy returned clean (TofuDestroyed) AND the provider's post-wipe
+	// zero-orphan verify passed (VerifiedZeroOrphans). On a partial wipe the
+	// workdir is left in place so the next (idempotent — see the file header +
+	// the wipeInFlight re-wipe guard) wipe re-destroys against the preserved
+	// tfstate and converges; that successful retry's epilogue reclaims it.
+	if report.TofuDestroyed && report.VerifiedZeroOrphans {
+		if err := os.RemoveAll(tofuWorkDir); err != nil {
+			report.Errors = append(report.Errors, "remove tofu workdir: "+err.Error())
+		}
+	} else {
+		emit("wipe", "warn", "tofu workdir RETAINED at "+tofuWorkDir+" — wipe not verified complete (tofuDestroyed="+boolStr(report.TofuDestroyed)+", verifiedZeroOrphans="+boolStr(report.VerifiedZeroOrphans)+"); a retried wipe re-destroys against the preserved tfstate until it converges (Refs #5193)")
 	}
 
 	// Refs #3728 — if the PDM pool release failed after retries, RETAIN the

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_workdir_retention_5193_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_workdir_retention_5193_test.go
@@ -1,0 +1,179 @@
+// wipe_workdir_retention_5193_test.go — #5193 (item 3) regression coverage.
+//
+// A PARTIAL destroy (the hw268 shape: region-a tore down but region-b /
+// EIPs / VPCs / OBS survived) leaves the wipe NOT verified complete. The
+// per-deployment tofu workdir (tofu.auto.tfvars.json + terraform.tfstate)
+// is the exact state a retried wipe re-`tofu destroy`s against — so the
+// purge epilogue must RETAIN it whenever the wipe did not converge, and
+// only reclaim it once BOTH convergence signals agree (TofuDestroyed AND
+// VerifiedZeroOrphans). Pre-fix the epilogue removed the workdir
+// UNCONDITIONALLY, clobbering the tfstate the retry needs and stranding
+// the env un-wipeable via the clean tofu path.
+//
+// These tests drive the real async purge (runWipePurge via WipeDeployment)
+// through a stub CloudProvider whose WipeResult TofuDestroyed /
+// VerifiedZeroOrphans flags are controllable, seed a real workdir on disk,
+// and assert its survival vs removal. Reverting the gate (back to an
+// unconditional os.RemoveAll) fails the partial-destroy case: the seeded
+// workdir would be gone.
+package handler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/providers"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// ── controllable stub CloudProvider ──────────────────────────────────
+
+// stub5193ProviderName is a test-only provider registered once (init
+// below) so runWipePurge's providers.Get() resolves to a WipeResult we
+// fully control — without hitting a real cloud API.
+const stub5193ProviderName = "stub5193"
+
+var (
+	stub5193Mu     sync.Mutex
+	stub5193Result *providers.WipeResult
+)
+
+func setStub5193Result(r *providers.WipeResult) {
+	stub5193Mu.Lock()
+	stub5193Result = r
+	stub5193Mu.Unlock()
+}
+
+type stub5193Provider struct{}
+
+func (stub5193Provider) Name() string { return stub5193ProviderName }
+
+func (stub5193Provider) Provision(context.Context, providers.ProvisionSpec, chan<- providers.ProvisionEvent) (*providers.ProvisionResult, error) {
+	return &providers.ProvisionResult{}, nil
+}
+
+func (stub5193Provider) Wipe(_ context.Context, _ providers.WipeSpec, progress func(msg string)) (*providers.WipeResult, error) {
+	if progress != nil {
+		progress("stub5193 wipe invoked")
+	}
+	stub5193Mu.Lock()
+	r := stub5193Result
+	stub5193Mu.Unlock()
+	if r == nil {
+		r = &providers.WipeResult{ProviderPurge: map[string][]string{}}
+	}
+	return r, nil
+}
+
+func (stub5193Provider) ListServers(context.Context, string, string, providers.ProviderCreds) ([]providers.ServerInfo, error) {
+	return nil, nil
+}
+
+func (stub5193Provider) ValidateCreds(context.Context, providers.ProviderCreds) error { return nil }
+
+func init() { providers.RegisterProvider(stub5193ProviderName, stub5193Provider{}) }
+
+// runStub5193Wipe seeds a real per-deployment workdir on disk, drives the
+// async wipe through the stub provider with the supplied WipeResult, and
+// returns the workdir path so the caller can assert survival/removal.
+func runStub5193Wipe(t *testing.T, id string, res *providers.WipeResult) string {
+	t.Helper()
+	workRoot := t.TempDir()
+	t.Setenv("CATALYST_TOFU_WORKDIR", workRoot)
+
+	// Seed the per-deployment workdir with the two files a retry needs.
+	depWorkDir := filepath.Join(workRoot, id)
+	if err := os.MkdirAll(depWorkDir, 0o755); err != nil {
+		t.Fatalf("seed workdir: %v", err)
+	}
+	for _, f := range []string{"terraform.tfstate", "tofu.auto.tfvars.json"} {
+		if err := os.WriteFile(filepath.Join(depWorkDir, f), []byte("{}"), 0o600); err != nil {
+			t.Fatalf("seed %s: %v", f, err)
+		}
+	}
+
+	setStub5193Result(res)
+	t.Cleanup(func() { setStub5193Result(nil) })
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	dep := &Deployment{
+		ID:        id,
+		Status:    "failed",
+		StartedAt: time.Now().Add(-45 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN: id + ".omani.works",
+			// NOT pool → the PDM release step no-ops, keeping this test
+			// focused purely on the workdir-retention gate.
+			SovereignDomainMode: "byo",
+			Regions:             []provisioner.RegionSpec{{Provider: stub5193ProviderName, CloudRegion: "test"}},
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	// Hetzner-shaped creds guard (provHint defaults to hetzner because
+	// dep.Request.Provider is empty) — the stub provider ignores them.
+	w := callWipeDeployment(h, dep.ID, "", `{"hetznerToken":"fake-token"}`)
+	if w.Code != 202 {
+		t.Fatalf("wipe status=%d, want 202 — body=%s", w.Code, w.Body.String())
+	}
+	waitForWipeDone(t, dep, 60*time.Second)
+	return depWorkDir
+}
+
+// TestWipePurge_PartialDestroy_RetainsWorkdir is the headline #5193 item-3
+// assertion: when the wipe is NOT verified complete, the per-deployment
+// tofu workdir (tfvars + tfstate) MUST survive so a retried wipe still has
+// the terraform state to destroy against. Each sub-case is a distinct
+// "did not converge" shape.
+func TestWipePurge_PartialDestroy_RetainsWorkdir(t *testing.T) {
+	cases := []struct {
+		name   string
+		result *providers.WipeResult
+	}{
+		{
+			// tofu destroy failed (region-a died mid-teardown) — the
+			// classic hw268 partial destroy.
+			name:   "tofu destroy failed",
+			result: &providers.WipeResult{TofuDestroyed: false, VerifiedZeroOrphans: false, ProviderPurge: map[string][]string{}},
+		},
+		{
+			// tofu destroy returned clean but the post-wipe verify found a
+			// survivor (e.g. a stuck SG / leaked EIP) — still not converged.
+			name:   "destroyed but orphans survived",
+			result: &providers.WipeResult{TofuDestroyed: true, VerifiedZeroOrphans: false, ProviderPurge: map[string][]string{}, ResidualOrphans: map[string][]string{"firewalls": {"catalyst-x-sg"}}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			depWorkDir := runStub5193Wipe(t, "dep-5193-retain", tc.result)
+			if _, err := os.Stat(depWorkDir); err != nil {
+				t.Fatalf("workdir %s was removed after a NON-verified wipe (%s) — the tfstate a retried wipe needs is gone; #5193 item-3 regression: %v", depWorkDir, tc.name, err)
+			}
+			// The state files specifically must still be there.
+			for _, f := range []string{"terraform.tfstate", "tofu.auto.tfvars.json"} {
+				if _, err := os.Stat(filepath.Join(depWorkDir, f)); err != nil {
+					t.Errorf("%s did not survive a partial wipe: %v", f, err)
+				}
+			}
+		})
+	}
+}
+
+// TestWipePurge_VerifiedComplete_RemovesWorkdir is the paired positive
+// case: a fully-converged wipe (tofu destroy clean AND zero orphans
+// verified) reclaims the workdir exactly as before — the gate must not
+// leak state on the happy path.
+func TestWipePurge_VerifiedComplete_RemovesWorkdir(t *testing.T) {
+	depWorkDir := runStub5193Wipe(t, "dep-5193-clean", &providers.WipeResult{
+		TofuDestroyed:       true,
+		VerifiedZeroOrphans: true,
+		ProviderPurge:       map[string][]string{},
+	})
+	if _, err := os.Stat(depWorkDir); !os.IsNotExist(err) {
+		t.Fatalf("workdir %s survived a VERIFIED-complete wipe (err=%v) — the epilogue must reclaim it on convergence, else every clean wipe leaks a workdir on the PVC", depWorkDir, err)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/pdm/client.go
+++ b/products/catalyst/bootstrap/api/internal/pdm/client.go
@@ -132,6 +132,21 @@ var ErrExpired = errors.New("pool allocation expired before commit")
 // CommitWithRetry).
 var ErrTokenMismatch = errors.New("pool allocation token mismatch")
 
+// ErrNotManaged — PDM returned 422 Unprocessable Entity on /release,
+// meaning the pool domain the caller asked to release from is NOT one
+// OpenOva's pool-domain-manager manages (e.g. a BYO / customer-owned
+// domain that a record has misclassified as SovereignDomainMode="pool",
+// or a Sovereign FQDN whose parent zone was never enrolled in the pool).
+//
+// Refs #5193 (item 4): there is no allocation row to release for such a
+// domain, so a 422 is the SAME terminal, non-retryable post-condition as
+// a 404 (ErrNotFound) — the slot is free because it was never a pool
+// slot. ReleaseWithRetry treats it as idempotent success (no retry, no
+// wipe-stranding). Distinct sentinel (not folded into ErrNotFound) so a
+// caller can still tell "row already gone" (404) from "domain isn't ours
+// to manage" (422) when it wants to log the difference.
+var ErrNotManaged = errors.New("pool domain is not managed by OpenOva")
+
 // Reserve calls POST /api/v1/pool/{domain}/reserve. Returns ErrConflict on
 // 409 so callers can distinguish "name taken" from "PDM down".
 func (c *Client) Reserve(ctx context.Context, poolDomain, subdomain, createdBy string) (*Reservation, error) {
@@ -405,9 +420,13 @@ func (c *Client) ReleaseWithRetry(ctx context.Context, poolDomain, subdomain str
 	backoff := cfg.InitialBackoff
 	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
 		err := c.Release(ctx, poolDomain, subdomain)
-		if err == nil || errors.Is(err, ErrNotFound) {
-			// 404 means the row is already gone — the slot is free, which
-			// is exactly the post-condition the caller wants. Idempotent.
+		if err == nil || errors.Is(err, ErrNotFound) || errors.Is(err, ErrNotManaged) {
+			// 404 (ErrNotFound) means the row is already gone; 422
+			// (ErrNotManaged, Refs #5193) means the domain was never a
+			// pool slot to begin with. Both are the exact post-condition
+			// the caller wants — the slot is free — so both are idempotent
+			// success. Neither is transient, so return immediately without
+			// burning the remaining retry attempts.
 			return nil
 		}
 		lastErr = err
@@ -451,6 +470,13 @@ func (c *Client) Release(ctx context.Context, poolDomain, subdomain string) erro
 		return nil
 	case http.StatusNotFound:
 		return ErrNotFound
+	case http.StatusUnprocessableEntity:
+		// Refs #5193 (item 4) — 422 "pool domain <x> is not managed by
+		// OpenOva". There is no allocation to release for a non-managed
+		// domain; surface the typed sentinel so ReleaseWithRetry treats it
+		// as idempotent success rather than retrying it 5× and then
+		// stranding the wipe's on-disk record cleanup.
+		return ErrNotManaged
 	default:
 		return fmt.Errorf("pdm release status %d: %s", resp.StatusCode, truncate(string(respBody), 256))
 	}

--- a/products/catalyst/bootstrap/api/internal/pdm/release_notmanaged_5193_test.go
+++ b/products/catalyst/bootstrap/api/internal/pdm/release_notmanaged_5193_test.go
@@ -1,0 +1,72 @@
+// release_notmanaged_5193_test.go — #5193 (item 4) regression coverage.
+//
+// A wipe of a record whose SovereignDomainMode is "pool" but whose pool
+// domain is NOT one OpenOva's pool-domain-manager actually manages (a BYO
+// / customer-owned domain, or a Sovereign FQDN whose parent zone was
+// never enrolled) makes PDM answer the release with 422 "pool domain <x>
+// is not managed by OpenOva". There is no allocation row to free, so a
+// 422 is the SAME terminal, non-retryable post-condition as a 404: the
+// slot is already free.
+//
+// Pre-fix, Release mapped 422 to a generic `fmt.Errorf("pdm release
+// status 422: …")`, which ReleaseWithRetry did NOT recognise as
+// success — so it burned all MaxAttempts retries against a permanent
+// error, then returned "retry exhausted". In the wipe handler that set
+// pdmReleaseFailed=true, which SKIPS deleting the on-disk deployment
+// record, stranding a non-managed-domain wipe as a partially-cleaned
+// record forever. This file locks the fix: 422 → ErrNotManaged →
+// treated as idempotent success with NO retry.
+package pdm
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRelease_422_MapsToErrNotManaged proves the single-shot Release maps
+// a 422 Unprocessable Entity to the typed ErrNotManaged sentinel (not a
+// generic status error), so callers can branch on it with errors.Is.
+func TestRelease_422_MapsToErrNotManaged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"error":"pool domain omantel.biz is not managed by OpenOva"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.Release(context.Background(), "omantel.biz", "hw276")
+	if !errors.Is(err, ErrNotManaged) {
+		t.Fatalf("Release on a 422 must return ErrNotManaged, got %v", err)
+	}
+}
+
+// TestReleaseWithRetry_422_IsSuccessNoRetry is the headline #5193 item-4
+// assertion: a 422 (non-managed pool domain) is idempotent success and
+// must NOT consume any retry attempt — exactly like a 404. Reverting the
+// fix (dropping the ErrNotManaged case from either Release's status
+// switch or ReleaseWithRetry's success guard) fails this test twice: the
+// returned error becomes non-nil AND the call count jumps to MaxAttempts.
+func TestReleaseWithRetry_422_IsSuccessNoRetry(t *testing.T) {
+	var releases int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&releases, 1)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"error":"pool domain omantel.biz is not managed by OpenOva"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.ReleaseWithRetry(context.Background(), "omantel.biz", "hw276",
+		CommitRetryConfig{MaxAttempts: 5, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond})
+	if err != nil {
+		t.Fatalf("ReleaseWithRetry: a 422 non-managed domain must be idempotent success, got %v", err)
+	}
+	if got := atomic.LoadInt32(&releases); got != 1 {
+		t.Errorf("releases=%d, want 1 (422 is terminal + non-retryable — it must return immediately, never burn the retry budget)", got)
+	}
+}


### PR DESCRIPTION
## Refs #5193 — the remaining tail (items 3 + 4)

#5193's **primary** stranding — the `huawei-operator-creds` env fallback, the async/detached `tofu destroy` (nginx-60s-proof), and the re-wipe of a stranded `status: wiping` record — shipped in **PR #5200** (per the maintainer's 2026-07-19 status-sweep comment moving the issue to `status/uat`). This PR closes the two items that comment flags as **not yet on main**, so a partially-wiped env always converges to fully-wiped on retry.

### Root-cause (file:line)

**Item 3 — the workdir/tfstate was clobbered after a partial destroy.**
`runWipePurge`'s epilogue removed the per-deployment tofu workdir **unconditionally** at `products/catalyst/bootstrap/api/internal/handler/wipe.go:914` (`os.RemoveAll(tofuWorkDir)`) — including `tofu.auto.tfvars.json` + `terraform.tfstate`, the exact state a retried wipe re-`tofu destroy`s against. `provisioner.Destroy` deliberately **preserves** the workdir when `tofu destroy` errors (`internal/provisioner/provisioner.go:2433` "operator may want to inspect") and removes it itself on a clean destroy (`:2438`) — the epilogue negated that preservation. On the hw268 partial-destroy shape (region-a tore down, region-b/EIPs/VPCs/OBS survived), this left the env un-wipeable via the clean tofu path (the retry fell back to the name-prefix orphan sweep only).

**Item 4 — a non-managed pool domain stranded the record cleanup.**
`pdm.Client.Release` (`internal/pdm/client.go`) mapped a 422 to a generic `fmt.Errorf("pdm release status 422: …")`, which `ReleaseWithRetry` did **not** recognise as terminal — so it burned all 5 retries against the permanent error, returned `"retry exhausted"`, and the wipe set `pdmReleaseFailed=true`, which **skips** deleting the on-disk deployment record. A record whose `SovereignDomainMode="pool"` but whose pool domain PDM does not manage (e.g. `omantel.biz`) was left partially-cleaned forever.

### The fix (durable, idempotent, provider-agnostic)

**Item 3** — reclaim the workdir only when the wipe is **verified complete** (`report.TofuDestroyed && report.VerifiedZeroOrphans` — both providers set `VerifiedZeroOrphans`). A non-converged wipe leaves the workdir in place (with a `RETAINED` warn on the SSE log) so the next idempotent wipe re-destroys against the preserved tfstate; that successful retry's epilogue reclaims it. Status/record semantics are untouched (the existing `status="wiped"` contract + the `wipeInFlight` re-wipe guard already handle re-firing).

**Item 4** — new `pdm.ErrNotManaged` sentinel; `Release` maps 422 → `ErrNotManaged`; `ReleaseWithRetry` treats it like `ErrNotFound` (idempotent success, **no** retry). The pool slot is free because it was never a pool slot — so the wipe's record cleanup proceeds.

### Not the gap — Huawei OBS cleanup already exists

The issue framing suggested OBS bucket cleanup was missing from the wipe path. It is **not**: `providers/huawei/provider.go` already empties-then-deletes every matching bucket — object **versions** + delete markers (`WithVersions:true` + batched `RemoveObjects`) + **incomplete-multipart** aborts, with idempotent 404 handling — in `Wipe()` (`:444` `purgeOBSBuckets` → `emptyAndRemoveOBSBucket`), plus a project-wide `SweepOrphanOBSBuckets` janitor reclaim (#4872). No OBS change was invented.

### Tests — anti-theater (reverting each fix fails its paired test)

- `internal/handler/wipe_workdir_retention_5193_test.go` — a stub `CloudProvider` drives the real async `runWipePurge` with controllable `TofuDestroyed`/`VerifiedZeroOrphans`; a seeded workdir **survives** two non-converged shapes (`tofu destroy failed`; `destroyed but orphans survived`) and is **removed** on a verified-complete wipe. Reverting the gate → the partial-destroy case fails (workdir gone).
- `internal/pdm/release_notmanaged_5193_test.go` — `Release` maps 422 → `ErrNotManaged`; `ReleaseWithRetry` returns success after **exactly one** call. Reverting the guard → `"retry exhausted (5 attempts)"` + call count 5 → fail.

Both revert-checks were run and confirmed to fail as expected.

### Green gates

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/handler/` (full, 156s) — `ok`
- `go test ./internal/pdm/ ./internal/providers/huawei/` — `ok` (incl. `-race` on the pdm suite)

**Do NOT merge yet** — a fresh-prov fire cycle is in progress; this queues for the post-cycle release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)