### PR TITLE
fix(harbor): sweep the duplicate-label class — the netpol template carries it twice more (1.2.46 still failed)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -230,7 +230,7 @@ spec:
       # camelCase; the s3 overlay above now sets the correct lowercase key).
       # 1.2.45: #5406 — ONE session/queue/cache store per Sovereign. See the
       # crossRegion block in `values:` below for the full wiring + rationale.
-      version: 1.2.46
+      version: 1.2.47
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.46  # lockstep with chart/Chart.yaml (#5406 cross-region Redis anchor — see Chart.yaml changelog)
+  version: 1.2.47  # lockstep with chart/Chart.yaml (#5406 cross-region Redis anchor — see Chart.yaml changelog)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -215,7 +215,7 @@ type: application
 #   ${SOVEREIGN_ENABLE_CNPG_PAIR}, which catalyst-api stamps true only once
 #   ClusterMesh is established) — a single-region render is byte-identical.
 #   Guarded by tests/redis-crossregion.sh.
-version: 1.2.46
+version: 1.2.47
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/redis-crossregion-netpol.yaml
+++ b/platform/harbor/chart/templates/redis-crossregion-netpol.yaml
@@ -58,7 +58,11 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "bp-harbor.labels" . | nindent 4 }}
-    catalyst.openova.io/component: harbor-crossregion-redis-netpol
+    {{- /* #5406 — see redis-mesh-service.yaml: `bp-harbor.labels` already sets
+         catalyst.openova.io/component, and re-emitting it is inert (Helm keeps
+         the first key) AND fails helm-controller's post-render unmarshal with
+         `mapping key already defined`. Use a distinct key. */}}
+    catalyst.openova.io/subcomponent: harbor-crossregion-redis-netpol
 spec:
   endpointSelector:
     matchLabels:
@@ -88,7 +92,11 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "bp-harbor.labels" . | nindent 4 }}
-    catalyst.openova.io/component: harbor-crossregion-redis-netpol
+    {{- /* #5406 — see redis-mesh-service.yaml: `bp-harbor.labels` already sets
+         catalyst.openova.io/component, and re-emitting it is inert (Helm keeps
+         the first key) AND fails helm-controller's post-render unmarshal with
+         `mapping key already defined`. Use a distinct key. */}}
+    catalyst.openova.io/subcomponent: harbor-crossregion-redis-netpol
 spec:
   # Every endpoint in the harbor namespace — matching the default-deny's own
   # scope. harbor-core / -jobservice / -registry all dial redis.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3327,7 +3327,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.46"
+  version: "1.2.47"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3351,7 +3351,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.46"
+    version: "1.2.47"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## What happened

1.2.46 fixed **one** occurrence of the duplicate label and still failed identically on both regions:

```
error while running post render
line 13: mapping key "catalyst.openova.io/component" already defined at line 12
```

`redis-crossregion-netpol.yaml` carries the same pattern **twice** — the ingress and egress CiliumNetworkPolicies both include `bp-harbor.labels` and then re-emit `catalyst.openova.io/component`. I fixed `redis-mesh-service.yaml` and stopped at the instance instead of sweeping the class.

## Why the incomplete fix looked complete

Two false confirmations, both worth recording:

1. **`helm template | yaml.safe_load` passed locally.** PyYAML's `safe_load` silently keeps the last duplicate key rather than raising; helm-controller's post-render unmarshal is stricter. **A local render is not a proxy for what the cluster will accept.**
2. **Pulling the published 1.2.46 and grepping confirmed the wrong thing** — the redis-mesh fix genuinely was in there. Verifying the fix I made says nothing about the fix I missed.

## This time the class is swept

No template re-emits `catalyst.openova.io/component` after including the labels helper — verified by a pattern search across every file in `templates/`, not by checking the one I edited. All four `crossRegion`/`role` combinations render with zero duplicate-key errors.

Chart `1.2.46 → 1.2.47`, all four lockstep sites. Drift-guards, pin-sync and `redis-crossregion.sh` pass.

## Third attempt at landing #5406

The first failed to publish (false-failing test). The second published but could not install (this label). This one clears the class. Each layer only became visible after the one above it was fixed — worth remembering that a green merge says nothing about publish, and a successful publish says nothing about install.

Refs #5406