### PR TITLE
fix(console): one card per Application CR — suppress fanned-out HelmRelease phantoms

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -2546,7 +2546,7 @@ func certOwnerFromObject(c *unstructured.Unstructured) precheck.CertOwner {
 	app := ""
 	if labels != nil {
 		org = strings.TrimSpace(labels["catalyst.openova.io/organization"])
-		app = strings.TrimSpace(labels["catalyst.openova.io/app"])
+		app = strings.TrimSpace(labels[labelCatalystApp])
 	}
 	if org == "" {
 		org = "sovereign"

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -142,6 +142,15 @@ var applicationGVR = ApplicationGVR()
 // chip MUST always render with a usable environment label.
 const defaultSovereignEnvironment = "dev"
 
+// labelCatalystApp is the HelmRelease label that ties every per-cluster
+// HR the application-controller fanned out back to its parent
+// Application CR. Mirrors render.LabelApp
+// (core/controllers/application/internal/render/topology.go) — a stable
+// G117.6 contract, restated here because that package is `internal/` to
+// a different Go module and cannot be imported. #5429 relies on it to
+// collapse an Application's N per-cluster HRs onto its ONE card.
+const labelCatalystApp = "catalyst.openova.io/app"
+
 // httpRouteGVR — Gateway API HTTPRoute. The canonical Sovereign
 // install uses Cilium Gateway as the only ingress; Console / Organization /
 // per-blueprint front-doors all surface as HTTPRoutes. We list both
@@ -767,6 +776,12 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 		// Contexts count from the instance's declared IaC values via
 		// the Blueprint's contextSchema (generic, declaration-only).
 		ctxSchemaByBP := map[string]*contextSchemaDecl{}
+		// #5429 — the set of Application CR names projected below, used
+		// by the HR fallback pass to suppress the per-cluster HelmReleases
+		// the application-controller fanned out for those CRs. Keyed
+		// lowercase because the HR label value carries the CR name
+		// verbatim while HR object names are DNS-1123 lowercased.
+		projectedAppCRs := map[string]bool{}
 		for i := range appCRs {
 			app := &appCRs[i]
 			bpFull, _, _ := unstructured.NestedString(app.Object, "spec", "blueprintRef", "name")
@@ -813,6 +828,7 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 			// gets its topology badge, same as string-form spine AHS apps. A
 			// raw NestedString read collapsed the object to "" → no badge.
 			topology := readTopology(app)
+			projectedAppCRs[strings.ToLower(app.GetName())] = true
 			instanceRows = append(instanceRows, sovereignAppItem{
 				ID:           app.GetName(),
 				Slug:         slug,
@@ -855,6 +871,30 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 			hr := &hrItems[i]
 			hrName := hr.GetName()
 			if adoptedHRs[hrName] {
+				continue
+			}
+			// #5429 — suppress the per-cluster HelmReleases the
+			// application-controller FANNED OUT for an Application CR that
+			// is already projected above. `adoptedHRs` alone cannot do this:
+			// it is keyed by `spec.helmRelease.name`, which is the
+			// bootstrap-ADOPTION pointer (read only by
+			// reconcileBootstrapOwned, gated on spec.bootstrap=true) and is
+			// a SINGULAR string. A fanned-out Application renders ONE HR PER
+			// CLUSTER — render.HRNameFor(<app>, <cluster>) — so no single
+			// name can ever suppress them all; an active-hot-standby app
+			// emits a phantom card per region. Every fanned-out HR instead
+			// carries render.LabelApp naming its parent CR (stamped
+			// unconditionally in render.renderOneHR, overlaying OwnerLabels
+			// so callers cannot subvert it), which is the identity that
+			// actually matches 1:N.
+			//
+			// Scoped to CRs we actually projected: if the parent CR is
+			// absent/unreadable the HR stays the only representation of that
+			// install and must still render, so it is NOT suppressed.
+			if owner := strings.TrimSpace(hr.GetLabels()[labelCatalystApp]); owner != "" && projectedAppCRs[strings.ToLower(owner)] {
+				// Also suppress any bootstrap SLOT row for this HR below —
+				// the Application CR's card is its one card.
+				adoptedHRs[hrName] = true
 				continue
 			}
 			chart, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "chart")

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_apps_one_card_per_cr_5429_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_apps_one_card_per_cr_5429_test.go
@@ -1,0 +1,178 @@
+// #5429 — the Apps grid must render EXACTLY ONE card per Application CR,
+// and that card's topology badge must come from the CR's spec.placement —
+// never from the fanned-out HelmRelease's stale spec.values.
+//
+// The defect this locks out (reproduced live on hw290, 4/4 acme-corp UAT
+// apps): the Application CR's `spec.helmRelease.name` is unset, so the
+// `adoptedHRs` suppression in HandleSovereignApps never matched and each
+// per-cluster HelmRelease emitted a SECOND row through the
+// readTopologyFromValues branch. One real card plus one phantom.
+//
+// The phantom was not merely a cosmetic duplicate. readTopologyFromValues
+// DEFAULTS to "singleton" when the HR values carry no topology.mode, so an
+// active-hot-standby Application rendered one card badged
+// `active-hot-standby` (from the CR) and another badged `singleton` (from
+// the HR) — two contradictory topologies for the same Application, with
+// nothing on screen telling a sovereign-admin which one is real.
+//
+// Why suppression keys off the LABEL and not spec.helmRelease.name:
+// `spec.helmRelease.name` is the bootstrap-ADOPTION pointer (read by
+// application_controller.reconcileBootstrapOwned, gated on
+// spec.bootstrap=true) and is a SINGULAR string, while a fanned-out
+// Application renders ONE HR PER CLUSTER via render.HRNameFor(app,
+// cluster). No single name can suppress N HRs — an active-hot-standby app
+// would keep one phantom per region. render.LabelApp is stamped on every
+// fanned-out HR, so it is the identity that matches 1:N.
+//
+// Refs #5429, #3370 (one-card-per-CR contract), #3375/#4897 (topology badge).
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// makeFannedOutHR builds one per-cluster HelmRelease exactly as
+// render.renderOneHR emits it: named `<app>-<cluster>` (render.HRNameFor)
+// and labelled `catalyst.openova.io/app: <app>` back at its parent
+// Application CR. It deliberately declares NO topology.mode in
+// spec.values — the live shape — so readTopologyFromValues would default
+// it to "singleton" if this HR were ever projected as its own card.
+//
+// The chart is bp-postgres because a phantom can only appear for a
+// SHAREABLE blueprint (the fallback pass skips charts with no
+// contextSchema valuesKey), and bp-postgres is the shareable chart the
+// four hw290 UAT apps installed from.
+func makeFannedOutHR(app, cluster, ready string) *unstructured.Unstructured {
+	u := makeHR(app+"-"+cluster, "flux-system", ready)
+	_ = unstructured.SetNestedField(u.Object, "bp-postgres", "spec", "chart", "spec", "chart")
+	_ = unstructured.SetNestedField(u.Object, app+"-"+cluster, "spec", "releaseName")
+	_ = unstructured.SetNestedSlice(u.Object, []interface{}{
+		map[string]interface{}{"name": "app", "owner": "app"},
+	}, "spec", "values", "databases")
+	u.SetLabels(map[string]string{
+		"catalyst.openova.io/app":      app,
+		"catalyst.openova.io/topology": "active-hot-standby",
+		"catalyst.openova.io/cluster":  cluster,
+	})
+	return u
+}
+
+// makeTopologyApplication builds an Application CR carrying the OBJECT
+// form of spec.placement ({mode, regions}) — what Catalog → New-instance
+// writes (#4897) — and NO spec.helmRelease, which is correct for a
+// controller-fanned-out app and is precisely why adoptedHRs never fired.
+func makeTopologyApplication(name, ns, env, mode string) *unstructured.Unstructured {
+	u := makeApplication(name, ns, env)
+	_ = unstructured.SetNestedField(u.Object, mode, "spec", "placement", "mode")
+	_ = unstructured.SetNestedStringSlice(u.Object, []string{"rtz-a", "rtz-b"}, "spec", "placement", "regions")
+	_ = unstructured.SetNestedField(u.Object, "bp-postgres", "spec", "blueprintRef", "name")
+	return u
+}
+
+// TestSovereignApps_OneCardPerApplicationCR_NoFanoutPhantom is the #5429
+// regression. An active-hot-standby Application CR fanned out across two
+// clusters must produce EXACTLY ONE card, badged from the CR.
+func TestSovereignApps_OneCardPerApplicationCR_NoFanoutPhantom(t *testing.T) {
+	dynObjs := []runtime.Object{
+		makeTopologyApplication("uat16-topo", "default", "acme-corp-prod", "active-hot-standby"),
+		// The two per-cluster HRs the application-controller fanned out.
+		makeFannedOutHR("uat16-topo", "hw290-rtz-a", "True"),
+		makeFannedOutHR("uat16-topo", "hw290-rtz-b", "True"),
+	}
+	h := newSovereignHandler(t, nil, dynObjs)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/apps", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignApps(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignAppsResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// (1) EXACTLY ONE card per Application CR — the #3370 contract.
+	// Count every instance row that belongs to this Application: its own
+	// card (ID == CR name) plus any phantom projected from a fanned-out
+	// HR (ID == releaseName `<app>-<cluster>`).
+	var mine []sovereignAppItem
+	for _, a := range got.Apps {
+		if !a.Instance {
+			continue
+		}
+		if a.ID == "uat16-topo" || a.ID == "uat16-topo-hw290-rtz-a" || a.ID == "uat16-topo-hw290-rtz-b" {
+			mine = append(mine, a)
+		}
+	}
+	if len(mine) != 1 {
+		ids := make([]string, 0, len(mine))
+		for _, a := range mine {
+			ids = append(ids, a.ID+"[topology="+a.Topology+",env="+a.Environment+"]")
+		}
+		t.Fatalf("Application CR uat16-topo projected %d cards %v; want exactly 1 (#3370 one-card-per-CR; the extra rows are fanned-out-HR phantoms)", len(mine), ids)
+	}
+
+	// (2) The surviving card is the CR's own, not an HR-derived row.
+	card := mine[0]
+	if card.ID != "uat16-topo" {
+		t.Errorf("surviving card ID = %q; want uat16-topo (the Application CR, not an HR release name)", card.ID)
+	}
+
+	// (3) The badge derives from the CR's spec.placement — NOT from the
+	// HR values, which carry no topology.mode and would default to
+	// "singleton" via readTopologyFromValues. A card badged "singleton"
+	// here is the exact contradiction #5429 reported.
+	if card.Topology != "active-hot-standby" {
+		t.Errorf("topology badge = %q; want active-hot-standby from the CR's spec.placement.mode (a %q badge means the card was sourced from stale HR values)", card.Topology, card.Topology)
+	}
+
+	// (4) The CR-sourced card carries the CR's environment, not the
+	// phantom's "dev" default, and is not mislabelled BOOTSTRAP (the HR
+	// branch hardcodes BootstrapKit: true).
+	if card.Environment != "acme-corp-prod" {
+		t.Errorf("environment chip = %q; want acme-corp-prod (from the CR's spec.environmentRef)", card.Environment)
+	}
+	if card.BootstrapKit {
+		t.Errorf("card marked BootstrapKit; a controller-fanned-out Application is not a bootstrap-kit slot (the HR branch hardcodes it true)")
+	}
+}
+
+// TestSovereignApps_FanoutSuppressionScopedToPresentCRs proves the
+// suppression is not a blanket "drop every labelled HR". When the parent
+// Application CR is absent (deleted, or its CRD/RBAC unreadable — the
+// handler lists Applications in a separate best-effort call), the
+// HelmRelease is the only surviving representation of a real running
+// install and MUST still project a card. Without this the fix would trade
+// a duplicate card for a vanished one.
+func TestSovereignApps_FanoutSuppressionScopedToPresentCRs(t *testing.T) {
+	dynObjs := []runtime.Object{
+		// Labelled HR whose parent Application CR does NOT exist.
+		makeFannedOutHR("orphan-app", "hw290-rtz-a", "True"),
+	}
+	h := newSovereignHandler(t, nil, dynObjs)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/apps", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignApps(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignAppsResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, a := range got.Apps {
+		if a.Instance && a.ID == "orphan-app-hw290-rtz-a" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("HR orphan-app-hw290-rtz-a projected no card; an HR whose parent Application CR is absent must still render (suppression must be scoped to CRs actually projected)")
+	}
+}


### PR DESCRIPTION
## Problem

The sovereign-admin Apps grid (`products/catalyst/bootstrap/ui`, fed by
`HandleSovereignApps`) rendered **two cards per Application CR**, violating the
#3370 one-card-per-CR contract. Reproduced live 4/4 on hw290 (`acme-corp`).

The duplicate was worse than cosmetic: `readTopologyFromValues` **defaults to
`singleton`** when the HelmRelease values carry no `topology.mode`, so an
`active-hot-standby` Application rendered one card badged `active-hot-standby`
(from the CR) and another badged `singleton` (from the HR) — two contradictory
topologies for the same Application, with nothing on screen marking either as
unreal.

## Root cause

The dedup set `adoptedHRs` is keyed by `spec.helmRelease.name`. That field is
the bootstrap-**adoption** pointer: it is read only by
`application_controller.reconcileBootstrapOwned`, which is gated on
`spec.bootstrap=true` and explicitly *never renders, never fans out*. It is
also a **singular string**.

A controller-fanned-out Application renders **one HelmRelease per cluster** via
`render.HRNameFor(app, cluster)`. So with the field unset — which is *correct*
for a fanned-out app — nothing matched, and each per-cluster HR emitted a second
row through the `readTopologyFromValues` branch.

## Which fix shape, and why

Two shapes were considered. Populating `spec.helmRelease.name` is **structurally
incapable** of fixing this: a singular string cannot name N per-cluster HRs, so
an `active-hot-standby` app would keep one phantom **per region**. Worse, that
field is the signal that routes a CR onto the status-only adoption path, so
setting it on a fanned-out app would stop it rendering at all. The field being
unset is not a defect here.

This PR therefore suppresses on the **`catalyst.openova.io/app` label**
(`render.LabelApp`), which `render.renderOneHR` stamps unconditionally on every
fanned-out HR, overlaying `OwnerLabels` so a caller cannot subvert it. That is
the identity that actually matches 1:N.

Suppression is **scoped to Application CRs actually projected in the same
response**, so an HR whose parent CR is absent or unreadable still renders as
the sole representation of a real install — the fix cannot trade a duplicate
card for a vanished one.

## Badge now derives from the CR

Every surviving card is CR-sourced and takes its badge from
`readTopology(spec.placement)`, never from stale HR values. The UI needed no
change — `AppsPage` renders `topologyLabel(a.topology)` verbatim from this
projection, so the badge source is decided entirely in the BFF.

## Guard, proven non-vacuous

`sovereign_apps_one_card_per_cr_5429_test.go` asserts exactly one card per
Application CR for an `active-hot-standby` app fanned out across two clusters,
and that its badge is `active-hot-standby` — not the HR's `singleton` default.

Reverted, it fails with the exact live symptom:

```
Application CR uat16-topo projected 3 cards [
  uat16-topo[topology=active-hot-standby,env=acme-corp-prod]
  uat16-topo-hw290-rtz-a[topology=singleton,env=dev]
  uat16-topo-hw290-rtz-b[topology=singleton,env=dev]
]; want exactly 1
```

Restored, it passes. Note the reverted run emits **two** phantoms, one per
region — direct evidence that a singular `spec.helmRelease.name` could not have
suppressed them.

A second test locks the CR-absent case so the suppression stays scoped.

## The colliding `postgres` CNPG cluster is a SEPARATE defect

Not folded in. `bp-postgres.instanceName` is
`default "postgres" .Values.instance.name`
(`platform/postgres/chart/templates/_helpers.tpl`), and the CNPG Cluster is
named from it. Four HelmReleases that do not set `.Values.instance.name` each
render a Cluster literally named `postgres` into the same target namespace —
a chart-default collision on a values key. It shares no mechanism with the
console dedup: the HRs are distinct objects with distinct names, and this
projection change cannot affect what they render.

## Gates

- `go build ./...`, `go vet ./...`, full `go test ./...` green in
  `products/catalyst/bootstrap/api` (0 failures).
- `gofmt` clean on all three touched files.
- No frontend files changed.
- No NodePorts involved.

## Adjacent finding (reported, not fixed)

`HandleOrgApplications` (`org_applications.go:358`) keys its `adopted` set the
same way. Its HR pass sets no `Topology`, so it could duplicate a card without
producing a contradictory badge, and it lists HRs only within the Org namespace
— so whether it triggers depends on where the fanout writes. Left alone
deliberately: unproven live, and a live cutover is in flight.

Refs #5429
Refs #3370
