### PR TITLE
fix(provisioning): vcluster-tier funnel cart with a HelmRelease app no longer poisons the whole per-Org apps Kustomization (Refs #5423)

### DIFF
--- a/core/services/provisioning/gitops/perorg_apps_tree.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree.go
@@ -89,9 +89,28 @@ var perOrgHostAppsBaselineDocs = []string{
 //     re-creating the `apps` ns here would collide with the targetNamespace
 //     rewrite the org-controller's apps Kustomization applies.
 //   - the host-scoped HelmRelease-shaped apps `<basePath>/<slug>/app-<x>.yaml`
-//     (openclaw / stalwart-mail / any HR app) → `vcluster/apps/app-<x>.yaml`.
-//     On the de-vcluster'd host-native Sovereign these install straight into
-//     the host `<slug>` ns the apps Kustomization targets.
+//     (openclaw / stalwart-mail / newapi) → **tier-dependent**:
+//   - HOST tier (free/S): → `vcluster/apps/app-<x>.yaml`. That Kustomization
+//     carries no `kubeConfig`, so it applies to the HOST `<slug>` ns where the
+//     Flux CRDs live and the HelmRelease reconciles normally.
+//   - VCLUSTER tier (m/l/xl/flexi, #5423): → `vcluster/host-apps/app-<x>.yaml`.
+//     The org-controller gives the apps Kustomization a `kubeConfig.secretRef`
+//     on this tier, so it applies INTO the Org vcluster — which registers no
+//     `helm.toolkit.fluxcd.io` / `source.toolkit.fluxcd.io` CRDs at all. A
+//     HelmRelease/HelmRepository doc there fails server dry-run with
+//     `no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2"`,
+//     and because Flux aborts the WHOLE Kustomization on a single dry-run
+//     failure, it took every sibling doc down with it: the customer's plain
+//     Deployment-shaped app (`app-wordpress.yaml`) and its database
+//     (`db-mysql.yaml`) were never applied either. Live on hw290 that read as
+//     `inventory=0` on `catalyst-tenant-<slug>-apps` for 2/2 such Orgs, an
+//     `app-<x>-hostroute` HTTPRoute stuck on
+//     `ResolvedRefs=False / BackendNotFound` (the routes live in host-apps and
+//     applied fine — only the backends were blocked), and HTTP 500 on
+//     `wordpress.<slug>.<parent>` (UAT rows 86/90/233/234).
+//     `vcluster/host-apps/` is the correct home: `kubeConfig: null` +
+//     `targetNamespace: <slug>` is exactly "the host `<slug>` ns" this routing
+//     always intended.
 //
 // The contabo-model host scaffolding (apps-sync.yaml, ingress.yaml,
 // provisioning-rbac.yaml, the host kustomization.yaml) is dropped: the
@@ -125,6 +144,18 @@ func (g *ManifestGenerator) GeneratePerOrgAppsTree(slug, planSlug string, appSlu
 			docSet[name] = struct{}{}
 		case isHostHelmReleaseAppFile(path, hostHRPrefix):
 			name := strings.TrimPrefix(path, hostHRPrefix)
+			// #5423 — on the vcluster tier the apps Kustomization is
+			// kubeConfig-targeted at the CRD-less Org vcluster, so a Flux doc
+			// there poisons the whole tree. Land it in host-apps instead
+			// (kubeConfig: null, targetNamespace: <slug>). appDocs must NOT
+			// list it: it no longer lives under vcluster/apps/, and a
+			// kustomization entry for a missing file breaks the build outright
+			// (the #4567 failure mode). PerOrgHostHelmReleaseAppDocs feeds the
+			// host-apps index instead.
+			if BoundaryIsVcluster(planSlug) {
+				out[PerOrgHostAppsDir+"/"+name] = content
+				continue
+			}
 			out[PerOrgAppsDir+"/"+name] = content
 			docSet[name] = struct{}{}
 		default:
@@ -286,6 +317,46 @@ func MergePerOrgHostAppsKustomization(existing string, treeDocs, hostAppDocs []s
 	return b.String()
 }
 
+// PerOrgHostHelmReleaseAppDocs returns the `app-<x>.yaml` basenames that
+// GeneratePerOrgAppsTree re-roots into `vcluster/host-apps/` for this cart —
+// i.e. the HelmRelease-shaped apps on the VCLUSTER tier (#5423). The caller
+// unions these into the host-apps kustomization index alongside the #4993
+// host-native route docs.
+//
+// Returns nil on the host tier: there the HR files stay in `vcluster/apps/`
+// (that Kustomization already applies to the host) and are indexed by
+// GeneratePerOrgAppsTree's own appDocs, exactly as before.
+//
+// Kept as a standalone pure function rather than a third return value of
+// GeneratePerOrgAppsTree so the render seam's signature — asserted by the
+// #4384/#4758/#3376 render-proof tests — stays stable. It is the deliberate
+// counterpart of the `continue` in GeneratePerOrgAppsTree: both key off
+// BoundaryIsVcluster + isHelmReleaseApp, so the file set and the index set
+// cannot drift.
+func PerOrgHostHelmReleaseAppDocs(planSlug string, appSlugs []string) []string {
+	if !BoundaryIsVcluster(planSlug) {
+		return nil
+	}
+	docs := make([]string, 0, len(appSlugs))
+	seen := map[string]struct{}{}
+	for _, a := range appSlugs {
+		if !isHelmReleaseApp(a) {
+			continue
+		}
+		name := fmt.Sprintf("app-%s.yaml", a)
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		docs = append(docs, name)
+	}
+	if len(docs) == 0 {
+		return nil
+	}
+	sort.Strings(docs)
+	return docs
+}
+
 // isHostHelmReleaseAppFile reports whether `path` is a host-scoped
 // HelmRelease-shaped app file (`<hostPrefix>app-<x>.yaml`) directly under the
 // tenant dir — i.e. NOT nested under `apps/`. These are the bp-* HelmReleases
@@ -336,6 +407,23 @@ func MergePerOrgAppsKustomization(existing, planSlug string, treeDocs, appDocs [
 	// "no such file or directory" and wedges the entire apps Kustomization.
 	excludedFromAppsTree := map[string]struct{}{
 		"ciliumnetworkpolicy.yaml": {},
+	}
+	// #5423 — same self-heal, same reason, one tier: on the VCLUSTER tier the
+	// HelmRelease-shaped app docs now live in `vcluster/host-apps/`, so an
+	// entry for them here points at a file this tree does not contain. A repo
+	// written by a pre-#5423 build still lists them in `existing`; strip them
+	// on every merge so the next cart install / reconcile heals an Org that
+	// would otherwise stay wedged on
+	// `no matches for kind "HelmRelease"` forever. The orphaned blob left at
+	// `vcluster/apps/app-<x>.yaml` is inert once unindexed — kustomize builds
+	// only what `resources:` lists.
+	//
+	// HOST tier is untouched: there the HR docs legitimately live in
+	// `vcluster/apps/` and MUST stay indexed.
+	if BoundaryIsVcluster(planSlug) {
+		for slug := range helmReleaseAppSlugs {
+			excludedFromAppsTree[fmt.Sprintf("app-%s.yaml", slug)] = struct{}{}
+		}
 	}
 
 	resources := map[string]struct{}{}

--- a/core/services/provisioning/gitops/perorg_hr_app_host_routing_5423_test.go
+++ b/core/services/provisioning/gitops/perorg_hr_app_host_routing_5423_test.go
@@ -1,0 +1,153 @@
+package gitops
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #5423 — a funnel Organization on a VCLUSTER-tier plan (m/l/xl/flexi) whose
+// cart contains a HelmRelease-shaped app (openclaw / stalwart-mail / newapi)
+// never deployed ANY app in that cart, including the plain Deployment-shaped
+// ones. Live on hw290 for 2/2 such Orgs (acme-corp, walk-two):
+//
+//	$ kubectl get kustomization -n flux-system catalyst-tenant-acme-corp-apps
+//	READY: False  ReconciliationFailed
+//	MSG:   HelmRelease/acme-corp/bp-openclaw dry-run failed:
+//	       no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2"
+//	inventory: 0
+//
+// GeneratePerOrgAppsTree re-rooted the host-scoped `app-<x>.yaml` HelmRelease
+// files into `vcluster/apps/` for EVERY plan. On the host tier that is correct
+// (the apps Kustomization has `kubeConfig: null` → applies to the host, where
+// the Flux CRDs live). On the vcluster tier the org-controller attaches
+// `kubeConfig.secretRef: tenant-<slug>-kubeconfig`, so the same doc is applied
+// INTO the Org vcluster — which registers no `helm.toolkit.fluxcd.io` CRDs at
+// all. Flux aborts the WHOLE Kustomization on one dry-run failure, so the two
+// poison docs took `app-wordpress.yaml` and `db-mysql.yaml` down with them.
+//
+// Downstream that was UAT rows 86 (timeline RED), 90 (wordpress → HTTP 500 via
+// `ResolvedRefs=False / BackendNotFound`), 233 (HTTPRoute present but nothing
+// serves — routes live in host-apps and applied fine, only the backends were
+// blocked) and 234 (stalwart-mail carted, no HelmRelease ever created).
+func TestPerOrgAppsTree_5423_VclusterTierKeepsFluxDocsOutOfTheKubeconfigTargetedTree(t *testing.T) {
+	cart := []string{"wordpress", "stalwart-mail", "openclaw"}
+
+	// The invariant that actually matters: nothing under vcluster/apps/ may
+	// carry a kind the Org vcluster cannot serve. Asserting on the KIND rather
+	// than the filename is what makes this a real guard — a future HR-shaped
+	// catalog app is caught even if it is named nothing like app-openclaw.yaml.
+	fluxOnlyKinds := []string{"HelmRelease", "HelmRepository", "OCIRepository", "GitRepository", "Kustomization"}
+
+	t.Run("vcluster tier routes HR apps to host-apps", func(t *testing.T) {
+		g := NewManifestGenerator("clusters/sov/org-tenants")
+		files, appDocs := g.GeneratePerOrgAppsTree("acmex", "m", cart, "pw123")
+
+		for path, content := range files {
+			if !strings.HasPrefix(path, PerOrgAppsDir+"/") {
+				continue
+			}
+			for _, k := range fluxOnlyKinds {
+				if strings.Contains(content, "\nkind: "+k) || strings.HasPrefix(content, "kind: "+k) {
+					t.Errorf("%s carries kind %s — the vcluster-tier apps Kustomization is kubeConfig-targeted at the Org vcluster, which has no Flux CRDs; the whole Kustomization fails dry-run and every sibling app dies with it (#5423)", path, k)
+				}
+			}
+		}
+
+		for _, want := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+			if _, ok := files[PerOrgHostAppsDir+"/"+want]; !ok {
+				t.Errorf("expected %s under %s (kubeConfig: null, targetNamespace: <slug> — the host ns these HRs always meant to install into)", want, PerOrgHostAppsDir)
+			}
+			if _, ok := files[PerOrgAppsDir+"/"+want]; ok {
+				t.Errorf("%s must NOT remain under %s on the vcluster tier", want, PerOrgAppsDir)
+			}
+		}
+
+		// The customer's actual purchase must still be in the vcluster tree —
+		// this is the payload that was collateral damage.
+		for _, want := range []string{"app-wordpress.yaml", "db-mysql.yaml"} {
+			if _, ok := files[PerOrgAppsDir+"/"+want]; !ok {
+				t.Errorf("expected %s to stay under %s", want, PerOrgAppsDir)
+			}
+		}
+
+		// appDocs indexes vcluster/apps/kustomization.yaml. Listing a file that
+		// is no longer in that dir breaks the kustomize build outright — the
+		// #4567 failure mode.
+		for _, d := range appDocs {
+			if d == "app-openclaw.yaml" || d == "app-stalwart-mail.yaml" {
+				t.Errorf("appDocs still lists %s; its file moved to %s, so the apps kustomization would reference a missing file", d, PerOrgHostAppsDir)
+			}
+		}
+
+		hostDocs := PerOrgHostHelmReleaseAppDocs("m", cart)
+		want := []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"}
+		sort.Strings(hostDocs)
+		if strings.Join(hostDocs, ",") != strings.Join(want, ",") {
+			t.Errorf("PerOrgHostHelmReleaseAppDocs = %v, want %v — the file set and the index set must not drift", hostDocs, want)
+		}
+	})
+
+	// The host tier is the path that always worked; a regression here would
+	// break every free/S Org, so pin it explicitly.
+	t.Run("host tier is unchanged", func(t *testing.T) {
+		g := NewManifestGenerator("clusters/sov/org-tenants")
+		files, appDocs := g.GeneratePerOrgAppsTree("acmex", "s", cart, "pw123")
+
+		for _, want := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+			if _, ok := files[PerOrgAppsDir+"/"+want]; !ok {
+				t.Errorf("host tier: %s must stay under %s (that Kustomization applies to the host, where the Flux CRDs live)", want, PerOrgAppsDir)
+			}
+			if _, ok := files[PerOrgHostAppsDir+"/"+want]; ok {
+				t.Errorf("host tier: %s must NOT move to %s", want, PerOrgHostAppsDir)
+			}
+		}
+		idx := strings.Join(appDocs, ",")
+		for _, want := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+			if !strings.Contains(idx, want) {
+				t.Errorf("host tier: appDocs must still index %s, got %v", want, appDocs)
+			}
+		}
+		if got := PerOrgHostHelmReleaseAppDocs("s", cart); got != nil {
+			t.Errorf("host tier: PerOrgHostHelmReleaseAppDocs must be nil, got %v", got)
+		}
+	})
+}
+
+// A per-Org repo written by a pre-#5423 build still lists app-<x>.yaml in
+// vcluster/apps/kustomization.yaml while the file now lives in host-apps. The
+// merge must strip that entry on the vcluster tier so the next cart install
+// heals an Org that would otherwise stay wedged forever — the same self-heal
+// #4567 applies to a stale ciliumnetworkpolicy.yaml entry.
+func TestMergePerOrgAppsKustomization_5423_StripsStaleHRAppEntryOnVclusterTier(t *testing.T) {
+	stale := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - networkpolicy.yaml
+  - app-openclaw.yaml
+  - app-stalwart-mail.yaml
+  - app-wordpress.yaml
+  - db-mysql.yaml
+`
+
+	got := MergePerOrgAppsKustomization(stale, "m", nil, []string{"app-wordpress.yaml", "db-mysql.yaml"})
+	for _, gone := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("vcluster tier: stale %s survived the merge — the Org stays wedged on a kustomization entry whose file is not in the dir:\n%s", gone, got)
+		}
+	}
+	for _, keep := range []string{"app-wordpress.yaml", "db-mysql.yaml", "networkpolicy.yaml", "namespace.yaml"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("vcluster tier: %s must survive the merge:\n%s", keep, got)
+		}
+	}
+
+	// Host tier: the very same entries are legitimate and must be preserved.
+	gotHost := MergePerOrgAppsKustomization(stale, "s", nil, []string{"app-wordpress.yaml", "db-mysql.yaml"})
+	for _, keep := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+		if !strings.Contains(gotHost, keep) {
+			t.Errorf("host tier: %s must be preserved — its file really is in vcluster/apps/:\n%s", keep, gotHost)
+		}
+	}
+}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -793,6 +793,17 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 			for p, c := range hostRouteFiles {
 				appFiles[p] = c
 			}
+			// #5423 — on this tier GeneratePerOrgAppsTree has already re-rooted
+			// the HelmRelease-shaped app files (openclaw / stalwart-mail /
+			// newapi) into vcluster/host-apps/, because the apps Kustomization
+			// is kubeConfig-targeted at the Org vcluster, which registers no
+			// Flux CRDs — a HelmRelease doc there fails dry-run and Flux aborts
+			// the ENTIRE Kustomization, so the customer's plain Deployment app
+			// and its DB never applied either (hw290 rows 86/90/233/234).
+			// Index them here so kustomize actually builds them; on uninstall
+			// the rebuilt list carries only the surviving HR apps, which prunes
+			// the removed one exactly like the route docs above.
+			hostAppDocs = append(hostAppDocs, gitops.PerOrgHostHelmReleaseAppDocs(planSlug, appSlugs)...)
 			hostKustPath := gitops.PerOrgHostAppsDir + "/kustomization.yaml"
 			existingHostKust := ""
 			if content, err := repoClient.ReadFile(ctx, branch, hostKustPath); err == nil {


### PR DESCRIPTION
## What was broken

A funnel Organization on a **vcluster-tier plan** (m/l/xl/flexi) whose cart contained a
**HelmRelease-shaped app** (`openclaw` / `stalwart-mail` / `newapi`) deployed **nothing** —
not the HR app, and not the plain Deployment-shaped app the customer actually bought.

Live on hw290 (`hw290.omani.works`, dep `31106b6aa4a7e8e7`), 2/2 such Orgs:

```
$ kubectl get kustomization -n flux-system catalyst-tenant-acme-corp-apps
READY: False  ReconciliationFailed
MSG:   HelmRelease/acme-corp/bp-openclaw dry-run failed:
       no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2"
inventory: 0        # nothing applied, ever
```

## Root cause

`GeneratePerOrgAppsTree` re-rooted the host-scoped `app-<x>.yaml` HelmRelease files into
`vcluster/apps/` for **every** plan. Its own doc comment recorded the assumption that made
that safe:

> On the de-vcluster'd host-native Sovereign these install straight into the host `<slug>`
> ns the apps Kustomization targets.

That holds only on the **host tier**, where the apps Kustomization has `kubeConfig: null`.
On the **vcluster tier** the org-controller attaches `kubeConfig.secretRef`, so the same doc
is applied **into the Org vcluster** — which registers no Flux CRDs at all:

```
catalyst-tenant-acme-corp-apps  (tier m)  kubeConfig = {"secretRef": {"name": "tenant-acme-corp-kubeconfig"}}
catalyst-tenant-beta-corp-apps  (tier s)  kubeConfig = null
$ kubectl --kubeconfig <acme-corp vcluster> api-resources | grep helm.toolkit
(empty)
```

Flux aborts the **whole** Kustomization on one dry-run failure, so the two poison docs took
`app-wordpress.yaml` and `db-mysql.yaml` down with them — which is why the customer's
WordPress never served even though WordPress itself was fine.

Render proof, before: the file map was **byte-identical for plan=s and plan=m**.

```
plan=m  vcluster/apps/app-openclaw.yaml       [HelmRepository, HelmRelease]   <-- neither CRD exists in the vcluster
plan=m  vcluster/apps/app-stalwart-mail.yaml  [HelmRepository, HelmRelease]   <-- same
plan=m  vcluster/apps/app-wordpress.yaml      [Deployment, Service, HTTPRoute]
plan=m  vcluster/apps/db-mysql.yaml           [Secret, ConfigMap, PVC, Deployment, Service]
```

After:

```
plan=m  vcluster/apps/app-wordpress.yaml           docs=[app-wordpress.yaml db-mysql.yaml]
plan=m  vcluster/apps/db-mysql.yaml
plan=m  vcluster/host-apps/app-openclaw.yaml       <-- kubeConfig: null, targetNamespace: <slug>
plan=m  vcluster/host-apps/app-stalwart-mail.yaml
plan=s  (unchanged — all four stay in vcluster/apps/)
```

## Four UAT rows, one cause

| Row | Symptom | Mechanism |
|---|---|---|
| 86 | funnel timeline RED, never Done | the apps Kustomization never reaches Ready |
| 90 | `wordpress.<slug>` → **500** | Deployment+Service never applied → `ResolvedRefs=False / BackendNotFound` → Gateway API mandates 500 |
| 233 | HTTPRoute exists but nothing serves | routes live in `host-apps` (applied fine); only the backends were blocked |
| 234 | `stalwart-mail` carted, no HelmRelease created | its HR doc is the object that poisons the tree |

## Why it looked intermittent

It needs the intersection of (vcluster tier) x (HR app in cart):

| Org | tier | HR app in cart | apps Kustomization |
|---|---|---|---|
| acme-corp | m | yes | FAILED, inventory=0 |
| walk-two | m | yes | FAILED, inventory=0 |
| theta-corp | m | no | OK, inventory=20 |
| delta-corp | m | no (HRs come from `org-tenants`) | OK, inventory=3 |
| beta / epsilon / zeta | s | n/a | OK |

## Not a duplicate of #5387 / #5398

- **#5387** (per-Org gitops commit race) is real, merged, and live on hw290 since 19:21Z. It
  made the manifests *land in git*; Flux then found the HR doc and refused it. Different stage.
- **#5398** (`:latest` image pins) is merged and live since 19:56Z.
- This defect is untouched by both and reproduces at HEAD from the pure render function.

## The fix

Route HelmRelease-shaped app files to `vcluster/host-apps/` on the vcluster tier — precisely
the "host `<slug>` ns" the original comment intended. Host tier untouched.

`PerOrgHostHelmReleaseAppDocs` feeds those docs into the host-apps index. It is a standalone
pure function rather than a third return value so the render seam's signature — asserted by
the #4384/#4758/#3376 render-proof tests — stays stable, and it keys off the same
`BoundaryIsVcluster` + `isHelmReleaseApp` predicates as the routing, so the file set and the
index set cannot drift.

`MergePerOrgAppsKustomization` additionally strips a stale `app-<x>.yaml` entry on the
vcluster tier — the same self-heal #4567 applies to a stale `ciliumnetworkpolicy.yaml`
entry. Without it, an Org provisioned by a pre-fix build keeps the entry in its committed
index while the file is no longer in that dir, and stays wedged forever. The orphaned blob
is inert once unindexed: kustomize builds only what `resources:` lists.

Nothing is dropped: the HR apps still install, still carry their own chart-emitted HTTPRoute
parented to `cilium-gateway-console`, and are still skipped by `GeneratePerOrgHostAppRoutes`
(they sync no `<app>-x-<slug>-x-vcluster` Service, so a second route would 404).

## Tests — both directions proven

Asserts on the **kind**, not the filename: no Flux-only kind may appear under `vcluster/apps/`
on the vcluster tier, so a future HR-shaped catalog app is caught even if it is named nothing
like `app-openclaw.yaml`. Pins the host tier as unchanged and the stale-entry self-heal in
both tiers.

Reverted-fix run — 8 failures:
```
app-openclaw.yaml must NOT remain under vcluster/apps on the vcluster tier
appDocs still lists app-stalwart-mail.yaml; its file moved to vcluster/host-apps
vcluster tier: stale app-openclaw.yaml survived the merge
```
Restored: green.

Gates: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...` all green
across the provisioning module.

## Runtime proof to close

Fresh funnel Org, plan `m`, cart = wordpress + stalwart-mail:
1. `catalyst-tenant-<slug>-apps` Ready=True with non-zero inventory
2. `kubectl get hr -n <slug>` shows `bp-stalwart-tenant`
3. `https://wordpress.<slug>.omani.homes/` returns 200
4. funnel timeline reaches Done, not RED

Refs #5423 #960
