### PR TITLE
fix(catalog): make catalog generation deterministic so the committed output can converge (#5520)

### DIFF
--- a/.github/workflows/check-catalog-generated-drift.yaml
+++ b/.github/workflows/check-catalog-generated-drift.yaml
@@ -1,0 +1,89 @@
+name: check — generated catalog is in sync (#5520)
+
+# The committed `blueprints.json` + `catalog.generated.ts` are BUILD OUTPUT:
+# `npm run build` in products/catalyst/bootstrap/ui runs a `prebuild` step
+# that regenerates them from the blueprint sources. When the committed copies
+# drift from what the generator produces, every PR that runs a real build
+# carries a spurious diff, and authors either commit unrelated churn or revert
+# it by hand. The revert path was the common one, which is exactly how the
+# 508-line drift in #5520 accumulated unnoticed — and it broke StepComponents
+# tests that then read as "pre-existing and unrelated".
+#
+# This gate makes the drift impossible to accumulate silently: regenerate, and
+# fail if the working tree changed. It is the mechanical enforcement of
+# "generated files are committed in sync", the same shape as the repo's other
+# drift guards (cluster-template-drift, check-catalog-seed-lockstep).
+#
+# Prerequisite that makes this gate meaningful: the generator is DETERMINISTIC.
+# `generatedAt` used to be a wall-clock stamp, so a rebuild of identical input
+# always produced a diff and a gate like this could never have gone green.
+# build-catalog.mjs now preserves the prior stamp when the content is
+# unchanged, so `generatedAt` marks when the catalog CONTENT last changed.
+
+on:
+  pull_request:
+    paths:
+      - 'platform/*/blueprint.yaml'
+      - 'products/*/blueprint.yaml'
+      - 'clusters/_template/bootstrap-kit/**'
+      - 'products/catalyst/bootstrap/ui/scripts/build-catalog.mjs'
+      - 'products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts'
+      - 'products/catalyst/bootstrap/api/internal/catalog/blueprints.json'
+      - '.github/workflows/check-catalog-generated-drift.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'platform/*/blueprint.yaml'
+      - 'products/*/blueprint.yaml'
+      - 'clusters/_template/bootstrap-kit/**'
+      - 'products/catalyst/bootstrap/ui/scripts/build-catalog.mjs'
+      - 'products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts'
+      - 'products/catalyst/bootstrap/api/internal/catalog/blueprints.json'
+  workflow_dispatch:
+
+jobs:
+  drift:
+    name: regenerate and prove no diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Regenerate the catalog
+        working-directory: products/catalyst/bootstrap/ui
+        run: node scripts/build-catalog.mjs
+
+      - name: Prove the generator is deterministic (run it twice)
+        working-directory: products/catalyst/bootstrap/ui
+        run: |
+          set -euo pipefail
+          cp ../api/internal/catalog/blueprints.json /tmp/first.json
+          node scripts/build-catalog.mjs
+          if ! diff -q /tmp/first.json ../api/internal/catalog/blueprints.json >/dev/null; then
+            echo "::error::build-catalog.mjs is NOT deterministic — two consecutive runs on identical input produced different output."
+            diff -u /tmp/first.json ../api/internal/catalog/blueprints.json | head -40 || true
+            exit 1
+          fi
+          echo "deterministic: two consecutive runs are byte-identical"
+
+      - name: Fail if the committed generated files drifted
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet -- \
+              products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts \
+              products/catalyst/bootstrap/api/internal/catalog/blueprints.json; then
+            echo "::error::The committed generated catalog is stale (#5520). Run 'node scripts/build-catalog.mjs' in products/catalyst/bootstrap/ui and COMMIT the result — do not revert it."
+            echo ""
+            echo "Drift:"
+            git --no-pager diff --stat -- \
+              products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts \
+              products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+            git --no-pager diff -- \
+              products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts \
+              products/catalyst/bootstrap/api/internal/catalog/blueprints.json | head -80
+            exit 1
+          fi
+          echo "generated catalog is in sync with build-catalog.mjs"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-30T13:12:27.881Z",
+  "generatedAt": "2026-07-31T16:28:03.702Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -1687,7 +1687,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.48",
+      "version": "1.2.49",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"

--- a/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
+++ b/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
@@ -723,15 +723,31 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = ${JSON.stringify(boot
 
   // Sister JSON output for the Go catalyst-api side. The Sovereign
   // Console's /api/v1/sovereign/apps endpoint embeds this via go:embed.
-  const jsonBody = JSON.stringify(
-    {
-      generatedAt: new Date().toISOString(),
-      blueprints: entries,
-      bootstrapKit,
-    },
-    null,
-    2,
-  )
+  //
+  // #5520 — `generatedAt` marks when the catalog CONTENT last changed, NOT
+  // when someone last ran a build. A wall-clock stamp made this generated
+  // file non-deterministic: every `npm run build` rewrote it, so every PR
+  // that ran a real build carried a spurious diff. Authors then either
+  // committed unrelated churn or reverted it by hand — and because the
+  // revert path was the common one, the committed file never converged with
+  // the generator (that is how the 508-line drift accumulated).
+  //
+  // Preserving the prior stamp when nothing else changed makes the field
+  // both deterministic AND more truthful: consumers (catalog.GeneratedAt →
+  // /sovereign/apps + /org applications) want to know when the catalog they
+  // are serving last CHANGED, which a rebuild-of-identical-input does not.
+  const payload = { blueprints: entries, bootstrapKit }
+  let generatedAt = new Date().toISOString()
+  try {
+    const prev = JSON.parse(readFileSync(OUT_FILE_JSON, 'utf8'))
+    const { generatedAt: prevStamp, ...prevPayload } = prev
+    if (prevStamp && JSON.stringify(prevPayload) === JSON.stringify(payload)) {
+      generatedAt = prevStamp // content identical — keep the real change time
+    }
+  } catch {
+    // No prior file (or unreadable/corrupt) — this IS a fresh generation.
+  }
+  const jsonBody = JSON.stringify({ generatedAt, ...payload }, null, 2)
   mkdirSync(dirname(OUT_FILE_JSON), { recursive: true })
   writeFileSync(OUT_FILE_JSON, jsonBody + '\n')
 

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1822,7 +1822,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.48",
+    "version": "1.2.49",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"


### PR DESCRIPTION
## Root cause

`build-catalog.mjs` stamped the output with `generatedAt: new Date().toISOString()`, so a rebuild of **identical input** always rewrote `blueprints.json`. The generated files could therefore never converge with the generator:

- every PR that ran a real build carried a spurious diff
- authors either committed unrelated churn or reverted by hand
- the **revert path was the common one**, so the committed copies fell further behind on every cycle

That is how the 508-line drift accumulated unnoticed, and how it came to fail `StepComponents` (`expected [...] to include 'axon'`) while reading as "pre-existing and unrelated" noise.

Two distinct causes were tangled together, which is worth separating because only one of them is a bug:

| cause | status |
|---|---|
| non-deterministic `generatedAt` — permanent churn engine | **the defect**, fixed here |
| genuine content drift (508 lines) | already absorbed by #5526 (`8523ecf33`) |
| genuine content drift (bp-gitea 1.2.48 → 1.2.49) | real, committed here |

## Fix

`generatedAt` now marks **when the catalog content last changed**: the generator preserves the prior stamp when the rest of the payload is byte-identical.

This is deterministic *and* more truthful. Its consumers — `catalog.GeneratedAt()` feeding `/sovereign/apps` and the per-Org applications endpoints — want to know when the catalog they are serving last *changed*; a rebuild of unchanged input did not change it. Deleting the field was not available: three Go call sites surface it in API responses.

Proven by running the generator three times — runs 2 and 3 are byte-identical to run 1.

## Gate

`check-catalog-generated-drift.yaml` regenerates and fails on any diff, so this cannot silently re-accumulate.

It also asserts **determinism directly** — two consecutive runs must be byte-identical. That check is the reason such a gate could not have existed before: against the old wall-clock stamp it would have failed on every single run, which is exactly why the drift had no guard.

## Verification

- generator run ×3 → byte-identical output after the first
- both gate legs simulated locally: the determinism leg passes; the in-sync leg correctly **failed** on the pending bp-gitea drift before it was committed, and passes after
- workflow YAML parses

Refs #5520

🤖 Generated with [Claude Code](https://claude.com/claude-code)
