### PR TITLE
fix(cutover): mirror litellm-database single-platform past its duplicated upstream index (Refs #5468)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1024,7 +1024,7 @@ spec:
       # — the live-cluster walk). New RBAC: read-only blueprints. New values:
       # prewarm.catalogCharts.*, prewarm.chartImages.*. Step count stays 11.
       # New chart test tests/catalog-chart-set.sh + contract Case 72.
-      version: 0.1.155
+      version: 0.1.156
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.155
+  version: 0.1.156
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2761,7 +2761,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.155
+version: 0.1.156
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -350,6 +350,15 @@ data:
             value: {{ .Values.prewarm.chartImages.enabled | quote }}
           - name: PREWARM_CHART_IMAGES_FATAL
             value: {{ .Values.prewarm.chartImages.fatal | quote }}
+          # #5468 — per-image single-platform copy exception (see
+          # prewarm_multiarch_flags). Space-separated ref substrings; empty
+          # means EVERY copy stays on the #4975 `--multi-arch all` default.
+          - name: PREWARM_SINGLE_PLATFORM_SUBSTRINGS
+            value: {{ include "bp-self-sovereign-cutover.singlePlatformSubstringsInline" . | quote }}
+          - name: PREWARM_SINGLE_PLATFORM_OS
+            value: {{ .Values.prewarm.singlePlatform.os | default "linux" | quote }}
+          - name: PREWARM_SINGLE_PLATFORM_ARCH
+            value: {{ .Values.prewarm.singlePlatform.arch | default "amd64" | quote }}
           - name: CATALOG_BLUEPRINT_RESOURCE
             value: {{ .Values.prewarm.catalogCharts.blueprintResource | quote }}
           - name: CATALOG_BLUEPRINT_RESOURCE_FALLBACK
@@ -1028,14 +1037,86 @@ data:
             #     images FAILED). containerd pulls BY the list digest, so the
             #     FULL list + all arch sub-manifests + blobs must land.
             #     Single-arch refs are unaffected.
+            #   • #5468 the ONE documented exception to `--multi-arch all`, per
+            #     image, via prewarm_multiarch_flags below.
+
+            # #5468 (Refs #5442 #4975) — emit the skopeo multi-arch flag set for
+            # ONE source ref.
+            #
+            # DEFAULT is `--multi-arch all` for every ref — the #4975 contract is
+            # untouched, and narrowing it GLOBALLY is the wrong fix (it
+            # reproduces hw239's `digest invalid` across every multi-arch image,
+            # because those copies are addressed BY the manifest-list digest).
+            #
+            # THE EXCEPTION. A ref matching PREWARM_SINGLE_PLATFORM_SUBSTRINGS is
+            # copied as a SINGLE platform instead. This exists for upstream
+            # manifest lists that are MALFORMED in a way Harbor cannot ingest, so
+            # that no amount of retrying or egress can ever land them whole.
+            #
+            # The proven instance is ghcr.io/berriai/litellm-database (live hw291
+            # 2026-07-28, step-03 A3 `ok=35 fail=1 durable_miss=1`). Its
+            # `main-v1.57.2` OCI index lists EIGHT entries that are only FOUR
+            # distinct children — every child appears TWICE, byte-identical in
+            # mediaType, digest, size, platform and annotations:
+            #
+            #   c94ccc84 linux/amd64      x2
+            #   10c24c81 linux/arm64      x2
+            #   df4ae6f5 unknown/unknown  x2   (attestation for c94ccc84)
+            #   bc165dad unknown/unknown  x2   (attestation for 10c24c81)
+            #
+            # skopeo copies all eight children fine (they are just the same four
+            # blobs pushed twice) and then FATALs on the manifest-LIST upload
+            # alone: Harbor accepts the PUT and its post-push artifact walk then
+            # inserts one artifact_reference row per index entry — the duplicate
+            # (parent,child) pairs violate the table's uniqueness, the enclosing
+            # transaction rolls back, and the immediately-following read of the
+            # index Harbor was just handed answers
+            #   `unknown: artifact …@sha256:a1ed0885… not found`
+            # for a digest Harbor itself computed. Deterministic and permanent.
+            #
+            # IT IS NOT THE ATTESTATIONS. The same repository's `main-latest` tag
+            # carries the SAME two `unknown/unknown` buildx attestation children
+            # and mirrors cleanly in the same wave — its index simply lists each
+            # child ONCE. Duplication is the whole defect; attestations are a
+            # red herring.
+            #
+            # WHY SINGLE-PLATFORM IS SAFE *HERE* and not globally: the #4975
+            # `digest invalid` trap fires only when the copy is addressed by the
+            # list digest. Both refs this repository declares are addressed BY
+            # TAG (`:main-v1.57.2` from the chart's appVersion, `:main-latest`
+            # hardcoded in the upstream migration Job), so the destination tag
+            # resolving to a single amd64 manifest is exactly what containerd
+            # asks for on a linux/amd64 Sovereign node. The Phase A3-guard
+            # asserts durable PRESENCE via harbor_durable_digest, never
+            # source-digest equality, so a single-platform copy satisfies it.
+            # The #4994 dest_already_current skip WILL miss for these refs (index
+            # digest != child digest), so they re-copy on every step-03 re-run —
+            # fail-OPEN, an extra transfer and never a false present.
+            prewarm_multiarch_flags() {
+              _ma_ref="$1"
+              for _ma_s in ${PREWARM_SINGLE_PLATFORM_SUBSTRINGS}; do
+                case "${_ma_ref}" in
+                  *"${_ma_s}"*)
+                    printf -- '--multi-arch system --override-os %s --override-arch %s' \
+                      "${PREWARM_SINGLE_PLATFORM_OS}" "${PREWARM_SINGLE_PLATFORM_ARCH}"
+                    return 0 ;;
+                esac
+              done
+              printf -- '--multi-arch all'
+            }
+
             prewarm_skopeo_copy() {
               _pc_src="$1"; _pc_creds="$2"; _pc_lref="$3"; _pc_log="$4"
-              # Optional --src-creds via the function's OWN positional params
-              # (empty for anonymous upstreams).
-              if [ -n "${_pc_creds}" ]; then set -- --src-creds="${_pc_creds}"; else set --; fi
+              # #5468 — multi-arch mode FIRST into the function's OWN positional
+              # params (deliberately unquoted: the flag string must word-split).
+              # Matching is on the SOURCE ref, which may be the mothership-proxy
+              # form or the #5095 direct-upstream form — a repository-path
+              # substring matches both, exactly as EXCLUDED_SUBSTRINGS does.
+              set -- $(prewarm_multiarch_flags "${_pc_src}")
+              # Optional --src-creds (empty for anonymous upstreams).
+              if [ -n "${_pc_creds}" ]; then set -- "$@" --src-creds="${_pc_creds}"; fi
               skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
                 --insecure-policy \
-                --multi-arch all \
                 --retry-times 5 \
                 "$@" \
                 --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -1092,13 +1092,20 @@ data:
             # The #4994 dest_already_current skip WILL miss for these refs (index
             # digest != child digest), so they re-copy on every step-03 re-run —
             # fail-OPEN, an extra transfer and never a false present.
+            #
+            # Every env read is `:-`-defaulted because this script runs under
+            # `set -eu` (L387): an unset var would abort the WHOLE step rather
+            # than fall back, and the fallback here — no exception, os/arch
+            # linux/amd64 — is exactly the safe direction. An empty
+            # substrings list iterates zero times, i.e. `--multi-arch all` for
+            # everything, which is the pre-#5468 behaviour.
             prewarm_multiarch_flags() {
               _ma_ref="$1"
-              for _ma_s in ${PREWARM_SINGLE_PLATFORM_SUBSTRINGS}; do
+              for _ma_s in ${PREWARM_SINGLE_PLATFORM_SUBSTRINGS:-}; do
                 case "${_ma_ref}" in
                   *"${_ma_s}"*)
                     printf -- '--multi-arch system --override-os %s --override-arch %s' \
-                      "${PREWARM_SINGLE_PLATFORM_OS}" "${PREWARM_SINGLE_PLATFORM_ARCH}"
+                      "${PREWARM_SINGLE_PLATFORM_OS:-linux}" "${PREWARM_SINGLE_PLATFORM_ARCH:-amd64}"
                     return 0 ;;
                 esac
               done

--- a/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
+++ b/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
@@ -275,3 +275,13 @@ loft-sh/vcluster = handled by step-10 vcluster-registry-pivot). Space-separated.
 {{- define "bp-self-sovereign-cutover.excludedSubstringsInline" -}}
 {{- .Values.offlineMirror.excludedImageSubstrings | default (list) | join " " -}}
 {{- end -}}
+
+{{/*
+#5468 — image-path substrings copied SINGLE-PLATFORM by step-03's skopeo
+mirror instead of the #4975 `--multi-arch all` default. Space-separated for
+the POSIX-sh `for` loop in prewarm_multiarch_flags. An empty list renders an
+empty string, which that loop iterates zero times — i.e. no exception at all.
+*/}}
+{{- define "bp-self-sovereign-cutover.singlePlatformSubstringsInline" -}}
+{{- .Values.prewarm.singlePlatform.imageSubstrings | default (list) | join " " -}}
+{{- end -}}

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1556,25 +1556,41 @@ echo "[cutover-contract] Case 39: Step-03 Phase A container-image skopeo copy ca
 # list digest, so the FULL manifest list + ALL arch sub-manifests + blobs MUST land.
 # Phase A (container images) MUST carry --multi-arch all; Phase A2 (helm chart OCI =
 # a SINGLE manifest, never a list) MUST NOT — leave chart-artifact copies alone.
+#
+# #5468 reshaped WHERE Phase A's flag comes from, without changing WHAT it is.
+# The Phase A copy no longer hardcodes the flag on the skopeo line; it asks
+# prewarm_multiarch_flags, whose DEFAULT is `--multi-arch all` and whose only
+# other answer is the narrow per-image single-platform exception (one malformed
+# upstream index — see tests/single-platform-copy.sh, which proves the branch
+# behaviourally in both directions). So this case now asserts three things:
+# the Phase A copy still routes through the multi-arch decision, that
+# decision's DEFAULT is still `--multi-arch all`, and the flag still did not
+# get sprinkled onto the Phase A2 chart-OCI copy.
 awk '/cutover-step-03-harbor-prewarm/{c=1} c{print} c&&/cutover-order: "4"/{exit}' "$TMP/render.yaml" > "$TMP/prewarm_ma_block.txt"
 [ -s "$TMP/prewarm_ma_block.txt" ] || cp "$TMP/render.yaml" "$TMP/prewarm_ma_block.txt"
-# Match the flag LINE (not the explanatory comment that also names the flag).
-if ! grep -Eq '^[[:space:]]*--multi-arch all \\$' "$TMP/prewarm_ma_block.txt"; then
-  echo "FAIL: Step-03 Phase A skopeo copy is missing --multi-arch all — a manifest-list image uploads only a single-arch manifest and Harbor rejects it 'digest invalid', fail-closing step-03 (#4975)" >&2
+# (a) The Phase A container-image copy routes through the multi-arch decision.
+if ! awk '/prewarm_skopeo_copy\(\) \{/,/^[[:space:]]*\}[[:space:]]*$/' "$TMP/prewarm_ma_block.txt" | grep -q 'prewarm_multiarch_flags'; then
+  echo "FAIL: Step-03 prewarm_skopeo_copy() does not consult prewarm_multiarch_flags — the Phase A container-image copy no longer makes a multi-arch decision at all, so a manifest-list image uploads only a single-arch manifest and Harbor rejects it 'digest invalid' (#4975 #5468)" >&2
   exit 1
 fi
-# EXACTLY TWO copies carry it: the Phase A container-image copy AND the Phase A4
-# xpkg package warm (#5204 — upbound provider packages are multi-arch manifest
-# LISTS too; the warm must pull EVERY arch sub-manifest + blobs through so the
-# proxy-cache holds the complete list). The Phase A2 chart-OCI copy (a single
-# manifest, never a list) is left alone, so the flag-line count is exactly 2 —
-# this also proves the flag did not get sprinkled onto the chart copy.
+# (b) That decision's DEFAULT is --multi-arch all. If this fallback is ever
+# narrowed, EVERY list-digest-addressed image regresses to hw239.
+if ! grep -Eq "printf -- '--multi-arch all'" "$TMP/prewarm_ma_block.txt"; then
+  echo "FAIL: prewarm_multiarch_flags no longer defaults to --multi-arch all — narrowing the GLOBAL default is the #4975 hw239 regression (all 8 multi-arch images FAILED 'digest invalid'). Single-platform is only ever a per-image exception (#5468)" >&2
+  exit 1
+fi
+# (c) EXACTLY ONE literal flag line remains: the Phase A4 xpkg package warm
+# (#5204 — upbound provider packages are multi-arch manifest LISTS too; the
+# warm must pull EVERY arch sub-manifest + blobs through so the proxy-cache
+# holds the complete list). The Phase A2 chart-OCI copy (a single manifest,
+# never a list) is left alone, so the literal-flag-line count is exactly 1 —
+# this still proves the flag did not get sprinkled onto the chart copy.
 ma_lines=$(grep -Ec '^[[:space:]]*--multi-arch all \\$' "$TMP/prewarm_ma_block.txt" || true)
-if [ "${ma_lines}" -ne 2 ]; then
-  echo "FAIL: Step-03 has ${ma_lines} --multi-arch all flag line(s), expected exactly 2 (the Phase A container-image copy + the Phase A4 xpkg warm #5204). The Phase A2 helm-chart-OCI copy must NOT carry it — chart artifacts are single manifests, not lists (#4975)" >&2
+if [ "${ma_lines}" -ne 1 ]; then
+  echo "FAIL: Step-03 has ${ma_lines} literal --multi-arch all flag line(s), expected exactly 1 (the Phase A4 xpkg warm #5204). The Phase A container-image copy takes its flags from prewarm_multiarch_flags (#5468) and the Phase A2 helm-chart-OCI copy must NOT carry it — chart artifacts are single manifests, not lists (#4975)" >&2
   exit 1
 fi
-echo "  PASS (Step-03 Phase A container-image copy uses --multi-arch all; Phase A2 chart-OCI copy left single-manifest)"
+echo "  PASS (Phase A copy routes through prewarm_multiarch_flags, whose default is --multi-arch all; Phase A4 xpkg warm keeps its literal flag; Phase A2 chart-OCI copy left single-manifest)"
 
 echo "[cutover-contract] Case 40: cutover step + resolver ConfigMaps re-render on helm upgrade (NO resource-policy: keep); only the status ConfigMap keeps (#4982 Finding A, Refs #3379)"
 # #4982 Finding A: a cutover-step / resolver ConfigMap that carries

--- a/platform/self-sovereign-cutover/chart/tests/single-platform-copy.sh
+++ b/platform/self-sovereign-cutover/chart/tests/single-platform-copy.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# bp-self-sovereign-cutover — step-03 SINGLE-PLATFORM copy-exception guardrail
+# (#5468 Refs #5442 #4975).
+#
+# WHAT THIS PROTECTS. Step-03 harbor-prewarm copies every image with skopeo
+# `--multi-arch all` (#4975) because containerd pulls by manifest-LIST digest
+# and a single-arch copy addressed by the list digest makes Harbor compute a
+# different digest -> `digest invalid` (live hw239: all 8 multi-arch images
+# FAILED). That default is load-bearing and must NEVER be narrowed globally.
+#
+# But ONE upstream index cannot be ingested by Harbor at all:
+# ghcr.io/berriai/litellm-database:main-v1.57.2 lists EIGHT entries that are
+# only FOUR distinct children -- every child appears twice, byte-identical.
+# Harbor's post-push artifact walk inserts duplicate artifact_reference rows,
+# violates their uniqueness, rolls back, and then answers `not found` for the
+# index digest it just computed. Live hw291 2026-07-28 step-03:
+# `Phase A3-chart-images ok=35 fail=1 durable_miss=1`, every child copied
+# 1/8..8/8 and only the manifest-list upload FATALed. The #5442 A3 guard is
+# right to make that fatal (bp-llm-gateway is `visibility: listed`), so the
+# cutover cannot proceed until the copy lands.
+#
+# The fix is a NARROW, per-image single-platform copy exception. This guardrail
+# fails the publish if that exception is reverted, if it silently stops
+# matching, or -- just as important -- if someone "fixes" a future image by
+# narrowing the GLOBAL default instead.
+#
+# WHY IT IS NOT A `grep -q` FOR A STRING. A grep for a present string passes
+# trivially against an empty or broken render, which is exactly how a guard
+# rots into theater. So this script:
+#
+#   1. VACUITY-CHECKS the render first -- non-empty, parses, and contains a
+#      control string that is independently known to be present. A render that
+#      cannot satisfy the control cannot be used to judge anything, and the
+#      script exits non-zero rather than reporting a pass.
+#   2. EXTRACTS the real `prewarm_multiarch_flags` shell function OUT of the
+#      rendered Job and EXECUTES it. The assertions are on observed behaviour,
+#      not on the presence of source text.
+#   3. Proves BOTH directions: a matching ref must select single-platform
+#      flags, a non-matching ref must still get `--multi-arch all`, and an
+#      EMPTY exception list must give `--multi-arch all` even for the ref that
+#      otherwise matches (which proves the list drives the branch rather than
+#      some hardcoded special case).
+#
+# Usage:
+#   tests/single-platform-copy.sh [CHART_DIR]   # CHART_DIR defaults to ../
+#
+# Exit: 0 = guarded behaviour intact; 1 = assertion failed; 2 = tool/input
+# error (including a render too broken to judge).
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# The ref whose upstream index is malformed -- the reason this mechanism exists.
+GUARDED_REF="ghcr.io/berriai/litellm-database:main-v1.57.2"
+# A ref that must keep the #4975 default. Real, multi-arch, mirrored in the
+# same wave, and deliberately NOT the litellm repository.
+CONTROL_REF="ghcr.io/cloudnative-pg/postgresql:16.4"
+# Independently-known-present env var in the same container spec -- the
+# vacuity control. If THIS is missing the render is not usable as evidence.
+VACUITY_CONTROL="PREWARM_CHART_IMAGES_FATAL"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+toolerr() { echo "ERROR: $*" >&2; exit 2; }
+
+command -v helm >/dev/null 2>&1 || toolerr "helm not installed"
+[ -d "${CHART_DIR}" ] || toolerr "chart dir not found: ${CHART_DIR}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+RENDER="${WORK}/render.yaml"
+
+# ── Render ───────────────────────────────────────────────────────────────────
+# The step-03 Job is gated behind the cutover's step toggles in some value
+# shapes, so render at defaults and let the vacuity check below decide whether
+# the output is usable rather than assuming it.
+if ! helm template cutover-guard "${CHART_DIR}" \
+      --namespace catalyst-system >"${RENDER}" 2>"${WORK}/render.err"; then
+  sed 's/^/  /' "${WORK}/render.err" >&2 || true
+  toolerr "helm template failed for ${CHART_DIR} -- cannot judge the copy path"
+fi
+
+# ── 1. VACUITY CHECK ────────────────────────────────────────────────────────
+# Every later assertion is a search over this file. If the file is empty, or
+# does not contain something we independently know must be there, then a
+# "not found" result carries no information and a "found" result is luck.
+render_lines="$(wc -l <"${RENDER}" | tr -d ' ')"
+if [ "${render_lines}" -lt 100 ]; then
+  toolerr "render is only ${render_lines} lines -- too small to contain the step-03 Job; every assertion below would be vacuous"
+fi
+grep -q "name: ${VACUITY_CONTROL}" "${RENDER}" \
+  || toolerr "vacuity control '${VACUITY_CONTROL}' absent from the render -- the step-03 Job did not render, so this script cannot prove anything about its copy path"
+grep -q 'prewarm_skopeo_copy()' "${RENDER}" \
+  || toolerr "vacuity control 'prewarm_skopeo_copy()' absent from the render -- the copy path did not render"
+echo "vacuity OK: ${render_lines}-line render carries ${VACUITY_CONTROL} + prewarm_skopeo_copy()"
+
+# ── 2. The global #4975 default must NOT have been narrowed ─────────────────
+# The wrong fix for this whole class is to drop `--multi-arch all` globally.
+# That reproduces hw239. Assert the default still exists in the copy path.
+grep -q -- '--multi-arch all' "${RENDER}" \
+  || fail "the skopeo copy path no longer contains '--multi-arch all' -- the #4975 default was narrowed globally, which reproduces hw239's 'digest invalid' on every list-digest-addressed image"
+
+# A literal `--multi-arch system` must NOT appear as an unconditional flag on
+# the skopeo invocation itself; it may only be produced by the flag helper.
+if grep -E '^\s+--multi-arch system' "${RENDER}" >/dev/null 2>&1; then
+  fail "'--multi-arch system' appears as a literal flag line in the skopeo invocation -- single-platform must be selected per-image by prewarm_multiarch_flags, never applied unconditionally"
+fi
+
+# ── 3. Extract the REAL function and execute it ─────────────────────────────
+FN="${WORK}/fn.sh"
+sed -n '/prewarm_multiarch_flags() {/,/^[[:space:]]*}[[:space:]]*$/p' "${RENDER}" \
+  | sed 's/^[[:space:]]\{1,\}//' >"${FN}"
+[ -s "${FN}" ] || fail "prewarm_multiarch_flags() not found in the render -- the #5468 per-image exception was removed; ${GUARDED_REF} will fail step-03's A3 guard again"
+grep -q 'prewarm_multiarch_flags() {' "${FN}" || toolerr "function extraction produced junk (no opening line)"
+tail -n 1 "${FN}" | grep -qE '^\}$' || toolerr "function extraction produced junk (no closing brace); got: $(tail -n 1 "${FN}")"
+
+# Read the rendered env values so the behavioural test runs against what the
+# chart ACTUALLY ships, not against values re-typed into this script.
+env_value() {
+  # $1 = env var name. Prints the `value:` on the line after `name: $1`.
+  awk -v want="name: $1" '
+    index($0, want) { getline; sub(/^[[:space:]]*value:[[:space:]]*/, ""); gsub(/^"|"$/, ""); print; exit }
+  ' "${RENDER}"
+}
+SUBSTRINGS="$(env_value PREWARM_SINGLE_PLATFORM_SUBSTRINGS)"
+SP_OS="$(env_value PREWARM_SINGLE_PLATFORM_OS)"
+SP_ARCH="$(env_value PREWARM_SINGLE_PLATFORM_ARCH)"
+
+[ -n "${SUBSTRINGS}" ] \
+  || fail "PREWARM_SINGLE_PLATFORM_SUBSTRINGS renders EMPTY -- the exception list is unset, so ${GUARDED_REF} takes the '--multi-arch all' path whose manifest-list upload Harbor rejects"
+[ -n "${SP_OS}" ]   || fail "PREWARM_SINGLE_PLATFORM_OS renders empty"
+[ -n "${SP_ARCH}" ] || fail "PREWARM_SINGLE_PLATFORM_ARCH renders empty"
+echo "rendered exception list: '${SUBSTRINGS}' (${SP_OS}/${SP_ARCH})"
+
+run_flags() {
+  # $1 = substring list to expose, $2 = ref. Executes the EXTRACTED function.
+  ( set +u
+    PREWARM_SINGLE_PLATFORM_SUBSTRINGS="$1"
+    PREWARM_SINGLE_PLATFORM_OS="${SP_OS}"
+    PREWARM_SINGLE_PLATFORM_ARCH="${SP_ARCH}"
+    export PREWARM_SINGLE_PLATFORM_SUBSTRINGS PREWARM_SINGLE_PLATFORM_OS PREWARM_SINGLE_PLATFORM_ARCH
+    # shellcheck disable=SC1090
+    . "${FN}"
+    prewarm_multiarch_flags "$2" )
+}
+
+EXPECT_SINGLE="--multi-arch system --override-os ${SP_OS} --override-arch ${SP_ARCH}"
+EXPECT_ALL="--multi-arch all"
+
+# 3a. POSITIVE — the guarded ref must select single-platform.
+got="$(run_flags "${SUBSTRINGS}" "${GUARDED_REF}")"
+[ "${got}" = "${EXPECT_SINGLE}" ] \
+  || fail "guarded ref took the wrong path.
+    ref:      ${GUARDED_REF}
+    expected: ${EXPECT_SINGLE}
+    got:      ${got}
+  The exception no longer matches this ref, so step-03 will again try to upload
+  its duplicated-child manifest list and Harbor will again answer 'not found'
+  for the index digest it just computed."
+echo "PASS 3a positive: ${GUARDED_REF} -> ${got}"
+
+# 3b. NEGATIVE — an unrelated multi-arch ref must keep the #4975 default.
+got="$(run_flags "${SUBSTRINGS}" "${CONTROL_REF}")"
+[ "${got}" = "${EXPECT_ALL}" ] \
+  || fail "control ref did NOT keep the #4975 default.
+    ref:      ${CONTROL_REF}
+    expected: ${EXPECT_ALL}
+    got:      ${got}
+  The exception leaked beyond its named image -- this is the hw239 'digest
+  invalid' regression in the making."
+echo "PASS 3b negative: ${CONTROL_REF} -> ${got}"
+
+# 3c. The proxy-sourced form of the guarded ref must ALSO match. copy_one may
+# hand prewarm_skopeo_copy either the direct upstream ref or the mothership
+# proxy form (#5095), and a tag-scoped or host-scoped match would silently miss
+# one of them.
+proxied="harbor.openova.io/proxy-ghcr/berriai/litellm-database:main-v1.57.2"
+got="$(run_flags "${SUBSTRINGS}" "${proxied}")"
+[ "${got}" = "${EXPECT_SINGLE}" ] \
+  || fail "the mothership-proxy form of the guarded ref did not match.
+    ref:      ${proxied}
+    expected: ${EXPECT_SINGLE}
+    got:      ${got}
+  #5095 can route either form into the copy; the exception must match both."
+echo "PASS 3c proxy form: ${proxied} -> ${got}"
+
+# 3d. The floating tag from the upstream migration Job must also match --
+# repository-scoped, not tag-scoped.
+latest="ghcr.io/berriai/litellm-database:main-latest"
+got="$(run_flags "${SUBSTRINGS}" "${latest}")"
+[ "${got}" = "${EXPECT_SINGLE}" ] \
+  || fail "the migration Job's floating tag did not match.
+    ref:      ${latest}
+    expected: ${EXPECT_SINGLE}
+    got:      ${got}
+  The exception must be repository-scoped: main-latest is rebuilt by the same
+  buildx pipeline that produced the duplicated index."
+echo "PASS 3d floating tag: ${latest} -> ${got}"
+
+# 3e. CONTROL ON THE MECHANISM — with an EMPTY list, even the guarded ref must
+# fall back to the default. This proves the branch is driven by the rendered
+# list and is not a hardcoded special case that would pass 3a for free.
+got="$(run_flags "" "${GUARDED_REF}")"
+[ "${got}" = "${EXPECT_ALL}" ] \
+  || fail "with an EMPTY exception list the guarded ref still selected '${got}'.
+  The single-platform branch is hardcoded rather than list-driven, so assertion
+  3a proves nothing and operators cannot turn the exception off."
+echo "PASS 3e empty-list control: ${GUARDED_REF} -> ${got}"
+
+# ── 4. The copy path must actually CONSUME the helper ───────────────────────
+# A correct helper that nothing calls is the purest form of this theater.
+awk '/prewarm_skopeo_copy\(\) \{/,/^[[:space:]]*\}[[:space:]]*$/' "${RENDER}" \
+  | grep -q 'prewarm_multiarch_flags' \
+  || fail "prewarm_skopeo_copy() does not call prewarm_multiarch_flags -- the helper renders but nothing consumes it, so every copy still uses the unconditional default"
+echo "PASS 4: prewarm_skopeo_copy() consumes prewarm_multiarch_flags"
+
+echo "OK: #5468 single-platform copy exception intact (positive, negative, proxy, floating-tag, empty-list control, and consumption all verified against the live render)"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -724,6 +724,42 @@ prewarm:
     # to RENDER is always a WARN and never fatal: it makes no claim about
     # images either way.
     fatal: true
+  # #5468 (Refs #5442 #4975) — the per-image SINGLE-PLATFORM copy exception.
+  #
+  # Every step-03 copy uses `--multi-arch all` (#4975) unless the source ref
+  # matches one of `imageSubstrings`, in which case it is copied as ONE
+  # platform (`--multi-arch system` + the os/arch below). Keep this list as
+  # short as the evidence demands — it exists for upstream manifest lists that
+  # are MALFORMED in a way no retry can fix, NOT as a general escape hatch, and
+  # narrowing `--multi-arch all` globally is a known-wrong fix (it reproduces
+  # hw239's `digest invalid` on every list-digest-addressed image).
+  #
+  # A ref belongs here only when ALL THREE hold:
+  #   1. the upstream index cannot be ingested by Harbor at all (not egress, not
+  #      a timeout — a deterministic, permanent rejection);
+  #   2. nothing pulls the ref BY its manifest-list digest (a tag-addressed pin
+  #      resolves to the single-platform manifest correctly, a digest-addressed
+  #      one would not);
+  #   3. the Sovereign's nodes are all `os`/`arch` below.
+  singlePlatform:
+    os: "linux"
+    arch: "amd64"
+    imageSubstrings:
+      # ghcr.io/berriai/litellm-database — the image bp-llm-gateway's upstream
+      # litellm-helm subchart pins for BOTH its proxy Deployment
+      # (`:main-v1.57.2`, from the chart appVersion) and its Prisma migration
+      # Job (`:main-latest`, hardcoded upstream). Its `main-v1.57.2` OCI index
+      # lists each of its four children TWICE, byte-identical; Harbor's
+      # post-push artifact walk inserts duplicate artifact_reference rows,
+      # violates their uniqueness, rolls the transaction back and then answers
+      # `not found` for the index digest it just computed. Live hw291
+      # 2026-07-28 step-03: `Phase A3-chart-images ok=35 fail=1
+      # durable_miss=1`, every child copied 1/8..8/8 and only the manifest-list
+      # upload FATALed. bp-llm-gateway is `visibility: listed`, so the A3 guard
+      # is right to treat it as contractual — the index is the defect, not the
+      # pin. The substring is repository-scoped, not tag-scoped, because
+      # `main-latest` is a floating tag rebuilt by the same buildx pipeline.
+      - "berriai/litellm-database"
   # #4994 (Refs #3379) — content-digest idempotency for the step-03 skopeo
   # mirror. When true (default) each container-image copy (Phase A) + chart-OCI
   # copy (Phase A2) first compares the SOURCE vs local-Harbor DEST manifest

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.155"
+  version: "0.1.156"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.155"
+    version: "0.1.156"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What was actually wrong

Step-03 `harbor-prewarm` fail-closed on hw291 with `ok=35 fail=1 durable_miss=1`. One image:

```
[harbor-prewarm] Phase A3-chart-images FAIL ghcr.io/berriai/litellm-database:main-v1.57.2 exit=1
```

skopeo copied children **1/8 … 8/8 successfully** and FATALed only on the final manifest-LIST upload, with Harbor answering `not found` for a digest Harbor itself had just computed.

The pin is correct and the image is not missing upstream. **The upstream index is malformed.** `main-v1.57.2` lists EIGHT entries that are only FOUR distinct children — every child appears twice, byte-identical in `mediaType`, `digest`, `size`, `platform` and `annotations`:

| child | platform | occurrences |
|---|---|---|
| `c94ccc84` | linux/amd64 | **2** |
| `10c24c81` | linux/arm64 | **2** |
| `df4ae6f5` | unknown/unknown (attestation for `c94ccc84`) | **2** |
| `bc165dad` | unknown/unknown (attestation for `10c24c81`) | **2** |

Harbor's post-push artifact walk inserts one `artifact_reference` row per index entry. The duplicate `(parent, child)` pairs violate that table's uniqueness, the enclosing transaction rolls back, and the immediately-following read of the index 404s. Deterministic and permanent — no retry and no egress window changes it. That is why the copy burned all three attempts in ~20s rather than timing out.

### It is not the attestation manifests

The same repository's `main-latest` tag carries the **same two `unknown/unknown` buildx attestation children** and mirrored cleanly in the very same wave (it is among the `ok=35`; the enumerator emits it because the upstream migration Job hardcodes it). Its index simply lists each child **once**. Duplication is the whole defect — attestations are a red herring, and the earlier "Harbor rejects an index referencing attestation children" reading does not survive that contrast.

## The fix

A narrow, per-image single-platform copy exception — `prewarm.singlePlatform.imageSubstrings` — consumed by a new `prewarm_multiarch_flags` helper. Its **default is unchanged `--multi-arch all`** for every other ref.

Why this is safe for this image specifically, and only this image:

- The #4975 `digest invalid` trap fires **only when the copy is addressed by the manifest-list digest**. Both refs this repository declares are addressed **by tag** — `:main-v1.57.2` from the chart appVersion for the proxy Deployment, `:main-latest` hardcoded in the upstream migration Job — so a destination tag resolving to a single amd64 manifest is exactly what containerd asks for on a linux/amd64 node.
- The A3 guard asserts durable **presence** via `harbor_durable_digest`, never source-digest equality, so a single-platform copy satisfies it.
- The child that gets pushed is a well-formed 16-layer `application/vnd.oci.image.manifest.v1+json` — a single manifest, so no index and no duplicate rows.
- The #4994 `dest_already_current` skip *will* miss for these refs (index digest != child digest) and they re-copy on every re-run. Fail-open: an extra transfer, never a false present.

The substring is repository-scoped rather than tag-scoped because `main-latest` is a floating tag rebuilt by the same buildx pipeline that produced the duplicated index.

### Levers evaluated and rejected on evidence

- **Narrowing `--multi-arch all` globally** — reproduces hw239 (`digest invalid` across every list-digest-addressed image). Case 39 now fails if the helper's default is ever narrowed.
- **`prewarm.chartImages.fatal=false`** — `bp-llm-gateway` is `visibility: listed`, so the guard is right to treat it as contractual; disabling it is the hw290 death the guard exists to prevent.
- **Dropping the declaration** (the shape used for nemo-guardrails) — checked against the real chart, not the comment. The published `bp-llm-gateway:1.0.1` renders a Deployment, a migration Job and a test Pod; `image.repository` drives the **proxy Deployment itself**. There is nothing to drop.

## Guards, proven in both directions

New `tests/single-platform-copy.sh` **extracts `prewarm_multiarch_flags` out of the live render and executes it** — the assertions are on observed behaviour, not on the presence of source text. It vacuity-checks the render against an independently-known-present control first and exits **2, not 0**, when the render cannot support judgment.

Passing, against the real render:

```
vacuity OK: 12079-line render carries PREWARM_CHART_IMAGES_FATAL + prewarm_skopeo_copy()
rendered exception list: 'berriai/litellm-database' (linux/amd64)
PASS 3a positive:       ghcr.io/berriai/litellm-database:main-v1.57.2 -> --multi-arch system --override-os linux --override-arch amd64
PASS 3b negative:       ghcr.io/cloudnative-pg/postgresql:16.4       -> --multi-arch all
PASS 3c proxy form:     harbor.openova.io/proxy-ghcr/berriai/...      -> --multi-arch system --override-os linux --override-arch amd64
PASS 3d floating tag:   ghcr.io/berriai/litellm-database:main-latest  -> --multi-arch system --override-os linux --override-arch amd64
PASS 3e empty-list control: ghcr.io/berriai/litellm-database:main-v1.57.2 -> --multi-arch all
PASS 4: prewarm_skopeo_copy() consumes prewarm_multiarch_flags
```

Failing, one scenario per way the fix can rot:

| reverted how | result |
|---|---|
| exception list emptied in `values.yaml` | `FAIL: PREWARM_SINGLE_PLATFORM_SUBSTRINGS renders EMPTY` (exit 1) |
| helper removed, unconditional flag restored | `FAIL: prewarm_multiarch_flags() not found in the render` (exit 1) |
| global default narrowed to `--multi-arch system` | `FAIL: control ref did NOT keep the #4975 default` (exit 1) |
| helper renders but nothing calls it | `FAIL: prewarm_skopeo_copy() does not call prewarm_multiarch_flags` (exit 1) |
| **step-03 Job stops rendering entirely** | `ERROR: vacuity control absent … cannot prove anything` (**exit 2**, refuses to report a pass) |

`3e` is the anti-hardcode control: with an empty list even the guarded ref must fall back to `--multi-arch all`, which is what makes `3a` mean something.

`cutover-contract.sh` Case 39 is re-expressed for the new shape rather than relaxed — it now asserts the Phase A copy routes through the helper, the helper's default remains `--multi-arch all`, and the literal flag-line count stays at the Phase A4 xpkg warm alone. Proven failing against both a pre-fix revert and a global-narrowing "fix".

## Verification

- All five `platform/self-sovereign-cutover/chart/tests/*.sh` pass; `helm lint` clean.
- `cd tests/e2e/bootstrap-kit && go test -count=1 ./...` → `ok` (the authoritative lockstep gate — the shell gates miss `blueprint.yaml` and catalog-seed).
- Rendered step-03 `podSpec` passes `sh -n`; the simulated argv was observed on both paths, including `--src-creds` ordering.
- Chart `0.1.155 -> 0.1.156` with full lockstep: `Chart.yaml`, `blueprint.yaml`, catalog-seed **display + source**, bootstrap-kit slot 06a. Same five-file shape as the preceding cutover bump (#5469).

## One finding not fixed here

`platform/llm-gateway/chart/values.yaml:33-35` says the `litellm-database` image is kept *"because the upstream chart's migration Job assumes it"*. That is wrong on the mechanism: the migration Job hardcodes its own `ghcr.io/berriai/litellm-database:main-latest` (`charts/litellm-helm/templates/migrations-job.yaml:21`) and never reads `image.repository`; our `image:` block drives the **proxy Deployment**. Correcting a comment there would force a republish of `bp-llm-gateway` and its own five-place lockstep on the eve of a cutover run, for zero behavioural change. The accurate mechanism is recorded in the cutover chart's values comment instead; the stale comment is worth a follow-up on a quiet train.

Refs #5468
