### PR TITLE
fix(continuum): #5311 standby-probe reads Secret via cached client → needs list+watch RBAC it lacks → probe inert (uncached APIReader)

### DIFF
--- a/core/controllers/continuum/cmd/main.go
+++ b/core/controllers/continuum/cmd/main.go
@@ -162,7 +162,13 @@ func main() {
 	sel := &witness.DefaultSelector{
 		InMemoryAllowed: envBool("WITNESS_IN_MEMORY", false),
 		SecretReader: &k8sSecretReader{
-			Client:    mgr.GetClient(),
+			// Uncached direct API reader (#5311): a Secret Get through the
+			// manager's cached client (mgr.GetClient()) forces a cluster-
+			// wide Secret list+watch informer, which the chart RBAC
+			// deliberately does NOT grant (secrets: get only). Use the
+			// APIReader so this honors get-only RBAC and never caches
+			// every Secret in the cluster in controller memory.
+			Client:    mgr.GetAPIReader(),
 			Namespace: witnessSecretNS,
 		},
 	}
@@ -244,14 +250,20 @@ func main() {
 		// this controller's local API). Authenticates with the
 		// CNPG-provisioned streaming_replica client cert
 		// (`<primary>-replication` Secret) — the same credential the
-		// dr-promoter / dr-failback probes use. The controller already
-		// holds `secrets: get` cluster-wide (see the chart RBAC), and
-		// the target is the LOCAL primary `-rw` Service. Reachable from
-		// the single mgr client since ClusterDomain defaults to
-		// cluster.local; CLUSTER_DOMAIN overrides for customized
+		// dr-promoter / dr-failback probes use. The controller holds
+		// `secrets: get` cluster-wide (see the chart RBAC) and reads the
+		// cert via the UNCACHED mgr.GetAPIReader(): a Secret Get through
+		// the cached mgr.GetClient() would force a cluster-wide Secret
+		// list+watch informer the RBAC does not grant, which silently
+		// wedged this probe (the Secret Get errored → "no standby
+		// determination" every tick → the #5311 pg_stat_replication
+		// observation never fired and standbyAvailable stayed UNSET — the
+		// exact false-green this fix targets). The target is the LOCAL
+		// primary `-rw` Service; reachable since ClusterDomain defaults
+		// to cluster.local; CLUSTER_DOMAIN overrides for customized
 		// kubelet cluster domains.
 		StandbyProbe: &pgprobe.PGXProber{
-			Secrets:       &pgSecretReader{Client: mgr.GetClient()},
+			Secrets:       &pgSecretReader{Client: mgr.GetAPIReader()},
 			ClusterDomain: env("CLUSTER_DOMAIN", pgprobe.DefaultClusterDomain),
 		},
 		HealthOpts: switchover.HealthOptions{
@@ -362,7 +374,10 @@ func podNamespace() string {
 // Mirrors the EPIC-3 F readClientSecret seam — but lifted to an
 // interface so the witness package doesn't import client-go.
 type k8sSecretReader struct {
-	Client    client.Client
+	// client.Reader (uncached APIReader) — NOT client.Client — so a
+	// Secret Get is a direct API read that needs only `secrets: get`
+	// and never starts a cluster-wide Secret list+watch informer.
+	Client    client.Reader
 	Namespace string
 }
 
@@ -402,7 +417,10 @@ func (r *k8sSecretReader) ReadSecret(ctx context.Context, secretName, key string
 // Per Inviolable Principle #5 the cert bytes stay in memory only until
 // PGXProber hands them to the TLS dialer. NEVER log; NEVER persist.
 type pgSecretReader struct {
-	Client client.Client
+	// client.Reader (uncached APIReader) — NOT client.Client — so a
+	// Secret Get is a direct API read that needs only `secrets: get`
+	// and never starts a cluster-wide Secret list+watch informer.
+	Client client.Reader
 }
 
 // ReadSecret implements pgprobe.SecretReader.


### PR DESCRIPTION
🛑 HOLD MERGE — next-train batch (validates on a fresh prov, not hand-healed)

## What this fixes

The #5311 standby-observation probe (the pg_stat_replication path meant to close the #4901 false-green on a TRUE 2-region Sovereign) is **INERT on deploy**. It reads the `<primary>-replication` client cert through `pgSecretReader{Client: mgr.GetClient()}` — the manager's **cached** client. A Secret `Get` through the cached client forces a cluster-wide Secret **list+watch** informer, but the `continuum-controller` ClusterRole grants only `secrets: get` (by design — the controller must not cache every Secret in the cluster).

### Live evidence — hw286 (dep `8252169e5cd7a2dc`, region-a control plane)

- `continuum-controller` (`registry.hw286.omani.works/openova-io/openova/continuum-controller:a8f89f2`) spams every ~40s:
  ```
  E reflector.go:158 Failed to watch *v1.Secret: secrets is forbidden:
  User "system:serviceaccount:catalyst-system:continuum-controller"
  cannot list resource "secrets" in API group "" at the cluster scope
  ```
- ClusterRole `continuum-controller` secrets rule: `[""] | ["secrets"] | ["get"]` — no `list`/`watch`.
- Net: the cached Secret `Get` never succeeds → `StandbyProbe.Observe` errors every tick → `observeCNPGStandby` (`core/controllers/continuum/internal/controller/continuum_controller.go:981`) logs "primary pg_stat_replication probe failed; no standby determination this tick" → `standbyAvailable` stays **UNSET** — the exact #4901/#5311 false-green.

The code comment at `cmd/main.go` even *assumed* get-only was sufficient ("The controller already holds `secrets: get` cluster-wide ... Reachable from the single mgr client") — but `mgr.GetClient()` is cached and needs list+watch, so the wiring contradicted the RBAC.

## The fix

Read Secrets via the **uncached `mgr.GetAPIReader()`** (a direct API `get`, no informer) in both SecretReaders — `pgSecretReader` (#5311 probe) and `k8sSecretReader` (lease-witness path). Struct fields change `client.Client → client.Reader`. This:

- honors the `get`-only RBAC the design intended,
- kills the reflector error spam,
- avoids caching all cluster Secrets in controller memory (security + memory win).

No chart / RBAC change needed — `secrets: get` is now correct as-is.

## Scope note — what this is NOT

This is **not** a regression of #4987 and **not** a "0 Continuum CRs" bug. On hw286 region-a there are **8 healthy Continuum CRs** (`dr-spine-{gitea,harbor,keycloak,openbao}` + `dr-shared-pg{,-b,-c}`); #4987's `dr-shared-pg*` CRs render `phase=Healthy` — #4987 works. The `cnpgpairs.dr.openova.io` CRD legitimately has **0 CRs by design** (no producer anywhere in the tree; it is read-only scaffolding for the bootstrap-API projections — the DR contract lives in `Continuum.spec.cnpgPair`). Full triage in the #5311 comment.

## Test evidence

Go-only controller change; needs a fresh-prov image rebuild to verify live (hence HOLD MERGE).

```
$ go build ./...   → exit 0
$ go vet ./cmd/... → exit 0
$ go test ./...    → all ok (controller, pgprobe, cnpg, switchover, witness/*, dns, pdm, api, events)
```

Refs #5311 #4901
