### PR TITLE
fix(854): NodePort guard advised deleting an allowlist entry CI still needs — advisory was blind to untracked dep cache

### DIFF
--- a/scripts/check-no-nodeports.sh
+++ b/scripts/check-no-nodeports.sh
@@ -254,10 +254,27 @@ is_render_skip_allowed() {
   return 1
 }
 
+# True when <chart>/charts/ holds a dependency tarball that is NOT tracked in
+# git — i.e. leftover from a `helm dependency update` on this machine. A chart
+# can render off that cache while being unbuildable from a clean checkout, so
+# "it rendered" must not be read as "the allowlist entry is stale".
+has_untracked_cached_dep() {
+  local chart="$1" f
+  [ -d "${chart}/charts" ] || return 1
+  for f in "${chart}"/charts/*.tgz; do
+    [ -e "${f}" ] || continue
+    if ! git ls-files --error-unmatch "${f}" >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 RENDERED_COUNT=0
 SKIPPED_COUNT=0
 RENDER_PHASE_RAN=0
 UNEXPECTED_RENDERABLE=""
+CACHE_MASKED=""
 
 echo ""
 echo "== Phase 2: rendered-chart NodePort scan =="
@@ -359,7 +376,21 @@ else
     fi
     RENDERED_COUNT=$((RENDERED_COUNT + 1))
     if is_render_skip_allowed "${chart}"; then
-      UNEXPECTED_RENDERABLE="${UNEXPECTED_RENDERABLE}  ${chart}"$'\n'
+      # An allowlisted chart that renders is normally allowlist rot — EXCEPT
+      # when it only rendered because an UNTRACKED dependency tarball is
+      # sitting in <chart>/charts/ from an earlier fetch on this machine. CI
+      # checks out clean, so there the same chart still cannot build, and
+      # "remove it from the allowlist" would break the sweep for everyone.
+      #
+      # This is not hypothetical: platform/sealed-secrets/chart declares
+      # https://bitnami-labs.github.io/sealed-secrets, which answers 404. It
+      # rendered here purely off a months-old untracked sealed-secrets-*.tgz,
+      # and this NOTE advised deleting the entry that documents exactly that.
+      if has_untracked_cached_dep "${chart}"; then
+        CACHE_MASKED="${CACHE_MASKED}  ${chart}"$'\n'
+      else
+        UNEXPECTED_RENDERABLE="${UNEXPECTED_RENDERABLE}  ${chart}"$'\n'
+      fi
     fi
     # `nodePort: 0` is the k8s "unspecified" sentinel (vcluster/upstream
     # ClusterIP Services render it) — inert; only a NONZERO nodePort or a
@@ -378,9 +409,20 @@ fi
 
 echo ""
 if [ -n "${UNEXPECTED_RENDERABLE}" ]; then
-  echo "NOTE: these charts are in RENDER_SKIP_ALLOWLIST but now render offline."
+  echo "NOTE: these charts are in RENDER_SKIP_ALLOWLIST but now render offline"
+  echo "      from a CLEAN tree (no untracked cached dependency)."
   echo "      Remove them from the list so the allowlist cannot rot:"
   printf '%s' "${UNEXPECTED_RENDERABLE}"
+  echo ""
+fi
+
+if [ -n "${CACHE_MASKED}" ]; then
+  echo "NOTE: these allowlisted charts rendered ONLY because an untracked"
+  echo "      dependency tarball is cached in <chart>/charts/ on this machine."
+  echo "      CI checks out clean, so they still cannot build there."
+  echo "      Do NOT remove their allowlist entries on the strength of this run:"
+  printf '%s' "${CACHE_MASKED}"
+  echo "      To test for real: git clean -xdf the chart dir, then re-run."
   echo ""
 fi
 


### PR DESCRIPTION
## The §854 guard told me to delete an allowlist entry that CI still needs

Running the NodePort sweep, it printed:

```
NOTE: these charts are in RENDER_SKIP_ALLOWLIST but now render offline.
      Remove them from the list so the allowlist cannot rot:
  platform/sealed-secrets/chart
```

Acting on that would have broken the sweep on every clean checkout.

### Why the advisory was wrong

`platform/sealed-secrets/chart` declares `https://bitnami-labs.github.io/sealed-secrets`, which
**still answers HTTP 404**. It rendered on this machine only because of:

```
platform/sealed-secrets/chart/charts/sealed-secrets-2.16.1.tgz    dated Jun 12
```

and `git ls-files` shows that tarball is **untracked** — only `Chart.yaml`, `values.yaml` and
`tests/` are in git. CI checks out clean, so the chart cannot build there at all.

The allowlist entry's own comment already said this — *"renders on dev machines only from a stale
cached tarball"* — and the guard's NOTE was advising deletion of the entry that documents it. The
advisory was blind to local cache state, which is the one thing that makes the render succeed.

### The fix

`has_untracked_cached_dep()` tests whether `<chart>/charts/*.tgz` is untracked. An allowlisted chart
that renders now splits two ways:

| situation | advice |
|---|---|
| clean tree, renders | genuine allowlist rot → remove the entry |
| rendered off untracked cache | **do not remove** → `git clean -xdf` the chart dir and re-run to test for real |

### Mutation-tested in both directions

The point is behaviour, not wording, so I verified the classification actually flips:

```
cache present  -> "Do NOT remove their allowlist entries", names the chart
cache removed  -> dependency fetch fails rc=1, chart SKIPs,
                  counts move 72->71 rendered, 17->18 allowlisted
```

That second run doubles as independent proof the allowlist entry is **still required** — so #5563
stays open and the entry stays put.

### Sweep result this run, for the record

- **openova-private**: zero NodePort declarations repo-wide. Two matches total, both comment lines
  in `cert-manager/helmrelease.yaml` documenting the ban. `clusters/` contains exactly one tree
  (`contabo-mkt`), so that is full coverage.
- **openova (public)**: zero non-test declarations; 72 charts render clean, 17 covered by source
  scan only.

Refs #5563 #4765 #5512
