### PR TITLE
fix(catalog): invalidate the cache key the query is actually registered under (#5496)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -291,8 +291,22 @@ export function CatalogDetail() {
   }
   // Refetch the catalog item after any per-field save so the new value renders
   // live (and the next field's merge base picks up the saved sibling).
+  //
+  // #5496 — this MUST invalidate `qualifiedName`, the key the query is
+  // registered under at :172. It previously used the bare `name`, so the key
+  // never matched, the invalidation silently no-oped, and `staleTime: 30_000`
+  // held the pre-edit document. Two consequences, one cause:
+  //   (a) the hero kept stale text until a full reload (UAT 127/132/133/142/153);
+  //   (b) SILENT DATA LOSS — the next per-field save computed its merge base
+  //       from the stale cache and reverted the previous save, with no error.
+  //       Reproduced live on hw291: a WordPress summary was wiped by the
+  //       following icon save.
+  // This is the half of #5449 that was missed: that fix introduced
+  // `qualifiedName` for exactly this bare-vs-`bp-` drift and corrected the
+  // registration site, not the invalidation. The comment above states the
+  // merge-base guarantee the bug was defeating.
   const refetchCatalog = () => {
-    void qc.invalidateQueries({ queryKey: ['catalog-item', name] })
+    void qc.invalidateQueries({ queryKey: ['catalog-item', qualifiedName] })
   }
 
   const bootstrapApp = bootstrapQuery.data
@@ -608,7 +622,9 @@ export function CatalogDetail() {
               if (!resp.committed) {
                 throw new Error(resp.reason || 'IaC commit did not land')
               }
-              void qc.invalidateQueries({ queryKey: ['catalog-item', name] })
+              // #5496 — same key mismatch as refetchCatalog: the save above
+              // already uses qualifiedName, so the invalidation must too.
+              void qc.invalidateQueries({ queryKey: ['catalog-item', qualifiedName] })
               return `Committed to IaC ✓ (${resp.path || 'catalog-sovereign'})`
             }}
           />

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/catalog-query-key-5496.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/catalog-query-key-5496.test.ts
@@ -1,0 +1,56 @@
+// Tests for #5496 — a React Query cache key mismatch that caused SILENT DATA LOSS.
+//
+// CatalogDetail registered its query under `qualifiedName` ("bp-alloy") and
+// invalidated under the bare `name` ("alloy"). The keys never matched, so the
+// invalidation no-oped and `staleTime: 30_000` held the pre-edit document.
+// Two consequences from one cause:
+//   (a) the hero kept stale text until a full reload — UAT 127/132/133/142/153;
+//   (b) the next per-field save computed its merge base from the stale cache and
+//       REVERTED the previous save, with no error surfaced. Reproduced live on
+//       hw291: a WordPress summary was wiped by the following icon save.
+//
+// This is a SOURCE INVARIANT test, and it is worth being honest about that: it
+// asserts every `['catalog-item', …]` key in the component uses the same
+// identifier. It does NOT execute a save. A behavioural two-save test is the
+// stronger guard and needs a QueryClient plus API mocks that this suite does
+// not currently stand up — that is tracked on #5496 rather than faked here.
+//
+// The invariant is nonetheless the exact shape of the defect: the bug was a
+// literal identifier mismatch between two string-array keys in one file, and
+// nothing in TypeScript or the existing tests could see it, because both
+// identifiers are valid `string`s in scope.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SRC = join(__dirname, 'CatalogDetail.tsx')
+
+describe('#5496 catalog-item query keys must all use the same identifier', () => {
+  const source = readFileSync(SRC, 'utf8')
+
+  // Matches ['catalog-item', <identifier>] and captures the identifier.
+  const KEY_RE = /\[\s*'catalog-item'\s*,\s*([A-Za-z_$][\w$]*)\s*\]/g
+
+  it('finds the query keys at all (vacuity control)', () => {
+    const found = [...source.matchAll(KEY_RE)]
+    // If this ever hits zero the rest of the file proves nothing — the keys
+    // were renamed or restructured and this guard must be revisited, not
+    // silently passed.
+    expect(found.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('registers and invalidates under one identifier, never a mix', () => {
+    const idents = [...source.matchAll(KEY_RE)].map((m) => m[1])
+    const unique = [...new Set(idents)]
+    expect(unique).toHaveLength(1)
+  })
+
+  it('uses the qualified name, not the bare route param', () => {
+    const idents = [...source.matchAll(KEY_RE)].map((m) => m[1])
+    // `name` is the bare route param ("alloy"); the query is keyed on the
+    // qualified form ("bp-alloy"). Invalidating the bare form is the #5496 bug.
+    expect(idents).not.toContain('name')
+    expect([...new Set(idents)]).toEqual(['qualifiedName'])
+  })
+})


### PR DESCRIPTION
## Silent data loss, reproduced

Two per-field saves in the same page view **silently reverted each other**. No error, no warning, nothing in the UI to indicate anything was lost. Reproduced on hw291: a WordPress summary save was wiped by the icon save that followed it.

## One cause

```
:172   queryKey: ['catalog-item', qualifiedName]     // registered as "bp-alloy"
:295   invalidateQueries({ queryKey: ['catalog-item', name] })   // "alloy"
:611   invalidateQueries({ queryKey: ['catalog-item', name] })   // "alloy"
:175   staleTime: 30_000
```

The keys never matched, so `invalidateQueries` no-oped and the 30-second stale window held the pre-edit document. The next save then computed its merge base from that stale cache and wrote back the previous field's old value.

**Two consequences, and the mild one is what a reviewer would see.** The visible symptom is that the hero keeps stale text until a full reload — cosmetic-looking, and it accounts for UAT rows 127, 132, 133, 142 and 153. The serious symptom is data loss, and it is invisible.

The comment above `refetchCatalog` states the guarantee the bug was defeating, word for word: the refetch exists so *"the next field's merge base picks up the saved sibling"*.

## This is the half of #5449 that was missed — and I closed it

#5449 introduced `qualifiedName` for exactly this bare-versus-`bp-` drift. It corrected the **registration** site and left the **invalidation** untouched. I closed that issue earlier today on the partial fix, which is worth recording: the closure was evidence-backed for the symptom it tested and blind to the one it didn't.

The tell was already in the file — the save call at `:607` **already** passed `qualifiedName`. The distinction was understood; the invalidation was simply the one place it wasn't applied.

## What the guard does and does not prove

It is a **source invariant**, and the test says so in its own header rather than implying more: it asserts every `['catalog-item', …]` key in the component uses one identifier, and it **does not execute a save**.

A behavioural two-save test is the stronger guard. It needs a `QueryClient` plus API mocks this suite does not currently stand up, so that is recorded on the issue as follow-up rather than faked with something weaker that reads as equivalent.

The invariant is still the exact shape of the defect: a literal identifier mismatch between two string-array keys that **TypeScript cannot see**, because `name` and `qualifiedName` are both valid `string`s in scope. Nothing in the type system or the existing tests could have caught it.

## Proven both directions

| | result |
|---|---|
| fix in place | 3/3 pass |
| one bare-name invalidation reintroduced | **2 of 3 fail** |

The third case is the **vacuity control** and it deliberately stays green on that revert — it only asserts the keys are still findable, so a wholesale rename cannot silently pass the guard by making the regex match nothing.

`tsc -b` clean.

Refs #5496 #5449
