### PR TITLE
fix(ci): vitest gate parses ANSI-wrapped FAIL lines + summary-vs-parse vacuity guard

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -108,9 +108,25 @@ jobs:
           NPM_RC=${PIPESTATUS[0]}
           set -e
 
-          # Vitest prints one ` FAIL  <path> > <test>` line per failure.
-          FAILED_FILES=$(grep -oE '^ *FAIL +[^ ]+\.test\.tsx?' /tmp/vitest-out.txt \
+          # Vitest prints one ` FAIL  <path> > <test>` line per failure — but
+          # wraps FAIL in ANSI color codes (\e[41m\e[1m FAIL \e[22m\e[49m ...),
+          # so a bare `^ *FAIL` grep matches NOTHING vitest emits and the
+          # allowlist logic never engages (#5589 — this fail-open admitted the
+          # #5579 onBack regression). Strip ANSI escapes BEFORE parsing; the
+          # captured live line from run 30788994174 proves old=[] / new=[path].
+          sed -e 's/\x1b\[[0-9;]*m//g' /tmp/vitest-out.txt > /tmp/vitest-plain.txt
+          FAILED_FILES=$(grep -oE '^ *FAIL +[^ ]+\.test\.tsx?' /tmp/vitest-plain.txt \
                           | awk '{print $2}' | sort -u || true)
+
+          # Vacuity guard on the PARSER itself (#5589 lead 2, the backstop
+          # question): if vitest reported a non-zero "Failed Tests N" summary
+          # but the per-file parse extracted nothing, the format drifted again
+          # — fail closed with the evidence instead of green-through.
+          SUMMARY_FAILS=$(grep -oE 'Failed Tests [0-9]+' /tmp/vitest-plain.txt | grep -oE '[0-9]+' | head -1 || true)
+          if [ -n "${SUMMARY_FAILS}" ] && [ "${SUMMARY_FAILS}" -gt 0 ] && [ -z "${FAILED_FILES}" ]; then
+            echo "FAIL: vitest summary says ${SUMMARY_FAILS} failed test(s) but the per-file parser extracted none — output format drifted again (#5589). Failing closed."
+            exit 1
+          fi
 
           # Backstop against the parser itself failing open: if vitest exited
           # non-zero but the grep above extracted NO failing files (config


### PR DESCRIPTION
## Problem

The G110 vitest gate (#5553) is fail-open in practice: it extracts failing files with a bare `^ *FAIL` grep, but vitest wraps FAIL in ANSI color codes (`\e[41m\e[1m FAIL \e[22m\e[49m <path>`), so `FAILED_FILES` is ALWAYS empty and the KNOWN_RED allowlist logic never engages. This admitted the #5579 onBack regression (2/12 contract tests red, CI green, merged).

## Fix

- Strip ANSI escapes from the vitest output before parsing. Proof against the captured live line from run 30788994174: old parser extracts `[]`, new parser extracts `[src/pages/wizard/steps/StepComponents.test.tsx]`.
- New vacuity guard for the next format drift (#5589 lead 2): if vitest's own `Failed Tests N` summary is non-zero while the per-file parse extracts nothing, fail closed with evidence instead of relying solely on the exit-code backstop.
- Workflow YAML validated; the extracted run block passes `bash -n`.

Effect on main: build-ui keeps failing (10 genuinely red tests, #5575/#5401 material) but now names each failing file against the allowlist instead of dying in the opaque backstop. The PR-side trigger-scope gap (#5579 passed because this workflow runs on main pushes only) stays open on #5589 as the remaining checkbox.

Workflow-only change: no chart, image, or catalog artifacts — outside the cutover merge-freeze blast radius.

Refs #5589 #5579 #5553

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
