### PR TITLE
test(powerdns): §854 Hetzner DNS front-door render-contract regression lock (Refs #5086)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -155,7 +155,8 @@ spec:
       # tofu dns LB :53->node:53 forward reaches a real listener (the LB-IPAM
       # anycast VIP path is dead on Hetzner). §854-clean: hostPort, NEVER a
       # NodePort. Driven below by ${POWERDNS_DNSDIST_HOSTPORT} (Hetzner-only).
-      version: 1.2.21
+      # 1.2.22 (#5086): render-contract regression lock (no chart behaviour change).
+      version: 1.2.22
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.21
+  version: 1.2.22
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -64,7 +64,14 @@ name: bp-powerdns
 #   a NodePort. No hostNetwork (pod-netns :53 bind dodges the Ubuntu-24.04
 #   systemd-resolved 127.0.0.53:53 stub). Live-gated: proven on a real Hetzner
 #   prov (dig @<node> <fqdn>), no Hetzner env currently up.
-version: 1.2.21
+# 1.2.22 (#5086, Refs #4765): regression lock for the 1.2.21 §854 front door.
+#   tests/hetzner-frontdoor-render.sh asserts the render contract both ways —
+#   default => dnsdist Deployment, ClusterIP Service, NO hostPort, NO NodePort;
+#   dnsdist.hostPortMode=true => DaemonSet + hostPort:53 (UDP+TCP), tolerate-all,
+#   NO hostNetwork, NO nodePort/type:NodePort; anycast Service stays
+#   type=LoadBalancer + allocateLoadBalancerNodePorts:false. Guards the Hetzner
+#   DNS front door against a silent §854 regression (no chart behaviour change).
+version: 1.2.22
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/tests/hetzner-frontdoor-render.sh
+++ b/platform/powerdns/chart/tests/hetzner-frontdoor-render.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# bp-powerdns — Hetzner DNS front-door render contract (#5086, Refs #4765 §854).
+#
+# The bp-powerdns 1.2.18 §854 flip (commit 3ce78f0d7) eradicated the anycast
+# NodePort Service. On Huawei / kom4dc / contabo the front door is the Cilium
+# LB-IPAM anycast VIP (node:53 == CP-node public IP) — unchanged. On Hetzner the
+# LB-IPAM `sovereign-vip` pool is gated OFF (hcloud-ccm owns LBs) and hcloud-ccm
+# cannot materialise the anycast Service, so node:53 never binds and the
+# Sovereign lost its DNS front door. 1.2.21 (PR #5090) restored it §854-cleanly
+# with `dnsdist.hostPortMode`: on Hetzner ONLY, dnsdist becomes a DaemonSet
+# binding hostPort:53 on every node the tofu `dns` LB targets — hostPort, NEVER
+# a NodePort.
+#
+# This test locks that render contract so a future edit cannot silently regress
+# the Hetzner front door (drop hostPort, flip a NodePort back in, add
+# hostNetwork, or narrow the DaemonSet off the CP node).
+#
+# Cases:
+#   1. DEFAULT (Huawei/kom4dc/contabo): dnsdist => Deployment, its Service =>
+#      ClusterIP, NO hostPort, NO NodePort — the anycast-VIP path is untouched.
+#   2. DEFAULT: anycast Service => type=LoadBalancer + allocateLoadBalancerNodePorts:false,
+#      NO nodePort port field (the §854 shared-VIP front door).
+#   3. HETZNER (dnsdist.hostPortMode=true): dnsdist => DaemonSet, hostPort:53 on
+#      BOTH the UDP and TCP ports, tolerations `operator: Exists` (covers the CP
+#      node — an LB :53 target), and NO hostNetwork (pod-netns :53 bind dodges
+#      the systemd-resolved 127.0.0.53 stub).
+#   4. §854: NEITHER render carries `type: NodePort` or a `nodePort:` port field
+#      anywhere (allocateLoadBalancerNodePorts:false is the suppression flag, not
+#      a NodePort, and is excluded from the scan).
+#   5. §854 hard guard: anycast.serviceType=NodePort FAILS the render (the
+#      template's explicit `fail`), so a NodePort can never be reintroduced by
+#      an overlay value.
+
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# ── Case 1: default dnsdist workload is a Deployment with no host binding ──
+echo "[bp-powerdns] Case 1: default dnsdist => Deployment, ClusterIP, no hostPort"
+def_dnsdist=$("$helm" template smoke "$chart_dir" --show-only templates/dnsdist.yaml 2>&1)
+if ! echo "$def_dnsdist" | grep -qE '^kind: Deployment$'; then
+  echo "FAIL: default render must produce a dnsdist Deployment (LB-IPAM anycast-VIP path)"
+  echo "$def_dnsdist" | grep -E '^kind:' || true
+  exit 1
+fi
+if echo "$def_dnsdist" | grep -qE '^kind: DaemonSet$'; then
+  echo "FAIL: default render must NOT be a DaemonSet — Huawei/kom4dc path would change"
+  exit 1
+fi
+if echo "$def_dnsdist" | grep -qE 'hostPort:'; then
+  echo "FAIL: default render must NOT bind a hostPort (that is the Hetzner-only path)"
+  exit 1
+fi
+if ! echo "$def_dnsdist" | grep -qE '^  type: ClusterIP$'; then
+  echo "FAIL: default dnsdist Service must be ClusterIP"
+  exit 1
+fi
+echo "[bp-powerdns] Case 1: PASS"
+
+# ── Case 2: default anycast Service is the §854 shared-VIP LoadBalancer ──
+echo "[bp-powerdns] Case 2: anycast Service => LoadBalancer, allocateLoadBalancerNodePorts:false"
+anycast=$("$helm" template smoke "$chart_dir" --show-only templates/anycast-endpoint.yaml 2>&1)
+if ! echo "$anycast" | grep -qE '^  type: LoadBalancer$'; then
+  echo "FAIL: anycast Service must be type=LoadBalancer (Cilium LB-IPAM shared VIP)"
+  echo "$anycast" | grep -E '^  type:' || true
+  exit 1
+fi
+if ! echo "$anycast" | grep -qE '^  allocateLoadBalancerNodePorts: false$'; then
+  echo "FAIL: anycast Service must set allocateLoadBalancerNodePorts:false (§854 — zero nodePorts)"
+  exit 1
+fi
+if echo "$anycast" | grep -qE '^ *nodePort:'; then
+  echo "FAIL: anycast Service must NOT carry a nodePort port field (§854)"
+  exit 1
+fi
+echo "[bp-powerdns] Case 2: PASS"
+
+# ── Case 3: Hetzner render flips dnsdist to a hostPort:53 DaemonSet ──
+echo "[bp-powerdns] Case 3: hostPortMode=true => DaemonSet + hostPort:53 (UDP+TCP), tolerate-all, no hostNetwork"
+hz_dnsdist=$("$helm" template smoke "$chart_dir" --set dnsdist.hostPortMode=true \
+             --show-only templates/dnsdist.yaml 2>&1)
+if ! echo "$hz_dnsdist" | grep -qE '^kind: DaemonSet$'; then
+  echo "FAIL: hostPortMode=true must produce a dnsdist DaemonSet (every-node :53 binder)"
+  echo "$hz_dnsdist" | grep -E '^kind:' || true
+  exit 1
+fi
+hostport_count=$(echo "$hz_dnsdist" | grep -cE '^ *hostPort: 53([^0-9]|$)' || true)
+if [ "$hostport_count" -ne 2 ]; then
+  echo "FAIL: expected hostPort:53 on BOTH the UDP and TCP ports (2), got $hostport_count"
+  exit 1
+fi
+if ! echo "$hz_dnsdist" | grep -qE '^ *- operator: Exists$'; then
+  echo "FAIL: Hetzner DaemonSet must tolerate all taints (operator: Exists) so the CP node — an LB :53 target — is covered"
+  exit 1
+fi
+if echo "$hz_dnsdist" | grep -qE 'hostNetwork:'; then
+  echo "FAIL: dnsdist must NOT use hostNetwork (pod-netns :53 bind dodges the systemd-resolved 127.0.0.53 stub)"
+  exit 1
+fi
+echo "[bp-powerdns] Case 3: PASS"
+
+# ── Case 4: §854 — neither render carries a NodePort anywhere ──
+echo "[bp-powerdns] Case 4: §854 — zero NodePorts in either render (full chart)"
+for mode in "default" "hetzner"; do
+  if [ "$mode" = "hetzner" ]; then
+    full=$("$helm" template smoke "$chart_dir" --set dnsdist.hostPortMode=true 2>&1)
+  else
+    full=$("$helm" template smoke "$chart_dir" 2>&1)
+  fi
+  # allocateLoadBalancerNodePorts:false is the §854 SUPPRESSION flag, not a
+  # NodePort — exclude it, then any residual nodePort/type:NodePort is a defect.
+  hits=$(echo "$full" \
+    | grep -vE 'allocateLoadBalancerNodePorts' \
+    | grep -niE 'type:[[:space:]]*NodePort|^ *nodePort:' || true)
+  if [ -n "$hits" ]; then
+    echo "FAIL: §854 violation — NodePort rendered in $mode mode:"
+    echo "$hits"
+    exit 1
+  fi
+done
+echo "[bp-powerdns] Case 4: PASS"
+
+# ── Case 5: §854 hard guard — anycast.serviceType=NodePort must fail render ──
+echo "[bp-powerdns] Case 5: anycast.serviceType=NodePort is a hard render failure (#4765)"
+if "$helm" template smoke "$chart_dir" --set anycast.serviceType=NodePort \
+     --show-only templates/anycast-endpoint.yaml >/dev/null 2>&1; then
+  echo "FAIL: anycast.serviceType=NodePort must FAIL the render (§854), but it rendered"
+  exit 1
+fi
+echo "[bp-powerdns] Case 5: PASS"
+
+echo "[bp-powerdns] All Hetzner front-door render-contract cases PASS"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4763,7 +4763,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.21"
+  version: "1.2.22"
   visibility: unlisted
   card:
     title: "PowerDNS"
@@ -4780,7 +4780,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-powerdns
-    version: "1.2.21"
+    version: "1.2.22"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Refs #5086 #4765

Do NOT merge yet — a fresh-prov fire cycle is in progress; this queues for the post-cycle release train (chart re-publish happens only on merge to `main`).

## Root cause (verified in-repo, no live cluster)

The bp-powerdns **1.2.18** §854 flip (commit `3ce78f0d7`, Refs #4765 — "ZERO NodePorts") eradicated the anycast NodePort Service. Diff (`platform/powerdns/chart/templates/anycast-endpoint.yaml`): the `nodePort` port field was removed, `serviceType=NodePort` was made a hard `{{ fail }}`, and the Service became `type=LoadBalancer` + `allocateLoadBalancerNodePorts: false` (Cilium LB-IPAM shared VIP).

- **Huawei/kom4dc/contabo:** cloud-init sets `CILIUM_LB_IPAM_CIDRS=<node_external_ip>/32` → the LB-IPAM VIP == CP-node public IP → `node:53` binds. Front door never broke.
- **Hetzner:** the LB-IPAM `sovereign-vip` pool is gated OFF (hcloud-ccm owns LBs) and hcloud-ccm cannot materialise the anycast Service (no `load-balancer.hetzner.cloud/location` annotation, no nodePort target) → `EXTERNAL-IP <pending>` → the tofu `dns` LB `:53 → node:53` forward has **no listener** → Hetzner Sovereign has no DNS front door (and thus no self-cert issuance / console reachability).

## Fix state — already restored on `main` (PR #5090, chart 1.2.21)

The §854-clean **runtime** fix already shipped in `platform/powerdns/chart/templates/dnsdist.yaml` (`0c0858866`, chart 1.2.21): `dnsdist.hostPortMode` (default `false` → Deployment/anycast-VIP path unchanged; `true` → DaemonSet binding **hostPort:53** UDP+TCP on every node the Hetzner DNS LB targets, tolerate-all, **no hostNetwork**). Gated to Hetzner via the cloud-init `POWERDNS_DNSDIST_HOSTPORT` substitute (inside the `provider == "hetzner"` block only). **hostPort ONLY — never a NodePort.** Independently re-verified here via `helm template` (both modes).

## What this PR adds — the missing regression lock

The 1.2.21 fix had **zero automated coverage** (the chart `tests/` dir asserted only HTTPRoute + observability). This adds `tests/hetzner-frontdoor-render.sh`, which the CI per-chart test runner (`blueprint-release.yaml`) auto-executes, asserting the §854 front-door render contract both ways:

1. default → dnsdist `Deployment` + `ClusterIP` Service, no `hostPort` (Huawei/kom4dc VIP path intact)
2. anycast Service → `type: LoadBalancer` + `allocateLoadBalancerNodePorts: false`, no `nodePort` field
3. `dnsdist.hostPortMode=true` → `DaemonSet` + `hostPort: 53` (UDP+TCP), tolerations `operator: Exists`, no `hostNetwork`
4. §854 — neither render carries `type: NodePort` or a `nodePort:` field
5. §854 hard guard — `anycast.serviceType=NodePort` **fails** the render

No chart behaviour change: rendered manifests are byte-identical to 1.2.21. Chart bumped **1.2.21 → 1.2.22** with `blueprint.yaml` + catalog-seed (`spec.version` + `source.version`) + bootstrap-kit pin lockstep so the merge-time GHCR publish does not collide with the already-published 1.2.21 tag.

## Render evidence (external address + zero NodePorts)

`helm template platform/powerdns/chart` (upstream subchart stubbed offline):

```
DEFAULT (Huawei/kom4dc/contabo):
  templates/dnsdist.yaml   -> kind: Deployment ; Service type: ClusterIP ; hostPort/nodePort: (none)
  templates/anycast-endpoint.yaml -> kind: Service ; type: LoadBalancer ; allocateLoadBalancerNodePorts: false

HETZNER (--set dnsdist.hostPortMode=true):
  templates/dnsdist.yaml   -> kind: DaemonSet ; hostPort: 53 (UDP) ; hostPort: 53 (TCP) ; nodePort: (none)
```

The Hetzner external address is the tofu `dns` LoadBalancer (`infra/providers/hetzner/main.tf`) targeting `node-IP:53`, now backed by the hostPort:53 DaemonSet listener — no NodePort anywhere in the path.

## Gates (all green locally)

- `scripts/check-no-nodeports.sh` → `OK: zero NodePorts across sources + rendered charts (#4765)` (exit 0)
- `tests/hetzner-frontdoor-render.sh` → all 5 cases PASS (exit 0)
- `scripts/check-bootstrap-kit-pin-sync.sh` → `bp-powerdns: chart=1.2.22 pin=1.2.22`
- `scripts/check-catalog-seed-lockstep.sh` → `0 fail`
- `go test` (bootstrap-kit) → `BlueprintVersionLockstepSweep` + `CatalogSeed_DeliveryPinsNotBehindComponentCharts` + `CatalogSeed_DisplayVersionNotBehindDeliveryPin` → `ok`

## Remaining (prov-gated, unchanged from #5086)

The live `dig @<hetzner-node> <fqdn>` proof from an external vantage still requires a standing Hetzner Sovereign (none up — Huawei kom4dc lane is active, one-env-at-a-time canon). This PR hardens the code contract; it does not substitute for that live walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)