### PR TITLE
fix(marketplace): surface the 429 rate-limit response in the redeem funnel (UAT row 92)

### DIFF
--- a/core/marketplace/package-lock.json
+++ b/core/marketplace/package-lock.json
@@ -12,8 +12,65 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
-        "tailwindcss": "^4.0.0"
+        "jsdom": "^28.0.0",
+        "tailwindcss": "^4.0.0",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/compiler-binding": {
       "version": "0.3.2",
@@ -74,9 +131,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -92,9 +146,6 @@
       "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -112,9 +163,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -130,9 +178,6 @@
       "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -325,6 +370,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bruits/satteri-darwin-arm64": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
@@ -358,9 +416,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -373,9 +428,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -390,9 +442,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -405,9 +454,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -528,6 +574,146 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -977,6 +1163,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1089,9 +1293,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1107,9 +1308,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1127,9 +1325,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1145,9 +1340,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1165,9 +1357,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1183,9 +1372,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1203,9 +1389,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1222,9 +1405,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1240,9 +1420,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1266,9 +1443,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1290,9 +1464,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1316,9 +1487,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1340,9 +1508,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1366,9 +1531,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1391,9 +1553,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1415,9 +1574,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1694,9 +1850,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1712,9 +1865,6 @@
       "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1732,9 +1882,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1750,9 +1897,6 @@
       "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1770,9 +1914,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,9 +1929,6 @@
       "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2000,6 +2138,13 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
@@ -2376,6 +2521,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2436,6 +2599,129 @@
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2446,6 +2732,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/am-i-vibing": {
@@ -2498,6 +2794,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -2612,6 +2918,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2626,6 +2942,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities-html4": {
@@ -2714,6 +3040,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "2.0.1",
@@ -2816,6 +3149,61 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent-js": {
       "version": "1.0.1",
@@ -3074,6 +3462,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3314,6 +3712,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -3335,6 +3746,34 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -3371,6 +3810,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
@@ -3411,6 +3857,73 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsonc-parser": {
@@ -3840,6 +4353,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -4021,6 +4541,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4101,6 +4628,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
@@ -4143,6 +4680,16 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -4233,6 +4780,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
@@ -4320,6 +4880,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -4356,6 +4923,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4446,6 +5027,13 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -4471,6 +5059,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyclip": {
@@ -4505,6 +5100,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -4565,6 +5216,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -5015,9 +5676,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5037,9 +5695,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5061,9 +5716,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5083,9 +5735,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5159,6 +5808,109 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -5168,6 +5920,75 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/core/marketplace/package.json
+++ b/core/marketplace/package.json
@@ -7,6 +7,8 @@
     "postbuild": "node scripts/check-served-domain-hygiene.mjs",
     "check:domain-hygiene": "node scripts/check-served-domain-hygiene.mjs",
     "preview": "astro preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test --config=./playwright.config.ts"
   },
   "dependencies": {
@@ -16,6 +18,8 @@
   },
   "devDependencies": {
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0"
+    "@tailwindcss/vite": "^4.0.0",
+    "jsdom": "^28.0.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { parseRateLimitBody, rateLimitMessage } from './rateLimitNotice';
+
 const API_BASE = '/api';
 
 let refreshing: Promise<void> | null = null;
@@ -80,16 +82,29 @@ async function request<T>(path: string, opts?: RequestInit): Promise<T> {
       const retry = await fetch(`${API_BASE}${path}`, { ...opts, headers: retryHeaders });
       if (!retry.ok) {
         const body = await retry.text();
-        throw new Error(`${retry.status}: ${body}`);
+        throw new Error(requestErrorMessage(retry.status, body));
       }
       return retry.json();
     }
   }
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`${res.status}: ${body}`);
+    throw new Error(requestErrorMessage(res.status, body));
   }
   return res.json();
+}
+
+/**
+ * #5634 (UAT row 92): callers surface `e.message` straight to the customer
+ * (CheckoutStep puts it in `provisionError`), so a throttled checkout used to
+ * read as a raw status code joined to a raw JSON blob. A 429 becomes the plain
+ * wait-and-retry notice instead, carrying the gateway's own `retry_after`.
+ * Every other status keeps the existing `<status>: <body>` shape that other
+ * call sites already match on.
+ */
+function requestErrorMessage(status: number, body: string): string {
+  if (status === 429) return rateLimitMessage(parseRateLimitBody(body), 'checkout');
+  return `${status}: ${body}`;
 }
 
 async function tryRefresh(): Promise<void> {

--- a/core/marketplace/src/lib/rateLimitNotice.ts
+++ b/core/marketplace/src/lib/rateLimitNotice.ts
@@ -1,0 +1,62 @@
+// #5634 (UAT row 92) — turn the gateway's 429 into something a customer can act on.
+//
+// `core/services/gateway/ratelimit.go` guards the funnel's submit paths with two
+// limiters, both of which answer HTTP 429 with a JSON body carrying a
+// `retry_after` field measured in seconds:
+//
+//   * the path-scoped voucher burst limiter (PR #4028), on the
+//     `/api/billing/vouchers/redeem` prefix —
+//     {"error":"too many redeem attempts — please wait a few seconds and try again","retry_after":10}
+//   * the global per-minute limiter —
+//     {"error":"rate limit exceeded","retry_after":<60-now.Second()>}
+//
+// The funnel used to discard both shapes, so a throttled customer was told their
+// voucher was invalid. These helpers keep the server's own retry window and turn
+// it into a notice that names what happened and how long to wait.
+
+/** Fallback wait when the server sends no usable `retry_after` — matches the
+ *  gateway's own `redeemWindowSec` default. */
+export const DEFAULT_RETRY_AFTER_SEC = 10;
+
+/** The subject of the throttled submit, so the notice can name the right thing. */
+export type RateLimitSubject = 'redeem' | 'checkout';
+
+type RateLimitBody = { error?: unknown; retry_after?: unknown };
+
+/**
+ * Read the server's retry window. Tolerates the field being absent, a string, or
+ * nonsense — a customer-facing wait must never render as `NaN` or `undefined`.
+ * Fractional windows round up so we never advise a wait shorter than the server's.
+ */
+export function retryAfterSeconds(body: unknown): number {
+  const raw = (body as RateLimitBody | null | undefined)?.retry_after;
+  const seconds = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isFinite(seconds) || seconds <= 0) return DEFAULT_RETRY_AFTER_SEC;
+  return Math.ceil(seconds);
+}
+
+/**
+ * The customer-facing notice. Deliberately states the cause (too many submits in
+ * a row) and the remedy (wait this long, then retry) rather than echoing a status
+ * code. For the redeem path it also says the code itself is still good, because
+ * the defect this fixes told throttled customers their voucher was invalid.
+ */
+export function rateLimitMessage(body: unknown, subject: RateLimitSubject): string {
+  const seconds = retryAfterSeconds(body);
+  const wait = seconds === 1 ? '1 second' : `${seconds} seconds`;
+  if (subject === 'redeem') {
+    return `You have submitted this voucher several times in a few seconds. `
+      + `Wait ${wait}, then try again — the code itself is still fine.`;
+  }
+  return `You have submitted checkout several times in a few seconds. `
+    + `Wait ${wait}, then try again — nothing has been charged.`;
+}
+
+/** Best-effort JSON parse of a response body that may be empty or not JSON. */
+export function parseRateLimitBody(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}

--- a/core/marketplace/src/lib/redeemPreview.test.ts
+++ b/core/marketplace/src/lib/redeemPreview.test.ts
@@ -1,0 +1,192 @@
+// #5634 (UAT row 92) — the funnel must surface the gateway's 429, and must NOT
+// surface it on a healthy submit.
+//
+// Both directions are asserted on purpose. A test that only proves "429 shows the
+// notice" passes just as happily against a page that shows the notice
+// unconditionally, which would be a worse bug than the one being fixed.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  applyRedeemOutcome,
+  classifyRedeemPreview,
+  GENERIC_VALIDATE_DETAIL,
+  NOT_VALID_DEFAULT_DETAIL,
+  REDEEM_PANELS,
+  showRedeemPanel,
+  type RedeemPanelId,
+} from './redeemPreview';
+import { DEFAULT_RETRY_AFTER_SEC, rateLimitMessage, retryAfterSeconds } from './rateLimitNotice';
+
+// The exact body `core/services/gateway/ratelimit.go` writes when the
+// voucher-redeem burst limiter trips (PR #4028).
+const GATEWAY_REDEEM_429 = {
+  error: 'too many redeem attempts — please wait a few seconds and try again',
+  retry_after: 10,
+};
+
+// The body the global per-minute limiter writes in the same middleware.
+const GATEWAY_GLOBAL_429 = { error: 'rate limit exceeded', retry_after: 37 };
+
+const VALID_PREVIEW = {
+  code: 'OMANI-WELCOME-25',
+  credit_omr: 25,
+  description: 'Welcome credit',
+  active: true,
+  accepting_redemptions: true,
+};
+
+/** Rebuild the panel skeleton that `src/pages/redeem.astro` renders. */
+function mountPanels(): void {
+  document.body.innerHTML = REDEEM_PANELS.map(id => {
+    const detail =
+      id === 'redeem-not-valid'
+        ? `<p id="redeem-not-valid-detail">${NOT_VALID_DEFAULT_DETAIL}</p>`
+        : id === 'redeem-throttled'
+          ? '<p id="redeem-throttled-detail"></p>'
+          : '';
+    return `<div id="${id}" class="hidden">${detail}</div>`;
+  }).join('');
+}
+
+function visiblePanels(): string[] {
+  return REDEEM_PANELS.filter(id => !document.getElementById(id)!.classList.contains('hidden'));
+}
+
+function throttleText(): string {
+  return document.getElementById('redeem-throttled-detail')!.textContent ?? '';
+}
+
+function notValidText(): string {
+  return document.getElementById('redeem-not-valid-detail')!.textContent ?? '';
+}
+
+/** Drive the page's decision the way `validate()` does: classify, then apply. */
+function submit(status: number, body: unknown): RedeemPanelId {
+  const outcome = classifyRedeemPreview(status, body);
+  applyRedeemOutcome(document, outcome);
+  return outcome.panel;
+}
+
+beforeEach(() => {
+  mountPanels();
+});
+
+describe('a rate-limited redeem submit IS surfaced', () => {
+  it('routes the gateway 429 to its own panel, not to "Voucher not valid"', () => {
+    expect(submit(429, GATEWAY_REDEEM_429)).toBe('redeem-throttled');
+    expect(visiblePanels()).toEqual(['redeem-throttled']);
+    // The regression this fixes: 429 reaching the not-valid panel.
+    expect(visiblePanels()).not.toContain('redeem-not-valid');
+  });
+
+  it('tells the customer what happened and how long to wait', () => {
+    submit(429, GATEWAY_REDEEM_429);
+    const text = throttleText();
+    expect(text).not.toBe('');
+    // What happened.
+    expect(text).toMatch(/several times in a few seconds/i);
+    // What to do — the server's own retry window, in seconds.
+    expect(text).toContain('Wait 10 seconds');
+    // Not a raw status code, and not an apology.
+    expect(text).not.toContain('429');
+    expect(text).not.toMatch(/sorry|apolog/i);
+    // Not the generic string that used to swallow this response.
+    expect(text).not.toBe(GENERIC_VALIDATE_DETAIL);
+  });
+
+  it('does not tell a throttled customer their voucher is invalid', () => {
+    submit(429, GATEWAY_REDEEM_429);
+    expect(throttleText()).toMatch(/still fine/i);
+    expect(throttleText()).not.toMatch(/not valid|does not exist|retired/i);
+  });
+
+  it('honours the global limiter body shape too', () => {
+    expect(submit(429, GATEWAY_GLOBAL_429)).toBe('redeem-throttled');
+    expect(throttleText()).toContain('Wait 37 seconds');
+  });
+
+  it('still renders a usable wait when the server sends no retry_after', () => {
+    expect(submit(429, { error: 'rate limit exceeded' })).toBe('redeem-throttled');
+    expect(throttleText()).toContain(`Wait ${DEFAULT_RETRY_AFTER_SEC} seconds`);
+    expect(throttleText()).not.toMatch(/NaN|undefined|null/);
+  });
+
+  it('still renders a usable wait when the 429 carries no body at all', () => {
+    expect(submit(429, null)).toBe('redeem-throttled');
+    expect(throttleText()).toContain(`Wait ${DEFAULT_RETRY_AFTER_SEC} seconds`);
+  });
+});
+
+describe('a normal submit does NOT surface the rate-limit notice', () => {
+  it('shows the valid panel on 200 and leaves the throttle copy empty', () => {
+    expect(submit(200, VALID_PREVIEW)).toBe('redeem-valid');
+    expect(visiblePanels()).not.toContain('redeem-throttled');
+    expect(throttleText()).toBe('');
+  });
+
+  it('keeps 404 on the not-valid panel with its own copy', () => {
+    expect(submit(404, null)).toBe('redeem-not-valid');
+    expect(visiblePanels()).toEqual(['redeem-not-valid']);
+    expect(notValidText()).toBe(NOT_VALID_DEFAULT_DETAIL);
+    expect(throttleText()).toBe('');
+  });
+
+  it('keeps 410 on the campaign-ended panel', () => {
+    expect(submit(410, { code: 'OLD', credit_omr: 5 })).toBe('redeem-ended');
+    expect(visiblePanels()).toEqual(['redeem-ended']);
+    expect(throttleText()).toBe('');
+  });
+
+  it('keeps other server errors on the generic not-valid copy', () => {
+    expect(submit(500, null)).toBe('redeem-not-valid');
+    expect(notValidText()).toBe(GENERIC_VALIDATE_DETAIL);
+    expect(throttleText()).toBe('');
+  });
+
+  it('does not leave the notice on screen after a throttled submit succeeds on retry', () => {
+    submit(429, GATEWAY_REDEEM_429);
+    expect(visiblePanels()).toEqual(['redeem-throttled']);
+    // The retry the customer makes after waiting out the window.
+    expect(submit(200, VALID_PREVIEW)).toBe('redeem-valid');
+    expect(visiblePanels()).toEqual(['redeem-valid']);
+    expect(document.getElementById('redeem-throttled')!.classList.contains('hidden')).toBe(true);
+  });
+});
+
+describe('showRedeemPanel', () => {
+  it('reveals exactly one panel', () => {
+    showRedeemPanel(document, 'redeem-loading');
+    expect(visiblePanels()).toEqual(['redeem-loading']);
+    showRedeemPanel(document, 'redeem-missing');
+    expect(visiblePanels()).toEqual(['redeem-missing']);
+  });
+});
+
+describe('retryAfterSeconds', () => {
+  it('uses the server value when usable', () => {
+    expect(retryAfterSeconds({ retry_after: 10 })).toBe(10);
+    expect(retryAfterSeconds({ retry_after: '25' })).toBe(25);
+    expect(retryAfterSeconds({ retry_after: 1.2 })).toBe(2); // never advise a shorter wait
+  });
+
+  it('falls back on missing or nonsense values', () => {
+    for (const body of [null, undefined, {}, { retry_after: 0 }, { retry_after: -5 }, { retry_after: 'soon' }]) {
+      expect(retryAfterSeconds(body)).toBe(DEFAULT_RETRY_AFTER_SEC);
+    }
+  });
+});
+
+describe('rateLimitMessage', () => {
+  it('names checkout on the checkout path and says nothing was charged', () => {
+    const text = rateLimitMessage(GATEWAY_GLOBAL_429, 'checkout');
+    expect(text).toMatch(/submitted checkout several times/i);
+    expect(text).toContain('Wait 37 seconds');
+    expect(text).toMatch(/nothing has been charged/i);
+    expect(text).not.toContain('429');
+  });
+
+  it('uses the singular for a one-second window', () => {
+    expect(rateLimitMessage({ retry_after: 1 }, 'redeem')).toContain('Wait 1 second,');
+  });
+});

--- a/core/marketplace/src/lib/redeemPreview.ts
+++ b/core/marketplace/src/lib/redeemPreview.ts
@@ -1,0 +1,74 @@
+// #5634 (UAT row 92) — the /redeem landing's response-to-panel decision, lifted
+// out of `src/pages/redeem.astro` so it can be tested without a browser.
+//
+// The page owns a set of sibling panels and reveals exactly one. Before this
+// module existed the page handled 404 and 410 by hand and then funnelled EVERY
+// other non-ok status — 429 included — into one `if (!res.ok)` branch that showed
+// the "Voucher not valid" panel. A rate-limited customer was therefore told their
+// code was bad. 429 now gets its own panel and carries the server's retry window.
+
+import { rateLimitMessage } from './rateLimitNotice';
+
+export const REDEEM_PANELS = [
+  'redeem-loading',
+  'redeem-missing',
+  'redeem-not-valid',
+  'redeem-ended',
+  'redeem-throttled',
+  'redeem-valid',
+] as const;
+
+export type RedeemPanelId = (typeof REDEEM_PANELS)[number];
+
+/** Shown when the voucher service answers, but with something we cannot read. */
+export const GENERIC_VALIDATE_DETAIL =
+  'Could not validate the voucher right now. Please try again in a moment.';
+
+/** The panel's own resting copy, restored on 404 so a previous failure's detail
+ *  text cannot bleed into an unrelated "unknown code" answer. */
+export const NOT_VALID_DEFAULT_DETAIL = 'This code does not exist or has been retired.';
+
+export type RedeemOutcome =
+  | { panel: 'redeem-valid' }
+  | { panel: 'redeem-ended' }
+  | { panel: 'redeem-not-valid'; detail: string }
+  | { panel: 'redeem-throttled'; detail: string };
+
+/**
+ * Map a redeem-preview response onto the panel the customer should see.
+ * `status` is the HTTP status; `body` is the parsed JSON body, or null when the
+ * response carried none.
+ */
+export function classifyRedeemPreview(status: number, body: unknown): RedeemOutcome {
+  if (status === 404) return { panel: 'redeem-not-valid', detail: NOT_VALID_DEFAULT_DETAIL };
+  if (status === 410) return { panel: 'redeem-ended' };
+  // #5634: 429 is answered by the gateway limiter, not by the voucher store —
+  // it says nothing about whether the code is valid, so it must not reach the
+  // "Voucher not valid" panel.
+  if (status === 429) return { panel: 'redeem-throttled', detail: rateLimitMessage(body, 'redeem') };
+  // Everything else non-2xx keeps the previous generic treatment (`!res.ok`).
+  if (status < 200 || status >= 300) {
+    return { panel: 'redeem-not-valid', detail: GENERIC_VALIDATE_DETAIL };
+  }
+  return { panel: 'redeem-valid' };
+}
+
+/** Reveal exactly one panel, hiding the rest. */
+export function showRedeemPanel(doc: Document, panel: RedeemPanelId): void {
+  for (const id of REDEEM_PANELS) {
+    const el = doc.getElementById(id);
+    if (el) el.classList.toggle('hidden', id !== panel);
+  }
+}
+
+/** Write the outcome's detail copy into its panel, then reveal that panel. */
+export function applyRedeemOutcome(doc: Document, outcome: RedeemOutcome): void {
+  if (outcome.panel === 'redeem-throttled') {
+    const el = doc.getElementById('redeem-throttled-detail');
+    if (el) el.textContent = outcome.detail;
+  } else if (outcome.panel === 'redeem-not-valid') {
+    const el = doc.getElementById('redeem-not-valid-detail');
+    if (el) el.textContent = outcome.detail;
+  }
+  showRedeemPanel(doc, outcome.panel);
+}

--- a/core/marketplace/src/pages/redeem.astro
+++ b/core/marketplace/src/pages/redeem.astro
@@ -85,6 +85,23 @@ import Layout from '../layouts/Layout.astro';
       </a>
     </div>
 
+    <!--
+      #5634 (UAT row 92): the gateway burst-limits the redeem path and answers 429
+      with its own retry window. That answer is about how fast the customer is
+      going, NOT about the voucher, so it gets its own panel — routing it to
+      "Voucher not valid" told throttled customers their code was bad.
+    -->
+    <div id="redeem-throttled" class="hidden rounded-2xl border border-[var(--color-warn)]/30 bg-[var(--color-warn)]/10 p-8 text-center">
+      <h1 class="text-2xl font-bold text-[var(--color-text-strong)]">Too many attempts</h1>
+      <p id="redeem-throttled-detail" class="mt-2 text-sm text-[var(--color-text-dim)]"></p>
+      <button
+        id="redeem-throttled-retry"
+        class="mt-6 inline-block rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+      >
+        Try again
+      </button>
+    </div>
+
     <div id="redeem-valid" class="hidden">
       <div class="rounded-2xl border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-8 text-center">
         <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-success)]/20">
@@ -128,16 +145,22 @@ import Layout from '../layouts/Layout.astro';
     // imports resolve. No new session mechanism is introduced.
     import { getMyOrgs, setActiveOrgConsoleHost } from '../lib/api';
     import { consoleLaunchHref } from '../lib/config';
+    // #5634 (UAT row 92): the response-to-panel decision lives in a plain module
+    // so it can be unit-tested; this page keeps only the DOM writes that need the
+    // response body.
+    import {
+      applyRedeemOutcome,
+      classifyRedeemPreview,
+      showRedeemPanel,
+      type RedeemPanelId,
+    } from '../lib/redeemPreview';
 
     // Storage key shared with CheckoutStep: when a pending voucher is set,
     // the checkout step will pre-fill the promo_code field.
     const PENDING_VOUCHER_KEY = 'org-pending-voucher';
 
-    function show(id: string) {
-      ['redeem-loading', 'redeem-missing', 'redeem-not-valid', 'redeem-ended', 'redeem-valid'].forEach(x => {
-        const el = document.getElementById(x);
-        if (el) el.classList.toggle('hidden', x !== id);
-      });
+    function show(id: RedeemPanelId) {
+      showRedeemPanel(document, id);
     }
 
     async function validate(code: string) {
@@ -148,25 +171,31 @@ import Layout from '../layouts/Layout.astro';
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ code }),
         });
-        if (res.status === 404) {
-          show('redeem-not-valid');
-          return;
-        }
-        if (res.status === 410) {
+        // Read the body once, up front: the 429 notice needs the server's
+        // `retry_after`, and 404 responses may carry no body at all.
+        let body: any = null;
+        try { body = await res.json(); } catch { body = null; }
+
+        const outcome = classifyRedeemPreview(res.status, body);
+
+        if (outcome.panel === 'redeem-ended') {
           // Campaign ended — body still has credit + description.
-          const body = await res.json();
-          (document.getElementById('redeem-ended-code') as HTMLElement).textContent = body.code || code;
-          (document.getElementById('redeem-ended-credit') as HTMLElement).textContent = String(body.credit_omr ?? '');
-          show('redeem-ended');
+          (document.getElementById('redeem-ended-code') as HTMLElement).textContent = body?.code || code;
+          (document.getElementById('redeem-ended-credit') as HTMLElement).textContent = String(body?.credit_omr ?? '');
+        }
+
+        if (outcome.panel === 'redeem-throttled') {
+          // #5634: let the customer retry once the server's window has passed
+          // without re-pasting the code.
+          const retry = document.getElementById('redeem-throttled-retry');
+          if (retry) retry.onclick = () => { validate(code); };
+        }
+
+        if (outcome.panel !== 'redeem-valid') {
+          applyRedeemOutcome(document, outcome);
           return;
         }
-        if (!res.ok) {
-          (document.getElementById('redeem-not-valid-detail') as HTMLElement).textContent =
-            'Could not validate the voucher right now. Please try again in a moment.';
-          show('redeem-not-valid');
-          return;
-        }
-        const body = await res.json();
+
         (document.getElementById('redeem-valid-credit') as HTMLElement).textContent =
           `${body.credit_omr} OMR credit`;
         (document.getElementById('redeem-valid-desc') as HTMLElement).textContent =

--- a/core/marketplace/vitest.config.ts
+++ b/core/marketplace/vitest.config.ts
@@ -1,0 +1,11 @@
+// #5634 (UAT row 92) — unit tests for the funnel's plain TypeScript modules.
+// The page-level Astro/Svelte surfaces stay covered by the Playwright suite in
+// `playwright/`; this config only picks up `src/**/*.test.ts`.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## What UAT row 92 asks for

As the signed-in customer, rapidly re-submit checkout/redeem more than 5 times in a few seconds and a rate-limit notice must appear; a single legitimate redeem stays unaffected.

## The split, confirmed in source

**The server is right.** `core/services/gateway/ratelimit.go` runs two limiters. The path-scoped voucher burst limiter (PR #4028) guards the `/api/billing/vouchers/redeem` prefix and answers **HTTP 429** with

    {"error":"too many redeem attempts — please wait a few seconds and try again","retry_after":10}

The global per-minute limiter in the same middleware answers 429 with `{"error":"rate limit exceeded","retry_after":<60-now.Second()>}`. The hw292-2026-08-03 walk recorded 12 of 20 serial POSTs limited, ending in seven consecutive 429s, with a clean 200 after waiting out `retry_after`. No server change is needed and none is made here.

**The customer-facing half threw the answer away.** `core/marketplace/src/pages/redeem.astro` handled 404 and 410 by hand and then funnelled every other non-ok status — 429 included — into one not-ok branch that overwrote the detail with

    Could not validate the voucher right now. Please try again in a moment.

and revealed the `redeem-not-valid` panel, whose heading reads **Voucher not valid**. So a throttled customer was told their code was bad, and `retry_after` was dropped.

Secondary, same row: `request()` in `src/lib/api.ts` threw an Error whose message was the status joined to the raw body. `CheckoutStep.svelte` assigns that straight to `provisionError`, so a throttled checkout rendered a status code and a JSON blob.

### Where the call site lives

All three console trees were grepped for the redeem/checkout endpoints — `core/console` (org-console), `products/catalyst/console`, and `products/catalyst/bootstrap/ui` (sovereign-admin). **None of them call these endpoints.** `core/console` only mentions 429 in two unrelated comments about caching a jobs slice. The funnel call sites are in a fourth surface, `core/marketplace/` (the storefront), which matches the row's `funnel` area column.

## The fix

- **`src/lib/rateLimitNotice.ts`** (new) — reads the server's `retry_after`, tolerating a missing, string, or nonsense value and rounding up so the advised wait is never shorter than the server's. Builds the notice.
- **`src/lib/redeemPreview.ts`** (new) — the response-to-panel decision, lifted out of the Astro page so it can be tested without a browser. 429 maps to its own outcome rather than falling through.
- **`redeem.astro`** — gains a `redeem-throttled` panel following the existing sibling-panel idiom (same markup shape and `show()` mechanism as `redeem-ended`), with a Try-again button that re-validates without the customer re-pasting the code. No new toast or notification system is introduced.
- **`api.ts`** — maps 429 onto the same notice so the checkout path surfaces prose instead of a status code. Every other status keeps the existing `<status>: <body>` shape that other call sites already match on.

The copy names the cause and the remedy rather than echoing a status code, and on the redeem path it explicitly says the code is still fine — countering the exact wrong impression the old behaviour gave:

> You have submitted this voucher several times in a few seconds. Wait 10 seconds, then try again — the code itself is still fine.

## Tests — both directions

`src/lib/redeemPreview.test.ts`, 16 cases. The positive direction asserts the notice IS surfaced on 429, for the voucher-burst body, the global-limiter body, a 429 with no `retry_after`, and a 429 with no body at all — and that the text carries the server's window, contains no status code, is not an apology, and does not say the voucher is invalid. The negative direction asserts the notice is NOT surfaced on 200, 404, 410 or 500, and that it clears once a throttled customer retries successfully.

A one-directional test would pass against a page that shows the notice unconditionally, so the negative half is load-bearing. **Vacuity-checked**: removing the 429 branch turns **7 of 16 red**, and the 9 that stay green are exactly the negative direction.

## Gates

Run in `core/marketplace`:

| Command | Result |
|---|---|
| `npm ci` | clean install |
| `npx vitest run src/lib/redeemPreview.test.ts` | **16 passed (16)**, 1 file |
| `npx vitest run` | **16 passed (16)**, 1 file |
| `npm run build` | 11 pages built; postbuild domain-hygiene **OK — 37 files scanned, zero banned domain literals** |
| `npx tsc --noEmit` on the changed modules | exit 0 |

This package has no `tsc -b` script and no composite tsconfig, so the type check was run directly against the changed modules. No Go source changed.

Built-artifact check: `dist/redeem/index.html` carries `redeem-throttled`, `redeem-throttled-detail` and `redeem-throttled-retry` plus the Too-many-attempts heading, and the notice string is bundled into `dist/_astro/api.*.js`.

## For the merger

- No server change. The limiter and its budget stay exactly as they are; #5484 tracks the server-side budget and trusted-proxy CIDR separately and is untouched here.
- `package.json` gains `vitest` and `jsdom` as devDependencies plus `test` / `test:watch` scripts — this package previously had no unit-test runner, only Playwright. `package-lock.json` is regenerated accordingly. The Playwright suite is unchanged and its selectors (`#redeem-valid`, `#redeem-valid-credit`, `#redeem-valid-code`, `#redeem-missing`, `#redeem-manual-code`) all still resolve.
- `vitest.config.ts` scopes collection to `src/**/*.test.ts` so it never picks up the Playwright specs.
- The 404 path now explicitly restores the panel's resting copy, so a previous failure's detail text can no longer bleed into an unrelated unknown-code answer.
- Row 92 stays red until an operator walks it on a live env; this lands the UI half.

Refs #5634
Refs #3376
