### PR TITLE
fix(harbor): duplicate catalyst.openova.io/component key failed the 1.2.45 upgrade on both regions

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -230,7 +230,7 @@ spec:
       # camelCase; the s3 overlay above now sets the correct lowercase key).
       # 1.2.45: #5406 — ONE session/queue/cache store per Sovereign. See the
       # crossRegion block in `values:` below for the full wiring + rationale.
-      version: 1.2.45
+      version: 1.2.46
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.45  # lockstep with chart/Chart.yaml (#5406 cross-region Redis anchor — see Chart.yaml changelog)
+  version: 1.2.46  # lockstep with chart/Chart.yaml (#5406 cross-region Redis anchor — see Chart.yaml changelog)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -215,7 +215,7 @@ type: application
 #   ${SOVEREIGN_ENABLE_CNPG_PAIR}, which catalyst-api stamps true only once
 #   ClusterMesh is established) — a single-region render is byte-identical.
 #   Guarded by tests/redis-crossregion.sh.
-version: 1.2.45
+version: 1.2.46
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/redis-mesh-service.yaml
+++ b/platform/harbor/chart/templates/redis-mesh-service.yaml
@@ -90,7 +90,16 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "bp-harbor.labels" . | nindent 4 }}
-    catalyst.openova.io/component: harbor-redis-cross-region-mesh
+    {{- /*
+      #5406 follow-up — do NOT re-emit `catalyst.openova.io/component` here.
+      `bp-harbor.labels` (_helpers.tpl:15) already sets it to `harbor`, and a
+      second occurrence is doubly wrong: Helm keeps the FIRST key so the
+      override is INERT, and the kustomize post-renderer rejects the duplicate
+      outright — `mapping key "catalyst.openova.io/component" already defined`
+      — which failed the 1.2.45 upgrade on BOTH regions. Use a distinct key.
+      Nothing selects on this value; it is descriptive only.
+    */}}
+    catalyst.openova.io/subcomponent: harbor-redis-cross-region-mesh
     catalyst.openova.io/cross-region-role: {{ $role | quote }}
   annotations:
     # Cilium ClusterMesh — the SAME name+namespace on both sides so the mesh

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3327,7 +3327,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.45"
+  version: "1.2.46"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3351,7 +3351,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.45"
+    version: "1.2.46"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## What broke

`bp-harbor 1.2.45` published, then failed to install on **both** regions:

```
error while running post render
line 13: mapping key "catalyst.openova.io/component" already defined at line 12
```

`redis-mesh-service.yaml` emitted `catalyst.openova.io/component` a second time, after `include "bp-harbor.labels"` had already set it to `harbor` (`_helpers.tpl:15`). The render carried both keys.

**Wrong twice over.** Helm keeps the *first* key, so the override was already **inert** — it never did what it appeared to do. And the kustomize post-renderer rejects the duplicate outright, which is what actually failed the upgrade.

## Fix

Use a distinct key, `catalyst.openova.io/subcomponent`. A repo-wide grep finds `harbor-redis-cross-region-mesh` **only on the line that emits it** — nothing selects on it, so the rename is safe and the descriptive intent is preserved.

Chart `1.2.45 → 1.2.46`, all four lockstep sites moved.

Worth noting: `platform/harbor/blueprint.yaml:9` carries a trailing comment, so a `$`-anchored sed silently misses it. The Go drift-guard caught that — the shell pin-sync check passed regardless.

## Gates

bootstrap-kit drift-guards, pin-sync 67/67, catalog-seed lockstep, no-nodeports, and the harbor chart tests — `redis-crossregion.sh` 5/5 and `registry-disableredirect.sh`.

## Accountability

This is my own regression from the #5406 merge. It also means the hollow pin was masking a **second** defect: even had 1.2.45 published on the first attempt, it could never have installed.

Refs #5406