### PR TITLE
fix(mcp): arm multiRegion on slot 13d — the #5341 secondary-edge fix has been inert since it merged

### DIFF
--- a/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
+++ b/clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml
@@ -152,6 +152,33 @@ spec:
     global:
       imageRegistry: ''
     sovereignFqdn: ${SOVEREIGN_FQDN}
+    # #5394 — ARM the #5341 secondary-edge path. The chart has shipped
+    # `multiRegion.enabled` since #5341/PR#5342, and its own values.yaml
+    # comment says "The bootstrap-kit slot sets this true on multi-region
+    # provs (mirrors how bp-catalyst-platform annotates catalyst-api/
+    # catalyst-ui, #5289)" — but this slot never set it, so the fix has
+    # been INERT on every 2-region prov since it landed.
+    #
+    # Live hw290 (dep 31106b6aa4a7e8e7): region-b's bp-catalyst-secondary-edge
+    # is installed and Ready, waiting to proxy mcp.<fqdn> to region-a — but
+    # the region-a Service carries an EMPTY service.cilium.io/global
+    # annotation, so there is nothing for it to reach. Result: `mcp` is the
+    # ONLY *.<fqdn> hostname asymmetric across regions (4 CEC vhosts in
+    # region-a, 0 in region-b, against 4-7/4-7 for every symmetric
+    # hostname), and ~50% of requests hit region-b's envoy and get a bare
+    # 404 with no x-envoy-upstream-service-time — envoy never forwarded
+    # them. On a region-A kill the MCP would be 100% dead, not degraded.
+    #
+    # openova-mcp is primary-only BY DESIGN (#5114 defect 2 — it dependsOn
+    # bp-catalyst-platform, which is SECONDARY_HR_SUSPEND on every
+    # secondary CP), so installing it in region-b is NOT the fix and would
+    # recreate the hw256 permanently-False HR fan-out. Publishing the
+    # region-a Service to ClusterMesh is.
+    #
+    # Same source var as slot 13 uses for the identical #5289 problem, so
+    # single-region provs render byte-identically to today.
+    multiRegion:
+      enabled: ${SOVEREIGN_ENABLE_HOT_STANDBY:-false}
     # The sovereign-mode topology pin (#3988 §4.3): full surface for
     # sovereign-admin bearers, in-cluster catalyst-api upstream (derived
     # by the chart), HTTPRoute mcp.${SOVEREIGN_FQDN} on the canonical


### PR DESCRIPTION
## What

Two lines on bootstrap-kit slot 13d. The interesting part is why they were missing.

`bp-openova-mcp` has shipped `multiRegion.enabled` since **#5341 / PR #5342**, and the chart's own `values.yaml` says:

> The bootstrap-kit slot sets this true on multi-region provs (mirrors how bp-catalyst-platform annotates catalyst-api/catalyst-ui, #5289).

The slot never set it. So the fix has been present in the chart and **doing nothing on every 2-region prov since it merged** — shipped but never armed.

## Live evidence — hw290, dep `31106b6aa4a7e8e7`

Everything on the receiving side is already in place and idle:

```
region-b  flux-system/bp-catalyst-secondary-edge   Ready=True
          (catalyst-secondary-edge.v1, bp-catalyst-edge-routes@0.2.0)

region-a  svc/openova-mcp-bp-openova-mcp
          service.cilium.io/global = <empty>
```

The region-b stub is installed and waiting to proxy `mcp.<fqdn>` to region-a, but the region-a Service was never published to ClusterMesh, so there is nothing for it to reach.

The consequence is visible in the per-region CEC vhost counts. `mcp` is the **only** `*.hw290.omani.works` hostname asymmetric across regions, and the only one that 404s:

| hostname | region-a | region-b | 404 rate |
|---|---|---|---|
| **mcp** | 4 | **0** | **~50%** |
| gitea / guacamole / newapi / registry | 4–7 | 4–7 | 0 / ~100 requests |
| harbor | 2 | 2 | 0% |

The 404s are envoy-generated — `server: envoy`, `content-length: 0`, and critically **no `x-envoy-upstream-service-time`**, which every 200 carries. Envoy never forwarded them. Roughly half of requests land on region-b's envoy, which has no `mcp` vhost.

**DR consequence:** on a region-A kill the MCP goes 100% dead rather than degraded — a Pillar-4 surface vanishing in exactly the scenario Pillar-3 exists to survive.

## Why not just install it in region-b

That was my first instinct and it is wrong — it would be a regression. `clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml:69-81` makes this primary-only deliberately (#5114 defect 2): the HR `dependsOn: bp-catalyst-platform`, which is `SECONDARY_HR_SUSPEND` on every secondary control plane. Un-suspending would leave it permanently at `dependency 'flux-system/bp-catalyst-platform' is not ready` — precisely the hw256 permanently-False HR fan-out that suspension was introduced to fix.

Publishing the region-a Service to ClusterMesh is the intended path, and the chart already implements it (`products/openova-mcp/chart/templates/service.yaml:12`).

## Safety

Sourced from `SOVEREIGN_ENABLE_HOT_STANDBY` — the same variable slot 13 uses for the identical #5289 problem. On a single-region prov it renders `false` and the Service annotations are byte-identical to today.

No chart change, so no `Chart.yaml` bump and no pin movement. `check-bootstrap-kit-pin-sync.sh` passes 67/67 and the `tests/e2e/bootstrap-kit` drift-guards are green.

## Still owed

Runtime proof on a 2-region prov: the region-a Service carrying `service.cilium.io/global`, a non-zero `mcp` vhost count in region-b, and a sustained 0% 404 rate over ~100 requests. hw290 was provisioned before this lands, so it needs a fresh prov or a targeted HR values patch to demonstrate.

Worth a follow-up sweep: `bp-catalyst-platform`, `bp-self-sovereign-cutover` and `bp-continuum` are the other primary-only slots. A per-region vhost diff would show whether any of them publishes on the shared VIP with the same asymmetry.

Refs #5394 #5341 #5114
