### PR TITLE
fix(newapi,openbao): region-local producer for catalyst-newapi-admin-token — close M2 region-B SecretSyncedError / DR gap (Refs #5375)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -161,7 +161,13 @@ spec:
       #   not bao's real rc=2, so the "reachable-but-sealed" branch never ran.
       #   Caught by the live region-kill DR proof on hw262 (openbao-0 restarted
       #   sealed, reconciler no-op'd every tick). Now captures rc directly.
-      version: 1.2.63
+      # 1.2.64 — #5375 (UAT M2): auth-bootstrap grants the ESO role the narrow
+      #   external-secrets-push policy (create/update on exactly secret/
+      #   {data,metadata}/catalyst/newapi/admin-token) so bp-newapi 1.4.141's
+      #   region-local admin-token PushSecret can seed every region's vault —
+      #   closes the region-B catalyst-newapi-admin-token SecretSyncedError
+      #   (path never written in region-B; post-promote DR gap).
+      version: 1.2.64
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1280,7 +1280,11 @@ spec:
       #   pg_stat_replication and surfaces status.standbyAvailable on a TRUE
       #   2-region topology (hw287 residual after the #5335 Secret-RBAC fix).
       #   Lockstep w/ Chart.yaml + 16b slot 0.2.22.
-      version: 1.4.1213
+      # 1.4.1214 — #5375 (UAT M2): catalog-seed pins bp-newapi 1.4.143 +
+      #   bp-openbao 1.2.64 (region-local catalyst-newapi-admin-token
+      #   producer pair — closes the region-B SecretSyncedError DR gap).
+      #   Lockstep w/ Chart.yaml (pin-sync gate).
+      version: 1.4.1214
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -308,7 +308,12 @@ spec:
       # 1.4.141 — #5374 (UAT row 238): chart-owned per-Org CNPG Cluster
       #   resources requests==limits (500m/512Mi) → the postgres instance
       #   pod runs Guaranteed QoS (was Burstable, live on hw288 beta-corp).
-      version: 1.4.142
+      # 1.4.143 — #5375 (UAT M2): region-local admin-token PushSecret seeds
+      #   catalyst/newapi/admin-token from the local bridge ADMIN_SECRET so the
+      #   ExternalSecret above resolves in region-B too (catalyst-api's #4477
+      #   seed is primary-only; each region runs its own OpenBao). Pairs with
+      #   bp-openbao 1.2.64 (external-secrets-push policy).
+      version: 1.4.143
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.142 # lockstep with chart/Chart.yaml (#5374: per-Org CNPG requests==limits Guaranteed QoS)
+  version: 1.4.143 # lockstep with chart/Chart.yaml (#5374 Guaranteed QoS; #5375: region-local admin-token PushSecret closes the M2 region-B SecretSyncedError / DR gap)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -951,7 +951,20 @@ name: bp-newapi
 #   drift, then hash-gated reload), mounts the OIDC secret, and its Role reads
 #   it. Live-verified on 91dc0591/omantel.biz: DB secret resynced, pod reloaded
 #   "Loaded 1 custom OAuth providers", KC authenticates the corrected secret.
-version: 1.4.142
+# 1.4.143 — #5375 (UAT row M2): REGION-LOCAL producer for the OpenBao path the
+#   catalyst-newapi-admin-token ExternalSecret reads. New templates/admin-token-
+#   pushsecret.yaml renders an ESO PushSecret that seeds `catalyst/newapi/
+#   admin-token` (property ADMIN_API_TOKEN) from the region-local token-signing-
+#   key Secret's ADMIN_SECRET via the SAME vault-region1 ClusterSecretStore. The
+#   only prior producer — catalyst-api's #4477 seed — runs solely in the primary
+#   region, and each region runs its own OpenBao, so on every 2-region prov
+#   region-B's ExternalSecret was permanently SecretSyncedError ("could not get
+#   secret data from provider", path absent in region-B's vault; live hw285-
+#   hw288) → a post-region-kill promote had NO NewAPI admin bearer (latent DR
+#   gap). Cross-region replication would be WRONG (the bearer must byte-match
+#   the REGION-LOCAL bridge ADMIN_SECRET), so the fix is the region-local
+#   producer. Pairs with bp-openbao 1.2.64 (external-secrets-push policy grant).
+version: 1.4.143
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-token-pushsecret.yaml
+++ b/platform/newapi/chart/templates/admin-token-pushsecret.yaml
@@ -1,0 +1,106 @@
+{{- /*
+PushSecret — REGION-LOCAL producer of `catalyst/newapi/admin-token` (#5375,
+UAT row M2; Refs #4477 #4915 #4877).
+
+ROOT CAUSE this closes (live-proven hw285/hw286/hw287/hw288): the OpenBao path
+the `catalyst-newapi-admin-token` ExternalSecret (templates/external-secret.yaml)
+reads is written ONLY by catalyst-api's seedNewapiAdminToken seam (#4477) +
+its #4877 startup/periodic reconciler — and catalyst-api runs ONLY in the
+PRIMARY region (bp-catalyst-platform is primary-suspended in region-B until a
+DR promote). Each region runs its OWN OpenBao (region-local raft, no stretched
+cluster — 08-openbao.yaml / SECURITY.md §5), so on a 2-region prov the path
+NEVER exists in region-B's vault → region-B's ExternalSecret is permanently
+`SecretSyncedError: could not get secret data from provider` → after a
+region-A loss + promote, the promoted catalyst-api's unified-rbac has NO
+NewAPI admin bearer and per-user-key issuance 401s (the original #4477 fault
+resurfacing exactly when DR needs it).
+
+WHY a PushSecret and NOT cross-region replication of region-A's value: the
+token's contract (#4477) is that it byte-matches the REGION-LOCAL sandbox-
+bridge's ADMIN_SECRET (templates/sandbox-token-signing-key-secret.yaml — a
+per-cluster random, lookup-persisted Secret; the bridge validates with
+subtle.ConstantTimeCompare). Region-A's bytes are NOT region-B's bytes, so a
+replicated value would 401 against region-B's bridge. The producer must be
+region-local — the exact pattern the sibling `newapi-oidc` secret already
+uses (region-local bp-sso-bridge → region-local OpenBao → region-local ESO).
+
+This PushSecret renders WITH the app (renderApp — the token-signing-key
+source Secret is app-side and PushSecret selectors are same-namespace-only),
+so EVERY region that installs newapi seeds its OWN vault with its OWN bridge
+ADMIN_SECRET via the SAME ClusterSecretStore the read-path uses. Level-
+triggered (refreshInterval): self-heals ordering races and follows a signing-
+key rotation. In the primary region it converges byte-identically with
+catalyst-api's idempotent seed (both source the same Secret bytes): ESO's
+vault provider no-ops when the remote property already matches, and the #4877
+reconciler only writes when the path is absent — no churn, no fight.
+
+Write authorisation: the ESO auth role carries the `external-secrets-push`
+policy (platform/openbao/chart/templates/auth-bootstrap-job.yaml, #5375) —
+create/update scoped to exactly this one KV path.
+
+Capabilities gate: PushSecret is external-secrets.io/v1alpha1 (shipped by the
+same bp-external-secrets CRD install as the v1beta1 ExternalSecret). Same
+cold-install rationale as external-secret.yaml (#190 pattern): never render a
+kind whose CRD is not yet registered.
+
+Per docs/PRINCIPLES.md #4 (never hardcode), every knob (enabled,
+refreshInterval, updatePolicy, sourceKey) is operator-tunable via
+`catalystIntegration.pushSecret.*`; the store ref + remote path deliberately
+REUSE `catalystIntegration.externalSecret.*` so push- and read-path can never
+drift apart.
+*/ -}}
+{{- $ci := .Values.catalystIntegration | default dict -}}
+{{- $es := $ci.externalSecret | default dict -}}
+{{- $push := $ci.pushSecret | default dict -}}
+{{- $pushEnabled := true -}}
+{{- if hasKey $push "enabled" -}}{{- $pushEnabled = $push.enabled -}}{{- end -}}
+{{- /* Source Secret name — SAME precedence as the Deployment / sandboxBridgeEnv:
+   explicit existingSecret > chart auto-provisioned <release>-token-signing-key.
+   autoProvision=false with no existingSecret ⇒ no source ⇒ skip render. */ -}}
+{{- $tk := .Values.sandboxTokenSigningKey | default dict -}}
+{{- $srcSecret := $tk.existingSecret -}}
+{{- if and (not $srcSecret) (default true $tk.autoProvision) -}}
+{{- $srcSecret = default (printf "%s-token-signing-key" (include "bp-newapi.fullname" .)) $tk.autoSecretName -}}
+{{- end -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") $ci.enabled $pushEnabled $srcSecret (.Capabilities.APIVersions.Has "external-secrets.io/v1alpha1") -}}
+{{- $store := $es.secretStoreRef | default dict -}}
+{{- $remote := $es.remoteRef | default dict -}}
+{{- $secretName := $ci.existingSecret | default "catalyst-newapi-admin-token" -}}
+{{- $remoteKey := $remote.key | default "" -}}
+{{- if not $remoteKey -}}
+{{- fail "catalystIntegration.pushSecret.enabled=true but catalystIntegration.externalSecret.remoteRef.key is empty — supply the OpenBao path in the bootstrap-kit overlay (canonical, cluster-shared: catalyst/newapi/admin-token — the SAME path the catalyst-newapi-admin-token ExternalSecret reads, #4477/#5375)" -}}
+{{- end -}}
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: {{ printf "%s-push" $secretName | quote }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: admin-token-push
+spec:
+  refreshInterval: {{ $push.refreshInterval | default "1h" | quote }}
+  secretStoreRefs:
+    - kind: {{ $store.kind | default "ClusterSecretStore" | quote }}
+      name: {{ $store.name | default "vault-region1" | quote }}
+  # Replace: a rotation of the token-signing-key Secret propagates to the
+  # vault path (and from there through the ExternalSecret + reflector mirror
+  # to unified-rbac) on the next refresh — the same self-heal contract as the
+  # #4477 promote-tick resync. ESO skips the write when the remote property
+  # already equals the source value, so steady state is read-only.
+  updatePolicy: {{ $push.updatePolicy | default "Replace" | quote }}
+  # None: never delete the remote path — catalyst-api's #4877 reconciler and
+  # the read-side ExternalSecret both treat it as durable state.
+  deletionPolicy: None
+  selector:
+    secret:
+      name: {{ $srcSecret | quote }}
+  data:
+    - match:
+        # ADMIN_SECRET is the bearer the sandbox-bridge validates
+        # (sandbox-token-signing-key-secret.yaml) — the source-of-truth
+        # value #4477 requires at the remote path.
+        secretKey: {{ $push.sourceKey | default "ADMIN_SECRET" | quote }}
+        remoteRef:
+          remoteKey: {{ $remoteKey | quote }}
+          property: {{ $remote.property | default "ADMIN_API_TOKEN" | quote }}
+{{- end }}

--- a/platform/newapi/chart/tests/admin-token-pushsecret-render.sh
+++ b/platform/newapi/chart/tests/admin-token-pushsecret-render.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# bp-newapi — admin-token PushSecret render audit (#5375, UAT row M2).
+#
+# Verifies the region-local producer of the `catalyst/newapi/admin-token`
+# OpenBao path: a PushSecret that seeds the vault from the chart's
+# token-signing-key Secret's ADMIN_SECRET, so the catalyst-newapi-admin-token
+# ExternalSecret resolves in EVERY region — including region-B, where the
+# only other producer (catalyst-api's #4477 seed) never runs and whose
+# region-local vault therefore never held the path (live-proven
+# SecretSyncedError on hw285-hw288; latent DR gap).
+#
+# Why this guard: the CI default-values smoke (blueprint-release.yaml) renders
+# WITHOUT --api-versions, so the PushSecret's external-secrets.io/v1alpha1
+# capability gate keeps it out of the smoke output — a regression in the
+# template (gate condition, wrong remoteKey/property, wrong source Secret)
+# would slip through smoke and surface only on a fresh 2-region prov as the
+# M2 SecretSyncedError.
+#
+# Cases:
+#   1. Capability-enabled render — PushSecret present; remoteKey + property
+#      match the ExternalSecret's read contract; store ref = the SAME
+#      ClusterSecretStore the ExternalSecret reads; selector names the chart's
+#      auto-provisioned token-signing-key Secret; sourceKey ADMIN_SECRET.
+#   2. CRD-absent render (no --api-versions) — NO PushSecret (cold-install
+#      safety, same pattern as the ExternalSecret's v1beta1 gate).
+#   3. pushSecret.enabled=false — NO PushSecret.
+#   4. sandboxTokenSigningKey.existingSecret override — selector follows the
+#      operator-supplied Secret name (same precedence as the Deployment).
+#   5. Empty remoteRef.key with the CRD present — render FAILS loudly (the
+#      push may never silently target a different path than the read side).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+overlay_values=$(mktemp)
+trap 'rm -f "$overlay_values"' EXIT
+# Mirrors the bootstrap-kit overlay at slot 80 (minus cluster creds; masterKey
+# mode so no Keycloak issuer is needed for a smoke render).
+cat > "$overlay_values" <<'EOF'
+sovereignFQDN: smoke.omani.works
+auth:
+  adminUI:
+    mode: masterKey
+database:
+  existingSecret: test-dsn
+catalystIntegration:
+  enabled: true
+  externalSecret:
+    enabled: true
+    remoteRef:
+      key: catalyst/newapi/admin-token
+      property: ADMIN_API_TOKEN
+EOF
+
+api_versions="external-secrets.io/v1alpha1"
+
+# ── Case 1: capability-enabled render — PushSecret present + correct ─────
+echo "[bp-newapi] Case 1: PushSecret renders with the read-path's remote contract"
+out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" --api-versions "$api_versions" 2>&1)
+echo "$out" | grep -q "kind: PushSecret" || {
+  echo "FAIL: no PushSecret rendered with external-secrets.io/v1alpha1 capability present"; exit 1; }
+echo "$out" | grep -q 'remoteKey: "catalyst/newapi/admin-token"' || {
+  echo "FAIL: PushSecret remoteKey does not match the ExternalSecret read path"; exit 1; }
+echo "$out" | grep -q 'property: "ADMIN_API_TOKEN"' || {
+  echo "FAIL: PushSecret property is not ADMIN_API_TOKEN"; exit 1; }
+echo "$out" | grep -q 'name: "vault-region1"' || {
+  echo "FAIL: PushSecret does not target the vault-region1 ClusterSecretStore default"; exit 1; }
+echo "$out" | grep -q 'secretKey: "ADMIN_SECRET"' || {
+  echo "FAIL: PushSecret does not push the bridge ADMIN_SECRET"; exit 1; }
+# fullname for release `smoke` + chart bp-newapi = smoke-bp-newapi.
+echo "$out" | grep -q 'name: "smoke-bp-newapi-token-signing-key"' || {
+  echo "FAIL: PushSecret selector does not name the chart's auto-provisioned token-signing-key Secret"; exit 1; }
+echo "$out" | grep -q 'deletionPolicy: None' || {
+  echo "FAIL: PushSecret deletionPolicy must be None (remote path is durable state)"; exit 1; }
+echo "  ok"
+
+# ── Case 2: CRD absent — no PushSecret ───────────────────────────────────
+echo "[bp-newapi] Case 2: no PushSecret without the v1alpha1 capability (cold-install safety)"
+out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" 2>&1)
+if echo "$out" | grep -q "kind: PushSecret"; then
+  echo "FAIL: PushSecret rendered without the external-secrets.io/v1alpha1 CRD registered"; exit 1
+fi
+echo "  ok"
+
+# ── Case 3: pushSecret.enabled=false — no PushSecret ─────────────────────
+echo "[bp-newapi] Case 3: catalystIntegration.pushSecret.enabled=false suppresses the PushSecret"
+out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" \
+  --set catalystIntegration.pushSecret.enabled=false \
+  --api-versions "$api_versions" 2>&1)
+if echo "$out" | grep -q "kind: PushSecret"; then
+  echo "FAIL: PushSecret rendered despite pushSecret.enabled=false"; exit 1
+fi
+echo "  ok"
+
+# ── Case 4: existingSecret override follows the operator Secret ──────────
+echo "[bp-newapi] Case 4: sandboxTokenSigningKey.existingSecret overrides the selector"
+out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" \
+  --set sandboxTokenSigningKey.existingSecret=operator-signing-key \
+  --api-versions "$api_versions" 2>&1)
+echo "$out" | grep -q 'name: "operator-signing-key"' || {
+  echo "FAIL: PushSecret selector does not follow sandboxTokenSigningKey.existingSecret"; exit 1; }
+echo "  ok"
+
+# ── Case 5: empty remoteRef.key fails loudly with the CRD present ────────
+echo "[bp-newapi] Case 5: empty externalSecret.remoteRef.key fails the render (no silent path drift)"
+if out=$("$helm" template smoke "$chart_dir" \
+  --set sovereignFQDN=smoke.omani.works \
+  --set auth.adminUI.mode=masterKey \
+  --set database.existingSecret=test-dsn \
+  --set catalystIntegration.externalSecret.enabled=false \
+  --api-versions "$api_versions" 2>&1); then
+  echo "FAIL: render succeeded with pushSecret enabled but remoteRef.key empty"; exit 1
+fi
+echo "$out" | grep -q "remoteRef.key is empty" || {
+  echo "FAIL: render failed but not with the expected remoteRef.key guidance"; exit 1; }
+echo "  ok"
+
+echo "[bp-newapi] admin-token-pushsecret-render: ALL CASES PASSED"

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -824,6 +824,31 @@ catalystIntegration:
       # `property` is the JSON field inside the OpenBao secret holding
       # the bearer token used by the Catalyst signup hook (ADR-0003 §3.2).
       property: "ADMIN_API_TOKEN"
+  # ─── Region-local admin-token producer (#5375, UAT row M2) ──────────────
+  # PushSecret (templates/admin-token-pushsecret.yaml) that seeds the OpenBao
+  # path the ExternalSecret above reads, FROM the region-local token-signing-
+  # key Secret's ADMIN_SECRET. Closes the M2 DR gap: catalyst-api's #4477
+  # seed runs only in the primary region, and each region runs its own
+  # OpenBao, so without this region-B's catalyst-newapi-admin-token
+  # ExternalSecret stays SecretSyncedError forever (path absent in region-B's
+  # vault) and a post-region-kill promote has no NewAPI admin bearer. The
+  # push value is deliberately REGION-LOCAL — it must byte-match the local
+  # sandbox-bridge's ADMIN_SECRET (subtle.ConstantTimeCompare), so
+  # replicating region-A's value cross-region would 401 in region-B.
+  # Store ref + remote path reuse externalSecret.* above (never drift).
+  pushSecret:
+    # Default ON wherever the app renders. The template additionally gates on
+    # the external-secrets.io/v1alpha1 CRD being registered (cold-install
+    # safety, same pattern as the ExternalSecret's v1beta1 gate).
+    enabled: true
+    # Reconcile cadence; also the max lag for a token-signing-key rotation to
+    # reach the vault path. ESO skips the write when the remote value already
+    # matches, so steady state costs one read per interval.
+    refreshInterval: "1h"
+    # Replace keeps the vault path following the live bridge secret.
+    updatePolicy: "Replace"
+    # Key inside the token-signing-key Secret holding the bridge bearer.
+    sourceKey: "ADMIN_SECRET"
 # ─── External-Secrets webhook readiness gate (Fix #138, prov #20) ────────
 # Pre-install/pre-upgrade hook that polls the external-secrets validating-
 # admission webhook until it serves a structured response (HTTP 200/400/

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.63  # lockstep with chart/Chart.yaml (#4879 snapshot-fetch: NoSuchBucket → graceful skip, not hard Job failure)
+  version: 1.2.64  # lockstep with chart/Chart.yaml (#5375: external-secrets-push policy so bp-newapi's region-local admin-token PushSecret can seed every region's vault)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -228,7 +228,18 @@ name: bp-openbao
 #   entity joined the sovereign-admins external group (direct_group_ids). Only
 #   the sso-configure reconcile.sh ROLE_PAYLOAD changes (+ the chart bump that
 #   rolls the Deployment per the #3374 checksum); no other template moves.
-version: 1.2.63
+# 1.2.64 — #5375 (UAT row M2): auth-bootstrap grants the ESO auth role a NARROW
+#   `external-secrets-push` policy — create/update/read on exactly
+#   `secret/{data,metadata}/catalyst/newapi/admin-token` — so bp-newapi's new
+#   admin-token PushSecret (bp-newapi 1.4.141) can seed that path in EVERY
+#   region's vault. Closes the region-B DR gap: the only prior producer
+#   (catalyst-api's #4477 seed) is primary-region-only and each region runs its
+#   own OpenBao, so region-B's catalyst-newapi-admin-token ExternalSecret was
+#   permanently SecretSyncedError (path never written; live hw285-hw288). The
+#   broad `secret/data/*` ESO grant stays read-only. On already-provisioned
+#   envs the auth-bootstrap hook exits 0 (root token revoked after first run) —
+#   the grant lands on the next fresh prov per the release-train lifecycle.
+version: 1.2.64
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/auth-bootstrap-job.yaml
+++ b/platform/openbao/chart/templates/auth-bootstrap-job.yaml
@@ -380,7 +380,8 @@ spec:
               # ─── ESO read-policy ────────────────────────────────────────
               # Read access to all keys under $KV_MOUNT_PATH. ESO does NOT
               # write — Catalyst rotation jobs hold the writer policy
-              # separately.
+              # separately. (Sole exception: the single-path push grant in
+              # external-secrets-push below, #5375.)
               cat <<EOF | bao policy write external-secrets-read -
               path "$KV_MOUNT_PATH/data/*" {
                 capabilities = ["read", "list"]
@@ -390,12 +391,36 @@ spec:
               }
               EOF
 
+              # ─── #5375 (UAT M2) ESO push-policy: region-local newapi admin-token ─
+              # bp-newapi renders a PushSecret (platform/newapi/chart/templates/
+              # admin-token-pushsecret.yaml) that seeds `$KV_MOUNT_PATH/catalyst/
+              # newapi/admin-token` (property ADMIN_API_TOKEN) from the REGION-
+              # LOCAL sandbox-bridge ADMIN_SECRET, so the catalyst-newapi-admin-
+              # token ExternalSecret resolves in EVERY region. Root cause it
+              # closes: the only other producer — catalyst-api's #4477 seed —
+              # runs solely in the PRIMARY region, and each region runs its OWN
+              # OpenBao (region-local raft, no stretched cluster), so region-B's
+              # vault never held the path → region-B ES permanently
+              # SecretSyncedError → a post-region-kill promote had NO NewAPI
+              # admin bearer (latent DR gap, live-proven hw285-hw288). NARROW
+              # grant: exactly ONE KV path, create/update only (+ the matching
+              # metadata path for ESO's managed-by custom-metadata stamp). The
+              # broad `secret/data/*` tree stays read-only for ESO.
+              cat <<EOF | bao policy write external-secrets-push -
+              path "$KV_MOUNT_PATH/data/catalyst/newapi/admin-token" {
+                capabilities = ["create", "update", "read"]
+              }
+              path "$KV_MOUNT_PATH/metadata/catalyst/newapi/admin-token" {
+                capabilities = ["create", "update", "read"]
+              }
+              EOF
+
               # ─── Bind role $AUTH_ROLE to the ESO ServiceAccount ─────────
               echo "[openbao-auth-bootstrap] writing auth/$AUTH_MOUNT_PATH/role/$AUTH_ROLE bound to $ESO_SA_NAMESPACE/$ESO_SA_NAME"
               bao write auth/$AUTH_MOUNT_PATH/role/$AUTH_ROLE \
                 bound_service_account_names=$ESO_SA_NAME \
                 bound_service_account_namespaces=$ESO_SA_NAMESPACE \
-                policies=external-secrets-read \
+                policies=external-secrets-read,external-secrets-push \
                 ttl=$TOKEN_TTL \
                 max_ttl=$TOKEN_MAX_TTL
 

--- a/platform/openbao/chart/tests/eso-push-policy-render.sh
+++ b/platform/openbao/chart/tests/eso-push-policy-render.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# bp-openbao — ESO push-policy render audit (#5375, UAT row M2).
+#
+# The auth-bootstrap Job must grant the ESO auth role a NARROW write policy
+# (`external-secrets-push`) on exactly `secret/{data,metadata}/catalyst/
+# newapi/admin-token`, so bp-newapi's admin-token PushSecret (the REGION-
+# LOCAL producer that closes the M2 region-B SecretSyncedError / DR gap) can
+# seed the path in every region's vault. Guard rails this test enforces:
+#
+#   1. The push policy renders in the auth-bootstrap args with BOTH the data
+#      and metadata grants for the single canonical path.
+#   2. The ESO role attaches BOTH policies (read + push) — a regression that
+#      drops either silently re-opens M2 (push 403s) or breaks every
+#      ExternalSecret (reads 403).
+#   3. The broad ESO read policy stays READ-ONLY — no create/update leaks
+#      into the `secret/data/*` tree grant.
+#
+# The auth-bootstrap Job renders only when autoUnseal.enabled — mirrored from
+# the Catalyst overlay (08-openbao.yaml).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+out=$("$helm" template openbao "$chart_dir" \
+  --set autoUnseal.enabled=true 2>&1)
+
+echo "[bp-openbao] Case 1: external-secrets-push policy present with both path grants"
+echo "$out" | grep -q "bao policy write external-secrets-push" || {
+  echo "FAIL: auth-bootstrap does not write the external-secrets-push policy"; exit 1; }
+# -F: the rendered script text contains the LITERAL string $KV_MOUNT_PATH
+# (shell expansion happens at Job runtime, not render time).
+# shellcheck disable=SC2016
+echo "$out" | grep -qF '"$KV_MOUNT_PATH/data/catalyst/newapi/admin-token"' || {
+  echo "FAIL: push policy lacks the data-path grant for catalyst/newapi/admin-token"; exit 1; }
+# shellcheck disable=SC2016
+echo "$out" | grep -qF '"$KV_MOUNT_PATH/metadata/catalyst/newapi/admin-token"' || {
+  echo "FAIL: push policy lacks the metadata-path grant for catalyst/newapi/admin-token"; exit 1; }
+echo "  ok"
+
+echo "[bp-openbao] Case 2: ESO role attaches read + push policies"
+echo "$out" | grep -q "policies=external-secrets-read,external-secrets-push" || {
+  echo "FAIL: ESO role does not attach external-secrets-read,external-secrets-push"; exit 1; }
+echo "  ok"
+
+echo "[bp-openbao] Case 3: broad ESO read grant stays read-only"
+# The external-secrets-read policy block must not gain write capabilities on
+# the wildcard tree. Extract the block between its heredoc markers and assert
+# no create/update appears inside it.
+read_policy_block=$(echo "$out" | sed -n '/bao policy write external-secrets-read -/,/^ *EOF$/p')
+[ -n "$read_policy_block" ] || {
+  echo "FAIL: could not locate the external-secrets-read policy block"; exit 1; }
+if echo "$read_policy_block" | grep -qE '"(create|update|delete)"'; then
+  echo "FAIL: external-secrets-read policy gained write capabilities on the broad tree"; exit 1
+fi
+echo "  ok"
+
+echo "[bp-openbao] eso-push-policy-render: ALL CASES PASSED"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3564,7 +3564,14 @@ name: bp-catalyst-platform
 #   topology (hw287 residual after the #5335 Secret-RBAC fix — the probe could
 #   read the cert but the connection was still NetworkPolicy-dropped). Bootstrap-
 #   kit slot-13 pin bumped in lockstep (pin-sync gate). Lockstep w/ 16b slot 0.2.22.
-version: 1.4.1213
+# 1.4.1214 — #5375 (UAT M2): catalog-seed pins bp-newapi 1.4.142 -> 1.4.143 +
+#   bp-openbao 1.2.63 -> 1.2.64 (spec.version display labels + delivery
+#   source.version, #4988 lockstep rule) — the pair that gives the
+#   catalyst-newapi-admin-token OpenBao path a REGION-LOCAL producer
+#   (bp-newapi PushSecret + bp-openbao external-secrets-push policy), closing
+#   the region-B SecretSyncedError / post-promote DR gap. Bootstrap-kit
+#   slot-13 pin bumped in lockstep (pin-sync gate).
+version: 1.4.1214
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2322,7 +2322,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.141"
+  version: "1.4.143"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2367,7 +2367,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.141"
+    version: "1.4.143"
   topology:
     supported:
     - active-passive
@@ -3422,7 +3422,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.63"
+  version: "1.2.64"
   visibility: unlisted
   card:
     title: "OpenBao"
@@ -3447,7 +3447,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openbao
-    version: "1.2.63"
+    version: "1.2.64"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## What this closes

UAT row **M2**'s remaining ◑ (region-B leg), live-proven on hw285/hw286/hw287/hw288: region-B's `catalyst-newapi-admin-token` ExternalSecret is permanently `Ready=False / SecretSyncedError: could not get secret data from provider`, backing Secret never materialises, admin-promote vacuous — a **latent DR gap** (post-region-kill promote has no NewAPI admin bearer; unified-rbac per-user-key issuance 401s, the original #4477 fault resurfacing exactly when DR needs it).

## Verified root cause

1. **Each region runs its own OpenBao** (`08-openbao.yaml`: region-local raft, no stretched cluster; the #3492 non-voter join is default-OFF and its documented cloud-init activation — `SOVEREIGN_OPENBAO_RAFT_CONFIG` — is wired nowhere: `grep -r SOVEREIGN_OPENBAO_RAFT_CONFIG infra/ products/` = 0 hits). Region-B's vault is initialised region-locally; region-B ESO's k8s-auth login against it **works** (the sibling `newapi-oidc` ES proves the region-B ESO→vault chain — its producer bp-sso-bridge runs region-locally in both regions).
2. **The only producer of `secret/catalyst/newapi/admin-token` is region-A-only**: catalyst-api's `seedNewapiAdminToken` (#4477) + the #4877 reconciler — and catalyst-api runs only in the primary (bp-catalyst-platform primary-suspended in region-B). Nothing ever writes the path into region-B's vault → the ES reads a nonexistent path → the exact live error.
3. **Why it matters despite the shared keycloak DB (#4915)**: the ES does not feed Keycloak users (replicated via bp-cnpg-pair); it feeds the ADMIN_API_TOKEN bearer unified-rbac presents to NewAPI's admin API (ADR-0003 §3.2), which must byte-match the **region-local** sandbox-bridge `ADMIN_SECRET` (`newapi-bp-newapi-token-signing-key` — per-cluster random, lookup-persisted; validated with `subtle.ConstantTimeCompare`).
4. **Cross-region replication would be the wrong fix**: region-A's bytes ≠ region-B's bridge bytes → a replicated value 401s in region-B. The producer must be region-local.

## The fix (region-local producer, same ESO ClusterSecretStore path as the read side)

- **bp-newapi 1.4.141** — `templates/admin-token-pushsecret.yaml`: ESO `PushSecret` (external-secrets.io/v1alpha1, CRD-capability-gated like the sibling ExternalSecret) pushing the chart's token-signing-key `ADMIN_SECRET` → `vault-region1` at `catalyst/newapi/admin-token` property `ADMIN_API_TOKEN`. Store ref + remote path deliberately reuse `catalystIntegration.externalSecret.*` so push- and read-path can never drift. Renders wherever the app renders → each region's ESO seeds its own vault with its own bridge secret. Level-triggered (1h refresh): self-heals ordering races + follows signing-key rotation. In the primary it converges byte-identically with catalyst-api's seed (ESO no-ops on equal remote value; the #4877 reconciler writes only when absent) — no churn, no fight. New `tests/admin-token-pushsecret-render.sh` (5 cases: contract render, CRD-absent skip, enabled=false, existingSecret override, empty-remoteKey loud fail).
- **bp-openbao 1.2.64** — auth-bootstrap grants the ESO auth role a **narrow** `external-secrets-push` policy: create/update/read on exactly `secret/{data,metadata}/catalyst/newapi/admin-token`. The broad `secret/data/*` ESO grant stays read-only (new `tests/eso-push-policy-render.sh` asserts all three: policy present, role attaches read+push, broad grant still read-only). Note: on already-provisioned envs the auth-bootstrap hook exits 0 (root token revoked after first run) — the grant lands on the next fresh prov, consistent with the one-env-at-a-time release-train lifecycle; no live mutation in this PR.
- **Lockstep**: `blueprint.yaml` ×2, bootstrap-kit slot pins 80/08, catalog-seed `spec.version` + delivery pins for both charts (#4988 rule), bp-catalyst-platform `1.4.1213` + slot-13 pin (pin-sync gate).

## DR acceptance criterion (for the next fresh 2-region prov walk)

Region-B `kubectl -n newapi get externalsecret catalyst-newapi-admin-token` → `SecretSynced / Ready=True`; backing Secret non-empty with `ADMIN_API_TOKEN` == region-B's `newapi-bp-newapi-token-signing-key.ADMIN_SECRET`; region-A unchanged. Then a post-region-kill promote comes up with a working NewAPI admin bearer (non-vacuous).

## Gates run locally

- 20/20 chart test scripts PASS (7 bp-newapi incl. new, 13 bp-openbao incl. new)
- `helm lint` PASS ×3 (bp-newapi, bp-openbao, bp-catalyst-platform)
- default-values `helm template` smoke PASS ×2 (mirrors the CI smoke — no `--api-versions`, PushSecret correctly gated out)
- `scripts/check-bootstrap-kit-pin-sync.sh` PASS
- `shellcheck` clean on both new test scripts

Refs #5375
Refs #4477 #4915 #4986

🤖 Generated with [Claude Code](https://claude.com/claude-code)
