### PR TITLE
fix(provisioning): per-Org GitOps tree emitters cutover-aware + step-07 Phase 3d stamps the fact (Refs #5527)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1024,7 +1024,13 @@ spec:
       # — the live-cluster walk). New RBAC: read-only blueprints. New values:
       # prewarm.catalogCharts.*, prewarm.chartImages.*. Step count stays 11.
       # New chart test tests/catalog-chart-set.sh + contract Case 72.
-      version: 0.1.159
+      # 0.1.160 (#5527): step-07 Phase 3d stamps CATALYST_LOCAL_REGISTRY_URL
+      # on the org-services provisioning Deployment so the per-Org GitOps
+      # tree generator emits the LOCAL Harbor OCI base post-cutover instead
+      # of re-tethering to ghcr on the next org mutation (Pillar 5; the
+      # hw291 step-08 OFFENDER wedge made durable). New values block
+      # orgProvisioning.*; step count stays 11; contract Case 74.
+      version: 0.1.160
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/core/services/provisioning/gitops/cutover_aware_5527.go
+++ b/core/services/provisioning/gitops/cutover_aware_5527.go
@@ -1,0 +1,122 @@
+package gitops
+
+// Cutover-aware bp-* catalog OCI base (#5527) — the per-Org tree emitters'
+// half of the fix PR #5529 shipped for the catalyst-api org-tenants writer.
+//
+// THE DEFECT (hw291 live, 2026-07-30): every OCI HelmRepository this module
+// emits declared a hardcoded `url: oci://ghcr.io/openova-io`. Cutover step-06
+// (helmrepository-patches) pivots the LIVE objects to the Sovereign-local
+// Harbor, but Flux drift-corrects them straight back from the generated git
+// source — and the NEXT org mutation regenerates the tree pointing at ghcr
+// again, silently re-tethering a cut-over Sovereign (Pillar-5 violation;
+// step-08's deny-egress hold fails with `OFFENDER ...=oci://ghcr.io/...`).
+// The invariant (#5527): no Flux-owned object may be pivoted only at the
+// object layer — the pivot must land in whatever source Flux asserts from.
+//
+// THE SEAM: unlike catalyst-api (whose step-07 Phase-3b issuer env pair is an
+// in-process pivot fact, see PR #5529), the provisioning Deployment
+// (org-services/provisioning, products/catalyst/chart/templates/org-services/
+// provisioning.yaml) is not touched by step-07's issuer stamp. So step-07
+// Phase 3d (added with this fix) stamps the EXPLICIT override —
+// CATALYST_LOCAL_REGISTRY_URL=oci://registry.<sovereign-fqdn>/openova-io —
+// onto the provisioning Deployment via `kubectl set env`. That is precisely
+// the forward-compatible seam PR #5529 designed: "a non-empty override is
+// itself the pivot fact, so a future cutover step-07 that stamps the exact
+// value flips the generator with no code change". The `kubectl set env`
+// triggers a rollout, so the regenerating process always carries the fact,
+// and the env entry survives pod restarts + helm/Flux 3-way merges (env
+// lists strategic-merge by name; an entry absent from both chart manifests
+// is preserved) — the same durability catalyst-api's post-cutover GitOps
+// loop already stakes on step-07's CATALYST_GITOPS_REPO_URL patch.
+//
+// Why NOT the neighbouring candidates:
+//
+//   - SOVEREIGN_FQDN alone: set from BIRTH on every Sovereign (the chart
+//     stamps it pre-cutover), so branching on it would emit local registry
+//     URLs on a pre-cutover Sovereign whose Harbor holds no charts yet.
+//   - The #3667 durable seal (secret/catalyst/cutover-complete in OpenBao,
+//     mirrored as cutoverComplete=true in the self-sovereign-cutover-status
+//     ConfigMap): this process has no OpenBao client, no ConfigMap RBAC —
+//     and, decisive even with both, the seal flips only AFTER step-08's
+//     deny-egress hold passes, while the generated source must already be
+//     local DURING the hold (the hw291 wedge was exactly an org-mutation
+//     window between step-06 and the seal). The step-07 stamp covers that
+//     window: it lands after step-03's harbor-prewarm, so the local Harbor
+//     already serves every chart these trees sourceRef.
+//   - Probing the catalyst-api Deployment's issuer envs over the K8s API at
+//     render time: a transient apiserver hiccup mid-mutation would fail
+//     safe to ghcr — i.e. nondeterministically reproduce the exact silent
+//     re-tether this issue is about. A process-local env fact renders
+//     deterministically.
+
+import (
+	"os"
+	"strings"
+)
+
+// orgBPCatalogGHCRBase is the pre-cutover (public catalog) OCI base every
+// emitted bp-* HelmRepository declares — byte-identical to the historical
+// hardcode so pre-cutover output produces zero Flux drift.
+const orgBPCatalogGHCRBase = "oci://ghcr.io/openova-io"
+
+// resolveCatalogOCIBase is the pure resolution core (unit-tested directly,
+// no env):
+//
+//   - localRegistryURL non-empty → the normalized override wins outright
+//     (the step-07 Phase-3d stamp; also Inviolable Principle #4's operator
+//     escape hatch). Missing `oci://` scheme is prefixed, a trailing slash
+//     is trimmed, an `https://`/`http://` scheme is swapped for `oci://`
+//     (the value derives from sovereign.harborPublicURL, which carries
+//     https).
+//   - else pinIssuer/handoverIssuer (the step-07 Phase-3b pair, present if
+//     a future train stamps this Deployment with the issuer fact instead)
+//     non-empty AND an FQDN resolvable → oci://registry.<fqdn>/openova-io,
+//     the SAME value shape step-06 patches the live objects to (hw292:
+//     oci://registry.hw292.omani.works/openova-io), per the platform canon
+//     `registry.<fqdn>` (bp-harbor HTTPRoute host,
+//     clusters/_template/bootstrap-kit/19-harbor.yaml).
+//   - fact without an FQDN is an inconsistent state this generator cannot
+//     mint a registry host from — fail safe to the public catalog rather
+//     than emit a URL that resolves nowhere.
+//   - no fact → the public catalog (mothership / Catalyst-Zero /
+//     pre-cutover Sovereign).
+//
+// secretRef stays `ghcr-pull` in both phases: the cutover rewrites that
+// Secret's CONTENTS to local-registry credentials without renaming it
+// (step-06 parity — the pivoted objects on hw291/hw292 keep the name).
+func resolveCatalogOCIBase(localRegistryURL, pinIssuer, handoverIssuer, sovereignFQDN, otechFQDN string) string {
+	if v := strings.TrimSpace(localRegistryURL); v != "" {
+		v = strings.TrimPrefix(v, "https://")
+		v = strings.TrimPrefix(v, "http://")
+		if !strings.HasPrefix(v, "oci://") {
+			v = "oci://" + v
+		}
+		return strings.TrimSuffix(v, "/")
+	}
+	if strings.TrimSpace(pinIssuer) == "" && strings.TrimSpace(handoverIssuer) == "" {
+		return orgBPCatalogGHCRBase
+	}
+	fqdn := strings.TrimSpace(sovereignFQDN)
+	if fqdn == "" {
+		// Synonym order matches catalyst-api's sovereign_self.go.
+		fqdn = strings.TrimSpace(otechFQDN)
+	}
+	if fqdn == "" {
+		return orgBPCatalogGHCRBase
+	}
+	return "oci://registry." + fqdn + "/openova-io"
+}
+
+// catalogOCIBase reads the process env and resolves the OCI base the emitted
+// bp-* HelmRepositories declare. Called at render time (per mutation), so the
+// value tracks the Deployment's CURRENT env — the pod rolls when step-07
+// stamps it, and every subsequent regeneration emits the local base.
+func catalogOCIBase() string {
+	return resolveCatalogOCIBase(
+		os.Getenv("CATALYST_LOCAL_REGISTRY_URL"),
+		os.Getenv("CATALYST_PIN_ISSUER"),
+		os.Getenv("CATALYST_HANDOVER_JWT_ISSUER"),
+		os.Getenv("SOVEREIGN_FQDN"),
+		os.Getenv("CATALYST_OTECH_FQDN"),
+	)
+}

--- a/core/services/provisioning/gitops/cutover_aware_5527_test.go
+++ b/core/services/provisioning/gitops/cutover_aware_5527_test.go
@@ -1,0 +1,186 @@
+package gitops
+
+// Golden tests for the cutover-aware bp-* catalog OCI base (#5527) — BOTH
+// directions, occurrence-counted against the block count so a silently
+// no-op'd swap cannot pass (vacuity discipline per
+// reference_render_guard_needs_a_vacuity_check_or_it_passes_on_nothing).
+//
+// Domains follow the test canon (docs/DOD.md §Domains-canon): omani.works /
+// omantel.biz — never openova.io.
+
+import (
+	"strings"
+	"testing"
+)
+
+// clearCutoverFactEnv guarantees a pre-cutover process env regardless of what
+// the host running the tests exports (t.Setenv registers cleanup + blocks
+// t.Parallel, which is exactly the isolation these need).
+func clearCutoverFactEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"CATALYST_LOCAL_REGISTRY_URL",
+		"CATALYST_PIN_ISSUER",
+		"CATALYST_HANDOVER_JWT_ISSUER",
+		"SOVEREIGN_FQDN",
+		"CATALYST_OTECH_FQDN",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// ── resolver matrix (pure function, no env) ────────────────────────────────
+
+func TestResolveCatalogOCIBase_Matrix(t *testing.T) {
+	cases := []struct {
+		name                                                    string
+		override, pinIssuer, handoverIssuer, fqdn, otech, want string
+	}{
+		{"no fact -> public catalog", "", "", "", "", "", orgBPCatalogGHCRBase},
+		// Sovereign identity alone must NOT flip: SOVEREIGN_FQDN is stamped
+		// from birth on every Sovereign (provisioning.yaml), pre-cutover its
+		// Harbor holds no charts.
+		{"fqdn alone stays public", "", "", "", "t90.omani.works", "", orgBPCatalogGHCRBase},
+		{"pin issuer + fqdn -> local", "", "https://console.t90.omani.works", "", "t90.omani.works", "", "oci://registry.t90.omani.works/openova-io"},
+		{"handover issuer alone suffices", "", "", "https://console.t91.omantel.biz", "t91.omantel.biz", "", "oci://registry.t91.omantel.biz/openova-io"},
+		{"otech fqdn synonym resolves", "", "https://console.t90.omani.works", "", "", "t90.omani.works", "oci://registry.t90.omani.works/openova-io"},
+		// Fact without identity is inconsistent -> fail safe to public,
+		// never mint a host that resolves nowhere.
+		{"fact without fqdn fails safe", "", "https://console.t90.omani.works", "", "", "", orgBPCatalogGHCRBase},
+		// The explicit override (step-07 Phase-3d stamp) wins outright.
+		{"override full base wins", "oci://registry.t90.omani.works/openova-io", "", "", "", "", "oci://registry.t90.omani.works/openova-io"},
+		{"override beats derivation", "oci://registry.t90.omani.works/openova-io", "x", "x", "t91.omantel.biz", "", "oci://registry.t90.omani.works/openova-io"},
+		{"override missing scheme prefixed", "registry.t90.omani.works/openova-io", "", "", "", "", "oci://registry.t90.omani.works/openova-io"},
+		{"override https scheme swapped", "https://registry.t90.omani.works/openova-io", "", "", "", "", "oci://registry.t90.omani.works/openova-io"},
+		{"override trailing slash trimmed", "oci://registry.t90.omani.works/openova-io/", "", "", "", "", "oci://registry.t90.omani.works/openova-io"},
+		{"whitespace-only override is no fact", "   ", "", "", "", "", orgBPCatalogGHCRBase},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveCatalogOCIBase(tc.override, tc.pinIssuer, tc.handoverIssuer, tc.fqdn, tc.otech)
+			if got != tc.want {
+				t.Fatalf("resolveCatalogOCIBase(%q,%q,%q,%q,%q) = %q, want %q",
+					tc.override, tc.pinIssuer, tc.handoverIssuer, tc.fqdn, tc.otech, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── golden render: fact=false emits upstream ───────────────────────────────
+
+func TestGenerateTree_PreCutover_EmitsPublicCatalog(t *testing.T) {
+	clearCutoverFactEnv(t)
+	g := NewManifestGenerator("clusters/t90.omani.works/org-tenants")
+	out := g.GenerateAllWithAppConfigs("acme", "m", []string{"openclaw", "stalwart-mail", "umami"},
+		"pw", map[string]map[string]any{"postgres": {
+			"active_hot_standby": true,
+			"primary_region":     "hz-fsn-rtz-prod",
+			"replica_region":     "hz-hel-rtz-prod",
+		}})
+
+	ghcrBlocks, localLeak := 0, 0
+	helmRepoFiles := 0
+	for name, content := range out {
+		ghcrBlocks += strings.Count(content, "url: "+orgBPCatalogGHCRBase)
+		localLeak += strings.Count(content, "registry.t90.omani.works")
+		if strings.Contains(content, "kind: HelmRepository") {
+			helmRepoFiles++
+		}
+		_ = name
+	}
+	// openclaw + stalwart HR files each carry one shared bp-* block; the
+	// active-hot-standby path adds bp-cnpg-pair primary + replica. All of
+	// them must declare the public catalog pre-cutover — and NOTHING may
+	// leak a local registry host.
+	if helmRepoFiles < 4 {
+		t.Fatalf("expected >=4 files carrying HelmRepository blocks (openclaw, stalwart, cnpg-pair primary+replica), got %d", helmRepoFiles)
+	}
+	if ghcrBlocks < 4 {
+		t.Fatalf("pre-cutover: expected >=4 public-catalog url lines, got %d — the ghcr default regressed", ghcrBlocks)
+	}
+	if localLeak != 0 {
+		t.Fatalf("pre-cutover: %d local-registry references leaked without any cutover fact", localLeak)
+	}
+}
+
+// ── golden render: fact=true emits local ───────────────────────────────────
+
+func TestGenerateTree_PostCutover_EmitsLocalRegistry(t *testing.T) {
+	clearCutoverFactEnv(t)
+	// The step-07 Phase-3d stamp: the exact value shape step-06 patches the
+	// live objects to (hw292: oci://registry.hw292.omani.works/openova-io).
+	t.Setenv("CATALYST_LOCAL_REGISTRY_URL", "oci://registry.t90.omani.works/openova-io")
+
+	g := NewManifestGenerator("clusters/t90.omani.works/org-tenants")
+	out := g.GenerateAllWithAppConfigs("acme", "m", []string{"openclaw", "stalwart-mail", "umami"},
+		"pw", map[string]map[string]any{"postgres": {
+			"active_hot_standby": true,
+			"primary_region":     "hz-fsn-rtz-prod",
+			"replica_region":     "hz-hel-rtz-prod",
+		}})
+
+	localBlocks, ghcrResidue, secretRefs := 0, 0, 0
+	for _, content := range out {
+		localBlocks += strings.Count(content, "url: oci://registry.t90.omani.works/openova-io")
+		ghcrResidue += strings.Count(content, "ghcr.io/openova-io")
+		secretRefs += strings.Count(content, "name: ghcr-pull")
+	}
+	if localBlocks < 4 {
+		t.Fatalf("post-cutover: expected >=4 local url lines (openclaw, stalwart, cnpg-pair primary+replica), got %d — the swap no-op'd", localBlocks)
+	}
+	// The whole point of #5527: ZERO upstream URL residue post-cutover —
+	// one leaked line re-tethers the Sovereign on the next Flux reconcile.
+	if ghcrResidue != 0 {
+		t.Fatalf("post-cutover: %d ghcr.io/openova-io references remain — the Sovereign re-tethers (Pillar 5)", ghcrResidue)
+	}
+	// secretRef keeps its NAME in both phases (the cutover rewrites the
+	// Secret's contents, not its name — step-06 parity, per #5529).
+	if secretRefs < 4 {
+		t.Fatalf("post-cutover: expected ghcr-pull secretRef retained on every HelmRepository block, got %d", secretRefs)
+	}
+}
+
+// The derived path (issuer fact, no explicit override) must produce the same
+// canonical registry.<fqdn> host end-to-end through a real render.
+func TestGenerateTree_PostCutover_DerivedFromIssuerFact(t *testing.T) {
+	clearCutoverFactEnv(t)
+	t.Setenv("CATALYST_PIN_ISSUER", "https://console.t91.omantel.biz")
+	t.Setenv("SOVEREIGN_FQDN", "t91.omantel.biz")
+
+	g := NewManifestGenerator("clusters/t91.omantel.biz/org-tenants")
+	out := g.GenerateAllWithAppConfigs("acme", "m", []string{"openclaw"}, "pw", nil)
+
+	local, ghcr := 0, 0
+	for _, content := range out {
+		local += strings.Count(content, "url: oci://registry.t91.omantel.biz/openova-io")
+		ghcr += strings.Count(content, "ghcr.io/openova-io")
+	}
+	if local < 1 {
+		t.Fatalf("issuer-fact derivation: expected >=1 local url line, got %d", local)
+	}
+	if ghcr != 0 {
+		t.Fatalf("issuer-fact derivation: %d ghcr references remain", ghcr)
+	}
+}
+
+// Pre-cutover output must be BYTE-IDENTICAL to the historical template so a
+// regeneration on the mothership / a pre-cutover Sovereign produces zero
+// Flux drift — assert the exact historical block shape survives.
+func TestHelmRepoBlock_PreCutover_ByteIdentical(t *testing.T) {
+	clearCutoverFactEnv(t)
+	got := helmRepoBlock("bp-openclaw")
+	want := `apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-openclaw
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull`
+	if got != want {
+		t.Fatalf("pre-cutover helmRepoBlock drifted from the historical template:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -1348,7 +1348,9 @@ metadata:
 spec:
   type: oci
   interval: 15m
-  url: oci://ghcr.io/openova-io
+  # url is cutover-aware (#5527, cutover_aware_5527.go): public catalog
+  # pre-cutover, Sovereign-local Harbor once the step-07 fact is stamped.
+  url: %s
   secretRef:
     name: ghcr-pull
 ---
@@ -1423,6 +1425,7 @@ spec:
 `,
 		side, side, side, opt.replicaRegion, // header comment
 		hrName, hrNamespace, // HelmRepository name/ns
+		catalogOCIBase(), // cutover-aware OCI base (#5527)
 		hrName, hrNamespace, side, releaseName, ns, kubeConfigBlock, // HR metadata + spec head
 		hrName, hrNamespace, // sourceRef name/ns
 		side,                                                              // cnpgPair.side

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -165,6 +165,15 @@ func (opt helmReleaseAppOpts) kubeConfigBlock() string {
 // Every HR-shaped app ships its own so a fresh funnel Org resolves the
 // sourceRef without the org-controller seeding it (the BSS door seeds these in
 // orgTenantSharedHelmRepositories; the funnel path has no such shared block).
+//
+// The URL is cutover-aware (#5527, see cutover_aware_5527.go): pre-cutover it
+// declares the canonical public catalog (oci://ghcr.io/openova-io); once the
+// step-07 registry-pivot fact is stamped on this Deployment it declares the
+// Sovereign-local Harbor — the SAME value step-06 patches the live objects
+// to, so the generated source and the pivoted objects agree and Flux has
+// nothing to drift-correct back to ghcr (the hw291 step-08 OFFENDER wedge).
+// secretRef stays ghcr-pull in both phases (the cutover rewrites that
+// Secret's contents, not its name).
 func helmRepoBlock(name string) string {
 	return fmt.Sprintf(`apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -174,9 +183,9 @@ metadata:
 spec:
   type: oci
   interval: 15m
-  url: oci://ghcr.io/openova-io
+  url: %s
   secretRef:
-    name: ghcr-pull`, name)
+    name: ghcr-pull`, name, catalogOCIBase())
 }
 
 // generateOpenClawHR mirrors orgTenantBPOpenClaw (#4272) for the generic

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.159
+  version: 0.1.160
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,32 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.160 (#5527 Refs #3379 #5529 #960 — step-07 Phase 3d: stamp the per-Org
+# GitOps tree generator with the local OCI base. The org-services provisioning
+# Deployment (core/services/provisioning) regenerates the per-Org trees —
+# HelmRepository blocks included — on EVERY org mutation, and its emitters
+# hardcoded oci://ghcr.io/openova-io: the git source Flux asserts from
+# re-tethered every step-06 object pivot (the hw291 step-08 OFFENDER wedge)
+# and any post-cutover org mutation silently reverted the pivot (Pillar 5).
+# PR #5529 fixed the catalyst-api writer by keying on the step-07 issuer
+# stamp that Deployment already receives; the provisioning Deployment gets NO
+# step-07 stamp, so its now-cutover-aware emitters (core/services/
+# provisioning/gitops/cutover_aware_5527.go, this train) key on the explicit
+# CATALYST_LOCAL_REGISTRY_URL override — which Phase 3d stamps via `kubectl
+# set env`, derived from sovereign.harborPublicURL as oci://<harbor-host>/
+# openova-io (the SAME value shape step-06 patches the live objects to). The
+# set-env rolls the Deployment so the regenerating process always carries the
+# fact. Read-back FATAL when the Deployment exists (fail-open here IS the
+# #5527 defect); loud SKIP when the marketplace tier is absent; rollout wait
+# best-effort (the fact lives in the pod template — durable across restarts +
+# helm 3-way merges — and step-08's roll-set re-rolls this workload anyway).
+# New values block orgProvisioning.{deploymentName,namespace} (Principle #4).
+# Template 07 + values only; no step-count / RBAC / deadline change (still 11
+# steps — the runner ClusterRole already grants deployments update/patch
+# cluster-wide). Contract Case 74 locks the stamp, the executed derivation
+# both input forms, the read-back FATAL, and the SKIP. Slot-06a pin +
+# blueprint.yaml + catalog-seed source.version + spec.version move to 0.1.160
+# in lockstep (Inviolable Principle #13).
+# ── prior ──
 # 0.1.158 (#5525 Refs #5442 #5095 #3379 — step-03 harbor-prewarm: three legs
 # against the hw291 2026-07-30 scarf.sh/Docker-Hub rate-limit wall (dep
 # 2c2d746b578c636b: 4 litmuschaos.docker.scarf.sh refs cycled 4 pod attempts
@@ -2862,7 +2889,7 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.159
+version: 0.1.160
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -113,6 +113,12 @@ data:
             value: "flux-system"
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
+          # #5527 Phase 3d: the org-services provisioning Deployment (per-Org
+          # GitOps tree generator) to stamp with the local OCI base.
+          - name: ORG_PROVISIONING_DEPLOYMENT
+            value: {{ .Values.orgProvisioning.deploymentName | quote }}
+          - name: ORG_PROVISIONING_NAMESPACE
+            value: {{ .Values.orgProvisioning.namespace | quote }}
           # G62 (#2613): Gitea persistence inputs — durable source-of-truth
           # edit so Flux Kustomization doesn't revert the HR patch.
           - name: GITEA_INTERNAL_URL
@@ -918,6 +924,49 @@ data:
               esac
               echo "[catalyst-api-env-patch] Phase 3 OK: ${VAR}=${LIVE}"
             done
+
+            # ---- Phase 3d (#5527): pivot the per-Org GitOps tree generator ----
+            # The org-services provisioning Deployment regenerates the per-Org
+            # trees (HelmRepository blocks included) on EVERY org mutation. Its
+            # emitters are cutover-aware (core/services/provisioning/gitops/
+            # cutover_aware_5527.go) but the fact must be stamped HERE: without
+            # it, the next org mutation after cutover re-emits
+            # oci://ghcr.io/openova-io and Flux drift-corrects the step-06
+            # object pivot straight back (the hw291 step-08 OFFENDER wedge,
+            # recurring silently post-cutover — Pillar 5). The stamped value is
+            # the SAME base step-06 patches the live objects to:
+            # oci://<harbor-host>/openova-io. The set-env rolls the Deployment
+            # (tiny, prewarmed image — step-03 mirrors every workload image),
+            # so the regenerating process always carries the fact.
+            #
+            # Deployment-absent is a SKIP (a Sovereign without the marketplace
+            # tier has no per-Org generator to re-tether); present-but-unstamped
+            # is FATAL (fail-open here IS the #5527 defect). The rollout wait is
+            # best-effort: the fact lives in the pod TEMPLATE (durable across
+            # restarts + helm 3-way merges), and step-08's roll-set re-rolls
+            # this workload under deny-egress anyway — a slow roll here must
+            # not add a new cutover wedge-class.
+            LOCAL_OCI_BASE="oci://$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/*$,,')/openova-io"
+            if kubectl get deploy "${ORG_PROVISIONING_DEPLOYMENT}" -n "${ORG_PROVISIONING_NAMESPACE}" >/dev/null 2>&1; then
+              echo "[catalyst-api-env-patch] #5527 Phase 3d: CATALYST_LOCAL_REGISTRY_URL=${LOCAL_OCI_BASE} -> deploy/${ORG_PROVISIONING_DEPLOYMENT} -n ${ORG_PROVISIONING_NAMESPACE}"
+              kubectl set env "deploy/${ORG_PROVISIONING_DEPLOYMENT}" \
+                -n "${ORG_PROVISIONING_NAMESPACE}" \
+                "CATALYST_LOCAL_REGISTRY_URL=${LOCAL_OCI_BASE}"
+              # Read-back assert — live template value, not intention.
+              LIVE=$(kubectl get deploy "${ORG_PROVISIONING_DEPLOYMENT}" \
+                -n "${ORG_PROVISIONING_NAMESPACE}" \
+                -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='CATALYST_LOCAL_REGISTRY_URL')].value}" 2>/dev/null || echo "")
+              if [ "${LIVE}" != "${LOCAL_OCI_BASE}" ]; then
+                echo "[catalyst-api-env-patch] #5527 FATAL Phase 3d: CATALYST_LOCAL_REGISTRY_URL='${LIVE}' (want '${LOCAL_OCI_BASE}') — the per-Org generator would re-emit ghcr on the next org mutation; Pillar 5 independence not met" >&2
+                exit 1
+              fi
+              echo "[catalyst-api-env-patch] #5527 Phase 3d OK: CATALYST_LOCAL_REGISTRY_URL=${LIVE}"
+              kubectl rollout status "deploy/${ORG_PROVISIONING_DEPLOYMENT}" \
+                -n "${ORG_PROVISIONING_NAMESPACE}" --timeout=180s \
+                || echo "[catalyst-api-env-patch] #5527 WARN Phase 3d: provisioning rollout slow (best-effort — the fact is in the pod template; step-08's roll-set covers the live roll)"
+            else
+              echo "[catalyst-api-env-patch] #5527 Phase 3d SKIP: deploy/${ORG_PROVISIONING_DEPLOYMENT} not found in ${ORG_PROVISIONING_NAMESPACE} (no marketplace tier — no per-Org generator to pivot)"
+            fi
 
             # ---- Phase 4 (#4973 #4975 #4961): comprehensive pod-spec image sweep ----
             # The HR global.imageRegistry pivots above (Phases 1-2 + the additionalHRs

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3822,4 +3822,60 @@ if ! grep -qF 'Phase A3-guard (#5442)' "$TMP/s03pin.yaml"; then
 fi
 echo "  PASS (#5525: scarf hosts fall back to the mothership proxy via the forward map lookup [direct-first stays proxy_src-gated], toomanyrequests latches the host + skips latched primaries + carries into A3, the dest-presence rescue keeps a durably-present image, and the A3 FATAL — executed both directions from the rendered condition — keys on durable_miss/unmapped only with the copy-fail shape a loud WARN)"
 
+# ── Case 74 (#5527, Refs #3379 #5529): step-07 Phase 3d stamps the per-Org
+# GitOps tree generator (org-services/provisioning) with the local OCI base ──
+# hw291 (2026-07-30): the org-tenant generators hardcoded oci://ghcr.io/
+# openova-io, so the git source Flux asserts from re-tethered every step-06
+# object pivot (step-08 OFFENDER wedge) and any post-cutover org mutation
+# silently reverted the pivot. PR #5529 fixed the catalyst-api writer via the
+# step-07 issuer stamp it already receives; the provisioning Deployment gets
+# NO such stamp, so its cutover-aware emitters (core/services/provisioning/
+# gitops/cutover_aware_5527.go) key on CATALYST_LOCAL_REGISTRY_URL — which
+# THIS phase must stamp, read-back-assert (FATAL when the Deployment exists),
+# and SKIP loudly when the marketplace tier is absent.
+echo "[cutover-contract] Case 74: step-07 Phase 3d stamps CATALYST_LOCAL_REGISTRY_URL on the per-Org provisioning Deployment (#5527)"
+awk '/name: cutover-step-07-catalyst-api-env-patch/{c=1} /name: cutover-step-08-egress-block-test/{c=0} c' "$TMP/render.yaml" > "$TMP/s07.yaml"
+if [ ! -s "$TMP/s07.yaml" ]; then
+  echo "FAIL: cannot extract the step-07 ConfigMap from the render (#5527 vacuity check)" >&2
+  exit 1
+fi
+# (a) the target inputs are values-driven (Inviolable Principle #4), rendered
+#     with the org-services defaults.
+if ! grep -qF 'ORG_PROVISIONING_DEPLOYMENT' "$TMP/s07.yaml" || ! grep -qF 'value: "provisioning"' "$TMP/s07.yaml" || ! grep -qF 'value: "org-services"' "$TMP/s07.yaml"; then
+  echo "FAIL: step-07 lacks the ORG_PROVISIONING_DEPLOYMENT/NAMESPACE inputs (defaults provisioning/org-services) — Phase 3d has no target (#5527)" >&2
+  exit 1
+fi
+# (b) the stamp itself + the read-back FATAL + the loud SKIP branch.
+if ! grep -qF '"CATALYST_LOCAL_REGISTRY_URL=${LOCAL_OCI_BASE}"' "$TMP/s07.yaml"; then
+  echo "FAIL: step-07 never stamps CATALYST_LOCAL_REGISTRY_URL on the provisioning Deployment — the next org mutation post-cutover re-emits ghcr and re-tethers the Sovereign (#5527)" >&2
+  exit 1
+fi
+if ! grep -qF "the per-Org generator would re-emit ghcr on the next org mutation" "$TMP/s07.yaml"; then
+  echo "FAIL: step-07 Phase 3d has no read-back FATAL — a failed stamp on an existing Deployment would fail open into the exact #5527 defect" >&2
+  exit 1
+fi
+if ! grep -qF 'Phase 3d SKIP' "$TMP/s07.yaml"; then
+  echo "FAIL: step-07 Phase 3d has no explicit Deployment-absent SKIP — a Sovereign without the marketplace tier would FATAL on a workload it does not run (#5527)" >&2
+  exit 1
+fi
+# (c) EXECUTE the rendered derivation line both directions so a re-worded but
+#     broken sed cannot pass: https scheme + trailing slash must normalise to
+#     oci://<host>/openova-io, and a bare host must pass through unchanged.
+d74=$(grep -F 'LOCAL_OCI_BASE="oci://' "$TMP/s07.yaml" | head -1 | sed 's/^ *//')
+if [ -z "$d74" ]; then
+  echo "FAIL: cannot extract the LOCAL_OCI_BASE derivation from the step-07 render (#5527 vacuity check)" >&2
+  exit 1
+fi
+got74=$(HARBOR_PUBLIC_URL="https://registry.t90.omani.works/" sh -c "$d74; printf '%s' \"\$LOCAL_OCI_BASE\"")
+if [ "$got74" != "oci://registry.t90.omani.works/openova-io" ]; then
+  echo "FAIL: rendered derivation maps https://registry.t90.omani.works/ -> '$got74', want oci://registry.t90.omani.works/openova-io — the stamp would diverge from the value shape step-06 patches the live objects to (#5527)" >&2
+  exit 1
+fi
+got74b=$(HARBOR_PUBLIC_URL="registry.t91.omantel.biz" sh -c "$d74; printf '%s' \"\$LOCAL_OCI_BASE\"")
+if [ "$got74b" != "oci://registry.t91.omantel.biz/openova-io" ]; then
+  echo "FAIL: rendered derivation maps a scheme-less host to '$got74b', want oci://registry.t91.omantel.biz/openova-io (#5527)" >&2
+  exit 1
+fi
+echo "  PASS (#5527: Phase 3d present with values-driven target, executed derivation matches the step-06 value shape both input forms, read-back FATAL on an existing Deployment, loud SKIP when the marketplace tier is absent)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1172,6 +1172,23 @@ catalystAPI:
       # Empty disables the broken-CSI cordon (the detach-gate still runs).
       zoneLabel: "topology.evs.csi.huaweicloud.com/zone"
 
+# #5527 — step-07 Phase 3d: the org-services provisioning Deployment (the
+# per-Org GitOps tree generator, core/services/provisioning) is NOT covered by
+# the catalyst-api env stamps above, yet its emitters declare the bp-* catalog
+# OCI base in every tree they regenerate. Without a pivot fact readable from
+# that process, the NEXT org mutation after cutover regenerates HelmRepository
+# blocks pointing at oci://ghcr.io/openova-io and Flux drift-corrects the
+# step-06 object pivot straight back — the hw291 step-08 OFFENDER wedge,
+# recurring silently post-cutover (Pillar 5). Phase 3d stamps
+# CATALYST_LOCAL_REGISTRY_URL=oci://<registry-host>/openova-io (derived from
+# sovereign.harborPublicURL — the SAME value shape step-06 patches the live
+# objects to) onto this Deployment via `kubectl set env`; the generator's
+# explicit-override seam (cutover_aware_5527.go) flips on it. The set-env
+# rolls the Deployment, so every subsequent regeneration carries the fact.
+orgProvisioning:
+  deploymentName: "provisioning"
+  namespace: "org-services"
+
 # #4885 (Refs #3379 #4563): step-07 image-registry pivot — the CURATED set of
 # ADDITIONAL openova-io HelmReleases whose chart HONOURS global.imageRegistry
 # and must be pivoted to the local Harbor at cutover.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T21:19:19.974Z",
+  "generatedAt": "2026-08-03T21:41:03.519Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.159",
+      "version": "0.1.160",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.159",
+    "version": "0.1.160",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.159"
+  version: "0.1.160"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.159"
+    version: "0.1.160"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem — the residual #5527 writers: the per-Org GitOps tree generator re-tethers a pivoted Sovereign on the next org mutation

PR #5529 (merged 2026-07-30) made the catalyst-api org-tenants writer cutover-aware and named the residual in its own body: `core/services/provisioning/gitops/helmrelease_apps.go` (helmRepoBlock) and `core/services/provisioning/gitops/gitops.go` (generateCNPGPair) also hardcode `url: oci://ghcr.io/openova-io`. That module is the org-services **provisioning** Deployment — the per-Org GitOps tree generator that regenerates trees on EVERY org mutation, and it runs the per-Org path by default on every Sovereign (`TENANT_GITOPS_PER_ORG` defaults ON whenever `global.sovereignFQDN` is set).

So on a cut-over Sovereign: cutover step-06 pivots the live HelmRepository objects to the local Harbor, but the next org mutation regenerates the git source with ghcr URLs and Flux drift-corrects the pivot straight back — the hw291 step-08 `OFFENDER ...=oci://ghcr.io/openova-io` wedge, recurring **silently post-cutover** (Pillar 5 re-tether). Invariant per the issue: no Flux-owned object may be pivoted only at the object layer — the pivot must land in whatever source Flux asserts from.

The GitRepository legs of this module were verified already clean: the generator references GitRepository by NAME only (no URL emitted), the commit target is the local Gitea from birth (`GITHUB_API_URL` -> `gitea-http...` when `sovereignFQDN` is set), and the 2026-08-03 hw292 walk on the issue confirmed all per-Org GitRepositories point at local Gitea. The OCI HelmRepository URLs were the only upstream residue.

## Fix — same seam as #5529, adapted to a Deployment that step-07 never stamped

### The cutover-fact seam (investigated, reused, not invented)

The provisioning Deployment receives NO step-07 issuer stamp (step-07 targets only catalyst-api), has no OpenBao client, no ConfigMap RBAC — and the #3667 `cutoverComplete` seal flips only AFTER step-08 passes, while the generated source must already be local DURING the hold (the hw291 wedge was exactly an org-mutation window between step-06 and the seal). Probing another Deployment's env over the K8s API at render time was rejected because its failure mode (transient apiserver hiccup -> fail-safe to ghcr) nondeterministically reproduces the exact silent re-tether this issue is about.

The chosen fact is the one PR #5529 explicitly designed for this continuation: *"a non-empty override is itself the pivot fact, so a future cutover step-07 that stamps the exact value flips this generator with no code change."* This PR is that step-07.

### Generator leg — `core/services/provisioning/gitops`

- `cutover_aware_5527.go`: pure resolver `resolveCatalogOCIBase` + env wrapper `catalogOCIBase()`, mirroring #5529: explicit `CATALYST_LOCAL_REGISTRY_URL` wins (normalised: scheme swap/prefix, trailing-slash trim); else the step-07 issuer pair (`CATALYST_PIN_ISSUER`/`CATALYST_HANDOVER_JWT_ISSUER`) + `SOVEREIGN_FQDN`/`CATALYST_OTECH_FQDN` derive `oci://registry.<fqdn>/openova-io` — the exact value shape step-06 patches the live objects to (hw292: `oci://registry.hw292.omani.works/openova-io`); else the public catalog. Sovereign identity alone never flips (a pre-cutover Sovereign's Harbor holds no charts); fact-without-identity fails safe to ghcr. `secretRef: ghcr-pull` retained in both phases (the cutover rewrites that Secret's contents, not its name).
- Both emitters (`helmRepoBlock`, `generateCNPGPair`) emit through the resolver. Pre-cutover output stays **byte-identical** to the historical template — zero Flux drift on the mothership / Catalyst-Zero / a pre-cutover Sovereign. `GeneratePerOrgAppsTree` routes through `GenerateAllWithAppConfigs`, so the per-Org (live-Sovereign) path is covered.

### Cutover chart leg — `bp-self-sovereign-cutover` 0.1.159 -> 0.1.160

- **Step-07 Phase 3d** stamps `CATALYST_LOCAL_REGISTRY_URL=oci://<harbor-host>/openova-io` (derived from `sovereign.harborPublicURL`, the same source step-06 derives its pivot value from) onto the provisioning Deployment via `kubectl set env`. The set-env rolls the Deployment so the regenerating process always carries the fact; the env entry survives pod restarts + helm/Flux 3-way merges (env lists strategic-merge by name — the same durability the post-cutover GitOps loop already stakes on step-07's `CATALYST_GITOPS_REPO_URL` patch, proven across hw291/hw292 for the issuer pair).
- Fail modes are deliberate: Deployment-present-but-unstamped is **FATAL with read-back assert** (fail-open here IS the #5527 defect); Deployment-absent is a **loud SKIP** (a Sovereign without the marketplace tier has no per-Org generator to re-tether); the rollout wait is best-effort (the fact lives in the pod template, and step-08's roll-set re-rolls this workload under deny-egress anyway — a slow roll must not add a new cutover wedge-class).
- New values block `orgProvisioning.{deploymentName,namespace}` (Inviolable Principle 4). No step-count / RBAC / deadline change — still 11 steps; the runner ClusterRole already grants `deployments` update/patch cluster-wide (the rule step-07 uses for catalyst-api).
- Timing note: Phase 3d lands after step-03's harbor-prewarm, so the local Harbor already serves every chart these trees sourceRef — covering the step-06-to-seal mutation window that wedged hw291.

## Tests

Golden tests BOTH ways in `cutover_aware_5527_test.go`, occurrence-counted against block counts (vacuity-proof — a silently no-op'd swap cannot pass):

- fact=false: >=4 public-catalog url lines across openclaw/stalwart/cnpg-pair-primary/replica, ZERO local-host leak, and `helmRepoBlock` byte-identical to the historical template
- fact=true (override): >=4 local url lines, **zero** `ghcr.io/openova-io` residue anywhere in the tree, `ghcr-pull` secretRef retained per block
- fact=true (issuer-derived): end-to-end render resolves `registry.<fqdn>` with zero ghcr residue
- resolver matrix: identity-alone stays public, fact-without-identity fails safe, override normalisation (missing scheme / https / trailing slash), override beats derivation

Contract **Case 74** (chart side, both directions): Phase 3d present with values-driven target; the rendered `LOCAL_OCI_BASE` derivation **executed** against two input forms and asserted equal to the step-06 value shape; read-back FATAL present; SKIP branch present. Test domains follow the canon (omani.works / omantel.biz).

## Gates

- `cd core/services/provisioning && go build ./... && go vet ./... && go test ./... -count=1` — all packages green
- `cd tests/e2e/bootstrap-kit && go test -count=1 ./...` — lockstep drift guards green (blueprint.yaml + catalog-seed spec/source.version)
- `bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` — all cases green incl. new Case 74
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs)
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)
- `scripts/check-no-nodeports.sh` — Phase 1/1b static scans clean for this diff (no Service or port change in it); the full Phase-2 all-chart helm-render sweep also runs in CI

Lockstep sites for the 0.1.160 bump: `chart/Chart.yaml`, `blueprint.yaml`, catalog-seed `spec.version` + `source.version`, bootstrap-kit slot `06a-bp-self-sovereign-cutover.yaml`.

## Residual (delivery, not code)

Runtime proof follows the issue's own discipline (merged != delivered): it needs this chart + provisioning image delivered to an env, a cutover run, then an org mutation post-cutover showing the regenerated tree carries the local URLs — the same Phase-D walk shape that verified #5529 on hw292 region-a. Region-B parity remains tracked by #5596 (separate, filed from the hw292 walk).

Refs #5527 #3379 #5529 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
