### PR TITLE
fix(keycloak): SECURITY — pin-broker credential is platform-only; per-Org releases were overwriting it via reflector auto-reflection

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -226,7 +226,7 @@ spec:
       #   values.yaml wires keycloak.auth.existingSecret=keycloak-admin so the
       #   password is reused (never regenerated) across reinstall + re-home. Chart
       #   + blueprint bumped in lockstep.
-      version: 1.5.6
+      version: 1.5.7
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.6
+  version: 1.5.7
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -436,7 +436,7 @@ name: bp-keycloak
 # retained (Tier-2 convention, guarded by g117-5-tier2-sso-clients.sh). Kept in
 # lockstep with bp-oidc-gate 0.1.7 instances.yaml. ONLY the powerdns-admin client
 # block changed — no other client's scopes touched.
-version: 1.5.6
+version: 1.5.7
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/templates/pin-broker-secret.yaml
+++ b/platform/keycloak/chart/templates/pin-broker-secret.yaml
@@ -15,8 +15,33 @@ package validates against in /oidc/token client_secret check).
 
 Created only when sovereignRealm.enabled — there's no broker IDP on
 Catalyst-Zero (the catalyst-pin alias only makes sense per-Sovereign).
+
+#5400 SECURITY — and ONLY in Sovereign mode, never for a per-Org release.
+bp-keycloak installs per-Organization too, and `sovereignRealm.enabled`
+defaults true, so a tenant release satisfied the old guard and rendered
+this Secret in its OWN namespace carrying the reflector auto-reflection
+annotations below — which target the single shared
+`catalyst-system/catalyst-pin-broker-credentials`. Every Org therefore
+overwrote the platform's broker credential, last writer wins, and
+`helm.sh/resource-policy: keep` made each copy durable.
+
+Live hw290 proof (sha256[:12] of client-secret): keycloak (the IdP's own,
+authoritative) `58a6a6c54300`; beta-corp `1bf615852b21`; delta-corp
+`dc43ecba7c9d`; gamma-corp `24b855cea675`; and catalyst-system — what
+catalyst-api actually reads — `24b855cea675`, annotated
+`reflects: gamma-corp/catalyst-pin-broker-credentials`. A tenant
+namespace was in control of a platform credential, and catalyst-api
+presented it to a Keycloak holding a different one, so every app
+federating through the pin broker got 401 invalid_client. Because it is
+last-writer-wins it presents as flake — green on one env, red on the
+next, purely by Org-creation order.
+
+`realmConfig.tenant.enabled` is the chart's own documented master switch
+("when false (default), chart stays in Sovereign mode"), so gating on it
+uses existing semantics rather than inventing a tier flag. Verified live:
+per-Org releases set it true, the platform release leaves it unset.
 */}}
-{{- if .Values.sovereignRealm.enabled -}}
+{{- if and .Values.sovereignRealm.enabled (not .Values.realmConfig.tenant.enabled) -}}
 {{- $secret := include "bp-keycloak.pinBrokerClientSecret" . -}}
 ---
 apiVersion: v1

--- a/platform/keycloak/chart/tests/pin-broker-secret-platform-only-5400.sh
+++ b/platform/keycloak/chart/tests/pin-broker-secret-platform-only-5400.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# pin-broker-secret-platform-only-5400.sh — #5400 SECURITY guard.
+#
+# The `catalyst-pin-broker-credentials` Secret carries reflector
+# auto-reflection annotations targeting the single shared
+# `catalyst-system/catalyst-pin-broker-credentials`. bp-keycloak installs
+# per-Organization as well as at platform tier, and `sovereignRealm.enabled`
+# defaults TRUE — so before this guard a tenant release rendered the Secret in
+# its own namespace and auto-reflected it OVER the platform's copy. Last
+# writer wins, and `helm.sh/resource-policy: keep` made every Org's copy
+# durable.
+#
+# Live hw290 proof (sha256[:12] of client-secret): the authoritative `keycloak`
+# copy was 58a6a6c54300, while `catalyst-system` — what catalyst-api actually
+# reads — held 24b855cea675, byte-identical to `gamma-corp` and annotated
+# `reflects: gamma-corp/catalyst-pin-broker-credentials`. A tenant namespace
+# controlled a platform credential, and catalyst-api presented it to a Keycloak
+# holding a different one, so every app federating through the pin broker got
+# 401 invalid_client.
+#
+# Because it is last-writer-wins it presents as FLAKE — green on one env, red
+# on the next, purely by Org-creation order. That is why it survived: it looked
+# like an intermittent SSO problem rather than a template defect.
+#
+# The sibling `configmap-sovereign-realm.yaml` already had the correct guard;
+# this template simply never got it. This test pins the alignment.
+#
+# Usage:  platform/keycloak/chart/tests/pin-broker-secret-platform-only-5400.sh
+# Exit:   0 = correct, 1 = the tenant guard regressed.
+
+set -euo pipefail
+
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+SECRET_NAME="catalyst-pin-broker-credentials"
+EXIT=0
+
+fail() { echo "FAIL: $1" >&2; EXIT=1; }
+
+# Tenant mode has REQUIRED values (Inviolable #4 — the chart fails the render
+# rather than hardcoding). Every one of them must be supplied or `helm template`
+# errors out, and an errored render contains no Secret — which would make this
+# whole test pass vacuously against a VULNERABLE template. That is exactly the
+# trap the first draft of this test fell into: it reported OK while the guard
+# was reverted. render_tenant_or_die below refuses to let that happen again.
+render_tenant() {
+  helm template kc "${CHART}" \
+    --set sovereignRealm.enabled=true \
+    --set realmConfig.tenant.enabled=true \
+    --set realmConfig.tenant.realmName=org-acme \
+    --set realmConfig.tenant.orgSlug=acme \
+    --set realmConfig.tenant.parentDomain=omani.homes \
+    --set realmConfig.tenant.subdomain=acme 2>&1
+}
+
+# A tenant render must SUCCEED and be substantial. If it errored, or came back
+# suspiciously small, we cannot conclude anything from "the Secret is absent" —
+# so fail loudly instead of reporting a green we did not earn.
+render_tenant_or_die() {
+  local out; out="$(render_tenant)"
+  if printf '%s\n' "${out}" | grep -qE '^Error'; then
+    echo "FAIL: tenant render ERRORED — this test cannot evaluate the guard, and an errored render would pass it vacuously. Fix the values below (a new required realmConfig.tenant.* was likely added):" >&2
+    printf '%s\n' "${out}" | grep -E '^Error' >&2
+    exit 1
+  fi
+  if [ "${#out}" -lt 5000 ]; then
+    echo "FAIL: tenant render is only ${#out} bytes — too small to be a real render; refusing to draw a conclusion from it." >&2
+    exit 1
+  fi
+  printf '%s' "${out}"
+}
+
+render_sovereign() {
+  helm template kc "${CHART}" --set sovereignRealm.enabled=true 2>/dev/null || true
+}
+
+echo "== #5400: platform (Sovereign-mode) render MUST contain the pin-broker Secret =="
+sov="$(render_sovereign)"
+if [ -z "${sov}" ]; then
+  echo "WARN: chart did not render offline — skipping (cannot evaluate)."
+  exit 0
+fi
+sov_hits="$(printf '%s\n' "${sov}" | grep -c "name: ${SECRET_NAME}" || true)"
+if [ "${sov_hits}" -lt 1 ]; then
+  fail "Sovereign-mode render has NO ${SECRET_NAME} — the platform lost its broker credential. The guard is too strict."
+else
+  echo "OK — Sovereign mode renders it (${sov_hits})."
+fi
+
+echo ""
+echo "== #5400: tenant (per-Org) render MUST NOT contain it =="
+ten="$(render_tenant_or_die)"
+ten_hits="$(printf '%s\n' "${ten}" | grep -c "name: ${SECRET_NAME}" || true)"
+if [ "${ten_hits}" -ne 0 ]; then
+  fail "TENANT MODE RENDERS ${SECRET_NAME} (${ten_hits}). A per-Org release would auto-reflect its own secret over catalyst-system and take control of the platform's OIDC broker credential (#5400)."
+else
+  echo "OK — tenant mode renders zero."
+fi
+
+echo ""
+echo "== #5400: no reflector auto-reflection of ANY object in tenant mode =="
+# Anything a per-Org release auto-reflects into a shared namespace is the same
+# class of defect, so assert the whole annotation is absent, not just this one
+# Secret. Catches a future template copying the annotation block without a guard.
+refl="$(printf '%s\n' "${ten}" | grep -n 'reflection-auto-namespaces' || true)"
+if [ -n "${refl}" ]; then
+  fail "tenant-mode render carries reflector auto-reflection annotations — a per-Org release must never auto-reflect into a shared namespace (#5400):"
+  printf '%s\n' "${refl}" >&2
+else
+  echo "OK — tenant mode auto-reflects nothing."
+fi
+
+echo ""
+if [ "${EXIT}" -ne 0 ]; then
+  echo "───────────────────────────────────────────────────────────────" >&2
+  echo "#5400: the pin-broker credential is PLATFORM-TIER. Gate it on" >&2
+  echo "  {{- if and .Values.sovereignRealm.enabled (not .Values.realmConfig.tenant.enabled) -}}" >&2
+  echo "matching the sibling configmap-sovereign-realm.yaml guard." >&2
+  echo "───────────────────────────────────────────────────────────────" >&2
+  exit 1
+fi
+echo "OK: pin-broker credential is platform-only (#5400)."
+exit 0

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.5.6"
+  version: "1.5.7"
   visibility: listed
   card:
     title: "Keycloak"
@@ -606,7 +606,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-keycloak
-    version: "1.5.6"
+    version: "1.5.7"
   # G117.1+G117.4+G117.6 #2744-followup (2026-06-03): bp-keycloak
   # catalog-seed needs topology + endpoints + sso so application-
   # controller can fan out HRs and operator console can mint silent-SSO


### PR DESCRIPTION
## What

`catalyst-pin-broker-credentials` is a **platform-tier** credential. It was being rendered — and auto-reflected over the platform's copy — by every per-Organization `bp-keycloak` release.

`bp-keycloak` installs per-Org as well as at platform tier, and `sovereignRealm.enabled` defaults **true**, so a tenant release satisfied the old guard. It then rendered the Secret in its own namespace carrying reflector annotations pointing at the single shared `catalyst-system/catalyst-pin-broker-credentials`. Last writer wins, and `helm.sh/resource-policy: keep` made each Org's copy durable.

Two consequences: a **tenant Organization controlled a platform credential**, and **SSO broke Sovereign-wide** whenever the last writer was an Org.

## Live evidence — hw290, `31106b6aa4a7e8e7`

Hashes only; values were never printed or stored.

| namespace | sha256[:12] | note |
|---|---|---|
| `keycloak` | `58a6a6c54300` | authoritative — what the IdP validates against |
| `beta-corp` | `1bf615852b21` | |
| `delta-corp` | `dc43ecba7c9d` | |
| `gamma-corp` | `24b855cea675` | |
| **`catalyst-system`** | **`24b855cea675`** | what catalyst-api reads — annotated `reflects: gamma-corp/…` |

`catalyst-system` is a byte-for-byte match with **gamma-corp** and says so in its own annotation. It does not match `keycloak`. `catalyst-api`'s `CATALYST_PIN_BROKER_CLIENT_SECRET` is a `secretKeyRef` env with no hot-reload, so the wrong value is baked in at pod start.

## Why it read as flake, not as a defect

It is last-writer-wins, so the symptom depends entirely on Organization-creation order — green on one environment, red on the next, same code. That is very likely why the SSO-family UAT rows have been treated as intermittent for some time rather than chased to a template.

## The fix aligns with a pattern this chart already had

`realmConfig.tenant.enabled` is the chart's own documented master switch — *"when false (default), chart stays in Sovereign mode"* — and the sibling `configmap-sovereign-realm.yaml:74` **already guards on exactly it**. That template renders nothing in tenant mode and was never exposed. `pin-broker-secret.yaml` simply never received the same guard. This is an alignment, not an invented tier flag.

Verified live: per-Org releases set `realmConfig.tenant.enabled: true`; the platform release leaves it unset.

## The test, and the trap it fell into first

Worth stating plainly: **the first draft of this test passed against the vulnerable template.** Tenant mode has required values (Inviolable #4 — the chart fails the render rather than hardcoding), the render errored, an errored render contains no Secret, and absence was read as success. It reported OK while the guard was reverted.

`render_tenant_or_die` now fails loudly if the tenant render errors or comes back implausibly small, rather than drawing a conclusion from an empty string. With that corrected, the negative proof is real:

| template | exit | output |
|---|---|---|
| vulnerable (`if .Values.sovereignRealm.enabled`) | **1** | `TENANT MODE RENDERS catalyst-pin-broker-credentials (1)…` + the auto-reflection assertion |
| fixed | **0** | all three checks OK |

The test also asserts that **no object at all** auto-reflects in tenant mode, not just this Secret — so a future template copying the annotation block without a guard is caught by the same run.

## Gates

Chart `1.5.6 → 1.5.7` with all four lockstep sites moved: `Chart.yaml`, `blueprint.yaml`, bootstrap-kit slot 09, and catalog-seed `spec.version` + `source.version`. `check-bootstrap-kit-pin-sync.sh` 67/67, `check-catalog-seed-lockstep.sh` 68/0-fail, and the `tests/e2e/bootstrap-kit` Go drift-guards all pass.

## Still owed

Runtime proof: on a Sovereign with ≥2 Organizations, `catalyst-system`'s hash must equal `keycloak`'s, its `reflects` annotation must name `keycloak/…`, and creating a new Org must change neither.

**Existing environments need remediation, not just this chart.** The stale per-Org copies carry `resource-policy: keep`, so they survive the upgrade — and `catalyst-system` keeps whichever value it last received until the correct one is re-reflected. hw290 will need the platform copy restored and the orphaned per-Org copies removed.

Refs #5400
