### PR TITLE
fix(bp-self-sovereign-cutover): map cgr.dev + the litmuschaos Scarf gateway into the offline-mirror coverage map (Refs #5442)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1024,7 +1024,7 @@ spec:
       # — the live-cluster walk). New RBAC: read-only blueprints. New values:
       # prewarm.catalogCharts.*, prewarm.chartImages.*. Step count stays 11.
       # New chart test tests/catalog-chart-set.sh + contract Case 72.
-      version: 0.1.156
+      version: 0.1.157
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.156
+  version: 0.1.157
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,51 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.157 (#5442 Refs #4975 #5443 #5095 — COVER THE TWO HOSTS THE
+# AUTHORING-TIME SCAN IS STRUCTURALLY BLIND TO. 0.1.154 made step-03 enumerate
+# images from the PINNED CATALOG CHARTS instead of only from what is installed.
+# That enumeration renders each chart at default values, so it sees what the
+# UPSTREAM SUB-CHARTS declare — and two upstream defaults name registry hosts
+# no file in this repo mentions:
+#
+#   • litmuschaos/litmus 3.28.0 (bp-litmus) defaults its image registry to the
+#     Scarf download gateway `litmuschaos.docker.scarf.sh` — 4 refs
+#     (litmusportal-frontend, -server, -auth-server, mongo:6);
+#   • sigstore/policy-controller (bp-sigstore) pins its leases-cleanup Job at
+#     `cgr.dev/chainguard/kubectl:latest-dev` — 1 ref.
+#
+# Live hw291 2026-07-29 therefore stalled step-03 at `copy_fail=0
+# durable_miss=0 unmapped=5` with NOTHING broken: ok=36 fail=0 and all 144
+# local image paths durably present, the coverage map simply had no entry for
+# those two hosts. tests/image-registry-coverage.sh could not have caught it —
+# its scan surface is this repo's chart values, and neither host appears there.
+#
+# FIX (values-only, no template change): offlineMirror.hostProjects gains
+#   litmuschaos.docker.scarf.sh -> proxy-dockerhub   (NOT a new project: the
+#     gateway delegates auth to Docker Hub's own token service —
+#     `GET https://litmuschaos.docker.scarf.sh/v2/` answers 401 with
+#     `realm="https://auth.docker.io/token",service="registry.docker.io"` — and
+#     serves Docker Hub content, so the same folding #4975 applied to
+#     mirror.gcr.io -> proxy-gcr applies here, and the local path is identical
+#     to the docker.io form's so the two dedupe);
+#   cgr.dev -> proxy-chainguard                      (a genuinely distinct
+#     registry: `GET https://cgr.dev/v2/` answers 405 from Chainguard's own
+#     front-end with no Docker Hub delegation, and its content exists in no
+#     other mapped namespace — so a NEW project, added to harbor.mirrorProjects
+#     in LOCKSTEP so step-02 creates it and step-03's push does not 404).
+# The Scarf entry is ordered AFTER docker.io so the #5095 inverse map walk
+# still resolves proxy-dockerhub back to docker.io.
+#
+# NEW GUARD tests/offline-mirror-host-projects.sh asserts the whole contract
+# from the RENDER (not from values.yaml, which proves nothing about the Job
+# that runs): the map must render into >=3 consuming steps, be byte-identical
+# in all of them, be a real non-empty token list, carry every required
+# host:project pair as a WHOLE token, keep the #5095 first-host-per-project
+# ordering, and name only projects step-02 actually creates. It ships 5
+# negative self-tests that run on every CI invocation — drop cgr.dev, drop the
+# Scarf host, drop proxy-chainguard from mirrorProjects, order the gateway
+# ahead of docker.io, and feed it an empty render — because a guard whose
+# failure path has never been observed is a trivially-green grep, not a guard.
+# No step-count / RBAC / deadline change (still 11 steps).
 # 0.1.154 (#5443 #5442 Refs #3627 #5237 #5437 — MIRROR WHAT THE MARKETPLACE
 # OFFERS, and WARM WHAT THE PINNED CHARTS DECLARE —
 # not only what is installed. Step-06 pivots `openova-catalog` — the one
@@ -2761,7 +2807,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.156
+version: 0.1.157
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/tests/offline-mirror-host-projects.sh
+++ b/platform/self-sovereign-cutover/chart/tests/offline-mirror-host-projects.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# bp-self-sovereign-cutover — offline-mirror HOST->PROJECT RENDER guard
+# (#5442 Refs #4975 #5443).
+#
+# WHAT THIS PROTECTS. `offlineMirror.hostProjects` is the single coverage map
+# step-03 (skopeo push dest), step-04 (containerd certs.d rewrite) and step-08
+# (pre-hold completeness HEAD + self-heal warm) all derive local paths from. A
+# registry host missing from it is not a cosmetic gap: step-03's Phase A3 guard
+# FATALs with `unmapped=N` and the cutover stops before step-04 — which is
+# exactly how live hw291 stalled on 2026-07-29 with `copy_fail=0 durable_miss=0
+# unmapped=5` while nothing was actually broken.
+#
+# WHY A RENDER GUARD AND NOT A VALUES GUARD. tests/image-registry-coverage.sh
+# already scans this repo's chart values for un-mapped hosts — but its surface
+# is THIS REPO. The two hosts that stalled hw291 are declared by UPSTREAM
+# sub-charts (litmuschaos/litmus 3.28.0 defaults its registry to the Scarf
+# gateway `litmuschaos.docker.scarf.sh`; sigstore/policy-controller pins
+# `cgr.dev/chainguard/kubectl:latest-dev`), so no in-repo values.yaml names
+# them and the authoring-time scan is structurally blind to them. Their only
+# in-repo trace is the coverage map itself — so the map entries must be
+# defended directly, at the RENDER, where the runtime steps actually read them.
+#
+# WHY IT CHECKS THE RENDER AND NOT values.yaml. `_helpers.tpl`
+# hostProjectMapInline is what the steps consume; a values key can be present
+# and still not reach the env (renamed helper, dropped `range`, a consumer that
+# stopped mounting the map). Asserting the values file proves nothing about the
+# Job that runs.
+#
+# WHY THE VACUITY CHECK. `grep -q 'cgr.dev' render.yaml` passes trivially
+# against an EMPTY render — a chart that fails to template, a `--show-only`
+# typo, or a helper that yields "" all produce a green grep. So before any
+# host assertion this guard proves the render is real: the HOST_PROJECT_MAP env
+# must exist in >=3 consuming steps, its value must be non-empty, must parse
+# into at least as many `host:project` tokens as the contract requires, and
+# every occurrence must be BYTE-IDENTICAL (one source of truth, per #4975).
+#
+# LOCKSTEP. Every non-empty project named by the map must also be created by
+# step-02 (`harbor.mirrorProjects`) — both read out of the SAME render. A host
+# mapped to a project step-02 never creates makes step-03's push 404 on a
+# non-existent Harbor project, i.e. it trades an `unmapped` failure for a
+# `copy_fail` one instead of fixing anything.
+#
+# Usage:
+#   tests/offline-mirror-host-projects.sh [CHART_DIR]
+#
+# The chart CI gate (.github/workflows/blueprint-release.yaml) invokes every
+# chart/tests/*.sh as `bash <script> <chart_dir>`, so CHART_DIR is positional
+# and defaults to the script's parent.
+#
+# Exit: 0 = contract holds (and both negative self-tests fired); 1 = contract
+# violated; 2 = tool/input error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_DIR="$(cd "${1:-${SCRIPT_DIR}/..}" && pwd)"
+
+command -v helm >/dev/null 2>&1 || { echo "ERROR: helm not installed" >&2; exit 2; }
+command -v yq   >/dev/null 2>&1 || { echo "ERROR: yq not installed" >&2; exit 2; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# ── The CONTRACT ─────────────────────────────────────────────────────────────
+# Every pair below MUST render into HOST_PROJECT_MAP. Removing any one of them
+# from values.yaml re-opens a cutover stall, so removing one must fail the
+# build. Empty project = host-swap (path already carries the project segment).
+REQUIRED_PAIRS=(
+  "ghcr.io:proxy-ghcr"
+  "docker.io:proxy-dockerhub"
+  "registry-1.docker.io:proxy-dockerhub"
+  "index.docker.io:proxy-dockerhub"
+  "quay.io:proxy-quay"
+  "registry.k8s.io:proxy-k8s"
+  "gcr.io:proxy-gcr"
+  "k8s.gcr.io:proxy-gcr"
+  # #4975 — Google's pull-through mirror of Docker Hub / GCR (bp-trivy).
+  "mirror.gcr.io:proxy-gcr"
+  # #5442 — Scarf download gateway in front of Docker Hub (bp-litmus, 4 refs:
+  # litmusportal-frontend / -server / -auth-server / mongo:6).
+  "litmuschaos.docker.scarf.sh:proxy-dockerhub"
+  # #5442 — Chainguard (bp-sigstore's policy-controller leases-cleanup Job).
+  "cgr.dev:proxy-chainguard"
+  "public.ecr.aws:proxy-ecr"
+  # #5026 — the mothership host-swap entry (empty project, path preserved).
+  "harbor.openova.io:"
+)
+
+# Vacuity floor: the smallest token count that still proves the rendered map is
+# a real list rather than a stub/empty helper output. Deliberately far below
+# the contract size — see the note in check_render.
+VACUITY_MIN_TOKENS=3
+
+# Projects whose canonical DIRECT upstream host must be the FIRST map entry
+# carrying that project: step-03 copy_one and step-08's self-heal both derive
+# the #5095 mothership-proxy direct-source fallback by walking the map and
+# taking the FIRST host whose project matches. A redirector host ordered ahead
+# of the real registry would silently retarget every fallback at the redirector.
+declare -A FIRST_HOST_FOR_PROJECT=(
+  ["proxy-dockerhub"]="docker.io"
+  ["proxy-gcr"]="gcr.io"
+  ["proxy-ghcr"]="ghcr.io"
+)
+
+# ── render helper ────────────────────────────────────────────────────────────
+render_chart() {
+  # $1 = chart dir, $2 = output file. Non-zero on template failure.
+  helm template smoke "$1" >"$2" 2>"$2.err"
+}
+
+# Extract every rendered HOST_PROJECT_MAP value, one per line.
+extract_maps() {
+  awk '
+    /name: HOST_PROJECT_MAP[[:space:]]*$/ {
+      if ((getline line) > 0) {
+        sub(/^[[:space:]]*value:[[:space:]]*/, "", line)
+        sub(/^"/, "", line); sub(/"[[:space:]]*$/, "", line)
+        print line
+      }
+    }' "$1"
+}
+
+# Extract step-02's rendered mirror-project list (the `for mirror_proj in …` loop).
+extract_mirror_projects() {
+  sed -n 's/^[[:space:]]*for mirror_proj in \(.*\); do[[:space:]]*$/\1/p' "$1" | head -1
+}
+
+# ── the assertion body, reusable so the self-tests can re-run it verbatim ─────
+# $1 = render file. Prints diagnostics; returns 0 pass / 1 fail.
+check_render() {
+  local render="$1" rc=0
+  local maps first_map n_tokens hpm_count
+
+  # ---- VACUITY GATE -------------------------------------------------------
+  if [ ! -s "${render}" ]; then
+    echo "FAIL[vacuity]: render is empty — every host assertion below would pass trivially (#5442)" >&2
+    return 1
+  fi
+  hpm_count=$(grep -c 'name: HOST_PROJECT_MAP' "${render}" || true)
+  if [ "${hpm_count}" -lt 3 ]; then
+    echo "FAIL[vacuity]: HOST_PROJECT_MAP env rendered ${hpm_count}x, expected >=3 (steps 03/04/08 must all consume the map) (#4975)" >&2
+    return 1
+  fi
+  maps="$(extract_maps "${render}")"
+  if [ -z "${maps}" ]; then
+    echo "FAIL[vacuity]: HOST_PROJECT_MAP is declared but its rendered value could not be extracted — the helper produced nothing (#5442)" >&2
+    return 1
+  fi
+  if [ "$(printf '%s\n' "${maps}" | sort -u | grep -c .)" -ne 1 ]; then
+    echo "FAIL: HOST_PROJECT_MAP renders with DIFFERENT values across consuming steps — the map must be one source of truth (#4975):" >&2
+    printf '%s\n' "${maps}" | sort -u | sed 's/^/  /' >&2
+    return 1
+  fi
+  first_map="$(printf '%s\n' "${maps}" | head -1)"
+  if [ -z "${first_map}" ]; then
+    echo "FAIL[vacuity]: HOST_PROJECT_MAP rendered EMPTY — a grep for any host would pass trivially (#5442)" >&2
+    return 1
+  fi
+  # Vacuity floor only — it proves the helper produced a REAL list rather than
+  # a stub. Completeness is the named-pair contract's job below, which reports
+  # WHICH entry went missing; a floor equal to the contract size would steal
+  # that diagnosis and report a count instead of a host.
+  n_tokens=$(printf '%s\n' ${first_map} | grep -c . || true)
+  if [ "${n_tokens}" -lt "${VACUITY_MIN_TOKENS}" ]; then
+    echo "FAIL[vacuity]: HOST_PROJECT_MAP parsed into ${n_tokens} token(s), below the ${VACUITY_MIN_TOKENS}-token floor that proves the map is a real rendered list (#5442)" >&2
+    echo "  rendered map: ${first_map}" >&2
+    return 1
+  fi
+  echo "  vacuity OK — map rendered in ${hpm_count} step(s), identical everywhere, ${n_tokens} host:project token(s)"
+
+  # ---- CONTRACT: every required pair is a WHOLE token ----------------------
+  # Whole-token comparison, never a substring grep on the render: `cgr.dev`
+  # appears in prose comments too, and a substring match would accept a
+  # mis-projected `cgr.dev:proxy-dockerhub`.
+  local want found tok
+  for want in "${REQUIRED_PAIRS[@]}"; do
+    found=0
+    for tok in ${first_map}; do
+      [ "${tok}" = "${want}" ] && { found=1; break; }
+    done
+    if [ "${found}" -ne 1 ]; then
+      echo "FAIL: HOST_PROJECT_MAP is missing the required entry '${want}' (#5442)" >&2
+      echo "  rendered map: ${first_map}" >&2
+      echo "  FIX: restore it under offlineMirror.hostProjects in values.yaml. Dropping a mapped host makes step-03 Phase A3 FATAL with 'unmapped=N' and the cutover stops before step-04." >&2
+      rc=1
+    fi
+  done
+  [ "${rc}" -eq 0 ] && echo "  all ${#REQUIRED_PAIRS[@]} required host:project entries present"
+
+  # ---- CONTRACT: inverse-lookup ordering (#5095) --------------------------
+  local proj want_first seen_first
+  for proj in "${!FIRST_HOST_FOR_PROJECT[@]}"; do
+    want_first="${FIRST_HOST_FOR_PROJECT[$proj]}"
+    seen_first=""
+    for tok in ${first_map}; do
+      case "${tok}" in
+        *:"${proj}") seen_first="${tok%%:*}"; break ;;
+      esac
+    done
+    if [ -n "${seen_first}" ] && [ "${seen_first}" != "${want_first}" ]; then
+      echo "FAIL: project '${proj}' is first claimed by host '${seen_first}', expected '${want_first}' (#5095)" >&2
+      echo "  The mothership-proxy direct-source fallback walks the map and takes the FIRST host whose project matches; a redirector ordered ahead of the real registry retargets every fallback at the redirector." >&2
+      rc=1
+    fi
+  done
+
+  # ---- LOCKSTEP: step-02 creates every project the map names --------------
+  local mirror_projects mp mp_found
+  mirror_projects="$(extract_mirror_projects "${render}")"
+  if [ -z "${mirror_projects}" ]; then
+    echo "FAIL[vacuity]: could not extract step-02's mirror-project loop from the render — the lockstep check would be vacuous (#5442)" >&2
+    return 1
+  fi
+  for tok in ${first_map}; do
+    mp="${tok#*:}"
+    [ -z "${mp}" ] && continue          # host-swap entry: no project to create
+    mp_found=0
+    for want in ${mirror_projects}; do
+      [ "${mp}" = "${want}" ] && { mp_found=1; break; }
+    done
+    if [ "${mp_found}" -ne 1 ]; then
+      echo "FAIL: HOST_PROJECT_MAP maps '${tok%%:*}' to Harbor project '${mp}', which step-02 does NOT create (#5442)" >&2
+      echo "  step-02 creates: ${mirror_projects}" >&2
+      echo "  FIX: add '${mp}' to harbor.mirrorProjects in values.yaml — otherwise step-03's skopeo push 404s on a non-existent project and one cutover failure is merely traded for a later one." >&2
+      rc=1
+    fi
+  done
+  [ "${rc}" -eq 0 ] && echo "  every mapped project is created by step-02 (${mirror_projects})"
+
+  return "${rc}"
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+echo "[offline-mirror-host-projects] rendering ${CHART_DIR}"
+if ! render_chart "${CHART_DIR}" "${TMP}/render.yaml"; then
+  echo "ERROR: helm template failed for ${CHART_DIR}" >&2
+  sed 's/^/  /' "${TMP}/render.yaml.err" >&2 || true
+  exit 2
+fi
+
+echo "[offline-mirror-host-projects] POSITIVE: the shipped chart satisfies the coverage contract"
+if ! check_render "${TMP}/render.yaml"; then
+  exit 1
+fi
+echo "  PASS"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# NEGATIVE self-tests — a guard that has never been observed to fail is not a
+# guard. Each mutates ONE value in a throwaway copy of the chart, renders THAT
+# copy, and asserts check_render rejects it.
+mutate_and_expect_fail() {
+  # $1 = human label, $2 = yq expression applied to the copy's values.yaml,
+  # $3 = substring the failure message must contain.
+  local label="$1" expr="$2" want_msg="$3"
+  local dir="${TMP}/mut-$(printf '%s' "${label}" | tr -c 'A-Za-z0-9' '_')"
+  rm -rf "${dir}"; cp -r "${CHART_DIR}" "${dir}"
+  yq -i "${expr}" "${dir}/values.yaml"
+  if ! render_chart "${dir}" "${dir}/render.yaml"; then
+    echo "SELF-TEST FAIL[${label}]: the mutated chart did not render at all — the negative test proves nothing" >&2
+    sed 's/^/  /' "${dir}/render.yaml.err" >&2 || true
+    return 1
+  fi
+  local out rc
+  set +e
+  out="$(check_render "${dir}/render.yaml" 2>&1)"
+  rc=$?
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    echo "SELF-TEST FAIL[${label}]: the guard PASSED a chart it must reject — it does not actually defend the map (#5442)" >&2
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qF "${want_msg}"; then
+    echo "SELF-TEST FAIL[${label}]: the guard failed, but not for the expected reason. Wanted a message containing:" >&2
+    echo "    ${want_msg}" >&2
+    echo "  got:" >&2
+    printf '%s\n' "${out}" | sed 's/^/    /' >&2
+    return 1
+  fi
+  echo "  PASS[${label}] — rejected, and for the right reason:"
+  printf '%s\n' "${out}" | grep -F "${want_msg}" | sed 's/^/    /'
+  return 0
+}
+
+echo "[offline-mirror-host-projects] NEGATIVE 1: removing the cgr.dev mapping must FAIL"
+mutate_and_expect_fail "drop-cgr" \
+  'del(.offlineMirror.hostProjects[] | select(.host == "cgr.dev"))' \
+  "missing the required entry 'cgr.dev:proxy-chainguard'"
+
+echo "[offline-mirror-host-projects] NEGATIVE 2: removing the Scarf-gateway mapping must FAIL"
+mutate_and_expect_fail "drop-scarf" \
+  'del(.offlineMirror.hostProjects[] | select(.host == "litmuschaos.docker.scarf.sh"))' \
+  "missing the required entry 'litmuschaos.docker.scarf.sh:proxy-dockerhub'"
+
+echo "[offline-mirror-host-projects] NEGATIVE 3: breaking the step-02 lockstep must FAIL"
+mutate_and_expect_fail "drop-project" \
+  'del(.harbor.mirrorProjects[] | select(. == "proxy-chainguard"))' \
+  "which step-02 does NOT create"
+
+echo "[offline-mirror-host-projects] NEGATIVE 4: ordering the Scarf gateway AHEAD of docker.io must FAIL"
+mutate_and_expect_fail "scarf-first" \
+  '.offlineMirror.hostProjects = [{"host":"litmuschaos.docker.scarf.sh","project":"proxy-dockerhub"}] + (.offlineMirror.hostProjects | map(select(.host != "litmuschaos.docker.scarf.sh")))' \
+  "expected 'docker.io'"
+
+echo "[offline-mirror-host-projects] NEGATIVE 5: an EMPTY render must be rejected as vacuous"
+: > "${TMP}/empty.yaml"
+set +e
+empty_out="$(check_render "${TMP}/empty.yaml" 2>&1)"
+empty_rc=$?
+set -e
+if [ "${empty_rc}" -eq 0 ]; then
+  echo "SELF-TEST FAIL[empty-render]: the guard PASSED an EMPTY render — it is a trivially-green grep, not a guard (#5442)" >&2
+  exit 1
+fi
+if ! printf '%s' "${empty_out}" | grep -qF "FAIL[vacuity]"; then
+  echo "SELF-TEST FAIL[empty-render]: an empty render was rejected, but not by the vacuity gate:" >&2
+  printf '%s\n' "${empty_out}" | sed 's/^/    /' >&2
+  exit 1
+fi
+echo "  PASS[empty-render] — rejected by the vacuity gate:"
+printf '%s\n' "${empty_out}" | sed 's/^/    /'
+
+echo "[offline-mirror-host-projects] ALL CHECKS PASSED (positive + 5 negative)"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -449,6 +449,13 @@ harbor:
     - "proxy-k8s"
     - "proxy-gcr"
     - "proxy-ecr"
+    # #5442 — Chainguard (cgr.dev). Kept in LOCKSTEP with the
+    # offlineMirror.hostProjects entry below: any host mapped to a project name
+    # this list does not create makes step-03's skopeo push 404 on a
+    # non-existent project, trading one cutover failure for a later one.
+    # tests/offline-mirror-host-projects.sh asserts the lockstep from the
+    # RENDER, in both directions.
+    - "proxy-chainguard"
   # Proxy-cache project(s) that REMAIN pull-through. Only `proxy-xpkg`:
   # Crossplane's xpkg fetcher (internal/xpkg/fetch.go remote.Image) bypasses
   # the node containerd mirror, so step-11 (crossplaneProviderPivot) — NOT the
@@ -527,6 +534,52 @@ offlineMirror:
     # already creates proxy-gcr (harbor.mirrorProjects), so no new project.
     - host: "mirror.gcr.io"
       project: "proxy-gcr"
+    # #5442 (Refs #4975 #5443) — Scarf DOWNLOAD-GATEWAY in front of Docker Hub.
+    # bp-litmus's upstream subchart (litmuschaos/litmus 3.28.0) defaults its
+    # image registry to `litmuschaos.docker.scarf.sh`, so a default-values
+    # render of the PINNED catalog chart declares 4 refs on that host
+    # (litmusportal-frontend / -server / -auth-server / mongo:6) that no
+    # in-repo values.yaml mentions — which is why the authoring-time scan
+    # (tests/image-registry-coverage.sh, whose surface is this repo's chart
+    # values) could not see it and the step-03 Phase A3 guard surfaced it at
+    # runtime on live hw291 as `unmapped=5`.
+    #
+    # It is NOT a distinct registry: `GET https://litmuschaos.docker.scarf.sh/v2/`
+    # answers 401 with `www-authenticate: Bearer realm="https://auth.docker.io/
+    # token",service="registry.docker.io"` — it delegates auth to Docker Hub's
+    # own token service — and an unauthenticated pull through it returns Docker
+    # Hub's verbatim rate-limit body ("You have reached your unauthenticated
+    # pull rate limit. https://www.docker.com/increase-rate-limit"). So it is a
+    # redirector whose content IS Docker Hub content: reuse proxy-dockerhub,
+    # exactly as #4975 folded mirror.gcr.io into proxy-gcr. Path is preserved,
+    # so `litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.28.0`
+    # resolves to registry.<fqdn>/proxy-dockerhub/litmuschaos/
+    # litmusportal-frontend:3.28.0 — the SAME local path the docker.io form
+    # resolves to, so the two dedupe instead of double-storing.
+    #
+    # ORDER MATTERS: this entry sits AFTER `docker.io:proxy-dockerhub` because
+    # step-03 copy_one + step-08 self-heal derive the mothership-proxy
+    # direct-source fallback (#5095) by an INVERSE map walk that takes the
+    # FIRST host whose project matches — proxy-dockerhub must keep resolving
+    # back to docker.io, not to the gateway. Same reason mirror.gcr.io is
+    # listed after gcr.io.
+    - host: "litmuschaos.docker.scarf.sh"
+      project: "proxy-dockerhub"
+    # #5442 (Refs #4975) — Chainguard's registry. bp-sigstore's upstream
+    # subchart (sigstore/policy-controller) pins its leases-cleanup Job at
+    # `cgr.dev/chainguard/kubectl:latest-dev`; same discovery path as the Scarf
+    # host above (upstream subchart default, invisible to the repo-values scan,
+    # surfaced by the runtime Phase A3 guard on hw291).
+    #
+    # Unlike Scarf this IS a genuinely distinct registry — cgr.dev is served by
+    # Chainguard's own front-end (`GET https://cgr.dev/v2/` answers 405 from
+    # `server: Google Frontend`, no Docker Hub delegation) and its content
+    # exists nowhere in the Docker Hub / GCR / Quay namespaces — so it gets its
+    # OWN project. `proxy-chainguard` is added to harbor.mirrorProjects in
+    # LOCKSTEP (step-02 must create the project or step-03's push 404s and this
+    # failure is merely traded for a later one).
+    - host: "cgr.dev"
+      project: "proxy-chainguard"
     - host: "public.ecr.aws"
       project: "proxy-ecr"
     # MOTHERSHIP — host-swap, path preserved. Must equal the host of

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.156"
+  version: "0.1.157"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.156"
+    version: "0.1.157"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #5442

## The stall

Cutover step-03 `harbor-prewarm` failed the #5442 Phase A3 guard on live hw291:

```
copy_fail=0   durable_miss=0   unmapped=5
```

Nothing was broken. `ok=36 fail=0` and all 144 local image paths were durably present. Five image references simply lived on two registry hosts absent from `offlineMirror.hostProjects`, so the guard correctly refused to let step-05 pivot Flux onto charts the local registry could not fully serve.

## The five references, located

Both hosts come from **upstream sub-chart defaults**, so no file in this repo names either one. That is exactly why the authoring-time scan (`tests/image-registry-coverage.sh`, whose scan surface is this repo's chart values) could not have caught them — a default-values render of the pinned catalog charts is the only place they appear, which is the enumeration 0.1.154 added.

Reproduced locally with the same mechanic `chart_declared_images` uses (`helm template <chart> --namespace catalog-prewarm`, then the image-scalar grep):

`platform/litmus/chart` (bp-litmus -> `litmuschaos/litmus` 3.28.0) renders **4**:

```
litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.28.0
litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.28.0
litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.28.0
litmuschaos.docker.scarf.sh/litmuschaos/mongo:6
```

`platform/sigstore/chart` (bp-sigstore -> `sigstore/policy-controller`) renders **1**:

```
cgr.dev/chainguard/kubectl:latest-dev
```

4 + 1 = 5. **The count matches the guard exactly** — no discrepancy, no sixth host hiding behind a conditional.

Note the shape: `platform/litmus/chart/values.yaml` pins `frontend.image.repository: litmuschaos/litmusportal-frontend`, but the upstream chart supplies the registry prefix, so the ref only becomes a Scarf ref at render time. A values grep sees `litmuschaos/...`; only the render sees the host.

## Project assignment, decided on evidence

**`litmuschaos.docker.scarf.sh` -> `proxy-dockerhub`** (existing project, no new one).

Verified rather than assumed — the Scarf gateway is a redirector in front of Docker Hub, and it says so twice:

```
$ curl -sSI https://litmuschaos.docker.scarf.sh/v2/
HTTP/2 401
docker-distribution-api-version: registry/2.0
www-authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io"
```

It delegates auth to Docker Hub's own token service for service `registry.docker.io`. And an unauthenticated pull through it returns Docker Hub's verbatim body:

```
$ skopeo inspect --raw docker://litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.28.0
level=fatal msg="... toomanyrequests: You have reached your unauthenticated pull rate limit.
https://www.docker.com/increase-rate-limit"
```

So it is Docker Hub content and folds into `proxy-dockerhub`, exactly as #4975 folded `mirror.gcr.io` into `proxy-gcr`. The path is preserved, so `litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.28.0` resolves to `registry.<fqdn>/proxy-dockerhub/litmuschaos/litmusportal-frontend:3.28.0` — the identical local path the `docker.io` form resolves to, so the two dedupe through the #4994 byte-identical skip instead of double-storing.

**Ordering matters and is now asserted.** The entry sits *after* `docker.io:proxy-dockerhub` because step-03 `copy_one` and step-08's self-heal derive the #5095 mothership-proxy direct-source fallback by walking the map and taking the **first** host whose project matches. A redirector ordered ahead of the real registry would silently retarget every fallback at the redirector. Same reason `mirror.gcr.io` sits after `gcr.io`.

**`cgr.dev` -> `proxy-chainguard`** (new project).

Chainguard is a genuinely distinct registry — no Docker Hub delegation, its own front-end:

```
$ curl -sSI https://cgr.dev/v2/
HTTP/2 405
server: Google Frontend
```

and `cgr.dev/chainguard/kubectl:latest-dev` inspects anonymously to a real OCI index, so the mirror copy needs no credential.

## Step-02's project list DID need a matching change

`harbor.mirrorProjects` (values.yaml) is what step-02 `harbor-projects` loops over to create the public push-mode projects. `proxy-dockerhub` was already there, so the Scarf host needed nothing. `proxy-chainguard` was not — mapping a host to a project step-02 never creates would have made step-03's skopeo push 404 on a non-existent project, trading this failure for a later one. Added in lockstep, and the new guard now asserts that lockstep from the render so it cannot drift again.

## New render guard

`platform/self-sovereign-cutover/chart/tests/offline-mirror-host-projects.sh` — picked up automatically by the existing `chart/tests/*.sh` gate in `blueprint-release.yaml`.

It asserts against the **render**, not `values.yaml`: `_helpers.tpl` `hostProjectMapInline` is what the steps actually consume, and a values key can be present without reaching the env (renamed helper, dropped `range`, a consumer that stopped mounting the map).

**Vacuity gate first**, because `grep -q 'cgr.dev' render.yaml` passes trivially against an empty render:

- the render must be non-empty;
- `HOST_PROJECT_MAP` must appear in >= 3 consuming steps;
- its value must extract, be non-empty, and parse into a real token list;
- every occurrence must be byte-identical (one source of truth, per #4975);
- step-02's mirror-project loop must extract, or the lockstep check would itself be vacuous.

Then the contract: every required `host:project` pair present as a **whole token** (never a substring grep — `cgr.dev` appears in prose comments too, and a substring match would happily accept a mis-projected `cgr.dev:proxy-dockerhub`), the #5095 first-host-per-project ordering, and no project the map names that step-02 fails to create.

It ships **5 negative self-tests that run on every CI invocation**, not behind a flag — a guard whose failure path has never been observed is a trivially-green grep, not a guard.

## Both-directions proof, surgical

Rendered directly, one value at a time — not through the suite, which under `set -e` could abort earlier and hide which assertion actually fired.

**Direction A — shipped chart:**

```
helm rc=0  render lines=12086
HOST_PROJECT_MAP = "ghcr.io:proxy-ghcr docker.io:proxy-dockerhub registry-1.docker.io:proxy-dockerhub
index.docker.io:proxy-dockerhub quay.io:proxy-quay registry.k8s.io:proxy-k8s gcr.io:proxy-gcr
k8s.gcr.io:proxy-gcr mirror.gcr.io:proxy-gcr litmuschaos.docker.scarf.sh:proxy-dockerhub
cgr.dev:proxy-chainguard public.ecr.aws:proxy-ecr harbor.openova.io:"

GUARD EXIT = 0
  vacuity OK — map rendered in 4 step(s), identical everywhere, 13 host:project token(s)
  all 13 required host:project entries present
  every mapped project is created by step-02 (proxy-ghcr proxy-dockerhub proxy-quay proxy-k8s
  proxy-gcr proxy-ecr proxy-chainguard)
```

**Direction B — exactly one value removed, that chart rendered directly:**

```
$ diff <(yq -r '.offlineMirror.hostProjects[].host' chart/values.yaml) \
       <(yq -r '.offlineMirror.hostProjects[].host' B/values.yaml)
11d10
< cgr.dev

helm rc=0  render lines=12086      <- still renders; NOT a template break
GUARD EXIT = 1
  vacuity OK — map rendered in 4 step(s), identical everywhere, 12 host:project token(s)
FAIL: HOST_PROJECT_MAP is missing the required entry 'cgr.dev:proxy-chainguard' (#5442)
  FIX: restore it under offlineMirror.hostProjects in values.yaml. Dropping a mapped host makes
  step-03 Phase A3 FATAL with 'unmapped=N' and the cutover stops before step-04.
```

The mutated chart still renders 12086 lines at rc=0 and still clears the vacuity gate at 12 tokens, so the failure is the contract assertion catching a missing entry — not a template break masquerading as a guard hit, and not the vacuity floor stealing the diagnosis.

The remaining 4 negatives, same mechanic (mutate one value, render that copy, assert the verdict flips and the message is the right one):

```
PASS[drop-scarf]    FAIL: ... missing the required entry 'litmuschaos.docker.scarf.sh:proxy-dockerhub'
PASS[drop-project]  FAIL: ... maps 'cgr.dev' to Harbor project 'proxy-chainguard', which step-02 does NOT create
PASS[scarf-first]   FAIL: project 'proxy-dockerhub' is first claimed by host 'litmuschaos.docker.scarf.sh', expected 'docker.io' (#5095)
PASS[empty-render]  FAIL[vacuity]: render is empty — every host assertion below would pass trivially
```

## Lockstep + gates

Chart `0.1.156` -> `0.1.157`, all four surfaces:

- `platform/self-sovereign-cutover/chart/Chart.yaml`
- `platform/self-sovereign-cutover/blueprint.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — **both** `spec.version` (display) and `spec.source.version` (source)
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`

Gates run:

```
$ cd tests/e2e/bootstrap-kit && go test -count=1 ./...
ok  github.com/openova-io/openova/tests/e2e/bootstrap-kit  0.429s

$ for s in platform/self-sovereign-cutover/chart/tests/*.sh; do ...; done
catalog-chart-set.sh            PASS
cutover-contract.sh             PASS
image-registry-coverage.sh      PASS
offline-mirror-host-projects.sh PASS   <- new
single-platform-copy.sh         PASS
step06-pivot-readback.sh        PASS

$ helm lint platform/self-sovereign-cutover/chart
1 chart(s) linted, 0 chart(s) failed
```

## Blast radius

Values-only for the runtime path — no template, step-count, RBAC, or deadline change; still 11 steps. The map is additive, so no existing host resolves differently. The one behavioural note worth carrying forward: the Scarf copies source through Docker Hub, so they carry the same unauthenticated rate-limit exposure every direct `docker.io` copy in the prewarm already carries, bounded by the existing `prewarm.proxyCopyAttempts` / `proxyBackoffBaseSeconds` retry envelope.

No live-cluster mutation. No NodePort.

Generated catalog artifacts (`products/catalyst/bootstrap/api/internal/catalog/blueprints.json`, `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts`) are left untouched: they are marked AUTO-GENERATED, are regenerated by `build-catalog.mjs`, and already carry `0.1.87` for this chart on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
