### PR TITLE
fix(bp-powerdns): state nodePort:0 explicitly — anycast LB kept live node ports behind a correct-looking chart (#5348)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -155,8 +155,14 @@ spec:
       # tofu dns LB :53->node:53 forward reaches a real listener (the LB-IPAM
       # anycast VIP path is dead on Hetzner). §854-clean: hostPort, NEVER a
       # NodePort. Driven below by ${POWERDNS_DNSDIST_HOSTPORT} (Hetzner-only).
+      # 1.2.23 (#5348): state nodePort:0 EXPLICITLY on the anycast LB ports.
+      #         allocateLoadBalancerNodePorts:false alone does NOT deallocate
+      #         ports already assigned, and an apply that OMITS nodePort leaves
+      #         them in place — the live mothership Service carried the flag AND
+      #         nodePort=32015/31425 at the same time (§854 violation invisible
+      #         to every source-side check).
       # 1.2.22 (#5086): render-contract regression lock (no chart behaviour change).
-      version: 1.2.22
+      version: 1.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.22
+  version: 1.2.23
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -71,7 +71,7 @@ name: bp-powerdns
 #   NO hostNetwork, NO nodePort/type:NodePort; anycast Service stays
 #   type=LoadBalancer + allocateLoadBalancerNodePorts:false. Guards the Hetzner
 #   DNS front door against a silent §854 regression (no chart behaviour change).
-version: 1.2.22
+version: 1.2.23
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/anycast-endpoint.yaml
+++ b/platform/powerdns/chart/templates/anycast-endpoint.yaml
@@ -52,5 +52,26 @@ spec:
       port: {{ .port }}
       targetPort: {{ .targetPort }}
       protocol: {{ .protocol }}
+      {{- if eq $svcType "LoadBalancer" }}
+      # 🛑 #5348: state ZERO explicitly — omitting nodePort is NOT enough.
+      #
+      # allocateLoadBalancerNodePorts:false above only stops the apiserver
+      # allocating NEW node ports; it does NOT deallocate ones already
+      # assigned. And a declarative apply that simply OMITS nodePort leaves
+      # the existing value in place — the field reads as unmanaged, so the
+      # allocation survives every reconcile.
+      #
+      # Live proof on the mothership 2026-08-01: this very Service carried
+      # allocateLoadBalancerNodePorts:false AND nodePort=32015 (53/UDP) +
+      # nodePort=31425 (53/TCP) at the same time. The chart rendered clean,
+      # scripts/check-no-nodeports.sh passed, and node:32015/udp was open —
+      # a §854 violation invisible to every source-side check.
+      #
+      # `nodePort: 0` is the release sentinel: the apiserver treats it as
+      # "no node port" and clears the allocation on apply. It is also the
+      # inert value the repo guard deliberately ignores (it flags only
+      # `nodePort: [1-9][0-9]*`), so this stays guard-clean by construction.
+      nodePort: 0
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4785,7 +4785,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.22"
+  version: "1.2.23"
   visibility: unlisted
   card:
     title: "PowerDNS"
@@ -4802,7 +4802,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-powerdns
-    version: "1.2.22"
+    version: "1.2.23"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## A §854 violation that every source-side check scored clean

Live on the mothership, `openova-system/powerdns-anycast`:

```
type                         : LoadBalancer
allocateLoadBalancerNodePorts: False     ← the anti-nodePort flag IS set
  port 53/UDP  nodePort=32015            ← …and the ports are open anyway
  port 53/TCP  nodePort=31425
```

`node:32015/udp` and `node:31425/tcp` on the mothership — the rule the founder stated in absolute terms.

## The chart was already correct. That is the point.

`platform/powerdns/chart/templates/anycast-endpoint.yaml` sets `allocateLoadBalancerNodePorts: false`, omits `nodePort` on every port, and even `fail`s the render if an overlay asks for `serviceType: NodePort`. Two Kubernetes behaviours defeat all of it:

1. **`allocateLoadBalancerNodePorts: false` does not deallocate.** It only stops the apiserver allocating *new* node ports. Ports already assigned survive the flag flip.
2. **An apply that omits `nodePort` does not clear one.** The field reads as unmanaged, so the existing allocation persists — Helm/Flux re-applies the clean manifest forever and the ports stay.

Net effect: the chart rendered clean, `scripts/check-no-nodeports.sh` passed, and the live Service was in violation the entire time. **A reviewer checking the spec flag would have scored it compliant.**

Same shape as [#5542](https://github.com/openova-io/openova/issues/5542) (HTTP 200 over a 400 body) and [#5545](https://github.com/openova-io/openova/issues/5545) (a `…Deleted` counter holding a would-reap count) — declared intention rendering as observed fact, this time on the hard rule.

## Fix

Emit `nodePort: 0` explicitly per port when the Service is a LoadBalancer. Zero is the release sentinel — the apiserver treats it as "no node port" and clears the allocation on apply. It is also the inert value the repo guard deliberately ignores (it flags only `nodePort: [1-9][0-9]*`), so this stays guard-clean by construction rather than by exemption.

## Deliberately NOT a live patch

No `kubectl patch` on the mothership. It is a write to shared production DNS on port 53, the mothership is read-only in this session, and the Service carries `helm.toolkit.fluxcd.io/name=powerdns` — the next reconcile would revert it. The reclaim lands when Flux applies this chart.

## Verified

| check | result |
|---|---|
| render | `nodePort: 0` on both 53/UDP and 53/TCP |
| `scripts/check-no-nodeports.sh` | **EXIT 0** — `platform/powerdns/chart renders zero NodePorts`, 72 charts rendered |
| `check-bootstrap-kit-pin-sync.sh` | EXIT 0 |
| `check-catalog-seed-lockstep.sh` | EXIT 0 |
| `check-chart-annotations.sh` | EXIT 0 |
| version lockstep | 1.2.22 → **1.2.23** across `Chart.yaml`, `blueprint.yaml`, slot-11 bootstrap-kit pin |

## Follow-on worth doing

The repo guard scans sources and rendered charts, so it structurally cannot see this class — the live object drifted from a spec that renders correctly. A cluster-side check flagging **any** Service with a non-zero `spec.ports[].nodePort`, regardless of `type`, would have caught it on day one. Related: #5544 just closed a different blind spot in that same guard (17 of 89 charts skipped while it reported full coverage).

Refs #5348 #4765 #960
