### PR TITLE
fix(janitor): failed-record reap preserves destroy capability while cloud infra is alive

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -182,6 +182,18 @@ type Handler struct {
 	// want to assert the gate (reachable → ready, down → failed).
 	consoleProbe func(fqdn string) error
 
+	// janitorFailedInfraProbe / janitorFailedDestroy — test-only overrides
+	// for the #5327 failed-record reap gate (janitor.go gateFailedReap).
+	// Production leaves both nil: the gate then uses
+	// failedDeploymentInfraAlive (provider ListServers + the huawei
+	// name-prefix double-check — tags are disabled on HCS) and
+	// destroyFailedDeploymentInfra (the canonical
+	// providers.CloudProvider.Wipe dispatch — the same steps the wipe
+	// handler runs). Tests inject fakes so the preserve / destroy+reap /
+	// fail-closed contract is exercised without a cloud endpoint.
+	janitorFailedInfraProbe func(ctx context.Context, dep *Deployment, tofuWorkDir string) (alive bool, err error)
+	janitorFailedDestroy    func(ctx context.Context, dep *Deployment, tofuWorkDir string) error
+
 	// phase1LatePollTimeout / phase1LatePollInterval — test-only
 	// overrides for the eventual-consistency late-poll window
 	// (issue #910). Zero means "fall back to env var →

--- a/products/catalyst/bootstrap/api/internal/handler/janitor.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor.go
@@ -34,21 +34,35 @@
 //
 //   1. List in-memory + on-disk deployments
 //   2. For each with Status=failed AND age > JanitorFailedMaxAge
-//      (default 24h): delete kubeconfig + tofu workdir + record
+//      (default 24h): PROBE the deployment's cloud inventory FIRST
+//      (#5327). Only when the infra is verifiably GONE: delete
+//      kubeconfig + tofu workdir + record. While the infra is ALIVE
+//      the record + tofu state (the only destroy capability) are
+//      preserved — log-only by default; with
+//      CATALYST_JANITOR_DESTRUCTIVE=true the janitor runs the
+//      canonical cloud destroy (the same providers.CloudProvider.Wipe
+//      steps the wipe handler dispatches) and reaps only after a
+//      verified-gone re-probe. See gateFailedReap.
 //   3. For each with Status=wiped AND wipedAt > JanitorWipedMaxAge
 //      (default 1h): cascading delete kubeconfig + tofu workdir +
 //      record (HCS resources already destroyed during the wipe)
 //   4. Walk kubeconfigsDir + tofuDir for orphan files/dirs whose ID
 //      has no matching record in deployments/ — delete the orphan.
 //
-// We DO NOT call cloud-provider destroy here — that path requires the
-// operator's cloud token which we GC from memory after Phase 0. For
-// failed deployments older than 24h we trust that either:
-//   (a) the operator already wiped via the wizard (Cancel & Wipe), in
-//       which case Status=wiped and we just clean orphans, OR
-//   (b) the operator forgot, in which case the cloud-provider resources
-//       are stranded but the per-cloud orphan-sweep CronJob in the
-//       Sovereign chart picks them up.
+// By default we DO NOT call cloud-provider destroy here. The former
+// rationale for reaping failed records anyway — "either (a) the
+// operator already wiped via the wizard (Status=wiped, we just clean
+// orphans), or (b) the operator forgot and the per-cloud orphan-sweep
+// CronJob in the Sovereign chart picks the leftovers up" — was WRONG
+// for phase-1-failed provs (#5327, hw284 dep 383db23ccaf13be5): a prov
+// that failed in phase 1 has no functioning Sovereign to run that
+// CronJob, and the mothership's own cloud sweeps are log-only by
+// default, so reaping the record + tofu state converted a still-alive
+// 2-region env into an unowned orphan — unaddressable by the canonical
+// wipe endpoint (record gone → 404) and undestroyable by tofu (state
+// gone). The Step-2 reap is therefore gated on the infra actually
+// being gone (gateFailedReap), honouring the same DEBUG-BEFORE-WIPE
+// contract buildActivePrefixes already applies to `failed` infra.
 //
 // What this janitor does NOT do
 // ==============================
@@ -85,6 +99,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -235,6 +250,16 @@ func (h *Handler) runJanitorPass(tofuWorkDir string, failedMaxAge, wipedMaxAge t
 	})
 
 	for _, t := range toReap {
+		// #5327 (hw284) — an ungated "failed-too-long" reap deletes the
+		// record, the tofu workdir INCLUDING STATE (the only destroy
+		// capability), and the kubeconfigs WITHOUT any cloud destroy, while
+		// markPhase1Done deliberately leaves a failed prov's infra alive
+		// (DEBUG-BEFORE-WIPE). Gate the reap on the infra actually being
+		// GONE; anything ambiguous preserves (fail-closed).
+		if t.Reason == "failed-too-long" && !h.gateFailedReap(t.ID, tofuWorkDir) {
+			stats.FailedPreserved++
+			continue
+		}
 		if err := h.reapDeployment(t.ID, t.Reason, tofuWorkDir); err != nil {
 			h.log.Warn("[JANITOR] reap failed",
 				"id", t.ID,
@@ -325,6 +350,7 @@ func (h *Handler) runJanitorPass(tofuWorkDir string, failedMaxAge, wipedMaxAge t
 		"destructive", janitorDestructive(),
 		"reaped", stats.Reaped,
 		"reapErrors", stats.ReapErrors,
+		"failedInfraPreserved", stats.FailedPreserved,
 		"orphanKubeconfigsDeleted", stats.OrphanKubeconfigs,
 		"orphanTofuWorkdirsDeleted", stats.OrphanTofuWorkdirs,
 		"orphanEIPsDeleted", stats.OrphanEIPs,
@@ -344,6 +370,7 @@ type reapTarget struct {
 type janitorStats struct {
 	Reaped             int
 	ReapErrors         int
+	FailedPreserved    int
 	OrphanKubeconfigs  int
 	GhostRecords       int
 	OrphanTofuWorkdirs int
@@ -408,6 +435,207 @@ func (h *Handler) reapDeployment(id, reason, tofuWorkDir string) error {
 	}
 
 	return firstErr
+}
+
+// gateFailedReap decides whether a "failed-too-long" reap target may proceed
+// to reapDeployment. #5327 (hw284, dep 383db23ccaf13be5): reapDeployment
+// deletes the record json, the tofu workdir INCLUDING STATE (the only handle
+// that can ever `tofu destroy` the env), and the kubeconfigs — while
+// markPhase1Done deliberately leaves a failed prov's cloud infra ALIVE for
+// forensics/resume (DEBUG-BEFORE-WIPE). Ungated, the 24h reap stranded
+// hw284's live 8-server 2-region env with no owner: the canonical wipe
+// endpoint 404'd (record gone), tofu could no longer destroy (state gone),
+// and teardown needed a raw Huawei-API break-glass (#5328/PR #5329).
+//
+// Contract (every ambiguity PROTECTS, mirroring cleanGhostRecords):
+//   - infra GONE → true: today's reap is correct local cleanup.
+//   - infra ALIVE, log-only (default) → false: ONE loud Warn; the record +
+//     tofu state (the destroy capability) are preserved and the target is
+//     re-evaluated next pass.
+//   - infra ALIVE, CATALYST_JANITOR_DESTRUCTIVE=true → run the canonical
+//     cloud destroy (the same providers.CloudProvider.Wipe steps the wipe
+//     handler dispatches: tofu destroy against the still-present workdir +
+//     provider orphan sweep + object-storage purge), then RE-PROBE; only a
+//     verified-gone footprint reaps. Destroy error / still-alive → false.
+//   - probe error / creds unresolvable / status no longer "failed" / a wipe
+//     already in flight → false (fail-closed).
+func (h *Handler) gateFailedReap(id, tofuWorkDir string) bool {
+	val, ok := h.deployments.Load(id)
+	if !ok {
+		return true // record vanished mid-pass — nothing left to protect
+	}
+	dep, ok := val.(*Deployment)
+	if !ok || dep == nil {
+		return true
+	}
+	dep.mu.Lock()
+	status := dep.Status
+	wipeInFlight := dep.wipeInFlight
+	dep.mu.Unlock()
+	if status != "failed" || wipeInFlight {
+		// Status moved since the Range snapshot (operator retry / wipe took
+		// ownership) — this pass must not touch it; next pass re-evaluates.
+		return false
+	}
+
+	probe := h.janitorFailedInfraProbe
+	if probe == nil {
+		probe = h.failedDeploymentInfraAlive
+	}
+	probeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	alive, perr := probe(probeCtx, dep, tofuWorkDir)
+	cancel()
+	if perr != nil {
+		h.log.Warn("[JANITOR] failed record infra probe errored — preserving record+tofu state (destroy capability); fail-closed, re-evaluating next pass",
+			"id", id,
+			"err", perr.Error(),
+		)
+		return false
+	}
+	if !alive {
+		return true
+	}
+	if !janitorDestructive() {
+		h.log.Warn("[JANITOR] failed record " + id + " has LIVE cloud infra — preserving record+tofu state (destroy capability); set CATALYST_JANITOR_DESTRUCTIVE=true to destroy+reap")
+		return false
+	}
+
+	destroy := h.janitorFailedDestroy
+	if destroy == nil {
+		destroy = h.destroyFailedDeploymentInfra
+	}
+	// Same wall-clock budget the wipe handler grants its async destroy
+	// (#5193) — a 2-region tofu destroy legitimately takes tens of minutes.
+	destroyCtx, dcancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer dcancel()
+	if derr := destroy(destroyCtx, dep, tofuWorkDir); derr != nil {
+		h.log.Warn("[JANITOR] failed record cloud destroy errored — preserving record+tofu state; re-evaluating next pass",
+			"id", id,
+			"err", derr.Error(),
+		)
+		return false
+	}
+	// VERIFIED destroy only: re-probe and reap solely on a confirmed-gone
+	// footprint. A partial destroy keeps the record + state so the next pass
+	// (or an operator wipe) can finish the job.
+	alive, perr = probe(destroyCtx, dep, tofuWorkDir)
+	if perr != nil || alive {
+		detail := "infra still alive after destroy"
+		if perr != nil {
+			detail = "verification probe errored: " + perr.Error()
+		}
+		h.log.Warn("[JANITOR] failed record cloud destroy NOT verified gone — preserving record+tofu state; re-evaluating next pass",
+			"id", id,
+			"detail", detail,
+		)
+		return false
+	}
+	h.log.Info("[JANITOR] failed record cloud destroy verified gone — proceeding to reap", "id", id)
+	return true
+}
+
+// failedDeploymentInfraAlive is the production infra probe behind
+// gateFailedReap (#5327). It asks the deployment's own cloud provider for the
+// server inventory scoped to this deployment — the same ListServers seam the
+// wizard's infrastructure tab and the wipe pre-flight use. Every error path
+// reports alive=true (fail-closed: never authorise a reap on a probe that
+// could not actually see the cloud).
+//
+// Huawei needs a second look: Wave 5.4 disabled tags on HCS, so the
+// tag-filtered ListServers returns ZERO for a live deployment (the exact
+// blindness Wave 5.147 closed for the wipe's purge path with
+// listECSByNamePrefix). A zero tag-scoped inventory therefore only counts as
+// "gone" once the canonical name-prefix listing
+// (catalyst-<fqdn-dashed>-<dep8>-*) ALSO comes back empty.
+func (h *Handler) failedDeploymentInfraAlive(ctx context.Context, dep *Deployment, tofuWorkDir string) (bool, error) {
+	providerName := resolveProviderName(dep)
+	cp, err := providers.Get(providerName)
+	if err != nil {
+		return true, fmt.Errorf("providers.Get(%s): %w", providerName, err)
+	}
+	credsRaw := h.janitorWipeCredsRaw(providerName, dep, tofuWorkDir)
+	servers, err := cp.ListServers(ctx, dep.ID, dep.Request.SovereignFQDN, providers.ProviderCreds{Raw: credsRaw})
+	if err != nil {
+		return true, fmt.Errorf("%s ListServers: %w", providerName, err)
+	}
+	if len(servers) > 0 {
+		return true, nil
+	}
+	if strings.EqualFold(providerName, "huawei") {
+		hp := h.huaweiProvider("failed-reap probe")
+		if hp == nil {
+			return true, errors.New("huawei provider not wired — cannot verify infra is gone")
+		}
+		creds, ok := huaweiSweepCredsFromRaw(credsRaw)
+		if !ok {
+			return true, errors.New("no huawei creds resolvable (request / workdir tfvars / operator env all empty) — cannot verify infra is gone")
+		}
+		alive, aerr := hp.HasServersByNamePrefix(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, dep.Request.SovereignFQDN, dep.ID)
+		if aerr != nil {
+			return true, fmt.Errorf("huawei name-prefix probe: %w", aerr)
+		}
+		return alive, nil
+	}
+	return false, nil
+}
+
+// destroyFailedDeploymentInfra is the production destroy behind gateFailedReap
+// when CATALYST_JANITOR_DESTRUCTIVE=true. It dispatches the SAME canonical
+// purge sequence the wipe handler's runWipePurge dispatches — the
+// providers.CloudProvider.Wipe seam (tofu destroy against the still-present
+// workdir + provider orphan sweep + object-storage purge) — with the same
+// body-less credential resolution. Any error, including a Wipe that reports
+// per-resource errors, is surfaced so the caller preserves record + state.
+func (h *Handler) destroyFailedDeploymentInfra(ctx context.Context, dep *Deployment, tofuWorkDir string) error {
+	providerName := resolveProviderName(dep)
+	cp, err := providers.Get(providerName)
+	if err != nil {
+		return fmt.Errorf("providers.Get(%s): %w", providerName, err)
+	}
+	credsRaw := h.janitorWipeCredsRaw(providerName, dep, tofuWorkDir)
+	res, werr := cp.Wipe(ctx, providers.WipeSpec{
+		DeploymentID:  dep.ID,
+		SovereignFQDN: dep.Request.SovereignFQDN,
+		Creds:         providers.ProviderCreds{Raw: credsRaw},
+	}, func(msg string) {
+		h.log.Info("[JANITOR] failed-reap destroy: " + providerName + ": " + msg)
+	})
+	if werr != nil {
+		return werr
+	}
+	if res != nil && len(res.Errors) > 0 {
+		return fmt.Errorf("%s wipe reported %d error(s): %s", providerName, len(res.Errors), strings.Join(res.Errors, "; "))
+	}
+	return nil
+}
+
+// janitorWipeCredsRaw mirrors the wipe handler's body-less credential
+// resolution for the janitor's background (no operator in the loop) probe +
+// destroy: in-memory dep.Request first (buildWipeCredsRaw with an empty
+// body), then the durable per-deployment tofu.auto.tfvars.json on the PVC
+// (#5135 — dep.Request secrets are GC'd post-writeTfvars and do not survive a
+// Pod roll; the failed dep's workdir still exists precisely BECAUSE this gate
+// preserved it), then the huawei-operator-creds Secret env (#5193 last
+// resort).
+func (h *Handler) janitorWipeCredsRaw(providerName string, dep *Deployment, tofuWorkDir string) map[string]string {
+	credsRaw := buildWipeCredsRaw(providerName, wipeRequest{}, dep.Request)
+	applyWorkdirEVSCredsFallback(providerName, credsRaw, filepath.Join(tofuWorkDir, dep.ID))
+	if strings.EqualFold(providerName, "huawei") {
+		if _, ok := huaweiSweepCredsFromRaw(credsRaw); !ok {
+			if env, eok := huaweiOperatorCredsFromEnv(); eok {
+				fill := func(key, val string) {
+					if strings.TrimSpace(credsRaw[key]) == "" {
+						credsRaw[key] = val
+					}
+				}
+				fill("access_key", env.AccessKey)
+				fill("secret_key", env.SecretKey)
+				fill("project_id", env.ProjectID)
+				fill("region", env.Region)
+			}
+		}
+	}
+	return credsRaw
 }
 
 // activeIDSet returns the union of deployment IDs known in-memory or

--- a/products/catalyst/bootstrap/api/internal/handler/janitor_reap_protection_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor_reap_protection_test.go
@@ -1,11 +1,14 @@
 package handler
 
 import (
+	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestBuildActivePrefixes_ProtectsEveryNonWipedStatus — #4454 regression.
@@ -198,5 +201,291 @@ func TestDiscoverHuaweiCreds_NoneAvailable(t *testing.T) {
 	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "")
 	if _, ok := discoverHuaweiCreds(t.TempDir()); ok {
 		t.Fatal("with neither tfvars nor env creds, discovery must report ok=false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #5327 — the Step-1 "failed-too-long" reap must preserve the destroy
+// capability (record + tofu state + kubeconfigs) while the deployment's cloud
+// infra is still alive.
+//
+// hw284 (dep 383db23ccaf13be5): phase-1 failure marked the record `failed`
+// and — by design (DEBUG-BEFORE-WIPE) — left the full 2-region Huawei infra
+// alive. 24h later the ungated reap deleted the record json, the tofu workdir
+// INCLUDING STATE, and the kubeconfigs WITHOUT any cloud destroy. The env
+// then ran orphaned-alive for ~40h: the canonical wipe endpoint 404'd (record
+// gone) and tofu could no longer destroy (state gone) — teardown needed a raw
+// Huawei-API break-glass (#5328/PR #5329). These tests pin the gate contract:
+//
+//	failed + infra ALIVE + log-only     → record & workdir & kubeconfigs preserved
+//	failed + infra ALIVE + destructive  → canonical destroy first, reap only
+//	                                      after the verified-gone re-probe
+//	failed + infra GONE                 → reaped exactly as before
+//	probe error                         → preserved (fail-closed)
+// ---------------------------------------------------------------------------
+
+// failedReapFixture seeds one deployment record (default status "failed",
+// FinishedAt 25h ago — past the 24h failedMaxAge) plus the on-disk artifacts
+// reapDeployment would delete: the tofu workdir with a state marker (the
+// destroy capability), the primary kubeconfig, and one secondary-region
+// kubeconfig.
+type failedReapFixture struct {
+	h     *Handler
+	work  string
+	kcDir string
+	id    string
+}
+
+func makeFailedReapFixture(t *testing.T, id, status string) *failedReapFixture {
+	t.Helper()
+	work := t.TempDir()
+	kcDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(work, id), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(work, id, "terraform.tfstate"), []byte(`{"resources":[{"mode":"managed"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kcDir, id+".yaml"), []byte("kubeconfig"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kcDir, id+"-region-b.yaml"), []byte("kubeconfig-b"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := &Handler{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		kubeconfigsDir: kcDir,
+	}
+	h.deployments.Store(id, &Deployment{
+		ID:         id,
+		Status:     status,
+		StartedAt:  time.Now().Add(-26 * time.Hour),
+		FinishedAt: time.Now().Add(-25 * time.Hour),
+	})
+	// Keep the pass's cloud sweeps + cred discovery inert: no tfvars in the
+	// workdir (only a bare tfstate marker) and no operator-env creds, so
+	// discoverHuaweiCreds reports ok=false and no sweep ever dials out.
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "")
+	return &failedReapFixture{h: h, work: work, kcDir: kcDir, id: id}
+}
+
+func (f *failedReapFixture) runPass() {
+	f.h.runJanitorPass(f.work, 24*time.Hour, time.Hour)
+}
+
+func (f *failedReapFixture) recordPresent() bool {
+	_, ok := f.h.deployments.Load(f.id)
+	return ok
+}
+
+func (f *failedReapFixture) tofuStatePresent(t *testing.T) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(f.work, f.id, "terraform.tfstate"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("stat tofu state: %v", err)
+	}
+	return err == nil
+}
+
+func (f *failedReapFixture) kubeconfigsPresent(t *testing.T) bool {
+	t.Helper()
+	_, perr := os.Stat(filepath.Join(f.kcDir, f.id+".yaml"))
+	_, serr := os.Stat(filepath.Join(f.kcDir, f.id+"-region-b.yaml"))
+	return perr == nil && serr == nil
+}
+
+// TestGateFailedReap_InfraAliveLogOnly_PreservesDestroyCapability — the exact
+// hw284 shape: failed record past failedMaxAge, cloud infra ALIVE, janitor in
+// its mandated log-only default. The pass must preserve record + tofu state +
+// kubeconfigs, never invoke a destroy, and keep re-evaluating on later passes.
+func TestGateFailedReap_InfraAliveLogOnly_PreservesDestroyCapability(t *testing.T) {
+	t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "")
+	f := makeFailedReapFixture(t, "383db23ccaf13be5", "failed")
+
+	probeCalls, destroyCalls := 0, 0
+	f.h.janitorFailedInfraProbe = func(ctx context.Context, dep *Deployment, tofuWorkDir string) (bool, error) {
+		probeCalls++
+		return true, nil // infra ALIVE
+	}
+	f.h.janitorFailedDestroy = func(ctx context.Context, dep *Deployment, tofuWorkDir string) error {
+		destroyCalls++
+		return nil
+	}
+
+	// Two passes — the skip must be a re-evaluate-next-pass, not a one-off.
+	f.runPass()
+	f.runPass()
+
+	if destroyCalls != 0 {
+		t.Fatalf("log-only janitor must NEVER destroy cloud infra, destroy ran %d time(s)", destroyCalls)
+	}
+	if probeCalls != 2 {
+		t.Fatalf("expected the infra probe once per pass (2), got %d", probeCalls)
+	}
+	if !f.recordPresent() {
+		t.Fatal("REGRESSION #5327: failed record with LIVE infra was reaped — the canonical wipe endpoint would 404 on a still-alive env")
+	}
+	if !f.tofuStatePresent(t) {
+		t.Fatal("REGRESSION #5327: tofu state (the ONLY destroy capability) was deleted while the cloud infra is alive")
+	}
+	if !f.kubeconfigsPresent(t) {
+		t.Fatal("REGRESSION #5327: kubeconfigs deleted while the cloud infra is alive")
+	}
+}
+
+// TestGateFailedReap_InfraAliveDestructive_DestroysThenReaps — with
+// CATALYST_JANITOR_DESTRUCTIVE=true the gate runs the canonical cloud destroy
+// first (the same providers.CloudProvider.Wipe steps the wipe handler
+// dispatches), re-probes, and only reaps a verified-gone footprint.
+func TestGateFailedReap_InfraAliveDestructive_DestroysThenReaps(t *testing.T) {
+	t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "true")
+	f := makeFailedReapFixture(t, "aa5327dstry00001", "failed")
+
+	destroyCalls := 0
+	infraGone := false
+	f.h.janitorFailedInfraProbe = func(ctx context.Context, dep *Deployment, tofuWorkDir string) (bool, error) {
+		return !infraGone, nil
+	}
+	f.h.janitorFailedDestroy = func(ctx context.Context, dep *Deployment, tofuWorkDir string) error {
+		destroyCalls++
+		// The destroy must run while the destroy capability still exists.
+		if _, err := os.Stat(filepath.Join(tofuWorkDir, dep.ID, "terraform.tfstate")); err != nil {
+			t.Errorf("destroy invoked AFTER the tofu state was deleted: %v", err)
+		}
+		infraGone = true
+		return nil
+	}
+
+	f.runPass()
+
+	if destroyCalls != 1 {
+		t.Fatalf("destructive mode must invoke the canonical destroy exactly once, got %d", destroyCalls)
+	}
+	if f.recordPresent() {
+		t.Fatal("after a VERIFIED destroy the failed record must be reaped")
+	}
+	if f.tofuStatePresent(t) {
+		t.Fatal("after a VERIFIED destroy the tofu workdir must be reaped")
+	}
+	if f.kubeconfigsPresent(t) {
+		t.Fatal("after a VERIFIED destroy the kubeconfigs must be reaped")
+	}
+}
+
+// TestGateFailedReap_InfraGone_ReapsAsToday — when the cloud footprint is
+// verifiably gone the historical reap behaviour is correct local cleanup and
+// must proceed unchanged (no destroy, artifacts removed). A sibling `wiped`
+// record must also keep reaping WITHOUT ever consulting the infra probe.
+func TestGateFailedReap_InfraGone_ReapsAsToday(t *testing.T) {
+	t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "")
+	f := makeFailedReapFixture(t, "bb5327gone000001", "failed")
+
+	// Sibling wiped record — its bookkeeping reap must not touch the probe.
+	f.h.deployments.Store("cc5327wiped00001", &Deployment{
+		ID:         "cc5327wiped00001",
+		Status:     "wiped",
+		StartedAt:  time.Now().Add(-3 * time.Hour),
+		FinishedAt: time.Now().Add(-2 * time.Hour),
+	})
+
+	destroyCalls := 0
+	f.h.janitorFailedInfraProbe = func(ctx context.Context, dep *Deployment, tofuWorkDir string) (bool, error) {
+		if dep.ID != f.id {
+			t.Errorf("infra probe consulted for a %q record (id %s) — the gate is for failed-too-long targets only", dep.Status, dep.ID)
+		}
+		return false, nil // infra GONE
+	}
+	f.h.janitorFailedDestroy = func(ctx context.Context, dep *Deployment, tofuWorkDir string) error {
+		destroyCalls++
+		return nil
+	}
+
+	f.runPass()
+
+	if destroyCalls != 0 {
+		t.Fatalf("infra-gone reap must not destroy anything, destroy ran %d time(s)", destroyCalls)
+	}
+	if f.recordPresent() {
+		t.Fatal("failed record with GONE infra must still be reaped (today's behaviour)")
+	}
+	if f.tofuStatePresent(t) {
+		t.Fatal("tofu workdir of a gone-infra failed record must still be reaped")
+	}
+	if f.kubeconfigsPresent(t) {
+		t.Fatal("kubeconfigs of a gone-infra failed record must still be reaped")
+	}
+	if _, ok := f.h.deployments.Load("cc5327wiped00001"); ok {
+		t.Fatal("wiped-bookkeeping reap regressed — the #5327 gate must only apply to failed-too-long targets")
+	}
+}
+
+// TestGateFailedReap_ProbeError_FailsClosed — a probe that cannot actually
+// see the cloud (HCS API down, creds unresolvable, provider unwired) must
+// PRESERVE, even with the janitor armed destructive: no destroy on
+// unverifiable state, no reap.
+func TestGateFailedReap_ProbeError_FailsClosed(t *testing.T) {
+	t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "true")
+	f := makeFailedReapFixture(t, "dd5327proberr001", "failed")
+
+	destroyCalls := 0
+	f.h.janitorFailedInfraProbe = func(ctx context.Context, dep *Deployment, tofuWorkDir string) (bool, error) {
+		return false, errors.New("HCS ECS API: status 503")
+	}
+	f.h.janitorFailedDestroy = func(ctx context.Context, dep *Deployment, tofuWorkDir string) error {
+		destroyCalls++
+		return nil
+	}
+
+	f.runPass()
+
+	if destroyCalls != 0 {
+		t.Fatalf("probe-error must never authorise a destroy, destroy ran %d time(s)", destroyCalls)
+	}
+	if !f.recordPresent() || !f.tofuStatePresent(t) || !f.kubeconfigsPresent(t) {
+		t.Fatal("REGRESSION #5327: probe error must fail CLOSED (record + tofu state + kubeconfigs preserved)")
+	}
+}
+
+// TestGateFailedReap_UnverifiedDestroy_Preserves — destructive mode without a
+// VERIFIED destroy must preserve: (a) the destroy itself errors, (b) the
+// destroy claims success but the re-probe still sees live infra, (c) the
+// re-probe errors. "Only reap after a verified destroy."
+func TestGateFailedReap_UnverifiedDestroy_Preserves(t *testing.T) {
+	cases := []struct {
+		name       string
+		destroyErr error
+		// reProbe is consulted on the post-destroy verification pass.
+		reProbeAlive bool
+		reProbeErr   error
+	}{
+		{name: "destroy_errors", destroyErr: errors.New("tofu destroy: exit 1")},
+		{name: "reprobe_still_alive", reProbeAlive: true},
+		{name: "reprobe_errors", reProbeErr: errors.New("HCS ECS API: timeout")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "true")
+			f := makeFailedReapFixture(t, "ee5327unverif001", "failed")
+
+			destroyed := false
+			f.h.janitorFailedInfraProbe = func(ctx context.Context, dep *Deployment, tofuWorkDir string) (bool, error) {
+				if !destroyed {
+					return true, nil // pre-destroy: alive
+				}
+				return tc.reProbeAlive, tc.reProbeErr
+			}
+			f.h.janitorFailedDestroy = func(ctx context.Context, dep *Deployment, tofuWorkDir string) error {
+				destroyed = true
+				return tc.destroyErr
+			}
+
+			f.runPass()
+
+			if !f.recordPresent() || !f.tofuStatePresent(t) || !f.kubeconfigsPresent(t) {
+				t.Fatal("an UNVERIFIED destroy must preserve record + tofu state + kubeconfigs for the next pass / an operator wipe")
+			}
+		})
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -674,6 +674,25 @@ func (p *Provider) ListServers(ctx context.Context, deploymentID, sovereignFQDN 
 	return out, nil
 }
 
+// HasServersByNamePrefix reports whether ANY ECS bearing the deployment's
+// canonical name prefix (`catalyst-<fqdn-dashed>-<dep8>-…`, the
+// local.name_prefix from infra/providers/huawei/main.tf) still exists in the
+// project. #5327 — the janitor's failed-record reap gate needs a
+// tag-independent liveness probe: Wave 5.4 disabled tags on HCS, so the
+// tag-filtered ListServers returns zero even for a LIVE deployment — the
+// exact blindness Wave 5.147 closed for the wipe's purge path with
+// listECSByNamePrefix. This exposes that same fallback read-only, so a zero
+// tag-scoped inventory is never mistaken for "infra gone" on HCS.
+func (p *Provider) HasServersByNamePrefix(ctx context.Context, ak, sk, projectID, region, sovereignFQDN, deploymentID string) (bool, error) {
+	hw := hwCreds{AccessKey: ak, SecretKey: sk, ProjectID: projectID}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": region}})
+	servers, err := listECSByNamePrefix(ctx, client, hw, region, sovereignFQDN, deploymentID)
+	if err != nil {
+		return false, err
+	}
+	return len(servers) > 0, nil
+}
+
 // BucketNameForDeployment returns the deterministic per-deployment
 // OBS bucket name. Pattern mirrors Hetzner's shape so the wipe
 // handler can reproduce the same name post-restart.


### PR DESCRIPTION
🛑 HOLD MERGE — merge window opens after hw285 reaches cutoverComplete (a merge rolls catalyst-api and abandons the in-flight prov).

Refs #5327

## Root cause (hw284, dep `383db23ccaf13be5`)

The janitor's Step-1 `failed-too-long` reap (`products/catalyst/bootstrap/api/internal/handler/janitor.go`, `case "failed": if age >= failedMaxAge` → `reapDeployment`) deleted the deployment record json (`h.store.Delete(id)`), the tofu workdir INCLUDING STATE (`os.RemoveAll(tofu/{id})` — the only handle that can ever `tofu destroy` the env), and the kubeconfigs — WITHOUT any cloud destroy and WITHOUT consulting `CATALYST_JANITOR_DESTRUCTIVE` (that gate only guarded ghost-record GC and the cloud sweeps). Since `markPhase1Done` deliberately leaves a failed prov's infra ALIVE (DEBUG-BEFORE-WIPE, and `buildActivePrefixes` even PROTECTS `failed` infra from the sweeps), the ungated 24h reap converted every mothership phase-1 failure into an orphaned-alive cloud footprint: on hw284 a still-alive 8-server 2-region env lost its destroy capability ~26h post-fire — canonical wipe endpoint 404'd (record gone), tofu undestroyable (state gone) — forcing the #5328 / PR #5329 break-glass raw Huawei-API wipe after ~40h of unowned spend.

## Fix contract (`gateFailedReap` — every ambiguity PROTECTS, mirroring `cleanGhostRecords`)

1. **infra GONE** → reap exactly as today (record + workdir + kubeconfigs local cleanup is correct).
2. **infra ALIVE + log-only default** → ONE loud Warn (`[JANITOR] failed record <id> has LIVE cloud infra — preserving record+tofu state (destroy capability); set CATALYST_JANITOR_DESTRUCTIVE=true to destroy+reap`), skip, re-evaluate next pass. Record, tofu state, and kubeconfigs all survive.
3. **infra ALIVE + `CATALYST_JANITOR_DESTRUCTIVE=true`** → run the canonical cloud destroy FIRST — the same `providers.CloudProvider.Wipe` steps the wipe handler's `runWipePurge` dispatches (tofu destroy against the still-present workdir + provider orphan purge + bucket purge), with the wipe handler's body-less cred chain (`dep.Request` → workdir tfvars #5135 → operator-env #5193) — then RE-PROBE; **only a verified-gone footprint reaps**. Destroy error / still-alive re-probe / re-probe error ⇒ preserve, retry next pass.
4. **probe error / creds unresolvable / status moved off `failed` / wipe already in flight** → preserve (fail-closed).

Production probe: the provider `ListServers` seam PLUS a huawei name-prefix double-check (new read-only `HasServersByNamePrefix`, wrapping the existing `listECSByNamePrefix` sweep helper). Wave 5.4 disabled tags on HCS, so the tag-filtered `ListServers` returns zero even for a LIVE deployment — the exact blindness Wave 5.147 closed for the wipe purge path; without the double-check the gate would have rubber-stamped the hw284 reap. A zero tag-scoped inventory on huawei only counts as "gone" once the `catalyst-<fqdn-dashed>-<dep8>-*` listing also comes back empty.

Files:
- `internal/handler/janitor.go` — the gate + production probe/destroy + updated file-header contract (+ `failedInfraPreserved` pass-stats counter).
- `internal/handler/handler.go` — two nil-in-production test seams (`janitorFailedInfraProbe` / `janitorFailedDestroy`, the `consoleProbe` idiom).
- `internal/providers/huawei/provider.go` — `HasServersByNamePrefix` (read-only, additive).
- `internal/handler/janitor_reap_protection_test.go` — regression coverage below.

## Test evidence

New tests pin all four behaviours (plus: destroy must run while the tofu state still exists; `wiped`-bookkeeping reap never consults the probe; log-only skip re-evaluates on the next pass; unverified-destroy preserve matrix):

- `TestGateFailedReap_InfraAliveLogOnly_PreservesDestroyCapability`
- `TestGateFailedReap_InfraAliveDestructive_DestroysThenReaps`
- `TestGateFailedReap_InfraGone_ReapsAsToday`
- `TestGateFailedReap_ProbeError_FailsClosed`
- `TestGateFailedReap_UnverifiedDestroy_Preserves` (destroy_errors / reprobe_still_alive / reprobe_errors)

```
$ go test ./internal/handler/ -run 'Janitor|GateFailedReap' -count=1
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.028s

$ go test ./internal/handler/ -count=1        # full package
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	158.453s

$ go test ./internal/providers/huawei/ -count=1
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/providers/huawei	0.259s
```

`go vet ./internal/handler/ ./internal/providers/huawei/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
