### PR TITLE
fix(ui): #5616 instance-create vCluster selector offers only real targets, keyed by real namespace

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
@@ -95,6 +95,18 @@ export type IsolationMode = 'dmz' | 'rtz' | 'mgmt'
 export interface VClusterSpec {
   id: string
   name: string
+  /**
+   * Host namespace the vCluster runs in — the REAL placement identity
+   * (#5616). The backend wire (bootstrap/api infrastructure.VCluster)
+   * has always carried this; the FE type dropped it, which pushed the
+   * create-instance dialog onto `name` (a display name — the per-Org
+   * vCluster is NAMED "vcluster" but RUNS in the Org namespace) and
+   * every explicit selection landed downstream as a namespace that
+   * does not exist. Optional: absent on stale API builds / fixtures.
+   */
+  namespace?: string
+  /** dmz | rtz | mgmt | other — the wire's role channel. */
+  role?: string
   isolationMode: IsolationMode
   status: TopologyStatus
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
@@ -7,7 +7,9 @@
  *       - Organization → <select> populated from listOrganizations()
  *       - Topology mode → <select> from the editor ALL_MODES set
  *       - Region(s) → checkboxes from the live infrastructure topology
- *       - vCluster → <select>
+ *       - vCluster → <select> of REAL placement targets only (#5616):
+ *         "host" + live vClusters keyed by their real host NAMESPACE
+ *         (never the display name, never fabricated tier options)
  *   • Placement is written onto the create request (#3599): the POST body
  *     carries placement {vcluster, regions} + topology.
  *   • active-active / active-hotstandby require ≥2 regions; Create stays
@@ -56,12 +58,23 @@ const ORG_ROWS = {
   ],
 }
 
+// #5616 — two live vClusters, both with a display NAME that differs from
+// their real host NAMESPACE:
+//   v1 "acme-rtz" runs in ns "rtz"  → tier-resolvable, MUST be offered
+//     with value = "rtz" (the real namespace), never "acme-rtz".
+//   v2 "vcluster" runs in ns "acme" → the per-Org boundary vCluster; no
+//     placement.vcluster spelling resolves it today, so it MUST NOT be
+//     offered (on hw292 its display name became a namespace that does
+//     not exist and the install Degraded).
 const TOPOLOGY = {
   topology: {
     pattern: 'multi-region',
     regions: [
       { id: 'r-a', name: 'rgn-a', provider: 'huawei', providerRegion: 'me-east-215-a', clusters: [
-        { id: 'c-a', name: 'cl-a', vclusters: [{ id: 'v1', name: 'acme-rtz', isolationMode: 'rtz', status: 'healthy' }] },
+        { id: 'c-a', name: 'cl-a', vclusters: [
+          { id: 'v1', name: 'acme-rtz', namespace: 'rtz', isolationMode: 'rtz', status: 'healthy' },
+          { id: 'v2', name: 'vcluster', namespace: 'acme', isolationMode: 'rtz', status: 'healthy' },
+        ] },
       ] },
       { id: 'r-b', name: 'rgn-b', provider: 'huawei', providerRegion: 'me-east-215-b', clusters: [] },
     ],
@@ -187,6 +200,37 @@ describe('NewInstanceDialog — dropdowns (#3600)', () => {
     expect(((await screen.findByTestId('select-instance-vcluster')) as HTMLSelectElement).tagName).toBe('SELECT')
   })
 
+  // #5616 — every offered option must be a REAL placement target. The
+  // hw292 walk proved the old dropdown was 5-for-5 wrong: fixed tier
+  // aliases (mgmt/dmz/rtz) were offered with no live vCluster behind
+  // them, and live vClusters were keyed by display NAME (the per-Org
+  // vCluster is named "vcluster" but runs in the Org namespace), so
+  // every explicit choice was consumed downstream as a namespace that
+  // does not exist and the Application landed Degraded.
+  it('#5616 — the vCluster select offers only real placement targets, keyed by real namespace', async () => {
+    await openDialog()
+    // Wait for the live topology to resolve (regions come from the same query).
+    await screen.findByTestId('region-checkbox-rgn-a')
+    const sel = (await screen.findByTestId('select-instance-vcluster')) as HTMLSelectElement
+    const options = Array.from(sel.querySelectorAll('option'))
+    const values = options.map((o) => o.getAttribute('value'))
+    // Exactly: blank default, host, and the ONE tier-resolvable live
+    // vCluster — by its real namespace.
+    expect(values).toEqual(['', 'host', 'rtz'])
+    // The live vCluster's display name is label-only, never the value.
+    const rtzOption = options.find((o) => o.getAttribute('value') === 'rtz')!
+    expect(rtzOption.textContent).toContain('acme-rtz')
+    expect(values).not.toContain('acme-rtz')
+    // Fabricated tier aliases with no live vCluster behind them are gone.
+    expect(values).not.toContain('mgmt')
+    expect(values).not.toContain('dmz')
+    // The per-Org vCluster resolves through the blank default, not an
+    // explicit option — neither its display name nor its Org namespace
+    // is offered as a value.
+    expect(values).not.toContain('vcluster')
+    expect(values).not.toContain('acme')
+  })
+
   it('Region(s) render as checkboxes from the live topology', async () => {
     await openDialog()
     expect(await screen.findByTestId('region-checkbox-rgn-a')).toBeTruthy()
@@ -243,6 +287,32 @@ describe('NewInstanceDialog — placement (#3599)', () => {
     // One vocabulary (#3375 DoD-1): the canonical topology is POSTed.
     expect(body.topology).toBe('active-hot-standby')
     expect(body.placement).toEqual({ vcluster: 'rtz', regions: ['rgn-a', 'rgn-b'] })
+  })
+
+  // #5616 both directions — selecting the live vCluster submits its REAL
+  // host namespace ("rtz"), and the display name ("acme-rtz") appears
+  // nowhere in the payload.
+  it('#5616 — the submitted payload carries the real namespace of the selected vCluster, never its display name', async () => {
+    await openDialog()
+    fireEvent.change(await screen.findByTestId('input-instance-name'), { target: { value: 'wp-2' } })
+    fireEvent.change(await screen.findByTestId('select-instance-org'), { target: { value: 'acme' } })
+    // Wait for the topology-fed options, then select the live vCluster
+    // (displayed with its name "acme-rtz", valued by its namespace).
+    await screen.findByTestId('region-checkbox-rgn-a')
+    const sel = (await screen.findByTestId('select-instance-vcluster')) as HTMLSelectElement
+    await waitFor(() => expect(sel.querySelector('option[value="rtz"]')).toBeTruthy())
+    fireEvent.change(sel, { target: { value: 'rtz' } })
+
+    fireEvent.click(await screen.findByTestId('btn-submit-instance'))
+
+    await waitFor(() => expect(captured.length).toBe(1))
+    const body = captured[0]
+    const placement = body.placement as { vcluster?: string }
+    // Right value present: the real namespace.
+    expect(placement.vcluster).toBe('rtz')
+    // Wrong value absent: the display name never reaches the wire.
+    expect(placement.vcluster).not.toBe('acme-rtz')
+    expect(JSON.stringify(body)).not.toContain('acme-rtz')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -32,11 +32,19 @@ import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { ALL_MODES, canonicalizeMode, describeModeForComponent } from '@/widgets/topology/TopologyEditor'
 import { BLUEPRINT_BY_ID, TOPOLOGY_BY_ID } from '@/shared/constants/catalog.generated'
 
-// #3599 / #3600 — the vCluster/zone options the catalyst-api backend
-// validates (`placement.vcluster ∈ {host, mgmt, dmz, rtz}`,
-// instances/create.go ValidateShape). Rendered as a dropdown (never
-// free-text) so an install can't be typo'd into an invalid zone.
-const VCLUSTER_OPTIONS = ['host', 'mgmt', 'dmz', 'rtz'] as const
+// #3599 / #3600 / #5616 — the tier namespaces the backend can RESOLVE:
+// catalyst-api validates `placement.vcluster ∈ {host, mgmt, dmz, rtz}`
+// (instances/create.go ValidateShape) and the application-controller
+// maps each tier key to the SAME-NAMED host namespace when addressing
+// the per-cluster HelmRelease (VClusterPlacements defaults). #5616 —
+// these are OFFERED only when the live topology reports a vCluster
+// actually running in that namespace: a fabricated option lands the
+// HelmRelease in a namespace that does not exist and the install
+// Degrades (`namespaces "rtz" not found`, hw292 walk 2026-08-04).
+// "host" is the one namespace-independent target (the controller
+// normalizes it to the host-cluster install in the Org's own
+// namespace), so it is always offered.
+const RESOLVABLE_TIER_NAMESPACES = ['mgmt', 'dmz', 'rtz'] as const
 
 /**
  * Modes that require ≥2 regions (the create-flow validation rule). ONE
@@ -439,9 +447,11 @@ export function PerClusterTable({
  *                  ALL_MODES option set (#3599 — no divergent vocab).
  *  - region(s)   — checkbox multiselect from the Sovereign's live cluster
  *                  regions (getHierarchicalInfrastructure topology tree).
- *  - vCluster    — <select> from {host, mgmt, dmz, rtz} (the backend's
- *                  validated zone set), enriched with the live vcluster
- *                  names when present.
+ *  - vCluster    — <select> of REAL placement targets only (#5616):
+ *                  "host" plus the live vClusters whose actual host
+ *                  namespace the backend tier map resolves (mgmt/dmz/
+ *                  rtz). Option value = the vCluster's real namespace,
+ *                  never its display name.
  *  - backing     — the #3370 Create new / Reuse existing selectors.
  *
  * Placement (#3599) is written onto the Application CR: the submit sends
@@ -506,18 +516,32 @@ export function NewInstanceDialog({
     }
     return Array.from(set).sort()
   }, [infraQuery.data])
-  // Live vcluster names (enrich the fixed zone set so the operator can
-  // pick the actual vcluster when the topology reports them).
-  const liveVclusters = useMemo<string[]>(() => {
-    const set = new Set<string>()
+  // #5616 — REAL placement targets from the live topology. Each option's
+  // VALUE is the vCluster's real host NAMESPACE (`vc.namespace` on the
+  // wire) — the identity the backend consumes when addressing the
+  // per-cluster HelmRelease — never its display name (`vc.name`: the
+  // per-Org vCluster is NAMED "vcluster" but RUNS in the Org namespace,
+  // so emitting the name produced `namespaces "vcluster" not found`).
+  // Only namespaces the backend tier map can resolve (mgmt/dmz/rtz) are
+  // offered; a live vCluster in any other namespace (e.g. the per-Org
+  // boundary) has no valid `placement.vcluster` spelling today — the
+  // blank default already lands those installs in the Org boundary
+  // server-side, which is the working path the hw292 control proved.
+  const liveVclusterTargets = useMemo<Array<{ namespace: string; name: string }>>(() => {
+    const byNs = new Map<string, string>()
     for (const region of infraQuery.data?.topology?.regions ?? []) {
       for (const cluster of region.clusters ?? []) {
         for (const vc of cluster.vclusters ?? []) {
-          if (vc.name) set.add(vc.name)
+          const ns = vc.namespace ?? ''
+          if (!ns) continue
+          if (!(RESOLVABLE_TIER_NAMESPACES as readonly string[]).includes(ns)) continue
+          if (!byNs.has(ns)) byNs.set(ns, vc.name || ns)
         }
       }
     }
-    return Array.from(set).sort()
+    return Array.from(byNs.entries())
+      .map(([namespace, name]) => ({ namespace, name }))
+      .sort((a, b) => a.namespace.localeCompare(b.namespace))
   }, [infraQuery.data])
 
   // Resolve the Blueprint's supported topologies via the catalog
@@ -830,8 +854,11 @@ export function NewInstanceDialog({
           ) : null}
         </fieldset>
 
-        {/* vCluster / zone — dropdown from the backend's validated zone
-            set, enriched with live vcluster names (#3599/#3600). */}
+        {/* vCluster / zone — REAL placement targets only (#5616): the
+            namespace-independent "host" plus the live vClusters whose
+            actual namespace the backend tier map resolves. Option VALUE
+            = the vCluster's real host namespace (what the per-cluster
+            HelmRelease is addressed with), never its display name. */}
         <label style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}>
           <span style={{ display: 'block', marginBottom: '0.2rem' }}>vCluster / zone</span>
           <select
@@ -841,18 +868,13 @@ export function NewInstanceDialog({
             style={fieldStyle}
           >
             <option value="">Default (server picks)</option>
-            {VCLUSTER_OPTIONS.map((z) => (
-              <option key={z} value={z}>
-                {z}
+            <option value="host">host — host cluster (no vCluster)</option>
+            {liveVclusterTargets.map((t) => (
+              <option key={t.namespace} value={t.namespace}>
+                {t.namespace}
+                {t.name && t.name !== t.namespace ? ` — vCluster ${t.name}` : ''}
               </option>
             ))}
-            {liveVclusters
-              .filter((v) => !VCLUSTER_OPTIONS.includes(v as (typeof VCLUSTER_OPTIONS)[number]))
-              .map((v) => (
-                <option key={v} value={v}>
-                  {v}
-                </option>
-              ))}
           </select>
         </label>
 


### PR DESCRIPTION
Refs #5616

## Root cause (confirmed in source, matching the hw292 walk evidence)

The "+ New instance" dialog (`products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx`) built its vCluster select from two broken channels:

1. **Four fabricated tier aliases** — `VCLUSTER_OPTIONS = ['host', 'mgmt', 'dmz', 'rtz']` was offered unconditionally, whether or not any such vCluster exists on the Sovereign. The consuming side (`products/catalyst/bootstrap/api/internal/instances/create.go` `ValidateShape` accepts the tier token; `core/controllers/application/internal/controller/application_controller.go` maps it via `VClusterPlacements` defaults `dmz→dmz / mgmt→mgmt / rtz→rtz`) then addresses the per-cluster HelmRelease **in a namespace named after the tier**. On hw292 none of those namespaces exist, so every pick produced `upsert per-cluster HelmRelease rtz/...: namespaces "rtz" not found` → Degraded.
2. **Live vClusters keyed by display name** — the enrichment loop emitted `vc.name`. The per-Org vCluster is *named* `vcluster` but *runs in the Org namespace*; the FE type (`lib/infrastructure.types.ts` `VClusterSpec`) had dropped the `namespace` field the bootstrap/api wire (`infrastructure.VCluster`) has always serialized, so the dialog had nothing else to key on. Emitting `vcluster` is rejected/unresolvable downstream — the fifth broken option.

That is exactly the label-vs-namespace mismatch the issue documents: 5 options offered, 5 consumed as a namespace that does not exist.

## Fix (emission side — the emitted values stay inside the backend's already-validated set, so zero Go changes)

- `lib/infrastructure.types.ts` — surface `namespace` + `role` on `VClusterSpec` (optional; the wire always carried them).
- `InstancesSection.tsx` — the select now offers **only real placement targets**:
  - `host` — always real: the controller normalizes it (`NormalizeVCluster`) to a host-cluster install in the Org's own namespace, no tier namespace needed;
  - live vClusters whose **actual namespace** is tier-resolvable (`mgmt`/`dmz`/`rtz`), with **option value = the vCluster's real host namespace** and the display name demoted to the option label.
  - Fabricated tiers with no live vCluster behind them are no longer rendered. A live vCluster in a non-tier namespace (the per-Org boundary) is not offered as an explicit value — no `placement.vcluster` spelling resolves it today, and the blank server-side default already lands those installs in the Org boundary (the path the hw292 control `uatco-openclaw` phase=Ready proved working).
- `InstancesSection.test.tsx` — fixture vClusters now carry namespaces that differ from their names (`acme-rtz` in ns `rtz`; per-Org `vcluster` in ns `acme`), plus two new #5616 tests locking both directions:
  - option set is exactly `['', 'host', 'rtz']`; display names, fabricated tiers, and non-resolvable namespaces are all absent;
  - the submitted payload carries `placement.vcluster === 'rtz'` (the real namespace) and the display name `acme-rtz` appears nowhere in the wire body.

On hw292 today this renders `Default (server picks)` + `host` — both of which actually work — instead of five options that all Degrade.

## What this PR does NOT change (documented boundary)

Explicitly addressing the **per-Org** vCluster via `placement.vcluster` needs a namespace-valued contract across catalyst-api `ValidateShape` and the application-controller `VClusterPlacements` lookup (plus the `vc-vcluster` kubeconfig-secret convention from `core/controllers/organization/internal/gitops/manifests.go`). That is a controller-contract change; this PR removes the broken emission so no offered option can land in a nonexistent namespace, per the issue's stated resolution options.

## Gates

- `npm run build` (products/catalyst/bootstrap/ui) — PASS
- `npx vitest run src/pages/sovereign/AppDetail/InstancesSection.test.tsx` — 13/13 PASS (incl. 2 new #5616 tests)
- `npx vitest run` (full suite) — 9 failed / 2000 passed; the 9 failures are pre-existing on clean `origin/main` (verified by stash-run: `SovereignConsoleLayout.test.tsx`, `SettingsPage.test.tsx`, `StepComponents.test.tsx` fail identically at baseline 9/2007). No new failures from this change.

No chart changes, no Service changes, no NodePorts, no `openova.io` domains in tests (fixtures use the existing acme/omani.works shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
