### PR TITLE
fix(cutover): secondary-region pivot + deny-egress legs — kill the 2-region false-positive cc=true (0.1.151, Refs #5359)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -974,7 +974,21 @@ spec:
       # only local Gitea+Harbor (zero egress) + emits the offline-media
       # missing-artifact manifest, warm mode helm-pulls+pushes on the operator's
       # schedule. No step-count/RBAC change (still 11 steps). Contract Case 69.
-      version: 0.1.150
+      # 0.1.151 (#5359 Refs #5265 #5339): SECONDARY-REGION pivot + proof legs.
+      # hw288 proved cc=true was a FALSE POSITIVE on a 2-region Sovereign —
+      # only region-A was pivoted; region-B's GitRepository stayed github.com,
+      # 64/64 HelmRepositories ghcr.io. Steps 05/06/08 now run a leg per
+      # secondary region via the optional cutover-secondary-kubeconfigs Secret
+      # catalyst-api materialises at run start (bp-catalyst-platform 1.4.1213
+      # RBAC): GitRepository -> local Gitea (mesh global-Service path,
+      # fail-loud Ready wait), HelmRepositories -> local Harbor (zero-upstream
+      # read-back assert, stripped-auth re-sync post-Phase-3b), and the step-08
+      # deny-egress hold + green assertion now cover EVERY region with
+      # per-region step.<step>.region.<key>.* status keys. Single-region
+      # is a behavioral no-op (empty optional mount -> glob guards skip every leg;
+      # the legs DO render). Step count stays 11.
+      # Contract Case 71.
+      version: 0.1.151
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1286,7 +1286,11 @@ spec:
       #   Lockstep w/ Chart.yaml (pin-sync gate).
       # 1.4.1216 — #5358: catalog-seed bp-guacamole 0.2.30 (server-side SSO via
       #   oidc-gate header mode; kills the implicit-flow nonce replay).
-      version: 1.4.1217
+      # 1.4.1218 — #5359: cutover-driver Secret RBAC for the
+      #   cutover-secondary-kubeconfigs bridge + catalog-seed
+      #   bp-self-sovereign-cutover 0.1.151 (region-B cutover legs) +
+      #   bp-guacamole 0.2.31 sync (TBD-A6 bot re-mint).
+      version: 1.4.1218
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.150
+  version: 0.1.151
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,35 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.151 (#5359 Refs #5265 #5339 — SECONDARY-REGION pivot + proof legs:
+# kill the 2-region FALSE-POSITIVE cc=true. Live-proven on hw288 (dep
+# 027f07559af1f9f7): only region-A was pivoted — region-B's Flux
+# GitRepository still github.com, 64/64 HelmRepositories still ghcr.io,
+# node images quay.io — yet cutoverComplete=true because the step-08
+# deny-egress proof never touched region-B; the drift is also the #5339
+# per-region chart-version split. NOW: steps 05/06/08 each run a
+# per-secondary-region leg via `kubectl --kubeconfig /secondary-
+# kubeconfigs/<regionKey>.yaml` — the optional:true mount of the
+# `cutover-secondary-kubeconfigs` Secret catalyst-api materialises at
+# every run start from the on-PVC secondary kubeconfig store it already
+# holds (the ClusterMesh-establish/#5244 mechanism; NO new credential
+# contract). Step-05: pivots the secondary GitRepository to local Gitea
+# (ClusterMesh global-Service alias, the bp-cnpg-pair/bp-openbao mesh
+# idiom) + FAIL-LOUD Ready wait. Step-06: syncs ghcr-pull auth + the
+# harbor-ca trust Secret, pivots every ghcr-prefixed secondary HR to
+# local Harbor, read-back-asserts ZERO remain upstream, re-syncs the
+# STRIPPED auth bytes after Phase-3b's proven-pullable gate. Step-08:
+# applies the deny-egress hold to EVERY region (ALLOW_CIDRS + provider
+# carve-outs inherited; + mesh toEndpoints + the Sovereign's own
+# registry./gitea. gateway IPs) and requires EVERY region regression-
+# free through the window; per-region verdicts land as
+# step.<step>.region.<key>.* status keys; teardown + the engine #5014
+# backstop cover the secondaries. SINGLE-REGION UNAFFECTED: no Secret →
+# empty mount → every leg no-ops at runtime → single-region BEHAVIOR is
+# unchanged vs 0.1.150 (the legs render unconditionally; the render is not
+# byte-identical — the no-op is behavioral, glob-guard enforced).
+# Step-04's region-B containerd/Dragonfly leg is the remaining #5359
+# increment — tracked, not faked. Engine half: catalyst-api
+# cutover_secondary_kubeconfigs.go + bp-catalyst-platform 1.4.1213 RBAC.)
 # 0.1.150 (#5265 Refs #5237 #5007 #3379 — POST-CUTOVER DAY-2 Harbor pin
 # reconciler: close the Day-2 Harbor leg of the sovereignty design. step-03
 # harbor-prewarm pushes every pinned chart into local Harbor EXACTLY ONCE at
@@ -2619,7 +2649,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.150
+version: 0.1.151
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/README.md
+++ b/platform/self-sovereign-cutover/chart/README.md
@@ -34,11 +34,28 @@ through `harbor.openova.io`) and becomes hard-independent only after the
 | 02 | `cutover-step-02-harbor-projects` ConfigMap | pre-pivot | Create 7 proxy_cache projects in local Harbor |
 | 03 | `cutover-step-03-harbor-prewarm` ConfigMap | pre-pivot | HEAD-pull every image referenced by bootstrap-kit through proxy-cache |
 | 04 | `registry-pivot` DaemonSet | pre-pivot | Always-on per-node reconcile loop (Dragonfly, #4639): on `registriesYamlActive=v2` it writes the containerd `_default/hosts.toml` catch-all → the node-local dfdaemon proxy, flips the `bp-dragonfly` dfdaemon upstream ghcr → local Harbor, and adds a `registry.<fqdn>` → cilium-gateway ClusterIP hostAlias (the #4637 hairpin kill) |
-| 05 | `cutover-step-05-flux-gitrepository-patch` ConfigMap | post-pivot | Patch `flux-system/openova` GitRepository.url → local Gitea |
-| 06 | `cutover-step-06-helmrepository-patches` ConfigMap | post-pivot | Patch every OCI HelmRepository → `oci://harbor.<sov-fqdn>/openova-io` |
+| 05 | `cutover-step-05-flux-gitrepository-patch` ConfigMap | post-pivot | Patch `flux-system/openova` GitRepository.url → local Gitea — in EVERY region (#5359: per-secondary-region leg via `/secondary-kubeconfigs`, fail-loud Ready wait) |
+| 06 | `cutover-step-06-helmrepository-patches` ConfigMap | post-pivot | Patch every OCI HelmRepository → `oci://harbor.<sov-fqdn>/openova-io` — in EVERY region (#5359: per-secondary leg syncs ghcr-pull auth + the harbor-ca trust Secret, pivots + read-back-asserts zero upstream HRs remain) |
 | 07 | `cutover-step-07-catalyst-api-env-patch` ConfigMap | post-pivot | `kubectl set env deploy/catalyst-api CATALYST_GITOPS_REPO_URL=...` |
-| 08 | `cutover-step-08-egress-block-test` ConfigMap | post-pivot | CiliumNetworkPolicy denies egress to upstream for 10 min, asserts cluster stays Ready |
-| 09 | `self-sovereign-cutover-status` ConfigMap | mutable state | Per-step state machine read+written by every step + the UI |
+| 08 | `cutover-step-08-egress-block-test` ConfigMap | post-pivot | CiliumNetworkPolicy denies egress to upstream for 10 min, asserts cluster stays Ready — the hold + green-assertion cover EVERY region (#5359) |
+| 09 | `self-sovereign-cutover-status` ConfigMap | mutable state | Per-step state machine read+written by every step + the UI (#5359 adds `step.<step>.region.<regionKey>.*` per-secondary-region keys) |
+
+### Secondary-region legs (#5359)
+
+On a 2-region Sovereign the pre-0.1.151 chain pivoted ONLY the
+control-plane region — region-B's Flux stayed on github/ghcr while
+`cutoverComplete=true` (hw288 false positive; also the #5339 per-region
+version drift). Steps 05/06/08 now run a leg per secondary region using
+`kubectl --kubeconfig /secondary-kubeconfigs/<regionKey>.yaml`. The
+kubeconfigs come from the `cutover-secondary-kubeconfigs` Secret that
+catalyst-api (cutover.go `runCutover`, bp-catalyst-platform ≥1.4.1213
+RBAC) materialises at every run start from the secondary kubeconfig
+store it already holds on its PVC (the ClusterMesh-establish / #5244
+mechanism). The volume is `optional: true`: on a single-region
+Sovereign the Secret is guaranteed absent and every leg no-ops —
+behavior identical to 0.1.150. See `values.yaml` `secondaryRegions.*`.
+Step-04's region-B leg (secondary node containerd/Dragonfly pivot) is
+the remaining increment, tracked on #5359.
 
 The phase column controls image routing: `pre`-phase steps must use
 upstream-public images because they run BEFORE step-04 pivots the node

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -26,6 +26,32 @@ GitRepository. Flux secretRef takes only a name (no namespace) and
 resolves it in the GitRepository's own namespace, so the Secret is
 created locally from the cross-namespace PAT here.
 
+#5359 (Refs #5265 #5339) — SECONDARY-REGION leg. On a 2-region Sovereign
+region-B runs its OWN flux whose bootstrap GitRepository still points at
+public github.com after the region-A patch — live-proven on hw288
+(cc=true, region-B GitRepository -> github.com). After the region-A
+patch this Job iterates every kubeconfig in /secondary-kubeconfigs
+(the `cutover-secondary-kubeconfigs` Secret catalyst-api materialises
+at run start from its on-PVC secondary kubeconfig store; mounted
+optional:true so a single-region Sovereign renders the leg inert) and:
+
+  1. establishes the ClusterMesh global-Service path to the local
+     Gitea (the bp-cnpg-pair / bp-openbao cross-region-mesh idiom):
+     annotates region-A's gitea-http Service `service.cilium.io/
+     global=true` + creates the same-named zero-backend alias Service
+     in the secondary's `gitea` namespace, so `gitea-http.gitea.svc`
+     resolves there and the dial crosses the mesh to region-A;
+  2. mirrors the basic-auth Secret into the secondary's flux-system;
+  3. applies the SAME url/branch/secretRef/ignore patch to the
+     secondary's GitRepository (secondaryRegions.giteaURL overrides
+     the URL; empty = the same in-cluster URL region-A uses);
+  4. FAIL-LOUD waits for the secondary GitRepository to reach
+     Ready=True on the pivoted URL (secondaryRegions.
+     gitRepositoryReadySeconds) — succeeding without region-B
+     reconciling local Gitea would re-mint the #5359 false positive;
+  5. records `step.flux-gitrepository-patch.region.<key>.result` on
+     the status ConfigMap (the per-region tracking #5359 asks for).
+
 Image phase: post.
 */ -}}
 apiVersion: v1
@@ -79,6 +105,19 @@ data:
             value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
           - name: GIT_AUTH_USERNAME
             value: {{ .Values.gitRepositorySecretRef.username | quote }}
+          # #5359 — secondary-region leg inputs. SECONDARY_GITEA_URL empty =
+          # reuse LOCAL_GITEA_URL (the in-cluster Service URL, reachable from
+          # the secondary via the ClusterMesh global-Service alias this leg
+          # establishes). STATUS_CONFIGMAP receives the per-region
+          # step.<step>.region.<key>.* tracking keys.
+          - name: SECONDARY_GITEA_URL
+            value: {{ if .Values.secondaryRegions.giteaURL }}{{ printf "%s/%s/%s" (.Values.secondaryRegions.giteaURL | trimSuffix "/") .Values.gitea.org .Values.gitea.repo | quote }}{{ else }}""{{ end }}
+          - name: SECONDARY_GITREPO_READY_SECONDS
+            value: {{ .Values.secondaryRegions.gitRepositoryReadySeconds | quote }}
+          - name: STATUS_CONFIGMAP
+            value: {{ .Values.status.configMapName | quote }}
+          - name: CUTOVER_NAMESPACE
+            value: {{ .Release.Namespace | quote }}
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -173,6 +212,127 @@ data:
             kubectl annotate --overwrite gitrepository "${GITREPO_NAME}" \
               -n "${GITREPO_NAMESPACE}" \
               "reconcile.fluxcd.io/requestedAt=$(date +%s)"
+            echo "[flux-gitrepository-patch] control-plane region done"
+
+            # ── #5359: SECONDARY-REGION legs ─────────────────────────────
+            # /secondary-kubeconfigs is the optional:true mount of the
+            # cutover-secondary-kubeconfigs Secret (one <regionKey>.yaml per
+            # secondary region, materialised by catalyst-api at run start).
+            # Empty/absent = single-region Sovereign = this whole block
+            # no-ops (pre-#5359 behavior byte-identical).
+            sec_url="${SECONDARY_GITEA_URL:-}"
+            [ -n "${sec_url}" ] || sec_url="${LOCAL_GITEA_URL}"
+            for skc in /secondary-kubeconfigs/*.yaml; do
+              [ -e "${skc}" ] || continue
+              region=$(basename "${skc}" .yaml)
+              echo "[flux-gitrepository-patch] #5359 secondary region ${region}: pivoting its GitRepository -> ${sec_url}"
+
+              # 1a. Share region-A's gitea-http endpoints into the mesh (the
+              # bp-cnpg-pair global-Service idiom). Annotating the LIVE
+              # Service is additive + idempotent; the durable bp-gitea-side
+              # annotation is tracked on #5359.
+              kubectl -n gitea annotate --overwrite service gitea-http \
+                "service.cilium.io/global=true" "service.cilium.io/shared=true" \
+                || echo "[flux-gitrepository-patch] WARN: could not annotate gitea/gitea-http global (mesh share) — secondary clone will fail if the alias has no reachable backend"
+
+              # 1b. Same-named zero-backend alias Service in the SECONDARY
+              # cluster so gitea-http.gitea.svc resolves there and the dial
+              # crosses the mesh to region-A (bp-openbao
+              # cross-region-mesh-service.yaml is the reference shape).
+              cat >/tmp/gitea-mesh-alias.yaml <<EOF
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: gitea
+            ---
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: gitea-http
+              namespace: gitea
+              labels:
+                app.kubernetes.io/managed-by: self-sovereign-cutover
+                catalyst.openova.io/component: cutover-secondary-gitea-mesh-alias
+              annotations:
+                service.cilium.io/global: "true"
+                catalyst.openova.io/mirrored-from: region-a/gitea/gitea-http
+            spec:
+              type: ClusterIP
+              selector:
+                app.kubernetes.io/name: gitea
+              ports:
+                - name: http
+                  port: 3000
+                  targetPort: 3000
+                  protocol: TCP
+            EOF
+              kubectl --kubeconfig "${skc}" apply -f /tmp/gitea-mesh-alias.yaml
+
+              # 2. Basic-auth Secret in the secondary's flux-system (same PAT
+              # bytes written to /tmp/git-auth-secret.yaml above).
+              kubectl --kubeconfig "${skc}" apply -f /tmp/git-auth-secret.yaml
+
+              # 3. Same patch shape as region-A (URL may differ via
+              # secondaryRegions.giteaURL).
+              if ! kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" >/dev/null 2>&1; then
+                echo "[flux-gitrepository-patch] #5359 secondary ${region}: GitRepository ${GITREPO_NAMESPACE}/${GITREPO_NAME} absent — no flux git tether to pivot in this region; recording skipped"
+                kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                  -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"skipped\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                continue
+              fi
+              cat >/tmp/patch-secondary.yaml <<EOF
+            spec:
+              url: ${sec_url}
+              ref:
+                branch: ${BRANCH}
+              secretRef:
+                name: ${GIT_AUTH_SECRET_NAME}
+              ignore: |
+                /*
+                !/clusters/_template
+                !/clusters/${SOVEREIGN_FQDN}
+                !/platform
+                !/products
+            EOF
+              kubectl --kubeconfig "${skc}" patch gitrepository "${GITREPO_NAME}" \
+                -n "${GITREPO_NAMESPACE}" \
+                --type=merge --patch-file /tmp/patch-secondary.yaml
+              kubectl --kubeconfig "${skc}" annotate --overwrite gitrepository "${GITREPO_NAME}" \
+                -n "${GITREPO_NAMESPACE}" \
+                "reconcile.fluxcd.io/requestedAt=$(date +%s)"
+
+              # 4. FAIL-LOUD readiness: the secondary MUST reconcile the
+              # local Gitea within the bounded window, or the step fails and
+              # cutoverComplete stays false — a silent skip here IS the
+              # #5359 false positive.
+              sg_deadline=$(( $(date +%s) + ${SECONDARY_GITREPO_READY_SECONDS} ))
+              sg_ready=""
+              while [ "$(date +%s)" -lt "${sg_deadline}" ]; do
+                sg_status=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+                sg_url=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
+                  -o jsonpath='{.spec.url}' 2>/dev/null || echo "")
+                if [ "${sg_status}" = "True" ] && [ "${sg_url}" = "${sec_url}" ]; then
+                  sg_ready="yes"
+                  break
+                fi
+                echo "[flux-gitrepository-patch] #5359 secondary ${region}: Ready=${sg_status:-<none>} url=${sg_url:-<none>} — re-checking in 10s"
+                sleep 10
+              done
+              if [ -z "${sg_ready}" ]; then
+                sg_msg=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || echo "")
+                echo "[flux-gitrepository-patch] FATAL: secondary region ${region} GitRepository did not reach Ready=True on ${sec_url} within ${SECONDARY_GITREPO_READY_SECONDS}s: ${sg_msg} — region-B is still git-tethered; refusing to succeed (#5359)" >&2
+                kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                  -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"failed\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                exit 1
+              fi
+
+              # 5. Per-region durable tracking (#5359).
+              kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"success\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+              echo "[flux-gitrepository-patch] #5359 secondary region ${region}: GitRepository Ready on local Gitea"
+            done
             echo "[flux-gitrepository-patch] done"
         resources:
           requests: { cpu: 50m, memory: 64Mi }
@@ -189,6 +349,18 @@ data:
         volumeMounts:
           - name: tmp
             mountPath: /tmp
+          # #5359 — optional secondary-region kubeconfigs (empty on a
+          # single-region Sovereign; the leg no-ops).
+          - name: secondary-kubeconfigs
+            mountPath: /secondary-kubeconfigs
+            readOnly: true
     volumes:
       - name: tmp
         emptyDir: {}
+      # #5359 — materialised by catalyst-api (cutover.go runCutover) from its
+      # on-PVC secondary kubeconfig store at every run start; optional:true
+      # so a single-region Sovereign (no Secret) schedules unchanged.
+      - name: secondary-kubeconfigs
+        secret:
+          secretName: {{ .Values.secondaryRegions.kubeconfigSecretName }}
+          optional: true

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -22,6 +22,31 @@ Three phases run in this Job:
   Phase 2  Push the YAML edit to local Gitea so the bootstrap-kit
            Kustomization reconcile doesn't revert Phase 1 within ~1m.
 
+#5359 (Refs #5265 #5339) — SECONDARY-REGION leg. On a 2-region Sovereign
+region-B runs its OWN flux with its OWN HelmRepository set, all still on
+oci://ghcr.io/openova-io after the region-A pivot (live-proven on hw288:
+64/64 region-B HRs on ghcr despite cc=true — the direct cause of the
+#5339 per-region chart-version drift). Between Phase 2 and Phase 3 this
+Job now iterates every kubeconfig in /secondary-kubeconfigs (the
+`cutover-secondary-kubeconfigs` Secret catalyst-api materialises at run
+start; optional:true so single-region renders the leg inert) and, per
+secondary region: syncs region-A's merged ghcr-pull auth bytes + the
+cutover-harbor-ca trust Secret into its flux-system, pivots EVERY
+ghcr-prefixed HelmRepository to local Harbor (same prefix-swap +
+certSecretRef shape as Phase 1), read-back-asserts ZERO upstream-
+prefixed HRs remain (fail-loud), and records `step.helmrepository-
+patches.region.<key>.*` on the status ConfigMap. After Phase-3b's
+readiness-gated strip lands on region-A, the (now-stripped) auth bytes
+are re-synced to every secondary so region-B sheds the mothership creds
+under the SAME proven-pullable gate — never before it (the hw139
+strip-before-proof lesson applies per-region). Durability is shared:
+the secondaries consume the SAME local Gitea tree Phase 2 pushed (their
+GitRepository was pivoted by step-05's #5359 leg), so their bootstrap-
+kit reconcile re-asserts the pivoted URLs instead of reverting them.
+Region-B chart PULLS go through the Sovereign's own public registry
+door (registry.<fqdn> via the region-A gateway — the same EIP the
+ClusterMesh control-plane already proves reachable cross-region).
+
 SCOPE — what this step does NOT touch (#2951 decision record):
   This step rewrites HelmRepository spec.url (the chart SOURCE: ghcr.io
   → local Harbor) ONLY. It deliberately does NOT rewrite per-Blueprint
@@ -243,6 +268,11 @@ data:
             value: {{ .Values.helmRepositoryTrust.sourceSecretNamePrefix | quote }}
           - name: HELMREPO_TRUST_DEST_SECRET
             value: {{ .Values.helmRepositoryTrust.destSecretName | quote }}
+          # #5359 — per-region status tracking for the secondary-region leg.
+          - name: STATUS_CONFIGMAP
+            value: {{ .Values.status.configMapName | quote }}
+          - name: CUTOVER_NAMESPACE
+            value: {{ .Release.Namespace | quote }}
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
@@ -252,6 +282,11 @@ data:
             readOnly: true
           - name: tmp
             mountPath: /tmp
+          # #5359 — optional secondary-region kubeconfigs (empty on a
+          # single-region Sovereign; the leg no-ops).
+          - name: secondary-kubeconfigs
+            mountPath: /secondary-kubeconfigs
+            readOnly: true
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -1115,6 +1150,166 @@ data:
             fi
 
             # ====================================================================
+            # #5359 — SECONDARY-REGION HelmRepository pivot legs
+            # ====================================================================
+            # Runs BEFORE Phase 3 on purpose: the secondaries get the MERGED
+            # (local-Harbor-added, mothership-retained) ghcr-pull bytes now, so
+            # their pivoted HRs can authenticate while region-A's Phase-3a
+            # proves local Harbor is pullable; the STRIPPED bytes are re-synced
+            # after Phase-3b (sync_secondary_ghcr_pull is called again there) —
+            # strip-before-proof is the hw139 half-pivot lesson, applied
+            # per-region.
+            sync_secondary_ghcr_pull() {
+              # No secondaries configured → genuine no-op (single-region).
+              sy_have_secondary=0
+              for sy_probe in /secondary-kubeconfigs/*.yaml; do
+                [ -e "${sy_probe}" ] || continue
+                sy_have_secondary=1
+                break
+              done
+              if [ "${sy_have_secondary}" = "0" ]; then
+                return 0
+              fi
+              # Read via read_secret_key (json+jq), NEVER kubectl jsonpath:
+              # jsonpath={.data.${GHCR_PULL_SECRET_KEY}} with the literal key
+              # ".dockerconfigjson" expands to {.data..dockerconfigjson}
+              # (recursive descent) → always empty → the sync silently
+              # no-ops and region-B HRs auth-fail AFTER the read-back
+              # passes — the exact fail-silent hole #5359 exists to close.
+              # (Same Fix-#77 trap Phase-0 documents above.)
+              sy_b64=$(read_secret_key "${GHCR_PULL_SECRET_NAMESPACE}")
+              if [ -z "${sy_b64}" ]; then
+                sy_b64=$(read_secret_key "flux-system")
+              fi
+              if [ -z "${sy_b64}" ]; then
+                echo "[helmrepository-patches] FATAL: #5359 cannot read ${GHCR_PULL_SECRET_NAME} key ${GHCR_PULL_SECRET_KEY} (tried ${GHCR_PULL_SECRET_NAMESPACE} + flux-system) for the secondary sync — refusing to fail-silent" >&2
+                return 1
+              fi
+              for sy_kc in /secondary-kubeconfigs/*.yaml; do
+                [ -e "${sy_kc}" ] || continue
+                sy_region=$(basename "${sy_kc}" .yaml)
+                cat >/tmp/sec-ghcr-pull.yaml <<EOF
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: ${GHCR_PULL_SECRET_NAME}
+              namespace: ${GHCR_PULL_SECRET_NAMESPACE}
+              labels:
+                app.kubernetes.io/managed-by: self-sovereign-cutover
+              annotations:
+                catalyst.openova.io/mirrored-from: region-a/${GHCR_PULL_SECRET_NAMESPACE}/${GHCR_PULL_SECRET_NAME}
+            type: kubernetes.io/dockerconfigjson
+            data:
+              ${GHCR_PULL_SECRET_KEY}: ${sy_b64}
+            EOF
+                if kubectl --kubeconfig "${sy_kc}" apply -f /tmp/sec-ghcr-pull.yaml >/dev/null; then
+                  echo "[helmrepository-patches] #5359 secondary ${sy_region}: ghcr-pull auth synced from region-A"
+                else
+                  echo "[helmrepository-patches] FATAL: #5359 secondary ${sy_region}: ghcr-pull sync failed — its pivoted HelmRepositories could not authenticate to ${harbor_host}" >&2
+                  return 1
+                fi
+              done
+              return 0
+            }
+
+            pivot_secondary_regions() {
+              for pv_kc in /secondary-kubeconfigs/*.yaml; do
+                [ -e "${pv_kc}" ] || continue
+                pv_region=$(basename "${pv_kc}" .yaml)
+                echo "[helmrepository-patches] #5359 secondary region ${pv_region}: pivoting its HelmRepositories ${UPSTREAM_PREFIX} -> ${local_prefix}"
+
+                # Trust anchor for the LE-staging in-cluster registry — same
+                # certSecretRef mechanism as Phase-1 (Flux OCI HRs have no
+                # insecureSkipVerify).
+                if [ -n "${trust_secret}" ]; then
+                  if kubectl -n "${HELMREPO_NAMESPACE}" get secret "${trust_secret}" -o json 2>/dev/null \
+                    | jq '{apiVersion, kind, type, metadata: {name: .metadata.name, namespace: .metadata.namespace, labels: {"app.kubernetes.io/managed-by": "self-sovereign-cutover"}}, data: (.data // {})}' \
+                    | kubectl --kubeconfig "${pv_kc}" apply -f - >/dev/null; then
+                    echo "[helmrepository-patches] #5359 secondary ${pv_region}: trust Secret ${trust_secret} synced"
+                  else
+                    echo "[helmrepository-patches] #5359 WARN secondary ${pv_region}: trust Secret sync failed — pivoting WITHOUT certSecretRef durability there"
+                  fi
+                fi
+
+                # Enumerate the secondary's LIVE HR set (drift-proof — its own
+                # set is authoritative, exactly the Phase-0.9 union discipline).
+                kubectl --kubeconfig "${pv_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
+                  -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' 2>/dev/null \
+                  > /tmp/sec_hrs.txt || true
+                if ! grep -q . /tmp/sec_hrs.txt; then
+                  echo "[helmrepository-patches] #5359 secondary ${pv_region}: no HelmRepositories found — recording skipped"
+                  kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                    -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"skipped\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                  continue
+                fi
+
+                pv_ok=0; pv_skip=0; pv_fail=0
+                while IFS= read -r pv_line; do
+                  [ -n "${pv_line}" ] || continue
+                  pv_name="${pv_line%%=*}"
+                  pv_url="${pv_line#*=}"
+                  case "${pv_url}" in
+                    "${UPSTREAM_PREFIX}"*)
+                      pv_new=$(printf '%s' "${pv_url}" | sed -e "s,${UPSTREAM_PREFIX},${local_prefix},")
+                      if [ -n "${trust_secret}" ]; then
+                        pv_patch=$(printf '{"spec":{"url":"%s","certSecretRef":{"name":"%s"}}}' "${pv_new}" "${trust_secret}")
+                      else
+                        pv_patch=$(printf '{"spec":{"url":"%s"}}' "${pv_new}")
+                      fi
+                      if kubectl --kubeconfig "${pv_kc}" patch helmrepository "${pv_name}" \
+                          -n "${HELMREPO_NAMESPACE}" --type=merge --patch "${pv_patch}" >/dev/null; then
+                        kubectl --kubeconfig "${pv_kc}" annotate --overwrite helmrepository "${pv_name}" \
+                          -n "${HELMREPO_NAMESPACE}" \
+                          "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
+                        pv_ok=$((pv_ok+1))
+                      else
+                        echo "[helmrepository-patches] #5359 FAIL secondary ${pv_region}: ${pv_name}"
+                        pv_fail=$((pv_fail+1))
+                      fi
+                      ;;
+                    *)
+                      pv_skip=$((pv_skip+1))
+                      ;;
+                  esac
+                done < /tmp/sec_hrs.txt
+                echo "[helmrepository-patches] #5359 secondary ${pv_region}: pivot ok=${pv_ok} skip=${pv_skip} fail=${pv_fail}"
+                if [ "${pv_fail}" -ne 0 ]; then
+                  kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                    -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"failed\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                  return 1
+                fi
+
+                # Read-back assert: ZERO upstream-prefixed HRs may remain — a
+                # partially-pivoted secondary succeeding anyway IS the #5359
+                # false positive.
+                kubectl --kubeconfig "${pv_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
+                  -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' 2>/dev/null \
+                  > /tmp/sec_hrs_after.txt || true
+                pv_left=$(grep -cF -- "=${UPSTREAM_PREFIX}" /tmp/sec_hrs_after.txt || true)
+                if [ "${pv_left}" -ne 0 ]; then
+                  echo "[helmrepository-patches] FATAL: #5359 secondary ${pv_region}: ${pv_left} HelmRepository(ies) still on ${UPSTREAM_PREFIX} after the pivot:" >&2
+                  grep -F -- "=${UPSTREAM_PREFIX}" /tmp/sec_hrs_after.txt | sed 's/^/  STILL-UPSTREAM /' >&2 || true
+                  kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                    -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"failed\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                  return 1
+                fi
+
+                kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                  -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"success\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                echo "[helmrepository-patches] #5359 secondary region ${pv_region}: all HelmRepositories on ${local_prefix}"
+              done
+              return 0
+            }
+
+            if ! sync_secondary_ghcr_pull; then
+              exit 1
+            fi
+            if ! pivot_secondary_regions; then
+              echo "[helmrepository-patches] FATAL: #5359 secondary-region HelmRepository pivot failed — region-B is still chart-tethered to the public upstream; refusing to succeed" >&2
+              exit 1
+            fi
+
+            # ====================================================================
             # Phase 3 — readiness-gated mothership-auth STRIP (Refs #3379 #3526)
             # ====================================================================
             #
@@ -1575,6 +1770,9 @@ data:
 
             if [ -z "${strip_remaining}" ]; then
               echo "[helmrepository-patches] Phase-3b skip: mothership auth entries already absent from ghcr-pull"
+              # #5359 — region-A's bytes are already stripped; re-sync them so
+              # a re-run also converges every secondary onto the stripped set.
+              sync_secondary_ghcr_pull || exit 1
               echo "[helmrepository-patches] step complete"
               exit 0
             fi
@@ -1611,6 +1809,11 @@ data:
               exit 1
             fi
 
+            # #5359 — propagate the now-STRIPPED auth bytes to every secondary
+            # region so region-B sheds the mothership creds under the same
+            # proven-pullable gate that just cleared region-A.
+            sync_secondary_ghcr_pull || exit 1
+
             echo "[helmrepository-patches] step complete"
         resources:
           requests: { cpu: 50m, memory: 128Mi }
@@ -1637,4 +1840,11 @@ data:
               path: extract-pins.sh
       - name: tmp
         emptyDir: {}
+      # #5359 — materialised by catalyst-api (cutover.go runCutover) from its
+      # on-PVC secondary kubeconfig store at every run start; optional:true
+      # so a single-region Sovereign (no Secret) schedules unchanged.
+      - name: secondary-kubeconfigs
+        secret:
+          secretName: {{ .Values.secondaryRegions.kubeconfigSecretName }}
+          optional: true
 # re-publish 0.1.145 (Blueprint Release for #5238 failed transiently — #5237 union-warm fix)

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -6,6 +6,24 @@ egress to upstream domains for .Values.egressTest.durationSeconds, then
 asserts every HelmRelease + Kustomization stays Ready throughout. The
 policy is removed at end-of-test regardless of pass/fail.
 
+#5359 — SECONDARY-REGION legs. On a 2-region Sovereign the hold is
+ALSO applied to every secondary region's cluster (kubeconfigs from the
+optional /secondary-kubeconfigs mount; empty on single-region = block
+inert), immediately before the survival window, with the SAME manifest
+(ALLOW_CIDRS + the #4596/#5020-5025 provider-API carve-outs inherited)
+plus a mesh-wide toEndpoints allow (cross-cluster pod identities that
+toCIDR never matches) and the Sovereign's OWN registry./gitea. gateway
+IPs. Every region's Flux must stay regression-free through the window
+or the proof FAILS — a region-A-only hold certified hw288 sovereign
+while region-B still pulled github/ghcr/quay (false-positive cc=true).
+Per-region verdicts land as step.egress-block-test.region.<key>.* on
+the status ConfigMap. Teardown covers every region on pass, fail, and
+trap paths; the catalyst-api #5014 backstop reaps the secondary
+policies too (reapSecondaryCutoverEgressPolicies) on SIGKILL/watch-loss.
+The region-A fresh-pull/call-home proofs stay region-A-scoped; the
+region-B node-image pivot (step-04 leg) is the remaining #5359
+increment and is NOT silently faked here.
+
 Image phase: post.
 */ -}}
 apiVersion: v1
@@ -89,6 +107,24 @@ data:
           # /24, which EXCLUDES the bastion .24.x + the GitHub/mothership ranges).
           - name: PROVIDER_API_CIDRS
             value: {{ .Values.egressTest.allowProviderCIDRs | default (list) | join " " | quote }}
+          # #5359 — SECONDARY-REGION deny-egress legs. The sovereignty hold is
+          # applied to EVERY region's cluster (kubeconfigs from the optional
+          # /secondary-kubeconfigs mount) and every region must stay green
+          # through the window — a region-A-only hold proved nothing about
+          # region-B (hw288 false-positive cc=true). The secondary manifest
+          # is the region-A manifest (ALLOW_CIDRS + PROVIDER_API_CIDRS
+          # carve-outs inherited verbatim — the #4596/#5020-5025 CSI-freeze
+          # trap catalog applies per-region) PLUS: a mesh-wide toEndpoints
+          # allow (cross-cluster pod dials carry a ClusterMesh identity that
+          # toCIDR NEVER matches — the ipBlock/remote-identity lesson), the
+          # auto-resolved public IPs of the Sovereign's OWN
+          # registry.<fqdn>/gitea.<fqdn> gateway door, and these extra CIDRs.
+          - name: SECONDARY_EXTRA_ALLOW_CIDRS
+            value: {{ .Values.secondaryRegions.extraEgressAllowCIDRs | default (list) | join " " | quote }}
+          - name: SOVEREIGN_FQDN
+            value: {{ .Values.sovereign.fqdn | quote }}
+          - name: STATUS_CONFIGMAP
+            value: {{ .Values.status.configMapName | quote }}
           # #3678 — active call-home assertion knobs. During the hold, curl
           # each CALL_HOME_HOSTS entry FROM this pod (under the policy); any
           # that connects fails the proof.
@@ -254,6 +290,11 @@ data:
           # image to the local Harbor path step-03 pushed it to.
           - name: offline-mirror-resolver
             mountPath: /resolver
+            readOnly: true
+          # #5359 — optional secondary-region kubeconfigs (empty on a
+          # single-region Sovereign; the secondary hold legs no-op).
+          - name: secondary-kubeconfigs
+            mountPath: /secondary-kubeconfigs
             readOnly: true
         command: ["/bin/sh", "-c"]
         args:
@@ -1489,6 +1530,83 @@ data:
               echo "[egress-block-test] #3695: host GitOps loop healthy — bootstrap-kit reconciles local git"
             fi
 
+            # ── #5359: SECONDARY-REGION deny-egress legs ─────────────────
+            # Applied HERE — after every pre-hold gate cleared on region-A
+            # and immediately before the baseline capture — so the
+            # secondaries are denied for exactly the survival window (the
+            # long region-A pre-hold roll sweep never runs with region-B
+            # blind-folded). Empty /secondary-kubeconfigs (single-region)
+            # renders this whole block inert.
+            secondary_policy_teardown() {
+              for td_kc in /secondary-kubeconfigs/*.yaml; do
+                [ -e "${td_kc}" ] || continue
+                kubectl --kubeconfig "${td_kc}" delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true 2>/dev/null || true
+              done
+            }
+            SECONDARY_POLICY_APPLIED=""
+            secondary_kubeconfig_count=0
+            for sc_kc in /secondary-kubeconfigs/*.yaml; do
+              [ -e "${sc_kc}" ] || continue
+              secondary_kubeconfig_count=$((secondary_kubeconfig_count+1))
+            done
+            if [ "${secondary_kubeconfig_count}" -gt 0 ] && [ "${POLICY_APPLIED}" = "yes" ]; then
+              echo "[egress-block-test] #5359: extending the deny-egress hold to ${secondary_kubeconfig_count} secondary region(s)"
+              cp /work/egress-deny.yaml /work/egress-deny-secondary.yaml
+              if [ "${DEFAULT_DENY_EGRESS}" = "true" ]; then
+                {
+                  # Cross-cluster (intra-Sovereign) pod dials: a ClusterMesh
+                  # remote endpoint carries a mesh identity that toCIDR NEVER
+                  # matches (reference_k8s_netpol_ipblock_never_matches_
+                  # clustermesh_remote_identity) — region-B's flux clones the
+                  # local Gitea over the mesh alias, so allow mesh endpoints
+                  # explicitly. Both clusters belong to THIS Sovereign; no
+                  # public destination is opened.
+                  echo "    - toEndpoints:"
+                  echo "        - {}"
+                  # The Sovereign's OWN gateway door (registry.<fqdn> +
+                  # gitea.<fqdn>): region-B's helm-controller pulls pivoted
+                  # charts through it. Its EIP is the Sovereign's own
+                  # infrastructure — allowing it proves nothing less about
+                  # github/ghcr/mothership independence. Resolved here (same
+                  # getent discipline as the UPSTREAM_HOSTS block-list).
+                  for sov_host in "${LOCAL_REGISTRY_HOST}" "gitea.${SOVEREIGN_FQDN}"; do
+                    for sov_ip in $(getent ahostsv4 "${sov_host}" 2>/dev/null | awk '{print $1}' | sort -u); do
+                      case "${sov_ip}" in
+                        10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*|127.*|"") : ;;
+                        *)
+                          echo "    - toCIDR:"
+                          echo "        - ${sov_ip}/32" ;;
+                      esac
+                    done
+                  done
+                  for sec_cidr in ${SECONDARY_EXTRA_ALLOW_CIDRS}; do
+                    echo "    - toCIDR:"
+                    echo "        - ${sec_cidr}"
+                  done
+                } >>/work/egress-deny-secondary.yaml
+              fi
+              for sc_kc in /secondary-kubeconfigs/*.yaml; do
+                [ -e "${sc_kc}" ] || continue
+                sc_region=$(basename "${sc_kc}" .yaml)
+                # Delete-before-apply: clears a stale hold policy leaked by a
+                # SIGKILLed prior run (idempotent re-run self-heal).
+                kubectl --kubeconfig "${sc_kc}" delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true 2>/dev/null || true
+                if kubectl --kubeconfig "${sc_kc}" apply -f /work/egress-deny-secondary.yaml; then
+                  SECONDARY_POLICY_APPLIED="${SECONDARY_POLICY_APPLIED} ${sc_region}"
+                  echo "[egress-block-test] #5359: deny-egress applied on secondary region ${sc_region}"
+                else
+                  echo "[egress-block-test] FATAL: #5359 could not apply the deny-egress hold on secondary region ${sc_region} — a region-A-only hold is NOT the 2-region sovereignty proof; refusing to continue" >&2
+                  secondary_policy_teardown
+                  exit 1
+                fi
+              done
+              # Re-arm the teardown trap to cover the secondaries too (the
+              # region-A-only trap was set at the region-A apply above).
+              trap 'kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true 2>/dev/null || true; secondary_policy_teardown' TERM EXIT
+            elif [ "${secondary_kubeconfig_count}" -gt 0 ]; then
+              echo "[egress-block-test] #5359: ${secondary_kubeconfig_count} secondary region(s) present but no region-A egressDeny was applied (enforce off / fail-safe fallback) — secondary legs run assertion-only like region-A"
+            fi
+
             echo "[egress-block-test] capturing baseline NotReady set"
             baseline_hr=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -A \
               -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
@@ -1517,12 +1635,38 @@ data:
             # busybox ash -n) and needs the baseline as a file.
             printf '%s\n' "${baseline_hr}" > /work/baseline_hr.txt
             printf '%s\n' "${baseline_ks}" > /work/baseline_ks.txt
+
+            # #5359 — per-secondary baselines (same only-NEW-regressions
+            # criterion as region-A; a secondary's pre-existing NotReady set
+            # is excluded, a NEW NotReady during the hold fails the proof).
+            for sb_kc in /secondary-kubeconfigs/*.yaml; do
+              [ -e "${sb_kc}" ] || continue
+              sb_region=$(basename "${sb_kc}" .yaml)
+              kubectl --kubeconfig "${sb_kc}" get helmreleases.helm.toolkit.fluxcd.io -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null \
+                | grep -E '=False$' | sort -u > "/work/baseline_hr_${sb_region}.txt" || true
+              kubectl --kubeconfig "${sb_kc}" get kustomizations.kustomize.toolkit.fluxcd.io -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null \
+                | grep -E '=False$' | sort -u > "/work/baseline_ks_${sb_region}.txt" || true
+              if [ -s "/work/baseline_hr_${sb_region}.txt" ] || [ -s "/work/baseline_ks_${sb_region}.txt" ]; then
+                echo "[egress-block-test] #5359 baseline (secondary ${sb_region}) pre-existing NotReady items (excluded from regression check):"
+                sed "s/^/  baseline[${sb_region}] HR /" "/work/baseline_hr_${sb_region}.txt" || true
+                sed "s/^/  baseline[${sb_region}] KS /" "/work/baseline_ks_${sb_region}.txt" || true
+              fi
+              # Normalize a 0-byte baseline to the single-newline shape the
+              # region-A files carry (printf '%s\n' "") so `grep -vxF -f`
+              # behaves identically across grep flavors.
+              [ -s "/work/baseline_hr_${sb_region}.txt" ] || printf '\n' > "/work/baseline_hr_${sb_region}.txt"
+              [ -s "/work/baseline_ks_${sb_region}.txt" ] || printf '\n' > "/work/baseline_ks_${sb_region}.txt"
+            done
+
             echo "[egress-block-test] entering ${DURATION_SECONDS}s survival window — only NEW NotReady regressions count as failure"
 
             start=$(date +%s)
             deadline=$((start + DURATION_SECONDS))
             poll_interval=30
             new_failures=0
+            : > /work/secondary_failed_regions.txt
 
             while [ "$(date +%s)" -lt "${deadline}" ]; do
               hr_not_ready=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -A \
@@ -1553,6 +1697,30 @@ data:
                 new_failures=$((new_failures+1))
               fi
 
+              # #5359 — the same regression diff against every SECONDARY
+              # region: a NEW NotReady on region-B during the hold means
+              # region-B still NEEDS an external tether — the proof must
+              # fail for the whole Sovereign, not just region-A.
+              for sp_kc in /secondary-kubeconfigs/*.yaml; do
+                [ -e "${sp_kc}" ] || continue
+                sp_region=$(basename "${sp_kc}" .yaml)
+                kubectl --kubeconfig "${sp_kc}" get helmreleases.helm.toolkit.fluxcd.io -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null \
+                  | grep -E '=False$' | sort -u > "/work/hr_not_ready_${sp_region}.txt" || true
+                kubectl --kubeconfig "${sp_kc}" get kustomizations.kustomize.toolkit.fluxcd.io -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null \
+                  | grep -E '=False$' | sort -u > "/work/ks_not_ready_${sp_region}.txt" || true
+                sp_new_hr=$(grep -vxF -f "/work/baseline_hr_${sp_region}.txt" "/work/hr_not_ready_${sp_region}.txt" || true)
+                sp_new_ks=$(grep -vxF -f "/work/baseline_ks_${sp_region}.txt" "/work/ks_not_ready_${sp_region}.txt" || true)
+                if [ -n "${sp_new_hr}${sp_new_ks}" ]; then
+                  echo "[egress-block-test] #5359 NEW NotReady on SECONDARY ${sp_region} at $(($(date +%s) - start))s (regression):"
+                  [ -n "${sp_new_hr}" ] && echo "${sp_new_hr}" | sed "s/^/  NEW[${sp_region}] HR /"
+                  [ -n "${sp_new_ks}" ] && echo "${sp_new_ks}" | sed "s/^/  NEW[${sp_region}] KS /"
+                  new_failures=$((new_failures+1))
+                  echo "${sp_region}" >> /work/secondary_failed_regions.txt
+                fi
+              done
+
               sleep "${poll_interval}"
             done
 
@@ -1564,11 +1732,28 @@ data:
               kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true || true
               echo "[egress-block-test] egressDeny removed"
             fi
+            # #5359 — remove the secondary holds on the same pass/fail paths.
+            if [ -n "${SECONDARY_POLICY_APPLIED}" ]; then
+              secondary_policy_teardown
+              echo "[egress-block-test] #5359 secondary egressDeny removed (${SECONDARY_POLICY_APPLIED} )"
+            fi
+            # #5359 — per-region durable verdict on the status ConfigMap.
+            for sv_kc in /secondary-kubeconfigs/*.yaml; do
+              [ -e "${sv_kc}" ] || continue
+              sv_region=$(basename "${sv_kc}" .yaml)
+              if grep -qxF "${sv_region}" /work/secondary_failed_regions.txt 2>/dev/null; then
+                sv_result="failed"
+              else
+                sv_result="success"
+              fi
+              kubectl -n "${NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                -p "{\"data\":{\"step.egress-block-test.region.${sv_region}.result\":\"${sv_result}\",\"step.egress-block-test.region.${sv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+            done
             if [ "${new_failures}" -gt 0 ]; then
-              echo "[egress-block-test] cluster developed NEW NotReady items during the window — sovereignty proof FAILED"
+              echo "[egress-block-test] cluster developed NEW NotReady items during the window (any region) — sovereignty proof FAILED"
               exit 1
             fi
-            echo "[egress-block-test] no new regressions during ${DURATION_SECONDS}s window — sovereignty proof PASSED"
+            echo "[egress-block-test] no new regressions during ${DURATION_SECONDS}s window (all $((secondary_kubeconfig_count + 1)) region(s)) — sovereignty proof PASSED"
         resources:
           requests: { cpu: 50m, memory: 64Mi }
           limits:   { memory: 256Mi }
@@ -1594,3 +1779,10 @@ data:
           items:
             - key: resolver.sh
               path: resolver.sh
+      # #5359 — materialised by catalyst-api (cutover.go runCutover) from its
+      # on-PVC secondary kubeconfig store at every run start; optional:true
+      # so a single-region Sovereign (no Secret) schedules unchanged.
+      - name: secondary-kubeconfigs
+        secret:
+          secretName: {{ .Values.secondaryRegions.kubeconfigSecretName }}
+          optional: true

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -144,6 +144,10 @@ rules:
   - apiGroups: [""]
     resources: ["services"]   # #4639 (Refs #4637): registry-pivot DaemonSet resolves the cilium-gateway Service ClusterIP (node-routable, serves registry.<fqdn> wildcard TLS + token realm) for the dfdaemon hostAlias instead of the un-hairpinnable public gateway EIP
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]   # #5359 step-05 secondary leg: annotate gitea-http with service.cilium.io/global+shared so the region-B zero-backend alias resolves it over ClusterMesh; without patch the annotate 403s and every 2-region cutover dies at the step-05 Ready wait
+    resourceNames: ["gitea-http"]
+    verbs: ["patch", "update"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]   # step 06 Phase -1 (#1871, chart 0.1.32): wait for cilium-gateway Programmed=True before URL rewrite
     verbs: ["get", "list", "watch"]

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3564,4 +3564,106 @@ fi
 if [ "$c70_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5265: Day-2 Harbor pin reconciler is a Deployment [region-kill canon], absent by default [severance-safe], reuses the 03b bootstrapkit_pins extractor + the durable artifact-API probe, publishes the offline-media missing manifest, defaults to zero-egress detect mode, and gates the upstream helm-pull/push behind opt-in warm mode; step count unchanged at 11)"
 
+echo "[cutover-contract] Case 71: #5359 secondary-region legs — steps 05/06/08 mount the optional cutover-secondary-kubeconfigs Secret and run fail-loud region-B pivot/hold legs; single-region renders inert; step count stays 11"
+# hw288 (dep 027f07559af1f9f7): cc=true with region-B still on github/ghcr/quay
+# — the cutover pivoted + deny-egress-proved ONLY the control-plane region.
+# 0.1.151 adds per-secondary-region legs driven by the kubeconfigs catalyst-api
+# materialises into the cutover-secondary-kubeconfigs Secret at run start.
+# SIGPIPE discipline (Case 16c): every assertion below is a FILE-fed grep.
+c71_fail=0
+S05="$TMP/c71-step05.yaml"
+S06="$TMP/c71-step06.yaml"
+S08="$TMP/c71-step08.yaml"
+awk 'BEGIN{RS="\n---\n"} /name: cutover-step-05-flux-gitrepository-patch/{print; exit}' "$TMP/render.yaml" > "$S05"
+awk 'BEGIN{RS="\n---\n"} /name: cutover-step-06-helmrepository-patches/{print; exit}' "$TMP/render.yaml" > "$S06"
+awk 'BEGIN{RS="\n---\n"} /name: cutover-step-08-egress-block-test/{print; exit}' "$TMP/render.yaml" > "$S08"
+# (a) Every leg-bearing step mounts the Secret OPTIONAL (single-region = no
+# Secret = the Pod still schedules and the leg no-ops — pre-#5359 behavior).
+for s in "$S05" "$S06" "$S08"; do
+  if ! grep -q 'secretName: cutover-secondary-kubeconfigs' "$s"; then
+    echo "FAIL: $(basename "$s"): missing the cutover-secondary-kubeconfigs Secret volume (#5359)" >&2
+    c71_fail=1
+  fi
+  if ! grep -q 'optional: true' "$s"; then
+    echo "FAIL: $(basename "$s"): secondary-kubeconfigs volume is not optional:true — a single-region Sovereign (no Secret) would wedge at Pod scheduling (#5359)" >&2
+    c71_fail=1
+  fi
+  if ! grep -q 'mountPath: /secondary-kubeconfigs' "$s"; then
+    echo "FAIL: $(basename "$s"): /secondary-kubeconfigs mount absent (#5359)" >&2
+    c71_fail=1
+  fi
+done
+# (b) Step-05 leg: mesh global-Service path + FAIL-LOUD Ready wait + per-region
+# status keys. A leg that silently skipped an unready region-B would re-mint
+# the exact hw288 false positive.
+if ! grep -q 'service.cilium.io/global' "$S05"; then
+  echo "FAIL: step-05 leg does not establish the ClusterMesh global-Service path to the local Gitea (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'SECONDARY_GITREPO_READY_SECONDS' "$S05"; then
+  echo "FAIL: step-05 leg has no bounded secondary GitRepository Ready wait (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'region-B is still git-tethered' "$S05"; then
+  echo "FAIL: step-05 leg lost its fail-loud secondary-not-Ready FATAL (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'step.flux-gitrepository-patch.region.' "$S05"; then
+  echo "FAIL: step-05 leg does not record per-region status keys on the status ConfigMap (#5359)" >&2
+  c71_fail=1
+fi
+# (c) Step-06 leg: pivot + ZERO-upstream read-back assert + the post-Phase-3b
+# stripped-auth re-sync (sync_secondary_ghcr_pull must appear at its
+# definition AND at the two post-strip call sites).
+if ! grep -q 'pivot_secondary_regions' "$S06"; then
+  echo "FAIL: step-06 has no secondary-region HelmRepository pivot leg (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'STILL-UPSTREAM' "$S06"; then
+  echo "FAIL: step-06 leg lost its zero-upstream-prefix read-back assert (#5359)" >&2
+  c71_fail=1
+fi
+c71_sync_calls=$(grep -c 'sync_secondary_ghcr_pull' "$S06")
+if [ "${c71_sync_calls}" -lt 3 ]; then
+  echo "FAIL: step-06 sync_secondary_ghcr_pull appears ${c71_sync_calls}x (< 3) — the post-Phase-3b stripped-auth re-sync call sites are missing (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'step.helmrepository-patches.region.' "$S06"; then
+  echo "FAIL: step-06 leg does not record per-region status keys (#5359)" >&2
+  c71_fail=1
+fi
+# (d) Step-08 leg: the secondary hold manifest is a COPY of the region-A
+# manifest (so ALLOW_CIDRS + the #4596/#5020-5025 provider-API carve-outs are
+# inherited verbatim), plus the mesh toEndpoints allow (toCIDR never matches a
+# ClusterMesh remote identity), delete-before-apply self-heal, teardown on
+# every path, and per-region verdicts.
+if ! grep -q 'cp /work/egress-deny.yaml /work/egress-deny-secondary.yaml' "$S08"; then
+  echo "FAIL: step-08 secondary manifest is not derived from the region-A manifest — the provider-API carve-outs (#4596/#5020-5025) would not be inherited (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'toEndpoints:' "$S08"; then
+  echo "FAIL: step-08 secondary manifest lacks the mesh-wide toEndpoints allow — cross-cluster dials carry a ClusterMesh identity toCIDR never matches (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'secondary_policy_teardown' "$S08"; then
+  echo "FAIL: step-08 has no secondary_policy_teardown — a leaked region-B default-deny would freeze its CSI attaches (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'SECONDARY_EXTRA_ALLOW_CIDRS' "$S08"; then
+  echo "FAIL: step-08 lost the secondaryRegions.extraEgressAllowCIDRs knob (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'step.egress-block-test.region.' "$S08"; then
+  echo "FAIL: step-08 leg does not record per-region verdicts on the status ConfigMap (#5359)" >&2
+  c71_fail=1
+fi
+# (e) The step count MUST stay 11 — the legs live INSIDE existing steps.
+c71_steps=$(grep -c 'bp.openova.io/cutover-order:' "$TMP/render.yaml")
+if [ "${c71_steps}" -ne 11 ]; then
+  echo "FAIL: #5359 legs changed the step count to ${c71_steps} (must stay 11)" >&2
+  c71_fail=1
+fi
+if [ "$c71_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5359: steps 05/06/08 mount cutover-secondary-kubeconfigs optional:true [single-region inert]; step-05 pivots + FAIL-LOUD Ready-waits every secondary GitRepository over the mesh global-Service path; step-06 pivots every secondary HR with a zero-upstream read-back assert + re-syncs the STRIPPED auth bytes post-Phase-3b; step-08 extends the deny-egress hold to every region [region-A manifest inherited + mesh toEndpoints + own-gateway IPs] with teardown + per-region verdicts; step count unchanged at 11)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2268,3 +2268,79 @@ trigger:
   # TTL on the completed Job — kept for audit so operators can read
   # the trigger Pod logs if something looks wrong.
   autoJobTTLSeconds: 86400
+
+# ── #5359 SECONDARY-REGION (region-B) pivot legs ──────────────────────
+#
+# On a 2-region Sovereign the 11-step chain runs in the CONTROL-PLANE
+# (region-A) cluster only, and pre-0.1.151 it pivoted ONLY region-A:
+# live-proven on hw288 (dep 027f07559af1f9f7) region-B's Flux
+# GitRepository still pointed at github.com, all 64 HelmRepositories at
+# ghcr.io — yet cutoverComplete=true (the step-08 deny-egress proof
+# never touched region-B). A FALSE-POSITIVE Pillar-5 claim, and the
+# direct cause of the #5339 per-region chart-version drift (region-A on
+# the frozen local mirror, region-B tracking latest public ghcr).
+#
+# 0.1.151 teaches steps 05/06/08 a per-secondary-region leg driven by
+# `kubectl --kubeconfig /secondary-kubeconfigs/<regionKey>.yaml`:
+#
+#   step 05  patches EVERY region's flux GitRepository -> local Gitea
+#            (region-B reaches it through a Cilium ClusterMesh global
+#            Service alias this leg establishes — the bp-cnpg-pair /
+#            bp-openbao cross-region-mesh-service idiom);
+#   step 06  pivots EVERY region's HelmRepositories -> local Harbor
+#            (+ syncs the ghcr-pull auth + the cutover-harbor-ca trust
+#            Secret into the secondary's flux-system);
+#   step 08  applies the SAME deny-egress hold manifest to EVERY region
+#            (inheriting the ALLOW_CIDRS + #4596/#5020-5025 provider-API
+#            carve-outs) and requires EVERY region's Flux to stay green
+#            through the window — the sovereignty proof now covers the
+#            whole Sovereign, not just its control-plane region.
+#
+# CREDENTIAL SOURCE (no new secret contract): catalyst-api's cutover
+# engine (cutover.go runCutover, #5359) materializes the secondary
+# kubeconfigs it ALREADY holds on its PVC (`<kubeconfigsDir>/<depID>-
+# <regionKey>.yaml`, the same store ClusterMesh establish + the #5244
+# gateway-ELB reconciler read; server host healed to the VPC-routable
+# private IP per #3991/#4000) into the Secret named below, one
+# `<regionKey>.yaml` data key per secondary region. The steps mount it
+# `optional: true`:
+#
+#   SINGLE-REGION Sovereign -> the engine guarantees the Secret is
+#   ABSENT -> the mount is empty -> every leg no-ops -> behavior is
+#   byte-identical to 0.1.150. No overlay change needed.
+#
+# Step 04 (registry-pivot: region-B node containerd certs.d + the
+# per-region Dragonfly/dfdaemon + coredns-custom chain) is the
+# remaining region-B increment, tracked on #5359 — it requires the
+# region-B bootstrap-kit's own bp-dragonfly plumbing and is NOT
+# silently faked here.
+secondaryRegions:
+  # Secret (in this release namespace) carrying one `<regionKey>.yaml`
+  # kubeconfig per secondary region. Written by catalyst-api at every
+  # cutover run start; mounted optional:true so its absence (single-
+  # region) renders the legs inert. Must match catalyst-api's
+  # CATALYST_CUTOVER_SECONDARY_KUBECONFIGS_SECRET (default identical).
+  kubeconfigSecretName: "cutover-secondary-kubeconfigs"
+  # Step 05 region-B leg: bounded wait for the secondary GitRepository
+  # to reach Ready=True on the pivoted local-Gitea URL. FAIL-LOUD: a
+  # secondary that cannot reconcile the local Gitea fails the step —
+  # succeeding anyway would re-mint the #5359 false positive.
+  gitRepositoryReadySeconds: 300
+  # Git URL the SECONDARY regions' GitRepository is pivoted to. Empty
+  # (default) = the same in-cluster URL region-A uses
+  # (sovereign.giteaInternalURL + gitea.org/gitea.repo), reachable from
+  # the secondary via the ClusterMesh global-Service alias the step-05
+  # leg establishes (gitea-http.gitea.svc, the bp-cnpg-pair idiom the
+  # #5359 design note names). Override per-Sovereign if a topology
+  # needs the public https://gitea.<fqdn> door instead (note: LE-staging
+  # certs on fresh provs make the public door x509-hostile; the mesh
+  # alias is the canonical path).
+  giteaURL: ""
+  # Extra CIDRs allowed by the SECONDARY regions' deny-egress hold, ON
+  # TOP of egressTest.allowIntraClusterCIDRs + allowProviderCIDRs (both
+  # inherited verbatim) + the auto-resolved public IPs of the
+  # Sovereign's OWN registry.<fqdn>/gitea.<fqdn> gateway (the
+  # secondary's helm-controller pulls charts through that door — the
+  # Sovereign's own infrastructure, not a mothership tether). Cloud-init
+  # overlays may add e.g. the peer region's node CIDR.
+  extraEgressAllowCIDRs: []

--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -1463,6 +1463,39 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 		Message: fmt.Sprintf("Self-Sovereignty Cutover started: %d steps", totalSteps),
 	})
 
+	// ── #5359 secondary-region credential bridge ────────────────────────
+	// Materialize every secondary region's kubeconfig into the
+	// cutover-secondary-kubeconfigs Secret BEFORE any step runs, so the
+	// chart's region-B legs (steps 05/06/08, chart 0.1.151) can pivot +
+	// deny-egress-prove the secondary cluster(s) via `kubectl
+	// --kubeconfig`. Runs on every entry (fresh fire, auto-trigger,
+	// resume) — idempotent. FAIL-LOUD: a multi-region deployment whose
+	// secondary kubeconfigs cannot all be materialized aborts here —
+	// running the chain anyway would re-mint the exact #5359 false
+	// positive (cc=true with region-B still tethered to github/ghcr).
+	if nSecondaries, err := h.materializeSecondaryKubeconfigsSecret(ctx, deps); err != nil {
+		finishedAt := time.Now().UTC()
+		_ = patchCutoverStatus(ctx, deps, map[string]string{
+			"currentStep": "",
+			"failedStep":  "secondary-kubeconfigs",
+			"lastError":   err.Error(),
+		})
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Time:    finishedAt.Format(time.RFC3339),
+			Phase:   cutoverPhaseStepFailed,
+			Level:   "error",
+			Message: fmt.Sprintf("secondary-region kubeconfig materialization failed — cutover aborted before step 1 (#5359): %v", err),
+		})
+		return
+	} else if nSecondaries > 0 {
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Time:    time.Now().UTC().Format(time.RFC3339),
+			Phase:   cutoverPhaseStarted,
+			Level:   "info",
+			Message: fmt.Sprintf("multi-region Sovereign: %d secondary region kubeconfig(s) materialized — steps 05/06/08 will pivot + deny-egress-prove every region (#5359)", nSecondaries),
+		})
+	}
+
 	// priorStatus (read above, before the seed) is the durable record used
 	// for resume-after-restart: if a previous run completed step 1 and 2
 	// then crashed before step 3, a fresh /start picks up at step 3. The
@@ -1657,6 +1690,9 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 		defer func() {
 			rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
+			// #5359 — reap the region-B hold policies too (best-effort;
+			// same SIGKILL/watch-loss leak class, per-secondary cluster).
+			h.reapSecondaryCutoverEgressPolicies(rctx)
 			if err := reapCutoverEgressPolicy(rctx, deps); err != nil {
 				h.publishCutoverEvent(bus, cutoverEvent{
 					Time:    time.Now().UTC().Format(time.RFC3339),

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go
@@ -1,0 +1,287 @@
+// cutover_secondary_kubeconfigs.go — #5359 secondary-region credential
+// bridge for the self-sovereignty cutover.
+//
+// Root cause (#5359, live-proven on hw288 dep 027f07559af1f9f7): on a
+// 2-region Sovereign the 11-step cutover chain runs its Jobs in the
+// CONTROL-PLANE (region-A) cluster only. Steps 04/05/06/08 pivoted only
+// region-A; region-B's Flux GitRepository stayed on github.com, all 64
+// HelmRepositories on ghcr.io, node images on quay.io — yet
+// cutoverComplete=true was earned because the step-08 deny-egress proof
+// never touched region-B. cc=true was a FALSE POSITIVE for Pillar-5.
+//
+// The chart-side fix (bp-self-sovereign-cutover 0.1.151) teaches steps
+// 05/06/08 to run a region-B leg with `kubectl --kubeconfig` against each
+// secondary region. The Jobs run in region-A, so they need the secondary
+// regions' kubeconfigs — which the platform ALREADY holds: the chroot
+// catalyst-api's PVC carries `<kubeconfigsDir>/<depID>-<regionKey>.yaml`
+// per secondary CP (deposited by the secondary cloud-init via the
+// mothership → forwarded at handover via POST /sovereign/secondary-
+// kubeconfig, #3991; server host healed to the VPC-routable private IP,
+// #4000). That store is the SAME mechanism ClusterMesh establish
+// (buildRegionSlots), the #5244 gateway-ELB reconciler and the #5261
+// stalled-HR force-reconcile use to reach region-B — no new credential
+// contract is invented here.
+//
+// This file bridges that store to the step Jobs: at every cutover run
+// start (fresh fire, internal auto-trigger, AND the resume path — all
+// funnel through runCutover) the engine materializes the secondary
+// kubeconfigs into ONE Secret in the cutover namespace:
+//
+//	Secret <cutover-ns>/cutover-secondary-kubeconfigs
+//	  data: "<regionKey>.yaml" -> kubeconfig bytes   (one key per region)
+//
+// The chart mounts it `optional: true` at /secondary-kubeconfigs; a step
+// leg iterates the mounted files. Contract:
+//
+//   - SINGLE-REGION Sovereign → no secondary kubeconfigs exist → any
+//     stale Secret is deleted and the mount is empty → every region-B
+//     leg no-ops → behavior EXACTLY as before #5359.
+//   - MULTI-REGION Sovereign → the Secret MUST carry every expected
+//     secondary region. If the deployment record says N-1 secondaries
+//     exist but fewer kubeconfigs can be resolved/read, the run FAILS
+//     LOUDLY before step 1 — a cutover that would silently skip
+//     region-B is the exact false-positive #5359 exists to kill.
+//
+// Idempotent: create-or-update with fully-replaced data (stale region
+// keys from a prior topology do not linger).
+package handler
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// envCutoverSecondaryKubeconfigsSecret overrides the Secret name (runtime-
+// overridable per Inviolable-Principle #4). Must match the chart value
+// `secondaryRegions.kubeconfigSecretName`.
+const envCutoverSecondaryKubeconfigsSecret = "CATALYST_CUTOVER_SECONDARY_KUBECONFIGS_SECRET"
+
+// defaultCutoverSecondaryKubeconfigsSecret is the canonical Secret name the
+// bp-self-sovereign-cutover chart mounts (values.yaml secondaryRegions.
+// kubeconfigSecretName).
+const defaultCutoverSecondaryKubeconfigsSecret = "cutover-secondary-kubeconfigs"
+
+func cutoverSecondaryKubeconfigsSecretName() string {
+	if v := strings.TrimSpace(os.Getenv(envCutoverSecondaryKubeconfigsSecret)); v != "" {
+		return v
+	}
+	return defaultCutoverSecondaryKubeconfigsSecret
+}
+
+// resolveCutoverDeployment returns the Deployment THIS catalyst-api serves
+// as an in-cluster chroot (SOVEREIGN_FQDN set + matching the record), or
+// nil when no record matches. The cutover engine only ever runs on a
+// chroot, and a chroot serves exactly one deployment (#5131
+// chrootServesDeployment discriminator — reused verbatim).
+func (h *Handler) resolveCutoverDeployment() *Deployment {
+	var found *Deployment
+	h.deployments.Range(func(_, value any) bool {
+		dep, ok := value.(*Deployment)
+		if !ok || dep == nil {
+			return true
+		}
+		if h.chrootServesDeployment(dep) {
+			found = dep
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// secondaryKubeconfigsForCutover returns regionKey → on-disk path for every
+// secondary region of dep, as the union of the in-memory
+// dep.secondaryKubeconfigPaths map and the on-disk `<depID>-<regionKey>.yaml`
+// files — the SAME union discoverSecondaryNodeInternalIPs (#5244) trusts,
+// immune to in-memory loss across catalyst-api restarts (#4000). Also
+// returns the number of secondaries the deployment SPEC expects, for the
+// fail-loud completeness check.
+func secondaryKubeconfigsForCutover(dep *Deployment) (map[string]string, int) {
+	dep.mu.Lock()
+	expected := 0
+	if len(dep.Request.Regions) > 1 {
+		expected = len(dep.Request.Regions) - 1
+	}
+	paths := make(map[string]string, len(dep.secondaryKubeconfigPaths))
+	for k, v := range dep.secondaryKubeconfigPaths {
+		paths[k] = v
+	}
+	depID := dep.ID
+	dep.mu.Unlock()
+
+	dir := secondaryKubeconfigsDir()
+	for _, key := range onDiskSecondaryKubeconfigKeys(dir, depID) {
+		if _, ok := paths[key]; !ok {
+			paths[key] = filepath.Join(dir, depID+"-"+key+".yaml")
+		}
+	}
+	return paths, expected
+}
+
+// sanitizeSecondaryRegionKey maps a regionKey to a ConfigMap/Secret-safe
+// data key stem ([-._a-zA-Z0-9]). Region keys are provider region ids
+// (e.g. "me-east-215-b", "nbg1-1") and are already safe in practice; any
+// other rune is replaced with '-' so a hostile/odd key can never wedge the
+// Secret write.
+func sanitizeSecondaryRegionKey(key string) string {
+	out := make([]rune, 0, len(key))
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			out = append(out, r)
+		default:
+			out = append(out, '-')
+		}
+	}
+	return string(out)
+}
+
+// materializeSecondaryKubeconfigsSecret creates/updates (or deletes, when
+// no secondary regions exist) the cutover-secondary-kubeconfigs Secret in
+// the cutover namespace. Returns the number of secondary regions
+// materialized.
+//
+// Fail-loud contract (#5359): on a deployment whose spec expects
+// secondaries, an unreadable/missing kubeconfig or a failed Secret write
+// returns an error — runCutover aborts BEFORE step 1 rather than running
+// a chain whose region-B legs would silently no-op into a false-positive
+// cc=true.
+func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, deps *cutoverDeps) (int, error) {
+	name := cutoverSecondaryKubeconfigsSecretName()
+
+	dep := h.resolveCutoverDeployment()
+	if dep == nil {
+		// No deployment record on this process (mothership never runs the
+		// cutover; a record-less chroot cannot know its region topology).
+		// Do NOT delete an existing Secret — a prior run with a live record
+		// may have materialized it and the files it points at are still the
+		// truth. Loud in the log so a record-less 2-region chroot is
+		// diagnosable rather than silently single-region.
+		h.log.Warn("cutover: no deployment record matches SOVEREIGN_FQDN — secondary-region detection unavailable; proceeding with any previously-materialized secondary kubeconfigs (#5359)",
+			"secret", name)
+		return 0, nil
+	}
+
+	paths, expected := secondaryKubeconfigsForCutover(dep)
+
+	data := make(map[string][]byte, len(paths))
+	var missing []string
+	for key, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil || len(raw) == 0 {
+			missing = append(missing, fmt.Sprintf("%s (%s)", key, path))
+			continue
+		}
+		data[sanitizeSecondaryRegionKey(key)+".yaml"] = raw
+	}
+
+	if expected > len(data) {
+		sort.Strings(missing)
+		return 0, fmt.Errorf(
+			"cutover: deployment %s expects %d secondary region(s) but only %d kubeconfig(s) are readable (missing/unreadable: %s) — refusing to start a cutover whose region-B pivot legs would silently no-op (#5359)",
+			dep.ID, expected, len(data), strings.Join(missing, ", "))
+	}
+
+	if len(data) == 0 {
+		// Single-region: guarantee the mount stays empty so the chart legs
+		// no-op — delete any stale Secret from a prior multi-region life.
+		err := deps.core.CoreV1().Secrets(deps.ns).Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return 0, fmt.Errorf("cutover: delete stale %s/%s: %w", deps.ns, name, err)
+		}
+		return 0, nil
+	}
+
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: deps.ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of":    cutoverStepPartOfValue,
+				"app.kubernetes.io/managed-by": "catalyst-api",
+				"app.kubernetes.io/component":  "cutover-secondary-kubeconfigs",
+			},
+			Annotations: map[string]string{
+				"catalyst.openova.io/deployment-id": dep.ID,
+				"catalyst.openova.io/materialized":  time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+
+	existing, err := deps.core.CoreV1().Secrets(deps.ns).Get(ctx, name, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+		if _, cerr := deps.core.CoreV1().Secrets(deps.ns).Create(ctx, desired, metav1.CreateOptions{}); cerr != nil {
+			return 0, fmt.Errorf("cutover: create %s/%s: %w", deps.ns, name, cerr)
+		}
+	case err != nil:
+		return 0, fmt.Errorf("cutover: get %s/%s: %w", deps.ns, name, err)
+	default:
+		// Full data replace (stale region keys must not linger); keep the
+		// live object's resourceVersion for a conflict-safe update.
+		updated := existing.DeepCopy()
+		updated.Labels = desired.Labels
+		updated.Annotations = desired.Annotations
+		updated.Type = desired.Type
+		updated.Data = desired.Data
+		updated.StringData = nil
+		if _, uerr := deps.core.CoreV1().Secrets(deps.ns).Update(ctx, updated, metav1.UpdateOptions{}); uerr != nil {
+			return 0, fmt.Errorf("cutover: update %s/%s: %w", deps.ns, name, uerr)
+		}
+	}
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, strings.TrimSuffix(k, ".yaml"))
+	}
+	sort.Strings(keys)
+	h.log.Info("cutover: secondary-region kubeconfigs materialized for the step Jobs (#5359)",
+		"secret", deps.ns+"/"+name,
+		"regions", strings.Join(keys, ","),
+		"deploymentID", dep.ID)
+	return len(data), nil
+}
+
+// reapSecondaryCutoverEgressPolicies is the #5014 backstop's region-B
+// counterpart: on EVERY exit of the egress-block-test step, delete the
+// cutover-egress-block CCNP from every secondary region cluster too. The
+// step Job's TERM/EXIT trap covers clean exits; this covers SIGKILL /
+// watch-loss, where a leaked default-deny egress policy on region-B would
+// freeze its CSI attaches exactly as it did on region-A (hw242 3x).
+// Best-effort per region: an unreachable secondary (possibly mid region
+// outage) is logged and skipped — the next step-08 leg deletes-before-
+// apply so a stale policy also self-heals on re-run.
+func (h *Handler) reapSecondaryCutoverEgressPolicies(ctx context.Context) {
+	dep := h.resolveCutoverDeployment()
+	if dep == nil {
+		return
+	}
+	paths, _ := secondaryKubeconfigsForCutover(dep)
+	for key, path := range paths {
+		cs, err := h.clientsetFromKubeconfigPath(path)
+		if err != nil {
+			h.log.Warn("cutover: secondary deny-egress backstop reap: clientset build failed (#5359)",
+				"region", key, "err", err)
+			continue
+		}
+		rc := cs.Discovery().RESTClient()
+		if rc == nil {
+			continue // fake clientsets (unit tests) expose no REST client
+		}
+		if err := rc.Delete().AbsPath(cutoverEgressBlockPolicyAbsPath).Do(ctx).Error(); err != nil && !apierrors.IsNotFound(err) {
+			h.log.Warn("cutover: secondary deny-egress backstop reap FAILED — manual `kubectl --kubeconfig <region> delete ccnp cutover-egress-block` may be required (#5359)",
+				"region", key, "err", err)
+			continue
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_test.go
@@ -1,0 +1,158 @@
+package handler
+
+// #5359 — secondary-region credential bridge tests.
+//
+// The chart's steps 05/06/08 grew region-B legs that read
+// `/secondary-kubeconfigs/*.yaml` from the cutover-secondary-kubeconfigs
+// Secret. These tests pin the engine-side contract that feeds that mount:
+//
+//   1. Single-region deployment → NO Secret (and a stale one is deleted)
+//      → the chart legs no-op → pre-#5359 behavior byte-identical.
+//   2. Multi-region deployment with every secondary kubeconfig on disk →
+//      Secret carries one `<regionKey>.yaml` key per secondary.
+//   3. Multi-region deployment whose secondary kubeconfig is MISSING →
+//      hard error (runCutover aborts before step 1) — never a silent
+//      single-region chain that would re-mint the #5359 false positive.
+//   4. Stale keys from a prior topology are replaced, not merged.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// newSecondaryKubeconfigFixture builds a chroot-shaped Handler + fake
+// cutoverDeps: SOVEREIGN_FQDN set, one deployment record served by this
+// chroot, kubeconfigs dir pointed at a temp dir.
+func newSecondaryKubeconfigFixture(t *testing.T, regions int) (*Handler, *cutoverDeps, string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "hw288.omani.works")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	dep := &Deployment{
+		ID: "dep5359",
+		Request: provisioner.Request{
+			SovereignFQDN: "hw288.omani.works",
+		},
+	}
+	for i := 0; i < regions; i++ {
+		dep.Request.Regions = append(dep.Request.Regions, provisioner.RegionSpec{
+			Provider:    "huawei",
+			CloudRegion: "me-east-215",
+		})
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	client := fakek8s.NewSimpleClientset()
+	deps := &cutoverDeps{core: client, ns: cutoverTestNS}
+	return h, deps, dir
+}
+
+func writeSecondaryKubeconfig(t *testing.T, dir, depID, region string) {
+	t.Helper()
+	path := filepath.Join(dir, depID+"-"+region+".yaml")
+	if err := os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\nclusters: []\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestMaterializeSecondaryKubeconfigs_SingleRegionDeletesStaleSecret(t *testing.T) {
+	h, deps, _ := newSecondaryKubeconfigFixture(t, 1)
+
+	// Seed a STALE Secret from a prior multi-region life — the
+	// single-region run must remove it so the chart mount stays empty.
+	_, err := deps.core.CoreV1().Secrets(cutoverTestNS).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverSecondaryKubeconfigsSecretName(), Namespace: cutoverTestNS},
+		Data:       map[string][]byte{"old-region.yaml": []byte("stale")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed stale secret: %v", err)
+	}
+
+	n, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("n = %d, want 0 for single-region", n)
+	}
+	_, err = deps.core.CoreV1().Secrets(cutoverTestNS).Get(context.Background(), cutoverSecondaryKubeconfigsSecretName(), metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("stale Secret survived a single-region run — chart legs would falsely fire a region-B pivot")
+	}
+}
+
+func TestMaterializeSecondaryKubeconfigs_TwoRegionMaterializesSecret(t *testing.T) {
+	h, deps, dir := newSecondaryKubeconfigFixture(t, 2)
+	writeSecondaryKubeconfig(t, dir, "dep5359", "me-east-215-b")
+
+	n, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("n = %d, want 1", n)
+	}
+	sec, err := deps.core.CoreV1().Secrets(cutoverTestNS).Get(context.Background(), cutoverSecondaryKubeconfigsSecretName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if _, ok := sec.Data["me-east-215-b.yaml"]; !ok {
+		t.Fatalf("secret missing me-east-215-b.yaml key; got keys %v", secretDataKeys(sec))
+	}
+}
+
+func TestMaterializeSecondaryKubeconfigs_MissingKubeconfigFailsLoud(t *testing.T) {
+	// 2-region spec, but NO secondary kubeconfig on disk and none in
+	// memory — the run must ABORT, not proceed single-region.
+	h, deps, _ := newSecondaryKubeconfigFixture(t, 2)
+
+	if _, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps); err == nil {
+		t.Fatalf("expected fail-loud error for a 2-region deployment with no secondary kubeconfig (the #5359 false-positive path); got nil")
+	}
+}
+
+func TestMaterializeSecondaryKubeconfigs_ReplacesStaleKeys(t *testing.T) {
+	h, deps, dir := newSecondaryKubeconfigFixture(t, 2)
+	writeSecondaryKubeconfig(t, dir, "dep5359", "me-east-215-b")
+
+	// Seed a Secret carrying a key from a PRIOR topology.
+	_, err := deps.core.CoreV1().Secrets(cutoverTestNS).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverSecondaryKubeconfigsSecretName(), Namespace: cutoverTestNS},
+		Data:       map[string][]byte{"gone-region.yaml": []byte("stale")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	if _, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	sec, err := deps.core.CoreV1().Secrets(cutoverTestNS).Get(context.Background(), cutoverSecondaryKubeconfigsSecretName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if _, stale := sec.Data["gone-region.yaml"]; stale {
+		t.Fatalf("stale region key survived the data replace; got keys %v", secretDataKeys(sec))
+	}
+	if _, ok := sec.Data["me-east-215-b.yaml"]; !ok {
+		t.Fatalf("current region key absent after update; got keys %v", secretDataKeys(sec))
+	}
+}
+
+func secretDataKeys(s *corev1.Secret) []string {
+	keys := make([]string, 0, len(s.Data))
+	for k := range s.Data {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3579,7 +3579,19 @@ name: bp-catalyst-platform
 #   guacamole-auth-header extension (no id_token in the browser — kills the
 #   1.5.5 implicit-flow nonce-replay #5358). Bootstrap-kit slot-13 pin bumped
 #   in lockstep (pin-sync gate).
-version: 1.4.1217
+# 1.4.1218 — #5359 (2-region cutover FALSE-POSITIVE cc=true, hw288): grant the
+#   catalyst-api cutover-driver SA the Secret verbs to materialize the
+#   `cutover-secondary-kubeconfigs` bridge Secret (cutover.go runCutover) that
+#   feeds the bp-self-sovereign-cutover 0.1.151 region-B legs (steps 05/06/08).
+#   `create` in its own rule (feedback_rbac_create_no_resourcenames.md);
+#   update/patch/delete name-scoped to the one bridge Secret. No template
+#   behavior change on single-region Sovereigns (the engine deletes the Secret
+#   when no secondary regions exist). Refs #5359. Also catalog-seed
+#   bp-self-sovereign-cutover 0.1.150 -> 0.1.151 lockstep AND catalog-seed
+#   bp-guacamole 0.2.30 -> 0.2.31 (TBD-A6 bot re-mint sync — 2nd occurrence
+#   after bp-newapi 1.4.144; bot lockstep gap tracked on #5370).
+#   (1.4.1217 was consumed by the TBD-A6 auto re-publish.)
+version: 1.4.1218
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1726,7 +1726,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.30"
+  version: "0.2.31"
   visibility: listed
   card:
     title: "Apache Guacamole"
@@ -1744,7 +1744,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.30"
+    version: "0.2.31"
   topology:
     supported:
     - active-hot-standby
@@ -5052,7 +5052,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.150"
+  version: "0.1.151"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5069,7 +5069,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.150"
+    version: "0.1.151"
   topology:
     supported:
       - singleton

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -125,6 +125,30 @@ rules:
     verbs: ["update", "patch", "delete", "create"]
 
   # ───────────────────────────────────────────────────────────────
+  # #5359 — secondary-region kubeconfig bridge. On every cutover run
+  # start (cutover.go runCutover) the engine materializes the
+  # secondary regions' kubeconfigs (already on the chroot PVC at
+  # <kubeconfigsDir>/<depID>-<regionKey>.yaml — the SAME store the
+  # ClusterMesh establish + #5244 gateway-ELB reconciler read) into the
+  # `cutover-secondary-kubeconfigs` Secret in the cutover namespace, so
+  # the bp-self-sovereign-cutover step Jobs (05/06/08 region-B legs,
+  # chart 0.1.151) can pivot + deny-egress-prove EVERY region — not
+  # just the control-plane one (the hw288 false-positive cc=true).
+  # `create` MUST be in its own Rule WITHOUT resourceNames per
+  # feedback_rbac_create_no_resourcenames.md; the mutating/removal
+  # verbs are name-scoped to the ONE bridge Secret. `get` on secrets
+  # is already granted by the k8scache read rule above (required
+  # alongside update/patch/delete for the named rule to be usable).
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["cutover-secondary-kubeconfigs"]
+    verbs: ["get", "update", "patch", "delete"]
+
+  # ───────────────────────────────────────────────────────────────
   # TokenReview — required by HandleCutoverInternalTrigger to
   # validate the in-cluster auto-trigger Job's projected SA token
   # against the apiserver's authentication chain (issue #957


### PR DESCRIPTION
## What

Kills the 2-region **false-positive `cutoverComplete=true`** (Refs #5359, live-proven on hw288 dep `027f07559af1f9f7`): the 11-step chain ran only in the control-plane cluster, so region-B's Flux `GitRepository` stayed on `github.com`, all 64 `HelmRepository` on `ghcr.io`, node images on `quay.io` — yet `cc=true` was earned because the step-08 deny-egress proof never touched region-B. This is also the direct cause of the #5339 per-region chart-version drift.

Steps **05 / 06 / 08** now run a **per-secondary-region leg**; step-04's region-B containerd/Dragonfly pivot is the remaining increment (tracked below, not faked).

## How region-B is reached (no new secret contract)

The cutover Jobs run in region-A. Their region-B credentials come from the store the platform **already** uses to reach secondary regions — the chroot catalyst-api's on-PVC `<kubeconfigsDir>/<depID>-<regionKey>.yaml` files (deposited via `POST /sovereign/secondary-kubeconfig` #3991, private-IP-healed #4000; the same union `discoverSecondaryNodeInternalIPs` #5244 and the ClusterMesh establish trust). At **every** cutover run start (`runCutover` — fresh fire, auto-trigger, resume), the engine materializes them into one Secret:

```
Secret <cutover-ns>/cutover-secondary-kubeconfigs
  data: "<regionKey>.yaml" -> kubeconfig bytes
```

The chart mounts it `optional: true` at `/secondary-kubeconfigs`.

- **Single-region**: the engine guarantees the Secret is absent (stale copies deleted) → empty mount → every leg no-ops → behavior byte-identical to 0.1.150. No overlay change.
- **Multi-region fail-loud**: if the deployment spec expects N−1 secondaries but fewer kubeconfigs are readable, the run **aborts before step 1** (`failedStep=secondary-kubeconfigs`) — a silently region-A-only chain is exactly the #5359 bug.

## Per-step legs (chart `bp-self-sovereign-cutover` 0.1.150 → 0.1.151)

| Step | Secondary leg | Fail-loud gate |
|---|---|---|
| 05 flux-gitrepository-patch | Establishes the ClusterMesh global-Service path to the local Gitea (annotates region-A `gitea/gitea-http` + creates the same-named zero-backend alias in the secondary — the bp-cnpg-pair / bp-openbao `cross-region-mesh-service` idiom), mirrors the basic-auth Secret, applies the same url/branch/secretRef/ignore patch (`secondaryRegions.giteaURL` overrides) | Bounded wait for the secondary GitRepository `Ready=True` **on the pivoted URL**; not-Ready = step fails, `cc` stays false |
| 06 helmrepository-patches | Syncs the merged `ghcr-pull` auth + `cutover-harbor-ca` trust Secret into the secondary `flux-system`, pivots every `oci://ghcr.io/openova-io*` HR to local Harbor (same prefix-swap + `certSecretRef` shape as Phase 1), then **re-syncs the STRIPPED auth bytes after Phase-3b** — the hw139 strip-before-proof lesson applied per-region | Read-back assert: **zero** upstream-prefixed HRs may remain in the secondary |
| 08 egress-block-test | Applies the deny-egress hold to every region immediately before the survival window: the region-A manifest **copied verbatim** (`ALLOW_CIDRS` + the #4596/#5020–#5025 provider-API carve-outs inherited) **plus** a mesh-wide `toEndpoints` allow (a `toCIDR` never matches a ClusterMesh remote identity) and the Sovereign's **own** `registry./gitea.<fqdn>` gateway IPs (resolved at hold time; `secondaryRegions.extraEgressAllowCIDRs` for operator additions). Per-secondary baseline + only-NEW-regression diff, same criterion as region-A | Any NEW NotReady in **any** region during the window fails the proof. Teardown covers all regions on pass/fail/trap; delete-before-apply self-heals a stale hold; the engine #5014 backstop now also reaps the secondary policies on SIGKILL/watch-loss |

Per-region durable tracking (the #5359 status-key ask): `step.<stepName>.region.<regionKey>.{result,finishedAt}` on `self-sovereign-cutover-status`.

Step-08 trap catalog inheritance: the roll-set exclusions (#5091 RWO-EVS singletons, #5074 CSI drivers) stay in force — the fresh-pull roll remains region-A-scoped in this PR; the secondary legs never roll workloads, so they cannot re-introduce those classes.

## Engine + RBAC (bp-catalyst-platform 1.4.1212 → 1.4.1213)

- `products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go` — materialization (+ 4 unit tests: single-region delete, 2-region materialize, missing-kubeconfig fail-loud, stale-key replace) and the secondary #5014 backstop reap.
- `clusterrole-cutover-driver.yaml` — Secret `create` in its own rule (feedback_rbac_create_no_resourcenames.md); `get/update/patch/delete` name-scoped to the one bridge Secret. Plain YAML (dual Helm/Kustomize consumer — no braces).
- Lockstep: slot 06a pin → 0.1.151, slot 13 pin → 1.4.1213, catalog-seed + blueprint.yaml → 0.1.151 (pin-sync + catalog-seed-lockstep gates green).

## Remaining increment (deliberately NOT in this PR)

**Step-04 region-B leg** — the secondary nodes' containerd `certs.d`/Dragonfly/coredns-custom pivot (why hw288 region-B images still pull quay/ghcr at the node layer). It requires the secondary bootstrap-kit's own bp-dragonfly plumbing and per-cluster CoreDNS surgery; shipping a fake DaemonSet copy would be scaffold theater. Tracked on #5359. Note the step-06/08 legs still remove the *Flux-layer* tethers and prove reconciliation under deny-egress in both regions; the node-image leg is the remaining surface.

Also follow-up: making the `gitea-http` global-Service annotation durable in bp-gitea (the leg's live annotate is additive + idempotent but could revert on a bp-gitea upgrade with drift-correction).

## Gates run locally

- `go build ./... && go vet ./...` + **full** `internal/handler` suite green (177s)
- `helm lint` + `helm template` on both charts
- Rendered podSpec YAML-parse + `sh -n`/`dash -n` on the steps 05/06/08 scripts (busybox-ash discipline, #3634)
- `tests/cutover-contract.sh` Cases 1–**71** green (new Case 71 pins the whole #5359 surface: optional mount, fail-loud legs, step count stays 11)
- `tests/image-registry-coverage.sh` green
- `scripts/check-bootstrap-kit-pin-sync.sh` + `scripts/check-catalog-seed-lockstep.sh` green

## Verification plan (next 2-region prov)

On a fresh 2-region prov + cutover: both regions' `GitRepository` → local Gitea; 0 HRs on ghcr/github in either region (`kubectl --kubeconfig <region-b> get helmrepository -A`); `step.*.region.<key>.result=success` keys on the status CM; deny-egress hold held both clusters green (#5359 acceptance).

Refs #5359
Refs #5339
Refs #5265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
