### PR TITLE
fix(bp-postgres): fail closed on an unresolvable region + emit it from the per-Org install door (#5639)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -161,7 +161,7 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.16
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -99,7 +99,7 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.16
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -87,7 +87,7 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.16
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -19,7 +19,12 @@ spec:
   # 0.2.15 (#5504): bootstrap.initdb.secret now names the owner's roleSecret;
   # initdb previously minted the owner with the generated <cluster>-app
   # password, so every consumer got 28P01 while CNPG reported reconciled.
-  version: 0.2.16
+  # 0.2.17 (#5639): both active-hot-standby halves FAIL CLOSED on an
+  # unresolvable region instead of rendering `openova.io/region In [""]` — an
+  # unsatisfiable nodeAffinity that left hw292's per-Org primary unschedulable
+  # for 7h behind an `install succeeded` HelmRelease. configSchema gains
+  # topology.primary.region, which the per-Org install door now emits.
+  version: 0.2.17
   card:
     title: PostgreSQL
     summary: |
@@ -110,6 +115,27 @@ spec:
             minimum: 1
             maximum: 5
             default: 1
+          primary:
+            type: object
+            description: |
+              #5639 — the OTHER HALF of `mode: active-hot-standby`. Declared
+              here because the per-Org install door now emits it alongside the
+              mode; a mode without a region renders an unsatisfiable
+              nodeAffinity and the primary never schedules.
+            properties:
+              region:
+                type: string
+                default: ""
+                description: |
+                  The canonical `openova.io/region` NODE LABEL the primary
+                  Cluster pins its required nodeAffinity on (e.g.
+                  hz-fsn-rtz-prod). NOT the cloud region and NOT
+                  Application.spec.regions[0], which carry different spellings
+                  (#5482). Stamped from the Sovereign's SOVEREIGN_PRIMARY_REGION
+                  — by the bootstrap-kit slot substitutes for the host shared
+                  instances, and by catalyst-api for a per-Org install. REQUIRED
+                  in active-hot-standby: chart 0.2.17+ refuses to render without
+                  it rather than emitting `openova.io/region In [""]`.
       databases:
         type: array
         description: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,33 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.17 — #5639 (Refs #960 #3986): FAIL CLOSED on an unresolvable region. Both
+#   active-hot-standby Cluster halves pin a REQUIRED nodeAffinity on the
+#   `openova.io/region` node label, and both read the value straight off
+#   `.Values.topology.{primary,replica}.region` — whose values.yaml default is
+#   the EMPTY STRING. An install that never set the key therefore rendered
+#   `openova.io/region In [""]`, which no node can ever satisfy: not a slow
+#   schedule, unschedulable forever. Proven live on hw292 2026-08-03 — the
+#   per-Org Cluster `hw292-omani-works/postgres` sat at
+#   phase="Setting up primary" for 7+ hours with `FailedScheduling: 0/4 nodes
+#   are available: 4 node(s) didn't match Pod's node affinity/selector` while
+#   all four nodes carried `openova.io/region=hw-me-east-215-a-rtz-prod`; the
+#   CONTROL, a cnpg/cnpg-pair primary on the same cluster, carried
+#   `openova.io/region=[hw-me-east-215-a-rtz-prod]` and was healthy. The
+#   HelmRelease reported `install succeeded` the whole time — Helm rendered
+#   valid YAML and the apiserver accepted the Cluster, so every status surface
+#   showed a green badge over a database with no running primary.
+#   templates/_helpers.tpl gains `bp-postgres.primaryRegion` +
+#   `bp-postgres.replicaRegion`, each a Helm `required` naming the exact missing
+#   key; cluster.yaml (label + nodeAffinity) and replica-cluster.yaml (same two
+#   sites) now resolve through them. This is the guard bp-wordpress-tenant
+#   (validateActiveHotStandbyRegions) and bp-cnpg-pair (validateRegions) have
+#   always had — bp-postgres was the chart that drifted. SINGLETON RENDER IS
+#   BYTE-IDENTICAL to 0.2.16 (no region is consumed there), and the bootstrap-kit
+#   slots are unaffected: cloud-init stamps SOVEREIGN_PRIMARY_REGION /
+#   SOVEREIGN_REPLICA_REGION unconditionally. blueprint.yaml + catalog-seed
+#   configSchema now declare `topology.primary.region`, which the per-Org install
+#   door (catalyst-api defaultedParameters) emits alongside topology.mode.
+#   Lockstep: 16a/16c/16d HR pins + blueprint.yaml + catalog-seed → 0.2.17.
 # 0.2.16 — #5311 (Refs #4901 #4986 #4987 #5337): templates/continuum.yaml now
 #   populates `spec.cnpgPair` (name = instanceName, namespace = the Cluster ns)
 #   on the dr-<instance> Continuum CR. dr-shared-pg{,-b,-c} previously carried
@@ -226,7 +254,7 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.16
+version: 0.2.17
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/_helpers.tpl
+++ b/platform/postgres/chart/templates/_helpers.tpl
@@ -134,6 +134,77 @@ opt-out) is honoured.
 {{- end -}}
 
 {{/*
+Region resolution — FAIL CLOSED (#5639).
+
+WHY THIS EXISTS. In active-hot-standby BOTH Cluster halves pin themselves to a
+region with a REQUIRED nodeAffinity on the `openova.io/region` node label
+(cluster.yaml primary, replica-cluster.yaml follower). Until 0.2.17 both sites
+read `.Values.topology.<side>.region` directly, so an install that never set the
+key rendered
+
+    values: [""]                 <- matchExpressions In [empty string]
+    openova.io/region: ""        <- the CR label
+
+which no node can ever satisfy. That is not a slow schedule; it is unschedulable
+FOREVER, and every status surface above it reports success: Helm rendered valid
+YAML, the apiserver accepted the Cluster, the HelmRelease went
+`install succeeded`, and the Application card showed a green badge over a
+database that never had a running primary.
+
+Proven live on hw292 (2026-08-03, #5639): the per-Org Cluster
+`hw292-omani-works/postgres` sat at phase="Setting up primary" for 7+ hours with
+
+    nodeAffinity required: openova.io/region In [""]
+    node label, all 4 nodes:  openova.io/region=hw-me-east-215-a-rtz-prod
+    FailedScheduling: 0/4 nodes are available: 4 node(s) didn't match Pod's
+                      node affinity/selector
+
+against the CONTROL of a healthy cnpg/cnpg-pair primary on the same cluster
+carrying `openova.io/region=[hw-me-east-215-a-rtz-prod]`. The per-Org
+HelmRelease values were `{"topology":{"mode":"active-hot-standby"}}` — mode set,
+region absent.
+
+WHAT THESE HELPERS DO. They make an unresolvable region an INSTALL ERROR naming
+the exact missing key, instead of an empty selector. `required` is Helm's
+fail-closed primitive and it treats the empty string as missing, which is
+precisely the shape values.yaml ships (`topology.primary.region: ""`). This is
+the SAME guard bp-wordpress-tenant has had since its own D31 work
+(`bp-wordpress-tenant.validateActiveHotStandbyRegions`, _helpers.tpl) — the
+sibling chart already refused to render a half-declared pair; bp-postgres was
+the one that drifted.
+
+SCOPE. Only the active-hot-standby render consumes a region, so these helpers
+are included ONLY from inside the `$ahs` branch of cluster.yaml and from
+replica-cluster.yaml (which is itself gated on renderReplicaHalf = ahs AND
+side=replica). A SINGLETON install has no nodeAffinity and needs no region — its
+render is byte-identical to 0.2.16, and the bootstrap-kit slots (16a/16c/16d)
+are unaffected because cloud-init stamps SOVEREIGN_PRIMARY_REGION /
+SOVEREIGN_REPLICA_REGION into every region's substitutes unconditionally
+(cloudinit-control-plane.tftpl; primary_region_canonical_label is non-empty on
+both the Hetzner and Huawei providers).
+
+nil-safe via `dig`, same as meshGlobalServices above: an overlay that nulls the
+`topology` map or its `primary`/`replica` sub-maps reaches `required` with ""
+rather than panicking on a nil dereference.
+*/}}
+{{- define "bp-postgres.primaryRegion" -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- required "bp-postgres: topology.primary.region is REQUIRED in active-hot-standby mode (topology.mode=active-hot-standby or topology.crossRegion=true). It is the canonical openova.io/region NODE LABEL the primary Cluster's required nodeAffinity pins on — set it from this Sovereign's SOVEREIGN_PRIMARY_REGION (e.g. hz-fsn-rtz-prod). Rendering it empty emits 'openova.io/region In [\"\"]', which no node can ever satisfy, so the primary is unschedulable forever while the HelmRelease still reports install succeeded (#5639)." (dig "primary" "region" "" $topology) -}}
+{{- end -}}
+
+{{/*
+Replica half of bp-postgres.primaryRegion — same fail-closed contract for the
+follower Cluster's region pin. replica-cluster.yaml renders ONLY when
+renderReplicaHalf is true (active-hot-standby AND side=replica), so every call
+site here is already inside the cross-region shape; an empty replica.region at
+that point is the identical #5639 defect on cluster-B.
+*/}}
+{{- define "bp-postgres.replicaRegion" -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- required "bp-postgres: topology.replica.region is REQUIRED when rendering the active-hot-standby REPLICA half (topology.side=replica|secondary). It is the canonical openova.io/region NODE LABEL the follower Cluster's required nodeAffinity pins on — set it from this Sovereign's SOVEREIGN_REPLICA_REGION (e.g. hz-hel-rtz-prod). Rendering it empty emits 'openova.io/region In [\"\"]', which no node can ever satisfy, so the follower is unschedulable forever while the HelmRelease still reports install succeeded (#5639)." (dig "replica" "region" "" $topology) -}}
+{{- end -}}
+
+{{/*
 The follower Cluster CR name on the replica side. Distinct from the
 primary instance name (which the consumer host `<instance>-rw` resolves
 to) so the two Cluster CRs never collide and bp-continuum's switchover

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -42,7 +42,11 @@ metadata:
     # `-rw` Service of THIS named Cluster is the consumer-facing write
     # endpoint; the cnpg-pair label ties it to the replica half for DR.
     openova.io/cnpg-role: primary
-    openova.io/region: {{ .Values.topology.primary.region | quote }}
+    {{- /* #5639 — FAIL CLOSED. Resolved through bp-postgres.primaryRegion so an
+         unset region is an install ERROR naming the key, never the empty label
+         + empty nodeAffinity selector that made hw292's per-Org primary
+         unschedulable for 7h behind an `install succeeded` HelmRelease. */}}
+    openova.io/region: {{ include "bp-postgres.primaryRegion" . | quote }}
     catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
     {{- end }}
 spec:
@@ -63,7 +67,10 @@ spec:
           - matchExpressions:
               - key: openova.io/region
                 operator: In
-                values: [{{ .Values.topology.primary.region | quote }}]
+                # #5639 — see bp-postgres.primaryRegion. An empty value here is
+                # `In [""]`: no node carries an empty region label, so the Pods
+                # are Pending FOREVER, not merely slow to schedule.
+                values: [{{ include "bp-postgres.primaryRegion" . | quote }}]
     podAntiAffinityType: preferred
   {{- else }}
   instances: {{ .Values.topology.instances | default 1 }}

--- a/platform/postgres/chart/templates/replica-cluster.yaml
+++ b/platform/postgres/chart/templates/replica-cluster.yaml
@@ -44,7 +44,11 @@ metadata:
   labels:
     {{- include "bp-postgres.labels" . | nindent 4 }}
     openova.io/cnpg-role: replica
-    openova.io/region: {{ .Values.topology.replica.region | quote }}
+    {{- /* #5639 — FAIL CLOSED, same contract as the primary half. This label is
+         ALSO load-bearing beyond scheduling: catalyst-api's continuum_live.go
+         reads openova.io/region off the Cluster CRs to project the DR panel's
+         regions, so an empty value degrades that surface too. */}}
+    openova.io/region: {{ include "bp-postgres.replicaRegion" . | quote }}
     catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
 spec:
   instances: {{ .Values.topology.haInstances | default 3 }}
@@ -68,7 +72,9 @@ spec:
           - matchExpressions:
               - key: openova.io/region
                 operator: In
-                values: [{{ .Values.topology.replica.region | quote }}]
+                # #5639 — see bp-postgres.replicaRegion. `In [""]` is
+                # unsatisfiable on every node in region-B, forever.
+                values: [{{ include "bp-postgres.replicaRegion" . | quote }}]
     podAntiAffinityType: preferred
 
   # ── Replica-cluster mode ─────────────────────────────────────────

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -996,3 +996,129 @@ if printf '%s' "${empty_out}" | awk '/^  bootstrap:/,/^  managed:/' | grep -qE '
   exit 1
 fi
 echo "  PASS (no-bindings fallback emits no dangling initdb secret)"
+
+# ── Case #5639: FAIL CLOSED on an unresolvable region — BOTH directions ──
+#
+# The defect (live on hw292, 2026-08-03): cluster.yaml + replica-cluster.yaml
+# read `.Values.topology.{primary,replica}.region` directly, and values.yaml
+# defaults both to the EMPTY STRING. An active-hot-standby install that never
+# set the key rendered `openova.io/region In [""]` — a required nodeAffinity no
+# node can EVER satisfy. The per-Org Cluster hw292-omani-works/postgres sat at
+# phase="Setting up primary" for 7+ hours with
+#   FailedScheduling: 0/4 nodes are available: 4 node(s) didn't match Pod's
+#                     node affinity/selector
+# while all four nodes carried openova.io/region=hw-me-east-215-a-rtz-prod. The
+# HelmRelease reported `install succeeded` the entire time.
+#
+# BOTH DIRECTIONS OR THE GUARD IS VACUOUS. The pre-existing Case-4 assertion
+# `grep -q 'key: openova.io/region'` passed on the BROKEN render too — the KEY is
+# present whether or not the VALUE is. So:
+#   (+) with the region set, assert the real region VALUE in the label AND in the
+#       nodeAffinity values list — the key alone proves nothing;
+#   (-) with the region absent, assert the render FAILS and that the error names
+#       the missing key.
+echo "[render] Case #5639: region fail-closed — value present when set, render FAILS when absent"
+
+pos_vals="$(mktemp)"
+cat > "${pos_vals}" <<'YAML'
+instance: { name: shared-pg }
+topology:
+  mode: active-hot-standby
+  side: primary
+  haInstances: 3
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+databases:
+  - { name: registry, owner: harbor }
+YAML
+
+# (+) PRIMARY half carries the REAL region in both sites.
+pos_out=$(helm template shared-pg . -f "${pos_vals}" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 2>&1) \
+  || { echo "FAIL (#5639): the region-BEARING render errored — the guard must not reject a valid install:" >&2
+       printf '%s\n' "${pos_out}" >&2; exit 1; }
+
+printf '%s' "${pos_out}" | grep -qE '^kind: Cluster$' \
+  || { echo "FAIL (#5639): no Cluster rendered — every assertion below is vacuous." >&2; exit 2; }
+printf '%s' "${pos_out}" | grep -qE '^    openova\.io/region: "hz-fsn-rtz-prod"$' \
+  || { echo "FAIL (#5639): primary Cluster LABEL is not the real region (empty label = the defect)." >&2; exit 1; }
+printf '%s' "${pos_out}" | grep -qE '^                values: \["hz-fsn-rtz-prod"\]$' \
+  || { echo "FAIL (#5639): primary nodeAffinity values[] is not [hz-fsn-rtz-prod]." >&2; exit 1; }
+if printf '%s' "${pos_out}" | grep -qE 'values: \[""\]'; then
+  echo "FAIL (#5639): the render still emits an EMPTY nodeAffinity selector." >&2; exit 1
+fi
+echo "  PASS (+ primary: label + nodeAffinity both carry hz-fsn-rtz-prod)"
+
+# (+) REPLICA half likewise, on the side that renders the follower.
+pos_replica=$(helm template shared-pg . -f "${pos_vals}" --namespace shared-data \
+  --set topology.side=secondary --api-versions postgresql.cnpg.io/v1 2>&1) \
+  || { echo "FAIL (#5639): the region-bearing REPLICA render errored:" >&2
+       printf '%s\n' "${pos_replica}" >&2; exit 1; }
+printf '%s' "${pos_replica}" | grep -qE '^    openova\.io/region: "hz-hel-rtz-prod"$' \
+  || { echo "FAIL (#5639): replica Cluster LABEL is not the real replica region." >&2; exit 1; }
+printf '%s' "${pos_replica}" | grep -qE '^                values: \["hz-hel-rtz-prod"\]$' \
+  || { echo "FAIL (#5639): replica nodeAffinity values[] is not [hz-hel-rtz-prod]." >&2; exit 1; }
+echo "  PASS (+ replica: label + nodeAffinity both carry hz-hel-rtz-prod)"
+
+rm -f "${pos_vals}"
+
+# (-) PRIMARY with NO region — the hw292 values shape verbatim. The render MUST
+#     fail, and the message MUST name the key.
+neg_vals="$(mktemp)"
+cat > "${neg_vals}" <<'YAML'
+instance: { name: postgres }
+topology:
+  mode: active-hot-standby
+YAML
+if neg_out=$(helm template postgres . -f "${neg_vals}" --namespace hw292-omani-works \
+      --api-versions postgresql.cnpg.io/v1 2>&1); then
+  echo "FAIL (#5639): active-hot-standby WITHOUT topology.primary.region still rendered." >&2
+  echo "  That is the hw292 defect: an empty selector Helm and the apiserver both accept," >&2
+  echo "  and a HelmRelease that reports install succeeded over a Pod that never schedules." >&2
+  printf '%s\n' "${neg_out}" | grep -E 'openova\.io/region|values: \[' >&2
+  rm -f "${neg_vals}"; exit 1
+fi
+printf '%s' "${neg_out}" | grep -q 'topology.primary.region' \
+  || { echo "FAIL (#5639): the render failed but the error does NOT name topology.primary.region:" >&2
+       printf '%s\n' "${neg_out}" >&2; rm -f "${neg_vals}"; exit 1; }
+echo "  PASS (- primary: render REFUSED, error names topology.primary.region)"
+
+# (-) REPLICA half with a primary region but NO replica region.
+neg_replica_vals="$(mktemp)"
+cat > "${neg_replica_vals}" <<'YAML'
+instance: { name: postgres }
+topology:
+  mode: active-hot-standby
+  side: secondary
+  primary: { region: hz-fsn-rtz-prod }
+YAML
+if neg_replica_out=$(helm template postgres . -f "${neg_replica_vals}" --namespace shared-data \
+      --api-versions postgresql.cnpg.io/v1 2>&1); then
+  echo "FAIL (#5639): the REPLICA half rendered without topology.replica.region." >&2
+  printf '%s\n' "${neg_replica_out}" | grep -E 'openova\.io/region|values: \[' >&2
+  rm -f "${neg_vals}" "${neg_replica_vals}"; exit 1
+fi
+printf '%s' "${neg_replica_out}" | grep -q 'topology.replica.region' \
+  || { echo "FAIL (#5639): the replica render failed but the error does NOT name topology.replica.region:" >&2
+       printf '%s\n' "${neg_replica_out}" >&2; rm -f "${neg_vals}" "${neg_replica_vals}"; exit 1; }
+echo "  PASS (- replica: render REFUSED, error names topology.replica.region)"
+
+# (=) NO REGRESSION: a SINGLETON install consumes no region, so it must still
+#     render cleanly with the key absent — the guard is scoped to the
+#     active-hot-standby shape, not applied to every install.
+singleton_vals="$(mktemp)"
+printf 'instance: { name: postgres }\ntopology:\n  mode: singleton\n' > "${singleton_vals}"
+sing_out=$(helm template postgres . -f "${singleton_vals}" --namespace org-acme \
+  --api-versions postgresql.cnpg.io/v1 2>&1) \
+  || { echo "FAIL (#5639): the SINGLETON render was broken by the region guard:" >&2
+       printf '%s\n' "${sing_out}" >&2; rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"; exit 1; }
+printf '%s' "${sing_out}" | grep -qE '^kind: Cluster$' \
+  || { echo "FAIL (#5639): singleton render emitted no Cluster." >&2
+       rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"; exit 1; }
+if printf '%s' "${sing_out}" | grep -q 'openova.io/region'; then
+  echo "FAIL (#5639): the singleton render grew a region pin — it must stay byte-identical." >&2
+  rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"; exit 1
+fi
+echo "  PASS (= singleton renders with NO region key and NO region pin)"
+
+rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -141,6 +141,17 @@ topology:
   # ── Region pinning (active-hot-standby only). Canonical openova.io/region
   # node labels the primary / replica Cluster CRs pin on. Stamped from the
   # cloud-init SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION substitutes.
+  #
+  # 🛑 REQUIRED in active-hot-standby (#5639, chart 0.2.17). The empty defaults
+  # below are the SINGLETON defaults — singleton renders no nodeAffinity and
+  # consumes no region. The moment `mode: active-hot-standby` or
+  # `crossRegion: true` is set, both halves pin a REQUIRED nodeAffinity on these
+  # values, and the chart now REFUSES to render rather than emitting
+  # `openova.io/region In [""]` (bp-postgres.primaryRegion /
+  # bp-postgres.replicaRegion in _helpers.tpl). Leaving them empty in the HA
+  # shape produced hw292's per-Org primary: Pending for 7+ hours behind a
+  # HelmRelease that reported `install succeeded`. replica.region is consulted
+  # only where the follower half renders (side=replica|secondary).
   primary:
     region: ""
   replica:

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T21:41:03.519Z",
+  "generatedAt": "2026-08-03T22:18:58.534Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4083,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
@@ -145,16 +145,151 @@ func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug, orgConsole
 		stampOpenovaMCPOrgParameters(out, sovereignFQDN, orgSlug, orgConsoleHost)
 	}
 
-	if len(out) > 0 {
-		return out
-	}
-
-	if isPostgresBlueprint(blueprint) {
+	// bp-postgres: seed `topology.mode` when the caller supplied NOTHING at all.
+	// Preserved verbatim from the #4283 shape — a caller that DID supply values
+	// keeps them, and we do not start declaring a mode where we previously
+	// declared none (that would silently promote the backing-service postgres
+	// from singleton to the cross-region pair shape).
+	if isPostgresBlueprint(blueprint) && len(out) == 0 {
 		out["topology"] = map[string]interface{}{
 			"mode": postgresConfigSchemaMode(topology),
 		}
 	}
+
+	// #5639 — the region is the OTHER HALF of the mode. Whenever the emitted
+	// parameters declare the bp-postgres HA shape, they must also carry the
+	// region that shape pins on; a mode without a region is a half-declared
+	// contract that renders an unsatisfiable nodeAffinity.
+	//
+	// This runs for BOTH doors — the seeded mode above AND a caller-supplied
+	// `topology.mode` / `topology.crossRegion` — because the defect is identical
+	// through either: the chart consumes one key, and neither door filled it.
+	//
+	// It must run AFTER the mode seed and OUTSIDE the len(out)==0 gate, and it
+	// must write into the SAME `topology` object: the application-controller
+	// merges Blueprint `manifests.values` with `spec.parameters` SHALLOWLY
+	// (mergeMaps, application_controller.go), so `spec.parameters.topology`
+	// REPLACES the Blueprint's whole topology object rather than merging into
+	// it. Mode and region therefore have to travel together or one of them is
+	// dropped on the way to HelmRelease.spec.values.
+	if isPostgresBlueprint(blueprint) {
+		stampPostgresPrimaryRegion(out)
+	}
 	return out
+}
+
+// postgresModeActiveHotStandby is the bp-postgres configSchema mode that
+// activates the cross-region pair render (chart values `topology.mode`). The
+// chart ALSO activates it on the boolean `topology.crossRegion`, which the
+// bootstrap-kit slots use because envsubst can substitute true/false but cannot
+// produce the mode STRING (platform/postgres/chart/values.yaml).
+const postgresModeActiveHotStandby = "active-hot-standby"
+
+// stampPostgresPrimaryRegion fills `parameters.topology.primary.region` — the
+// canonical `openova.io/region` NODE LABEL the chart's primary Cluster pins its
+// required nodeAffinity on — whenever the emitted parameters activate the
+// bp-postgres active-hot-standby shape.
+//
+// THE BUG IT FIXES (#5639, proven live on hw292 2026-08-03). The per-Org install
+// door emitted `{"topology":{"mode":"active-hot-standby"}}` and nothing else. The
+// chart read `.Values.topology.primary.region` off a values tree that had no such
+// key, so it rendered
+//
+//	openova.io/region: ""                      (the Cluster label)
+//	values: [""]                               (the required nodeAffinity)
+//
+// while all four nodes carried `openova.io/region=hw-me-east-215-a-rtz-prod`. The
+// Cluster `hw292-omani-works/postgres` sat at phase="Setting up primary" for over
+// seven hours with `FailedScheduling: 0/4 nodes are available: 4 node(s) didn't
+// match Pod's node affinity/selector` — unschedulable forever, not slow. The
+// CONTROL that pins the mechanism: the cnpg/cnpg-pair primary on the same cluster
+// carried `openova.io/region=[hw-me-east-215-a-rtz-prod]` and was healthy.
+//
+// And nothing upstream noticed: Helm rendered valid YAML, the apiserver accepted
+// the Cluster, and the HelmRelease reported `install succeeded`. A customer-visible
+// Organization had a green badge over a database that never had a running primary.
+//
+// THE VALUE. `SOVEREIGN_PRIMARY_REGION` is the canonical node label, mounted on the
+// catalyst-api Deployment from the `sovereign-fqdn` ConfigMap key `primaryRegion`
+// (products/catalyst/chart/templates/api-deployment.yaml) and ultimately from
+// cloud-init's `primary_region_canonical_label`
+// (infra/providers/_shared/cloudinit-control-plane.tftpl). It is the SAME string
+// the bootstrap-kit slots 16a/16c/16d substitute into `topology.primary.region`
+// for the host shared-pg instances, so the per-Org install now pins exactly what
+// the proven host path pins. Same env, same read, same precedent as
+// renderOrganizationOverlay's D31 block (organization_gitops.go).
+//
+// Deliberately NOT used: `Application.spec.regions[0]`. On hw292 that field held
+// `me-east-215-a` — the CLOUD region — while the node label was
+// `hw-me-east-215-a-rtz-prod` (#5482 recorded all three divergent spellings on one
+// Application). The seed door defaults it to the literal string "primary"
+// (endpoint_handler.go), which is not a node label at all. A near-miss region is
+// exactly as unschedulable as an empty one.
+//
+// FAIL-CLOSED ON EMPTY. When the env is unset (the mothership / Catalyst-Zero,
+// where a per-Org postgres is not a production path) we stamp NOTHING rather than
+// guess. The chart then refuses to render and names the missing key
+// (bp-postgres.primaryRegion), which is the outcome #5639 asks for: an install
+// error a human reads, instead of a green badge over a Pending Pod.
+//
+// An explicit non-empty caller value is never clobbered — same deference as every
+// other stamp helper in this file.
+func stampPostgresPrimaryRegion(params map[string]interface{}) {
+	topo, _ := params["topology"].(map[string]interface{})
+	if topo == nil {
+		// No topology declared at all ⇒ the chart's own singleton default
+		// applies, which reads no region. Nothing to complete.
+		return
+	}
+	if !postgresTopologyIsActiveHotStandby(topo) {
+		return
+	}
+
+	primary, _ := topo["primary"].(map[string]interface{})
+	if primary == nil {
+		primary = map[string]interface{}{}
+	}
+	if existing, ok := primary["region"].(string); ok && strings.TrimSpace(existing) != "" {
+		return
+	}
+
+	region := sovereignPrimaryRegionNodeLabel()
+	if region == "" {
+		return
+	}
+
+	primary["region"] = region
+	topo["primary"] = primary
+	params["topology"] = topo
+}
+
+// postgresTopologyIsActiveHotStandby mirrors the chart's own activation gate
+// (platform/postgres/chart/templates/_helpers.tpl, bp-postgres.activeHotStandby):
+// EITHER `topology.mode` folds to active-hot-standby OR the boolean
+// `topology.crossRegion` is on. Both render the region-pinned pair, so both need
+// the region. The mode is folded through postgresConfigSchemaMode so a caller who
+// passed a broad placement token (active-active / active-passive) is treated the
+// same way the seed path treats it.
+func postgresTopologyIsActiveHotStandby(topo map[string]interface{}) bool {
+	if mode, ok := topo["mode"].(string); ok &&
+		postgresConfigSchemaMode(mode) == postgresModeActiveHotStandby {
+		return true
+	}
+	switch cr := topo["crossRegion"].(type) {
+	case bool:
+		return cr
+	case string:
+		return strings.EqualFold(strings.TrimSpace(cr), "true")
+	}
+	return false
+}
+
+// sovereignPrimaryRegionNodeLabel returns this Sovereign's canonical
+// `openova.io/region` PRIMARY node label, or "" when the Sovereign did not
+// declare one. Read through the same osGetenv seam the rest of this package
+// uses (applications_wire_compat.go) so tests can pin it.
+func sovereignPrimaryRegionNodeLabel() string {
+	return strings.TrimSpace(osGetenv("SOVEREIGN_PRIMARY_REGION"))
 }
 
 // stampAgenitySovereignFqdn sets `parameters.sovereignFqdn` to the Sovereign's

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_region_5639_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_region_5639_test.go
@@ -1,0 +1,296 @@
+// Producer-side tests for #5639 — the per-Org bp-postgres install door must
+// emit `topology.primary.region` whenever it emits an active-hot-standby
+// `topology.mode`. Mode and region are ONE contract: the chart pins a REQUIRED
+// nodeAffinity on the region, so a mode without a region renders
+// `openova.io/region In [""]`, which no node can ever satisfy.
+//
+// Live evidence these tests encode (hw292, 2026-08-03): the HelmRelease values
+// for the per-Org Cluster `hw292-omani-works/postgres` were exactly
+// {"topology":{"mode":"active-hot-standby"}} — mode present, region absent. The
+// Cluster sat at phase="Setting up primary" for 7+ hours with
+// `FailedScheduling: 0/4 nodes are available: 4 node(s) didn't match Pod's node
+// affinity/selector` while every node carried
+// openova.io/region=hw-me-east-215-a-rtz-prod. The HelmRelease reported
+// `install succeeded` throughout.
+//
+// ANTI-VACUITY. Every assertion here was run against the UNFIXED producer first:
+//   - StampsPrimaryRegion / SeedDoor / InstallDoor / CrossRegionBool / Completes-
+//     ExplicitMode all FAIL on unfixed code with the region key simply absent
+//     (`topology.primary` missing), which is the defect itself.
+//   - SingletonStampsNoRegion and ExplicitRegionNeverClobbered PASS on unfixed
+//     code — they are the no-regression side of the pair and are here so the
+//     fix cannot be "stamp a region everywhere".
+//   - NoEnvStampsNothing PASSES on unfixed code for the same reason; it pins the
+//     deliberate fail-closed handoff to the chart's `required`.
+// A one-sided suite would go green on a producer that stamped the region into
+// every install, including singleton ones that must not carry it.
+//
+// Domains: the region strings here are canonical openova.io/region NODE LABELS
+// (hz-fsn-rtz-prod / hw-me-east-215-a-rtz-prod), not hostnames.
+
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/core/controllers/pkg/validate"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
+)
+
+// postgresTopologyOf pulls spec.parameters.topology as a map, failing loudly
+// rather than panicking on a producer that emitted a different shape.
+func postgresTopologyOf(t *testing.T, params map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	topo, ok := params["topology"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("parameters carry no topology object: %#v", params)
+	}
+	return topo
+}
+
+// postgresPrimaryRegionOf returns topology.primary.region, or "" when the
+// producer emitted no primary block at all (the #5639 defect shape).
+func postgresPrimaryRegionOf(t *testing.T, params map[string]interface{}) string {
+	t.Helper()
+	topo := postgresTopologyOf(t, params)
+	primary, ok := topo["primary"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	region, _ := primary["region"].(string)
+	return region
+}
+
+// ── the defect: mode emitted without its region ─────────────────────────
+
+// FAILS on unfixed code (topology.primary absent) — this is #5639 verbatim.
+func TestDefaultedParameters_PostgresActiveHotStandby_StampsPrimaryRegion(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hw-me-east-215-a-rtz-prod")
+
+	got := defaultedParameters("bp-postgres", "active-hot-standby", "", "", "", nil)
+	topo := postgresTopologyOf(t, got)
+
+	if topo["mode"] != "active-hot-standby" {
+		t.Fatalf("topology.mode = %v, want active-hot-standby", topo["mode"])
+	}
+	if region := postgresPrimaryRegionOf(t, got); region != "hw-me-east-215-a-rtz-prod" {
+		t.Fatalf("topology.primary.region = %q, want hw-me-east-215-a-rtz-prod — "+
+			"a mode without a region renders `openova.io/region In [\"\"]` and the "+
+			"primary is unschedulable forever (#5639)", region)
+	}
+
+	// Mode and region MUST live in the SAME topology object: the
+	// application-controller merges Blueprint manifests.values with
+	// spec.parameters SHALLOWLY, so a region emitted under a separate
+	// top-level key would be dropped before it reaches HelmRelease.spec.values.
+	if _, stray := got["primary"]; stray {
+		t.Fatalf("region was emitted as a TOP-LEVEL `primary` key; it must sit "+
+			"inside `topology` or the shallow mergeMaps drops it: %#v", got)
+	}
+}
+
+// Every canonical HA placement token folds to the chart's active-hot-standby
+// mode, so every one of them must also carry the region.
+func TestDefaultedParameters_PostgresEveryHAToken_StampsPrimaryRegion(t *testing.T) {
+	for _, placement := range []string{
+		"active-hot-standby", "active-hotstandby", "active-active", "active-passive",
+	} {
+		t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+		got := defaultedParameters("postgres", placement, "", "", "", nil)
+		if region := postgresPrimaryRegionOf(t, got); region != "hz-fsn-rtz-prod" {
+			t.Errorf("placement %q → topology.primary.region = %q, want hz-fsn-rtz-prod",
+				placement, region)
+		}
+	}
+}
+
+// The chart ALSO activates the region-pinned pair on the boolean
+// topology.crossRegion (the bootstrap-kit slot signal, because envsubst cannot
+// produce the mode STRING). A caller riding that seam needs the region just as
+// much. FAILS on unfixed code.
+func TestDefaultedParameters_PostgresCrossRegionBool_StampsPrimaryRegion(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+
+	explicit := map[string]interface{}{
+		"topology": map[string]interface{}{"mode": "singleton", "crossRegion": true},
+	}
+	got := defaultedParameters("bp-postgres", "singleton", "", "", "", explicit)
+
+	if region := postgresPrimaryRegionOf(t, got); region != "hz-fsn-rtz-prod" {
+		t.Fatalf("crossRegion=true → topology.primary.region = %q, want hz-fsn-rtz-prod — "+
+			"crossRegion renders the SAME region-pinned Cluster as mode=active-hot-standby", region)
+	}
+}
+
+// A caller that supplies its own active-hot-standby mode goes through the same
+// chart code path and hits the same empty selector, so the region is completed
+// there too. FAILS on unfixed code (which returned explicit values verbatim and
+// stamped nothing).
+func TestDefaultedParameters_PostgresExplicitMode_RegionCompleted(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+
+	explicit := map[string]interface{}{
+		"topology":  map[string]interface{}{"mode": "active-hot-standby"},
+		"databases": []interface{}{map[string]interface{}{"name": "wp", "owner": "wp"}},
+	}
+	got := defaultedParameters("bp-postgres", "singleton", "", "", "", explicit)
+
+	if postgresTopologyOf(t, got)["mode"] != "active-hot-standby" {
+		t.Fatalf("explicit topology.mode must survive: %#v", got["topology"])
+	}
+	if _, ok := got["databases"]; !ok {
+		t.Fatalf("explicit databases must survive: %#v", got)
+	}
+	if region := postgresPrimaryRegionOf(t, got); region != "hz-fsn-rtz-prod" {
+		t.Fatalf("explicit-mode install got topology.primary.region = %q, want hz-fsn-rtz-prod", region)
+	}
+}
+
+// ── the other direction: no region where none belongs ───────────────────
+
+// PASSES on unfixed code. Present so the fix cannot be "always stamp a region":
+// the singleton render consumes no region and must stay byte-identical.
+func TestDefaultedParameters_PostgresSingleton_StampsNoRegion(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+
+	got := defaultedParameters("bp-postgres", "singleton", "", "", "", nil)
+	topo := postgresTopologyOf(t, got)
+
+	if topo["mode"] != "singleton" {
+		t.Fatalf("topology.mode = %v, want singleton", topo["mode"])
+	}
+	if _, ok := topo["primary"]; ok {
+		t.Fatalf("singleton must NOT carry topology.primary — the singleton Cluster "+
+			"renders no nodeAffinity and pinning it would change a shape that works: %#v", topo)
+	}
+}
+
+// PASSES on unfixed code. An operator who pinned a region explicitly owns it.
+func TestDefaultedParameters_PostgresExplicitRegion_NeverClobbered(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+
+	explicit := map[string]interface{}{
+		"topology": map[string]interface{}{
+			"mode":    "active-hot-standby",
+			"primary": map[string]interface{}{"region": "hz-hel-rtz-prod"},
+		},
+	}
+	got := defaultedParameters("bp-postgres", "active-hot-standby", "", "", "", explicit)
+
+	if region := postgresPrimaryRegionOf(t, got); region != "hz-hel-rtz-prod" {
+		t.Fatalf("explicit topology.primary.region was overwritten: got %q, want hz-hel-rtz-prod", region)
+	}
+}
+
+// PASSES on unfixed code. FAIL-CLOSED handoff: with no Sovereign region declared
+// (the mothership / Catalyst-Zero case) the producer guesses NOTHING. The chart's
+// `required` then refuses to render and names the key — an install error a human
+// reads, rather than a green badge over a Pending Pod. Stamping a fabricated
+// region here would be worse than stamping none: a near-miss region is exactly as
+// unschedulable as an empty one.
+func TestDefaultedParameters_PostgresActiveHotStandby_NoEnv_StampsNothing(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "")
+
+	got := defaultedParameters("bp-postgres", "active-hot-standby", "", "", "", nil)
+	topo := postgresTopologyOf(t, got)
+
+	if topo["mode"] != "active-hot-standby" {
+		t.Fatalf("topology.mode = %v, want active-hot-standby", topo["mode"])
+	}
+	if _, ok := topo["primary"]; ok {
+		t.Fatalf("with no SOVEREIGN_PRIMARY_REGION the producer must stamp NOTHING and "+
+			"let the chart fail closed; got %#v", topo)
+	}
+}
+
+// A non-postgres Blueprint never grows a topology block from this path.
+func TestDefaultedParameters_NonPostgres_NoRegionStamp(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+
+	got := defaultedParameters("bp-grafana", "active-hot-standby", "", "", "", nil)
+	if len(got) != 0 {
+		t.Fatalf("non-postgres parameters must stay empty {}, got %#v", got)
+	}
+}
+
+// ── both real doors, end to end onto the Application CR ─────────────────
+
+// The create-instance seed door. FAILS on unfixed code.
+func TestNewApplicationCRFromSeed_PostgresAHS_CarriesPrimaryRegion(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hw-me-east-215-a-rtz-prod")
+
+	seed := instances.ApplicationSeed{
+		Name:      "postgres",
+		Namespace: "hw292-omani-works",
+		Blueprint: "bp-postgres",
+		Topology:  "active-hot-standby",
+	}
+	obj := newApplicationCRFromSeed(seed)
+
+	params, found, err := unstructured.NestedMap(obj.Object, "spec", "parameters")
+	if err != nil {
+		t.Fatalf("read spec.parameters: %v", err)
+	}
+	if !found || params == nil {
+		t.Fatal("spec.parameters absent/nil")
+	}
+	if region := postgresPrimaryRegionOf(t, params); region != "hw-me-east-215-a-rtz-prod" {
+		t.Fatalf("seed door emitted topology.primary.region = %q, want hw-me-east-215-a-rtz-prod — "+
+			"this is the exact CR shape that produced the hw292 hang", region)
+	}
+
+	rep, vErr := validate.Parameters(bpPostgresConfigSchema(), params)
+	if vErr != nil {
+		t.Fatalf("validate.Parameters internal error: %v", vErr)
+	}
+	if !rep.Valid {
+		t.Fatalf("region-bearing parameters must still satisfy the bp-postgres configSchema: %v", rep.Errors)
+	}
+}
+
+// The POST /applications install door. FAILS on unfixed code.
+func TestNewApplicationUnstructured_PostgresAHS_CarriesPrimaryRegion(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hw-me-east-215-a-rtz-prod")
+
+	req := applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-postgres", Version: "0.2.17"},
+		Name:            "postgres",
+		OrganizationRef: "hw292-omani-works",
+		EnvironmentRef:  "hw292-omani-works-prod",
+		Placement: applicationPlacement{
+			Mode:    "active-hot-standby",
+			Regions: []string{"me-east-215-a", "me-east-215-b"},
+		},
+	}
+	obj := newApplicationUnstructured(req, "", "")
+
+	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
+	if !found || params == nil {
+		t.Fatal("spec.parameters absent/nil")
+	}
+
+	region := postgresPrimaryRegionOf(t, params)
+	if region != "hw-me-east-215-a-rtz-prod" {
+		t.Fatalf("install door emitted topology.primary.region = %q, want the NODE LABEL "+
+			"hw-me-east-215-a-rtz-prod", region)
+	}
+	// The node label is NOT the placement region. #5482 recorded all three
+	// spellings on one hw291 Application (me-east-215-a in the CR,
+	// hw-me-east-215-a-rtz-prod on the node, platform-bootstrap-owned-host in
+	// the Overview). A near-miss region is exactly as unschedulable as an empty
+	// one, so this pins that we did not reach for Placement.Regions[0].
+	if region == req.Placement.Regions[0] {
+		t.Fatalf("the region was taken from Placement.Regions[0] (%q) — that is the CLOUD "+
+			"region, not the openova.io/region node label (#5482)", req.Placement.Regions[0])
+	}
+
+	rep, vErr := validate.Parameters(bpPostgresConfigSchema(), params)
+	if vErr != nil {
+		t.Fatalf("validate.Parameters internal error: %v", vErr)
+	}
+	if !rep.Valid {
+		t.Fatalf("region-bearing parameters must still satisfy the bp-postgres configSchema: %v", rep.Errors)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
@@ -44,6 +44,15 @@ func bpPostgresConfigSchema() map[string]interface{} {
 					"instances": map[string]interface{}{
 						"type": "integer", "minimum": 1, "maximum": 5, "default": 1,
 					},
+					// #5639 — the region half of the active-hot-standby
+					// contract, declared alongside `mode` in
+					// platform/postgres/blueprint.yaml spec.configSchema.
+					"primary": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"region": map[string]interface{}{"type": "string", "default": ""},
+						},
+					},
 				},
 			},
 			"databases": map[string]interface{}{

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.16",
+    "version": "0.2.17",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5760,7 +5760,7 @@ spec:
   # 0.2.13 (#5224): role-secrets side-gate — replica-role region never mints
   # role/hub Secrets; pair password set single-sourced from the primary region.
   # 0.2.14 (#5473): replication-source Service selectorType r -> rw (primary only).
-  version: "0.2.16"
+  version: "0.2.17"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5838,6 +5838,27 @@ spec:
             minimum: 1
             maximum: 5
             default: 1
+          primary:
+            type: object
+            description: |
+              #5639 — the OTHER HALF of `mode: active-hot-standby`. Declared
+              here because the per-Org install door now emits it alongside the
+              mode; a mode without a region renders an unsatisfiable
+              nodeAffinity and the primary never schedules.
+            properties:
+              region:
+                type: string
+                default: ""
+                description: |
+                  The canonical `openova.io/region` NODE LABEL the primary
+                  Cluster pins its required nodeAffinity on (e.g.
+                  hz-fsn-rtz-prod). NOT the cloud region and NOT
+                  Application.spec.regions[0], which carry different spellings
+                  (#5482). Stamped from the Sovereign's SOVEREIGN_PRIMARY_REGION
+                  — by the bootstrap-kit slot substitutes for the host shared
+                  instances, and by catalyst-api for a per-Org install. REQUIRED
+                  in active-hot-standby: chart 0.2.17+ refuses to render without
+                  it rather than emitting `openova.io/region In [""]`.
   placementSchema:
     # Canonical placement vocabulary (#3375 / #3768 / #3784). The catalog
     # New-instance picker reads these modes off the wire; the seed
@@ -5859,7 +5880,7 @@ spec:
     # 0.2.12 (#4986): active-hot-standby emits the dr-<instance> Continuum CR so
     # the per-app Topology DR panel renders (shared-pg #3375 rows 51/52/56/57/64).
     # 0.2.13 (#5224): role-secrets side-gate (replica-role region mints nothing).
-    version: "0.2.16"
+    version: "0.2.17"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## The defect

A per-Org `bp-postgres` in active-hot-standby rendered an **empty region selector** and was unschedulable forever — while its HelmRelease reported `install succeeded`.

Live on hw292, Cluster `hw292-omani-works/postgres`, 7+ hours at `phase="Setting up primary"`:

```
nodeAffinity required: openova.io/region In [""]
node label, all 4 nodes:  openova.io/region=hw-me-east-215-a-rtz-prod
FailedScheduling: 0/4 nodes are available: 4 node(s) didn't match Pod's node affinity/selector
CONTROL - the healthy cnpg/cnpg-pair primary, same cluster:
                          openova.io/region=[hw-me-east-215-a-rtz-prod]
```

No node carries an empty region label, so this was never going to schedule. The expensive part is that nothing upstream asked: Helm rendered valid YAML, the apiserver accepted the Cluster, the HelmRelease went green, and a customer-visible Organization showed a healthy badge over a database that never had a running primary.

The HelmRelease values were `{"topology":{"mode":"active-hot-standby"}}` — mode present, region absent.

## Half 1 — the chart refuses to render a region it cannot resolve

`platform/postgres/chart/templates/_helpers.tpl` gains two guards, each a Helm `required` naming the exact missing key:

- `bp-postgres.primaryRegion`
- `bp-postgres.replicaRegion`

`cluster.yaml` now resolves through the first at **line 49** (the `openova.io/region` label) and **line 73** (the nodeAffinity `values[]`); `replica-cluster.yaml` resolves through the second at **lines 51 and 77**. Live message:

```
Error: execution error at (bp-postgres/templates/cluster.yaml:49:26): bp-postgres:
topology.primary.region is REQUIRED in active-hot-standby mode
(topology.mode=active-hot-standby or topology.crossRegion=true). It is the canonical
openova.io/region NODE LABEL the primary Cluster's required nodeAffinity pins on — set
it from this Sovereign's SOVEREIGN_PRIMARY_REGION (e.g. hz-fsn-rtz-prod). Rendering it
empty emits 'openova.io/region In [""]', which no node can ever satisfy, so the primary
is unschedulable forever while the HelmRelease still reports install succeeded (#5639).
```

The guard is scoped to the active-hot-standby render. **The singleton render is byte-identical to 0.2.16** and consumes no region, and the bootstrap-kit slots are unaffected — cloud-init stamps `SOVEREIGN_PRIMARY_REGION` / `SOVEREIGN_REPLICA_REGION` unconditionally (`primary_region_canonical_label` is non-empty on both the Hetzner and Huawei providers).

## Half 2 — the producer emits the region with the mode

`products/catalyst/bootstrap/api/internal/handler/application_parameters.go` — `defaultedParameters`, **line 176**, calling the new `stampPostgresPrimaryRegion` (defined at line 237, with `postgresTopologyIsActiveHotStandby` at 273 and `sovereignPrimaryRegionNodeLabel` at 291).

The value is `SOVEREIGN_PRIMARY_REGION`: the canonical `openova.io/region` node label, already mounted on the catalyst-api Deployment from the `sovereign-fqdn` ConfigMap, already read by `renderOrganizationOverlay` for its D31 block, and byte-identical to what bootstrap-kit slots 16a/16c/16d substitute into `topology.primary.region` for the host shared instances. The per-Org install now pins exactly what the proven host path pins.

Three details that are load-bearing:

- **Mode and region go into the SAME `topology` object.** The application-controller merges Blueprint `manifests.values` with `spec.parameters` *shallowly* (`mergeMaps`), so `spec.parameters.topology` replaces the whole object. Split across two keys, one of them is dropped before it reaches `HelmRelease.spec.values`.
- **Not `Application.spec.regions[0]`.** On hw292 that field held `me-east-215-a` — the cloud region — while the node label was `hw-me-east-215-a-rtz-prod`; the seed door defaults it to the literal string `"primary"`. #5482 recorded three divergent spellings on a single Application. A near-miss region is exactly as unschedulable as an empty one.
- **The producer never emits a mode it did not emit before.** The mode seed still only fires when the caller supplied nothing; the region completion additionally covers a caller-supplied `topology.mode` and the `topology.crossRegion` boolean, because the chart activates the same region-pinned shape through all three.

With no Sovereign region declared (mothership / Catalyst-Zero) the producer stamps **nothing** and hands off to the chart guard — an install error a human reads, rather than a green badge over a Pending Pod.

## Class sweep

Swept every Helm template under `platform/**/chart/templates/` and `products/**/chart*/**/templates/` for the shape "a `.Values.*` region/zone value interpolated into `nodeAffinity` / `nodeSelector` / `topologySpreadConstraints` / a region label, with no guard". Greps run: `nodeAffinity`, `nodeSelector`, `topologySpreadConstraints`, `matchExpressions`, `openova.io/region`, `topology.kubernetes.io/zone`.

**Exactly one same-class sibling, and it is in this same chart** — so it is fixed here rather than in a second PR (PRINCIPLES III.4):

| file:line | expression | guard before |
|---|---|---|
| `platform/postgres/chart/templates/replica-cluster.yaml:47` (pre-fix; now 51) | `.Values.topology.replica.region` (region **label**) | none |
| `platform/postgres/chart/templates/replica-cluster.yaml:71` (pre-fix; now 77) | `.Values.topology.replica.region` (nodeAffinity `values[]`) | none |

Everything else in the class is already guarded and was left alone:

- `platform/cnpg-pair/` — `cnpg-pair.validateRegions` (`required` + a distinctness `fail`) covers `primary-cluster.yaml` / `replica-cluster.yaml` directly and `failover-readiness.yaml` / `dr-promoter.yaml` / `dr-failback.yaml` transitively (their gates are subsets of the guarded one).
- `platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml` — `bp-wordpress-tenant.validateActiveHotStandbyRegions`, the same `required` + distinctness pattern.
- `products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml` — non-empty default `hz-fsn-rtz-prod`.
- `platform/bp-mgmt-vcluster` region nodeSelector helper — `if and $k $v`, emits nothing when empty.
- Every other `nodeSelector` / `topologySpreadConstraints` in `platform/` and `products/` is `{{- with }}` / `{{- if }}` guarded.

So bp-postgres was the drift: two sibling charts had this guard already and this one never adopted it.

**Two adjacent findings, different class — flagged, not fixed here.** `platform/bp-rtz-vcluster` and `platform/bp-dmz-vcluster` declare `nodeSelector.regionLabelKey/regionLabelValue` in values.yaml with comments saying the vCluster pod must run on its region's own control-plane node, but neither chart consumes those values in any template; `platform/bp-mgmt-vcluster`'s `nodeSelector` helper is defined and never invoked. That is the opposite failure mode — no constraint rather than an impossible one — so it is not this defect and is not touched.

## Tests — both directions, each run against the UNFIXED code first

### Chart: `platform/postgres/chart/tests/postgres-render.sh` Case #5639

The pre-existing Case-4 assertion was `grep -q 'key: openova.io/region'` — that passes on the **broken** render too, because the KEY is present whether or not the VALUE is. That vacuity is closed here.

| assertion | on origin/main templates |
|---|---|
| (+) primary: label AND nodeAffinity `values[]` carry `hz-fsn-rtz-prod` | PASS — control, proves the guard does not over-fire |
| (+) replica: label AND nodeAffinity `values[]` carry `hz-hel-rtz-prod` | PASS — same control |
| (-) AHS with **no** `topology.primary.region` must FAIL and name the key | **FAILS as expected**, printing the defect verbatim: `openova.io/region: ""` and `values: [""]` |
| (-) replica half with no `topology.replica.region` must FAIL and name the key | **FAILS as expected** — unfixed render emits `openova.io/region: ""` / `values: [""]` at replica-cluster.yaml lines 65/91 |
| (=) singleton renders with no region key and grows no region pin | PASS — no-regression lock |

### Producer: `application_parameters_region_5639_test.go` (10 assertions)

Against the unfixed `application_parameters.go`, **6 FAIL with `topology.primary.region = ""`** — which is #5639 verbatim — and **4 PASS**:

FAIL on unfixed (the defect):
- `TestDefaultedParameters_PostgresActiveHotStandby_StampsPrimaryRegion`
- `TestDefaultedParameters_PostgresEveryHAToken_StampsPrimaryRegion` (all four canonical HA tokens)
- `TestDefaultedParameters_PostgresCrossRegionBool_StampsPrimaryRegion`
- `TestDefaultedParameters_PostgresExplicitMode_RegionCompleted`
- `TestNewApplicationCRFromSeed_PostgresAHS_CarriesPrimaryRegion` (real door)
- `TestNewApplicationUnstructured_PostgresAHS_CarriesPrimaryRegion` (real door; also asserts the region is NOT `Placement.Regions[0]`)

PASS on unfixed (the no-regression side, present so the fix cannot be "stamp a region everywhere"):
- `TestDefaultedParameters_PostgresSingleton_StampsNoRegion`
- `TestDefaultedParameters_PostgresExplicitRegion_NeverClobbered`
- `TestDefaultedParameters_PostgresActiveHotStandby_NoEnv_StampsNothing`
- `TestDefaultedParameters_NonPostgres_NoRegionStamp`

## Gates

| command | result |
|---|---|
| `helm lint platform/postgres/chart` | `1 chart(s) linted, 0 chart(s) failed` |
| `helm template` — AHS **with** region | renders; label `openova.io/region: "hz-fsn-rtz-prod"`, nodeAffinity `values: ["hz-fsn-rtz-prod"]` |
| `helm template` — AHS **without** region | **fails** at `cluster.yaml:49:26` naming `topology.primary.region` |
| `helm template` — replica half without replica region | **fails** at `replica-cluster.yaml:51:26` naming `topology.replica.region` |
| `helm template` — singleton, no region key | renders, zero `openova.io/region` occurrences |
| `bash platform/postgres/chart/tests/postgres-render.sh` | full gate green, all 5 new #5639 sub-cases PASS |
| `bash scripts/check-bootstrap-kit-pin-sync.sh` | `Checked 67 chart→pin pair(s)` — PASS |
| `bash scripts/check-catalog-seed-lockstep.sh` | `checked: 68  skipped: 13  fail: 0` — PASS |
| `go build ./...` + `go test ./...` in `products/catalyst/bootstrap/api` | build OK, all packages `ok` |
| `go test ./...` in `tests/e2e/bootstrap-kit` (the guard the shell scripts miss) | `ok 0.427s` |
| `bash scripts/check-no-nodeports.sh` | Phase 0 vacuity self-test OK (4/4 banned forms matched, 2/2 allowed rejected, 2759 files in scope); **Phase 1 static source scan OK**; **Phase 1b IaC port-literal scan OK** (the two authoritative phases). Phase 2 is the best-effort per-chart render and it does **not** cover this chart either way: `platform/postgres/chart` is already in `RENDER_SKIP_ALLOWLIST` (`scripts/check-no-nodeports.sh:238`) and `scripts/` is untouched by this PR. Phase 2 also reported 2 unrelated failures — `platform/matrix/chart` and `platform/powerdns/chart` — both `helm dependency` fetch timeouts against upstream repos in this sandbox (rc=1 DNS timeout to `gitlab.com`, rc=124 timeout respectively), not NodePort findings, and neither chart appears in this diff. Verified directly instead: `helm template platform/postgres/chart` in **both** the singleton and the active-hot-standby shapes greps **0** case-insensitive `nodeport` occurrences. |

No NodePort appears anywhere in this diff: `git diff | grep -iE 'nodeport|3[0-2][0-9]{3}'` returns nothing. No Service is touched at all — the diff is two Cluster templates, a helpers file, values/schema docs, one Go producer, tests, and version pins.

## Five-site lockstep — 0.2.16 → 0.2.17

1. `platform/postgres/chart/Chart.yaml`
2. `platform/postgres/blueprint.yaml`
3. `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (both the display `spec.version` and the delivery `source.version`)
4. `clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml`, `16c-bp-postgres-shared-b.yaml`, `16d-bp-postgres-shared-c.yaml`
5. Regenerated via `cd products/catalyst/bootstrap/ui && node scripts/build-catalog.mjs`, both committed: `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` + `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts`

`blueprint.yaml` and the catalog seed also now declare `topology.primary.region` in `configSchema`, since the per-Org door emits it. bp-postgres has no umbrella dependency, so there is no umbrella pin; `products/catalyst/chart/Chart.yaml` is not bumped, matching the two most recent catalog-seed commits (e5d632a21, 95083478d).

## For the merger

- **The `ghcr-pin-existence` CI job will report a miss for `bp-postgres:0.2.17` on this PR.** That is the #5559 publish race and the job is `continue-on-error` on `pull_request` / `push` by design; `blueprint-release.yaml` publishes the tag on merge to main, and the hourly `schedule` run is the fail-loud one. Nothing to do — but do not add a row to `scripts/expected-unpublished-catalog-seed-pins.yaml` for it, since that register self-retires the moment a chart publishes.
- **Ordering matters slightly.** The chart guard makes a half-declared active-hot-standby install fail loudly instead of silently. Any existing per-Org bp-postgres HelmRelease that carries mode-without-region will flip from a green-but-broken `install succeeded` to a visible install error once it upgrades to 0.2.17. That is the intended outcome — the workload was already dead — but it will look like new breakage in the HelmRelease list until catalyst-api ships the producer half. Both halves are in this one PR, so merging it whole avoids the window.
- Not verified live: this fixes the render and the emit; the hw292 Cluster itself is untouched (that env was read-only for this work) and will need a re-walk on a fresh prov to close the row.

Refs #5639 #960 #3986
