### PR TITLE
fix(sso): one cookie secret per Keycloak client, not one per region

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -141,7 +141,7 @@ spec:
       # 1370 → 1420 (WG-only). Layers on the 1.4.9/1.4.10 zero-nodeport +
       # authMode=legacy work. Cross-region ClusterMesh pod path needs a fresh
       # 2-region prov to verify (datapath change). Refs #4656.
-      version: 1.4.17
+      version: 1.4.18
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -170,7 +170,7 @@ spec:
       #   policy-dropped → `no OpenBao token` every tick → grafana/hubble 503,
       #   gitea 500. Fix: CNP egress now also names kube-dns + keycloak + openbao.
       #   #4449 fixed the INGRESS side; this is the EGRESS side. Refs #4458 #4449.
-      version: 0.2.25
+      version: 0.2.26
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -87,7 +87,7 @@ spec:
       # `/app/?token=<sentinel>` so the SPA seeds the token and lands
       # authenticated with NO paste (the durable path — the daemon's `oidc`
       # authMode is a non-functional upstream scaffold, #128).
-      version: 0.1.7
+      version: 0.1.8
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.17
+  version: 1.4.18
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -299,7 +299,23 @@ name: bp-cilium
 #   Layers ON TOP of the 1.4.9/1.4.10 zero-nodeport + authMode=legacy work.
 #   Needs a fresh 2-region prov to verify the cross-region ClusterMesh pod
 #   path end-to-end (datapath change, not CI-provable). Refs #4656.
-version: 1.4.17
+# 1.4.18 (#5416, 2026-07-27): hubble-ui oauth2-proxy COOKIE secret stops being
+#   minted per region. hubble-ui-oauth2-proxy-secret.yaml generates it with
+#   `lookup`-or-`randAlphaNum 32`; on a 2-region Sovereign each region's own
+#   Flux/Helm misses the lookup and mints a DIFFERENT value, and hubble.<fqdn>
+#   is fanned at BOTH regions' envoys by one shared wildcard VIP — so the two
+#   proxies reject each other's AES-encrypted session cookie ("cookie signature
+#   not valid" / "CSRF token mismatch"). Same class + same chart idiom as the
+#   bp-oidc-gate defect measured live on hw290. The client secret never had the
+#   problem because 1.4.2 moved it off the generator onto the bp-sso-bridge
+#   AppRegistration → OpenBao → ExternalSecret carrier; the cookie secret now
+#   follows it: the declaration uses bp-sso-bridge 0.2.26's multi-key `data`
+#   form so ONE ExternalSecret delivers client-secret AND cookie-secret, and
+#   the Deployment reads both from it when ssoBridgeSync is on (default). With
+#   ssoBridgeSync off both stay chart-managed — single-region shape unchanged.
+#   Needs bp-sso-bridge >= 0.2.26 (both pins bump in the same commit; an older
+#   bridge still applies the 1-key form, so no other key regresses).
+version: 1.4.18
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -315,6 +315,18 @@ name: bp-cilium
 #   ssoBridgeSync off both stay chart-managed — single-region shape unchanged.
 #   Needs bp-sso-bridge >= 0.2.26 (both pins bump in the same commit; an older
 #   bridge still applies the 1-key form, so no other key regresses).
+#   ALSO: hubble-ui-oauth2-proxy-secret.yaml no longer renders under the
+#   Catalyst default (now additionally gated on ssoBridgeSync being OFF). It
+#   was minting a SECOND, chart-local `client-secret` that nothing consumed —
+#   hubble-ui was the only gate carrying two client secrets (bridge-published
+#   in `…-oidc`, chart-minted in `…-sso`), which is why an audit sweeping "each
+#   gate's client secret" finds hubble's split across regions while the other
+#   three match: the chart-minted copy is lookup-or-generate and per-region by
+#   construction. It is a pre-#3374 leftover that #3374 superseded for
+#   consumption but never removed, and it silently reinstates the hw130
+#   `unauthorized_client` callback failure if ssoBridgeSync is ever flipped
+#   off. Now there is exactly ONE client secret + ONE cookie secret per gate,
+#   both bridge-published and region-consistent. Refs #5416.
 version: 1.4.18
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the

--- a/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml
@@ -126,8 +126,26 @@ spec:
             # #3374: with ssoBridgeSync the client-secret comes from the
             # bp-sso-bridge-published ExternalSecret (the LIVE Keycloak
             # value) instead of the chart-generated one that Keycloak
-            # never learned (the hw130 unauthorized_client 500). The
-            # cookie-secret stays chart-managed either way.
+            # never learned (the hw130 unauthorized_client 500).
+            #
+            # #5416: the cookie-secret now follows it. Chart-managed meant
+            # `lookup`-or-generate, which mints a DIFFERENT value in each
+            # region of a 2-region Sovereign (separate apiservers, separate
+            # Flux/Helm) — and hubble.<fqdn> is fanned at both regions' envoys
+            # by one shared wildcard VIP, so each proxy rejected the peer
+            # region's session cookie. bp-sso-bridge 0.2.26 derives one value
+            # per KC client into the OpenBao bundle and its multi-key
+            # declaration delivers it alongside client-secret. With
+            # ssoBridgeSync off, both keys stay on the chart-managed Secret
+            # (single-region behaviour, unchanged).
+            #
+            # UPGRADE WINDOW: bp-sso-bridge must reach 0.2.26 for the
+            # `cookie-secret` key to appear on hubble-ui-oauth2-proxy-oidc.
+            # Both pins bump in the same commit; until the bridge's next tick
+            # applies the 2-key ExternalSecret this Pod waits in
+            # CreateContainerConfigError, then starts on its own. An older
+            # bridge still applies the 1-key form (the declaration keeps the
+            # legacy secretKey/property fields), so nothing else regresses.
             - name: OAUTH2_PROXY_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -140,7 +158,11 @@ spec:
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
+                  {{- if $proxy.ssoBridgeSync.enabled }}
+                  name: hubble-ui-oauth2-proxy-oidc
+                  {{- else }}
                   name: {{ $proxy.existingSecret | quote }}
+                  {{- end }}
                   key: cookie-secret
           ports:
             - name: http

--- a/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-secret.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-secret.yaml
@@ -32,6 +32,16 @@ oauth2-proxy needs two secrets:
      and let `lookup` persist it across reconciles so existing browser
      sessions are not invalidated on every chart upgrade.
 
+     🛑 #5416 — `lookup`-or-generate is PER-CLUSTER, so on a 2-region
+     Sovereign the second region generates its OWN value and the two
+     proxies behind the one shared wildcard VIP reject each other's
+     session cookie. This key is therefore only the SINGLE-REGION /
+     ssoBridgeSync-disabled fallback: with ssoBridgeSync on (the Catalyst
+     default) the Deployment reads cookie-secret from the
+     bp-sso-bridge-published `hubble-ui-oauth2-proxy-oidc` Secret, whose
+     value is derived once per KC client and delivered identically to
+     every region.
+
 OPERATOR ESCAPE HATCH
 ------------------------------------------------------------------------
 `.Values.catalystOverlay.hubbleUI.oauth2Proxy.chartManagedSecret: false`

--- a/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-secret.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-secret.yaml
@@ -42,6 +42,33 @@ oauth2-proxy needs two secrets:
      value is derived once per KC client and delivered identically to
      every region.
 
+🛑 #5416 — THIS TEMPLATE NO LONGER RENDERS UNDER THE CATALYST DEFAULT.
+
+It is now gated on `ssoBridgeSync.enabled` being FALSE as well, because with
+ssoBridgeSync ON (the Catalyst default) the Deployment reads BOTH keys from the
+bp-sso-bridge-published `hubble-ui-oauth2-proxy-oidc` Secret and NOTHING
+consumes this one.
+
+Why that gate matters rather than leaving a harmless unused Secret: until
+#5416, hubble-ui was the ONLY gate that carried a SECOND, chart-minted
+`client-secret` — bridge-published in `…-oidc`, chart-minted here in `…-sso`,
+with the Deployment silently consuming the first and ignoring the second. The
+three bp-oidc-gate gates render no chart-minted client secret at all, so they
+have exactly ONE client secret each. That asymmetry is why an audit sweeping
+"the client secret of each gate" finds hubble's split across regions while the
+other three match: the chart-minted copy is `lookup`-or-generate and therefore
+per-region BY CONSTRUCTION, and it is a leftover of the pre-#3374 topology that
+#3374 superseded for consumption but never removed. Keeping a Keycloak-unknown
+client secret sitting in kube-system also means flipping ssoBridgeSync off
+silently reinstates the hw130 `unauthorized_client` callback failure.
+
+So: exactly one client secret and one cookie secret per gate, both published by
+bp-sso-bridge, both region-consistent.
+
+NOTE on upgrade: this Secret carries `helm.sh/resource-policy: keep`, so an
+existing one is NOT deleted by the upgrade — it remains behind, unconsumed.
+Reaping the stale object is a housekeeping follow-up, not a correctness one.
+
 OPERATOR ESCAPE HATCH
 ------------------------------------------------------------------------
 `.Values.catalystOverlay.hubbleUI.oauth2Proxy.chartManagedSecret: false`
@@ -56,7 +83,7 @@ band (SealedSecret / ExternalSecret) provide the Secret named by
 {{- $hostname = printf "hubble.%s" $ov.sovereignFQDN -}}
 {{- end -}}
 {{- $proxy := $ov.oauth2Proxy -}}
-{{- if and $ov.enabled $hostname (eq $ov.auth "oidc") (ne (toString $proxy.chartManagedSecret) "false") -}}
+{{- if and $ov.enabled $hostname (eq $ov.auth "oidc") (ne (toString $proxy.chartManagedSecret) "false") (not $proxy.ssoBridgeSync.enabled) -}}
 {{- $secretName := $proxy.existingSecret -}}
 {{- $existing := lookup "v1" "Secret" $ov.serviceRef.namespace $secretName -}}
 {{- $clientSecret := "" -}}

--- a/platform/cilium/chart/templates/hubble-ui-sso-registration-configmap.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-sso-registration-configmap.yaml
@@ -97,16 +97,37 @@ data:
   # re-added (helm-controller drift-check uses the install-time capability
   # snapshot — see Chart.yaml 1.4.2). bp-sso-bridge's AppRegistration watcher
   # runs post-ESO with the CRD present and applies THIS declaration verbatim
-  # every tick, materialising `hubble-ui-oauth2-proxy-oidc` (key
-  # `client-secret`) in kube-system from OpenBao sso/sovereign/hubble-ui —
-  # the secret the oauth2-proxy Deployment consumes for
-  # OAUTH2_PROXY_CLIENT_SECRET when ssoBridgeSync is enabled. Fresh-prov-safe
-  # + zero-touch.
+  # every tick, materialising `hubble-ui-oauth2-proxy-oidc` in kube-system from
+  # OpenBao sso/sovereign/hubble-ui — the secret the oauth2-proxy Deployment
+  # consumes when ssoBridgeSync is enabled. Fresh-prov-safe + zero-touch.
+  #
+  # #5416 (2026-07-27) — `cookie-secret` joins `client-secret` in the SAME
+  # declared Secret, via bp-sso-bridge 0.2.26's multi-key `data` form.
+  #
+  # WHY: the cookie secret was chart-managed
+  # (hubble-ui-oauth2-proxy-secret.yaml, `lookup`-or-`randAlphaNum 32`). On a
+  # 2-region Sovereign each region runs its own Flux/Helm against its own
+  # apiserver, so the lookup misses in the second region and a DIFFERENT value
+  # is minted there. hubble.<fqdn> is fanned at BOTH regions' envoys by one
+  # shared wildcard VIP, so requests round-robin and each proxy rejects the
+  # peer region's AES-encrypted session cookie ("cookie signature not valid" /
+  # "CSRF token mismatch") — the exact defect measured on the bp-oidc-gate
+  # instances on hw290 (#5416), same class, same chart idiom.
+  #
+  # The client secret never had that problem because it does not come from a
+  # per-region generator: Keycloak owns it and bp-sso-bridge publishes it to
+  # this bundle. Adding `cookie_secret` to the bundle (derived deterministically
+  # from the KC client secret, the idiom the bundle's `session_secret` already
+  # used) puts the cookie secret on the same proven carrier.
   externalSecret.json: |
     {
       "name": "hubble-ui-oauth2-proxy-oidc",
       "namespace": {{ $ov.serviceRef.namespace | quote }},
       "secretKey": "client-secret",
-      "property": "client_secret"
+      "property": "client_secret",
+      "data": [
+        { "secretKey": "client-secret", "property": "client_secret" },
+        { "secretKey": "cookie-secret", "property": "cookie_secret" }
+      ]
     }
 {{- end }}

--- a/platform/cilium/chart/tests/g117-hubble-oauth2-proxy-enforcement.sh
+++ b/platform/cilium/chart/tests/g117-hubble-oauth2-proxy-enforcement.sh
@@ -59,22 +59,53 @@ if [ "$b1" != "hubble-ui" ]; then
 fi
 echo "  PASS (backend=hubble-ui, no proxy)"
 
-# ── Case 2: auth=oidc → proxy Deployment+Service+Secret + route→proxy ─────
+# ── Case 2: auth=oidc → proxy Deployment+Service + route→proxy ────────────
+#
+# #5416: under the Catalyst default (ssoBridgeSync on) NO chart-managed Secret
+# renders and BOTH credentials come from the bp-sso-bridge-published
+# `hubble-ui-oauth2-proxy-oidc`. Before #5416 the cookie-secret was minted here
+# by `lookup`-or-generate, which yields a DIFFERENT value in each region of a
+# 2-region Sovereign (separate apiservers ⇒ separate Helm ⇒ the lookup misses),
+# so the two proxies behind the one shared wildcard VIP rejected each other's
+# session cookie. The chart also minted a SECOND client-secret that nothing
+# consumed — the reason a per-gate credential audit finds hubble's client
+# secret split across regions while the other three gates match.
 echo "[g117-hubble-oauth2-proxy] Case 2: auth=oidc renders proxy + routes through it"
 dep_oidc="$(show hubble-ui-oauth2-proxy-deployment.yaml --set catalystOverlay.hubbleUI.auth=oidc)"
 svc_oidc="$(show hubble-ui-oauth2-proxy-service.yaml --set catalystOverlay.hubbleUI.auth=oidc)"
 sec_oidc="$(show hubble-ui-oauth2-proxy-secret.yaml --set catalystOverlay.hubbleUI.auth=oidc)"
 grep -q "kind: Deployment" <<<"$dep_oidc" || { echo "FAIL: oauth2-proxy Deployment missing under auth=oidc" >&2; exit 1; }
 grep -q "kind: Service"    <<<"$svc_oidc" || { echo "FAIL: oauth2-proxy Service missing under auth=oidc" >&2; exit 1; }
-grep -q "kind: Secret"     <<<"$sec_oidc" || { echo "FAIL: chart-managed Secret missing under auth=oidc" >&2; exit 1; }
-grep -q "client-secret:"   <<<"$sec_oidc" || { echo "FAIL: Secret missing client-secret key" >&2; exit 1; }
-grep -q "cookie-secret:"   <<<"$sec_oidc" || { echo "FAIL: Secret missing cookie-secret key" >&2; exit 1; }
+if grep -q "kind: Secret" <<<"$sec_oidc"; then
+  echo "FAIL: #5416 — chart-managed per-region Secret rendered under the ssoBridgeSync default" >&2; exit 1
+fi
 route_oidc="$(show hubble-ui-httproute.yaml --set catalystOverlay.hubbleUI.auth=oidc)"
 b2="$(route_backend "$route_oidc")"
 if [ "$b2" != "hubble-ui-oauth2-proxy" ]; then
   echo "FAIL: auth=oidc HTTPRoute backend is '$b2' (expected hubble-ui-oauth2-proxy)" >&2; exit 1
 fi
-echo "  PASS (Deployment+Service+Secret render; route→proxy)"
+echo "  PASS (Deployment+Service render, no per-region Secret; route→proxy)"
+
+# ── Case 2b: #5416 — BOTH credentials resolve from the bridge-published Secret
+echo "[g117-hubble-oauth2-proxy] Case 2b: #5416 both creds come from hubble-ui-oauth2-proxy-oidc"
+env_src() {
+  # Secret name backing the given env var in the rendered Deployment.
+  awk -v want="$1" '
+    $0 ~ ("- name: " want) {hit=1; next}
+    hit && /name:/ { v=$0; sub(/.*name:[ \t]*/,"",v); gsub(/["[:space:]]/,"",v); print v; exit }
+  ' <<<"$dep_oidc"
+}
+for var in OAUTH2_PROXY_CLIENT_SECRET OAUTH2_PROXY_COOKIE_SECRET; do
+  src="$(env_src "$var")"
+  if [ "$src" != "hubble-ui-oauth2-proxy-oidc" ]; then
+    echo "FAIL: #5416 — ${var} sourced from '${src}' (expected hubble-ui-oauth2-proxy-oidc)" >&2; exit 1
+  fi
+done
+# The declared ExternalSecret must ask bp-sso-bridge for BOTH properties.
+cm_reg="$(show hubble-ui-sso-registration-configmap.yaml --set catalystOverlay.hubbleUI.auth=oidc)"
+grep -q '"property": "client_secret"' <<<"$cm_reg" || { echo "FAIL: declaration missing client_secret property" >&2; exit 1; }
+grep -q '"property": "cookie_secret"' <<<"$cm_reg" || { echo "FAIL: #5416 — declaration missing cookie_secret property" >&2; exit 1; }
+echo "  PASS (client-secret + cookie-secret both from the bridge-published Secret)"
 
 # ── Case 3: oauth2-proxy args wire the silent-SSO chain ───────────────────
 echo "[g117-hubble-oauth2-proxy] Case 3: oauth2-proxy args wire silent SSO"
@@ -88,13 +119,32 @@ assert_arg "--upstream=http://hubble-ui.kube-system.svc.cluster.local:80"
 assert_arg "kc_idp_hint=catalyst-pin"
 echo "  PASS (issuer + client + redirect + upstream + kc_idp_hint)"
 
-# ── Case 4: chartManagedSecret=false suppresses Secret, keeps Deployment ──
-echo "[g117-hubble-oauth2-proxy] Case 4: chartManagedSecret=false → BYO secret"
-sec_byo="$(show hubble-ui-oauth2-proxy-secret.yaml --set catalystOverlay.hubbleUI.auth=oidc --set catalystOverlay.hubbleUI.oauth2Proxy.chartManagedSecret=false)"
+# ── Case 4: ssoBridgeSync=false → chart-managed fallback still works ──────
+# The single-region / no-bridge path is unchanged by #5416: the chart mints
+# both keys and the Deployment reads both from `existingSecret`.
+echo "[g117-hubble-oauth2-proxy] Case 4: ssoBridgeSync=false → chart-managed fallback"
+nobridge=(--set catalystOverlay.hubbleUI.auth=oidc --set catalystOverlay.hubbleUI.oauth2Proxy.ssoBridgeSync.enabled=false)
+sec_nb="$(show hubble-ui-oauth2-proxy-secret.yaml "${nobridge[@]}")"
+grep -q "kind: Secret"   <<<"$sec_nb" || { echo "FAIL: chart-managed Secret missing with ssoBridgeSync=false" >&2; exit 1; }
+grep -q "client-secret:" <<<"$sec_nb" || { echo "FAIL: fallback Secret missing client-secret key" >&2; exit 1; }
+grep -q "cookie-secret:" <<<"$sec_nb" || { echo "FAIL: fallback Secret missing cookie-secret key" >&2; exit 1; }
+# Strip YAML comments — the template's #5416 rationale names the bridge Secret
+# in prose, which would otherwise match these greps.
+uncomment() { sed 's/[[:space:]]*#.*$//' <<<"$1"; }
+dep_nb="$(uncomment "$(show hubble-ui-oauth2-proxy-deployment.yaml "${nobridge[@]}")")"
+if grep -q "hubble-ui-oauth2-proxy-oidc" <<<"$dep_nb"; then
+  echo "FAIL: bridge Secret referenced with ssoBridgeSync=false" >&2; exit 1
+fi
+grep -q "hubble-ui-oauth2-proxy-sso"  <<<"$dep_nb" || { echo "FAIL: Deployment does not reference existingSecret" >&2; exit 1; }
+echo "  PASS (both keys chart-managed; Deployment references existingSecret)"
+
+# ── Case 4b: chartManagedSecret=false suppresses the fallback Secret ──────
+echo "[g117-hubble-oauth2-proxy] Case 4b: chartManagedSecret=false → BYO secret"
+sec_byo="$(show hubble-ui-oauth2-proxy-secret.yaml "${nobridge[@]}" --set catalystOverlay.hubbleUI.oauth2Proxy.chartManagedSecret=false)"
 if grep -q "kind: Secret" <<<"$sec_byo"; then
   echo "FAIL: chart-managed Secret rendered despite chartManagedSecret=false" >&2; exit 1
 fi
-dep_byo="$(show hubble-ui-oauth2-proxy-deployment.yaml --set catalystOverlay.hubbleUI.auth=oidc --set catalystOverlay.hubbleUI.oauth2Proxy.chartManagedSecret=false)"
+dep_byo="$(show hubble-ui-oauth2-proxy-deployment.yaml "${nobridge[@]}" --set catalystOverlay.hubbleUI.oauth2Proxy.chartManagedSecret=false)"
 grep -q "kind: Deployment" <<<"$dep_byo" || { echo "FAIL: Deployment missing under chartManagedSecret=false" >&2; exit 1; }
 grep -q "hubble-ui-oauth2-proxy-sso" <<<"$dep_byo" || { echo "FAIL: Deployment does not reference existingSecret" >&2; exit 1; }
 echo "  PASS (Secret suppressed; Deployment references existingSecret)"

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -451,6 +451,11 @@ catalystOverlay:
       # templates/hubble-ui-oauth2-proxy-secret.yaml). Set false to bring
       # your own Secret named by `existingSecret` (keys: client-secret,
       # cookie-secret) — e.g. an ExternalSecret synced by bp-sso-bridge.
+      # #5416: this only takes effect when ssoBridgeSync is OFF. With
+      # ssoBridgeSync on (the Catalyst default) BOTH keys come from the
+      # bp-sso-bridge-published Secret and the chart-managed one is not
+      # rendered at all — so hubble-ui no longer carries a second,
+      # Keycloak-unknown client secret that diverges per region.
       chartManagedSecret: true
       existingSecret: hubble-ui-oauth2-proxy-sso
       # #3374 — converge the client-secret with Keycloak. The chart-

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -462,7 +462,13 @@ catalystOverlay:
       # client and publishes the LIVE KC secret to OpenBao
       # `sso/sovereign/hubble-ui`, and (b) consumes it via ExternalSecret
       # `hubble-ui-oauth2-proxy-oidc` for OAUTH2_PROXY_CLIENT_SECRET.
-      # cookie-secret remains chart-managed (no KC counterpart).
+      # #5416: OAUTH2_PROXY_COOKIE_SECRET now comes down the same
+      # ExternalSecret (key `cookie-secret` <- bundle property
+      # `cookie_secret`, published by bp-sso-bridge 0.2.26+). Chart-managed
+      # meant lookup-or-generate, which mints a DIFFERENT value per region on
+      # a 2-region Sovereign, so the two proxies behind the one shared
+      # wildcard VIP rejected each other's session cookie. With
+      # ssoBridgeSync off both keys stay chart-managed.
       ssoBridgeSync:
         enabled: true
         externalSecretStoreName: vault-region1

--- a/platform/oidc-gate/README.md
+++ b/platform/oidc-gate/README.md
@@ -24,8 +24,7 @@ Per `instances[]` entry the chart renders:
 | Service `oidc-gate-<name>` | :80 → :4180 |
 | HTTPRoute `oidc-gate-<name>` | OWNS the app's public hostname on the Sovereign gateway. The gated app's own HTTPRoute must be disabled (two HTTPRoutes on one hostname is undefined routing) |
 | ConfigMap `…-sso-registration` | `sso.openova.io/app-registration` label — bp-sso-bridge 0.2.3+ mints/adopts the Keycloak client in the sovereign realm and publishes the LIVE client_secret to OpenBao `sso/sovereign/<clientId>` |
-| ExternalSecret `…-oidc` | materialises that client_secret for the proxy (the credential topology that fixed hubble-ui, #3374) |
-| Secret `…-cookie` | gate-local cookie secret (lookup-or-generate, `helm.sh/resource-policy: keep`) |
+| ExternalSecret `…-oidc` | materialises BOTH the `client-secret` and the `cookie-secret` for the proxy from the one `sso/<realm>/<clientId>` bundle (the credential topology that fixed hubble-ui, #3374, extended to the cookie secret in #5416) |
 
 ## Configuration knobs
 
@@ -47,8 +46,14 @@ non-excluded namespaces.
 
 ## Operational notes
 
-- Stateless; cookie secret survives uninstall (`keep`). Multi-region:
-  per-cluster instances, no cross-region state.
+- Stateless. Multi-region: per-cluster instances, but the session-cookie
+  encryption key is NOT per-cluster state — bp-sso-bridge (≥ 0.2.26) derives
+  one `cookie_secret` per Keycloak client into the OpenBao bundle and both
+  regions resolve it, so a session minted behind either region is accepted by
+  both. Before #5416 each region's Helm minted its own value and, with one
+  shared wildcard VIP fanning the hostname at both regions' envoys, each gate
+  rejected the peer's session cookie ("cookie signature not valid" / "CSRF
+  token mismatch") — guacamole's SPA never rendered as a result.
 - A gate instance serves 302s before bp-sso-bridge publishes the
   client bundle; the ExternalSecret converges eventually (same pattern
   as the Tier-1/2 SSO apps).

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -9,7 +9,7 @@ spec:
   # 0.1.6 (#4556): spaTokenSeed — TRUE zero-click for a token-paste SPA
   # (agenity/chepherd). 302s the bare root, post-SSO, to /app/?token=<sentinel>
   # so the SPA seeds localStorage and lands authenticated with NO paste.
-  version: 0.1.7
+  version: 0.1.8
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -125,7 +125,29 @@ name: bp-oidc-gate
 # every instance (fixes openova-flow/agenity too) and drops the cookie under 4 KB.
 # `groups` retained. Lockstep with the config-cli powerdns-admin seed (bp-keycloak
 # 1.5.6). Template-only change; render tests unaffected.
-version: 0.1.7
+#
+# 0.1.8 (#5416, 2026-07-27): the cookie secret STOPS being minted per region.
+# It was a `lookup`-or-`randAlphaNum 32` Secret rendered by this chart; on a
+# 2-region Sovereign each region's own Flux/Helm hits its own apiserver, so
+# the lookup misses in the second region and a DIFFERENT 32-char value is
+# generated there. One shared wildcard VIP fans each gated hostname at BOTH
+# regions' envoys, so requests round-robin and each gate rejects the peer
+# region's AES-encrypted session cookie — measured live on hw290 for all
+# three instances, region-a and region-b logging `cookie signature not
+# valid, removing session` + `CSRF token mismatch, potential attack` in the
+# same window. Static assets split ~50/50 between 200 and 302 (0 of 14
+# probes served on one established session), concurrent re-auth flows
+# collided on the single `_oidc_gate_<app>_csrf` cookie so callbacks 403'd,
+# and XHR got 401 rather than following the redirect — which is why
+# guacamole's SPA never rendered (UAT rows 35/115) while server-rendered
+# powerdns-admin merely looked unstyled and still PASSED its row.
+# FIX: carry it on the SAME seam the sibling client secret already used —
+# bp-sso-bridge 0.2.26 derives `cookie_secret` once per KC client into the
+# OpenBao `sso/<realm>/<clientId>` bundle (the idiom its `session_secret`
+# has used since #2807) and the per-instance ExternalSecret now pulls BOTH
+# properties into the one `oidc-gate-<name>-oidc` Secret. Requires
+# bp-sso-bridge >= 0.2.26.
+version: 0.1.8
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/instances.yaml
+++ b/platform/oidc-gate/chart/templates/instances.yaml
@@ -7,8 +7,10 @@ skip-provider-button, kc_idp_hint=catalyst-pin login-url for the silent
 zero-click chain. Credential topology mirrors the #3374 hubble-ui fix:
 the client secret is the LIVE Keycloak value published by bp-sso-bridge
 (AppRegistration ConfigMap -> OpenBao sso/<realm>/<clientId> ->
-ExternalSecret); the cookie secret is gate-local (lookup-or-generate +
-keep — no KC counterpart).
+ExternalSecret). Since #5416 the cookie secret rides that SAME carrier —
+bp-sso-bridge derives it once per KC client into the same OpenBao bundle,
+so both regions of a 2-region Sovereign resolve one value and a session
+minted behind either region is accepted by both.
 
 Loop-safety per the pdns-admin 0.1.11 lesson: the gate's own callback
 (/oauth2/callback) is SERVED by oauth2-proxy itself, never redirected;
@@ -49,27 +51,6 @@ internally. Empty → restore pre-#3844 public-discovery behavior.
 {{- $kcInternal := trimSuffix "/" ($root.Values.keycloakInternalURL | default "") }}
 {{- $internalRealm := "" }}
 {{- if $kcInternal }}{{- $internalRealm = printf "%s/realms/%s" $kcInternal $root.Values.realm }}{{- end }}
----
-# ── cookie secret (gate-local; lookup-or-generate, survives uninstall) ──
-{{- $existing := lookup "v1" "Secret" $root.Release.Namespace (printf "%s-cookie" $gateName) }}
-{{- $cookieSecret := "" }}
-{{- if $existing }}
-{{- $cookieSecret = index $existing.data "cookie-secret" | default "" | b64dec }}
-{{- end }}
-{{- if not $cookieSecret }}{{- $cookieSecret = randAlphaNum 32 }}{{- end }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ printf "%s-cookie" $gateName | quote }}
-  namespace: {{ $root.Release.Namespace }}
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    {{- include "bp-oidc-gate.labels" $root | nindent 4 }}
-    catalyst.openova.io/component: {{ $gateName | quote }}
-type: Opaque
-stringData:
-  cookie-secret: {{ $cookieSecret | quote }}
 ---
 # ── AppRegistration — bp-sso-bridge mints/adopts the KC client ─────────
 apiVersion: v1
@@ -142,7 +123,47 @@ data:
     }
 {{- if $root.Capabilities.APIVersions.Has "external-secrets.io/v1beta1" }}
 ---
-# ── client secret — the LIVE KC value via bp-sso-bridge + OpenBao ──────
+{{- /*
+#5416 — client secret AND cookie secret, both from the SAME OpenBao bundle.
+
+THE DEFECT THIS CLOSES (measured live on hw290, all three gates): the cookie
+secret used to be minted by a `lookup`-or-`randAlphaNum 32` Secret template
+right here in the chart. On a 2-region Sovereign each region runs its own
+Flux/Helm against its own apiserver, so the lookup misses in the second region
+and a DIFFERENT 32-char value is generated there. One shared wildcard VIP fans
+the single gated hostname at BOTH regions' envoys, so requests round-robin and
+each gate rejects the peer region's AES-encrypted session cookie:
+
+  [stored_session.go:94] Error loading cookied session: cookie signature not
+                         valid, removing session
+  [AuthFailure] Invalid authentication via OAuth2: CSRF token mismatch
+
+…logged on region-a AND region-b in the same window. Static assets split
+~50/50 between 200 and 302; concurrent re-auth flows collide on the single
+`_oidc_gate_<app>_csrf` cookie so callbacks 403; XHR gets 401 instead of
+following the redirect, so guacamole's SPA (~10 parallel requests, none able to
+survive a redirect) never mints its `POST /api/tokens` session and stays blank
+(UAT rows 35/115, 0/6 render attempts). powerdns-admin is server-rendered so
+each navigation silently re-runs the dance and eventually succeeds — it PASSES
+its row while carrying the identical defect, visible only as unstyled pages.
+
+WHY THIS CARRIER: the sibling `client-secret` was ALREADY identical in both
+regions, and not by luck — it is never generated per region at all. Keycloak
+(one DB shared by both regions, #4915) owns it; bp-sso-bridge reads the live
+value and publishes it to OpenBao `sso/<realm>/<clientId>`; this ExternalSecret
+delivers it into each region through the ClusterSecretStore. bp-sso-bridge
+0.2.26 adds `cookie_secret` to that same bundle — derived deterministically
+from the KC client secret, exactly the way the bundle's pre-existing
+`session_secret` (#2807, librechat's OPENID_SESSION_SECRET) already is — so the
+cookie secret now rides the proven carrier instead of being minted twice. No
+second synchronisation path is introduced.
+
+Both keys land in ONE Secret because ESO already owns this target; adding a key
+to it needs no ownership migration, whereas pointing an ExternalSecret at the
+old `-cookie` Secret could not take it over (it carries
+`helm.sh/resource-policy: keep`, so Helm leaves it behind un-owned).
+*/ -}}
+# ── client + cookie secret — LIVE KC values via bp-sso-bridge + OpenBao ─
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -163,11 +184,16 @@ spec:
       type: Opaque
       data:
         client-secret: "{{ "{{ .client_secret }}" }}"
+        cookie-secret: "{{ "{{ .cookie_secret }}" }}"
   data:
     - secretKey: client_secret
       remoteRef:
         key: {{ printf "sso/%s/%s" $root.Values.realm $cid | quote }}
         property: client_secret
+    - secretKey: cookie_secret
+      remoteRef:
+        key: {{ printf "sso/%s/%s" $root.Values.realm $cid | quote }}
+        property: cookie_secret
 {{- end }}
 ---
 # ── oauth2-proxy Deployment ────────────────────────────────────────────
@@ -247,10 +273,13 @@ spec:
                 secretKeyRef:
                   name: {{ printf "%s-oidc" $gateName | quote }}
                   key: client-secret
+            # #5416 — same Secret as the client secret. Region-consistent
+            # because bp-sso-bridge derives it once per KC client and both
+            # regions resolve it from the shared OpenBao bundle.
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ printf "%s-cookie" $gateName | quote }}
+                  name: {{ printf "%s-oidc" $gateName | quote }}
                   key: cookie-secret
           ports:
             - name: http

--- a/platform/oidc-gate/chart/values.yaml
+++ b/platform/oidc-gate/chart/values.yaml
@@ -7,10 +7,12 @@
 #     arg set from bp-cilium G117.5 #2744)
 #   - Service oidc-gate-<name> (:80 -> :4180)
 #   - HTTPRoute owning the instance hostname on the Sovereign gateway
-#   - cookie Secret oidc-gate-<name>-cookie (lookup-or-generate + keep)
 #   - AppRegistration ConfigMap (bp-sso-bridge mints/adopts the KC
 #     client + publishes the LIVE secret to OpenBao sso/sovereign/<cid>)
-#   - ExternalSecret oidc-gate-<name>-oidc (client-secret from OpenBao)
+#   - ExternalSecret oidc-gate-<name>-oidc (client-secret AND cookie-secret
+#     from the one OpenBao bundle — #5416; the cookie secret used to be a
+#     chart-minted per-region Secret, which diverged between regions and
+#     made each gate reject the peer region's session cookie)
 
 global:
   # Harbor proxy-cache prefix (kyverno harbor-proxy-pull glob `*/proxy-*/*`

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.25
+  version: 0.2.26
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,29 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.25
+version: 0.2.26
+# 0.2.26 (#5416, 2026-07-27): PUBLISH `cookie_secret` in the sso/<realm>/<cid>
+# bundle + accept a MULTI-key `externalSecret.json` declaration.
+# WHY: every oauth2-proxy gate chart (bp-oidc-gate's three instances,
+# bp-agenity's per-Org gate, bp-cilium's hubble-ui) minted its own cookie
+# secret with a `lookup`-or-`randAlphaNum 32` Helm template. On a 2-region
+# Sovereign each region runs its OWN Flux/Helm against its OWN apiserver, so
+# the lookup misses in the second region and a DIFFERENT value is generated
+# there — and because one shared wildcard VIP fans each gated hostname at BOTH
+# regions' envoys, requests round-robin and each gate rejects the peer region's
+# AES-encrypted session cookie ("cookie signature not valid, removing session"
+# + "CSRF token mismatch, potential attack", logged on region-a AND region-b in
+# the same window on hw290). The sibling client_secret never diverged because
+# it is not generated per region at all: Keycloak owns it (one DB shared by
+# both regions, #4915), this reconciler publishes it here, and each region's
+# ExternalSecret resolves the one bundle. So the cookie secret joins it —
+# derived deterministically from cid+realm+client_secret, the SAME idiom the
+# bundle's `session_secret` has used since #2807, truncated to 32 hex chars
+# because oauth2-proxy base64url-decodes the value and demands 16/24/32 bytes
+# (the full 64-char digest decodes to 48 and is rejected at startup).
+# The declaration gains an optional `data: [{secretKey, property}, ...]` array
+# so ONE declared ExternalSecret can carry both client-secret and cookie-secret
+# (bp-cilium's hubble-ui needs exactly that). Declarations using the original
+# single secretKey/property fields render byte-identically.
 # 0.2.24 (#4458, 2026-06-26): EGRESS half of the #4448/#4449 sso-bridge↔openbao
 # netpol gap. THE CILIUM TRAP: the `sso-bridge-reconciler-apiserver`
 # CiliumNetworkPolicy attaches an egress rule to the reconciler endpoint, which

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -949,17 +949,53 @@ data:
       # deterministically from cid+realm+client_secret so it is stable
       # across reconcile ticks AND distinct from client_secret. Other
       # Tier-3 apps that don't reference this key just ignore it.
-      local issuer session_secret
+      #
+      # #5416 (2026-07-27) — `cookie_secret`, the SAME derivation idiom, for
+      # oauth2-proxy's OAUTH2_PROXY_COOKIE_SECRET (bp-oidc-gate's three gates,
+      # bp-agenity's per-Org gate, bp-cilium's hubble-ui gate).
+      #
+      # WHY IT BELONGS IN THIS BUNDLE: every gate chart used to mint its own
+      # cookie secret with a `lookup`-or-`randAlphaNum 32` Helm template. On a
+      # 2-region Sovereign each region runs its OWN Flux/Helm against its OWN
+      # apiserver, so the lookup misses in the second region and a DIFFERENT
+      # 32-char value is generated there. Both regions serve the one hostname
+      # behind one shared wildcard VIP, so requests round-robin and each gate
+      # rejects the peer region's AES-encrypted session cookie — measured live
+      # on hw290 for all three bp-oidc-gate instances (`cookie signature not
+      # valid, removing session` + `CSRF token mismatch, potential attack`, on
+      # BOTH regions in the same window; guacamole's SPA never rendered because
+      # its ~10 parallel XHRs cannot survive the resulting 302/401 storm).
+      #
+      # The sibling `client_secret` was ALREADY region-consistent, and this is
+      # exactly why: it is not generated per region at all — it is read from
+      # Keycloak (whose DB is shared across both regions, #4915) and published
+      # HERE, then delivered to each region by an ExternalSecret resolving the
+      # same `sso/<realm>/<cid>` bundle through the ClusterSecretStore. Riding
+      # the same carrier is what makes the cookie secret consistent; deriving
+      # it from `${secret}` is what keeps it secret-grade rather than guessable
+      # from public inputs (fqdn/realm/clientId are all public).
+      #
+      # LENGTH: oauth2-proxy's secretBytes() base64url-decodes the value first
+      # and requires 16/24/32 bytes. 32 hex chars decode cleanly to 24 bytes
+      # (AES-192) on every tick, in every region — so truncate the digest to 32
+      # rather than passing the full 64-char hex, which decodes to 48 bytes and
+      # is REJECTED at startup ("cookie_secret must be 16, 24, or 32 bytes").
+      # Distinct from session_secret (different domain-separation tag) so a
+      # consumer of one never gains the other.
+      local issuer session_secret cookie_secret
       issuer="https://auth.$(sovereign_fqdn)/realms/${realm}"
       session_secret="$(printf '%s|session|%s|%s' "${cid}" "${realm}" "${secret}" | sha256sum | awk '{print $1}')"
+      cookie_secret="$(printf '%s|cookie|%s|%s' "${cid}" "${realm}" "${secret}" | sha256sum | awk '{print substr($1,1,32)}')"
       local bundle
       bundle="$(jq -nc \
         --arg cid "${cid}" \
         --arg secret "${secret}" \
         --arg session "${session_secret}" \
+        --arg cookie "${cookie_secret}" \
         --arg issuer "${issuer}" \
         --arg realm "${realm}" \
         '{client_id:$cid, client_secret:$secret, session_secret:$session,
+          cookie_secret:$cookie,
           issuer_url:$issuer, realm:$realm,
           authorize_url:($issuer+"/protocol/openid-connect/auth"),
           token_url:($issuer+"/protocol/openid-connect/token"),
@@ -984,27 +1020,46 @@ data:
       # verbatim here, every tick (idempotent). Consumers that omit the
       # field (the 6 Tier-3 apps + per-Org charts) are unaffected.
       #
-      # Declared shape (all fields required when the block is present):
+      # Declared shape — single-key (the original #3374 form):
       #   { "name": "<es+secret name>", "namespace": "<target ns>",
       #     "secretKey": "<key in the produced Secret>",
       #     "property": "<property in the OpenBao bundle, e.g. client_secret>" }
+      #
+      # #5416 (2026-07-27) — MULTI-key form, for a consumer that needs two
+      # bundle properties in ONE Secret (bp-cilium's hubble-ui oauth2-proxy
+      # wants `client-secret` <- client_secret AND `cookie-secret` <-
+      # cookie_secret; the cookie secret must come down the SAME carrier or it
+      # diverges per region, the #5416 defect):
+      #   { "name": ..., "namespace": ...,
+      #     "data": [ {"secretKey": "client-secret", "property": "client_secret"},
+      #               {"secretKey": "cookie-secret", "property": "cookie_secret"} ] }
+      # `data` wins when present; otherwise the single-key fields are used, so
+      # every pre-#5416 declaration renders a byte-identical ExternalSecret.
+      #
       # The remoteRef key is ALWAYS the canonical sso/<realm>/<cid> this
       # function just wrote — callers never override the storage path.
       local es_decl
       es_decl="$(printf '%s' "${cm_json}" | jq -r '.data["externalSecret.json"] // empty')"
       if [ -n "${es_decl}" ]; then
-        local es_name es_ns es_key es_prop
+        local es_name es_ns es_key es_prop es_pairs es_data_yaml es_summary
         es_name="$(printf '%s' "${es_decl}" | jq -r '.name // empty')"
         es_ns="$(printf '%s' "${es_decl}" | jq -r '.namespace // empty')"
-        es_key="$(printf '%s' "${es_decl}" | jq -r '.secretKey // empty')"
-        es_prop="$(printf '%s' "${es_decl}" | jq -r '.property // "client_secret"')"
-        if [ -z "${es_name}" ] || [ -z "${es_ns}" ] || [ -z "${es_key}" ]; then
+        # Normalise both declared shapes to a TSV stream of `<secretKey>\t<property>`.
+        es_pairs="$(printf '%s' "${es_decl}" | jq -r 'def entries: if (.data | type) == "array" then .data else [{secretKey: .secretKey, property: .property}] end; entries[] | select((.secretKey // "") != "") | [.secretKey, (.property // "client_secret")] | @tsv' 2>/dev/null || true)"
+        es_data_yaml=""
+        es_summary=""
+        while IFS=$'\t' read -r es_key es_prop; do
+          [ -z "${es_key}" ] && continue
+          es_data_yaml="${es_data_yaml}$(printf '    - secretKey: %s\n      remoteRef:\n        key: sso/%s/%s\n        property: %s' "${es_key}" "${realm}" "${cid}" "${es_prop}")"$'\n'
+          es_summary="${es_summary}${es_key}<-${es_prop} "
+        done <<< "${es_pairs}"
+        if [ -z "${es_name}" ] || [ -z "${es_ns}" ] || [ -z "${es_data_yaml}" ]; then
           warn "app-registration[${cid}]: externalSecret.json present but missing name/namespace/secretKey; skipping ES apply"
         else
           # Render via printf (consistent leading-space indent — the same
           # convention emit_external_secret uses; column-0 heredoc body
           # lines silently terminate a YAML literal block).
-          if printf '%s\n' \
+          if { printf '%s\n' \
             "apiVersion: external-secrets.io/v1beta1" \
             "kind: ExternalSecret" \
             "metadata:" \
@@ -1022,13 +1077,9 @@ data:
             "  target:" \
             "    name: ${es_name}" \
             "    creationPolicy: Owner" \
-            "  data:" \
-            "    - secretKey: ${es_key}" \
-            "      remoteRef:" \
-            "        key: sso/${realm}/${cid}" \
-            "        property: ${es_prop}" \
+            "  data:"; printf '%s' "${es_data_yaml}"; } \
             | kubectl --request-timeout=15s apply -f - >/dev/null 2>&1; then
-            log "app-registration[${cid}]: applied ExternalSecret ${es_ns}/${es_name} (key=${es_key} <- sso/${realm}/${cid}#${es_prop})"
+            log "app-registration[${cid}]: applied ExternalSecret ${es_ns}/${es_name} (${es_summary}from sso/${realm}/${cid})"
             # #3374-cleanup-race (2026-06-19): record this clientId in the
             # app-registration keep-list so the main loop's cleanup_orphans
             # does NOT treat the ES we just applied (labelled managed=true,

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -14,7 +14,7 @@ spec:
   # 0.5.17 (#4604): chart adds a default-on external-HTTPS egress CNP +
   # seeds the openova MCP into ~/.claude.json for a standalone claude (durable
   # Pillar-4 North-Star wiring). Lockstep with products/agenity/chart.
-  version: 0.5.20
+  version: 0.5.21
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -188,7 +188,17 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.20
+version: 0.5.21
+# 0.5.21 (#5416): the per-Org gate's cookie secret stops being minted per
+# region. templates/oidc-gate.yaml rendered it with `lookup`-or-`randAlphaNum
+# 32`; on a 2-region Sovereign the second region misses the lookup and mints a
+# DIFFERENT value, and the Org hostname is fanned at BOTH regions' envoys by
+# one shared wildcard VIP — so each gate rejects the peer region's
+# AES-encrypted session cookie. It now rides the SAME carrier as the sibling
+# client secret (bp-sso-bridge 0.2.26 derives `cookie_secret` into the OpenBao
+# sso/<realm>/<clientId> bundle; the gate's ExternalSecret pulls both
+# properties into one Secret). Kept byte-aligned with platform/oidc-gate 0.1.8.
+# Template-only; appVersion (image) UNCHANGED. Requires bp-sso-bridge >= 0.2.26.
 # 0.5.19 (#4624): the StatefulSet SELF-WIRES the OPENOVA_MCP_BEARER + RS256
 # verify-pubkey projection from the enabled per-Org mcpBearer ExternalSecret
 # (agenity.mcpBearerSecretName / agenity.mcpPubkeySecretName helpers) — an

--- a/products/agenity/chart/templates/oidc-gate.yaml
+++ b/products/agenity/chart/templates/oidc-gate.yaml
@@ -12,8 +12,9 @@ so a fresh agenity Org / a re-prov got NO gate (the host served the dashboard
 UN-gated). Templating the gate AS PART OF the bp-agenity chart makes the gate
 arrive WITH the agenity install — chart-managed, drift-detected, zero hand-
 creation. The resource set is byte-equivalent to a bp-oidc-gate instances[]
-entry (#3374): cookie Secret + AppRegistration ConfigMap (bp-sso-bridge mints
-the KC client) + ExternalSecret (client secret from OpenBao) + oauth2-proxy
+entry (#3374): AppRegistration ConfigMap (bp-sso-bridge mints the KC client) +
+ExternalSecret (client secret AND cookie secret from OpenBao — #5416) +
+oauth2-proxy
 Deployment (the WALKED hubble-ui arg set, #2744) + Service + HTTPRoute that
 OWNS the agenity hostname with the spaTokenSeed redirect + a CNP admitting the
 gateway entity to the gate pod.
@@ -43,27 +44,6 @@ for redeem/jwks/userinfo, keeping the browser legs public.
 {{- $kcInternal := trimSuffix "/" ($g.keycloakInternalURL | default "") }}
 {{- $internalRealm := "" }}
 {{- if $kcInternal }}{{- $internalRealm = printf "%s/realms/%s" $kcInternal $g.realm }}{{- end }}
----
-# ── cookie secret (gate-local; lookup-or-generate, survives uninstall) ──
-{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-cookie" $gateName) }}
-{{- $cookieSecret := "" }}
-{{- if $existing }}
-{{- $cookieSecret = index $existing.data "cookie-secret" | default "" | b64dec }}
-{{- end }}
-{{- if not $cookieSecret }}{{- $cookieSecret = randAlphaNum 32 }}{{- end }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ printf "%s-cookie" $gateName | quote }}
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    {{- include "agenity.labels" . | nindent 4 }}
-    catalyst.openova.io/component: {{ $gateName | quote }}
-type: Opaque
-stringData:
-  cookie-secret: {{ $cookieSecret | quote }}
 ---
 # ── AppRegistration — bp-sso-bridge mints/adopts the KC client ─────────
 apiVersion: v1
@@ -109,7 +89,20 @@ data:
     }
 {{- if .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" }}
 ---
-# ── client secret — the LIVE KC value via bp-sso-bridge + OpenBao ──────
+{{- /*
+#5416 — client secret AND cookie secret from the SAME OpenBao bundle. The
+cookie secret used to be a chart-minted `lookup`-or-`randAlphaNum 32` Secret
+right here; on a 2-region Sovereign each region's own Flux/Helm missed the
+lookup and generated its OWN value, so the two gates behind the one shared
+wildcard VIP rejected each other's AES-encrypted session cookie ("cookie
+signature not valid" / "CSRF token mismatch"). The sibling client secret never
+had that problem because it is not generated per region at all — Keycloak owns
+it and bp-sso-bridge publishes it to `sso/<realm>/<clientId>`. bp-sso-bridge
+0.2.26 puts a deterministically-derived `cookie_secret` in that same bundle
+(the idiom its `session_secret` already used, #2807), so the cookie secret now
+rides the proven carrier. Kept byte-aligned with platform/oidc-gate.
+*/ -}}
+# ── client + cookie secret — LIVE KC values via bp-sso-bridge + OpenBao ─
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -130,11 +123,16 @@ spec:
       type: Opaque
       data:
         client-secret: "{{ "{{ .client_secret }}" }}"
+        cookie-secret: "{{ "{{ .cookie_secret }}" }}"
   data:
     - secretKey: client_secret
       remoteRef:
         key: {{ printf "sso/%s/%s" $g.realm $cid | quote }}
         property: client_secret
+    - secretKey: cookie_secret
+      remoteRef:
+        key: {{ printf "sso/%s/%s" $g.realm $cid | quote }}
+        property: cookie_secret
 {{- end }}
 ---
 # ── oauth2-proxy Deployment ────────────────────────────────────────────
@@ -208,10 +206,11 @@ spec:
                 secretKeyRef:
                   name: {{ printf "%s-oidc" $gateName | quote }}
                   key: client-secret
+            # #5416 — same Secret as the client secret; region-consistent.
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ printf "%s-cookie" $gateName | quote }}
+                  name: {{ printf "%s-oidc" $gateName | quote }}
                   key: cookie-secret
           ports:
             - name: http

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3817,7 +3817,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.17"
+  version: "1.4.18"
   visibility: unlisted
   card:
     title: "Cilium"
@@ -3834,7 +3834,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cilium
-    version: "1.4.17"
+    version: "1.4.18"
   topology:
     supported:
       - singleton
@@ -5173,7 +5173,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.25"
+  version: "0.2.26"
   visibility: unlisted
   card:
     title: "SSO Bridge"
@@ -5190,7 +5190,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-sso-bridge
-    version: "0.2.25"
+    version: "0.2.26"
   topology:
     supported:
       - active-passive
@@ -5945,7 +5945,7 @@ spec:
   # projection from the enabled per-Org mcpBearer ExternalSecret (no door has to
   # hand-couple bearerSecret.name) so a fresh Org's agenity MCP tools/list
   # surfaces create_application. Lockstep with products/agenity/chart.
-  version: "0.5.20"
+  version: "0.5.21"
   visibility: listed
   card:
     title: "Agenity"
@@ -5975,7 +5975,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.20
+    version: 0.5.21
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5416

## The defect

Every `bp-oidc-gate` instance minted its oauth2-proxy cookie secret with a `lookup`-or-`randAlphaNum 32` Helm template. On a 2-region Sovereign each region runs its own Flux/Helm against its own apiserver, so the lookup misses in the second region and a **different** 32-char value is generated there. One shared wildcard VIP fans each gated hostname at **both** regions' envoys, so requests round-robin and each gate rejects the peer region's AES-encrypted session cookie.

Measured live on hw290, region-a and region-b logging in the same window:

```
[stored_session.go:94] Error loading cookied session: cookie signature not valid, removing session
[AuthFailure] Invalid authentication via OAuth2: CSRF token mismatch, potential attack
```

Everything else follows from that one cause: static assets split ~50/50 between 200 and 302 (0 of 14 probes served on one established session); concurrent re-auth flows collide on the single `_oidc_gate_<app>_csrf` cookie so callbacks 403; XHR receives 401 rather than following the redirect. Guacamole fails visibly because its SPA fires ~10 parallel requests that cannot survive a redirect, so `POST /api/tokens` never mints a session. powerdns-admin is server-rendered, so each navigation silently re-runs the dance and succeeds — it *passes* its UAT row while carrying the same defect, visible only as unstyled pages.

## The mechanism reused, and why it is the right carrier

**The sibling `client-secret` was already identical across regions — and not by luck. It is never generated per region at all.**

Keycloak owns it (both regions share one Keycloak DB, #4915). `bp-sso-bridge`'s AppRegistration watcher reads the live value and publishes it to OpenBao at `sso/<realm>/<clientId>`; each region's `ExternalSecret` resolves that one bundle through the `vault-region1` `ClusterSecretStore`. A value only stays consistent here by being *anchored in a shared store and delivered per region*, never by being generated twice.

So the cookie secret now rides that exact carrier. `bp-sso-bridge` publishes a `cookie_secret` in the same bundle, derived deterministically from `cid|cookie|realm|client_secret` — **the idiom the bundle's pre-existing `session_secret` has used since #2807** (librechat's `OPENID_SESSION_SECRET`). No second synchronisation path is introduced; one property is added to a bundle that three consumers already read.

Two details worth stating:

- **Why derived rather than random-once**: derivation from `client_secret` keeps it secret-grade. Deriving from `sovereignFQDN`/`realm`/`clientId` would make it publicly guessable, and a random-once value would need its own storage-and-race story.
- **Why truncated to 32 hex chars**: oauth2-proxy's `secretBytes()` base64url-decodes the value first and requires 16/24/32 bytes. 32 hex chars decode cleanly to 24 (AES-192) on every tick in every region; the full 64-char digest decodes to 48 and is rejected at startup with `cookie_secret must be 16, 24, or 32 bytes`.

Both keys land in the **existing** `…-oidc` Secret because ESO already owns it — adding a key needs no ownership migration. Pointing an ExternalSecret at the old `…-cookie` Secret could not take it over: it carries `helm.sh/resource-policy: keep`, so Helm leaves it behind un-owned and ESO would refuse it.

## The hubble exception — a second, independent fault

A walk measured hubble's **client** secret as also split, unlike the other three. The cause is structural and visible in the tree: **hubble-ui is the only gate carrying two client secrets.**

| | source | region-consistent? | read by the Pod? |
|---|---|---|---|
| `hubble-ui-oauth2-proxy-oidc` | bp-sso-bridge → OpenBao → ESO | yes | yes (ssoBridgeSync on = default) |
| `hubble-ui-oauth2-proxy-sso` | chart `lookup`-or-generate | **no, by construction** | no |

The three `bp-oidc-gate` gates render no chart-minted client secret at all, so they have exactly one each. hubble's second copy is a pre-#3374 leftover: #3374 moved *consumption* onto the bridge carrier but left the *generator* in place. That is precisely why a sweep of "each gate's client secret" finds hubble's split and the other three consistent.

This PR closes it at the generation seam: the chart-managed Secret is now gated on `ssoBridgeSync` being **off**, so under the Catalyst default there is exactly one client secret and one cookie secret per gate, both bridge-published. Leaving it in place was not cosmetic — it is a secret Keycloak never learned, so flipping `ssoBridgeSync` off silently reinstates the hw130 `unauthorized_client` callback failure.

**One check is still owed on the walk**, because it changes what remains: read which Secret each region's hubble Pod actually resolves (`kubectl -n kube-system get deploy hubble-ui-oauth2-proxy -o jsonpath` over the two env `secretKeyRef` names, per region). If the split value came from `…-sso`, it was never consumed and rows 36/39 are cookie-secret faults like 35/115 — a 403 on `/oauth2/callback` is the textbook CSRF-cookie failure, and row 39's 401s on `/api/control-stream` + `/api/service-map-stream` are the `--api-route` 401 behaviour (#4507) firing because the serving region rejects the session cookie. If instead the **bridge-published** `…-oidc` value differs across regions, then hubble has a genuinely separate fault in bundle delivery and needs a follow-up — though note that all four gates share one delivery mechanism, and three match, which argues against that branch.

## Scope — the class, not the instance

Four consumers of `OAUTH2_PROXY_COOKIE_SECRET` exist; all four are covered.

| Chart | Change |
|---|---|
| `bp-sso-bridge` 0.2.26 | publishes `cookie_secret`; accepts a multi-key `data:` declaration |
| `bp-oidc-gate` 0.1.8 | guacamole + openova-flow + powerdns-admin — per-region Secret dropped |
| `bp-agenity` 0.5.21 | the per-Org gate (same template lineage) |
| `bp-cilium` 1.4.18 | hubble-ui — cookie secret moved, redundant client secret retired |

`grep` confirms no per-region cookie-secret generator remains on the consumed path.

## Verification

- Negative proof, `bp-oidc-gate`: rendering the `origin/main` template twice (each render = one region's Helm run with an empty lookup) yields cookie secrets hashing `ef148c4f…` and `b9c7dbee…` — divergence reproduced. On this branch the chart renders **zero** `cookie-secret:` literals and sources it from `oidc-gate-<app>-oidc`.
- Derivation: deterministic across runs, distinct from `session_secret`, and base64url-decodes to a valid 24-byte AES key.
- Declaration compatibility: a pre-#5416 single-key `externalSecret.json` renders a byte-identical ExternalSecret; the multi-key form adds the second entry; a malformed declaration is skipped as before.
- `bash -n` on the **rendered** `reconcile.sh` (extracted from the rendered ConfigMap), plus a harness exercising all four declaration shapes.
- Green: `tests/e2e/bootstrap-kit` go test · `check-no-nodeports.sh` · `check-catalog-seed-lockstep.sh` · `check-bootstrap-kit-pin-sync.sh` (only the pre-existing `bp-catalyst-platform` 1.4.1234/1.4.1233 drift, present on `origin/main`) · `helm lint` ×4 · all `bp-oidc-gate`, `bp-cilium` and `bp-keycloak` chart render tests.
- `g117-hubble-oauth2-proxy-enforcement.sh` updated to the new contract, with a #5416 regression assertion that both env vars resolve from the bridge-published Secret and the declaration requests both properties.

## Runtime proof owed

Not obtainable until this lands. On the next walk:

1. `cookie-secret` hashes **match** across regions for all four gates (and `client-secret` too, hubble included).
2. Guacamole's connections list renders — rows 35/115.
3. Hubble: `/oauth2/callback` stops 403ing (row 36) and `/api/control-stream` + `/api/service-map-stream` return 200 with namespaces selectable (row 39).
4. Repeated static-asset fetches on one established session return 200 consistently rather than ~50/50 200/302.

## Rollout note

`bp-cilium` 1.4.18 requires `bp-sso-bridge` 0.2.26 for the `cookie-secret` key to appear. Both pins bump in this commit; between the two HelmRelease upgrades the hubble Pod waits in `CreateContainerConfigError`, then starts once the bridge's next tick applies the two-key ExternalSecret. An older bridge still applies the one-key form, so nothing else regresses. Existing `…-cookie` and `…-sso` Secrets carry `helm.sh/resource-policy: keep` and stay behind unconsumed; reaping them is housekeeping, not correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
