### PR TITLE
fix(provisioning): mount the per-Org postgres PVC at a subPath — lost+found on ext4 EVS made initdb refuse, so no purchased app ever ran (Refs #5445)

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -1119,8 +1119,28 @@ spec:
               cpu: 250m
               memory: 256Mi
           volumeMounts:
+            # #5445 — mount a SUBDIRECTORY of the PVC, never its root.
+            #
+            # Every Huawei EVS volume is ext4, so the filesystem root always
+            # contains a lost+found directory. Mounting the PVC root directly
+            # at PGDATA therefore hands initdb a non-empty directory and it
+            # refuses to initialise the cluster at all:
+            #
+            #   initdb: error: directory /var/lib/postgresql/data exists but is not empty
+            #   initdb: detail: It contains a lost+found directory, perhaps due
+            #                   to it being a mount point.
+            #
+            # Live on hw290 theta-corp this was postgres CrashLoopBackOff x50,
+            # with umami and uptime-kuma crashlooping downstream of it — on an
+            # Org where the GitOps write, the Flux apply and all 20 inventory
+            # entries were green. It is the gap between provisioned and
+            # working, and it is invisible to any check that stops at Flux.
+            #
+            # subPath is preferred over a PGDATA env override because it does
+            # not depend on the image honouring PGDATA.
             - name: pgdata
               mountPath: /var/lib/postgresql/data
+              subPath: pgdata
             - name: initdb
               mountPath: /docker-entrypoint-initdb.d
       volumes:

--- a/core/services/provisioning/gitops/gitops_postgres_subpath_5445_test.go
+++ b/core/services/provisioning/gitops/gitops_postgres_subpath_5445_test.go
@@ -1,0 +1,78 @@
+package gitops
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #5445 — the per-Org postgres PVC must be mounted at a SUBDIRECTORY, never at
+// the volume root.
+//
+// Every Huawei EVS volume is ext4, so its filesystem root always contains a
+// `lost+found` directory. Mounting the PVC root directly at PGDATA hands initdb
+// a non-empty directory and it refuses outright:
+//
+//	initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
+//	initdb: detail: It contains a lost+found directory, perhaps due to it being
+//	                a mount point.
+//
+// Live on hw290 Org theta-corp this was postgres CrashLoopBackOff x50, with
+// umami and uptime-kuma crashlooping downstream — on an Organization where the
+// GitOps write succeeded, Flux applied cleanly, and all 20 inventory entries
+// were present. Every upstream stage was green and not one purchased app ran.
+// That is Pillar 1's terminal acceptance failing at the last step, and it is
+// invisible to any check that stops at Flux inventory.
+//
+// Asserts on the RENDERED manifest rather than on a source constant, so a
+// refactor that reintroduces a root mount by another route still trips it.
+func renderPostgresForTest() string {
+	return generatePostgres(
+		"theta-corp",
+		"pw-not-a-real-secret",
+		[]string{"umami", "uptime-kuma"},
+		map[string]any{},
+		"",
+	)
+}
+
+func TestPerOrgPostgres_MountsSubPathNotVolumeRoot_5445(t *testing.T) {
+	rendered := renderPostgresForTest()
+
+	const pgdataMount = "mountPath: /var/lib/postgresql/data"
+	if !strings.Contains(rendered, pgdataMount) {
+		t.Fatalf("postgres manifest no longer mounts %q — if PGDATA moved, move this guard with it "+
+			"rather than deleting it; the lost+found hazard follows the mount, not the path", pgdataMount)
+	}
+
+	// mountPath and subPath must travel together: capture the pgdata block and
+	// require subPath inside it, before the next list entry.
+	block := regexp.MustCompile(`(?s)- name: pgdata\s*\n(.*?)(?:\n\s*- name: |\n\s*volumes:)`)
+	m := block.FindStringSubmatch(rendered)
+	if m == nil {
+		t.Fatal("could not locate the pgdata volumeMount block in the rendered manifest")
+	}
+	mount := m[1]
+
+	if !strings.Contains(mount, pgdataMount) {
+		t.Fatalf("the pgdata block does not carry %q:\n%s", pgdataMount, mount)
+	}
+	if !strings.Contains(mount, "subPath:") {
+		t.Errorf("pgdata is mounted at the PVC ROOT with no subPath — on ext4 EVS the root contains "+
+			"lost+found, so initdb refuses and NO purchased app ever runs (#5445). Block was:\n%s", mount)
+	}
+}
+
+// The failure this guards is silent at every layer above the container: the
+// manifest is valid, Flux applies it, inventory is non-zero, the Deployment
+// exists. Only the pod logs reveal it. Assert the pre-fix shape directly so a
+// regression cannot hide behind a green Kustomization.
+func TestPerOrgPostgres_RootMountIsNeverRendered_5445(t *testing.T) {
+	rendered := renderPostgresForTest()
+
+	bad := regexp.MustCompile(`- name: pgdata\s*\n\s*mountPath: /var/lib/postgresql/data\s*\n\s*- name:`)
+	if bad.MatchString(rendered) {
+		t.Error("rendered manifest mounts the pgdata PVC root straight at PGDATA with no subPath — " +
+			"this is the #5445 defect verbatim: initdb sees lost+found and never initialises")
+	}
+}


### PR DESCRIPTION
fix(provisioning): mount the per-Org postgres PVC at a subPath — lost+found on ext4 EVS made initdb refuse, so no purchased app ever ran (Refs #5445)

Every Huawei EVS volume is ext4, so its filesystem root always contains a
lost+found directory. gitops.go mounted the PVC root directly at
/var/lib/postgresql/data, which hands initdb a non-empty directory:

  initdb: error: directory /var/lib/postgresql/data exists but is not empty
  initdb: detail: It contains a lost+found directory, perhaps due to it being
                  a mount point.

Live on hw290 Org theta-corp this was postgres CrashLoopBackOff x50, with umami
and uptime-kuma crashlooping downstream because they could not reach a database
that never initialised.

What makes this worth more than its size: theta-corp is the Organization that
PROVES the GitOps writer works. Four apps committed cleanly, the apps
Kustomization Ready=True with 20 inventory entries, every Deployment, Service
and HTTPRoute applied. And not one purchased app runs. That is Pillar 1's
terminal acceptance failing at the last possible step on an Org where every
upstream stage is green, and it is invisible to any check that stops at Flux
inventory.

It is also not either of the two neighbouring defects that produce a similar
"no working app" symptom. The per-Org GitOps CAS race (#5387/#5384) is dead —
theta-corp's four concurrent commits all landed. The vcluster-tier HelmRelease
poisoning the whole Kustomization to inventory=0 (#5423) is not this either —
inventory is 20 and the objects exist. Here the manifests are present, applied
and correct, and the container refuses to start on its own data directory.

subPath rather than a PGDATA env override, because it does not depend on the
image honouring PGDATA.

Guards assert on the RENDERED manifest, not on a source constant, so a refactor
that reintroduces a root mount by another route still trips them. One requires
mountPath and subPath to travel together inside the same pgdata block; the other
asserts the pre-fix shape is never rendered, because this failure is silent at
every layer above the container and could otherwise hide behind a green
Kustomization.

Verified non-vacuous rather than assumed: reverting the subPath makes both
tests FAIL with the live symptom; restoring makes both pass. go build, go vet
and the package tests are clean.

One incidental note for anyone editing this file: the manifest is a Go raw
string literal, so a backtick in a YAML comment terminates it. My first draft
used backticks around lost+found and broke the build at a line 40 below the
edit, which is a confusing place to land.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
