### PR TITLE
fix(bp-self-sovereign-cutover): step-03 scarf.sh mothership fallback + toomanyrequests host latch + A3 FATAL keys on durable_miss/unmapped only (0.1.158) (Refs #5525)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1024,7 +1024,7 @@ spec:
       # — the live-cluster walk). New RBAC: read-only blueprints. New values:
       # prewarm.catalogCharts.*, prewarm.chartImages.*. Step count stays 11.
       # New chart test tests/catalog-chart-set.sh + contract Case 72.
-      version: 0.1.157
+      version: 0.1.158
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.157
+  version: 0.1.158
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,60 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.158 (#5525 Refs #5442 #5095 #3379 — step-03 harbor-prewarm: three legs
+# against the hw291 2026-07-30 scarf.sh/Docker-Hub rate-limit wall (dep
+# 2c2d746b578c636b: 4 litmuschaos.docker.scarf.sh refs cycled 4 pod attempts
+# over ~60 min on `toomanyrequests`, then a LATER attempt printed `Phase
+# A3-guard (#5442): PASS ... durable_miss=0` immediately followed by `FATAL ...
+# copy_fail=4` — the gate contradicted its own sweep):
+#   LEG 1 — scarf.sh engages the #5095 mothership fallback. Scarf download
+#     gateways (*.docker.scarf.sh) are redirectors in front of Docker Hub (they
+#     delegate auth to auth.docker.io and pass through Hub's verbatim
+#     rate-limit body — the 0.1.157 discovery), so Hub's ANONYMOUS per-IP quota
+#     applies THROUGH them; but the #5095 fallback fires only for
+#     mothership-SOURCED refs, so these direct-sourced copies hammered the
+#     exhausted anonymous path while harbor.openova.io/proxy-dockerhub served
+#     the SAME artifacts anonymously the whole time (proven live). copy_one now
+#     derives the INVERSE fallback for scarf hosts — mothership proxy as the
+#     SECONDARY source — via the FORWARD coverage-map lookup (the host's own
+#     project: litmuschaos.docker.scarf.sh -> proxy-dockerhub), path preserved;
+#     no second hand-list; DEST untouched (step-04/07/08 resolve the identical
+#     local artifact). The #5095-round-2 proxy-DOWN direct-first short-circuit
+#     is now ALSO gated on proxy_src so a .proxy_down latch never reorders a
+#     scarf ref onto the dead proxy first.
+#   LEG 2 — `toomanyrequests` short-circuits the host for the job attempt.
+#     Retrying a per-IP quota window from the same egress IP inside the same
+#     window is guaranteed waste that itself RE-ARMS the window (3 outer x 5
+#     inner manifest reads per image per pod attempt sustained the exhaustion
+#     across 4 pod attempts). prewarm_skopeo_copy now sniffs each failed leg's
+#     own log region (byte-offset bounded) for `toomanyrequests` and latches
+#     ${cpdir}/.ratelimited.<host>; copy_one skips a latched PRIMARY source and
+#     goes straight to the fallback wherever one exists (a fallback-less
+#     primary keeps its attempts — failing instantly with zero copies tried
+#     would trade a slow failure for a certain one). Latches carry into the
+#     Phase A3 chart-image wave like the .proxy_down latch does.
+#   LEG 3 — the #5442 A3 FATAL keys on { durable_miss>0 || unmapped } ONLY.
+#     copy_fail>0 with durable_miss=0 and no unmapped host means every failed
+#     copy was a freshness re-copy against a source we no longer need — that
+#     shape degrades to a LOUD WARN naming the refs (the A3-guard durability
+#     sweep via harbor_durable_digest stays the authoritative assertion, and it
+#     runs over the WHOLE chart-declared set including live-wave-credited
+#     refs). AND copy_one gains a dest-presence rescue: when every copy attempt
+#     failed AND the SOURCE manifest is unreadable (rate-limit latch or a fresh
+#     raw-manifest read returning nothing — i.e. the #4994 digest-compare skip
+#     genuinely could not run), a harbor_durable_digest probe of the dest
+#     rescues the image with a WARN (freshness unverified) instead of a .fail —
+#     a rate-limited source can no longer fail an image the local registry
+#     already serves. A READABLE source keeps strict fail semantics, so a real
+#     transfer/dest defect still counts. Phase A's push_fail>0 FATAL and the
+#     A3-guard durable_miss FATAL are untouched — the sovereignty guarantee
+#     (every image durably in local Harbor before the deny-egress hold) is
+#     asserted where it belongs, by presence, not by copy-exit-codes.
+# Template 03 only; no new values knobs; no step-count / RBAC / deadline
+# change (still 11 steps). Contract Case 73 locks all three legs including a
+# both-directions proof of the FATAL-gate key set. Slot-06a pin +
+# blueprint.yaml + catalog-seed source.version + spec.version move to 0.1.158
+# in lockstep (Inviolable Principle #13).
+# ── prior ──
 # 0.1.157 (#5442 Refs #4975 #5443 #5095 — COVER THE TWO HOSTS THE
 # AUTHORING-TIME SCAN IS STRUCTURALLY BLIND TO. 0.1.154 made step-03 enumerate
 # images from the PINNED CATALOG CHARTS instead of only from what is installed.
@@ -2807,7 +2862,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.157
+version: 0.1.158
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -1112,6 +1112,10 @@ data:
               printf -- '--multi-arch all'
             }
 
+            # #5525 leg 2 — slug a registry host into a latch-file-safe token
+            # (same tr class as the per-image log slug above).
+            rl_slug() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+
             prewarm_skopeo_copy() {
               _pc_src="$1"; _pc_creds="$2"; _pc_lref="$3"; _pc_log="$4"
               # #5468 — multi-arch mode FIRST into the function's OWN positional
@@ -1122,14 +1126,40 @@ data:
               set -- $(prewarm_multiarch_flags "${_pc_src}")
               # Optional --src-creds (empty for anonymous upstreams).
               if [ -n "${_pc_creds}" ]; then set -- "$@" --src-creds="${_pc_creds}"; fi
-              skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
+              # #5525 leg 2 — byte offset of the log BEFORE this leg runs, so
+              # the rate-limit sniff below reads ONLY this leg's own output —
+              # never a prior attempt's, never another source's.
+              _pc_off=$(wc -c < "${_pc_log}" 2>/dev/null || echo 0)
+              if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
                 --insecure-policy \
                 --retry-times 5 \
                 "$@" \
                 --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
                 --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
                 --src-tls-verify=true \
-                "docker://${_pc_src}" "docker://${_pc_lref}" >>"${_pc_log}" 2>&1
+                "docker://${_pc_src}" "docker://${_pc_lref}" >>"${_pc_log}" 2>&1; then
+                return 0
+              else
+                # Capture skopeo's REAL exit status INSIDE the else branch
+                # (the #3379 hw138 always-0 trap).
+                _pc_rc=$?
+              fi
+              # #5525 leg 2 — `toomanyrequests` is a PER-IP quota window: every
+              # further pull from this host inside the same window (same cluster
+              # egress IP) is guaranteed waste that itself keeps the window
+              # exhausted (hw291 2026-07-30: 3 outer x 5 inner manifest reads
+              # per image per pod attempt SUSTAINED the exhaustion for ~60 min
+              # across 4 pod attempts). Latch the SOURCE host so copy_one skips
+              # it for the remainder of this job attempt wherever a fallback
+              # source exists.
+              _pc_h="${_pc_src%%/*}"
+              if tail -c +"$((_pc_off+1))" "${_pc_log}" 2>/dev/null | grep -qi 'toomanyrequests'; then
+                if [ ! -f "${cpdir}/.ratelimited.$(rl_slug "${_pc_h}")" ]; then
+                  touch "${cpdir}/.ratelimited.$(rl_slug "${_pc_h}")" 2>/dev/null || true
+                  echo "[harbor-prewarm] ${_pc_h} answered toomanyrequests (per-IP rate limit) — latching this host OFF for the remainder of this job attempt wherever a fallback source exists; retrying inside the same quota window is guaranteed waste (#5525)"
+                fi
+              fi
+              return "${_pc_rc}"
             }
 
             # #4975 — copy ONE upstream image to ALL of its local Harbor
@@ -1194,6 +1224,40 @@ data:
                     fi
                     ;;
                 esac
+              elif [ -n "${MOTHERSHIP_HOST:-}" ]; then
+                # #5525 leg 1 (Refs #5095 #5442) — Scarf download gateways
+                # (*.docker.scarf.sh) are REDIRECTORS in front of Docker Hub,
+                # not registries: they delegate auth to Docker Hub's own token
+                # service and pass through Hub's verbatim rate-limit body, so
+                # Hub's ANONYMOUS per-IP quota applies THROUGH them. Live hw291
+                # 2026-07-30 (dep 2c2d746b578c636b): 4 litmuschaos refs burned
+                # 4 pod attempts over ~60 min on `toomanyrequests` while the
+                # SAME artifacts were anonymously servable from the mothership
+                # proxy the whole time — the #5095 fallback never engaged
+                # because it fires only for mothership-SOURCED refs. Derive the
+                # INVERSE fallback here — mothership proxy as the SECONDARY
+                # source — via the FORWARD coverage-map lookup (this host's own
+                # project, e.g. litmuschaos.docker.scarf.sh -> proxy-dockerhub),
+                # path preserved: ${MOTHERSHIP_HOST}/<project>/<path>. No
+                # second hand-list; a scarf host absent from the map stays
+                # fallback-less (it would be UNMAPPED in the pre-pass anyway).
+                # Source selection ONLY: the DEST path is untouched, so
+                # step-04/07/08 resolve the identical LOCAL artifact.
+                case "${srchost}" in
+                  *.docker.scarf.sh)
+                    _fb_proj=""
+                    for _fb_pair in ${HOST_PROJECT_MAP}; do
+                      _fb_h="${_fb_pair%%:*}"
+                      case "${_fb_pair}" in *:*) _fb_p="${_fb_pair#*:}" ;; *) _fb_p="" ;; esac
+                      if [ "${_fb_h}" = "${srchost}" ] && [ -n "${_fb_p}" ]; then _fb_proj="${_fb_p}"; break; fi
+                    done
+                    if [ -n "${_fb_proj}" ]; then
+                      fb_up="${MOTHERSHIP_HOST}/${_fb_proj}/${up#*/}"
+                      fb_creds=$(src_creds_for "${MOTHERSHIP_HOST}")
+                      echo "[harbor-prewarm] scarf.sh redirector source ${up}: mothership-proxy fallback available (${fb_up}; #5525)" >>"${cpdir}/${slug}.log"
+                    fi
+                    ;;
+                esac
               fi
               all_ok=1
               last_rc=0
@@ -1247,7 +1311,11 @@ data:
                   # preserved), so step-04/07/08 resolve the same LOCAL artifact.
                   # On a direct-first MISS we fall straight through to the round-1
                   # proxy-first path below (the proxy might have just recovered).
-                  if [ -n "${fb_up}" ] && [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ] && [ -f "${cpdir}/.proxy_down" ]; then
+                  # #5525 — additionally gated on proxy_src: for a scarf-sourced
+                  # ref (leg 1 above) fb_up IS the mothership proxy, so a
+                  # .proxy_down latch must keep the ordering primary-first, not
+                  # route it to the dead proxy first.
+                  if [ "${proxy_src}" -eq 1 ] && [ -n "${fb_up}" ] && [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ] && [ -f "${cpdir}/.proxy_down" ]; then
                     echo "[harbor-prewarm] proxy latched DOWN; direct-first ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5095 round 2)" >>"${cpdir}/${slug}.log"
                     if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" "${cpdir}/${slug}.log"; then
                       rc=0
@@ -1257,15 +1325,28 @@ data:
                       rc=$?
                     fi
                   fi
-                  echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt}/${max_attempts}" >>"${cpdir}/${slug}.log"
-                  if prewarm_skopeo_copy "${up}" "${sc}" "${lref}" "${cpdir}/${slug}.log"; then
-                    rc=0
-                    src_used="${up}"
-                    break
+                  # #5525 leg 2 — the primary source host answered
+                  # `toomanyrequests` earlier in this job attempt and a fallback
+                  # source exists: skip the primary leg outright (every pull
+                  # from the same egress IP inside the same quota window is
+                  # guaranteed waste that re-arms the window) and go straight to
+                  # the fallback below. Without a fallback the primary keeps its
+                  # attempts — failing instantly with zero copies tried would
+                  # trade a slow failure for a certain one.
+                  if [ -n "${fb_up}" ] && [ -f "${cpdir}/.ratelimited.$(rl_slug "${srchost}")" ]; then
+                    echo "[harbor-prewarm] skip rate-limited primary ${up} (host latched toomanyrequests); straight to fallback ${fb_up} attempt ${attempt}/${max_attempts} (#5525)" >>"${cpdir}/${slug}.log"
+                    rc=1
                   else
-                    # Capture skopeo's REAL exit status INSIDE the else branch
-                    # (the #3379 hw138 always-0 trap).
-                    rc=$?
+                    echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt}/${max_attempts}" >>"${cpdir}/${slug}.log"
+                    if prewarm_skopeo_copy "${up}" "${sc}" "${lref}" "${cpdir}/${slug}.log"; then
+                      rc=0
+                      src_used="${up}"
+                      break
+                    else
+                      # Capture skopeo's REAL exit status INSIDE the else branch
+                      # (the #3379 hw138 always-0 trap).
+                      rc=$?
+                    fi
                   fi
                   # #5095 — direct-source fallback: BEFORE counting this
                   # attempt failed, retry the SAME image from its canonical
@@ -1275,7 +1356,11 @@ data:
                   # reachable (proven hw255: ghcr.io copies all ok while every
                   # harbor.openova.io copy FAILed exit=1).
                   if [ -n "${fb_up}" ]; then
-                    echo "[harbor-prewarm] proxy source failed (exit=${rc}); direct-source fallback ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5095)" >>"${cpdir}/${slug}.log"
+                    if [ "${proxy_src}" -eq 1 ]; then
+                      echo "[harbor-prewarm] proxy source failed (exit=${rc}); direct-source fallback ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5095)" >>"${cpdir}/${slug}.log"
+                    else
+                      echo "[harbor-prewarm] primary source failed/skipped (exit=${rc}); mothership-proxy fallback ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5525)" >>"${cpdir}/${slug}.log"
+                    fi
                     if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" "${cpdir}/${slug}.log"; then
                       rc=0
                       src_used="${fb_up}"
@@ -1316,11 +1401,51 @@ data:
                     fi
                   fi
                 done
+                # #5525 leg 3 — a source-side outage must not fail an image the
+                # local registry ALREADY serves. The #4994 skip keys on a SOURCE
+                # manifest read; when that source is rate-limited/unreachable
+                # the skip cannot run, the copy is attempted, fails, and the
+                # image counts failed even though the dest is current (hw291
+                # attempt 1785396281: A3-guard PASS durable_miss=0 alongside
+                # FATAL copy_fail=4 — a self-contradiction). So before counting
+                # the failure: if the SOURCE manifest is unreadable (the host is
+                # rate-limit-latched, or a fresh raw-manifest read yields
+                # nothing — i.e. the skip genuinely could not have run), fall
+                # back to a DEST-presence probe via harbor_durable_digest
+                # (Harbor CORE's DB, never a pull-through). Durably present ⇒
+                # WARN + keep the artifact: freshness against the source is
+                # unverifiable this run, and durable presence is exactly what
+                # the post-pivot pull contract needs. A READABLE source keeps
+                # the strict fail semantics — the failure then is a real
+                # transfer/dest defect, not a source blind spot.
+                if [ "${rc}" -ne 0 ]; then
+                  _rs_raw=""
+                  if [ ! -f "${cpdir}/.ratelimited.$(rl_slug "${srchost}")" ]; then
+                    if [ -n "${sc}" ]; then
+                      _rs_raw=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
+                        --creds="${sc}" --tls-verify=true "docker://${up}" 2>/dev/null || true)
+                    else
+                      _rs_raw=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
+                        --tls-verify=true "docker://${up}" 2>/dev/null || true)
+                    fi
+                  fi
+                  if [ -z "${_rs_raw}" ] && [ -n "$(harbor_durable_digest "${lref}")" ]; then
+                    echo "[harbor-prewarm] WARN ${up} -> ${lref}: source manifest unreadable (rate limit/outage) and every copy attempt failed, but the dest is durably present in local Harbor — keeping the durable artifact; source freshness UNVERIFIED this run (#5525)"
+                    echo "  WARN source unreadable + dest durably present; counted ok, freshness unverified (#5525)" >>"${cpdir}/${slug}.log"
+                    rc=0
+                    src_used=""
+                  fi
+                fi
                 # #5095 — log which source ultimately succeeded (stdout, real
                 # time, next to the done/skip lines + the per-image log).
                 if [ "${rc}" -eq 0 ] && [ -n "${src_used}" ] && [ "${src_used}" != "${up}" ]; then
-                  echo "[harbor-prewarm] ${up} -> ${lref} succeeded via DIRECT upstream ${src_used} (mothership proxy path failing; #5095)"
-                  echo "  succeeded via direct upstream ${src_used} (mothership proxy path failing)" >>"${cpdir}/${slug}.log"
+                  if [ "${proxy_src}" -eq 1 ]; then
+                    echo "[harbor-prewarm] ${up} -> ${lref} succeeded via DIRECT upstream ${src_used} (mothership proxy path failing; #5095)"
+                    echo "  succeeded via direct upstream ${src_used} (mothership proxy path failing)" >>"${cpdir}/${slug}.log"
+                  else
+                    echo "[harbor-prewarm] ${up} -> ${lref} succeeded via mothership-proxy fallback ${src_used} (primary source failing/rate-limited; #5525)"
+                    echo "  succeeded via mothership-proxy fallback ${src_used} (primary source failing/rate-limited)" >>"${cpdir}/${slug}.log"
+                  fi
                 fi
                 [ "${rc}" -eq 0 ] || { all_ok=0; last_rc="${rc}"; }
               done
@@ -2214,6 +2339,13 @@ data:
                 cat_cpdir=/tmp/prewarm-chart-image-copies
                 rm -rf "${cat_cpdir}"; mkdir -p "${cat_cpdir}"
                 [ -f "${cpdir}/.proxy_down" ] && touch "${cat_cpdir}/.proxy_down"
+                # #5525 leg 2 — carry the per-host toomanyrequests latches into
+                # the chart-image wave too, so a host that exhausted its quota
+                # during Phase A is not re-hammered by Phase A3.
+                for _rl_f in "${cpdir}"/.ratelimited.*; do
+                  [ -e "${_rl_f}" ] || continue
+                  cp "${_rl_f}" "${cat_cpdir}/" 2>/dev/null || true
+                done
                 # copy_one writes its sentinels into the GLOBAL cpdir; point it
                 # at this wave's dir and restore afterwards so nothing later in
                 # the step observes a mutated global.
@@ -2315,9 +2447,26 @@ data:
               if [ "${cat_render_fail}" -gt 0 ]; then
                 echo "[harbor-prewarm] Phase A3-chart-images WARN: ${cat_render_fail} chart(s) could not be pulled back or rendered (named above) — their images were NOT enumerated from the chart; those charts rely on the live-cluster wave alone (#5442)"
               fi
+              # #5525 leg 3 — copy_fail ALONE is not a post-severance
+              # ImagePullBackOff: the A3-guard durability sweep directly above
+              # is the AUTHORITATIVE assertion of what the pivoted registry
+              # serves, and copy_fail>0 with durable_miss=0 means every failed
+              # copy was a freshness re-copy against a source we no longer need
+              # (live hw291 attempt 1785396281: `Phase A3-guard (#5442): PASS`
+              # with durable_miss=0 immediately followed by `FATAL ...
+              # copy_fail=4` — the gate contradicted its own sweep). That shape
+              # degrades to a LOUD WARN naming the refs; FATAL keys on
+              # { durable_miss>0 || unmapped } ONLY.
+              if [ "${cat_img_fail}" -gt 0 ] && [ "${img_missing_n}" -eq 0 ] && [ -z "${cat_img_unmapped}" ]; then
+                echo "[harbor-prewarm] Phase A3-chart-images WARN (#5525): ${cat_img_fail} copy attempt(s) failed but EVERY chart-declared image path is durably present in local Harbor (A3-guard PASS, durable_miss=0) — the failures were freshness re-copies against unreachable/rate-limited sources; the pivoted registry serves the full set. Failed ref(s):"
+                for f in "${cat_cpdir}"/*.fail; do
+                  [ -e "${f}" ] || continue
+                  echo "  WARN-COPY-FAIL $(cat "${f}")"
+                done
+              fi
               if [ "${PREWARM_CHART_IMAGES_FATAL}" = "true" ] \
-                 && { [ "${cat_img_fail}" -gt 0 ] || [ "${img_missing_n}" -gt 0 ] || [ -n "${cat_img_unmapped}" ]; }; then
-                echo "[harbor-prewarm] FATAL (#5442): the pinned charts declare image(s) the local registry cannot serve (copy_fail=${cat_img_fail} durable_miss=${img_missing_n} unmapped=$(printf '%s\n' ${cat_img_unmapped} | grep -c . || true)). Step-05 pivots flux onto these exact chart versions, so every workload whose image is missing goes ImagePullBackOff against a registry that correctly answers NotFound — and if catalyst-api is among them the Sovereign cannot self-heal, because catalyst-api is what drives the cutover (live hw290 2026-07-27). Fix the named refs (extend offlineMirror.hostProjects for an UNMAPPED host; re-trigger step-03 with egress open for a copy failure) or set prewarm.chartImages.fatal=false to proceed knowing the post-pivot world is not fully pullable."
+                 && { [ "${img_missing_n}" -gt 0 ] || [ -n "${cat_img_unmapped}" ]; }; then
+                echo "[harbor-prewarm] FATAL (#5442 #5525): the pinned charts declare image(s) the local registry cannot serve (durable_miss=${img_missing_n} unmapped=$(printf '%s\n' ${cat_img_unmapped} | grep -c . || true) copy_fail=${cat_img_fail}). Step-05 pivots flux onto these exact chart versions, so every workload whose image is missing goes ImagePullBackOff against a registry that correctly answers NotFound — and if catalyst-api is among them the Sovereign cannot self-heal, because catalyst-api is what drives the cutover (live hw290 2026-07-27). Fix the named refs (extend offlineMirror.hostProjects for an UNMAPPED host; re-trigger step-03 with egress open for a durable miss) or set prewarm.chartImages.fatal=false to proceed knowing the post-pivot world is not fully pullable."
                 exit 1
               fi
             else

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3704,4 +3704,120 @@ if ! bash "${CATSET}" "$(pwd)" >/dev/null 2>&1; then
 fi
 echo "  PASS (03c library derives the catalog chart set + HARD/SOFT split, the guard names exactly the unservable contractual entries, chart-rendered image enumeration works, and step-03 + RBAC wire all of it)"
 
+# ── Case 73 (#5525, Refs #5442 #5095): step-03 rides out a scarf.sh/Docker-Hub
+# anonymous rate limit — mothership fallback for scarf hosts, toomanyrequests
+# host latch, and a FATAL gate that keys on durable_miss/unmapped ONLY ────────
+# hw291 (dep 2c2d746b578c636b, 2026-07-30): 4 litmuschaos.docker.scarf.sh refs
+# cycled 4 pod attempts over ~60 min on `toomanyrequests` — the #5095 fallback
+# never engaged (it fires only for mothership-SOURCED refs) while
+# harbor.openova.io/proxy-dockerhub served the SAME artifacts anonymously the
+# whole time; each retry wave itself kept the per-IP quota window exhausted;
+# and a LATER attempt printed `Phase A3-guard (#5442): PASS ... durable_miss=0`
+# immediately followed by `FATAL ... copy_fail=4` — the gate contradicting its
+# own authoritative durability sweep.
+echo "[cutover-contract] Case 73: step-03 scarf.sh mothership fallback + toomanyrequests host latch + A3 FATAL keys on durable_miss/unmapped only (#5525)"
+[ -s "$TMP/s03pin.yaml" ] || awk '/name: cutover-step-03-harbor-prewarm/{c=1} /name: cutover-step-04-registry-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s03pin.yaml"
+# (a) LEG 1 — scarf hosts derive a mothership-proxy fallback via the FORWARD
+#     coverage-map lookup (no second hand-list), and the proxy-DOWN
+#     direct-first short-circuit is gated on proxy_src so a .proxy_down latch
+#     never reorders a scarf ref onto the dead proxy first.
+if ! grep -qF '*.docker.scarf.sh)' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 copy_one has no *.docker.scarf.sh source arm — scarf-sourced refs keep hammering the anonymous Docker Hub path with no mothership fallback (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF 'fb_up="${MOTHERSHIP_HOST}/${_fb_proj}/${up#*/}"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 scarf fallback is not derived as \${MOTHERSHIP_HOST}/<project>/<path> via the forward coverage-map lookup — either a second hand-list exists or the fallback is absent (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF 'scarf.sh redirector source' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not log the scarf mothership-proxy fallback availability — a silent source pivot hides the rate-limit degradation from the operator (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF '[ "${proxy_src}" -eq 1 ] && [ -n "${fb_up}" ] && [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ]' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 direct-first short-circuit is not gated on proxy_src — a .proxy_down latch would route a scarf ref to the DEAD mothership proxy FIRST (#5525)" >&2
+  exit 1
+fi
+# (b) LEG 2 — a toomanyrequests reply latches the source host (offset-bounded
+#     sniff of the leg's OWN log region), latched primaries are skipped
+#     straight to the fallback, and the latch carries into the A3 wave.
+if ! grep -qF 'tail -c +"$((_pc_off+1))"' "$TMP/s03pin.yaml" || ! grep -qF "grep -qi 'toomanyrequests'" "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 prewarm_skopeo_copy does not sniff its own log region for toomanyrequests — rate-limited hosts are never latched and every retry re-arms the quota window (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF 'touch "${cpdir}/.ratelimited.$(rl_slug "${_pc_h}")"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 never latches .ratelimited.<host> — the short-circuit has no signal to key on (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF 'skip rate-limited primary' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 copy_one never skips a rate-limit-latched primary source — remaining attempts keep burning the exhausted window instead of going straight to the fallback (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF 'cp "${_rl_f}" "${cat_cpdir}/"' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 does not carry the .ratelimited.* latches into the Phase A3 chart-image wave — a host exhausted during Phase A gets re-hammered by A3 (#5525)" >&2
+  exit 1
+fi
+# (c) LEG 3 — the dest-presence rescue: a failed copy whose SOURCE manifest is
+#     unreadable consults harbor_durable_digest on the DEST before counting a
+#     failure.
+if ! grep -qF '[ -z "${_rs_raw}" ] && [ -n "$(harbor_durable_digest "${lref}")" ]' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 copy_one has no dest-presence rescue — a rate-limited source still fails an image the local registry already serves (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF 'WARN source unreadable + dest durably present' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 dest-presence rescue is silent — the freshness-unverified degrade must be a LOUD WARN in the per-image log (#5525)" >&2
+  exit 1
+fi
+# (d) LEG 3 — the A3 FATAL condition keys on { durable_miss>0 || unmapped }
+#     ONLY, proven BOTH DIRECTIONS by EXECUTING the exact rendered condition:
+#     the two physical lines of the `if` are extracted from the render,
+#     reassembled, and run under sh with scenario env — so this cannot pass on
+#     a re-worded-but-equivalent-to-the-old gate, and cannot pass vacuously on
+#     an empty extraction.
+grep -A1 -F 'if [ "${PREWARM_CHART_IMAGES_FATAL}" = "true" ]' "$TMP/s03pin.yaml" > "$TMP/a3gate.txt" || true
+if [ ! -s "$TMP/a3gate.txt" ]; then
+  echo "FAIL: cannot extract the A3 FATAL condition from the render — the PREWARM_CHART_IMAGES_FATAL gate is gone entirely (#5525 vacuity check)" >&2
+  exit 1
+fi
+a3cond=$(sed -e 's/^ *//' -e 's/ \\$//' "$TMP/a3gate.txt" | tr '\n' ' ' | sed -e 's/^if //' -e 's/; then *$//')
+# Direction 1 (the hw291 self-contradiction): copy_fail>0 with durable_miss=0
+# and no unmapped host must NOT fatal.
+if ! PREWARM_CHART_IMAGES_FATAL=true cat_img_fail=4 img_missing_n=0 cat_img_unmapped="" \
+     sh -c "if ${a3cond}; then exit 1; else exit 0; fi"; then
+  echo "FAIL: the A3 gate still FATALs on copy_fail=4 durable_miss=0 unmapped=0 — the gate contradicts its own durability sweep exactly as on hw291 attempt 1785396281 (#5525)" >&2
+  exit 1
+fi
+# Direction 2a: a durable miss MUST still fatal.
+if ! PREWARM_CHART_IMAGES_FATAL=true cat_img_fail=0 img_missing_n=1 cat_img_unmapped="" \
+     sh -c "if ${a3cond}; then exit 0; else exit 1; fi"; then
+  echo "FAIL: the A3 gate no longer FATALs on durable_miss=1 — the #5442 sovereignty guarantee was waived, not re-keyed (#5525)" >&2
+  exit 1
+fi
+# Direction 2b: an unmapped host MUST still fatal.
+if ! PREWARM_CHART_IMAGES_FATAL=true cat_img_fail=0 img_missing_n=0 cat_img_unmapped=" host(ref)" \
+     sh -c "if ${a3cond}; then exit 0; else exit 1; fi"; then
+  echo "FAIL: the A3 gate no longer FATALs on an unmapped registry host — an uncoverable image would surface as ImagePullBackOff mid deny-egress hold instead of failing loud here (#5525)" >&2
+  exit 1
+fi
+# Direction 2c: the fatal=false override still disarms the gate.
+if ! PREWARM_CHART_IMAGES_FATAL=false cat_img_fail=0 img_missing_n=1 cat_img_unmapped="" \
+     sh -c "if ${a3cond}; then exit 1; else exit 0; fi"; then
+  echo "FAIL: prewarm.chartImages.fatal=false no longer disarms the A3 gate (#5525)" >&2
+  exit 1
+fi
+# The copy-fail-only shape must degrade to a LOUD WARN naming the refs.
+if ! grep -qF 'WARN-COPY-FAIL' "$TMP/s03pin.yaml"; then
+  echo "FAIL: the copy_fail-with-durable_miss=0 shape has no loud WARN naming the failed refs — degrading the FATAL must not degrade the visibility (#5525)" >&2
+  exit 1
+fi
+# (e) untouched guarantees: Phase A's push_fail FATAL + the A3 durability sweep.
+if ! grep -qF 'failed to push — Sovereign cannot survive ghcr.io deny-egress post-cutover' "$TMP/s03pin.yaml"; then
+  echo "FAIL: step-03 Phase A lost the push_fail>0 FATAL — #5525 re-keys the A3 gate only, never the Phase A completeness guarantee (#5525)" >&2
+  exit 1
+fi
+if ! grep -qF 'Phase A3-guard (#5442)' "$TMP/s03pin.yaml"; then
+  echo "FAIL: the A3-guard durability sweep is gone — the re-keyed FATAL has lost its authoritative input (#5525)" >&2
+  exit 1
+fi
+echo "  PASS (#5525: scarf hosts fall back to the mothership proxy via the forward map lookup [direct-first stays proxy_src-gated], toomanyrequests latches the host + skips latched primaries + carries into A3, the dest-presence rescue keeps a durably-present image, and the A3 FATAL — executed both directions from the rendered condition — keys on durable_miss/unmapped only with the copy-fail shape a loud WARN)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-30T09:22:07.592Z",
+  "generatedAt": "2026-07-30T13:12:27.881Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -2490,7 +2490,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -4083,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.157",
+      "version": "0.1.158",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -2625,7 +2625,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.49",
+    "version": "1.0.50",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.157",
+    "version": "0.1.158",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.157"
+  version: "0.1.158"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.157"
+    version: "0.1.158"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

Durable three-leg fix for the hw291 2026-07-30 step-03 `harbor-prewarm` rate-limit wall (dep `2c2d746b578c636b`: 4 `litmuschaos.docker.scarf.sh` refs cycled 4 pod attempts over ~60 min on `toomanyrequests`, then a later attempt printed `Phase A3-guard (#5442): PASS ... durable_miss=0` immediately followed by `FATAL ... copy_fail=4`). The live heals are already applied on hw291; this ships the chart fix so no future prov repeats it. All behavior changes are in `platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml` (chart `0.1.158`).

### Leg 1 — scarf.sh engages the mothership fallback

`*.docker.scarf.sh` hosts are redirectors in front of Docker Hub (they delegate auth to `auth.docker.io` and pass through Hub's verbatim rate-limit body), so Hub's anonymous per-IP quota applies through them — but the #5095 fallback fires only for mothership-SOURCED refs, so these direct-sourced copies had no secondary source while `harbor.openova.io/proxy-dockerhub` served the same artifacts anonymously the whole time (proven live: `proxy-dockerhub/litmuschaos/mongo:6` digest `sha256:8f6a9...`). `copy_one` now derives the inverse fallback for scarf hosts via the FORWARD coverage-map lookup (the host's own project: `litmuschaos.docker.scarf.sh -> proxy-dockerhub`), path preserved — `${MOTHERSHIP_HOST}/<project>/<path>` — no second hand-list, DEST untouched (step-04/07/08 resolve the identical local artifact). The #5095-round-2 proxy-DOWN direct-first short-circuit is additionally gated on `proxy_src` so a `.proxy_down` latch never reorders a scarf ref onto the dead mothership proxy first.

### Leg 2 — `toomanyrequests` short-circuits the host for the job attempt

`prewarm_skopeo_copy` now records the per-image log's byte offset before each leg and, on failure, sniffs only that leg's own output for `toomanyrequests`; a hit latches `${cpdir}/.ratelimited.<host>` (loud stdout line, once). `copy_one` skips a latched PRIMARY source and goes straight to the fallback wherever one exists — retrying a per-IP quota window from the same egress IP inside the same window is guaranteed waste that itself re-arms the window (hw291: 3 outer x 5 inner manifest reads per image per pod attempt sustained the exhaustion across 4 pod attempts). A fallback-less primary keeps its attempts (failing instantly with zero copies tried would trade a slow failure for a certain one). Latches carry into the Phase A3 chart-image wave exactly like the `.proxy_down` latch.

### Leg 3 — the A3 FATAL keys on `{ durable_miss>0 || unmapped }` only, plus a dest-presence rescue

The exact new gate line:

    if [ "${PREWARM_CHART_IMAGES_FATAL}" = "true" ] \
       && { [ "${img_missing_n}" -gt 0 ] || [ -n "${cat_img_unmapped}" ]; }; then

`copy_fail>0` with `durable_miss=0` and no unmapped host now degrades to a loud WARN naming the refs (`WARN-COPY-FAIL ...`) — the A3-guard durability sweep (`harbor_durable_digest`, Harbor CORE's DB, whole chart-declared set) stays the authoritative assertion. And `copy_one` gains the dest-presence rescue: when every copy attempt failed AND the SOURCE manifest is unreadable (rate-limit latch, or a fresh raw-manifest read returning nothing — i.e. the #4994 digest-compare skip genuinely could not run), a `harbor_durable_digest` probe of the dest rescues the image with a WARN (freshness unverified) instead of a `.fail`. A readable source keeps strict fail semantics, so a real transfer/dest defect still counts. NOT weakened: Phase A's `push_fail>0` FATAL, the A3-guard `durable_miss` FATAL, the `prewarm.chartImages.fatal=false` override.

## Tests

- **Contract Case 73 (new)** locks all three legs, and proves the FATAL-gate change BOTH DIRECTIONS by executing the exact rendered condition (extracted from the render, reassembled, run under `sh` with scenario env): copy_fail=4/durable_miss=0/unmapped=0 must NOT fatal (verified non-vacuous — the pre-fix condition FATALs under the same scenario); durable_miss=1 must fatal; unmapped must fatal; `fatal=false` disarms. Plus fixed-string presence assertions for the scarf arm, the forward-map fallback construction, the proxy_src gate, the offset-bounded sniff, the latch + skip + A3 carry, the dest-presence rescue, and the untouched Phase A FATAL.
- `tests/cutover-contract.sh`: all cases green (1..73, including prior Cases 60/69 on the #5095 paths this touches).
- `tests/offline-mirror-host-projects.sh`: ALL CHECKS PASSED (positive + 5 negative).
- `tests/single-platform-copy.sh`: OK (incl. `prewarm_skopeo_copy` consumption check against the reworked function).
- `tests/catalog-chart-set.sh`: all gates green. `tests/image-registry-coverage.sh`: PASS (169 refs / 6 hosts). `tests/step06-pivot-readback.sh`: 13 passed, 0 failed.
- Rendered step-03 script extracted from the render and `sh -n` / `bash -n` clean (2422 lines).
- `tests/e2e/bootstrap-kit`: `go test -count=1 ./...` ok (the lockstep guard covering blueprint.yaml + catalog-seed pins).
- `products/catalyst/bootstrap/api`: `go build ./...` ok (regenerated embedded catalog).

## Version lockstep (0.1.158)

`chart/Chart.yaml` + `platform/self-sovereign-cutover/blueprint.yaml` + `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` + both catalog-seed entries (`spec.version` + `source.version`) move together. `blueprints.json` + `catalog.generated.ts` regenerated via `build-catalog.mjs` (this also syncs the lagging bp-kyverno-policies `1.0.50` and bp-postgres `0.2.15` entries — mechanical catalog sync from their already-merged blueprint.yaml bumps).

No new values knobs; no step-count / RBAC / deadline change (still 11 steps); no NodePort anywhere; code-only, no live clusters touched.

Refs #5525 #5442 #5095 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
