### PR TITLE
fix(console): catalog per-field Save is a partial patch, not a whole-record replace (Refs #5510)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.partial-patch-5510.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.partial-patch-5510.test.ts
@@ -1,0 +1,211 @@
+/**
+ * commerce.api.partial-patch-5510.test.ts — regression lock-in for #5510:
+ * a single-field catalog Save must not destroy other fields' data.
+ *
+ * Live reproduction on hw291 (`bp-alloy`, store row `b6ac3a3b…`):
+ *
+ *   before:  name       = "Alloy-NAMEPROOF-1785352700"
+ *            icon_light = "/component-logos/cilium.svg"
+ *   action:  edit Summary only → Save        ("Saved to IaC ✓", PUT 200)
+ *   after:   name       = "Alloy"                      ← reverted, never touched
+ *            icon_light = "/component-logos/alloy.svg" ← reverted, never touched
+ *
+ * Both destroyed values were UAT walk evidence (a NAMEPROOF marker and a
+ * deliberately-changed icon), so the mechanism erased exactly the durable state
+ * an acceptance walk establishes — while reporting success.
+ *
+ * Root cause: the save was a whole-record replace whose base was built from the
+ * IaC card alone, so every field the STORE held but the IaC lacked came back as
+ * an IaC-derived default. saveCatalogEdit now takes a PATCH of only the edited
+ * keys and overlays it on the stored row.
+ *
+ * The wire endpoint cannot express a partial patch — `PUT /catalog/admin/apps/
+ * {id}` decodes into a `store.App` and `Store.UpdateApp` `$set`s every column —
+ * so these tests assert the read-modify-write that implements partial-patch
+ * semantics client-side: the PUT body must carry the STORED values for every
+ * key the patch omits.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { saveCatalogEdit } from './commerce.api'
+
+/** One captured outbound request. */
+interface Call {
+  url: string
+  method: string
+  body: Record<string, unknown> | null
+}
+
+const calls: Call[] = []
+/** The commerce store's `apps` rows the mocked GET returns. */
+const storeRows: { value: Array<Record<string, unknown>> } = { value: [] }
+
+/**
+ * The live store row from the hw291 reproduction: `name` and `icon_light` are
+ * STORE-ONLY values (the IaC card carries neither) and `published` /
+ * `deployable` / `helm_chart` are the untouched columns the full-$set
+ * UpdateApp would zero if the body dropped them.
+ */
+const NAMEPROOF_ROW = {
+  id: 'b6ac3a3b-0000-4000-8000-000000000000',
+  slug: 'alloy',
+  name: 'Alloy-NAMEPROOF-1785352700',
+  tagline: 'Unified node agent',
+  icon_light: '/component-logos/cilium.svg',
+  icon_dark: '',
+  supported_topologies: ['singleton'],
+  published: true,
+  deployable: true,
+  helm_chart: 'alloy',
+}
+
+/** The IaC-derived values the detail page passes as the create-only seed. */
+const IAC_SEED = {
+  name: 'Alloy',
+  tagline: 'Unified node agent for logs, metrics, and traces',
+  supported_topologies: ['singleton'],
+  icon_light: '',
+  icon_dark: '',
+}
+
+function jsonRes(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as unknown as Response)
+}
+
+beforeEach(() => {
+  calls.length = 0
+  storeRows.value = []
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+    let body: Record<string, unknown> | null = null
+    if (typeof init?.body === 'string') {
+      body = JSON.parse(init.body) as Record<string, unknown>
+    }
+    calls.push({ url, method, body })
+    if (url.includes('/org/commerce/apps') && method === 'GET') {
+      return jsonRes(storeRows.value)
+    }
+    // Both the PUT (update) and POST (create) legs answer with the #3668
+    // {stored, committed} envelope catalyst-api wraps the store row in.
+    return jsonRes({ stored: true, committed: true, store: body })
+  }) as typeof fetch
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/** The single mutation the save issued (PUT or POST) — never the list GET. */
+function mutation(): Call {
+  const writes = calls.filter((c) => c.method === 'PUT' || c.method === 'POST')
+  expect(writes).toHaveLength(1)
+  return writes[0]
+}
+
+describe('saveCatalogEdit — partial patch, stored row is the merge base (#5510)', () => {
+  it('a Summary-only save leaves the store-only name AND icon_light intact', async () => {
+    storeRows.value = [{ ...NAMEPROOF_ROW }]
+
+    const verdict = await saveCatalogEdit(
+      'bp-alloy',
+      { tagline: 'Summary edited by the walk' },
+      IAC_SEED,
+    )
+
+    // Non-vacuity: the write actually happened, against the row's _id, and the
+    // server verdict came back — none of the assertions below can pass on a
+    // no-op that never reached the wire.
+    const put = mutation()
+    expect(put.method).toBe('PUT')
+    expect(put.url).toContain('/org/commerce/apps/b6ac3a3b-0000-4000-8000-000000000000')
+    expect(verdict).toEqual({ slug: 'alloy', stored: true, committed: true })
+
+    const sent = put.body!
+    // The edited field landed…
+    expect(sent.tagline).toBe('Summary edited by the walk')
+    // …and the two fields the live repro destroyed SURVIVED with their STORED
+    // values — not the IaC-derived defaults in IAC_SEED.
+    expect(sent.name).toBe('Alloy-NAMEPROOF-1785352700')
+    expect(sent.icon_light).toBe('/component-logos/cilium.svg')
+    expect(sent.name).not.toBe(IAC_SEED.name)
+    // The untouched non-card columns still round-trip (full-$set UpdateApp).
+    expect(sent.published).toBe(true)
+    expect(sent.deployable).toBe(true)
+    expect(sent.helm_chart).toBe('alloy')
+  })
+
+  it('an icon-only save leaves the store-only name intact', async () => {
+    storeRows.value = [{ ...NAMEPROOF_ROW }]
+
+    await saveCatalogEdit(
+      'bp-alloy',
+      { icon_light: '/component-logos/loki.svg', icon_dark: '' },
+      IAC_SEED,
+    )
+
+    const sent = mutation().body!
+    expect(sent.icon_light).toBe('/component-logos/loki.svg')
+    expect(sent.name).toBe('Alloy-NAMEPROOF-1785352700')
+    expect(sent.tagline).toBe('Unified node agent')
+  })
+
+  it('an explicit edit to a field STILL persists (requirement 3, direction A)', async () => {
+    storeRows.value = [{ ...NAMEPROOF_ROW }]
+
+    await saveCatalogEdit('bp-alloy', { name: 'Alloy-NAMEPROOF-2' }, IAC_SEED)
+
+    const sent = mutation().body!
+    expect(sent.name).toBe('Alloy-NAMEPROOF-2')
+    // …and the sibling the operator did not touch is untouched.
+    expect(sent.icon_light).toBe('/component-logos/cilium.svg')
+  })
+
+  it('an explicitly CLEARED field is written as empty (undefined ≠ empty string)', async () => {
+    storeRows.value = [{ ...NAMEPROOF_ROW }]
+
+    await saveCatalogEdit('bp-alloy', { icon_light: '' }, IAC_SEED)
+
+    const sent = mutation().body!
+    // Present-but-empty means "the operator cleared it" — it must reach the
+    // store, otherwise clearing an override would be impossible.
+    expect(sent.icon_light).toBe('')
+    expect(sent.name).toBe('Alloy-NAMEPROOF-1785352700')
+  })
+
+  it('with NO store row yet, the create seeds from the IaC values + the edit', async () => {
+    storeRows.value = []
+
+    await saveCatalogEdit('bp-alloy', { tagline: 'First edit' }, IAC_SEED)
+
+    const post = mutation()
+    expect(post.method).toBe('POST')
+    const sent = post.body!
+    expect(sent.slug).toBe('alloy')
+    expect(sent.tagline).toBe('First edit')
+    // There is nothing stored to preserve on this path, so seeding the row with
+    // the values the page already renders keeps the create non-destructive.
+    expect(sent.name).toBe('Alloy')
+    // The seed carries no icon: the IaC declares none, and the bundled console
+    // asset (`/component-logos/alloy.svg`) is a build-time bundle path, not an
+    // IaC declaration — materializing it as a stored value is the same class of
+    // defect. An absent key leaves the catalog read falling back to the seed.
+    expect(sent.icon_light).toBe('')
+  })
+
+  it('with no store row and no seed, name falls back to the slug', async () => {
+    storeRows.value = []
+
+    await saveCatalogEdit('bp-alloy', { tagline: 'First edit' })
+
+    const sent = mutation().body!
+    expect(sent.slug).toBe('alloy')
+    expect(sent.name).toBe('alloy')
+    expect(sent.tagline).toBe('First edit')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
@@ -182,6 +182,39 @@ export interface CatalogEntryEdit {
 }
 
 /**
+ * CatalogEntryPatch — the fields ONE per-field inline save changes (#5510).
+ *
+ * A per-field save must carry ONLY the keys the operator actually edited. A
+ * key that is ABSENT means "leave whatever the store holds alone"; a key that
+ * is PRESENT-but-empty means "the operator cleared this field" and is written.
+ * `undefined` is therefore load-bearing — never spread a full 5-field record
+ * into a patch to "keep the shape regular".
+ */
+export type CatalogEntryPatch = Partial<CatalogEntryEdit>
+
+/**
+ * toStoreColumns — project a CatalogEntryPatch onto the store's column names,
+ * carrying ONLY the keys the patch actually declares (#5510).
+ *
+ * This is the whole point of the patch type: the returned object is spread
+ * over the authoritative store row, so a key we omit here is a column the
+ * store keeps. Written key-by-key on purpose — a generic key loop would need
+ * a cast to satisfy the per-key value types, and a cast here is exactly how a
+ * stray `undefined` would sneak back into the wire body.
+ */
+function toStoreColumns(patch: CatalogEntryPatch): Partial<CommerceApp> {
+  const columns: Partial<CommerceApp> = {}
+  if (patch.name !== undefined) columns.name = patch.name
+  if (patch.tagline !== undefined) columns.tagline = patch.tagline
+  if (patch.supported_topologies !== undefined) {
+    columns.supported_topologies = patch.supported_topologies
+  }
+  if (patch.icon_light !== undefined) columns.icon_light = patch.icon_light
+  if (patch.icon_dark !== undefined) columns.icon_dark = patch.icon_dark
+  return columns
+}
+
+/**
  * CatalogSaveVerdict — the #3668/#5113 dual-write verdict for one catalog
  * card-save. The catalyst-api `apps` create/update proxy wraps the upstream
  * store row in a `{stored, committed, reason}` envelope
@@ -218,60 +251,75 @@ export function parseCatalogEditEnvelope(body: unknown, slug: string): CatalogSa
 }
 
 /**
- * saveCatalogEdit persists an admin's catalog-entry edit to the Organization
- * commerce catalog store.
+ * saveCatalogEdit persists ONE per-field catalog-entry edit to the
+ * Organization commerce catalog store.
  *
- * The store's UpdateApp does a FULL `$set` of every column from the decoded
- * row, so a partial PUT would zero the untouched columns (deployable,
- * published, helm_chart, …). To stay additive we therefore:
+ * ── #5510: this is a PARTIAL PATCH, not a whole-record replace ──────────
+ *
+ * The wire endpoint cannot express a partial patch: `PUT /catalog/admin/apps/
+ * {id}` decodes the body into a `store.App` and `Store.UpdateApp` issues a
+ * full `$set` of every column (core/services/catalog/store/store.go), so
+ * whatever the body omits is written as its zero value. Partial-patch
+ * SEMANTICS are therefore implemented here, client-side, as read-modify-write
+ * against the authoritative store row:
  *
  *   1. list every store App and find the row whose slug matches this
  *      catalog entry (slugs are bare — the catalog id's `bp-` prefix is
  *      stripped by the caller);
- *   2. if it exists, MERGE the edited fields onto the FULL existing row
- *      (the runtime object still carries every store column even though the
- *      CommerceApp type only declares a few) and PUT it back by its `_id`,
- *      so no column is lost;
+ *   2. if it exists, overlay ONLY the keys `patch` declares onto the FULL
+ *      existing row (the runtime object still carries every store column
+ *      even though the CommerceApp type only declares a few) and PUT it back
+ *      by its `_id`, so no column is lost;
  *   3. if no row exists yet (a seed-only catalog entry the commerce store
- *      never had), POST a new minimal row (slug + the edited fields) so the
- *      edit still persists and overlays the seed on the next catalog read.
+ *      never had), POST a new row from `createSeed` + the patch — there is
+ *      no stored value to preserve on this path, so seeding the row with the
+ *      values the page currently renders keeps the create non-destructive.
+ *
+ * The bug this shape fixes: the caller used to build a FULL 5-field record
+ * from the IaC card and PUT `{...existing, ...allFiveFields}`, so every field
+ * the store held but the IaC lacked was overwritten with an IaC-derived
+ * default on the next per-field save — a Summary-only save silently reverted
+ * `name` and `icon_light`, with a green toast and HTTP 200. The same body is
+ * also what catalyst-api commits to git (commitCatalogAppEditToGit decodes
+ * these exact JSON tags), so a fat body destroyed the value in BOTH legs.
+ * Passing only the edited keys removes the class in both.
  *
  * Returns the CatalogSaveVerdict (#5113 facet-a / UAT row 132): the caller
  * surfaces "Saved to IaC ✓" vs "Saved to store — IaC commit failed: …"
  * instead of closing silently.
+ *
+ * @param slug       catalog entry id (`bp-`-prefixed or bare).
+ * @param patch      ONLY the fields this save edits (#5510).
+ * @param createSeed values to seed a brand-new store row with, used ONLY
+ *                  when no row exists yet. Never applied over a stored value.
  */
 export async function saveCatalogEdit(
   slug: string,
-  edit: CatalogEntryEdit,
+  patch: CatalogEntryPatch,
+  createSeed: CatalogEntryPatch = {},
 ): Promise<CatalogSaveVerdict> {
   const bare = slug.replace(/^bp-/, '')
+  const columns = toStoreColumns(patch)
   const apps = await listApps()
   const existing = apps.find((a) => (a.slug ?? '').replace(/^bp-/, '') === bare)
 
-  // The edited fields, with the legacy `icon` kept in sync to the light
-  // icon when the admin set one (so a single-icon consumer still updates).
-  const patch: Partial<CommerceApp> = {
-    name: edit.name,
-    tagline: edit.tagline,
-    supported_topologies: edit.supported_topologies,
-    icon_light: edit.icon_light,
-    icon_dark: edit.icon_dark,
-  }
-
   if (existing && existing.id) {
-    // Merge onto the full runtime row so untouched columns survive the
-    // full-$set UpdateApp.
-    const merged = { ...existing, ...patch }
+    // Overlay the edited keys onto the full runtime row: the untouched
+    // columns keep their STORED values through the full-$set UpdateApp.
+    const merged: CommerceApp = { ...existing, ...columns }
     const body = await updateCommerce('apps', existing.id, merged)
     return parseCatalogEditEnvelope(body, bare)
   }
 
-  // No store row yet — create one carrying the edit. slug is required by
-  // the store; name falls back to the slug when the admin left it blank.
-  const body = await createCommerce<CommerceApp>('apps', {
+  // No store row yet — create one from the seed + the edit. slug is required
+  // by the store; name falls back to the seed, then to the slug when neither
+  // the edit nor the seed names the entry.
+  const created: CommerceApp = {
+    ...toStoreColumns(createSeed),
+    ...columns,
     slug: bare,
-    name: edit.name || bare,
-    ...patch,
-  })
+    name: patch.name ?? createSeed.name ?? bare,
+  }
+  const body = await createCommerce<CommerceApp>('apps', created)
   return parseCatalogEditEnvelope(body, bare)
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
@@ -11,7 +11,8 @@
  *   • NO single global "Edit" button — each card field is independently editable
  *     in place (name / summary / supported-topologies / icon);
  *   • editing one field and saving commits THAT field via saveCatalogEdit,
- *     merging onto the current values so siblings are preserved;
+ *     sending ONLY that field's keys so no sibling is on the wire (#5510 —
+ *     the merge base is the STORED row, resolved inside saveCatalogEdit);
  *   • the icon field opens the VISUAL icon picker (a grid of the vendored
  *     logos), not a bare filename input;
  *   • a non-admin sees none of the edit affordances.
@@ -46,13 +47,26 @@ vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
   useResolvedDeploymentId: () => ({ deploymentId: undefined, loading: false }),
 }))
 
-// Commerce API — capture per-field saveCatalogEdit calls.
-const saveSpy = vi.fn((slug: string, edit: Record<string, unknown>): Promise<string> => {
-  void edit
-  return Promise.resolve(slug.replace(/^bp-/, ''))
-})
+// Commerce API — capture per-field saveCatalogEdit calls. Three args since
+// #5510: (slug, patch, createSeed). `patch` carries ONLY the edited field;
+// `createSeed` carries the page's IaC values for the no-store-row case.
+const saveSpy = vi.fn(
+  (
+    slug: string,
+    patch: Record<string, unknown>,
+    createSeed: Record<string, unknown> | undefined,
+  ): Promise<string> => {
+    void patch
+    void createSeed
+    return Promise.resolve(slug.replace(/^bp-/, ''))
+  },
+)
 vi.mock('@/lib/commerce.api', () => ({
-  saveCatalogEdit: (slug: string, edit: Record<string, unknown>) => saveSpy(slug, edit),
+  saveCatalogEdit: (
+    slug: string,
+    patch: Record<string, unknown>,
+    createSeed: Record<string, unknown> | undefined,
+  ) => saveSpy(slug, patch, createSeed),
 }))
 
 // Import AFTER mocks.
@@ -160,26 +174,31 @@ describe('CatalogDetail per-field inline editing (#3668 §5A)', () => {
     expect(screen.queryByTestId('catalog-detail-edit-iac')).toBeNull()
   })
 
-  it('editing the NAME field saves only that field, merged onto current values', async () => {
+  it('editing the NAME field sends ONLY name — no sibling keys in the patch (#5510)', async () => {
     renderCatalog()
     fireEvent.click(await screen.findByTestId('cif-name-edit'))
     const input = screen.getByTestId('cif-name-input') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'Grafana (Renamed)' } })
     fireEvent.click(screen.getByTestId('cif-name-save'))
     await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1))
-    const [slug, edit] = saveSpy.mock.calls[0]
+    const [slug, patch, createSeed] = saveSpy.mock.calls[0]
     expect(slug).toBe('bp-grafana')
     // The edited field changed…
-    expect(edit.name).toBe('Grafana (Renamed)')
-    // …and the sibling fields are preserved (merge base), not wiped.
-    expect(edit.tagline).toBe('Visualization and dashboarding')
-    // One vocabulary (#3375 DoD-1): the edit form carries the CANONICAL
-    // topology tokens (the fixture declares them canonical; the form folds
-    // any spelling onto the canonical set).
-    expect(edit.supported_topologies).toEqual(['singleton', 'active-hot-standby'])
+    expect(patch.name).toBe('Grafana (Renamed)')
+    // …and NOTHING else is on the wire. #5510: this used to be the FULL
+    // 5-field record (`{...currentEdit, ...patch}`), which made every save a
+    // whole-record replace and silently reverted store-only siblings.
+    expect(Object.keys(patch)).toEqual(['name'])
+    // The IaC values ride along as the create-only seed, never as a merge base.
+    expect(createSeed?.name).toBe('Grafana')
+    expect(createSeed?.tagline).toBe('Visualization and dashboarding')
+    // One vocabulary (#3375 DoD-1): the seed carries the CANONICAL topology
+    // tokens (the fixture declares them canonical; the page folds any spelling
+    // onto the canonical set).
+    expect(createSeed?.supported_topologies).toEqual(['singleton', 'active-hot-standby'])
   })
 
-  it('editing the SUMMARY field saves tagline only, preserving the name', async () => {
+  it('editing the SUMMARY field sends ONLY tagline — name is not on the wire (#5510)', async () => {
     renderCatalog()
     fireEvent.click(await screen.findByTestId('cif-summary-edit'))
     fireEvent.change(screen.getByTestId('cif-summary-input'), {
@@ -187,12 +206,16 @@ describe('CatalogDetail per-field inline editing (#3668 §5A)', () => {
     })
     fireEvent.click(screen.getByTestId('cif-summary-save'))
     await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1))
-    const edit = saveSpy.mock.calls[0][1]
-    expect(edit.tagline).toBe('New tagline')
-    expect(edit.name).toBe('Grafana')
+    const patch = saveSpy.mock.calls[0][1]
+    expect(patch.tagline).toBe('New tagline')
+    // The live #5510 repro: a Summary-only save carried `name` (IaC-derived)
+    // and overwrote the store's value. `name` must be ABSENT, not merely equal
+    // to the IaC title — absent is what leaves the stored value alone.
+    expect(patch.name).toBeUndefined()
+    expect(Object.keys(patch)).toEqual(['tagline'])
   })
 
-  it('editing SUPPORTED TOPOLOGIES toggles a mode and saves the set', async () => {
+  it('editing SUPPORTED TOPOLOGIES toggles a mode and sends only that set', async () => {
     renderCatalog()
     fireEvent.click(await screen.findByTestId('cif-topologies-edit'))
     // The canonical current set pre-checks singleton + active-hot-standby;
@@ -200,10 +223,14 @@ describe('CatalogDetail per-field inline editing (#3668 §5A)', () => {
     fireEvent.click(screen.getByTestId('catalog-edit-topo-active-active'))
     fireEvent.click(screen.getByTestId('cif-topologies-save'))
     await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1))
-    const edit = saveSpy.mock.calls[0][1] as { supported_topologies: string[] }
+    const patch = saveSpy.mock.calls[0][1] as {
+      supported_topologies: string[]
+      name?: string
+    }
     // One vocabulary (#3375 DoD-1): the saved set is canonical.
-    expect(edit.supported_topologies).toContain('active-active')
-    expect(edit.supported_topologies).toContain('singleton')
+    expect(patch.supported_topologies).toContain('active-active')
+    expect(patch.supported_topologies).toContain('singleton')
+    expect(patch.name).toBeUndefined()
   })
 
   it('Cancel closes a field editor without saving', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.merge-base-5510.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.merge-base-5510.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * CatalogDetail.merge-base-5510.test.tsx — the END-TO-END lock-in for #5510:
+ * editing ONE field in the catalog card editor must not silently revert other,
+ * untouched fields.
+ *
+ * Unlike CatalogDetail.edit.test.tsx (which mocks saveCatalogEdit and inspects
+ * the patch) this suite mocks ONLY `fetch`, so the whole chain runs for real —
+ * CatalogDetail's merge-base construction → CatalogInlineField.save →
+ * saveCatalogEdit's read-modify-write → the outbound PUT body. That is the
+ * layer the live defect lived at: every individual piece looked correct, and
+ * the destruction only appeared in the bytes on the wire.
+ *
+ * The live hw291 reproduction, replayed here verbatim (`bp-alloy`, store row
+ * `b6ac3a3b…`):
+ *
+ *   IaC card:   title "Alloy", no iconLight  (the incomplete base)
+ *   store row:  name "Alloy-NAMEPROOF-1785352700", icon_light ".../cilium.svg"
+ *   action:     edit Summary only → Save     ("Saved to IaC ✓", PUT 200)
+ *   defect:     name → "Alloy", icon_light → ".../alloy.svg" (the bundled asset)
+ *
+ * Both destroyed values were UAT walk evidence, so this mechanism erased exactly
+ * the durable state an acceptance walk establishes while reporting success.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+// Admin (the edit affordances render) + light theme + no self-discovered
+// deploymentId (keeps the bootstrap-singleton branch off).
+vi.mock('@/shared/lib/useCatalogAdmin', () => ({ useCatalogAdmin: () => true }))
+vi.mock('@/shared/lib/useTheme', () => ({
+  useTheme: () => ({ theme: 'light' as const, toggle: () => {} }),
+}))
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: undefined, loading: false }),
+}))
+
+// NOTE: @/lib/commerce.api is deliberately NOT mocked — saveCatalogEdit is the
+// unit under test here, exercised through the page.
+import { CatalogDetail } from './CatalogDetail'
+
+/**
+ * The IaC card as the catalog read returns it: title "Alloy", NO iconLight.
+ * This is the incomplete base the old code built its whole-record replace from.
+ */
+const ALLOY_CATALOG = {
+  name: 'bp-alloy',
+  version: '1.0.2',
+  card: {
+    title: 'Alloy',
+    summary: 'Unified node agent for logs, metrics, and traces',
+    category: 'observability',
+  },
+  origin: 'upstream',
+  source: 'gitea',
+  raw: { spec: { multiInstance: { enabled: true }, topology: { supported: ['singleton'] } } },
+}
+
+/** The live store row — `name` + `icon_light` exist ONLY in the store. */
+const NAMEPROOF_ROW = {
+  id: 'b6ac3a3b-0000-4000-8000-000000000000',
+  slug: 'alloy',
+  name: 'Alloy-NAMEPROOF-1785352700',
+  tagline: 'Unified node agent',
+  icon_light: '/component-logos/cilium.svg',
+  icon_dark: '',
+  supported_topologies: ['singleton'],
+  published: true,
+  deployable: true,
+}
+
+interface Call {
+  url: string
+  method: string
+  body: Record<string, unknown> | null
+}
+
+const calls: Call[] = []
+const storeRows: { value: Array<Record<string, unknown>> } = { value: [] }
+
+function jsonRes(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as unknown as Response)
+}
+
+function renderCatalog() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const catalogRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/catalog/$blueprintName',
+    component: CatalogDetail,
+  })
+  const appRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/app/$componentId',
+    component: () => <div data-testid="app-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([catalogRoute, appRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/catalog/alloy'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+/** The single card-save mutation (PUT or POST) — never the list GETs. */
+function mutation(): Call {
+  const writes = calls.filter(
+    (c) => c.url.includes('/org/commerce/apps') && c.method !== 'GET',
+  )
+  expect(writes).toHaveLength(1)
+  return writes[0]
+}
+
+beforeEach(() => {
+  calls.length = 0
+  storeRows.value = [{ ...NAMEPROOF_ROW }]
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+    let body: Record<string, unknown> | null = null
+    if (typeof init?.body === 'string') body = JSON.parse(init.body) as Record<string, unknown>
+    calls.push({ url, method, body })
+    // Order matters: the commerce path must be matched BEFORE the generic
+    // /catalog/ check, and /instances before both.
+    if (url.includes('/instances')) return jsonRes({ items: [] })
+    if (url.includes('/org/commerce/apps')) {
+      if (method === 'GET') return jsonRes(storeRows.value)
+      return jsonRes({ stored: true, committed: true, store: body })
+    }
+    if (url.includes('/v1/catalog/')) return jsonRes(ALLOY_CATALOG)
+    return jsonRes({})
+  }) as typeof fetch
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('CatalogDetail — a single-field Save must not destroy siblings (#5510)', () => {
+  it('a Summary-only Save preserves the store-only name AND icon_light on the wire', async () => {
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('cif-summary-edit'))
+    fireEvent.change(screen.getByTestId('cif-summary-input'), {
+      target: { value: 'Summary edited by the walk' },
+    })
+    fireEvent.click(screen.getByTestId('cif-summary-save'))
+
+    // Non-vacuity: wait for the save to land and assert the PUT reached the
+    // store row's _id. Nothing below can pass on a save that never happened.
+    await waitFor(() => expect(mutation().method).toBe('PUT'))
+    const put = mutation()
+    expect(put.url).toContain('/org/commerce/apps/b6ac3a3b-0000-4000-8000-000000000000')
+    // And the UI reported the durable verdict, i.e. the round-trip completed.
+    const toast = await screen.findByTestId('cif-summary-save-verdict')
+    expect(toast.textContent).toBe('Saved to IaC ✓')
+
+    const sent = put.body!
+    expect(sent.tagline).toBe('Summary edited by the walk')
+    // The exact two reverts observed live — now preserved.
+    expect(sent.name).toBe('Alloy-NAMEPROOF-1785352700')
+    expect(sent.icon_light).toBe('/component-logos/cilium.svg')
+    // Restated as the defect: the IaC title and the bundled console asset must
+    // NOT be what goes on the wire for a field the operator never touched.
+    expect(sent.name).not.toBe('Alloy')
+    expect(sent.icon_light).not.toBe('/component-logos/alloy.svg')
+  })
+
+  it('an icon-only Save preserves the store-only name (the reverse pairing)', async () => {
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('cif-icon-edit'))
+    fireEvent.click(screen.getByTestId('iconpicker-light-tile-loki'))
+    fireEvent.click(screen.getByTestId('cif-icon-save'))
+
+    await waitFor(() => expect(mutation().method).toBe('PUT'))
+    const sent = mutation().body!
+    expect(String(sent.icon_light)).toContain('loki')
+    expect(sent.name).toBe('Alloy-NAMEPROOF-1785352700')
+    expect(sent.tagline).toBe('Unified node agent')
+  })
+
+  it('an explicit NAME edit still persists (requirement 3, direction A)', async () => {
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('cif-name-edit'))
+    fireEvent.change(screen.getByTestId('cif-name-input'), {
+      target: { value: 'Alloy-NAMEPROOF-2' },
+    })
+    fireEvent.click(screen.getByTestId('cif-name-save'))
+
+    await waitFor(() => expect(mutation().method).toBe('PUT'))
+    const sent = mutation().body!
+    expect(sent.name).toBe('Alloy-NAMEPROOF-2')
+    // …and the untouched icon still survives.
+    expect(sent.icon_light).toBe('/component-logos/cilium.svg')
+  })
+
+  it('with an EMPTY store the IaC value still renders (requirement 3, direction B)', async () => {
+    storeRows.value = []
+    renderCatalog()
+    // The IaC card title renders — the store holds nothing to overlay.
+    const titleEl = await screen.findByTestId('catalog-title')
+    expect(titleEl.textContent).toBe('Alloy')
+    // The hero icon falls back to the bundled console asset (resolveCatalogIcon
+    // step 3) since the IaC declares no iconLight. Rendering it is correct;
+    // PERSISTING it on an unrelated save is the defect.
+    const heroLogo = document.querySelector('img.hero-logo') as HTMLImageElement | null
+    expect(heroLogo?.getAttribute('src')).toContain('/component-logos/alloy.svg')
+
+    // A first Summary edit then CREATES the row, seeded from the IaC values —
+    // and must not bake the bundled console asset into the store.
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    fireEvent.change(screen.getByTestId('cif-summary-input'), {
+      target: { value: 'First ever summary' },
+    })
+    fireEvent.click(screen.getByTestId('cif-summary-save'))
+
+    await waitFor(() => expect(mutation().method).toBe('POST'))
+    const sent = mutation().body!
+    expect(sent.slug).toBe('alloy')
+    expect(sent.tagline).toBe('First ever summary')
+    expect(sent.name).toBe('Alloy')
+    expect(sent.icon_light).toBe('')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -277,20 +277,44 @@ export function CatalogDetail() {
   const logoLightUrl = resolveCatalogIcon(card, 'light', bundledLogo)
   const logoDarkUrl = resolveCatalogIcon(card, 'dark', bundledLogo)
 
-  // #3668 §5A — the FULL current catalog-edit values, the merge base every
-  // per-field inline save round-trips so editing one field never clobbers a
-  // sibling (saveCatalogEdit does a full upsert). Light-icon pre-fills from the
-  // CURRENT IaC icon (`card.iconLight`), falling back to the bundled asset so
-  // the icon picker opens showing the rendered default rather than blank.
-  const currentEdit: CatalogEntryEdit = {
+  // #5510 — the IaC-declared card values, passed to each inline field as its
+  // `createSeed`: the values a brand-new store row is created from when this
+  // Blueprint has none yet. This is NOT a merge base. It used to be one —
+  // every per-field save PUT `{...currentEdit, ...patch}`, i.e. a whole-record
+  // replace built from an INCOMPLETE base (the IaC card only), so any field
+  // the store held but the IaC lacked was overwritten with an IaC-derived
+  // default. Live on hw291: a Summary-only save reverted `name`
+  // ("Alloy-NAMEPROOF-…" → "Alloy") and `icon_light`
+  // (".../cilium.svg" → ".../alloy.svg") — both of them UAT walk evidence —
+  // with a green "Saved to IaC ✓" toast and HTTP 200. The merge base now lives
+  // in saveCatalogEdit and is the STORED row.
+  //
+  // `icon_light` deliberately does NOT fall back to `bundledLogo` here: that
+  // asset is a build-time console bundle path, not an IaC declaration, and
+  // seeding it would materialize a console default as a persisted value. The
+  // bundled fallback belongs to the icon editor's DRAFT (below), so the picker
+  // still opens showing the rendered default rather than blank.
+  const iacSeed: CatalogEntryEdit = {
     name: title,
     tagline: card.tagline || card.summary || '',
     supported_topologies: topologies.map(canonicalizeMode),
-    icon_light: card.iconLight || bundledLogo || '',
+    icon_light: card.iconLight || '',
     icon_dark: card.iconDark || '',
   }
+  // The icon editor's initial DRAFT — the currently RENDERED icons, so the
+  // picker opens on the visible default (#3668 §5B) instead of blank. Only a
+  // Save on the icon field itself persists these.
+  const iconDraft = {
+    light: card.iconLight || bundledLogo || '',
+    dark: card.iconDark || '',
+  }
   // Refetch the catalog item after any per-field save so the new value renders
-  // live (and the next field's merge base picks up the saved sibling).
+  // live (and the next field's create-seed picks up the saved sibling).
+  //
+  // #5510 note: the invalidation below is no longer load-bearing for DATA
+  // SAFETY — the merge base is the stored row, resolved inside saveCatalogEdit,
+  // so a stale cache can no longer revert a sibling. It remains required for
+  // the LIVE RENDER (rows 127/132/133/142/153) and for a fresh create-seed.
   //
   // #5496 — this MUST invalidate `qualifiedName`, the key the query is
   // registered under at :172. It previously used the bare `name`, so the key
@@ -340,10 +364,10 @@ export function CatalogDetail() {
             blueprintId={qualifiedName}
             fieldKey="icon"
             label="Icon (light + dark)"
-            current={currentEdit}
+            createSeed={iacSeed}
             editable={isAdmin && !editingIaC}
             block
-            initialDraft={{ light: currentEdit.icon_light, dark: currentEdit.icon_dark }}
+            initialDraft={iconDraft}
             renderDisplay={() =>
               logoUrl ? (
                 <img src={logoUrl} alt={title} className="hero-logo" loading="lazy" />
@@ -398,9 +422,9 @@ export function CatalogDetail() {
               blueprintId={qualifiedName}
               fieldKey="name"
               label="Display name"
-              current={currentEdit}
+              createSeed={iacSeed}
               editable={isAdmin && !editingIaC}
-              initialDraft={currentEdit.name}
+              initialDraft={iacSeed.name}
               renderDisplay={() => <span data-testid="catalog-title">{title}</span>}
               renderEditor={(draft, setDraft) => (
                 <input
@@ -449,9 +473,9 @@ export function CatalogDetail() {
                 blueprintId={qualifiedName}
                 fieldKey="summary"
                 label="Summary"
-                current={currentEdit}
+                createSeed={iacSeed}
                 editable={isAdmin && !editingIaC}
-                initialDraft={currentEdit.tagline}
+                initialDraft={iacSeed.tagline}
                 renderDisplay={() => (
                   <span data-testid="catalog-summary">
                     {card.tagline || card.summary || card.description || (
@@ -769,14 +793,14 @@ export function CatalogDetail() {
                 blueprintId={qualifiedName}
                 fieldKey="topologies"
                 label="Supported topologies"
-                current={currentEdit}
+                createSeed={iacSeed}
                 editable={isAdmin && !editingIaC}
                 block
-                initialDraft={currentEdit.supported_topologies}
+                initialDraft={iacSeed.supported_topologies}
                 renderDisplay={() => (
                   <span className="cif-topo-summary" data-testid="catalog-topologies-edit-summary">
-                    {currentEdit.supported_topologies.length > 0
-                      ? currentEdit.supported_topologies.join(', ')
+                    {iacSeed.supported_topologies.length > 0
+                      ? iacSeed.supported_topologies.join(', ')
                       : 'set supported topologies…'}
                   </span>
                 )}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.tsx
@@ -10,10 +10,19 @@
  *
  * This component is the standard inline-edit affordance, one per field: the
  * field renders its current value with a subtle "Edit" pencil on hover; clicking
- * it (or the value) expands an inline editor in place; Save commits THAT field
- * independently (merging onto the current values via the SAME saveCatalogEdit
- * Gitea/store seam #3702/#3710 wired, so no sibling field is clobbered); Cancel
- * reverts. Escape cancels, ⌘/Ctrl+Enter saves — standard inline-edit ergonomics.
+ * it (or the value) expands an inline editor in place; Save commits THAT FIELD
+ * ALONE through the shared saveCatalogEdit Gitea/store seam (#3702/#3710);
+ * Cancel reverts. Escape cancels, ⌘/Ctrl+Enter saves — standard inline-edit
+ * ergonomics.
+ *
+ * #5510 — a save sends ONLY the edited field. It used to send a FULL 5-field
+ * record built by spreading the page's IaC-derived values under the patch
+ * (`{...current, ...toPatch(draft)}`), which made every save a whole-record
+ * replace: any field the store held but the IaC lacked was overwritten with an
+ * IaC-derived default. A Summary-only save silently reverted `name` and
+ * `icon_light` — green toast, HTTP 200, data gone. The merge base is now the
+ * STORE row (applied inside saveCatalogEdit), and the page's IaC values are
+ * only a `createSeed` for the case where no store row exists yet.
  *
  * Field kinds (the `render`/`editor` are injected by the caller so this stays
  * generic — one mechanism for text, textarea, topology-multiselect, and the
@@ -24,7 +33,7 @@
  */
 
 import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { saveCatalogEdit, type CatalogEntryEdit } from '@/lib/commerce.api'
+import { saveCatalogEdit, type CatalogEntryEdit, type CatalogEntryPatch } from '@/lib/commerce.api'
 
 /** How long the save-verdict toast stays visible (#5113 facet-a). */
 export const TOAST_MS = 6_000
@@ -42,19 +51,25 @@ export interface CatalogInlineFieldProps<T> {
   fieldKey: string
   /** Human label for the field (shown above the editor + as the a11y name). */
   label: string
-  /** The FULL current catalog values — the merge base so a per-field save
-   *  preserves every sibling field (saveCatalogEdit does a full upsert). */
-  current: CatalogEntryEdit
-  /** This field's working draft initial value (derived from `current`). */
+  /**
+   * #5510 — the page's IaC-derived values, used ONLY to seed a store row that
+   * does not exist yet. It is NOT a merge base: the merge base is the stored
+   * row, resolved inside saveCatalogEdit. Spreading these values under the
+   * patch is the defect this prop's name now forbids — it made every
+   * per-field save a whole-record replace that carried IaC-derived defaults
+   * over store-only values.
+   */
+  createSeed: CatalogEntryEdit
+  /** This field's working draft initial value. */
   initialDraft: T
   /** Render the read-only display of the current value (the non-editing view). */
   renderDisplay: () => ReactNode
   /** Render the inline editor for the working draft. */
   renderEditor: (draft: T, setDraft: (next: T) => void) => ReactNode
-  /** Fold the working draft into a CatalogEntryEdit patch (only this field's keys). */
-  toPatch: (draft: T) => Partial<CatalogEntryEdit>
+  /** Fold the working draft into a patch of ONLY this field's keys. */
+  toPatch: (draft: T) => CatalogEntryPatch
   /** Called after a successful per-field save so the caller can refetch. */
-  onSaved: (saved: CatalogEntryEdit) => void
+  onSaved: (savedPatch: CatalogEntryPatch) => void
   /** Admin gate — when false the field renders display-only (no edit affordance). */
   editable: boolean
   /** Optional: render the editor inline-beside the label (text) vs block (icons). */
@@ -65,7 +80,7 @@ export function CatalogInlineField<T>({
   blueprintId,
   fieldKey,
   label,
-  current,
+  createSeed,
   initialDraft,
   renderDisplay,
   renderEditor,
@@ -126,11 +141,14 @@ export function CatalogInlineField<T>({
   const save = async () => {
     setSaving(true)
     setError(null)
-    // Merge ONLY this field's keys onto the full current values so the save is
-    // surgical — every sibling field round-trips unchanged.
-    const edit: CatalogEntryEdit = { ...current, ...toPatch(draft) }
+    // #5510 — send ONLY this field's keys. saveCatalogEdit overlays them onto
+    // the STORED row, so every sibling keeps its stored value; `createSeed` is
+    // consulted only when there is no stored row to overlay. Do NOT spread the
+    // page's values under this patch — that is the whole-record replace that
+    // silently reverted untouched fields.
+    const patch: CatalogEntryPatch = toPatch(draft)
     try {
-      const verdict = await saveCatalogEdit(blueprintId, edit)
+      const verdict = await saveCatalogEdit(blueprintId, patch, createSeed)
       setSaving(false)
       setEditing(false)
       // Row 132 — surface the dual-write verdict instead of closing
@@ -148,7 +166,7 @@ export function CatalogInlineField<T>({
           text: 'Saved to store — no IaC verdict reported by the server',
         })
       }
-      onSaved(edit)
+      onSaved(patch)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
       setSaving(false)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.verdict.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.verdict.test.tsx
@@ -37,7 +37,7 @@ function renderField() {
       blueprintId="bp-wordpress"
       fieldKey="name"
       label="Display name"
-      current={CURRENT}
+      createSeed={CURRENT}
       editable
       initialDraft={CURRENT.name}
       renderDisplay={() => <span>WordPress</span>}


### PR DESCRIPTION
Refs #5510

## The defect

Editing ONE field in the catalog card editor silently reverted OTHER, untouched fields in the store. Green toast, HTTP 200, no error, data gone. Reproduced live on hw291 (`bp-alloy`, store row `b6ac3a3b…`) from a **Summary-only** save:

```
before:  name       = "Alloy-NAMEPROOF-1785352700"
         icon_light = "/component-logos/cilium.svg"
action:  edit Summary only -> Save        ("Saved to IaC ✓", PUT 200)
after:   name       = "Alloy"                        <- reverted, never touched
         icon_light = "/component-logos/alloy.svg"   <- reverted, never touched
```

Both destroyed values were **UAT walk evidence** (a NAMEPROOF marker and a deliberately-changed icon), so this mechanism erased exactly the durable state an acceptance walk establishes — while reporting success. Same "a control that reports rather than does" family as #5477 / #5489 / #5501 / #5508 / #5511 / #5513 / #5514.

**Not #5496.** That is the query-key invalidation; the browser was fresh here and the card was fetched in the same load. Both fixes are needed; neither subsumes the other. After this change the invalidation is no longer load-bearing for data safety — only for the live render.

## Approach taken: true partial patch (not a store-backed merge base)

The ticket offered either building the merge base from the store row or making the write a true partial patch, preferring the patch. **I took the partial patch**, because it removes the class rather than one instance: with a patch, no future caller can reintroduce the bug by assembling a base from the wrong source. There is no longer any base for the component to get wrong.

**Can the endpoint express a partial patch? On the wire, no — and that is stated explicitly rather than compromised silently.** `PUT /catalog/admin/apps/{id}` decodes the body into a `store.App` and `Store.UpdateApp` issues a full `$set` of every column (`core/services/catalog/store/store.go:295`), so whatever the body omits is written as its zero value. Partial-patch **semantics** are therefore implemented client-side in `saveCatalogEdit` as read-modify-write against the authoritative store row — which is where the merge now happens, on the STORED row, not on an IaC-derived guess:

- `saveCatalogEdit(slug, patch, createSeed?)` takes a `CatalogEntryPatch` (`Partial<CatalogEntryEdit>`) of only the edited keys.
- An **absent** key means "leave the stored value alone". A **present-but-empty** key means "the operator cleared this field" and is written — so clearing an icon override still works. `undefined` is load-bearing; `toStoreColumns` is written key-by-key rather than as a generic loop precisely so no cast can let a stray `undefined` back onto the wire.
- The page's IaC values become a `createSeed`, consulted **only** when no store row exists yet (nothing stored to destroy on that path).

This also fixes the git leg for free: catalyst-api's `commitCatalogAppEditToGit` decodes the same PUT body, so a fat body destroyed the value in **both** the store and `catalog-sovereign` git. A thin body cannot.

### Root cause, precisely

`CatalogInlineField.save` built the write as `{ ...current, ...toPatch(draft) }`, where `current` was `CatalogDetail`'s `currentEdit` — assembled purely from the IaC card (`name: title`, `icon_light: card.iconLight || bundledLogo || ''`) and never from the store row. Every save was a whole-record replace built from an **incomplete base**, so any field the store held but the IaC lacked came back as an IaC-derived default.

One extra detail worth naming: the seed deliberately **drops** the `bundledLogo` fallback. That asset is a build-time console bundle path, not an IaC declaration, and persisting it would materialize a console default as stored state — the same class of defect at create time. The fallback stays in the icon editor's **draft** so the picker still opens on the rendered default rather than blank (#3668 §5B preserved).

## No-regress (requirement 3), both directions covered

- An explicit user edit still persists — asserted at both layers.
- An IaC-sourced value still renders when the store has nothing — asserted by rendering with an empty store and checking the hero title and icon `src`.

## Tests — 10 new, verified FAIL on unfixed then PASS on the fix

`src/lib/commerce.api.partial-patch-5510.test.ts` (6) — the seam: store-only siblings survive a Summary-only and an icon-only save, an explicit edit persists, an explicit clear is written, and both create paths seed correctly. Non-vacuous: every case asserts the mutation actually reached the wire (exactly one PUT/POST, against the row's `_id`, with the returned verdict).

`src/pages/sovereign/CatalogDetail.merge-base-5510.test.tsx` (4) — the faithful reproduction, with **only `fetch`** mocked so `CatalogDetail` -> `CatalogInlineField` -> `saveCatalogEdit` -> the outbound PUT body all run for real. That is the layer the defect lived at: every piece looked correct in isolation and the destruction only appeared in the bytes on the wire. Non-vacuous: waits for the PUT, asserts its URL carries the row `_id`, and asserts the UI reported "Saved to IaC ✓" (the round-trip completed).

Observed against the **unfixed** code — the live symptom byte for byte:

```
× a Summary-only Save preserves the store-only name AND icon_light on the wire
  AssertionError: expected 'Alloy' to be 'Alloy-NAMEPROOF-1785352700'
× an explicit NAME edit still persists (requirement 3, direction A)
  AssertionError: expected '/component-logos/alloy.svg' to be '/component-logos/cilium.svg'
× with an EMPTY store the IaC value still renders (requirement 3, direction B)
  AssertionError: expected '/component-logos/alloy.svg' to be ''
 Test Files  1 failed (1)
      Tests  4 failed (4)
```

Observed against the fix:

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

`CatalogDetail.edit.test.tsx` — its assertions **locked in the buggy contract** (`expect(edit.tagline).toBe('Visualization and dashboarding')` on a name-only save, i.e. "the fat body is correct"). Rewritten to assert the patch-only contract: `Object.keys(patch)` is exactly the edited field, and on a Summary save `patch.name` is **undefined** — absent, not merely equal to the IaC title, since absent is what leaves the stored value alone. Those three rewritten cases also fail on the unfixed code (3 failed | 10 passed).

## Gates

```
$ npx tsc -b
(clean, exit 0)

$ npm run build
✓ 10245 modules transformed.
✓ built in 1.39s

$ npx vitest run
 Test Files  3 failed | 204 passed (207)
      Tests  9 failed | 1963 passed (1972)

$ npx eslint <7 changed files>
(clean, no output)
```

The 9 failures are **pre-existing and unrelated** — verified by running the full suite on the pristine tree at the same commit: `Test Files 3 failed | 202 passed (205)`, `Tests 9 failed | 1953 passed (1962)`, the same 3 files (`SovereignConsoleLayout.test.tsx`, `SettingsPage.test.tsx`, `StepComponents.test.tsx`) and the same 9 tests. None of the three imports `commerce.api`, `CatalogDetail`, or `CatalogInlineField`. Test count moved 1962 -> 1972 (+10 new, all passing).

No `as` casts were added to satisfy the compiler. The type change is a narrowing of `saveCatalogEdit`'s second parameter plus a renamed prop; `tsc -b` surfaced no other consumers, and the two test files that construct `CatalogInlineField` were updated properly rather than cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
