### PR TITLE
fix(console): never claim DR health without live backing — phantom standby + fail-open pattern (Refs #5514 #5515)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -340,6 +340,52 @@ describe('TopologyTab — #3982 runtime-derived placement', () => {
   })
 })
 
+describe('TopologyTab — #5515 an empty placement is "not reported", never a confident singleton', () => {
+  it('targets: [] renders Pattern "not reported" beside the empty note — NOT singleton', async () => {
+    // The live hw291 `cilium` case: /placement reports targets: [] and the
+    // panel already says "No placement targets reported yet." — yet the Pattern
+    // label read `singleton`, the one pattern that MEANS "no failover, and
+    // that's fine". Two contradictory claims in one panel.
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'cilium', namespace: 'kube-system', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+
+    render(withProviders(<TopologyTab sovereignId="dep-hw291" applicationName="cilium" namespace="kube-system" />))
+
+    // POSITIVE CONTROL — the panel + the pattern cell really rendered, so the
+    // negative assertion below is not passing on an empty render.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-placement-panel')).toBeTruthy()
+    })
+    const cell = screen.getByTestId('topology-tab-pattern')
+    expect(cell.textContent).toBe('not reported')
+    // THE regression: the confident pattern must not be claimed.
+    expect(cell.textContent).not.toBe('singleton')
+    // And the panel's own empty note is still there — the two now AGREE.
+    expect(screen.getByTestId('topology-tab-placement-empty')).toBeTruthy()
+  })
+
+  it('CONTROL — a real single-Primary app still renders the confident "singleton"', async () => {
+    // The other direction: the guard must not swallow real data. A component
+    // that returns "not reported" unconditionally fails here.
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'harbor', namespace: 'harbor', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [{ region: 'me-east-215-a', cluster: 'c', vcluster: 'mgmt', role: 'Primary' }],
+      derivedFromRuntime: true,
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-hw291" applicationName="harbor" namespace="harbor" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-target-card-0')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('singleton')
+    expect(screen.getByTestId('topology-tab-pattern').textContent).not.toBe('not reported')
+    expect(screen.queryByTestId('topology-tab-placement-empty')).toBeNull()
+  })
+})
+
 describe('TopologyTab — DR / replication surface (#3375 rows 51/52/56/57)', () => {
   const standbyPlacement = {
     targets: [
@@ -612,6 +658,155 @@ describe('TopologyTab — #4886 bootstrap-HR DR off the live Continuum CR', () =
     expect(screen.getByTestId('topology-tab-dr-source').textContent).toContain('live')
     // The Status panel's honest "n/a — bootstrap component" note is unaffected.
     expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+  })
+
+  it('#5514: a DECLARED active-hot-standby with ZERO backing arms NOTHING — no lag, no follower card, switchover DISABLED', async () => {
+    // The live hw291 phantom (uatcorp/uatwalk-ahs-07300830): the Application
+    // DECLARES active-hot-standby, but the standby region has no namespace at
+    // all. Two things conspired:
+    //   • /placement returns targets: [] → the targetsFromLegacy fallback
+    //     projects Primary + Standby·Hot from the DECLARED mode → hasStandby.
+    //   • replication-status returns HTTP 200 (NOT a 404) with the
+    //     `source:"pending"` fallback envelope carrying a fabricated
+    //     replicas[] entry + walLagSeconds 0 + replicaPromotable false.
+    // Pre-fix that rendered "Replication lag 0.0 s", a "hot replica (follows
+    // WAL)" card, and an ARMED "Switch over…" targeting the phantom region.
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({
+      name: 'uatwalk-ahs-07300830',
+      namespace: 'uatcorp',
+      // The DECLARED legacy posture — no spec.placement.targets[] at all.
+      spec: { placement: 'active-hot-standby', regions: ['me-east-215-a', 'me-east-215-b'] },
+      status: { placementRecon: 'Reconciling' },
+    })
+    getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-uatwalk-ahs-07300830',
+      namespace: 'uatcorp',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0,
+      replicaPromotable: false,
+      replicas: [{ region: 'me-east-215-b', role: 'replica' }],
+      source: 'pending',
+    })
+
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-hw291"
+          applicationName="uatwalk-ahs-07300830"
+          namespace="uatcorp"
+        />,
+      ),
+    )
+
+    // POSITIVE CONTROL (rule 2) — the surface really did render. Without this
+    // the absence assertions below would pass on an empty render.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    // The declared standby DID drive the panel open, and the honest
+    // not-live badge is present — so we are on the real code path.
+    expect(screen.getByTestId('topology-tab-dr-source').textContent).toContain('not live')
+    // And the honest unbacked note renders (previously DEAD code, because the
+    // endpoint answers 200 and `drQ.isError` never fired).
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-none')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-dr-unbacked').textContent).toContain('DECLARES a standby')
+
+    // ── The three defects, each asserted absent ────────────────────────
+    // 1. NO numeric replication lag anywhere.
+    expect(screen.queryByTestId('topology-tab-dr-lag-value')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-lag')).toBeNull()
+    expect(document.body.textContent).not.toContain('0.0 s')
+    // 2. NO "hot replica (follows WAL)" standby card for the phantom region.
+    expect(screen.queryByTestId('topology-tab-dr-standby')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-standby-me-east-215-b')).toBeNull()
+    expect(document.body.textContent).not.toContain('hot replica (follows WAL)')
+    // 3. NO switchover control armed against a region with no namespace.
+    expect(screen.queryByTestId('topology-tab-dr-switchover-open')).toBeNull()
+    expect(screen.queryByTestId('continuum-switchover-dialog')).toBeNull()
+  })
+
+  it('#5514: an explicit replicaPromotable:false on a LIVE reading DISABLES the switchover (the verdict is consulted)', async () => {
+    // Backing IS live (so the panel + lag render honestly), but the backend
+    // says the replica cannot be promoted. The button must be disabled with a
+    // plain reason — pre-fix `disabled={!switchoverTarget}` ignored the verdict
+    // entirely and armed off a region STRING.
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: true,
+    })
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 3.2,
+      replicaPromotable: false,
+      streamingState: 'catchup',
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    // POSITIVE CONTROL — a live backing renders the full panel + real lag.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-switchover-open')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-dr-lag-value').textContent).toContain('3.2 s')
+    // The button exists but is DISARMED, with the reason stated.
+    const btn = screen.getByTestId('topology-tab-dr-switchover-open') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(screen.getByTestId('topology-tab-dr-switchover').textContent).toContain('not promotable')
+    // Clicking a disabled control opens nothing.
+    fireEvent.click(btn)
+    expect(screen.queryByTestId('continuum-switchover-dialog')).toBeNull()
+  })
+
+  it('#5514: a VERIFIED-absent standby disarms the switchover and shows no false 0.0 s lag', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: true,
+    })
+    // #4901 shape — lag stays 0 through the outage, so a rendered "0.0 s"
+    // reads as perfect health exactly when the standby is gone.
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0,
+      standbyAvailable: false,
+      streamingState: 'interrupted',
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    // POSITIVE CONTROL — the panel and the absent banner rendered.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-standby-absent')).toBeTruthy()
+    })
+    // The lag cell renders, but as an honest dash — not a false 0.0 s.
+    expect(screen.getByTestId('topology-tab-dr-lag-value').textContent).toContain('—')
+    expect(screen.getByTestId('topology-tab-dr-lag-value').textContent).not.toContain('0.0 s')
+    // Switchover disarmed: there is no standby leg to promote.
+    const btn = screen.getByTestId('topology-tab-dr-switchover-open') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(screen.getByTestId('topology-tab-dr-switchover').textContent).toContain('nothing to promote')
   })
 
   it('does NOT render DR for a SINGLETON bootstrap app (synthesized fallback is never passed off as live)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -41,8 +41,11 @@ import {
   type Capability,
   type PlacementTarget,
   type ReconStatus,
+  PATTERN_NOT_REPORTED,
   derivePattern,
+  describePattern,
   normalizeCapability,
+  patternLabel,
   targetsFromLegacy,
 } from '@/shared/lib/placement'
 
@@ -244,10 +247,11 @@ export function TopologyTab({
   //     component, yet a live 2-region cnpg-pair genuinely backs it. Polling
   //     unconditionally lets the DR panel render it as a pair with the
   //     switchover control instead of a stale singleton.
-  // Rendering is ALWAYS gated on a live cross-region result (source:"live" + a
-  // distinct standby region), so a genuine singleton — which 404s or returns a
-  // synthesized/pending shape — never fabricates a DR panel. A 404 (no
-  // Continuum CR / no live pair) does NOT retry and leaves drStatus undefined.
+  // #5514 — the endpoint does NOT 404 for an unbacked app: it answers HTTP 200
+  // with the `source:"pending"` fallback envelope. So the panel's CONTENT is
+  // gated on `drBacked` (source === "live") below, never on `drQ.isError`.
+  // A real transport error does not retry and leaves drStatus undefined, which
+  // lands on the same unbacked branch.
   // Bootstrap components query with an EMPTY namespace so the cluster-wide
   // lookup finds the CR in its own namespace (the HR lives in flux-system, the
   // Continuum in the spine's namespace) — mirrors the #4000 placement rule.
@@ -309,6 +313,24 @@ export function TopologyTab({
     [drStatus, drPrimaryRegion],
   )
   const hasLiveDR = drStatus?.source === 'live' && !!liveStandbyRegion
+
+  // #5514 — THE DR-BACKING GATE. The replication-status endpoint does NOT 404
+  // for an app with no Continuum CR: catalyst-api answers HTTP 200 carrying
+  // `pendingReplicationStatus()` (continuum_dr_extras.go) — a fallback envelope
+  // with `source:"pending"`, `replicaPromotable:false`, `walLagSeconds:0`, and
+  // a `replicas[]` entry synthesized from the Sovereign's CONFIGURED region env
+  // (SOVEREIGN_REPLICA_REGION), not from an observed replica. So `drQ.isError`
+  // never fires, and every downstream render read that envelope as real: hw291
+  // showed `Replication lag 0.0 s`, a "hot replica (follows WAL)" card, and an
+  // ARMED "Switch over…" for `uatcorp/uatwalk-ahs-07300830` — an Application
+  // declaring active-hot-standby whose standby region has no namespace at all.
+  //
+  // `source === 'live'` is the backend's own honesty flag and the ONLY value
+  // that means "read off the real Continuum + CNPGPair CR status". Nothing
+  // numeric and no control may render without it. The server is already honest
+  // here; it was the client that ignored the flag.
+  const drBacked = drStatus?.source === 'live'
+
   const showDR = hasStandby || hasLiveDR
 
   // #4923/#4901 — the EXPLICIT standby-absent condition. The backend verifies
@@ -325,6 +347,34 @@ export function TopologyTab({
     () => drStandbyRegions[0] || liveStandbyRegion || '',
     [drStandbyRegions, liveStandbyRegion],
   )
+
+  // #5514 — arming the switchover needs THREE independent facts, not just a
+  // region string. `switchoverTarget` alone is a DECLARED region name, which on
+  // hw291 pointed at a region with no namespace: a string is not a standby.
+  //
+  //   1. drBacked            — the reading is live, not the pending envelope.
+  //   2. replicaPromotable   — the backend's positive verdict. It DOES return
+  //                            this (`false` for the phantom) and it was never
+  //                            consulted. `undefined` = unverified, which stays
+  //                            armed: the SwitchoverDialog then runs its own
+  //                            read-only RPO/health preflight and only arms
+  //                            [ Confirm Switchover ] on `promotable`. Only an
+  //                            EXPLICIT `false` disarms here.
+  //   3. !standbyAbsent      — a VERIFIED-absent standby (#4923/#4901) has no
+  //                            leg to promote.
+  const replicaPromotable = drStatus?.replicaPromotable
+  const switchoverArmed =
+    drBacked && !!switchoverTarget && replicaPromotable !== false && !standbyAbsent
+
+  // The plain reason the control is not armed — the operator must never see a
+  // dead button with no explanation.
+  const switchoverBlockedReason = useMemo(() => {
+    if (switchoverArmed) return ''
+    if (!switchoverTarget) return 'resolving standby region…'
+    if (standbyAbsent) return 'standby unreachable — nothing to promote'
+    if (replicaPromotable === false) return 'the replica is not promotable — no caught-up standby to promote'
+    return 'no live replication reading — cannot promote'
+  }, [switchoverArmed, switchoverTarget, standbyAbsent, replicaPromotable])
 
   // Owned dependencies that cascade — read from spec.placement.ownedDependencies
   // when present (override state); the names also come from the blueprint's
@@ -409,10 +459,22 @@ export function TopologyTab({
       >
         <div className="mb-3 flex items-baseline justify-between">
           <h3 className="text-sm font-semibold text-[var(--color-text-strong)]">Placement</h3>
+          {/* #5515 — an un-derivable pattern renders as prose ("not reported")
+              in the DIM colour, never a pattern NAME in the accent colour. The
+              pre-fix code printed a confident `singleton` next to this panel's
+              own "No placement targets reported yet." note. */}
           <span className="text-xs text-[var(--color-text-dim)]">
             Pattern:{' '}
-            <span className="font-semibold text-[var(--color-accent)]" data-testid="topology-tab-pattern">
-              {pattern}
+            <span
+              className={
+                pattern === PATTERN_NOT_REPORTED
+                  ? 'font-semibold text-[var(--color-text-dim)] italic'
+                  : 'font-semibold text-[var(--color-accent)]'
+              }
+              data-testid="topology-tab-pattern"
+              title={describePattern(pattern)}
+            >
+              {patternLabel(pattern)}
             </span>
           </span>
         </div>
@@ -549,12 +611,32 @@ export function TopologyTab({
             ) : null}
           </div>
 
-          {drQ.isError ? (
-            // The replication-status endpoint 404s when no Continuum CR
-            // backs this app — a calm "no DR pair yet" note, NOT an error.
-            <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-dr-none">
-              No cross-region replica reporting yet for this component.
-            </p>
+          {!drBacked ? (
+            // #5514 — NO LIVE BACKING. Reached on all three unbacked shapes:
+            // the endpoint erroring, the `source:"pending"` fallback envelope
+            // (the hw291 phantom — HTTP 200, NOT an error, which is why the old
+            // `drQ.isError` condition here was dead code), and the still-loading
+            // first paint. Renders the honest note and NOTHING else: no standby
+            // card, no numeric lag, no switchover control. A DR control must
+            // never arm against a region we have not observed.
+            <div data-testid="topology-tab-dr-none">
+              <p className="text-xs text-[var(--color-text-dim)]">
+                {drQ.isLoading
+                  ? 'Checking for a cross-region replica…'
+                  : 'No cross-region replica reporting yet for this component.'}
+              </p>
+              {hasStandby && drStatus && !drQ.isLoading ? (
+                <p
+                  className="mt-2 text-xs text-yellow-400"
+                  data-testid="topology-tab-dr-unbacked"
+                >
+                  This placement DECLARES a standby, but the replication endpoint
+                  returned a fallback reading (source: {drStatus.source}) — no live
+                  Continuum / cnpg pair backs it. Replication lag and switchover
+                  stay unavailable until a real replica reports.
+                </p>
+              ) : null}
+            </div>
           ) : (
             <>
               <div
@@ -667,8 +749,15 @@ export function TopologyTab({
                   }`}
                   data-testid="topology-tab-dr-lag-value"
                 >
-                  {lagSeconds == null ? '—' : `${lagSeconds.toFixed(1)} s`}
+                  {/* #5514 — a lag NUMBER is a claim that a standby is being
+                      measured. On a VERIFIED-absent standby (#4901) the backend
+                      keeps reporting 0, which reads as perfect health during an
+                      outage; render "—" instead of that false zero. */}
+                  {lagSeconds == null || standbyAbsent ? '—' : `${lagSeconds.toFixed(1)} s`}
                 </span>
+                {standbyAbsent ? (
+                  <span className="text-[10px] text-red-400">no standby leg to measure</span>
+                ) : null}
                 {lagSeconds == null && drQ.isLoading ? (
                   <span className="text-[10px] text-[var(--color-text-dim)]">measuring…</span>
                 ) : null}
@@ -691,19 +780,19 @@ export function TopologyTab({
                   type="button"
                   className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs hover:border-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
                   onClick={() => setShowSwitchover(true)}
-                  disabled={!switchoverTarget}
+                  disabled={!switchoverArmed}
                   data-testid="topology-tab-dr-switchover-open"
                 >
                   Switch over…
                 </button>
                 <span className="text-[10px] text-[var(--color-text-dim)]">
-                  {switchoverTarget
+                  {switchoverArmed
                     ? `promote standby ${switchoverTarget} — runs an RPO/health preflight before you confirm`
-                    : 'resolving standby region…'}
+                    : switchoverBlockedReason}
                 </span>
               </div>
 
-              {showSwitchover && switchoverTarget ? (
+              {showSwitchover && switchoverArmed ? (
                 <SwitchoverDialog
                   sovereignId={sovereignId}
                   continuumName={continuumName}

--- a/products/catalyst/bootstrap/ui/src/shared/lib/placement.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/placement.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from 'vitest'
 
 import {
   MULTI_PRIMARY_NOT_SUPPORTED,
+  PATTERN_NOT_REPORTED,
   type PlacementTarget,
   canAddPrimary,
   derivePattern,
+  describePattern,
   normalizeCapability,
+  patternLabel,
   targetsFromLegacy,
   validatePlacement,
 } from './placement'
@@ -28,8 +31,81 @@ describe('derivePattern (#3969 §7.3)', () => {
   it('2 Primary -> active-active', () => {
     expect(derivePattern([primaryA, primaryB])).toBe('active-active')
   })
-  it('empty -> singleton', () => {
-    expect(derivePattern([])).toBe('singleton')
+})
+
+/**
+ * #5515 — derivePattern must NOT fail open into `singleton`.
+ *
+ * The pre-fix body was:
+ *     if (primaries >= 2) return 'active-active'
+ *     if (standbys === 0) return 'singleton'    // fires when targets is EMPTY
+ * so `targets: []` produced the one pattern that MEANS "no failover, and
+ * that's fine". Live on hw291 this rendered `Pattern: singleton` next to the
+ * same panel's "No placement targets reported yet."
+ *
+ * These assertions are deliberately TWO-SIDED: a `derivePattern` that returns
+ * `not-reported` unconditionally fails the positive cases below just as hard as
+ * the old fail-open version fails the negative ones.
+ */
+describe('#5515 derivePattern never fails open into singleton', () => {
+  it('an EMPTY target list is not-reported — and specifically NOT singleton', () => {
+    expect(derivePattern([])).toBe(PATTERN_NOT_REPORTED)
+    // The exact regression: the confident pattern must not be claimed.
+    expect(derivePattern([])).not.toBe('singleton')
+  })
+
+  it('a target list with NO Primary (roles unrecognised) is not-reported, not singleton', () => {
+    // Same counters as the empty list (primaries 0 / standbys 0) — the other
+    // input that reached the fail-open branch.
+    const garbage = [{ region: 'region-a', cluster: 'c', vcluster: 'mgmt', role: 'Replica' }] as unknown as PlacementTarget[]
+    expect(derivePattern(garbage)).toBe(PATTERN_NOT_REPORTED)
+    expect(derivePattern(garbage)).not.toBe('singleton')
+  })
+
+  it('a Standby-only list is not-reported — no "active-*" claim without an active', () => {
+    expect(derivePattern([hotB])).toBe(PATTERN_NOT_REPORTED)
+    expect(derivePattern([hotB])).not.toBe('active-hot-standby')
+    // Consistent with the validator's own verdict on the same input.
+    expect(validatePlacement([hotB], 'primary+standby')?.reason).toBe('NoPrimary')
+  })
+
+  /* ── The POSITIVE control side (rule 3: one-sided tests are rejected) ────
+     A derivePattern hard-wired to return not-reported must fail here. Every
+     real pattern still derives, so the guard cannot be satisfied by a
+     function that simply stopped deriving. */
+  it('CONTROL — a real single Primary still derives singleton (the guard did not swallow real data)', () => {
+    expect(derivePattern([primaryA])).toBe('singleton')
+    expect(derivePattern([primaryA])).not.toBe(PATTERN_NOT_REPORTED)
+  })
+
+  it('CONTROL — every real pattern still derives its own name', () => {
+    expect(derivePattern([primaryA, hotB])).toBe('active-hot-standby')
+    expect(derivePattern([primaryA, coldB])).toBe('active-passive')
+    expect(derivePattern([primaryA, primaryB])).toBe('active-active')
+    for (const ts of [[primaryA], [primaryA, hotB], [primaryA, coldB], [primaryA, primaryB]]) {
+      expect(derivePattern(ts)).not.toBe(PATTERN_NOT_REPORTED)
+    }
+  })
+
+  it('describePattern covers not-reported with prose, and never returns undefined', () => {
+    // The tsc exhaustiveness gate (TS2366) is the compile-time half; this is
+    // the runtime half — a missing case would return undefined here.
+    for (const p of ['singleton', 'active-passive', 'active-hot-standby', 'active-active', PATTERN_NOT_REPORTED] as const) {
+      expect(typeof describePattern(p)).toBe('string')
+      expect(describePattern(p).length).toBeGreaterThan(0)
+    }
+    expect(describePattern(PATTERN_NOT_REPORTED)).toContain('cannot be derived')
+    // The un-derivable description must NOT reassure the reader with the
+    // singleton wording ("no cross-region failover").
+    expect(describePattern(PATTERN_NOT_REPORTED)).not.toContain('no cross-region failover')
+  })
+
+  it('patternLabel renders the un-derivable case as prose, real patterns verbatim', () => {
+    expect(patternLabel(PATTERN_NOT_REPORTED)).toBe('not reported')
+    expect(patternLabel(PATTERN_NOT_REPORTED)).not.toBe('singleton')
+    // CONTROL — real patterns pass through unchanged.
+    expect(patternLabel('singleton')).toBe('singleton')
+    expect(patternLabel('active-hot-standby')).toBe('active-hot-standby')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/shared/lib/placement.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/placement.ts
@@ -24,6 +24,26 @@ export type StandbyType = 'Hot' | 'Cold'
 export type Capability = 'multi-primary' | 'primary+standby'
 export type Pattern = 'singleton' | 'active-passive' | 'active-hot-standby' | 'active-active'
 
+/**
+ * The token for "no pattern could be derived" (#5515). NOT a pattern — the
+ * explicit absence of one.
+ */
+export const PATTERN_NOT_REPORTED = 'not-reported'
+
+/**
+ * DerivedPattern — what `derivePattern` can honestly return: one of the four
+ * real patterns, or `not-reported` when the target list carries no derivable
+ * placement at all (#5515).
+ *
+ * `not-reported` exists because `singleton` is a CONFIDENT CLAIM — "there is
+ * exactly one Primary, in one region, and no cross-region failover is wanted".
+ * Returning it for an EMPTY target list turns "we know nothing" into "we know
+ * this is fine", which is the DR-truthfulness defect #5515 caught live on
+ * hw291 (`cilium` rendered `Pattern: singleton` directly beside its own text
+ * "No placement targets reported yet.").
+ */
+export type DerivedPattern = Pattern | typeof PATTERN_NOT_REPORTED
+
 /** One desired target. A Standby carries a standbyType. */
 export interface PlacementTarget {
   region: string
@@ -53,31 +73,56 @@ export type ReconStatus = 'Reconciled' | 'Reconciling' | 'Degraded'
  * derivePattern — the ONLY place patterns come from (#3969 §7.3). Computed
  * from targets + roles + standby types for DISPLAY ONLY; never stored.
  *
+ *   no Primary target        -> not-reported   (#5515 — nothing to derive)
  *   primaries ≥ 2            -> active-active
  *   standbys  == 0           -> singleton
  *   any standby is Hot       -> active-hot-standby
  *   else                     -> active-passive
+ *
+ * #5515 — the no-Primary guard MUST come first and MUST NOT fall through to
+ * `singleton`. Every one of the four patterns asserts a live Primary; with
+ * zero Primary targets there is no pattern, only missing data. The three
+ * inputs that land here:
+ *
+ *   • `[]` — the /placement endpoint reported `targets: []` (the live hw291
+ *     `cilium` case). Pre-fix this hit `standbys === 0` and returned the
+ *     confident `singleton`.
+ *   • a list whose roles are all unrecognised (neither Primary nor Standby) —
+ *     same counters, same false `singleton`.
+ *   • a Standby-only list — asserting an "active-*" pattern with no active.
+ *     `validatePlacement` already rejects this as `NoPrimary`; the derived
+ *     label must not contradict that verdict.
  */
-export function derivePattern(targets: PlacementTarget[]): Pattern {
+export function derivePattern(targets: PlacementTarget[]): DerivedPattern {
   let primaries = 0
   let standbys = 0
   let anyHot = false
-  for (const t of targets) {
+  for (const t of targets ?? []) {
     if (t.role === 'Primary') primaries++
     else if (t.role === 'Standby') {
       standbys++
       if (t.standbyType === 'Hot') anyHot = true
     }
   }
+  // #5515 — no Primary ⇒ no pattern. Never fail open into `singleton`.
+  if (primaries === 0) return PATTERN_NOT_REPORTED
   if (primaries >= 2) return 'active-active'
   if (standbys === 0) return 'singleton'
   if (anyHot) return 'active-hot-standby'
   return 'active-passive'
 }
 
-/** Human one-liner per derived pattern (display only). */
-export function describePattern(pattern: Pattern): string {
+/**
+ * Human one-liner per derived pattern (display only).
+ *
+ * Exhaustive over DerivedPattern with NO trailing return — so adding a member
+ * to the union without describing it fails `tsc` here (TS2366) instead of
+ * silently returning undefined into the UI.
+ */
+export function describePattern(pattern: DerivedPattern): string {
   switch (pattern) {
+    case PATTERN_NOT_REPORTED:
+      return 'No placement targets reported — the pattern cannot be derived yet.'
     case 'singleton':
       return 'One Primary in one region; no cross-region failover.'
     case 'active-passive':
@@ -87,6 +132,15 @@ export function describePattern(pattern: Pattern): string {
     case 'active-active':
       return 'Two or more Primary targets serve live traffic; data syncs between them.'
   }
+}
+
+/**
+ * patternLabel — the display string for a derived pattern. Renders the
+ * un-derivable case as prose ("not reported") so no surface ever prints a
+ * pattern NAME for data it does not have (#5515).
+ */
+export function patternLabel(pattern: DerivedPattern): string {
+  return pattern === PATTERN_NOT_REPORTED ? 'not reported' : pattern
 }
 
 /** Normalize a Blueprint capability string to the canonical enum (default primary+standby). */

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
@@ -29,9 +29,11 @@ import {
   type OwnedDependencyOverride,
   type PlacementTarget,
   type StandbyType,
+  PATTERN_NOT_REPORTED,
   canAddPrimary,
   derivePattern,
   describePattern,
+  patternLabel,
   validatePlacement,
 } from '@/shared/lib/placement'
 
@@ -362,9 +364,19 @@ export function PlacementEditor({
         + add target
       </button>
 
+      {/* #5515 — the un-derivable case (every target removed / no Primary)
+          reads as prose in the dim colour; never a confident pattern name. */}
       <p className="mb-3 text-xs" data-testid="placement-editor-derived-pattern">
         <span className="text-[var(--color-text-dim)]">Derived pattern: </span>
-        <span className="font-medium text-[var(--color-accent)]">{pattern}</span>
+        <span
+          className={
+            pattern === PATTERN_NOT_REPORTED
+              ? 'font-medium italic text-[var(--color-text-dim)]'
+              : 'font-medium text-[var(--color-accent)]'
+          }
+        >
+          {patternLabel(pattern)}
+        </span>
         <span className="ml-2 text-[var(--color-text-dim)]">{describePattern(pattern)}</span>
       </p>
 


### PR DESCRIPTION
## What

Two DR-truthfulness defects walked live on hw291. Both turn **missing data into a
confident claim** on the Application Topology tab — the exact class of defect that
makes an operator trust a standby that is not there.

Refs #5514
Refs #5515

## #5514 — `Switch over…` armed against a phantom standby

`uatcorp/uatwalk-ahs-07300830` declares `active-hot-standby` with ZERO backing.
The DR panel rendered `○ NOT LIVE` and **still** showed `Replication lag 0.0 s`, a
"hot replica (follows WAL)" standby card, and an **enabled** `Switch over…`
targeting a region that has no namespace at all.

Three linked causes:

| # | Cause |
|---|---|
| 1 | The component asserted the replication-status endpoint 404s when no Continuum CR backs the app. **It does not** — catalyst-api answers **HTTP 200** with `pendingReplicationStatus()`: `source:"pending"`, `replicaPromotable:false`, `walLagSeconds:0`, plus a `replicas[]` entry synthesized from the Sovereign's *configured* region env rather than an observed replica. `drQ.isError` therefore never fired and the `topology-tab-dr-none` branch was **dead code**. |
| 2 | `showDR = hasStandby \|\| hasLiveDR` — the never-arm-a-phantom guard sat only on `hasLiveDR`, while `hasStandby` came from **declared** targets via the `targetsFromLegacy` fallback (engaged because `/placement` returned `targets: []`). |
| 3 | The switchover armed on `!switchoverTarget` — a region **string**. The API's own `replicaPromotable` verdict (`false` here) was never consulted. |

**Fix — entirely client-side.** The panel's *content* is gated on `drBacked`
(`source === "live"`, the backend's own honesty flag) instead of `drQ.isError`, so
the pending envelope lands on the honest no-DR branch and renders nothing numeric
and no control. The switchover arms only on `drBacked` **and** a resolvable target
**and** `replicaPromotable !== false` **and** `!standbyAbsent`, each with a plain
operator-visible reason when disarmed. The lag *number* is also suppressed on a
verified-absent standby — #4901 keeps reporting `0` through the outage, which read
as perfect health exactly when the standby was gone.

**The server needed no change.** It already emits `source:"pending"` *and*
`replicaPromotable:false` for the phantom; the client was ignoring both signals.
The `200 + pending` contract is left alone deliberately: #4923 chose it over a 404
so the UI can distinguish "not live" from a transport error, and it has other
consumers.

## #5515 — `derivePattern` failed open into `singleton`

```ts
if (primaries >= 2) return 'active-active'
if (standbys === 0) return 'singleton'   // fires when targets is EMPTY
```

With `targets: []` both counters are 0, so **no data rendered as a confident
`singleton`** — the one pattern meaning "no failover, and that's fine". Live,
`cilium` showed `Pattern: singleton` directly beside the same panel's own text
"No placement targets reported yet."

`derivePattern` now returns an explicit `PATTERN_NOT_REPORTED` when there is no
Primary target. That single guard covers the empty list, an
all-unrecognised-roles list, and a Standby-only list — the last of which
`validatePlacement` already rejects as `NoPrimary`, so the derived label no longer
contradicts the validator.

The return type widens to `DerivedPattern = Pattern | 'not-reported'`.
`describePattern` is exhaustive over it **with no trailing return**, so adding a
member without describing it now fails `tsc` (TS2366) instead of silently
returning `undefined` into the UI. Both render sites (TopologyTab and
PlacementEditor) print prose via the new `patternLabel()` and never a pattern
NAME for data they do not have.

## Gates

| Gate | Result |
|---|---|
| `npx tsc -b` | clean, exit 0 |
| `npm run build` | clean (`built in 1.92s`) |
| `npx vitest run` | **1964 passed**, 9 pre-existing unrelated failures |
| `npx eslint <5 changed files>` | clean, exit 0 |

The 9 failures are **byte-identical on a stashed baseline** (`9 failed / 1953
passed` before vs `9 failed / 1964 passed` after — +11 new tests, all passing,
zero regressions). They live in `SovereignConsoleLayout` / `StepComponents` /
`ExecPanel`; none touches placement, topology or DR. The `prebuild` catalog step
also regenerates `blueprints.json` + `catalog.generated.ts`; those regenerations
were reverted and are **not** in this branch.

## Both-directions proof

Every guard was proven by reintroducing the defect and observing the failure —
not merely asserted:

| Reintroduction | Observed failure |
|---|---|
| Remove the no-Primary guard | 4 tests fail with the exact pre-fix values (`expected 'singleton' to be 'not-reported'`, `expected 'active-hot-standby' to be 'not-reported'`) |
| `derivePattern` returns `not-reported` **unconditionally** | 15 tests fail, including the named `CONTROL —` cases (`expected 'not-reported' to be 'singleton'`) |
| Panel gate reverted to `drQ.isError` | `Unable to find an element by: [data-testid="topology-tab-dr-none"]` — the dead-code proof |
| Switchover reverted to `!switchoverTarget` | `expected false to be true` on `btn.disabled`, twice |
| Lag suppression reverted | `expected '0.0 s' to contain '—'` |
| `describePattern` case removed | `error TS2366: Function lacks ending return statement` |

Per the repo's test discipline: no negative assertion stands alone. Each phantom
test first asserts the surface **did** render (the DR panel is present, the
`not live` badge is present, the pattern cell is present) so the absence
assertions cannot pass on an empty render, and each `derivePattern` guard carries
a positive `CONTROL` case that a function returning the new value unconditionally
fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
