### PR TITLE
fix(keycloak,oidc-gate): drop `roles` default scope from pdns-admin gate client (oauth2-proxy cookie <4KB) — Refs #5334

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -226,7 +226,7 @@ spec:
       #   values.yaml wires keycloak.auth.existingSecret=keycloak-admin so the
       #   password is reused (never regenerated) across reinstall + re-home. Chart
       #   + blueprint bumped in lockstep.
-      version: 1.5.5
+      version: 1.5.6
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -87,7 +87,7 @@ spec:
       # `/app/?token=<sentinel>` so the SPA seeds the token and lands
       # authenticated with NO paste (the durable path — the daemon's `oidc`
       # authMode is a non-functional upstream scaffold, #128).
-      version: 0.1.6
+      version: 0.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -425,7 +425,18 @@ name: bp-keycloak
 # images pass admission. No chart-content change beyond the version line + this
 # changelog — the 1.4.38 templates/values are byte-identical and already
 # proxy-compliant. Refs #3785 (sibling proxy-class defect for the WP image).
-version: 1.5.5
+# 1.5.6 (#5334, 2026-07-23): DROP `roles` from the `powerdns-admin` client's
+# defaultClientScopes. The oauth2-proxy/oidc-gate session for pdns-admin stuffed
+# the full ~44 realm+client role graph into the browser cookie → >4 KB → oauth2-
+# proxy split-cookie → intermittent "Secured with OAuth2 Proxy" callback 500 (the
+# ONLY per-service SSO that failed on hw286; native-OIDC grafana/gitea/harbor are
+# immune via server-side sessions). The gate does no role auth and PDA maps only
+# username/email, so dropping `roles` shrinks the session to
+# [sovereign-admins sovereign-viewers] and the cookie falls under 4 KB. `groups`
+# retained (Tier-2 convention, guarded by g117-5-tier2-sso-clients.sh). Kept in
+# lockstep with bp-oidc-gate 0.1.7 instances.yaml. ONLY the powerdns-admin client
+# block changed — no other client's scopes touched.
+version: 1.5.6
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -885,11 +885,17 @@ data:
           "webOrigins": [
             "https://pdns-admin.{{ .Values.sovereignFQDN }}"
           ],
+          {{- /*
+            #5334 — `roles` DROPPED from defaultClientScopes (gate-only): the
+            oauth2-proxy session stuffed the full ~44-role graph into the browser
+            cookie → >4 KB split → intermittent callback 500. Gate does no
+            role auth; PDA maps only username/email. `groups` stays (Tier-2
+            convention). Lockstep with bp-oidc-gate instances.yaml.
+          */ -}}
           "defaultClientScopes": [
             "web-origins",
             "acr",
             "profile",
-            "roles",
             "email",
             "groups"
           ],

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -115,7 +115,17 @@ name: bp-oidc-gate
 # leave the API open yet still demand a localStorage token. Default unset → no
 # rule (byte-identical to a login-less gated app). Slot 13c sets spaTokenSeed
 # on the agenity-agnstar instance.
-version: 0.1.6
+# 0.1.7 (#5334, 2026-07-23): DROP `roles` from the gate clients' defaultClient-
+# Scopes. oauth2-proxy's keycloak-oidc provider extracted every realm+client role
+# (~44) into the browser-cookie session → >4 KB → split cookie → intermittent
+# "Secured with OAuth2 Proxy" 500 on the proxied callback (worst on pdns-admin's
+# double-OIDC rootRedirect+appNativeCallback flow). The gate performs NO group/
+# role authorization (no --allowed-groups) and requests no `roles` scope, so
+# dropping it shrinks the session to [sovereign-admins sovereign-viewers] for
+# every instance (fixes openova-flow/agenity too) and drops the cookie under 4 KB.
+# `groups` retained. Lockstep with the config-cli powerdns-admin seed (bp-keycloak
+# 1.5.6). Template-only change; render tests unaffected.
+version: 0.1.7
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/instances.yaml
+++ b/platform/oidc-gate/chart/templates/instances.yaml
@@ -112,7 +112,18 @@ data:
       "webOrigins": [
         "https://{{ $hostname }}"
       ],
-      "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email", "groups"],
+      {{- /*
+        #5334 — `roles` DROPPED from the gate clients' default scopes. With it,
+        oauth2-proxy's keycloak-oidc provider stuffed the full ~44 realm+client
+        role graph into the browser-cookie session → >4 KB → split cookie →
+        intermittent "Secured with OAuth2 Proxy" 500 on the proxied callback
+        (worst on pdns-admin's double-OIDC flow). The gate does NO group/role
+        authorization (no --allowed-groups) and requests no `roles` scope, so
+        dropping it shrinks the session to [sovereign-admins sovereign-viewers]
+        for EVERY instance (openova-flow/agenity too). `groups` retained. Kept in
+        lockstep with the config-cli powerdns-admin client seed.
+      */ -}}
+      "defaultClientScopes": ["web-origins", "acr", "profile", "email", "groups"],
       "protocolMappers": [
         {
           "name": {{ printf "audience-%s" $cid | quote }},

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3564,7 +3564,7 @@ name: bp-catalyst-platform
 #   topology (hw287 residual after the #5335 Secret-RBAC fix — the probe could
 #   read the cert but the connection was still NetworkPolicy-dropped). Bootstrap-
 #   kit slot-13 pin bumped in lockstep (pin-sync gate). Lockstep w/ 16b slot 0.2.22.
-version: 1.4.1204
+version: 1.4.1205
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8


### PR DESCRIPTION
🛑 HOLD MERGE — next-train batch (edits the config-cli realm seed; validates on a fresh prov: pdns-admin OIDC login completes + oauth2-proxy session cookie < 4KB / no split-cookie 500).

## Root cause (confirmed live hw286, dep 8252169e5cd7a2dc — see #5334 root-cause comment)
Every per-service SSO except **pdns-admin** lands authed via the correct issuer. pdns-admin's oidc-gate/oauth2-proxy **callback returns HTTP 500** intermittently. The gate's code→token exchange actually *succeeds* — the real defect is an **oversized oauth2-proxy session cookie**:

- The `powerdns-admin` Keycloak client carries **`roles` as a DEFAULT client scope**, so oauth2-proxy's `keycloak-oidc` provider extracts **every realm + client role** (~44 entries) into the browser-cookie session.
- The session (groups + id/access/refresh tokens, all carrying the full role graph) exceeds **4 KB** → oauth2-proxy **splits it into multiple cookies** (`session_store.go:170` WARNING) → the well-known oauth2-proxy cause of **intermittent "Secured with OAuth2 Proxy v7.6.0" 500s** on the reassembly / oversized `Cookie` header.
- Native-OIDC services (**grafana / gitea / harbor**) are immune — they keep **server-side sessions** and only read the claims they need; nothing lands in a 4 KB browser cookie.

## The fix — drop `roles` from the gate client's default scopes
The gate performs **no** group/role authorization (`--allowed-groups` unset) and PDA's authlib maps only `preferred_username`/`email` — **`roles` is unused here**. Removing it shrinks the session groups to `[sovereign-admins sovereign-viewers]`, the cookie falls well under 4 KB, the split (and its 500) disappears. `groups` is retained (Tier-2 convention, guarded by `g117-5-tier2-sso-clients.sh` Case 4).

### Exact scope diff (2 files, functional change = one line each)
**1. `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml`** — the config-cli FULL-managed realm seed, `powerdns-admin` client only (no other client touched):
```diff
           "defaultClientScopes": [
             "web-origins",
             "acr",
             "profile",
-            "roles",
             "email",
             "groups"
           ],
```
**2. `platform/oidc-gate/chart/templates/instances.yaml`** — the shared gate AppRegistration client.json, kept in **lockstep** with the config-cli seed (also fixes `openova-flow`/`agenity`, and avoids the config-cli↔sso-bridge scope disagreement the Chart.yaml documents):
```diff
-      "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email", "groups"],
+      "defaultClientScopes": ["web-origins", "acr", "profile", "email", "groups"],
```
Chart bumps (single increment each): `bp-keycloak 1.5.5 → 1.5.6`, `bp-oidc-gate 0.1.6 → 0.1.7`.

## Render-gate evidence (all PASS on this branch)
- `platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh` → **All cases PASS** (Case 4 `groups` default scope still present on all Tier-2 clients).
- `platform/keycloak/chart/tests/g117-5-tier1-sso-clients.sh` → **All cases PASS**.
- `platform/oidc-gate/chart/tests/{root-redirect,internal-discovery,spa-token-seed}-render.sh` → **All PASS**.
- `helm lint` both charts → `0 chart(s) failed`.
- Direct render check of the config-cli realm JSON: parses OK (12 clients); `powerdns-admin` default scopes = `['web-origins','acr','profile','email','groups']` (**roles removed, groups kept**); **all 9 other role-bearing clients unchanged** (kubectl, catalyst-ui, catalyst-api-server, grafana, gitea, harbor, openbao, guacamole, hubble-ui still carry `roles`).
- Direct render check of the oidc-gate AppRegistration `client.json`: parses OK; `powerdns-admin` + `openova-flow` default scopes both = `['web-origins','acr','profile','email','groups']` (**roles removed, groups kept**).

## Fresh-prov acceptance (post-merge, on next train)
Browser-walk `pdns-admin.<fqdn>` → lands on `/dashboard/` with **no 500**, oauth2-proxy session cookie **< 4 KB** (no `_0/_1/_2` split), and the `session_store.go:170` "exceeds the 4kb cookie limit" WARNING **gone** from the gate log.

No live cluster mutation. No NodePort.

Refs #5334