### PR TITLE
fix(cutover): step-06 reads back what it pivoted instead of trusting its own patch calls (0.1.153)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -988,7 +988,24 @@ spec:
       # is a behavioral no-op (empty optional mount -> glob guards skip every leg;
       # the legs DO render). Step count stays 11.
       # Contract Case 71.
-      version: 0.1.152
+      # 0.1.153 (#5436): step-06 region-A pivot READ-BACK. Step-06's only
+      # region-A failure signal was the Phase-1 `fail` counter — `kubectl
+      # patch` CALLS that returned non-zero, never the cluster state after.
+      # An HR the Phase-0.9 enumeration missed (org-tenant pipeline seeds
+      # bp-agenity/bp-keycloak/bp-newapi/bp-openclaw/bp-stalwart-tenant/
+      # bp-wordpress-tenant hardcoded to ghcr.io) or one Flux reverted was
+      # invisible: Job exited 0, result=success, cutoverComplete reachable
+      # on a still-tethered Sovereign (LIVE hw290 2026-07-27, six flux-system
+      # HRs on ghcr.io with the step green). The #5359 secondary leg already
+      # had this read-back; region-A now does too — single-shot after
+      # Phase-1 and bounded at the head of Phase 3, before the irreversible
+      # mothership-auth strip. Same class wired in step-11 (both Provider
+      # patch-failure arms now record the #5204 marker). New values:
+      # helmRepositories.readbackExcludeNames/.readbackReconcileKustomizations,
+      # stepTimeouts.pivotReadbackSeconds. Step count stays 11; no RBAC or
+      # deadline change. New chart test tests/step06-pivot-readback.sh
+      # asserts on the step's EXIT CODE, not its log text.
+      version: 0.1.153
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.152
+  version: 0.1.153
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,42 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.153 (#5436 — step-06 region-A pivot READ-BACK: stop reporting
+# `success` on a half-pivoted Sovereign). Step-06's only region-A failure
+# signal was the Phase-1 `fail` counter, which counts `kubectl patch`
+# CALLS that returned non-zero — never the cluster state afterwards. A
+# HelmRepository the Phase-0.9 enumeration never saw (the catalyst-api
+# org-tenant pipeline seeds bp-agenity / bp-keycloak / bp-newapi /
+# bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant into
+# clusters/<fqdn>/org-tenants/helmrepositories.yaml hardcoded to
+# oci://ghcr.io/openova-io) or one Flux reverted from a durable source
+# Phase-2/2b did not rewrite was therefore INVISIBLE: zero patch calls
+# failed, the Job exited 0, catalyst-api recorded
+# `step.helmrepository-patches.result=success` — and cutoverComplete=true
+# became reachable on an environment still chart-tethered to the
+# mothership. LIVE hw290 2026-07-27: six flux-system HRs on ghcr.io with
+# step-06 green and the Job succeeded=1. The SECONDARY-region leg has had
+# exactly this read-back since #5359; region-A never did. NOW: a shared
+# `assert_region_a_pivot` asserts ZERO HelmRepositories in
+# helmRepositories.namespace remain on the upstream prefix, called TWICE —
+# single-shot right after Phase-1 (fail-fast on an enumeration miss) and
+# with a bounded convergence budget at the HEAD of Phase 3, before the
+# irreversible mothership-auth strip (so the hw139 half-pivot — ghcr.io
+# creds gone while HRs still point at ghcr.io — is unreachable). The
+# tolerated set mirrors step-08's own count_offenders whitelist so this
+# assert is never STRICTER than the gate that follows it. Same class fixed
+# in step-11: both `kubectl patch provider.pkg.crossplane.io` failure arms
+# printed `FAIL <name>` and recorded nothing (the loop is a `printf |
+# while` SUBSHELL, so only the #5204 marker file can carry a verdict out) —
+# they now touch /tmp/xpkg-verify-failed, which the existing fail-loud
+# check already turns into exit 1 before the durable Gitea rewrite. New
+# values: helmRepositories.readbackExcludeNames /
+# .readbackReconcileKustomizations, stepTimeouts.pivotReadbackSeconds (300).
+# No step-count / RBAC / deadline change (still 11 steps; the read-back's
+# 300s budget sits inside the existing 2400s step-06 deadline). New chart
+# test tests/step06-pivot-readback.sh EXECUTES the rendered step-06 script
+# against a fake kubectl and asserts on the EXIT CODE (the log text was
+# already correct before the fix — that is why this shipped).
+#
 # 0.1.151 (#5359 Refs #5265 #5339 — SECONDARY-REGION pivot + proof legs:
 # kill the 2-region FALSE-POSITIVE cc=true. Live-proven on hw288 (dep
 # 027f07559af1f9f7): only region-A was pivoted — region-B's Flux
@@ -2649,7 +2686,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.152
+version: 0.1.153
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -273,6 +273,23 @@ data:
             value: {{ .Values.status.configMapName | quote }}
           - name: CUTOVER_NAMESPACE
             value: {{ .Release.Namespace | quote }}
+          # #5436 — region-A pivot READ-BACK assert inputs. Until this
+          # landed, region-A's only failure signal was the Phase-1 `fail`
+          # counter, which counts `kubectl patch` invocations that returned
+          # non-zero — NOT the state of the cluster afterwards. See the
+          # assert_region_a_pivot block in args: below.
+          #
+          # readbackExcludeNames MUST stay a superset-tolerant mirror of the
+          # slot-managed self-reference whitelist step-08's own offender scan
+          # applies (08-egress-block-test-job.yaml count_offenders). This
+          # assert must never be STRICTER than the step-08 gate that follows
+          # it, or a cutover step-08 would pass dies here instead.
+          - name: HELMREPO_READBACK_EXCLUDE
+            value: {{ join "," .Values.helmRepositories.readbackExcludeNames | quote }}
+          - name: HELMREPO_READBACK_KUSTOMIZATIONS
+            value: {{ join " " .Values.helmRepositories.readbackReconcileKustomizations | quote }}
+          - name: HELMREPO_READBACK_BUDGET_SECONDS
+            value: {{ .Values.stepTimeouts.pivotReadbackSeconds | quote }}
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
@@ -667,6 +684,105 @@ data:
             sort -u "${combined_names}" -o "${combined_names}"
             echo "[helmrepository-patches] Phase-1 input: $(grep -c . "${combined_names}") HelmRepository name(s) (curated ∪ live-upstream)"
 
+            # ---- #5436: region-A HelmRepository pivot READ-BACK assert ----
+            #
+            # THE DEFECT THIS CLOSES. Before this block, region-A's ONLY
+            # failure signal was Phase-1's `fail` counter — which counts
+            # `kubectl patch` invocations that returned non-zero, NOT the
+            # state of the cluster afterwards. Every HelmRepository that
+            # Phase-0.9's enumeration never saw (seeded by the catalyst-api
+            # org-tenant pipeline AFTER the enumeration ran) or that Flux
+            # reverted from a durable source Phase-2/2b did not rewrite is
+            # therefore INVISIBLE to this step: zero patch calls fail,
+            # `fail` stays 0, the Job exits 0, and catalyst-api records
+            # `step.helmrepository-patches.result=success` on a Sovereign
+            # whose charts still resolve to the mothership. Live on hw290
+            # 2026-07-27: SIX flux-system HelmRepositories still on
+            # oci://ghcr.io/openova-io (bp-agenity / bp-keycloak /
+            # bp-newapi / bp-openclaw / bp-stalwart-tenant /
+            # bp-wordpress-tenant) with the step green and the Job
+            # succeeded=1. That makes `cutoverComplete=true` reachable on a
+            # still-tethered environment — the sovereignty claim would be
+            # false while the evidence trail said otherwise.
+            #
+            # The SECONDARY-region leg has had exactly this read-back since
+            # #5359 (see pivot_secondary_regions below, "Read-back assert:
+            # ZERO upstream-prefixed HRs may remain"). Region-A never did.
+            # This is that same assertion, for the region that matters most.
+            #
+            # Scope: HELMREPO_NAMESPACE (the namespace Phase-1 patches) —
+            # the same scope the #5359 secondary read-back uses, and where
+            # every hw290 offender lived. Step-08's `-A` scan remains the
+            # wider net; this assert deliberately fails EARLIER and closer
+            # to the code that could have fixed it.
+            #
+            # $1 = phase label for the log.
+            # $2 = bounded convergence budget in seconds (0 = single-shot).
+            #      The budget exists for the post-Phase-2 call: a durable
+            #      rewrite has to be pulled by the `openova` GitRepository
+            #      and re-applied by the bootstrap-kit / org-tenants
+            #      Kustomizations before a Flux-reverted URL settles back on
+            #      local Harbor — the same revert-race #3526 documents for
+            #      step-08. Reconciles are re-poked each cycle so a missed
+            #      request cannot strand the poll. The Phase-1.5 call is
+            #      single-shot: Phase-1's patches are synchronous API
+            #      writes, so there is nothing to converge.
+            #
+            # NB: the offender list is written to a FILE and grepped from
+            # the file — never `printf '%s' "$big" | grep -q`. Under
+            # `set -o pipefail` (which a future edit may add) grep closing
+            # the pipe on its first match SIGPIPEs the upstream writer and
+            # fails the whole script; that shape has bitten this repo twice
+            # (#5370, #5406) and once in this chart's own test harness
+            # (#4969, see tests/cutover-contract.sh Case 16c).
+            assert_region_a_pivot() {
+              ra_label="$1"
+              ra_budget="${2:-0}"
+              ra_deadline=$(( $(date +%s) + ra_budget ))
+              ra_left=0
+              while : ; do
+                kubectl get helmrepositories.source.toolkit.fluxcd.io -n "${HELMREPO_NAMESPACE}" \
+                  -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' \
+                  2>/dev/null > /tmp/.ra-hrs.txt || : > /tmp/.ra-hrs.txt
+                : > /tmp/.ra-offenders.txt
+                while IFS= read -r ra_line; do
+                  [ -n "${ra_line}" ] || continue
+                  ra_name="${ra_line%%=*}"
+                  ra_url="${ra_line#*=}"
+                  # Only the upstream prefix counts as an offender — a
+                  # non-default URL (an operator overlay pointing somewhere
+                  # else entirely) is not this step's business.
+                  case "${ra_url}" in
+                    "${UPSTREAM_PREFIX}"*) : ;;
+                    *) continue ;;
+                  esac
+                  case ",${HELMREPO_READBACK_EXCLUDE:-}," in
+                    *",${ra_name},"*) continue ;;
+                  esac
+                  printf '%s=%s\n' "${ra_name}" "${ra_url}" >> /tmp/.ra-offenders.txt
+                done < /tmp/.ra-hrs.txt
+                ra_left=$(grep -c . /tmp/.ra-offenders.txt || true)
+                if [ "${ra_left}" -eq 0 ]; then break; fi
+                if [ "$(date +%s)" -ge "${ra_deadline}" ]; then break; fi
+                echo "[helmrepository-patches] ${ra_label}: ${ra_left} region-A HelmRepository(ies) still on ${UPSTREAM_PREFIX}; re-poking the GitRepository + Kustomization reconciles, re-checking in 15s (#5436)"
+                ra_poke=$(date +%s)
+                kubectl annotate --overwrite gitrepository openova -n flux-system \
+                  "reconcile.fluxcd.io/requestedAt=${ra_poke}" >/dev/null 2>&1 || true
+                for ra_ks in ${HELMREPO_READBACK_KUSTOMIZATIONS:-}; do
+                  kubectl annotate --overwrite kustomization "${ra_ks}" -n flux-system \
+                    "reconcile.fluxcd.io/requestedAt=${ra_poke}" >/dev/null 2>&1 || true
+                done
+                sleep 15
+              done
+              if [ "${ra_left}" -ne 0 ]; then
+                echo "[helmrepository-patches] FATAL: ${ra_label}: ${ra_left} region-A HelmRepository(ies) are STILL on ${UPSTREAM_PREFIX} after the pivot — the Sovereign would record a SUCCESSFUL cutover step while its charts resolve to the mothership; refusing to succeed (#5436)" >&2
+                sed 's/^/  STILL-UPSTREAM /' /tmp/.ra-offenders.txt >&2 || true
+                return 1
+              fi
+              echo "[helmrepository-patches] ${ra_label} OK: zero region-A HelmRepositories on ${UPSTREAM_PREFIX} in ${HELMREPO_NAMESPACE} (tolerated: ${HELMREPO_READBACK_EXCLUDE:-<none>})"
+              return 0
+            }
+
             # ---- Phase 1: live K8s patches (immediate) ----
             ok=0
             skip=0
@@ -749,6 +865,14 @@ data:
 
             echo "[helmrepository-patches] live-K8s ok=${ok} skip=${skip} fail=${fail}"
             [ "${fail}" -eq 0 ] || exit 1
+
+            # ---- Phase 1.5 (#5436): read back what Phase-1 actually did ----
+            # `fail=0` only means every patch CALL returned zero. Assert the
+            # cluster state directly, single-shot (Phase-1's writes are
+            # synchronous) — an HR seeded between the Phase-0.9 enumeration
+            # and now, or one whose patch silently no-op'd, fails HERE
+            # instead of shipping a green step on a half-pivoted Sovereign.
+            assert_region_a_pivot "Phase-1.5 read-back" 0 || exit 1
 
             # ---- Phase 1.6: parent HelmRelease values override for openova-catalog (TBD-C19) ----
             #
@@ -1344,6 +1468,24 @@ data:
             # Idempotency: if every strip target is already absent, the block
             # is a pure no-op (no Secret churn). A re-run after a partial strip
             # (jq del of a missing key is a no-op) re-converges cleanly.
+            #
+            # ── #5436: region-A read-back, second call ──
+            # Placed at the HEAD of Phase 3 so it runs on EVERY path,
+            # including the MOTHERSHIP_AUTHS_TO_STRIP-empty early exit
+            # directly below. Two invariants ride on it:
+            #   (a) the Phase-2/2b durable Gitea rewrite actually held —
+            #       this call runs after the git push AND after the
+            #       secondary-region legs, so a non-durable pivot has had a
+            #       Flux reconcile tick to revert and be caught. Bounded
+            #       convergence budget (HELMREPO_READBACK_BUDGET_SECONDS)
+            #       absorbs the #3526 revert-race rather than fail-fasting
+            #       into it.
+            #   (b) the strip below NEVER removes the ghcr.io fallback while
+            #       a region-A HelmRepository still points at ghcr.io — that
+            #       combination is the hw139 half-pivot that wedged 8 HRs
+            #       for 10h on "no auth config for 'ghcr.io'".
+            assert_region_a_pivot "Phase-3 pre-strip read-back" "${HELMREPO_READBACK_BUDGET_SECONDS:-300}" || exit 1
+
             if [ -z "${MOTHERSHIP_AUTHS_TO_STRIP:-}" ]; then
               echo "[helmrepository-patches] Phase-3 skip: MOTHERSHIP_AUTHS_TO_STRIP empty — nothing to strip"
               echo "[helmrepository-patches] step complete"

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -493,7 +493,19 @@ data:
                           --type=merge --patch "${patch_json}" >/dev/null 2>&1; then
                         echo "[crossplane-provider-pivot]   OK ${name}"
                       else
-                        echo "[crossplane-provider-pivot]   FAIL ${name}" >&2
+                        # #5436 (same class as step-06): this arm used to
+                        # print FAIL and nothing else — no counter, no
+                        # marker, no exit. The Provider stayed on
+                        # xpkg.upbound.io / the mothership proxy, the loop
+                        # ran in a `printf | while` SUBSHELL so a variable
+                        # could not carry the verdict out anyway, and the
+                        # step exited 0 with the tether intact. Record it on
+                        # the SAME marker file the #5204 verify misses use,
+                        # so the fail-loud check below (which already runs
+                        # BEFORE the durable Gitea rewrite) covers a failed
+                        # patch too.
+                        echo "[crossplane-provider-pivot]   FAIL ${name}: kubectl patch spec.package -> ${new_pkg} returned non-zero — the Provider is STILL on ${pkg} (#5436)" >&2
+                        touch /tmp/xpkg-verify-failed
                       fi
                       ;;
                     "${target_prefix}/"*)
@@ -533,7 +545,11 @@ data:
                             --type=merge --patch "${patch_json}" >/dev/null 2>&1; then
                           echo "[crossplane-provider-pivot]   OK ${name}"
                         else
-                          echo "[crossplane-provider-pivot]   FAIL ${name}" >&2
+                          # #5436 — same un-wired verdict as the arm above;
+                          # a failed tag->digest upgrade leaves a TAG-form
+                          # local ref that 404s post-severance. Record it.
+                          echo "[crossplane-provider-pivot]   FAIL ${name}: kubectl patch spec.package -> ${new_pkg} returned non-zero — the Provider is STILL on the TAG-form ${pkg} and will 404 post-severance (#5436 #5232)" >&2
+                          touch /tmp/xpkg-verify-failed
                         fi
                       fi
                       ;;

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -193,7 +193,7 @@ rules:
     verbs: ["update", "patch"]   # step 06 phase-1.6 (catalog override) + step 10 vcluster-registry-pivot (TBD-V24 MISS-1)
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources: ["kustomizations"]
-    verbs: ["update", "patch"]   # step 08 (#3526) force-reconciles the bootstrap-kit Kustomization so Step-06's durable git-push lands before the pivot assertion (the annotate reconcile.fluxcd.io/requestedAt patch)
+    verbs: ["update", "patch"]   # step 08 (#3526) force-reconciles the bootstrap-kit Kustomization so Step-06's durable git-push lands before the pivot assertion (the annotate reconcile.fluxcd.io/requestedAt patch); step 06 (#5436) re-pokes the SAME reconciles (bootstrap-kit + org-tenants, helmRepositories.readbackReconcileKustomizations) inside its own pre-strip pivot read-back — do NOT narrow this to step-08, the step-06 annotate is `|| true` and would degrade SILENTLY into a read-back that times out instead of converging
   - apiGroups: ["pkg.crossplane.io"]
     resources: ["providers", "imageconfigs"]
     verbs: ["update", "patch"]   # step 11 crossplane-provider-pivot (TBD-V24 MISS-3); #5204 patches the ImageConfig on re-run (kubectl apply)

--- a/platform/self-sovereign-cutover/chart/tests/step06-pivot-readback.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step06-pivot-readback.sh
@@ -238,8 +238,13 @@ run_case() {
   : > "${TMP}/listcount"
   local rc=0
   set +e
+  # env -i so the step script sees ONLY the rendered env + the harness fakes —
+  # a stray inherited HELMREPO_* would make the assertions meaningless. The
+  # ambient PATH is carried through (behind ${TMP}/bin, so the fake kubectl
+  # still wins) because jq/base64/coreutils live in different prefixes on
+  # different runners.
   env -i \
-    PATH="${TMP}/bin:/usr/bin:/bin" \
+    PATH="${TMP}/bin:${PATH}" \
     HOME="${TMP}" \
     FAKE_STATE="${TMP}/state.txt" \
     FAKE_LIST_COUNT="${TMP}/listcount" \

--- a/platform/self-sovereign-cutover/chart/tests/step06-pivot-readback.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step06-pivot-readback.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# bp-self-sovereign-cutover — step-06 region-A pivot READ-BACK guard (#5436).
+#
+# THE DEFECT THIS LOCKS OUT
+# ─────────────────────────
+# Step-06 used to report `success` whenever every `kubectl patch` CALL
+# returned zero. It never read the cluster back. So a HelmRepository that
+# Phase-0.9's enumeration never saw (the catalyst-api org-tenant pipeline
+# seeds one AFTER the enumeration ran) or whose patch was accepted by the
+# API without changing anything was INVISIBLE: zero patch calls failed,
+# `fail` stayed 0, the Job exited 0, and catalyst-api recorded
+# `step.helmrepository-patches.result=success` on a Sovereign whose charts
+# still resolved to the mothership. Live on hw290 2026-07-27: SIX
+# flux-system HelmRepositories on oci://ghcr.io/openova-io with the step
+# green and the Job succeeded=1 — which makes `cutoverComplete=true`
+# reachable on a still-tethered environment.
+#
+# WHY THIS TEST EXECUTES THE SCRIPT INSTEAD OF GREPPING THE RENDER
+# ───────────────────────────────────────────────────────────────
+# The rendered log text was ALREADY correct before the fix — the step
+# printed per-HR results and step-08 printed the OFFENDER list. Log text is
+# exactly what made this ship. So the assertions below are on the SCRIPT'S
+# EXIT CODE, driven by a fake kubectl that reproduces the live shape:
+# `kubectl patch` returns 0 and the object does not change.
+#
+# WHAT IS EXECUTED
+# ────────────────
+# The REAL rendered step-06 script bytes, truncated immediately after the
+# Phase-1.5 read-back call (everything past it — the Gitea clone/push, the
+# secondary-region legs, the helm pull probe — needs a live cluster and is
+# out of this guard's reach). Two container mount paths are relocated into
+# the test tmpdir because the harness is not a container:
+#   /work/helmrepository-names.txt   (the step ConfigMap projection)
+# Nothing else is rewritten; the logic under test is verbatim.
+#
+# Usage: bash tests/step06-pivot-readback.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+CHART_DIR="$(cd "${CHART_DIR}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+pass=0; fail=0
+ok()  { echo "  ok: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+mkdir -p "${TMP}/bin" "${TMP}/work"
+
+echo "[step06-pivot-readback] rendering chart"
+helm template smoke "${CHART_DIR}" > "${TMP}/render.yaml"
+
+# ── Extract the step-06 script + its rendered env ─────────────────────────
+python3 - "${TMP}/render.yaml" "${TMP}/step06.sh" "${TMP}/step06.env" <<'PY'
+import sys, yaml
+render, out_sh, out_env = sys.argv[1], sys.argv[2], sys.argv[3]
+for d in yaml.safe_load_all(open(render)):
+    if not d or d.get("kind") != "ConfigMap":
+        continue
+    if d["metadata"]["name"] != "cutover-step-06-helmrepository-patches":
+        continue
+    spec = yaml.safe_load(d["data"]["podSpec"])
+    c = [x for x in spec["containers"] if x["name"] == "helmrepository-patches"][0]
+    open(out_sh, "w").write(c["args"][0])
+    # Export every literal-value env the render carries, so this test tracks
+    # values.yaml rather than a hardcoded copy of it. secretKeyRef-form envs
+    # (HARBOR_USERNAME / HARBOR_PASSWORD / GITEA_*) are supplied by the harness.
+    def shquote(v):
+        return "'" + str(v).replace("'", "'\\''") + "'"
+    with open(out_env, "w") as fh:
+        for e in c.get("env", []):
+            if "value" in e:
+                fh.write("export %s=%s\n" % (e["name"], shquote(e["value"])))
+    # Also emit the projected names list so /work is faithful.
+    open(out_sh + ".names", "w").write(d["data"]["helmrepository-names.txt"])
+    sys.exit(0)
+sys.exit("step-06 ConfigMap not found in render")
+PY
+
+[ -s "${TMP}/step06.sh" ] && ok "extracted the rendered step-06 script" \
+                          || bad "could not extract the step-06 script"
+
+cp "${TMP}/step06.sh.names" "${TMP}/work/helmrepository-names.txt"
+
+# ── A. render/wiring assertions ───────────────────────────────────────────
+echo "== A. read-back is present and wired at both call sites =="
+
+if grep -q 'assert_region_a_pivot()' "${TMP}/step06.sh"; then
+  ok "step-06 defines assert_region_a_pivot"
+else
+  bad "step-06 has no assert_region_a_pivot function — the region-A read-back was dropped (#5436)"
+fi
+
+# Both call sites must be fail-wired. `|| exit 1` (or a bare call under
+# set -e) is acceptable; `|| true` / `|| echo` is the regression.
+if grep -nE 'assert_region_a_pivot "[^"]+"[^|]*\|\|[[:space:]]*(true|echo|:)' "${TMP}/step06.sh" >/dev/null; then
+  bad "an assert_region_a_pivot call site swallows its verdict (|| true / || echo) — the exact #5436 shape"
+else
+  ok "no assert_region_a_pivot call site swallows its verdict"
+fi
+
+callsites=$(grep -cE '^[[:space:]]*assert_region_a_pivot "' "${TMP}/step06.sh" || true)
+if [ "${callsites}" -ge 2 ]; then
+  ok "read-back is called at ${callsites} sites (post-Phase-1 + pre-strip)"
+else
+  bad "read-back called at ${callsites} site(s); expected >= 2 (post-Phase-1 fail-fast + pre-strip gate)"
+fi
+
+# The pre-strip call MUST precede the executable mothership-auth strip, or
+# the hw139 half-pivot (ghcr.io creds gone, HRs still on ghcr.io) is
+# reachable again.
+prestrip_ln=$(awk 'index($0,"assert_region_a_pivot \"Phase-3"){print NR; exit}' "${TMP}/step06.sh")
+del_ln=$(awk 'index($0,"jq_filter=\"${jq_filter} | del(.auths["){print NR; exit}' "${TMP}/step06.sh")
+[ -n "${del_ln}" ] || del_ln=$(awk '/jq_filter=.*del\(\.auths\[/{print NR; exit}' "${TMP}/step06.sh")
+if [ -n "${prestrip_ln}" ] && [ -n "${del_ln}" ] && [ "${prestrip_ln}" -lt "${del_ln}" ]; then
+  ok "pre-strip read-back (line ${prestrip_ln}) runs BEFORE the executable strip (line ${del_ln})"
+else
+  bad "pre-strip read-back at ${prestrip_ln:-<none>} does not precede the strip at ${del_ln:-<none>} — the strip could fire on a half-pivoted region-A (hw139 shape)"
+fi
+
+# ── B. execution harness ──────────────────────────────────────────────────
+echo "== B. exit-code assertions against a fake kubectl =="
+
+# Truncate the real script immediately after the Phase-1.5 read-back call.
+cut_ln=$(awk 'index($0,"assert_region_a_pivot \"Phase-1.5"){print NR; exit}' "${TMP}/step06.sh")
+if [ -z "${cut_ln}" ]; then
+  bad "no Phase-1.5 read-back call to truncate at — cannot run the exit-code cases"
+  echo; echo "RESULT: ${pass} passed, ${fail} failed"; [ "${fail}" -eq 0 ]; exit
+fi
+head -n "${cut_ln}" "${TMP}/step06.sh" > "${TMP}/step06.phase15.sh"
+
+# Relocate the container mount path (the harness is not a container). Assert
+# the substitution actually applied so a template rename cannot silently turn
+# this into a no-op test.
+work_hits=$(grep -c '/work/helmrepository-names.txt' "${TMP}/step06.phase15.sh" || true)
+if [ "${work_hits}" -lt 1 ]; then
+  bad "step-06 no longer reads /work/helmrepository-names.txt — harness mount relocation is stale"
+fi
+sed -i "s,/work/helmrepository-names.txt,${TMP}/work/helmrepository-names.txt,g" "${TMP}/step06.phase15.sh"
+
+# ── fake kubectl ──
+# Models the LIVE shape: `kubectl patch helmrepository` returns 0 and the
+# object does not change when the name is in FAKE_STUBBORN.
+cat > "${TMP}/bin/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+# fake kubectl. State = ${FAKE_STATE}, one `name=url` per line.
+args="$*"
+verb="$1"; shift
+
+listing_name_url() {
+  # Phase-0.9 sees the state as-is; every LATER `name=url` listing (the
+  # Phase-1.5 read-back) additionally sees FAKE_LATE_ARRIVAL — modelling a
+  # HelmRepository the org-tenant pipeline seeded after the enumeration ran.
+  n=0
+  [ -f "${FAKE_LIST_COUNT}" ] && n=$(cat "${FAKE_LIST_COUNT}")
+  echo $((n+1)) > "${FAKE_LIST_COUNT}"
+  cat "${FAKE_STATE}"
+  if [ -n "${FAKE_LATE_ARRIVAL:-}" ] && [ "${n}" -ge 1 ]; then
+    printf '%s\n' "${FAKE_LATE_ARRIVAL}"
+  fi
+}
+
+case "${verb}" in
+  get)
+    res="$1"
+    case "${res}" in
+      gateway.gateway.networking.k8s.io)
+        case "${args}" in *jsonpath*) printf 'True' ;; esac
+        exit 0 ;;
+      secret)
+        name="$2"
+        if [ "${name}" = "${GHCR_PULL_SECRET_NAME}" ]; then
+          cat "${FAKE_GHCR_SECRET}"
+          exit 0
+        fi
+        # wildcard TLS secret absent -> Phase-0.5 WARN path (trust_secret="")
+        exit 1 ;;
+      helmrepositories|helmrepositories.source.toolkit.fluxcd.io)
+        case "${args}" in
+          *'{.metadata.namespace}{" "}{.metadata.name}'*)
+            sed -e 's/=.*//' -e 's/^/flux-system /' "${FAKE_STATE}" ;;
+          *'{.metadata.name}={.spec.url}'*)
+            listing_name_url ;;
+          *'{.metadata.name}{" "}{.spec.url}'*)
+            sed 's/=/ /' "${FAKE_STATE}" ;;
+        esac
+        exit 0 ;;
+      helmrepository)
+        name="$2"
+        case "${args}" in
+          *'{.spec.url}'*)
+            grep "^${name}=" "${FAKE_STATE}" | head -n1 | cut -d= -f2- ;;
+          *'{.spec.certSecretRef.name}'*) : ;;
+        esac
+        # not-found => empty stdout, non-zero (the script's SKIP path)
+        grep -q "^${name}=" "${FAKE_STATE}" || exit 1
+        exit 0 ;;
+      *) exit 1 ;;
+    esac ;;
+  patch)
+    res="$1"
+    case "${res}" in
+      secret) exit 0 ;;
+      helmrepository)
+        name="$2"
+        case " ${FAKE_PATCH_ERRORS:-} " in
+          *" ${name} "*) exit 1 ;;   # the API itself rejects the patch
+        esac
+        case " ${FAKE_STUBBORN:-} " in
+          *" ${name} "*) exit 0 ;;   # accepted, object does NOT change
+        esac
+        newurl=$(printf '%s' "${args}" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
+        if [ -n "${newurl}" ]; then
+          grep -v "^${name}=" "${FAKE_STATE}" > "${FAKE_STATE}.n" || true
+          printf '%s=%s\n' "${name}" "${newurl}" >> "${FAKE_STATE}.n"
+          sort -o "${FAKE_STATE}" "${FAKE_STATE}.n"
+        fi
+        exit 0 ;;
+      *) exit 0 ;;
+    esac ;;
+  annotate|apply|delete) exit 0 ;;
+  *) exit 0 ;;
+esac
+FAKE
+chmod +x "${TMP}/bin/kubectl"
+
+# ghcr-pull Secret fixture: upstream auth present, local Harbor auth absent
+# (so Phase-0 takes the ADD path rather than the idempotent skip).
+dockercfg=$(printf '{"auths":{"ghcr.io":{"username":"x","auth":"eA=="}}}' | base64 -w0)
+printf '{"data":{".dockerconfigjson":"%s"}}\n' "${dockercfg}" > "${TMP}/ghcr-secret.json"
+
+run_case() {
+  # $1 label  $2 initial state (newline-separated name=url)  $3 stubborn names
+  # $4 expected exit (0|nonzero)  $5 late-arrival line (optional)
+  local label="$1" state="$2" stubborn="$3" expect="$4" late="${5:-}"
+  printf '%s\n' "${state}" | grep -v '^$' > "${TMP}/state.txt"
+  : > "${TMP}/listcount"
+  local rc=0
+  set +e
+  env -i \
+    PATH="${TMP}/bin:/usr/bin:/bin" \
+    HOME="${TMP}" \
+    FAKE_STATE="${TMP}/state.txt" \
+    FAKE_LIST_COUNT="${TMP}/listcount" \
+    FAKE_GHCR_SECRET="${TMP}/ghcr-secret.json" \
+    FAKE_STUBBORN="${stubborn}" \
+    FAKE_PATCH_ERRORS="${FAKE_PATCH_ERRORS:-}" \
+    FAKE_LATE_ARRIVAL="${late}" \
+    HARBOR_USERNAME=admin HARBOR_PASSWORD=notasecret \
+    bash -c "set -a; . '${TMP}/step06.env'; set +a; bash '${TMP}/step06.phase15.sh'" \
+    > "${TMP}/out.log" 2>&1
+  rc=$?
+  set -e
+  if [ "${expect}" = "0" ]; then
+    if [ "${rc}" -eq 0 ]; then ok "${label}: exit ${rc} (expected 0)"
+    else bad "${label}: exit ${rc} (expected 0)"; sed 's/^/      /' "${TMP}/out.log" | tail -20; fi
+  else
+    if [ "${rc}" -ne 0 ]; then ok "${label}: exit ${rc} (expected non-zero)"
+    else bad "${label}: exit 0 — step-06 reported SUCCESS with an un-pivoted HelmRepository (#5436)"; sed 's/^/      /' "${TMP}/out.log" | tail -20; fi
+  fi
+}
+
+UP="oci://ghcr.io/openova-io"
+
+# B1 — happy path: every HR pivots. Proves the assert is not a blanket fail.
+run_case "B1 all HelmRepositories pivot" \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}
+bp-agenity=${UP}" \
+  "" 0
+
+# B2 — THE #5436 CASE: the API accepts the patch, the object does not change.
+#      This is the hw290 shape: patch call returns 0, HR still on ghcr.io.
+run_case "B2 one HelmRepository refuses to pivot (patch OK, state unchanged)" \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}
+bp-agenity=${UP}" \
+  "bp-agenity" 1
+
+# B3 — six offenders, mirroring the hw290 live set exactly.
+run_case "B3 the hw290 six (agenity/keycloak/newapi/openclaw/stalwart/wordpress)" \
+  "bp-cilium=${UP}
+bp-agenity=${UP}
+bp-keycloak=${UP}
+bp-openclaw=${UP}
+bp-stalwart-tenant=${UP}
+bp-wordpress-tenant=${UP}" \
+  "bp-agenity bp-keycloak bp-openclaw bp-stalwart-tenant bp-wordpress-tenant" 1
+
+# B4 — an HR the Phase-0.9 enumeration never saw (org-tenant pipeline seeds
+#      it mid-step). Phase-1 patches nothing wrong; only a read-back catches it.
+run_case "B4 HelmRepository seeded after the Phase-0.9 enumeration" \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}" \
+  "" 1 "bp-openclaw=${UP}"
+
+# B5 — the read-back must NOT be stricter than step-08's offender scan: the
+#      slot-managed self-refs step-08 whitelists must not fail step-06.
+run_case "B5 whitelisted self-ref left upstream does not fail the step" \
+  "bp-cilium=${UP}
+bp-newapi=${UP}
+bp-self-sovereign-cutover=${UP}" \
+  "bp-newapi bp-self-sovereign-cutover" 0
+
+# B6 — regression anchor for the pre-existing signal: a patch the API itself
+#      rejects must still fail via the Phase-1 fail counter.
+FAKE_PATCH_ERRORS="bp-keycloak" run_case "B6 kubectl patch returns non-zero" \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}" \
+  "" 1
+
+# ── C. sibling step-11: same class, same wiring requirement ───────────────
+echo "== C. step-11 crossplane-provider-pivot patch verdicts are wired (#5436) =="
+python3 - "${TMP}/render.yaml" "${TMP}/step11.sh" <<'PY'
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind") != "ConfigMap":
+        continue
+    if d["metadata"]["name"] != "cutover-step-11-crossplane-provider-pivot":
+        continue
+    spec = yaml.safe_load(d["data"]["podSpec"])
+    c = spec["containers"][0]
+    open(sys.argv[2], "w").write(c["args"][0])
+    sys.exit(0)
+sys.exit("step-11 ConfigMap not found in render")
+PY
+# Step-11's Provider patch loop runs inside a `printf | while` SUBSHELL, so a
+# shell variable cannot carry the verdict out — the marker FILE the #5204
+# verify misses already use is the only working seam. Every `FAIL <name>`
+# branch in the patch loop must touch it, or the step exits 0 with the
+# Provider still on xpkg.upbound.io / the mothership proxy.
+unwired=$(awk '
+  /echo "\[crossplane-provider-pivot\]   FAIL /{ n=NR }
+  n && NR>n && NR<=n+2 && /touch \/tmp\/xpkg-verify-failed/ { n=0 }
+  n && NR==n+2 { print n; n=0 }
+' "${TMP}/step11.sh" | wc -l | tr -d ' ')
+if [ "${unwired}" = "0" ]; then
+  ok "every step-11 Provider-patch FAIL branch records the fail-loud marker"
+else
+  bad "${unwired} step-11 Provider-patch FAIL branch(es) print a verdict without recording /tmp/xpkg-verify-failed — the step exits 0 on a failed pivot (#5436)"
+fi
+if grep -q 'if \[ -e /tmp/xpkg-verify-failed \]; then' "${TMP}/step11.sh"; then
+  ok "step-11 still checks the marker and exits non-zero"
+else
+  bad "step-11 lost the /tmp/xpkg-verify-failed fail-loud check"
+fi
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -865,6 +865,38 @@ helmRepositories:
     # ghcr.io). Caught live on t22.omantel.biz 2026-05-18.
     - "openova-catalog"
 
+  # ── #5436: region-A pivot READ-BACK assert ────────────────────────────
+  #
+  # Step-06 used to report `success` whenever every `kubectl patch` CALL
+  # returned zero — it never read the cluster back. An HelmRepository the
+  # Phase-0.9 enumeration missed (org-tenant pipeline seeds one AFTER the
+  # enumeration ran) or one Flux reverted from a durable source Phase-2/2b
+  # did not rewrite was invisible: the step exited 0 and catalyst-api
+  # recorded `step.helmrepository-patches.result=success` on a Sovereign
+  # whose charts still resolved to the mothership (live hw290 2026-07-27,
+  # six flux-system HRs on oci://ghcr.io/openova-io with the step green).
+  # Step-06 now read-back-asserts region-A the same way the #5359
+  # secondary-region leg already asserted every secondary.
+  #
+  # Names tolerated by the read-back. This MUST mirror the slot-managed
+  # self-reference whitelist step-08's own offender scan applies
+  # (08-egress-block-test-job.yaml, count_offenders' `grep -vE`) — the
+  # step-06 assert must never be STRICTER than the step-08 gate that
+  # follows it, or a cutover step-08 would pass dies at step-06 instead.
+  readbackExcludeNames:
+    - "bp-newapi"
+    - "bp-self-sovereign-cutover"
+  # Kustomizations re-poked (alongside the `openova` GitRepository) inside
+  # the read-back's bounded convergence window, so a durable Phase-2/2b
+  # rewrite is pulled + re-applied rather than waited out at the polling
+  # interval. `bootstrap-kit` carries the slot HelmRepositories;
+  # `org-tenants` carries the per-Org tenant HelmRepositories Phase-2b
+  # rewrites. All are in flux-system; a name that does not exist is a
+  # harmless no-op (the annotate is `|| true`).
+  readbackReconcileKustomizations:
+    - "bootstrap-kit"
+    - "org-tenants"
+
 # ── HelmRepository TLS-trust for the in-cluster Harbor (Refs #3379) ──────
 #
 # THE LAST LEG OF THE CUTOVER CERT-TAIL. Step-06 Phase-1 pivots every
@@ -1971,6 +2003,21 @@ stepTimeouts:
   # seconds. The re-poke-reconcile inside the loop means a fast converge
   # returns well under the ceiling.
   stripReadinessSeconds: 600
+  # Step 06 Phase-3 pre-strip read-back (#5436). Bounded convergence budget
+  # for the region-A "zero HelmRepositories left on the upstream prefix"
+  # assert placed at the head of Phase 3. It exists purely to absorb the
+  # #3526 revert-race: Phase-2/2b pushed the durable rewrite to local Gitea,
+  # but the `openova` GitRepository has to pull it and the bootstrap-kit /
+  # org-tenants Kustomizations have to re-apply it before a Flux-reverted
+  # URL settles back on local Harbor. Same 300s the step-08 pivot-poll uses,
+  # for the same race. Reconciles are re-poked every 15s inside the window,
+  # so a converged cluster returns on the FIRST pass and never waits this
+  # out; the budget only costs wall-clock on a genuinely un-pivoted
+  # Sovereign, where spending 5 minutes before failing loud is exactly the
+  # right trade. Set 0 to make the assert single-shot.
+  # NB: this is inside helmRepositoryPatchesSeconds (2400s) alongside the
+  # gateway-wait + stripReadinessSeconds worst-case sum.
+  pivotReadbackSeconds: 300
   catalystAPIEnvPatchSeconds: 600
   # 600s deny survival window + up to 300s #3526 bounded pivot-poll
   # (force-reconcile GitRepository + bootstrap-kit Kustomization and wait

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5068,7 +5068,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.152"
+  version: "0.1.153"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5085,7 +5085,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.152"
+    version: "0.1.153"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The defect

Step-06's only region-A failure signal was the Phase-1 `fail` counter. That counter counts `kubectl patch` **calls** that returned non-zero — it never read the cluster back.

`platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml:751` (pre-fix):

```sh
echo "[helmrepository-patches] live-K8s ok=${ok} skip=${skip} fail=${fail}"
[ "${fail}" -eq 0 ] || exit 1
```

That was the whole verdict. Nothing after it looked at `spec.url` again. So a HelmRepository the Phase-0.9 enumeration never saw, or one Flux reverted from a durable source Phase-2/2b did not rewrite, was invisible: zero patch calls fail, the Job exits 0, catalyst-api records `step.helmrepository-patches.result=success`, and `cutoverComplete=true` becomes reachable on a Sovereign still chart-tethered to the mothership.

Live on hw290 2026-07-27: six flux-system HelmRepositories on `oci://ghcr.io/openova-io` (`bp-agenity`, `bp-keycloak`, `bp-newapi`, `bp-openclaw`, `bp-stalwart-tenant`, `bp-wordpress-tenant`) with the step green and the Job `succeeded=1`.

All six are emitted by the catalyst-api org-tenant pipeline into `clusters/<fqdn>/org-tenants/helmrepositories.yaml`, hardcoded to `oci://ghcr.io/openova-io` — `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go:304` (`orgTenantSharedHelmRepositories`). That is exactly the durable source Phase-2b exists to rewrite, and exactly the source that reverts a live patch when the rewrite does not land.

## The fix

The secondary-region leg has read-back-asserted *zero upstream-prefixed HRs remain* since #5359 (`06-…:1282`). Region-A never did. One shared `assert_region_a_pivot`, called at two points:

| call site | budget | why |
|---|---|---|
| right after Phase-1 | single-shot | Phase-1's writes are synchronous; an enumeration miss fails immediately instead of shipping a green step on a half-pivoted Sovereign |
| head of Phase 3 | bounded (`pivotReadbackSeconds`, 300s) | runs on every path incl. the `MOTHERSHIP_AUTHS_TO_STRIP`-empty early exit; proves the Phase-2/2b durable rewrite held, and refuses the irreversible strip on a half-pivot — the hw139 shape (ghcr.io creds gone, HRs still on ghcr.io) becomes unreachable |

The bounded budget re-pokes the `openova` GitRepository and the `bootstrap-kit` / `org-tenants` Kustomizations every 15s, absorbing the #3526 revert-race rather than fail-fasting into it. A converged cluster returns on the first pass.

The tolerated set (`readbackExcludeNames`) mirrors step-08's own `count_offenders` whitelist. This assert must never be **stricter** than the gate that follows it, or a cutover step-08 would pass dies at step-06 instead.

## Sibling steps — the class, enumerated

All ten job-mode step scripts were rendered, extracted, and swept for "verdict printed, exit code untouched". One other hit:

**step-11 `crossplane-provider-pivot`** — both `kubectl patch provider.pkg.crossplane.io` failure arms (`11-…:496`, `:536`) printed `FAIL <name>` and recorded nothing: no counter, no marker, no exit. The Provider stayed on `xpkg.upbound.io` / the mothership proxy and the step exited 0. The loop is a `printf | while` **subshell**, so a shell variable cannot carry the verdict out — the `/tmp/xpkg-verify-failed` marker file the #5204 verify misses already use is the only working seam. Both arms now touch it; the existing fail-loud check at `:552` turns that into `exit 1` before the durable Gitea rewrite.

The other eight are clean, and here is what each actually fails on, so this is a checked claim rather than an assumed one:

| step | verdict wiring |
|---|---|
| 01 gitea-mirror | `set -e` on the mutation + explicit `exit 1` on every G75 post-verify miss |
| 02 harbor-projects | per-call HTTP-code `case` with `exit 1` on any non-201/409 |
| 03 harbor-prewarm | Phase-B failure-rate gate (`fail > total/4` → `exit 1`) plus per-phase FATALs |
| 05 flux-gitrepository-patch | `set -e` on `kubectl patch`; secondary leg has a fail-loud Ready wait |
| 07 catalyst-api-env-patch | `image_warmed_gate \|\| exit 1` + `case` FAILs |
| 08 egress-block-test | `rc=1` return on roll failures; `host_ks_bad` → `exit 1`; `new_failures` → `exit 1` |
| 09 gitea-token-mint | `exit 1` on mint/validate/patch failure |
| 10 vcluster-registry-pivot | `fail` counter **plus** the #2951 residual-tether read-back (`residual != 0` → `exit 1`) |

Step-10 is worth calling out: it already had the exact read-back shape step-06 was missing, added by #2951/#2940 for the same reason ("the cutover automation does not assert the pivots actually landed").

## The four-vs-six discrepancy

Both mechanisms, one each.

The `OFFENDER … / FAIL — at least one HelmRepository did not pivot within the bounded reconcile wait (#3526)` lines are **step-08's**, not step-06's — that string exists only at `08-egress-block-test-job.yaml:417`, and step-08 does `exit 1` on the next line. Step-06 never printed a verdict at all; it printed `live-K8s ok=… fail=0` and exited 0. So the four-line list came from step-08's `count_offenders` at `08-…:365`:

```sh
kubectl get helmrepositories.source.toolkit.fluxcd.io -A -o jsonpath='…' \
  | grep -E '=oci://ghcr\.io/openova-io' \
  | grep -vE '/(bp-newapi|bp-self-sovereign-cutover)='
```

- **`bp-newapi` — enumeration gap, by design.** It is on that whitelist, so it can never appear in an OFFENDER line no matter what its URL is.
- **`bp-keycloak` — later drift.** It is *not* whitelisted, so it was on local Harbor when step-08 scanned and reverted afterwards. Mechanism: it is one of the `orgTenantSharedHelmRepositories` above, and catalyst-api **regenerates that file verbatim** on any Org signup/teardown (`organization_gitops.go:251`), wiping step-06's Phase-2b sed. The `org-tenants` Kustomization then re-applies ghcr.io.

That regeneration is a durable-source hole this PR does not close — step-06's Phase-2b rewrite is correct but not durable against the next Org event. It is the `#4885 durable-source follow-on` the template comment already names; worth its own issue against `organization_gitops.go`, not something to smuggle into a chart fix.

## Guard

`platform/self-sovereign-cutover/chart/tests/step06-pivot-readback.sh` — picked up by the existing `blueprint-release.yaml` `chart/tests/*.sh` gate.

It **executes** the real rendered step-06 bytes (truncated at the Phase-1.5 call; only the `/work/…` container mount path is relocated, and the test asserts that relocation applied) against a fake `kubectl` and asserts on the **exit code**. The fake models the live shape precisely: `kubectl patch` returns 0 and the object does not change.

Log text is deliberately not the assertion. The log was already correct before this fix — that is why the defect shipped.

```
B1 all HelmRepositories pivot                                      exit 0
B2 one HelmRepository refuses to pivot (patch OK, state unchanged)  exit non-zero
B3 the hw290 six                                                    exit non-zero
B4 HelmRepository seeded after the Phase-0.9 enumeration            exit non-zero
B5 whitelisted self-ref left upstream                               exit 0
B6 kubectl patch returns non-zero (pre-existing signal)             exit non-zero
```

### Non-vacuous proof

Pre-fix chart (`git show HEAD:…06-…yaml` + HEAD values), truncated at the pre-fix verdict `[ "${fail}" -eq 0 ] || exit 1`, same fixture as B3 (five HelmRepositories that accept the patch and do not move):

```
PRE-FIX : exit 0
          [helmrepository-patches] OK bp-wordpress-tenant -> oci://registry.example.local/openova-io
          [helmrepository-patches] live-K8s ok=6 skip=60 fail=0
          offenders remaining: 5

POST-FIX: exit 1
          FATAL: Phase-1.5 read-back: 5 region-A HelmRepository(ies) are STILL on
          oci://ghcr.io/openova-io after the pivot …
            STILL-UPSTREAM bp-keycloak=oci://ghcr.io/openova-io
            STILL-UPSTREAM bp-openclaw=oci://ghcr.io/openova-io
            STILL-UPSTREAM bp-stalwart-tenant=oci://ghcr.io/openova-io
            STILL-UPSTREAM bp-wordpress-tenant=oci://ghcr.io/openova-io
```

The pre-fix run reproduces the reported shape exactly: per-HR `OK` lines for objects that never moved, `fail=0`, exit 0.

Second proof, against un-wiring rather than removal — replace `|| exit 1` with `|| true` on the Phase-1.5 call (the exact #5436 shape: FATAL printed, exit 0):

```
RESULT: 9 passed, 4 failed
  FAIL: an assert_region_a_pivot call site swallows its verdict (|| true / || echo)
  FAIL: B2 … exit 0 — step-06 reported SUCCESS with an un-pivoted HelmRepository
  FAIL: B3 … exit 0 — step-06 reported SUCCESS with an un-pivoted HelmRepository
  FAIL: B4 … exit 0 — step-06 reported SUCCESS with an un-pivoted HelmRepository
```

Restored: 13 passed, 0 failed.

## Gates

- `tests/cutover-contract.sh` — 71 cases green
- `tests/image-registry-coverage.sh` — green
- `tests/step06-pivot-readback.sh` — 13/13
- `cd tests/e2e/bootstrap-kit && go test -count=1 ./...` — ok
- `scripts/check-bootstrap-kit-pin-sync.sh` — 67 pairs in sync
- `scripts/check-catalog-seed-lockstep.sh` — 68 checked, 0 fail
- `scripts/check-no-nodeports.sh` — zero NodePorts
- every rendered step script re-checked with `bash -n`, `dash -n`, `busybox ash -n`

Chart `0.1.152` → `0.1.153`, with all four lockstep sites moved: `chart/Chart.yaml`, `blueprint.yaml`, `clusters/_template/bootstrap-kit/06a-…yaml`, and the catalog-seed's **both** `spec.version` and `source.version`. Step count stays 11; no RBAC change; the 300s read-back budget sits inside the existing 2400s step-06 deadline.

## Shared-file note

`products/catalyst/chart/templates/catalog-seed/blueprints.yaml` is touched — two lines, the `0.1.153` pin only. Same file set as the last cutover bump (35c6f64d0, #5392). Flagging it in case the concurrent #5437 work lands in the same file.

Repo-only. No cluster was touched.

Refs #5436
