### PR TITLE
fix(console): Overview must not assert a placement the API never reported (#5422)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.placement-5422.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.placement-5422.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * AppDetail.placement-5422.test.tsx — #5422 (#3969): the Overview tab must
+ * NEVER assert a placement the API did not report.
+ *
+ * The defect: `apiApp?.placement ?? 'singleton'` stated a specific,
+ * load-bearing value for an app whose placement this response simply does
+ * not carry. The Topology tab on the SAME screen derives its value from
+ * live targets, so a two-region hot-standby app was described as a
+ * `singleton` in Overview and correctly in Topology — two contradictory
+ * values for one app, with the wrong one reading as authoritative because
+ * it sits in the summary. #3969 forbids exactly that second value.
+ *
+ * Both directions are pinned deliberately. A guard that only asserts the
+ * absent case passes just as happily against a component that renders
+ * nothing at all, and a guard that only asserts the present case cannot
+ * see the fallback come back. The pair is what makes the fix durable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { PATTERN_NOT_REPORTED } from '@/shared/lib/placement'
+import * as catalogApi from '@/lib/catalog.api'
+import { AppDetail } from './AppDetail'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+function renderDetail() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/app/$componentId',
+    component: () => <AppDetail disableStream />,
+  })
+  const tree = rootRoute.addChildren([detailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/app/bp-cilium'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+/** A minimal application response; `placement` is supplied per-test. */
+function appResponse(placement?: string) {
+  return {
+    name: 'cilium',
+    blueprint: 'bp-cilium',
+    ...(placement === undefined ? {} : { placement }),
+  } as unknown as Awaited<ReturnType<typeof catalogApi.getApplication>>
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cleanup()
+})
+
+describe('#5422 Overview placement never fails open into singleton', () => {
+  it('renders "not reported" — NOT singleton — when the API omits placement', async () => {
+    vi.spyOn(catalogApi, 'getApplication').mockResolvedValue(appResponse(undefined))
+    renderDetail()
+
+    const dd = await screen.findByTestId('app-detail-overview-placement')
+    expect(dd.textContent).toBe('not reported')
+    // The precise regression: the word `singleton` must not appear as an
+    // asserted value for an app whose placement is unknown.
+    expect(dd.textContent).not.toContain('singleton')
+    // And it must be visually marked as non-authoritative, matching the
+    // treatment TopologyTab gives the same sentinel (#5515).
+    expect(dd.className).toContain('italic')
+  })
+
+  it('renders a REAL placement verbatim and unmarked when the API reports one', async () => {
+    vi.spyOn(catalogApi, 'getApplication').mockResolvedValue(
+      appResponse('active-hot-standby'),
+    )
+    renderDetail()
+
+    const dd = await screen.findByTestId('app-detail-overview-placement')
+    expect(dd.textContent).toBe('active-hot-standby')
+    expect(dd.className ?? '').not.toContain('italic')
+  })
+
+  it('renders a genuine singleton when the API actually says singleton', async () => {
+    // The fix must not overcorrect: `singleton` is a legitimate value when
+    // it is the server's answer rather than the client's invention.
+    vi.spyOn(catalogApi, 'getApplication').mockResolvedValue(appResponse('singleton'))
+    renderDetail()
+
+    const dd = await screen.findByTestId('app-detail-overview-placement')
+    expect(dd.textContent).toBe('singleton')
+    expect(dd.className ?? '').not.toContain('italic')
+  })
+
+  it('uses the same sentinel constant as the Topology tab, not a private string', async () => {
+    // Guards against the two surfaces drifting into separate dialects for
+    // "unknown" — the failure mode #5422 is fundamentally about.
+    expect(PATTERN_NOT_REPORTED).toBe('not-reported')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -50,6 +50,7 @@ import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { findComponent } from '@/pages/wizard/steps/componentGroups'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { PATTERN_NOT_REPORTED } from '@/shared/lib/placement'
 import { useSession } from '@/shared/lib/useSession'
 import { API_BASE } from '@/shared/config/urls'
 import type { ApplicationStatus } from './eventReducer'
@@ -252,7 +253,16 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
   const appDependsOn = apiApp?.dependsOn ?? []
   const appRegions = apiApp?.regions ?? []
   const appLastReconciled = apiApp?.lastReconciledAt ?? ''
-  const appPlacement = apiApp?.placement ?? 'singleton'
+  // #5422 (#3969) — NEVER assert a placement the API did not report. The
+  // old `?? 'singleton'` fallback stated a specific, load-bearing value for
+  // an app whose placement is simply unknown to this response, and the
+  // Topology tab on the SAME screen derives its own value from live
+  // targets — so a two-region hot-standby app was described as a singleton
+  // in the Overview and correctly in Topology, with no way to tell which
+  // was true. Reuses the sentinel #5515 shipped for the identical
+  // fails-open defect in derivePattern, so both surfaces say "not-reported"
+  // in the same words rather than inventing two dialects for "unknown".
+  const appPlacement = apiApp?.placement ?? PATTERN_NOT_REPORTED
   const appPrimaryRegion = apiApp?.primaryRegion ?? appRegions[0] ?? ''
   // Family B (2026-05-17 t10 C4-005/007): the namespace the workload
   // actually lives in (HR spec.targetNamespace), and the label that
@@ -1304,7 +1314,20 @@ function OverviewPanel({
           ) : null}
           <div className="overview-row">
             <dt>Placement</dt>
-            <dd data-testid="app-detail-overview-placement">{appPlacement}</dd>
+            {/* #5422 — an unreported placement renders as dim italic prose,
+                matching the treatment TopologyTab.tsx already gives the same
+                sentinel (#5515). A real value keeps the normal weight. The two
+                tabs must not describe the same app in two different dialects. */}
+            <dd
+              data-testid="app-detail-overview-placement"
+              className={
+                appPlacement === PATTERN_NOT_REPORTED
+                  ? 'italic text-[var(--color-text-dim)]'
+                  : undefined
+              }
+            >
+              {appPlacement === PATTERN_NOT_REPORTED ? 'not reported' : appPlacement}
+            </dd>
           </div>
           {appRegions.length > 0 ? (
             <div className="overview-row">


### PR DESCRIPTION
## Defect

`AppDetail.tsx:255` read `apiApp?.placement ?? 'singleton'`.

When the API response omits `placement`, the Overview tab did not degrade to unknown or hide the field — it asserted the specific, load-bearing value **`singleton`**. Meanwhile the Topology tab, on the *same app, same screen*, derives placement from live targets and shows `active-hot-standby`.

So a two-region hot-standby application was described by the console as a single-region singleton in one tab and correctly in another, with no way for the operator to tell which was true — and the wrong one reads as authoritative because it sits in the Overview summary. #3969 forbids exactly that second contradictory value.

## Fix

The fallback now yields `PATTERN_NOT_REPORTED` — **the sentinel #5515 already shipped** for the byte-identical fails-open defect in `derivePattern` — and renders as dim italic prose, matching the treatment `TopologyTab.tsx:462-478` gives the same sentinel.

Reusing the constant rather than inventing a second "unknown" string is the substance of the fix, not a detail: #5422 is fundamentally about two surfaces describing one app in two dialects, so a private `'unknown'` here would have re-created the defect in a quieter form.

## Tests — both directions, vacuity-checked

`AppDetail.placement-5422.test.tsx`, 4 cases:

| case | asserts |
|---|---|
| API omits `placement` | renders `not reported`, never contains `singleton`, carries the dim-italic marking |
| API reports `active-hot-standby` | renders verbatim, unmarked |
| API reports `singleton` | renders verbatim, unmarked — the fix must not overcorrect a legitimate server value into a sentinel |
| sentinel identity | the constant is the same one Topology uses, guarding against dialect drift |

**Vacuity proof executed, not asserted:** restoring the `?? 'singleton'` fallback makes case 1 fail with `AssertionError: expected 'singleton' to be 'not reported'` — the live defect string from the issue — and restoring the fix returns 4/4 green.

## Gates

`tsc -b` clean · `npm run build` clean · **53 tests green** across `AppDetail.test.tsx` + the new suite + `placement.test.ts` (no regression in the existing AppDetail lock-in).

## Scope deliberately left

`#5420` (Topology renders declared placement, not effective per-cluster) is the sibling seam in the same family and is a separate change against a different derivation path; next action: address it on its own branch so this fix stays reviewable.

Refs #5422 #3969 #5515

🤖 Generated with [Claude Code](https://claude.com/claude-code)
