### PR TITLE
fix(guacamole): #5598 REST-session lifetime aligned with the oidc-gate session (bp-guacamole 0.2.34)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1304,7 +1304,11 @@ spec:
       #   w/ 16b slot 0.2.23 (pin-sync gate).
       # 1.4.1246 (#5468): catalog-seed bp-nemo-guardrails -> unlisted (its image
       #   was never built); restores the advertise-only-what-installs invariant.
-      version: 1.4.1264
+      # 1.4.1265 (#5598): catalog-seed bp-guacamole 0.2.33 -> 0.2.34 —
+      #   API_SESSION_TIMEOUT aligned to the oidc-gate session so >60-min
+      #   revisits stop 403-wedging on a dead cached token; lockstep w/
+      #   slot-52 pin 0.2.34 (pin-sync gate).
+      version: 1.4.1265
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -192,7 +192,13 @@ spec:
       # flow (fragment-replay "invalid/old nonce" on hw288, UAT rows
       # 35/115) is retired from the canonical path — values below drop
       # httproute + oidc.issuer accordingly.
-      version: 0.2.33
+      # 0.2.34 (#5598): API_SESSION_TIMEOUT=10080 — the webapp REST token
+      # previously died on the upstream 60-minute default while the
+      # oidc-gate session lives ~168h, so any >60-min revisit reused the
+      # dead cached GUAC_AUTH token → 403 PERMISSION_DENIED on every
+      # session API call → bare "An error has occurred" page (UAT rows
+      # 35/115 on hw292). Session lifetime now matches the gate cookie.
+      version: 0.2.34
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.33
+  version: 0.2.34
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -235,7 +235,17 @@ name: bp-guacamole
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
 # 0.2.26 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 0.2.33
+# 0.2.34 (#5598): API_SESSION_TIMEOUT env (values
+# guacamole.webapp.apiSessionTimeoutMinutes, default 10080) — the webapp's
+# REST-session token previously expired on the upstream 60-minute default
+# while the fronting oidc-gate session lives ~168h, so any >60-min revisit
+# reused a dead localStorage GUAC_AUTH token, 403'd PERMISSION_DENIED on
+# every session API call and rendered the bare "An error has occurred"
+# banner (UAT rows 35/115 ❌ on hw292). Group-inherited admin permissions
+# were proven INTACT on the same env (fresh-login effectivePermissions
+# carried ADMINISTER + 5 CREATE_*), so the session lifetime, not the JDBC
+# permission chain, was the operator-visible failure.
+version: 0.2.34
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -162,6 +162,19 @@ spec:
             - name: EXTENSION_PRIORITY
               value: {{ printf "%s, postgresql" $ssoMode | quote }}
             {{- end }}
+            # #5598 — REST-session lifetime. The image entrypoint maps this
+            # to the `api-session-timeout` property (upstream default 60
+            # minutes). Behind the oidc-gate the OUTER session lives ~168h,
+            # so the upstream default left the browser's cached GUAC_AUTH
+            # token dead on any >60-min revisit: every session API call
+            # 403'd PERMISSION_DENIED and the SPA rendered the bare
+            # "An error has occurred" banner without re-authenticating
+            # (hw292 access-log proof — see values.yaml
+            # webapp.apiSessionTimeoutMinutes for the full evidence chain).
+            # Aligned to the gate's cookie lifetime so the inner token
+            # never expires before the outer session.
+            - name: API_SESSION_TIMEOUT
+              value: {{ .Values.guacamole.webapp.apiSessionTimeoutMinutes | default 10080 | quote }}
             # Recording path — guacd writes here; the webapp ships
             # captures off to SeaweedFS via the shipper container below.
             - name: RECORDING_PATH

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -90,6 +90,31 @@ guacamole:
       limits:
         memory: 768Mi
     port: 8080
+    # ── REST-session lifetime (#5598) ──────────────────────────────
+    # Minutes of inactivity before the webapp's own REST session token
+    # (the browser's localStorage GUAC_AUTH) expires — the upstream
+    # `api-session-timeout` property, which the image entrypoint maps
+    # from the API_SESSION_TIMEOUT env (guacamole-docker start.sh
+    # `set_optional_property "api-session-timeout"`). Upstream default
+    # is 60, and that default is the #5598 ERROR-page wedge on every
+    # Sovereign: behind the slot-13c oidc-gate the GATE session lives
+    # ~168h (oauth2-proxy --cookie-expire default), so the operator's
+    # browser stays "signed in" while Guacamole's own 60-minute token
+    # dies underneath it. On the next visit the SPA reuses the cached
+    # dead token, every session API call returns 403 PERMISSION_DENIED
+    # (the 1.5.5 client re-authenticates only on INVALID/INSUFFICIENT_
+    # CREDENTIALS, never on PERMISSION_DENIED), and the app renders the
+    # bare "An error has occurred" banner — indistinguishable from an
+    # outage. Proven live on hw292 (dep 1c56518035a83e03) from the
+    # webapp access log: fresh logins at 10:26Z/17:27Z → all-200 with
+    # the FULL group-inherited effective permission set; revisits at
+    # 14:35Z/16:55Z (>60 min idle) → 403 on every session call, no
+    # re-auth POST, ERROR page. 10080 = 7 days, matching the gate's
+    # 168h cookie so the inner token never expires before the outer
+    # session. NOT a security relaxation: the webapp is reachable only
+    # through the gate (see networkpolicy.yaml ingress guard), which
+    # re-checks the Keycloak session on every request.
+    apiSessionTimeoutMinutes: 10080
   # ── Recording (SeaweedFS PVC) ──────────────────────────────────
   recordings:
     # #3374: persistence DEFAULT false → the recordings volume is an emptyDir,

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1817,7 +1817,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.33",
+      "version": "0.2.34",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1952,7 +1952,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.33",
+    "version": "0.2.34",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3618,7 +3618,14 @@ name: bp-catalyst-platform
 #   the customer marketplace grid and made it CONTRACTUAL for the cutover's #5442
 #   A3 guard, failing hw291 at step-03. Unlisting restores the #5443 invariant
 #   (advertise only what can install); restore to listed with the build.
-version: 1.4.1264
+# 1.4.1265 — #5598: catalog-seed bp-guacamole pin 0.2.33 -> 0.2.34 (+
+#   spec.version display label). 0.2.34 adds API_SESSION_TIMEOUT (default
+#   10080 min) so the Guacamole REST-session token no longer expires on the
+#   upstream 60-minute default underneath the ~168h oidc-gate session — the
+#   cause of the "An error has occurred" 403-PERMISSION_DENIED page on every
+#   >60-min revisit (UAT rows 35/115 on hw292). Bootstrap-kit slot-52 pin
+#   bumped in lockstep (pin-sync gate).
+version: 1.4.1265
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1727,7 +1727,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.33"
+  version: "0.2.34"
   visibility: listed
   card:
     title: "Apache Guacamole"
@@ -1745,7 +1745,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.33"
+    version: "0.2.34"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## What broke, actually — the #5598 hypothesis re-tested read-only on hw292

Refs #5598 (UAT rows 35/115, Refs #3374 #3642)

Investigated live on hw292 (dep `1c56518035a83e03`, post-cutover) with kubectl get/logs/exec-read-only + psql SELECT only — zero mutations, zero live patches.

### Finding 1 — the group-permission chain is INTACT; the "systemPermissions":[] evidence measured the wrong endpoint

The issue's central claim was that `sovereign-admins`' `ADMINISTER` grant never reaches the session. Three independent proofs say it does:

1. **DB layer**: `guacamole_db` holds entity 1 `sovereign-admins` (USER_GROUP, not disabled, 6 system permissions incl. `ADMINISTER`), entity 2 `emrah.baysal@openova.io` (USER, not disabled), membership row `user_group_id=1 member_entity_id=2` — re-confirmed by psql SELECT.
2. **Mapper layer**: extracted `EntityMapper.xml` from the DEPLOYED `guacamole-auth-jdbc-postgresql-1.5.5.jar` — `selectEffectiveGroupIdentifiers` walks `guacamole_user_group_member` recursively from the user's own entity id, so DB-seeded membership feeds effective permissions regardless of the authenticating extension (header mode included).
3. **Session layer (decisive)**: the webapp access log (`localhost_access_log.2026-08-03.txt`) shows the app's OWN fresh-login session at `17:27:40Z` received `GET /api/session/data/postgresql/self/effectivePermissions -> 200, 345 bytes`. The explicit-set body is 228 bytes (the founder captured it verbatim at `17:27:53Z`, logged 228 B); adding exactly the six system grants `["ADMINISTER","CREATE_CONNECTION","CREATE_CONNECTION_GROUP","CREATE_SHARING_PROFILE","CREATE_USER","CREATE_USER_GROUP"]` measures **exactly 345 bytes**. The session carried the full inherited set.

The `"systemPermissions":[]` observation came from **`/self/permissions`**, which by upstream API design returns the EXPLICIT set only — group-inherited grants never appear there, even when inheritance works. The discriminating endpoint is `/self/effectivePermissions`, and it answered 345 bytes.

Also re-verified as NOT the cause: `POSTGRESQL_AUTO_CREATE_ACCOUNTS=true` live (and the account exists), `EXTENSION_PRIORITY="header, postgresql"` live with both extensions loaded (catalina log), username case-consistent end-to-end.

### Finding 2 — the ERROR page is the 60-minute REST-token expiry underneath a ~168h gate session

Access-log timeline (gate log cross-confirms the same requests, same identity):

| time (Z) | what happened |
|---|---|
| 10:26:15 | fresh login: `POST /api/tokens` 200 → effectivePermissions/tree all **200** |
| 14:35:05 | revisit, cached token >60 min old: tree + effectivePermissions + shared-tree → **403 ×3**, **no re-auth POST** → "An error has occurred" |
| 16:55:57 | same wedge again: tree → **403**, no re-auth |
| 17:27:40 | fresh context: `POST /api/tokens` 200, `DELETE /api/session` (old token) 403 (client-ignored), effectivePermissions **200 (345 B — full grants)**, tree **200 (97 B — empty)** |

Mechanism: Guacamole's REST session (`api-session-timeout`, upstream default **60 minutes**; unset in the generated `guacamole.properties` on hw292) dies while the fronting oidc-gate session (oauth2-proxy `--cookie-expire` default 168h) keeps the page reachable. The SPA reuses the dead localStorage `GUAC_AUTH` token; the 1.5.5 client re-authenticates only on `INVALID_CREDENTIALS`/`INSUFFICIENT_CREDENTIALS`, never on `PERMISSION_DENIED`, so it renders the bare fatal ERROR dialog — indistinguishable from an outage (the issue's ask 2).

### The fix (bp-guacamole 0.2.33 → 0.2.34)

The deployed image's entrypoint already maps `API_SESSION_TIMEOUT` → `api-session-timeout` (`/opt/guacamole/bin/start.sh:1007`, verified in-container). The chart now sets it:

- `guacamole-deployment.yaml`: `API_SESSION_TIMEOUT` env from `guacamole.webapp.apiSessionTimeoutMinutes`
- `values.yaml`: default **10080** (7 days = the gate's 168h cookie), with the full evidence comment

Not a security relaxation: the webapp is reachable ONLY through the gate (chart NetworkPolicy ingress guard), and the gate re-validates the Keycloak session on every request. The inner token now cannot expire before the outer session; a revisit inside the gate-session window renders the connections list instead of the ERROR page.

Residual (upstream client behavior, documented in values.yaml): a revisit after BOTH sessions expire (>7 idle days) still reuses the stale token until the gate forces a full re-login round trip. Removing that entirely needs the upstream client to treat `PERMISSION_DENIED` on a session call as a re-auth trigger.

### Deliberately not in this PR — connection seeding (the issue's defect 2)

`select count(*) from guacamole_connection` = 0 is real, and an empty tree (97 B) renders an empty list. Seeding is held out because the intended exec-fan-out target, `bp-k8s-ws-proxy`, accepts only HMAC-signed WebSocket upgrades (`X-Catalyst-Timestamp`/`X-Catalyst-HMAC` on `/proxy/exec/...` — `core/cmd/k8s-ws-proxy/DESIGN.md`), which guacd's `kubernetes` protocol cannot produce. A seeded connection today would be a dead endpoint that fails on click — worse than an empty list. The honest path is a protocol bridge on the bp-k8s-ws-proxy side first; follow-up noted on #5598.

### Lockstep + gates

Five lockstep sites + regeneration: chart `Chart.yaml` 0.2.34, `blueprint.yaml`, slot-52 pin, catalog-seed `blueprints.yaml` (spec.version + source.version) with bp-catalyst-platform `1.4.1265` + slot-13 pin, `blueprints.json` + regenerated `catalog.generated.ts` (`build-catalog.mjs`, byte-stable on re-run).

- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs)
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)
- `tests/e2e/bootstrap-kit` `go test ./...` — ok
- `platform/guacamole/chart/tests/render.sh` + `httproute-render.sh` + `g117-w3d1-sso-secret.sh` — all PASS
- `helm template` renders `API_SESSION_TIMEOUT: "10080"` default / `"120"` override
- `products/catalyst/bootstrap/api` `go build ./...` + catalog/handler tests — PASS (post-rebase onto the #5619 compile fix)
- NodePort guard: this PR touches no Service; the diff greps clean for `nodePort`/`NodePort` and the fully rendered bp-guacamole output greps clean. The full `scripts/check-no-nodeports.sh` Phase-2 (helm-template-every-chart) stalls locally on `helm dependency update` network fetches for unrelated charts — CI runs the authoritative full guard on this PR.

Verification on env: re-walk UAT rows 35/115 on the next prov carrying 0.2.34 — the bare URL must land on the (empty) connections list with the Settings/admin surface present, and a revisit >60 min later must land there too instead of the ERROR page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
