### PR TITLE
fix(catalog): uptime-kuma OOMKills forever at its hard-coded 128Mi ceiling — raise to 512Mi

### DIFF
--- a/core/services/provisioning/gitops/apps.go
+++ b/core/services/provisioning/gitops/apps.go
@@ -158,7 +158,27 @@ var KnownApps = map[string]AppSpec{
 	"uptime-kuma": {
 		Image: "louislam/uptime-kuma:1", Port: 3001,
 		NeedsDB: "",
-		RAMMI:   "128Mi", CPUMilli: "50m",
+		// #5410 — was 128Mi/50m, which OOMKilled forever. Live on hw290 Org
+		// theta-corp: 49 restarts, lastState.terminated.reason=OOMKilled, at
+		// exactly the declared 128Mi ceiling. Uptime Kuma is Node.js with an
+		// embedded SQLite store; its baseline working set exceeds 128Mi before
+		// it finishes booting, so it OOMs, restarts, and OOMs again — the app
+		// installs, reports provisioned, and never once serves a request.
+		//
+		// This value is BOTH the request and the hard limit: qosResources()
+		// returns it for both on every paid plan so the pod is Guaranteed QoS
+		// (which the per-Org LimitRange's maxLimitRequestRatio {cpu:1,memory:1}
+		// requires to admit it at all). So there is no burst headroom to absorb
+		// an under-estimate — the declared number is the ceiling, full stop.
+		//
+		// 512Mi matches the tier already used for the other Node-heavy apps in
+		// this map (chatwoot, rocket-chat). CPU 50m→100m because the liveness
+		// probe was also failing during boot; 50m is 5% of a core, and Node
+		// startup is CPU-hungry even when steady-state draw is small. Both are
+		// deliberately modest — region-A already sits at 98-100% CPU *requests*
+		// (#5393), so this is sized to stop a proven hard failure, not to be
+		// generous.
+		RAMMI: "512Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"vaultwarden": {

--- a/core/services/provisioning/gitops/apps_uptime_kuma_oom_5410_test.go
+++ b/core/services/provisioning/gitops/apps_uptime_kuma_oom_5410_test.go
@@ -1,0 +1,79 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5410 — uptime-kuma must not regress to a memory ceiling that OOMKills it.
+//
+// It shipped at 128Mi and died permanently: live on hw290 Org theta-corp,
+// 49 restarts with lastState.terminated.reason=OOMKilled, at exactly the
+// declared value. The app installed, reported provisioned, and never served
+// a single request — a customer-visible dead application.
+//
+// The value is load-bearing in a way that is easy to miss: qosResources()
+// returns the declared request as the LIMIT too on every paid plan, so the
+// pod is Guaranteed QoS (which the per-Org LimitRange's maxLimitRequestRatio
+// {cpu:1,memory:1} requires in order to admit it). There is therefore no
+// burst headroom — whatever is declared here is a hard ceiling.
+//
+// This guard is deliberately NOT a blanket floor across the catalog. A
+// floor set high enough to catch uptime-kuma would also flag vaultwarden,
+// which runs happily in 128Mi (Rust, genuinely lightweight) and has no
+// evidence against it. Inventing a rule that fails a working app to catch a
+// broken one trades a real defect for a false one. So this pins the specific
+// app that has a proven OOM, and the accompanying issue records that the
+// durable answer is runtime feedback — an OOMKill should surface as a
+// provisioning signal — rather than a static threshold guess.
+func TestUptimeKuma_MemoryAboveProvenOOMCeiling_5410(t *testing.T) {
+	spec, ok := KnownApps["uptime-kuma"]
+	if !ok {
+		t.Fatal("uptime-kuma missing from KnownApps — if it was renamed, move this guard with it")
+	}
+
+	const provenOOMCeiling = 128 // Mi — the value that OOMKilled 49 times
+
+	mem := strings.TrimSpace(spec.RAMMI)
+	mi, err := memMi(mem)
+	if err != nil {
+		t.Fatalf("uptime-kuma RAMMI %q is unparseable: %v", mem, err)
+	}
+	if mi <= provenOOMCeiling {
+		t.Errorf("uptime-kuma RAMMI is %q (%dMi) — at or below the %dMi ceiling that was PROVEN to OOMKill it 49 times on hw290. "+
+			"This value is also the hard limit (Guaranteed QoS), so there is no burst headroom to absorb it.",
+			mem, mi, provenOOMCeiling)
+	}
+}
+
+// memMi parses a Kubernetes memory quantity limited to the Mi/Gi forms this
+// map actually uses, and returns it in Mi.
+func memMi(q string) (int, error) {
+	mult := 1
+	num := q
+	switch {
+	case strings.HasSuffix(q, "Gi"):
+		mult, num = 1024, strings.TrimSuffix(q, "Gi")
+	case strings.HasSuffix(q, "Mi"):
+		num = strings.TrimSuffix(q, "Mi")
+	default:
+		return 0, errUnsupportedQuantity
+	}
+	n := 0
+	for _, r := range num {
+		if r < '0' || r > '9' {
+			return 0, errUnsupportedQuantity
+		}
+		n = n*10 + int(r-'0')
+	}
+	if n == 0 {
+		return 0, errUnsupportedQuantity
+	}
+	return n * mult, nil
+}
+
+var errUnsupportedQuantity = &quantityError{}
+
+type quantityError struct{}
+
+func (*quantityError) Error() string { return "unsupported memory quantity (want NNNMi or NNNGi)" }


### PR DESCRIPTION
## What

`uptime-kuma` is hard-coded to **128Mi** and is **OOMKilled permanently**. Live on hw290 Org `theta-corp`:

```
uptime-kuma-...-x-theta-corp-x-vcluster   0/1   OOMKilled   49 restarts
  requests={"cpu":"50m","memory":"128Mi"}
  limits  ={"cpu":"50m","memory":"128Mi"}
```

Uptime Kuma is Node.js with an embedded SQLite store; its baseline working set exceeds 128Mi before it finishes booting, so it OOMs, restarts, and OOMs again. The app installs, reports provisioned, and **never once serves a request** — a customer-visible dead application.

## Why the number is load-bearing

`qosResources()` returns the declared *request* as the **limit** too on every paid plan, so the pod is Guaranteed QoS — which the per-Org LimitRange's `maxLimitRequestRatio {cpu:1, memory:1}` requires in order to admit it at all. There is no burst headroom to absorb an under-estimate: whatever is declared here is a hard ceiling.

That mechanism is correct and stays untouched. Only the value is wrong.

## The change

`uptime-kuma` `128Mi/50m` → `512Mi/100m`. 512Mi matches the tier already used for the other Node-heavy apps in this map (chatwoot, rocket-chat). CPU moves because the liveness probe was also failing during boot — 50m is 5% of a core and Node startup is CPU-hungry even where steady-state draw is small.

Both are deliberately modest. Region-A already sits at 98–100% CPU **requests** (#5393), so this is sized to stop a proven hard failure, not to be generous.

**Exactly one entry changes.** Two other apps share the 128Mi tier and are deliberately left alone — see below.

## Second defect in this same map today

#5397 was nine images pinned to `:latest` and refused by Kyverno at admission. Both are hard-coded Go data with no validation and no runtime feedback loop, which is why neither surfaced until an app was actually walked. Worth considering whether values this consequential should be reviewable — a single number here silently decides whether a purchased application can run.

## The guard is narrow on purpose

`TestUptimeKuma_MemoryAboveProvenOOMCeiling_5410` pins the one app with proven evidence. It is **not** a catalog-wide memory floor, because a floor high enough to catch uptime-kuma would also fail `vaultwarden` — which runs fine at 128Mi (Rust, genuinely lightweight) and has no evidence against it. Trading a real defect for a false one is not an improvement.

`listmonk` shares the 128Mi tier but has **never run** (Kyverno-denied under #5397), so there is no evidence either way. It is left unchanged pending a real measurement rather than raised on suspicion.

#5410 records that the durable answer here is runtime feedback — an OOMKill should surface as a provisioning signal — rather than a static threshold guess.

## Verification

- **Negative proof**: reverting to `128Mi` fails the guard with the exact diagnosis (`at or below the 128Mi ceiling that was PROVEN to OOMKill it 49 times on hw290`); restoring passes.
- `go build ./...`, `go vet ./...`, and the full `gitops` package suite with `-count=1` — green.
- Both touched files `gofmt`-clean.

## Owed

Runtime proof: a fresh install reaching Ready and serving, rather than restart-looping. That needs the provisioning image to roll and a new cart.

Refs #5410 #5397 #5393
