### PR TITLE
fix(openova-mcp): route Org-context reads to the own-org seam so per-Org MCP tools work

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
@@ -79,6 +79,14 @@ func TestPathIsOrgSafe(t *testing.T) {
 		"/api/v1/organizations",
 		"/api/v1/parent-domains",
 		"/api/v1/org/commerce/plans",
+		// #5516 — the DEPLOYMENT-ADDRESSED Application seam is Sovereign-wide
+		// (HandleApplicationList/Get resolve across every namespace) and stays
+		// denied for an Org session. This is why an Org-scoped bearer cannot be
+		// made to work on it by stamping a deployment_id claim: the guard never
+		// looks at deployment_id, only at the tier. The own-org seam
+		// /api/v1/org/applications (allowlisted above) is the reachable path.
+		"/api/v1/sovereigns/29b7e14918178f7e/applications",
+		"/api/v1/sovereigns/29b7e14918178f7e/applications/shop",
 		// #4937 stays NARROW: the sibling catalyst/v1 app surfaces (endpoint
 		// mutation, launch-url) are NOT opened to Org sessions by this change.
 		"/catalyst/v1/apps/uid-1/endpoints",
@@ -124,6 +132,62 @@ func TestOrgScopeGuard_OrgScoped_DeniesSovereignEndpoint(t *testing.T) {
 	guard.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("org-scoped session must be 403'd on deployments, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOrgScopeGuard_OrgScoped_DeniesDeploymentAddressedApplicationRoutes is
+// the #5516 root-cause proof, and the reason the fix lives in the openova-MCP
+// facade rather than in the bearer the Sovereign mints.
+//
+// The per-Org agenity MCP is handed an Org-scoped session bearer
+// (sovereign_mcp_bearer_seed.go: tier=org-admin, org+org_id=<slug>, NO
+// deployment_id). Its read tools used to call the deployment-addressed seam
+// GET /api/v1/sovereigns/{id}/applications, which fails on the MCP side with
+// "no deployment binding on the caller's token".
+//
+// The tempting fix — stamp a deployment_id claim onto the minted bearer — does
+// NOT work, and this test is what proves it: OrgScopeGuard's verdict is a pure
+// function of the TIER (claimsAreOrgScoped) and the PATH, and the
+// deployment-addressed path is not allowlisted. So a deployment_id would only
+// convert the MCP-side error into an upstream 403 `org-scoped-forbidden` — an
+// opaque failure further from its cause. Both legs are asserted below:
+// the deployment-addressed seam 403s, the own-org seam passes.
+func TestOrgScopeGuard_OrgScoped_DeniesDeploymentAddressedApplicationRoutes(t *testing.T) {
+	h := &Handler{log: quietLog()}
+	guard := h.OrgScopeGuard(http.HandlerFunc(orgScopeGuardTestHandler))
+
+	// The exact claim set mintOrgScopedMCPBearer produces, PLUS a
+	// deployment_id — i.e. the hypothetical "fixed" bearer. It still 403s.
+	orgClaimsWithDeployment := &auth.Claims{
+		Email:        "openova-mcp@acme",
+		Tier:         orgScopedTier,
+		Org:          "acme",
+		DeploymentID: "29b7e14918178f7e",
+	}
+
+	for _, path := range []string{
+		"/api/v1/sovereigns/29b7e14918178f7e/applications",
+		"/api/v1/sovereigns/29b7e14918178f7e/applications/shop",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, orgClaimsWithDeployment))
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s: org-scoped session must be 403'd even WITH a deployment_id claim, got %d body=%s",
+				path, rec.Code, rec.Body.String())
+		}
+	}
+
+	// The seam the MCP must use instead is reachable for the SAME session —
+	// otherwise the assertions above would merely prove "everything 403s".
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/org/applications", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, orgClaimsWithDeployment))
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("the own-org Application seam must be reachable for an Org session, got %d body=%s",
+			rec.Code, rec.Body.String())
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed.go
@@ -52,6 +52,26 @@
 //	context=sovereign and 403 under the #4110 host-scope guard — the exact
 //	wedge values.yaml warns about.
 //
+// It deliberately carries NO `deployment_id` claim (#5516):
+//
+//	Neither HandlePinVerify nor auth_org_handover stamps `deployment_id` on
+//	an Org-scoped session — only the mothership HANDOVER path (auth_handover.go)
+//	does, for a sovereign-admin. Adding one here would BREAK the byte-for-byte
+//	parity this mint is contracted to hold, and it would fix nothing: the
+//	openova-MCP tools that once demanded the claim used it to address the
+//	Sovereign-wide seam `/api/v1/sovereigns/{id}/applications`, which
+//	OrgScopeGuard 403s for ANY tier=org-admin session regardless of its claims
+//	(the path is not in orgSafePathPrefixes — see
+//	TestOrgScopeGuard_OrgScoped_DeniesDeploymentAddressedApplicationRoutes).
+//	Stamping the claim would only convert the MCP's "no deployment binding"
+//	error into an upstream `org-scoped-forbidden` 403.
+//
+//	The fix therefore lives in the MCP facade: Org context reads the own-org
+//	seam GET /api/v1/org/applications (allowlisted, namespace resolved
+//	server-side from X-Tenant-Host), mirroring what create_application already
+//	does with POST /api/v1/org/applications. Do NOT re-add a deployment_id
+//	claim here to "unblock" an MCP tool — route the tool instead.
+//
 // Why this path (NOT bare secret/agenity/...):
 //
 //	Identical reasoning to the Anthropic seed (sovereign_anthropic_seed.go):
@@ -180,8 +200,28 @@ func mintOrgScopedMCPBearer(signer customClaimsSigner, slug, email string) (stri
 		"typ":    "session",
 		"org":    slug,
 		"org_id": slug,
+		// NO "deployment_id" — see the file doc comment §"It deliberately
+		// carries NO deployment_id claim (#5516)". The key set here is locked to
+		// HandlePinVerify's Org-scoped session by
+		// Test_mintOrgScopedMCPBearer_ClaimKeySetMatchesPinVerifyOrgSession.
 	}
 	return signer.SignCustomClaims(claims)
+}
+
+// orgScopedSessionClaimKeys is the EXACT claim key set an Org-scoped Catalyst
+// session carries, as minted by HandlePinVerify (auth.go, org branch) and
+// auth_org_handover (org_handover.go). mintOrgScopedMCPBearer above MUST
+// produce this same set — the MCP + OrgScopeGuard resolve the seeded service
+// bearer and an interactive Org-console session through identical code, so a
+// divergence means the headless path is being authorized on a shape the
+// interactive path never produces.
+//
+// `deployment_id` is absent by design (#5516): an Org-scoped session is not
+// deployment-bound. Only the mothership handover mints that claim, for a
+// sovereign-admin.
+var orgScopedSessionClaimKeys = []string{
+	"iss", "sub", "email", "email_verified", "role", "tier",
+	"realm_access", "iat", "exp", "jti", "typ", "org", "org_id",
 }
 
 // customClaimsSigner is the narrow surface this producer needs from the

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed_test.go
@@ -159,6 +159,72 @@ func Test_mintOrgScopedMCPBearer_ClaimShape(t *testing.T) {
 	}
 }
 
+// Test_mintOrgScopedMCPBearer_ClaimKeySetMatchesPinVerifyOrgSession locks the
+// seeded service bearer's claim key set to orgScopedSessionClaimKeys — the set
+// HandlePinVerify (auth.go, Org branch) and auth_org_handover mint for an
+// interactive Org-console session.
+//
+// The load-bearing assertion is the EXACT-SET match, in both directions: a
+// missing key fails, and so does an EXTRA one. That second direction is the
+// #5516 guard. `deployment_id` is absent from an Org session on every mint
+// path, and the deployment-addressed seam it would address is 403'd for
+// tier=org-admin regardless (see
+// TestOrgScopeGuard_OrgScoped_DeniesDeploymentAddressedApplicationRoutes), so
+// re-adding it here would break parity while fixing nothing. If an MCP tool
+// needs Org data, route it to the own-org seam instead of widening this token.
+func Test_mintOrgScopedMCPBearer_ClaimKeySetMatchesPinVerifyOrgSession(t *testing.T) {
+	signer := newTestSigner(t)
+
+	raw, err := mintOrgScopedMCPBearer(signer, "acme", "owner@acme.omani.homes")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	pub, _ := signer.PublicRSAKey()
+	claims := jwt.MapClaims{}
+	if _, perr := jwt.ParseWithClaims(raw, claims, func(*jwt.Token) (any, error) { return pub, nil },
+		jwt.WithValidMethods([]string{"RS256"})); perr != nil {
+		t.Fatalf("parse minted bearer: %v", perr)
+	}
+
+	// Vacuity guard: without a decoded, populated claim map every set
+	// comparison below would pass on nothing. Assert the map is non-empty AND
+	// carries a known-present control claim before comparing sets.
+	if len(claims) == 0 {
+		t.Fatal("minted bearer decoded to an EMPTY claim map — the set assertions would pass vacuously")
+	}
+	if got, _ := claims["org_id"].(string); got != "acme" {
+		t.Fatalf("control claim org_id = %q, want acme (the parse produced an unusable map)", got)
+	}
+
+	want := map[string]bool{}
+	for _, k := range orgScopedSessionClaimKeys {
+		want[k] = true
+	}
+
+	// Direction 1 — every contracted claim is present.
+	for k := range want {
+		if _, ok := claims[k]; !ok {
+			t.Errorf("minted bearer is MISSING contracted claim %q", k)
+		}
+	}
+	// Direction 2 — no claim beyond the contract. This is what fails if
+	// deployment_id (or any other claim an Org console session never carries)
+	// is stamped onto the service bearer.
+	for k := range claims {
+		if !want[k] {
+			t.Errorf("minted bearer carries claim %q, which an Org-scoped session (HandlePinVerify / auth_org_handover) never mints — parity broken", k)
+		}
+	}
+
+	// Spelled out for the reader: the claim the openova-MCP's requireDeployment
+	// used to demand is deliberately absent, and the MCP no longer asks for it
+	// in Org context.
+	if _, present := claims["deployment_id"]; present {
+		t.Error("deployment_id must NOT be stamped on an Org-scoped bearer (#5516) — the deployment-addressed seam is 403'd for tier=org-admin anyway; route the MCP tool to /api/v1/org/applications instead")
+	}
+}
+
 // Test_mintOrgScopedMCPBearer_SyntheticSubjectWhenNoEmail verifies the
 // headless-Org fallback: no owner email ⇒ a stable Org-scoped synthetic
 // subject (never an empty claim).

--- a/products/openova-mcp/internal/catalystapi/client.go
+++ b/products/openova-mcp/internal/catalystapi/client.go
@@ -12,6 +12,15 @@
 //   - GET  /api/v1/sovereigns/{id}/applications/{name}       (HandleApplicationGet)
 //   - GET  /api/v1/organizations                             (HandleListOrganizations)
 //   - POST /api/v1/sovereigns/{id}/applications              (HandleApplicationInstall)
+//   - GET  /api/v1/org/applications                          (HandleOrgApplications)
+//   - POST /api/v1/org/applications                          (HandleOrgApplicationInstall)
+//
+// The `/api/v1/sovereigns/{id}/…` seam is DEPLOYMENT-ADDRESSED and
+// Sovereign-wide; the catalyst-api OrgScopeGuard 403s an Org-scoped session
+// on it (it is NOT in orgSafePathPrefixes). The `/api/v1/org/…` pair is the
+// own-org seam an Org-scoped session must use — it IS allowlisted, and it
+// resolves the caller's own Org namespace SERVER-SIDE from X-Tenant-Host.
+// See the ListApplicationsOrg doc comment for the full #5516 reasoning.
 //
 // The POST is the FIRST write tool (#3988 — create_application, UAT rows
 // 221-223). It reuses the SAME UI create seam (HandleApplicationInstall)
@@ -90,6 +99,13 @@ func (e *APIError) Error() string {
 // the session cookie, covering both the gateway (Authorization) and the
 // catalyst-api RequireSession (cookie) read paths.
 func (c *Client) get(ctx context.Context, path, bearer string, out any) error {
+	return c.getWithHeaders(ctx, path, bearer, nil, out)
+}
+
+// getWithHeaders is get() with caller-supplied extra request headers (e.g.
+// X-Tenant-Host for the own-org read path, #5516). The bearer + accept
+// headers are set identically to get().
+func (c *Client) getWithHeaders(ctx context.Context, path, bearer string, extra map[string]string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
 		return fmt.Errorf("catalyst-api: build request: %w", err)
@@ -102,6 +118,11 @@ func (c *Client) get(ctx context.Context, path, bearer string, out any) error {
 		req.Header.Set("Cookie", "catalyst_session="+bearer)
 	}
 	req.Header.Set("Accept", "application/json")
+	for k, v := range extra {
+		if k != "" && v != "" {
+			req.Header.Set(k, v)
+		}
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -203,6 +224,70 @@ type ApplicationItem struct {
 	Blueprint string `json:"blueprint,omitempty"`
 	Version   string `json:"version,omitempty"`
 	Phase     string `json:"phase,omitempty"`
+
+	// Environment — the Application's Environment ref (`<org>-<env_type>`,
+	// e.g. acme-prod). The Sovereign-wide list endpoint does not project it
+	// (list_environments derives the partition from Namespace there), but the
+	// own-org endpoint DOES (spec.environmentRef verbatim), and it is a
+	// strictly better grouping key than the namespace. Empty on the
+	// deployment-addressed path.
+	Environment string `json:"environment,omitempty"`
+
+	// Topology — the instance's resolved placement chip (singleton,
+	// active-active, active-hot-standby, …) as the console renders it. Only
+	// projected by the own-org endpoint.
+	Topology string `json:"topology,omitempty"`
+
+	// ExternalURL — the instance's front-door launch URL when an HTTPRoute
+	// fronts it. Only projected by the own-org endpoint; empty for workloads
+	// with no HTTP surface.
+	ExternalURL string `json:"externalURL,omitempty"`
+}
+
+// orgAppsResponse mirrors the `sovereignAppsResponse` envelope
+// HandleOrgApplications returns (products/catalyst/bootstrap/api/internal/
+// handler/sovereign.go). It is the per-Org instance-card projection the
+// customer console's AppsPage consumes — the SAME wire shape as
+// /api/v1/sovereign/apps, restricted server-side to the caller's own Org
+// namespace.
+type orgAppsResponse struct {
+	Apps        []orgAppItem `json:"apps"`
+	GeneratedAt string       `json:"generatedAt,omitempty"`
+}
+
+// orgAppItem is the subset of `sovereignAppItem` the MCP projects. `ID` is
+// the Application CR / HelmRelease name; `Status` is the card status
+// vocabulary (installed | installing | available | bootstrap) rather than the
+// CR `status.phase` the Sovereign-wide list reports.
+type orgAppItem struct {
+	ID          string `json:"id"`
+	Slug        string `json:"slug"`
+	Title       string `json:"title"`
+	Status      string `json:"status"`
+	Environment string `json:"environment,omitempty"`
+	Blueprint   string `json:"blueprint,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Topology    string `json:"topology,omitempty"`
+	ExternalURL string `json:"externalURL,omitempty"`
+	Instance    bool   `json:"instance,omitempty"`
+}
+
+// orgStatusToPhase maps the own-org endpoint's CARD-status vocabulary onto
+// the CR-phase vocabulary the deployment-addressed list reports, so
+// `list_applications` speaks one language regardless of which seam served it.
+// An unrecognised value is passed through verbatim rather than silently
+// coerced — the facade never invents a status it was not told.
+func orgStatusToPhase(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "installed", "bootstrap":
+		return "Ready"
+	case "installing":
+		return "Installing"
+	case "available":
+		return "NotInstalled"
+	default:
+		return strings.TrimSpace(status)
+	}
 }
 
 // OrganizationListResponse mirrors the {items:[…]} envelope from
@@ -229,6 +314,64 @@ func (c *Client) GetApplication(ctx context.Context, depID, name, bearer string)
 	if err := c.get(ctx, fmt.Sprintf("/api/v1/sovereigns/%s/applications/%s", depID, name), bearer, &out); err != nil {
 		return nil, err
 	}
+	return out, nil
+}
+
+// ListApplicationsOrg calls GET /api/v1/org/applications — the own-org read
+// path an Org-scoped session MUST use (#5516).
+//
+// WHY this exists rather than passing a deployment_id to ListApplications:
+// the deployment-addressed seam `/api/v1/sovereigns/{id}/applications` is NOT
+// in the catalyst-api's orgSafePathPrefixes allowlist, so OrgScopeGuard 403s
+// every Org-scoped session (tier=org-admin) on it — deny-by-default, the
+// #4110 privilege-escalation fix. An Org bearer therefore CANNOT read that
+// seam no matter what claims it carries: stamping a deployment_id onto the
+// bearer only converts the MCP-side "no deployment binding" error into an
+// upstream 403 `org-scoped-forbidden`. The own-org route is the seam that is
+// actually reachable, exactly as CreateApplicationOrg already is for writes.
+//
+// The Org namespace is resolved SERVER-SIDE from X-Tenant-Host against the
+// tenant registry, with the #4110 binding ensuring an Org session can only
+// ever resolve its OWN Org — so the rows come back pre-confined and the
+// facade does no client-side namespace filtering on this path.
+//
+// The response is normalised into the SAME ApplicationListResponse the
+// deployment-addressed list returns, so the tool layer is seam-agnostic. Only
+// rows the endpoint marked `instance:true` are surfaced — a catalog/blueprint
+// row is not a running Application.
+func (c *Client) ListApplicationsOrg(ctx context.Context, bearer string) (*ApplicationListResponse, error) {
+	var raw orgAppsResponse
+	headers := map[string]string{}
+	if c.tenantHost != "" {
+		headers["X-Tenant-Host"] = c.tenantHost
+	}
+	if err := c.getWithHeaders(ctx, "/api/v1/org/applications", bearer, headers, &raw); err != nil {
+		return nil, err
+	}
+	out := &ApplicationListResponse{Kind: "ApplicationList", Items: []ApplicationItem{}}
+	for _, a := range raw.Apps {
+		if !a.Instance {
+			continue
+		}
+		name := strings.TrimSpace(a.ID)
+		if name == "" {
+			name = strings.TrimSpace(a.Title)
+		}
+		if name == "" {
+			continue
+		}
+		out.Items = append(out.Items, ApplicationItem{
+			Kind:        "Application",
+			Name:        name,
+			Blueprint:   a.Blueprint,
+			Version:     a.Version,
+			Phase:       orgStatusToPhase(a.Status),
+			Environment: a.Environment,
+			Topology:    a.Topology,
+			ExternalURL: a.ExternalURL,
+		})
+	}
+	out.Total = len(out.Items)
 	return out, nil
 }
 

--- a/products/openova-mcp/internal/tools/catalogue.go
+++ b/products/openova-mcp/internal/tools/catalogue.go
@@ -16,12 +16,17 @@
 // vouchers.*, cutover.*, placement.*) stay DEFERRED to follow-ups per
 // #3988 §5.
 //
-// Org scoping is enforced at the handler boundary: an Org-context caller
-// only ever sees/touches data for their own OrgID (the catalyst-api
-// endpoint is addressed by the caller's bound deployment; Application items
-// are filtered to the caller's Org namespace on read, and the target
-// organizationRef is gated to the caller's Org on create). A sovereign-
-// admin sees/acts on the full set unfiltered.
+// Org scoping is enforced by SEAM CHOICE, not by client-side filtering
+// (#5516). An Org-context caller is routed to the catalyst-api's own-org
+// endpoints — GET/POST /api/v1/org/applications — which resolve the caller's
+// Org namespace server-side from X-Tenant-Host and are the only application
+// paths the catalyst-api OrgScopeGuard allowlists for tier=org-admin. The
+// deployment-addressed `/api/v1/sovereigns/{id}/…` seam is Sovereign-wide and
+// 403s an Org session, so it is reserved for sovereign-admin context, where
+// the session IS deployment-bound and reads across every Org unfiltered.
+//
+// Consequence: no Org-context tool may call requireDeployment. An Org session
+// carries no deployment_id claim and does not need one.
 package tools
 
 import (
@@ -62,14 +67,14 @@ func catalogue() []Tool {
 		},
 		{
 			Name:        "list_applications",
-			Description: "List the Applications in the caller's Organization, with blueprint, version, namespace, and phase — exactly what the console Applications page shows for that user. Thin facade over GET /api/v1/sovereigns/{id}/applications, Org-scoped.",
+			Description: "List the Applications in the caller's Organization, with blueprint, version, environment, topology and phase — exactly what the console Applications page shows for that user. Thin facade over GET /api/v1/org/applications in Org context (own-org, server-side scoped) and GET /api/v1/sovereigns/{id}/applications for a sovereign-admin.",
 			InputSchema: emptyObj,
 			MinTier:     identity.TierViewer,
 			Handler:     handleListApplications,
 		},
 		{
 			Name:        "get_application",
-			Description: "Get a single Application by name in the caller's Organization (full status + spec the console detail view renders). Org-scoped: a name outside the caller's Org is not returned.",
+			Description: "Get a single Application by name in the caller's Organization. Org-scoped: the name is resolved against the caller's own-org estate only, so a name outside their Organization is reported as not found. A sovereign-admin gets the full Application object from the deployment-addressed endpoint.",
 			InputSchema: map[string]any{
 				"type":                 "object",
 				"additionalProperties": false,
@@ -140,19 +145,38 @@ func handleListApplications(ctx context.Context, id *identity.Identity, api *cat
 	if api == nil {
 		return nil, fmt.Errorf("catalyst-api client not configured")
 	}
+	resp, err := listApplicationsForCaller(ctx, id, api)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"kind": resp.Kind, "items": resp.Items, "total": len(resp.Items)}, nil
+}
+
+// listApplicationsForCaller reads the caller's visible Applications from the
+// seam their session can actually REACH, and returns them already Org-scoped.
+//
+// Org context → GET /api/v1/org/applications (#5516). The
+// deployment-addressed seam is 403'd for an Org session by the catalyst-api
+// OrgScopeGuard (it is not in orgSafePathPrefixes), so an Org bearer must use
+// the own-org route — the read-side mirror of what create_application already
+// does with CreateApplicationOrg. The endpoint confines the rows to the
+// caller's own Org namespace server-side, so no client-side filter is applied
+// (and, critically, NO deployment_id claim is required: an Org session never
+// carries one — HandlePinVerify / auth_org_handover do not stamp it).
+//
+// Sovereign context → the deployment-addressed seam, unchanged. A
+// sovereign-admin session IS bound to a deployment (the mothership handover
+// JWT stamps deployment_id) and legitimately reads across every Org, so the
+// binding stays a hard requirement there.
+func listApplicationsForCaller(ctx context.Context, id *identity.Identity, api *catalystapi.Client) (*catalystapi.ApplicationListResponse, error) {
+	if id.Context == identity.ContextOrganization {
+		return api.ListApplicationsOrg(ctx, bearerOf(id))
+	}
 	depID, err := requireDeployment(id)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := api.ListApplications(ctx, depID, bearerOf(id))
-	if err != nil {
-		return nil, err
-	}
-	items := resp.Items
-	if id.Context == identity.ContextOrganization {
-		items = filterAppsToOrg(items, id.OrgID)
-	}
-	return map[string]any{"kind": resp.Kind, "items": items, "total": len(items)}, nil
+	return api.ListApplications(ctx, depID, bearerOf(id))
 }
 
 func handleGetApplication(ctx context.Context, id *identity.Identity, api *catalystapi.Client, args json.RawMessage) (any, error) {
@@ -170,30 +194,41 @@ func handleGetApplication(ctx context.Context, id *identity.Identity, api *catal
 	if strings.TrimSpace(in.Name) == "" {
 		return nil, fmt.Errorf("missing required argument: name")
 	}
+
+	// Org context (#5516): the deployment-addressed get-by-name seam is 403'd
+	// for an Org session by OrgScopeGuard, so resolve the name against the
+	// caller's OWN-ORG estate instead (GET /api/v1/org/applications, which the
+	// allowlist permits and the catalyst-api confines to the caller's Org
+	// namespace server-side). A name outside the caller's Org is simply ABSENT
+	// from that list — cross-Org leakage is structurally impossible here, a
+	// strictly stronger guarantee than the client-side namespace check the
+	// deployment-addressed path needs.
+	if id.Context == identity.ContextOrganization {
+		resp, err := api.ListApplicationsOrg(ctx, bearerOf(id))
+		if err != nil {
+			return nil, err
+		}
+		want := strings.ToLower(strings.TrimSpace(in.Name))
+		for _, it := range resp.Items {
+			if strings.ToLower(strings.TrimSpace(it.Name)) == want {
+				return it, nil
+			}
+		}
+		// Deliberately NOT ErrForbidden: from inside the Org's own estate we
+		// cannot tell "exists in another Org" from "does not exist at all", and
+		// a not-found answer is the one that leaks neither.
+		return nil, fmt.Errorf("application %q not found in organization %q", in.Name, id.OrgID)
+	}
+
+	// Sovereign context: the deployment-addressed get-by-name seam. A
+	// sovereign-admin is deployment-bound (the mothership handover JWT stamps
+	// deployment_id) and legitimately reads across every Org, so no Org filter
+	// applies here.
 	depID, err := requireDeployment(id)
 	if err != nil {
 		return nil, err
 	}
-	obj, err := api.GetApplication(ctx, depID, in.Name, bearerOf(id))
-	if err != nil {
-		return nil, err
-	}
-	// Org scoping: reject an app whose namespace is not the caller's Org
-	// (defense in depth — the get-by-name endpoint resolves across
-	// namespaces and does NOT scope, so the facade MUST: a cross-Org name
-	// must not leak another Org's data). The catalyst-api get response
-	// carries `namespace` at the top level (HandleApplicationGet wire
-	// shape); fall back to metadata.namespace for the raw-CR shape.
-	if id.Context == identity.ContextOrganization {
-		ns := nestedString(obj, "namespace")
-		if ns == "" {
-			ns = nestedString(obj, "metadata", "namespace")
-		}
-		if ns != "" && !namespaceBelongsToOrg(ns, id.OrgID) {
-			return nil, fmt.Errorf("%w: application %q is not in organization %q", ErrForbidden, in.Name, id.OrgID)
-		}
-	}
-	return obj, nil
+	return api.GetApplication(ctx, depID, in.Name, bearerOf(id))
 }
 
 // handleCreateApplication installs an Application in the caller's Org by
@@ -340,23 +375,21 @@ func handleListEnvironments(ctx context.Context, id *identity.Identity, api *cat
 	if api == nil {
 		return nil, fmt.Errorf("catalyst-api client not configured")
 	}
-	depID, err := requireDeployment(id)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := api.ListApplications(ctx, depID, bearerOf(id))
+	resp, err := listApplicationsForCaller(ctx, id, api)
 	if err != nil {
 		return nil, err
 	}
 	items := resp.Items
-	if id.Context == identity.ContextOrganization {
-		items = filterAppsToOrg(items, id.OrgID)
-	}
-	// Group apps by their Environment (the namespace = `<org>-<env_type>`
-	// per the naming convention in CLAUDE.md §Naming).
+	// Group apps by their Environment. The own-org seam projects
+	// spec.environmentRef verbatim (`<org>-<env_type>`); the
+	// deployment-addressed seam does not, so fall back to the namespace, which
+	// carries the same `<org>-<env_type>` shape per CLAUDE.md §Naming.
 	envs := map[string]int{}
 	for _, it := range items {
-		env := it.Namespace
+		env := it.Environment
+		if env == "" {
+			env = it.Namespace
+		}
 		if env == "" {
 			env = "(unknown)"
 		}
@@ -383,10 +416,16 @@ func bearerOf(id *identity.Identity) string {
 	return id.RawBearer
 }
 
-// requireDeployment returns the deployment ID the caller's session is
-// bound to (handover JWT deployment_id). The catalyst-api route table is
-// addressed by `/api/v1/sovereigns/{id}/…`; without a deployment binding
-// the facade cannot resolve which Sovereign to query.
+// requireDeployment returns the deployment ID the caller's session is bound
+// to (handover JWT deployment_id). It gates ONLY the Sovereign-context,
+// deployment-addressed `/api/v1/sovereigns/{id}/…` seam.
+//
+// #5516 — it must NEVER gate an Org-context call. An Org-scoped session
+// carries no deployment_id (neither HandlePinVerify nor auth_org_handover
+// stamps one) AND could not use the deployment-addressed seam even if it did,
+// because OrgScopeGuard 403s that path for tier=org-admin. Org context routes
+// to the own-org seam instead — see listApplicationsForCaller. Reintroducing
+// this call on an Org path re-breaks every Org-scoped read tool.
 func requireDeployment(id *identity.Identity) (string, error) {
 	if id.DeploymentID == "" {
 		return "", fmt.Errorf("no deployment binding on the caller's token (deployment_id claim required)")
@@ -415,44 +454,10 @@ func orgMatches(rec map[string]any, orgID string) bool {
 	return false
 }
 
-// filterAppsToOrg keeps only Applications whose namespace belongs to the
-// caller's Org. The namespace convention is `<org>-<env_type>` (or the
-// per-Org vcluster namespace `<org>`), so a prefix match on the slug is
-// the scoping rule the console uses.
-func filterAppsToOrg(items []catalystapi.ApplicationItem, orgID string) []catalystapi.ApplicationItem {
-	out := make([]catalystapi.ApplicationItem, 0, len(items))
-	for _, it := range items {
-		if namespaceBelongsToOrg(it.Namespace, orgID) {
-			out = append(out, it)
-		}
-	}
-	return out
-}
-
-// namespaceBelongsToOrg reports whether a namespace belongs to orgID. The
-// Organization owns namespaces named `<org>` and `<org>-<env_type>`
-// (CLAUDE.md §Naming), so an exact match or a `<org>-` prefix qualifies.
-func namespaceBelongsToOrg(ns, orgID string) bool {
-	ns = strings.ToLower(strings.TrimSpace(ns))
-	org := strings.ToLower(strings.TrimSpace(orgID))
-	if org == "" || ns == "" {
-		return false
-	}
-	return ns == org || strings.HasPrefix(ns, org+"-")
-}
-
-// nestedString safely reads a string at a nested path in a generic map.
-func nestedString(obj map[string]any, path ...string) string {
-	cur := any(obj)
-	for _, p := range path {
-		m, ok := cur.(map[string]any)
-		if !ok {
-			return ""
-		}
-		cur = m[p]
-	}
-	if s, ok := cur.(string); ok {
-		return s
-	}
-	return ""
-}
+// NOTE (#5516): the former client-side Org filters (filterAppsToOrg /
+// namespaceBelongsToOrg / nestedString) are gone. Org-context reads now go
+// through GET /api/v1/org/applications, which confines the result to the
+// caller's own Org namespace SERVER-SIDE, so a client-side namespace filter is
+// both redundant and actively harmful — the own-org projection carries no
+// `namespace` field, so a namespace-prefix filter would drop EVERY row and
+// report an empty estate as success. Do not reintroduce one on that path.

--- a/products/openova-mcp/internal/tools/tools_test.go
+++ b/products/openova-mcp/internal/tools/tools_test.go
@@ -38,6 +38,22 @@ func orgIdentity(org, dep string, tier identity.Tier) *identity.Identity {
 	}
 }
 
+// orgIdentityNoDeployment is the REAL shape of the Org-scoped bearer the
+// Sovereign seeds for a per-Org agenity MCP (#5516): tier=org-admin, org_id
+// set, and NO deployment_id — neither HandlePinVerify nor auth_org_handover
+// stamps that claim on an Org session, so the seeded service bearer
+// (sovereign_mcp_bearer_seed.go) carries none either. Every Org-context tool
+// must work with exactly this identity.
+func orgIdentityNoDeployment(org string, tier identity.Tier) *identity.Identity {
+	return &identity.Identity{
+		Claims:    &sharedauth.Claims{OrgID: org},
+		Context:   identity.ContextOrganization,
+		Tier:      tier,
+		OrgID:     org,
+		RawBearer: "org-bearer",
+	}
+}
+
 func sovereignIdentity(dep string) *identity.Identity {
 	return &identity.Identity{
 		Claims:       &sharedauth.Claims{Role: "sovereign-admin", DeploymentID: dep},
@@ -87,47 +103,135 @@ func TestCallGate(t *testing.T) {
 	}
 }
 
-// TestListApplicationsOrgScoped — the facade forwards the caller's bearer
-// and filters items to the caller's Org namespace.
-func TestListApplicationsOrgScoped(t *testing.T) {
-	var sawAuth, sawCookie, sawPath string
+// TestListApplicationsOrgUsesOwnOrgSeamWithoutDeploymentID is the #5516
+// regression test.
+//
+// THE DEFECT: every Org-context read tool called requireDeployment first, so
+// an Org bearer (which carries no deployment_id — see orgIdentityNoDeployment)
+// failed with "no deployment binding on the caller's token" before any HTTP
+// request was made. Stamping a deployment_id onto the bearer would NOT have
+// fixed it: the deployment-addressed seam it unlocks is not in the
+// catalyst-api's orgSafePathPrefixes allowlist, so OrgScopeGuard 403s an
+// org-admin session on it (proven in the catalyst-api's own
+// TestOrgScopeGuard_OrgScoped_DeniesDeploymentAddressedApplicationRoutes).
+//
+// THE FIX: Org context reads the own-org seam GET /api/v1/org/applications —
+// allowlisted, and confined to the caller's Org namespace server-side.
+func TestListApplicationsOrgUsesOwnOrgSeamWithoutDeploymentID(t *testing.T) {
+	var sawAuth, sawCookie, sawPath, sawMethod, sawTenantHost string
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		sawAuth = r.Header.Get("Authorization")
 		sawCookie = r.Header.Get("Cookie")
 		sawPath = r.URL.Path
-		return jsonResp(200, `{"kind":"ApplicationList","items":[
-			{"kind":"Application","name":"shop","namespace":"acme-prod","blueprint":"bp-wordpress","phase":"Ready"},
-			{"kind":"Application","name":"blog","namespace":"acme","blueprint":"bp-ghost","phase":"Ready"},
-			{"kind":"Application","name":"other","namespace":"globex-prod","blueprint":"bp-gitea","phase":"Ready"}
-		],"total":3}`), nil
+		sawMethod = r.Method
+		sawTenantHost = r.Header.Get("X-Tenant-Host")
+		// The real HandleOrgApplications envelope: instance rows for the
+		// caller's own Org, plus a NON-instance catalog row that must not be
+		// reported as a running Application.
+		return jsonResp(200, `{"apps":[
+			{"id":"shop","slug":"wordpress","title":"shop","status":"installed","environment":"acme-prod","blueprint":"bp-wordpress","version":"1.2.3","topology":"singleton","externalURL":"https://shop.acme.omani.homes","instance":true},
+			{"id":"blog","slug":"ghost","title":"blog","status":"installing","environment":"acme-dev","blueprint":"bp-ghost","instance":true},
+			{"id":"bp-gitea","slug":"gitea","title":"Gitea","status":"available","instance":false}
+		],"generatedAt":"2026-07-30T00:00:00Z","bootstrapKit":[]}`), nil
 	})
-	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
 	reg := NewRegistry(api)
 
-	out, err := reg.Call(context.Background(), orgIdentity("acme", "7bb723da8da06047", identity.TierViewer), "list_applications", nil)
+	// The identity deliberately carries NO deployment_id.
+	out, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierViewer), "list_applications", nil)
 	if err != nil {
-		t.Fatalf("call: %v", err)
+		t.Fatalf("Org-context list must NOT require a deployment binding, got: %v", err)
 	}
-	// Forwarded identity assertions (thin facade).
+
+	// Reached the own-org seam, with the tenant host the server needs to
+	// resolve the Org namespace.
+	if sawMethod != "GET" {
+		t.Errorf("want GET, got %q", sawMethod)
+	}
+	if sawPath != "/api/v1/org/applications" {
+		t.Errorf("Org context must use the own-org seam, got %q", sawPath)
+	}
+	if sawTenantHost != "console.acme.omani.homes" {
+		t.Errorf("X-Tenant-Host not forwarded (server cannot resolve the Org namespace without it): %q", sawTenantHost)
+	}
+	// Thin facade: the caller's bearer is forwarded verbatim on both carriers.
 	if sawAuth != "Bearer org-bearer" {
 		t.Errorf("Authorization not forwarded: %q", sawAuth)
 	}
 	if !strings.Contains(sawCookie, "catalyst_session=org-bearer") {
 		t.Errorf("session cookie not forwarded: %q", sawCookie)
 	}
-	if sawPath != "/api/v1/sovereigns/7bb723da8da06047/applications" {
-		t.Errorf("wrong path: %q", sawPath)
-	}
-	// Org scoping: only acme-* namespaces remain.
+
+	// Vacuity guard: the envelope MUST have decoded into rows before any
+	// per-row assertion below can mean anything.
 	m := out.(map[string]any)
 	items := m["items"].([]catalystapi.ApplicationItem)
-	if len(items) != 2 {
-		t.Fatalf("org scoping failed: want 2 acme apps, got %d: %+v", len(items), items)
+	if len(items) == 0 {
+		t.Fatal("no Applications decoded from the own-org envelope — a per-row assertion would pass vacuously")
 	}
+	if len(items) != 2 {
+		t.Fatalf("want the 2 instance rows (the catalog row is not a running Application), got %d: %+v", len(items), items)
+	}
+	if m["total"] != 2 {
+		t.Errorf("total = %v, want 2", m["total"])
+	}
+
+	byName := map[string]catalystapi.ApplicationItem{}
 	for _, it := range items {
-		if !strings.HasPrefix(it.Namespace, "acme") {
-			t.Errorf("leaked cross-org app: %+v", it)
-		}
+		byName[it.Name] = it
+	}
+	shop, ok := byName["shop"]
+	if !ok {
+		t.Fatalf("own-org app %q missing from the projection: %+v", "shop", items)
+	}
+	// Card status → CR phase vocabulary, so the tool speaks one language
+	// regardless of which seam served it.
+	if shop.Phase != "Ready" {
+		t.Errorf("shop.Phase = %q, want Ready (mapped from status=installed)", shop.Phase)
+	}
+	if shop.Blueprint != "bp-wordpress" || shop.Version != "1.2.3" {
+		t.Errorf("shop blueprint/version not projected: %+v", shop)
+	}
+	if shop.Environment != "acme-prod" {
+		t.Errorf("shop.Environment = %q, want acme-prod", shop.Environment)
+	}
+	if shop.Topology != "singleton" || shop.ExternalURL == "" {
+		t.Errorf("shop topology/externalURL not projected: %+v", shop)
+	}
+	if blog := byName["blog"]; blog.Phase != "Installing" {
+		t.Errorf("blog.Phase = %q, want Installing (mapped from status=installing)", blog.Phase)
+	}
+	if _, leaked := byName["bp-gitea"]; leaked {
+		t.Error("a non-instance catalog row was reported as a running Application")
+	}
+}
+
+// TestListApplicationsSovereignStillRequiresDeploymentBinding — the #5516 fix
+// must NOT weaken the Sovereign path. A sovereign-admin session IS
+// deployment-bound (the mothership handover JWT stamps deployment_id); without
+// it the facade cannot address a Sovereign, so the call fails BEFORE any HTTP
+// request rather than silently falling back to the own-org seam (which would
+// be meaningless for a caller with no Org scope).
+func TestListApplicationsSovereignStillRequiresDeploymentBinding(t *testing.T) {
+	called := false
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return jsonResp(200, `{"kind":"ApplicationList","items":[],"total":0}`), nil
+	})
+	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	_, err := reg.Call(context.Background(), sovereignIdentity(""), "list_applications", nil)
+	if err == nil {
+		t.Fatal("a sovereign-admin session with no deployment binding must error")
+	}
+	if !strings.Contains(err.Error(), "deployment_id") {
+		t.Errorf("error should name the missing claim, got: %v", err)
+	}
+	if called {
+		t.Error("no backend request should be made without a deployment binding")
 	}
 }
 
@@ -170,44 +274,111 @@ func TestParity403(t *testing.T) {
 	}
 }
 
-// TestGetApplicationCrossOrgDenied — a name resolving to another Org's
-// namespace is denied by the facade's defense-in-depth scope check. The
-// catalyst-api get-by-name response carries `namespace` at the top level
-// (the real HandleApplicationGet wire shape, confirmed on hw173); the
-// metadata.namespace fallback covers the raw-CR shape.
-func TestGetApplicationCrossOrgDenied(t *testing.T) {
-	for _, body := range []string{
-		`{"name":"leak","namespace":"globex-prod","blueprint":"bp-gitea"}`, // top-level (real endpoint shape)
-		`{"metadata":{"name":"leak","namespace":"globex-prod"},"spec":{}}`, // raw-CR shape
-	} {
-		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			return jsonResp(200, body), nil
-		})
-		api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
-		reg := NewRegistry(api)
+// orgAppsEnvelope is the own-org estate the fake catalyst-api serves: one app
+// belonging to the caller's Org. Anything NOT in this envelope is, by
+// construction, outside the caller's Org — the server-side confinement the
+// own-org seam applies.
+const orgAppsEnvelope = `{"apps":[
+	{"id":"shop","slug":"wordpress","title":"shop","status":"installed","environment":"acme-prod","blueprint":"bp-wordpress","instance":true}
+],"bootstrapKit":[]}`
 
-		args, _ := json.Marshal(map[string]string{"name": "leak"})
-		_, err := reg.Call(context.Background(), orgIdentity("acme", "dep1", identity.TierViewer), "get_application", args)
-		if !errors.Is(err, ErrForbidden) {
-			t.Fatalf("cross-org get should be ErrForbidden for body %q, got %v", body, err)
-		}
+// TestGetApplicationOrgResolvesAgainstOwnEstate — an Org caller with NO
+// deployment_id resolves a name against its own-org estate (#5516) and gets
+// the row back.
+func TestGetApplicationOrgResolvesAgainstOwnEstate(t *testing.T) {
+	var sawPath string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sawPath = r.URL.Path
+		return jsonResp(200, orgAppsEnvelope), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	args, _ := json.Marshal(map[string]string{"name": "shop"})
+	out, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierViewer), "get_application", args)
+	if err != nil {
+		t.Fatalf("own-org get must NOT require a deployment binding, got %v", err)
+	}
+	if sawPath != "/api/v1/org/applications" {
+		t.Errorf("Org context must resolve via the own-org seam, got %q", sawPath)
+	}
+	item, ok := out.(catalystapi.ApplicationItem)
+	if !ok {
+		t.Fatalf("unexpected result type %T: %+v", out, out)
+	}
+	if item.Name != "shop" || item.Blueprint != "bp-wordpress" || item.Environment != "acme-prod" {
+		t.Fatalf("wrong app returned: %+v", item)
 	}
 }
 
-// TestGetApplicationOwnOrgAllowed — the caller's own Org app is returned.
-func TestGetApplicationOwnOrgAllowed(t *testing.T) {
+// TestGetApplicationOrgNameOutsideOwnEstateNotFound — a name that is not in
+// the caller's own-org estate (another Org's app, or a typo) yields a
+// not-found error and NO object. Cross-Org leakage is structurally impossible
+// on this seam: the catalyst-api never puts another Org's rows in the
+// response, so there is nothing to filter and nothing to leak.
+func TestGetApplicationOrgNameOutsideOwnEstateNotFound(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		return jsonResp(200, `{"name":"shop","namespace":"acme-prod","blueprint":"bp-wordpress"}`), nil
+		return jsonResp(200, orgAppsEnvelope), nil
 	})
-	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
 	reg := NewRegistry(api)
-	args, _ := json.Marshal(map[string]string{"name": "shop"})
-	out, err := reg.Call(context.Background(), orgIdentity("acme", "dep1", identity.TierViewer), "get_application", args)
-	if err != nil {
-		t.Fatalf("own-org get should succeed, got %v", err)
+
+	args, _ := json.Marshal(map[string]string{"name": "globex-secret"})
+	out, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierViewer), "get_application", args)
+	if err == nil {
+		t.Fatal("a name outside the caller's own-org estate must not resolve")
 	}
-	if out.(map[string]any)["namespace"] != "acme-prod" {
-		t.Fatalf("wrong app returned: %+v", out)
+	if out != nil {
+		t.Errorf("no object may be returned for an out-of-estate name, got %+v", out)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want a not-found error (which leaks neither existence nor scope), got: %v", err)
+	}
+}
+
+// TestListEnvironmentsOrgWithoutDeploymentID — list_environments was equally
+// blocked by requireDeployment (#5516). It now derives the partitions from the
+// own-org estate, grouping on the endpoint's `environment` projection
+// (spec.environmentRef) rather than the namespace the own-org seam omits.
+func TestListEnvironmentsOrgWithoutDeploymentID(t *testing.T) {
+	var sawPath string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sawPath = r.URL.Path
+		return jsonResp(200, `{"apps":[
+			{"id":"shop","status":"installed","environment":"acme-prod","instance":true},
+			{"id":"api","status":"installed","environment":"acme-prod","instance":true},
+			{"id":"blog","status":"installing","environment":"acme-dev","instance":true}
+		],"bootstrapKit":[]}`), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	out, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierViewer), "list_environments", nil)
+	if err != nil {
+		t.Fatalf("Org-context list_environments must NOT require a deployment binding, got %v", err)
+	}
+	if sawPath != "/api/v1/org/applications" {
+		t.Errorf("Org context must use the own-org seam, got %q", sawPath)
+	}
+	items := out.(map[string]any)["items"].([]map[string]any)
+	if len(items) == 0 {
+		t.Fatal("no Environments derived — the per-row assertions below would pass vacuously")
+	}
+	counts := map[string]any{}
+	for _, it := range items {
+		counts[it["name"].(string)] = it["applications"]
+	}
+	if counts["acme-prod"] != 2 {
+		t.Errorf("acme-prod app count = %v, want 2 (grouped on environmentRef)", counts["acme-prod"])
+	}
+	if counts["acme-dev"] != 1 {
+		t.Errorf("acme-dev app count = %v, want 1", counts["acme-dev"])
 	}
 }
 


### PR DESCRIPTION
## What was broken

Every Org-scoped openova-MCP read tool except `list_organizations` was unreachable with the bearer the Sovereign seeds for a per-Org agenity workspace. `list_applications`, `get_application` and `list_environments` all called `requireDeployment` first; an Org session carries no `deployment_id` claim, so each returned the identical `-32000 no deployment binding on the caller's token` — matching the live hw291 observation, where `whoami` on the same bearer returned `deployment_id:""` with every other claim correct.

## Root cause: a seam mismatch, not a missing claim

Those tools addressed `GET /api/v1/sovereigns/{id}/applications`. That seam is Sovereign-wide and is **not** in the catalyst-api's `orgSafePathPrefixes`, so `OrgScopeGuard` 403s any `tier=org-admin` session on it. The guard's verdict is a pure function of the tier and the path — it never reads `deployment_id`.

So stamping a `deployment_id` onto the seeded bearer fixes nothing: it converts the MCP-side error into an upstream `403 org-scoped-forbidden`, one layer further from its cause. It would also break the byte-for-byte parity `mintOrgScopedMCPBearer` is contracted to hold with `HandlePinVerify` / `auth_org_handover` — **neither of those stamps `deployment_id` on an Org session.** Only the mothership handover path does, for a sovereign-admin. The absent claim was never drift; it was the contract.

`create_application` was already routed correctly (`CreateApplicationOrg` → `POST /api/v1/org/applications`), which is why the write leg was not among the failures. This change makes the read legs match it.

## The fix

Org context reads the own-org seam `GET /api/v1/org/applications` — allowlisted, and resolving the caller's Org namespace server-side from `X-Tenant-Host`.

- `catalystapi`: new `ListApplicationsOrg` + `getWithHeaders`. The own-org card envelope is normalised into the same `ApplicationListResponse` the deployment-addressed seam returns, so the tool layer is seam-agnostic; non-instance catalog rows are dropped, and card status is mapped onto the CR phase vocabulary.
- `ApplicationItem` gains `environment` / `topology` / `externalURL` (projected only by the own-org seam). `list_environments` groups on `environmentRef`, falling back to the namespace on the deployment-addressed path.
- Server-side confinement replaces the former client-side namespace filter, so cross-Org leakage is structurally impossible rather than filtered. The removed `filterAppsToOrg` would have *dropped every row* on this seam — the own-org projection carries no `namespace` field — and reported an empty estate as success. A comment at the removal site says so.
- Sovereign path unchanged: a sovereign-admin is deployment-bound and still requires the binding.
- catalyst-api: the producer keeps minting no `deployment_id`; the reasoning is recorded at the mint site so it is not "fixed" later by widening the token.

## Tests — both directions actually executed

Defect reintroduced, observed failing, restored, observed passing.

Routing the Org path back to the deployment-addressed seam:

```
--- FAIL: TestListApplicationsOrgUsesOwnOrgSeamWithoutDeploymentID (0.00s)
    tools_test.go:145: Org-context list must NOT require a deployment binding, got: no deployment binding on the caller's token (deployment_id claim required)
--- FAIL: TestListEnvironmentsOrgWithoutDeploymentID (0.00s)
    tools_test.go:364: Org-context list_environments must NOT require a deployment binding, got no deployment binding on the caller's token (deployment_id claim required)
```

Stamping `deployment_id` onto the bearer:

```
--- FAIL: Test_mintOrgScopedMCPBearer_ClaimKeySetMatchesPinVerifyOrgSession (0.06s)
    minted bearer carries claim "deployment_id", which an Org-scoped session
    (HandlePinVerify / auth_org_handover) never mints — parity broken
```

`TestOrgScopeGuard_OrgScoped_DeniesDeploymentAddressedApplicationRoutes` proves the 403 holds **even with** a `deployment_id` claim, and asserts the own-org seam passes for the same session — so the denial is not the vacuous "everything 403s". Assertions are non-vacuous by construction: the claim-set test checks the map is non-empty and carries a known-present control claim before comparing sets; the list tests assert rows decoded before any per-row check; the projection is asserted present **and** non-empty **and** equal to expected. `TestListApplicationsSovereignStillRequiresDeploymentBinding` pins the unchanged Sovereign contract.

## Gates

```
products/catalyst/bootstrap/api : go build ./... OK | go vet ./... OK | go test ./... all packages ok
products/openova-mcp            : go build ./... OK | go vet ./... OK | go test ./... 4/4 ok
```

Code-only change; no live-cluster action, no chart or ledger edits.

## Follow-up found while tracing

`list_organizations` calls `GET /api/v1/organizations`, which is also not allowlisted (the catalyst-api's own `TestPathIsOrgSafe` already lists it as denied), so it 403s for an Org bearer too. It is not fixed here: there is no own-org organizations endpoint — `/api/v1/org/self` is in the allowlist but has **no route registered**. Closing that needs a new server-side seam plus its own scope review, not a facade change.

Refs #5516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
