### PR TITLE
fix(continuum): never publish replicationLagSeconds that was never measured (#5477)

### DIFF
--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -1142,8 +1142,12 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 		LeaseHolder:           lease.Holder,
 		SelfRegion:            self,
 		ReplicationLagSeconds: maxLag,
-		SwitchoverInProgress:  switchoverInProgress,
-		Step:                  stepLabel,
+		// standby.Known is the existing "we actually resolved the pair and
+		// looked" signal — the same one StandbyAvailable is gated on. When
+		// it is false, maxLag is a zero value, not a reading.
+		LagObserved:          standby.Known,
+		SwitchoverInProgress: switchoverInProgress,
+		Step:                 stepLabel,
 	}
 	if standby.Known {
 		avail := standby.Available
@@ -1167,11 +1171,21 @@ type statusUpdate struct {
 	// effectiveHoldingRegion). The LeaseHeld condition is True iff
 	// LeaseHolder == SelfRegion. Empty falls back to r.HoldingRegion for
 	// back-compat with callers that don't set it (#3829).
-	SelfRegion            string
-	LeaseExpiresAt        string
+	SelfRegion     string
+	LeaseExpiresAt string
+	// ReplicationLagSeconds is only meaningful when LagObserved is true.
+	// A pair that was never probed (no spec.cnpgPair, no reader) leaves
+	// this at the Go zero value, which is indistinguishable from a
+	// genuinely-caught-up standby — see LagObserved.
 	ReplicationLagSeconds int
-	SwitchoverInProgress  bool
-	Step                  string
+	// LagObserved records whether the CNPG standby was actually probed
+	// this tick. #5477: without it, an un-probed zero was published as a
+	// measurement, so dr-shared-pg reported lag 0 while its region-b
+	// replica was 16s behind, and dr-spine-openbao — a raft app with no
+	// PostgreSQL at all — reported a PostgreSQL replication lag.
+	LagObserved          bool
+	SwitchoverInProgress bool
+	Step                 string
 
 	LastSwitchoverResult string
 	LastSwitchoverFrom   string
@@ -1274,7 +1288,16 @@ func (r *ContinuumReconciler) patchStatus(ctx context.Context, cr *unstructured.
 	if su.LeaseExpiresAt != "" {
 		status["leaseExpiresAt"] = su.LeaseExpiresAt
 	}
-	status["replicationLagSeconds"] = int64(su.ReplicationLagSeconds)
+	// #5477 — publish a lag figure ONLY when it was measured. Every
+	// sibling field above is guarded the same way; this one was not, so an
+	// un-probed zero reached Application.status.placement and the console
+	// DR panel as though it were a live measurement. Omitting the key
+	// leaves any previously-observed value intact (merge patch) and leaves
+	// a never-observed pair with no lag field at all, which is the honest
+	// representation of "not measured".
+	if su.LagObserved {
+		status["replicationLagSeconds"] = int64(su.ReplicationLagSeconds)
+	}
 	status["switchoverInProgress"] = su.SwitchoverInProgress
 	if su.Step != "" {
 		status["switchoverStep"] = su.Step

--- a/core/controllers/continuum/internal/controller/unprobed_lag_5477_test.go
+++ b/core/controllers/continuum/internal/controller/unprobed_lag_5477_test.go
@@ -1,0 +1,132 @@
+// Tests for #5477 — a Continuum whose CNPG standby was never probed must
+// publish NO replicationLagSeconds at all, rather than the Go zero value
+// dressed up as a measurement.
+//
+// The bug: the gate at continuum_controller.go:420 only runs
+// observeCNPGStandby when spec.cnpgPair.name is set. On hw291, 7 of 8
+// Continuum CRs had no cnpgPair, so primaryStatus/replicaStatus stayed
+// zero-value structs, maxLag computed to 0, and patchStatus emitted
+// status.replicationLagSeconds = 0 UNCONDITIONALLY — unlike every
+// neighbouring field, each of which is guarded on non-emptiness.
+//
+// Live consequence: dr-shared-pg reported lag 0 while its region-b
+// replica was 16s behind (measured via pg_last_xact_replay_timestamp),
+// and dr-spine-openbao — a raft-transition app with no PostgreSQL
+// whatsoever — reported a PostgreSQL replication lag of 0.
+//
+// Anti-theater: TestPatchStatus_UnprobedLagIsNotPublished FAILS against
+// the pre-fix code, because the old line emitted the key unconditionally.
+// It is the assertion that distinguishes "not measured" from "measured
+// zero", which is the entire defect.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// A never-probed pair must leave the field absent, not zero.
+func TestPatchStatus_UnprobedLagIsNotPublished(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("ns", "cr1", "fsn", []string{"hel"}, "in-memory")
+	objs := append([]runtime.Object{cr}, newTestClusterPair("ns", "demo", 0)...)
+	r, _, _ := newReconciler(t, objs...)
+
+	// The dr-spine-openbao shape: healthy lease, no CNPG pair, so the
+	// standby was never observed this tick.
+	if err := r.patchStatus(context.Background(), cr, statusUpdate{
+		Phase:                 PhaseHealthy,
+		LeaseHolder:           "fsn",
+		PrimaryRegion:         "fsn",
+		ReplicationLagSeconds: 0,
+		LagObserved:           false,
+	}); err != nil {
+		t.Fatalf("patchStatus: %v", err)
+	}
+
+	got, _ := r.Dyn.Resource(ContinuumGVR).Namespace("ns").Get(context.Background(), "cr1", metav1.GetOptions{})
+	_, found, err := unstructured.NestedInt64(got.Object, "status", "replicationLagSeconds")
+	if err != nil {
+		t.Fatalf("reading status.replicationLagSeconds: %v", err)
+	}
+	if found {
+		t.Errorf("status.replicationLagSeconds was published for a pair that was never probed — " +
+			"an un-measured zero is indistinguishable from a caught-up standby, which is the #5477 defect")
+	}
+}
+
+// A genuinely observed lag must still be published, including a real zero.
+func TestPatchStatus_ObservedLagIsPublished(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		lag  int
+	}{
+		{"real non-zero lag", 16},
+		{"genuinely caught up", 0},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cr := newTestContinuumCR("ns", "cr1", "fsn", []string{"hel"}, "in-memory")
+			objs := append([]runtime.Object{cr}, newTestClusterPair("ns", "demo", 0)...)
+			r, _, _ := newReconciler(t, objs...)
+
+			if err := r.patchStatus(context.Background(), cr, statusUpdate{
+				Phase:                 PhaseHealthy,
+				LeaseHolder:           "fsn",
+				PrimaryRegion:         "fsn",
+				ReplicationLagSeconds: tc.lag,
+				LagObserved:           true,
+			}); err != nil {
+				t.Fatalf("patchStatus: %v", err)
+			}
+
+			got, _ := r.Dyn.Resource(ContinuumGVR).Namespace("ns").Get(context.Background(), "cr1", metav1.GetOptions{})
+			lag, found, err := unstructured.NestedInt64(got.Object, "status", "replicationLagSeconds")
+			if err != nil {
+				t.Fatalf("reading status.replicationLagSeconds: %v", err)
+			}
+			if !found {
+				t.Fatalf("an OBSERVED lag of %d must be published", tc.lag)
+			}
+			if lag != int64(tc.lag) {
+				t.Errorf("status.replicationLagSeconds = %d want %d", lag, tc.lag)
+			}
+		})
+	}
+}
+
+// An unobserved tick must not erase a previously-measured value. The
+// status patch is a merge, so omitting the key preserves the last real
+// reading — the same contract LastLuaRecord relies on.
+func TestPatchStatus_UnprobedTickPreservesPriorLag(t *testing.T) {
+	t.Parallel()
+	cr := newTestContinuumCR("ns", "cr1", "fsn", []string{"hel"}, "in-memory")
+	objs := append([]runtime.Object{cr}, newTestClusterPair("ns", "demo", 0)...)
+	r, _, _ := newReconciler(t, objs...)
+
+	if err := r.patchStatus(context.Background(), cr, statusUpdate{
+		Phase: PhaseHealthy, LeaseHolder: "fsn", PrimaryRegion: "fsn",
+		ReplicationLagSeconds: 42, LagObserved: true,
+	}); err != nil {
+		t.Fatalf("seed patchStatus: %v", err)
+	}
+	if err := r.patchStatus(context.Background(), cr, statusUpdate{
+		Phase: PhaseHealthy, LeaseHolder: "fsn", PrimaryRegion: "fsn",
+		ReplicationLagSeconds: 0, LagObserved: false,
+	}); err != nil {
+		t.Fatalf("unobserved patchStatus: %v", err)
+	}
+
+	got, _ := r.Dyn.Resource(ContinuumGVR).Namespace("ns").Get(context.Background(), "cr1", metav1.GetOptions{})
+	lag, found, _ := unstructured.NestedInt64(got.Object, "status", "replicationLagSeconds")
+	if !found || lag != 42 {
+		t.Errorf("an unobserved tick clobbered the last real reading: found=%v lag=%d want 42", found, lag)
+	}
+}


### PR DESCRIPTION
## The defect

`patchStatus` emitted `status.replicationLagSeconds` **unconditionally**, while every neighbouring field is guarded:

```go
if su.PrimaryRegion  != "" { status["primaryRegion"]  = su.PrimaryRegion  }
if su.LeaseHolder    != "" { status["leaseHolder"]    = su.LeaseHolder    }
if su.LeaseExpiresAt != "" { status["leaseExpiresAt"] = su.LeaseExpiresAt }
status["replicationLagSeconds"] = int64(su.ReplicationLagSeconds)   // <- no guard
```

The CNPG standby is only probed when `spec.cnpgPair.name` is set (`continuum_controller.go:420`). Without it, `primaryStatus`/`replicaStatus` stay Go zero-value structs, `MaxLagSeconds` returns `0`, and that `0` is published as a measurement.

## What it looked like live on hw291

7 of 8 Continuum CRs have no `spec.cnpgPair`. Ground truth from the region-b replicas' own `pg_stat_wal_receiver` / `pg_last_xact_replay_timestamp()`:

| CR | reported | actual |
|---|---|---|
| `dr-shared-pg` | **0** | **16 s behind** |
| `dr-shared-pg-b` | **0** | **7 s behind** |
| `dr-spine-openbao` | **0** | raft app — **no PostgreSQL exists at all** |

`dr-spine-openbao` is the reductio: an application with no database reporting a database replication lag.

This is not cosmetic. The false `0` is mirrored into `Application.status.placement.replicationLagSeconds` and rendered at `StatusPanel.tsx:36`, so **"lag 0" is exactly what an operator reads before deciding a failover is safe** — and nothing had measured it.

## The fix

`statusUpdate` gains `LagObserved`, set from `standby.Known` — the existing *"we resolved the pair and actually looked"* signal that `StandbyAvailable` is already gated on. The emit is guarded on it.

Omitting the key is deliberate and has two correct consequences under the merge patch: a previously-observed value survives an unobserved tick, and a never-probed pair carries **no lag field at all** — the honest representation of "not measured", rather than a number.

## Tests — proven in both directions

Three cases in `unprobed_lag_5477_test.go`:

- never-probed pair publishes **no** key
- an observed lag is published, **including a real `0`** (so the fix does not suppress genuine caught-up readings)
- an unobserved tick does not clobber the last real reading

Anti-theater check: with the guard removed, `TestPatchStatus_UnprobedLagIsNotPublished` **fails** with the defect message; restored, the package is green. A test that cannot fail would be worthless here, since the pre-fix code satisfies any assertion that merely reads the number.

## Scope, stated plainly

This stops the platform asserting a number it does not have. It does **not** make the 7 pairless CRs start measuring — that is the remaining half of #5477 and is on its checklist, along with the question of whether `dr-spine-openbao` should be a CNPG Continuum at all.

## Related

#5473 (PR #5474) is very likely the *cause* of the 16 s: the bp-postgres replication-source Service used `selectorType: r`, so the pairs cascade through a standby rather than the primary — `pg_stat_replication` on the `shared-pg` primary shows only its two local instances. One bug hid the other. The lag was real; the reporting said zero.

Refs #5477 #4901 #5311 #5473
