### PR TITLE
fix(kyverno): grant cilium read + narrow the Enforce flip to the NodePort ban (Refs #5505)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -154,7 +154,7 @@ spec:
       # mixed-source pods (proxy-cache sidecars + openova-io plugin) —
       # un-wedges huawei-evs-csi + its 24-HR dependency cascade (#5017,
       # #4973 family).
-      version: 1.0.49
+      version: 1.0.50
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.49
+  version: 1.0.50
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -326,7 +326,7 @@ type: application
 #   (helm.sh/hook annotation) — hooks get no Flux labels + Helm force-stamps
 #   managed-by:Helm, so a legit hook Job (bp-powerdns zone-bootstrap) was
 #   Enforce-denied on live upgrade, stranding the powerdns anycast NodePort.
-version: 1.0.49
+version: 1.0.50
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/rbac-cilium-read.yaml
+++ b/platform/kyverno-policies/chart/templates/rbac-cilium-read.yaml
@@ -1,0 +1,43 @@
+{{- /*
+#5505: Kyverno needs READ on cilium.io/ciliumnetworkpolicies.
+
+`14-networkpolicy-present.yaml` resolves a `cnpCount` context variable via an
+APICall to /apis/cilium.io/v2/namespaces/<ns>/ciliumnetworkpolicies. Kyverno's
+built-in aggregated roles grant networking.k8s.io (so the sibling `npCount`
+call works) but nothing under cilium.io, so `cnpCount` has NEVER resolved.
+
+While the policy sat at `action: Audit` the unresolvable context was merely
+reported and the request proceeded — the policy looked healthy and enforced
+nothing. When #5494 flipped it to Enforce, the same failure began DENYING
+through the fail-closed webhook (validate.kyverno.svc-fail,
+failurePolicy=Fail, whose rules include `namespaces`), so EVERY Namespace
+create on the Sovereign was rejected:
+
+  resource Namespace//uatcorp was blocked ... networkpolicy-present:
+    failed to resolve cnpCount ... ciliumnetworkpolicies: permission denied
+
+That took bootstrap-kit (Namespace/cnpg-system), org-tenants, and every
+per-Org Kustomization down with it.
+
+Granting the read is the durable fix: a policy whose context cannot resolve is
+not a guard, it is a reporter. Aggregated to Kyverno's admission + background
+controllers via the labels Kyverno itself watches, so this survives a Kyverno
+upgrade without patching vendor roles.
+*/ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bp-kyverno-policies-cilium-read
+  labels:
+    app.kubernetes.io/name: bp-kyverno-policies
+    app.kubernetes.io/managed-by: Helm
+    catalyst.openova.io/blueprint: bp-kyverno-policies
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups: ["cilium.io"]
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumclusterwidenetworkpolicies
+    verbs: ["get", "list", "watch"]

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -68,7 +68,7 @@ compliancePolicies:
   #     key bundle is supplied.
   multiReplica:
     enabled: true
-    action: Enforce
+    action: Audit
     # #4422: exempt deliberate single-replica stateful singletons (the per-Org
     # funnel cart's mysql/postgres single-PVC DBs + redis cache) by the
     # `openova.io/singleton-db: "true"` label the funnel generator stamps on the
@@ -149,12 +149,12 @@ compliancePolicies:
 
   pdb:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   topologySpread:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   probesPresent:
@@ -173,17 +173,17 @@ compliancePolicies:
 
   resourceLimits:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   pvcExpansion:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   hpaEffective:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   ciliumL7Mtls:
@@ -349,13 +349,13 @@ compliancePolicies:
 
   prometheusScrape:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   # K2 added policies
   networkpolicyPresent:
     enabled: true
-    action: Enforce
+    action: Audit
     # Match on Namespace kind — `excludeNamespaces` here is consumed via
     # `resources.names` (the namespace IS the resource). Same default
     # exemption set as the workload policies.
@@ -363,7 +363,7 @@ compliancePolicies:
 
   otelInjected:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   hubbleFlowsSeen:
@@ -372,12 +372,12 @@ compliancePolicies:
     # today is harmless (renders nothing) but reserved as the cutover
     # knob once W2 lands so operators can toggle a single flag.
     enabled: false
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   runAsNonRootReadonlyRootFs:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   cosignVerified:
@@ -387,7 +387,7 @@ compliancePolicies:
     # surface the config gap rather than silently passing. Operator
     # opts in per Sovereign once the cosign key bundle is supplied.
     enabled: false
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
     # Cosign verifyImages rule fields. Defaults reference openova-io
     # images only; operator extends per Sovereign.
@@ -403,12 +403,12 @@ compliancePolicies:
 
   secretNotInEnv:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   backupConfigured:
     enabled: true
-    action: Enforce
+    action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   # G92.6 (Refs #2665, 2026-06-01) — substrate-stays-on-host

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4622,7 +4622,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.49"
+  version: "1.0.50"
   visibility: unlisted
   card:
     title: "Kyverno Policy Library"
@@ -4639,7 +4639,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-kyverno-policies
-    version: "1.0.49"
+    version: "1.0.50"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
P0 regression I introduced in #5494. That PR was described as enforcing the
§854 NodePort ban; its diff actually flipped FIFTEEN policies from Audit to
Enforce. One of them, networkpolicy-present, resolves a cnpCount context via an
APICall to cilium.io/ciliumnetworkpolicies -- and Kyverno has no cilium.io
RBAC, so that call has never resolved. Under Audit the unresolvable context was
merely reported; under Enforce it began DENYING through the fail-closed webhook
validate.kyverno.svc-fail (failurePolicy=Fail, rules include namespaces), so
EVERY Namespace create on the Sovereign was rejected.

Control pair, same ServiceAccount, the policy's two APICalls:
  can-i get networkpolicies.networking.k8s.io -> yes   (npCount works)
  can-i get ciliumnetworkpolicies.cilium.io   -> no    (cnpCount fails)

Window: chart 1.0.48 deployed 11:47:54Z and Namespace/hw291-omantel-biz -- the
same shape as uatcorp -- was created 8s later. #5494 merged 18:56:24Z, chart
1.0.49 deployed 18:58:12Z, Namespace/uatcorp denied at 22:08:14Z. No namespace
has been created since 11:48:02Z. Blast radius was platform-wide: bootstrap-kit
wedged on Namespace/cnpg-system and cluster-autoscaler, org-tenants and all
three per-Org Kustomizations failing. It is also the upstream cause of a chain
diagnosed downstream this session -- no uatcorp namespace, so the org-controller
correctly holds Ready=False (#5502) while the console fabricates Active (#5501).

Two parts, both needed:

1. New aggregated ClusterRole grants Kyverno get/list/watch on
   ciliumnetworkpolicies + ciliumclusterwidenetworkpolicies, via the
   rbac.kyverno.io/aggregate-to-* labels Kyverno watches, so it survives a
   Kyverno upgrade without patching vendor roles. A policy whose context cannot
   resolve is not a guard, it is a reporter -- this one guarded nothing from the
   day it was written and Audit mode hid that.

2. The fourteen incidentally-flipped policies return to Audit.
   forbidNodePortService stays Enforce, which was the stated scope of #5494.
   The action map is now the seven policies that were Enforce before #5494 plus
   forbidNodePortService. Each of the others earns Enforce on its own evidence,
   with its context resolution proven first.

The guard I shipped with #5494 asserted the NodePort policy's own action and its
bootstrapMode behaviour, but never pinned WHICH OTHER policies changed action --
so a fourteen-policy blast radius passed a green gate. An action-flip guard has
to pin the whole map, not one entry.

Verified: helm lint clean, ClusterRole renders, the #5491 NodePort guard still
passes (forbidNodePortService remains Enforce), and the authoritative
tests/e2e/bootstrap-kit Go gate is green. Lockstep 1.0.49 -> 1.0.50 across
Chart.yaml, blueprint.yaml, catalog-seed display + source, and slot 27a.

Refs #5505
Refs #5491

🤖 Generated with [Claude Code](https://claude.com/claude-code)