### PR TITLE
fix(#5317): read-back-verify replica consumer-hub secret sync before counting synced

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -249,6 +249,22 @@ const (
 	// zero falls back to the defaults below.
 	clusterMeshStartupRetryIntervalDefault = 5 * time.Second
 	clusterMeshStartupRetryBudgetDefault   = 3 * time.Minute
+
+	// #5317 — bounded inner verify-and-re-write budget for
+	// syncSharedPGConsumerHubSecrets. Each write of a consumer-hub Secret
+	// onto a replica region is READ BACK to confirm it actually landed;
+	// copySecretAcrossClusters reports success the instant the replica
+	// apiserver accepts the Create/Update, yet region-b's bp-postgres flux
+	// Kustomization can GC the not-yet-flux-owned Secret straight back out of
+	// shared-data during its early reconcile window (hw283: 'synced 13'
+	// logged while region-b held ZERO consumer secrets → keycloak-0 stuck
+	// Init:0/1 for 78min). If the read-back shows the Secret absent/divergent
+	// the sync re-asserts it up to Attempts times, pacing by Backoff, before
+	// deferring the rest to the next level-triggered pass (steady-state heal
+	// / convergence backoff). The Handler fields consumerHubSyncVerify*
+	// override these for tests; zero falls back to the defaults below.
+	consumerHubSyncVerifyAttemptsDefault = 4
+	consumerHubSyncVerifyBackoffDefault  = 3 * time.Second
 )
 
 // ClusterMesh-gated cnpg-pair enable (#3236) — names of the Flux
@@ -1924,12 +1940,29 @@ func (h *Handler) syncSharedPGReplicaAuthSecrets(ctx context.Context, dep *Deplo
 // replica), so pushing it would make things WORSE; skipping waits for the next
 // pass. Single-region (len(slots)<2) is a no-op.
 //
-// #5261 COMPLETION STEP: a replica pass that actually DELIVERED hub bytes
-// (copySecretAcrossClusters changed=true — the moment the missing input
-// arrives) closes its own loop by force-reconciling that replica's
-// flux-system HelmReleases which wedged BEFORE the delivery
-// (forceReconcileStalledReplicaHelmReleases). Steady-state passes (no byte
-// change) never kick, so the #3241/#3583 no-thrash contract holds.
+// #5317 VERIFY-AND-RETRY: copySecretAcrossClusters reports success the
+// instant the replica apiserver ACCEPTS the write, but on a fresh 2-region
+// prov the replica's bp-postgres flux Kustomization (owns shared-data with
+// prune=true) can garbage-collect the not-yet-flux-owned Secret straight back
+// out of the namespace during its early reconcile window. On hw283 that made
+// this sync log `synced 13` off the optimistic accept while region-b's
+// shared-data held ZERO consumer secrets, so keycloak-0 sat Init:0/1 for 78min
+// on `secret "keycloak-database-secret" not found` and the whole replica
+// SSO/app tier wedged (the prov FAILED). Every write is therefore READ BACK
+// (copyAndVerifyConsumerHubSecret) — a Secret is counted in the HONEST `synced`
+// total, and its stalled HRs force-reconciled, ONLY once a fresh Get confirms
+// the bytes present on the replica; an unverified write is logged and left for
+// the next level-triggered pass to re-assert. The count this emits can never
+// overstate delivery.
+//
+// #5261 COMPLETION STEP: a replica pass that actually DELIVERED hub bytes AND
+// verified them present (copyAndVerifyConsumerHubSecret delivered=true — the
+// moment the missing input arrives AND lands) closes its own loop by
+// force-reconciling that replica's flux-system HelmReleases which wedged
+// BEFORE the delivery (forceReconcileStalledReplicaHelmReleases). Steady-state
+// passes (no byte change) and unverified writes never kick, so the #3241/#3583
+// no-thrash contract holds and keycloak is never kicked against a Secret that
+// is not actually there.
 func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deployment, slots []regionSlot) {
 	if len(slots) < 2 {
 		return // single-region — no replica to sync to
@@ -1970,23 +2003,41 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 				"id", dep.ID, "secret", name, "host", host)
 			continue
 		}
-		copied := true
+		// #5317 — a Secret name goes into `synced` (the HONEST count) ONLY
+		// when a read-back confirms it present+matching on EVERY replica
+		// region this pass. A write the apiserver accepted but that did not
+		// survive (region-b flux GC'd it) is NOT counted, so the emitted
+		// "synced N" can never overstate delivery.
+		verifiedOnAllReplicas := true
 		for i := 1; i < len(slots); i++ {
 			replica := &slots[i]
 			if replica.clientset == nil {
-				copied = false
+				verifiedOnAllReplicas = false
 				continue
 			}
-			changed, err := h.copySecretAcrossClusters(ctx, src, replica.clientset, sharedPGNamespace)
+			delivered, verified, err := h.copyAndVerifyConsumerHubSecret(ctx, src, replica.clientset, sharedPGNamespace)
 			if err != nil {
 				h.log.Warn("clustermesh: shared-pg consumer-hub sync: copy to replica failed — skipping this Secret/region (best-effort, re-run converges)",
 					"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name, "err", err)
-				copied = false
+				verifiedOnAllReplicas = false
 				continue
 			}
-			if changed {
+			if !verified {
+				// #5317 — the write did NOT land (or did not survive) on the
+				// replica: the read-back found the Secret absent/divergent after
+				// the write. Do NOT count it as synced and do NOT kick this
+				// replica's stalled HRs against a Secret that is not there (the
+				// exact failure #5263's force-reconcile could not cover); the
+				// next level-triggered pass re-asserts it.
+				h.log.Warn("clustermesh: shared-pg consumer-hub sync: write did NOT land on replica (read-back absent/divergent) — NOT counting as synced, will retry on the next level-triggered pass (#5317, best-effort)",
+					"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name)
+				verifiedOnAllReplicas = false
+				continue
+			}
+			if delivered {
 				// #5261 — this pass DELIVERED hub bytes to this replica (create
-				// or heal), so its pre-delivery stalled HRs get kicked below.
+				// or heal) AND the read-back verified them present, so its
+				// pre-delivery stalled HRs get kicked below.
 				deliveredToReplica[i] = true
 			}
 			// #4878 (+ residual, live hw232): after we OVERWRITE the replica's
@@ -2011,23 +2062,26 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 				h.reconcileSharedPGConsumerRestart(ctx, dep, replica, name, target, src)
 			}
 		}
-		if copied {
+		if verifiedOnAllReplicas {
 			synced = append(synced, name)
 		}
 	}
 
 	if len(synced) > 0 {
-		h.log.Info("clustermesh: shared-pg consumer-hub Secrets synced primary → replica region(s) (#3629 cross-region consumer DB host/password)",
+		// #5317 — `synced` carries ONLY Secrets a read-back confirmed present
+		// on every replica this pass, so this count is honest by construction.
+		h.log.Info("clustermesh: shared-pg consumer-hub Secrets synced + verified primary → replica region(s) (#3629 cross-region consumer DB host/password; #5317 read-back confirmed present)",
 			"id", dep.ID, "namespace", sharedPGNamespace, "secrets", synced, "replicaRegions", len(slots)-1)
 		h.emitClusterMeshProgress(dep, "info",
-			fmt.Sprintf("ClusterMesh: synced %d shared-pg consumer-hub Secret(s) (%s) primary → %d replica region(s) — cross-region consumer DB host/password (#3629)",
+			fmt.Sprintf("ClusterMesh: synced %d shared-pg consumer-hub Secret(s) (%s) primary → %d replica region(s) — read-back verified present on the replica (#3629, #5317)",
 				len(synced), strings.Join(synced, ", "), len(slots)-1))
 	}
 
 	// #5261 — the cascade closes its own loop: every replica that received
-	// changed hub bytes THIS pass gets its pre-delivery stalled flux-system
-	// HelmReleases force-reconciled. Best-effort: a kick failure never fails
-	// the sync (matching the #4878 consumer-restart idiom above).
+	// changed hub bytes THIS pass AND had them read-back-verified present
+	// (#5317) gets its pre-delivery stalled flux-system HelmReleases
+	// force-reconciled. Best-effort: a kick failure never fails the sync
+	// (matching the #4878 consumer-restart idiom above).
 	for i := 1; i < len(slots); i++ {
 		if !deliveredToReplica[i] {
 			continue
@@ -2601,6 +2655,107 @@ func (h *Handler) updateCopiedSecret(ctx context.Context, desired *corev1.Secret
 		return false, fmt.Errorf("Update Secret %s/%s on replica (race fallback): %w", namespace, desired.Name, updErr)
 	}
 	return true, nil
+}
+
+// copyAndVerifyConsumerHubSecret (#5317) writes src onto the replica's
+// shared-data namespace and then READS THE SECRET BACK to confirm the bytes
+// actually landed — the anti-optimism guard that closes the hw283 no-op.
+//
+// copySecretAcrossClusters reports success the instant the replica apiserver
+// ACCEPTS the Create/Update, but on a fresh 2-region prov the replica's
+// bp-postgres flux Kustomization (which owns shared-data with prune=true) can
+// garbage-collect the not-yet-flux-owned consumer-hub Secret straight back out
+// of the namespace during its early reconcile window. The old sync logged
+// `synced 13` off that optimistic accept while region-b's shared-data held
+// ZERO consumer secrets, so keycloak-0 sat Init:0/1 for 78min on
+// `secret "keycloak-database-secret" not found` and the whole replica SSO/app
+// tier wedged. Reading the Secret back — and RE-ASSERTING it up to
+// consumerHubSyncVerifyAttempts times when the read-back shows it absent or
+// divergent — makes the sync self-healing against that GC flap within a single
+// pass; anything still unverified after the bounded budget defers to the next
+// level-triggered pass (steady-state heal / convergence backoff), which keeps
+// re-running until the read-back finally confirms the Secret present.
+//
+// Returns:
+//   - delivered: this call actually WROTE changed bytes AND the read-back
+//     confirms them present (the #5261 force-reconcile "the missing input just
+//     arrived AND landed" signal — a steady-state pass that found the Secret
+//     already present returns delivered=false so it never re-kicks).
+//   - verified: the Secret is confirmed present+matching on the replica right
+//     now (present-from-the-start OR just-delivered). Only a verified Secret is
+//     counted in the honest `synced` total.
+//   - err: a hard client error on the final attempt (best-effort — the caller
+//     logs it and skips the Secret/region; the level-triggered re-run converges
+//     it). A persistently-absent Secret (write accepted, read-back NotFound)
+//     returns (wrote, false, nil): not an error, just unverified — retry later.
+func (h *Handler) copyAndVerifyConsumerHubSecret(ctx context.Context, src *corev1.Secret, dst kubernetes.Interface, namespace string) (delivered bool, verified bool, err error) {
+	attempts := h.consumerHubSyncVerifyAttempts
+	if attempts <= 0 {
+		attempts = consumerHubSyncVerifyAttemptsDefault
+	}
+	backoff := h.consumerHubSyncVerifyBackoff
+	if backoff <= 0 {
+		backoff = consumerHubSyncVerifyBackoffDefault
+	}
+
+	wrote := false
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		changed, copyErr := h.copySecretAcrossClusters(ctx, src, dst, namespace)
+		if copyErr != nil {
+			lastErr = copyErr
+		} else {
+			if changed {
+				wrote = true
+			}
+			// Read the Secret back from the replica to confirm the write
+			// actually landed (or was already present+matching). A copy the
+			// apiserver accepted but GC'd straight back out reads NotFound
+			// here → not verified → re-assert on the next inner attempt.
+			present, verifyErr := h.consumerHubSecretPresentAndMatches(ctx, src, dst, namespace)
+			if verifyErr != nil {
+				lastErr = verifyErr
+			} else if present {
+				return wrote, true, nil
+			} else {
+				// A landed-then-verified-present pass clears lastErr; an
+				// unverified pass is NOT an error, so don't leave a stale one.
+				lastErr = nil
+			}
+		}
+		if attempt < attempts {
+			if sleepErr := sleepCtx(ctx, backoff); sleepErr != nil {
+				return wrote, false, sleepErr
+			}
+		}
+	}
+	return wrote, false, lastErr
+}
+
+// consumerHubSecretPresentAndMatches (#5317) reports whether the replica now
+// holds the consumer-hub Secret with region-A's authoritative bytes. Used by
+// copyAndVerifyConsumerHubSecret as the read-back verify: it Gets the Secret
+// fresh from the replica and compares Type + effective data against the source,
+// reusing the exact secretContentMatches semantics copySecretAcrossClusters
+// writes with (so a divergent leftover the writer would have overwritten does
+// NOT read as present). A NotFound reads as (false, nil) — absent, keep
+// retrying — never an error.
+func (h *Handler) consumerHubSecretPresentAndMatches(ctx context.Context, src *corev1.Secret, dst kubernetes.Interface, namespace string) (bool, error) {
+	desired := &corev1.Secret{
+		Type:       src.Type,
+		Data:       src.Data,
+		StringData: src.StringData,
+	}
+	getCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	defer cancel()
+	got, err := dst.CoreV1().Secrets(namespace).Get(getCtx, src.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read-back Secret %s/%s on replica: %w", namespace, src.Name, err)
+	}
+	return secretContentMatches(got, desired), nil
 }
 
 // clusterMeshDynamicClient builds a dynamic.Interface for the cluster

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -3064,6 +3064,239 @@ func TestSyncSharedPGConsumerHubSecrets_KicksStalledHRsOnDeliveryPassOnly(t *tes
 	}
 }
 
+// ── #5317 — verify-and-retry: read-back before counting a Secret synced ──
+
+// TestSyncSharedPGConsumerHubSecrets_VerifyAndRetry locks in the #5317 fix for
+// the hw283 wedge (dep 101cd122d394af22): the consumer-hub sync logged
+// `synced 13` off the OPTIMISTIC copySecretAcrossClusters accept while
+// region-b's shared-data held ZERO consumer secrets — the replica's bp-postgres
+// flux Kustomization GC'd the not-yet-flux-owned Secret straight back out of
+// shared-data — so keycloak-0 sat Init:0/1 for 78min on
+// `secret "keycloak-database-secret" not found` and the whole replica SSO/app
+// tier wedged, failing the 2-region prov (#5263's force-reconcile could not
+// cover it because the Secret was NEVER delivered). The sync must now READ THE
+// SECRET BACK after each write and (a) re-assert a write the apiserver accepted
+// but did not persist until it lands, (b) NEVER count / NEVER kick a Secret a
+// read-back cannot confirm present, (c) tally an HONEST count of only the
+// read-back-verified Secrets.
+func TestSyncSharedPGConsumerHubSecrets_VerifyAndRetry(t *testing.T) {
+	const secretName = "keycloak-database-secret"
+	const meshRWHost = "shared-pg-mesh-rw.shared-data.svc.cluster.local"
+
+	// noPersistCreateReactor returns a "create" reactor that ACCEPTS the write
+	// (as the apiserver does) but does NOT store the object when gc() is true —
+	// the region-b flux GC flap. When gc() returns false the reactor falls
+	// through so the fake's tracker persists the Secret normally.
+	noPersistCreateReactor := func(gc func() bool) ktesting.ReactionFunc {
+		return func(action ktesting.Action) (bool, runtime.Object, error) {
+			if action.GetNamespace() != sharedPGNamespace {
+				return false, nil, nil
+			}
+			if gc() {
+				return true, action.(ktesting.CreateAction).GetObject(), nil // accepted, not stored
+			}
+			return false, nil, nil // settle — let the tracker persist it
+		}
+	}
+
+	// (b) write-then-verify catches a silent no-op and RE-ASSERTS within one
+	// pass until the read-back confirms the Secret present.
+	t.Run("silent-no-op-then-lands-is-reasserted-within-one-pass", func(t *testing.T) {
+		var logBuf bytes.Buffer
+		h := &Handler{
+			log:                           slog.New(slog.NewTextHandler(&logBuf, nil)),
+			consumerHubSyncVerifyAttempts: 6,
+			consumerHubSyncVerifyBackoff:  time.Millisecond,
+		}
+		dep := &Deployment{ID: "dep-5317-b"}
+
+		primaryCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, secretName, meshRWHost, "region-A-pw")
+
+		replicaCS := kfake.NewSimpleClientset()
+		var creates int
+		replicaCS.PrependReactor("create", "secrets", noPersistCreateReactor(func() bool {
+			creates++
+			return creates <= 2 // first two writes are GC'd; the third settles
+		}))
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		if creates < 3 {
+			t.Fatalf("create called %d times — the sync did not re-assert the Secret past the GC flap (want >=3, #5317)", creates)
+		}
+		got, ok := getSharedDataSecret(t, replicaCS, secretName)
+		if !ok {
+			t.Fatalf("replica Secret still absent after verify-retry — the GC-flap self-heal did not converge (#5317)")
+		}
+		if p := string(got.Data["password"]); p != "region-A-pw" {
+			t.Errorf("replica password = %q, want the authoritative region-A password", p)
+		}
+		if !hasClusterMeshEvent(dep, "info", "synced 1", secretName) {
+			t.Errorf("the landed Secret was not reported synced after read-back verify (honest count missing, #5317); events:\n%s", dumpClusterMeshEvents(dep))
+		}
+	})
+
+	// (b′) ANTI-THEATER: a write the apiserver accepts but that NEVER lands
+	// must NOT be counted synced and must NOT be emitted as delivered.
+	// Reverting to the optimistic count (append on copySecretAcrossClusters
+	// success, no read-back) makes this fail — that is the hw283 lie.
+	t.Run("silent-no-op-forever-is-never-counted", func(t *testing.T) {
+		var logBuf bytes.Buffer
+		h := &Handler{
+			log:                           slog.New(slog.NewTextHandler(&logBuf, nil)),
+			consumerHubSyncVerifyAttempts: 3,
+			consumerHubSyncVerifyBackoff:  time.Millisecond,
+		}
+		dep := &Deployment{ID: "dep-5317-noop"}
+
+		primaryCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, secretName, meshRWHost, "region-A-pw")
+
+		replicaCS := kfake.NewSimpleClientset()
+		replicaCS.PrependReactor("create", "secrets", noPersistCreateReactor(func() bool { return true }))
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		if _, ok := getSharedDataSecret(t, replicaCS, secretName); ok {
+			t.Fatalf("replica Secret unexpectedly present — the reactor was supposed to model a permanent GC")
+		}
+		if strings.Contains(logBuf.String(), "consumer-hub Secrets synced") {
+			t.Errorf("sync logged a 'synced' success while the read-back found the Secret ABSENT on the replica — the #5317 verify was bypassed (the hw283 lie):\n%s", logBuf.String())
+		}
+		if hasClusterMeshEvent(dep, "info", "synced 1") {
+			t.Errorf("emitted a 'synced' progress event while region-b held zero consumer secrets — #5317 verify bypassed; events:\n%s", dumpClusterMeshEvents(dep))
+		}
+		if !strings.Contains(logBuf.String(), "write did NOT land") {
+			t.Errorf("expected the #5317 'write did NOT land' warning when the read-back found the Secret absent, got:\n%s", logBuf.String())
+		}
+	})
+
+	// (a) target-namespace-absent-at-first → the write errors and nothing is
+	// counted; once the replica's shared-data namespace materialises a later
+	// level-triggered pass lands + verifies the Secret.
+	t.Run("target-namespace-absent-at-first-then-lands-once-it-appears", func(t *testing.T) {
+		var logBuf bytes.Buffer
+		h := &Handler{
+			log:                           slog.New(slog.NewTextHandler(&logBuf, nil)),
+			consumerHubSyncVerifyAttempts: 3,
+			consumerHubSyncVerifyBackoff:  time.Millisecond,
+		}
+		dep := &Deployment{ID: "dep-5317-a"}
+
+		primaryCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, secretName, meshRWHost, "region-A-pw")
+
+		replicaCS := kfake.NewSimpleClientset()
+		var nsReady bool
+		replicaCS.PrependReactor("create", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if action.GetNamespace() != sharedPGNamespace {
+				return false, nil, nil
+			}
+			if !nsReady {
+				// The replica's shared-data namespace does not exist yet — the
+				// apiserver rejects the Secret create with NotFound.
+				return true, nil, apierrors.NewNotFound(corev1.Resource("namespaces"), sharedPGNamespace)
+			}
+			return false, nil, nil
+		})
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+
+		// Pass 1 — namespace absent: every write errors → NOTHING synced, Secret absent.
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+		if _, ok := getSharedDataSecret(t, replicaCS, secretName); ok {
+			t.Fatalf("replica Secret present despite the target namespace being absent on pass 1")
+		}
+		if strings.Contains(logBuf.String(), "consumer-hub Secrets synced") {
+			t.Errorf("pass 1 claimed a Secret synced while the write errored (namespace absent):\n%s", logBuf.String())
+		}
+		if !strings.Contains(logBuf.String(), "copy to replica failed") {
+			t.Errorf("pass 1 did not surface the namespace-absent write failure:\n%s", logBuf.String())
+		}
+
+		// The replica's shared-data namespace materialises (its bp-postgres
+		// reconciles) → the next level-triggered pass lands + verifies the Secret.
+		nsReady = true
+		logBuf.Reset()
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+		got, ok := getSharedDataSecret(t, replicaCS, secretName)
+		if !ok {
+			t.Fatalf("replica Secret still absent after the namespace appeared — the level-triggered retry did not converge (#5317)")
+		}
+		if p := string(got.Data["password"]); p != "region-A-pw" {
+			t.Errorf("replica password = %q, want the authoritative region-A password", p)
+		}
+		if !hasClusterMeshEvent(dep, "info", "synced 1", secretName) {
+			t.Errorf("Secret was not reported synced after it landed on pass 2 (#5317); events:\n%s", dumpClusterMeshEvents(dep))
+		}
+	})
+
+	// (c) honest count: with TWO source Secrets where one lands and one is
+	// GC'd forever, the emitted count tallies ONLY the verified-present one.
+	t.Run("honest-count-tallies-only-verified-secrets", func(t *testing.T) {
+		var logBuf bytes.Buffer
+		h := &Handler{
+			log:                           slog.New(slog.NewTextHandler(&logBuf, nil)),
+			consumerHubSyncVerifyAttempts: 3,
+			consumerHubSyncVerifyBackoff:  time.Millisecond,
+		}
+		dep := &Deployment{ID: "dep-5317-c"}
+
+		primaryCS := kfake.NewSimpleClientset()
+		// grafana lands; keycloak is GC'd forever on the replica.
+		seedHubSecret(t, primaryCS, "grafana-database-env", meshRWHost, "grafana-pw")
+		seedHubSecret(t, primaryCS, "keycloak-database-secret", meshRWHost, "keycloak-pw")
+
+		replicaCS := kfake.NewSimpleClientset()
+		replicaCS.PrependReactor("create", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if action.GetNamespace() != sharedPGNamespace {
+				return false, nil, nil
+			}
+			if ca, ok := action.(ktesting.CreateAction); ok {
+				if s, ok := ca.GetObject().(*corev1.Secret); ok && s.Name == "keycloak-database-secret" {
+					return true, ca.GetObject(), nil // keycloak: accepted but GC'd
+				}
+			}
+			return false, nil, nil // grafana settles
+		})
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		if _, ok := getSharedDataSecret(t, replicaCS, "grafana-database-env"); !ok {
+			t.Fatalf("grafana Secret absent — the verified-present Secret did not land")
+		}
+		if _, ok := getSharedDataSecret(t, replicaCS, "keycloak-database-secret"); ok {
+			t.Fatalf("keycloak Secret present — the reactor was supposed to GC it forever")
+		}
+		// Honest count = 1, naming ONLY the landed Secret.
+		if !hasClusterMeshEvent(dep, "info", "synced 1", "grafana-database-env") {
+			t.Errorf("expected an honest 'synced 1 (grafana-database-env)' event; events:\n%s", dumpClusterMeshEvents(dep))
+		}
+		if hasClusterMeshEvent(dep, "info", "keycloak-database-secret") {
+			t.Errorf("emitted event named the un-landed keycloak Secret as synced — the count is not honest (#5317); events:\n%s", dumpClusterMeshEvents(dep))
+		}
+		if !strings.Contains(logBuf.String(), "write did NOT land") {
+			t.Errorf("expected the #5317 'write did NOT land' warning for the GC'd keycloak Secret, got:\n%s", logBuf.String())
+		}
+	})
+}
+
 // TestAutoEstablishClusterMesh_ConsumerHubSecretsSyncPreMesh locks in #5230:
 // the #3629 consumer-hub Secret sync must fire from the EARLY per-slot phase of
 // autoEstablishClusterMesh — clustermesh NOT required — not from behind the

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -987,6 +987,14 @@ func TestRestoreFromStore_StartupKicksClusterMeshReconcile(t *testing.T) {
 	h.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
 	h.clusterMeshRetryBudget = 20 * time.Second
 	h.clusterMeshAttemptTimeout = 5 * time.Second
+	// #5317: shrink the consumer-hub secret verify-retry backoff so the
+	// startup-kicked reconcile goroutine finishes within the test body.
+	// The default 3s×4 would keep the goroutine writing to t.TempDir()
+	// after the test returns, racing t.TempDir()'s RemoveAll cleanup
+	// ("directory not empty"). Same rationale as the clusterMeshRetry*
+	// overrides above.
+	h.consumerHubSyncVerifyBackoff = 20 * time.Millisecond
+	h.consumerHubSyncVerifyAttempts = 3
 
 	h.restoreFromStore()
 

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -282,6 +282,26 @@ type Handler struct {
 	// production leaves it at zero.
 	clusterMeshSteadyStateInterval time.Duration
 
+	// consumerHubSyncVerify* (#5317) — bounded inner verify-and-re-write
+	// budget for syncSharedPGConsumerHubSecrets. After each write of a
+	// consumer-hub Secret onto a replica region the sync READS THE SECRET
+	// BACK to confirm the bytes actually landed. copySecretAcrossClusters
+	// returns success the instant the replica apiserver ACCEPTS the write,
+	// but on a fresh 2-region prov the replica's bp-postgres flux
+	// Kustomization (owns shared-data with prune=true) can garbage-collect
+	// the not-yet-flux-owned Secret straight back out of the namespace during
+	// its early reconcile window — the hw283 no-op where 'synced 13' was
+	// logged while region-b's shared-data held ZERO consumer secrets and
+	// keycloak-0 sat Init:0/1 for 78min on `secret
+	// "keycloak-database-secret" not found`. When the read-back shows the
+	// Secret absent/divergent the sync re-asserts it up to Attempts times,
+	// pacing by Backoff, before deferring the rest to the next
+	// level-triggered pass. Zero falls back to the consumerHubSyncVerify*Default
+	// constants in clustermesh.go. Tests inject tiny values so the
+	// verify-retry runs in microseconds; production leaves both at zero.
+	consumerHubSyncVerifyAttempts int
+	consumerHubSyncVerifyBackoff  time.Duration
+
 	// clusterMeshStartupRetry* (#4811) — bounded retry for the STARTUP
 	// ClusterMesh reconcile when restoreFromStore finds a ready multi-region
 	// deployment whose primary kubeconfig was merely UNRESOLVED at restore.


### PR DESCRIPTION
## Problem (hw283, dep 101cd122d394af22, 2026-07-21)

Fresh 2-region prov **failed** in phase-1: region-b `keycloak-0` sat `Init:0/1` for 78min on `MountVolume.SetUp failed ... secret "keycloak-database-secret" not found`, `bp-keycloak` flux hit `RetriesExceeded`, and `bp-gitea`/`bp-sso-bridge`/app-tier all wedged at `dependency 'bp-keycloak' is not ready` → region-b stuck 52/67 HR → phase-1 watch context-cancelled → deployment `failed`. DBs were healthy — purely the **secret sync**.

The ClusterMesh log claimed `ClusterMesh: synced 13 shared-pg consumer-hub Secret(s) (…keycloak-database-secret…)` while region-b's `shared-data` held **ZERO** consumer secrets — a no-op that logged success.

## Root cause (file:line)

`products/catalyst/bootstrap/api/internal/handler/clustermesh.go` — `syncSharedPGConsumerHubSecrets`. The sync appended a Secret to the `synced` count (and set the #5261 `deliveredToReplica` force-reconcile flag) whenever `copySecretAcrossClusters` returned **no error**. `copySecretAcrossClusters` reports success the instant the replica apiserver **ACCEPTS** the Create/Update — but on a fresh 2-region prov the replica's `bp-postgres` flux Kustomization (owns `shared-data` with `prune=true`) can garbage-collect the not-yet-flux-owned Secret straight back out of `shared-data` during its early reconcile window. The accept succeeds; the Secret never lands. There was **no read-back** to confirm the bytes present, so an accepted-then-GC'd write was logged as `synced`. The old code's only convergence relied on a level-triggered re-run whose own success signal was equally optimistic.

### Why #5263 didn't cover it
#5263 force-reconciles a stalled keycloak HR once the secret is **delivered**. Here the secret was **never delivered** (the sync no-op'd), so the delivery-gated kick never fired. This defect is **upstream** of #5263.

## Fix — verify-and-retry (idempotent, self-healing)

- New `copyAndVerifyConsumerHubSecret`: after each write, **READ THE SECRET BACK** from the replica (`consumerHubSecretPresentAndMatches`, reusing the exact `secretContentMatches` semantics the writer uses). A Secret is counted in the honest `synced` total — and its pre-delivery stalled HRs force-reconciled — **only once a fresh Get confirms it present+matching** on the replica.
- An accepted-but-absent write **re-asserts** up to `consumerHubSyncVerifyAttempts` times (bounded inner loop paced by `consumerHubSyncVerifyBackoff`, both test-overridable Handler knobs; defaults 4 / 3s) to close the GC flap within one pass. Anything still unverified defers to the next **level-triggered** pass (steady-state heal / convergence backoff), which re-runs until the read-back confirms present.
- Honest count: the emitted `synced N` now reflects **only read-back-verified** Secrets, so it can never overstate delivery. An unverified write logs `write did NOT land … will retry` and does **not** kick keycloak against a Secret that isn't there.
- A steady-state pass (already present) does **zero** writes and never re-kicks — the #3241/#3583 no-thrash contract holds. The #5261 delivery-gated kick now fires on `delivered = wrote-this-pass AND verified-present`.

## Tests

`TestSyncSharedPGConsumerHubSecrets_VerifyAndRetry` (fake region-b client via reactors):
- **silent-no-op-then-lands** — an accepted-but-GC'd write is re-asserted within one pass until the read-back confirms present.
- **silent-no-op-forever** — a write that never lands is NEVER counted synced / NEVER emitted delivered. **Anti-theater**: neutering the read-back makes this fail (verified locally — the neutered code emits `synced 2` including the un-landed keycloak secret, the exact hw283 lie).
- **target-namespace-absent-at-first** — the write errors, nothing is counted, and a later pass lands + verifies once the ns appears.
- **honest-count** — one landing + one GC'd-forever Secret → count tallies only the verified-present one.

All existing consumer-hub / #5261 / #5230 tests unchanged and green.

## Gates
`go build ./...` + `go vet ./...` clean; full `bootstrap/api/internal/handler` suite green (`ok … 158.870s`). Only `products/catalyst/bootstrap/api/` is touched; `core/controllers/application/`'s `shared-pg` references are Application-CR adoption/Continuum planning, unrelated to this cross-region sync (unchanged).

No NodePorts. Diagnosis was read-only.

Refs #5317 #5261 #5263 #4915 #4878

🤖 Generated with [Claude Code](https://claude.com/claude-code)