### PR TITLE
fix(sovereign-tls-vars): console gateway specific-hostname listeners — stop the #5341 mcp 404 flake

### DIFF
--- a/clusters/_template/bootstrap-kit/12a-bp-sovereign-tls-vars.yaml
+++ b/clusters/_template/bootstrap-kit/12a-bp-sovereign-tls-vars.yaml
@@ -89,7 +89,7 @@ spec:
   chart:
     spec:
       chart: bp-sovereign-tls-vars
-      version: 0.1.0
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-sovereign-tls-vars

--- a/clusters/_template/sovereign-tls/cilium-gateway-console.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway-console.yaml
@@ -46,10 +46,15 @@
 # and inlined here by Flux postBuild.substituteFrom — same scalar-placeholder
 # pattern as the shared gateway (see cilium-gateway.yaml header for why a scalar
 # `listeners: ${VAR}` parses cleanly through kustomize-build before envsubst).
-# The console listener pair is hostnamed `*.${SOVEREIGN_FQDN}` and binds the
-# per-prov wildcard Secret `sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}` —
-# the SAME cert the shared gateway uses for the apex wildcard, so no extra
-# Let's-Encrypt issuance and no extra cert resource is required.
+# The console listeners are hostnamed to the SPECIFIC operator endpoints this
+# gateway serves — console./api./marketplace.${SOVEREIGN_FQDN} — NOT the apex
+# wildcard `*.${SOVEREIGN_FQDN}` (#5341: a wildcard here made this gateway's
+# cilium-envoy filter chain claim every `*.<fqdn>` TLS handshake, colliding
+# with the shared gateway's own `*.<fqdn>` chain and 404'ing ~50% of every
+# other subdomain like mcp.<fqdn>). They still bind the per-prov wildcard
+# Secret `sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}` — the SAME cert the
+# shared gateway uses (a `*.<fqdn>` cert covers all three 2-label hosts), so no
+# extra Let's-Encrypt issuance and no extra cert resource is required.
 
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/platform/sovereign-tls-vars/blueprint.yaml
+++ b/platform/sovereign-tls-vars/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: Sovereign TLS Vars
     summary: |

--- a/platform/sovereign-tls-vars/chart/Chart.yaml
+++ b/platform/sovereign-tls-vars/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sovereign-tls-vars
-version: 0.1.0
+version: 0.1.1
 appVersion: "n/a"
 description: |
   Catalyst Blueprint that renders the `sovereign-tls-vars` ConfigMap

--- a/platform/sovereign-tls-vars/chart/templates/configmap.yaml
+++ b/platform/sovereign-tls-vars/chart/templates/configmap.yaml
@@ -180,11 +180,15 @@ parses it as the materialised listener list.
        Service, so its distinct listener ports never collide with the shared
        gateway even though both terminate public :443 at their own LB front.
 
-       Why a single `*.<fqdn>` listener pair (not the full per-zone fan-out):
-       the console + api hostnames always live under the Sovereign FQDN apex,
+       Why SPECIFIC per-host listeners (not one `*.<fqdn>` pair): the console +
+       api + marketplace hostnames always live under the Sovereign FQDN apex,
        never under an org-pool zone (those are tenant/app surfaces and stay on
-       the SHARED gateway). One wildcard pair on the primary cert is therefore
-       sufficient and keeps the console CEC minimal.
+       the SHARED gateway). A wildcard `*.<fqdn>` listener here made the console
+       CEC's envoy filter chain claim EVERY `*.<fqdn>` TLS handshake, colliding
+       with the shared gateway's own `*.<fqdn>` chain and 404'ing ~50% of every
+       OTHER subdomain (#5341). Each console endpoint therefore gets its exact
+       2-label hostname (see the $consoleHosts loop below); the primary wildcard
+       cert still covers all of them, so the console CEC stays minimal + cheap.
 
        Consumed by clusters/_template/sovereign-tls/cilium-gateway-console.yaml
        at `listeners: ${CONSOLE_LISTENERS_YAML}` via the same Flux postBuild
@@ -193,25 +197,55 @@ parses it as the materialised listener list.
 {{- $consoleCfg := default dict .Values.consoleGateway }}
 {{- $consoleHttpsPort := default 443 $consoleCfg.httpsPort }}
 {{- $consoleHttpPort := default 80 $consoleCfg.httpPort }}
+{{- /* #5341 — the console gateway MUST hostname its listeners to the SPECIFIC
+       operator endpoints it serves, NOT the apex wildcard `*.<fqdn>`.
+       ─────────────────────────────────────────────────────────────────────
+       ROOT CAUSE the wildcard caused (confirmed live on hw288, dep 027f0755):
+       the shared gateway AND this console gateway each compile a cilium-envoy
+       filter chain whose `filterChainMatch.serverNames` was `*.<fqdn>`. Both
+       chains load onto the SAME shared cilium-envoy DaemonSet, so a TLS
+       handshake for ANY subdomain (e.g. `mcp.<fqdn>`) matched BOTH chains.
+       Envoy resolves the duplicate-wildcard match non-deterministically, so
+       ~50% of `mcp.<fqdn>` requests landed on the CONSOLE chain — whose router
+       only has console/api/marketplace vhosts, no mcp — and returned a bare
+       `404 (server: envoy, connection: close)` that cleared on retry. Every
+       non-console subdomain on the shared gateway was exposed to this flake.
+
+       FIX: give each console listener its EXACT 2-label hostname. Envoy prefers
+       an exact `server_name` over the shared gateway's `*.<fqdn>` wildcard, so
+       console/api/marketplace deterministically bind the console chain, while
+       every OTHER subdomain no longer matches the console chain at all and is
+       served solely by the shared gateway. The per-prov wildcard cert already
+       covers all three 2-label hosts, so no extra Let's-Encrypt issuance.
+
+       `hostPrefixes` is the set of HTTPRoute hostnames re-parented to the
+       console gateway (catalyst-ui=console, catalyst-api/catalyst-catalog=api,
+       marketplace=marketplace). A new console-gateway route needs its prefix
+       added here or its listener won't accept it — the deliberate, testable
+       cost of a specific (non-wildcard) listener. */}}
+{{- $consoleHosts := default (list "console" "api" "marketplace") $consoleCfg.hostPrefixes }}
 {{- $consoleListeners := list }}
-{{- $consoleListeners = append $consoleListeners (dict
-      "name" "console-https"
-      "port" $consoleHttpsPort
-      "protocol" "HTTPS"
-      "hostname" (printf "*.%s" $fqdn)
-      "tls" (dict
-        "mode" "Terminate"
-        "certificateRefs" (list (dict "kind" "Secret" "name" $secretName))
-      )
-      "allowedRoutes" (dict "namespaces" (dict "from" "All"))
-    ) }}
-{{- $consoleListeners = append $consoleListeners (dict
-      "name" "console-http"
-      "port" $consoleHttpPort
-      "protocol" "HTTP"
-      "hostname" (printf "*.%s" $fqdn)
-      "allowedRoutes" (dict "namespaces" (dict "from" "All"))
-    ) }}
+{{- range $hp := $consoleHosts }}
+{{-   $consoleHost := printf "%s.%s" $hp $fqdn }}
+{{-   $consoleListeners = append $consoleListeners (dict
+        "name" (printf "%s-https" $hp)
+        "port" $consoleHttpsPort
+        "protocol" "HTTPS"
+        "hostname" $consoleHost
+        "tls" (dict
+          "mode" "Terminate"
+          "certificateRefs" (list (dict "kind" "Secret" "name" $secretName))
+        )
+        "allowedRoutes" (dict "namespaces" (dict "from" "All"))
+      ) }}
+{{-   $consoleListeners = append $consoleListeners (dict
+        "name" (printf "%s-http" $hp)
+        "port" $consoleHttpPort
+        "protocol" "HTTP"
+        "hostname" $consoleHost
+        "allowedRoutes" (dict "namespaces" (dict "from" "All"))
+      ) }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh
+++ b/platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh
@@ -10,8 +10,10 @@
 #   2. Single-zone render (parentZones empty, only sovereignFQDN set) →
 #      exactly 1 ConfigMap named sovereign-tls-vars in flux-system,
 #      carrying PARENT_DOMAINS_LISTENERS_YAML with bare "https"/"http"
-#      listener names + CONSOLE_LISTENERS_YAML with "console-https"/
-#      "console-http", both referencing the per-prov wildcard Secret.
+#      listener names + CONSOLE_LISTENERS_YAML with SPECIFIC per-host
+#      listeners (console-/api-/marketplace-https+http hostnamed to the
+#      exact 2-label endpoint, NEVER `*.<fqdn>` — #5341), all referencing
+#      the per-prov wildcard Secret.
 #   3. Multi-zone render (2 parentZones) → per-zone-sanitised listener
 #      names, org-pool zone bound to its OWN per-zone Secret (#3376).
 #   4. consoleGateway port overrides (Huawei hostNetwork 8443/8080) flow
@@ -84,10 +86,32 @@ grep -q '\\"name\\":\\"https\\"' "$TMP/single.yaml" || {
   cat "$TMP/single.yaml" >&2
   exit 1
 }
-grep -q '\\"name\\":\\"console-https\\"' "$TMP/single.yaml" || {
-  echo "FAIL: CONSOLE_LISTENERS_YAML missing 'console-https' listener name." >&2
+# CONSOLE_LISTENERS_YAML (#5341) — the dedicated console gateway MUST hostname
+# each listener to the SPECIFIC operator endpoint it serves (console./api./
+# marketplace.<fqdn>), NEVER the apex wildcard `*.<fqdn>`. A wildcard here made
+# the console CEC's cilium-envoy filter chain claim every `*.<fqdn>` TLS
+# handshake, colliding with the shared gateway's own `*.<fqdn>` chain and
+# 404'ing ~50% of every OTHER subdomain (e.g. mcp.<fqdn>).
+CONSOLE_LINE="$(grep 'CONSOLE_LISTENERS_YAML:' "$TMP/single.yaml")"
+for want in \
+  '\\"name\\":\\"console-https\\"' \
+  '\\"hostname\\":\\"console.t99.omani.works\\"' \
+  '\\"name\\":\\"api-https\\"' \
+  '\\"hostname\\":\\"api.t99.omani.works\\"' \
+  '\\"name\\":\\"marketplace-https\\"' \
+  '\\"hostname\\":\\"marketplace.t99.omani.works\\"'; do
+  echo "$CONSOLE_LINE" | grep -q "$want" || {
+    echo "FAIL: CONSOLE_LISTENERS_YAML missing expected #5341 token: $want" >&2
+    echo "$CONSOLE_LINE" >&2
+    exit 1
+  }
+done
+# Collision guard: the console listener set must carry NO `*.<fqdn>` hostname.
+if echo "$CONSOLE_LINE" | grep -q '\\"hostname\\":\\"\*\.t99\.omani\.works\\"'; then
+  echo "FAIL: CONSOLE_LISTENERS_YAML still carries a wildcard '*.t99.omani.works' hostname — the #5341 gateway collision is back." >&2
+  echo "$CONSOLE_LINE" >&2
   exit 1
-}
+fi
 grep -q '\\"name\\":\\"sovereign-wildcard-tls-t99-omani-works\\"' "$TMP/single.yaml" || {
   echo "FAIL: listener certificateRefs does not target the per-prov wildcard Secret sovereign-wildcard-tls-t99-omani-works." >&2
   exit 1

--- a/platform/sovereign-tls-vars/chart/values.yaml
+++ b/platform/sovereign-tls-vars/chart/values.yaml
@@ -22,3 +22,15 @@ parentZones: []
 consoleGateway:
   httpsPort: 443
   httpPort: 80
+  # hostPrefixes (#5341) — the 2-label host set the dedicated console Gateway
+  # serves, one specific listener pair per entry (NOT a `*.<fqdn>` wildcard —
+  # a wildcard here collides with the shared gateway's own `*.<fqdn>` filter
+  # chain on the shared cilium-envoy and 404's ~50% of every other subdomain).
+  # Must match the HTTPRoutes re-parented to cilium-gateway-console:
+  #   console → catalyst-ui · api → catalyst-api + catalyst-catalog ·
+  #   marketplace → marketplace. Add a prefix here when a new route is
+  #   re-parented onto the console gateway, or its listener won't accept it.
+  hostPrefixes:
+    - console
+    - api
+    - marketplace


### PR DESCRIPTION
## Root cause (confirmed live, not inferred)

The dedicated console Cilium Gateway `cilium-gateway-console` hostnamed its listeners **`*.<fqdn>`**. Both it and the shared `cilium-gateway` compile a cilium-envoy filter chain with `filterChainMatch.serverNames = ['*.<fqdn>']`, and **both load onto the same shared cilium-envoy DaemonSet**. So a TLS handshake for *any* subdomain matches **both** chains; envoy resolves the duplicate-wildcard match non-deterministically.

Measured on hw288 (dep `027f0755`, 2026-07-25):
- **12/24 `POST https://mcp.hw288.omani.works/mcp` → `404 (server: envoy, connection: close)`**, rest reach the app; every 404 clears on immediate retry.
- Console CEC listener `serverNames=['*.hw288.omani.works']`, route vhosts = `api`/`console`/`marketplace` only (**no mcp**).
- Main CEC listener `serverNames=['*.hw288.omani.works','hw288.omani.works']`, route vhosts **include** `mcp.hw288.omani.works`.

→ ~50% of `mcp.<fqdn>` requests land on the console chain, whose router has no mcp vhost → bare envoy 404. Every non-console subdomain on the shared gateway was exposed to this.

## Fix

Give each console endpoint its **exact 2-label hostname** listener (`console.` / `api.` / `marketplace.<fqdn>`) via the new `consoleGateway.hostPrefixes` values list. Envoy prefers an exact `server_name` over a wildcard, so:
- `console/api/marketplace.<fqdn>` deterministically bind the console chain (console isolation preserved).
- **every other subdomain no longer matches the console chain at all** → served solely by the shared gateway → no more 404.

The per-prov wildcard cert (`*.<fqdn>`) already covers all three 2-label hosts, so **no extra Let's-Encrypt issuance**.

## Verification
- `helm template` renders **6 specific listeners, zero `*.<fqdn>`** in `CONSOLE_LISTENERS_YAML`.
- Render test (`tests/sovereign-tls-vars-render.sh`) extended: asserts the three specific hostnames **and** a collision guard (fails if any `*.<fqdn>` hostname reappears in the console set). All 4 cases green; `helm lint` clean.
- Chart `0.1.0 → 0.1.1` (blueprint + bootstrap-kit slot-12a pin lockstep).

**Roll-gated:** the fix lands on the cilium-gateway-console listeners once slot-12a rolls `bp-sovereign-tls-vars@0.1.1` on the next prov (or a targeted HR reconcile). Verify post-roll by re-running the 24× `POST /mcp` loop → expect 0 envoy-404.

Refs #5341
