### PR TITLE
fix(org-controller): emit tenant.deleted on finalizer so raw kubectl delete prunes org-tenants gitops dir (#5364)

### DIFF
--- a/core/controllers/go.mod
+++ b/core/controllers/go.mod
@@ -7,6 +7,7 @@ go 1.23
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/nats-io/nats.go v1.37.0
 	github.com/prometheus/client_golang v1.19.1
@@ -37,7 +38,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/core/controllers/organization/cmd/main.go
+++ b/core/controllers/organization/cmd/main.go
@@ -329,6 +329,26 @@ func main() {
 	// requeue fallback inside r.Reconcile keeps the controller correct.
 	natsURL := strings.TrimSpace(os.Getenv("NATS_URL"))
 	if natsURL != "" {
+		// #5364 — publish leg: wire a NATS publisher so the reconciler emits the
+		// canonical `tenant.deleted` event on Org-CR finalizer teardown. That
+		// event drives the provisioning service's tenant.deleted consumer to run
+		// the SECOND half of Org teardown (prune the `org-tenants` gitops dir: the
+		// <slug> ns manifest + tenant HelmReleases). Without it a raw
+		// `kubectl delete organization` runs only the org-controller half of
+		// teardown and the org-tenants Kustomization recreates the ns + HRs
+		// forever. Best-effort: a connect failure logs + leaves the publisher nil
+		// (the reconciler's publishTenantDeleted then degrades to a no-op), never
+		// fatal — the informer/finalizer path stays correct either way.
+		if pub, err := natsbus.NewPublisher(natsURL); err != nil {
+			log.Error(err, "natsbus: publisher connect failed — tenant.deleted emit-on-finalizer disabled (#5364); Org deletes still run the org-controller-half teardown",
+				"nats_url", natsURL)
+		} else {
+			r.TenantEventPublisher = pub
+			defer pub.Close()
+			log.Info("natsbus: tenant.deleted publish-leg wired (#5364)",
+				"nats_url", natsURL, "subject", natsbus.SubjectTenantDeleted)
+		}
+
 		if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 			sub, err := natsbus.Connect(natsURL)
 			if err != nil {

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -49,7 +49,18 @@ import (
 	"github.com/openova-io/openova/core/controllers/organization/internal/iacbootstrap"
 	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
 )
+
+// TenantEventPublisher is the narrow publish seam the deletion path uses to
+// emit the canonical `tenant.deleted` domain event (#5364). *natsbus.Publisher
+// satisfies it in production; unit tests inject a fake. The interface (rather
+// than a concrete *natsbus.Publisher field) keeps the Reconciler testable and
+// lets main.go leave the field nil on a no-NATS install (Catalyst-Zero), where
+// the emit degrades to a logged no-op.
+type TenantEventPublisher interface {
+	Publish(ctx context.Context, subject string, ev *natsbus.Event) error
+}
 
 // userAccessGVR is the CLUSTER-scoped UserAccess CR group/version/kind
 // the reconciler writes per Org owner. Defined in
@@ -90,6 +101,19 @@ type Reconciler struct {
 
 	// Keycloak is the Keycloak Admin client (interface for testability).
 	Keycloak KeycloakClient
+
+	// TenantEventPublisher publishes the canonical `tenant.deleted` domain
+	// event on Org-CR finalizer teardown so the provisioning service's
+	// tenant.deleted consumer runs the SECOND half of Org teardown — pruning
+	// the `org-tenants` gitops dir (the <slug> Namespace manifest + tenant
+	// HelmReleases from the org-tenants Flux Kustomization inventory). Without
+	// this, a raw `kubectl delete organization` fires ONLY the org-controller
+	// half of teardown (per-Org vCluster Flux + tenant-networking) and never
+	// publishes tenant.deleted, so the org-tenants Kustomization perpetually
+	// recreates the ns + HRs (#5364). Nil on a no-NATS install (Catalyst-Zero /
+	// NATS_URL unset) — the publish then degrades to a logged no-op, matching
+	// pre-#5364 behavior. Interface for testability + nil-safety.
+	TenantEventPublisher TenantEventPublisher
 
 	// PerOrgRealmEnabled gates the per-Org Keycloak realm auto-wiring
 	// (#3084 Part 2). When true, Reconcile find-or-creates a realm named
@@ -384,6 +408,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// before the Keycloak/Gitea ensure steps prevents recreating
 	// artifacts we're about to delete.
 	if !org.DeletionTimestamp.IsZero() {
+		// #5364 — emit the canonical `tenant.deleted` event so the provisioning
+		// service's tenant.deleted consumer runs the SECOND half of Org teardown:
+		// pruning the `org-tenants` gitops dir (the <slug> Namespace manifest +
+		// tenant HelmReleases from the org-tenants Flux Kustomization inventory).
+		// The teardowns below are only the FIRST half (per-Org vCluster Flux +
+		// tenant-networking); the org-tenants dir is owned by the provisioning
+		// service and is pruned ONLY on a tenant.deleted event. Before this fix a
+		// raw `kubectl delete organization` never published tenant.deleted (only
+		// tenant-service's DELETE /api/organizations/{id} route did), so the
+		// org-tenants Kustomization perpetually recreated the ns + HRs.
+		//
+		// Published FIRST (before dropping any finalizer) + BEST-EFFORT: a nil
+		// publisher (no NATS) or a publish failure logs + continues — it NEVER
+		// blocks finalizer removal, so a NATS hiccup cannot wedge the CR in
+		// Terminating. We are unambiguously in the delete path (DeletionTimestamp
+		// is set), which is the only guard the consumer's idempotent git prune
+		// needs against a day-2-reinstall race. A duplicate publish across
+		// finalizer-requeue passes is harmless (the consumer prune is idempotent).
+		r.publishTenantDeleted(ctx, &org)
+
 		// Per-Org vCluster Flux teardown (PR #3700 §4.3). The Flux CR pair
 		// carries NO ownerRef (cross-namespace GC trap), so the GC won't
 		// reap it — delete explicitly. Best-effort + absent-as-success +
@@ -839,6 +883,61 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// publishTenantDeleted best-effort emits the canonical `tenant.deleted` domain
+// event so the provisioning service's tenant.deleted consumer runs the SECOND
+// half of Org teardown — pruning the `org-tenants` gitops dir (the <slug>
+// Namespace manifest + tenant HelmReleases). See the Reconcile deletion-branch
+// comment + the TenantEventPublisher field doc for the split-teardown root
+// cause (#5364).
+//
+// Contract (all enforced here so callers stay a single line):
+//   - Nil publisher (no NATS / Catalyst-Zero) → silent no-op: the Org-delete
+//     path degrades to its pre-#5364 behavior, never a wedge.
+//   - The payload carries {id, slug} both set to the Org slug. The consumer
+//     keys its teardown off `slug` (a tenant UUID is not required); `id` is set
+//     non-empty so the envelope matches what tenant-service emits.
+//   - The publish is BOUNDED (5s ctx) and BEST-EFFORT: a marshal error, a nil
+//     typed publisher, a broker stall, or a Nak all log a warning and RETURN —
+//     the finalizer removal in the caller proceeds regardless, so a NATS hiccup
+//     can never strand the CR in Terminating. The consumer's git prune is
+//     idempotent, so the next tenant.deleted (or a live re-walk) reconverges.
+func (r *Reconciler) publishTenantDeleted(ctx context.Context, org *orgapi.Organization) {
+	if r.TenantEventPublisher == nil {
+		// No NATS wired (NATS_URL unset) — degrade to pre-#5364 behavior. The
+		// org-controller half of teardown still runs; only the org-tenants prune
+		// (which requires the bus) is skipped, exactly as before this fix.
+		return
+	}
+	slug := org.Spec.Slug
+	if slug == "" {
+		slug = org.Name
+	}
+	ev, err := natsbus.NewEvent("tenant.deleted", "organization-controller", slug,
+		map[string]string{
+			// The provisioning consumer unmarshals {id, slug} and keys teardown
+			// off slug (consumer.go handleTenantDeleted). id is set to the slug so
+			// the envelope is non-empty + shape-compatible with tenant-service.
+			"id":   slug,
+			"slug": slug,
+		})
+	if err != nil {
+		r.Log.Error(err, "tenant.deleted: build event failed — skipping publish (finalizer proceeds; #5364)",
+			"slug", slug)
+		return
+	}
+	// Bound the wait so a broker stall cannot hang the delete. On timeout/err we
+	// log + continue — the finalizer must not wedge on a NATS hiccup.
+	pubCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := r.TenantEventPublisher.Publish(pubCtx, natsbus.SubjectTenantDeleted, ev); err != nil {
+		r.Log.Error(err, "tenant.deleted: publish failed — org-tenants gitops prune deferred (finalizer still proceeds; consumer prune is idempotent on the next tenant.deleted / re-walk; #5364)",
+			"slug", slug, "subject", natsbus.SubjectTenantDeleted)
+		return
+	}
+	r.Log.Info("tenant.deleted published — provisioning consumer will prune the org-tenants gitops dir (ns + tenant HelmReleases) (#5364)",
+		"slug", slug, "subject", natsbus.SubjectTenantDeleted)
 }
 
 // reconcileConsoleServing brings up the per-Org customer console EDGE — the

--- a/core/controllers/organization/internal/controller/tenant_deleted_emit_5364_test.go
+++ b/core/controllers/organization/internal/controller/tenant_deleted_emit_5364_test.go
@@ -1,0 +1,188 @@
+// tenant_deleted_emit_5364_test.go — pins the #5364 emit-on-finalizer fix.
+//
+// Root cause (#5364): Org teardown is SPLIT across two producers.
+//   1. The org-controller finalizer prunes the per-Org vCluster Flux +
+//      tenant-networking (this file's Reconciler).
+//   2. The provisioning service's `tenant.deleted` consumer prunes the
+//      `org-tenants` gitops dir (the <slug> Namespace manifest + tenant
+//      HelmReleases from the org-tenants Flux Kustomization inventory).
+//
+// The tenant-service's DELETE /api/organizations/{id} route publishes
+// tenant.deleted → half #2 runs. But a raw `kubectl delete organization`
+// runs ONLY the org-controller (half #1) and never publishes tenant.deleted,
+// so the org-tenants dir survives and the Kustomization perpetually recreates
+// the ns + HRs. The fix makes the org-controller finalizer ALSO publish
+// tenant.deleted so BOTH halves fire on ANY Org-CR delete.
+//
+// These tests pin the three behaviors the fix must guarantee:
+//   1. The delete branch publishes a tenant.deleted{slug} event via the
+//      injected publisher.
+//   2. With a nil publisher (no NATS), the teardown still completes without
+//      error (degrade to pre-#5364 behavior).
+//   3. A publish error does NOT block finalizer removal (the CR still
+//      tombstones — a NATS hiccup must never wedge the delete).
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// fakeTenantEventPublisher records every Publish call so the tests can assert
+// the subject + envelope. When err is set, Publish returns it (to exercise the
+// best-effort / non-blocking path). Implements controller.TenantEventPublisher.
+type fakeTenantEventPublisher struct {
+	mu       sync.Mutex
+	subjects []string
+	events   []*natsbus.Event
+	err      error
+}
+
+func (f *fakeTenantEventPublisher) Publish(_ context.Context, subject string, ev *natsbus.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.subjects = append(f.subjects, subject)
+	f.events = append(f.events, ev)
+	return f.err
+}
+
+func (f *fakeTenantEventPublisher) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.events)
+}
+
+// deleteReq is the reconcile request for the sampleOrg (name == slug == "acme").
+var deleteReq = ctrl.Request{NamespacedName: types.NamespacedName{Name: "acme"}}
+
+// driveToDeletion brings the sampleOrg to steady state (adds the
+// per-org-realm finalizer so the CR is held through deletion), then marks it
+// for deletion. The caller runs the delete-path Reconcile.
+func driveToDeletion(t *testing.T, r *Reconciler) {
+	t.Helper()
+	// PerOrgRealmEnabled=true makes the reconciler add the per-org-realm
+	// finalizer — the single finalizer that holds the CR long enough for the
+	// deletion branch (and our publish) to run. The fakeKeycloak DeleteRealm is
+	// a no-op-safe stub.
+	r.PerOrgRealmEnabled = true
+	reconcileTwice(t, r, "acme")
+	var got orgapi.Organization
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, &got); err != nil {
+		t.Fatalf("get steady: %v", err)
+	}
+	if !containsFinalizer(got.Finalizers, PerOrgRealmFinalizer) {
+		t.Fatalf("precondition: per-org-realm finalizer should hold the CR, got %v", got.Finalizers)
+	}
+	if err := r.Delete(context.Background(), &got); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+// TestReconcile_Delete_PublishesTenantDeleted pins behavior #1: the deletion
+// branch publishes a tenant.deleted event on the canonical subject with the
+// Org slug in both the tenant_id and the {id, slug} payload.
+func TestReconcile_Delete_PublishesTenantDeleted(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	r, _, _ := makeReconciler(t, org)
+	fp := &fakeTenantEventPublisher{}
+	r.TenantEventPublisher = fp
+
+	driveToDeletion(t, r)
+
+	if fp.count() != 0 {
+		t.Fatalf("no publish should occur before the delete-path reconcile, got %d", fp.count())
+	}
+	if _, err := r.Reconcile(context.Background(), deleteReq); err != nil {
+		t.Fatalf("delete reconcile: %v", err)
+	}
+
+	if fp.count() == 0 {
+		t.Fatalf("delete branch must publish tenant.deleted, got 0 publishes")
+	}
+	if fp.subjects[0] != natsbus.SubjectTenantDeleted {
+		t.Errorf("publish subject = %q, want %q", fp.subjects[0], natsbus.SubjectTenantDeleted)
+	}
+	ev := fp.events[0]
+	if ev.Type != "tenant.deleted" {
+		t.Errorf("event type = %q, want tenant.deleted", ev.Type)
+	}
+	if ev.Source != "organization-controller" {
+		t.Errorf("event source = %q, want organization-controller", ev.Source)
+	}
+	if ev.TenantID != "acme" {
+		t.Errorf("event tenant_id = %q, want acme", ev.TenantID)
+	}
+	var payload struct {
+		ID   string `json:"id"`
+		Slug string `json:"slug"`
+	}
+	if err := json.Unmarshal(ev.Data, &payload); err != nil {
+		t.Fatalf("unmarshal event data: %v", err)
+	}
+	if payload.Slug != "acme" {
+		t.Errorf("payload.slug = %q, want acme (the provisioning consumer keys teardown off slug)", payload.Slug)
+	}
+	if payload.ID == "" {
+		t.Errorf("payload.id must be non-empty (envelope shape parity with tenant-service)")
+	}
+}
+
+// TestReconcile_Delete_NilPublisher_NoError pins behavior #2: with NO publisher
+// wired (Catalyst-Zero / NATS_URL unset), the teardown still completes without
+// error and the CR tombstones — degrade to pre-#5364 behavior, never a wedge.
+func TestReconcile_Delete_NilPublisher_NoError(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	r, _, _ := makeReconciler(t, org)
+	// r.TenantEventPublisher is nil (default).
+
+	driveToDeletion(t, r)
+
+	if _, err := r.Reconcile(context.Background(), deleteReq); err != nil {
+		t.Fatalf("delete reconcile with nil publisher must not error: %v", err)
+	}
+	// The finalizer must have been dropped → the CR is fully deleted.
+	var gone orgapi.Organization
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, &gone); !apierrors.IsNotFound(err) {
+		t.Errorf("CR should tombstone after teardown (finalizer dropped), get err = %v (want NotFound)", err)
+	}
+}
+
+// TestReconcile_Delete_PublishError_DoesNotBlockFinalizer pins behavior #3: a
+// publish failure is best-effort — it is logged + swallowed, the reconcile
+// returns no error, and the finalizer teardown proceeds so the CR tombstones.
+// A NATS hiccup must never strand the CR in Terminating.
+func TestReconcile_Delete_PublishError_DoesNotBlockFinalizer(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	r, _, _ := makeReconciler(t, org)
+	fp := &fakeTenantEventPublisher{err: errors.New("broker unreachable")}
+	r.TenantEventPublisher = fp
+
+	driveToDeletion(t, r)
+
+	if _, err := r.Reconcile(context.Background(), deleteReq); err != nil {
+		t.Fatalf("publish error must not fail the reconcile: %v", err)
+	}
+	if fp.count() == 0 {
+		t.Fatalf("the publish must have been ATTEMPTED before the finalizer dropped, got 0")
+	}
+	// Despite the publish error, the finalizer teardown proceeded → CR gone.
+	var gone orgapi.Organization
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, &gone); !apierrors.IsNotFound(err) {
+		t.Errorf("CR should tombstone even when publish fails (finalizer must not wedge), get err = %v (want NotFound)", err)
+	}
+}

--- a/core/controllers/pkg/natsbus/publisher.go
+++ b/core/controllers/pkg/natsbus/publisher.go
@@ -1,0 +1,128 @@
+// publisher.go adds the minimal PUBLISH leg to natsbus (#5364).
+//
+// natsbus was subscriber-only: the Group-C controllers CONSUMED
+// catalyst.* envelopes but never emitted any. The organization-controller
+// now needs to PUBLISH a `tenant.deleted` envelope on Org-CR finalizer
+// teardown so the provisioning service's tenant.deleted consumer runs the
+// SECOND half of Org teardown (prune the `org-tenants` gitops dir). See
+// SubjectTenantDeleted in subscriber.go for the split-teardown rationale.
+//
+// The surface deliberately mirrors Subscriber's connect/config style
+// (MaxReconnects=-1, 2s ReconnectWait, 20s PingInterval) and stays narrow:
+//
+//   - NewPublisher(url) → *Publisher, Close() teardown.
+//   - Publisher.Publish(ctx, subject, ev) JSON-marshals ev and publishes it
+//     to subject on the CATALYST_ORG JetStream stream, waiting for the
+//     broker PubAck (bounded by ctx — callers pass a short timeout so a
+//     broker stall cannot wedge them).
+//   - NewEvent(...) mirrors core/services/shared/events.NewEvent so the JSON
+//     wire format is identical (id / type / source / timestamp / tenant_id /
+//     data / metadata). It is re-implemented here (rather than imported) for
+//     the same reason Event is: to keep the controllers module free of a
+//     dependency on core/services/shared/events (which drags in franz-go +
+//     Kafka transports the controllers never touch).
+package natsbus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Publisher holds an open NATS+JetStream connection for PUBLISHING domain
+// events. Construct via NewPublisher; close via Close. Publish is safe for
+// concurrent use (nats.Conn + jetstream.JetStream are goroutine-safe).
+type Publisher struct {
+	nc *nats.Conn
+	js jetstream.JetStream
+}
+
+// NewPublisher opens a NATS connection at url and binds a JetStream client
+// for publishing. Empty url falls back to nats.DefaultURL so unit tests can
+// exercise the package against a local nats-server without env wiring.
+// Connection options mirror Connect (the subscriber leg) exactly.
+//
+// Returns an error if the broker is unreachable; the caller (main.go) is
+// expected to log + continue (the emit-on-finalizer is best-effort — a
+// missing publisher degrades the Org-delete path to its pre-#5364 behavior,
+// it never wedges the controller).
+func NewPublisher(url string) (*Publisher, error) {
+	if url == "" {
+		url = nats.DefaultURL
+	}
+	nc, err := nats.Connect(url,
+		nats.Name("catalyst-controllers-publisher"),
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2*time.Second),
+		nats.PingInterval(20*time.Second),
+		nats.MaxPingsOutstanding(3),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("natsbus: publisher connect %s: %w", url, err)
+	}
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("natsbus: publisher jetstream init: %w", err)
+	}
+	return &Publisher{nc: nc, js: js}, nil
+}
+
+// Publish JSON-marshals ev and publishes it to subject on the JetStream
+// stream that captures it (CATALYST_ORG for catalyst.* subjects), waiting for
+// the broker PubAck. The wait is bounded by ctx: callers pass a short timeout
+// so a broker stall surfaces as a ctx-deadline error the caller can log +
+// swallow rather than blocking indefinitely.
+func (p *Publisher) Publish(ctx context.Context, subject string, ev *Event) error {
+	if p == nil || p.js == nil {
+		return errors.New("natsbus: publisher not initialised")
+	}
+	if subject == "" {
+		return errors.New("natsbus: Publish requires subject")
+	}
+	if ev == nil {
+		return errors.New("natsbus: Publish requires an event")
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("natsbus: marshal event: %w", err)
+	}
+	if _, err := p.js.Publish(ctx, subject, data); err != nil {
+		return fmt.Errorf("natsbus: publish %s: %w", subject, err)
+	}
+	return nil
+}
+
+// Close drains the underlying NATS connection. Idempotent.
+func (p *Publisher) Close() {
+	if p == nil || p.nc == nil {
+		return
+	}
+	_ = p.nc.Drain()
+}
+
+// NewEvent creates an Event with a unique ID and marshals data into the Data
+// field. It mirrors core/services/shared/events.NewEvent so an envelope this
+// controller publishes is byte-compatible with one the tenant-service emits —
+// the provisioning consumer unmarshals both identically.
+func NewEvent(eventType, source, tenantID string, data any) (*Event, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Event{
+		ID:        uuid.New().String(),
+		Type:      eventType,
+		Source:    source,
+		Timestamp: time.Now().UTC(),
+		TenantID:  tenantID,
+		Data:      raw,
+		Metadata:  map[string]string{},
+	}, nil
+}

--- a/core/controllers/pkg/natsbus/subscriber.go
+++ b/core/controllers/pkg/natsbus/subscriber.go
@@ -86,6 +86,20 @@ const (
 	// PR #1633). sandbox-controller subscribes so the per-Sandbox
 	// reconcile loop runs immediately on cart completion.
 	SubjectTenantSandboxRequested = "catalyst.tenant.sandbox_requested"
+
+	// SubjectTenantDeleted is the canonical NATS subject the
+	// organization-controller PUBLISHES on when an Organization CR is being
+	// finalized (#5364). It mirrors the subject core/services/shared/events
+	// derives for the `tenant.deleted` event type (CanonicalSubject) so the
+	// provisioning service's `tenant.deleted` consumer — subscribed to the same
+	// CATALYST_ORG stream — runs the SECOND half of Org teardown (prune the
+	// `org-tenants` gitops dir: the <slug> Namespace manifest + tenant
+	// HelmReleases). The org-controller's own finalizer runs only the FIRST half
+	// (per-Org vCluster Flux + tenant-networking); before #5364 a raw
+	// `kubectl delete organization` never emitted this event (only the
+	// tenant-service's DELETE /api/organizations/{id} route did), so the
+	// org-tenants Kustomization perpetually recreated the ns + HRs.
+	SubjectTenantDeleted = "catalyst.tenant.deleted"
 )
 
 // Event is the JSON envelope on every catalyst.* subject. The shape


### PR DESCRIPTION
## Root cause (proven)

Org teardown is **split across two producers**, and a raw `kubectl delete organization <slug>` fires only one half:

1. **org-controller finalizer** (`organization_controller.go` delete branch) runs `teardownPerOrgFlux` + `teardownTenantNetworking` — prunes the per-Org vCluster Flux (`catalyst-tenant-<slug>-*`) + tenant-networking. **This is the ONLY half a raw CR-delete runs.**
2. **provisioning service's `tenant.deleted` consumer** (`core/services/provisioning/handlers/consumer.go`) prunes the tenant's **`org-tenants` gitops dir** — `RemoveTenantFromParentKustomization` + prune `Generator.TenantDir(slug)` — which is what removes the `<slug>` **Namespace manifest** + the **tenant HelmReleases** (bp-keycloak / bp-newapi / …) from the `org-tenants` Flux Kustomization inventory.

The tenant-service `DeleteOrg` route (`DELETE /api/organizations/{id}`) publishes `tenant.deleted` → half #2 runs. But a raw `kubectl delete organization` **never publishes `tenant.deleted`**, so half #2 never runs → the `org-tenants` gitops dir survives → the `org-tenants` Kustomization **perpetually recreates the ns + HelmReleases**.

**Live proof:** a deleted Org (`beta-corp`) still had its ns + `bp-keycloak`/`bp-newapi` Running 137 min after CR deletion, ns labeled `kustomize.toolkit.fluxcd.io/name: org-tenants`.

## Fix — emit on finalizer

Make the org-controller's finalizer teardown **also publish `tenant.deleted{slug}`** so BOTH halves fire on ANY Org-CR delete.

- **`core/controllers/pkg/natsbus`** (was subscriber-only): add a minimal `Publisher` (`NewPublisher` / `Publish` / `Close`) mirroring the subscriber's connect/config style, a `NewEvent(...)` helper mirroring `core/services/shared/events.NewEvent` (identical JSON envelope), and the `SubjectTenantDeleted = "catalyst.tenant.deleted"` constant.
- **`organization_controller.go`**: publish `tenant.deleted` at the **top of the delete branch** (before dropping any finalizer). Payload `{id, slug}` both set to the Org slug — the consumer keys teardown off `slug`. **BEST-EFFORT + bounded (5s ctx):** a nil publisher (no NATS / Catalyst-Zero) or a publish failure **logs + returns and NEVER blocks finalizer removal**, so a NATS hiccup cannot wedge the CR in `Terminating`. The consumer's git prune is idempotent, so a duplicate publish across finalizer-requeue passes is harmless.
- **`cmd/main.go`**: construct the publisher when `NATS_URL` is set and inject it into the Reconciler; when unset the field stays nil and the emit degrades to a no-op (pre-fix behavior).

Edits are confined to `core/controllers/organization/` + `core/controllers/pkg/natsbus/`. The provisioning consumer + tenant-service (their half already works) are **untouched**.

## Tests

`go build ./...` + `go test ./...` green in `core/controllers/`. New unit tests (`tenant_deleted_emit_5364_test.go`):

1. the delete branch publishes a `tenant.deleted{slug}` event on `catalyst.tenant.deleted` via a fake publisher;
2. with a **nil publisher** (no NATS) the teardown still completes without error and the CR tombstones;
3. a **publish error does NOT block finalizer removal** (the CR still tombstones).

## Needs live verification

On a live env with NATS wired: `kubectl delete organization <slug>` → the `<slug>` ns + tenant HelmReleases (bp-keycloak/bp-newapi/…) are pruned within a reconcile, with **no orphan** (the `org-tenants` Kustomization no longer recreates them).

Refs #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)