### PR TITLE
fix(chart-tests): eliminate the catalog-wide SIGPIPE false-FAIL class — grep -q closes the pipe, echo exits 141, pipefail turns a PASSING assertion into a FAIL (247 sites / 34 scripts)

### DIFF
--- a/platform/cilium/chart/tests/g117-w3d1-hubble-decorative-gate-removed.sh
+++ b/platform/cilium/chart/tests/g117-w3d1-hubble-decorative-gate-removed.sh
@@ -27,7 +27,7 @@ out=$("$helm" template smoke "$chart_dir" "${base_args[@]}" --show-only template
 
 # ── Case 1: decorative annotation is GONE ─────────────────────────────────
 echo "[g117-w3d1-hubble-decorative-gate-removed] Case 1: hubble-ui-auth annotation is gone"
-if echo "$out" | grep -q "catalyst.openova.io/hubble-ui-auth"; then
+if grep -q "catalyst.openova.io/hubble-ui-auth" <<<"$out"; then
   echo "FAIL: misleading hubble-ui-auth annotation still rendered" >&2
   echo "$out" | grep -B1 -A1 "hubble-ui-auth" >&2
   exit 1
@@ -51,7 +51,7 @@ echo "  PASS (auth=$default_auth)"
 
 # ── Case 3: HTTPRoute still renders the canonical hostname ───────────────
 echo "[g117-w3d1-hubble-decorative-gate-removed] Case 3: HTTPRoute still renders hubble.<fqdn> hostname"
-if ! echo "$out" | grep -q '"hubble.smoke.example.com"'; then
+if ! grep -q '"hubble.smoke.example.com"' <<<"$out"; then
   echo "FAIL: HTTPRoute hostname missing or wrong" >&2
   exit 1
 fi

--- a/platform/grafana/chart/tests/httproute-render.sh
+++ b/platform/grafana/chart/tests/httproute-render.sh
@@ -40,7 +40,7 @@ if [ -z "$route_block" ]; then
   echo "(would surface on fresh Sovereign prov as NXDOMAIN for grafana.<fqdn>)"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "grafana.smoke.omani.works"; then
+if ! grep -q "grafana.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: HTTPRoute hostname does not match gateway.host"
   echo "$route_block"
   exit 1
@@ -49,11 +49,11 @@ echo "[bp-grafana] Case 1: PASS"
 
 # ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
 echo "[bp-grafana] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
-if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+if ! grep -q "name: \"cilium-gateway\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+if ! grep -q "namespace: \"kube-system\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
   exit 1
 fi
@@ -62,7 +62,7 @@ echo "[bp-grafana] Case 2: PASS"
 # ── Case 3: default-off path — HTTPRoute absent ───────────────────────
 echo "[bp-grafana] Case 3: default-off path — HTTPRoute not rendered"
 out_default=$("$helm" template smoke "$chart_dir" 2>&1)
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
   exit 1
 fi
@@ -75,11 +75,11 @@ out_override=$("$helm" template smoke "$chart_dir" \
         --set gateway.host=custom.smoke.example 2>&1)
 
 route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+if ! grep -q "custom.smoke.example" <<<"$route_block_override"; then
   echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
   exit 1
 fi
-if echo "$route_block_override" | grep -q "grafana.smoke.omani.works"; then
+if grep -q "grafana.smoke.omani.works" <<<"$route_block_override"; then
   echo "FAIL: explicit override leaked the case-1 hostname"
   exit 1
 fi
@@ -98,12 +98,12 @@ appcr=$("$helm" template smoke "$chart_dir" \
         --set bootstrapOwned.enabled=true \
         --set bootstrapOwned.helmRelease.name=bp-grafana \
         --api-versions apps.openova.io/v1 2>&1)
-if ! echo "$appcr" | grep -qE '^  placement: singleton$'; then
+if ! grep -qE '^  placement: singleton$' <<<"$appcr"; then
   echo "FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')"
   echo "$appcr" | grep -E '^  placement:' || true
   exit 1
 fi
-if echo "$appcr" | grep -qE '^  placement: single-region$'; then
+if grep -qE '^  placement: single-region$' <<<"$appcr"; then
   echo "FAIL: #3375 REGRESSION — Application CR re-introduced the banned 'single-region' placement"
   exit 1
 fi

--- a/platform/grafana/chart/tests/sso-admin-role-mapping.sh
+++ b/platform/grafana/chart/tests/sso-admin-role-mapping.sh
@@ -54,16 +54,16 @@ if [ -z "${role_line}" ]; then
   echo "FAIL: role_attribute_path missing from [auth.generic_oauth]" >&2
   exit 1
 fi
-if ! echo "${role_line}" | grep -q "sovereign-admins"; then
+if ! grep -q "sovereign-admins" <<<"${role_line}"; then
   echo "FAIL: role_attribute_path no longer keys on sovereign-admins: ${role_line}" >&2
   exit 1
 fi
-if ! echo "${role_line}" | grep -q "GrafanaAdmin"; then
+if ! grep -q "GrafanaAdmin" <<<"${role_line}"; then
   echo "FAIL: role_attribute_path must grant 'GrafanaAdmin' (server admin), got: ${role_line}" >&2
   echo "      Org-level 'Admin' leaves the owner without the Administration nav (hw130 founder NS-3 measurement)." >&2
   exit 1
 fi
-if ! echo "${role_line}" | grep -q "Viewer"; then
+if ! grep -q "Viewer" <<<"${role_line}"; then
   echo "FAIL: role_attribute_path lost its non-admin 'Viewer' fallback: ${role_line}" >&2
   exit 1
 fi
@@ -76,7 +76,7 @@ if [ -z "${allow_line}" ]; then
   echo "FAIL: allow_assign_grafana_admin missing — Grafana degrades GrafanaAdmin to org Admin" >&2
   exit 1
 fi
-if ! echo "${allow_line}" | grep -qiE "allow_assign_grafana_admin *= *true"; then
+if ! grep -qiE "allow_assign_grafana_admin *= *true" <<<"${allow_line}"; then
   echo "FAIL: allow_assign_grafana_admin must be true, got: ${allow_line}" >&2
   exit 1
 fi

--- a/platform/guacamole/chart/tests/g117-w3d1-sso-secret.sh
+++ b/platform/guacamole/chart/tests/g117-w3d1-sso-secret.sh
@@ -42,7 +42,7 @@ base_args=(
 # ── Case 1: kc_idp_hint appended ──────────────────────────────────────────
 echo "[g117-w3d1-sso-secret] Case 1: OPENID_AUTHORIZATION_ENDPOINT carries kc_idp_hint=catalyst-pin"
 out_default=$("$helm" template smoke "$chart_dir" "${base_args[@]}" 2>/dev/null)
-if ! echo "$out_default" | grep -qE 'value:.*openid-connect/auth\?kc_idp_hint=catalyst-pin'; then
+if ! grep -qE 'value:.*openid-connect/auth\?kc_idp_hint=catalyst-pin' <<<"$out_default"; then
   echo "FAIL: OPENID_AUTHORIZATION_ENDPOINT does NOT contain ?kc_idp_hint=catalyst-pin" >&2
   echo "$out_default" | grep -A1 OPENID_AUTHORIZATION_ENDPOINT | head -5 >&2
   exit 1
@@ -66,7 +66,7 @@ echo "  PASS"
 
 # ── Case 2: divergent realm-patch ConfigMap REMOVED ───────────────────────
 echo "[g117-w3d1-sso-secret] Case 2: bp-guacamole-realm-patch ConfigMap is gone"
-if echo "$out_default" | grep -q "name: bp-guacamole-realm-patch"; then
+if grep -q "name: bp-guacamole-realm-patch" <<<"$out_default"; then
   echo "FAIL: divergent realm-patch ConfigMap still rendering (template not deleted?)" >&2
   exit 1
 fi
@@ -87,7 +87,7 @@ if [ -z "$got_secret" ]; then
   echo "FAIL: Secret guacamole-oidc did not render in default chartManagedSecret=ON mode" >&2
   exit 1
 fi
-if ! echo "$got_secret" | grep -q "resource-policy=keep"; then
+if ! grep -q "resource-policy=keep" <<<"$got_secret"; then
   echo "FAIL: Secret guacamole-oidc missing helm.sh/resource-policy: keep" >&2
   echo "Got: $got_secret" >&2
   exit 1
@@ -96,11 +96,11 @@ echo "  PASS"
 
 # ── Case 3b: chartManagedSecret default ON → SealedSecret + Job NOT rendered
 echo "[g117-w3d1-sso-secret] Case 3b: default ON does not render SealedSecret nor legacy bootstrap Job"
-if echo "$out_default" | grep -q "^kind: SealedSecret"; then
+if grep -q "^kind: SealedSecret" <<<"$out_default"; then
   echo "FAIL: SealedSecret rendered in default chartManagedSecret=ON mode (gating broken)" >&2
   exit 1
 fi
-if echo "$out_default" | grep -q "name: bp-guacamole-oidc-bootstrap"; then
+if grep -q "name: bp-guacamole-oidc-bootstrap" <<<"$out_default"; then
   echo "FAIL: legacy bootstrap Job rendered in default chartManagedSecret=ON mode" >&2
   exit 1
 fi
@@ -109,11 +109,11 @@ echo "  PASS"
 # ── Case 4a: chartManagedSecret=false → SealedSecret renders ──────────────
 echo "[g117-w3d1-sso-secret] Case 4a: chartManagedSecret=false renders the SealedSecret + Job back-compat path"
 out_off=$("$helm" template smoke "$chart_dir" "${base_args[@]}" --set guacamole.oidc.chartManagedSecret=false 2>/dev/null)
-if ! echo "$out_off" | grep -q "^kind: SealedSecret"; then
+if ! grep -q "^kind: SealedSecret" <<<"$out_off"; then
   echo "FAIL: SealedSecret did not render when chartManagedSecret=false" >&2
   exit 1
 fi
-if ! echo "$out_off" | grep -q "name: bp-guacamole-oidc-bootstrap"; then
+if ! grep -q "name: bp-guacamole-oidc-bootstrap" <<<"$out_off"; then
   echo "FAIL: legacy bootstrap Job did not render when chartManagedSecret=false" >&2
   exit 1
 fi

--- a/platform/guacamole/chart/tests/httproute-render.sh
+++ b/platform/guacamole/chart/tests/httproute-render.sh
@@ -38,7 +38,7 @@ if [ -z "$route_block" ]; then
   echo "FAIL: HTTPRoute did not render"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "guac.smoke.omani.works"; then
+if ! grep -q "guac.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: hostname not propagated"
   exit 1
 fi
@@ -46,11 +46,11 @@ echo "[bp-guacamole] Case 1: PASS"
 
 # Case 2
 echo "[bp-guacamole] Case 2: parentRefs cite cilium-gateway / kube-system"
-if ! echo "$route_block" | grep -q "name: cilium-gateway"; then
+if ! grep -q "name: cilium-gateway" <<<"$route_block"; then
   echo "FAIL: parentRef name != cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "namespace: kube-system"; then
+if ! grep -q "namespace: kube-system" <<<"$route_block"; then
   echo "FAIL: parentRef namespace != kube-system"
   exit 1
 fi
@@ -59,7 +59,7 @@ echo "[bp-guacamole] Case 2: PASS"
 # Case 3
 echo "[bp-guacamole] Case 3: default-off (guacamole.enabled=false) — HTTPRoute absent"
 out_default=$("$helm" template smoke "$chart_dir" 2>&1)
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render with guacamole.enabled=false"
   exit 1
 fi
@@ -72,7 +72,7 @@ out_empty=$("$helm" template smoke "$chart_dir" \
   --set guacamole.enabled=true \
   --set guacamole.sso.mode=openid \
   --set guacamole.oidc.issuer=https://keycloak.smoke.omani.works/realms/ops 2>&1 || true)
-if ! echo "$out_empty" | grep -q "hostname is empty"; then
+if ! grep -q "hostname is empty" <<<"$out_empty"; then
   echo "FAIL: bp-guacamole.host should hard-fail when hostname empty"
   echo "$out_empty" | tail -5
   exit 1
@@ -93,12 +93,12 @@ appcr=$("$helm" template smoke "$chart_dir" \
         --set bootstrapOwned.enabled=true \
         --set bootstrapOwned.helmRelease.name=bp-guacamole \
         --api-versions apps.openova.io/v1 2>&1)
-if ! echo "$appcr" | grep -qE '^  placement: singleton$'; then
+if ! grep -qE '^  placement: singleton$' <<<"$appcr"; then
   echo "FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')"
   echo "$appcr" | grep -E '^  placement:' || true
   exit 1
 fi
-if echo "$appcr" | grep -qE '^  placement: single-region$'; then
+if grep -qE '^  placement: single-region$' <<<"$appcr"; then
   echo "FAIL: #3375 REGRESSION — Application CR re-introduced the banned 'single-region' placement"
   exit 1
 fi
@@ -115,7 +115,7 @@ out_header=$("$helm" template smoke "$chart_dir" \
   --set guacamole.enabled=true \
   --set guacamole.httproute.enabled=true \
   --set guacamole.httproute.hostname=guac.smoke.omani.works 2>&1)
-if echo "$out_header" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_header"; then
   echo "FAIL: header mode rendered a direct HTTPRoute (gate owns the hostname)"
   exit 1
 fi

--- a/platform/harbor/chart/tests/httproute-render.sh
+++ b/platform/harbor/chart/tests/httproute-render.sh
@@ -40,7 +40,7 @@ if [ -z "$route_block" ]; then
   echo "(would surface on fresh Sovereign prov as NXDOMAIN for harbor.<fqdn>)"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "harbor.smoke.omani.works"; then
+if ! grep -q "harbor.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: HTTPRoute hostname does not match gateway.host"
   echo "$route_block"
   exit 1
@@ -49,11 +49,11 @@ echo "[bp-harbor] Case 1: PASS"
 
 # ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
 echo "[bp-harbor] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
-if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+if ! grep -q "name: \"cilium-gateway\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+if ! grep -q "namespace: \"kube-system\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
   exit 1
 fi
@@ -62,7 +62,7 @@ echo "[bp-harbor] Case 2: PASS"
 # ── Case 3: default-off path — HTTPRoute absent ───────────────────────
 echo "[bp-harbor] Case 3: default-off path — HTTPRoute not rendered"
 out_default=$("$helm" template smoke "$chart_dir" 2>&1)
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
   exit 1
 fi
@@ -75,11 +75,11 @@ out_override=$("$helm" template smoke "$chart_dir" \
         --set gateway.host=custom.smoke.example 2>&1)
 
 route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+if ! grep -q "custom.smoke.example" <<<"$route_block_override"; then
   echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
   exit 1
 fi
-if echo "$route_block_override" | grep -q "harbor.smoke.omani.works"; then
+if grep -q "harbor.smoke.omani.works" <<<"$route_block_override"; then
   echo "FAIL: explicit override leaked the case-1 hostname"
   exit 1
 fi
@@ -98,12 +98,12 @@ appcr=$("$helm" template smoke "$chart_dir" \
         --set bootstrapOwned.enabled=true \
         --set bootstrapOwned.helmRelease.name=bp-harbor \
         --api-versions apps.openova.io/v1 2>&1)
-if ! echo "$appcr" | grep -qE '^  placement: singleton$'; then
+if ! grep -qE '^  placement: singleton$' <<<"$appcr"; then
   echo "FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')"
   echo "$appcr" | grep -E '^  placement:' || true
   exit 1
 fi
-if echo "$appcr" | grep -qE '^  placement: single-region$'; then
+if grep -qE '^  placement: single-region$' <<<"$appcr"; then
   echo "FAIL: #3375 REGRESSION — Application CR re-introduced the banned 'single-region' placement"
   exit 1
 fi
@@ -122,18 +122,18 @@ out_alias=$("$helm" template smoke "$chart_dir" \
         --set gateway.enabled=true \
         --set gateway.host=registry.smoke.omani.works 2>&1)
 route_block_alias=$(echo "$out_alias" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if ! echo "$route_block_alias" | grep -q "registry.smoke.omani.works"; then
+if ! grep -q "registry.smoke.omani.works" <<<"$route_block_alias"; then
   echo "FAIL: canonical gateway.host missing from HTTPRoute hostnames"
   echo "$route_block_alias"
   exit 1
 fi
-if ! echo "$route_block_alias" | grep -q "harbor.smoke.omani.works"; then
+if ! grep -q "harbor.smoke.omani.works" <<<"$route_block_alias"; then
   echo "FAIL: #4913 REGRESSION — harbor.<fqdn> alias NOT added (bare-envoy 404 returns)"
   echo "$route_block_alias"
   exit 1
 fi
 # The sign-in redirect must stay on the canonical registry host (loop-safety).
-if ! echo "$route_block_alias" | grep -q "hostname: \"registry.smoke.omani.works\""; then
+if ! grep -q "hostname: \"registry.smoke.omani.works\"" <<<"$route_block_alias"; then
   echo "FAIL: sign-in RequestRedirect hostname must stay canonical registry.<fqdn>"
   exit 1
 fi
@@ -143,7 +143,7 @@ out_noalias=$("$helm" template smoke "$chart_dir" \
         --set gateway.host=registry.smoke.omani.works \
         --set gateway.aliasHarborHost=false 2>&1)
 route_block_noalias=$(echo "$out_noalias" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if echo "$route_block_noalias" | grep -q "harbor.smoke.omani.works"; then
+if grep -q "harbor.smoke.omani.works" <<<"$route_block_noalias"; then
   echo "FAIL: gateway.aliasHarborHost=false should NOT emit the harbor.<fqdn> alias"
   exit 1
 fi

--- a/platform/keycloak/chart/tests/frontend-url-pin.sh
+++ b/platform/keycloak/chart/tests/frontend-url-pin.sh
@@ -47,7 +47,7 @@ cm_block=$(echo "$out" | awk -v n="$cm_name" '
 
 # ── Case 1: PUBLIC https KC_HOSTNAME present ──────────────────────────
 echo "[bp-keycloak] Case 1: ConfigMap carries the public https KC_HOSTNAME"
-if ! echo "$cm_block" | grep -q "KC_HOSTNAME: \"https://${host}\""; then
+if ! grep -q "KC_HOSTNAME: \"https://${host}\"" <<<"$cm_block"; then
   echo "FAIL: ${cm_name} did not carry KC_HOSTNAME=https://${host}"
   echo "(without the public frontend pin, gitea 307s the browser to the"
   echo " in-cluster keycloak.keycloak.svc.cluster.local issuer — hw126 FAIL)"
@@ -58,7 +58,7 @@ echo "[bp-keycloak] Case 1: PASS"
 
 # ── Case 2: backchannel stays request-Host dynamic ────────────────────
 echo "[bp-keycloak] Case 2: KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true present"
-if ! echo "$cm_block" | grep -q 'KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"'; then
+if ! grep -q 'KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"' <<<"$cm_block"; then
   echo "FAIL: backchannel-dynamic not set true — token/userinfo would be"
   echo "forced through the public host (no in-cluster hairpin support)"
   echo "$cm_block"
@@ -68,7 +68,7 @@ echo "[bp-keycloak] Case 2: PASS"
 
 # ── Case 3: KC_HOSTNAME is never the in-cluster service DNS ───────────
 echo "[bp-keycloak] Case 3: KC_HOSTNAME never points at the in-cluster service"
-if echo "$cm_block" | grep -q "keycloak.keycloak.svc.cluster.local"; then
+if grep -q "keycloak.keycloak.svc.cluster.local" <<<"$cm_block"; then
   echo "FAIL: frontend KC_HOSTNAME leaked the in-cluster svc DNS — this is"
   echo "the exact hw126 chrome-error symptom the pin exists to prevent"
   echo "$cm_block"
@@ -83,7 +83,7 @@ sts_block=$(echo "$out" | awk '
   /^kind: StatefulSet$/{inblock=1}
   inblock{print}
 ')
-if ! echo "$sts_block" | grep -q "name: ${cm_name}"; then
+if ! grep -q "name: ${cm_name}" <<<"$sts_block"; then
   echo "FAIL: keycloak StatefulSet does not reference ${cm_name} (extraEnvVarsCM"
   echo "not wired) — the frontend pin would never reach the KC container"
   exit 1
@@ -104,7 +104,7 @@ if [ -z "$cm_default" ]; then
   echo "CreateContainerConfigError)"
   exit 1
 fi
-if echo "$cm_default" | grep -q "KC_HOSTNAME"; then
+if grep -q "KC_HOSTNAME" <<<"$cm_default"; then
   echo "FAIL: KC_HOSTNAME set with no gateway.host — must stay hostname-dynamic"
   echo "for non-Catalyst standalone installs"
   echo "$cm_default"

--- a/platform/keycloak/chart/tests/g117-5-tier1-sso-clients.sh
+++ b/platform/keycloak/chart/tests/g117-5-tier1-sso-clients.sh
@@ -59,7 +59,7 @@ d = json.load(sys.stdin)
 print(' '.join(c['clientId'] for c in d.get('clients', [])))
 ")
 for cid in "${expected[@]}"; do
-  if ! echo " $actual " | grep -q " $cid "; then
+  if ! grep -q " $cid " <<<" $actual "; then
     echo "FAIL: Tier-1 clientId '$cid' missing from realm import (got: $actual)" >&2
     exit 1
   fi
@@ -79,7 +79,7 @@ for c in d.get('clients', []):
         print(' | '.join(c.get('redirectUris', [])))
         break
 ")
-  if ! echo "$actual_uris" | grep -qF "$want_uri"; then
+  if ! grep -qF "$want_uri" <<<"$actual_uris"; then
     echo "FAIL: client '$cid' redirectUris missing '$want_uri' (got: $actual_uris)" >&2
     exit 1
   fi

--- a/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
+++ b/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
@@ -53,7 +53,7 @@ d = json.load(sys.stdin)
 print(' '.join(c['clientId'] for c in d.get('clients', [])))
 ")
 for cid in "${expected[@]}"; do
-  if ! echo " $actual " | grep -q " $cid "; then
+  if ! grep -q " $cid " <<<" $actual "; then
     echo "FAIL: Tier-2 clientId '$cid' missing from realm import (got: $actual)" >&2
     exit 1
   fi
@@ -73,7 +73,7 @@ for c in d.get('clients', []):
         print(' | '.join(c.get('redirectUris', [])))
         break
 ")
-  if ! echo "$actual_uris" | grep -qF "$want_uri"; then
+  if ! grep -qF "$want_uri" <<<"$actual_uris"; then
     echo "FAIL: client '$cid' redirectUris missing '$want_uri' (got: $actual_uris)" >&2
     exit 1
   fi

--- a/platform/keycloak/chart/tests/httproute-render.sh
+++ b/platform/keycloak/chart/tests/httproute-render.sh
@@ -40,7 +40,7 @@ if [ -z "$route_block" ]; then
   echo "(would surface on fresh Sovereign prov as NXDOMAIN for keycloak.<fqdn>)"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "keycloak.smoke.omani.works"; then
+if ! grep -q "keycloak.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: HTTPRoute hostname does not match gateway.host"
   echo "$route_block"
   exit 1
@@ -49,11 +49,11 @@ echo "[bp-keycloak] Case 1: PASS"
 
 # ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
 echo "[bp-keycloak] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
-if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+if ! grep -q "name: \"cilium-gateway\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+if ! grep -q "namespace: \"kube-system\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
   exit 1
 fi
@@ -62,7 +62,7 @@ echo "[bp-keycloak] Case 2: PASS"
 # ── Case 3: default-off path — HTTPRoute absent ───────────────────────
 echo "[bp-keycloak] Case 3: default-off path — HTTPRoute not rendered"
 out_default=$("$helm" template smoke "$chart_dir" 2>&1)
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
   exit 1
 fi
@@ -75,11 +75,11 @@ out_override=$("$helm" template smoke "$chart_dir" \
         --set gateway.host=custom.smoke.example 2>&1)
 
 route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+if ! grep -q "custom.smoke.example" <<<"$route_block_override"; then
   echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
   exit 1
 fi
-if echo "$route_block_override" | grep -q "keycloak.smoke.omani.works"; then
+if grep -q "keycloak.smoke.omani.works" <<<"$route_block_override"; then
   echo "FAIL: explicit override leaked the case-1 hostname"
   exit 1
 fi
@@ -98,12 +98,12 @@ appcr=$("$helm" template smoke "$chart_dir" \
         --set bootstrapOwned.enabled=true \
         --set bootstrapOwned.helmRelease.name=bp-keycloak \
         --api-versions apps.openova.io/v1 2>&1)
-if ! echo "$appcr" | grep -qE '^  placement: singleton$'; then
+if ! grep -qE '^  placement: singleton$' <<<"$appcr"; then
   echo "FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')"
   echo "$appcr" | grep -E '^  placement:' || true
   exit 1
 fi
-if echo "$appcr" | grep -qE '^  placement: single-region$'; then
+if grep -qE '^  placement: single-region$' <<<"$appcr"; then
   echo "FAIL: #3375 REGRESSION — Application CR re-introduced the banned 'single-region' placement"
   exit 1
 fi

--- a/platform/newapi/chart/tests/admin-token-pushsecret-render.sh
+++ b/platform/newapi/chart/tests/admin-token-pushsecret-render.sh
@@ -61,27 +61,27 @@ api_versions="external-secrets.io/v1alpha1"
 # ── Case 1: capability-enabled render — PushSecret present + correct ─────
 echo "[bp-newapi] Case 1: PushSecret renders with the read-path's remote contract"
 out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" --api-versions "$api_versions" 2>&1)
-echo "$out" | grep -q "kind: PushSecret" || {
+grep -q "kind: PushSecret" <<<"$out" || {
   echo "FAIL: no PushSecret rendered with external-secrets.io/v1alpha1 capability present"; exit 1; }
-echo "$out" | grep -q 'remoteKey: "catalyst/newapi/admin-token"' || {
+grep -q 'remoteKey: "catalyst/newapi/admin-token"' <<<"$out" || {
   echo "FAIL: PushSecret remoteKey does not match the ExternalSecret read path"; exit 1; }
-echo "$out" | grep -q 'property: "ADMIN_API_TOKEN"' || {
+grep -q 'property: "ADMIN_API_TOKEN"' <<<"$out" || {
   echo "FAIL: PushSecret property is not ADMIN_API_TOKEN"; exit 1; }
-echo "$out" | grep -q 'name: "vault-region1"' || {
+grep -q 'name: "vault-region1"' <<<"$out" || {
   echo "FAIL: PushSecret does not target the vault-region1 ClusterSecretStore default"; exit 1; }
-echo "$out" | grep -q 'secretKey: "ADMIN_SECRET"' || {
+grep -q 'secretKey: "ADMIN_SECRET"' <<<"$out" || {
   echo "FAIL: PushSecret does not push the bridge ADMIN_SECRET"; exit 1; }
 # fullname for release `smoke` + chart bp-newapi = smoke-bp-newapi.
-echo "$out" | grep -q 'name: "smoke-bp-newapi-token-signing-key"' || {
+grep -q 'name: "smoke-bp-newapi-token-signing-key"' <<<"$out" || {
   echo "FAIL: PushSecret selector does not name the chart's auto-provisioned token-signing-key Secret"; exit 1; }
-echo "$out" | grep -q 'deletionPolicy: None' || {
+grep -q 'deletionPolicy: None' <<<"$out" || {
   echo "FAIL: PushSecret deletionPolicy must be None (remote path is durable state)"; exit 1; }
 echo "  ok"
 
 # ── Case 2: CRD absent — no PushSecret ───────────────────────────────────
 echo "[bp-newapi] Case 2: no PushSecret without the v1alpha1 capability (cold-install safety)"
 out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" 2>&1)
-if echo "$out" | grep -q "kind: PushSecret"; then
+if grep -q "kind: PushSecret" <<<"$out"; then
   echo "FAIL: PushSecret rendered without the external-secrets.io/v1alpha1 CRD registered"; exit 1
 fi
 echo "  ok"
@@ -91,7 +91,7 @@ echo "[bp-newapi] Case 3: catalystIntegration.pushSecret.enabled=false suppresse
 out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" \
   --set catalystIntegration.pushSecret.enabled=false \
   --api-versions "$api_versions" 2>&1)
-if echo "$out" | grep -q "kind: PushSecret"; then
+if grep -q "kind: PushSecret" <<<"$out"; then
   echo "FAIL: PushSecret rendered despite pushSecret.enabled=false"; exit 1
 fi
 echo "  ok"
@@ -101,7 +101,7 @@ echo "[bp-newapi] Case 4: sandboxTokenSigningKey.existingSecret overrides the se
 out=$("$helm" template smoke "$chart_dir" -f "$overlay_values" \
   --set sandboxTokenSigningKey.existingSecret=operator-signing-key \
   --api-versions "$api_versions" 2>&1)
-echo "$out" | grep -q 'name: "operator-signing-key"' || {
+grep -q 'name: "operator-signing-key"' <<<"$out" || {
   echo "FAIL: PushSecret selector does not follow sandboxTokenSigningKey.existingSecret"; exit 1; }
 echo "  ok"
 
@@ -115,7 +115,7 @@ if out=$("$helm" template smoke "$chart_dir" \
   --api-versions "$api_versions" 2>&1); then
   echo "FAIL: render succeeded with pushSecret enabled but remoteRef.key empty"; exit 1
 fi
-echo "$out" | grep -q "remoteRef.key is empty" || {
+grep -q "remoteRef.key is empty" <<<"$out" || {
   echo "FAIL: render failed but not with the expected remoteRef.key guidance"; exit 1; }
 echo "  ok"
 

--- a/platform/newapi/chart/tests/bridge-readiness-render.sh
+++ b/platform/newapi/chart/tests/bridge-readiness-render.sh
@@ -83,7 +83,7 @@ if [ -z "$bridge_init" ]; then
   echo "--- initContainers ---"; echo "$init_block"
   exit 1
 fi
-if ! echo "$bridge_init" | grep -q "restartPolicy: Always"; then
+if ! grep -q "restartPolicy: Always" <<<"$bridge_init"; then
   echo "FAIL: native-sidecar bridge missing restartPolicy: Always (KEP-753 native sidecar)"
   exit 1
 fi
@@ -98,11 +98,11 @@ if [ -z "$bridge_ready" ]; then
   echo "FAIL: native-sidecar bridge has no readinessProbe"
   exit 1
 fi
-if ! echo "$bridge_ready" | grep -q "path: /healthz"; then
+if ! grep -q "path: /healthz" <<<"$bridge_ready"; then
   echo "FAIL: bridge readinessProbe path is not /healthz"
   exit 1
 fi
-if ! echo "$bridge_ready" | grep -q "port: 8080"; then
+if ! grep -q "port: 8080" <<<"$bridge_ready"; then
   echo "FAIL: bridge readinessProbe port is not the bridge port 8080"
   exit 1
 fi
@@ -116,7 +116,7 @@ if [ -n "$dsn_line" ] && [ "$bridge_line" -ge "$dsn_line" ]; then
 fi
 # It must NOT also appear as a plain container (no duplication).
 containers_only=$(echo "$dep" | awk '/^      containers:/{f=1} f' | awk '/^      volumes:/{exit} {print}')
-if echo "$containers_only" | grep -q "name: sandbox-bridge"; then
+if grep -q "name: sandbox-bridge" <<<"$containers_only"; then
   echo "FAIL: sandbox-bridge duplicated as a plain container while native sidecar is on"
   exit 1
 fi
@@ -129,12 +129,12 @@ if [ -z "$bridge_svc" ]; then
   echo "FAIL: dedicated bridge-only Service <fullname>-bridge did not render"
   exit 1
 fi
-if ! echo "$bridge_svc" | grep -q "publishNotReadyAddresses: true"; then
+if ! grep -q "publishNotReadyAddresses: true" <<<"$bridge_svc"; then
   echo "FAIL: bridge-only Service missing publishNotReadyAddresses: true"
   echo "--- bridge service ---"; echo "$bridge_svc"
   exit 1
 fi
-if ! echo "$bridge_svc" | grep -q "port: 8080"; then
+if ! grep -q "port: 8080" <<<"$bridge_svc"; then
   echo "FAIL: bridge-only Service does not expose the bridge port 8080"
   exit 1
 fi
@@ -152,7 +152,7 @@ exact_backend=$(echo "$httproute" | awk '
   /type: Exact/{e=1}
   e && /name: /{print; e=0}
 ')
-if ! echo "$exact_backend" | grep -q "smoke-bp-newapi-bridge"; then
+if ! grep -q "smoke-bp-newapi-bridge" <<<"$exact_backend"; then
   echo "FAIL: Exact / rule does not backendRef the bridge-only Service smoke-bp-newapi-bridge"
   echo "--- Exact backendRef ---"; echo "$exact_backend"
   echo "--- httproute rules ---"; echo "$httproute" | awk '/rules:/{f=1} f'
@@ -181,12 +181,12 @@ dep2=$(echo "$out2" | awk '/^kind: Deployment$/{f=1} f&&/^kind: /&&!/^kind: Depl
 
 # In opt-out mode the bridge must be a PLAIN container, never a native sidecar.
 init_block2=$(echo "$dep2" | awk '/initContainers:/{f=1} f&&/^      containers:/{f=0} f')
-if echo "$init_block2" | grep -q "name: sandbox-bridge"; then
+if grep -q "name: sandbox-bridge" <<<"$init_block2"; then
   echo "FAIL: nativeSidecar=false but bridge still rendered as a native sidecar (default-true-bool coercion bug?)"
   exit 1
 fi
 containers2=$(echo "$dep2" | awk '/^      containers:/{f=1} f' | awk '/^      volumes:/{exit} {print}')
-if ! echo "$containers2" | grep -q "name: sandbox-bridge"; then
+if ! grep -q "name: sandbox-bridge" <<<"$containers2"; then
   echo "FAIL: nativeSidecar=false but bridge not present as a plain container"
   exit 1
 fi

--- a/platform/newapi/chart/tests/dsn-secret-preserve-render.sh
+++ b/platform/newapi/chart/tests/dsn-secret-preserve-render.sh
@@ -76,23 +76,23 @@ if [ -z "$secret_block" ]; then
   echo "FAIL: DSN placeholder Secret did not render"
   exit 1
 fi
-if ! echo "$secret_block" | grep -q "name: ${dsn_secret_name}"; then
+if ! grep -q "name: ${dsn_secret_name}" <<<"$secret_block"; then
   echo "FAIL: rendered Secret is not the expected ${dsn_secret_name}"
   echo "$secret_block" | grep "name:" | head -1
   exit 1
 fi
-if ! echo "$secret_block" | grep -q "helm.sh/resource-policy: keep"; then
+if ! grep -q "helm.sh/resource-policy: keep" <<<"$secret_block"; then
   echo "FAIL: DSN Secret missing 'helm.sh/resource-policy: keep' — it will be"
   echo "      clobbered to empty on the next render and CrashLoop the data plane"
   exit 1
 fi
-if ! echo "$secret_block" | grep -qE '^[[:space:]]*SQL_DSN:'; then
+if ! grep -qE '^[[:space:]]*SQL_DSN:' <<<"$secret_block"; then
   echo "FAIL: DSN Secret has no SQL_DSN key"
   exit 1
 fi
 # First-install render (no existing Secret in a dry-run) must be the empty
 # placeholder so kubelet does not trip CreateContainerConfigError.
-if ! echo "$secret_block" | grep -qE '^[[:space:]]*SQL_DSN:[[:space:]]*""[[:space:]]*$'; then
+if ! grep -qE '^[[:space:]]*SQL_DSN:[[:space:]]*""[[:space:]]*$' <<<"$secret_block"; then
   echo "FAIL: first-install/dry-run SQL_DSN should be the empty placeholder"
   exit 1
 fi
@@ -102,12 +102,12 @@ echo "[bp-newapi] Case 1+2: PASS"
 echo "[bp-newapi] Case 3: wait-for-sql-dsn gate + Deployment env target the preserved Secret"
 full=$("$helm" template "$release" "$chart_dir" -f "$common_values" "${api_flag[@]}" 2>&1)
 
-if ! echo "$full" | grep -q "name: wait-for-sql-dsn"; then
+if ! grep -q "name: wait-for-sql-dsn" <<<"$full"; then
   echo "FAIL: wait-for-sql-dsn initContainer did not render"
   exit 1
 fi
 gate_vol=$(echo "$full" | awk '/name: sql-dsn-gate/{f=1} f&&/secretName:/{print; exit}')
-if ! echo "$gate_vol" | grep -q "secretName: ${dsn_secret_name}"; then
+if ! grep -q "secretName: ${dsn_secret_name}" <<<"$gate_vol"; then
   echo "FAIL: sql-dsn-gate volume does not mount ${dsn_secret_name}"
   echo "      (got: ${gate_vol})"
   exit 1
@@ -138,7 +138,7 @@ EOF
 # "could not find template" — that is the PASS signal here.
 if vc_out=$("$helm" template "$release" "$chart_dir" -f "$vc_values" "${api_flag[@]}" \
      --show-only templates/cnpg-cluster.yaml 2>&1); then
-  if echo "$vc_out" | grep -q "${dsn_secret_name}"; then
+  if grep -q "${dsn_secret_name}" <<<"$vc_out"; then
     echo "FAIL: vcluster-app should NOT render the host-side DSN Secret"
     rm -f "$vc_values"
     exit 1

--- a/platform/newapi/chart/tests/httproute-render.sh
+++ b/platform/newapi/chart/tests/httproute-render.sh
@@ -65,7 +65,7 @@ if [ -z "$route_block" ]; then
   echo "(would surface on fresh Sovereign prov as NXDOMAIN for newapi.<fqdn> — exactly the #2421 symptom)"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "newapi.smoke.omani.works"; then
+if ! grep -q "newapi.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: HTTPRoute hostname is not derived as 'newapi.<sovereignFQDN>'"
   echo "$route_block"
   exit 1
@@ -74,11 +74,11 @@ echo "[bp-newapi] Case 1: PASS"
 
 # ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
 echo "[bp-newapi] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
-if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+if ! grep -q "name: \"cilium-gateway\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+if ! grep -q "namespace: \"kube-system\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
   exit 1
 fi
@@ -86,7 +86,7 @@ echo "[bp-newapi] Case 2: PASS"
 
 # ── Case 3: backendRefs point at bp-newapi Service ────────────────────
 echo "[bp-newapi] Case 3: backendRefs point at bp-newapi Service"
-if ! echo "$route_block" | grep -q "smoke-bp-newapi"; then
+if ! grep -q "smoke-bp-newapi" <<<"$route_block"; then
   echo "FAIL: HTTPRoute backendRefs name does not match include 'bp-newapi.fullname'"
   exit 1
 fi
@@ -105,7 +105,7 @@ EOF
 out_default=$("$helm" template smoke "$chart_dir" -f "$default_values" 2>&1)
 rm -f "$default_values"
 
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render when httpRoute.enabled is unset (default)"
   exit 1
 fi
@@ -131,11 +131,11 @@ out_override=$("$helm" template smoke "$chart_dir" -f "$override_values" 2>&1)
 rm -f "$override_values"
 
 route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if ! echo "$route_block_override" | grep -q "llm.smoke.omani.works"; then
+if ! grep -q "llm.smoke.omani.works" <<<"$route_block_override"; then
   echo "FAIL: explicit httpRoute.host override not propagated to HTTPRoute hostnames"
   exit 1
 fi
-if echo "$route_block_override" | grep -q "newapi.smoke.omani.works"; then
+if grep -q "newapi.smoke.omani.works" <<<"$route_block_override"; then
   echo "FAIL: explicit override leaked the derived 'newapi.<fqdn>' default"
   exit 1
 fi
@@ -166,12 +166,12 @@ EOF
 appcr=$("$helm" template smoke "$chart_dir" -f "$appcr_values" \
         --api-versions apps.openova.io/v1 2>&1)
 rm -f "$appcr_values"
-if ! echo "$appcr" | grep -qE '^  placement: singleton$'; then
+if ! grep -qE '^  placement: singleton$' <<<"$appcr"; then
   echo "FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')"
   echo "$appcr" | grep -E '^  placement:' || true
   exit 1
 fi
-if echo "$appcr" | grep -qE '^  placement: single-region$'; then
+if grep -qE '^  placement: single-region$' <<<"$appcr"; then
   echo "FAIL: #3375 REGRESSION — Application CR re-introduced the banned 'single-region' placement"
   exit 1
 fi

--- a/platform/newapi/chart/tests/imagepullsecrets-render.sh
+++ b/platform/newapi/chart/tests/imagepullsecrets-render.sh
@@ -54,11 +54,11 @@ if [ -z "$deployment_block" ]; then
   exit 1
 fi
 
-if ! echo "$deployment_block" | grep -q "imagePullSecrets:"; then
+if ! grep -q "imagePullSecrets:" <<<"$deployment_block"; then
   echo "FAIL: Deployment has no imagePullSecrets block"
   exit 1
 fi
-if ! echo "$deployment_block" | grep -q "name: ghcr-pull"; then
+if ! grep -q "name: ghcr-pull" <<<"$deployment_block"; then
   echo "FAIL: Deployment imagePullSecrets does not reference ghcr-pull"
   exit 1
 fi
@@ -91,11 +91,11 @@ if [ -z "$job_block" ]; then
   echo "FAIL: channel-seed Job did not render with default channel enabled"
   exit 1
 fi
-if ! echo "$job_block" | grep -q "imagePullSecrets:"; then
+if ! grep -q "imagePullSecrets:" <<<"$job_block"; then
   echo "FAIL: channel-seed Job has no imagePullSecrets block"
   exit 1
 fi
-if ! echo "$job_block" | grep -q "name: ghcr-pull"; then
+if ! grep -q "name: ghcr-pull" <<<"$job_block"; then
   echo "FAIL: channel-seed Job imagePullSecrets does not reference ghcr-pull"
   exit 1
 fi
@@ -120,7 +120,7 @@ if [ -z "$deployment_block3" ]; then
   echo "FAIL: Deployment did not render with empty imagePullSecrets"
   exit 1
 fi
-if echo "$deployment_block3" | grep -q "imagePullSecrets:"; then
+if grep -q "imagePullSecrets:" <<<"$deployment_block3"; then
   echo "FAIL: empty override should suppress imagePullSecrets block (Inviolable Principle #4)"
   exit 1
 fi
@@ -142,11 +142,11 @@ out4=$("$helm" template smoke "$chart_dir" -f "$custom_values" 2>&1)
 rm -f "$custom_values"
 
 deployment_block4=$(echo "$out4" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
-if ! echo "$deployment_block4" | grep -q "name: my-private-registry-creds"; then
+if ! grep -q "name: my-private-registry-creds" <<<"$deployment_block4"; then
   echo "FAIL: custom imagePullSecret name not propagated to Deployment"
   exit 1
 fi
-if echo "$deployment_block4" | grep -q "name: ghcr-pull"; then
+if grep -q "name: ghcr-pull" <<<"$deployment_block4"; then
   echo "FAIL: custom override leaked default ghcr-pull reference"
   exit 1
 fi

--- a/platform/newapi/chart/tests/startup-probe-render.sh
+++ b/platform/newapi/chart/tests/startup-probe-render.sh
@@ -63,7 +63,7 @@ if [ -z "$newapi_container" ]; then
   exit 1
 fi
 
-if ! echo "$newapi_container" | grep -q "startupProbe:"; then
+if ! grep -q "startupProbe:" <<<"$newapi_container"; then
   echo "FAIL: newapi container has no startupProbe block"
   echo "--- newapi container ---"
   echo "$newapi_container"
@@ -82,26 +82,26 @@ if [ -z "$startup_block" ]; then
   echo "FAIL: could not extract startupProbe block from newapi container"
   exit 1
 fi
-if ! echo "$startup_block" | grep -q "failureThreshold: 30"; then
+if ! grep -q "failureThreshold: 30" <<<"$startup_block"; then
   echo "FAIL: startupProbe failureThreshold is not 30 (5-minute budget for GORM AutoMigrate)"
   echo "--- startupProbe block ---"
   echo "$startup_block"
   exit 1
 fi
-if ! echo "$startup_block" | grep -q "periodSeconds: 10"; then
+if ! grep -q "periodSeconds: 10" <<<"$startup_block"; then
   echo "FAIL: startupProbe periodSeconds is not 10"
   exit 1
 fi
-if ! echo "$startup_block" | grep -q "path: /api/status"; then
+if ! grep -q "path: /api/status" <<<"$startup_block"; then
   echo "FAIL: startupProbe path is not /api/status"
   exit 1
 fi
 # Liveness must stay present (kubelet semantics: after startup success).
-if ! echo "$newapi_container" | grep -q "livenessProbe:"; then
+if ! grep -q "livenessProbe:" <<<"$newapi_container"; then
   echo "FAIL: livenessProbe removed (must remain for post-startup kubelet supervision)"
   exit 1
 fi
-if ! echo "$newapi_container" | grep -q "readinessProbe:"; then
+if ! grep -q "readinessProbe:" <<<"$newapi_container"; then
   echo "FAIL: readinessProbe removed"
   exit 1
 fi
@@ -135,11 +135,11 @@ newapi_container2=$(echo "$deployment_block2" | awk '
 ')
 # When startup is null the {{- if .Values.newapi.probes.startup }} gate
 # is false and the entire block (key + httpGet + thresholds) is omitted.
-if echo "$newapi_container2" | grep -q "^[[:space:]]*startupProbe:"; then
+if grep -q "^[[:space:]]*startupProbe:" <<<"$newapi_container2"; then
   echo "FAIL: startup=null should suppress the startupProbe block (Inviolable Principle #4)"
   exit 1
 fi
-if ! echo "$newapi_container2" | grep -q "livenessProbe:"; then
+if ! grep -q "livenessProbe:" <<<"$newapi_container2"; then
   echo "FAIL: livenessProbe missing in override path"
   exit 1
 fi

--- a/platform/oidc-gate/chart/tests/internal-discovery-render.sh
+++ b/platform/oidc-gate/chart/tests/internal-discovery-render.sh
@@ -47,7 +47,7 @@ YAML
 echo "[internal-discovery] Case 1: fix ON renders skip-discovery + internal backchannel"
 on="$("$helm" template oidc-gate "$chart_dir" -f "$vals" 2>/dev/null)"
 
-assert_arg() { echo "$on" | grep -qF -- "$1" || { echo "FAIL: missing arg '$1'" >&2; echo "$on" >&2; exit 1; }; }
+assert_arg() { grep -qF -- "$1" <<<"$on" || { echo "FAIL: missing arg '$1'" >&2; echo "$on" >&2; exit 1; }; }
 
 assert_arg "--skip-oidc-discovery=true"
 assert_arg "--redeem-url=${internal}/realms/sovereign/protocol/openid-connect/token"
@@ -63,7 +63,7 @@ echo "  PASS"
 echo "[internal-discovery] Case 2: no backchannel arg points at the public auth host"
 for bc in redeem-url oidc-jwks-url profile-url; do
   line="$(echo "$on" | grep -E -- "--${bc}=" | head -1)"
-  if echo "$line" | grep -qF "auth.${fqdn}"; then
+  if grep -qF "auth.${fqdn}" <<<"$line"; then
     echo "FAIL: --${bc} dials the public EIP host (auth.${fqdn}) — hairpin bug not fixed" >&2
     echo "$line" >&2; exit 1
   fi
@@ -73,13 +73,13 @@ echo "  PASS"
 # ── Case 3: fix OFF (keycloakInternalURL="") — pre-#3844 shape ──────────────
 echo "[internal-discovery] Case 3: keycloakInternalURL=\"\" renders NO skip-discovery flags"
 off="$("$helm" template oidc-gate "$chart_dir" -f "$vals" --set keycloakInternalURL="" 2>/dev/null)"
-if echo "$off" | grep -qE -- '--skip-oidc-discovery|--redeem-url|--oidc-jwks-url|--profile-url'; then
+if grep -qE -- '--skip-oidc-discovery|--redeem-url|--oidc-jwks-url|--profile-url' <<<"$off"; then
   echo "FAIL: empty keycloakInternalURL must NOT render skip-discovery flags (pre-#3844 shape)" >&2
   echo "$off" | grep -E -- '--skip-oidc-discovery|--redeem-url|--oidc-jwks-url|--profile-url' >&2
   exit 1
 fi
 # the public issuer + login URL still render in the OFF path
-echo "$off" | grep -qF -- "--oidc-issuer-url=https://auth.${fqdn}/realms/sovereign" \
+grep -qF -- "--oidc-issuer-url=https://auth.${fqdn}/realms/sovereign" <<<"$off" \
   || { echo "FAIL: OFF path lost the public --oidc-issuer-url" >&2; exit 1; }
 echo "  PASS"
 

--- a/platform/oidc-gate/chart/tests/root-redirect-render.sh
+++ b/platform/oidc-gate/chart/tests/root-redirect-render.sh
@@ -63,28 +63,28 @@ route_doc() {
 echo "[root-redirect] Case 1: pda renders Exact / RequestRedirect to /oidc/login"
 pda="$(route_doc pda)"
 if [ -z "$pda" ]; then echo "FAIL: no HTTPRoute oidc-gate-pda rendered" >&2; echo "$out" >&2; exit 1; fi
-echo "$pda" | grep -qE 'type:\s*Exact'                       || { echo "FAIL: pda missing Exact path match" >&2; echo "$pda" >&2; exit 1; }
-echo "$pda" | grep -qE 'type:\s*RequestRedirect'             || { echo "FAIL: pda missing RequestRedirect filter" >&2; echo "$pda" >&2; exit 1; }
-echo "$pda" | grep -qE 'replaceFullPath:\s*"?/oidc/login"?'  || { echo "FAIL: pda redirect not to /oidc/login" >&2; echo "$pda" >&2; exit 1; }
-echo "$pda" | grep -qE 'port:\s*443'                         || { echo "FAIL: pda redirect not on default port 443" >&2; echo "$pda" >&2; exit 1; }
-echo "$pda" | grep -qE 'statusCode:\s*302'                   || { echo "FAIL: pda redirect not 302" >&2; echo "$pda" >&2; exit 1; }
+grep -qE 'type:\s*Exact' <<<"$pda"                       || { echo "FAIL: pda missing Exact path match" >&2; echo "$pda" >&2; exit 1; }
+grep -qE 'type:\s*RequestRedirect' <<<"$pda"             || { echo "FAIL: pda missing RequestRedirect filter" >&2; echo "$pda" >&2; exit 1; }
+grep -qE 'replaceFullPath:\s*"?/oidc/login"?' <<<"$pda"  || { echo "FAIL: pda redirect not to /oidc/login" >&2; echo "$pda" >&2; exit 1; }
+grep -qE 'port:\s*443' <<<"$pda"                         || { echo "FAIL: pda redirect not on default port 443" >&2; echo "$pda" >&2; exit 1; }
+grep -qE 'statusCode:\s*302' <<<"$pda"                   || { echo "FAIL: pda redirect not 302" >&2; echo "$pda" >&2; exit 1; }
 echo "  PASS"
 
 # ── Case 2: flowless (no rootRedirectPath) renders NO redirect ──────────────
 echo "[root-redirect] Case 2: flowless renders NO redirect (only PathPrefix backend)"
 flowless="$(route_doc flowless)"
 if [ -z "$flowless" ]; then echo "FAIL: no HTTPRoute oidc-gate-flowless rendered" >&2; exit 1; fi
-if echo "$flowless" | grep -qE 'RequestRedirect|type:\s*Exact'; then
+if grep -qE 'RequestRedirect|type:\s*Exact' <<<"$flowless"; then
   echo "FAIL: flowless (no rootRedirectPath) should NOT render a redirect" >&2; echo "$flowless" >&2; exit 1
 fi
-echo "$flowless" | grep -qE 'type:\s*PathPrefix' || { echo "FAIL: flowless missing PathPrefix backend" >&2; exit 1; }
+grep -qE 'type:\s*PathPrefix' <<<"$flowless" || { echo "FAIL: flowless missing PathPrefix backend" >&2; exit 1; }
 echo "  PASS"
 
 # ── Case 3: rootRedirectPort override ───────────────────────────────────────
 echo "[root-redirect] Case 3: customport honours rootRedirectPort: 8443"
 cp="$(route_doc customport)"
-echo "$cp" | grep -qE 'replaceFullPath:\s*"?/sso/start"?' || { echo "FAIL: customport redirect path wrong" >&2; echo "$cp" >&2; exit 1; }
-echo "$cp" | grep -qE 'port:\s*8443'                      || { echo "FAIL: customport did not honour rootRedirectPort 8443" >&2; echo "$cp" >&2; exit 1; }
+grep -qE 'replaceFullPath:\s*"?/sso/start"?' <<<"$cp" || { echo "FAIL: customport redirect path wrong" >&2; echo "$cp" >&2; exit 1; }
+grep -qE 'port:\s*8443' <<<"$cp"                      || { echo "FAIL: customport did not honour rootRedirectPort 8443" >&2; echo "$cp" >&2; exit 1; }
 echo "  PASS"
 
 echo "[bp-oidc-gate #3374 rootRedirectPath] All cases PASS"

--- a/platform/oidc-gate/chart/tests/spa-token-seed-render.sh
+++ b/platform/oidc-gate/chart/tests/spa-token-seed-render.sh
@@ -89,41 +89,41 @@ route_doc() {
 echo "[spa-token-seed] Case 1: agenity-org1 renders Exact / RequestRedirect to /app/?token=sso"
 a1="$(route_doc agenity-org1)"
 if [ -z "$a1" ]; then echo "FAIL: no HTTPRoute oidc-gate-agenity-org1 rendered" >&2; echo "$out" >&2; exit 1; fi
-echo "$a1" | grep -qE 'type:\s*Exact'                                  || { echo "FAIL: missing Exact path match" >&2; echo "$a1" >&2; exit 1; }
-echo "$a1" | grep -qE 'type:\s*RequestRedirect'                        || { echo "FAIL: missing RequestRedirect filter" >&2; echo "$a1" >&2; exit 1; }
-echo "$a1" | grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?'        || { echo "FAIL: redirect not to /app/?token=sso" >&2; echo "$a1" >&2; exit 1; }
-echo "$a1" | grep -qE 'port:\s*443'                                    || { echo "FAIL: redirect not on port 443" >&2; echo "$a1" >&2; exit 1; }
-echo "$a1" | grep -qE 'statusCode:\s*302'                              || { echo "FAIL: redirect not 302" >&2; echo "$a1" >&2; exit 1; }
+grep -qE 'type:\s*Exact' <<<"$a1"                                  || { echo "FAIL: missing Exact path match" >&2; echo "$a1" >&2; exit 1; }
+grep -qE 'type:\s*RequestRedirect' <<<"$a1"                        || { echo "FAIL: missing RequestRedirect filter" >&2; echo "$a1" >&2; exit 1; }
+grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?' <<<"$a1"        || { echo "FAIL: redirect not to /app/?token=sso" >&2; echo "$a1" >&2; exit 1; }
+grep -qE 'port:\s*443' <<<"$a1"                                    || { echo "FAIL: redirect not on port 443" >&2; echo "$a1" >&2; exit 1; }
+grep -qE 'statusCode:\s*302' <<<"$a1"                              || { echo "FAIL: redirect not 302" >&2; echo "$a1" >&2; exit 1; }
 echo "  PASS"
 
 # ── Case 2: defaults → /app/?token=sso on port 443 ─────────────────────────
 echo "[spa-token-seed] Case 2: agenity-defaults uses dashboardPath=/app/ value=sso port=443 defaults"
 a2="$(route_doc agenity-defaults)"
-echo "$a2" | grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?' || { echo "FAIL: defaults not /app/?token=sso" >&2; echo "$a2" >&2; exit 1; }
-echo "$a2" | grep -qE 'port:\s*443'                            || { echo "FAIL: default port not 443" >&2; echo "$a2" >&2; exit 1; }
+grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?' <<<"$a2" || { echo "FAIL: defaults not /app/?token=sso" >&2; echo "$a2" >&2; exit 1; }
+grep -qE 'port:\s*443' <<<"$a2"                            || { echo "FAIL: default port not 443" >&2; echo "$a2" >&2; exit 1; }
 echo "  PASS"
 
 # ── Case 3: custom path/value/port honoured ────────────────────────────────
 echo "[spa-token-seed] Case 3: agenity-custom honours /dashboard/?token=seed42 on 8443"
 a3="$(route_doc agenity-custom)"
-echo "$a3" | grep -qE 'replaceFullPath:\s*"?/dashboard/\?token=seed42"?' || { echo "FAIL: custom path/value wrong" >&2; echo "$a3" >&2; exit 1; }
-echo "$a3" | grep -qE 'port:\s*8443'                                    || { echo "FAIL: custom port 8443 not honoured" >&2; echo "$a3" >&2; exit 1; }
+grep -qE 'replaceFullPath:\s*"?/dashboard/\?token=seed42"?' <<<"$a3" || { echo "FAIL: custom path/value wrong" >&2; echo "$a3" >&2; exit 1; }
+grep -qE 'port:\s*8443' <<<"$a3"                                    || { echo "FAIL: custom port 8443 not honoured" >&2; echo "$a3" >&2; exit 1; }
 echo "  PASS"
 
 # ── Case 4: control (no spaTokenSeed) renders NO redirect ──────────────────
 echo "[spa-token-seed] Case 4: flowless (no spaTokenSeed) renders NO redirect"
 fl="$(route_doc flowless)"
-if echo "$fl" | grep -qE 'RequestRedirect|type:\s*Exact'; then
+if grep -qE 'RequestRedirect|type:\s*Exact' <<<"$fl"; then
   echo "FAIL: flowless should NOT render a redirect" >&2; echo "$fl" >&2; exit 1
 fi
-echo "$fl" | grep -qE 'type:\s*PathPrefix' || { echo "FAIL: flowless missing PathPrefix backend" >&2; exit 1; }
+grep -qE 'type:\s*PathPrefix' <<<"$fl" || { echo "FAIL: flowless missing PathPrefix backend" >&2; exit 1; }
 echo "  PASS"
 
 # ── Case 5: spaTokenSeed precedence over rootRedirectPath ──────────────────
 echo "[spa-token-seed] Case 5: spaTokenSeed wins over rootRedirectPath (no /oidc/login redirect)"
 ap="$(route_doc agenity-precedence)"
-echo "$ap" | grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?' || { echo "FAIL: precedence instance did not render the seed redirect" >&2; echo "$ap" >&2; exit 1; }
-if echo "$ap" | grep -qE 'replaceFullPath:\s*"?/oidc/login"?'; then
+grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?' <<<"$ap" || { echo "FAIL: precedence instance did not render the seed redirect" >&2; echo "$ap" >&2; exit 1; }
+if grep -qE 'replaceFullPath:\s*"?/oidc/login"?' <<<"$ap"; then
   echo "FAIL: rootRedirectPath rule rendered alongside spaTokenSeed (must be mutually exclusive)" >&2; echo "$ap" >&2; exit 1
 fi
 # exactly ONE Exact-/ match in this route (no double redirect rule)

--- a/platform/openbao/chart/tests/continuum-render.sh
+++ b/platform/openbao/chart/tests/continuum-render.sh
@@ -73,18 +73,18 @@ if [ -z "$cr_block" ]; then
   exit 1
 fi
 # The mechanism MUST be raft-transition (NOT the cnpg-pair default).
-if ! echo "$cr_block" | grep -q "mechanism: raft-transition"; then
+if ! grep -q "mechanism: raft-transition" <<<"$cr_block"; then
   echo "FAIL: Continuum CR is missing switchover.mechanism=raft-transition." >&2
   echo "$cr_block" >&2
   exit 1
 fi
 # The raftTransition target must carry the standby Pod selector + raft data path.
-if ! echo "$cr_block" | grep -q 'podSelector: "app.kubernetes.io/name=openbao"'; then
+if ! grep -q 'podSelector: "app.kubernetes.io/name=openbao"' <<<"$cr_block"; then
   echo "FAIL: Continuum CR raftTransition.podSelector is wrong/missing." >&2
   exit 1
 fi
 # raftDataPath is where the OSS peers.json recovery file is written.
-if ! echo "$cr_block" | grep -q 'raftDataPath: "/openbao/data"'; then
+if ! grep -q 'raftDataPath: "/openbao/data"' <<<"$cr_block"; then
   echo "FAIL: Continuum CR raftTransition.raftDataPath is wrong/missing (peers.json recovery target)." >&2
   echo "$cr_block" >&2
   exit 1
@@ -92,17 +92,17 @@ fi
 # The DEFAULT CR must NOT carry a snapshotPath — the common stretched-raft case
 # promotes from the survivor's live replicated state (region-B already holds
 # region-A's KV as a retry_join non-voter), so no snapshot restore is needed.
-if echo "$cr_block" | grep -q 'snapshotPath:'; then
+if grep -q 'snapshotPath:' <<<"$cr_block"; then
   echo "FAIL: Continuum CR carries a snapshotPath by default — it must be empty (stretched-raft promotes from live state, not a snapshot restore)." >&2
   echo "$cr_block" >&2
   exit 1
 fi
 # applicationRef must be openbao, and the regions wired through.
-if ! echo "$cr_block" | grep -q "applicationRef: openbao"; then
+if ! grep -q "applicationRef: openbao" <<<"$cr_block"; then
   echo "FAIL: Continuum CR applicationRef is not openbao." >&2
   exit 1
 fi
-if ! echo "$cr_block" | grep -q "hz-fsn-rtz-prod"; then
+if ! grep -q "hz-fsn-rtz-prod" <<<"$cr_block"; then
   echo "FAIL: Continuum CR did not wire the primaryRegion." >&2
   exit 1
 fi

--- a/platform/openbao/chart/tests/eso-push-policy-render.sh
+++ b/platform/openbao/chart/tests/eso-push-policy-render.sh
@@ -62,7 +62,7 @@ echo "[bp-openbao] Case 3: broad ESO read grant stays read-only"
 read_policy_block=$(echo "$out" | sed -n '/bao policy write external-secrets-read -/,/^ *EOF$/p')
 [ -n "$read_policy_block" ] || {
   echo "FAIL: could not locate the external-secrets-read policy block"; exit 1; }
-if echo "$read_policy_block" | grep -qE '"(create|update|delete)"'; then
+if grep -qE '"(create|update|delete)"' <<<"$read_policy_block"; then
   echo "FAIL: external-secrets-read policy gained write capabilities on the broad tree"; exit 1
 fi
 echo "  ok"

--- a/platform/openbao/chart/tests/httproute-render.sh
+++ b/platform/openbao/chart/tests/httproute-render.sh
@@ -40,7 +40,7 @@ if [ -z "$route_block" ]; then
   echo "(would surface on fresh Sovereign prov as NXDOMAIN for openbao.<fqdn>)"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "openbao.smoke.omani.works"; then
+if ! grep -q "openbao.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: HTTPRoute hostname does not match gateway.host"
   echo "$route_block"
   exit 1
@@ -49,11 +49,11 @@ echo "[bp-openbao] Case 1: PASS"
 
 # ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
 echo "[bp-openbao] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
-if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+if ! grep -q "name: \"cilium-gateway\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+if ! grep -q "namespace: \"kube-system\"" <<<"$route_block"; then
   echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
   exit 1
 fi
@@ -62,7 +62,7 @@ echo "[bp-openbao] Case 2: PASS"
 # ── Case 3: default-off path — HTTPRoute absent ───────────────────────
 echo "[bp-openbao] Case 3: default-off path — HTTPRoute not rendered"
 out_default=$("$helm" template smoke "$chart_dir" 2>&1)
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
   exit 1
 fi
@@ -75,11 +75,11 @@ out_override=$("$helm" template smoke "$chart_dir" \
         --set gateway.host=custom.smoke.example 2>&1)
 
 route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+if ! grep -q "custom.smoke.example" <<<"$route_block_override"; then
   echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
   exit 1
 fi
-if echo "$route_block_override" | grep -q "openbao.smoke.omani.works"; then
+if grep -q "openbao.smoke.omani.works" <<<"$route_block_override"; then
   echo "FAIL: explicit override leaked the case-1 hostname"
   exit 1
 fi
@@ -98,12 +98,12 @@ appcr=$("$helm" template smoke "$chart_dir" \
         --set bootstrapOwned.enabled=true \
         --set bootstrapOwned.helmRelease.name=bp-openbao \
         --api-versions apps.openova.io/v1 2>&1)
-if ! echo "$appcr" | grep -qE '^  placement: singleton$'; then
+if ! grep -qE '^  placement: singleton$' <<<"$appcr"; then
   echo "FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')"
   echo "$appcr" | grep -E '^  placement:' || true
   exit 1
 fi
-if echo "$appcr" | grep -qE '^  placement: single-region$'; then
+if grep -qE '^  placement: single-region$' <<<"$appcr"; then
   echo "FAIL: #3375 REGRESSION — Application CR re-introduced the banned 'single-region' placement"
   exit 1
 fi

--- a/platform/openova-flow-server/chart/tests/httproute-render.sh
+++ b/platform/openova-flow-server/chart/tests/httproute-render.sh
@@ -34,7 +34,7 @@ if [ -z "$route_block" ]; then
   echo "FAIL: HTTPRoute did not render"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "flow.smoke.omani.works"; then
+if ! grep -q "flow.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: hostname not propagated"
   exit 1
 fi
@@ -42,11 +42,11 @@ echo "[bp-openova-flow-server] Case 1: PASS"
 
 # Case 2
 echo "[bp-openova-flow-server] Case 2: parentRefs cite gatewayRef"
-if ! echo "$route_block" | grep -q "name: cilium-gateway"; then
+if ! grep -q "name: cilium-gateway" <<<"$route_block"; then
   echo "FAIL: parentRef name != cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "namespace: kube-system"; then
+if ! grep -q "namespace: kube-system" <<<"$route_block"; then
   echo "FAIL: parentRef namespace != kube-system"
   exit 1
 fi
@@ -55,7 +55,7 @@ echo "[bp-openova-flow-server] Case 2: PASS"
 # Case 3
 echo "[bp-openova-flow-server] Case 3: default-off — HTTPRoute absent"
 out_default=$("$helm" template smoke "$chart_dir" 2>&1)
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render with flowServer.httproute.enabled=false (default)"
   exit 1
 fi
@@ -69,11 +69,11 @@ out_override=$("$helm" template smoke "$chart_dir" \
   --set flowServer.httproute.hostname=custom.smoke.example \
   --set flowServer.httproute.gatewayRef.name=cilium-gateway 2>&1)
 route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+if ! grep -q "custom.smoke.example" <<<"$route_block_override"; then
   echo "FAIL: override hostname not propagated"
   exit 1
 fi
-if echo "$route_block_override" | grep -q "flow.smoke.omani.works"; then
+if grep -q "flow.smoke.omani.works" <<<"$route_block_override"; then
   echo "FAIL: override leaked case-1 hostname"
   exit 1
 fi

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -776,18 +776,18 @@ BP_YAML="$CHART_DIR/../blueprint.yaml"
 modes_line=$(grep -E '^[[:space:]]*modes:[[:space:]]*\[' "$BP_YAML" | head -1)
 [ -n "$modes_line" ] || fail "#3375: placementSchema.modes line not found in blueprint.yaml"
 for canon in singleton active-active active-hot-standby active-passive; do
-  echo "$modes_line" | grep -qw "$canon" \
+  grep -qw "$canon" <<<"$modes_line" \
     || fail "#3375: placementSchema.modes missing canonical mode '$canon' (got: $modes_line)"
 done
 # The banned legacy spellings must NOT appear as placementSchema modes.
-if echo "$modes_line" | grep -qE '\bsingle-region\b'; then
+if grep -qE '\bsingle-region\b' <<<"$modes_line"; then
   fail "#3375 REGRESSION: placementSchema.modes lists the banned 'single-region' (use canonical 'singleton')"
 fi
-if echo "$modes_line" | grep -qE '\bactive-hotstandby\b'; then
+if grep -qE '\bactive-hotstandby\b' <<<"$modes_line"; then
   fail "#3375 REGRESSION: placementSchema.modes lists the banned 'active-hotstandby' (use canonical 'active-hot-standby')"
 fi
 default_line=$(grep -E '^[[:space:]]*default:[[:space:]]' "$BP_YAML" | head -1)
-if echo "$default_line" | grep -qE '\bsingle-region\b'; then
+if grep -qE '\bsingle-region\b' <<<"$default_line"; then
   fail "#3375 REGRESSION: placementSchema.default is the banned 'single-region' (use canonical 'singleton')"
 fi
 
@@ -871,7 +871,7 @@ assert_no_continuum() { # $1=label ; rest=helm --set flags (+ implicit --api-ver
   local label="$1"; shift
   local out
   out=$(helm template shared-pg . "$@" --api-versions dr.openova.io/v1 --show-only templates/continuum.yaml 2>&1 || true)
-  if echo "$out" | grep -qE '^kind: Continuum$'; then fail "#4986: Continuum MUST be absent — $label"; fi
+  if grep -qE '^kind: Continuum$' <<<"$out"; then fail "#4986: Continuum MUST be absent — $label"; fi
 }
 assert_no_continuum "singleton" \
   --set enabled=true --set instance.name=shared-pg --set topology.mode=singleton
@@ -891,7 +891,7 @@ cont_nocrd=$(helm template shared-pg . \
   --set enabled=true --set instance.name=shared-pg --set topology.mode=active-hot-standby --set topology.side=primary \
   --set topology.primary.region=hw-me-east-215-a-rtz-prod --set topology.replica.region=hw-me-east-215-b-rtz-prod \
   --show-only templates/continuum.yaml 2>&1 || true)
-if echo "$cont_nocrd" | grep -qE '^kind: Continuum$'; then fail "#4986: Continuum MUST be absent when the dr.openova.io/v1 CRD is not registered"; fi
+if grep -qE '^kind: Continuum$' <<<"$cont_nocrd"; then fail "#4986: Continuum MUST be absent when the dr.openova.io/v1 CRD is not registered"; fi
 
 echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked; #3878 reflect.mangledTarget vc-mgmt native DB-secret delivery locked; #4986 per-app Continuum DR contract renders on AHS-primary + absent for singleton/replica/single-region/disabled/CRD-absent)"
 

--- a/platform/powerdns-admin/chart/tests/g117-w3d1-kc-idp-hint.sh
+++ b/platform/powerdns-admin/chart/tests/g117-w3d1-kc-idp-hint.sh
@@ -22,7 +22,7 @@ out=$("$helm" template smoke "$chart_dir" \
 
 # ── Case 1: OIDC_OAUTH_AUTHORIZE_URL carries kc_idp_hint=catalyst-pin ────
 echo "[g117-w3d1-kc-idp-hint] Case 1: OIDC_OAUTH_AUTHORIZE_URL appends ?kc_idp_hint=catalyst-pin"
-if ! echo "$out" | grep -qE 'OIDC_OAUTH_AUTHORIZE_URL:.*\?kc_idp_hint=catalyst-pin'; then
+if ! grep -qE 'OIDC_OAUTH_AUTHORIZE_URL:.*\?kc_idp_hint=catalyst-pin' <<<"$out"; then
   echo "FAIL: OIDC_OAUTH_AUTHORIZE_URL missing ?kc_idp_hint=catalyst-pin suffix" >&2
   echo "$out" | grep "OIDC_OAUTH_AUTHORIZE_URL" >&2 || true
   exit 1
@@ -32,7 +32,7 @@ echo "  PASS"
 # ── Case 2: other OIDC env vars unchanged (regression guard) ────────────
 echo "[g117-w3d1-kc-idp-hint] Case 2: other OIDC_OAUTH_* env vars unchanged"
 for v in OIDC_OAUTH_KEY OIDC_OAUTH_SECRET OIDC_OAUTH_API_URL OIDC_OAUTH_TOKEN_URL OIDC_OAUTH_LOGOUT_URL OIDC_OAUTH_METADATA_URL; do
-  if ! echo "$out" | grep -q "${v}:"; then
+  if ! grep -q "${v}:" <<<"$out"; then
     echo "FAIL: env var $v missing from rendered ExternalSecret template" >&2
     exit 1
   fi

--- a/platform/powerdns/chart/tests/hetzner-frontdoor-render.sh
+++ b/platform/powerdns/chart/tests/hetzner-frontdoor-render.sh
@@ -42,20 +42,20 @@ helm="${HELM_BIN:-helm}"
 # ── Case 1: default dnsdist workload is a Deployment with no host binding ──
 echo "[bp-powerdns] Case 1: default dnsdist => Deployment, ClusterIP, no hostPort"
 def_dnsdist=$("$helm" template smoke "$chart_dir" --show-only templates/dnsdist.yaml 2>&1)
-if ! echo "$def_dnsdist" | grep -qE '^kind: Deployment$'; then
+if ! grep -qE '^kind: Deployment$' <<<"$def_dnsdist"; then
   echo "FAIL: default render must produce a dnsdist Deployment (LB-IPAM anycast-VIP path)"
   echo "$def_dnsdist" | grep -E '^kind:' || true
   exit 1
 fi
-if echo "$def_dnsdist" | grep -qE '^kind: DaemonSet$'; then
+if grep -qE '^kind: DaemonSet$' <<<"$def_dnsdist"; then
   echo "FAIL: default render must NOT be a DaemonSet — Huawei/kom4dc path would change"
   exit 1
 fi
-if echo "$def_dnsdist" | grep -qE 'hostPort:'; then
+if grep -qE 'hostPort:' <<<"$def_dnsdist"; then
   echo "FAIL: default render must NOT bind a hostPort (that is the Hetzner-only path)"
   exit 1
 fi
-if ! echo "$def_dnsdist" | grep -qE '^  type: ClusterIP$'; then
+if ! grep -qE '^  type: ClusterIP$' <<<"$def_dnsdist"; then
   echo "FAIL: default dnsdist Service must be ClusterIP"
   exit 1
 fi
@@ -64,12 +64,12 @@ echo "[bp-powerdns] Case 1: PASS"
 # ── Case 2: default anycast Service is the §854 shared-VIP LoadBalancer ──
 echo "[bp-powerdns] Case 2: anycast Service => LoadBalancer, allocateLoadBalancerNodePorts:false"
 anycast=$("$helm" template smoke "$chart_dir" --show-only templates/anycast-endpoint.yaml 2>&1)
-if ! echo "$anycast" | grep -qE '^  type: LoadBalancer$'; then
+if ! grep -qE '^  type: LoadBalancer$' <<<"$anycast"; then
   echo "FAIL: anycast Service must be type=LoadBalancer (Cilium LB-IPAM shared VIP)"
   echo "$anycast" | grep -E '^  type:' || true
   exit 1
 fi
-if ! echo "$anycast" | grep -qE '^  allocateLoadBalancerNodePorts: false$'; then
+if ! grep -qE '^  allocateLoadBalancerNodePorts: false$' <<<"$anycast"; then
   echo "FAIL: anycast Service must set allocateLoadBalancerNodePorts:false (§854 — zero nodePorts)"
   exit 1
 fi
@@ -85,7 +85,7 @@ fi
 # the defect it guards — it blocked the bp-powerdns 1.2.23 publish on main and
 # left the catalog-seed + bootstrap-kit pins hollow. Match a nonzero value, the
 # same way scripts/check-no-nodeports.sh does.
-if echo "$anycast" | grep -qE '^ *nodePort:[[:space:]]*[1-9][0-9]*'; then
+if grep -qE '^ *nodePort:[[:space:]]*[1-9][0-9]*' <<<"$anycast"; then
   echo "FAIL: anycast Service carries a NONZERO nodePort (§854)"
   echo "$anycast" | grep -nE '^ *nodePort:' || true
   exit 1
@@ -93,7 +93,7 @@ fi
 # Vacuity guard: `nodePort: 0` must be PRESENT. Without it the render is
 # "compliant" only by omission, which is precisely the #5348 shape that let a
 # live allocation survive. Absence is not compliance here.
-if ! echo "$anycast" | grep -qE '^ *nodePort:[[:space:]]*0[[:space:]]*$'; then
+if ! grep -qE '^ *nodePort:[[:space:]]*0[[:space:]]*$' <<<"$anycast"; then
   echo "FAIL: anycast Service must state nodePort: 0 EXPLICITLY on each port (§854/#5348)"
   echo "      Omitting the field does not deallocate an existing nodePort."
   exit 1
@@ -104,7 +104,7 @@ echo "[bp-powerdns] Case 2: PASS"
 echo "[bp-powerdns] Case 3: hostPortMode=true => DaemonSet + hostPort:53 (UDP+TCP), tolerate-all, no hostNetwork"
 hz_dnsdist=$("$helm" template smoke "$chart_dir" --set dnsdist.hostPortMode=true \
              --show-only templates/dnsdist.yaml 2>&1)
-if ! echo "$hz_dnsdist" | grep -qE '^kind: DaemonSet$'; then
+if ! grep -qE '^kind: DaemonSet$' <<<"$hz_dnsdist"; then
   echo "FAIL: hostPortMode=true must produce a dnsdist DaemonSet (every-node :53 binder)"
   echo "$hz_dnsdist" | grep -E '^kind:' || true
   exit 1
@@ -114,11 +114,11 @@ if [ "$hostport_count" -ne 2 ]; then
   echo "FAIL: expected hostPort:53 on BOTH the UDP and TCP ports (2), got $hostport_count"
   exit 1
 fi
-if ! echo "$hz_dnsdist" | grep -qE '^ *- operator: Exists$'; then
+if ! grep -qE '^ *- operator: Exists$' <<<"$hz_dnsdist"; then
   echo "FAIL: Hetzner DaemonSet must tolerate all taints (operator: Exists) so the CP node — an LB :53 target — is covered"
   exit 1
 fi
-if echo "$hz_dnsdist" | grep -qE 'hostNetwork:'; then
+if grep -qE 'hostNetwork:' <<<"$hz_dnsdist"; then
   echo "FAIL: dnsdist must NOT use hostNetwork (pod-netns :53 bind dodges the systemd-resolved 127.0.0.53 stub)"
   exit 1
 fi

--- a/platform/powerdns/chart/tests/httproute-render.sh
+++ b/platform/powerdns/chart/tests/httproute-render.sh
@@ -32,18 +32,18 @@ if [ -z "$route_block" ]; then
   echo "FAIL: HTTPRoute did not render with api.gateway.enabled=true"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "pdns.smoke.omani.works"; then
+if ! grep -q "pdns.smoke.omani.works" <<<"$route_block"; then
   echo "FAIL: hostname not propagated"
   exit 1
 fi
 echo "[bp-powerdns] Case 1: PASS"
 
 echo "[bp-powerdns] Case 2: parentRefs cite cilium-gateway / kube-system"
-if ! echo "$route_block" | grep -q "cilium-gateway"; then
+if ! grep -q "cilium-gateway" <<<"$route_block"; then
   echo "FAIL: parentRef name != cilium-gateway"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "kube-system"; then
+if ! grep -q "kube-system" <<<"$route_block"; then
   echo "FAIL: parentRef namespace != kube-system"
   exit 1
 fi
@@ -61,7 +61,7 @@ echo "[bp-powerdns] Case 3: PASS"
 
 echo "[bp-powerdns] Case 4: default-off — HTTPRoute absent"
 out_default=$("$helm" template smoke "$chart_dir" 2>&1)
-if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+if grep -q "^kind: HTTPRoute$" <<<"$out_default"; then
   echo "FAIL: HTTPRoute should NOT render with api.gateway.enabled=false (default)"
   exit 1
 fi
@@ -80,12 +80,12 @@ appcr=$("$helm" template smoke "$chart_dir" \
         --set bootstrapOwned.enabled=true \
         --set bootstrapOwned.helmRelease.name=bp-powerdns \
         --api-versions apps.openova.io/v1 2>&1)
-if ! echo "$appcr" | grep -qE '^  placement: singleton$'; then
+if ! grep -qE '^  placement: singleton$' <<<"$appcr"; then
   echo "FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')"
   echo "$appcr" | grep -E '^  placement:' || true
   exit 1
 fi
-if echo "$appcr" | grep -qE '^  placement: single-region$'; then
+if grep -qE '^  placement: single-region$' <<<"$appcr"; then
   echo "FAIL: #3375 REGRESSION — Application CR re-introduced the banned 'single-region' placement"
   exit 1
 fi

--- a/platform/powerdns/chart/tests/httproute-ui-redirect.sh
+++ b/platform/powerdns/chart/tests/httproute-ui-redirect.sh
@@ -37,31 +37,31 @@ if [ -z "$route_block" ]; then
   echo "FAIL: HTTPRoute did not render with api.gateway.enabled=true"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "type: RequestRedirect"; then
+if ! grep -q "type: RequestRedirect" <<<"$route_block"; then
   echo "FAIL: no RequestRedirect filter for root path"
   exit 1
 fi
-if ! echo "$route_block" | grep -Eq "hostname: \"?$redirect_host\"?"; then
+if ! grep -Eq "hostname: \"?$redirect_host\"?" <<<"$route_block"; then
   echo "FAIL: RequestRedirect hostname != $redirect_host"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "statusCode: 302"; then
+if ! grep -q "statusCode: 302" <<<"$route_block"; then
   echo "FAIL: RequestRedirect statusCode != 302"
   exit 1
 fi
 # The redirect must match the catch-all root prefix.
-if ! echo "$route_block" | grep -Eq 'value: "?/"?'; then
+if ! grep -Eq 'value: "?/"?' <<<"$route_block"; then
   echo "FAIL: redirect rule does not match PathPrefix /"
   exit 1
 fi
 echo "[bp-powerdns] Case 1: PASS"
 
 echo "[bp-powerdns] Case 2: /api → powerdns backend forward rule PRESERVED"
-if ! echo "$route_block" | grep -Eq 'value: "?/api"?'; then
+if ! grep -Eq 'value: "?/api"?' <<<"$route_block"; then
   echo "FAIL: /api match value not present — API forward rule lost"
   exit 1
 fi
-if ! echo "$route_block" | grep -q "name: powerdns"; then
+if ! grep -q "name: powerdns" <<<"$route_block"; then
   echo "FAIL: powerdns backendRef lost — API no longer routed"
   exit 1
 fi
@@ -72,12 +72,12 @@ out_default=$("$helm" template smoke "$chart_dir" \
   --set api.gateway.enabled=true \
   --set api.host=pdns.example.com 2>&1)
 default_route=$(echo "$out_default" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
-if echo "$default_route" | grep -q "type: RequestRedirect"; then
+if grep -q "type: RequestRedirect" <<<"$default_route"; then
   echo "FAIL: RequestRedirect rendered without api.uiRedirectHost set"
   exit 1
 fi
 # The API forward rule must still be present in the default case.
-if ! echo "$default_route" | grep -q "name: powerdns"; then
+if ! grep -q "name: powerdns" <<<"$default_route"; then
   echo "FAIL: powerdns backendRef missing in default render"
   exit 1
 fi

--- a/platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh
+++ b/platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh
@@ -100,14 +100,14 @@ for want in \
   '\\"hostname\\":\\"api.t99.omani.works\\"' \
   '\\"name\\":\\"marketplace-https\\"' \
   '\\"hostname\\":\\"marketplace.t99.omani.works\\"'; do
-  echo "$CONSOLE_LINE" | grep -q "$want" || {
+  grep -q "$want" <<<"$CONSOLE_LINE" || {
     echo "FAIL: CONSOLE_LISTENERS_YAML missing expected #5341 token: $want" >&2
     echo "$CONSOLE_LINE" >&2
     exit 1
   }
 done
 # Collision guard: the console listener set must carry NO `*.<fqdn>` hostname.
-if echo "$CONSOLE_LINE" | grep -q '\\"hostname\\":\\"\*\.t99\.omani\.works\\"'; then
+if grep -q '\\"hostname\\":\\"\*\.t99\.omani\.works\\"' <<<"$CONSOLE_LINE"; then
   echo "FAIL: CONSOLE_LISTENERS_YAML still carries a wildcard '*.t99.omani.works' hostname — the #5341 gateway collision is back." >&2
   echo "$CONSOLE_LINE" >&2
   exit 1

--- a/platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh
+++ b/platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh
@@ -19,25 +19,25 @@ RENDERED="$(helm template smoke "$CHART_DIR" --show-only templates/configmap-rec
 echo "=== G117.5c-followup session_secret bundle tests ==="
 
 # Test 1: session_secret derivation present
-if ! echo "$RENDERED" | grep -q 'session_secret="\$('; then
+if ! grep -q 'session_secret="\$(' <<<"$RENDERED"; then
   echo "FAIL 1: session_secret derivation not found in rendered reconciler"
   exit 1
 fi
 echo "PASS 1: session_secret derivation present"
 
 # Test 2: jq bundle includes session_secret:$session
-if ! echo "$RENDERED" | grep -q 'session_secret:\$session'; then
+if ! grep -q 'session_secret:\$session' <<<"$RENDERED"; then
   echo "FAIL 2: jq bundle expression missing session_secret:\$session"
   exit 1
 fi
 echo "PASS 2: jq bundle includes session_secret"
 
 # Test 3: derivation uses sha256 + the |session| delimiter
-if ! echo "$RENDERED" | grep -qE 'sha256sum.*\|session\||\\\|session\\\|.*sha256sum'; then
-  if ! echo "$RENDERED" | grep -q 'session|.*sha256sum'; then
+if ! grep -qE 'sha256sum.*\|session\||\\\|session\\\|.*sha256sum' <<<"$RENDERED"; then
+  if ! grep -q 'session|.*sha256sum' <<<"$RENDERED"; then
     # Multi-line — verify presence of both elements
-    echo "$RENDERED" | grep -q 'sha256sum' || { echo "FAIL 3: sha256sum not in derivation"; exit 1; }
-    echo "$RENDERED" | grep -q '|session|' || { echo "FAIL 3: |session| delimiter not in derivation"; exit 1; }
+    grep -q 'sha256sum' <<<"$RENDERED" || { echo "FAIL 3: sha256sum not in derivation"; exit 1; }
+    grep -q '|session|' <<<"$RENDERED" || { echo "FAIL 3: |session| delimiter not in derivation"; exit 1; }
   fi
 fi
 echo "PASS 3: derivation uses sha256 + |session| delimiter"

--- a/platform/stalwart-sovereign/chart/tests/sovereign-render.sh
+++ b/platform/stalwart-sovereign/chart/tests/sovereign-render.sh
@@ -29,9 +29,9 @@ helm="${HELM_BIN:-helm}"
 # ── Case 1: smoke render (default values) ─────────────────────────────
 echo "[stalwart-sovereign] Case 1: smoke render (default values)"
 out=$("$helm" template smoke "$chart_dir" 2>&1)
-echo "$out" | grep -q "kind: StatefulSet"   || { echo "FAIL: no StatefulSet"; exit 1; }
-echo "$out" | grep -q "kind: ServiceAccount" || { echo "FAIL: no ServiceAccount"; exit 1; }
-echo "$out" | grep -q "kind: NetworkPolicy"  || { echo "FAIL: no NetworkPolicy"; exit 1; }
+grep -q "kind: StatefulSet" <<<"$out"   || { echo "FAIL: no StatefulSet"; exit 1; }
+grep -q "kind: ServiceAccount" <<<"$out" || { echo "FAIL: no ServiceAccount"; exit 1; }
+grep -q "kind: NetworkPolicy" <<<"$out"  || { echo "FAIL: no NetworkPolicy"; exit 1; }
 # Smoke-render-safe: dns-records ConfigMap MUST NOT render the actual
 # ConfigMap object when sovereignFQDN is empty (skip-on-empty gate). The
 # RBAC + Job env templates may still REFERENCE the name (they always
@@ -56,19 +56,19 @@ EOF
 out=$("$helm" template smoke "$chart_dir" -f "$values" 2>&1)
 
 # Image SHA-pin
-echo "$out" | grep -q "stalwartlabs/stalwart@sha256:" \
+grep -q "stalwartlabs/stalwart@sha256:" <<<"$out" \
   || { echo "FAIL: image not SHA-pinned"; exit 1; }
 
 # LoadBalancer Service with SMTP ports
-echo "$out" | grep -q "type: LoadBalancer" \
+grep -q "type: LoadBalancer" <<<"$out" \
   || { echo "FAIL: no LoadBalancer Service"; exit 1; }
-echo "$out" | grep -q "name: smtp" \
+grep -q "name: smtp" <<<"$out" \
   || { echo "FAIL: no smtp port name"; exit 1; }
-echo "$out" | grep -q "name: submission" \
+grep -q "name: submission" <<<"$out" \
   || { echo "FAIL: no submission port name"; exit 1; }
 
 # ClusterIP for admin API
-echo "$out" | grep -q "stalwart-sovereign-http" \
+grep -q "stalwart-sovereign-http" <<<"$out" \
   || { echo "FAIL: no http ClusterIP Service"; exit 1; }
 
 # config.toml using == not = for equality (stalwart_expression_syntax.md).
@@ -80,15 +80,15 @@ if echo "$toml" | grep -E '^[[:space:]]*if[[:space:]]*=[[:space:]]*"[^=]+",' >/d
 fi
 
 # dns-records ConfigMap with operator content
-echo "$out" | grep -q "stalwart-sovereign-dns-records-required" \
+grep -q "stalwart-sovereign-dns-records-required" <<<"$out" \
   || { echo "FAIL: dns-records ConfigMap missing"; exit 1; }
-echo "$out" | grep -q "mail.omantel.omani.works" \
+grep -q "mail.omantel.omani.works" <<<"$out" \
   || { echo "FAIL: mailHost not composed"; exit 1; }
-echo "$out" | grep -q "v=spf1 a mx" \
+grep -q "v=spf1 a mx" <<<"$out" \
   || { echo "FAIL: SPF record string missing"; exit 1; }
-echo "$out" | grep -q "v=DMARC1" \
+grep -q "v=DMARC1" <<<"$out" \
   || { echo "FAIL: DMARC record string missing"; exit 1; }
-echo "$out" | grep -q "_domainkey.omantel.omani.works" \
+grep -q "_domainkey.omantel.omani.works" <<<"$out" \
   || { echo "FAIL: DKIM record name missing"; exit 1; }
 
 # Submission Secret with canonical 5-key shape (b64-encoded values).
@@ -104,15 +104,15 @@ from_dec=$(echo "$b64from" | base64 -d 2>/dev/null || true)
   || { echo "FAIL: smtp-from decoded to '$from_dec'"; exit 1; }
 
 # Setup Job mounts both Secrets
-echo "$out" | grep -q "name: ADMIN_PASSWORD" \
+grep -q "name: ADMIN_PASSWORD" <<<"$out" \
   || { echo "FAIL: ADMIN_PASSWORD env missing"; exit 1; }
-echo "$out" | grep -q "name: SUBMISSION_PASSWORD" \
+grep -q "name: SUBMISSION_PASSWORD" <<<"$out" \
   || { echo "FAIL: SUBMISSION_PASSWORD env missing"; exit 1; }
 
 # Setup Job creates mirror Secret with both key shapes
-echo "$out" | grep -q '"smtp-user": "${B64_USER}"' \
+grep -q '"smtp-user": "${B64_USER}"' <<<"$out" \
   || { echo "FAIL: mirror Secret missing smtp-user key"; exit 1; }
-echo "$out" | grep -q '"user": "${B64_USER}"' \
+grep -q '"user": "${B64_USER}"' <<<"$out" \
   || { echo "FAIL: mirror Secret missing legacy user key"; exit 1; }
 
 echo "[stalwart-sovereign] Case 2: PASS"
@@ -127,7 +127,7 @@ sovereignSMTPCredentialsMirror:
 EOF
 out=$("$helm" template smoke "$chart_dir" -f "$values" 2>&1)
 # Mirror disabled — cross-namespace Role into catalyst-system MUST NOT render.
-if echo "$out" | grep -q "namespace: catalyst-system"; then
+if grep -q "namespace: catalyst-system" <<<"$out"; then
   echo "FAIL: mirror Role rendered into catalyst-system despite enabled=false"
   exit 1
 fi

--- a/platform/wordpress-tenant/chart/tests/imagepullsecrets-render.sh
+++ b/platform/wordpress-tenant/chart/tests/imagepullsecrets-render.sh
@@ -63,10 +63,10 @@ deployment_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
 if [ -z "$deployment_block" ]; then
   echo "FAIL: Deployment did not render"; exit 1
 fi
-if ! echo "$deployment_block" | grep -q "imagePullSecrets:"; then
+if ! grep -q "imagePullSecrets:" <<<"$deployment_block"; then
   echo "FAIL: Deployment has no imagePullSecrets block"; exit 1
 fi
-if ! echo "$deployment_block" | grep -q "name: ghcr-pull"; then
+if ! grep -q "name: ghcr-pull" <<<"$deployment_block"; then
   echo "FAIL: Deployment imagePullSecrets does not reference ghcr-pull"; exit 1
 fi
 echo "[bp-wordpress-tenant] Case 1: PASS"
@@ -77,10 +77,10 @@ admin_job=$(job_by_name "$out" "-admin-user")
 if [ -z "$admin_job" ]; then
   echo "FAIL: admin-user Job did not render (adminUser.email set?)"; exit 1
 fi
-if ! echo "$admin_job" | grep -q "imagePullSecrets:"; then
+if ! grep -q "imagePullSecrets:" <<<"$admin_job"; then
   echo "FAIL: admin-user Job has no imagePullSecrets block"; exit 1
 fi
-if ! echo "$admin_job" | grep -q "name: ghcr-pull"; then
+if ! grep -q "name: ghcr-pull" <<<"$admin_job"; then
   echo "FAIL: admin-user Job imagePullSecrets does not reference ghcr-pull"; exit 1
 fi
 echo "[bp-wordpress-tenant] Case 2: PASS"
@@ -91,7 +91,7 @@ oidc_job=$(job_by_name "$out" "-oidc-config")
 if [ -z "$oidc_job" ]; then
   echo "FAIL: oidc-config Job did not render"; exit 1
 fi
-if echo "$oidc_job" | grep -q "imagePullSecrets:"; then
+if grep -q "imagePullSecrets:" <<<"$oidc_job"; then
   echo "FAIL: oidc-config Job (public wordpress:cli-* image) must not carry imagePullSecrets"; exit 1
 fi
 echo "[bp-wordpress-tenant] Case 3: PASS"
@@ -112,7 +112,7 @@ deployment_block5=$(echo "$out5" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f
 if [ -z "$deployment_block5" ]; then
   echo "FAIL: Deployment did not render with empty pullSecrets"; exit 1
 fi
-if echo "$deployment_block5" | grep -q "imagePullSecrets:"; then
+if grep -q "imagePullSecrets:" <<<"$deployment_block5"; then
   echo "FAIL: empty override should suppress imagePullSecrets block (Inviolable Principle #4)"; exit 1
 fi
 echo "[bp-wordpress-tenant] Case 4: PASS"
@@ -131,10 +131,10 @@ EOF
 out6=$("$helm" template wp "$chart_dir" -f "$custom_values" 2>&1)
 rm -f "$custom_values"
 deployment_block6=$(echo "$out6" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
-if ! echo "$deployment_block6" | grep -q "name: my-private-registry-creds"; then
+if ! grep -q "name: my-private-registry-creds" <<<"$deployment_block6"; then
   echo "FAIL: custom imagePullSecret name not propagated to Deployment"; exit 1
 fi
-if echo "$deployment_block6" | grep -q "name: ghcr-pull"; then
+if grep -q "name: ghcr-pull" <<<"$deployment_block6"; then
   echo "FAIL: custom override leaked default ghcr-pull reference"; exit 1
 fi
 echo "[bp-wordpress-tenant] Case 5: PASS"

--- a/products/agenity/chart/tests/oidc-gate-companion-render.sh
+++ b/products/agenity/chart/tests/oidc-gate-companion-render.sh
@@ -46,12 +46,12 @@ render_gated() {
 echo "[oidc-gate-companion] Case 1: gated per-Org install renders the gate + suppresses chart route"
 g="$(render_gated)"
 
-echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar"'                  || { echo "FAIL: no gate Deployment/Service/HTTPRoute oidc-gate-agenity-agnstar" >&2; echo "$g" >&2; exit 1; }
-echo "$g" | grep -qE 'kind: Deployment'                                   || { echo "FAIL: no gate Deployment" >&2; exit 1; }
-echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar-sso-registration"' || { echo "FAIL: no AppRegistration ConfigMap" >&2; exit 1; }
-echo "$g" | grep -qE 'sso.openova.io/app-registration: "agenity-agnstar"' || { echo "FAIL: AppRegistration not labelled for bp-sso-bridge" >&2; exit 1; }
-echo "$g" | grep -qE 'kind: ExternalSecret'                               || { echo "FAIL: no client-secret ExternalSecret (with external-secrets API)" >&2; exit 1; }
-echo "$g" | grep -qE 'key: "sso/sovereign/agenity-agnstar"'               || { echo "FAIL: ExternalSecret remoteRef not sso/sovereign/agenity-agnstar" >&2; exit 1; }
+grep -qE 'name: "oidc-gate-agenity-agnstar"' <<<"$g"                  || { echo "FAIL: no gate Deployment/Service/HTTPRoute oidc-gate-agenity-agnstar" >&2; echo "$g" >&2; exit 1; }
+grep -qE 'kind: Deployment' <<<"$g"                                   || { echo "FAIL: no gate Deployment" >&2; exit 1; }
+grep -qE 'name: "oidc-gate-agenity-agnstar-sso-registration"' <<<"$g" || { echo "FAIL: no AppRegistration ConfigMap" >&2; exit 1; }
+grep -qE 'sso.openova.io/app-registration: "agenity-agnstar"' <<<"$g" || { echo "FAIL: AppRegistration not labelled for bp-sso-bridge" >&2; exit 1; }
+grep -qE 'kind: ExternalSecret' <<<"$g"                               || { echo "FAIL: no client-secret ExternalSecret (with external-secrets API)" >&2; exit 1; }
+grep -qE 'key: "sso/sovereign/agenity-agnstar"' <<<"$g"               || { echo "FAIL: ExternalSecret remoteRef not sso/sovereign/agenity-agnstar" >&2; exit 1; }
 # #5416 — the cookie secret is NO LONGER a chart-minted Secret. It is carried in
 # the SAME bp-sso-bridge/OpenBao bundle as the client secret and delivered by the
 # `-oidc` ExternalSecret, because a chart-minted value is generated INDEPENDENTLY
@@ -65,22 +65,22 @@ echo "$g" | grep -qE 'key: "sso/sovereign/agenity-agnstar"'               || { e
 #   (c) the oauth2-proxy Deployment actually CONSUMES it from that Secret.
 # (c) matters most: an unconsumed key would satisfy (a)+(b) while the Pod still
 # read a per-region value — exactly the inert-copy trap hubble was carrying.
-echo "$g" | grep -qE 'cookie-secret: "\{\{ \.cookie_secret \}\}"'         || { echo "FAIL: -oidc ExternalSecret template does not publish a cookie-secret key (#5416)" >&2; echo "$g" >&2; exit 1; }
-echo "$g" | grep -qE 'property: cookie_secret'                            || { echo "FAIL: -oidc ExternalSecret does not resolve the shared bundle's cookie_secret (#5416)" >&2; exit 1; }
-echo "$g" | grep -qzE 'name: OAUTH2_PROXY_COOKIE_SECRET[[:space:]]+valueFrom:[[:space:]]+secretKeyRef:[[:space:]]+name: "oidc-gate-agenity-agnstar-oidc"[[:space:]]+key: cookie-secret' \
+grep -qE 'cookie-secret: "\{\{ \.cookie_secret \}\}"' <<<"$g"         || { echo "FAIL: -oidc ExternalSecret template does not publish a cookie-secret key (#5416)" >&2; echo "$g" >&2; exit 1; }
+grep -qE 'property: cookie_secret' <<<"$g"                            || { echo "FAIL: -oidc ExternalSecret does not resolve the shared bundle's cookie_secret (#5416)" >&2; exit 1; }
+grep -qzE 'name: OAUTH2_PROXY_COOKIE_SECRET[[:space:]]+valueFrom:[[:space:]]+secretKeyRef:[[:space:]]+name: "oidc-gate-agenity-agnstar-oidc"[[:space:]]+key: cookie-secret' <<<"$g" \
   || { echo "FAIL: OAUTH2_PROXY_COOKIE_SECRET is not consumed from oidc-gate-agenity-agnstar-oidc#cookie-secret (#5416)" >&2; echo "$g" >&2; exit 1; }
 # Regression guard: no chart-minted per-region cookie value may come back.
-if echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar-cookie"'; then
+if grep -qE 'name: "oidc-gate-agenity-agnstar-cookie"' <<<"$g"; then
   echo "FAIL: a chart-minted cookie Secret rendered — that value is generated per region and breaks ~50% of requests behind the shared VIP (#5416)" >&2; exit 1
 fi
-echo "$g" | grep -qE -- '--client-id=agenity-agnstar'                     || { echo "FAIL: oauth2-proxy --client-id not agenity-agnstar" >&2; exit 1; }
-echo "$g" | grep -qE -- '--upstream=http://agenity-bp-agenity\..*\.svc\.cluster\.local:8080' || { echo "FAIL: gate --upstream not the agenity Service" >&2; echo "$g" >&2; exit 1; }
-echo "$g" | grep -qE -- '--login-url=https://auth\.agnstar\.omani\.homes/realms/sovereign.*kc_idp_hint=catalyst-pin' || { echo "FAIL: silent SSO login-url/kc_idp_hint missing" >&2; exit 1; }
+grep -qE -- '--client-id=agenity-agnstar' <<<"$g"                     || { echo "FAIL: oauth2-proxy --client-id not agenity-agnstar" >&2; exit 1; }
+grep -qE -- '--upstream=http://agenity-bp-agenity\..*\.svc\.cluster\.local:8080' <<<"$g" || { echo "FAIL: gate --upstream not the agenity Service" >&2; echo "$g" >&2; exit 1; }
+grep -qE -- '--login-url=https://auth\.agnstar\.omani\.homes/realms/sovereign.*kc_idp_hint=catalyst-pin' <<<"$g" || { echo "FAIL: silent SSO login-url/kc_idp_hint missing" >&2; exit 1; }
 echo "  PASS — gate resource set rendered"
 
 # spaTokenSeed redirect present (Exact / -> /app/?token=sso 302)
-echo "$g" | grep -qE 'replaceFullPath: "/app/\?token=sso"' || { echo "FAIL: missing spaTokenSeed /app/?token=sso redirect" >&2; echo "$g" >&2; exit 1; }
-echo "$g" | grep -qE 'statusCode: 302'                     || { echo "FAIL: spaTokenSeed redirect not 302" >&2; exit 1; }
+grep -qE 'replaceFullPath: "/app/\?token=sso"' <<<"$g" || { echo "FAIL: missing spaTokenSeed /app/?token=sso redirect" >&2; echo "$g" >&2; exit 1; }
+grep -qE 'statusCode: 302' <<<"$g"                     || { echo "FAIL: spaTokenSeed redirect not 302" >&2; exit 1; }
 echo "  PASS — #4556 spaTokenSeed no-paste redirect present"
 
 # EXACTLY ONE HTTPRoute (the gate's) — chart's own route suppressed
@@ -93,32 +93,32 @@ fi
 echo "  PASS — chart's own HTTPRoute suppressed (gate owns the host)"
 
 # gateway-ingress CNP admits the ingress entity to the gate
-echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar-gateway-ingress"' || { echo "FAIL: no gate gateway-ingress CiliumNetworkPolicy" >&2; exit 1; }
-echo "$g" | grep -qE 'kind: CiliumNetworkPolicy'                          || { echo "FAIL: no CiliumNetworkPolicy" >&2; exit 1; }
-echo "$g" | grep -qE 'port: "4180"'                                       || { echo "FAIL: gate CNP not admitting port 4180" >&2; exit 1; }
+grep -qE 'name: "oidc-gate-agenity-agnstar-gateway-ingress"' <<<"$g" || { echo "FAIL: no gate gateway-ingress CiliumNetworkPolicy" >&2; exit 1; }
+grep -qE 'kind: CiliumNetworkPolicy' <<<"$g"                          || { echo "FAIL: no CiliumNetworkPolicy" >&2; exit 1; }
+grep -qE 'port: "4180"' <<<"$g"                                       || { echo "FAIL: gate CNP not admitting port 4180" >&2; exit 1; }
 echo "  PASS — gateway-entity CNP present"
 
 # ── Case 2: oidcGate.enabled=false → chart's own route, NO gate ──────────────
 echo "[oidc-gate-companion] Case 2: oidcGate.enabled=false renders the chart's own route, NO gate"
 ng="$("$helm" template agenity "$chart_dir" --set "sovereignFqdn=$FQDN" --set "httpRoute.hostnames[0]=$HOST" --set oidcGate.enabled=false 2>/dev/null)"
-if echo "$ng" | grep -qE 'oidc-gate-'; then echo "FAIL: gate resources rendered with oidcGate.enabled=false" >&2; echo "$ng" >&2; exit 1; fi
+if grep -qE 'oidc-gate-' <<<"$ng"; then echo "FAIL: gate resources rendered with oidcGate.enabled=false" >&2; echo "$ng" >&2; exit 1; fi
 n2="$(echo "$ng" | grep -c 'kind: HTTPRoute' || true)"
 [ "$n2" -eq 1 ] || { echo "FAIL: expected the chart's own HTTPRoute (1), got $n2" >&2; exit 1; }
-echo "$ng" | grep -qE 'replaceFullPath: "/app/"' || { echo "FAIL: chart's own bare-root -> /app/ redirect missing" >&2; exit 1; }
+grep -qE 'replaceFullPath: "/app/"' <<<"$ng" || { echo "FAIL: chart's own bare-root -> /app/ redirect missing" >&2; exit 1; }
 echo "  PASS"
 
 # ── Case 3: fail-closed — no hostname, no fqdn → no gate ─────────────────────
 echo "[oidc-gate-companion] Case 3: fail-closed (no hostname, no sovereignFqdn) renders no gate"
 fc="$("$helm" template agenity "$chart_dir" --set 'httpRoute.hostnames={}' 2>/dev/null)"
-if echo "$fc" | grep -qE 'oidc-gate-'; then echo "FAIL: gate rendered with no hostname (must fail closed, Inviolable #4)" >&2; echo "$fc" >&2; exit 1; fi
+if grep -qE 'oidc-gate-' <<<"$fc"; then echo "FAIL: gate rendered with no hostname (must fail closed, Inviolable #4)" >&2; echo "$fc" >&2; exit 1; fi
 echo "  PASS"
 
 # ── Case 4: clientId override honoured ──────────────────────────────────────
 echo "[oidc-gate-companion] Case 4: oidcGate.clientId override honoured"
 co="$(render_gated --set oidcGate.clientId=agenity-custom)"
-echo "$co" | grep -qE -- '--client-id=agenity-custom'        || { echo "FAIL: clientId override not applied to --client-id" >&2; exit 1; }
-echo "$co" | grep -qE 'name: "oidc-gate-agenity-custom"'     || { echo "FAIL: gate name did not pick up clientId override" >&2; exit 1; }
-echo "$co" | grep -qE 'key: "sso/sovereign/agenity-custom"'  || { echo "FAIL: ExternalSecret key did not pick up clientId override" >&2; exit 1; }
+grep -qE -- '--client-id=agenity-custom' <<<"$co"        || { echo "FAIL: clientId override not applied to --client-id" >&2; exit 1; }
+grep -qE 'name: "oidc-gate-agenity-custom"' <<<"$co"     || { echo "FAIL: gate name did not pick up clientId override" >&2; exit 1; }
+grep -qE 'key: "sso/sovereign/agenity-custom"' <<<"$co"  || { echo "FAIL: ExternalSecret key did not pick up clientId override" >&2; exit 1; }
 echo "  PASS"
 
 echo "[bp-agenity #4553/#4556 oidc-gate companion] All cases PASS"

--- a/products/catalyst/chart/tests/api-single-writer-dr-contract.sh
+++ b/products/catalyst/chart/tests/api-single-writer-dr-contract.sh
@@ -61,7 +61,7 @@ if [ -z "$REPLICAS_LINE" ]; then
   echo "FAIL: catalyst-api Deployment no longer renders an explicit 'replicas:' — the single-writer contract must stay explicit, see ${DOC_REF}" >&2
   exit 1
 fi
-if ! echo "$REPLICAS_LINE" | grep -qE 'replicas:[[:space:]]*1$'; then
+if ! grep -qE 'replicas:[[:space:]]*1$' <<<"$REPLICAS_LINE"; then
   echo "FAIL: catalyst-api Deployment replicas != 1 (got: '${REPLICAS_LINE// /}')." >&2
   echo "      catalyst-api persists the tofu/deployment store on a zone-scoped RWO EVS PVC" >&2
   echo "      with no leader election — a second replica is a split-brain over infrastructure" >&2


### PR DESCRIPTION
## The mechanism

Every chart-test script runs under `set -o pipefail`, and asserts with:

```bash
if ! echo "$var" | grep -q PATTERN; then FAIL; fi
```

`grep -q` exits the **instant** it finds its first match. That closes the read
end of the pipe. `echo` is then still writing, takes `SIGPIPE`, and exits
**141**. Under `pipefail` the pipeline's status is the rightmost non-zero
status — so the pipeline reports **141**, non-zero, **even though grep
matched**. The `!` inverts that into the FAIL branch.

The assertion therefore reports FAILURE on a value that PASSES.

It only fires when the piped value is large enough that `echo` is still writing
when `grep` exits — which is why it is size-dependent, intermittent, and went
unnoticed across the whole catalog.

Deterministic local repro (400 KB value, match on line 1, 40 trials each):

```
OLD idiom  echo "$v" | grep -q      : false FAILs in 40 runs = 40
NEW idiom  grep -q ... <<<"$v"      : false FAILs in 40 runs = 0
```

## Proven real-world damage

This is not theoretical. Today it made the `blueprint-release` job step
**"Run chart integration tests"** reject the **bp-gitea 1.2.49** chart publish.
`platform/gitea/chart/tests/httproute-render.sh` Case 5 printed:

```
line 101: echo: write error: Broken pipe
FAIL: Application CR placement must be canonical 'singleton' (not banned 'single-region')
  placement: singleton
```

The assertion's own diagnostic — printed on the very next line — proved the
value was **correct**. The OCI artifact never landed, and the Sovereign-side
`HelmChart` could not resolve the pin.

Fixed there in **bf59fb5f0**, which is the reference implementation this PR
generalizes to the rest of the catalog.

## The fix

```
echo "$var" | grep -qFLAGS 'PATTERN'   ->   grep -qFLAGS 'PATTERN' <<<"$var"
```

A herestring feeds `grep` from a temp file. No pipe, no `SIGPIPE`, no spurious
141. Every grep flag (`-q`, `-qE`, `-qF`, `-qi`, `-qw`, `-qzE`, `-Eq`, and the
`--` end-of-options marker) and every pattern byte is preserved.

## Counts

| | |
|---|---|
| Scripts converted | **34** |
| Occurrences converted | **247** |
| Diff | 247 insertions, 247 deletions (pure 1-line-for-1-line rewrites) |
| `bash -n` clean | **35 / 35** (34 converted + the already-herestring `sso-bridge/3646-reconciler-marker.sh`) |

The conversion was done by a quote-aware scanner, not a naive regex. The
pattern token is walked with real bash quoting rules, so patterns carrying
escaped double quotes survive byte-identical — e.g.

```bash
grep -q "name: \"cilium-gateway\"" <<<"$route_block"
grep -q '\\"hostname\\":\\"\*\.t99\.omani\.works\\"' <<<"$CONSOLE_LINE"
grep -Eq "hostname: \"?$redirect_host\"?" <<<"$route_block"
```

A naive `sed` mangles exactly these. All 14 sites whose pattern contains a `\"`
were additionally read by eye.

The scanner is also heredoc-aware (0 rewrites landed inside a heredoc body).

### Independent round-trip check

Every one of the 247 changed lines was re-parsed **from both sides** — original
and converted — and asserted byte-identical on prefix, grep flags, `--` marker,
pattern, source variable, and trailing text:

```
changed lines round-trip-checked: 247
mismatches: 0
```

## Verification — every script was actually run

Run exactly the way CI runs them (`bash <script> <chart_dir>` from the repo
root), with `helm` on PATH.

**Before the change: 34 / 34 pass. After the change: 35 / 35 pass.**
(The 35th, `platform/sso-bridge/chart/tests/3646-reconciler-marker.sh`, already
used herestrings and needed no edit; it was run as a control.)

<details>
<summary>Per-script results (35 PASS, 0 FAIL)</summary>

```
PASS  platform/cilium/chart/tests/g117-w3d1-hubble-decorative-gate-removed.sh
PASS  platform/grafana/chart/tests/httproute-render.sh
PASS  platform/grafana/chart/tests/sso-admin-role-mapping.sh
PASS  platform/guacamole/chart/tests/g117-w3d1-sso-secret.sh
PASS  platform/guacamole/chart/tests/httproute-render.sh
PASS  platform/harbor/chart/tests/httproute-render.sh
PASS  platform/keycloak/chart/tests/frontend-url-pin.sh
PASS  platform/keycloak/chart/tests/g117-5-tier1-sso-clients.sh
PASS  platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
PASS  platform/keycloak/chart/tests/httproute-render.sh
PASS  platform/newapi/chart/tests/admin-token-pushsecret-render.sh
PASS  platform/newapi/chart/tests/bridge-readiness-render.sh
PASS  platform/newapi/chart/tests/dsn-secret-preserve-render.sh
PASS  platform/newapi/chart/tests/httproute-render.sh
PASS  platform/newapi/chart/tests/imagepullsecrets-render.sh
PASS  platform/newapi/chart/tests/startup-probe-render.sh
PASS  platform/oidc-gate/chart/tests/internal-discovery-render.sh
PASS  platform/oidc-gate/chart/tests/root-redirect-render.sh
PASS  platform/oidc-gate/chart/tests/spa-token-seed-render.sh
PASS  platform/openbao/chart/tests/continuum-render.sh
PASS  platform/openbao/chart/tests/eso-push-policy-render.sh
PASS  platform/openbao/chart/tests/httproute-render.sh
PASS  platform/openova-flow-server/chart/tests/httproute-render.sh
PASS  platform/postgres/chart/tests/postgres-render.sh
PASS  platform/powerdns-admin/chart/tests/g117-w3d1-kc-idp-hint.sh
PASS  platform/powerdns/chart/tests/hetzner-frontdoor-render.sh
PASS  platform/powerdns/chart/tests/httproute-render.sh
PASS  platform/powerdns/chart/tests/httproute-ui-redirect.sh
PASS  platform/sovereign-tls-vars/chart/tests/sovereign-tls-vars-render.sh
PASS  platform/sso-bridge/chart/tests/3646-reconciler-marker.sh   (control, unedited)
PASS  platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh
PASS  platform/stalwart-sovereign/chart/tests/sovereign-render.sh
PASS  platform/wordpress-tenant/chart/tests/imagepullsecrets-render.sh
PASS  products/agenity/chart/tests/oidc-gate-companion-render.sh
PASS  products/catalyst/chart/tests/api-single-writer-dr-contract.sh
```

</details>

**Every converted script was executed locally. There is no "converted but not
run" entry.** One note on reproducing the run:
`platform/stalwart-sovereign/chart` needs `helm dependency build` first (it
vendors `common` from the sigstore repo); CI does this in an earlier step. With
that dependency present it passes both before and after.

### Vacuity control

A guard that passes is only evidence if it can also fail. Three converted
assertions — deliberately chosen as the awkward shapes — had their pattern
corrupted, and each was confirmed to still reject:

| Site | Shape | Corrupted-pattern result |
|---|---|---|
| `grafana/httproute-render.sh:52` | pattern with escaped `\"` | bites: `FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway` |
| `agenity/oidc-gate-companion-render.sh:70` | `-qzE` + line continuation | bites: `FAIL: OAUTH2_PROXY_COOKIE_SECRET is not consumed from ...` |
| `postgres/postgres-render.sh:779` | `-qw "$canon"` + line continuation | bites: `FAIL: #3375: placementSchema.modes missing canonical mode 'singleton'` |

So the herestrings did not make the guards fail open.

## Deliberately left

**1. Output-consuming pipelines — not exposed, no change needed.**
`| grep -c`, `| grep -o`, `| grep -n`, `| grep -A/-B`, and `grep` feeding
`wc`/`head`/`sed`/`cut`. `grep` **without** `-q` drains its whole input, so the
writer never receives `SIGPIPE`. Converting these would also break them, since
they need the output. Untouched by design.

**2. Command-source `| grep -q` — named follow-up set, 134 occurrences in 25
files.** These pipe a *command* (`helm template …`, `grep … file`, `awk … file`,
`yq …`) into `grep -q` rather than a variable, so they carry the same exposure
but need a `$(…)` capture or a temp file first — a genuinely different edit
whose safety cannot be established by the same mechanical proof. The heaviest
concentrations are
`platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` (~80),
`platform/cnpg-pair/chart/tests/cnpg-pair-render.sh`,
`platform/harbor/chart/tests/*`, `platform/gitea/chart/tests/*`,
`products/catalyst/chart/tests/*`. Next action: a follow-up PR that captures to
a temp file (the pattern `cutover-contract.sh` already documents in its own
comments at lines 494 / 1300 / 3485).

**3. `printf … "$var" | grep -q` — named follow-up set, 22 occurrences in 8
files** (`harbor/admin-secret.sh`, `keycloak/pin-broker-secret-platform-only-5400.sh`,
`kyverno-policies/nodeport-enforce-5491.sh`, `postgres/postgres-render.sh`,
`self-sovereign-cutover/offline-mirror-host-projects.sh`,
`stalwart-tenant/expression-syntax.sh`, `catalyst/baseline-cnp-allowlist.sh`,
`catalyst/oidc-broker-secret-reloader-contract.sh`). Same exposure, and a
herestring is the same fix — but `printf '%s'` (no trailing newline) and `<<<`
(adds one) differ on an **empty** value, which can flip a negative assertion.
Each of those 22 needs its empty-value case reasoned about individually, so
they are held for a separate change rather than swept in mechanically here.

## Not for merge yet

Do **not** merge or enable auto-merge on this from a provisioning window — a
merge triggers a deploybot roll, and a roll mid-fire abandons an in-flight
Sovereign provision.

Refs #5531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
