### PR TITLE
docs(canon): §854 section pointed at a dead issue and omitted the live-drift class (#5348)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,24 @@ The gateway is served **DIRECT** (§854): cilium LB-IPAM VIP / shared-EIP
 (`lbipam.cilium.io/sharing-key`), OR Local-ETP + **hostPort** on the hostNetwork
 `cilium-envoy` pods (podIP == node IP → envoy listens on `node:443/:80` directly),
 with any Huawei ELB targeting `node-IP:443/:80` — never a nodePort. The #4691
-ELB→nodePort fallback is itself a §854 violation (removal tracked in #4706). See
-memory `feedback_nodeports_absolutely_forbidden.md`.
+ELB→nodePort fallback was itself a §854 violation and is **RETIRED** (the cilium
+1.19.3 bump moved the ELB to TCP passthrough onto the hostNetwork host ports).
+Verified 2026-08-01, not taken from the code comment that asserts it: every
+port literal in `infra/providers/huawei/*.tf` is 80 / 443 / 8080 / 8443 — zero
+in the nodePort range 30000-32767, which `scripts/check-no-nodeports.sh`
+Phase 1b independently enforces. (This line previously read "removal tracked in
+#4706"; that issue is CLOSED and about console-EIP readiness, so it pointed
+every future session at a dead reference.)
+
+**Source-side clean is NOT platform clean.** A chart can render correctly and the
+live Service still carry a node port: `allocateLoadBalancerNodePorts: false`
+only stops NEW allocations, and an apply that OMITS `nodePort` never clears an
+existing one. That is #5348 — `openova-system/powerdns-anycast` held
+`nodePort=32015/31425` behind a clean render. Charts must state `nodePort: 0`
+explicitly, and `scripts/check-live-nodeports.sh` is the cluster-side check that
+sees what the source scan structurally cannot. See memory
+`feedback_nodeports_absolutely_forbidden.md` and
+`reference_mothership_has_live_nodeports_audit_both_contexts.md`.
 
 ### Anti-theater discipline during PR review
 


### PR DESCRIPTION
## Two corrections to the CLAUDE.md §854 block

Both found while closing out the NodePort work.

### 1. Dead pointer

The section read:

> The #4691 ELB→nodePort fallback is itself a §854 violation (removal tracked in **#4706**).

**#4706 is CLOSED** and is about console-EIP readiness — not the fallback. The canon sent every future session to a reference that tracks nothing.

The fallback is in fact **retired**. Verified directly rather than trusting the IaC comment that asserts it:

```
$ grep -E '(destination_port|protocol_port|port)\s*=' infra/providers/huawei/*.tf
   2  protocol_port = 80
   2  protocol_port = 443
   1  protocol_port = 8443
   1  protocol_port = 8080
   1  port          = 8443
   1  port          = 8080
```

Zero literals in the nodePort range 30000–32767 — the same range `scripts/check-no-nodeports.sh` Phase 1b independently enforces. The line now records the retirement *and* how it was verified, so the next reader doesn't re-derive it.

### 2. Missing class

The section described only source-side shapes, which reads as *"if the chart is clean, we are clean."* That is false, and it cost a live violation:

- `allocateLoadBalancerNodePorts: false` only stops **new** allocations
- an apply that **omits** `nodePort` never clears an existing one

#5348 — `openova-system/powerdns-anycast` carried `nodePort=32015/31425` while its chart rendered clean and the source guard passed.

Added: charts must state `nodePort: 0` explicitly (PR #5547), and `scripts/check-live-nodeports.sh` (PR #5548) is the cluster-side check that sees what a source scan structurally cannot.

---

Canon that points at a closed issue, or that implies a guarantee the guards don't actually provide, is the same declared-vs-actual shape this session has been clearing out of the handlers (#5542), the janitor counters (#5545), and the guards themselves (#5544).

Refs #4691 #5348 #4765 #960