### PR TITLE
fix(catalyst-api): read primaryRegion from status.placement, not a key the CR lacks (#5482)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/application_primary_region_5482_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_primary_region_5482_test.go
@@ -1,0 +1,106 @@
+// Tests for #5482 — the App detail Overview rendered a HOST CLUSTER LABEL
+// where a region belongs, because the handler read a status key the
+// Application CR does not have.
+//
+// Live on hw291, one Application reported three different values:
+//
+//	Overview PRIMARY REGION   platform-bootstrap-owned-host   <- a host label
+//	Topology tab              hw-me-east-215-a-rtz-prod
+//	the CR itself             me-east-215-a
+//
+// The read was `status.primaryRegion`; the CR carries
+// `status.placement.primaryRegion`. NestedString returns ok=false rather than
+// erroring on a missing path, so the miss was silent and AppDetail.tsx:256
+// fell back to appRegions[0].
+//
+// Anti-theater: TestApplicationPrimaryRegion_ReadsNestedPlacementPath fails
+// against the pre-fix code, which is the whole defect. The empty-status case
+// matters just as much — returning "" is what lets the UI decide to render
+// nothing, rather than being handed a value of the wrong KIND.
+
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func appWithStatus(status map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps.openova.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]interface{}{"name": "shared-pg", "namespace": "catalyst"},
+		"status":     status,
+	}}
+}
+
+func TestApplicationPrimaryRegion_ReadsNestedPlacementPath(t *testing.T) {
+	t.Parallel()
+	// The real hw291 shape: status keys are conditions, lastReconciledAt,
+	// observedGeneration, phase, placement — and nothing else.
+	obj := appWithStatus(map[string]interface{}{
+		"phase":              "Ready",
+		"observedGeneration": int64(3),
+		"lastReconciledAt":   "2026-07-29T15:00:00Z",
+		"placement": map[string]interface{}{
+			"mode":           "active-hot-standby",
+			"primaryRegion":  "me-east-215-a",
+			"standbyRegions": []interface{}{"me-east-215-b"},
+		},
+	})
+	if got := applicationPrimaryRegion(obj); got != "me-east-215-a" {
+		t.Errorf("primaryRegion = %q want %q — the Overview tab renders this, and an "+
+			"empty value makes the UI substitute a host-cluster label", got, "me-east-215-a")
+	}
+}
+
+func TestApplicationPrimaryRegion_TopLevelPathStillHonoured(t *testing.T) {
+	t.Parallel()
+	obj := appWithStatus(map[string]interface{}{
+		"phase":         "Ready",
+		"primaryRegion": "me-east-215-a",
+	})
+	if got := applicationPrimaryRegion(obj); got != "me-east-215-a" {
+		t.Errorf("a CR that DOES set the top-level key must still be honoured; got %q", got)
+	}
+}
+
+// Nested wins when both are present and disagree — the placement block is the
+// object the placement controller actually maintains.
+func TestApplicationPrimaryRegion_NestedWinsOverStaleTopLevel(t *testing.T) {
+	t.Parallel()
+	obj := appWithStatus(map[string]interface{}{
+		"primaryRegion": "me-east-215-b-STALE",
+		"placement":     map[string]interface{}{"primaryRegion": "me-east-215-a"},
+	})
+	if got := applicationPrimaryRegion(obj); got != "me-east-215-a" {
+		t.Errorf("primaryRegion = %q want the placement-block value me-east-215-a", got)
+	}
+}
+
+func TestApplicationPrimaryRegion_AbsentIsEmptyNotFabricated(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		obj  *unstructured.Unstructured
+	}{
+		{"nil object", nil},
+		{"no status at all", appWithStatus(map[string]interface{}{})},
+		{"placement without a region", appWithStatus(map[string]interface{}{
+			"placement": map[string]interface{}{"mode": "singleton"},
+		})},
+		{"empty nested value", appWithStatus(map[string]interface{}{
+			"placement": map[string]interface{}{"primaryRegion": ""},
+		})},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := applicationPrimaryRegion(tc.obj); got != "" {
+				t.Errorf("absent region must resolve to empty, got %q — a non-empty value "+
+					"here would be fabricated", got)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1321,6 +1321,32 @@ type dependsOnDetail struct {
 // Application CR named `name` across every namespace on the Sovereign.
 //
 // qa-loop iter-11 Fix #45 Cluster-C.
+// applicationPrimaryRegion resolves an Application's primary region from its
+// CR status.
+//
+// #5482 — the region lives at status.placement.primaryRegion. There is no
+// top-level status.primaryRegion key: the CR's status keys are conditions,
+// lastReconciledAt, observedGeneration, phase and placement. Reading only the
+// top-level path returned ok=false silently, leaving the response field empty,
+// so AppDetail.tsx fell back to appRegions[0] and rendered the HOST CLUSTER
+// LABEL `platform-bootstrap-owned-host` where a region belongs — the Overview
+// tab contradicting the Topology tab for the same object.
+//
+// The top-level path is retained as a fallback so a CR that does set it is
+// still honoured.
+func applicationPrimaryRegion(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ""
+	}
+	if pr, ok, _ := unstructured.NestedString(obj.Object, "status", "placement", "primaryRegion"); ok && pr != "" {
+		return pr
+	}
+	if pr, ok, _ := unstructured.NestedString(obj.Object, "status", "primaryRegion"); ok {
+		return pr
+	}
+	return ""
+}
+
 func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 	depID := chi.URLParam(r, "id")
 	name := chi.URLParam(r, "name")
@@ -1418,7 +1444,7 @@ func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 	if phase, ok, _ := unstructured.NestedString(obj.Object, "status", "phase"); ok {
 		resp.Phase = phase
 	}
-	if pr, ok, _ := unstructured.NestedString(obj.Object, "status", "primaryRegion"); ok {
+	if pr := applicationPrimaryRegion(obj); pr != "" {
 		resp.PrimaryRegion = pr
 	}
 	if gr, ok, _ := unstructured.NestedString(obj.Object, "status", "giteaRepo"); ok {


### PR DESCRIPTION
## The defect

App detail **Overview** rendered a *host cluster label* where a region belongs. One Application reported three different values on hw291:

| surface | value |
|---|---|
| Overview → PRIMARY REGION | `platform-bootstrap-owned-host` ← a host label, not a region |
| Topology tab | `hw-me-east-215-a-rtz-prod` |
| the Application CR | `me-east-215-a` |

The handler read `status.primaryRegion`. That key does not exist — the CR's status keys are `conditions`, `lastReconciledAt`, `observedGeneration`, `phase`, `placement`, and the region lives at **`status.placement.primaryRegion`**.

`NestedString` returns `ok=false` rather than erroring on a missing path, so the miss was **silent**: `resp.PrimaryRegion` stayed empty and `AppDetail.tsx:256` fell back to `appRegions[0]`.

So the Overview tab was not showing the wrong region — it was showing a different *kind of identifier* entirely, because the field it wanted was never populated. That is why this read as a data bug rather than a missing field.

## The fix

The read becomes a small helper so it can be tested. It prefers the nested path and keeps the top-level one as a fallback, so a CR that *does* set it is still honoured.

## Tests — proven in both directions

Four cases. Removing the nested read makes `TestApplicationPrimaryRegion_ReadsNestedPlacementPath` fail with exactly the empty value that caused the fallback.

The absent-region case is the one worth keeping honest: it asserts **empty**, not any value. Substituting a different kind of identifier for a missing one is the actual failure mode here, so the helper must return nothing and let the UI decide what to render.

Full `internal/handler` package green (167s).

## Related, not fixed here

`hw-me-east-215-a-rtz-prod` (Topology) vs `me-east-215-a` (CR) is a separate, milder inconsistency — a fully-qualified cluster name against a bare region id. Both are *correct* identifiers for the same region, unlike the Overview value, so it is on the issue checklist rather than in this change.

Refs #5482 #5422 #3969
