### PR TITLE
fix(jobs): resolve controller-generated Job names so Re-run works (#5496, UAT 176)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
@@ -233,7 +233,7 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 
 	case jobs.KindReconcile:
 		// Flux Kustomization — discover its namespace, then annotate.
-		ns, err := resolveObjectNamespace(ctx, dyn, helmwatch.KustomizationGVR, name)
+		ns, _, err := resolveObjectNamespace(ctx, dyn, helmwatch.KustomizationGVR, name)
 		if err != nil {
 			return "", err
 		}
@@ -245,7 +245,7 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 	case jobs.KindReconciler:
 		// Reconciler Deployment — bump the pod-template annotation to roll
 		// it (the Flux-native equivalent for a non-HR reconciler workload).
-		ns, err := resolveObjectNamespace(ctx, dyn, helmwatch.DeploymentGVR, name)
+		ns, _, err := resolveObjectNamespace(ctx, dyn, helmwatch.DeploymentGVR, name)
 		if err != nil {
 			return "", err
 		}
@@ -256,7 +256,7 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 
 	case jobs.KindCron:
 		// CronJob — create a one-off Job from its jobTemplate ("Run now").
-		ns, err := resolveObjectNamespace(ctx, dyn, helmwatch.CronJobGVR, name)
+		ns, _, err := resolveObjectNamespace(ctx, dyn, helmwatch.CronJobGVR, name)
 		if err != nil {
 			return "", err
 		}
@@ -289,13 +289,15 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 		// immutable fields stripped. A Job OWNED by a CronJob is re-driven
 		// through its CronJob ("Run now") instead — recreating a
 		// CronJob-managed Job standalone would orphan it from its owner.
-		ns, err := resolveObjectNamespace(ctx, dyn, helmwatch.JobGVR, name)
+		ns, jobName, err := resolveObjectNamespace(ctx, dyn, helmwatch.JobGVR, name)
 		if err != nil {
 			return "", err
 		}
-		old, err := dyn.Resource(helmwatch.JobGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+		// #5496 — Get the RESOLVED name: for a controller-generated Job the
+		// row name has no object behind it, only `<name>-<digits>` does.
+		old, err := dyn.Resource(helmwatch.JobGVR).Namespace(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
-			return "", fmt.Errorf("get Job %s/%s: %w", ns, name, err)
+			return "", fmt.Errorf("get Job %s/%s: %w", ns, jobName, err)
 		}
 		if cron := cronJobOwnerName(old); cron != "" {
 			runName, cerr := createJobFromCronJob(ctx, dyn, ns, cron, now)
@@ -551,19 +553,56 @@ func isControllerOwnedLabel(k string) bool {
 // don't persist their namespace on the Job, so we re-discover it at retry
 // time (the list is cheap + the name is unique within the cluster for these
 // reconciler objects). Returns an error when no/many matches.
-func resolveObjectNamespace(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, name string) (string, error) {
+//
+// #5496 (Refs #4845, UAT 176) — it ALSO resolves the object's real name. The
+// Jobs page passes a reconciler-row name (`cutover-harbor-prewarm`) while the
+// controller names the actual Job with a generated numeric suffix
+// (`cutover-harbor-prewarm-1785348872`). Exact-match-only meant no candidate
+// was ever found, so Re-run rendered on a genuinely-failed row and always
+// returned 422. #4845 converted that from a raw 502 into a graceful 422; it
+// never made suffixed Jobs resolvable.
+//
+// The suffix match is deliberately NARROW: `<name>-<digits>` only. A bare
+// prefix match is the #5485 defect in a new place — there, `bp-velero` matched
+// `bp-velero-hcs` and the reconciler drill-in served an operator 100%
+// wrong-object logs. `hcs` is not digits, so it cannot match here.
+//
+// When several digit-suffixed candidates exist, the NEWEST by creation
+// timestamp wins — the most recent attempt, which is what Re-run means.
+func resolveObjectNamespace(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, name string) (string, string, error) {
 	list, err := dyn.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return "", fmt.Errorf("list %s to resolve namespace of %q: %w", gvr.Resource, name, err)
+		return "", "", fmt.Errorf("list %s to resolve namespace of %q: %w", gvr.Resource, name, err)
 	}
 	ns := ""
 	for i := range list.Items {
 		if list.Items[i].GetName() == name {
 			if ns != "" && ns != list.Items[i].GetNamespace() {
-				return "", fmt.Errorf("%s %q exists in multiple namespaces; cannot disambiguate for retry", gvr.Resource, name)
+				return "", "", fmt.Errorf("%s %q exists in multiple namespaces; cannot disambiguate for retry", gvr.Resource, name)
 			}
 			ns = list.Items[i].GetNamespace()
 		}
+	}
+	if ns != "" {
+		return ns, name, nil
+	}
+	genNS, genName := "", ""
+	var genAt metav1.Time
+	for i := range list.Items {
+		cand := list.Items[i].GetName()
+		if !hasGeneratedNumericSuffix(cand, name) {
+			continue
+		}
+		at := list.Items[i].GetCreationTimestamp()
+		if genName != "" && genNS != list.Items[i].GetNamespace() {
+			return "", "", fmt.Errorf("%s %q resolves to generated names in multiple namespaces; cannot disambiguate for retry", gvr.Resource, name)
+		}
+		if genName == "" || at.After(genAt.Time) {
+			genNS, genName, genAt = list.Items[i].GetNamespace(), cand, at
+		}
+	}
+	if genName != "" {
+		return genNS, genName, nil
 	}
 	if ns == "" {
 		// #4845: a synthetic AGGREGATE reconciler (e.g. the "Trivy Security
@@ -572,9 +611,25 @@ func resolveObjectNamespace(ctx context.Context, dyn dynamic.Interface, gvr sche
 		// resolve fails. That is NOT a server fault — the row simply has no
 		// directly-retryable backing. Wrap with errNotDirectlyRetryable so
 		// the HTTP handler returns a graceful 422 instead of a raw 502.
-		return "", fmt.Errorf("%s %q not found in any namespace: %w", gvr.Resource, name, errNotDirectlyRetryable)
+		return "", "", fmt.Errorf("%s %q not found in any namespace: %w", gvr.Resource, name, errNotDirectlyRetryable)
 	}
-	return ns, nil
+	return ns, name, nil
+}
+
+// hasGeneratedNumericSuffix reports whether cand is exactly base + "-" +
+// one-or-more digits. This is the ONLY accepted suffix shape, so a sibling
+// whose name merely starts with base (bp-velero vs bp-velero-hcs, the #5485
+// collision) can never match.
+func hasGeneratedNumericSuffix(cand, base string) bool {
+	if len(cand) <= len(base)+1 || !strings.HasPrefix(cand, base) || cand[len(base)] != '-' {
+		return false
+	}
+	for _, r := range cand[len(base)+1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // jobRetryableStatus reports whether a leaf's status warrants a retry

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry_suffix_5496_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry_suffix_5496_test.go
@@ -1,0 +1,72 @@
+// Tests for #5496 (Refs #4845, UAT 176) — Re-run returned 422 on a genuinely
+// failed row because the resolver matched exact names only.
+//
+// The Jobs page passes a reconciler-row name (`cutover-harbor-prewarm`) while
+// the controller names the real Job with a generated numeric suffix
+// (`cutover-harbor-prewarm-1785348872`, observed live on hw291). No exact
+// match meant ns == "", wrapped in errNotDirectlyRetryable → graceful 422.
+// #4845 turned a raw 502 into that 422; it never made suffixed Jobs resolvable.
+//
+// The suffix rule is deliberately NARROW, and the bp-velero case below is the
+// reason: a bare prefix match is the #5485 defect in a new place, where
+// `bp-velero` matched `bp-velero-hcs` and the drill-in served 100% wrong-object
+// logs. Anything looser than `<name>-<digits>` reintroduces it.
+//
+// Vacuity: the suite asserts real positives AND real negatives, so neither a
+// match-everything nor a match-nothing implementation can pass.
+
+package handler
+
+import "testing"
+
+func TestHasGeneratedNumericSuffix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		cand string
+		base string
+		want bool
+	}{
+		// The live hw291 shapes — these fail against exact-match-only code.
+		{"cutover job with unix-ish suffix", "cutover-harbor-prewarm-1785348872", "cutover-harbor-prewarm", true},
+		{"gitea mirror", "cutover-gitea-mirror-1785356082", "cutover-gitea-mirror", true},
+		{"single digit", "some-job-7", "some-job", true},
+
+		// THE #5485 COLLISION — the case that must never match.
+		{"bp-velero must not match bp-velero-hcs", "bp-velero-hcs", "bp-velero", false},
+		{"bp-cnpg must not match bp-cnpg-pair", "bp-cnpg-pair", "bp-cnpg", false},
+
+		// Other non-digit suffixes.
+		{"alphanumeric suffix", "some-job-7a", "some-job", false},
+		{"hash-like suffix", "admin-865b6dd6c7", "admin", false},
+		{"nested name, digits deeper", "some-job-extra-1", "some-job", false},
+
+		// Boundary shapes.
+		{"exact name is not a generated suffix", "some-job", "some-job", false},
+		{"trailing dash with no digits", "some-job-", "some-job", false},
+		{"no separator", "some-job1", "some-job", false},
+		{"shorter than base", "some", "some-job", false},
+		{"empty candidate", "", "some-job", false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasGeneratedNumericSuffix(tc.cand, tc.base); got != tc.want {
+				t.Errorf("hasGeneratedNumericSuffix(%q, %q) = %v want %v", tc.cand, tc.base, got, tc.want)
+			}
+		})
+	}
+}
+
+// A match-everything implementation would pass every positive above; this
+// pins that it does not, by requiring the collision cases to be rejected
+// while a real generated name is still accepted.
+func TestHasGeneratedNumericSuffix_NotDegenerate(t *testing.T) {
+	t.Parallel()
+	if !hasGeneratedNumericSuffix("cutover-harbor-prewarm-1785348872", "cutover-harbor-prewarm") {
+		t.Fatal("a real generated Job name must resolve — a match-nothing resolver leaves UAT 176 unmet")
+	}
+	if hasGeneratedNumericSuffix("bp-velero-hcs", "bp-velero") {
+		t.Fatal("a match-everything resolver reintroduces the #5485 wrong-object collision")
+	}
+}


### PR DESCRIPTION
## The defect

Re-run rendered on a **genuinely failed** row and always returned `422 not directly retryable`.

The Jobs page passes a reconciler-row name; the controller names the real Job with a generated numeric suffix. Live on hw291 right now:

```
row name passed:  cutover-harbor-prewarm
actual Jobs:      cutover-harbor-prewarm-1785348872
                  cutover-gitea-mirror-1785356082
                  cutover-harbor-projects-1785356082
```

`resolveObjectNamespace` matched **exact names only**, so no candidate was ever found and the miss got wrapped in `errNotDirectlyRetryable`.

**#4845 is closed and covers this row** — but it only converted a raw 502 into that graceful 422. It never made suffixed Jobs resolvable. The affordance was present, honest about failing, and still unable to do what the row asserts. Same shape as #5449: closed on the half that was testable.

## The fix

The resolver now also returns the object's **real name**, because the Job caller does a `Get` with it and the row name has no object behind it. All four call sites updated; the three reconciler paths discard the resolved name since those objects carry exact names.

## The trap, and why the rule is narrow

The obvious approach is prefix matching. **Prefix matching is the #5485 defect in a new place** — there, `bp-velero` matched `bp-velero-hcs` and the reconciler drill-in served an operator **100% wrong-object logs**, which is worse than empty output because it looks like data.

So the accepted shape is `<name>-<digits>` and nothing else. `hcs` is not digits, so it cannot match. `admin-865b6dd6c7` cannot match `admin`. `some-job-7a` cannot match `some-job`.

When several digit-suffixed candidates exist, the **newest by creation timestamp** wins — the most recent attempt, which is what an operator clicking Re-run means. Candidates spanning namespaces keep the existing ambiguity error rather than guessing.

## What is deliberately preserved

The genuine #4845 case still behaves correctly: a **synthetic aggregate** row with no standalone backing Job (e.g. "Trivy Security Scan" aggregating `scan-vulnerabilityreport-*`) still returns `errNotDirectlyRetryable` → 422. The fix distinguishes *no Job exists* from *the Job has a generated suffix*; it does not flatten both into retryable.

## Tests — both directions, and non-degenerate

Fifteen cases. The two that carry the most weight are negatives: `bp-velero` must not match `bp-velero-hcs`, and `bp-cnpg` must not match `bp-cnpg-pair`.

| | result |
|---|---|
| fix in place | all pass |
| loosened to a bare prefix match | **8 failures**, including the explicit collision assertion |

`TestHasGeneratedNumericSuffix_NotDegenerate` pins both ends in one test, so **neither** a match-everything nor a match-nothing resolver can pass — a resolver that returned false for everything would satisfy every negative and leave UAT 176 exactly as broken as before.

Full `internal/handler` package green (169s).

Refs #5496 #4845 #5485
