### PR TITLE
fix(console): revoke stale authed marker on 401 + run the silent-SSO leg on cookie expiry (Refs #5460)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
@@ -185,6 +185,32 @@ describe('probeWhoamiAndCacheMarker', () => {
     expect(sessionStorage.getItem('catalyst:authed')).toBeNull()
   })
 
+  it('REVOKES a stale marker on 401 (#5460 — the flag must not outlive the session)', async () => {
+    // hw290 row-29: after TTL expiry the marker survived, hasCatalystSession()
+    // short-circuited the gate past its whoami probe AND the silent-SSO leg,
+    // and every marker-consuming surface rendered authenticated chrome
+    // against a dead session. The authority's 401 must clear the cache.
+    sessionStorage.setItem('catalyst:authed', '1')
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 401,
+    } as Response) as typeof fetch
+    const result = await probeWhoamiAndCacheMarker('/api')
+    expect(result).toBe(false)
+    expect(sessionStorage.getItem('catalyst:authed')).toBeNull()
+  })
+
+  it('does NOT revoke the marker on 5xx or network error (no verdict, no revocation)', async () => {
+    // A 503 or network blip is not an authority verdict — revoking on it
+    // would log operators out on every transient (#5461-class flake).
+    sessionStorage.setItem('catalyst:authed', '1')
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 503 } as Response) as typeof fetch
+    expect(await probeWhoamiAndCacheMarker('/api')).toBeNull()
+    expect(sessionStorage.getItem('catalyst:authed')).toBe('1')
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down')) as typeof fetch
+    expect(await probeWhoamiAndCacheMarker('/api')).toBeNull()
+    expect(sessionStorage.getItem('catalyst:authed')).toBe('1')
+  })
+
   it('returns null on 5xx (fail-open signal to caller)', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       status: 503,

--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
@@ -286,7 +286,22 @@ export async function probeWhoamiAndCacheMarker(
       }
       return true
     }
-    if (res.status === 401) return false
+    if (res.status === 401) {
+      // #5460 — the authority's NEGATIVE verdict must revoke the cached
+      // marker, symmetrically with the positive one writing it. A stale
+      // `catalyst:authed=1` surviving session expiry short-circuits the
+      // rootBeforeLoad gate (`hasCatalystSession()`), which skips the
+      // whoami probe AND the #3374 row-29 silent-SSO leg — the operator
+      // lands on the PIN wall even with a live Keycloak session, and
+      // every surface consulting the marker renders authenticated chrome
+      // against a dead session (hw290 row-29 walk, 2026-07-29).
+      try {
+        sessionStorage.removeItem('catalyst:authed')
+      } catch {
+        /* private browsing may throw */
+      }
+      return false
+    }
     return null
   } catch {
     return null

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
@@ -239,6 +239,26 @@ export function SovereignConsoleLayout() {
       // forbidden for operator-facing flows.
       const existing = loadTokens()
       if (!existing) {
+        // #5460 (hw290 row-29): this is the PIN-cookie EXPIRY path — the
+        // cookie probe 401'd and there are no OIDC tokens. Two duties the
+        // old bail-out skipped:
+        //  1. Revoke the stale `catalyst:authed` marker. It is what let the
+        //     rootBeforeLoad gate short-circuit past its own whoami probe
+        //     and silent-SSO leg, landing here instead — and while it
+        //     survives, every marker-consuming surface renders
+        //     authenticated chrome against a dead session.
+        //  2. Attempt the SAME loop-guarded silent prompt=none round-trip
+        //     the gate would have run: a live Keycloak SSO session re-mints
+        //     the console session with no PIN form (the row-29 contract).
+        //     The one-shot guard in attemptSilentSovereignSSO makes the
+        //     genuinely-logged-out case land on /login exactly once.
+        try { sessionStorage.removeItem('catalyst:authed') } catch { /* private browsing */ }
+        const { attemptSilentSovereignSSO } = await import('../router')
+        if (await attemptSilentSovereignSSO()) {
+          // Navigation handed to Keycloak (window.location.replace inside
+          // initiateLogin) — keep the spinner while the document unloads.
+          return
+        }
         setAuthState({ status: 'unauthenticated' })
         redirectToLogin()
         return

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -381,7 +381,11 @@ export const SILENT_SSO_GUARD_KEY = 'catalyst:silent-sso-attempted'
  */
 export const SILENT_SSO_NAV_GRACE_MS = 8000
 
-async function attemptSilentSovereignSSO(): Promise<boolean> {
+// Exported for SovereignConsoleLayout's cookie-expiry path (#5460): the
+// layout discovers the 401 when the stale-marker fast path has bypassed
+// this gate, and must be able to run the SAME loop-guarded silent leg
+// before falling back to the PIN wall.
+export async function attemptSilentSovereignSSO(): Promise<boolean> {
   if (typeof window === 'undefined') return false
   const fqdn = DETECTED_MODE.sovereignFQDN
   if (!fqdn) return false


### PR DESCRIPTION
## What

Both halves of #5460 in one root cause: the `catalyst:authed` sessionStorage marker outliving the session it describes.

## The mechanism (hw290 row-29 walk, 2026-07-29)

1. Session TTL expires; the marker stays `'1'`.
2. `rootBeforeLoad` hits `if (hasCatalystSession()) return` — the stale marker short-circuits the gate **past both its whoami probe and the #3374 Layer-B silent `prompt=none` leg**.
3. The 401 instead surfaces in `SovereignConsoleLayout`'s cookie probe, whose expiry path bails directly to the PIN wall.
4. Result: an operator with a live Keycloak SSO session gets a PIN re-prompt (defect A), and every marker-consuming surface renders authenticated chrome against a dead session (defect B). Defect B causes defect A.

## Changes

- **`auth-gate.ts`** — `probeWhoamiAndCacheMarker` revokes the marker on the authority's 401, symmetric with the 200 writing it. 5xx/network remain non-verdicts and revoke nothing (revoking on a transient would log operators out on every #5461-class flake).
- **`router.tsx`** — `attemptSilentSovereignSSO` exported; behavior unchanged (same one-shot loop guard, same `SILENT_SSO_NAV_GRACE_MS` parking).
- **`SovereignConsoleLayout.tsx`** — the cookie-expiry path (probe 401 + no OIDC tokens) now clears the marker and runs the same loop-guarded silent leg before `redirectToLogin()`. Dynamic import avoids a static router↔layout cycle (router already statically imports the layout).

## Verification

- `auth-gate.test.ts` 57/57, including two new cases: a stale marker is REVOKED on 401; 5xx/network do NOT revoke (no verdict, no revocation).
- `tsc -b` clean.
- Runtime proof rides hw291 (converging now): row 29's re-walk needs a console session aged past TTL while the KC session lives — the silent leg either lands signed-in with no PIN form, or the genuinely-logged-out case hits /login exactly once via the one-shot guard.

## The pattern this closes

Fifth instance of the session's recurring class — a local cached signal trusted over the authority (#5451 intent-vs-runtime, #5459 redirect-vs-403, the tally line-scan, G11's lying status surface, and here a flag outliving its session). The fix is the same shape every time: the authority's negative verdict must propagate to the cache.

Refs #5460 #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
