### PR TITLE
fix(retry): phase-retry ran no post-apply chain — stamped ready with no DNS committed

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/retry.go
+++ b/products/catalyst/bootstrap/api/internal/handler/retry.go
@@ -249,17 +249,52 @@ func (h *Handler) runProvisioningRetry(dep *Deployment, retriedPhase string) {
 	close(producer)
 	<-teeDone
 
-	dep.mu.Lock()
-	dep.FinishedAt = time.Now()
 	if err != nil {
+		dep.mu.Lock()
+		dep.FinishedAt = time.Now()
 		dep.Status = "failed"
 		dep.Error = err.Error()
+		dep.mu.Unlock()
 		h.log.Error("retry provision failed", "id", dep.ID, "phase", retriedPhase, "err", err)
-	} else {
-		dep.Status = "ready"
-		dep.Result = result
-		h.log.Info("retry provision complete", "id", dep.ID, "phase", retriedPhase)
+		close(dep.done)
+		h.persistDeployment(dep)
+		return
 	}
+
+	// #5381 — a retry MUST run the SAME post-apply chain as
+	// runProvisioning. Before this, retryPhase0 set Status="ready"
+	// straight off a successful Provision() and never called
+	// commitPDMWithRetry / upsertSovereignParentZoneRecordsFromResult /
+	// runPhase1Watch. Those live only in runProvisioning, so the
+	// operator's "Retry phase" button could stamp a deployment READY
+	// with **no DNS records committed and no Phase-1 watch** — a green
+	// wizard pill over a Sovereign whose console FQDN does not resolve
+	// (observed on hw289: console./api./hw289.omani.works all NXDOMAIN
+	// while the record claimed a terminal status). Marking ready without
+	// the DNS commit is the same fabricated-verdict class as the #5381
+	// region-truncation bug this ticket fixed; both make the control
+	// plane lie about a Sovereign's real state.
+	//
+	// Order mirrors runProvisioning exactly: PDM commit (pool-allocated
+	// FQDNs) → parent-zone A records (BYO parent shapes, best-effort) →
+	// Phase-1 HelmRelease watch, which is what actually flips Status to
+	// ready once components converge. We deliberately do NOT set
+	// Status="ready" here: runPhase1Watch owns that transition, so a
+	// retry can no longer out-run its own convergence proof.
+	dep.mu.Lock()
+	dep.Result = result
+	dep.mu.Unlock()
+
+	h.commitPDMWithRetry(dep, result)
+	h.upsertSovereignParentZoneRecordsFromResult(context.Background(), dep, result)
+
+	h.log.Info("retry provision complete — running post-apply chain (PDM commit + phase-1 watch)",
+		"id", dep.ID, "phase", retriedPhase)
+
+	h.runPhase1Watch(dep)
+
+	dep.mu.Lock()
+	dep.FinishedAt = time.Now()
 	dep.mu.Unlock()
 	close(dep.done)
 	// Terminal persist for the retry — same reason as runProvisioning.


### PR DESCRIPTION
## Defect

`retryPhase0` (`internal/handler/retry.go`) set `dep.Status = "ready"` directly after a successful `Provision()` and never called `commitPDMWithRetry`, `upsertSovereignParentZoneRecordsFromResult`, or `runPhase1Watch`. Those three live only in `runProvisioning` (`deployments.go:2188-2216`).

Consequence: the documented operator recovery — the wizard's **"Retry phase"** button — could stamp a deployment **READY with zero DNS records committed and no Phase-1 convergence proof**. A green wizard pill over a Sovereign whose console FQDN does not resolve.

## How it was found

While evaluating whether phase-retry could salvage hw289's #5381 false `partial-failure` (its infra was fully materialised, so a retry looked attractive versus a 50-minute rebuild). It could not: hw289 had `console.` / `api.` / `hw289.omani.works` **all NXDOMAIN**, and a retry would have painted that green rather than surfacing it. hw289 was wiped and re-fired instead — and hw290, on the #5382-fixed control plane, now resolves all hosts and serves `console.hw290.omani.works` **HTTP 200 with a valid chain**.

Same fabricated-verdict class as #5381 itself: the control plane reporting a state the Sovereign is not in.

## Fix

Mirror `runProvisioning`'s order exactly:

1. `commitPDMWithRetry(dep, result)` — pool-allocated FQDNs
2. `upsertSovereignParentZoneRecordsFromResult(...)` — BYO-parent shapes, best-effort
3. `runPhase1Watch(dep)` — the HelmRelease watch

`Status` is deliberately **not** set in `retryPhase0` any more: `runPhase1Watch` owns the ready transition, so a retry cannot out-run its own convergence proof. The failure path returns early and is behaviourally unchanged.

## Gates

- `go build ./...` clean
- `go vet ./internal/handler` clean
- full `internal/handler` suite green (177s, includes the existing retry/phase tests)

Refs #5381 #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)