### PR TITLE
fix(bp-postgres): bear the initdb owner with its managed-role Secret (Refs #5504)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -161,7 +161,7 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.14
+      version: 0.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -99,7 +99,7 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.14
+      version: 0.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -87,7 +87,7 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.14
+      version: 0.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -16,7 +16,10 @@ spec:
   # from the primary region (#4915 remedy class).
   # 0.2.14 (#5473): replication-source Service selectorType r -> rw; `r`
   # selected ALL instances, so a standby could serve as the DR source.
-  version: 0.2.14
+  # 0.2.15 (#5504): bootstrap.initdb.secret now names the owner's roleSecret;
+  # initdb previously minted the owner with the generated <cluster>-app
+  # password, so every consumer got 28P01 while CNPG reported reconciled.
+  version: 0.2.15
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,15 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.15 — #5504 (Refs #5499): the FIRST binding's owner was minted TWICE with
+# different credentials — bootstrap.initdb created it with CNPG's generated
+# `<cluster>-app` password, while managed.roles declared it with the
+# roleSecret. initdb's credential is what Postgres keeps, so every consumer
+# (handed the roleSecret) got SQLSTATE 28P01 while CNPG reported the role
+# `reconciled` over a password that never took effect. bootstrap.initdb.secret
+# now names the SAME roleSecret, so the role is born with one source of truth.
+# Proven live on hw291: shared-pg-harbor REJECTED as user harbor while
+# shared-pg-app AUTHENTICATED; gitea + keycloak (not the initdb owner) both
+# authenticated. Harbor down held cutover step-02/03 closed at 9%.
 # 0.2.14 — #5473 (Refs #4986): the cross-region replication-source Service
 # declared `selectorType: r`, which CNPG expands to a selector matching EVERY
 # instance (`cnpg.io/podRole: instance`), not the primary. The mesh Service
@@ -200,7 +210,7 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.14
+version: 0.2.15
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -81,6 +81,35 @@ spec:
       {{- $first := first .Values.databases }}
       database: {{ (default (dict) $first).name | default "app" | quote }}
       owner: {{ (default (dict) $first).owner | default "app" | quote }}
+      {{- if $first }}
+      {{- /*
+      #5504: the initdb OWNER must be born holding the SAME Secret the
+      managed.roles entry below declares for it.
+
+      Without this, the first binding's owner is created TWICE over: initdb
+      mints it with CNPG's auto-generated `<cluster>-app` credential, and
+      managed.roles then declares it with `passwordSecret: <roleSecretName>`.
+      The initdb credential is the one Postgres actually keeps, so every
+      consumer — which is handed the roleSecret — is rejected with
+      SQLSTATE 28P01, while CNPG reports the role as
+      `managedRolesStatus.byStatus.reconciled` over a password that never
+      took effect. The comment below asserts drift is "ALTER USER'd away";
+      proven false on hw291 for the initdb owner specifically.
+
+      Live proof (hw291, shared-pg, owner=harbor): shared-pg-harbor (len 32)
+      was REJECTED as user harbor while shared-pg-app (len 64) AUTHENTICATED.
+      `gitea` and `keycloak` — same chart, same managed.roles shape, but NOT
+      the initdb owner — both authenticated. That control isolates the owner
+      collision as the mechanism. Consequence was a hard Pillar-5 stall:
+      harbor-core/jobservice crashlooping took cutover step-02/03 down with
+      them and parked the chain at 9%.
+
+      Naming the same Secret in both places makes the role have ONE source of
+      truth from creation rather than two that CNPG silently ranks.
+      */}}
+      secret:
+        name: {{ include "bp-postgres.roleSecretName" (dict "ctx" $ "db" $first) | quote }}
+      {{- end }}
 
   {{- /*
   managed.roles — one declarative per-consumer login role per binding.

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -925,3 +925,67 @@ if ! printf '%s' "${repl_sel}" | grep -q 'catalyst.openova.io/role: replication-
   exit 1
 fi
 echo "  PASS (no 'selectorType: r' in the managed services block; replication-source present)"
+
+# ── #5504 — the initdb OWNER must be born holding the managed-role Secret ──
+# The first binding's owner is declared in TWO places: bootstrap.initdb.owner
+# (CNPG mints it during initdb) and managed.roles[] (passwordSecret). Without
+# bootstrap.initdb.secret, initdb mints the role with CNPG's auto-generated
+# `<cluster>-app` credential and that is the password Postgres KEEPS — so every
+# consumer, which is handed the roleSecret, gets SQLSTATE 28P01 while CNPG
+# reports the role `managedRolesStatus.byStatus.reconciled` over a password that
+# never took effect. Proven live on hw291: shared-pg-harbor (len 32) REJECTED as
+# user harbor, shared-pg-app (len 64) AUTHENTICATED; gitea + keycloak (same
+# chart, same managed.roles shape, NOT the initdb owner) both authenticated.
+# Harbor down took cutover step-02/03 with it and parked the chain at 9%.
+echo "[render] Case #5504: initdb owner Secret == its managed-role passwordSecret"
+seed_out=$(helm template shared-pg . \
+  --set enabled=true --set instance.name=shared-pg \
+  --set 'databases[0].name=registry' --set 'databases[0].owner=harbor' \
+  --set 'databases[1].name=gitea'    --set 'databases[1].owner=gitea' \
+  --api-versions postgresql.cnpg.io/v1 2>/dev/null)
+
+# VACUITY FIRST: a grep for a missing key "passes" trivially on an empty render.
+if ! printf '%s' "${seed_out}" | grep -q '^kind: Cluster'; then
+  echo "FAIL (#5504): no Cluster CR rendered — every assertion below is vacuous." >&2
+  exit 2
+fi
+if ! printf '%s' "${seed_out}" | grep -qE '^      owner: "harbor"'; then
+  echo "FAIL (#5504): initdb owner did not render — assertion vacuous." >&2
+  exit 2
+fi
+
+# The initdb block must carry a `secret:` naming the owner's role Secret.
+initdb_secret=$(printf '%s' "${seed_out}" \
+  | awk '/^  bootstrap:/,/^  managed:/' | awk '/^      secret:/{f=1;next} f&&/name:/{print $2;exit}')
+role_secret=$(printf '%s' "${seed_out}" \
+  | awk '/^    roles:/{f=1} f&&/- name: "harbor"/{g=1} g&&/name:/&&!/- name:/{print $2;exit}')
+
+if [ -z "${initdb_secret}" ]; then
+  echo "FAIL (#5504): bootstrap.initdb has no 'secret:' — the owner will be minted with the" >&2
+  echo "  auto-generated <cluster>-app credential and every consumer will get 28P01." >&2
+  exit 1
+fi
+if [ "${initdb_secret}" != "${role_secret}" ]; then
+  echo "FAIL (#5504): initdb secret ${initdb_secret} != managed-role passwordSecret ${role_secret}." >&2
+  echo "  Two credentials for one role; CNPG ranks initdb and reports the other reconciled." >&2
+  exit 1
+fi
+echo "  PASS (initdb secret == managed-role passwordSecret == ${initdb_secret})"
+
+# Guard the no-bindings fallback: with zero databases there is no owner Secret to
+# name, so initdb must NOT emit a dangling `secret:` (CNPG would fail to find it).
+nobind_vals="$(mktemp)"
+printf 'enabled: true\ninstance:\n  name: shared-pg\ndatabases: []\n' > "${nobind_vals}"
+empty_out=$(helm template shared-pg . -f "${nobind_vals}" \
+  --api-versions postgresql.cnpg.io/v1 2>/dev/null || true)
+rm -f "${nobind_vals}"
+if [ -z "${empty_out}" ]; then
+  echo "FAIL (#5504): the no-bindings render produced nothing — cannot assert the fallback." >&2
+  exit 2
+fi
+if printf '%s' "${empty_out}" | awk '/^  bootstrap:/,/^  managed:/' | grep -qE '^      secret:'; then
+  echo "FAIL (#5504): initdb emitted a 'secret:' with no bindings declared — it would name a" >&2
+  echo "  Secret nothing creates. The block must be guarded on the first binding existing." >&2
+  exit 1
+fi
+echo "  PASS (no-bindings fallback emits no dangling initdb secret)"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5760,7 +5760,7 @@ spec:
   # 0.2.13 (#5224): role-secrets side-gate — replica-role region never mints
   # role/hub Secrets; pair password set single-sourced from the primary region.
   # 0.2.14 (#5473): replication-source Service selectorType r -> rw (primary only).
-  version: "0.2.14"
+  version: "0.2.15"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5859,7 +5859,7 @@ spec:
     # 0.2.12 (#4986): active-hot-standby emits the dr-<instance> Continuum CR so
     # the per-app Topology DR panel renders (shared-pg #3375 rows 51/52/56/57/64).
     # 0.2.13 (#5224): role-secrets side-gate (replica-role region mints nothing).
-    version: "0.2.14"
+    version: "0.2.15"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
The first binding's owner was minted twice with different credentials:
bootstrap.initdb created it with CNPG's auto-generated <cluster>-app password,
while managed.roles declared it with the roleSecret. initdb's credential is the
one Postgres keeps, so every consumer -- all of which are handed the roleSecret
-- was rejected with SQLSTATE 28P01, while CNPG reported the role under
managedRolesStatus.byStatus.reconciled over a password that never took effect.

bootstrap.initdb.secret now names the same roleSecret the managed role uses, so
the role is born with one source of truth instead of two that CNPG ranks
silently.

Proven live on hw291 (shared-data/shared-pg, initdb owner harbor):
  shared-pg-harbor  len=32  REJECTED as user harbor
  shared-pg-app     len=64  AUTHENTICATES as user harbor
gitea and keycloak -- same chart, same managed.roles shape, but NOT the initdb
owner -- both authenticated. That three-way control isolates the owner
collision as the mechanism rather than a secret split or a rotation mismatch:
all five copies of the consumer-facing secret are byte-identical.

Consequence was a hard Pillar-5 stall: harbor-core and harbor-jobservice
crashlooping took cutover step-02/03 with them and parked the chain at 9%.

Render guard asserts initdb secret == managed-role passwordSecret, with a
vacuity check (exit 2) that the Cluster CR and the owner actually rendered --
a missing-key grep passes trivially on an empty render. A second case pins the
no-bindings fallback so initdb cannot emit a dangling secret naming something
nothing creates. Guard proven to FAIL on defect reintroduction and pass on
restore.

Lockstep 0.2.14 -> 0.2.15 across all seven sites: Chart.yaml, blueprint.yaml,
catalog-seed display + source, and slots 16a/16c/16d. bp-rtz-vcluster sits at a
coincidentally identical 0.2.14 and is deliberately untouched. Verified with
the authoritative Go gate (tests/e2e/bootstrap-kit), the render suite, and
helm lint.

Refs #5504
Refs #5499

🤖 Generated with [Claude Code](https://claude.com/claude-code)