### PR TITLE
fix(test): eso-push-policy-render SIGPIPE false-FAIL — unblocks bp-openbao 1.2.64 publish

### DIFF
--- a/platform/openbao/chart/tests/eso-push-policy-render.sh
+++ b/platform/openbao/chart/tests/eso-push-policy-render.sh
@@ -28,21 +28,30 @@ helm="${HELM_BIN:-helm}"
 out=$("$helm" template openbao "$chart_dir" \
   --set autoUnseal.enabled=true 2>&1)
 
+# Write the render to a file and grep THAT — `echo "$out" | grep -q` under
+# `set -o pipefail` fails on a SUCCESSFUL match when the render exceeds the
+# pipe buffer: grep -q exits at first hit, echo takes SIGPIPE, pipefail
+# surfaces echo's 141 → the || branch fires with a misleading FAIL. Broke
+# the Blueprint Release publish of 1.2.64 (size-dependent, green on PR CI).
+render_file=$(mktemp)
+trap 'rm -f "$render_file"' EXIT
+printf '%s\n' "$out" > "$render_file"
+
 echo "[bp-openbao] Case 1: external-secrets-push policy present with both path grants"
-echo "$out" | grep -q "bao policy write external-secrets-push" || {
+grep -q -- "bao policy write external-secrets-push" "$render_file" || {
   echo "FAIL: auth-bootstrap does not write the external-secrets-push policy"; exit 1; }
 # -F: the rendered script text contains the LITERAL string $KV_MOUNT_PATH
 # (shell expansion happens at Job runtime, not render time).
 # shellcheck disable=SC2016
-echo "$out" | grep -qF '"$KV_MOUNT_PATH/data/catalyst/newapi/admin-token"' || {
+grep -qF -- '"$KV_MOUNT_PATH/data/catalyst/newapi/admin-token"' "$render_file" || {
   echo "FAIL: push policy lacks the data-path grant for catalyst/newapi/admin-token"; exit 1; }
 # shellcheck disable=SC2016
-echo "$out" | grep -qF '"$KV_MOUNT_PATH/metadata/catalyst/newapi/admin-token"' || {
+grep -qF -- '"$KV_MOUNT_PATH/metadata/catalyst/newapi/admin-token"' "$render_file" || {
   echo "FAIL: push policy lacks the metadata-path grant for catalyst/newapi/admin-token"; exit 1; }
 echo "  ok"
 
 echo "[bp-openbao] Case 2: ESO role attaches read + push policies"
-echo "$out" | grep -q "policies=external-secrets-read,external-secrets-push" || {
+grep -q -- "policies=external-secrets-read,external-secrets-push" "$render_file" || {
   echo "FAIL: ESO role does not attach external-secrets-read,external-secrets-push"; exit 1; }
 echo "  ok"
 


### PR DESCRIPTION
Blueprint Release failed twice on `build (platform/openbao)` at the new eso-push-policy-render.sh: `line 32: echo: write error: Broken pipe` → `FAIL: auth-bootstrap does not write the external-secrets-push policy` — but the policy IS in the render. Under `set -o pipefail`, `echo "$out" | grep -q` reports echo's SIGPIPE (grep -q exits at first match) as pipeline failure. Size-dependent, so the PR-level run passed.

Fix: write the render to a mktemp file once and grep the file — zero pipes, deterministic. All 3 cases pass locally; assertions unchanged.

Until this merges + Blueprint Release goes green, main's bp-openbao `1.2.64` pins (catalog-seed + slot 08, from #5377) are HOLLOW — ghcr's newest is 1.2.63. This PR is the unblock; no prov may fire before ghcr has 1.2.64.

Refs #5375 #5370

🤖 Generated with [Claude Code](https://claude.com/claude-code)