### PR TITLE
fix(catalyst-api): wipe falls back to CATALYST_HUAWEI_* operator env — re-wipe a partial-destroy env (#5193)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -1244,10 +1244,26 @@ func buildWipeCredsRaw(providerName string, body wipeRequest, depReq provisioner
 		// atomic: no need for the operator to re-prompt creds after
 		// a Pod restart, because catalyst-api wrote them to disk
 		// during provision.
-		out["access_key"] = firstNonEmpty(body.HuaweiAccessKey, body.HetznerToken, depReq.HuaweiAccessKey)
-		out["secret_key"] = firstNonEmpty(body.HuaweiSecretKey, body.ObjectStorageSecretKey, depReq.HuaweiSecretKey)
-		out["project_id"] = firstNonEmpty(body.HuaweiProjectID, body.ObjectStorageAccessKey, depReq.HuaweiProjectID)
-		out["region"] = firstNonEmpty(body.HuaweiRegion, body.ObjectStorageRegion, depReq.HuaweiRegion)
+		// #5193 — final fallback to the huawei-operator-creds projected env
+		// (CATALYST_HUAWEI_*, api-deployment.yaml). WORST case a partial destroy
+		// leaves behind: the per-deployment tofu.auto.tfvars.json is gone, the Pod
+		// rolled (no in-memory depReq creds), and the wipe body carries none —
+		// without this the bag is empty → the wipe 400s "huawei credentials are
+		// required" and the record strands at status=wiping, blocking the
+		// one-environment-at-a-time preflight for the next fire. catalyst-api's
+		// OWN env still holds the operator creds, so a re-wipe can authenticate.
+		// Precedence: body > depReq > operator env.
+		out["access_key"] = firstNonEmpty(body.HuaweiAccessKey, body.HetznerToken, depReq.HuaweiAccessKey, os.Getenv("CATALYST_HUAWEI_ACCESS_KEY"))
+		out["secret_key"] = firstNonEmpty(body.HuaweiSecretKey, body.ObjectStorageSecretKey, depReq.HuaweiSecretKey, os.Getenv("CATALYST_HUAWEI_SECRET_KEY"))
+		out["project_id"] = firstNonEmpty(body.HuaweiProjectID, body.ObjectStorageAccessKey, depReq.HuaweiProjectID, os.Getenv("CATALYST_HUAWEI_PROJECT_ID"))
+		out["region"] = firstNonEmpty(body.HuaweiRegion, body.ObjectStorageRegion, depReq.HuaweiRegion, os.Getenv("CATALYST_HUAWEI_REGION"))
+		// Region defaults to me-east-215 ONLY when AK/SK/PID all resolved
+		// (mirrors janitor.go:818). The truly-empty case stays region="" so the
+		// EVS/orphan backstop reads "no creds" instead of scanning me-east-215
+		// with a blank AK/SK.
+		if out["region"] == "" && out["access_key"] != "" && out["secret_key"] != "" && out["project_id"] != "" {
+			out["region"] = "me-east-215"
+		}
 	default:
 		// hetzner (canonical) — same wire shape pre-Wave-3.
 		token := strings.TrimSpace(body.HetznerToken)

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_creds_env_fallback_5193_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_creds_env_fallback_5193_test.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// #5193 — an env the platform created must stay wipeable from the
+// huawei-operator-creds projected env (CATALYST_HUAWEI_*) even in the worst case
+// a partial destroy hit: the per-deployment tfvars are gone, the pod rolled (no
+// in-memory dep.Request creds), and the wipe body carries no creds. Without this
+// fallback buildWipeCredsRaw yields an empty bag → the wipe 400s "huawei
+// credentials are required" and the record strands at status=wiping, blocking the
+// one-environment-at-a-time preflight gate for the next fire.
+func TestBuildWipeCredsRaw_HuaweiOperatorCredsEnvFallback_5193(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "AK-FROM-SECRET")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "SK-FROM-SECRET")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "PID-FROM-SECRET")
+	t.Setenv("CATALYST_HUAWEI_REGION", "me-east-215")
+
+	// Worst case: no body creds, no in-memory dep.Request creds.
+	got := buildWipeCredsRaw("huawei", wipeRequest{}, provisioner.Request{})
+
+	for k, want := range map[string]string{
+		"access_key": "AK-FROM-SECRET",
+		"secret_key": "SK-FROM-SECRET",
+		"project_id": "PID-FROM-SECRET",
+		"region":     "me-east-215",
+	} {
+		if got[k] != want {
+			t.Fatalf("%s: want env fallback %q, got %q", k, want, got[k])
+		}
+	}
+}
+
+// Body-supplied creds still WIN over the env fallback (operator override intact).
+func TestBuildWipeCredsRaw_BodyWinsOverEnv_5193(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "AK-FROM-SECRET")
+	got := buildWipeCredsRaw("huawei", wipeRequest{HuaweiAccessKey: "AK-FROM-BODY"}, provisioner.Request{})
+	if got["access_key"] != "AK-FROM-BODY" {
+		t.Fatalf("access_key: body must win over env, got %q", got["access_key"])
+	}
+}
+
+// Region defaults to me-east-215 ONLY when AK/SK/PID resolved (matches janitor.go);
+// the truly-empty case stays empty so the EVS/orphan backstop reads "no creds".
+func TestBuildWipeCredsRaw_RegionDefaultOnlyWithCreds_5193(t *testing.T) {
+	// No env, no body, no depReq → everything empty, region NOT defaulted.
+	empty := buildWipeCredsRaw("huawei", wipeRequest{}, provisioner.Request{})
+	if empty["region"] != "" {
+		t.Fatalf("region: empty-everything case must stay empty, got %q", empty["region"])
+	}
+	// Creds present but region absent → default fills in.
+	got := buildWipeCredsRaw("huawei", wipeRequest{
+		HuaweiAccessKey: "ak", HuaweiSecretKey: "sk", HuaweiProjectID: "pid",
+	}, provisioner.Request{})
+	if got["region"] != "me-east-215" {
+		t.Fatalf("region: want default me-east-215 when creds present, got %q", got["region"])
+	}
+}


### PR DESCRIPTION
## Problem
A partial `tofu destroy` (nginx 60s timeout / roll-mid-wipe) can strand an env at `status: wiping` — un-wipeable, blocking the one-environment-at-a-time preflight for the next fire (hit live on hw268, dep `7e7a0a1f`).

One link in that chain: after a partial destroy the per-deployment `tofu.auto.tfvars.json` is gone, and if the Pod also rolled (no in-memory `depReq` creds) and the wipe body carries none, `buildWipeCredsRaw` returned an **empty** bag → the re-wipe 400s `"huawei credentials are required"` and can never clean up the surviving region-b / EIPs / VPCs / S3.

## Fix
Append the **huawei-operator-creds projected env** (`CATALYST_HUAWEI_ACCESS_KEY` / `_SECRET_KEY` / `_PROJECT_ID` / `_REGION`) as the final fallback in `buildWipeCredsRaw`. Those are already wired into `api-deployment.yaml:656` (server-side operator IAM, never in the wizard payload), so **catalyst-api's own env re-authenticates the wipe** even when every per-deployment source is gone.

- Precedence preserved: **body > depReq > operator env** (operator override intact — see `BodyWinsOverEnv` test).
- Region defaults to `me-east-215` **only** when AK/SK/PID all resolve (mirrors `janitor.go:818`); the truly-empty case stays `region=""` so the EVS/orphan backstop reads "no creds" rather than scanning the wrong region with a blank AK/SK.

## Verification
- Lands + greens the pre-existing **RED** spec `wipe_creds_env_fallback_5193_test.go` (was an untracked local spec, failing the handler suite): **3/3 PASS**.
- `go build ./...` OK; wipe/janitor/creds suite green; `go vet` clean.

Scope note: this closes the **creds-fallback** link of #5193. The async-destroy / nginx-timeout links (root-cause items 1–2 in the issue) are separate and remain tracked there.

Refs #5193
