### PR TITLE
fix(stalwart-tenant): §854 — disable nodePort allocation on SMTP/IMAP LB Services (0.1.14)

### DIFF
--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -56,7 +56,9 @@ spec:
   # webadmin stays in-cluster on `-web` with an optional default-off
   # `mailadmin.<slug>` HTTPRoute.
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.13
+  # 0.1.14 (#5615): §854 — allocateLoadBalancerNodePorts:false + nodePort: 0
+  # on the SMTP/IMAP LoadBalancer Services so the Kyverno guard admits them.
+  version: 0.1.14
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -175,7 +175,20 @@ name: bp-stalwart-tenant
 #   224/232 stayed red. Live-root-caused on hw228 walk-stranger: used 1600m/2000m
 #   with stalwart at 1000m. 500m is ample for an idle demo mailserver and frees
 #   the headroom openclaw needs to schedule. Refs #4272 #4307 #4292.
-version: 0.1.13
+#
+# 0.1.14 (#5615, 2026-08-04): §854 — the SMTP + IMAP LoadBalancer Services
+#   rendered WITHOUT allocateLoadBalancerNodePorts, so the apiserver silently
+#   allocated a nodePort per port and the Kyverno forbid-nodeport-service /
+#   loadbalancer-must-disable-nodeport-allocation guard DENIED the install at
+#   admission — per-Org mail never provisioned on a guard-enforcing Sovereign
+#   (live evidence: hw292 funnel Org uatco, HR InstallFailed/RetriesExceeded).
+#   Fix mirrors the in-tree control platform/powerdns/chart/templates/
+#   anycast-endpoint.yaml: (a) allocateLoadBalancerNodePorts: false on both
+#   Services when type=LoadBalancer; (b) explicit `nodePort: 0` on every port
+#   entry (#5348 — false alone only stops NEW allocations; an apply that OMITS
+#   nodePort never clears an existing one); (c) template `fail` on
+#   type=NodePort so an overlay can never opt back in. Refs #5615 #5348 #5088.
+version: 0.1.14
 appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/templates/service-imap.yaml
+++ b/platform/stalwart-tenant/chart/templates/service-imap.yaml
@@ -19,7 +19,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.imap.type }}
+  {{- $svcType := .Values.service.imap.type | default "LoadBalancer" }}
+  {{- if eq $svcType "NodePort" }}
+  {{- fail "bp-stalwart-tenant: service.imap.type=NodePort is FORBIDDEN (§854, #4765) — use LoadBalancer (Cilium LB-IPAM shared VIP) or ClusterIP" }}
+  {{- end }}
+  type: {{ $svcType }}
+  {{- if eq $svcType "LoadBalancer" }}
+  # 🛑 zero nodePorts, ever (§854, #5615): the LB VIP is served directly by
+  # the cloud-LB / Cilium LB-IPAM datapath — node:3xxxx must not exist.
+  # Without this field the apiserver silently allocates a nodePort per port
+  # and the Kyverno forbid-nodeport-service guard denies the install.
+  allocateLoadBalancerNodePorts: false
+  {{- end }}
   externalTrafficPolicy: {{ .Values.service.imap.externalTrafficPolicy }}
   selector:
     {{- include "bp-stalwart-tenant.selectorLabels" . | nindent 4 }}
@@ -28,8 +39,19 @@ spec:
       port: {{ .Values.service.imap.ports.imaps }}
       targetPort: imaps
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      # 🛑 #5348: state ZERO explicitly — omitting nodePort is NOT enough.
+      # allocateLoadBalancerNodePorts:false only stops NEW allocations; an
+      # apply that OMITS nodePort leaves an existing allocation in place.
+      # `nodePort: 0` is the release sentinel the apiserver clears on apply,
+      # and the inert value the repo guard deliberately ignores.
+      nodePort: 0
+      {{- end }}
     - name: imap
       port: {{ .Values.service.imap.ports.imap }}
       targetPort: imap
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
 {{- end }}

--- a/platform/stalwart-tenant/chart/templates/service-smtp.yaml
+++ b/platform/stalwart-tenant/chart/templates/service-smtp.yaml
@@ -20,7 +20,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.smtp.type }}
+  {{- $svcType := .Values.service.smtp.type | default "LoadBalancer" }}
+  {{- if eq $svcType "NodePort" }}
+  {{- fail "bp-stalwart-tenant: service.smtp.type=NodePort is FORBIDDEN (§854, #4765) — use LoadBalancer (Cilium LB-IPAM shared VIP) or ClusterIP" }}
+  {{- end }}
+  type: {{ $svcType }}
+  {{- if eq $svcType "LoadBalancer" }}
+  # 🛑 zero nodePorts, ever (§854, #5615): the LB VIP is served directly by
+  # the cloud-LB / Cilium LB-IPAM datapath — node:3xxxx must not exist.
+  # Without this field the apiserver silently allocates a nodePort per port
+  # and the Kyverno forbid-nodeport-service guard denies the install.
+  allocateLoadBalancerNodePorts: false
+  {{- end }}
   externalTrafficPolicy: {{ .Values.service.smtp.externalTrafficPolicy }}
   selector:
     {{- include "bp-stalwart-tenant.selectorLabels" . | nindent 4 }}
@@ -29,12 +40,26 @@ spec:
       port: {{ .Values.service.smtp.ports.smtp }}
       targetPort: smtp
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      # 🛑 #5348: state ZERO explicitly — omitting nodePort is NOT enough.
+      # allocateLoadBalancerNodePorts:false only stops NEW allocations; an
+      # apply that OMITS nodePort leaves an existing allocation in place.
+      # `nodePort: 0` is the release sentinel the apiserver clears on apply,
+      # and the inert value the repo guard deliberately ignores.
+      nodePort: 0
+      {{- end }}
     - name: submission
       port: {{ .Values.service.smtp.ports.submission }}
       targetPort: submission
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
     - name: submissions
       port: {{ .Values.service.smtp.ports.submissions }}
       targetPort: submissions
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
 {{- end }}

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T19:51:09.140Z",
+  "generatedAt": "2026-08-03T20:34:46.711Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4960,7 +4960,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5095,7 +5095,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2735,7 +2735,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.13"
+  version: "0.1.14"
   visibility: listed
   card:
     title: "Stalwart (per-Organization)"
@@ -2776,7 +2776,7 @@ is event-driven (ADR-0003 §3).
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-stalwart-tenant
-    version: "0.1.13"
+    version: "0.1.14"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## What

`bp-stalwart-tenant` 0.1.13 rendered its SMTP and IMAP Services as `type: LoadBalancer` with **no** `allocateLoadBalancerNodePorts`, so the apiserver silently allocated a nodePort per port and the Kyverno `forbid-nodeport-service / loadbalancer-must-disable-nodeport-allocation` guard denied the install at admission — per-Org mail never provisioned on a guard-enforcing Sovereign. Live evidence on hw292 (funnel Org `uatco`): `HelmRelease uatco/uatco-mail-rtz-a Ready=False InstallFailed/RetriesExceeded`, both Services blocked by the webhook.

This chart bump (0.1.14) applies the in-tree control pattern that passes the guard, `platform/powerdns/chart/templates/anycast-endpoint.yaml`:

1. `allocateLoadBalancerNodePorts: false` on both Services when `type=LoadBalancer`.
2. Explicit `nodePort: 0` on **every** port entry (#5348 — `false` alone only stops NEW allocations; an apply that OMITS `nodePort` never clears an existing one; `0` is the release sentinel the apiserver clears on apply, and the inert value `scripts/check-no-nodeports.sh` deliberately ignores).
3. Template `fail` on `type=NodePort` so an overlay can never opt back in (§854, #4765).

Both fields are gated on `LoadBalancer` so a `ClusterIP` overlay still renders a valid Service (control render verified: 0 occurrences of either field under ClusterIP).

## Rendered Service (default values, `helm template`)

```yaml
# Source: bp-stalwart-tenant/templates/service-smtp.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-render-bp-stalwart-tenant-smtp
  labels:
    helm.sh/chart: bp-stalwart-tenant-0.1.14
    catalyst.openova.io/exposure: public-mail
spec:
  type: LoadBalancer
  allocateLoadBalancerNodePorts: false
  externalTrafficPolicy: Local
  selector:
    app.kubernetes.io/name: bp-stalwart-tenant
    app.kubernetes.io/instance: test-render
  ports:
    - name: smtp
      port: 25
      targetPort: smtp
      protocol: TCP
      nodePort: 0
    - name: submission
      port: 587
      targetPort: submission
      protocol: TCP
      nodePort: 0
    - name: submissions
      port: 465
      targetPort: submissions
      protocol: TCP
      nodePort: 0
```

```yaml
# Source: bp-stalwart-tenant/templates/service-imap.yaml
spec:
  type: LoadBalancer
  allocateLoadBalancerNodePorts: false
  externalTrafficPolicy: Local
  ports:
    - name: imaps
      port: 993
      targetPort: imaps
      protocol: TCP
      nodePort: 0
    - name: imap
      port: 143
      targetPort: imap
      protocol: TCP
      nodePort: 0
```

(comment lines elided from the snippets; full render carries the §854/#5348 rationale comments)

## Lockstep (chart 0.1.13 -> 0.1.14)

| Site | File | Change |
|---|---|---|
| 1 | `platform/stalwart-tenant/chart/Chart.yaml` | `version: 0.1.14` + changelog entry |
| 2 | `platform/stalwart-tenant/blueprint.yaml` | `spec.version: 0.1.14` |
| 3 | `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` | `spec.version: "0.1.14"` |
| 4 | `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` | `source.version: "0.1.14"` |
| 5 | `clusters/_template/bootstrap-kit/` | no slot exists for this per-Org chart — `check-bootstrap-kit-pin-sync.sh` reports it in the 30 "not in the bootstrap kit" charts; the per-Org HR generators resolve `version: "*"` / env-supplied pins, so nothing else pins 0.1.13 |

## Gates run

- `helm lint platform/stalwart-tenant/chart` — PASS (0 failed)
- `helm template` default values — both Services carry `allocateLoadBalancerNodePorts: false` + `nodePort: 0` (snippet above)
- `helm template --set service.{smtp,imap}.type=ClusterIP` — 0 occurrences of either LB-only field (vacuity control)
- `helm template --set service.{smtp,imap}.type=NodePort` — template FAILS with the §854 message (both templates)
- `scripts/check-no-nodeports.sh` — PASS (Phase 1 static scan + Phase 2 rendered-output scan; `nodePort: 0` is the guard's inert sentinel)
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs in sync)
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)
- `tests/e2e/bootstrap-kit` `go test ./...` — ok (includes `TestBootstrapKit_BlueprintVersionLockstepSweep`, `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts`, `TestCatalogSeed_DisplayVersionNotBehindDeliveryPin`)

## Not addressed here (disclosed)

The same hw292 install surfaced a secondary defect — the Stalwart StatefulSet pod stuck `ContainerCreating` on `secret "stalwart-tls" not found`. That is a cert-materialisation ordering question (chart `certificate.yaml` vs reflection), independent of the §854 admission denial this PR fixes, and it only manifests after the Services are admitted. It stays tracked on #5615.

Note on region asymmetry (#5591): with `forbid-nodeport-service` Enforce in region-a but Audit in region-b, the 0.1.13 chart would have been silently ADMITTED with open nodePorts had the install landed in region-b — this fix closes the chart side regardless of where the policy split lands.

Refs #5615 #5348 #5088 #4765 #5591 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
