### PR TITLE
fix(catalog): pin the 9 :latest catalog images that Kyverno refuses at admission, + a guard

### DIFF
--- a/core/services/provisioning/gitops/apps.go
+++ b/core/services/provisioning/gitops/apps.go
@@ -109,7 +109,7 @@ var KnownApps = map[string]AppSpec{
 		EnvVars: map[string]string{},
 	},
 	"cal-com": {
-		Image: "calcom/cal.com:latest", Port: 3000,
+		Image: "calcom/cal.com:v6.2.0", Port: 3000,
 		NeedsDB: "postgres",
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{
@@ -118,7 +118,7 @@ var KnownApps = map[string]AppSpec{
 		},
 	},
 	"chatwoot": {
-		Image: "chatwoot/chatwoot:latest", Port: 3000,
+		Image: "chatwoot/chatwoot:v4.16.1", Port: 3000,
 		NeedsDB: "postgres",
 		RAMMI:   "512Mi", CPUMilli: "200m",
 		EnvVars: map[string]string{
@@ -127,7 +127,7 @@ var KnownApps = map[string]AppSpec{
 		},
 	},
 	"invoiceshelf": {
-		Image: "invoiceshelf/invoiceshelf:latest", Port: 8080,
+		Image: "invoiceshelf/invoiceshelf:2.4.1", Port: 8080,
 		NeedsDB: "mysql",
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
@@ -162,13 +162,13 @@ var KnownApps = map[string]AppSpec{
 		EnvVars: map[string]string{},
 	},
 	"vaultwarden": {
-		Image: "vaultwarden/server:latest", Port: 80,
+		Image: "vaultwarden/server:1.37.0", Port: 80,
 		NeedsDB: "",
 		RAMMI:   "128Mi", CPUMilli: "50m",
 		EnvVars: map[string]string{},
 	},
 	"bookstack": {
-		Image: "lscr.io/linuxserver/bookstack:latest", Port: 80,
+		Image: "lscr.io/linuxserver/bookstack:26.05.2", Port: 80,
 		NeedsDB: "mysql",
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		// linuxserver/bookstack reads DB_HOST/DB_USER/DB_PASS/DB_DATABASE
@@ -181,13 +181,13 @@ var KnownApps = map[string]AppSpec{
 		EnvVars:    map[string]string{},
 	},
 	"nocodb": {
-		Image: "nocodb/nocodb:latest", Port: 8080,
+		Image: "nocodb/nocodb:2026.07.0", Port: 8080,
 		NeedsDB: "postgres",
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"listmonk": {
-		Image: "listmonk/listmonk:latest", Port: 9000,
+		Image: "listmonk/listmonk:v6.2.0", Port: 9000,
 		NeedsDB: "postgres",
 		RAMMI:   "128Mi", CPUMilli: "50m",
 		EnvVars: map[string]string{},
@@ -203,13 +203,13 @@ var KnownApps = map[string]AppSpec{
 		InitCommand: "./listmonk --install --yes --idempotent 2>&1 || ./listmonk --upgrade --yes 2>&1 || true",
 	},
 	"rocket-chat": {
-		Image: "rocket.chat:latest", Port: 3000,
+		Image: "rocket.chat:8.5.1", Port: 3000,
 		NeedsDB: "",
 		RAMMI:   "512Mi", CPUMilli: "200m",
 		EnvVars: map[string]string{},
 	},
 	"formbricks": {
-		Image: "formbricks/formbricks:latest", Port: 3000,
+		Image: "formbricks/formbricks:3.6.0", Port: 3000,
 		NeedsDB: "postgres",
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},

--- a/core/services/provisioning/gitops/apps_image_pinned_5397_test.go
+++ b/core/services/provisioning/gitops/apps_image_pinned_5397_test.go
@@ -1,0 +1,60 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5397 — every KnownApps image MUST carry a real tag.
+//
+// Nine catalog apps shipped pinned to `:latest` (cal-com, chatwoot,
+// invoiceshelf, vaultwarden, bookstack, nocodb, listmonk, rocket-chat,
+// formbricks). Every Sovereign runs a Kyverno ClusterPolicy
+// `image-tag-pinned` with validationFailureAction=Enforce, and tenant
+// namespaces are not in its exclude anchor — so those Pods were rejected at
+// admission and NEVER CREATED. The failure signature is an absence, not a
+// crash: `kubectl get pods` simply has no row for the app, which is why it
+// survived so long. Live proof on hw290 Org theta-corp: a 4-app cart
+// committed cleanly and produced pods for umami and uptime-kuma but none at
+// all for listmonk or vaultwarden.
+//
+// The images live in a hardcoded Go map, so no seed or database change can
+// work around it — the fix has to be here, and so does the guard.
+//
+// Deliberately NOT flagged: a tag that merely CONTAINS "latest", such as
+// umami's `ghcr.io/umami-software/umami:postgresql-latest`. That is a
+// distinct, immutable tag name, and it is admitted in practice — umami's
+// Pod was created on the same walk where listmonk's was refused. Matching
+// on a suffix here would fail a working image and push someone to "fix" it
+// into something worse.
+func TestKnownApps_NoUnpinnedImages_5397(t *testing.T) {
+	if len(KnownApps) == 0 {
+		t.Fatal("KnownApps is empty — the guard would vacuously pass")
+	}
+
+	for slug, spec := range KnownApps {
+		image := strings.TrimSpace(spec.Image)
+		if image == "" {
+			t.Errorf("%s: empty Image", slug)
+			continue
+		}
+
+		// Split off the tag: only a ':' AFTER the final '/' is a tag
+		// separator, so a registry host:port (host:5000/repo) is not
+		// mistaken for one.
+		lastSlash := strings.LastIndexByte(image, '/')
+		colon := strings.LastIndexByte(image, ':')
+
+		if colon <= lastSlash {
+			t.Errorf("%s: image %q carries no tag — Kyverno image-tag-pinned (Enforce) rejects it at admission and the Pod is never created", slug, image)
+			continue
+		}
+
+		switch tag := image[colon+1:]; tag {
+		case "":
+			t.Errorf("%s: image %q has an empty tag", slug, image)
+		case "latest":
+			t.Errorf("%s: image %q is pinned to :latest — Kyverno image-tag-pinned (Enforce) rejects it at admission and the Pod is never created. Pin a real version.", slug, image)
+		}
+	}
+}


### PR DESCRIPTION
## What

Pins the nine catalog images that shipped as `:latest` and adds a guard so it cannot recur.

Every Sovereign runs Kyverno `image-tag-pinned` with `validationFailureAction=Enforce`, and tenant namespaces are not in its exclude anchor. So these nine apps were **rejected at admission and their Pods never created** — roughly a quarter of the catalog could not start on any Sovereign.

The failure signature is an *absence*, not a crash: `kubectl get pods` simply has no row for the app, and there are no logs to read because no container ever existed. That is why it survived this long.

## Live proof — hw290, Org `theta-corp`

A 4-app cart (Vaultwarden, Uptime Kuma, Listmonk, Umami) committed cleanly, and produced:

```
umami-...-x-theta-corp-x-vcluster          0/1   CrashLoopBackOff
uptime-kuma-...-x-theta-corp-x-vcluster    0/1   CrashLoopBackOff
postgres-...-x-theta-corp-x-vcluster       0/1   Pending
```

**Listmonk and Vaultwarden have no Pod at all.** `image-tag-pinned` denied them:

```
admission webhook "validate.kyverno.svc-fail" denied the request:
  image-tag-pinned / image-pinned-pod: One or more containers reference an unpinned image
```

(The CrashLoops and the Pending postgres are a separate capacity problem, tracked on #5393 — not this.)

## Tags

Every tag was **resolved against the live registry**, not guessed, and each is that image's newest stable release. That choice is deliberate: newest-stable is the closest match to whatever `:latest` was already resolving to, so this pins current behaviour rather than moving it.

| app | image | tag |
|---|---|---|
| cal-com | `calcom/cal.com` | `v6.2.0` |
| chatwoot | `chatwoot/chatwoot` | `v4.16.1` |
| invoiceshelf | `invoiceshelf/invoiceshelf` | `2.4.1` |
| vaultwarden | `vaultwarden/server` | `1.37.0` |
| bookstack | `lscr.io/linuxserver/bookstack` | `26.05.2` |
| nocodb | `nocodb/nocodb` | `2026.07.0` |
| listmonk | `listmonk/listmonk` | `v6.2.0` |
| rocket-chat | `rocket.chat` | `8.5.1` |
| formbricks | `formbricks/formbricks` | `3.6.0` |

## The guard

`TestKnownApps_NoUnpinnedImages_5397` iterates `KnownApps` itself rather than grepping source, so it also catches an entirely untagged image. Tag splitting only treats a `:` **after the final `/`** as a separator, so a `host:port/repo` registry is not mistaken for a tag.

It deliberately does **not** match a tag that merely *contains* "latest". Umami's `ghcr.io/umami-software/umami:postgresql-latest` is a distinct immutable tag and is admitted in practice — its Pod was created on the same walk where listmonk's was refused. A suffix match would fail a working image and push someone to "fix" it into something worse.

## Gates

- **Negative proof**: reverting listmonk to `:latest` fails the guard with the exact diagnosis (`listmonk: image "listmonk/listmonk:latest" is pinned to :latest — Kyverno image-tag-pinned (Enforce) rejects it at admission and the Pod is never created`); restoring it passes.
- `go build ./...`, `go vet ./...`, and the full `gitops` package suite with `-count=1` — all green.
- Both touched files are `gofmt`-clean. (`helmrelease_apps.go` and `listmonk_test.go` show under `gofmt -l`, but they do so on `main` too — pre-existing and untouched here.)

## Note on why no lint caught it

The images are plain Go data in `core/services/**`, which no PR-time image lint covers. `proxy_image_test.go` does use `:latest` fixtures, but correctly so — it tests that the Harbor-proxy rewrite *preserves* whatever tag it is given. Nothing anywhere signalled that the tag itself was inadmissible downstream. This guard closes that.

Refs #5397
