### PR TITLE
fix(cutover): settled-roll pre-flight distinguishes TERMINAL offenders from genuinely mid-roll ones

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -988,7 +988,7 @@ spec:
       # is a behavioral no-op (empty optional mount -> glob guards skip every leg;
       # the legs DO render). Step count stays 11.
       # Contract Case 71.
-      version: 0.1.151
+      version: 0.1.152
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1290,7 +1290,7 @@ spec:
       #   cutover-secondary-kubeconfigs bridge + catalog-seed
       #   bp-self-sovereign-cutover 0.1.151 (region-B cutover legs) +
       #   bp-guacamole 0.2.31 sync (TBD-A6 bot re-mint).
-      version: 1.4.1221
+      version: 1.4.1222
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -635,10 +635,40 @@ func (c *Client) ensureBranchExists(ctx context.Context, branch string) error {
 //   - "sha does not match [given: …, expected: …]" — our `update` op carried
 //     a per-file SHA that went stale because a concurrent writer changed the
 //     file after our tree/contents probe.
+//
 // Both mean a concurrent writer won; a fresh re-probe on the next attempt
 // converts the op (create→update / stale-SHA→current-SHA) and succeeds.
 // Before this they fell through to the fatal `change files` branch and the
 // retry loop never engaged.
+//
+// #5387 (hw290) — THE KEYSTONE SHAPE. Every funnel Org that installed an app
+// failed provisioning on:
+//
+//	POST …/repos/<slug>/catalyst-tenant/contents: 500
+//	{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}
+//
+// Gitea's ChangeFiles handler builds the commit in a temp clone of the branch
+// head and then `git push`es it back to the bare repo. When a concurrent writer
+// (the org-controller's PutFile burst, or a sibling cart-app commit) advanced
+// the head between our clone and that push, git rejects the push and Gitea
+// wraps it in `git.ErrPushOutOfDate`, whose Error() renders as
+// `PushOutOfDate Error: <err>: <git stderr>` — the stderr carrying git's own
+// `! [rejected] <sha> -> <branch> (non-fast-forward)`. That error type is NOT
+// in Gitea's handleCreateOrUpdateFileError mapping table, so it falls through
+// to a bare **500**, not a 409/422. None of the shapes above matched it: the
+// status is not 409, and git spells it `non-fast-forward` (hyphenated), not
+// `not a fast forward`. So the error was classified FATAL, the retry loop
+// never ran even once, and the funnel step went straight to red on attempt 1 —
+// with no "ref-race persisted after N attempts" in the message, which is how
+// we know the CAS retry never engaged. This is a pure branch-head CAS loss:
+// re-reading the head and re-pushing (what the outer loop already does) is
+// exactly the right remedy.
+//
+// Deliberately NOT matched: Gitea's sibling `git.ErrPushRejected`
+// ("PushRejected Error", stderr `! [remote rejected] … (pre-receive hook
+// declined)`) — a branch-protection / hook refusal that no amount of retrying
+// can convert into a success. Gitea itself splits the two on exactly the
+// `non-fast-forward` substring, so keying on it keeps us precise.
 func isGiteaRefRaceError(err error) bool {
 	if err == nil {
 		return false
@@ -659,7 +689,11 @@ func isGiteaRefRaceError(err error) bool {
 		// file-level CAS losses from the ChangeFiles per-file SHA
 		// preconditions (#5234) — see doc comment above.
 		strings.Contains(s, "repository file already exists") ||
-		strings.Contains(s, "sha does not match")
+		strings.Contains(s, "sha does not match") ||
+		// branch-head CAS loss inside Gitea's own ChangeFiles push, served
+		// as a bare 500 (#5387) — see doc comment above.
+		strings.Contains(s, "PushOutOfDate") ||
+		strings.Contains(s, "non-fast-forward")
 }
 
 // getContentSHA returns the blob SHA of `path` at `branch`, or "" if the

--- a/core/services/provisioning/github/client_pushoutofdate_5387_test.go
+++ b/core/services/provisioning/github/client_pushoutofdate_5387_test.go
@@ -1,0 +1,216 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// #5387 (hw290) — THE KEYSTONE regression. Every funnel Organization that
+// installed an app failed provisioning with a terminal red step:
+//
+//	git commit to per-Org repo failed: commit to per-Org repo walk-two/catalyst-tenant:
+//	POST …/api/v1/repos/walk-two/catalyst-tenant/contents: 500
+//	{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}
+//
+// Gitea's ChangeFiles handler builds the commit in a temp clone of the branch
+// head and pushes it back. A concurrent writer that advanced the head in
+// between makes git reject the push; Gitea wraps that in ErrPushOutOfDate,
+// which is absent from its handleCreateOrUpdateFileError mapping table and so
+// escapes as a bare 500 whose body spells the reason `non-fast-forward` — not
+// the `not a fast forward` / 409 / 422 shapes isGiteaRefRaceError knew. The
+// classifier therefore called it FATAL and CommitFilesWithPruneAndRebuild
+// returned on attempt 1: the ref-race retry machinery built by #3376/#5234
+// existed but NEVER ENGAGED for the shape that was actually killing the
+// funnel. (The live message carried no "ref-race persisted after N attempts",
+// which is the tell that zero retries ran.)
+//
+// This is a pure branch-head compare-and-swap loss — re-reading the head and
+// re-pushing is exactly the right remedy, which is what the retry loop already
+// does once the error is classified correctly.
+
+// giteaPushOutOfDateBody is the response Gitea 1.22 actually serves for this
+// case: HTTP 500, message = git.ErrPushOutOfDate.Error(), i.e.
+// "PushOutOfDate Error: <err>: <git stderr>".
+const giteaPushOutOfDateBody = `{"message":"PushOutOfDate Error: exit status 1: To /data/git/repositories/walk-two/catalyst-tenant.git\n ! [rejected]        a480a0e7f31c0b7a0b6b0a0d5c1f1e2a3b4c5d6e -> main (non-fast-forward)\nerror: failed to push some refs to '/data/git/repositories/walk-two/catalyst-tenant.git'\n"}`
+
+// TestIsGiteaRefRaceError_PushOutOfDate_5387 pins the classifier against the
+// VERBATIM hw290 wire shape, and against the sibling error Gitea returns for a
+// genuine (non-retryable) refusal so the widened match can't turn a hook
+// rejection into an infinite-ish retry.
+func TestIsGiteaRefRaceError_PushOutOfDate_5387(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The exact hw290 error, as doRequest renders it.
+			name: "hw290 live shape — 500 PushOutOfDate / non-fast-forward",
+			err: fmt.Errorf("GitHub API POST http://gitea-http.gitea.svc:3000/api/v1/repos/walk-two/catalyst-tenant/contents: 500 %s",
+				giteaPushOutOfDateBody),
+			want: true,
+		},
+		{
+			name: "abbreviated ledger shape (message truncated by the console)",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}`),
+			want: true,
+		},
+		{
+			// git's other fast-forward-impossible wording; same remedy.
+			name: "git 'fetch first' reject wrapped as PushOutOfDate",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"PushOutOfDate Error: exit status 1: ! [rejected] main -> main (fetch first)"}`),
+			want: true,
+		},
+		{
+			// Gitea's sibling type for a pre-receive/branch-protection refusal.
+			// Retrying can NEVER convert it — it must stay fatal.
+			name: "PushRejected (pre-receive hook declined) stays fatal",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"PushRejected Error: exit status 1: ! [remote rejected] main -> main (pre-receive hook declined)"}`),
+			want: false,
+		},
+		{
+			name: "unrelated 500 stays fatal",
+			err:  errors.New(`GitHub API POST .../contents: 500 {"message":"database is locked"}`),
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		if got := isGiteaRefRaceError(tc.err); got != tc.want {
+			t.Errorf("%s: isGiteaRefRaceError = %v, want %v\n  err: %v", tc.name, got, tc.want, tc.err)
+		}
+	}
+}
+
+// TestCommitFilesWithPruneAndRebuild_RetriesGiteaPushOutOfDate_5387 drives the
+// real commit path against a fake Gitea that serves the hw290 500 on the first
+// batch and accepts the second — the shape of a concurrent writer that landed
+// once and then went quiet.
+//
+// Before the fix this returns the 500 immediately (1 POST, rebuild called
+// once) and the funnel step goes red. After it, the loop re-reads the moved
+// head, re-runs the caller's rebuild, and lands the commit.
+func TestCommitFilesWithPruneAndRebuild_RetriesGiteaPushOutOfDate_5387(t *testing.T) {
+	shrinkCommitRetryDelays(t)
+
+	var (
+		mu        sync.Mutex
+		postCount int
+		headReads int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			mu.Lock()
+			headReads++
+			// The head MOVES after the first read — the concurrent writer.
+			sha := "aaaa0000000000000000000000000000aaaa0000"
+			if headReads > 1 {
+				sha = "bbbb1111111111111111111111111111bbbb1111"
+			}
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"` + sha + `"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r) // fresh files → create ops
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			first := postCount == 1
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			if first {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(giteaPushOutOfDateBody))
+				return
+			}
+			_, _ = w.Write([]byte(`{"commit":{"sha":"ccccc22222222222222222222222222ccccc222"}}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var rebuilds int
+	c := NewClientWithAPIURL("token", "walk-two", "catalyst-tenant", srv.URL)
+	err := c.CommitFilesWithPruneAndRebuild(
+		context.Background(), "main", "day-2: install wordpress on Org walk-two",
+		nil, nil,
+		func(context.Context) (map[string]string, error) {
+			rebuilds++
+			return map[string]string{
+				"vcluster/apps/app-wordpress.yaml": "kind: HelmRelease\n",
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("PushOutOfDate must be retried as a ref-race, not returned as fatal (#5387); got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != 2 {
+		t.Errorf("expected 2 batch POSTs (1 PushOutOfDate + 1 win), got %d", postCount)
+	}
+	if rebuilds != 2 {
+		t.Errorf("expected the retry to re-run the caller's rebuild against the moved head, got %d rebuild(s)", rebuilds)
+	}
+	if headReads < 2 {
+		t.Errorf("expected the retry to re-read the branch head, got %d read(s)", headReads)
+	}
+}
+
+// TestCommitFilesWithPruneAndRebuild_PushOutOfDateExhaustionIsTerminal_5387
+// guards the other direction: a branch that is hot FOREVER must still fail
+// loudly after commitAttemptsMax, with the descriptive exhaustion error the
+// funnel turns into a red step (#5234). Retrying a real defect into silence is
+// not the fix.
+func TestCommitFilesWithPruneAndRebuild_PushOutOfDateExhaustionIsTerminal_5387(t *testing.T) {
+	shrinkCommitRetryDelays(t)
+
+	var (
+		mu        sync.Mutex
+		postCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"aaaa0000000000000000000000000000aaaa0000"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(giteaPushOutOfDateBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "walk-two", "catalyst-tenant", srv.URL)
+	err := c.CommitFiles(context.Background(), "main", "day-2: install wordpress", map[string]string{
+		"vcluster/apps/app-wordpress.yaml": "kind: HelmRelease\n",
+	})
+	if err == nil {
+		t.Fatalf("a permanently-hot branch must still fail — silent success would drop the purchased app")
+	}
+	if !strings.Contains(err.Error(), "ref-race persisted") {
+		t.Errorf("exhaustion must carry the descriptive ref-race error the funnel paints red, got: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != commitAttemptsMax {
+		t.Errorf("expected %d attempts before giving up, got %d", commitAttemptsMax, postCount)
+	}
+}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -687,6 +687,21 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 	// GitRepository actually watches.
 	branch := h.perOrgBranch()
 
+	// #5387 — hold the per-branch gate for the WHOLE read-merge-commit cycle.
+	// A cart with N Applications dispatches N concurrent installs (one per cart
+	// entry, each in its own goroutine), and every one of them re-renders the
+	// full cart and pushes it to this same branch. Un-gated they collide on the
+	// branch head and Gitea rejects the losers with `PushOutOfDate`, which on
+	// hw290 failed the funnel outright. Serialising them makes each commit build
+	// on the head its sibling just wrote, and leaves the whole CAS-retry budget
+	// for the genuinely out-of-process racer (the org-controller). The gate is
+	// released before we return, on every path.
+	release, err := h.perOrgCommits.acquire(ctx, slug+"/"+h.perOrgRepoName()+"@"+branch)
+	if err != nil {
+		return fmt.Errorf("per-Org commit gate for %s/%s@%s: %w", slug, h.perOrgRepoName(), branch, err)
+	}
+	defer release()
+
 	// #4999: render the per-Org app hosts under the Org's CHOSEN (served) pool
 	// zone — the SAME zone resolveOrgParentDomain stamps on the Org CR's
 	// spec.tenantPublic.parentDomain (which drives the per-Org console DNS / TLS /

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -120,6 +120,11 @@ type Handler struct {
 	// once the org-controller finishes creating the repo, so a slow per-Org
 	// create never drops the purchased app. Zero value is ready to use.
 	pendingInstalls pendingInstallRegistry
+
+	// perOrgCommits serialises this process's commits to a single per-Org
+	// gitops branch so the funnel's own N concurrent cart-app installs cannot
+	// contend for one branch head (#5387). Zero value is ready to use.
+	perOrgCommits perOrgCommitGate
 }
 
 // VerifyCommitTargetSafe re-runs the issue #944 cross-cluster pollution

--- a/core/services/provisioning/handlers/perorg_commit_gate.go
+++ b/core/services/provisioning/handlers/perorg_commit_gate.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+)
+
+// perOrgCommitGate serialises this process's commits to ONE per-Org gitops
+// branch, keyed by `<owner>/<repo>@<branch>`.
+//
+// #5387 (hw290) — the funnel dispatches a cart with N Applications as N
+// SEPARATE `/provisioning/apps/install` calls (tenant service: one POST + one
+// `tenant.app_install_requested` event PER cart entry), and ApplyAppInstall
+// runs each in its own detached goroutine. Every one of those goroutines then
+// re-renders the WHOLE cart and commits it to the SAME
+// `<slug>/catalyst-tenant@main` branch. So the per-Org gitops writer was
+// literally racing itself: N concurrent Gitea ChangeFiles batches contending
+// for one branch head, of which at most one can fast-forward. The losers came
+// back as Gitea `PushOutOfDate` (see isGiteaRefRaceError) and burned the
+// funnel's finite CAS-retry budget fighting siblings that were pushing
+// byte-identical content.
+//
+// The gate removes that entire class of contention at the source: the cart's N
+// commits queue behind each other and land sequentially, each rebuilt against
+// the head its predecessor just wrote. The out-of-process racer (the
+// org-controller's own PutFile burst on the same branch) is NOT covered by a
+// process-local gate — that one is handled by the CAS retry in
+// CommitFilesWithPruneAndRebuild, which now has the whole retry budget
+// available for it instead of spending it on self-inflicted collisions.
+//
+// It is a gate, not a dedup: every queued commit still runs, still re-reads the
+// head, and still reports its own errors. Nothing is swallowed.
+//
+// Zero value is usable. Entries are refcounted and dropped when the last
+// waiter leaves, so a long-lived process that serves many Organizations does
+// not accumulate them.
+type perOrgCommitGate struct {
+	mu    sync.Mutex
+	slots map[string]*commitGateSlot
+}
+
+// commitGateSlot is one branch's mutual-exclusion slot. `ch` is a 1-buffered
+// channel used as a ctx-cancellable mutex; `waiters` refcounts the goroutines
+// holding or queued on it so the map entry can be reclaimed.
+type commitGateSlot struct {
+	ch      chan struct{}
+	waiters int
+}
+
+// acquire blocks until the caller owns the gate for key, then returns the
+// release func. It returns ctx.Err() (without acquiring) if ctx is cancelled
+// while queued, so a tenant-deleted preempt or a shutting-down consumer never
+// parks forever behind another Org's commit.
+//
+// Callers MUST invoke the returned release exactly once — `defer release()` is
+// the idiom. Release is itself idempotent.
+func (g *perOrgCommitGate) acquire(ctx context.Context, key string) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	g.mu.Lock()
+	if g.slots == nil {
+		g.slots = make(map[string]*commitGateSlot)
+	}
+	slot, ok := g.slots[key]
+	if !ok {
+		slot = &commitGateSlot{ch: make(chan struct{}, 1)}
+		g.slots[key] = slot
+	}
+	slot.waiters++
+	g.mu.Unlock()
+
+	select {
+	case slot.ch <- struct{}{}:
+		var once sync.Once
+		return func() {
+			once.Do(func() {
+				<-slot.ch
+				g.drop(key)
+			})
+		}, nil
+	case <-ctx.Done():
+		g.drop(key)
+		return nil, ctx.Err()
+	}
+}
+
+// drop decrements the slot's refcount and removes the map entry once nobody
+// holds or waits on it.
+func (g *perOrgCommitGate) drop(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	slot, ok := g.slots[key]
+	if !ok {
+		return
+	}
+	slot.waiters--
+	if slot.waiters <= 0 {
+		delete(g.slots, key)
+	}
+}

--- a/core/services/provisioning/handlers/perorg_commit_race_5387_test.go
+++ b/core/services/provisioning/handlers/perorg_commit_race_5387_test.go
@@ -1,0 +1,366 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
+	"github.com/openova-io/openova/core/services/provisioning/gitops"
+)
+
+// #5387 (hw290) — every funnel Organization that installed an app failed
+// provisioning, terminally, at "Deploying <app>":
+//
+//	git commit to per-Org repo failed: commit to per-Org repo walk-two/catalyst-tenant:
+//	POST …/repos/walk-two/catalyst-tenant/contents: 500
+//	{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}
+//
+// Two independent defects stacked into that one red step, and the tests below
+// pin one each:
+//
+//  1. THE WRITER RACED ITSELF. The tenant service dispatches a cart as ONE
+//     `/provisioning/apps/install` per cart entry, and ApplyAppInstall runs each
+//     in its own detached goroutine — every one of which re-renders the WHOLE
+//     cart and pushes it to the SAME `<slug>/catalyst-tenant@main` branch. N
+//     concurrent Gitea ChangeFiles batches, one branch head, at most one
+//     fast-forward. applyTenantChangePerOrg now holds a per-branch gate across
+//     the whole read-merge-commit cycle so the siblings queue instead of
+//     colliding.
+//
+//  2. THE RETRY NEVER ENGAGED. Gitea serves this branch-head CAS loss as a bare
+//     500 spelled `non-fast-forward`, which isGiteaRefRaceError did not match,
+//     so CommitFilesWithPruneAndRebuild treated it as fatal on attempt 1. See
+//     github/client_pushoutofdate_5387_test.go for the classifier-level proof;
+//     the second test here pins the handler-visible consequence — the funnel
+//     step no longer goes red on a single recoverable collision.
+
+// perOrgRaceFake is a fake per-Org Gitea that models the ChangeFiles commit
+// the way the real one behaves: the batch POST clones the branch head, applies,
+// and pushes — with a real window in between. Two overlapping POSTs therefore
+// produce a PushOutOfDate for the loser, exactly as on hw290.
+//
+// It also records the maximum number of commit CYCLES (first remote read →
+// batch POST) that were ever in flight at once, which is the direct measure of
+// whether the per-Org gate is doing its job.
+type perOrgRaceFake struct {
+	t *testing.T
+
+	mu sync.Mutex
+	// head advances on every accepted batch — the branch tip.
+	head int
+	// inFlight/maxInFlight track overlapping commit cycles.
+	inFlight    int
+	maxInFlight int
+	postCount   int
+	rejects     int
+	// commitWindow is how long the fake holds a batch between reading the
+	// head and pushing — the race window a concurrent writer can land in.
+	commitWindow time.Duration
+}
+
+// enterCycle/leaveCycle bracket one handler-side commit cycle. The cycle opens
+// on the branch-ref read (the first remote call applyTenantChangePerOrg makes
+// through the commit client) and closes when its batch POST is answered.
+func (f *perOrgRaceFake) enterCycle() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inFlight++
+	if f.inFlight > f.maxInFlight {
+		f.maxInFlight = f.inFlight
+	}
+}
+
+func (f *perOrgRaceFake) leaveCycle() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.inFlight > 0 {
+		f.inFlight--
+	}
+}
+
+func (f *perOrgRaceFake) handler() http.HandlerFunc {
+	// refSeen tracks which cycles have opened, so a retry's second ref read
+	// inside the same handler call doesn't double-count. Keyed by nothing
+	// fancy — we simply pair every ref read with the next POST from the same
+	// connection-agnostic sequence, which is sufficient because the client
+	// always does ref-read → … → POST.
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/plans"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"s","slug":"s"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"wordpress","slug":"wordpress"},{"id":"listmonk","slug":"listmonk"},{"id":"openclaw","slug":"openclaw"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			f.enterCycle()
+			f.mu.Lock()
+			head := f.head
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `[{"object":{"sha":"headsha-%032d"}}]`, head)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/trees/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tree":[],"truncated":false}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"name":"networkpolicy.yaml","type":"file"},{"name":"kustomization.yaml","type":"file"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps/kustomization.yaml"):
+			f.mu.Lock()
+			head := f.head
+			f.mu.Unlock()
+			content := base64.StdEncoding.EncodeToString([]byte(
+				"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - networkpolicy.yaml\n"))
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"sha":"kustsha-%d","content":"%s","encoding":"base64"}`, head, content)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			// Gitea's ChangeFiles: clone at `base`, apply, push. Anything that
+			// moved the head inside the window makes the push non-fast-forward.
+			f.mu.Lock()
+			f.postCount++
+			base := f.head
+			f.mu.Unlock()
+
+			time.Sleep(f.commitWindow)
+
+			f.mu.Lock()
+			moved := f.head != base
+			if !moved {
+				f.head++
+			} else {
+				f.rejects++
+			}
+			f.mu.Unlock()
+
+			f.leaveCycle()
+			w.Header().Set("Content-Type", "application/json")
+			if moved {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, `{"message":"PushOutOfDate Error: exit status 1: To /data/git/repositories/w5387/catalyst-tenant.git\n ! [rejected]        a480a0e7 -> main (non-fast-forward)\n"}`)
+				return
+			}
+			fmt.Fprintf(w, `{"commit":{"sha":"commitsha-%032d"}}`, base+1)
+		default:
+			f.t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func newPerOrgRaceHandler(t *testing.T, srvURL string) *Handler {
+	t.Helper()
+	gen := gitops.NewManifestGenerator("clusters/sov/org-tenants")
+	gen.ParentDomain = "omani.homes"
+	return &Handler{
+		Generator:    gen,
+		GitHubClient: ghclient.NewClientWithAPIURL("token", "openova", "openova", srvURL),
+		GitBranch:    "main",
+		PerOrgGitops: true,
+		CatalogURL:   srvURL,
+	}
+}
+
+// TestApplyTenantChangePerOrg_SerialisesConcurrentCartInstalls_5387 dispatches
+// a 3-app cart the way the funnel does — three concurrent installs for the SAME
+// Org — against a Gitea that rejects overlapping pushes exactly like the real
+// one.
+//
+// Without the per-Org gate the three commit cycles interleave on one branch
+// head (maxInFlight == 3) and the fake serves PushOutOfDate to the losers: the
+// hw290 failure, self-inflicted. With the gate they queue, so the branch never
+// sees more than one writer, no push is ever rejected, and all three installs
+// commit.
+func TestApplyTenantChangePerOrg_SerialisesConcurrentCartInstalls_5387(t *testing.T) {
+	fake := &perOrgRaceFake{t: t, commitWindow: 25 * time.Millisecond}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	h := newPerOrgRaceHandler(t, srv.URL)
+
+	cart := []string{"wordpress", "listmonk", "openclaw"}
+	errs := make([]error, len(cart))
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i, app := range cart {
+		wg.Add(1)
+		go func(i int, app string) {
+			defer wg.Done()
+			<-start // release all three at once — the funnel's fan-out
+			errs[i] = h.applyTenantChange(context.Background(), appChangeData{
+				TenantSlug: "w5387",
+				AppSlug:    app,
+				Apps:       cart,
+				PlanID:     "s",
+			}, "install")
+		}(i, app)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("cart app %q failed to commit: %v", cart[i], err)
+		}
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.maxInFlight != 1 {
+		t.Errorf("the per-Org branch saw %d concurrent commit cycles — the funnel's own cart installs are racing each other on one head (#5387); want 1",
+			fake.maxInFlight)
+	}
+	if fake.rejects != 0 {
+		t.Errorf("Gitea rejected %d push(es) as PushOutOfDate — serialised commits must never collide with each other (#5387)", fake.rejects)
+	}
+	if fake.postCount != len(cart) {
+		t.Errorf("expected exactly %d batch POSTs (one per cart install, no retries needed), got %d", len(cart), fake.postCount)
+	}
+	if fake.head != len(cart) {
+		t.Errorf("expected the branch head to advance once per install (%d), got %d", len(cart), fake.head)
+	}
+}
+
+// TestApplyTenantChangePerOrg_RecoversFromGiteaPushOutOfDate_5387 pins the
+// handler-visible half of the classifier fix: an out-of-process writer (the
+// org-controller, which no gate in this process can hold back) advances the
+// head under us once. On hw290 that single collision was terminal — the day-2
+// commit returned the raw 500 and "Deploying <app>" went red. It must now be
+// absorbed by the ref-race retry and the install must land.
+func TestApplyTenantChangePerOrg_RecoversFromGiteaPushOutOfDate_5387(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		postCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/plans"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"s","slug":"s"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"wordpress","slug":"wordpress"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"headsha-00000000000000000000000000000001"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/trees/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tree":[],"truncated":false}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/contents/vcluster/apps"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"name":"networkpolicy.yaml","type":"file"}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			first := postCount == 1
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			if first {
+				// The VERBATIM hw290 shape: 500 + PushOutOfDate.
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"commit":{"sha":"commitsha-0000000000000000000000000002"}}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	h := newPerOrgRaceHandler(t, srv.URL)
+	err := h.applyTenantChange(context.Background(), appChangeData{
+		TenantSlug: "w5387b",
+		AppSlug:    "wordpress",
+		Apps:       []string{"wordpress"},
+		PlanID:     "s",
+	}, "install")
+	if err != nil {
+		t.Fatalf("a single PushOutOfDate collision must be retried, not fail the install (#5387); got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != 2 {
+		t.Errorf("expected 2 batch POSTs (1 PushOutOfDate + 1 win), got %d", postCount)
+	}
+}
+
+// TestPushOutOfDateExhaustionIsTerminalNotParkable_5387 — a PushOutOfDate that
+// survives every CAS attempt must still be a TERMINAL failure that paints the
+// funnel red, not the parkable #4404 "per-Org Gitea repo not ready" race. The
+// 500 body must never be mistaken for the 404 shapes isGiteaNotReadyError
+// keys on, or a genuinely wedged branch would sit in the pending-install
+// registry for 30 minutes with no red step anywhere.
+func TestPushOutOfDateExhaustionIsTerminalNotParkable_5387(t *testing.T) {
+	exhausted := fmt.Errorf(`commit to per-Org repo walk-two/catalyst-tenant: commit: ref-race persisted after 10 attempts: update ref: GitHub API POST http://gitea-http.gitea.svc:3000/api/v1/repos/walk-two/catalyst-tenant/contents: 500 {"message":"PushOutOfDate Error … ! [rejected] a480a0e7… -> main (non-fast-forward)"}: not a fast forward (gitea contents API)`)
+	if isGiteaNotReadyError(exhausted) {
+		t.Fatalf("an exhausted PushOutOfDate ref-race must NOT be parkable as #4404 Gitea-not-ready — it would wait 30 minutes with no red step")
+	}
+}
+
+// TestPerOrgCommitGate_ReleasesAndIsCtxCancellable_5387 pins the gate's own
+// contract: mutual exclusion per key, independence across keys, a ctx-abortable
+// wait (so a tenant-deleted preempt never parks behind another Org), and no map
+// growth once every holder has released.
+func TestPerOrgCommitGate_ReleasesAndIsCtxCancellable_5387(t *testing.T) {
+	var g perOrgCommitGate
+	ctx := context.Background()
+
+	relA, err := g.acquire(ctx, "acme/catalyst-tenant@main")
+	if err != nil {
+		t.Fatalf("first acquire must succeed: %v", err)
+	}
+
+	// A DIFFERENT Org must not be blocked by acme's in-flight commit.
+	relB, err := g.acquire(ctx, "beta/catalyst-tenant@main")
+	if err != nil {
+		t.Fatalf("a different Org must not be gated behind acme: %v", err)
+	}
+	relB()
+
+	// The SAME Org must block — and must give up when its ctx is cancelled.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	blocked := make(chan error, 1)
+	go func() { _, aerr := g.acquire(cancelCtx, "acme/catalyst-tenant@main"); blocked <- aerr }()
+	select {
+	case aerr := <-blocked:
+		t.Fatalf("second acquire on the same key must block while the first holds it, returned %v", aerr)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case aerr := <-blocked:
+		if aerr == nil {
+			t.Errorf("a cancelled waiter must return ctx.Err(), not acquire the gate")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("a cancelled waiter must abort promptly instead of parking forever")
+	}
+
+	// Once released the key is re-acquirable, and the registry drains.
+	relA()
+	relA() // release is idempotent
+	relC, err := g.acquire(ctx, "acme/catalyst-tenant@main")
+	if err != nil {
+		t.Fatalf("gate must be re-acquirable after release: %v", err)
+	}
+	relC()
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.slots) != 0 {
+		t.Errorf("gate leaked %d slot(s) after every holder released: %v", len(g.slots), g.slots)
+	}
+}

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.151
+  version: 0.1.152
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2649,7 +2649,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.151
+version: 0.1.152
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -413,6 +413,15 @@ data:
               # Otherwise flag when the spec out-ran the controller
               # (observedGeneration < generation — the pin-bump case) OR Ready !=
               # True (mid-reconcile / failed upgrade).
+              # #5391: distinguish TERMINAL from mid-roll. Once Flux marks an HR
+              # Stalled=True (reason RetriesExceeded) it has stopped retrying
+              # PERMANENTLY — that release will never reach Ready on its own, so
+              # "wait for the roll to settle and re-trigger" is false advice: the
+              # operator would wait forever. Live hw290 (dep 31106b6aa4a7e8e7):
+              # 7 offenders, ALL per-Org customer apps, ALL Stalled/RetriesExceeded
+              # (delta-corp/bp-keycloak `context deadline exceeded` alone cascaded
+              # DependencyNotReady onto 4 siblings). Tag those rows so the operator
+              # can tell "wait 5 minutes" from "this blocks you until you act".
               hr_pending=$(kubectl get helmreleases -A -o json 2>/dev/null | jq -r '
                 .items[]
                 | select((.spec.suspend // false) | not)
@@ -420,7 +429,11 @@ data:
                     ((.status.observedGeneration // -1) < (.metadata.generation // 0))
                     or (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].status // "Unknown")) != "True")
                   )
-                | "HelmRelease/\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null || true)
+                | (((.status.conditions // []) | map(select(.type=="Stalled")) | (.[0].status // "False")) == "True") as $stalled
+                | (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].message // "")) | split("\n")[0]) as $why
+                | "HelmRelease/\(.metadata.namespace)/\(.metadata.name)"
+                  + (if $stalled then "  [TERMINAL: Flux stalled — it has STOPPED retrying and will never clear itself]" else "" end)
+                  + (if ($why | length) > 0 then "  (\($why))" else "" end)' 2>/dev/null || true)
               # Deployments + StatefulSets: a pending rollout — observedGeneration
               # behind the spec, or updated/ready replicas short of desired. Skip
               # intentionally scaled-to-zero (spec.replicas == 0). DaemonSets are
@@ -437,9 +450,20 @@ data:
                 | "\(.kind // "Workload")/\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null || true)
               unsettled=$(printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep -c . || true)
               if [ "${unsettled}" -gt 0 ]; then
-                echo "[harbor-prewarm] FATAL: env NOT settled — ${unsettled} release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired). Wait for these to settle (HelmRelease Ready=True + observedGeneration==generation; workloads updated==ready==desired replicas), then re-trigger the cutover:"
+                terminal=$(printf '%s\n' "${hr_pending}" | grep -c 'TERMINAL:' || true)
+                echo "[harbor-prewarm] FATAL: env NOT settled — ${unsettled} release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired):"
                 printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep . | sed 's/^/  mid-roll: /'
-                echo "[harbor-prewarm] (settled-roll pre-flight #4982; emergency override for a manually confirmed-settled env: prewarm.settledRollPreflight.enabled=false)"
+                if [ "${terminal}" -gt 0 ]; then
+                  # #5391 — do NOT tell the operator to wait when waiting cannot work.
+                  echo "[harbor-prewarm] ${terminal} of these are TERMINAL (Flux Stalled/RetriesExceeded). Waiting will NOT clear them — Flux has already given up retrying. Each one needs an explicit re-drive before the cutover can proceed:"
+                  echo "[harbor-prewarm]   flux reconcile helmrelease <name> -n <namespace> --reset     # clears Stalled and retries"
+                  echo "[harbor-prewarm]   (or remove the Organization if the release belongs to a customer app you no longer need)"
+                  echo "[harbor-prewarm] Fix the underlying failure first — the message in parentheses above is the Helm error that stalled it."
+                fi
+                if [ "${unsettled}" -gt "${terminal}" ]; then
+                  echo "[harbor-prewarm] The remainder are genuinely mid-roll — wait for them to settle (HelmRelease Ready=True + observedGeneration==generation; workloads updated==ready==desired replicas), then re-trigger the cutover."
+                fi
+                echo "[harbor-prewarm] (settled-roll pre-flight #4982/#5391; emergency override for a manually confirmed-settled env: prewarm.settledRollPreflight.enabled=false)"
                 exit 1
               fi
               echo "[harbor-prewarm] Phase A0: env settled — no HelmRelease/Deployment/StatefulSet mid-roll; building the mirror from running == desired tags"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3591,7 +3591,7 @@ name: bp-catalyst-platform
 #   bp-guacamole 0.2.30 -> 0.2.31 (TBD-A6 bot re-mint sync — 2nd occurrence
 #   after bp-newapi 1.4.144; bot lockstep gap tracked on #5370).
 #   (1.4.1217 was consumed by the TBD-A6 auto re-publish.)
-version: 1.4.1221
+version: 1.4.1222
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8
@@ -3734,7 +3734,7 @@ version: 1.4.1221
 #   unsatisfiable on kom4dc (me-east-215-*), which kept the production
 #   Continuum seed unfireable. Backwards-compatible (all-letter labels
 #   still match). Flux CreateReplace flows it to live Sovereigns.
-appVersion: 1.4.1197
+appVersion: 1.4.1222
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5052,7 +5052,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.151"
+  version: "0.1.152"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5069,7 +5069,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.151"
+    version: "0.1.152"
   topology:
     supported:
       - singleton

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -600,7 +600,7 @@ images:
   # (verified live on g8mail). 903eed4 is the image built from main AFTER
   # #4390 merged — it carries #4387 (per-Org <slug>/catalyst-tenant commit) for
   # the HR-app path too. Pin it so the cart HR apps land in the per-Org repo.
-  orgTag: "4a027b3"
+  orgTag: "05b9a23"
   # Marketplace storefront image tag (the `marketplace` frontend, distinct from
   # the `marketplaceApi` backend). Bumped by .github/workflows/marketplace-build.yaml
   # on every push to core/marketplace/**. Kept as a flat, uniquely-named field


### PR DESCRIPTION
## What

The #4982 settled-roll pre-flight refuses to build the Harbor mirror while any non-suspended HelmRelease is not Ready. **That gate is correct and unchanged here** — it prevents mirroring running tags the cutover then rolls away from.

What it could not do is distinguish an offender that will clear itself from one that never will. Once Flux marks an HR `Stalled=True` (reason `RetriesExceeded`) it has stopped retrying permanently. The gate printed the same advice for both — *"Wait for these to settle … then re-trigger the cutover"* — which for a stalled release is guidance that can never come true. An operator following it waits indefinitely while the Sovereign's cutover stays unreachable.

## Change

- Each offender line now carries its Flux state and the first line of its Helm error.
- The remedy text splits by kind: terminal releases get the explicit re-drive command (`flux reconcile helmrelease … --reset`), genuinely mid-roll ones keep the wait-and-retry guidance. Neither line prints when its count is zero.
- No change to what the gate accepts or rejects — the predicate is byte-identical apart from the two added computed fields. This is strictly a diagnostics change.

## Validation — against a live cluster, not a fixture

The jq and the counting arithmetic were run against live hw290 (dep `31106b6aa4a7e8e7`), which is currently sitting in exactly this state:

```
HelmRelease/delta-corp/bp-keycloak  [TERMINAL: Flux stalled — it has STOPPED retrying and will never clear itself]  (Helm upgrade failed … bp-keycloak@1.5.6: context deadline exceeded)
HelmRelease/delta-corp/bp-newapi  (dependency 'delta-corp/bp-keycloak' is not ready)
HelmRelease/delta-corp/bp-openclaw  (dependency 'delta-corp/bp-keycloak' is not ready)
HelmRelease/delta-corp/bp-stalwart-tenant  (dependency 'delta-corp/bp-keycloak' is not ready)
HelmRelease/delta-corp/bp-wordpress-tenant  (dependency 'delta-corp/bp-keycloak' is not ready)
HelmRelease/gamma-corp/bp-openclaw  [TERMINAL: …]  (Helm upgrade failed … bp-openclaw@0.2.17: context deadline exceeded)
HelmRelease/gamma-corp/bp-wordpress-tenant  [TERMINAL: …]  (… post-upgrade hooks failed)
```

The value is visible immediately: three releases are genuinely stuck, and four others are merely downstream of one of them. Fixing `bp-keycloak` clears four. The old output was seven undifferentiated names and an instruction to wait.

Branch selection proven on that same live data: `unsettled=8 terminal=3` → prints the terminal remedy for 3 and the wait guidance for the remaining 5.

## Gates

- `helm template` renders (11,144 lines); the rendered 97KB `harbor-prewarm` script extracted from the `cutover-step-03-harbor-prewarm` ConfigMap `podSpec` passes `bash -n`.
- `scripts/check-bootstrap-kit-pin-sync.sh` — 67 pairs PASS.
- `scripts/check-catalog-seed-lockstep.sh` — 68 checked, 0 fail.
- `scripts/check-no-nodeports.sh` — clean (chart touched, so §854 re-verified).
- Chart `0.1.151 → 0.1.152` with the slot-06a pin moved in lockstep.

## What this does not do

It does not give a stalled release a recovery path from the browser, and it does not decide whether a per-Org customer app should gate the platform cutover at all. Both are open questions on #5391; this lands the part that is unambiguously an improvement regardless of how those are answered.

Refs #5391 #4982 #3379
