### PR TITLE
fix(org-controller): verify provisioning postconditions before reporting an Organization Ready

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1290,7 +1290,11 @@ spec:
       #   cutover-secondary-kubeconfigs bridge + catalog-seed
       #   bp-self-sovereign-cutover 0.1.151 (region-B cutover legs) +
       #   bp-guacamole 0.2.31 sync (TBD-A6 bot re-mint).
-      version: 1.4.1226
+      # 1.4.1227 — #5395: organization-controller read-only resourcequotas +
+      #   limitranges, so its provisioning-postcondition verifier can read back
+      #   the boundary objects it authors. An Org missing its console Gateway
+      #   listener pair or its plan cap no longer reports Ready/Active.
+      version: 1.4.1227
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -810,11 +810,66 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// 6b. POSTCONDITION VERIFICATION (#5395). vclusterReadiness above reads back
+	// exactly ONE of the artifacts this reconciler authors (the vCluster HR, or
+	// for a host-tier Org merely the `<slug>` namespace). Everything else — the
+	// plan ResourceQuota + LimitRange authored into the per-Org repo, and the
+	// per-Org console Gateway listener pair — was fire-and-forget: nothing ever
+	// read it back, and reconcileConsoleServing's only output (`degraded`) fed a
+	// requeue and never reached status. So an Org could be missing its console
+	// listener (every HTTPRoute Accepted=False NoMatchingListenerHostname → the
+	// customer's console, mail, and apps all unreachable) or its purchased plan
+	// cap, and STILL report phase=Ready + Ready=True on every surface. Live on
+	// hw290: gamma-corp, 6/6 routes unrouted, Org green.
+	//
+	// verifyProvisioned re-reads what the controller claims to have provisioned.
+	// A proven-absent artifact holds BOTH the phase and the Ready condition back
+	// — the phase matters because the console derives an Org's "Active" badge
+	// from status.vcluster.phase FIRST and only falls through to the Ready
+	// condition (products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
+	// orgStateFromCR), so downgrading the condition alone would have left the
+	// operator-visible state green.
+	//
+	// Deliberately NOT a retry: a retry would keep re-appending the listener
+	// while the Org still read Active, so a permanent failure would stay
+	// invisible. Naming the missing artifact is the fix; the requeue below is
+	// the self-heal that follows from it — and because a non-empty result keeps
+	// the requeue alive, this also closes the drift hole where a Ready Org
+	// (which returns ctrl.Result{} and has no Gateway watch) could lose its
+	// listener to an external rewrite and never re-converge.
+	//
+	// ensureEnvironment above stays gated on vcReady, NOT on this: an Org with a
+	// broken console edge must still get its Environment, or a cosmetic status
+	// fix would become a functional regression for the app-install path.
+	postconditions := provisioningPostconditions{}
+	if vcReady {
+		postconditions = r.verifyProvisioned(ctx, &org)
+		for _, u := range postconditions.Unverifiable {
+			// NOT evidence of absence (RBAC not yet rolled out, apiserver blip,
+			// CRD absent on a Catalyst-Zero install). Log + requeue; never
+			// fabricate a red from a failed probe — one botched RBAC rollout
+			// would otherwise red-flag every Org on the Sovereign at once.
+			log.Info("provisioning postcondition could not be verified (not treated as missing) — requeueing",
+				"organization", org.Spec.Slug, "probe", u)
+		}
+		if !postconditions.complete() {
+			log.Info("Organization is NOT fully provisioned — holding Ready back (#5395)",
+				"organization", org.Spec.Slug, "missing", postconditions.Missing)
+			// The console reads Active off the phase first — hold it too.
+			vcPhase = "Provisioning"
+		}
+	}
+
 	readyCond := orgapi.Condition{
 		Type:               "Ready",
 		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
-	if vcReady {
+	switch {
+	case vcReady && !postconditions.complete():
+		readyCond.Status = "False"
+		readyCond.Reason = "ProvisioningIncomplete"
+		readyCond.Message = postconditions.message()
+	case vcReady:
 		readyCond.Status = "True"
 		readyCond.Reason = "Reconciled"
 		// #4813 (status honesty): word the Ready message off the SAME
@@ -826,7 +881,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// anti-pattern, cf. #3687 / #856). Only the vcluster tier
 		// (m/l/xl/flexi) authors + waits on the HR, so only it may claim it.
 		readyCond.Message = readyOrgMessage(org.Spec.PlanSlug)
-	} else {
+	default:
 		readyCond.Status = "False"
 		readyCond.Reason = "VClusterProvisioning"
 		readyCond.Message = vcMsg
@@ -879,7 +934,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// retry on the 30s cadence even for an Org that is otherwise Ready (a
 	// host-tier Org goes Ready immediately, so without this a transient console
 	// route write would sit un-retried until the next spec change).
-	if !vcReady || consoleServingDegraded {
+	//
+	// #5395 — ALSO requeue while any provisioning postcondition is missing or
+	// could not be verified. This is what makes the check self-healing rather
+	// than merely diagnostic: each pass re-runs reconcileConsoleServing (which
+	// re-appends a listener that was never written or was rewritten away) and
+	// re-reads the boundary tree, and the Org converges to Ready=True the moment
+	// the artifacts are genuinely there. Without it a Ready Org returns
+	// ctrl.Result{} and — since SetupWithManager registers no Gateway watch —
+	// would never look again.
+	if !vcReady || consoleServingDegraded ||
+		!postconditions.complete() || len(postconditions.Unverifiable) > 0 {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 	return ctrl.Result{}, nil

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -617,6 +617,14 @@ func TestReconcile_HappyPath(t *testing.T) {
 // namespace, then reconciles and asserts status.vcluster.phase=Ready,
 // Ready=True, and no requeue — the converse of the HappyPath test which
 // proves it sits False/Pending while the HR is absent.
+//
+// #5395: the fixture now ALSO seeds the boundary LimitRange + ResourceQuota.
+// Ready is no longer a readback of the vCluster HR alone — the reconciler
+// verifies every artifact it authored (provisioning_postconditions.go), so the
+// "fully provisioned" fixture this test asserts on must actually be fully
+// provisioned. sampleOrg carries no tenantPublic.parentDomain, so the console
+// Gateway listener postcondition does not apply here; it is covered
+// end-to-end in provisioning_postconditions_5395_test.go.
 func TestReconcile_ReadyOnlyWhenVClusterHRReady(t *testing.T) {
 	t.Parallel()
 	org := sampleOrg()
@@ -632,7 +640,8 @@ func TestReconcile_ReadyOnlyWhenVClusterHRReady(t *testing.T) {
 		map[string]any{"type": "Ready", "status": "True"},
 	}, "status", "conditions")
 
-	r, _, _ := makeReconciler(t, org, ns, hr)
+	r, _, _ := makeReconciler(t, org, ns, hr,
+		boundaryLimitRange("acme"), boundaryResourceQuota("acme"))
 
 	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "acme"},

--- a/core/controllers/organization/internal/controller/provisioning_postconditions.go
+++ b/core/controllers/organization/internal/controller/provisioning_postconditions.go
@@ -1,0 +1,249 @@
+// provisioning_postconditions.go — #5395. Post-provisioning verification for
+// the Organization reconciler.
+//
+// THE FAILURE SHAPE THIS CLOSES
+// -----------------------------
+// Live on hw290: Organization `gamma-corp` read Ready/Active on every status
+// surface while ALL SIX of its HTTPRoutes sat
+// `Accepted=False reason=NoMatchingListenerHostname` —
+// console./agenity./keycloak./mail./openclaw./wordpress.gamma-corp.omani.homes
+// were unreachable because the `*.gamma-corp.omani.homes` listener pair was
+// absent from the shared `cilium-gateway-console` Gateway (six sibling Orgs had
+// theirs). Nothing anywhere surfaced an error. That is the worst shape the
+// platform can ship: every status surface green, the customer sees nothing.
+//
+// WHY IT WAS INVISIBLE
+// --------------------
+// The reconciler authors a SET of artifacts but derived Ready from exactly ONE
+// of them:
+//
+//   - `vclusterReadiness` (organization_controller.go) reads back the vCluster
+//     HelmRelease + the `<slug>` Namespace, and NOTHING else. For a host-tier
+//     Org it is satisfied by the namespace alone.
+//   - `reconcileConsoleServing` (organization_controller.go) runs the DNS +
+//     console-TLS + HTTPRoute trio best-effort. Its only output is
+//     `degraded bool`, which feeds a requeue and is discarded — it never
+//     reaches `status`. A permanent failure therefore loops silently.
+//   - `ensureConsoleOrgListener` (tenant_console_tls.go) returns `(false, nil)`
+//     — indistinguishable from success — when the console Gateway is not yet
+//     present, so an Org provisioned inside that window is never retried once
+//     it goes Ready (a Ready Org returns `ctrl.Result{}`: no requeue, and
+//     `SetupWithManager` registers no watch on the Gateway).
+//   - The boundary ResourceQuota + LimitRange are authored into the per-Org
+//     Gitea repo and applied by Flux. Whether they ever landed is never read
+//     back at all.
+//
+// So the Org could be missing its console listener, its quota, or both, and
+// still report `status.vcluster.phase=Ready` + `Ready=True`.
+//
+// WHAT THIS FILE DOES
+// -------------------
+// `verifyProvisioned` reads back the artifacts the reconciler CLAIMS to have
+// provisioned and returns the ones that are missing. Reconcile refuses to
+// report Ready over a non-empty result: `status.vcluster.phase` stays
+// `Provisioning` and the Ready condition goes False with reason
+// `ProvisioningIncomplete` and a message naming EXACTLY what is absent.
+//
+// This is deliberately a postcondition check rather than a retry. A retry
+// would hide the same gap one layer down — it would keep re-appending the
+// listener while the Org still read Active, so a permanent failure would still
+// be invisible. Naming the missing artifact in `status` is what makes the gap
+// impossible to mistake for success; the 30s requeue that follows is the
+// self-heal, and because the check is what keeps the requeue alive it ALSO
+// closes the drift hole above (a Ready Org that loses its listener to an
+// external rewrite now re-enters the loop instead of sitting silently broken).
+//
+// EVIDENCE OF ABSENCE, NOT ABSENCE OF EVIDENCE
+// --------------------------------------------
+// Only an explicit NotFound counts as missing. Any other read error (RBAC 403
+// during a partial chart rollout, an apiserver blip, a CRD that is not
+// installed on a Catalyst-Zero install) is reported as UNVERIFIABLE and is
+// deliberately NOT treated as a failed postcondition — otherwise one botched
+// RBAC rollout would red-flag every Organization on the Sovereign at once. An
+// unverifiable probe logs and requeues; it never fabricates a red.
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openova-io/openova/core/controllers/organization/internal/gitops"
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+)
+
+// provisioningPostconditions is the outcome of one verification pass.
+//
+// Missing holds human-readable descriptions of artifacts proven ABSENT (an
+// explicit NotFound). Unverifiable holds artifacts whose probe errored for a
+// reason that is not evidence of absence. The two are kept apart because they
+// demand opposite treatment: Missing downgrades the Org's reported readiness;
+// Unverifiable only requeues.
+type provisioningPostconditions struct {
+	Missing      []string
+	Unverifiable []string
+}
+
+// complete reports whether every postcondition that COULD be checked passed.
+// An unverifiable probe is not a failure — see the file header.
+func (p provisioningPostconditions) complete() bool { return len(p.Missing) == 0 }
+
+// message renders the Missing set into the Ready condition's message. Sorted so
+// the string is stable across reconciles — an unstable message would defeat the
+// byte-equal status-skip in patchStatus and hot-loop the controller (#5305).
+func (p provisioningPostconditions) message() string {
+	missing := append([]string(nil), p.Missing...)
+	sort.Strings(missing)
+	return "Organization is NOT fully provisioned — missing: " + strings.Join(missing, "; ")
+}
+
+// verifyProvisioned reads back the artifacts this controller authored for the
+// Org and reports which ones are absent.
+//
+// Scope note: it verifies only artifacts THIS controller is the producer of.
+// It does not assert on the customer's purchased Applications, the funnel's
+// app tree, or anything a peer component owns — a postcondition check that
+// reaches past its own producer boundary produces false reds it cannot fix.
+//
+// Checked:
+//
+//  1. The boundary LimitRange (`plan-limits`) in ns `<slug>` — rendered for
+//     EVERY plan by gitops.Render, so its absence always means the boundary
+//     tree never landed.
+//  2. The boundary ResourceQuota (`plan-quota`) in ns `<slug>` — rendered only
+//     for plans where gitops.PlanRendersResourceQuota is true. Flexi is the
+//     on-demand soft-cap plan and renders none, so for Flexi the check is
+//     skipped rather than failed. Pairing (1) and (2) is what turns "no
+//     ResourceQuota" from an ambiguous observation into a decided one: quota
+//     absent + LimitRange present == Flexi by design; both absent == the
+//     boundary tree never landed (#5395 symptom B).
+//  3. The per-Org console Gateway listener pair
+//     (`console-https-<sub>` / `console-http-<sub>`) — only for an Org that
+//     engages the tenant-networking up-path (a pool parentDomain). This is the
+//     artifact whose absence produced NoMatchingListenerHostname on all six of
+//     gamma-corp's routes (#5395 symptom A).
+//
+// The namespace itself is NOT re-probed here — vclusterReadiness already gates
+// on it and verifyProvisioned is only consulted once that returned ready, so a
+// second probe would be redundant work on the hot path.
+func (r *Reconciler) verifyProvisioned(ctx context.Context, org *orgapi.Organization) provisioningPostconditions {
+	var out provisioningPostconditions
+	slug := strings.TrimSpace(org.Spec.Slug)
+	if slug == "" {
+		return out
+	}
+
+	// 1 + 2 — the plan boundary the customer paid for.
+	lr := &corev1.LimitRange{}
+	switch err := r.Get(ctx, client.ObjectKey{Namespace: slug, Name: gitops.BoundaryLimitRangeName}, lr); {
+	case err == nil:
+	case apierrors.IsNotFound(err):
+		out.Missing = append(out.Missing, fmt.Sprintf(
+			"LimitRange %s/%s (the per-plan boundary the org-controller renders into the per-Org repo — its absence means the boundary tree was never applied by Flux)",
+			slug, gitops.BoundaryLimitRangeName))
+	default:
+		out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
+			"LimitRange %s/%s: %s", slug, gitops.BoundaryLimitRangeName, err))
+	}
+
+	if gitops.PlanRendersResourceQuota(org.Spec.PlanSlug) {
+		rq := &corev1.ResourceQuota{}
+		switch err := r.Get(ctx, client.ObjectKey{Namespace: slug, Name: gitops.BoundaryResourceQuotaName}, rq); {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			out.Missing = append(out.Missing, fmt.Sprintf(
+				"ResourceQuota %s/%s (plan %q is a hard-capped tier — the cap the customer pays for is not on the namespace)",
+				slug, gitops.BoundaryResourceQuotaName, org.Spec.PlanSlug))
+		default:
+			out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
+				"ResourceQuota %s/%s: %s", slug, gitops.BoundaryResourceQuotaName, err))
+		}
+	}
+
+	// 3 — the console edge. Only meaningful for an Org that engages the
+	// tenant-networking up-path; an Org with no pool parentDomain is reached
+	// via the Sovereign-wide `*.<sovFQDN>` wildcard and authors no listener.
+	names, ok := orgConsoleTLSNamesForOrg(org)
+	if !ok {
+		return out
+	}
+	present, err := r.consoleOrgListenersPresent(ctx, names)
+	switch {
+	case err != nil:
+		out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
+			"console Gateway %s/%s listeners for %q: %s",
+			r.consoleGatewayNamespace(), r.consoleGatewayName(), names.WildcardHost, err))
+	case !present:
+		out.Missing = append(out.Missing, fmt.Sprintf(
+			"console Gateway listeners %s/%s on %s/%s for hostname %q (without them every HTTPRoute on that host is Accepted=False NoMatchingListenerHostname — the Org is unreachable)",
+			names.HTTPSName, names.HTTPName,
+			r.consoleGatewayNamespace(), r.consoleGatewayName(), names.WildcardHost))
+	}
+	return out
+}
+
+// consoleOrgListenersPresent reports whether BOTH per-Org listeners are live on
+// the shared console Gateway. A missing Gateway is reported as absent listeners
+// (not an error): during the bootstrap window before sovereign-tls has applied
+// the Gateway the Org genuinely has no console edge, and saying so honestly is
+// the entire point — `ensureConsoleOrgListener` returning `(false, nil)` for
+// that same case is what let the gap pass as success in the first place.
+func (r *Reconciler) consoleOrgListenersPresent(ctx context.Context, names orgConsoleTLSNames) (bool, error) {
+	gw := unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: r.consoleGatewayNamespace(),
+		Name:      r.consoleGatewayName(),
+	}, &gw); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	listeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		return false, err
+	}
+	var https, http bool
+	for _, l := range listeners {
+		m, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch n, _ := m["name"].(string); n {
+		case names.HTTPSName:
+			https = true
+		case names.HTTPName:
+			http = true
+		}
+	}
+	return https && http, nil
+}
+
+// orgConsoleTLSNamesForOrg derives the per-Org console-TLS names from the CR,
+// reporting ok=false when the Org does not engage the tenant-networking up-path
+// (no pool parentDomain, or no subdomain to form a 2-label host from).
+//
+// This is the SAME derivation reconcileTenantConsoleTLS + teardownTenantConsoleTLS
+// perform inline; centralising it here means the verifier can never probe for a
+// listener name different from the one the up-path writes.
+func orgConsoleTLSNamesForOrg(org *orgapi.Organization) (orgConsoleTLSNames, bool) {
+	parentDomain := strings.TrimSpace(org.Spec.TenantPublic.ParentDomain)
+	if parentDomain == "" {
+		return orgConsoleTLSNames{}, false
+	}
+	subdomain := strings.TrimSpace(org.Spec.TenantPublic.Subdomain)
+	if subdomain == "" {
+		subdomain = strings.TrimSpace(org.Spec.Slug)
+	}
+	if subdomain == "" {
+		return orgConsoleTLSNames{}, false
+	}
+	return orgConsoleTLSNamesFor(subdomain, parentDomain), true
+}

--- a/core/controllers/organization/internal/controller/provisioning_postconditions_5395_test.go
+++ b/core/controllers/organization/internal/controller/provisioning_postconditions_5395_test.go
@@ -1,0 +1,450 @@
+// provisioning_postconditions_5395_test.go — #5395.
+//
+// The live failure these tests lock down (hw290): Organization `gamma-corp`
+// reported Ready/Active on every status surface while all six of its HTTPRoutes
+// sat `Accepted=False reason=NoMatchingListenerHostname` — the
+// `*.gamma-corp.omani.homes` listener pair was absent from the shared
+// `cilium-gateway-console` Gateway. Separately its boundary namespace carried
+// no `plan-quota` ResourceQuota. Two artifacts the org-controller authors were
+// missing and NOTHING surfaced an error, because Ready derived from the
+// vCluster HR / namespace readback alone.
+//
+// NEGATIVE PROOF (how to confirm these tests are not theater): delete the
+// `postconditions` block from Reconcile (organization_controller.go step 6b) —
+// TestReconcile_5395_ConsoleListenerMissing_MustNotReadReady and
+// TestReconcile_5395_HardCappedPlanWithoutQuota_MustNotReadReady both fail with
+// `phase="Ready"` / `Ready=True`, i.e. they reproduce the exact hw290 shape.
+// Reverting just the `vcPhase = "Provisioning"` line leaves the condition red
+// but the phase green, which is what the console actually renders — the
+// PhaseAlsoHeldBack test isolates that half.
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openova-io/openova/core/controllers/organization/internal/gitops"
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+)
+
+// boundaryLimitRange / boundaryResourceQuota build the two boundary objects
+// gitops.Render authors into the `<slug>` namespace, named off the SAME
+// exported constants the renderer and the verifier use — so a rename cannot
+// leave these fixtures silently asserting nothing.
+func boundaryLimitRange(slug string) *corev1.LimitRange {
+	return &corev1.LimitRange{ObjectMeta: metav1.ObjectMeta{
+		Namespace: slug, Name: gitops.BoundaryLimitRangeName,
+	}}
+}
+
+func boundaryResourceQuota(slug string) *corev1.ResourceQuota {
+	return &corev1.ResourceQuota{ObjectMeta: metav1.ObjectMeta{
+		Namespace: slug, Name: gitops.BoundaryResourceQuotaName,
+	}}
+}
+
+// readyVClusterHR builds the Ready vCluster HelmRelease a paid-tier Org needs
+// before vclusterReadiness reports ready.
+func readyVClusterHR(slug string) *unstructured.Unstructured {
+	hr := &unstructured.Unstructured{}
+	hr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease",
+	})
+	hr.SetNamespace(slug)
+	hr.SetName("vcluster")
+	_ = unstructured.SetNestedSlice(hr.Object, []any{
+		map[string]any{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+	return hr
+}
+
+// consoleGateway builds the shared console Gateway carrying the apex listener
+// plus whichever per-Org listener names the caller passes — the live shape on
+// `kube-system/cilium-gateway-console`.
+func consoleGateway(perOrgListenerNames ...string) *unstructured.Unstructured {
+	listeners := []any{
+		map[string]any{
+			"name": "console-https", "hostname": "*.omantel.omani.works",
+			"port": int64(31443), "protocol": "HTTPS",
+		},
+	}
+	for _, n := range perOrgListenerNames {
+		listeners = append(listeners, map[string]any{
+			"name": n, "hostname": "*.acme.omani.homes",
+			"port": int64(31443), "protocol": "HTTPS",
+		})
+	}
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	gw.SetNamespace(consoleGatewayDefaultNamespace)
+	gw.SetName(consoleGatewayDefaultName)
+	_ = unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners")
+	return gw
+}
+
+// poolOrg is a paid-tier Org that engages the tenant-networking up-path — the
+// gamma-corp shape: a pool parentDomain, so it MUST get a per-Org console
+// listener pair on the shared console Gateway.
+func poolOrg() *orgapi.Organization {
+	org := sampleOrg()
+	org.Spec.TenantPublic.ParentDomain = "omani.homes"
+	return org
+}
+
+// reconcileToStatus drives Reconcile until it has written a status, and returns
+// that pass's result + the post-reconcile CR. An Org that engages the
+// tenant-networking up-path spends its FIRST pass adding the finalizer and
+// returning `{Requeue: true}` before any status is written, so a single pass
+// would assert on an empty status block.
+func reconcileToStatus(t *testing.T, r *Reconciler, slug string) (ctrl.Result, orgapi.Organization) {
+	t.Helper()
+	const maxPasses = 4
+	var res ctrl.Result
+	var got orgapi.Organization
+	for i := 0; i < maxPasses; i++ {
+		var err error
+		res, err = r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: slug},
+		})
+		if err != nil {
+			t.Fatalf("reconcile pass %d: %v", i+1, err)
+		}
+		if err := r.Get(context.Background(), client.ObjectKey{Name: slug}, &got); err != nil {
+			t.Fatalf("get post-reconcile pass %d: %v", i+1, err)
+		}
+		if readyCondition(&got) != nil {
+			return res, got
+		}
+	}
+	t.Fatalf("no status written after %d reconcile passes", maxPasses)
+	return res, got
+}
+
+// mustReadyCondition is readyCondition (perorg_repo_hotloop_5305_test.go) with
+// a fatal on absence, so each assertion below can read the condition inline.
+func mustReadyCondition(t *testing.T, org orgapi.Organization) orgapi.Condition {
+	t.Helper()
+	c := readyCondition(&org)
+	if c == nil {
+		t.Fatalf("no Ready condition on status: %+v", org.Status.Conditions)
+	}
+	return *c
+}
+
+// TestReconcile_5395_ConsoleListenerMissing_MustNotReadReady is the hw290
+// gamma-corp reproduction. Everything vclusterReadiness looks at is green (ns
+// Active + vCluster HR Ready) and the boundary tree landed — but the shared
+// console Gateway carries the apex listener and ANOTHER Org's pair, never this
+// Org's, because every append this Org attempts loses to a writer conflict.
+// Every HTTPRoute on `*.acme.omani.homes` is therefore
+// NoMatchingListenerHostname and the customer's console/mail/apps are
+// unreachable. The Org MUST NOT read Ready, and MUST requeue.
+func TestReconcile_5395_ConsoleListenerMissing_MustNotReadReady(t *testing.T) {
+	t.Parallel()
+	org := poolOrg()
+
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		readyVClusterHR("acme"),
+		boundaryLimitRange("acme"),
+		boundaryResourceQuota("acme"),
+		// A sibling Org's listeners are present; this Org's are not — exactly
+		// the hw290 shape where six Orgs had theirs and gamma-corp did not.
+		consoleGateway("console-https-otherorg", "console-http-otherorg"),
+	)
+	// Every append this Org attempts fails, so the listener never lands. Reads
+	// pass through, so the verifier sees the Gateway exactly as an operator
+	// would: apex + the sibling Org, no acme pair.
+	r.Client = gatewayUpdateFails{Client: r.Client}
+
+	res, got := reconcileToStatus(t, r, "acme")
+
+	cond := mustReadyCondition(t, got)
+	if cond.Status != "False" || cond.Reason != "ProvisioningIncomplete" {
+		t.Errorf("an Org whose console listener pair is absent must NOT read Ready=True — got %+v", cond)
+	}
+	if !strings.Contains(cond.Message, "console Gateway listeners") {
+		t.Errorf("Ready message must name the missing listener pair so the gap is diagnosable, got %q", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "console-https-acme") {
+		t.Errorf("Ready message must name the exact listener the up-path writes, got %q", cond.Message)
+	}
+	// The console derives the Org's Active badge from status.vcluster.phase
+	// FIRST (org_list_from_cr.go orgStateFromCR) — a red condition under a
+	// green phase would still render Active.
+	if got.Status.VCluster.Phase == "Ready" {
+		t.Errorf("status.vcluster.phase must not read Ready while the console edge is missing — the console maps phase=Ready to Active regardless of the condition")
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("a missing postcondition must keep the requeue alive so the listener is re-appended, got %v", res)
+	}
+}
+
+// TestReconcile_5395_SilentListenerSkip_MustNotReadReady is the nastier half of
+// the same hole, and the one nothing could have caught before this change:
+// `ensureConsoleOrgListener` returns `(false, nil)` — INDISTINGUISHABLE FROM
+// SUCCESS — when the console Gateway is not present (the bootstrap window
+// before sovereign-tls applies it). So `reconcileConsoleServing` reports
+// degraded=false, the Org goes Ready=True, Reconcile returns `ctrl.Result{}`
+// with NO requeue, and `SetupWithManager` registers no Gateway watch — the Org
+// never looks again. Silent, permanent, and green.
+//
+// Post-fix the Org must read ProvisioningIncomplete AND keep requeueing, which
+// is what eventually re-runs the append once the Gateway appears.
+func TestReconcile_5395_SilentListenerSkip_MustNotReadReady(t *testing.T) {
+	t.Parallel()
+	org := poolOrg()
+
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		readyVClusterHR("acme"),
+		boundaryLimitRange("acme"),
+		boundaryResourceQuota("acme"),
+		// No console Gateway at all — ensureConsoleOrgListener's NotFound
+		// branch returns (false, nil) and reports no degradation whatsoever.
+	)
+
+	res, got := reconcileToStatus(t, r, "acme")
+
+	cond := mustReadyCondition(t, got)
+	if cond.Status != "False" || cond.Reason != "ProvisioningIncomplete" {
+		t.Errorf("a silently-skipped listener append must NOT leave the Org reading Ready=True — got %+v", cond)
+	}
+	if got.Status.VCluster.Phase == "Ready" {
+		t.Errorf("status.vcluster.phase must not read Ready while the console edge was never written")
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("the silent-skip path reports no degradation, so the postcondition is the ONLY thing that can keep the retry alive — got %v", res)
+	}
+}
+
+// TestReconcile_5395_ListenerAppendedThenVerified — the converse: once the
+// per-Org listener pair IS on the Gateway (the up-path's own append lands in
+// this same pass), the Org reaches Ready=True and stops requeueing. Without
+// this, the test above could be satisfied by a check that never goes green.
+func TestReconcile_5395_ListenerAppendedThenVerified(t *testing.T) {
+	t.Parallel()
+	org := poolOrg()
+
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		readyVClusterHR("acme"),
+		boundaryLimitRange("acme"),
+		boundaryResourceQuota("acme"),
+		consoleGateway(),
+	)
+
+	// Pass 1: reconcileConsoleServing appends the pair; the verifier reads the
+	// Gateway back afterwards, so the Org may already be green here. Pass 2
+	// asserts the steady state regardless of intra-pass ordering.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	res, got := reconcileToStatus(t, r, "acme")
+
+	cond := mustReadyCondition(t, got)
+	if cond.Status != "True" || cond.Reason != "Reconciled" {
+		t.Errorf("with the listener pair present the Org must reach Ready=True, got %+v", cond)
+	}
+	if got.Status.VCluster.Phase != "Ready" {
+		t.Errorf("status.vcluster.phase: got %q want Ready", got.Status.VCluster.Phase)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a fully provisioned Org must stop requeueing, got %v", res)
+	}
+
+	// And the listeners really are on the Gateway — proving the green came from
+	// delivered artifacts, not from a check that silently passes.
+	gw := unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleGatewayDefaultNamespace, Name: consoleGatewayDefaultName,
+	}, &gw); err != nil {
+		t.Fatalf("get console gateway: %v", err)
+	}
+	listeners, _, _ := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	names := map[string]bool{}
+	for _, l := range listeners {
+		if m, ok := l.(map[string]any); ok {
+			n, _ := m["name"].(string)
+			names[n] = true
+		}
+	}
+	if !names["console-https-acme"] || !names["console-http-acme"] {
+		t.Errorf("expected the per-Org listener pair on the Gateway, got %v", names)
+	}
+	if !names["console-https"] {
+		t.Errorf("the apex listener must be preserved (regression guard), got %v", names)
+	}
+}
+
+// TestReconcile_5395_HardCappedPlanWithoutQuota_MustNotReadReady — symptom B.
+// A hard-capped plan (M) whose boundary namespace carries no `plan-quota`
+// ResourceQuota is running WITHOUT the cap the customer paid for. It must not
+// read Ready.
+func TestReconcile_5395_HardCappedPlanWithoutQuota_MustNotReadReady(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg() // PlanSlug "m" — hard-capped
+
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		readyVClusterHR("acme"),
+		boundaryLimitRange("acme"),
+		// No ResourceQuota.
+	)
+
+	res, got := reconcileToStatus(t, r, "acme")
+
+	cond := mustReadyCondition(t, got)
+	if cond.Status != "False" || cond.Reason != "ProvisioningIncomplete" {
+		t.Errorf("a hard-capped Org with no ResourceQuota must NOT read Ready=True — got %+v", cond)
+	}
+	if !strings.Contains(cond.Message, gitops.BoundaryResourceQuotaName) {
+		t.Errorf("Ready message must name the missing ResourceQuota, got %q", cond.Message)
+	}
+	if got.Status.VCluster.Phase == "Ready" {
+		t.Errorf("status.vcluster.phase must not read Ready while the plan cap is absent")
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("a missing quota must keep the requeue alive, got %v", res)
+	}
+}
+
+// TestReconcile_5395_FlexiWithoutQuotaIsNotAGap — the disambiguation that makes
+// "no ResourceQuota" a DECIDED outcome. Flexi is the on-demand soft-cap plan;
+// gitops.Render deliberately emits no ResourceQuota for it, so a quota-less
+// Flexi namespace is correct and the Org must stay green. The LimitRange —
+// which Render emits for EVERY plan — is what still has to be there.
+func TestReconcile_5395_FlexiWithoutQuotaIsNotAGap(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	org.Spec.PlanSlug = "flexi"
+
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		readyVClusterHR("acme"),
+		boundaryLimitRange("acme"),
+		// No ResourceQuota — correct for Flexi.
+	)
+
+	res, got := reconcileToStatus(t, r, "acme")
+
+	cond := mustReadyCondition(t, got)
+	if cond.Status != "True" {
+		t.Errorf("a Flexi Org renders no ResourceQuota by design — it must still read Ready, got %+v", cond)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a fully provisioned Flexi Org must stop requeueing, got %v", res)
+	}
+
+	// Same Org, LimitRange also gone → now it IS a delivery gap, because the
+	// LimitRange has no per-plan gate. This asymmetry is the whole diagnostic:
+	// quota absent alone == Flexi; both absent == the boundary tree never landed.
+	org2 := sampleOrg()
+	org2.Spec.PlanSlug = "flexi"
+	r2, _, _ := makeReconciler(t, org2,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		readyVClusterHR("acme"),
+	)
+	_, got2 := reconcileToStatus(t, r2, "acme")
+	cond2 := mustReadyCondition(t, got2)
+	if cond2.Status != "False" || cond2.Reason != "ProvisioningIncomplete" {
+		t.Errorf("a Flexi Org missing the always-rendered LimitRange IS a delivery gap and must not read Ready, got %+v", cond2)
+	}
+	if !strings.Contains(cond2.Message, gitops.BoundaryLimitRangeName) {
+		t.Errorf("Ready message must name the missing LimitRange, got %q", cond2.Message)
+	}
+	if strings.Contains(cond2.Message, gitops.BoundaryResourceQuotaName) {
+		t.Errorf("a Flexi Org must NEVER be reported as missing a ResourceQuota it is not supposed to have, got %q", cond2.Message)
+	}
+}
+
+// TestVerifyProvisioned_UnreadableProbeIsNotEvidenceOfAbsence — a read error
+// that is NOT NotFound (RBAC 403 mid-rollout, apiserver blip, absent CRD) must
+// land in Unverifiable, never in Missing. Otherwise one botched RBAC rollout
+// would red-flag every Organization on the Sovereign simultaneously.
+func TestVerifyProvisioned_UnreadableProbeIsNotEvidenceOfAbsence(t *testing.T) {
+	t.Parallel()
+	org := poolOrg()
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		boundaryLimitRange("acme"),
+		boundaryResourceQuota("acme"),
+		consoleGateway("console-https-acme", "console-http-acme"),
+	)
+	// Wrap the client so every Gateway read fails with a non-NotFound error.
+	r.Client = gatewayReadFails{Client: r.Client}
+
+	out := r.verifyProvisioned(context.Background(), org)
+	if len(out.Missing) != 0 {
+		t.Errorf("a failed (non-NotFound) probe must NOT be reported as a missing artifact, got %v", out.Missing)
+	}
+	if len(out.Unverifiable) != 1 {
+		t.Fatalf("expected exactly 1 unverifiable probe, got %v", out.Unverifiable)
+	}
+	if !out.complete() {
+		t.Errorf("an unverifiable probe must not fail the postcondition set (it is not evidence of absence)")
+	}
+}
+
+// TestVerifyProvisioned_NoParentDomainSkipsConsoleCheck — an Org with no pool
+// parentDomain is reached via the Sovereign-wide `*.<sovFQDN>` wildcard and
+// authors no per-Org listener, so demanding one would be a false red.
+func TestVerifyProvisioned_NoParentDomainSkipsConsoleCheck(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg() // no tenantPublic.parentDomain
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		boundaryLimitRange("acme"),
+		boundaryResourceQuota("acme"),
+		// No console Gateway at all.
+	)
+
+	out := r.verifyProvisioned(context.Background(), org)
+	if !out.complete() {
+		t.Errorf("an Org with no pool parentDomain must not be held back on a console listener it never authors, got %v", out.Missing)
+	}
+}
+
+// gatewayReadFails makes every Gateway Get return a non-NotFound error while
+// passing every other read through untouched.
+type gatewayReadFails struct{ client.Client }
+
+func (g gatewayReadFails) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if u, ok := obj.(*unstructured.Unstructured); ok && u.GroupVersionKind() == gatewayGVK {
+		return errGatewayUnreadable
+	}
+	return g.Client.Get(ctx, key, obj, opts...)
+}
+
+// gatewayUpdateFails makes every Gateway Update fail (the shared-Gateway writer
+// conflict a per-Org listener append loses) while leaving reads — and every
+// other object's writes — untouched.
+type gatewayUpdateFails struct{ client.Client }
+
+func (g gatewayUpdateFails) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if u, ok := obj.(*unstructured.Unstructured); ok && u.GroupVersionKind() == gatewayGVK {
+		return errGatewayConflict
+	}
+	return g.Client.Update(ctx, obj, opts...)
+}
+
+var (
+	errGatewayUnreadable = &probeError{"gateways.gateway.networking.k8s.io is forbidden: RBAC not yet rolled out"}
+	errGatewayConflict   = &probeError{"Operation cannot be fulfilled on gateways.gateway.networking.k8s.io: the object has been modified"}
+)
+
+type probeError struct{ msg string }
+
+func (e *probeError) Error() string { return e.msg }

--- a/core/controllers/organization/internal/controller/tenant_console_tls.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls.go
@@ -255,27 +255,16 @@ func orgConsoleTLSNamesFor(subdomain, parentDomain string) orgConsoleTLSNames {
 // failing the whole Org reconcile, so the per-Org Flux loop / realm /
 // UserAccess steps still converge while the cert is being issued.
 func (r *Reconciler) reconcileTenantConsoleTLS(ctx context.Context, org *orgapi.Organization) (bool, error) {
-	parentDomain := strings.TrimSpace(org.Spec.TenantPublic.ParentDomain)
-	if parentDomain == "" {
-		// Feature disabled — Org has no pool-parent public hostname.
+	// Feature disabled (no pool-parent public hostname) or no slug to form a
+	// 2-label host from → no-op; the Org's other reconcile outputs still land
+	// and a later pass re-runs this. The derivation lives in
+	// orgConsoleTLSNamesForOrg (provisioning_postconditions.go) so the up-path,
+	// the teardown, and the #5395 postcondition verifier cannot drift onto
+	// different listener names.
+	names, ok := orgConsoleTLSNamesForOrg(org)
+	if !ok {
 		return false, nil
 	}
-
-	// Subdomain defaults to the Org slug — the SAME derivation
-	// tenant_route.go uses for the HTTPRoute hostname, so the per-Org cert
-	// SAN + listener hostname + route host all line up on
-	// `*.<slug>.<parent>` / `console.<slug>.<parent>`.
-	subdomain := strings.TrimSpace(org.Spec.TenantPublic.Subdomain)
-	if subdomain == "" {
-		subdomain = org.Spec.Slug
-	}
-	if strings.TrimSpace(subdomain) == "" {
-		// No slug at all — cannot form a 2-label host. No-op (the Org's
-		// other reconcile outputs still land); a later pass with a slug
-		// set re-runs this.
-		return false, nil
-	}
-	names := orgConsoleTLSNamesFor(subdomain, parentDomain)
 
 	certChanged, err := r.reconcileOrgWildcardCert(ctx, org, names)
 	if err != nil {
@@ -461,18 +450,12 @@ func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgCons
 // had a pool parentDomain. Best-effort + absent-as-success — a missing
 // artifact is success, not an error, so a repeated reconcile is idempotent.
 func (r *Reconciler) teardownTenantConsoleTLS(ctx context.Context, org *orgapi.Organization) (bool, error) {
-	parentDomain := strings.TrimSpace(org.Spec.TenantPublic.ParentDomain)
-	if parentDomain == "" {
+	// Same derivation the up-path uses (orgConsoleTLSNamesForOrg) so teardown
+	// strips exactly the listener names the up-path appended.
+	names, ok := orgConsoleTLSNamesForOrg(org)
+	if !ok {
 		return false, nil
 	}
-	subdomain := strings.TrimSpace(org.Spec.TenantPublic.Subdomain)
-	if subdomain == "" {
-		subdomain = org.Spec.Slug
-	}
-	if strings.TrimSpace(subdomain) == "" {
-		return false, nil
-	}
-	names := orgConsoleTLSNamesFor(subdomain, parentDomain)
 
 	listenerChanged, err := r.removeConsoleOrgListener(ctx, names)
 	if err != nil {

--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -172,6 +172,47 @@ func boundaryIsVcluster(planSlug string) bool {
 // the NetworkPolicy reconciler targets the same boundary the apps land on.
 func BoundaryIsVcluster(planSlug string) bool { return boundaryIsVcluster(planSlug) }
 
+// BoundaryResourceQuotaName / BoundaryLimitRangeName are the object names the
+// boundary templates below render into the `<slug>` host namespace. They are
+// exported AND interpolated into the templates through renderView (never
+// re-typed as a string literal in either place) so the controller's
+// provisioning-postcondition readback (provisioning_postconditions.go, #5395)
+// probes for EXACTLY the objects this renderer authored — one source of truth,
+// so a rename here can never leave the verifier looking for a name nothing
+// writes (a verifier that silently checks the wrong name is worse than none).
+const (
+	BoundaryResourceQuotaName = "plan-quota"
+	BoundaryLimitRangeName    = "plan-limits"
+)
+
+// PlanRendersResourceQuota reports whether Render emits
+// `vcluster/resourcequota.yaml` for a plan — i.e. whether the Org's boundary
+// namespace is EXPECTED to carry a `plan-quota` ResourceQuota once Flux has
+// applied the boundary tree.
+//
+// This is the exported form of the `!quota.Burstable` gate inside Render, and
+// it exists so that "this Org has no ResourceQuota" becomes a DECIDED outcome
+// instead of an ambiguous one (#5395). Fixed tiers (S/M/L/XL — plus the
+// ""/free/unknown slugs planQuota defaults to "s") are hard-capped and MUST
+// carry the quota; Flexi is the on-demand soft-cap plan and deliberately
+// carries none. Without this predicate an operator looking at a quota-less
+// namespace cannot distinguish "Flexi, uncapped by design" from "the boundary
+// tree never landed" — the two are byte-identical on the cluster, which is
+// exactly how a partially-provisioned Org passed for a healthy one.
+//
+// The LimitRange (BoundaryLimitRangeName) has no such gate — Render emits it
+// for EVERY plan including Flexi — so its absence is ALWAYS a delivery gap.
+// That asymmetry is what makes the pair a usable diagnostic; see
+// provisioning_postconditions.go.
+//
+// NOTE (Refs #5393): the SIZE of the cap — in particular whether vCluster
+// control-plane overhead should count against the customer's purchased plan —
+// is a separate, open product question. This predicate answers only "is a quota
+// object expected at all", never "how big should it be".
+func PlanRendersResourceQuota(planSlug string) bool {
+	return !planQuota(planSlug).Burstable
+}
+
 // renderTemplates is the named template set the controller uses.
 // Keep these inline (text/template) — the rendered output is YAML
 // that Flux applies via Kustomization. Per Inviolable Principle #4
@@ -445,7 +486,7 @@ spec:
 const resourceQuotaTemplate = `apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: plan-quota
+  name: {{ .ResourceQuotaName }}
   namespace: {{ .Slug }}
   labels:
     openova.io/organization: {{ .Slug }}
@@ -470,7 +511,7 @@ spec:
 const limitRangeTemplate = `apiVersion: v1
 kind: LimitRange
 metadata:
-  name: plan-limits
+  name: {{ .LimitRangeName }}
   namespace: {{ .Slug }}
   labels:
     openova.io/organization: {{ .Slug }}
@@ -853,6 +894,12 @@ type renderView struct {
 	// references (#4991) — ciliumnetworkpolicy.yaml + provisioning-rbac.yaml,
 	// both always applied host-side onto `<slug>`.
 	HostAppsResources []string
+	// ResourceQuotaName / LimitRangeName carry BoundaryResourceQuotaName /
+	// BoundaryLimitRangeName into the boundary templates so the rendered object
+	// names and the controller's postcondition readback (#5395) cannot drift
+	// apart — the constants are the single definition of both.
+	ResourceQuotaName string
+	LimitRangeName    string
 }
 
 // limitRangeDefaults derives the per-container default request==limit for a
@@ -910,11 +957,13 @@ func Render(in Inputs) (map[string][]byte, error) {
 	quota := planQuota(in.PlanSlug)
 	defCPU, defMem := limitRangeDefaults(quota)
 	view := renderView{
-		Inputs:       in,
-		Quota:        quota,
-		DefaultCPU:   defCPU,
-		DefaultMem:   defMem,
-		AppNamespace: "apps",
+		Inputs:            in,
+		Quota:             quota,
+		DefaultCPU:        defCPU,
+		DefaultMem:        defMem,
+		AppNamespace:      "apps",
+		ResourceQuotaName: BoundaryResourceQuotaName,
+		LimitRangeName:    BoundaryLimitRangeName,
 	}
 
 	// Assemble the file set as a function of the tier-gate + plan. The
@@ -926,7 +975,11 @@ func Render(in Inputs) (map[string][]byte, error) {
 		"vcluster/limitrange.yaml": limitRangeTemplate,
 	}
 	res := []string{"namespace.yaml", "limitrange.yaml"}
-	if !quota.Burstable {
+	// PlanRendersResourceQuota is the exported form of this same gate — the
+	// controller's postcondition verifier (#5395) calls it to decide whether a
+	// quota-less boundary namespace is Flexi-by-design or a delivery gap, so the
+	// decision MUST be made here through that one predicate.
+	if PlanRendersResourceQuota(in.PlanSlug) {
 		files["vcluster/resourcequota.yaml"] = resourceQuotaTemplate
 		res = append(res, "resourcequota.yaml")
 	}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3591,7 +3591,19 @@ name: bp-catalyst-platform
 #   bp-guacamole 0.2.30 -> 0.2.31 (TBD-A6 bot re-mint sync — 2nd occurrence
 #   after bp-newapi 1.4.144; bot lockstep gap tracked on #5370).
 #   (1.4.1217 was consumed by the TBD-A6 auto re-publish.)
-version: 1.4.1226
+# 1.4.1227 — #5395 (partial Org provisioning read as success, hw290): grant the
+#   organization-controller read-only `resourcequotas` + `limitranges` so its new
+#   provisioning-postcondition verifier can read back the two boundary objects it
+#   authors into the `<slug>` namespace. Before this the reconciler derived Ready
+#   from ONE artifact (the vCluster HR / namespace) and never read back the plan
+#   ResourceQuota + LimitRange or the per-Org console Gateway listener pair — so
+#   gamma-corp reported Ready/Active with all 6 HTTPRoutes
+#   Accepted=False:NoMatchingListenerHostname and no cap on its namespace. The
+#   verifier holds BOTH status.vcluster.phase and the Ready condition back
+#   (reason=ProvisioningIncomplete) naming the missing artifact, and keeps the 30s
+#   requeue alive so the up-path re-converges. Read-only — Flux still owns the
+#   apply. Refs #5395.
+version: 1.4.1227
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
@@ -122,6 +122,23 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
+  # #5395: the controller VERIFIES ITS OWN POSTCONDITIONS before reporting an
+  # Organization Ready (provisioning_postconditions.go). Two of the artifacts it
+  # authors into the per-Org repo land as plain core/v1 objects in the `<slug>`
+  # boundary namespace — the plan `plan-quota` ResourceQuota and the
+  # `plan-limits` LimitRange — and until this grant nothing ever read them back,
+  # so an Org whose boundary tree was never applied by Flux still reported
+  # Ready=True with no cap on the namespace the customer paid for.
+  # Read-only: the manifests are authored in Git and applied by Flux; the
+  # controller only reads them back to decide whether its own work landed.
+  #
+  # A missing grant here is NOT interpreted as a missing artifact — the verifier
+  # separates NotFound (evidence of absence) from any other read error
+  # (unverifiable), so a partially-rolled-out RBAC cannot red-flag every
+  # Organization on the Sovereign at once.
+  - apiGroups: [""]
+    resources: ["resourcequotas", "limitranges"]
+    verbs: ["get", "list", "watch"]
   # Issue #4077: the controller find-or-creates the parent Environment CR
   # (`<slug>-<envType>`) once the Org's vCluster is Ready, so Applications
   # installed into the Org resolve their Environment instead of wedging at


### PR DESCRIPTION
## Problem

An Organization can finish provisioning with its console Gateway listener pair and/or its plan `ResourceQuota` absent and **still report Ready/Active on every status surface**. Live on hw290: `gamma-corp` read green while all six of its HTTPRoutes sat `Accepted=False reason=NoMatchingListenerHostname` — `console.` / `agenity.` / `keycloak.` / `mail.` / `openclaw.` / `wordpress.gamma-corp.omani.homes` all unreachable — and its boundary namespace carried no `plan-quota`. Nothing surfaced an error anywhere.

## Root cause — the file:line chain

`Reconcile` authors a **set** of artifacts but derived readiness from exactly **one** of them.

| # | Path | What it does |
|---|---|---|
| 1 | `core/controllers/organization/internal/controller/organization_controller.go:1022` `vclusterReadiness` | Reads back the vCluster HelmRelease + the `<slug>` Namespace and **nothing else**. Line 1039: a host-tier Org is Ready as soon as the namespace exists. This is the sole input to `readyCond` (line 863) and `status.vcluster.phase`. |
| 2 | `organization_controller.go:956` `reconcileConsoleServing` | Runs the pool-DNS / console-TLS / HTTPRoute trio best-effort. Its only output is `degraded bool`, which feeds the requeue at line 937 and **never reaches `status`**. A permanent failure loops silently forever. |
| 3 | `tenant_console_tls.go:370` `ensureConsoleOrgListener` | On console-Gateway `NotFound` it `return false, nil` — **indistinguishable from success**. `degraded` stays false, the Org goes Ready, `Reconcile` returns `ctrl.Result{}` (no requeue), and `SetupWithManager` (`organization_controller.go:380`) registers **no watch on the Gateway**. The Org never looks again. |
| 4 | `internal/gitops/manifests.go` `Render` → `vcluster/resourcequota.yaml` + `vcluster/limitrange.yaml` | Authored into the per-Org Gitea repo, applied by Flux via `catalyst-tenant-<slug>-vcluster`. Whether they ever landed was **never read back at all**. |
| 5 | `products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go:211` `orgStateFromCR` | Maps `status.vcluster.phase == "Ready"` → `STSDone` **before** it ever looks at the Ready condition. So the phase, not the condition, is what renders the Active badge. |

So (1) reports green while (2)/(3)/(4) are silently absent, and (5) shows that green to the operator.

## Are the two omissions the same cause?

**Partly — same silent-success property, different mechanisms.** Worth knowing:

- **Symptom A (listener)** is a genuine defect: paths 2 + 3 above make a failed or skipped listener append unobservable and, in the `NotFound` case, un-retried.
- **Symptom B (quota)** is more likely *correct behavior that is indistinguishable from a failure*. The **only** code path that yields no `ResourceQuota` is `planSlug == "flexi"` (`manifests.go` `planQuotaTable` — Flexi is `Burstable: true`, and `Render` skips `resourcequota.yaml` for it). Every other slug — including `""`, `free`, and anything unknown — falls back to `"s"` and gets a quota. Read against the live data: 4-CPU = M, 2-CPU = S, absent = Flexi is fully consistent.

**One command settles it**, and this PR makes it a first-class signal: the `plan-limits` **LimitRange** is rendered for **every** plan including Flexi. So on hw290:

```
kubectl -n gamma-corp get limitrange plan-limits
```

- **present** → gamma-corp is Flexi; no quota is correct, and this PR keeps it green while making the reasoning explicit.
- **absent** → the boundary tree never landed; this PR now reports that loudly.

## Fix — verify, don't retry

New `core/controllers/organization/internal/controller/provisioning_postconditions.go`. `verifyProvisioned` reads back what the controller claims to have provisioned:

1. `plan-limits` LimitRange in `<slug>` — expected for every plan.
2. `plan-quota` ResourceQuota in `<slug>` — expected only where `gitops.PlanRendersResourceQuota` is true.
3. The `console-https-<sub>` / `console-http-<sub>` listener pair on the console Gateway — only for an Org with a pool `parentDomain`.

A proven-absent artifact holds back **both** `status.vcluster.phase` **and** the Ready condition, which goes `False / ProvisioningIncomplete` with a message naming exactly what is missing. Holding the phase is load-bearing per (5) above — downgrading the condition alone would have left the operator-visible state green.

A retry alone was rejected deliberately: it would keep re-appending the listener while the Org still read Active, so a permanent failure stayed invisible. Naming the missing artifact is the fix; the 30s requeue follows from it — and because a non-empty result is what keeps the requeue alive, this also closes the drift hole in path 3 (a Ready Org with no Gateway watch that loses its listener to an external rewrite now re-converges instead of sitting silently broken).

`ensureEnvironment` stays gated on `vcReady`, **not** on the postconditions, so an Org with a broken console edge still gets its Environment — a status fix must not become a functional regression for the app-install path.

### Coherence, without touching sizing

- `gitops.PlanRendersResourceQuota` exports the `!Burstable` gate, and `Render` now calls it, so the renderer and the verifier make the decision through one predicate.
- `BoundaryResourceQuotaName` / `BoundaryLimitRangeName` replace the string literals in the templates (interpolated via `renderView`), so a rename can never leave the verifier probing a name nothing writes.
- The **size** of any cap is untouched. Whether vCluster control-plane overhead should count against the customer's plan is a product decision, not a code change — Refs #5393.

### Evidence of absence, not absence of evidence

Only an explicit `NotFound` counts as missing. Any other read error (RBAC mid-rollout, apiserver blip, absent CRD) lands in `Unverifiable`: it logs and requeues but never downgrades the Org. Otherwise one botched RBAC rollout would red-flag every Organization on the Sovereign simultaneously.

## Negative proof

Required by the ticket, and it earned its keep. Reverting just the wiring (`postconditions = r.verifyProvisioned(...)` → discard the result) reproduces the exact hw290 shape:

```
--- FAIL: TestReconcile_5395_ConsoleListenerMissing_MustNotReadReady
    an Org whose console listener pair is absent must NOT read Ready=True —
    got {Type:Ready Status:True Reason:Reconciled
         Message:vCluster HelmRelease Ready + Keycloak group + Gitea Org reconciled}
    status.vcluster.phase must not read Ready while the console edge is missing
--- FAIL: TestReconcile_5395_SilentListenerSkip_MustNotReadReady
    a silently-skipped listener append must NOT leave the Org reading Ready=True
    the silent-skip path reports no degradation, so the postcondition is the ONLY
    thing that can keep the retry alive — got {false 0s}
--- FAIL: TestReconcile_5395_HardCappedPlanWithoutQuota_MustNotReadReady
    a hard-capped Org with no ResourceQuota must NOT read Ready=True
--- FAIL: TestReconcile_5395_FlexiWithoutQuotaIsNotAGap
    a Flexi Org missing the always-rendered LimitRange IS a delivery gap
```

Note `{false 0s}` on the silent-skip case: pre-fix that Org was green **with no requeue at all** — permanently broken, permanently green. Restored, all pass.

Six tests in `provisioning_postconditions_5395_test.go`, each paired with its converse so none can be satisfied by a check that never goes green:

- listener absent (write conflict) → not Ready + requeue
- listener silently skipped (Gateway absent) → not Ready + requeue
- listener appended → Ready, no requeue, **and the pair is really on the Gateway**, apex preserved
- hard-capped plan, no quota → not Ready
- Flexi, no quota → **Ready** (by design); Flexi with no LimitRange → not Ready, and never reported as missing a quota it should not have
- unreadable probe → `Unverifiable`, never `Missing`
- no `parentDomain` → console check skipped entirely

`TestReconcile_ReadyOnlyWhenVClusterHRReady` now seeds the boundary objects — its "fully provisioned" fixture has to actually be fully provisioned.

## Chart

ClusterRole gains read-only `resourcequotas` + `limitranges` (Flux still owns the apply). `products/catalyst/chart` 1.4.1226 → 1.4.1227 with the bootstrap-kit slot-13 pin in lockstep. bp-catalyst-platform has no `blueprint.yaml` and its catalog-seed entry renders `.Chart.Version`, so those two sites are self-maintaining.

## Gates

- `go build ./...`, `go vet ./...`, `go test -count=1 ./...` — green across all of `core/controllers`
- `gofmt` clean on every touched file (`iac_bootstrap_test.go` + `tenant_deleted_emit_5364_test.go` are unformatted on `main` and untouched here)
- `cd tests/e2e/bootstrap-kit && go test -count=1 ./...` — ok
- `scripts/check-bootstrap-kit-pin-sync.sh` — `bp-catalyst-platform: chart=1.4.1227 pin=1.4.1227`, 67/67 in sync
- `scripts/check-chart-annotations.sh` — GUARD 1 + GUARD 2 pass, 10873-line render
- `helm template` confirms the new ClusterRole rule renders

No cluster was touched. No NodePorts.

Refs #5395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
