### PR TITLE
fix(catalyst-api): Organization DELETE deletes the CR so the org-controller finalizer cascade fires (Refs #5426)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr.go
@@ -113,6 +113,64 @@ func (h *Handler) createOrgOrganizationCR(ctx context.Context, rec store.Organiz
 	)
 }
 
+// deleteOrgOrganizationCR deletes the canonical Organization CR for a
+// record being torn down — THE trigger for the org-controller's finalizer
+// cascade (#5426). The complete teardown
+// (core/controllers/organization/internal/controller/organization_controller.go
+// deletion-timestamp branch: publishTenantDeleted → teardownPerOrgFlux →
+// teardownTenantNetworking → iac-bootstrap → per-org-realm finalizers) only
+// runs when the CR is marked for deletion; before this helper existed the
+// REST DELETE reaped the GitOps overlay + registry + DNS but never touched
+// the CR, so the `orgs.openova.io/tenant-networking` finalizer never fired
+// and every console-deleted Organization leaked its namespace, vCluster,
+// Keycloak realm, per-Org Flux sources and gateway listeners (the exact
+// orphan set that holds the sovereignty-cutover pre-flight closed).
+//
+// MUST be called AFTER the GitOps overlay reap — #4459/R17 order: deleting
+// the CR while the org-tenants tree still holds the overlay lets Flux
+// recreate the namespace the cascade just tore down (observed live at
+// T+5m07s on hw290). With the overlay commit already pushed, anything a
+// stale artifact transiently re-applies is pruned on the next source fetch,
+// and the cascade itself removes the per-Org Flux sources.
+//
+// Best-effort like the sibling teardown steps, but a failure is logged at
+// Error level (a silent skip IS the #5426 bug): the CR survives, so
+// re-running the DELETE — every step of which is idempotent — retries the
+// cascade trigger. NotFound is success (kubectl-side delete or a prior
+// DELETE already triggered / completed the cascade). Nil-tolerant on the
+// dynamic client for CI / out-of-cluster, matching createOrgOrganizationCR.
+func (h *Handler) deleteOrgOrganizationCR(ctx context.Context, rec store.OrganizationProvisionRecord) {
+	slug := strings.ToLower(strings.TrimSpace(rec.Subdomain))
+	if !orgSlugRE.MatchString(slug) {
+		// createOrgOrganizationCR never mints a CR for an invalid slug, so
+		// there is nothing to cascade.
+		h.log.Warn("org-tenant: skipping Organization CR delete — subdomain is not a valid Org slug",
+			"subdomain", rec.Subdomain,
+			"org_tenant_id", rec.OrganizationID,
+		)
+		return
+	}
+
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		h.log.Info("org-tenant: Organization CR delete skipped — no in-cluster dynamic client",
+			"org_tenant_id", rec.OrganizationID, "err", err)
+		return
+	}
+
+	if err := deps.dyn.Resource(organizationGVR()).Delete(ctx, slug, metav1.DeleteOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Already gone — idempotent success.
+			return
+		}
+		h.log.Error("org-tenant: Organization CR delete FAILED — finalizer cascade NOT triggered; namespace/vCluster/realm/Flux sources leak until this DELETE is retried (#5426)",
+			"slug", slug, "org_tenant_id", rec.OrganizationID, "err", err)
+		return
+	}
+	h.log.Info("org-tenant: Organization CR deleted — org-controller finalizer cascade triggered",
+		"slug", slug, "org_tenant_id", rec.OrganizationID)
+}
+
 // ensureOrganizationCR builds the Organization CR from the Organization record
 // and POSTs it via the dynamic client, treating AlreadyExists as success
 // (idempotent — a pipeline re-run or a redelivered create lands on the same

--- a/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_delete_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_delete_test.go
@@ -214,3 +214,4 @@ func TestDeleteOrganization_CRAlreadyGoneIsIdempotent(t *testing.T) {
 		t.Fatalf("delete with CR already gone: want 204 got %d body=%s", delW.Code, delW.Body.String())
 	}
 }
+

--- a/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_delete_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_delete_test.go
@@ -1,0 +1,216 @@
+// org_tenant_org_cr_delete_test.go — #5426 guard. DELETE
+// /api/v1/organizations/{id} MUST delete the canonical Organization CR:
+// that delete is the ONLY trigger for the org-controller finalizer
+// cascade (publishTenantDeleted → teardownPerOrgFlux →
+// teardownTenantNetworking → iac-bootstrap → per-org-realm), which is
+// the only complete teardown of an Organization's namespace / vCluster /
+// Keycloak realm / per-Org Flux sources / gateway listeners. Before the
+// fix the handler reaped the GitOps overlay + registry + DNS and returned
+// 204 while the CR kept an EMPTY deletionTimestamp — observed live on
+// hw292 (r17probe: listeners + GitRepository + cert all survived the
+// DELETE) and hw290 (gamma-corp: 5 orphaned HelmReleases with no owning
+// CR, un-reapable because a finalizer cannot run on a CR that no longer
+// exists).
+//
+// Also guards the #4459/R17 ordering: the overlay reap must commit
+// BEFORE the CR delete, otherwise Flux recreates the namespace the
+// cascade just tore down (observed at T+5m07s on hw290).
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orderRecordingGitOps wraps fakeGitOps and appends to a shared step log
+// on every overlay delete, so tests can assert the reap-before-CR-delete
+// order against the dynamic client's reactor writing to the same log.
+type orderRecordingGitOps struct {
+	fakeGitOps
+	mu    *sync.Mutex
+	steps *[]string
+}
+
+func (g *orderRecordingGitOps) DeleteTenantOverlay(ctx context.Context, rec store.OrganizationProvisionRecord) (string, error) {
+	g.mu.Lock()
+	*g.steps = append(*g.steps, "overlay-reap")
+	g.mu.Unlock()
+	return g.fakeGitOps.DeleteTenantOverlay(ctx, rec)
+}
+
+// newOrgDeleteCascadeHarness wires the Organization pipeline deps + a fake
+// dynamic client registering the Organization GVR (mirroring
+// newOrgTenantHandlerWithDynamic) plus the shared ordering log.
+func newOrgDeleteCascadeHarness(t *testing.T) (*Handler, *dynamicfake.FakeDynamicClient, *sync.Mutex, *[]string) {
+	t.Helper()
+	dir := t.TempDir()
+	tenantStore, err := store.NewOrganizationProvisionStore(dir)
+	if err != nil {
+		t.Fatalf("tenant store: %v", err)
+	}
+	registry, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("tenant registry: %v", err)
+	}
+	var mu sync.Mutex
+	steps := []string{}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	h.SetTenantRegistry(registry)
+	h.SetOrganizationDeps(OrganizationDeps{
+		Store:            tenantStore,
+		GitOps:           &orderRecordingGitOps{mu: &mu, steps: &steps},
+		DNS:              &fakeDNS{},
+		KeycloakClients:  &fakeKCClients{},
+		Events:           &fakeTenantEmitter{},
+		TenantRegistry:   registry,
+		OTECHFQDN:        "otech.example",
+		OTECHIngressIPv4: "192.0.2.10",
+		MaxRetryCount:    5,
+	})
+
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		organizationGVR(): "OrganizationList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+	dyn.PrependReactor("delete", "organizations", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		steps = append(steps, "cr-delete")
+		mu.Unlock()
+		return false, nil, nil // fall through to the default delete
+	})
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: dyn}, nil
+	})
+	return h, dyn, &mu, &steps
+}
+
+// seedOrgRecordAndCR seeds a converged Organization directly: provision
+// record in the store + the canonical Organization CR in the fake
+// apiserver — the state a real create leaves behind (the mint contract
+// itself is owned by TestCreateOrgTenant_MintsOrganizationCR). Seeding
+// directly keeps these tests off the create pipeline's polling waits.
+func seedOrgRecordAndCR(t *testing.T, h *Handler, dyn *dynamicfake.FakeDynamicClient, subdomain string) store.OrganizationProvisionRecord {
+	t.Helper()
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID: "t-" + subdomain,
+		Subdomain:      subdomain,
+		AdminEmail:     "owner@" + subdomain + ".omani.homes",
+		CompanyName:    "Probe Corp",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		State:          store.STSDone,
+	}
+	if err := h.orgTenantDeps.Store.Save(&rec); err != nil {
+		t.Fatalf("seed record: %v", err)
+	}
+	if err := ensureOrganizationCR(context.Background(), dyn, rec, "otech.example"); err != nil {
+		t.Fatalf("seed Organization CR: %v", err)
+	}
+	return rec
+}
+
+func deleteOrgViaHandler(t *testing.T, h *Handler, id string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/organizations/"+id, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	h.HandleDeleteOrganization(w, req)
+	return w
+}
+
+// TestDeleteOrganization_DeletesOrganizationCR is the #5426 binary proof:
+// the console DELETE path issues the apiserver delete on the Organization
+// CR. On a real cluster that delete stamps deletionTimestamp, which is
+// exactly what fires the `orgs.openova.io/tenant-networking` finalizer
+// cascade in the org-controller — the r17probe walk showed the identical
+// object fully reaped in ~2s once the CR delete was issued (kubectl-side),
+// and untouched (deletionTimestamp empty) when it was not.
+func TestDeleteOrganization_DeletesOrganizationCR(t *testing.T) {
+	h, dyn, _, _ := newOrgDeleteCascadeHarness(t)
+
+	rec := seedOrgRecordAndCR(t, h, dyn, "r17probe")
+
+	// Precondition: the CR exists (the state the #3687 create mint leaves).
+	if _, err := dyn.Resource(organizationGVR()).Get(context.Background(), "r17probe", metav1.GetOptions{}); err != nil {
+		t.Fatalf("precondition: Organization CR `r17probe` missing after seed: %v", err)
+	}
+
+	delW := deleteOrgViaHandler(t, h, rec.OrganizationID)
+	if delW.Code != http.StatusNoContent {
+		t.Fatalf("delete: want 204 got %d body=%s", delW.Code, delW.Body.String())
+	}
+
+	// The CR must be GONE — i.e. the handler issued the apiserver delete
+	// that triggers the finalizer cascade. Before the fix this Get
+	// succeeded with an empty deletionTimestamp (the hw292 r17probe state).
+	_, err := dyn.Resource(organizationGVR()).Get(context.Background(), "r17probe", metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("Organization CR `r17probe` survived DELETE — the finalizer cascade was never triggered (#5426)")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound after delete, got: %v", err)
+	}
+}
+
+// TestDeleteOrganization_OverlayReapBeforeCRDelete guards the #4459/R17
+// order: the GitOps source reap must land BEFORE the CR delete, or Flux
+// recreates the namespace the cascade tears down (hw290, T+5m07s).
+func TestDeleteOrganization_OverlayReapBeforeCRDelete(t *testing.T) {
+	h, dyn, mu, steps := newOrgDeleteCascadeHarness(t)
+
+	rec := seedOrgRecordAndCR(t, h, dyn, "orderprobe")
+
+	delW := deleteOrgViaHandler(t, h, rec.OrganizationID)
+	if delW.Code != http.StatusNoContent {
+		t.Fatalf("delete: want 204 got %d", delW.Code)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), *steps...)
+	mu.Unlock()
+	want := []string{"overlay-reap", "cr-delete"}
+	if len(got) != len(want) {
+		t.Fatalf("teardown steps: want %v got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("teardown order: want %v got %v — CR delete before the source reap is the R17 recreate race", want, got)
+		}
+	}
+}
+
+// TestDeleteOrganization_CRAlreadyGoneIsIdempotent — a kubectl-side delete
+// (or a prior DELETE run) already removed the CR; the handler must treat
+// NotFound as success and still return 204 so the remaining teardown steps
+// (registry, DNS, audit row) complete.
+func TestDeleteOrganization_CRAlreadyGoneIsIdempotent(t *testing.T) {
+	h, dyn, _, _ := newOrgDeleteCascadeHarness(t)
+
+	rec := seedOrgRecordAndCR(t, h, dyn, "goneprobe")
+
+	if err := dyn.Resource(organizationGVR()).Delete(context.Background(), "goneprobe", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("pre-delete CR: %v", err)
+	}
+
+	delW := deleteOrgViaHandler(t, h, rec.OrganizationID)
+	if delW.Code != http.StatusNoContent {
+		t.Fatalf("delete with CR already gone: want 204 got %d body=%s", delW.Code, delW.Body.String())
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -983,10 +983,17 @@ func (h *Handler) HandleReconcileOrganization(w http.ResponseWriter, r *http.Req
 // HandleDeleteOrganization — DELETE /api/v1/org/tenants/{id}.
 //
 // Inverse pipeline: removes the per-tenant overlay from the GitOps
-// repo (Flux reconciles → tenant resources GC), unregisters from the
-// host registry, and emits the deletion event. Each step is idempotent
-// + best-effort; partial failure leaves a STSDeleted audit row so the
-// reconciler can finish on the next pass.
+// repo (Flux reconciles → tenant resources GC), deletes the canonical
+// Organization CR — which fires the org-controller finalizer cascade
+// (publishTenantDeleted → teardownPerOrgFlux → teardownTenantNetworking
+// → iac-bootstrap → per-org-realm), the ONLY complete teardown (#5426)
+// — unregisters from the host registry, and emits the deletion event.
+// Each step is idempotent + best-effort; partial failure leaves a
+// STSDeleted audit row so the reconciler can finish on the next pass.
+//
+// Ordering is load-bearing (#4459/R17): the overlay reap commits FIRST
+// so Flux cannot recreate what the cascade tears down, THEN the CR
+// delete triggers the cascade.
 func (h *Handler) HandleDeleteOrganization(w http.ResponseWriter, r *http.Request) {
 	deps := h.orgTenantDeps
 	if deps.Store == nil {
@@ -1011,6 +1018,15 @@ func (h *Handler) HandleDeleteOrganization(w http.ResponseWriter, r *http.Reques
 			rec.CommitSHA = sha
 		}
 	}
+	// #5426 — the CR delete is what actually tears the Organization down:
+	// marking the CR for deletion fires the `orgs.openova.io/tenant-networking`
+	// finalizer cascade in the org-controller (namespace, vCluster, Keycloak
+	// realm, per-Org Flux sources, gateway listeners, certs). Without this
+	// call the DELETE returned 204 while the CR kept an empty
+	// deletionTimestamp and every one of those surfaces leaked — proven live
+	// on hw292 (r17probe) and hw290 (gamma-corp/delta-corp). Runs strictly
+	// AFTER the overlay reap above per the #4459/R17 recreate-race order.
+	h.deleteOrgOrganizationCR(r.Context(), rec)
 	if deps.TenantRegistry != nil {
 		host := deriveConsoleHost(rec)
 		if host != "" {


### PR DESCRIPTION
## Defect

`DELETE /api/v1/organizations/{id}` (`HandleDeleteOrganization`, wired at `cmd/api/main.go:1924`) reaped the GitOps overlay, tenant registry and pool DNS and returned 204 — but never touched the canonical Organization CR. The org-controller's complete teardown (`core/controllers/organization/internal/controller/organization_controller.go` deletion-timestamp branch: `publishTenantDeleted` -> `teardownPerOrgFlux` -> `teardownTenantNetworking` -> iac-bootstrap -> per-org-realm finalizers) fires only when the CR is marked for deletion, so the console DELETE path left every Organization's namespace, vCluster, Keycloak realm, per-Org Flux sources and gateway listeners behind.

Live proof already on the issue:
- hw292 `r17probe`: DELETE returned 204, CR `deletionTimestamp` stayed empty, listeners/GitRepository/cert survived; the same object was fully reaped in ~2s by `kubectl delete organization` (the cascade working when triggered correctly).
- hw290 `gamma-corp`: CR gone but overlay present -> 5 orphaned HelmReleases nothing could ever reap; the orphan set is exactly what holds the cutover pre-flight closed.

## Fix

`HandleDeleteOrganization` now deletes the Organization CR through the in-cluster dynamic client — the new `deleteOrgOrganizationCR` in `org_tenant_org_cr.go`, co-located with and symmetric to the #3687 create-mint (`createOrgOrganizationCR`; same GVR, same slug derivation, same `sovereignDepsFor()` seam, nil-tolerant for CI/out-of-cluster).

Ordering is load-bearing and preserved per #4459/R17: the overlay reap commits FIRST (so Flux cannot recreate what the cascade tears down — the recreate race observed at T+5m07s on hw290), THEN the CR delete triggers the cascade. NotFound is idempotent success (kubectl-side delete or a prior run); a failed CR delete is logged at Error level (a silent skip IS this bug) and the surviving CR lets a re-run of the fully idempotent DELETE retry the trigger.

The delete-path event propagation the dead `deps.Events` leg was meant to provide now genuinely happens through the cascade's own `publishTenantDeleted` (step 1). The nil-guarded `deps.Events` field itself is untouched here; assigning-or-deleting it across the create path too is a separate cleanup per the issue's fix note.

## Tests (`org_tenant_org_cr_delete_test.go`)

- `TestDeleteOrganization_DeletesOrganizationCR` — the handler issues the apiserver delete on the CR (fake dynamic client via `SetSovereignDepsFactory`); before the fix this Get succeeded with an empty deletionTimestamp, the exact hw292 state.
- `TestDeleteOrganization_OverlayReapBeforeCRDelete` — R17 ordering guard: a shared step log between the gitops fake and a `delete`/`organizations` reactor must read `[overlay-reap, cr-delete]`.
- `TestDeleteOrganization_CRAlreadyGoneIsIdempotent` — CR already removed kubectl-side -> still 204 so the remaining teardown steps complete.

## Build unblock (pre-existing break on main)

`post_handover_policy_enforce.go:118` still consumed the old 2-value return of `secondaryKubeconfigsForCutover` after #5535 (`71c54d8d6`) changed it to a resolution struct while #5592 (`bb8ceec71`) landed the 2-value call — `go build ./...` failed on origin/main for the whole module, blocking any test in this package. One-line mechanical fix mirroring the existing consumer at `cutover_secondary_kubeconfigs.go:500` (`.paths` carries the same regionKey -> path union the old first return value did).

## Gates

- `go build ./...` in `products/catalyst/bootstrap/api` — PASS (fails on origin/main before the unblock above)
- `go vet ./internal/handler/` — PASS
- `go test ./...` in `products/catalyst/bootstrap/api` — ALL PASS (incl. the 3 new tests + the pre-existing `TestDeleteOrganization_RemovesFromRegistry` / `_DeprovisionsDNS`)

## Proof that closes the issue (post-merge, live walk)

Create a probe Organization on a live env, DELETE it from the console path, and verify: CR gone -> ns Terminating -> per-Org GitRepository/Certificate 0 -> gateway listeners removed -> a subsequent cutover pre-flight finds no orphaned HelmReleases. UAT row R17.

Refs #5426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
