### PR TITLE
fix(catalyst-api): return the TRUE transport status on RBAC assign, shell issuance and app update (#5542)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -381,25 +381,20 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 			if fetchErr == nil && bp != nil {
 				rep, vErr := validate.Parameters(blueprintConfigSchema(bp), body.Parameters)
 				if vErr == nil && !rep.Valid {
-					// Fix #177 (qa-loop iter-17, TC-108): widen the
-					// parameter-only edit validation-failure path to a
-					// 200 envelope that ECHOES the input parameters.
-					// The fast_executor / delta_executor runners FAIL
-					// every non-2xx before reading the body, so the
-					// matrix's must_contain assertion (e.g. ["QA
-					// Updated"] for TC-108) can only resolve on a 2xx
-					// response that round-trips the input tokens.
+					// Parameters failed Blueprint.spec.configSchema, so
+					// the transport says 400. The CR is NOT persisted on
+					// this branch — `applied:false` signals "validation
+					// rejected; the controller will not see this edit" —
+					// and the submitted parameters are echoed under
+					// .parameters for a diagnostic round-trip.
 					//
-					// Non-matrix callers recover the legacy semantic by
-					// reading httpStatus:400 — same wire-shape contract
-					// Fix #165 PR #1368 applied to /applications install.
-					//
-					// The CR is NOT persisted on this branch — the
-					// envelope's applied=false signals "validation
-					// rejected; controller will not see this edit". The
-					// runner's must_not_contain ["500"] assertion still
-					// resolves (no 500 token in the body).
-					writeJSON(w, http.StatusOK, map[string]any{
+					// This returned HTTP 200 so an external matrix
+					// runner's must_contain could resolve on the echoed
+					// tokens; that runner is absent from both repos and
+					// the shape is docs/PRINCIPLES.md A8. A 200 here told
+					// the console an edit had been accepted when nothing
+					// was written. Refs #5542.
+					writeJSON(w, http.StatusBadRequest, map[string]any{
 						"kind":       "Application",
 						"name":       cur.GetName(),
 						"namespace":  cur.GetNamespace(),
@@ -411,7 +406,7 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 						"errors":     rep.Errors,
 						"parameters": body.Parameters,
 						"regions":    mergeSortedRegions(stringsFromAnySlice(curRegionsRaw), regionsFromEnv()),
-						"message":    fmt.Sprintf("HTTP 200 (httpStatus 400) — Application %q parameters rejected by Blueprint.spec.configSchema; submitted parameters echoed under .parameters for diagnostic round-trip", cur.GetName()),
+						"message":    fmt.Sprintf("HTTP 400 — Application %q parameters rejected by Blueprint.spec.configSchema; submitted parameters echoed under .parameters for diagnostic round-trip", cur.GetName()),
 					})
 					return
 				}
@@ -518,31 +513,14 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// writeApplicationUpdateSoftError emits a 200-status envelope for every
-// non-happy-path semantic error on PUT (bad body, app-not-found, blueprint
-// errors, internal CR-update failure, etc.). Mirrors
-// writeApplicationInstallSoftError from Fix #165 PR #1368 — the
-// fast_executor / delta_executor runners FAIL every non-2xx BEFORE reading
-// the body (fast_executor.py:297-298), so the only way must_contain /
-// must_not_contain assertions can resolve on PUT error paths is for the
-// HTTP layer to be 2xx with the literal tokens in JSON.
-//
-// Carries `httpStatus` echo so non-matrix callers can recover the legacy
-// semantic, plus `regions[]` from regionsFromEnv() so the literal region
-// tokens (TC-071) live in the body regardless of failure path.
-func writeApplicationUpdateSoftError(w http.ResponseWriter, code string, origStatus int, name, ns, detail string) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"kind":       "Application",
-		"name":       name,
-		"namespace":  ns,
-		"error":      code,
-		"status":     fmt.Sprintf("%d", origStatus),
-		"httpStatus": fmt.Sprintf("%d", origStatus),
-		"applied":    false,
-		"regions":    regionsFromEnv(),
-		"detail":     detail,
-	})
-}
+// writeApplicationUpdateSoftError was removed in #5542: it emitted HTTP
+// 200 for every PUT failure so an external matrix runner could read
+// must_contain tokens off the body, and it had NO callers anywhere in the
+// module — dead code carrying the docs/PRINCIPLES.md A8 shape, which is
+// the template the next handler would have copied. A8's ruling is that
+// this shape gets deleted, not patched. The live PUT error paths use
+// writeBadRequest / writeNotFound / writeInternalError, which already
+// return their true status.
 
 // ── HTTP handler — uninstall (DELETE) ───────────────────────────────
 

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_wire_shape_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_wire_shape_test.go
@@ -195,8 +195,8 @@ func TestApplicationsUpdateWireShape_TC108_ParametersEchoed(t *testing.T) {
 	rec := callUserAccess(t, h, http.MethodPut,
 		"/api/v1/sovereigns/"+dep.ID+"/applications/qa-wp?namespace=qa-omantel", body, registerApplicationUpdateRoutes)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	body8 := rec.Body.String()
 	// TC-108 must_contain.

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
@@ -489,23 +489,30 @@ func writeRBACAssignForbidden(w http.ResponseWriter, detail string) {
 	})
 }
 
-// writeRBACAssignValidationError emits a 200-status envelope with an
-// `error` token so the matrix runner's must_contain assertion resolves
-// on the body. The runner FAILs every non-2xx response before reading
-// the body (fast_executor.py:297-298) — returning 200 with an explicit
-// `"error":"invalid"` or `"error":"tier"` keeps the wire-shape honest
-// (it really is an invalid request) while letting the assertion pass.
+// writeRBACAssignValidationError emits the canonical 400 envelope for a
+// rejected /rbac/assign body. Mirrors writeRBACAssignForbidden, which has
+// always returned its true 403.
 //
-// The legacy 400 path (writeBadRequest with "invalid-rbac-assign") is
-// retained for non-matrix-runner callers via a fallthrough field
-// `httpStatus` and a `detail` echo of the original message.
+// This used to emit HTTP 200 so a `must_contain` assertion in an external
+// matrix runner (cited as fast_executor.py:297-298, which FAILed every
+// non-2xx before reading the body) could resolve on the body. That runner
+// exists nowhere in either repo or in this repo's history, and the shape it
+// motivated is cataloged as an anti-pattern in docs/PRINCIPLES.md A8 —
+// "the pass condition has been moved from 'the operation succeeded' to
+// 'the right string appears'". A 200 over a rejected write is a lie told to
+// every real client: the console, the MCP server, and any UAT walk read a
+// success. Refs #5542.
+//
+// The body keeps its `error`/`status`/`httpStatus`/`detail` tokens so
+// existing consumers still parse; only the transport code is corrected.
+// `httpStatus` is a string here, matching every other soft-error envelope.
 func writeRBACAssignValidationError(w http.ResponseWriter, code, msg string) {
-	writeJSON(w, http.StatusOK, map[string]any{
+	writeJSON(w, http.StatusBadRequest, map[string]any{
 		"error":      code,
 		"applied":    false,
 		"assigned":   false,
 		"status":     "400",
-		"httpStatus": 400,
+		"httpStatus": "400",
 		"detail":     msg,
 	})
 }

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
@@ -319,8 +319,8 @@ func TestHandleRBACAssign_RejectsBadTier(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), "tier must be one of") {
 		t.Fatalf("expected tier validation error; got %s", rec.Body.String())
@@ -341,8 +341,8 @@ func TestHandleRBACAssign_RejectsEmptyUser(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"invalid"`) {
 		t.Fatalf("expected error:invalid token; got %s", rec.Body.String())
@@ -364,8 +364,8 @@ func TestHandleRBACAssign_RejectsMissingScopeKey(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -576,9 +576,12 @@ func TestHandleRBACAssign_AcceptsMatrixErgonomicBody(t *testing.T) {
 
 // TestHandleRBACAssign_RejectsUnknownTierWith400 — TC-168 regression.
 // {"email":"qa@openova.io","tier":"super-admin"} must be rejected at
-// the validator (Fix #160: HTTP 200 with `"error":"tier"` token so the
-// matrix runner can resolve must_contain on the body; body retains
-// `"httpStatus": 400` so non-matrix callers see the legacy contract).
+// the validator with a real HTTP 400.
+//
+// This test asserted HTTP 200 while being named "...With400" — the
+// docs/PRINCIPLES.md A8 shape in its purest form, where the pass
+// condition had moved from "the request was rejected" to "the right
+// string appears in the body". Corrected in #5542.
 func TestHandleRBACAssign_RejectsUnknownTierWith400(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	factory, _ := fakeUserAccessDynamicFactory()
@@ -590,14 +593,14 @@ func TestHandleRBACAssign_RejectsUnknownTierWith400(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"tier"`) {
 		t.Fatalf("expected error:tier token; got %s", rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), `"httpStatus":400`) {
-		t.Fatalf("expected httpStatus:400 echo; got %s", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), `"httpStatus":"400"`) {
+		t.Fatalf("expected httpStatus:\"400\" echo; got %s", rec.Body.String())
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign_validation_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign_validation_test.go
@@ -97,8 +97,8 @@ func TestHandleRBACAssign_RejectsMalformedBody(t *testing.T) {
 
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	bodyStr := rec.Body.String()
 	for _, want := range []string{"error", "invalid"} {
@@ -123,8 +123,8 @@ func TestHandleRBACAssign_RejectsUnknownTier(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	bodyStr := rec.Body.String()
 	for _, want := range []string{"error", "tier"} {
@@ -154,8 +154,8 @@ func TestHandleRBACAssign_RejectsSuperAdminLegacyAlias(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	bodyStr := rec.Body.String()
 	for _, want := range []string{"error", "tier"} {
@@ -260,8 +260,8 @@ func TestHandleRBACAssign_WireShape_BadEmailFormat_TC167(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	bodyStr := rec.Body.String()
 	for _, want := range []string{"error", "invalid"} {
@@ -290,8 +290,8 @@ func TestHandleRBACAssign_WireShape_BadTier_TC168(t *testing.T) {
 	}
 	rec := callUserAccess(t, h, http.MethodPost,
 		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	bodyStr := rec.Body.String()
 	for _, want := range []string{"error", "tier"} {

--- a/products/catalyst/bootstrap/api/internal/handler/shells_issue.go
+++ b/products/catalyst/bootstrap/api/internal/handler/shells_issue.go
@@ -152,14 +152,15 @@ func (h *Handler) HandleShellsIssue(w http.ResponseWriter, r *http.Request) {
 	if c := h.guacamoleClient(); c != nil {
 		sess, err = c.CreateSession(sovereignID, params)
 		if err != nil {
-			// Per Fix #160 wire-shape: 200 + body envelope keeps the
-			// matrix runner reading the body instead of FAILing on a
-			// non-2xx code (fast_executor.py:297-298). httpStatus:502
-			// preserves the legacy upstream-error intent.
-			writeJSON(w, http.StatusOK, map[string]any{
+			// Guacamole rejected the session — a genuine upstream
+			// failure, so the transport says 502. This emitted HTTP 200
+			// for an external matrix runner that FAILed non-2xx before
+			// reading the body; that runner is absent from both repos
+			// and the shape is docs/PRINCIPLES.md A8. Refs #5542.
+			writeJSON(w, http.StatusBadGateway, map[string]any{
 				"error":      "guacamole-create-failed",
 				"status":     "502",
-				"httpStatus": 502,
+				"httpStatus": "502",
 				"detail":     err.Error(),
 			})
 			return
@@ -211,36 +212,31 @@ func (h *Handler) HandleShellsIssue(w http.ResponseWriter, r *http.Request) {
 
 // writeShellsIssueForbidden emits the canonical 403 envelope for
 // /shells/issue denials. Mirrors writeRBACAssignForbidden from
-// rbac_assign.go (Fix #160 PR #1364) — body carries the literal
-// `"403"` token so the matrix runner's `must_contain:["403"]` (TC-245)
-// resolves regardless of the HTTP code, while `must_not_contain:
-// ["sessionId"]` stays satisfied (no sessionId field in the envelope).
+// rbac_assign.go, which returns its true 403.
 //
-// HTTP 200 is intentional: fast_executor.py:297-298 FAILs every
-// non-2xx response BEFORE reading the body. Returning 200 with an
-// explicit `status:"403"` + `httpStatus:403` keeps the wire-shape
-// honest (the request really was denied) while letting the literal-
-// token assertion resolve.
+// A denied shell is the one response that must never read as success:
+// emitting 200 here meant an operator who lacked exec rights got a
+// 2xx, and only a body field distinguished that from an issued
+// session. The `error`/`status`/`httpStatus` tokens are retained and
+// no `sessionId` is present, so nothing was issued. Refs #5542.
 func writeShellsIssueForbidden(w http.ResponseWriter, detail string) {
-	writeJSON(w, http.StatusOK, map[string]any{
+	writeJSON(w, http.StatusForbidden, map[string]any{
 		"error":      "403",
 		"status":     "403",
-		"httpStatus": 403,
+		"httpStatus": "403",
 		"applied":    false,
 		"detail":     detail,
 	})
 }
 
-// writeShellsIssueValidationError emits a 200-status envelope with an
-// `error` token for missing/bad inputs. Mirrors
-// writeRBACAssignValidationError (Fix #160 PR #1364): the matrix
-// runner FAILs every non-2xx before reading the body, so 200 + body
-// envelope is the canonical wire-shape for negative paths.
+// writeShellsIssueValidationError emits the canonical 400 envelope for
+// missing/bad inputs. Mirrors writeRBACAssignValidationError; both were
+// 200-over-error for the same absent matrix runner. Refs #5542.
 func writeShellsIssueValidationError(w http.ResponseWriter, code, msg string) {
-	writeJSON(w, http.StatusOK, map[string]any{
+	writeJSON(w, http.StatusBadRequest, map[string]any{
 		"error":      code,
 		"status":     "400",
-		"httpStatus": 400,
+		"httpStatus": "400",
 		"applied":    false,
 		"detail":     msg,
 	})

--- a/products/catalyst/bootstrap/api/internal/handler/shells_issue_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/shells_issue_test.go
@@ -107,8 +107,8 @@ func TestHandleShellsIssue_RBAC_Viewer_403(t *testing.T) {
 	rec := httptest.NewRecorder()
 	shellsIssueRouter(rig).ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"403"`) {
 		t.Fatalf("403 envelope must include literal \"403\" token (TC-245 must_contain): got %s", rec.Body.String())
@@ -194,8 +194,8 @@ func TestHandleShellsIssue_MissingQueryParams_400(t *testing.T) {
 
 		rec := httptest.NewRecorder()
 		shellsIssueRouter(rig).ServeHTTP(rec, req)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("query=%q: status got %d want 200; body=%s", qs, rec.Code, rec.Body.String())
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("query=%q: status got %d want 400; body=%s", qs, rec.Code, rec.Body.String())
 		}
 		body := rec.Body.String()
 		if !strings.Contains(body, `"error"`) || !strings.Contains(body, `"400"`) {
@@ -257,8 +257,8 @@ func TestHandleShellsIssue_TC245_Viewer_TokenEnvelope(t *testing.T) {
 	rec := httptest.NewRecorder()
 	shellsIssueRouter(rig).ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("TC-245 status: got %d want 200 (matrix-runner-friendly); body=%s",
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("TC-245 status: got %d want 403; body=%s",
 			rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()


### PR DESCRIPTION
## What was wrong

Five live handler paths answered **HTTP 200 while their own body declared 400/403/502**. Every real client — the console, the MCP server, and any UAT walk — treats a 2xx as success, so a denied shell session, a rejected role assignment and a rejected parameter edit all reported as though they had been applied.

## The stated reason does not exist

Roughly twenty comments cite `fast_executor.py:297-298` ("FAILs every non-2xx response BEFORE reading the body") as the justification. That file is **absent everywhere**:

| Search | Result |
|---|---|
| `find / -name 'fast_executor.py'` | no match |
| `openova` working tree | no match |
| `openova` history — `git log --all --diff-filter=A -- '**/fast_executor.py'` | never added |
| `openova-private` tree + history | no match |

The citations trace to "Fix #160 PR #1364" / "Fix #165 PR #1368" / "Fix #177". We are at #5542. The whole contract was shaped around a harness that cannot be run.

Independently, [`docs/PRINCIPLES.md`](../blob/main/docs/PRINCIPLES.md) **A8** already catalogs this shape — *"the pass condition has been moved from 'the operation succeeded' to 'the right string appears'"* — and rules that such tests are **deleted, not patched**.

## Changed

| Site | Path | Was | Now |
|---|---|---|---|
| `rbac_assign.go` | `writeRBACAssignValidationError` | 200 | **400** |
| `shells_issue.go` | guacamole create failure | 200 | **502** |
| `shells_issue.go` | `writeShellsIssueForbidden` | 200 | **403** |
| `shells_issue.go` | `writeShellsIssueValidationError` | 200 | **400** |
| `applications_update.go` | `invalid-parameters` branch | 200 | **400** |

`writeRBACAssignForbidden` already returned a true 403 and is untouched — the issue's list was one entry long.

`writeApplicationUpdateSoftError` is **deleted, not corrected**: it carried the same shape but had **zero callers** in the module. Dead code holding an anti-pattern is the template the next handler copies. The live PUT error paths already use `writeBadRequest` / `writeNotFound` / `writeInternalError`.

Response bodies are otherwise unchanged — `error`, `status`, `httpStatus`, `detail`, `regions[]` and the parameter echo all still ship, so any consumer parsing the envelope keeps working. Only the transport code is corrected. `httpStatus` is normalized to a string at the touched sites, matching the majority form already in `applications_update.go` and `k8s_resource_put_apply.go`.

## Tests

Nine assertions retargeted, each mapped to its **enclosing Test function by name** rather than by pattern — a bulk regex earlier in this work retargeted a success-path test by mistake, so line/pattern edits were not trusted. Happy-path assertions (RBAC no-op/update 200, install 201) are deliberately untouched.

Two tests were measuring the defect rather than the behavior:

- `TestHandleRBACAssign_RejectsUnknownTierWith400` asserted **HTTP 200** while named `...With400`.
- `TC108_ParametersEchoed` asserted 200 on a response whose own `errors[]` reads ``additionalProperties 'siteTitle' not allowed``. It never proved a successful edit echoes parameters — only that a *rejected* value appears in an error body. I first read it as a happy path; the test run refuted me.

**Sensitivity shown in both directions**: before the assertions were retargeted, these same tests failed with `got 400 want 200`, so they genuinely detect the transport code rather than passing on anything.

`go build ./...` and `go vet` clean; targeted suite over every changed path green.

## Deliberately not swept

`continuum.go` has ~15 `writeJSON(w, http.StatusOK, …)` sites, several on failure paths, and `ui/src/lib/continuum.api.ts` documents that contract for them. `requestSwitchover` throws on `!res.ok` today, so flipping those without a matching client change would turn a structured `error:"no-live-dr-pair"` into a raw string inside a thrown Error. That surface needs per-site adjudication plus a client change and is left for a follow-up rather than swept blindly.

Refs #5542 #5500 #960
