### PR TITLE
fix(catalyst-api): P0 — main compiles again; unstall catalyst-build (Refs #5618)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_policy_enforce.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_policy_enforce.go
@@ -115,7 +115,7 @@ func (h *Handler) runPostHandoverPolicyEnforceFlip(dep *Deployment) {
 	targets := map[string]string{
 		policyFlipPrimaryRegionLabel: filepath.Join(h.kubeconfigsDir, dep.ID+".yaml"),
 	}
-	secondaries, _ := secondaryKubeconfigsForCutover(dep)
+	secondaries := secondaryKubeconfigsForCutover(dep).paths
 	for key, path := range secondaries {
 		targets[key] = path
 	}


### PR DESCRIPTION
## P0 — restore compilation of main; unstall catalyst-build after 8 red runs

One line: post_handover_policy_enforce.go:118 destructured two values from secondaryKubeconfigsForCutover, which returns a single secondaryKubeconfigResolution since #5535 (parallel-merge signature drift — each PR was green against pre-merge main). Consume .paths, matching the healthy caller at cutover_secondary_kubeconfigs.go:500.

Gates run locally in the module:
- go build ./... — BUILD-OK
- go test ./internal/handler/ — ok (256s)

Consequence of the breakage this repairs: no catalyst image has published since 2026-08-02T20:42Z; every thaw-window merge (including the #5579 wizard fix behind UAT rows W1/W2) is stranded merged-not-delivered.

Refs #5618 #5535

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
