### PR TITLE
fix(cnpg-pair): NetworkPolicy carve-out for the continuum-controller standby probe (Refs #5311)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1274,7 +1274,13 @@ spec:
       #   gate now also requires CNPG ConsistentSystemID=True, so a divergent
       #   equal-LSN standby can no longer be declared re-cloned without a real
       #   pg_basebackup re-clone. Lockstep w/ Chart.yaml + 16b slot 0.2.21.
-      version: 1.4.1203
+      # 1.4.1204 — #5311: catalog-seed bp-cnpg-pair pin 0.2.21 -> 0.2.22 —
+      #   NetworkPolicy carve-out admitting the continuum-controller
+      #   (catalyst-system) to the primary -rw:5432 so its standby probe reads
+      #   pg_stat_replication and surfaces status.standbyAvailable on a TRUE
+      #   2-region topology (hw287 residual after the #5335 Secret-RBAC fix).
+      #   Lockstep w/ Chart.yaml + 16b slot 0.2.22.
+      version: 1.4.1204
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -305,7 +305,15 @@ spec:
       # 'streaming') and the signals 'streaming' arm keeps the peer-writable
       # proof fresh so the re-clone escalation no longer starves.
       # Substitutes unchanged.
-      version: 0.2.21
+      # 0.2.22 (#5311): NetworkPolicy carve-out admitting the continuum-controller
+      # (catalyst-system) to the primary -rw:5432 so its standby probe reads
+      # pg_stat_replication and surfaces status.standbyAvailable on a TRUE
+      # 2-region topology. Residual after #5335 (Secret-RBAC): the probe could
+      # read the cert but the connection to the primary was still dropped by the
+      # -allow-replication-to-primary policy (default-denies all other ingress).
+      # hw287: cnpg-pair region-b replica pg_stat_wal_receiver=streaming yet all
+      # 8 Continuum CRs read standbyAvailable=UNSET. Substitutes unchanged.
+      version: 0.2.22
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -114,7 +114,13 @@ spec:
   # 'streaming' arm keeps the peer-writable proof fresh so the escalation no
   # longer starves; post-re-clone watch keys off converged-recorded.
   # Script-only; no schema/RBAC/resource delta.
-  version: 0.2.21
+  # 0.2.22 (#5311): NetworkPolicy carve-out admitting the continuum-controller
+  # (catalyst-system) to the primary -rw:5432 so its standby probe can read
+  # pg_stat_replication and surface status.standbyAvailable on a TRUE 2-region
+  # topology (the #5335 Secret-RBAC fix was necessary-not-sufficient; the
+  # connection was still NetworkPolicy-dropped — hw287 residual). NetworkPolicy
+  # + values only; no schema/RBAC/resource delta to the Cluster CRs.
+  version: 0.2.22
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.22 (#5311): NetworkPolicy carve-out for the continuum-controller standby
+# probe — the residual after the #5335 Secret-RBAC fix. #5311 taught the
+# continuum-controller to read the acting primary's pg_stat_replication over
+# 5432 (the only standby-observation source on a TRUE 2-region topology, where
+# the region-b replica CR is absent from the primary region's API). But the
+# `-allow-replication-to-primary` NetworkPolicy selects the primary Pods and
+# default-denies all OTHER ingress, and the controller runs in a DIFFERENT
+# namespace (catalyst-system) — so its probe connection to primary -rw:5432 was
+# NetworkPolicy-DROPPED, the probe errored every tick (logged at V(1), invisible
+# at info), and `status.standbyAvailable` stayed UNSET even with a live streaming
+# standby (hw287: cnpg-pair region-b replica pg_stat_wal_receiver=streaming, yet
+# all 8 Continuum CRs read standbyAvailable=UNSET — the #4901/#5311 false-green).
+# Fix: a new primary-side ingress rule admits the continuum-controller Pod (new
+# values `networkPolicy.continuumControllerNamespace` = catalyst-system +
+# `continuumControllerPodLabels` = {app.kubernetes.io/name: continuum-controller},
+# ANDed namespaceSelector+podSelector) on 5432. Empty namespace → rule omitted
+# (byte-identical to 0.2.21). Lockstep slot 16b pin → 0.2.22.
 # 0.2.21 (#5331): dr-failback VERIFIED CONVERGENCE — the hw285 residual.
 # hw285 G12 (2026-07-23, dep 27350950bef5c882) had a CLEAN failover (region-B
 # promoted RPO=0) but a FALSE failback: region-A powered back on, self-promoted
@@ -346,7 +363,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.21
+version: 0.2.22
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -89,6 +89,33 @@ spec:
           protocol: TCP
         - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+{{- if .Values.cnpgPair.networkPolicy.continuumControllerNamespace }}
+    # #5311 continuum-controller standby probe — the continuum-controller
+    # reads the ACTING PRIMARY's pg_stat_replication over 5432 to surface
+    # `status.standbyAvailable` on a TRUE 2-region topology (the region-b
+    # replica Cluster CR is not in the primary region's API, so FindPair is
+    # "pair incomplete" and the SQL probe is the only observation source).
+    # The controller runs in a DIFFERENT namespace than the pair
+    # (catalyst-system), so this policy — which default-denies all OTHER
+    # ingress to the primary Pods — drops its connection unless carved out.
+    # WITHOUT this rule the probe's SYN to the primary -rw:5432 is denied →
+    # pgx connect times out → observeCNPGStandby makes "no determination"
+    # every tick → standbyAvailable stays UNSET (the #4901/#5311 false-green
+    # a live streaming standby exists but the DR health surface never shows
+    # it). Live-proven on hw287: #5335 fixed the probe's Secret-GET RBAC but
+    # the connection was STILL dropped here — the residual #5311 gap. The
+    # namespaceSelector + podSelector AND to the controller Pod alone.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.cnpgPair.networkPolicy.continuumControllerNamespace }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.cnpgPair.networkPolicy.continuumControllerPodLabels | nindent 14 }}
+      ports:
+        - port: 5432
+          protocol: TCP
+{{- end }}
 {{- if (include "cnpg-pair.failbackActive" .) }}
     # #5245 dr-failback signals container — polls the primary's -rw for
     # the post-failover geometry (local recovery/timeline state + the

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -219,6 +219,19 @@ grep -qE '^\s+- port: 9187' "$TMP/primary.yaml" || {
   echo "FAIL: primary-side NetworkPolicy missing the operator metrics port (9187)." >&2
   exit 1
 }
+# 0.2.22 (#5311): the primary-side NetworkPolicy must ALSO admit the
+# continuum-controller (catalyst-system) to 5432, or its standby probe's
+# connection to the primary -rw is default-denied → the probe errors every
+# tick → status.standbyAvailable stays UNSET on a TRUE 2-region topology (the
+# residual after the #5335 Secret-RBAC fix; hw287 live-proven false-green).
+grep -q 'kubernetes.io/metadata.name: catalyst-system' "$TMP/primary.yaml" || {
+  echo "FAIL: #5311 primary-side NetworkPolicy missing the continuum-controller namespace carve-out (catalyst-system) — the standby probe's connect to primary -rw:5432 will be default-denied and standbyAvailable stays UNSET." >&2
+  exit 1
+}
+grep -q 'app.kubernetes.io/name: continuum-controller' "$TMP/primary.yaml" || {
+  echo "FAIL: #5311 primary-side NetworkPolicy missing the continuum-controller podSelector label — the carve-out must AND namespaceSelector+podSelector to the controller Pod alone." >&2
+  exit 1
+}
 echo "  PASS (4 non-test + 4 test resources)"
 
 # ── Case 3: side=replica enabled render ──────────────────────────

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -497,6 +497,24 @@ cnpgPair:
     # cnpg-system (or the operator's own metrics collection) is not
     # default-denied once the gate flips ON.
     operatorMetricsPort: 9187
+    # continuumControllerNamespace + continuumControllerPodLabels (#5311) —
+    # the continuum-controller's standby probe reads the acting primary's
+    # pg_stat_replication over 5432 to surface `status.standbyAvailable` on a
+    # TRUE 2-region topology (the region-b replica CR is not in the primary
+    # region's API, so the CR-based observation is structurally blind and the
+    # SQL probe is the only source). This policy selects the primary Pods and
+    # default-denies all OTHER ingress to them, so the controller — which runs
+    # in a DIFFERENT namespace (catalyst-system) — is denied unless carved out
+    # here. WITHOUT this the probe's connect to primary -rw:5432 times out →
+    # "no standby determination" every tick → standbyAvailable stays UNSET
+    # even with a live streaming standby (the #4901/#5311 false-green; the
+    # residual on hw287 AFTER the #5335 Secret-RBAC fix — the probe could read
+    # the cert but the connection was still NetworkPolicy-dropped). Empty
+    # namespace → the carve-out is omitted (byte-identical to pre-#5311). The
+    # labels AND to the controller Pod alone (namespaceSelector+podSelector).
+    continuumControllerNamespace: catalyst-system
+    continuumControllerPodLabels:
+      app.kubernetes.io/name: continuum-controller
     # crossRegionPeerClusters (#4846) — the Cilium ClusterMesh cluster.name(s)
     # of the PEER region('s) cluster, allowed to reach the pair's 5432 for
     # cross-region replication. REQUIRED: the podSelector `cnpg.io/cluster=

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3557,7 +3557,14 @@ name: bp-catalyst-platform
 #   be declared "re-cloned and streaming" without a real pg_basebackup re-clone
 #   (the hw285 data-loss trap on switchback). Bootstrap-kit slot-13 pin bumped in
 #   lockstep (pin-sync gate). Lockstep w/ 16b slot pin 0.2.21.
-version: 1.4.1203
+# 1.4.1204 — #5311: catalog-seed bp-cnpg-pair pin 0.2.21 -> 0.2.22 (+ spec.version
+#   display label) — NetworkPolicy carve-out admitting the continuum-controller
+#   (catalyst-system) to the primary -rw:5432 so its standby probe reads
+#   pg_stat_replication and surfaces status.standbyAvailable on a TRUE 2-region
+#   topology (hw287 residual after the #5335 Secret-RBAC fix — the probe could
+#   read the cert but the connection was still NetworkPolicy-dropped). Bootstrap-
+#   kit slot-13 pin bumped in lockstep (pin-sync gate). Lockstep w/ 16b slot 0.2.22.
+version: 1.4.1204
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -411,12 +411,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  # 0.2.21 (#5331): dr-failback VERIFIED convergence (hw285 residual) —
-  # the CONVERGED gate now also requires CNPG ConsistentSystemID=True, so a
-  # divergent equal-LSN standby can no longer be declared re-cloned. Keep
-  # this display-version in lockstep with delivery source.version +
+  # 0.2.22 (#5311): NetworkPolicy carve-out admitting the continuum-controller
+  # to the primary -rw:5432 so its standby probe surfaces status.standbyAvailable
+  # on a TRUE 2-region topology (hw287 residual after the #5335 Secret-RBAC fix).
+  # Keep this display-version in lockstep with delivery source.version +
   # blueprint.yaml (the #4988 precedent).
-  version: "0.2.21"
+  version: "0.2.22"
   visibility: listed
   card:
     title: "CNPG Cluster-Pair (Active-Hotstandby DR)"
@@ -446,7 +446,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.21"
+    version: "0.2.22"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
🛑 HOLD MERGE — next-train batch (validates on fresh prov: standbyAvailable surfaces True on a Continuum with a live streaming standby).

## The residual #5311 gap (after #5335)

#5335 (uncached APIReader) correctly ELIMINATED the continuum-controller `secrets is forbidden` RBAC spam, but it was **necessary-not-sufficient**: `status.standbyAvailable` STILL never surfaces on any Continuum CR even with a live streaming standby. Live-confirmed on **hw287** (dep `4b5e42caac23429f`, cc=true, controller image `6e42f32`): all 8 Continuum CRs read `standbyAvailable=UNSET` (conditions only `[LeaseHeld, Ready]`) even though the cnpg-pair region-b replica is `pg_stat_wal_receiver.status=streaming`.

## Root cause (chart-level NetworkPolicy gap, NOT a controller-code gap)

On a TRUE 2-region topology the region-b replica Cluster CR is absent from the primary region's API, so `cnpg.FindPair` (`internal/cnpg/status.go:182-205`) is always "pair incomplete" → `observeCNPGStandby` (`internal/controller/continuum_controller.go:975-1005`) takes the **#5311 `pg_stat_replication` probe branch**, which is the only standby-observation source there.

But the probe's TCP connection never lands:

- `platform/cnpg-pair/chart/templates/networkpolicy.yaml` — the `-allow-replication-to-primary` NetworkPolicy selects the primary Pods with `policyTypes:[Ingress]`, **default-denying ALL ingress** except from: replica Pods, own primary Pods, the `cnpg-system` operator (8000/9187), dr-failback Pods, and (via the crossregion CNP) region-b clustermesh Pods.
- The **continuum-controller runs in `catalyst-system`** — a different namespace — and matches **none** of those `from` selectors. So its probe connection to `<primary>-rw.<ns>.svc:5432` is dropped.
- The probe errors every tick; `observeCNPGStandby` logs it at `log.V(1)` (invisible at the default info level → "no observe lines"); `resolveStandbyPosture` makes **no determination** → `standbyAvailable` stays UNSET. The #4901/#5311 false-green.

### Live evidence (hw287 region-a, read-only)
- `pg_stat_replication` on the region-a primary shows 2 connected streaming standbys → the probe, IF it connected, would set `StandbyPresent=true` → `standbyAvailable=true`.
- Reproducing the **exact probe connection** (streaming_replica cert, `dbname=postgres sslmode=require`) from **inside** a cnpg-namespace Pod → succeeds (2 rows, exit 0). pg_hba (`hostssl postgres streaming_replica all cert`) and RBAC (`can-i get secrets -n cnpg` → yes; `list` → no, honoring #5335) are both fine.
- The drop is purely the **cross-namespace ingress** the policy never carved out (controller in catalyst-system ∉ any `from` selector).

## Fix

A new primary-side ingress rule admits the continuum-controller Pod on 5432 (ANDed `namespaceSelector`+`podSelector`), driven by two new values:

```yaml
networkPolicy:
  continuumControllerNamespace: catalyst-system
  continuumControllerPodLabels:
    app.kubernetes.io/name: continuum-controller
```

Empty namespace → rule omitted (byte-identical to 0.2.21). No Cluster-CR schema/RBAC/resource delta.

## Lockstep + gates
- Chart `bp-cnpg-pair` 0.2.21 → **0.2.22**; `blueprint.yaml`, catalog-seed `blueprints.yaml`, bootstrap-kit slots **13** + **16b**, umbrella `bp-catalyst-platform` 1.4.1203 → **1.4.1204** — all bumped in lockstep so the fix bakes into a fresh prov.
- `scripts/check-bootstrap-kit-pin-sync.sh` → PASS
- `scripts/check-catalog-seed-lockstep.sh` → PASS
- `platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` → PASS (Case 2 extended: asserts the continuum-controller carve-out renders)
- `core/controllers/continuum` `go test ./...` → PASS (regression baseline; no Go change)

## Validates on next fresh prov
On a fresh 2-region prov, the primary-side NetworkPolicy admits the continuum-controller → its `pg_stat_replication` probe connects → `status.standbyAvailable=True` surfaces on the cnpg-pair Continuum (and flips to `False`/degraded when the standby genuinely vanishes past grace). Clears UAT rows 51-64.

Refs #5311 #5335 #4901

🤖 Generated with [Claude Code](https://claude.com/claude-code)