### PR TITLE
fix(catalyst-api): prune compliance_score series on resource delete — #5352 OOM root cause (+ gated pprof)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -684,6 +684,19 @@ func main() {
 	r.Get("/readyz", h.Ready)
 	r.Handle("/metrics", promhttp.Handler())
 
+	// #5352 — pprof diagnostics, gated behind CATALYST_PPROF_ENABLED (default off).
+	// catalyst-api OOMs periodically on some Sovereigns (RSS grows to the 4Gi
+	// limit → OOMKilled, observed 28× on hw288). pprof isn't exposed, so the
+	// unbounded allocation can't be located. Enable this flag TRANSIENTLY
+	// (kubectl set env / values override) to capture `go tool pprof .../debug/pprof/heap`,
+	// find the growth (k8scache Indexer / SSE fanout buffers / deployment cache),
+	// then turn it back off. Do NOT leave enabled in production — it exposes
+	// process internals on /debug/pprof.
+	if env("CATALYST_PPROF_ENABLED", "false") == "true" {
+		r.Mount("/debug", middleware.Profiler())
+		log.Warn("pprof diagnostics ENABLED at /debug/pprof (CATALYST_PPROF_ENABLED=true) — transient OOM diagnosis only; do not leave on in production")
+	}
+
 	// /api/v1/version — build identification (git SHA + chart version).
 	// Always 200, no auth gate (probe-friendly). Operators + the QA
 	// matrix probe this to confirm "what version is live right now"

--- a/products/catalyst/bootstrap/api/internal/handler/compliance.go
+++ b/products/catalyst/bootstrap/api/internal/handler/compliance.go
@@ -671,6 +671,24 @@ func (c *ComplianceHandler) onEvent(ctx context.Context, ev k8scache.Event) {
 	if ev.Object == nil {
 		return
 	}
+	// #5352 — a DELETED report must PRUNE its compliance state + gauge
+	// series, not be re-ingested as if live. Kyverno emits a per-resource
+	// PolicyReport for every Pod/Workload it audits (k8scache/kinds.go), so
+	// a churning pod/job produces a `policyreport` DELETED event on teardown.
+	// The pre-#5352 onEvent ignored ev.Type and handled DELETED exactly like
+	// ADDED/MODIFIED, so `catalyst_compliance_score{scope="resource",id=…}`
+	// accumulated one gauge series per pod/job ever seen and never dropped
+	// any → the Prometheus registry grew unbounded → catalyst-api RSS climbed
+	// to its limit → OOMKilled (observed 28× on hw288). Prune on delete.
+	if ev.Type == k8scache.EventDeleted {
+		switch ev.Kind {
+		case "policyreport", "clusterpolicyreport":
+			c.pruneKyvernoReport(ctx, ev)
+		case k8scache.KindComplianceEvaluator:
+			c.pruneSyntheticReport(ctx, ev)
+		}
+		return
+	}
 	switch ev.Kind {
 	case "policyreport", "clusterpolicyreport":
 		c.ingestKyvernoReport(ctx, ev)
@@ -844,6 +862,76 @@ func (c *ComplianceHandler) ingestSyntheticReport(ctx context.Context, ev k8scac
 	c.recordVerdict(ctx, ev.Cluster, key, resName, resNS, stateful, policy, rule, result, message, "evaluator", ev.At)
 }
 
+// pruneKyvernoReport removes the compliance state + gauge series for every
+// resource subject of a DELETED PolicyReport, then republishes the rollups
+// so they no longer count the torn-down resource. #5352 — without this the
+// per-resource `catalyst_compliance_score` series leak on every pod/job
+// churn (the OOM root cause).
+func (c *ComplianceHandler) pruneKyvernoReport(ctx context.Context, ev k8scache.Event) {
+	keys := map[string]struct{}{}
+	results, _, _ := unstructured.NestedSlice(ev.Object.Object, "results")
+	for _, ri := range results {
+		r, ok := ri.(map[string]any)
+		if !ok {
+			continue
+		}
+		if k, ns, name := kyvernoResourceFor(ev.Object, r); name != "" {
+			keys[resourceKey(k, ns, name)] = struct{}{}
+		}
+	}
+	// Reports with no per-result subject (e.g. a single-scope report):
+	// resolve the subject once off the report's top-level scope/metadata.
+	if len(keys) == 0 {
+		if k, ns, name := kyvernoResourceFor(ev.Object, nil); name != "" {
+			keys[resourceKey(k, ns, name)] = struct{}{}
+		}
+	}
+	if len(keys) == 0 {
+		return
+	}
+	for key := range keys {
+		c.pruneResource(key, ev.Cluster)
+	}
+	c.publishRollups(ctx, ev.Cluster)
+}
+
+// pruneSyntheticReport is pruneKyvernoReport's counterpart for a DELETED
+// evaluator SyntheticReport (single resource subject). #5352.
+func (c *ComplianceHandler) pruneSyntheticReport(ctx context.Context, ev k8scache.Event) {
+	obj := ev.Object.Object
+	resKind, _, _ := unstructured.NestedString(obj, "resource", "kind")
+	resName, _, _ := unstructured.NestedString(obj, "resource", "name")
+	if resName == "" {
+		return
+	}
+	resNS, _, _ := unstructured.NestedString(obj, "namespace")
+	c.pruneResource(resourceKey(resKind, resNS, resName), ev.Cluster)
+	c.publishRollups(ctx, ev.Cluster)
+}
+
+// pruneResource drops one resource's compliance state and its gauge series.
+// The DeleteLabelValues tuple MUST match the one complianceObserve set:
+// (scope="resource", id=resourceKey, environment=rs.environment,
+// sovereign=clusterID). No-op (and safe) when the resource was never
+// scored. #5352.
+func (c *ComplianceHandler) pruneResource(key, clusterID string) {
+	c.mu.Lock()
+	cs, ok := c.state[clusterID]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	rs, ok := cs[key]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	env := rs.environment
+	delete(cs, key)
+	c.mu.Unlock()
+	metricComplianceScore.DeleteLabelValues("resource", key, env, clusterID)
+}
+
 // recordVerdict stores one (resource, policy) verdict and triggers a
 // score recompute + publish for the affected scopes. Holds c.mu only
 // for the state-update — the recompute + publish run unlocked.
@@ -918,8 +1006,16 @@ func (c *ComplianceHandler) recomputeAndPublish(ctx context.Context, clusterID, 
 	c.publishScore(ctx, clusterID, resourceScore)
 
 	// Roll up: application → environment → organization → sovereign.
-	rolls := c.rollupsFor(clusterID)
-	for _, s := range rolls {
+	c.publishRollups(ctx, clusterID)
+}
+
+// publishRollups recomputes + publishes every rollup scope for the cluster
+// (application → environment → organization → sovereign). Shared by
+// recomputeAndPublish (after a resource score changes) and the #5352 prune
+// path (after a resource is removed) so the rollups never keep counting a
+// torn-down resource.
+func (c *ComplianceHandler) publishRollups(ctx context.Context, clusterID string) {
+	for _, s := range c.rollupsFor(clusterID) {
 		c.publishScore(ctx, clusterID, s)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/compliance_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/compliance_test.go
@@ -46,6 +46,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -500,6 +502,88 @@ func TestCompliance_IngestSyntheticReport(t *testing.T) {
 	_ = json.Unmarshal(body, &s)
 	if s.PolicyResults["flux-managed"] != "fail" {
 		t.Fatalf("synthetic ingest: expected fail, got %v", s.PolicyResults)
+	}
+}
+
+// complianceScoreSeriesExists reports whether metricComplianceScore currently
+// holds a series with the given `id` label — WITHOUT instantiating it (unlike
+// WithLabelValues, which would resurrect a just-deleted series at 0 and make
+// the assertion meaningless). Collects the vec directly and scans labels.
+func complianceScoreSeriesExists(id string) bool {
+	ch := make(chan prometheus.Metric, 4096)
+	metricComplianceScore.Collect(ch)
+	close(ch)
+	for m := range ch {
+		var dm dto.Metric
+		if m.Write(&dm) != nil {
+			continue
+		}
+		for _, lp := range dm.Label {
+			if lp.GetName() == "id" && lp.GetValue() == id {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestCompliance_PruneOnPolicyReportDelete_5352 proves that a DELETED
+// per-resource PolicyReport prunes BOTH the in-memory resourceState and the
+// per-resource `catalyst_compliance_score` gauge series. Before #5352 the
+// handler ignored ev.Type, so every churning pod/job left a permanent gauge
+// series → unbounded registry growth → catalyst-api OOM (28× on hw288).
+func TestCompliance_PruneOnPolicyReportDelete_5352(t *testing.T) {
+	_, c, nats, f := newComplianceTestRig(t)
+
+	const key = "pod/ns1/pod-xyz" // resourceKey(Pod, ns1, pod-xyz), kind lower-cased
+
+	report := mkPolicyReport("ns1", "pod-xyz-report", []map[string]any{
+		{
+			"policy":  "probes-present",
+			"rule":    "probes-present",
+			"result":  "pass",
+			"message": "ok",
+			"resources": []any{
+				map[string]any{"kind": "Pod", "namespace": "ns1", "name": "pod-xyz"},
+			},
+		},
+	})
+	publishToFactory(f, "policyreport", report)
+
+	// Scored → resourceState + gauge series both exist.
+	waitFor(t, 1*time.Second, func() bool {
+		_, ok := nats.Get("resource." + key)
+		return ok
+	})
+	if !complianceScoreSeriesExists(key) {
+		t.Fatalf("precondition: gauge series for %q missing after ingest", key)
+	}
+	c.mu.RLock()
+	_, present := c.state["acme"][key]
+	c.mu.RUnlock()
+	if !present {
+		t.Fatalf("precondition: resourceState for %q missing after ingest", key)
+	}
+
+	// Pod torn down → Kyverno deletes its per-resource PolicyReport. The
+	// informer delivers the final object body on the DELETED event.
+	f.Publish(k8scache.Event{
+		Cluster: "acme",
+		Kind:    "policyreport",
+		Type:    k8scache.EventDeleted,
+		Object:  report,
+		At:      time.Now(),
+	})
+
+	// #5352 — the resourceState AND the gauge series must both be pruned.
+	waitFor(t, 1*time.Second, func() bool {
+		c.mu.RLock()
+		_, present := c.state["acme"][key]
+		c.mu.RUnlock()
+		return !present
+	})
+	if complianceScoreSeriesExists(key) {
+		t.Fatalf("#5352 regression: gauge series for %q still present after PolicyReport delete — the leak is back", key)
 	}
 }
 


### PR DESCRIPTION
## Root cause + fix (the substantive change)

catalyst-api was **OOMKilled 28×** on hw288 (RSS → the 4Gi limit). Root cause, pinpointed from **live `/metrics`** (no pprof needed): the compliance aggregator's `catalyst_compliance_score{scope="resource",id=<resourceKey>,environment,sovereign}` GaugeVec was **1127 of 1646 total series (68%)**, with **742 distinct resource ids** covering churning **286 pods + 39 jobs**.

`ComplianceHandler.onEvent` ignored `ev.Type` and processed `DELETED` PolicyReports **identically to ADDED/MODIFIED**. Kyverno emits a *per-resource* PolicyReport for every Pod/Workload it audits (see `k8scache/kinds.go`), so every pod/job teardown left its gauge series (and its in-memory `resourceState`) behind **forever** → the Prometheus registry grew unbounded → RSS climbed to the limit → OOMKill.

### The fix (`compliance.go`)
- `onEvent` now branches on `ev.Type == EventDeleted` and **prunes** rather than re-ingesting.
- `pruneKyvernoReport` / `pruneSyntheticReport` derive each deleted report's subject `resourceKey`(s) and call `pruneResource`, which:
  - `delete`s the `c.state[cluster][key]` entry (also closes a parallel state-map leak), and
  - `metricComplianceScore.DeleteLabelValues("resource", key, env, sovereign)` — the tuple matches exactly what `complianceObserve` set.
- Rollups are republished after a prune (`publishRollups`, extracted and shared with `recomputeAndPublish`) so the app/env/org/sovereign scores stop counting the torn-down resource.
- Only `scope="resource"` series leaked (per-resource `id`). Rollup scopes and the **policy-keyed** `violations`/`policy_mode` metrics are bounded — untouched.

### On the "reflector churn on absent hcloud" line in the issue title
Refuted during diagnosis: `k8scache/kinds.go` documents that absent-GVR informers retry with exponential backoff **by design** (no hot loop, no allocation growth). That is **not** the OOM source — the unbounded metric series is. The issue title's second clause is a red herring; no code change is warranted there.

### Verification
- New `TestCompliance_PruneOnPolicyReportDelete_5352` collects the vec directly (avoids the `WithLabelValues` resurrection trap) and asserts the per-resource series is **gone** after a DELETED report. **Fails pre-fix** (series survives), **passes post-fix**.
- Full compliance/score test set green; `go build ./...` + `go vet` clean. The one unrelated `wipe_creds_env_fallback_5193` failure is pre-existing + environment-sensitive (wants `AK-FROM-SECRET` env fallback absent in CI sandbox) — fails identically on a clean tree with these edits stashed.

## Secondary: gated pprof (commit 2d31d3a0e)
Mounts pprof at `/debug/pprof` behind `CATALYST_PPROF_ENABLED` (default **off**) for future transient-OOM diagnosis. Kept as a safe, off-by-default observability aid — though this leak was ultimately found via `/metrics` without it.

Refs #5352