### PR TITLE
fix(newapi): declare the ui endpoint so the console's per-app Open control exists (#5389)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1294,7 +1294,12 @@ spec:
       #   limitranges, so its provisioning-postcondition verifier can read back
       #   the boundary objects it authors. An Org missing its console Gateway
       #   listener pair or its plan cap no longer reports Ready/Active.
-      version: 1.4.1228
+      # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint so
+      #   the console's per-app "Open" control exists at all for NewAPI —
+      #   `endpoints: []` made userUIGatePasses fail closed, suppressing the
+      #   externalURL the hero CTA + grid button render from, and 404'ing
+      #   GET /catalyst/v1/apps/bp-newapi/launch-url. UAT row 114.
+      version: 1.4.1229
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -329,9 +329,53 @@ spec:
           roles:
             mgmt-A: singleton
   # ── G117.3: Endpoints ──────────────────────────────────────────────────
-  # Per audit row: internal — exposed via Catalyst's API ingress (api.<sov>)
-  # not as a standalone external hostname.
-  endpoints: []
+  # #5389 (2026-07-27) — this used to read `endpoints: []` with the note
+  # "internal — exposed via Catalyst's API ingress (api.<sov>) not as a
+  # standalone external hostname". That stopped being true at #3374: the
+  # chart ships `templates/httproute.yaml`, which publishes the standalone
+  # host `newapi.<sovereign-fqdn>` and routes an **Exact `/`** match to the
+  # sandbox-bridge sidecar's zero-click SSO landing page, and
+  # `templates/sso-app-registration.yaml` registers the Keycloak redirect
+  # URI `https://newapi.<sovereign-fqdn>/oauth/<providerSlug>`. NewAPI has
+  # a first-class, SSO-gated admin console on its own hostname.
+  #
+  # The empty list was not merely stale metadata — it was load-bearing, and
+  # it removed the console's launch affordance entirely:
+  #
+  #   * `Handler.userUIGatePasses` (applications.go) FAILS CLOSED on
+  #     `len(bp.Endpoints) == 0`, so `externalURLIfUserUI` suppressed the
+  #     Application's externalURL. AppDetail renders the hero "Open" CTA
+  #     only under `{appExternalURL ? … : null}` and HandleSovereignApps
+  #     projects the AppsPage grid button from the same gate — so BOTH the
+  #     detail-page and the grid Open buttons were absent for bp-newapi.
+  #   * `HandleGetLaunchURL` (endpoint_handler.go) resolves the silent-SSO
+  #     target through `pickEndpoint`, which returns nil against an empty
+  #     endpoints[] → `GET /catalyst/v1/apps/bp-newapi/launch-url` answered
+  #     404 `endpoint-not-found`, so even the fallback launch path had
+  #     nothing to open.
+  #
+  # Measured live on hw290 2026-07-26 (UAT row 114): the bp-newapi app
+  # detail page exposed NO `data-testid=btn-launch-app`, and the launch-url
+  # endpoint returned `{"code":"endpoint-not-found","message":"Blueprint
+  # newapi has no endpoint \"\""}`. Declaring the endpoint restores both.
+  #
+  # ssoInitPath is the BARE ROOT `/` on purpose: unlike Grafana
+  # (`/login/generic_oauth`) or Harbor (`/c/oidc/login`), NewAPI has no
+  # app-local OIDC-init route — the platform supplies one, as the bridge
+  # sidecar's Exact-`/` landing page (internal/handler/sso_init.go 404s
+  # every path except `/`), which runs NewAPI's own onCustomOAuthClicked
+  # sequence (mint /api/oauth/state → /api/status → authorize redirect
+  # carrying kc_idp_hint=catalyst-pin). Root IS the init route here.
+  endpoints:
+    - name: ui
+      hostnameTemplate: "newapi.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+      ssoInitPath: "/"
   # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
   # NewAPI admin UI gated by KC OIDC; customer-API uses Catalyst-issued
   # API keys (not OIDC).

--- a/products/catalyst/bootstrap/api/internal/handler/applications_newapi_open_launch_5389_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_newapi_open_launch_5389_test.go
@@ -1,0 +1,236 @@
+// applications_newapi_open_launch_5389_test.go — the per-app "Open"
+// (launch) control for bp-newapi, driven by the REAL on-disk
+// platform/newapi/blueprint.yaml rather than a synthetic fixture.
+//
+// # What was broken (#5389, UAT row 114, measured live on hw290 2026-07-26)
+//
+// platform/newapi/blueprint.yaml declared `endpoints: []`. Two independent
+// console surfaces read that list, and BOTH went dark:
+//
+//  1. Handler.userUIGatePasses fails closed on len(Endpoints) == 0, so
+//     externalURLIfUserUI suppressed the Application's externalURL. AppDetail
+//     renders the hero CTA only under `{appExternalURL ? … : null}` and
+//     HandleSovereignApps projects the AppsPage grid button from the same
+//     gate — so NEITHER Open button existed for bp-newapi. The live walk
+//     recorded a locator timeout on [data-testid=btn-launch-app].
+//  2. HandleGetLaunchURL resolves its target via pickEndpoint, which returns
+//     nil against an empty list — GET /catalyst/v1/apps/bp-newapi/launch-url
+//     answered 404 {"code":"endpoint-not-found","message":"Blueprint newapi
+//     has no endpoint \"\""} (reproduced against the live hw290 catalyst-api
+//     before the fix).
+//
+// So there was no button to click, and no URL behind it either.
+//
+// # Why these tests read the file instead of a fixture
+//
+// The neighbouring #3224 tests in applications_open_button_gate_test.go all
+// build synthetic blueprintMeta values, so they would have passed unchanged
+// with bp-newapi's real declaration empty — a fixture can only prove the
+// predicate, never the declaration the Sovereign actually ships. These tests
+// therefore parse platform/newapi/blueprint.yaml itself: revert that file to
+// `endpoints: []` and they fail, naming the exact live symptom. The
+// `pre-#5389 shape` sub-tests below assert the failure direction explicitly,
+// so a green run means the fix is load-bearing, not that the assertions are
+// vacuous.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+)
+
+// repoRootFor5389 walks up from this test file to the monorepo root (the dir
+// containing platform/newapi/blueprint.yaml).
+func repoRootFor5389(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(thisFile)
+	for i := 0; i < 12; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "platform", "newapi", "blueprint.yaml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Skip("monorepo root (platform/newapi/blueprint.yaml) not found from test cwd — skipping on-disk blueprint test")
+	return ""
+}
+
+// newapiBlueprintEndpoints parses spec.endpoints[] out of the shipped
+// platform/newapi/blueprint.yaml and returns it in the shape the catalog
+// client hands to resolveBlueprintMeta.
+func newapiBlueprintEndpoints(t *testing.T) []map[string]interface{} {
+	t.Helper()
+	root := repoRootFor5389(t)
+	raw, err := os.ReadFile(filepath.Join(root, "platform", "newapi", "blueprint.yaml"))
+	if err != nil {
+		t.Fatalf("read platform/newapi/blueprint.yaml: %v", err)
+	}
+	var doc struct {
+		Spec struct {
+			Endpoints []map[string]interface{} `yaml:"endpoints"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse platform/newapi/blueprint.yaml: %v", err)
+	}
+	return doc.Spec.Endpoints
+}
+
+// TestNewAPIBlueprint_DeclaresLaunchableUIEndpoint — the declaration itself.
+// bp-newapi's chart publishes the standalone host newapi.<fqdn>
+// (chart/templates/httproute.yaml) and routes an Exact `/` match to the
+// sandbox-bridge sidecar's zero-click SSO landing page, so the Blueprint MUST
+// advertise that front door or the console cannot offer it.
+func TestNewAPIBlueprint_DeclaresLaunchableUIEndpoint(t *testing.T) {
+	eps := newapiBlueprintEndpoints(t)
+	if len(eps) == 0 {
+		t.Fatal("platform/newapi/blueprint.yaml declares NO endpoints — this is the #5389 regression: " +
+			"userUIGatePasses fails closed on an empty list, so the AppDetail hero Open CTA and the " +
+			"AppsPage grid button are both suppressed, and GET /catalyst/v1/apps/bp-newapi/launch-url " +
+			"404s endpoint-not-found. NewAPI serves an SSO-gated admin console on newapi.<fqdn>; declare it.")
+	}
+
+	meta := blueprintMetaFromEndpoints(t, eps)
+	if !blueprintHasUserUIEndpoint(meta) {
+		t.Fatalf("bp-newapi endpoints %+v carry no user-UI endpoint (need ssoEnabled || launchDefault || name==\"ui\") — "+
+			"the Open button gate would suppress the control", meta.Endpoints)
+	}
+
+	ep := pickEndpoint(meta, "")
+	if ep == nil {
+		t.Fatal("pickEndpoint(bp-newapi, \"\") = nil — the launch-url handler would answer 404 endpoint-not-found")
+	}
+	if !ep.SSOEnabled {
+		t.Fatalf("bp-newapi launch endpoint %q must be ssoEnabled: NewAPI's admin console is Keycloak-gated "+
+			"(chart/templates/sso-app-registration.yaml registers the KC redirect URI)", ep.Name)
+	}
+	if got, want := strings.TrimSpace(ep.HostnameTemplate), "newapi.{{.SovereignFQDN}}"; got != want {
+		t.Fatalf("bp-newapi hostnameTemplate = %q, want %q (chart/templates/httproute.yaml publishes "+
+			"`newapi.<sovereignFQDN>`; any other host has no listener)", got, want)
+	}
+	// The bare root IS NewAPI's OIDC-init route: the chart's Exact-`/` match
+	// hands it to the bridge sidecar, whose sso_init.go 404s every other path.
+	if got := strings.TrimSpace(ep.SSOInitPath); got != "/" {
+		t.Fatalf("bp-newapi ssoInitPath = %q, want \"/\" — NewAPI has no app-local OIDC-init route; the "+
+			"platform supplies one as the Exact-`/` bridge landing page (internal/handler/sso_init.go)", got)
+	}
+}
+
+// TestGetLaunchURL_NewAPI_FromShippedBlueprint — the control's target.
+// Both directions: the shipped declaration must mint the newapi front door,
+// and the pre-#5389 `endpoints: []` shape must reproduce the live 404.
+func TestGetLaunchURL_NewAPI_FromShippedBlueprint(t *testing.T) {
+	t.Run("shipped blueprint mints the front door", func(t *testing.T) {
+		h, _, _ := newTestHandlerWithEndpoint(t)
+		h.SetCatalogClient(fakeBlueprintInCatalog("newapi", newapiBlueprintEndpoints(t), false, []string{"singleton"}))
+
+		rec := httptest.NewRecorder()
+		// The console addresses bootstrap-kit apps by blueprint name (#3150 —
+		// launchKey = componentId when no Application CR uid exists).
+		newTestRouter(h).ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/bp-newapi/launch-url", nil))
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("launch-url for bp-newapi = %d (body=%s), want 200", rec.Code, rec.Body.String())
+		}
+		var resp launchURLResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode launch-url response: %v", err)
+		}
+		// SovereignFQDN is t01.omani.works in newTestHandlerWithEndpoint.
+		if want := "https://newapi.t01.omani.works/"; resp.URL != want {
+			t.Fatalf("launch-url = %q, want %q — the Open button opens this exact URL", resp.URL, want)
+		}
+		if resp.Endpoint != "ui" {
+			t.Fatalf("launch-url endpoint = %q, want \"ui\"", resp.Endpoint)
+		}
+	})
+
+	t.Run("pre-#5389 empty endpoints reproduce the live 404", func(t *testing.T) {
+		h, _, _ := newTestHandlerWithEndpoint(t)
+		h.SetCatalogClient(fakeBlueprintInCatalog("newapi", []map[string]interface{}{}, false, []string{"singleton"}))
+
+		rec := httptest.NewRecorder()
+		newTestRouter(h).ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/bp-newapi/launch-url", nil))
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("empty endpoints[]: launch-url = %d, want 404 — this sub-test guards that the "+
+				"assertion above is load-bearing (body=%s)", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "endpoint-not-found") {
+			t.Fatalf("empty endpoints[]: body = %s, want the live hw290 code endpoint-not-found", rec.Body.String())
+		}
+	})
+}
+
+// TestOpenButtonGate_NewAPI_FromShippedBlueprint — the control's existence.
+// externalURLIfUserUI is what AppDetail's `{appExternalURL ? … : null}` and
+// the AppsPage grid both render from; with the shipped declaration it must
+// survive, and with the pre-#5389 empty list it must be suppressed (the
+// live "no btn-launch-app" symptom).
+func TestOpenButtonGate_NewAPI_FromShippedBlueprint(t *testing.T) {
+	route := newHTTPRoute("newapi", "newapi-bp-newapi-public", "newapi.hw290.omani.works", "newapi")
+
+	t.Run("shipped blueprint renders the Open button", func(t *testing.T) {
+		f := newFactoryWithHTTPRoutes(t, route)
+		h := &Handler{log: quietLog()}
+		h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
+		h.SetCatalogClient(fakeBlueprintInCatalog("newapi", newapiBlueprintEndpoints(t), false, []string{"singleton"}))
+
+		if !h.userUIGatePasses(context.Background(), "bp-newapi") {
+			t.Fatal("bp-newapi must pass the user-UI gate — otherwise AppDetail renders no hero CTA and " +
+				"AppsPage renders no grid button (UAT row 114: btn-launch-app locator timeout)")
+		}
+		got := h.externalURLIfUserUI(context.Background(), "alpha", "bp-newapi", "newapi", "newapi")
+		if want := "https://newapi.hw290.omani.works"; got != want {
+			t.Fatalf("externalURL = %q, want %q — this is the value AppDetail gates the Open button on", got, want)
+		}
+	})
+
+	t.Run("pre-#5389 empty endpoints suppress the Open button", func(t *testing.T) {
+		f := newFactoryWithHTTPRoutes(t, route)
+		h := &Handler{log: quietLog()}
+		h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
+		h.SetCatalogClient(fakeBlueprintInCatalog("newapi", []map[string]interface{}{}, false, []string{"singleton"}))
+
+		if h.userUIGatePasses(context.Background(), "bp-newapi") {
+			t.Fatal("empty endpoints[] must fail the gate — guards that the assertion above is load-bearing")
+		}
+		if got := h.externalURLIfUserUI(context.Background(), "alpha", "bp-newapi", "newapi", "newapi"); got != "" {
+			t.Fatalf("empty endpoints[]: externalURL = %q, want empty (the live no-Open-button symptom)", got)
+		}
+	})
+}
+
+// blueprintMetaFromEndpoints decodes raw endpoint maps into blueprintMeta via
+// the SAME json round-trip resolveBlueprintMeta uses, so the test sees exactly
+// what the handler sees (field tags, defaulting, unknown-key tolerance).
+func blueprintMetaFromEndpoints(t *testing.T, eps []map[string]interface{}) *blueprintMeta {
+	t.Helper()
+	jsonBytes, err := json.Marshal(map[string]interface{}{"endpoints": eps})
+	if err != nil {
+		t.Fatalf("marshal endpoints: %v", err)
+	}
+	out := &blueprintMeta{}
+	if err := json.Unmarshal(jsonBytes, out); err != nil {
+		t.Fatalf("unmarshal into blueprintMeta: %v", err)
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_open_button_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_open_button_gate_test.go
@@ -5,9 +5,19 @@
 // HTTPRoute that matches an installed Application by name / backendRef /
 // hostname-leftmost-label. The SPA renders the "Open" button whenever
 // resp.ExternalURL is non-empty — so apps whose only endpoint is an
-// API/protocol surface (bp-newapi backend, bp-openova-flow-server,
-// keycloak's admin-only realm, an OCI registry endpoint, …) got a DEAD
-// "Open" button that lands the operator on a bare login form or a 404.
+// API/protocol surface (bp-openova-flow-server, keycloak's admin-only realm,
+// an OCI registry endpoint, …) got a DEAD "Open" button that lands the
+// operator on a bare login form or a 404.
+//
+// NOTE (#5389, 2026-07-27): the `newapi` names below are SYNTHETIC fixture
+// shapes kept for historical continuity — they are NOT bp-newapi's shipped
+// declaration. bp-newapi was the original #3224 exemplar, but its chart
+// publishes a standalone SSO-gated admin console on newapi.<fqdn>, and
+// carrying `endpoints: []` in platform/newapi/blueprint.yaml is what removed
+// its Open button entirely (UAT row 114). The real declaration is asserted
+// from disk in applications_newapi_open_launch_5389_test.go. What these cases
+// still prove is the predicate: an api/protocol-ONLY endpoint list must not
+// mint a launch affordance, whichever Blueprint happens to carry one.
 //
 // The fix: gate ExternalURL on the SAME blueprint-endpoint signal the
 // silent-SSO launch-url endpoint uses (endpoint_handler.go) — an app only
@@ -34,8 +44,9 @@ func TestBlueprintHasUserUIEndpoint(t *testing.T) {
 		want bool
 	}{
 		{
-			// bp-newapi: a single backend/protocol endpoint, no SSO UI.
-			// This is the regression case — must NOT show an Open button.
+			// A single backend/protocol endpoint, no SSO UI. This is the
+			// regression case — must NOT show an Open button. (Synthetic
+			// shape; see the #5389 note in the file header.)
 			name: "api-only endpoint does not qualify",
 			bp: &blueprintMeta{Endpoints: []endpointDecl{
 				{Name: "api", Protocol: "https", SSOEnabled: false, LaunchDefault: false},

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3603,7 +3603,14 @@ name: bp-catalyst-platform
 #   (reason=ProvisioningIncomplete) naming the missing artifact, and keeps the 30s
 #   requeue alive so the up-path re-converges. Read-only — Flux still owns the
 #   apply. Refs #5395.
-version: 1.4.1228
+version: 1.4.1229
+# 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
+#   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
+#   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
+#   suppressed the Application's externalURL — so the AppDetail hero "Open"
+#   CTA and the AppsPage grid button were BOTH absent for bp-newapi, and
+#   GET /catalyst/v1/apps/bp-newapi/launch-url answered 404
+#   endpoint-not-found. UAT row 114 (hw290 2026-07-26).
 # 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
 #   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2400,7 +2400,23 @@ business model is reselling LLM access to its own customers; use
           - mgmt-A
           roles:
             mgmt-A: singleton
-  endpoints: []
+  # #5389 — lockstep with platform/newapi/blueprint.yaml (see the long note
+  # there). This seed is the in-cluster fallback the bp-catalog-client reads
+  # when the gitea catalog-sovereign repo 404s, so an empty endpoints[] here
+  # reproduces the missing "Open" button + launch-url 404 on exactly the
+  # provs where gitea is unreachable. ssoInitPath is the bare root: the
+  # chart's Exact-`/` HTTPRoute match hands the root to the sandbox-bridge
+  # sidecar, whose zero-click landing page IS NewAPI's OIDC-init route.
+  endpoints:
+  - name: ui
+    hostnameTemplate: "newapi.{{ "{{" }}.SovereignFQDN{{ "}}" }}"
+    port: 443
+    protocol: https
+    tls: true
+    visibility: public
+    launchDefault: true
+    ssoEnabled: true
+    ssoInitPath: "/"
   sso:
     realm: sovereign
     protocolMapper: oidc


### PR DESCRIPTION
## What the four rows actually do

Rows 110 / 112 / 114 / 115 were all filed against #5389, but they do not share one cause. Walked live on hw290 as the owner (2026-07-26/27), against `dep=31106b6aa4a7e8e7`:

| row | app | what the Open control produces | verdict |
|---|---|---|---|
| 110 | Gitea | `https://gitea.hw290.omani.works/user/oauth2/openova-sso` — correct | control OK; lands SIGNED IN |
| 112 | Grafana | `https://grafana.hw290.omani.works/login/generic_oauth` — correct | control OK; lands SIGNED IN |
| **114** | **NewAPI** | **nothing — no button, and `launch-url` 404s** | **fixed here** |
| 115 | Guacamole | `https://guacamole.hw290.omani.works/guacamole/` — correct; gate leg completes | control OK; in-app leg is #5358 territory |

Three of the four produce the right target. One had no control at all. This PR fixes that one and does not paper over the other three.

### Row 114 — the defect

`platform/newapi/blueprint.yaml` carried `endpoints: []`, annotated *"internal — exposed via Catalyst's API ingress (api.<sov>) not as a standalone external hostname"*. That stopped being true at #3374: the chart ships `templates/httproute.yaml`, which publishes the standalone host `newapi.<sovereign-fqdn>` and routes an **Exact `/`** match to the sandbox-bridge sidecar's zero-click SSO landing page, and `templates/sso-app-registration.yaml` registers the Keycloak redirect URI `https://newapi.<sovereign-fqdn>/oauth/<providerSlug>`. NewAPI has a first-class, SSO-gated admin console on its own hostname.

The empty list was load-bearing. Two console surfaces read it and both went dark:

- `Handler.userUIGatePasses` fails closed on `len(bp.Endpoints) == 0`, so `externalURLIfUserUI` suppressed the Application's `externalURL`. AppDetail renders the hero CTA only under `{appExternalURL ? … : null}`, and `HandleSovereignApps` projects the AppsPage grid button from the same gate — so **neither** Open button rendered. That is the row's verbatim `btn-launch-app` locator timeout.
- `HandleGetLaunchURL` resolves its target via `pickEndpoint`, which returns nil against an empty list.

Measured against the live hw290 catalyst-api before this change, same session, same second:

```
GET /catalyst/v1/apps/bp-newapi/launch-url
  {"code":"endpoint-not-found","message":"Blueprint newapi has no endpoint \"\"","status":404}

GET /catalyst/v1/apps/bp-grafana/launch-url
  {"url":"https://grafana.hw290.omani.works/login/generic_oauth","endpoint":"ui", ...}
```

Same handler, same catalog — the only difference is the `endpoints[]` declaration.

### Why `ssoInitPath: "/"`

Unlike Grafana (`/login/generic_oauth`) or Harbor (`/c/oidc/login`), NewAPI has no app-local OIDC-init route. The platform supplies one: the chart's Exact-`/` HTTPRoute match hands the bare root to the bridge sidecar, whose `internal/handler/sso_init.go` 404s every path except `/` and runs NewAPI's own `onCustomOAuthClicked` sequence (mint `/api/oauth/state` → `/api/status` → authorize redirect carrying `kc_idp_hint=catalyst-pin`). Root **is** the init route here. Walked live 3/3: `https://newapi.hw290.omani.works/` → 200 through the catalyst-pin broker.

### Both delivery paths, in lockstep

The Blueprint reaches a Sovereign two ways, and an empty list in **either** reproduces the dead control on the provs that use that path:

- `platform/newapi/blueprint.yaml` — the gitea `catalog-sovereign` mirror.
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — the in-cluster fallback `bp-catalog-client` reads when gitea 404s.

`scripts/check-catalog-seed-lockstep.sh`: 68 checked, 0 drift. Umbrella bumped 1.4.1228 → 1.4.1229 (the seed lives inside that chart) with the bootstrap-kit slot-13 pin in lockstep.

## Tests — both directions, off disk not off a fixture

The neighbouring #3224 gate tests build synthetic `blueprintMeta` values, so they stayed green the whole time bp-newapi's real declaration was empty. That is exactly how this survived. The new tests parse the shipped `platform/newapi/blueprint.yaml` itself.

Reverting `endpoints: []` fails them with the live diagnosis verbatim:

```
--- FAIL: TestGetLaunchURL_NewAPI_FromShippedBlueprint/shipped_blueprint_mints_the_front_door
    launch-url for bp-newapi = 404 (body={"code":"endpoint-not-found",
    "message":"Blueprint newapi has no endpoint \"\"","status":404}), want 200
--- FAIL: TestOpenButtonGate_NewAPI_FromShippedBlueprint/shipped_blueprint_renders_the_Open_button
    bp-newapi must pass the user-UI gate — otherwise AppDetail renders no hero CTA
    and AppsPage renders no grid button (UAT row 114: btn-launch-app locator timeout)
```

Each test also carries a `pre-#5389 shape` sub-test asserting the failure direction, so a green run means the fix is load-bearing rather than the assertions being vacuous.

## What this PR does NOT claim

Rows 110 / 112 / 115 are **not** Open-control defects, and nothing here touches them:

- **110 / 112** — the launch URL is correct and lands signed in. Gitea 3/5 attempts reached its dashboard with the avatar + `Sign Out` + the owner's name in the DOM; Grafana 3/5 issued `grafana_session`. The misses are the pre-existing transport flake, measured independently at ~14% per request on every hw290 hostname (`api` 2/12, `auth` 2/12, `newapi` 1/12 connection timeouts). The silent-SSO chain is six external hops, so ~14% per hop compounds to roughly half of end-to-end attempts — which matches the observed miss rate. One Gitea miss surfaced as HTTP 500 rather than a timeout: its back-channel token POST to `https://auth.hw290.omani.works/.../token` was reset mid-flight (`read: connection reset by peer` in the gitea pod log), i.e. the same transport fault on the hairpin leg.
- **115** — the oidc-gate leg now completes end-to-end: `guacamole-gate` → catalyst-pin → `/oauth2/callback` → `_oidc_gate_guacamole` session cookie issued → SPA shell 200. bp-guacamole 0.2.31 (the #5358 code-flow + header-auth fix) is live on hw290. Whether the connections list itself renders needs a JS-executing walk; that is #5358's surface, not the launch control's.
- The earlier `invalid_client` root cause quoted in rows 110/112 is gone — hw290's Keycloak now logs `cookie_not_found` on the residual failures instead, consistent with #5403 having landed.

## Note for a follow-up

`spec.card.summary` / `description` still say NewAPI's admin UI lives at `admin.<host>`; it is served at `newapi.<host>`. Left alone to keep this diff to the control being fixed.

Refs #5389
