### PR TITLE
feat(cutover): post-cutover image delivery — Day-2 reconciler gains an IMAGE leg + a fail-loud pin-resolvability gate

### DIFF
--- a/.github/workflows/check-image-pins-resolvable.yaml
+++ b/.github/workflows/check-image-pins-resolvable.yaml
@@ -1,0 +1,83 @@
+name: check-image-pins-resolvable
+
+# #5640 — assert that every openova-io container image the Catalyst chart pins
+# is actually resolvable in the registry the target cluster is permitted to use.
+#
+# WHY THIS EXISTS. `catalyst-build` publishes an image, deploy-bot sed-bumps the
+# SHA into products/catalyst/chart/values.yaml, the chart is released and the
+# pin ships. Every one of those steps can be green while the tag is unservable:
+#   • upstream — the publish for that SHA silently did not land;
+#   • post-cutover Sovereign — cutover step-03 mirrored the catalog AS OF
+#     cutover and nothing mirrors what is published afterwards, so the local
+#     Harbor (the only registry that Sovereign may use) 404s the new tag.
+#       Live hw292 2026-08-03: catalyst-ui tags/list -> ["fad88bd"];
+#       d674a94 -> 404 while the Pod pinned to it sat in ImagePullBackOff.
+# Nothing on the repo side revealed either: main green, GHCR tag present, pin
+# committed. This job is what notices.
+#
+# TWO LEGS, deliberately separated:
+#   selftest — drives scripts/check-image-pins-resolvable.sh through all four
+#     exit codes against a stub registry on 127.0.0.1. Hermetic, no credential,
+#     no network. This is what proves the gate is not a `|| echo WARN`.
+#   ghcr — runs the real gate against ghcr.io with the workflow's own
+#     packages:read token. Exit 1 (a genuinely absent tag) fails the build and
+#     names the reference; exit 3 (auth/unreachable) also fails, because a gate
+#     that cannot form an opinion must say so rather than pass.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/catalyst/chart/values.yaml'
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-image-pins-resolvable.sh'
+      - 'scripts/tests/test-image-pins-resolvable.sh'
+      - '.github/workflows/check-image-pins-resolvable.yaml'
+  pull_request:
+    paths:
+      - 'products/catalyst/chart/values.yaml'
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-image-pins-resolvable.sh'
+      - 'scripts/tests/test-image-pins-resolvable.sh'
+      - '.github/workflows/check-image-pins-resolvable.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  selftest:
+    name: gate self-test (stub registry, all four exit codes)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prove the gate goes RED for each failure class and GREEN when restored
+        run: bash scripts/tests/test-image-pins-resolvable.sh
+
+  ghcr:
+    name: pinned images resolve in GHCR
+    runs-on: ubuntu-latest
+    needs: selftest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+      - name: Resolve every chart-pinned openova-io image in ghcr.io
+        env:
+          # The SAME credential pair docker/login-action uses in catalyst-build.
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          bash scripts/check-image-pins-resolvable.sh --verbose
+          rc=$?
+          set -e
+          case "${rc}" in
+            0) echo "All chart-pinned images resolve upstream." ;;
+            1) echo "::error::A chart-pinned image tag does not exist in GHCR — the pin shipped ahead of its publish. See the MISSING lines above."; exit 1 ;;
+            2) echo "::error::The gate parsed ZERO image references — the chart render or the reference extraction broke. Failing closed rather than passing on nothing."; exit 1 ;;
+            3) echo "::error::The gate could not reach or authenticate to GHCR, so it could not form an opinion. This is NOT a missing-image finding; fix access (packages:read) and re-run."; exit 1 ;;
+            *) echo "::error::Unexpected exit ${rc} from check-image-pins-resolvable.sh"; exit 1 ;;
+          esac

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1030,7 +1030,26 @@ spec:
       # of re-tethering to ghcr on the next org mutation (Pillar 5; the
       # hw291 step-08 OFFENDER wedge made durable). New values block
       # orgProvisioning.*; step count stays 11; contract Case 74.
-      version: 0.1.160
+      # 0.1.161 (#5640 Refs #5265 #4975 #5095 #5525): POST-CUTOVER IMAGE
+      # DELIVERY. hw292 (dep 1c56518035a83e03, cutoverComplete=true,
+      # 2026-08-03) proved the local Harbor is the ONLY registry that matters
+      # after cutover and NOTHING mirrors what is published afterwards:
+      # registry.<fqdn>/v2/openova-io/openova/catalyst-ui/tags/list returned
+      # only ["fad88bd"], the freshly-pinned d674a94 404'd, and its Pod sat in
+      # ImagePullBackOff — with main green, the GHCR tag present and the pin
+      # committed. The #5265 Day-2 Deployment gains an IMAGE leg that
+      # enumerates running Pods UNION declared workload templates (the #3944
+      # union; the declared half is load-bearing because the offender had no
+      # running container), maps each ref through the SAME 03a
+      # offlinemirror_local_paths resolver step-03/step-08 use, HEADs the local
+      # Harbor manifest, and — in warm mode only — copies with step-03's exact
+      # skopeo invocation plus the #5095/#5525 secondary-source fallbacks. It
+      # now ships ENABLED in zero-egress detect mode (see the daytwoReconciler
+      # overlay below): the severance-safe property is "no upstream egress by
+      # default", which detect holds literally, and shipping it off left the
+      # gap as silent as the issue describes. Step count stays 11; no RBAC
+      # change. New chart test tests/daytwo-image-leg.sh + contract Case 75.
+      version: 0.1.161
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
@@ -1199,3 +1218,28 @@ spec:
     # #4669 level-triggered reconciler once the operator flips the flag).
     trigger:
       fireCutoverOnHandover: ${FIRE_CUTOVER_ON_HANDOVER:-false}
+    # #5640 (Refs #5265) — POST-CUTOVER artifact delivery. Made explicit here
+    # rather than left to the chart default so the posture of every fresh prov
+    # is readable in the slot the operator actually reviews.
+    #
+    # `enabled: true` + `mode: detect` is a ZERO-EGRESS posture: the loop
+    # reaches only the local Gitea mirror and the local Harbor, never downloads
+    # skopeo and never dials an upstream registry, so the step-08 deny-egress
+    # proof and the "no automatic upstream tether" contract are untouched. What
+    # it adds is the SIGNAL that hw292 lacked — each cycle publishes the exact
+    # set of chart pins and declared images the local Harbor cannot serve to
+    # the durable `self-sovereign-cutover-daytwo-missing` ConfigMap (and to the
+    # Pod log), which is simultaneously the air-gapped Sovereign's
+    # offline-media side-load list.
+    #
+    # An operator on a managed-update posture flips DAYTWO_RECONCILE_MODE=warm
+    # (cloud-init substitution, same seam as FIRE_CUTOVER_ON_HANDOVER above) to
+    # turn the signal into delivery: missing charts are helm-pulled/pushed and
+    # missing images are skopeo-copied into local Harbor on the operator's own
+    # schedule — the exact companion of the Git mirror reaching github.com on
+    # that schedule. Private openova-io artifacts additionally need
+    # daytwoReconciler.warm.credentialSecret, since step-06 strips the
+    # cutover's own ghcr auth by design.
+    daytwoReconciler:
+      enabled: true
+      mode: ${DAYTWO_RECONCILE_MODE:-detect}

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.160
+  version: 0.1.161
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2889,7 +2889,73 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
-version: 0.1.160
+# 0.1.161 (#5640 Refs #5265 #4975 #5095 #5525 #3944) — the Day-2 reconciler
+# gains an IMAGE leg, and ships ON by default in zero-egress detect mode.
+#
+# THE DEFECT (live hw292, dep 1c56518035a83e03, cutoverComplete=true,
+# 2026-08-03). Cutover step-04 pivots node containerd certs.d and step-06
+# repoints every HelmRepository at the local Harbor, so post-cutover the local
+# Harbor is the ONLY registry that matters. step-03 harbor-prewarm mirrors the
+# catalog AS OF cutover; nothing mirrors anything published afterwards. After
+# catalyst-build went green and deploy-bot pinned the catalyst images to
+# d674a94:
+#     curl -sk -u admin:*** https://registry.<fqdn>/v2/openova-io/openova/catalyst-ui/tags/list
+#     -> {"tags":["fad88bd"]}     d674a94 -> 404     fad88bd -> 200 (CONTROL)
+# and the Pod pinned to catalyst-ui:d674a94 sat in ImagePullBackOff. The chain
+# merge -> build -> publish -> deploy-bot pin is complete for a PRE-cutover
+# Sovereign and SILENTLY incomplete for a post-cutover one; nothing on the repo
+# side reveals it (main green, GHCR tag present, pin committed). #5265 had
+# already closed the same structure one layer up, for CHART pins only.
+#
+# THE FIX. 12-daytwo-harbor-pin-reconciler.yaml keeps its single Deployment
+# (region-kill canon #5157 — a CronJob's scheduler dies with the control-plane
+# region) and gains a second leg that guarantees the property "any image or
+# chart version the Sovereign's own GitOps references is resolvable in the
+# registry that Sovereign is permitted to use". Nothing here is a second
+# mechanism:
+#   • enumeration = running Pods UNION declared workload templates
+#     (Deployments/StatefulSets/DaemonSets/CronJobs/Jobs) — the #3944
+#     completeness union step-03 Phase A performs. The declared half is
+#     load-bearing: the hw292 offender was in ImagePullBackOff and had NO
+#     running container to enumerate.
+#   • image -> local Harbor path = the SAME 03a offlinemirror_local_paths
+#     resolver step-03 (push dest) and step-08 (pre-hold completeness HEAD)
+#     source; the reconciler now mounts cutover-offline-mirror-resolver and
+#     projects the identical HOST_PROJECT_MAP / EXCLUDED_HOSTS /
+#     EXCLUDED_SUBSTRINGS / LOCAL_REGISTRY_HOST / MOTHERSHIP_HOST env. Three
+#     consumers, ONE mapping function.
+#   • presence = step-08's local-Harbor /v2/<repo>/manifests/<ref> probe
+#     (3 attempts to absorb a Harbor blip; a genuine 404 is the signal).
+#   • copy = step-03's exact `skopeo copy --insecure-policy --multi-arch all
+#     --retry-times 5` with --src-creds/--dest-creds, plus the #5095
+#     mothership-proxy -> DIRECT inverse-coverage-map fallback AND the #5525
+#     scarf.sh -> mothership-proxy forward-map fallback. skopeo acquisition
+#     reuses step-08's pinned static build verbatim and is LAZY.
+#
+# WHY IT NOW SHIPS ENABLED. daytwoReconciler.enabled flips false -> true. The
+# severance-safe property was never "no Deployment" — it was "no upstream
+# egress by default", and mode=detect (still the default) holds that literally:
+# the loop reaches ONLY the local Gitea mirror and the local Harbor, never
+# downloads skopeo, never dials an upstream registry. What it does do is
+# publish the exact missing set — CHART and IMAGE lines — to the durable
+# self-sovereign-cutover-daytwo-missing ConfigMap plus loud logs, which is
+# precisely the "today nothing notices" half of #5640. Every upstream reach
+# stays behind opt-in mode=warm. enabled=false still renders nothing at all.
+#
+# ANTI-VACUITY. A zero-ref enumeration is treated as a BROKEN READ, never an
+# all-clear: status becomes `enumeration-empty` and ALL_PINS_PRESENT is
+# withheld. New chart test tests/daytwo-image-leg.sh EXECUTES the rendered
+# script against a stub kubectl/curl and asserts the outcome (present control
+# stays resolved while the missing tag is named; miss count tracks the input;
+# an empty enumeration publishes no all-clear; detect mode dials no upstream
+# host and never invokes skopeo). Contract Case 70 is re-keyed to the
+# egress property and Case 75 pins the image leg's contract.
+#
+# New values: daytwoReconciler.charts.enabled, daytwoReconciler.images.{enabled,
+# copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
+# ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
+# get+list+watch). Step count unchanged at 11.
+version: 0.1.161
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
@@ -1,76 +1,125 @@
 {{- /*
-#5265 — POST-CUTOVER DAY-2 Harbor pin reconciler.
+#5265 + #5640 — POST-CUTOVER DAY-2 local-Harbor reconciler.
 
 The gap
 ───────
 `bp-self-sovereign-cutover` mirrors the public catalog into the local Gitea
 (step-01) and prewarms every pinned chart+image into the local Harbor
-(step-03) EXACTLY ONCE at cutover time. Post-cutover, on the operator's chosen
-schedule, the local Gitea RE-SYNCS upstream pin bumps (CLAUDE.md §Customer-Sync)
-and Flux picks the new pin up — verified live hw277 (dep 1708c340ffc0e3f2,
-2026-07-19): after cc=true, catalog merges #5258/#5260 landed, the mirror
-re-synced, the bootstrap-kit pin moved (region-b bp-continuum HR
-spec.chart.spec.version=0.1.12) — but the local Harbor still held ONLY the
-versions the one-time step-03 prewarm pushed. The HelmChart could not reconcile
-("latest generation not reconciled") → the HR upgrade wedged. Workloads stay
-healthy on the installed version (an upgrade wedge, not an outage), but EVERY
-upstream chart bump SILENTLY strands the Sovereign's HR upgrades.
+(step-03) EXACTLY ONCE at cutover time. Post-cutover the local Harbor is the
+ONLY registry that matters — step-04 pivots node containerd `certs.d` and
+step-06 repoints every HelmRepository at it — so anything published UPSTREAM
+after step-03 ran can never reach the Sovereign.
+
+  • #5265 (the CHART half). On the operator's chosen schedule the local Gitea
+    RE-SYNCS upstream pin bumps (CLAUDE.md §Customer-Sync) and Flux picks the
+    new pin up — verified live hw277 (dep 1708c340ffc0e3f2, 2026-07-19): after
+    cc=true, catalog merges #5258/#5260 landed, the mirror re-synced, the
+    bootstrap-kit pin moved (region-b bp-continuum HR spec.chart.spec.version=
+    0.1.12) — but the local Harbor still held ONLY the versions the one-time
+    step-03 prewarm pushed. The HelmChart could not reconcile → the HR upgrade
+    wedged.
+
+  • #5640 (the IMAGE half). The SAME structure, one layer down and strictly
+    worse: a chart version that DOES reconcile installs workload templates
+    pinned to image tags published after cutover. Verified live hw292 (dep
+    1c56518035a83e03, cutoverComplete=true, 2026-08-03) —
+
+        curl -sk -u admin:*** https://registry.<fqdn>/v2/openova-io/openova/catalyst-ui/tags/list
+        {"name":"openova-io/openova/catalyst-ui","tags":["fad88bd"]}
+        d674a94 -> 404      # the tag deploy-bot pinned today
+        fad88bd -> 200      # CONTROL: same probe, the tag deployed at cutover
+
+    …and the Pod pinned to `catalyst-ui:d674a94` sat in ImagePullBackOff. The
+    delivery chain merge → build → publish → deploy-bot pin is complete for a
+    PRE-cutover Sovereign and SILENTLY incomplete for a post-cutover one:
+    main is green, the GHCR tag exists, the pin is committed, and nothing on
+    the repo side reveals a thing.
 
 The Git leg has a companion (step-01's re-runnable mirror + the operator's
-sync schedule). The Harbor leg had none — this reconciler IS that companion.
+sync schedule). The Harbor leg had none — this reconciler IS that companion,
+for BOTH artifact kinds, in ONE loop.
 
 Why a Deployment, not a CronJob
 ───────────────────────────────
 `reference_region_local_reconciler_must_be_deployment_not_cronjob_survives_
-region_kill.md`: a CronJob's scheduler lives in the control-plane region; when
-that region is killed the CronJob stops firing and the loop dies silently. A
-Deployment (replicas: 1, Recreate) is rescheduled onto a surviving node by the
-kube scheduler, so the Day-2 loop keeps running across a region kill — exactly
-the failure the multi-region Sovereign is built to survive. (The #1899
-gitea-mirror-resync CronJob predates this canon; the issue #5265 fix direction
-mandates a Deployment here.)
+region_kill.md` (#5157): a CronJob's scheduler lives in the control-plane
+region; when that region is killed the CronJob stops firing and the loop dies
+silently. A Deployment (replicas: 1, Recreate) is rescheduled onto a surviving
+node by the kube scheduler, so the Day-2 loop keeps running across a region
+kill — exactly the failure the multi-region Sovereign is built to survive.
+(The #1899 gitea-mirror-resync CronJob predates this canon.)
+
+Why region-local, not a mothership-side push (#5640 shape choice)
+─────────────────────────────────────────────────────────────────
+The alternative shape — the deploy-bot pin commit triggering a push FROM the
+mothership INTO each Sovereign's Harbor — requires OpenOva to hold a standing
+write credential for every customer-run Sovereign and to reach it on demand.
+That is a permanent INBOUND tether from the mothership into the Sovereign: the
+exact inverse of Pillar 5 / ADR-0002, and structurally impossible for an
+air-gapped Sovereign. It also cannot be substituted by Harbor pull-through:
+step-02 creates `openova-io` as a PUSH-mode project (no `registry_id`, see
+02-harbor-projects-job.yaml) and step-06 pivots the workload refs onto exactly
+that project, so no proxy-cache sits behind the path that 404'd on hw292.
+Keeping the loop ON the Sovereign keeps the Sovereign self-sufficient.
+
+Single-source discipline — nothing here is a second mechanism
+─────────────────────────────────────────────────────────────
+  • chart pins  ← the SAME 03b `bootstrapkit_pins` extractor step-03 (Phase
+    A2-pins) and step-06 (Phase 3a-pin) use, mounted from the
+    `cutover-bootstrap-kit-pins` ConfigMap (03b's documented #5265 reuse seam).
+  • image → local path  ← the SAME 03a `offlinemirror_local_paths` resolver
+    step-03 (skopeo push dest) and step-08 (pre-hold completeness HEAD) use,
+    mounted from the `cutover-offline-mirror-resolver` ConfigMap. THREE
+    consumers, ONE mapping function.
+  • image enumeration  ← running Pods ∪ declared workload templates
+    (Deployments/StatefulSets/DaemonSets/CronJobs/Jobs), the #3944 completeness
+    union step-03 Phase A performs, so a scaled-to-zero or ImagePullBackOff
+    workload is still seen (which is the whole point here — the hw292 Pod was
+    NOT Running).
+  • image copy  ← the SAME `skopeo copy --insecure-policy --multi-arch all
+    --retry-times 5` invocation, the SAME #5095 mothership-proxy → DIRECT
+    inverse-coverage-map fallback, and the SAME #5525 scarf.sh → mothership-
+    proxy forward-map fallback that step-03 `copy_one` and step-08's #5194
+    self-heal already run. skopeo acquisition reuses step-08's pinned static
+    build verbatim.
+  • presence probe ← the Harbor artifact API for charts (#5030 durable probe)
+    and the local `/v2/<repo>/manifests/<ref>` HEAD for images (step-08's).
 
 Sovereignty — this NEVER weakens the Pillar-5 guarantee
 ───────────────────────────────────────────────────────
-Ships DISABLED by default (`daytwoReconciler.enabled: false`), the SAME
-severance-safe default as the #2622 gitea-mirror-resync CronJob: a canonical
-fresh-prov Sovereign renders NOTHING here, so the step-08 deny-egress proof and
-the "no automatic upstream tether" contract are untouched. When an operator
-OPTS IN (they have chosen a managed-update posture — the CLAUDE.md
-§Customer-Sync "operator's chosen schedule"):
+  • mode=detect (THE DEFAULT) — the loop reaches ONLY the local Gitea mirror
+    and the local Harbor. ZERO external egress: skopeo is never downloaded, no
+    upstream registry is dialled, no `helm pull` runs. It emits the exact set
+    of pinned charts AND declared images MISSING from local Harbor to a durable
+    ConfigMap + loud logs. That set IS the air-gapped Sovereign's offline-media
+    manifest (side-load exactly these) and it turns the previously-SILENT
+    strand into a visible, actionable signal — the #5640 "today nothing
+    notices" defect, closed.
 
-  • mode=detect (DEFAULT when enabled) — the loop reaches ONLY the local Gitea
-    mirror (frozen pins) + the local Harbor (artifact API). ZERO external
-    egress. It emits the exact set of pinned (chart, version) artifacts MISSING
-    from local Harbor to a durable ConfigMap + loud logs. That set IS the
-    air-gapped Sovereign's offline-media manifest (side-load exactly these) and
-    it turns the previously-silent strand into a visible, actionable signal.
+  • mode=warm — additionally fetches each missing artifact from the operator-
+    nominated upstream (`helm pull`/`helm push` for charts, `skopeo copy` for
+    images, authenticating with the operator-SUPPLIED credential Secret; the
+    cutover's own ghcr auth is stripped by step-06, by design) and re-checks.
+    Only this mode reaches upstream, and only on the operator's schedule — the
+    exact companion of the Git mirror reaching github.com on that schedule. A
+    warm failure is fail-SOFT (logged, left in the missing manifest) so the
+    loop never crash-loops and workloads keep running on the installed version.
 
-  • mode=warm — additionally `helm pull`s each missing chart from the operator-
-    nominated upstream (authenticating with an operator-SUPPLIED credential
-    Secret; the cutover's own ghcr auth is stripped by step-06, by design) and
-    `helm push`es it into the local Harbor, then re-checks. Only this mode
-    reaches upstream, and only for chart OCI bytes on the operator's schedule —
-    the exact companion of the Git mirror reaching github.com on that schedule.
-    A warm failure is fail-SOFT (logged, left in the missing manifest) so the
-    loop never crash-loops and the workloads keep running on the installed
-    version.
-
-Single-source discipline
-────────────────────────
-The pin enumeration is the SAME 03b `bootstrapkit_pins` extractor step-03
-(Phase A2-pins) and step-06 (Phase 3a-pin) use — mounted here from the
-`cutover-bootstrap-kit-pins` ConfigMap, sourced at runtime. Two cutover steps
-and this Day-2 watch, ONE parser: the mirror set and the gate can never
-disagree about what "the pins" are (03b's documented #5265 reuse seam).
+#5640 flips `daytwoReconciler.enabled` to TRUE by default. The severance-safe
+property that mattered was never "no Deployment" — it was "no upstream egress
+by default", and mode=detect holds that with zero egress. Shipping the loop
+OFF would have shipped a knob nobody turns on, leaving the failure exactly as
+silent as the issue describes.
 
 NOT a cutover-step ConfigMap: no `bp.openova.io/cutover-order` label, so it does
 NOT count toward the 11-step contract (tests/cutover-contract.sh Case 2/4).
 
 Image phase: pre — like the #1899 mirror-resync CronJob, this workload is
 created at chart-install time and uses the upstream-public image reference;
-post-cutover the node containerd (step-04 registries.yaml v2) resolves that
-reference from the local Harbor, so the ref is self-contained either way.
+because it RENDERS at install time, step-03 Phase A's declared-workload-template
+enumeration mirrors that very image into local Harbor, and post-cutover the node
+containerd (step-04 registries.yaml v2) resolves the reference from there. The
+loop's own image is therefore self-contained either way.
 */ -}}
 {{- if .Values.daytwoReconciler.enabled }}
 apiVersion: apps/v1
@@ -147,13 +196,19 @@ spec:
             # ── loop policy ──
             - name: RECONCILE_INTERVAL_SECONDS
               value: {{ .Values.daytwoReconciler.intervalSeconds | quote }}
-            # detect (default; zero egress) | warm (opt-in upstream chart pulls)
+            # detect (default; zero egress) | warm (opt-in upstream fetches)
             - name: RECONCILE_MODE
               value: {{ .Values.daytwoReconciler.mode | quote }}
             - name: MISSING_MANIFEST_CM
               value: {{ .Values.daytwoReconciler.missingManifestConfigMapName | quote }}
             - name: RELEASE_NAMESPACE
               value: {{ .Release.Namespace | quote }}
+            # Per-leg switches. Both default true; an operator debugging one
+            # half can silence the other without losing the loop.
+            - name: CHART_LEG_ENABLED
+              value: {{ eq (toString .Values.daytwoReconciler.charts.enabled) "true" | quote }}
+            - name: IMAGE_LEG_ENABLED
+              value: {{ eq (toString .Values.daytwoReconciler.images.enabled) "true" | quote }}
             # ── warm-mode source (operator-supplied; only read when mode=warm) ──
             - name: WARM_UPSTREAM_OCI_PREFIX
               value: {{ .Values.daytwoReconciler.warm.upstreamOciPrefix | quote }}
@@ -167,9 +222,46 @@ spec:
               value: {{ .Values.daytwoReconciler.warm.credentialSecret.usernameKey | quote }}
             - name: WARM_CRED_PASSWORD_KEY
               value: {{ .Values.daytwoReconciler.warm.credentialSecret.passwordKey | quote }}
+            # ── #5640 image leg: the SAME offline-mirror env step-03/04/08 read.
+            # The coverage map is the single declaration of host→local-project;
+            # forking it here would re-open the very drift #4975 closed.
+            - name: HOST_PROJECT_MAP
+              value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
+            - name: EXCLUDED_HOSTS
+              value: {{ include "bp-self-sovereign-cutover.excludedHostsInline" . | quote }}
+            - name: EXCLUDED_SUBSTRINGS
+              value: {{ include "bp-self-sovereign-cutover.excludedSubstringsInline" . | quote }}
+            - name: LOCAL_REGISTRY_HOST
+              value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
+            - name: MOTHERSHIP_HOST
+              value: {{ include "bp-self-sovereign-cutover.mothershipHost" . | quote }}
+            # Optional ghcr/mothership dockerconfigjson — present pre-cutover,
+            # stripped by step-06 post-cutover (by design). Absent => the warm
+            # leg is anonymous-only and private refs stay in the manifest.
+            - name: GHCR_DOCKERCONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.harbor.ghcrSecretRef.name }}
+                  key: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey }}
+                  optional: true
+            - name: PREWARM_SKOPEO_TIMEOUT
+              value: {{ .Values.prewarm.skopeoCommandTimeout | default "1200s" | quote }}
+            - name: PREWARM_DEST_TLS_VERIFY
+              value: {{ .Values.prewarm.destTLSVerify | default false | quote }}
+            - name: PREWARM_COPY_ATTEMPTS
+              value: {{ .Values.daytwoReconciler.images.copyAttempts | default 3 | quote }}
+            - name: PREWARM_PROXY_COPY_ATTEMPTS
+              value: {{ .Values.prewarm.proxyCopyAttempts | default 6 | quote }}
+            - name: SKOPEO_STATIC_URL
+              value: {{ .Values.daytwoReconciler.images.skopeoStaticURL | quote }}
+            - name: IMAGE_SCAN_MAX
+              value: {{ .Values.daytwoReconciler.images.maxRefsPerCycle | quote }}
           volumeMounts:
             - name: pin-extractor
               mountPath: /pin-extractor
+              readOnly: true
+            - name: offline-mirror
+              mountPath: /offline-mirror
               readOnly: true
             - name: tmp
               mountPath: /tmp
@@ -181,6 +273,11 @@ spec:
               : "${HARBOR_USERNAME:=admin}"
               : "${RECONCILE_INTERVAL_SECONDS:=300}"
               : "${RECONCILE_MODE:=detect}"
+              : "${CHART_LEG_ENABLED:=true}"
+              : "${IMAGE_LEG_ENABLED:=true}"
+              : "${IMAGE_SCAN_MAX:=400}"
+              WORK=/tmp/daytwo-work
+              mkdir -p "${WORK}"
 
               # Bare host of the local Harbor (registry.<fqdn>) — the helm
               # registry login + push target in warm mode. Post-cutover its
@@ -189,11 +286,23 @@ spec:
               HARBOR_HOST=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
               gitea_host="$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E 's|^https?://||' | cut -d: -f1 | cut -d/ -f1)"
 
-              echo "[daytwo] post-cutover Harbor pin reconciler starting (mode=${RECONCILE_MODE}, interval=${RECONCILE_INTERVAL_SECONDS}s, #5265)"
-              echo "[daytwo] local Gitea mirror=${GITEA_INTERNAL_URL} (${GITEA_ORG}/${GITEA_REPO}@${UPSTREAM_BRANCH}); local Harbor=${HARBOR_INTERNAL_URL}"
+              # Shared 03a resolver — the SAME image→local-path mapping
+              # function step-03 (push dest) and step-08 (completeness HEAD)
+              # source. Fail-LOUD if absent: silently skipping the image leg is
+              # exactly the invisible-strand shape #5640 is about.
+              RESOLVER_OK=0
+              if [ -f /offline-mirror/resolver.sh ]; then
+                . /offline-mirror/resolver.sh
+                RESOLVER_OK=1
+              else
+                echo "[daytwo] ERROR: /offline-mirror/resolver.sh absent — the cutover-offline-mirror-resolver ConfigMap (03a) is not mounted; the IMAGE leg cannot derive local Harbor paths and is DISABLED this run (#5640)"
+              fi
+
+              echo "[daytwo] post-cutover local-Harbor reconciler starting (mode=${RECONCILE_MODE}, interval=${RECONCILE_INTERVAL_SECONDS}s, charts=${CHART_LEG_ENABLED}, images=${IMAGE_LEG_ENABLED}; #5265 #5640)"
+              echo "[daytwo] local Gitea mirror=${GITEA_INTERNAL_URL} (${GITEA_ORG}/${GITEA_REPO}@${UPSTREAM_BRANCH}); local Harbor=${HARBOR_INTERNAL_URL} (${HARBOR_HOST})"
               case "${RECONCILE_MODE}" in
-                warm) echo "[daytwo] mode=warm — missing chart OCI artifacts are pulled from ${WARM_UPSTREAM_OCI_PREFIX} (operator-scheduled; the Git-mirror companion) and pushed to local Harbor" ;;
-                *)    echo "[daytwo] mode=detect — reaching ONLY the local Gitea mirror + local Harbor (zero external egress); missing artifacts are reported to ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} as the offline-media manifest" ;;
+                warm) echo "[daytwo] mode=warm — missing chart OCI artifacts are helm-pulled from ${WARM_UPSTREAM_OCI_PREFIX} and missing IMAGES are skopeo-copied from their recorded upstream (operator-scheduled; the Git-mirror companion), then pushed to local Harbor" ;;
+                *)    echo "[daytwo] mode=detect — reaching ONLY the local Gitea mirror + local Harbor (zero external egress; skopeo is never downloaded); missing artifacts are reported to ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} as the offline-media manifest" ;;
               esac
 
               # Read the catalyst-gitea-token PAT (never echoed; sent only via
@@ -241,22 +350,302 @@ spec:
                 return 0
               }
 
-              reconcile_once() {
+              # ── #5640 IMAGE LEG ─────────────────────────────────────────────
+              # skopeo acquisition — the SAME pinned static build step-03
+              # harbor-prewarm and step-08's #5194 self-heal use. Downloaded
+              # LAZILY and ONLY in warm mode, so detect mode keeps its
+              # zero-external-egress contract literally (no github.com dial).
+              _skopeo_ready=0
+              daytwo_ensure_skopeo() {
+                [ "${_skopeo_ready}" = "1" ] && return 0
+                if command -v skopeo >/dev/null 2>&1; then
+                  _skopeo_ready=1
+                  return 0
+                fi
+                echo "[daytwo] image warm: skopeo not on PATH; downloading the pinned static binary (same build step-03 harbor-prewarm uses)"
+                _sk_try=1
+                while [ "${_sk_try}" -le 3 ]; do
+                  if curl -fsSL --max-time 600 --retry 3 --retry-delay 5 -C - "${SKOPEO_STATIC_URL}" -o "${WORK}/skopeo" 2>&1 \
+                    && chmod +x "${WORK}/skopeo" \
+                    && "${WORK}/skopeo" --version >/dev/null 2>&1; then
+                    export PATH="${WORK}:${PATH}"
+                    _skopeo_ready=1
+                    echo "[daytwo] image warm: skopeo static binary installed: $(skopeo --version)"
+                    return 0
+                  fi
+                  echo "[daytwo] image warm: skopeo download attempt ${_sk_try}/3 failed; retrying in 5s"
+                  _sk_try=$((_sk_try+1))
+                  sleep 5
+                done
+                rm -f "${WORK}/skopeo"
+                echo "[daytwo] image warm: skopeo unavailable after 3 download attempts — the warm path is disabled this cycle; every missing image stays in the manifest (fail-soft)"
+                return 1
+              }
+
+              # Parses the SAME flux-system/ghcr-pull dockerconfigjson step-03
+              # and step-08 read. Absent/empty => anonymous-only warm.
+              _creds_loaded=0
+              _ghcr_user=""; _ghcr_pat=""
+              _moth_user=""; _moth_pat=""
+              daytwo_load_creds() {
+                [ "${_creds_loaded}" = "1" ] && return 0
+                _creds_loaded=1
+                if [ -z "${GHCR_DOCKERCONFIG:-}" ]; then
+                  echo "[daytwo] image warm: no ghcr dockerconfig mounted (stripped post-cutover by step-06, by design) — anonymous-only warm; supply daytwoReconciler.warm.credentialSecret for private refs"
+                  return 0
+                fi
+                case "${GHCR_DOCKERCONFIG}" in
+                  "{"*) _dc="${GHCR_DOCKERCONFIG}" ;;
+                  *) _dc=$(printf '%s' "${GHCR_DOCKERCONFIG}" | base64 -d 2>/dev/null || printf '%s' "${GHCR_DOCKERCONFIG}") ;;
+                esac
+                _ga=$(printf '%s' "${_dc}" | jq -r '.auths["ghcr.io"].auth // empty' 2>/dev/null || true)
+                if [ -n "${_ga}" ]; then
+                  _ghcr_user=$(printf '%s' "${_ga}" | base64 -d | awk -F: '{print $1}')
+                  _ghcr_pat=$(printf '%s' "${_ga}" | base64 -d | cut -d: -f2-)
+                fi
+                _ma=$(printf '%s' "${_dc}" | jq -r --arg h "${MOTHERSHIP_HOST}" '.auths[$h].auth // empty' 2>/dev/null || true)
+                if [ -n "${_ma}" ]; then
+                  _moth_user=$(printf '%s' "${_ma}" | base64 -d | awk -F: '{print $1}')
+                  _moth_pat=$(printf '%s' "${_ma}" | base64 -d | cut -d: -f2-)
+                fi
+                # An operator-supplied warm credential OVERRIDES the (possibly
+                # stripped) cutover one for the upstream registry host.
+                if [ -n "${WARM_CRED_SECRET_NAME}" ]; then
+                  _wu=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_USERNAME_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+                  _wp=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_PASSWORD_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+                  if [ -n "${_wu}" ] && [ -n "${_wp}" ] && [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]; then
+                    _ghcr_user="${_wu}"; _ghcr_pat="${_wp}"
+                    echo "[daytwo] image warm: using the operator-supplied credential Secret ${WARM_CRED_SECRET_NAMESPACE}/${WARM_CRED_SECRET_NAME} for ${WARM_REGISTRY_HOST}"
+                  fi
+                fi
+              }
+
+              daytwo_src_creds_for() {
+                case "$1" in
+                  ghcr.io) [ -n "${_ghcr_user}" ] && printf '%s:%s' "${_ghcr_user}" "${_ghcr_pat}" || printf '' ;;
+                  "${MOTHERSHIP_HOST}") [ -n "${_moth_user}" ] && printf '%s:%s' "${_moth_user}" "${_moth_pat}" || printf '' ;;
+                  *) printf '' ;;
+                esac
+              }
+
+              # daytwo_manifest_present LOCAL_PATH -> 0 present, 1 absent.
+              # The SAME local-Harbor /v2 manifest HEAD step-08's completeness
+              # gate performs (3 attempts absorb a Harbor blip; a genuine 404
+              # is the signal).
+              daytwo_manifest_present() {
+                _mp_lp="$1"
+                _mp_repo="${_mp_lp}"; _mp_ref="latest"
+                case "${_mp_lp}" in
+                  *@*) _mp_ref="${_mp_lp##*@}"; _mp_repo="${_mp_lp%@*}"; case "${_mp_repo##*/}" in *:*) _mp_repo="${_mp_repo%:*}" ;; esac ;;
+                  *) case "${_mp_lp##*/}" in *:*) _mp_ref="${_mp_lp##*:}"; _mp_repo="${_mp_lp%:*}" ;; esac ;;
+                esac
+                DAYTWO_LAST_REPO="${_mp_repo}"; DAYTWO_LAST_REF="${_mp_ref}"
+                _mp_try=1; _mp_code=000
+                while [ "${_mp_try}" -le 3 ]; do
+                  _mp_code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
+                    -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                    -H "Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+                    -I "${HARBOR_PUBLIC_URL}/v2/${_mp_repo}/manifests/${_mp_ref}" 2>/dev/null || echo 000)
+                  case "${_mp_code}" in 200|301|302) DAYTWO_LAST_CODE="${_mp_code}"; return 0 ;; esac
+                  _mp_try=$((_mp_try+1)); [ "${_mp_try}" -le 3 ] && sleep 3
+                done
+                DAYTWO_LAST_CODE="${_mp_code}"
+                return 1
+              }
+
+              # daytwo_warm_image UPSTREAM_REF LOCAL_PATH -> 0 warmed, 1 not.
+              # Byte-for-byte the step-08 #5194 self-heal copy: the same skopeo
+              # flags, the same #5095 mothership-proxy -> DIRECT inverse-map
+              # fallback, plus the #5525 scarf.sh -> mothership-proxy forward-map
+              # fallback step-03 copy_one carries. Source selection ONLY — the
+              # DEST is the resolver-derived local path, never re-derived here.
+              daytwo_warm_image() {
+                _wi_up=$(offlinemirror_normalize_ref "$1")
+                _wi_lp="$2"
+                daytwo_ensure_skopeo || return 1
+                daytwo_load_creds
+                _wi_lref="${LOCAL_REGISTRY_HOST}/${_wi_lp}"
+                _wi_srchost="${_wi_up%%/*}"
+                case "${_wi_srchost}" in *.*|*:*|localhost) : ;; *) _wi_srchost="docker.io" ;; esac
+                _wi_sc=$(daytwo_src_creds_for "${_wi_srchost}")
+                _wi_fb_up=""; _wi_fb_sc=""
+                if [ -n "${MOTHERSHIP_HOST:-}" ] && [ "${_wi_srchost}" = "${MOTHERSHIP_HOST}" ]; then
+                  # #5095 — INVERSE coverage-map walk: harbor.openova.io/proxy-<x>/<path>
+                  # -> the FIRST mapped host whose project is <x>. No second hand-list.
+                  _wi_rest="${_wi_up#*/}"
+                  case "${_wi_rest}" in
+                    */*)
+                      _wi_proj="${_wi_rest%%/*}"; _wi_path="${_wi_rest#*/}"
+                      for _wi_pair in ${HOST_PROJECT_MAP}; do
+                        _wi_h="${_wi_pair%%:*}"
+                        case "${_wi_pair}" in *:*) _wi_p="${_wi_pair#*:}" ;; *) _wi_p="" ;; esac
+                        if [ -n "${_wi_p}" ] && [ "${_wi_p}" = "${_wi_proj}" ]; then
+                          _wi_fb_up="${_wi_h}/${_wi_path}"
+                          _wi_fb_sc=$(daytwo_src_creds_for "${_wi_h}")
+                          break
+                        fi
+                      done
+                      ;;
+                  esac
+                elif [ -n "${MOTHERSHIP_HOST:-}" ]; then
+                  # #5525 — a *.docker.scarf.sh redirector shares Docker Hub's
+                  # ANONYMOUS per-IP quota, so its secondary source is the
+                  # mothership proxy, derived by the FORWARD map lookup.
+                  case "${_wi_srchost}" in
+                    *.docker.scarf.sh)
+                      _wi_sp=""
+                      for _wi_pair in ${HOST_PROJECT_MAP}; do
+                        _wi_h="${_wi_pair%%:*}"
+                        case "${_wi_pair}" in *:*) _wi_p="${_wi_pair#*:}" ;; *) _wi_p="" ;; esac
+                        if [ "${_wi_h}" = "${_wi_srchost}" ] && [ -n "${_wi_p}" ]; then _wi_sp="${_wi_p}"; break; fi
+                      done
+                      if [ -n "${_wi_sp}" ]; then
+                        _wi_fb_up="${MOTHERSHIP_HOST}/${_wi_sp}/${_wi_up#*/}"
+                        _wi_fb_sc=$(daytwo_src_creds_for "${MOTHERSHIP_HOST}")
+                      fi
+                      ;;
+                  esac
+                fi
+                _wi_attempts="${PREWARM_COPY_ATTEMPTS:-3}"
+                [ -n "${MOTHERSHIP_HOST:-}" ] && [ "${_wi_srchost}" = "${MOTHERSHIP_HOST}" ] && _wi_attempts="${PREWARM_PROXY_COPY_ATTEMPTS:-6}"
+                _wi_attempt=1
+                while [ "${_wi_attempt}" -le "${_wi_attempts}" ]; do
+                  echo "[daytwo] image warm: copying ${_wi_up} -> ${_wi_lref} (attempt ${_wi_attempt}/${_wi_attempts})"
+                  if [ -n "${_wi_sc}" ]; then set -- --src-creds="${_wi_sc}"; else set --; fi
+                  if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT:-1200s}" copy \
+                    --insecure-policy --multi-arch all --retry-times 5 "$@" \
+                    --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                    --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY:-false}" \
+                    --src-tls-verify=true \
+                    "docker://${_wi_up}" "docker://${_wi_lref}" >"${WORK}/warm.log" 2>&1; then
+                    echo "[daytwo] image warm OK ${_wi_up} -> ${_wi_lref}"
+                    return 0
+                  fi
+                  sed 's/^/    /' "${WORK}/warm.log"
+                  if [ -n "${_wi_fb_up}" ]; then
+                    echo "[daytwo] image warm: primary source failed; secondary-source fallback ${_wi_fb_up} -> ${_wi_lref} (#5095/#5525)"
+                    if [ -n "${_wi_fb_sc}" ]; then set -- --src-creds="${_wi_fb_sc}"; else set --; fi
+                    if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT:-1200s}" copy \
+                      --insecure-policy --multi-arch all --retry-times 5 "$@" \
+                      --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                      --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY:-false}" \
+                      --src-tls-verify=true \
+                      "docker://${_wi_fb_up}" "docker://${_wi_lref}" >"${WORK}/warm.log" 2>&1; then
+                      echo "[daytwo] image warm OK ${_wi_fb_up} -> ${_wi_lref} (secondary-source fallback)"
+                      return 0
+                    fi
+                    sed 's/^/    /' "${WORK}/warm.log"
+                  fi
+                  _wi_attempt=$((_wi_attempt+1))
+                  [ "${_wi_attempt}" -le "${_wi_attempts}" ] && sleep 5
+                done
+                echo "[daytwo] image warm FAILED ${_wi_up} -> ${_wi_lref} after ${_wi_attempts} attempt(s) (left in the missing manifest; workloads keep running on the installed version)"
+                return 1
+              }
+
+              # reconcile_images_once — the #5640 leg. Enumerate what the
+              # Sovereign's OWN GitOps declares, map each ref through the shared
+              # resolver, and assert the local Harbor can serve it.
+              CHART_PINS=0; CHART_PRESENT=0; CHART_WARMED=0; CHART_MISS=0; CHART_STATUS="skipped"
+              IMAGE_REFS=0; IMAGE_PRESENT=0; IMAGE_WARMED=0; IMAGE_MISS=0; IMAGE_STATUS="skipped"
+              MISSING_CHARTS_FILE="${WORK}/missing-charts.tsv"
+              MISSING_IMAGES_FILE="${WORK}/missing-images.tsv"
+
+              reconcile_images_once() {
+                : > "${MISSING_IMAGES_FILE}"
+                IMAGE_REFS=0; IMAGE_PRESENT=0; IMAGE_WARMED=0; IMAGE_MISS=0
+                if [ "${RESOLVER_OK}" != "1" ]; then
+                  IMAGE_STATUS="no-resolver"
+                  return 1
+                fi
+                if [ -z "${HOST_PROJECT_MAP:-}" ]; then
+                  echo "[daytwo] image leg: HOST_PROJECT_MAP is empty — the coverage map did not project; skipping this cycle rather than guessing paths"
+                  IMAGE_STATUS="no-coverage-map"
+                  return 1
+                fi
+                # running Pods ∪ declared workload templates — the #3944
+                # completeness union. The declared half is load-bearing HERE:
+                # the hw292 offender was in ImagePullBackOff, i.e. it had NO
+                # running container to enumerate.
+                _running=$(kubectl get pods -A -o json 2>/dev/null | \
+                  jq -r '.items[].spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
+                _declared=$(kubectl get deployments,statefulsets,daemonsets -A -o json 2>/dev/null | \
+                  jq -r '.items[].spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
+                _cron=$(kubectl get cronjobs -A -o json 2>/dev/null | \
+                  jq -r '.items[].spec.jobTemplate.spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
+                _jobs=$(kubectl get jobs -A -o json 2>/dev/null | \
+                  jq -r '.items[].spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
+                _imgs=$(printf '%s\n%s\n%s\n%s\n' "${_running}" "${_declared}" "${_cron}" "${_jobs}" | \
+                  grep -E '^[^[:space:]]+$' | grep -v '^null$' | sort -u || true)
+                _n=$(printf '%s\n' "${_imgs}" | grep -c . || true)
+                # VACUITY GUARD. A zero-ref parse is NEVER "all clear" — it is a
+                # broken enumeration (RBAC lost, jq missing, API unreachable).
+                # Reporting it as green is precisely the failure mode that let
+                # #5640 stay invisible, so it is a loud, distinct outcome.
+                if [ "${_n}" -eq 0 ]; then
+                  echo "[daytwo] image leg: enumeration returned ZERO image refs — that is a broken read (RBAC/jq/apiserver), NOT an all-clear; skipping this cycle"
+                  IMAGE_STATUS="enumeration-empty"
+                  return 1
+                fi
+                if [ "${_n}" -gt "${IMAGE_SCAN_MAX}" ]; then
+                  echo "[daytwo] image leg: ${_n} refs exceeds IMAGE_SCAN_MAX=${IMAGE_SCAN_MAX}; scanning the first ${IMAGE_SCAN_MAX} this cycle (raise daytwoReconciler.images.maxRefsPerCycle to widen)"
+                  _imgs=$(printf '%s\n' "${_imgs}" | head -n "${IMAGE_SCAN_MAX}")
+                fi
+                for _img in ${_imgs}; do
+                  [ -z "${_img}" ] && continue
+                  _paths=$(offlinemirror_local_paths "${_img}")
+                  case "${_paths}" in
+                    __UNMAPPED__*)
+                      _uh=$(printf '%s' "${_paths}" | awk '{print $2}')
+                      printf 'UNMAPPED\t%s\t%s\n' "${_img}" "${_uh}" >> "${MISSING_IMAGES_FILE}"
+                      IMAGE_MISS=$((IMAGE_MISS+1))
+                      echo "[daytwo] UNMAPPED host ${_uh} for ${_img} — offlineMirror.hostProjects has no project for it, so no local path exists to check (#4975)"
+                      continue ;;
+                    "") continue ;;   # excluded by design — not mirrored
+                  esac
+                  for _lp in ${_paths}; do
+                    IMAGE_REFS=$((IMAGE_REFS+1))
+                    if daytwo_manifest_present "${_lp}"; then
+                      IMAGE_PRESENT=$((IMAGE_PRESENT+1))
+                      continue
+                    fi
+                    _code="${DAYTWO_LAST_CODE:-000}"
+                    if [ "${RECONCILE_MODE}" = "warm" ] && daytwo_warm_image "${_img}" "${_lp}" && daytwo_manifest_present "${_lp}"; then
+                      IMAGE_WARMED=$((IMAGE_WARMED+1))
+                      echo "[daytwo] image warm restored ${LOCAL_REGISTRY_HOST}/${_lp}"
+                      continue
+                    fi
+                    printf 'IMAGE\t%s\t%s\t%s\n' "${_img}" "${_lp}" "${_code}" >> "${MISSING_IMAGES_FILE}"
+                    IMAGE_MISS=$((IMAGE_MISS+1))
+                    echo "[daytwo] MISSING local Harbor image: ${LOCAL_REGISTRY_HOST}/${_lp} (HTTP ${_code}) declared by ${_img} — any Pod rolled onto it will ImagePullBackOff until this artifact is present (#5640)"
+                  done
+                done
+                IMAGE_STATUS="ok"
+                echo "[daytwo] image leg: refs=${IMAGE_REFS} present=${IMAGE_PRESENT} warmed=${IMAGE_WARMED} missing=${IMAGE_MISS}"
+                return 0
+              }
+
+              reconcile_charts_once() {
+                : > "${MISSING_CHARTS_FILE}"
+                CHART_PINS=0; CHART_PRESENT=0; CHART_WARMED=0; CHART_MISS=0
                 # Idempotent pre-flight: pre-cutover (or before step-01 mirrored)
                 # the local Gitea repo isn't present — skip this iteration.
                 if [ -n "${gitea_host}" ] && ! nslookup "${gitea_host}" >/dev/null 2>&1; then
-                  echo "[daytwo] ${gitea_host} not resolvable yet — local Gitea not up (pre-cutover?); skipping this cycle"
+                  echo "[daytwo] ${gitea_host} not resolvable yet — local Gitea not up (pre-cutover?); skipping the chart leg this cycle"
+                  CHART_STATUS="gitea-absent"
                   return 0
                 fi
                 _pat=$(read_pat)
                 if [ -z "${_pat}" ]; then
                   echo "[daytwo] PAT ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY} not readable — cannot read the local Gitea mirror this cycle; retrying next interval"
+                  CHART_STATUS="pat-unreadable"
                   return 1
                 fi
                 _api="${GITEA_INTERNAL_URL%/}/api/v1/repos/${GITEA_ORG}/${GITEA_REPO}"
                 # Repo present? (Not yet mirrored => nothing to reconcile.)
                 if ! curl -fsS --max-time 30 -H "Authorization: token ${_pat}" "${_api}" 2>/dev/null | grep -q '"full_name"'; then
-                  echo "[daytwo] local repo ${GITEA_ORG}/${GITEA_REPO} not present yet — step-01 gitea-mirror has not completed; skipping this cycle"
+                  echo "[daytwo] local repo ${GITEA_ORG}/${GITEA_REPO} not present yet — step-01 gitea-mirror has not completed; skipping the chart leg this cycle"
+                  CHART_STATUS="repo-absent"
                   return 0
                 fi
 
@@ -270,6 +659,7 @@ spec:
                   | jq -r '.[] | select(.type=="file") | .name | select(test("^[0-9].*\\.ya?ml$"))' 2>/dev/null || true)
                 if [ -z "${_list}" ]; then
                   echo "[daytwo] could not list ${_bkpath} in the local Gitea mirror this cycle; retrying next interval"
+                  CHART_STATUS="slot-list-failed"
                   return 1
                 fi
                 _ff=0
@@ -284,45 +674,52 @@ spec:
                 . /pin-extractor/extract-pins.sh
                 _pins=/tmp/daytwo-pins.tsv
                 bootstrapkit_pins "${_dir}" "${UPSTREAM_PREFIX}" "oci://${HARBOR_HOST}/openova-io" > "${_pins}" 2>/dev/null || true
-                _pn=$(grep -c . "${_pins}" 2>/dev/null || true)
-                if [ "${_pn}" -eq 0 ]; then
-                  echo "[daytwo] extractor parsed zero pins this cycle (mirror mid-sync or slot drift) — skipping; retrying next interval"
+                CHART_PINS=$(grep -c . "${_pins}" 2>/dev/null || true)
+                if [ "${CHART_PINS}" -eq 0 ]; then
+                  echo "[daytwo] extractor parsed zero pins this cycle (mirror mid-sync or slot drift) — that is a broken parse, NOT an all-clear; retrying next interval"
+                  CHART_STATUS="pins-empty"
                   return 1
                 fi
 
                 # Diff every frozen chart pin against local Harbor.
-                _missing=/tmp/daytwo-missing.txt; : > "${_missing}"
-                _present=0; _miss=0; _warmed=0
                 while IFS="$(printf '\t')" read -r _c _v; do
                   [ -z "${_c}" ] && continue
                   if harbor_has "${_c}" "${_v}"; then
-                    _present=$((_present+1)); continue
+                    CHART_PRESENT=$((CHART_PRESENT+1)); continue
                   fi
                   # Missing. In warm mode, try to fetch it; re-check after.
                   if [ "${RECONCILE_MODE}" = "warm" ] && warm_chart "${_c}" "${_v}" && harbor_has "${_c}" "${_v}"; then
-                    _warmed=$((_warmed+1)); continue
+                    CHART_WARMED=$((CHART_WARMED+1)); continue
                   fi
-                  printf '%s\t%s\n' "${_c}" "${_v}" >> "${_missing}"
-                  _miss=$((_miss+1))
-                  echo "[daytwo] MISSING local Harbor: openova-io/${_c}:${_v} (frozen bootstrap-kit pin) — its HR upgrade will wedge until this artifact is present"
+                  printf 'CHART\t%s\t%s\n' "${_c}" "${_v}" >> "${MISSING_CHARTS_FILE}"
+                  CHART_MISS=$((CHART_MISS+1))
+                  echo "[daytwo] MISSING local Harbor chart: openova-io/${_c}:${_v} (frozen bootstrap-kit pin) — its HR upgrade will wedge until this artifact is present"
                 done < "${_pins}"
+                CHART_STATUS="ok"
+                echo "[daytwo] chart leg: pins=${CHART_PINS} present=${CHART_PRESENT} warmed=${CHART_WARMED} missing=${CHART_MISS}"
+                return 0
+              }
 
-                # Publish the missing set to a durable ConfigMap (the offline-
-                # media manifest for air-gapped Sovereigns; the actionable signal
-                # for everyone). Always write it — an EMPTY manifest is the
-                # "all pins present" all-clear.
-                _mf=/tmp/daytwo-manifest.txt
+              # Publish the missing set to a durable ConfigMap (the offline-media
+              # manifest for air-gapped Sovereigns; the actionable signal for
+              # everyone). ALWAYS written — an empty manifest is the all-clear,
+              # and a leg that could not run says so EXPLICITLY rather than
+              # silently contributing zero misses.
+              publish_manifest() {
+                _mf="${WORK}/manifest.txt"
+                _total=$((CHART_MISS + IMAGE_MISS))
                 {
-                  echo "# self-sovereign-cutover Day-2 Harbor pin manifest (#5265)"
+                  echo "# self-sovereign-cutover Day-2 local-Harbor manifest (#5265 charts + #5640 images)"
                   echo "# generated $(date -u +%Y-%m-%dT%H:%M:%SZ) mode=${RECONCILE_MODE}"
-                  echo "# pins=${_pn} present=${_present} warmed=${_warmed} missing=${_miss}"
-                  echo "# each MISSING line is a chart OCI artifact to side-load into local Harbor project openova-io:"
+                  echo "# chartLeg=${CHART_STATUS} pins=${CHART_PINS} present=${CHART_PRESENT} warmed=${CHART_WARMED} missing=${CHART_MISS}"
+                  echo "# imageLeg=${IMAGE_STATUS} refs=${IMAGE_REFS} present=${IMAGE_PRESENT} warmed=${IMAGE_WARMED} missing=${IMAGE_MISS}"
+                  echo "# CHART lines side-load as:"
                   echo "#   helm pull ${WARM_UPSTREAM_OCI_PREFIX}/<chart> --version <version>  &&  helm push <tgz> oci://${HARBOR_HOST}/openova-io"
-                  if [ "${_miss}" -gt 0 ]; then
-                    sort -u "${_missing}" | while IFS="$(printf '\t')" read -r _mc _mv; do
-                      [ -n "${_mc}" ] && printf 'MISSING\t%s\t%s\n' "${_mc}" "${_mv}"
-                    done
-                  else
+                  echo "# IMAGE lines side-load as:"
+                  echo "#   skopeo copy docker://<upstream-ref> docker://${LOCAL_REGISTRY_HOST}/<local-path>"
+                  if [ -s "${MISSING_CHARTS_FILE}" ]; then sort -u "${MISSING_CHARTS_FILE}"; fi
+                  if [ -s "${MISSING_IMAGES_FILE}" ]; then sort -u "${MISSING_IMAGES_FILE}"; fi
+                  if [ "${_total}" -eq 0 ] && [ "${CHART_STATUS}" != "pins-empty" ] && [ "${IMAGE_STATUS}" != "enumeration-empty" ]; then
                     echo "ALL_PINS_PRESENT"
                   fi
                 } > "${_mf}"
@@ -331,13 +728,29 @@ spec:
                   --dry-run=client -o yaml 2>/dev/null \
                   | kubectl -n "${RELEASE_NAMESPACE}" apply -f - >/dev/null 2>&1 \
                   || echo "[daytwo] WARN: could not update ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} (logs still carry the manifest)"
-
-                echo "[daytwo] cycle complete: pins=${_pn} present=${_present} warmed=${_warmed} missing=${_miss} (manifest -> ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM})"
-                return 0
               }
 
-              # warm-mode one-time upstream + local registry logins (best-effort;
-              # login failure falls through to per-chart fail-soft handling).
+              reconcile_once() {
+                _rc=0
+                CHART_STATUS="disabled"; IMAGE_STATUS="disabled"
+                : > "${MISSING_CHARTS_FILE}"; : > "${MISSING_IMAGES_FILE}"
+                CHART_PINS=0; CHART_PRESENT=0; CHART_WARMED=0; CHART_MISS=0
+                IMAGE_REFS=0; IMAGE_PRESENT=0; IMAGE_WARMED=0; IMAGE_MISS=0
+                if [ "${CHART_LEG_ENABLED}" = "true" ]; then
+                  reconcile_charts_once || _rc=1
+                fi
+                if [ "${IMAGE_LEG_ENABLED}" = "true" ]; then
+                  reconcile_images_once || _rc=1
+                fi
+                publish_manifest
+                echo "[daytwo] cycle complete: charts(${CHART_STATUS}) missing=${CHART_MISS} | images(${IMAGE_STATUS}) missing=${IMAGE_MISS} (manifest -> ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM})"
+                return "${_rc}"
+              }
+
+              # warm-mode one-time upstream + local registry logins for the CHART
+              # leg (best-effort; login failure falls through to per-chart
+              # fail-soft handling). The image leg authenticates per-copy via
+              # skopeo --src-creds/--dest-creds, so it needs no login here.
               if [ "${RECONCILE_MODE}" = "warm" ]; then
                 export HELM_CACHE_HOME=/tmp/.helm-cache HELM_CONFIG_HOME=/tmp/.helm-config HELM_DATA_HOME=/tmp/.helm-data
                 if [ -n "${WARM_CRED_SECRET_NAME}" ]; then
@@ -362,7 +775,7 @@ spec:
               # in one cycle must not stop the reconciler (region-kill canon: the
               # loop is the durable surface).
               while : ; do
-                reconcile_once || echo "[daytwo] this cycle could not complete (transient); retrying next interval"
+                reconcile_once || echo "[daytwo] this cycle could not complete fully (transient); retrying next interval"
                 echo "[daytwo] sleeping ${RECONCILE_INTERVAL_SECONDS}s"
                 sleep "${RECONCILE_INTERVAL_SECONDS}"
               done
@@ -383,6 +796,12 @@ spec:
             items:
               - key: extract-pins.sh
                 path: extract-pins.sh
+        - name: offline-mirror
+          configMap:
+            name: cutover-offline-mirror-resolver
+            items:
+              - key: resolver.sh
+                path: resolver.sh
         - name: tmp
           emptyDir: {}
 {{- end }}

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3474,15 +3474,17 @@ if ! grep -qF 'failed to push — Sovereign cannot survive ghcr.io deny-egress p
   exit 1
 fi
 echo "  PASS (#5095 round 2: step-03 probes the mothership proxy once [bounded, values-knobbed, never fatal], latches .proxy_down when unreachable, then tries the DIRECT upstream first for proxy-sourced refs — gated on the toggle + latch, probe skipped on an all-ghcr wave, adaptive latch on the proxy-bad/direct-good signal — eliminating the per-image proxy timeout tax while keeping the round-1 after-failure fallback + the Phase A FATAL intact)"
-echo "[cutover-contract] Case 70: #5265 post-cutover Day-2 Harbor pin reconciler — a Deployment (NOT CronJob), ABSENT by default, sharing the 03b extractor; detect-only reaches only local Gitea+Harbor, warm helm-pulls+pushes"
+echo "[cutover-contract] Case 70: #5265/#5640 post-cutover Day-2 local-Harbor reconciler — a Deployment (NOT CronJob), PRESENT by default in zero-egress detect mode, sharing the 03b extractor; warm helm-pulls+pushes"
 # The reconciler closes the Day-2 Harbor leg: after cutover the local Gitea
 # mirror re-syncs upstream pin bumps and Flux moves the HR to the new pin, but
 # local Harbor still holds only the cutover-time versions → the HR upgrade
-# wedges (LIVE hw277 bp-continuum 0.1.12). It ships DISABLED (severance-safe,
-# like mirrorResync) and — when opted in — enumerates the frozen bootstrap-kit
-# pins via the SAME 03b extractor step-03/step-06 use, diffs local Harbor, and
-# reports (detect) or warms (warm) the drift. Region-kill canon mandates a
-# Deployment, not a CronJob.
+# wedges (LIVE hw277 bp-continuum 0.1.12). #5640 flipped it ON by default: the
+# severance-safe property is "no upstream egress by default", which detect mode
+# holds literally, and shipping it OFF left the post-cutover delivery gap as
+# silent as the issue describes. When enabled it enumerates the frozen
+# bootstrap-kit pins via the SAME 03b extractor step-03/step-06 use, diffs local
+# Harbor, and reports (detect) or warms (warm) the drift. Region-kill canon
+# mandates a Deployment, not a CronJob.
 # NOTE (#4969 SIGPIPE trap — see Case 16c): the suite runs under
 # `set -o pipefail`, so NEVER `... | grep -q` here — grep -q closes the pipe on
 # its first match, the upstream awk/grep takes EPIPE and the pipeline exits
@@ -3490,9 +3492,15 @@ echo "[cutover-contract] Case 70: #5265 post-cutover Day-2 Harbor pin reconciler
 # has no upstream writer to SIGPIPE); the doc blocks are captured to files via
 # an RS-split awk FIRST.
 c70_fail=0
-# (a) ABSENT by default (enabled=false) — no automatic tether on a canonical prov.
-if grep -q 'cutover-daytwo-harbor-reconciler' "$TMP/render.yaml"; then
-  echo "FAIL: Day-2 Harbor reconciler rendered by default — it MUST be off unless daytwoReconciler.enabled=true (severance-safe default; #5265)" >&2
+# (a) PRESENT by default (#5640) — the signal must exist on a canonical prov…
+if ! grep -q 'cutover-daytwo-harbor-reconciler' "$TMP/render.yaml"; then
+  echo "FAIL: Day-2 local-Harbor reconciler ABSENT from the default render — #5640 requires it on by default so a post-cutover Sovereign reports its own missing artifacts instead of failing silently" >&2
+  c70_fail=1
+fi
+# …and the operator can still render NOTHING at all.
+helm template smoke-daytwo-off . --set daytwoReconciler.enabled=false > "$TMP/render-daytwo-off.yaml"
+if grep -q 'cutover-daytwo-harbor-reconciler' "$TMP/render-daytwo-off.yaml"; then
+  echo "FAIL: daytwoReconciler.enabled=false still renders the reconciler — the master switch is inert (#5265)" >&2
   c70_fail=1
 fi
 # Render an enabled (detect, default) variant + an enabled warm variant.
@@ -3580,7 +3588,7 @@ if ! grep -q '"${RECONCILE_MODE}" = "warm"' "$DT_W"; then
   c70_fail=1
 fi
 if [ "$c70_fail" -ne 0 ]; then exit 1; fi
-echo "  PASS (#5265: Day-2 Harbor pin reconciler is a Deployment [region-kill canon], absent by default [severance-safe], reuses the 03b bootstrapkit_pins extractor + the durable artifact-API probe, publishes the offline-media missing manifest, defaults to zero-egress detect mode, and gates the upstream helm-pull/push behind opt-in warm mode; step count unchanged at 11)"
+echo "  PASS (#5265/#5640: Day-2 local-Harbor reconciler is a Deployment [region-kill canon], PRESENT by default with enabled=false still rendering nothing, reuses the 03b bootstrapkit_pins extractor + the durable artifact-API probe, publishes the offline-media missing manifest, defaults to zero-egress detect mode, and gates the upstream helm-pull/push behind opt-in warm mode; step count unchanged at 11)"
 
 echo "[cutover-contract] Case 71: #5359 secondary-region legs — steps 05/06/08 mount the optional cutover-secondary-kubeconfigs Secret and run fail-loud region-B pivot/hold legs; single-region renders inert; step count stays 11"
 # hw288 (dep 027f07559af1f9f7): cc=true with region-B still on github/ghcr/quay
@@ -3877,5 +3885,115 @@ if [ "$got74b" != "oci://registry.t91.omantel.biz/openova-io" ]; then
   exit 1
 fi
 echo "  PASS (#5527: Phase 3d present with values-driven target, executed derivation matches the step-06 value shape both input forms, read-back FATAL on an existing Deployment, loud SKIP when the marketplace tier is absent)"
+# ── Case 75 (#5640): the Day-2 reconciler's IMAGE leg — post-cutover delivery of
+# tags published AFTER step-03 ran ───────────────────────────────────────────
+# LIVE hw292 2026-08-03 (dep 1c56518035a83e03, cutoverComplete=true): deploy-bot
+# pinned catalyst images to d674a94, GHCR carried the tag, main was green — and
+#   curl -sk -u admin:*** https://registry.<fqdn>/v2/openova-io/openova/catalyst-ui/tags/list
+#   -> {"tags":["fad88bd"]}      d674a94 -> 404   fad88bd -> 200 (CONTROL)
+# with the Pod on d674a94 in ImagePullBackOff. step-03 mirrors the catalog AS OF
+# cutover; nothing mirrored anything published afterwards. The #5265 Day-2 loop
+# covered CHART pins only. This case pins the IMAGE leg's contract: it must reuse
+# the shared 03a resolver (never fork the host→project map), enumerate the
+# DECLARED workload templates (the hw292 offender had no running container), use
+# the SAME skopeo copy + #5095/#5525 fallbacks step-03/step-08 run, keep every
+# upstream reach behind mode=warm, and never report a broken read as an all-clear.
+echo "[cutover-contract] Case 75: #5640 Day-2 IMAGE leg — shared 03a resolver, declared-template enumeration, step-03 skopeo copy + #5095/#5525 fallbacks, warm-gated egress, vacuity-guarded"
+c75_fail=0
+# (a) The shared 03a resolver is MOUNTED and SOURCED — one mapping function for
+#     step-03 (push dest), step-08 (completeness HEAD) and this loop.
+if ! grep -q 'name: cutover-offline-mirror-resolver' "$DT_F"; then
+  echo "FAIL: Day-2 reconciler does not mount the cutover-offline-mirror-resolver ConfigMap (03a) — it would have to fork the host->project map (#5640 Refs #4975)" >&2
+  c75_fail=1
+fi
+if ! grep -q '/offline-mirror/resolver.sh' "$DT_F"; then
+  echo "FAIL: Day-2 reconciler does not source the shared 03a resolver.sh (#5640 Refs #4975)" >&2
+  c75_fail=1
+fi
+if ! grep -q 'offlinemirror_local_paths ' "$DT_F"; then
+  echo "FAIL: Day-2 reconciler never calls offlinemirror_local_paths — it is not deriving local Harbor paths from the shared coverage map (#5640)" >&2
+  c75_fail=1
+fi
+# (b) The coverage-map env is projected from the SAME helpers step-03/04/08 read.
+for c75_env in HOST_PROJECT_MAP EXCLUDED_HOSTS EXCLUDED_SUBSTRINGS LOCAL_REGISTRY_HOST MOTHERSHIP_HOST; do
+  if ! grep -qF "name: ${c75_env}" "$DT_F"; then
+    echo "FAIL: Day-2 reconciler does not project ${c75_env} — the shared resolver cannot run without the coverage-map env (#5640 Refs #4975)" >&2
+    c75_fail=1
+  fi
+done
+# (c) DECLARED workload templates are enumerated, not just running Pods. This is
+#     load-bearing: the hw292 offender was in ImagePullBackOff, i.e. it had NO
+#     running container to enumerate.
+if ! grep -q 'kubectl get deployments,statefulsets,daemonsets -A' "$DT_F"; then
+  echo "FAIL: Day-2 image leg does not enumerate DECLARED workload templates — an ImagePullBackOff workload (the exact hw292 shape) would be invisible (#5640 Refs #3944)" >&2
+  c75_fail=1
+fi
+# (d) Presence is the local-Harbor /v2 manifest probe step-08's completeness gate uses.
+if ! grep -q '/v2/${_mp_repo}/manifests/${_mp_ref}' "$DT_F"; then
+  echo "FAIL: Day-2 image leg does not HEAD the local Harbor /v2 manifest — it is not proving the image is pullable (#5640 Refs #4975)" >&2
+  c75_fail=1
+fi
+# (e) The copy is step-03's skopeo invocation, with BOTH documented fallbacks.
+if ! grep -q 'skopeo --command-timeout' "$DT_W"; then
+  echo "FAIL: Day-2 image warm does not use the bounded skopeo copy step-03/step-08 use (#5640 Refs #3944)" >&2
+  c75_fail=1
+fi
+if ! grep -qF -- '--insecure-policy --multi-arch all --retry-times 5' "$DT_W"; then
+  echo "FAIL: Day-2 image warm does not carry the step-03 skopeo flag set (--insecure-policy --multi-arch all --retry-times 5) — it forked the copy mechanism (#5640 Refs #4975 #5468)" >&2
+  c75_fail=1
+fi
+if ! grep -qF '#5095/#5525' "$DT_W"; then
+  echo "FAIL: Day-2 image warm has no secondary-source fallback leg — the #5095 mothership-proxy->DIRECT and #5525 scarf->proxy paths are not reused (#5640)" >&2
+  c75_fail=1
+fi
+if ! grep -qF '*.docker.scarf.sh' "$DT_W"; then
+  echo "FAIL: Day-2 image warm does not special-case the scarf.sh redirectors — Docker Hub's anonymous quota applies through them (#5640 Refs #5525)" >&2
+  c75_fail=1
+fi
+# (f) SOVEREIGNTY. detect must never download skopeo nor dial upstream: every
+#     egress-bearing call sits behind a mode=warm runtime branch. Assert the
+#     warm-gate is what guards the image copy, not merely present somewhere.
+if ! grep -qF '[ "${RECONCILE_MODE}" = "warm" ] && daytwo_warm_image' "$DT_F"; then
+  echo "FAIL: the Day-2 image copy is not runtime-gated on mode=warm — detect mode would reach upstream and break the zero-egress contract (#5640 Refs #5265)" >&2
+  c75_fail=1
+fi
+if ! grep -qF 'daytwo_ensure_skopeo || return 1' "$DT_F"; then
+  echo "FAIL: skopeo acquisition is not lazy inside the warm copy — detect mode must never dial github.com for the static binary (#5640)" >&2
+  c75_fail=1
+fi
+# (g) VACUITY GUARD. A zero-ref enumeration is a broken read, never an
+#     all-clear — reporting it green is the failure shape that let #5640 hide.
+if ! grep -qF 'enumeration-empty' "$DT_F"; then
+  echo "FAIL: Day-2 image leg has no zero-ref vacuity guard — an RBAC/jq/apiserver failure would publish ALL_PINS_PRESENT on nothing (#5640)" >&2
+  c75_fail=1
+fi
+if ! grep -qF 'ALL_PINS_PRESENT' "$DT_F"; then
+  echo "FAIL: the manifest lost its explicit all-clear line (#5640 Refs #5265)" >&2
+  c75_fail=1
+fi
+# The all-clear must be conditioned on BOTH legs having actually run.
+if ! grep -qF '[ "${IMAGE_STATUS}" != "enumeration-empty" ]' "$DT_F"; then
+  echo "FAIL: ALL_PINS_PRESENT is not conditioned on the image leg having really enumerated — a broken read would read as clean (#5640)" >&2
+  c75_fail=1
+fi
+# (h) The manifest names the missing IMAGE refs, not only charts.
+if ! grep -qF 'MISSING local Harbor image:' "$DT_F"; then
+  echo "FAIL: Day-2 image leg does not log the missing image by name — the operator gets no actionable reference (#5640)" >&2
+  c75_fail=1
+fi
+if ! grep -qF "printf 'IMAGE" "$DT_F"; then
+  echo "FAIL: the missing-artifact manifest carries no IMAGE lines — the offline-media side-load list is chart-only (#5640)" >&2
+  c75_fail=1
+fi
+# (i) VACUITY CONTROL for this case itself: the captured doc must be the real
+#     reconciler render, not an empty file that makes every negative assertion
+#     above pass trivially.
+c75_lines=$(wc -l < "$DT_F")
+if [ "${c75_lines}" -lt 200 ] || ! grep -qF 'kind: Deployment' "$DT_F"; then
+  echo "FAIL: vacuity control — the captured Day-2 render is ${c75_lines} lines and/or is not a Deployment; the Case 75 assertions were evaluated against nothing (#5640)" >&2
+  c75_fail=1
+fi
+if [ "$c75_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5640: the Day-2 IMAGE leg mounts+sources the shared 03a resolver and its coverage-map env, enumerates declared workload templates as well as running Pods, proves presence with step-08's local-Harbor /v2 manifest probe, copies with step-03's exact skopeo invocation plus the #5095 and #5525 secondary-source fallbacks, keeps every upstream reach behind a mode=warm runtime branch, and refuses to report a zero-ref enumeration as an all-clear; render vacuity control: ${c75_lines}-line Deployment)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/tests/daytwo-image-leg.sh
+++ b/platform/self-sovereign-cutover/chart/tests/daytwo-image-leg.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# daytwo-image-leg.sh — #5640 BEHAVIOURAL gate for the Day-2 reconciler's image leg.
+#
+# Case 75 in cutover-contract.sh asserts the leg's SHAPE (which functions and env
+# render). That is necessary but not sufficient: a render can carry every token
+# and still compute the wrong answer. This gate EXECUTES the rendered shell.
+#
+# It extracts the reconciler's `args[0]` script from the real chart render,
+# truncates it before the infinite loop, points the two ConfigMap mount paths at
+# the rendered ConfigMap contents, stubs `kubectl` (workload enumeration) and
+# `curl` (local Harbor manifest probe), then runs `reconcile_images_once` and
+# asserts the OUTCOME.
+#
+# The scenarios are the hw292 defect and its controls:
+#   S1  one declared image present in local Harbor, one 404 → exactly the 404 is
+#       recorded, named, and written to the manifest. (The 200 leg is the CONTROL
+#       that proves the probe is not simply reporting everything missing.)
+#   S2  every probe 404s → the miss count tracks the input, so S1's single miss
+#       was a discrimination, not a constant.
+#   S3  the enumeration returns nothing → status is `enumeration-empty` and the
+#       manifest must NOT claim ALL_PINS_PRESENT. A guard that treats a broken
+#       read as an all-clear is the exact shape that let #5640 stay invisible.
+#   S4  detect mode never dials an upstream registry: the stub records every
+#       host curl/skopeo is asked for, and only the local Harbor may appear.
+#
+# Usage: bash tests/daytwo-image-leg.sh [CHART_DIR]
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+HELM="${HELM_BIN:-helm}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$CHART_DIR"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not installed — the behavioural gate needs it to extract args[0]"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not installed — the rendered script parses kubectl JSON with it"; exit 0; }
+
+# ── Render the reconciler + the two ConfigMaps it mounts ──────────────────────
+"$HELM" template dt . --show-only templates/12-daytwo-harbor-pin-reconciler.yaml > "$TMP/dt.yaml"
+"$HELM" template dt . --show-only templates/03a-offline-mirror-resolver.yaml > "$TMP/03a.yaml"
+
+yq -r '.spec.template.spec.containers[0].args[0]' "$TMP/dt.yaml" > "$TMP/script.raw.sh"
+[ -s "$TMP/script.raw.sh" ] || fail "could not extract the reconciler args[0] script from the render"
+yq -r '.data."resolver.sh"' "$TMP/03a.yaml" > "$TMP/resolver.sh"
+[ -s "$TMP/resolver.sh" ] || fail "could not extract resolver.sh from the 03a ConfigMap render"
+
+# Vacuity control on the extraction itself — an empty/short script would make
+# every assertion below pass on nothing.
+raw_lines=$(wc -l < "$TMP/script.raw.sh")
+[ "${raw_lines}" -ge 200 ] || fail "extracted script is only ${raw_lines} lines — the render did not carry the loop body"
+grep -q 'reconcile_images_once()' "$TMP/script.raw.sh" || fail "extracted script has no reconcile_images_once() — nothing to execute"
+
+# Truncate before the infinite loop so the harness terminates, and repoint the
+# two hardcoded ConfigMap mount paths at the extracted copies.
+awk '/^[[:space:]]*# The Day-2 loop\./{exit} {print}' "$TMP/script.raw.sh" \
+  | sed -e "s#/offline-mirror/resolver.sh#${TMP}/resolver.sh#g" \
+        -e "s#/pin-extractor/extract-pins.sh#${TMP}/extract-pins.sh#g" \
+  > "$TMP/script.sh"
+grep -q 'reconcile_images_once()' "$TMP/script.sh" || fail "truncation removed reconcile_images_once()"
+if grep -q 'while : ; do' "$TMP/script.sh"; then fail "truncation did not remove the infinite loop"; fi
+: > "$TMP/extract-pins.sh"
+
+# ── Env: taken from the REAL render so the harness cannot drift from the chart ─
+yq -r '.spec.template.spec.containers[0].env[] | select(has("value")) | .name + "=" + (.value|tostring)' "$TMP/dt.yaml" > "$TMP/env.txt"
+grep -q '^HOST_PROJECT_MAP=' "$TMP/env.txt" || fail "render does not project HOST_PROJECT_MAP"
+
+# ── Stubs ─────────────────────────────────────────────────────────────────────
+mkdir -p "$TMP/bin"
+
+# kubectl: workload enumeration + the manifest ConfigMap write.
+cat > "$TMP/bin/kubectl" <<'KSTUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"get deployments,statefulsets,daemonsets"*) cat "${STUB_DECLARED}" ;;
+  *"get pods -A"*)                             echo '{"items":[]}' ;;
+  *"get cronjobs"*)                            echo '{"items":[]}' ;;
+  *"get jobs"*)                                echo '{"items":[]}' ;;
+  *"create configmap"*)                        echo 'apiVersion: v1'; echo 'kind: ConfigMap' ;;
+  *"apply -f -"*)                              cat > /dev/null ;;
+  *)                                           exit 0 ;;
+esac
+KSTUB
+chmod +x "$TMP/bin/kubectl"
+
+# curl: the local-Harbor /v2 manifest probe. Records every host it is asked for
+# (the S4 egress witness) and answers from ${STUB_PRESENT_RE}.
+cat > "$TMP/bin/curl" <<'CSTUB'
+#!/usr/bin/env bash
+url=""
+for a in "$@"; do case "$a" in http://*|https://*) url="$a" ;; esac; done
+[ -n "$url" ] && printf '%s\n' "$url" >> "${STUB_CURL_LOG}"
+if [ -n "${STUB_PRESENT_RE:-}" ] && printf '%s' "$url" | grep -Eq "${STUB_PRESENT_RE}"; then
+  echo "200"
+else
+  echo "404"
+fi
+CSTUB
+chmod +x "$TMP/bin/curl"
+
+# skopeo / nslookup: presence-only witnesses. detect mode must never invoke skopeo.
+cat > "$TMP/bin/skopeo" <<'SSTUB'
+#!/usr/bin/env bash
+echo "SKOPEO_INVOKED $*" >> "${STUB_CURL_LOG}"
+exit 1
+SSTUB
+chmod +x "$TMP/bin/skopeo"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/nslookup"; chmod +x "$TMP/bin/nslookup"
+
+# Two declared images: catalyst-ui on the tag deployed at cutover (present) and
+# on the tag deploy-bot pinned afterwards (missing) — the hw292 pair verbatim.
+cat > "$TMP/declared.json" <<'JSON'
+{"items":[
+ {"spec":{"template":{"spec":{"containers":[
+   {"image":"ghcr.io/openova-io/openova/catalyst-ui:fad88bd"},
+   {"image":"ghcr.io/openova-io/openova/catalyst-ui:d674a94"}]}}}}
+]}
+JSON
+cat > "$TMP/declared-empty.json" <<'JSON'
+{"items":[]}
+JSON
+
+run_leg() {   # run_leg <declared-json> <present-regex> -> writes $TMP/out.txt
+  : > "$TMP/curl.log"
+  {
+    echo 'set +e'
+    while IFS= read -r line; do printf 'export %q\n' "$line"; done < "$TMP/env.txt"
+    # Secret-backed env has no .value in the render; supply harness values.
+    echo 'export HARBOR_USERNAME=admin HARBOR_PASSWORD=stub GHCR_DOCKERCONFIG='
+    cat "$TMP/script.sh"
+    echo 'reconcile_images_once'
+    echo 'echo "RESULT status=${IMAGE_STATUS} refs=${IMAGE_REFS} present=${IMAGE_PRESENT} warmed=${IMAGE_WARMED} missing=${IMAGE_MISS}"'
+    echo 'echo "---MISSING---"; cat "${MISSING_IMAGES_FILE}" 2>/dev/null'
+    echo 'echo "---MANIFEST---"; publish_manifest; cat "${WORK}/manifest.txt"'
+  } > "$TMP/harness.sh"
+  STUB_DECLARED="$1" STUB_PRESENT_RE="$2" STUB_CURL_LOG="$TMP/curl.log" \
+    PATH="$TMP/bin:$PATH" sh "$TMP/harness.sh" > "$TMP/out.txt" 2>&1
+}
+
+# ── S1: one present, one missing ──────────────────────────────────────────────
+echo "[daytwo-image-leg] S1: hw292 pair — catalyst-ui:fad88bd present (CONTROL), catalyst-ui:d674a94 404"
+run_leg "$TMP/declared.json" 'manifests/fad88bd$'
+grep -q 'RESULT status=ok refs=4 present=2 warmed=0 missing=2' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S1 did not discriminate present from missing (each ghcr.io/openova-io ref resolves to TWO local paths: proxy-ghcr/... and the host-drop openova-io/...)"; }
+grep -q 'openova-io/openova/catalyst-ui:d674a94' "$TMP/out.txt" \
+  || fail "S1 did not NAME the missing reference — the operator gets no actionable output"
+grep -q 'openova-io/openova/catalyst-ui:fad88bd' "$TMP/out.txt" \
+  && fail "S1 reported the PRESENT control tag as missing — the probe is answering constant-404"
+grep -q 'ALL_PINS_PRESENT' "$TMP/out.txt" \
+  && fail "S1 manifest claims ALL_PINS_PRESENT while an image is missing"
+echo "  PASS (missing d674a94 named on both local paths; present fad88bd control untouched; no false all-clear)"
+
+# ── S2: everything missing ────────────────────────────────────────────────────
+echo "[daytwo-image-leg] S2: no tag present in local Harbor — the count must track the input, not a constant"
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+grep -q 'RESULT status=ok refs=4 present=0 warmed=0 missing=4' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S2 miss count did not track the input — S1's result was not a discrimination"; }
+echo "  PASS (4/4 missing — the S1 single-miss was a real comparison)"
+
+# ── S3: broken enumeration must NOT read as clean ─────────────────────────────
+echo "[daytwo-image-leg] S3: zero-ref enumeration is a broken read, never an all-clear"
+run_leg "$TMP/declared-empty.json" 'manifests/fad88bd$'
+grep -q 'RESULT status=enumeration-empty' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S3 did not flag the empty enumeration"; }
+grep -q 'ALL_PINS_PRESENT' "$TMP/out.txt" \
+  && fail "S3 published ALL_PINS_PRESENT on a ZERO-ref enumeration — a broken read laundered into an all-clear (#5640)"
+echo "  PASS (status=enumeration-empty, no all-clear published)"
+
+# ── S4: detect mode reaches only the local Harbor ─────────────────────────────
+echo "[daytwo-image-leg] S4: detect mode must not dial any upstream registry"
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+if grep -q 'SKOPEO_INVOKED' "$TMP/curl.log"; then
+  fail "S4 detect mode invoked skopeo — the zero-external-egress contract is broken (#5640 Refs #5265)"
+fi
+offhost=$(grep -Ev '^https?://registry\.' "$TMP/curl.log" | grep -E '^https?://' || true)
+if [ -n "${offhost}" ]; then
+  printf '%s\n' "${offhost}" | sed 's/^/    /'
+  fail "S4 detect mode dialled a non-local host — every URL must be the local Harbor"
+fi
+probes=$(grep -c '^https\?://' "$TMP/curl.log" || true)
+[ "${probes}" -ge 4 ] || fail "S4 vacuity control — only ${probes} URL(s) recorded; the leg did not actually probe, so 'no upstream' is meaningless"
+echo "  PASS (${probes} probes, all against the local Harbor; skopeo never invoked)"
+
+echo "[daytwo-image-leg] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1924,31 +1924,50 @@ mirrorResync:
   # days; well under typical 5 min cycle so jobs don't pile up.
   jobTimeoutSeconds: 900
 
-# #5265 — POST-CUTOVER DAY-2 Harbor pin reconciler (template
+# #5265 + #5640 — POST-CUTOVER DAY-2 local-Harbor reconciler (template
 # 12-daytwo-harbor-pin-reconciler.yaml).
 #
-# THE GAP. step-03 harbor-prewarm pushes every pinned chart into local Harbor
-# EXACTLY ONCE at cutover. Post-cutover the local Gitea mirror re-syncs upstream
-# pin bumps on the operator's schedule and Flux moves the HR to the new pin —
-# but local Harbor still holds only the cutover-time versions, so the HelmChart
-# cannot reconcile and the HR upgrade wedges (live hw277: region-b bp-continuum
-# HR wanted chart 0.1.12 that local Harbor lacked). The Git leg has a companion
-# (step-01's re-runnable mirror); the Harbor leg had none. This is that
-# companion — a Deployment (NOT a CronJob: region-kill canon — the loop must
-# survive the control-plane region dying) that enumerates the frozen
-# bootstrap-kit chart pins via the SAME 03b `bootstrapkit_pins` extractor
-# step-03/step-06 use, diffs them against local Harbor, and closes the drift.
+# THE GAP. step-03 harbor-prewarm pushes every pinned chart AND every workload
+# image into local Harbor EXACTLY ONCE at cutover. Post-cutover the local Harbor
+# is the ONLY registry that matters (step-04 pivots node containerd certs.d,
+# step-06 repoints every HelmRepository), so anything published upstream AFTER
+# step-03 ran cannot reach the Sovereign. Two live proofs of one structure:
+#   • #5265 CHART half — the local Gitea mirror re-syncs upstream pin bumps on
+#     the operator's schedule and Flux moves the HR to the new pin, but local
+#     Harbor still holds only the cutover-time versions, so the HelmChart cannot
+#     reconcile and the HR upgrade wedges (hw277: region-b bp-continuum HR wanted
+#     chart 0.1.12 that local Harbor lacked).
+#   • #5640 IMAGE half — a chart version that DOES reconcile installs workload
+#     templates pinned to image tags published after cutover (hw292 2026-08-03:
+#     registry.<fqdn>/v2/openova-io/openova/catalyst-ui/tags/list returned only
+#     ["fad88bd"]; the freshly-pinned d674a94 404'd and its Pod sat in
+#     ImagePullBackOff). merge → build → publish → deploy-bot pin is complete for
+#     a PRE-cutover Sovereign and silently incomplete for a post-cutover one.
+# The Git leg has a companion (step-01's re-runnable mirror); the Harbor leg had
+# none. This is that companion for BOTH artifact kinds — a Deployment (NOT a
+# CronJob: region-kill canon #5157 — the loop must survive the control-plane
+# region dying) that enumerates the frozen bootstrap-kit chart pins via the SAME
+# 03b `bootstrapkit_pins` extractor step-03/step-06 use AND the declared image
+# set via the SAME 03a `offlinemirror_local_paths` resolver step-03/step-08 use,
+# diffs both against local Harbor, and closes the drift.
 #
-# SOVEREIGNTY. Ships DISABLED by default — the SAME severance-safe default as
-# mirrorResync above: a canonical fresh-prov Sovereign renders nothing here, so
-# the step-08 deny-egress proof and the "no automatic upstream tether" contract
-# are untouched. An operator running a managed-update posture opts IN.
+# SOVEREIGNTY. #5640 flips `enabled` to TRUE by default. The property that
+# mattered was never "no Deployment" — it was "no upstream egress by default",
+# and mode=detect (the default) holds that literally: the loop reaches ONLY the
+# local Gitea mirror and the local Harbor, never downloads skopeo, never dials an
+# upstream registry. What it DOES do is publish the exact missing set to a
+# durable ConfigMap + loud logs, which is what "today nothing notices" (#5640)
+# needed. Reaching upstream stays opt-in behind mode=warm, exactly as before.
 daytwoReconciler:
-  # Master switch. false (default) => the whole template renders to nothing.
-  # Flip true in a per-Sovereign overlay ONLY on a Sovereign the operator keeps
-  # on a managed upstream-update schedule (the companion of opting mirrorResync
-  # / the operator's Git-sync schedule in).
-  enabled: false
+  # Master switch. false => the whole template renders to nothing.
+  #
+  # #5640 flipped the default false -> true. Shipping OFF meant shipping a knob
+  # nobody turns on, leaving the post-cutover delivery gap exactly as silent as
+  # the issue describes. Default mode is detect (zero external egress), so a
+  # canonical fresh-prov Sovereign gains the SIGNAL without gaining a tether;
+  # the step-08 deny-egress proof and the "no automatic upstream tether"
+  # contract are untouched. Operators who want nothing at all still set false.
+  enabled: true
   # Reconcile loop interval (seconds). 300 = 5 min, matching the mirrorResync
   # cadence so a Git pin bump and its Harbor artifact land in the same window.
   intervalSeconds: 300
@@ -1961,8 +1980,9 @@ daytwoReconciler:
   #     visible, actionable signal.
   #   warm — additionally `helm pull`s each missing chart from
   #     warm.upstreamOciPrefix (operator credential) and `helm push`es it into
-  #     local Harbor, then re-checks. Only this mode reaches upstream, and only
-  #     for chart OCI bytes on the operator's schedule (the exact companion of
+  #     local Harbor, and `skopeo copy`s each missing IMAGE from its recorded
+  #     upstream into local Harbor, then re-checks. Only this mode reaches
+  #     upstream, and only on the operator's schedule (the exact companion of
   #     the Git mirror reaching github.com on that schedule). Fail-SOFT: a warm
   #     miss is logged + left in the manifest; the loop never crash-loops and
   #     workloads keep running on the installed version.
@@ -1970,7 +1990,32 @@ daytwoReconciler:
   # Durable ConfigMap (release namespace) the loop writes the missing-artifact
   # manifest into each cycle. An empty manifest (ALL_PINS_PRESENT) is the
   # all-clear. Air-gapped operators consume this as the offline-media manifest.
+  # Lines are `CHART\t<chart>\t<version>`, `IMAGE\t<upstream-ref>\t<local-path>
+  # \t<http-code>` and `UNMAPPED\t<ref>\t<host>`.
   missingManifestConfigMapName: "self-sovereign-cutover-daytwo-missing"
+  # #5265 leg — the frozen bootstrap-kit CHART pins.
+  charts:
+    enabled: true
+  # #5640 leg — the declared IMAGE set. Enumerates running Pods ∪ declared
+  # workload templates (the #3944 completeness union step-03 Phase A performs;
+  # the declared half is load-bearing because the hw292 offender was in
+  # ImagePullBackOff and had no running container), maps each ref through the
+  # SAME 03a offlinemirror_local_paths resolver step-03/step-08 use, and asserts
+  # local Harbor serves it.
+  images:
+    enabled: true
+    # Per-image copy attempts for a NON-proxy source in warm mode. Mirrors
+    # step-03's PREWARM_COPY_ATTEMPTS default; proxy-sourced refs use
+    # prewarm.proxyCopyAttempts (single-source with step-03/step-08).
+    copyAttempts: 3
+    # The pinned skopeo static build step-03 harbor-prewarm and step-08's #5194
+    # self-heal already download. Fetched LAZILY and ONLY in warm mode, so
+    # detect keeps its zero-external-egress contract literally.
+    skopeoStaticURL: "https://github.com/lework/skopeo-binary/releases/download/v1.15.2/skopeo-linux-amd64"
+    # Upper bound on refs probed per cycle, so a Sovereign with hundreds of
+    # per-Org workloads cannot make one cycle unbounded. Raise on a large
+    # Sovereign; the cycle is idempotent so the remainder is picked up next pass.
+    maxRefsPerCycle: 400
   warm:
     # Upstream OCI prefix missing charts are pulled from in warm mode. Default
     # is the public openova-io catalog; an operator who mirrors the catalog to

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T22:18:58.534Z",
+  "generatedAt": "2026-08-03T22:43:19.703Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.160",
+      "version": "0.1.161",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.160",
+    "version": "0.1.161",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.160"
+  version: "0.1.161"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.160"
+    version: "0.1.161"
   topology:
     supported:
       - singleton

--- a/scripts/check-image-pins-resolvable.sh
+++ b/scripts/check-image-pins-resolvable.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# check-image-pins-resolvable.sh — #5640 fail-loud gate.
+#
+# THE DEFECT THIS CATCHES
+# ───────────────────────
+# `catalyst-build` publishes an image, deploy-bot sed-bumps the SHA into
+# products/catalyst/chart/values.yaml, the chart is released, the bootstrap-kit
+# pin moves, Flux rolls it. Every one of those steps can be green while the
+# referenced tag is not actually servable by the registry the target cluster is
+# ALLOWED to use — and nothing notices:
+#
+#   • Post-cutover Sovereign (the #5640 shape, live hw292 2026-08-03): step-04
+#     pivots node containerd to the local Harbor and step-06 repoints every
+#     HelmRepository at it, so the local Harbor is the ONLY registry that
+#     matters. `harbor-prewarm` (cutover step-03) mirrors the catalog AS OF
+#     cutover; nothing mirrors anything published afterwards.
+#         /v2/openova-io/openova/catalyst-ui/tags/list -> {"tags":["fad88bd"]}
+#         d674a94 -> 404   (today's pin)      fad88bd -> 200  (CONTROL)
+#     Pod on d674a94: ImagePullBackOff. Repo side: main green, GHCR tag exists,
+#     pin committed. Invisible.
+#   • Upstream (GHCR): a pin bump whose publish job silently failed leaves the
+#     chart pinned at a tag that was never pushed (the #1872 class, one layer
+#     down from chart artifacts to container images).
+#
+# WHAT IT ASSERTS
+#   Every openova-io container image reference the Catalyst chart renders is
+#   resolvable in the TARGET registry, and each unresolvable reference is named.
+#
+# EXIT CODES (distinct on purpose — an auth failure must NEVER be laundered
+# into "everything is missing", which would make the gate both useless and
+# unbelievable the first time a credential expires):
+#   0  every reference resolved
+#   1  at least one reference is genuinely absent (HTTP 404) — each one named
+#   2  usage / parse error, INCLUDING a zero-reference parse. A gate that
+#      passes because it found nothing to check is worse than no gate.
+#   3  registry unreachable or authentication failed — the gate could not
+#      form an opinion. NOT reported as missing.
+#
+# USAGE
+#   scripts/check-image-pins-resolvable.sh                       # GHCR
+#   scripts/check-image-pins-resolvable.sh --registry registry.t42.omani.works \
+#       --username admin --password "$HARBOR_PW"                 # a Sovereign
+#   scripts/check-image-pins-resolvable.sh --refs-file refs.txt  # explicit set
+#
+# ENV: REGISTRY_USERNAME / REGISTRY_PASSWORD are read when the matching flags
+# are absent (so CI never puts a credential on a command line).
+#
+# HOST MAPPING. When --registry names a Sovereign Harbor, an upstream
+# `ghcr.io/openova-io/<path>` reference is probed at `<path>` — the host-drop
+# destination `offlinemirror_local_paths` (platform/self-sovereign-cutover/
+# chart/templates/03a-offline-mirror-resolver.yaml) derives and step-06/07 pivot
+# the workload refs onto. One rule, same as the chart.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+CHART_DIR="${REPO_ROOT}/products/catalyst/chart"
+
+REGISTRY=""
+SCHEME="https"
+USERNAME="${REGISTRY_USERNAME:-}"
+PASSWORD="${REGISTRY_PASSWORD:-}"
+REFS_FILE=""
+INSECURE=""
+VERBOSE=""
+
+usage() {
+  sed -n '2,48p' "${BASH_SOURCE[0]:-$0}" | sed 's/^# \{0,1\}//'
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --registry)  REGISTRY="$2"; shift 2 ;;
+    --scheme)    SCHEME="$2"; shift 2 ;;
+    --username)  USERNAME="$2"; shift 2 ;;
+    --password)  PASSWORD="$2"; shift 2 ;;
+    --refs-file) REFS_FILE="$2"; shift 2 ;;
+    --chart-dir) CHART_DIR="$2"; shift 2 ;;
+    --insecure)  INSECURE="-k"; shift ;;
+    --verbose)   VERBOSE=1; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl not installed" >&2; exit 2; }
+
+# ── 1. Collect the reference set ─────────────────────────────────────────────
+# Default source is a helm render of the Catalyst chart: the renders are what a
+# Sovereign's GitOps actually applies, so there is no hand-maintained image list
+# to drift (the failure mode that produced #4573 F4 in the cutover chart).
+REFS_TMP="$(mktemp)"
+trap 'rm -f "${REFS_TMP}" "${REFS_TMP}.hdr" 2>/dev/null' EXIT
+
+if [ -n "${REFS_FILE}" ]; then
+  [ -f "${REFS_FILE}" ] || { echo "ERROR: --refs-file '${REFS_FILE}' not found" >&2; exit 2; }
+  grep -Ev '^\s*(#|$)' "${REFS_FILE}" | sort -u > "${REFS_TMP}"
+else
+  HELM="${HELM_BIN:-helm}"
+  command -v "${HELM}" >/dev/null 2>&1 || { echo "ERROR: helm not installed (needed to render the reference set)" >&2; exit 2; }
+  [ -d "${CHART_DIR}" ] || { echo "ERROR: chart dir '${CHART_DIR}' not found" >&2; exit 2; }
+  # Two render profiles: the default install, and the profile that unlocks the
+  # per-Organization services (`ingress.marketplace.enabled`) whose images carry
+  # their own SHA pins (images.orgTag / images.marketplaceTag / admin / console).
+  {
+    "${HELM}" template pins "${CHART_DIR}" 2>/dev/null
+    "${HELM}" template pins "${CHART_DIR}" --set ingress.marketplace.enabled=true 2>/dev/null
+  } | grep -oE 'image: *"?[^"[:space:]]+' \
+    | sed -e 's/^image: *"\?//' \
+    | grep -E '(^|/)openova-io/' \
+    | sort -u > "${REFS_TMP}"
+fi
+
+REF_COUNT=$(grep -c . "${REFS_TMP}" 2>/dev/null || true)
+# VACUITY GUARD. Zero references is never "all clear": it means the render
+# broke, the chart moved, or the grep stopped matching. Exit 2, loudly.
+if [ "${REF_COUNT}" -eq 0 ]; then
+  echo "FAIL(2): parsed ZERO image references." >&2
+  if [ -n "${REFS_FILE}" ]; then
+    echo "  source: --refs-file ${REFS_FILE}" >&2
+  else
+    echo "  source: helm render of ${CHART_DIR} (default + ingress.marketplace.enabled=true)" >&2
+    echo "  A green run on an empty reference set would assert nothing. Check that the chart still renders and that its openova-io image refs still match." >&2
+  fi
+  exit 2
+fi
+
+TARGET_DESC="ghcr.io (upstream)"
+[ -n "${REGISTRY}" ] && TARGET_DESC="${SCHEME}://${REGISTRY}"
+echo "[image-pins] ${REF_COUNT} openova-io image reference(s) to resolve in ${TARGET_DESC}"
+
+# ── 2. Probe helpers ─────────────────────────────────────────────────────────
+# curl_code URL [EXTRA...] -> prints the HTTP status, 000 on transport failure.
+curl_code() {
+  local url="$1"; shift
+  curl -s ${INSECURE} -o /dev/null -w '%{http_code}' --max-time 30 \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json' \
+    "$@" "${url}" 2>/dev/null || echo 000
+}
+
+# bearer_token REGISTRY_HOST REPO -> prints a token, or empty on failure.
+# The realm/service come from the registry's own challenge, so this works for
+# GHCR, Harbor and any other v2 registry without a per-registry special case.
+bearer_token() {
+  local host="$1" repo="$2" realm service tok
+  curl -s ${INSECURE} -o /dev/null -D "${REFS_TMP}.hdr" --max-time 20 "${SCHEME}://${host}/v2/" 2>/dev/null
+  realm=$(grep -i '^www-authenticate:' "${REFS_TMP}.hdr" 2>/dev/null | sed -n 's/.*realm="\([^"]*\)".*/\1/p' | head -1)
+  service=$(grep -i '^www-authenticate:' "${REFS_TMP}.hdr" 2>/dev/null | sed -n 's/.*service="\([^"]*\)".*/\1/p' | head -1)
+  [ -n "${realm}" ] || return 0
+  if [ -n "${USERNAME}" ] && [ -n "${PASSWORD}" ]; then
+    tok=$(curl -s ${INSECURE} --max-time 20 -u "${USERNAME}:${PASSWORD}" \
+      "${realm}?service=${service}&scope=repository:${repo}:pull" 2>/dev/null)
+  else
+    tok=$(curl -s ${INSECURE} --max-time 20 \
+      "${realm}?service=${service}&scope=repository:${repo}:pull" 2>/dev/null)
+  fi
+  printf '%s' "${tok}" | sed -n 's/.*"\(token\|access_token\)":"\([^"]*\)".*/\2/p' | head -1
+}
+
+# ── 3. Resolve each reference ────────────────────────────────────────────────
+MISSING=""
+UNRESOLVED=""
+OK_COUNT=0
+AUTH_FAILURES=0
+
+while IFS= read -r ref; do
+  [ -n "${ref}" ] || continue
+  # Split host / path, then path / manifest reference.
+  case "${ref}" in
+    */*) src_host="${ref%%/*}"; rest="${ref#*/}" ;;
+    *)   src_host="docker.io"; rest="${ref}" ;;
+  esac
+  case "${src_host}" in
+    *.*|*:*|localhost) : ;;
+    *) rest="${ref}"; src_host="docker.io" ;;
+  esac
+  mref="latest"; repo="${rest}"
+  case "${rest}" in
+    *@*) mref="${rest##*@}"; repo="${rest%@*}"; case "${repo##*/}" in *:*) repo="${repo%:*}" ;; esac ;;
+    *)   case "${rest##*/}" in *:*) mref="${rest##*:}"; repo="${rest%:*}" ;; esac ;;
+  esac
+
+  if [ -n "${REGISTRY}" ]; then
+    target_host="${REGISTRY}"          # host-drop: the local path is the ref path
+  else
+    target_host="${src_host}"
+  fi
+
+  url="${SCHEME}://${target_host}/v2/${repo}/manifests/${mref}"
+  code=$(curl_code "${url}")
+  if [ "${code}" = "401" ] || [ "${code}" = "403" ]; then
+    tok=$(bearer_token "${target_host}" "${repo}")
+    if [ -n "${tok}" ]; then
+      code=$(curl_code "${url}" -H "Authorization: Bearer ${tok}")
+    elif [ -n "${USERNAME}" ] && [ -n "${PASSWORD}" ]; then
+      code=$(curl_code "${url}" -u "${USERNAME}:${PASSWORD}")
+    fi
+  fi
+
+  case "${code}" in
+    200|301|302)
+      OK_COUNT=$((OK_COUNT+1))
+      [ -n "${VERBOSE}" ] && echo "  OK       ${ref} -> ${target_host}/${repo}:${mref} (HTTP ${code})"
+      ;;
+    404)
+      MISSING="${MISSING}${ref} => ${target_host}/${repo}/manifests/${mref} (HTTP 404)"$'\n'
+      ;;
+    401|403)
+      AUTH_FAILURES=$((AUTH_FAILURES+1))
+      UNRESOLVED="${UNRESOLVED}${ref} => ${target_host}/${repo}/manifests/${mref} (HTTP ${code}, authentication)"$'\n'
+      ;;
+    *)
+      UNRESOLVED="${UNRESOLVED}${ref} => ${target_host}/${repo}/manifests/${mref} (HTTP ${code}, registry unreachable)"$'\n'
+      ;;
+  esac
+done < "${REFS_TMP}"
+
+# ── 4. Verdict ───────────────────────────────────────────────────────────────
+# Auth / transport failures are reported FIRST and with their OWN exit code:
+# the gate could not form an opinion, so it must not claim the images are gone.
+if [ -n "${UNRESOLVED}" ]; then
+  echo "FAIL(3): could not determine resolvability for $(printf '%s' "${UNRESOLVED}" | grep -c .) reference(s) in ${TARGET_DESC} — this is an ACCESS failure, not a missing-image finding:" >&2
+  printf '%s' "${UNRESOLVED}" | sed 's/^/    UNRESOLVED /' >&2
+  if [ "${AUTH_FAILURES}" -gt 0 ] && { [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; }; then
+    echo "    HINT: openova-io images are PRIVATE. Pass --username/--password (or REGISTRY_USERNAME/REGISTRY_PASSWORD)." >&2
+  fi
+  echo "    resolved OK so far: ${OK_COUNT}/${REF_COUNT}" >&2
+  exit 3
+fi
+
+if [ -n "${MISSING}" ]; then
+  echo "FAIL(1): $(printf '%s' "${MISSING}" | grep -c .) image reference(s) are NOT resolvable in ${TARGET_DESC}:" >&2
+  printf '%s' "${MISSING}" | sed 's/^/    MISSING /' >&2
+  echo "" >&2
+  echo "  Every reference above is pinned by the Catalyst chart but absent from the registry the target cluster is permitted to use." >&2
+  if [ -n "${REGISTRY}" ]; then
+    echo "  On a post-cutover Sovereign this is #5640: step-03 harbor-prewarm mirrored the catalog as of cutover and nothing mirrors what was published afterwards. The Day-2 reconciler (daytwoReconciler, mode=warm) delivers it; to side-load by hand:" >&2
+    echo "    skopeo copy docker://<upstream-ref> docker://${REGISTRY}/<local-path>" >&2
+  else
+    echo "  Upstream: the publish job for that SHA did not land. Re-run the build workflow before letting the pin ship." >&2
+  fi
+  echo "  resolved OK: ${OK_COUNT}/${REF_COUNT}" >&2
+  exit 1
+fi
+
+echo "[image-pins] PASS — all ${OK_COUNT}/${REF_COUNT} openova-io image reference(s) resolve in ${TARGET_DESC}"
+exit 0

--- a/scripts/tests/test-image-pins-resolvable.sh
+++ b/scripts/tests/test-image-pins-resolvable.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# test-image-pins-resolvable.sh — non-vacuity proof for scripts/check-image-pins-resolvable.sh
+#
+# A guard that has only ever passed is worthless. This harness stands up a stub
+# OCI registry on 127.0.0.1 and drives the gate through EVERY outcome, asserting
+# the exit code each time:
+#
+#   T1  every tag present                      -> 0
+#   T2  one tag 404s                           -> 1  and the reference is NAMED
+#   T3  registry answers 401 on the manifest   -> 3  (auth) and NOT 1
+#   T4  nothing listening on the port          -> 3  (unreachable) and NOT 1
+#   T5  empty reference set                    -> 2  (vacuity guard)
+#   T6  back to the T1 fixture                 -> 0  (the RED states were the
+#                                                     mutation, not a wedge)
+#
+# T3 is the load-bearing one: an expired credential must never be laundered into
+# "every image is missing", which is both wrong and the fastest way to teach
+# everyone to ignore the gate.
+#
+# Usage: bash scripts/tests/test-image-pins-resolvable.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+GATE="${REPO_ROOT}/scripts/check-image-pins-resolvable.sh"
+TMP="$(mktemp -d)"
+PORT=""
+SRV_PID=""
+
+cleanup() {
+  [ -n "${SRV_PID}" ] && kill "${SRV_PID}" 2>/dev/null
+  rm -rf "${TMP}"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not available for the stub registry"; exit 0; }
+[ -x "${GATE}" ] || chmod +x "${GATE}"
+
+# The hw292 pair: the tag deployed at cutover and the tag deploy-bot pinned after.
+cat > "${TMP}/refs.txt" <<'EOF'
+ghcr.io/openova-io/openova/catalyst-ui:fad88bd
+ghcr.io/openova-io/openova/catalyst-api:d674a94
+EOF
+: > "${TMP}/refs-empty.txt"
+
+# ── Stub registry ────────────────────────────────────────────────────────────
+# MODE file drives the response so a single server covers T1/T2/T3.
+cat > "${TMP}/registry.py" <<'PY'
+import os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MODE_FILE = sys.argv[1]
+
+class H(BaseHTTPRequestHandler):
+    def _mode(self):
+        with open(MODE_FILE) as f:
+            return f.read().strip()
+
+    def do_GET(self):
+        mode = self._mode()
+        if mode == "auth401":
+            # Challenge with a realm this harness never satisfies -> the gate
+            # must classify it as an ACCESS failure, not a missing image.
+            self.send_response(401)
+            self.send_header("Www-Authenticate",
+                             'Bearer realm="http://127.0.0.1:1/token",service="stub"')
+            self.end_headers()
+            return
+        if self.path.startswith("/v2/") and "/manifests/" in self.path:
+            tag = self.path.rsplit("/", 1)[-1]
+            if mode == "missing-d674a94" and tag == "d674a94":
+                self.send_response(404); self.end_headers(); return
+            self.send_response(200)
+            self.send_header("Content-Type",
+                             "application/vnd.oci.image.manifest.v1+json")
+            self.end_headers()
+            self.wfile.write(b'{"schemaVersion":2}')
+            return
+        self.send_response(200); self.end_headers()
+
+    do_HEAD = do_GET
+
+    def log_message(self, *a):
+        pass
+
+HTTPServer(("127.0.0.1", int(os.environ["STUB_PORT"])), H).serve_forever()
+PY
+
+PORT=$(python3 - <<'PY'
+import socket
+s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()
+PY
+)
+DEAD_PORT=$(python3 - <<'PY'
+import socket
+s = socket.socket(); s.bind(("127.0.0.1", 0)); p = s.getsockname()[1]; s.close(); print(p)
+PY
+)
+
+echo "all-present" > "${TMP}/mode"
+STUB_PORT="${PORT}" python3 "${TMP}/registry.py" "${TMP}/mode" &
+SRV_PID=$!
+for _ in $(seq 1 50); do
+  if curl -s -o /dev/null --max-time 1 "http://127.0.0.1:${PORT}/v2/"; then break; fi
+  sleep 0.1
+done
+curl -s -o /dev/null --max-time 2 "http://127.0.0.1:${PORT}/v2/" || fail "stub registry never came up on 127.0.0.1:${PORT}"
+
+run_gate() {   # run_gate <refs-file> <port> -> sets RC, writes $TMP/out.txt
+  "${GATE}" --refs-file "$1" --registry "127.0.0.1:$2" --scheme http --insecure \
+    > "${TMP}/out.txt" 2>&1
+  RC=$?
+}
+
+expect() {     # expect <want-rc> <label>
+  if [ "${RC}" -ne "$1" ]; then
+    sed 's/^/    /' "${TMP}/out.txt"
+    fail "$2 — wanted exit $1, got ${RC}"
+  fi
+  echo "  exit ${RC}  $2"
+}
+
+echo "[image-pins-selftest] T1 GREEN: every tag present"
+echo "all-present" > "${TMP}/mode"
+run_gate "${TMP}/refs.txt" "${PORT}"
+expect 0 "all references resolve"
+grep -q 'PASS — all 2/2' "${TMP}/out.txt" || fail "T1 did not report 2/2 resolved — the gate is not actually probing both refs"
+
+echo "[image-pins-selftest] T2 RED: MUTATION — catalyst-api:d674a94 now 404s"
+echo "missing-d674a94" > "${TMP}/mode"
+run_gate "${TMP}/refs.txt" "${PORT}"
+expect 1 "one reference genuinely absent"
+grep -q 'MISSING ghcr.io/openova-io/openova/catalyst-api:d674a94' "${TMP}/out.txt" \
+  || { sed 's/^/    /' "${TMP}/out.txt"; fail "T2 did not NAME the missing reference"; }
+grep -q 'MISSING ghcr.io/openova-io/openova/catalyst-ui:fad88bd' "${TMP}/out.txt" \
+  && fail "T2 also flagged the PRESENT control tag — the gate is reporting constant-missing, not discriminating"
+grep -q 'resolved OK: 1/2' "${TMP}/out.txt" || fail "T2 lost the resolved-count control line"
+echo "         (control ghcr.io/openova-io/openova/catalyst-ui:fad88bd stayed resolved: 1/2)"
+
+echo "[image-pins-selftest] T3 RED: MUTATION — registry answers 401 (auth), must NOT read as missing"
+echo "auth401" > "${TMP}/mode"
+run_gate "${TMP}/refs.txt" "${PORT}"
+expect 3 "authentication failure gets its own exit code"
+grep -q 'ACCESS failure, not a missing-image finding' "${TMP}/out.txt" \
+  || { sed 's/^/    /' "${TMP}/out.txt"; fail "T3 did not distinguish an access failure from a missing image"; }
+grep -q 'MISSING ' "${TMP}/out.txt" && fail "T3 reported MISSING on an auth failure — the exact laundering this exit code exists to prevent"
+
+echo "[image-pins-selftest] T4 RED: MUTATION — nothing listening on the target port"
+run_gate "${TMP}/refs.txt" "${DEAD_PORT}"
+expect 3 "registry unreachable gets the access exit code"
+grep -q 'registry unreachable' "${TMP}/out.txt" || fail "T4 did not classify a dead port as unreachable"
+grep -q 'MISSING ' "${TMP}/out.txt" && fail "T4 reported MISSING on an unreachable registry"
+
+echo "[image-pins-selftest] T5 RED: MUTATION — empty reference set (vacuity guard)"
+echo "all-present" > "${TMP}/mode"
+run_gate "${TMP}/refs-empty.txt" "${PORT}"
+expect 2 "a zero-reference parse fails closed"
+grep -q 'parsed ZERO image references' "${TMP}/out.txt" || fail "T5 did not name the vacuity condition"
+
+echo "[image-pins-selftest] T6 GREEN: restore the T1 fixture"
+run_gate "${TMP}/refs.txt" "${PORT}"
+expect 0 "back to green — the RED states above were the mutations, not a wedged harness"
+
+echo "[image-pins-selftest] All gates green (0/1/2/3 all reachable and distinct)."


### PR DESCRIPTION
## What this fixes

After sovereignty cutover the Sovereign's local Harbor is the only registry that matters — step-04 pivots node containerd `certs.d` and step-06 repoints every HelmRepository at it. `harbor-prewarm` (step-03) mirrors the catalog **as it exists at cutover time**; nothing mirrored anything published afterwards. Proven live on hw292 (dep `1c56518035a83e03`, `cutoverComplete=true`, 2026-08-03):

```
curl -sk -u admin:*** https://registry.<fqdn>/v2/openova-io/openova/catalyst-ui/tags/list
-> {"tags":["fad88bd"]}          # only the tag deployed at cutover
d674a94 -> 404                    # today's newly published tag
fad88bd -> 200                    # CONTROL: same probe, the deployed tag
```

…with the Pod pinned to `catalyst-ui:d674a94` in ImagePullBackOff. merge → build → publish → deploy-bot pin is complete for a pre-cutover Sovereign and silently incomplete for a post-cutover one, and nothing on the repo side reveals it: main green, GHCR tag present, pin committed.

The property this PR guarantees: **any image or chart version referenced by the Sovereign's own GitOps pins is resolvable in the registry that Sovereign is permitted to use.**

## Shape chosen: (a) region-local reconciler on the Sovereign

Justified from the code, not from preference:

1. **The mechanism already exists for the chart half.** `platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml` is the #5265 Day-2 Deployment that closes the identical structure one layer up — chart pins whose versions local Harbor lacks. `03b-bootstrap-kit-pins.yaml` even documents the seam: *"REUSE CONTRACT (#5265 Day-2 leg) … the callable seam is deliberately runtime-agnostic."* Adding a second, differently-shaped delivery path next to it would be the fork this chart has spent #4975/#5237/#5443 eliminating. So the image half becomes a second leg of the same loop.
2. **Deployment, not CronJob** — `reference_region_local_reconciler_must_be_deployment_not_cronjob_survives_region_kill.md` / #5157: a CronJob's scheduler lives in the control-plane region and stops firing when that region is killed. The Deployment (replicas 1, Recreate) is rescheduled onto a surviving node.
3. **Shape (b) is structurally anti-Pillar-5.** A mothership-side push on the deploy-bot pin commit requires OpenOva to hold a standing write credential for every customer-run Sovereign and to reach it on demand — a permanent inbound tether from the mothership into the Sovereign, and impossible for an air-gapped one. It also cannot be replaced by Harbor pull-through: `02-harbor-projects-job.yaml` creates `openova-io` as a **push-mode** project (no `registry_id`), and step-06/07 pivot the workload refs onto exactly that project, which is the path that 404'd on hw292.

## Exact mechanism reused from step-03

Nothing here is a second mechanism. Each leg names its source:

| Concern | Reused from | How |
|---|---|---|
| image → local Harbor path | `03a-offline-mirror-resolver.yaml` (#4975) | the reconciler now mounts `cutover-offline-mirror-resolver` and sources `offlinemirror_local_paths` / `offlinemirror_normalize_ref`. Third consumer, one mapping function (step-03 push dest, step-08 completeness HEAD, this loop). |
| coverage-map data | `_helpers.tpl` | projects the identical `HOST_PROJECT_MAP` / `EXCLUDED_HOSTS` / `EXCLUDED_SUBSTRINGS` / `LOCAL_REGISTRY_HOST` / `MOTHERSHIP_HOST` env step-03/04/08 read. |
| enumeration | step-03 Phase A (#3944) | running Pods ∪ declared workload templates (Deployments/StatefulSets/DaemonSets/CronJobs/Jobs). The declared half is load-bearing: the hw292 offender was in ImagePullBackOff and had **no running container**. |
| presence probe | step-08 `run_offline_mirror_completeness` (#4975) | local Harbor `/v2/<repo>/manifests/<ref>` with the same Accept set and 3 attempts to absorb a Harbor blip. Charts keep the #5030 Harbor artifact-API probe. |
| copy | step-03 `prewarm_skopeo_copy` / step-08 `self_heal_warm_image` (#5194) | `skopeo --command-timeout … copy --insecure-policy --multi-arch all --retry-times 5 --src-creds … --dest-creds … --dest-tls-verify …`, verbatim. |
| proxy → DIRECT fallback | #5095 | the same inverse `HOST_PROJECT_MAP` walk: `harbor.openova.io/proxy-<x>/<path>` → the first mapped host whose project is `<x>`. No second hand-list. |
| scarf.sh handling | #5525 | a `*.docker.scarf.sh` source (which shares Docker Hub's anonymous per-IP quota) gets the mothership proxy as secondary source via the forward map lookup. |
| skopeo acquisition | step-08 `self_heal_ensure_skopeo` | the same pinned static build and retry shape — fetched **lazily and only in warm mode**. |
| credentials | step-03 / step-08 | the same `flux-system/ghcr-pull` dockerconfigjson parse, with an operator-supplied Secret able to override the (deliberately stripped) cutover credential. |

## Sovereignty posture, and why the loop now ships enabled

`daytwoReconciler.enabled` flips `false` → `true`. The severance-safe property was never "no Deployment" — it was **"no upstream egress by default"**, and `mode: detect` (still the default) holds that literally: the loop reaches only the local Gitea mirror and the local Harbor, never downloads skopeo, never dials an upstream registry. What it adds is the signal hw292 lacked: every cycle publishes the exact missing set — `CHART` and `IMAGE` lines — to the durable `self-sovereign-cutover-daytwo-missing` ConfigMap and to the Pod log, which is simultaneously the air-gapped Sovereign's offline-media side-load list. Shipping it off would have shipped a knob nobody turns on, leaving the failure exactly as silent as the issue describes. `enabled: false` still renders nothing at all, and every upstream reach stays behind opt-in `mode: warm` (`DAYTWO_RECONCILE_MODE` in the slot-06a overlay). Step count stays 11; no RBAC change.

## The fail-loud gate

`scripts/check-image-pins-resolvable.sh` derives the reference set from a helm render of the Catalyst chart (default profile ∪ `ingress.marketplace.enabled=true`) — 19 refs today — and asserts each resolves in the target registry, naming every one that does not. `--registry <sovereign-harbor>` probes a Sovereign using the same host-drop rule the resolver derives.

Exit codes are deliberately distinct so an auth failure is never laundered into "everything is missing":

| exit | meaning |
|---|---|
| 0 | every reference resolved |
| 1 | at least one reference genuinely absent (404), each named |
| 2 | usage/parse error **including a zero-reference parse** — fails closed |
| 3 | registry unreachable or authentication failed — the gate could not form an opinion |

Wired in `.github/workflows/check-image-pins-resolvable.yaml`: a hermetic `selftest` job (stub registry, no credential) gates a `ghcr` job that runs the real probe with the workflow's `packages: read` token. All four exit codes fail the build with a distinct `::error::`.

## Red-then-green proof

Every guard was deliberately broken and shown RED, then restored and shown GREEN. Template and gate were verified byte-identical to their pre-mutation state afterwards (`cmp -s` → identical).

| # | mutation | gate | exit | failure the gate printed |
|---|---|---|---|---|
| — | baseline, unmutated | contract / behavioural / self-test | 0 / 0 / 0 | — |
| M1 | drop the shared 03a resolver mount from the Deployment | `cutover-contract.sh` | **1** | `Day-2 reconciler does not mount the cutover-offline-mirror-resolver ConfigMap (03a) — it would have to fork the host->project map` |
| M2 | enumerate running Pods only (drop declared templates) | `cutover-contract.sh` | **1** | `Day-2 image leg does not enumerate DECLARED workload templates — an ImagePullBackOff workload (the exact hw292 shape) would be invisible` |
| M2 | same | `daytwo-image-leg.sh` | **1** | `S1 did not discriminate present from missing` |
| M3 | vacuity guard removed — zero refs reported as a clean cycle | `daytwo-image-leg.sh` | **1** | `S3 did not flag the empty enumeration` |
| M4 | manifest probe always answers present | `daytwo-image-leg.sh` | **1** | `S1 did not discriminate present from missing` |
| M5 | image copy no longer gated on `mode=warm` | `cutover-contract.sh` | **1** | `the Day-2 image copy is not runtime-gated on mode=warm — detect mode would reach upstream and break the zero-egress contract` |
| M5 | same | `daytwo-image-leg.sh` | **1** | `S4 detect mode invoked skopeo — the zero-external-egress contract is broken` |
| M6 | make the repo gate always `exit 0` (the `\|\| echo WARN` shape) | `test-image-pins-resolvable.sh` | **1** | `T1 did not report 2/2 resolved — the gate is not actually probing both refs` |
| M7 | launder an auth failure into "missing" (exit 1 instead of 3) | `test-image-pins-resolvable.sh` | **1** | `FAIL(1): 2 image reference(s) are NOT resolvable` — caught by the T3 assertion |
| — | restore all | contract / behavioural / self-test | 0 / 0 / 0 | — |

The gate's own self-test additionally walks all four exit codes against a stub registry — T1 present → 0, T2 one tag 404 → 1 (named, control tag still resolved 1/2), T3 401 → 3, T4 dead port → 3, T5 empty ref set → 2, T6 restored → 0 — and the behavioural chart test executes the rendered reconciler script against stub `kubectl`/`curl` using the hw292 pair verbatim: `catalyst-ui:fad88bd` present as the control, `catalyst-ui:d674a94` 404, `refs=4 present=2 missing=2` (each `ghcr.io/openova-io/*` ref resolves to two local paths), miss count tracking the input on the all-missing run, and 12 probes recorded all against the local Harbor with skopeo never invoked.

The gate was also run against the **real** GHCR: 19 references discovered from the render, unauthenticated → `FAIL(3) … ACCESS failure, not a missing-image finding`, zero `MISSING` lines. That is the anti-laundering behaviour on the live registry, not only the stub.

## Gates run

| gate | result |
|---|---|
| `bash scripts/check-no-nodeports.sh` | **exit 0** — zero NodePorts; 72 charts rendered and scanned, 17 allowlisted covered by the source scan |
| `bash scripts/check-bootstrap-kit-pin-sync.sh` | **exit 0** — 67 chart→pin pairs in sync |
| `bash scripts/check-catalog-seed-lockstep.sh` | **exit 0** — checked 68, fail 0 |
| `bash scripts/check-chart-annotations.sh` | **exit 0** — 95 charts, 0 hollow, 0 empty-render, 0 render-fail |
| `bash scripts/check-no-banned-words.sh` | **exit 0** |
| `helm lint platform/self-sovereign-cutover/chart` | **exit 0** |
| `helm lint products/catalyst/chart` | **exit 0** |
| `tests/cutover-contract.sh` | **exit 0** — all gates green, 11 steps, new Case 75 |
| `tests/daytwo-image-leg.sh` (new) | **exit 0** — S1–S4 green |
| `tests/{arg-strlen-guard,catalog-chart-set,image-registry-coverage,offline-mirror-host-projects,single-platform-copy,step06-pivot-readback}.sh` | **exit 0** each |
| `scripts/tests/test-image-pins-resolvable.sh` (new) | **exit 0** — 0/1/2/3 all reachable and distinct |
| `go test ./...` in `tests/e2e/bootstrap-kit` | **exit 0** |
| `go build ./...` + `go test ./...` in `products/catalyst/bootstrap/api` | **exit 0** |
| rendered chart scanned for `nodePort:` / `type: NodePort` | 0 / 0 |

## Chart lockstep

`bp-self-sovereign-cutover` 0.1.160 → **0.1.161** (0.1.160 was taken by #5527 while this branch was in flight; rebased onto it and renumbered, and the new contract case moved 74 → 75 for the same reason). All five sites plus both generated artifacts:

- `platform/self-sovereign-cutover/chart/Chart.yaml`
- `platform/self-sovereign-cutover/blueprint.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (×2)
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`
- regenerated via `node scripts/build-catalog.mjs` → `catalog.generated.ts` + `internal/catalog/blueprints.json`

## What the merger must know

- **hw292 does not heal itself from this merge.** A post-cutover Sovereign pulls its charts from its own local Harbor, so the new chart version cannot reach it by the very mechanism this PR fixes. hw292 needs either a manual `skopeo copy` of the missing refs (the gate names them, and the manifest ConfigMap will list them on any Sovereign running the new chart) or a fresh prov. The fix lands for every prov from 0.1.161 onward.
- **`mode: detect` reports, it does not deliver.** Delivery is `DAYTWO_RECONCILE_MODE=warm`, and private `openova-io` artifacts additionally need `daytwoReconciler.warm.credentialSecret` because step-06 strips the cutover's own ghcr auth by design. That is an operator policy decision, not a default we can make for a customer-run Sovereign.
- **The GHCR leg of the CI gate needs `packages: read` to work.** The workflow requests it and uses the same `github.actor` + `GITHUB_TOKEN` pair `docker/login-action` uses in `catalyst-build`. If that token cannot read the org's private packages the job exits 3 and says so explicitly rather than passing.
- `platform/matrix/chart` fails both `check-no-nodeports.sh` and `check-chart-annotations.sh` on a machine that has not fetched its `matrix-synapse` dependency. Untouched by this PR; both gates go green after `helm dependency build platform/matrix/chart`, and the results above are from that state.

Refs #5640 #5265 #4975 #5095 #5525 #3944 #5157
