### PR TITLE
fix(catalog-seed): gate every seed delivery pin on GHCR existence + complete the guacamole 5th-site lockstep

### DIFF
--- a/.github/workflows/check-catalog-seed-lockstep.yaml
+++ b/.github/workflows/check-catalog-seed-lockstep.yaml
@@ -10,7 +10,11 @@ name: catalog-seed lockstep guard
 # See scripts/check-catalog-seed-lockstep.sh for the check + the 14/14
 # initial lockstep sweep (PRs #2906-#2909 + #2883-#2905).
 #
-# Refs G117 #2744.
+# The second job (`ghcr-pin-existence`, #5559 / UAT row R21) asserts every seed
+# delivery pin resolves to a real published tag on ghcr.io — the one seed
+# property no in-repo guard can see. See the script header for why.
+#
+# Refs G117 #2744, #5559.
 
 on:
   push:
@@ -19,18 +23,33 @@ on:
       - 'products/catalyst/chart/templates/catalog-seed/blueprints.yaml'
       - 'platform/**/blueprint.yaml'
       - 'scripts/check-catalog-seed-lockstep.sh'
+      - 'scripts/expected-unpublished-catalog-seed-pins.yaml'
+      - 'scripts/lib/parse-catalog-seed-pins.awk'
       - '.github/workflows/check-catalog-seed-lockstep.yaml'
   pull_request:
     paths:
       - 'products/catalyst/chart/templates/catalog-seed/blueprints.yaml'
       - 'platform/**/blueprint.yaml'
       - 'scripts/check-catalog-seed-lockstep.sh'
+      - 'scripts/expected-unpublished-catalog-seed-pins.yaml'
+      - 'scripts/lib/parse-catalog-seed-pins.awk'
       - '.github/workflows/check-catalog-seed-lockstep.yaml'
   workflow_dispatch:
+  # #5559 — publish-lag safety net, same cadence rationale as the #4409 cron on
+  # test-bootstrap-kit.yaml. A seed pin can be merged minutes before
+  # blueprint-release.yaml finishes publishing its chart; the PR/push run would
+  # then see a legitimately-in-flight tag as missing. Those events are therefore
+  # observational for the GHCR phase (see continue-on-error below) and this
+  # hourly sweep is the fail-loud one: by the time it fires there is no publish
+  # race left to excuse a missing tag.
+  schedule:
+    - cron: '43 * * * *'
 
 jobs:
   lockstep:
+    # Field-level seed-vs-source drift. Blocking on every event, unchanged.
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - name: Install yq + helm
@@ -44,3 +63,36 @@ jobs:
           helm version --short || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Run catalog-seed lockstep check
         run: bash scripts/check-catalog-seed-lockstep.sh
+
+  ghcr-pin-existence:
+    # #5559 (UAT row R21) — every catalog-seed `source.chart`:`source.version`
+    # must exist as a published tag on ghcr.io/openova-io.
+    #
+    # Why this is a separate job from `lockstep` above: the GHCR phase races
+    # blueprint-release.yaml on push/PR (a chart bump merges before its publish
+    # run finishes), so it needs continue-on-error on those events. Putting it
+    # in the same job would extend that tolerance over the field-drift check,
+    # which must stay hard-blocking. The `schedule` event is excluded from the
+    # tolerance and fails loud.
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ github.event_name != 'schedule' }}
+    permissions:
+      # `gh api /orgs/<org>/packages/container/<chart>/versions` needs
+      # read:packages for package metadata.
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yq + helm
+        run: |
+          set -e
+          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -O /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+          helm version --short || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Assert every catalog-seed delivery pin exists on GHCR
+        env:
+          # `gh` defers to GH_TOKEN on a runner; pass the workflow token so the
+          # package-listing call picks up the `packages: read` scope above.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/check-catalog-seed-lockstep.sh --check-ghcr

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T20:34:46.711Z",
+  "generatedAt": "2026-08-03T21:19:19.974Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -1817,7 +1817,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1952,7 +1952,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.34",
+    "version": "0.2.35",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1727,7 +1727,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.34"
+  version: "0.2.35"
   visibility: listed
   card:
     title: "Apache Guacamole"
@@ -1745,7 +1745,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.34"
+    version: "0.2.35"
   topology:
     supported:
     - active-hot-standby

--- a/scripts/check-catalog-seed-lockstep.sh
+++ b/scripts/check-catalog-seed-lockstep.sh
@@ -269,9 +269,36 @@ if [ -n "${CHECK_GHCR}" ]; then
   # reason TestCatalogSeed_DeliveryPinsNotBehindComponentCharts excludes it.
   SELF_REFERENTIAL="bp-catalyst-platform"
 
-  # Register rows, as `chart<TAB>version` — the two fields the invariants key on.
-  register="$(yq eval '.unpublished[] | .chart + "\t" + .version' "${UNPUBLISHED_REGISTER}" 2>/dev/null || true)"
-  register_charts="$(printf '%s\n' "$register" | cut -f1 | grep -v '^$' || true)"
+  # Register rows, as `chart|version` — the two fields the invariants key on.
+  #
+  # The delimiter is a literal `|`, NOT "\t". yq's handling of the "\t" escape
+  # is build-dependent: v4.53 emits a real tab, v4.45 (what CI installs) emits a
+  # literal backslash-t, which silently turned every chart name into
+  # `bp-redis\t1.0.0` and made every register lookup miss. Caught on the first
+  # CI run of this gate. A delimiter with no escape sequence cannot regress that
+  # way.
+  register="$(yq eval '.unpublished[] | .chart + "|" + .version' "${UNPUBLISHED_REGISTER}" 2>/dev/null || true)"
+  register_charts="$(printf '%s\n' "$register" | cut -d'|' -f1 | grep -v '^$' || true)"
+
+  # Control on the register parser itself. A malformed parse (wrong delimiter,
+  # yq version skew, a hand-edited row) yields chart names carrying whitespace,
+  # a backslash, or a stray `|`. Left undetected, every lookup misses and the
+  # gate reports the declared known-gaps as fresh defects — which is exactly how
+  # the yq "\t" skew above presented. Fail as an input error, not a pin defect.
+  register_rows="$(printf '%s\n' "$register" | grep -c . || true)"
+  if [ "${register_rows}" -eq 0 ]; then
+    echo "ERROR: parsed zero rows from ${UNPUBLISHED_REGISTER#${REPO_ROOT}/} — the register parser is broken." >&2
+    exit 2
+  fi
+  for rc in $register_charts; do
+    case "$rc" in
+      *[!A-Za-z0-9._-]*)
+        echo "ERROR: register parsed a malformed chart name '${rc}'." >&2
+        echo "Expected a bare chart name. Check the yq expression and ${UNPUBLISHED_REGISTER#${REPO_ROOT}/}." >&2
+        exit 2
+        ;;
+    esac
+  done
 
   # Rendered seed rows, as `name|visibility|source.chart|source.version`.
   # Parsed with awk, not yq: `yq eval-all 'select(.kind == "Blueprint")'` over
@@ -313,7 +340,7 @@ if [ -n "${CHECK_GHCR}" ]; then
     fi
 
     # Is this (chart, version) declared in the known-gap register?
-    registered_ver="$(printf '%s\n' "$register" | awk -F'\t' -v c="$src_chart" '$1 == c {print $2; exit}')"
+    registered_ver="$(printf '%s\n' "$register" | awk -F'|' -v c="$src_chart" '$1 == c {print $2; exit}')"
 
     if [ -n "$registered_ver" ]; then
       # ── Invariant 3: the register self-retires the moment the chart ships.

--- a/scripts/check-catalog-seed-lockstep.sh
+++ b/scripts/check-catalog-seed-lockstep.sh
@@ -25,16 +25,56 @@
 #   2 — missing required tool (yq) or input files
 #
 # Usage:
-#   ./scripts/check-catalog-seed-lockstep.sh
+#   ./scripts/check-catalog-seed-lockstep.sh [--check-ghcr] [--ghcr-org <org>]
 #
 # CI integration: invoked by .github/workflows/check-catalog-seed-lockstep.yaml
 # on every push/PR touching either tree.
+#
+# ─────────────────────────────────────────────────────────────────────────
+# `--check-ghcr` — catalog-seed GHCR existence gate (UAT row R21, #5559)
+# ─────────────────────────────────────────────────────────────────────────
+# Every field-level check above compares the seed against ANOTHER FILE IN
+# THIS REPO. So does every existing seed guard:
+#
+#   - TestCatalogSeed_DeliveryPinsNotBehindComponentCharts (#4415) compares
+#     source.version against platform/<x>/chart/Chart.yaml;
+#   - TestCatalogSeed_DisplayVersionNotBehindDeliveryPin  (#4432) compares
+#     spec.version against the same;
+#   - check-bootstrap-kit-pin-sync.sh --check-ghcr (TBD-A26) DOES query GHCR,
+#     but only for charts pinned in clusters/_template/bootstrap-kit/ — 67
+#     slot pins, and only charts that have a Chart.yaml in the repo.
+#
+# None of them can see a seed pin whose chart was NEVER PUBLISHED, because a
+# chart with no co-located Chart.yaml is skipped as "external — not a drift".
+# That is the whole #5559 blind spot: 5 of the 80 seeded Blueprints reference
+# a package that returns HTTP 404 on ghcr.io, and every in-repo guard is green.
+#
+# This phase closes it: for every `source.chart` + `source.version` pin in the
+# RENDERED seed, call the GHCR versions API and assert the pinned version is a
+# published tag. Known gaps are declared in
+# scripts/expected-unpublished-catalog-seed-pins.yaml, which the gate holds to
+# four self-retiring invariants (see that file's header). Requires `gh`
+# authenticated with the read:packages scope.
+#
+# Exit code 1 also covers a missing GHCR tag / a stale or dead register entry.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CHART_SEED="${REPO_ROOT}/products/catalyst/chart/templates/catalog-seed/blueprints.yaml"
 PLATFORM_DIR="${REPO_ROOT}/platform"
+UNPUBLISHED_REGISTER="${REPO_ROOT}/scripts/expected-unpublished-catalog-seed-pins.yaml"
+
+CHECK_GHCR=""
+GHCR_ORG="openova-io"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check-ghcr) CHECK_GHCR=1; shift ;;
+    --ghcr-org)   GHCR_ORG="$2"; shift 2 ;;
+    -h|--help)    sed -n '2,70p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
 
 if ! command -v yq >/dev/null 2>&1; then
   echo "ERROR: yq not installed (apt-get install yq OR brew install yq)" >&2
@@ -199,6 +239,180 @@ if [ "$fail" -ne 0 ]; then
   echo "  - update products/catalyst/chart/templates/catalog-seed/blueprints.yaml to match platform/<bp>/blueprint.yaml, OR"
   echo "  - update platform/<bp>/blueprint.yaml to match the chart-seed entry."
   echo "The chart-seed is the in-cluster fallback path when gitea catalog-sovereign 404s — keeping them aligned is the contract."
+else
+  echo "PASS: every chart-seed Blueprint with a platform/ source declares matching topology + endpoints + sso fields."
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# #5559 (UAT row R21) — catalog-seed GHCR artifact existence gate
+# ──────────────────────────────────────────────────────────────────────
+# Assert every seed delivery pin (source.chart + source.version) resolves to
+# a published tag on ghcr.io/<org>. See the header for why no existing guard
+# can see this class of defect.
+if [ -n "${CHECK_GHCR}" ]; then
+  echo
+  echo "── #5559: catalog-seed GHCR artifact existence check (${GHCR_ORG}) ──"
+  for tool in gh jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "ERROR: --check-ghcr requires '$tool' on PATH" >&2
+      exit 2
+    fi
+  done
+  if [ ! -f "${UNPUBLISHED_REGISTER}" ]; then
+    echo "ERROR: known-gap register not found at ${UNPUBLISHED_REGISTER}" >&2
+    exit 2
+  fi
+
+  # bp-catalyst-platform is the umbrella chart this very seed ships INSIDE;
+  # its version auto-increments on every merge, so the seed can never
+  # reference an already-published version of itself. Excluded for the same
+  # reason TestCatalogSeed_DeliveryPinsNotBehindComponentCharts excludes it.
+  SELF_REFERENTIAL="bp-catalyst-platform"
+
+  # Register rows, as `chart<TAB>version` — the two fields the invariants key on.
+  register="$(yq eval '.unpublished[] | .chart + "\t" + .version' "${UNPUBLISHED_REGISTER}" 2>/dev/null || true)"
+  register_charts="$(printf '%s\n' "$register" | cut -f1 | grep -v '^$' || true)"
+
+  # Rendered seed rows, as `name|visibility|source.chart|source.version`.
+  # Parsed with awk, not yq: `yq eval-all 'select(.kind == "Blueprint")'` over
+  # this ~6000-line/80-document stream takes ~3 minutes. See the header of
+  # scripts/lib/parse-catalog-seed-pins.awk.
+  seed_rows="$(awk -f "${REPO_ROOT}/scripts/lib/parse-catalog-seed-pins.awk" "$TMP/rendered.yaml")"
+
+  ghcr_fail=0
+  ghcr_checked=0
+  ghcr_waived=0
+  ghcr_ok=0
+  seen_charts=""
+  TAGCACHE="$TMP/tagcache"
+  mkdir -p "$TAGCACHE"
+
+  while IFS='|' read -r bp_name bp_vis src_chart src_ver; do
+    [ -n "$src_chart" ] || continue
+    [ -n "$src_ver" ] || continue
+    [ "$src_chart" = "$SELF_REFERENTIAL" ] && continue
+    seen_charts="${seen_charts}${src_chart}
+"
+
+    # Fetch + cache the published tag list for this package. A non-zero exit
+    # from `gh api` means the package itself does not exist (HTTP 404) — an
+    # empty tag list, which is exactly the condition we are gating on.
+    cache_file="${TAGCACHE}/${src_chart}"
+    if [ ! -f "$cache_file" ]; then
+      if ! gh api "/orgs/${GHCR_ORG}/packages/container/${src_chart}/versions" --paginate \
+           --jq '.[].metadata.container.tags[]?' > "$cache_file" 2>/dev/null; then
+        : > "$cache_file"
+      fi
+      grep -v '^sha256-' "$cache_file" | sort -u > "${cache_file}.tags" || true
+      mv "${cache_file}.tags" "$cache_file"
+    fi
+
+    published=0
+    if grep -qx -- "$src_ver" "$cache_file" 2>/dev/null; then
+      published=1
+    fi
+
+    # Is this (chart, version) declared in the known-gap register?
+    registered_ver="$(printf '%s\n' "$register" | awk -F'\t' -v c="$src_chart" '$1 == c {print $2; exit}')"
+
+    if [ -n "$registered_ver" ]; then
+      # ── Invariant 3: the register self-retires the moment the chart ships.
+      if [ "$published" -eq 1 ]; then
+        echo "  FAIL ${bp_name}: ${src_chart}:${src_ver} IS published on ghcr.io/${GHCR_ORG} but is still listed in"
+        echo "       scripts/expected-unpublished-catalog-seed-pins.yaml — delete that row (stale register entry)."
+        ghcr_fail=$((ghcr_fail + 1))
+        continue
+      fi
+      # ── Invariant 1: register version must track the seed pin.
+      if [ "$registered_ver" != "$src_ver" ]; then
+        echo "  FAIL ${bp_name}: seed pins ${src_chart}:${src_ver} but the register declares ${src_chart}:${registered_ver}."
+        echo "       Re-pinning a seed entry re-arms this gate on purpose — publish the chart, or update the register row."
+        ghcr_fail=$((ghcr_fail + 1))
+        continue
+      fi
+      # ── Invariant 2: an unpublished chart must never be storefront-visible.
+      if [ "$bp_vis" != "unlisted" ]; then
+        echo "  FAIL ${bp_name}: visibility='${bp_vis}' while ${src_chart}:${src_ver} does NOT exist on ghcr.io/${GHCR_ORG}."
+        echo "       A customer-reachable Blueprint whose chart cannot be pulled is a customer-facing defect."
+        echo "       Either publish the chart, or set 'visibility: unlisted' on this seed entry."
+        ghcr_fail=$((ghcr_fail + 1))
+        continue
+      fi
+      echo "  KNOWN-GAP ${bp_name}: ${src_chart}:${src_ver} unpublished, unlisted, declared (#5559)"
+      ghcr_waived=$((ghcr_waived + 1))
+      continue
+    fi
+
+    ghcr_checked=$((ghcr_checked + 1))
+    if [ "$published" -eq 1 ]; then
+      ghcr_ok=$((ghcr_ok + 1))
+      echo "  GHCR OK   ${bp_name}: ${src_chart}:${src_ver}"
+    else
+      echo "  GHCR MISS ${bp_name}: ${src_chart}:${src_ver} — tag NOT FOUND on ghcr.io/${GHCR_ORG}/${src_chart} (visibility=${bp_vis})"
+      ghcr_fail=$((ghcr_fail + 1))
+    fi
+  done <<< "$seed_rows"
+
+  # ── Invariant 4: no dead register rows.
+  for rc in $register_charts; do
+    if ! printf '%s' "$seen_charts" | grep -qx -- "$rc"; then
+      echo "  FAIL register: '${rc}' is declared in scripts/expected-unpublished-catalog-seed-pins.yaml"
+      echo "       but no catalog-seed entry delivers that chart — delete the dead row."
+      ghcr_fail=$((ghcr_fail + 1))
+    fi
+  done
+
+  # ── Vacuity guard: if the parser stops finding pins, the loop above would
+  # pass on nothing. A negative assertion that runs zero times is not a gate.
+  if [ "$ghcr_checked" -eq 0 ]; then
+    echo
+    echo "FAIL: zero catalog-seed delivery pins were GHCR-checked — the rendered-seed parser is broken."
+    echo "The seed carries dozens of source blocks; checking none of them means this gate proves nothing."
+    exit 1
+  fi
+
+  # ── Control probe: distinguish "the pins are wrong" from "the API is".
+  # An unauthenticated / scope-less `gh` makes EVERY lookup return nothing, and
+  # the loop above would then report every pin as a defect. Dozens of charts
+  # cannot un-publish simultaneously, so zero resolutions with a non-zero
+  # check count is an API or auth failure. Exit 2 (infrastructure) rather than
+  # 1 (pin defect) so the diagnosis is not inverted.
+  if [ "$ghcr_ok" -eq 0 ]; then
+    echo
+    echo "ERROR: ${ghcr_checked} pin(s) were checked and NOT ONE resolved on ghcr.io/${GHCR_ORG}."
+    echo "That is an API/auth failure, not ${ghcr_checked} simultaneous pin defects."
+    echo "Check that 'gh' is authenticated with the read:packages scope"
+    echo "(in CI: grant 'packages: read' and pass GH_TOKEN to the step)."
+    exit 2
+  fi
+
+  echo
+  echo "GHCR-checked ${ghcr_checked} seed pin(s) (${ghcr_ok} resolved); ${ghcr_waived} declared known-gap(s); ${ghcr_fail} failure(s)."
+  if [ "$ghcr_fail" -gt 0 ]; then
+    echo
+    echo "FAIL: ${ghcr_fail} catalog-seed pin(s) reference a chart version that does NOT"
+    echo "exist on ghcr.io/${GHCR_ORG}, or violate the known-gap register's invariants."
+    echo
+    echo "A seeded Blueprint whose chart cannot be pulled renders a catalog entry that can"
+    echo "never install. When it is also 'visibility: listed', a customer can select it."
+    echo
+    echo "Fix, in order of preference:"
+    echo "  1. Publish the chart, then sync ALL FIVE lockstep sites:"
+    echo "     chart/Chart.yaml, blueprint.yaml, the catalog seed, the umbrella/bootstrap"
+    echo "     pin, and clusters/_template/bootstrap-kit/<NN>-<name>.yaml."
+    echo "  2. If the publish is genuinely in flight, re-run once blueprint-release.yaml"
+    echo "     finishes — this gate is observational on push/PR for exactly that race."
+    echo "  3. If the chart does not exist yet, declare it in"
+    echo "     scripts/expected-unpublished-catalog-seed-pins.yaml AND set the seed entry"
+    echo "     to 'visibility: unlisted'."
+    echo
+    echo "Deleting the seed entry to make this gate pass is NOT a fix — it hides the"
+    echo "defect while leaving the catalog exactly as broken."
+    exit 1
+  fi
+  echo "PASS: every catalog-seed delivery pin resolves to a published GHCR tag."
+fi
+
+if [ "$fail" -ne 0 ]; then
   exit 1
 fi
-echo "PASS: every chart-seed Blueprint with a platform/ source declares matching topology + endpoints + sso fields."

--- a/scripts/expected-unpublished-catalog-seed-pins.yaml
+++ b/scripts/expected-unpublished-catalog-seed-pins.yaml
@@ -1,0 +1,76 @@
+# scripts/expected-unpublished-catalog-seed-pins.yaml
+#
+# Declared known-gap register for the catalog-seed GHCR existence gate
+# (`scripts/check-catalog-seed-lockstep.sh --check-ghcr`, UAT row R21, #5559).
+#
+# ── What this file is ────────────────────────────────────────────────────
+# The gate asserts that EVERY `source.chart` + `source.version` pin in
+# products/catalyst/chart/templates/catalog-seed/blueprints.yaml resolves to a
+# real published tag on ghcr.io/openova-io. A seeded Blueprint whose chart was
+# never published renders a Blueprint CR the catalog advertises and the
+# application-controller can never install.
+#
+# The entries below are the Blueprint CRs that are seeded today with NO chart
+# behind them. They are recorded here — not deleted from the seed — because
+# deleting them would make the gate pass while leaving the operator-visible
+# behaviour (a catalog entry that cannot install) exactly as broken. Recording
+# them converts an invisible defect into an enumerated, CI-enforced one.
+#
+# ── Invariants the gate enforces on every entry below ────────────────────
+# 1. `version` MUST equal the seed's current pin for that chart. Re-pin the
+#    seed and the register goes stale → the gate fails until it is updated.
+# 2. The seed entry MUST be `visibility: unlisted`. A registered chart that is
+#    flipped to `listed` fails the gate: an unpublished chart must never be
+#    reachable from the customer-facing storefront.
+# 3. The chart MUST still be absent from GHCR. The moment it is published, the
+#    gate fails with "stale register entry" — so the register self-retires and
+#    cannot rot into a permanent waiver.
+# 4. The chart MUST still appear in the seed. A register row for a chart that
+#    is no longer seeded fails as a dead entry.
+#
+# ── How to retire an entry ───────────────────────────────────────────────
+# Author the chart under platform/<name>/chart/, let blueprint-release.yaml
+# publish it, sync all five lockstep sites, then delete the row here. The gate
+# will tell you if you forget.
+#
+# Refs #5559 #4432 #960
+
+unpublished:
+  # platform/clickhouse/ carries blueprint.yaml + README.md but NO chart/
+  # directory, and its blueprint.yaml declares the repo's explicit "unbuilt"
+  # marker `version: 0.0.0`. The seed nonetheless pins 1.0.0 — a version that
+  # never existed on GHCR or in this repo.
+  - chart: bp-clickhouse
+    version: "1.0.0"
+    issue: 5559
+    reason: "platform/clickhouse has blueprint.yaml (version 0.0.0) but no chart/ — nothing to publish yet"
+
+  # Same shape as bp-clickhouse: blueprint.yaml + README.md, version 0.0.0,
+  # no chart/ directory.
+  - chart: bp-opensearch
+    version: "1.0.0"
+    issue: 5559
+    reason: "platform/opensearch has blueprint.yaml (version 0.0.0) but no chart/ — nothing to publish yet"
+
+  # No platform/prometheus directory at all. The Sovereign's metrics path is
+  # served by bp-mimir + bp-alloy + bp-opentelemetry, all of which are
+  # published and seeded; this CR is a leftover of the original 14-CR baseline
+  # documented in templates/catalog-seed/_README.txt.
+  - chart: bp-prometheus
+    version: "1.0.0"
+    issue: 5559
+    reason: "no platform/prometheus source in the monorepo — leftover of the original 14-CR baseline seed"
+
+  # No platform/redis directory. bp-valkey (published, 1.1.5) is the in-repo
+  # key/value store Blueprint. Re-pointing this CR at bp-valkey would change
+  # what the card delivers, so it stays recorded rather than silently swapped.
+  - chart: bp-redis
+    version: "1.0.0"
+    issue: 5559
+    reason: "no platform/redis source in the monorepo — leftover of the original 14-CR baseline seed"
+
+  # No platform/n8n directory.
+  - chart: bp-n8n
+    version: "1.0.0"
+    issue: 5559
+    reason: "no platform/n8n source in the monorepo — leftover of the original 14-CR baseline seed"

--- a/scripts/lib/parse-catalog-seed-pins.awk
+++ b/scripts/lib/parse-catalog-seed-pins.awk
@@ -1,0 +1,48 @@
+# scripts/lib/parse-catalog-seed-pins.awk
+#
+# Emit one `name|visibility|source.chart|source.version` row per Blueprint in a
+# RENDERED catalog-seed document stream
+# (products/catalyst/chart/templates/catalog-seed/blueprints.yaml after
+# `helm template`).
+#
+# Why a line scan and not yq: `yq eval-all 'select(.kind == "Blueprint") | ...'`
+# over this ~6000-line, 80-document stream takes ~3 minutes on a CI runner —
+# slow enough that a gate built on it gets disabled. The `source:` blocks are
+# static YAML with a fixed 2-/4-space shape, so a scoped line scan is both
+# sufficient and robust. This mirrors catalogSeedPins() in
+# tests/e2e/bootstrap-kit/main_test.go, which line-parses the same blocks for
+# the same reason.
+#
+# Field anchors (all at a fixed indent, verified against every seeded entry):
+#   `  name:`        — 2-space, the only 2-space `name:` key (metadata.name;
+#                      `name` is not a direct child of `spec`)
+#   `  visibility:`  — 2-space, spec.visibility
+#   `  source:`      — 2-space, opens the delivery block
+#   `    chart:`     — 4-space inside source
+#   `    version:`   — 4-space inside source
+#
+# Refs #5559 (UAT row R21).
+
+function flush() {
+  if (name != "") print name "|" vis "|" chart "|" ver
+  name = ""; vis = ""; chart = ""; ver = ""; in_source = 0
+}
+
+/^---[[:space:]]*$/ { flush(); next }
+
+/^  name:[[:space:]]/ {
+  if (name == "") { name = $2; gsub(/["']/, "", name) }
+  next
+}
+
+/^  visibility:[[:space:]]/ { vis = $2; gsub(/["']/, "", vis); next }
+
+/^  source:[[:space:]]*$/ { in_source = 1; next }
+
+# Any other 2-space key closes the source block.
+/^  [A-Za-z]/ { in_source = 0 }
+
+in_source && /^    chart:[[:space:]]/   { chart = $2; gsub(/["']/, "", chart); next }
+in_source && /^    version:[[:space:]]/ { ver   = $2; gsub(/["']/, "", ver);   next }
+
+END { flush() }


### PR DESCRIPTION
## What this is

UAT row **R21** asserts: *"catalog-seed pins match the published ghcr chart versions — no inert lagging Blueprint CR."*

I re-derived that claim from zero: every one of the **80** seeded entries in
`products/catalyst/chart/templates/catalog-seed/blueprints.yaml`, queried against
`/orgs/openova-io/packages/container/<pkg>/versions`. Full table below — no spot check.

| result | count |
|---|---|
| pin resolves to a published GHCR tag | **74** |
| no package at all (HTTP 404) | **5** |
| self-referential umbrella, excluded | **1** (`bp-catalyst-platform`, version is `{{ .Chart.Version }}`) |

**The existence check must key on `source.chart`, not on the Blueprint name.** `source.chart` +
`source.version` is what Flux pulls; `metadata.name` is just the CR's name. One seeded entry
differs between the two, and it is the one this issue was reopened over.

## Defect 1 — `bp-guacamole` seed pin lagged a published chart

Caught live while sampling: the seed pinned `0.2.34`, which at that moment did not exist on GHCR
(newest published was `0.2.33`), on a `visibility: listed` Blueprint. Mid-audit, `blueprint-release`
published `0.2.34` and then `0.2.35`, and the auto-bump commit `e612a1a9c` moved
`platform/guacamole/chart/Chart.yaml`, `blueprint.yaml`, and
`clusters/_template/bootstrap-kit/52-bp-guacamole.yaml` to `0.2.35` — **but not the catalog seed**.

That is the durable finding: the auto-bump heals three of the five lockstep sites and never touches
the seed, so the seed is where this class of drift accumulates. It left `main` red on two Go guards:

```
--- FAIL: TestCatalogSeed_DeliveryPinsNotBehindComponentCharts
      catalog-seed source.version = "0.2.34"   component chart/Chart.yaml = "0.2.35"
--- FAIL: TestCatalogSeed_DisplayVersionNotBehindDeliveryPin
      catalog-seed spec.version   = "0.2.34"   component chart/Chart.yaml = "0.2.35"
```

`0.2.35` is published, so the seed now pins `0.2.35` (both `spec.version` and `source.version`).
Both guards return to green. The other four lockstep sites were already at `0.2.35`.

## Defect 2 — five seeded Blueprints have no chart behind them

`bp-clickhouse`, `bp-opensearch`, `bp-prometheus`, `bp-redis`, `bp-n8n` — all pinned `1.0.0`, all
HTTP 404. Cross-checked against the monorepo:

| Blueprint | source in repo | reading |
|---|---|---|
| `bp-clickhouse` | `platform/clickhouse/` has `blueprint.yaml` + `README.md`, **no `chart/`**, and `blueprint.yaml` declares `version: 0.0.0` | the repo's own unbuilt marker; the seed's `1.0.0` is a version that never existed anywhere |
| `bp-opensearch` | same shape, also `version: 0.0.0` | same |
| `bp-prometheus` | no `platform/prometheus/` at all | leftover of the original 14-CR baseline seed |
| `bp-redis` | no `platform/redis/` at all | same |
| `bp-n8n` | no `platform/n8n/` at all | same |

They are recorded in `scripts/expected-unpublished-catalog-seed-pins.yaml`, **not deleted from the
seed**. Deleting them would make the check pass while leaving the operator-visible behaviour — a
catalog entry that can never install — exactly as broken. Recording them converts an invisible
defect into an enumerated, CI-enforced one, and the register is built so it cannot rot (below).

Publishing these is not one workflow dispatch away: two need a chart authored, three need the
component itself. Re-pointing `bp-redis` at the published `bp-valkey` chart would change what the
card delivers, so it stays recorded rather than silently swapped.

## `bp-wordpress` visibility — evidence says `listed` is correct, unchanged

The reproduction that reopened this issue reported `bp-wordpress` as customer-visible and
uninstallable. That keys the existence check on the Blueprint **name**. The `bp-wordpress` package
is indeed empty — but that entry's delivery contract is:

```yaml
metadata:
  name: bp-wordpress
  labels:
    catalyst.openova.io/alias-of: bp-wordpress-tenant
spec:
  visibility: listed
  source:
    chart: bp-wordpress-tenant
    version: "0.4.22"
```

`bp-wordpress-tenant:0.4.22` **is published** (verified: `0.4.22`, `0.4.21`, `0.4.20` on GHCR). The
entry is a bare-slug alias so `GET /api/v1/catalog/wordpress` resolves for the marketplace funnel
and the literal `"blueprint":"bp-wordpress"` install path; the seed comments record it was added for
exactly that after a live 404 on hw167. It installs. **No visibility change** — flipping a working
storefront entry to `unlisted` would remove a working product from the catalog to satisfy a check
that was reading the wrong field.

This is the same name-vs-chart split that has now bitten two audits, so the new gate reads
`source.chart` and prints it in every line of output.

## The gate

`scripts/check-catalog-seed-lockstep.sh --check-ghcr` — extending the script that already owns the
seed, per the existing `--check-ghcr` shape on `check-bootstrap-kit-pin-sync.sh`.

**Why no existing gate could catch this.** Every in-repo seed guard compares the seed against
another file in this repo — `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` (#4415) and
`TestCatalogSeed_DisplayVersionNotBehindDeliveryPin` (#4432) both compare against
`platform/<x>/chart/Chart.yaml`, and both **skip** a pin with no co-located chart as
"external — not a drift". `check-bootstrap-kit-pin-sync.sh --check-ghcr` does query GHCR, but only
for the 67 bootstrap-kit slot pins, and only for charts that have a `Chart.yaml`. All five 404s live
precisely in that skip.

The known-gap register is held to four invariants so it self-retires and cannot become a permanent
waiver:

1. its `version` must equal the seed's current pin — re-pinning re-arms the gate;
2. the seed entry must be `visibility: unlisted` — an unpublished chart must never be
   storefront-reachable;
3. it fails the moment the chart **is** published ("stale register entry — delete this row");
4. a row for a chart no longer seeded fails as dead.

Two further hardenings:

- **Control probe.** An unauthenticated `gh` makes every lookup return nothing, which would report
  74 false pin defects. Zero resolutions with a non-zero check count exits **2** (infrastructure)
  rather than 1 (pin defect), so the diagnosis is not inverted.
- **Vacuity guard.** Zero pins checked is a hard fail — a negative assertion that runs zero times
  proves nothing.

Parsed with `awk`, not `yq`: `yq eval-all 'select(.kind == "Blueprint")'` over the ~6000-line,
80-document rendered stream takes **~3 minutes** (measured), slow enough that a gate built on it gets
disabled. `catalogSeedPins()` in the Go guards line-parses the same blocks for the same reason.

**CI wiring.** The GHCR phase runs as its own job so the existing field-drift job stays
hard-blocking. The new job is observational on push/PR — it races `blueprint-release`, which is
exactly what the `0.2.34` sample caught mid-publish — and fail-loud on an hourly schedule, mirroring
the #4409 pin-propagation cron on `test-bootstrap-kit.yaml`.

## Proof the gate is not vacuous

Seven mutations, each run against the real gate, then restored:

| # | mutation | expected | exit | evidence line |
|---|---|---|---|---|
| 0 | baseline, unmutated | green | **0** | `GHCR-checked 74 seed pin(s) (74 resolved); 5 declared known-gap(s); 0 failure(s).` |
| 1 | `bp-openclaw` pin `0.2.17` → `0.2.99` (never published) | red | **1** | `GHCR MISS bp-openclaw: bp-openclaw:0.2.99 — tag NOT FOUND ... (visibility=listed)` |
| 2 | declared `bp-redis` flipped to `visibility: listed` | red | **1** | `FAIL bp-redis: visibility='listed' while bp-redis:1.0.0 does NOT exist on ghcr.io/openova-io.` |
| 3 | `bp-n8n` register row deleted | red | **1** | `GHCR MISS bp-n8n: bp-n8n:1.0.0 — tag NOT FOUND ... (visibility=unlisted)` |
| 4 | dead register row `bp-does-not-exist` added | red | **1** | `FAIL register: 'bp-does-not-exist' ... no catalog-seed entry delivers that chart` |
| 5 | stale register row for the published `bp-cnpg:1.0.14` | red | **1** | `FAIL bp-cnpg: bp-cnpg:1.0.14 IS published ... but is still listed in` the register |
| 6 | parser neutralised to emit zero rows | red | **1** | `FAIL: zero catalog-seed delivery pins were GHCR-checked — the rendered-seed parser is broken.` |
| 7 | `gh` given an invalid token | red | **2** | `ERROR: 74 pin(s) were checked and NOT ONE resolved ... That is an API/auth failure, not 74 simultaneous pin defects.` |
| — | tree restored | green | **0** | `PASS: every catalog-seed delivery pin resolves to a published GHCR tag.` |

Case 6 is worth calling out: my **first** attempt at it appended `{ next }` to the end of the awk
program, which does not disable the earlier rules — the gate stayed green and I recorded it as a
pass. It was a faulty mutation, not a passing guard. Replacing the parser with `BEGIN { }` so it
genuinely emits nothing produced the exit-1 above. A red-then-green table is only worth anything if
the red is real, so the first attempt is recorded here rather than quietly dropped.

## Gates run

| command | result |
|---|---|
| `bash scripts/check-bootstrap-kit-pin-sync.sh` | **exit 0** — `Checked 67 chart→pin pair(s), skipped 30` · `PASS` |
| `bash scripts/check-catalog-seed-lockstep.sh` | **exit 0** — `checked: 68   skipped (no platform/ source): 13   fail: 0` |
| `bash scripts/check-catalog-seed-lockstep.sh --check-ghcr` | **exit 0** — `GHCR-checked 74 seed pin(s) (74 resolved); 5 declared known-gap(s); 0 failure(s).` |
| `go test -count=1 ./...` in `tests/e2e/bootstrap-kit` | **ok** — the two `TestCatalogSeed_*` failures on `main` are healed |
| `node scripts/build-catalog.mjs` | regenerated; committed both `catalog.generated.ts` and `internal/catalog/blueprints.json`; re-ran to confirm the generator is deterministic (no second diff) |

## Notes for the merger

- The full 80-row pin table is posted on #5559.
- R21 stays ❌ until an operator walk re-stamps it — merge is not a walk. What this changes is that
  the row's first clause is now mechanically enforced instead of asserted, and its second clause has
  an exact, enumerated count of 5 with a self-retiring register.
- `platform/clickhouse` and `platform/opensearch` are one authored chart away from retiring two
  register rows; the register header documents the retire path.
- No NodePorts touched anywhere in this change.

Refs #5559 #4432 #960

---

## Addendum — the gate's first CI run went red, and that was worth more than a green one

Commit `72cd8cd0b`. The first CI run of `ghcr-pin-existence` failed with 10 errors against a tree
that is clean, and the local run could not have found it.

```
GHCR MISS bp-prometheus: bp-prometheus:1.0.0 — tag NOT FOUND ...      (x5)
FAIL register: 'bp-clickhouse\t1.0.0' is declared in ...              (x5)
GHCR-checked 79 seed pin(s) (74 resolved); 0 declared known-gap(s); 10 failure(s).
```

Look at the quoted chart name: `bp-clickhouse\t1.0.0`. The register was parsed with
`yq eval '.chart + "\t" + .version'`, and yq's handling of that escape is **build-dependent**.
Reproduced against the exact binary the workflow installs:

```
yq v4.45.1 (CI)     .chart + "\t" + .version  ->  bp-clickhouse\t1.0.0
yq v4.45.1 (CI)     .chart + "|"  + .version  ->  bp-clickhouse|1.0.0
yq v4.53.2 (local)  .chart + "|"  + .version  ->  bp-clickhouse|1.0.0
```

My local yq (v4.53.2) emits a real tab, so every register lookup matched and the gate was green.
CI's v4.45.1 emits a literal backslash-t, so every lookup missed: the five declared known-gaps were
re-reported as fresh pin defects, plus five dead-register errors.

Two changes:

1. The delimiter is a literal `|` — no escape sequence, so it cannot diverge across builds.
2. **A control on the register parser itself.** The failure mode here was not "the gate said no", it
   was "the gate said the *wrong* no" — a parser bug laundered into a list of fake pin defects. A
   malformed parse now exits **2** (input error) naming the offending token, rather than exit 1
   (pin defect):

   ```
   ERROR: register parsed a malformed chart name 'bp-clickhouse\t1.0.0'.
   ```

Verified both directions with the v4.45.1 binary first on `PATH`:

| run | exit | result |
|---|---|---|
| fixed script, CI's yq v4.45.1 | **0** | `GHCR-checked 74 seed pin(s) (74 resolved); 5 declared known-gap(s); 0 failure(s).` |
| `"\t"` delimiter re-injected, same binary | **2** | `ERROR: register parsed a malformed chart name 'bp-clickhouse\t1.0.0'.` |

This is why the red-then-green demonstration matters as a practice and not a formality: the gate's
red path was exercised by CI on day one and found a defect in the gate itself. A gate whose failure
output has never been read is only half-built.
