### PR TITLE
fix(catalyst-api): gate the legacy org-tenants overlay writer on TENANT_GITOPS_PER_ORG (Refs #5425)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -89,9 +89,91 @@ type OrganizationChartVersions struct {
 	Agenity string
 }
 
+// perOrgGitopsEnabled reports whether this Sovereign materialises an
+// Organization through the per-Org GitOps tree (the `<slug>/catalyst-tenant`
+// repo the CRD org-controller bootstraps, #4384/#4827) instead of the legacy
+// SHARED `clusters/<fqdn>/org-tenants/<id>/` overlay this file writes.
+//
+// #5425 — the two pipelines coexisted and only ONE of them was gated. Every
+// global-tree write in core/services/provisioning/gitops/ sits behind
+// `!PerOrgGitops`, but this second, older base-create leg never received the
+// switch: WriteTenantOverlay ran unconditionally on every
+// POST /api/v1/organizations. On a per-Org-GitOps Sovereign that leaves a
+// full 9-resource overlay on the shared path that NOTHING owns once the Org
+// is gone — deleting the namespace does not delete the git source, so Flux
+// restores the HelmReleases forever. Measured on hw290: two Organizations'
+// leftovers = 13 not-Ready items (10 HelmReleases + 3 workloads) holding the
+// sovereignty-cutover pre-flight closed, and 6395m of CPU requests on a
+// region already at 99-100% of allocatable.
+//
+// It reads the SAME env key as the provisioning service
+// (core/services/provisioning/main.go, the `perOrgGitops` local) so there is
+// one switch name across both pipelines, and NOT a second parallel knob:
+//
+//	TENANT_GITOPS_PER_ORG=true  → per-Org GitOps owns the Org; this leg is a
+//	                              no-op and the legacy tree stays empty.
+//	TENANT_GITOPS_PER_ORG=false → this leg writes the overlay (legacy mode).
+//	unset (the default)         → this leg writes the overlay.
+//
+// ── Why the DEFAULT deliberately differs from provisioning's ─────────
+//
+// provisioning defaults the switch ON whenever SOVEREIGN_FQDN is set. This
+// leg MUST NOT: per-Org GitOps does not yet emit an equivalent for four of
+// the nine resources this overlay carries, and this overlay is their ONLY
+// producer in the entire repo (`chart: bp-agenity`, `chart: bp-keycloak` and
+// `chart: bp-wordpress-tenant` each resolve to exactly one emitter — the
+// templates in this file):
+//
+//	bp-agenity           — the per-Org Agenity workspace. DoD Pillar 4.
+//	bp-keycloak          — the per-Org Keycloak. The per-Org-realm substitute
+//	                       in core/controllers/organization (per_org_realm.go)
+//	                       is itself default-OFF (CATALYST_PER_ORG_REALM_ENABLED).
+//	bp-wordpress-tenant  — the SSO-pre-wired tenant WordPress. The per-Org
+//	                       tree installs a raw upstream `wordpress:6-apache`
+//	                       Deployment instead (an intentional divergence
+//	                       recorded in gitops/helmrelease_apps.go).
+//	continuum.yaml       — the per-Application Continuum CR (#2066). Nothing
+//	                       in the per-Org tree emits one.
+//
+// The org-controller's per-Org tree emits only the Namespace, vCluster,
+// ResourceQuota, NetworkPolicies, provisioning RBAC and kustomizations
+// (internal/gitops/manifests.go) — no bp-* HelmRelease at all. bp-newapi,
+// bp-openclaw and bp-stalwart-tenant do have per-Org emitters, but only when
+// the Org has purchased them; this overlay emits them for every Org.
+//
+// So defaulting ON here would silently strip the per-Org application stack
+// from every Organization on every Sovereign — the exact "gating alone
+// silently drops resources" failure. The switch is therefore EXPLICIT
+// opt-in: the mechanism is in place and guarded, and flipping it to `true`
+// becomes correct once the four gaps above are closed in the per-Org tree.
+// Deliberately not wired into the catalyst-api Deployment yet for the same
+// reason — the chart's existing `perOrgGitops` value defaults to "true" on a
+// Sovereign, so wiring it today would enable exactly the drop described here.
+//
+// Per Inviolable Principle #4 the key is read from env, never hardcoded.
+func perOrgGitopsEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("TENANT_GITOPS_PER_ORG")), "true")
+}
+
 // WriteTenantOverlay implements OrganizationGitOpsWriter. Returns the
 // commit SHA on success.
+//
+// #5425 — no-ops (empty SHA, nil error) when per-Org GitOps owns the Org.
+// The gate is the FIRST statement so no clone, no scratch directory and no
+// commit is attempted: the guarantee is zero writes under the legacy overlay
+// root, not "writes that are later cleaned up". The empty SHA is only
+// surfaced cosmetically (store.OrganizationProvisionRecord.CommitSHA is
+// `omitempty` and no step gates on it), and the caller advances the pipeline
+// exactly as it does for a real commit — on a per-Org-GitOps Sovereign the
+// Org's base stack is materialised by the CRD org-controller, not here.
 func (w DefaultOrganizationGitOpsWriter) WriteTenantOverlay(ctx context.Context, rec store.OrganizationProvisionRecord) (string, error) {
+	if perOrgGitopsEnabled() {
+		if w.Log != nil {
+			w.Log.Info("org-tenant: per-Org GitOps owns this Organization — legacy org-tenants overlay write skipped (#5425)",
+				"org", rec.OrganizationID, "subdomain", rec.Subdomain, "sovereign", rec.OTECHFQDN)
+		}
+		return "", nil
+	}
 	cfg := loadGitOpsConfig()
 	if cfg.Token == "" {
 		return "", errors.New("gitops token unconfigured — set CATALYST_GITOPS_TOKEN")
@@ -388,7 +470,29 @@ spec:
 // DeleteTenantOverlay implements OrganizationGitOpsWriter. Removes the
 // per-tenant overlay directory. Idempotent — a missing path commits
 // an empty change with `--allow-empty`.
+//
+// #5425 — gated on the SAME switch as WriteTenantOverlay, for a reason that
+// is easy to miss: this leg is not write-free. Even when the per-tenant
+// directory does not exist, it calls writeParentTenantsIndex, which
+// (re)creates `clusters/<fqdn>/org-tenants/kustomization.yaml` AND
+// `helmrepositories.yaml` — materialising the legacy tree, complete with the
+// six shared bp-* HelmRepositories, on a Sovereign whose whole invariant is
+// that the tree stays empty. Teardown of an Org that this leg never wrote
+// has nothing to remove, so skipping is also the correct semantic: the
+// per-Org tree's own teardown owns it.
+//
+// Consequence to know: flipping a Sovereign from legacy to per-Org GitOps
+// mid-life orphans any overlay written before the flip. Flipping
+// TENANT_GITOPS_PER_ORG back to `false` restores this leg and lets the
+// normal teardown reap them.
 func (w DefaultOrganizationGitOpsWriter) DeleteTenantOverlay(ctx context.Context, rec store.OrganizationProvisionRecord) (string, error) {
+	if perOrgGitopsEnabled() {
+		if w.Log != nil {
+			w.Log.Info("org-tenant: per-Org GitOps owns this Organization — legacy org-tenants overlay teardown skipped (#5425)",
+				"org", rec.OrganizationID, "subdomain", rec.Subdomain, "sovereign", rec.OTECHFQDN)
+		}
+		return "", nil
+	}
 	cfg := loadGitOpsConfig()
 	if cfg.Token == "" {
 		return "", errors.New("gitops token unconfigured — set CATALYST_GITOPS_TOKEN")

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops_perorg_gate_5425_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops_perorg_gate_5425_test.go
@@ -1,0 +1,208 @@
+package handler
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// #5425 — guard for the per-Org-GitOps gate on the LEGACY
+// clusters/<fqdn>/org-tenants/<id>/ overlay writer.
+//
+// ── Why the assertions look the way they do ──────────────────────────
+//
+// The requirement is "an Organization created with per-Org GitOps enabled
+// produces ZERO writes under the legacy overlay root". Asserting that by
+// grepping for the literal path "org-tenants" would be worthless: renaming
+// the directory would silently un-guard the defect. So these tests assert on
+// the WRITE PATH itself — whether the writer performs any filesystem work at
+// all — which no rename can slip past.
+//
+// The observation channel is CATALYST_GITOPS_TMPDIR. Both writers' first
+// filesystem action, immediately after the (env-only) config load and token
+// check, is:
+//
+//	os.MkdirTemp(envOr("CATALYST_GITOPS_TMPDIR", os.TempDir()), ...)
+//
+// Point that at a directory that does not exist and the call fails with
+// ENOENT the instant the write path is entered — deterministically, offline,
+// and regardless of uid (a chmod-based trap would be defeated by tests
+// running as root, and a real repo URL would drag a network `git clone` into
+// a unit test). So:
+//
+//	gated   → ("", nil)      the writer returned before touching the disk
+//	ungated → ("", non-nil)  the writer entered the write path and tripped
+//
+// CATALYST_GITOPS_TOKEN is deliberately set to a non-empty dummy in every
+// case. Without it WriteTenantOverlay short-circuits on its own
+// "gitops token unconfigured" check and the test would pass for the wrong
+// reason — it must be the GATE that stops execution, not a missing token.
+//
+// TestLegacyOverlayWritePathIsReachable_5425 is the non-vacuity proof: it
+// exercises the identical harness with the gate OFF and asserts the write
+// path IS entered. If that test ever stops failing-to-write, this file has
+// stopped testing anything and the gated assertions above are hollow.
+
+// gate5425Env pins the switch plus the observation channel. The tmpdir is a
+// path under a fresh t.TempDir() that is never created, so os.MkdirTemp
+// against it always fails.
+func gate5425Env(t *testing.T, perOrgGitops string) {
+	t.Helper()
+	t.Setenv("TENANT_GITOPS_PER_ORG", perOrgGitops)
+	// SOVEREIGN_FQDN is pinned set in EVERY case on purpose: this leg must
+	// key off the explicit switch alone. If someone later re-introduces the
+	// `SOVEREIGN_FQDN != ""` default that provisioning uses, the ungated
+	// tests below start failing instead of silently stripping the per-Org
+	// application stack on every Sovereign (see the gate's doc comment).
+	t.Setenv("SOVEREIGN_FQDN", "hw290.omani.works")
+	// Non-empty so the writer's own token guard cannot be what stops it.
+	t.Setenv("CATALYST_GITOPS_TOKEN", "dummy-token-not-a-secret")
+	t.Setenv("CATALYST_GITOPS_TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+}
+
+// With per-Org GitOps owning the Organization, creating one MUST NOT write
+// anything to the legacy shared overlay root. This is the defect: before
+// #5425 WriteTenantOverlay ran unconditionally and committed a 9-resource
+// overlay that nothing owned once the Org was gone.
+func TestWriteTenantOverlay_PerOrgGitops_WritesNothing_5425(t *testing.T) {
+	gate5425Env(t, "true")
+
+	sha, err := DefaultOrganizationGitOpsWriter{}.WriteTenantOverlay(context.Background(), d31TestRec())
+	if err != nil {
+		t.Fatalf("gated write must be a silent no-op, got error: %v\n"+
+			"a non-nil error here means the writer entered the write path "+
+			"(it tripped on the unreachable CATALYST_GITOPS_TMPDIR) — i.e. the "+
+			"per-Org-GitOps gate did not fire and the legacy org-tenants overlay "+
+			"is being committed again (#5425)", err)
+	}
+	if sha != "" {
+		t.Fatalf("gated write must report no commit, got sha=%q", sha)
+	}
+}
+
+// Teardown is gated too, and for a non-obvious reason: DeleteTenantOverlay
+// calls writeParentTenantsIndex unconditionally, which (re)creates the
+// parent kustomization.yaml AND helmrepositories.yaml — materialising the
+// legacy tree, with its six shared bp-* HelmRepositories, on a Sovereign
+// whose invariant is that the tree stays empty.
+func TestDeleteTenantOverlay_PerOrgGitops_WritesNothing_5425(t *testing.T) {
+	gate5425Env(t, "true")
+
+	sha, err := DefaultOrganizationGitOpsWriter{}.DeleteTenantOverlay(context.Background(), d31TestRec())
+	if err != nil {
+		t.Fatalf("gated teardown must be a silent no-op, got error: %v\n"+
+			"a non-nil error here means the writer entered the write path and "+
+			"would have re-materialised the legacy org-tenants parent index (#5425)", err)
+	}
+	if sha != "" {
+		t.Fatalf("gated teardown must report no commit, got sha=%q", sha)
+	}
+}
+
+// NON-VACUITY PROOF. Same harness, switch UNSET — which is the default
+// posture of every deployment today, including Sovereigns. The writer MUST
+// enter the write path and trip on the unreachable tmpdir. This test does
+// double duty:
+//
+//  1. If it ever passes with a nil error, the harness has stopped observing
+//     anything and the two gated assertions above are hollow.
+//  2. It pins the DEFAULT. The legacy overlay is the only emitter of
+//     bp-agenity / bp-keycloak / bp-wordpress-tenant / the Continuum CR, so
+//     a default that gates them off would strip the per-Org application
+//     stack from every Organization. That must fail loudly here, not in
+//     production.
+func TestLegacyOverlayWritePathIsReachable_5425(t *testing.T) {
+	gate5425Env(t, "")
+
+	for _, tc := range []struct {
+		name string
+		call func() (string, error)
+	}{
+		{"write", func() (string, error) {
+			return DefaultOrganizationGitOpsWriter{}.WriteTenantOverlay(context.Background(), d31TestRec())
+		}},
+		{"delete", func() (string, error) {
+			return DefaultOrganizationGitOpsWriter{}.DeleteTenantOverlay(context.Background(), d31TestRec())
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.call()
+			if err == nil {
+				t.Fatal("ungated writer must reach the write path — the harness " +
+					"is no longer observing anything, so the #5425 gate assertions " +
+					"are hollow (see file header)")
+			}
+			// Pin the observation to the FIRST filesystem action so a future
+			// refactor that moves work ahead of it cannot go unnoticed.
+			if !strings.Contains(err.Error(), "mktempdir") {
+				t.Fatalf("expected the write path to trip at its first filesystem "+
+					"action (mktempdir), got: %v", err)
+			}
+		})
+	}
+}
+
+// The gate is EXPLICIT opt-in on this leg: only TENANT_GITOPS_PER_ORG=true
+// enables it. SOVEREIGN_FQDN must never enable it by inference the way
+// provisioning's default does — see the gate's doc comment for the four
+// resources that would be dropped.
+func TestPerOrgGitopsEnabled_ExplicitOptInOnly_5425(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		sovereignFQDN string
+		switchVal     string
+		want          bool
+	}{
+		{"unset is off even on a sovereign", "hw290.omani.works", "", false},
+		{"unset is off on mothership", "", "", false},
+		{"explicit true enables", "hw290.omani.works", "true", true},
+		{"explicit true enables on mothership too", "", "true", true},
+		{"explicit false disables", "hw290.omani.works", "false", false},
+		{"case-insensitive", "", "TRUE", true},
+		{"whitespace-tolerant", "", "  true  ", true},
+		{"non-true reads as false", "hw290.omani.works", "yes", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SOVEREIGN_FQDN", tc.sovereignFQDN)
+			t.Setenv("TENANT_GITOPS_PER_ORG", tc.switchVal)
+			if got := perOrgGitopsEnabled(); got != tc.want {
+				t.Fatalf("perOrgGitopsEnabled() = %v, want %v (SOVEREIGN_FQDN=%q TENANT_GITOPS_PER_ORG=%q)",
+					got, tc.want, tc.sovereignFQDN, tc.switchVal)
+			}
+		})
+	}
+}
+
+// The gate must not change what the legacy path RENDERS. Ungated, the
+// overlay inventory is still the full base-create set — gating is a routing
+// decision, never a silent drop of resources.
+func TestLegacyOverlayInventoryUnchanged_5425(t *testing.T) {
+	gate5425Env(t, "")
+
+	files, err := renderOrganizationOverlay(d31TestRec(), OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{
+		"kustomization.yaml",
+		"namespace.yaml",
+		"certificate.yaml",
+		"bp-agenity.yaml",
+		"bp-keycloak.yaml",
+		"bp-newapi.yaml",
+		"bp-openclaw.yaml",
+		"bp-stalwart-tenant.yaml",
+		"bp-wordpress-tenant.yaml",
+	} {
+		if strings.TrimSpace(files[want]) == "" {
+			t.Errorf("legacy overlay lost %s — the #5425 gate must route, not drop", want)
+		}
+	}
+}
+
+var _ OrganizationGitOpsWriter = DefaultOrganizationGitOpsWriter{}
+
+var _ = store.OrganizationProvisionRecord{}


### PR DESCRIPTION
## What changed

`WriteTenantOverlay` and `DeleteTenantOverlay` in
`products/catalyst/bootstrap/api/internal/handler/organization_gitops.go` ran
unconditionally on every `POST /api/v1/organizations`, committing a 9-resource
overlay to `clusters/<sovereign-fqdn>/org-tenants/<org_tenant_id>/`. The
`PerOrgGitops` switch (#4384/#4827) lived only in `core/services/provisioning/`,
where every global-tree write is correctly gated — this second, older
base-create leg never received it.

Both legs now consult `TENANT_GITOPS_PER_ORG`, the **same env key** the
provisioning service reads, and return a no-op (empty SHA, nil error) when it
is `true`. The gate is the first statement in each function, so no clone, no
scratch directory and no commit is attempted — the guarantee is zero writes
under the legacy root, not writes that are cleaned up afterwards.

The `org-tenants` branch is untouched. Nothing moved to `main`.

## Chose (a) — gate. (b) would break Organization create outright.

The deciding question was whether the per-Org GitOps path covers what the
overlay provides. It does not: **4 of the 9 entries have no equivalent, and
this overlay is their only emitter in the repo.**

| # | Overlay entry | Per-Org GitOps | Evidence |
|---|---|---|---|
| 1 | Namespace | COVERED | `core/controllers/organization/internal/gitops/manifests.go:974` renders `vcluster/namespace.yaml`; same `<slug>` target since #4179 |
| 2 | `cert-strategy-<org>` ConfigMap | PARTIAL | repo-wide `cert-strategy` resolves to one hit — `organization_gitops.go:1903`. A wildcard Certificate is created by a different mechanism (`internal/controller/tenant_console_tls.go:286`, name `org-wildcard-tls-…`, applied via the K8s API, not committed). No equivalent of the 4-SAN BYO Certificate. |
| 3 | Continuum CR | **NOT COVERED** | no `Continuum` emitter in `core/controllers/organization/` or `core/services/provisioning/`; `cnpg-pair`'s template is gated on `cnpgPair.continuum.enabled`, default-OFF, and the per-Org HR never sets it |
| 4 | HelmRelease `bp-agenity` | **NOT COVERED** | `chart: bp-agenity` resolves to exactly one Go emitter — `organization_gitops.go:1726`. Not in `helmReleaseAppSlugs`, not in the provisioning app catalog. **This is DoD Pillar 4.** |
| 5 | HelmRelease `bp-keycloak` | **NOT COVERED** | `chart: bp-keycloak` resolves to one emitter — `organization_gitops.go:955`. `gitops/helmrelease_apps.go:44-50` records the divergence explicitly. The per-Org-realm substitute (`per_org_realm.go:71`) is itself default-OFF via `CATALYST_PER_ORG_REALM_ENABLED` (`cmd/main.go:77`). |
| 6 | HelmRelease `bp-newapi` | COVERED, cart-conditional | `gitops/helmrelease_apps.go:61,308-386` — emitted only when purchased; the overlay emits it for every Org |
| 7 | HelmRelease `bp-openclaw` | COVERED, cart-conditional | `gitops/helmrelease_apps.go:59,213-304` |
| 8 | HelmRelease `bp-stalwart-tenant` | COVERED, cart-conditional | `gitops/helmrelease_apps.go:60,409-477` |
| 9 | HelmRelease `bp-wordpress-tenant` | **NOT COVERED** | no `chart: bp-wordpress-tenant` in the per-Org tree; it installs a raw upstream `wordpress:6-apache` Deployment (`gitops/apps.go:99-100`), an intentional divergence noted at `helmrelease_apps.go:51-53`. The SSO-pre-wired tenant WordPress has no equivalent. |

The org-controller's per-Org tree emits only Namespace, vCluster,
ResourceQuota, NetworkPolicies, provisioning RBAC and kustomizations
(`manifests.go:974-1045`) — no `bp-*` HelmRelease at all.

So removal is wrong, as the issue anticipated. **It also means a
default-enabled gate is wrong**, for the same reason: on a Sovereign it would
strip the per-Org application stack — Agenity, Keycloak, the SSO WordPress and
the Continuum CR — from every Organization created through the BSS door. That
is the "gating alone silently drops resources" failure, reached from the other
direction.

The switch is therefore **explicit opt-in on this leg**: `unset` (today's state
everywhere) keeps the legacy write, `true` gates it. Provisioning defaults ON
from `SOVEREIGN_FQDN`; this leg deliberately does not, and the reason is
recorded at the gate. Flipping it to `true` becomes correct once the four gaps
above are closed. For the same reason the key is **not** wired into the
catalyst-api Deployment yet — the chart's existing `perOrgGitops` value
defaults to `"true"` on a Sovereign
(`chart/templates/org-services/provisioning.yaml:534`), so wiring it today
would enable exactly the drop described here. No chart change, no version bump.

## Guard, and the proof it is not vacuous

`organization_gitops_perorg_gate_5425_test.go`.

The assertion is on the **write path**, never on a filename — a rename of
`org-tenants` cannot slip past it. `CATALYST_GITOPS_TMPDIR` points at a
directory that does not exist, so `os.MkdirTemp` — the first filesystem action
of both writers — fails with ENOENT the instant the write path is entered.
Deterministic, offline, and uid-independent (a chmod trap would be defeated by
tests running as root; a real repo URL would drag `git clone` into a unit
test). `CATALYST_GITOPS_TOKEN` is set non-empty throughout so the writer's own
token check cannot be what stops execution.

Negative proof, both directions:

- Gate reverted (`if false && perOrgGitopsEnabled()`), guard **FAILS**:
  - `TestWriteTenantOverlay_PerOrgGitops_WritesNothing_5425` — `got error: mktempdir: stat …/does-not-exist: no such file or directory`
  - `TestDeleteTenantOverlay_PerOrgGitops_WritesNothing_5425` — same
- Gate restored, guard **PASSES**: `ok … 0.018s`

`TestLegacyOverlayWritePathIsReachable_5425` is the standing non-vacuity check:
same harness, switch unset, asserts the write path **is** entered and trips at
`mktempdir`. It also pins the default, so a future change that gates the
overlay off by inference fails here rather than in production.
`TestLegacyOverlayInventoryUnchanged_5425` asserts the ungated render still
carries all nine files — gating routes, it never drops.

## Gates

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` — green in
  `products/catalyst/bootstrap/api`
- `scripts/check-no-nodeports.sh` — `OK: zero NodePorts across sources + rendered charts`
- No chart touched, so no lockstep bump

## Known, not addressed here

`DeleteTenantOverlay` only runs from `DELETE /api/v1/org/tenants/{id}`
(`organization_provisioning.go:902`). An Organization removed by any other
route leaves the overlay in git, and Flux restores the HelmReleases — which
matches the orphan pattern measured on hw290 more directly than the write
itself does. Worth a separate issue; naming it rather than widening this one.

Refs #5425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
