### PR TITLE
fix(org-controller): name the pending boundary honestly for host-tier Orgs (Refs #5502)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -883,7 +883,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		readyCond.Message = readyOrgMessage(org.Spec.PlanSlug)
 	default:
 		readyCond.Status = "False"
-		readyCond.Reason = "VClusterProvisioning"
+		// #5502 (Refs #4813/#4292/#4339): name the pending reason off the SAME
+		// tier gate vclusterReadiness + readyOrgMessage use. vcMsg was already
+		// tier-aware here; the machine-readable Reason was not, so a host-tier
+		// Org waiting on its host NAMESPACE reported VClusterProvisioning and
+		// sent the diagnosis hunting a vCluster that is correctly never
+		// authored for that tier.
+		readyCond.Reason = pendingBoundaryReason(org.Spec.PlanSlug)
 		readyCond.Message = vcMsg
 	}
 	desired := orgapi.OrganizationStatus{
@@ -1053,6 +1059,34 @@ func readyOrgMessage(planSlug string) string {
 		return "vCluster HelmRelease Ready + Keycloak group + Gitea Org reconciled"
 	}
 	return "host namespace Active + Keycloak group + Gitea Org reconciled (namespace-isolated tier — no vCluster authored)"
+}
+
+// pendingBoundaryReason names the artifact a not-yet-Ready Org is ACTUALLY
+// waiting on, keyed off the same #4292/#4339 tier gate
+// (gitops.BoundaryIsVcluster) that vclusterReadiness and readyOrgMessage use.
+//
+// #4813 made the Ready=True *message* tier-aware for exactly this reason, but
+// the Ready=False *Reason* stayed hardcoded to "VClusterProvisioning". Reason
+// is the machine-readable field — it is what `kubectl get org -o jsonpath`,
+// operators, and tooling filter on — so a host-tier (""/s/free) Org, which
+// authors NO vCluster HelmRelease and whose host `<slug>` namespace IS the
+// boundary, reported that it was waiting on a vCluster.
+//
+// Observed cost (#5502): on hw291 the Org `uatcorp` (plan=s → namespace by
+// design) sat at Ready=False:VClusterProvisioning, and the acceptance walk
+// duly went hunting — `kubectl get vclusters -A` returned "No resources
+// found" in both regions and vcluster StatefulSets were 0, all of which is
+// the CORRECT state for that tier. The real missing artifact was the
+// `uatcorp` namespace. The honest explanation was already sitting in the
+// message; the Reason contradicted it.
+//
+// The vcluster tier keeps the original string, so nothing that legitimately
+// waits on a vCluster changes.
+func pendingBoundaryReason(planSlug string) string {
+	if gitops.BoundaryIsVcluster(planSlug) {
+		return "VClusterProvisioning"
+	}
+	return "NamespaceProvisioning"
 }
 
 // vclusterReadiness reads back the vCluster HelmRelease the controller

--- a/core/controllers/organization/internal/controller/pending_boundary_reason_5502_test.go
+++ b/core/controllers/organization/internal/controller/pending_boundary_reason_5502_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import "testing"
+
+// #5502: the Ready=False reason must name the artifact the Org is ACTUALLY
+// waiting on, keyed off the same #4292/#4339 tier gate that vclusterReadiness
+// and readyOrgMessage use.
+//
+// Both directions are asserted deliberately. A test that only checked the
+// host-tier branch would pass against a function that returned
+// "NamespaceProvisioning" unconditionally — which would be a NEW lie for the
+// vcluster tier, the exact mirror of the bug being fixed. Asserting only the
+// vcluster branch would have passed against the original hardcoded string and
+// caught nothing at all.
+func TestPendingBoundaryReasonIsTierAware(t *testing.T) {
+	// Host-tier: no vCluster HelmRelease is ever authored for these plans
+	// (gitops.Render omits vcluster.yaml), so the pending artifact is the host
+	// `<slug>` namespace. Reporting VClusterProvisioning here sent the hw291
+	// uatcorp walk hunting a vCluster that correctly does not exist.
+	for _, plan := range []string{"", "s", "S", "free", "  s  "} {
+		if got := pendingBoundaryReason(plan); got != "NamespaceProvisioning" {
+			t.Errorf("pendingBoundaryReason(%q) = %q, want NamespaceProvisioning (host-tier authors no vCluster HR)", plan, got)
+		}
+	}
+
+	// vcluster tier: unchanged — these plans really do wait on the vCluster HR.
+	for _, plan := range []string{"m", "l", "xl", "flexi", "M"} {
+		if got := pendingBoundaryReason(plan); got != "VClusterProvisioning" {
+			t.Errorf("pendingBoundaryReason(%q) = %q, want VClusterProvisioning (vcluster tier waits on the HR)", plan, got)
+		}
+	}
+}
+
+// The pending reason and the Ready=True message must agree about which
+// boundary backs the Org. If they ever disagree, one of the two is lying about
+// the same tier — the asymmetry #5502 fixed (honest message, wrong reason)
+// would reappear silently on any future edit to either helper.
+func TestPendingBoundaryReasonAgreesWithReadyOrgMessage(t *testing.T) {
+	cases := []struct {
+		plan          string
+		wantNamespace bool
+	}{
+		{"", true}, {"s", true}, {"free", true},
+		{"m", false}, {"l", false}, {"xl", false}, {"flexi", false},
+	}
+	for _, tc := range cases {
+		reasonSaysNamespace := pendingBoundaryReason(tc.plan) == "NamespaceProvisioning"
+		msg := readyOrgMessage(tc.plan)
+		msgSaysNamespace := msg == "host namespace Active + Keycloak group + Gitea Org reconciled (namespace-isolated tier — no vCluster authored)"
+
+		if reasonSaysNamespace != msgSaysNamespace {
+			t.Errorf("plan %q: pending reason and ready message disagree on the boundary (reason-says-namespace=%v, message-says-namespace=%v, message=%q)",
+				tc.plan, reasonSaysNamespace, msgSaysNamespace, msg)
+		}
+		if reasonSaysNamespace != tc.wantNamespace {
+			t.Errorf("plan %q: boundary = namespace? got %v want %v", tc.plan, reasonSaysNamespace, tc.wantNamespace)
+		}
+	}
+}


### PR DESCRIPTION
## What

The org-controller's `Ready=False` **reason** was hardcoded to `VClusterProvisioning`
regardless of tier. Now it names the artifact the Org is actually waiting on, keyed off
the same `#4292`/`#4339` tier gate (`gitops.BoundaryIsVcluster`) that `vclusterReadiness`
and `readyOrgMessage` already use:

| tier | plans | pending reason |
|---|---|---|
| host-tier | `""` / `s` / `free` | `NamespaceProvisioning` (new) |
| vcluster | `m` / `l` / `xl` / `flexi` | `VClusterProvisioning` (unchanged) |

## Why it mattered

A host-tier Org authors **no** vCluster HelmRelease — `gitops.Render` omits `vcluster.yaml`
for that tier and `vclusterReadiness` correctly short-circuits to host-namespace readiness.
The `Message` was already honest ("host-tier Org namespace not yet Active (no vCluster HR is
authored for this tier...)"), but `Reason` — the machine-readable field operators,
`kubectl -o jsonpath`, and tooling filter on — contradicted it.

`#4813` fixed exactly this asymmetry for the `Ready=True` message. The failure reason was
left behind.

**Observed cost on hw291.** Org `uatcorp` (kind=customer, plan=`s` → namespace-isolated
**by design**) sat at `Ready=False reason=VClusterProvisioning`. The acceptance walk
followed the reason and spent its investigation on a vCluster:

- `kubectl get vclusters -A` → `No resources found`, both regions
- vcluster StatefulSets = 0, both regions
- `status.vcluster.phase=Pending`

All three are the **correct** state for that tier. The real missing artifact was the
`uatcorp` namespace. This is the same "a control that reports rather than does" class the
surrounding `Ready-over-absent-backing` guard was written to prevent — the control was
reporting the wrong subsystem.

## Blast radius — checked before renaming a machine-readable field

- `orgStateFromCR` (`products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go`)
  switches on `status.vcluster.phase` and the Ready condition **status**; it never reads
  `Reason`. Console/directory state is unaffected.
- Repo-wide grep for the literal: one code site (fixed), one test assertion
  (`organization_controller_test.go:577`) whose fixture authors 11 files including
  `vcluster` — a **vcluster-tier** Org, so it stays green — plus prose in two Kyverno
  policy templates and two test comments.

## Verification

- `go build ./...` clean, `go vet ./internal/controller/` clean.
- New test asserts **both** directions. A one-sided assertion would pass against a
  function returning either string unconditionally: checking only host-tier would accept a
  new lie for the vcluster tier, and checking only vcluster would have accepted the
  original hardcoded string and caught nothing.
- A second test pins reason and message to agree per-tier, so the honest-message /
  wrong-reason split cannot silently reappear on a future edit to either helper.
- **Both-directions proof run, not just asserted**: reintroduced the defect (`sed` the
  return value) → guard FAILS on `""`/`s`/`free` and on the reason-vs-message
  cross-check; restored → PASSES. Full `internal/controller` package suite green.

Refs #5502
Refs #4813
Refs #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
