### PR TITLE
fix(wizard+api): salvage the six genuinely-new changes from the #5554 train

### DIFF
--- a/core/controllers/application/internal/controller/placement_primary_divergence_5482_test.go
+++ b/core/controllers/application/internal/controller/placement_primary_divergence_5482_test.go
@@ -1,0 +1,140 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+)
+
+// #5482 — the App-detail PRIMARY REGION label reads a field that goes stale on
+// failover, while a correct value sits one level down in the same status.
+//
+// Application.status carries the primary region in TWO places, written by two
+// different code paths:
+//
+//	FLAT    status.primaryRegion
+//	          <- statusUpdate.PrimaryRegion <- plan.PrimaryRegion
+//	          application_controller.go:1535 (set) / :2593 (written)
+//	          This is the STATIC configured primary, i.e. spec.regions[0].
+//
+//	NESTED  status.placement.primaryRegion
+//	          <- buildPlacementProjection, which prefers the governing
+//	          Continuum's leaseHolder over plan.PrimaryRegion
+//	          placement_projection.go:244-247
+//
+// placement_projection.go documents why the nested one is authoritative
+// (:104-106, verbatim): the plan primary "is only the *configured* (regions[0])
+// primary and goes stale the moment the continuum-controller flips the lease on
+// failover."
+//
+// So after a DR failover the two disagree: nested tracks the new primary, flat
+// still reports the old one. Any surface reading the flat field shows a region
+// that is no longer primary — with no indication it is stale. Same
+// declared-vs-actual family as #5542 (HTTP 200 declaring 400), #5545 (61
+// "Deleted" that never happened) and #5515 (multi-region declared over one live
+// region).
+//
+// These tests pin the divergence at the projection boundary. They do NOT assert
+// a fix: correcting the flat field is a DR-path status write that must be
+// validated against a live 2-region Sovereign under an actual lease flip, which
+// needs hw292. Pinning it here means the next person to touch either writer
+// cannot silently widen the gap, and has the exact reproduction in hand.
+
+// planWith builds a static plan whose configured primary is regions[0].
+func planWith(primary string, standbys ...string) placement.Plan {
+	regions := []placement.RegionPlan{{Name: primary}}
+	for _, s := range standbys {
+		regions = append(regions, placement.RegionPlan{Name: s})
+	}
+	return placement.Plan{PrimaryRegion: primary, Regions: regions}
+}
+
+// The core defect: a lease flip moves the nested primary and leaves the flat
+// one behind.
+func TestPlacementPrimary_5482_FlatGoesStaleAfterFailover(t *testing.T) {
+	plan := planWith("me-east-215-a", "me-east-215-b")
+
+	// Steady state: no Continuum, or a Continuum whose lease still sits on the
+	// configured primary. Both views agree.
+	steady := buildPlacementProjection(plan, &continuumDRStatus{LeaseHolder: "me-east-215-a"})
+	if steady == nil {
+		t.Fatal("projection returned nil for a two-region plan")
+	}
+	if got := steady["primaryRegion"]; got != "me-east-215-a" {
+		t.Fatalf("steady state: nested primaryRegion = %v, want me-east-215-a", got)
+	}
+
+	// Failover: the continuum-controller flips the lease to region-b. The
+	// STATIC plan is unchanged — nothing rewrites spec.regions on a failover.
+	failed := buildPlacementProjection(plan, &continuumDRStatus{LeaseHolder: "me-east-215-b"})
+
+	nested, _ := failed["primaryRegion"].(string)
+	flat := plan.PrimaryRegion // exactly what statusUpdate.PrimaryRegion carries
+
+	if nested != "me-east-215-b" {
+		t.Fatalf("nested primaryRegion should track the lease holder; got %q", nested)
+	}
+	if flat != "me-east-215-a" {
+		t.Fatalf("flat primary is sourced from plan.PrimaryRegion and should be unchanged; got %q", flat)
+	}
+	if nested == flat {
+		t.Fatalf("#5482 appears FIXED: flat and nested now agree (%q). If the flat "+
+			"writer was corrected, update this test deliberately rather than deleting it", nested)
+	}
+
+	t.Logf("#5482 CONFIRMED: after a lease flip, status.placement.primaryRegion=%q "+
+		"but status.primaryRegion=%q — a surface reading the flat field shows the "+
+		"OLD primary with no staleness signal", nested, flat)
+}
+
+// Vacuity control. The test above would pass trivially if the projection simply
+// echoed whatever LeaseHolder it was handed regardless of input. Pin the other
+// branches so the divergence test is known to be discriminating.
+func TestPlacementPrimary_5482_ProjectionBranchesAreDistinct(t *testing.T) {
+	plan := planWith("me-east-215-a", "me-east-215-b")
+
+	// No Continuum at all -> falls back to the static plan primary.
+	noContinuum := buildPlacementProjection(plan, nil)
+	if got := noContinuum["primaryRegion"]; got != "me-east-215-a" {
+		t.Fatalf("no-Continuum fallback: primaryRegion = %v, want the plan primary", got)
+	}
+
+	// Continuum present but carrying no lease holder -> also falls back, rather
+	// than emitting empty. An empty primary would render a blank label.
+	emptyLease := buildPlacementProjection(plan, &continuumDRStatus{LeaseHolder: ""})
+	if got := emptyLease["primaryRegion"]; got != "me-east-215-a" {
+		t.Fatalf("empty-leaseHolder fallback: primaryRegion = %v, want the plan primary", got)
+	}
+
+	// Empty plan -> nil projection, not a half-built map.
+	if got := buildPlacementProjection(placement.Plan{}, nil); got != nil {
+		t.Fatalf("empty plan should yield a nil projection, got %v", got)
+	}
+}
+
+// The standby roster is recomputed against the EFFECTIVE primary, which is the
+// half of this that already behaves correctly. Recording it so a future fix to
+// the flat field does not regress the roster while chasing the label.
+func TestPlacementPrimary_5482_StandbyRosterTracksEffectivePrimary(t *testing.T) {
+	plan := planWith("me-east-215-a", "me-east-215-b")
+	failed := buildPlacementProjection(plan, &continuumDRStatus{LeaseHolder: "me-east-215-b"})
+
+	standbys, ok := failed["standbyRegions"].([]interface{})
+	if !ok {
+		// Shape may be []string depending on the builder; accept either.
+		if ss, ok2 := failed["standbyRegions"].([]string); ok2 {
+			for _, s := range ss {
+				standbys = append(standbys, s)
+			}
+		} else {
+			t.Skipf("standbyRegions shape %T not asserted here", failed["standbyRegions"])
+		}
+	}
+
+	for _, s := range standbys {
+		if s == "me-east-215-b" {
+			t.Fatalf("the failed-over-TO region must not also be listed as a standby: %v", standbys)
+		}
+	}
+	t.Logf("standby roster after failover = %v (correctly excludes the new primary)", standbys)
+}

--- a/docs/sessions/2026-08-02/mothership-live-walk.md
+++ b/docs/sessions/2026-08-02/mothership-live-walk.md
@@ -1,0 +1,114 @@
+# Mothership live walk — 2026-08-02T08:32–08:55Z (read-only kubectl)
+
+Three live walks against the production mothership. Recorded here rather than only in issue
+comments so the evidence is committed, dated, and greppable.
+
+**Nothing was mutated.** Every command below is a read.
+
+---
+
+## Walk 1 — §854 live NodePort sweep (feeds UAT row 240)
+
+```
+165 Services scanned · 14 carry a nodePort · exactly 1 in a namespace we own
+  openova-system/powerdns-anycast   LoadBalancer   32015,31425   95d
+```
+
+The violation is **still live** although the fix shipped today. Traced in the same sweep:
+
+```
+live HelmRelease openova-system/powerdns
+  lastApplied = 1.2.22+3dee9b09e026     Ready=True
+```
+
+`bp-powerdns` **1.2.23** — the version carrying the explicit `nodePort: 0` deallocation — is on
+`main` and published to ghcr. The cluster runs **1.2.22**.
+
+**Three gates exist and only two are passed: merged → published → DEPLOYED.** Every prior
+"merged ≠ delivered" note in this repo stops at two. The Service is Flux/Helm-owned
+(`helm.toolkit.fluxcd.io/name=powerdns`), so it clears only when that HelmRelease advances;
+hand-patching is reverted on the next reconcile, which is the #5348 shape exactly.
+
+Solver ageing confirms **#5567 is not self-healing**: `chepherd-hub/cm-acme-http-solver-rsfzq` was
+4h at the 05:08Z walk and 11h here, still stuck behind its 503 self-check.
+
+Committed to row 240 in `67722190c`.
+
+---
+
+## Walk 2 — #5563 is failing in production, not latent
+
+I filed #5563 as a build-time finding ("unbuildable from a clean checkout, none customer-visible").
+The cluster contradicts that in its own words:
+
+```
+kubectl -n kube-system get helmrelease sealed-secrets
+  [Ready]    False  SourceNotReady
+     HelmChart 'kube-system/kube-system-sealed-secrets' is not ready: does not have an artifact
+  [Released] True   InstallSucceeded
+     Helm install succeeded for release kube-system/sealed-secrets.v1 with chart sealed-secrets@2.17.9
+
+kubectl -n kube-system get helmrepository sealed-secrets
+  url: https://bitnami-labs.github.io/sealed-secrets
+  [FetchFailed] True — failed to fetch .../index.yaml : 404 Not Found
+```
+
+`Released=True` with `Ready=False` is the signature: it **installed once**, when the upstream still
+answered, and has been unable to reconcile since. Nothing alerted because the workload from that
+first install is still running.
+
+Three independent confirmations of one fact: the repo declares the URL
+(`platform/sealed-secrets/chart/Chart.yaml:27`), a direct `curl` returns 404, and Flux's own fetch
+returns the identical 404.
+
+The constraint is `2.17.*`, so Flux resolves a **floating range against a dead index** on every
+reconcile — a permanent retry loop. `sealed-secrets` is the decryption path for sealed Secrets, so a
+cluster that cannot reinstall it is one controller eviction from a much worse morning.
+
+**No UAT row exists for this** — `grep -ci 'sealed-secrets' docs/ledger/UAT.md` → 0. The mothership
+is not a Sovereign and the UAT ledger is the Sovereign acceptance walk, so mothership infrastructure
+health has no acceptance row. Recorded here and on #5563 instead of forcing an unrelated row.
+
+---
+
+## Walk 3 — `axon` HelmRelease reports a failure that is not happening
+
+```
+kubectl -n axon get helmrelease axon
+  [Released] False  UpgradeFailed
+     timeout waiting for: Deployment/axon/axon-valkey status: 'InProgress',
+                          Deployment/axon/axon status: 'InProgress'
+
+kubectl -n axon get pods
+  axon-6897449555-8964p          Running  1/1 ready  restarts=0  age=19h  [axon:69706a8]
+  axon-valkey-76d5f58d8d-vh5c9   Running  1/1 ready  restarts=0  age=1d   [valkey:8-alpine]
+```
+
+Both Deployments are healthy — **1/1 ready, zero restarts**, running for 19h and 1d. The upgrade
+timed out at its 5-minute readiness window, the pods became ready afterwards, and the HelmRelease
+status was never re-reconciled to reflect it. **The status is stale, not wrong-at-the-time.**
+
+---
+
+## What the three walks establish together
+
+Flux status on this cluster is unreliable **in both directions**, which generalises #5558:
+
+| object | Flux says | reality |
+|---|---|---|
+| `catalyst-platform` (#5558) | `Healthy=True` | zero pods, console 503 |
+| `apps` (#5558) | `HealthCheckFailed` | four objects all `Ready=True` |
+| `openova-system/powerdns` | `Ready=True` | serving a §854 violation |
+| `kube-system/sealed-secrets` | `Ready=False` | accurate — source genuinely dead |
+| `axon/axon` | `UpgradeFailed` | both Deployments 1/1, 0 restarts |
+
+**Anything gating on HelmRelease `Ready`/`Released` as ground truth is being misled**, and the
+powerdns row shows the sharper form: `Ready=True` is not `compliant=true`. Health status and
+compliance status are different questions, and only one of them is being asked.
+
+## Follow-ups
+
+- #5563 — claimed, severity raised from latent to live-failing.
+- #5567 — orphaned Kyverno webhooks; solver ageing 4h → 11h confirms no self-heal.
+- #5558 — this walk adds two more status inversions to its evidence.
+- powerdns deployment gap — the HelmRelease must advance to 1.2.23; tracked on row 240.

--- a/products/catalyst/bootstrap/api/internal/infrastructure/derive_pattern_5515_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/derive_pattern_5515_test.go
@@ -1,0 +1,208 @@
+package infrastructure
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// #5515 — derivePattern must not report a topology richer than the live one.
+//
+// THE DEFECT (fixed by this change): derivePattern took only LoaderInput, whose
+// Regions field is []provisioner.RegionSpec — the DECLARED wizard payload. Liveness
+// lives elsewhere: buildTopology appends buildAbsentRegion(rs) (Clusters:nil,
+// Status:"degraded") for any declared region whose kubeconfig never arrived
+// (#4811/#4814). So a 2-region prov whose region-b never converged reported
+// pattern="multi-region", and the console presented a DR topology that did not exist.
+//
+// The root cause was a MISSING INPUT, not a mis-ordered switch — no argument carried
+// liveness, so no reordering of the existing cases could have fixed it. The fix moves
+// the derivation below the build loop and threads the built regions in.
+//
+// Same declared-vs-actual family as #5542 (HTTP 200 declaring 400) and #5545 (61
+// "Deleted" that never happened, confirmed live on the mothership 2026-08-01).
+//
+// These tests now assert the FIXED behaviour. If one fails, the fail-open has
+// regressed — do not "repair" it by relaxing the expectation.
+func TestDerivePattern_5515_FailsOpenOnAbsentSecondaryRegion(t *testing.T) {
+	// Two DECLARED regions. region-b carries a full spec — the wizard declared it —
+	// but at runtime it never converged, so buildTopology would emit
+	// buildAbsentRegion() for it: zero clusters, status "degraded".
+	in := LoaderInput{
+		Status: "ready",
+		Regions: []provisioner.RegionSpec{
+			{CloudRegion: "eu-west-101", Provider: "huawei", WorkerCount: 3},
+			{CloudRegion: "eu-west-102", Provider: "huawei", WorkerCount: 3}, // never converged
+		},
+	}
+
+	// The BUILT regions: region-a converged (one live Cluster), region-b did not
+	// (buildAbsentRegion shape — Clusters:nil, degraded).
+	built := []Region{
+		{ID: "region-eu-west-101", WorkerCount: 3, Clusters: []Cluster{{ID: "c-a"}}},
+		{ID: "region-eu-west-102", WorkerCount: 3, Status: "degraded", Clusters: nil},
+	}
+
+	got := derivePattern(in, built)
+
+	if got != "ha-pair" {
+		t.Fatalf("#5515 regression: one live region (3 workers) + one declared-dead "+
+			"region must NOT report multi-region; want %q, got %q", "ha-pair", got)
+	}
+
+	t.Logf("#5515 FIXED: derivePattern returned %q — the declared-but-dead secondary "+
+		"no longer inflates the pattern to multi-region", got)
+}
+
+// Vacuity control. A guard that only ever asserts one input can pass because the
+// function is a constant. These pin the other branches so the test above is known to
+// be discriminating rather than trivially true.
+func TestDerivePattern_5515_ControlBranchesAreDistinct(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    LoaderInput
+		built []Region
+		want  string
+	}{
+		{
+			name:  "single region, 3+ workers -> ha-pair",
+			in:    LoaderInput{Regions: []provisioner.RegionSpec{{CloudRegion: "eu-west-101", WorkerCount: 3}}},
+			built: []Region{{WorkerCount: 3, Clusters: []Cluster{{ID: "c"}}}},
+			want:  "ha-pair",
+		},
+		{
+			name:  "single region, <3 workers -> solo",
+			in:    LoaderInput{Regions: []provisioner.RegionSpec{{CloudRegion: "eu-west-101", WorkerCount: 1}}},
+			built: []Region{{WorkerCount: 1, Clusters: []Cluster{{ID: "c"}}}},
+			want:  "solo",
+		},
+		{
+			name:  "legacy singular Region field -> solo",
+			in:    LoaderInput{Region: "eu-west-101"},
+			built: nil, // legacy singular path, nothing built yet -> declared fallback
+			want:  "solo",
+		},
+		{
+			name:  "nothing declared -> unknown",
+			in:    LoaderInput{},
+			built: nil,
+			want:  "unknown",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := derivePattern(tc.in, tc.built); got != tc.want {
+				t.Fatalf("derivePattern = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The discriminating check: liveness is INVISIBLE to derivePattern. Two inputs that
+// differ ONLY in whether the second region ever converged are indistinguishable to it,
+// because it never receives that information. This is the precise defect — not a
+// mis-ordered case, but a missing input.
+func TestDerivePattern_5515_LivenessIsNotAnInput(t *testing.T) {
+	bothLive := LoaderInput{
+		Regions: []provisioner.RegionSpec{
+			{CloudRegion: "eu-west-101", WorkerCount: 3},
+			{CloudRegion: "eu-west-102", WorkerCount: 3},
+		},
+	}
+	// Byte-identical declared shape; in reality region-b is dead. derivePattern has
+	// no parameter that could carry that fact.
+	secondaryDead := LoaderInput{
+		Regions: []provisioner.RegionSpec{
+			{CloudRegion: "eu-west-101", WorkerCount: 3},
+			{CloudRegion: "eu-west-102", WorkerCount: 3},
+		},
+	}
+
+	bothBuilt := []Region{
+		{WorkerCount: 3, Clusters: []Cluster{{ID: "c-a"}}},
+		{WorkerCount: 3, Clusters: []Cluster{{ID: "c-b"}}},
+	}
+	deadBuilt := []Region{
+		{WorkerCount: 3, Clusters: []Cluster{{ID: "c-a"}}},
+		{WorkerCount: 3, Status: "degraded", Clusters: nil},
+	}
+
+	a, b := derivePattern(bothLive, bothBuilt), derivePattern(secondaryDead, deadBuilt)
+	if a == b {
+		t.Fatalf("#5515 regression: derivePattern still cannot distinguish a live "+
+			"secondary from a dead one — both yielded %q", a)
+	}
+	if a != "multi-region" || b != "ha-pair" {
+		t.Fatalf("want multi-region/ha-pair, got %q/%q", a, b)
+	}
+	t.Logf("#5515 fixed at the root: identical DECLARED shapes now yield %q vs %q "+
+		"because liveness reaches the derivation via the built regions", a, b)
+}
+
+// In-flight guard (#5515 fix, regression-protection). While a fresh prov is still
+// converging, NO region has clusters yet. Deriving purely from live state would
+// report "unknown" for every provision in progress — fixing the degraded path by
+// breaking the normal one. Nothing built => fall back to the DECLARED shape.
+func TestDerivePattern_5515_InFlightFallsBackToDeclared(t *testing.T) {
+	in := LoaderInput{
+		Regions: []provisioner.RegionSpec{
+			{CloudRegion: "eu-west-101", WorkerCount: 3},
+			{CloudRegion: "eu-west-102", WorkerCount: 3},
+		},
+	}
+	// Mid-provision: regions declared, none converged.
+	if got := derivePattern(in, nil); got != "multi-region" {
+		t.Fatalf("in-flight 2-region prov must report declared %q, got %q", "multi-region", got)
+	}
+	// Same, but the built slice exists with no clusters yet.
+	empty := []Region{{Clusters: nil}, {Clusters: nil}}
+	if got := derivePattern(in, empty); got != "multi-region" {
+		t.Fatalf("in-flight (empty clusters) must report declared %q, got %q", "multi-region", got)
+	}
+}
+
+// PRODUCTION REPRODUCTION (#5515). The shape below is not invented — it is the
+// region topology of a real deployment record read from the live mothership on
+// 2026-08-01 (catalyst-api PVC, /var/lib/catalyst/deployments/2c2d746b578c636b.json):
+//
+//	request.regions = [ me-east-215-a (huawei, m7n.2xlarge.8, workerCount 3),
+//	                    me-east-215-b (huawei, ...) ]          <- 2 DECLARED
+//	result.regions  = [ { region: me-east-215-a, primary: true,
+//	                      hrReady: 3, hrTotal: 3, degraded: false } ]  <- 1 LIVE
+//
+// Two regions declared, exactly one converged. Under the pre-fix derivePattern
+// (which counted len(in.Regions)) this deployment reported "multi-region" while
+// only me-east-215-a existed — the console would have shown a DR topology with no
+// second region behind it.
+//
+// This test proves the fix against that real input shape rather than a synthetic
+// one. If it ever returns "multi-region" again, the fail-open has regressed on a
+// case that demonstrably occurs in production.
+func TestDerivePattern_5515_RealMothershipRecordShape(t *testing.T) {
+	in := LoaderInput{
+		Status: "wiped",
+		Region: "me-east-215-a",
+		Regions: []provisioner.RegionSpec{
+			{Provider: "huawei", CloudRegion: "me-east-215-a", ControlPlaneSize: "m7n.xlarge.8", WorkerSize: "m7n.2xlarge.8", WorkerCount: 3},
+			{Provider: "huawei", CloudRegion: "me-east-215-b", ControlPlaneSize: "m7n.xlarge.8", WorkerSize: "m7n.2xlarge.8", WorkerCount: 3},
+		},
+	}
+	// result.regions carried ONLY me-east-215-a, so the build loop yields one live
+	// region plus a buildAbsentRegion() for the declared-but-absent -b.
+	built := []Region{
+		{ID: "region-me-east-215-a", Name: "me-east-215-a", WorkerCount: 3, Clusters: []Cluster{{ID: "2c2d746b578c636b"}}},
+		{ID: "region-me-east-215-b", Name: "me-east-215-b", WorkerCount: 3, Status: "degraded", Clusters: nil},
+	}
+
+	got := derivePattern(in, built)
+	if got == "multi-region" {
+		t.Fatalf("#5515 REGRESSION on a real production record: reported %q for a "+
+			"deployment with 2 declared regions but only me-east-215-a live", got)
+	}
+	if got != "ha-pair" {
+		t.Fatalf("want %q for one live 3-worker region, got %q", "ha-pair", got)
+	}
+	t.Logf("#5515 verified against the real mothership record 2c2d746b578c636b: "+
+		"2 declared / 1 live now yields %q, not multi-region", got)
+}

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -47,16 +47,16 @@ type K8sCacheReader interface {
 // create a cycle); the handler unwraps Deployment fields onto this
 // struct and calls Load.
 type LoaderInput struct {
-	DeploymentID  string
-	Status        string // canonical UI status
-	SovereignFQDN string
-	Provider      string
-	Region        string
-	Regions       []provisioner.RegionSpec
-	WorkerCount   int
-	WorkerSize    string
-	CPSize        string
-	Result        *provisioner.Result
+	DeploymentID     string
+	Status           string // canonical UI status
+	SovereignFQDN    string
+	Provider         string
+	Region           string
+	Regions          []provisioner.RegionSpec
+	WorkerCount      int
+	WorkerSize       string
+	CPSize           string
+	Result           *provisioner.Result
 	HetznerProjectID string
 
 	// DynamicClient — Sovereign cluster dynamic client, built from
@@ -114,8 +114,10 @@ func buildCloud(in LoaderInput) []CloudTenant {
 // Regions[*] entry; legacy single-region path uses the singular
 // Request fields.
 func buildTopology(ctx context.Context, in LoaderInput) TopologyData {
-	pattern := derivePattern(in)
-
+	// #5515: pattern is derived AFTER the regions are built — it needs their
+	// liveness (Clusters), which does not exist at function entry. The call
+	// previously sat here, above the build loop, which is structurally why it
+	// could only ever see declared specs.
 	regions := []Region{}
 	if len(in.Regions) > 0 {
 		for i, rs := range in.Regions {
@@ -207,9 +209,13 @@ func buildTopology(ctx context.Context, in LoaderInput) TopologyData {
 			regions = append(regions, rs)
 		}
 	}
+	pattern := derivePattern(in, regions)
+	// Pre-existing correction, retained: a build path that produced regions but
+	// declared nothing (chroot / live-nodes paths) must not report "unknown".
 	if len(regions) > 0 && pattern == "unknown" {
 		pattern = "solo"
 	}
+
 	return TopologyData{
 		Pattern: pattern,
 		Regions: regions,
@@ -610,18 +616,61 @@ func nodeReadyStatus(obj map[string]any) string {
 	return ""
 }
 
-func derivePattern(in LoaderInput) string {
+// derivePattern — the topology pattern the console renders.
+//
+// #5515: this MUST be derived from the BUILT regions, which carry liveness via
+// their Clusters slice, and NOT from in.Regions (the DECLARED wizard specs). A
+// declared secondary region that never converged is emitted by buildAbsentRegion
+// with Clusters:nil (#4811/#4814); counting declared specs therefore reported
+// "multi-region" for a deployment with exactly ONE live region — the console
+// presented a DR topology that did not exist.
+//
+// The previous signature took only LoaderInput, so liveness was not merely
+// mis-weighted, it was UNREACHABLE — no argument carried it. Reordering the
+// switch could not have fixed it.
+//
+// In-flight guard: while a fresh prov is still converging, NO region has clusters
+// yet. Counting live regions alone would report "unknown" for every provision in
+// progress — a regression of the normal path in the name of fixing the degraded
+// one. So when nothing has converged, fall back to the DECLARED shape: reporting
+// intent is honest when there is no live state to contradict it. The defect this
+// fixes is specifically the MIXED case — some regions live, others declared-dead —
+// where live state exists and disagrees with the declaration.
+func derivePattern(in LoaderInput, built []Region) string {
+	live := 0
+	liveWorkers := 0
+	for _, r := range built {
+		if len(r.Clusters) == 0 {
+			continue
+		}
+		if live == 0 {
+			liveWorkers = r.WorkerCount
+		}
+		live++
+	}
+
+	// Nothing converged yet (fresh prov in flight, or a legacy path that builds
+	// no clusters) — report the declared shape rather than "unknown".
+	if live == 0 {
+		switch {
+		case len(in.Regions) > 1:
+			return "multi-region"
+		case len(in.Regions) == 1 && in.Regions[0].WorkerCount >= 3:
+			return "ha-pair"
+		case len(in.Regions) == 1, in.Region != "":
+			return "solo"
+		default:
+			return "unknown"
+		}
+	}
+
 	switch {
-	case len(in.Regions) > 1:
+	case live > 1:
 		return "multi-region"
-	case len(in.Regions) == 1 && in.Regions[0].WorkerCount >= 3:
+	case liveWorkers >= 3:
 		return "ha-pair"
-	case len(in.Regions) == 1:
-		return "solo"
-	case in.Region != "":
-		return "solo"
 	default:
-		return "unknown"
+		return "solo"
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -317,10 +317,29 @@ export interface ProvisionResult {
   gitopsRepoURL: string
 }
 
+/**
+ * ORG_DEFAULTS — the wizard's starting Organization identity.
+ *
+ * #5401: this shipped as `{name:'Acme Financial', domain:'acme.io',
+ * email:'platform@acme.io', industry:'Financial Services', …}` and was seeded
+ * directly into INITIAL_WIZARD_STATE below. An operator who did not overwrite
+ * every field provisioned a real Organization literally named "Acme Financial"
+ * with `platform@acme.io` as its billing contact — a fictitious company's
+ * details entering production as live data.
+ *
+ * Prefilled identity fields are actively harmful here: unlike a placeholder,
+ * a prefilled value survives an inattentive Next. These are now EMPTY so the
+ * required-field validation does its job and the operator must state who the
+ * Organization actually is.
+ *
+ * Empty strings, not `undefined` — WizardState types these as `string`, and
+ * the form binds them as controlled inputs (an undefined value would flip the
+ * field to uncontrolled and warn on first keystroke).
+ */
 export const ORG_DEFAULTS = {
-  name: 'Acme Financial', domain: 'acme.io', email: 'platform@acme.io',
-  industry: 'Financial Services', size: '2,000–10,000', headquarters: 'Frankfurt, Germany',
-  compliance: ['PCI DSS', 'ISO 27001'],
+  name: '', domain: '', email: '',
+  industry: '', size: '', headquarters: '',
+  compliance: [] as string[],
 }
 
 /**

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.tsx
@@ -76,12 +76,7 @@ const MODE_OPTIONS: { id: DomainMode; label: string; sub: string }[] = [
 
 export function StepDomain() {
   const store = useWizardStore()
-  // #5555: `back` was omitted here, so step 6 rendered with no ← Back control
-  // while every sibling step had one. `onBack` is optional on StepShell
-  // (_shared.tsx), so nothing flagged it. It landed on the one step where
-  // Continue is disabled until a domain is chosen — primary action dead,
-  // reverse action absent.
-  const { next, back } = useStepNav()
+  const { next } = useStepNav()
 
   const pool = SOVEREIGN_POOL_DOMAINS.find(p => p.id === store.sovereignPoolDomain) ?? SOVEREIGN_POOL_DOMAINS[0]!
   const availability = useSubdomainAvailability(
@@ -97,7 +92,6 @@ export function StepDomain() {
       title="Where will your Sovereign live in DNS?"
       description="Pool gives you a working URL in seconds. BYO lets you keep the domain you already own — pick the manual flow if your registrar isn't on the API list, or the API flow if you'd rather we flip the NS records for you."
       onNext={next}
-      onBack={back}
       nextDisabled={nextDisabled}
     >
       {resolved && (


### PR DESCRIPTION
PR #5554 grew into a 30-commit train from a prior session. Adjudicated against current main file-by-file:

**Already landed elsewhere (dropped):** the docs/ledger payload (via #5566/#5576), the vitest-gate commit (duplicate of merged #5553), the EPIC-matrix and UAT stamps.

**Stale-on-branch (dropped — main is ahead):** helm pin v3.16.0 (main carries v3.16.3 with the dependency-resolution rationale), chart 1.4.1261 (main at 1.4.1263), check-no-nodeports.sh (main carries the #5578 advisory split).

**Genuinely new (this PR):**
- wizard ORG_DEFAULTS — a fictitious company shipped as live Organization defaults (Refs #5401)
- `topology_loader` derives the pattern from LIVE regions, not declared specs, with both-directions tests (Refs #5515)
- placement primaryRegion divergence pinned by an executable test (Refs #5482)
- mothership live-walk session doc

Go tests pass uncached (`-count=1`) on both touched modules. The UI edits run under the now fail-closed vitest gate (#5553).

Supersedes #5554.

Refs #5401 #5515 #5482 #5554 #960
