### PR TITLE
fix(console): four source defects behind the fail-open vitest gate — build-ui green again (Refs #5626)

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -88,20 +88,24 @@ jobs:
           # nobody noticing. Its own comment says the assertion "has never
           # run green".
           #
-          # Ratcheted: the gate now FAILS on any failing test file except
-          # the one explicitly allowlisted below. A new red test breaks the
-          # build; the known one stays visible and tracked.
+          # Ratcheted: the gate FAILS on any failing test file except those
+          # explicitly allowlisted below. A new red test breaks the build.
           #
-          # KNOWN_RED — each entry needs an owning issue and a reason:
-          #   SettingsPage.test.tsx — the Members link renders bare `/users`
-          #     instead of `/provision/$id/users`. The component serves BOTH
-          #     the mothership route and the chroot `/settings` (where
-          #     deploymentId is empty), so hardcoding the scoped path yields
-          #     `/provision//users` on every chroot Sovereign. The correct
-          #     shape is the open route-gating decision in #5401 (SECURITY:
-          #     per-Org /settings exposes the Sovereign operator panel), so
-          #     the fix belongs there, not here.
-          KNOWN_RED='SettingsPage.test.tsx'
+          # KNOWN_RED — each entry needs an owning issue and a reason.
+          # Currently EMPTY: the suite is fully green.
+          #
+          # The last entry was SettingsPage.test.tsx (the Members link
+          # rendered bare `/users` instead of `/provision/$id/users`). It is
+          # fixed — SettingsPage picks the link form from the presence of
+          # the `:deploymentId` path param, so the mothership route gets the
+          # scoped target and the chroot Sovereign keeps the root-relative
+          # one. Do not re-add an entry to make a red file pass; an
+          # allowlisted file is a file nothing is watching.
+          #
+          # The value is used as a `case` glob, and an empty glob is a bash
+          # syntax error — so "allowlist nothing" is spelled as a sentinel
+          # that can never equal a basename, not as an empty string.
+          KNOWN_RED='__no_known_red__'
 
           set +e
           npm test 2>&1 | tee /tmp/vitest-out.txt
@@ -143,7 +147,7 @@ jobs:
           UNEXPECTED=""
           for f in ${FAILED_FILES}; do
             case "$(basename "$f")" in
-              ${KNOWN_RED}) echo "KNOWN-RED (tracked, #5401): $f" ;;
+              ${KNOWN_RED}) echo "KNOWN-RED (tracked): $f" ;;
               *)            UNEXPECTED="${UNEXPECTED} $f" ;;
             esac
           done

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.test.tsx
@@ -44,7 +44,11 @@ vi.mock('@/shared/lib/detectMode', () => ({
 
 // Stub the OIDC module — initiateLogin must NEVER be called from this
 // layout post-#1089. We export it as a spy so we can assert that.
-const initiateLoginSpy = vi.fn<(fqdn: string) => Promise<void>>()
+// The options argument is forwarded, not dropped: `{ prompt: 'none' }` is
+// the difference between an invisible re-auth and Keycloak rendering an
+// interactive login wall, so a spy that only records the FQDN cannot tell
+// the two apart.
+const initiateLoginSpy = vi.fn<(fqdn: string, opts?: { prompt?: string }) => Promise<void>>()
 const initiateLogoutSpy = vi.fn<(fqdn: string) => void>()
 const silentRefreshSpy = vi.fn<(fqdn: string) => Promise<unknown>>()
 const loadTokensSpy = vi.fn<() => unknown>()
@@ -56,7 +60,7 @@ vi.mock('@/shared/lib/oidc', () => ({
   loadTokens: () => loadTokensSpy(),
   isTokenExpired: () => true,
   silentRefresh: (fqdn: string) => silentRefreshSpy(fqdn),
-  initiateLogin: (fqdn: string) => initiateLoginSpy(fqdn),
+  initiateLogin: (fqdn: string, opts?: { prompt?: string }) => initiateLoginSpy(fqdn, opts),
   initiateLogout: (fqdn: string) => initiateLogoutSpy(fqdn),
   parseJWTClaims: () => ({ email: 'kc-user@example.com', name: 'KC User' }),
   getRequiredActions: () => [],
@@ -89,6 +93,11 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 
 // Now safe to import the SUT.
 import { SovereignConsoleLayout } from './SovereignConsoleLayout'
+// The silent-SSO contract constants come from the router module the SUT
+// itself lazy-imports — read them rather than restating the values, so a
+// change to the grace period or the guard key can never silently
+// desynchronise this suite from the code under test.
+import { SILENT_SSO_GUARD_KEY, SILENT_SSO_NAV_GRACE_MS } from '../router'
 
 /**
  * Stub `window.location` so we can observe redirect targets without
@@ -117,6 +126,16 @@ beforeEach(() => {
   silentRefreshSpy.mockClear()
   loadTokensSpy.mockClear()
   loadTokensSpy.mockReturnValue(null)
+  // jsdom hands every test in this file the SAME window, so sessionStorage
+  // is shared state. Two keys the SUT writes are scenario-defining:
+  // `catalyst:authed` (contract A's cookie path sets it) and the silent-SSO
+  // one-shot guard. Leaking either makes a later test model a DIFFERENT
+  // scenario than its title claims — contract B ("no sessionStorage
+  // tokens", i.e. an anonymous visitor) would inherit contract A's marker
+  // and be read as a session EXPIRY instead. Real browsers scope
+  // sessionStorage per tab, so a fresh anonymous visit genuinely has
+  // neither key; clear both between tests.
+  sessionStorage.clear()
 })
 
 afterEach(() => {
@@ -275,4 +294,65 @@ describe('SovereignConsoleLayout — #1089 anon redirect to OpenOva /login', () 
     expect(target).toContain('/login?next=')
     expect(initiateLoginSpy).not.toHaveBeenCalled()
   })
+})
+
+/* ── Contract E: cookie EXPIRY still runs the silent leg (#5460) ───── */
+
+/**
+ * The counterpart to contract B. B asserts the silent Keycloak leg does
+ * NOT fire for an anonymous visitor; on its own that is a negative
+ * assertion, and a negative assertion passes just as happily if the leg
+ * were deleted outright. This block pins the other direction so the
+ * discriminator is verified both ways: a stale `catalyst:authed` marker
+ * means this tab HELD a live console session, so a 401 is a cookie
+ * EXPIRY and the silent prompt=none re-mint is exactly right there.
+ *
+ * It also pins the safety net. `attemptSilentSovereignSSO` returning true
+ * means "the browser is being navigated to Keycloak", which normally ends
+ * this document. When that navigation never commits (auth host
+ * unreachable) the layout must not leave the operator on the
+ * "Authenticating…" spinner forever — after the grace period it re-arms
+ * the one-shot guard and falls back to the PIN page, mirroring
+ * rootBeforeLoad.
+ */
+describe('SovereignConsoleLayout — #5460 cookie-expiry silent SSO', () => {
+  it('with a stale catalyst:authed marker, runs the silent prompt=none leg, then falls back to /login when the KC navigation never commits', async () => {
+    const replaceSpy = stubLocation('/dashboard')
+    sessionStorage.setItem('catalyst:authed', '1')
+    vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      if (url.endsWith('/v1/whoami')) {
+        return new Response(JSON.stringify({ error: 'unauthenticated' }), { status: 401 })
+      }
+      return new Response(null, { status: 404 })
+    })
+    loadTokensSpy.mockReturnValue(null)
+
+    render(<SovereignConsoleLayout />)
+
+    // The silent leg fired — and truly silently: `prompt: 'none'` is what
+    // stops Keycloak rendering the interactive PIN wall during what is
+    // supposed to be an invisible re-auth.
+    await waitFor(() => {
+      expect(initiateLoginSpy).toHaveBeenCalled()
+    })
+    expect(initiateLoginSpy.mock.calls[0]![1]).toEqual({ prompt: 'none' })
+
+    // The stale marker is revoked either way — it must never outlive the
+    // session it claims.
+    expect(sessionStorage.getItem('catalyst:authed')).toBeNull()
+
+    // initiateLogin is stubbed here, so the document never actually
+    // unloads — the same shape as an auth host that fails to answer.
+    // The grace-period safety net must still land the operator on /login
+    // and re-arm the one-shot guard for a later genuine expiry.
+    await waitFor(
+      () => {
+        expect(replaceSpy).toHaveBeenCalled()
+      },
+      { timeout: SILENT_SSO_NAV_GRACE_MS + 4000 },
+    )
+    expect(replaceSpy.mock.calls[0]![0]).toContain('/login?next=')
+    expect(sessionStorage.getItem(SILENT_SSO_GUARD_KEY)).toBeNull()
+  }, SILENT_SSO_NAV_GRACE_MS + 12000)
 })

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
@@ -252,12 +252,38 @@ export function SovereignConsoleLayout() {
         //     the console session with no PIN form (the row-29 contract).
         //     The one-shot guard in attemptSilentSovereignSSO makes the
         //     genuinely-logged-out case land on /login exactly once.
-        try { sessionStorage.removeItem('catalyst:authed') } catch { /* private browsing */ }
-        const { attemptSilentSovereignSSO } = await import('../router')
-        if (await attemptSilentSovereignSSO()) {
-          // Navigation handed to Keycloak (window.location.replace inside
-          // initiateLogin) — keep the spinner while the document unloads.
-          return
+        //
+        // Duty 2 is scoped to the EXPIRY case the commit title names — a
+        // stale `catalyst:authed` marker is the evidence that this tab
+        // HELD a live console session, so re-minting it silently is
+        // meaningful. A visitor with no marker never authenticated here:
+        // rootBeforeLoad's marker fast-path (`if (hasCatalystSession())
+        // return`) did NOT fire for them, so the gate already ran its own
+        // whoami probe and its own silent leg. Repeating it from the
+        // layout is not a second chance, it is a duplicate — and it broke
+        // the #1089 contract, which is that an anonymous chroot visitor
+        // lands on the OpenOva PIN page and the Keycloak surface is never
+        // touched. It also burned the one-shot guard on the way, so the
+        // FIRST anonymous page load left the console on the
+        // "Authenticating…" spinner and only the second reached /login.
+        let hadSessionMarker = false
+        try {
+          hadSessionMarker = sessionStorage.getItem('catalyst:authed') === '1'
+          sessionStorage.removeItem('catalyst:authed')
+        } catch { /* private browsing */ }
+        if (hadSessionMarker) {
+          const { attemptSilentSovereignSSO, SILENT_SSO_NAV_GRACE_MS, SILENT_SSO_GUARD_KEY } =
+            await import('../router')
+          if (await attemptSilentSovereignSSO()) {
+            // Navigation handed to Keycloak (window.location.replace inside
+            // initiateLogin) — keep the spinner while the document unloads.
+            // Safety net, mirroring rootBeforeLoad: if the document
+            // navigation never commits (auth host unreachable), the console
+            // must not hang on the spinner forever. Re-arm the one-shot
+            // guard and fall through to the explicit /login.
+            await new Promise((resolve) => setTimeout(resolve, SILENT_SSO_NAV_GRACE_MS))
+            try { sessionStorage.removeItem(SILENT_SSO_GUARD_KEY) } catch { /* private browsing */ }
+          }
         }
         setAuthState({ status: 'unauthenticated' })
         redirectToLogin()

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.test.tsx
@@ -247,37 +247,37 @@ describe('SettingsPage — API tokens', () => {
 
 describe('SettingsPage — Members links to User Access', () => {
   /**
-   * 🛑 KNOWN-FAILING — this is a REAL defect, not a stale expectation.
-   * Do NOT "fix" it by relaxing the regex to `/users`.
+   * Regression guard — this WAS red on `main`, and it was a REAL defect,
+   * not a stale expectation. Do NOT "fix" it by relaxing the regex to
+   * `/users`.
    *
    * SettingsPage renders on BOTH the mothership route
    * (/provision/$deploymentId/settings) and the chroot Sovereign route
    * (/settings) — see the SettingsPage.tsx docstring at the useParams
-   * call. But the Members link hardcodes the chroot form:
+   * call. The Members link used to hardcode the chroot form:
    *
-   *     SettingsPage.tsx:399   to={`/users` as never}
+   *     to={`/users` as never}
    *
-   * The `as never` cast defeats TanStack Router's typed-route checking,
+   * The `as never` cast defeated TanStack Router's typed-route checking,
    * which is what would otherwise reject a target that can't resolve
-   * under the current route. Twenty lines later the SAME file uses the
+   * under the current route. Twenty lines later the SAME file used the
    * correct mode-safe pattern for its sibling CTA:
    *
-   *     SettingsPage.tsx:420-422
-   *       to="/decommission/$deploymentId" params={{ deploymentId }}
+   *     to="/decommission/$deploymentId" params={{ deploymentId }}
    *
    * Both routes are registered in the one tree — `/provision/$deploymentId/users`
-   * (router.tsx:1112) and the chroot `/users` under consoleLayoutRoute
-   * (router.tsx:1463-1466, mounted at router.tsx:2411). So on the
-   * mothership this link navigates into SovereignConsoleLayout, where
+   * and the chroot `/users` under consoleLayoutRoute. So on the
+   * mothership that link navigated into SovereignConsoleLayout, where
    * useResolvedDeploymentId has no :deploymentId param and falls back to
    * /sovereign/self — which that hook's own doc comment states 404s on a
-   * mothership host. Result: Members is a dead link on the mothership.
+   * mothership host. Members was a dead link on the mothership.
    *
-   * This assertion has never run green: the file threw on a missing
+   * The assertion had never run green: the file threw on a missing
    * QueryClient before reaching it, so the contradiction (present since
    * the earliest commit that has both files, a7fb48245) stayed masked.
-   * Fixing the link is a navigation behaviour change and overlaps the
-   * open route-gating decision in #5401, so it is left to that issue.
+   * SettingsPage now picks the link form from the presence of the
+   * `:deploymentId` PATH PARAM, so each route gets a target it can
+   * resolve and neither needs a cast.
    */
   it('Members link points at /provision/$id/users', async () => {
     renderSettings('d-test-1234')

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
@@ -145,6 +145,13 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
   const params = useParams({ strict: false }) as { deploymentId?: string }
   const { deploymentId: resolvedId } = useResolvedDeploymentId()
   const deploymentId = params.deploymentId ?? resolvedId ?? ''
+  // Which of the two routes are we actually mounted on? The presence of a
+  // `:deploymentId` PATH PARAM is the only honest signal — `deploymentId`
+  // above falls back to the resolver, which answers on both routes. Links
+  // to sibling pages must be built from this, because the mothership
+  // routes are `/provision/$deploymentId/*` while the chroot Sovereign
+  // serves the same pages at the domain root.
+  const scopedToProvisionRoute = Boolean(params.deploymentId)
 
   const store = useWizardStore()
 
@@ -395,13 +402,35 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
                 Operators are managed on the dedicated User Access page so role bindings, app
                 grants, and namespace scopes share one editor.
               </p>
-              <Link
-                to={`/users` as never}
-                className="mt-2 inline-flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] no-underline hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
-                data-testid="settings-members-link"
-              >
-                Open User Access →
-              </Link>
+              {/* Both User Access routes are registered in the one tree:
+                  `/provision/$deploymentId/users` (mothership) and the
+                  chroot `/users` under consoleLayoutRoute. This link used
+                  to hardcode the chroot form for both, so on the
+                  mothership it navigated into SovereignConsoleLayout with
+                  no :deploymentId param, where useResolvedDeploymentId
+                  falls back to /sovereign/self — which 404s on a
+                  mothership host. Members was a dead link there. Pick the
+                  form that matches the route we are mounted on rather
+                  than casting the target past the router's typed-route
+                  check. */}
+              {scopedToProvisionRoute ? (
+                <Link
+                  to="/provision/$deploymentId/users"
+                  params={{ deploymentId }}
+                  className="mt-2 inline-flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] no-underline hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+                  data-testid="settings-members-link"
+                >
+                  Open User Access →
+                </Link>
+              ) : (
+                <Link
+                  to="/users"
+                  className="mt-2 inline-flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] no-underline hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+                  data-testid="settings-members-link"
+                >
+                  Open User Access →
+                </Link>
+              )}
             </SectionCard>
 
             {/* 11. Danger zone */}

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.test.tsx
@@ -163,28 +163,29 @@ describe('component catalog', () => {
   })
 
   /**
-   * 🛑 KNOWN DEFECT — this test is EXPECTED TO FAIL on `main` and is left
-   * red deliberately. Do NOT relax it.
+   * Regression guard — this WAS red on `main`. Do NOT relax it.
    *
-   * `componentGroups.ts:536` overrides every component's `dependencies`
-   * with `depsFor(id)` from `src/data/blueprint-deps.generated.json`,
-   * which is generated from Flux `HelmRelease.dependsOn` names. Three of
-   * those names are bootstrap-kit HelmReleases that have NO ComponentDef
-   * in the wizard catalog, so they leak into the graph as dangling ids:
+   * `componentGroups.ts` overrides every component's `dependencies` with
+   * `depsFor(id)` from `src/data/blueprint-deps.generated.json`, which is
+   * generated from Flux `HelmRelease.dependsOn` names. Three of those
+   * names are bootstrap-kit HelmReleases that have NO ComponentDef in the
+   * wizard catalog, and they used to leak into the graph as dangling ids:
    *
    *   gateway-api  ← gitea, powerdns, harbor, keycloak, openbao, grafana
    *   reflector    ← external-dns, postgres
    *   spire        ← openbao
    *
-   * Operator-visible symptom: `computeDefaultSelection()` returns 48 ids,
-   * three of which (`gateway-api`, `reflector`, `spire`) have no card, no
-   * name and no logo anywhere in the wizard — yet they are written into
-   * `selectedComponents` and travel into the deployment payload, and the
-   * "Selected (N) of M" counter counts them.
+   * Operator-visible symptom was: `computeDefaultSelection()` returned 48
+   * ids, three of which (`gateway-api`, `reflector`, `spire`) had no card,
+   * no name and no logo anywhere in the wizard — yet they were written
+   * into `selectedComponents`, travelled into the deployment payload, and
+   * were counted by the "Selected (N) of M" counter.
    *
-   * Fix belongs in the catalog layer (filter `depsFor()` through the
-   * known-component id set, or give the three HelmReleases ComponentDefs)
-   * — NOT here.
+   * Fixed in the catalog layer: `resolveCatalogDependencies()` filters the
+   * resolved list through `CATALOG_COMPONENT_IDS`. The three HelmReleases
+   * are unconditional platform plumbing the bootstrap kit installs on
+   * every Sovereign whatever the operator picks, so they are deliberately
+   * card-less and dropping them from the wizard graph loses nothing.
    */
   it('every dependency points at a known component id', () => {
     const ids = new Set(ALL_COMPONENTS.map(c => c.id))
@@ -652,37 +653,31 @@ describe('cascading remove', () => {
 /* ── Tab 2: Always Included ───────────────────────────────────────── */
 
 /**
- * 🛑 KNOWN DEFECT pinned by this block (2 tests here + 2 in the
- * transitive-promotion block below are EXPECTED TO FAIL on `main`).
- * Do NOT relax them.
+ * Regression guard — 2 tests here + 2 in the transitive-promotion block
+ * below WERE red on `main`. Do NOT relax them.
  *
- * `StepComponents.tsx:637-644` (AlwaysIncludedTab) builds Tab 2 from
+ * `AlwaysIncludedTab` used to build Tab 2 from
  * `PRODUCTS.filter(product => product.tier === 'mandatory')` — i.e. it
- * keys visibility off the PRODUCT tier, not the COMPONENT tier. The
- * Foundation counter next to it (`StepComponents.tsx:773-775`) keys off
- * the COMPONENT tier (`ALL_COMPONENTS.filter(c => c.tier === 'mandatory')`).
- * The two disagree.
+ * keyed visibility off the PRODUCT tier, not the COMPONENT tier. The
+ * Foundation counter next to it keys off the COMPONENT tier
+ * (`ALL_COMPONENTS.filter(c => c.tier === 'mandatory')`). The two
+ * disagreed.
  *
  * `cnpg` and `postgres` are `tier: 'mandatory'` (promoted — the
  * unconditionally-mandatory gitea / harbor / keycloak depend on them)
- * but live in FABRIC, whose PRODUCT tier is 'recommended'
- * (componentGroups.ts:454). So they are filtered out of Tab 2, and Tab 1
- * already excludes them for being mandatory (StepComponents.tsx:768).
- * Net effect: CloudNative PG and PostgreSQL are installed on every
- * Sovereign but appear in NEITHER tab, and the tab reads
+ * but live in FABRIC, whose PRODUCT tier is 'recommended'. So they were
+ * filtered out of Tab 2, while Tab 1 already excludes them for being
+ * mandatory. Net effect: CloudNative PG and PostgreSQL were installed on
+ * every Sovereign but appeared in NEITHER tab, and the tab read
  * "Foundation (24)" while rendering 22 cards.
  *
- * The filter was added to stop KServe (then CORTEX-internal
+ * The product-tier filter existed to stop KServe (then CORTEX-internal
  * `tier: 'mandatory'`) showing under "Always Included" on Sovereigns that
- * never picked CORTEX — see the comment at StepComponents.tsx:628-635.
- * That root cause was independently fixed by demoting KServe to
- * `tier: 'recommended'` (componentGroups.ts:338), and CORTEX / RELAY /
- * INSIGHTS now carry zero mandatory components. The product-tier filter
- * therefore excludes exactly {cnpg, postgres} and nothing else — it is
- * now pure collateral damage.
- *
- * Fix belongs in AlwaysIncludedTab (filter on component tier, or on
- * "promoted from a raw-mandatory seed") — NOT here.
+ * never picked CORTEX. That guard is preserved: AlwaysIncludedTab now
+ * admits a component when it is mandatory in a mandatory-tier product OR
+ * when it appears in `TRANSITIVE_MANDATORY_PROMOTIONS` — something
+ * unconditional depends on it, so it ships either way. A family-internal
+ * raw-mandatory member is neither, so it still stays out.
  */
 describe('Tab 2 (Always Included) — read-only mandatory grid', () => {
   it('renders a card for every mandatory component', () => {
@@ -945,7 +940,7 @@ describe('transitive-mandatory promotion (issue #175 fix A)', () => {
     expect(screen.queryByTestId('component-card-cnpg')).toBeNull()
   })
 
-  // 🛑 EXPECTED TO FAIL — pins the AlwaysIncludedTab product-tier filter
+  // Regression guard — pins the AlwaysIncludedTab product-tier filter
   // defect documented above the "Tab 2 (Always Included)" describe block.
   it('cnpg DOES appear in Tab 2 ("Always Included")', () => {
     render(<StepComponents />)
@@ -964,10 +959,10 @@ describe('transitive-mandatory promotion (issue #175 fix A)', () => {
     expect(within(tab).queryByTestId('component-card-valkey')).toBeNull()
   })
 
-  // 🛑 EXPECTED TO FAIL — same AlwaysIncludedTab defect. The valkey
+  // Regression guard — same AlwaysIncludedTab defect. The valkey
   // assertion that used to sit here was dropped (valkey is no longer a
-  // promotion), so this now fails ONLY for the real reason: FABRIC has
-  // two promoted mandatory members and renders no section at all.
+  // promotion), so this covers ONLY the real reason it was red: FABRIC
+  // has two promoted mandatory members and used to render no section.
   it('promoted components are grouped under their owning product in Tab 2', () => {
     render(<StepComponents />)
     fireEvent.click(screen.getByTestId('tab-always'))
@@ -1014,37 +1009,37 @@ describe('product-family model (issue #175 fix B)', () => {
   })
 
   /**
-   * 🛑 KNOWN DEFECT — EXPECTED TO FAIL on `main`. Do NOT relax it, and do
+   * Regression guard — this WAS red on `main`. Do NOT relax it, and do
    * NOT "fix" it by deleting the expectation.
    *
    * The Specter → CORTEX product rule is operator-requested (issue #175:
    * "when Specter is selected all the Cortex family is required") and is
-   * still actively documented in the catalog in two places:
-   *   componentGroups.ts:261-275 — "Specter requires the entire CORTEX
+   * documented in the catalog in two places:
+   *   the Specter ComponentDef — "Specter requires the entire CORTEX
    *     family at runtime … selecting Specter adds the full CORTEX family
    *     even if the user never opens the CORTEX chip."
-   *   componentGroups.ts:442-446 — "Selecting the INSIGHTS product as a
+   *   the INSIGHTS Product entry — "Selecting the INSIGHTS product as a
    *     whole brings in Specter, which in turn pulls CORTEX through the
    *     component->product cascade chain."
-   * and componentGroups.ts:275 still literally declares
-   *   dependencies: ['bge','milvus','langfuse','vllm','kserve'].
-   *
-   * That literal is DEAD. componentGroups.ts:536 replaces it with
+   * It used to be written as a literal
+   *   dependencies: ['bge','milvus','langfuse','vllm','kserve']
+   * which was DEAD: RAW_COMPONENTS replaces `dependencies` with
    * `depsFor('specter')`, and there is no bp-specter HelmRelease, so
-   * Specter's dependencies are `[]`. Specter belongs to INSIGHTS
-   * (cascadeOnMemberSelection: false), so nothing else fires either.
+   * Specter's dependencies resolved to `[]`. Specter belongs to INSIGHTS
+   * (cascadeOnMemberSelection: false), so nothing else fired either.
    *
-   * Operator-visible symptom: ticking Specter (the AIOps brain) installs
-   * Specter alone — no vLLM, no Milvus, no BGE, no LangFuse, no KServe —
-   * i.e. an AIOps component with no AI runtime under it.
+   * Operator-visible symptom was: ticking Specter (the AIOps brain)
+   * installed Specter alone — no vLLM, no Milvus, no BGE, no LangFuse, no
+   * KServe — i.e. an AIOps component with no AI runtime under it.
    *
    * This is NOT the same class as the other #652 casualties: those were
    * install-ordering edges the founder ruled Flux owns. This is a
-   * product-family SELECTION rule, which the wizard models separately via
-   * `Product.familyDependencies` / `cascadeOnMemberSelection` —
-   * untouched by #652. The rule was simply encoded in the wrong layer and
-   * is now unimplemented. Fix belongs in the PRODUCTS table
-   * (componentGroups.ts:434-448), not here.
+   * product-family SELECTION rule, which Flux has no opinion on. It now
+   * lives in the layer that survives the Flux override: the Specter
+   * ComponentDef declares `familyRequires: ['cortex']`, and
+   * `resolveCatalogDependencies()` expands it from the PRODUCTS table at
+   * module load — so the member list can never drift from the CORTEX
+   * family definition, and no per-component id list is hand-maintained.
    */
   it('Specter component-level deps cover the major CORTEX runtime members', () => {
     const specter = findComponent('specter')!
@@ -1199,10 +1194,10 @@ describe('addComponent → product family cascade (CORTEX)', () => {
     }
   })
 
-  // 🛑 EXPECTED TO FAIL — pins the Specter → CORTEX defect documented in
+  // Regression guard — pins the Specter → CORTEX defect documented in
   // full above the "Specter component-level deps" test. The cascade
-  // MECHANISM is fine (the BGE test directly above proves it fires); the
-  // Specter → CORTEX edge is what went missing.
+  // MECHANISM was always fine (the BGE test directly above proves it
+  // fires); the Specter → CORTEX edge is what had gone missing.
   it('selecting Specter cascades to every CORTEX component', () => {
     useWizardStore.setState({ selectedComponents: [...MANDATORY_COMPONENT_IDS].sort() })
     useWizardStore.getState().addComponent('specter')

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.tsx
@@ -55,6 +55,7 @@ import {
   ALL_COMPONENTS,
   GROUPS,
   PRODUCTS,
+  TRANSITIVE_MANDATORY_PROMOTIONS,
   findComponent,
   componentsByProduct,
   resolveTransitiveDependents,
@@ -625,21 +626,42 @@ function AlwaysIncludedTab({ groups: _groups, cols }: { groups: readonly GroupDe
   // owning product section rather than vanishing into Tab 1's pool. Hide
   // any product that has zero mandatories.
   //
-  // Critical filter: only PRODUCT FAMILIES with `tier: 'mandatory'`
-  // (PILOT, SPINE, SURGE, SILO, GUARDIAN) contribute their mandatories
-  // here. Opt-in families (CORTEX/RELAY tier:optional, INSIGHTS/FABRIC
-  // tier:recommended) carry `tier: 'mandatory'` components INTERNAL to
-  // their family — those are mandatory ONLY IF the family is selected.
-  // Without this filter, KServe (CORTEX-internal mandatory) misleadingly
-  // appears in "Always Included" even on Sovereigns that don't pick
-  // CORTEX. Caught on omantel.biz wizard 2026-05-06.
+  // Critical filter: a component belongs here only when it is installed
+  // UNCONDITIONALLY. Two ways to earn that:
+  //
+  //   a) it is `tier: 'mandatory'` inside a PRODUCT FAMILY that is itself
+  //      `tier: 'mandatory'` (PILOT, SPINE, SURGE, SILO, GUARDIAN), or
+  //   b) it was PROMOTED to mandatory by the transitive-closure walk —
+  //      i.e. something unconditional depends on it, so it ships whether
+  //      or not the operator picks its family.
+  //
+  // Opt-in families (CORTEX/RELAY tier:optional, INSIGHTS/FABRIC
+  // tier:recommended) may carry `tier: 'mandatory'` components INTERNAL to
+  // their family — mandatory ONLY IF the family is selected. Clause (b)
+  // does not admit those: KServe (the CORTEX-internal mandatory caught on
+  // the omantel.biz wizard 2026-05-06) is not a promotion, so it still
+  // stays out of "Always Included".
+  //
+  // The previous filter keyed on the PRODUCT tier alone, which is a
+  // different question from the one the Foundation counter below asks
+  // (`ALL_COMPONENTS.filter(c => c.tier === 'mandatory')`, component tier).
+  // The two disagreed on exactly {cnpg, postgres}: promoted to mandatory
+  // because the unconditional gitea / harbor / keycloak dependsOn them,
+  // but living in FABRIC (product tier 'recommended'). Tab 1 already
+  // excludes them for being mandatory, so CloudNative PG and PostgreSQL
+  // were installed on every Sovereign while appearing in NEITHER tab, and
+  // the counter read "Foundation (24)" over 22 rendered cards.
   void _groups // keep prop for callsite back-compat (#175 cleanup deferred)
   const productSections = useMemo(() => {
+    const promoted = new Set(TRANSITIVE_MANDATORY_PROMOTIONS)
     return PRODUCTS
-      .filter((product) => product.tier === 'mandatory')
       .map((product) => ({
         product,
-        mandatories: componentsByProduct(product.id).filter(c => c.tier === 'mandatory'),
+        mandatories: componentsByProduct(product.id).filter(
+          (c) =>
+            c.tier === 'mandatory' &&
+            (product.tier === 'mandatory' || promoted.has(c.id)),
+        ),
       }))
       .filter((s) => s.mandatories.length > 0)
   }, [])

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.ts
@@ -85,6 +85,28 @@ export interface ComponentDef {
    */
   dependencies?: string[]
   /**
+   * Product families this component requires at runtime — a product-family
+   * SELECTION rule, expressed as PRODUCTS ids.
+   *
+   * This is a DIFFERENT graph from `dependencies`. `dependencies` is the
+   * Flux install-ordering graph and is overwritten at module load from
+   * `blueprint-deps.generated.json` (the founder directive: "the single
+   * source of truth for the dependencies is flux"). A component that has
+   * no `bp-<id>` HelmRelease therefore has no Flux opinion at all, and a
+   * hand-written `dependencies` literal on it is silently discarded.
+   *
+   * `familyRequires` is the layer that survives, because Flux has nothing
+   * to say about it: it is the wizard's own product model. At module load
+   * each entry expands to the member ids of the named product (read from
+   * PRODUCTS — no second hand-maintained id list) and is merged into the
+   * component's resolved `dependencies`, so the existing cascade / removal
+   * resolvers pick it up unchanged.
+   *
+   * Currently one user: Specter (issue #175 — "when Specter is selected all
+   * the Cortex family is required").
+   */
+  familyRequires?: string[]
+  /**
    * URL to the brand asset vendored under
    * `products/catalyst/bootstrap/ui/public/component-logos/<id>.{svg,png}`.
    * Defaults to `/component-logos/<id>.svg` per id when omitted. Set
@@ -262,17 +284,20 @@ export const GROUPS: GroupDef[] = [
       // dependency-model feedback (issue #175): Specter requires the
       // entire CORTEX family at runtime — vector store (Milvus),
       // embeddings (BGE), LLM observability (LangFuse), serving (KServe),
-      // inference (vLLM). The relationship is encoded BOTH at component
-      // level (specter → bge, milvus, langfuse, vllm, kserve) AND at
-      // product level (CORTEX is auto-selected when any CORTEX member
-      // appears, and Specter's component deps include CORTEX members so
-      // selecting Specter triggers the CORTEX product cascade through
-      // the store's `addComponent` path). Result: selecting Specter adds
-      // the full CORTEX family even if the user never opens the CORTEX
-      // chip.
+      // inference (vLLM). Result: selecting Specter adds the full CORTEX
+      // family even if the user never opens the CORTEX chip.
+      //
+      // Declared as `familyRequires: ['cortex']`, NOT as a `dependencies`
+      // literal. There is no bp-specter HelmRelease, so `depsFor('specter')`
+      // returns [] and any `dependencies` literal here is discarded at
+      // module load — which is exactly how this rule silently stopped
+      // working: the catalog kept documenting it while the wizard
+      // installed Specter alone, an AIOps brain with no AI runtime under
+      // it. `familyRequires` expands from PRODUCTS at load time, so the
+      // member list can never drift from the CORTEX family definition.
       // Specter is an OpenOva-internal component without a finalized
       // upstream brand mark — render the letter-mark fallback (#173).
-      { id: 'specter',       name: 'Specter',       desc: 'Anomaly detection and root-cause correlation over telemetry', tier: 'optional', dependencies: ['bge', 'milvus', 'langfuse', 'vllm', 'kserve'], logoUrl: null },
+      { id: 'specter',       name: 'Specter',       desc: 'Anomaly detection and root-cause correlation over telemetry', tier: 'optional', familyRequires: ['cortex'], logoUrl: null },
     ],
   },
   /* ── À LA CARTE ───────────────────────────────────────────────── */
@@ -523,17 +548,55 @@ export interface ComponentEntry extends ComponentDef {
 // bootstrap-kit/*.yaml HelmRelease.dependsOn, parsed by
 // scripts/generate-blueprint-deps.sh into blueprint-deps.generated.json.
 // Hardcoded `dependencies: [...]` arrays in the GROUPS literal above are
-// IGNORED at module load — see import below.
+// IGNORED at module load — see import below. Product-family selection
+// rules are NOT install ordering and Flux has no opinion on them, so they
+// are declared as `familyRequires: ['<product-id>']` and expanded from
+// PRODUCTS here instead.
 import { depsFor as _bpDepsFor } from '../../../data/blueprintDeps'
+
+/**
+ * Every id that has a card in the wizard catalog. The Flux dependency
+ * graph is drawn from the bootstrap kit, which reconciles HelmReleases the
+ * wizard deliberately does not offer as cards (`bp-gateway-api`,
+ * `bp-reflector`, `bp-spire` — unconditional platform plumbing, installed
+ * on every Sovereign whatever the operator picks). Those names used to
+ * leak into `dependencies` as dangling ids: `computeDefaultSelection()`
+ * emitted `gateway-api` / `reflector` / `spire` into `selectedComponents`
+ * (and from there into the deployment payload) with no card, no name and
+ * no logo to resolve them, and the "Selected (N) of M" counter counted
+ * them. Dropping them loses nothing operationally — the bootstrap kit
+ * installs them regardless of the wizard — and keeps the graph closed
+ * over the catalog so every dep resolves to a real card.
+ */
+const CATALOG_COMPONENT_IDS: ReadonlySet<string> = new Set(
+  GROUPS.flatMap(g => g.components.map(c => c.id)),
+)
+
+/**
+ * Resolved dependency list for one component:
+ *   Flux install-ordering edges (canonical, from HelmRelease.dependsOn)
+ *   ∪ the members of every product named in `familyRequires`
+ *   minus self-references and ids with no card in the catalog.
+ */
+function resolveCatalogDependencies(c: ComponentDef): string[] {
+  const familyMembers = (c.familyRequires ?? []).flatMap(
+    productId => PRODUCTS.find(p => p.id === productId)?.components ?? [],
+  )
+  return [...new Set([..._bpDepsFor(c.id), ...familyMembers])].filter(
+    id => id !== c.id && CATALOG_COMPONENT_IDS.has(id),
+  )
+}
 
 export const RAW_COMPONENTS: ComponentEntry[] = GROUPS.flatMap(g =>
   g.components.map(c => ({
     ...c,
     // Override every component's `dependencies` with the Flux-canonical
-    // list from blueprint-deps.generated.json. Components without a
-    // bp-* HelmRelease (e.g. opentofu, vcluster — Phase-0 fixtures, not
-    // bootstrap-kit reconciled) fall back to an empty list.
-    dependencies: _bpDepsFor(c.id),
+    // list from blueprint-deps.generated.json, merged with the
+    // product-family expansion of `familyRequires` (the graph Flux has no
+    // opinion on). Components without a bp-* HelmRelease (e.g. opentofu,
+    // vcluster — Phase-0 fixtures, not bootstrap-kit reconciled) and
+    // without a `familyRequires` fall back to an empty list.
+    dependencies: resolveCatalogDependencies(c),
     // Default logo path: vendored SVG keyed by component id, prefixed
     // with the Vite `base` so the URL works behind /sovereign/ (prod)
     // or / (dev / test). `null` in the source overrides the default


### PR DESCRIPTION
Refs #5626

`build-ui` was red on `main`, so `deploy` never ran and no `catalyst-ui` / `catalyst-api` image published — every merged console fix stranded merged-not-delivered. The vitest gate had swallowed failures since the 2026-06-02 emergency unblock; #5553 removed the `|| echo` and #5595 fixed the ANSI-stripping, and four accumulated console defects surfaced at once.

**All four are SOURCE defects. No test was deleted, skipped, or loosened.** Each failing test carried a docblock naming the defect and where the fix belongs; this PR follows those pointers.

## Per-failure verdict

| Failing test | Wrong side | Fix |
|---|---|---|
| `component catalog > every dependency points at a known component id` | SOURCE | `resolveCatalogDependencies()` filters the resolved list through `CATALOG_COMPONENT_IDS`, dropping `gateway-api` / `reflector` / `spire` |
| `Tab 2 > renders a card for every mandatory component` | SOURCE | `AlwaysIncludedTab` admits a component mandatory in a mandatory-tier product **or** present in `TRANSITIVE_MANDATORY_PROMOTIONS` |
| `Tab 2 > groups mandatory components by product` | SOURCE | same |
| `transitive-mandatory promotion > cnpg DOES appear in Tab 2` | SOURCE | same |
| `transitive-mandatory promotion > promoted components are grouped under their owning product` | SOURCE | same |
| `product-family model > Specter component-level deps cover the major CORTEX runtime members` | SOURCE | Specter declares `familyRequires: ['cortex']`; `resolveCatalogDependencies()` expands it from `PRODUCTS` |
| `addComponent -> product family cascade (CORTEX) > selecting Specter cascades to every CORTEX component` | SOURCE | same — the cascade mechanism was always fine, the Specter edge had gone missing |
| `#1089 anon redirect > on /whoami 401 + no sessionStorage tokens, redirects to /login?next=` | SOURCE | the #5460 silent-SSO leg is scoped to the cookie-expiry case (stale `catalyst:authed` marker) and gains the `rootBeforeLoad` grace-period fallback |
| `SettingsPage > Members link points at /provision/$id/users` | SOURCE | link form chosen from the presence of the `:deploymentId` path param; the `as never` cast is gone |

## What each defect did to an operator

1. **Dangling catalog ids** — `computeDefaultSelection()` returned 48 ids, three of which (`gateway-api`, `reflector`, `spire`) had no card, no name and no logo anywhere in the wizard, yet were written into `selectedComponents`, travelled into the deployment payload, and were counted by the "Selected (N) of M" counter. They are bootstrap-kit HelmReleases the platform installs unconditionally, so dropping them from the wizard graph loses nothing.

2. **Specter with no AI runtime** — the issue #175 rule ("when Specter is selected all the Cortex family is required") was written as a `dependencies` literal on a component with no `bp-specter` HelmRelease, so the Flux override resolved it to `[]`. Ticking the AIOps brain installed Specter alone — no vLLM, no Milvus, no BGE, no LangFuse, no KServe. The catalog documented the rule in two places while the wizard had stopped implementing it. The new `familyRequires` field is the layer that survives the override, because Flux has no opinion on product-family selection; the member list expands from `PRODUCTS`, so it cannot drift and no per-component id list is hand-maintained.

3. **CloudNative PG and PostgreSQL invisible** — Tab 2 filtered on the PRODUCT tier, the Foundation counter beside it on the COMPONENT tier. `cnpg` / `postgres` are mandatory by transitive promotion but live in FABRIC (`recommended`), so Tab 2 dropped them while Tab 1 excludes them for being mandatory. Two components installed on every Sovereign appeared in neither tab, and the tab read "Foundation (24)" over 22 cards. The KServe guard that the product-tier filter existed for is preserved: a family-internal raw-mandatory member is neither clause, so it still stays out.

4. **Anonymous chroot visitor hung on the spinner** — the #5460 leg fired on every 401. A visitor with no `catalyst:authed` marker never authenticated in that tab, so `rootBeforeLoad`'s marker fast-path did not fire and the gate had already run its own whoami probe and silent leg; repeating it from the layout is a duplicate, it broke the #1089 contract (anonymous visitors land on the OpenOva PIN page, Keycloak untouched), and it burned the one-shot guard on the way — so the FIRST anonymous page load sat on "Authenticating…" and only the second reached `/login`. The layout also lacked the grace-period fallback its sibling in `rootBeforeLoad` has, so a Keycloak navigation that never commits left the console spinning forever.

5. **Members dead on the mothership** — the link hardcoded the chroot `/users` behind an `as never` cast that defeats the typed-route check. On the mothership it navigated into `SovereignConsoleLayout` with no `:deploymentId`, where `useResolvedDeploymentId` falls back to `/sovereign/self`, which 404s on a mothership host.

## Test-side changes — assertions untouched

Three of these are in `SovereignConsoleLayout.test.tsx` and none change what is asserted:

- **`sessionStorage.clear()` between tests.** jsdom hands every test in a file the same window, so the cookie-200 test's `catalyst:authed` marker leaked into the anonymous case and made it model a session EXPIRY instead of the scenario in its own title. Real browsers scope sessionStorage per tab, so a fresh anonymous visit genuinely has neither key. Proof the leak (not the assertion) was the difference: with the cookie-200 test filtered out, the #1089 test passes against this branch's source fix and fails against `main`.
- **The `initiateLogin` mock forwards its options argument.** It previously recorded only the FQDN, so the suite could not distinguish an invisible `prompt=none` re-auth from Keycloak rendering an interactive login wall.
- **Added the positive counterpart for the expiry branch** (`#5460 cookie-expiry silent SSO`). The #1089 test is a negative assertion, which would pass just as happily if the silent leg were deleted outright; the new test pins the other direction and the grace-period fallback with it.

Stale `🛑 EXPECTED TO FAIL on main` / `KNOWN DEFECT` docblocks are rewritten as regression guards. Left as they were, they would tell the next reader that a green test is supposed to be red.

## CI

`KNOWN_RED` is emptied — its only entry was `SettingsPage.test.tsx`, now fixed. An allowlisted file is a file nothing is watching. The value is used as a `case` glob and an empty glob is a bash syntax error, so "allowlist nothing" is spelled as a sentinel that can never equal a basename. Verified by parsing the workflow, running `bash -n` over the extracted gate script, and simulating the loop with a red file: it reports `UNEXPECTED` and fails the build.

## Gates

Run in `products/catalyst/bootstrap/ui`:

```
npm ci                    -> exit 0
npx vitest run            -> Test Files 211 passed (211) | Tests 2008 passed (2008) | 0 failed
npx tsc -b                -> exit 0
npm run build             -> exit 0 (built in 1.91s)
npx eslint <7 touched files> -> 0 problems
```

Before this branch, the same suite was 3 files failed / 208 passed.

## For the merger

- `ComponentDef.familyRequires` is a new field on the wizard catalog. It holds PRODUCT ids, not component ids, and expands from `PRODUCTS` at module load. Specter is the only user today.
- The Specter card's "Includes:" line now lists the whole CORTEX family (9 components) rather than nothing. That is the issue #175 rule finally rendering.
- `computeDefaultSelection()` drops from 48 to 45 ids. The three removed (`gateway-api`, `reflector`, `spire`) never had cards and are installed by the bootstrap kit regardless of wizard selection, so no Sovereign loses a component.
- The new expiry test deliberately waits out `SILENT_SSO_NAV_GRACE_MS` (8 s) to prove the safety net fires, so the layout suite now takes ~13 s instead of ~1 s. That is the cost of pinning the no-hang behaviour deterministically rather than asserting it by eye.
- `SettingsPage`'s Decommission CTA still uses `to="/decommission/$deploymentId"` unconditionally, which has the mirror-image shape on the chroot route. No test covers it and it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
