### PR TITLE
fix(bp-powerdns): front-door guard rejected the §854 fix it guards — main pins a chart that never published

### DIFF
--- a/platform/powerdns/chart/tests/hetzner-frontdoor-render.sh
+++ b/platform/powerdns/chart/tests/hetzner-frontdoor-render.sh
@@ -19,14 +19,16 @@
 #   1. DEFAULT (Huawei/kom4dc/contabo): dnsdist => Deployment, its Service =>
 #      ClusterIP, NO hostPort, NO NodePort — the anycast-VIP path is untouched.
 #   2. DEFAULT: anycast Service => type=LoadBalancer + allocateLoadBalancerNodePorts:false,
-#      NO nodePort port field (the §854 shared-VIP front door).
+#      and `nodePort: 0` stated EXPLICITLY on each port (#5348 — omitting the
+#      field does NOT deallocate an already-assigned port).
 #   3. HETZNER (dnsdist.hostPortMode=true): dnsdist => DaemonSet, hostPort:53 on
 #      BOTH the UDP and TCP ports, tolerations `operator: Exists` (covers the CP
 #      node — an LB :53 target), and NO hostNetwork (pod-netns :53 bind dodges
 #      the systemd-resolved 127.0.0.53 stub).
-#   4. §854: NEITHER render carries `type: NodePort` or a `nodePort:` port field
-#      anywhere (allocateLoadBalancerNodePorts:false is the suppression flag, not
-#      a NodePort, and is excluded from the scan).
+#   4. §854: NEITHER render carries `type: NodePort` or a NONZERO `nodePort:`
+#      anywhere. `nodePort: 0` is the k8s released-sentinel and is INERT;
+#      allocateLoadBalancerNodePorts:false is the suppression flag, not a
+#      NodePort. Both are excluded from the scan (#5348).
 #   5. §854 hard guard: anycast.serviceType=NodePort FAILS the render (the
 #      template's explicit `fail`), so a NodePort can never be reintroduced by
 #      an overlay value.
@@ -71,8 +73,29 @@ if ! echo "$anycast" | grep -qE '^  allocateLoadBalancerNodePorts: false$'; then
   echo "FAIL: anycast Service must set allocateLoadBalancerNodePorts:false (§854 — zero nodePorts)"
   exit 1
 fi
-if echo "$anycast" | grep -qE '^ *nodePort:'; then
-  echo "FAIL: anycast Service must NOT carry a nodePort port field (§854)"
+# §854: a NONZERO nodePort is the violation. `nodePort: 0` is the k8s
+# "unspecified/released" sentinel and is INERT — it is also the deallocation
+# instruction #5348 requires, because `allocateLoadBalancerNodePorts: false`
+# does NOT free ports the apiserver already assigned, and a declarative apply
+# that OMITS the field leaves the existing value untouched forever. The live
+# mothership proved that: the chart set the flag, omitted nodePort, and
+# powerdns-anycast still served 32015/31425.
+#
+# This assertion previously matched the FIELD, so it failed the very fix for
+# the defect it guards — it blocked the bp-powerdns 1.2.23 publish on main and
+# left the catalog-seed + bootstrap-kit pins hollow. Match a nonzero value, the
+# same way scripts/check-no-nodeports.sh does.
+if echo "$anycast" | grep -qE '^ *nodePort:[[:space:]]*[1-9][0-9]*'; then
+  echo "FAIL: anycast Service carries a NONZERO nodePort (§854)"
+  echo "$anycast" | grep -nE '^ *nodePort:' || true
+  exit 1
+fi
+# Vacuity guard: `nodePort: 0` must be PRESENT. Without it the render is
+# "compliant" only by omission, which is precisely the #5348 shape that let a
+# live allocation survive. Absence is not compliance here.
+if ! echo "$anycast" | grep -qE '^ *nodePort:[[:space:]]*0[[:space:]]*$'; then
+  echo "FAIL: anycast Service must state nodePort: 0 EXPLICITLY on each port (§854/#5348)"
+  echo "      Omitting the field does not deallocate an existing nodePort."
   exit 1
 fi
 echo "[bp-powerdns] Case 2: PASS"
@@ -113,7 +136,7 @@ for mode in "default" "hetzner"; do
   # NodePort — exclude it, then any residual nodePort/type:NodePort is a defect.
   hits=$(echo "$full" \
     | grep -vE 'allocateLoadBalancerNodePorts' \
-    | grep -niE 'type:[[:space:]]*NodePort|^ *nodePort:' || true)
+    | grep -niE 'type:[[:space:]]*NodePort|^ *nodePort:[[:space:]]*[1-9][0-9]*' || true)
   if [ -n "$hits" ]; then
     echo "FAIL: §854 violation — NodePort rendered in $mode mode:"
     echo "$hits"


### PR DESCRIPTION
## Urgent: `main` has a live hollow pin

`Blueprint Release` **FAILED** on main (run `30737881774`) immediately after #5547 merged:

```
FAIL: anycast Service must NOT carry a nodePort port field (§854)
```

**bp-powerdns 1.2.23 never published.** main's catalog-seed *and* bootstrap-kit pin 1.2.23; ghcr holds only 1.2.22. A fresh prov cannot resolve the chart.

## Root cause — the guard rejected the fix for the defect it guards

It matched the **field**, not a nonzero **value**. But `nodePort: 0` is the k8s released-sentinel and is exactly what #5348 requires: `allocateLoadBalancerNodePorts: false` does **not** free ports the apiserver already assigned, and a declarative apply that *omits* the field leaves the old value forever. The live mothership proved it — flag set, field omitted, `powerdns-anycast` still serving 32015/31425.

The template author already anticipated the right shape: `anycast-endpoint.yaml:73` notes the repo pattern is `nodePort: [1-9][0-9]*`. Only this release guard was never updated.

## Mutation-tested, not assumed

| mutation | result |
|---|---|
| FIELD `0` → `32015` | **FAILS** ✅ |
| delete `nodePort: 0` (the #5348 omission shape) | **FAILS** ✅ |
| clean chart | **PASSES** — all 5 cases |

The vacuity half matters as much as the first: without it a render is "compliant" by omission, which is precisely how #5348 survived a clean-looking chart. **Absence is not compliance.**

Case 4 carried the identical defect and is fixed the same way; header comments corrected.

> A first mutation attempt appeared to pass — it had rewritten a **comment** containing `nodePort: 0` rather than the field. I verified the mutant render actually carried 2× `nodePort: 32015` before trusting it.

Merging this lets Blueprint Release republish 1.2.23 and clears the hollow pin.

Refs #5348 #5086 #4765 #960