### PR TITLE
fix(console): stop asserting a vCluster and an Environment that do not exist (#5489)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -60,7 +60,12 @@ export interface OrgRow {
   kind: OrgKind
   tier: OrgTier
   billingMode: OrgBillingMode
-  isolation: OrgIsolation
+  /** A real Organization is namespace- or vcluster-isolated. The
+   *  sovereign-root row is the CLUSTER itself — isolated within nothing —
+   *  so it carries 'cluster'. #5489: it previously claimed 'vcluster', a
+   *  hardcoded literal with no backing object; on hw291 the directory
+   *  advertised a vCluster while `kubectl get vclusters -A` returned none. */
+  isolation: OrgIsolation | 'cluster'
   status: OrgStatus
   /** True for the sovereign-root row (parentOrg empty). The Enter-org
    *  button is hidden on this row (#3378 §5: "you are already inside it"). */
@@ -139,7 +144,12 @@ export function parentRowFromSelf(self: SovereignSelf | null): OrgRow {
     kind: 'internal',
     tier: 'corporate',
     billingMode: 'showback',
-    isolation: 'vcluster',
+    // #5489 — the sovereign root IS the cluster; it is not isolated inside
+    // one. `GET /api/v1/sovereign/self` returns only {deploymentId,
+    // sovereignFQDN}, so there is no field to derive a namespace/vcluster
+    // answer from, and inventing 'vcluster' made the directory claim an
+    // object that does not exist.
+    isolation: 'cluster',
     status: 'active',
     isParent: true,
     ownerEmail: '',

--- a/products/catalyst/bootstrap/ui/src/lib/parent-row-isolation-5489.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/parent-row-isolation-5489.test.ts
@@ -1,0 +1,47 @@
+// Tests for #5489 — the Organizations directory asserted a vCluster that
+// does not exist.
+//
+// On hw291 the parent row rendered `isolation: vcluster` while
+// `kubectl get vclusters.vcluster.com -A` returned *No resources found*,
+// `vcluster-system` was empty, and the topology API reported vclusters=0 in
+// both regions. It was not a mislabelled API field: `GET /api/v1/sovereign/
+// self` returns only {deploymentId, sovereignFQDN}, so there was no value to
+// derive from — the literal was invented in the client.
+//
+// The sovereign root IS the cluster; it is not isolated inside one.
+//
+// Anti-theater: the first assertion is the one that fails against the pre-fix
+// code. The rest are the control — a fix that returned undefined, or dropped
+// the row, would satisfy "not vcluster" while breaking the directory, so the
+// shape is pinned too.
+
+import { describe, it, expect } from 'vitest'
+import { parentRowFromSelf } from './organizations.api'
+
+describe('#5489 parent row must not claim a vCluster', () => {
+  const self = { deploymentId: '2c2d746b578c636b', sovereignFQDN: 'hw291.omantel.biz' }
+
+  it('does not assert vcluster isolation for the sovereign root', () => {
+    expect(parentRowFromSelf(self).isolation).not.toBe('vcluster')
+  })
+
+  it('reports the sovereign root as the cluster itself', () => {
+    expect(parentRowFromSelf(self).isolation).toBe('cluster')
+  })
+
+  it('still renders a usable parent row', () => {
+    const row = parentRowFromSelf(self)
+    expect(row.isParent).toBe(true)
+    expect(row.slug).toBe('hw291.omantel.biz')
+    expect(row.displayName).toBe('hw291.omantel.biz')
+    expect(row.id).toBe('2c2d746b578c636b')
+    expect(row.consoleHost).toBe('console.hw291.omantel.biz')
+  })
+
+  it('degrades safely when self-discovery has not resolved', () => {
+    const row = parentRowFromSelf(null)
+    expect(row.isolation).toBe('cluster')
+    expect(row.id).toBe('__parent__')
+    expect(row.slug).toBe('sovereign')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -279,11 +279,17 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
   const externalURLById = liveAppsQuery.data?.externalURLById ?? {}
   const liveInstances = liveAppsQuery.data?.instances ?? []
   const refetchLive = liveAppsQuery.refetch
-  // DEFAULT_APP_ENVIRONMENT mirrors the BE's defaultSovereignEnvironment
+  // UNRESOLVED_APP_ENVIRONMENT is the honest stand-in when no Environment
   // so even when the live API hasn't responded yet (cold load) every
   // card still renders an environment chip — the matrix's TC-090
   // contract is invariant to fetch state. Closes qa-loop iter-7 TC-090.
-  const DEFAULT_APP_ENVIRONMENT = 'dev'
+  // #5489 — this was 'dev', a name no Environment on any Sovereign carries.
+  // On hw291 it painted 42 of 50 cards with a membership that does not exist
+  // (both Environment CRs are envType: prod), so the chip could not
+  // distinguish a resolved binding from an absent one. TC-090's contract is
+  // that a chip RENDERS, not that it names a real Environment when none
+  // resolved — an explicit unresolved marker satisfies that honestly.
+  const UNRESOLVED_APP_ENVIRONMENT = 'unassigned'
 
   const isFailed = streamStatus === 'failed' || streamStatus === 'unreachable'
   const failureMessage = streamError ?? snapshot?.error ?? null
@@ -798,7 +804,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             const published = Object.prototype.hasOwnProperty.call(publishedBySlug, slug)
               ? publishedBySlug[slug]
               : null
-            const environment = environmentById[app.id] ?? DEFAULT_APP_ENVIRONMENT
+            const environment = environmentById[app.id] ?? UNRESOLVED_APP_ENVIRONMENT
             const externalURL = externalURLById[app.id] ?? ''
             return (
               <AppCard


### PR DESCRIPTION
Two client-side literals were painting objects the platform never authored. Both are **operator-visible in the browser**, which is what separates them from the latent half of #5489.

## 1. The Organizations directory claimed a vCluster

The sovereign parent row rendered `isolation: vcluster` while, on the same env:

```
kubectl get vclusters.vcluster.com -A   ->  No resources found
vcluster-system                          ->  empty
topology API                             ->  vclusters = 0   (both regions)
```

This was **not** a mislabelled API field. `GET /api/v1/sovereign/self` returns only `{deploymentId, sovereignFQDN}` — there is no isolation value to derive from, so the literal was invented in the client at `organizations.api.ts`. It rendered identically on the parent **detail** page.

The sovereign root **is** the cluster; it is not isolated inside one. It now carries `'cluster'`, which both render sites print unchanged since they emit the raw string.

**`OrgIsolation` stays a two-value union.** A real Organization is only ever namespace- or vcluster-isolated, and `CreateOrganizationPage` passes that type straight into a two-value API parameter — only the *row* field widens. Worth recording: my first attempt widened the union itself and `tsc` immediately failed on that call site. The typechecker caught the wrong shape before any test did.

## 2. The apps grid claimed an Environment

The environment chip fell back to `'dev'` — a name **no Environment on any Sovereign carries**. On hw291 that painted **42 of 50 cards** with a membership that does not exist, since both Environment CRs are `envType: prod`. The chip therefore could not distinguish a resolved binding from an absent one, which is precisely what it exists to show.

It now reads `'unassigned'`. TC-090's contract is that a chip **renders**, not that it names a real Environment when none resolved — and no test asserts the literal; `TC-090` appears only in source comments.

## Tests — both directions

Four cases. Restoring the `vcluster` literal fails **three** of them.

The remaining assertions are the control, and they earn their place: a "fix" that returned `undefined` or dropped the parent row entirely would satisfy *"not vcluster"* while breaking the directory. The row's id, slug, displayName and consoleHost are pinned, plus the null-`self` degradation path.

## Gates

`tsc -b` clean; **34 existing tests green across 7 files** (organizations directory, org detail, apps grid).

## Not in this change

#5489 lists four fake-green surfaces. The two here are the browser-visible ones. The remaining two are server-side — `org_list_from_cr.go:191` synthesizing `vcluster_name` for a namespace-isolated Org, and `organization_controller.go:890/1106` stamping `status.vcluster.phase: Ready` so that `kubectl get organizations -o wide` prints `vCluster: Ready` over an unauthored vCluster. Both stay on the issue checklist.

Refs #5489 #5476
