### PR TITLE
fix(phase2b): flip bootstrapMode false in EVERY region, not just the primary

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_policy_enforce.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_policy_enforce.go
@@ -1,13 +1,13 @@
-// post_handover_policy_enforce.go — Wave 5.90 phase 2b (#2441).
+// post_handover_policy_enforce.go — Wave 5.90 phase 2b (#2441, #5591).
 //
 // After Phase 1 reaches OutcomeReady + fireHandover + clustermesh
 // auto-establish, this hook PATCHes the Sovereign-side bp-kyverno-
 // policies HelmRelease values to flip `compliancePolicies.bootstrapMode`
-// from true (fresh-prov default) → false. Flux reconciles; Helm
-// upgrades the 6 canonically-Enforce ClusterPolicies (probesPresent /
-// resourceRequests / ciliumL7Mtls / fluxManaged / harborProxyPull /
-// imageTagPinned) from Audit (their bootstrap render) to Enforce
-// (their target-state action).
+// from true (fresh-prov default) → false — in EVERY region of the
+// deployment. Flux reconciles; Helm upgrades the 6 canonically-Enforce
+// ClusterPolicies (probesPresent / resourceRequests / ciliumL7Mtls /
+// fluxManaged / harborProxyPull / imageTagPinned) from Audit (their
+// bootstrap render) to Enforce (their target-state action).
 //
 // Why this hook: Wave 5.90 phase 2a (#2440) introduced the bootstrap-
 // mode override on the chart side — a fresh Sovereign installs every
@@ -16,6 +16,18 @@
 // layer RCA). But without an automatic post-handover flip, every
 // Sovereign stays at Audit forever, defeating the governance value of
 // the 6 Enforce policies. This hook IS that automatic flip.
+//
+// Why every region (#5591): each region runs its own Flux with its own
+// bp-kyverno-policies HelmRelease, so a flip that PATCHes only the
+// primary leaves every secondary region at Audit forever — live-proven
+// on hw291 + hw292 (region-a Enforce / region-b Audit on a fresh
+// 2-region prov). The secondary kubeconfigs come from the SAME
+// `<depID>-<regionKey>.yaml` store (#3991/#4000) that ClusterMesh
+// establish, the #5244 gateway-ELB reconciler and the #5359 cutover
+// secondary bridge already trust, via the #5359 union helper — this
+// loop can never disagree with their view of the topology. Per-region
+// best-effort: a failed secondary logs loudly but does not abort the
+// other regions (the flip is idempotent and re-triggerable per #2441).
 //
 // Run on a background goroutine from runPhase1Watch's OutcomeReady
 // terminal block (alongside fireHandover + runAutoEstablishClusterMesh
@@ -29,6 +41,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -50,16 +64,33 @@ const (
 	bpKyvernoPoliciesHRNamespace = "flux-system"
 )
 
+// policyFlipPrimaryRegionLabel labels the primary region's flip target in
+// logs + the SSE event. Secondary targets are labelled by their regionKey.
+const policyFlipPrimaryRegionLabel = "primary"
+
+// dynamicClientForPolicyFlip builds the per-region dynamic client from raw
+// kubeconfig bytes. Package-level var (test-seam convention, mirroring
+// applySpineApplicationCR) so the #5591 unit test can substitute fakes and
+// assert the per-region PATCHes.
+var dynamicClientForPolicyFlip = func(kcRaw []byte) (dynamic.Interface, error) {
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kcRaw)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Timeout = 30 * time.Second
+	return dynamic.NewForConfig(cfg)
+}
+
 // runPostHandoverPolicyEnforceFlip drives the Wave 5.90 phase 2b
-// PATCH against the Sovereign-side bp-kyverno-policies HelmRelease.
-// Idempotent — re-running on a Sovereign whose bootstrapMode is
-// already false is a no-op merge.
+// PATCH against the bp-kyverno-policies HelmRelease of EVERY region of
+// the deployment (#5591). Idempotent — re-running on a region whose
+// bootstrapMode is already false is a no-op merge.
 //
 // Called from runPhase1Watch's OutcomeReady terminal block (see
 // phase1_watch.go after runSecondaryBridgeBackfill). Background
 // goroutine so the Phase-1 terminate path's own SSE event ordering
-// is not blocked by the per-request REST timeout (30s) of the
-// HelmRelease PATCH.
+// is not blocked by the per-region REST timeout (30s) of the
+// HelmRelease PATCHes.
 func (h *Handler) runPostHandoverPolicyEnforceFlip(dep *Deployment) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -77,34 +108,76 @@ func (h *Handler) runPostHandoverPolicyEnforceFlip(dep *Deployment) {
 		return
 	}
 
-	kcPath := filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
+	// Every region gets the flip: the primary `<depID>.yaml` plus each
+	// secondary region's `<depID>-<regionKey>.yaml` from the #5359 union
+	// (in-memory map + on-disk files — immune to in-memory loss across
+	// catalyst-api restarts, #4000).
+	targets := map[string]string{
+		policyFlipPrimaryRegionLabel: filepath.Join(h.kubeconfigsDir, dep.ID+".yaml"),
+	}
+	secondaries, _ := secondaryKubeconfigsForCutover(dep)
+	for key, path := range secondaries {
+		targets[key] = path
+	}
+
+	labels := make([]string, 0, len(targets))
+	for label := range targets {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+
+	flipped := make([]string, 0, len(targets))
+	for _, label := range labels {
+		if h.flipRegionPolicyBootstrapMode(dep, label, targets[label]) {
+			flipped = append(flipped, label)
+		}
+	}
+	if len(flipped) == 0 {
+		// Every region already logged its own warn/error above.
+		return
+	}
+
+	h.log.Info("phase2b: bp-kyverno-policies bootstrapMode flipped false; Flux will reconcile 6 Enforce policies",
+		"id", dep.ID,
+		"regions", strings.Join(flipped, ","),
+		"flipped", len(flipped),
+		"of", len(targets),
+	)
+
+	// SSE event so the wizard's post-handover banner can render
+	// "Compliance policies upgraded to Enforce mode". Mirrors the
+	// fireHandover SSE pattern.
+	dep.recordEvent(provisioner.Event{
+		Time:    time.Now().UTC().Format(time.RFC3339),
+		Phase:   "post-handover",
+		Level:   "info",
+		Message: "Wave 5.90 phase 2b: bp-kyverno-policies bootstrapMode → false on " + strings.Join(flipped, ", ") + "; Flux reconciling 6 ClusterPolicies to Enforce target-state action",
+	})
+}
+
+// flipRegionPolicyBootstrapMode PATCHes one region's bp-kyverno-policies
+// HelmRelease. Returns true on success; every failure path logs with the
+// region label and returns false without aborting the sibling regions.
+func (h *Handler) flipRegionPolicyBootstrapMode(dep *Deployment, region, kcPath string) bool {
 	kcRaw, err := os.ReadFile(kcPath)
 	if err != nil {
-		h.log.Warn("phase2b: read kubeconfig failed; skipping bootstrapMode flip",
+		h.log.Warn("phase2b: read kubeconfig failed; skipping bootstrapMode flip for this region",
 			"id", dep.ID,
+			"region", region,
 			"path", kcPath,
 			"err", err,
 		)
-		return
+		return false
 	}
 
-	cfg, err := clientcmd.RESTConfigFromKubeConfig(kcRaw)
-	if err != nil {
-		h.log.Warn("phase2b: parse kubeconfig failed",
-			"id", dep.ID,
-			"err", err,
-		)
-		return
-	}
-	cfg.Timeout = 30 * time.Second
-
-	dyn, err := dynamic.NewForConfig(cfg)
+	dyn, err := dynamicClientForPolicyFlip(kcRaw)
 	if err != nil {
 		h.log.Warn("phase2b: build dynamic client failed",
 			"id", dep.ID,
+			"region", region,
 			"err", err,
 		)
-		return
+		return false
 	}
 
 	patch, err := json.Marshal(map[string]any{
@@ -119,9 +192,10 @@ func (h *Handler) runPostHandoverPolicyEnforceFlip(dep *Deployment) {
 	if err != nil {
 		h.log.Warn("phase2b: marshal patch failed",
 			"id", dep.ID,
+			"region", region,
 			"err", err,
 		)
-		return
+		return false
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -133,29 +207,23 @@ func (h *Handler) runPostHandoverPolicyEnforceFlip(dep *Deployment) {
 	})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			h.log.Warn("phase2b: bp-kyverno-policies HR not found (Sovereign may not have it installed); skipping",
+			h.log.Warn("phase2b: bp-kyverno-policies HR not found (region may not have it installed); skipping",
 				"id", dep.ID,
+				"region", region,
 			)
-			return
+			return false
 		}
 		h.log.Error("phase2b: HelmRelease PATCH failed",
 			"id", dep.ID,
+			"region", region,
 			"err", err,
 		)
-		return
+		return false
 	}
 
-	h.log.Info("phase2b: bp-kyverno-policies bootstrapMode flipped false; Flux will reconcile 6 Enforce policies",
+	h.log.Info("phase2b: region bootstrapMode flipped false",
 		"id", dep.ID,
+		"region", region,
 	)
-
-	// SSE event so the wizard's post-handover banner can render
-	// "Compliance policies upgraded to Enforce mode". Mirrors the
-	// fireHandover SSE pattern.
-	dep.recordEvent(provisioner.Event{
-		Time:    time.Now().UTC().Format(time.RFC3339),
-		Phase:   "post-handover",
-		Level:   "info",
-		Message: "Wave 5.90 phase 2b: bp-kyverno-policies bootstrapMode → false; Flux reconciling 6 ClusterPolicies to Enforce target-state action",
-	})
+	return true
 }

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_policy_enforce_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_policy_enforce_test.go
@@ -1,0 +1,189 @@
+// post_handover_policy_enforce_test.go — unit coverage for the Wave 5.90
+// phase 2b bootstrapMode flip (#2441), specifically its #5591 contract:
+// the flip PATCHes the bp-kyverno-policies HelmRelease in EVERY region of
+// the deployment, not just the primary. Live-proven defect: on hw291 and
+// hw292 (2-region me-east-215-a/-b-1) region-a came up Enforce while
+// region-b stayed Audit forever, because the flip read only
+// `<depID>.yaml` and never the secondary `<depID>-<regionKey>.yaml`.
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// policyFlipHRObj builds the bp-kyverno-policies HelmRelease as a fresh
+// prov installs it: bootstrapMode true (every policy at Audit).
+func policyFlipHRObj() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      bpKyvernoPoliciesHRName,
+			"namespace": bpKyvernoPoliciesHRNamespace,
+		},
+		"spec": map[string]any{
+			"values": map[string]any{
+				"compliancePolicies": map[string]any{
+					"bootstrapMode": true,
+				},
+			},
+		},
+	}}
+}
+
+func policyFlipFakeDynamic() *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		helmReleaseGVR: "HelmReleaseList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, policyFlipHRObj())
+}
+
+// policyFlipBootstrapMode reads the HR's live bootstrapMode from a fake.
+func policyFlipBootstrapMode(t *testing.T, fake *dynamicfake.FakeDynamicClient) (bool, bool) {
+	t.Helper()
+	obj, err := fake.Resource(helmReleaseGVR).Namespace(bpKyvernoPoliciesHRNamespace).Get(t.Context(), bpKyvernoPoliciesHRName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get HR from fake: %v", err)
+	}
+	v, found, err := unstructured.NestedBool(obj.Object, "spec", "values", "compliancePolicies", "bootstrapMode")
+	if err != nil {
+		t.Fatalf("read bootstrapMode: %v", err)
+	}
+	return v, found
+}
+
+// stubPolicyFlipClients routes each kubeconfig file's CONTENT to its
+// region's fake client, restoring the real seam on cleanup.
+func stubPolicyFlipClients(t *testing.T, byContent map[string]*dynamicfake.FakeDynamicClient) {
+	t.Helper()
+	orig := dynamicClientForPolicyFlip
+	dynamicClientForPolicyFlip = func(kcRaw []byte) (dynamic.Interface, error) {
+		fake, ok := byContent[string(kcRaw)]
+		if !ok {
+			t.Fatalf("dynamicClientForPolicyFlip called with unexpected kubeconfig content %q", string(kcRaw))
+		}
+		return fake, nil
+	}
+	t.Cleanup(func() { dynamicClientForPolicyFlip = orig })
+}
+
+// TestPolicyEnforceFlip_FlipsEveryRegion_5591 — a 2-region deployment must
+// end with bootstrapMode=false on BOTH regions' HRs. The secondary
+// kubeconfig is discovered via the on-disk `<depID>-<regionKey>.yaml`
+// store (the restart-immune #4000 path), NOT the in-memory map.
+func TestPolicyEnforceFlip_FlipsEveryRegion_5591(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "dep-1.yaml"), []byte("kc-primary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "dep-1-eu-west-101.yaml"), []byte("kc-secondary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := policyFlipFakeDynamic()
+	secondary := policyFlipFakeDynamic()
+	stubPolicyFlipClients(t, map[string]*dynamicfake.FakeDynamicClient{
+		"kc-primary":   primary,
+		"kc-secondary": secondary,
+	})
+
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	dep := &Deployment{
+		ID: "dep-1",
+		Request: provisioner.Request{
+			SovereignFQDN: "t99.omani.works",
+			Regions: []provisioner.RegionSpec{
+				{CloudRegion: "me-east-215"},
+				{CloudRegion: "eu-west-101"},
+			},
+		},
+	}
+
+	h.runPostHandoverPolicyEnforceFlip(dep)
+
+	for label, fake := range map[string]*dynamicfake.FakeDynamicClient{"primary": primary, "secondary": secondary} {
+		v, found := policyFlipBootstrapMode(t, fake)
+		if !found || v {
+			t.Errorf("%s region: bootstrapMode = %v (found=%v), want false — the #5591 regression leaves a region at Audit forever", label, v, found)
+		}
+	}
+}
+
+// TestPolicyEnforceFlip_SingleRegionUnchanged — a 1-region deployment
+// flips exactly its primary; no secondary lookup may fail the run.
+func TestPolicyEnforceFlip_SingleRegionUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "dep-2.yaml"), []byte("kc-primary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := policyFlipFakeDynamic()
+	stubPolicyFlipClients(t, map[string]*dynamicfake.FakeDynamicClient{"kc-primary": primary})
+
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	dep := &Deployment{
+		ID: "dep-2",
+		Request: provisioner.Request{
+			SovereignFQDN: "t98.omani.works",
+			Regions:       []provisioner.RegionSpec{{CloudRegion: "me-east-215"}},
+		},
+	}
+
+	h.runPostHandoverPolicyEnforceFlip(dep)
+
+	if v, found := policyFlipBootstrapMode(t, primary); !found || v {
+		t.Errorf("primary bootstrapMode = %v (found=%v), want false", v, found)
+	}
+}
+
+// TestPolicyEnforceFlip_SecondaryUnreadableStillFlipsPrimary — per-region
+// best-effort: an in-memory secondary path whose file is gone must not
+// abort the primary flip (idempotent re-trigger covers the secondary).
+func TestPolicyEnforceFlip_SecondaryUnreadableStillFlipsPrimary(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "dep-3.yaml"), []byte("kc-primary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := policyFlipFakeDynamic()
+	stubPolicyFlipClients(t, map[string]*dynamicfake.FakeDynamicClient{"kc-primary": primary})
+
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	dep := &Deployment{
+		ID: "dep-3",
+		Request: provisioner.Request{
+			SovereignFQDN: "t97.omani.works",
+			Regions: []provisioner.RegionSpec{
+				{CloudRegion: "me-east-215"},
+				{CloudRegion: "eu-west-101"},
+			},
+		},
+		secondaryKubeconfigPaths: map[string]string{
+			"eu-west-101": filepath.Join(dir, "does-not-exist.yaml"),
+		},
+	}
+
+	h.runPostHandoverPolicyEnforceFlip(dep)
+
+	if v, found := policyFlipBootstrapMode(t, primary); !found || v {
+		t.Errorf("primary bootstrapMode = %v (found=%v), want false even when a secondary kubeconfig is unreadable", v, found)
+	}
+}


### PR DESCRIPTION
## Problem

On every multi-region Sovereign, the Wave 5.90 phase 2b post-handover flip of compliancePolicies.bootstrapMode (true -> false, which upgrades the 6 canonically-Enforce Kyverno ClusterPolicies from Audit to Enforce) reached ONLY the primary region. Secondary regions kept every policy at Audit forever.

Live evidence (hw292, dep 1c56518035a83e03, fresh zero-touch 2-region prov 2026-08-03): region-a ClusterPolicies Enforce, region-b Audit; region-a HR carries bootstrapMode: false, region-b HR carries no bootstrapMode key at all. Same posture on hw291, where it was mis-read as a per-region split of the #5505 remediation and healed live — hiding the durable defect.

## Root cause

runPostHandoverPolicyEnforceFlip built exactly one dynamic client from filepath.Join(h.kubeconfigsDir, dep.ID+".yaml") and PATCHed one HR. It never iterated the secondary regions' <depID>-<regionKey>.yaml kubeconfigs.

## Fix

- Iterate primary + every secondary region via secondaryKubeconfigsForCutover — the #5359 union (in-memory map + on-disk store, #3991/#4000) already trusted by ClusterMesh establish, the #5244 gateway-ELB reconciler and the cutover secondary bridge, so this loop can never disagree with their view of the topology.
- Per-region best-effort: a failed region logs loudly (with region label) without aborting siblings; the flip stays idempotent + re-triggerable per #2441.
- SSE event now names the flipped regions.
- Test seam dynamicClientForPolicyFlip (package-level var, mirroring the applySpineApplicationCR convention).

## Tests

- TestPolicyEnforceFlip_FlipsEveryRegion_5591 — 2-region dep ends with bootstrapMode=false on BOTH fake HRs; secondary discovered via the on-disk restart-immune path.
- TestPolicyEnforceFlip_SingleRegionUnchanged — 1-region behavior identical to before.
- TestPolicyEnforceFlip_SecondaryUnreadableStillFlipsPrimary — unreadable secondary does not abort the primary.
- Full handler suite green (253s), go build + go vet clean.

## Merge gating

HOLD until hw292 cutover reaches cutoverComplete=true (merge freeze — a catalyst-api image bump mid-cutover risks the step-06 catalog-latest vs flux-pinned drift class).

Refs #5591 #2441 #5359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
