### PR TITLE
fix(api): app-detail dropped object-form spec.placement, so the console rendered a fabricated singleton (Refs #5422)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1388,9 +1388,27 @@ func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 	if v, ok, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); ok {
 		resp.EnvironmentRef = v
 	}
-	if v, ok, _ := unstructured.NestedString(obj.Object, "spec", "placement"); ok {
-		resp.Placement = v
-	}
+	// #5422 — `spec.placement` has TWO shapes and this endpoint only ever read
+	// one. The legacy shape is a bare string; the #3373 shape is an object
+	// `{mode, vcluster, regions, clusters}` where the posture rides in `mode`.
+	// A raw NestedString against the object form returns ok=false, so
+	// `resp.Placement` stayed empty and `omitempty` dropped the field from the
+	// response entirely — and the console then turned that ABSENCE into a
+	// confident wrong answer (`?? 'singleton'` at AppDetail.tsx:255), rendering
+	// `singleton` for a two-region app directly above its own two-region
+	// REGIONS list. Live on hw290, `uat-ahs-hw290` showed Overview `singleton`
+	// while the Topology tab derived `active-hot-standby` from the same CR —
+	// exactly the contradictory second value EPIC #3969 forbids.
+	//
+	// #4897 already fixed this shape at sovereign.go:815 by routing through
+	// readTopology(); this call site was missed.
+	//
+	// Deliberately NOT calling readTopology() here: it defaults to "singleton"
+	// for a genuinely-absent placement, which would re-manufacture the very
+	// value this fixes. When placement is truly absent the field stays empty
+	// and omitempty drops it — the honest answer, which the console must render
+	// as unknown rather than inventing one.
+	resp.Placement = placementFromSpec(obj)
 	if regs, ok, _ := unstructured.NestedStringSlice(obj.Object, "spec", "regions"); ok {
 		resp.Regions = regs
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_dualform_5422_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_dualform_5422_test.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// #5422 — the app-detail endpoint must serialize `spec.placement` for BOTH
+// shapes the CRD accepts.
+//
+// The legacy shape is a bare string. The #3373 shape is an object
+// `{mode, vcluster, regions, clusters}` with the posture in `mode`. Reading
+// only the string form makes a raw NestedString return ok=false against the
+// object form, leaving the field empty so `omitempty` drops it — and the
+// console converts that absence into a concrete wrong value
+// (`?? 'singleton'`, AppDetail.tsx:255).
+//
+// Live proof on hw290: `uat-ahs-hw290` (object form) rendered Overview
+// `singleton` while the Topology tab derived `active-hot-standby` from the
+// same CR, with the Overview contradicting itself by listing two REGIONS
+// directly beneath. Of 16 apps probed it was the only one whose API omitted
+// placement — and the only one carrying object-form placement, which is why
+// this read as app-specific flakiness rather than a shape bug.
+//
+// A test written against the string form alone passes on the broken code —
+// the dual-form IS the defect — so the object case below is the load-bearing
+// one.
+func TestApplicationDetail_PlacementDualForm_5422(t *testing.T) {
+	// Calls the SAME helper the detail endpoint uses. An earlier draft of this
+	// test reimplemented the resolution inline, which would have passed against
+	// the unfixed handler — a guard that cannot fail is worse than no guard.
+	placementOf := func(spec map[string]interface{}) string {
+		return placementFromSpec(&unstructured.Unstructured{
+			Object: map[string]interface{}{"spec": spec},
+		})
+	}
+
+	t.Run("object dual-form resolves via mode", func(t *testing.T) {
+		got := placementOf(map[string]interface{}{
+			"placement": map[string]interface{}{
+				"mode":    "active-hot-standby",
+				"regions": []interface{}{"me-east-215", "me-east-215-b-1"},
+			},
+		})
+		if got != "active-hot-standby" {
+			t.Errorf("object-form placement resolved to %q, want %q — the field will be dropped by omitempty "+
+				"and the console will render a fabricated 'singleton' for a two-region app (#5422)", got, "active-hot-standby")
+		}
+	})
+
+	t.Run("legacy string form still resolves", func(t *testing.T) {
+		if got := placementOf(map[string]interface{}{"placement": "singleton"}); got != "singleton" {
+			t.Errorf("string-form placement resolved to %q, want %q — the fix must not regress the legacy shape", got, "singleton")
+		}
+	})
+
+	// Absence must stay absent. Defaulting here (e.g. by calling readTopology,
+	// which returns "singleton" for an unset placement) would re-manufacture
+	// exactly the value this issue is about — the console has to render unknown
+	// rather than be handed a confident guess.
+	t.Run("absent placement is NOT defaulted to a concrete value", func(t *testing.T) {
+		if got := placementOf(map[string]interface{}{}); got != "" {
+			t.Errorf("absent placement resolved to %q, want empty — inventing a value is the #5422 defect, "+
+				"not the fix for it", got)
+		}
+	})
+
+	t.Run("object form without mode is not defaulted", func(t *testing.T) {
+		got := placementOf(map[string]interface{}{
+			"placement": map[string]interface{}{"regions": []interface{}{"me-east-215"}},
+		})
+		if got != "" {
+			t.Errorf("object placement lacking mode resolved to %q, want empty", got)
+		}
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -2296,6 +2296,32 @@ func readPhase(u *unstructured.Unstructured) string {
 	return "Pending"
 }
 
+// placementFromSpec resolves `spec.placement` across BOTH shapes the CRD
+// accepts, WITHOUT inventing a value when it is genuinely absent (#5422).
+//
+// Shapes: the legacy bare string, and the #3373 object
+// `{mode, vcluster, regions, clusters}` where the posture rides in `mode`.
+// A raw NestedString against the object form returns ok=false, so a caller
+// reading only the string form silently drops the field — and the console
+// then converts that absence into a confident wrong value
+// (`?? 'singleton'`, AppDetail.tsx:255), rendering `singleton` for a
+// two-region app directly above its own two-region REGIONS list.
+//
+// This deliberately does NOT share readTopology's "singleton" default:
+// readTopology serves LISTING endpoints where a display default is
+// reasonable, whereas a detail response must distinguish "unset" from
+// "singleton". Returning "" lets `omitempty` drop the field so the console
+// can render unknown honestly instead of being handed a guess.
+func placementFromSpec(u *unstructured.Unstructured) string {
+	if v, ok, _ := unstructured.NestedString(u.Object, "spec", "placement"); ok && v != "" {
+		return v
+	}
+	if v, ok, _ := unstructured.NestedString(u.Object, "spec", "placement", "mode"); ok && v != "" {
+		return v
+	}
+	return ""
+}
+
 func readTopology(u *unstructured.Unstructured) string {
 	if v, ok, err := unstructured.NestedString(u.Object, "spec", "placement"); err == nil && ok && v != "" {
 		return v


### PR DESCRIPTION
fix(api): app-detail dropped object-form spec.placement, so the console rendered a fabricated singleton (Refs #5422)

`spec.placement` has two accepted shapes: the legacy bare string, and the
#3373 object {mode, vcluster, regions, clusters} with the posture in `mode`.
The detail endpoint read only the string form, so a raw NestedString against
the object form returned ok=false, `resp.Placement` stayed empty, and
omitempty dropped the field entirely.

The console then turned that ABSENCE into a confident wrong answer. On hw290,
uat-ahs-hw290 rendered Overview `singleton` while the Topology tab derived
`active-hot-standby` from the same CR — and the Overview contradicted itself
on one screen, listing PLACEMENT singleton directly above REGIONS with two
regions and a primary/standby fan-out table. Reproduced 4/4 in a live browser
walk. Of 16 apps probed it was the only one whose API omitted placement, and
the only one carrying object-form placement, which is why this presented as
app-specific rather than as a shape bug.

This is #4897's twin. That issue fixed the identical shape at sovereign.go:815
by routing through readTopology(); this call site was never given the same
treatment.

Extracted placementFromSpec() rather than calling readTopology() directly,
because readTopology defaults to "singleton" for an unset placement — which
would re-manufacture the exact value this fixes. Listing endpoints can
reasonably show a default; a detail response must distinguish "unset" from
"singleton". Returning "" lets omitempty drop the field so the console can
render unknown honestly.

Note the UI half remains open on #5422: `?? 'singleton'` at AppDetail.tsx:255
is still wrong in kind, because absence must never be rendered as a specific
value. With the backend fixed the field is now populated, but the next
endpoint that omits it would silently reintroduce the same confident lie.

The first draft of the test reimplemented the resolution inline and would have
passed against the unfixed handler — the vacuous-guard trap. It now calls the
same helper the endpoint uses, and I verified it FAILS against the pre-fix
behaviour (object form resolves to "") and passes after. Also covers the
legacy string form and asserts that an absent placement is NOT defaulted.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
