### PR TITLE
fix(catalyst-api): stop POST /organizations reporting terminal success over an unprovisioned Organization

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_boundary_observation.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_boundary_observation.go
@@ -1,0 +1,149 @@
+// org_boundary_observation.go — #5501. The Organization provisioning
+// pipeline (organization_provisioning.go) is a chain of SUBMITS: it commits
+// a GitOps overlay, writes DNS rrsets, creates Keycloak clients, writes a
+// registry row and POSTs the canonical Organization CR. Not one of those
+// steps observes that the Organization's boundary — the per-Org namespace or
+// the dedicated vCluster — actually came up, because the boundary is authored
+// downstream by the org-controller reconciling the CR the pipeline mints.
+//
+// Before this file the pipeline nevertheless marched to the terminal STSDone
+// in the same request, so `POST /api/v1/organizations` answered
+// `state:"done"` with six `"done"` steps in ZERO seconds while the walked
+// Sovereign had no namespace, no vCluster and an empty `status.phase`
+// (hw291, 2026-07-29). The truth was already on the cluster: the CR the
+// pipeline had just minted said `status.vcluster.phase: Pending`.
+//
+// This file is the read-back seam. It resolves the SAME dynamic client the
+// CR mint uses (sovereignDepsFor — test-overridable via
+// SetSovereignDepsFactory) and reports the observed boundary phase, which
+// the pipeline stamps onto the record, gates STSDone on, and the wire
+// response derives its substrate-side steps from.
+//
+// Deliberately fail-CLOSED: "no in-cluster client" / "the read errored" is
+// reported as UNOBSERVED (empty phase, ready=false), never as ready. An
+// Organization whose substrate nobody could look at is not a provisioned
+// Organization, and publishing terminal success for it is the exact defect
+// this file exists to remove. Nothing is stranded by that choice — the
+// record stays at the highest non-terminal state and the NATS-driven
+// reconciler (ReconcileAllPending, which walks every non-terminal row)
+// re-runs the pipeline until the boundary is observed Ready.
+
+package handler
+
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// Boundary phases. These mirror the org-controller's ladder
+// (core/controllers/organization/internal/controller/organization_controller.go
+// vclusterReadiness): Pending → Provisioning → Ready, plus Failed.
+const (
+	boundaryPhaseReady        = "Ready"
+	boundaryPhaseProvisioning = "Provisioning"
+	boundaryPhasePending      = "Pending"
+	boundaryPhaseFailed       = "Failed"
+)
+
+// boundaryPhaseFromCR derives the observed boundary phase from an
+// Organization CR. Both tiers are covered by the SAME read, because the
+// org-controller reports them differently (#5489):
+//
+//   - vcluster tier (plan m/l/xl/flexi): `status.vcluster.phase` carries the
+//     ladder — the controller only stamps that block when it actually
+//     authors a vCluster.
+//   - host-namespace tier (internal, plan ""/s/free): NO vcluster block is
+//     ever written, so readiness is the top-level Ready condition the
+//     controller stamps once the `<slug>` namespace exists.
+//
+// Returns "" ONLY for an object that carries no status at all — an honest
+// "the controller has not observed this object yet", which is exactly what
+// the walked hw291 Org looked like seconds after create.
+func boundaryPhaseFromCR(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ""
+	}
+	if phase, _, _ := unstructured.NestedString(obj.Object, "status", "vcluster", "phase"); strings.TrimSpace(phase) != "" {
+		switch strings.ToLower(strings.TrimSpace(phase)) {
+		case "ready":
+			return boundaryPhaseReady
+		case "failed":
+			return boundaryPhaseFailed
+		case "provisioning":
+			return boundaryPhaseProvisioning
+		default:
+			return boundaryPhasePending
+		}
+	}
+	// Host-namespace tier: the Ready condition is the boundary signal.
+	conds, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	for _, c := range conds {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		ctype, _ := cm["type"].(string)
+		if !strings.EqualFold(ctype, "Ready") {
+			continue
+		}
+		cstatus, _ := cm["status"].(string)
+		if strings.EqualFold(cstatus, "True") {
+			return boundaryPhaseReady
+		}
+		// An explicit Ready=False means the controller HAS observed the
+		// object and is still working on it.
+		return boundaryPhaseProvisioning
+	}
+	return ""
+}
+
+// observeOrgBoundary reads back the canonical Organization CR for rec and
+// reports (phase, ready).
+//
+//   - ready is true ONLY for an observed Ready boundary.
+//   - phase is "" whenever the substrate could not be observed at all (no
+//     in-cluster dynamic client — CI / out-of-cluster catalyst-api — or the
+//     Get errored). An absent CR is a real observation, not an unknown: the
+//     pipeline mints the CR before calling this, so a missing object means
+//     the mint did not land, and the boundary is reported Pending.
+func (h *Handler) observeOrgBoundary(ctx context.Context, rec store.OrganizationProvisionRecord) (string, bool) {
+	slug := strings.ToLower(strings.TrimSpace(rec.Subdomain))
+	if slug == "" {
+		return "", false
+	}
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		// Unobservable — NOT "ready". See the fail-closed note in the file
+		// header.
+		h.log.Info("org-tenant: boundary unobserved — no in-cluster dynamic client; holding non-terminal",
+			"slug", slug, "org_tenant_id", rec.OrganizationID, "err", err)
+		return "", false
+	}
+	obj, err := deps.dyn.Resource(organizationGVR()).Get(ctx, slug, metav1.GetOptions{})
+	if err != nil || obj == nil {
+		h.log.Warn("org-tenant: boundary unobserved — Organization CR read failed; holding non-terminal",
+			"slug", slug, "org_tenant_id", rec.OrganizationID, "err", err)
+		return "", false
+	}
+	phase := boundaryPhaseFromCR(obj)
+	return phase, phase == boundaryPhaseReady
+}
+
+// boundaryStepFor maps an observed boundary phase onto the wire step value
+// the SPA renders. An UNOBSERVED boundary ("") is "pending" — the honest
+// rendering of "this has not been seen to exist", never "done".
+func boundaryStepFor(phase string) string {
+	switch phase {
+	case boundaryPhaseReady:
+		return "done"
+	case boundaryPhaseFailed:
+		return "failed"
+	default:
+		return "pending"
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_create_fake_green_5501_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_create_fake_green_5501_test.go
@@ -1,0 +1,380 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// Tests for #5501 — `POST /api/v1/organizations` answered HTTP 202 with
+// `state:"done"`, all six provisioning steps `"done"`, in ZERO seconds, over a
+// Sovereign that had no namespace, no vCluster and an empty `status.phase`
+// (walked live on hw291, 2026-07-29). Unlike every other fake-green in this
+// codebase — a display reading stale data — this one FABRICATED SUCCESS AT
+// CREATION on the write path.
+//
+// Anti-theater: every case is proven in BOTH directions. The fresh-create
+// assertions fail against the pre-fix code (which reported done/6-done), and
+// the observed-Ready control assertions pin that an Organization whose
+// boundary IS up still reports done — a fix that simply inverted the bug
+// ("never report success") would satisfy the first half and break the second.
+
+// newOrgPipelineHandlerWithCRs wires the FULL Organization provisioning
+// pipeline (gitops/dns/keycloak/registry stubs — the same fakes the #804
+// suite uses) AND a fake dynamic client pre-seeded with the supplied
+// Organization CRs, so the create path can be exercised against a cluster
+// whose boundary state we control.
+func newOrgPipelineHandlerWithCRs(t *testing.T, crs ...*unstructured.Unstructured) (*Handler, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	// The pipeline's step-7 console-TLS finaliser polls the console Gateway
+	// for listener admission and spends its whole 60s budget against a fake
+	// client that has no Gateway. Shrink it the way org_console_tls_test.go
+	// does, or five creates alone would push the package past its 10m
+	// deadline.
+	prevBudget, prevInterval := orgConsoleListenerAdmitBudget, orgConsoleListenerAdmitPollInterval
+	orgConsoleListenerAdmitBudget = 50 * time.Millisecond
+	orgConsoleListenerAdmitPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		orgConsoleListenerAdmitBudget, orgConsoleListenerAdmitPollInterval = prevBudget, prevInterval
+	})
+
+	dir := t.TempDir()
+	tenantStore, err := store.NewOrganizationProvisionStore(dir)
+	if err != nil {
+		t.Fatalf("tenant store: %v", err)
+	}
+	registry, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("tenant registry: %v", err)
+	}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	h.SetTenantRegistry(registry)
+	h.SetOrganizationDeps(OrganizationDeps{
+		Store:            tenantStore,
+		GitOps:           &fakeGitOps{},
+		DNS:              &fakeDNS{},
+		KeycloakClients:  &fakeKCClients{},
+		Events:           &fakeTenantEmitter{},
+		TenantRegistry:   registry,
+		OTECHFQDN:        "otech.example",
+		OTECHIngressIPv4: "192.0.2.10",
+		MaxRetryCount:    5,
+	})
+
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		organizationGVR(): "OrganizationList",
+	}
+	objs := make([]runtime.Object, 0, len(crs))
+	for _, c := range crs {
+		objs = append(objs, c)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, objs...)
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: dyn}, nil
+	})
+	return h, dyn
+}
+
+// orgCRHostNsReady builds a host-namespace-tier Organization CR (customer +
+// plan s — the tier the walked hw291 Org actually was) whose boundary the
+// org-controller has reported READY via the top-level Ready condition. A
+// host-ns Org never gets a `status.vcluster` block (#5489), so the condition
+// is the only readiness signal — the fixture deliberately omits the block.
+func orgCRHostNsReady(slug string) *unstructured.Unstructured {
+	cr := orgReadyCR(slug, strings.ToUpper(slug), "", "owner@"+slug+".test", "")
+	cr.Object["status"] = map[string]any{
+		"conditions": []any{
+			map[string]any{"type": "Ready", "status": "True", "reason": "Provisioned"},
+		},
+	}
+	return cr
+}
+
+func postCreateOrg(t *testing.T, h *Handler, body string) (*httptest.ResponseRecorder, orgTenantResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleCreateOrganization(w, req)
+	var got orgTenantResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode create response: %v body=%s", err, w.Body.String())
+	}
+	return w, got
+}
+
+// TestCreateOrganization_FreshOrgIsNotTerminal_5501 is the issue's explicit
+// task: a freshly-created Organization must report a NON-terminal state and
+// non-"done" steps until the substrate is actually observed.
+//
+// The pipeline mints the Organization CR inside this very request, so the CR
+// exists with NO status — precisely the hw291 shape. Pre-fix this returned
+// `state:"done"` + six "done" steps; the fix holds it at tenant_registered
+// with the substrate-side steps reporting the unobserved boundary.
+func TestCreateOrganization_FreshOrgIsNotTerminal_5501(t *testing.T) {
+	h, dyn := newOrgPipelineHandlerWithCRs(t)
+
+	w, got := postCreateOrg(t, h, `{
+		"subdomain":    "uatcorp",
+		"admin_email":  "admin@uatcorp.test",
+		"company_name": "UAT Corp",
+		"domain_mode":  "free-subdomain"
+	}`)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status: want 202 got %d body=%s", w.Code, w.Body.String())
+	}
+	// 202 is correct — the resource IS being created. The body is what lied.
+	if got.State == store.STSDone {
+		t.Fatalf("fresh create must NOT report terminal success: state=%q — no namespace, no vCluster and no status.phase exist yet (#5501)", got.State)
+	}
+	if got.State != store.STSTenantRegistered {
+		t.Errorf("fresh create should hold at the highest NON-terminal state; want %q got %q (lastError=%q)",
+			store.STSTenantRegistered, got.State, got.LastError)
+	}
+	if got.Steps.BPCharts == "done" {
+		t.Errorf("steps.bp_charts must not claim done over a boundary that has not been observed: got %q (#5501)", got.Steps.BPCharts)
+	}
+	if got.Steps.BPCharts != "pending" {
+		t.Errorf("steps.bp_charts: want pending (boundary unobserved) got %q", got.Steps.BPCharts)
+	}
+
+	// Raw-JSON check — the struct decode cannot see an omitted key, and the
+	// #5489 vcluster-step omission rides omitempty.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	var steps map[string]string
+	if err := json.Unmarshal(raw["steps"], &steps); err != nil {
+		t.Fatalf("decode steps: %v", err)
+	}
+	if _, present := steps["vcluster"]; present {
+		t.Errorf("namespace-tier Org must not carry a vcluster step at all (#5489), got %v", steps)
+	}
+	doneCount := 0
+	for _, v := range steps {
+		if v == "done" {
+			doneCount++
+		}
+	}
+	if doneCount == len(steps) {
+		t.Errorf("every step reported done in zero seconds — the exact #5501 defect; steps=%v", steps)
+	}
+
+	// Vacuity control: the pipeline really did run (the CR was minted), so
+	// the non-terminal state above is a HONEST read of an unready boundary,
+	// not a pipeline that silently did nothing.
+	if _, err := dyn.Resource(organizationGVR()).Get(context.Background(), "uatcorp", metav1.GetOptions{}); err != nil {
+		t.Fatalf("precondition: the pipeline must still mint the Organization CR: %v", err)
+	}
+	if got.CommitSHA == "" {
+		t.Errorf("precondition: the GitOps overlay must still be committed (commit_sha empty)")
+	}
+}
+
+// TestCreateOrganization_ObservedReadyBoundary_ReportsDone_5501 is the
+// CONTROL direction: an Organization whose boundary the org-controller has
+// already reported Ready must STILL report done with a fully green timeline.
+// Without this case the fix could have been "never report success", which
+// would break every genuinely-provisioned Org.
+func TestCreateOrganization_ObservedReadyBoundary_ReportsDone_5501(t *testing.T) {
+	// The CR exists and is Ready BEFORE the create (same-slug re-provision:
+	// ensureOrganizationCR treats AlreadyExists as success and leaves the
+	// controller-owned status untouched).
+	h, _ := newOrgPipelineHandlerWithCRs(t, orgCRHostNsReady("acme"))
+
+	w, got := postCreateOrg(t, h, `{
+		"subdomain":   "acme",
+		"admin_email": "admin@acme.test",
+		"domain_mode": "free-subdomain"
+	}`)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status: want 202 got %d body=%s", w.Code, w.Body.String())
+	}
+	if got.State != store.STSDone {
+		t.Fatalf("an Org whose boundary is OBSERVED Ready must still report done, got %q (lastError=%q)", got.State, got.LastError)
+	}
+	for name, step := range map[string]string{
+		"bp_charts":        got.Steps.BPCharts,
+		"dns":              got.Steps.DNS,
+		"certs":            got.Steps.Certs,
+		"keycloak_clients": got.Steps.KeycloakClients,
+		"registry":         got.Steps.Registry,
+	} {
+		if step != "done" {
+			t.Errorf("completed Org: steps.%s want done got %q", name, step)
+		}
+	}
+}
+
+// TestOrganization_HeldRecordPromotedWhenBoundaryTurnsReady_5501 proves the
+// held record is not STRANDED: once the org-controller reports the boundary
+// Ready, the NATS-driven reconciler promotes the same record to done. This is
+// what makes the honest non-terminal answer safe — the caller's Organization
+// still completes, it just completes when it is true rather than when it is
+// submitted.
+func TestOrganization_HeldRecordPromotedWhenBoundaryTurnsReady_5501(t *testing.T) {
+	h, dyn := newOrgPipelineHandlerWithCRs(t)
+
+	_, created := postCreateOrg(t, h, `{
+		"subdomain":   "latecorp",
+		"admin_email": "admin@latecorp.test",
+		"domain_mode": "free-subdomain"
+	}`)
+	if created.State == store.STSDone {
+		t.Fatalf("precondition: fresh create must be non-terminal, got %q", created.State)
+	}
+
+	// The org-controller finishes authoring the boundary and stamps Ready.
+	ctx := context.Background()
+	cr, err := dyn.Resource(organizationGVR()).Get(ctx, "latecorp", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get minted CR: %v", err)
+	}
+	cr.Object["status"] = map[string]any{
+		"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+	}
+	if _, err := dyn.Resource(organizationGVR()).Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("stamp Ready on CR: %v", err)
+	}
+
+	// The reconciler walks every non-terminal row.
+	h.ReconcileAllPending(ctx)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/"+created.OrganizationID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", created.OrganizationID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	h.HandleGetOrganization(w, req)
+	var after orgTenantResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &after); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if after.State != store.STSDone {
+		t.Fatalf("after the boundary is observed Ready the record must promote to done, got %q (lastError=%q)", after.State, after.LastError)
+	}
+	if after.Steps.BPCharts != "done" {
+		t.Errorf("promoted Org: steps.bp_charts want done got %q", after.Steps.BPCharts)
+	}
+}
+
+// TestOrgCreateResponse_NeverPublishesZeroTimestamps_5501 — `created_at` /
+// `updated_at` were Go zero values (`0001-01-01T00:00:00Z`) on the create
+// response because the store stamped them on a by-value copy. A zero
+// timestamp serializes as a valid RFC-3339 instant, so every consumer reads
+// it as a real measurement. Asserted on the SERIALIZED JSON, not the struct:
+// the wire is what lied.
+func TestOrgCreateResponse_NeverPublishesZeroTimestamps_5501(t *testing.T) {
+	h, _ := newOrgPipelineHandlerWithCRs(t)
+
+	w, got := postCreateOrg(t, h, `{
+		"subdomain":   "stamped",
+		"admin_email": "admin@stamped.test",
+		"domain_mode": "free-subdomain"
+	}`)
+
+	if body := w.Body.String(); strings.Contains(body, "0001-01-01") {
+		t.Fatalf("response published a Go zero timestamp as a measurement (#5501/#5477): %s", body)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Errorf("created_at is the Go zero value")
+	}
+	if got.UpdatedAt.IsZero() {
+		t.Errorf("updated_at is the Go zero value")
+	}
+
+	// Vacuity control: the keys must actually be PRESENT and parse — an
+	// omitted-everywhere timestamp would also pass the substring check.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	for _, key := range []string{"created_at", "updated_at"} {
+		if _, present := raw[key]; !present {
+			t.Errorf("%s must be present on a record whose timestamps ARE known", key)
+		}
+	}
+
+	// The list view reads the same record back off disk — both views must
+	// agree, which is what exposed the defect live (GET had real timestamps,
+	// POST did not).
+	lw := httptest.NewRecorder()
+	h.HandleListOrganizations(lw, httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil))
+	if body := lw.Body.String(); strings.Contains(body, "0001-01-01") {
+		t.Errorf("list view published a Go zero timestamp: %s", body)
+	}
+}
+
+// TestOrgCreateResponse_NamespaceTier_OmitsVClusterName_5501 is the #5489
+// contract carried onto the create path: a namespace-isolated Org authors no
+// vCluster, so the payload must not name one. Raw-JSON assertion — the field
+// is omitempty, so a struct check alone could pass while the key still
+// shipped as `"vcluster_name": ""`.
+func TestOrgCreateResponse_NamespaceTier_OmitsVClusterName_5501(t *testing.T) {
+	h, _ := newOrgPipelineHandlerWithCRs(t)
+
+	w, got := postCreateOrg(t, h, `{
+		"subdomain":   "nsonly",
+		"admin_email": "admin@nsonly.test",
+		"domain_mode": "free-subdomain"
+	}`)
+
+	if got.Isolation != "namespace" {
+		t.Fatalf("fixture must be namespace-tier (customer + default plan s), got isolation=%q", got.Isolation)
+	}
+	if got.VClusterName != "" {
+		t.Errorf("namespace-tier Org must not name a vCluster, got vcluster_name=%q", got.VClusterName)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	if _, present := raw["vcluster_name"]; present {
+		t.Errorf("vcluster_name key must be OMITTED for a namespace-tier Org, got %s", string(raw["vcluster_name"]))
+	}
+	// Vacuity control: the payload is not empty — the fields that DO describe
+	// this Org's boundary are still present.
+	if _, present := raw["tenant_namespace"]; !present {
+		t.Errorf("tenant_namespace must still be reported")
+	}
+}
+
+// TestVClusterName_MatchesOrgControllerAuthority_5501 — the API synthesized
+// `vc-<slug>` while the CR the org-controller owns says the BARE SLUG
+// (vclusterStatusFor stamps `status.vcluster.name = <slug>`). Two names for
+// one object, and the one the API published named nothing that exists. The
+// API must report the owner's name.
+func TestVClusterName_MatchesOrgControllerAuthority_5501(t *testing.T) {
+	t.Parallel()
+	got := vclusterNameFor("vcluster", "uatcorp")
+	if strings.HasPrefix(got, "vc-") {
+		t.Errorf("vcluster_name must not be synthesized with a vc- prefix the CR does not use, got %q", got)
+	}
+	if got != "uatcorp" {
+		t.Errorf("vcluster_name must match the org-controller's status.vcluster.name (the bare slug), want uatcorp got %q", got)
+	}
+	if ns := vclusterNameFor("namespace", "uatcorp"); ns != "" {
+		t.Errorf("namespace tier authors no vCluster, want empty got %q", ns)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
@@ -201,8 +201,12 @@ func orgCRToResponse(obj *unstructured.Unstructured, otechFQDN string) orgTenant
 		BillingMode:     billingMode,
 		Isolation:       isolation,
 		PlanSlug:        planSlug,
-		CreatedAt:       obj.GetCreationTimestamp().Time,
-		UpdatedAt:       obj.GetCreationTimestamp().Time,
+		// #5501 — carry the OBSERVED boundary phase straight off the CR, so a
+		// CR-derived row's substrate-side steps report what the org-controller
+		// reports instead of whatever the state ladder implies.
+		BoundaryPhase: boundaryPhaseFromCR(obj),
+		CreatedAt:     obj.GetCreationTimestamp().Time,
+		UpdatedAt:     obj.GetCreationTimestamp().Time,
 	}
 	return orgTenantRecordToResponse(rec)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_test.go
@@ -85,8 +85,17 @@ func TestCreateOrgTenant_MintsOrganizationCR(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if got.State != store.STSDone {
-		t.Fatalf("state: want done got %s (lastError=%s)", got.State, got.LastError)
+	// #5501 — the CR mint is a SUBMIT, not a completion: the org-controller
+	// authors the boundary from this CR and has not observed it yet (the CR
+	// this request just POSTed carries no status), so the record holds at the
+	// highest non-terminal state. This test's subject is the mint below; the
+	// terminal-state contract is owned by
+	// org_create_fake_green_5501_test.go.
+	if got.State == store.STSDone {
+		t.Fatalf("state: a create whose boundary was never observed must not report done (#5501), lastError=%s", got.LastError)
+	}
+	if got.State != store.STSTenantRegistered {
+		t.Fatalf("state: want %s got %s (lastError=%s)", store.STSTenantRegistered, got.State, got.LastError)
 	}
 
 	// The Organization CR must now exist — the dead-object-model fix.

--- a/products/catalyst/bootstrap/api/internal/handler/org_vcluster_fabrication_5489_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_vcluster_fabrication_5489_test.go
@@ -32,8 +32,11 @@ import (
 
 func TestVClusterNameFor(t *testing.T) {
 	t.Parallel()
-	if got := vclusterNameFor("vcluster", "acme"); got != "vc-acme" {
-		t.Errorf("vcluster tier: got %q want vc-acme", got)
+	// #5501 — the reported name is the BARE SLUG, the name the org-controller
+	// (the object's only producer) stamps at status.vcluster.name. The former
+	// `vc-<slug>` synthesis disagreed with the CR on a walked Sovereign.
+	if got := vclusterNameFor("vcluster", "acme"); got != "acme" {
+		t.Errorf("vcluster tier: got %q want acme (the CR-authoritative name)", got)
 	}
 	if got := vclusterNameFor("namespace", "acme"); got != "" {
 		t.Errorf("namespace tier must not synthesize a vCluster name, got %q", got)
@@ -132,8 +135,9 @@ func TestOrgResponseFromCR_VclusterTier_KeepsVClusterFields(t *testing.T) {
 	if row.Isolation != "vcluster" {
 		t.Fatalf("fixture must derive vcluster isolation (customer + plan m), got %q", row.Isolation)
 	}
-	if row.VClusterName != "vc-acme" {
-		t.Errorf("vcluster-tier row keeps its vCluster name, got %q want vc-acme", row.VClusterName)
+	// #5501 — still named, but with the CR-authoritative bare slug.
+	if row.VClusterName != "acme" {
+		t.Errorf("vcluster-tier row keeps its vCluster name, got %q want acme", row.VClusterName)
 	}
 	if row.Steps.VCluster != "done" {
 		t.Errorf("vcluster-tier Ready row keeps steps.vcluster=done, got %q", row.Steps.VCluster)

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -396,10 +396,14 @@ type orgTenantResponse struct {
 	ParentDomain    string                           `json:"parent_domain,omitempty"`
 	AdminEmail      string                           `json:"admin_email"`
 	CompanyName     string                           `json:"company_name,omitempty"`
-	OTECHFQDN       string                           `json:"otech_fqdn"`
-	VClusterName    string                           `json:"vcluster_name"`
-	TenantNamespace string                           `json:"tenant_namespace"`
-	ConsoleHost     string                           `json:"console_host"`
+	OTECHFQDN string `json:"otech_fqdn"`
+	// VClusterName — omitempty (#5501): a host-namespace Org authors no
+	// vCluster, and an empty string in the payload still reads as "there is
+	// a vcluster_name field for this Org" to anything that binds it. An
+	// absent key is the honest shape.
+	VClusterName    string `json:"vcluster_name,omitempty"`
+	TenantNamespace string `json:"tenant_namespace"`
+	ConsoleHost     string `json:"console_host"`
 	// Organizations model (issue #3378 B1) — surfaced so the directory
 	// can badge the org by kind/tier/billingMode/isolation.
 	Kind        string         `json:"kind,omitempty"`
@@ -409,21 +413,41 @@ type orgTenantResponse struct {
 	CommitSHA   string         `json:"commit_sha,omitempty"`
 	LastError   string         `json:"last_error,omitempty"`
 	Steps       orgTenantSteps `json:"steps"`
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
+	// BoundaryPhase — the observed phase of the Org's boundary (#5501),
+	// read back from the canonical Organization CR. Absent when the
+	// substrate has never been observed; the SPA can distinguish
+	// "unobserved" from "Pending" because one omits the key and the other
+	// names a real controller phase.
+	BoundaryPhase string `json:"boundary_phase,omitempty"`
+	// CreatedAt / UpdatedAt — omitzero (#5501). A Go zero time serialized
+	// as `0001-01-01T00:00:00Z` is a FALSE MEASUREMENT: it reads as a real
+	// RFC-3339 instant to every consumer. When the timestamp is genuinely
+	// unknown the key is omitted instead — an absent field is honest, a
+	// zero timestamp is not. Same class as #5477.
+	CreatedAt time.Time `json:"created_at,omitzero"`
+	UpdatedAt time.Time `json:"updated_at,omitzero"`
 }
 
-// vclusterNameFor returns the synthesized `vc-<slug>` name for a
-// vcluster-tier Org and "" for anything else (#5489): only the vcluster
-// tier has a vCluster to name. The legacy unconditional `vc-<slug>` put a
-// `vcluster_name` in the payload right beside `isolation: "namespace"` —
-// latent (the UI declares the field and never binds it), but it would
-// assert an object that does not exist the moment anyone rendered it.
-// Since #4188 no overlay template consumes the value either, so an empty
-// name is inert on the provisioning pipeline.
+// vclusterNameFor returns the name of a vcluster-tier Org's vCluster and ""
+// for anything else (#5489): only the vcluster tier has a vCluster to name.
+// The legacy unconditional `vc-<slug>` put a `vcluster_name` in the payload
+// right beside `isolation: "namespace"` — latent (the UI declares the field
+// and never binds it), but it would assert an object that does not exist the
+// moment anyone rendered it. Since #4188 no overlay template consumes the
+// value either, so an empty name is inert on the provisioning pipeline.
+//
+// #5501 — the name is the BARE SLUG, not the synthesized `vc-<slug>`. The
+// org-controller is the only producer of the object and it reports
+// `status.vcluster.name = <slug>` (vclusterStatusFor in
+// core/controllers/organization/internal/controller/organization_controller.go),
+// which is what a walked Sovereign returns from `kubectl get organization
+// <slug> -o yaml`. The API used to answer `vc-uatcorp` for a CR that said
+// `uatcorp`: two names for one object, and the one the API published named
+// nothing that exists. Synthesizing a SECOND name for a resource another
+// component owns is the defect — this function now mirrors that owner.
 func vclusterNameFor(isolation, slug string) string {
 	if isolation == "vcluster" {
-		return "vc-" + slug
+		return strings.ToLower(strings.TrimSpace(slug))
 	}
 	return ""
 }
@@ -525,6 +549,40 @@ func stepsForState(state store.OrganizationProvisionState, lastError string) org
 
 func orgTenantRecordToResponse(rec store.OrganizationProvisionRecord) orgTenantResponse {
 	steps := stepsForState(rec.State, rec.LastError)
+
+	// #5501 — the two SUBSTRATE-side steps report the OBSERVED boundary,
+	// not the orchestrator's position on its own ladder.
+	//
+	// stepsForState is right about what it models: the linear state machine
+	// records which SUBMITS the orchestrator has completed. But `vcluster`
+	// and `bp_charts` are claims about things that exist on the cluster —
+	// the Org's boundary, and the bp-* HelmReleases that install INTO it —
+	// and the orchestrator only ever committed manifests for those. So the
+	// ladder alone reported `vcluster:"done"` + `bp_charts:"done"` zero
+	// seconds after create, against a CR that said `phase: Pending` and a
+	// cluster with no namespace at all (hw291, #5501).
+	//
+	// rec.BoundaryPhase is the read-back of that CR (org_boundary_observation.go).
+	// The inference runs in ONE direction only: a boundary that is not up
+	// cannot have charts installed in it, so both steps degrade to the
+	// observed phase. It never promotes a step — an unobserved boundary
+	// reads "pending", never "done" (boundaryStepFor).
+	//
+	// Terminal records are left alone: STSDone is now itself gated on an
+	// observed-Ready boundary (runOrganizationPipeline step 7), and a
+	// STSFailed record's per-step failure detail comes from last_error.
+	if rec.State != store.STSDone && rec.State != store.STSFailed {
+		observed := boundaryStepFor(rec.BoundaryPhase)
+		if observed != "done" {
+			if steps.VCluster == "done" {
+				steps.VCluster = observed
+			}
+			if steps.BPCharts == "done" {
+				steps.BPCharts = observed
+			}
+		}
+	}
+
 	// #5489 — a namespace-isolated Org has no vCluster step to report.
 	// Blank it (the field is omitempty) only when the record EXPLICITLY
 	// says namespace; legacy rows with an empty isolation keep the full
@@ -554,6 +612,7 @@ func orgTenantRecordToResponse(rec store.OrganizationProvisionRecord) orgTenantR
 		CommitSHA:       rec.CommitSHA,
 		LastError:       rec.LastError,
 		Steps:           steps,
+		BoundaryPhase:   rec.BoundaryPhase,
 		CreatedAt:       rec.CreatedAt,
 		UpdatedAt:       rec.UpdatedAt,
 	}
@@ -610,10 +669,17 @@ var validBYODomain = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[
 //
 // The marketplace signup form POSTs here. The orchestrator persists
 // the pending row, fires the pipeline synchronously, and returns the
-// current (likely partial) state immediately — the SPA renders a
+// current (necessarily partial) state immediately — the SPA renders a
 // progress timeline against the steps[] field while the reconciler
 // runs in the background. Returns 202 (not 201) because the resource
 // is "accepted, materialising" rather than "created".
+//
+// #5501 — 202 was always right; the BODY was the lie. A fresh create can
+// NEVER be `state:"done"`: the Org's boundary is authored downstream by the
+// org-controller and takes minutes, so the pipeline holds the record at the
+// highest non-terminal state until it observes that boundary Ready (see the
+// terminal gate in runOrganizationPipeline step 7). The response now reports
+// that honestly instead of claiming six completed steps in zero seconds.
 func (h *Handler) HandleCreateOrganization(w http.ResponseWriter, r *http.Request) {
 	deps := h.orgTenantDeps
 	if deps.Store == nil {
@@ -778,7 +844,11 @@ func (h *Handler) HandleCreateOrganization(w http.ResponseWriter, r *http.Reques
 		// boundary namespace at (ResourceQuota + LimitRange).
 		PlanSlug: shape.PlanSlug,
 	}
-	if err := deps.Store.Put(rec); err != nil {
+	// #5501 — Save (not Put) so the CreatedAt/UpdatedAt the store stamps
+	// land on THIS record. Put persists a by-value copy, so the record the
+	// handler goes on to serialize kept Go zero timestamps and the create
+	// response published `0001-01-01T00:00:00Z` as a measurement.
+	if err := deps.Store.Save(&rec); err != nil {
 		h.log.Error("org-tenant: persist pending failed", "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error":  "persist-failed",
@@ -1014,7 +1084,11 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 	}
 
 	persist := func(updated store.OrganizationProvisionRecord) store.OrganizationProvisionRecord {
-		if err := deps.Store.Put(updated); err != nil {
+		// #5501 — Save writes the stamped CreatedAt/UpdatedAt back onto
+		// `updated`, so every record this pipeline returns (and every
+		// record the response mapper serializes) carries the same
+		// timestamps the persisted row does, instead of Go zero values.
+		if err := deps.Store.Save(&updated); err != nil {
 			h.log.Warn("org-tenant: persist failed during pipeline", "err", err)
 		}
 		if deps.Events != nil {
@@ -1253,6 +1327,36 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 		// valid), and a later reconcile / HandleReconcileOrganization pass
 		// re-applies the trio. BYO Orgs are skipped (own cert + CNAME).
 		h.provisionOrgConsoleTLS(ctx, rec)
+
+		// #5501 — THE TERMINAL GATE. Everything above this line is a
+		// SUBMIT: an overlay committed to Git, DNS rrsets written, Keycloak
+		// clients created, a registry row persisted, the Organization CR
+		// POSTed. None of it observes that the Org's boundary exists — the
+		// boundary is authored downstream by the org-controller reconciling
+		// the CR this step just minted, which takes minutes. Stamping
+		// STSDone here is what made `POST /api/v1/organizations` answer
+		// `state:"done"` with six "done" steps in ZERO seconds over a
+		// Sovereign with no namespace and no vCluster (hw291, 2026-07-29).
+		//
+		// So: read the CR back and promote ONLY on an observed-Ready
+		// boundary. Anything else — Pending, Provisioning, Failed, or
+		// unobservable — holds the record at STSTenantRegistered, the
+		// highest NON-terminal state, meaning exactly "every side effect
+		// the orchestrator owns is committed; the substrate has not been
+		// confirmed". Nothing is stranded: ListPending returns every
+		// non-terminal row, so the NATS-driven reconciler
+		// (ReconcileAllPending) re-runs this step until the boundary comes
+		// up, and both finalisers above are idempotent so they are simply
+		// re-ensured on each pass.
+		phase, ready := h.observeOrgBoundary(ctx, rec)
+		rec.BoundaryPhase = phase
+		if !ready {
+			h.log.Info("org-tenant: holding non-terminal — boundary not observed Ready",
+				"slug", rec.Subdomain, "org_tenant_id", rec.OrganizationID,
+				"boundary_phase", phase, "state", string(rec.State))
+			rec.LastError = ""
+			return persist(rec)
+		}
 
 		rec.State = store.STSDone
 		rec.LastError = ""

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -175,8 +175,17 @@ func TestCreateOrganization_HappyPathFreeSubdomain(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if got.State != store.STSDone {
-		t.Fatalf("state: want done got %s (lastError=%s)", got.State, got.LastError)
+	// #5501 — the happy path is that every ORCHESTRATOR-side side effect ran
+	// (asserted below: overlay committed, DNS written, Keycloak clients
+	// created, registry row present). It is NOT that the Organization is
+	// provisioned: the boundary is authored downstream by the org-controller
+	// and this handler has no in-cluster client here, so the substrate was
+	// never observed. Terminal success over an unobserved substrate is the
+	// defect (`state:"done"` in zero seconds over an empty cluster), so the
+	// record holds at the highest non-terminal state.
+	if got.State != store.STSTenantRegistered {
+		t.Fatalf("state: want %s (all side effects committed, boundary unobserved) got %s (lastError=%s)",
+			store.STSTenantRegistered, got.State, got.LastError)
 	}
 	if got.ConsoleHost != "console.acme.otech.example" {
 		t.Errorf("console_host: %s", got.ConsoleHost)
@@ -317,8 +326,19 @@ func TestCreateOrganization_GitOpsTransientFailure_Retryable(t *testing.T) {
 	h.HandleGetOrganization(w2, r2)
 	var second orgTenantResponse
 	_ = json.Unmarshal(w2.Body.Bytes(), &second)
-	if second.State != store.STSDone {
-		t.Fatalf("after reconcile: want done got %s lastError=%s", second.State, second.LastError)
+	// The retry is proven by the record having MOVED PAST the failing gitops
+	// step to the end of the orchestrator's own ladder. It does not reach
+	// STSDone here because no in-cluster client exists to observe the
+	// boundary (#5501) — the terminal promotion is exercised against an
+	// observed-Ready CR in org_create_fake_green_5501_test.go.
+	if second.State != store.STSTenantRegistered {
+		t.Fatalf("after reconcile: want %s got %s lastError=%s", store.STSTenantRegistered, second.State, second.LastError)
+	}
+	if second.LastError != "" {
+		t.Errorf("after a successful retry last_error must be cleared, got %q", second.LastError)
+	}
+	if second.CommitSHA == "" {
+		t.Errorf("after a successful retry the overlay commit SHA must be recorded")
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/store/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/store/organization_provisioning.go
@@ -193,8 +193,25 @@ type OrganizationProvisionRecord struct {
 	// (legacy records) reads as "s" at the renderer.
 	PlanSlug string `json:"plan_slug,omitempty"`
 
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	// BoundaryPhase — the LAST OBSERVED phase of the Org's boundary
+	// (#5501), read back from the canonical Organization CR the pipeline
+	// mints: `status.vcluster.phase` for a vcluster-tier Org, the
+	// top-level Ready condition for a host-namespace one. One of
+	// "Ready" | "Provisioning" | "Pending" | "Failed"; EMPTY means
+	// NEVER OBSERVED (no in-cluster client, or the read failed) — it is
+	// deliberately NOT defaulted to a phase, because "we could not look"
+	// and "we looked and it is up" are different facts.
+	//
+	// This is the only substrate truth the API has: every step of the
+	// provisioning pipeline is a SUBMIT (commit an overlay, write a DNS
+	// rrset, POST a CR), so the state machine alone can never tell a
+	// caller whether the Organization actually exists. The pipeline
+	// stamps this field, gates the terminal STSDone promotion on it, and
+	// the wire response derives its substrate-side steps from it.
+	BoundaryPhase string `json:"boundary_phase,omitempty"`
+
+	CreatedAt time.Time `json:"created_at,omitzero"`
+	UpdatedAt time.Time `json:"updated_at,omitzero"`
 }
 
 // orgTenantDir is the on-disk subdirectory under <store>/org-tenant.
@@ -229,7 +246,27 @@ func NewOrganizationProvisionStore(dir string) (*OrganizationProvisionStore, err
 // Put upserts a record. CreatedAt is preserved across upserts; the
 // caller is responsible for setting State/Subdomain/etc. before
 // calling. UpdatedAt is bumped automatically.
+//
+// #5501 — Put takes the record BY VALUE, so the CreatedAt/UpdatedAt it
+// stamps land on this function's local copy and are invisible to the
+// caller. Callers that serialize the record they just persisted (the
+// Organization create handler) therefore published Go ZERO timestamps
+// (0001-01-01T00:00:00Z) while the on-disk row carried the real ones —
+// which is why a GET showed real timestamps and the POST response did
+// not. Use Save when the caller keeps the record; Put is retained for
+// fire-and-forget writers.
 func (s *OrganizationProvisionStore) Put(rec OrganizationProvisionRecord) error {
+	return s.Save(&rec)
+}
+
+// Save persists rec and writes the stamped CreatedAt/UpdatedAt BACK onto
+// the caller's record (#5501), so an in-memory record that has just been
+// persisted carries the same timestamps the on-disk row does. Same
+// semantics as Put in every other respect.
+func (s *OrganizationProvisionStore) Save(rec *OrganizationProvisionRecord) error {
+	if rec == nil {
+		return errors.New("org-tenant: record is required")
+	}
 	if strings.TrimSpace(rec.OrganizationID) == "" {
 		return errors.New("org-tenant: org_tenant_id is required")
 	}
@@ -244,7 +281,7 @@ func (s *OrganizationProvisionStore) Put(rec OrganizationProvisionRecord) error 
 
 	path := filepath.Join(s.dir, sanitizeID(rec.OrganizationID)+".json")
 	if rec.CreatedAt.IsZero() {
-		if existing, err := readOrganizationRec(path); err == nil {
+		if existing, err := readOrganizationRec(path); err == nil && !existing.CreatedAt.IsZero() {
 			rec.CreatedAt = existing.CreatedAt
 		} else {
 			rec.CreatedAt = now

--- a/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
@@ -141,15 +141,25 @@ export interface OrgProvisionRecord {
   admin_email: string
   company_name?: string
   otech_fqdn: string
-  vcluster_name: string
+  /** #5489/#5501 — absent for a namespace-isolated Org (no vCluster is
+   *  authored for that tier), and the bare slug for a vcluster-tier one:
+   *  the name the org-controller stamps at status.vcluster.name, never a
+   *  client-side `vc-` synthesis. */
+  vcluster_name?: string
   /** Legacy BE wire key — see org_tenant_id note above. */
   tenant_namespace: string
   console_host: string
   commit_sha?: string
   last_error?: string
   steps: OrgProvisionSteps
-  created_at: string
-  updated_at: string
+  /** #5501 — the OBSERVED phase of the Org's boundary as the
+   *  org-controller reports it (Ready | Provisioning | Pending | Failed).
+   *  Absent when the substrate has never been observed. */
+  boundary_phase?: string
+  /** #5501 — absent when genuinely unknown; the API no longer publishes a
+   *  Go zero timestamp (0001-01-01T00:00:00Z) as a measurement. */
+  created_at?: string
+  updated_at?: string
 }
 
 export interface OrgCreateRequest {


### PR DESCRIPTION
## What was walked

`POST /api/v1/organizations` on hw291 (2026-07-29) answered **HTTP 202 with `state:"done"`, all six provisioning steps `"done"`, in ZERO seconds** — over a Sovereign with no namespace, no vCluster and an empty `status.phase`. Every other fake-green found that session was a display reading stale data; this one **fabricated success on the write path**, at creation.

Four distinct defects in that one response:

1. `steps.*` all `"done"` rather than real provisioning state — while the CR the request had just minted said `status.vcluster.phase: Pending`.
2. `state:"done"` claimed terminal success before the controller had observed the object at all.
3. `vcluster_name: "vc-uatcorp"` synthesized, disagreeing with the CR's `uatcorp` — two names for one thing, neither verified to exist.
4. `created_at` / `updated_at` = `0001-01-01T00:00:00Z` — an unpopulated struct serialized as a measurement.

## The real root cause

`stepsForState` was **not** the bug — it correctly derives the timeline from `store.OrganizationProvisionState`. There are **two independent upstream causes**, and both are the same mistake in different places: publishing a value nobody measured.

**A. The pipeline sets a terminal state without the work being observed.** `runOrganizationPipeline` is a chain of **submits**: step 1 commits a GitOps overlay, step 2 advances unconditionally ("the orchestrator advances optimistically here"), step 3 writes DNS rrsets, step 4 advances unconditionally, step 5 calls Keycloak, step 6 writes a registry row, step 7 POSTs the Organization CR and then stamps `STSDone`. Not one step observes that the Org's boundary exists — and it **cannot** have existed, because the boundary is authored downstream by the org-controller reconciling the CR step 7 had just created, which takes minutes. So `State` was terminal in zero seconds and `stepsForState` faithfully rendered six honest-looking `"done"`s over it.

**B. The store stamped timestamps on a copy the caller never saw.** `OrganizationProvisionStore.Put` takes the record **by value** and sets `CreatedAt`/`UpdatedAt` on its own local copy. The on-disk row got real timestamps; the in-memory record the handler went on to serialize kept Go zero values. That is exactly why a `GET` showed real timestamps and the `POST` did not — same record, two different answers.

## Per-defect fix

**(2) — the terminal gate.** `runOrganizationPipeline` step 7 now reads the Organization CR back (`observeOrgBoundary`, new `internal/handler/org_boundary_observation.go`) and promotes to `STSDone` **only on an observed-Ready boundary**. Anything else — Pending, Provisioning, Failed, or unobservable — holds the record at `STSTenantRegistered`, the highest non-terminal state, meaning exactly *"every side effect the orchestrator owns is committed; the substrate has not been confirmed"*. 202 Accepted was always the right status; the body stopped claiming completion.

Deliberately **fail-closed**: "no in-cluster client" / "the read errored" is reported as unobserved, never as ready. Nothing is stranded by that — `ListPending` returns every non-terminal row, so the NATS-driven reconciler re-runs step 7 until the boundary comes up, and both finalisers in that step (`createOrgOrganizationCR`, `provisionOrgConsoleTLS`) are idempotent, so they are simply re-ensured on each pass. catalyst-api's ServiceAccount already carries `get/list/watch` on `orgs.openova.io/organizations` (`clusterrole-cutover-driver.yaml:457`), so the read needs no RBAC change.

**(1) — steps derive from the observed boundary.** The record carries a new `BoundaryPhase` (the read-back of the CR: `status.vcluster.phase` for a vcluster-tier Org, the top-level Ready condition for a host-namespace one — the two tiers report readiness differently per #5489). `orgTenantRecordToResponse` degrades the two **substrate-side** steps (`vcluster`, `bp_charts`) to that observed phase on any non-terminal record. The inference runs in one direction only — a boundary that is not up cannot have charts installed in it — and it never promotes a step: an unobserved boundary reads `"pending"`, never `"done"`. `stepsForState` is untouched; it still derives the orchestrator-side steps (dns, certs, keycloak_clients, registry), which report calls this process actually made in-request. CR-derived rows (`orgCRToResponse`) carry the phase straight off the CR.

**(3) — one name, the owner's name.** `vclusterNameFor` returns the **bare slug** for a vcluster-tier Org, matching `vclusterStatusFor` in `core/controllers/organization/internal/controller/organization_controller.go`, which stamps `status.vcluster.name = <slug>` and is the object's only producer. Namespace-tier still returns empty (#5489), and `vcluster_name` is now `omitempty`, so the key is absent rather than shipping `""`.

**(4) — real timestamps or no timestamps.** New `OrganizationProvisionStore.Save(*OrganizationProvisionRecord)` stamps through the pointer and writes the values back onto the caller's record; `Put` delegates to it, so every existing caller is unchanged. The create handler and the pipeline's `persist` use `Save`. Belt and braces: `created_at`/`updated_at` are `omitzero` on both the wire shape and the stored record, so a genuinely unknown timestamp is an **absent field** rather than a false RFC-3339 instant. Same class as #5477.

## Test evidence — both directions

New `internal/handler/org_create_fake_green_5501_test.go`:

| test | direction |
|---|---|
| `TestCreateOrganization_FreshOrgIsNotTerminal_5501` | fresh create is non-terminal, `steps.bp_charts` is `pending`, not every step is `done`, no `vcluster` step on a namespace-tier Org — with a vacuity control asserting the pipeline DID run (CR minted, overlay commit SHA present) |
| `TestCreateOrganization_ObservedReadyBoundary_ReportsDone_5501` | **control** — an Org whose CR reports Ready still reports `done` with a fully green timeline |
| `TestOrganization_HeldRecordPromotedWhenBoundaryTurnsReady_5501` | **control** — a held record is not stranded: stamp Ready on the CR, run the reconciler, the same record promotes to `done` |
| `TestOrgCreateResponse_NeverPublishesZeroTimestamps_5501` | serialized JSON contains no `0001-01-01`, with a vacuity control that the keys are present and parse, plus the list view |
| `TestOrgCreateResponse_NamespaceTier_OmitsVClusterName_5501` | the `vcluster_name` key is omitted, not empty (raw JSON — omitempty is invisible to a struct check) |
| `TestVClusterName_MatchesOrgControllerAuthority_5501` | no `vc-` synthesis; the CR-authoritative name |

**Pre-fix behaviour fails these tests.** Run with the tests kept and the three source files reverted to `origin/main`:

```
--- FAIL: TestCreateOrganization_FreshOrgIsNotTerminal_5501 (5.06s)
    fresh create must NOT report terminal success: state="done" — no namespace,
    no vCluster and no status.phase exist yet (#5501)
--- FAIL: TestOrganization_HeldRecordPromotedWhenBoundaryTurnsReady_5501 (5.06s)
    precondition: fresh create must be non-terminal, got "done"
--- FAIL: TestOrgCreateResponse_NeverPublishesZeroTimestamps_5501 (5.06s)
    response published a Go zero timestamp as a measurement (#5501/#5477):
    {"org_tenant_id":"71e5...","state":"done","subdomain":"stamped",...,
     "vcluster_name":"","created_at":"0001-01-01T00:00:00Z", ...}
--- FAIL: TestOrgCreateResponse_NamespaceTier_OmitsVClusterName_5501 (5.06s)
    vcluster_name key must be OMITTED for a namespace-tier Org, got ""
--- FAIL: TestVClusterName_MatchesOrgControllerAuthority_5501 (0.00s)
    vcluster_name must not be synthesized with a vc- prefix the CR does not use,
    got "vc-uatcorp"
    vcluster_name must match the org-controller's status.vcluster.name (the bare
    slug), want uatcorp got "vc-uatcorp"
FAIL
```

Five of the six fail pre-fix. The sixth — `TestCreateOrganization_ObservedReadyBoundary_ReportsDone_5501` — **passes in both directions by design**: it is the control that pins that a genuinely-completed Organization still reports `done`, so a fix that inverted the bug would break it while satisfying the other five.

Existing expectations that encoded the defect were updated in place, each with the reason:

- `TestCreateOrganization_HappyPathFreeSubdomain` — the happy path is that every orchestrator-side side effect ran (still asserted: overlay, DNS, Keycloak, registry row). It is not that the Organization is provisioned.
- `TestCreateOrganization_GitOpsTransientFailure_Retryable` — the retry is now proven by the record moving past the failing step with `last_error` cleared and a commit SHA recorded.
- `TestCreateOrgTenant_MintsOrganizationCR` — that test's subject is the CR mint, which is still asserted; the mint is a submit, not a completion.
- `TestVClusterNameFor` / `TestOrgResponseFromCR_VclusterTier_KeepsVClusterFields` — the #5489 control direction now pins the CR-authoritative name.

## Gates

`cd products/catalyst/bootstrap/api && go build ./... && go vet ./... && go test ./internal/handler/ ./internal/store/` — all green. Go-only, no chart bumps (rides the deploybot image pins).

## Deliberately left

- `steps.certs` and the three orchestrator-side steps keep deriving from the state machine: they report calls this process actually made in-request, and no substrate truth for them is available to the API. Inventing an observation for them would be the same fabrication in a new place.
- The `bootstrap/ui` type for `OrgProvisionRecord` was corrected to match the new wire (optional `vcluster_name` / `created_at` / `updated_at`, new `boundary_phase`); no consumer reads those fields today, so there is no render change — the timeline already renders a `pending` step as a dim dot.
- Next action for the walk: create an Organization through the real endpoint on a live Sovereign and confirm the response is non-terminal at t=0 and reaches `done` only once `kubectl get organization <slug>` reports Ready — that is UAT row 9's assertion.

Refs #5501 #5489 #5477

🤖 Generated with [Claude Code](https://claude.com/claude-code)
