### PR TITLE
fix(showback,treemap): collapse one-shot Job rows, name Applications after their Deployment (#5485 A+B)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -559,7 +559,11 @@ func podBelongsToComponent(p *unstructured.Unstructured, name, ns string) bool {
 	if ns != "" && !objectInAppNamespace(p, ns) {
 		return false
 	}
-	appKey := applicationKey(p)
+	// nil ReplicaSet index: this join has no cache handle, so a Pod owned
+	// by a ReplicaSet keeps the ReplicaSet name (pre-#5485 behavior). The
+	// instance/name labels below carry the match in the cases this
+	// function is called for.
+	appKey := applicationKey(p, nil)
 	chartName := p.GetLabels()["app.kubernetes.io/name"]
 	// The de-mangled in-vCluster object name (loft annotation), e.g. a host
 	// Pod `grafana-…-x-grafana-x-mgmt-vcluster` carries object-name

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard.go
@@ -283,7 +283,15 @@ func (h *Handler) GetDashboardTreemap(w http.ResponseWriter, r *http.Request) {
 		// the cloud-list canvas) and the per-pod lookup is a map probe.
 		namespaces, _, _ := h.k8sCache.List(cid, "namespace", labels.Everything())
 		nodes, _, _ := h.k8sCache.List(cid, "node", labels.Everything())
-		rows = append(rows, buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, cid, clusterRegion[cid])...)
+		// #5485 defect B: a Deployment's Pods are owned by an
+		// intermediate ReplicaSet, so the ownerRef fallback in
+		// applicationKey yields the hash-suffixed RS name
+		// (`admin-865b6dd6c7`) as the "application" for every workload
+		// that carries no app.kubernetes.io/{instance,name} label. List
+		// the ReplicaSets so buildPodRows can take the second hop
+		// RS → Deployment and render the durable workload name.
+		replicaSets, _, _ := h.k8sCache.List(cid, "replicaset", labels.Everything())
+		rows = append(rows, buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets, cid, clusterRegion[cid])...)
 	}
 	// #3687 (fold #3692): one-shot batch/v1 Job pods (cutover-*,
 	// scan-vulnerabilityreport-*, *-snapshot-save-*) are ephemeral
@@ -295,16 +303,31 @@ func (h *Handler) GetDashboardTreemap(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// isEphemeralRow reports whether a pod row is one-shot batch activity
+// rather than a durable application: the cutover / scan / snapshot Job
+// pods (`cutover-harbor-prewarm-1785340840`, `scan-vulnerabilityreport-…`,
+// `openbao-snapshot-save-29755690`). Keys on the pod's top-level ownerRef
+// Kind (podRow.ownerKind), resolved in buildPodRows — no name-pattern
+// matching (#3687 §7c). CronJob-spawned pods are Job-owned too, so they
+// classify here as well.
+//
+// THE single definition of "ephemeral" for every display layer. The
+// treemap drops these rows outright (dropEphemeralRows); showback keeps
+// their cost but collapses them into one Platform-overhead line
+// (aggregateConsumption). Both call this predicate so the two surfaces
+// can never disagree about what counts as one-shot (#5485).
+func isEphemeralRow(r podRow) bool {
+	return strings.EqualFold(r.ownerKind, "Job")
+}
+
 // dropEphemeralRows filters out pods owned by a batch/v1 Job — the
 // one-shot cutover / scan / snapshot workloads that are activity, not a
 // running application. Pods owned by anything else (Deployment,
-// StatefulSet, DaemonSet, ReplicaSet, CronJob-via-Job is still Job-owned)
-// are retained. Keys on the pod's top-level ownerRef Kind (podRow.ownerKind),
-// resolved in buildPodRows — no name-pattern matching (#3687 §7c).
+// StatefulSet, DaemonSet, ReplicaSet) are retained.
 func dropEphemeralRows(rows []podRow) []podRow {
 	out := rows[:0]
 	for _, r := range rows {
-		if strings.EqualFold(r.ownerKind, "Job") {
+		if isEphemeralRow(r) {
 			continue
 		}
 		out = append(out, r)
@@ -368,7 +391,7 @@ type podRow struct {
 // HandleTreemap. Used as a region fallback when Pods/Nodes lack the
 // `openova.io/region`/`topology.kubernetes.io/region` label — common
 // on HCS where Huawei CCM doesn't stamp the topology label.
-func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes []*unstructured.Unstructured, clusterID string, clusterCloudRegion string) []podRow {
+func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets []*unstructured.Unstructured, clusterID string, clusterCloudRegion string) []podRow {
 	pvcByKey := map[string]*unstructured.Unstructured{}
 	for _, p := range pvcs {
 		key := p.GetNamespace() + "/" + p.GetName()
@@ -393,6 +416,12 @@ func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes []*unstructured.Unst
 	for _, n := range nodes {
 		nodeByName[n.GetName()] = n
 	}
+	// ReplicaSet join key: the intermediate hop on the Deployment→Pod
+	// ownerRef chain. applicationKey uses it to resolve a Pod owned by
+	// `admin-865b6dd6c7` to the Deployment `admin` (#5485). Nil/empty
+	// when the caller has no ReplicaSet list — applicationKey then keeps
+	// the ownerRef name rather than inventing one.
+	rsByKey := indexReplicaSets(replicaSets)
 
 	out := make([]podRow, 0, len(pods))
 	for _, p := range pods {
@@ -468,7 +497,7 @@ func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes []*unstructured.Unst
 		row := podRow{
 			namespace:   p.GetNamespace(),
 			cluster:     clusterID,
-			application: applicationKey(p),
+			application: applicationKey(p, rsByKey),
 			family:      family,
 			region:      region,
 			vcluster:    vcluster,
@@ -528,20 +557,42 @@ func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes []*unstructured.Unst
 	return out
 }
 
+// indexReplicaSets keys ReplicaSets by "<namespace>/<name>" for the
+// Pod → ReplicaSet → Deployment hop in applicationKey. Returns an empty
+// (non-nil) map for an empty list so callers can probe unconditionally.
+func indexReplicaSets(replicaSets []*unstructured.Unstructured) map[string]*unstructured.Unstructured {
+	byKey := make(map[string]*unstructured.Unstructured, len(replicaSets))
+	for _, rs := range replicaSets {
+		if rs == nil {
+			continue
+		}
+		byKey[rs.GetNamespace()+"/"+rs.GetName()] = rs
+	}
+	return byKey
+}
+
 // applicationKey returns the application identifier per the chart-
 // authoring convention. Order of precedence:
 //
 //  1. label app.kubernetes.io/instance (set by Helm and most chart
 //     authors); this is what `group_by=application` should bucket on.
-//  2. top-level ownerRef Kind+Name when no instance label is set.
-//     Daemonset/Statefulset/Deployment/Job all get hit; the
-//     ReplicaSet hop is collapsed by walking the RS ownerRef chain
-//     would require a second cache lookup — we treat the pod's first
-//     ownerRef as the application unit instead, which is correct for
-//     all bp-* charts in the catalyst registry.
-//  3. the pod's own name when unowned (rare — DaemonSet stub pods,
-//     statically-defined pods).
-func applicationKey(p *unstructured.Unstructured) string {
+//  2. label app.kubernetes.io/name.
+//  3. the owning workload's name, resolved from the pod's ownerRefs.
+//     StatefulSet / DaemonSet / Job pods are owned by their workload
+//     directly, so the ownerRef name IS the application. A Deployment's
+//     pods are owned by an intermediate ReplicaSet, so stopping at the
+//     first ownerRef would surface the hash-suffixed RS name
+//     (`admin-865b6dd6c7`, `coredns-57fc96f748`) as an "application" —
+//     #5485 defect B, 24 of 101 live treemap leaves. When `rsByKey`
+//     carries the pod's ReplicaSet we take one more hop to the RS's own
+//     controller (the Deployment) and use THAT name.
+//  4. the pod's own name when unowned (rare — statically-defined pods).
+//
+// No-further-owner cases resolve without inventing a name: a ReplicaSet
+// absent from rsByKey (nil index / cache miss), or a bare ReplicaSet with
+// no controller of its own, both keep the ReplicaSet name — the same
+// value this returned before #5485, never "" and never a guess.
+func applicationKey(p *unstructured.Unstructured, rsByKey map[string]*unstructured.Unstructured) string {
 	if v := p.GetLabels()["app.kubernetes.io/instance"]; v != "" {
 		return v
 	}
@@ -549,11 +600,36 @@ func applicationKey(p *unstructured.Unstructured) string {
 		return v
 	}
 	for _, ref := range p.GetOwnerReferences() {
+		if ref.Name == "" {
+			continue
+		}
+		if ref.Kind != "ReplicaSet" {
+			return ref.Name
+		}
+		if owner := replicaSetOwnerName(rsByKey[p.GetNamespace()+"/"+ref.Name]); owner != "" {
+			return owner
+		}
+		return ref.Name
+	}
+	return p.GetName()
+}
+
+// replicaSetOwnerName returns the name of the workload that controls this
+// ReplicaSet — the Deployment in every Helm/Flux-managed case, an Argo
+// Rollout or another custom controller elsewhere. Returns "" when the RS
+// is nil (not in the index) or genuinely has no owner (a hand-applied,
+// bare ReplicaSet), which keeps applicationKey on the ReplicaSet name
+// instead of fabricating one.
+func replicaSetOwnerName(rs *unstructured.Unstructured) string {
+	if rs == nil {
+		return ""
+	}
+	for _, ref := range rs.GetOwnerReferences() {
 		if ref.Name != "" {
 			return ref.Name
 		}
 	}
-	return p.GetName()
+	return ""
 }
 
 func stringLabel(p *unstructured.Unstructured, key, fallback string) string {

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
@@ -185,6 +185,11 @@ func dashFixtureClients(objs ...runtime.Object) (*dynamicfake.FakeDynamicClient,
 		{schema.GroupVersionKind{Version: "v1", Kind: "NamespaceList"}},
 		{schema.GroupVersionKind{Version: "v1", Kind: "Node"}},
 		{schema.GroupVersionKind{Version: "v1", Kind: "NodeList"}},
+		// #5485: ReplicaSets are the Deployment→Pod ownerRef hop the
+		// treemap walks to name an application after its Deployment
+		// rather than the hash-suffixed ReplicaSet.
+		{schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}},
+		{schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSetList"}},
 	}
 	for _, g := range gvks {
 		if strings.HasSuffix(g.gvk.Kind, "List") {
@@ -199,6 +204,7 @@ func dashFixtureClients(objs ...runtime.Object) (*dynamicfake.FakeDynamicClient,
 		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}: "PodMetricsList",
 		{Version: "v1", Resource: "namespaces"}:                         "NamespaceList",
 		{Version: "v1", Resource: "nodes"}:                              "NodeList",
+		{Group: "apps", Version: "v1", Resource: "replicasets"}:         "ReplicaSetList",
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
 	core := kfake.NewSimpleClientset()
@@ -253,6 +259,14 @@ func newDashHandlerWithCache(t *testing.T, clusterID string, withMetrics bool, o
 		GVR:        schema.GroupVersionResource{Version: "v1", Resource: "nodes"},
 		Namespaced: false,
 	})
+	// #5485 defect B: the Deployment→Pod ownerRef hop. Registered so the
+	// handler's h.k8sCache.List(cid, "replicaset", …) returns the seeded
+	// fixtures and applicationKey can resolve past the ReplicaSet.
+	_ = r.Add(k8scache.Kind{
+		Name:       "replicaset",
+		GVR:        schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"},
+		Namespaced: true,
+	})
 	cfg := k8scache.Config{
 		Logger:   quietHandlerLogger(),
 		Registry: r,
@@ -277,6 +291,7 @@ func newDashHandlerWithCache(t *testing.T, clusterID string, withMetrics bool, o
 	wantPVCs := 0
 	wantNS := 0
 	wantNodes := 0
+	wantRS := 0
 	for _, o := range objs {
 		switch o.GetKind() {
 		case "Pod":
@@ -287,6 +302,8 @@ func newDashHandlerWithCache(t *testing.T, clusterID string, withMetrics bool, o
 			wantNS++
 		case "Node":
 			wantNodes++
+		case "ReplicaSet":
+			wantRS++
 		}
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -295,8 +312,10 @@ func newDashHandlerWithCache(t *testing.T, clusterID string, withMetrics bool, o
 		gotPVCs, _, _ := f.List(clusterID, "persistentvolumeclaim", labels.Everything())
 		gotNS, _, _ := f.List(clusterID, "namespace", labels.Everything())
 		gotNodes, _, _ := f.List(clusterID, "node", labels.Everything())
+		gotRS, _, _ := f.List(clusterID, "replicaset", labels.Everything())
 		if len(gotPods) >= wantPods && len(gotPVCs) >= wantPVCs &&
-			len(gotNS) >= wantNS && len(gotNodes) >= wantNodes {
+			len(gotNS) >= wantNS && len(gotNodes) >= wantNodes &&
+			len(gotRS) >= wantRS {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -983,3 +1002,225 @@ func TestDimensionKey_OrganizationFallsBackToPlatformOverhead(t *testing.T) {
 	}
 }
 
+/* ── #5485 defect B — Application names, not ReplicaSet names ────────── */
+
+// mkDashOwnedPod produces an unstructured Pod carrying NO
+// app.kubernetes.io/{instance,name} labels — the shape of the 31 live
+// pods (org-services/, flux-system/, kube-system/coredns, metrics-server,
+// nats-jetstream, openbao-unseal-reconciler, provider-opentofu) that made
+// #5485 defect B operator-visible. Its application identity therefore has
+// to come from the ownerRef chain. `ownerKind`/`ownerName` empty ⇒ a bare
+// unowned pod.
+func mkDashOwnedPod(ns, name, ownerKind, ownerName, cpuRequest string) *unstructured.Unstructured {
+	meta := map[string]any{
+		"namespace":         ns,
+		"name":              name,
+		"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		"resourceVersion":   "1",
+	}
+	if ownerKind != "" && ownerName != "" {
+		apiVersion := "apps/v1"
+		if ownerKind == "Job" {
+			apiVersion = "batch/v1"
+		}
+		meta["ownerReferences"] = []any{map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       ownerKind,
+			"name":       ownerName,
+			"uid":        "uid-" + ownerName,
+			"controller": true,
+		}}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   meta,
+		"spec": map[string]any{
+			"containers": []any{map[string]any{
+				"name":      "main",
+				"image":     "ghcr.io/openova-io/test:1",
+				"resources": map[string]any{"requests": map[string]any{"cpu": cpuRequest}},
+			}},
+			"volumes": []any{},
+		},
+		"status": map[string]any{
+			"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+		},
+	}}
+}
+
+// mkDashReplicaSet produces the intermediate Deployment→Pod hop. Empty
+// `deployment` ⇒ a bare ReplicaSet with no controller of its own (the
+// no-further-owner case).
+func mkDashReplicaSet(ns, name, deployment string) *unstructured.Unstructured {
+	meta := map[string]any{
+		"namespace":       ns,
+		"name":            name,
+		"resourceVersion": "1",
+	}
+	if deployment != "" {
+		meta["ownerReferences"] = []any{map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"name":       deployment,
+			"uid":        "uid-" + deployment,
+			"controller": true,
+		}}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "ReplicaSet",
+		"metadata":   meta,
+		"spec":       map[string]any{"replicas": int64(1)},
+	}}
+}
+
+// TestApplicationKey_ResolvesDeploymentThroughReplicaSet — #5485 defect B.
+// A Deployment's pods are owned by a hash-suffixed ReplicaSet; stopping at
+// the pod's first ownerRef rendered `admin-865b6dd6c7` /
+// `coredns-57fc96f748` / `source-controller-cc7bd674d` as "applications"
+// (24 of 101 live treemap leaves). The resolver takes the second hop
+// RS → Deployment, and leaves every other owner shape untouched.
+func TestApplicationKey_ResolvesDeploymentThroughReplicaSet(t *testing.T) {
+	rsIndex := indexReplicaSets([]*unstructured.Unstructured{
+		mkDashReplicaSet("org-services", "admin-865b6dd6c7", "admin"),
+		mkDashReplicaSet("kube-system", "coredns-57fc96f748", "coredns"),
+		// A ReplicaSet with no controller of its own — hand-applied,
+		// no Deployment above it.
+		mkDashReplicaSet("edge", "bare-rs-7d9f", ""),
+	})
+
+	cases := []struct {
+		name string
+		pod  *unstructured.Unstructured
+		want string
+	}{
+		{
+			// THE defect: Deployment pod resolves to the Deployment.
+			name: "deployment pod via replicaset hop",
+			pod:  mkDashOwnedPod("org-services", "admin-865b6dd6c7-p4xkv", "ReplicaSet", "admin-865b6dd6c7", "50m"),
+			want: "admin",
+		},
+		{
+			name: "kube-system coredns via replicaset hop",
+			pod:  mkDashOwnedPod("kube-system", "coredns-57fc96f748-abcde", "ReplicaSet", "coredns-57fc96f748", "100m"),
+			want: "coredns",
+		},
+		// ── no-further-owner cases: keep a real name, invent nothing ──
+		{
+			name: "replicaset absent from the index keeps the replicaset name",
+			pod:  mkDashOwnedPod("flux-system", "source-controller-cc7bd674d-zzz", "ReplicaSet", "source-controller-cc7bd674d", "10m"),
+			want: "source-controller-cc7bd674d",
+		},
+		{
+			name: "bare replicaset with no controller keeps the replicaset name",
+			pod:  mkDashOwnedPod("edge", "bare-rs-7d9f-qqq", "ReplicaSet", "bare-rs-7d9f", "10m"),
+			want: "bare-rs-7d9f",
+		},
+		{
+			name: "daemonset pod keeps its workload name (no hop)",
+			pod:  mkDashOwnedPod("kube-system", "cilium-9xk2p", "DaemonSet", "cilium", "100m"),
+			want: "cilium",
+		},
+		{
+			name: "statefulset pod keeps its workload name (no hop)",
+			pod:  mkDashOwnedPod("shared-data", "shared-pg-1", "StatefulSet", "shared-pg", "200m"),
+			want: "shared-pg",
+		},
+		{
+			name: "job pod keeps its job name (no hop)",
+			pod:  mkDashOwnedPod("catalyst-system", "cutover-harbor-prewarm-1785340840-tt7", "Job", "cutover-harbor-prewarm-1785340840", "50m"),
+			want: "cutover-harbor-prewarm-1785340840",
+		},
+		{
+			name: "unowned pod falls back to its own name",
+			pod:  mkDashOwnedPod("edge", "static-probe", "", "", "10m"),
+			want: "static-probe",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := applicationKey(tc.pod, rsIndex); got != tc.want {
+				t.Errorf("applicationKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplicationKey_LabelsWinAndNeverEmpty — the vacuity control for
+// defect B. A "fix" that returned "" (or dropped the ownerRef fallback)
+// would satisfy "no hash-suffixed names" while destroying the grouping:
+// every pod would collapse into one nameless cell. Locks that the
+// chart-authoring precedence still holds and that NO input yields "".
+func TestApplicationKey_LabelsWinAndNeverEmpty(t *testing.T) {
+	rsIndex := indexReplicaSets([]*unstructured.Unstructured{
+		mkDashReplicaSet("apps", "blog-6c7d", "blog-deploy"),
+	})
+
+	// 1. app.kubernetes.io/instance wins over the whole ownerRef chain.
+	labelled := mkDashOwnedPod("apps", "blog-6c7d-aaa", "ReplicaSet", "blog-6c7d", "50m")
+	labelled.SetLabels(map[string]string{"app.kubernetes.io/instance": "blog"})
+	if got := applicationKey(labelled, rsIndex); got != "blog" {
+		t.Errorf("instance label must win: got %q, want %q", got, "blog")
+	}
+	// 2. app.kubernetes.io/name is the second precedence step.
+	named := mkDashOwnedPod("apps", "blog-6c7d-bbb", "ReplicaSet", "blog-6c7d", "50m")
+	named.SetLabels(map[string]string{"app.kubernetes.io/name": "blog-chart"})
+	if got := applicationKey(named, rsIndex); got != "blog-chart" {
+		t.Errorf("name label must be second: got %q, want %q", got, "blog-chart")
+	}
+	// 3. NOTHING resolves to the empty string — not a nil index, not a
+	//    missing ReplicaSet, not a pod with no owner at all.
+	probes := map[string]*unstructured.Unstructured{
+		"rs-owned, nil index":    mkDashOwnedPod("apps", "blog-6c7d-ccc", "ReplicaSet", "blog-6c7d", "50m"),
+		"rs-owned, missing rs":   mkDashOwnedPod("apps", "ghost-1111-ddd", "ReplicaSet", "ghost-1111", "50m"),
+		"unowned":                mkDashOwnedPod("apps", "loner", "", "", "50m"),
+		"owner ref with no name": mkDashOwnedPod("apps", "nameless-owner", "", "", "50m"),
+		"labelled":               labelled,
+	}
+	for what, p := range probes {
+		if got := applicationKey(p, nil); got == "" {
+			t.Errorf("%s: applicationKey returned the empty string — every pod must land in a named bucket", what)
+		}
+	}
+	// A nil index must NOT change the pre-#5485 answer for an RS-owned
+	// pod: the ReplicaSet name, never "" and never a fabricated one.
+	if got := applicationKey(probes["rs-owned, nil index"], nil); got != "blog-6c7d" {
+		t.Errorf("nil rs index: got %q, want the replicaset name %q", got, "blog-6c7d")
+	}
+}
+
+// TestDashboardTreemap_ApplicationNamedAfterDeploymentNotReplicaSet —
+// the wired proof for defect B: the handler lists ReplicaSets from the
+// same cluster cache and the rendered treemap leaves carry Deployment
+// names. Exercises the full HTTP path, so a fix that resolves correctly
+// in applicationKey but is never threaded through buildPodRows fails here.
+func TestDashboardTreemap_ApplicationNamedAfterDeploymentNotReplicaSet(t *testing.T) {
+	h := newDashHandlerWithCache(t, "alpha", false,
+		mkDashReplicaSet("org-services", "admin-865b6dd6c7", "admin"),
+		mkDashReplicaSet("kube-system", "coredns-57fc96f748", "coredns"),
+		mkDashOwnedPod("org-services", "admin-865b6dd6c7-p4xkv", "ReplicaSet", "admin-865b6dd6c7", "100m"),
+		mkDashOwnedPod("org-services", "admin-865b6dd6c7-w2mnb", "ReplicaSet", "admin-865b6dd6c7", "100m"),
+		mkDashOwnedPod("kube-system", "coredns-57fc96f748-abcde", "ReplicaSet", "coredns-57fc96f748", "50m"),
+	)
+	out := dashGet(t, h, "deployment_id=alpha&group_by=application&color_by=health&size_by=cpu_request")
+
+	bySize := map[string]float64{}
+	for _, it := range out.Items {
+		bySize[it.Name] = it.SizeValue
+		if strings.Contains(it.Name, "865b6dd6c7") || strings.Contains(it.Name, "57fc96f748") {
+			t.Errorf("a raw ReplicaSet name rendered as an Application leaf: %q", it.Name)
+		}
+	}
+	// Vacuity control: the leaves are still THERE, still named, and still
+	// carry the summed request of their pods.
+	if len(out.Items) != 2 {
+		t.Fatalf("expected 2 application leaves (admin + coredns), got %d: %+v", len(out.Items), out.Items)
+	}
+	if bySize["admin"] != 200 {
+		t.Errorf("admin cpu_request: got %v want 200m (two pods folded under the Deployment)", bySize["admin"])
+	}
+	if bySize["coredns"] != 50 {
+		t.Errorf("coredns cpu_request: got %v want 50m", bySize["coredns"])
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
@@ -112,6 +112,29 @@ const (
 // [a-z][a-z0-9-]{2,30}).
 const platformOrg = "__platform__"
 
+// ephemeralApp is the single app row every one-shot Job pod folds into
+// inside the platform-overhead org. Before #5485 each Job pod produced
+// its own `appConsumption` row, so the Application table itemized
+// `cutover-harbor-prewarm-1785340840`, `cutover-gitea-mirror-…`,
+// `openbao-snapshot-save-29755690` — the exact "render as a single
+// Platform overhead line" contract this file's header states it honors.
+// Their cost is NOT dropped (it is real consumption of the estate, and
+// the platform row's totals still include it) — only the itemization
+// collapses. Ephemeral classification is isEphemeralRow in dashboard.go,
+// shared with the treemap so the two surfaces cannot drift.
+//
+// The parenthesized form matches the existing "(unlabeled)" convention
+// for synthetic rows and cannot collide with a real workload name
+// (K8s names are DNS labels — no spaces, no parentheses).
+const ephemeralApp = "(one-shot jobs)"
+
+// ephemeralMixedNamespace is the namespace shown for the collapsed
+// one-shot row when its pods span more than one namespace (cutover Jobs
+// in catalyst-system, snapshot Jobs in openbao, scan Jobs in
+// trivy-system). A single-namespace collapse keeps the real namespace so
+// the operator still sees where the activity ran.
+const ephemeralMixedNamespace = "(various)"
+
 // defaultInfraNamespaces is the baked-in default set of host /
 // control-plane namespaces whose pods are NEVER tenant consumption. It is
 // the floor, not the law: SHOWBACK_INFRA_NAMESPACES (comma-separated)
@@ -189,8 +212,12 @@ func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Requ
 	podMetrics, _, _ := h.k8sCache.List(clusterID, "podmetrics", labels.Everything())
 	namespaces, _, _ := h.k8sCache.List(clusterID, "namespace", labels.Everything())
 	nodes, _, _ := h.k8sCache.List(clusterID, "node", labels.Everything())
+	// ReplicaSets: the Deployment→Pod ownerRef hop. Without them the
+	// per-app breakdown lists hash-suffixed ReplicaSet names instead of
+	// the Deployment that owns them (#5485 defect B).
+	replicaSets, _, _ := h.k8sCache.List(clusterID, "replicaset", labels.Everything())
 
-	rows := buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, clusterID, "")
+	rows := buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets, clusterID, "")
 
 	resp := aggregateConsumption(rows, parentOrg, infraNamespaceSet(os.Getenv("SHOWBACK_INFRA_NAMESPACES")))
 	writeJSON(w, http.StatusOK, resp)
@@ -207,6 +234,12 @@ func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Requ
 // Real per-Org namespaces (stamped by the organization-controller) yield
 // their own org row immediately, with no per-name special-casing — adding
 // a third org needs zero code change (the generality proof §7c).
+//
+// Inside the platform bucket the one-shot Job pods further collapse into
+// a SINGLE `(one-shot jobs)` app row (#5485 defect A) instead of one row
+// per Job pod. Their cost still counts toward the platform row's totals
+// and the Sovereign-wide total — only the per-app itemization folds, so
+// the table shows durable platform workloads plus one activity line.
 func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[string]struct{}) SovereignConsumptionResponse {
 	// org → namespace+app key → app rollup.
 	type appKey struct{ org, ns, app string }
@@ -249,10 +282,25 @@ func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[s
 			app = "(unlabeled)"
 		}
 		k := appKey{org: org, ns: row.namespace, app: app}
+		// #5485 defect A: one-shot Job pods collapse into ONE row for the
+		// whole platform bucket — same ephemeral predicate the treemap
+		// filters on (isEphemeralRow). Keyed with an empty namespace so
+		// Jobs from different namespaces fold together; the displayed
+		// Namespace is resolved below.
+		if isEphemeralRow(row) {
+			k = appKey{org: org, ns: "", app: ephemeralApp}
+		}
 		ac, ok := appAgg[k]
 		if !ok {
 			ac = &appConsumption{Application: app, Namespace: row.namespace}
+			if isEphemeralRow(row) {
+				ac.Application = ephemeralApp
+			}
 			appAgg[k] = ac
+		} else if ac.Namespace != row.namespace {
+			// Only reachable for the collapsed one-shot row (every other
+			// key pins the namespace): its pods span >1 namespace.
+			ac.Namespace = ephemeralMixedNamespace
 		}
 		ac.CostUnits += cost
 		ac.CPUMilli += cpuMilli

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption_test.go
@@ -206,3 +206,167 @@ func TestInfraNamespaceSet_EnvOverrideExtendsFloor(t *testing.T) {
 		t.Errorf("a real tenant namespace must NOT be in the infra set")
 	}
 }
+
+/* ── #5485 defect A — one-shot Jobs collapse to ONE overhead line ────── */
+
+// TestAggregateConsumption_OneShotJobsCollapseToASingleRow — #5485
+// defect A. orgForRow already routed every Job pod to the platform
+// bucket, but nothing collapsed them, so the __platform__ Application
+// table itemized one row per Job pod:
+// `cutover-harbor-prewarm-1785340840`, `cutover-gitea-mirror-…`,
+// `cutover-harbor-projects-…`, `openbao-snapshot-save-29755690`,
+// `legacy-cert-cleanup`, `cert-nextkey-guard` — contradicting this
+// handler's own "single Platform overhead line" contract. They now fold
+// into one row, WITHOUT dropping their cost.
+func TestAggregateConsumption_OneShotJobsCollapseToASingleRow(t *testing.T) {
+	const parent = "hw291.omani.works"
+	rows := []podRow{
+		// Durable platform workloads — must stay individually itemized.
+		{namespace: "catalyst-system", application: "catalyst-api", ownerKind: "ReplicaSet", cpuReq: 500, memReq: 1 << 30},
+		{namespace: "kube-system", application: "cilium", ownerKind: "DaemonSet", cpuReq: 100, memReq: 128 << 20},
+		// The six live one-shot Job pods from the #5485 report.
+		{namespace: "catalyst-system", application: "cutover-harbor-prewarm-1785340840", ownerKind: "Job", cpuReq: 10, memReq: 32 << 20},
+		{namespace: "catalyst-system", application: "cutover-gitea-mirror-1785340111", ownerKind: "Job", cpuReq: 10, memReq: 32 << 20},
+		{namespace: "catalyst-system", application: "cutover-harbor-projects-1785340222", ownerKind: "Job", cpuReq: 10, memReq: 32 << 20},
+		{namespace: "openbao", application: "openbao-snapshot-save-29755690", ownerKind: "Job", cpuReq: 10, memReq: 32 << 20},
+		{namespace: "cert-manager", application: "legacy-cert-cleanup", ownerKind: "Job", cpuReq: 10, memReq: 32 << 20},
+		{namespace: "cert-manager", application: "cert-nextkey-guard", ownerKind: "Job", cpuReq: 10, memReq: 32 << 20},
+	}
+
+	resp := aggregateConsumption(rows, parent, testInfraSet())
+
+	platform := resp.Orgs[len(resp.Orgs)-1]
+	if !platform.IsPlatform {
+		t.Fatalf("last row must be the platform-overhead rollup, got %#v", resp.Orgs)
+	}
+
+	// Not one row per Job pod: exactly ONE collapsed activity line.
+	ephemeralRows := 0
+	for _, a := range platform.Apps {
+		if a.Application == ephemeralApp {
+			ephemeralRows++
+		}
+		for _, jobName := range []string{
+			"cutover-harbor-prewarm-1785340840",
+			"cutover-gitea-mirror-1785340111",
+			"cutover-harbor-projects-1785340222",
+			"openbao-snapshot-save-29755690",
+			"legacy-cert-cleanup",
+			"cert-nextkey-guard",
+		} {
+			if a.Application == jobName {
+				t.Errorf("one-shot Job pod itemized as its own Application row: %q", jobName)
+			}
+		}
+	}
+	if ephemeralRows != 1 {
+		t.Errorf("expected exactly 1 collapsed %q row, got %d (apps=%#v)", ephemeralApp, ephemeralRows, platform.Apps)
+	}
+
+	// The collapse spans namespaces, so the row says so rather than
+	// claiming one namespace owns all six Jobs.
+	var collapsed *appConsumption
+	for i := range platform.Apps {
+		if platform.Apps[i].Application == ephemeralApp {
+			collapsed = &platform.Apps[i]
+		}
+	}
+	// NOTE: no t.Fatalf below this point — a bail here would skip the
+	// vacuity assertions that follow, which is exactly how a
+	// drop-everything "fix" sneaks through a green run.
+	if collapsed == nil {
+		t.Errorf("no collapsed one-shot row at all — apps=%#v", platform.Apps)
+	} else {
+		if collapsed.Namespace != ephemeralMixedNamespace {
+			t.Errorf("collapsed row Namespace = %q, want %q (Jobs span catalyst-system/openbao/cert-manager)",
+				collapsed.Namespace, ephemeralMixedNamespace)
+		}
+		// Cost is COLLAPSED, not discarded: all six Job pods' CPU lands
+		// on the one row.
+		if collapsed.CPUMilli != 60 {
+			t.Errorf("collapsed row CPUMilli = %v, want 60 (six Job pods folded)", collapsed.CPUMilli)
+		}
+	}
+	// The platform total still carries every pod, collapsed or not.
+	if platform.CPUMilli != 660 {
+		t.Errorf("platform CPUMilli = %v, want 660 (durable 600 + one-shot 60) — the fix must collapse, not drop", platform.CPUMilli)
+	}
+
+	/* ── Vacuity control ────────────────────────────────────────────
+	   A "fix" that filtered every row out (or emptied Apps) would also
+	   produce "no Job pod rows" while destroying showback. Assert the
+	   durable platform workloads are STILL itemized, the totals are
+	   non-zero, and per-app percents still sum to ~100 within the org. */
+	byApp := map[string]float64{}
+	for _, a := range platform.Apps {
+		byApp[a.Application] = a.CPUMilli
+	}
+	if byApp["catalyst-api"] != 500 {
+		t.Errorf("durable app catalyst-api lost its row/cost: CPUMilli=%v, want 500", byApp["catalyst-api"])
+	}
+	if byApp["cilium"] != 100 {
+		t.Errorf("durable app cilium lost its row/cost: CPUMilli=%v, want 100", byApp["cilium"])
+	}
+	if len(platform.Apps) != 3 {
+		t.Errorf("expected 3 platform app rows (catalyst-api + cilium + one collapsed activity line), got %d: %#v",
+			len(platform.Apps), platform.Apps)
+	}
+	if resp.TotalCostUnits <= 0 || platform.CostUnits <= 0 {
+		t.Errorf("showback totals collapsed to zero: total=%v platform=%v", resp.TotalCostUnits, platform.CostUnits)
+	}
+	var pct float64
+	for _, a := range platform.Apps {
+		pct += a.Percent
+	}
+	if math.Abs(pct-100) > 0.5 {
+		t.Errorf("per-app percents within the platform org must still sum to ~100, got %v", pct)
+	}
+}
+
+// TestAggregateConsumption_SingleNamespaceCollapseKeepsRealNamespace —
+// when every one-shot Job ran in the SAME namespace the collapsed row
+// keeps that namespace instead of the "(various)" marker, so the
+// operator still sees where the activity happened.
+func TestAggregateConsumption_SingleNamespaceCollapseKeepsRealNamespace(t *testing.T) {
+	resp := aggregateConsumption([]podRow{
+		{namespace: "catalyst-system", application: "cutover-harbor-prewarm-1785340840", ownerKind: "Job", cpuReq: 10},
+		{namespace: "catalyst-system", application: "cutover-gitea-mirror-1785340111", ownerKind: "Job", cpuReq: 20},
+	}, "hw291.omani.works", testInfraSet())
+
+	platform := resp.Orgs[len(resp.Orgs)-1]
+	if !platform.IsPlatform || len(platform.Apps) != 1 {
+		t.Fatalf("expected one collapsed row on the platform org, got %#v", platform)
+	}
+	if got := platform.Apps[0]; got.Application != ephemeralApp || got.Namespace != "catalyst-system" || got.CPUMilli != 30 {
+		t.Errorf("collapsed row = %+v, want {%s catalyst-system 30m}", got, ephemeralApp)
+	}
+}
+
+// TestAggregateConsumption_TenantAppsNeverCollapse — the collapse is
+// scoped to one-shot Job pods. A tenant's durable Applications keep their
+// own per-app rows (the DoD 3 "per-app cost attribution" contract).
+func TestAggregateConsumption_TenantAppsNeverCollapse(t *testing.T) {
+	resp := aggregateConsumption([]podRow{
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200},
+		{namespace: "acme", application: "api", org: "acme", ownerKind: "Deployment", cpuReq: 300},
+		{namespace: "acme", application: "shop", org: "acme", ownerKind: "Deployment", cpuReq: 100},
+	}, "hw291.omani.works", testInfraSet())
+
+	var acme *orgConsumption
+	for i := range resp.Orgs {
+		if resp.Orgs[i].Org == "acme" {
+			acme = &resp.Orgs[i]
+		}
+	}
+	if acme == nil {
+		t.Fatal("acme org row missing")
+	}
+	if len(acme.Apps) != 3 {
+		t.Errorf("tenant apps must stay itemized: got %d rows, want 3 (%#v)", len(acme.Apps), acme.Apps)
+	}
+	for _, a := range acme.Apps {
+		if a.Application == ephemeralApp {
+			t.Errorf("a tenant's durable app was folded into the one-shot row: %#v", acme.Apps)
+		}
+	}
+}


### PR DESCRIPTION
Refs #5485

Two operator-visible defects from #5485. Same shape: a display layer inheriting its identity from the wrong object.

## Defect A — showback listed ephemeral Job pods as Application rows

The `__platform__` group's Application table rendered one row per one-shot Job pod — `cutover-harbor-prewarm-1785340840`, `cutover-gitea-mirror-*`, `cutover-harbor-projects-*`, `openbao-snapshot-save-29755690`, `legacy-cert-cleanup`, `cert-nextkey-guard` — contradicting `org_consumption.go`'s own contract to "render as a single Platform overhead line". `orgForRow` routed them to the platform bucket correctly; nothing collapsed them.

They now fold into ONE `(one-shot jobs)` row. The row shows the real namespace when every Job ran in one, `(various)` when they span several.

**Collapsed, not dropped.** Job pods are real consumption of the estate, so their cost stays on the platform row's totals and in the Sovereign-wide total — only the itemization folds. Dropping them would make showback stop summing to the estate, and would have broken the existing `TestAggregateConsumption_PlatformOverheadRollup` which already locks that Job cost lands in the platform rollup.

**Reused, not re-implemented.** The treemap's `dropEphemeralRows` predicate is extracted as `isEphemeralRow`; `dropEphemeralRows` and `aggregateConsumption` both call it. One definition of "ephemeral", so the surface that drops these rows and the surface that folds them cannot drift on what counts as one-shot.

## Defect B — treemap and showback emitted raw ReplicaSet names

24 of 101 live treemap Application leaves were hash-suffixed ReplicaSets: `admin-865b6dd6c7`, `coredns-57fc96f748`, `source-controller-cc7bd674d`, `metrics-server-5985cbc9d7`. `applicationKey` fell back to `GetOwnerReferences()[0].Name`, which for a Deployment pod is the ReplicaSet. The comment rationalised this as "correct for all bp-* charts" — true of those charts, false for the 31 live pods carrying neither `app.kubernetes.io/instance` nor `app.kubernetes.io/name`: `org-services/`, `flux-system/`, `kube-system/coredns`, `metrics-server`, `nats-jetstream`, `openbao-unseal-reconciler`, `provider-opentofu`.

A ReplicaSet-owned pod now takes one more hop — the RS's own controller ownerRef, i.e. the Deployment — and uses that name.

**No-further-owner cases, none of which invent a name:**

| case | resolves to |
|---|---|
| ReplicaSet present, owned by a Deployment | the Deployment name (the fix) |
| ReplicaSet missing from the index (nil index / cache miss) | the ReplicaSet name — the pre-fix value |
| bare ReplicaSet with no controller of its own | the ReplicaSet name |
| DaemonSet / StatefulSet / Job pod | its ownerRef name, no hop taken |
| unowned pod | the pod's own name |

`replicaset` is already a non-Optional kind in `k8scache.DefaultKinds`, so the added `List` reads an informer that runs on every Sovereign anyway — no new watch, no apiserver call. `podBelongsToComponent` passes a nil index and keeps its exact prior behavior.

## Both-directions proof

Each defect has a case that fails against the pre-fix code and passes after. Each revert was done surgically — one edit, then only the affected tests — so no earlier failure could mask a later one.

**A — revert the collapse to the exact pre-fix aggregation block:**

```
--- FAIL: TestAggregateConsumption_OneShotJobsCollapseToASingleRow
    one-shot Job pod itemized as its own Application row: "cutover-harbor-prewarm-1785340840"
    one-shot Job pod itemized as its own Application row: "cutover-gitea-mirror-1785340111"
    one-shot Job pod itemized as its own Application row: "cutover-harbor-projects-1785340222"
    one-shot Job pod itemized as its own Application row: "openbao-snapshot-save-29755690"
    one-shot Job pod itemized as its own Application row: "legacy-cert-cleanup"
    one-shot Job pod itemized as its own Application row: "cert-nextkey-guard"
    expected exactly 1 collapsed "(one-shot jobs)" row, got 0
```

**B — revert `applicationKey` to stop at the first ownerRef:**

```
--- FAIL: TestApplicationKey_ResolvesDeploymentThroughReplicaSet/deployment_pod_via_replicaset_hop
    applicationKey = "admin-865b6dd6c7", want "admin"
--- FAIL: TestApplicationKey_ResolvesDeploymentThroughReplicaSet/kube-system_coredns_via_replicaset_hop
    applicationKey = "coredns-57fc96f748", want "coredns"
--- FAIL: TestDashboardTreemap_ApplicationNamedAfterDeploymentNotReplicaSet
    a raw ReplicaSet name rendered as an Application leaf: "admin-865b6dd6c7"
    a raw ReplicaSet name rendered as an Application leaf: "coredns-57fc96f748"
```

**B — wiring is load-bearing too.** Passing `nil` instead of the listed ReplicaSets (a correct resolver that was never threaded through `buildPodRows`) leaves the unit test green and fails the HTTP-level test:

```
--- FAIL: TestDashboardTreemap_ApplicationNamedAfterDeploymentNotReplicaSet
    a raw ReplicaSet name rendered as an Application leaf: "admin-865b6dd6c7"
```

## Vacuity controls, each shown firing

A filter that drops every row would satisfy "no Job pod rows" while destroying the feature, so both controls were exercised against a plausible wrong fix rather than merely asserted.

**A — a naive drop-everything fix (`rows = dropEphemeralRows(rows)` at the top of `aggregateConsumption`):**

```
--- FAIL: TestAggregateConsumption_OneShotJobsCollapseToASingleRow
    platform CPUMilli = 600, want 660 (durable 600 + one-shot 60) - the fix must collapse, not drop
    expected 3 platform app rows (catalyst-api + cilium + one collapsed activity line), got 2
```

The same test also holds durable platform apps to their own rows and costs, keeps totals non-zero, and keeps per-app percents summing to ~100. `TestAggregateConsumption_TenantAppsNeverCollapse` holds a tenant's three durable apps as three rows.

**B — a fix that suppresses the hash-suffixed name by returning `""`:**

```
--- FAIL: TestApplicationKey_LabelsWinAndNeverEmpty
    rs-owned, nil index: applicationKey returned the empty string - every pod must land in a named bucket
    rs-owned, missing rs: applicationKey returned the empty string - every pod must land in a named bucket
    nil rs index: got "", want the replicaset name "blog-6c7d"
```

That test also holds the chart-authoring precedence: `app.kubernetes.io/instance` first, `app.kubernetes.io/name` second. The treemap test additionally asserts the two leaves are still there with their pods' summed CPU request (`admin` 200m from two pods, `coredns` 50m).

## Full package

```
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  169.080s
```

`go build ./...` and `go vet ./...` clean. `products/catalyst/chart/Chart.yaml` deliberately untouched — the deploy pipeline owns that bump.
