### PR TITLE
fix(catalyst-api): reconciler log matcher must respect the trailing name boundary (#5485)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/reconciler_log_prefix_5485_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/reconciler_log_prefix_5485_test.go
@@ -1,0 +1,97 @@
+// Tests for #5485 — the reconciler drill-in rendered ANOTHER object's logs.
+//
+// Live on hw291: GET .../reconcilers/bp-velero/logs returned total=1 with
+// payload name "bp-velero-hcs" — 100% wrong object, with nothing in the UI
+// indicating the substitution. GET .../bp-cnpg/logs mixed bp-cnpg with
+// bp-cnpg-pair.
+//
+// Cause: the matchers guarded only the LEADING boundary. `name=bp-velero`
+// and `/bp-velero` both match inside `name=bp-velero-hcs`, and the primary
+// check was a bare strings.Contains on `<ns>/<name>`, so
+// `flux-system/bp-velero` matched `flux-system/bp-velero-hcs`. The old
+// function's own doc comment claimed it prevented exactly this.
+//
+// Anti-theater: every "must NOT match" case below passes trivially against
+// the pre-fix code only if you delete the assertion — with the old bare
+// Contains they all FAIL. The "must still match" cases are the control:
+// without them a matcher that returns false for everything would pass.
+
+package handler
+
+import "testing"
+
+func TestLogLineMentionsName_DoesNotMatchLongerSiblingName(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		query string
+		line  string
+		want  bool
+	}{
+		// The exact hw291 failures.
+		{"velero vs velero-hcs, name= form", "bp-velero",
+			`ts=2026-07-29T16:00:00Z level=info name=bp-velero-hcs namespace=flux-system msg="reconciliation finished"`, false},
+		{"velero vs velero-hcs, path form", "bp-velero",
+			`ts=2026-07-29T16:00:00Z level=info msg="applied" path=/flux-system/bp-velero-hcs`, false},
+		{"cnpg vs cnpg-pair", "bp-cnpg",
+			`level=info name=bp-cnpg-pair namespace=flux-system msg="drift detected"`, false},
+
+		// The object itself must still match — otherwise the fix is a
+		// matcher that never matches, and the drill-in renders nothing.
+		{"exact name= match", "bp-velero",
+			`level=info name=bp-velero namespace=flux-system msg="reconciliation finished"`, true},
+		{"exact path match", "bp-velero",
+			`level=info msg="applied" path=/flux-system/bp-velero`, true},
+		{"quoted name form", "bp-velero",
+			`level=info name="bp-velero" namespace="flux-system"`, true},
+		{"json name form", "bp-velero",
+			`{"level":"info","name":"bp-velero","namespace":"flux-system"}`, true},
+		{"name= followed by a space", "bp-cnpg",
+			`level=info name=bp-cnpg msg="ok"`, true},
+
+		// A quoted marker is delimited on both sides, so a longer sibling
+		// cannot produce a false positive through it.
+		{"quoted form is not fooled by a sibling", "bp-velero",
+			`level=info name="bp-velero-hcs" namespace="flux-system"`, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := logLineMentionsName(tc.line, tc.query); got != tc.want {
+				t.Errorf("logLineMentionsName(%q) = %v want %v\n  line: %s",
+					tc.query, got, tc.want, tc.line)
+			}
+		})
+	}
+}
+
+// The namespaced primary check has the same boundary requirement.
+func TestLogLineMentionsToken_NamespacedFormRespectsBoundary(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		token string
+		line  string
+		want  bool
+	}{
+		{"sibling must not match", "flux-system/bp-velero",
+			`level=info msg="reconciled" object=flux-system/bp-velero-hcs`, false},
+		{"exact must match", "flux-system/bp-velero",
+			`level=info msg="reconciled" object=flux-system/bp-velero`, true},
+		{"exact at end of line", "flux-system/bp-cnpg",
+			`level=info object=flux-system/bp-cnpg`, true},
+		{"a later exact occurrence still matches", "flux-system/bp-cnpg",
+			`msg="saw flux-system/bp-cnpg-pair then flux-system/bp-cnpg"`, true},
+		{"empty token never matches", "",
+			`level=info name=anything`, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := logLineMentionsToken(tc.line, tc.token); got != tc.want {
+				t.Errorf("logLineMentionsToken(%q) = %v want %v\n  line: %s",
+					tc.token, got, tc.want, tc.line)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/handler/reconcilers.go
@@ -360,7 +360,7 @@ func tailControllerLogsForObject(ctx context.Context, core kubernetes.Interface,
 		// namespace=). The namespaced form is the precise match; the bare
 		// name is a fallback that still scopes to this object on a normal
 		// Sovereign (object names are unique within flux-system).
-		if !strings.Contains(line, nsName) && !logLineMentionsName(line, name) {
+		if !logLineMentionsToken(line, nsName) && !logLineMentionsName(line, name) {
 			continue
 		}
 		n++
@@ -376,18 +376,66 @@ func tailControllerLogsForObject(ctx context.Context, core kubernetes.Interface,
 	return clampLogTail(out, tail), nil
 }
 
+// nameCharByte reports whether b can appear INSIDE a Kubernetes object name
+// (RFC 1123: lowercase alphanumerics, '-', '.'). Used to decide whether a
+// substring match ended at a real boundary or in the middle of a longer name.
+func nameCharByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') || b == '-' || b == '.' || b == '_'
+}
+
+// logLineMentionsToken reports whether `line` contains `token` as a WHOLE
+// token — i.e. the character immediately after the match is not another
+// name character.
+//
+// #5485: the previous code used a bare strings.Contains for the namespaced
+// form, so `flux-system/bp-velero` matched inside
+// `flux-system/bp-velero-hcs` and the bp-velero drill-in rendered 100%
+// bp-velero-hcs log lines with nothing indicating the substitution. Only the
+// LEADING boundary was guarded; the trailing one was open.
+func logLineMentionsToken(line, token string) bool {
+	if token == "" {
+		return false
+	}
+	for i := 0; ; {
+		j := strings.Index(line[i:], token)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(token)
+		if end >= len(line) || !nameCharByte(line[end]) {
+			return true
+		}
+		i = i + j + 1
+	}
+}
+
 // logLineMentionsName reports whether a controller log line references the
 // object by bare name in a name= / "name": field (avoids matching a random
-// substring). Conservative: requires a delimiter before the name so
-// "foo" doesn't match "foobar".
+// substring).
+//
+// #5485: the quoted markers are delimited on BOTH sides and are safe as
+// plain substrings. The unquoted ones (`name=<n>` and `/<n>`) are delimited
+// only on the left, so they need an explicit trailing-boundary check —
+// otherwise `bp-cnpg` matches `bp-cnpg-pair` and `bp-velero` matches
+// `bp-velero-hcs`.
 func logLineMentionsName(line, name string) bool {
+	if name == "" {
+		return false
+	}
 	for _, marker := range []string{
 		`name="` + name + `"`,
-		`name=` + name,
 		`"name":"` + name + `"`,
-		`/` + name,
 	} {
 		if strings.Contains(line, marker) {
+			return true
+		}
+	}
+	for _, marker := range []string{
+		`name=` + name,
+		`/` + name,
+	} {
+		if logLineMentionsToken(line, marker) {
 			return true
 		}
 	}


### PR DESCRIPTION
## The defect

The reconciler drill-in rendered **another object's logs**, with nothing indicating the substitution.

```
GET .../reconcilers/bp-velero/logs   ->  total=1, payload name "bp-velero-hcs"   (100% wrong object)
GET .../reconcilers/bp-cnpg/logs     ->  bp-cnpg lines MIXED with bp-cnpg-pair
```

Three matchers guarded only the **leading** boundary:

- `` `name=` + name `` matches inside `name=bp-velero-hcs`
- `` `/` + name `` matches inside `/flux-system/bp-velero-hcs`
- the primary check was a bare `strings.Contains(line, nsName)`, so `flux-system/bp-velero` matched `flux-system/bp-velero-hcs`

The old function's own doc comment claimed it prevented exactly this — *"requires a delimiter before the name so 'foo' doesn't match 'foobar'"*. It guarded the prefix side and left the suffix side open, which is the half that mattered here.

## The fix

The two **quoted** markers (`name="<n>"`, `"name":"<n>"`) are delimited on both sides and stay plain substring checks. The unquoted markers and the namespaced check now go through `logLineMentionsToken`, which requires the character immediately after a match not to be a name character (RFC 1123 plus underscore).

## Tests — both directions

Nine cases in the matcher test, five in the token test. Restoring the bare `Contains` produces **three failures**, and the must-still-match cases are the control: without them, a matcher that returned `false` for everything would pass just as well.

One case worth naming: `"a later exact occurrence still matches"` — a line mentioning `bp-cnpg-pair` *and* `bp-cnpg` must match `bp-cnpg`, so the scan continues past a boundary rejection rather than returning early.

## Why this ranked first of the six in #5485

An operator debugging a suspended `bp-velero` was shown a different chart's log lines. That is worse than empty output, because it looks like data — the panel renders, the lines are real, and nothing says they belong to another object. Same family as the other findings in that issue: a display layer inheriting from the wrong object.

Full `internal/handler` package green (166s).

Refs #5485
