### PR TITLE
fix(bp-valkey): scope NetworkPolicy ingress to the declared consumers (Refs #5487)

### DIFF
--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -80,7 +80,15 @@ spec:
       # Harbor proxy-cache (bitnamilegacy, pinned) — bare dockerhub
       # `bitnami/valkey:latest` 404'd the node mirror → ImagePullBackOff →
       # bp-newapi Redis-ping CrashLoop (UAT 37/38/114).
-      version: 1.1.4
+      # 1.1.5 (#5487, hw291 2026-07-29): SECURITY — the rendered
+      # NetworkPolicy carried an ingress rule with NO `from:` (upstream
+      # `networkPolicy.allowExternal` defaults true), which admits every Pod
+      # in the cluster on 6379. With auth off (1.0.2) any container foothold
+      # anywhere could FLUSHALL the gateway's rate-limit counters. Ingress is
+      # now scoped to the declared consumers — ns `org-services` and ns
+      # `newapi`, the same pair bp-plane-isolation (slot 26b) already
+      # declares for this namespace.
+      version: 1.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-valkey

--- a/core/services/shared/db/valkey.go
+++ b/core/services/shared/db/valkey.go
@@ -19,16 +19,27 @@ func ConnectValkey(addr string) (valkey.Client, error) {
 //
 // Why this overload exists (issue #863):
 //
-//	bp-valkey (Catalyst Blueprint slot 17, bitnami valkey 5.5.1) defaults
-//	to `auth.enabled=true` and exposes the auto-generated password via the
-//	`valkey-password` key in the `valkey` Secret. Sovereign-side Organization
-//	services consume Valkey cross-namespace from `org-services` ns; the catalyst
-//	chart mirrors the password into `org-valkey-auth` Secret in `org-services` ns
+//	bp-valkey (Catalyst Blueprint slot 17, bitnami valkey 5.5.1) exposes an
+//	auto-generated password via the `valkey-password` key in the `valkey`
+//	Secret WHEN auth is enabled. Sovereign-side Organization services consume
+//	Valkey cross-namespace from `org-services` ns; the catalyst chart mirrors
+//	the password into the `org-valkey-auth` Secret in `org-services` ns
 //	(see products/catalyst/chart/templates/org-services/
 //	valkey-cross-ns-secret.yaml) and the auth + gateway Deployments wire
 //	it into VALKEY_USERNAME / VALKEY_PASSWORD env. Without these, NEWHELLO
 //	is rejected with "NOAUTH HELLO must be called with the client already
 //	authenticated".
+//
+//	NOT the default posture (#5487): bp-valkey flipped to
+//	`auth.enabled: false` in 1.0.2 (TBD-V12 #2003) to match bp-newapi's
+//	passwordless REDIS_CONN_STRING, so on a stock Sovereign no `valkey`
+//	Secret exists, no `org-valkey-auth` mirror is produced, and the callers
+//	below take the no-auth ConnectValkey path with an empty password. Both
+//	the mirror and the VALKEY_PASSWORD env now render only when the operator
+//	sets `orgServices.valkey.auth.enabled: true` alongside bp-valkey's own
+//	`valkey.auth.enabled: true`. Until then the isolation is carried by the
+//	network: bp-valkey 1.1.5 scopes its NetworkPolicy ingress to the
+//	`org-services` + `newapi` namespaces (#5487).
 //
 // Username may be empty — bitnami's auth scheme uses the implicit
 // `default` ACL user with the password set via `requirepass`, so passing

--- a/platform/valkey/README.md
+++ b/platform/valkey/README.md
@@ -152,6 +152,37 @@ spec:
 
 ---
 
+## Network posture (who may reach 6379)
+
+Since chart **1.1.5** (#5487) the rendered NetworkPolicy scopes ingress to the
+declared consumers instead of admitting the whole cluster:
+
+| Source | Admitted on 6379 | Why |
+|--------|------------------|-----|
+| ns `org-services` | yes | the `auth` + `gateway` Deployments read `VALKEY_ADDR` |
+| ns `newapi` | yes | `REDIS_CONN_STRING` + the slot-17 `keyspaces[]` Context |
+| Pods in ns `valkey` labelled `valkey-client: "true"` | yes | upstream client-label seam |
+| valkey's own Pods | yes | primary ↔ replica replication |
+| everything else | no | — |
+
+The lever is `valkey.networkPolicy.allowExternal: false`. Leaving it at the
+upstream default (`true`) renders an ingress rule with **no `from:`**, which in
+Kubernetes admits every Pod in the cluster and — because policies are unioned —
+also cancels bp-plane-isolation's `valkey-default-deny`. `tests/networkpolicy-ingress-scope.sh`
+fails the build if that regresses.
+
+Password auth remains **off** by default (TBD-V12 #2003): bp-newapi's default
+connection string is passwordless, so isolation is carried by the network
+policy above. An operator enabling `valkey.auth.enabled: true` must also set
+`orgServices.valkey.auth.enabled: true` on bp-catalyst-platform so the auth +
+gateway Deployments consume the mirrored password (#5487).
+
+Adding a consumer means editing **both** `valkey.networkPolicy.extraIngress`
+here and the `valkey` component's `allowIngressFrom` list in
+`platform/plane-isolation/chart/values.yaml`.
+
+---
+
 ## Use Cases
 
 | Use Case | TTL | Eviction | DR Needed |

--- a/platform/valkey/blueprint.yaml
+++ b/platform/valkey/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.1.4
+  version: 1.1.5
   card:
     title: Valkey
     summary: |

--- a/platform/valkey/chart/Chart.yaml
+++ b/platform/valkey/chart/Chart.yaml
@@ -53,7 +53,28 @@ name: bp-valkey
 # `harbor.openova.io/proxy-dockerhub/bitnamilegacy/…` + set
 # global.security.allowInsecureImages:true (bitnami/charts#30850 render
 # guard) — the proven bp-keycloak/bp-cnpg pattern. Chart-only.
-version: 1.1.4
+# 1.1.5 (#5487, hw291 2026-07-29): SECURITY — the NetworkPolicy admitted the
+# ENTIRE cluster on 6379. `networkPolicy.enabled: true` was restated in
+# values.yaml as "the Catalyst posture is default-deny", but the upstream
+# bitnami template keys the ingress `from:` off a SECOND value,
+# `networkPolicy.allowExternal`, which defaults TRUE — so the rendered rule
+# was `ingress: [{ports: [6379]}]` with no `from:`, and a k8s ingress rule
+# with no `from:` admits every Pod in the cluster. Combined with
+# `auth.enabled: false` (1.0.2 above — no requirepass) any container
+# foothold in any namespace could run arbitrary commands against the shared
+# cache holding the gateway's rate-limit counters (#5484) and the
+# newapi-keyspace-credential Context data; `PING` → `+PONG` from an
+# unrelated `grafana` Pod was the live proof. It also silently defeated
+# bp-plane-isolation's `valkey-default-deny` (slot 26b), since k8s/Cilium
+# take the UNION of every policy selecting a Pod. Fix: `allowExternal:
+# false` (the only lever that emits a `from:`) + an `extraIngress` rule
+# naming the two declared consumers — ns `org-services` (the auth + gateway
+# Deployments that read VALKEY_ADDR) and ns `newapi` (its
+# REDIS_CONN_STRING + the slot-17 keyspace Context). Auth stays OFF; this is
+# the network half of the isolation #2003 assumed was already in place.
+# Locked by tests/networkpolicy-ingress-scope.sh (vacuity check + two
+# negative controls). Chart-only — no image or subchart change.
+version: 1.1.5
 description: |
   Catalyst-curated Blueprint umbrella chart for Valkey (Redis-compatible
   cache, BSD-3). Depends on the upstream `valkey` chart (Bitnami) as a

--- a/platform/valkey/chart/tests/networkpolicy-ingress-scope.sh
+++ b/platform/valkey/chart/tests/networkpolicy-ingress-scope.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# bp-valkey NetworkPolicy ingress-scope gate (#5487).
+#
+# THE DEFECT THIS LOCKS OUT (verified live on hw291, 2026-07-29):
+#   The upstream bitnami template keys the ingress `from:` off
+#   `networkPolicy.allowExternal`, which defaults to TRUE. With it true the
+#   rendered rule is `ingress: [{ports: [6379]}]` — NO `from:` — and a
+#   Kubernetes ingress rule with no `from:` admits EVERY Pod in the cluster.
+#   With `auth.enabled: false` (TBD-V12 #2003) that meant any container
+#   foothold anywhere could run arbitrary commands against the shared cache
+#   holding the gateway's rate-limit counters. `PING` → `+PONG` from an
+#   unrelated `grafana` Pod was the live proof.
+#
+# WHAT THIS GATE ASSERTS
+#   Case 1 (VACUITY): the default render actually emits a NetworkPolicy that
+#           selects the valkey Pods. A `grep -q` for an absent string passes
+#           trivially against an empty render, so every later assertion is
+#           worthless unless this one holds first.
+#   Case 2: EVERY ingress rule in that policy carries a non-empty `from:`,
+#           and no `from:` peer is an empty/match-everything selector.
+#   Case 3: the declared consumers (org-services + newapi) are admitted on
+#           6379 — the fix must not close the hole by breaking the product.
+#   Case 4 (NEGATIVE CONTROL): re-render with `allowExternal=true` and assert
+#           the Case-2 detector FIRES. Without this the detector could be
+#           silently inert and Cases 1-3 would still report green.
+#   Case 5 (NEGATIVE CONTROL): re-render with `extraIngress` emptied and
+#           assert the Case-3 detector FIRES.
+#
+# Usage: bash tests/networkpolicy-ingress-scope.sh [CHART_DIR]
+# CI consumes this via blueprint-release.yaml's `tests/*.sh` gate.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Same dep handling as contexts-render.sh / observability-toggle.sh.
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ── The checker ───────────────────────────────────────────────────────────
+# Reads a rendered manifest stream, isolates the valkey NetworkPolicy, and
+# runs one named check. Exits 0 = check satisfied, 1 = violated, 2 = the
+# render carried no NetworkPolicy at all (vacuous input — never "satisfied").
+check() {
+  local mode="$1" file="$2"
+  python3 - "$mode" "$file" <<'PY'
+import sys, yaml
+
+mode, path = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    docs = [d for d in yaml.safe_load_all(fh) if d]
+
+pols = [d for d in docs
+        if d.get("kind") == "NetworkPolicy"
+        and (d.get("spec", {}).get("podSelector", {}).get("matchLabels", {})
+             .get("app.kubernetes.io/name") == "valkey")]
+
+# VACUITY — an empty/NetworkPolicy-less render makes every other assertion
+# below trivially true. Treat it as a hard, distinct failure.
+if not pols:
+    kinds = sorted({d.get("kind", "?") for d in docs})
+    print("VACUOUS RENDER: no NetworkPolicy selecting app.kubernetes.io/name=valkey "
+          f"in {len(docs)} rendered doc(s) (kinds: {', '.join(kinds) or 'none'}). "
+          "Every ingress assertion in this gate would pass trivially.", file=sys.stderr)
+    sys.exit(2)
+
+# An "open" peer: a rule with no `from:` at all admits every Pod in the
+# cluster; a `from:` peer that is an empty namespaceSelector/podSelector does
+# the same thing one level down.
+def open_peers(rule):
+    peers = rule.get("from")
+    if not peers:
+        return ["<no from: — admits ALL Pods in the cluster>"]
+    bad = []
+    for p in peers:
+        if not p:
+            bad.append("<empty peer>")
+        for key in ("namespaceSelector", "podSelector"):
+            if key in p and not p[key]:
+                bad.append(f"<empty {key}: matches everything>")
+    return bad
+
+def ns_values(pol):
+    """Namespaces admitted by a namespaceSelector on a 6379 rule."""
+    out = set()
+    for rule in pol.get("spec", {}).get("ingress", []) or []:
+        ports = {str(p.get("port")) for p in (rule.get("ports") or [])}
+        if ports and "6379" not in ports:
+            continue
+        for peer in rule.get("from") or []:
+            sel = peer.get("namespaceSelector") or {}
+            for k, v in (sel.get("matchLabels") or {}).items():
+                if k == "kubernetes.io/metadata.name":
+                    out.add(v)
+            for expr in sel.get("matchExpressions") or []:
+                if expr.get("key") == "kubernetes.io/metadata.name" and \
+                   expr.get("operator") == "In":
+                    out.update(expr.get("values") or [])
+    return out
+
+rc = 0
+for pol in pols:
+    name = pol.get("metadata", {}).get("name", "?")
+
+    if mode == "vacuity":
+        rules = pol.get("spec", {}).get("ingress", []) or []
+        if not rules:
+            print(f"NetworkPolicy/{name} renders with an EMPTY ingress list — "
+                  "nothing for this gate to assert against.", file=sys.stderr)
+            rc = 1
+        else:
+            print(f"ok: NetworkPolicy/{name} renders with {len(rules)} ingress rule(s)")
+
+    elif mode == "scoped":
+        for i, rule in enumerate(pol.get("spec", {}).get("ingress", []) or []):
+            bad = open_peers(rule)
+            if bad:
+                print(f"NetworkPolicy/{name} ingress[{i}] is OPEN TO THE CLUSTER: "
+                      f"{'; '.join(bad)}  (#5487 — set "
+                      "valkey.networkPolicy.allowExternal=false)", file=sys.stderr)
+                rc = 1
+
+    elif mode == "consumers":
+        want = {"org-services", "newapi"}
+        got = ns_values(pol)
+        missing = want - got
+        if missing:
+            print(f"NetworkPolicy/{name} does not admit the declared Valkey "
+                  f"consumer namespace(s) {sorted(missing)} on 6379 "
+                  f"(admitted: {sorted(got) or 'none'}) — the fix must not close "
+                  "the hole by breaking org-services/newapi.", file=sys.stderr)
+            rc = 1
+
+    else:
+        print(f"unknown check mode {mode!r}", file=sys.stderr)
+        sys.exit(2)
+
+sys.exit(rc)
+PY
+}
+
+echo "[netpol] rendering default values"
+helm template valkey . --namespace valkey > "$TMP/default.yaml" 2> "$TMP/default.err" || {
+  cat "$TMP/default.err" >&2; fail "default render errored"; }
+
+echo "[netpol] Case 1: VACUITY — the NetworkPolicy actually renders"
+check vacuity "$TMP/default.yaml" \
+  || fail "default render carries no usable valkey NetworkPolicy (see above) — every assertion below would be vacuous"
+
+echo "[netpol] Case 2: every ingress rule carries a real from: selector"
+check scoped "$TMP/default.yaml" \
+  || fail "#5487 REGRESSION — the valkey NetworkPolicy admits the whole cluster on 6379"
+
+echo "[netpol] Case 3: the declared consumers are still admitted"
+check consumers "$TMP/default.yaml" \
+  || fail "the ingress allow-list no longer names the declared Valkey consumers"
+
+echo "[netpol] Case 4: NEGATIVE CONTROL — allowExternal=true must trip Case 2"
+helm template valkey . --namespace valkey \
+  --set valkey.networkPolicy.allowExternal=true > "$TMP/open.yaml" 2> "$TMP/open.err" || {
+  cat "$TMP/open.err" >&2; fail "negative-control render errored"; }
+if check scoped "$TMP/open.yaml" > "$TMP/open.out" 2>&1; then
+  cat "$TMP/open.out" >&2
+  fail "the Case-2 detector did NOT fire against a deliberately allow-all render — this gate is inert and would never catch the #5487 revert"
+fi
+echo "[netpol]   detector fired as expected: $(head -1 "$TMP/open.out")"
+
+echo "[netpol] Case 5: NEGATIVE CONTROL — empty extraIngress must trip Case 3"
+helm template valkey . --namespace valkey \
+  --set-json 'valkey.networkPolicy.extraIngress=[]' > "$TMP/noconsumers.yaml" 2> "$TMP/nc.err" || {
+  cat "$TMP/nc.err" >&2; fail "negative-control render errored"; }
+if check consumers "$TMP/noconsumers.yaml" > "$TMP/nc.out" 2>&1; then
+  cat "$TMP/nc.out" >&2
+  fail "the Case-3 detector did NOT fire against a render with no consumer allow-list — this gate is inert"
+fi
+echo "[netpol]   detector fired as expected: $(head -1 "$TMP/nc.out")"
+
+echo "[netpol] PASS — ingress is scoped to the declared consumers, and both detectors are live"

--- a/platform/valkey/chart/values.yaml
+++ b/platform/valkey/chart/values.yaml
@@ -142,11 +142,98 @@ valkey:
   auth:
     enabled: false
 
-  # NetworkPolicy from upstream chart — already enabled by default;
-  # restate to make the Catalyst posture explicit. (Default-deny is
-  # appropriate for a cache that should only be consumed in-cluster.)
+  # ── NetworkPolicy — ingress scoped to the DECLARED consumers (#5487) ────
+  #
+  # ROOT CAUSE (#5487, caught LIVE on hw291 2026-07-29):
+  #   `networkPolicy.enabled: true` was restated here as "the Catalyst
+  #   posture is default-deny", but the upstream bitnami template keys the
+  #   ingress `from:` off a SECOND value — `networkPolicy.allowExternal`,
+  #   which defaults to TRUE. With allowExternal true the rendered rule is
+  #
+  #       ingress:
+  #         - ports: [{port: 6379}]        ← NO `from:` at all
+  #
+  #   and a Kubernetes ingress rule with no `from:` admits EVERY Pod in the
+  #   cluster. Combined with `auth.enabled: false` below (TBD-V12 #2003 —
+  #   no `requirepass`), any container foothold in any namespace could
+  #   `redis-cli -h valkey-primary.valkey.svc` and run arbitrary commands.
+  #   Verified live: `PING` → `+PONG` from an unrelated `grafana` Pod.
+  #   Blast radius is not theoretical — this Valkey holds the gateway's
+  #   rate-limit counters (a `FLUSHALL` disables the redeem limiter, #5484)
+  #   and the `newapi-keyspace-credential` Context data below.
+  #
+  #   It ALSO silently defeated bp-plane-isolation (slot 26b), which already
+  #   ships a `valkey-default-deny` NetworkPolicy admitting ONLY
+  #   org-services + newapi: Kubernetes (and Cilium) take the UNION of every
+  #   policy selecting a Pod, so one allow-all rule re-opened the whole
+  #   namespace no matter how tight the sibling policy was.
+  #
+  # THE FIX — `allowExternal: false` is the only lever that emits a `from:`.
+  #   It narrows the upstream rule to Pods IN THE RELEASE NAMESPACE carrying
+  #   `valkey-client: "true"` plus valkey's own Pods (primary↔replica
+  #   replication). `extraIngress` then names the real cross-namespace
+  #   consumers. Auth stays OFF (see `auth` above) — this is the network
+  #   half of the isolation that #2003 assumed was already there.
+  #
+  # THE CONSUMER SET (derived from the repo, not from guesswork; two
+  # independent in-repo declarations agree):
+  #   - `org-services` — the BSS control plane. `VALKEY_ADDR` is stamped
+  #     into the org-services ConfigMap (products/catalyst/chart/templates/
+  #     org-services/configmap.yaml) and consumed by the `auth` + `gateway`
+  #     Deployments, both of which live in ns `org-services`.
+  #   - `newapi`       — `valkey.url: redis://valkey-primary.valkey.svc…`
+  #     (platform/newapi/chart/values.yaml); also the declared consumer of
+  #     the `keyspaces[]` Context seeded by slot 17 (reflect.namespaces).
+  #   Corroborated by platform/plane-isolation/chart/values.yaml, whose
+  #   `namespace: valkey` component lists exactly
+  #   `allowIngressFrom: [org-services, newapi]`.
+  #
+  # NOT included, deliberately (parity with bp-plane-isolation's list):
+  #   - `catalyst-system` — the catalyst-projector dials Valkey but ships
+  #     DEFAULT-OFF (`services.projector.enabled: false`). An operator who
+  #     flips it on adds `catalyst-system` to BOTH lists.
+  #   - `matrix` — `externalRedis.enabled: false` by default, same rule.
+  #
+  # MULTI-REGION: bp-valkey is a per-region install (slot 17 renders in
+  # every region's own cluster) and its Services are NOT Cilium global
+  # services (`service.cilium.io/global` is absent), so every consumer
+  # dials its own region's `valkey-primary` ClusterIP and this policy is
+  # correct on BOTH regions unchanged. Cilium AND-injects
+  # `io.cilium.k8s.policy.cluster=<local>` into every selector derived from
+  # a k8s NetworkPolicy, so a genuine cross-region dial (were Valkey ever
+  # promoted to a global Service) would need an identity-based
+  # CiliumNetworkPolicy carve-out — the proven #5406 shape in
+  # platform/harbor/chart/templates/redis-crossregion-netpol.yaml. Adding
+  # peers here would NOT work and must not be attempted with this key.
+  #
+  # Per Inviolable Principle #4 every element stays operator-overridable —
+  # but note `extraIngress` is a LIST: an overlay that sets it REPLACES this
+  # rule wholesale, so an overlay adding a consumer must restate these two
+  # namespaces alongside its own.
   networkPolicy:
     enabled: true
+    # false ⇒ the upstream ingress rule renders a real `from:` selector.
+    # NEVER flip this back to true — that is the #5487 defect verbatim.
+    allowExternal: false
+    extraIngress:
+      # Port MUST track `primary.containerPorts.valkey` (upstream default
+      # 6379, restated in `contextsService.port` below).
+      - ports:
+          - port: 6379
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchExpressions:
+                - key: kubernetes.io/metadata.name
+                  operator: In
+                  values:
+                    - org-services
+                    - newapi
+    # Metrics stays at the upstream default (`metrics.allowExternal: true`)
+    # because `metrics.enabled` is false below — no metrics rule renders at
+    # all. An operator enabling the exporter must scope that port to the
+    # scraper's namespace in the same breath; leaving a guessed scraper
+    # namespace here would silently break scraping instead.
 
   # Prometheus exporter sidecar + ServiceMonitor — DEFAULT OFF.
   #

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3015,7 +3015,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.1.4"
+  version: "1.1.5"
   visibility: unlisted
   # Shareability + Contexts (#3370 generality proof) — seeded verbatim
   # from platform/valkey/blueprint.yaml (lockstep-guarded). One instance
@@ -3058,7 +3058,7 @@ docs/SRE.md §2.5).
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-valkey
-    version: "1.1.4"
+    version: "1.1.5"
   topology:
     supported:
     - active-passive

--- a/products/catalyst/chart/templates/org-services/auth.yaml
+++ b/products/catalyst/chart/templates/org-services/auth.yaml
@@ -72,20 +72,30 @@ spec:
                 configMapKeyRef:
                   name: org-services-config
                   key: VALKEY_ADDR
-            # bp-valkey ships auth.enabled=true (bitnami default); the
-            # `default` ACL user uses requirepass, so VALKEY_USERNAME stays
-            # empty and VALKEY_PASSWORD reads from the cross-ns mirror
-            # Secret rendered by templates/org-services/valkey-cross-ns-
-            # secret.yaml. Issue #863. optional=true so contabo-mkt's
-            # auth-less in-namespace Valkey (data/valkey.yaml) works
-            # unchanged — empty VALKEY_PASSWORD triggers the no-auth
-            # connect path in core/services/shared/db/valkey.go.
+            {{- /* #5487 — VALKEY_PASSWORD is rendered ONLY when the operator
+                 has declared that Valkey wants a password. bp-valkey ships
+                 `auth.enabled: false` since 1.0.2 (TBD-V12 #2003), so bitnami
+                 creates no `valkey` Secret, the lookup in
+                 valkey-cross-ns-secret.yaml finds nothing, and
+                 `org-valkey-auth` never exists — verified live on hw291. The
+                 previous unconditional `optional: true` ref therefore READ as
+                 authenticated while RESOLVING to anonymous on every Sovereign.
+                 Default (auth off) now emits no env at all: the manifest says
+                 exactly what the connection does, and
+                 core/services/shared/db/valkey.go takes its no-auth path on the
+                 empty value as before. With auth on, `optional: false` makes a
+                 missing mirror a LOUD CreateContainerConfigError (kubelet
+                 retries until the mirror lands) rather than a silent
+                 anonymous connect. The `default` ACL user uses requirepass, so
+                 VALKEY_USERNAME stays empty either way. Issue #863. */}}
+            {{- if .Values.orgServices.valkey.auth.enabled }}
             - name: VALKEY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: org-valkey-auth
-                  key: valkey-password
-                  optional: true
+                  name: {{ .Values.orgServices.valkey.destSecretName | default "org-valkey-auth" }}
+                  key: {{ .Values.orgServices.valkey.sourcePasswordKey | default "valkey-password" }}
+                  optional: false
+            {{- end }}
             - name: REDPANDA_BROKERS
               valueFrom:
                 configMapKeyRef:

--- a/products/catalyst/chart/templates/org-services/gateway.yaml
+++ b/products/catalyst/chart/templates/org-services/gateway.yaml
@@ -36,20 +36,30 @@ spec:
                 configMapKeyRef:
                   name: org-services-config
                   key: VALKEY_ADDR
-            # bp-valkey ships auth.enabled=true (bitnami default); the
-            # `default` ACL user uses requirepass, so VALKEY_USERNAME stays
-            # empty and VALKEY_PASSWORD reads from the cross-ns mirror
-            # Secret rendered by templates/org-services/valkey-cross-ns-
-            # secret.yaml. Issue #863. optional=true so contabo-mkt's
-            # auth-less in-namespace Valkey (data/valkey.yaml) works
-            # unchanged — empty VALKEY_PASSWORD triggers the no-auth
-            # connect path in core/services/shared/db/valkey.go.
+            {{- /* #5487 — VALKEY_PASSWORD is rendered ONLY when the operator
+                 has declared that Valkey wants a password. bp-valkey ships
+                 `auth.enabled: false` since 1.0.2 (TBD-V12 #2003), so bitnami
+                 creates no `valkey` Secret, the lookup in
+                 valkey-cross-ns-secret.yaml finds nothing, and
+                 `org-valkey-auth` never exists — verified live on hw291. The
+                 previous unconditional `optional: true` ref therefore READ as
+                 authenticated while RESOLVING to anonymous on every Sovereign.
+                 Default (auth off) now emits no env at all: the manifest says
+                 exactly what the connection does, and
+                 core/services/shared/db/valkey.go takes its no-auth path on the
+                 empty value as before. With auth on, `optional: false` makes a
+                 missing mirror a LOUD CreateContainerConfigError (kubelet
+                 retries until the mirror lands) rather than a silent
+                 anonymous connect. The `default` ACL user uses requirepass, so
+                 VALKEY_USERNAME stays empty either way. Issue #863. */}}
+            {{- if .Values.orgServices.valkey.auth.enabled }}
             - name: VALKEY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: org-valkey-auth
-                  key: valkey-password
-                  optional: true
+                  name: {{ .Values.orgServices.valkey.destSecretName | default "org-valkey-auth" }}
+                  key: {{ .Values.orgServices.valkey.sourcePasswordKey | default "valkey-password" }}
+                  optional: false
+            {{- end }}
             - name: CORS_ORIGIN
               valueFrom:
                 configMapKeyRef:

--- a/products/catalyst/chart/templates/org-services/valkey-cross-ns-secret.yaml
+++ b/products/catalyst/chart/templates/org-services/valkey-cross-ns-secret.yaml
@@ -1,9 +1,20 @@
 {{- /*
 Cross-namespace mirror of bp-valkey's auto-generated auth Secret (issue
-#863).
+#863, gated on orgServices.valkey.auth.enabled since #5487).
+
+DORMANT BY DEFAULT (#5487): bp-valkey has shipped `auth.enabled: false`
+since 1.0.2 (TBD-V12 #2003), so the bitnami subchart creates NO `valkey`
+Secret, the lookup below finds nothing, and this template has rendered
+nothing on every Sovereign since — `org-valkey-auth` does not exist on
+hw291 today. That is correct behaviour, but auth.yaml/gateway.yaml used to
+reference the absent Secret with `optional: true` and connect anonymously
+without saying so. Both sides now key off ONE flag,
+`orgServices.valkey.auth.enabled` (default false), so the rendered manifests
+and the actual wire agree. Flip it only together with
+`valkey.auth.enabled: true` on bp-valkey.
 
 Why this template exists:
-  bp-valkey 1.0.0 (Catalyst Blueprint slot 17) ships with
+  bp-valkey 1.0.0 (Catalyst Blueprint slot 17) shipped with
   `auth.enabled=true` (bitnami valkey 5.5.1 default). The bitnami subchart
   auto-generates a random password on first install and exposes it via
   the `valkey-password` key in the `valkey` Secret in the `valkey`
@@ -51,6 +62,7 @@ Per #4 (never hardcode): source/destination namespace + Secret names
 flow through .Values.orgServices.valkey.* with sensible defaults.
 */}}
 {{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- if .Values.orgServices.valkey.auth.enabled -}}
 {{- $sourceNamespace := .Values.orgServices.valkey.namespace | default "valkey" -}}
 {{- $sourceSecretName := .Values.orgServices.valkey.sourceSecretName | default "valkey" -}}
 {{- $sourcePasswordKey := .Values.orgServices.valkey.sourcePasswordKey | default "valkey-password" -}}
@@ -80,5 +92,6 @@ data:
   # the implicit `default` ACL user, so VALKEY_USERNAME is empty by
   # convention (auth.yaml + gateway.yaml don't set it explicitly).
   valkey-password: {{ index $sourceSecret.data $sourcePasswordKey | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -2053,8 +2053,8 @@ orgServices:
     host: valkey-primary.valkey.svc.cluster.local
     port: 6379
     namespace: valkey
-    # ─── Cross-ns auth Secret mirror (issue #863) ──────────────────────
-    # bp-valkey 1.0.0 ships auth.enabled=true; bitnami auto-generates a
+    # ─── Cross-ns auth Secret mirror (issue #863, re-gated #5487) ──────
+    # bp-valkey 1.0.0 shipped auth.enabled=true; bitnami auto-generates a
     # random password and exposes it via the `valkey` Secret in the
     # `valkey` namespace. The catalyst chart renders templates/
     # org-services/valkey-cross-ns-secret.yaml which uses Helm `lookup`
@@ -2063,6 +2063,45 @@ orgServices:
     # secretKeyRef. Each knob below is operator-overridable in case a
     # Sovereign uses a forked bp-valkey with a different Secret name
     # or key.
+    #
+    # ── auth.enabled — the single truth for "Valkey needs a password" ──
+    #
+    # WHY THIS FLAG EXISTS (#5487, hw291 2026-07-29):
+    #   bp-valkey flipped to `auth.enabled: false` in 1.0.2 (TBD-V12 #2003),
+    #   so bitnami no longer creates the `valkey` Secret at all → the
+    #   `lookup` in valkey-cross-ns-secret.yaml can NEVER find a password →
+    #   `org-valkey-auth` is never created. Confirmed live on hw291:
+    #   `kubectl get secret -A | grep valkey` returns no such Secret. But
+    #   auth.yaml + gateway.yaml still referenced it with
+    #   `optional: true`, so both Deployments rendered a VALKEY_PASSWORD env
+    #   that silently resolved to NOTHING and connected anonymously — and
+    #   their inline comments still asserted "bp-valkey ships
+    #   auth.enabled=true (bitnami default)", which has been false since
+    #   1.0.2. A config that READS as authenticated but RESOLVES to
+    #   anonymous is worse than one that is plainly anonymous: it hides the
+    #   very premise (network isolation carries the risk) that #2003 relied
+    #   on and #5487 found broken.
+    #
+    # SEMANTICS:
+    #   false (DEFAULT, matches bp-valkey's shipped posture) — no mirror
+    #     Secret, no VALKEY_PASSWORD env anywhere. The rendered Deployment
+    #     says exactly what it does: it connects without credentials. The
+    #     no-auth connect path in core/services/shared/db/valkey.go is the
+    #     one that was already being taken.
+    #   true — the operator has ALSO set `valkey.auth.enabled: true` on
+    #     bp-valkey (per-Sovereign overlay). The mirror renders and the env
+    #     is wired with `optional: false`, so a missing/late mirror holds the
+    #     Pod at CreateContainerConfigError (loud, and kubelet retries until
+    #     the mirror lands) instead of silently degrading to an anonymous
+    #     connect that a `NOAUTH` error would only surface at first command.
+    #
+    # Do NOT flip this alone: without `valkey.auth.enabled: true` on
+    # bp-valkey there is no password to mirror. Re-enabling auth platform-
+    # wide additionally requires bp-newapi to consume the generated
+    # password (its REDIS_CONN_STRING default is passwordless) — that is the
+    # #2003 follow-up, unchanged by #5487.
+    auth:
+      enabled: false
     sourceSecretName: valkey
     sourcePasswordKey: valkey-password
     destNamespace: org-services       # #3383: was `sme`


### PR DESCRIPTION
## What was wrong

`kubectl -n valkey get netpol valkey -o json` on hw291 rendered:

```yaml
ingress:
  - ports: [{port: 6379}]        # no `from:` — admits ALL Pods in the cluster
```

A Kubernetes ingress rule with no `from:` admits every Pod in the cluster.
`platform/valkey/chart/values.yaml` restated `networkPolicy.enabled: true` as
"the Catalyst posture is default-deny", but the upstream bitnami template keys
the ingress `from:` off a **second** value — `networkPolicy.allowExternal` —
which defaults to `true`.

Combined with `auth.enabled: false` (TBD-V12 #2003 — no `requirepass`), any
container foothold in any namespace could `redis-cli -h valkey-primary.valkey.svc`
and run arbitrary commands. A walker confirmed `PING` -> `+PONG` from the
unrelated `grafana` namespace.

This is P1, not hardening: this Valkey holds the gateway's rate-limit counters,
so one foothold anywhere could `FLUSHALL` and disable the redeem limiter tracked
in #5484. It also holds the `newapi-keyspace-credential` Context data.

Auth-off is a **deliberate** decision under #2003 (closed, and about a different
symptom — newapi Redis NOAUTH CrashLoop; not reopened here), taken on the premise
that network isolation carries the risk. The NetworkPolicy did not provide that
isolation, so the premise was false.

### It also cancelled the isolation that already existed

`platform/plane-isolation/chart/values.yaml` already declares, for the `valkey`
namespace, `allowIngressFrom: [org-services, newapi]`, and slot 26b renders a
`valkey-default-deny` NetworkPolicy from it. Kubernetes and Cilium evaluate the
**union** of every policy selecting a Pod, so the one allow-all rule re-opened
the namespace no matter how tight the sibling policy was. After this PR the two
policies finally agree.

## The consumer set, and how it was derived

| Namespace | Evidence |
|---|---|
| `org-services` | `VALKEY_ADDR` stamped into the org-services ConfigMap (`products/catalyst/chart/templates/org-services/configmap.yaml`), consumed by the `auth` + `gateway` Deployments — both `namespace: org-services` |
| `newapi` | `valkey.url: redis://valkey-primary.valkey.svc.cluster.local:6379` in `platform/newapi/chart/values.yaml`; also the declared consumer of the slot-17 `keyspaces[]` Context (`reflect.namespaces: [newapi]`) |

Corroborated independently by `platform/plane-isolation/chart/values.yaml`,
whose `valkey` component lists exactly that pair.

Deliberately **not** included, keeping parity with the plane-isolation list:
`catalyst-system` (catalyst-projector dials Valkey but ships
`services.projector.enabled: false`) and `matrix` (`externalRedis.enabled: false`).
An operator flipping either on adds the namespace to both lists; the values
comment says so.

### Both regions

bp-valkey is a per-region install (slot 17 renders in every region's own
cluster) and its Services are **not** Cilium global services
(`service.cilium.io/global` appears nowhere for valkey), so each region's
consumers dial their own region's `valkey-primary` ClusterIP and this policy is
correct on both regions unchanged. Cilium AND-injects
`io.cilium.k8s.policy.cluster=<local>` into every selector derived from a k8s
NetworkPolicy, so if Valkey were ever promoted to a global Service the
cross-region leg would need an identity-based CiliumNetworkPolicy — the proven
#5406 shape in `platform/harbor/chart/templates/redis-crossregion-netpol.yaml`.
The values comment records that peers cannot be expressed through this key.

## The dangling `org-valkey-auth` reference — lever chosen: delete it from the default render

**Evidence.** `products/catalyst/chart/templates/org-services/valkey-cross-ns-secret.yaml`
mints `org-valkey-auth` by Helm `lookup` of the bitnami-generated `valkey` Secret.
With `valkey.auth.enabled: false` the bitnami subchart creates no such Secret, so
the lookup can never resolve and the mirror can never render — which is exactly
why `kubectl get secret -A | grep valkey` finds no `org-valkey-auth` on hw291.
Meanwhile `auth.yaml` + `gateway.yaml` referenced it with `optional: true` under
comments still asserting "bp-valkey ships auth.enabled=true (bitnami default)" —
false since bp-valkey 1.0.2. The config read as authenticated and resolved to
anonymous on every Sovereign.

**Why not "wire it properly".** There is nothing to wire: producing the Secret
requires enabling `requirepass`, and enabling auth without bp-newapi consuming
the generated password is the #2003 regression verbatim (45x newapi CrashLoop on
NOAUTH). That work stays where #2003 left it.

**Why not a bare delete.** Deleting the env outright would also delete the
operator's supported path to run Valkey with auth on (`values.yaml` explicitly
offers `valkey.auth.enabled: true` per-Sovereign).

So both sides now key off one flag, `orgServices.valkey.auth.enabled`
(default `false`):

- **off (default, matches what bp-valkey actually ships)** — no mirror, no
  `VALKEY_PASSWORD` env anywhere. The manifest states exactly what the connection
  does. `core/services/shared/db/valkey.go` takes the same no-auth path it was
  already taking.
- **on** — the env renders with `optional: false`, so a missing or late mirror
  holds the Pod at `CreateContainerConfigError` (kubelet retries until it lands)
  instead of silently degrading to an anonymous connect that only surfaces as a
  `NOAUTH` error at first command.

`requirepass` is **not** enabled by this PR. Enabling it platform-wide still
requires bp-newapi to consume the bp-valkey-generated password first; that
remains the #2003 follow-up.

## Render guard — `platform/valkey/chart/tests/networkpolicy-ingress-scope.sh`

CI picks it up automatically via blueprint-release's `chart/tests/*.sh` gate.

1. **Vacuity** — the default render must actually emit a NetworkPolicy selecting
   the valkey Pods, with a non-empty ingress list. A `grep -q` for an absent
   string passes trivially against an empty render, so every later assertion is
   worthless unless this holds first.
2. Every ingress rule carries a non-empty `from:`, and no peer is an
   empty/match-everything selector.
3. `org-services` + `newapi` are still admitted on 6379 (the fix must not close
   the hole by breaking the product).
4. **Negative control** — re-render with `allowExternal=true`; assertion 2's
   detector must fire.
5. **Negative control** — re-render with `extraIngress` emptied; assertion 3's
   detector must fire.

4 and 5 run on every CI invocation, so the gate cannot go quietly inert.

### Both-directions proof (run surgically: sed one value, render that chart directly)

Fix present:

```
[netpol] Case 1: VACUITY — the NetworkPolicy actually renders
ok: NetworkPolicy/valkey renders with 2 ingress rule(s)
[netpol] Case 2: every ingress rule carries a real from: selector
[netpol] Case 3: the declared consumers are still admitted
[netpol] Case 4: NEGATIVE CONTROL — allowExternal=true must trip Case 2
[netpol]   detector fired as expected: NetworkPolicy/valkey ingress[0] is OPEN TO THE CLUSTER: <no from: — admits ALL Pods in the cluster>
[netpol] Case 5: NEGATIVE CONTROL — empty extraIngress must trip Case 3
[netpol]   detector fired as expected: NetworkPolicy/valkey does not admit the declared Valkey consumer namespace(s) ['newapi', 'org-services'] on 6379 (admitted: none)
[netpol] PASS — ingress is scoped to the declared consumers, and both detectors are live
EXIT=0
```

Fix reverted (`sed -i 's/allowExternal: false/allowExternal: true/'`) — fails at
Case 2, not at some earlier case:

```
[netpol] Case 1: VACUITY — the NetworkPolicy actually renders
ok: NetworkPolicy/valkey renders with 2 ingress rule(s)
[netpol] Case 2: every ingress rule carries a real from: selector
NetworkPolicy/valkey ingress[0] is OPEN TO THE CLUSTER: <no from: — admits ALL Pods in the cluster>  (#5487 — set valkey.networkPolicy.allowExternal=false)
FAIL: #5487 REGRESSION — the valkey NetworkPolicy admits the whole cluster on 6379
EXIT=1
```

NetworkPolicy suppressed entirely (`networkPolicy.enabled: false`) — the shape
where a naive grep guard reports green:

```
--- naive-grep control ---
naive grep: NOT FOUND -> a grep-based guard would report PASS here (vacuous)
kind: NetworkPolicy count = 0
--- guard verdict ---
[netpol] Case 1: VACUITY — the NetworkPolicy actually renders
VACUOUS RENDER: no NetworkPolicy selecting app.kubernetes.io/name=valkey in 12 rendered doc(s) (kinds: ConfigMap, PodDisruptionBudget, Service, ServiceAccount, StatefulSet). Every ingress assertion in this gate would pass trivially.
FAIL: default render carries no usable valkey NetworkPolicy (see above) — every assertion below would be vacuous
EXIT=1
```

## Lockstep + verification

bp-valkey 1.1.4 -> **1.1.5** across all four surfaces: `chart/Chart.yaml`,
`blueprint.yaml`, catalog-seed **display (`spec.version`) and delivery
(`source.version`)** pins, and bootstrap-kit slot 17.

- `cd tests/e2e/bootstrap-kit && go test -count=1 ./...` -> `ok` (the authoritative
  guard; the shell lockstep gates miss `blueprint.yaml` and catalog-seed)
- `platform/valkey/chart/tests/*.sh` -> 3/3 pass (contexts-render,
  networkpolicy-ingress-scope, observability-toggle)
- `products/catalyst/chart/tests/*.sh` -> 7/7 pass
- `helm lint` clean on both charts
- `go build ./...` clean in `core/services/shared`
- Slot-17-shaped render (keyspaces + bootstrapOwned) unchanged apart from the
  ingress rules

`products/catalyst/chart/Chart.yaml` is intentionally not bumped here: the
deploy pipeline bumps it and repins slot 13 on every merge, and hand-bumping it
in a PR races that treadmill. Same convention as #5481/#5473/#5469, which also
edited this chart's templates without touching its version.

No live-cluster mutation, no NodePort.

Refs #5487
Refs #5484
Refs #2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
