### PR TITLE
fix(preflight): check-5 counts only roll-capable CI (in_progress/waiting/fresh-queued), not runner-starved queued zombies

### DIFF
--- a/scripts/prov-preflight.sh
+++ b/scripts/prov-preflight.sh
@@ -282,9 +282,37 @@ else
   bad "4b. catalyst-api DEPLOYED=${_deployed_tag} != PINNED=${_pinned_tag} — a deploybot roll is PENDING; it WILL reconcile mid-prov and ABANDON it (hw265). Wait for Flux to roll catalyst-api to the pinned image + settle, THEN fire."
 fi
 
-# 5. NO in-flight Build-&-Deploy / blueprint-release CI (a merge mid-prov rolls catalyst-api -> abandon)
-inflight=$(gh run list --repo openova-io/openova --limit 12 --json name,status -q '[.[]|select(.status!="completed")]|length' 2>/dev/null)
-[ "${inflight:-x}" = "0" ] && pass "5. no in-flight CI (and HOLD all merges until ready)" || bad "5. ${inflight:-unknown} CI run(s) in flight — wait + DO NOT MERGE until prov is ready"
+# 5. NO in-flight Build-&-Deploy / blueprint-release CI (a merge mid-prov rolls catalyst-api -> abandon).
+#    Roll-capable = in_progress / waiting, or queued <15min (a runner may pick it
+#    up any second). A queued run OLDER than 15min is a runner-starved zombie
+#    (#5325, hw285 2026-07-22: a docs-only privacy-redact-guard run sat queued
+#    10+min and failed this gate on 6 consecutive fire attempts; 2026-05-15
+#    zombies queue forever) — it is not progressing and cannot merge/roll
+#    catalyst-api mid-prov, so it must NOT fail the gate; surface it as a
+#    ⚠ info line (id + age) instead. gh/API errors stay fail-closed (unknown -> ❌).
+ci5=$(gh run list --repo openova-io/openova --limit 12 --json databaseId,name,status,createdAt 2>/dev/null | NOW="$(date -u +%s)" python3 -c '
+import sys,json,os,datetime
+now=int(os.environ["NOW"])
+try:
+    runs=json.load(sys.stdin)
+except Exception:
+    sys.exit()  # no output -> read leaves inflight empty -> fail-closed below
+blocking=0; stale=[]
+for r in runs:
+    s=r.get("status")
+    if s in ("completed",None): continue
+    try:
+        age=(now-int(datetime.datetime.strptime(r.get("createdAt",""),"%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc).timestamp()))//60
+    except Exception:
+        age=-1  # unparseable createdAt -> treat as blocking (fail-closed)
+    if s=="queued" and age>=15:
+        stale.append("{} {} queued {}min".format(r.get("name"),r.get("databaseId"),age))
+    else:
+        blocking+=1
+print(blocking, "; ".join(stale))' 2>/dev/null)
+read -r inflight stale_q <<<"${ci5:-}"
+[ -n "${stale_q:-}" ] && echo "  ⚠ 5. runner-starved queued zombie(s) — NOT gate-failing (a queued run cannot roll catalyst-api): ${stale_q}"
+[ "${inflight:-x}" = "0" ] && pass "5. no roll-capable in-flight CI (and HOLD all merges until ready)" || bad "5. ${inflight:-unknown} roll-capable CI run(s) in flight (in_progress/waiting/fresh-queued) — wait + DO NOT MERGE until prov is ready"
 
 # 6. fresh bucket (caller asserts uniqueness)
 pass "6. bucket: ${BUCKET} (caller must confirm it is fresh/unused)"


### PR DESCRIPTION
## HOLD MERGE — merge window opens after hw285 reaches cutoverComplete (mid-prov merge rolls catalyst-api).

Refs #5325
Refs #960

## What

`scripts/prov-preflight.sh` check 5 counted ANY non-completed run in the 12 most recent as in-flight CI. A runner-starved `queued` run cannot roll catalyst-api (no runner has picked it up; nothing merges, builds, or reconciles from it), yet it failed the fire gate.

Tonight (2026-07-22 ~21:15–21:26Z) a docs-only `privacy-redact-guard` run (id **29958477166**, `docs(tracker): auto-refresh 2026-07-22T21:15:03Z`) sat `status=queued` for 10+ minutes and failed check 5 on **6 consecutive hw285 fire attempts (~25 min stalled)**; identical sibling runs at 20:45Z/21:00Z completed in ~2 min. Resolution was cancel-then-fire. The repo also carries `queued` zombies from **2026-05-15** (25907071032, 25907070113) that would fail the gate forever if they ever entered the 12 most recent.

New rule — a run is gate-failing iff:

- `status == in_progress`, OR
- `status == waiting`, OR
- `status == queued` AND created within the last **15 minutes** (a runner may pick it up any second — live proof below).

Queued runs older than 15 min are runner-starved zombies: emitted as a ⚠ info line (name + id + age), gate passes. gh/API/parse errors (and unparseable `createdAt`) remain **fail-closed** (unknown → ❌), exactly as before. Only the check-5 block changed; the WHY comment is preserved and extended.

Under this rule any future starvation window stalls the fire for at most 15 minutes instead of indefinitely, with the zombie surfaced instead of silently gating.

## Validation (live repo API, 2026-07-22 ~21:5xZ)

`bash -n scripts/prov-preflight.sh` → clean.

**Old rule vs new rule on the gate's actual input (12 most recent runs):**

| Snapshot | Old-rule count | New-rule count | Note |
|---|---|---|---|
| 21:48Z (run 29960398718 `queued`, age 3 min) | **1** | **1** | fresh-queued still gate-fails under both rules — correct: that run WAS picked up and completed at ~21:49Z |
| 21:5xZ (after it completed) | **0** | **0** | rules agree when nothing is in flight |

**Real zombie data — the two live 2026-05-15 queued runs fed through both rules (`gh api .../actions/runs?status=queued`, same JSON shape):**

- Old rule: **2** gate-failing (would fail the gate forever)
- New rule: **0** gate-failing, with info line:
  `⚠ 5. runner-starved queued zombie(s) — NOT gate-failing (a queued run cannot roll catalyst-api): Vendor-coupling guardrail 25907071032 queued 98753min; Test — Hetzner Sovereign E2E (real cloud) 25907070113 queued 98753min`

**Fail-closed simulation** (garbage on stdin in place of the gh JSON): count = `unknown` → `❌ 5. unknown roll-capable CI run(s) in flight …` → gate FAIL. Unchanged behavior.

## Explicitly excluded

- Cancelling/cleaning the 2026-05-15 zombie runs themselves (repo hygiene, separate concern).
- Any change to checks 1–4b/6/7 or any other file.
- Runner-capacity scheduling for the docs guards.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
