### PR TITLE
fix(catalog-seed): sync bp-keycloak 1.5.5→1.5.6 — unblock manifest-validation on all PRs

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1280,7 +1280,7 @@ spec:
       #   pg_stat_replication and surfaces status.standbyAvailable on a TRUE
       #   2-region topology (hw287 residual after the #5335 Secret-RBAC fix).
       #   Lockstep w/ Chart.yaml + 16b slot 0.2.22.
-      version: 1.4.1206
+      version: 1.4.1207
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3564,7 +3564,7 @@ name: bp-catalyst-platform
 #   topology (hw287 residual after the #5335 Secret-RBAC fix — the probe could
 #   read the cert but the connection was still NetworkPolicy-dropped). Bootstrap-
 #   kit slot-13 pin bumped in lockstep (pin-sync gate). Lockstep w/ 16b slot 0.2.22.
-version: 1.4.1206
+version: 1.4.1207
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.5.5"
+  version: "1.5.6"
   visibility: listed
   card:
     title: "Keycloak"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -606,7 +606,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-keycloak
-    version: "1.5.5"
+    version: "1.5.6"
   # G117.1+G117.4+G117.6 #2744-followup (2026-06-03): bp-keycloak
   # catalog-seed needs topology + endpoints + sso so application-
   # controller can fan out HRs and operator console can mint silent-SSO


### PR DESCRIPTION
## Problem
`manifest-validation` (TestCatalogSeed_DeliveryPinsNotBehindComponentCharts + DisplayVersionNotBehindDeliveryPin) fails on **every** open PR because origin/main carries a pre-existing catalog-seed drift: #5336 bumped the bp-keycloak chart to **1.5.6** (blueprint.yaml + slot 09 pin) but did **not** sync the catalog-seed card. So the seed's card spec.version (line 581) and delivery-pin source.version (line 609) still read **1.5.5** < chart 1.5.6.

Confirmed on origin/main: seed=1.5.5, `platform/keycloak/chart/Chart.yaml`=1.5.6.

## Fix
Sync both seed refs to 1.5.6; bump the umbrella bp-catalyst-platform 1.4.1206→1.4.1207 (the seed lives in its template). This clears the gate for all open PRs — incl. the two defect PRs #5340 (DR-RTO) and #5342 (mcp-404-flap), whose own core fixes already pass pin-sync-audit.

Refs #5336

🤖 Generated with [Claude Code](https://claude.com/claude-code)