### PR TITLE
test(console): restore the vitest gate — 68 red → 8, each remaining failure a verified defect (Refs #5404)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/PinInput6.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/PinInput6.test.tsx
@@ -1,16 +1,36 @@
 /**
  * PinInput6.test.tsx — paste-friendly 6-digit PIN input (issue #688).
  *
- * What we assert:
- *   - Typing one digit per box auto-advances focus.
- *   - Pasting "123456" anywhere splits across all 6 boxes.
+ * ARCHITECTURE NOTE (why this file was migrated — #5404)
+ * -----------------------------------------------------
+ * PinInput6 was re-architected (see the docblock at PinInput6.tsx:1-31,
+ * founder rule "paste must just work" 2026-05-04) from *6 real inputs*
+ * to **ONE real `<input maxLength=6>` overlaid on 6 DECORATIVE boxes**:
+ *
+ *   - `pin-box-input` is the only focusable/editable element. Every
+ *     keystroke, deletion and paste flows through it (PinInput6.tsx:161-187).
+ *   - `pin-box-{0..5}` are `<div>`s that MIRROR the digits — they render
+ *     `{digit}` as text (PinInput6.tsx:149) and carry
+ *     `aria-label="Digit N: <digit|empty>"` (PinInput6.tsx:133). They have
+ *     no `.value` and no `.disabled`.
+ *
+ * So the assertions below read box **text**, not `.value`, and drive all
+ * interaction through the single overlay input.
+ *
+ * What we assert (the behaviours the original file was written to protect):
+ *   - Typing a digit mirrors into the box and advances the "next-to-fill"
+ *     highlight (the surviving expression of the old auto-advance).
+ *   - Pasting "123456" anywhere on the row fills all 6 boxes.
  *   - Pasting "Your code is 372 458." extracts only the digits.
  *   - Pasting more than 6 digits keeps only the first 6.
  *   - Pasting alphanumerics drops the letters.
- *   - Backspace on an empty box steps back; on a filled box clears.
- *   - Enter submits when all 6 boxes are filled.
+ *   - Deleting (Backspace) clears the last digit and steps the highlight back.
+ *   - Enter does NOT double-fire onComplete — submission is the parent
+ *     form's job now (VerifyPinPage.tsx:245-252, PinSignInModal.tsx:369).
  *   - onComplete fires once on the 6th digit.
- *   - Initial focus lands on the first box when autoFocus is true.
+ *   - Initial focus lands on the overlay input when autoFocus is true.
+ *   - Clicking any decorative box focuses the overlay input.
+ *   - disabled marks the real input disabled and skips auto-focus.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
@@ -19,12 +39,48 @@ import { PinInput6 } from './PinInput6'
 
 afterEach(() => cleanup())
 
-function getBoxes(): HTMLInputElement[] {
-  const out: HTMLInputElement[] = []
+/** The 6 decorative mirror boxes (divs — no value/disabled of their own). */
+function getBoxes(): HTMLElement[] {
+  const out: HTMLElement[] = []
   for (let i = 0; i < 6; i += 1) {
-    out.push(screen.getByTestId(`pin-box-${i}`) as HTMLInputElement)
+    out.push(screen.getByTestId(`pin-box-${i}`))
   }
   return out
+}
+
+/** Digits currently rendered by the 6 mirror boxes. */
+function boxDigits(): string[] {
+  return getBoxes().map((b) => b.textContent ?? '')
+}
+
+/** The single real input that owns every keystroke + paste. */
+function overlayInput(): HTMLInputElement {
+  return screen.getByTestId('pin-box-input') as HTMLInputElement
+}
+
+/**
+ * Index of the box carrying the "next-to-fill" ring, or -1.
+ *
+ * PinInput6.tsx:128 computes `isActive = !disabled && pin.length === i`
+ * and line 143 renders it as `ring-[3px]`. With one shared input there is
+ * no per-box DOM focus any more, so this ring IS the auto-advance the
+ * original test asserted via `document.activeElement`.
+ */
+function activeBoxIndex(): number {
+  return getBoxes().findIndex((b) => b.className.includes('ring-[3px]'))
+}
+
+/**
+ * Simulate what the browser does on paste (or on any native edit).
+ *
+ * PinInput6 deliberately has NO paste handler (PinInput6.tsx:16-27): the
+ * browser writes the pasted text into the ONE real input itself and React
+ * sees exactly one `change`. Firing a synthetic `paste` event would be a
+ * no-op against this component, so the faithful simulation of the shipped
+ * design is the `change` the browser produces.
+ */
+function nativeEdit(value: string) {
+  fireEvent.change(overlayInput(), { target: { value } })
 }
 
 describe('PinInput6 — typing', () => {
@@ -37,38 +93,74 @@ describe('PinInput6 — typing', () => {
     expect(input.getAttribute('maxlength')).toBe('6')
   })
 
+  it('the decorative boxes are not inputs — the overlay input is the only editable element', () => {
+    render(<PinInput6 />)
+    // Guards the re-architecture at PinInput6.tsx:117-152: if a box ever
+    // becomes an <input> again the single-input paste contract is broken.
+    for (const b of getBoxes()) {
+      expect(b.tagName).toBe('DIV')
+    }
+    expect(overlayInput().tagName).toBe('INPUT')
+  })
+
   it('auto-focuses the overlay input on mount', () => {
     render(<PinInput6 />)
     const input = screen.getByTestId('pin-box-input') as HTMLInputElement
     expect(document.activeElement).toBe(input)
   })
 
-  it('typing a digit advances focus to the next box', () => {
+  it('typing a digit mirrors it into box 0 and advances the next-to-fill box', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    fireEvent.change(boxes[0], { target: { value: '3' } })
-    expect(boxes[0].value).toBe('3')
-    expect(document.activeElement).toBe(boxes[1])
+    expect(activeBoxIndex()).toBe(0)
+    nativeEdit('3')
+    expect(boxDigits()).toEqual(['3', '', '', '', '', ''])
+    // Old design moved DOM focus to box 1; new design keeps focus on the
+    // single input and moves the next-to-fill ring instead.
+    expect(activeBoxIndex()).toBe(1)
+    expect(document.activeElement).toBe(overlayInput())
+  })
+
+  it('exposes each digit on the mirror box aria-label', () => {
+    render(<PinInput6 />)
+    nativeEdit('37')
+    // PinInput6.tsx:133 — the boxes are the accessible surface since the
+    // overlay input is visually hidden.
+    expect(getBoxes()[0].getAttribute('aria-label')).toBe('Digit 1: 3')
+    expect(getBoxes()[1].getAttribute('aria-label')).toBe('Digit 2: 7')
+    expect(getBoxes()[2].getAttribute('aria-label')).toBe('Digit 3: empty')
   })
 
   it('typing a non-digit is dropped', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    // onChange is the path we filter — letters are stripped before set.
-    fireEvent.change(boxes[0], { target: { value: 'a' } })
-    expect(boxes[0].value).toBe('')
+    // extractDigits (PinInput6.tsx:45-47) filters in handleChange:102.
+    nativeEdit('a')
+    expect(boxDigits()).toEqual(['', '', '', '', '', ''])
+    expect(overlayInput().value).toBe('')
   })
 
-  it('Backspace on empty box steps back to the previous box', () => {
+  it('Backspace clears the last digit and steps the next-to-fill box back', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    fireEvent.change(boxes[0], { target: { value: '3' } })
-    fireEvent.change(boxes[1], { target: { value: '7' } })
-    expect(document.activeElement).toBe(boxes[2])
-    // boxes[2] is empty — backspace should step back to boxes[1] and clear.
-    fireEvent.keyDown(boxes[2], { key: 'Backspace' })
-    expect(document.activeElement).toBe(boxes[1])
-    expect(boxes[1].value).toBe('')
+    nativeEdit('3')
+    nativeEdit('37')
+    expect(activeBoxIndex()).toBe(2)
+    // The overlay input owns deletion natively: Backspace at the end of the
+    // value drops the last character and fires `input`. jsdom implements no
+    // native editing, so we hand it the value the browser would produce and
+    // assert the component's response.
+    nativeEdit('3')
+    expect(boxDigits()).toEqual(['3', '', '', '', '', ''])
+    expect(activeBoxIndex()).toBe(1)
+  })
+
+  it('clicking a decorative box focuses the overlay input', () => {
+    render(<PinInput6 />)
+    const input = overlayInput()
+    input.blur()
+    expect(document.activeElement).not.toBe(input)
+    // PinInput6.tsx:122 — onClick={focusInput} on the wrapper; clicks on any
+    // box bubble to it (PinInput6.tsx:10, 106-113).
+    fireEvent.click(getBoxes()[3])
+    expect(document.activeElement).toBe(input)
   })
 })
 
@@ -76,70 +168,55 @@ describe('PinInput6 — paste', () => {
   it('pasting "123456" fills all 6 boxes', () => {
     const onComplete = vi.fn()
     render(<PinInput6 onComplete={onComplete} />)
-    const boxes = getBoxes()
-    fireEvent.paste(boxes[0], {
-      clipboardData: {
-        getData: () => '123456',
-      },
-    })
-    expect(boxes.map((b) => b.value)).toEqual(['1', '2', '3', '4', '5', '6'])
+    nativeEdit('123456')
+    expect(boxDigits()).toEqual(['1', '2', '3', '4', '5', '6'])
     expect(onComplete).toHaveBeenCalledWith('123456')
   })
 
+  // ⚠️ BROWSER CAVEAT for the three "noisy paste" cases below.
+  // The overlay input carries maxLength={6} (PinInput6.tsx:167). Real
+  // browsers truncate pasted text to maxlength BEFORE firing `input`, so in
+  // Chrome/Firefox "Your code is 372 458." arrives as "Your c" and no digits
+  // land. jsdom does not enforce maxlength, so these tests pin the
+  // component's extraction contract (extractDigits PinInput6.tsx:45-47 +
+  // handleChange:102) — which is exactly the logic that exists to serve
+  // these cases — and NOT the end-to-end browser paste. Reported as a
+  // separate defect; the cap is redundant (the input is controlled by `pin`,
+  // already sliced to 6 at line 102), so the fix is to drop maxLength.
   it('pasting "Your code is 372 458." extracts the digits only', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    fireEvent.paste(boxes[0], {
-      clipboardData: {
-        getData: () => 'Your code is 372 458.',
-      },
-    })
-    expect(boxes.map((b) => b.value)).toEqual(['3', '7', '2', '4', '5', '8'])
+    nativeEdit('Your code is 372 458.')
+    expect(boxDigits()).toEqual(['3', '7', '2', '4', '5', '8'])
   })
 
   it('pasting 7+ digits keeps only the first 6', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    fireEvent.paste(boxes[0], {
-      clipboardData: {
-        getData: () => '1234567890',
-      },
-    })
-    expect(boxes.map((b) => b.value)).toEqual(['1', '2', '3', '4', '5', '6'])
+    nativeEdit('1234567890')
+    expect(boxDigits()).toEqual(['1', '2', '3', '4', '5', '6'])
   })
 
   it('pasting alphanumerics extracts only digits', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    fireEvent.paste(boxes[0], {
-      clipboardData: {
-        getData: () => 'abc1d2e3-XX4Y5Z6',
-      },
-    })
-    expect(boxes.map((b) => b.value)).toEqual(['1', '2', '3', '4', '5', '6'])
+    nativeEdit('abc1d2e3-XX4Y5Z6')
+    expect(boxDigits()).toEqual(['1', '2', '3', '4', '5', '6'])
   })
 
   it('pasting fewer than 6 digits fills from the left and stops', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    fireEvent.paste(boxes[0], {
-      clipboardData: {
-        getData: () => '372',
-      },
-    })
-    expect(boxes.map((b) => b.value)).toEqual(['3', '7', '2', '', '', ''])
+    nativeEdit('372')
+    expect(boxDigits()).toEqual(['3', '7', '2', '', '', ''])
+    expect(activeBoxIndex()).toBe(3)
   })
 
-  it('paste anywhere on the row (not just first box) still distributes from box 0', () => {
+  it('paste anywhere on the row (not just the first box) still distributes from box 0', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    // Paste while box 3 has focus — should still spread from index 0.
-    fireEvent.paste(boxes[3], {
-      clipboardData: {
-        getData: () => '123456',
-      },
-    })
-    expect(boxes.map((b) => b.value)).toEqual(['1', '2', '3', '4', '5', '6'])
+    // Old design: 6 inputs, so a paste could land on box 3. New design: any
+    // click on the row focuses the ONE input (PinInput6.tsx:122), so the
+    // paste always lands there and always fills from index 0.
+    fireEvent.click(getBoxes()[3])
+    expect(document.activeElement).toBe(overlayInput())
+    nativeEdit('123456')
+    expect(boxDigits()).toEqual(['1', '2', '3', '4', '5', '6'])
   })
 })
 
@@ -147,34 +224,34 @@ describe('PinInput6 — submit', () => {
   it('onComplete fires once when the 6th digit lands via typing', () => {
     const onComplete = vi.fn()
     render(<PinInput6 onComplete={onComplete} />)
-    const boxes = getBoxes()
     const digits = ['3', '7', '2', '4', '5', '8']
-    digits.forEach((d, i) => {
-      fireEvent.change(boxes[i], { target: { value: d } })
+    digits.forEach((_, i) => {
+      nativeEdit(digits.slice(0, i + 1).join(''))
     })
     expect(onComplete).toHaveBeenCalledWith('372458')
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
-  it('Enter on a filled row triggers onComplete', () => {
+  it('Enter on a filled row does not re-fire onComplete (the parent form submits)', () => {
     const onComplete = vi.fn()
     render(<PinInput6 onComplete={onComplete} />)
-    const boxes = getBoxes()
-    const digits = ['3', '7', '2', '4', '5', '8']
-    digits.forEach((d, i) => {
-      fireEvent.change(boxes[i], { target: { value: d } })
-    })
-    onComplete.mockClear()
-    fireEvent.keyDown(boxes[5], { key: 'Enter' })
+    nativeEdit('372458')
     expect(onComplete).toHaveBeenCalledWith('372458')
+    onComplete.mockClear()
+    // PinInput6 has no key handler at all any more — it is presentational
+    // (PinInput6.tsx:29-30, INVIOLABLE #4). Enter-to-submit now comes from
+    // the wrapping <form> in the consumers (VerifyPinPage.tsx:245-252,
+    // PinSignInModal.tsx:369-454), so the component must NOT fire a second
+    // onComplete — a one-time PIN double-submit would be a real bug.
+    fireEvent.keyDown(overlayInput(), { key: 'Enter' })
+    expect(onComplete).not.toHaveBeenCalled()
   })
 
   it('onChange fires on every keystroke with the joined value', () => {
     const onChange = vi.fn()
     render(<PinInput6 onChange={onChange} />)
-    const boxes = getBoxes()
-    fireEvent.change(boxes[0], { target: { value: '3' } })
-    fireEvent.change(boxes[1], { target: { value: '7' } })
+    nativeEdit('3')
+    nativeEdit('37')
     // initial mount fires onChange once with empty string
     expect(onChange).toHaveBeenCalledWith('')
     expect(onChange).toHaveBeenCalledWith('3')
@@ -185,24 +262,29 @@ describe('PinInput6 — submit', () => {
 describe('PinInput6 — controlled-ish initial value', () => {
   it('respects the value prop on initial render', () => {
     render(<PinInput6 value="372458" />)
-    const boxes = getBoxes()
-    expect(boxes.map((b) => b.value)).toEqual(['3', '7', '2', '4', '5', '8'])
+    expect(boxDigits()).toEqual(['3', '7', '2', '4', '5', '8'])
+    expect(overlayInput().value).toBe('372458')
   })
 
   it('strips non-digits in the value prop', () => {
     render(<PinInput6 value="3-7-2 458" />)
-    const boxes = getBoxes()
-    expect(boxes.map((b) => b.value)).toEqual(['3', '7', '2', '4', '5', '8'])
+    expect(boxDigits()).toEqual(['3', '7', '2', '4', '5', '8'])
   })
 })
 
 describe('PinInput6 — disabled', () => {
-  it('marks all boxes disabled and skips auto-focus', () => {
+  it('disables the overlay input, dims every box and skips auto-focus', () => {
     render(<PinInput6 disabled />)
-    const boxes = getBoxes()
-    for (const b of boxes) {
-      expect(b.disabled).toBe(true)
+    // The real control is the single overlay input (PinInput6.tsx:170).
+    const input = overlayInput()
+    expect(input.disabled).toBe(true)
+    // The boxes express disabled as the dimmed style (PinInput6.tsx:146)
+    // and drop the next-to-fill ring (PinInput6.tsx:128 `!disabled && …`).
+    for (const b of getBoxes()) {
+      expect(b.className).toContain('opacity-50')
     }
-    expect(document.activeElement).not.toBe(boxes[0])
+    expect(activeBoxIndex()).toBe(-1)
+    // autoFocus is skipped while disabled (PinInput6.tsx:79).
+    expect(document.activeElement).not.toBe(input)
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsPage.test.tsx
@@ -10,10 +10,73 @@
 
 import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
 import { ParentDomainsPage } from './ParentDomainsPage'
 import type { ParentDomain } from './parentDomains.api'
 
 afterEach(cleanup)
+
+/**
+ * Harness — since #4093 (commit e8dd34764) ParentDomainsPage is a thin
+ * PortalShell wrapper around ParentDomainsSection. That pulls in two
+ * context dependencies the original standalone-render harness never had:
+ *
+ *   • TanStack Router — PortalShell renders Sidebar, which calls
+ *     useRouterState + <Link> (Sidebar.tsx:154, :210).
+ *   • TanStack Query  — ParentDomainsPage calls useResolvedDeploymentId
+ *     (useQuery), and PortalShell renders ReadinessChip (#3935,
+ *     ReadinessChip.tsx:149, also useQuery).
+ *
+ * src/main.tsx:69 wraps the real app in a QueryClientProvider; this
+ * mirrors it. Every assertion below is unchanged — the harness moved,
+ * not the contract.
+ */
+function renderPage(props: { initialItems: ParentDomain[] }) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const domainsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/organizations/domains',
+    component: () => <ParentDomainsPage initialItems={props.initialItems} disableFetch />,
+  })
+  // Sidebar <Link> targets — registered so href resolution works.
+  const stub = (path: string) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path,
+      component: () => <div />,
+    })
+  const tree = rootRoute.addChildren([
+    domainsRoute,
+    stub('/provision/$deploymentId'),
+    stub('/provision/$deploymentId/dashboard'),
+    stub('/provision/$deploymentId/jobs'),
+    stub('/provision/$deploymentId/cloud'),
+    stub('/provision/$deploymentId/settings'),
+    stub('/provision/$deploymentId/users'),
+  ])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({
+      initialEntries: ['/provision/d-test-1234/organizations/domains'],
+    }),
+  })
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
 
 const sampleItems: ParentDomain[] = [
   {
@@ -33,16 +96,16 @@ const sampleItems: ParentDomain[] = [
 ]
 
 describe('ParentDomainsPage', () => {
-  it('renders the empty state when items list is empty', () => {
-    render(<ParentDomainsPage initialItems={[]} disableFetch />)
-    expect(screen.getByTestId('parent-domains-page')).toBeTruthy()
+  it('renders the empty state when items list is empty', async () => {
+    renderPage({ initialItems: [] })
+    expect(await screen.findByTestId('parent-domains-page')).toBeTruthy()
     expect(screen.getByTestId('parent-domains-empty')).toBeTruthy()
     expect(screen.getByTestId('parent-domains-add-cta')).toBeTruthy()
   })
 
-  it('renders one row per item with role + status badges', () => {
-    render(<ParentDomainsPage initialItems={sampleItems} disableFetch />)
-    expect(screen.getByTestId('parent-domain-row-omani.works')).toBeTruthy()
+  it('renders one row per item with role + status badges', async () => {
+    renderPage({ initialItems: sampleItems })
+    expect(await screen.findByTestId('parent-domain-row-omani.works')).toBeTruthy()
     expect(screen.getByTestId('parent-domain-row-omani.trade')).toBeTruthy()
     expect(screen.getByTestId('parent-domain-role-omani.works').textContent).toContain('primary')
     expect(screen.getByTestId('parent-domain-role-omani.trade').textContent).toContain('org-pool')
@@ -50,15 +113,15 @@ describe('ParentDomainsPage', () => {
     expect(screen.getByTestId('parent-domain-status-omani.trade').textContent).toContain('Flipping')
   })
 
-  it('locks delete on the primary row', () => {
-    render(<ParentDomainsPage initialItems={sampleItems} disableFetch />)
+  it('locks delete on the primary row', async () => {
+    renderPage({ initialItems: sampleItems })
+    expect(await screen.findByTestId('parent-domain-delete-omani.trade')).toBeTruthy()
     expect(screen.queryByTestId('parent-domain-delete-omani.works')).toBeNull()
-    expect(screen.getByTestId('parent-domain-delete-omani.trade')).toBeTruthy()
   })
 
-  it('opens the add-domain modal on CTA click', () => {
-    render(<ParentDomainsPage initialItems={[]} disableFetch />)
-    fireEvent.click(screen.getByTestId('parent-domains-add-cta'))
+  it('opens the add-domain modal on CTA click', async () => {
+    renderPage({ initialItems: [] })
+    fireEvent.click(await screen.findByTestId('parent-domains-add-cta'))
     expect(screen.getByTestId('add-domain-modal')).toBeTruthy()
     expect(screen.getByTestId('add-domain-name')).toBeTruthy()
     expect(screen.getByTestId('add-domain-role')).toBeTruthy()
@@ -67,16 +130,17 @@ describe('ParentDomainsPage', () => {
     expect(screen.getByTestId('add-domain-submit')).toBeTruthy()
   })
 
-  it('expands the propagation drawer on row toggle', () => {
-    render(<ParentDomainsPage initialItems={sampleItems} disableFetch />)
+  it('expands the propagation drawer on row toggle', async () => {
+    renderPage({ initialItems: sampleItems })
+    const toggle = await screen.findByTestId('parent-domain-toggle-omani.trade')
     expect(screen.queryByTestId('parent-domain-drawer-omani.trade')).toBeNull()
-    fireEvent.click(screen.getByTestId('parent-domain-toggle-omani.trade'))
+    fireEvent.click(toggle)
     expect(screen.getByTestId('parent-domain-drawer-omani.trade')).toBeTruthy()
   })
 
-  it('renders the propagation panel with disabled polling for tests', () => {
-    render(<ParentDomainsPage initialItems={sampleItems} disableFetch />)
-    fireEvent.click(screen.getByTestId('parent-domain-toggle-omani.trade'))
+  it('renders the propagation panel with disabled polling for tests', async () => {
+    renderPage({ initialItems: sampleItems })
+    fireEvent.click(await screen.findByTestId('parent-domain-toggle-omani.trade'))
     // disablePolling propagated to PropagationPanel — null result means
     // the panel rendered but didn't fire the network call.
     expect(screen.getByTestId('parent-domain-drawer-omani.trade')).toBeTruthy()

--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.test.tsx
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   RouterProvider,
   createRouter,
@@ -66,7 +67,17 @@ function renderEdit(opts: RenderOpts) {
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: [opts.path] }),
   })
-  return render(<RouterProvider router={router} />)
+  // UserAccessEditPage mounts PortalShell, whose ReadinessChip (#3935)
+  // and useResolvedDeploymentId are TanStack-Query consumers. Mirror the
+  // src/main.tsx QueryClientProvider so the shell can render at all.
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
 }
 
 afterEach(() => cleanup())

--- a/products/catalyst/bootstrap/ui/src/pages/provision/ProvisionPage.sse-url.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/provision/ProvisionPage.sse-url.test.tsx
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   RouterProvider,
   createRouter,
@@ -89,7 +90,18 @@ function renderProvision(deploymentId: string) {
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}`] }),
   })
-  return render(<RouterProvider router={router} />)
+  // ProvisionPage (== AppsPage) mounts PortalShell, whose ReadinessChip
+  // (#3935) and useResolvedDeploymentId are TanStack-Query consumers.
+  // src/main.tsx wraps the app in a QueryClientProvider; the harness must
+  // do the same or the shell throws before the SSE effect ever fires.
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
 }
 
 beforeEach(() => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
@@ -50,11 +50,6 @@ function renderJobs(deploymentId: string) {
     path: '/provision/$deploymentId/jobs/$jobId',
     component: () => <div data-testid="job-detail-target" />,
   })
-  const flowRoute = createRoute({
-    getParentRoute: () => rootRoute,
-    path: '/provision/$deploymentId/flow',
-    component: () => <div data-testid="flow-target" />,
-  })
   const wizardRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/wizard',
@@ -65,7 +60,6 @@ function renderJobs(deploymentId: string) {
     homeRoute,
     detailRoute,
     jobDetailRoute,
-    flowRoute,
     wizardRoute,
   ])
   const router = createRouter({
@@ -199,7 +193,20 @@ describe('JobsPage — batches concept removed (issue #351)', () => {
   })
 })
 
-describe('JobsPage — v3 routing (no Tab strip, has Show-as-Flow button)', () => {
+// #3701 ("one honest /jobs canvas", Refs #3646) retired the Flow view of
+// /jobs: it dropped `flowJobs` / `synthesizeJobFromFlowNode` as a list
+// source (JobsPage.tsx:32-33), deleted JobsPage.flow-merge.test.tsx, and
+// removed the "Show as Flow" line from the JobsPage docblock. The tab
+// strip went with it. What survives is the single table canvas.
+//
+// The former 'exposes a "Show as Flow" button that navigates to /flow'
+// case is deleted rather than repaired: `sov-jobs-show-as-flow` was only
+// ever added to THIS test file (git log -S over src/ matches the test and
+// nothing else), and `/provision/$deploymentId/flow` is not a route in
+// src/app/router.tsx — the test stood up a private flowRoute in its own
+// harness to make the target exist. Adding the button to satisfy it would
+// ship a link to a 404.
+describe('JobsPage — v3 routing (single table canvas, no Tab strip)', () => {
   it('does NOT render a jobs-view-tabs strip', async () => {
     renderJobs('d-1')
     await screen.findByTestId('jobs-table')
@@ -208,11 +215,9 @@ describe('JobsPage — v3 routing (no Tab strip, has Show-as-Flow button)', () =
     expect(screen.queryByTestId('jobs-view-tab-flow')).toBeNull()
   })
 
-  it('exposes a "Show as Flow" button that navigates to /flow', async () => {
+  it('does NOT offer a Flow affordance (retired by #3701)', async () => {
     renderJobs('d-1')
-    const btn = await screen.findByTestId('sov-jobs-show-as-flow') as HTMLAnchorElement
-    expect(btn.tagName.toLowerCase()).toBe('a')
-    const href = btn.getAttribute('href') ?? ''
-    expect(href).toMatch(/^\/provision\/d-1\/flow/)
+    await screen.findByTestId('jobs-table')
+    expect(screen.queryByTestId('sov-jobs-show-as-flow')).toBeNull()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.test.tsx
@@ -21,6 +21,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   RouterProvider,
   createRouter,
@@ -94,11 +95,47 @@ function renderSettings(deploymentId: string, initialPath?: string) {
       initialEntries: [initialPath ?? `/provision/${deploymentId}/settings`],
     }),
   })
-  return render(<RouterProvider router={router} />)
+  // SettingsPage mounts PortalShell (→ ReadinessChip, #3935) and calls
+  // useResolvedDeploymentId — both are TanStack-Query consumers, so the
+  // harness must supply a QueryClient exactly as src/main.tsx does.
+  // Retries off + gcTime 0 so a failing stub fetch never stalls the test.
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
 }
 
 beforeEach(() => {
   useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  // jsdom doesn't ship EventSource. The page's own SSE attach is off via
+  // `disableStream`, but the #settings-sovereign section renders
+  // <SovereigntyCard /> (SettingsPage.tsx:451), whose useCutoverEvents
+  // opens its own stream (SovereigntyCard.tsx:77 → useCutoverEvents.ts:278)
+  // — that seam is `override`, not `disableStream`, so the shell needs a
+  // shim. Same stub the hook's own suite installs
+  // (useCutoverEvents.test.tsx:31-52).
+  if (typeof (globalThis as unknown as { EventSource?: unknown }).EventSource === 'undefined') {
+    class StubEventSource {
+      url: string
+      readyState = 0
+      onopen: ((this: EventSource, ev: Event) => unknown) | null = null
+      onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null
+      onerror: ((this: EventSource, ev: Event) => unknown) | null = null
+      static readonly CLOSED = 2
+      constructor(url: string) {
+        this.url = url
+      }
+      addEventListener(): void {}
+      removeEventListener(): void {}
+      close(): void {}
+    }
+    ;(globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+      StubEventSource as unknown as typeof EventSource
+  }
   // Prevent the snapshot fetch from polluting the test by serving an
   // empty events response with no terminal state. This isolates the
   // test from the network and lets us assert "no FQDN yet" rendering.
@@ -111,6 +148,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  delete (globalThis as unknown as { EventSource?: unknown }).EventSource
 })
 
 const ALL_SECTIONS = [
@@ -208,6 +246,39 @@ describe('SettingsPage — API tokens', () => {
 })
 
 describe('SettingsPage — Members links to User Access', () => {
+  /**
+   * 🛑 KNOWN-FAILING — this is a REAL defect, not a stale expectation.
+   * Do NOT "fix" it by relaxing the regex to `/users`.
+   *
+   * SettingsPage renders on BOTH the mothership route
+   * (/provision/$deploymentId/settings) and the chroot Sovereign route
+   * (/settings) — see the SettingsPage.tsx docstring at the useParams
+   * call. But the Members link hardcodes the chroot form:
+   *
+   *     SettingsPage.tsx:399   to={`/users` as never}
+   *
+   * The `as never` cast defeats TanStack Router's typed-route checking,
+   * which is what would otherwise reject a target that can't resolve
+   * under the current route. Twenty lines later the SAME file uses the
+   * correct mode-safe pattern for its sibling CTA:
+   *
+   *     SettingsPage.tsx:420-422
+   *       to="/decommission/$deploymentId" params={{ deploymentId }}
+   *
+   * Both routes are registered in the one tree — `/provision/$deploymentId/users`
+   * (router.tsx:1112) and the chroot `/users` under consoleLayoutRoute
+   * (router.tsx:1463-1466, mounted at router.tsx:2411). So on the
+   * mothership this link navigates into SovereignConsoleLayout, where
+   * useResolvedDeploymentId has no :deploymentId param and falls back to
+   * /sovereign/self — which that hook's own doc comment states 404s on a
+   * mothership host. Result: Members is a dead link on the mothership.
+   *
+   * This assertion has never run green: the file threw on a missing
+   * QueryClient before reaching it, so the contradiction (present since
+   * the earliest commit that has both files, a7fb48245) stayed masked.
+   * Fixing the link is a navigation behaviour change and overlaps the
+   * open route-gating decision in #5401, so it is left to that issue.
+   */
   it('Members link points at /provision/$id/users', async () => {
     renderSettings('d-test-1234')
     const link = (await screen.findByTestId('settings-members-link')) as HTMLAnchorElement

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-compute/CloudComputePage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-compute/CloudComputePage.test.tsx
@@ -73,12 +73,32 @@ describe('CloudComputePage', () => {
     expect(screen.getByTestId('cloud-compute-page-tile-worker-nodes')).toBeTruthy()
   })
 
-  it('counts derive from the fixture (2 clusters, 4 vclusters, 3 node-pools, 6 worker nodes)', async () => {
+  // The worker-nodes tile counts WORKER nodes only, never control planes
+  // (#4739, CloudComputePage.tsx `role !== 'control-plane'` filter). The
+  // fixture carries 6 nodes total but only 4 with role 'worker' —
+  // eu-w-0 / eu-w-1 / eu-w-2 (infrastructure-topology.fixture.ts) plus
+  // hel-w-0 — the other 2 (eu-cp-0, hel-cp-0) are role 'control-plane'.
+  // This assertion previously expected 6, i.e. it pinned the exact
+  // over-count #4739 fixed.
+  it('counts derive from the fixture (2 clusters, 4 vclusters, 3 node-pools, 4 worker nodes)', async () => {
     renderLanding(infrastructureTopologyFixture)
     expect((await screen.findByTestId('cloud-compute-page-tile-clusters-count')).textContent).toBe('2')
     expect(screen.getByTestId('cloud-compute-page-tile-vclusters-count').textContent).toBe('4')
     expect(screen.getByTestId('cloud-compute-page-tile-node-pools-count').textContent).toBe('3')
-    expect(screen.getByTestId('cloud-compute-page-tile-worker-nodes-count').textContent).toBe('6')
+    expect(screen.getByTestId('cloud-compute-page-tile-worker-nodes-count').textContent).toBe('4')
+  })
+
+  it('excludes control-plane nodes from the worker-nodes tile (#4739)', async () => {
+    renderLanding(infrastructureTopologyFixture)
+    const allNodes = (infrastructureTopologyFixture.topology.regions ?? [])
+      .flatMap((r) => r.clusters ?? [])
+      .flatMap((c) => c.nodes ?? [])
+    const workers = allNodes.filter((n) => n.role !== 'control-plane')
+    expect(allNodes.length).toBe(6)
+    expect(workers.length).toBe(4)
+    expect(
+      (await screen.findByTestId('cloud-compute-page-tile-worker-nodes-count')).textContent,
+    ).toBe(String(workers.length))
   })
 
   it('each tile is a Link to the per-resource list page', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.test.tsx
@@ -53,6 +53,7 @@ import {
   componentsByProduct,
   computeDefaultSelection,
   GROUPS,
+  type ComponentEntry,
 } from './componentGroups'
 import { useWizardStore } from '@/entities/deployment/store'
 import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
@@ -161,6 +162,30 @@ describe('component catalog', () => {
     }
   })
 
+  /**
+   * 🛑 KNOWN DEFECT — this test is EXPECTED TO FAIL on `main` and is left
+   * red deliberately. Do NOT relax it.
+   *
+   * `componentGroups.ts:536` overrides every component's `dependencies`
+   * with `depsFor(id)` from `src/data/blueprint-deps.generated.json`,
+   * which is generated from Flux `HelmRelease.dependsOn` names. Three of
+   * those names are bootstrap-kit HelmReleases that have NO ComponentDef
+   * in the wizard catalog, so they leak into the graph as dangling ids:
+   *
+   *   gateway-api  ← gitea, powerdns, harbor, keycloak, openbao, grafana
+   *   reflector    ← external-dns, postgres
+   *   spire        ← openbao
+   *
+   * Operator-visible symptom: `computeDefaultSelection()` returns 48 ids,
+   * three of which (`gateway-api`, `reflector`, `spire`) have no card, no
+   * name and no logo anywhere in the wizard — yet they are written into
+   * `selectedComponents` and travel into the deployment payload, and the
+   * "Selected (N) of M" counter counts them.
+   *
+   * Fix belongs in the catalog layer (filter `depsFor()` through the
+   * known-component id set, or give the three HelmReleases ComponentDefs)
+   * — NOT here.
+   */
   it('every dependency points at a known component id', () => {
     const ids = new Set(ALL_COMPONENTS.map(c => c.id))
     for (const c of ALL_COMPONENTS) {
@@ -170,20 +195,44 @@ describe('component catalog', () => {
     }
   })
 
-  it('Harbor depends on cnpg + seaweedfs + valkey', () => {
+  it('Harbor depends on cnpg + cert-manager, and NOT on seaweedfs', () => {
+    // Dependencies are Flux-canonical since #652 (commit 544dc86b5) —
+    // `componentGroups.ts:536` replaces the inline literals with
+    // `HelmRelease.dependsOn`. Ground truth for Harbor is
+    // `clusters/_template/bootstrap-kit/19-harbor.yaml:114-118`
+    // (bp-cnpg + bp-cert-manager) and `19-harbor.yaml:35-37`:
+    //   "The earlier dependency on bp-seaweedfs is REMOVED in 1.1.0
+    //    (cloud-direct architecture rule; SeaweedFS is no longer a Harbor
+    //    prerequisite on Sovereigns)."
+    // The pre-#652 expectation ['cnpg','seaweedfs','valkey'] is the exact
+    // hand-maintained triple the founder directive called out as baseless.
     const harbor = findComponent('harbor')
     expect(harbor).toBeDefined()
-    expect(harbor!.dependencies).toEqual(expect.arrayContaining(['cnpg', 'seaweedfs', 'valkey']))
+    expect(harbor!.dependencies).toEqual(expect.arrayContaining(['cnpg', 'cert-manager']))
+    expect(harbor!.dependencies).not.toContain('seaweedfs')
+    // The Harbor HelmRelease carries no Redis/Valkey dependency either.
+    expect(harbor!.dependencies).not.toContain('valkey')
   })
 
   it('OpenSearch has no dependencies (it owns its storage)', () => {
     expect(findComponent('opensearch')!.dependencies).toEqual([])
   })
 
-  it('Reloader / KEDA / VPA / Cilium / Crossplane / Flux have no deps', () => {
-    for (const id of ['reloader', 'keda', 'vpa', 'cilium', 'crossplane', 'flux']) {
+  it('Reloader / KEDA / VPA / Cilium have no deps', () => {
+    for (const id of ['reloader', 'keda', 'vpa', 'cilium']) {
       expect(findComponent(id)!.dependencies ?? []).toEqual([])
     }
+  })
+
+  it('Flux and Crossplane carry their Flux-canonical install edges', () => {
+    // Pre-#652 these were asserted as dependency-free. The bootstrap kit
+    // says otherwise and is now canonical:
+    //   clusters/_template/bootstrap-kit/03-flux.yaml:59-60 — bp-flux
+    //     dependsOn bp-cert-manager.
+    //   bp-crossplane dependsOn bp-flux (blueprint-deps.generated.json
+    //     "crossplane": ["flux"], from 04-crossplane.yaml).
+    expect(findComponent('flux')!.dependencies).toContain('cert-manager')
+    expect(findComponent('crossplane')!.dependencies).toContain('flux')
   })
 
   it('every component carries an upstream brand mark or an explicit fallback', () => {
@@ -372,15 +421,26 @@ describe('Tab 1 — category filter', () => {
   it('clicking a category chip narrows the grid to that group', () => {
     render(<StepComponents />)
     fireEvent.click(screen.getByTestId('category-chip-fabric'))
-    // Fabric non-mandatories (post-#175 promotion) include strimzi,
-    // debezium, flink, temporal, clickhouse, ferretdb, iceberg, superset.
-    expect(screen.getByTestId('component-card-strimzi')).toBeTruthy()
-    expect(screen.getByTestId('component-card-debezium')).toBeTruthy()
-    expect(screen.queryByTestId('component-card-grafana')).toBeNull()
-    // cnpg / valkey are mandatory after #175 and should not surface
-    // in Tab 1 even when their parent product is filtered to.
+    // Derived rather than hardcoded: exactly the FABRIC non-mandatories
+    // render, and no non-mandatory from any other group does. Deriving
+    // keeps this valid as the transitive-mandatory promotion set moves
+    // with the Flux-canonical dependency map (#652).
+    const fabricNonMandatory = NON_MANDATORY.filter((c) => c.groupId === 'fabric')
+    expect(fabricNonMandatory.length).toBeGreaterThan(0)
+    for (const c of fabricNonMandatory) {
+      expect(screen.getByTestId(`component-card-${c.id}`)).toBeTruthy()
+    }
+    for (const c of NON_MANDATORY.filter((c) => c.groupId !== 'fabric')) {
+      expect(screen.queryByTestId(`component-card-${c.id}`)).toBeNull()
+    }
+    // cnpg is mandatory (promoted — gitea/harbor/keycloak depend on it)
+    // so it must not surface in Tab 1 even with its parent product
+    // filtered to. valkey is NOT promoted any more: Harbor's Flux
+    // HelmRelease carries no valkey dependency
+    // (clusters/_template/bootstrap-kit/19-harbor.yaml:114-118), so
+    // valkey is a user-toggleable FABRIC card and IS in the loop above.
     expect(screen.queryByTestId('component-card-cnpg')).toBeNull()
-    expect(screen.queryByTestId('component-card-valkey')).toBeNull()
+    expect(screen.getByTestId('component-card-valkey')).toBeTruthy()
   })
 
   it('toggling the same chip a second time clears the filter', () => {
@@ -411,22 +471,46 @@ describe('Tab 1 — sort: selected first', () => {
 /* ── Cascading add ────────────────────────────────────────────────── */
 
 describe('cascading add', () => {
-  it('selecting a non-mandatory component adds its deps via the store', () => {
+  it('selecting a non-mandatory component adds its transitive deps via the store', () => {
+    // Derived fixture. The pre-#652 fixture was `milvus → seaweedfs`, a
+    // hand-maintained edge; there is no bp-milvus HelmRelease so
+    // `depsFor('milvus')` is now `[]` (componentGroups.ts:533-535) and
+    // the pair no longer exercises anything. Pick, from the catalog, a
+    // non-mandatory component that actually HAS deps and belongs to an
+    // à-la-carte product, so the assertion isolates the COMPONENT-level
+    // cascade from the product-family cascade.
+    const seed = ALL_COMPONENTS.find(
+      (c) =>
+        c.tier !== 'mandatory' &&
+        resolveTransitiveDependencies(c.id).length > 0 &&
+        findProduct(c.product)?.cascadeOnMemberSelection === false,
+    )
+    expect(seed, 'catalog must contain a non-mandatory component with deps').toBeDefined()
+    const deps = resolveTransitiveDependencies(seed!.id)
+    expect(deps.length).toBeGreaterThan(0)
+
     useWizardStore.setState({ selectedComponents: [] })
-    useWizardStore.getState().addComponent('milvus')
+    useWizardStore.getState().addComponent(seed!.id)
     const sel = useWizardStore.getState().selectedComponents
-    expect(sel).toContain('milvus')
-    expect(sel).toContain('seaweedfs')
+    expect(sel).toContain(seed!.id)
+    for (const d of deps) {
+      expect(sel).toContain(d)
+    }
   })
 
-  it('store cascades Harbor → cnpg + seaweedfs + valkey', () => {
+  it('store cascades Harbor → cnpg + cert-manager + postgres (not seaweedfs)', () => {
+    // Flux-canonical Harbor edges — see the catalog test above and
+    // clusters/_template/bootstrap-kit/19-harbor.yaml:35-37 + :114-118.
     useWizardStore.setState({ selectedComponents: [] })
     useWizardStore.getState().addComponent('harbor')
     const sel = useWizardStore.getState().selectedComponents
     expect(sel).toContain('harbor')
     expect(sel).toContain('cnpg')
-    expect(sel).toContain('seaweedfs')
-    expect(sel).toContain('valkey')
+    expect(sel).toContain('cert-manager')
+    expect(sel).toContain('postgres')
+    // Transitive: cnpg → flux (blueprint-deps.generated.json "cnpg").
+    expect(sel).toContain('flux')
+    expect(sel).not.toContain('seaweedfs')
   })
 
   it('UI emits a single toast announcing the cascade', () => {
@@ -458,58 +542,84 @@ describe('cascading add', () => {
 /* ── Cascading remove ─────────────────────────────────────────────── */
 
 describe('cascading remove', () => {
+  /**
+   * Cascade-remove fixture, DERIVED from the catalog: the first
+   * non-mandatory component that has at least one non-mandatory
+   * dependent — i.e. a chain the wizard can fully unwind.
+   *
+   * The pre-#652 fixture was the hardcoded `strimzi → debezium` pair.
+   * Neither strimzi nor debezium has a bp-* HelmRelease, so since #652
+   * (componentGroups.ts:536) both resolve to `dependencies: []` and the
+   * pair produces no cascade at all. Deriving keeps the test exercising
+   * the real feature as the Flux-canonical map evolves.
+   *
+   * (Today this resolves to `opentelemetry → alloy` —
+   * blueprint-deps.generated.json `"alloy": ["opentelemetry"]`.)
+   */
+  function cascadeRemovePair(): { target: ComponentEntry; dependents: ComponentEntry[] } {
+    for (const c of NON_MANDATORY) {
+      const dependents = resolveTransitiveDependents(c.id)
+        .map((id) => findComponent(id))
+        .filter((d): d is ComponentEntry => !!d && d.tier !== 'mandatory')
+      if (dependents.length > 0) return { target: c, dependents }
+    }
+    throw new Error(
+      'catalog has no non-mandatory component with a non-mandatory dependent — ' +
+        'the cascade-remove flow is untestable and this is itself a defect',
+    )
+  }
+
   it('opens a confirm dialog when removing a component with dependents', () => {
-    // strimzi (recommended, fabric) has Debezium depending on it, so
-    // toggling-off strimzi triggers the cascade-remove confirm. Replaces
-    // the pre-#175 cnpg test (cnpg was promoted to mandatory by the
-    // transitive-mandatory rule and no longer surfaces in Tab 1).
+    const { target, dependents } = cascadeRemovePair()
     useWizardStore.setState({
       selectedComponents: [
         ...new Set([
           ...useWizardStore.getState().selectedComponents,
-          'strimzi',
-          'debezium',
+          target.id,
+          ...dependents.map((d) => d.id),
         ]),
       ].sort(),
     })
     render(<StepComponents />)
-    fireEvent.click(screen.getByTestId('category-chip-fabric'))
-    fireEvent.click(screen.getByTestId('toggle-strimzi'))
+    fireEvent.click(screen.getByTestId(`toggle-${target.id}`))
     expect(screen.getByTestId('cascade-dialog')).toBeTruthy()
     const list = screen.getByTestId('cascade-dependents')
-    expect(list.textContent).toMatch(/Debezium/)
+    for (const d of dependents) {
+      expect(list.textContent).toContain(d.name)
+    }
   })
 
   it('cancel keeps the component selected', () => {
+    const { target, dependents } = cascadeRemovePair()
     useWizardStore.setState({
       selectedComponents: [
         ...new Set([
           ...useWizardStore.getState().selectedComponents,
-          'strimzi',
-          'debezium',
+          target.id,
+          ...dependents.map((d) => d.id),
         ]),
       ].sort(),
     })
     render(<StepComponents />)
-    fireEvent.click(screen.getByTestId('category-chip-fabric'))
-    fireEvent.click(screen.getByTestId('toggle-strimzi'))
+    fireEvent.click(screen.getByTestId(`toggle-${target.id}`))
     fireEvent.click(screen.getByTestId('cascade-cancel'))
-    expect(useWizardStore.getState().selectedComponents).toContain('strimzi')
+    expect(useWizardStore.getState().selectedComponents).toContain(target.id)
     expect(screen.queryByTestId('cascade-dialog')).toBeNull()
   })
 
   it('confirm cascades through the impact set', () => {
-    // strimzi → debezium is a non-mandatory chain we can fully unwind.
+    const { target, dependents } = cascadeRemovePair()
     useWizardStore.setState({
-      selectedComponents: ['strimzi', 'debezium'].sort(),
+      selectedComponents: [target.id, ...dependents.map((d) => d.id)].sort(),
     })
     render(<StepComponents />)
-    fireEvent.click(screen.getByTestId('category-chip-fabric'))
-    fireEvent.click(screen.getByTestId('toggle-strimzi'))
+    fireEvent.click(screen.getByTestId(`toggle-${target.id}`))
     fireEvent.click(screen.getByTestId('cascade-confirm'))
     const sel = useWizardStore.getState().selectedComponents
-    expect(sel).not.toContain('strimzi')
-    expect(sel).not.toContain('debezium')
+    expect(sel).not.toContain(target.id)
+    for (const d of dependents) {
+      expect(sel).not.toContain(d.id)
+    }
   })
 
   it('mandatory components are NEVER removed even via cascade', () => {
@@ -541,6 +651,39 @@ describe('cascading remove', () => {
 
 /* ── Tab 2: Always Included ───────────────────────────────────────── */
 
+/**
+ * 🛑 KNOWN DEFECT pinned by this block (2 tests here + 2 in the
+ * transitive-promotion block below are EXPECTED TO FAIL on `main`).
+ * Do NOT relax them.
+ *
+ * `StepComponents.tsx:637-644` (AlwaysIncludedTab) builds Tab 2 from
+ * `PRODUCTS.filter(product => product.tier === 'mandatory')` — i.e. it
+ * keys visibility off the PRODUCT tier, not the COMPONENT tier. The
+ * Foundation counter next to it (`StepComponents.tsx:773-775`) keys off
+ * the COMPONENT tier (`ALL_COMPONENTS.filter(c => c.tier === 'mandatory')`).
+ * The two disagree.
+ *
+ * `cnpg` and `postgres` are `tier: 'mandatory'` (promoted — the
+ * unconditionally-mandatory gitea / harbor / keycloak depend on them)
+ * but live in FABRIC, whose PRODUCT tier is 'recommended'
+ * (componentGroups.ts:454). So they are filtered out of Tab 2, and Tab 1
+ * already excludes them for being mandatory (StepComponents.tsx:768).
+ * Net effect: CloudNative PG and PostgreSQL are installed on every
+ * Sovereign but appear in NEITHER tab, and the tab reads
+ * "Foundation (24)" while rendering 22 cards.
+ *
+ * The filter was added to stop KServe (then CORTEX-internal
+ * `tier: 'mandatory'`) showing under "Always Included" on Sovereigns that
+ * never picked CORTEX — see the comment at StepComponents.tsx:628-635.
+ * That root cause was independently fixed by demoting KServe to
+ * `tier: 'recommended'` (componentGroups.ts:338), and CORTEX / RELAY /
+ * INSIGHTS now carry zero mandatory components. The product-tier filter
+ * therefore excludes exactly {cnpg, postgres} and nothing else — it is
+ * now pure collateral damage.
+ *
+ * Fix belongs in AlwaysIncludedTab (filter on component tier, or on
+ * "promoted from a raw-mandatory seed") — NOT here.
+ */
 describe('Tab 2 (Always Included) — read-only mandatory grid', () => {
   it('renders a card for every mandatory component', () => {
     render(<StepComponents />)
@@ -706,10 +849,25 @@ describe('reset to defaults', () => {
 
 describe('reverse-graph helpers', () => {
   it('resolveTransitiveDependents includes every component that needs cnpg directly or transitively', () => {
+    // Flux-canonical dependents since #652. The pre-#652 expectation also
+    // listed ferretdb / temporal / librechat / matrix / superset /
+    // openmeter — every one of those was a hand-maintained `→ cnpg` edge
+    // on a component with NO bp-* HelmRelease, so `depsFor()` now returns
+    // `[]` for them (componentGroups.ts:533-535) and they are no longer
+    // cnpg dependents. The ids below each have a real bootstrap-kit HR
+    // whose `dependsOn` reaches cnpg:
+    //   gitea      — 10-gitea.yaml:65-72   (bp-cnpg, bp-postgres-shared)
+    //   keycloak   — 09-keycloak.yaml:68-74 (→ bp-postgres-shared → bp-cnpg)
+    //   harbor     — 19-harbor.yaml:114-118 (bp-cnpg)
+    //   grafana    — 25-grafana.yaml:57-59  (bp-cnpg)
+    //   powerdns   — 11-powerdns.yaml       (bp-cnpg)
+    //   openbao    — 08-openbao.yaml        (bp-cnpg)
+    //   postgres   — the shared data-instance, dependsOn bp-cnpg
+    //   langfuse   — bp-langfuse dependsOn bp-cnpg
     const dependents = resolveTransitiveDependents('cnpg')
     for (const id of [
-      'gitea', 'keycloak', 'harbor', 'ferretdb', 'temporal',
-      'langfuse', 'librechat', 'matrix', 'superset', 'openmeter',
+      'gitea', 'keycloak', 'harbor', 'grafana',
+      'powerdns', 'openbao', 'postgres', 'langfuse',
     ]) {
       expect(dependents).toContain(id)
     }
@@ -738,13 +896,27 @@ describe('transitive-mandatory promotion (issue #175 fix A)', () => {
     expect(findComponent('cnpg')!.tier).toBe('mandatory')
   })
 
-  it('valkey is mandatory in the post-promotion catalog', () => {
-    expect(findComponent('valkey')!.tier).toBe('mandatory')
+  it('postgres is mandatory in the post-promotion catalog', () => {
+    // postgres (the #3370 shareable data-instance) replaced valkey as the
+    // promoted FABRIC member: gitea / harbor / keycloak — all raw
+    // mandatory — dependsOn bp-postgres-shared
+    // (10-gitea.yaml:65-72, 19-harbor.yaml:114-118, 09-keycloak.yaml:68-74),
+    // so the closure walk lifts it.
+    expect(findComponent('postgres')!.tier).toBe('mandatory')
   })
 
-  it('TRANSITIVE_MANDATORY_PROMOTIONS includes cnpg + valkey', () => {
+  it('valkey is NOT promoted — no mandatory component depends on it', () => {
+    // Pre-#652 valkey was promoted solely via Harbor's hand-maintained
+    // `['cnpg','seaweedfs','valkey']` literal. The Harbor HelmRelease
+    // (clusters/_template/bootstrap-kit/19-harbor.yaml:114-118) carries no
+    // valkey/Redis dependency, so valkey stays user-toggleable.
+    expect(findComponent('valkey')!.tier).not.toBe('mandatory')
+    expect(TRANSITIVE_MANDATORY_PROMOTIONS).not.toContain('valkey')
+  })
+
+  it('TRANSITIVE_MANDATORY_PROMOTIONS includes cnpg + postgres', () => {
     expect(TRANSITIVE_MANDATORY_PROMOTIONS).toContain('cnpg')
-    expect(TRANSITIVE_MANDATORY_PROMOTIONS).toContain('valkey')
+    expect(TRANSITIVE_MANDATORY_PROMOTIONS).toContain('postgres')
   })
 
   it('every promoted component is reachable from a raw mandatory seed', () => {
@@ -773,26 +945,35 @@ describe('transitive-mandatory promotion (issue #175 fix A)', () => {
     expect(screen.queryByTestId('component-card-cnpg')).toBeNull()
   })
 
+  // 🛑 EXPECTED TO FAIL — pins the AlwaysIncludedTab product-tier filter
+  // defect documented above the "Tab 2 (Always Included)" describe block.
   it('cnpg DOES appear in Tab 2 ("Always Included")', () => {
     render(<StepComponents />)
     fireEvent.click(screen.getByTestId('tab-always'))
     expect(screen.getByTestId('component-card-cnpg')).toBeTruthy()
   })
 
-  it('valkey DOES appear in Tab 2 ("Always Included")', () => {
+  it('valkey does NOT appear in Tab 2 — it is user-selectable in Tab 1', () => {
+    // Inverted from the pre-#652 expectation: valkey is no longer
+    // promoted (see "valkey is NOT promoted" above), so it belongs in the
+    // Components tab, not Foundation.
     render(<StepComponents />)
-    fireEvent.click(screen.getByTestId('tab-always'))
     expect(screen.getByTestId('component-card-valkey')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('tab-always'))
+    const tab = screen.getByTestId('always-included-tab')
+    expect(within(tab).queryByTestId('component-card-valkey')).toBeNull()
   })
 
+  // 🛑 EXPECTED TO FAIL — same AlwaysIncludedTab defect. The valkey
+  // assertion that used to sit here was dropped (valkey is no longer a
+  // promotion), so this now fails ONLY for the real reason: FABRIC has
+  // two promoted mandatory members and renders no section at all.
   it('promoted components are grouped under their owning product in Tab 2', () => {
     render(<StepComponents />)
     fireEvent.click(screen.getByTestId('tab-always'))
-    // cnpg lives in FABRIC; the FABRIC section should now appear in
-    // Tab 2 because of cnpg / valkey's promotion.
     const fabricSection = screen.getByTestId('always-included-section-fabric')
     expect(within(fabricSection).getByTestId('component-card-cnpg')).toBeTruthy()
-    expect(within(fabricSection).getByTestId('component-card-valkey')).toBeTruthy()
+    expect(within(fabricSection).getByTestId('component-card-postgres')).toBeTruthy()
   })
 })
 
@@ -832,6 +1013,39 @@ describe('product-family model (issue #175 fix B)', () => {
     expect(findProduct('cortex')!.familyDependencies).toEqual([])
   })
 
+  /**
+   * 🛑 KNOWN DEFECT — EXPECTED TO FAIL on `main`. Do NOT relax it, and do
+   * NOT "fix" it by deleting the expectation.
+   *
+   * The Specter → CORTEX product rule is operator-requested (issue #175:
+   * "when Specter is selected all the Cortex family is required") and is
+   * still actively documented in the catalog in two places:
+   *   componentGroups.ts:261-275 — "Specter requires the entire CORTEX
+   *     family at runtime … selecting Specter adds the full CORTEX family
+   *     even if the user never opens the CORTEX chip."
+   *   componentGroups.ts:442-446 — "Selecting the INSIGHTS product as a
+   *     whole brings in Specter, which in turn pulls CORTEX through the
+   *     component->product cascade chain."
+   * and componentGroups.ts:275 still literally declares
+   *   dependencies: ['bge','milvus','langfuse','vllm','kserve'].
+   *
+   * That literal is DEAD. componentGroups.ts:536 replaces it with
+   * `depsFor('specter')`, and there is no bp-specter HelmRelease, so
+   * Specter's dependencies are `[]`. Specter belongs to INSIGHTS
+   * (cascadeOnMemberSelection: false), so nothing else fires either.
+   *
+   * Operator-visible symptom: ticking Specter (the AIOps brain) installs
+   * Specter alone — no vLLM, no Milvus, no BGE, no LangFuse, no KServe —
+   * i.e. an AIOps component with no AI runtime under it.
+   *
+   * This is NOT the same class as the other #652 casualties: those were
+   * install-ordering edges the founder ruled Flux owns. This is a
+   * product-family SELECTION rule, which the wizard models separately via
+   * `Product.familyDependencies` / `cascadeOnMemberSelection` —
+   * untouched by #652. The rule was simply encoded in the wrong layer and
+   * is now unimplemented. Fix belongs in the PRODUCTS table
+   * (componentGroups.ts:434-448), not here.
+   */
   it('Specter component-level deps cover the major CORTEX runtime members', () => {
     const specter = findComponent('specter')!
     for (const dep of ['bge', 'milvus', 'langfuse', 'vllm', 'kserve']) {
@@ -839,23 +1053,40 @@ describe('product-family model (issue #175 fix B)', () => {
     }
   })
 
-  it('LibreChat depends on FerretDB (Mongo-compatible) — not cnpg directly', () => {
-    // Audit 2026-04: LibreChat speaks MongoDB, not PostgreSQL. The
-    // OpenOva drop-in is FerretDB, which itself runs on cnpg, so cnpg
-    // arrives transitively. The earlier `['cnpg']` dep would have
-    // attached cnpg without any actual Mongo-compatible backend.
+  it('LibreChat has no Flux-canonical deps (no bp-librechat HelmRelease)', () => {
+    // The 2026-04 audit's `librechat → ferretdb` edge was hand-maintained.
+    // #652 (commit 544dc86b5) made Flux `HelmRelease.dependsOn` the single
+    // source of truth per founder directive — "The single source of truth
+    // for the dependencies is flux!!!" — and there is no bp-librechat
+    // HelmRelease in clusters/_template/bootstrap-kit, so `depsFor()`
+    // returns the documented empty-list fallback
+    // (componentGroups.ts:533-535).
+    //
+    // NOTE for whoever revisits this: LibreChat genuinely speaks MongoDB,
+    // so the Mongo-compat requirement is real — it just has to be
+    // expressed by adding a bp-librechat HelmRelease with the right
+    // `dependsOn`, not by re-introducing a literal that :536 discards.
     const librechat = findComponent('librechat')!
-    expect(librechat.dependencies).toContain('ferretdb')
-    expect(librechat.dependencies).not.toContain('cnpg')
+    expect(librechat.dependencies).toEqual([])
   })
 
-  it('Grafana has no hard dependencies (uses SQLite by default; HA can opt into PG)', () => {
-    // Audit 2026-04: Grafana the dashboard server stores its own state
-    // in SQLite by default and does not require object storage. The
-    // companion stores Loki / Mimir / Tempo need seaweedfs; Grafana
-    // does not. Removing the spurious dep avoids dragging SILO-internal
-    // coupling onto every Grafana selection.
-    expect(findComponent('grafana')!.dependencies).toEqual([])
+  it('Grafana depends on its Flux-canonical datastores and datasources', () => {
+    // Inverted from the 2026-04 "Grafana uses SQLite by default" audit
+    // claim, which the bootstrap kit contradicts.
+    // clusters/_template/bootstrap-kit/25-grafana.yaml:11-17 documents the
+    // intent and :57-70 declares it:
+    //   bp-cnpg    (":12 — Postgres backend for Grafana state")
+    //   bp-loki    (":13 — datasource for logs")
+    //   bp-mimir   (":14 — datasource for metrics")
+    //   bp-tempo   (":15 — datasource for traces")
+    //   bp-keycloak(":16 — OIDC IdP for SSO")
+    const grafana = findComponent('grafana')!
+    for (const dep of ['cnpg', 'loki', 'mimir', 'tempo', 'keycloak']) {
+      expect(grafana.dependencies).toContain(dep)
+    }
+    // seaweedfs is still NOT a direct Grafana dep — it arrives only
+    // transitively through Loki / Mimir / Tempo.
+    expect(grafana.dependencies).not.toContain('seaweedfs')
   })
 })
 
@@ -887,10 +1118,13 @@ describe('store: addProduct cascade', () => {
     ]) {
       expect(sel).not.toContain(id)
     }
-    // cnpg stays present because it's mandatory; ferretdb arrives via
-    // librechat's component dep.
+    // cnpg stays present because it's mandatory. The pre-#652 companion
+    // assertion `toContain('ferretdb')` is gone: it relied on the
+    // hand-maintained `librechat → ferretdb` edge, which #652 replaced
+    // with the empty Flux-canonical list (see the LibreChat test above).
+    // ferretdb is now covered by the FABRIC-exclusion loop instead.
     expect(sel).toContain('cnpg')
-    expect(sel).toContain('ferretdb')
+    expect(sel).not.toContain('ferretdb')
   })
 
   it('addProduct(unknown) is a no-op', () => {
@@ -914,13 +1148,36 @@ describe('store: removeProduct cascade', () => {
     }
   })
 
-  it('removeProduct(cortex) preserves CORTEX mandatory members (kserve)', () => {
-    const fullCortex = resolveProductComponentClosure('cortex')
+  it('removeProduct preserves the product’s mandatory members (FABRIC)', () => {
+    // Retargeted from CORTEX. The old fixture asserted `kserve` survived
+    // removeProduct('cortex') because KServe was `tier: 'mandatory'`.
+    // KServe was deliberately demoted to `tier: 'recommended'` —
+    // componentGroups.ts:338 and the comment at :326-337: "KServe was
+    // tier:'mandatory' — semantically wrong … Demoting to 'recommended'"
+    // (caught on the omantel.biz wizard 2026-05-06). CORTEX now has ZERO
+    // mandatory members, so the old assertion is unsatisfiable and the
+    // guard at store.ts:653 went untested.
+    //
+    // FABRIC does have mandatory members (cnpg + postgres, promoted), so
+    // it exercises the same invariant for real. Derived, not hardcoded.
+    const fabricMandatory = componentsByProduct('fabric').filter((c) => c.tier === 'mandatory')
+    expect(fabricMandatory.length).toBeGreaterThan(0)
+
+    const fullFabric = resolveProductComponentClosure('fabric')
     useWizardStore.setState({
-      selectedComponents: [...new Set([...MANDATORY_COMPONENT_IDS, ...fullCortex])].sort(),
+      selectedComponents: [...new Set([...MANDATORY_COMPONENT_IDS, ...fullFabric])].sort(),
     })
-    useWizardStore.getState().removeProduct('cortex')
-    expect(useWizardStore.getState().selectedComponents).toContain('kserve')
+    useWizardStore.getState().removeProduct('fabric')
+    const sel = useWizardStore.getState().selectedComponents
+    for (const c of fabricMandatory) {
+      expect(sel).toContain(c.id)
+    }
+    // …and the non-mandatory members really did leave, so this cannot
+    // pass by removeProduct being a no-op.
+    for (const c of componentsByProduct('fabric')) {
+      if (c.tier === 'mandatory') continue
+      expect(sel).not.toContain(c.id)
+    }
   })
 
   it('removeProduct(unknown) is a no-op', () => {
@@ -942,6 +1199,10 @@ describe('addComponent → product family cascade (CORTEX)', () => {
     }
   })
 
+  // 🛑 EXPECTED TO FAIL — pins the Specter → CORTEX defect documented in
+  // full above the "Specter component-level deps" test. The cascade
+  // MECHANISM is fine (the BGE test directly above proves it fires); the
+  // Specter → CORTEX edge is what went missing.
   it('selecting Specter cascades to every CORTEX component', () => {
     useWizardStore.setState({ selectedComponents: [...MANDATORY_COMPONENT_IDS].sort() })
     useWizardStore.getState().addComponent('specter')
@@ -959,6 +1220,12 @@ describe('addComponent → product family cascade (CORTEX)', () => {
   // ClickHouse, Iceberg, or Superset. The previous CORTEX
   // `familyDependencies: ['fabric']` was over-broad and is removed in
   // this commit.
+  // ⚠️ CURRENTLY VACUOUS, deliberately kept. This guards the 2026-04
+  // over-cascade regression (CORTEX `familyDependencies: ['fabric']`).
+  // While the Specter → CORTEX defect above is open Specter cascades
+  // NOTHING, so this passes trivially; it regains its teeth the moment
+  // that defect is fixed. Left in place rather than deleted so the
+  // regression stays guarded — do not treat its green as coverage today.
   it('selecting Specter does NOT auto-select the FABRIC family (regression)', () => {
     useWizardStore.setState({ selectedComponents: [...MANDATORY_COMPONENT_IDS].sort() })
     useWizardStore.getState().addComponent('specter')
@@ -971,25 +1238,14 @@ describe('addComponent → product family cascade (CORTEX)', () => {
     }
   })
 
-  it('selecting Specter does NOT auto-select FerretDB (no Mongo workload in Specter)', () => {
-    // FerretDB is reached only via librechat's dep. Specter doesn't
-    // pull librechat (CORTEX cascade does — but on a clean state it's
-    // a separate addComponent). Verify Specter alone (without
-    // librechat) does not drag FerretDB in.
-    useWizardStore.setState({ selectedComponents: [...MANDATORY_COMPONENT_IDS].sort() })
-    // Component-level cascade adds librechat via CORTEX family cascade
-    // (CORTEX has cascadeOnMemberSelection: true). Librechat then
-    // pulls FerretDB. So FerretDB IS expected. Document this clearly:
-    useWizardStore.getState().addComponent('specter')
-    const sel = useWizardStore.getState().selectedComponents
-    // FerretDB ARRIVES because LibreChat (a CORTEX member with
-    // ferretdb as a dep) is pulled in by CORTEX's cascadeOnMemberSelection.
-    // That is the correct behavior — librechat genuinely needs a
-    // Mongo-compatible backend.
-    expect(sel).toContain('librechat')
-    expect(sel).toContain('ferretdb')
-    // But the rest of FABRIC stays out (verified above).
-  })
+  // The former 'selecting Specter does NOT auto-select FerretDB' test was
+  // DELETED here. Its title asserted Specter must not pull FerretDB while
+  // its body asserted the opposite (`toContain('ferretdb')`) — the 2026-04
+  // audit inverted the body and left the title behind. Both of its
+  // assertions were duplicates: the `librechat` half restates
+  // 'selecting Specter cascades to every CORTEX component' above, and the
+  // `ferretdb` half restates the LibreChat dependency test in the
+  // product-family block. Nothing it covered is now uncovered.
 
   it('selecting clickhouse (FABRIC à-la-carte) does NOT cascade FABRIC', () => {
     useWizardStore.setState({ selectedComponents: [...MANDATORY_COMPONENT_IDS].sort() })

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/ExecPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/ExecPanel.test.tsx
@@ -1,9 +1,23 @@
 /**
- * ExecPanel.test.tsx — EPIC-4 Slice E1+E2 (#1099). Vitest coverage for:
- *   - Open Shell button → POST /session → iframe mounts at embedURL
- *   - Recording-on badge when server reports recording=true
- *   - Iframe load timeout → fallback WebSocket path
- *   - Iframe `onerror` → fallback path
+ * ExecPanel.test.tsx — EPIC-4 Slice E1+E2 (#1099).
+ *
+ * TRANSPORT NOTE (why this file was migrated — #5404)
+ * ---------------------------------------------------
+ * G85 #2632 (2026-06-01) INVERTED the default transport — see the comment
+ * at ExecPanel.tsx:99-107. The Guacamole embed URL pointed at
+ * `guacamole.<dep>.sovereign.local`, a cluster-internal host the operator's
+ * browser cannot resolve, so 100% of "Open Shell" clicks fell through to the
+ * WebSocket fallback after a visible 5s spinner. `openShell()` now sets
+ * `phase` straight to `'fallback-loading'` (ExecPanel.tsx:107) and the
+ * iframe renders only in the `iframe-loading` / `iframe-ready` phases
+ * (ExecPanel.tsx:289). The old iframe-first assertions were therefore
+ * asserting a path the shipped code no longer takes.
+ *
+ * Vitest coverage for the shipped contract:
+ *   - Open Shell button → POST /session → WS+xterm mounts immediately
+ *   - No Guacamole iframe and no "Recording: ON" claim on the WS path
+ *   - No iframe-load timeout to wait out (the #2632 regression guard)
+ *   - WebSocket construction failure → visible error + retry
  *   - Disabled button when canExec=false (per RBAC contract)
  *   - Server error surface
  */
@@ -44,7 +58,11 @@ class FakeWebSocket {
   constructor(url: string) {
     this.url = url
   }
-  send(_: unknown) {}
+  // Stub — the panel only calls send() from the xterm stdin wiring, which
+  // is off in these tests (disableTerminal). Takes no params so the
+  // no-unused-vars rule stays green; the double-cast at the call site keeps
+  // it assignable to WebSocket.
+  send() {}
   close() {
     this.onclose?.({ code: 1000 })
   }
@@ -81,7 +99,8 @@ describe('ExecPanel', () => {
     expect(btn.disabled).toBe(true)
   })
 
-  it('happy path mounts iframe and shows recording badge', async () => {
+  it('happy path opens the WebSocket shell directly — no Guacamole iframe (G85 #2632)', async () => {
+    let wsInstance: FakeWebSocket | null = null
     render(
       <ExecPanel
         deploymentId="dep"
@@ -89,19 +108,39 @@ describe('ExecPanel', () => {
         pod="wp-1"
         container="web"
         createSession={async () => HAPPY_SESSION}
+        websocketFactory={(url) => {
+          wsInstance = new FakeWebSocket(url)
+          return wsInstance as unknown as WebSocket
+        }}
         disableTerminal
       />,
     )
     fireEvent.click(screen.getByTestId('exec-panel-open'))
     await waitFor(() => {
-      expect(screen.getByTestId('exec-panel-iframe')).toBeTruthy()
+      expect(screen.getByTestId('exec-panel-fallback-terminal')).toBeTruthy()
     })
-    expect(screen.getByTestId('exec-panel-recording-on').textContent).toContain('Recording: ON')
-    const iframe = screen.getByTestId('exec-panel-iframe') as HTMLIFrameElement
-    expect(iframe.src).toContain('guac.local')
+    // The WS is dialled against the server-supplied fallback URL
+    // (ExecPanel.tsx:131-140).
+    expect(wsInstance).not.toBeNull()
+    expect(wsInstance!.url).toBe(HAPPY_SESSION.fallbackWebSocketUrl)
+    // …and the Guacamole iframe never mounts: ExecPanel.tsx:289 gates it on
+    // the `iframe-*` phases and openShell no longer enters them
+    // (ExecPanel.tsx:107).
+    expect(screen.queryByTestId('exec-panel-iframe')).toBeNull()
+    // The server reported recording:true, but a direct WS exec is NOT
+    // recorded. The badge stays inside the iframe branch
+    // (ExecPanel.tsx:291-295) and the WS banner states the opposite — the
+    // UI must never claim a recording it isn't making.
+    expect(screen.queryByTestId('exec-panel-recording-on')).toBeNull()
+    expect(screen.getByTestId('exec-panel-fallback-banner').textContent).toContain(
+      'recording disabled',
+    )
   })
 
-  it('falls back to WebSocket when iframe load times out', async () => {
+  it('reaches a usable shell without waiting out any iframe-load timeout', async () => {
+    // Regression guard for the exact bug G85 #2632 fixed (ExecPanel.tsx:99-107):
+    // every click used to burn a visible 5s spinner before falling through.
+    // Nothing here advances timers before the assertions.
     let wsInstance: FakeWebSocket | null = null
     render(
       <ExecPanel
@@ -120,26 +159,26 @@ describe('ExecPanel', () => {
     )
     fireEvent.click(screen.getByTestId('exec-panel-open'))
     await waitFor(() => {
-      expect(screen.getByTestId('exec-panel-iframe')).toBeTruthy()
-    })
-    // Advance past the 100ms iframe-load timeout — we never fire onLoad.
-    act(() => {
-      vi.advanceTimersByTime(150)
-    })
-    await waitFor(() => {
       expect(screen.getByTestId('exec-panel-fallback-banner')).toBeTruthy()
     })
     expect(wsInstance).not.toBeNull()
     expect(wsInstance!.url).toContain('/k8s/exec/default/wp-1/web')
+    // Draining well past the iframe-load timeout must not disturb the live
+    // shell — that timer is only armed in the `iframe-loading` phase
+    // (ExecPanel.tsx:115-127), which this path never enters.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(screen.getByTestId('exec-panel-fallback-terminal')).toBeTruthy()
+    expect(screen.queryByTestId('exec-panel-iframe')).toBeNull()
   })
 
-  it('falls back when iframe load timeout elapses (mirrors onerror fallback path)', async () => {
-    // Note: jsdom's iframe doesn't propagate the onError prop reliably,
-    // so this test exercises the same fallback code path via the
-    // 5-second iframe-load-timeout — the practical equivalent that the
-    // 5s timeout brief specifies. The onError branch is wired in
-    // ExecPanel.tsx and statically routes to the same setPhase call.
-    let wsInstance: FakeWebSocket | null = null
+  it('surfaces a WebSocket dial failure instead of hanging on a blank terminal', async () => {
+    // Replaces the old iframe-onerror coverage: the transport that can fail
+    // on the default path is now the WebSocket, and ExecPanel.tsx:139-145
+    // is the branch that has to degrade visibly. The iframe onError handler
+    // (ExecPanel.tsx:236-242) is no longer reachable — see the file
+    // docblock — so its coverage moves here.
     render(
       <ExecPanel
         deploymentId="dep"
@@ -147,25 +186,20 @@ describe('ExecPanel', () => {
         pod="wp-1"
         container="web"
         createSession={async () => HAPPY_SESSION}
-        iframeLoadTimeoutMs={50}
-        websocketFactory={(url) => {
-          wsInstance = new FakeWebSocket(url)
-          return wsInstance as unknown as WebSocket
+        websocketFactory={() => {
+          throw new Error('SecurityError: ws dial blocked')
         }}
         disableTerminal
       />,
     )
     fireEvent.click(screen.getByTestId('exec-panel-open'))
     await waitFor(() => {
-      expect(screen.getByTestId('exec-panel-iframe')).toBeTruthy()
+      expect(screen.getByTestId('exec-panel-error').textContent).toContain(
+        'SecurityError: ws dial blocked',
+      )
     })
-    act(() => {
-      vi.advanceTimersByTime(100)
-    })
-    await waitFor(() => {
-      expect(screen.getByTestId('exec-panel-fallback-banner')).toBeTruthy()
-    })
-    expect(wsInstance).not.toBeNull()
+    expect(screen.queryByTestId('exec-panel-fallback-terminal')).toBeNull()
+    expect(screen.getByTestId('exec-panel-error').textContent).toContain('Retry')
   })
 
   it('surfaces server error and offers retry', async () => {


### PR DESCRIPTION
## What

The operator-console vitest suite was red on `main`, so the frontend gate caught nothing.

| | Before (clean `origin/main`) | After |
|---|---|---|
| Test files | 9 failed / 193 passed (202) | **2 failed / 200 passed (202)** |
| Tests | 68 failed / 1876 passed (1944) | **8 failed / 1941 passed (1949)** |

**Test files only — zero application source changed.** `npx tsc -b` clean, `npm run build` clean, `eslint` clean on all 9 files.

The 8 remaining failures are **left red deliberately**. Each is a real defect with a traced root cause, not a stale expectation. A red test telling the truth is worth more than a green one that isn't.

## Per-file verdict

| File | Verdict | Result |
|---|---|---|
| `PinInput6.test.tsx` | test stale | 17/17 |
| `ExecPanel.test.tsx` | test stale | 9/9 |
| `ParentDomainsPage.test.tsx` | test stale | 6/6 |
| `UserAccessEditPage.test.tsx` | test stale | 8/8 |
| `ProvisionPage.sse-url.test.tsx` | test stale | 3/3 |
| `CloudComputePage.test.tsx` | test stale — pinned a fixed bug | 4/4 |
| `JobsPage.test.tsx` | test asserted an unimplemented feature | 13/13 |
| `SettingsPage.test.tsx` | 11 stale + **1 real defect** | 11/12 |
| `StepComponents.test.tsx` | 17 stale + **7 real defects** | 87/94 |

## Why each repaired expectation is correct

Every changed expectation is justified against shipped code or the commit that superseded it — never "it returns X now, so expect X".

- **PinInput6** — the component was deliberately re-architected to **one real `<input maxLength=6>` + 6 decorative boxes** (its own docblock, founder rule "paste must just work" 2026-05-04). The test still cast the boxes to `HTMLInputElement` and read `.value`/`.disabled`, which are `undefined` on non-inputs. The file was already half-migrated — its first test asserts the new design and passed. Digit expectations are preserved verbatim; they are now read from `textContent`. Coverage was *added* (aria-labels, tagName guards).
- **ExecPanel** — G85 #2632 (2026-06-01) made WS+xterm the primary path and the iframe a fallback, because the Guacamole embed URL was a cluster-internal address the operator's browser cannot resolve. `openShell()` sets `'fallback-loading'` directly. Tests still asserted iframe-first.
- **QueryClient cluster** (ParentDomains / UserAccessEdit / Settings / ProvisionPage.sse-url) — 24 failures, one cause: the harnesses never wrapped in `QueryClientProvider`, which `src/main.tsx:69` supplies in the real app. `ReadinessChip` (added to `PortalShell.tsx:125` by #3935) and `useResolvedDeploymentId` are both Query consumers. Every missing-testid error was downstream of the error boundary catching that throw. Matches the convention already used in 10+ sibling tests.
- **CloudComputePage** — the test expected **6** worker nodes; the fixture has 6 nodes but only **4** with `role: 'worker'` (the other 2 are `control-plane`). #4739 added the `role !== 'control-plane'` filter precisely to stop the over-count. **The old expectation pinned the exact bug #4739 fixed.** Added a companion test deriving the count from the fixture so it cannot drift again.
- **JobsPage** — `sov-jobs-show-as-flow` was only ever added to *this test file* (`git log -S` over `src/` matches the test and nothing else), and `/provision/$deploymentId/flow` **is not a route** in `router.tsx` — the test stood up a private `flowRoute` in its own harness so the target would exist. #3701 retired the Flow view of `/jobs`. Adding the button would have shipped a link to a 404, so the case is replaced by an assertion that the affordance is absent.
- **StepComponents** — `componentGroups.ts:527-536` overrides every component's `dependencies` with the Flux-canonical list from `blueprint-deps.generated.json`; the inline literals are dead code. Introduced by #652 under an explicit founder directive ("The single source of truth for the dependencies is flux!!!"), which never updated this test file. Each repaired expectation is cited to the real `HelmRelease.dependsOn` in `clusters/_template/bootstrap-kit/` (e.g. Harbor's seaweedfs dep was removed in 1.1.0 — `19-harbor.yaml:35-37`). New fixtures are **derived from the catalog** rather than hardcoded, and guarded so they cannot pass vacuously.

## 🛑 The 8 deliberate failures — verified defects

**S1 — Settings "Members" link drops the deploymentId** (1 test)
`SettingsPage.tsx:399` uses ``to={`/users` as never}``; the `as never` cast defeats typed-route checking. The sibling Decommission link 20 lines later uses the correct `to="/decommission/$deploymentId" params={{ deploymentId }}`, and its test passes — so `deploymentId` resolves fine. Both `/provision/$deploymentId/users` and the chroot `/users` exist, and SettingsPage renders on both routes, so on the mothership this navigates into the id-less console layout. This is the same defect class #4704 fixed for `/dashboard`; the codebase already has the id-safe helper `sovereignPathOrDeployments()`, used at 8+ sibling call sites and bypassed only here.
*Non-circular evidence:* at the earliest commit carrying both files, the source already read `/users` and the test already expected `/provision/.../users`. They have contradicted each other for their entire visible history — the assertion never ran green because the file threw on the missing QueryClient first. One-line fix available; held back because it is a navigation behaviour change adjacent to the open routing decision in #5401.

**S2 — dangling dependency ids reach the deployment payload** (1 test)
`depsFor()` injects Flux HelmRelease names with no `ComponentDef`: `gateway-api`, `reflector`, `spire` (verified: referenced as deps in `blueprint-deps.generated.json`, no matching `id:` in `componentGroups.ts`). `computeDefaultSelection()` returns 48 ids, 3 of them phantom — no card, no name — yet they land in `selectedComponents` and ship in the deployment payload.

**S3 — cnpg + postgres are installed on every Sovereign but appear in neither wizard tab** (4 tests)
`StepComponents.tsx:637-644` builds Tab 2 from `PRODUCTS.filter(p => p.tier === 'mandatory')` — **product** tier — while the counter beside it uses **component** tier. cnpg/postgres are `tier:'mandatory'` components inside FABRIC (`product.tier:'recommended'`), so Tab 2 drops them; Tab 1 already drops them for being mandatory. The rendered DOM reads **"Foundation (24)" above 22 cards**. The filter was added to stop KServe leaking into Always Included, but that cause was independently fixed by demoting KServe, so the filter now excludes exactly `{cnpg, postgres}`.

**S4 — Specter no longer cascades the CORTEX family** (2 tests)
`componentGroups.ts:275` still declares `dependencies: ['bge','milvus','langfuse','vllm','kserve']` with two comment blocks describing the operator-requested #175 rule. That literal is discarded (no `bp-specter` HelmRelease — confirmed absent from the generated deps), and **Specter is not a member of CORTEX's `components` list**, whose `cascadeOnMemberSelection: true` is the only cascade in the table. So ticking Specter — the AIOps brain — installs it alone: no vLLM, no Milvus, no BGE, no LangFuse, no KServe. Unlike the other #652 casualties (install-ordering edges Flux legitimately owns), this is a product-family *selection* rule the wizard models separately via `Product.familyDependencies`, so it belongs in the `PRODUCTS` table, not in Flux.

## Also worth flagging (not changed here)

- **`blueprint-deps.generated.json` has drifted from the bootstrap-kit** — 51 of 71 keys differ from the live `clusters/_template/bootstrap-kit/`. #652 listed a CI drift check as a follow-up and it was never added, so the declared "single source of truth" has diverged unchecked. New test fixtures were made derived so they survive a regeneration.
- **`PinInput6` `maxLength={6}` defeats its own paste contract** — browsers truncate a paste to `maxlength` *before* `input` fires, so "Your code is 372 458." becomes "Your c" and yields no digits. jsdom does not enforce `maxlength`, which is why no test catches it. This is on the passwordless-PIN login path.
- Running `npm run build` regenerates `catalog.generated.ts` + `blueprints.json` with substantial diffs, i.e. the committed artifacts are stale against their sources. Reverted here to keep this change test-only.

Refs #5404
Refs #5401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
