### PR TITLE
fix(k8scache): bounded discovery gate for optional GVRs — stop reflector churn OOM (Refs #5352)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -542,6 +542,78 @@ func NewFactory(cfg Config) (*Factory, error) {
 	return f, nil
 }
 
+// optionalGVProbeTimeout bounds each distinct Optional-kind GroupVersion
+// discovery probe in AddCluster (#5352). Chosen at 3s: long enough for a
+// healthy apiserver to answer a single discovery GET, short enough that a
+// dead / unreachable Sovereign kubeconfig adds only a few seconds total to
+// startup (one timeout per distinct Optional GroupVersion — two today:
+// hcloud.crossplane.io/v1alpha1 and cilium.io/v2alpha1) instead of the
+// unbounded multi-minute hang the pre-#5352 synchronous probe caused. Only
+// Optional kinds are probed; universally-present kinds never touch the
+// network on the startup path. See kinds.go Kind.Optional.
+const optionalGVProbeTimeout = 3 * time.Second
+
+// gvProbe caches the outcome of one ServerResourcesForGroupVersion call so
+// Optional kinds that share a GroupVersion (the four
+// hcloud.crossplane.io/v1alpha1 resources) probe the apiserver at most once.
+type gvProbe struct {
+	ok        bool            // probe completed without error/timeout
+	resources map[string]bool // plural resource name → served (valid iff ok)
+}
+
+// served reports whether the given plural resource is served under this
+// GroupVersion. A probe that errored or timed out (ok=false) always reports
+// not-served, so the caller skips the informer rather than let its reflector
+// hot-loop against an absent GVR (#5352 churn → OOM).
+func (p *gvProbe) served(resource string) bool {
+	return p != nil && p.ok && p.resources[resource]
+}
+
+// probeGroupVersion asks the cluster's discovery client whether groupVersion
+// is served, bounded by timeout. The discovery method
+// (ServerResourcesForGroupVersion) has NO context parameter, so the call runs
+// in a detached goroutine and its result is selected against a
+// context.WithTimeout — a dead apiserver therefore costs at most `timeout`,
+// never the underlying TCP-connect timeout (minutes). This is the bounded
+// re-introduction of the gate removed in the comment above the AddCluster
+// informer loop: it closes the original startup-hang (the old probe had no
+// timeout) while stopping the reflector churn that leaked memory on hw288.
+//
+// The result channel is buffered (size 1) so the detached goroutine never
+// leaks even when we return on timeout — its eventual send simply lands in
+// the buffer and is GC'd with the channel.
+func probeGroupVersion(core kubernetes.Interface, groupVersion string, timeout time.Duration) *gvProbe {
+	if core == nil {
+		return &gvProbe{ok: false}
+	}
+	type result struct {
+		list *metav1.APIResourceList
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		list, err := core.Discovery().ServerResourcesForGroupVersion(groupVersion)
+		ch <- result{list: list, err: err}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	select {
+	case r := <-ch:
+		if r.err != nil || r.list == nil {
+			// IsNotFound, transport error, or a nil list all mean "treat as
+			// not served" — the informer would only churn.
+			return &gvProbe{ok: false}
+		}
+		served := make(map[string]bool, len(r.list.APIResources))
+		for _, ar := range r.list.APIResources {
+			served[ar.Name] = true
+		}
+		return &gvProbe{ok: true, resources: served}
+	case <-ctx.Done():
+		return &gvProbe{ok: false}
+	}
+}
+
 // AddCluster registers a Sovereign + spawns its informer set. Safe to
 // call before or after Start. Idempotent — re-adding a cluster id
 // shadows the previous entry.
@@ -663,6 +735,18 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 	// out (often minutes), and AddCluster is on the main startup
 	// path — so the contabo mothership boot blocked while iterating
 	// dead clusters. Removed.
+	//
+	// #5352 re-introduces that gate for Optional kinds ONLY, now
+	// BOUNDED by optionalGVProbeTimeout (see probeGroupVersion). The
+	// original hang is closed by the per-GroupVersion context timeout;
+	// the reflector churn (an informer for a GVR the apiserver 404s
+	// hot-loops "Failed to watch → retry" forever, leaking memory
+	// until OOMKill — 62 restarts / 2.5d on hw288) is closed by
+	// skipping the informer when discovery reports the GVR absent.
+	// Non-optional kinds (namespace/pod/deployment/…) are universally
+	// present and register unconditionally with NO probe, preserving
+	// the synchronous-network-free startup fast path.
+	gvServedCache := map[string]*gvProbe{}
 	for _, k := range f.registry.All() {
 		// TBD-V50 (#2125): no more per-Kind routing — every Kind uses the
 		// single unbounded factory because every Kind in DefaultKinds has
@@ -670,6 +754,22 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 		// grew unbounded) are no longer registered at all; consumers
 		// query the apiserver directly. See kinds.go for the architectural
 		// rationale.
+		//
+		// #5352 Optional gate — probe discovery (bounded) once per distinct
+		// GroupVersion; skip the informer where the GVR is not served.
+		if k.Optional {
+			gv := k.GVR.GroupVersion().String()
+			p, cached := gvServedCache[gv]
+			if !cached {
+				p = probeGroupVersion(cs.core, gv, optionalGVProbeTimeout)
+				gvServedCache[gv] = p
+			}
+			if !p.served(k.GVR.Resource) {
+				f.log.Info("k8scache: skipping optional kind — GVR not served",
+					"cluster", c.ID, "kind", k.Name, "gvr", k.GVR.String())
+				continue
+			}
+		}
 		inf := cs.factory.ForResource(k.GVR).Informer()
 		k := k // capture per-iteration
 		_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -60,6 +60,25 @@ type Kind struct {
 	// Secret. ConfigMap data is treated as PII-adjacent and also
 	// stripped (see redactObject).
 	Sensitive bool
+
+	// Optional — true for kinds whose GVR is NOT served on every
+	// managed cluster (provider-hcloud Crossplane managed resources
+	// only exist where the Hetzner provider is installed;
+	// cilium.io/v2alpha1 CiliumEndpointSlice is not served on every
+	// Cilium build). Universally-present kinds (namespace, pod,
+	// deployment, …) leave this false.
+	//
+	// #5352 — registering an informer for a GVR the apiserver does
+	// NOT serve makes the client-go reflector hot-loop
+	// "Failed to watch … → retry" forever, leaking memory until
+	// catalyst-api OOMKills (62 restarts / 2.5d on hw288). The
+	// factory therefore gates Optional kinds behind a BOUNDED
+	// discovery probe in AddCluster: it registers the informer only
+	// when the apiserver actually serves the GVR, and skips it
+	// otherwise. Non-optional kinds skip the probe entirely so the
+	// synchronous-network-free startup fast path is preserved (a dead
+	// kubeconfig can never block boot). See factory.go AddCluster.
+	Optional bool
 }
 
 // DefaultKinds is the built-in registry — every Sovereign starts with
@@ -107,10 +126,18 @@ var DefaultKinds = []Kind{
 	// Crossplane managed resources — provider-hcloud's K8s projection
 	// of cloud-side objects (ADR-0001 §5: cloud + K8s data are
 	// pre-married before reaching Catalyst).
-	{Name: "server.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "servers"}, Namespaced: false},
-	{Name: "loadbalancer.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "loadbalancers"}, Namespaced: false},
-	{Name: "network.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "networks"}, Namespaced: false},
-	{Name: "volume.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "volumes"}, Namespaced: false},
+	//
+	// Optional: true (#5352) — the hcloud.crossplane.io provider is
+	// installed ONLY on the Hetzner mothership. On a Huawei-hosted
+	// Sovereign (hw288) these GVRs are not served, and an
+	// unconditionally-registered informer's reflector hot-loops
+	// "Failed to watch → retry" forever, leaking memory until
+	// catalyst-api OOMKills. The AddCluster discovery gate skips them
+	// where the provider is absent (see factory.go).
+	{Name: "server.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "servers"}, Namespaced: false, Optional: true},
+	{Name: "loadbalancer.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "loadbalancers"}, Namespaced: false, Optional: true},
+	{Name: "network.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "networks"}, Namespaced: false, Optional: true},
+	{Name: "volume.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "volumes"}, Namespaced: false, Optional: true},
 
 	// vCluster.io tenants.
 	{Name: "vcluster", GVR: schema.GroupVersionResource{Group: "vcluster.com", Version: "v1alpha1", Resource: "vclusters"}, Namespaced: true},
@@ -304,30 +331,28 @@ var DefaultKinds = []Kind{
 	// Cilium ClusterMesh (cilium.io/v2alpha1) — multi-region peering
 	// records. Matrix asserts on TC-273/297 (omantel-fsn ↔ omantel-hel
 	// peer status).
-	{Name: "ciliumendpointslice", GVR: schema.GroupVersionResource{Group: "cilium.io", Version: "v2alpha1", Resource: "ciliumendpointslices"}, Namespaced: false},
+	//
+	// Optional: true (#5352) — cilium.io/v2alpha1 CiliumEndpointSlice
+	// is not served on every Cilium build (it depends on the
+	// endpointslice-based ClusterMesh mode being enabled). Where the
+	// version is absent an unconditionally-registered informer's
+	// reflector hot-loops "Failed to watch → retry", leaking memory
+	// (a #5352 contributor on hw288). The AddCluster discovery gate
+	// registers it only where the GVR is actually served.
+	{Name: "ciliumendpointslice", GVR: schema.GroupVersionResource{Group: "cilium.io", Version: "v2alpha1", Resource: "ciliumendpointslices"}, Namespaced: false, Optional: true},
 	// k8s.io NetworkPolicy (networking.k8s.io/v1) — vanilla NPs
 	// surfaced alongside CNPs on the Policies tab. Already covered by
 	// the cutover-driver ClusterRole (`networking.k8s.io/networkpolicies`)
 	// but the kind was never registered for the generic /k8s/ surface.
 	{Name: "networkpolicy", GVR: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}, Namespaced: true},
 
-	// Sandbox Wave 7 (PR sandbox-wave7-sessions-api) — sandbox.openova.io/v1
-	// Sandbox CRD backing the Sovereign Console's per-Org coding-agent
-	// surface (products/sandbox/docs/architecture.md §7). The
-	// /api/v1/sandbox/sessions CRUD handlers in
-	// products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
-	// also read+write the kind directly via DynamicClientFor; registering
-	// it here lets the generic /k8s/{kind} surface enumerate Sandboxes
-	// the same way it does Applications + UserAccess.
-	//
-	// Per feedback_chroot_in_cluster_fallback.md: every new GVR added
-	// here MUST get a matching rule on catalyst-api-cutover-driver
-	// ClusterRole (clusterrole-cutover-driver.yaml). The Sandbox CR
-	// carries no secret material (the controller writes
-	// placeholder Secrets in the Sandbox namespace for newapi tokens —
-	// those are gated by the existing `secret` Sensitive=true entry),
-	// so Sensitive=false is correct.
-	{Name: "sandbox", GVR: schema.GroupVersionResource{Group: "sandbox.openova.io", Version: "v1", Resource: "sandboxes"}, Namespaced: true},
+	// The Sandbox CRD (sandbox.openova.io/v1) was REMOVED platform-wide
+	// by founder direction 2026-06-30 — the Sandbox concept + menu are
+	// gone, superseded by the per-Org Agenity workspace + bp-openova-mcp.
+	// Its former kinds.go registry entry is deliberately NOT re-added:
+	// no cluster serves the GVR anymore, so an informer would only
+	// hot-loop "Failed to watch → retry" and leak memory (the #5352
+	// churn class). See TestDefaultKinds_NoSandboxKind.
 
 	// Issue #3978 (Refs #3970) — restore the rich per-kind cloud-list
 	// (`/cloud?view=list`) page. Each reconciler resource kind must render

--- a/products/catalyst/bootstrap/api/internal/k8scache/optional_gvr_gate_5352_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/optional_gvr_gate_5352_test.go
@@ -1,0 +1,251 @@
+// optional_gvr_gate_5352_test.go — #5352 regression guard.
+//
+// Root cause: the AddCluster informer loop registered an informer for EVERY
+// registered Kind unconditionally. On a Huawei-hosted Sovereign (hw288) the
+// hcloud.crossplane.io/v1alpha1 managed-resource GVRs (servers /
+// loadbalancers / networks / volumes) and cilium.io/v2alpha1
+// CiliumEndpointSlice are NOT served — the provider is Hetzner-only and that
+// cilium version is not built. A client-go reflector watching an absent GVR
+// hot-loops "Failed to watch … → retry" forever, leaking memory until
+// catalyst-api OOMKills (62 restarts over 2.5 days).
+//
+// The fix restores a BOUNDED existence gate that applies ONLY to Optional
+// kinds: before registering an Optional kind's informer, AddCluster probes
+// discovery (ServerResourcesForGroupVersion) under a per-GroupVersion
+// context timeout. Served → register; absent / error / timeout → skip.
+// Non-optional (universally present) kinds register with no probe, so a dead
+// kubeconfig can never block startup — the original hang the pre-#5352 probe
+// caused (it had no timeout) stays closed.
+package k8scache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// hasInformer reports whether cluster `clusterID` built an informer for the
+// Kind registered under `kindName`. Reads the package-internal per-cluster
+// map under the factory lock.
+func hasInformer(f *Factory, clusterID, kindName string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	cs, ok := f.clusters[clusterID]
+	if !ok || cs == nil {
+		return false
+	}
+	_, ok = cs.informers[kindName]
+	return ok
+}
+
+// TestAddCluster_OptionalKindGate is the end-to-end guard: with a registry of
+// one non-optional kind + one SERVED optional kind + one ABSENT optional kind,
+// AddCluster must build informers for the non-optional and served-optional
+// kinds and SKIP the absent optional kind (the churn source). Informers are
+// built during AddCluster (no Start needed), so nothing dials the fake.
+func TestAddCluster_OptionalKindGate(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Kind{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true})
+	_ = r.Add(Kind{Name: "server.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "servers"}, Namespaced: false, Optional: true})
+	_ = r.Add(Kind{Name: "ciliumendpointslice", GVR: schema.GroupVersionResource{Group: "cilium.io", Version: "v2alpha1", Resource: "ciliumendpointslices"}, Namespaced: false, Optional: true})
+
+	// The apiserver serves ONLY hcloud.crossplane.io/v1alpha1 (with the
+	// `servers` resource). cilium.io/v2alpha1 is absent → discovery 404s it.
+	core := kfake.NewSimpleClientset()
+	core.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "hcloud.crossplane.io/v1alpha1",
+			APIResources: []metav1.APIResource{{Name: "servers", Namespaced: false, Kind: "Server"}},
+		},
+	}
+	dyn := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	f, err := NewFactory(Config{
+		Logger:   quietLogger(),
+		Registry: r,
+		Clusters: []ClusterRef{{ID: "alpha", DynamicClient: dyn, CoreClient: core}},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	// Non-optional kind: registered unconditionally (fast path).
+	if !hasInformer(f, "alpha", "pod") {
+		t.Errorf("non-optional kind 'pod' not registered — the no-probe fast path is broken")
+	}
+	// Served optional kind: probe confirms it is served → registered.
+	if !hasInformer(f, "alpha", "server.hcloud") {
+		t.Errorf("served optional kind 'server.hcloud' not registered — the gate wrongly skipped a served GVR")
+	}
+	// Absent optional kind: probe reports absent → SKIPPED. This is the
+	// #5352 churn fix: no informer, no reflector, no OOM.
+	if hasInformer(f, "alpha", "ciliumendpointslice") {
+		t.Errorf("absent optional kind 'ciliumendpointslice' WAS registered — its reflector would hot-loop 'Failed to watch' and leak memory (#5352)")
+	}
+}
+
+// TestAddCluster_OptionalGate_NilCoreSkipsOptional proves that when no
+// discovery client is available the gate fails safe (skips Optional kinds)
+// rather than registering a possibly-absent GVR — and still registers every
+// non-optional kind. The gate must never panic on a nil core.
+func TestAddCluster_OptionalGate_NilCoreSkipsOptional(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Kind{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true})
+	_ = r.Add(Kind{Name: "server.hcloud", GVR: schema.GroupVersionResource{Group: "hcloud.crossplane.io", Version: "v1alpha1", Resource: "servers"}, Namespaced: false, Optional: true})
+
+	dyn := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	// CoreClient omitted → cs.core is nil.
+	f, err := NewFactory(Config{
+		Logger:   quietLogger(),
+		Registry: r,
+		Clusters: []ClusterRef{{ID: "alpha", DynamicClient: dyn}},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	if !hasInformer(f, "alpha", "pod") {
+		t.Errorf("non-optional 'pod' not registered with nil core — fast path must not depend on discovery")
+	}
+	if hasInformer(f, "alpha", "server.hcloud") {
+		t.Errorf("optional 'server.hcloud' registered despite nil discovery — gate must fail safe (skip)")
+	}
+}
+
+// TestProbeGroupVersion_ServedListsResources — a served GroupVersion reports
+// each of its resources as served, and a resource NOT in the returned list
+// as not-served (resource-level precision, so one hcloud GV that omits a
+// resource still skips only that resource).
+func TestProbeGroupVersion_ServedListsResources(t *testing.T) {
+	core := kfake.NewSimpleClientset()
+	core.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "hcloud.crossplane.io/v1alpha1",
+			APIResources: []metav1.APIResource{{Name: "servers"}, {Name: "loadbalancers"}},
+		},
+	}
+	p := probeGroupVersion(core, "hcloud.crossplane.io/v1alpha1", optionalGVProbeTimeout)
+	if !p.ok {
+		t.Fatalf("served GroupVersion probe returned ok=false")
+	}
+	if !p.served("servers") || !p.served("loadbalancers") {
+		t.Errorf("served resources reported not-served: %+v", p.resources)
+	}
+	if p.served("networks") {
+		t.Errorf("resource absent from the served list wrongly reported served")
+	}
+}
+
+// TestProbeGroupVersion_AbsentGVSkips — an unserved GroupVersion (the fake
+// returns an IsNotFound StatusError) yields not-served.
+func TestProbeGroupVersion_AbsentGVSkips(t *testing.T) {
+	core := kfake.NewSimpleClientset() // no Resources set → NotFound
+	p := probeGroupVersion(core, "cilium.io/v2alpha1", optionalGVProbeTimeout)
+	if p.served("ciliumendpointslices") {
+		t.Errorf("absent GroupVersion must report not-served (IsNotFound path), got %+v", p)
+	}
+}
+
+// TestProbeGroupVersion_ErrorSkips — a discovery transport error yields
+// not-served (the informer would only churn against an unreachable apiserver).
+func TestProbeGroupVersion_ErrorSkips(t *testing.T) {
+	core := kfake.NewSimpleClientset()
+	core.PrependReactor("get", "resource", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("boom: apiserver unreachable")
+	})
+	p := probeGroupVersion(core, "hcloud.crossplane.io/v1alpha1", optionalGVProbeTimeout)
+	if p.ok || p.served("servers") {
+		t.Errorf("discovery error must yield ok=false / not-served, got %+v", p)
+	}
+}
+
+// TestProbeGroupVersion_TimeoutSkipsWithoutHanging — a discovery call slower
+// than the timeout must NOT hang the probe: it returns not-served within the
+// bound. This is the guard against reintroducing the #5352 startup hang (the
+// removed probe had no timeout and blocked boot for minutes on a dead cluster).
+func TestProbeGroupVersion_TimeoutSkipsWithoutHanging(t *testing.T) {
+	core := kfake.NewSimpleClientset()
+	core.PrependReactor("get", "resource", func(clienttesting.Action) (bool, runtime.Object, error) {
+		time.Sleep(500 * time.Millisecond) // far longer than the probe timeout below
+		return true, nil, nil
+	})
+	start := time.Now()
+	p := probeGroupVersion(core, "hcloud.crossplane.io/v1alpha1", 30*time.Millisecond)
+	elapsed := time.Since(start)
+	if p.ok || p.served("servers") {
+		t.Errorf("timed-out probe must yield ok=false / not-served, got %+v", p)
+	}
+	if elapsed > 300*time.Millisecond {
+		t.Fatalf("probe hung for %v — timeout did not bound the wait (would reintroduce the #5352 startup hang)", elapsed)
+	}
+}
+
+// TestProbeGroupVersion_NilCoreSkips — a nil discovery client never panics and
+// reports not-served.
+func TestProbeGroupVersion_NilCoreSkips(t *testing.T) {
+	p := probeGroupVersion(nil, "hcloud.crossplane.io/v1alpha1", optionalGVProbeTimeout)
+	if p.served("servers") {
+		t.Errorf("nil core must report not-served, got %+v", p)
+	}
+}
+
+// TestDefaultKinds_OptionalFlags pins the config-level invariant: the GVRs
+// not served on every cluster carry Optional:true (so the gate probes them),
+// while universally-present kinds stay non-optional (so they always register
+// with no probe — "non-optional kinds always register").
+func TestDefaultKinds_OptionalFlags(t *testing.T) {
+	byName := map[string]Kind{}
+	for _, k := range DefaultKinds {
+		byName[k.Name] = k
+	}
+	wantOptional := []string{
+		"server.hcloud", "loadbalancer.hcloud", "network.hcloud", "volume.hcloud",
+		"ciliumendpointslice",
+	}
+	for _, name := range wantOptional {
+		k, ok := byName[name]
+		if !ok {
+			t.Errorf("DefaultKinds missing expected optional kind %q", name)
+			continue
+		}
+		if !k.Optional {
+			t.Errorf("#5352: kind %q must be Optional:true — its GVR is not served on every cluster", name)
+		}
+	}
+	wantNonOptional := []string{"namespace", "node", "pod", "service", "secret", "deployment"}
+	for _, name := range wantNonOptional {
+		k, ok := byName[name]
+		if !ok {
+			t.Errorf("DefaultKinds missing expected non-optional kind %q", name)
+			continue
+		}
+		if k.Optional {
+			t.Errorf("#5352: universally-present kind %q must stay non-optional (registers unconditionally, no probe)", name)
+		}
+	}
+}
+
+// TestDefaultKinds_NoSandboxKind guards the #5352 removal of the Sandbox CRD
+// from the registry. The Sandbox concept was removed platform-wide (founder
+// 2026-06-30); no cluster serves sandbox.openova.io/v1, so an informer for it
+// would only hot-loop "Failed to watch" and leak memory. It must not be
+// re-added to DefaultKinds.
+func TestDefaultKinds_NoSandboxKind(t *testing.T) {
+	for _, k := range DefaultKinds {
+		if k.Name == "sandbox" || k.GVR.Group == "sandbox.openova.io" {
+			t.Fatalf("#5352: DefaultKinds must not register the removed Sandbox CRD "+
+				"(kind %q, gvr %q) — the Sandbox concept was removed 2026-06-30 and no "+
+				"cluster serves the GVR; an informer would churn and leak.",
+				k.Name, k.GVR.String())
+		}
+	}
+}


### PR DESCRIPTION
## Root cause (#5352)

`catalyst-api` OOMKilled every ~56 min (**62 restarts over 2.5 days on hw288**). The `k8scache` `AddCluster` informer loop registered an informer for **every** registered `Kind` unconditionally — no existence gate. On a Huawei-hosted Sovereign these GVRs are **not served**:

- `hcloud.crossplane.io/v1alpha1` — `servers` / `loadbalancers` / `networks` / `volumes` (the Hetzner-only Crossplane provider)
- `cilium.io/v2alpha1` — `ciliumendpointslices` (not served on this Cilium build)
- `sandbox.openova.io/v1` — `sandboxes` (the Sandbox CRD was removed platform-wide 2026-06-30)

A client-go reflector watching a GVR the apiserver 404s **hot-loops `Failed to watch … → retry` forever**, leaking memory until the Pod OOMKills. That is the churn → OOM chain.

An earlier discovery probe that skipped absent kinds was previously **removed** because it was synchronous with **no context timeout** — a dead/unreachable kubeconfig hung `catalyst-api` boot for minutes. This PR must not (and does not) reintroduce that hang.

## The fix — bounded existence gate, Optional kinds only

- Add `Kind.Optional`. Mark the four `hcloud.crossplane.io` GVRs and `cilium.io/v2alpha1 ciliumendpointslices` `Optional: true`. Universally-present kinds (`namespace`/`pod`/`deployment`/…) stay non-optional.
- **Remove the dead `sandbox` kind** entirely (no cluster serves the GVR anymore).
- `AddCluster` now gates **only Optional kinds** behind a discovery probe: `core.Discovery().ServerResourcesForGroupVersion(gv)` run in a detached goroutine and selected against a **`context.WithTimeout` of 3s**, **cached once per distinct GroupVersion**. Served → register the informer as before; **absent / IsNotFound / error / timeout → skip** (logged at Info: `k8scache: skipping optional kind — GVR not served`).
- **Non-optional kinds register unconditionally with no probe** — the synchronous-network-free startup fast path is preserved, so a dead kubeconfig can never block boot. The per-GV 3s timeout bounds any dead-cluster startup delay to a few seconds total (two distinct optional GVs today), closing the original hang while stopping the churn.

## Tests

New `internal/k8scache/optional_gvr_gate_5352_test.go` (fake discovery client):

- served optional kind → informer registered; absent optional kind → **skipped**; non-optional kind → always registered (end-to-end through `AddCluster`).
- nil core → optional skipped (fail-safe), non-optional still registered.
- `probeGroupVersion`: served lists resources (resource-level precision), absent GV skips (IsNotFound), discovery **error** skips, discovery **timeout** skips **without hanging** (bounded) and without panicking, nil core skips.
- config-level guards: the five GVRs are `Optional:true` and universal kinds are not; the removed Sandbox kind is not re-added.

```
go build ./...                       # exit 0
go vet ./internal/k8scache/...        # exit 0
go test ./internal/k8scache/...       # ok (all pass)
```

## Verification required on a fresh Huawei prov

PR merge ≠ shipped. Must be verified on a fresh Huawei Sovereign:
- reflector `Failed to watch … ciliumendpointslices / servers / …` errors **gone** from `catalyst-api` logs;
- `catalyst-api` memory **flat** (no sawtooth);
- **0 OOMKills** over several hours (vs 62 restarts / 2.5d before).

Scope: edits confined to `products/catalyst/bootstrap/api/internal/k8scache/` (`kinds.go`, `factory.go`, new test). The chart memory-request bump is tracked separately and intentionally not touched here.

Refs #5352

🤖 Generated with [Claude Code](https://claude.com/claude-code)