### PR TITLE
fix(ci): make the §854 NodePort guard unable to pass vacuously (Refs #5517)

### DIFF
--- a/scripts/check-no-nodeports.sh
+++ b/scripts/check-no-nodeports.sh
@@ -56,6 +56,62 @@ SCAN_ROOTS=(platform products clusters infra core)
 # marker (# // *), and drop lines that carry an explicit ban marker.
 BAN_MARKERS='FORBIDDEN|forbidden|§854|#4765|NEVER|never use|must not|not a nodeport'
 
+echo "== Phase 0: guard self-test (vacuity) =="
+# #5517: this guard is an ABSENCE assertion, and absence assertions fail OPEN.
+# Two ways this script could have passed while checking nothing:
+#   1. SCAN_ROOTS drift (a dir renamed/moved) -> grep matches no files -> RAW
+#      empty -> "no violations". Indistinguishable from a clean repo.
+#   2. PATTERN rot (an edit that breaks the regex) -> matches nothing, forever
+#      green.
+# The #5473 lesson generalised: a negative assertion needs a POSITIVE control.
+# Phase 0 proves the pattern still bites and the scan still reaches real files
+# BEFORE any verdict is trusted. Exit 2 (not 1) so a broken guard is never
+# mistaken for a NodePort violation.
+
+# 0a. PATTERN must still match every banned form. If an edit breaks the regex
+#     this fails loudly instead of going quietly green.
+for probe in \
+  '  type: NodePort' \
+  '  serviceType: NodePort' \
+  '  nodePort: 30853' \
+  '  type = "NodePort"'
+do
+  if ! printf '%s\n' "${probe}" | grep -qE "${PATTERN}"; then
+    echo "GUARD BROKEN (#5517): PATTERN no longer matches a banned form: ${probe}" >&2
+    echo "  The scan below would report 'clean' while NodePorts pass through." >&2
+    exit 2
+  fi
+done
+
+# 0b. PATTERN must NOT match the k8s inert sentinel or the LB viewer label,
+#     or the guard would cry wolf on every LoadBalancer Service.
+for negprobe in '  nodePort: 0' '  allocateLoadBalancerNodePorts: true'; do
+  if printf '%s\n' "${negprobe}" | grep -qE "${PATTERN}"; then
+    echo "GUARD OVER-BROAD (#5517): PATTERN matches an allowed form: ${negprobe}" >&2
+    exit 2
+  fi
+done
+
+# 0c. The scan must actually reach files. A floor, not an exact count, so
+#     ordinary repo growth never trips it but a vanished tree does.
+# `|| true` is load-bearing: under `set -e` a grep that matches nothing exits
+# non-zero and would abort the script HERE, before the check below ever runs --
+# making this very vacuity guard unreachable in exactly the scenario it exists
+# to catch. Observed while proving the guard: a SCAN_ROOTS drift exited 1 from
+# the assignment instead of 2 from the check.
+SCANNED="$( { grep -rlIE '.' \
+  --include='*.yaml' --include='*.yml' \
+  --include='*.tf' --include='*.tftpl' \
+  --include='*.go' --include='*.ts' \
+  "${SCAN_ROOTS[@]}" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+if [ "${SCANNED:-0}" -lt 200 ]; then
+  echo "GUARD VACUOUS (#5517): static scan reached only ${SCANNED} files across" >&2
+  echo "  SCAN_ROOTS=(${SCAN_ROOTS[*]}) — expected >=200." >&2
+  echo "  A root was renamed/moved, so a 'clean' result would prove nothing." >&2
+  exit 2
+fi
+echo "  self-test OK: pattern matches 4/4 banned forms, rejects 2/2 allowed forms, ${SCANNED} files in scope"
+
 echo "== Phase 1: static NodePort source scan =="
 RAW="$(grep -rnIE "${PATTERN}" \
   --include='*.yaml' --include='*.yml' \


### PR DESCRIPTION
## Problem

`scripts/check-no-nodeports.sh` is the permanent guard behind the §854 NodePort ban (#4765). It is an
**absence assertion**, and absence assertions fail **open**. Across 200 lines it had **zero** vacuity
checks, so two silent failure modes would both have rendered as "OK — no NodePort":

1. **SCAN_ROOTS drift.** The static scan is
   `grep -rnIE "${PATTERN}" --include='*.yaml' … "${SCAN_ROOTS[@]}"`. If a root is renamed or moved,
   grep matches no files, `RAW` is empty, and the guard reports clean — indistinguishable from a
   genuinely clean repo.
2. **PATTERN rot.** Any edit that breaks the regex makes it match nothing, forever green.

This is the #5473 lesson (a negative assertion that passes on an empty render) applied to the one
guard the founder's absolute rule depends on. It is also the shape #5512 exploited: a literal search
that can be satisfied while the forbidden thing is present.

## Fix

A **Phase 0 self-test** that runs before any verdict is trusted, exiting **2** (distinct from a
violation's 1) so a broken guard can never be mistaken for a clean repo:

- **0a — positive control:** `PATTERN` must still match all four banned forms
  (`type: NodePort`, `serviceType: NodePort`, `nodePort: <n>`, `type = "NodePort"`).
- **0b — negative control:** it must NOT match the allowed forms (`nodePort: 0`, the k8s inert
  sentinel, and `allocateLoadBalancerNodePorts:`, the LoadBalancer viewer label) — otherwise the
  guard would cry wolf on every LoadBalancer Service.
- **0c — reach:** the scan must actually reach files, with a floor (>=200) rather than an exact count
  so ordinary repo growth never trips it but a vanished tree does.

## A defect found in the fix itself, while proving it

The first version of 0c was **unreachable in the exact case it guards**. Under `set -euo pipefail`,
`SCANNED="$(grep … | wc -l)"` aborts the script when grep matches nothing, so a SCAN_ROOTS drift
exited **1 from the assignment** instead of **2 from the check**. Caught by running the
reintroduction proof rather than assuming it; fixed by wrapping the grep in `{ …; || true; }`.

Recording it because it is the same class as the bug being fixed: a guard that cannot run is
worth exactly as much as a guard that cannot fail.

## Verification — both directions, actually executed

```
clean repo                        -> exit 0   "self-test OK: pattern matches 4/4 banned forms,
                                               rejects 2/2 allowed forms, 9877 files in scope"
PATTERN broken                    -> exit 2   "GUARD BROKEN (#…): PATTERN no longer matches
                                               a banned form:   type: NodePort"
SCAN_ROOTS drifted to docs/adr    -> exit 2   "GUARD VACUOUS (#…): static scan reached only 0 files"
restored                          -> exit 0
```

Phase 1 / 1b / 2 behaviour is unchanged; this is purely additive hardening in front of them.
