### PR TITLE
fix(cutover): Case 34 asserts lowercase disableredirect per #5302 — unblocks bp-self-sovereign-cutover 0.1.149 publish

### DIFF
--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1330,7 +1330,10 @@ echo "[cutover-contract] Case 34: bootstrap-kit slot 19-harbor disables the blob
 # (#4557), skopeo's dest/src-tls-verify, and a HelmRepo certSecretRef all trust
 # ONLY the registry host -> x509 wedges the step-08 fresh-pull proof + any
 # in-cluster blob fetch under the deny-egress hold. The Sovereign overlay MUST
-# set harbor.persistence.imageChartStorage.disableRedirect: true.
+# set harbor.persistence.imageChartStorage.disableredirect: true — ALL-LOWERCASE
+# per #5302: upstream Harbor's registry-cm template reads only the lowercase
+# key ({{ $storage.disableredirect }}); the camelCase spelling is silently
+# dropped by Helm and left the guard INERT (#5323).
 # Resolve 19-harbor.yaml robustly: the CI harness invokes this script from the
 # repo ROOT as `bash <script> <chart_dir>` ($1=platform/self-sovereign-cutover/
 # chart), so derive the slot path from $CHART_DIR (4 levels up to repo root)
@@ -1345,11 +1348,11 @@ for cand in \
   [ -n "$cand" ] && [ -f "$cand" ] && { HARBOR_SLOT="$cand"; break; }
 done
 if [ -n "$HARBOR_SLOT" ]; then
-  if ! grep -Eq 'disableRedirect:[[:space:]]*true' "$HARBOR_SLOT"; then
-    echo "FAIL: 19-harbor.yaml does not set imageChartStorage.disableRedirect: true — blob GETs 302 to the OBS host and x509 the in-cluster TLS-pinned cutover clients (#4573 F2)" >&2
+  if ! grep -Eq 'disableredirect:[[:space:]]*true' "$HARBOR_SLOT"; then
+    echo "FAIL: 19-harbor.yaml does not set imageChartStorage.disableredirect: true (ALL-LOWERCASE per #5302 — camelCase is Helm-dropped/inert) — blob GETs 302 to the OBS host and x509 the in-cluster TLS-pinned cutover clients (#4573 F2)" >&2
     exit 1
   fi
-  echo "  PASS (19-harbor.yaml sets imageChartStorage.disableRedirect: true — registry streams blobs directly from registry.<fqdn>, no OBS 302)"
+  echo "  PASS (19-harbor.yaml sets imageChartStorage.disableredirect: true — registry streams blobs directly from registry.<fqdn>, no OBS 302)"
 else
   echo "  SKIP (19-harbor.yaml not reachable from test cwd — chart consumed standalone)"
 fi


### PR DESCRIPTION
## What
Cutover-contract **Case 34** still grepped the camelCase `disableRedirect:` in `clusters/_template/bootstrap-kit/19-harbor.yaml`. #5302/#5303 renamed that key to ALL-LOWERCASE `disableredirect: true` (the camelCase spelling is silently dropped by Helm and never reaches Harbor's registry-cm — the exact defect #5302 fixed). The stale assertion failed the blueprint-release publish of the #5310 bump (run 29788416404), leaving `bp-self-sovereign-cutover:0.1.149` pinned in the catalog but **absent from ghcr** — the cutover chart is unpullable on hw284 (HelmChart `0.1.149: not found`, cutover stuck `tethered` 0/0 steps) and on every future fresh prov.

## Fix
Assert the lowercase key (grep + FAIL/PASS messages + comment), matching the #5302 canon. Chart version stays `0.1.149` — it was never published, so the merge's blueprint-release push run publishes exactly the pinned version.

## Verification
Full contract suite green locally from repo root: `bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh platform/self-sovereign-cutover/chart` → `All gates green` (69 cases incl. the fixed Case 34 asserting `disableredirect: true` present at 19-harbor.yaml:414).

Refs #5323, #5310, #5302, #4573

🤖 Generated with [Claude Code](https://claude.com/claude-code)