### PR TITLE
fix(gitea): durable db session provider so OAuth state survives pod rolls (#5531)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -185,7 +185,7 @@ spec:
       #   (giteaAdmin.mirrorNamespaces) instead of minting a fresh one that
       #   drifts from Gitea's DB (live hw277: cutover step-10 clone 401 /
       #   git exit 128). Refs #5262 #5214 #3379.
-      version: 1.2.48
+      version: 1.2.49
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.48 # lockstep with chart/Chart.yaml (#5262 admin-secret vanish-proof mirror-fallback lookup; #4885 admin-secret reloader annotation; #4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
+  version: 1.2.49 # lockstep with chart/Chart.yaml (#5531 durable db session provider — memory sessions lost OAuth state on pod roll; #5262 admin-secret vanish-proof mirror-fallback lookup; #4885 admin-secret reloader annotation; #4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -219,7 +219,7 @@ name: bp-gitea
 #   The reflector reflection-*-namespaces annotations are templated from the
 #   SAME values knob so annotation list and fallback order can never drift.
 #   Non-cutover render unchanged (annotation values identical at defaults).
-version: 1.2.48
+version: 1.2.49
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -81,6 +81,18 @@ gitea:
         NAME: gitea
         USER: gitea
         SSL_MODE: disable
+      # Durable session store (#5531). Upstream gitea defaults `[session]
+      # PROVIDER=memory`, which keeps the OAuth2 `state` that gitea mints on
+      # the redirect-to-Keycloak in process memory only. Any gitea pod roll
+      # between BeginAuth and the callback — the cutover registry-pivot
+      # restart, an image bump, a node drain — flushes that in-memory session,
+      # so the callback lands with no stored state and gitea 500s with
+      # "could not find a matching session for this request". `db` persists
+      # sessions in the gitea Postgres (already wired above), so the OAuth
+      # round-trip survives a mid-flow restart. PROVIDER_CONFIG is unused for
+      # the db provider (it reuses the configured database engine).
+      session:
+        PROVIDER: db
       # G91.gitea (#2653) — global OAuth2-client toggles. Per-provider
       # config (clientId/secret/autoDiscoverUrl) lives under `gitea.oauth`
       # below; these are the global app.ini knobs.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4364,7 +4364,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.48"
+  version: "1.2.49"
   visibility: unlisted
   card:
     title: "Gitea"
@@ -4387,7 +4387,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-gitea
-    version: "1.2.48"
+    version: "1.2.49"
   topology:
     supported:
       - active-hot-standby


### PR DESCRIPTION
## Problem

Gitea's SSO callback 500s with `could not find a matching session for this request` (`oauth.go SignInOAuthCallback`, #5531 / UAT row 31). Live inspection on hw291 found gitea running the **upstream default `[session] PROVIDER = memory`**.

The OAuth2 `state` gitea mints on the redirect-to-Keycloak is stored in **process memory only**. Any gitea pod roll between `BeginAuth` and the callback — the cutover **registry-pivot** restart, a chart image bump, a node drain — flushes that in-memory session, so the callback arrives with no stored state and gitea 500s.

## Fix

Set `[session] PROVIDER = db` so sessions persist in the gitea Postgres (already wired via `[database] DB_TYPE=postgres`, `HOST=gitea-pg-rw…`). Sessions then survive a mid-flow restart / rolling update. `PROVIDER_CONFIG` is unused for the `db` provider (it reuses the configured DB engine).

```yaml
      session:
        PROVIDER: db
```

## Live evidence (hw291, read-only)

- `app.ini [session] PROVIDER = memory`, `[database] DB_TYPE = postgres` (db provider available).
- gitea pod `gitea-55df7b4d58-9scks`: single replica, **0 restarts, 41h** at the row-31 walk time.

## Honest scope

Because the pod had 0 restarts at walk time and gitea's default session cookie is `SameSite=Lax` (which *does* survive a top-level OAuth callback), the **specific** row-31 500 is most consistent with the walk-harness caveat the issue itself raised (a scripted two-navigation Playwright flow that may drop gitea's pre-redirect cookie) — harbor SSO passed on the same walk, so the realm is healthy. This PR hardens the **roll-induced** variant of the error class, which is the real latent defect (`memory` is not production-appropriate for an SSO flow that must survive the cutover roll). Row 31 still owes a clean single-browser repro to fully close; this PR does not by itself flip it.

## Lockstep + gate

Bumped `1.2.48 → 1.2.49` across `chart/Chart.yaml`, `blueprint.yaml`, and the two `catalog-seed/blueprints.yaml` pins. `tests/e2e/bootstrap-kit` go guard green.

Refs #5531 #3374 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
