### PR TITLE
fix(bp-powerdns): state nodePort:0 EXPLICITLY on the anycast LB — §854 (#5348)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -155,8 +155,14 @@ spec:
       # tofu dns LB :53->node:53 forward reaches a real listener (the LB-IPAM
       # anycast VIP path is dead on Hetzner). §854-clean: hostPort, NEVER a
       # NodePort. Driven below by ${POWERDNS_DNSDIST_HOSTPORT} (Hetzner-only).
+      # 1.2.23 (#5348): state nodePort:0 EXPLICITLY on the anycast LB ports.
+      #         allocateLoadBalancerNodePorts:false alone does NOT deallocate
+      #         ports already assigned, and an apply that OMITS nodePort leaves
+      #         them in place — the live mothership Service carried the flag AND
+      #         nodePort=32015/31425 at the same time (§854 violation invisible
+      #         to every source-side check).
       # 1.2.22 (#5086): render-contract regression lock (no chart behaviour change).
-      version: 1.2.22
+      version: 1.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.22
+  version: 1.2.23
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -71,7 +71,7 @@ name: bp-powerdns
 #   NO hostNetwork, NO nodePort/type:NodePort; anycast Service stays
 #   type=LoadBalancer + allocateLoadBalancerNodePorts:false. Guards the Hetzner
 #   DNS front door against a silent §854 regression (no chart behaviour change).
-version: 1.2.22
+version: 1.2.23
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/anycast-endpoint.yaml
+++ b/platform/powerdns/chart/templates/anycast-endpoint.yaml
@@ -52,5 +52,26 @@ spec:
       port: {{ .port }}
       targetPort: {{ .targetPort }}
       protocol: {{ .protocol }}
+      {{- if eq $svcType "LoadBalancer" }}
+      # 🛑 #5348: state ZERO explicitly — omitting nodePort is NOT enough.
+      #
+      # allocateLoadBalancerNodePorts:false above only stops the apiserver
+      # allocating NEW node ports; it does NOT deallocate ones already
+      # assigned. And a declarative apply that simply OMITS nodePort leaves
+      # the existing value in place — the field reads as unmanaged, so the
+      # allocation survives every reconcile.
+      #
+      # Live proof on the mothership 2026-08-01: this very Service carried
+      # allocateLoadBalancerNodePorts:false AND nodePort=32015 (53/UDP) +
+      # nodePort=31425 (53/TCP) at the same time. The chart rendered clean,
+      # scripts/check-no-nodeports.sh passed, and node:32015/udp was open —
+      # a §854 violation invisible to every source-side check.
+      #
+      # `nodePort: 0` is the release sentinel: the apiserver treats it as
+      # "no node port" and clears the allocation on apply. It is also the
+      # inert value the repo guard deliberately ignores (it flags only
+      # `nodePort: [1-9][0-9]*`), so this stays guard-clean by construction.
+      nodePort: 0
+      {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
§854 elimination, not deferral. The live mothership Service **still carries two nodePorts right
now**; this is the change that clears them.

## Live evidence (audited today, 2026-08-01)

```
$ kubectl get svc -A          # 164 services scanned
openova-system/powerdns-anycast   type=LoadBalancer   nodePorts=32015,31425
```

## Why `main` produces this

`main`'s template already sets `allocateLoadBalancerNodePorts: false` — and that is **not enough**:

> The flag stops the apiserver allocating **new** ports. It does not retract ports already assigned,
> and a declarative apply that merely **omits** `nodePort` leaves an existing one in place.

So a Service can hold `allocateLoadBalancerNodePorts: false` **and** live nodePorts simultaneously.
That is exactly what `main` yields today, and it is why a repo-only scan reports clean while the
cluster violates.

The in-chart comment written when this fix was authored names `nodePort=32015 (53/UDP)` and
`nodePort=31425 (53/TCP)` explicitly. Today's independent audit re-observed **those same two ports**
live — upgrading that comment from a claim to a verified prediction.

## The fix

`nodePort: 0` is the apiserver's **deallocate sentinel** — it is read as "no node port" and clears
the allocation on apply. It is also the inert value the repo guard deliberately ignores (the guard
flags only `nodePort: [1-9][0-9]*`), so the chart stays guard-clean by construction.

Four-site lockstep, all verified on this branch:

| site | value |
|---|---|
| `chart/Chart.yaml` | 1.2.23 |
| `blueprint.yaml` | 1.2.23 |
| `clusters/_template/bootstrap-kit/11-powerdns.yaml` | 1.2.23 |
| `chart/templates/anycast-endpoint.yaml` | `nodePort: 0` per LB port |

## Why NOT ClusterIP

Worth stating, because it is the intuitive wrong turn: PowerDNS must answer DNS on an **external
VIP**. §854's *compliant* pattern is a `LoadBalancer` served by Cilium LB-IPAM sharing the Sovereign
EIP (`lbipam.cilium.io/sharing-key`) — which this Service already is. The violation is the
auto-allocated nodePorts riding along, **not** the LoadBalancer type. Switching to ClusterIP would
trade a §854 finding for a DNS outage.

## Verification

```
scripts/check-no-nodeports.sh  ->  OK: zero NodePorts across sources + rendered charts (#4765)
```

This commit previously existed only inside two large unrelated branches
(`fix/5401-org-defaults-…`, `fix/5555-wizard-…`), with no focused PR — which is why it never
merged. This is that PR.

Refs #5348 #4765
