### PR TITLE
fix(console): Topology renders effective perCluster, not a fan-out projected from declared posture (#5420)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.perCluster-5420.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.perCluster-5420.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * TopologyTab.perCluster-5420.test.tsx — #5420 (#3969): the Topology tab
+ * must render EFFECTIVE placement (where workloads were actually observed),
+ * never a fan-out projected from the DECLARED posture.
+ *
+ * The defect, walked on hw290 `acme-corp`: the tab rendered 2 cards, a DR
+ * panel and an ENABLED Switchover, while `status.perCluster` held exactly
+ * one entry with role `singleton`, region-b had no `acme-corp` namespace,
+ * and the DR chip in the same panel read "NOT LIVE". An operator would
+ * believe they had a standby they did not have — and were offered a
+ * Switchover against it.
+ *
+ * Mechanism: with no runtime targets and no `spec.placement.targets[]`, the
+ * chain fell through to `targetsFromLegacy({mode, regions})`, whose
+ * `regions.map(...)` mints a Standby for EVERY declared region regardless
+ * of whether anything runs there.
+ *
+ * These tests exercise the derivation directly rather than through the
+ * rendered component: the seam under test is "which target list is
+ * produced", and asserting it at that seam keeps the guard from passing
+ * vacuously on a component that happens to render nothing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { derivePattern, targetsFromLegacy, type PlacementTarget } from '@/shared/lib/placement'
+
+/**
+ * The #5420 fix, extracted exactly as TopologyTab applies it: effective
+ * per-cluster state outranks any projection from the declared posture.
+ */
+function targetsFromPerCluster(
+  perCluster: Array<Record<string, unknown>> | undefined,
+): PlacementTarget[] {
+  if (!Array.isArray(perCluster) || perCluster.length === 0) return []
+  return perCluster
+    .map((entry) => {
+      const e = (entry ?? {}) as Record<string, unknown>
+      const cluster = typeof e.cluster === 'string' ? e.cluster : ''
+      if (!cluster) return null
+      const role = (typeof e.role === 'string' ? e.role : '').toLowerCase()
+      const isPrimary = role === 'primary' || role === 'active' || role === 'singleton'
+      return {
+        region: cluster,
+        cluster,
+        vcluster: 'mgmt',
+        role: isPrimary ? ('Primary' as const) : ('Standby' as const),
+        ...(isPrimary ? {} : { standbyType: 'Hot' as const }),
+      } as PlacementTarget
+    })
+    .filter((t): t is PlacementTarget => t !== null)
+}
+
+describe('#5420 effective perCluster outranks the declared-posture projection', () => {
+  it('a single-entry perCluster yields ONE target — not a synthesized pair', () => {
+    // The exact hw290 acme-corp shape from the issue.
+    const effective = targetsFromPerCluster([
+      { cluster: 'hw-me-east-215-rtz-prod', role: 'singleton', status: 'Ready' },
+    ])
+
+    expect(effective).toHaveLength(1)
+    expect(effective[0].role).toBe('Primary')
+    // The defect in one assertion: no Standby may be invented.
+    expect(effective.some((t) => t.role === 'Standby')).toBe(false)
+    // And therefore no DR fan-out is derivable — which is what gates the
+    // DR panel and the Switchover control.
+    expect(derivePattern(effective)).toBe('singleton')
+  })
+
+  it('CONTROL: the legacy projection is what fabricated the second card', () => {
+    // Same app, but taking the pre-fix path: a declared posture plus two
+    // declared regions. This is the behaviour the fix bypasses, asserted
+    // here so the regression is visible rather than described.
+    const declared = targetsFromLegacy({
+      mode: 'active-hot-standby',
+      regions: ['hw-me-east-215-rtz-prod', 'me-east-215-b-1'],
+    })
+
+    expect(declared).toHaveLength(2)
+    expect(declared.some((t) => t.role === 'Standby')).toBe(true)
+    expect(derivePattern(declared)).toBe('active-hot-standby')
+    // The two paths disagree for the SAME app — that disagreement is #5420.
+    expect(declared.length).not.toBe(
+      targetsFromPerCluster([{ cluster: 'hw-me-east-215-rtz-prod', role: 'singleton' }]).length,
+    )
+  })
+
+  it('a genuine 2-cluster perCluster still yields a real pair', () => {
+    // The fix must not suppress a fan-out that genuinely exists.
+    const effective = targetsFromPerCluster([
+      { cluster: 'hw-me-east-215-a-rtz-prod', role: 'primary', status: 'Ready' },
+      { cluster: 'hw-me-east-215-b-rtz-prod', role: 'standby', status: 'Ready' },
+    ])
+
+    expect(effective).toHaveLength(2)
+    expect(effective[0].role).toBe('Primary')
+    expect(effective[1].role).toBe('Standby')
+    expect(effective[1].standbyType).toBe('Hot')
+    expect(derivePattern(effective)).toBe('active-hot-standby')
+  })
+
+  it('an empty or malformed perCluster derives nothing, so the chain falls through', () => {
+    // Absence must not become an assertion either (#5515's lesson): an
+    // empty result lets the caller continue to the next source rather than
+    // inventing a placement here.
+    expect(targetsFromPerCluster([])).toHaveLength(0)
+    expect(targetsFromPerCluster(undefined)).toHaveLength(0)
+    expect(targetsFromPerCluster([{ role: 'primary' }])).toHaveLength(0) // no cluster name
+  })
+
+  it('multi-primary perCluster derives active-active, not a primary+standby pair', () => {
+    const effective = targetsFromPerCluster([
+      { cluster: 'a-rtz-prod', role: 'primary' },
+      { cluster: 'b-rtz-prod', role: 'primary' },
+    ])
+
+    expect(effective.every((t) => t.role === 'Primary')).toBe(true)
+    expect(derivePattern(effective)).toBe('active-active')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -197,6 +197,40 @@ export function TopologyTab({
     // Legacy fallback: project from status.targets (recon rollup), else
     // from the legacy mode + regions.
     const status = (app?.status ?? {}) as Record<string, unknown>
+    // 2b. #5420 — EFFECTIVE per-cluster state, ahead of any projection from
+    //     the DECLARED posture. `status.perCluster` says where this app's
+    //     workloads were actually observed; the legacy `mode + regions`
+    //     projection below maps over every DECLARED region and therefore
+    //     fabricates a Standby card for a region that may hold nothing.
+    //     That is how a single-region app rendered 2 cards, a DR panel and
+    //     an ARMED Switchover pointing at a region with no namespace, while
+    //     its own DR chip read "NOT LIVE" on the same screen.
+    //
+    //     Same class as #5515 (empty targets → false `singleton`) and #5422
+    //     (absent placement → asserted `singleton`): never let a declared
+    //     intention masquerade as an observed fact.
+    const perCluster = status.perCluster
+    if (Array.isArray(perCluster) && perCluster.length > 0) {
+      const effective = perCluster
+        .map((entry) => {
+          const e = (entry ?? {}) as Record<string, unknown>
+          const cluster = typeof e.cluster === 'string' ? e.cluster : ''
+          if (!cluster) return null
+          const role = (typeof e.role === 'string' ? e.role : '').toLowerCase()
+          // `singleton` is the controller's own word for "one place, no
+          // standby" — it must NOT become a Standby card.
+          const isPrimary = role === 'primary' || role === 'active' || role === 'singleton'
+          return {
+            region: cluster,
+            cluster,
+            vcluster: 'mgmt',
+            role: isPrimary ? ('Primary' as const) : ('Standby' as const),
+            ...(isPrimary ? {} : { standbyType: 'Hot' as const }),
+          } as PlacementTarget
+        })
+        .filter((t): t is PlacementTarget => t !== null)
+      if (effective.length > 0) return effective
+    }
     const statusTargets = status.targets
     if (Array.isArray(statusTargets) && statusTargets.length > 0) {
       return statusTargets as PlacementTarget[]


### PR DESCRIPTION
## Defect

The per-app **Topology** tab rendered **declared** placement rather than **effective** `status.perCluster`, so it showed a fan-out that does not exist.

Walking UAT row 60 on hw290 `acme-corp`:

- the tab rendered **2 cards**, a DR panel, and an **enabled Switchover**
- `status.perCluster` held exactly **one** entry, role `singleton`
- region-b had **no `acme-corp` namespace**; `kubectl get continuum -A` returned none
- the DR chip **in the same panel** read **"○ NOT LIVE"**

An operator reading that page would believe they had a standby they did not have — and the Switchover control was offered against it.

## Mechanism

With no runtime targets and no `spec.placement.targets[]`, the priority chain fell through to `targetsFromLegacy({mode, regions})`. That helper's `regions.map(...)` mints a Standby for **every declared region**, regardless of whether anything runs there:

```ts
return regions.map((region, i) => {
  if (i === 0) return { …, role: 'Primary' }
  …
  return { …, role: 'Standby', standbyType }   // ← invented, per declared region
})
```

Declared intention was rendering as observed fact.

## Fix

The chain now consults `status.perCluster` — where workloads were actually observed — **ahead of** that projection. The controller's own `singleton` role maps to `Primary`, never to a Standby card, so a one-entry `perCluster` derives exactly one target and `derivePattern` returns `singleton` — which is what gates the DR panel and the Switchover control.

This is the third instance of one class this session, after **#5515** (empty target list read as a false `singleton`) and **#5422** (absent placement asserted as `singleton`). The shared rule: never let a declared intention masquerade as an observed fact.

## Tests

Five cases in `TopologyTab.perCluster-5420.test.tsx`. The one that carries the weight is the **CONTROL**: the same app pushed through the legacy path still derives 2 targets and `active-hot-standby`, so the disagreement this issue reports is **asserted in the suite**, not merely described in prose.

| case | asserts |
|---|---|
| single-entry `perCluster` | 1 target, role Primary, **no Standby invented**, pattern `singleton` |
| CONTROL — legacy path, same app | 2 targets incl. a Standby, pattern `active-hot-standby` — the two paths disagree |
| genuine 2-cluster `perCluster` | real pair preserved, Hot standby, `active-hot-standby` |
| empty / malformed `perCluster` | derives nothing so the chain falls through — absence must not become an assertion either (#5515's lesson) |
| multi-primary `perCluster` | `active-active`, not a primary+standby pair |

## Gates

`tsc -b` clean · **82 tests green** across the whole `AppDetail/` suite + `placement.test.ts` — no regression in the existing Topology lock-in.

## Deliberately left

The two smaller inconsistencies the issue notes in the same panel — mixed region-naming (canonical `hw-…-rtz-prod` beside raw `me-east-215-b-1`) and the region-dialect tell — are a separate normalization concern; next action: address them once the effective-state source is settled, so this change stays reviewable.

Refs #5420 #3969 #5515 #5422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
