### PR TITLE
fix(cnpg-pair): dr-failback surfaces peer-probe starvation on the HR — no more silent split-brain at D0 (Refs #5388)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1299,7 +1299,10 @@ spec:
       #   `endpoints: []` made userUIGatePasses fail closed, suppressing the
       #   externalURL the hero CTA + grid button render from, and 404'ing
       #   GET /catalyst/v1/apps/bp-newapi/launch-url. UAT row 114.
-      version: 1.4.1242
+      # 1.4.1243 (#5388): catalog-seed bp-cnpg-pair 0.2.22 -> 0.2.23 —
+      #   dr-failback starvation surfacing (hw290 G12 leg-6); lockstep
+      #   w/ 16b slot 0.2.23 (pin-sync gate).
+      version: 1.4.1243
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -313,7 +313,14 @@ spec:
       # -allow-replication-to-primary policy (default-denies all other ingress).
       # hw287: cnpg-pair region-b replica pg_stat_wal_receiver=streaming yet all
       # 8 Continuum CRs read standbyAvailable=UNSET. Substitutes unchanged.
-      version: 0.2.22
+      # 0.2.23 (#5388): dr-failback starvation surfacing (hw290 G12 leg-6) —
+      # when the post-failover geometry candidate (local writable primary, sync
+      # standby absent) persists with the peer probe failing observability-dead
+      # (nxdomain/unreachable/tl-unreadable — the rebooted-region datapath
+      # shape, #5339), the actor records dr-failback-starved-at + reason on the
+      # HR instead of idling silently at D0 while a split-brain persists.
+      # Diagnostic only; substitutes unchanged.
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -120,7 +120,12 @@ spec:
   # topology (the #5335 Secret-RBAC fix was necessary-not-sufficient; the
   # connection was still NetworkPolicy-dropped — hw287 residual). NetworkPolicy
   # + values only; no schema/RBAC/resource delta to the Cluster CRs.
-  version: 0.2.22
+  # 0.2.23 (#5388): dr-failback starvation surfacing — when the post-failover
+  # geometry candidate persists with the peer unobservable (the hw290 G12 leg-6
+  # rebooted-region datapath shape, #5339), the actor records
+  # dr-failback-starved-at + reason on the HR instead of idling silently at D0
+  # while a split-brain persists. Script + env + value only.
+  version: 0.2.23
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.23 (#5388): dr-failback STARVATION SURFACING (hw290 G12 leg-6). All four
+# region-A nodes rebooted through the kill, the per-node cross-region routes
+# were gone (#5339 shape), and the failback actor idled at D0 forever while the
+# split-brain persisted — the only evidence in region-A pod logs. The signals
+# container now accrues a starvation clock while the post-failover geometry
+# candidate (local writable primary, sync standby ABSENT) persists with the
+# peer probe failing for an OBSERVABILITY-DEAD reason (nxdomain / unreachable /
+# tl-unreadable; an observable-but-ineligible peer clears), and the actor
+# records `dr-failback-starved-at` + reason on the HR after
+# starvationSurfaceSeconds (default 300). Diagnostic only — a 2-node actor
+# cannot tell region-B-dead from region-B-unreachable, so it never acts on
+# blindness, but it no longer stays silent about it. Script + one env + one
+# value; no schema/RBAC/resource delta.
 # 0.2.22 (#5311): NetworkPolicy carve-out for the continuum-controller standby
 # probe — the residual after the #5335 Secret-RBAC fix. #5311 taught the
 # continuum-controller to read the acting primary's pg_stat_replication over
@@ -363,7 +376,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.22
+version: 0.2.23
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/dr-failback.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-failback.yaml
@@ -284,6 +284,7 @@ cluster-B).
 {{- $probeTimeout := $fb.livenessProbeTimeoutSeconds | default 5 }}
 {{- $wedgeHold := $fb.wedgeHoldSeconds | default 600 }}
 {{- $divergenceGrace := $fb.divergenceGraceSeconds | default 180 }}
+{{- $starvationSurface := $fb.starvationSurfaceSeconds | default 300 }}
 {{- $peerClusters := .Values.cnpgPair.networkPolicy.crossRegionPeerClusters | default list }}
 ---
 apiVersion: v1
@@ -533,6 +534,11 @@ spec:
                 rm -f /shared/peer-ahead-since
               }
               clear_wedge() { rm -f /shared/wedge-since; }
+              # #5388 — starvation clock: accrues ONLY while the
+              # post-failover geometry candidate (local primary, sync
+              # standby absent) persists with the peer probe failing for
+              # an observability-dead reason. Every other path clears it.
+              starve_clear() { rm -f /shared/peer-starved-since; }
               # peer_report <key> <message> — #5245 FAIL-LOUD probe
               # diagnostics (chart 0.2.19). hw277: the loop sat 57 min
               # after 'loop started' with ZERO output while the peer
@@ -638,6 +644,7 @@ spec:
                 if [ "$((NOW - STARTED))" -lt "${STARTUP_GRACE_SECONDS}" ]; then
                   clear_hold "startup grace ($((NOW - STARTED))s<${STARTUP_GRACE_SECONDS}s, state=${STATE})"
                   clear_wedge
+                  starve_clear
                   sleep "${INTERVAL_SECONDS}"; continue
                 fi
                 case "${STATE}" in
@@ -648,21 +655,37 @@ spec:
                       # Standby streaming from us (or probe failed) — the pair
                       # is healthy (or unknowable): fail-safe, no failback.
                       clear_hold "local primary with sync standby ${SYNC}"
+                      starve_clear
                       sleep "${INTERVAL_SECONDS}"; continue
                     fi
                     TL_LOCAL=$(tl_of "${LOCAL_REPL}")
                     if ! is_int "${TL_LOCAL}"; then
                       clear_hold "local timeline unreadable — fail-safe"
+                      starve_clear
                       sleep "${INTERVAL_SECONDS}"; continue
                     fi
                     echo "${TL_LOCAL}" > /shared/tl-local
                     if probe_peer_ahead "${TL_LOCAL}"; then
+                      starve_clear
                       if [ ! -f /shared/peer-ahead-since ]; then
                         echo "${NOW}" > /shared/peer-ahead-since
                         echo "$(date -u +"%FT%TZ") [dr-failback/signals] POST-FAILOVER GEOMETRY: local writable TL=${TL_LOCAL}, sync standby ABSENT, peer WRITABLE on TL=$(cat /shared/tl-peer) (>= local) — peer-ahead hold clock started (#5245)"
                       fi
                     else
                       clear_hold "peer not provably writable+equal-or-ahead (reason in the fail-loud peer-probe line above)"
+                      # #5388 — this is the hw290 leg-6 shape: local primary,
+                      # sync standby gone, and the peer UNOBSERVABLE
+                      # (nxdomain / unreachable / tl-unreadable — e.g. the
+                      # rebooted region's cross-region routes not yet healed,
+                      # #5339). Accrue the starvation clock so the actor can
+                      # surface it on the HR; an observable-but-ineligible
+                      # peer (in-recovery / tl-behind) clears instead — those
+                      # geometries are diagnosed by their own reasons.
+                      case "$(cat /shared/peer-probe-reason 2>/dev/null || echo '')" in
+                        nxdomain|unreachable|tl-unreadable)
+                          [ -f /shared/peer-starved-since ] || echo "${NOW}" > /shared/peer-starved-since ;;
+                        *) starve_clear ;;
+                      esac
                     fi
                     ;;
                   streaming)
@@ -682,6 +705,7 @@ spec:
                     # and never consumes the proof.
                     clear_hold "local standby streaming (data-plane signal; actor verifies ConsistentSystemID)"
                     clear_wedge
+                    starve_clear
                     : > /shared/converged-streaming
                     probe_peer_writable_report
                     ;;
@@ -691,6 +715,7 @@ spec:
                     # wedge candidate (stale TL-N PGDATA that cannot follow) —
                     # accrue the wedge clock for the actor's escalation.
                     clear_hold "local standby state=${STATE}"
+                    starve_clear
                     rm -f /shared/converged-streaming
                     TL_LOCAL=$(tl_of "${LOCAL_REPL}")
                     if is_int "${TL_LOCAL}" && probe_peer_ahead "${TL_LOCAL}"; then
@@ -717,6 +742,7 @@ spec:
                     # bootstrap-looping re-clone has no endpoints at all).
                     clear_hold "local state unknown (probe failed — fail-safe)"
                     clear_wedge
+                    starve_clear
                     rm -f /shared/converged-streaming
                     probe_peer_writable_report
                     ;;
@@ -897,6 +923,36 @@ spec:
 
                   # ── D0: DECIDE — flip the durable demotion substitute ─
                   if [ "${SUB}" != "true" ]; then
+                    # ── #5388 STARVATION SURFACING (0.2.23, hw290 G12 leg-6) ──
+                    # The post-failover geometry candidate (local writable
+                    # primary, sync standby ABSENT) has persisted while the
+                    # peer probe fails for an OBSERVABILITY-DEAD reason —
+                    # on hw290 the rebooted region's cross-region routes
+                    # were gone (#5339 shape) and this actor idled at D0
+                    # forever while the split-brain persisted, with the only
+                    # evidence in this pod's logs. Record the starvation on
+                    # the HR where an operator looks. Diagnostic only: a
+                    # 2-node actor cannot distinguish region-B-dead (serving
+                    # here is CORRECT) from region-B-unreachable (split-
+                    # brain), so it must never act on blindness — but it
+                    # must not be silent about it either. Re-records on
+                    # reason change; clears its marker when the probe
+                    # recovers so a later episode records afresh.
+                    if [ -f /shared/peer-starved-since ]; then
+                      _ss=$(cat /shared/peer-starved-since 2>/dev/null || echo "")
+                      _now=$(date -u +%s)
+                      _reason=$(cat /shared/peer-probe-reason 2>/dev/null || echo "unknown")
+                      if [ -n "${_ss}" ] && [ "$((_now - _ss))" -ge "${STARVATION_SURFACE_SECONDS}" ] && [ "$(cat /shared/starved-recorded 2>/dev/null || echo '')" != "${_reason}" ]; then
+                        if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-starved-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-failback-starved-reason\":\"peer probe ${_reason} for >=${STARVATION_SURFACE_SECONDS}s while local is a writable primary with the sync standby absent — failback cannot observe the peer; if region-B was promoted this IS a live split-brain until the mesh/datapath heals (#5388 #5339)\"}}}" >/dev/null 2>&1; then
+                          echo "${_reason}" > /shared/starved-recorded
+                          echo "$(date -u +"%FT%TZ") [dr-failback/actor] STARVED: post-failover geometry candidate held $((_now - _ss))s with peer probe '${_reason}' — recorded dr-failback-starved-at on HR ${HR_NAMESPACE}/${HR_NAME}; failback is BLIND, not idle (#5388)"
+                        else
+                          echo "$(date -u +"%FT%TZ") [dr-failback/actor] WARN: could not record starvation on HR (RBAC/conflict?) — retrying next tick (#5388)"
+                        fi
+                      fi
+                    else
+                      rm -f /shared/starved-recorded
+                    fi
                     [ -f /shared/peer-ahead-since ] || exit 0
                     SINCE=$(cat /shared/peer-ahead-since)
                     NOW=$(date -u +%s)
@@ -1069,6 +1125,8 @@ spec:
               value: {{ $wedgeHold | quote }}
             - name: DIVERGENCE_GRACE_SECONDS
               value: {{ $divergenceGrace | quote }}
+            - name: STARVATION_SURFACE_SECONDS
+              value: {{ $starvationSurface | quote }}
             - name: INTERVAL_SECONDS
               value: {{ $interval | quote }}
             - name: PRIMARY_CLUSTER

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -1493,6 +1493,30 @@ PYEOF
 sh -n "$TMP/fb-signals.sh" || { echo "FAIL: #5331 signals script is not valid POSIX shell." >&2; exit 1; }
 sh -n "$TMP/fb-actor.sh"   || { echo "FAIL: #5331 actor script is not valid POSIX shell." >&2; exit 1; }
 
-echo "  PASS (CONVERGED gated on ConsistentSystemID=True + streaming + demoted · divergence escalation on CNPG verdict alone · streaming arm keeps peer-writable proof fresh · post-re-clone watch keys off converged-recorded)"
+# (f) 0.2.23 #5388 — STARVATION SURFACING. The hw290 G12 leg-6 shape: the
+#     post-failover geometry candidate persists while the peer probe fails
+#     observability-dead, and the actor idled at D0 forever with the split-
+#     brain visible only in pod logs. The signals script must accrue the
+#     starvation clock ONLY on the observability-dead reasons (an
+#     observable-but-ineligible peer — in-recovery/tl-behind — must clear),
+#     and the actor must surface it on the HR before the peer-ahead early-exit.
+python3 - "$TMP/fb-signals.sh" "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #5388 starvation-surfacing assertions failed." >&2; exit 1; }
+import sys
+sig=open(sys.argv[1]).read(); act=open(sys.argv[2]).read()
+i=sig.find('nxdomain|unreachable|tl-unreadable)')
+assert i!=-1, "#5388: signals must accrue the starvation clock on exactly the observability-dead probe reasons"
+arm=sig[i:i+220]
+assert 'peer-starved-since' in arm, "#5388: the observability-dead case must write /shared/peer-starved-since"
+assert 'starve_clear' in sig[i:i+400], "#5388: any other probe reason must CLEAR the starvation clock (in-recovery/tl-behind are diagnosed by their own reasons)"
+assert sig.count('starve_clear')>=8, "#5388: every non-accruing path through the signals loop must clear the starvation clock (helper + 7 call sites)"
+j=act.find('dr-failback-starved-at')
+assert j!=-1, "#5388: actor must record dr-failback-starved-at on the HR"
+assert 'STARVATION_SURFACE_SECONDS' in act, "#5388: the surfacing threshold must be env-wired (starvationSurfaceSeconds)"
+k=act.find('peer-ahead-since ] || exit 0')
+assert k!=-1 and j<k, "#5388: the starvation surfacing must run BEFORE the D0 peer-ahead early-exit or it never executes on the starved path"
+assert 'delete' not in act[j:k], "#5388: the starvation path is DIAGNOSTIC-ONLY — it must never touch a destructive verb"
+PYEOF
+
+echo "  PASS (CONVERGED gated on ConsistentSystemID=True + streaming + demoted · divergence escalation on CNPG verdict alone · streaming arm keeps peer-writable proof fresh · post-re-clone watch keys off converged-recorded · starvation surfaced on HR before D0 early-exit, diagnostic-only)"
 
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -132,6 +132,21 @@ cnpgPair:
       # is never deleted (bounded destruction), and the delete still
       # requires a <60s-fresh writable-peer proof.
       divergenceGraceSeconds: 180
+      # 0.2.23 (#5388 hw290 G12 leg-6): how long the post-failover
+      # geometry candidate (local writable primary + pinned sync
+      # standby ABSENT) may persist with the peer probe failing for an
+      # OBSERVABILITY-DEAD reason (nxdomain / unreachable /
+      # tl-unreadable) before the actor surfaces the starvation on the
+      # HR (`dr-failback-starved-at` + reason). On hw290 all four
+      # region-A nodes rebooted through the kill, the per-node
+      # cross-region routes were gone (#5339 shape), and the failback
+      # actor sat silently at D0 forever — the split-brain persisted
+      # with the only evidence buried in region-A pod logs. This
+      # surfaces the wedge where an operator looks; it changes NO
+      # destructive behaviour (a 2-node actor still cannot tell
+      # region-B-dead from region-B-unreachable, so it must not act —
+      # but it CAN say loudly that it is blind).
+      starvationSurfaceSeconds: 300
       # The flux Kustomization whose postBuild.substitute map carries
       # the durable SOVEREIGN_CNPG_PAIR_DEMOTED flip (the catalyst-api
       # enableCNPGPairAfterFullMesh precedent — a custom field manager

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3603,7 +3603,15 @@ name: bp-catalyst-platform
 #   (reason=ProvisioningIncomplete) naming the missing artifact, and keeps the 30s
 #   requeue alive so the up-path re-converges. Read-only — Flux still owns the
 #   apply. Refs #5395.
-version: 1.4.1242
+# 1.4.1243 — #5388: catalog-seed bp-cnpg-pair pin 0.2.22 -> 0.2.23 (+ spec.version
+#   display label) — dr-failback STARVATION SURFACING (hw290 G12 leg-6): when the
+#   post-failover geometry candidate persists with the peer probe failing
+#   observability-dead (nxdomain/unreachable/tl-unreadable — the rebooted-region
+#   datapath shape, #5339), the actor records dr-failback-starved-at + reason on
+#   the HR instead of idling silently at D0 while a split-brain persists.
+#   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync gate). Lockstep w/ 16b
+#   slot 0.2.23.
+version: 1.4.1243
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -411,12 +411,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  # 0.2.22 (#5311): NetworkPolicy carve-out admitting the continuum-controller
-  # to the primary -rw:5432 so its standby probe surfaces status.standbyAvailable
-  # on a TRUE 2-region topology (hw287 residual after the #5335 Secret-RBAC fix).
-  # Keep this display-version in lockstep with delivery source.version +
-  # blueprint.yaml (the #4988 precedent).
-  version: "0.2.22"
+  # 0.2.23 (#5388): dr-failback starvation surfacing — the actor records
+  # dr-failback-starved-at + reason on the HR when the post-failover geometry
+  # persists with the peer unobservable (hw290 G12 leg-6 rebooted-region
+  # datapath shape, #5339), instead of idling silently while a split-brain
+  # persists. Keep this display-version in lockstep with delivery
+  # source.version + blueprint.yaml (the #4988 precedent).
+  version: "0.2.23"
   visibility: listed
   card:
     title: "CNPG Cluster-Pair (Active-Hotstandby DR)"
@@ -446,7 +447,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.22"
+    version: "0.2.23"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## What

The observability half of #5388 (P0, G12 leg 6): `dr-failback` now **surfaces peer-probe starvation on the HelmRelease** (`dr-failback-starved-at` + reason) instead of idling silently at its D0 early-exit while a split-brain persists.

## The hw290 leg-6 mechanism this addresses

The demote+re-clone machinery exists and was proven on hw288 (#5332). On hw290 it never acted because it never *could*: the region-kill was a hard `os-stop`/`os-start` of all four region-A nodes, which is exactly the #5339 rebooted-region shape — per-node cross-region routes gone — so the actor's peer probe (`pg_isready` over the `-replica-mesh` global Service) failed every tick. D0 is `[ -f /shared/peer-ahead-since ] || exit 0`: with the probe starved, the actor idled forever, region-A resumed its stale TL-1 primary, and the only evidence was `peer probe STILL: unreachable` lines in a region-A pod log nobody reads.

## How

- **signals**: a starvation clock (`/shared/peer-starved-since`) accrues ONLY while the post-failover geometry candidate (local writable primary, pinned sync standby ABSENT) persists with the probe failing for an **observability-dead** reason (`nxdomain` / `unreachable` / `tl-unreadable`). An observable-but-ineligible peer (`in-recovery`, `tl-behind`) clears — those geometries are already diagnosed by their own fail-loud reasons. Every other path through the loop clears (helper + 7 call sites).
- **actor**: after `starvationSurfaceSeconds` (default 300), records `dr-failback-starved-at` + `dr-failback-starved-reason` on the HR, **before** the D0 early-exit; re-records on reason change; clears its marker when the probe recovers.
- **Diagnostic only, deliberately**: a 2-node actor cannot distinguish region-B-dead (serving locally is CORRECT) from region-B-unreachable (split-brain), so acting on blindness would be wrong in one of the two worlds. It must not be silent about blindness either — that silence is what made leg 6 invisible.

## Verification

- Render gate **(f)** added: asserts the exact accrual reasons, the clear discipline (≥8 sites), env wiring, placement before the early-exit, and that the starved path carries **no destructive verb**. Full suite 21/21 PASS.
- `tests/e2e/bootstrap-kit` lockstep guards green (chart 0.2.23 across Chart.yaml, blueprint.yaml, 16b slot, catalog-seed display+source, umbrella 1.4.1243, slot-13 — renumbered after the deploy-bot took 1.4.1242).

## What this PR deliberately leaves open on the issue

Issue #5388 stays open: its checklist items 1 and 3 (demote + re-clone on return; identical row set on both regions post-failback) are proven only by a live G12 leg-6 pass, which rides the next fresh prov together with the already-merged #5340 route-reconciler (the datapath heal that lets the probe recover at all). This PR makes the failure mode diagnosable from the console/jobs surface if it ever recurs.

Refs #5388 #5339 #5245

🤖 Generated with [Claude Code](https://claude.com/claude-code)