### PR TITLE
fix(ci): sandbox-mcp-server builder golang:1.23→1.25-alpine (match go.mod)

### DIFF
--- a/products/sandbox/mcp-server/Dockerfile
+++ b/products/sandbox/mcp-server/Dockerfile
@@ -13,10 +13,10 @@
 # mirroring core/controllers/sandbox/Dockerfile (same Slice-CC1 layout).
 #
 # Two stages:
-#   build  — golang:1.23-alpine
+#   build  — golang:1.25-alpine (must satisfy go.mod `go 1.25.0`)
 #   final  — distroless/static-debian12:nonroot (scratch-equivalent)
 
-FROM docker.io/library/golang:1.23-alpine AS build
+FROM docker.io/library/golang:1.25-alpine AS build
 WORKDIR /repo
 RUN apk add --no-cache git
 


### PR DESCRIPTION
## Problem
`Build sandbox-mcp-server` is red on main since 8b7fc3b9f: `go.mod requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)`.

The break is latent, not introduced by 8b7fc3b9f: go.mod's `go 1.25.0` directive predates it, but Docker layer caching skipped the `go mod download` layer until a COPY'd replace-target (core/controllers) changed checksum and busted the cache.

## Fix
One line: build stage `golang:1.23-alpine` → `golang:1.25-alpine`, comment updated to state the constraint.

## Notes
products/sandbox is LEGACY (superseded by agenity + openova-mcp); retiring the workflow entirely is tracked as a checklist item on #5370 — this PR just restores green CI on main.

Refs #5370

🤖 Generated with [Claude Code](https://claude.com/claude-code)