### PR TITLE
fix(provisioning): match vCluster pods for any inner namespace and dashed slugs (Refs #5453 #5451)

### DIFF
--- a/core/services/provisioning/handlers/backing_services.go
+++ b/core/services/provisioning/handlers/backing_services.go
@@ -105,15 +105,21 @@ func (h *Handler) GetTenantBackingServices(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Aggregate pods per service slug. The vCluster pod-sync pattern is
-	// `<service>-<hash>-x-apps-x-vcluster` for services running in the inner
-	// "apps" namespace of the vcluster.
-	const vclusterSuffix = "-x-apps-x-vcluster"
+	// Aggregate pods per service slug. vCluster syncs inner pods up to the host
+	// namespace as `<pod>-x-<inner-namespace>-x-vcluster`.
+	//
+	// The inner namespace is NOT a constant. This used to hardcode
+	// `-x-apps-x-vcluster`, but since #4290 the inner namespace is the Org slug,
+	// so real pods look like `umami-7c4df67dc6-vdwb7-x-theta-corp-x-vcluster`.
+	// Verified live on hw290: ZERO pods across the whole cluster carried the
+	// hardcoded `-x-apps-x-vcluster` form, so this matched nothing and every
+	// service reported "not_found" — a silent, total miss that looked like an
+	// answer.
 	type agg struct {
-		phase  string
-		ready  int
-		total  int
-		image  string
+		phase string
+		ready int
+		total int
+		image string
 	}
 	out := map[string]*agg{}
 	for name := range wanted {
@@ -121,16 +127,16 @@ func (h *Handler) GetTenantBackingServices(w http.ResponseWriter, r *http.Reques
 	}
 
 	for _, pod := range podList.Items {
-		name := pod.Metadata.Name
-		if !strings.HasSuffix(name, vclusterSuffix) {
+		podName, ok := vclusterInnerPodName(pod.Metadata.Name)
+		if !ok {
 			continue
 		}
-		// Strip suffix, then anything after the first `-` is the replica hash.
-		core := strings.TrimSuffix(name, vclusterSuffix)
-		// e.g. "postgres-79dc6fc6d-4n9r5" → prefix "postgres"
-		prefix := core
-		if i := strings.Index(core, "-"); i > 0 {
-			prefix = core[:i]
+		// Match against the requested slugs directly rather than splitting on
+		// the first `-`. Slugs contain dashes: splitting "uptime-kuma-8c8...-x-"
+		// on the first dash yields "uptime", which matches no requested slug.
+		prefix := matchWantedSlug(podName, wanted)
+		if prefix == "" {
+			continue
 		}
 		a, ok := out[prefix]
 		if !ok {
@@ -183,6 +189,44 @@ func (h *Handler) GetTenantBackingServices(w http.ResponseWriter, r *http.Reques
 		})
 	}
 	respond.OK(w, map[string]any{"services": services})
+}
+
+// vclusterInnerPodName recovers the inner pod name from a vCluster-synced host
+// pod name of the form `<pod>-x-<inner-namespace>-x-vcluster`, for ANY inner
+// namespace. Returns false for pods that are not vCluster-synced.
+func vclusterInnerPodName(hostName string) (string, bool) {
+	const tail = "-x-vcluster"
+	if !strings.HasSuffix(hostName, tail) {
+		return "", false
+	}
+	core := strings.TrimSuffix(hostName, tail)
+	// What remains is `<pod>-x-<inner-namespace>`. The inner namespace cannot
+	// itself contain `-x-`, so the LAST occurrence is the true separator even
+	// when the pod name contains one.
+	i := strings.LastIndex(core, "-x-")
+	if i <= 0 {
+		return "", false
+	}
+	return core[:i], true
+}
+
+// matchWantedSlug returns the requested slug that owns this pod, or "" if none
+// does. A pod belongs to a slug when its name is that slug or begins with
+// `<slug>-` (the replica-set/hash tail that Deployments append).
+//
+// The LONGEST match wins, so a slug like "uptime" can never shadow
+// "uptime-kuma" when both are requested.
+func matchWantedSlug(podName string, wanted map[string]bool) string {
+	best := ""
+	for slug := range wanted {
+		if podName != slug && !strings.HasPrefix(podName, slug+"-") {
+			continue
+		}
+		if len(slug) > len(best) {
+			best = slug
+		}
+	}
+	return best
 }
 
 func buildUnknownStatuses(wanted map[string]bool) []BackingServiceStatus {

--- a/core/services/provisioning/handlers/backing_services_vcluster_suffix_5451_test.go
+++ b/core/services/provisioning/handlers/backing_services_vcluster_suffix_5451_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import "testing"
+
+// The pod-name matcher hardcoded the inner vCluster namespace as `apps`. Since
+// #4290 the inner namespace is the Org slug, so the matcher matched NOTHING and
+// every service reported "not_found" — a total miss that read as an answer.
+//
+// Every fixture below is a VERBATIM pod name observed live on hw290
+// (2026-07-27, namespace theta-corp), not an invented shape.
+
+func TestVclusterInnerPodName_RealHw290Names(t *testing.T) {
+	cases := []struct {
+		host string
+		want string
+		ok   bool
+	}{
+		// The form that broke it: inner namespace is the Org slug, not "apps".
+		{"umami-7c4df67dc6-vdwb7-x-theta-corp-x-vcluster", "umami-7c4df67dc6-vdwb7", true},
+		{"uptime-kuma-8c896959b-dqdbn-x-theta-corp-x-vcluster", "uptime-kuma-8c896959b-dqdbn", true},
+		{"postgres-6686dd746c-ljztg-x-theta-corp-x-vcluster", "postgres-6686dd746c-ljztg", true},
+		{"coredns-7f84df6475-lscbf-x-kube-system-x-vcluster", "coredns-7f84df6475-lscbf", true},
+		// The legacy form must keep working.
+		{"postgres-79dc6fc6d-4n9r5-x-apps-x-vcluster", "postgres-79dc6fc6d-4n9r5", true},
+		// Host-native pods are not vCluster-synced.
+		{"vcluster-0", "", false},
+		{"orgpg-1", "", false},
+		{"postgres-1-initdb-v67jd", "", false},
+	}
+	for _, c := range cases {
+		got, ok := vclusterInnerPodName(c.host)
+		if ok != c.ok || got != c.want {
+			t.Errorf("%s → (%q,%v), want (%q,%v)", c.host, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// Slugs contain dashes. Splitting on the first dash mapped "uptime-kuma-..." to
+// "uptime", which matches no requested slug — so even with the suffix fixed,
+// every multi-word app would still have reported not_found.
+func TestMatchWantedSlug_DashedSlugsAndLongestWins(t *testing.T) {
+	wanted := map[string]bool{"umami": true, "uptime-kuma": true, "postgres": true}
+
+	if got := matchWantedSlug("uptime-kuma-8c896959b-dqdbn", wanted); got != "uptime-kuma" {
+		t.Errorf("dashed slug: got %q, want uptime-kuma", got)
+	}
+	if got := matchWantedSlug("umami-7c4df67dc6-vdwb7", wanted); got != "umami" {
+		t.Errorf("simple slug: got %q, want umami", got)
+	}
+	if got := matchWantedSlug("coredns-7f84df6475-lscbf", wanted); got != "" {
+		t.Errorf("unrequested workload must not match, got %q", got)
+	}
+
+	// A shorter slug must never shadow a longer one that also matches.
+	shadow := map[string]bool{"uptime": true, "uptime-kuma": true}
+	if got := matchWantedSlug("uptime-kuma-8c896959b-dqdbn", shadow); got != "uptime-kuma" {
+		t.Errorf("longest match must win, got %q", got)
+	}
+
+	// A slug must not match a different workload that merely shares a prefix.
+	if got := matchWantedSlug("umamiother-abc", map[string]bool{"umami": true}); got != "" {
+		t.Errorf("prefix must be dash-delimited, got %q", got)
+	}
+}


### PR DESCRIPTION
## Defect

`GetTenantBackingServices` matches vCluster-synced pods against a **hardcoded inner namespace**:

```go
const vclusterSuffix = "-x-apps-x-vcluster"
if !strings.HasSuffix(name, vclusterSuffix) { continue }
```

Since #4290 the inner vCluster namespace is the **Org slug**, not `apps`. Real pods on hw290 look like:

```
umami-7c4df67dc6-vdwb7-x-theta-corp-x-vcluster
uptime-kuma-8c896959b-dqdbn-x-theta-corp-x-vcluster
postgres-6686dd746c-ljztg-x-theta-corp-x-vcluster
```

**Measured live on hw290 (2026-07-27):** across the entire cluster, pods carrying the required `-x-apps-x-vcluster` suffix: **0**. The only vCluster-sync suffixes present are `-x-theta-corp-x-vcluster` (3) and `-x-kube-system-x-vcluster` (3).

So the matcher matches nothing, every backing service falls to `total == 0`, and the endpoint reports **`not_found`** for all of them. It has been returning a confident wrong answer rather than an error.

## Second, independent defect in the same loop

Even with the suffix fixed, the slug is derived by splitting on the **first** dash:

```go
prefix = core[:strings.Index(core, "-")]   // "uptime-kuma-8c8..." -> "uptime"
```

Every multi-word slug (`uptime-kuma`, and any future dashed app) maps to a prefix that matches no requested slug. Both defects had to be fixed for either to work.

## Blast radius

- **Existing:** the per-Org console's backing-services view has been showing `not_found` for live, healthy databases.
- **New:** #5451's app-status endpoint reuses this matcher. Because `not_found` drives the NOT SERVING badge, the #5451 fix as merged in #5452 would have badged **every application** NOT SERVING — including healthy ones. That is precisely the over-correction #5452 claimed to guard against, and it would have been visible the moment it deployed.

## How it was found

Not by a test — by walking hw290 live and reading the actual pod names. Both the endpoint and its callers were internally consistent and agreed on a wrong answer; only ground truth disagreed.

## Fix

`vclusterInnerPodName()` accepts `<pod>-x-<any-namespace>-x-vcluster` (last `-x-` is the separator, since a namespace cannot contain `-x-`), and `matchWantedSlug()` matches requested slugs by dash-delimited prefix with longest-match-wins so `uptime` can never shadow `uptime-kuma`.

Guards use the verbatim hw290 pod names as fixtures, including the legacy `-x-apps-x-vcluster` form so the old convention keeps working.
