### PR TITLE
fix(console): per-row Re-run on a FAILED cutover-step row (UAT 165)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
@@ -159,6 +159,17 @@ func (h *Handler) RetryJob(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	action, rerr := h.dispatchRetry(r.Context(), dyn, job, now)
 	if rerr != nil {
+		// #3379: a cutover-step Re-run that arrives while the engine already
+		// holds its single-run flag is a CONFLICT, not a fault — the same
+		// answer HandleCutoverStart gives a concurrent /start. Spawning a
+		// second engine goroutine would race the first over the step Jobs.
+		if errors.Is(rerr, errCutoverRunInFlight) {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error":  "cutover-in-progress",
+				"detail": rerr.Error(),
+			})
+			return
+		}
 		// #4845: a leaf with no directly-retryable backing (aggregate
 		// trivy-operator scan, mutation-bridge, unsupported kind) is a
 		// client-side condition, not a server fault — return a graceful 422
@@ -254,6 +265,13 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 			return "", err
 		}
 		return "created one-off Job " + runName + " from CronJob " + name, nil
+
+	case jobs.KindStep:
+		// One step of a projected activity ("cutover-step-<slug>"). Re-drives
+		// the cutover engine in operator-retry mode so the failed step's
+		// stale Job is deleted + re-run and the chain resumes — see
+		// jobs_retry_cutover_step.go (issue #3379, UAT row 165).
+		return h.retryActivityStep(ctx, job, now)
 
 	case jobs.KindMutation:
 		// Crossplane XRC re-submit — bump the catalyst reconcile annotation

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry_cutover_step.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry_cutover_step.go
@@ -1,0 +1,145 @@
+// jobs_retry_cutover_step.go — the KindStep leg of the ONE generic
+// remediation endpoint (jobs_retry.go): the operator console's per-row
+// **Re-run** control on a FAILED `cutover-step-*` row of the /jobs board.
+//
+// # Why this leg was missing (issue #3379, UAT row 165)
+//
+// The self-sovereign cutover engine already had the correct re-drive
+// capability: `runCutover(..., operatorRetry=true)` DELETES a step whose
+// prior Job failed genuinely (BackoffLimitExceeded etc.) and RE-RUNS it,
+// rather than re-surfacing it as a terminal wedge (cutover.go:1405-1412).
+// The auto-resume + in-cluster auto-trigger deliberately pass false so a
+// broken step never auto-loops — the operator CTA is the intended escape
+// hatch.
+//
+// The console side was the gap. `cutover_activity_bridge.go` projects each
+// of the 11 steps into the jobs store as a leaf with `Kind = jobs.KindStep`
+// and JobName `cutover-step-<slug>`, and JobsTable already renders the
+// generic Retry control on any `failed` row — but `dispatchRetry` had no
+// `KindStep` case, so the control fell through to `default:` and every
+// click on a failed cutover step answered
+//
+//	422 kind "step" does not support retry
+//
+// i.e. a button the operator could see but that could never work. The only
+// real recovery was a hand-crafted `POST /api/v1/sovereign/cutover/start`.
+//
+// # What this leg does
+//
+// Reuses the existing engine rather than inventing a second cutover write
+// path: it discovers the step ConfigMaps, verifies the clicked row's slug
+// is one of them, then spawns the SAME `runCutover(..., operatorRetry=true)`
+// goroutine `HandleCutoverStart` spawns. Already-succeeded steps are skipped
+// from the durable per-step status (cutover.go's skip-success basis), so the
+// engine resumes exactly at the failed step, deletes its stale Job, re-runs
+// it, and carries the chain onward. Because the chain is sequential and
+// halts at its first failure, at most ONE step is `failed` at a time — so
+// "re-run this row" and "resume the chain" are the same operation.
+//
+// Every guarantee of the generic endpoint still applies: owner-checked
+// (404 cross-tenant), operator-tier RBAC (403 otherwise), session-gated by
+// the RequireSession group the route is registered in, and the attempt is
+// recorded as a new Execution carrying the operator's identity.
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// errCutoverRunInFlight marks a Re-run request that arrived while a cutover
+// run already holds the engine's single-run flag. Spawning a second engine
+// goroutine would race the first over the same step Jobs + status ConfigMap,
+// so the honest answer is 409 "already running" — the same answer
+// HandleCutoverStart gives for a concurrent /start.
+var errCutoverRunInFlight = errors.New("a cutover run is already in flight on this catalyst-api Pod")
+
+// cutoverStepSlugFromJobName extracts the cutover step slug from an activity
+// step leaf's JobName, or "" when the leaf is not a CUTOVER step.
+//
+// The projected leaf name is `ActivityStepJobName(GroupCutover, slug)` ==
+// "cutover-step-<slug>" (jobs/activity_bridge.go). Other activity groups
+// (a future DR switchover) mint "<group>-step-<slug>" under their own slug
+// and are deliberately NOT matched here — they need their own engine leg.
+func cutoverStepSlugFromJobName(jobName string) string {
+	prefix := jobs.ActivityStepJobName(jobs.GroupCutover, "")
+	if !strings.HasPrefix(jobName, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(jobName, prefix))
+}
+
+// retryActivityStep re-drives a FAILED projected activity step. Today the
+// only activity projecting steps is the self-sovereign cutover; any other
+// group returns errNotDirectlyRetryable so the operator gets an honest 422
+// instead of a silent no-op.
+func (h *Handler) retryActivityStep(ctx context.Context, job jobs.Job, _ time.Time) (string, error) {
+	slug := cutoverStepSlugFromJobName(job.JobName)
+	if slug == "" {
+		return "", fmt.Errorf(
+			"step leaf %q belongs to an activity with no re-run engine: %w",
+			job.JobName, errNotDirectlyRetryable,
+		)
+	}
+	return h.retryCutoverStep(ctx, slug)
+}
+
+// retryCutoverStep spawns the cutover engine in operator-retry mode so the
+// named step's stale failed Job is deleted + re-run and the chain resumes.
+// Returns a short human description of the action for the audit LogLine.
+func (h *Handler) retryCutoverStep(ctx context.Context, slug string) (string, error) {
+	deps, err := h.cutoverDepsFor()
+	if err != nil {
+		return "", fmt.Errorf("cutover engine unconfigured on this catalyst-api: %w", err)
+	}
+
+	steps, err := listCutoverSteps(ctx, deps)
+	if err != nil {
+		return "", fmt.Errorf("cutover step discovery failed: %w", err)
+	}
+	if len(steps) == 0 {
+		return "", fmt.Errorf(
+			"no cutover-step ConfigMaps found in namespace %q — bp-self-sovereign-cutover not installed?: %w",
+			deps.ns, errNotDirectlyRetryable,
+		)
+	}
+
+	known := false
+	for _, s := range steps {
+		if s.stepName == slug {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return "", fmt.Errorf(
+			"cutover step %q is not among the %d steps installed on this Sovereign: %w",
+			slug, len(steps), errNotDirectlyRetryable,
+		)
+	}
+
+	// Single-run flag — the same guard HandleCutoverStart uses. Released by
+	// runCutover's `defer bus.endRun()`.
+	bus := h.cutoverBusFor()
+	if !bus.tryStartRun() {
+		return "", errCutoverRunInFlight
+	}
+
+	// context.Background() (not the request context): a multi-step cutover
+	// must not be cancelled when the operator's browser closes the POST.
+	// Each step is bounded by cutoverStepTimeout.
+	//
+	// operatorRetry=true — this IS the deliberate human CTA #3379 describes,
+	// reached through the session-gated + operator-RBAC-gated retry route.
+	go h.runCutover(context.Background(), deps, steps, true)
+
+	return fmt.Sprintf(
+		"re-ran cutover step %q (operator retry: prior failed Job deleted + re-run, chain resumed)",
+		slug,
+	), nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry_cutover_step_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry_cutover_step_test.go
@@ -1,0 +1,270 @@
+// jobs_retry_cutover_step_test.go — coverage for the KindStep leg of the
+// generic remediation endpoint: the per-row **Re-run** control on a FAILED
+// `cutover-step-*` row of the operator console's /jobs board (UAT row 165,
+// issue #3379).
+//
+// Gates:
+//
+//  1. A FAILED cutover-step leaf re-drives the engine with
+//     operatorRetry=true — the prior failed Job is deleted + re-run, and
+//     the durable status ConfigMap reflects the fresh run.
+//  2. A SUCCEEDED / RUNNING / PENDING cutover-step leaf is rejected 409
+//     (nothing to re-run) — the "gated to Failed" half of row 165.
+//  3. A viewer-tier session gets 403 (the control is operator-gated).
+//  4. A second Re-run while a run is already in flight gets 409 rather
+//     than spawning a colliding engine goroutine.
+//  5. A step leaf whose slug is not among the discovered step ConfigMaps
+//     gets a graceful 422, never a raw 502.
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// cutoverStepRetryHarness wires a Handler that has BOTH a jobs Store (so a
+// `cutover-step-*` leaf can be seeded + retried) and a cutover deps factory
+// bound to a fake clientset pre-seeded with the step ConfigMaps — the two
+// halves the KindStep retry leg needs.
+func cutoverStepRetryHarness(
+	t *testing.T, ownerEmail, jobName, status string, objs ...k8sruntime.Object,
+) (*chi.Mux, *Handler, *fakek8s.Clientset, string) {
+	t.Helper()
+
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	h := NewWithJobsStore(silentLogger(), js)
+
+	// RetryJob builds a dynamic client before dispatching; the KindStep leg
+	// never uses it, but the handler must not 502 on the way in.
+	factory, _ := fakeReconcilerDynamicFactory()
+	h.dynamicFactory = factory
+
+	client := fakek8s.NewSimpleClientset(objs...)
+	h.SetCutoverDepsFactory(func() (*cutoverDeps, error) {
+		return &cutoverDeps{core: client, ns: cutoverTestNS}, nil
+	})
+
+	depID := "dep-cutover-retry"
+	kubePath := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(kubePath, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	h.deployments.Store(depID, &Deployment{
+		ID:         depID,
+		OwnerEmail: ownerEmail,
+		Request:    provisioner.Request{SovereignFQDN: "t99.omani.works"},
+		Result:     &provisioner.Result{KubeconfigPath: kubePath},
+	})
+
+	if err := js.UpsertJob(jobs.Job{
+		DeploymentID: depID,
+		JobName:      jobName,
+		Type:         jobs.JobTypeInstall,
+		Kind:         jobs.KindStep,
+		Status:       status,
+	}); err != nil {
+		t.Fatalf("seed cutover step leaf: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Post("/api/v1/deployments/{depId}/jobs/{jobId}/retry", h.RetryJob)
+	return r, h, client, depID
+}
+
+// staleFailedCutoverJob builds a prior GENUINELY-failed
+// (BackoffLimitExceeded, i.e. non-transient) Job for a step — exactly the
+// object `jobFailedTransiently` refuses to auto-retry and that only the
+// operator CTA is allowed to delete + re-run.
+//
+// It is pre-seeded into the fake clientset's tracker (passed via objs)
+// rather than Created through the client: installJobReactor auto-completes
+// every CREATED Job, which would overwrite the Failed condition.
+func staleFailedCutoverJob(name, stepName string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cutoverTestNS,
+			Labels:    map[string]string{cutoverStepLabelKey: stepName},
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type:   batchv1.JobFailed,
+			Status: corev1.ConditionTrue,
+			Reason: "BackoffLimitExceeded",
+		}}},
+	}
+}
+
+// Row 165, positive direction: the operator's Re-run on a FAILED
+// cutover-step row re-drives the engine with operatorRetry=true — the
+// step's stale non-transient failed Job is DELETED + re-run and the chain
+// resumes through the remaining steps.
+func TestRetryJob_CutoverStep_Failed_RedrivesEngine(t *testing.T) {
+	const staleJobName = "cutover-gitea-mirror-1"
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-harbor-projects", "harbor-projects", 2, cutoverModeJob, minimalPodSpecYAML, ""),
+		staleFailedCutoverJob(staleJobName, "gitea-mirror"),
+	}
+	jobName := jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror")
+	r, h, client, depID := cutoverStepRetryHarness(t, "owner@t99.omani.works", jobName, jobs.StatusFailed, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, jobName,
+		&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 for a failed cutover-step re-run, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	waitCutoverIdle(t, h)
+
+	// The stale non-transient failed Job was DELETED — the operatorRetry=true
+	// semantic the control exists to reach. Without it the engine re-surfaces
+	// that Job as a terminal wedge and the step never re-executes.
+	if _, err := client.BatchV1().Jobs(cutoverTestNS).Get(
+		context.Background(), staleJobName, metav1.GetOptions{},
+	); err == nil {
+		t.Error("stale failed Job still present — the re-run did not delete + re-run the step")
+	}
+
+	// …and a FRESH Job for the step was created in its place.
+	jl, err := client.BatchV1().Jobs(cutoverTestNS).List(context.Background(), metav1.ListOptions{
+		LabelSelector: cutoverStepLabelKey + "=gitea-mirror",
+	})
+	if err != nil {
+		t.Fatalf("list step Jobs: %v", err)
+	}
+	if len(jl.Items) == 0 {
+		t.Error("no fresh Job created for the re-run step")
+	}
+
+	deps, _ := h.cutoverDepsFor()
+	status, err := readCutoverStatus(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("readCutoverStatus: %v", err)
+	}
+	if got := status["step.gitea-mirror.result"]; got != "success" {
+		t.Errorf("step.gitea-mirror.result = %q, want success (the re-run drove it green); status=%v",
+			got, status)
+	}
+	// The chain resumed past the re-run step rather than stopping at it.
+	if got := status["step.harbor-projects.result"]; got != "success" {
+		t.Errorf("step.harbor-projects.result = %q, want success (chain resumed); status=%v", got, status)
+	}
+
+	// The retry is auditable — a new Execution with the operator identity.
+	_, execs, err := h.jobs.GetJob(depID, jobs.JobID(depID, jobName))
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if len(execs) == 0 {
+		t.Fatal("no Execution recorded for the cutover-step re-run")
+	}
+}
+
+// Row 165, negative direction: the control is gated to Failed. A
+// succeeded / running / pending step is rejected 409 by the backend so a
+// UI that ever rendered the control on those rows cannot silently mutate
+// a healthy cutover.
+func TestRetryJob_CutoverStep_NonFailedStatuses_409(t *testing.T) {
+	for _, status := range []string{jobs.StatusSucceeded, jobs.StatusRunning, jobs.StatusPending} {
+		t.Run(status, func(t *testing.T) {
+			objs := []k8sruntime.Object{
+				makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+			}
+			jobName := jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror")
+			r, _, _, depID := cutoverStepRetryHarness(t, "owner@t99.omani.works", jobName, status, objs...)
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, retryReq(depID, jobName,
+				&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("status %q: want 409 (not retryable), got %d; body=%s",
+					status, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// The control is operator-gated — a viewer session cannot re-drive a
+// cutover step on a customer cluster.
+func TestRetryJob_CutoverStep_Viewer_403(t *testing.T) {
+	t.Setenv("OPERATOR_EMAIL", "")
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+	}
+	jobName := jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror")
+	r, _, _, depID := cutoverStepRetryHarness(t, "" /* legacy: no owner */, jobName, jobs.StatusFailed, objs...)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, jobName,
+		&auth.Claims{Email: "viewer@t99.omani.works", Tier: "viewer"}))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403 for viewer, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A Re-run fired while the engine is already mid-run is rejected 409
+// rather than spawning a second colliding engine goroutine.
+func TestRetryJob_CutoverStep_RunInFlight_409(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+	}
+	jobName := jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror")
+	r, h, _, depID := cutoverStepRetryHarness(t, "owner@t99.omani.works", jobName, jobs.StatusFailed, objs...)
+
+	// Claim the run flag as an in-flight cutover would.
+	if !h.cutoverBusFor().tryStartRun() {
+		t.Fatal("tryStartRun on a fresh bus must succeed")
+	}
+	t.Cleanup(h.cutoverBusFor().endRun)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, jobName,
+		&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409 while a run is in flight, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A step leaf whose slug is not among the discovered step ConfigMaps is a
+// client-side condition (nothing to re-run), so it must surface as a
+// graceful 422 with an actionable detail — never a raw 502.
+func TestRetryJob_CutoverStep_UnknownSlug_422(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+	}
+	jobName := jobs.ActivityStepJobName(jobs.GroupCutover, "no-such-step")
+	r, _, _, depID := cutoverStepRetryHarness(t, "owner@t99.omani.works", jobName, jobs.StatusFailed, objs...)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, jobName,
+		&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422 for an unknown step slug, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	// …and for the RIGHT reason: the detail must name the unknown step, not
+	// the generic "kind %q does not support retry" the leg replaces.
+	if body := rec.Body.String(); !strings.Contains(body, "no-such-step") {
+		t.Errorf("422 detail must name the unknown step slug; got %s", body)
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.cutoverRerun.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.cutoverRerun.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * JobsTable.cutoverRerun.test.tsx — UAT row 165 lock-in (issue #3379).
+ *
+ * Row 165, verbatim:
+ *
+ *   "On a failed `cutover-step-*` row, a Re-run button is present
+ *    (per-row, gated to Failed) — the operator can re-drive a failed
+ *    cutover step from the browser."
+ *
+ * Both halves are asserted here:
+ *
+ *   • PRESENT + labelled "Re-run" on a `failed` cutover-step row.
+ *   • ABSENT on the SAME row when its status is succeeded / running /
+ *     pending — the "gated to Failed" clause. This is the direction that
+ *     catches a regression where the gate is loosened to "any row".
+ *
+ * The row shape mirrors the backend projection in
+ * products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge.go:
+ * a leaf whose JobName is `cutover-step-<slug>` (jobs.ActivityStepJobName)
+ * and whose Kind is `step`.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { JobsTable } from './JobsTable'
+import type { Job, JobStatus } from '@/lib/jobs.types'
+
+afterEach(() => cleanup())
+
+const CUTOVER_STEP_JOB_NAME = 'cutover-step-egress-block-test'
+
+/** One projected cutover step leaf in the given lifecycle state. */
+function cutoverStepRow(status: JobStatus): Job {
+  return {
+    id: `d-1:${CUTOVER_STEP_JOB_NAME}`,
+    jobName: CUTOVER_STEP_JOB_NAME,
+    displayName: 'egress-block-test',
+    type: 'install',
+    kind: 'step',
+    appId: '',
+    parentId: 'd-1:cutover',
+    dependsOn: ['d-1:cutover-step-helmrepository-patches'],
+    childIds: [],
+    status,
+    startedAt: '2026-07-26T10:00:00Z',
+    finishedAt: status === 'running' || status === 'pending' ? null : '2026-07-26T10:11:00Z',
+    durationMs: status === 'running' || status === 'pending' ? 0 : 660000,
+  }
+}
+
+function renderJobs(jobs: Job[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <JobsTable jobs={jobs} deploymentId="d-1" />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <div data-testid="job-detail-target" />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([homeRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/jobs'] }),
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+describe('UAT row 165 — per-row Re-run on a FAILED cutover-step row', () => {
+  it('renders the Re-run control on a failed cutover-step row', async () => {
+    renderJobs([cutoverStepRow('failed')])
+    await screen.findByTestId('jobs-table')
+
+    const btn = screen.getByTestId(`jobs-retry-${CUTOVER_STEP_JOB_NAME}`)
+    expect(btn).toBeTruthy()
+    // Row 165 names the verb: "Re-run", not the generic "Retry reconcile".
+    expect(btn.textContent).toBe('Re-run')
+    // The control is dispatched on the backend-stamped kind, so a
+    // regression that loses the `step` kind is visible here too.
+    expect(btn.getAttribute('data-kind')).toBe('step')
+  })
+
+  it.each<JobStatus>(['succeeded', 'running', 'pending'])(
+    'does NOT render the Re-run control on a %s cutover-step row',
+    async (status) => {
+      renderJobs([cutoverStepRow(status)])
+      await screen.findByTestId('jobs-table')
+
+      expect(screen.queryByTestId(`jobs-retry-${CUTOVER_STEP_JOB_NAME}`)).toBeNull()
+      // The Actions cell still renders — it shows the empty marker, so the
+      // absence is the GATE firing, not the whole column disappearing.
+      expect(
+        screen.getByTestId(`jobs-cell-actions-empty-d-1:${CUTOVER_STEP_JOB_NAME}`),
+      ).toBeTruthy()
+    },
+  )
+
+  it('gates per-row: only the failed step in a chain offers Re-run', async () => {
+    const succeeded: Job = {
+      ...cutoverStepRow('succeeded'),
+      id: 'd-1:cutover-step-gitea-mirror',
+      jobName: 'cutover-step-gitea-mirror',
+      displayName: 'gitea-mirror',
+    }
+    renderJobs([succeeded, cutoverStepRow('failed')])
+    await screen.findByTestId('jobs-table')
+
+    expect(screen.getByTestId(`jobs-retry-${CUTOVER_STEP_JOB_NAME}`)).toBeTruthy()
+    expect(screen.queryByTestId('jobs-retry-cutover-step-gitea-mirror')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -1142,7 +1142,14 @@ const JOBS_TABLE_CSS = `
 .jobs-retry-btn:disabled { opacity: 0.6; cursor: default; }
 .jobs-retry-result { font-size: 11px; font-weight: 600; }
 .jobs-retry-done  { color: #4ADE80; }
-.jobs-retry-error { color: #F87171; }
+/* The error text is the SERVER's own detail (#3379), which can be a full
+ * sentence — clamp it to one line so a long 422/409 reason cannot widen the
+ * Actions column and push the table into a horizontal scroll. The element
+ * carries the untruncated message in its title for hover/copy. */
+.jobs-retry-error {
+  color: #F87171; max-width: 28ch; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap;
+}
 /* #3656 (founder #6) — provisional "Confirming…" badge: a reducer-derived
  * row the live cluster state has not confirmed yet. Amber + DASHED border so
  * it reads as a distinct "settling, not committed" state — unmistakable from

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.test.tsx
@@ -2,25 +2,40 @@
  * RetryJobButton.test.tsx — the §5c per-row remediation control (issue
  * #3646): clicking POSTs the retry endpoint; 200 → "Requested"; 403 →
  * "Not permitted"; the label is kind-specific ("Run now" for a cron).
+ *
+ * Extended for UAT row 165 / issue #3379 — the `step` kind (a projected
+ * `cutover-step-*` row) labels "Re-run", shows a real PENDING state while
+ * the POST is in flight, and surfaces the backend's own failure detail
+ * rather than an optimistic green.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { RetryJobButton } from './RetryJobButton'
+import { retryLabel } from './retryJobFeedback'
 
 let nextStatus = 200
+let nextBody: Record<string, unknown> = { executionId: 'e1', action: 'annotated' }
+/** Resolver for the in-flight response — lets a test hold the POST open. */
+let releaseResponse: (() => void) | null = null
 
 vi.mock('@/shared/lib/authedFetch', () => ({
-  authedFetch: (_url: string, _init?: RequestInit) =>
-    Promise.resolve(
-      new Response(JSON.stringify({ executionId: 'e1', action: 'annotated' }), {
-        status: nextStatus,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    ),
+  authedFetch: async () => {
+    if (releaseResponse) {
+      await new Promise<void>((resolve) => {
+        releaseResponse = resolve
+      })
+    }
+    return new Response(JSON.stringify(nextBody), {
+      status: nextStatus,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  },
 }))
 
 beforeEach(() => {
   nextStatus = 200
+  nextBody = { executionId: 'e1', action: 'annotated' }
+  releaseResponse = null
   cleanup()
 })
 
@@ -50,6 +65,90 @@ describe('RetryJobButton', () => {
     fireEvent.click(screen.getByTestId('jobs-retry-d1:install-velero'))
     await waitFor(() => {
       expect(screen.getByTestId('jobs-retry-error-d1:install-velero').textContent).toContain('Not permitted')
+    })
+  })
+})
+
+describe('RetryJobButton — cutover step (UAT row 165, issue #3379)', () => {
+  const jobId = 'cutover-step-egress-block-test'
+
+  it('labels "Re-run" for a step — the verb row 165 names', () => {
+    expect(retryLabel('step')).toBe('Re-run')
+    render(<RetryJobButton deploymentId="d1" jobId={jobId} kind="step" />)
+    expect(screen.getByTestId(`jobs-retry-${jobId}`).textContent).toBe('Re-run')
+  })
+
+  it('shows a PENDING state while the re-run is dispatched, before any result', async () => {
+    releaseResponse = () => {} // placeholder — replaced by the mock's resolver
+    render(<RetryJobButton deploymentId="d1" jobId={jobId} kind="step" />)
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+
+    const btn = await screen.findByTestId(`jobs-retry-${jobId}`)
+    await waitFor(() => {
+      expect(btn.textContent).toBe('Requesting…')
+    })
+    // The pending state is a real gate, not cosmetic — a second click
+    // cannot fire a duplicate re-run while the first is in flight.
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+    expect(btn.getAttribute('aria-busy')).toBe('true')
+    // No premature success claim while the call is still open.
+    expect(screen.queryByTestId(`jobs-retry-done-${jobId}`)).toBeNull()
+
+    releaseResponse?.()
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-done-${jobId}`).textContent).toContain('Requested')
+    })
+  })
+
+  it('on 422 surfaces the backend detail verbatim — never a fake green', async () => {
+    nextStatus = 422
+    nextBody = {
+      error: 'not-directly-retryable',
+      detail: 'cutover step "no-such-step" is not among the 11 steps installed on this Sovereign',
+    }
+    render(<RetryJobButton deploymentId="d1" jobId={jobId} kind="step" />)
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-error-${jobId}`).textContent).toContain(
+        'is not among the 11 steps',
+      )
+    })
+    expect(screen.queryByTestId(`jobs-retry-done-${jobId}`)).toBeNull()
+  })
+
+  it('on 409 surfaces the in-flight-cutover detail', async () => {
+    nextStatus = 409
+    nextBody = {
+      error: 'cutover-in-progress',
+      detail: 'a cutover run is already in flight on this catalyst-api Pod',
+    }
+    render(<RetryJobButton deploymentId="d1" jobId={jobId} kind="step" />)
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-error-${jobId}`).textContent).toContain(
+        'already in flight',
+      )
+    })
+  })
+
+  it('falls back to "Not retryable" on a detail-less 409', async () => {
+    nextStatus = 409
+    nextBody = {}
+    render(<RetryJobButton deploymentId="d1" jobId={jobId} kind="step" />)
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-error-${jobId}`).textContent).toContain('Not retryable')
+    })
+  })
+
+  it('surfaces the status code when the body is not JSON', async () => {
+    nextStatus = 502
+    render(<RetryJobButton deploymentId="d1" jobId={jobId} kind="step" />)
+    // A body with neither detail nor error → the status-code fallback.
+    nextBody = {}
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-error-${jobId}`).textContent).toContain('Failed (502)')
     })
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.tsx
@@ -12,21 +12,43 @@
  *   install / reconcile / reconciler → "Retry reconcile"
  *   cron                             → "Run now"
  *   task                             → "Re-run"
+ *   step                             → "Re-run"
  *   mutation                         → "Re-submit"
  *
+ * `step` is the self-sovereign-cutover leg (issue #3379, UAT row 165): a
+ * FAILED `cutover-step-*` row re-drives the cutover engine in operator-retry
+ * mode, which deletes the step's stale failed Job, re-runs it, and resumes
+ * the chain. The row is only offered the control when it is Failed
+ * (`isJobRetryable`), and the backend independently rejects a non-failed row
+ * with 409 — so a Succeeded/Running/Pending step can never be re-driven.
+ *
  * The control is OBSERVE-ONLY-NO-MORE: clicking it re-drives the actual
- * reconcile via the backend (annotation bump / one-off Job), never a
- * client-side kubectl. The button optimistically shows "Requesting…",
- * then "Requested" on 200 (the live /jobs backfill reflects the new
- * Execution + real state on its next poll), or the error on failure. A
- * 403 surfaces "Not permitted" (the viewer lacks operator RBAC); a 409
- * surfaces "Not retryable".
+ * reconcile via the backend (annotation bump / one-off Job / cutover
+ * re-run), never a client-side kubectl.
+ *
+ * # Honest feedback, never optimistic green
+ *
+ * The button shows a PENDING "Requesting…" state while the POST is in
+ * flight, and only claims success on a real 2xx — at which point the label
+ * is "Requested", NOT "Succeeded": the request was accepted, the live /jobs
+ * backfill reports the actual outcome on its next poll. Every non-2xx is
+ * surfaced verbatim rather than swallowed:
+ *
+ *   403 → "Not permitted"      (the viewer lacks operator RBAC)
+ *   409 → "Not retryable"      (nothing to re-run) / the server's detail
+ *                               when a cutover run is already in flight
+ *   422 → the server's `detail` (e.g. "cutover step … is not among the …")
+ *   any other status / network error → the status code or "Network error"
+ *
+ * The label + error-message ladders themselves live in `retryJobFeedback.ts`
+ * so they are unit-testable on their own.
  */
 
 import { useState } from 'react'
 import { authedFetch } from '@/shared/lib/authedFetch'
 import { API_BASE } from '@/shared/config/urls'
 import type { JobKind } from '@/lib/jobs.types'
+import { retryLabel, errorMessageFor } from './retryJobFeedback'
 
 interface RetryJobButtonProps {
   deploymentId: string
@@ -35,20 +57,6 @@ interface RetryJobButtonProps {
 }
 
 type RetryPhase = 'idle' | 'requesting' | 'done' | 'error'
-
-/** Kind-specific action label (mirrors the backend dispatch). */
-function retryLabel(kind: JobKind): string {
-  switch (kind) {
-    case 'cron':
-      return 'Run now'
-    case 'task':
-      return 'Re-run'
-    case 'mutation':
-      return 'Re-submit'
-    default:
-      return 'Retry reconcile'
-  }
-}
 
 export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProps) {
   const [phase, setPhase] = useState<RetryPhase>('idle')
@@ -68,19 +76,11 @@ export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProp
           body: '{}',
         },
       )
-      if (res.status === 403) {
-        setPhase('error')
-        setMessage('Not permitted')
-        return
-      }
-      if (res.status === 409) {
-        setPhase('error')
-        setMessage('Not retryable')
-        return
-      }
       if (!res.ok) {
+        // Honest failure — surface the server's own reason. Never a
+        // green confirmation for a call that did not succeed.
         setPhase('error')
-        setMessage(`Failed (${res.status})`)
+        setMessage(await errorMessageFor(res))
         return
       }
       setPhase('done')
@@ -92,13 +92,17 @@ export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProp
   }
 
   const label = retryLabel(kind)
+  const hint =
+    kind === 'step'
+      ? `${label} — re-drives this cutover step via the catalyst-api (the failed step's Job is deleted and run again)`
+      : `${label} — re-drives the reconcile via the catalyst-api (Flux-native, no kubectl)`
 
   if (phase === 'done') {
     return (
       <span
         className="jobs-retry-result jobs-retry-done"
         data-testid={`jobs-retry-done-${jobId}`}
-        title="Reconcile requested — the live state refreshes on the next poll"
+        title="Request accepted — the live state refreshes on the next poll"
       >
         ✓ {message}
       </span>
@@ -114,7 +118,8 @@ export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProp
         data-kind={kind}
         disabled={phase === 'requesting'}
         onClick={onClick}
-        title={`${label} — re-drives the reconcile via the catalyst-api (Flux-native, no kubectl)`}
+        title={hint}
+        aria-busy={phase === 'requesting'}
       >
         {phase === 'requesting' ? 'Requesting…' : label}
       </button>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.tsx
@@ -127,6 +127,10 @@ export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProp
         <span
           className="jobs-retry-result jobs-retry-error"
           data-testid={`jobs-retry-error-${jobId}`}
+          role="alert"
+          // The cell clamps a long server detail to one line; the full,
+          // untruncated reason stays available on hover.
+          title={message}
         >
           {message}
         </span>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/retryJobFeedback.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/retryJobFeedback.ts
@@ -1,0 +1,68 @@
+/**
+ * retryJobFeedback.ts — the pure label + error-message contract behind the
+ * per-row remediation control (RetryJobButton).
+ *
+ * Kept OUT of the component module so both halves can be unit-tested
+ * directly (and so the component file exports only a component — the
+ * react-refresh rule).
+ */
+
+import type { JobKind } from '@/lib/jobs.types'
+
+/**
+ * retryLabel — kind-specific action label. Mirrors the backend's
+ * `dispatchRetry` switch so the verb the operator reads matches the action
+ * the catalyst-api actually performs.
+ *
+ *   install / reconcile / reconciler → "Retry reconcile" (annotation bump)
+ *   cron                             → "Run now"        (one-off Job)
+ *   task                             → "Re-run"         (delete + recreate)
+ *   step                             → "Re-run"         (cutover step re-drive)
+ *   mutation                         → "Re-submit"
+ *
+ * `step` is a projected activity step (`cutover-step-*`, issue #3379 / UAT
+ * row 165). "Re-run" is the verb row 165 names, and it is honest: the
+ * backend deletes the step's stale failed Job and runs it again — it does
+ * not merely nudge a reconciler.
+ */
+export function retryLabel(kind: JobKind): string {
+  switch (kind) {
+    case 'cron':
+      return 'Run now'
+    case 'task':
+      return 'Re-run'
+    case 'step':
+      return 'Re-run'
+    case 'mutation':
+      return 'Re-submit'
+    default:
+      return 'Retry reconcile'
+  }
+}
+
+/**
+ * errorMessageFor — turns a non-2xx retry response into the message the
+ * operator sees. Prefers the server's own `detail` (the backend writes an
+ * actionable one for 409/422) and falls back to a fixed label per status, so
+ * the control NEVER renders a green "success" for a call that failed.
+ *
+ * Ladder, in order:
+ *   403                     → "Not permitted"   (the viewer lacks operator RBAC)
+ *   any status with detail  → that detail verbatim
+ *   409 without detail      → "Not retryable"
+ *   anything else           → "Failed (<status>)"
+ */
+export async function errorMessageFor(res: Response): Promise<string> {
+  let detail = ''
+  try {
+    const body = (await res.json()) as { detail?: unknown; error?: unknown }
+    if (typeof body?.detail === 'string') detail = body.detail.trim()
+    else if (typeof body?.error === 'string') detail = body.error.trim()
+  } catch {
+    // Non-JSON body (proxy error page) — fall through to the status label.
+  }
+  if (res.status === 403) return 'Not permitted'
+  if (detail) return detail
+  if (res.status === 409) return 'Not retryable'
+  return `Failed (${res.status})`
+}


### PR DESCRIPTION
## What UAT row 165 asks for

> On a failed `cutover-step-*` row, a Re-run button is present (per-row, gated to Failed) — the sovereign-admin can re-drive a failed cutover step from the browser.

## Which surface renders `cutover-step-*` rows, and how that was proven

`products/catalyst/bootstrap/ui` — the React/TSX operator console. A walker reaches it at **`https://console.<sovereign-fqdn>/jobs`** (`consoleJobsRoute`, `src/app/router.tsx:1380-1383` → `JobsPage` → `JobsTable`); the mothership-scoped twin is `/provision/$deploymentId/jobs` (`router.tsx:878-881`).

Evidence chain:

- `internal/handler/cutover_activity_bridge.go` projects the 11-step cutover execution through `jobs.ActivityBridge`, which mints one leaf per step with `Kind: jobs.KindStep` and `JobName = ActivityStepJobName("cutover", slug)` → `cutover-step-<slug>` (`internal/jobs/activity_bridge.go:276`, `:96`).
- `JobsPage.tsx` reads exactly one backend list — `GET /api/v1/deployments/{depId}/jobs` via `useLiveJobsBackfill` — and threads `deploymentId` into `<JobsTable>`; its own header comment names cutover steps as rows it lists.
- `JobsTable.tsx:810-822` renders the Actions cell whenever `deploymentId` is present, and the control inside it whenever `isJobRetryable(job.status)`.

Note for anyone repeating the search: this is *not* `core/console` (that is the per-Organization portal — `getMyOrgs`, "No jobs yet for this organization") nor `products/catalyst/console`. A grep restricted to those two trees finds nothing and reads as "no UI exists".

## The actual gap — not a missing button, a button that always failed

The control already rendered on a failed cutover-step row and was already gated to Failed. What was missing was the backend leg: `dispatchRetry` had no `case jobs.KindStep`, so every click fell through to `default:` and returned

```
422 {"error":"not-directly-retryable","detail":"kind \"step\" does not support retry: …"}
```

Reproduced before the fix by `TestRetryJob_CutoverStep_Failed_RedrivesEngine`. So the row-165 assertion was false in the way that matters: the sovereign-admin could see the control and could not re-drive the step. The label was wrong too — `step` fell to the default `"Retry reconcile"`, which describes an annotation bump, not what a cutover step re-run does.

## Which backend path the button calls, and why that one

`POST /api/v1/deployments/{depId}/jobs/{jobId}/retry` — the existing generic remediation endpoint (`cmd/api/main.go:1475`), extended with a `KindStep` case rather than given a new sibling endpoint. That case calls `runCutover(ctx, deps, steps, operatorRetry=true)` — the same engine entry `HandleCutoverStart` spawns at `cutover.go:2306`.

Why not have the UI call `POST /api/v1/sovereign/cutover/start` directly:

- The retry route already carries the four properties this action needs — session gate (registered inside the `RequireSession` group), operator-tier RBAC (`jobRetryCallerAuthorized`, 403 otherwise), the ownership gate (404 on cross-tenant), and an Execution recorded on the row with the operator identity in its first LogLine. `/cutover/start` has the session gate but none of the per-row audit or ownership plumbing.
- It keeps one remediation write surface for the jobs canvas, which is what `jobs_retry.go` was built to be.

Why re-driving the whole engine is the correct per-row semantic: the chain is sequential and halts at its first failure, so at most one step is `failed` at any time. `runCutover` skips steps whose durable per-step status is already `success`, so it resumes exactly at the failed step, deletes its stale Job, re-runs it, and continues. "Re-run this row" and "resume the chain" are the same operation here.

No new endpoint. No chart change. `jobFailedTransiently`'s fail-closed design is untouched — the auto-resume and in-cluster trigger still pass `operatorRetry=false`, so an unattended genuine failure still never auto-loops; only the deliberate human CTA re-runs it.

## Changes

**Backend** — `products/catalyst/bootstrap/api`

- `internal/handler/jobs_retry_cutover_step.go` (new): `retryActivityStep` / `retryCutoverStep`. Resolves the step slug from the leaf's JobName, verifies it against the installed step ConfigMaps, claims the engine's single-run flag, spawns `runCutover(..., true)` on a background context so a closed browser cannot cancel a multi-step cutover.
- `internal/handler/jobs_retry.go`: the `KindStep` dispatch case, plus `errCutoverRunInFlight` → **409** so a Re-run fired during an in-flight run cannot race a second engine goroutine.

Failure mapping is honest rather than uniform: unknown/foreign step slug, cutover chart absent, or a step leaf from a future non-cutover activity group → **422** with an actionable detail; engine busy → **409**; non-failed row → **409** (the pre-existing `jobRetryableStatus` gate, which independently enforces "gated to Failed" server-side).

**Frontend** — `products/catalyst/bootstrap/ui`

- `retryJobFeedback.ts` (new): `retryLabel` gains `case 'step' → "Re-run"`; `errorMessageFor` surfaces the server's own `detail` for any non-2xx, falling back to `Not permitted` (403) / `Not retryable` (409, detail-less) / `Failed (<status>)`. Extracted to its own module so both ladders are unit-testable and the component file exports only a component.
- `RetryJobButton.tsx`: uses those, adds `aria-busy` on the in-flight state and a step-specific tooltip. The success state now reads "Request accepted — the live state refreshes on the next poll" rather than implying the step itself succeeded.

The Failed-only gate is unchanged (`isJobRetryable`) — this PR locks it down with tests rather than touching it.

## Honest feedback, no optimistic green

Pending state while the POST is in flight ("Requesting…", button disabled + `aria-busy`, no success element rendered). Success claims only "Requested" on a real 2xx — the request was accepted; the live `/jobs` backfill reports the actual outcome on its next poll. Every non-2xx renders the server's reason verbatim in the error slot. A rejected re-run can never render as green.

## Tests, including the negative direction

Backend — `jobs_retry_cutover_step_test.go` (5 cases): failed step re-drives the engine (stale failed Job deleted, fresh Job created, both steps end `success`, Execution recorded); succeeded/running/pending each → 409; viewer → 403; engine busy → 409; unknown slug → 422 naming the slug.

Frontend — `JobsTable.cutoverRerun.test.tsx`: control present and labelled "Re-run" on a failed `cutover-step-*` row; absent for succeeded/running/pending (with the Actions cell still rendering its empty marker, so absence is the gate firing and not the column vanishing); in a two-row chain only the failed row offers it. `RetryJobButton.test.tsx` adds the step label, the pending state, and 422/409/detail-less-409/status-fallback rendering.

Each half was reverted and the matching tests confirmed failing:

| Reverted | Result |
|---|---|
| `case jobs.KindStep` in `dispatchRetry` | 3 backend tests fail — `got 422 … kind "step" does not support retry` |
| `case 'step'` in `retryLabel` | `expected "Re-run", received "Retry reconcile"` |
| `isJobRetryable(job.status)` gate → always render | 4 of 5 row-165 render tests fail |

## Gates

Backend: `go build ./...`, `go vet ./...`, `go test -count=1 ./...` all green; `gofmt` clean on every touched file.

Frontend: `npm run build` (`tsc -b && vite build`) green; `tsc -b --noEmit` green; `eslint` clean on all four touched files (it also clears two pre-existing unused-arg errors in `RetryJobButton.test.tsx`).

Full `vitest run`: 9 files / 68 tests fail — **identical on `origin/main` with this change stashed** (same 9 files, same 68 count), so they are pre-existing and unrelated. The four files in this PR's blast radius (`RetryJobButton`, `JobsTable.cutoverRerun`, `JobsTable`, `jobs.types`) are 76/76 green.

No chart touched, so no `Chart.yaml` bump or lockstep script applies. No cluster was touched — repo-only.

## Verification still owed

This is unit-proven, not walked. Row 165 flips green when a sovereign-admin lands on `/jobs` of a Sovereign with a genuinely failed cutover step, clicks Re-run, and the step re-executes — screenshot plus the `[retry] requested by …` Execution LogLine on the row.

Refs #3379
