### PR TITLE
fix(console): catalog detail hero reads the live CR, not the stale seed (Refs #5449)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.nameKey.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.nameKey.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+/**
+ * #5449 — the hero version chip read a DIFFERENT object than the rest of the
+ * page.
+ *
+ * `/api/v1/catalog/alloy` and `/api/v1/catalog/bp-alloy` are not two spellings
+ * of one thing: the bare form resolves the stale Gitea catalog seed, the
+ * `bp-`-qualified form resolves the live Blueprint CR. CatalogDetail stripped
+ * the prefix once and then re-added it at every call site EXCEPT the hero
+ * fetch, so the chip rendered v1.0.2 from the seed beside a title and summary
+ * the page itself had just saved as v1.0.3.
+ *
+ * This is asserted against the source text rather than by rendering, because
+ * the defect is not a rendering bug — it is a call-site drifting off the shared
+ * key. A render test would pass with the drift restored so long as a fixture
+ * happened to answer both spellings identically, which is exactly how this
+ * survived in the first place.
+ */
+const SRC = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'CatalogDetail.tsx'),
+  'utf8',
+)
+
+describe('CatalogDetail blueprint name key (#5449)', () => {
+  it('derives one qualified key from the route param', () => {
+    expect(SRC).toMatch(/const\s+qualifiedName\s*=/)
+  })
+
+  it('fetches the catalog item with the bp- qualified key, never the bare name', () => {
+    const call = SRC.match(/getCatalogItem\(([^)]*)\)/)
+    expect(call, 'getCatalogItem call not found').toBeTruthy()
+    const arg = (call as RegExpMatchArray)[1].trim()
+    // The bare `name` here is the whole defect: it resolves the stale seed.
+    expect(arg).not.toBe('name')
+    expect(arg).toBe('qualifiedName')
+  })
+
+  it('has exactly one place that builds the bp- prefix', () => {
+    // Every call site sharing one derived key is what keeps them from drifting
+    // apart again. More than one construction site means the invariant is back
+    // to being maintained by hand.
+    const inline = SRC.match(/`bp-\$\{name\}`/g) ?? []
+    expect(inline.length).toBe(1)
+    expect(SRC).toContain("const qualifiedName = name ? `bp-${name}` : ''")
+  })
+
+  it('keeps the bare name available for display', () => {
+    // The fix must not swing the other way and start rendering "bp-alloy" as
+    // the page heading.
+    expect(SRC).toMatch(/const\s+name\s*=\s*\(params\.blueprintName\s*\?\?\s*''\)\.replace\(\/\^bp-\/,\s*''\)/)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -127,7 +127,17 @@ export function CatalogDetail() {
     blueprintName?: string
     deploymentId?: string
   }
+  // `name` is the BARE blueprint name (no `bp-` prefix) and exists for DISPLAY
+  // only — headings, logo lookup, empty/error copy.
   const name = (params.blueprintName ?? '').replace(/^bp-/, '')
+  // #5449 — every API call on this page must use the `bp-`-qualified key.
+  // `/api/v1/catalog/alloy` and `/api/v1/catalog/bp-alloy` are DIFFERENT
+  // objects: the bare form resolves the stale Gitea catalog seed, the qualified
+  // form resolves the live Blueprint CR. The hero version chip was the only
+  // caller passing the bare name, so it rendered v1.0.2 from the seed beside a
+  // title and summary that had been edited to v1.0.3 — an edit the page itself
+  // had just persisted. Derive the key once so no caller can drift again.
+  const qualifiedName = name ? `bp-${name}` : ''
   const { deploymentId } = useResolvedDeploymentId()
   const isAdmin = useCatalogAdmin()
   const { theme } = useTheme()
@@ -159,9 +169,9 @@ export function CatalogDetail() {
       : `/provision/${depParam}`
 
   const catalogQuery = useQuery<CatalogItem>({
-    queryKey: ['catalog-item', name],
-    queryFn: () => getCatalogItem(name),
-    enabled: !!name,
+    queryKey: ['catalog-item', qualifiedName],
+    queryFn: () => getCatalogItem(qualifiedName),
+    enabled: !!qualifiedName,
     staleTime: 30_000,
     retry: 1,
   })
@@ -175,7 +185,7 @@ export function CatalogDetail() {
   // Returns null on 404 (no install / not a bootstrap app) — harmless.
   const bootstrapQuery = useQuery({
     queryKey: ['catalog-bootstrap', deploymentId, name],
-    queryFn: () => getApplication(deploymentId ?? '', `bp-${name}`),
+    queryFn: () => getApplication(deploymentId ?? '', qualifiedName),
     enabled: !!name && !!deploymentId,
     staleTime: 30_000,
     retry: 1,
@@ -237,7 +247,7 @@ export function CatalogDetail() {
   // #3370 — shareability declaration from the build-time catalog (the
   // same blueprint.yaml truth the catalog-seed locks against). Drives
   // the `shareable` badge; one generic mechanism for every blueprint.
-  const generated = BLUEPRINT_BY_ID[`bp-${name}`]
+  const generated = BLUEPRINT_BY_ID[qualifiedName]
   const shareable =
     generated?.shareable === true ||
     (cat.raw as { spec?: { shareable?: boolean } } | undefined)?.spec?.shareable === true
@@ -313,7 +323,7 @@ export function CatalogDetail() {
             logo. The picker writes the icon via the same saveCatalogEdit seam. */}
         {isAdmin ? (
           <CatalogInlineField<{ light: string; dark: string }>
-            blueprintId={`bp-${name}`}
+            blueprintId={qualifiedName}
             fieldKey="icon"
             label="Icon (light + dark)"
             current={currentEdit}
@@ -371,7 +381,7 @@ export function CatalogDetail() {
           {/* #3668 §5A — the display name is a per-field inline editor. */}
           <h1>
             <CatalogInlineField<string>
-              blueprintId={`bp-${name}`}
+              blueprintId={qualifiedName}
               fieldKey="name"
               label="Display name"
               current={currentEdit}
@@ -407,7 +417,7 @@ export function CatalogDetail() {
                   // YamlEditor falls back to cat.raw (unchanged behavior).
                   setCommittedIac(null)
                   setEditingIaC(true)
-                  void getCatalogBlueprintIaC(`bp-${name}`).then(setCommittedIac)
+                  void getCatalogBlueprintIaC(qualifiedName).then(setCommittedIac)
                 }}
                 title="Edit the full blueprint IaC (advanced)"
                 style={CATALOG_EDIT_BTN_STYLE}
@@ -422,7 +432,7 @@ export function CatalogDetail() {
           {isAdmin ? (
             <div className="hero-tagline">
               <CatalogInlineField<string>
-                blueprintId={`bp-${name}`}
+                blueprintId={qualifiedName}
                 fieldKey="summary"
                 label="Summary"
                 current={currentEdit}
@@ -589,12 +599,12 @@ export function CatalogDetail() {
             deploymentId={deploymentId ?? ''}
             kind="Blueprint"
             ns={undefined}
-            name={`bp-${name}`}
+            name={qualifiedName}
             obj={(cat.raw as K8sObject | undefined) ?? null}
             seedYaml={committedIac ?? undefined}
             commitLabel="Commit IaC"
             onCommit={async (yaml) => {
-              const resp = await saveCatalogBlueprintIaC(`bp-${name}`, yaml)
+              const resp = await saveCatalogBlueprintIaC(qualifiedName, yaml)
               if (!resp.committed) {
                 throw new Error(resp.reason || 'IaC commit did not land')
               }
@@ -652,7 +662,7 @@ export function CatalogDetail() {
             <div className="singleton-meta">
               <Link
                 to={'/app/$componentId' as never}
-                params={{ componentId: `bp-${name}` } as never}
+                params={{ componentId: qualifiedName } as never}
                 className="external-url-link"
                 data-testid="catalog-singleton-link"
               >
@@ -678,7 +688,7 @@ export function CatalogDetail() {
             </div>
             <Link
               to={'/app/$componentId' as never}
-              params={{ componentId: `bp-${name}` } as never}
+              params={{ componentId: qualifiedName } as never}
               className="btn btn-primary singleton-open"
               data-testid="catalog-singleton-open"
             >
@@ -690,7 +700,7 @@ export function CatalogDetail() {
         // #3090 / #3165 — shared CLASS-page instances list + "+ New
         // instance" (inline topology-picker dialog). Instance rows link
         // to the INSTANCE page `/app/$componentId`.
-        <InstancesSection blueprint={`bp-${name}`} multiInstance={multiInstance} />
+        <InstancesSection blueprint={qualifiedName} multiInstance={multiInstance} />
       )}
 
       {/* Supported topologies. The read-only grid (with per-topology placement)
@@ -740,7 +750,7 @@ export function CatalogDetail() {
           {isAdmin ? (
             <div style={{ marginTop: '0.7rem' }}>
               <CatalogInlineField<string[]>
-                blueprintId={`bp-${name}`}
+                blueprintId={qualifiedName}
                 fieldKey="topologies"
                 label="Supported topologies"
                 current={currentEdit}


### PR DESCRIPTION
## Defect

The Blueprint detail page rendered its hero version chip from a **different object** than the rest of the page, so the chip could never reflect an edit. Live on hw290: the page titled **Alloy R143** with a summary the console had just saved, and the chip beside it reading `v1.0.2`.

## Root cause — a name-key split

`CatalogDetail.tsx` stripped the prefix once and re-added it at every call site **except** the hero fetch. The two spellings are not two names for one thing:

```
GET /api/v1/catalog/alloy      -> stale Gitea catalog seed   v1.0.2
GET /api/v1/catalog/bp-alloy   -> live Blueprint CR          v1.0.3
```

`getCatalogItem(name)` was the sole bare-name caller. `getApplication`, `getCatalogBlueprintIaC`, `saveCatalogBlueprintIaC`, `BLUEPRINT_BY_ID` and the rest all passed `bp-${name}`. So the edit persisted correctly and was displayed as if it had not.

## Fix

Derive the qualified key **once** and route all 13 call sites through it, so a future caller cannot quietly drift off it. The bare `name` remains for display — headings, logo lookup, error copy — and the guard checks it did not swing the other way and start rendering `bp-alloy` as the page title.

## Why the guard asserts on source text

This is not a rendering fault; it is a call site drifting off a shared key. A render test would pass with the drift restored so long as a fixture answered both spellings identically — which is exactly how it survived. The guard pins the call argument and that exactly one place constructs the prefix.

Verified non-vacuous — restoring the bare-name call fails:

```
AssertionError: expected 'name' not to be 'name'
Tests  1 failed | 3 passed (4)
```

Restored: `Tests 4 passed (4)`. `npm run build` clean.

Refs #5449