### PR TITLE
fix(catalog): unlist bp-nemo-guardrails — the image it pins was never built, so a listed entry both misadvertised and blocked the cutover (Refs #5468)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1302,7 +1302,9 @@ spec:
       # 1.4.1243 (#5388): catalog-seed bp-cnpg-pair 0.2.22 -> 0.2.23 —
       #   dr-failback starvation surfacing (hw290 G12 leg-6); lockstep
       #   w/ 16b slot 0.2.23 (pin-sync gate).
-      version: 1.4.1245
+      # 1.4.1246 (#5468): catalog-seed bp-nemo-guardrails -> unlisted (its image
+      #   was never built); restores the advertise-only-what-installs invariant.
+      version: 1.4.1246
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/nemo-guardrails/blueprint.yaml
+++ b/platform/nemo-guardrails/blueprint.yaml
@@ -15,7 +15,15 @@ spec:
     tags: [ai-safety, guardrails, prompt-injection, pii, llm, nvidia]
     documentation: https://docs.nvidia.com/nemo/guardrails/
     license: Apache-2.0
-  visibility: listed
+  # #5468 — UNLISTED until the image exists. This Blueprint pins
+  # ghcr.io/openova-io/openova/nemo-guardrails:0.21.0 and Chart.yaml asserts
+  # "Catalyst's CI builds a reproducible image" there — but no such build
+  # exists: the package 404s, there is no Containerfile, and no workflow
+  # references it. `listed` put an UNINSTALLABLE entry in the customer
+  # marketplace grid (a customer install can only ImagePullBackOff) AND made
+  # it CONTRACTUAL for the cutover's #5442 A3 guard, failing hw291 at step-03.
+  # Restore to `listed` in the same commit that ships the build.
+  visibility: unlisted
   owner:
     team: ai-platform
     contact: ai-platform@openova.io

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3611,7 +3611,14 @@ name: bp-catalyst-platform
 #   the HR instead of idling silently at D0 while a split-brain persists.
 #   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync gate). Lockstep w/ 16b
 #   slot 0.2.23.
-version: 1.4.1245
+# 1.4.1246 — #5468: catalog-seed bp-nemo-guardrails visibility listed -> unlisted.
+#   The Blueprint pins ghcr.io/openova-io/openova/nemo-guardrails:0.21.0 and its
+#   Chart.yaml asserts Catalyst CI builds it — no such build exists (package 404,
+#   no Containerfile, no workflow). `listed` advertised an UNINSTALLABLE entry in
+#   the customer marketplace grid and made it CONTRACTUAL for the cutover's #5442
+#   A3 guard, failing hw291 at step-03. Unlisting restores the #5443 invariant
+#   (advertise only what can install); restore to listed with the build.
+version: 1.4.1246
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2258,7 +2258,10 @@ metadata:
     app.kubernetes.io/instance: {{ $instance }}
 spec:
   version: "1.0.0"
-  visibility: listed
+  # #5468 — UNLISTED until ghcr.io/openova-io/openova/nemo-guardrails:0.21.0
+  # actually exists (never built: package 404, no Containerfile, no workflow).
+  # Keep in lockstep with platform/nemo-guardrails/blueprint.yaml.
+  visibility: unlisted
   card:
     title: "NeMo Guardrails"
     category: "ai-safety"


### PR DESCRIPTION
## What

`bp-nemo-guardrails` was advertised in the customer-facing marketplace grid while the container image it pins **has never been built**. This unlists it until the image exists.

## Evidence the image does not exist

- `gh api /orgs/openova-io/packages/container/openova%2Fnemo-guardrails/versions` → **404 Package not found**
- **Control proving the method sound**: the identical call for `openova%2Fcert-manager-webhook-pdns` returns `v2.5.5` — same `openova/<name>` convention, same encoding, and the token can see private packages
- Full paginated org listing (21 container packages) contains no `nemo`/`guardrail` entry
- `platform/nemo-guardrails/` has only `README.md`, `blueprint.yaml`, `chart/` — **no Containerfile**; no workflow in `.github/workflows/` references it
- `platform/nemo-guardrails/chart/Chart.yaml:11` asserts *"Catalyst's CI builds a reproducible image at ghcr.io/openova-io/openova/nemo-guardrails"* — **that claim is false**

The upstream project is real (NVIDIA publishes `nemoguardrails` 0.21.0 on PyPI). Only the container was never produced.

## Why `listed` caused two distinct harms

1. **Customer-facing**: the marketplace offered a Blueprint whose install can only ever ImagePullBackOff.
2. **Cutover-blocking**: only `listed` entries are CONTRACTUAL to the #5442 A3 guard (`HARD_VISIBILITY` defaults to `listed`; every other row is best-effort). So a nonexistent image became a hard requirement and **failed hw291's cutover at step-03**, alongside the two other misses tracked in #5468.

## Why unlisting is the correct stopgap, not a paper-over

This restores exactly the invariant #5443 exists to enforce — *the marketplace offers what a cut-over Sovereign can actually install*. That issue measured the same breakage from the other side: 29 listed entries, 14 installable after pivot. Leaving the entry `listed` would keep asserting a capability the platform does not have.

It also does **not** silence the guard: the miss degrades from FATAL to a best-effort WARN, so the gap stays visible in every prewarm run.

**This is explicitly not the destination.** The real fix is to ship the missing build workflow + Containerfile and restore `visibility: listed` in that same commit. Comments at both edit sites say so, so the next reader cannot mistake the stopgap for a decision.

## Verification

Render suite (`catalog-chart-set.sh`) green; `tests/e2e/bootstrap-kit` lockstep guards green. Catalog-seed and `platform/nemo-guardrails/blueprint.yaml` kept in lockstep; umbrella 1.4.1245 + slot-13.

Refs #5468 #5443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
