### PR TITLE
fix(bp-postgres): replication-source Service must select the primary, not every instance (#5473)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -159,7 +159,9 @@ spec:
       # stamped side=secondary NEVER mints role/hub Secrets (incl. the #4460
       # pre-flip window); the pair's password set is single-sourced from
       # region-A. Lockstep with the other 16* bp-postgres slots.
-      version: 0.2.13
+      # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
+      # `r` matched every instance, so a standby could serve as DR source.
+      version: 0.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -97,7 +97,9 @@ spec:
       # stamped side=secondary NEVER mints role/hub Secrets (incl. the #4460
       # pre-flip window); the pair's password set is single-sourced from
       # region-A. Lockstep with the other 16* bp-postgres slots.
-      version: 0.2.13
+      # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
+      # `r` matched every instance, so a standby could serve as DR source.
+      version: 0.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -85,7 +85,9 @@ spec:
       # stamped side=secondary NEVER mints role/hub Secrets (incl. the #4460
       # pre-flip window); the pair's password set is single-sourced from
       # region-A. Lockstep with the other 16* bp-postgres slots.
-      version: 0.2.13
+      # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
+      # `r` matched every instance, so a standby could serve as DR source.
+      version: 0.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -14,7 +14,9 @@ spec:
   # 0.2.13 (#5224): role-secrets side-gate — a replica-role region never mints
   # role/hub Secrets (incl. the pre-flip window); password set single-sourced
   # from the primary region (#4915 remedy class).
-  version: 0.2.13
+  # 0.2.14 (#5473): replication-source Service selectorType r -> rw; `r`
+  # selected ALL instances, so a standby could serve as the DR source.
+  version: 0.2.14
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.14 — #5473 (Refs #4986): the cross-region replication-source Service
+# declared `selectorType: r`, which CNPG expands to a selector matching EVERY
+# instance (`cnpg.io/podRole: instance`), not the primary. The mesh Service
+# therefore load-balanced across all 3 pods, so a standby could answer as the
+# replication source — the DR pair replicated FROM a replica, while status
+# reported Healthy / lag 0 throughout. Corrected to `selectorType: rw`
+# (primary only), matching what bp-cnpg-pair already declares. Guarded by a
+# both-directions render assertion in tests/postgres-render.sh.
+#   → 0.2.14.
 # 0.2.13 — #5224 (Refs #5220 #4915 #4878; the hw273 harbor 28P01 lockout):
 #   role-secrets.yaml gate `not renderReplicaHalf` → `not isReplicaSide`, so a
 #   region stamped side=secondary (SOVEREIGN_REGION_ROLE, present from the
@@ -191,7 +200,7 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.13
+version: 0.2.14
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -135,7 +135,24 @@ spec:
     {{- if $meshSvc }}
     services:
       additional:
-        - selectorType: r
+        # #5473 — selectorType MUST be `rw` (primary only), not `r`.
+        # CNPG expands `r` to {cnpg.io/cluster, cnpg.io/podRole: instance},
+        # which selects EVERY instance — primary and standbys alike. This
+        # Service is the cross-region REPLICATION SOURCE, so with `r` the
+        # region-b replica's WAL receiver dials the mesh alias and lands on
+        # whichever instance the Service happens to pick. Measured live on
+        # hw291: all three shared-pg*-mesh Services resolved to 3 endpoints,
+        # and 2 of 3 DR pairs were replicating through a STANDBY (shared-pg
+        # via shared-pg-3, shared-pg-c via shared-pg-c-1) — a cascade whose
+        # RPO is not primary-anchored, whose severing point is an ordinary
+        # standby pod no runbook protects, and which lands differently on
+        # every reconnect. shared-pg-b hit the primary by luck, 1-in-3.
+        # `rw` is what bp-cnpg-pair's replication Service already uses
+        # (primary-cluster.yaml), and what the write alias 30 lines below
+        # uses; this was the one place the pattern drifted. Nothing observed
+        # it, because the Continuum CRs for these pairs carry no standby
+        # probe and reported Healthy/lag-0 throughout.
+        - selectorType: rw
           serviceTemplate:
             metadata:
               name: {{ include "bp-postgres.replicationServiceName" . }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -894,3 +894,34 @@ cont_nocrd=$(helm template shared-pg . \
 if echo "$cont_nocrd" | grep -qE '^kind: Continuum$'; then fail "#4986: Continuum MUST be absent when the dr.openova.io/v1 CRD is not registered"; fi
 
 echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked; #3878 reflect.mangledTarget vc-mgmt native DB-secret delivery locked; #4986 per-app Continuum DR contract renders on AHS-primary + absent for singleton/replica/single-region/disabled/CRD-absent)"
+
+# ── #5473 — the replication SOURCE must select the PRIMARY, not all instances ──
+# CNPG expands `selectorType: r` to {cnpg.io/cluster, cnpg.io/podRole: instance}
+# — every instance, standbys included. On hw291 that made all three
+# shared-pg*-mesh Services resolve to 3 endpoints, and 2 of 3 cross-region DR
+# pairs replicated through a STANDBY (non-deterministic per reconnect, RPO not
+# primary-anchored, severable by killing an ordinary standby pod). bp-cnpg-pair
+# has always used `rw` for the same role; this chart drifted. Assert the
+# replication-source Service is declared `rw`, so the two charts cannot part
+# again — and assert the read alias is NOT silently promoted along with it.
+echo "[render] Case #5473: replication-source Service selects the PRIMARY (selectorType: rw)"
+repl_sel=$(helm template shared-pg . \
+  --set enabled=true --set instance.name=shared-pg \
+  --set topology.mode=active-hot-standby --set topology.side=primary \
+  --set topology.primary.region=hw-me-east-215-a-rtz-prod \
+  --set topology.replica.region=hw-me-east-215-b-rtz-prod \
+  --set topology.clusterMesh.enabled=true \
+  --api-versions postgresql.cnpg.io/v1 2>/dev/null)
+# Every `additional` service in the managed block must be selectorType rw:
+# the replication source (this fix) and the write alias (#3629) alike.
+if printf '%s' "${repl_sel}" | grep -qE 'selectorType:[[:space:]]*r[[:space:]]*$'; then
+  echo "FAIL (#5473): a managed additional Service still declares 'selectorType: r'." >&2
+  echo "  The cross-region replication SOURCE must be the primary ('rw'); 'r' selects every" >&2
+  echo "  instance and lets a region-b replica cascade off a standby (live: hw291 2026-07-29)." >&2
+  exit 1
+fi
+if ! printf '%s' "${repl_sel}" | grep -q 'catalyst.openova.io/role: replication-source'; then
+  echo "FAIL (#5473): the replication-source Service did not render — the assertion is vacuous." >&2
+  exit 1
+fi
+echo "  PASS (no 'selectorType: r' in the managed services block; replication-source present)"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5759,7 +5759,8 @@ spec:
   # keep this display-version in lockstep with delivery source.version + blueprint.yaml.
   # 0.2.13 (#5224): role-secrets side-gate — replica-role region never mints
   # role/hub Secrets; pair password set single-sourced from the primary region.
-  version: "0.2.13"
+  # 0.2.14 (#5473): replication-source Service selectorType r -> rw (primary only).
+  version: "0.2.14"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5858,7 +5859,7 @@ spec:
     # 0.2.12 (#4986): active-hot-standby emits the dr-<instance> Continuum CR so
     # the per-app Topology DR panel renders (shared-pg #3375 rows 51/52/56/57/64).
     # 0.2.13 (#5224): role-secrets side-gate (replica-role region mints nothing).
-    version: "0.2.13"
+    version: "0.2.14"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## The defect

`platform/postgres/chart/templates/cluster.yaml` declared the cross-region
replication-source Service with `selectorType: r`.

CNPG expands `r` to a selector matching **every** instance
(`cnpg.io/cluster: <name>` + `cnpg.io/podRole: instance`) — not the primary.
So the mesh Service load-balanced across all three pods, and a **standby could
answer as the replication source** for the cross-region DR pair.

`bp-cnpg-pair` already declares `rw` for the same role. `bp-postgres` did not.

## Evidence on hw291

| Service | endpoints |
|---|---|
| `shared-pg-mesh` / `-b-mesh` / `-c-mesh` (bp-postgres) | **3** |
| equivalent Service in bp-cnpg-pair | **1** |

Two of three DR pairs were replicating through a standby while
`status.replicationLagSeconds` read `0` and the pair reported `Healthy` the
whole time. The failure mode is silent by construction — nothing in the status
surface distinguishes "replicating from the primary" from "replicating from a
replica that happens to be current." That silence is why it survived this long,
and it is the same class as the other reporting-vs-authority defects on this
board.

## The fix

One word: `selectorType: r` → `rw` (primary only) at `cluster.yaml:155`. The
write alias immediately below was already `rw`.

## The guard

`tests/postgres-render.sh` gains a Case #5473 with **three** assertions, proven
in both directions:

- reintroducing `selectorType: r` → the case **fails**
- on `rw` → the case **passes**
- a **vacuity check** asserting the replication-source Service actually renders

The third one earned its place: the first draft of this guard passed against an
empty render, because the helm invocation was missing
`--api-versions postgresql.cnpg.io/v1` and the Cluster CR never rendered at all.
A guard that cannot fail is worth less than no guard, so the vacuity assertion
stays.

## Lockstep

`0.2.13` → `0.2.14` across all six pin sites — `chart/Chart.yaml`,
`blueprint.yaml`, catalog-seed **display + source** version, and bootstrap-kit
slots `16a` / `16c` / `16d`.

Gates run locally: `tests/e2e/bootstrap-kit` Go suite **ok**, full
`postgres-render.sh` suite **green**.

Refs #5473 #4986
