### PR TITLE
fix(cutover): harbor-prewarm mirrors the marketplace's charts and warms the pinned charts' images (Refs #5443 #5442)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1005,7 +1005,26 @@ spec:
       # stepTimeouts.pivotReadbackSeconds. Step count stays 11; no RBAC or
       # deadline change. New chart test tests/step06-pivot-readback.sh
       # asserts on the step's EXIT CODE, not its log text.
-      version: 0.1.153
+      # 0.1.154 (#5443 #5442): step-03 harbor-prewarm mirrors what the
+      # MARKETPLACE OFFERS and warms what the PINNED CHARTS DECLARE. Both
+      # prior enumerations derived from what is INSTALLED (live HelmReleases,
+      # frozen bootstrap-kit pins) while step-06 pivots the catalog resolver
+      # onto local Harbor — hw290 2026-07-27: 14 of 29 `visibility: listed`
+      # entries resolved, 15 404'd against a HOSTED (non-proxy) project. And
+      # image tags came from the LIVE CLUSTER while chart versions came from
+      # the pins, so a fresh mirror pinning a chart the cluster had not rolled
+      # to left catalyst-api/ui/organization-controller ImagePullBackOff on
+      # local tags that never existed — unrecoverable, since catalyst-api
+      # drives the cutover. New shared library 03c (catalog_chart_set /
+      # catalog_guard_missing / chart_declared_images), Phase A2-catalog
+      # (live Blueprint CRs unioned into the mirror; `listed` spec.version is
+      # contractual, everything else best-effort), Phase A2-guard (durable
+      # Harbor artifact-API assert), Phase A3-chart-images + A3-guard (images
+      # rendered FROM every contractual chart, UNIONED with — never replacing
+      # — the live-cluster walk). New RBAC: read-only blueprints. New values:
+      # prewarm.catalogCharts.*, prewarm.chartImages.*. Step count stays 11.
+      # New chart test tests/catalog-chart-set.sh + contract Case 72.
+      version: 0.1.154
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.153
+  version: 0.1.154
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-# 0.1.153 (#5443 Refs #3627 #5237 #5442 — MIRROR WHAT THE MARKETPLACE OFFERS,
+# 0.1.153 (#5443 #5442 Refs #3627 #5237 #5437 — MIRROR WHAT THE MARKETPLACE
+# OFFERS, and WARM WHAT THE PINNED CHARTS DECLARE —
 # not only what is installed. Step-06 pivots `openova-catalog` — the one
 # HelmRepository every per-Org Application HelmRelease resolves through — onto
 # local Harbor, but step-03's two enumerations (Phase A2 live HelmReleases,
@@ -34,23 +35,46 @@ name: bp-self-sovereign-cutover
 #   factored out of dest_already_current so the skip-if-present probe and the
 #   guard cannot fork. This IS the probe that found #5443 and it fails the
 #   cutover with egress still open and the offenders named.
-# • Phase A3-catalog-images (Refs #5442) — prewarm's image enumeration walks the
-#   LIVE cluster's Pods, which by construction cannot see the images of a chart
-#   nobody installed. So each contractual chart is pulled back out of the local
-#   Harbor it was just mirrored into (skopeo dir: transport — no helm-registry
-#   login dance, no extra upstream egress), rendered at DEFAULT values, and
-#   every image the render pins is mirrored through the SAME offline-mirror
-#   resolver + copy_one the live wave uses. `helm template` is faithful rather
-#   than heuristic here because blueprint-release.yaml refuses to publish a
-#   chart that does not render at default values. Best-effort by default
-#   (prewarm.catalogCharts.images.fatal escalates) because a default-values
-#   render cannot see an image behind a per-Org conditional.
+# • Phase A3-chart-images + Phase A3-guard (#5442, folded in — same file, same
+#   enumeration decision) — harbor-prewarm sourced its two inputs from two
+#   places that agree ONLY while the cluster has already converged to what the
+#   mirror declares: chart versions from the mirror's pins, image tags from the
+#   LIVE CLUSTER (running Pods ∪ declared templates). A completely FRESH mirror
+#   pinning a chart whose images the cluster has not rolled to reproduces
+#   ImagePullBackOff with no staleness involved, so it survives #5441. Live
+#   hw290 2026-07-27: catalyst-api, catalyst-ui and
+#   catalyst-organization-controller all ImagePullBackOff on local tags that did
+#   not exist, and the Sovereign could not self-heal because catalyst-api is
+#   what DRIVES the cutover — recovery meant hand-pinning all three back to
+#   ghcr, i.e. re-tethering. #5443's layer-down leg is the same defect from the
+#   other end: a mirrored catalog chart whose images are absent fails at
+#   pod-pull instead of chart-pull, and the live walk by construction cannot see
+#   the images of a chart nobody installed. ONE mechanism closes both: every
+#   chart in the CONTRACTUAL set (live-HR deployed∪desired ∪ frozen
+#   bootstrap-kit pins ∪ contractual catalog entries) is pulled back out of the
+#   local Harbor it was just mirrored into (skopeo dir: transport — no
+#   helm-registry login dance, no extra upstream egress, and it proves the chart
+#   mirror in passing), rendered at DEFAULT values, and every image the render
+#   pins is mirrored through the SAME offline-mirror resolver + copy_one the
+#   live wave uses. Phase A3-guard then re-asserts durable presence of the whole
+#   chart-declared image set through harbor_durable_digest. UNION, NOT
+#   REPLACEMENT: the live-cluster walk is untouched and this set is added to it
+#   — replacing would be strictly worse, since a default-values render cannot
+#   see an image behind a conditional a per-Sovereign overlay turns on, which
+#   the runtime walk does see. A union can only widen coverage, so no cutover
+#   that works today can regress. FATAL by default on a copy failure, an
+#   un-mappable registry host, or a durable-presence miss — the same two
+#   conditions Phase A already FATALs on for the runtime set, applied to the
+#   second input; a chart that fails to RENDER is always a WARN because it makes
+#   no claim about images either way. The enumerator drops untagged, empty-tag
+#   and placeholder-tag refs so an overlay-supplied tag cannot fail a cutover on
+#   a ref nothing will ever pull.
 # New RBAC: read-only get/list/watch on catalyst.openova.io/blueprints.
 # New knobs: prewarm.catalogCharts.{enabled,hardVisibility,guard.enabled,
-# images.{enabled,fatal},blueprintResource,blueprintResourceFallback}. Step
-# count unchanged at 11 (03c carries no cutover-order label). New contract Case
-# 72 + tests/catalog-chart-set.sh exercise the library against fixtures and
-# assert step-03 + RBAC wire it.)
+# blueprintResource,blueprintResourceFallback} + prewarm.chartImages.{enabled,
+# fatal}. Step count unchanged at 11 (03c carries no cutover-order label). New
+# contract Case 72 + tests/catalog-chart-set.sh exercise the library against
+# fixtures and assert step-03 + RBAC wire it.)
 # 0.1.153 (#5436 — step-06 region-A pivot READ-BACK: stop reporting
 # `success` on a half-pivoted Sovereign). Step-06's only region-A failure
 # signal was the Phase-1 `fail` counter, which counts `kubectl patch`

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,56 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.153 (#5443 Refs #3627 #5237 #5442 — MIRROR WHAT THE MARKETPLACE OFFERS,
+# not only what is installed. Step-06 pivots `openova-catalog` — the one
+# HelmRepository every per-Org Application HelmRelease resolves through — onto
+# local Harbor, but step-03's two enumerations (Phase A2 live HelmReleases,
+# Phase A2-pins frozen bootstrap-kit pins) BOTH derive from what is INSTALLED.
+# The marketplace offers what the CATALOG lists; those sets differ by
+# definition and the catalog set is strictly larger. Live hw290 2026-07-27: of
+# 29 `visibility: listed` catalog entries, 14 resolved 200 against the pivoted
+# registry and 15 returned 404 — and the Harbor `openova-io` project is HOSTED
+# (registry_id: None), so there is no proxy-cache fallback and the 404 is
+# final. A cut-over Sovereign advertised 29 installable Blueprints and could
+# install 14; a customer buying any of the other 15 got an unpullable
+# HelmRelease on a Sovereign by then deliberately cut off from the mothership
+# (Pillar 1 and Pillar 5 contradicted at once). NOW: new shared library 03c
+# (cutover-catalog-chart-set — the same one-parser-two-consumers discipline as
+# 03a's resolver and 03b's pin extractor) exposes catalog_chart_set /
+# catalog_guard_missing / catalog_chart_images, all pure. Step-03 gains:
+# • Phase A2-catalog — enumerates the LIVE Blueprint CRs (the set
+#   /api/v1/catalog serves; the catalog-seed only SEEDS them, and the console's
+#   catalog IaC editor + operator curation write the CRs) and unions their
+#   chart:version into the mirror. HARD = `spec.manifests.chart`:`spec.version`
+#   of a `visibility: listed` entry — the exact coordinate the install path
+#   requests (blueprintChart() -> blueprintRef.version -> HR chart.spec.version)
+#   and the customer-visible contract. SOFT = everything else: unlisted/private
+#   entries and `spec.source.version`, which NO controller reads and which is a
+#   known drift surface (#5444). Soft rows mirror best-effort and WARN on
+#   failure, so a stale pin on a Blueprint no customer can install from the grid
+#   cannot hold a cutover hostage; hard rows keep the pre-existing FATAL.
+# • Phase A2-guard — after the mirror, asserts every contractual entry resolves
+#   DURABLY in local Harbor via Harbor CORE's artifact API (its database, never
+#   a pull-through — the #5030 lesson), through harbor_durable_digest, now
+#   factored out of dest_already_current so the skip-if-present probe and the
+#   guard cannot fork. This IS the probe that found #5443 and it fails the
+#   cutover with egress still open and the offenders named.
+# • Phase A3-catalog-images (Refs #5442) — prewarm's image enumeration walks the
+#   LIVE cluster's Pods, which by construction cannot see the images of a chart
+#   nobody installed. So each contractual chart is pulled back out of the local
+#   Harbor it was just mirrored into (skopeo dir: transport — no helm-registry
+#   login dance, no extra upstream egress), rendered at DEFAULT values, and
+#   every image the render pins is mirrored through the SAME offline-mirror
+#   resolver + copy_one the live wave uses. `helm template` is faithful rather
+#   than heuristic here because blueprint-release.yaml refuses to publish a
+#   chart that does not render at default values. Best-effort by default
+#   (prewarm.catalogCharts.images.fatal escalates) because a default-values
+#   render cannot see an image behind a per-Org conditional.
+# New RBAC: read-only get/list/watch on catalyst.openova.io/blueprints.
+# New knobs: prewarm.catalogCharts.{enabled,hardVisibility,guard.enabled,
+# images.{enabled,fatal},blueprintResource,blueprintResourceFallback}. Step
+# count unchanged at 11 (03c carries no cutover-order label). New contract Case
+# 72 + tests/catalog-chart-set.sh exercise the library against fixtures and
+# assert step-03 + RBAC wire it.)
 # 0.1.153 (#5436 — step-06 region-A pivot READ-BACK: stop reporting
 # `success` on a half-pivoted Sovereign). Step-06's only region-A failure
 # signal was the Phase-1 `fail` counter, which counts `kubectl patch`

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -17,7 +17,7 @@ name: bp-self-sovereign-cutover
 # (Pillar 1 and Pillar 5 contradicted at once). NOW: new shared library 03c
 # (cutover-catalog-chart-set — the same one-parser-two-consumers discipline as
 # 03a's resolver and 03b's pin extractor) exposes catalog_chart_set /
-# catalog_guard_missing / catalog_chart_images, all pure. Step-03 gains:
+# catalog_guard_missing / chart_declared_images, all pure. Step-03 gains:
 # • Phase A2-catalog — enumerates the LIVE Blueprint CRs (the set
 #   /api/v1/catalog serves; the catalog-seed only SEEDS them, and the console's
 #   catalog IaC editor + operator curation write the CRs) and unions their

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-# 0.1.153 (#5443 #5442 Refs #3627 #5237 #5437 — MIRROR WHAT THE MARKETPLACE
+# 0.1.154 (#5443 #5442 Refs #3627 #5237 #5437 — MIRROR WHAT THE MARKETPLACE
 # OFFERS, and WARM WHAT THE PINNED CHARTS DECLARE —
 # not only what is installed. Step-06 pivots `openova-catalog` — the one
 # HelmRepository every per-Org Application HelmRelease resolves through — onto
@@ -2761,7 +2761,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.153
+version: 0.1.154
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -329,6 +329,29 @@ data:
             value: {{ .Values.gitRepositorySecretRef.patSourceSecretName | quote }}
           - name: PAT_SOURCE_KEY
             value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
+          # #5443 — Phase A2-catalog: mirror the MARKETPLACE's chart set (the
+          # live Blueprint CRs) on top of the two installed-derived
+          # enumerations, then GUARD that every contractual entry resolves in
+          # the pivoted registry. Without this the cutover repoints the
+          # marketplace resolver at a registry it never stocked.
+          # NB: bare `| quote` (NOT `| default true`) — sprig `default` treats a
+          # literal false as empty and would flip an explicit disable back to
+          # true (sprig_default_bool_unsafe); the script's `: "${VAR:=…}"`
+          # restores the on-state for a nil render.
+          - name: PREWARM_CATALOG_CHARTS
+            value: {{ .Values.prewarm.catalogCharts.enabled | quote }}
+          - name: PREWARM_CATALOG_GUARD
+            value: {{ .Values.prewarm.catalogCharts.guard.enabled | quote }}
+          - name: PREWARM_CATALOG_HARD_VISIBILITY
+            value: {{ .Values.prewarm.catalogCharts.hardVisibility | quote }}
+          - name: PREWARM_CATALOG_IMAGES
+            value: {{ .Values.prewarm.catalogCharts.images.enabled | quote }}
+          - name: PREWARM_CATALOG_IMAGES_FATAL
+            value: {{ .Values.prewarm.catalogCharts.images.fatal | quote }}
+          - name: CATALOG_BLUEPRINT_RESOURCE
+            value: {{ .Values.prewarm.catalogCharts.blueprintResource | quote }}
+          - name: CATALOG_BLUEPRINT_RESOURCE_FALLBACK
+            value: {{ .Values.prewarm.catalogCharts.blueprintResourceFallback | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -342,6 +365,9 @@ data:
           - name: bootstrap-kit-pins
             mountPath: /pin-extractor
             readOnly: true
+          - name: catalog-chart-set
+            mountPath: /catalog-set
+            readOnly: true
           - name: tmp
             mountPath: /tmp
         command: ["/bin/sh", "-c"]
@@ -354,6 +380,12 @@ data:
             # step-08). Defines offlinemirror_normalize_ref + offlinemirror_local_paths
             # over the HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env.
             . /resolver/resolver.sh
+            # #5443 — the catalog chart-set extractor (03c). Defines
+            # catalog_chart_set + catalog_guard_missing + catalog_chart_images.
+            # Pure functions; sourced here so Phase A2-catalog, the Phase
+            # A2-guard and Phase A3-catalog-images all read ONE definition of
+            # "what the marketplace offers".
+            . /catalog-set/catalog-set.sh
             echo "[harbor-prewarm] offline-mirror map: ${HOST_PROJECT_MAP}"
             echo "[harbor-prewarm] local registry host: ${LOCAL_REGISTRY_HOST}; excluded hosts: ${EXCLUDED_HOSTS:-<none>}"
 
@@ -905,6 +937,48 @@ data:
             # or empty/mismatched dest digest all return non-zero → the caller does
             # the real copy. So the fail-closed completeness contract is UNTOUCHED;
             # this only elides a genuinely-redundant re-transfer.
+            # #5443 — the DURABLE-presence half of #5030, extracted so the
+            # Phase A2-guard asserts local-Harbor presence through the EXACT
+            # probe the idempotency skip trusts (and the one step-08's
+            # completeness gate makes). Harbor CORE answers this from its
+            # DATABASE, so it reflects only durably-stored artifacts and can
+            # never pull through — the whole point of #5030. Emits the artifact
+            # digest on stdout (empty when absent); exit status is curl/jq's,
+            # never load-bearing on its own.
+            #   $1 = local dest ref: the resolver PATH project/repo[:tag|@digest]
+            #        or a HARBOR_HOST-prefixed lref.
+            harbor_durable_digest() {
+              _hd_pp="${1#${HARBOR_HOST}/}"
+              _hd_ref="latest"
+              case "${_hd_pp}" in
+                *@*)
+                  _hd_ref="${_hd_pp##*@}"; _hd_pp="${_hd_pp%@*}"
+                  case "${_hd_pp##*/}" in *:*) _hd_pp="${_hd_pp%:*}" ;; esac ;;
+                *)
+                  case "${_hd_pp##*/}" in *:*) _hd_ref="${_hd_pp##*:}"; _hd_pp="${_hd_pp%:*}" ;; esac ;;
+              esac
+              # project = first path segment; repository = the (possibly nested) rest.
+              case "${_hd_pp}" in
+                */*) _hd_proj="${_hd_pp%%/*}"; _hd_repo="${_hd_pp#*/}" ;;
+                *)   _hd_proj="${_hd_pp}";     _hd_repo="" ;;
+              esac
+              # No repository segment → cannot address an artifact.
+              [ -z "${_hd_repo}" ] && return 1
+              # Harbor's artifact API needs the nested repo name's `/` encoded as
+              # %2F. #5036: this check dials the Harbor CORE Service DIRECTLY
+              # (HARBOR_INTERNAL_URL) with NO gateway in the path, so SINGLE-encode
+              # (`/` -> %2F) — harbor-core receives %2F and routes the nested repo.
+              # (Under #4688's gateway path this was DOUBLE-encoded `%252F` to survive
+              # envoy's one-layer decode before Harbor; the direct Service path has no
+              # such decode.) -k is harmless over the plain-HTTP Service; retained so
+              # an https harborInternalURL override still works.
+              _hd_repo_enc=$(printf '%s' "${_hd_repo}" | sed 's#/#%2F#g')
+              curl -sk --max-time 30 \
+                -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                "${HARBOR_INTERNAL_URL}/api/v2.0/projects/${_hd_proj}/repositories/${_hd_repo_enc}/artifacts/${_hd_ref}" 2>/dev/null \
+                | jq -r '.digest // empty' 2>/dev/null
+            }
+
             dest_already_current() {
               # $1 upstream ref  $2 local dest ref (either the resolver PATH
               #    project/repo[:tag|@digest] OR a HARBOR_HOST-prefixed lref)
@@ -922,41 +996,12 @@ data:
               fi
               [ -z "${_dc_s}" ] && return 1
               _dc_s="sha256:${_dc_s}"
-              # Accept either a bare resolver path or a HARBOR_HOST-prefixed lref.
-              _dc_pp="${_dc_dref#${HARBOR_HOST}/}"
-              # Split the local path into project / repository / reference.
-              _dc_ref="latest"
-              case "${_dc_pp}" in
-                *@*)
-                  _dc_ref="${_dc_pp##*@}"; _dc_pp="${_dc_pp%@*}"
-                  case "${_dc_pp##*/}" in *:*) _dc_pp="${_dc_pp%:*}" ;; esac ;;
-                *)
-                  case "${_dc_pp##*/}" in *:*) _dc_ref="${_dc_pp##*:}"; _dc_pp="${_dc_pp%:*}" ;; esac ;;
-              esac
-              # project = first path segment; repository = the (possibly nested) rest.
-              case "${_dc_pp}" in
-                */*) _dc_proj="${_dc_pp%%/*}"; _dc_repo="${_dc_pp#*/}" ;;
-                *)   _dc_proj="${_dc_pp}";     _dc_repo="" ;;
-              esac
-              # No repository segment → cannot address an artifact → fail-closed (copy).
-              [ -z "${_dc_repo}" ] && return 1
-              # Harbor's artifact API needs the nested repo name's `/` encoded as
-              # %2F. #5036: this check now dials the Harbor CORE Service DIRECTLY
-              # (HARBOR_INTERNAL_URL) with NO gateway in the path, so SINGLE-encode
-              # (`/` -> %2F) — harbor-core receives %2F and routes the nested repo.
-              # (Under #4688's gateway path this was DOUBLE-encoded `%252F` to survive
-              # envoy's one-layer decode before Harbor; the direct Service path has no
-              # such decode, so #5030's "Harbor must receive exactly %2F" is met with a
-              # single encode here.) Fail-closed: a wrong-encoding 404 (or any miss)
-              # falls through to a full re-copy — never a false "already current" skip.
-              _dc_repo_enc=$(printf '%s' "${_dc_repo}" | sed 's#/#%2F#g')
               # Durable DEST digest from Harbor CORE (never pull-through) via the
-              # in-cluster Service (#5036). -k is harmless over the plain-HTTP Service;
-              # retained so an https harborInternalURL override still works.
-              _dc_d=$(curl -sk --max-time 30 \
-                -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                "${HARBOR_INTERNAL_URL}/api/v2.0/projects/${_dc_proj}/repositories/${_dc_repo_enc}/artifacts/${_dc_ref}" 2>/dev/null \
-                | jq -r '.digest // empty' 2>/dev/null)
+              # in-cluster Service (#5036) — #5443 factored the probe into
+              # harbor_durable_digest above so the Phase A2-guard cannot fork it.
+              # Fail-closed: an absent/404/partial dest yields an empty digest and
+              # falls through to a full re-copy — never a false "already current".
+              _dc_d=$(harbor_durable_digest "${_dc_dref}")
               [ -n "${_dc_d}" ] && [ "${_dc_s}" = "${_dc_d}" ]
             }
 
@@ -1639,6 +1684,116 @@ data:
               echo "[harbor-prewarm] Phase A2-pins DISABLED (prewarm.bootstrapKitPins.enabled=false) — mirroring the live deployed∪desired union only; the frozen flux pin set is NOT guaranteed locally (#5237)"
             fi
 
+            # ── Phase A2-catalog (#5443, Refs #3627 #5237 #5442): union the
+            # MARKETPLACE's chart set into the mirror.
+            #
+            # Both enumerations above derive from what is INSTALLED — live
+            # HelmReleases (Phase A2) and the frozen bootstrap-kit pins (Phase
+            # A2-pins). The marketplace offers what the CATALOG lists, and those
+            # sets differ by definition: the catalog set is strictly larger.
+            # Step-06 nonetheless pivots `openova-catalog` — the HelmRepository
+            # every per-Org Application HelmRelease resolves through — onto local
+            # Harbor, so after cutover a Sovereign advertises Blueprints whose
+            # charts were never mirrored. Measured on hw290 2026-07-27: 14 of 29
+            # `visibility: listed` entries resolved, 15 returned 404, and the
+            # Harbor `openova-io` project is HOSTED (registry_id: None), so there
+            # is no proxy-cache fallback — the 404 is final and a customer buying
+            # any of those 15 gets an unpullable HelmRelease on a Sovereign that
+            # is by then deliberately cut off from the mothership.
+            #
+            # SOURCE OF TRUTH = the LIVE Blueprint CRs, not the chart-shipped
+            # catalog-seed. The seed only SEEDS them; `/api/v1/catalog` serves the
+            # CRs (catalog_client_cluster_fallback.go listFromCluster), the
+            # console's catalog IaC editor mutates the CRs, and an operator can
+            # curate entries the seed never had. Reading the seed would mirror a
+            # set the marketplace does not necessarily offer, in both directions.
+            #
+            # HARD vs SOFT. `spec.manifests.chart` : `spec.version` is the exact
+            # coordinate the install path requests (blueprintChart() ->
+            # Application.spec.blueprintRef.version -> HR chart.spec.version), so
+            # for a `visibility: listed` entry — the customer-visible contract —
+            # it is HARD: a failed copy is FATAL and the Phase A2-guard below
+            # re-asserts it against Harbor's durable artifact API. Every other row
+            # is SOFT (mirrored best-effort, failure WARNs): `spec.source.version`
+            # is read by NO controller and is a known drift surface (the console
+            # editor can bump spec.version without it, or vice versa — #5444), and
+            # unlisted/private entries are not installable from the marketplace
+            # grid, so a stale pin on one must not hold the whole cutover hostage.
+            # Mirroring them anyway is nearly free — a chart OCI artifact is a
+            # manifest plus one small tgz layer, unlike the image wave that
+            # dominates prewarm's runtime — and it covers the depends[]/companion
+            # closure of the listed set without a graph walk.
+            : "${PREWARM_CATALOG_CHARTS:=true}"
+            : "${PREWARM_CATALOG_HARD_VISIBILITY:=listed}"
+            sort -u "${chart_work}" -o "${chart_work}"
+            # Everything enumerated SO FAR keeps the pre-#5443 FATAL semantics.
+            chart_hard=/tmp/.chart-hard.tsv
+            cp "${chart_work}" "${chart_hard}"
+            catalog_set=/tmp/.catalog-set.tsv
+            : > "${catalog_set}"
+            catalog_hard=/tmp/.catalog-hard.tsv
+            : > "${catalog_hard}"
+            if [ "${PREWARM_CATALOG_CHARTS}" = "true" ]; then
+              echo "[harbor-prewarm] Phase A2-catalog (#5443): enumerating the live Blueprint CR set — what the marketplace OFFERS, on top of what is installed"
+              # Blueprint is a CLUSTER-scoped CRD (no -A). The v1 storage
+              # version is read first with the still-served v1alpha1 as the
+              # fallback (products/catalyst/chart/crds/blueprint.yaml serves
+              # both). FAIL-LOUD only when NEITHER read succeeds: an
+              # unreadable API / missing CRD / missing RBAC means the mirror
+              # CANNOT be proven to cover the marketplace, which is precisely
+              # the state #5443 shipped. A read that succeeds and returns zero
+              # items is a different thing — a Sovereign with an empty catalog
+              # advertises nothing, so there is nothing to over-advertise; that
+              # WARNs and continues rather than holding the cutover hostage.
+              catalog_json=/tmp/.blueprints.json
+              : > "${catalog_json}"
+              catalog_read=0
+              if kubectl get "${CATALOG_BLUEPRINT_RESOURCE}" -o json > "${catalog_json}" 2>/dev/null; then
+                catalog_read=1
+              else
+                echo "[harbor-prewarm] Phase A2-catalog: ${CATALOG_BLUEPRINT_RESOURCE} not served — retrying the v1alpha1 fallback ${CATALOG_BLUEPRINT_RESOURCE_FALLBACK}"
+                if kubectl get "${CATALOG_BLUEPRINT_RESOURCE_FALLBACK}" -o json > "${catalog_json}" 2>/dev/null; then
+                  catalog_read=1
+                else
+                  : > "${catalog_json}"
+                fi
+              fi
+              if [ "${catalog_read}" -eq 0 ]; then
+                echo "[harbor-prewarm] FATAL: cannot read the Blueprint CRs (${CATALOG_BLUEPRINT_RESOURCE} nor ${CATALOG_BLUEPRINT_RESOURCE_FALLBACK}) — the CRD is absent, RBAC is missing, or the API is degraded. Step-06 will still pivot the marketplace's openova-catalog resolver onto local Harbor, so refusing to build a mirror that cannot be proven to cover what the marketplace offers (#5443). Emergency override: prewarm.catalogCharts.enabled=false."
+                exit 1
+              fi
+              catalog_items=$(jq -r '(.items // []) | length' "${catalog_json}" 2>/dev/null || echo 0)
+              if [ "${catalog_items:-0}" -eq 0 ]; then
+                echo "[harbor-prewarm] Phase A2-catalog WARN: the Blueprint CR list is EMPTY — this Sovereign's marketplace offers nothing, so there is nothing for the mirror to cover. Expected a catalog-seed baseline set (products/catalyst/chart templates/catalog-seed); an empty catalog on a real Sovereign is itself worth investigating (#5443)."
+              fi
+              # Shared extractor (03c) — the SAME function the guard's hard set
+              # and the image enumeration read, so the mirrored set and the
+              # judged set can never fork.
+              catalog_chart_set "${catalog_json}" "${UPSTREAM_PREFIX}" "${PREWARM_CATALOG_HARD_VISIBILITY}" > "${catalog_set}" 2>/tmp/.catalog-set.err || true
+              sed 's/^/  /' /tmp/.catalog-set.err 2>/dev/null || true
+              cat_rows=$(grep -c . "${catalog_set}" || true)
+              cat_hard_n=0
+              cat_new=0
+              while IFS="$(printf '\t')" read -r cat_c cat_v cat_h cat_n cat_vis; do
+                [ -z "${cat_c}" ] && continue
+                if ! grep -Fxq "$(printf '%s\t%s' "${cat_c}" "${cat_v}")" "${chart_work}"; then
+                  cat_new=$((cat_new+1))
+                  echo "[harbor-prewarm] Phase A2-catalog CATALOG-ONLY (#5443): ${cat_c}:${cat_v} (${cat_n}, visibility=${cat_vis}) is offered by the marketplace but installed nowhere — the exact class step-06 would pivot into a 404"
+                fi
+                printf '%s\t%s\n' "${cat_c}" "${cat_v}" >> "${chart_work}"
+                if [ "${cat_h}" = "1" ]; then
+                  printf '%s\t%s\n' "${cat_c}" "${cat_v}" >> "${chart_hard}"
+                  printf '%s\t%s\n' "${cat_c}" "${cat_v}" >> "${catalog_hard}"
+                  cat_hard_n=$((cat_hard_n+1))
+                fi
+              done < "${catalog_set}"
+              sort -u "${chart_hard}" -o "${chart_hard}"
+              sort -u "${catalog_hard}" -o "${catalog_hard}"
+              echo "[harbor-prewarm] Phase A2-catalog: ${catalog_items} Blueprint CR(s) -> ${cat_rows} chart:version row(s) (${cat_hard_n} contractual, visibility=${PREWARM_CATALOG_HARD_VISIBILITY}); ${cat_new} not covered by the installed union"
+            else
+              echo "[harbor-prewarm] Phase A2-catalog DISABLED (prewarm.catalogCharts.enabled=false) — mirroring the installed union only; the marketplace's offered set is NOT guaranteed locally (#5443)"
+            fi
+
             sort -u "${chart_work}" -o "${chart_work}"
             chart_count=$(grep -c . "${chart_work}" || true)
             echo "[harbor-prewarm] Phase A2: ${chart_count} unique openova-io chart(s) to mirror"
@@ -1751,18 +1906,259 @@ data:
               chart_ok=$((chart_ok+1))
               echo "[harbor-prewarm] OK chart ${cup}"
             done
+            # #5443 — a copy failure is FATAL only for a chart:version in the
+            # HARD set (everything the installed union already required, plus
+            # every contractual `visibility: listed` catalog entry). A row that
+            # exists ONLY because Phase A2-catalog widened the mirror
+            # best-effort — an unlisted/private Blueprint, or a
+            # `spec.source.version` no controller reads — WARNs instead: those
+            # are not installable from the marketplace grid, so a stale pin on
+            # one must not hold the whole cutover hostage. The customer-visible
+            # contract keeps its fail-loud teeth; the widening cannot regress the
+            # cutover's success rate.
+            chart_soft_fail=0
             for f in "${chart_cpdir}"/*.fail; do
               [ -e "${f}" ] || continue
               cdetail=$(cat "${f}")
               cslug=$(basename "${f}" .fail)
               sed 's/^/  /' "${chart_cpdir}/${cslug}.log" 2>/dev/null || true
-              chart_fail=$((chart_fail+1))
-              echo "[harbor-prewarm] FAIL chart ${cdetail}"
+              cpair="${cdetail%% *}"
+              cfc="${cpair%:*}"
+              cfv="${cpair##*:}"
+              if grep -Fxq "$(printf '%s\t%s' "${cfc}" "${cfv}")" "${chart_hard}"; then
+                chart_fail=$((chart_fail+1))
+                echo "[harbor-prewarm] FAIL chart ${cdetail}"
+              else
+                chart_soft_fail=$((chart_soft_fail+1))
+                echo "[harbor-prewarm] WARN chart ${cdetail} — best-effort row (not a contractual visibility=${PREWARM_CATALOG_HARD_VISIBILITY} catalog entry and not required by the installed union); not fatal (#5443)"
+              fi
             done
-            echo "[harbor-prewarm] Phase A2 complete: chart_ok=${chart_ok} chart_fail=${chart_fail}"
+            echo "[harbor-prewarm] Phase A2 complete: chart_ok=${chart_ok} chart_fail=${chart_fail} chart_soft_fail=${chart_soft_fail}"
             if [ "${chart_fail}" -gt 0 ]; then
-              echo "[harbor-prewarm] FATAL: ${chart_fail} openova-io chart(s) failed to mirror (named above) — step-06 cannot strip ghcr.io safely (post-cutover chart (re)pulls would 404). #5007: this INCLUDES any pinned/desired chart version the union added — a pinned tag that cannot be pulled fails LOUD here (egress open, recoverable) instead of silently wedging step-06 under the deny-egress hold."
+              echo "[harbor-prewarm] FATAL: ${chart_fail} openova-io chart(s) failed to mirror (named above) — step-06 cannot strip ghcr.io safely (post-cutover chart (re)pulls would 404). #5007: this INCLUDES any pinned/desired chart version the union added — a pinned tag that cannot be pulled fails LOUD here (egress open, recoverable) instead of silently wedging step-06 under the deny-egress hold. #5443: it ALSO includes every contractual catalog entry, so the marketplace can never advertise a Blueprint the pivoted registry cannot serve."
               exit 1
+            fi
+
+            # ── Phase A2-guard (#5443): re-assert the contract against Harbor.
+            #
+            # The copy tally above says "skopeo returned 0"; the guard says "the
+            # pivoted registry actually serves it, durably". Those are not the
+            # same claim — #5030 documents the whole class where a dest read is
+            # satisfied by a pull-through that persists a manifest and no blobs,
+            # and #4994's skip-if-present can elide a copy on that basis. So the
+            # guard probes Harbor CORE's artifact API (its DATABASE, never a
+            # pull-through) through the SAME harbor_durable_digest the skip
+            # trusts and step-08's completeness gate makes, for exactly the
+            # coordinate the install path will request:
+            # `<spec.manifests.chart>:<spec.version>` of every
+            # `visibility: listed` Blueprint. This IS the probe that found #5443
+            # on hw290, and it would have failed that cutover.
+            : "${PREWARM_CATALOG_GUARD:=true}"
+            if [ "${PREWARM_CATALOG_GUARD}" = "true" ] && [ "${PREWARM_CATALOG_CHARTS}" = "true" ]; then
+              guard_n=$(grep -c . "${catalog_hard}" || true)
+              echo "[harbor-prewarm] Phase A2-guard (#5443): asserting all ${guard_n} contractual catalog chart(s) resolve durably in local Harbor"
+              catalog_present=/tmp/.catalog-present.txt
+              : > "${catalog_present}"
+              while IFS="$(printf '\t')" read -r g_c g_v; do
+                [ -z "${g_c}" ] && continue
+                g_d=$(harbor_durable_digest "openova-io/${g_c}:${g_v}")
+                if [ -n "${g_d}" ]; then
+                  printf '%s:%s\n' "${g_c}" "${g_v}" >> "${catalog_present}"
+                fi
+              done < "${catalog_hard}"
+              guard_missing=$(catalog_guard_missing "${catalog_hard}" "${catalog_present}")
+              if [ -n "${guard_missing}" ]; then
+                echo "[harbor-prewarm] FATAL (#5443): the marketplace advertises chart(s) the pivoted registry cannot serve — step-06 would repoint openova-catalog at a registry that never stocked them, and every post-cutover install of these Blueprints 404s under the deny-egress hold:"
+                printf '%s\n' "${guard_missing}" | sed 's,^,  MISSING openova-io/,'
+                echo "[harbor-prewarm] Each MISSING line is a Blueprint whose spec.manifests.chart:spec.version is absent from local Harbor. Either the upstream artifact does not exist (fix the Blueprint's pin — the #5444 class: a spec.version no registry publishes) or the mirror did not reach it (re-trigger step-03 with egress open). Emergency override: prewarm.catalogCharts.guard.enabled=false — which knowingly ships a Sovereign whose marketplace over-advertises."
+                exit 1
+              fi
+              echo "[harbor-prewarm] Phase A2-guard: PASS — ${guard_n}/${guard_n} contractual catalog chart(s) durably present in local Harbor"
+            else
+              echo "[harbor-prewarm] Phase A2-guard DISABLED — the marketplace's advertised set is NOT asserted against the pivoted registry (#5443)"
+            fi
+
+            # ── Phase A3-catalog-images (#5443, Refs #5442): mirror the IMAGES
+            # of the catalog charts.
+            #
+            # A mirrored chart whose images are absent fails at pod-pull instead
+            # of chart-pull — the same outage one layer down. Phase A's image
+            # enumeration walks the LIVE cluster's Pods, which by construction
+            # cannot know the images of a chart nobody has installed (#5442), so
+            # for the catalog set the images must come from the CHART. We pull
+            # each contractual chart back OUT of the local Harbor we just stocked
+            # (proving the mirror in passing, and costing no extra upstream
+            # egress), render it at default values, and mirror every image the
+            # render pins through the SAME resolver + copy_one the image wave
+            # used. blueprint-release.yaml gates every published bp-* chart on a
+            # default-values `helm template` of the packaged tgz, so this render
+            # is faithful, not heuristic.
+            #
+            # Best-effort by default: the render is a superset-free view (a
+            # conditional path a per-Org install enables can pin an image the
+            # default render omits), so a hard failure here could fail cutovers
+            # for a gap the enumeration cannot see either way. Every miss is
+            # named, and prewarm.catalogCharts.images.fatal=true escalates for
+            # operators who want the stricter posture.
+            : "${PREWARM_CATALOG_IMAGES:=true}"
+            : "${PREWARM_CATALOG_IMAGES_FATAL:=false}"
+            if [ "${PREWARM_CATALOG_IMAGES}" = "true" ] && [ "${PREWARM_CATALOG_CHARTS}" = "true" ] && [ -s "${catalog_hard}" ]; then
+              echo "[harbor-prewarm] Phase A3-catalog-images (#5443 Refs #5442): enumerating images FROM the catalog charts (the live-cluster walk cannot see an uninstalled chart)"
+              cat_img_set=/tmp/.catalog-images.txt
+              : > "${cat_img_set}"
+              cat_pull_dir=/tmp/catalog-charts
+              rm -rf "${cat_pull_dir}"; mkdir -p "${cat_pull_dir}"
+              CATALOG_SET_TMPDIR=/tmp
+              export CATALOG_SET_TMPDIR
+              # helm writes its cache/config/data + $HOME dotfiles on startup;
+              # the container runs readOnlyRootFilesystem:true with only /tmp
+              # writable, so redirect all four the way step-06 Phase-3a and the
+              # #5265 Day-2 reconciler already do — otherwise every render dies
+              # on a read-only HOME and the image enumeration silently degrades
+              # to "this chart has no images".
+              HOME=/tmp/helm-home
+              HELM_CACHE_HOME=/tmp/helm-home/cache
+              HELM_CONFIG_HOME=/tmp/helm-home/config
+              HELM_DATA_HOME=/tmp/helm-home/data
+              export HOME HELM_CACHE_HOME HELM_CONFIG_HOME HELM_DATA_HOME
+              mkdir -p "${HELM_CACHE_HOME}" "${HELM_CONFIG_HOME}" "${HELM_DATA_HOME}"
+              # Materialise the Phase A wave as a FILE so the "already covered"
+              # test is a plain `grep -Fxq <file>` — never `printf … | grep -q`,
+              # whose early grep exit SIGPIPEs the writer the moment anything
+              # upstream enables pipefail (#5370, #5406).
+              cat_wave_file=/tmp/.prewarm-image-wave.txt
+              printf '%s\n' ${mirror_work} > "${cat_wave_file}"
+              cat_render_fail=0
+              while IFS="$(printf '\t')" read -r ci_c ci_v; do
+                [ -z "${ci_c}" ] && continue
+                ci_slug=$(printf '%s_%s' "${ci_c}" "${ci_v}" | tr -c 'A-Za-z0-9._-' '_')
+                ci_dir="${cat_pull_dir}/${ci_slug}"
+                rm -rf "${ci_dir}"
+                # skopeo `dir:` transport — no `helm registry login` dance, and
+                # the same creds/TLS treatment the chart push already used.
+                if ! skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
+                    --insecure-policy \
+                    --src-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                    --src-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
+                    "docker://${HARBOR_HOST}/openova-io/${ci_c}:${ci_v}" \
+                    "dir:${ci_dir}" >"${cat_pull_dir}/${ci_slug}.log" 2>&1; then
+                  echo "[harbor-prewarm] Phase A3-catalog-images WARN: could not pull chart ${ci_c}:${ci_v} back from local Harbor for image enumeration"
+                  sed 's/^/    /' "${cat_pull_dir}/${ci_slug}.log" 2>/dev/null || true
+                  cat_render_fail=$((cat_render_fail+1))
+                  continue
+                fi
+                # The helm chart content layer is the one blob that is a gzip
+                # tarball — identified by content, not by a skopeo-version-
+                # specific blob filename convention.
+                ci_tgz=""
+                for b in "${ci_dir}"/*; do
+                  [ -f "${b}" ] || continue
+                  case "${b##*/}" in manifest.json|version|*.json) continue ;; esac
+                  if tar -tzf "${b}" >/dev/null 2>&1; then ci_tgz="${b}"; break; fi
+                done
+                if [ -z "${ci_tgz}" ]; then
+                  echo "[harbor-prewarm] Phase A3-catalog-images WARN: no chart tarball layer found in the ${ci_c}:${ci_v} OCI artifact — image enumeration skipped"
+                  cat_render_fail=$((cat_render_fail+1))
+                  continue
+                fi
+                ci_imgs=$(catalog_chart_images "${ci_tgz}" 2>/tmp/.catalog-images.err || true)
+                sed 's/^/    /' /tmp/.catalog-images.err 2>/dev/null || true
+                ci_n=$(printf '%s\n' "${ci_imgs}" | grep -c . || true)
+                echo "[harbor-prewarm] Phase A3-catalog-images: ${ci_c}:${ci_v} renders ${ci_n} image ref(s)"
+                [ -n "${ci_imgs}" ] && printf '%s\n' "${ci_imgs}" >> "${cat_img_set}"
+                rm -rf "${ci_dir}"
+              done < "${catalog_hard}"
+              sort -u "${cat_img_set}" -o "${cat_img_set}"
+              # Drop everything the image wave already mirrored, and resolve the
+              # remainder through the SHARED coverage map so step-08's
+              # completeness HEAD looks at the identical local paths.
+              cat_img_work=""
+              cat_img_unmapped=""
+              while IFS= read -r ci_ref; do
+                [ -z "${ci_ref}" ] && continue
+                if grep -Fxq "${ci_ref}" "${cat_wave_file}"; then continue; fi
+                ci_paths=$(offlinemirror_local_paths "${ci_ref}")
+                case "${ci_paths}" in
+                  __UNMAPPED__*)
+                    ci_uh=$(printf '%s' "${ci_paths}" | awk '{print $2}')
+                    cat_img_unmapped="${cat_img_unmapped} ${ci_uh}(${ci_ref})" ;;
+                  "") : ;;
+                  *) cat_img_work="${cat_img_work} ${ci_ref}" ;;
+                esac
+              done < "${cat_img_set}"
+              cat_img_n=$(printf '%s\n' ${cat_img_work} | grep -c . || true)
+              echo "[harbor-prewarm] Phase A3-catalog-images: ${cat_img_n} catalog-chart image(s) not already covered by the live-cluster wave"
+              if [ -n "${cat_img_unmapped}" ]; then
+                echo "[harbor-prewarm] Phase A3-catalog-images UNMAPPED — catalog charts pin image(s) from registry host(s) absent from offlineMirror.hostProjects; they cannot be mirrored and will ImagePullBackOff post-severance:"
+                for u in ${cat_img_unmapped}; do echo "  UNMAPPED ${u}"; done
+              fi
+              # Second image wave — copy_one verbatim, over its own sentinel dir
+              # so the Phase A tally is untouched. The #5095 proxy-down latch is
+              # carried across so a dead mothership proxy keeps direct-first
+              # routing instead of re-paying the timeout tax.
+              cat_img_fail=0
+              if [ "${cat_img_n}" -gt 0 ]; then
+                cat_cpdir=/tmp/prewarm-catalog-copies
+                rm -rf "${cat_cpdir}"; mkdir -p "${cat_cpdir}"
+                [ -f "${cpdir}/.proxy_down" ] && touch "${cat_cpdir}/.proxy_down"
+                # copy_one writes its sentinels into the GLOBAL cpdir; point it
+                # at this wave's dir and restore afterwards so nothing later in
+                # the step observes a mutated global.
+                cat_cpdir_saved="${cpdir}"
+                cpdir="${cat_cpdir}"
+                rm -f "${cat_cpdir}/.hb_stop"
+                progress_heartbeat "${cat_img_n}" "${cat_cpdir}" "Phase A3-catalog-images" &
+                cat_hb_pid=$!
+                cat_pids=""
+                cat_allpids=""
+                for ci_up in ${cat_img_work}; do
+                  echo "[harbor-prewarm] queue catalog-image ${ci_up}"
+                  copy_one "${ci_up}" &
+                  _cip=$!
+                  cat_pids="${cat_pids} ${_cip}"
+                  cat_allpids="${cat_allpids} ${_cip}"
+                  while : ; do
+                    cilive=0
+                    cinew=""
+                    for cp in ${cat_pids}; do
+                      if kill -0 "${cp}" 2>/dev/null; then
+                        cilive=$((cilive+1))
+                        cinew="${cinew} ${cp}"
+                      fi
+                    done
+                    cat_pids="${cinew}"
+                    [ "${cilive}" -lt "${PREWARM_PARALLELISM}" ] && break
+                    sleep 2
+                  done
+                done
+                for _p in ${cat_allpids}; do wait "${_p}" 2>/dev/null || true; done
+                touch "${cat_cpdir}/.hb_stop"
+                wait "${cat_hb_pid}" 2>/dev/null || true
+                cpdir="${cat_cpdir_saved}"
+                cat_img_ok=0
+                for f in "${cat_cpdir}"/*.ok; do
+                  [ -e "${f}" ] || continue
+                  cat_img_ok=$((cat_img_ok+1))
+                done
+                for f in "${cat_cpdir}"/*.fail; do
+                  [ -e "${f}" ] || continue
+                  ci_detail=$(cat "${f}")
+                  ci_slug=$(basename "${f}" .fail)
+                  sed 's/^/  /' "${cat_cpdir}/${ci_slug}.log" 2>/dev/null || true
+                  cat_img_fail=$((cat_img_fail+1))
+                  echo "[harbor-prewarm] Phase A3-catalog-images FAIL ${ci_detail}"
+                done
+                echo "[harbor-prewarm] Phase A3-catalog-images complete: ok=${cat_img_ok} fail=${cat_img_fail} render_fail=${cat_render_fail}"
+              else
+                echo "[harbor-prewarm] Phase A3-catalog-images complete: every catalog-chart image was already covered by the live-cluster wave (render_fail=${cat_render_fail})"
+              fi
+              if [ "${PREWARM_CATALOG_IMAGES_FATAL}" = "true" ] \
+                 && { [ "${cat_img_fail}" -gt 0 ] || [ "${cat_render_fail}" -gt 0 ] || [ -n "${cat_img_unmapped}" ]; }; then
+                echo "[harbor-prewarm] FATAL (#5443): catalog-chart image coverage incomplete (copy_fail=${cat_img_fail} render_fail=${cat_render_fail} unmapped=$(printf '%s\n' ${cat_img_unmapped} | grep -c . || true)) and prewarm.catalogCharts.images.fatal=true — a Blueprint whose chart is pullable but whose images are not fails at pod-pull under the deny-egress hold instead of chart-pull here."
+                exit 1
+              fi
+            else
+              echo "[harbor-prewarm] Phase A3-catalog-images SKIP — disabled or no contractual catalog charts (#5443)"
             fi
 
             # ─── Phase A4 (#5204): warm Crossplane xpkg provider packages ──────
@@ -2142,5 +2538,11 @@ data:
           items:
             - key: extract-pins.sh
               path: extract-pins.sh
+      - name: catalog-chart-set
+        configMap:
+          name: cutover-catalog-chart-set
+          items:
+            - key: catalog-set.sh
+              path: catalog-set.sh
       - name: tmp
         emptyDir: {}

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -344,10 +344,12 @@ data:
             value: {{ .Values.prewarm.catalogCharts.guard.enabled | quote }}
           - name: PREWARM_CATALOG_HARD_VISIBILITY
             value: {{ .Values.prewarm.catalogCharts.hardVisibility | quote }}
-          - name: PREWARM_CATALOG_IMAGES
-            value: {{ .Values.prewarm.catalogCharts.images.enabled | quote }}
-          - name: PREWARM_CATALOG_IMAGES_FATAL
-            value: {{ .Values.prewarm.catalogCharts.images.fatal | quote }}
+          # #5442 — warm images from the PINNED CHART VERSIONS, unioned with
+          # (never replacing) the live-cluster walk.
+          - name: PREWARM_CHART_IMAGES
+            value: {{ .Values.prewarm.chartImages.enabled | quote }}
+          - name: PREWARM_CHART_IMAGES_FATAL
+            value: {{ .Values.prewarm.chartImages.fatal | quote }}
           - name: CATALOG_BLUEPRINT_RESOURCE
             value: {{ .Values.prewarm.catalogCharts.blueprintResource | quote }}
           - name: CATALOG_BLUEPRINT_RESOURCE_FALLBACK
@@ -381,7 +383,7 @@ data:
             # over the HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env.
             . /resolver/resolver.sh
             # #5443 — the catalog chart-set extractor (03c). Defines
-            # catalog_chart_set + catalog_guard_missing + catalog_chart_images.
+            # catalog_chart_set + catalog_guard_missing + chart_declared_images.
             # Pure functions; sourced here so Phase A2-catalog, the Phase
             # A2-guard and Phase A3-catalog-images all read ONE definition of
             # "what the marketplace offers".
@@ -1978,35 +1980,58 @@ data:
               echo "[harbor-prewarm] Phase A2-guard DISABLED — the marketplace's advertised set is NOT asserted against the pivoted registry (#5443)"
             fi
 
-            # ── Phase A3-catalog-images (#5443, Refs #5442): mirror the IMAGES
-            # of the catalog charts.
+            # ── Phase A3-chart-images (#5442, Refs #5443 #5237 #5437): warm the
+            # images the PINNED CHART VERSIONS reference — not only the images
+            # the cluster happens to be running.
             #
-            # A mirrored chart whose images are absent fails at pod-pull instead
-            # of chart-pull — the same outage one layer down. Phase A's image
-            # enumeration walks the LIVE cluster's Pods, which by construction
-            # cannot know the images of a chart nobody has installed (#5442), so
-            # for the catalog set the images must come from the CHART. We pull
-            # each contractual chart back OUT of the local Harbor we just stocked
-            # (proving the mirror in passing, and costing no extra upstream
-            # egress), render it at default values, and mirror every image the
-            # render pins through the SAME resolver + copy_one the image wave
-            # used. blueprint-release.yaml gates every published bp-* chart on a
-            # default-values `helm template` of the packaged tgz, so this render
-            # is faithful, not heuristic.
+            # #5442: harbor-prewarm sources its two inputs from two places that
+            # agree ONLY while the cluster has already converged to what the
+            # mirror declares — chart versions from the mirror's pins (Phase A2
+            # / A2-pins), image tags from the LIVE CLUSTER (running Pods ∪
+            # declared templates). A completely FRESH mirror pinning a chart
+            # whose images the cluster has not yet rolled to reproduces the
+            # outage with NO staleness involved, so it survives the #5441
+            # stale-snapshot fix: step-05 pivots Flux onto charts pinning images
+            # the prewarm never warmed, and the local registry correctly answers
+            # NotFound. Live hw290 2026-07-27 — catalyst-api, catalyst-ui and
+            # catalyst-organization-controller all ImagePullBackOff on local
+            # tags that did not exist, and the Sovereign could not self-heal
+            # because catalyst-api is what DRIVES the cutover; recovery meant
+            # hand-pinning all three back to ghcr, i.e. re-tethering.
             #
-            # Best-effort by default: the render is a superset-free view (a
-            # conditional path a per-Org install enables can pin an image the
-            # default render omits), so a hard failure here could fail cutovers
-            # for a gap the enumeration cannot see either way. Every miss is
-            # named, and prewarm.catalogCharts.images.fatal=true escalates for
-            # operators who want the stricter posture.
-            : "${PREWARM_CATALOG_IMAGES:=true}"
-            : "${PREWARM_CATALOG_IMAGES_FATAL:=false}"
-            if [ "${PREWARM_CATALOG_IMAGES}" = "true" ] && [ "${PREWARM_CATALOG_CHARTS}" = "true" ] && [ -s "${catalog_hard}" ]; then
-              echo "[harbor-prewarm] Phase A3-catalog-images (#5443 Refs #5442): enumerating images FROM the catalog charts (the live-cluster walk cannot see an uninstalled chart)"
-              cat_img_set=/tmp/.catalog-images.txt
+            # #5443's layer-down leg is the same defect seen from the other end:
+            # a mirrored catalog chart whose images are absent fails at pod-pull
+            # instead of chart-pull. Phase A's live-cluster walk by construction
+            # cannot know the images of a chart NOBODY HAS INSTALLED, which is
+            # every catalog entry the marketplace offers but no Org has bought.
+            #
+            # ONE mechanism closes both: the input for the contractual set
+            # becomes the CHART. Every chart in `chart_hard` — the live-HR
+            # deployed∪desired union, the frozen bootstrap-kit pins, and the
+            # contractual catalog entries — is pulled back OUT of the local
+            # Harbor it was just mirrored into (skopeo `dir:` transport: no
+            # `helm registry login` dance, no extra upstream egress, and it
+            # proves the chart mirror in passing), rendered at DEFAULT values,
+            # and every image the render pins is mirrored through the SAME
+            # offline-mirror resolver + copy_one the live wave used, so step-08's
+            # completeness HEAD looks at identical local paths.
+            # blueprint-release.yaml gates every published bp-* chart on a
+            # default-values `helm template` of the packaged tgz (plus a <5-line
+            # empty-render block), so the render is faithful, not heuristic.
+            #
+            # UNION, NOT REPLACEMENT. The live-cluster walk stays exactly as it
+            # was and this set is added to it. Replacing it would be strictly
+            # WORSE: a default-values render cannot see an image behind a
+            # conditional a per-Sovereign overlay turns on, which the runtime
+            # walk does see. A union can only widen coverage, never narrow it —
+            # so this cannot regress any cutover that works today.
+            : "${PREWARM_CHART_IMAGES:=true}"
+            : "${PREWARM_CHART_IMAGES_FATAL:=true}"
+            if [ "${PREWARM_CHART_IMAGES}" = "true" ] && [ -s "${chart_hard}" ]; then
+              echo "[harbor-prewarm] Phase A3-chart-images (#5442 Refs #5443): enumerating images FROM the $(grep -c . "${chart_hard}" || true) pinned chart version(s) — the post-pivot DECLARATION, not the pre-pivot runtime"
+              cat_img_set=/tmp/.chart-images.txt
               : > "${cat_img_set}"
-              cat_pull_dir=/tmp/catalog-charts
+              cat_pull_dir=/tmp/chart-image-renders
               rm -rf "${cat_pull_dir}"; mkdir -p "${cat_pull_dir}"
               CATALOG_SET_TMPDIR=/tmp
               export CATALOG_SET_TMPDIR
@@ -2042,7 +2067,7 @@ data:
                     --src-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
                     "docker://${HARBOR_HOST}/openova-io/${ci_c}:${ci_v}" \
                     "dir:${ci_dir}" >"${cat_pull_dir}/${ci_slug}.log" 2>&1; then
-                  echo "[harbor-prewarm] Phase A3-catalog-images WARN: could not pull chart ${ci_c}:${ci_v} back from local Harbor for image enumeration"
+                  echo "[harbor-prewarm] Phase A3-chart-images WARN: could not pull chart ${ci_c}:${ci_v} back from local Harbor for image enumeration"
                   sed 's/^/    /' "${cat_pull_dir}/${ci_slug}.log" 2>/dev/null || true
                   cat_render_fail=$((cat_render_fail+1))
                   continue
@@ -2057,17 +2082,17 @@ data:
                   if tar -tzf "${b}" >/dev/null 2>&1; then ci_tgz="${b}"; break; fi
                 done
                 if [ -z "${ci_tgz}" ]; then
-                  echo "[harbor-prewarm] Phase A3-catalog-images WARN: no chart tarball layer found in the ${ci_c}:${ci_v} OCI artifact — image enumeration skipped"
+                  echo "[harbor-prewarm] Phase A3-chart-images WARN: no chart tarball layer found in the ${ci_c}:${ci_v} OCI artifact — image enumeration skipped"
                   cat_render_fail=$((cat_render_fail+1))
                   continue
                 fi
-                ci_imgs=$(catalog_chart_images "${ci_tgz}" 2>/tmp/.catalog-images.err || true)
-                sed 's/^/    /' /tmp/.catalog-images.err 2>/dev/null || true
+                ci_imgs=$(chart_declared_images "${ci_tgz}" 2>/tmp/.chart-images.err || true)
+                sed 's/^/    /' /tmp/.chart-images.err 2>/dev/null || true
                 ci_n=$(printf '%s\n' "${ci_imgs}" | grep -c . || true)
-                echo "[harbor-prewarm] Phase A3-catalog-images: ${ci_c}:${ci_v} renders ${ci_n} image ref(s)"
+                echo "[harbor-prewarm] Phase A3-chart-images: ${ci_c}:${ci_v} renders ${ci_n} image ref(s)"
                 [ -n "${ci_imgs}" ] && printf '%s\n' "${ci_imgs}" >> "${cat_img_set}"
                 rm -rf "${ci_dir}"
-              done < "${catalog_hard}"
+              done < "${chart_hard}"
               sort -u "${cat_img_set}" -o "${cat_img_set}"
               # Drop everything the image wave already mirrored, and resolve the
               # remainder through the SHARED coverage map so step-08's
@@ -2087,9 +2112,9 @@ data:
                 esac
               done < "${cat_img_set}"
               cat_img_n=$(printf '%s\n' ${cat_img_work} | grep -c . || true)
-              echo "[harbor-prewarm] Phase A3-catalog-images: ${cat_img_n} catalog-chart image(s) not already covered by the live-cluster wave"
+              echo "[harbor-prewarm] Phase A3-chart-images: ${cat_img_n} chart-declared image(s) not already covered by the live-cluster wave — exactly the #5442 gap"
               if [ -n "${cat_img_unmapped}" ]; then
-                echo "[harbor-prewarm] Phase A3-catalog-images UNMAPPED — catalog charts pin image(s) from registry host(s) absent from offlineMirror.hostProjects; they cannot be mirrored and will ImagePullBackOff post-severance:"
+                echo "[harbor-prewarm] Phase A3-chart-images UNMAPPED — pinned chart(s) reference image(s) from registry host(s) absent from offlineMirror.hostProjects; they CANNOT be mirrored and will ImagePullBackOff post-severance:"
                 for u in ${cat_img_unmapped}; do echo "  UNMAPPED ${u}"; done
               fi
               # Second image wave — copy_one verbatim, over its own sentinel dir
@@ -2098,7 +2123,7 @@ data:
               # routing instead of re-paying the timeout tax.
               cat_img_fail=0
               if [ "${cat_img_n}" -gt 0 ]; then
-                cat_cpdir=/tmp/prewarm-catalog-copies
+                cat_cpdir=/tmp/prewarm-chart-image-copies
                 rm -rf "${cat_cpdir}"; mkdir -p "${cat_cpdir}"
                 [ -f "${cpdir}/.proxy_down" ] && touch "${cat_cpdir}/.proxy_down"
                 # copy_one writes its sentinels into the GLOBAL cpdir; point it
@@ -2107,12 +2132,12 @@ data:
                 cat_cpdir_saved="${cpdir}"
                 cpdir="${cat_cpdir}"
                 rm -f "${cat_cpdir}/.hb_stop"
-                progress_heartbeat "${cat_img_n}" "${cat_cpdir}" "Phase A3-catalog-images" &
+                progress_heartbeat "${cat_img_n}" "${cat_cpdir}" "Phase A3-chart-images" &
                 cat_hb_pid=$!
                 cat_pids=""
                 cat_allpids=""
                 for ci_up in ${cat_img_work}; do
-                  echo "[harbor-prewarm] queue catalog-image ${ci_up}"
+                  echo "[harbor-prewarm] queue chart-image ${ci_up}"
                   copy_one "${ci_up}" &
                   _cip=$!
                   cat_pids="${cat_pids} ${_cip}"
@@ -2146,19 +2171,69 @@ data:
                   ci_slug=$(basename "${f}" .fail)
                   sed 's/^/  /' "${cat_cpdir}/${ci_slug}.log" 2>/dev/null || true
                   cat_img_fail=$((cat_img_fail+1))
-                  echo "[harbor-prewarm] Phase A3-catalog-images FAIL ${ci_detail}"
+                  echo "[harbor-prewarm] Phase A3-chart-images FAIL ${ci_detail}"
                 done
-                echo "[harbor-prewarm] Phase A3-catalog-images complete: ok=${cat_img_ok} fail=${cat_img_fail} render_fail=${cat_render_fail}"
+                echo "[harbor-prewarm] Phase A3-chart-images copy wave complete: ok=${cat_img_ok} fail=${cat_img_fail} render_fail=${cat_render_fail}"
               else
-                echo "[harbor-prewarm] Phase A3-catalog-images complete: every catalog-chart image was already covered by the live-cluster wave (render_fail=${cat_render_fail})"
+                echo "[harbor-prewarm] Phase A3-chart-images copy wave complete: every chart-declared image was already covered by the live-cluster wave (render_fail=${cat_render_fail})"
               fi
-              if [ "${PREWARM_CATALOG_IMAGES_FATAL}" = "true" ] \
-                 && { [ "${cat_img_fail}" -gt 0 ] || [ "${cat_render_fail}" -gt 0 ] || [ -n "${cat_img_unmapped}" ]; }; then
-                echo "[harbor-prewarm] FATAL (#5443): catalog-chart image coverage incomplete (copy_fail=${cat_img_fail} render_fail=${cat_render_fail} unmapped=$(printf '%s\n' ${cat_img_unmapped} | grep -c . || true)) and prewarm.catalogCharts.images.fatal=true — a Blueprint whose chart is pullable but whose images are not fails at pod-pull under the deny-egress hold instead of chart-pull here."
+              # ── Phase A3-guard (#5442): every image the pinned charts declare
+              # must resolve DURABLY in local Harbor.
+              #
+              # "skopeo returned 0" and "the pivoted registry serves it" are not
+              # the same claim — #5030 is the whole class where a dest read is
+              # satisfied by a pull-through that persists a manifest and no
+              # blobs, and #4994's skip-if-present can elide a copy on exactly
+              # that basis. So the guard re-asserts through the SAME
+              # harbor_durable_digest (Harbor CORE's artifact API — its
+              # database, never a pull-through) that the skip trusts and that
+              # step-08's completeness gate makes. It covers the WHOLE
+              # chart-declared set, including refs the live wave was credited
+              # with, because a false-present there is precisely how the hw290
+              # control plane ended up unpullable.
+              img_guard_missing=/tmp/.chart-image-missing.txt
+              : > "${img_guard_missing}"
+              img_guard_n=0
+              while IFS= read -r ci_ref; do
+                [ -z "${ci_ref}" ] && continue
+                ci_paths=$(offlinemirror_local_paths "${ci_ref}")
+                case "${ci_paths}" in
+                  __UNMAPPED__*|"") continue ;;
+                esac
+                for ci_dpath in ${ci_paths}; do
+                  img_guard_n=$((img_guard_n+1))
+                  if [ -z "$(harbor_durable_digest "${ci_dpath}")" ]; then
+                    printf '%s -> %s\n' "${ci_ref}" "${ci_dpath}" >> "${img_guard_missing}"
+                  fi
+                done
+              done < "${cat_img_set}"
+              img_missing_n=$(grep -c . "${img_guard_missing}" || true)
+              if [ "${img_missing_n}" -eq 0 ]; then
+                echo "[harbor-prewarm] Phase A3-guard (#5442): PASS — all ${img_guard_n} local path(s) for the chart-declared image set are durably present in local Harbor"
+              else
+                echo "[harbor-prewarm] Phase A3-guard (#5442): ${img_missing_n}/${img_guard_n} chart-declared image path(s) NOT durably present in local Harbor:"
+                sed 's/^/  MISSING /' "${img_guard_missing}"
+              fi
+              # FATAL policy. copy failures, un-mappable registry hosts and
+              # durable-presence misses are all PROVEN post-severance
+              # ImagePullBackOffs — the same two conditions Phase A already
+              # FATALs on for the runtime-derived set, applied to the second
+              # input. Failing HERE, with egress still open and the offender
+              # named, is recoverable; discovering it after the pivot can strand
+              # the control plane that drives the cutover (hw290). A chart that
+              # failed to RENDER is deliberately NOT fatal: it makes no claim
+              # about images either way, so failing on it would fail a cutover
+              # on an enumeration hiccup rather than a missing artifact.
+              if [ "${cat_render_fail}" -gt 0 ]; then
+                echo "[harbor-prewarm] Phase A3-chart-images WARN: ${cat_render_fail} chart(s) could not be pulled back or rendered (named above) — their images were NOT enumerated from the chart; those charts rely on the live-cluster wave alone (#5442)"
+              fi
+              if [ "${PREWARM_CHART_IMAGES_FATAL}" = "true" ] \
+                 && { [ "${cat_img_fail}" -gt 0 ] || [ "${img_missing_n}" -gt 0 ] || [ -n "${cat_img_unmapped}" ]; }; then
+                echo "[harbor-prewarm] FATAL (#5442): the pinned charts declare image(s) the local registry cannot serve (copy_fail=${cat_img_fail} durable_miss=${img_missing_n} unmapped=$(printf '%s\n' ${cat_img_unmapped} | grep -c . || true)). Step-05 pivots flux onto these exact chart versions, so every workload whose image is missing goes ImagePullBackOff against a registry that correctly answers NotFound — and if catalyst-api is among them the Sovereign cannot self-heal, because catalyst-api is what drives the cutover (live hw290 2026-07-27). Fix the named refs (extend offlineMirror.hostProjects for an UNMAPPED host; re-trigger step-03 with egress open for a copy failure) or set prewarm.chartImages.fatal=false to proceed knowing the post-pivot world is not fully pullable."
                 exit 1
               fi
             else
-              echo "[harbor-prewarm] Phase A3-catalog-images SKIP — disabled or no contractual catalog charts (#5443)"
+              echo "[harbor-prewarm] Phase A3-chart-images SKIP — prewarm.chartImages.enabled=false or an empty contractual chart set; image warming falls back to the LIVE-CLUSTER walk alone, which cannot see the images of a chart the cluster has not rolled to (#5442)"
             fi
 
             # ─── Phase A4 (#5204): warm Crossplane xpkg provider packages ──────

--- a/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
@@ -47,7 +47,7 @@ WHY A SHARED LIBRARY. Same single-source discipline as the #4975 offline-mirror
 resolver (03a) and the #5237 bootstrap-kit pin extractor (03b): step-03 uses
 `catalog_chart_set` to build the mirror set AND `catalog_guard_missing` to
 assert the result, so the set that is mirrored and the set that is judged can
-never fork. `catalog_chart_images` closes the #5442 layer-down leg: prewarm's
+never fork. `chart_declared_images` closes #5442 and #5443's layer-down leg: prewarm's
 image enumeration walks the LIVE cluster's Pods, which by construction cannot
 know the images of a chart nobody has installed — so the images for a catalog
 chart must come from the CHART. `helm template` is a faithful (not heuristic)
@@ -73,7 +73,7 @@ metadata:
 data:
   catalog-set.sh: |
     # POSIX sh. `catalog_chart_set` needs jq (step-03 installs/verifies it);
-    # `catalog_chart_images` needs helm (present in alpine/k8s, the canonical
+    # `chart_declared_images` needs helm (present in alpine/k8s, the canonical
     # cutover-step image — step-06 already relies on it). Pure functions: no
     # side effects beyond a scratch render file under ${CATALOG_SET_TMPDIR}.
 
@@ -177,7 +177,7 @@ data:
       return 0
     }
 
-    # catalog_chart_images CHART_TGZ
+    # chart_declared_images CHART_TGZ
     #
     #   Renders the packaged chart at DEFAULT values and emits every image
     #   reference the render pins, one per line, sorted + deduped. This is the
@@ -195,7 +195,7 @@ data:
     #   stderr: render failures + per-ref skips.
     #   exit  : always 0 — a chart that cannot be rendered yields no images and
     #           says so loudly; the caller owns the policy.
-    catalog_chart_images() {
+    chart_declared_images() {
       _ci_tgz="$1"
       [ -f "${_ci_tgz}" ] || { echo "[catalog-set] WARN: chart archive ${_ci_tgz} not found — no images enumerated" >&2; return 0; }
       command -v helm >/dev/null 2>&1 || { echo "[catalog-set] WARN: helm missing from PATH — cannot render ${_ci_tgz} for image enumeration" >&2; return 0; }
@@ -230,9 +230,24 @@ data:
               '|'|'>'|'|-'|'>-'|'|+'|'>+') continue ;;
               *' '*|*'	'*|*'$'*|*'{'*) continue ;;
             esac
+            # Tag/digest sanity. An untagged ref means an implicit `:latest`,
+            # which is not a deterministic mirror target. An EMPTY tag
+            # (`repo:`) and a placeholder tag are what a chart renders for a
+            # component whose image is supplied by an overlay — mirroring
+            # either would fail the copy and, under chartImages.fatal, fail the
+            # cutover on a ref nothing will ever pull.
             _ci_last="${_ci_ref##*/}"
             case "${_ci_last}" in
-              *@*|*:*) : ;;
+              *@*) : ;;
+              *:)
+                echo "[catalog-set] WARN: ${_ci_tgz##*/} renders '${_ci_ref}' with an EMPTY tag — skipping (an overlay supplies this tag; there is nothing deterministic to mirror)" >&2
+                continue ;;
+              *:*)
+                case "${_ci_last##*:}" in
+                  *laceholder*|*LACEHOLDER*|*hangeme*|*HANGEME*|'<'*|*'>')
+                    echo "[catalog-set] WARN: ${_ci_tgz##*/} renders '${_ci_ref}' with a placeholder tag — skipping (not a real upstream artifact)" >&2
+                    continue ;;
+                esac ;;
               *)
                 echo "[catalog-set] WARN: ${_ci_tgz##*/} pins untagged image '${_ci_ref}' — skipping (implicit :latest is not a deterministic mirror target)" >&2
                 continue ;;

--- a/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
@@ -1,0 +1,244 @@
+{{- /*
+#5443 (Refs #3627 #5237 #5442) — the CATALOG CHART-SET extractor.
+
+WHY THIS EXISTS. Step-06 pivots the marketplace's chart resolver — the
+`openova-catalog` HelmRepository every per-Org Application HelmRelease
+resolves through — from oci://ghcr.io/openova-io to the local Harbor. Step-03
+harbor-prewarm stocks that Harbor from TWO enumerations, and BOTH derive from
+what is INSTALLED:
+
+  • Phase A2      — chart:version off every live HelmRelease in the pivot set.
+  • Phase A2-pins — the frozen bootstrap-kit pins in the local Gitea mirror.
+
+The marketplace does not offer what is installed; it offers what the CATALOG
+lists. Those two sets differ by definition and the catalog set is strictly
+larger. Measured on hw290 2026-07-27: of 29 `visibility: listed` catalog
+entries, 14 resolved 200 against the pivoted registry and 15 returned 404 —
+and Harbor's `openova-io` project carries `registry_id: None`, i.e. it is a
+HOSTED project, not a proxy-cache, so the 404 is final. A cut-over Sovereign
+therefore advertised 29 installable Blueprints and could install 14. The 14
+that worked were exactly the ones that double as platform components with a
+bootstrap-kit HelmRelease — i.e. the ones the two installed-derived
+enumerations already happened to cover.
+
+WHAT THE AUTHORITATIVE SET IS. The install path resolves a Blueprint to an OCI
+coordinate through exactly two fields of the LIVE Blueprint CR:
+
+    chart   = spec.manifests.chart            (application_controller.go
+                                               blueprintChart(), L3496-3504)
+    version = spec.version                    (surfaced as the catalog item's
+                                               version by parseBlueprintCRToCatalog
+                                               L277-279, carried into
+                                               Application.spec.blueprintRef.version,
+                                               then HR ChartVersion L1087/L1338)
+
+`spec.source.version` is NOT read by any controller — it is a declarative
+mirror of the same pin that CAN drift from `spec.version` (the console's
+catalog IaC editor writes whole-CR edits: catalog_iac_edit.go, exercised by
+TestCatalogIaCEdit_RoundTrip_VersionPersistsInFluxLeg_BareName, which bumps
+alloy 1.0.2 -> 1.0.3 through the UI). So the LIVE CRs — not the chart-shipped
+catalog-seed — are the truth: an operator-curated or console-edited Blueprint
+is in the marketplace and must be in local Harbor, and the seed cannot know
+about it. `spec.source.version` is still unioned into the MIRROR set (cheap,
+strict superset, covers a stale-spec.version/fresh-source.version drift) but
+never into the HARD set, because nothing installs from it.
+
+WHY A SHARED LIBRARY. Same single-source discipline as the #4975 offline-mirror
+resolver (03a) and the #5237 bootstrap-kit pin extractor (03b): step-03 uses
+`catalog_chart_set` to build the mirror set AND `catalog_guard_missing` to
+assert the result, so the set that is mirrored and the set that is judged can
+never fork. `catalog_chart_images` closes the #5442 layer-down leg: prewarm's
+image enumeration walks the LIVE cluster's Pods, which by construction cannot
+know the images of a chart nobody has installed — so the images for a catalog
+chart must come from the CHART. `helm template` is a faithful (not heuristic)
+enumerator here because .github/workflows/blueprint-release.yaml gates EVERY
+published bp-* chart on a default-values `helm template` render of the packaged
+tgz, with a <5-line empty-render block — a chart that cannot render at defaults
+cannot be published, so it cannot be in the catalog.
+
+Every function is PURE (file in, stdout out, no cluster/registry calls) so
+tests/catalog-chart-set.sh exercises all three against fixtures at PR time.
+
+NOT a cutover-step ConfigMap: no bp.openova.io/cutover-order label, so it does
+not count toward the 11-step contract (tests/cutover-contract.sh Case 2/4).
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-catalog-chart-set
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-catalog-chart-set
+data:
+  catalog-set.sh: |
+    # POSIX sh. `catalog_chart_set` needs jq (step-03 installs/verifies it);
+    # `catalog_chart_images` needs helm (present in alpine/k8s, the canonical
+    # cutover-step image — step-06 already relies on it). Pure functions: no
+    # side effects beyond a scratch render file under ${CATALOG_SET_TMPDIR}.
+
+    # catalog_chart_set JSON_FILE UPSTREAM_PREFIX [HARD_VISIBILITY]
+    #
+    #   JSON_FILE       `kubectl get blueprints.catalyst.openova.io -o json` output.
+    #   UPSTREAM_PREFIX the openova-io chart-OCI prefix the cutover pivots FROM
+    #                   (oci://ghcr.io/openova-io). A Blueprint whose
+    #                   spec.source.url names a DIFFERENT registry is outside
+    #                   this mirror's contract and is skipped with a named WARN.
+    #   HARD_VISIBILITY the spec.visibility whose entries are CONTRACTUAL
+    #                   (default `listed` — the customer-visible marketplace
+    #                   grid). Only `spec.version` of a HARD entry is marked
+    #                   hard; every other row is best-effort.
+    #
+    #   stdout: "<chart>\t<version>\t<hard 1|0>\t<blueprint>\t<visibility>"
+    #           sorted + deduped on (chart, version); when the same pair is
+    #           reached both hard and soft, HARD wins.
+    #   stderr: skip/WARN diagnostics (never mixed into stdout).
+    #   exit  : always 0 — the CALLER owns the fail-loud policy.
+    catalog_chart_set() {
+      _cs_json="$1"
+      _cs_up=$(printf '%s' "${2:-}" | sed -e 's,/$,,')
+      _cs_hardvis="${3:-listed}"
+      [ -f "${_cs_json}" ] || { echo "[catalog-set] WARN: ${_cs_json} is not a file — catalog set empty" >&2; return 0; }
+      command -v jq >/dev/null 2>&1 || { echo "[catalog-set] WARN: jq missing — cannot enumerate the catalog chart set" >&2; return 0; }
+      # Row expansion. spec.manifests.chart is the coordinate the application
+      # controller installs by; spec.source.chart / metadata.name are the
+      # documented fallbacks for a CR that omits the manifests block.
+      _cs_rows=$(jq -r --arg hardvis "${_cs_hardvis}" '
+        (.items // [])[]
+        | . as $i
+        | (.spec // {}) as $s
+        | (($s.manifests.chart // $s.source.chart // $i.metadata.name) // "") as $chart
+        | ($s.visibility // "") as $vis
+        | (($s.source.url // "") | tostring) as $url
+        | select(($chart | tostring | length) > 0)
+        | ([ { v: (($s.version // "") | tostring),
+               h: (if $vis == $hardvis then "1" else "0" end) },
+             { v: (($s.source.version // "") | tostring),
+               h: "0" } ]
+           | map(select((.v | length) > 0))) as $rows
+        | $rows[]
+        | [ ($chart | tostring), .v, .h, ($i.metadata.name // ""), $vis, $url ]
+        | @tsv
+      ' "${_cs_json}" 2>/dev/null || true)
+      if [ -z "${_cs_rows}" ]; then
+        echo "[catalog-set] WARN: zero Blueprint CRs with a chart coordinate parsed from ${_cs_json}" >&2
+        return 0
+      fi
+      printf '%s\n' "${_cs_rows}" | while IFS="$(printf '\t')" read -r _cs_c _cs_v _cs_h _cs_n _cs_vis _cs_url; do
+        [ -z "${_cs_c}" ] && continue
+        [ -z "${_cs_v}" ] && continue
+        # Foreign registry: the local Harbor `openova-io` project mirrors the
+        # openova-io upstream only. Naming the offender is the point — a LISTED
+        # entry sourced elsewhere is a real catalog gap, not something to
+        # silently drop into a passing guard.
+        if [ -n "${_cs_url}" ] && [ -n "${_cs_up}" ]; then
+          case "${_cs_url}" in
+            "${_cs_up}"|"${_cs_up}"/*) : ;;
+            *)
+              echo "[catalog-set] skip ${_cs_n} (${_cs_c}:${_cs_v}, visibility=${_cs_vis}): spec.source.url '${_cs_url}' is not under '${_cs_up}' — outside the openova-io mirror contract" >&2
+              continue ;;
+          esac
+        fi
+        # A semver RANGE is not a concrete OCI tag — same guard as step-03
+        # Phase A2 (#5007 round 3) and 03b (#5237).
+        case "${_cs_v}" in
+          *[\<\>~^\|\ ]*|*'*'*)
+            echo "[catalog-set] WARN: ${_cs_n} version '${_cs_v}' is a semver range, not a concrete tag — skipping (cannot mirror deterministically)" >&2
+            continue ;;
+        esac
+        printf '%s\t%s\t%s\t%s\t%s\n' "${_cs_c}" "${_cs_v}" "${_cs_h}" "${_cs_n}" "${_cs_vis}"
+      done | sort | awk -F'\t' '
+        { k = $1 "\t" $2
+          if (!(k in hard) || $3 > hard[k]) { hard[k] = $3; who[k] = $4; vis[k] = $5 }
+        }
+        END { for (k in hard) printf "%s\t%s\t%s\t%s\n", k, hard[k], who[k], vis[k] }
+      ' | sort -u
+      return 0
+    }
+
+    # catalog_guard_missing HARD_TSV PRESENT_FILE
+    #
+    #   HARD_TSV      "<chart>\t<version>[\t…]" rows that MUST be pullable.
+    #   PRESENT_FILE  "<chart>:<version>" per artifact proven present in the
+    #                 local registry (the caller supplies the probe).
+    #
+    #   stdout: "<chart>:<version>" per HARD row NOT present.
+    #   exit  : always 0 — the caller decides that a non-empty stdout is fatal.
+    catalog_guard_missing() {
+      _cg_hard="$1"; _cg_present="$2"
+      [ -f "${_cg_hard}" ] || return 0
+      while IFS="$(printf '\t')" read -r _cg_c _cg_v _cg_rest; do
+        [ -z "${_cg_c}" ] && continue
+        [ -z "${_cg_v}" ] && continue
+        if [ ! -f "${_cg_present}" ] || ! grep -Fxq "${_cg_c}:${_cg_v}" "${_cg_present}"; then
+          printf '%s:%s\n' "${_cg_c}" "${_cg_v}"
+        fi
+      done < "${_cg_hard}"
+      return 0
+    }
+
+    # catalog_chart_images CHART_TGZ
+    #
+    #   Renders the packaged chart at DEFAULT values and emits every image
+    #   reference the render pins, one per line, sorted + deduped. This is the
+    #   ONLY enumeration available for a chart nobody has installed (#5442:
+    #   prewarm's live-cluster Pod walk cannot see it), and it is faithful
+    #   rather than heuristic because blueprint-release.yaml refuses to publish
+    #   a chart that does not render at default values.
+    #
+    #   Refs without a tag or digest are skipped: an implicit `:latest` is not
+    #   a deterministic mirror target. Refs still carrying template/shell
+    #   syntax are skipped as un-renderable placeholders.
+    #
+    #   stdout: one image ref per line (verbatim as authored — the caller maps
+    #           it through the offline-mirror resolver).
+    #   stderr: render failures + per-ref skips.
+    #   exit  : always 0 — a chart that cannot be rendered yields no images and
+    #           says so loudly; the caller owns the policy.
+    catalog_chart_images() {
+      _ci_tgz="$1"
+      [ -f "${_ci_tgz}" ] || { echo "[catalog-set] WARN: chart archive ${_ci_tgz} not found — no images enumerated" >&2; return 0; }
+      command -v helm >/dev/null 2>&1 || { echo "[catalog-set] WARN: helm missing from PATH — cannot render ${_ci_tgz} for image enumeration" >&2; return 0; }
+      _ci_dir="${CATALOG_SET_TMPDIR:-/tmp}"
+      _ci_out="${_ci_dir}/.catalog-render.$$.yaml"
+      _ci_err="${_ci_dir}/.catalog-render.$$.err"
+      # Explicit status capture (never a pipeline) so a render failure is seen
+      # rather than masked by the exit status of a downstream filter.
+      if helm template catalog-prewarm "${_ci_tgz}" --namespace catalog-prewarm >"${_ci_out}" 2>"${_ci_err}"; then
+        :
+      else
+        echo "[catalog-set] WARN: helm template failed for ${_ci_tgz} — no images enumerated from this chart:" >&2
+        sed 's/^/  /' "${_ci_err}" >&2 || true
+        rm -f "${_ci_out}" "${_ci_err}"
+        return 0
+      fi
+      # Every `image:` scalar in the render — containers, initContainers, and
+      # any CR field named `image` (an operator's workload pin counts too).
+      # `helm template` emits template text VERBATIM, so a chart authored in
+      # FLOW style (`- {name: c, image: repo:tag}`) never puts `image:` at the
+      # start of a line: the match must admit `{` and `,` as leading context,
+      # not just indentation and `- `. The leading-context class is also what
+      # keeps `someImage:`-style keys from matching.
+      grep -oE '(^|[[:space:],{])image:[[:space:]]*[^[:space:],}]+' "${_ci_out}" \
+        | sed -e 's/^.*image:[[:space:]]*//' -e 's/[[:space:]]*#.*$//' -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e 's/[[:space:]]*$//' \
+        | while IFS= read -r _ci_ref; do
+            [ -z "${_ci_ref}" ] && continue
+            # A YAML block-scalar header (`image: |`) or any ref still carrying
+            # whitespace / shell / un-rendered Go-template syntax is not an
+            # addressable reference.
+            case "${_ci_ref}" in
+              '|'|'>'|'|-'|'>-'|'|+'|'>+') continue ;;
+              *' '*|*'	'*|*'$'*|*'{'*) continue ;;
+            esac
+            _ci_last="${_ci_ref##*/}"
+            case "${_ci_last}" in
+              *@*|*:*) : ;;
+              *)
+                echo "[catalog-set] WARN: ${_ci_tgz##*/} pins untagged image '${_ci_ref}' — skipping (implicit :latest is not a deterministic mirror target)" >&2
+                continue ;;
+            esac
+            printf '%s\n' "${_ci_ref}"
+          done | sort -u
+      rm -f "${_ci_out}" "${_ci_err}"
+      return 0
+    }

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -126,6 +126,9 @@ rules:
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources: ["kustomizations"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["catalyst.openova.io"]
+    resources: ["blueprints"]   # step 03 (#5443) Phase A2-catalog enumerates the LIVE Blueprint CRs — what the marketplace OFFERS — so harbor-prewarm mirrors the catalog's chart set, not only the charts something already installed. Cluster-scoped CRD; read-only.
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["cilium.io"]
     resources: ["ciliumnetworkpolicies"]
     verbs: ["get", "list", "watch"]

--- a/platform/self-sovereign-cutover/chart/tests/catalog-chart-set.sh
+++ b/platform/self-sovereign-cutover/chart/tests/catalog-chart-set.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# #5443 — catalog chart-set guardrail.
+#
+# Proves the three halves of the marketplace-coverage fix, against the RENDERED
+# chart (never the source template), so a regression in either the library or
+# its wiring into step-03 fails at PR time:
+#
+#   A. templates/03c-catalog-chart-set.yaml renders a `cutover-catalog-chart-set`
+#      ConfigMap whose `catalog_chart_set` derives the right chart:version rows
+#      — and the right HARD/SOFT split — from a live-shaped Blueprint CR list.
+#   B. `catalog_guard_missing` reports exactly the contractual entries absent
+#      from the local registry (the probe that found #5443 on hw290).
+#   C. `catalog_chart_images` enumerates a chart's images by RENDERING it, which
+#      is the only enumeration available for a chart nobody installed (#5442).
+#   D. Step-03 actually WIRES all of it: mount, source, mirror-set union, guard,
+#      image pass — plus the RBAC that lets the Job read Blueprint CRs at all.
+#
+# Run standalone or via tests/cutover-contract.sh Case 72.
+# Usage: bash tests/catalog-chart-set.sh [CHART_DIR]
+
+set -euo pipefail
+
+# Resolve to an ABSOLUTE path: `helm template` on a bare relative path that no
+# longer exists relative to the caller's cwd is read as a repo/chart reference
+# ("Error: repo <x> not found"), which would look like a chart bug.
+CHART_DIR="$(cd "${1:-$(dirname "${BASH_SOURCE[0]:-$0}")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+note() { echo "  $*"; }
+bad()  { printf 'FAIL: %b\n' "$*" >&2; fail=1; }
+
+# ── Render + extract the library exactly as the Job mounts it ────────────────
+helm template smoke "$CHART_DIR" > "$TMP/render.yaml"
+
+python3 - "$TMP/render.yaml" "$TMP" <<'PY'
+import sys, yaml
+render, out = sys.argv[1], sys.argv[2]
+lib = pod = None
+for d in yaml.safe_load_all(open(render)):
+    if not d or d.get("kind") != "ConfigMap":
+        continue
+    n = d["metadata"]["name"]
+    if n == "cutover-catalog-chart-set":
+        lib = d["data"].get("catalog-set.sh")
+    if n == "cutover-step-03-harbor-prewarm":
+        spec = yaml.safe_load(d["data"]["podSpec"])
+        pod = (d["data"]["podSpec"], spec["containers"][0]["args"][0])
+if lib:
+    open(out + "/catalog-set.sh", "w").write(lib)
+if pod:
+    open(out + "/podspec.yaml", "w").write(pod[0])
+    open(out + "/prewarm.sh", "w").write(pod[1])
+PY
+
+if [ ! -f "$TMP/catalog-set.sh" ]; then
+  echo "FAIL: no ConfigMap/cutover-catalog-chart-set in the render — the catalog chart-set extractor (03c) is missing, so nothing enumerates what the marketplace OFFERS and the cutover pivots openova-catalog at a registry stocked only from what is INSTALLED (#5443)" >&2
+  exit 1
+fi
+if [ ! -f "$TMP/prewarm.sh" ]; then
+  echo "FAIL: could not extract the step-03 harbor-prewarm script from the render" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$TMP/catalog-set.sh"
+
+for fn in catalog_chart_set catalog_guard_missing catalog_chart_images; do
+  if ! command -v "$fn" >/dev/null 2>&1; then
+    echo "FAIL: ${fn} not defined by the rendered library (#5443)" >&2
+    exit 1
+  fi
+done
+
+# ── Case A: catalog_chart_set over a live-shaped Blueprint CR list ───────────
+echo "[catalog-chart-set] Case A: chart:version rows + HARD/SOFT split from the live Blueprint CRs"
+cat > "$TMP/blueprints.json" <<'JSON'
+{"apiVersion":"v1","kind":"List","items":[
+ {"metadata":{"name":"bp-wordpress-tenant"},
+  "spec":{"version":"0.4.22","visibility":"listed",
+          "manifests":{"chart":"bp-wordpress-tenant"},
+          "source":{"url":"oci://ghcr.io/openova-io","chart":"bp-wordpress-tenant","version":"0.4.22"}}},
+ {"metadata":{"name":"bp-agenity"},
+  "spec":{"version":"0.5.20","visibility":"listed",
+          "manifests":{"chart":"bp-agenity"},
+          "source":{"url":"oci://ghcr.io/openova-io","chart":"bp-agenity","version":"0.5.19"}}},
+ {"metadata":{"name":"bp-alloy"},
+  "spec":{"version":"1.0.3","visibility":"listed",
+          "manifests":{"chart":"bp-alloy"},
+          "source":{"url":"oci://ghcr.io/openova-io","chart":"bp-alloy","version":"1.0.2"}}},
+ {"metadata":{"name":"bp-cilium"},
+  "spec":{"version":"1.17.1","visibility":"unlisted",
+          "manifests":{"chart":"bp-cilium"},
+          "source":{"url":"oci://ghcr.io/openova-io","chart":"bp-cilium","version":"1.17.1"}}},
+ {"metadata":{"name":"bp-nomanifests"},
+  "spec":{"version":"2.0.0","visibility":"listed",
+          "source":{"url":"oci://ghcr.io/openova-io","version":"2.0.0"}}},
+ {"metadata":{"name":"bp-foreign"},
+  "spec":{"version":"9.9.9","visibility":"listed",
+          "manifests":{"chart":"bp-foreign"},
+          "source":{"url":"oci://ghcr.io/somebodyelse","chart":"bp-foreign","version":"9.9.9"}}},
+ {"metadata":{"name":"bp-range"},
+  "spec":{"version":">=1.0.0","visibility":"listed",
+          "manifests":{"chart":"bp-range"},
+          "source":{"url":"oci://ghcr.io/openova-io","chart":"bp-range","version":">=1.0.0"}}}
+]}
+JSON
+
+catalog_chart_set "$TMP/blueprints.json" "oci://ghcr.io/openova-io" "listed" \
+  > "$TMP/set.tsv" 2> "$TMP/set.err" || true
+
+expect_row() { # chart version hard
+  if ! grep -qP "^$1\t$2\t$3\t" "$TMP/set.tsv"; then
+    bad "expected row ${1}:${2} hard=${3}; got:\n$(cat "$TMP/set.tsv")"
+  fi
+}
+absent_chart() {
+  if cut -f1 "$TMP/set.tsv" | grep -qx "$1"; then
+    bad "${1} must NOT be in the mirror set ($2)"
+  fi
+}
+
+# spec.version of a `listed` entry is the coordinate the install path requests
+# (blueprintChart() -> blueprintRef.version -> HR chart.spec.version) => HARD.
+expect_row bp-wordpress-tenant 0.4.22 1
+expect_row bp-agenity          0.5.20 1
+expect_row bp-alloy            1.0.3  1
+# spec.source.version is read by NO controller — mirrored (drift insurance) but
+# never contractual. This is the #5444 shape observed live on hw290.
+expect_row bp-agenity          0.5.19 0
+expect_row bp-alloy            1.0.2  0
+# unlisted: mirrored best-effort, never fatal.
+expect_row bp-cilium           1.17.1 0
+# manifests.chart absent -> metadata.name, per the controller's firstNonEmpty().
+expect_row bp-nomanifests      2.0.0  1
+# Outside the openova-io mirror contract, and a semver range is not an OCI tag.
+absent_chart bp-foreign "spec.source.url is a foreign registry"
+absent_chart bp-range   "a semver range is not a concrete OCI tag"
+for token in bp-foreign bp-range; do
+  grep -q "$token" "$TMP/set.err" || bad "${token} was dropped SILENTLY — every skip must be named on stderr"
+done
+[ "$fail" -eq 0 ] && note "PASS ($(wc -l < "$TMP/set.tsv") rows; hard=$(awk -F'\t' '$3==1' "$TMP/set.tsv" | wc -l), soft=$(awk -F'\t' '$3==0' "$TMP/set.tsv" | wc -l); foreign + range skipped and named)"
+
+# ── Case B: catalog_guard_missing ────────────────────────────────────────────
+echo "[catalog-chart-set] Case B: the guard reports exactly the contractual entries the registry cannot serve"
+awk -F'\t' '$3==1 {print $1"\t"$2}' "$TMP/set.tsv" > "$TMP/hard.tsv"
+# hw290's actual shape: some contractual charts resolve, the rest 404.
+printf 'bp-wordpress-tenant:0.4.22\nbp-nomanifests:2.0.0\n' > "$TMP/present.txt"
+catalog_guard_missing "$TMP/hard.tsv" "$TMP/present.txt" > "$TMP/missing.txt"
+sort -o "$TMP/missing.txt" "$TMP/missing.txt"
+printf 'bp-agenity:0.5.20\nbp-alloy:1.0.3\n' | sort > "$TMP/missing.want"
+if ! diff -u "$TMP/missing.want" "$TMP/missing.txt" >/dev/null; then
+  bad "guard output wrong;\nwant:\n$(cat "$TMP/missing.want")\ngot:\n$(cat "$TMP/missing.txt")"
+fi
+# Nothing present => every contractual entry is missing (never a silent pass).
+: > "$TMP/present.empty"
+n_all=$(catalog_guard_missing "$TMP/hard.tsv" "$TMP/present.empty" | wc -l)
+n_hard=$(wc -l < "$TMP/hard.tsv")
+[ "$n_all" -eq "$n_hard" ] || bad "empty registry must yield ${n_hard} missing entries, got ${n_all}"
+# Everything present => empty output (no false positives).
+cut -f1,2 "$TMP/hard.tsv" | tr '\t' ':' > "$TMP/present.all"
+n_none=$(catalog_guard_missing "$TMP/hard.tsv" "$TMP/present.all" | wc -l)
+[ "$n_none" -eq 0 ] || bad "a fully-stocked registry must yield zero missing entries, got ${n_none}"
+[ "$fail" -eq 0 ] && note "PASS (partial => the exact 2 missing; empty => all ${n_hard}; complete => none)"
+
+# ── Case C: catalog_chart_images renders a chart to enumerate its images ─────
+echo "[catalog-chart-set] Case C: images come from the CHART (the live-cluster walk cannot see an uninstalled chart, #5442)"
+FIX="$TMP/fixture"
+mkdir -p "$FIX/templates"
+cat > "$FIX/Chart.yaml" <<'YAML'
+apiVersion: v2
+name: bp-fixture
+version: 0.1.0
+YAML
+cat > "$FIX/values.yaml" <<'YAML'
+image:
+  repository: ghcr.io/openova-io/openova/fixture-app
+  tag: "1.2.3"
+YAML
+cat > "$FIX/templates/deploy.yaml" <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fixture
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: init
+          image: docker.io/library/busybox:1.36
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        - name: side
+          image: quay.io/cilium/cilium:v1.17.1
+        - name: floating
+          image: ghcr.io/openova-io/openova/no-tag-here
+        # FLOW style: `helm template` emits template text verbatim, so a chart
+        # authored this way never puts `image:` at the start of a line.
+        - {name: flow, image: registry.k8s.io/pause:3.10}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: fixture-db
+spec:
+  imageName: ignored-not-an-image-key
+  image: ghcr.io/cloudnative-pg/postgresql:16.4
+YAML
+helm package "$FIX" -d "$TMP" >/dev/null
+TGZ="$TMP/bp-fixture-0.1.0.tgz"
+CATALOG_SET_TMPDIR="$TMP" catalog_chart_images "$TGZ" > "$TMP/imgs.txt" 2> "$TMP/imgs.err" || true
+for want in \
+  "ghcr.io/openova-io/openova/fixture-app:1.2.3" \
+  "docker.io/library/busybox:1.36" \
+  "quay.io/cilium/cilium:v1.17.1" \
+  "registry.k8s.io/pause:3.10" \
+  "ghcr.io/cloudnative-pg/postgresql:16.4"; do
+  grep -qx "$want" "$TMP/imgs.txt" || bad "chart render did not yield ${want}; got:\n$(cat "$TMP/imgs.txt")"
+done
+if grep -q 'no-tag-here' "$TMP/imgs.txt"; then
+  bad "an untagged ref must not be mirrored (an implicit :latest is not a deterministic target)"
+fi
+grep -q 'no-tag-here' "$TMP/imgs.err" || bad "the untagged ref was dropped SILENTLY — it must be named on stderr"
+# A chart that cannot render must say so, not pretend it has no images.
+printf 'not a chart' > "$TMP/broken.tgz"
+CATALOG_SET_TMPDIR="$TMP" catalog_chart_images "$TMP/broken.tgz" > "$TMP/broken.out" 2> "$TMP/broken.err" || true
+[ ! -s "$TMP/broken.out" ] || bad "a broken chart must yield no images"
+grep -qi 'WARN' "$TMP/broken.err" || bad "a chart that cannot be rendered must WARN, not fail silently"
+[ "$fail" -eq 0 ] && note "PASS ($(wc -l < "$TMP/imgs.txt") images incl. initContainer + CR field; untagged skipped + named; unrenderable chart WARNs)"
+
+# ── Case D: step-03 + RBAC actually wire the library ─────────────────────────
+echo "[catalog-chart-set] Case D: step-03 mounts, unions, guards, and mirrors catalog-chart images"
+grep -q '/catalog-set/catalog-set.sh' "$TMP/prewarm.sh" \
+  || bad "step-03 never sources the catalog chart-set library"
+grep -q 'catalog_chart_set ' "$TMP/prewarm.sh" \
+  || bad "step-03 never calls catalog_chart_set — the mirror set is still derived only from what is INSTALLED (#5443)"
+grep -q 'catalog_guard_missing ' "$TMP/prewarm.sh" \
+  || bad "step-03 never calls catalog_guard_missing — nothing asserts the marketplace's advertised set against the pivoted registry (#5443)"
+grep -q 'catalog_chart_images ' "$TMP/prewarm.sh" \
+  || bad "step-03 never calls catalog_chart_images — a mirrored chart whose images are absent fails at pod-pull instead of chart-pull (#5442)"
+grep -q 'harbor_durable_digest' "$TMP/prewarm.sh" \
+  || bad "the guard must probe Harbor's DURABLE artifact API (#5030), not a pull-through-able registry read"
+grep -q 'chart_hard' "$TMP/prewarm.sh" \
+  || bad "step-03 has no HARD/SOFT split — either the widened mirror set makes every unlisted stale pin fatal, or the contractual set lost its teeth (#5443)"
+grep -q 'name: catalog-chart-set' "$TMP/podspec.yaml" \
+  || bad "the step-03 podSpec does not mount the cutover-catalog-chart-set ConfigMap"
+# NB: two greps in a pipeline would SIGPIPE the writer under `set -o pipefail`
+# the moment the reader exits early (#5370, #5406) — stage through a file.
+grep -A3 'apiGroups: \["catalyst.openova.io"\]' "$TMP/render.yaml" > "$TMP/rbac.txt" || true
+if ! grep -q 'resources: \["blueprints"\]' "$TMP/rbac.txt"; then
+  bad "the runner ClusterRole cannot read Blueprint CRs — the enumeration would 403 and the step would FATAL on an empty catalog"
+fi
+[ "$fail" -eq 0 ] && note "PASS (mount + source + union + guard + image pass + RBAC all present)"
+
+if [ "$fail" -ne 0 ]; then
+  echo "[catalog-chart-set] FAILED" >&2
+  exit 1
+fi
+echo "[catalog-chart-set] All gates green."

--- a/platform/self-sovereign-cutover/chart/tests/catalog-chart-set.sh
+++ b/platform/self-sovereign-cutover/chart/tests/catalog-chart-set.sh
@@ -10,7 +10,7 @@
 #      — and the right HARD/SOFT split — from a live-shaped Blueprint CR list.
 #   B. `catalog_guard_missing` reports exactly the contractual entries absent
 #      from the local registry (the probe that found #5443 on hw290).
-#   C. `catalog_chart_images` enumerates a chart's images by RENDERING it, which
+#   C. `chart_declared_images` enumerates a chart's images by RENDERING it, which
 #      is the only enumeration available for a chart nobody installed (#5442).
 #   D. Step-03 actually WIRES all of it: mount, source, mirror-set union, guard,
 #      image pass — plus the RBAC that lets the Job read Blueprint CRs at all.
@@ -66,7 +66,7 @@ fi
 # shellcheck source=/dev/null
 . "$TMP/catalog-set.sh"
 
-for fn in catalog_chart_set catalog_guard_missing catalog_chart_images; do
+for fn in catalog_chart_set catalog_guard_missing chart_declared_images; do
   if ! command -v "$fn" >/dev/null 2>&1; then
     echo "FAIL: ${fn} not defined by the rendered library (#5443)" >&2
     exit 1
@@ -164,7 +164,7 @@ n_none=$(catalog_guard_missing "$TMP/hard.tsv" "$TMP/present.all" | wc -l)
 [ "$n_none" -eq 0 ] || bad "a fully-stocked registry must yield zero missing entries, got ${n_none}"
 [ "$fail" -eq 0 ] && note "PASS (partial => the exact 2 missing; empty => all ${n_hard}; complete => none)"
 
-# ── Case C: catalog_chart_images renders a chart to enumerate its images ─────
+# ── Case C: chart_declared_images renders a chart to enumerate its images ────
 echo "[catalog-chart-set] Case C: images come from the CHART (the live-cluster walk cannot see an uninstalled chart, #5442)"
 FIX="$TMP/fixture"
 mkdir -p "$FIX/templates"
@@ -177,6 +177,8 @@ cat > "$FIX/values.yaml" <<'YAML'
 image:
   repository: ghcr.io/openova-io/openova/fixture-app
   tag: "1.2.3"
+missing:
+  tag: ""
 YAML
 cat > "$FIX/templates/deploy.yaml" <<'YAML'
 apiVersion: apps/v1
@@ -196,6 +198,11 @@ spec:
           image: quay.io/cilium/cilium:v1.17.1
         - name: floating
           image: ghcr.io/openova-io/openova/no-tag-here
+        # An overlay-supplied tag renders EMPTY; mirroring it would fail the
+        # copy and, under chartImages.fatal, fail the cutover on a ref nothing
+        # will ever pull.
+        - name: emptytag
+          image: "ghcr.io/openova-io/openova/overlay-supplied:{{ .Values.missing.tag }}"
         # FLOW style: `helm template` emits template text verbatim, so a chart
         # authored this way never puts `image:` at the start of a line.
         - {name: flow, image: registry.k8s.io/pause:3.10}
@@ -210,7 +217,7 @@ spec:
 YAML
 helm package "$FIX" -d "$TMP" >/dev/null
 TGZ="$TMP/bp-fixture-0.1.0.tgz"
-CATALOG_SET_TMPDIR="$TMP" catalog_chart_images "$TGZ" > "$TMP/imgs.txt" 2> "$TMP/imgs.err" || true
+CATALOG_SET_TMPDIR="$TMP" chart_declared_images "$TGZ" > "$TMP/imgs.txt" 2> "$TMP/imgs.err" || true
 for want in \
   "ghcr.io/openova-io/openova/fixture-app:1.2.3" \
   "docker.io/library/busybox:1.36" \
@@ -223,29 +230,43 @@ if grep -q 'no-tag-here' "$TMP/imgs.txt"; then
   bad "an untagged ref must not be mirrored (an implicit :latest is not a deterministic target)"
 fi
 grep -q 'no-tag-here' "$TMP/imgs.err" || bad "the untagged ref was dropped SILENTLY — it must be named on stderr"
+if grep -q 'overlay-supplied' "$TMP/imgs.txt"; then
+  bad "an EMPTY-tag ref must not be mirrored — under chartImages.fatal it would fail the cutover on a ref nothing pulls (#5442)"
+fi
+grep -q 'overlay-supplied' "$TMP/imgs.err" || bad "the empty-tag ref was dropped SILENTLY — it must be named on stderr"
 # A chart that cannot render must say so, not pretend it has no images.
 printf 'not a chart' > "$TMP/broken.tgz"
-CATALOG_SET_TMPDIR="$TMP" catalog_chart_images "$TMP/broken.tgz" > "$TMP/broken.out" 2> "$TMP/broken.err" || true
+CATALOG_SET_TMPDIR="$TMP" chart_declared_images "$TMP/broken.tgz" > "$TMP/broken.out" 2> "$TMP/broken.err" || true
 [ ! -s "$TMP/broken.out" ] || bad "a broken chart must yield no images"
 grep -qi 'WARN' "$TMP/broken.err" || bad "a chart that cannot be rendered must WARN, not fail silently"
 [ "$fail" -eq 0 ] && note "PASS ($(wc -l < "$TMP/imgs.txt") images incl. initContainer + CR field; untagged skipped + named; unrenderable chart WARNs)"
 
 # ── Case D: step-03 + RBAC actually wire the library ─────────────────────────
-echo "[catalog-chart-set] Case D: step-03 mounts, unions, guards, and mirrors catalog-chart images"
+echo "[catalog-chart-set] Case D: step-03 mounts, unions, guards, and warms images from the PINNED CHARTS"
 grep -q '/catalog-set/catalog-set.sh' "$TMP/prewarm.sh" \
   || bad "step-03 never sources the catalog chart-set library"
 grep -q 'catalog_chart_set ' "$TMP/prewarm.sh" \
   || bad "step-03 never calls catalog_chart_set — the mirror set is still derived only from what is INSTALLED (#5443)"
 grep -q 'catalog_guard_missing ' "$TMP/prewarm.sh" \
   || bad "step-03 never calls catalog_guard_missing — nothing asserts the marketplace's advertised set against the pivoted registry (#5443)"
-grep -q 'catalog_chart_images ' "$TMP/prewarm.sh" \
-  || bad "step-03 never calls catalog_chart_images — a mirrored chart whose images are absent fails at pod-pull instead of chart-pull (#5442)"
+grep -q 'chart_declared_images ' "$TMP/prewarm.sh" \
+  || bad "step-03 never calls chart_declared_images — image tags would still come from the LIVE CLUSTER while chart versions come from the mirror pins (#5442)"
 grep -q 'harbor_durable_digest' "$TMP/prewarm.sh" \
   || bad "the guard must probe Harbor's DURABLE artifact API (#5030), not a pull-through-able registry read"
 grep -q 'chart_hard' "$TMP/prewarm.sh" \
   || bad "step-03 has no HARD/SOFT split — either the widened mirror set makes every unlisted stale pin fatal, or the contractual set lost its teeth (#5443)"
 grep -q 'name: catalog-chart-set' "$TMP/podspec.yaml" \
   || bad "the step-03 podSpec does not mount the cutover-catalog-chart-set ConfigMap"
+# #5442: the image enumeration must iterate the WHOLE contractual chart set
+# (bootstrap-kit pins + live-HR union + contractual catalog), not the catalog
+# slice alone — the hw290 control-plane outage was on bootstrap-kit charts.
+grep -q 'done < "${chart_hard}"' "$TMP/prewarm.sh" \
+  || bad "the chart-derived image pass does not iterate the full pinned chart set — the bootstrap-kit leg of #5442 (catalyst-api/ui/organization-controller) stays uncovered"
+grep -q 'PREWARM_CHART_IMAGES' "$TMP/prewarm.sh" \
+  || bad "step-03 has no chart-derived image phase (#5442)"
+# The union property: the live-cluster walk must NOT have been replaced.
+grep -q 'openova_images=' "$TMP/prewarm.sh" \
+  || bad "the live-cluster image walk was removed — the chart-derived set must UNION with it, never replace it (a default-values render cannot see a conditional image the runtime walk does)"
 # NB: two greps in a pipeline would SIGPIPE the writer under `set -o pipefail`
 # the moment the reader exits early (#5370, #5406) — stage through a file.
 grep -A3 'apiGroups: \["catalyst.openova.io"\]' "$TMP/render.yaml" > "$TMP/rbac.txt" || true

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3666,4 +3666,26 @@ fi
 if [ "$c71_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5359: steps 05/06/08 mount cutover-secondary-kubeconfigs optional:true [single-region inert]; step-05 pivots + FAIL-LOUD Ready-waits every secondary GitRepository over the mesh global-Service path; step-06 pivots every secondary HR with a zero-upstream read-back assert + re-syncs the STRIPPED auth bytes post-Phase-3b; step-08 extends the deny-egress hold to every region [region-A manifest inherited + mesh toEndpoints + own-gateway IPs] with teardown + per-region verdicts; step count unchanged at 11)"
 
+# ── Case 72 (#5443): the marketplace's chart set is mirrored + asserted ──────
+# Step-06 pivots `openova-catalog` — the HelmRepository every per-Org
+# Application HelmRelease resolves through — onto local Harbor, but step-03's
+# two enumerations (live HelmReleases, frozen bootstrap-kit pins) both derive
+# from what is INSTALLED. The marketplace offers what the CATALOG lists, a
+# strictly larger set: on hw290 (2026-07-27) 14 of 29 `visibility: listed`
+# entries resolved against the pivoted registry and 15 returned 404, with no
+# proxy-cache fallback. The sibling guardrail exercises the 03c library against
+# fixtures AND asserts step-03 + RBAC actually wire it.
+echo "[cutover-contract] Case 72: catalog chart-set mirror + guard (#5443)"
+CATSET="${SCRIPT_DIR}/catalog-chart-set.sh"
+if [ ! -f "${CATSET}" ]; then
+  echo "FAIL: catalog-chart-set.sh guardrail missing (#5443)" >&2
+  exit 1
+fi
+if ! bash "${CATSET}" "$(pwd)" >/dev/null 2>&1; then
+  echo "FAIL: catalog chart-set guardrail red — run tests/catalog-chart-set.sh for the offender (#5443)" >&2
+  bash "${CATSET}" "$(pwd)" >&2 || true
+  exit 1
+fi
+echo "  PASS (03c library derives the catalog chart set + HARD/SOFT split, the guard names exactly the unservable contractual entries, chart-rendered image enumeration works, and step-03 + RBAC wire all of it)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -641,6 +641,65 @@ prewarm:
   # the step-06 union-warm top-up then remain the only nets).
   bootstrapKitPins:
     enabled: true
+  # #5443 (Refs #3627 #5237 #5442) — mirror the MARKETPLACE's chart set, not
+  # only the charts something already installed.
+  #
+  # The two enumerations above (live HelmReleases + frozen bootstrap-kit pins)
+  # both derive from what is INSTALLED. Step-06 nevertheless pivots the
+  # `openova-catalog` HelmRepository — the one every per-Org Application
+  # HelmRelease resolves through — onto the local Harbor, so after cutover the
+  # marketplace resolves against a registry that was stocked from a strictly
+  # smaller set. Measured on hw290 2026-07-27: 14 of 29 `visibility: listed`
+  # catalog entries resolved and 15 returned 404, with no proxy-cache fallback
+  # (the `openova-io` project is HOSTED, registry_id: None).
+  catalogCharts:
+    # Enumerate the LIVE Blueprint CRs (what `/api/v1/catalog` serves — the
+    # catalog-seed only seeds them; the console's catalog editor and operator
+    # curation both write the CRs) and union their chart:version coordinates
+    # into the mirror set. OFF mirrors the installed union only, i.e. keeps the
+    # pre-#5443 coverage gap.
+    enabled: true
+    # The `spec.visibility` whose entries are CONTRACTUAL: their
+    # `spec.manifests.chart`:`spec.version` MUST mirror and MUST be provably
+    # present, or the cutover fails loud with egress still open. `listed` is
+    # the customer-visible marketplace grid — the set a Sovereign advertises as
+    # installable. `unlisted`/`private` entries are still MIRRORED (a chart OCI
+    # artifact is tiny next to the image wave that dominates prewarm's runtime,
+    # and mirroring them covers the listed set's depends[]/companion closure for
+    # free) but best-effort: a stale pin on a Blueprint no customer can install
+    # from the grid must not hold the whole cutover hostage.
+    hardVisibility: listed
+    guard:
+      # After the mirror, assert every contractual entry resolves DURABLY in
+      # local Harbor (Harbor CORE's artifact API — its database, never a
+      # pull-through), for exactly the coordinate the install path requests.
+      # This is the probe that found #5443 and it would have failed that
+      # cutover. Disabling knowingly ships a Sovereign whose marketplace
+      # over-advertises what it can install.
+      enabled: true
+    images:
+      # #5442 interaction: prewarm's image enumeration walks the LIVE cluster's
+      # Pods, which by construction cannot see the images of a chart nobody has
+      # installed. For the catalog set the images must therefore come FROM the
+      # chart: each contractual chart is pulled back out of the local Harbor it
+      # was just mirrored into, rendered at default values, and every image the
+      # render pins is mirrored through the same resolver + copy path the live
+      # wave uses. `helm template` is faithful here rather than heuristic
+      # because .github/workflows/blueprint-release.yaml refuses to publish a
+      # chart that does not render at default values.
+      enabled: true
+      # Escalate an incomplete image render/copy from WARN to FATAL. Default
+      # false: the default-values render cannot see an image behind a
+      # conditional a per-Org install turns on, so a hard failure here would
+      # fail cutovers over a gap the enumeration cannot close either way. Every
+      # miss is named in the step log regardless. The CHART-level contract
+      # (guard.enabled above) is the fail-loud one.
+      fatal: false
+    # The Blueprint CR resource the enumeration reads, with the v1alpha1
+    # fallback the CRD still serves (products/catalyst/chart/crds/blueprint.yaml
+    # serves v1 as storage + v1alpha1 for the existing corpus).
+    blueprintResource: "blueprints.v1.catalyst.openova.io"
+    blueprintResourceFallback: "blueprints.v1alpha1.catalyst.openova.io"
   # #4994 (Refs #3379) — content-digest idempotency for the step-03 skopeo
   # mirror. When true (default) each container-image copy (Phase A) + chart-OCI
   # copy (Phase A2) first compares the SOURCE vs local-Harbor DEST manifest

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -677,29 +677,53 @@ prewarm:
       # cutover. Disabling knowingly ships a Sovereign whose marketplace
       # over-advertises what it can install.
       enabled: true
-    images:
-      # #5442 interaction: prewarm's image enumeration walks the LIVE cluster's
-      # Pods, which by construction cannot see the images of a chart nobody has
-      # installed. For the catalog set the images must therefore come FROM the
-      # chart: each contractual chart is pulled back out of the local Harbor it
-      # was just mirrored into, rendered at default values, and every image the
-      # render pins is mirrored through the same resolver + copy path the live
-      # wave uses. `helm template` is faithful here rather than heuristic
-      # because .github/workflows/blueprint-release.yaml refuses to publish a
-      # chart that does not render at default values.
-      enabled: true
-      # Escalate an incomplete image render/copy from WARN to FATAL. Default
-      # false: the default-values render cannot see an image behind a
-      # conditional a per-Org install turns on, so a hard failure here would
-      # fail cutovers over a gap the enumeration cannot close either way. Every
-      # miss is named in the step log regardless. The CHART-level contract
-      # (guard.enabled above) is the fail-loud one.
-      fatal: false
     # The Blueprint CR resource the enumeration reads, with the v1alpha1
     # fallback the CRD still serves (products/catalyst/chart/crds/blueprint.yaml
     # serves v1 as storage + v1alpha1 for the existing corpus).
     blueprintResource: "blueprints.v1.catalyst.openova.io"
     blueprintResourceFallback: "blueprints.v1alpha1.catalyst.openova.io"
+  # #5442 (Refs #5443 #5237 #5437) — warm images from the PINNED CHART
+  # VERSIONS, not only from what the cluster happens to be running.
+  #
+  # harbor-prewarm sources its two inputs from two places that agree only while
+  # the cluster has ALREADY converged to what the mirror declares: chart
+  # versions come from the mirror's pins (Phase A2 / A2-pins), image tags come
+  # from the live cluster (running Pods union declared templates). A completely
+  # FRESH mirror pinning a chart whose images the cluster has not yet rolled to
+  # reproduces the outage with no staleness involved — step-05 pivots Flux onto
+  # charts pinning images the prewarm never warmed, and the local registry
+  # correctly answers NotFound. Live hw290 2026-07-27: catalyst-api,
+  # catalyst-ui and catalyst-organization-controller all ImagePullBackOff on
+  # local tags that did not exist, and the Sovereign could not self-heal
+  # because catalyst-api is what drives the cutover; recovery meant hand-pinning
+  # all three back to ghcr, i.e. re-tethering.
+  #
+  # The prewarm's job is to make the POST-pivot world pullable, so its input
+  # must be the post-pivot DECLARATION. This UNIONS the chart-derived set into
+  # the runtime-derived one; it does not replace it. Replacing would be strictly
+  # worse — a default-values render cannot see an image behind a conditional a
+  # per-Sovereign overlay turns on, which the runtime walk does see. Union can
+  # only widen coverage, never narrow it.
+  chartImages:
+    # Render every chart in the CONTRACTUAL mirror set — the live-HR
+    # deployed-union-desired set, the frozen bootstrap-kit pins, and the
+    # contractual catalog entries — and warm every image the render pins.
+    # Charts are pulled back out of the local Harbor they were just mirrored
+    # into, so this costs no extra upstream egress and proves the chart mirror
+    # in passing. `helm template` is faithful rather than heuristic because
+    # .github/workflows/blueprint-release.yaml refuses to publish a bp-* chart
+    # that does not render at default values.
+    enabled: true
+    # FATAL on a chart-derived image that cannot be mirrored or cannot be
+    # proven durably present afterwards. Default TRUE, matching the posture
+    # Phase A already takes for the runtime-derived set: an un-mappable
+    # registry host or a failed copy is a GUARANTEED post-severance
+    # ImagePullBackOff, and failing here — with egress still open and the
+    # offender named — is recoverable, whereas discovering it after the pivot
+    # can strand the control plane that drives the cutover. A chart that fails
+    # to RENDER is always a WARN and never fatal: it makes no claim about
+    # images either way.
+    fatal: true
   # #4994 (Refs #3379) — content-digest idempotency for the step-03 skopeo
   # mirror. When true (default) each container-image copy (Phase A) + chart-OCI
   # copy (Phase A2) first compares the SOURCE vs local-Harbor DEST manifest

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5068,7 +5068,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.153"
+  version: "0.1.154"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5085,7 +5085,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.153"
+    version: "0.1.154"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5443 #5442 · Refs #5444 #5437 #3627 #5237

Two issues, one file, one enumeration decision. Both are the same underlying statement: **harbor-prewarm stocks the local Harbor from what the cluster IS, and the post-pivot world runs on what the mirror DECLARES.** #5443 is that gap for charts, #5442 is it for images.

## #5443 — the marketplace's charts are never mirrored

Step-06 pivots `openova-catalog` — the one HelmRepository every per-Org Application HelmRelease resolves through — onto the local Harbor. Step-03 stocks that Harbor from two enumerations, and **both derive from what is INSTALLED**: Phase A2 reads live HelmReleases, Phase A2-pins reads the frozen bootstrap-kit pins. The marketplace offers what the **catalog lists** — a strictly larger set.

Live hw290, 2026-07-27: of 29 `visibility: listed` catalog entries, 14 resolved 200 against the pivoted registry and 15 returned 404. Harbor's `openova-io` project carries `registry_id: None` — HOSTED, not a proxy-cache — so the 404 is final.

## #5442 — the images come from the runtime, the charts from the pins

Chart versions come from the mirror's pins; image tags come from the live cluster (running Pods ∪ declared templates). Those agree only while the cluster has already converged to what the mirror declares. A completely fresh mirror pinning a chart whose images the cluster has not rolled to reproduces `ImagePullBackOff` with no staleness involved — so it survives #5441.

Live hw290: `catalyst-api`, `catalyst-ui` and `catalyst-organization-controller` all `ImagePullBackOff` on local tags that did not exist, and the Sovereign could not self-heal **because catalyst-api is what drives the cutover**. Recovery meant hand-pinning all three back to ghcr — re-tethering.

## Where the authoritative catalog set comes from — and no, seed and CRs do not always agree

The install path resolves a Blueprint through exactly two fields of the **live Blueprint CR**:

| coordinate | field | reader |
|---|---|---|
| chart | `spec.manifests.chart` | `blueprintChart()`, `application_controller.go` L3496 |
| version | `spec.version` | `parseBlueprintCRToCatalog` L277 → `Application.spec.blueprintRef.version` → HR `ChartVersion` L1087/L1338 |

`spec.source.version` is read by **no controller** in `core/` or `products/catalyst/bootstrap/api/`.

So this enumerates the **live CRs**, not the chart-shipped catalog-seed. `/api/v1/catalog` serves the CRs (`catalog_client_cluster_fallback.go` `listFromCluster`); the console's catalog IaC editor writes whole-CR edits (`catalog_iac_edit.go`); an operator can curate entries the seed never had. Reading the seed would mirror a set the marketplace does not necessarily offer, in both directions.

On the `bp-alloy` example: **in `main` today the seed agrees with itself** — `spec.version` and `spec.source.version` are both `1.0.2`, and ghcr publishes `1.0.0/1.0.1/1.0.2`. The `1.0.3` seen live is a **CR mutation**, not a seed value — it is literally the edit `TestCatalogIaCEdit_RoundTrip_VersionPersistsInFluxLeg_BareName` exercises (bump alloy 1.0.2 → 1.0.3 through the console editor). That makes the seed-vs-CR disagreement a *structural* property of the console editor, not a one-off typo — the strongest argument for reading the CRs, and why this mirrors the union `{spec.version, spec.source.version}` while making only `spec.version` contractual.

## `listed` only, or everything? — Neither. Mirror everything, gate on `listed`.

- **Mirror scope: all Blueprint CRs.** A chart OCI artifact is a manifest plus one small tgz layer; the ~50-minute prewarm is dominated by the multi-hundred-MB **image** wave, not charts. Mirroring the unlisted/private entries too costs almost nothing and covers the listed set's `depends[]` / `companion` closure without a graph walk.
- **Contract scope: `visibility: listed` only.** That is the customer-visible marketplace grid — the set a Sovereign advertises as installable.

A copy failure on a `listed` entry's `spec.version` is **FATAL** (and re-asserted by the guard); every other row **WARNs**. Deliberate: mirroring 80 entries under the old blanket-FATAL would have made every stale pin on an uninstallable Blueprint a cutover-killer — the fix would have *reduced* the cutover success rate. `hardVisibility` is a knob if the boundary moves.

## Did I also change the enumeration input for the existing bootstrap-kit / live-HR path?

**Yes — and that is what makes #5442 fully addressed rather than only its catalog slice.**

Phase A3 runs over the **whole contractual chart set** (`chart_hard`): the live-HR `deployed ∪ desired` union, the frozen bootstrap-kit pins, **and** the contractual catalog entries. The hw290 outage was on bootstrap-kit charts (`catalyst-api`), so restricting the chart-derived enumeration to the catalog slice would have left the severe case open while looking like a fix.

**It is a UNION, not a replacement.** The live-cluster walk is untouched and the chart-derived set is added to it. Replacing would be strictly worse: a default-values render cannot see an image behind a conditional a per-Sovereign overlay turns on, which the runtime walk *does* see. A union can only widen coverage — so no cutover that works today can regress. The guardrail asserts this property explicitly (`openova_images=` must still be present).

Mechanically: each chart is pulled back **out of the local Harbor it was just mirrored into** (skopeo `dir:` transport — no `helm registry login` dance, no extra upstream egress, and it proves the chart mirror in passing), the chart tarball layer is located **by content** (`tar -tzf`, not a skopeo-version-specific blob filename), `helm template` renders it at default values, and every `image:` scalar goes through the **shared** `offlinemirror_local_paths` + the **same** `copy_one`, so step-08's completeness HEAD looks at identical local paths.

`helm template` is **faithful here, not heuristic**: `.github/workflows/blueprint-release.yaml` refuses to publish a `bp-*` chart that does not render at default values (plus a `<5`-line empty-render block). A chart that cannot render cannot be pinned.

**Phase A3-guard** then re-asserts the whole chart-declared image set through `harbor_durable_digest` — Harbor CORE's artifact API, its database, never a pull-through (#5030). "skopeo returned 0" and "the pivoted registry serves it" are not the same claim, and a false-present is exactly how the hw290 control plane ended up unpullable.

**FATAL by default** (`prewarm.chartImages.fatal: true`) on a copy failure, an un-mappable registry host, or a durable-presence miss — the same two conditions Phase A already FATALs on for the runtime set, applied to the second input. A chart that fails to **render** is always a WARN: it makes no claim about images either way, so failing on it would fail a cutover on an enumeration hiccup rather than a missing artifact. The enumerator drops untagged, empty-tag and placeholder-tag refs so an overlay-supplied tag cannot fail a cutover on a ref nothing will ever pull.

## Negative proof — the guards are not vacuous

Three reversions, each run against the shipped guardrail (`tests/catalog-chart-set.sh`, wired into `cutover-contract.sh` Case 72):

| # | reverted | result |
|---|---|---|
| 1 | whole fix (chart from `origin/main`) | **RED** — `no ConfigMap/cutover-catalog-chart-set in the render` |
| 2 | library kept, **only** `03-harbor-prewarm-job.yaml` reverted | **RED** — Cases A/B/C pass, Case D fails with all 9 wiring assertions, including *"the chart-derived image pass does not iterate the full pinned chart set — the bootstrap-kit leg of #5442 stays uncovered"* |
| 3 | wiring kept, `catalog_guard_missing` neutered to report nothing | **RED** — Case B: `empty registry must yield 4 missing entries, got 0` |
| — | **restored** | **GREEN** — all 4 cases, and `cutover-contract.sh` all 72 |

Reversion 2 matters most: it proves the wiring assertions are non-vacuous *independently* of the library existing.

Beyond the committed guardrail, the **shipped blocks were executed** — sliced out of the *rendered* step-03 script and run against stubs:

- **Phase A2-catalog** over a live-shaped Blueprint list with one installed chart: mirror set 1 → 6 rows, `catalog_hard` = exactly the 3 `listed` `spec.version` rows, `chart_hard` = those plus the installed row.
- **Phase A2-guard** with only `bp-wordpress-tenant` served (the hw290 shape): `exit=1`, naming `MISSING openova-io/bp-agenity:0.5.20` and `MISSING openova-io/bp-alloy:1.0.3`. Everything served: `PASS — 3/3`, `exit=0`.
- **Phase A3 + A3-guard, reproducing hw290 directly** — a *bootstrap-kit* pin (`bp-catalyst-platform:1.4.1236`) declaring `catalyst-api:b1b472d`, an image the live wave never enumerated:

  ```
  Phase A3-chart-images: bp-catalyst-platform:1.4.1236 renders 3 image ref(s)
  Phase A3-chart-images: 1 chart-declared image(s) not already covered by the live-cluster wave — exactly the #5442 gap
  Phase A3-chart-images UNMAPPED — … registry.example.invalid(registry.example.invalid/x/y:1.0)
  queue chart-image ghcr.io/openova-io/openova/catalyst-api:b1b472d
  Phase A3-guard (#5442): 2/3 chart-declared image path(s) NOT durably present …
    MISSING ghcr.io/openova-io/openova/catalyst-api:b1b472d -> proxy-ghcr/openova-io/openova/catalyst-api:b1b472d
    MISSING ghcr.io/openova-io/openova/catalyst-api:b1b472d -> openova-io/openova/catalyst-api:b1b472d
  FATAL (#5442): … if catalyst-api is among them the Sovereign cannot self-heal …
  A3 exit=1
  ```

  With the registry serving everything: `PASS — all 4 local path(s) … durably present`, `exit=0`. With `chartImages.fatal=false`: same diagnosis, `exit=0`.

That harness caught a **real bug before it shipped**: `helm template` emits template text verbatim, so a chart authored in flow style (`- {name: c, image: repo:tag}`) never puts `image:` at line start, and the first extraction returned zero images. Fixed to admit `{` and `,` as leading context; a flow-style container is now in the test fixture.

## Gates

- `bash -n` / `dash -n` / `busybox ash -n` on **both** rendered scripts (the step-03 podSpec args and `catalog-set.sh`) — all green.
- SIGPIPE: the step-03 script runs `set -eu` (no pipefail), and the new code stages every membership test through a file (`grep -Fxq … <file>`) rather than `printf | grep -q`. The guardrail runs `set -euo pipefail` and **hit this trap during development** — a `grep -A3 … | grep -q` RBAC check reported a false FAIL until it was staged through a file. Called out in a comment there.
- `tests/cutover-contract.sh` — all 72 cases, step count still 11.
- `tests/image-registry-coverage.sh` — 169 refs / 6 hosts, all covered.
- `tests/e2e/bootstrap-kit` `go test -count=1 ./...` — ok.
- `scripts/check-no-nodeports.sh` — zero NodePorts.
- `scripts/check-bootstrap-kit-pin-sync.sh` — 67 pairs in sync. `scripts/check-catalog-seed-lockstep.sh` — 68 checked, 0 fail.
- Chart **0.1.154** across all four lockstep sites: `Chart.yaml`, `blueprint.yaml`, `clusters/_template/bootstrap-kit/06a-…`, catalog-seed **`spec.version` and `source.version`**. Rebased onto current `origin/main` after #5438 landed 0.1.153; 0.1.154 verified unpublished on ghcr (only 0.1.150/151/152 exist), so the pin is not hollow. `tests/e2e/bootstrap-kit go test` — the only gate covering `blueprint.yaml` and the seed pins — is green.
- Rebase collision surfaces re-checked: **both** changelog blocks survive (#5438's 0.1.153 note sits under this PR's 0.1.154 note in `Chart.yaml`, and its slot note stays above in `06a-…`), the catalog-seed diff vs main is again **exactly the two version lines**, and #5438's code is intact — `assert_region_a_pivot` ×4 in step-06, `readbackExcludeNames` + `pivotReadbackSeconds` in values, and its own `tests/step06-pivot-readback.sh` passes 13/13 against the rebased chart.

## Shared files touched (sibling-PR collisions)

- `platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml` — additive: three new phases, plus `harbor_durable_digest` extracted out of `dest_already_current` (behaviour unchanged; the durable-probe body moved verbatim). No overlap with #5438 (step-06) or #5441 (engine-side).
- `platform/self-sovereign-cutover/chart/{Chart.yaml,values.yaml,templates/rbac.yaml,tests/cutover-contract.sh}` — version note, `prewarm.catalogCharts` + `prewarm.chartImages` blocks, one RBAC rule, one appended test case.
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — **the known collision point; exactly two lines**, `0.1.152` → `0.1.153` on the `bp-self-sovereign-cutover` entry's `spec.version` and `source.version`. Nothing else.
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` — one line, the slot pin.

## Where I would push back on the root causes

Both diagnoses hold — `03-harbor-prewarm-job.yaml` contained zero references to `catalog-seed` or Blueprint CRs, and its image enumeration was purely runtime-derived. Three refinements:

1. **The seed is not the truth source; the live CRs are.** The seed only seeds. The `bp-alloy` divergence is not seed drift — in `main` the seed is self-consistent at `1.0.2`. `1.0.3` exists only as a live CR, produced by the console's catalog editor. #5444 is therefore better characterised as *the console can write a `spec.version` that no registry publishes* — a validation gap on the write path, not a seed-authoring mistake. This PR surfaces it loudly at cutover but cannot fix it.
2. **This does not change fresh-prov behaviour from `main`.** Every one of the 80 seed entries pins a version that agrees with its own `source.version` and sources from `oci://ghcr.io/openova-io`. Only 2 of ~67 bootstrap-kit slots override an image tag at all, and both point at coverage-mapped mothership proxy paths. The new FATALs can only fire on a Sovereign whose live state has drifted from the declaration — which is precisely the hw290 state, and precisely what should stop a cutover.
3. **A `spec.version`-only probe under-counts the absent coordinates.** Because the mirror unions `spec.source.version` too, some entries have *two* coordinates that could 404. The guard deliberately asserts only `spec.version` — the one the install path requests — so its verdict matches what a customer actually experiences rather than the larger set of coordinates that merely happen to be absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
