### PR TITLE
fix(org-controller): per-Org console listeners ride the LIVE apex ports + a silently-dropped listener can no longer read as provisioned

### DIFF
--- a/core/controllers/organization/internal/controller/provisioning_postconditions.go
+++ b/core/controllers/organization/internal/controller/provisioning_postconditions.go
@@ -128,6 +128,18 @@ func (p provisioningPostconditions) message() string {
 //     engages the tenant-networking up-path (a pool parentDomain). This is the
 //     artifact whose absence produced NoMatchingListenerHostname on all six of
 //     gamma-corp's routes (#5395 symptom A).
+//  4. That the SAME pair is ADMITTED — present in the Gateway's
+//     `status.listeners`, and bound to the ports the console LoadBalancer
+//     actually forwards to (#5511). Presence in `spec` is not serving. On
+//     hw291 `cilium-gateway-console` accepted 8 listeners into spec and
+//     published only 6 in status; the two it silently declined were exactly
+//     the per-Org pair, with no error, no condition and no event anywhere, so
+//     `agenity.uatcorp.omani.homes` answered 000 on 6 of 6 probes while its
+//     HelmRelease, Pod and HTTPRoute were all healthy and the apex console on
+//     the same VIP served 200. A listener accepted into spec and absent from
+//     status is, from the operator's side, indistinguishable from one that was
+//     never configured — so it must be named in status, loudly, the same way
+//     an absent one is.
 //
 // The namespace itself is NOT re-probed here — vclusterReadiness already gates
 // on it and verifyProvisioned is only consulted once that returned ready, so a
@@ -173,28 +185,87 @@ func (r *Reconciler) verifyProvisioned(ctx context.Context, org *orgapi.Organiza
 	if !ok {
 		return out
 	}
-	present, err := r.consoleOrgListenersPresent(ctx, names)
+	rb, err := r.consoleOrgListenersReadback(ctx, names)
+	gwNS, gwName := r.consoleGatewayNamespace(), r.consoleGatewayName()
 	switch {
 	case err != nil:
 		out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
 			"console Gateway %s/%s listeners for %q: %s",
-			r.consoleGatewayNamespace(), r.consoleGatewayName(), names.WildcardHost, err))
-	case !present:
+			gwNS, gwName, names.WildcardHost, err))
+	case rb.GatewayAbsent || len(rb.SpecMissing) > 0:
 		out.Missing = append(out.Missing, fmt.Sprintf(
 			"console Gateway listeners %s/%s on %s/%s for hostname %q (without them every HTTPRoute on that host is Accepted=False NoMatchingListenerHostname — the Org is unreachable)",
-			names.HTTPSName, names.HTTPName,
-			r.consoleGatewayNamespace(), r.consoleGatewayName(), names.WildcardHost))
+			names.HTTPSName, names.HTTPName, gwNS, gwName, names.WildcardHost))
+	default:
+		// 4 — the listener is in spec. That is NOT the same as serving. Both
+		// checks below close a way for the door to be dead while every status
+		// surface reads green (#5511).
+		if len(rb.PortDrift) > 0 {
+			out.Missing = append(out.Missing, fmt.Sprintf(
+				"console Gateway listeners on %s/%s bind the wrong port — %s (the console LoadBalancer forwards public 443/80 to the apex console-https/console-http ports and nothing else, so a per-Org listener on any other port receives no traffic and %q answers 000 while the workload behind it is healthy)",
+				gwNS, gwName, strings.Join(rb.PortDrift, ", "), names.WildcardHost))
+		}
+		switch {
+		case !rb.StatusObserved:
+			// The Gateway controller has not published ANY listener status
+			// yet. Absence of evidence, not evidence of absence — requeue.
+			// This is also the vacuity guard on the check below: without it,
+			// "our listener is in status" would pass trivially on an empty
+			// status and assert nothing at all.
+			out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
+				"console Gateway %s/%s status.listeners is empty — the Gateway controller has not published listener status yet, so acceptance of %s/%s cannot be decided",
+				gwNS, gwName, names.HTTPSName, names.HTTPName))
+		case len(rb.StatusDropped) > 0:
+			out.Missing = append(out.Missing, fmt.Sprintf(
+				"console Gateway %s/%s ACCEPTED %d listeners into spec but published only %d in status — silently dropped: %s (a listener in spec and absent from status carries no condition and no event: from the operator's side it is indistinguishable from one that was never configured, yet every per-Org customer door depends on it)",
+				gwNS, gwName, rb.SpecCount, rb.StatusCount, strings.Join(rb.StatusDropped, ", ")))
+		}
 	}
 	return out
 }
 
-// consoleOrgListenersPresent reports whether BOTH per-Org listeners are live on
-// the shared console Gateway. A missing Gateway is reported as absent listeners
-// (not an error): during the bootstrap window before sovereign-tls has applied
-// the Gateway the Org genuinely has no console edge, and saying so honestly is
-// the entire point — `ensureConsoleOrgListener` returning `(false, nil)` for
-// that same case is what let the gap pass as success in the first place.
-func (r *Reconciler) consoleOrgListenersPresent(ctx context.Context, names orgConsoleTLSNames) (bool, error) {
+// consoleListenerReadback is one probe of the shared console Gateway, across
+// BOTH spec and status (#5511).
+//
+// Reading spec alone is what let the #5511 defect ship: the org-controller
+// appended the per-Org pair, the pair WAS in spec, the postcondition check
+// passed green — and the Gateway controller had silently declined to admit both
+// listeners, so `status.listeners` carried 6 of the 8 in spec, with no error, no
+// condition and no event anywhere. The customer door answered 000 on every
+// probe while the Organization, its HelmRelease and its Pod all read Ready.
+type consoleListenerReadback struct {
+	// GatewayAbsent — the console Gateway itself is NotFound.
+	GatewayAbsent bool
+	// SpecMissing — our listener names absent from spec.listeners.
+	SpecMissing []string
+	// SpecCount / StatusCount — the two listener counts. A gateway that
+	// admits fewer listeners than it accepted is the #5511 signature.
+	SpecCount   int
+	StatusCount int
+	// StatusObserved — the Gateway controller has published a NON-EMPTY
+	// status.listeners. Everything derived from status is meaningless until
+	// this is true, so it gates the StatusDropped verdict.
+	StatusObserved bool
+	// StatusDropped — listener names present in spec.listeners and absent
+	// from a non-empty status.listeners. Not scoped to this Org: a sibling
+	// Org's dropped listener is the same defect and worth surfacing on the
+	// first Org that notices it.
+	StatusDropped []string
+	// PortDrift — our listeners whose port differs from the live apex pair,
+	// described for the operator.
+	PortDrift []string
+}
+
+// consoleOrgListenersReadback probes the shared console Gateway for this Org's
+// listener pair and reports what it found in spec, in status, and on the ports.
+// A missing Gateway is reported as GatewayAbsent (not an error): during the
+// bootstrap window before sovereign-tls has applied the Gateway the Org
+// genuinely has no console edge, and saying so honestly is the entire point —
+// `ensureConsoleOrgListener` returning `(false, nil)` for that same case is
+// what let the gap pass as success in the first place.
+func (r *Reconciler) consoleOrgListenersReadback(ctx context.Context, names orgConsoleTLSNames) (consoleListenerReadback, error) {
+	var out consoleListenerReadback
+
 	gw := unstructured.Unstructured{}
 	gw.SetGroupVersionKind(gatewayGVK)
 	if err := r.Get(ctx, client.ObjectKey{
@@ -202,28 +273,75 @@ func (r *Reconciler) consoleOrgListenersPresent(ctx context.Context, names orgCo
 		Name:      r.consoleGatewayName(),
 	}, &gw); err != nil {
 		if apierrors.IsNotFound(err) {
-			return false, nil
+			out.GatewayAbsent = true
+			return out, nil
 		}
-		return false, err
+		return out, err
 	}
-	listeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+
+	specListeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
 	if err != nil {
-		return false, err
+		return out, fmt.Errorf("read spec.listeners: %w", err)
 	}
-	var https, http bool
-	for _, l := range listeners {
+	statusListeners, _, err := unstructured.NestedSlice(gw.Object, "status", "listeners")
+	if err != nil {
+		return out, fmt.Errorf("read status.listeners: %w", err)
+	}
+	out.SpecCount = len(specListeners)
+	out.StatusCount = len(statusListeners)
+	out.StatusObserved = len(statusListeners) > 0
+
+	specByName := map[string]map[string]any{}
+	specOrder := make([]string, 0, len(specListeners))
+	for _, l := range specListeners {
 		m, ok := l.(map[string]any)
 		if !ok {
 			continue
 		}
-		switch n, _ := m["name"].(string); n {
-		case names.HTTPSName:
-			https = true
-		case names.HTTPName:
-			http = true
+		if n, _ := m["name"].(string); n != "" {
+			specByName[n] = m
+			specOrder = append(specOrder, n)
 		}
 	}
-	return https && http, nil
+	inStatus := map[string]bool{}
+	for _, l := range statusListeners {
+		if m, ok := l.(map[string]any); ok {
+			if n, _ := m["name"].(string); n != "" {
+				inStatus[n] = true
+			}
+		}
+	}
+
+	// The per-Org pair MUST ride the live apex ports — same derivation the
+	// up-path uses, so the verifier can never demand a port the writer would
+	// not have written.
+	httpsPort, httpPort := consoleApexListenerPorts(specListeners)
+	wantPort := map[string]int64{names.HTTPSName: httpsPort, names.HTTPName: httpPort}
+
+	for _, n := range []string{names.HTTPSName, names.HTTPName} {
+		m, ok := specByName[n]
+		if !ok {
+			out.SpecMissing = append(out.SpecMissing, n)
+			continue
+		}
+		if got, ok := listenerPort(m); ok && got != wantPort[n] {
+			out.PortDrift = append(out.PortDrift, fmt.Sprintf(
+				"%s binds %d, the apex pair serves %d", n, got, wantPort[n]))
+		}
+	}
+
+	// Count-based: every listener the Gateway accepted into spec but did not
+	// publish in status. Iterated in spec order, so the rendered message is
+	// stable across reconciles (an unstable message defeats the byte-equal
+	// status-skip in patchStatus and hot-loops the controller, #5305).
+	if out.StatusObserved {
+		for _, n := range specOrder {
+			if !inStatus[n] {
+				out.StatusDropped = append(out.StatusDropped, n)
+			}
+		}
+	}
+	return out, nil
 }
 
 // orgConsoleTLSNamesForOrg derives the per-Org console-TLS names from the CR,

--- a/core/controllers/organization/internal/controller/provisioning_postconditions_5395_test.go
+++ b/core/controllers/organization/internal/controller/provisioning_postconditions_5395_test.go
@@ -243,14 +243,33 @@ func TestReconcile_5395_ListenerAppendedThenVerified(t *testing.T) {
 		consoleGateway(),
 	)
 
-	// Pass 1: reconcileConsoleServing appends the pair; the verifier reads the
-	// Gateway back afterwards, so the Org may already be green here. Pass 2
-	// asserts the steady state regardless of intra-pass ordering.
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "acme"},
-	}); err != nil {
-		t.Fatalf("first reconcile: %v", err)
+	// Drive reconcile until reconcileConsoleServing's append has actually landed
+	// in spec (the first pass only adds the finalizer and requeues).
+	const wantSpecListeners = 3 // apex + the per-Org pair
+	appended := false
+	for i := 0; i < 4 && !appended; i++ {
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "acme"},
+		}); err != nil {
+			t.Fatalf("reconcile pass %d: %v", i+1, err)
+		}
+		if _, n := gatewayListeners(t, r, "spec"); n == wantSpecListeners {
+			appended = true
+		}
 	}
+	if !appended {
+		t.Fatalf("the up-path never appended the per-Org listener pair to spec")
+	}
+
+	// #5511: a live Gateway publishes `status.listeners`, and being in spec is
+	// not being served. Simulate the Gateway controller admitting every listener
+	// the append just wrote — without this the Org sits (correctly) UNVERIFIABLE
+	// on an unpublished status and never reaches its steady state.
+	specCount, statusCount := admitGatewayListeners(t, r)
+	if specCount != wantSpecListeners || statusCount != specCount {
+		t.Fatalf("admission fixture: spec=%d status=%d, want %d/%d", specCount, statusCount, wantSpecListeners, wantSpecListeners)
+	}
+
 	res, got := reconcileToStatus(t, r, "acme")
 
 	cond := mustReadyCondition(t, got)

--- a/core/controllers/organization/internal/controller/tenant_console_tls.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls.go
@@ -119,16 +119,84 @@ const (
 	consoleUIDefaultService      = "catalyst-ui"
 	consoleUIDefaultPort         = int32(80)
 
-	// Host ports the console Gateway's listeners bind — the dedicated
-	// console Gateway uses 31443/31080 (NOT the shared gateway's
-	// 30443/30080). See cilium-gateway-console.yaml header for the
-	// bind-collision rationale. The per-pool listeners reuse the SAME
-	// host ports as the apex console listeners (a Gateway listener is
-	// selected by hostname+port; multiple HTTPS listeners can share one
-	// port as long as their hostnames differ — SNI routes between them).
-	consoleListenerHTTPSPort = int64(31443)
-	consoleListenerHTTPPort  = int64(31080)
+	// Apex console listener names on the shared console Gateway. The per-Org
+	// listeners derive their PORTS from these at apply time — see
+	// consoleApexListenerPorts (#5511).
+	consoleApexListenerHTTPSName = "console-https"
+	consoleApexListenerHTTPName  = "console-http"
+
+	// Fallback host ports, used ONLY when the apex pair cannot be read off
+	// the live Gateway. These are the #4718 canonical hostNetwork scheme and
+	// match the catalyst-api BSS-door emitter's fallbacks byte-for-byte
+	// (org_console_tls.go consoleListener*PortFallback).
+	//
+	// 🛑 #5511 — these are a FALLBACK, never a hardcode. The per-Org listeners
+	// MUST ride the SAME ports as the live apex `console-https`/`console-http`
+	// pair, because the console ELB forwards public 443/80 to exactly those
+	// ports and NOTHING else. A per-Org listener on any other port receives no
+	// traffic at all: the customer door answers `000` on every probe while the
+	// workload behind it is perfectly healthy. This reconciler previously
+	// hardcoded the pre-#4718 pair 31443/31080, which is dead on every current
+	// Sovereign — the catalyst-api twin was fixed for exactly this in #4732(2)
+	// (commit 8663202bc) and this twin was left behind, so whichever door
+	// provisioned a given Org decided whether its console worked. A Gateway
+	// listener is selected by hostname+port, so multiple HTTPS listeners share
+	// the apex port safely — SNI differentiates the per-Org wildcard hosts
+	// from the apex hosts.
+	consoleListenerHTTPSPortFallback = int64(8443)
+	consoleListenerHTTPPortFallback  = int64(8080)
 )
+
+// listenerPort reads a Gateway listener's `port`, tolerating every numeric
+// shape an unstructured round-trip can produce (int64 from apimachinery's JSON
+// decode, float64 from a raw map, int from a hand-built test fixture).
+func listenerPort(l map[string]any) (int64, bool) {
+	switch v := l["port"].(type) {
+	case int64:
+		return v, true
+	case float64:
+		return int64(v), true
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	}
+	return 0, false
+}
+
+// consoleApexListenerPorts reads the console Gateway's apex
+// `console-https`/`console-http` listener ports out of the listener slice
+// already fetched from the live Gateway — the ONLY ports the console
+// LoadBalancer actually forwards to (#4732 item 2, #5511). Falls back to the
+// #4718 canonical 8443/8080 pair when an apex listener is absent (fresh
+// install race), so the append still lands on the current canonical scheme
+// rather than resurrecting a dead one.
+//
+// Reading from the passed-in slice rather than issuing its own Get is
+// deliberate: the caller has already read the Gateway, and deriving the port
+// from the SAME read that the append is written back onto makes the port and
+// the listener set consistent by construction.
+func consoleApexListenerPorts(listeners []any) (httpsPort, httpPort int64) {
+	httpsPort = consoleListenerHTTPSPortFallback
+	httpPort = consoleListenerHTTPPortFallback
+	for _, l := range listeners {
+		m, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		port, ok := listenerPort(m)
+		if !ok {
+			continue
+		}
+		switch n, _ := m["name"].(string); n {
+		case consoleApexListenerHTTPSName:
+			httpsPort = port
+		case consoleApexListenerHTTPName:
+			httpPort = port
+		}
+	}
+	return httpsPort, httpPort
+}
 
 // dnsDashed converts a DNS name to a Secret/Certificate-safe slug:
 // `omani.homes` → `omani-homes`. Matches the apex wildcard naming
@@ -381,24 +449,15 @@ func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgCons
 		return false, fmt.Errorf("read Gateway %s/%s listeners: %w", gwNS, gwName, err)
 	}
 
-	have := map[string]bool{}
-	for _, l := range listeners {
-		if m, ok := l.(map[string]any); ok {
-			if n, ok := m["name"].(string); ok {
-				have[n] = true
-			}
-		}
-	}
-	if have[httpsName] && have[httpName] {
-		// Both listeners already present — idempotent no-op.
-		return false, nil
-	}
+	// #5511 — the per-Org ports come from the LIVE apex pair, never from a
+	// constant. See consoleApexListenerPorts.
+	httpsPort, httpPort := consoleApexListenerPorts(listeners)
 
-	if !have[httpsName] {
-		listeners = append(listeners, map[string]any{
+	desired := map[string]map[string]any{
+		httpsName: {
 			"name":     httpsName,
 			"hostname": hostname,
-			"port":     consoleListenerHTTPSPort,
+			"port":     httpsPort,
 			"protocol": "HTTPS",
 			"allowedRoutes": map[string]any{
 				"namespaces": map[string]any{"from": "All"},
@@ -413,18 +472,64 @@ func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgCons
 					},
 				},
 			},
-		})
-	}
-	if !have[httpName] {
-		listeners = append(listeners, map[string]any{
+		},
+		httpName: {
 			"name":     httpName,
 			"hostname": hostname,
-			"port":     consoleListenerHTTPPort,
+			"port":     httpPort,
 			"protocol": "HTTP",
 			"allowedRoutes": map[string]any{
 				"namespaces": map[string]any{"from": "All"},
 			},
-		})
+		},
+	}
+
+	// Pass 1 — repair drift IN PLACE on a listener we already own.
+	//
+	// 🛑 #5511: this used to short-circuit on `have[httpsName] && have[httpName]`
+	// — name presence alone counted as success. That made every wrong-port
+	// listener PERMANENT: the pre-#4718 31443/31080 pair this reconciler used
+	// to write is already on the live Gateway of every affected Sovereign, and
+	// a presence-only check would never correct it, so fixing the port constant
+	// alone would repair new Orgs and leave every existing customer door at
+	// 000 forever. Drift is compared against the fields we OWN only (a subset
+	// match, listenerSatisfies) so an apiserver-defaulted field never reads as
+	// drift and hot-loops the controller.
+	changed := false
+	seen := map[string]bool{}
+	for i, l := range listeners {
+		m, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		n, _ := m["name"].(string)
+		want, mine := desired[n]
+		if !mine {
+			// Another Org's listener, or an apex listener — never touched.
+			continue
+		}
+		seen[n] = true
+		if listenerSatisfies(m, want) {
+			continue
+		}
+		listeners[i] = want
+		changed = true
+	}
+
+	// Pass 2 — append the ones that are genuinely absent, in a deterministic
+	// order (HTTPS then HTTP) so two reconciles never produce different specs.
+	for _, n := range []string{httpsName, httpName} {
+		if seen[n] {
+			continue
+		}
+		listeners = append(listeners, desired[n])
+		changed = true
+	}
+
+	if !changed {
+		// Both listeners present AND already carrying the desired hostname,
+		// port, protocol and certificateRef — idempotent no-op.
+		return false, nil
 	}
 
 	if err := unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners"); err != nil {
@@ -542,6 +647,47 @@ func (r *Reconciler) deleteOrgWildcardCert(ctx context.Context, names orgConsole
 		return false, fmt.Errorf("delete Certificate %s/%s: %w", ns, names.CertName, err)
 	}
 	return true, nil
+}
+
+// listenerSatisfies reports whether a LIVE Gateway listener already carries
+// every field the desired listener specifies — a subset match, not an equality
+// check (#5511).
+//
+// Subset rather than equality is deliberate. The Gateway API CRD and the
+// gateway controller both default fields we do not set (`tls.options`, and an
+// operator may legitimately add `allowedRoutes.kinds`). A full-map compare
+// would read every such defaulted field as drift, rewrite the listener on
+// every single reconcile pass, and hot-loop the controller against the
+// apiserver — the #5305 shape. Comparing only the fields we own means we
+// correct a wrong port, hostname, protocol or certificateRef and stay silent
+// about everything else.
+func listenerSatisfies(live, want any) bool {
+	switch w := want.(type) {
+	case map[string]any:
+		l, ok := live.(map[string]any)
+		if !ok {
+			return false
+		}
+		for k, wv := range w {
+			if !listenerSatisfies(l[k], wv) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		l, ok := live.([]any)
+		if !ok || len(l) != len(w) {
+			return false
+		}
+		for i := range w {
+			if !listenerSatisfies(l[i], w[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return fmt.Sprintf("%v", live) == fmt.Sprintf("%v", want)
+	}
 }
 
 // specEqual is a shallow structural compare of two map[string]any specs.

--- a/core/controllers/organization/internal/controller/tenant_console_tls_5511_test.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_5511_test.go
@@ -1,0 +1,493 @@
+// tenant_console_tls_5511_test.go — #5511. The per-Org console listener pair
+// must ride the ports the console LoadBalancer actually forwards to, and a
+// listener the Gateway silently declines must never read as provisioned.
+//
+// THE DEFECT
+// ----------
+// Measured live on hw291: `Gateway/kube-system/cilium-gateway-console` declared
+// 8 listeners and published 6 in `.status.listeners`. The two absent ones were
+// exactly the per-Org pair `console-https-uatcorp` / `console-http-uatcorp`.
+// No error, no condition, no event. Consequences, on independent fresh-TCP
+// probes:
+//
+//	https://agenity.uatcorp.omani.homes/  -> 000  x6 of 6
+//	https://console.uatcorp.omani.homes/  -> 000  x8 of 8
+//	https://console.hw291.omantel.biz/    -> 200        (same VIP, control)
+//
+// The control matters: `agenity.uatcorp` was FULLY healthy behind that door —
+// HelmRelease Ready=True, `bp-agenity-0` 1/1 Running, HTTPRoute present, DNS
+// resolving to the console ELB — and still answered 000. Routing failed
+// independently of workload health.
+//
+// ROOT CAUSE
+// ----------
+// `ensureConsoleOrgListener` appended the pair on the PRE-#4718 ports
+// 31443/31080. The console LoadBalancer forwards public 443/80 to the live apex
+// `console-https`/`console-http` listener ports and to nothing else, so a
+// per-Org listener on any other port receives no traffic at all. The catalyst-api
+// twin (`products/catalyst/bootstrap/api/internal/handler/org_console_tls.go`)
+// was fixed for precisely this in #4732 item 2 (commit 8663202bc, verbatim: "the
+// console ELB only forwards to the apex ports (8443/8080), so any other pair
+// receives no traffic"), and its test bans the 31443/31080 literals outright.
+// This twin never received the fix — so whichever of the two doors provisioned a
+// given Org silently decided whether that Org's console would work. The two
+// doors are supposed to be byte-identical (#4241).
+//
+// A second, independent bug made it permanent: the append short-circuited on
+// listener-NAME presence, so a pair already sitting on the dead ports was never
+// corrected. Fixing the constant alone would have repaired new Orgs and left
+// every existing customer door at 000 forever.
+//
+// WHAT IS ASSERTED HERE
+// ---------------------
+// Part 1 — the ports are derived from the live apex pair, the dead literals can
+// never be written again, and an existing wrong-port pair is HEALED in place.
+// Part 2 — a listener present in `spec` and absent from a published `status`
+// blocks Ready with a message naming the count mismatch. Part 2 is asserted in
+// both directions: an EMPTY status is Unverifiable (a requeue, never a
+// fabricated red), which is also what keeps the status check from passing
+// vacuously on a Gateway that has published nothing at all.
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+)
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+// consoleTLSReconciler builds a Reconciler with the Certificate + Gateway GVKs
+// registered (the console-TLS up-path writes both as Unstructured) and seeds the
+// console Gateway carrying the listeners passed in.
+func consoleTLSReconciler(t *testing.T, org *orgapi.Organization, listeners []any) *Reconciler {
+	t.Helper()
+	r, _, _ := makeReconciler(t, org)
+	for _, gvk := range []schema.GroupVersionKind{certificateGVK, gatewayGVK} {
+		r.Scheme().AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		r.Scheme().AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+	}
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	gw.SetName(consoleGatewayDefaultName)
+	gw.SetNamespace(consoleGatewayDefaultNamespace)
+	gw.Object["spec"] = map[string]any{"gatewayClassName": "cilium"}
+	if err := unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners"); err != nil {
+		t.Fatalf("seed listeners: %v", err)
+	}
+	if err := r.Create(context.Background(), gw); err != nil {
+		t.Fatalf("seed console Gateway: %v", err)
+	}
+	return r
+}
+
+// apexPair is the bootstrap-rendered console listener set: one exact-hostname
+// pair per operator endpoint on the ports the console LB forwards to. Shape and
+// ports come from platform/sovereign-tls-vars/chart/templates/configmap.yaml
+// (consoleGateway.httpsPort=443 / httpPort=80).
+func apexPair() []any {
+	return []any{
+		map[string]any{
+			"name": consoleApexListenerHTTPSName, "hostname": "console.hw291.omantel.biz",
+			"port": int64(443), "protocol": "HTTPS",
+		},
+		map[string]any{
+			"name": consoleApexListenerHTTPName, "hostname": "console.hw291.omantel.biz",
+			"port": int64(80), "protocol": "HTTP",
+		},
+	}
+}
+
+// deadPortPair is the live hw291 shape: this reconciler's own pre-fix append,
+// sitting on the dead pre-#4718 ports while the apex pair serves 443/80.
+func deadPortPair(hostname string) []any {
+	return []any{
+		map[string]any{
+			"name": "console-https-acme", "hostname": hostname,
+			"port": int64(31443), "protocol": "HTTPS",
+			"tls": map[string]any{
+				"mode":            "Terminate",
+				"certificateRefs": []any{map[string]any{"group": "", "kind": "Secret", "name": "org-wildcard-tls-acme-omani-homes"}},
+			},
+		},
+		map[string]any{
+			"name": "console-http-acme", "hostname": hostname,
+			"port": int64(31080), "protocol": "HTTP",
+		},
+	}
+}
+
+// gatewayListeners reads back one of the console Gateway's listener slices
+// ("spec" or "status") as a name→port map, plus the raw count.
+func gatewayListeners(t *testing.T, r *Reconciler, where string) (map[string]int64, int) {
+	t.Helper()
+	gw := unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleGatewayDefaultNamespace, Name: consoleGatewayDefaultName,
+	}, &gw); err != nil {
+		t.Fatalf("get console Gateway: %v", err)
+	}
+	raw, _, err := unstructured.NestedSlice(gw.Object, where, "listeners")
+	if err != nil {
+		t.Fatalf("read %s.listeners: %v", where, err)
+	}
+	out := map[string]int64{}
+	for _, l := range raw {
+		m, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		n, _ := m["name"].(string)
+		p, _ := listenerPort(m)
+		out[n] = p
+	}
+	return out, len(raw)
+}
+
+// admitGatewayListeners simulates the Gateway controller's admission step: it
+// copies the console Gateway's spec.listeners into status.listeners, DECLINING
+// the names passed in `decline` — which is exactly the #5511 shape, a spec
+// listener that is silently absent from status with no condition and no event.
+// Returns the resulting (specCount, statusCount).
+func admitGatewayListeners(t *testing.T, r *Reconciler, decline ...string) (int, int) {
+	t.Helper()
+	declined := map[string]bool{}
+	for _, n := range decline {
+		declined[n] = true
+	}
+	gw := unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleGatewayDefaultNamespace, Name: consoleGatewayDefaultName,
+	}, &gw); err != nil {
+		t.Fatalf("get console Gateway for admission: %v", err)
+	}
+	spec, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		t.Fatalf("read spec.listeners: %v", err)
+	}
+	status := make([]any, 0, len(spec))
+	for _, l := range spec {
+		m, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		n, _ := m["name"].(string)
+		if declined[n] {
+			continue
+		}
+		status = append(status, map[string]any{
+			"name":           n,
+			"attachedRoutes": int64(1),
+		})
+	}
+	if err := unstructured.SetNestedSlice(gw.Object, status, "status", "listeners"); err != nil {
+		t.Fatalf("set status.listeners: %v", err)
+	}
+	if err := r.Update(context.Background(), &gw); err != nil {
+		t.Fatalf("publish gateway status: %v", err)
+	}
+	return len(spec), len(status)
+}
+
+// poolOrgFor is the acme Org that engages the tenant-networking up-path.
+func poolOrgFor() *orgapi.Organization {
+	org := sampleOrg()
+	org.Spec.TenantPublic = orgapi.OrganizationTenantPublic{ParentDomain: "omani.homes"}
+	return org
+}
+
+// ── Part 1 — the ports ───────────────────────────────────────────────────────
+
+// TestEnsureConsoleOrgListener_5511_RidesLiveApexPorts — the appended pair must
+// take its ports from the LIVE apex listeners (443/80 here), not from a
+// constant. The dead pre-#4718 31443/31080 pair must never appear again: those
+// are the ports that produced 000 on every hw291 per-Org probe.
+func TestEnsureConsoleOrgListener_5511_RidesLiveApexPorts(t *testing.T) {
+	t.Parallel()
+	org := poolOrgFor()
+	r := consoleTLSReconciler(t, org, apexPair())
+
+	changed, err := r.reconcileTenantConsoleTLS(context.Background(), org)
+	if err != nil {
+		t.Fatalf("reconcileTenantConsoleTLS: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true (cert + listener pair written)")
+	}
+
+	ports, count := gatewayListeners(t, r, "spec")
+	// Positive control: the append really happened. Without this the port
+	// assertions below would pass on a Gateway with no listeners at all.
+	if count != 4 {
+		t.Fatalf("spec.listeners: got %d %v, want 4 (apex pair + per-Org pair)", count, ports)
+	}
+
+	for name, want := range map[string]int64{
+		"console-https-acme": 443,
+		"console-http-acme":  80,
+	} {
+		got, ok := ports[name]
+		if !ok {
+			t.Fatalf("per-Org listener %q was not appended: %v", name, ports)
+		}
+		if got != want {
+			t.Errorf("listener %q port: got %d, want %d (the live apex port — the console LB forwards public 443/80 there and nowhere else)", name, got, want)
+		}
+		if got == 31443 || got == 31080 {
+			t.Errorf("listener %q is back on the dead pre-#4718 port %d — this is the #5511 defect: the console LB forwards no traffic to it, so the customer door answers 000 while the workload is healthy", name, got)
+		}
+	}
+
+	// The apex pair must be untouched.
+	if ports[consoleApexListenerHTTPSName] != 443 || ports[consoleApexListenerHTTPName] != 80 {
+		t.Errorf("apex listeners were modified: %v", ports)
+	}
+}
+
+// TestEnsureConsoleOrgListener_5511_HealsDeadPortsInPlace — the live hw291
+// state: the pair is ALREADY on the Gateway at 31443/31080. A presence-only
+// check reads that as success and never repairs it, which is what made the
+// defect permanent — fixing the port constant alone would repair new Orgs and
+// leave every existing customer door at 000. The pair must be healed in place.
+func TestEnsureConsoleOrgListener_5511_HealsDeadPortsInPlace(t *testing.T) {
+	t.Parallel()
+	org := poolOrgFor()
+	seeded := append(apexPair(), deadPortPair("*.acme.omani.homes")...)
+	r := consoleTLSReconciler(t, org, seeded)
+
+	before, count := gatewayListeners(t, r, "spec")
+	// Positive control on the fixture itself: the defect really is present
+	// before we act, so a green below cannot come from a fixture that never
+	// carried the wrong ports.
+	if count != 4 || before["console-https-acme"] != 31443 || before["console-http-acme"] != 31080 {
+		t.Fatalf("fixture must start with the pair on the dead ports: %v (%d listeners)", before, count)
+	}
+
+	changed, err := r.ensureConsoleOrgListener(context.Background(), orgConsoleTLSNamesFor("acme", "omani.homes"))
+	if err != nil {
+		t.Fatalf("ensureConsoleOrgListener: %v", err)
+	}
+	if !changed {
+		t.Fatalf("a pair sitting on the dead 31443/31080 ports MUST be reported as changed — a presence-only no-op here is the bug that made #5511 permanent")
+	}
+
+	after, count := gatewayListeners(t, r, "spec")
+	if count != 4 {
+		t.Errorf("heal must repair in place, not duplicate: got %d listeners %v, want 4", count, after)
+	}
+	if after["console-https-acme"] != 443 {
+		t.Errorf("console-https-acme port: got %d, want 443 (healed onto the live apex port)", after["console-https-acme"])
+	}
+	if after["console-http-acme"] != 80 {
+		t.Errorf("console-http-acme port: got %d, want 80 (healed onto the live apex port)", after["console-http-acme"])
+	}
+
+	// Idempotent once healed — otherwise the controller rewrites the Gateway on
+	// every pass and hot-loops against the apiserver.
+	changed, err = r.ensureConsoleOrgListener(context.Background(), orgConsoleTLSNamesFor("acme", "omani.homes"))
+	if err != nil {
+		t.Fatalf("ensureConsoleOrgListener pass 2: %v", err)
+	}
+	if changed {
+		t.Errorf("pass 2 must be a no-op once the pair is correct — got changed=true (rewrite-every-reconcile hot-loop)")
+	}
+}
+
+// TestEnsureConsoleOrgListener_5511_ApexAbsentUsesCanonicalFallback — when the
+// apex pair cannot be read (the fresh-install race), the append must fall back
+// to the #4718 canonical 8443/8080 scheme, matching the catalyst-api twin's
+// fallbacks byte-for-byte. It must NOT resurrect the dead pre-#4718 pair.
+func TestEnsureConsoleOrgListener_5511_ApexAbsentUsesCanonicalFallback(t *testing.T) {
+	t.Parallel()
+	org := poolOrgFor()
+	// A Gateway carrying an unrelated listener only — no apex console pair.
+	r := consoleTLSReconciler(t, org, []any{
+		map[string]any{
+			"name": "marketplace-https", "hostname": "marketplace.hw291.omantel.biz",
+			"port": int64(443), "protocol": "HTTPS",
+		},
+	})
+
+	if _, err := r.ensureConsoleOrgListener(context.Background(), orgConsoleTLSNamesFor("acme", "omani.homes")); err != nil {
+		t.Fatalf("ensureConsoleOrgListener: %v", err)
+	}
+
+	ports, count := gatewayListeners(t, r, "spec")
+	if count != 3 {
+		t.Fatalf("spec.listeners: got %d %v, want 3", count, ports)
+	}
+	if ports["console-https-acme"] != consoleListenerHTTPSPortFallback {
+		t.Errorf("console-https-acme port: got %d, want the #4718 canonical fallback %d", ports["console-https-acme"], consoleListenerHTTPSPortFallback)
+	}
+	if ports["console-http-acme"] != consoleListenerHTTPPortFallback {
+		t.Errorf("console-http-acme port: got %d, want the #4718 canonical fallback %d", ports["console-http-acme"], consoleListenerHTTPPortFallback)
+	}
+}
+
+// ── Part 2 — a dropped listener can never be silent ──────────────────────────
+
+// verifyPoolOrg drives verifyProvisioned against a fully-provisioned pool Org
+// whose console Gateway carries `listeners` in spec.
+func verifyPoolOrg(t *testing.T, listeners []any) (*Reconciler, *orgapi.Organization) {
+	t.Helper()
+	org := poolOrgFor()
+	r, _, _ := makeReconciler(t, org,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}},
+		readyVClusterHR("acme"),
+		boundaryLimitRange("acme"),
+		boundaryResourceQuota("acme"),
+	)
+	for _, gvk := range []schema.GroupVersionKind{certificateGVK, gatewayGVK} {
+		r.Scheme().AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		r.Scheme().AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+	}
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	gw.SetName(consoleGatewayDefaultName)
+	gw.SetNamespace(consoleGatewayDefaultNamespace)
+	gw.Object["spec"] = map[string]any{"gatewayClassName": "cilium"}
+	if err := unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners"); err != nil {
+		t.Fatalf("seed listeners: %v", err)
+	}
+	if err := r.Create(context.Background(), gw); err != nil {
+		t.Fatalf("seed console Gateway: %v", err)
+	}
+	return r, org
+}
+
+// healthyPairListeners is the post-fix steady state: apex pair on 443/80 plus
+// the per-Org pair on the SAME ports.
+func healthyPairListeners() []any {
+	return append(apexPair(),
+		map[string]any{
+			"name": "console-https-acme", "hostname": "*.acme.omani.homes",
+			"port": int64(443), "protocol": "HTTPS",
+		},
+		map[string]any{
+			"name": "console-http-acme", "hostname": "*.acme.omani.homes",
+			"port": int64(80), "protocol": "HTTP",
+		},
+	)
+}
+
+// TestVerifyProvisioned_5511_SilentlyDroppedListenerBlocksReady — THE #5511
+// assertion. The pair is in spec on the right ports; the Gateway published a
+// status that silently omits it. That is indistinguishable, from the operator's
+// side, from a listener that was never configured — so it must block Ready and
+// name the count mismatch.
+func TestVerifyProvisioned_5511_SilentlyDroppedListenerBlocksReady(t *testing.T) {
+	t.Parallel()
+	r, org := verifyPoolOrg(t, healthyPairListeners())
+
+	specCount, statusCount := admitGatewayListeners(t, r, "console-https-acme", "console-http-acme")
+	// Positive control: status really was published and really is non-empty.
+	// Without this the "our listener is missing from status" verdict could be
+	// satisfied by a Gateway that published nothing, which is a different
+	// (and non-decidable) condition.
+	if statusCount == 0 {
+		t.Fatalf("fixture must publish a NON-EMPTY status.listeners, else the check below is vacuous")
+	}
+	if specCount != 4 || statusCount != 2 {
+		t.Fatalf("fixture counts: spec=%d status=%d, want 4/2 (the hw291 8-vs-6 shape)", specCount, statusCount)
+	}
+
+	out := r.verifyProvisioned(context.Background(), org)
+	if out.complete() {
+		t.Fatalf("a listener present in spec and silently ABSENT from a published status must NOT read as provisioned — got Missing=%v Unverifiable=%v", out.Missing, out.Unverifiable)
+	}
+	msg := out.message()
+	for _, want := range []string{"console-https-acme", "console-http-acme", "silently dropped"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the Ready message must name the drop — %q absent from: %s", want, msg)
+		}
+	}
+	if !strings.Contains(msg, "4 listeners into spec") || !strings.Contains(msg, "only 2 in status") {
+		t.Errorf("the Ready message must carry the COUNT mismatch (spec 4 vs status 2) — got: %s", msg)
+	}
+}
+
+// TestVerifyProvisioned_5511_AdmittedPairGoesGreen — the converse, and the
+// count-based assertion in its positive direction: with every spec listener
+// published in status the Org is fully provisioned. Without this the test above
+// could be satisfied by a check that never goes green.
+func TestVerifyProvisioned_5511_AdmittedPairGoesGreen(t *testing.T) {
+	t.Parallel()
+	r, org := verifyPoolOrg(t, healthyPairListeners())
+
+	specCount, statusCount := admitGatewayListeners(t, r) // decline nothing
+	if specCount != statusCount {
+		t.Fatalf("fixture must admit every listener: spec=%d status=%d", specCount, statusCount)
+	}
+	if statusCount == 0 {
+		t.Fatalf("fixture must publish a non-empty status.listeners")
+	}
+
+	// The count assertion the defect violated: every declared listener admitted.
+	_, liveSpec := gatewayListeners(t, r, "spec")
+	_, liveStatus := gatewayListeners(t, r, "status")
+	if liveStatus != liveSpec {
+		t.Errorf("len(status.listeners)=%d != len(spec.listeners)=%d", liveStatus, liveSpec)
+	}
+
+	out := r.verifyProvisioned(context.Background(), org)
+	if !out.complete() {
+		t.Errorf("an Org whose listener pair is in spec AND admitted into status must read fully provisioned — got Missing=%v", out.Missing)
+	}
+}
+
+// TestVerifyProvisioned_5511_EmptyStatusIsUnverifiableNotMissing — the
+// evidence-of-absence guard. A Gateway that has published NO listener status
+// yet (the bootstrap window) cannot be judged: reporting that as Missing would
+// red-flag every pool Org on the Sovereign the moment the Gateway is created.
+// It must requeue instead. This is also what stops the status check from
+// passing vacuously — an empty status is explicitly undecided, never a pass.
+func TestVerifyProvisioned_5511_EmptyStatusIsUnverifiableNotMissing(t *testing.T) {
+	t.Parallel()
+	r, org := verifyPoolOrg(t, healthyPairListeners()) // no admission simulated
+
+	_, statusCount := gatewayListeners(t, r, "status")
+	if statusCount != 0 {
+		t.Fatalf("fixture must have an EMPTY status.listeners, got %d", statusCount)
+	}
+
+	out := r.verifyProvisioned(context.Background(), org)
+	if len(out.Missing) != 0 {
+		t.Errorf("an unpublished status.listeners is not evidence of absence — must not fabricate a red: %v", out.Missing)
+	}
+	if len(out.Unverifiable) == 0 {
+		t.Errorf("an unpublished status.listeners must be reported UNVERIFIABLE so the Org requeues rather than silently passing")
+	}
+}
+
+// TestVerifyProvisioned_5511_PortDriftBlocksReady — admission alone is not
+// enough. A pair admitted into status but bound to the dead pre-#4718 ports
+// still receives no traffic, so the port drift itself must block Ready. This
+// fires even though `status.listeners` is complete.
+func TestVerifyProvisioned_5511_PortDriftBlocksReady(t *testing.T) {
+	t.Parallel()
+	r, org := verifyPoolOrg(t, append(apexPair(), deadPortPair("*.acme.omani.homes")...))
+
+	specCount, statusCount := admitGatewayListeners(t, r) // every listener admitted
+	if specCount != statusCount || statusCount == 0 {
+		t.Fatalf("fixture must admit every listener: spec=%d status=%d", specCount, statusCount)
+	}
+
+	out := r.verifyProvisioned(context.Background(), org)
+	if out.complete() {
+		t.Fatalf("a pair on the dead 31443/31080 ports receives no traffic and must NOT read as provisioned, even fully admitted — got Missing=%v", out.Missing)
+	}
+	msg := out.message()
+	if !strings.Contains(msg, "wrong port") || !strings.Contains(msg, "31443") {
+		t.Errorf("the Ready message must name the port drift — got: %s", msg)
+	}
+}


### PR DESCRIPTION
Refs #5511

## The defect, measured

`Gateway/kube-system/cilium-gateway-console` on hw291 declared **8** listeners and published **6** in `.status.listeners`. The two absent ones were exactly the per-Org pair `console-https-uatcorp` / `console-http-uatcorp` — no error, no condition, no event anywhere.

```
https://agenity.uatcorp.omani.homes/  ->  000  x6 of 6
https://console.uatcorp.omani.homes/  ->  000  x8 of 8
https://console.hw291.omantel.biz/    ->  200        (same VIP, control)
```

The control is what makes this decisive: `agenity.uatcorp` was **fully healthy** behind that door — HelmRelease `Ready=True`, `bp-agenity-0` 1/1 Running, HTTPRoute present, DNS resolving to the console ELB — and still answered 000. Routing failed independently of workload health, and the apex console on the same VIP served 200.

## Root cause

`ensureConsoleOrgListener` appended the per-Org pair on the **pre-#4718 ports 31443/31080**. The console LoadBalancer forwards public 443/80 to the **live apex** `console-https`/`console-http` listener ports and to nothing else, so a per-Org listener on any other port receives no traffic at all.

This is not a new theory — it is the **same defect already fixed once in the catalyst-api twin** by #4732 item 2 (commit `8663202bc`), verbatim:

> Per-Org console listeners ride the SAME ports as the live apex console-https/console-http pair (SNI-differentiated) instead of the dead pre-#4718 31443/31080 constants — the console ELB only forwards to the apex ports (8443/8080), so any other pair receives no traffic.

That twin's test bans the literals outright (`org_console_tls_test.go:336`). The org-controller twin never received the fix, so **whichever of the two doors provisioned a given Org silently decided whether that Org's console worked** — even though the two are specified to render byte-identical resources (#4241).

A second, independent bug made it permanent: the append short-circuited on listener-**name** presence, so a pair already sitting on the dead ports was never corrected. Fixing the port derivation alone would have repaired new Orgs and left every existing customer door at 000 forever.

## #5341 wildcard-collision hypothesis: REFUTED

- **#5341 is already fixed in this very gateway.** `platform/sovereign-tls-vars/chart/templates/configmap.yaml` renders the console listeners with **exact 2-label hostnames** (`console.`/`api.`/`marketplace.<fqdn>`), explicitly never `*.<fqdn>` — the gateway therefore carries **no wildcard listener** for the per-Org wildcard to collide with.
- The 6 published listeners are exactly `3 hostPrefixes x 2 protocols`, accounting for all six with zero wildcards.
- `*.uatcorp.omani.homes` and the apex `*.hw291.omantel.biz` hosts are under different registered domains — no SNI overlap is even possible.
- Symptom shapes differ: #5341 produced ~50% **non-deterministic envoy 404s** (a served response). This was **deterministic 000** on 6/6 and 8/8 with a 200 control on the same VIP.

## Part 1 — make the listeners admit

`core/controllers/organization/internal/controller/tenant_console_tls.go`

- `consoleApexListenerPorts` derives the pair's ports from the live apex listeners **in the same read the append is written back onto**, so port and listener set are consistent by construction. Falls back to the #4718 canonical 8443/8080 — matching the catalyst-api twin's fallbacks byte-for-byte — when the apex cannot be read. The 31443/31080 constants are gone.
- The append now **repairs drift in place** instead of short-circuiting on name presence, so the wrong-port pairs already live on affected Sovereigns are healed rather than frozen. Drift is a **subset match on the fields we own** (`listenerSatisfies`), so an apiserver-defaulted field never reads as drift and rewrite-every-reconcile cannot hot-loop the controller. Other Orgs' listeners and the apex pair are never touched.

## Part 2 — a dropped listener can never be silent again

`core/controllers/organization/internal/controller/provisioning_postconditions.go`

#5395's verifier read `spec.listeners` **only**, which is why it passed green on hw291: the pair *was* in spec. Presence in spec is not serving. `verifyProvisioned` now reads back `status.listeners` too and refuses `Ready` over:

- **a count mismatch** — any listener accepted into spec and absent from a published status, named individually with both counts (`ACCEPTED 8 listeners into spec but published only 6 in status — silently dropped: ...`);
- **port drift** against the live apex pair, which fires even when admission succeeded, because an admitted listener on a dead port still serves nothing.

An **empty** `status.listeners` is reported `Unverifiable`, not `Missing` — the bootstrap window is absence of evidence, and reporting it as a red would flag every pool Org on the Sovereign at once. That gate is also what stops the status check from passing **vacuously** on a Gateway that has published nothing at all.

Part 2 is the durable half: it surfaces the drop regardless of cause, including if the status omission turns out to be an upstream Cilium constraint.

## Gates

```
$ cd core/controllers/organization && go build ./... && go vet ./... && go test ./...
=== go build ===  OK
=== go vet ===    OK
ok  github.com/openova-io/openova/core/controllers/organization/internal/controller
ok  github.com/openova-io/openova/core/controllers/organization/internal/gitops
ok  github.com/openova-io/openova/core/controllers/organization/internal/iacbootstrap

$ cd tests/e2e/bootstrap-kit && go test -count=1 ./...
ok  github.com/openova-io/openova/tests/e2e/bootstrap-kit  0.453s
```

No chart, chart version, or bootstrap-kit file is touched; the lockstep gate was run as insurance and is green.

## FAIL-then-PASS, executed not asserted

Each guard was verified by reintroducing the defect, observing the failure, restoring, and observing the pass.

**Proof A — hardcode the dead ports back into `consoleApexListenerPorts`:**

```
--- FAIL: TestEnsureConsoleOrgListener_5511_RidesLiveApexPorts
    listener "console-https-acme" port: got 31443, want 443 (the live apex port ...)
    listener "console-https-acme" is back on the dead pre-#4718 port 31443 — this is the #5511 defect
    listener "console-http-acme" port: got 31080, want 80
--- FAIL: TestEnsureConsoleOrgListener_5511_ApexAbsentUsesCanonicalFallback
    console-https-acme port: got 31443, want the #4718 canonical fallback 8443
--- FAIL: TestEnsureConsoleOrgListener_5511_HealsDeadPortsInPlace
--- FAIL: TestVerifyProvisioned_5511_PortDriftBlocksReady
--- FAIL: TestVerifyProvisioned_5511_EmptyStatusIsUnverifiableNotMissing
--- FAIL: TestVerifyProvisioned_5511_AdmittedPairGoesGreen
```

**Proof B — restore the presence-only short-circuit** (isolates the self-heal guard alone):

```
--- FAIL: TestEnsureConsoleOrgListener_5511_HealsDeadPortsInPlace
    a pair sitting on the dead 31443/31080 ports MUST be reported as changed —
    a presence-only no-op here is the bug that made #5511 permanent
```

**Proof C — revert the readback to spec-only** (the silence itself):

```
--- FAIL: TestVerifyProvisioned_5511_SilentlyDroppedListenerBlocksReady
    a listener present in spec and silently ABSENT from a published status must NOT
    read as provisioned — got Missing=[] Unverifiable=[]
```

`Missing=[] Unverifiable=[]` is the #5511 shape verbatim: completely silent.

**Restored — all 14 guards pass:**

```
--- PASS: TestEnsureConsoleOrgListener_5511_RidesLiveApexPorts
--- PASS: TestEnsureConsoleOrgListener_5511_HealsDeadPortsInPlace
--- PASS: TestEnsureConsoleOrgListener_5511_ApexAbsentUsesCanonicalFallback
--- PASS: TestVerifyProvisioned_5511_SilentlyDroppedListenerBlocksReady
--- PASS: TestVerifyProvisioned_5511_AdmittedPairGoesGreen
--- PASS: TestVerifyProvisioned_5511_EmptyStatusIsUnverifiableNotMissing
--- PASS: TestVerifyProvisioned_5511_PortDriftBlocksReady
--- PASS: TestReconcile_5395_ConsoleListenerMissing_MustNotReadReady
--- PASS: TestReconcile_5395_SilentListenerSkip_MustNotReadReady
--- PASS: TestReconcile_5395_ListenerAppendedThenVerified
--- PASS: TestReconcile_5395_HardCappedPlanWithoutQuota_MustNotReadReady
--- PASS: TestReconcile_5395_FlexiWithoutQuotaIsNotAGap
--- PASS: TestReconcileTenantConsoleTLS_IssuesCertAndAppendsListener
--- PASS: TestReconcileTenantConsoleTLS_NoopWhenNoParentDomain
ok  github.com/openova-io/openova/core/controllers/organization/internal/controller
```

### Test discipline notes

- **No vacuous assertion.** Every port assertion carries a positive control that the append actually produced listeners (`spec.listeners` count checked before the port is read), and the drift fixture asserts the wrong ports are present *before* the heal, so a green cannot come from a fixture that never carried the defect.
- **Count-based, not name-based.** The part-2 guard asserts on `len(status.listeners)` vs `len(spec.listeners)` with the pair declined, and its converse asserts equality on the green path — the bug is a silent count mismatch, not a single missing name.
- The #5395 fixture now simulates the Gateway controller's admission step (`admitGatewayListeners`), because a live Gateway always publishes `status.listeners`. The fixture became a **stricter** model of reality, not a looser one — it now exercises the full append-then-admit loop.

### Not verified here

Whether Cilium *also* declines to publish status for a listener on an unforwarded port is a Cilium-internal behaviour I could not confirm — no hw291 kubeconfig is present on this host, and the task is code-only. The port defect is proven from the writer and fully explains the measured 000; the status omission is consistent with it. Part 2 deliberately does not depend on that answer: it surfaces the drop whatever the cause.

No NodePort is introduced or relied upon anywhere in this change — the per-Org listeners ride the same ports the DIRECT-served console gateway already binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
