### PR TITLE
fix(bp-newapi): per-Org CNPG Postgres pod Guaranteed QoS — requests==limits (UAT row 238, Refs #5374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -305,7 +305,10 @@ spec:
       #   remoteRef.key → catalyst/newapi/admin-token (the path catalyst-api's
       #   seedNewapiAdminToken seam writes); fixes the SecretSyncedError that
       #   left unified-rbac's admin-API calls 401'd on a fresh prov.
-      version: 1.4.140
+      # 1.4.141 — #5374 (UAT row 238): chart-owned per-Org CNPG Cluster
+      #   resources requests==limits (500m/512Mi) → the postgres instance
+      #   pod runs Guaranteed QoS (was Burstable, live on hw288 beta-corp).
+      version: 1.4.141
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.140 # lockstep with chart/Chart.yaml (#4885: global.imageRegistry seam for openova-io images)
+  version: 1.4.141 # lockstep with chart/Chart.yaml (#5374: per-Org CNPG requests==limits Guaranteed QoS)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.141 (#5374, UAT row 238): the chart-owned per-Org CNPG Cluster's
+# resources go requests==limits (500m/512Mi) → Guaranteed QoS on the
+# long-running postgres instance pod. Pre-fix the 50m/128Mi requests vs
+# 500m/512Mi limits shape made `bp-newapi-newapi-pg-1` Burstable (live on
+# hw288 Org beta-corp) — evictable under node pressure, and DENIED at
+# admission on host-ns Org tiers whose plan-limits LimitRange pins
+# maxLimitRequestRatio {cpu:1, memory:1} (#4292). CNPG stamps
+# Cluster.spec.resources onto the instance pod (its bootstrap-controller
+# init container inherits the same block), so the values-only pin is
+# sufficient — same fix shape as bp-postgres instance.resources (#4282).
+# Sizing preserved: the prior LIMITS remain the sizing; requests rise to
+# meet them, so plan-quota limits-side accounting is unchanged. Lockstep:
+# 80-newapi.yaml pin + blueprint.yaml + catalog-seed spec.version/
+# source.version → 1.4.141. Refs #5374.
 # 1.4.138 (#4885): honour global.imageRegistry for the openova-io images
 # (newapi-mirror, newapi-sandbox-bridge, services-metering-sidecar) so the
 # self-sovereign-cutover step-07 image pivot reaches those Pods. New
@@ -937,7 +951,7 @@ name: bp-newapi
 #   drift, then hash-gated reload), mounts the OIDC secret, and its Role reads
 #   it. Live-verified on 91dc0591/omantel.biz: DB secret resynced, pod reloaded
 #   "Loaded 1 custom OAuth providers", KC authenticates the corrected secret.
-version: 1.4.140
+version: 1.4.141
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -273,10 +273,21 @@ cnpg:
     # CREATE EXTENSION / additional databases here without forking
     # the chart.
     postInitApplicationSQL: []
+    # #5374 (UAT row 238, live on hw288/beta-corp) — requests == limits
+    # (Guaranteed QoS). CNPG stamps Cluster.spec.resources onto the
+    # long-running instance pod (and its operator-injected
+    # bootstrap-controller init container inherits the same block), so a
+    # requests<limits shape here (the old 50m/128Mi vs 500m/512Mi) made
+    # the per-Org DB pod Burstable — evictable under node pressure, and
+    # DENIED outright on host-ns Org tiers whose plan-limits LimitRange
+    # pins maxLimitRequestRatio {cpu:1, memory:1}. Same fix shape as
+    # bp-postgres instance.resources (#4282). Sizing preserved: the
+    # prior LIMITS stay the sizing; requests rise to meet them, so the
+    # plan-quota limits-side accounting is byte-identical.
     resources:
       requests:
-        cpu: 50m
-        memory: 128Mi
+        cpu: 500m
+        memory: 512Mi
       limits:
         cpu: 500m
         memory: 512Mi

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2322,7 +2322,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.140"
+  version: "1.4.141"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2367,7 +2367,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.140"
+    version: "1.4.141"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## What

UAT row 238 sub-gap fix (live-proven on hw288 via customer Org `beta-corp`): the chart-owned per-Org CNPG Postgres pod ran **Burstable** QoS; row 238 requires **Guaranteed**. This PR pins `cnpg.cluster.resources` requests==limits in `bp-newapi` so the long-running postgres instance pod is Guaranteed.

## Root cause

`platform/newapi/chart/values.yaml` shipped `cnpg.cluster.resources` with requests (50m/128Mi) < limits (500m/512Mi). The CNPG Cluster template copies the block verbatim into `Cluster.spec.resources`, CNPG stamps it onto the instance pod (the operator-injected `bootstrap-controller` init container inherits the same block) → `bp-newapi-newapi-pg-1` Burstable. Neither per-Org emitter overrides it (BSS-door `orgTenantBPNewAPI` + funnel `generateNewAPIHR` both leave `cnpg` unset by design), so the chart default IS the per-Org sizing on every Org.

Same defect class bp-postgres fixed under #4282 (`instance.resources` requests==limits, 500m/512Mi); bp-newapi's chart-owned CNPG never got that treatment.

## Sizing decision (no capacity change)

- The prior **limits stay the sizing** (500m/512Mi); requests rise to meet them — nothing grows or shrinks.
- Per-plan check: **no per-plan CNPG sizing seam exists** — plan tiers are enforced at the Org boundary (`planQuotaTable` ResourceQuota + LimitRange, #4292), so requests==limits at the single chart default is the correct shape, not a new hardcoded per-plan table.
- Plan-quota arithmetic: the pod already charged 500m/512Mi on the limits side and the quota's requests ceiling equals its limits ceiling, so the binding constraint is unchanged.
- Transient CNPG jobs (initdb) are not part of row 238's Guaranteed requirement — only the long-running instance pod must be Guaranteed (it inherits this same block anyway).

## Changes

- `platform/newapi/chart/values.yaml` — `cnpg.cluster.resources` requests 50m/128Mi → 500m/512Mi (== limits), with rationale comment
- `platform/newapi/chart/Chart.yaml` — 1.4.140 → 1.4.141 + changelog entry
- Locksteps (Inviolable Principle #14): `clusters/_template/bootstrap-kit/80-newapi.yaml` pin, `platform/newapi/blueprint.yaml` spec.version, catalog-seed `spec.version` + `source.version` → 1.4.141

## Render-proof (requests==limits)

`helm template platform/newapi/chart --api-versions "postgresql.cnpg.io/v1" --show-only templates/cnpg-cluster.yaml`:

```yaml
  resources:
    limits:
      cpu: 500m
      memory: 512Mi
    requests:
      cpu: 500m
      memory: 512Mi
```

## Gates run locally

- `helm lint platform/newapi/chart` — clean (0 failed)
- All 6 `platform/newapi/chart/tests/*.sh` render tests — PASS
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs in sync)
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)

## Verification plan (issue checklist)

On the next fresh prov / fresh Org after the pin rolls: `kubectl get pod -n <org-ns> bp-newapi-newapi-pg-1 -o jsonpath='{.status.qosClass}'` must print `Guaranteed`. The sibling `bp-wordpress-tenant` gap (memory-only limit; cpu limit currently plan-LimitRange-defaulted) is tracked as a checklist item on the issue — it needs an explicit sizing decision and is deliberately not bundled here.

Refs #5374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

