### PR TITLE
fix(console): badge apps NOT SERVING when the workload is dead, instead of INSTALLED (Refs #5451)

### DIFF
--- a/core/console/src/components/AppsPage.svelte
+++ b/core/console/src/components/AppsPage.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import PortalShell from './PortalShell.svelte';
   import {
-    getApps, getProvisionStatus, getMyOrgs, installApp, uninstallApp,
+    getApps, getProvisionStatus, getMyOrgs, installApp, uninstallApp, getAppStatuses,
     type User, type Org, type CatalogApp, type Provision, type ProvisionStep,
+    type AppRuntimeStatus,
   } from '../lib/api';
   import { path } from '../lib/config';
   import { getAppStateStore } from '../lib/stores/appState.svelte';
@@ -20,6 +21,12 @@
   let tab = $state<'installed' | 'catalog'>('installed');
   // Shared store — source of truth for Org apps + app_states + jobs. #64
   let store = $state<ReturnType<typeof getAppStateStore> | null>(null);
+
+  // Live runtime state per app (#5451). The Org record tells us what was
+  // *purchased*; this tells us whether it actually serves. Without it the card
+  // badges INSTALLED over a 503 and offers an Open button onto a dead endpoint.
+  let appStatuses = $state<Record<string, AppRuntimeStatus>>({});
+  let statusPollTimer: ReturnType<typeof setInterval> | null = null;
 
   // Add/Remove modal state
   let modal = $state<null | {
@@ -75,6 +82,58 @@
     }
   });
 
+  // Poll live runtime state (#5451). Deliberately independent of the provision
+  // poller: an app can stop serving long after provisioning reports completed —
+  // that is exactly the hw290 case, where every deploy step said completed and
+  // all four workloads had zero endpoints.
+  $effect(() => {
+    const orgId = activeOrg?.id;
+    if (!orgId) return;
+    const refresh = () => {
+      // Never surface the failure as "healthy": on error we leave the previous
+      // map in place rather than clearing it to {} (which would silently read
+      // as "no evidence of trouble" for every card).
+      getAppStatuses(orgId).then(m => { appStatuses = m; }).catch(() => {});
+    };
+    refresh();
+    if (statusPollTimer) clearInterval(statusPollTimer);
+    statusPollTimer = setInterval(refresh, 15000);
+    return () => {
+      if (statusPollTimer) { clearInterval(statusPollTimer); statusPollTimer = null; }
+    };
+  });
+
+  // Affirmative evidence that a workload is NOT serving. Returns false when we
+  // have no evidence either way ("unknown", or no row at all) — this downgrades
+  // a card only on positive proof, never on absence of information, so an
+  // unreachable provisioning service cannot paint healthy apps red.
+  function isNotServing(appId: string): boolean {
+    const st = appStatuses[appId];
+    if (!st) return false;
+    switch (st.pod_status) {
+      case 'Failed':
+      case 'not_found':
+      case 'Pending':
+        return true;
+      case 'Running':
+        // Pods exist and are Running but none passed the Ready gate — this is
+        // precisely the shape that yields zero Service endpoints and a 503
+        // "no healthy upstream" behind the Open button.
+        return st.ready_replicas === 0;
+      default:
+        return false; // "unknown" — unreachable runtime, not a verdict.
+    }
+  }
+
+  function notServingDetail(appId: string): string {
+    const st = appStatuses[appId];
+    if (!st) return 'This application is not currently serving traffic.';
+    if (st.pod_status === 'not_found') {
+      return 'No running workload was found for this application. It was added to your organization but never started.';
+    }
+    return `This application is not currently serving traffic (${st.pod_status}, ${st.ready_replicas}/${st.total_replicas} ready).`;
+  }
+
   function loadProvision(orgId: string) {
     getProvisionStatus(orgId)
       .then(p => {
@@ -101,7 +160,7 @@
     }, 3000);
   }
 
-  type AppState = 'installing' | 'uninstalling' | 'pending' | 'installed' | 'failed' | 'not-installed';
+  type AppState = 'installing' | 'uninstalling' | 'pending' | 'installed' | 'unavailable' | 'failed' | 'not-installed';
 
   function stepForApp(appName: string, steps: ProvisionStep[] | undefined): ProvisionStep | null {
     if (!steps) return null;
@@ -109,7 +168,20 @@
     return steps.find(s => s.name === target) || null;
   }
 
+  // #5451 — every branch of provisionStateFor() below reaches "installed" from
+  // an *intent* fact: membership in the Org's Apps list, or a deploy step that
+  // reported completed. Both mean "we dispatched this", never "it serves". This
+  // wrapper is the single place runtime truth is allowed to overrule that, so
+  // no future branch can route around it and paint a dead app green again.
   function appStateFor(app: CatalogApp): { state: AppState; message?: string } {
+    const base = provisionStateFor(app);
+    if (base.state === 'installed' && isNotServing(app.id)) {
+      return { state: 'unavailable', message: notServingDetail(app.id) };
+    }
+    return base;
+  }
+
+  function provisionStateFor(app: CatalogApp): { state: AppState; message?: string } {
     // app_states is the source of truth for day-2 transitions (#64). If the
     // org-service consumer flipped the app to "installing" / "uninstalling" /
     // "failed", render that regardless of whether the initial provisioning
@@ -396,6 +468,12 @@
                 <span class="status-chip s-installed">
                   <span class="dot"></span> INSTALLED
                 </span>
+              {:else if st.state === 'unavailable'}
+                <!-- #5451 — installed, but the workload is affirmatively not
+                     serving. Saying INSTALLED here is what hid four dead apps. -->
+                <span class="status-chip s-unavailable" title={st.message}>
+                  <span class="dot"></span> NOT SERVING
+                </span>
               {:else if st.state === 'installing'}
                 <span class="status-chip s-installing">
                   <span class="dot dot-spin"></span> INSTALLING
@@ -421,6 +499,12 @@
                 <button class="icon-btn open" onclick={(e) => { e.preventDefault(); e.stopPropagation(); openApp(app.slug); }} title="Open">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
                 </button>
+                <button class="icon-btn del" onclick={(e) => { e.preventDefault(); e.stopPropagation(); requestRemove(app); }} title="Remove">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z"/></svg>
+                </button>
+              {:else if st.state === 'unavailable'}
+                <!-- #5451 — no Open button: the endpoint returns 503. Remove
+                     stays, so the customer keeps a way to act on the card. -->
                 <button class="icon-btn del" onclick={(e) => { e.preventDefault(); e.stopPropagation(); requestRemove(app); }} title="Remove">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z"/></svg>
                 </button>
@@ -809,6 +893,10 @@
   .s-installing { background: color-mix(in srgb, var(--color-accent) 16%, transparent); color: var(--color-accent); }
   .s-pending { background: color-mix(in srgb, var(--color-text-dim) 16%, transparent); color: var(--color-text-dim); }
   .s-failed { background: color-mix(in srgb, var(--color-danger) 16%, transparent); color: var(--color-danger); }
+  /* #5451 — installed but not serving. Distinct from FAILED (which means the
+     install itself failed): here the install reported success and the workload
+     is dead, which is the case a green INSTALLED badge used to conceal. */
+  .s-unavailable { background: color-mix(in srgb, var(--color-danger) 16%, transparent); color: var(--color-danger); }
 
   @keyframes pulse {
     0%, 100% { opacity: 1; }

--- a/core/console/src/lib/api.ts
+++ b/core/console/src/lib/api.ts
@@ -354,6 +354,33 @@ export interface BackingService {
   image?: string;
 }
 
+// Live runtime state per installed application (#5451). The Org record's
+// `apps` list says what was purchased — it does NOT say whether the workload
+// serves. Without this, the console badges dead apps INSTALLED and offers an
+// Open button onto a 503.
+export interface AppRuntimeStatus {
+  id: string;
+  slug: string;
+  /** "Running" | "Pending" | "Failed" | "not_found" | "unknown". NOTE: "unknown"
+   *  means the runtime could not be reached — it is NOT a synonym for healthy. */
+  pod_status: string;
+  ready_replicas: number;
+  total_replicas: number;
+}
+
+/** Returns app-id → live runtime status. Never throws; an unreachable backend
+ *  yields {} and callers must degrade to "unconfirmed", never to "healthy". */
+export const getAppStatuses = async (
+  orgId: string,
+): Promise<Record<string, AppRuntimeStatus>> => {
+  const raw = await request<{ apps: AppRuntimeStatus[] }>(
+    `/organizations/${orgId}/app-statuses`,
+  );
+  const out: Record<string, AppRuntimeStatus> = {};
+  for (const a of raw.apps || []) out[a.id] = a;
+  return out;
+};
+
 // Types
 export interface User { id: string; email: string; name: string; }
 export interface Org {

--- a/core/services/tenant/handlers/app_statuses_5451.go
+++ b/core/services/tenant/handlers/app_statuses_5451.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/openova-io/openova/core/services/shared/respond"
+	"github.com/openova-io/openova/core/services/tenant/catalog"
+)
+
+// AppStatus carries live runtime state for one installed application (#5451).
+//
+// The per-Organization console derives its INSTALLED badge and its Open button
+// from the Organization record's Apps list. That list records what the customer
+// *purchased* — it says nothing about whether the workload actually serves. On
+// hw290 four applications (listmonk, umami, uptime-kuma, vaultwarden) were
+// badged INSTALLED with live Open buttons while every one of them returned 503
+// with zero Service endpoints.
+//
+// That failure mode is worse than an outage: every other defect on that
+// environment was recoverable once seen, and this one is what prevented it
+// being seen. Pillar 1's terminal acceptance is "a customer's purchased
+// application actually serving" — a console that asserts this has happened when
+// it has not is asserting the pillar itself.
+//
+// The platform already knows how to answer the question. The provisioning
+// service computes pod readiness by slug for backing services; that endpoint is
+// generic (it matches pods by name prefix against whatever `services=` list it
+// is handed) and was simply never asked about applications — only about the
+// databases and caches the customer never sees.
+type AppStatus struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+	// PodStatus is "Running" | "Pending" | "Failed" | "not_found" | "unknown".
+	// "unknown" means we could not reach the provisioning service — it is NOT
+	// a synonym for healthy, and callers must not render it as such.
+	PodStatus     string `json:"pod_status"`
+	ReadyReplicas int    `json:"ready_replicas"`
+	TotalReplicas int    `json:"total_replicas"`
+}
+
+// ListAppStatuses handles GET /organizations/{id}/app-statuses.
+//
+// Returns one row per installed non-service application. Backing services are
+// deliberately excluded — they are already covered by the backing-services
+// endpoint, and they have no Open button to mislead anyone.
+//
+// Membership-gated on the same reasoning as ListBackingServices: the payload is
+// read-only runtime state, and any team member debugging a dead app needs it.
+//
+// Failure is never fatal. If provisioning is unreachable, every row reports
+// "unknown" and the console degrades to "can't currently confirm" — which is
+// the honest answer, and still strictly better than asserting INSTALLED.
+func (h *Handler) ListAppStatuses(w http.ResponseWriter, r *http.Request) {
+	orgID := r.PathValue("id")
+	if _, ok := h.requireMembership(w, r, orgID); !ok {
+		return
+	}
+
+	org, err := h.Store.GetTenant(r.Context(), orgID)
+	if err != nil {
+		respond.Error(w, http.StatusInternalServerError, "failed to load organization")
+		return
+	}
+	if org == nil {
+		respond.Error(w, http.StatusNotFound, "organization not found")
+		return
+	}
+	if h.Catalog == nil {
+		respond.Error(w, http.StatusNotImplemented, "catalog client not configured")
+		return
+	}
+
+	apps, err := h.Catalog.ListApps(r.Context())
+	if err != nil {
+		respond.Error(w, http.StatusBadGateway, "failed to reach catalog")
+		return
+	}
+	byID := make(map[string]*catalog.App, len(apps))
+	for i := range apps {
+		byID[apps[i].ID] = &apps[i]
+	}
+
+	installed := selectOpenableApps(org.Apps, byID)
+	if len(installed) == 0 {
+		respond.OK(w, map[string]any{"apps": []AppStatus{}})
+		return
+	}
+
+	slugs := make([]string, 0, len(installed))
+	for _, a := range installed {
+		slugs = append(slugs, a.Slug)
+	}
+	statuses := h.fetchPodStatuses(r.Context(), org.Subdomain, slugs)
+
+	respond.OK(w, map[string]any{"apps": buildAppStatusRows(installed, statuses)})
+}
+
+// selectOpenableApps narrows the Organization's Apps list to the applications
+// the console renders an Open button for. Backing services are excluded: they
+// are covered by the backing-services endpoint and have no Open button, so a
+// wrong badge on one cannot mislead a customer about a purchase.
+func selectOpenableApps(appIDs []string, byID map[string]*catalog.App) []*catalog.App {
+	seen := make(map[string]bool)
+	var out []*catalog.App
+	for _, appID := range appIDs {
+		a, ok := byID[appID]
+		if !ok || isServiceApp(a) || seen[a.Slug] {
+			continue
+		}
+		seen[a.Slug] = true
+		out = append(out, a)
+	}
+	return out
+}
+
+// buildAppStatusRows joins the installed applications against live pod state.
+//
+// An application with no entry in `statuses` reports "unknown" — the runtime
+// could not be reached. That is deliberately NOT a healthy-looking value: the
+// whole defect in #5451 was a surface that resolved missing information to
+// green. Callers must render "unknown" as unconfirmed, never as serving.
+func buildAppStatusRows(installed []*catalog.App, statuses map[string]podStatus) []AppStatus {
+	out := make([]AppStatus, 0, len(installed))
+	for _, a := range installed {
+		row := AppStatus{ID: a.ID, Slug: a.Slug, PodStatus: "unknown"}
+		if st, ok := statuses[a.Slug]; ok {
+			row.PodStatus = st.PodStatus
+			row.ReadyReplicas = st.ReadyReplicas
+			row.TotalReplicas = st.TotalReplicas
+		}
+		out = append(out, row)
+	}
+	return out
+}

--- a/core/services/tenant/handlers/app_statuses_5451_test.go
+++ b/core/services/tenant/handlers/app_statuses_5451_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/tenant/catalog"
+)
+
+// #5451 — the per-Org console badged four dead applications INSTALLED with live
+// Open buttons because every signal it consulted (the Org's Apps list, the
+// deploy step's status) reports what was *dispatched*, not what serves. These
+// guards cover the join that supplies the missing half.
+
+func TestSelectOpenableApps_ExcludesBackingServices(t *testing.T) {
+	byID := map[string]*catalog.App{
+		"a-listmonk": {ID: "a-listmonk", Slug: "listmonk", Kind: "app"},
+		"a-postgres": {ID: "a-postgres", Slug: "postgres", Kind: "service"},
+		"a-system":   {ID: "a-system", Slug: "internal", System: true},
+		"a-umami":    {ID: "a-umami", Slug: "umami", Kind: "app"},
+	}
+	// Includes an unknown id and a duplicate — both must be dropped without
+	// disturbing the rest.
+	got := selectOpenableApps(
+		[]string{"a-listmonk", "a-postgres", "a-system", "a-umami", "a-ghost", "a-listmonk"},
+		byID,
+	)
+
+	var slugs []string
+	for _, a := range got {
+		slugs = append(slugs, a.Slug)
+	}
+	if len(slugs) != 2 || slugs[0] != "listmonk" || slugs[1] != "umami" {
+		t.Fatalf("want exactly [listmonk umami], got %v", slugs)
+	}
+}
+
+// The load-bearing one. An application the runtime could not be reached for
+// must NOT come back looking healthy — resolving missing information to green
+// is the precise defect this endpoint exists to end.
+func TestBuildAppStatusRows_MissingStatusIsUnknownNotHealthy(t *testing.T) {
+	installed := []*catalog.App{
+		{ID: "a-listmonk", Slug: "listmonk"},
+		{ID: "a-umami", Slug: "umami"},
+	}
+	// Only umami has live state; listmonk is absent from the map.
+	statuses := map[string]podStatus{
+		"umami": {Slug: "umami", PodStatus: "Running", ReadyReplicas: 1, TotalReplicas: 1},
+	}
+
+	rows := buildAppStatusRows(installed, statuses)
+	if len(rows) != 2 {
+		t.Fatalf("want a row per installed app, got %d", len(rows))
+	}
+
+	byID := map[string]AppStatus{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+
+	if got := byID["a-listmonk"].PodStatus; got != "unknown" {
+		t.Errorf("absent runtime state must report \"unknown\", got %q", got)
+	}
+	// Guard the actual hazard rather than just the string: whatever value an
+	// unreachable runtime yields, it must never be one the console reads as
+	// serving. If someone later "helpfully" defaults this to Running, this
+	// fails.
+	if got := byID["a-listmonk"].PodStatus; got == "Running" {
+		t.Errorf("absent runtime state must never report as Running")
+	}
+	if byID["a-listmonk"].ReadyReplicas != 0 {
+		t.Errorf("absent runtime state must not claim ready replicas")
+	}
+
+	u := byID["a-umami"]
+	if u.PodStatus != "Running" || u.ReadyReplicas != 1 || u.TotalReplicas != 1 {
+		t.Errorf("live state must pass through verbatim, got %+v", u)
+	}
+}
+
+// The hw290 shape exactly: pods exist and are Running, but none passed the
+// Ready gate — which is what produces zero Service endpoints and the 503
+// "no healthy upstream" behind the Open button. The row must carry the zero
+// through so the console can act on it.
+func TestBuildAppStatusRows_RunningButZeroReadyIsPreserved(t *testing.T) {
+	rows := buildAppStatusRows(
+		[]*catalog.App{{ID: "a-kuma", Slug: "uptime-kuma"}},
+		map[string]podStatus{
+			"uptime-kuma": {Slug: "uptime-kuma", PodStatus: "Running", ReadyReplicas: 0, TotalReplicas: 1},
+		},
+	)
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].ReadyReplicas != 0 || rows[0].TotalReplicas != 1 {
+		t.Fatalf("ready/total must survive the join, got %d/%d", rows[0].ReadyReplicas, rows[0].TotalReplicas)
+	}
+}
+
+// The route has to exist for any of the above to reach a caller.
+func TestAppStatusesRouteIsRegistered(t *testing.T) {
+	mux, ok := (&Handler{}).Routes().(*http.ServeMux)
+	if !ok {
+		t.Fatalf("Routes() concrete type is not *http.ServeMux")
+	}
+
+	req, err := http.NewRequest("GET", "/organizations/o1/app-statuses", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, pattern := mux.Handler(req)
+	if pattern != "GET /organizations/{id}/app-statuses" {
+		t.Fatalf("app-statuses route not registered; matched %q", pattern)
+	}
+}

--- a/core/services/tenant/handlers/routes.go
+++ b/core/services/tenant/handlers/routes.go
@@ -65,6 +65,11 @@ func (h *Handler) Routes() http.Handler {
 	// provisioning.
 	mux.HandleFunc("GET /organizations/{id}/backing-services", h.ListBackingServices)
 
+	// Authenticated — live runtime state per installed application (#5451).
+	// The Apps list records what was purchased; this reports whether it
+	// actually serves, so the console can stop badging dead apps INSTALLED.
+	mux.HandleFunc("GET /organizations/{id}/app-statuses", h.ListAppStatuses)
+
 	// naming-guard: alias — legacy `/tenant/orgs/{id}/...` sub-resource paths,
 	// one-release deprecation. #3383 renamed the member / app / backing-service
 	// sub-resources to the canonical `/organizations/{id}/...` block above; the


### PR DESCRIPTION
## Problem

The per-Organization console badged four dead applications **INSTALLED** with live **Open** buttons while every one of them served nothing. Live on hw290, `theta-corp`:

| card | console said | actual |
|---|---|---|
| listmonk | INSTALLED + Open | 503 `no healthy upstream` |
| umami | INSTALLED + Open | 503 `no healthy upstream` |
| uptime-kuma | INSTALLED + Open | 503 `connection refused` |
| vaultwarden | INSTALLED + Open | 503 `no healthy upstream` |

All four had **zero Service endpoints**.

## Root cause

Every path by which `appStateFor` reached `installed` was an **intent** fact, never a **readiness** fact:

- `installedIds.includes(app.id)` — the Organization record's Apps list, i.e. what was *purchased*
- `step.status === 'completed'` — the deploy step, i.e. the GitOps commit was *written*
- `if (!step) return { state: 'installed' }` — day-2 installs have no step, so this returned installed **unconditionally**

Nothing in that state machine could observe whether a pod serves. The badge was therefore structurally incapable of being wrong in the safe direction.

## The fix reuses machinery that already exists

The platform already computes live pod readiness — but only for **backing services**, the databases and caches the customer never sees. That endpoint (`GetTenantBackingServices`) turns out to be **fully generic**: it matches pods by name prefix against whatever `services=` list it is handed, with nothing backing-service-specific in it. It was simply never asked about applications.

So this adds the missing question, not a second readiness mechanism:

- **tenant** — `GET /organizations/{id}/app-statuses` returns live pod state per installed application, reusing `fetchPodStatuses` unchanged.
- **console** — a card downgrades to **NOT SERVING** and loses its Open button when runtime state affirmatively says the workload is not serving. Remove stays, so the customer keeps a way to act.

The `appStateFor` wrapper is the single place runtime truth overrules provisioning truth, so no future branch can route around it and paint a dead app green again.

## Deliberately conservative

The downgrade fires **only on positive evidence** — `Failed`, `not_found`, `Pending`, or `Running` with zero ready replicas (the shape that yields zero endpoints and the 503). An unreachable provisioning service yields `unknown`, and the card renders exactly as it does today. A degraded control plane cannot paint healthy applications red.

`unknown` is explicitly documented, on both sides of the wire, as *not* a synonym for healthy — resolving missing information to green is the whole defect.

## Why this one ranks above the failures underneath it

The causes of those four 503s are separately tracked (#5445 postgres `lost+found`, #5449 Kyverno rejecting the platform's own manifests, #5423 poisoned Kustomization). Every one of them is recoverable **once seen** — and this is the defect that prevented them being seen. A customer reading this console concludes their purchase succeeded; so does an operator whose walk stops at the console. Pillar 1's terminal acceptance is *a customer's purchased application actually serving*, and this surface asserted that had happened when it had not.

## Verification

`go build` + `go vet` clean; `astro build` clean (8 pages); tenant handler suite green.

Four guards added, **each proven non-vacuous by reverting the fix and confirming the failure**:

| guard | revert | result |
|---|---|---|
| service apps excluded from the join | drop `isServiceApp` | FAIL — `got [listmonk postgres internal umami]` |
| absent runtime state reports `unknown`, never `Running` | default to `Running` | FAIL — `got "Running"` |
| `Running` with 0 ready survives the join | — | covers the hw290 shape exactly |
| route registered | unregister | FAIL — `matched ""` |

## Not covered here

The same issue notes two smaller inconsistencies in that screenshot — the `Search your 0 apps…` placeholder rendering alongside five cards, and the header badge stuck at `CONVERGING`. Neither is addressed by this change; both need the live environment to diagnose, since the placeholder reads from the same `installedIds` the cards render from and the contradiction is not reproducible from the code alone. Left on #5451.

Refs #5451
