### PR TITLE
chore(catalyst): umbrella 1.4.1210 — deliver #5346 catalog-seed unlist (Refs #5345)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1280,7 +1280,7 @@ spec:
       #   pg_stat_replication and surfaces status.standbyAvailable on a TRUE
       #   2-region topology (hw287 residual after the #5335 Secret-RBAC fix).
       #   Lockstep w/ Chart.yaml + 16b slot 0.2.22.
-      version: 1.4.1209
+      version: 1.4.1210
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3564,7 +3564,7 @@ name: bp-catalyst-platform
 #   topology (hw287 residual after the #5335 Secret-RBAC fix — the probe could
 #   read the cert but the connection was still NetworkPolicy-dropped). Bootstrap-
 #   kit slot-13 pin bumped in lockstep (pin-sync gate). Lockstep w/ 16b slot 0.2.22.
-version: 1.4.1209
+version: 1.4.1210
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8


### PR DESCRIPTION
Republishes the umbrella so the merged #5346 fix (unlist 5 chartless blueprints) actually reaches a fresh prov.

**Why needed:** `templates/catalog-seed/blueprints.yaml` is baked into the umbrella chart with `helm.sh/resource-policy: keep`. The published `1.4.1209` predates #5346, so a fresh prov pinned at 1.4.1209 renders the OLD (listed) Blueprint CRs — the merged-but-inert trap.

**Change:** `chart/Chart.yaml` + slot-13 pin `1.4.1209`→`1.4.1210` (2 lines). The catalog-seed self-entry uses `{{ .Chart.Version }}` so it auto-follows; no other static pin moves.

Refs #5345 #960