### PR TITLE
fix(agenity): per-Org oidc-gate egress CNP — DNS + Keycloak backchannel + upstream (0.5.22)

### DIFF
--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -14,7 +14,11 @@ spec:
   # 0.5.17 (#4604): chart adds a default-on external-HTTPS egress CNP +
   # seeds the openova MCP into ~/.claude.json for a standalone claude (durable
   # Pillar-4 North-Star wiring). Lockstep with products/agenity/chart.
-  version: 0.5.21
+  # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP (kube-dns +
+  # Keycloak backchannel + upstream) — the per-Org namespace is default-deny
+  # and the gate's ingress-only CNP left the OAuth callback 500ing on a DNS
+  # timeout. Lockstep with products/agenity/chart + the catalog-seed pin.
+  version: 0.5.22
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -188,7 +188,22 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.21
+version: 0.5.22
+# 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
+# CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
+# The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org
+# namespace, so its DNS lookups and the Keycloak token-exchange dial were
+# dropped and every OAuth callback 500'd AFTER a successful login (live on
+# hw292 Org uatco: `lookup keycloak.keycloak.svc.cluster.local on
+# 10.96.0.10:53: i/o timeout`, oauthproxy.go:881 — the #4437 sso-bridge
+# class: ingress allowed, egress forgotten). New egress allow-list: kube-dns
+# :53 UDP+TCP, the Keycloak backchannel (Service port + Pod target port 8080,
+# the #4437 post-DNAT port trap), the proxied agenity upstream in-namespace,
+# plus a `toEntities:[world]:443` discovery fallback ONLY when
+# keycloakInternalURL is unset. toEndpoints/toEntities only — ipBlock never
+# matches ClusterMesh remote pod identities. Values knobs
+# oidcGate.networkPolicy.keycloakNamespace/keycloakPort added. Template +
+# values change; appVersion (image) UNCHANGED.
 # 0.5.21 (#5416): the per-Org gate's cookie secret stops being minted per
 # region. templates/oidc-gate.yaml rendered it with `lookup`-or-`randAlphaNum
 # 32`; on a 2-region Sovereign the second region misses the lookup and mints a

--- a/products/agenity/chart/templates/oidc-gate.yaml
+++ b/products/agenity/chart/templates/oidc-gate.yaml
@@ -337,4 +337,91 @@ spec:
             - port: "4180"
               protocol: TCP
 {{- end }}
+{{- if and .Values.networkPolicy.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- $gnp := $g.networkPolicy | default dict }}
+---
+# ── CiliumNetworkPolicy — the gate's EGRESS half (#5617) ──────────────────
+# The per-Org namespace is DEFAULT-DENY and the gateway-ingress CNP above is
+# ingress-only — so before this policy the gate pod could not resolve DNS or
+# dial the Keycloak backchannel, and every OAuth callback 500'd AFTER a
+# successful login (live on hw292 Org uatco, oauthproxy.go:881: `lookup
+# keycloak.keycloak.svc.cluster.local on 10.96.0.10:53: i/o timeout` — the
+# #4437 sso-bridge class: ingress allowed, egress forgotten). The rule set is
+# exactly the gate's dial surface:
+#   1. kube-dns :53 UDP+TCP — name resolution (the templates/
+#      cilium-egress-networkpolicy.yaml idiom: DNS is LOAD-BEARING once any
+#      egress rule attaches, everything else default-denies).
+#   2. the Keycloak backchannel (redeem/jwks/userinfo via keycloakInternalURL)
+#      — Service port AND Pod target port 8080, because under Cilium the
+#      policy verdict runs AFTER the Service DNAT so the Pod port is the
+#      load-bearing one (#4437's port trap: allowing only 80 drops it).
+#   3. the proxied upstream — the agenity workload in this same namespace.
+# ClusterMesh note (#4439/#4656 family): rules are expressed as toEndpoints /
+# toEntities ONLY — an ipBlock/toCIDR NEVER matches a ClusterMesh remote pod
+# identity, so on a 2-region Sovereign a CIDR-shaped allow would silently
+# re-break the region whose Keycloak backend is remote.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" $gateName | quote }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: {{ printf "%s-netpol" $gateName | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bp-oidc-gate
+      catalyst.openova.io/component: {{ $gateName }}
+  egress:
+    # 1. Cluster DNS — kube-dns :53 UDP+TCP. Without this the gate cannot
+    #    resolve the Keycloak or upstream Service names and the callback
+    #    times out into a 500 (the exact hw292 failure).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    # 2. Keycloak backchannel — token redeem + JWKS + userinfo against
+    #    keycloakInternalURL. Both the Service port and the Pod target port
+    #    8080 are stated (#4437 port trap; Cilium enforces post-DNAT).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $gnp.keycloakNamespace | default "keycloak" }}
+      toPorts:
+        - ports:
+            - port: {{ $gnp.keycloakPort | default 80 | quote }}
+              protocol: TCP
+            - port: "8080"
+              protocol: TCP
+    # 3. The proxied upstream — the agenity workload in this namespace
+    #    (containerPort == service.port, templates/statefulset.yaml).
+    - toEndpoints:
+        - matchLabels:
+            {{- include "agenity.selectorLabels" . | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.service.port | quote }}
+              protocol: TCP
+{{- if not $kcInternal }}
+    # 4. Public-issuer discovery fallback — only when keycloakInternalURL is
+    #    UNSET (#3844 restored public-discovery mode): the gate then fetches
+    #    the OIDC discovery document + backchannel legs from the public
+    #    issuer EIP, an off-cluster :443 hop only `toEntities: [world]` can
+    #    name (the cilium-egress-networkpolicy.yaml #4604 idiom).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+{{- end }}
+{{- end }}
 {{- end }}

--- a/products/agenity/chart/tests/oidc-gate-companion-render.sh
+++ b/products/agenity/chart/tests/oidc-gate-companion-render.sh
@@ -98,6 +98,59 @@ grep -qE 'kind: CiliumNetworkPolicy' <<<"$g"                          || { echo 
 grep -qE 'port: "4180"' <<<"$g"                                       || { echo "FAIL: gate CNP not admitting port 4180" >&2; exit 1; }
 echo "  PASS — gateway-entity CNP present"
 
+# ── #5617 — the gate's EGRESS CNP. The per-Org namespace is DEFAULT-DENY and
+# the gateway-ingress CNP above is ingress-only, so without an egress
+# counterpart the gate cannot resolve DNS or dial the Keycloak token endpoint
+# and every OAuth callback 500s AFTER a successful login (live on hw292 Org
+# uatco: `lookup keycloak.keycloak.svc.cluster.local on 10.96.0.10:53: i/o
+# timeout`, oauthproxy.go:881 — the #4437 sso-bridge class). These values
+# mirror the org-gitops emitter's HR values (networkPolicy.enabled=true), so
+# this render IS the generated-Org shape.
+# Scope every egress assertion to the egress CNP document ONLY — a match that
+# leaks in from another doc (e.g. the agenity workload's own egress CNP) would
+# pass vacuously while the gate still had no egress.
+eg="$(echo "$g" | awk 'BEGIN{RS="\n---\n"} /name: "oidc-gate-agenity-agnstar-egress"/')"
+[ -n "$eg" ] || { echo "FAIL: no gate egress CiliumNetworkPolicy oidc-gate-agenity-agnstar-egress (#5617) — under per-Org default-deny the OAuth callback 500s on a DNS timeout" >&2; echo "$g" >&2; exit 1; }
+# (1) kube-dns :53 UDP+TCP — DNS is load-bearing under default-deny.
+grep -qE 'k8s-app: kube-dns' <<<"$eg"                     || { echo "FAIL: egress CNP has no kube-dns rule (#5617)" >&2; echo "$eg" >&2; exit 1; }
+grep -qzE 'port: "53"[[:space:]]+protocol: UDP' <<<"$eg"  || { echo "FAIL: egress CNP does not allow :53 UDP (#5617)" >&2; echo "$eg" >&2; exit 1; }
+grep -qzE 'port: "53"[[:space:]]+protocol: TCP' <<<"$eg"  || { echo "FAIL: egress CNP does not allow :53 TCP (#5617)" >&2; echo "$eg" >&2; exit 1; }
+# (2) the Keycloak backchannel — Service port AND Pod target port 8080 (the
+# #4437 port trap: Cilium enforces post-DNAT, allowing only 80 drops it).
+grep -qE 'k8s:io.kubernetes.pod.namespace: keycloak' <<<"$eg" || { echo "FAIL: egress CNP has no keycloak-namespace rule (#5617)" >&2; echo "$eg" >&2; exit 1; }
+grep -qE 'port: "80"' <<<"$eg"                            || { echo "FAIL: egress CNP does not allow the keycloak Service port 80 (#5617)" >&2; echo "$eg" >&2; exit 1; }
+grep -qE 'port: "8080"' <<<"$eg"                          || { echo "FAIL: egress CNP does not allow the keycloak Pod target port 8080 (#4437 port trap)" >&2; echo "$eg" >&2; exit 1; }
+# (3) the proxied upstream — the agenity workload in the same namespace.
+grep -qzE 'app.kubernetes.io/name: bp-agenity[[:space:]]+app.kubernetes.io/instance: agenity' <<<"$eg" || { echo "FAIL: egress CNP does not allow the proxied agenity upstream (#5617)" >&2; echo "$eg" >&2; exit 1; }
+# ClusterMesh guard: identity-based selectors ONLY — an ipBlock/toCIDR NEVER
+# matches a ClusterMesh remote pod identity, so a CIDR-shaped allow silently
+# re-breaks the region whose Keycloak backend is remote (#4439/#4656 class).
+# (YAML keys only — comment lines stripped so the template's own prose about
+# the trap cannot trip this guard.)
+eg_yaml="$(grep -vE '^[[:space:]]*#' <<<"$eg")"
+if grep -qE 'toCIDR|ipBlock' <<<"$eg_yaml"; then
+  echo "FAIL: egress CNP uses toCIDR/ipBlock — never matches ClusterMesh remote pod identities (#5617)" >&2; echo "$eg" >&2; exit 1
+fi
+# keycloakInternalURL is SET by default (#3844 backchannel mode) → the
+# world:443 public-discovery fallback must NOT render in the default shape.
+if grep -qE 'toEntities' <<<"$eg_yaml"; then
+  echo "FAIL: egress CNP carries a toEntities rule while keycloakInternalURL is set — the world fallback must be conditional (#5617)" >&2; echo "$eg" >&2; exit 1
+fi
+echo "  PASS — #5617 egress CNP present (kube-dns + keycloak 80/8080 + upstream, identity-based only)"
+
+# world:443 discovery fallback renders ONLY when keycloakInternalURL is unset
+wg="$(render_gated --set oidcGate.keycloakInternalURL="" | awk 'BEGIN{RS="\n---\n"} /name: "oidc-gate-agenity-agnstar-egress"/')"
+grep -qE '\- world' <<<"$wg"    || { echo "FAIL: keycloakInternalURL unset but egress CNP has no world:443 discovery fallback (#5617)" >&2; echo "$wg" >&2; exit 1; }
+grep -qE 'port: "443"' <<<"$wg" || { echo "FAIL: world discovery fallback not on :443 (#5617)" >&2; echo "$wg" >&2; exit 1; }
+echo "  PASS — world:443 fallback renders only in public-discovery mode"
+
+# vacuity check (both directions): networkPolicy.enabled=false → NO egress CNP
+npoff="$(render_gated --set networkPolicy.enabled=false)"
+if grep -qE 'name: "oidc-gate-agenity-agnstar-egress"' <<<"$npoff"; then
+  echo "FAIL: egress CNP rendered with networkPolicy.enabled=false" >&2; exit 1
+fi
+echo "  PASS — egress CNP suppressed when networkPolicy.enabled=false"
+
 # ── Case 2: oidcGate.enabled=false → chart's own route, NO gate ──────────────
 echo "[oidc-gate-companion] Case 2: oidcGate.enabled=false renders the chart's own route, NO gate"
 ng="$("$helm" template agenity "$chart_dir" --set "sovereignFqdn=$FQDN" --set "httpRoute.hostnames[0]=$HOST" --set oidcGate.enabled=false 2>/dev/null)"

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -331,6 +331,22 @@ oidcGate:
   # ClusterSecretStore the gate's client-secret ExternalSecret resolves through.
   externalSecretStoreName: vault-region1
   refreshInterval: 1h
+  # ── Egress targets for the gate's CiliumNetworkPolicy (#5617) ────────────
+  # The per-Org namespace is default-deny, and the gate used to ship an
+  # INGRESS-only CNP — so its DNS lookups and the Keycloak token-exchange dial
+  # were dropped and every OAuth callback 500'd after a successful login
+  # (live on hw292 Org uatco: `lookup keycloak.keycloak.svc.cluster.local on
+  # 10.96.0.10:53: i/o timeout`, oauthproxy.go:881). These knobs point the
+  # egress CNP at the Keycloak backchannel; keep them in lockstep with
+  # keycloakInternalURL above (namespace + Service port of that URL).
+  networkPolicy:
+    # Namespace the in-cluster Keycloak Service lives in.
+    keycloakNamespace: keycloak
+    # Keycloak SERVICE port (the port in keycloakInternalURL; no port = 80).
+    # The template additionally always allows the Pod target port 8080 — under
+    # Cilium the policy verdict runs AFTER the Service DNAT, so the Pod port is
+    # the load-bearing one (the #4437 port trap: allowing only 80 drops it).
+    keycloakPort: 80
   # The SPA bootstrap-token seed (#4556): 302 the bare root, AFTER the full KC
   # SSO, to `<dashboardPath>?token=<value>` so the agenity `/app/` SPA seeds
   # localStorage and lands authenticated with NO paste. value is a SENTINEL

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-02T20:30:57.599Z",
+  "generatedAt": "2026-08-03T19:51:09.140Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.21",
+      "version": "0.5.22",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.21",
+    "version": "0.5.22",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5950,7 +5950,10 @@ spec:
   # projection from the enabled per-Org mcpBearer ExternalSecret (no door has to
   # hand-couple bearerSecret.name) so a fresh Org's agenity MCP tools/list
   # surfaces create_application. Lockstep with products/agenity/chart.
-  version: "0.5.21"
+  # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP — the per-Org
+  # namespace is default-deny and the gate's ingress-only CNP left DNS + the
+  # Keycloak token exchange dropped, 500ing every OAuth callback after login.
+  version: "0.5.22"
   visibility: listed
   card:
     title: "Agenity"
@@ -5980,7 +5983,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.21
+    version: 0.5.22
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

The per-Org `bp-agenity` oidc-gate companion ships an **ingress-only** CiliumNetworkPolicy (`oidc-gate-<cid>-gateway-ingress`) into a namespace that is default-deny in both directions. The gate pod therefore cannot resolve cluster DNS, its Keycloak token-exchange dial times out, and **every OAuth callback 500s after a successful login**. Live on hw292 Org `uatco` (issue evidence, `oauthproxy.go:881`):

```
Error redeeming code during OAuth2 callback: token exchange failed:
Post "http://keycloak.keycloak.svc.cluster.local/realms/sovereign/protocol/openid-connect/token":
dial tcp: lookup keycloak.keycloak.svc.cluster.local on 10.96.0.10:53: i/o timeout
```

Same class as the #4437 sso-bridge gap: ingress allowed, egress forgotten. The in-repo control is the agenity workload's own `cilium-egress-networkpolicy.yaml` (same chart, same namespace) — its pod resolves the same name fine because it HAS an egress CNP.

## Fix — products/agenity/chart 0.5.21 -> 0.5.22

`templates/oidc-gate.yaml` now renders a second CNP, `oidc-gate-<cid>-egress`, selecting the gate pod and allowing exactly its dial surface:

1. **kube-dns :53 UDP+TCP** (`dns matchPattern "*"`) — DNS is load-bearing once any egress policy attaches to the endpoint.
2. **Keycloak backchannel** (redeem/jwks/userinfo via `keycloakInternalURL`) — the Service port **and** the Pod target port 8080, because Cilium enforces post-DNAT and allowing only 80 drops the traffic (the #4437 port trap).
3. **The proxied agenity upstream** in the same namespace on `service.port`.
4. `toEntities:[world]:443` **only** when `keycloakInternalURL` is unset (public-discovery mode, #3844).

`toEndpoints`/`toEntities` only — an ipBlock/toCIDR never matches a ClusterMesh remote pod identity (#4439/#4656 class), so a CIDR-shaped allow would silently re-break the region whose Keycloak backend is remote. The render test enforces this structurally.

New values knobs: `oidcGate.networkPolicy.keycloakNamespace` / `keycloakPort` (lockstep with `keycloakInternalURL`).

## Tests

`tests/oidc-gate-companion-render.sh` extended — the egress assertions are scoped to the egress CNP document only (no vacuous cross-document matches) and run under the exact value shape the org-tenant gitops emitter generates (`networkPolicy.enabled=true`, `oidcGate` defaults), so the gated Case 1 render IS the generated-Org shape:

- egress CNP present with all three rule groups (kube-dns 53/UDP+TCP, keycloak ns 80+8080, upstream);
- world:443 fallback renders only when `keycloakInternalURL` is cleared;
- no `toCIDR`/`ipBlock` anywhere in the egress CNP (ClusterMesh guard);
- `networkPolicy.enabled=false` suppresses the egress CNP (vacuity check in both directions);
- pre-existing cases (cookie-secret wiring #5416, route suppression, fail-closed) unchanged and green.

## Lockstep (5-site check)

- `products/agenity/chart/Chart.yaml` -> 0.5.22 (+ changelog)
- `products/agenity/blueprint.yaml` -> 0.5.22
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` -> 0.5.22 (spec.version + source.version)
- `blueprints.json` + `catalog.generated.ts` regenerated via `build-catalog.mjs`
- bp-agenity has **no bootstrap-kit slot pin** (per-Org chart); the org-gitops `agenityChartConstraint` (`>=0.5.0 <0.6.0`) already admits 0.5.22 — no generator change needed.

## Gates

- `bash products/agenity/chart/tests/oidc-gate-companion-render.sh` — PASS (all cases)
- `helm lint products/agenity/chart` — PASS (0 failed)
- `bash scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)
- `bash scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs in sync)
- `products/catalyst/bootstrap/api`: `go build ./...` + `go test ./...` — PASS (28 pkgs ok, incl. the full handler suite)
- `products/catalyst/bootstrap/ui`: `npm run build` — PASS; `npx vitest run` — 1998 passed, 9 failed, and the same 9 fail identically on clean origin/main (verified via stash), none in catalog-consuming paths — pre-existing, unrelated
- No Service/port changes outside 53/80/8080/443 — nothing NodePort-shaped anywhere in the diff (§854)

Branch note: mid-session origin/main was itself uncompilable in `bootstrap/api` (the #5535/#5592 merge race); main fixed it in #5619 (`ef2d59767`) and this branch is rebased on top — this PR carries **no** Go source change, only the regenerated `blueprints.json`.

## Runtime proof pending

Chart-render proof only in this PR. The runtime walk (fresh browser -> `https://agenity.uatco.omani.homes/` -> silent SSO -> callback 200 -> workspace) lands on the issue after the 0.5.22 chart publishes and the Org HR reconciles; hw292's apiserver was unreachable from this worktree's vantage during authoring (bastion transit), so no live re-check was possible here.

Refs #5617 #4437 #3374 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
