### PR TITLE
fix(cnpg-pair): dr-failback CONVERGED must verify ConsistentSystemID, not bare streaming — re-clone divergent standby (#5331) [HOLD MERGE]

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1269,7 +1269,12 @@ spec:
       #   bp-catalyst-edge-routes (slot 13b) can proxy api./console./
       #   marketplace. to region-a's singletons. Set below from
       #   ${SOVEREIGN_ENABLE_HOT_STANDBY}. Lockstep w/ Chart.yaml.
-      version: 1.4.1201
+      # 1.4.1202 — #5331: catalog-seed bp-cnpg-pair pin 0.2.20 -> 0.2.21 —
+      #   dr-failback VERIFIED CONVERGENCE (hw285 residual): the CONVERGED
+      #   gate now also requires CNPG ConsistentSystemID=True, so a divergent
+      #   equal-LSN standby can no longer be declared re-cloned without a real
+      #   pg_basebackup re-clone. Lockstep w/ Chart.yaml + 16b slot 0.2.21.
+      version: 1.4.1202
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -293,7 +293,19 @@ spec:
       # (grace 180s, pre-episode-bounded), episode-marker self-heal,
       # post-re-clone convergence watch + psql-dark writable probe.
       # Substitutes unchanged.
-      version: 0.2.20
+      # 0.2.21 (#5331): dr-failback VERIFIED CONVERGENCE (hw285 residual).
+      # hw285 G12 had a clean failover (region-B RPO=0) but a FALSE failback:
+      # a divergent in-place-demoted region-A (ConsistentSystemID=False) was
+      # declared "CONVERGED: re-cloned and streaming" 10s into the 180s
+      # divergence grace with NO re-clone, because the CONVERGED gate keyed
+      # off the local 'streaming' signal alone (which a divergent equal-LSN
+      # standby also satisfies). Fixes: the CONVERGED gate now also requires
+      # CNPG ConsistentSystemID=True; the D2a divergence escalation gates on
+      # that verdict alone (no longer suppressed by a coincidental
+      # 'streaming') and the signals 'streaming' arm keeps the peer-writable
+      # proof fresh so the re-clone escalation no longer starves.
+      # Substitutes unchanged.
+      version: 0.2.21
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/DESIGN.md
+++ b/platform/cnpg-pair/DESIGN.md
@@ -445,6 +445,33 @@ every escalation), and a **post-re-clone convergence watch** (phase +
 ConsistentSystemID logged every ~30 ticks until streaming) — a wedged
 re-clone names itself.
 
+*Verified convergence (chart 0.2.21, the hw285 residual)*: hw285 G12
+had a clean failover (region-B promoted RPO=0) but a FALSE failback.
+region-A powered back on, self-promoted to its own TL2 fork, was
+demoted **in place** (the webhook admitted the shape change before the
+delete → stale-PGDATA standby, `ConsistentSystemID=False`), and the
+actor declared `CONVERGED: region-A re-cloned and streaming` **10 s
+into the 180 s divergence grace, with no re-clone** — leaving region-A
+on a divergent line missing region-B's post-failover write (a data-loss
+trap on switchback). Root cause: the CONVERGED gate keyed off the local
+`streaming` signal alone (`pg_stat_wal_receiver` row + a set
+receive-LSN), which a divergent in-place-demoted standby ALSO satisfies
+— it momentarily attached to region-B at a **coincidentally-equal LSN**
+while sitting on its own fork. Two coupled fixes: (1) the CONVERGED gate
+now ALSO requires CNPG's **`ConsistentSystemID=True`** — its own
+positive attestation of consistent lineage, which cannot hold on a
+divergent line (LSN-equality is deliberately NOT used — equal LSNs are
+exactly the false signal); (2) the D2a divergence escalation gates on
+that verdict **alone** (dropping the `! -f converged-streaming`
+conjunct that let a false `streaming` both suppress the re-clone and
+reset the divergence clock), and the signals `streaming` arm keeps the
+**peer-writable proof fresh** so the now-reachable escalation has a
+<60 s writable-peer proof to act on instead of starving. The
+clean-in-place-follow path (tail exactly at the fork →
+`ConsistentSystemID=True` without a re-clone) still converges,
+cheapest-path-wins, because the gate keys off CNPG's consistency
+verdict, not on re-clone provenance.
+
 End state after a kill+recover cycle: region-B primary, region-A
 streaming replica, both HRs unsuspended, the failed-over topology
 rendered from source. The controlled switchback to the original roles

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -99,7 +99,22 @@ spec:
   # default 180, pre-episode-bounded) + episode-marker self-heal +
   # post-re-clone convergence watch + psql-dark writable probe — a wedged
   # re-clone can never be silent again.
-  version: 0.2.20
+  # 0.2.21 (#5331): dr-failback VERIFIED CONVERGENCE — the hw285 residual.
+  # hw285 G12 had a clean failover (region-B RPO=0) but a FALSE failback: a
+  # divergent in-place-demoted region-A (ConsistentSystemID=False) was
+  # declared "CONVERGED: re-cloned and streaming" 10s into the 180s divergence
+  # grace with NO re-clone, because the CONVERGED gate keyed off the local
+  # 'streaming' signal alone (a walreceiver row + a set receive-LSN that a
+  # divergent equal-LSN standby also has). Fixes: (1) the CONVERGED gate now
+  # ALSO requires CNPG's ConsistentSystemID=True (its own consistent-lineage
+  # attestation — cannot hold on a divergent fork; LSN-equality is NOT used);
+  # (2) the D2a divergence escalation gates on that verdict alone (dropping
+  # the `! -f converged-streaming` conjunct that let a false 'streaming'
+  # suppress the re-clone and reset the divergence clock), and the signals
+  # 'streaming' arm keeps the peer-writable proof fresh so the escalation no
+  # longer starves; post-re-clone watch keys off converged-recorded.
+  # Script-only; no schema/RBAC/resource delta.
+  version: 0.2.21
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,32 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.21 (#5331): dr-failback VERIFIED CONVERGENCE — the hw285 residual.
+# hw285 G12 (2026-07-23, dep 27350950bef5c882) had a CLEAN failover (region-B
+# promoted RPO=0) but a FALSE failback: region-A powered back on, self-promoted
+# to its OWN TL2 fork, was demoted IN PLACE (webhook admitted the shape change
+# before the delete → stale-PGDATA standby, ConsistentSystemID=False), and the
+# actor declared "CONVERGED: region-A re-cloned and streaming" 10s into the
+# 180s divergence grace WITH NO RE-CLONE — leaving region-A on a divergent line
+# missing region-B's post-failover write (data-loss trap on switchback). TWO
+# coupled defects, both fixed:
+# (1) DATA-BLIND CONVERGED GATE: it keyed off the local 'streaming' signal
+#     alone (pg_stat_wal_receiver row + set receive-LSN), which a DIVERGENT
+#     in-place-demoted standby ALSO satisfies — it momentarily attached to
+#     region-B at a COINCIDENTALLY-EQUAL LSN (0/D000138 on both) while sitting
+#     on its own fork. The CONVERGED gate now ALSO requires CNPG's
+#     ConsistentSystemID=True (its positive attestation of consistent lineage,
+#     which CANNOT hold on a divergent line). LSN-equality is deliberately NOT
+#     used — equal LSNs are exactly the false signal.
+# (2) DIVERGENCE ESCALATION SUPPRESSED BY THE SAME FALSE SIGNAL: the D2a
+#     ConsistentSystemID=False escalation was ANDed with
+#     `! -f /shared/converged-streaming`, so the coincidental 'streaming' both
+#     blocked the re-clone AND reset the divergence clock. D2a now gates on
+#     CNPG's verdict alone, and the signals `streaming` arm keeps the
+#     peer-writable proof fresh so the (now-reachable) escalation has a
+#     <60s-fresh writable-peer proof instead of starving. The post-re-clone
+#     watch keys off converged-RECORDED (streaming+consistent), never the bare
+#     streaming signal. Render Case 21 pins all of it. Lockstep slot 16b pin
+#     → 0.2.21.
 # 0.2.20 (#5245): dr-failback RE-CLONE CONVERGENCE — the hw278 residual.
 # hw278 G12 (2026-07-19/20) live-proved the 0.2.19 chain fires clean (demote
 # 23:10:36Z on the -ge gate at 122s held; wedge escalation + bounded delete
@@ -319,7 +346,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.20
+version: 0.2.21
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/dr-failback.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-failback.yaml
@@ -91,9 +91,12 @@ fence IS the authority proof.
      escalation (below) and ONLY when it predates this failback episode
      — a fresh clone is NEVER deleted, so destruction is bounded to one
      re-clone per episode.
-  5. CONVERGE: the re-cloned cluster streams from region-B
-     (walreceiver row + receive-LSN — the #5239-readable signal); the
-     actor records dr-failback-converged-at on the HR and goes idle.
+  5. CONVERGE: the re-cloned cluster streams from region-B (walreceiver
+     row + receive-LSN — the #5239-readable signal) AND CNPG reports
+     ConsistentSystemID=True (the verified-consistent-lineage proof,
+     #5331 — a divergent equal-LSN standby ALSO streams but reports
+     False); only then does the actor record dr-failback-converged-at on
+     the HR and go idle.
 
 WEDGE ESCALATION (in-place demote left a stale standby)
 -------------------------------------------------------
@@ -209,6 +212,48 @@ delete 23:20:50Z — and then the RE-CLONE ITSELF wedged, silently, for
      while the local cluster is psql-dark (probe_peer_writable in the
      'unknown' branch): the destructive escalations need a live
      writable peer precisely when local observability is gone.
+
+VERIFIED CONVERGENCE (#5331, chart 0.2.21 — the hw285 residual)
+---------------------------------------------------------------
+hw285 G12 (2026-07-23, dep 27350950bef5c882) had a CLEAN failover
+(region-B promoted RPO=0) but a FALSE failback: region-A powered back
+on, self-promoted to its OWN TL2 fork, and was demoted IN PLACE (the
+webhook admitted the shape change before the delete → stale-PGDATA
+standby, ConsistentSystemID=False reason=NotFound). At 00:16:18Z the
+actor logged DIVERGENCE DETECTED and started the 180s grace; at
+00:16:28Z — only 10s later, no re-clone — the actor declared "CONVERGED:
+region-A re-cloned and streaming from region-B". Root cause, TWO coupled
+defects:
+
+  1. THE CONVERGED GATE WAS DATA-BLIND. It keyed off the local
+     'streaming' signal alone (converged-streaming + demoted). That
+     signal is `pg_stat_wal_receiver` row + `pg_last_wal_receive_lsn()
+     IS NOT NULL` — which a DIVERGENT in-place-demoted standby ALSO
+     satisfies: it momentarily attached to region-B at a
+     COINCIDENTALLY-EQUAL LSN (0/D000138 on both) while sitting on its
+     own TL-fork, missing region-B's post-failover write. So it declared
+     converged on an equal-LSN divergent standby. FIX: the CONVERGED gate
+     now ALSO requires CNPG's `ConsistentSystemID=True` — CNPG's own
+     positive attestation of consistent lineage, which CANNOT hold on a
+     divergent line. (LSN-equality is deliberately NOT used: equal LSNs
+     are the false signal.)
+  2. THE DIVERGENCE ESCALATION WAS SUPPRESSED BY THE SAME FALSE SIGNAL.
+     The D2a `ConsistentSystemID=False` escalation was ANDed with
+     `! -f /shared/converged-streaming`, so the same coincidental
+     'streaming' both blocked the re-clone AND reset the divergence
+     clock (the else-branch). FIX: D2a now gates on CNPG's verdict alone
+     — ConsistentSystemID=False overrides a coincidental streaming
+     appearance. And the signals `streaming)` arm now keeps the
+     peer-WRITABLE proof fresh, so the (now-reachable) divergence
+     escalation has a <60s writable-peer proof to authorize the re-clone
+     instead of starving.
+
+Net contract: CONVERGED is declared ONLY after (grace elapsed → real
+pg_basebackup re-clone of region-A from region-B → fresh clone reports
+ConsistentSystemID=True while streaming). The clean-in-place-follow path
+(tail exactly at the fork → ConsistentSystemID=True without a re-clone)
+still converges, cheapest-path-wins, because the gate keys off CNPG's
+consistency verdict, not on re-clone provenance.
 
 WHAT IT NEVER DOES
 ------------------
@@ -621,10 +666,24 @@ spec:
                     fi
                     ;;
                   streaming)
-                    # Demoted + streaming from region-B — converged.
-                    clear_hold "local standby streaming (converged)"
+                    # Demoted + streaming from region-B — the DATA-PLANE
+                    # signal only. A divergent in-place-demoted standby on its
+                    # own TL-fork also reads 'streaming' (walreceiver row + a
+                    # set receive-LSN) at a coincidentally-equal LSN; the ACTOR
+                    # makes the convergence call by ALSO checking CNPG's
+                    # ConsistentSystemID verdict (#5331). Keep the
+                    # peer-WRITABLE proof fresh here so that, if the actor
+                    # finds this 'streaming' is actually the divergent case
+                    # (ConsistentSystemID=False), its re-clone escalation has a
+                    # <60s-fresh writable-peer proof to act on — this arm never
+                    # refreshed it before, so the divergence escalation would
+                    # starve for a fresh proof and wedge. Harmless for a
+                    # genuinely-converged replica: the actor exits at CONVERGED
+                    # and never consumes the proof.
+                    clear_hold "local standby streaming (data-plane signal; actor verifies ConsistentSystemID)"
                     clear_wedge
                     : > /shared/converged-streaming
+                    probe_peer_writable_report
                     ;;
                   receiving|noreceiver)
                     # A local standby that is NOT streaming. If the peer is
@@ -794,12 +853,44 @@ spec:
                   # divergence escalation and the post-re-clone watch.
                   CR_JSON=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" -o jsonpath="{.spec.replica.enabled}|{.metadata.creationTimestamp}|{.metadata.deletionTimestamp}|{.status.conditions[?(@.type=='ConsistentSystemID')].status}|{.status.conditions[?(@.type=='ConsistentSystemID')].reason}|{.status.phase}" 2>/dev/null || echo "__absent__")
                   STARTED_AT=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.metadata.annotations.catalyst\.openova\.io/dr-failback-started-at}' 2>/dev/null || echo "")
+                  # 0.2.21 (#5331): parse the CR fields up-front — the
+                  # CONVERGED verification gate below needs CNPG's own
+                  # ConsistentSystemID verdict, not just the psql streaming
+                  # signal. When the CR is absent (mid-re-clone) every field
+                  # is empty and the gate correctly declines to converge.
+                  CR_REPLICA=$(echo "${CR_JSON}" | cut -d'|' -f1)
+                  CR_CREATED=$(echo "${CR_JSON}" | cut -d'|' -f2)
+                  CR_DELETING=$(echo "${CR_JSON}" | cut -d'|' -f3)
+                  CR_SYSID_OK=$(echo "${CR_JSON}" | cut -d'|' -f4)
+                  CR_SYSID_REASON=$(echo "${CR_JSON}" | cut -d'|' -f5)
+                  CR_PHASE=$(echo "${CR_JSON}" | cut -d'|' -f6)
 
                   # ── CONVERGED — record once, then idle ────────────────
-                  if [ -f /shared/converged-streaming ] && [ "${VALS_DEMOTED}" = "true" ] && [ ! -f /shared/converged-recorded ]; then
+                  # #5331 (hw285 P0 data-loss trap): gate on VERIFIED data
+                  # convergence, NEVER on the bare local 'streaming' signal.
+                  # region-A must be BOTH (a) streaming from region-B (the
+                  # data-plane signal /shared/converged-streaming) AND (b)
+                  # reporting CNPG's ConsistentSystemID=True — CNPG's own
+                  # positive attestation that region-A's PGDATA / system
+                  # lineage is CONSISTENT with the source it streams from.
+                  # A divergent in-place-demoted standby on its OWN TL-fork
+                  # also reads 'streaming' (a walreceiver row + a set
+                  # receive-LSN) at a COINCIDENTALLY-EQUAL LSN, yet holds
+                  # ConsistentSystemID=False and is missing region-B's
+                  # post-failover writes. On hw285 the 0.2.20 gate
+                  # (converged-streaming + demoted only) declared such a
+                  # standby CONVERGED 10s into the 180s divergence grace,
+                  # with NO re-clone — a data-loss trap on switchback.
+                  # ConsistentSystemID=True CANNOT hold on a divergent line,
+                  # so it is the load-bearing positive proof; LSN-equality is
+                  # NOT (equal LSNs are exactly the false signal). The
+                  # divergence path below (D2a) re-clones region-A from
+                  # region-B, after which a genuine pg_basebackup replica
+                  # reports ConsistentSystemID=True and converges here.
+                  if [ -f /shared/converged-streaming ] && [ "${VALS_DEMOTED}" = "true" ] && [ "${CR_SYSID_OK}" = "True" ] && [ ! -f /shared/converged-recorded ]; then
                     if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-converged-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1; then
                       : > /shared/converged-recorded
-                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] CONVERGED: region-A re-cloned and streaming from region-B — recorded dr-failback-converged-at on HR ${HR_NAMESPACE}/${HR_NAME}. Cross-region replication restored, roles swapped; the controlled switchback (demote region-B, restore region-A primary) is the sovereign-admin's RUNBOOKS §6.1 action (#5245)"
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] CONVERGED: region-A streaming from region-B AND CNPG reports ConsistentSystemID=True (verified consistent lineage — not a divergent equal-LSN standby) — recorded dr-failback-converged-at on HR ${HR_NAMESPACE}/${HR_NAME}. Cross-region replication restored, roles swapped; the controlled switchback (demote region-B, restore region-A primary) is the sovereign-admin's RUNBOOKS §6.1 action (#5245 #5331)"
                     fi
                     exit 0
                   fi
@@ -852,12 +943,7 @@ spec:
                     nudge helmrelease "${HR_NAMESPACE}" "${HR_NAME}" nudged-hr
                     exit 0
                   fi
-                  CR_REPLICA=$(echo "${CR_JSON}" | cut -d'|' -f1)
-                  CR_CREATED=$(echo "${CR_JSON}" | cut -d'|' -f2)
-                  CR_DELETING=$(echo "${CR_JSON}" | cut -d'|' -f3)
-                  CR_SYSID_OK=$(echo "${CR_JSON}" | cut -d'|' -f4)
-                  CR_SYSID_REASON=$(echo "${CR_JSON}" | cut -d'|' -f5)
-                  CR_PHASE=$(echo "${CR_JSON}" | cut -d'|' -f6)
+                  # CR fields parsed up-front (before the CONVERGED gate, #5331).
                   if [ -n "${CR_DELETING}" ]; then
                     exit 0   # teardown in progress — wait
                   fi
@@ -886,7 +972,18 @@ spec:
                     # hw278 crawled to its escalation). One clock, cleared
                     # whenever the condition leaves False; the delete still
                     # requires a fresh writable-peer proof.
-                    if [ "${CR_SYSID_OK}" = "False" ] && [ ! -f /shared/converged-streaming ]; then
+                    # #5331: ConsistentSystemID=False is CNPG's AUTHORITATIVE
+                    # divergence verdict and OVERRIDES a coincidental local
+                    # 'streaming' appearance. A divergent in-place-demoted
+                    # standby momentarily attaches to region-B at an equal LSN
+                    # (walreceiver row + set receive-LSN → local state
+                    # 'streaming' → /shared/converged-streaming) yet can never
+                    # follow region-B's line. The removed
+                    # `! -f /shared/converged-streaming` conjunct let that
+                    # false 'streaming' suppress the escalation AND reset the
+                    # divergence clock via the else-branch below — exactly how
+                    # hw285 skipped the re-clone. Gate on CNPG's verdict alone.
+                    if [ "${CR_SYSID_OK}" = "False" ]; then
                       if [ ! -f /shared/diverged-since ]; then
                         date -u +%s > /shared/diverged-since
                         echo "$(date -u +"%FT%TZ") [dr-failback/actor] DIVERGENCE DETECTED: in-place-demoted Cluster (created ${CR_CREATED} < episode ${STARTED_AT}) reports ConsistentSystemID=False (reason=${CR_SYSID_REASON:-?}, phase='${CR_PHASE:-?}') — the stale-PGDATA line cannot consistently follow region-B; divergence clock started (grace ${DIVERGENCE_GRACE_SECONDS}s) (#5245 hw278)"
@@ -931,12 +1028,17 @@ spec:
                   # pgbasebackup Job FATAL-looped on x509 for 5+ hours with
                   # the actor totally silent — a wedged re-clone must name
                   # itself. Log the live phase + ConsistentSystemID every
-                  # 30 ticks (~5 min) until streaming converges.
-                  if [ ! -f /shared/converged-streaming ]; then
+                  # 30 ticks (~5 min) until CONVERGED records. #5331: key the
+                  # heartbeat on converged-RECORDED, not converged-STREAMING —
+                  # a fresh clone that is streaming but not yet
+                  # ConsistentSystemID=True is NOT converged (the CONVERGED
+                  # gate requires both), and must keep naming itself rather
+                  # than go dark on the bare streaming signal.
+                  if [ ! -f /shared/converged-recorded ]; then
                     _n=$(($(cat /shared/postclone-ticks 2>/dev/null || echo 0) + 1))
                     if [ "${_n}" -ge 30 ]; then
                       _n=0
-                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONE NOT YET STREAMING: Cluster phase='${CR_PHASE:-?}', ConsistentSystemID=${CR_SYSID_OK:-?}(${CR_SYSID_REASON:-?}), local state=$(cat /shared/local-state 2>/dev/null || echo '?') — the pg_basebackup bootstrap has not converged; check the ${PRIMARY_CLUSTER}-1-pgbasebackup Job logs (hw278 wedge shape: x509 unknown-authority = a root cert pinned against the wrong CA) (#5245)"
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONE NOT YET CONVERGED: Cluster phase='${CR_PHASE:-?}', ConsistentSystemID=${CR_SYSID_OK:-?}(${CR_SYSID_REASON:-?}), local state=$(cat /shared/local-state 2>/dev/null || echo '?') — streaming AND ConsistentSystemID=True not both observed yet; check the ${PRIMARY_CLUSTER}-1-pgbasebackup Job logs (hw278 wedge shape: x509 unknown-authority = a root cert pinned against the wrong CA; hw285 shape: ConsistentSystemID=False = a divergent line that never re-cloned) (#5245 #5331)"
                     fi
                     echo "${_n}" > /shared/postclone-ticks
                   else

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -1370,8 +1370,8 @@ grep -q 'self-healing the episode marker' "$TMP/fb-actor.sh" || {
 
 # (e) POST-RE-CLONE WATCH: a wedged re-clone must name itself — phase +
 #     ConsistentSystemID logged periodically until streaming converges.
-grep -q 'RE-CLONE NOT YET STREAMING' "$TMP/fb-actor.sh" || {
-  echo "FAIL: #5245 hw278 actor missing the post-re-clone convergence heartbeat (the 5h-silent wedge)." >&2; exit 1; }
+grep -q 'RE-CLONE NOT YET CONVERGED' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5245 hw278 actor missing the post-re-clone convergence heartbeat (the 5h-silent wedge); #5331 renamed it NOT-YET-CONVERGED (streaming+ConsistentSystemID=True) and keys it off converged-recorded." >&2; exit 1; }
 
 # (f) DARK-WINDOW PEER PROOF: the signals container must keep the
 #     writable-peer proof fresh while the local cluster is psql-dark — the
@@ -1401,5 +1401,85 @@ sh -n "$TMP/fb-signals.sh" || { echo "FAIL: #5245 hw278 signals script is not va
 sh -n "$TMP/fb-actor.sh"   || { echo "FAIL: #5245 hw278 actor script is not valid POSIX shell." >&2; exit 1; }
 
 echo "  PASS (no wrong-CA root pin on the rejoin stream + forward pin kept · preserve_pki before every delete + pinned get/patch RBAC · ConsistentSystemID divergence escalation, graced + pre-episode-bounded + writable-proof-guarded · episode-marker self-heal · post-re-clone watch · dark-window peer probe · healthy-pair no-op)"
+
+# ── Case 21: #5331 hw285 residual — CONVERGED must be VERIFIED, not streaming ─
+# hw285 G12 (2026-07-23, dep 27350950bef5c882): a CLEAN failover (region-B
+# promoted RPO=0) then a FALSE failback. region-A powered back on, self-promoted
+# to its OWN TL2 fork, was demoted IN PLACE (ConsistentSystemID=False), and the
+# actor declared "CONVERGED: region-A re-cloned and streaming" 10s into the 180s
+# divergence grace with NO re-clone — region-A kept a divergent line missing
+# region-B's post-failover write (data-loss trap on switchback). Root cause: the
+# CONVERGED gate keyed off the local 'streaming' signal alone (a walreceiver row
+# + a set receive-LSN that a divergent equal-LSN standby also has), and the D2a
+# divergence escalation was suppressed by that same false 'streaming'.
+echo "[render] Case 21: #5331 hw285 — CONVERGED gated on ConsistentSystemID=True (not bare streaming) + divergence escalation not suppressed by a coincidental streaming"
+
+# (a) THE CONVERGED GATE requires CNPG's ConsistentSystemID=True in addition to
+#     the local streaming signal and the demoted-values proof — a divergent
+#     equal-LSN standby (ConsistentSystemID=False) can never trip it.
+python3 - "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5331 CONVERGED-gate assertions failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+# Anchor directly on the CONVERGED gate guard (unique: D2a/D3 no longer key
+# off converged-streaming). The guard line runs to its `then`.
+g=s.find('if [ -f /shared/converged-streaming ]')
+assert g!=-1, "CONVERGED record must still require the local streaming data-plane signal"
+guard=s[g:s.find('then', g)]
+assert '/shared/converged-streaming' in guard, "CONVERGED must keep the streaming data-plane signal"
+assert 'VALS_DEMOTED' in guard and '"true"' in guard, "CONVERGED must keep the demoted-values proof"
+assert 'CR_SYSID_OK' in guard and '"True"' in guard, \
+    "#5331: CONVERGED must ALSO require CNPG ConsistentSystemID=True (a divergent equal-LSN standby reads as streaming but is False)"
+PYEOF
+grep -q 'ConsistentSystemID=True' "$TMP/fb-actor.sh" || {
+  echo "FAIL: #5331 the CONVERGED log must cite the verified ConsistentSystemID=True proof (not a bare 're-cloned and streaming' claim)." >&2; exit 1; }
+
+# (b) THE DIVERGENCE ESCALATION must gate on CNPG's verdict ALONE — the old
+#     `! -f /shared/converged-streaming` conjunct let a coincidental streaming
+#     both suppress the re-clone and reset the divergence clock (hw285).
+python3 - "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5331 divergence-escalation gate assertions failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+d=s.find('DIVERGENCE DETECTED')
+assert d!=-1, "actor lost the divergence detection branch"
+# The `if` that opens the divergence branch (nearest above the detection log).
+g=s.rfind('if [ "${CR_SYSID_OK}" = "False" ]', 0, d)
+assert g!=-1, "divergence branch must gate on ConsistentSystemID=False"
+guard=s[g:s.find('then', g)]
+assert 'converged-streaming' not in guard, \
+    "#5331: the divergence escalation must NOT be ANDed with `! -f /shared/converged-streaming` — a coincidental streaming was suppressing the re-clone and resetting the divergence clock (the hw285 short-circuit)"
+PYEOF
+
+# (c) THE SIGNALS streaming ARM keeps the peer-WRITABLE proof fresh, so the
+#     (now-reachable) divergence escalation has a <60s writable-peer proof to
+#     authorize the re-clone instead of starving.
+python3 - "$TMP/fb-signals.sh" <<'PYEOF' || { echo "FAIL: #5331 signals streaming-arm peer-writable-refresh assertion failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+i=s.find('streaming)')
+assert i!=-1, "signals ladder lost its streaming arm"
+arm=s[i:s.find(';;', i)]
+assert ': > /shared/converged-streaming' in arm, "streaming arm must still raise the data-plane converged signal"
+assert 'probe_peer_writable' in arm, \
+    "#5331: the streaming arm must keep the peer-writable proof fresh (probe_peer_writable_report) so the divergence escalation does not starve for a fresh writable-peer proof when a divergent standby momentarily reads 'streaming'"
+PYEOF
+
+# (d) THE POST-RE-CLONE WATCH keys off converged-RECORDED (streaming AND
+#     ConsistentSystemID=True), never the bare streaming signal — a fresh clone
+#     that streams but is not yet consistent must keep naming itself.
+python3 - "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5331 post-re-clone watch key assertion failed." >&2; exit 1; }
+import sys
+s=open(sys.argv[1]).read()
+w=s.find('POST-RE-CLONE convergence watch')
+assert w!=-1, "actor missing the post-re-clone convergence watch"
+seg=s[w:w+900]
+assert '! -f /shared/converged-recorded' in seg, \
+    "#5331: the post-re-clone heartbeat must key off converged-recorded (streaming+consistent), not the bare converged-streaming signal"
+PYEOF
+
+# (e) Scripts still valid POSIX shell with the 0.2.21 additions.
+sh -n "$TMP/fb-signals.sh" || { echo "FAIL: #5331 signals script is not valid POSIX shell." >&2; exit 1; }
+sh -n "$TMP/fb-actor.sh"   || { echo "FAIL: #5331 actor script is not valid POSIX shell." >&2; exit 1; }
+
+echo "  PASS (CONVERGED gated on ConsistentSystemID=True + streaming + demoted · divergence escalation on CNPG verdict alone · streaming arm keeps peer-writable proof fresh · post-re-clone watch keys off converged-recorded)"
 
 echo "[render] All bp-cnpg-pair render gates green."

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3550,7 +3550,14 @@ name: bp-catalyst-platform
 #   while warm SSO works (hw278: harbor/openbao/guacamole/pdns-admin/hubble). Same
 #   self-heal idiom already used for handover-jwt-public + provisioning-github-token.
 #   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync gate).
-version: 1.4.1201
+# 1.4.1202 — #5331: catalog-seed bp-cnpg-pair pin 0.2.20 -> 0.2.21 (+ spec.version
+#   display label) — dr-failback VERIFIED CONVERGENCE (hw285 residual): the
+#   CONVERGED gate now also requires CNPG ConsistentSystemID=True, so a divergent
+#   in-place-demoted standby streaming at a coincidentally-equal LSN can no longer
+#   be declared "re-cloned and streaming" without a real pg_basebackup re-clone
+#   (the hw285 data-loss trap on switchback). Bootstrap-kit slot-13 pin bumped in
+#   lockstep (pin-sync gate). Lockstep w/ 16b slot pin 0.2.21.
+version: 1.4.1202
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -411,10 +411,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  # 0.2.20 (#5245): dr-failback re-clone convergence (hw278 residual) —
-  # keep this display-version in lockstep with delivery source.version +
+  # 0.2.21 (#5331): dr-failback VERIFIED convergence (hw285 residual) —
+  # the CONVERGED gate now also requires CNPG ConsistentSystemID=True, so a
+  # divergent equal-LSN standby can no longer be declared re-cloned. Keep
+  # this display-version in lockstep with delivery source.version +
   # blueprint.yaml (the #4988 precedent).
-  version: "0.2.20"
+  version: "0.2.21"
   visibility: listed
   card:
     title: "CNPG Cluster-Pair (Active-Hotstandby DR)"
@@ -444,7 +446,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.20"
+    version: "0.2.21"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
🛑 HOLD MERGE — next-train batch (a merge rolls catalyst-api; this fix must bake into a fresh prov, not hand-heal hw285).

## P0 DR failback data-integrity defect (#5331)

**Surfaced live on hw285** (dep `27350950bef5c882`, omantel.biz, 2-region me-east-215). The G12 **failover** was clean (region-B promoted, RPO=0). The **failback** falsely reported convergence: after region-A powered back on and self-promoted to its own TL2 fork, the dr-failback controller declared `CONVERGED: region-A re-cloned and streaming from region-B` **10s after** logging `DIVERGENCE DETECTED … ConsistentSystemID=False … grace 180s` — **before the 180s grace and without any re-clone**. region-A kept stale divergent PGDATA (missing region-B's post-failover write) while reporting `streaming` at a coincidentally-equal LSN — a data-loss trap on operator switchback.

## Root cause (file:line on `origin/main` @ `3dbcb78`)

`platform/cnpg-pair/chart/templates/dr-failback.yaml` — two coupled defects:

1. **The CONVERGED gate was data-blind** — `dr-failback.yaml:799` (actor container):
   ```sh
   if [ -f /shared/converged-streaming ] && [ "${VALS_DEMOTED}" = "true" ] && [ ! -f /shared/converged-recorded ]; then
   ```
   `/shared/converged-streaming` is set by the signals container's `streaming)` arm (`:624-628`), and `streaming` is defined (`:466-471`) as `EXISTS(pg_stat_wal_receiver) AND pg_last_wal_receive_lsn() IS NOT NULL`. A **divergent** in-place-demoted standby also satisfies that — it momentarily attached to region-B at a coincidentally-equal LSN (`0/D000138` on both) while sitting on its own TL-fork. The gate makes **no** check that a re-clone happened or that CNPG's `ConsistentSystemID=True`, yet the log unconditionally claims "re-cloned and streaming".

2. **The divergence escalation was suppressed by the same false signal** — `dr-failback.yaml:889` (D2a):
   ```sh
   if [ "${CR_SYSID_OK}" = "False" ] && [ ! -f /shared/converged-streaming ]; then
   ```
   Because the divergent standby momentarily reads `streaming`, `converged-streaming` exists → the escalation is skipped and its `else` branch (`:909`) `rm -f`s the divergence clock. So even without defect 1, the 180s grace could never complete and the re-clone never fires.

The CONVERGED block is also evaluated **first**, before D0/D1/D2a, so it short-circuits the whole loop (`exit 0`) the instant a divergent standby flickers to `streaming`.

## Fix contract

- **CONVERGED is gated on verified convergence, not `streaming` alone.** The gate now also requires CNPG's own **`ConsistentSystemID=True`** — its positive attestation that region-A's PGDATA/system lineage is consistent with the source it streams from. This condition **cannot** hold on a divergent line (hw285 held `False reason=NotFound`). LSN-equality is deliberately **not** used — equal LSNs are exactly the false signal the issue warns about. The log now cites the verified `ConsistentSystemID=True` proof instead of an unconditional "re-cloned" claim.
- **The D2a divergence escalation gates on CNPG's verdict alone** (dropped the `! -f /shared/converged-streaming` conjunct). `ConsistentSystemID=False` now overrides a coincidental `streaming` appearance, so the pre-episode in-place-demoted standby accrues the full 180s grace and then triggers the **real** re-clone (delete the stale Cluster CR → CNPG re-bootstraps via `pg_basebackup` from region-B — the existing bounded, PKI-preserving, peer-proof-guarded seam from #5245/hw278). The signals `streaming)` arm now keeps the peer-writable proof fresh so the now-reachable escalation doesn't starve.
- **Never short-circuits the grace.** CONVERGED is declared only after: grace elapsed → real pg_basebackup re-clone → fresh clone reports `ConsistentSystemID=True` while streaming. The post-re-clone watch keys off `converged-recorded` (streaming **and** consistent), never the bare streaming signal, so a wedged clone still names itself.
- **Preserved:** the no-split-brain demote logic (#5245/#5268), bounded single-re-clone-per-episode destruction, and the clean-in-place-follow cheapest-path (tail exactly at the fork → `ConsistentSystemID=True` without a re-clone still converges — the gate keys off CNPG's verdict, not on re-clone provenance).

### Why `ConsistentSystemID`, not a sentinel/LSN check
The dr-failback containers connect as the `streaming_replica` replication role and cannot write app tables, so a write+read sentinel would need an invasive new write path into the production DB. `ConsistentSystemID=True` is CNPG's authoritative *positive* proof of consistent lineage and is strictly stronger than an LSN check (equal LSNs on divergent lines are the exact hw285 trap). It is read from the Cluster CR the actor already queries — no new RBAC, no new value knob.

## Lockstep version bumps (so the fix reaches a fresh prov)
- `bp-cnpg-pair` chart + blueprint `0.2.20 → 0.2.21`
- catalog-seed `bp-cnpg-pair` display + source pins `0.2.20 → 0.2.21`
- bootstrap-kit slot `16b-bp-cnpg-pair` pin `0.2.20 → 0.2.21`
- umbrella `bp-catalyst-platform` `1.4.1201 → 1.4.1202` + bootstrap-kit slot `13` pin (same lockstep the #5245/hw278 `0.2.19→0.2.20` change used)

## Test evidence
Extended the chart render gate (`platform/cnpg-pair/chart/tests/cnpg-pair-render.sh`, new **Case 21**): asserts the CONVERGED gate requires `ConsistentSystemID=True` (+ streaming + demoted), the divergence escalation is not ANDed with `converged-streaming`, the signals `streaming` arm refreshes the peer-writable proof, and the post-re-clone watch keys off `converged-recorded`. All rendered actor/signals scripts still pass `sh -n`.

```
[render] Case 20: #5245 hw278 …
  PASS (…)
[render] Case 21: #5331 hw285 — CONVERGED gated on ConsistentSystemID=True (not bare streaming) + divergence escalation not suppressed by a coincidental streaming
  PASS (CONVERGED gated on ConsistentSystemID=True + streaming + demoted · divergence escalation on CNPG verdict alone · streaming arm keeps peer-writable proof fresh · post-re-clone watch keys off converged-recorded)
[render] All bp-cnpg-pair render gates green.
```
`helm lint platform/cnpg-pair/chart` → `0 chart(s) failed`.

Refs #5331, #5245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
