### PR TITLE
fix(catalyst-api): per-Org console gateway surface to EVERY region + listener-admission read-back (Refs #5511)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
@@ -66,20 +66,52 @@
 // HandleReconcileOrganization pass). BYO-domain Orgs are skipped — they carry
 // their own per-host Certificate (orgTenantCertificate IsBYO branch) and a
 // CNAME, not a pool-parent wildcard.
+//
+// #5511 — MULTI-REGION + READ-BACK. Two defects proven live on hw291:
+//
+//	A. The trio above was applied to the HOST region cluster only. On a
+//	   multi-region Sovereign one shared EIP round-robins every region's
+//	   cilium-envoy, so a region that never received the listener pair, the
+//	   cert secret, or the console HTTPRoute TLS-resets ~1/N of all
+//	   connections to EVERY per-Org console — the per-region split-write
+//	   class (#5394/#5406/#5414/#5416), now for the whole per-Org gateway
+//	   surface. Fix: fan the listener pair + the console HTTPRoute out to
+//	   every secondary region cluster registered in h.k8sCache (the same
+//	   per-region client seam the D20 jobs fan-out and the /cloud page use),
+//	   and mirror the ISSUED cert secret from the host region (issuing a
+//	   second identical LE cert per region would burn the duplicate-cert
+//	   rate limit; the mirror follows the proven live heal). The keycloak /
+//	   oidc-gate per-app HTTPRoutes are deliberately NOT fanned out — their
+//	   backends are region-local singletons and mirroring them trades a TLS
+//	   reset for a 503; that routing decision belongs to the placement model.
+//	B. A successful SSA apply was never read back. cilium-operator can miss
+//	   the listener append (observed live: gateway generation=2,
+//	   observedGeneration=1 for 8h after an operator restart) and the apply
+//	   path only logged FAILURES — success-without-admission was invisible.
+//	   Fix: after the applies, poll Gateway.status.listeners (bounded by
+//	   orgConsoleListenerAdmitBudget) until BOTH per-Org listener names are
+//	   PRESENT (vacuity-proof: presence is asserted, never absence of an
+//	   error), and log a loud error naming the gateway, the listener names,
+//	   and generation vs observedGeneration when a region never admits them.
 
 package handler
 
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
@@ -205,14 +237,126 @@ func resolveOrgConsoleTLSNames(rec store.OrganizationProvisionRecord) (orgConsol
 	}, true
 }
 
+// orgConsoleListenerAdmitBudget bounds the #5511 read-back verification: how
+// long provisionOrgConsoleTLS waits, TOTAL across all regions, for every
+// region's cilium-gateway-console to ADMIT the per-Org listener pair into
+// status.listeners after the SSA apply. In the healthy case cilium-operator
+// admits within a second or two, so the poll returns almost immediately; the
+// budget is only consumed when a region's operator has missed the append (the
+// hw291 defect-A shape), which is exactly when the loud error must fire.
+// Package vars (not consts) so tests shrink them.
+var (
+	orgConsoleListenerAdmitBudget       = 60 * time.Second
+	orgConsoleListenerAdmitPollInterval = 3 * time.Second
+)
+
+// orgConsoleTLSHostRegion labels the host-region (in-cluster) target in logs.
+const orgConsoleTLSHostRegion = "host"
+
+// orgConsoleTLSTarget is one region cluster the per-Org console gateway
+// surface must be written to: the host region (via sovereignDepsFor) plus, on
+// a multi-region Sovereign, every secondary region registered in h.k8sCache.
+type orgConsoleTLSTarget struct {
+	region    string // orgConsoleTLSHostRegion, or the secondary's region key
+	clusterID string // k8sCache cluster id ("" for the host target)
+	dyn       dynamic.Interface
+	core      kubernetes.Interface
+}
+
+// orgConsoleTLSSecondaryRegions — pure helper: given the full k8sCache
+// cluster-id set of a CHROOT (one primary + this Sovereign's secondaries, per
+// the deploymentScopedClusterIDs invariant), map each SECONDARY cluster id to
+// its region key.
+//
+// Secondary ids follow `<primaryID>-<regionKey>` (HandleSovereignSecondary-
+// Kubeconfig). The primary id is derived from the set itself rather than a
+// *Deployment record (the Org funnel has none in hand): an id is a candidate
+// primary iff NO other id in the set is a prefix of it; every non-candidate
+// derives its region by stripping its LONGEST candidate-primary prefix
+// (longest so region keys that themselves contain hyphens — "nbg1-1",
+// "ap-southeast-3" — split on the deployment boundary, mirroring
+// regionFromSecondaryClusterID's contract). A set with no prefix relations
+// (e.g. a mothership cache holding sibling deployments, or a chroot whose
+// self-registered alias never matched its secondaries) yields the empty map —
+// the safe no-op that preserves the pre-#5511 host-only behaviour.
+func orgConsoleTLSSecondaryRegions(clusterIDs []string) map[string]string {
+	isSecondary := func(id string) bool {
+		for _, p := range clusterIDs {
+			if p != id && strings.HasPrefix(id, p+"-") {
+				return true
+			}
+		}
+		return false
+	}
+	out := map[string]string{}
+	for _, id := range clusterIDs {
+		best := ""
+		for _, p := range clusterIDs {
+			if p == id || isSecondary(p) {
+				continue // only candidate primaries may donate a prefix
+			}
+			if strings.HasPrefix(id, p+"-") && len(p) > len(best) {
+				best = p
+			}
+		}
+		if best != "" {
+			out[id] = strings.TrimPrefix(id, best+"-")
+		}
+	}
+	return out
+}
+
+// orgConsoleTLSTargets resolves every region cluster the per-Org console
+// gateway surface must be written to. The host region always leads; secondary
+// regions are appended ONLY on a chroot (SOVEREIGN_FQDN set) — on the
+// mothership h.k8sCache holds EVERY managed Sovereign's clusters (#3987) and
+// a blind fan-out would write per-Org listeners onto alien deployments.
+// This is the same per-region client seam the D20 jobs fan-out
+// (chrootSeedSecondaryRegions) and the /cloud page use — no new plumbing.
+func (h *Handler) orgConsoleTLSTargets(deps *sovereignDeps) []orgConsoleTLSTarget {
+	targets := []orgConsoleTLSTarget{{region: orgConsoleTLSHostRegion, dyn: deps.dyn, core: deps.core}}
+	if h.k8sCache == nil || !isChroot() {
+		return targets
+	}
+	secondaries := orgConsoleTLSSecondaryRegions(h.k8sCache.Clusters())
+	cids := make([]string, 0, len(secondaries))
+	for cid := range secondaries {
+		cids = append(cids, cid)
+	}
+	sort.Strings(cids)
+	for _, cid := range cids {
+		region := secondaries[cid]
+		dyn, err := h.k8sCache.DynamicClientFor(cid)
+		if err != nil || dyn == nil {
+			h.log.Warn("org-console-tls: secondary region dynamic client unavailable — its per-Org gateway surface is NOT written this pass; the next reconcile retries (#5511)",
+				"clusterID", cid, "region", region, "err", err)
+			continue
+		}
+		targets = append(targets, orgConsoleTLSTarget{
+			region:    region,
+			clusterID: cid,
+			dyn:       dyn,
+			core:      h.k8sCache.CoreClient(cid),
+		})
+	}
+	return targets
+}
+
 // provisionOrgConsoleTLS is the best-effort, non-gating finalisation step that
 // makes the Org's console host (`console.<slug>.<parent>`) serve TLS. Mirrors
 // createOrgOrganizationCR's idiom: resolve the in-cluster dynamic client via
-// sovereignDepsFor() (nil-tolerant for CI / out-of-cluster), apply the three
+// sovereignDepsFor() (nil-tolerant for CI / out-of-cluster), apply the
 // resources idempotently, and log loud on failure WITHOUT failing the Org
 // pipeline. Each sub-step is independent: a failure on one is logged and the
 // rest still run, and the org-controller / next HandleReconcileOrganization
 // pass retries the whole thing.
+//
+// #5511: the listener pair + console HTTPRoute are applied to EVERY region
+// cluster (host + registered secondaries); the cert-manager Certificate is
+// created on the host region only and its issued secret MIRRORED to the
+// secondaries; after the applies, every region's Gateway status.listeners is
+// read back until both per-Org listener names are admitted — see the file
+// header for the two live defects this closes.
 func (h *Handler) provisionOrgConsoleTLS(ctx context.Context, rec store.OrganizationProvisionRecord) {
 	names, ok := resolveOrgConsoleTLSNames(rec)
 	if !ok {
@@ -235,25 +379,236 @@ func (h *Handler) provisionOrgConsoleTLS(ctx context.Context, rec store.Organiza
 		return
 	}
 
-	if err := ensureOrgConsoleCertificate(ctx, deps.dyn, names, rec); err != nil {
-		h.log.Error("org-console-tls: Certificate apply failed — reconcile will retry",
-			"cert", names.CertName, "host", names.WildcardHost, "err", err)
+	targets := h.orgConsoleTLSTargets(deps)
+	regions := make([]string, 0, len(targets))
+	for _, tgt := range targets {
+		regions = append(regions, tgt.region)
+		if tgt.region == orgConsoleTLSHostRegion {
+			if err := ensureOrgConsoleCertificate(ctx, tgt.dyn, names, rec); err != nil {
+				h.log.Error("org-console-tls: Certificate apply failed — reconcile will retry",
+					"region", tgt.region, "cert", names.CertName, "host", names.WildcardHost, "err", err)
+			}
+		} else if err := mirrorOrgConsoleCertSecret(ctx, deps.core, tgt.core, names, rec); err != nil {
+			// Includes the benign "host cert not issued yet" case right after
+			// Org creation — the next reconcile pass mirrors it. Until then the
+			// secondary's listeners sit ResolvedRefs=False but PRESENT in
+			// status, so the read-back below still verifies admission.
+			h.log.Error("org-console-tls: cert-secret mirror to secondary region failed — reconcile will retry (#5511)",
+				"region", tgt.region, "clusterID", tgt.clusterID, "secret", names.CertName, "err", err)
+		}
+		if err := ensureOrgConsoleListener(ctx, tgt.dyn, names, rec); err != nil {
+			h.log.Error("org-console-tls: Gateway listener apply failed — reconcile will retry",
+				"region", tgt.region, "gateway", consoleGatewayName, "https_listener", names.HTTPSName, "err", err)
+		}
+		if err := ensureOrgConsoleHTTPRoute(ctx, tgt.dyn, names, rec); err != nil {
+			h.log.Error("org-console-tls: HTTPRoute apply failed — reconcile will retry",
+				"region", tgt.region, "route", names.RouteName, "host", names.ConsoleHost, "err", err)
+		}
 	}
-	if err := ensureOrgConsoleListener(ctx, deps.dyn, names, rec); err != nil {
-		h.log.Error("org-console-tls: Gateway listener apply failed — reconcile will retry",
-			"gateway", consoleGatewayName, "https_listener", names.HTTPSName, "err", err)
+
+	// #5511 defect B — read-back verification. An SSA apply that returned nil
+	// is NOT admission: cilium-operator can miss the append (observed live —
+	// generation=2 / observedGeneration=1 for 8h) and nothing above would
+	// notice. Poll each region's Gateway until BOTH per-Org listener names are
+	// PRESENT in status.listeners; one deadline bounds the whole pass.
+	admitDeadline := time.Now().Add(orgConsoleListenerAdmitBudget)
+	admitted := true
+	for _, tgt := range targets {
+		if err := waitOrgConsoleListenersAdmitted(ctx, tgt.dyn, names, admitDeadline); err != nil {
+			admitted = false
+			h.log.Error("org-console-tls: Gateway did NOT admit the per-Org listener pair — the per-Org console door is CLOSED in this region (#5511)",
+				"org_tenant_id", rec.OrganizationID,
+				"region", tgt.region,
+				"clusterID", tgt.clusterID,
+				"gateway", consoleGatewayNamespace+"/"+consoleGatewayName,
+				"https_listener", names.HTTPSName,
+				"http_listener", names.HTTPName,
+				"err", err,
+			)
+		}
 	}
-	if err := ensureOrgConsoleHTTPRoute(ctx, deps.dyn, names, rec); err != nil {
-		h.log.Error("org-console-tls: HTTPRoute apply failed — reconcile will retry",
-			"route", names.RouteName, "host", names.ConsoleHost, "err", err)
+	if !admitted {
+		// NOT ready — the loud per-region errors above are the durable
+		// evidence trail for the next env walk. Never emit the "ensured"
+		// line on an unadmitted surface.
+		h.log.Error("org-console-tls: per-Org console TLS surface applied but NOT admitted in every region — NOT ready (#5511)",
+			"org_tenant_id", rec.OrganizationID,
+			"console_host", names.ConsoleHost,
+			"regions", strings.Join(regions, ","),
+		)
+		return
 	}
-	h.log.Info("org-console-tls: ensured per-Org console TLS trio",
+	h.log.Info("org-console-tls: ensured per-Org console TLS trio — listener pair admitted in every region",
 		"org_tenant_id", rec.OrganizationID,
 		"console_host", names.ConsoleHost,
 		"cert", names.CertName,
 		"https_listener", names.HTTPSName,
 		"route", names.RouteName,
+		"regions", strings.Join(regions, ","),
 	)
+}
+
+// waitOrgConsoleListenersAdmitted polls the console Gateway on ONE region
+// cluster until BOTH per-Org listener names are PRESENT in status.listeners,
+// the shared deadline passes, or ctx is cancelled. The assertion is presence
+// (vacuity-proof — an empty or apex-only status keeps failing), never the
+// absence of an apply error. The timeout error names the gateway, both
+// listener names, the observed status.listeners set, and generation vs
+// observedGeneration so a "cilium-operator missed the append" wedge (#5511
+// defect A: gen=2/obsGen=1) is diagnosable straight from the log line.
+func waitOrgConsoleListenersAdmitted(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, deadline time.Time) error {
+	var (
+		lastNames []string
+		lastGen   = int64(-1)
+		lastObs   = int64(-1)
+		lastErr   error
+	)
+	for {
+		gw, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+			Get(ctx, consoleGatewayName, metav1.GetOptions{})
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = nil
+			lastGen = gw.GetGeneration()
+			lastObs = gatewayMaxObservedGeneration(gw)
+			lastNames = gatewayStatusListenerNames(gw)
+			if statusListenersContain(lastNames, names.HTTPSName) &&
+				statusListenersContain(lastNames, names.HTTPName) {
+				return nil
+			}
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for gateway %s/%s to admit listeners %s + %s: %w",
+				consoleGatewayNamespace, consoleGatewayName, names.HTTPSName, names.HTTPName, ctx.Err())
+		case <-time.After(orgConsoleListenerAdmitPollInterval):
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("gateway %s/%s unreadable while verifying admission of listeners %s + %s: %w",
+			consoleGatewayNamespace, consoleGatewayName, names.HTTPSName, names.HTTPName, lastErr)
+	}
+	return fmt.Errorf("gateway %s/%s did not admit listeners %s + %s within %s: status.listeners=%v generation=%d observedGeneration=%d",
+		consoleGatewayNamespace, consoleGatewayName, names.HTTPSName, names.HTTPName,
+		orgConsoleListenerAdmitBudget, lastNames, lastGen, lastObs)
+}
+
+// gatewayStatusListenerNames extracts the listener NAMES present in the
+// Gateway's status.listeners — the admission ground truth (#5511): a listener
+// accepted into spec but absent here is a closed door with no condition.
+func gatewayStatusListenerNames(gw *unstructured.Unstructured) []string {
+	out := []string{}
+	listeners, found, err := unstructured.NestedSlice(gw.Object, "status", "listeners")
+	if err != nil || !found {
+		return out
+	}
+	for _, l := range listeners {
+		lm, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _, _ := unstructured.NestedString(lm, "name"); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// gatewayMaxObservedGeneration returns the highest observedGeneration across
+// the Gateway's top-level status.conditions, or -1 when unreadable. Gateway
+// has no single status.observedGeneration field; the per-condition value is
+// what exposed the hw291 wedge (generation=2, every condition's
+// observedGeneration=1).
+func gatewayMaxObservedGeneration(gw *unstructured.Unstructured) int64 {
+	maxObs := int64(-1)
+	conds, found, err := unstructured.NestedSlice(gw.Object, "status", "conditions")
+	if err != nil || !found {
+		return maxObs
+	}
+	for _, c := range conds {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if og, okOG, _ := unstructured.NestedInt64(cm, "observedGeneration"); okOG && og > maxObs {
+			maxObs = og
+		}
+	}
+	return maxObs
+}
+
+func statusListenersContain(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// mirrorOrgConsoleCertSecret copies the HOST region's issued per-Org wildcard
+// cert secret (kube-system/<CertName>, written by cert-manager for the
+// Certificate ensureOrgConsoleCertificate creates) onto a SECONDARY region's
+// kube-system, where the mirrored listener pair references it by the same
+// name (#5511 defect B live heal, codified). The secret is MIRRORED rather
+// than re-issued: a second Certificate CR per region would double the
+// Let's Encrypt duplicate-certificate burn for identical SANs on every Org.
+// Create-or-update: a later pass (Org reconcile) refreshes a drifted copy, so
+// a host-side renewal propagates on the next reconcile.
+func mirrorOrgConsoleCertSecret(ctx context.Context, hostCore, regionCore kubernetes.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
+	if hostCore == nil || regionCore == nil {
+		return fmt.Errorf("core client unavailable (host=%t region=%t)", hostCore != nil, regionCore != nil)
+	}
+	src, err := hostCore.CoreV1().Secrets(consoleCertNamespace).Get(ctx, names.CertName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("host-region cert secret %s/%s not issued yet — the next reconcile pass mirrors it", consoleCertNamespace, names.CertName)
+		}
+		return fmt.Errorf("read host-region cert secret %s/%s: %w", consoleCertNamespace, names.CertName, err)
+	}
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.CertName,
+			Namespace: consoleCertNamespace,
+			Labels:    orgConsoleTLSStringLabels(names, rec, consoleGatewayName),
+		},
+		Type: src.Type,
+		Data: src.Data,
+	}
+	if _, err := regionCore.CoreV1().Secrets(consoleCertNamespace).Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create mirrored cert secret %s/%s: %w", consoleCertNamespace, names.CertName, err)
+		}
+		existing, gerr := regionCore.CoreV1().Secrets(consoleCertNamespace).Get(ctx, names.CertName, metav1.GetOptions{})
+		if gerr != nil {
+			return fmt.Errorf("read existing mirrored cert secret %s/%s: %w", consoleCertNamespace, names.CertName, gerr)
+		}
+		if reflect.DeepEqual(existing.Data, src.Data) {
+			return nil // converged — renewal-drift check is a true no-op
+		}
+		existing.Data = src.Data
+		if _, uerr := regionCore.CoreV1().Secrets(consoleCertNamespace).Update(ctx, existing, metav1.UpdateOptions{}); uerr != nil {
+			return fmt.Errorf("update drifted mirrored cert secret %s/%s: %w", consoleCertNamespace, names.CertName, uerr)
+		}
+	}
+	return nil
+}
+
+// orgConsoleTLSStringLabels — orgConsoleTLSLabels as map[string]string for
+// typed objects (the mirrored Secret).
+func orgConsoleTLSStringLabels(names orgConsoleTLSNames, rec store.OrganizationProvisionRecord, component string) map[string]string {
+	src := orgConsoleTLSLabels(names, rec, component)
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
 }
 
 // orgConsoleTLSLabels is the common label set stamped on all three resources

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_test.go
@@ -11,15 +11,31 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
+
+// shrinkAdmitBudget shrinks the #5511 read-back poll budget/interval so unit
+// tests never sit in the production 60s wait; restored on cleanup.
+func shrinkAdmitBudget(t *testing.T) {
+	t.Helper()
+	prevBudget, prevInterval := orgConsoleListenerAdmitBudget, orgConsoleListenerAdmitPollInterval
+	orgConsoleListenerAdmitBudget = 50 * time.Millisecond
+	orgConsoleListenerAdmitPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		orgConsoleListenerAdmitBudget, orgConsoleListenerAdmitPollInterval = prevBudget, prevInterval
+	})
+}
 
 // TestResolveOrgConsoleTLSNames_AllPoolParents proves the naming/host
 // derivation is generic across every role=org-pool parent (omani.homes/rest/
@@ -107,12 +123,22 @@ func TestResolveOrgConsoleTLSNames_SkipCases(t *testing.T) {
 // an existing object, mirroring the live Sovereign).
 func fakeDynForConsoleTLS(t *testing.T) *dynamicfake.FakeDynamicClient {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	gvrToList := map[schema.GroupVersionResource]string{
-		certificateGVR:    "CertificateList",
-		consoleGatewayGVR: "GatewayList",
-		httpRouteGVR:      "HTTPRouteList",
-	}
+	return fakeDynForConsoleTLSWithApexPorts(t, 8443, 8080)
+}
+
+// fakeDynForConsoleTLSWithApexPorts is fakeDynForConsoleTLS with the apex
+// listener pair on caller-chosen ports, so consoleApexListenerPorts tests can
+// use NON-fallback ports (a fallback-equal seed cannot distinguish "derived
+// from the apex" from "gateway unreadable, fell back" — vacuity).
+//
+// The Gateway is seeded via an explicit-GVR Create, NOT via the constructor's
+// object list: the fake's constructor maps an unstructured seed to a resource
+// by GUESSING the plural from the Kind ("Gateway" → "gatewaies" per the
+// y→ies pluralizer), so a constructor-seeded Gateway is invisible under the
+// real "gateways" resource and every GET on it 404s (#5511 — this masked the
+// read-back tests until caught).
+func fakeDynForConsoleTLSWithApexPorts(t *testing.T, httpsPort, httpPort int64) *dynamicfake.FakeDynamicClient {
+	t.Helper()
 	gw := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "gateway.networking.k8s.io/v1",
 		"kind":       "Gateway",
@@ -123,19 +149,48 @@ func fakeDynForConsoleTLS(t *testing.T) *dynamicfake.FakeDynamicClient {
 		"spec": map[string]any{
 			"gatewayClassName": "cilium",
 			"listeners": []any{
-				map[string]any{"name": "console-https", "port": int64(8443), "protocol": "HTTPS", "hostname": "*.omantel.biz"},
-				map[string]any{"name": "console-http", "port": int64(8080), "protocol": "HTTP", "hostname": "*.omantel.biz"},
+				map[string]any{"name": "console-https", "port": httpsPort, "protocol": "HTTPS", "hostname": "*.omantel.biz"},
+				map[string]any{"name": "console-http", "port": httpPort, "protocol": "HTTP", "hostname": "*.omantel.biz"},
 			},
 		},
 	}}
-	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, gw)
+	return fakeDynSeededWithGateway(t, gw)
+}
+
+// fakeDynSeededWithGateway registers the console-TLS GVR set on an EMPTY fake
+// and then Creates the given Gateway under the explicit consoleGatewayGVR, so
+// subsequent GETs on the real "gateways" resource find it (see the pluralizer
+// trap documented on fakeDynForConsoleTLSWithApexPorts).
+func fakeDynSeededWithGateway(t *testing.T, gw *unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		certificateGVR:    "CertificateList",
+		consoleGatewayGVR: "GatewayList",
+		httpRouteGVR:      "HTTPRouteList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Create(context.Background(), gw, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed console gateway: %v", err)
+	}
+	return dyn
 }
 
 func newConsoleTLSHandler(t *testing.T, dyn *dynamicfake.FakeDynamicClient) *Handler {
 	t.Helper()
+	return newConsoleTLSHandlerWithCore(t, dyn, nil)
+}
+
+func newConsoleTLSHandlerWithCore(t *testing.T, dyn *dynamicfake.FakeDynamicClient, core *k8sfake.Clientset) *Handler {
+	t.Helper()
+	shrinkAdmitBudget(t)
 	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
-		return &sovereignDeps{core: nil, dyn: dyn}, nil
+		if core == nil {
+			return &sovereignDeps{core: nil, dyn: dyn}, nil
+		}
+		return &sovereignDeps{core: core, dyn: dyn}, nil
 	})
 	return h
 }
@@ -274,12 +329,17 @@ func sliceContains(ss []string, want string) bool {
 // per-Org listener pair must ride the SAME ports as the live apex
 // console-https/console-http listeners (the only ports the console ELB
 // forwards to), never a hardcoded pair from an older port scheme.
+//
+// The seeded apex ports are deliberately NON-fallback (9443/9090): a
+// fallback-equal seed cannot distinguish "derived from the apex gateway" from
+// "gateway unreadable, silently fell back" — which is exactly how this test
+// stayed green while the constructor-seeded Gateway was invisible to GETs
+// (the gatewaies pluralizer trap, see fakeDynForConsoleTLSWithApexPorts).
 func TestConsoleApexListenerPorts_DerivesFromApex(t *testing.T) {
-	dyn := fakeDynForConsoleTLS(t)
+	dyn := fakeDynForConsoleTLSWithApexPorts(t, 9443, 9090)
 	httpsPort, httpPort := consoleApexListenerPorts(context.Background(), dyn)
-	// fakeDynForConsoleTLS seeds the apex pair on 8443/8080 (#4718 scheme).
-	if httpsPort != 8443 || httpPort != 8080 {
-		t.Errorf("apex-derived ports = %d/%d, want 8443/8080 from the seeded apex", httpsPort, httpPort)
+	if httpsPort != 9443 || httpPort != 9090 {
+		t.Errorf("apex-derived ports = %d/%d, want 9443/9090 from the seeded apex (fallback leak?)", httpsPort, httpPort)
 	}
 }
 
@@ -297,6 +357,272 @@ func TestConsoleApexListenerPorts_FallbackWhenGatewayMissing(t *testing.T) {
 	if httpsPort != consoleListenerHTTPSPortFallback || httpPort != consoleListenerHTTPPortFallback {
 		t.Errorf("fallback ports = %d/%d, want %d/%d", httpsPort, httpPort,
 			consoleListenerHTTPSPortFallback, consoleListenerHTTPPortFallback)
+	}
+}
+
+// ── #5511 — multi-region fan-out + listener admission read-back ────────────
+
+// TestOrgConsoleTLSSecondaryRegions locks the pure cluster-id → region
+// derivation: secondaries split on the deployment boundary (longest
+// candidate-primary prefix, so hyphenated region keys survive), and any set
+// with no prefix relations yields the safe empty map (host-only behaviour).
+func TestOrgConsoleTLSSecondaryRegions(t *testing.T) {
+	cases := []struct {
+		name string
+		ids  []string
+		want map[string]string
+	}{
+		{"two-secondaries", []string{"dep291", "dep291-hel1-1", "dep291-nbg1-2"},
+			map[string]string{"dep291-hel1-1": "hel1-1", "dep291-nbg1-2": "nbg1-2"}},
+		{"hyphenated-region-keys", []string{"dep", "dep-ap-southeast-3", "dep-ap-southeast-3-1"},
+			map[string]string{"dep-ap-southeast-3": "ap-southeast-3", "dep-ap-southeast-3-1": "ap-southeast-3-1"}},
+		{"fqdn-alias-primary", []string{"sovereign-hw291.omantel.biz", "sovereign-hw291.omantel.biz-hel1-1"},
+			map[string]string{"sovereign-hw291.omantel.biz-hel1-1": "hel1-1"}},
+		{"no-prefix-relation-safe-noop", []string{"sovereign-x.y", "dep123-r1"}, map[string]string{}},
+		{"single-cluster", []string{"dep291"}, map[string]string{}},
+		{"empty", nil, map[string]string{}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := orgConsoleTLSSecondaryRegions(tc.ids)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for cid, region := range tc.want {
+				if got[cid] != region {
+					t.Errorf("region for %q = %q, want %q (full: %v)", cid, got[cid], region, got)
+				}
+			}
+		})
+	}
+}
+
+// fakeDynWithGatewayStatus builds a fake dynamic client whose console gateway
+// carries an explicit metadata.generation, a status condition with
+// observedGeneration, and the given status.listeners names — the read-back
+// verification's ground truth surface.
+func fakeDynWithGatewayStatus(t *testing.T, generation, observedGeneration int64, statusListenerNames ...string) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	statusListeners := make([]any, 0, len(statusListenerNames))
+	for _, n := range statusListenerNames {
+		statusListeners = append(statusListeners, map[string]any{"name": n, "attachedRoutes": int64(1)})
+	}
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name":       consoleGatewayName,
+			"namespace":  consoleGatewayNamespace,
+			"generation": generation,
+		},
+		"spec": map[string]any{
+			"gatewayClassName": "cilium",
+			"listeners": []any{
+				map[string]any{"name": "console-https", "port": int64(8443), "protocol": "HTTPS", "hostname": "*.omantel.biz"},
+				map[string]any{"name": "console-http", "port": int64(8080), "protocol": "HTTP", "hostname": "*.omantel.biz"},
+			},
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Accepted", "status": "True", "observedGeneration": observedGeneration},
+			},
+			"listeners": statusListeners,
+		},
+	}}
+	return fakeDynSeededWithGateway(t, gw)
+}
+
+// TestWaitOrgConsoleListenersAdmitted_Success — read-back success path: both
+// per-Org listener names PRESENT in status.listeners (among the apex pair)
+// returns nil. The trailing vacuity guard proves the same checker FAILS when
+// the names are absent — the presence assertion cannot pass on nothing.
+func TestWaitOrgConsoleListenersAdmitted_Success(t *testing.T) {
+	shrinkAdmitBudget(t)
+	names, ok := resolveOrgConsoleTLSNames(store.OrganizationProvisionRecord{
+		Subdomain:    "acme",
+		DomainMode:   store.OrganizationDomainFreeSubdomain,
+		ParentDomain: "omani.homes",
+	})
+	if !ok {
+		t.Fatal("resolveOrgConsoleTLSNames returned !ok")
+	}
+	admitted := fakeDynWithGatewayStatus(t, 2, 2,
+		"console-https", "console-http", names.HTTPSName, names.HTTPName)
+	if err := waitOrgConsoleListenersAdmitted(context.Background(), admitted, names,
+		time.Now().Add(orgConsoleListenerAdmitBudget)); err != nil {
+		t.Fatalf("expected admission success, got: %v", err)
+	}
+	// Vacuity guard: apex-only status MUST fail the same check.
+	apexOnly := fakeDynWithGatewayStatus(t, 2, 1, "console-https", "console-http")
+	if err := waitOrgConsoleListenersAdmitted(context.Background(), apexOnly, names,
+		time.Now().Add(orgConsoleListenerAdmitBudget)); err == nil {
+		t.Fatal("vacuity: checker returned nil on a status WITHOUT the per-Org listeners")
+	}
+}
+
+// TestWaitOrgConsoleListenersAdmitted_Timeout — read-back timeout path: a
+// gateway that never admits the pair (the hw291 defect-A shape: generation=2,
+// observedGeneration=1, apex-only status) errors after the bounded budget and
+// the error names the gateway, BOTH listener names, and gen vs obsGen so the
+// next env walk can diagnose the wedge from the log line alone.
+func TestWaitOrgConsoleListenersAdmitted_Timeout(t *testing.T) {
+	shrinkAdmitBudget(t)
+	names, ok := resolveOrgConsoleTLSNames(store.OrganizationProvisionRecord{
+		Subdomain:    "acme",
+		DomainMode:   store.OrganizationDomainFreeSubdomain,
+		ParentDomain: "omani.homes",
+	})
+	if !ok {
+		t.Fatal("resolveOrgConsoleTLSNames returned !ok")
+	}
+	wedged := fakeDynWithGatewayStatus(t, 2, 1, "console-https", "console-http")
+	err := waitOrgConsoleListenersAdmitted(context.Background(), wedged, names,
+		time.Now().Add(orgConsoleListenerAdmitBudget))
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		consoleGatewayName,
+		names.HTTPSName,
+		names.HTTPName,
+		"generation=2",
+		"observedGeneration=1",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("timeout error missing %q\nerror: %s", want, msg)
+		}
+	}
+}
+
+// TestProvisionOrgConsoleTLS_MultiRegionFanOut is the #5511 defect-A lock: on
+// a chroot with secondary regions registered in k8sCache, the listener pair +
+// console HTTPRoute are applied to EVERY region cluster, the issued cert
+// secret is MIRRORED from the host region to each secondary, and the
+// cert-manager Certificate CR stays host-only (no duplicate LE issuance).
+func TestProvisionOrgConsoleTLS_MultiRegionFanOut(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw291.omantel.biz") // chroot gate for the fan-out
+
+	hostDyn := fakeDynForConsoleTLS(t)
+	secDynB := fakeDynForConsoleTLS(t)
+	secDynC := fakeDynForConsoleTLS(t)
+
+	issued := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-wildcard-tls-acme-omani-homes", Namespace: consoleCertNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": []byte("host-issued-cert"),
+			"tls.key": []byte("host-issued-key"),
+		},
+	}
+	hostCore := k8sfake.NewSimpleClientset(issued)
+	secCoreB := k8sfake.NewSimpleClientset()
+	secCoreC := k8sfake.NewSimpleClientset()
+
+	h := newConsoleTLSHandlerWithCore(t, hostDyn, hostCore)
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clusters: []k8scache.ClusterRef{
+			{ID: "dep291", DynamicClient: hostDyn, CoreClient: hostCore},
+			{ID: "dep291-hel1-1", DynamicClient: secDynB, CoreClient: secCoreB},
+			{ID: "dep291-nbg1-2", DynamicClient: secDynC, CoreClient: secCoreC},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		OTECHFQDN:      "hw291.omantel.biz",
+	}
+	ctx := context.Background()
+	h.provisionOrgConsoleTLS(ctx, rec)
+
+	for name, sec := range map[string]*dynamicfake.FakeDynamicClient{"hel1-1": secDynB, "nbg1-2": secDynC} {
+		// (a) listener SSA patch reached the secondary's console gateway.
+		sawGatewayApply := false
+		for _, a := range sec.Actions() {
+			if a.GetResource() == consoleGatewayGVR && a.GetVerb() == "patch" {
+				if pa, ok := a.(interface{ GetName() string }); ok && pa.GetName() == consoleGatewayName {
+					sawGatewayApply = true
+				}
+			}
+		}
+		if !sawGatewayApply {
+			t.Errorf("[%s] no Gateway listener SSA patch on the secondary region", name)
+		}
+		// (b) console HTTPRoute created on the secondary region.
+		if _, err := sec.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+			Get(ctx, "catalyst-ui-acme-omani-homes", metav1.GetOptions{}); err != nil {
+			t.Errorf("[%s] console HTTPRoute not created on the secondary region: %v", name, err)
+		}
+		// (c) Certificate CR must stay HOST-only — no duplicate LE issuance.
+		if _, err := sec.Resource(certificateGVR).Namespace(consoleCertNamespace).
+			Get(ctx, "org-wildcard-tls-acme-omani-homes", metav1.GetOptions{}); err == nil {
+			t.Errorf("[%s] Certificate CR must NOT be created on a secondary region", name)
+		}
+	}
+	// (d) issued cert secret mirrored into each secondary's kube-system.
+	for name, core := range map[string]*k8sfake.Clientset{"hel1-1": secCoreB, "nbg1-2": secCoreC} {
+		got, err := core.CoreV1().Secrets(consoleCertNamespace).
+			Get(ctx, "org-wildcard-tls-acme-omani-homes", metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("[%s] cert secret not mirrored to the secondary region: %v", name, err)
+			continue
+		}
+		if string(got.Data["tls.crt"]) != "host-issued-cert" || got.Type != corev1.SecretTypeTLS {
+			t.Errorf("[%s] mirrored secret drifted: type=%s data=%v", name, got.Type, got.Data)
+		}
+	}
+	// (e) host region unchanged by the fan-out — trio still applied there.
+	if _, err := hostDyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		Get(ctx, "org-wildcard-tls-acme-omani-homes", metav1.GetOptions{}); err != nil {
+		t.Errorf("host Certificate CR missing: %v", err)
+	}
+	if _, err := hostDyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Get(ctx, "catalyst-ui-acme-omani-homes", metav1.GetOptions{}); err != nil {
+		t.Errorf("host console HTTPRoute missing: %v", err)
+	}
+}
+
+// TestProvisionOrgConsoleTLS_FanOutSkippedOffChroot locks the mothership
+// guard: without SOVEREIGN_FQDN the k8sCache fan-out must NOT run (the
+// mothership cache holds ALIEN deployments' clusters — #3987), so a
+// registered non-chroot cluster receives nothing.
+func TestProvisionOrgConsoleTLS_FanOutSkippedOffChroot(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "") // mothership: not a chroot
+	hostDyn := fakeDynForConsoleTLS(t)
+	alienDyn := fakeDynForConsoleTLS(t)
+	h := newConsoleTLSHandler(t, hostDyn)
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clusters: []k8scache.ClusterRef{
+			{ID: "dep291", DynamicClient: hostDyn, CoreClient: k8sfake.NewSimpleClientset()},
+			{ID: "dep291-hel1-1", DynamicClient: alienDyn, CoreClient: k8sfake.NewSimpleClientset()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+	alienDyn.ClearActions() // drop the builder's own gateway-seed Create
+
+	h.provisionOrgConsoleTLS(context.Background(), store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+	})
+	for _, a := range alienDyn.Actions() {
+		if a.GetVerb() == "patch" || a.GetVerb() == "create" {
+			t.Fatalf("mothership fan-out guard breached: %s on %v", a.GetVerb(), a.GetResource())
+		}
 	}
 }
 


### PR DESCRIPTION
## 🛑 MERGE HOLD: cutover in flight on hw291 — do not merge until cutoverComplete (RT-11)

Refs #5511 (durable half of the live-healed P1; live forensics + heal record are in the issue comment). Refs #5394 #5406 #5414 #5416 #5318.

## Problem — two defects, proven live on hw291

**A — per-region split-write.** `provisionOrgConsoleTLS` wrote the per-Org gateway surface (listener pair `console-https-<slug>`/`console-http-<slug>`, cert secret, console HTTPRoute) to the HOST region cluster only. One shared EIP round-robins every region's cilium-envoy, so a region that never received the surface TLS-resets ~1/N of all connections to every per-Org console (`agenity.uatcorp.omani.homes` = 000 x6/6 while the workload was Ready 1/1). Same class as the per-region secret splits #5394/#5406/#5414/#5416, now for the whole per-Org gateway surface.

**B — apply without read-back.** A successful SSA apply was never verified against `Gateway.status.listeners`. cilium-operator missed the append live (generation=2, observedGeneration=1 for 8h) and the code only logged apply FAILURES — success-without-admission was invisible, the "reports rather than does" family (#5477/#5489/#5496/#5501/#5508).

## Fix — rides the existing per-region client seam, no new plumbing

The multi-region client seam turned out to already exist: `h.k8sCache` (`k8scache.Factory`) holds one registered cluster per region on a chroot — the in-cluster primary (self-registered by `FactoryFromEnv`) plus every secondary posted at handover via `POST /api/v1/sovereign/secondary-kubeconfig` — with `Clusters()` / `DynamicClientFor(cid)` / `CoreClient(cid)` accessors. It is the same seam the D20 jobs fan-out (`chrootSeedSecondaryRegions`, jobs.go) and the `/cloud` page fan-out (sovereign.go) already use.

`products/catalyst/bootstrap/api/internal/handler/org_console_tls.go`:

- `orgConsoleTLSTargets` — host region (via `sovereignDepsFor`, unchanged) + every secondary region registered in k8sCache. Chroot-gated (`SOVEREIGN_FQDN`): on the mothership the cache holds ALIEN deployments' clusters (#3987) and a blind fan-out would write per-Org listeners onto sibling Sovereigns.
- `orgConsoleTLSSecondaryRegions` — pure cluster-id → region derivation (longest candidate-primary prefix, so hyphenated region keys like `nbg1-1` split on the deployment boundary; a set with no prefix relations degrades to the safe host-only no-op).
- Listener pair + console HTTPRoute now applied to EVERY region (each region's apply reads its OWN apex listener ports, #4732 semantics preserved).
- Cert: the cert-manager `Certificate` stays HOST-only; its ISSUED secret is MIRRORED to each secondary's kube-system (create-or-update, so a host-side renewal propagates on a later reconcile). A per-region `Certificate` would double the Let's Encrypt duplicate-certificate burn per Org; the mirror codifies the proven live heal.
- `waitOrgConsoleListenersAdmitted` — read-back verification: bounded poll (60s budget shared across regions, package vars for tests) of `Gateway.status.listeners` asserting PRESENCE of BOTH per-Org listener names (vacuity-proof — an empty or apex-only status keeps failing; the checker is proven to fail in that direction by test). On timeout the error names the gateway, both listener names, the observed `status.listeners` set, and generation vs observedGeneration — the exact hw291 wedge signature — and the "ensured" info line only fires when every region admitted; otherwise loud per-region errors + a NOT-ready summary error.
- The keycloak / oidc-gate per-app HTTPRoutes are deliberately NOT fanned out — their backends are region-local singletons; mirroring them trades the TLS reset for a 503. That routing decision belongs to the placement model (as recorded on the issue).

No NodePort anywhere. No live-cluster interaction — code + tests only.

## Tests

`org_console_tls_test.go` (extends the existing fake-client patterns):

- `TestProvisionOrgConsoleTLS_MultiRegionFanOut` — real `k8scache.NewFactory` with injected fake dynamic/typed clients per region (the established livedata-test pattern): listener SSA + HTTPRoute land on BOTH secondaries, issued cert secret mirrored to both, `Certificate` CR stays host-only, host trio unchanged.
- `TestProvisionOrgConsoleTLS_FanOutSkippedOffChroot` — mothership guard: no writes to a registered non-chroot cluster.
- `TestWaitOrgConsoleListenersAdmitted_Success` — admission presence path + vacuity guard (same checker fails on an apex-only status).
- `TestWaitOrgConsoleListenersAdmitted_Timeout` — bounded failure path; error carries both listener names + `generation=2` vs `observedGeneration=1`.
- `TestOrgConsoleTLSSecondaryRegions` — pure derivation incl. hyphenated region keys, fqdn-alias primary, safe no-op shapes.

Also fixed a latent test vacuity found en route: client-go's fake constructor pluralizes Kind `Gateway` to resource `gatewaies`, so the constructor-seeded gateway was invisible to every GET on `gateways` — `TestConsoleApexListenerPorts_DerivesFromApex` was passing on the FALLBACK ports, not the apex-derived ones. Gateways are now seeded via explicit-GVR Create and that test uses non-fallback ports (9443/9090) so a fallback leak fails it.

## Verification

- `go build ./...` — clean.
- `go test ./internal/handler/ -run OrgConsole -count=1` — ok.
- Full module `go test ./... -count=1` — ALL packages ok (handler 230s, k8scache 26s, helmwatch 20s; zero failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
