### PR TITLE
fix(security): declare the Cilium control-plane node-encryption exclusion and gate the fleet on it (Refs #5637)

### DIFF
--- a/.github/workflows/check-node-encryption-uniformity.yaml
+++ b/.github/workflows/check-node-encryption-uniformity.yaml
@@ -1,0 +1,87 @@
+name: check — WireGuard node-encryption uniformity (#5637)
+
+# Keeps the detector in scripts/check-live-node-encryption.sh honest.
+#
+# The guard itself needs a live Sovereign, so CI cannot run the sweep. What CI
+# CAN do — and what actually matters — is prove the detector is not vacuous:
+# a fleet-shaped fixture that must come back GREEN, plus nine divergent
+# fixtures that must each come back RED, plus two malformed ones that must come
+# back as setup errors. All eleven run through the SAME evaluator the live
+# sweep uses, so a refactor that quietly turns the guard into `exit 0` fails
+# here instead of on a Sovereign nobody re-walked.
+#
+# Why the fixtures matter more than usual for this one: the property is
+# per-node and exactly one node per region legitimately differs (each region's
+# control-plane node is excluded upstream-by-default — docs/SECURITY.md §2.1).
+# A guard written as "every agent must read Enabled" would be red on every
+# healthy Sovereign and would be deleted within a week; this one pins the
+# label→state mapping instead, and the fixtures prove it still reddens on a
+# worker that opted out, on a control-plane node that did not, on an agent
+# whose node labels no longer imply its state, and on an exclusion set that grew.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/check-live-node-encryption.sh'
+      - 'scripts/verify-sovereign-convergence.sh'
+      - 'platform/cilium/**'
+      - 'docs/SECURITY.md'
+      - '.github/workflows/check-node-encryption-uniformity.yaml'
+  pull_request:
+    paths:
+      - 'scripts/check-live-node-encryption.sh'
+      - 'scripts/verify-sovereign-convergence.sh'
+      - 'platform/cilium/**'
+      - 'docs/SECURITY.md'
+      - '.github/workflows/check-node-encryption-uniformity.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  node-encryption-detector:
+    name: Detector self-test (11 cases, both directions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detector self-test
+        run: bash scripts/check-live-node-encryption.sh --self-test
+
+      - name: Refuse a guard that passes on nothing
+        # Belt-and-braces on the vacuity direction: an empty fleet must exit 2,
+        # never 0. If someone "fixes" the empty-snapshot case into a pass, the
+        # self-test above would still be green for the other ten cases.
+        run: |
+          set +e
+          printf '# empty\n' | bash scripts/check-live-node-encryption.sh --fixture - >/dev/null 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -ne 2 ]; then
+            echo "::error title=Vacuous guard::empty snapshot exited $rc, expected 2"
+            exit 1
+          fi
+          echo "empty snapshot exits 2 — an empty fleet is not a clean fleet"
+
+      - name: Guard is wired into the post-convergence battery
+        # A guard nobody invokes is documentation. This asserts the live wiring
+        # survives refactors of verify-sovereign-convergence.sh.
+        run: |
+          grep -q 'check-live-node-encryption.sh' scripts/verify-sovereign-convergence.sh \
+            || { echo "::error title=Guard unwired::verify-sovereign-convergence.sh no longer calls the node-encryption guard"; exit 1; }
+          echo "verify-sovereign-convergence.sh calls the guard"
+
+      - name: Declared posture matches the documented posture
+        # EXPECTED_OPT_OUT_SELECTOR in the guard and the selector stated in
+        # docs/SECURITY.md §2.1 are one decision recorded twice. Drift between
+        # them is how a security posture quietly becomes two postures.
+        run: |
+          sel=$(grep -m1 '^EXPECTED_OPT_OUT_SELECTOR=' scripts/check-live-node-encryption.sh \
+                | sed 's/.*:-\([^}]*\)}.*/\1/')
+          echo "guard declares: $sel"
+          grep -q "$sel" docs/SECURITY.md \
+            || { echo "::error title=Posture drift::docs/SECURITY.md does not mention the selector '$sel'"; exit 1; }
+          echo "docs/SECURITY.md states the same selector"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,7 +31,11 @@ Two systems, never conflated. Workload identity is bound to a Kubernetes Service
 │  - encryption.wireguard.userspaceFallback = false                     │
 │  - every pod-to-pod packet that leaves a node is wrapped in a         │
 │    WireGuard tunnel keyed per node-pair, at the kernel layer          │
-│  - 100% mesh coverage (no exemptions), zero sidecars                  │
+│  - 100% pod-to-pod coverage (no exemptions), zero sidecars            │
+│  - encryption.nodeEncryption = true extends the same tunnel to        │
+│    node↔node / node↔pod (host-namespace) traffic — on every node      │
+│    EXCEPT one that matches the opt-out selector. Read §2.1 before     │
+│    citing this as fleet-wide host-traffic encryption.                 │
 │  - L7 policy + identity-aware enforcement via Cilium NetworkPolicy    │
 │    and CiliumNetworkPolicy CRs                                        │
 └──────────────────────────────────────────────────────────────────────┘
@@ -66,11 +70,80 @@ ns=catalyst-openbao    sa=openbao                  ← OpenBao itself
 
 **Catalyst REST API auth:** workload calls are authenticated by SA bound-token (TokenReview); user calls by Keycloak-issued JWT.
 
+### 2.1 Node-to-node encryption — the control-plane exclusion is declared, not accidental
+
+**The posture, stated once so nobody has to re-derive it from a ConfigMap:**
+
+> WireGuard node-encryption is on for every node in every region **except** a node
+> whose labels match `--node-encryption-opt-out-labels`, whose value is
+> `node-role.kubernetes.io/control-plane`. On k3s every server node carries that
+> label, so **the control-plane node of each region is excluded** — by upstream
+> default, deliberately, for a reason that matters (below). Pod-to-pod encryption
+> is unaffected on those nodes and remains 100%.
+
+**Mechanism** (Cilium 1.19.3, read off the agent rather than off the docs):
+
+```
+$ cilium-agent --help | grep node-encryption-opt-out-labels
+  --node-encryption-opt-out-labels string   Label selector for nodes which will
+       opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
+```
+
+The agent logs the decision at startup on a matching node:
+
+```
+level=info msg="Opting out from node-to-node encryption on this node as per
+ node-encryption-opt-out-labels label selector"
+ module=agent.datapath.wireguard-agent Selector=node-role.kubernetes.io/control-plane
+```
+
+`platform/cilium/chart/values.yaml` sets `encryption.nodeEncryption: true` and does
+**not** set the selector, so the upstream default is in force. Nothing in the
+rendered chart, in `cilium-config`, or in the headline `Encryption: Wireguard
+[… Peers: N]` status line reveals the exclusion — only the `NodeEncryption:`
+sub-field of `cilium-dbg status` does, on the excluded node alone.
+
+**Why the exclusion is kept rather than overridden.** The connection a node uses to
+publish its rotated WireGuard public key would otherwise be encrypted with the very
+key being replaced. Excluding the node that hosts the API server keeps key rotation
+and node re-provisioning from deadlocking against themselves. Overriding it (an empty
+selector) is a security-posture change that has to be argued here **and** re-proven on
+a fresh prov through a key rotation — never flipped silently in a values file.
+
+**What the exclusion costs, precisely.** On an excluded node, traffic sourced from or
+destined to the **host network namespace** is not WireGuard-wrapped: API server
+(:6443), etcd (:2379/:2380), kubelet (:10250), cilium-health probes, the cilium
+agent's ClusterMesh client connections, and the hostNetwork `cilium-envoy` gateway
+hop to backend pods. Every one of those except the envoy hop carries its own TLS
+(k3s serving certs, etcd peer/client TLS, ClusterMesh mTLS), so the loss is a layer of
+defence in depth rather than credentials in the clear. The envoy hop is the one that
+is post-TLS-termination, and it stays on the per-region private VPC subnet. **Pod-to-pod
+traffic — including every cross-region ClusterMesh pod flow — is unaffected**, because
+that is the base WireGuard feature and not the node-encryption extension.
+
+**The gate.** `scripts/check-live-node-encryption.sh` reads every cilium agent in every
+region given to it and fails closed unless each agent's `NodeEncryption` state is the
+one its node's labels imply under the selector declared above. It catches a worker that
+silently opted out, a control-plane node that silently did not, an agent still carrying
+a state its node's labels no longer imply, an exclusion set that grew, and a state it
+could not read. It is wired into `scripts/verify-sovereign-convergence.sh` (step 7) and
+its detector self-test runs on every PR that touches the guard or the Cilium chart.
+
+```bash
+scripts/check-live-node-encryption.sh --kubeconfig <region-a> --kubeconfig <region-b>
+scripts/check-live-node-encryption.sh --self-test     # detector proof, no cluster
+```
+
+Live on hw292 (dep `1c56518035a83e03`, 2026-08-03): 8 agents, 2 regions —
+`NodeEncryption Enabled=6  OptedOut=2`, the two being `…-a-cp1-54be6d` and
+`…-b-cp1-6a755c`, exactly the label-selector match. Refs #5637.
+
 ### Why this configuration is sufficient today
 
 | Concern | How it's met today |
 |---|---|
-| In-flight encryption | Cilium WireGuard, kernel-level, 100% mesh, no opt-out |
+| In-flight encryption (pod-to-pod) | Cilium WireGuard, kernel-level, 100% mesh, no opt-out |
+| In-flight encryption (host-namespace: node↔node, node↔pod) | Cilium WireGuard node-encryption on every node whose labels do not match the opt-out selector — today that is every worker; the control-plane node of each region is excluded upstream-by-default. Declared and gated in §2.1 |
 | Workload-to-workload authentication | K8s SA tokens validated server-side via TokenReview |
 | Token rotation | Projected SA bound-tokens auto-rotate hourly (kubelet) |
 | Defense against stolen long-lived tokens | Bound tokens are scoped to a single Pod + audience + 1h TTL; the legacy unbound SA secret-tokens are not used |

--- a/platform/cilium/README.md
+++ b/platform/cilium/README.md
@@ -138,6 +138,17 @@ encryption:
   enabled: true
   type: wireguard
 
+# ⚠️ `encryption.nodeEncryption: true` (set in chart/values.yaml) does NOT mean
+# every node encrypts host-namespace traffic. The agent applies a per-node
+# opt-out from `--node-encryption-opt-out-labels`, default
+# `node-role.kubernetes.io/control-plane`, and on k3s every server node carries
+# that label — so each region's control-plane node reports
+# `NodeEncryption: OptedOut` while cilium-config still reads encrypt-node=true.
+# The exclusion is upstream-deliberate (a rotated WireGuard public key would
+# otherwise be published over a connection encrypted with the key being
+# replaced). Posture + what it costs: docs/SECURITY.md §2.1. Fleet gate:
+# scripts/check-live-node-encryption.sh (#5637).
+
 # L7 proxy
 envoy:
   enabled: true

--- a/scripts/check-live-node-encryption.sh
+++ b/scripts/check-live-node-encryption.sh
@@ -1,0 +1,518 @@
+#!/usr/bin/env bash
+# check-live-node-encryption.sh — CLUSTER-side WireGuard node-encryption
+# uniformity guard (#5637).
+#
+# WHY THIS EXISTS
+#
+# `cilium-config` carrying `enable-wireguard: true` + `encrypt-node: true` is
+# NOT evidence that node-to-node encryption is on for every node. The Cilium
+# agent applies a per-node opt-out driven by the label selector in
+# `--node-encryption-opt-out-labels`, whose UPSTREAM DEFAULT is
+# `node-role.kubernetes.io/control-plane`. On k3s every server node carries
+# that label, so on every Catalyst Sovereign the control-plane node of each
+# region silently drops out of node-to-node encryption while the ConfigMap,
+# the chart values, and `cilium-dbg status`'s own "Wireguard, Peers: N" line
+# all keep saying encryption is on. Only the `NodeEncryption:` sub-field
+# disagrees, and only on that one node per region.
+#
+# Proven live on hw292 (dep 1c56518035a83e03, 2026-08-03):
+#
+#   cilium-97bpn  (region-A cp1) Encryption: Wireguard [NodeEncryption: OptedOut, …]
+#   cilium-s8mw5  (region-B cp1) Encryption: Wireguard [NodeEncryption: OptedOut, …]
+#   the other six agents          Encryption: Wireguard [NodeEncryption: Enabled,  …]
+#
+#   cilium-97bpn log, verbatim:
+#     "Opting out from node-to-node encryption on this node as per
+#      node-encryption-opt-out-labels label selector"
+#      module=agent.datapath.wireguard-agent
+#      Selector=node-role.kubernetes.io/control-plane
+#
+# A per-node security property that exactly one node per region lacks is the
+# shape a spot check never catches: sample a worker and the fleet reads
+# uniform. So this guard reads EVERY agent in EVERY region given to it and
+# fails closed the moment the fleet stops matching its declared posture.
+#
+# WHAT IT ASSERTS (all fail closed — no WARN, no silent skip)
+#
+#   1. Every region's cilium-config has enable-wireguard=true, encrypt-node=true.
+#   2. The EFFECTIVE opt-out selector equals the posture declared in
+#      docs/SECURITY.md §2.1 (EXPECTED_OPT_OUT_SELECTOR below). An upstream
+#      default that drifts — or a hand-widened selector — is a violation even
+#      though every node would still "agree" with it.
+#   3. Every agent reports a NodeEncryption state that is exactly `Enabled` or
+#      `OptedOut`. Unreadable, absent, not-Running, or any other token is a
+#      violation, never a skip.
+#   4. Each agent's state is the one its node's LABELS predict: a node matching
+#      the declared selector must report OptedOut, every other node must report
+#      Enabled. This catches, in one rule, all four failure shapes:
+#        - a worker that silently opted out            (the #5637 fear)
+#        - a control-plane node that silently encrypts (undeclared drift)
+#        - an agent still carrying a state its node's labels no longer imply
+#          (the "agent started before the setting applied" shape — a restart
+#          would mask it, so the guard names it instead)
+#        - a selector nobody can parse (parse failure is a violation)
+#   5. An empty fleet is a setup error, not a pass. A guard that reports clean
+#      on zero rows is the vacuity trap this repo has paid for before.
+#
+# WHY IT DOES NOT DEMAND ONE UNIFORM STATE ACROSS THE WHOLE FLEET
+#
+# It cannot: the control-plane opt-out is upstream-deliberate, documented, and
+# load-bearing (the connection that updates a node's WireGuard public key would
+# otherwise be encrypted with the very key being replaced). A "all agents must
+# read Enabled" gate would be red on every healthy Sovereign, and a gate that
+# is always red gets deleted. Pinning the label→state MAPPING is strictly
+# stronger than pinning uniformity: it still fails closed on divergence, and it
+# additionally catches an exclusion set that grows.
+#
+# RELATIONSHIP TO THE OTHER CHART/SOURCE GUARDS
+#
+# Same split as check-no-nodeports.sh (source) vs check-live-nodeports.sh
+# (live): no amount of chart reading can see this, because the chart is
+# correct — `encryption.nodeEncryption: true` is set and renders. The divergence
+# only exists in the agent's runtime decision on a specific node. It is wired
+# into scripts/verify-sovereign-convergence.sh so it runs in the existing
+# post-convergence battery rather than as a guard nobody invokes.
+#
+# Usage:
+#   scripts/check-live-node-encryption.sh --kubeconfig <A> --kubeconfig <B>
+#   scripts/check-live-node-encryption.sh --context <ctx> [--context <ctx2>]
+#   scripts/check-live-node-encryption.sh --fixture <snapshot.tsv>   # replay
+#   scripts/check-live-node-encryption.sh --self-test                # no cluster
+#   scripts/check-live-node-encryption.sh --kubeconfig <A> --dump    # capture
+#
+# Exit: 0 = fleet matches the declared posture
+#       1 = divergence (a node's encryption state is not what it must be)
+#       2 = setup / self-test failure / nothing to check
+#
+# Refs #5637 #960.
+
+set -uo pipefail
+
+# ── the declared posture ────────────────────────────────────────────────
+# Verified against Cilium 1.19.3 on 2026-08-03 by reading the agent itself,
+# not by reading the docs:
+#   cilium-agent --help | grep node-encryption-opt-out-labels
+#   →  (default "node-role.kubernetes.io/control-plane")
+# Keep this in lockstep with docs/SECURITY.md §2.1. Changing it is a security-
+# posture change and must be argued there, not here.
+EXPECTED_OPT_OUT_SELECTOR="${EXPECTED_OPT_OUT_SELECTOR:-node-role.kubernetes.io/control-plane}"
+
+KUBECONFIGS=()
+CONTEXTS=()
+FIXTURE=""
+SELF_TEST_ONLY=0
+DUMP=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --kubeconfig) KUBECONFIGS+=("$2"); shift 2 ;;
+    --context)    CONTEXTS+=("$2");    shift 2 ;;
+    --fixture)    FIXTURE="$2";        shift 2 ;;
+    --self-test)  SELF_TEST_ONLY=1;    shift ;;
+    --dump)       DUMP=1;              shift ;;
+    -h|--help)
+      sed -n '/^# Usage:/,/^# Refs/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2
+       echo "Usage: $0 [--kubeconfig <path>]... [--context <ctx>]... [--fixture <f>] [--self-test] [--dump]" >&2
+       exit 2 ;;
+  esac
+done
+
+# ── the evaluator ───────────────────────────────────────────────────────
+#
+# Pure function of a snapshot, so the self-test exercises THE SAME code the
+# live sweep uses — a classifier tested only through a copy of itself is not
+# tested.
+#
+# Snapshot format (TSV, one line per cilium agent, '#' lines ignored):
+#   region  pod  node  labels_csv  state  encrypt_node  enable_wireguard  selector
+#
+#   labels_csv        k=v pairs, comma separated (valueless label ⇒ bare key)
+#   state             Enabled | OptedOut | anything else (⇒ violation)
+#   encrypt_node      the region's cilium-config encrypt-node value
+#   enable_wireguard  the region's cilium-config enable-wireguard value
+#   selector          effective --node-encryption-opt-out-labels for the region;
+#                     prefix "default:" when inherited (key absent from the
+#                     ConfigMap) rather than pinned in it
+evaluate() {
+  EXPECTED_OPT_OUT_SELECTOR="$EXPECTED_OPT_OUT_SELECTOR" python3 -c '
+import os, sys
+
+EXPECTED = os.environ["EXPECTED_OPT_OUT_SELECTOR"]
+rows, bad = [], []
+
+def parse_labels(csv):
+    out = {}
+    for item in csv.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" in item:
+            k, v = item.split("=", 1)
+            out[k.strip()] = v.strip()
+        else:
+            out[item] = ""
+    return out
+
+class Unparseable(Exception):
+    pass
+
+def matches(selector, labels):
+    """Minimal k8s label-selector match: exists / = / == / !=.
+
+    Anything else raises, and the caller turns that into a violation. A
+    selector this cannot read is a selector whose blast radius is unknown,
+    and an unknown blast radius on an encryption exclusion is never a pass."""
+    if selector.strip() == "":
+        return False              # empty selector excludes nothing
+    for term in selector.split(","):
+        term = term.strip()
+        if not term:
+            continue
+        if "!=" in term:
+            k, v = term.split("!=", 1)
+            if labels.get(k.strip()) == v.strip():
+                return False
+        elif "==" in term:
+            k, v = term.split("==", 1)
+            if labels.get(k.strip()) != v.strip():
+                return False
+        elif "=" in term:
+            k, v = term.split("=", 1)
+            if labels.get(k.strip()) != v.strip():
+                return False
+        elif term.replace("-", "").replace(".", "").replace("/", "").replace("_", "").isalnum():
+            if term not in labels:
+                return False
+        else:
+            raise Unparseable(term)
+    return True
+
+for lineno, raw in enumerate(sys.stdin, 1):
+    line = raw.rstrip("\n")
+    if not line.strip() or line.lstrip().startswith("#"):
+        continue
+    f = line.split("\t")
+    if len(f) != 8:
+        bad.append("line %d: expected 8 tab-separated fields, got %d" % (lineno, len(f)))
+        continue
+    rows.append(dict(zip(
+        ["region", "pod", "node", "labels", "state",
+         "encrypt_node", "enable_wireguard", "selector"], f)))
+
+if bad:
+    for b in bad:
+        print("SNAPSHOT-ERROR: %s" % b)
+    sys.exit(2)
+
+if not rows:
+    print("SETUP-ERROR: no cilium agents in the snapshot — nothing was checked.")
+    print("             An empty fleet is not a clean fleet.")
+    sys.exit(2)
+
+violations = []
+print("%-10s %-16s %-58s %-9s %s" % ("REGION", "AGENT", "NODE", "STATE", "VERDICT"))
+
+for r in rows:
+    labels = parse_labels(r["labels"])
+    sel_raw = r["selector"]
+    sel = sel_raw[len("default:"):] if sel_raw.startswith("default:") else sel_raw
+    inherited = sel_raw.startswith("default:")
+    verdict = []
+
+    if r["enable_wireguard"] != "true":
+        violations.append("%s: cilium-config enable-wireguard=%r (want \"true\")"
+                          % (r["region"], r["enable_wireguard"]))
+        verdict.append("WIREGUARD-OFF")
+    if r["encrypt_node"] != "true":
+        violations.append("%s: cilium-config encrypt-node=%r (want \"true\")"
+                          % (r["region"], r["encrypt_node"]))
+        verdict.append("ENCRYPT-NODE-OFF")
+
+    if sel != EXPECTED:
+        violations.append(
+            "%s: effective node-encryption-opt-out-labels=%r (declared posture is %r%s)"
+            % (r["region"], sel, EXPECTED,
+               "; inherited from the agent default" if inherited else "; pinned in cilium-config"))
+        verdict.append("SELECTOR-DRIFT")
+
+    if r["state"] not in ("Enabled", "OptedOut"):
+        violations.append("%s/%s on %s: NodeEncryption state is %r — unreadable states are violations, not skips"
+                          % (r["region"], r["pod"], r["node"], r["state"]))
+        verdict.append("STATE-UNREADABLE")
+    else:
+        try:
+            excluded = matches(sel, labels)
+        except Unparseable as e:
+            violations.append("%s: opt-out selector term %r is not parseable by this guard — "
+                              "extend the matcher rather than widening the exclusion silently"
+                              % (r["region"], str(e)))
+            verdict.append("SELECTOR-UNPARSEABLE")
+            excluded = None
+        if excluded is not None:
+            want = "OptedOut" if excluded else "Enabled"
+            if r["state"] != want:
+                if want == "Enabled":
+                    why = ("node does NOT match the declared opt-out selector, so its "
+                           "node-to-node traffic must be encrypted")
+                else:
+                    why = ("node matches the declared opt-out selector, so reporting Enabled "
+                           "means the live fleet no longer matches the declared posture")
+                violations.append("%s/%s on %s: NodeEncryption=%s, expected %s — %s"
+                                  % (r["region"], r["pod"], r["node"], r["state"], want, why))
+                verdict.append("MISMATCH")
+            else:
+                verdict.append("excluded-by-declared-selector" if excluded else "encrypted")
+
+    print("%-10s %-16s %-58s %-9s %s"
+          % (r["region"], r["pod"], r["node"][:58], r["state"], ",".join(verdict)))
+
+enabled  = sum(1 for r in rows if r["state"] == "Enabled")
+optedout = sum(1 for r in rows if r["state"] == "OptedOut")
+print("")
+print("agents=%d  NodeEncryption Enabled=%d  OptedOut=%d  regions=%d"
+      % (len(rows), enabled, optedout, len(set(r["region"] for r in rows))))
+
+if violations:
+    print("")
+    print("❌ NODE-ENCRYPTION DIVERGENCE (%d):" % len(violations))
+    for v in violations:
+        print("   - %s" % v)
+    sys.exit(1)
+
+print("✅ every agent reports the NodeEncryption state its node labels imply, "
+      "under the declared opt-out selector %r." % EXPECTED)
+sys.exit(0)
+'
+}
+
+# ── Phase 0 — detector self-test (vacuity guard) ────────────────────────
+#
+# Runs before ANY live sweep. Both directions are proven: the golden fixture
+# must come back GREEN (a detector that flags everything is as useless as one
+# that flags nothing), and each divergent fixture must come back RED.
+GOLDEN_SNAPSHOT='# region	pod	node	labels	state	encrypt_node	enable_wireguard	selector
+region-a	cilium-97bpn	hw292-a-cp1	node-role.kubernetes.io/control-plane=true,node-role.kubernetes.io/etcd=true	OptedOut	true	true	default:node-role.kubernetes.io/control-plane
+region-a	cilium-cfspn	hw292-a-w63852a	kubernetes.io/os=linux	Enabled	true	true	default:node-role.kubernetes.io/control-plane
+region-a	cilium-mg727	hw292-a-w784020	kubernetes.io/os=linux	Enabled	true	true	default:node-role.kubernetes.io/control-plane
+region-a	cilium-vlz6f	hw292-a-w5020a3	kubernetes.io/os=linux	Enabled	true	true	default:node-role.kubernetes.io/control-plane
+region-b	cilium-s8mw5	hw292-b-cp1	node-role.kubernetes.io/control-plane=true,node-role.kubernetes.io/etcd=true	OptedOut	true	true	default:node-role.kubernetes.io/control-plane
+region-b	cilium-28xdd	hw292-b-w8e097b	kubernetes.io/os=linux	Enabled	true	true	default:node-role.kubernetes.io/control-plane
+region-b	cilium-nb5ll	hw292-b-wa9df1f	kubernetes.io/os=linux	Enabled	true	true	default:node-role.kubernetes.io/control-plane
+region-b	cilium-tvdn6	hw292-b-w54fec6	kubernetes.io/os=linux	Enabled	true	true	default:node-role.kubernetes.io/control-plane'
+
+self_test() {
+  local out rc failures=0
+
+  st_case() {
+    local name="$1" want_rc="$2" snapshot="$3"
+    out="$(printf '%s\n' "$snapshot" | evaluate 2>&1)"; rc=$?
+    if [ "$rc" -ne "$want_rc" ]; then
+      echo "SELF-TEST FAIL: $name — exit $rc, expected $want_rc" >&2
+      printf '%s\n' "$out" | sed 's/^/    /' >&2
+      failures=$((failures + 1))
+    else
+      echo "  ok  [exit $rc] $name"
+    fi
+  }
+
+  echo "── Phase 0: detector self-test ─────────────────────────────────"
+
+  # GREEN control — the real hw292 fleet shape must pass, or the guard is
+  # merely a fleet-shaped tripwire that reddens on everything.
+  st_case "hw292 golden fleet (2 cp OptedOut + 6 workers Enabled)" 0 "$GOLDEN_SNAPSHOT"
+
+  # RED — a worker silently opted out. This is the shape #5637 was filed as.
+  st_case "a worker reports OptedOut" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's/cilium-cfspn\(.*\)Enabled/cilium-cfspn\1OptedOut/')"
+
+  # RED — a control-plane node reports Enabled: undeclared drift the other way.
+  st_case "a control-plane node reports Enabled" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's/cilium-97bpn\(.*\)OptedOut/cilium-97bpn\1Enabled/')"
+
+  # RED — the node lost the control-plane label but the agent still carries the
+  # opt-out. This is exactly the "started before the setting applied and never
+  # re-evaluated" case: a restart would mask it, so the guard must name it.
+  st_case "stale agent: labels no longer imply the state it reports" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's|\(cilium-97bpn\thw292-a-cp1\t\)[^\t]*|\1kubernetes.io/os=linux|')"
+
+  # RED — encryption switched off in one region while the other stays on.
+  st_case "encrypt-node=false in one region" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's/\(cilium-28xdd.*Enabled\)\ttrue\ttrue/\1\tfalse\ttrue/')"
+
+  # RED — WireGuard itself off in one region.
+  st_case "enable-wireguard=false in one region" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's/\(cilium-nb5ll.*Enabled\)\ttrue\ttrue/\1\ttrue\tfalse/')"
+
+  # RED — an agent whose state could not be read. Unreadable is not clean.
+  st_case "an agent state is UNREADABLE" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's/cilium-tvdn6\(.*\)Enabled/cilium-tvdn6\1UNREADABLE/')"
+
+  # RED — the exclusion set grew. Every agent still agrees with the selector,
+  # so a uniformity-only check would pass this; the declared-posture check
+  # does not.
+  st_case "opt-out selector widened beyond the declared posture" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's|default:node-role.kubernetes.io/control-plane|default:node-role.kubernetes.io/control-plane,kubernetes.io/os=linux|')"
+
+  # RED — a selector this matcher cannot read must not be assumed harmless.
+  st_case "unparseable selector term" 1 \
+    "$(printf '%s\n' "$GOLDEN_SNAPSHOT" | sed 's|default:node-role.kubernetes.io/control-plane$|default:role in (cp, worker)|')"
+
+  # SETUP-ERROR — an empty fleet must never read clean.
+  st_case "empty snapshot" 2 "# nothing here"
+
+  # SETUP-ERROR — a malformed snapshot must never read clean either.
+  st_case "malformed snapshot row" 2 "region-a	cilium-x	node-x	labels	Enabled"
+
+  echo ""
+  if [ "$failures" -ne 0 ]; then
+    echo "❌ detector self-test FAILED ($failures case(s)) — refusing to report on a real fleet." >&2
+    return 2
+  fi
+  echo "✅ detector self-test passed (11 cases, both directions)."
+  return 0
+}
+
+self_test || exit 2
+if [ "$SELF_TEST_ONLY" -eq 1 ]; then
+  exit 0
+fi
+
+# ── live acquisition ────────────────────────────────────────────────────
+if [ -n "$FIXTURE" ]; then
+  echo ""
+  echo "── replaying snapshot: $FIXTURE ────────────────────────────────"
+  if [ "$FIXTURE" = "-" ]; then
+    evaluate
+  else
+    [ -r "$FIXTURE" ] || { echo "ERROR: cannot read fixture $FIXTURE" >&2; exit 2; }
+    evaluate < "$FIXTURE"
+  fi
+  exit $?
+fi
+
+if [ "${#KUBECONFIGS[@]}" -eq 0 ] && [ "${#CONTEXTS[@]}" -eq 0 ]; then
+  echo "ERROR: give at least one --kubeconfig or --context (a one-region sweep of a" >&2
+  echo "       two-region Sovereign is exactly the spot check this guard replaces)." >&2
+  exit 2
+fi
+
+command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found" >&2; exit 2; }
+
+KC_TIMEOUT="${KC_TIMEOUT:-25}"
+K_REQ_TIMEOUT="${K_REQ_TIMEOUT:-20s}"
+
+# Read one region into snapshot rows on stdout. $1 = region tag, rest = the
+# kubectl selector args for that region.
+snapshot_region() {
+  local region="$1"; shift
+  local kargs=("$@")
+  local cm nodes pods
+
+  cm="$(timeout "$KC_TIMEOUT" kubectl "${kargs[@]}" --request-timeout="$K_REQ_TIMEOUT" \
+        -n kube-system get cm cilium-config -o json 2>/dev/null)"
+  if [ -z "$cm" ]; then
+    echo "ERROR: $region: cannot read kube-system/cilium-config" >&2
+    return 2
+  fi
+  nodes="$(timeout "$KC_TIMEOUT" kubectl "${kargs[@]}" --request-timeout="$K_REQ_TIMEOUT" \
+           get nodes -o json 2>/dev/null)"
+  pods="$(timeout "$KC_TIMEOUT" kubectl "${kargs[@]}" --request-timeout="$K_REQ_TIMEOUT" \
+          -n kube-system get pods -l k8s-app=cilium -o json 2>/dev/null)"
+  if [ -z "$nodes" ] || [ -z "$pods" ]; then
+    echo "ERROR: $region: cannot list nodes / cilium agents" >&2
+    return 2
+  fi
+
+  local encrypt_node enable_wg selector
+  encrypt_node="$(printf '%s' "$cm" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("data",{}).get("encrypt-node",""))')"
+  enable_wg="$(printf '%s' "$cm" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("data",{}).get("enable-wireguard",""))')"
+  selector="$(printf '%s' "$cm" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("data",{}).get("node-encryption-opt-out-labels",""))')"
+  # An absent key means the agent default is in force. Carry that fact into the
+  # snapshot instead of pretending the value was declared: "inherited" is a
+  # materially different posture from "pinned", and the report says which.
+  if [ -z "$selector" ]; then
+    selector="default:${EXPECTED_OPT_OUT_SELECTOR}"
+  fi
+
+  # pod<TAB>node for every cilium agent, plus its phase.
+  local agents
+  agents="$(printf '%s' "$pods" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+for p in d.get("items",[]):
+    m=p.get("metadata",{}); s=p.get("status",{}); sp=p.get("spec",{})
+    print("%s\t%s\t%s" % (m.get("name","?"), sp.get("nodeName","?"), s.get("phase","?")))
+')"
+  [ -n "$agents" ] || { echo "ERROR: $region: zero cilium agents found" >&2; return 2; }
+
+  local labels_json
+  labels_json="$(printf '%s' "$nodes" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+out={}
+for n in d.get("items",[]):
+    m=n.get("metadata",{})
+    out[m.get("name","?")]={k:v for k,v in (m.get("labels") or {}).items()}
+print(json.dumps(out))
+')"
+
+  while IFS=$'\t' read -r pod node phase; do
+    [ -n "$pod" ] || continue
+    local state labels
+    labels="$(printf '%s' "$labels_json" | NODE="$node" python3 -c '
+import json,os,sys
+d=json.load(sys.stdin)
+print(",".join("%s=%s" % (k,v) if v != "" else k
+               for k,v in sorted(d.get(os.environ["NODE"],{}).items())))
+')"
+    if [ "$phase" != "Running" ]; then
+      # Not a skip: an agent we cannot interrogate is an agent whose encryption
+      # state we cannot claim. Re-run once the DaemonSet roll settles.
+      state="NOT-RUNNING(${phase})"
+    else
+      state="$(timeout "$KC_TIMEOUT" kubectl "${kargs[@]}" --request-timeout="$K_REQ_TIMEOUT" \
+               -n kube-system exec "$pod" -c cilium-agent -- cilium-dbg status 2>/dev/null \
+               | sed -n 's/.*NodeEncryption: \([A-Za-z]*\).*/\1/p' | head -1)"
+      [ -n "$state" ] || state="UNREADABLE"
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$region" "$pod" "$node" "${labels:-none}" "$state" \
+      "${encrypt_node:-MISSING}" "${enable_wg:-MISSING}" "$selector"
+  done <<< "$agents"
+}
+
+SNAPSHOT_FILE="$(mktemp)"
+trap 'rm -f "$SNAPSHOT_FILE"' EXIT
+ACQ_FAIL=0
+
+for kc in ${KUBECONFIGS[@]+"${KUBECONFIGS[@]}"}; do
+  region="$(basename "$kc" | sed 's/\.ya\?ml$//')"
+  echo ""
+  echo "── region snapshot: $region (kubeconfig $kc) ───────────────────"
+  snapshot_region "$region" --kubeconfig "$kc" >> "$SNAPSHOT_FILE" || ACQ_FAIL=1
+done
+
+for ctx in ${CONTEXTS[@]+"${CONTEXTS[@]}"}; do
+  echo ""
+  echo "── region snapshot: $ctx (context) ─────────────────────────────"
+  snapshot_region "$ctx" --context "$ctx" >> "$SNAPSHOT_FILE" || ACQ_FAIL=1
+done
+
+if [ "$ACQ_FAIL" -ne 0 ]; then
+  echo "" >&2
+  echo "❌ a region could not be read — a partial sweep is not a pass." >&2
+  exit 2
+fi
+
+if [ "$DUMP" -eq 1 ]; then
+  echo ""
+  echo "── snapshot (TSV — replay with --fixture) ──────────────────────"
+  cat "$SNAPSHOT_FILE"
+fi
+
+echo ""
+echo "── verdict ─────────────────────────────────────────────────────"
+evaluate < "$SNAPSHOT_FILE"
+exit $?

--- a/scripts/verify-sovereign-convergence.sh
+++ b/scripts/verify-sovereign-convergence.sh
@@ -114,6 +114,40 @@ else
   say "== single-region prov: skipping region-B / mesh / pair checks =="
 fi
 
+# ── 7. WireGuard node-encryption uniformity (#5637) ──────────────────────
+#
+# Runs for single- AND multi-region provs: the property is per-NODE, so a
+# single-region Sovereign has the same exposure on its one control-plane node.
+# `cilium-config` saying encrypt-node=true is not evidence — the agent applies
+# a per-node opt-out from `--node-encryption-opt-out-labels` (upstream default
+# `node-role.kubernetes.io/control-plane`), so on hw292 both control-plane
+# agents reported NodeEncryption=OptedOut behind a ConfigMap that read clean.
+# The guard asserts every agent's state is the one its node's labels imply and
+# fails closed on anything else. See docs/SECURITY.md §2.1.
+say "== node-encryption uniformity (every cilium agent, every region) =="
+NODE_ENC_GUARD="$(cd "$(dirname "$0")" && pwd)/check-live-node-encryption.sh"
+if [ ! -r "$NODE_ENC_GUARD" ]; then
+  fail "check-live-node-encryption.sh not found next to this script ($NODE_ENC_GUARD)"
+else
+  NE_ARGS=(--kubeconfig "$PRIMARY")
+  if [ -n "$SECONDARY" ] && [ -f "$SECONDARY" ]; then
+    NE_ARGS+=(--kubeconfig "$SECONDARY")
+  fi
+  NE_OUT="$(bash "$NODE_ENC_GUARD" "${NE_ARGS[@]}" 2>&1)"
+  NE_RC=$?
+  NE_TALLY="$(printf '%s\n' "$NE_OUT" | grep -m1 '^agents=' || true)"
+  if [ "$NE_RC" -eq 0 ]; then
+    pass "every cilium agent matches the declared node-encryption posture (${NE_TALLY:-tally unavailable})"
+  else
+    # exit 1 = divergence, 2 = a region/agent could not be read. Both are
+    # failures here: an agent whose encryption state cannot be verified is not
+    # an agent that can be claimed encrypted.
+    fail "node-encryption guard exit $NE_RC (${NE_TALLY:-no tally})"
+    printf '%s\n' "$NE_OUT" | sed -n '/NODE-ENCRYPTION DIVERGENCE/,$p' | sed 's/^/       /'
+    printf '%s\n' "$NE_OUT" | grep -E '^(ERROR|SETUP-ERROR|SNAPSHOT-ERROR)' | sed 's/^/       /'
+  fi
+fi
+
 say ""
 if [ "$FAIL" -eq 0 ]; then say "ALL CHECKS PASSED ✅"; else say "$FAIL CHECK(S) FAILED ❌"; fi
 exit "$FAIL"


### PR DESCRIPTION
## What #5637 turned out to be

**Deliberate — upstream-deliberate, and wider than filed.** Not our chart, not a startup race.

Cilium 1.19.3 ships `--node-encryption-opt-out-labels` defaulting to `node-role.kubernetes.io/control-plane`. k3s puts that label on every server node. The agent on a matching node opts itself out of node-to-node encryption and says so:

```
time=2026-08-03T18:32:25Z level=info
  msg="Opting out from node-to-node encryption on this node as per node-encryption-opt-out-labels label selector"
  module=agent.datapath.wireguard-agent Selector=node-role.kubernetes.io/control-plane
```

The evidence that settles deliberate-vs-incidental, all read-only on hw292 (dep `1c56518035a83e03`):

| # | Evidence | Result |
|---|---|---|
| 1 | `cilium-agent --help \| grep node-encryption-opt-out-labels` | `(default "node-role.kubernetes.io/control-plane")` |
| 2 | Region-A CP agent startup flag dump | `--encrypt-node='true'` **and** `--node-encryption-opt-out-labels='node-role.kubernetes.io/control-plane'` in the same startup |
| 3 | Opt-out log line, CP agent vs worker agent | CP `cilium-97bpn`: 1 occurrence. Worker `cilium-cfspn`: 0. Same fleet, same config |
| 4 | Node labels, CP vs worker | CP carries `node-role.kubernetes.io/control-plane=true`; workers do not. No `node.cilium.io/*` annotation anywhere — nothing hand-applied |
| 5 | `cilium-config` creation vs agent start | ConfigMap created `2026-08-03T04:06:52Z`; agents (re)started `18:32Z` / `20:06Z` — the config predates every agent start by 14+ hours, so "started before the setting applied" is refuted, and a restart reproduces the opt-out rather than clearing it |
| 6 | ConfigMap keys | `enable-wireguard=true`, `encrypt-node=true`, **no** `node-encryption-opt-out-labels` key — the upstream default is in force, inherited rather than declared |

**Correction to the filing's scope.** It is not one node in region A. The region-B control-plane agent `cilium-s8mw5` reports `NodeEncryption: OptedOut` too, and had done since its `18:32Z` start — before the `20:35Z` walk. The walk sampled region-B workers, so a fleet diverging by role read as one odd node in one region. Full sweep: 8 agents, `Enabled=6  OptedOut=2`, the two being `…-a-cp1-54be6d` and `…-b-cp1-6a755c` — exactly the label-selector match, nothing else.

## What is NOT changed, and why

The exclusion stays. Upstream excludes the API-server node because the connection a node uses to publish a **rotated** WireGuard public key would otherwise be encrypted with the very key being replaced; excluding it keeps key rotation and node re-provisioning from deadlocking against themselves. Forcing it on is a posture change that needs a fresh-prov rotation proof, not a values-file flip.

The Cilium chart is deliberately untouched: `platform/cilium/chart/values.yaml` already sets `encryption.nodeEncryption: true` and is correct, and any edit under `platform/*/chart/**` triggers `blueprint-release` to publish `bp-cilium` at its current version — a chart-version collision for a comment. The knowledge lands in `platform/cilium/README.md` (not a publish trigger) and in `docs/SECURITY.md`.

## What was actually wrong: the posture overclaimed

`docs/SECURITY.md` read **"Cilium WireGuard, kernel-level, 100% mesh, no opt-out"** while two nodes per Sovereign were opted out. That line is how a reviewer concludes the fleet is uniformly encrypted without ever looking at a node.

New `docs/SECURITY.md §2.1` states the mechanism, the default, why it is kept, and what it costs: on an excluded node, **host-namespace** traffic is not WireGuard-wrapped — apiserver `:6443`, etcd `:2379/:2380`, kubelet `:10250`, cilium-health, the agent's ClusterMesh client connections, and the hostNetwork `cilium-envoy` gateway hop to backend pods. All but the envoy hop carry their own TLS, so the loss is a layer of defence in depth rather than credentials in the clear; the envoy hop is the post-TLS-termination one and stays on the per-region private VPC subnet. **Pod-to-pod is unaffected** — including every cross-region ClusterMesh pod flow — because that is the base WireGuard feature, not the node-encryption extension.

## The gate

`scripts/check-live-node-encryption.sh` reads **every** cilium agent in **every** region handed to it and fails closed unless each agent's `NodeEncryption` state is the one its node's labels imply under the declared selector.

Pinning the label→state **mapping** rather than plain uniformity is deliberate and strictly stronger. "Every agent must read Enabled" would be red on every healthy Sovereign and would be deleted within a week. The mapping check still reddens on any divergence **and** additionally catches an exclusion set that grew — a case where every agent agrees with the selector and a uniformity check passes.

It fails closed on: a worker that opted out · a control-plane node that did not · an agent whose node labels no longer imply the state it reports (the "restart would mask it" shape) · a selector that drifted from the declared posture · a selector it cannot parse · a state it cannot read · a non-Running agent · an empty or malformed fleet.

Wiring — `verify-sovereign-convergence.sh` step 7, single- and multi-region, because the property is per-node and a one-region Sovereign has the same exposure on its one control-plane node. `--self-test` runs in CI on every PR touching the guard, the Cilium chart, or `docs/SECURITY.md`.

## Proof the gate is not vacuous — exit codes

Run in this worktree, all against the SAME evaluator the live sweep uses:

| Command | Exit | Meaning |
|---|---|---|
| `scripts/check-live-node-encryption.sh --self-test` | **0** | 11 cases, both directions (1 GREEN control + 8 RED + 2 setup-error) |
| `--fixture <hw292 real snapshot>` | **0** | GREEN on the real fleet capture |
| `sed 's/\(cilium-tvdn6.*\)Enabled/\1OptedOut/' <same snapshot> \| --fixture -` | **1** | RED — one worker flipped, one byte of difference |
| `printf '# empty\n' \| --fixture -` | **2** | an empty fleet is a setup error, never a pass |
| `--kubeconfig <region-a> --kubeconfig <region-b>` (live hw292) | **0** | 8 agents, 2 regions, `Enabled=6 OptedOut=2` |

Self-test roster, each asserting its own expected exit code (a case that returns the wrong code fails the run):

```
  ok  [exit 0] hw292 golden fleet (2 cp OptedOut + 6 workers Enabled)
  ok  [exit 1] a worker reports OptedOut
  ok  [exit 1] a control-plane node reports Enabled
  ok  [exit 1] stale agent: labels no longer imply the state it reports
  ok  [exit 1] encrypt-node=false in one region
  ok  [exit 1] enable-wireguard=false in one region
  ok  [exit 1] an agent state is UNREADABLE
  ok  [exit 1] opt-out selector widened beyond the declared posture
  ok  [exit 1] unparseable selector term
  ok  [exit 2] empty snapshot
  ok  [exit 2] malformed snapshot row
```

The GREEN control is load-bearing: without it a detector that reddens on everything would score full marks on the eight RED cases.

Live RED message, from the doctored real snapshot:

```
❌ NODE-ENCRYPTION DIVERGENCE (1):
   - …-me-east-215-b-1/cilium-tvdn6 on …-b-w54fec6: NodeEncryption=OptedOut, expected Enabled
     — node does NOT match the declared opt-out selector, so its node-to-node traffic must be encrypted
```

## For the merger

- **The live environment was read-only throughout.** No apply, patch, delete, label, or restart. Every state above came from `get` / `logs` / read-only `exec`.
- **No NodePorts anywhere** in this change; the guard only reads.
- **No chart change**, so no five-site lockstep and no catalog regeneration is due.
- The guard shells `kubectl exec … cilium-dbg status` once per agent (8 execs on a 2-region Sovereign, ~30s). It is not on any hot path.
- `EXPECTED_OPT_OUT_SELECTOR` in the guard and the selector in `docs/SECURITY.md §2.1` are one decision recorded twice; CI asserts they agree, so changing the posture means changing both on purpose.
- A cilium DaemonSet roll in flight makes the guard RED (`NOT-RUNNING`) rather than green — an agent that cannot be interrogated is not an agent that can be claimed encrypted. Re-run once the roll settles.
- `sovereign-dod-verify.sh` was left alone on purpose: it drives kubectl from inside the mothership catalyst-api pod, so wiring the guard there means a nested `exec` this session could not exercise, and an unproven leg in the readiness contract buys a false RED. `verify-sovereign-convergence.sh` runs local kubectl against fetched kubeconfigs — the exact path proven above.

Refs #5637 #960
