### PR TITLE
fix(sealed-secrets): repoint chart dependency to the live bitnami.github.io host — byte-identical artifact, buildable from a clean checkout again

### DIFF
--- a/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
@@ -36,7 +36,7 @@ spec:
   chart:
     spec:
       chart: bp-sealed-secrets
-      version: 1.1.2
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-sealed-secrets

--- a/platform/sealed-secrets/blueprint.yaml
+++ b/platform/sealed-secrets/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.2
+  version: 1.1.3
   card:
     title: sealed-secrets
     summary: Sealed Secrets — used during Phase 0 bootstrap to transport bootstrap-only secrets, then archived after OpenBao + ESO replace it.

--- a/platform/sealed-secrets/chart/Chart.yaml
+++ b/platform/sealed-secrets/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sealed-secrets
-version: 1.1.2
+version: 1.1.3
 description: |
   Catalyst-curated Blueprint umbrella chart for sealed-secrets. Depends on
   the upstream `sealed-secrets` chart (bitnami-labs) as a Helm subchart so
@@ -24,4 +24,4 @@ maintainers:
 dependencies:
   - name: sealed-secrets
     version: "2.16.1"
-    repository: "https://bitnami-labs.github.io/sealed-secrets"
+    repository: "https://bitnami.github.io/sealed-secrets"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-02T18:01:23.648Z",
+  "generatedAt": "2026-08-02T20:15:04.760Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4534,7 +4534,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4669,7 +4669,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5026,7 +5026,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.1.2"
+  version: "1.1.3"
   visibility: unlisted
   card:
     title: "Sealed Secrets"
@@ -5043,7 +5043,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-sealed-secrets
-    version: "1.1.2"
+    version: "1.1.3"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
The declared dependency repository (`bitnami-labs.github.io/sealed-secrets`) 404s — the chart was unbuildable from a clean checkout and only looked healthy via a stale gitignored tarball, exactly as #5563 documents.

**The fix is the host upstream itself names**: the project README says `helm repo add sealed-secrets https://bitnami.github.io/sealed-secrets`, and that index is live (200, 85 versions, 2.16.1 present, tarballs served from bitnami-labs GitHub releases).

**Proof, clean-state**: copied the chart to scratch, deleted `charts/` + `Chart.lock`, applied the one-host change, `helm dependency update` → success. Supply-chain check: fetched `sealed-secrets-2.16.1.tgz` is **byte-identical** to the previously cached tarball — `sha256 c8d461480187ae7fc638e8475d98d634d5429f694a9bac825b9bd01db7cf245e` on both — so the relocated host serves the exact artifact the platform has been deploying all along.

Full five-site lockstep per the #5583 discipline: chart 1.1.2→1.1.3, blueprint.yaml, both catalog-seed sites, kit pin, regenerated catalog. Bootstrap-kit go guards + pin-sync PASS locally.

Refs #5563 #960
