### PR TITLE
fix(catalog): chartRef double prefix, origin enum collision, hero summary fallback (#5475)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/catalog_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_client.go
@@ -112,7 +112,12 @@ type CatalogBlueprintVersion struct {
 // charts. Per INVIOLABLE-PRINCIPLES #4 the registry is overridable via
 // CATALYST_BLUEPRINT_OCI_BASE; defaults to the production registry the
 // blueprint-release.yaml workflow pushes to.
-const catalogBlueprintChartRef = "ghcr.io/openova-io/bp-"
+// #5475: this is the registry BASE only. It previously carried a trailing
+// `bp-`, which was then concatenated with a blueprint name that already
+// begins with `bp-` — producing `ghcr.io/openova-io/bp-bp-alloy:1.0.2` on
+// all 80 blueprints, a package that 404s while the real `bp-alloy` has 11
+// published tags.
+const catalogBlueprintChartRef = "ghcr.io/openova-io/"
 
 // PopulateVersionsAlias stamps Versions + ChartRef from the headline
 // version when the upstream response doesn't carry them inline. Called
@@ -129,7 +134,14 @@ func (b *CatalogBlueprint) PopulateVersionsAlias() {
 		return
 	}
 	if b.ChartRef == "" {
-		b.ChartRef = catalogBlueprintChartRef + b.Name + ":" + b.Version
+		// Normalise to EXACTLY one `bp-` prefix: catalog names arrive
+		// already-qualified (`bp-alloy`), but tolerate a bare name so a
+		// future caller cannot silently reintroduce the #5475 doubling.
+		chart := b.Name
+		if !strings.HasPrefix(chart, "bp-") {
+			chart = "bp-" + chart
+		}
+		b.ChartRef = catalogBlueprintChartRef + chart + ":" + b.Version
 	}
 	if len(b.Versions) > 0 {
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
@@ -49,6 +49,12 @@ import (
 // first and fall back to v1alpha1 on the version-not-served path so the
 // fallback works on any Sovereign regardless of which version the
 // chart's Blueprint CRs were authored under.
+// catalogOriginSovereign mirrors source.OriginSovereign. The canonical
+// enum lives in an `internal/` package of a different module and cannot be
+// imported here, so it is restated rather than duplicated as a literal —
+// a bare 3 is what caused #5475.
+const catalogOriginSovereign = 2
+
 func blueprintCRGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "catalyst.openova.io",
@@ -268,7 +274,12 @@ func parseBlueprintCRToCatalog(u *unstructured.Unstructured) (*CatalogBlueprint,
 	bp := &CatalogBlueprint{
 		Name:   name,
 		Source: "in-cluster",
-		Origin: 3, // distinct from public(1)/sovereign(2)/org-private(0)
+		// #5475: this was 3 with a comment claiming org-private was 0.
+		// The canonical enum (core/services/catalyst-catalog/internal/
+		// source.Origin) is public=1, sovereign=2, org-private=3, so 3
+		// mislabelled every platform blueprint as org-private. A blueprint
+		// read from the in-cluster CR is sovereign-curated.
+		Origin: catalogOriginSovereign,
 	}
 	spec, ok, _ := unstructured.NestedMap(u.Object, "spec")
 	if !ok {

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_contract_5475_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_contract_5475_test.go
@@ -1,0 +1,79 @@
+// Tests for #5475 — two catalog API contract defects found on hw291.
+//
+// 1. chartRef carried a DOUBLE `bp-` prefix on all 80 blueprints, because
+//    the registry const ended in `bp-` and was concatenated with a name
+//    that already began with `bp-`:
+//        got  ghcr.io/openova-io/bp-bp-alloy:1.0.2   (404 - no such package)
+//        want ghcr.io/openova-io/bp-alloy:1.0.2      (11 published tags)
+//
+//    It had no consumers, so nothing broke - but it did produce a wrong
+//    inference during an R21 walk, where `chartRef -> 404` was read as
+//    proof that specific blueprints would hollow-install. The doubling
+//    was universal, including for the 75 whose charts DO exist, so that
+//    reasoning was unsound.
+//
+// 2. The cluster-fallback path stamped Origin: 3 with a comment asserting
+//    org-private was 0. The canonical enum (core/services/catalyst-catalog/
+//    internal/source.Origin) is public=1, sovereign=2, org-private=3 - so 3
+//    mislabelled every platform blueprint as org-private. Latent only
+//    because no sovereign surface renders origin yet.
+
+package handler
+
+import "testing"
+
+func TestPopulateVersionsAlias_ChartRefHasExactlyOneBPPrefix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		bpName  string
+		version string
+		want    string
+	}{
+		{"already-qualified name (the real catalog shape)", "bp-alloy", "1.0.2", "ghcr.io/openova-io/bp-alloy:1.0.2"},
+		{"another qualified name", "bp-wordpress", "0.4.22", "ghcr.io/openova-io/bp-wordpress:0.4.22"},
+		{"bare name is tolerated, not doubled", "alloy", "1.0.2", "ghcr.io/openova-io/bp-alloy:1.0.2"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := &CatalogBlueprint{Name: tc.bpName, Version: tc.version}
+			b.PopulateVersionsAlias()
+			if b.ChartRef != tc.want {
+				t.Errorf("ChartRef = %q want %q", b.ChartRef, tc.want)
+			}
+		})
+	}
+}
+
+// An explicitly-supplied chartRef must survive untouched — the function
+// only fills a blank.
+func TestPopulateVersionsAlias_DoesNotOverwriteSuppliedChartRef(t *testing.T) {
+	t.Parallel()
+	b := &CatalogBlueprint{Name: "bp-alloy", Version: "1.0.2", ChartRef: "registry.example/custom:9.9.9"}
+	b.PopulateVersionsAlias()
+	if b.ChartRef != "registry.example/custom:9.9.9" {
+		t.Errorf("an upstream-supplied ChartRef was overwritten: %q", b.ChartRef)
+	}
+}
+
+// The cluster-fallback origin must not collide with org-private.
+//
+// Anti-theater: this asserts the VALUE, not merely that a constant exists.
+// Restoring the literal 3 makes it fail, which is the whole defect.
+func TestCatalogOriginSovereign_DoesNotCollideWithOrgPrivate(t *testing.T) {
+	t.Parallel()
+	const (
+		canonicalPublic     = 1
+		canonicalSovereign  = 2
+		canonicalOrgPrivate = 3
+	)
+	if catalogOriginSovereign == canonicalOrgPrivate {
+		t.Fatalf("cluster-fallback origin %d collides with org-private — every platform "+
+			"blueprint would be labelled as belonging to the caller's Org", catalogOriginSovereign)
+	}
+	if catalogOriginSovereign != canonicalSovereign {
+		t.Errorf("cluster-fallback origin = %d want %d (sovereign-curated); public=%d org-private=%d",
+			catalogOriginSovereign, canonicalSovereign, canonicalPublic, canonicalOrgPrivate)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/iter12_phase2_codemods_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/iter12_phase2_codemods_test.go
@@ -93,7 +93,12 @@ func TestCatalogBlueprint_PopulateVersionsAlias_RealChartRef(t *testing.T) {
 	}
 	bp.PopulateVersionsAlias()
 
-	wantRef := "ghcr.io/openova-io/bp-bp-wordpress:1.5.0"
+	// #5475: this previously asserted "bp-bp-wordpress" — the doubled
+	// prefix the code actually produced. Asserting an implementation's
+	// output rather than the intended contract is what kept the defect
+	// alive: `gh api /orgs/openova-io/packages/container/bp-bp-wordpress`
+	// 404s, while bp-wordpress is a real published package.
+	wantRef := "ghcr.io/openova-io/bp-wordpress:1.5.0"
 	if bp.ChartRef != wantRef {
 		t.Errorf("expected chartRef=%q, got %q", wantRef, bp.ChartRef)
 	}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -440,7 +440,7 @@ export function CatalogDetail() {
                 initialDraft={currentEdit.tagline}
                 renderDisplay={() => (
                   <span data-testid="catalog-summary">
-                    {card.tagline || card.summary || (
+                    {card.tagline || card.summary || card.description || (
                       <span className="hero-tagline-empty">Add a one-line summary…</span>
                     )}
                   </span>


### PR DESCRIPTION
Three catalog API contract defects found during a read-only catalog-family walk on hw291. Filed together because they share one owner and one fix window.

Worth stating first, because it bounds the blast radius: the catalog API serves the Blueprint CR truth **exactly** — 80 CRs, 80 API items, zero name-only-in-one-side, zero version mismatches, zero visibility mismatches. #5449's name-key split is structurally gone. These are defects in what the API *decorates* that truth with.

## 1. `chartRef` had a double `bp-` prefix on all 80 blueprints

```
was:  ghcr.io/openova-io/bp-bp-alloy:1.0.2     -> 404 Package not found
now:  ghcr.io/openova-io/bp-alloy:1.0.2        -> 11 published tags
```

The registry const ended in `bp-` and was concatenated with a name that already begins with `bp-`. It is now the registry base, and the name is normalised to **exactly one** `bp-` prefix so a bare name cannot silently reintroduce the doubling.

**An existing test was holding this defect in place.** `iter12_phase2_codemods_test.go` asserted `bp-bp-wordpress` — the value the code produced, not the value the contract requires. That is the difference between a test and a snapshot, and it is why a 404-on-every-blueprint survived. Corrected, with a comment recording why.

This also produced a wrong inference of mine that belongs on the record: earlier R21 evidence used `chartRef -> 404` as proof that 5 chartless blueprints would hollow-install. Unsound — the doubling was universal, including for the 75 whose charts do exist. The R21 conclusion holds on other evidence; not on that.

## 2. `origin: 3` collided with the org-private enum value

`catalog_client_cluster_fallback.go` stamped `Origin: 3` next to a comment asserting org-private was `0`. The canonical enum is `public=1, sovereign=2, org-private=3`, so **every platform blueprint was labelled as belonging to the caller's Organization**. A blueprint read from the in-cluster CR is sovereign-curated, so it is now a named constant with value 2 — and the comment that caused the mistake is gone.

The canonical enum lives in an `internal/` package of a different module and cannot be imported here, so the value is restated behind a named constant rather than left as a bare literal. A bare `3` is what caused this.

## 3. The catalog hero had no `description` fallback; the grid did

```
grid  (CatalogPage.tsx:66)   card.summary ?? card.description ?? card.tagline ?? ''
hero  (CatalogDetail.tsx)    card.tagline || card.summary || "Add a one-line summary…"
```

So a blueprint with only a `description` showed real text in the grid and an empty-state placeholder in its own hero. 7 of the 28 listed blueprints are in that state: `bp-alloy`, `bp-litmus`, `bp-mimir`, `bp-opentelemetry`, `bp-tempo`, `bp-velero`, `bp-velero-hcs`.

## Severity, stated honestly

1 and 2 are **latent** — `chartRef` has no consumers and installs resolve through `spec.source`, and no sovereign surface renders `origin` yet. 3 is **operator-visible** and degrades UAT rows 124/125, which name Alloy specifically.

## Gates

Full `internal/handler` package green (168s), UI `tsc -b` clean. The new tests assert values rather than existence — restoring the literal `3` or the doubled prefix makes them fail.

Refs #5475 #5449
