### PR TITLE
fix(provisioning): per-Org gitops commit survives Gitea PushOutOfDate — classify the 500 as a ref-race and stop the funnel racing itself (Refs #5387)

### DIFF
--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -635,10 +635,40 @@ func (c *Client) ensureBranchExists(ctx context.Context, branch string) error {
 //   - "sha does not match [given: …, expected: …]" — our `update` op carried
 //     a per-file SHA that went stale because a concurrent writer changed the
 //     file after our tree/contents probe.
+//
 // Both mean a concurrent writer won; a fresh re-probe on the next attempt
 // converts the op (create→update / stale-SHA→current-SHA) and succeeds.
 // Before this they fell through to the fatal `change files` branch and the
 // retry loop never engaged.
+//
+// #5387 (hw290) — THE KEYSTONE SHAPE. Every funnel Org that installed an app
+// failed provisioning on:
+//
+//	POST …/repos/<slug>/catalyst-tenant/contents: 500
+//	{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}
+//
+// Gitea's ChangeFiles handler builds the commit in a temp clone of the branch
+// head and then `git push`es it back to the bare repo. When a concurrent writer
+// (the org-controller's PutFile burst, or a sibling cart-app commit) advanced
+// the head between our clone and that push, git rejects the push and Gitea
+// wraps it in `git.ErrPushOutOfDate`, whose Error() renders as
+// `PushOutOfDate Error: <err>: <git stderr>` — the stderr carrying git's own
+// `! [rejected] <sha> -> <branch> (non-fast-forward)`. That error type is NOT
+// in Gitea's handleCreateOrUpdateFileError mapping table, so it falls through
+// to a bare **500**, not a 409/422. None of the shapes above matched it: the
+// status is not 409, and git spells it `non-fast-forward` (hyphenated), not
+// `not a fast forward`. So the error was classified FATAL, the retry loop
+// never ran even once, and the funnel step went straight to red on attempt 1 —
+// with no "ref-race persisted after N attempts" in the message, which is how
+// we know the CAS retry never engaged. This is a pure branch-head CAS loss:
+// re-reading the head and re-pushing (what the outer loop already does) is
+// exactly the right remedy.
+//
+// Deliberately NOT matched: Gitea's sibling `git.ErrPushRejected`
+// ("PushRejected Error", stderr `! [remote rejected] … (pre-receive hook
+// declined)`) — a branch-protection / hook refusal that no amount of retrying
+// can convert into a success. Gitea itself splits the two on exactly the
+// `non-fast-forward` substring, so keying on it keeps us precise.
 func isGiteaRefRaceError(err error) bool {
 	if err == nil {
 		return false
@@ -659,7 +689,11 @@ func isGiteaRefRaceError(err error) bool {
 		// file-level CAS losses from the ChangeFiles per-file SHA
 		// preconditions (#5234) — see doc comment above.
 		strings.Contains(s, "repository file already exists") ||
-		strings.Contains(s, "sha does not match")
+		strings.Contains(s, "sha does not match") ||
+		// branch-head CAS loss inside Gitea's own ChangeFiles push, served
+		// as a bare 500 (#5387) — see doc comment above.
+		strings.Contains(s, "PushOutOfDate") ||
+		strings.Contains(s, "non-fast-forward")
 }
 
 // getContentSHA returns the blob SHA of `path` at `branch`, or "" if the

--- a/core/services/provisioning/github/client_pushoutofdate_5387_test.go
+++ b/core/services/provisioning/github/client_pushoutofdate_5387_test.go
@@ -1,0 +1,216 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// #5387 (hw290) — THE KEYSTONE regression. Every funnel Organization that
+// installed an app failed provisioning with a terminal red step:
+//
+//	git commit to per-Org repo failed: commit to per-Org repo walk-two/catalyst-tenant:
+//	POST …/api/v1/repos/walk-two/catalyst-tenant/contents: 500
+//	{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}
+//
+// Gitea's ChangeFiles handler builds the commit in a temp clone of the branch
+// head and pushes it back. A concurrent writer that advanced the head in
+// between makes git reject the push; Gitea wraps that in ErrPushOutOfDate,
+// which is absent from its handleCreateOrUpdateFileError mapping table and so
+// escapes as a bare 500 whose body spells the reason `non-fast-forward` — not
+// the `not a fast forward` / 409 / 422 shapes isGiteaRefRaceError knew. The
+// classifier therefore called it FATAL and CommitFilesWithPruneAndRebuild
+// returned on attempt 1: the ref-race retry machinery built by #3376/#5234
+// existed but NEVER ENGAGED for the shape that was actually killing the
+// funnel. (The live message carried no "ref-race persisted after N attempts",
+// which is the tell that zero retries ran.)
+//
+// This is a pure branch-head compare-and-swap loss — re-reading the head and
+// re-pushing is exactly the right remedy, which is what the retry loop already
+// does once the error is classified correctly.
+
+// giteaPushOutOfDateBody is the response Gitea 1.22 actually serves for this
+// case: HTTP 500, message = git.ErrPushOutOfDate.Error(), i.e.
+// "PushOutOfDate Error: <err>: <git stderr>".
+const giteaPushOutOfDateBody = `{"message":"PushOutOfDate Error: exit status 1: To /data/git/repositories/walk-two/catalyst-tenant.git\n ! [rejected]        a480a0e7f31c0b7a0b6b0a0d5c1f1e2a3b4c5d6e -> main (non-fast-forward)\nerror: failed to push some refs to '/data/git/repositories/walk-two/catalyst-tenant.git'\n"}`
+
+// TestIsGiteaRefRaceError_PushOutOfDate_5387 pins the classifier against the
+// VERBATIM hw290 wire shape, and against the sibling error Gitea returns for a
+// genuine (non-retryable) refusal so the widened match can't turn a hook
+// rejection into an infinite-ish retry.
+func TestIsGiteaRefRaceError_PushOutOfDate_5387(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The exact hw290 error, as doRequest renders it.
+			name: "hw290 live shape — 500 PushOutOfDate / non-fast-forward",
+			err: fmt.Errorf("GitHub API POST http://gitea-http.gitea.svc:3000/api/v1/repos/walk-two/catalyst-tenant/contents: 500 %s",
+				giteaPushOutOfDateBody),
+			want: true,
+		},
+		{
+			name: "abbreviated ledger shape (message truncated by the console)",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}`),
+			want: true,
+		},
+		{
+			// git's other fast-forward-impossible wording; same remedy.
+			name: "git 'fetch first' reject wrapped as PushOutOfDate",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"PushOutOfDate Error: exit status 1: ! [rejected] main -> main (fetch first)"}`),
+			want: true,
+		},
+		{
+			// Gitea's sibling type for a pre-receive/branch-protection refusal.
+			// Retrying can NEVER convert it — it must stay fatal.
+			name: "PushRejected (pre-receive hook declined) stays fatal",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"PushRejected Error: exit status 1: ! [remote rejected] main -> main (pre-receive hook declined)"}`),
+			want: false,
+		},
+		{
+			name: "unrelated 500 stays fatal",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"database is locked"}`),
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		if got := isGiteaRefRaceError(tc.err); got != tc.want {
+			t.Errorf("%s: isGiteaRefRaceError = %v, want %v\n  err: %v", tc.name, got, tc.want, tc.err)
+		}
+	}
+}
+
+// TestCommitFilesWithPruneAndRebuild_RetriesGiteaPushOutOfDate_5387 drives the
+// real commit path against a fake Gitea that serves the hw290 500 on the first
+// batch and accepts the second — the shape of a concurrent writer that landed
+// once and then went quiet.
+//
+// Before the fix this returns the 500 immediately (1 POST, rebuild called
+// once) and the funnel step goes red. After it, the loop re-reads the moved
+// head, re-runs the caller's rebuild, and lands the commit.
+func TestCommitFilesWithPruneAndRebuild_RetriesGiteaPushOutOfDate_5387(t *testing.T) {
+	shrinkCommitRetryDelays(t)
+
+	var (
+		mu        sync.Mutex
+		postCount int
+		headReads int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			mu.Lock()
+			headReads++
+			// The head MOVES after the first read — the concurrent writer.
+			sha := "aaaa0000000000000000000000000000aaaa0000"
+			if headReads > 1 {
+				sha = "bbbb1111111111111111111111111111bbbb1111"
+			}
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"` + sha + `"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r) // fresh files → create ops
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			first := postCount == 1
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			if first {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(giteaPushOutOfDateBody))
+				return
+			}
+			_, _ = w.Write([]byte(`{"commit":{"sha":"ccccc22222222222222222222222222ccccc222"}}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var rebuilds int
+	c := NewClientWithAPIURL("token", "walk-two", "catalyst-tenant", srv.URL)
+	err := c.CommitFilesWithPruneAndRebuild(
+		context.Background(), "main", "day-2: install wordpress on Org walk-two",
+		nil, nil,
+		func(context.Context) (map[string]string, error) {
+			rebuilds++
+			return map[string]string{
+				"vcluster/apps/app-wordpress.yaml": "kind: HelmRelease\n",
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("PushOutOfDate must be retried as a ref-race, not returned as fatal (#5387); got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != 2 {
+		t.Errorf("expected 2 batch POSTs (1 PushOutOfDate + 1 win), got %d", postCount)
+	}
+	if rebuilds != 2 {
+		t.Errorf("expected the retry to re-run the caller's rebuild against the moved head, got %d rebuild(s)", rebuilds)
+	}
+	if headReads < 2 {
+		t.Errorf("expected the retry to re-read the branch head, got %d read(s)", headReads)
+	}
+}
+
+// TestCommitFilesWithPruneAndRebuild_PushOutOfDateExhaustionIsTerminal_5387
+// guards the other direction: a branch that is hot FOREVER must still fail
+// loudly after commitAttemptsMax, with the descriptive exhaustion error the
+// funnel turns into a red step (#5234). Retrying a real defect into silence is
+// not the fix.
+func TestCommitFilesWithPruneAndRebuild_PushOutOfDateExhaustionIsTerminal_5387(t *testing.T) {
+	shrinkCommitRetryDelays(t)
+
+	var (
+		mu        sync.Mutex
+		postCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"aaaa0000000000000000000000000000aaaa0000"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(giteaPushOutOfDateBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "walk-two", "catalyst-tenant", srv.URL)
+	err := c.CommitFiles(context.Background(), "main", "day-2: install wordpress", map[string]string{
+		"vcluster/apps/app-wordpress.yaml": "kind: HelmRelease\n",
+	})
+	if err == nil {
+		t.Fatalf("a permanently-hot branch must still fail — silent success would drop the purchased app")
+	}
+	if !strings.Contains(err.Error(), "ref-race persisted") {
+		t.Errorf("exhaustion must carry the descriptive ref-race error the funnel paints red, got: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != commitAttemptsMax {
+		t.Errorf("expected %d attempts before giving up, got %d", commitAttemptsMax, postCount)
+	}
+}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -687,6 +687,21 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 	// GitRepository actually watches.
 	branch := h.perOrgBranch()
 
+	// #5387 — hold the per-branch gate for the WHOLE read-merge-commit cycle.
+	// A cart with N Applications dispatches N concurrent installs (one per cart
+	// entry, each in its own goroutine), and every one of them re-renders the
+	// full cart and pushes it to this same branch. Un-gated they collide on the
+	// branch head and Gitea rejects the losers with `PushOutOfDate`, which on
+	// hw290 failed the funnel outright. Serialising them makes each commit build
+	// on the head its sibling just wrote, and leaves the whole CAS-retry budget
+	// for the genuinely out-of-process racer (the org-controller). The gate is
+	// released before we return, on every path.
+	release, err := h.perOrgCommits.acquire(ctx, slug+"/"+h.perOrgRepoName()+"@"+branch)
+	if err != nil {
+		return fmt.Errorf("per-Org commit gate for %s/%s@%s: %w", slug, h.perOrgRepoName(), branch, err)
+	}
+	defer release()
+
 	// #4999: render the per-Org app hosts under the Org's CHOSEN (served) pool
 	// zone — the SAME zone resolveOrgParentDomain stamps on the Org CR's
 	// spec.tenantPublic.parentDomain (which drives the per-Org console DNS / TLS /

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -120,6 +120,11 @@ type Handler struct {
 	// once the org-controller finishes creating the repo, so a slow per-Org
 	// create never drops the purchased app. Zero value is ready to use.
 	pendingInstalls pendingInstallRegistry
+
+	// perOrgCommits serialises this process's commits to a single per-Org
+	// gitops branch so the funnel's own N concurrent cart-app installs cannot
+	// contend for one branch head (#5387). Zero value is ready to use.
+	perOrgCommits perOrgCommitGate
 }
 
 // VerifyCommitTargetSafe re-runs the issue #944 cross-cluster pollution

--- a/core/services/provisioning/handlers/perorg_commit_gate.go
+++ b/core/services/provisioning/handlers/perorg_commit_gate.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+)
+
+// perOrgCommitGate serialises this process's commits to ONE per-Org gitops
+// branch, keyed by `<owner>/<repo>@<branch>`.
+//
+// #5387 (hw290) — the funnel dispatches a cart with N Applications as N
+// SEPARATE `/provisioning/apps/install` calls (tenant service: one POST + one
+// `tenant.app_install_requested` event PER cart entry), and ApplyAppInstall
+// runs each in its own detached goroutine. Every one of those goroutines then
+// re-renders the WHOLE cart and commits it to the SAME
+// `<slug>/catalyst-tenant@main` branch. So the per-Org gitops writer was
+// literally racing itself: N concurrent Gitea ChangeFiles batches contending
+// for one branch head, of which at most one can fast-forward. The losers came
+// back as Gitea `PushOutOfDate` (see isGiteaRefRaceError) and burned the
+// funnel's finite CAS-retry budget fighting siblings that were pushing
+// byte-identical content.
+//
+// The gate removes that entire class of contention at the source: the cart's N
+// commits queue behind each other and land sequentially, each rebuilt against
+// the head its predecessor just wrote. The out-of-process racer (the
+// org-controller's own PutFile burst on the same branch) is NOT covered by a
+// process-local gate — that one is handled by the CAS retry in
+// CommitFilesWithPruneAndRebuild, which now has the whole retry budget
+// available for it instead of spending it on self-inflicted collisions.
+//
+// It is a gate, not a dedup: every queued commit still runs, still re-reads the
+// head, and still reports its own errors. Nothing is swallowed.
+//
+// Zero value is usable. Entries are refcounted and dropped when the last
+// waiter leaves, so a long-lived process that serves many Organizations does
+// not accumulate them.
+type perOrgCommitGate struct {
+	mu    sync.Mutex
+	slots map[string]*commitGateSlot
+}
+
+// commitGateSlot is one branch's mutual-exclusion slot. `ch` is a 1-buffered
+// channel used as a ctx-cancellable mutex; `waiters` refcounts the goroutines
+// holding or queued on it so the map entry can be reclaimed.
+type commitGateSlot struct {
+	ch      chan struct{}
+	waiters int
+}
+
+// acquire blocks until the caller owns the gate for key, then returns the
+// release func. It returns ctx.Err() (without acquiring) if ctx is cancelled
+// while queued, so a tenant-deleted preempt or a shutting-down consumer never
+// parks forever behind another Org's commit.
+//
+// Callers MUST invoke the returned release exactly once — `defer release()` is
+// the idiom. Release is itself idempotent.
+func (g *perOrgCommitGate) acquire(ctx context.Context, key string) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	g.mu.Lock()
+	if g.slots == nil {
+		g.slots = make(map[string]*commitGateSlot)
+	}
+	slot, ok := g.slots[key]
+	if !ok {
+		slot = &commitGateSlot{ch: make(chan struct{}, 1)}
+		g.slots[key] = slot
+	}
+	slot.waiters++
+	g.mu.Unlock()
+
+	select {
+	case slot.ch <- struct{}{}:
+		var once sync.Once
+		return func() {
+			once.Do(func() {
+				<-slot.ch
+				g.drop(key)
+			})
+		}, nil
+	case <-ctx.Done():
+		g.drop(key)
+		return nil, ctx.Err()
+	}
+}
+
+// drop decrements the slot's refcount and removes the map entry once nobody
+// holds or waits on it.
+func (g *perOrgCommitGate) drop(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	slot, ok := g.slots[key]
+	if !ok {
+		return
+	}
+	slot.waiters--
+	if slot.waiters <= 0 {
+		delete(g.slots, key)
+	}
+}

--- a/core/services/provisioning/handlers/perorg_commit_race_5387_test.go
+++ b/core/services/provisioning/handlers/perorg_commit_race_5387_test.go
@@ -1,0 +1,366 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
+	"github.com/openova-io/openova/core/services/provisioning/gitops"
+)
+
+// #5387 (hw290) — every funnel Organization that installed an app failed
+// provisioning, terminally, at "Deploying <app>":
+//
+//	git commit to per-Org repo failed: commit to per-Org repo walk-two/catalyst-tenant:
+//	POST …/repos/walk-two/catalyst-tenant/contents: 500
+//	{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}
+//
+// Two independent defects stacked into that one red step, and the tests below
+// pin one each:
+//
+//  1. THE WRITER RACED ITSELF. The tenant service dispatches a cart as ONE
+//     `/provisioning/apps/install` per cart entry, and ApplyAppInstall runs each
+//     in its own detached goroutine — every one of which re-renders the WHOLE
+//     cart and pushes it to the SAME `<slug>/catalyst-tenant@main` branch. N
+//     concurrent Gitea ChangeFiles batches, one branch head, at most one
+//     fast-forward. applyTenantChangePerOrg now holds a per-branch gate across
+//     the whole read-merge-commit cycle so the siblings queue instead of
+//     colliding.
+//
+//  2. THE RETRY NEVER ENGAGED. Gitea serves this branch-head CAS loss as a bare
+//     500 spelled `non-fast-forward`, which isGiteaRefRaceError did not match,
+//     so CommitFilesWithPruneAndRebuild treated it as fatal on attempt 1. See
+//     github/client_pushoutofdate_5387_test.go for the classifier-level proof;
+//     the second test here pins the handler-visible consequence — the funnel
+//     step no longer goes red on a single recoverable collision.
+
+// perOrgRaceFake is a fake per-Org Gitea that models the ChangeFiles commit
+// the way the real one behaves: the batch POST clones the branch head, applies,
+// and pushes — with a real window in between. Two overlapping POSTs therefore
+// produce a PushOutOfDate for the loser, exactly as on hw290.
+//
+// It also records the maximum number of commit CYCLES (first remote read →
+// batch POST) that were ever in flight at once, which is the direct measure of
+// whether the per-Org gate is doing its job.
+type perOrgRaceFake struct {
+	t *testing.T
+
+	mu sync.Mutex
+	// head advances on every accepted batch — the branch tip.
+	head int
+	// inFlight/maxInFlight track overlapping commit cycles.
+	inFlight    int
+	maxInFlight int
+	postCount   int
+	rejects     int
+	// commitWindow is how long the fake holds a batch between reading the
+	// head and pushing — the race window a concurrent writer can land in.
+	commitWindow time.Duration
+}
+
+// enterCycle/leaveCycle bracket one handler-side commit cycle. The cycle opens
+// on the branch-ref read (the first remote call applyTenantChangePerOrg makes
+// through the commit client) and closes when its batch POST is answered.
+func (f *perOrgRaceFake) enterCycle() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inFlight++
+	if f.inFlight > f.maxInFlight {
+		f.maxInFlight = f.inFlight
+	}
+}
+
+func (f *perOrgRaceFake) leaveCycle() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.inFlight > 0 {
+		f.inFlight--
+	}
+}
+
+func (f *perOrgRaceFake) handler() http.HandlerFunc {
+	// refSeen tracks which cycles have opened, so a retry's second ref read
+	// inside the same handler call doesn't double-count. Keyed by nothing
+	// fancy — we simply pair every ref read with the next POST from the same
+	// connection-agnostic sequence, which is sufficient because the client
+	// always does ref-read → … → POST.
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/plans"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"s","slug":"s"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"wordpress","slug":"wordpress"},{"id":"listmonk","slug":"listmonk"},{"id":"openclaw","slug":"openclaw"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			f.enterCycle()
+			f.mu.Lock()
+			head := f.head
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `[{"object":{"sha":"headsha-%032d"}}]`, head)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/trees/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tree":[],"truncated":false}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"name":"networkpolicy.yaml","type":"file"},{"name":"kustomization.yaml","type":"file"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps/kustomization.yaml"):
+			f.mu.Lock()
+			head := f.head
+			f.mu.Unlock()
+			content := base64.StdEncoding.EncodeToString([]byte(
+				"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - networkpolicy.yaml\n"))
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"sha":"kustsha-%d","content":"%s","encoding":"base64"}`, head, content)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			// Gitea's ChangeFiles: clone at `base`, apply, push. Anything that
+			// moved the head inside the window makes the push non-fast-forward.
+			f.mu.Lock()
+			f.postCount++
+			base := f.head
+			f.mu.Unlock()
+
+			time.Sleep(f.commitWindow)
+
+			f.mu.Lock()
+			moved := f.head != base
+			if !moved {
+				f.head++
+			} else {
+				f.rejects++
+			}
+			f.mu.Unlock()
+
+			f.leaveCycle()
+			w.Header().Set("Content-Type", "application/json")
+			if moved {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, `{"message":"PushOutOfDate Error: exit status 1: To /data/git/repositories/w5387/catalyst-tenant.git\n ! [rejected]        a480a0e7 -> main (non-fast-forward)\n"}`)
+				return
+			}
+			fmt.Fprintf(w, `{"commit":{"sha":"commitsha-%032d"}}`, base+1)
+		default:
+			f.t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func newPerOrgRaceHandler(t *testing.T, srvURL string) *Handler {
+	t.Helper()
+	gen := gitops.NewManifestGenerator("clusters/sov/org-tenants")
+	gen.ParentDomain = "omani.homes"
+	return &Handler{
+		Generator:    gen,
+		GitHubClient: ghclient.NewClientWithAPIURL("token", "openova", "openova", srvURL),
+		GitBranch:    "main",
+		PerOrgGitops: true,
+		CatalogURL:   srvURL,
+	}
+}
+
+// TestApplyTenantChangePerOrg_SerialisesConcurrentCartInstalls_5387 dispatches
+// a 3-app cart the way the funnel does — three concurrent installs for the SAME
+// Org — against a Gitea that rejects overlapping pushes exactly like the real
+// one.
+//
+// Without the per-Org gate the three commit cycles interleave on one branch
+// head (maxInFlight == 3) and the fake serves PushOutOfDate to the losers: the
+// hw290 failure, self-inflicted. With the gate they queue, so the branch never
+// sees more than one writer, no push is ever rejected, and all three installs
+// commit.
+func TestApplyTenantChangePerOrg_SerialisesConcurrentCartInstalls_5387(t *testing.T) {
+	fake := &perOrgRaceFake{t: t, commitWindow: 25 * time.Millisecond}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	h := newPerOrgRaceHandler(t, srv.URL)
+
+	cart := []string{"wordpress", "listmonk", "openclaw"}
+	errs := make([]error, len(cart))
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i, app := range cart {
+		wg.Add(1)
+		go func(i int, app string) {
+			defer wg.Done()
+			<-start // release all three at once — the funnel's fan-out
+			errs[i] = h.applyTenantChange(context.Background(), appChangeData{
+				TenantSlug: "w5387",
+				AppSlug:    app,
+				Apps:       cart,
+				PlanID:     "s",
+			}, "install")
+		}(i, app)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("cart app %q failed to commit: %v", cart[i], err)
+		}
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.maxInFlight != 1 {
+		t.Errorf("the per-Org branch saw %d concurrent commit cycles — the funnel's own cart installs are racing each other on one head (#5387); want 1",
+			fake.maxInFlight)
+	}
+	if fake.rejects != 0 {
+		t.Errorf("Gitea rejected %d push(es) as PushOutOfDate — serialised commits must never collide with each other (#5387)", fake.rejects)
+	}
+	if fake.postCount != len(cart) {
+		t.Errorf("expected exactly %d batch POSTs (one per cart install, no retries needed), got %d", len(cart), fake.postCount)
+	}
+	if fake.head != len(cart) {
+		t.Errorf("expected the branch head to advance once per install (%d), got %d", len(cart), fake.head)
+	}
+}
+
+// TestApplyTenantChangePerOrg_RecoversFromGiteaPushOutOfDate_5387 pins the
+// handler-visible half of the classifier fix: an out-of-process writer (the
+// org-controller, which no gate in this process can hold back) advances the
+// head under us once. On hw290 that single collision was terminal — the day-2
+// commit returned the raw 500 and "Deploying <app>" went red. It must now be
+// absorbed by the ref-race retry and the install must land.
+func TestApplyTenantChangePerOrg_RecoversFromGiteaPushOutOfDate_5387(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		postCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/plans"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"s","slug":"s"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"wordpress","slug":"wordpress"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"headsha-00000000000000000000000000000001"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/trees/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tree":[],"truncated":false}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"name":"networkpolicy.yaml","type":"file"}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			first := postCount == 1
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			if first {
+				// The VERBATIM hw290 shape: 500 + PushOutOfDate.
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"commit":{"sha":"commitsha-0000000000000000000000000002"}}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	h := newPerOrgRaceHandler(t, srv.URL)
+	err := h.applyTenantChange(context.Background(), appChangeData{
+		TenantSlug: "w5387b",
+		AppSlug:    "wordpress",
+		Apps:       []string{"wordpress"},
+		PlanID:     "s",
+	}, "install")
+	if err != nil {
+		t.Fatalf("a single PushOutOfDate collision must be retried, not fail the install (#5387); got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != 2 {
+		t.Errorf("expected 2 batch POSTs (1 PushOutOfDate + 1 win), got %d", postCount)
+	}
+}
+
+// TestPushOutOfDateExhaustionIsTerminalNotParkable_5387 — a PushOutOfDate that
+// survives every CAS attempt must still be a TERMINAL failure that paints the
+// funnel red, not the parkable #4404 "per-Org Gitea repo not ready" race. The
+// 500 body must never be mistaken for the 404 shapes isGiteaNotReadyError
+// keys on, or a genuinely wedged branch would sit in the pending-install
+// registry for 30 minutes with no red step anywhere.
+func TestPushOutOfDateExhaustionIsTerminalNotParkable_5387(t *testing.T) {
+	exhausted := fmt.Errorf(`commit to per-Org repo walk-two/catalyst-tenant: commit: ref-race persisted after 10 attempts: update ref: GitHub API POST http://gitea-http.gitea.svc:3000/api/v1/repos/walk-two/catalyst-tenant/contents: 500 {"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}: not a fast forward (gitea contents API)`)
+	if isGiteaNotReadyError(exhausted) {
+		t.Fatalf("an exhausted PushOutOfDate ref-race must NOT be parkable as #4404 Gitea-not-ready — it would wait 30 minutes with no red step")
+	}
+}
+
+// TestPerOrgCommitGate_ReleasesAndIsCtxCancellable_5387 pins the gate's own
+// contract: mutual exclusion per key, independence across keys, a ctx-abortable
+// wait (so a tenant-deleted preempt never parks behind another Org), and no map
+// growth once every holder has released.
+func TestPerOrgCommitGate_ReleasesAndIsCtxCancellable_5387(t *testing.T) {
+	var g perOrgCommitGate
+	ctx := context.Background()
+
+	relA, err := g.acquire(ctx, "acme/catalyst-tenant@main")
+	if err != nil {
+		t.Fatalf("first acquire must succeed: %v", err)
+	}
+
+	// A DIFFERENT Org must not be blocked by acme's in-flight commit.
+	relB, err := g.acquire(ctx, "beta/catalyst-tenant@main")
+	if err != nil {
+		t.Fatalf("a different Org must not be gated behind acme: %v", err)
+	}
+	relB()
+
+	// The SAME Org must block — and must give up when its ctx is cancelled.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	blocked := make(chan error, 1)
+	go func() { _, aerr := g.acquire(cancelCtx, "acme/catalyst-tenant@main"); blocked <- aerr }()
+	select {
+	case aerr := <-blocked:
+		t.Fatalf("second acquire on the same key must block while the first holds it, returned %v", aerr)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case aerr := <-blocked:
+		if aerr == nil {
+			t.Errorf("a cancelled waiter must return ctx.Err(), not acquire the gate")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("a cancelled waiter must abort promptly instead of parking forever")
+	}
+
+	// Once released the key is re-acquirable, and the registry drains.
+	relA()
+	relA() // release is idempotent
+	relC, err := g.acquire(ctx, "acme/catalyst-tenant@main")
+	if err != nil {
+		t.Fatalf("gate must be re-acquirable after release: %v", err)
+	}
+	relC()
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.slots) != 0 {
+		t.Errorf("gate leaked %d slot(s) after every holder released: %v", len(g.slots), g.slots)
+	}
+}


### PR DESCRIPTION
## Root cause

Two defects stacked into the single terminal red step that killed every funnel Organization's app install on hw290:

```
git commit to per-Org repo failed: commit to per-Org repo walk-two/catalyst-tenant:
POST …/api/v1/repos/walk-two/catalyst-tenant/contents: 500
{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}
```

**1 — the ref-race retry never engaged (the keystone).** Gitea's batch `ChangeFiles` endpoint builds the commit in a temp clone of the branch head and then `git push`es it back to the bare repo. A concurrent writer that advances the head inside that window makes git reject the push, and Gitea wraps it in `git.ErrPushOutOfDate`. That error type is **not** in Gitea's `handleCreateOrUpdateFileError` mapping table, so it escapes as a bare **500** whose body spells the reason `non-fast-forward`. `isGiteaRefRaceError` matched `409` / `422 sha does not match` / `not a fast forward` / `cannot lock ref` — none of which match a 500 saying `non-fast-forward` (hyphenated). So the error was classified **fatal**, `CommitFilesWithPruneAndRebuild` returned on attempt 1, and the entire compare-and-swap retry machinery built by #3376 and #5234 sat unreachable behind a classifier gap. The tell is in the live message itself: it carries no `ref-race persisted after N attempts`, because zero retries ran.

**2 — the writer raced itself.** `core/services/tenant/handlers/handlers.go` dispatches a cart as **one `/provisioning/apps/install` per cart entry**, and `ApplyAppInstall` runs each in its own detached goroutine. Every one of those goroutines re-renders the **whole** cart and pushes it to the **same** `<slug>/catalyst-tenant@main` head. N concurrent `ChangeFiles` batches, one branch head, at most one fast-forward — the losers came back as `PushOutOfDate` and (per defect 1) died instantly. This is why the issue title reads "races itself".

This also explains the correction in the walk notes: `epsilon-corp` failed on a **single-app** cart. App count was never the trigger. Any concurrent writer on the branch — a sibling cart app **or** the org-controller's own PutFile burst — produced a 500 that was unconditionally fatal.

## Fix

**`core/services/provisioning/github/client.go`** — `isGiteaRefRaceError` now recognises `PushOutOfDate` / `non-fast-forward` as a branch-head CAS loss, which is precisely what the existing retry loop already handles correctly: re-read the head, re-run the caller's rebuild closure (#5234), re-push with fresh per-file SHA preconditions. Gitea's sibling `ErrPushRejected` (`! [remote rejected] … pre-receive hook declined`) is deliberately **not** matched — a hook/branch-protection refusal can never be retried into a success, and Gitea itself splits the two error types on exactly the `non-fast-forward` substring, so keying on it stays precise.

**`core/services/provisioning/handlers/perorg_commit_gate.go`** (new) + `applyTenantChangePerOrg` — a ctx-abortable, refcounted per-branch gate keyed `<owner>/<repo>@<branch>`, held across the whole read-merge-commit cycle. The cart's N commits queue instead of colliding, and each is rebuilt against the head its predecessor just wrote.

**Why both, and why this shape over the alternatives.** The ticket offered three shapes. The writer already does (1) re-read-the-head-per-attempt and (3) a single atomic multi-file commit — #5234 shipped those; they were simply unreachable for this error. So the durable repair is the classifier plus (2) serialisation. Serialisation alone cannot work: the org-controller writes the same branch from a **different process**, which no process-local gate can hold back. The classifier alone works but is wasteful — the test below shows three cart apps colliding 3× and burning 6 batch POSTs where 3 suffice. Together, the self-inflicted contention is eliminated at the source and the full CAS-retry budget is left for the genuinely out-of-process racer.

**Nothing is swallowed.** A branch that stays hot through all 10 attempts still fails with the descriptive `ref-race persisted after 10 attempts` error the funnel paints red (#5234), and that error is still not classified as the parkable #4404 "per-Org Gitea repo not ready" race — a test pins that explicitly.

## Regression tests — both directions proven

New: `core/services/provisioning/github/client_pushoutofdate_5387_test.go`, `core/services/provisioning/handlers/perorg_commit_race_5387_test.go`.

**Reverted-fix run — classifier reverted:**

```
--- FAIL: TestIsGiteaRefRaceError_PushOutOfDate_5387
    hw290 live shape — 500 PushOutOfDate / non-fast-forward: isGiteaRefRaceError = false, want true
--- FAIL: TestCommitFilesWithPruneAndRebuild_RetriesGiteaPushOutOfDate_5387
    got: change files: GitHub API POST .../contents: 500 {"message":"PushOutOfDate Error: exit status 1: …(non-fast-forward)…"}
--- FAIL: TestCommitFilesWithPruneAndRebuild_PushOutOfDateExhaustionIsTerminal_5387
    expected 10 attempts before giving up, got 1
```

`got 1` is the whole defect on one line: the retry loop ran exactly once.

**Reverted-fix run — both reverted, handler level (this reproduces the live walk verbatim):**

```
--- FAIL: TestApplyTenantChangePerOrg_SerialisesConcurrentCartInstalls_5387
    cart app "wordpress" failed to commit: commit to per-Org repo w5387/catalyst-tenant:
      change files: GitHub API POST …/contents: 500 {"message":"PushOutOfDate Error … (non-fast-forward)"}
    cart app "openclaw" failed to commit: … (same)
    the per-Org branch saw 3 concurrent commit cycles — the funnel's own cart installs
      are racing each other on one head (#5387); want 1
    Gitea rejected 2 push(es) as PushOutOfDate
    expected the branch head to advance once per install (3), got 1
--- FAIL: TestApplyTenantChangePerOrg_RecoversFromGiteaPushOutOfDate_5387
    a single PushOutOfDate collision must be retried, not fail the install (#5387)
```

**Reverted-gate only (classifier restored) — proves the gate is independently load-bearing:**

```
--- FAIL: TestApplyTenantChangePerOrg_SerialisesConcurrentCartInstalls_5387
    the per-Org branch saw 3 concurrent commit cycles … want 1
    Gitea rejected 3 push(es) as PushOutOfDate
    expected exactly 3 batch POSTs (one per cart install, no retries needed), got 6
```

The installs now succeed, but only after 3 self-inflicted collisions and double the pushes.

**Fixed run:**

```
--- PASS: TestIsGiteaRefRaceError_PushOutOfDate_5387 (0.00s)
--- PASS: TestCommitFilesWithPruneAndRebuild_RetriesGiteaPushOutOfDate_5387 (0.00s)
--- PASS: TestCommitFilesWithPruneAndRebuild_PushOutOfDateExhaustionIsTerminal_5387 (0.03s)
--- PASS: TestApplyTenantChangePerOrg_SerialisesConcurrentCartInstalls_5387 (0.08s)
--- PASS: TestApplyTenantChangePerOrg_RecoversFromGiteaPushOutOfDate_5387 (0.05s)
--- PASS: TestPushOutOfDateExhaustionIsTerminalNotParkable_5387 (0.00s)
--- PASS: TestPerOrgCommitGate_ReleasesAndIsCtxCancellable_5387 (0.02s)
```

The fake Gitea is not a token-matcher: it tracks a real branch head, holds each batch for a real clone→push window, and rejects any push whose base moved — the same mechanic that produced the live 500.

## Gates run

```
go build ./...   OK
go vet ./...     OK
go test ./...    ok  github/  gitguard/  gitops/  handlers/  store/
go test -race    ok  (all five packages)
gofmt            clean on every touched file
```

No chart touched, so no `Chart.yaml` bump and no bootstrap-kit / catalog-seed lockstep is in play. The provisioning binary ships through `products/catalyst/chart/values.yaml` `images.orgTag`, which `.github/workflows/services-build.yaml` auto-bumps to the merge SHA — hand-pinning here would collide with the deploy job.

## Verification still owed

Runtime proof on a live Sovereign: a funnel Org carting 3+ apps reaching Done with every app Ready, plus the downstream unblock the issue thread describes — with no funnel Org leaving HelmReleases mid-roll, cutover step-03 `harbor-prewarm`'s #4982 settled-roll pre-flight can pass, which is what gates G11 / 166 and the Pillar-5 sovereignty proof. Until that walk lands as a comment on the issue, this stays open.

Refs #5387 #5234 #5305 #3376 #4982 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
