### PR TITLE
fix(catalog-seed): unlist 5 chartless blueprints (hollow install) — Refs #5345

### DIFF
--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -813,7 +813,7 @@ metadata:
     app.kubernetes.io/instance: {{ $instance }}
 spec:
   version: "1.0.0"
-  visibility: listed
+  visibility: unlisted
   card:
     title: "Prometheus"
     category: observability
@@ -954,7 +954,7 @@ metadata:
     app.kubernetes.io/instance: {{ $instance }}
 spec:
   version: "1.0.0"
-  visibility: listed
+  visibility: unlisted
   card:
     title: "Redis"
     category: database
@@ -1016,7 +1016,7 @@ metadata:
     app.kubernetes.io/instance: {{ $instance }}
 spec:
   version: "1.0.0"
-  visibility: listed
+  visibility: unlisted
   card:
     title: "ClickHouse"
     category: analytics
@@ -1107,7 +1107,7 @@ metadata:
     app.kubernetes.io/instance: {{ $instance }}
 spec:
   version: "1.0.0"
-  visibility: listed
+  visibility: unlisted
   card:
     title: "OpenSearch"
     category: search
@@ -1303,7 +1303,7 @@ metadata:
     app.kubernetes.io/instance: {{ $instance }}
 spec:
   version: "1.0.0"
-  visibility: listed
+  visibility: unlisted
   card:
     title: "n8n"
     category: automation


### PR DESCRIPTION
## What

Flip `visibility: listed` → `unlisted` for **bp-redis, bp-prometheus, bp-n8n, bp-clickhouse, bp-opensearch** in `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`.

## Why (evidence — R21 walk on hw288, 2026-07-24)

Full 80-pin ghcr cross-check: 75/80 deliverable pins resolve to published charts. These **5 do not resolve under any naming** (`bp-redis` AND `bp-bp-redis` both 404) and have **no Chart.yaml source** in the repo — yet they were `visibility: listed`, so the owner `/api/v1/catalog` (Blueprint-CR view) presented them as fully installable (source+chartRef+valueSchema, same shape as deliverable bp-alloy) → a hollow install.

**Scope corrected from the filed issue:** the *customer* marketplace is unaffected — it uses the `seedApps` store where redis is `System: true` (backing service, excluded by the `Published+!System+Deployable` filter) and the other 4 are absent. The wizard grid (`blueprints.json`) already excludes all 5 (clickhouse/opensearch already `unlisted` there). This PR aligns `blueprints.yaml` with those two sources.

## Safety

- Bounded to one file; only 5 visibility lines change (5/5).
- Curated card metadata preserved (just hidden from the listed grid); reversible once charts are built.
- `unlisted` blueprints remain valid dependency targets — no provisioning-path impact.
- No test pins these 5 as `listed` (test refs are unit fixtures).

Refs #5345 #960