### PR TITLE
fix(harbor): one session/queue/cache store per Sovereign, anchored in the active region (Refs #5406)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -228,7 +228,9 @@ spec:
       # deadlocked cutover step-08's forced roll on Multi-Attach (#5022).
       # 1.2.44: #5302 — fix the disableredirect key casing (was silently-dropped
       # camelCase; the s3 overlay above now sets the correct lowercase key).
-      version: 1.2.44
+      # 1.2.45: #5406 — ONE session/queue/cache store per Sovereign. See the
+      # crossRegion block in `values:` below for the full wiring + rationale.
+      version: 1.2.45
       sourceRef:
         kind: HelmRepository
         name: bp-harbor
@@ -296,6 +298,39 @@ spec:
   # - harbor.persistence.imageChartStorage.s3.existingSecret matches the
   #   credentials Secret name templated by the umbrella chart.
   values:
+    # ── Cross-region session/queue/cache store (#5406) ──────────────────
+    # Harbor's OIDC session lives in Redis db 0 (`_REDIS_URL_CORE`), its job
+    # queue in db 1, its registry blob-descriptor cache in db 2. On a 2-region
+    # Sovereign ONE shared wildcard VIP fans `registry.${SOVEREIGN_FQDN}` at
+    # BOTH regions' envoys, so both regions' harbor-core serve — but upstream's
+    # `redis.type: internal` default gave each region its OWN redis. A session
+    # minted by whichever region handled /c/oidc/callback was invisible to the
+    # other, so the SPA's `/api/v2.0/users/current` 401'd on every request that
+    # landed on the other region and bounced the operator to /account/sign-in.
+    # Measured live on hw290 (dep 31106b6aa4a7e8e7, 2026-07-26 21:13:44Z):
+    # region-A users/current 200 + region-B users/current 401 in the SAME
+    # second, one page-load, same referer + UA.
+    #
+    # Harbor's OTHER two stateful stores were ALREADY anchored in the active
+    # region — Postgres via SOVEREIGN_HARBOR_PG_HOST=shared-pg-mesh-rw (a
+    # zero-endpoint ClusterMesh global-Service alias on the secondary) and blobs
+    # via one Object Storage bucket. Redis is simply brought in line: it is
+    # anchored in the ACTIVE region and the standby reaches it over ClusterMesh.
+    #
+    # SOVEREIGN_ENABLE_CNPG_PAIR is stamped `true` on BOTH regions by
+    # catalyst-api ONLY after Cilium ClusterMesh is established, so:
+    #   - single-region prov  → stays false → chart renders NOTHING here
+    #     (no Service, no CiliumNetworkPolicy) → byte-identical to pre-#5406;
+    #   - 2-region prov       → region-B boots with its OWN local redis and
+    #     flips to the shared one only once the mesh is proven up — no
+    #     bootstrap-ordering crashloop window.
+    crossRegion:
+      enabled: ${SOVEREIGN_ENABLE_CNPG_PAIR:=false}
+      role: ${SOVEREIGN_REGION_ROLE:=primary}
+      # Peer ClusterMesh cluster name(s) — same source var bp-postgres (16a/16c/
+      # 16d) + bp-cnpg-pair (16b) consume for their cross-region DR CNP. EMPTY
+      # (single-region) → no CiliumNetworkPolicy rendered.
+      peerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:=[]}
     # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
     # The chart self-registers the Application CR for harbor (the canonical
     # instance representation every console surface reads), marked
@@ -378,6 +413,20 @@ spec:
       # than "registry.<sov-fqdn>" → silent-SSO callback 400s on every
       # operator login. Caught live by H12 Playwright walk on hw86 2026-06-03.
       externalURL: "https://registry.${SOVEREIGN_FQDN}"
+      # #5406 — the SECONDARY half of the cross-region store above. Upstream
+      # ties BOTH "render the redis StatefulSet" AND "which address harbor
+      # dials" to this one `type` key (charts/harbor/templates/redis/*.yaml is
+      # `if eq .Values.redis.type "internal"`, and harbor.redis.addr ternaries
+      # on the same key), so flipping the standby to `external` is what removes
+      # its duplicate redis AND points it at the merged global Service in one
+      # move. Both substitutes are stamped by catalyst-api's post-mesh gate
+      # (the same gate that stamps SOVEREIGN_HARBOR_PG_HOST) on SECONDARY
+      # regions only — so the ACTIVE region and every single-region prov keep
+      # the defaults below and render byte-identically to pre-#5406.
+      redis:
+        type: ${SOVEREIGN_HARBOR_REDIS_TYPE:=internal}
+        external:
+          addr: "${SOVEREIGN_HARBOR_REDIS_ADDR:=}"
       # ADR-0010: when harbor SHARES the bp-postgres `shared-pg` instance,
       # its external DB host points at the shared cluster's -rw Service
       # (in the shared-data namespace). Default points at harbor's OWN

--- a/platform/harbor/README.md
+++ b/platform/harbor/README.md
@@ -161,6 +161,44 @@ core:
   secretName: harbor-core-secret
 ```
 
+### Multi-region: one session/queue/cache store per Sovereign (#5406)
+
+A 2-region Sovereign runs a Harbor front-end on **both** control planes, and one
+shared wildcard VIP fans `registry.<sovereign-fqdn>` at both regions' envoys —
+so both regions serve. Harbor's three stateful stores are therefore anchored in
+the **active** region and reached from the standby over Cilium ClusterMesh:
+
+| Store | Contents | Anchor |
+|---|---|---|
+| Postgres | registry metadata | `shared-pg-mesh-rw.shared-data` (global-Service alias) |
+| Object Storage | image + chart blobs | one bucket, written by both regions |
+| **Redis** | OIDC **session** (db 0), jobservice queue (db 1), registry blob-descriptor cache (db 2) | **`harbor-redis-mesh.harbor`** (global-Service alias) |
+
+Redis used to be the exception: upstream's `redis.type: internal` default gave
+each region its own store, so a session minted by whichever region handled
+`/c/oidc/callback` was invisible to the other and `/api/v2.0/users/current`
+401'd on every request that landed on the other region — per-request, within a
+single page load. The same split ran the jobservice queue and the registry blob
+cache twice, uncoordinated, over one shared database and one shared bucket.
+
+The chart now publishes `harbor-redis-mesh` as a Cilium ClusterMesh global
+Service on both regions (`crossRegion.enabled`, wired by bootstrap-kit slot 19
+to `SOVEREIGN_ENABLE_CNPG_PAIR`), and the standby's upstream redis is flipped to
+`type: external` pointing at it — which both removes its duplicate store and
+repoints every consumer. Ships alongside identity-based CiliumNetworkPolicies,
+because a plain NetworkPolicy can never admit a ClusterMesh peer (Cilium
+AND-injects the local cluster label into every selector it derives).
+
+**Failover:** on an active-region kill the standby loses this Redis — it already
+loses its Postgres the same way, so Harbor's control plane needs
+`bp-continuum`'s switchover either way (see `blueprint.yaml`
+`topology.perTopology.active-hot-standby.switchover`). The Redis anchor rides
+the same substitute seam as `SOVEREIGN_HARBOR_PG_HOST`, so a switchover
+repoints it exactly the way it repoints the database.
+
+A **single-region** Sovereign never reaches the ClusterMesh gate: no global
+Service, no policy, `redis.type: internal` — identical to the pre-#5406 render.
+
 ### Pull-mirror policy
 
 ```json

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.44  # lockstep with chart/Chart.yaml (#5302 disableredirect key casing — see Chart.yaml changelog)
+  version: 1.2.45  # lockstep with chart/Chart.yaml (#5406 cross-region Redis anchor — see Chart.yaml changelog)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -181,7 +181,41 @@ type: application
 #   sovereign registry streams blobs over its own trusted host, never redirects
 #   to a differently-certed Object Storage backend. tests/registry-disableredirect.sh
 #   guards the wiring so the casing typo cannot recur.
-version: 1.2.44
+# 1.2.45 (#5406): ONE Harbor session/queue/cache store per Sovereign, anchored
+#   in the ACTIVE region and reached from the standby over Cilium ClusterMesh.
+#   Harbor keeps its OIDC session in Redis db 0, its job queue in db 1 and its
+#   registry blob-descriptor cache in db 2. Two of Harbor's three stateful
+#   stores were already anchored in region-A on a 2-region Sovereign (Postgres
+#   via the zero-endpoint `shared-pg-mesh-rw` global-Service alias; blobs via a
+#   single Object Storage bucket) — Redis was the only one left region-local,
+#   because upstream's `redis.type: internal` default survived into a topology
+#   it does not fit. Since ONE shared wildcard VIP fans `registry.<fqdn>` at
+#   BOTH regions' envoys, a session minted by whichever region handled
+#   /c/oidc/callback was invisible to the other and every request that landed
+#   on the other region 401'd — per-request, so it read as flake. Measured live
+#   on hw290 (dep 31106b6aa4a7e8e7, 2026-07-26 21:13:44Z): region-A
+#   `/api/v2.0/users/current` 200 and region-B `/api/v2.0/users/current` 401 in
+#   the SAME second, same referer + UA, one page-load. The same split also ran
+#   harbor-jobservice's work queue and harbor-registry's blob cache twice,
+#   uncoordinated, over one shared DB and one shared bucket.
+#   Ships templates/redis-mesh-service.yaml (the `harbor-redis-mesh` Cilium
+#   global Service, rendered on BOTH regions — the openbao `openbao-active-mesh`
+#   / cnpg-pair `*-primary-mesh` idiom) + templates/redis-crossregion-netpol.yaml
+#   (identity-based CiliumNetworkPolicies; a k8s NetworkPolicy can never admit a
+#   ClusterMesh peer because Cilium AND-injects the LOCAL cluster label into
+#   every selector it derives — verified with cilium-dbg on hw290, same class as
+#   #4846/#4854). The slot flips the SECONDARY to `harbor.redis.type: external`
+#   pointing at the mesh Service, so upstream renders no local redis there.
+#   FAILOVER: on a region-A kill the standby loses this Redis — it ALREADY
+#   loses its Postgres the same way, so Harbor needs bp-continuum's switchover
+#   either way (blueprint.yaml topology.perTopology.active-hot-standby.
+#   switchover.mechanism), and the Redis anchor rides the SAME substitute seam
+#   as SOVEREIGN_HARBOR_PG_HOST so the switchover repoints it identically.
+#   All of it is gated on crossRegion.enabled (slot-wired to
+#   ${SOVEREIGN_ENABLE_CNPG_PAIR}, which catalyst-api stamps true only once
+#   ClusterMesh is established) — a single-region render is byte-identical.
+#   Guarded by tests/redis-crossregion.sh.
+version: 1.2.45
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/redis-crossregion-netpol.yaml
+++ b/platform/harbor/chart/templates/redis-crossregion-netpol.yaml
@@ -1,0 +1,111 @@
+{{- /*
+Cross-region Redis reachability CiliumNetworkPolicies (#5406).
+
+The `harbor` namespace carries bp-plane-isolation's `harbor-default-deny`
+NetworkPolicy. A plain k8s NetworkPolicy can NEVER admit a ClusterMesh peer:
+Cilium AND-injects `io.cilium.k8s.policy.cluster=<local>` into every selector
+it derives from a k8s NetworkPolicy. Verified live on hw290 region-A —
+`cilium-dbg policy selectors` renders the harbor default-deny's ingress rule as
+
+    &LabelSelector{MatchLabels:map[string]string{
+        k8s.io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: catalyst-system,
+        k8s.io.cilium.k8s.policy.cluster: hw290-mesh,}}   ← LOCAL cluster pinned
+      LABELS: harbor/harbor-default-deny
+
+while the policies that deliberately reach the peer carry
+`MatchExpressions{Key: any.io.cilium.k8s.policy.cluster, Operator: In,
+Values:[hw290-me-east-b]}`. Same finding as #4846/#4854 (an `ipBlock` is
+equally inert — a ClusterMesh remote Pod is a KNOWN endpoint with its own
+identity, never a CIDR identity).
+
+So the cross-region redis dial needs identity-based CiliumNetworkPolicies.
+Cilium unions every policy selecting an endpoint, so these are purely
+ADDITIVE to the default-deny: they grant peer-region reachability on 6379
+only, to/from peer-cluster identities only — no `world`, no extra ports.
+
+Both halves render on BOTH regions so a bp-continuum switchover (which swaps
+which region is active) needs no policy change and has no ordering hazard:
+  - INGRESS: admit peer-region Pods to this region's harbor-redis on 6379.
+    Live on the ACTIVE region; inert on the standby (no local redis Pod).
+  - EGRESS:  admit this region's harbor Pods to a peer-region redis on 6379.
+    Live on the standby; inert on the active region (its redis is local, and
+    a local ClusterIP is already covered by the default-deny's
+    namespaceSelector:{}).
+
+ANY-NAMESPACE note (#4854 row 67 L2): a namespaced CNP's from/toEndpoints is
+implicitly ANDed with BOTH `io.cilium.k8s.policy.cluster=<local>` AND
+`k8s:io.kubernetes.pod.namespace=<this policy's namespace>`. Referencing the
+namespace key with `Exists` suppresses the second AND-injection so the rule
+is not silently narrowed to peer-region Pods that happen to sit in a
+same-named namespace.
+
+Gated on `crossRegion.peerClusters` (the peer ClusterMesh name(s), stamped by
+catalyst-api at the post-mesh cnpg-pair flip as
+SOVEREIGN_PEER_CLUSTERMESH_NAMES) and on the cilium.io/v2 Capabilities check
+(the #2988/#3102 idiom) so the chart still installs on CRD-less clusters
+(kind CI). EMPTY peer list (singleton / single-region) → NO policy → the
+default render is byte-identical to origin/main.
+*/ -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- $peers := $cr.peerClusters | default list -}}
+{{- if and $cr.enabled (gt (len $peers) 0) (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
+{{- $redis := $cr.redis | default dict -}}
+{{- $port := $redis.port | default 6379 | toString -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: harbor-crossregion-redis-ingress
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    catalyst.openova.io/component: harbor-crossregion-redis-netpol
+spec:
+  endpointSelector:
+    matchLabels:
+      app: {{ $redis.appLabel | default "harbor" | quote }}
+      release: {{ $redis.releaseLabel | default .Release.Name | quote }}
+      component: redis
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peers }}
+                - {{ . | quote }}
+                {{- end }}
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
+      toPorts:
+        - ports:
+            - port: {{ $port | quote }}
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: harbor-crossregion-redis-egress
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    catalyst.openova.io/component: harbor-crossregion-redis-netpol
+spec:
+  # Every endpoint in the harbor namespace — matching the default-deny's own
+  # scope. harbor-core / -jobservice / -registry all dial redis.
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peers }}
+                - {{ . | quote }}
+                {{- end }}
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
+      toPorts:
+        - ports:
+            - port: {{ $port | quote }}
+              protocol: TCP
+{{- end }}

--- a/platform/harbor/chart/templates/redis-mesh-service.yaml
+++ b/platform/harbor/chart/templates/redis-mesh-service.yaml
@@ -1,0 +1,121 @@
+{{- /*
+Cross-region Harbor session/queue/cache store — ClusterMesh global Service (#5406).
+
+── WHY ────────────────────────────────────────────────────────────────────
+Harbor keeps THREE stateful stores. On a 2-region Sovereign two of them are
+already anchored in the ACTIVE region and reached from the standby region:
+
+  1. Postgres  — the secondary's harbor-core dials `shared-pg-mesh-rw.
+     shared-data` (a ZERO-endpoint ClusterMesh global-Service alias) and
+     resolves to region-A's `shared-pg` primary. Stamped by cloud-init /
+     re-stamped by catalyst-api's post-mesh gate (#4436).
+  2. Blob store — ONE Object Storage bucket, written by both regions
+     (persistence.imageChartStorage.s3, ADR-0001 §13).
+  3. Redis      — upstream default `redis.type: internal`, so EACH region
+     ran its OWN `harbor-redis` StatefulSet on its OWN PVC.
+
+(3) was never a decision; it is the upstream default surviving into a
+topology it does not fit. Harbor's Blueprint declares `active-hot-standby`
+(mgmt-A active, mgmt-B passive, switchover via bp-continuum) — not
+active/active — yet the shared wildcard VIP fans requests for
+`registry.<fqdn>` at BOTH regions' envoys, so BOTH region's harbor-core
+serve. Harbor's OIDC session lives in Redis db 0 (`_REDIS_URL_CORE`), so a
+session minted by whichever region handled `/c/oidc/callback` is invisible
+to the other, and every later request that lands on the other region 401s.
+
+Measured live on hw290 (dep 31106b6aa4a7e8e7, 2026-07-26 21:13:43-44Z), one
+browser page-load split across both regions in the SAME second:
+    region-A nginx  GET /c/oidc/callback…            302   (session minted here)
+    region-A nginx  GET /api/v2.0/users/current       200
+    region-B nginx  GET /api/v2.0/users/current       401
+    region-B nginx  GET /api/v2.0/projects…           200   (shared DB — fine)
+…then the SPA bounces to /account/sign-in and every subsequent
+`users/current` that lands on region-B 401s forever.
+
+The same split silently duplicated TWO more things over one shared DB and
+one shared bucket: harbor-jobservice's work queue (Redis db 1) and
+harbor-registry's blob-descriptor cache (Redis db 2) each ran twice,
+uncoordinated.
+
+── WHAT THIS DOES ─────────────────────────────────────────────────────────
+Anchors Redis in the ACTIVE region and lets the standby region reach it over
+Cilium ClusterMesh — the SAME idiom already load-bearing in this repo for
+bp-openbao (`openbao-active-mesh`), bp-cnpg-pair / bp-postgres
+(`*-mesh-rw`), and the region-b catalyst edge stubs
+(bp-catalyst-edge-routes `catalyst-api`):
+
+  - BOTH regions render this Service under the SAME name+namespace — Cilium
+    merges ClusterMesh global services by name+namespace, so the name must
+    exist on every participating cluster.
+  - PRIMARY: the selector matches the local `harbor-redis` Pod (upstream
+    `redis.type: internal` still renders its StatefulSet + Service there), and
+    `service.cilium.io/shared: "true"` exports those backends to the peer.
+  - SECONDARY: the slot flips `harbor.redis.type: external` +
+    `external.addr` at this Service, so upstream renders NO local redis. The
+    selector therefore matches ZERO local Pods and `affinity: local` falls
+    through the mesh to the primary's redis. `shared: "false"` keeps the
+    standby from ever exporting a redis of its own, so the primary can never
+    land a session in the standby region.
+
+── FAILOVER ───────────────────────────────────────────────────────────────
+On a region-A kill the secondary's harbor-core loses this Redis. It ALREADY
+loses its Postgres in exactly the same way (`shared-pg-mesh-rw` has no local
+backends in region-B), so the failure envelope is unchanged in kind: Harbor's
+control plane needs bp-continuum's switchover either way — which is precisely
+what platform/harbor/blueprint.yaml `topology.perTopology.active-hot-standby.
+switchover.mechanism: bp-continuum` already declares. The anchor is exposed as
+`crossRegion.redis.meshServiceName` + driven by the SAME substitute seam as
+`SOVEREIGN_HARBOR_PG_HOST`, so a switchover repoints Redis exactly the way it
+repoints the DB.
+
+── GATING ─────────────────────────────────────────────────────────────────
+`crossRegion.enabled` is wired by the slot to `${SOVEREIGN_ENABLE_CNPG_PAIR}`
+— stamped `true` on BOTH regions by catalyst-api only once Cilium ClusterMesh
+is actually established. A single-region prov never reaches that flip, so a
+default `helm template` renders NOTHING here and the single-region output is
+byte-identical to origin/main.
+*/ -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- if $cr.enabled -}}
+{{- $redis := $cr.redis | default dict -}}
+{{- $svcName := $redis.meshServiceName | default "harbor-redis-mesh" -}}
+{{- $affinity := $redis.affinity | default "local" -}}
+{{- $port := $redis.port | default 6379 -}}
+{{- $role := $cr.role | default "primary" -}}
+{{- $isPrimary := not (eq $role "secondary") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $svcName | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    catalyst.openova.io/component: harbor-redis-cross-region-mesh
+    catalyst.openova.io/cross-region-role: {{ $role | quote }}
+  annotations:
+    # Cilium ClusterMesh — the SAME name+namespace on both sides so the mesh
+    # merges the two Services into one global service.
+    service.cilium.io/global: "true"
+    # Export backends from the ACTIVE region only. The standby has no redis
+    # Pod to export (redis.type=external there), and pinning shared=false
+    # makes that explicit: the primary must never land a session in the
+    # standby region.
+    service.cilium.io/shared: {{ $isPrimary | ternary "true" "false" | quote }}
+    service.cilium.io/affinity: {{ $affinity | quote }}
+    catalyst.openova.io/blueprint: bp-harbor
+spec:
+  type: ClusterIP
+  selector:
+    # Upstream goharbor selector for the internal redis Pod
+    # (charts/harbor/templates/redis/service.yaml = harbor.matchLabels +
+    # component: redis). Matches the local redis on the PRIMARY; matches
+    # ZERO Pods on the SECONDARY (no local redis) → the dial crosses the mesh.
+    app: {{ $redis.appLabel | default "harbor" | quote }}
+    release: {{ $redis.releaseLabel | default .Release.Name | quote }}
+    component: redis
+  ports:
+    - name: redis
+      port: {{ $port }}
+      targetPort: 6379
+      protocol: TCP
+{{- end }}

--- a/platform/harbor/chart/tests/redis-crossregion.sh
+++ b/platform/harbor/chart/tests/redis-crossregion.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# bp-harbor — cross-region session/queue/cache store wiring guard (#5406).
+#
+# Harbor keeps its OIDC session in Redis db 0 (`_REDIS_URL_CORE`), its
+# jobservice work queue in db 1 and its registry blob-descriptor cache in db 2.
+# On a 2-region Sovereign ONE shared wildcard VIP fans registry.<fqdn> at BOTH
+# regions' envoys, so both regions' harbor-core serve — but upstream's default
+# `redis.type: internal` gave each region its OWN redis StatefulSet, so the
+# session minted by whichever region handled /c/oidc/callback was invisible to
+# the other and every request that landed on the other region 401'd. Measured
+# live on hw290 (dep 31106b6aa4a7e8e7, 2026-07-26 21:13:44Z): region-A
+# /api/v2.0/users/current 200 and region-B /api/v2.0/users/current 401 in the
+# SAME second, one page-load.
+#
+# The fix anchors Redis in the ACTIVE region and reaches it from the standby
+# over Cilium ClusterMesh — the openbao `openbao-active-mesh` /
+# bp-cnpg-pair `*-primary-mesh` idiom, and the same shape Harbor's Postgres
+# already uses (`shared-pg-mesh-rw`).
+#
+# Cases:
+#   1. GUARD: default (single-region) render emits NO mesh Service and NO
+#      CiliumNetworkPolicy — byte-identical to pre-#5406.
+#   2. PRIMARY: mesh Service renders, exports its backends
+#      (service.cilium.io/shared=true), selects the local redis Pod.
+#   3. SECONDARY: mesh Service renders under the SAME name (Cilium merges
+#      global services by name+namespace) but does NOT export
+#      (service.cilium.io/shared=false) — the standby must never land a
+#      session of its own that the active region could pick up.
+#   4. SECONDARY: `harbor.redis.type: external` at the mesh Service removes the
+#      duplicate redis StatefulSet AND repoints every consumer's _REDIS_URL_*
+#      at it. This is what the bootstrap-kit slot wires from
+#      SOVEREIGN_HARBOR_REDIS_{TYPE,ADDR}.
+#   5. Cross-region CiliumNetworkPolicies render ONLY when peerClusters is
+#      non-empty, and carry the peer-cluster identity selector on 6379.
+#      (A k8s NetworkPolicy can never admit a ClusterMesh peer — Cilium
+#      AND-injects the LOCAL cluster label into every selector it derives, so
+#      the harbor-default-deny cannot express this. Same class as #4846/#4854.)
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+svc_tpl="templates/redis-mesh-service.yaml"
+cnp_tpl="templates/redis-crossregion-netpol.yaml"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+render() { "$helm" template smoke "$chart_dir" "$@" 2>/dev/null; }
+
+# `helm template --show-only <f>` EXITS NON-ZERO when the template renders
+# nothing, so absence is asserted via the exit code, not an empty string.
+renders_nothing() {
+  local tpl="$1"; shift
+  ! "$helm" template smoke "$chart_dir" --show-only "$tpl" "$@" >/dev/null 2>&1
+}
+
+# ── Case 1: default render is inert ───────────────────────────────────
+echo "[bp-harbor] Case 1: default (single-region) → NO mesh Service, NO cross-region CNP"
+if ! renders_nothing "$svc_tpl"; then
+  echo "FAIL: the ClusterMesh redis Service rendered on a DEFAULT (single-region) render."
+  echo "crossRegion.enabled must gate it — a single-region Sovereign has no peer to mesh with."
+  exit 1
+fi
+if ! renders_nothing "$cnp_tpl"; then
+  echo "FAIL: the cross-region CiliumNetworkPolicies rendered on a DEFAULT render."
+  exit 1
+fi
+echo "[bp-harbor] Case 1: PASS"
+
+# ── Case 2: primary exports its redis to the mesh ─────────────────────
+echo "[bp-harbor] Case 2: crossRegion.role=primary → mesh Service exports backends"
+primary_svc=$(render --set crossRegion.enabled=true --set crossRegion.role=primary \
+                --show-only "$svc_tpl")
+echo "$primary_svc" | grep -q 'name: "harbor-redis-mesh"' || {
+  echo "FAIL: mesh Service is not named harbor-redis-mesh (Cilium merges global services by NAME+namespace)"; exit 1; }
+echo "$primary_svc" | grep -q 'service.cilium.io/global: "true"' || {
+  echo "FAIL: mesh Service is missing service.cilium.io/global — Cilium will not publish it across the mesh"; exit 1; }
+echo "$primary_svc" | grep -q 'service.cilium.io/shared: "true"' || {
+  echo "FAIL: the ACTIVE region must EXPORT its redis backends (service.cilium.io/shared=true) or the standby has nothing to reach"; exit 1; }
+echo "$primary_svc" | grep -q 'component: redis' || {
+  echo "FAIL: mesh Service does not select the upstream redis Pod (app/release/component: redis)"; exit 1; }
+echo "$primary_svc" | grep -qE 'port: 6379' || {
+  echo "FAIL: mesh Service does not publish 6379"; exit 1; }
+echo "[bp-harbor] Case 2: PASS"
+
+# ── Case 3: secondary renders the same name but never exports ─────────
+echo "[bp-harbor] Case 3: crossRegion.role=secondary → same Service name, shared=false"
+secondary_svc=$(render --set crossRegion.enabled=true --set crossRegion.role=secondary \
+                  --show-only "$svc_tpl")
+echo "$secondary_svc" | grep -q 'name: "harbor-redis-mesh"' || {
+  echo "FAIL: the secondary must render the SAME Service name or Cilium cannot merge the two into one global service"; exit 1; }
+echo "$secondary_svc" | grep -q 'service.cilium.io/shared: "false"' || {
+  echo "FAIL: the STANDBY must NOT export redis backends — otherwise the active region can land a session in the standby, re-creating the split"; exit 1; }
+echo "[bp-harbor] Case 3: PASS"
+
+# ── Case 4: the secondary's external flip removes its duplicate redis ──
+echo "[bp-harbor] Case 4: harbor.redis.type=external → no local redis, consumers dial the mesh"
+sec_full=$(render \
+  --set crossRegion.enabled=true --set crossRegion.role=secondary \
+  --set harbor.redis.type=external \
+  --set harbor.redis.external.addr=harbor-redis-mesh.harbor.svc.cluster.local:6379)
+if echo "$sec_full" | grep -qE '^kind: StatefulSet' && echo "$sec_full" | grep -q 'name: harbor-redis$'; then
+  echo "FAIL: the secondary still renders its OWN harbor-redis StatefulSet — the session store is still split."
+  exit 1
+fi
+echo "$sec_full" | grep -q 'redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/0' || {
+  echo "FAIL: harbor-core's _REDIS_URL_CORE (db 0 — the OIDC SESSION store) does not point at the mesh Service."
+  echo "This is the exact wire whose absence 401s every cross-region request (#5406)."
+  exit 1; }
+echo "$sec_full" | grep -q 'redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/2' || {
+  echo "FAIL: the registry blob-descriptor cache (db 2) does not point at the mesh Service"; exit 1; }
+echo "[bp-harbor] Case 4: PASS"
+
+# ── Case 5: cross-region CNPs are peer-gated + identity-based ──────────
+echo "[bp-harbor] Case 5: peerClusters → identity-based CiliumNetworkPolicies on 6379"
+if ! renders_nothing "$cnp_tpl" --set crossRegion.enabled=true; then
+  echo "FAIL: the cross-region CNPs rendered with an EMPTY peerClusters list —"
+  echo "there is no peer identity to admit, so the policy would be inert at best."
+  exit 1
+fi
+cnp=$(render --set crossRegion.enabled=true \
+        --set crossRegion.peerClusters[0]=hw290-me-east-b \
+        --api-versions cilium.io/v2 --show-only "$cnp_tpl")
+echo "$cnp" | grep -q 'name: harbor-crossregion-redis-ingress' || {
+  echo "FAIL: the INGRESS carve-out is missing — the active region's harbor-default-deny drops the peer's redis SYN"; exit 1; }
+echo "$cnp" | grep -q 'name: harbor-crossregion-redis-egress' || {
+  echo "FAIL: the EGRESS carve-out is missing — the standby's dial is dropped before it leaves"; exit 1; }
+echo "$cnp" | grep -q 'key: io.cilium.k8s.policy.cluster' || {
+  echo "FAIL: the CNPs do not select the peer by ClusterMesh cluster identity."
+  echo "A CIDR/ipBlock rule can NEVER match a ClusterMesh remote Pod (it is a known endpoint"
+  echo "with its own identity, not a CIDR identity) — proven on hw228 (#4846/#4854)."
+  exit 1; }
+echo "$cnp" | grep -q 'hw290-me-east-b' || {
+  echo "FAIL: the peer cluster name did not reach the rendered policy"; exit 1; }
+echo "$cnp" | grep -q 'port: "6379"' || {
+  echo "FAIL: the CNPs do not scope to 6379 — either the port is wrong or the surface is too wide"; exit 1; }
+# The namespace key must be referenced with Exists so Cilium does NOT AND-inject
+# `namespace=harbor` and silently narrow the rule (#4854 row 67 L2).
+echo "$cnp" | grep -q 'key: k8s:io.kubernetes.pod.namespace' || {
+  echo "FAIL: the namespace key is not referenced — Cilium will AND-inject namespace=harbor and narrow the rule"; exit 1; }
+echo "[bp-harbor] Case 5: PASS"
+
+echo "[bp-harbor] All cross-region redis wiring cases PASS"

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -711,3 +711,52 @@ bootstrapOwned:
   helmRelease:
     name: ""
     namespace: flux-system
+
+# ── Cross-region session/queue/cache store (#5406) ───────────────────────
+# Harbor's OIDC session lives in Redis db 0 (`_REDIS_URL_CORE`), its job
+# queue in db 1 and its registry blob-descriptor cache in db 2. On a
+# 2-region Sovereign BOTH regions serve `registry.<fqdn>` (one shared
+# wildcard VIP fans requests at both regions' envoys), while upstream's
+# default `redis.type: internal` gave each region its OWN redis — so a
+# session minted in one region 401s in the other, on a PER-REQUEST basis.
+# Meanwhile Harbor's other two stateful stores (Postgres via
+# `shared-pg-mesh-rw`, blobs via one Object Storage bucket) were ALREADY
+# anchored in the active region. This block makes Redis follow the same
+# rule instead of being the odd one out.
+#
+# `enabled` is wired by bootstrap-kit slot 19 to ${SOVEREIGN_ENABLE_CNPG_PAIR}
+# — stamped true on BOTH regions by catalyst-api only once Cilium ClusterMesh
+# is established. A single-region prov never reaches that flip, so the
+# default render below emits NOTHING (no Service, no CiliumNetworkPolicy)
+# and is byte-identical to the pre-#5406 chart.
+#
+# The SECONDARY region additionally receives `harbor.redis.type: external` +
+# `harbor.redis.external.addr: <meshServiceName>:6379` from the slot (driven
+# by the SOVEREIGN_HARBOR_REDIS_* substitutes catalyst-api stamps at the same
+# post-mesh gate that stamps SOVEREIGN_HARBOR_PG_HOST), so upstream renders no
+# local redis there and every dial crosses the mesh to the active region.
+crossRegion:
+  # Render the ClusterMesh global Service + the cross-region CiliumNetworkPolicies.
+  enabled: false
+  # This region's role in the pair: primary | secondary. Drives
+  # service.cilium.io/shared (the standby must never export a redis of its own).
+  role: primary
+  # Peer ClusterMesh cluster name(s) — stamped by catalyst-api as
+  # SOVEREIGN_PEER_CLUSTERMESH_NAMES. EMPTY → no CiliumNetworkPolicy rendered.
+  peerClusters: []
+  redis:
+    # Name of the merged global Service. MUST be identical on both regions —
+    # Cilium merges ClusterMesh global services by name+namespace.
+    meshServiceName: harbor-redis-mesh
+    # Cilium global-service backend preference. `local` falls through to the
+    # peer when there are no local backends (the standby's case), which is the
+    # same idiom bp-openbao's openbao-active-mesh and bp-cnpg-pair's
+    # *-primary-mesh Services use.
+    affinity: local
+    port: 6379
+    # Selector for the upstream goharbor internal-redis Pod
+    # (charts/harbor/templates/redis/service.yaml → harbor.matchLabels +
+    # component: redis). Defaults track the upstream chart; override only if
+    # `harbor.nameOverride` / the release name is customised.
+    appLabel: harbor
+    releaseLabel: ""

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -336,6 +336,40 @@ const (
 	clusterMeshKeycloakPGHostSubstituteKey = "SOVEREIGN_KEYCLOAK_PG_HOST"
 	clusterMeshGiteaPGHostSubstituteKey    = "SOVEREIGN_GITEA_PG_HOST"
 	clusterMeshHarborPGHostSubstituteKey   = "SOVEREIGN_HARBOR_PG_HOST"
+
+	// Cross-region Harbor session/queue/cache store substitute keys (#5406).
+	//
+	// Harbor keeps its OIDC session in Redis db 0, its jobservice work queue in
+	// db 1 and its registry blob-descriptor cache in db 2. On a 2-region
+	// Sovereign ONE shared wildcard VIP fans registry.<fqdn> at BOTH regions'
+	// envoys, so both regions' harbor-core serve — but upstream's default
+	// `redis.type: internal` gave each region its OWN redis StatefulSet. A
+	// session minted by whichever region handled /c/oidc/callback was invisible
+	// to the other, so `/api/v2.0/users/current` 401'd on every request that
+	// landed on the other region (measured live on hw290 dep 31106b6aa4a7e8e7:
+	// region-A 200 + region-B 401 in the SAME second of one page-load).
+	//
+	// Harbor's OTHER two stateful stores are ALREADY anchored in the active
+	// region — Postgres via clusterMeshHarborPGHostSubstituteKey above, blobs via
+	// a single Object Storage bucket — so this brings Redis in line rather than
+	// adding a new cross-region dependency. bp-harbor ≥1.2.45 publishes
+	// `harbor-redis-mesh` as a Cilium ClusterMesh global Service on BOTH regions
+	// (gated on SOVEREIGN_ENABLE_CNPG_PAIR, flipped by patchOne above); flipping
+	// the SECONDARY's upstream `redis.type` to `external` is what removes its
+	// duplicate redis AND repoints it at that merged Service — upstream ties both
+	// behaviours to the one key.
+	//
+	// Stamped HERE rather than in cloud-init deliberately: the standby then boots
+	// with its own local redis and flips to the shared one only once ClusterMesh
+	// is proven established, so there is no bootstrap window where harbor-core
+	// crashloops against an unresolvable mesh alias. Absent keys fall back to the
+	// slot-19 defaults (`internal` / empty addr), so a single-region prov — which
+	// never reaches this gate — renders byte-identically.
+	clusterMeshHarborRedisTypeSubstituteKey = "SOVEREIGN_HARBOR_REDIS_TYPE"
+	clusterMeshHarborRedisAddrSubstituteKey = "SOVEREIGN_HARBOR_REDIS_ADDR"
+	// Upstream harbor.redis.external.addr wants host:port with no scheme.
+	clusterMeshHarborRedisExternalType = "external"
+	clusterMeshHarborRedisMeshAddr     = "harbor-redis-mesh.harbor.svc.cluster.local:6379"
 )
 
 // Cross-cluster CNPG replica-auth Secret sync (#3254, the prerequisite
@@ -1699,7 +1733,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			// substitute maps to the ClusterMesh-global `shared-pg-mesh-rw` WRITE
 			// alias so stale envs self-heal AND fresh provs stay idempotent. NEVER
 			// gates the flip.
-			h.patchSecondaryCrossRegionPGHosts(ctx, dep, slots)
+			h.patchSecondaryCrossRegionHosts(ctx, dep, slots)
 		}
 	}
 	if patched == 0 {
@@ -2218,7 +2252,7 @@ func helmReleaseWedgedSince(hr *unstructured.Unstructured) (bool, time.Time) {
 	return wedged, latest
 }
 
-// patchSecondaryCrossRegionPGHosts re-stamps the cross-region shared-pg WRITE
+// patchSecondaryCrossRegionHosts re-stamps the cross-region shared-pg WRITE
 // host onto every SECONDARY region's bootstrap-kit Kustomization substitute map
 // (#4436, Refs #4159). keycloak/gitea/harbor run on every region's control
 // plane and dial the write host as a SCALAR (bitnami externalDatabase.host / a
@@ -2247,14 +2281,34 @@ func helmReleaseWedgedSince(hr *unstructured.Unstructured) (bool, time.Time) {
 // #3241/#3583 level-trigger re-run converges it on a later pass. It returns
 // nothing precisely so it can never wedge convergence.
 //
-// Scope guard: ONLY secondary regions whose substitute map carries
-// SOVEREIGN_ENABLE_SHARED_PG=true are patched. The PRIMARY region keeps its
+// Scope guard for the PG-host keys: ONLY secondary regions whose substitute map
+// carries SOVEREIGN_ENABLE_SHARED_PG=true. The PRIMARY region keeps its
 // region-local `shared-pg-rw` (its `-rw` Service is local and resolves — flipping
 // it to `-mesh-rw` would be a needless indirection), and an own-cluster
-// (non-shared) Sovereign is left entirely untouched (its keycloak/gitea/harbor
-// dial their OWN per-app `<app>-pg-rw` host, never shared-pg). Single-region
+// (non-shared) Sovereign keeps its per-app `<app>-pg-rw` hosts. Single-region
 // (len(slots)<2) is a no-op.
-func (h *Handler) patchSecondaryCrossRegionPGHosts(ctx context.Context, dep *Deployment, slots []regionSlot) {
+//
+// ── #5406: also the cross-region Harbor session/queue/cache store ──────────
+// The same "the standby's stateful backing lives in the active region" problem
+// applies to Harbor's Redis, which holds the OIDC session (db 0), the
+// jobservice work queue (db 1) and the registry blob-descriptor cache (db 2).
+// Upstream's `redis.type: internal` default gave EACH region its own redis
+// while ONE shared wildcard VIP fans registry.<fqdn> at both regions' envoys,
+// so a session minted in one region 401'd in the other on a per-request basis
+// (hw290, dep 31106b6aa4a7e8e7: region-A users/current 200 + region-B 401 in
+// the same second of one page-load). bp-harbor ≥1.2.45 publishes
+// `harbor-redis-mesh` as a Cilium ClusterMesh global Service on BOTH regions;
+// this gate flips the SECONDARY's upstream redis to `external` pointing at it,
+// which both removes the standby's duplicate redis and repoints it (upstream
+// ties both behaviours to the one `redis.type` key).
+//
+// Those two keys are stamped OUTSIDE the shared-pg guard — harbor owns its
+// redis in the own-cluster topology too, and the split-session defect is
+// identical either way. They are stamped HERE rather than in cloud-init so the
+// standby boots with its own local redis and flips to the shared one only once
+// ClusterMesh is proven established — no crashloop window against an
+// unresolvable mesh alias.
+func (h *Handler) patchSecondaryCrossRegionHosts(ctx context.Context, dep *Deployment, slots []regionSlot) {
 	if len(slots) < 2 {
 		return // single-region — no secondary control plane to patch
 	}
@@ -2293,29 +2347,45 @@ func (h *Handler) patchSecondaryCrossRegionPGHosts(ctx context.Context, dep *Dep
 				"id", dep.ID, "region", regionLabel, "found", found, "err", err)
 			continue
 		}
-		// Scope guard: only shared-pg Sovereigns. An own-cluster install dials
-		// per-app hosts (gitea-pg-rw.gitea, …) that resolve locally — never touch.
-		if !strings.EqualFold(strings.TrimSpace(substitute[clusterMeshSharedPGSubstituteKey]), "true") {
-			h.log.Info("clustermesh: secondary PG-host patch: shared-pg not enabled on this region — skipping (own-cluster hosts resolve locally)",
-				"id", dep.ID, "region", regionLabel)
-			continue
-		}
-		// Build the merge patch ONLY for keys that are missing or still carry a
-		// region-local (non-`-mesh-rw`) host — so the patch is a true no-op once
-		// the map already carries the mesh host (fresh prov / already-healed).
-		hostKeys := []string{
-			clusterMeshKeycloakPGHostSubstituteKey,
-			clusterMeshGiteaPGHostSubstituteKey,
-			clusterMeshHarborPGHostSubstituteKey,
-		}
 		sub := map[string]any{}
-		for _, k := range hostKeys {
-			if strings.TrimSpace(substitute[k]) != clusterMeshSharedPGMeshRWHost {
-				sub[k] = clusterMeshSharedPGMeshRWHost
-			}
+
+		// ── Harbor cross-region session/queue/cache store (#5406) ──────────
+		// UNGATED by shared-pg: harbor owns its redis in BOTH the own-cluster
+		// and the shared-pg topology, and the split-session defect is the same
+		// either way. Only keys that are missing or still carry the region-local
+		// value are patched, so this is a true no-op once healed.
+		if strings.TrimSpace(substitute[clusterMeshHarborRedisTypeSubstituteKey]) != clusterMeshHarborRedisExternalType {
+			sub[clusterMeshHarborRedisTypeSubstituteKey] = clusterMeshHarborRedisExternalType
 		}
+		if strings.TrimSpace(substitute[clusterMeshHarborRedisAddrSubstituteKey]) != clusterMeshHarborRedisMeshAddr {
+			sub[clusterMeshHarborRedisAddrSubstituteKey] = clusterMeshHarborRedisMeshAddr
+		}
+
+		// Scope guard: the PG-host keys apply to shared-pg Sovereigns ONLY. An
+		// own-cluster install dials per-app hosts (gitea-pg-rw.gitea, …) that
+		// resolve locally — never touch those. The harbor-redis keys above are
+		// deliberately outside this guard.
+		if strings.EqualFold(strings.TrimSpace(substitute[clusterMeshSharedPGSubstituteKey]), "true") {
+			// Build the merge patch ONLY for keys that are missing or still carry a
+			// region-local (non-`-mesh-rw`) host — so the patch is a true no-op once
+			// the map already carries the mesh host (fresh prov / already-healed).
+			hostKeys := []string{
+				clusterMeshKeycloakPGHostSubstituteKey,
+				clusterMeshGiteaPGHostSubstituteKey,
+				clusterMeshHarborPGHostSubstituteKey,
+			}
+			for _, k := range hostKeys {
+				if strings.TrimSpace(substitute[k]) != clusterMeshSharedPGMeshRWHost {
+					sub[k] = clusterMeshSharedPGMeshRWHost
+				}
+			}
+		} else {
+			h.log.Info("clustermesh: secondary cross-region patch: shared-pg not enabled on this region — PG hosts left alone (own-cluster hosts resolve locally); harbor-redis keys still evaluated",
+				"id", dep.ID, "region", regionLabel)
+		}
+
 		if len(sub) == 0 {
-			h.log.Info("clustermesh: secondary PG-host patch: substitute map already carries the -mesh-rw write host on every key — no-op",
+			h.log.Info("clustermesh: secondary cross-region patch: substitute map already carries every cross-region value — no-op",
 				"id", dep.ID, "region", regionLabel)
 			continue
 		}
@@ -2351,14 +2421,14 @@ func (h *Handler) patchSecondaryCrossRegionPGHosts(ctx context.Context, dep *Dep
 		for k := range sub {
 			keys = append(keys, k)
 		}
-		h.log.Info("clustermesh: secondary PG-host patch: stamped shared-pg-mesh-rw WRITE host onto secondary region's bootstrap-kit Kustomization (keycloak/gitea/harbor cross-region DB host, #4436)",
-			"id", dep.ID, "region", regionLabel, "keys", keys, "host", clusterMeshSharedPGMeshRWHost, "requestedAt", stamp)
+		h.log.Info("clustermesh: secondary cross-region patch: stamped shared-pg-mesh-rw WRITE host (keycloak/gitea/harbor DB, #4436) and/or the harbor-redis-mesh session store (#5406) onto the secondary region's bootstrap-kit Kustomization",
+			"id", dep.ID, "region", regionLabel, "keys", keys, "pgHost", clusterMeshSharedPGMeshRWHost, "harborRedisAddr", clusterMeshHarborRedisMeshAddr, "requestedAt", stamp)
 		patchedRegions = append(patchedRegions, regionLabel)
 	}
 	if len(patchedRegions) > 0 {
 		h.emitClusterMeshProgress(dep, "info",
-			fmt.Sprintf("ClusterMesh: flipped keycloak/gitea/harbor cross-region DB write host to %s on %d secondary region(s) (%s) — region-local shared-pg-rw NXDOMAINs the replica region (#4436)",
-				clusterMeshSharedPGMeshRWHost, len(patchedRegions), strings.Join(patchedRegions, ", ")))
+			fmt.Sprintf("ClusterMesh: flipped keycloak/gitea/harbor cross-region DB write host to %s and harbor's session/queue/cache store to %s on %d secondary region(s) (%s) — region-local shared-pg-rw NXDOMAINs the replica region (#4436) and a region-local harbor redis splits every Harbor login (#5406)",
+				clusterMeshSharedPGMeshRWHost, clusterMeshHarborRedisMeshAddr, len(patchedRegions), strings.Join(patchedRegions, ", ")))
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -3772,7 +3772,7 @@ func TestSyncSSOOIDCMangledSecrets(t *testing.T) {
 	})
 }
 
-// TestPatchSecondaryCrossRegionPGHosts — #4436. On a 2-region shared-pg
+// TestPatchSecondaryCrossRegionHosts — #4436. On a 2-region shared-pg
 // Sovereign the CNPG primary's region-local `shared-pg-rw` Service exists ONLY
 // in region-A; the SECONDARY region has no such Service, so keycloak/gitea/
 // harbor (which dial the write host as a scalar) NXDOMAIN there. The post-mesh
@@ -3782,7 +3782,7 @@ func TestSyncSSOOIDCMangledSecrets(t *testing.T) {
 // the keycloak key entirely → the slot 09 default `shared-pg-rw` wins). The
 // PRIMARY region's map is left untouched (its `-rw` Service resolves locally),
 // and an own-cluster (non-shared-pg) Sovereign is skipped entirely.
-func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
+func TestPatchSecondaryCrossRegionHosts(t *testing.T) {
 	h := &Handler{log: silentLogger()}
 	dep := &Deployment{ID: "dep4436"}
 
@@ -3818,7 +3818,7 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 		})
 		defer restore()
 
-		h.patchSecondaryCrossRegionPGHosts(context.Background(), dep, slots)
+		h.patchSecondaryCrossRegionHosts(context.Background(), dep, slots)
 
 		// SECONDARY: every write-host key now resolves to the mesh alias.
 		secKS := getBootstrapKitKustomization(t, secondaryDyn)
@@ -3831,6 +3831,15 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 			if got := gotSub[k]; got != meshHost {
 				t.Errorf("secondary substitute[%s] = %q, want %q (region-local -rw NXDOMAINs the replica region)", k, got, meshHost)
 			}
+		}
+		// #5406 — the SECONDARY's harbor redis flips to the ClusterMesh alias in
+		// the same patch, so its Harbor session store is the ACTIVE region's.
+		if got := gotSub[clusterMeshHarborRedisTypeSubstituteKey]; got != clusterMeshHarborRedisExternalType {
+			t.Errorf("secondary substitute[%s] = %q, want %q (a region-local harbor redis splits every Harbor login, #5406)",
+				clusterMeshHarborRedisTypeSubstituteKey, got, clusterMeshHarborRedisExternalType)
+		}
+		if got := gotSub[clusterMeshHarborRedisAddrSubstituteKey]; got != clusterMeshHarborRedisMeshAddr {
+			t.Errorf("secondary substitute[%s] = %q, want %q", clusterMeshHarborRedisAddrSubstituteKey, got, clusterMeshHarborRedisMeshAddr)
 		}
 		// Sibling keys must survive the MERGE patch (never replaced).
 		if got := gotSub[clusterMeshPrimaryRegionSubstituteKey]; got != testPrimaryRegionLabel {
@@ -3851,6 +3860,12 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 		if _, present := priSub[clusterMeshKeycloakPGHostSubstituteKey]; present {
 			t.Errorf("primary substitute[%s] should stay ABSENT (slot default resolves locally); patch wrongly touched the primary", clusterMeshKeycloakPGHostSubstituteKey)
 		}
+		// #5406 — the ACTIVE region must KEEP its own redis (`redis.type: internal`
+		// renders the StatefulSet the merged global Service selects). Flipping the
+		// primary to `external` would leave the Sovereign with NO redis at all.
+		if _, present := priSub[clusterMeshHarborRedisTypeSubstituteKey]; present {
+			t.Errorf("primary substitute[%s] should stay ABSENT — the active region OWNS the redis every region shares (#5406)", clusterMeshHarborRedisTypeSubstituteKey)
+		}
 		if stamp := priKS.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
 			t.Errorf("primary: %q annotation set — primary must not be patched/reconciled", fluxReconcileRequestedAtAnnotation)
 		}
@@ -3863,6 +3878,8 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 		secSub[clusterMeshKeycloakPGHostSubstituteKey] = meshHost
 		secSub[clusterMeshGiteaPGHostSubstituteKey] = meshHost
 		secSub[clusterMeshHarborPGHostSubstituteKey] = meshHost
+		secSub[clusterMeshHarborRedisTypeSubstituteKey] = clusterMeshHarborRedisExternalType
+		secSub[clusterMeshHarborRedisAddrSubstituteKey] = clusterMeshHarborRedisMeshAddr
 		secondaryDyn := newFakeKustomizationDynClient(t, buildBootstrapKitKustomization(secSub))
 		primaryDyn := newFakeKustomizationDynClient(t, buildBootstrapKitKustomization(defaultBootstrapKitSubstitute()))
 
@@ -3872,7 +3889,7 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 		})
 		defer restore()
 
-		h.patchSecondaryCrossRegionPGHosts(context.Background(), dep, slots)
+		h.patchSecondaryCrossRegionHosts(context.Background(), dep, slots)
 
 		// No-op: nothing to change → no reconcile stamp (the merge patch never fired).
 		secKS := getBootstrapKitKustomization(t, secondaryDyn)
@@ -3881,9 +3898,12 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 		}
 	})
 
-	t.Run("own-cluster-shared-pg-off-is-skipped", func(t *testing.T) {
+	t.Run("own-cluster-shared-pg-off-skips-pg-hosts-but-still-flips-harbor-redis", func(t *testing.T) {
 		// shared-pg DISABLED → keycloak/gitea/harbor dial their OWN <app>-pg-rw
-		// hosts (resolve locally) → must NOT be touched.
+		// hosts (resolve locally) → the PG-host keys must NOT be touched. The
+		// harbor-redis keys ARE still flipped: harbor owns its redis in the
+		// own-cluster topology too, and the split-session defect (#5406) is
+		// identical there.
 		secSub := defaultBootstrapKitSubstitute()
 		secSub[clusterMeshRegionRoleSubstituteKey] = "secondary"
 		// SOVEREIGN_ENABLE_SHARED_PG intentionally absent (own-cluster).
@@ -3896,21 +3916,28 @@ func TestPatchSecondaryCrossRegionPGHosts(t *testing.T) {
 		})
 		defer restore()
 
-		h.patchSecondaryCrossRegionPGHosts(context.Background(), dep, slots)
+		h.patchSecondaryCrossRegionHosts(context.Background(), dep, slots)
 
 		secKS := getBootstrapKitKustomization(t, secondaryDyn)
 		gotSub, _, _ := unstructured.NestedStringMap(secKS.Object, "spec", "postBuild", "substitute")
 		if _, present := gotSub[clusterMeshKeycloakPGHostSubstituteKey]; present {
 			t.Errorf("own-cluster Sovereign: keycloak host key was wrongly stamped (shared-pg is OFF — apps dial their own local host)")
 		}
-		if stamp := secKS.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
-			t.Errorf("own-cluster Sovereign: reconcile stamp %q written — must be skipped entirely", stamp)
+		if _, present := gotSub[clusterMeshGiteaPGHostSubstituteKey]; present {
+			t.Errorf("own-cluster Sovereign: gitea host key was wrongly stamped (shared-pg is OFF)")
+		}
+		if got := gotSub[clusterMeshHarborRedisTypeSubstituteKey]; got != clusterMeshHarborRedisExternalType {
+			t.Errorf("own-cluster Sovereign: substitute[%s] = %q, want %q — the harbor-redis flip is NOT gated on shared-pg (#5406)",
+				clusterMeshHarborRedisTypeSubstituteKey, got, clusterMeshHarborRedisExternalType)
+		}
+		if got := gotSub[clusterMeshHarborRedisAddrSubstituteKey]; got != clusterMeshHarborRedisMeshAddr {
+			t.Errorf("own-cluster Sovereign: substitute[%s] = %q, want %q", clusterMeshHarborRedisAddrSubstituteKey, got, clusterMeshHarborRedisMeshAddr)
 		}
 	})
 
 	t.Run("single-region-is-noop", func(t *testing.T) {
 		// len(slots) == 1 → no secondary → return immediately, no panic.
-		h.patchSecondaryCrossRegionPGHosts(context.Background(), dep, []regionSlot{{key: "", kubeconfigPath: primaryPath}})
+		h.patchSecondaryCrossRegionHosts(context.Background(), dep, []regionSlot{{key: "", kubeconfigPath: primaryPath}})
 	})
 }
 

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2322,7 +2322,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.144"
+  version: "1.4.145"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2367,7 +2367,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.144"
+    version: "1.4.145"
   topology:
     supported:
     - active-passive

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3327,7 +3327,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.44"
+  version: "1.2.45"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3351,7 +3351,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.44"
+    version: "1.2.45"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
Refs #5406 — UAT row 32.

## The defect, restated precisely

Harbor's OIDC leg is healthy. What fails is that the session it mints does not exist for the next request.

Harbor keeps **three** stateful stores. On a 2-region Sovereign, two of them were already anchored in the **active** region and reached from the standby over ClusterMesh:

| Store | Contents | Anchor before this PR |
|---|---|---|
| Postgres | registry metadata | `shared-pg-mesh-rw.shared-data` — a **zero-endpoint** global-Service alias in region-B, resolving to region-A's `shared-pg` primary |
| Object Storage | image + chart blobs | **one** bucket, written by both regions |
| **Redis** | OIDC **session** (db 0), jobservice queue (db 1), registry blob-descriptor cache (db 2) | **region-local** — each region ran its own `harbor-redis` StatefulSet on its own PVC |

Redis was not a decision. It is upstream goharbor's `redis.type: internal` default surviving into a topology it does not fit. Since one shared wildcard VIP fans `registry.<fqdn>` at **both** regions' envoys, the session minted by whichever region handled `/c/oidc/callback` was invisible to the other, and every later request that landed on the other region 401'd.

### Live evidence — hw290, dep `31106b6aa4a7e8e7`, 2026-07-26

One browser page-load split across both regions **in the same second**, same referer, same UA (`harbor-nginx` access logs):

```
region-A  21:13:43  GET /c/oidc/callback?state=...&code=...   302     <- session minted HERE
region-A  21:13:44  GET /api/v2.0/users/current               200
region-B  21:13:44  GET /api/v2.0/users/current               401
region-B  21:13:44  GET /api/v2.0/projects?page=1&...         200     <- shared DB, fine
region-B  21:13:58+ GET /api/v2.0/users/current               401 x14  referer=/account/sign-in
```

Supporting live state:

- `harbor-core` ConfigMap, region-A: `_REDIS_URL_CORE: redis://harbor-redis:6379/0` — region-local. Region-B: identical string, **different pod**.
- `harbor-core` ConfigMap DB host: region-A `shared-pg-rw.shared-data`, region-B `shared-pg-mesh-rw.shared-data` (`ENDPOINTS <none>`, `service.cilium.io/global: "true"`, `affinity: local`) — the DB was **already** cross-region and works.
- `/etc/core/key` (`harbor-core` Secret `secretKey`) is **identical** across regions (md5 `6a6400210318f59f3bfaf021a4b166c0`) — so this was never a key mismatch.

The same split also ran **harbor-jobservice's work queue** (db 1) and **harbor-registry's blob-descriptor cache** (db 2) twice, uncoordinated, over one shared database and one shared bucket.

## Why option 1 (share the session store), not 2 or 3

**Option 1 is the option that restores internal consistency.** Two of three stores were already anchored in the active region; this is not adding a cross-region dependency, it is removing the last inconsistency. The mechanism is already load-bearing in this exact environment: `openbao-active-mesh` (bp-openbao), `shared-pg-mesh-rw` (bp-postgres / bp-cnpg-pair), and the region-b `catalyst-api` edge stub (bp-catalyst-edge-routes) are all live zero-endpoint global-Service aliases resolving across the mesh today. It also repairs the queue and cache duplication as a consequence, not as a separate change.

**Option 2 (pin the hostname to one region) is not reachable from a chart, and the interim state is worse than the bug.** `registry.`, `auth.`, and the apex `hw290.omani.works` all resolve to the **single** wildcard EIP `212.72.24.35` (only `console.` has its own, `.82`), and requests for one hostname demonstrably reach **both** clusters' envoys. There is no per-region address to point at, so "pin to region A" is a per-Sovereign infra change, not a value change. Worse, the chart-level way to express it — suspending the region-B HR — would make region-B's envoy answer roughly half the requests with a bare-envoy 404 instead of a 401. That is exactly the #5394 shape, i.e. trading this defect for a strictly more severe one.

**Option 3 (session affinity) cannot reach the decision point.** The split happens at the external load balancer, above `svc/harbor` — proven by two regions logging different requests of one page-load in the same second. `sessionAffinity: ClientIP` on a Service cannot influence which **cluster** the LB picked. It would lower the failure rate and leave the defect.

### The cross-region datapath objection, answered with evidence

The concern that the datapath makes option 1 unreliable (#4656 per-node black-holes, #4869 CNP egress) does not hold here, and the proof is running right now: **region-B's `harbor-core` is `Running` and served `/api/v2.0/projects` 200 using region-A's Postgres over ClusterMesh** in the same log window that shows the 401s. Harbor already depends on this datapath for a store it cannot function without. Redis rides the identical path.

What that history *did* leave behind is a policy requirement, which this PR ships (see below).

## What changed

**`platform/harbor/chart` → 1.2.45**

- `templates/redis-mesh-service.yaml` — `harbor-redis-mesh`, rendered on **both** regions under the same name+namespace (Cilium merges global services by name+namespace). Primary selects the local redis Pod and exports it (`service.cilium.io/shared: "true"`); secondary has no local redis so the selector matches zero Pods and `affinity: local` falls through the mesh, with `shared: "false"` so the standby can never export a store of its own.
- `templates/redis-crossregion-netpol.yaml` — identity-based `CiliumNetworkPolicy` ingress + egress on 6379, gated on `crossRegion.peerClusters`.
- `values.yaml` — the `crossRegion` block, default off.
- `tests/redis-crossregion.sh` — 5 cases (see verification).

**`clusters/_template/bootstrap-kit/19-harbor.yaml`** — pin 1.2.45; `crossRegion.{enabled,role,peerClusters}` from `SOVEREIGN_ENABLE_CNPG_PAIR` / `SOVEREIGN_REGION_ROLE` / `SOVEREIGN_PEER_CLUSTERMESH_NAMES`; `harbor.redis.{type,external.addr}` from the new `SOVEREIGN_HARBOR_REDIS_{TYPE,ADDR}`.

**`products/catalyst/bootstrap/api/.../clustermesh.go`** — `patchSecondaryCrossRegionPGHosts` → `patchSecondaryCrossRegionHosts`; it now also stamps the two harbor-redis substitutes onto secondary regions, deliberately **outside** the shared-pg guard (harbor owns its redis in the own-cluster topology too, and the defect is identical there). Stamping here rather than in cloud-init means the standby boots with its own local redis and flips only once ClusterMesh is proven established — no window where `harbor-core` crashloops against an unresolvable alias — and live 2-region Sovereigns self-heal without a re-prov.

**Lockstep** — `Chart.yaml`, `blueprint.yaml`, slot-19 pin, catalog-seed `spec.version` **and** `source.version`, all 1.2.45.

### Why the NetworkPolicy half is not optional

The `harbor` namespace carries bp-plane-isolation's `harbor-default-deny`. A plain k8s NetworkPolicy can **never** admit a ClusterMesh peer — Cilium AND-injects the local cluster label into every selector it derives. Read straight off region-A with `cilium-dbg policy selectors`:

```
&LabelSelector{MatchLabels:map[string]string{
    k8s.io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: catalyst-system,
    k8s.io.cilium.k8s.policy.cluster: hw290-mesh,}}        <- LOCAL cluster pinned
  LABELS: harbor/harbor-default-deny
```

against the shape a policy that *does* reach the peer must use:

```
MatchExpressions{Key: any.io.cilium.k8s.policy.cluster, Operator: In, Values:[hw290-me-east-b]}
```

Same finding as #4846/#4854. Cilium unions policies, so the two new CNPs are purely additive to the default-deny: peer-cluster identities only, 6379 only, no `world`.

## Failover — stated plainly

**On a region-A kill, Harbor's control plane is unavailable in region-B until `bp-continuum` switches over.**

This is unchanged in kind. Region-B's `harbor-core` already loses its Postgres in that scenario — `shared-pg-mesh-rw` has no local backends there — so Harbor already required the switchover, and `blueprint.yaml` already names the mechanism (`topology.perTopology.active-hot-standby.switchover.mechanism: bp-continuum`, RTO 30s / RPO 0). What this PR adds is one more thing the switchover must repoint, and it rides the **same seam** as the DB host (`SOVEREIGN_HARBOR_PG_HOST` ↔ `SOVEREIGN_HARBOR_REDIS_ADDR`, both stamped by the same catalyst-api gate), so no new mechanism is introduced. Registry **blob pulls** through region-B also need core + DB, so they were already active-region-anchored.

Completing region-B promotion for Harbor (a redis for the promoted region, driven by the same Continuum step that promotes `shared-pg-replica`) is follow-up work that belongs with the Continuum switchover, not here — building it without a switchover to drive it would be unproven scaffolding.

Upgrade note: the standby's existing `data-harbor-redis-0` PVC is left behind when its StatefulSet is removed (StatefulSet PVCs are never garbage-collected). It is an orphan, not a hazard — the pod terminates cleanly and the RWO EVS volume detaches.

## Verification

**Gates**

| Gate | Result |
|---|---|
| `cd tests/e2e/bootstrap-kit && go test -count=1 ./...` | ok |
| `scripts/check-no-nodeports.sh` | `OK: zero NodePorts across sources + rendered charts` |
| `scripts/check-bootstrap-kit-pin-sync.sh` | `PASS` — 67 pairs |
| `scripts/check-catalog-seed-lockstep.sh` | `PASS` — 68 checked |
| `scripts/render-slot-placement.py check` | `PASSED` — 67 slots |
| `scripts/check-tofu-flux-envsubst.sh` | `OK` |
| `scripts/check-chart-annotations.sh` | `platform/harbor/chart` GUARD 1 + GUARD 2 both green (1710-line render) |
| all 8 `platform/harbor/chart/tests/*.sh` | PASS |
| `go test ./internal/handler/ -run 'ClusterMesh\|CrossRegion'` + `go vet` | ok |

**Render proof — Flux envsubst simulated over slot 19 in all four states**

```
single-region           crossRegion {enabled:false, role:primary,   peers:[]}                harbor.redis {type:internal}
region-A (primary)      crossRegion {enabled:true,  role:primary,   peers:[hw290-me-east-b]} harbor.redis {type:internal}
region-B pre-mesh-gate  crossRegion {enabled:true,  role:secondary, peers:[hw290-mesh]}      harbor.redis {type:internal}
region-B post-mesh-gate crossRegion {enabled:true,  role:secondary, peers:[hw290-mesh]}      harbor.redis {type:external,
                                                                          addr:harbor-redis-mesh.harbor.svc.cluster.local:6379}
```

End-to-end `helm template` of those value sets:

```
region-A: _REDIS_URL_CORE=redis://harbor-redis:6379/0   StatefulSets=1  shared="true"   both CNPs present
region-B: _REDIS_URL_CORE=redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/0
          _REDIS_URL_REG =redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/2
          StatefulSets=0  shared="false"
```

**Negative proof — reverted, failed, restored**

1. Pre-fix render (both regions): `_REDIS_URL_CORE: redis://smoke-harbor-redis:6379/0` — a region-local name, plus its own StatefulSet. Two independent stores, which is the defect.
2. Secondary without the external flip: `grep -c harbor-redis-mesh...:6379/0` → **0 matches**, Case 4 assertion fails.
3. `templates/redis-mesh-service.yaml` moved aside → `tests/redis-crossregion.sh` **exit 1** at Case 2.
4. Restored → **exit 0**, all 5 cases PASS.

Test cases: (1) default render emits no Service and no CNP; (2) primary exports backends; (3) secondary renders the same name but never exports; (4) the external flip removes the duplicate StatefulSet **and** repoints db 0 + db 2; (5) CNPs are peer-gated, identity-based, scoped to 6379, with the namespace key referenced so Cilium does not narrow the rule.

## Runtime proof owed, and what it will be

This is a chart + control-plane change; the wire proof needs the chart published and reconciled. On the next 2-region Sovereign carrying bp-harbor >= 1.2.45:

1. **Pre-state** — region-B `kubectl -n harbor get sts` shows no `harbor-redis`; `harbor-core` ConfigMap `_REDIS_URL_CORE` reads `harbor-redis-mesh...:6379/0`; region-A `svc/harbor-redis-mesh` carries `service.cilium.io/global: "true"` with a non-empty endpoint list, region-B's the same name with none.
2. **The walk** — sign in once at `https://registry.<fqdn>/` through the silent-SSO chain, then issue **N >= 20** consecutive `GET /api/v2.0/users/current` on that cookie.
3. **Green** — `200 x N, 401 x 0`, **and** `harbor-nginx` access logs in **both** regions each show a non-zero share of those N with `200` (the requests must demonstrably land on both regions — an all-region-A run proves nothing here).
4. **Cross-check** — `cilium-dbg` on a region-B node shows the egress to region-A's redis identity allowed with non-zero packet counts.

## Adjacent, reported not acted on

Enumerated from live hw290 while diagnosing — **unverified beyond what is stated**, no changes made.

**Hostname-level symmetry on the shared VIP** (`212.72.24.35`), region-A vs region-B HTTPRoutes: 15 of 16 hostnames are published in both regions. The one asymmetry is **`mcp.<fqdn>` — routed in region-A only**, which is #5394, already known.

**Backend-level symmetry in region-B** is the more useful cut, because a route can exist while its backend does not:

- *Deliberate ClusterMesh stubs* (zero endpoints, `global=true`, forwarding to region-A): `catalyst-api`, `catalyst-catalog`, `catalyst-ui`, and `org-services/{gateway,admin,marketplace}`. Correct by design.
- *Real region-local workloads*: `keycloak`, `openbao`, `gitea`, `grafana`, `oidc-gate-*`, `hubble-ui-oauth2-proxy`, `newapi`, `powerdns`, `harbor`. These serve — but each is worth the same question this PR asked of Harbor: **does it hold region-local state that a request landing on the other region cannot see?**
  - **`keycloak`** is the strongest candidate: one single-replica StatefulSet per region, **not** clustered (Infinispan caches are per-node), over **one shared database** (#4915). A login session minted on region-A is not in region-B's cache. The user-visible effect would be softer than Harbor's — a re-prompt rather than a hard 401, because each app re-initiates OIDC — but it is the same class.
  - **`gitea`** and **`newapi`** are secondary candidates on the same question.
  - **`openbao`** is genuinely symmetric — stretched raft across regions (#3492).

**Region-B's `harbor-sso-configure` reconciler cannot authenticate.** `harbor-core` in region-B logs `failed to authenticate user:admin ... 'Invalid credentials'` on a ~60s loop for its entire uptime, with `Login failed, locking admin`. Each region mints its **own** random `harbor-admin` Secret (md5 `94cdfd04…` region-A vs `43e1435f…` region-B) while the admin password hash lives in the **shared** database written by region-A. Harbor still works because region-A's reconciler sets `auth_mode` in that same shared DB, so this is log noise plus repeated admin-account lockout churn rather than an outage — but it is the same "region symmetry never checked" root, and it is a real defect. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
