### PR TITLE
fix(cutover): re-take the gitea-mirror snapshot on a new attempt instead of skipping it (Refs #5437)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -178,6 +178,12 @@ const (
 	// registry-pivot DaemonSet-wait then asserts per-node v2 acks.
 	cutoverStepHarborPrewarm = "harbor-prewarm"
 	cutoverStepRegistryPivot = "registry-pivot"
+	// #5437: the SNAPSHOT step (its success is a point-in-time capture of a
+	// moving upstream — see cutover_snapshot_steps.go) and the PIVOT BOUNDARY
+	// step (from which the mirrored repo becomes the live GitOps source and
+	// later steps commit sovereign-local changes onto it).
+	cutoverStepGiteaMirror      = "gitea-mirror"
+	cutoverStepFluxGitRepoPatch = "flux-gitrepository-patch"
 	// #5014: the step whose Job applies the 10-min deny-egress hold. The
 	// driver reaps its CiliumClusterwideNetworkPolicy on ANY step exit —
 	// the Job's own TERM/EXIT traps cover clean paths, but a SIGKILLed pod
@@ -1446,6 +1452,42 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 		// existing value is preserved (NOT in the seed map ⇒ untouched).
 		seed["cutoverStartedAt"] = startedAt.Format(time.RFC3339)
 	}
+
+	// ── #5437 stale-snapshot re-run ─────────────────────────────────────
+	//
+	// Skip-on-success is correct idempotency for a step that ENSURES state,
+	// and WRONG for a step whose output is a snapshot of a moving upstream.
+	// gitea-mirror is the latter: its success only means "at time T the local
+	// Gitea matched upstream", and every later step consumes that snapshot.
+	// On hw290 (2026-07-27) a re-attempt 14h later skipped it while
+	// harbor-prewarm re-ran fresh, so the mirror pinned catalyst-api:b1b472d
+	// which the fresh prewarm never pushed → post-pivot ImagePullBackOff →
+	// control plane down. Re-take the snapshot, and cascade-invalidate every
+	// later step so no consumer carries a success computed from the old one.
+	// The judgement lives in cutover_snapshot_steps.go.
+	forceRerun := map[string]bool{}
+	var snapshotNotices []string
+	stepHasJobs := func(stepName string) bool {
+		jobs, err := findExistingJobsForStep(ctx, deps, stepName)
+		return err == nil && len(jobs) > 0
+	}
+	for i, step := range steps {
+		d := decideSnapshotRerun(step, steps, priorStatus, startedAt, stepHasJobs)
+		if d.reason != "" {
+			snapshotNotices = append(snapshotNotices, d.reason)
+		}
+		if !d.rerun {
+			continue
+		}
+		for _, s := range steps[i:] {
+			forceRerun[s.stepName] = true
+		}
+		for k, v := range snapshotRerunCascade(steps, priorStatus, i) {
+			seed[k] = v
+		}
+		break
+	}
+
 	if err := patchCutoverStatus(ctx, deps, seed); err != nil {
 		h.publishCutoverEvent(bus, cutoverEvent{
 			Time:    time.Now().UTC().Format(time.RFC3339),
@@ -1462,6 +1504,19 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 		Level:   "info",
 		Message: fmt.Sprintf("Self-Sovereignty Cutover started: %d steps", totalSteps),
 	})
+
+	// #5437 — surface the snapshot judgement on the wizard's event stream so
+	// an operator sees WHY the mirror re-ran (or why it was kept).
+	for _, notice := range snapshotNotices {
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Time:    startedAt.Format(time.RFC3339),
+			Phase:   cutoverPhaseStarted,
+			Level:   "info",
+			Step:    cutoverStepGiteaMirror,
+			Message: notice,
+		})
+		h.log.Info("cutover: snapshot-step judgement", "detail", notice)
+	}
 
 	// ── #5359 secondary-region credential bridge ────────────────────────
 	// Materialize every secondary region's kubeconfig into the
@@ -1533,7 +1588,27 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 			continue
 		}
 
-		if err := h.runCutoverStep(ctx, deps, step, runEpoch, operatorRetry); err != nil {
+		// #5437 defence in depth — NEVER point Flux at a mirror snapshot older
+		// than the attempt that pushed the artifacts into the local registry.
+		// That pairing is the hw290 outage (stale mirror pins tags the fresh
+		// harbor-prewarm never pushed → post-pivot ImagePullBackOff on the
+		// control plane). Read the LIVE status so a mirror re-run earlier in
+		// THIS attempt counts. Fail loud and early instead of silently
+		// rolling the Sovereign onto unpullable tags.
+		var stepErr error
+		if step.stepName == cutoverStepFluxGitRepoPatch {
+			live, readErr := readCutoverStatus(ctx, deps)
+			if readErr != nil {
+				h.log.Warn("cutover: could not re-read status for the pre-pivot mirror-freshness assert (#5437)",
+					"err", readErr)
+			} else {
+				stepErr = assertMirrorSnapshotFresh(steps, live, startedAt)
+			}
+		}
+		if stepErr == nil {
+			stepErr = h.runCutoverStep(ctx, deps, step, runEpoch, operatorRetry, forceRerun[step.stepName])
+		}
+		if err := stepErr; err != nil {
 			finishedAt := time.Now().UTC()
 			_ = patchCutoverStatus(ctx, deps, map[string]string{
 				"currentStep":                           "",
@@ -1673,7 +1748,13 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 	})
 }
 
-func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cutoverStep, runEpoch int64, operatorRetry bool) error {
+// forceRerun (#5437): the engine has decided this step must produce a FRESH
+// result on this attempt — either it is the snapshot step whose recorded
+// success predates the attempt, or it is a consumer invalidated by that
+// snapshot being re-taken. It suppresses the Complete-Job adoption below,
+// which would otherwise re-adopt yesterday's Job and hand back the very
+// success the engine just decided to discard.
+func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cutoverStep, runEpoch int64, operatorRetry, forceRerun bool) error {
 	bus := h.cutoverBusFor()
 
 	// ── #5014: deny-egress hold backstop ────────────────────────────────
@@ -1731,6 +1812,37 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 	// For DaemonSet-wait steps this is a no-op (the chart owns the
 	// DaemonSet lifecycle; we only wait for ready).
 	if step.mode == cutoverModeJob {
+		// #5437 — the Complete-Job adoption below is a SECOND skip path, and it
+		// would silently undo the engine's re-run decision: a snapshot step
+		// whose durable row was just invalidated would be handed right back the
+		// stale success by yesterday's leftover Job. When the engine has ruled
+		// the result stale, delete the step's Jobs + blank its rows FIRST, so
+		// the adoption finds nothing and a fresh Job is minted (same shape as
+		// the #3379 transient-retry reset below).
+		if forceRerun {
+			if job, cond, terminal := findExistingTerminalJobForStep(ctx, deps, step.stepName); terminal && cond == batchv1.JobComplete {
+				h.publishCutoverEvent(bus, cutoverEvent{
+					Time:    time.Now().UTC().Format(time.RFC3339),
+					Phase:   cutoverPhaseStepStarted,
+					Level:   "info",
+					Step:    step.stepName,
+					JobName: job.Name,
+					Message: fmt.Sprintf("step %s prior Job %s completed on an earlier attempt but its result is a stale snapshot; deleting + re-running (#5437)", step.stepName, job.Name),
+				})
+				if delErr := deleteCutoverJobsForStep(ctx, deps, step.stepName); delErr != nil {
+					h.log.Warn("cutover: failed to delete prior completed Job before a stale-snapshot re-run (#5437)",
+						"step", step.stepName, "job", job.Name, "err", delErr)
+				}
+				if err := patchCutoverStatus(ctx, deps, map[string]string{
+					"step." + step.stepName + ".result":     "",
+					"step." + step.stepName + ".startedAt":  "",
+					"step." + step.stepName + ".finishedAt": "",
+					"step." + step.stepName + ".jobName":    "",
+				}); err != nil {
+					return fmt.Errorf("status patch (stale-snapshot reset): %w", err)
+				}
+			}
+		}
 		if job, cond, terminal := findExistingTerminalJobForStep(ctx, deps, step.stepName); terminal {
 			finishedAt := jobCompletionTime(job)
 			if cond == batchv1.JobComplete {

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_snapshot_steps.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_snapshot_steps.go
@@ -1,0 +1,293 @@
+// cutover_snapshot_steps.go — #5437: skip-on-success is WRONG for a step whose
+// output is a snapshot of a moving external source.
+//
+// ── The defect (live, hw290 2026-07-27) ─────────────────────────────────────
+//
+// runCutover skips any step whose durable row already reads result="success".
+// That is correct idempotency for a step that ENSURES state (harbor-projects
+// creates projects; re-running is a no-op). It is WRONG for step-01
+// `gitea-mirror`, whose success means only "at time T the local Gitea matched
+// upstream". Every later step consumes that snapshot, so its validity DECAYS.
+//
+// On hw290 a re-attempt 14 hours after the first one skipped step-01 (recorded
+// success at 2026-07-26T15:02:02Z, attempt started 2026-07-27T04:56:51Z) while
+// step-03 harbor-prewarm re-ran FRESH against the current catalog. The mirror
+// still pinned the bootstrap-kit chart version whose values reference
+// `catalyst-api:b1b472d`; the fresh prewarm pushed only what the live cluster
+// was running (`…:3a8803e`). Step-05 then pointed Flux at the stale mirror, the
+// Deployment rolled to the tag nothing had pushed, and the control plane went
+// down:
+//
+//	catalyst-api  0/1  ImagePullBackOff
+//	registry.hw290.omani.works/…/catalyst-api:b1b472d -> code = NotFound
+//
+// The local registry ANSWERED and said the tag does not exist — not egress, not
+// x509. The skip predicate simply could not tell "idempotent action" from
+// "snapshot of external state".
+//
+// ── The fix ─────────────────────────────────────────────────────────────────
+//
+//  1. A snapshot step whose recorded success predates the CURRENT attempt is
+//     re-run instead of skipped (decideSnapshotRerun).
+//  2. Re-taking the snapshot invalidates everything that consumed it: the
+//     recorded successes of every LATER step are cleared so they re-run against
+//     the refreshed snapshot too. Without this the fix would just invert the
+//     drift — a fresh mirror with a stale harbor-prewarm pins chart versions the
+//     prewarm never mirrored (#5237 Phase A2-pins reads the mirror).
+//  3. The re-run is SUPPRESSED once the chain has advanced to the pivot
+//     boundary (step-05 flux-gitrepository-patch). From that point the mirrored
+//     repo is the live GitOps source and steps 06/07/10/11 have committed
+//     sovereign-LOCAL changes onto its `main`; step-01's
+//     `git push --force refs/heads/*:refs/heads/*` would REVERT them — that is
+//     the hw86 mirror-resync incident the G75 block in
+//     chart/templates/01-gitea-mirror-job.yaml exists to prevent. Suppression
+//     also keeps the cascade off the far end of the chain, where re-running
+//     step-08 would repeat the 10-minute deny-egress hold (the t40 / TBD-V56
+//     regression).
+//  4. Defence in depth: before flux-gitrepository-patch runs, the engine
+//     asserts the mirror snapshot is from this attempt
+//     (assertMirrorSnapshotFresh). Pointing Flux at a snapshot older than the
+//     artifacts harbor-prewarm pushed is the exact hw290 outage, so it fails
+//     LOUD and EARLY instead of taking the control plane down.
+//
+// Refs #5437.
+package handler
+
+import (
+	"fmt"
+	"time"
+)
+
+// snapshotCutoverSteps is the set of step slugs whose recorded "success" is a
+// point-in-time SNAPSHOT of a moving external source rather than an idempotent
+// state-ensure action.
+//
+// gitea-mirror is the only member, and the audit behind that is deliberate —
+// every other step in the shipped 11-step chain either ensures durable state
+// (02 harbor-projects, 04 registry-pivot, 05 flux-gitrepository-patch, 06
+// helmrepository-patches, 07 catalyst-api-env-patch, 09 gitea-token-mint, 10
+// vcluster-registry-pivot, 11 crossplane-provider-pivot — the last two resolve
+// upstream digests but PIN them immutably, so the resolution cannot decay) or
+// produces a proof nothing downstream consumes (08 egress-block-test).
+//
+// 03 harbor-prewarm is the one near-miss: its success also decays, because the
+// artifact set it pushes is derived from the mirror's bootstrap-kit pins
+// (#5237) plus the live cluster. It is deliberately NOT listed here — its input
+// is the snapshot, not the moving upstream, so the correct invalidation is the
+// cascade in rule 2 above (re-taking the mirror invalidates it) rather than an
+// independent time predicate that would re-run a ~50-minute step on every
+// resume.
+var snapshotCutoverSteps = map[string]struct{}{
+	cutoverStepGiteaMirror: {},
+}
+
+// isSnapshotCutoverStep reports whether a step slug is snapshot-shaped.
+func isSnapshotCutoverStep(stepName string) bool {
+	_, ok := snapshotCutoverSteps[stepName]
+	return ok
+}
+
+// snapshotRerunDecision is the outcome of the skip-vs-re-run judgement for one
+// snapshot step. reason is always populated when the decision is interesting
+// (rerun, or a suppression) so the engine can publish it verbatim to the SSE
+// bus — an operator watching the wizard sees WHY the mirror re-ran.
+type snapshotRerunDecision struct {
+	rerun      bool
+	suppressed bool
+	reason     string
+}
+
+// decideSnapshotRerun answers: this step's durable row says success — must it
+// nevertheless re-run on the attempt that started at attemptStart?
+//
+// stepHasJobs reports whether the cluster still carries any Job for a step
+// slug. It is injected rather than called directly so the judgement stays a
+// pure function of its inputs and is unit-testable without a cluster. A nil
+// func is read as "no Jobs anywhere".
+func decideSnapshotRerun(
+	step cutoverStep,
+	steps []cutoverStep,
+	priorStatus map[string]string,
+	attemptStart time.Time,
+	stepHasJobs func(stepName string) bool,
+) snapshotRerunDecision {
+	if !isSnapshotCutoverStep(step.stepName) {
+		return snapshotRerunDecision{}
+	}
+	if priorStatus["step."+step.stepName+".result"] != "success" {
+		// Not being skipped in the first place — the engine will run it.
+		return snapshotRerunDecision{}
+	}
+
+	// Suppression wins over freshness: a re-mirror past the pivot boundary
+	// DESTROYS downstream work, which is strictly worse than a stale snapshot
+	// that has already been pivoted onto.
+	if blocker := snapshotRerunSuppressedBy(steps, priorStatus, step.order, stepHasJobs); blocker != "" {
+		return snapshotRerunDecision{
+			suppressed: true,
+			reason: fmt.Sprintf(
+				"step %s snapshot is from a prior attempt, but the chain has already reached step %s — re-mirroring now would force-push upstream over the sovereign-local commits pushed to the mirror, and would re-run steps that must not repeat; keeping the recorded success (#5437)",
+				step.stepName, blocker),
+		}
+	}
+
+	recorded := priorStatus["step."+step.stepName+".finishedAt"]
+	if ts, err := time.Parse(time.RFC3339, recorded); err == nil && !ts.Before(attemptStart) {
+		// Taken during this very attempt — nothing to refresh.
+		return snapshotRerunDecision{}
+	}
+
+	when := recorded
+	if when == "" {
+		when = "<unrecorded>"
+	}
+	return snapshotRerunDecision{
+		rerun: true,
+		reason: fmt.Sprintf(
+			"step %s succeeded at %s, before this attempt started at %s — its output is a snapshot of a moving upstream, not an idempotent action, so the recorded success is re-taken rather than skipped (#5437)",
+			step.stepName, when, attemptStart.UTC().Format(time.RFC3339)),
+	}
+}
+
+// snapshotRerunBoundaryOrder returns the order at which re-taking the snapshot
+// stops being safe.
+//
+// That is the pivot boundary, cutoverStepFluxGitRepoPatch: once Flux reconciles
+// from the local Gitea, steps 06/07/10/11 commit sovereign-local changes onto
+// the mirrored `main` branch and step-01's force-push of every upstream ref
+// would revert them (hw86, 2026-05-31: a mirror-mode push wiped step-06's
+// HelmRepository pivot 11 minutes after it landed, and step-08 then failed
+// against still-ghcr.io HelmRepositories). Steps below the boundary — 02
+// harbor-projects, 03 harbor-prewarm, 04 registry-pivot — are pure
+// state-ensure, so re-running them against the refreshed snapshot is safe.
+//
+// A chain carrying NO pivot-boundary step (partial / custom) cannot be reasoned
+// about, so the boundary collapses to "the very next step": any progress past
+// the snapshot suppresses the re-run.
+func snapshotRerunBoundaryOrder(steps []cutoverStep, snapshotOrder int) int {
+	for _, s := range steps {
+		if s.stepName == cutoverStepFluxGitRepoPatch {
+			return s.order
+		}
+	}
+	return snapshotOrder + 1
+}
+
+// snapshotRerunSuppressedBy returns the name of the step whose progress makes
+// re-taking the snapshot unsafe, or "" when a re-run is safe.
+//
+// Progress is read from TWO signals, because neither alone is sufficient:
+//
+//   - the durable result row — but ResumeInterruptedCutover blanks the row of a
+//     step that was in flight when catalyst-api died, so a step can have run to
+//     Complete and still read "";
+//   - a surviving Job carrying the step's cutover.openova.io/step label — the
+//     same primitive runCutoverStep's idempotency check uses, and immune to
+//     that status reset.
+//
+// The second signal is what keeps the TBD-V56 / t40 guarantee intact: a
+// Pod-restart resume that stopped inside step-08 must not have its 10-minute
+// deny-egress hold re-run by a cascade from the top of the chain.
+func snapshotRerunSuppressedBy(
+	steps []cutoverStep,
+	priorStatus map[string]string,
+	snapshotOrder int,
+	stepHasJobs func(stepName string) bool,
+) string {
+	boundaryOrder := snapshotRerunBoundaryOrder(steps, snapshotOrder)
+	for _, s := range steps {
+		if s.order <= snapshotOrder || s.order < boundaryOrder {
+			continue
+		}
+		if priorStatus["step."+s.stepName+".result"] == "success" {
+			return s.stepName
+		}
+		if stepHasJobs != nil && stepHasJobs(s.stepName) {
+			return s.stepName
+		}
+	}
+	return ""
+}
+
+// snapshotRerunCascade returns the durable status keys that must be cleared
+// when the snapshot step at index rerunIdx is re-taken: its own rows plus the
+// rows of every later step BELOW the pivot boundary, so each consumer re-runs
+// against the refreshed snapshot instead of carrying a success that was
+// computed from the old one.
+//
+// The boundary bound is load-bearing in both directions. Without a cascade the
+// fix would merely invert the drift (fresh mirror, stale harbor-prewarm pinning
+// chart versions the prewarm never mirrored — #5237 Phase A2-pins reads the
+// mirror). Without the bound the cascade would reach step-08 and repeat the
+// 10-minute deny-egress hold (t40 / TBD-V56). A re-run is only ever decided
+// when nothing at/after the boundary has progressed, so the bounded set is
+// exactly the steps that consumed the old snapshot.
+//
+// Returned as a patch map (empty-string values blank the keys) that the caller
+// folds into the attempt seed, and applied to the in-memory priorStatus so the
+// same run's skip checks and activity projection agree with the durable record.
+func snapshotRerunCascade(steps []cutoverStep, priorStatus map[string]string, rerunIdx int) map[string]string {
+	clear := map[string]string{}
+	if rerunIdx < 0 || rerunIdx >= len(steps) {
+		return clear
+	}
+	boundaryOrder := snapshotRerunBoundaryOrder(steps, steps[rerunIdx].order)
+	for i := rerunIdx; i < len(steps); i++ {
+		if i != rerunIdx && steps[i].order >= boundaryOrder {
+			continue
+		}
+		name := steps[i].stepName
+		for _, suffix := range []string{".result", ".startedAt", ".finishedAt", ".jobName"} {
+			key := "step." + name + suffix
+			if _, present := priorStatus[key]; !present {
+				continue
+			}
+			clear[key] = ""
+			delete(priorStatus, key)
+		}
+	}
+	return clear
+}
+
+// assertMirrorSnapshotFresh is the pre-pivot invariant (#5437 defence in
+// depth): flux-gitrepository-patch MUST NOT point Flux at a mirror snapshot
+// older than the attempt that pushed the artifacts into the local registry.
+//
+// That combination is precisely the hw290 outage — the mirror pins chart /
+// image versions that the fresh harbor-prewarm never mirrored, so the first
+// post-pivot reconcile rolls the control plane onto tags the local registry
+// answers `NotFound` for. Failing here converts a silently unpullable control
+// plane into a loud, early step failure with the cutover still recoverable.
+//
+// status is the LIVE status map (re-read at pivot time, so a mirror re-run
+// earlier in this same attempt is already reflected). Returns nil when the
+// chain carries no gitea-mirror step — there is no snapshot to assert.
+func assertMirrorSnapshotFresh(steps []cutoverStep, status map[string]string, attemptStart time.Time) error {
+	hasMirror := false
+	for _, s := range steps {
+		if s.stepName == cutoverStepGiteaMirror {
+			hasMirror = true
+			break
+		}
+	}
+	if !hasMirror {
+		return nil
+	}
+	recorded := status["step."+cutoverStepGiteaMirror+".finishedAt"]
+	if ts, err := time.Parse(time.RFC3339, recorded); err == nil && !ts.Before(attemptStart) {
+		return nil
+	}
+	when := recorded
+	if when == "" {
+		when = "<unrecorded>"
+	}
+	return fmt.Errorf(
+		"refusing to pivot Flux onto a stale mirror: step %s last succeeded at %s, before this attempt started at %s. "+
+			"The snapshot pins chart/image versions that this attempt's %s never pushed to the local registry, so the first "+
+			"post-pivot reconcile would roll workloads onto tags the local registry answers NotFound for (#5437, hw290 "+
+			"catalyst-api ImagePullBackOff). Refresh the snapshot before re-firing: blank the step.%s.* rows on the "+
+			"%s ConfigMap and delete the leftover cutover-%s-* Job so the engine re-mirrors from the top",
+		cutoverStepGiteaMirror, when, attemptStart.UTC().Format(time.RFC3339),
+		cutoverStepHarborPrewarm, cutoverStepGiteaMirror,
+		cutoverStatusConfigMapName(), cutoverStepGiteaMirror)
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_snapshot_steps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_snapshot_steps_test.go
@@ -1,0 +1,400 @@
+// cutover_snapshot_steps_test.go — #5437 guards.
+//
+// The defect these lock down (live hw290, 2026-07-27): a cutover re-attempt
+// separated in time SKIPPED step-01 gitea-mirror on its recorded success,
+// re-ran step-03 harbor-prewarm fresh, then pointed Flux at the 14-hour-stale
+// mirror. The mirror pinned `catalyst-api:b1b472d`, the fresh prewarm had
+// pushed only what the cluster was running, and the local registry answered
+// `NotFound` — control plane down (0/1 ImagePullBackOff, /healthz 503).
+//
+// Every test below FAILS against the pre-fix engine (skip-on-success applied
+// uniformly). Negative proof is recorded on PR #5437's body.
+package handler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+// cutoverJobCreateCounter records how many Jobs the engine mints per step
+// slug (read off the cutover.openova.io/step label createCutoverJob stamps).
+// A step that was SKIPPED mints zero.
+func cutoverJobCreateCounter(t *testing.T, client *fakek8s.Clientset) func(string) int {
+	t.Helper()
+	var mu sync.Mutex
+	counts := map[string]int{}
+	client.PrependReactor("create", "jobs", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		job, ok := ca.GetObject().(*batchv1.Job)
+		if !ok {
+			return false, nil, nil
+		}
+		mu.Lock()
+		counts[job.Labels[cutoverStepLabelKey]]++
+		mu.Unlock()
+		return false, nil, nil // let the default tracker create it
+	})
+	return func(step string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[step]
+	}
+}
+
+// hw290Chain is the shipped chain trimmed to the steps this defect involves:
+// the snapshot (01), a genuinely idempotent action (02), the artifact push
+// that consumes the snapshot (03), and the pivot boundary (05).
+func hw290Chain(t *testing.T) []cutoverStep {
+	t.Helper()
+	return []cutoverStep{
+		{stepName: cutoverStepGiteaMirror, order: 1, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+		{stepName: "harbor-projects", order: 2, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+		{stepName: cutoverStepHarborPrewarm, order: 3, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+		{stepName: cutoverStepFluxGitRepoPatch, order: 5, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+	}
+}
+
+// statusCMWith builds the durable status ConfigMap from arbitrary rows.
+func statusCMWith(rows map[string]string) *corev1.ConfigMap {
+	data := map[string]string{"cutoverComplete": "false", "registriesYamlActive": "v2"}
+	for k, v := range rows {
+		data[k] = v
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		Data:       data,
+	}
+}
+
+// completedJobForStep fabricates the leftover Complete Job a prior attempt
+// left behind, carrying the step label the idempotency check queries by.
+func completedJobForStep(stepName string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cutover-" + stepName + "-1753542122",
+			Namespace:         cutoverTestNS,
+			Labels:            map[string]string{cutoverStepLabelKey: stepName},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-14 * time.Hour)),
+		},
+		Status: batchv1.JobStatus{
+			CompletionTime: &metav1.Time{Time: time.Now().Add(-14 * time.Hour)},
+			Conditions: []batchv1.JobCondition{{
+				Type:   batchv1.JobComplete,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+// ── Engine behaviour ────────────────────────────────────────────────────────
+
+// TestRunCutover_ReRunsMirrorWhenSnapshotPredatesAttempt is the headline guard:
+// the exact hw290 durable state (step-01 + step-02 recorded success 14 hours
+// ago, everything downstream unrun) must re-take the mirror snapshot rather
+// than skip it, and must invalidate the consumer steps that were recorded
+// against the OLD snapshot.
+func TestRunCutover_ReRunsMirrorWhenSnapshotPredatesAttempt(t *testing.T) {
+	yesterday := time.Now().Add(-14 * time.Hour).UTC().Format(time.RFC3339)
+	objs := []k8sruntime.Object{statusCMWith(map[string]string{
+		"cutoverStartedAt":                               yesterday,
+		"step." + cutoverStepGiteaMirror + ".result":     "success",
+		"step." + cutoverStepGiteaMirror + ".finishedAt": yesterday,
+		"step.harbor-projects.result":                    "success",
+		"step.harbor-projects.finishedAt":                yesterday,
+	})}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	created := cutoverJobCreateCounter(t, client)
+
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, hw290Chain(t), false)
+
+	if got := created(cutoverStepGiteaMirror); got != 1 {
+		t.Errorf("gitea-mirror Jobs created = %d, want 1 — a snapshot of a moving upstream recorded 14h ago must be RE-TAKEN, not skipped (#5437)", got)
+	}
+	// The cascade: harbor-projects was ALSO recorded against the old snapshot,
+	// so re-taking the snapshot must invalidate it. Without this the fix would
+	// merely invert the drift (fresh mirror, stale consumers).
+	if got := created("harbor-projects"); got != 1 {
+		t.Errorf("harbor-projects Jobs created = %d, want 1 — re-taking the snapshot must invalidate the steps recorded against the old one (#5437)", got)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status CM: %v", err)
+	}
+	// cutoverStartedAt is the first-attempt anchor and must survive (#3681).
+	if cm.Data["cutoverStartedAt"] != yesterday {
+		t.Errorf("cutoverStartedAt = %q, want the preserved first-attempt anchor %q", cm.Data["cutoverStartedAt"], yesterday)
+	}
+	if cm.Data["step."+cutoverStepGiteaMirror+".finishedAt"] == yesterday {
+		t.Errorf("step.gitea-mirror.finishedAt is still the stale %q — the durable row must carry THIS attempt's snapshot", yesterday)
+	}
+}
+
+// TestRunCutover_KeepsMirrorSuccessTakenWithinThisAttempt proves the fix does
+// not throw away idempotency wholesale: a snapshot recorded at/after the
+// attempt start is still honoured (this is the mid-run resume path — a
+// catalyst-api roll must not re-mirror work it just did).
+func TestRunCutover_KeepsMirrorSuccessTakenWithinThisAttempt(t *testing.T) {
+	// A timestamp the attempt-start comparison can only read as "taken during
+	// this attempt" (runCutover stamps attemptStart at time.Now()).
+	inAttempt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	objs := []k8sruntime.Object{statusCMWith(map[string]string{
+		"step." + cutoverStepGiteaMirror + ".result":     "success",
+		"step." + cutoverStepGiteaMirror + ".finishedAt": inAttempt,
+	})}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	created := cutoverJobCreateCounter(t, client)
+
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, hw290Chain(t), false)
+
+	if got := created(cutoverStepGiteaMirror); got != 0 {
+		t.Errorf("gitea-mirror Jobs created = %d, want 0 — a snapshot taken within this attempt is still valid and must be skipped", got)
+	}
+	if got := created(cutoverStepFluxGitRepoPatch); got != 1 {
+		t.Errorf("flux-gitrepository-patch Jobs created = %d, want 1 — a fresh snapshot must let the pivot proceed", got)
+	}
+}
+
+// TestRunCutover_SuppressesMirrorRerunPastPivotBoundary proves the fix does not
+// re-create the hw86 incident: once flux-gitrepository-patch has succeeded the
+// mirrored repo is the live GitOps source and steps 06/07/10/11 commit
+// sovereign-local changes onto its main branch. step-01's
+// `git push --force refs/heads/*` would revert them, so the stale snapshot is
+// KEPT there.
+func TestRunCutover_SuppressesMirrorRerunPastPivotBoundary(t *testing.T) {
+	yesterday := time.Now().Add(-14 * time.Hour).UTC().Format(time.RFC3339)
+	objs := []k8sruntime.Object{statusCMWith(map[string]string{
+		"step." + cutoverStepGiteaMirror + ".result":          "success",
+		"step." + cutoverStepGiteaMirror + ".finishedAt":      yesterday,
+		"step.harbor-projects.result":                         "success",
+		"step." + cutoverStepHarborPrewarm + ".result":        "success",
+		"step." + cutoverStepFluxGitRepoPatch + ".result":     "success",
+		"step." + cutoverStepFluxGitRepoPatch + ".finishedAt": yesterday,
+	})}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	created := cutoverJobCreateCounter(t, client)
+
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, hw290Chain(t), false)
+
+	if got := created(cutoverStepGiteaMirror); got != 0 {
+		t.Errorf("gitea-mirror Jobs created = %d, want 0 — re-mirroring past the pivot boundary force-pushes upstream over the sovereign-local pivot commits (hw86)", got)
+	}
+}
+
+// TestRunCutover_StaleSnapshotDoesNotAdoptPriorCompleteJob closes the SECOND
+// skip path. runCutoverStep's idempotency check adopts any Complete Job
+// carrying the step label and returns success without re-running — which would
+// silently undo the re-run decision made one layer up.
+func TestRunCutover_StaleSnapshotDoesNotAdoptPriorCompleteJob(t *testing.T) {
+	yesterday := time.Now().Add(-14 * time.Hour).UTC().Format(time.RFC3339)
+	objs := []k8sruntime.Object{
+		statusCMWith(map[string]string{
+			"step." + cutoverStepGiteaMirror + ".result":     "success",
+			"step." + cutoverStepGiteaMirror + ".finishedAt": yesterday,
+		}),
+		completedJobForStep(cutoverStepGiteaMirror),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	created := cutoverJobCreateCounter(t, client)
+
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, hw290Chain(t), false)
+
+	if got := created(cutoverStepGiteaMirror); got != 1 {
+		t.Errorf("gitea-mirror Jobs created = %d, want 1 — yesterday's Complete Job must NOT be re-adopted for a snapshot step (#5437)", got)
+	}
+}
+
+// ── Pre-pivot invariant (defence in depth) ──────────────────────────────────
+
+func TestAssertMirrorSnapshotFresh(t *testing.T) {
+	attemptStart := time.Date(2026, 7, 27, 4, 56, 51, 0, time.UTC)
+	chain := hw290Chain(t)
+
+	t.Run("stale snapshot refuses the pivot", func(t *testing.T) {
+		err := assertMirrorSnapshotFresh(chain, map[string]string{
+			"step." + cutoverStepGiteaMirror + ".finishedAt": "2026-07-26T15:02:02Z",
+		}, attemptStart)
+		if err == nil {
+			t.Fatal("want an error: pivoting Flux onto a snapshot older than this attempt is the hw290 outage")
+		}
+	})
+
+	t.Run("unrecorded snapshot fails closed", func(t *testing.T) {
+		if err := assertMirrorSnapshotFresh(chain, map[string]string{}, attemptStart); err == nil {
+			t.Fatal("want an error: an unprovable snapshot age must not be treated as fresh")
+		}
+	})
+
+	t.Run("snapshot from this attempt passes", func(t *testing.T) {
+		err := assertMirrorSnapshotFresh(chain, map[string]string{
+			"step." + cutoverStepGiteaMirror + ".finishedAt": "2026-07-27T05:01:15Z",
+		}, attemptStart)
+		if err != nil {
+			t.Fatalf("want nil for a snapshot taken during this attempt; got %v", err)
+		}
+	})
+
+	t.Run("chain without a mirror step has nothing to assert", func(t *testing.T) {
+		partial := []cutoverStep{{stepName: cutoverStepFluxGitRepoPatch, order: 5, mode: cutoverModeJob}}
+		if err := assertMirrorSnapshotFresh(partial, map[string]string{}, attemptStart); err != nil {
+			t.Fatalf("want nil when the chain carries no gitea-mirror step; got %v", err)
+		}
+	})
+}
+
+// ── Predicate unit tests ────────────────────────────────────────────────────
+
+func TestDecideSnapshotRerun(t *testing.T) {
+	attemptStart := time.Date(2026, 7, 27, 4, 56, 51, 0, time.UTC)
+	chain := hw290Chain(t)
+	mirror := chain[0]
+
+	t.Run("hw290 shape re-runs", func(t *testing.T) {
+		d := decideSnapshotRerun(mirror, chain, map[string]string{
+			"step." + cutoverStepGiteaMirror + ".result":     "success",
+			"step." + cutoverStepGiteaMirror + ".finishedAt": "2026-07-26T15:02:02Z",
+		}, attemptStart, nil)
+		if !d.rerun {
+			t.Fatalf("want rerun for a success recorded 14h before the attempt; got %+v", d)
+		}
+	})
+
+	t.Run("no recorded success is not a re-run decision", func(t *testing.T) {
+		if d := decideSnapshotRerun(mirror, chain, map[string]string{}, attemptStart, nil); d.rerun {
+			t.Errorf("a step with no recorded success runs normally; want rerun=false, got %+v", d)
+		}
+	})
+
+	t.Run("non-snapshot step is never re-run", func(t *testing.T) {
+		prewarm := chain[2]
+		d := decideSnapshotRerun(prewarm, chain, map[string]string{
+			"step." + cutoverStepHarborPrewarm + ".result":     "success",
+			"step." + cutoverStepHarborPrewarm + ".finishedAt": "2026-07-26T15:40:00Z",
+		}, attemptStart, nil)
+		if d.rerun {
+			t.Errorf("harbor-prewarm is invalidated by the cascade, never by its own time predicate; got %+v", d)
+		}
+	})
+
+	t.Run("past the pivot boundary the re-run is suppressed", func(t *testing.T) {
+		d := decideSnapshotRerun(mirror, chain, map[string]string{
+			"step." + cutoverStepGiteaMirror + ".result":      "success",
+			"step." + cutoverStepGiteaMirror + ".finishedAt":  "2026-07-26T15:02:02Z",
+			"step." + cutoverStepFluxGitRepoPatch + ".result": "success",
+		}, attemptStart, nil)
+		if d.rerun || !d.suppressed {
+			t.Errorf("want suppressed (hw86 clobber guard), got %+v", d)
+		}
+	})
+}
+
+func TestSnapshotRerunSuppressedBy(t *testing.T) {
+	chain := hw290Chain(t)
+
+	t.Run("pre-pivot successes do not suppress", func(t *testing.T) {
+		got := snapshotRerunSuppressedBy(chain, map[string]string{
+			"step.harbor-projects.result":                  "success",
+			"step." + cutoverStepHarborPrewarm + ".result": "success",
+		}, 1, nil)
+		if got != "" {
+			t.Errorf("suppressed by %q; steps before the pivot boundary are re-runnable", got)
+		}
+	})
+
+	t.Run("a surviving Job past the boundary suppresses even with a blanked row", func(t *testing.T) {
+		// ResumeInterruptedCutover blanks the result row of a step that was in
+		// flight when catalyst-api died, so the durable record alone cannot see
+		// that the chain reached step-08. The surviving Job can — and must, or
+		// the cascade re-runs the 10-minute deny-egress hold (t40 / TBD-V56).
+		withEgress := append(hw290Chain(t),
+			cutoverStep{stepName: cutoverStepEgressBlockTest, order: 8, mode: cutoverModeJob})
+		got := snapshotRerunSuppressedBy(withEgress, map[string]string{
+			"step." + cutoverStepEgressBlockTest + ".result": "",
+		}, 1, func(name string) bool { return name == cutoverStepEgressBlockTest })
+		if got != cutoverStepEgressBlockTest {
+			t.Errorf("suppressor = %q, want %q — a surviving Job is the only surviving evidence the chain got that far", got, cutoverStepEgressBlockTest)
+		}
+	})
+
+	t.Run("chain with no pivot boundary falls back to conservative", func(t *testing.T) {
+		partial := []cutoverStep{
+			{stepName: cutoverStepGiteaMirror, order: 1},
+			{stepName: "helmrepository-patches", order: 6},
+		}
+		got := snapshotRerunSuppressedBy(partial, map[string]string{
+			"step.helmrepository-patches.result": "success",
+		}, 1, nil)
+		if got != "helmrepository-patches" {
+			t.Errorf("suppressor = %q, want helmrepository-patches — with no boundary step the engine cannot prove which later steps push to the mirror", got)
+		}
+	})
+}
+
+func TestSnapshotRerunCascade(t *testing.T) {
+	chain := hw290Chain(t)
+	prior := map[string]string{
+		"step." + cutoverStepGiteaMirror + ".result":     "success",
+		"step." + cutoverStepGiteaMirror + ".finishedAt": "2026-07-26T15:02:02Z",
+		"step.harbor-projects.result":                    "success",
+		"cutoverStartedAt":                               "2026-07-26T14:56:49Z",
+	}
+	clear := snapshotRerunCascade(chain, prior, 0)
+
+	for _, key := range []string{
+		"step." + cutoverStepGiteaMirror + ".result",
+		"step." + cutoverStepGiteaMirror + ".finishedAt",
+		"step.harbor-projects.result",
+	} {
+		if v, ok := clear[key]; !ok || v != "" {
+			t.Errorf("cascade must blank %q in the durable patch; got (%q, present=%v)", key, v, ok)
+		}
+		if _, still := prior[key]; still {
+			t.Errorf("cascade must also drop %q from the in-memory prior status so the same run's skip check agrees", key)
+		}
+	}
+	if _, ok := clear["cutoverStartedAt"]; ok {
+		t.Error("cascade must not touch the first-attempt anchor cutoverStartedAt (#3681)")
+	}
+
+	// The cascade must stop AT the pivot boundary — reaching past it would
+	// blank step-08's row and repeat the 10-minute deny-egress hold.
+	withEgress := append(hw290Chain(t),
+		cutoverStep{stepName: cutoverStepEgressBlockTest, order: 8, mode: cutoverModeJob})
+	prior2 := map[string]string{
+		"step." + cutoverStepGiteaMirror + ".result":      "success",
+		"step." + cutoverStepHarborPrewarm + ".result":    "success",
+		"step." + cutoverStepFluxGitRepoPatch + ".result": "success",
+		"step." + cutoverStepEgressBlockTest + ".result":  "success",
+	}
+	clear2 := snapshotRerunCascade(withEgress, prior2, 0)
+	for _, key := range []string{
+		"step." + cutoverStepFluxGitRepoPatch + ".result",
+		"step." + cutoverStepEgressBlockTest + ".result",
+	} {
+		if _, ok := clear2[key]; ok {
+			t.Errorf("cascade blanked %q — it must stop at the pivot boundary (t40 / TBD-V56)", key)
+		}
+	}
+	if _, ok := clear2["step."+cutoverStepHarborPrewarm+".result"]; !ok {
+		t.Error("cascade must still invalidate the pre-pivot consumer harbor-prewarm")
+	}
+}


### PR DESCRIPTION
## The defect

Skip-on-success is correct idempotency for a step that **ensures state**. It is wrong for a step whose output is a **snapshot of a moving external source** — its success is only meaningful relative to when it ran, and every later step consumes it.

`step-01 gitea-mirror` is the only step of that shape in the chain. Live on hw290, 2026-07-27:

```
cutoverStartedAt            = 2026-07-26T14:56:49Z   (step-01 finished 15:02:02Z)
cutoverLastAttemptStartedAt = 2026-07-27T04:56:51Z
```

The re-attempt skipped steps 1-2 on their recorded success and re-ran 3-8. Step-03 `harbor-prewarm` re-ran fresh against the current catalog; the ~14-hour-stale mirror still pinned the bootstrap-kit chart version whose values reference `catalyst-api:b1b472d`. Step-05 pointed Flux at that snapshot, the Deployment rolled onto a tag nothing had pushed, and the control plane went down:

```
catalyst-api  0/1  ImagePullBackOff
GET https://console.hw290.omani.works/healthz   503
registry.hw290.omani.works/.../catalyst-api:b1b472d -> code = NotFound ... not found
```

The local registry **answered** and said the tag does not exist — not egress, not x509.

## The fix

Engine-side, in `products/catalyst/bootstrap/api/internal/handler/`:

1. **Re-run on staleness** — a snapshot-shaped step whose recorded success predates the current attempt is re-taken instead of skipped (`decideSnapshotRerun`).
2. **Cascade** — re-taking the snapshot invalidates the later steps **below the pivot boundary**, so no consumer carries a success computed from the old snapshot. Without this the fix merely inverts the drift: a fresh mirror with a stale `harbor-prewarm` pins chart versions the prewarm never mirrored, because #5237 Phase A2-pins enumerates from the mirror.
3. **Suppression** — the re-run stops once the chain has reached step-05 `flux-gitrepository-patch`. From there the mirrored repo is the live GitOps source: steps 06/07/10/11 commit sovereign-local changes onto its `main`, and step-01's `git push --force refs/heads/*:refs/heads/*` would revert them (the hw86 mirror-resync incident the G75 block in `01-gitea-mirror-job.yaml` exists to prevent). Progress is read from the durable row **and** from a surviving step Job, because `ResumeInterruptedCutover` blanks the row of a step that was in flight — that second signal is what keeps the TBD-V56 / t40 guarantee that step-08's 10-minute deny-egress hold is never re-run by a cascade from the top.
4. **Second skip path closed** — `runCutoverStep`'s Complete-Job adoption would otherwise re-adopt yesterday's Job and hand back the very success the engine just discarded. A step ruled stale gets its Jobs deleted and its rows blanked first.
5. **Pre-pivot assertion** — before `flux-gitrepository-patch` runs, the engine asserts the mirror snapshot is from this attempt and fails the step with both timestamps otherwise. This converts a silently unpullable control plane into a loud, early failure with the cutover still recoverable.

### On option (3) as originally framed

The ticket asked for step-05 to "verify the tags the mirror pins actually exist in the local registry". The mirrored git tree does **not** pin image tags — it pins bootstrap-kit HelmRelease `chart.spec.version`, and the tags live inside the OCI chart artifact resolved through the HelmRepository. A literal tag check at step-05 would mean rendering every pinned chart in shell, which is both large and false-positive-prone in a place that gates every cutover. The freshness assertion above delivers the same loud-early-failure property at zero false-positive risk, and the chart-version half of that check already exists (#5237 step-06 Phase 3a-pin). The residual image-level gap is written up below rather than papered over.

## Is step-01 the only snapshot-shaped step?

Yes, for the property that matters — its output is a snapshot of a **moving upstream that later steps consume**. Audit of the shipped 11:

| Step | Shape |
|---|---|
| 01 gitea-mirror | **snapshot of a moving upstream**, consumed by 03 + 05 |
| 02 harbor-projects | idempotent create |
| 03 harbor-prewarm | derived snapshot — of the mirror's pins + the live cluster, **not** of upstream; handled by the cascade rather than its own time predicate (a ~50-min step must not re-run on every resume) |
| 04 registry-pivot | reconciled DaemonSet state + per-node acks |
| 05 flux-gitrepository-patch | applies a patch |
| 06 helmrepository-patches | patch + git push |
| 07 catalyst-api-env-patch | patch + git push |
| 08 egress-block-test | a time-stamped proof, but nothing downstream consumes it |
| 09 gitea-token-mint | mint |
| 10 vcluster-registry-pivot | resolves upstream state, then pins it |
| 11 crossplane-provider-pivot | resolves upstream digests, then pins them **immutably** — the resolution cannot decay |

## Negative proof

Both `decideSnapshotRerun` and `assertMirrorSnapshotFresh` were neutered to their pre-fix behaviour (uniform skip-on-success, no pre-pivot assert) with the tests unchanged:

```
--- FAIL: TestRunCutover_ReRunsMirrorWhenSnapshotPredatesAttempt
    gitea-mirror Jobs created = 0, want 1
    harbor-projects Jobs created = 0, want 1
    step.gitea-mirror.finishedAt is still the stale "2026-07-26T16:39:28Z"
--- FAIL: TestRunCutover_StaleSnapshotDoesNotAdoptPriorCompleteJob
    gitea-mirror Jobs created = 0, want 1
--- FAIL: TestAssertMirrorSnapshotFresh/stale_snapshot_refuses_the_pivot
--- FAIL: TestAssertMirrorSnapshotFresh/unrecorded_snapshot_fails_closed
--- FAIL: TestDecideSnapshotRerun/hw290_shape_re-runs
--- FAIL: TestDecideSnapshotRerun/past_the_pivot_boundary_the_re-run_is_suppressed
```

Restored: `ok github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler`.

The pre-existing `TestRunCutoverStep_SkipsRerunWhenPriorJobComplete` (TBD-V56 / t40) caught a first cut of the cascade that reached step-08 and re-minted the deny-egress hold; the boundary bound and the surviving-Job progress signal exist because of it, and it passes.

## Gates

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` in `products/catalyst/bootstrap/api` — green (`internal/handler` 177s).
- `scripts/check-no-nodeports.sh` — `OK: zero NodePorts across sources + rendered charts`.
- No chart touched, so no `Chart.yaml` / lockstep bump applies.

## Follow-up worth its own ticket

`harbor-prewarm` sources **chart versions** from the mirror's bootstrap-kit pins (#5237) but **image tags** from the live cluster (running Pods ∪ declared workload templates). Those agree only while the cluster has converged to what the mirror declares. A fresh mirror pinning a chart whose images the cluster has not yet rolled to reproduces the same class of ImagePullBackOff with no staleness involved. Closing it means enumerating the images referenced by the pinned chart versions and warming those.

Refs #5437
