### PR TITLE
fix(#5358): guacamole SSO off the implicit flow — bp-oidc-gate code flow + header auth (bp-guacamole 0.2.30)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1284,7 +1284,9 @@ spec:
       #   bp-openbao 1.2.64 (region-local catalyst-newapi-admin-token
       #   producer pair — closes the region-B SecretSyncedError DR gap).
       #   Lockstep w/ Chart.yaml (pin-sync gate).
-      version: 1.4.1215
+      # 1.4.1216 — #5358: catalog-seed bp-guacamole 0.2.30 (server-side SSO via
+      #   oidc-gate header mode; kills the implicit-flow nonce replay).
+      version: 1.4.1216
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -188,6 +188,50 @@ spec:
         rootRedirectPath: /oidc/login
         appNativeCallbackPath: /oidc/authorized
 
+      # guacamole (#5358). Guacamole's native guacamole-auth-sso-openid
+      # extension is IMPLICIT-flow-only upstream (response_type=id_token
+      # in the URL fragment, through 1.6.0 and git master) and its SPA
+      # re-submits the fragment token on every route change while the
+      # server-side nonce is single-use — the replay poisoned the fresh
+      # session ("Rejected OpenID token with invalid/old nonce" +
+      # error page, live on hw288; UAT rows 35/115, 4/4 deterministic
+      # under Playwright). No upstream version or config knob fixes it,
+      # so the OIDC leg moves OUT of the browser: this gate instance
+      # runs the authorization-code flow server-side and asserts the
+      # principal to the webapp via X-Forwarded-Email (oauth2-proxy
+      # --pass-user-headers default), consumed by the image-bundled
+      # guacamole-auth-header extension (bp-guacamole 0.2.30
+      # sso.mode=header). The JDBC permission store + #3374 admin-enroll
+      # CronJob are auth-source-agnostic; usernames stay byte-identical
+      # (the openid mode's username claim default was `email`).
+      #
+      # hostname defaults to guacamole.<sovereignFQDN> — the canonical
+      # host slot 52 previously served via the chart's own HTTPRoute
+      # (now suppressed: two HTTPRoutes on one hostname is undefined
+      # routing; a direct route would also bypass the gate and expose
+      # the header-trusting webapp). bp-guacamole 0.2.30 additionally
+      # netpol-guards webapp :8080 ingress to these gate pods only.
+      #
+      # clientId is guacamole-gate, NOT the legacy `guacamole` client:
+      # bp-keycloak's sovereign realm-import still owns `guacamole`
+      # (public/implicit shape for the retired native flow) and
+      # keycloak-config-cli re-applies it on every bp-keycloak deploy —
+      # adopting it here would flap the client between the config-cli
+      # shape and the sso-bridge shape. A fresh confidential client is
+      # minted/owned end-to-end by bp-sso-bridge instead (secret →
+      # OpenBao sso/sovereign/guacamole-gate → ExternalSecret).
+      #
+      # rootRedirectPath: the Guacamole WAR serves under Tomcat's
+      # /guacamole/ context; the bare root is Tomcat's 404 ROOT context
+      # (#3150 landmine). Same Exact-`/`-only 302 the chart's own
+      # rootRedirect rule used to provide — loop-safe: the webapp lives
+      # entirely under /guacamole/ and never redirects back to `/`.
+      - name: guacamole
+        enabled: true
+        clientId: guacamole-gate
+        upstream: http://guacamole-server.guacamole.svc.cluster.local:80
+        rootRedirectPath: /guacamole/
+
       # ── GENERALITY PROOF (#3374 DoD box 10a) ──────────────────────────
       # A brand-new throwaway app gated with ONLY a name + hostname +
       # upstream and NOTHING else — no app-specific redirect, no shim, no

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -183,7 +183,16 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve guacamole (no more "no Application CR").
-      version: 0.2.29
+      # 0.2.30 (#5358): SSO switched to the DEFAULT sso.mode=header — the
+      # slot-13c bp-oidc-gate `guacamole` instance now owns
+      # guacamole.<fqdn> and runs the Keycloak authorization-code flow
+      # server-side; the webapp consumes the gate's X-Forwarded-Email via
+      # guacamole-auth-header. The chart no longer renders its own
+      # HTTPRoute (gate owns the hostname) and the native openid implicit
+      # flow (fragment-replay "invalid/old nonce" on hw288, UAT rows
+      # 35/115) is retired from the canonical path — values below drop
+      # httproute + oidc.issuer accordingly.
+      version: 0.2.30
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole
@@ -242,23 +251,20 @@ spec:
       # opts out per-Sovereign by removing this slot from
       # clusters/<sovereign>/bootstrap-kit/kustomization.yaml.
       enabled: true
+      # #5358 — SSO via the slot-13c bp-oidc-gate `guacamole` instance
+      # (authorization-code flow at the gate + guacamole-auth-header
+      # behind it). The gate's HTTPRoute OWNS guacamole.${SOVEREIGN_FQDN}
+      # (see 13c-bp-oidc-gate.yaml), so this chart renders NO HTTPRoute in
+      # header mode and the former `oidc.issuer` value is retired (the
+      # native guacamole-auth-sso-openid implicit flow replayed its
+      # single-use nonce on every SPA route change — "Rejected OpenID
+      # token with invalid/old nonce" live on hw288, UAT rows 35/115).
+      # `header` is the chart default; pinned here explicitly so the
+      # canonical prov path never drifts on a chart-default change.
+      sso:
+        mode: header
       httproute:
-        enabled: true  # #4291 DE-VCLUSTER — guacamole renders its OWN HTTPRoute natively in host ns `guacamole` (was suppressed by the #3642 host-bridge)
-        # Resolved from the per-Sovereign Kustomize overlay's
-        # SOVEREIGN_FQDN env var, which envsubst materializes when the
-        # bootstrap-kit Kustomization renders.
-        hostname: guacamole.${SOVEREIGN_FQDN}
-      oidc:
-        # Same SOVEREIGN_FQDN substitution. Canonical issuer is the
-        # EXTERNALLY-reachable Keycloak host `auth.<fqdn>` + the `sovereign`
-        # realm (where the catalyst-pin IdP lives). The prior
-        # `keycloak.<fqdn>/realms/catalyst` was stale drift — the `catalyst`
-        # realm was consolidated into `sovereign` (#2744), and `keycloak.`
-        # is the in-cluster host the browser cannot reach (404 at the edge)
-        # → guacamole silent SSO never completed (the OpenID extension built
-        # a redirect to a dead host + dead realm; POST /api/tokens returned
-        # 500). Matches grafana's auth_url. (#3150)
-        issuer: https://auth.${SOVEREIGN_FQDN}/realms/sovereign
+        enabled: false  # #5358 — the slot-13c oidc-gate HTTPRoute owns guacamole.${SOVEREIGN_FQDN}; two HTTPRoutes on one hostname is undefined routing
       recordings:
         # SeaweedFS-CSI is the canonical RWX storageClass for
         # multi-pod session-recording workloads on Sovereigns; see

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.29
+  version: 0.2.30
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -1,5 +1,34 @@
 apiVersion: v2
 name: bp-guacamole
+# 0.2.30 (#5358): SSO moves off the upstream implicit flow — new
+# `guacamole.sso.mode` knob, DEFAULT `header`. Root cause (live on hw288):
+# guacamole-auth-sso-openid is implicit-flow-only (response_type=id_token in
+# the URL fragment) through 1.6.0 AND git master — no released version
+# supports the authorization-code flow (verified against upstream
+# ConfigurationService/AuthenticationProviderService source for 1.5.5, 1.6.0
+# and master) — and the AngularJS SPA re-submits the fragment id_token via
+# updateCurrentToken($location.search()) on EVERY route change while the
+# server-side nonce is strictly single-use (NonceService.isValid removes on
+# first test, 1.6.0 unchanged). The replay poisons the just-created session:
+# "TokenValidationService - Rejected OpenID token with invalid/old nonce" →
+# generic error page + local login form (UAT rows 35/115; 4/4 deterministic
+# under Playwright). No 1.5.x/1.6.x config knob eliminates the replay, so the
+# FIX moves the OIDC leg out of the browser: the Sovereign's bp-oidc-gate
+# (oauth2-proxy, slot 13c) now fronts guacamole.<fqdn> running the
+# authorization-code flow server-side (client secret via bp-sso-bridge →
+# OpenBao → ExternalSecret) and asserts the principal to the webapp via
+# X-Forwarded-Email (oauth2-proxy --pass-user-headers), consumed by the
+# image-bundled guacamole-auth-header extension (HEADER_ENABLED=true) — no
+# id_token ever transits the browser URL. JDBC permission store + the #3374
+# admin-enroll CronJob are auth-source-agnostic and unchanged; usernames stay
+# byte-identical (openid-username-claim-type default was `email`). In header
+# mode the chart renders NO HTTPRoute (the slot-13c gate instance owns the
+# hostname; a direct route would bypass auth) and adds a webapp ingress
+# NetworkPolicy admitting ONLY the oidc-gate pods (header identity is
+# trusted). sso.mode=openid preserves the legacy shape byte-identically for
+# operators fronting guacamole with their own code-flow proxy. Lockstep:
+# 52-bp-guacamole.yaml pin + 13c-bp-oidc-gate.yaml guacamole instance +
+# blueprint.yaml + catalog-seed source.version → 0.2.30. Refs #5358.
 # 0.2.28 (#4885): honour global.imageRegistry for the guacd + webapp openova-io
 # images so the self-sovereign-cutover step-07 image pivot reaches these Pods.
 # _helpers.tpl guacdImage/webappImage now route through a new registryImage
@@ -206,7 +235,7 @@ name: bp-guacamole
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
 # 0.2.26 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 0.2.29
+version: 0.2.30
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/README.md
+++ b/platform/guacamole/chart/README.md
@@ -11,6 +11,26 @@ multi-cluster fan-out).
 See `../README.md` (the `platform/guacamole/README.md`) for the
 architecture diagram + use-case matrix.
 
+## SSO — `guacamole.sso.mode` (#5358)
+
+- **`header` (DEFAULT)** — the Sovereign's `bp-oidc-gate` (oauth2-proxy,
+  bootstrap-kit slot 13c, instance `guacamole`) fronts
+  `guacamole.<fqdn>` and runs the Keycloak **authorization-code flow**
+  server-side; the webapp consumes the gate-injected
+  `X-Forwarded-Email` via the image-bundled `guacamole-auth-header`
+  extension. No `id_token` ever transits the browser URL. In this mode
+  the chart renders **no HTTPRoute** (the gate owns the hostname) and
+  adds an **ingress NetworkPolicy** so only the gate pods reach the
+  webapp `:8080` (header identity is trusted).
+- **`openid` (legacy)** — the native `guacamole-auth-sso-openid`
+  extension. Upstream is implicit-flow-only through 1.6.0 and the SPA
+  re-submits the fragment `id_token` on every route change while the
+  server-side nonce is single-use — the replay poisons the fresh
+  session (`Rejected OpenID token with invalid/old nonce`, live on
+  hw288 — issue #5358). Kept for operators fronting guacamole with
+  their own code-flow proxy; requires `httproute.hostname` +
+  `oidc.issuer`.
+
 ## Default-OFF gate
 
 `values.yaml` ships with `guacamole.enabled: false`. Per-Sovereign
@@ -18,10 +38,10 @@ overlay flips the gate on AND populates:
 
 - `guacamole.guacd.image.tag` — SHA-pinned (CI populates)
 - `guacamole.webapp.image.tag` — SHA-pinned (CI populates)
-- `guacamole.httproute.hostname` — browser-facing FQDN
-- `guacamole.oidc.issuer` — Keycloak realm URL
+- `guacamole.httproute.hostname` — browser-facing FQDN (`sso.mode=openid` only)
+- `guacamole.oidc.issuer` — Keycloak realm URL (`sso.mode=openid` only)
 
-Empty values for any of those four `fail` the helm template render
+Empty values for any required key `fail` the helm template render
 (see `templates/_helpers.tpl`). This is INVIOLABLE-PRINCIPLES #4a +
 #5 in action: the chart never ships floating tags or empty issuer
 strings.
@@ -32,40 +52,35 @@ strings.
 # 0 resources when off
 helm template bp-guacamole . | grep -c '^kind:'
 
-# Full set when on (with required values supplied)
+# Full set when on (default header mode — no hostname/issuer required)
 helm template bp-guacamole . \
   --set guacamole.enabled=true \
   --set guacamole.guacd.image.tag=1.5.5-r1 \
   --set guacamole.webapp.image.tag=1.5.5-r1 \
-  --set guacamole.httproute.hostname=guacamole.sandbox.openova.io \
-  --set guacamole.oidc.issuer=https://keycloak.sandbox.openova.io/realms/catalyst \
   | grep -c '^kind:'
 ```
 
-## Resources rendered when ON
+## Resources rendered when ON (default header mode)
 
 | Kind | Count | Purpose |
 |---|---|---|
 | Deployment | 2 | guacd + webapp |
 | Service | 2 | guacd ClusterIP + webapp ClusterIP |
-| HTTPRoute | 1 | Cilium Gateway browser entrypoint |
-| PersistentVolumeClaim | 1 | recordings (RWO, hcloud-volumes) |
-| SealedSecret | 1 | Keycloak OIDC client secret (placeholder) |
-| NetworkPolicy | 1 | webapp egress (default-deny + selective) |
-| ConfigMap | 1 | bp-keycloak realm-patch (guacamole client + role + group) |
+| NetworkPolicy | 2 | webapp egress + #5358 gate-only ingress guard |
+| Job + SA + Role + RB + CR + CRB | 6 | recordings storageClass-migration hook (with `recordings.persistence=true`) |
+| PersistentVolumeClaim | 1 | recordings (only with `recordings.persistence=true`) |
 
-That's **9 resources** when fully on.
+The CNPG `Cluster` + JDBC schema-seed Job + admin-enroll CronJob
+(#3374 permission store) additionally render on clusters exposing the
+`postgresql.cnpg.io/v1` API. In `sso.mode=openid` the HTTPRoute + the
+chart-managed OIDC `Secret` (or SealedSecret/bootstrap-Job legacy pair)
+render as before — see `tests/render.sh` for the exact bundles.
 
 ## Notes
 
-- `bp-keycloak` post-deploy `keycloak-config-cli` Job picks up the
-  `bp-guacamole-realm-patch` ConfigMap (label
-  `catalyst.openova.io/keycloak-config: realm-patch`) and merges its
-  `realm-patch.json` into the named realm. This is the same pattern
-  the rest of the Catalyst-curated stack uses for OIDC-client
-  bootstrapping.
-- The SealedSecret carries an empty placeholder; the operator runs
-  `kubeseal` once to seal the real secret value.
+- The public hostname `guacamole.<fqdn>` is served by the slot-13c
+  `bp-oidc-gate` HTTPRoute (instance `guacamole`), NOT by this chart,
+  in the default header mode.
 - `bp-k8s-ws-proxy` is the per-node DaemonSet the webapp tunnels
   kubectl-exec sessions through. Without it the kubectl-shell
   protocol path is non-functional (other protocols still work).

--- a/platform/guacamole/chart/templates/_helpers.tpl
+++ b/platform/guacamole/chart/templates/_helpers.tpl
@@ -120,6 +120,21 @@ Usage: {{ include "bp-guacamole.registryImage" (dict "repo" <repo> "tag" <tag> "
 {{- end }}
 
 {{/*
+SSO mode (#5358). `header` (default) = bp-oidc-gate authorization-code
+flow in front + guacamole-auth-header behind; `openid` = LEGACY native
+guacamole-auth-sso-openid implicit flow (fragment-replay-broken upstream
+— see values.yaml `guacamole.sso`). Any other value fails the render.
+*/}}
+{{- define "bp-guacamole.ssoMode" -}}
+{{- $sso := .Values.guacamole.sso | default dict -}}
+{{- $mode := $sso.mode | default "header" -}}
+{{- if not (has $mode (list "header" "openid")) -}}
+{{- fail (printf "bp-guacamole: invalid guacamole.sso.mode %q — must be \"header\" (bp-oidc-gate front, default) or \"openid\" (legacy native implicit flow)" $mode) -}}
+{{- end -}}
+{{- $mode -}}
+{{- end }}
+
+{{/*
 OIDC issuer fail-fast — Guacamole won't authenticate without it.
 */}}
 {{- define "bp-guacamole.oidcIssuer" -}}

--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -53,9 +53,35 @@ spec:
             - name: GUACD_PORT
               value: {{ .Values.guacamole.guacd.port | quote }}
 
-            # OIDC — every value below is operator-driven via per-Sovereign
-            # overlay, never hardcoded (INVIOLABLE-PRINCIPLES #4). Empty
-            # values fail the helm template render via _helpers.tpl.
+            {{- $ssoMode := include "bp-guacamole.ssoMode" . }}
+            {{- if eq $ssoMode "header" }}
+            # SSO — header mode (#5358, DEFAULT). The Sovereign's
+            # bp-oidc-gate (oauth2-proxy, slot 13c) fronts the public
+            # hostname, runs the Keycloak AUTHORIZATION-CODE flow
+            # server-side, and asserts the authenticated principal to
+            # this webapp on every proxied request via the header below
+            # (oauth2-proxy --pass-user-headers, default-on). The
+            # image-bundled guacamole-auth-header extension consumes it.
+            # No id_token ever transits the browser URL, so the #5358
+            # implicit-flow fragment-replay ("Rejected OpenID token with
+            # invalid/old nonce" → error page + session poison) is
+            # structurally impossible. The webapp is reachable ONLY from
+            # the gate pods (see networkpolicy.yaml ingress guard) —
+            # header identity is trusted, so the direct path is closed.
+            {{- $ssoHeader := ((.Values.guacamole.sso | default dict).header) | default dict }}
+            - name: HEADER_ENABLED
+              value: "true"
+            - name: HTTP_AUTH_HEADER
+              value: {{ $ssoHeader.name | default "X-Forwarded-Email" | quote }}
+            {{- else }}
+            # OIDC — LEGACY sso.mode=openid path (see values.yaml
+            # guacamole.sso for why this is no longer the default:
+            # upstream guacamole-auth-sso-openid is implicit-flow-only
+            # through 1.6.0 and the SPA's fragment re-submission replays
+            # the single-use nonce, #5358). Every value below is
+            # operator-driven via per-Sovereign overlay, never hardcoded
+            # (INVIOLABLE-PRINCIPLES #4). Empty values fail the helm
+            # template render via _helpers.tpl.
             #
             # G117.5 W3.D1 #2744 — `?kc_idp_hint=catalyst-pin` appended
             # so the Guacamole webapp's auth redirect carries the IdP
@@ -85,17 +111,19 @@ spec:
                   name: {{ .Values.guacamole.oidc.clientSecretRef.name }}
                   key: {{ .Values.guacamole.oidc.clientSecretRef.key }}
                   optional: false
+            {{- end }}
 
             {{- $db := .Values.guacamole.database | default dict }}
             {{- if and (default true $db.enabled) ((default dict $db.cluster).enabled | default true) }}
             # PostgreSQL JDBC permission store (#3374). The guacamole
             # entrypoint installs the bundled guacamole-auth-jdbc-postgresql
             # extension when POSTGRESQL_HOSTNAME is set; combined with the
-            # openid extension (above) it gives SSO users a real permission
-            # store. AUTO_CREATE_ACCOUNTS provisions a JDBC record per SSO
-            # principal on first login; the schema-seed Job's <adminGroup>
-            # USER_GROUP (ADMINISTER) + OPENID_GROUPS_CLAIM_TYPE=groups make
-            # sovereign-admins members land as admin.
+            # SSO extension above (header or openid per sso.mode) it gives
+            # SSO users a real permission store. AUTO_CREATE_ACCOUNTS
+            # provisions a JDBC record per SSO principal on first login; the
+            # schema-seed Job's <adminGroup> USER_GROUP (ADMINISTER) + the
+            # #3374 admin-enroll CronJob membership rows make
+            # sovereign-admins members land as admin (auth-source-agnostic).
             {{- $cl := $db.cluster | default dict }}
             {{- $clName := $cl.name | default "guacamole-pg" }}
             {{- $clNs := $cl.namespace | default .Release.Namespace }}
@@ -126,12 +154,13 @@ spec:
               value: {{ $db.sslMode | default "require" | quote }}
             - name: POSTGRESQL_AUTO_CREATE_ACCOUNTS
               value: {{ $db.autoCreateAccounts | default true | quote }}
-            # When multiple auth extensions are present, openid must run so
-            # the SSO identity is the authenticated principal and JDBC is the
-            # permission store (not a second login). Extension priority puts
-            # openid first; JDBC accounts are auto-created/looked-up for it.
+            # When multiple auth extensions are present, the SSO extension
+            # (header or openid per sso.mode) must run first so the SSO
+            # identity is the authenticated principal and JDBC is the
+            # permission store (not a second login); JDBC accounts are
+            # auto-created/looked-up for it.
             - name: EXTENSION_PRIORITY
-              value: "openid, postgresql"
+              value: {{ printf "%s, postgresql" $ssoMode | quote }}
             {{- end }}
             # Recording path — guacd writes here; the webapp ships
             # captures off to SeaweedFS via the shipper container below.

--- a/platform/guacamole/chart/templates/guacamole-httproute.yaml
+++ b/platform/guacamole/chart/templates/guacamole-httproute.yaml
@@ -1,4 +1,13 @@
-{{- if and .Values.guacamole.enabled .Values.guacamole.httproute.enabled -}}
+{{- /*
+#5358: this direct HTTPRoute renders ONLY in the LEGACY sso.mode=openid
+path. In the default header mode the bp-oidc-gate instance (bootstrap-kit
+slot 13c) OWNS guacamole.<fqdn> — two HTTPRoutes on one hostname is
+undefined routing, and a direct route would bypass the gate entirely,
+exposing the header-trusting webapp unauthenticated. The gate's
+rootRedirectPath handles the bare-root → /guacamole/ Tomcat-context hop
+that the rootRedirect rule below provided.
+*/ -}}
+{{- if and .Values.guacamole.enabled .Values.guacamole.httproute.enabled (eq (include "bp-guacamole.ssoMode" .) "openid") -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/platform/guacamole/chart/templates/keycloak-client-secret.yaml
+++ b/platform/guacamole/chart/templates/keycloak-client-secret.yaml
@@ -1,5 +1,6 @@
-{{- /* See secret-sso-oidc-credentials.yaml note on the toString/ne idiom. */ -}}
-{{- if and .Values.guacamole.enabled (eq (toString .Values.guacamole.oidc.chartManagedSecret) "false") -}}
+{{- /* See secret-sso-oidc-credentials.yaml note on the toString/ne idiom
+and on the #5358 sso.mode=openid gate. */ -}}
+{{- if and .Values.guacamole.enabled (eq (include "bp-guacamole.ssoMode" .) "openid") (eq (toString .Values.guacamole.oidc.chartManagedSecret) "false") -}}
 # SealedSecret placeholder for the Keycloak OIDC client secret.
 #
 # G117.5 W3.D1 #2744 (2026-06-02) — render-gated on

--- a/platform/guacamole/chart/templates/networkpolicy.yaml
+++ b/platform/guacamole/chart/templates/networkpolicy.yaml
@@ -108,4 +108,40 @@ spec:
         - protocol: TCP
           port: 5432
     {{- end }}
+{{- if eq (include "bp-guacamole.ssoMode" .) "header" }}
+---
+# #5358 header-mode ingress guard. In sso.mode=header the webapp TRUSTS
+# the identity header the bp-oidc-gate injects (guacamole-auth-header),
+# so any pod that can dial the webapp :8080 directly could assert an
+# arbitrary principal. This policy closes the direct path: ONLY the
+# oidc-gate pods (which overwrite the inbound header with the
+# session-derived value on every proxied request) may reach the webapp.
+# Kubelet liveness/readiness probes bypass NetworkPolicy by design.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-guacamole.webappName" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "bp-guacamole.webappSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- $sso := .Values.guacamole.sso | default dict }}
+    {{- $gate := $sso.gate | default dict }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $gate.namespace | default "oidc-gate" }}
+          podSelector:
+            matchLabels:
+              {{- $gate.podSelector | default (dict "app.kubernetes.io/name" "bp-oidc-gate") | toYaml | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.guacamole.webapp.port }}
+{{- end }}
 {{- end }}

--- a/platform/guacamole/chart/templates/oidc-secret-bootstrap-job.yaml
+++ b/platform/guacamole/chart/templates/oidc-secret-bootstrap-job.yaml
@@ -97,8 +97,9 @@ and avoids the API-call + RBAC + race-with-operator risk this Job
 carries. The Job is preserved as the back-compat path operators can
 re-enable by flipping `chartManagedSecret: false`.
 */}}
-{{- /* See secret-sso-oidc-credentials.yaml note on the toString/ne idiom. */ -}}
-{{- if and .Values.guacamole.enabled (eq (toString .Values.guacamole.oidc.chartManagedSecret) "false") -}}
+{{- /* See secret-sso-oidc-credentials.yaml note on the toString/ne idiom
+and on the #5358 sso.mode=openid gate. */ -}}
+{{- if and .Values.guacamole.enabled (eq (include "bp-guacamole.ssoMode" .) "openid") (eq (toString .Values.guacamole.oidc.chartManagedSecret) "false") -}}
 {{- $secretName := .Values.guacamole.oidc.clientSecretRef.name }}
 {{- $secretKey := .Values.guacamole.oidc.clientSecretRef.key }}
 {{- $ns := .Release.Namespace }}

--- a/platform/guacamole/chart/templates/secret-sso-oidc-credentials.yaml
+++ b/platform/guacamole/chart/templates/secret-sso-oidc-credentials.yaml
@@ -4,7 +4,12 @@ NOTE on the gate: Sprig's `default` is unsafe for booleans because
 explicitly check for "not equal to false" instead, so the chart-managed
 path is ON unless the operator EXPLICITLY sets the value to false.
 */ -}}
-{{- if and .Values.guacamole.enabled (ne (toString .Values.guacamole.oidc.chartManagedSecret) "false") -}}
+{{- /* #5358: OIDC client-secret material is only consumed by the LEGACY
+sso.mode=openid deployment env — in the default header mode the KC
+client + secret belong to the bp-oidc-gate instance (bp-sso-bridge →
+OpenBao → ExternalSecret in the oidc-gate namespace), so none of the
+oidc secret templates render. */ -}}
+{{- if and .Values.guacamole.enabled (eq (include "bp-guacamole.ssoMode" .) "openid") (ne (toString .Values.guacamole.oidc.chartManagedSecret) "false") -}}
 {{/*
 G117.5 W3.D1 #2744 — chart-managed OIDC client-secret Secret.
 

--- a/platform/guacamole/chart/tests/g117-w3d1-sso-secret.sh
+++ b/platform/guacamole/chart/tests/g117-w3d1-sso-secret.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # bp-guacamole — G117.5 W3.D1 #2744 SSO Secret gating + kc_idp_hint guards.
 #
+# #5358: the chart's DEFAULT sso mode is now `header` (bp-oidc-gate
+# authorization-code flow in front + guacamole-auth-header behind — the
+# native implicit flow's fragment-replay broke every silent SSO on hw288).
+# Every contract in THIS file belongs to the LEGACY native-openid path, so
+# all cases pin `guacamole.sso.mode=openid` explicitly. The header-mode
+# contracts live in tests/render.sh section 3a.
+#
 # Verifies:
 #   1. `?kc_idp_hint=catalyst-pin` is appended to OPENID_AUTHORIZATION_ENDPOINT.
 #   1b. OPENID_REDIRECT_URI carries the `/guacamole/` context path (#3150) —
@@ -25,6 +32,7 @@ helm="${HELM_BIN:-helm}"
 
 base_args=(
   --set guacamole.enabled=true
+  --set guacamole.sso.mode=openid
   --set guacamole.guacd.image.tag=1.5.5
   --set guacamole.webapp.image.tag=1.5.5
   --set guacamole.oidc.issuer=https://auth.smoke.omani.works/realms/sovereign

--- a/platform/guacamole/chart/tests/httproute-render.sh
+++ b/platform/guacamole/chart/tests/httproute-render.sh
@@ -18,8 +18,14 @@ chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
 helm="${HELM_BIN:-helm}"
 "$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
 
+# #5358: the chart's own HTTPRoute belongs to the LEGACY sso.mode=openid
+# path only — in the default header mode the slot-13c bp-oidc-gate instance
+# owns the hostname (a direct route would bypass the gate and expose the
+# header-trusting webapp). Cases 1/2/4 therefore pin sso.mode=openid; a new
+# Case 6 asserts the header-mode suppression.
 overlay=(
   --set guacamole.enabled=true
+  --set guacamole.sso.mode=openid
   --set guacamole.httproute.hostname=guac.smoke.omani.works
   --set guacamole.oidc.issuer=https://keycloak.smoke.omani.works/realms/ops
 )
@@ -59,10 +65,12 @@ if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
 fi
 echo "[bp-guacamole] Case 3: PASS"
 
-# Case 4 — helper fail-fast
+# Case 4 — helper fail-fast (openid mode — header mode never resolves the
+# hostname because the HTTPRoute template is the only chart-side consumer)
 echo "[bp-guacamole] Case 4: helper bp-guacamole.host fails fast when hostname empty"
 out_empty=$("$helm" template smoke "$chart_dir" \
   --set guacamole.enabled=true \
+  --set guacamole.sso.mode=openid \
   --set guacamole.oidc.issuer=https://keycloak.smoke.omani.works/realms/ops 2>&1 || true)
 if ! echo "$out_empty" | grep -q "hostname is empty"; then
   echo "FAIL: bp-guacamole.host should hard-fail when hostname empty"
@@ -95,5 +103,22 @@ if echo "$appcr" | grep -qE '^  placement: single-region$'; then
   exit 1
 fi
 echo "[bp-guacamole] Case 5: PASS"
+
+# ── Case 6: header mode (DEFAULT) suppresses the direct HTTPRoute ──────
+# #5358 — the slot-13c bp-oidc-gate instance owns guacamole.<fqdn>; the
+# chart must NOT render a second HTTPRoute on the same hostname (undefined
+# routing) nor any direct route that bypasses the gate (the webapp trusts
+# the gate-injected identity header). httproute.enabled=true + a hostname
+# must still render NOTHING under the default header mode.
+echo "[bp-guacamole] Case 6: default header mode renders no HTTPRoute even when httproute.enabled=true"
+out_header=$("$helm" template smoke "$chart_dir" \
+  --set guacamole.enabled=true \
+  --set guacamole.httproute.enabled=true \
+  --set guacamole.httproute.hostname=guac.smoke.omani.works 2>&1)
+if echo "$out_header" | grep -q "^kind: HTTPRoute$"; then
+  echo "FAIL: header mode rendered a direct HTTPRoute (gate owns the hostname)"
+  exit 1
+fi
+echo "[bp-guacamole] Case 6: PASS"
 
 echo "[bp-guacamole] All HTTPRoute render cases PASS"

--- a/platform/guacamole/chart/tests/render.sh
+++ b/platform/guacamole/chart/tests/render.sh
@@ -104,40 +104,43 @@ echo "PASS: empty image.tag fails fast"
 # ─────────────────────────────────────────────────────────────────────
 render_on="$TMP/on.yaml"
 # #3374 (2026-06-14): recordings.persistence is now DEFAULT false (emptyDir,
-# no node-pin). The canonical 14-resource "full" bundle includes the
-# recordings PVC + its storageClass-migration hook (Job + SA + Role + RB), so
-# the full-ON case sets persistence=true to exercise that complete shape. The
-# default (emptyDir) path drops those 5 resources by design — covered by the
-# dedicated persistence-default check below.
+# no node-pin). The canonical "full" bundle includes the recordings PVC + its
+# storageClass-migration hook (Job + SA + Role + RB), so the full-ON case sets
+# persistence=true to exercise that complete shape. The default (emptyDir)
+# path drops those 5 resources by design — covered by the dedicated
+# persistence-default check below.
+#
+# #5358: the DEFAULT sso mode is now `header` (bp-oidc-gate code flow in
+# front + guacamole-auth-header behind). In header mode the chart renders NO
+# HTTPRoute (the gate owns the hostname) and NO oidc Secret (the client
+# secret belongs to the gate via bp-sso-bridge/OpenBao), and ADDS the webapp
+# ingress-guard NetworkPolicy. Neither httproute.hostname nor oidc.issuer is
+# required.
 helm template bp-guacamole . \
   --set guacamole.enabled=true \
   --set guacamole.guacd.image.tag=1.5.5-r1 \
   --set guacamole.webapp.image.tag=1.5.5-r1 \
-  --set guacamole.httproute.hostname=guacamole.test \
-  --set guacamole.oidc.issuer=https://kc.test/realms/sovereign \
   --set guacamole.recordings.persistence=true \
   > "$render_on"
 
-# 14-doc target with chartManagedSecret default ON: Deployment×2 (guacd
-# + webapp), Service×2, HTTPRoute, PVC, Secret (chart-managed),
-# NetworkPolicy, Job (recordings-migrate), ServiceAccount, Role,
-# RoleBinding, ClusterRole, ClusterRoleBinding.
-expect_total=14
+# 13-doc target in default header mode: Deployment×2 (guacd + webapp),
+# Service×2, PVC, NetworkPolicy×2 (webapp egress + #5358 ingress guard),
+# Job (recordings-migrate), ServiceAccount, Role, RoleBinding, ClusterRole,
+# ClusterRoleBinding.
+expect_total=13
 got_total="$(grep -cE '^kind:' "$render_on")"
 if [[ "$got_total" != "$expect_total" ]]; then
-  echo "FAIL: full-ON rendered $got_total resources, want $expect_total"
+  echo "FAIL: full-ON (header mode) rendered $got_total resources, want $expect_total"
   grep -E '^kind:' "$render_on" | sort
   exit 1
 fi
-echo "PASS: full-ON renders $got_total resources"
+echo "PASS: full-ON (header mode) renders $got_total resources"
 
 # Each individual kind must appear at least once.
 required_kinds=(
   Deployment
   Service
-  HTTPRoute
   PersistentVolumeClaim
-  Secret
   NetworkPolicy
   Job
   ServiceAccount
@@ -154,6 +157,86 @@ for k in "${required_kinds[@]}"; do
 done
 echo "PASS: every required kind present"
 
+# ─────────────────────────────────────────────────────────────────────
+# 3a. #5358 header-mode contract:
+#   - guacamole-auth-header wired (HEADER_ENABLED + HTTP_AUTH_HEADER)
+#   - EXTENSION_PRIORITY puts header before the JDBC store
+#   - ZERO OPENID_* env (no implicit flow anywhere)
+#   - NO HTTPRoute (the slot-13c oidc-gate owns the hostname; a direct
+#     route would bypass the gate and expose the header-trusting webapp)
+#   - the webapp ingress guard admits ONLY the oidc-gate pods
+# ─────────────────────────────────────────────────────────────────────
+if ! grep -q 'name: HEADER_ENABLED' "$render_on"; then
+  echo "FAIL: header mode missing HEADER_ENABLED env"
+  exit 1
+fi
+if ! grep -q 'value: "X-Forwarded-Email"' "$render_on"; then
+  echo "FAIL: header mode missing HTTP_AUTH_HEADER=X-Forwarded-Email"
+  exit 1
+fi
+if ! grep -q 'value: "header, postgresql"' "$render_on"; then
+  echo "FAIL: header mode EXTENSION_PRIORITY is not 'header, postgresql'"
+  exit 1
+fi
+if grep -q 'OPENID_' "$render_on"; then
+  echo "FAIL: header mode still renders OPENID_* env (implicit flow must be gone)"
+  grep 'OPENID_' "$render_on"
+  exit 1
+fi
+if grep -qE '^kind: HTTPRoute$' "$render_on"; then
+  echo "FAIL: header mode rendered a direct HTTPRoute (gate owns the hostname)"
+  exit 1
+fi
+if ! grep -q 'name: guacamole-server-ingress' "$render_on"; then
+  echo "FAIL: header mode missing the webapp ingress-guard NetworkPolicy"
+  exit 1
+fi
+if ! grep -q 'kubernetes.io/metadata.name: oidc-gate' "$render_on"; then
+  echo "FAIL: ingress guard does not scope to the oidc-gate namespace"
+  exit 1
+fi
+echo "PASS: header mode wires guacamole-auth-header + ingress guard, no OPENID/HTTPRoute"
+
+# ─────────────────────────────────────────────────────────────────────
+# 3b. LEGACY sso.mode=openid keeps the pre-#5358 14-doc bundle
+#     byte-compatible: HTTPRoute + chart-managed oidc Secret return, the
+#     ingress guard is NOT rendered, and the OPENID_* env is present.
+# ─────────────────────────────────────────────────────────────────────
+render_legacy="$TMP/legacy-openid.yaml"
+helm template bp-guacamole . \
+  --set guacamole.enabled=true \
+  --set guacamole.sso.mode=openid \
+  --set guacamole.guacd.image.tag=1.5.5-r1 \
+  --set guacamole.webapp.image.tag=1.5.5-r1 \
+  --set guacamole.httproute.hostname=guacamole.test \
+  --set guacamole.oidc.issuer=https://kc.test/realms/sovereign \
+  --set guacamole.recordings.persistence=true \
+  > "$render_legacy"
+expect_legacy=14
+got_legacy="$(grep -cE '^kind:' "$render_legacy")"
+if [[ "$got_legacy" != "$expect_legacy" ]]; then
+  echo "FAIL: legacy openid mode rendered $got_legacy resources, want $expect_legacy"
+  grep -E '^kind:' "$render_legacy" | sort
+  exit 1
+fi
+if ! grep -qE '^kind: HTTPRoute$' "$render_legacy"; then
+  echo "FAIL: legacy openid mode did not render the HTTPRoute"
+  exit 1
+fi
+if ! grep -q 'name: OPENID_AUTHORIZATION_ENDPOINT' "$render_legacy"; then
+  echo "FAIL: legacy openid mode missing OPENID_* env"
+  exit 1
+fi
+if ! grep -q 'value: "openid, postgresql"' "$render_legacy"; then
+  echo "FAIL: legacy openid mode EXTENSION_PRIORITY is not 'openid, postgresql'"
+  exit 1
+fi
+if grep -q 'name: guacamole-server-ingress' "$render_legacy"; then
+  echo "FAIL: legacy openid mode rendered the header-mode ingress guard"
+  exit 1
+fi
+echo "PASS: legacy sso.mode=openid keeps the pre-#5358 bundle ($got_legacy docs)"
+
 # #3374 (2026-06-14): recordings.persistence DEFAULT false → the webapp Pod
 # uses an emptyDir recordings volume (no node-pin) + Recreate strategy, and
 # the recordings PVC / migration hook are NOT rendered. This is what unwedges
@@ -163,8 +246,6 @@ helm template bp-guacamole . \
   --set guacamole.enabled=true \
   --set guacamole.guacd.image.tag=1.5.5-r1 \
   --set guacamole.webapp.image.tag=1.5.5-r1 \
-  --set guacamole.httproute.hostname=guacamole.test \
-  --set guacamole.oidc.issuer=https://kc.test/realms/sovereign \
   > "$render_default"
 if grep -qE '^kind: PersistentVolumeClaim$' "$render_default"; then
   echo "FAIL: recordings PVC rendered with persistence default (should be emptyDir)"
@@ -183,12 +264,14 @@ echo "PASS: persistence-default renders emptyDir recordings + Recreate, no PVC"
 # G117.5 W3.D1 #2744 (2026-06-02): the chart-managed Secret carries
 # `helm.sh/resource-policy: keep` per memory
 # feedback_chart_credential_persistence_defense.md so reinstalls don't
-# rotate the OIDC client-secret.
-if ! grep -q "helm.sh/resource-policy: keep" "$render_on"; then
+# rotate the OIDC client-secret. #5358: the Secret only exists on the
+# LEGACY sso.mode=openid path (header mode has no chart-side client
+# secret), so this contract is asserted against the legacy render.
+if ! grep -q "helm.sh/resource-policy: keep" "$render_legacy"; then
   echo "FAIL: chart-managed Secret missing helm.sh/resource-policy: keep annotation"
   exit 1
 fi
-echo "PASS: chart-managed OIDC Secret has resource-policy: keep"
+echo "PASS: chart-managed OIDC Secret has resource-policy: keep (legacy openid mode)"
 
 # qa-loop iter-7 Fix #39 — canonical short resource names. The
 # catalyst-api shells/issue handler + the qa-loop test matrix
@@ -245,8 +328,6 @@ helm template bp-guacamole . \
   --set guacamole.enabled=true \
   --set guacamole.guacd.image.tag=1.5.5-r1 \
   --set guacamole.webapp.image.tag=1.5.5-r1 \
-  --set guacamole.httproute.hostname=guacamole.test \
-  --set guacamole.oidc.issuer=https://kc.test/realms/sovereign \
   --set guacamole.recordings.allowMigration=false \
   > "$no_mig"
 if grep -q 'storageclass-migrate' "$no_mig"; then

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -140,7 +140,53 @@ guacamole:
     # harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md inviolable
     # rule.
     migrationImage: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7
-  # ── Keycloak OIDC ──────────────────────────────────────────────
+  # ── SSO mode (#5358) ───────────────────────────────────────────
+  # How the operator's Keycloak identity reaches Guacamole.
+  #
+  #   header (DEFAULT — the #5358 fix): the Sovereign's bp-oidc-gate
+  #     (oauth2-proxy, bootstrap-kit slot 13c) fronts guacamole.<fqdn>
+  #     and runs the OIDC AUTHORIZATION-CODE flow server-side (client
+  #     secret via bp-sso-bridge → OpenBao → ExternalSecret). The gate
+  #     asserts the authenticated principal to the webapp on every
+  #     proxied request via an HTTP header (oauth2-proxy
+  #     --pass-user-headers, default-on), consumed by the image-bundled
+  #     guacamole-auth-header extension. No id_token ever transits the
+  #     browser URL → the #5358 fragment-replay class is structurally
+  #     impossible. In this mode the chart renders NO HTTPRoute (the
+  #     gate owns the hostname — two HTTPRoutes on one hostname is
+  #     undefined routing) and adds an ingress NetworkPolicy so ONLY
+  #     the gate pods can reach the webapp :8080 (header identity is
+  #     trusted, so the direct path must be closed).
+  #
+  #   openid (LEGACY): the native guacamole-auth-sso-openid extension.
+  #     Upstream implements ONLY the OIDC implicit flow
+  #     (response_type=id_token in the URL fragment) through 1.6.0 AND
+  #     git master — no released version supports the code flow, and
+  #     the SPA re-submits the fragment token on every route change
+  #     while the server-side nonce is strictly single-use
+  #     (NonceService.isValid removes on first test). The re-submission
+  #     poisons the just-created session: "Rejected OpenID token with
+  #     invalid/old nonce" + error page (live on hw288, #5358 — 4/4
+  #     deterministic under Playwright walk). Kept only for operators
+  #     fronting guacamole with their own code-flow proxy.
+  sso:
+    mode: header
+    header:
+      # Header carrying the authenticated principal, as injected by
+      # oauth2-proxy (--pass-user-headers). X-Forwarded-Email matches
+      # the JDBC usernames the openid mode created (its
+      # openid-username-claim-type default is `email`), so existing
+      # permission-store records carry over across the mode switch.
+      name: X-Forwarded-Email
+    gate:
+      # Namespace + pod labels of the bp-oidc-gate deployment allowed
+      # through the webapp ingress NetworkPolicy. Matches the slot-13c
+      # bp-oidc-gate chart (targetNamespace oidc-gate, chart label
+      # app.kubernetes.io/name: bp-oidc-gate).
+      namespace: oidc-gate
+      podSelector:
+        app.kubernetes.io/name: bp-oidc-gate
+  # ── Keycloak OIDC (sso.mode=openid LEGACY path only — see #5358) ──
   oidc:
     # Issuer URL — render in per-Sovereign overlay as
     # `https://auth.<sovereign-fqdn>/realms/sovereign`. Empty value

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -2045,14 +2045,26 @@ func (h *Handler) lookupExternalURL(ctx context.Context, depID, targetNamespace,
 		return ""
 	}
 	for _, rt := range routes {
-		if !routeNamespaceMatchesApp(rt.GetNamespace(), targetNamespace) {
+		// #5358 — gate-owned front door. Apps served through the generic
+		// bp-oidc-gate (slot 13c) have NO HTTPRoute in their own namespace:
+		// the gate's `oidc-gate-<release>` route in the `oidc-gate`
+		// namespace owns `<release>.<sovereign-fqdn>` instead (guacamole
+		// since bp-guacamole 0.2.30; powerdns-admin since the #3374
+		// Layer-A migration). Without this rule the namespace filter below
+		// skips the gate route → externalURL comes back empty → the
+		// AppDetail/AppsPage "Open" button vanishes even though the front
+		// door is live. The `oidc-gate-<release>` name is the slot-13c
+		// instances.yaml naming contract, so this cannot false-positive
+		// across apps.
+		gateOwned := rt.GetNamespace() == "oidc-gate" && rt.GetName() == "oidc-gate-"+releaseName
+		if !gateOwned && !routeNamespaceMatchesApp(rt.GetNamespace(), targetNamespace) {
 			continue
 		}
 		hosts, _, _ := unstructured.NestedStringSlice(rt.Object, "spec", "hostnames")
 		if len(hosts) == 0 || hosts[0] == "" {
 			continue
 		}
-		if rt.GetName() == releaseName {
+		if gateOwned || rt.GetName() == releaseName {
 			return "https://" + hosts[0]
 		}
 		// (3) hostname leftmost-label match — the route's front-door host

--- a/products/catalyst/bootstrap/api/internal/handler/applications_external_url_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_external_url_test.go
@@ -215,6 +215,33 @@ func TestLookupExternalURL_MatchRules(t *testing.T) {
 			releaseName:     "gitea",
 			want:            "",
 		},
+		{
+			// #5358 — gate-owned front door. bp-guacamole 0.2.30 renders NO
+			// HTTPRoute of its own (sso.mode=header); the slot-13c
+			// bp-oidc-gate route `oidc-gate-guacamole` in the `oidc-gate`
+			// namespace owns guacamole.<fqdn>. The gate-owned rule must
+			// resolve it even though the namespace differs from the app's
+			// targetNamespace.
+			name: "oidc-gate-owned route resolves for gated app",
+			routes: []*unstructured.Unstructured{
+				newHTTPRoute("oidc-gate", "oidc-gate-guacamole", "guacamole.hw290.omani.works", "oidc-gate-guacamole"),
+			},
+			targetNamespace: "guacamole",
+			releaseName:     "guacamole",
+			want:            "https://guacamole.hw290.omani.works",
+		},
+		{
+			// #5358 — the gate-owned rule keys on the oidc-gate-<release>
+			// NAME contract, not on hostname: another instance's gate route
+			// must NOT resolve for this release.
+			name: "other gate instance route stays excluded",
+			routes: []*unstructured.Unstructured{
+				newHTTPRoute("oidc-gate", "oidc-gate-powerdns-admin", "pdns-admin.hw290.omani.works", "oidc-gate-powerdns-admin"),
+			},
+			targetNamespace: "guacamole",
+			releaseName:     "guacamole",
+			want:            "",
+		},
 	}
 
 	for _, tc := range cases {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3571,7 +3571,15 @@ name: bp-catalyst-platform
 #   (bp-newapi PushSecret + bp-openbao external-secrets-push policy), closing
 #   the region-B SecretSyncedError / post-promote DR gap. Bootstrap-kit
 #   slot-13 pin bumped in lockstep (pin-sync gate).
-version: 1.4.1215
+# 1.4.1216 — #5358: catalog-seed bp-guacamole 0.2.29 -> 0.2.30 (spec.version
+#   display + delivery source.version) — guacamole SSO moves server-side:
+#   bp-oidc-gate `guacamole` instance (slot 13c) runs the authorization-code
+#   flow (confidential client guacamole-gate) and injects X-Forwarded-Email;
+#   bp-guacamole sso.mode=header consumes it via the image-bundled
+#   guacamole-auth-header extension (no id_token in the browser — kills the
+#   1.5.5 implicit-flow nonce-replay #5358). Bootstrap-kit slot-13 pin bumped
+#   in lockstep (pin-sync gate).
+version: 1.4.1216
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2322,7 +2322,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.143"
+  version: "1.4.144"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2367,7 +2367,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.143"
+    version: "1.4.144"
   topology:
     supported:
     - active-passive

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1744,7 +1744,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.29"
+    version: "0.2.30"
   topology:
     supported:
     - active-hot-standby

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1726,7 +1726,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.29"
+  version: "0.2.30"
   visibility: listed
   card:
     title: "Apache Guacamole"


### PR DESCRIPTION
## Problem (live on hw288, Refs #5358)

Bare-URL SSO to `guacamole.<fqdn>` fails with the pod-log-confirmed
`TokenValidationService - Rejected OpenID token with invalid/old nonce` → generic error page + local login form instead of the signed-in connections list (UAT rows 35/115; ~50% for human clicks, **4/4 deterministic** under Playwright walks).

## Root cause (verified against upstream source, not vibes)

- `guacamole-auth-sso-openid` implements **only the OIDC implicit flow** (`response_type=id_token` in the URL fragment). Verified in upstream `AuthenticationProviderService`/`ConfigurationService` for **1.5.5, 1.6.0 AND git master** — no released version supports the authorization-code flow and no `openid-client-secret` property exists, so the ticket's preferred option (a) 'bump to a code-flow extension version' has **no real artifact to pin**.
- The webapp SPA re-submits the fragment `id_token` through `updateCurrentToken($location.search())` on **every route change**, while the server-side nonce is strictly single-use (`NonceService.isValid` removes on first test — unchanged in 1.6.0). The replay poisons the just-created session. There is **no 1.5.x/1.6.x config knob** that eliminates this class (option (b) verified empty), so a plain image bump would be theater.

## Fix — move the OIDC leg out of the browser (authorization-code flow, per the ticket's intent)

1. **`13c-bp-oidc-gate.yaml`** — new `guacamole` gate instance: oauth2-proxy runs the Keycloak **code flow server-side** (fresh confidential client `guacamole-gate` minted by bp-sso-bridge; secret via OpenBao → ExternalSecret — the exact client-secret wiring the ticket asked for), owns `guacamole.<fqdn>`, 302s the bare root → `/guacamole/` (Tomcat context, #3150 class). Silent zero-click preserved via `kc_idp_hint=catalyst-pin` (the proven pdns-admin/openova-flow arg set).
2. **bp-guacamole 0.2.30** — new `guacamole.sso.mode` knob, **default `header`**: the webapp consumes the gate-injected `X-Forwarded-Email` via the image-bundled `guacamole-auth-header` extension (`HEADER_ENABLED=true`, same proven 1.5.5 image — no new tags). No `id_token` ever transits the browser URL → the replay class is structurally impossible. JDBC permission store + #3374 admin-enroll CronJob are auth-source-agnostic and untouched; usernames stay byte-identical (openid's username claim default was `email`).
   - Header mode renders **no HTTPRoute** (gate owns the hostname; a direct route would bypass auth) and adds an **ingress NetworkPolicy** admitting only the oidc-gate pods to webapp :8080 (header identity is trusted → direct path closed).
   - `sso.mode=openid` keeps the legacy shape **byte-compatibly** (asserted by tests) for operators fronting guacamole with their own code-flow proxy.
3. **`lookupExternalURL`** (bootstrap api) — resolves gate-owned `oidc-gate-<release>` routes so the console Open button keeps its URL for gated apps (also heals the same latent gap for powerdns-admin) + 2 new unit-test cases.
4. **Lockstep** — slot-52 pin, `blueprint.yaml`, catalog-seed → 0.2.30; chart tests reworked (header-mode contract incl. no-OPENID/no-HTTPRoute/ingress-guard asserts + legacy openid guard suite).

## Render proof (helm template, default header mode)

```
- name: HEADER_ENABLED
  value: "true"
- name: HTTP_AUTH_HEADER
  value: "X-Forwarded-Email"
- name: EXTENSION_PRIORITY
  value: "header, postgresql"
```
Plus `guacamole-server-ingress` NetworkPolicy scoped to `kubernetes.io/metadata.name: oidc-gate` + `app.kubernetes.io/name: bp-oidc-gate`, port 8080; zero `OPENID_*` env; zero HTTPRoute. Gate side proven with the new instance: hostname `guacamole.<fqdn>`, `--upstream=http://guacamole-server.guacamole.svc.cluster.local:80`, bare-root 302 → `/guacamole/`, client `guacamole-gate` w/ `/oauth2/callback`.

## Gates run

- `helm lint` PASS; `tests/render.sh` (12 asserts incl. new header/legacy suites) PASS; `tests/g117-w3d1-sso-secret.sh` PASS; `tests/httproute-render.sh` (incl. new Case 6 header-suppression) PASS
- `scripts/check-bootstrap-kit-pin-sync.sh` PASS (67 pairs); `scripts/check-catalog-seed-lockstep.sh` PASS (68 checked, 0 fail)
- `go build ./... && go vet && go test ./internal/handler` (products/catalyst/bootstrap/api) PASS
- Registry existence verified on the wire: `docker.io/guacamole/guacamole:1.5.5` → HTTP 200; `quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` → HTTP 200 (no nonexistent tags pinned)

## Notes / follow-ups

- The legacy `guacamole` KC client in bp-keycloak's realm-import stays (unused by the canonical path; removing it is a bp-keycloak lockstep change a follow-up PR (bp-keycloak lockstep) — flagged for the next bp-keycloak touch).
- Delivery to post-cutover hw288 remains blocked by #5265; this lands on the next fresh prov, where UAT rows 35/115 walk the gate path.

Refs #5358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
