### PR TITLE
fix(catalyst-api): DR Switchover gate — derive replicaPromotable from the status keys the Continuum controller actually writes

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -297,7 +297,15 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 		}
 		gvr := schema.GroupVersionResource{Group: "dr.openova.io", Version: "v1", Resource: "cnpgpairs"}
 		if pair, perr := client.Resource(gvr).Namespace(cnpgPairNS).Get(r.Context(), cnpgPairName, metav1.GetOptions{}); perr == nil {
+			// #5601 — consume the lag key a producer actually writes.
+			// `walLagSeconds` is the CNPGPair-CRD spelling (stamped by the QA
+			// fixture); the live controllers publish the same axis as
+			// `replicationLagSeconds`. Probing only the first spelling left the
+			// panel's lag reading stuck on the CR-derived value.
 			lag := readNumericNested(pair.Object, "status", "walLagSeconds")
+			if lag == 0 {
+				lag = readNumericNested(pair.Object, "status", "replicationLagSeconds")
+			}
 			if lag > 0 {
 				resp.WALLagSeconds = lag
 			}
@@ -314,9 +322,24 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 			if hb, _, _ := unstructured.NestedString(pair.Object, "status", "lastHeartbeat"); hb != "" {
 				resp.LastHeartbeat = hb
 			}
-			promotable, found, _ := unstructured.NestedBool(pair.Object, "status", "replicaPromotable")
-			if found {
+			// #5601 — `status.replicaPromotable` has NO live producer (the QA
+			// fixture is its only writer), so probing for it alone silently
+			// kept the zero-value false and the Switchover control rendered
+			// "no caught-up standby to promote" against a healthy caught-up
+			// pair. Honor an explicit reading when present; otherwise derive
+			// promotability from the keys the CNPGPair CRD contract actually
+			// carries — replica streaming AND lag under the 30s threshold
+			// (the CRD's own stated switchover-safety predicate, same shape
+			// as liveReplicationStatusFromCNPGPair). A pair reporting neither
+			// key leaves the CR-derived verdict untouched.
+			// augmentReplicationStandbyStatus still runs after this and
+			// forces non-promotable when the live standby leg is verified
+			// absent (#4901), so a lag-0-during-outage reading cannot arm
+			// the control.
+			if promotable, found, _ := unstructured.NestedBool(pair.Object, "status", "replicaPromotable"); found {
 				resp.ReplicaPromotable = promotable
+			} else if streaming, sFound, _ := unstructured.NestedBool(pair.Object, "status", "streaming"); sFound {
+				resp.ReplicaPromotable = streaming && lag <= 30
 			}
 		}
 	}
@@ -1028,17 +1051,41 @@ func enrichReplicationStatus(cr *unstructured.Unstructured) continuumReplication
 	out.StreamingState, _, _ = unstructured.NestedString(cr.Object, "status", "streamingState")
 	out.SyncState, _, _ = unstructured.NestedString(cr.Object, "status", "syncState")
 	// #4923 — replicaPromotable needs POSITIVE evidence that a standby exists
-	// and follows (status.replicationHealthy), not just "lag number is small":
-	// an ABSENT standby also reads lag=0 (#4901 — health/lag stayed green for
-	// the whole hot-standby outage), so the old `lag <= 30` marked a lost
-	// standby promotable. The live-pair standby augmentation upgrades this
-	// when it verifies the standby off the cnpg cluster-pair.
+	// and follows, not just "lag number is small": an ABSENT standby also
+	// reads lag=0 (#4901 — health/lag stayed green for the whole hot-standby
+	// outage), so the old `lag <= 30` marked a lost standby promotable. The
+	// live-pair standby augmentation upgrades this when it verifies the
+	// standby off the cnpg cluster-pair.
+	//
+	// #5601 — the Continuum controller NEVER writes status.replicationHealthy.
+	// Its status writer (core/controllers/continuum patchStatus) publishes the
+	// standby posture as status.standbyAvailable (#4901) with replica health
+	// folded into status.phase. Probing only the absent key silently kept the
+	// zero-value false, so a fully healthy caught-up pair on hw292
+	// (standbyAvailable=true, phase=Healthy, replicationLagSeconds=0,
+	// StandbyAvailable condition True/StandbyReachable) rendered the
+	// Switchover control disabled with "no caught-up standby to promote" —
+	// asserting the opposite of the CR it claims to read. Consume the keys
+	// the controller actually writes, deriving promotability identically to
+	// liveReplicationStatusFromCNPGPair: positive standby evidence AND
+	// healthy AND lag under the 30s threshold. Healthy/FailedOver are the two
+	// reconciled-ready phases (phaseToReady in the controller) — FailedOver is
+	// the post-switchover steady state and must keep the failback path armed.
+	// A CR carrying NEITHER key still yields false: never promotable without
+	// positive evidence.
+	phase, _, _ := unstructured.NestedString(cr.Object, "status", "phase")
 	replHealthy, replHealthyFound, _ := unstructured.NestedBool(cr.Object, "status", "replicationHealthy")
-	out.ReplicaPromotable = replHealthyFound && replHealthy && out.WALLagSeconds <= 30
+	standbyAvailable, standbyAvailableFound, _ := unstructured.NestedBool(cr.Object, "status", "standbyAvailable")
+	switch {
+	case replHealthyFound:
+		out.ReplicaPromotable = replHealthy && out.WALLagSeconds <= 30
+	case standbyAvailableFound:
+		phaseReady := phase == "Healthy" || phase == "FailedOver"
+		out.ReplicaPromotable = standbyAvailable && phaseReady && out.WALLagSeconds <= 30
+	}
 	// #4923 — health gates DERIVED from the observed CR status, never a
 	// hardcoded all-Pass wall (the prior shape reported "streaming-replication
 	// Pass" during a proven standby outage).
-	phase, _, _ := unstructured.NestedString(cr.Object, "status", "phase")
 	leaseHolder, _, _ := unstructured.NestedString(cr.Object, "status", "leaseHolder")
 	out.HealthGates = []continuumHealthGate{
 		replicationHealthGate(replHealthy, replHealthyFound, phase),

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_5601_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_5601_test.go
@@ -1,0 +1,237 @@
+// continuum_dr_extras_5601_test.go — #5601 regression coverage.
+//
+// hw292 (dep 1c56185…, post-cutover) rendered the DR panel's Switchover
+// control DISABLED with "the replica is not promotable — no caught-up standby
+// to promote" while the SAME panel showed a healthy hot standby at 0.0s lag,
+// and the Continuum CR itself said standbyAvailable=true / phase=Healthy /
+// replicationLagSeconds=0 (StandbyAvailable condition True/StandbyReachable).
+//
+// Root cause: the replication-status readers probed status keys NO live
+// producer writes — status.replicaPromotable / status.replicationHealthy /
+// status.walLagSeconds (QA-fixture-only spellings) — so found=false and
+// ReplicaPromotable silently kept its zero value. The Continuum controller's
+// status writer (core/controllers/continuum patchStatus) publishes
+// standbyAvailable / phase / replicationLagSeconds instead.
+//
+// This file locks:
+//   - a healthy caught-up CR (the exact hw292 status shape) yields
+//     ReplicaPromotable=true with the lag field populated;
+//   - the controller's replicationLagSeconds spelling reaches walLagSeconds;
+//   - the derivation is NOT a standbyAvailable pass-through: Degraded phase,
+//     standbyAvailable=false, and over-threshold lag each disarm it;
+//   - the linked-CNPGPair reader derives promotability from the keys the
+//     CNPGPair CRD contract carries (streaming + lag) when replicaPromotable
+//     is absent, and still honors an explicit replicaPromotable=false.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// setContinuumControllerStatus stamps the EXACT status keys the Continuum
+// controller's patchStatus writes (verified against
+// core/controllers/continuum/internal/controller/continuum_controller.go and
+// the live hw292 CR capture in #5601) — never the QA-fixture-only spellings.
+func setContinuumControllerStatus(cr *unstructured.Unstructured, phase string, standbyAvailable bool, lagSeconds int64) {
+	_ = unstructured.SetNestedField(cr.Object, phase, "status", "phase")
+	_ = unstructured.SetNestedField(cr.Object, standbyAvailable, "status", "standbyAvailable")
+	_ = unstructured.SetNestedField(cr.Object, !standbyAvailable, "status", "hotStandbyAbsent")
+	_ = unstructured.SetNestedField(cr.Object, lagSeconds, "status", "replicationLagSeconds")
+	_ = unstructured.SetNestedField(cr.Object, false, "status", "switchoverInProgress")
+}
+
+func fetchReplicationStatus(t *testing.T, h *Handler, depID, name, ns string) continuumReplicationStatus {
+	t.Helper()
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+depID+"/continuum/"+name+"/replication-status?namespace="+ns, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+// The hw292 shape: Continuum CR healthy + caught up (standbyAvailable=true,
+// phase=Healthy, replicationLagSeconds=0) with the live cnpg pair's replica
+// half Ready. The switchover gate MUST arm: replicaPromotable=true.
+func TestReplicationStatus_5601_HealthyCaughtUpCRIsPromotable(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	setContinuumControllerStatus(cr, "Healthy", true, 0)
+	primary, replica := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5601-healthy-promotable")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+
+	if !resp.ReplicaPromotable {
+		t.Errorf("replicaPromotable: got false want true — the CR says standbyAvailable=true/phase=Healthy/lag=0 and the live replica is Ready (the #5601 hw292 contradiction)")
+	}
+	if resp.StandbyAvailable == nil || !*resp.StandbyAvailable {
+		t.Errorf("standbyAvailable: got %v want true", resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Pass" {
+		t.Errorf("standby-available gate: got %q want Pass (msg=%q)", g.Status, g.Message)
+	}
+	if resp.WALLagSeconds != 0 {
+		t.Errorf("walLagSeconds: got %v want 0 (the CR-reported reading)", resp.WALLagSeconds)
+	}
+	if resp.Source != "live" {
+		t.Errorf("source: got %q want live", resp.Source)
+	}
+}
+
+// The controller's lag spelling — status.replicationLagSeconds — must reach
+// the response's walLagSeconds AND a low reading must keep the pair
+// promotable.
+func TestReplicationStatus_5601_ControllerLagSpellingPopulatesWALLag(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	setContinuumControllerStatus(cr, "Healthy", true, 7)
+	primary, replica := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5601-lag-spelling")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+
+	if resp.WALLagSeconds != 7 {
+		t.Errorf("walLagSeconds: got %v want 7 (status.replicationLagSeconds is the controller's spelling)", resp.WALLagSeconds)
+	}
+	if !resp.ReplicaPromotable {
+		t.Errorf("replicaPromotable: got false want true (7s lag is under the 30s threshold)")
+	}
+}
+
+// Controls — the fix must NOT collapse into a standbyAvailable pass-through.
+// Each variant shares the suspect property (a healthy-looking sibling field)
+// and must still disarm.
+func TestReplicationStatus_5601_DerivationControlsStayDisarmed(t *testing.T) {
+	cases := []struct {
+		name             string
+		phase            string
+		standbyAvailable bool
+		lagSeconds       int64
+	}{
+		{"degraded-phase", "Degraded", true, 0},
+		{"standby-unavailable", "Healthy", false, 0},
+		{"lag-over-threshold", "Healthy", true, 45},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewWithPDM(silentLogger(), &fakePDM{})
+			cr := newContinuumUnstructured(
+				"dr-shared-pg", "shared-data", "shared-pg",
+				"me-east-215-a", []string{"me-east-215-b"})
+			setContinuumControllerStatus(cr, tc.phase, tc.standbyAvailable, tc.lagSeconds)
+			// No cnpg pair seeded: the live augmentation stays undetermined and
+			// must not upgrade the CR-derived verdict.
+			factory, _ := fakeContinuumDynamicFactory(cr)
+			h.dynamicFactory = factory
+			dep := installUserAccessDeployment(t, h, "dep-5601-ctl-"+tc.name)
+
+			resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+
+			if resp.ReplicaPromotable {
+				t.Errorf("replicaPromotable: got true want false (%s)", tc.name)
+			}
+		})
+	}
+}
+
+// newCNPGPairCRUnstructured composes a dr.openova.io CNPGPair CR carrying the
+// given status keys.
+func newCNPGPairCRUnstructured(name, namespace string, status map[string]interface{}) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("dr.openova.io/v1")
+	u.SetKind("CNPGPair")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"primaryCluster": name + "-primary",
+		"replicaCluster": name + "-replica",
+		"primaryRegion":  "me-east-215-a",
+		"replicaRegion":  "me-east-215-b",
+	}, "spec")
+	_ = unstructured.SetNestedMap(u.Object, status, "status")
+	return u
+}
+
+// Linked-CNPGPair reader — when the pair CR reports the keys its CRD contract
+// actually carries (streaming bool + a lag axis) but NO replicaPromotable,
+// the reader must derive promotability instead of silently keeping false.
+func TestReplicationStatus_5601_LinkedPairDerivesPromotableFromStreaming(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	// The Continuum CR itself reports no health keys — only the linked pair
+	// carries the reading, so a promotable=true can only come from the pair.
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"name":      "shared-pg-pair",
+		"namespace": "shared-data",
+	}, "spec", "cnpgPair")
+	pair := newCNPGPairCRUnstructured("shared-pg-pair", "shared-data", map[string]interface{}{
+		"phase":                 "Streaming",
+		"streaming":             true,
+		"replicationLagSeconds": int64(3),
+	})
+	factory, _ := fakeContinuumDynamicFactory(cr, pair)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5601-pair-streaming")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+
+	if !resp.ReplicaPromotable {
+		t.Errorf("replicaPromotable: got false want true (pair streaming=true, lag 3s under threshold)")
+	}
+	if resp.WALLagSeconds != 3 {
+		t.Errorf("walLagSeconds: got %v want 3 (pair status.replicationLagSeconds)", resp.WALLagSeconds)
+	}
+}
+
+// An EXPLICIT replicaPromotable=false on the pair CR must still win over the
+// streaming-derived verdict (both directions honest — never fail-open).
+func TestReplicationStatus_5601_LinkedPairExplicitFalseStillWins(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"name":      "shared-pg-pair",
+		"namespace": "shared-data",
+	}, "spec", "cnpgPair")
+	pair := newCNPGPairCRUnstructured("shared-pg-pair", "shared-data", map[string]interface{}{
+		"phase":             "Streaming",
+		"streaming":         true,
+		"walLagSeconds":     int64(2),
+		"replicaPromotable": false,
+	})
+	factory, _ := fakeContinuumDynamicFactory(cr, pair)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5601-pair-explicit-false")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+
+	if resp.ReplicaPromotable {
+		t.Errorf("replicaPromotable: got true want false — an explicit producer-written false must never be overridden by the derived reading")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_5601_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_5601_test.go
@@ -235,3 +235,4 @@ func TestReplicationStatus_5601_LinkedPairExplicitFalseStillWins(t *testing.T) {
 		t.Errorf("replicaPromotable: got true want false — an explicit producer-written false must never be overridden by the derived reading")
 	}
 }
+


### PR DESCRIPTION
## What

The DR panel's Switchover control on hw292 was disabled with *"the replica is not promotable — no caught-up standby to promote"* while the same panel showed a healthy hot standby at 0.0s lag, and the Continuum CR itself reported `standbyAvailable: true`, `phase: Healthy`, `replicationLagSeconds: 0` with condition `StandbyAvailable=True/StandbyReachable`.

Root cause (confirmed in the #5601 forensics comment): the replication-status readers in `products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go` probe status keys **no live producer writes**, so `found=false` and `ReplicaPromotable` silently keeps its zero value — `false` — which `TopologyTab.tsx` then renders as a positive factual claim.

- `enrichReplicationStatus` read `status.replicationHealthy` off the Continuum CR. The controller's status writer (`core/controllers/continuum/internal/controller/continuum_controller.go`, `patchStatus`) publishes `standbyAvailable` (#4901) + `phase` + `replicationLagSeconds` — never `replicationHealthy`.
- The linked-CNPGPair reader probed `status.replicaPromotable` and `status.walLagSeconds`. Their only producer is the QA fixture (`products/catalyst/chart/templates/qa-fixtures/cnpgpair-qa.yaml`); the CNPGPair CRD's status contract carries `streaming` + `walLagSeconds`, and the CRD comment states no live producer writes the pair CR's status today.

## Fix

Consume the keys the producers actually write, deriving promotability identically to the already-correct `liveReplicationStatusFromCNPGPair` derivation (`standbyAvailable && healthy && lag <= 30`):

- **enrich**: honor `replicationHealthy` when a producer writes it; otherwise derive from `standbyAvailable` + phase (`Healthy`/`FailedOver` — the two reconciled-ready phases per the controller's `phaseToReady`; `FailedOver` keeps the failback path armed) + lag. A CR carrying **neither** key still yields `false` — never promotable without positive evidence (the #4923 contract is preserved).
- **pair reader**: fall back to the `replicationLagSeconds` spelling for the lag axis; when `replicaPromotable` is absent, derive from the CRD's stated switchover-safety predicate (`streaming` AND lag under threshold). An explicit producer-written `replicaPromotable` wins in both directions, and `augmentReplicationStandbyStatus` still runs afterwards and forces non-promotable on a verified-absent standby (#4901) — a lag-0-during-outage reading cannot arm the control.

No UI change: the arming logic in `TopologyTab.tsx` already consumes `replicaPromotable` correctly; the API truth was wrong.

## Also in this PR (disclosed, required to build)

`main` does not compile in this module: #5535 (71c54d8d6) changed `secondaryKubeconfigsForCutover` to return the single `secondaryKubeconfigResolution` struct while #5592 (bb8ceec71) merged independently with a caller destructuring the older two-value signature (`post_handover_policy_enforce.go:118`). The first commit ports the caller to `.paths` — behavior identical to #5592's intent. Without it, `go build ./...` and every test in the package fail regardless of this fix.

## Tests

`continuum_dr_extras_5601_test.go` — verified to FAIL on the unfixed reader code and pass with the fix:

- the exact hw292 status shape (controller-written keys only) yields `replicaPromotable=true`, `standbyAvailable=true`, gate Pass, lag populated;
- the controller's `replicationLagSeconds` spelling reaches `walLagSeconds` (7 → 7) and stays promotable;
- controls sharing the suspect property stay disarmed: `Degraded` phase, `standbyAvailable=false`, lag 45s;
- linked-pair derivation: `streaming=true` + lag 3s (no `replicaPromotable`) → promotable + lag populated;
- an explicit `replicaPromotable=false` on the pair still wins over the streaming derivation.

## Gates

- `go build ./...` — PASS (fails on main before the merge-race repair)
- `go vet ./internal/handler/` — PASS
- `go test ./internal/handler/ -run TestReplicationStatus_5601 -v` — 5/5 PASS (3/5 FAIL against the unfixed code, on exactly the predicted assertions)
- `go test ./...` (whole `products/catalyst/bootstrap/api` module) — ALL PASS

## Live evidence note

The hw292 apiserver was unreachable from this workspace at fix time (dial timeout to 212.72.24.1:6443 on both region contexts), so the producer-side key names were verified three ways instead: the Continuum controller's `patchStatus` source, the CNPGPair CRD schema + its no-live-producer comment, and the verbatim live-CR capture already recorded in the #5601 forensics comment. UAT row 57 stays ❌ until an operator re-walks the panel on a rolled catalyst-api.

Refs #5601 #4923 #4901 #3375 #5535 #5592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
