### PR TITLE
fix(harbor): SIGPIPE-proof the cross-region redis test — a false FAIL left bp-harbor 1.2.45 unpublished and both HelmReleases on a hollow pin

### DIFF
--- a/platform/harbor/chart/tests/redis-crossregion.sh
+++ b/platform/harbor/chart/tests/redis-crossregion.sh
@@ -38,6 +38,23 @@
 
 set -euo pipefail
 
+# #5406 follow-up — SIGPIPE-proof matching. `has "$big" -q PAT` is
+# unsafe under `set -o pipefail`: grep -q exits the instant it matches, closing
+# the pipe while echo is still writing a multi-KB helm render. echo then takes
+# SIGPIPE/EPIPE, pipefail promotes that to a script failure, and the test FAILS
+# even though the assertion PASSED. That is exactly what happened on merge
+# commit 87aab2a66 — CI reported
+#   redis-crossregion.sh: line 106: echo: write error: Broken pipe
+#   FAIL: harbor-core's _REDIS_URL_CORE ... does not point at the mesh Service
+# for a chart whose wiring was correct, which left bp-harbor 1.2.45 unpublished
+# and both regions' HelmRelease stuck on a hollow pin.
+#
+# Same defect class as the openbao eso-push-policy-render.sh fix (#5370). The
+# cure is to remove the pipe entirely: write once to a temp file, grep the file.
+_m_tmp="$(mktemp)"; trap 'rm -f "$_m_tmp"' EXIT
+# has <text> <grep-args...> — true when the pattern matches, no pipe involved.
+has() { local text="$1"; shift; printf '%s\n' "$text" > "$_m_tmp"; grep "$@" "$_m_tmp"; }
+
 chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
 helm="${HELM_BIN:-helm}"
 svc_tpl="templates/redis-mesh-service.yaml"
@@ -71,15 +88,15 @@ echo "[bp-harbor] Case 1: PASS"
 echo "[bp-harbor] Case 2: crossRegion.role=primary → mesh Service exports backends"
 primary_svc=$(render --set crossRegion.enabled=true --set crossRegion.role=primary \
                 --show-only "$svc_tpl")
-echo "$primary_svc" | grep -q 'name: "harbor-redis-mesh"' || {
+has "$primary_svc" -q 'name: "harbor-redis-mesh"' || {
   echo "FAIL: mesh Service is not named harbor-redis-mesh (Cilium merges global services by NAME+namespace)"; exit 1; }
-echo "$primary_svc" | grep -q 'service.cilium.io/global: "true"' || {
+has "$primary_svc" -q 'service.cilium.io/global: "true"' || {
   echo "FAIL: mesh Service is missing service.cilium.io/global — Cilium will not publish it across the mesh"; exit 1; }
-echo "$primary_svc" | grep -q 'service.cilium.io/shared: "true"' || {
+has "$primary_svc" -q 'service.cilium.io/shared: "true"' || {
   echo "FAIL: the ACTIVE region must EXPORT its redis backends (service.cilium.io/shared=true) or the standby has nothing to reach"; exit 1; }
-echo "$primary_svc" | grep -q 'component: redis' || {
+has "$primary_svc" -q 'component: redis' || {
   echo "FAIL: mesh Service does not select the upstream redis Pod (app/release/component: redis)"; exit 1; }
-echo "$primary_svc" | grep -qE 'port: 6379' || {
+has "$primary_svc" -qE 'port: 6379' || {
   echo "FAIL: mesh Service does not publish 6379"; exit 1; }
 echo "[bp-harbor] Case 2: PASS"
 
@@ -87,9 +104,9 @@ echo "[bp-harbor] Case 2: PASS"
 echo "[bp-harbor] Case 3: crossRegion.role=secondary → same Service name, shared=false"
 secondary_svc=$(render --set crossRegion.enabled=true --set crossRegion.role=secondary \
                   --show-only "$svc_tpl")
-echo "$secondary_svc" | grep -q 'name: "harbor-redis-mesh"' || {
+has "$secondary_svc" -q 'name: "harbor-redis-mesh"' || {
   echo "FAIL: the secondary must render the SAME Service name or Cilium cannot merge the two into one global service"; exit 1; }
-echo "$secondary_svc" | grep -q 'service.cilium.io/shared: "false"' || {
+has "$secondary_svc" -q 'service.cilium.io/shared: "false"' || {
   echo "FAIL: the STANDBY must NOT export redis backends — otherwise the active region can land a session in the standby, re-creating the split"; exit 1; }
 echo "[bp-harbor] Case 3: PASS"
 
@@ -99,15 +116,15 @@ sec_full=$(render \
   --set crossRegion.enabled=true --set crossRegion.role=secondary \
   --set harbor.redis.type=external \
   --set harbor.redis.external.addr=harbor-redis-mesh.harbor.svc.cluster.local:6379)
-if echo "$sec_full" | grep -qE '^kind: StatefulSet' && echo "$sec_full" | grep -q 'name: harbor-redis$'; then
+if has "$sec_full" -qE '^kind: StatefulSet' && has "$sec_full" -q 'name: harbor-redis$'; then
   echo "FAIL: the secondary still renders its OWN harbor-redis StatefulSet — the session store is still split."
   exit 1
 fi
-echo "$sec_full" | grep -q 'redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/0' || {
+has "$sec_full" -q 'redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/0' || {
   echo "FAIL: harbor-core's _REDIS_URL_CORE (db 0 — the OIDC SESSION store) does not point at the mesh Service."
   echo "This is the exact wire whose absence 401s every cross-region request (#5406)."
   exit 1; }
-echo "$sec_full" | grep -q 'redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/2' || {
+has "$sec_full" -q 'redis://harbor-redis-mesh.harbor.svc.cluster.local:6379/2' || {
   echo "FAIL: the registry blob-descriptor cache (db 2) does not point at the mesh Service"; exit 1; }
 echo "[bp-harbor] Case 4: PASS"
 
@@ -121,22 +138,22 @@ fi
 cnp=$(render --set crossRegion.enabled=true \
         --set crossRegion.peerClusters[0]=hw290-me-east-b \
         --api-versions cilium.io/v2 --show-only "$cnp_tpl")
-echo "$cnp" | grep -q 'name: harbor-crossregion-redis-ingress' || {
+has "$cnp" -q 'name: harbor-crossregion-redis-ingress' || {
   echo "FAIL: the INGRESS carve-out is missing — the active region's harbor-default-deny drops the peer's redis SYN"; exit 1; }
-echo "$cnp" | grep -q 'name: harbor-crossregion-redis-egress' || {
+has "$cnp" -q 'name: harbor-crossregion-redis-egress' || {
   echo "FAIL: the EGRESS carve-out is missing — the standby's dial is dropped before it leaves"; exit 1; }
-echo "$cnp" | grep -q 'key: io.cilium.k8s.policy.cluster' || {
+has "$cnp" -q 'key: io.cilium.k8s.policy.cluster' || {
   echo "FAIL: the CNPs do not select the peer by ClusterMesh cluster identity."
   echo "A CIDR/ipBlock rule can NEVER match a ClusterMesh remote Pod (it is a known endpoint"
   echo "with its own identity, not a CIDR identity) — proven on hw228 (#4846/#4854)."
   exit 1; }
-echo "$cnp" | grep -q 'hw290-me-east-b' || {
+has "$cnp" -q 'hw290-me-east-b' || {
   echo "FAIL: the peer cluster name did not reach the rendered policy"; exit 1; }
-echo "$cnp" | grep -q 'port: "6379"' || {
+has "$cnp" -q 'port: "6379"' || {
   echo "FAIL: the CNPs do not scope to 6379 — either the port is wrong or the surface is too wide"; exit 1; }
 # The namespace key must be referenced with Exists so Cilium does NOT AND-inject
 # `namespace=harbor` and silently narrow the rule (#4854 row 67 L2).
-echo "$cnp" | grep -q 'key: k8s:io.kubernetes.pod.namespace' || {
+has "$cnp" -q 'key: k8s:io.kubernetes.pod.namespace' || {
   echo "FAIL: the namespace key is not referenced — Cilium will AND-inject namespace=harbor and narrow the rule"; exit 1; }
 echo "[bp-harbor] Case 5: PASS"
 


### PR DESCRIPTION
## Why this is urgent

`Blueprint Release` **failed** on merge commit `87aab2a66`, so **bp-harbor 1.2.45 was never published to ghcr** (newest there is still 1.2.44 from 2026-07-20). Both regions on hw290 are stuck on a hollow pin:

```
region-a  chart=1.2.45  attempted=1.2.44  Ready=False
region-b  chart=1.2.45  attempted=1.2.44  Ready=False
  SourceNotReady: chart pull error: failed to get
  'oci://ghcr.io/openova-io/bp-harbor:1.2.45'
```

Harbor still **runs** on 1.2.44 — `Released=True InstallSucceeded` — so there is no outage. But the #5406 cross-region redis fix cannot land, and the HelmRelease cannot reconcile at all until 1.2.45 exists.

## The chart was never wrong — the test was

```
redis-crossregion.sh: line 106: echo: write error: Broken pipe
FAIL: harbor-core's _REDIS_URL_CORE (db 0 — the OIDC SESSION store) does not point at the mesh Service.
```

`echo "$big" | grep -q PAT` is unsafe under `set -o pipefail`. `grep -q` exits the instant it matches, closing the pipe while `echo` is still writing a multi-KB helm render. `echo` takes EPIPE, `pipefail` promotes that to a script failure, and the assertion reports FAIL **even though it passed**.

All 16 assertions in the file used that shape, so which one tripped was luck — and the failure message points at the chart, which is actively misleading.

Running the test against the shipped chart today: **5/5 PASS**.

## Same class as #5370

The openbao `eso-push-policy-render.sh` had this identical defect earlier today. Two independent chart test suites, same shape — worth a sweep of the others rather than waiting for the third.

## Fix

Remove the pipe entirely: write once to a temp file, grep the file, via a `has` helper. Zero pipe-into-grep patterns remain.

## Proven not vacuous

A fix like this invites exactly one trap — a helper that always succeeds would make all 5 cases pass meaninglessly. Checked both directly and end to end:

- absent pattern → non-zero; present pattern → zero; 200KB input → no SIGPIPE
- breaking the chart (`service.cilium.io/global` `"true"` → `"false"`) fails with *"mesh Service is missing service.cilium.io/global"*; restoring passes 5/5

## After merge

Blueprint Release should publish 1.2.45, both HelmReleases should leave `SourceNotReady`, and the #5406 redis-mesh wiring finally applies. Runtime proof for #5406 is still owed and unchanged: N ≥ 20 consecutive `users/current` returning `200 × N`, with `harbor-nginx` logs in **both** regions showing a non-zero share.

Refs #5406 #5370
