### PR TITLE
fix(wizard): restore the #5572 onBack fix that the #5579 salvage silently reverted — contract suite back to 12/12

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.tsx
@@ -76,7 +76,12 @@ const MODE_OPTIONS: { id: DomainMode; label: string; sub: string }[] = [
 
 export function StepDomain() {
   const store = useWizardStore()
-  const { next } = useStepNav()
+  // #5555: `back` was omitted here, so step 6 rendered with no ← Back control
+  // while every sibling step had one. `onBack` is optional on StepShell
+  // (_shared.tsx), so nothing flagged it. It landed on the one step where
+  // Continue is disabled until a domain is chosen — primary action dead,
+  // reverse action absent.
+  const { next, back } = useStepNav()
 
   const pool = SOVEREIGN_POOL_DOMAINS.find(p => p.id === store.sovereignPoolDomain) ?? SOVEREIGN_POOL_DOMAINS[0]!
   const availability = useSubdomainAvailability(
@@ -92,6 +97,7 @@ export function StepDomain() {
       title="Where will your Sovereign live in DNS?"
       description="Pool gives you a working URL in seconds. BYO lets you keep the domain you already own — pick the manual flow if your registrar isn't on the API list, or the API flow if you'd rather we flip the NS records for you."
       onNext={next}
+      onBack={back}
       nextDisabled={nextDisabled}
     >
       {resolved && (


### PR DESCRIPTION
My #5579 salvage reverted merged work and I own that per the orchestrator-owns-regressions rule. The mechanism: the salvage checked out `StepDomain.tsx` wholesale from the #5554 branch, whose head predated #5572's merge — so the step-6 Back control vanished from main while the contract test (not part of the salvage) correctly went red 2/12.

**The restore**: exactly the two lost hunks from `91ed1e71b` (`const { next, back } = useStepNav()` + `onBack={back}`), reapplied via the verbatim diff. `StepNavContract.5555.test.ts` back to 12/12 locally.

**Explicitly outside this blast radius, control-verified**: the 7 `StepComponents.test.tsx` failures are the pre-existing #5575 set and fail identically on untouched origin/main.

**Follow-up being filed separately**: the fail-closed vitest gate (#5553) did not block the reverting merge despite a red contract test on the merged tree — two concrete leads: the gate's FAIL-line parser expects a Jest-style FAIL-path line this vitest version does not emit, and the crash backstop keys on npm's exit code, which needs verification against the npm test script's behavior.

Refs #5555 #5572 #5579 #5575 #960

