### PR TITLE
docs(console): parentRowFromSelf doc-comment still asserted isolation=vcluster after the code was corrected (#5489)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -132,8 +132,14 @@ export async function getSovereignSelf(): Promise<SovereignSelf | null> {
  * sovereign self-discovery payload. The parent is kind=internal (it is
  * the sovereign-root department), tier=corporate (the operator's own
  * estate), billingMode=showback (#3378 §5: "showback works day one —
- * 100% of consumption attributes to the parent"), isolation=vcluster
- * (the sovereign cluster itself).
+ * 100% of consumption attributes to the parent"), isolation=cluster
+ * (the sovereign root IS the cluster; it is not isolated inside one).
+ *
+ * This doc-comment said `isolation=vcluster` until #5489 — it kept
+ * asserting the value AFTER the code below was corrected, so a reader
+ * trusting the comment would still believe the directory claims a
+ * vCluster. A comment that contradicts the line it documents is the same
+ * declared-vs-actual defect the fix itself removed.
  */
 export function parentRowFromSelf(self: SovereignSelf | null): OrgRow {
   const fqdn = self?.sovereignFQDN ?? ''


### PR DESCRIPTION
## Delivery audit — 5 of 6 tasks are DONE and every box is still unticked

Verified against `main` today, file:line for each. The board shows this issue at 0/6
while the code says otherwise, which is the same declared-vs-actual gap the issue itself
is about.

| # | task | state | evidence on `main` |
|---|---|---|---|
| 1 | `organizations.api.ts:142` — derive the parent row's isolation | ✅ **done** | `isolation: 'cluster'` with an inline `#5489` rationale. (Its doc-comment still asserted `isolation=vcluster` — corrected in the PR below.) |
| 2 | `org_list_from_cr.go:191` — stop synthesizing `vcluster_name` | ✅ **done** | now `VClusterName: vclusterNameFor(isolation, slug)` — derived, not unconditional `"vc-"+slug` |
| 3 | `organization_controller.go:890/1106` — stop stamping `vcluster.phase: Ready` | ✅ **done** | `vclusterStatusFor()` returns the zero `VClusterStatus{}` when `!gitops.BoundaryIsVcluster(planSlug)`; the comment records that the zero value serializes absent so the printer column renders blank |
| 4 | `CreateOrganizationPage.tsx:564` — hide the vCluster step | ✅ **done** | zero `vcluster`/`vCluster` matches remain in that file |
| 5 | `AppsPage.tsx:286` — drop `DEFAULT_APP_ENVIRONMENT` | ✅ **done** | the symbol no longer exists anywhere in `AppsPage.tsx` |
| 6 | give Environment CRs a console surface | ❌ **open** | grep across all three console trees still returns no `EnvironmentsPage` and no `/environments` route |

## What this PR adds

The one artifact the fix left behind: `parentRowFromSelf`'s doc-comment kept saying
`isolation=vcluster` six lines above the corrected `isolation: 'cluster'`. A reader
trusting the comment would still believe the directory claims a vCluster that does not
exist — the defect removed from the code, surviving in the prose.

`tsc --noEmit` clean; `vitest src/lib` 17 files / 153 tests pass.

## What genuinely remains

**Task 6 only** — and it is a feature, not a fix: there is no Environments list and no
Environment detail page, so an operator cannot see any of #5476's findings from the
console at all. That is a scoped, nameable piece of work rather than an open-ended
frontier.

Every other task's *runtime* verification still needs the hw292 walk — this audit
proves the code is delivered, not that the surface renders correctly, and the two are
not the same claim.