### PR TITLE
fix(kyverno): §854 policy exempted any Service NAMED cm-acme-http-solver-* (#5564)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -154,7 +154,7 @@ spec:
       # mixed-source pods (proxy-cache sidecars + openova-io plugin) —
       # un-wedges huawei-evs-csi + its 24-HR dependency cascade (#5017,
       # #4973 family).
-      version: 1.0.50
+      version: 1.0.51
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.50
+  version: 1.0.51
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.51 (#5564): forbid-nodeport-service — REMOVE the `cm-acme-http-solver-*`
+#   NAME exclusion. `exclude` is an `any:` list, so that clause alone exempted
+#   ANY Service with that name from the §854 ban, with no cert-manager
+#   involvement — a self-service bypass. The solver carve-out is now by the
+#   upstream LABEL acme.cert-manager.io/http01-solver only; a live sweep found
+#   7/7 solvers carrying it, so no real coverage is lost. Policy ACTION is
+#   unchanged (no Audit/Enforce flip, #5505 shape avoided). Test fixture
+#   `cm-acme-http-solver-9xk2p` flipped from admitted to DENIED, and a new
+#   `scripts/check-kyverno-nodeport-exclusions.sh` asserts on policy TEXT
+#   because `kyverno test` cannot catch this: with the bypass restored, an
+#   EXCLUDED resource still satisfies `result: fail`. Refs #5564 #5088 #4765.
 # 1.0.48 (#5088): NEW baseline policy `forbid-nodeport-service` (24) — the
 #   systemic §854 AUDIT guard. §854 was enforced ONLY at chart-render time
 #   (per-chart `fail` guards); nothing caught a runtime / non-chart NodePort
@@ -326,7 +337,7 @@ type: application
 #   (helm.sh/hook annotation) — hooks get no Flux labels + Helm force-stamps
 #   managed-by:Helm, so a legit hook Job (bp-powerdns zone-bootstrap) was
 #   Enforce-denied on live upgrade, stranding the powerdns anycast NodePort.
-version: 1.0.50
+version: 1.0.51
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/24-forbid-nodeport-service.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/24-forbid-nodeport-service.yaml
@@ -92,16 +92,26 @@ spec:
       exclude:
         any:
           # cert-manager ACME HTTP-01 solver — auto-created type=NodePort,
-          # GCs on challenge completion. Carved out by BOTH the upstream
-          # solver label and the name pattern (belt-and-braces; the label
-          # is the durable contract, the name pattern a fallback).
+          # GCs on challenge completion. Carved out by the upstream solver
+          # LABEL ONLY.
+          #
+          # #5564: there used to be a second clause here matching the NAME
+          # `cm-acme-http-solver-*` with no label requirement. Because `exclude`
+          # is an `any:` list, either clause sufficed, so ANY Service named
+          # `cm-acme-http-solver-<anything>` was exempt from the §854 ban with
+          # no cert-manager involvement at all — a permanent, self-service
+          # bypass available to anyone who can create a Service. It was
+          # described as "belt-and-braces ... the name pattern a fallback", but
+          # a fallback that admits UNLABELLED Services is not a fallback.
+          #
+          # Removing it costs no real coverage: cert-manager sets
+          # acme.cert-manager.io/http01-solver="true" unconditionally on solver
+          # Services, and a live sweep of the mothership found 7 of 7 solvers
+          # carrying it. The label is the contract; the name is not.
           - resources:
               selector:
                 matchLabels:
                   acme.cert-manager.io/http01-solver: "true"
-          - resources:
-              names:
-                - "cm-acme-http-solver-*"
           {{- with .Values.compliancePolicies.forbidNodePortService.excludeNamespaces }}
           - resources:
               namespaces:

--- a/platform/kyverno-policies/chart/tests/forbid-nodeport-service/kyverno-test.yaml
+++ b/platform/kyverno-policies/chart/tests/forbid-nodeport-service/kyverno-test.yaml
@@ -20,7 +20,7 @@
 #     - powerdns-api (type=ClusterIP)                   → admitted
 #     - gateway-lb-leaky / gateway-lb-clean (LB)        → admitted (not NodePort)
 #     - cm-acme-http-solver-by-label (NodePort+label)   → SKIPPED (carve-out)
-#     - cm-acme-http-solver-9xk2p (NodePort, name only) → SKIPPED (carve-out)
+#     - cm-acme-http-solver-9xk2p (NodePort, NAME only, no label) → DENIED (#5564)
 #   Rule 2 (loadbalancer-must-disable-nodeport-allocation):
 #     - gateway-lb-leaky (LB, no allocateLoadBalancerNodePorts) → DENIED (§854 subtlety)
 #     - gateway-lb-clean (LB, allocateLoadBalancerNodePorts:false) → admitted
@@ -56,9 +56,16 @@ results:
     rule: service-type-not-nodeport
     resources:
       - iogrid/cm-acme-http-solver-by-label
-      - iogrid/cm-acme-http-solver-9xk2p
     kind: Service
     result: skip
+  # #5564 NEGATIVE CONTROL: solver-shaped NAME without the solver LABEL is a
+  # plain NodePort and must be DENIED. Was `skip` here, which pinned the bypass.
+  - policy: forbid-nodeport-service
+    rule: service-type-not-nodeport
+    resources:
+      - iogrid/cm-acme-http-solver-9xk2p
+    kind: Service
+    result: fail
   # ── Rule 2: loadbalancer-must-disable-nodeport-allocation ──────────────
   # LoadBalancer WITHOUT allocateLoadBalancerNodePorts:false → DENIED (§854 subtlety).
   - policy: forbid-nodeport-service

--- a/platform/kyverno-policies/chart/tests/forbid-nodeport-service/policy.yaml
+++ b/platform/kyverno-policies/chart/tests/forbid-nodeport-service/policy.yaml
@@ -40,9 +40,6 @@ spec:
               selector:
                 matchLabels:
                   acme.cert-manager.io/http01-solver: "true"
-          - resources:
-              names:
-                - "cm-acme-http-solver-*"
       validate:
         message: >-
           Service {{request.object.metadata.namespace}}/{{request.object.metadata.name}}

--- a/platform/kyverno-policies/chart/tests/forbid-nodeport-service/resource-services.yaml
+++ b/platform/kyverno-policies/chart/tests/forbid-nodeport-service/resource-services.yaml
@@ -65,8 +65,17 @@ spec:
     - port: 8089
       nodePort: 30633
 ---
-# 6. CARVE-OUT (by name): cert-manager HTTP-01 solver Service — type=NodePort,
-#    no solver label but name matches cm-acme-http-solver-* → EXCLUDED from rule 1.
+# 6. NEGATIVE CONTROL (#5564): a Service whose NAME looks like a solver but which
+#    carries NO `acme.cert-manager.io/http01-solver` label must be DENIED.
+#
+#    This fixture previously asserted the opposite — it was admitted purely on
+#    its name, which pinned a self-service §854 bypass as intended behaviour and
+#    is precisely why the hole survived review. Anyone able to create a Service
+#    could name it `cm-acme-http-solver-<anything>` and opt out of the ban.
+#
+#    Keeping it as a DENY case turns the former bypass into a regression test:
+#    if the name-glob exclusion is ever reintroduced, this case flips to
+#    admitted and the suite fails.
 apiVersion: v1
 kind: Service
 metadata:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4622,7 +4622,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.50"
+  version: "1.0.51"
   visibility: unlisted
   card:
     title: "Kyverno Policy Library"
@@ -4639,7 +4639,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-kyverno-policies
-    version: "1.0.50"
+    version: "1.0.51"
   topology:
     supported:
       - singleton

--- a/scripts/check-kyverno-nodeport-exclusions.sh
+++ b/scripts/check-kyverno-nodeport-exclusions.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# check-kyverno-nodeport-exclusions.sh — §854 admission carve-out guard (#5564).
+#
+# WHY THIS EXISTS, AND WHY `kyverno test` CANNOT REPLACE IT
+#
+# The forbid-nodeport-service ClusterPolicy carves out cert-manager's HTTP-01
+# solver Services. #5564: that carve-out had a SECOND clause matching the NAME
+# `cm-acme-http-solver-*` with no label requirement. `exclude` is an `any:` list,
+# so either clause sufficed — any Service named `cm-acme-http-solver-<anything>`
+# was exempt from the NodePort ban with no cert-manager involvement at all. A
+# self-service §854 bypass for anyone who can create a Service.
+#
+# The obvious defence is a kyverno test case asserting that an UNLABELLED
+# solver-shaped Service is denied. That defence does not work, and the failure
+# mode was measured rather than assumed:
+#
+#   policy state        expectation   `kyverno test` verdict
+#   ------------------  ------------  ---------------------------------
+#   glob REMOVED        result: skip  FAILS  ("Want skip, got fail")  <- discriminates
+#   glob PRESENT        result: skip  passes
+#   glob PRESENT        result: fail  passes                          <- THE PROBLEM
+#
+# With the bypass restored, the resource is EXCLUDED, and kyverno's matcher
+# accepts that as satisfying `result: fail`. So a deny-assertion stays green
+# after someone adds an exclusion that neuters it. That is fail-open, and it
+# applies to EVERY deny case in the suite, not only this one: any future
+# `exclude` clause silently keeps the corresponding test passing.
+#
+# Hence this guard asserts on the POLICY TEXT, where an exclusion cannot hide.
+#
+# WHAT IT ENFORCES
+#   1. The solver carve-out is by LABEL only — no bare `cm-acme-http-solver-*`
+#      name exclusion in either the Helm template or the test's policy copy.
+#   2. The label selector IS still present (removing the carve-out entirely
+#      would break cert issuance; this guard must not push anyone that way).
+#   3. Template and test copy agree, because the suite validates a hand-kept
+#      COPY of the policy — so the shipped template can drift from what is
+#      tested, and did.
+#
+# Exit: 0 clean, 1 a bypass/drift is present, 2 self-test failed (fails closed).
+
+set -uo pipefail
+
+TPL="platform/kyverno-policies/chart/templates/baseline/24-forbid-nodeport-service.yaml"
+COPY="platform/kyverno-policies/chart/tests/forbid-nodeport-service/policy.yaml"
+
+GLOB_RE='names:'
+SOLVER_NAME_RE='cm-acme-http-solver-\*'
+LABEL_RE='acme\.cert-manager\.io/http01-solver'
+
+# Strip BOTH comment syntaxes before asserting. `#` line comments are the
+# obvious one; the non-obvious one is Helm's `{{/* ... */}}` block, which spans
+# lines and is NOT a `#` comment. The policy opens with exactly such a block
+# explaining the solver class and naming `cm-acme-http-solver-*` in prose — with
+# only `#`-stripping this guard flagged that documentation as a bypass. Failing
+# on a file for describing the rule it enforces would train people to delete the
+# explanation, which is the opposite of the intent.
+strip_comments() {
+  python3 - "$1" <<'PY' 2>/dev/null
+import re,sys
+try:
+    s=open(sys.argv[1]).read()
+except Exception:
+    sys.exit(0)
+s=re.sub(r'\{\{-?/\*.*?\*/-?\}\}', '', s, flags=re.S)   # Helm block comments
+s=re.sub(r'#[^\n]*', '', s)                             # YAML line comments
+sys.stdout.write(s)
+PY
+}
+
+# Does $1 contain a NAME-based solver exclusion in LIVE policy text?
+has_name_bypass() {
+  strip_comments "$1" | grep -qE "\"?${SOLVER_NAME_RE}\"?"
+}
+has_label_carveout() {
+  strip_comments "$1" | grep -qE "${LABEL_RE}"
+}
+
+# ─── Phase 0 — self-test ────────────────────────────────────────────────
+# A text assertion that never fires is worth nothing. Prove both detectors
+# discriminate against fixtures before trusting them on real files.
+self_test() {
+  local d rc=0
+  d="$(mktemp -d)"
+  printf 'exclude:\n  any:\n    - resources:\n        names:\n          - "cm-acme-http-solver-*"\n' > "$d/bypass.yaml"
+  printf 'exclude:\n  any:\n    - resources:\n        selector:\n          matchLabels:\n            acme.cert-manager.io/http01-solver: "true"\n' > "$d/clean.yaml"
+  printf '# a comment naming cm-acme-http-solver-* to document the ban\nexclude: {}\n' > "$d/comment.yaml"
+  # The case that actually bit: the policy's own Helm block comment names the
+  # pattern in prose. Only `#`-stripping flagged that documentation as a bypass.
+  printf '{{/*\nSolver Services (`cm-acme-http-solver-*`) are carved out below.\n*/}}\nexclude: {}\n' > "$d/helmcomment.yaml"
+
+  has_name_bypass "$d/bypass.yaml"  || { echo "SELF-TEST FAIL: bypass fixture not detected"; rc=1; }
+  has_name_bypass "$d/clean.yaml"   && { echo "SELF-TEST FAIL: clean fixture flagged"; rc=1; }
+  has_name_bypass "$d/comment.yaml" && { echo "SELF-TEST FAIL: a '#' COMMENT was treated as a bypass"; rc=1; }
+  has_name_bypass "$d/helmcomment.yaml" && { echo "SELF-TEST FAIL: a Helm {{/* */}} COMMENT was treated as a bypass"; rc=1; }
+  has_label_carveout "$d/clean.yaml" || { echo "SELF-TEST FAIL: label carve-out not detected"; rc=1; }
+  has_label_carveout "$d/bypass.yaml" && { echo "SELF-TEST FAIL: label detector fires on a name-only file"; rc=1; }
+
+  rm -rf "$d"
+  [ "$rc" -eq 0 ] && echo "OK — self-test passed (detects a name bypass, ignores comments, sees the label)."
+  return "$rc"
+}
+
+if [ "${1:-}" = "--self-test" ]; then self_test; exit $?; fi
+if ! self_test >/dev/null 2>&1; then
+  echo "FAIL: self-test did not pass — refusing to report. Run: $0 --self-test" >&2
+  exit 2
+fi
+
+EXIT=0
+for f in "$TPL" "$COPY"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: expected policy file missing: $f" >&2
+    echo "      (a rename needs this guard updated, not deleted)" >&2
+    EXIT=1; continue
+  fi
+  if has_name_bypass "$f"; then
+    echo "FAIL: ${f} excludes Services by NAME (cm-acme-http-solver-*) — §854 bypass (#5564)." >&2
+    echo "      exclude.any means this clause alone exempts ANY Service with that name," >&2
+    echo "      regardless of whether cert-manager created it. Carve out by the label" >&2
+    echo "      acme.cert-manager.io/http01-solver only — that is the upstream contract." >&2
+    EXIT=1
+  fi
+  if ! has_label_carveout "$f"; then
+    echo "FAIL: ${f} has no solver LABEL carve-out — genuine cert-manager solvers would be" >&2
+    echo "      denied and certificate issuance would stall. Restore the matchLabels clause." >&2
+    EXIT=1
+  fi
+done
+
+# Template and test copy must agree: the suite validates the COPY, so drift
+# means the shipped policy is untested. This is not hypothetical — the copy
+# still carried the bypass after the template was fixed (#5564).
+if [ -f "$TPL" ] && [ -f "$COPY" ]; then
+  t="$(has_name_bypass "$TPL" && echo bypass || echo clean)"
+  c="$(has_name_bypass "$COPY" && echo bypass || echo clean)"
+  if [ "$t" != "$c" ]; then
+    echo "FAIL: template says '${t}' but the test's policy copy says '${c}'." >&2
+    echo "      kyverno test validates the COPY, so the shipped template is unverified." >&2
+    EXIT=1
+  fi
+fi
+
+if [ "$EXIT" -eq 0 ]; then
+  echo "OK: §854 solver carve-out is label-only in both the template and the test copy (#5564)."
+fi
+exit "$EXIT"


### PR DESCRIPTION
## The hole

`forbid-nodeport-service` carved out cert-manager solvers with **two** clauses, and `exclude` is an
`any:` list:

```yaml
exclude:
  any:
    - resources: {selector: {matchLabels: {acme.cert-manager.io/http01-solver: "true"}}}
    - resources: {names: ["cm-acme-http-solver-*"]}      # <- by NAME alone
```

Either clause suffices, so a hand-applied `type=NodePort` Service named
`cm-acme-http-solver-anything` was admitted with **no cert-manager involvement at all** — a
permanent, self-service §854 exemption available to anyone who can create a Service.

The policy described the name clause as *"belt-and-braces … the label is the durable contract, the
name pattern a fallback"*. A fallback that admits **unlabelled** Services is not a fallback.

Removing it costs no real coverage — cert-manager sets the label unconditionally, and a live sweep of
the mothership found **7 of 7** solver Services carrying it:

```
chepherd-hub  cm-acme-http-solver-rsfzq  label=true      ping  cm-acme-http-solver-f8q8p  label=true
iogrid        cm-acme-http-solver-sh4np  label=true      ping  cm-acme-http-solver-mn9jq  label=true
ping-mkt      cm-acme-http-solver-85625  label=true      ping  cm-acme-http-solver-zs2f5  label=true
ping-mkt      cm-acme-http-solver-slc4n  label=true
```

**Policy action is untouched.** This narrows an exclusion; it does not flip Audit/Enforce — no repeat
of the #5505 action-flip shape.

## Why a shell guard rather than just a test case

The obvious defence is a kyverno case asserting an unlabelled solver-shaped Service is denied. **That
defence does not work**, and I measured it rather than assuming:

| policy state | expectation | `kyverno test` verdict |
|---|---|---|
| glob REMOVED | `result: skip` | **FAILS** — "Want skip, got fail" ✅ discriminates |
| glob PRESENT | `result: skip` | passes |
| glob PRESENT | `result: fail` | **passes** ← the problem |

With the bypass restored the resource is **EXCLUDED**, and kyverno's matcher accepts that as
satisfying `result: fail`. So a deny-assertion stays green after someone adds an exclusion that
neuters it. That is fail-open, and it applies to **every** deny case in this suite, not only mine.

`scripts/check-kyverno-nodeport-exclusions.sh` therefore asserts on **policy text**, where an
exclusion cannot hide.

## A second defect it caught

The suite validates `tests/forbid-nodeport-service/policy.yaml` — a **hand-maintained copy** of the
policy, not the Helm template. So the shipped template can drift from what is tested, and it did:
the copy still carried the bypass after the template was fixed, and the suite happily passed 12/12.
The guard now fails on that mismatch.

## Verification

- **Self-test** proves both detectors discriminate, including that a Helm `{{/* */}}` block comment
  naming the pattern in prose is **not** a bypass. The first version flagged the policy's own
  documentation — failing a file for explaining the rule it enforces would train people to delete
  the explanation.
- **Mutation-tested end to end:** restoring the glob → guard exits 1 reporting *both* the bypass and
  the template/copy drift; removing it → exit 0.
- `kyverno test` 12/12 pass; fixture `cm-acme-http-solver-9xk2p` flipped from admitted to denied so
  the former hole is now a regression test.
- Four-site lockstep → 1.0.51 (Chart.yaml, blueprint.yaml, two catalog-seed pins); bootstrap-kit
  `CatalogSeed` guards pass with `-count=1`.

Refs #5564 #5088 #4765 #5561
