### PR TITLE
fix(provisioner): Huawei digit-tailed region codes truncated into a false partial-failure (#5381)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/provisioner/partial_region_materialisation_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/partial_region_materialisation_test.go
@@ -290,3 +290,63 @@ func TestNormalisePerRegionKeys_HuaweiPassThrough(t *testing.T) {
 		}
 	}
 }
+
+// Test 11 (#5381) — Huawei DIGIT-TAILED codes must pass through.
+//
+// The pre-#5381 normaliser stripped any trailing "-<digits>" segment for
+// every provider (a Hetzner "<cloudRegion>-<index>" rule). Huawei region
+// codes end in digits themselves, so "me-east-215" became "me-east" and
+// "me-east-215-b-1" became "me-east-215-b" → detectPartialRegionMaterialisation
+// found NEITHER declared code → a fully-materialised 2-region Sovereign was
+// stamped partial-failure and never reached commitPDM/phase-1 (hw289 live,
+// dep 44ac86240f0afab7). Test 10 missed it because its codes end in letters.
+func TestNormalisePerRegionKeys_HuaweiDigitTailedCodes_5381(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b-1"},
+	}
+	huaweiShape := map[string]string{
+		"me-east-215":     "100.100.100.10",
+		"me-east-215-b-1": "100.100.100.20",
+	}
+	normalised := normalisePerRegionKeys(declared, huaweiShape)
+	for code, ip := range huaweiShape {
+		if got := normalised[code]; got != ip {
+			t.Errorf("normalised[%q] = %q, want %q (digit-tailed Huawei codes must NOT be truncated)", code, got, ip)
+		}
+	}
+	if _, truncated := normalised["me-east"]; truncated {
+		t.Errorf("normalised contains truncated key %q — the digit-suffix strip fired on a declared code", "me-east")
+	}
+	materialised, missing := detectPartialRegionMaterialisation(declared, normalised)
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want empty (both regions materialised)", missing)
+	}
+	if len(materialised) != 2 {
+		t.Errorf("materialised = %v, want both declared codes", materialised)
+	}
+}
+
+// Test 12 (#5381) — the Hetzner "<cloudRegion>-<index>" strip still fires
+// when the raw key is NOT itself a declared region (the behaviour Test 8/9
+// rely on), proving the declared-set-aware guard is a strict superset.
+func TestNormalisePerRegionKeys_HetznerIndexStripStillFires_5381(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+		{Provider: "hetzner", CloudRegion: "hel1"},
+	}
+	hetznerShape := map[string]string{
+		"primary": "10.0.0.1",
+		"hel1-1":  "10.0.0.2",
+	}
+	normalised := normalisePerRegionKeys(declared, hetznerShape)
+	if got := normalised["fsn1"]; got != "10.0.0.1" {
+		t.Errorf("normalised[fsn1] = %q, want 10.0.0.1 (literal 'primary' remap)", got)
+	}
+	if got := normalised["hel1"]; got != "10.0.0.2" {
+		t.Errorf("normalised[hel1] = %q, want 10.0.0.2 (index strip must still fire for undeclared raw keys)", got)
+	}
+	if _, missing := detectPartialRegionMaterialisation(declared, normalised); len(missing) != 0 {
+		t.Errorf("missing = %v, want empty", missing)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1586,18 +1586,35 @@ func normalisePerRegionKeys(declaredRegions []RegionSpec, perRegion map[string]s
 	if len(declaredRegions) > 0 {
 		primaryCode = strings.TrimSpace(declaredRegions[0].CloudRegion)
 	}
+	// #5381: the suffix-strip below MUST be declared-set-aware. Huawei
+	// cloud-region codes END IN DIGITS ("me-east-215",
+	// "me-east-215-b-1"), so an unconditional "<region>-<index>" strip
+	// corrupted them into "me-east" / "me-east-215-b", detection found
+	// neither declared code, and a fully-materialised 2-region Sovereign
+	// was stamped partial-failure (hw289 live). A key that already IS a
+	// declared cloudRegion is final — only a key that is NOT declared may
+	// be a Hetzner "<cloudRegion>-<index>" form.
+	declaredSet := make(map[string]struct{}, len(declaredRegions))
+	for _, r := range declaredRegions {
+		if code := strings.TrimSpace(r.CloudRegion); code != "" {
+			declaredSet[code] = struct{}{}
+		}
+	}
 	for k, v := range perRegion {
 		if strings.TrimSpace(v) == "" {
 			continue
 		}
 		code := k
+		_, keyIsDeclared := declaredSet[k]
 		if k == "primary" && primaryCode != "" {
 			code = primaryCode
-		} else if idx := strings.LastIndexByte(k, '-'); idx > 0 {
+		} else if idx := strings.LastIndexByte(k, '-'); idx > 0 && !keyIsDeclared {
 			// Hetzner secondaries: "<cloudRegion>-<index>" — strip the
 			// numeric trailing segment if it parses as an int. Keep the
 			// raw key when the suffix isn't numeric (defensive against
-			// future key formats).
+			// future key formats) OR when stripping would not yield a
+			// declared region (so a digit-tailed provider code is never
+			// truncated into a code nobody declared).
 			suffix := k[idx+1:]
 			allDigit := suffix != ""
 			for _, r := range suffix {
@@ -1607,7 +1624,9 @@ func normalisePerRegionKeys(declaredRegions []RegionSpec, perRegion map[string]s
 				}
 			}
 			if allDigit {
-				code = k[:idx]
+				if _, strippedIsDeclared := declaredSet[k[:idx]]; strippedIsDeclared || len(declaredSet) == 0 {
+					code = k[:idx]
+				}
 			}
 		}
 		if existing, ok := out[code]; !ok || existing == "" {


### PR DESCRIPTION
## Live evidence

hw289 (dep `44ac86240f0afab7`), a fresh 2-region Huawei prov, was stamped `status=partial-failure` with a self-contradicting error while **both regions were genuinely up and converging** (region-A 16/65 HRs, region-B 35/65 and climbing):

```
partial-region materialisation: declared 2 regions [me-east-215 me-east-215-b-1],
only 2 materialised [me-east me-east-215-b] (missing: [me-east-215 me-east-215-b-1])
```

"only **2** materialised" out of 2 — but both reported missing, because the codes were truncated.

## Root cause

`normalisePerRegionKeys` (provisioner.go) stripped a trailing `-<digits>` segment from every per-region key for every provider — a rule written for Hetzner's `<cloudRegion>-<index>` shape. Huawei region codes end in digits themselves, so `me-east-215`→`me-east` and `me-east-215-b-1`→`me-east-215-b`. `detectPartialRegionMaterialisation` found neither declared code → typed error → handler stamps `partial-failure` and **skips `commitPDMWithRetry` + `runPhase1Watch`**, so DNS never commits and the prov can never reach `ready`.

The function's own upstream comment already said Huawei is "keyed by cloudRegion **verbatim**" — the strip should never have applied to it.

## Fix

Declared-set-aware normalisation:
1. key exactly matches a declared `cloudRegion` → final, verbatim;
2. else `<declaredCode>-<digits>` → strip (Hetzner secondaries);
3. else raw.

Strict superset of prior Hetzner behaviour; provider-agnostic.

## Verification

- New `TestNormalisePerRegionKeys_HuaweiDigitTailedCodes_5381` reproduces the live failure **exactly** without the fix (`missing = [me-east-215 me-east-215-b-1]`) and passes with it.
- Companion `TestNormalisePerRegionKeys_HetznerIndexStripStillFires_5381` pins that the index-strip + literal `primary` remap still work.
- Full `internal/provisioner` suite green; `go build ./...` + `go vet` clean.

Existing Test 10 (Huawei pass-through) missed this because its codes end in **letters** (`me-east-215-a/-b`) — the digit tail was the untested edge.

Refs #5381 #2840

🤖 Generated with [Claude Code](https://claude.com/claude-code)