### PR TITLE
fix(catalog): pin 4 registry-verified floating image tags that evade the Kyverno :latest regex (Refs #5397)

### DIFF
--- a/core/services/provisioning/gitops/apps.go
+++ b/core/services/provisioning/gitops/apps.go
@@ -103,7 +103,7 @@ var KnownApps = map[string]AppSpec{
 		EnvVars: map[string]string{},
 	},
 	"umami": {
-		Image: "ghcr.io/umami-software/umami:postgresql-latest", Port: 3000,
+		Image: "ghcr.io/umami-software/umami:postgresql-v2.9.0", Port: 3000,
 		NeedsDB: "postgres",
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
@@ -150,13 +150,13 @@ var KnownApps = map[string]AppSpec{
 		EnvVars: map[string]string{},
 	},
 	"gitea": {
-		Image: "gitea/gitea:1-rootless", Port: 3000,
+		Image: "gitea/gitea:1.27.0-rootless", Port: 3000,
 		NeedsDB: "postgres",
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"uptime-kuma": {
-		Image: "louislam/uptime-kuma:1", Port: 3001,
+		Image: "louislam/uptime-kuma:1.23.17", Port: 3001,
 		NeedsDB: "",
 		// #5410 — was 128Mi/50m, which OOMKilled forever. Live on hw290 Org
 		// theta-corp: 49 restarts, lastState.terminated.reason=OOMKilled, at
@@ -262,7 +262,7 @@ func GetAppSpec(slug string) AppSpec {
 	}
 	if slug == "placeholder" {
 		return AppSpec{
-			Image:    "nginx:1-alpine",
+			Image:    "nginx:1.31.3-alpine",
 			Port:     80,
 			NeedsDB:  "",
 			RAMMI:    "64Mi",


### PR DESCRIPTION
fix(catalog): pin 4 registry-verified floating image tags that evade the Kyverno :latest regex (Refs #5397)

#5397's nine `:latest` pins are already in and digest-verified in the running
binary — `grep -c ':latest' apps.go` returns 0, and the guard at
apps_image_pinned_5397_test.go:56 enforces it. This is the adjacent gap that
audit surfaced.

Kyverno's image-tag-pinned policy matches `^.*:latest$`, so a tag only has to
avoid that exact suffix to pass admission while still being mutable. Four did:

  ghcr.io/umami-software/umami:postgresql-latest -> postgresql-v2.9.0
  gitea/gitea:1-rootless                        -> 1.27.0-rootless
  louislam/uptime-kuma:1                        -> 1.23.17
  nginx:1-alpine                                -> 1.31.3-alpine

umami is the clearest case: literally "latest" with a prefix, admitted because
the regex needs a literal colon before it. The other three are major- or
minor-only tags that silently move under the platform.

Every replacement was resolved against the LIVE registry before being written —
Docker Hub tag lists for gitea/uptime-kuma/nginx, the ghcr tag list for umami.
None was inferred from a version-numbering convention. That matters here more
than usual: a guessed version that does not exist produces exactly the hollow
pin filed tonight as #5444 (bp-alloy listed at 1.0.3, which exists in no
registry) and #5345, where the install fails at chart-pull on a Sovereign that
is by then cut off from the mothership. Writing a plausible-looking version
would have created the defect this repo is currently trying to eliminate.

DELIBERATELY NOT PINNED — three tags whose registries did not return a matching
immutable version on the first page of results:

  wordpress:6-apache
  ghost:5-alpine
  nextcloud:29-apache

These are still floating and still want pinning, but each needs its own registry
lookup and I would rather leave three honest gaps than write three guesses. They
are the remainder of #5397's spirit and belong in a follow-up that verifies each.

Note the runtime leg of #5397 stays open regardless of this commit: theta-corp's
cart was rendered at 19:31Z by an image predating #5398, so the live per-Org git
tree still carries listmonk:latest and vaultwarden/server:latest. Only a fresh
cart install clears that, and PR #5446 (postgres subPath) is what makes such an
install produce anything that actually runs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
