### PR TITLE
fix(org): stop fabricating a vCluster on the three remaining #5489 seams (controller status stamp, vcluster_name, provision timeline)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -893,11 +893,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		readyCond.Message = vcMsg
 	}
 	desired := orgapi.OrganizationStatus{
-		VCluster: orgapi.VClusterStatus{
-			Name:        org.Spec.Slug,
-			HostCluster: r.HostCluster,
-			Phase:       vcPhase,
-		},
+		VCluster: vclusterStatusFor(org.Spec.Slug, r.HostCluster, org.Spec.PlanSlug, vcPhase),
 		KeycloakGroup: orgapi.KeycloakGroupStatus{
 			ID:    kcID,
 			Path:  kcPath,
@@ -1087,6 +1083,39 @@ func pendingBoundaryReason(planSlug string) string {
 		return "VClusterProvisioning"
 	}
 	return "NamespaceProvisioning"
+}
+
+// vclusterStatusFor returns the status.vcluster block to stamp on the
+// Organization, keyed off the SAME #4292/#4339 tier gate
+// (gitops.BoundaryIsVcluster) that decides whether a vCluster is authored at
+// all (#5489):
+//
+//   - vcluster tier (m/l/xl/flexi): the controller authors a real vCluster
+//     HelmRelease, so the block carries name + hostCluster + the phase
+//     vclusterReadiness derived — exactly the pre-#5489 shape.
+//   - host tier (""/s/free): NO vCluster is ever authored. The old
+//     unconditional stamp wrote status.vcluster{name, hostCluster, phase:
+//     Ready} over that absence, and the CRD printer column
+//     (products/catalyst/chart/crds/organization.yaml, .status.vcluster.phase)
+//     surfaced it as `vCluster: Ready` on `kubectl get organizations -o wide`
+//     — a fabricated object beside an honest Ready message (#4813 fixed the
+//     message; the field kept lying). The zero value serializes as an
+//     empty/absent block, which the printer column renders as blank — the
+//     honest representation of "no vCluster exists for this Org".
+//
+// The console directory is unaffected: orgStateFromCR (bootstrap api,
+// org_list_from_cr.go) reads phase first and falls through to the Ready
+// condition, which this controller still stamps tier-honestly via
+// readyOrgMessage.
+func vclusterStatusFor(slug, hostCluster, planSlug, vcPhase string) orgapi.VClusterStatus {
+	if !gitops.BoundaryIsVcluster(planSlug) {
+		return orgapi.VClusterStatus{}
+	}
+	return orgapi.VClusterStatus{
+		Name:        slug,
+		HostCluster: hostCluster,
+		Phase:       vcPhase,
+	}
 }
 
 // vclusterReadiness reads back the vCluster HelmRelease the controller

--- a/core/controllers/organization/internal/controller/vcluster_status_stamp_5489_test.go
+++ b/core/controllers/organization/internal/controller/vcluster_status_stamp_5489_test.go
@@ -1,0 +1,130 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+)
+
+// Tests for #5489 — `kubectl get organizations -o wide` printed
+// `vCluster: Ready` for host-tier Orgs. The controller stamped
+// status.vcluster{name, hostCluster, phase} UNCONDITIONALLY, so a
+// namespace-isolated Org (which authors NO vCluster — the host `<slug>`
+// namespace is the boundary) carried a green phase over an unauthored
+// object, and the CRD printer column (products/catalyst/chart/crds/
+// organization.yaml, .status.vcluster.phase) surfaced it to the operator.
+// The Ready condition MESSAGE was already honest (#4813) while the field
+// beside it was not; predecessor #3669.
+//
+// Anti-theater: the host-tier assertions fail against the pre-fix code, and
+// the vcluster-tier rows are the control — a fix that blanked the block for
+// every tier would satisfy "no fake Ready" while erasing the real status of
+// Orgs that DO have a vCluster.
+
+func TestVClusterStatusFor_TierMatrix(t *testing.T) {
+	t.Parallel()
+
+	// Host tiers (""/s/free — gitops.BoundaryIsVcluster == false): the block
+	// stays zero, so the printer column renders blank instead of a
+	// fabricated phase.
+	for _, plan := range []string{"", "s", "free"} {
+		got := vclusterStatusFor("acme", "ct-eu-mgt-prod", plan, "Ready")
+		if got != (orgapi.VClusterStatus{}) {
+			t.Errorf("plan=%q: host tier must stamp an empty vcluster block, got %+v", plan, got)
+		}
+	}
+
+	// vcluster tiers (m/l/xl/flexi): the exact pre-#5489 stamp survives —
+	// name + hostCluster + whatever phase vclusterReadiness derived.
+	for _, plan := range []string{"m", "l", "xl", "flexi"} {
+		got := vclusterStatusFor("acme", "ct-eu-mgt-prod", plan, "Provisioning")
+		want := orgapi.VClusterStatus{Name: "acme", HostCluster: "ct-eu-mgt-prod", Phase: "Provisioning"}
+		if got != want {
+			t.Errorf("plan=%q: got %+v want %+v", plan, got, want)
+		}
+	}
+}
+
+// TestVClusterStatusFor_SerializedAbsence proves the honest wire shape, in
+// both directions: the host-tier status JSON carries no phase (the printer
+// column's jsonPath resolves to nothing → blank cell), while the
+// vcluster-tier control DOES carry it. The control is what makes the
+// negative assertion non-vacuous — a marshalling change that dropped the
+// field everywhere would trip it.
+func TestVClusterStatusFor_SerializedAbsence(t *testing.T) {
+	t.Parallel()
+
+	host, err := json.Marshal(orgapi.OrganizationStatus{
+		VCluster: vclusterStatusFor("acme", "hc", "s", "Ready"),
+	})
+	if err != nil {
+		t.Fatalf("marshal host-tier: %v", err)
+	}
+	if strings.Contains(string(host), `"phase"`) {
+		t.Errorf("host-tier status must serialize with no vcluster phase, got %s", host)
+	}
+
+	vc, err := json.Marshal(orgapi.OrganizationStatus{
+		VCluster: vclusterStatusFor("acme", "hc", "m", "Ready"),
+	})
+	if err != nil {
+		t.Fatalf("marshal vcluster-tier: %v", err)
+	}
+	if !strings.Contains(string(vc), `"phase":"Ready"`) {
+		t.Errorf("vcluster-tier control must keep phase Ready, got %s", vc)
+	}
+}
+
+// TestReconcile_HostTier_NoVClusterStatusStamp is the end-to-end proof at
+// the Reconcile seam: a fully-provisioned host-tier Org (plan s — namespace
+// Active + boundary quota/limits seeded, no HR because none is ever
+// authored) goes Ready=True with the honest namespace-boundary message, and
+// its status.vcluster block stays EMPTY — where the pre-fix controller
+// stamped {name: acme, hostCluster: …, phase: Ready} over nothing.
+func TestReconcile_HostTier_NoVClusterStatusStamp(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	org.Spec.PlanSlug = "s"
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}}
+	r, _, _ := makeReconciler(t, org, ns,
+		boundaryLimitRange("acme"), boundaryResourceQuota("acme"))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a fully-provisioned host-tier Org must stop the requeue, got %v", res)
+	}
+
+	var got orgapi.Organization
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, &got); err != nil {
+		t.Fatalf("get post-reconcile: %v", err)
+	}
+	if got.Status.VCluster != (orgapi.VClusterStatus{}) {
+		t.Errorf("host-tier Org must not stamp status.vcluster (no vCluster is authored), got %+v",
+			got.Status.VCluster)
+	}
+	if got.Status.Conditions[0].Type != "Ready" || got.Status.Conditions[0].Status != "True" {
+		t.Errorf("host-tier Org must still go Ready=True off the namespace boundary, got %+v",
+			got.Status.Conditions[0])
+	}
+	// The message keeps naming the REAL boundary — that honesty (#4813) is
+	// what the empty vcluster block now matches instead of contradicting.
+	if !strings.Contains(got.Status.Conditions[0].Message, "no vCluster authored") {
+		t.Errorf("Ready message must name the namespace boundary, got %q",
+			got.Status.Conditions[0].Message)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-25T07:56:33.618Z",
+  "generatedAt": "2026-07-30T09:22:07.592Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.9",
+      "version": "0.5.21",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"
@@ -30,7 +30,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A"
               ],
@@ -228,6 +228,73 @@
         }
       },
       "hasUserUIEndpoint": true
+    },
+    {
+      "id": "bp-catalyst-edge-routes",
+      "slug": "catalyst-edge-routes",
+      "title": "Catalyst control-plane edge (region-b)",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "0.2.0",
+      "section": "pts-3-1-networking-and-service-mesh",
+      "depends": [
+        "bp-cilium",
+        "bp-gateway-api"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "producesInstances": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": 0,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "passive",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-catalyst-platform",
@@ -523,7 +590,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.3",
+      "version": "1.4.18",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
@@ -741,7 +808,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.12",
+      "version": "1.0.14",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-flux"
@@ -796,7 +863,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.7",
+      "version": "0.2.23",
       "section": "pts-9-disaster-recovery",
       "depends": [
         "bp-cnpg",
@@ -850,7 +917,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -904,7 +971,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.5",
+      "version": "1.1.7",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [],
       "shareable": false,
@@ -958,7 +1025,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.0",
+      "version": "1.3.4",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [
         "bp-crossplane"
@@ -1118,6 +1185,48 @@
       "hasUserUIEndpoint": false
     },
     {
+      "id": "bp-dragonfly",
+      "slug": "dragonfly",
+      "title": "Dragonfly",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "0.1.1",
+      "section": "pts-3-5-storage-and-data",
+      "depends": [
+        "bp-cilium"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "producesInstances": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      },
+      "hasUserUIEndpoint": false
+    },
+    {
       "id": "bp-external-dns",
       "slug": "external-dns",
       "title": "ExternalDNS",
@@ -1127,7 +1236,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
@@ -1238,7 +1347,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -1292,7 +1401,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -1524,7 +1633,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
@@ -1578,7 +1687,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.40",
+      "version": "1.2.48",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -1606,7 +1715,7 @@
               "rpoSeconds": 0
             },
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A",
                 "mgmt-B"
@@ -1621,7 +1730,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A"
               ],
@@ -1644,7 +1753,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.16",
+      "version": "1.0.18",
       "section": "pts-3-observability",
       "depends": [],
       "shareable": false,
@@ -1708,7 +1817,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.27",
+      "version": "0.2.31",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",
@@ -1778,7 +1887,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.36",
+      "version": "1.2.47",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cnpg",
@@ -1808,7 +1917,7 @@
               "rpoSeconds": 0
             },
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A",
                 "mgmt-B"
@@ -1823,7 +1932,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A"
               ],
@@ -1946,7 +2055,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.3",
+      "version": "1.0.9",
       "section": "pts-3-5-storage-and-data",
       "depends": [],
       "shareable": false,
@@ -2060,7 +2169,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.14",
+      "version": "0.1.16",
       "section": "pts-3-3-security-and-policy",
       "depends": [
         "bp-sealed-secrets"
@@ -2126,7 +2235,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.5.2",
+      "version": "1.5.7",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -2154,7 +2263,7 @@
               "rpoSeconds": 0
             },
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A",
                 "mgmt-B"
@@ -2169,7 +2278,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A"
               ],
@@ -2381,7 +2490,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.40",
+      "version": "1.0.49",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -2746,7 +2855,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "section": "pts-3-observability",
       "depends": [],
       "shareable": false,
@@ -2991,7 +3100,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.5",
+      "version": "1.0.9",
       "section": "pts-3-observability",
       "depends": [],
       "shareable": false,
@@ -3055,7 +3164,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.3.3",
+      "version": "1.3.5",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
@@ -3118,7 +3227,7 @@
       "category": "ai-safety",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "1.0.0",
       "section": "pts-4-7-ai-safety",
       "depends": [
@@ -3373,7 +3482,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.129",
+      "version": "1.4.145",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -3431,7 +3540,7 @@
           }
         }
       },
-      "hasUserUIEndpoint": false
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-oidc-gate",
@@ -3443,7 +3552,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.5",
+      "version": "0.1.8",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-cilium",
@@ -3511,7 +3620,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.51",
+      "version": "1.2.64",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
@@ -3537,7 +3646,7 @@
               "rpoSeconds": 30
             },
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A",
                 "mgmt-B"
@@ -3552,7 +3661,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "mgmt",
+              "tier": "",
               "clusters": [
                 "mgmt-A"
               ],
@@ -3575,7 +3684,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.6",
+      "version": "0.2.17",
       "section": "pts-4-7-agentic-workspace",
       "depends": [
         "bp-newapi",
@@ -3596,7 +3705,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A"
               ],
@@ -3681,19 +3790,13 @@
       "id": "bp-openova-mcp",
       "slug": "openova-mcp",
       "title": "OpenOva MCP",
-      "summary": "OpenOva MCP server — exposes the OpenOva surface (Applications, Environments, Organizations) as MCP tools for AI agents, RBAC-scoped per user so an agent can do exactly what that user can do in the console (thin facade over the live catalyst-api; #3988).",
+      "summary": "|",
       "icon": "openova-mcp.svg",
       "category": "ai-runtime",
       "tagline": null,
-      "tags": [
-        "mcp",
-        "agent",
-        "rbac",
-        "thin-facade",
-        "pillar-4"
-      ],
+      "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.2",
+      "version": "0.1.6",
       "section": "pts-4-7-agentic-workspace",
       "depends": [],
       "shareable": false,
@@ -3821,7 +3924,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "section": "pts-3-observability",
       "depends": [],
       "shareable": false,
@@ -3871,7 +3974,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "section": "pts-3-2-observability-and-tracing",
       "depends": [
         "bp-opentelemetry",
@@ -3924,7 +4027,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.0",
+      "version": "0.1.13",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-cilium"
@@ -3980,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.8",
+      "version": "0.2.14",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",
@@ -4057,7 +4160,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.17",
+      "version": "1.2.22",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [
         "bp-cert-manager"
@@ -4263,7 +4366,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -4362,7 +4465,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.3.10",
+      "version": "0.3.12",
       "section": "pts-4-sandbox",
       "depends": [
         "bp-rtz-vcluster",
@@ -4393,7 +4496,7 @@
               "rpoSeconds": 0
             },
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A",
                 "rtz-B"
@@ -4408,7 +4511,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A"
               ],
@@ -4481,7 +4584,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.3",
+      "version": "1.2.5",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cert-manager"
@@ -4537,11 +4640,12 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.87",
+      "version": "0.1.157",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",
-        "bp-harbor"
+        "bp-harbor",
+        "bp-dragonfly"
       ],
       "shareable": false,
       "contextSchema": null,
@@ -4584,8 +4688,58 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "producesInstances": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      },
+      "hasUserUIEndpoint": false
+    },
+    {
+      "id": "bp-sovereign-tls-vars",
+      "slug": "sovereign-tls-vars",
+      "title": "Sovereign TLS Vars",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "0.1.1",
+      "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
       "contextSchema": null,
@@ -4698,7 +4852,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.22",
+      "version": "0.2.26",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-keycloak",
@@ -4837,7 +4991,7 @@
               "rpoSeconds": 0
             },
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A",
                 "rtz-B"
@@ -4852,7 +5006,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A"
               ],
@@ -5080,7 +5234,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "section": "pts-3-observability",
       "depends": [],
       "shareable": false,
@@ -5211,7 +5365,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -5261,7 +5415,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-flux"
@@ -5443,7 +5597,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "section": "pts-3-observability",
       "depends": [],
       "shareable": false,
@@ -5563,7 +5717,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -5609,11 +5763,11 @@
       "title": "WordPress (per-Organization)",
       "summary": "|",
       "icon": "wordpress.svg",
-      "category": "tenant-app",
+      "category": "organization-app",
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.17",
+      "version": "0.4.22",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",
@@ -5645,7 +5799,7 @@
               "rpoSeconds": 0
             },
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A",
                 "rtz-B"
@@ -5660,7 +5814,7 @@
             "replication": null,
             "switchover": null,
             "placement": {
-              "tier": "rtz",
+              "tier": "",
               "clusters": [
                 "rtz-A"
               ],
@@ -5709,6 +5863,13 @@
       "label": "sealed-secrets",
       "file": "05-sealed-secrets.yaml",
       "order": 5
+    },
+    {
+      "id": "bp-dragonfly",
+      "slug": "dragonfly",
+      "label": "dragonfly",
+      "file": "06-bp-dragonfly.yaml",
+      "order": 6
     },
     {
       "id": "bp-nats-jetstream",

--- a/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
@@ -187,8 +187,14 @@ func orgCRToResponse(obj *unstructured.Unstructured, otechFQDN string) orgTenant
 		ParentDomain:    parentDomain,
 		AdminEmail:      adminEmail,
 		CompanyName:     displayName,
-		OTECHFQDN:       strings.TrimSpace(otechFQDN),
-		VClusterName:    "vc-" + slug,
+		OTECHFQDN: strings.TrimSpace(otechFQDN),
+		// #5489 — derived from the same isolation the row carries: only a
+		// vcluster-tier Org has a vCluster to name. The old unconditional
+		// `vc-<slug>` shipped `vcluster_name: "vc-…"` right next to
+		// `isolation: "namespace"` — latent (the UI declares the field at
+		// pages/org/org.api.ts and never consumes it), but it would assert
+		// an object that does not exist the moment anyone bound it.
+		VClusterName:    vclusterNameFor(isolation, slug),
 		TenantNamespace: slug,
 		Kind:            kind,
 		Tier:            tier,

--- a/products/catalyst/bootstrap/api/internal/handler/org_vcluster_fabrication_5489_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_vcluster_fabrication_5489_test.go
@@ -1,0 +1,175 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// Tests for #5489 — the bootstrap API synthesized a vCluster for
+// namespace-isolated Organizations on two seams:
+//
+//  1. `vcluster_name: "vc-<slug>"` was stamped unconditionally
+//     (org_list_from_cr.go + the create path), so the payload asserted a
+//     vCluster right next to `isolation: "namespace"`. Latent — the UI
+//     declares the field and never binds it — but a lie in the wire shape.
+//  2. `steps.vcluster: "done"` was emitted for every Org, so the
+//     post-create timeline painted a completed vCluster step for a tier
+//     that never provisions one (proven live on hw291, dep w/ zero
+//     vclusters.vcluster.com resources).
+//
+// Anti-theater: each case is proven in BOTH directions — the namespace-tier
+// assertions fail against the pre-fix code, and the vcluster-tier control
+// assertions pin that the honest value still renders for Orgs that DO have
+// a vCluster (a fix that blanked the field everywhere would satisfy the
+// first half while breaking the directory for real vcluster-tier Orgs).
+
+func TestVClusterNameFor(t *testing.T) {
+	t.Parallel()
+	if got := vclusterNameFor("vcluster", "acme"); got != "vc-acme" {
+		t.Errorf("vcluster tier: got %q want vc-acme", got)
+	}
+	if got := vclusterNameFor("namespace", "acme"); got != "" {
+		t.Errorf("namespace tier must not synthesize a vCluster name, got %q", got)
+	}
+	if got := vclusterNameFor("", "acme"); got != "" {
+		t.Errorf("unknown isolation must not synthesize a vCluster name, got %q", got)
+	}
+}
+
+// TestOrgResponseFromCR_NamespaceTier_NoVClusterFields — a namespace-tier CR
+// (customer + plan s, the same shape orgReadyCR mints and the same tier live
+// on hw291) must carry NO vcluster_name and NO steps.vcluster in the wire
+// payload. The raw JSON is asserted (not just the struct) because the step
+// omission rides the omitempty tag — a struct-only check could pass while
+// the key still shipped.
+func TestOrgResponseFromCR_NamespaceTier_NoVClusterFields(t *testing.T) {
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("omantel", "Omantel", "", "admin@omantel.biz", "Ready"),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil)
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var typed struct {
+		Items []orgTenantResponse `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &typed); err != nil {
+		t.Fatalf("decode typed: %v", err)
+	}
+	if len(typed.Items) != 1 {
+		t.Fatalf("items: want 1 got %d: %s", len(typed.Items), w.Body.String())
+	}
+	row := typed.Items[0]
+	if row.Isolation != "namespace" {
+		t.Fatalf("fixture must derive namespace isolation (customer + plan s), got %q", row.Isolation)
+	}
+	if row.VClusterName != "" {
+		t.Errorf("namespace-tier row must not name a vCluster, got vcluster_name=%q", row.VClusterName)
+	}
+	if row.Steps.VCluster != "" {
+		t.Errorf("namespace-tier row must not carry a vCluster step, got steps.vcluster=%q", row.Steps.VCluster)
+	}
+
+	// Raw-JSON check: the steps object must OMIT the key entirely, and the
+	// remaining timeline must still be present (vacuity control — an empty
+	// steps object would also pass the absence check while breaking the
+	// timeline).
+	var raw struct {
+		Items []map[string]json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	var steps map[string]string
+	if err := json.Unmarshal(raw.Items[0]["steps"], &steps); err != nil {
+		t.Fatalf("decode steps: %v", err)
+	}
+	if _, present := steps["vcluster"]; present {
+		t.Errorf("steps JSON must omit the vcluster key for a namespace-tier Org, got %v", steps)
+	}
+	if steps["bp_charts"] != "done" || steps["registry"] != "done" {
+		t.Errorf("the rest of the Ready timeline must survive the omission, got %v", steps)
+	}
+}
+
+// TestOrgResponseFromCR_VclusterTier_KeepsVClusterFields is the control
+// direction: a vcluster-tier CR (customer + plan m) keeps the exact pre-fix
+// shape — vc-<slug> name + a rendered vCluster step.
+func TestOrgResponseFromCR_VclusterTier_KeepsVClusterFields(t *testing.T) {
+	cr := orgReadyCR("acme", "ACME Corp", "", "ceo@acme.com", "Ready")
+	if err := unstructured.SetNestedField(cr.Object, "m", "spec", "planSlug"); err != nil {
+		t.Fatalf("set planSlug: %v", err)
+	}
+	h, _ := newOrgHandlerWithSeededCRs(t, cr)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil)
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var typed struct {
+		Items []orgTenantResponse `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &typed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(typed.Items) != 1 {
+		t.Fatalf("items: want 1 got %d", len(typed.Items))
+	}
+	row := typed.Items[0]
+	if row.Isolation != "vcluster" {
+		t.Fatalf("fixture must derive vcluster isolation (customer + plan m), got %q", row.Isolation)
+	}
+	if row.VClusterName != "vc-acme" {
+		t.Errorf("vcluster-tier row keeps its vCluster name, got %q want vc-acme", row.VClusterName)
+	}
+	if row.Steps.VCluster != "done" {
+		t.Errorf("vcluster-tier Ready row keeps steps.vcluster=done, got %q", row.Steps.VCluster)
+	}
+}
+
+// TestOrgTenantRecordToResponse_StepOmission_TierMatrix pins the store-record
+// mapper directly: explicit namespace blanks the step, explicit vcluster
+// keeps it, and a LEGACY record with empty isolation keeps the full timeline
+// (there is nothing to derive from — guessing either way would be the same
+// fabrication class this fix removes).
+func TestOrgTenantRecordToResponse_StepOmission_TierMatrix(t *testing.T) {
+	t.Parallel()
+	base := store.OrganizationProvisionRecord{
+		OrganizationID: "tid-x",
+		State:          store.STSDone,
+		Subdomain:      "x",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	ns := base
+	ns.Isolation = "namespace"
+	if got := orgTenantRecordToResponse(ns).Steps.VCluster; got != "" {
+		t.Errorf("isolation=namespace: steps.vcluster must be omitted, got %q", got)
+	}
+
+	vc := base
+	vc.Isolation = "vcluster"
+	if got := orgTenantRecordToResponse(vc).Steps.VCluster; got != "done" {
+		t.Errorf("isolation=vcluster: steps.vcluster must stay done, got %q", got)
+	}
+
+	legacy := base // Isolation == "" (pre-#3378 record)
+	if got := orgTenantRecordToResponse(legacy).Steps.VCluster; got != "done" {
+		t.Errorf("legacy record (no isolation): timeline must be unchanged, got %q", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -413,10 +413,32 @@ type orgTenantResponse struct {
 	UpdatedAt   time.Time      `json:"updated_at"`
 }
 
+// vclusterNameFor returns the synthesized `vc-<slug>` name for a
+// vcluster-tier Org and "" for anything else (#5489): only the vcluster
+// tier has a vCluster to name. The legacy unconditional `vc-<slug>` put a
+// `vcluster_name` in the payload right beside `isolation: "namespace"` —
+// latent (the UI declares the field and never binds it), but it would
+// assert an object that does not exist the moment anyone rendered it.
+// Since #4188 no overlay template consumes the value either, so an empty
+// name is inert on the provisioning pipeline.
+func vclusterNameFor(isolation, slug string) string {
+	if isolation == "vcluster" {
+		return "vc-" + slug
+	}
+	return ""
+}
+
 // orgTenantSteps surfaces the 7-state machine to the SPA so it can
 // render a progress timeline.
+//
+// #5489 — `vcluster` is omitempty: a namespace-isolated Org never
+// provisions a vCluster, so its timeline must not carry a `vcluster:
+// "done"` step over an unauthored object. orgTenantRecordToResponse
+// blanks the step for records that explicitly say isolation=namespace;
+// the SPA (CreateOrganizationPage ProvisionSteps) renders only the steps
+// the payload carries.
 type orgTenantSteps struct {
-	VCluster        string `json:"vcluster"`
+	VCluster        string `json:"vcluster,omitempty"`
 	BPCharts        string `json:"bp_charts"`
 	DNS             string `json:"dns"`
 	Certs           string `json:"certs"`
@@ -502,6 +524,16 @@ func stepsForState(state store.OrganizationProvisionState, lastError string) org
 }
 
 func orgTenantRecordToResponse(rec store.OrganizationProvisionRecord) orgTenantResponse {
+	steps := stepsForState(rec.State, rec.LastError)
+	// #5489 — a namespace-isolated Org has no vCluster step to report.
+	// Blank it (the field is omitempty) only when the record EXPLICITLY
+	// says namespace; legacy rows with an empty isolation keep the full
+	// timeline — there is nothing to derive from, and guessing is the
+	// exact fabrication this fix removes. A failed boundary still
+	// surfaces via state=failed + last_error.
+	if rec.Isolation == "namespace" {
+		steps.VCluster = ""
+	}
 	return orgTenantResponse{
 		OrganizationID:  rec.OrganizationID,
 		State:           rec.State,
@@ -521,7 +553,7 @@ func orgTenantRecordToResponse(rec store.OrganizationProvisionRecord) orgTenantR
 		Isolation:       rec.Isolation,
 		CommitSHA:       rec.CommitSHA,
 		LastError:       rec.LastError,
-		Steps:           stepsForState(rec.State, rec.LastError),
+		Steps:           steps,
 		CreatedAt:       rec.CreatedAt,
 		UpdatedAt:       rec.UpdatedAt,
 	}
@@ -715,7 +747,11 @@ func (h *Handler) HandleCreateOrganization(w http.ResponseWriter, r *http.Reques
 		AdminEmail:     email,
 		CompanyName:    strings.TrimSpace(body.CompanyName),
 		OTECHFQDN:      otech,
-		VClusterName:   "vc-" + subdomain,
+		// #5489 — only a vcluster-tier Org gets a vCluster name; a
+		// namespace-tier record stays empty rather than naming an object
+		// the platform never authors. Inert on the pipeline: since #4188
+		// no overlay template renders VClusterName.
+		VClusterName: vclusterNameFor(shape.Isolation, subdomain),
 		// Workstream A (#4290 / EPIC #4293) — the per-Organization host
 		// namespace is the org-controller-owned `<slug>`, NOT a stray
 		// `org-<uuid>`. The org-controller (core/controllers/organization/

--- a/products/catalyst/bootstrap/api/internal/store/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/store/organization_provisioning.go
@@ -151,9 +151,11 @@ type OrganizationProvisionRecord struct {
 	// Per Inviolable Principle 4 the value is operator-supplied at
 	// create time, never inferred from OTECHFQDN.
 	ParentDomain string `json:"parent_domain,omitempty"`
-	// VClusterName — derived as `vc-<subdomain>`. Captured at create
-	// so the orchestrator can reference it in GitOps manifest paths
-	// without re-deriving on every reconcile.
+	// VClusterName — `vc-<subdomain>` for a vcluster-tier Org, "" for a
+	// namespace-tier one (#5489: only the vcluster tier has a vCluster to
+	// name). Captured at create so the orchestrator can reference it in
+	// GitOps manifest paths without re-deriving on every reconcile —
+	// though since #4188 no overlay template renders it.
 	VClusterName string `json:"vcluster_name"`
 	// TenantNamespace — `org-<org_tenant_id>` per #804 scope §1. The
 	// bp-wordpress-tenant / bp-openclaw / bp-stalwart-tenant charts

--- a/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.tsx
@@ -30,6 +30,7 @@ import {
   isParentDomainReady,
   listSovereignParentDomains,
   type OrgProvisionRecord,
+  type OrgProvisionStepState,
   type OrgDomainMode,
   type SovereignParentDomain,
 } from './org.api'
@@ -555,12 +556,16 @@ export function CreateOrganizationPage({
   )
 }
 
-function ProvisionSteps({
-  steps,
-}: {
-  steps: OrgProvisionRecord['steps']
-}) {
-  const items: { key: keyof OrgProvisionRecord['steps']; label: string }[] = [
+// provisionStepItems — the ordered timeline entries for a provisioning
+// payload. #5489: the API omits `steps.vcluster` for a namespace-isolated
+// Org (no vCluster is ever provisioned for that tier), so only the steps
+// the payload actually carries render — the old fixed list painted a
+// "vCluster: done" dot over an object that does not exist. Exported for
+// the unit test; the render below is a straight map over this.
+export function provisionStepItems(
+  steps: OrgProvisionRecord['steps'],
+): { key: keyof OrgProvisionRecord['steps']; label: string; state: OrgProvisionStepState }[] {
+  const ordered: { key: keyof OrgProvisionRecord['steps']; label: string }[] = [
     { key: 'vcluster', label: 'vCluster' },
     { key: 'bp_charts', label: 'Charts' },
     { key: 'dns', label: 'DNS' },
@@ -568,10 +573,22 @@ function ProvisionSteps({
     { key: 'keycloak_clients', label: 'Keycloak' },
     { key: 'registry', label: 'Registry' },
   ]
+  return ordered.flatMap((s) => {
+    const state = steps[s.key]
+    return state ? [{ ...s, state }] : []
+  })
+}
+
+function ProvisionSteps({
+  steps,
+}: {
+  steps: OrgProvisionRecord['steps']
+}) {
+  const items = provisionStepItems(steps)
   return (
     <div className="flex flex-wrap items-center gap-2">
       {items.map((s, i) => {
-        const state = steps[s.key]
+        const state = s.state
         const cls =
           state === 'done'
             ? 'bg-[var(--color-success,#16a34a)]'

--- a/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
@@ -117,7 +117,11 @@ export type OrgDomainMode = 'free-subdomain' | 'byo'
 export type OrgProvisionStepState = 'pending' | 'done' | 'failed'
 
 export interface OrgProvisionSteps {
-  vcluster: OrgProvisionStepState
+  /** #5489 — absent for a namespace-isolated Org: no vCluster is ever
+   *  provisioned for that tier, so the API omits the step rather than
+   *  reporting "done" over an object that does not exist. Render only
+   *  the steps the payload carries. */
+  vcluster?: OrgProvisionStepState
   bp_charts: OrgProvisionStepState
   dns: OrgProvisionStepState
   certs: OrgProvisionStepState

--- a/products/catalyst/bootstrap/ui/src/pages/org/provision-steps-5489.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/org/provision-steps-5489.test.ts
@@ -1,0 +1,57 @@
+// Tests for #5489 — the post-create timeline rendered a `vCluster` step for
+// namespace-isolated Organizations. The API returned `steps.vcluster:
+// "done"` for a tier that never provisions a vCluster (proven live on hw291
+// — zero vclusters.vcluster.com resources), and the SPA's fixed step list
+// painted the dot regardless. The API now omits the key for namespace-tier
+// Orgs; provisionStepItems renders only the steps the payload carries.
+//
+// Anti-theater: the omission assertion fails against the pre-fix fixed list;
+// the full-payload control pins that a vcluster-tier timeline still renders
+// all six steps in order — a fix that dropped the step everywhere would pass
+// the first half while erasing a real step from real vcluster-tier Orgs.
+
+import { describe, it, expect } from 'vitest'
+import { provisionStepItems } from './CreateOrganizationPage'
+import type { OrgProvisionSteps } from './org.api'
+
+const REST: Omit<OrgProvisionSteps, 'vcluster'> = {
+  bp_charts: 'done',
+  dns: 'done',
+  certs: 'done',
+  keycloak_clients: 'done',
+  registry: 'done',
+}
+
+describe('#5489 provision timeline must not paint a vCluster step over nothing', () => {
+  it('omits the vCluster step when the payload carries none (namespace tier)', () => {
+    const items = provisionStepItems({ ...REST })
+    expect(items.map((i) => i.key)).not.toContain('vcluster')
+    // Control within the case: the remaining timeline survives, in order.
+    expect(items.map((i) => i.key)).toEqual([
+      'bp_charts',
+      'dns',
+      'certs',
+      'keycloak_clients',
+      'registry',
+    ])
+  })
+
+  it('keeps the vCluster step for a payload that carries one (vcluster tier)', () => {
+    const items = provisionStepItems({ vcluster: 'done', ...REST })
+    expect(items[0]).toEqual({ key: 'vcluster', label: 'vCluster', state: 'done' })
+    expect(items).toHaveLength(6)
+  })
+
+  it('carries per-step state through unchanged (failed boundary still renders red)', () => {
+    const items = provisionStepItems({
+      vcluster: 'failed',
+      bp_charts: 'pending',
+      dns: 'pending',
+      certs: 'pending',
+      keycloak_clients: 'pending',
+      registry: 'pending',
+    })
+    expect(items[0]?.state).toBe('failed')
+    expect(items[1]?.state).toBe('pending')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.9",
+    "version": "0.5.21",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"
@@ -165,7 +165,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A"
             ],
@@ -363,6 +363,73 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       }
     },
     "hasUserUIEndpoint": true
+  },
+  {
+    "id": "bp-catalyst-edge-routes",
+    "slug": "catalyst-edge-routes",
+    "title": "Catalyst control-plane edge (region-b)",
+    "summary": "|",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "0.2.0",
+    "section": "pts-3-1-networking-and-service-mesh",
+    "depends": [
+      "bp-cilium",
+      "bp-gateway-api"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "producesInstances": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": 0,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "passive",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-catalyst-platform",
@@ -658,7 +725,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.3",
+    "version": "1.4.18",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
@@ -876,7 +943,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.12",
+    "version": "1.0.14",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-flux"
@@ -931,7 +998,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.7",
+    "version": "0.2.23",
     "section": "pts-9-disaster-recovery",
     "depends": [
       "bp-cnpg",
@@ -985,7 +1052,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -1039,7 +1106,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.5",
+    "version": "1.1.7",
     "section": "pts-3-2-gitops-and-iac",
     "depends": [],
     "shareable": false,
@@ -1093,7 +1160,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.0",
+    "version": "1.3.4",
     "section": "pts-3-2-gitops-and-iac",
     "depends": [
       "bp-crossplane"
@@ -1253,6 +1320,48 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "hasUserUIEndpoint": false
   },
   {
+    "id": "bp-dragonfly",
+    "slug": "dragonfly",
+    "title": "Dragonfly",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "0.1.1",
+    "section": "pts-3-5-storage-and-data",
+    "depends": [
+      "bp-cilium"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "producesInstances": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    },
+    "hasUserUIEndpoint": false
+  },
+  {
     "id": "bp-external-dns",
     "slug": "external-dns",
     "title": "ExternalDNS",
@@ -1262,7 +1371,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
@@ -1373,7 +1482,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.7",
+    "version": "1.0.9",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -1427,7 +1536,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -1659,7 +1768,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.0",
+    "version": "1.3.0",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
@@ -1713,7 +1822,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.40",
+    "version": "1.2.48",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"
@@ -1741,7 +1850,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
             "rpoSeconds": 0
           },
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A",
               "mgmt-B"
@@ -1756,7 +1865,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A"
             ],
@@ -1779,7 +1888,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.16",
+    "version": "1.0.18",
     "section": "pts-3-observability",
     "depends": [],
     "shareable": false,
@@ -1843,7 +1952,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.27",
+    "version": "0.2.31",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",
@@ -1913,7 +2022,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.36",
+    "version": "1.2.47",
     "section": "pts-3-5-storage-and-data",
     "depends": [
       "bp-cnpg",
@@ -1943,7 +2052,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
             "rpoSeconds": 0
           },
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A",
               "mgmt-B"
@@ -1958,7 +2067,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A"
             ],
@@ -2081,7 +2190,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.3",
+    "version": "1.0.9",
     "section": "pts-3-5-storage-and-data",
     "depends": [],
     "shareable": false,
@@ -2195,7 +2304,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.14",
+    "version": "0.1.16",
     "section": "pts-3-3-security-and-policy",
     "depends": [
       "bp-sealed-secrets"
@@ -2261,7 +2370,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.5.2",
+    "version": "1.5.7",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"
@@ -2289,7 +2398,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
             "rpoSeconds": 0
           },
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A",
               "mgmt-B"
@@ -2304,7 +2413,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A"
             ],
@@ -2516,7 +2625,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.40",
+    "version": "1.0.49",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -2881,7 +2990,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "section": "pts-3-observability",
     "depends": [],
     "shareable": false,
@@ -3126,7 +3235,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.5",
+    "version": "1.0.9",
     "section": "pts-3-observability",
     "depends": [],
     "shareable": false,
@@ -3190,7 +3299,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.3.3",
+    "version": "1.3.5",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
@@ -3253,7 +3362,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "ai-safety",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "1.0.0",
     "section": "pts-4-7-ai-safety",
     "depends": [
@@ -3508,7 +3617,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.129",
+    "version": "1.4.145",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -3566,7 +3675,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
         }
       }
     },
-    "hasUserUIEndpoint": false
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-oidc-gate",
@@ -3578,7 +3687,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.5",
+    "version": "0.1.8",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-cilium",
@@ -3646,7 +3755,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.51",
+    "version": "1.2.64",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
@@ -3672,7 +3781,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
             "rpoSeconds": 30
           },
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A",
               "mgmt-B"
@@ -3687,7 +3796,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "mgmt",
+            "tier": "",
             "clusters": [
               "mgmt-A"
             ],
@@ -3710,7 +3819,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.6",
+    "version": "0.2.17",
     "section": "pts-4-7-agentic-workspace",
     "depends": [
       "bp-newapi",
@@ -3731,7 +3840,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A"
             ],
@@ -3811,6 +3920,46 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       }
     },
     "hasUserUIEndpoint": true
+  },
+  {
+    "id": "bp-openova-mcp",
+    "slug": "openova-mcp",
+    "title": "OpenOva MCP",
+    "summary": "|",
+    "icon": "openova-mcp.svg",
+    "category": "ai-runtime",
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "0.1.6",
+    "section": "pts-4-7-agentic-workspace",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "producesInstances": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-opensearch",
@@ -3910,7 +4059,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "section": "pts-3-observability",
     "depends": [],
     "shareable": false,
@@ -3960,7 +4109,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "section": "pts-3-2-observability-and-tracing",
     "depends": [
       "bp-opentelemetry",
@@ -4013,7 +4162,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.0",
+    "version": "0.1.13",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-cilium"
@@ -4069,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.8",
+    "version": "0.2.14",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",
@@ -4146,7 +4295,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.17",
+    "version": "1.2.22",
     "section": "pts-3-2-gitops-and-iac",
     "depends": [
       "bp-cert-manager"
@@ -4352,7 +4501,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -4451,7 +4600,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.3.10",
+    "version": "0.3.12",
     "section": "pts-4-sandbox",
     "depends": [
       "bp-rtz-vcluster",
@@ -4482,7 +4631,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
             "rpoSeconds": 0
           },
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A",
               "rtz-B"
@@ -4497,7 +4646,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A"
             ],
@@ -4570,7 +4719,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.3",
+    "version": "1.2.5",
     "section": "pts-3-5-storage-and-data",
     "depends": [
       "bp-cert-manager"
@@ -4626,11 +4775,12 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.80",
+    "version": "0.1.157",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",
-      "bp-harbor"
+      "bp-harbor",
+      "bp-dragonfly"
     ],
     "shareable": false,
     "contextSchema": null,
@@ -4673,8 +4823,58 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "producesInstances": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    },
+    "hasUserUIEndpoint": false
+  },
+  {
+    "id": "bp-sovereign-tls-vars",
+    "slug": "sovereign-tls-vars",
+    "title": "Sovereign TLS Vars",
+    "summary": "|",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "0.1.1",
+    "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
     "contextSchema": null,
@@ -4787,7 +4987,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.22",
+    "version": "0.2.26",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-keycloak",
@@ -4895,7 +5095,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.8",
+    "version": "0.1.13",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-keycloak",
@@ -4926,7 +5126,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
             "rpoSeconds": 0
           },
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A",
               "rtz-B"
@@ -4941,7 +5141,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A"
             ],
@@ -5169,7 +5369,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "section": "pts-3-observability",
     "depends": [],
     "shareable": false,
@@ -5300,7 +5500,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.3",
+    "version": "1.0.5",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -5350,7 +5550,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-flux"
@@ -5532,7 +5732,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "section": "pts-3-observability",
     "depends": [],
     "shareable": false,
@@ -5652,7 +5852,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -5702,7 +5902,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.4.17",
+    "version": "0.4.22",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-postgres",
@@ -5734,7 +5934,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
             "rpoSeconds": 0
           },
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A",
               "rtz-B"
@@ -5749,7 +5949,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           "replication": null,
           "switchover": null,
           "placement": {
-            "tier": "rtz",
+            "tier": "",
             "clusters": [
               "rtz-A"
             ],
@@ -5796,6 +5996,7 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/alloy/blueprint.yaml",
   "platform/anthropic-adapter/blueprint.yaml",
   "platform/bge/blueprint.yaml",
+  "platform/catalyst-edge-routes/blueprint.yaml",
   "platform/catalyst-platform/blueprint.yaml",
   "platform/cert-manager-dynadot-webhook/blueprint.yaml",
   "platform/cert-manager-issuers/blueprint.yaml",
@@ -5812,6 +6013,7 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/crossplane/blueprint.yaml",
   "platform/debezium/blueprint.yaml",
   "platform/dmz-vcluster/blueprint.yaml",
+  "platform/dragonfly/blueprint.yaml",
   "platform/external-dns/blueprint.yaml",
   "platform/external-secrets-stores/blueprint.yaml",
   "platform/external-secrets/blueprint.yaml",
@@ -5854,6 +6056,7 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/openbao/blueprint.yaml",
   "platform/openclaw/blueprint.yaml",
   "platform/openmeter/blueprint.yaml",
+  "platform/openova-mcp/blueprint.yaml",
   "platform/opensearch/blueprint.yaml",
   "platform/opentelemetry-operator/blueprint.yaml",
   "platform/opentelemetry/blueprint.yaml",
@@ -5870,6 +6073,7 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/seaweedfs/blueprint.yaml",
   "platform/self-sovereign-cutover/blueprint.yaml",
   "platform/sigstore/blueprint.yaml",
+  "platform/sovereign-tls-vars/blueprint.yaml",
   "platform/spire/blueprint.yaml",
   "platform/sso-bridge/blueprint.yaml",
   "platform/stalwart-sovereign/blueprint.yaml",
@@ -5944,6 +6148,13 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = [
     "label": "sealed-secrets",
     "file": "05-sealed-secrets.yaml",
     "order": 5
+  },
+  {
+    "id": "bp-dragonfly",
+    "slug": "dragonfly",
+    "label": "dragonfly",
+    "file": "06-bp-dragonfly.yaml",
+    "order": 6
   },
   {
     "id": "bp-nats-jetstream",


### PR DESCRIPTION
MERGE HOLD: cutover in flight on hw291 — do not merge until cutoverComplete (RT-11).

Refs #5489 #5476 #3669 #4813

## What

PR #5490 killed the two client-side literals (parent-row `isolation: vcluster`, apps-grid `dev` chip). This PR closes the remaining three fabrication seams from #5489, all proven live on hw291 where `kubectl get vclusters.vcluster.com -A` returns *No resources found* and the topology API reports vclusters=0 in both regions.

The pattern on every seam: derive from the real tier/binding, and when there is nothing to derive, show an honest absent state — never a fabricated value.

### 1. org-controller — `kubectl get organizations -o wide` printed `vCluster: Ready` over nothing

`organization_controller.go` stamped `status.vcluster{name, hostCluster, phase}` unconditionally. A host-tier Org (plans ""/s/free) authors NO vCluster — the host `<slug>` namespace is the boundary — yet the CRD printer column (`products/catalyst/chart/crds/organization.yaml`, `.status.vcluster.phase`) surfaced `Ready` for an unauthored object. #4813 fixed the Ready *message*; the field beside it kept lying (predecessor #3669).

New `vclusterStatusFor` keys the stamp off the SAME `gitops.BoundaryIsVcluster` tier gate that decides whether a vCluster is authored at all:

- host tier: empty block — the printer column renders blank, matching the honest Ready message ("namespace-isolated tier — no vCluster authored")
- vcluster tier (m/l/xl/flexi): the exact previous shape, byte-for-byte

Console directory unaffected: `orgStateFromCR` reads phase first and falls through to the Ready condition, which is still stamped tier-honestly.

### 2. bootstrap api — `vcluster_name: "vc-<slug>"` synthesized for namespace-tier Orgs

Both row sources stamped it unconditionally: `org_list_from_cr.go:191` and the create-path store record (`organization_provisioning.go`). The payload carried `vcluster_name: "vc-hw291-omantel-biz"` right next to `isolation: "namespace"`. Latent — the UI declares the field (`pages/org/org.api.ts`) and never binds it — but it would assert a nonexistent object the moment anyone rendered it.

New `vclusterNameFor(isolation, slug)` derives from the isolation the row already carries; namespace-tier stays empty. Inert on the provisioning pipeline: since #4188 no overlay template renders `VClusterName` (verified — no template consumers exist).

### 3. post-create timeline — `steps.vcluster: "done"` for a tier that never provisions one

`steps.vcluster` is now `omitempty` and blanked when the record EXPLICITLY says `isolation=namespace`. Legacy rows with empty isolation keep the full timeline — there is nothing to derive from, and guessing either way is the same fabrication class this fix removes. A failed boundary still surfaces via `state=failed` + `last_error`.

FE: `ProvisionSteps` no longer renders a fixed six-step list — `provisionStepItems` renders only the steps the payload carries, so the omitted step never paints.

## Both-directions proof

Every seam is tested with a control (a fix that blanked the field for every tier would pass the absence checks while erasing real vcluster-tier status):

- `vcluster_status_stamp_5489_test.go` — tier matrix + serialized-absence (host JSON has no `"phase"`, vcluster control keeps `"phase":"Ready"`) + a full host-tier Reconcile asserting empty `status.vcluster` beside `Ready=True` with the namespace-boundary message
- `org_vcluster_fabrication_5489_test.go` — CR-derived namespace row: no `vcluster_name`, raw steps JSON omits the `vcluster` key while the rest of the timeline survives; plan-m control keeps `vc-<slug>` + `steps.vcluster=done`; store-record matrix incl. the legacy empty-isolation pin
- `provision-steps-5489.test.ts` — omission + six-step control + failed-state carry-through

Negative proof executed: temporarily restoring each pre-fix behavior fails exactly the new tests (3 controller FAILs on the unconditional stamp; 3 handler FAILs on unconditional `vc-<slug>` + non-omitted step), then restored.

## Gates

- `products/catalyst/bootstrap/api`: `go build ./...` + `go test ./... -count=1` — all packages ok (handler 169s)
- `core/controllers/organization`: `go test ./... -count=1` — all packages ok
- `products/catalyst/bootstrap/ui`: `tsc -b --noEmit` clean; `vite build` green; vitest 1956 passed, 9 failed — the same 9 fail on clean main (wizard StepComponents / SettingsPage / SovereignConsoleLayout), pre-existing and untouched by this PR

## Not in scope

The Environment-CR console surface (#5489's last section) and the Environment status defects (shared jetstreamSubjectPrefix, `status.vclusters[].host` semantic split, Ready-over-Provisioning) — tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
