### PR TITLE
fix(catalyst-api): Application install returns the TRUE status for a rejected install (#5500)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -464,10 +464,10 @@ func (h *Handler) installApplicationCore(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	if !rep.Valid {
-		writeJSON(w, http.StatusOK, map[string]any{
+		writeJSON(w, http.StatusBadRequest, map[string]any{
 			"error":      "invalid-parameters",
 			"status":     "400",
-			"httpStatus": 400,
+			"httpStatus": "400",
 			"applied":    false,
 			"detail":     "parameters do not satisfy Blueprint.spec.configSchema",
 			"errors":     rep.Errors,
@@ -501,13 +501,13 @@ func (h *Handler) installApplicationCore(w http.ResponseWriter, r *http.Request,
 	// orgNamespace() so they resolve to ONE consistent namespace.
 	appNS := orgNamespace(body.OrganizationRef)
 	if nsErr := ensureOrgNamespace(r.Context(), client, body.OrganizationRef); nsErr != nil {
-		writeJSON(w, http.StatusOK, map[string]any{
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 			"kind":       "Application",
 			"name":       body.Name,
 			"namespace":  appNS,
 			"error":      "namespace-ensure-failed",
 			"status":     "503",
-			"httpStatus": 503,
+			"httpStatus": "503",
 			"applied":    false,
 			"detail":     fmt.Sprintf("could not ensure namespace %q: %v", appNS, nsErr),
 		})
@@ -539,13 +539,13 @@ func (h *Handler) installApplicationCore(w http.ResponseWriter, r *http.Request,
 		r.Context(), obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			writeJSON(w, http.StatusOK, map[string]any{
+			writeJSON(w, http.StatusConflict, map[string]any{
 				"kind":       "Application",
 				"name":       body.Name,
 				"namespace":  appNS,
 				"error":      "application-exists",
 				"status":     "409",
-				"httpStatus": 409,
+				"httpStatus": "409",
 				"applied":    false,
 				"detail":     fmt.Sprintf("Application %q already exists in namespace %q", body.Name, appNS),
 			})
@@ -596,11 +596,11 @@ func (h *Handler) installApplicationCore(w http.ResponseWriter, r *http.Request,
 // Mirrors writeRBACAssignForbidden from Fix #160 PR #1364
 // (rbac_assign.go).
 func writeApplicationInstallForbidden(w http.ResponseWriter, detail string) {
-	writeJSON(w, http.StatusOK, map[string]any{
+	writeJSON(w, http.StatusForbidden, map[string]any{
 		"kind":       "Application",
 		"error":      "403",
 		"status":     "403",
-		"httpStatus": 403,
+		"httpStatus": "403",
 		"applied":    false,
 		"detail":     detail,
 	})
@@ -620,17 +620,33 @@ func writeApplicationInstallForbidden(w http.ResponseWriter, detail string) {
 //     ["Application"] resolves regardless of which error path fired
 //   - detail     — the original error message
 //
-// This is the same wire-shape contract Fix #160 PR #1364 applied to
-// /rbac/assign via writeRBACAssignValidationError — the runner FAILs
-// every non-2xx BEFORE reading the body, so returning 200 with
-// explicit error tokens is the only way must_contain / must_not_contain
-// assertions can resolve on the JSON.
+// #5500 — this used to emit HTTP 200 for EVERY one of those failures,
+// with the real code echoed only in the body. The rationale was a test
+// runner that FAILs a non-2xx before reading the body, so a 200 was the
+// only way its must_contain assertions could resolve on the JSON.
+//
+// That inverted the dependency: the production wire contract lied to
+// every real client so a harness could read a body. A caller doing the
+// normal thing — `response.ok`, `status < 300`, a non-2xx branch — read
+// a REJECTED install as a completed one, and had to know to parse the
+// body and trust a nested field over the status line it just received.
+//
+// docs/PRINCIPLES.md A8 ("must_contain token-passing test churn") already
+// names this shape and prescribes the direction: token-passing assertions
+// "must be deleted, not patched" — the pass condition belongs on the
+// behaviour, not on a string appearing. The status line IS the behaviour
+// here, so it now carries the truth and the body keeps every token
+// (kind/error/detail/status/httpStatus) for any consumer that reads it.
+//
+// httpStatus is also a STRING now, matching the success path's
+// `"httpStatus":"201"`. It was an int on this path, so a consumer
+// unmarshalling into a typed field failed on exactly one of the two.
 func writeApplicationInstallSoftError(w http.ResponseWriter, code string, origStatus int, detail string) {
-	writeJSON(w, http.StatusOK, map[string]any{
+	writeJSON(w, origStatus, map[string]any{
 		"kind":       "Application",
 		"error":      code,
 		"status":     fmt.Sprintf("%d", origStatus),
-		"httpStatus": origStatus,
+		"httpStatus": fmt.Sprintf("%d", origStatus),
 		"applied":    false,
 		"detail":     detail,
 	})

--- a/products/catalyst/bootstrap/api/internal/handler/applications_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_test.go
@@ -250,8 +250,8 @@ func TestHandleApplicationInstall_RejectsInvalidParameters(t *testing.T) {
 	// (fast_executor.py:297-298 FAILs every non-2xx before reading body).
 	// Body retains `"httpStatus":400` echo so non-matrix callers see the
 	// legacy contract.
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	var resp map[string]interface{}
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
@@ -292,8 +292,8 @@ func TestHandleApplicationInstall_RejectsMissingName(t *testing.T) {
 		"/api/v1/sovereigns/"+dep.ID+"/applications", body, registerApplicationRoutes)
 	// Fix #165 flipped validation failures from HTTP 400 → 200 (see
 	// writeApplicationInstallSoftError); body retains httpStatus:400 echo.
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	var resp map[string]interface{}
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
@@ -338,8 +338,8 @@ func TestHandleApplicationInstall_ForbiddenWhenNotTierAdmin(t *testing.T) {
 	// so the matrix runner's must_contain ['403'] resolves on the JSON
 	// (fast_executor.py:297-298 FAILs every non-2xx before body read).
 	// Mirrors Fix #160 PR #1364 wire-shape contract on /rbac/assign.
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"403"`) {
 		t.Fatalf("expected error:403 token; got %s", rec.Body.String())
@@ -376,8 +376,8 @@ func TestHandleApplicationInstall_404OnUnknownBlueprint(t *testing.T) {
 	// Fix #165 (wire-shape): unknown-blueprint flipped 404 → HTTP 200
 	// with `"httpStatus":404` body echo so the matrix runner can resolve
 	// must_contain on the JSON.
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"blueprint-not-found"`) {
 		t.Fatalf("expected blueprint-not-found token; got %s", rec.Body.String())
@@ -418,8 +418,8 @@ func TestHandleApplicationInstall_409OnDuplicate(t *testing.T) {
 		"/api/v1/sovereigns/"+dep.ID+"/applications", body, registerApplicationRoutes)
 	// Fix #165 (wire-shape): conflict flipped 409 → HTTP 200 with
 	// `"httpStatus":409` body echo and `"kind":"Application"` anchor.
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"application-exists"`) {
 		t.Fatalf("expected application-exists token; got %s", rec.Body.String())
@@ -453,8 +453,8 @@ func TestHandleApplicationInstall_503WhenCatalogUnwired(t *testing.T) {
 	// Fix #165 (wire-shape): catalog-unwired flipped 503 → HTTP 200 with
 	// `"httpStatus":503` body echo. Same envelope as every other
 	// non-happy-path so the matrix runner has a stable wire-shape.
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"catalog-not-wired"`) {
 		t.Fatalf("expected catalog-not-wired token; got %s", rec.Body.String())
@@ -662,8 +662,8 @@ func TestHandleApplicationInstall_502OnCatalogUpstreamError(t *testing.T) {
 	// Fix #165 (wire-shape): catalog-upstream flipped 502 → HTTP 200
 	// with `"httpStatus":502` body echo so the matrix runner can grep
 	// the JSON.
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"catalog-upstream"`) {
 		t.Fatalf("expected catalog-upstream token; got %s", rec.Body.String())

--- a/products/catalyst/bootstrap/api/internal/handler/applications_wire_shape_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_wire_shape_test.go
@@ -100,8 +100,8 @@ func TestApplicationsWireShape_TC091_ViewerForbidden(t *testing.T) {
 		})
 
 	// Wire-shape contract: HTTP 200, body contains "403".
-	if rec.Code != http.StatusOK {
-		t.Fatalf("TC-091 status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("TC-091 status: got %d want 403; body=%s", rec.Code, rec.Body.String())
 	}
 	body8 := rec.Body.String()
 	if !strings.Contains(body8, `403`) {
@@ -195,8 +195,8 @@ func TestApplicationsWireShape_TC093_DeveloperProdForbidden(t *testing.T) {
 			Tier: "developer",
 		})
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("TC-093 status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("TC-093 status: got %d want 403; body=%s", rec.Code, rec.Body.String())
 	}
 	body8 := rec.Body.String()
 	if !strings.Contains(body8, `403`) {


### PR DESCRIPTION
## Defect

A rejected install returned **HTTP 200** with the real code echoed only in the body:

```
POST .../applications  ->  transport: HTTP 200
                           body: {"applied":false,"httpStatus":400,"status":"400",
                                  "error":"invalid-application-install", ...}
```

A client doing the normal thing — `response.ok`, `status < 300`, a non-2xx branch — read a **rejected install as a completed one**. To learn the truth it had to know to parse the body and trust a nested field over the status line it had just received.

## Why it was that way, and why that is backwards

The 200 was deliberate. The code said so:

> *"the runner FAILs every non-2xx BEFORE reading the body, so returning 200 with explicit error tokens is the only way must_contain / must_not_contain assertions can resolve on the JSON."*

That inverts the dependency: the **production wire contract lied to every real client so a test harness could read a body**.

`docs/PRINCIPLES.md` **A8 — "must_contain token-passing test churn"** already names this exact shape and prescribes the direction:

> *"The pass condition has been moved from 'the operation succeeded' to 'the right string appears.' … Token-passing tests must be deleted, not patched."*

Here the status line **is** the behaviour, so it now carries the truth.

## Five lying sites, not one

The issue reported the `invalid-application-install` path. Fixing that one made the test run surface four more that wrote 200-with-error-body **inline**, bypassing the shared helper:

| site | was | now |
|---|---|---|
| `writeApplicationInstallSoftError` (10 call sites) | 200 | the real code |
| `invalid-parameters` | 200 | **400** |
| `namespace-ensure-failed` | 200 | **503** |
| `application-exists` | 200 | **409** |
| forbidden (not tier-admin) | 200 | **403** |

## Secondary: `httpStatus` typing

Now a **string** on every path, matching the success path's `"httpStatus":"201"`. It was an int on the error paths, so a consumer unmarshalling into a typed field failed on exactly one of the two.

## Compatibility

The body keeps every token — `kind`, `error`, `detail`, `status`, `httpStatus` — so any consumer that reads bodies still resolves. **Only the status line changed.**

## Tests

Nine tests encoded the defect by asserting `http.StatusOK` on paths their own names call `403`/`404`/`409`/`502`/`503`/rejection. Each now asserts the status its name declares.

**Vacuity proven by execution**, not claimed: reverting the handler reproduces

```
status: got 200 want 400   (RejectsMissingName)
status: got 200 want 409   (409OnDuplicate)
```

and restoring it returns the package to green.

## Gates

`go build ./...` clean · `go vet ./...` clean · `go test ./internal/handler/` ok.

## Deliberately left

Sibling write endpoints (`/api/v1/org/applications`, voucher issue, catalog commit) share this wrapper shape — the issue's fourth task. Next action: audit them on their own branch so this change stays reviewable.

Refs #5500 #5496 #5477 #5489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
