### PR TITLE
fix(k8scache): AddCluster no-ops on an unchanged kubeconfig — root-cause fix for the hourly catalyst-api OOMKill (Refs #5642)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -2153,6 +2153,23 @@ func main() {
 	// through the in-process running flag (tryStartRun).
 	h.ResumeInterruptedCutover(ctx)
 
+	// #5642 — always-on, loopback-ONLY pprof. catalyst-api OOMKills on a
+	// ~60-minute metronome on hw292 and the retaining allocation cannot be
+	// named without a heap profile of the LEAKING process. The pre-existing
+	// CATALYST_PPROF_ENABLED flag above cannot supply one: it is read at
+	// process start, so turning it on rolls the Pod and destroys the heap
+	// that was about to be profiled. This listener is up from boot, is a
+	// separate mux on its own listener (unreachable through the public
+	// router on :8080), and binds 127.0.0.1 — no Service port, no ingress,
+	// no NodePort. `kubectl port-forward` into the Pod's netns is the only
+	// way in. See cmd/api/pprof_loopback.go for the full rationale.
+	if ln, pprofErr := startLoopbackPprof(log, env("CATALYST_PPROF_LOOPBACK_ADDR", defaultPprofLoopbackAddr)); pprofErr != nil {
+		log.Warn("pprof loopback listener not started — heap profiles unavailable on this Pod (#5642)", "err", pprofErr)
+	} else if ln != nil {
+		log.Info("pprof loopback listener ready — capture with: kubectl -n catalyst-system port-forward pod/$POD 6060:6060 (#5642)",
+			"addr", ln.Addr().String())
+	}
+
 	log.Info("catalyst api listening", "port", port)
 	if err := http.ListenAndServe(":"+port, r); err != nil {
 		log.Error("server error", "err", err)

--- a/products/catalyst/bootstrap/api/cmd/api/pprof_loopback.go
+++ b/products/catalyst/bootstrap/api/cmd/api/pprof_loopback.go
@@ -1,0 +1,147 @@
+// pprof_loopback.go — always-on, loopback-ONLY pprof listener (#5642).
+//
+// Why this exists, and why the pre-existing CATALYST_PPROF_ENABLED flag
+// (#5352, main.go) is not enough:
+//
+// catalyst-api OOMKills on a ~60-minute metronome on hw292 (dep
+// 1c56518035a83e03) — RSS climbs from ~200Mi at start to the 4Gi limit,
+// exit 137, restart, repeat. The 2026-08-03 investigation could rule out
+// goroutine growth, file-descriptor growth, Prometheus label-cardinality
+// growth, informer Indexer growth and SSE-subscriber growth from
+// /metrics alone, but could NOT name the retaining allocation — because
+// there is no way to read a heap profile out of the leaking process.
+//
+// CATALYST_PPROF_ENABLED mounts chi's profiler onto the PUBLIC router,
+// and it is read at process start. Turning it on therefore means
+// `kubectl set env` / a values override → a new Pod → the leaked heap
+// that was about to be profiled is destroyed by the very act of
+// arranging to profile it. The flag is unusable for the defect class it
+// was added for. Every future occurrence of this class inherits the same
+// dead end unless the profile surface is present *before* the process
+// starts leaking.
+//
+// The listener below is therefore ALWAYS ON and bound to the loopback
+// interface only:
+//
+//   - It is a SEPARATE http.ServeMux on its own net.Listener. It is not
+//     reachable through the public chi router, so no request that
+//     arrives on :8080 can ever route to it.
+//   - It binds 127.0.0.1 (guarded — see requireLoopback). It is not
+//     reachable from another Pod, from the Service, from the gateway, or
+//     from the network. No Service port, no ingress, no NodePort is
+//     added or required.
+//   - The only way in is `kubectl port-forward`, which attaches to the
+//     Pod's own network namespace and dials 127.0.0.1 from inside it.
+//     That already requires pods/portforward RBAC in catalyst-system —
+//     a caller who holds it can equally exec into the Pod, so this
+//     grants no capability that did not already exist.
+//
+// Capturing a profile from a live, leaking Pod is then one command, with
+// no restart and no state loss:
+//
+//	kubectl -n catalyst-system port-forward pod/<catalyst-api-pod> 6060:6060
+//	go tool pprof -top -sample_index=inuse_space http://127.0.0.1:6060/debug/pprof/heap
+//
+// CATALYST_PPROF_LOOPBACK_ADDR overrides the bind address; setting it to
+// the empty string disables the listener entirely. A non-loopback value
+// is REFUSED rather than honoured — see requireLoopback.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"strings"
+	"time"
+)
+
+// defaultPprofLoopbackAddr — loopback-only bind address for the
+// diagnostics listener. 6060 is the Go ecosystem's conventional pprof
+// port; nothing else in the container binds it.
+const defaultPprofLoopbackAddr = "127.0.0.1:6060"
+
+// errPprofNotLoopback is returned when the configured bind address does
+// not resolve to a loopback IP. Deliberately fatal-to-the-listener
+// rather than best-effort: a diagnostics surface that silently binds
+// 0.0.0.0 because someone typed ":6060" would expose process internals
+// (goroutine stacks, heap contents, command line) to every Pod in the
+// cluster. Refusing keeps the blast radius at "no profiler" instead of
+// "profiler on the pod network".
+var errPprofNotLoopback = errors.New("pprof loopback listener: bind address is not a loopback address")
+
+// pprofMux builds the diagnostics mux. Only the pprof handlers are
+// registered — no catalyst routes, no metrics, no auth surface.
+func pprofMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return mux
+}
+
+// requireLoopback verifies that addr's host half is a loopback address.
+//
+// An empty host ("::6060" / ":6060") is REJECTED: net.Listen treats it
+// as "all interfaces", which is precisely the exposure this listener
+// must never have. A hostname is rejected too — resolution can change
+// underneath the process, so only literal loopback IPs are accepted.
+func requireLoopback(addr string) error {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("pprof loopback listener: parse %q: %w", addr, err)
+	}
+	if strings.TrimSpace(port) == "" {
+		return fmt.Errorf("pprof loopback listener: %q has no port", addr)
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return fmt.Errorf("%w: %q binds every interface", errPprofNotLoopback, addr)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("%w: %q is not a literal IP", errPprofNotLoopback, addr)
+	}
+	if !ip.IsLoopback() {
+		return fmt.Errorf("%w: %q", errPprofNotLoopback, addr)
+	}
+	return nil
+}
+
+// startLoopbackPprof binds the diagnostics listener and serves it in the
+// background. Returns the bound address so callers (and tests) can dial
+// it; returns a nil listener with a nil error when addr is empty
+// (explicitly disabled).
+//
+// Errors are returned, not fatal: catalyst-api must keep serving even if
+// port 6060 is somehow taken. main() logs and continues.
+func startLoopbackPprof(log *slog.Logger, addr string) (net.Listener, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return nil, nil
+	}
+	if err := requireLoopback(addr); err != nil {
+		return nil, err
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("pprof loopback listener: listen %q: %w", addr, err)
+	}
+	srv := &http.Server{
+		Handler: pprofMux(),
+		// A CPU profile / trace request is long-lived by design
+		// (?seconds=30 is the common default), so no write timeout.
+		// The read timeout only bounds header reads.
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		if serveErr := srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			log.Warn("pprof loopback listener stopped", "addr", ln.Addr().String(), "err", serveErr)
+		}
+	}()
+	return ln, nil
+}

--- a/products/catalyst/bootstrap/api/cmd/api/pprof_loopback_test.go
+++ b/products/catalyst/bootstrap/api/cmd/api/pprof_loopback_test.go
@@ -1,0 +1,166 @@
+// pprof_loopback_test.go — #5642 guards for the always-on diagnostics
+// listener.
+//
+// The two properties that matter are opposites, so both are asserted
+// (a one-directional test here would pass on a listener that binds
+// nothing at all, and equally on one that binds every interface):
+//
+//  1. A loopback address DOES serve a usable heap profile. If this
+//     regresses, the next OOM cycle is undiagnosable again — which is
+//     the whole defect #5642 exists to close.
+//  2. A non-loopback address is REFUSED and binds nothing. If this
+//     regresses, goroutine stacks / heap contents / the process command
+//     line become readable by every Pod on the cluster network.
+package main
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func quietPprofLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestPprofLoopback_DefaultAddrIsLoopback pins the shipped default. A
+// change to ":6060" or "0.0.0.0:6060" fails here rather than silently
+// widening exposure on the next deploy.
+func TestPprofLoopback_DefaultAddrIsLoopback(t *testing.T) {
+	if err := requireLoopback(defaultPprofLoopbackAddr); err != nil {
+		t.Fatalf("defaultPprofLoopbackAddr %q must be loopback: %v", defaultPprofLoopbackAddr, err)
+	}
+	host, _, err := net.SplitHostPort(defaultPprofLoopbackAddr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", defaultPprofLoopbackAddr, err)
+	}
+	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+		t.Fatalf("defaultPprofLoopbackAddr host %q is not a literal loopback IP", host)
+	}
+}
+
+// TestPprofLoopback_RejectsNonLoopback is the negative half. Each input
+// is a real way this could be widened by accident.
+func TestPprofLoopback_RejectsNonLoopback(t *testing.T) {
+	for _, addr := range []string{
+		":6060",          // every interface — the classic mistake
+		"0.0.0.0:6060",   // every interface, explicit
+		"[::]:6060",      // every interface, v6
+		"10.42.2.7:6060", // this Pod's routable IP
+		"localhost:6060", // resolvable name, not a literal IP
+	} {
+		t.Run(addr, func(t *testing.T) {
+			if err := requireLoopback(addr); err == nil {
+				t.Fatalf("requireLoopback(%q) = nil; want rejection", addr)
+			}
+			ln, err := startLoopbackPprof(quietPprofLogger(), addr)
+			if err == nil {
+				if ln != nil {
+					_ = ln.Close()
+				}
+				t.Fatalf("startLoopbackPprof(%q) started a listener; want refusal", addr)
+			}
+			if ln != nil {
+				_ = ln.Close()
+				t.Fatalf("startLoopbackPprof(%q) returned a listener alongside its error", addr)
+			}
+			if !errors.Is(err, errPprofNotLoopback) && !strings.Contains(err.Error(), "loopback") {
+				t.Fatalf("startLoopbackPprof(%q) err = %v; want a loopback refusal", addr, err)
+			}
+		})
+	}
+}
+
+// TestPprofLoopback_EmptyAddrDisables — the documented off switch.
+func TestPprofLoopback_EmptyAddrDisables(t *testing.T) {
+	ln, err := startLoopbackPprof(quietPprofLogger(), "   ")
+	if err != nil {
+		t.Fatalf("empty addr should disable cleanly, got err: %v", err)
+	}
+	if ln != nil {
+		_ = ln.Close()
+		t.Fatal("empty addr started a listener; want none")
+	}
+}
+
+// TestPprofLoopback_ServesHeapProfile is the positive half: the
+// listener must actually hand back a heap profile, not merely accept a
+// connection. Binds :0 on loopback so the test never collides with a
+// developer's own pprof server.
+func TestPprofLoopback_ServesHeapProfile(t *testing.T) {
+	ln, err := startLoopbackPprof(quietPprofLogger(), "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("startLoopbackPprof: %v", err)
+	}
+	if ln == nil {
+		t.Fatal("startLoopbackPprof returned no listener")
+	}
+	defer ln.Close()
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	base := "http://" + ln.Addr().String()
+
+	resp, err := client.Get(base + "/debug/pprof/heap?debug=1")
+	if err != nil {
+		t.Fatalf("GET heap: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /debug/pprof/heap status = %d; want 200", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read heap body: %v", err)
+	}
+	// debug=1 renders the textual profile; its header is the marker that
+	// this is a real profile rather than an empty 200.
+	if !strings.Contains(string(body), "heap profile:") {
+		t.Fatalf("heap response is not a profile (len=%d, head=%q)", len(body), string(body[:min(120, len(body))]))
+	}
+
+	idx, err := client.Get(base + "/debug/pprof/")
+	if err != nil {
+		t.Fatalf("GET index: %v", err)
+	}
+	defer idx.Body.Close()
+	if idx.StatusCode != http.StatusOK {
+		t.Fatalf("GET /debug/pprof/ status = %d; want 200", idx.StatusCode)
+	}
+}
+
+// TestPprofLoopback_NotOnPublicMux — the diagnostics handlers must live
+// on their own mux. A request the public router would forward (any path
+// that is not /debug/pprof/*) must 404 here, proving the mux carries
+// nothing but the profiler.
+func TestPprofLoopback_NotOnPublicMux(t *testing.T) {
+	ln, err := startLoopbackPprof(quietPprofLogger(), "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("startLoopbackPprof: %v", err)
+	}
+	defer ln.Close()
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, path := range []string{"/healthz", "/metrics", "/api/v1/deployments"} {
+		resp, err := client.Get("http://" + ln.Addr().String() + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		code := resp.StatusCode
+		resp.Body.Close()
+		if code != http.StatusNotFound {
+			t.Fatalf("diagnostics mux served %s with %d; it must carry pprof ONLY", path, code)
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -38,7 +38,9 @@ package k8scache
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -297,6 +299,19 @@ type clusterState struct {
 	// an empty path are NEVER pruned (the chroot's own in-cluster
 	// cluster has no backing file and must survive every rescan).
 	kubeconfigPath string
+	// kubeconfigSHA — hex SHA-256 of the kubeconfig bytes this cluster
+	// was built from. Empty for pre-built-client (chroot / test)
+	// registrations, which have no backing file.
+	//
+	// #5642 — this is the idempotence key for AddCluster. Every
+	// level-triggered re-delivery of an UNCHANGED secondary kubeconfig
+	// used to rebuild all 42 informers for the same cluster id; the
+	// fingerprint lets AddCluster recognise "same cluster, same
+	// credentials, already running" and return without touching the
+	// informer set. A CHANGED kubeconfig (token rotation #5210, the
+	// #3991/#4000 EIP→private-SAN heal) produces a different SHA and
+	// still rebuilds, which is the behaviour those fixes rely on.
+	kubeconfigSHA string
 	// factory — the dynamicinformer factory for this cluster. Watches
 	// every registered Kind with no per-Kind LIST bound.
 	//
@@ -645,6 +660,7 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 	// against the apiserver's pods/exec subresource. Nil on the
 	// pre-built-DynamicClient test path.
 	var restCfg *rest.Config
+	var kubeconfigSHA string
 	if dyn == nil {
 		if c.KubeconfigPath == "" {
 			return errors.New("k8scache: ClusterRef requires either DynamicClient or KubeconfigPath")
@@ -653,6 +669,44 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 		if err != nil {
 			return fmt.Errorf("read kubeconfig %q: %w", c.KubeconfigPath, err)
 		}
+		kubeconfigSHA = sha256Hex(raw)
+
+		// #5642 — IDEMPOTENCE GATE. Re-registering a cluster that is
+		// already running on byte-identical credentials must be a no-op.
+		//
+		// It was not. POST /api/v1/sovereign/secondary-kubeconfig is
+		// LEVEL-TRIGGERED: runClusterMeshSteadyStateHeal re-forwards every
+		// on-disk secondary kubeconfig on every pass (5 min), and the
+		// mothership + the region-b node + the chroot each re-POST the
+		// same bytes. Each POST reached the rebuild path below, tore down
+		// the previous clusterState and built a fresh set of 42 informers
+		// for the SAME cluster id — measured on hw292 at ~2 rebuilds per
+		// 5-minute cycle, each replaying a full ADD sweep over region-b's
+		// entire object graph (the per-kind ADDED counters in
+		// catalyst_k8scache_informer_events_total doubled inside one
+		// 6.5-minute window). The teardown does not fully reclaim: live
+		// heap grew ~1.2 MB/s and RSS ~1.7 MB/s until the 4Gi limit
+		// OOMKilled the Pod on a ~60-minute metronome.
+		//
+		// phase1_watch.go's re-forward comment already ASSERTS this
+		// property — "The chroot's handler is idempotent (overwrite +
+		// AddCluster no-op)". This gate makes the assertion true.
+		//
+		// Scope is deliberately narrow: same id, same on-disk path, same
+		// bytes, and an existing registration that was itself file-backed.
+		// Anything else — rotated token, healed server host, a pre-built
+		// client, a first registration — falls through and rebuilds.
+		f.mu.RLock()
+		prev, registered := f.clusters[c.ID]
+		f.mu.RUnlock()
+		if registered && prev != nil &&
+			prev.kubeconfigSHA != "" && prev.kubeconfigSHA == kubeconfigSHA &&
+			prev.kubeconfigPath == c.KubeconfigPath {
+			f.log.Debug("k8scache: cluster already registered on identical kubeconfig — skipping informer rebuild (#5642)",
+				"cluster", c.ID, "kubeconfig", c.KubeconfigPath)
+			return nil
+		}
+
 		restCfg, err = clientcmd.RESTConfigFromKubeConfig(raw)
 		if err != nil {
 			return fmt.Errorf("parse kubeconfig %q: %w", c.KubeconfigPath, err)
@@ -708,6 +762,7 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 	cs := &clusterState{
 		id:             c.ID,
 		kubeconfigPath: c.KubeconfigPath, // #3987 — empty for pre-built-client (chroot/test) clusters; rescan-prune only evicts file-backed clusters whose file disappeared.
+		kubeconfigSHA:  kubeconfigSHA,    // #5642 — idempotence key; empty for pre-built-client refs, which always rebuild.
 		dyn:            dyn,
 		core:           core,
 		restCfg:        restCfg, // G95.1 (Refs #2642) — nil on pre-built-client test path; production kubeconfig path populates it for exec-stream SPDY dials.
@@ -1622,6 +1677,14 @@ func mustKind(r *Registry, name string) Kind {
 }
 
 // helpers ---------------------------------------------------------
+
+// sha256Hex fingerprints kubeconfig bytes for AddCluster's #5642
+// idempotence gate. Hex-encoded so it is safe to log; the digest of a
+// credential is not a credential.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
 
 func firstNonEmpty(m map[string]string, keys ...string) string {
 	for _, k := range keys {

--- a/products/catalyst/bootstrap/api/internal/k8scache/informer_rebuild_idempotence_5642_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/informer_rebuild_idempotence_5642_test.go
@@ -1,0 +1,217 @@
+// informer_rebuild_idempotence_5642_test.go — #5642 bounded-growth guard.
+//
+// Defect: AddCluster rebuilt the ENTIRE informer set every time it was
+// called for an already-registered cluster id, even when the kubeconfig
+// bytes were byte-identical to the running registration.
+//
+// That path is level-triggered and therefore fires forever:
+// runClusterMeshSteadyStateHeal re-forwards every on-disk secondary
+// kubeconfig on each 5-minute pass, and POST
+// /api/v1/sovereign/secondary-kubeconfig calls AddCluster unconditionally.
+// Measured live on hw292 (dep 1c56518035a83e03) 2026-08-03: two
+// "k8scache: cluster registered + informers started (runtime add)" lines
+// per 5-minute cycle for cluster 1c56518035a83e03-me-east-215-b-1, and
+// every per-kind ADDED counter in catalyst_k8scache_informer_events_total
+// for that cluster DOUBLED inside one 6.5-minute window (secret
+// 1212→2424, clusterrole 788→1576, policyreport 2118→4202, …) — i.e. a
+// full re-ADD sweep of the whole region-b object graph per rebuild.
+// Teardown of the superseded set did not reclaim: live heap climbed
+// ~1.2 MB/s and RSS ~1.7 MB/s until the 4Gi limit OOMKilled the Pod on a
+// ~60-minute metronome (restartCount 16 over 15h).
+//
+// The guard below is a BOUNDED-GROWTH assertion, not an exercise: it
+// drives AddCluster N times and asserts the number of informer sets
+// constructed for that cluster id stays at 1 rather than growing with N.
+// Against the unfixed AddCluster it reports N distinct sets.
+//
+// The second test is the opposite direction, so neither can pass
+// vacuously: a kubeconfig whose bytes CHANGED (token rotation #5210, the
+// #3991/#4000 EIP→private-SAN heal) must still rebuild.
+package k8scache
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// writeKubeconfig drops a syntactically-valid kubeconfig carrying `token`
+// into dir and returns its path. AddCluster parses it and builds clients
+// but never dials — these tests deliberately do not call Start().
+func writeKubeconfig(t *testing.T, path, token string) {
+	t.Helper()
+	body := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://10.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: u
+current-context: c
+users:
+- name: u
+  user:
+    token: %s
+`, token)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write kubeconfig %q: %v", path, err)
+	}
+}
+
+// registryTwoPlainKinds — two universally-present, non-Optional kinds, so
+// AddCluster takes the no-discovery-probe fast path (#5352) and the test
+// never touches the network.
+func registryTwoPlainKinds(t *testing.T) *Registry {
+	t.Helper()
+	r := NewRegistry()
+	if err := r.Add(Kind{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true}); err != nil {
+		t.Fatalf("registry add pod: %v", err)
+	}
+	if err := r.Add(Kind{Name: "namespace", GVR: schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}}); err != nil {
+		t.Fatalf("registry add namespace: %v", err)
+	}
+	return r
+}
+
+// clusterStateFor returns the live *clusterState pointer for id, or nil.
+// Pointer identity is the observable for "was a new informer set built".
+func clusterStateFor(f *Factory, id string) *clusterState {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.clusters[id]
+}
+
+// TestAddCluster_UnchangedKubeconfigDoesNotRebuild_BoundedGrowth is the
+// bounded-growth guard. Retained structure = the set of informer sets
+// constructed for one cluster id. It must NOT grow with the number of
+// re-registrations.
+func TestAddCluster_UnchangedKubeconfigDoesNotRebuild_BoundedGrowth(t *testing.T) {
+	const n = 25
+
+	dir := t.TempDir()
+	path := dir + "/dep-me-east-215-b-1.yaml"
+	writeKubeconfig(t, path, "static-token")
+
+	f, err := NewFactory(Config{Logger: quietLogger(), Registry: registryTwoPlainKinds(t)})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	ref := ClusterRef{ID: "dep-me-east-215-b-1", KubeconfigPath: path}
+
+	// Every distinct *clusterState observed is one informer set that was
+	// constructed. A set that stays at size 1 across n registrations is
+	// the property under test.
+	built := map[*clusterState]struct{}{}
+	for i := 0; i < n; i++ {
+		if err := f.AddCluster(ref); err != nil {
+			t.Fatalf("AddCluster call %d: %v", i+1, err)
+		}
+		cs := clusterStateFor(f, ref.ID)
+		if cs == nil {
+			t.Fatalf("AddCluster call %d: cluster not registered", i+1)
+		}
+		built[cs] = struct{}{}
+	}
+
+	if len(built) != 1 {
+		t.Fatalf("re-registering an UNCHANGED kubeconfig %d times built %d informer sets; want 1 — every extra set is a full re-ADD sweep whose predecessor is not reclaimed (#5642)",
+			n, len(built))
+	}
+
+	// The surviving set must still be a working registration, not a
+	// short-circuit that left the cluster half-registered.
+	cs := clusterStateFor(f, ref.ID)
+	if got := len(cs.informers); got != 2 {
+		t.Fatalf("surviving clusterState has %d informers; want 2", got)
+	}
+	if cs.kubeconfigSHA == "" {
+		t.Fatal("surviving clusterState carries no kubeconfig fingerprint; the gate can never match again")
+	}
+	if !containsClusterID(f.Clusters(), ref.ID) {
+		t.Fatalf("Clusters() = %v, want to contain %q", f.Clusters(), ref.ID)
+	}
+}
+
+// TestAddCluster_ChangedKubeconfigStillRebuilds is the opposite
+// direction. Without it the guard above would also pass on an AddCluster
+// that never rebuilds anything — which would strand a rotated token
+// (#5210) or a healed server host (#3991/#4000) on dead credentials.
+func TestAddCluster_ChangedKubeconfigStillRebuilds(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/dep-me-east-215-b-1.yaml"
+	writeKubeconfig(t, path, "first-token")
+
+	f, err := NewFactory(Config{Logger: quietLogger(), Registry: registryTwoPlainKinds(t)})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	ref := ClusterRef{ID: "dep-me-east-215-b-1", KubeconfigPath: path}
+	if err := f.AddCluster(ref); err != nil {
+		t.Fatalf("AddCluster (first): %v", err)
+	}
+	first := clusterStateFor(f, ref.ID)
+	if first == nil {
+		t.Fatal("first AddCluster did not register the cluster")
+	}
+	firstSHA := first.kubeconfigSHA
+
+	// Rotate the credential on disk — the #5210 shape.
+	writeKubeconfig(t, path, "rotated-token")
+	if err := f.AddCluster(ref); err != nil {
+		t.Fatalf("AddCluster (after rotation): %v", err)
+	}
+	second := clusterStateFor(f, ref.ID)
+	if second == nil {
+		t.Fatal("post-rotation AddCluster did not register the cluster")
+	}
+	if second == first {
+		t.Fatal("a CHANGED kubeconfig reused the old informer set; the rotated credential would never reach the reflectors (#5210)")
+	}
+	if second.kubeconfigSHA == firstSHA {
+		t.Fatalf("fingerprint did not change across a credential rotation (%q); the gate is keyed on something that is not the bytes", firstSHA)
+	}
+}
+
+// TestAddCluster_PrebuiltClientRefStillRebuilds — refs carrying a
+// pre-built DynamicClient (chroot self-register, test injection) have no
+// backing file and therefore no fingerprint. They must keep the old
+// unconditional behaviour rather than being silently short-circuited.
+func TestAddCluster_PrebuiltClientRefStillRebuilds(t *testing.T) {
+	podA := newPodWithLabels("default", "p", map[string]string{"app": "a"}, "")
+	dynA, coreA := fakeClientsWithRS(podA)
+
+	f, err := NewFactory(Config{Logger: quietLogger(), Registry: registryWithRSAndPod()})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	ref := ClusterRef{ID: "chroot", DynamicClient: dynA, CoreClient: coreA}
+	if err := f.AddCluster(ref); err != nil {
+		t.Fatalf("AddCluster (first): %v", err)
+	}
+	first := clusterStateFor(f, "chroot")
+	if first == nil {
+		t.Fatal("first AddCluster did not register the cluster")
+	}
+	if first.kubeconfigSHA != "" {
+		t.Fatalf("pre-built-client registration carries fingerprint %q; it has no backing file to fingerprint", first.kubeconfigSHA)
+	}
+	if err := f.AddCluster(ref); err != nil {
+		t.Fatalf("AddCluster (second): %v", err)
+	}
+	if clusterStateFor(f, "chroot") == first {
+		t.Fatal("pre-built-client re-registration was short-circuited; that path must keep rebuilding")
+	}
+}


### PR DESCRIPTION
## What this is

`catalyst-api` OOMKills on a ~60-minute metronome on hw292 (dep `1c56518035a83e03`). The framing in #5642 is the right one: **the request/limit are not the defect and were not touched.** The chart documents a designed steady state of 80-120Mi and live usage was ~32x that, so something was retaining memory that should not have been.

Root cause found, with live evidence. Fix is one early return.

## Root cause

`Factory.AddCluster` rebuilt the **entire 42-informer set** for a cluster id on every call — including when the kubeconfig bytes were byte-identical to the registration already running.

That call site is **level-triggered**, so it fires forever:

- `runClusterMeshSteadyStateHeal` (`internal/handler/phase1_watch.go`) re-forwards every on-disk secondary kubeconfig on each 5-minute pass
- `POST /api/v1/sovereign/secondary-kubeconfig` (`internal/handler/sovereign_secondary_kubeconfig.go:289`) called `AddCluster` unconditionally
- the mothership, the region-b node and the chroot each re-POST the same bytes

The comment on the re-forward in `phase1_watch.go` already **asserts** the property that was missing — *"The chroot's handler is idempotent (overwrite + AddCluster no-op)"*. It was not a no-op. This PR makes that sentence true.

## Live evidence (hw292, read-only, 2026-08-03 23:10-23:41Z)

**Rebuild cadence** — two per 5-minute cycle, one cluster:

```
23:30:31  k8scache: cluster registered + informers started (runtime add)  cluster=1c56518035a83e03-me-east-215-b-1 kinds=42
23:31:08  k8scache: cluster registered + informers started (runtime add)  cluster=1c56518035a83e03-me-east-215-b-1 kinds=42
23:35:38  k8scache: cluster registered + informers started (runtime add)  cluster=1c56518035a83e03-me-east-215-b-1 kinds=42
23:36:34  k8scache: cluster registered + informers started (runtime add)  cluster=1c56518035a83e03-me-east-215-b-1 kinds=42
```

**Each rebuild replays a full ADD sweep of region-b's whole object graph.** Every per-kind `ADDED` counter for that cluster doubled inside one 6.5-minute window:

```
secret         1212 -> 2424      clusterrole     788 -> 1576
policyreport   2118 -> 4202      crd             708 -> 1416
service         636 -> 1272      endpointslice   636 -> 1272
configmap       564 -> 1128      replicaset      380 ->  760
```

The primary cluster `1c56518035a83e03`, which is never re-POSTed, shows no such doubling — the control.

**The superseded informer set is not reclaimed.** `go_goroutines` steps up in the sample immediately after each rebuild and is flat between them:

```
23:29:54  935
23:30:31  <- rebuild
23:30:43  948   (+13)
23:31:08  <- rebuild
23:31:32  960   (+12)
23:32:21  959     no rebuild in window
23:33:10  957
23:33:59  959
23:34:48  959
23:35:38  <- rebuild
23:36:27  973   (+10)
23:36:34  <- rebuild
23:37:16  982   (+9)
```

Each leaked goroutine keeps its Indexer reachable, i.e. a full retained copy of that kind's objects. The resulting climb, measured off `/metrics` over 16 minutes:

```
          RSS      heap_inuse   next_gc/2 (live)   alloc_total
23:25   1323MB      967MB          649MB            20.9GB
23:31   2003MB     1723MB         1132MB            29.7GB
23:36   2187MB     1806MB         1064MB            36.8GB
23:41   2505MB     1971MB         1228MB            42.8GB
```

RSS +1.26 MB/s and live heap +0.6 MB/s, both monotonic; ~4Gi at roughly the 60-minute mark, which is exactly the observed OOM period (previous container ran 22:10:29 -> 23:10:01, 59.5 minutes).

## The fix

Fingerprint the kubeconfig bytes on `clusterState` and return early when the same cluster id is already registered from the same path on the same bytes.

Deliberately narrow. A **changed** kubeconfig still rebuilds, so token rotation (#5210) and the EIP -> private-SAN heal (#3991 / #4000) are unaffected, and pre-built-client refs (chroot self-register, tests) keep the old unconditional behaviour.

## Second change: pprof that can actually see a leaking process

`CATALYST_PPROF_ENABLED` (#5352) is read at process start and mounts chi's profiler on the **public** router. Turning it on rolls the Pod — which destroys the very heap that needed profiling. It cannot diagnose this defect class, and that is why this investigation had to reach its conclusion from `/metrics` counters rather than an `inuse_space` top-10.

`cmd/api/pprof_loopback.go` adds an always-on listener on its own mux and its own listener, bound to `127.0.0.1` only:

- not reachable through the public router on :8080
- not reachable from another Pod, from the Service, from the gateway, or from the network
- **no Service port, no ingress, no NodePort** added or required
- the only way in is `kubectl port-forward`, which attaches to the Pod's own netns; that already needs `pods/portforward` RBAC, and a caller holding it can equally `exec` in

A non-loopback bind address is **refused**, not honoured, so a future `":6060"` cannot silently widen it.

```
kubectl -n catalyst-system port-forward pod/$POD 6060:6060
go tool pprof -top -sample_index=inuse_space http://127.0.0.1:6060/debug/pprof/heap
```

## Gates

`go build ./...`, `go vet ./...`, `go test ./...` all clean in `products/catalyst/bootstrap/api` (the only module touched).

**Bounded-growth guard, shown failing on the unfixed code.** With only the idempotence gate removed and everything else identical:

```
=== RUN   TestAddCluster_UnchangedKubeconfigDoesNotRebuild_BoundedGrowth
    informer_rebuild_idempotence_5642_test.go:126: re-registering an UNCHANGED
    kubeconfig 25 times built 25 informer sets; want 1 — every extra set is a
    full re-ADD sweep whose predecessor is not reclaimed (#5642)
--- FAIL: TestAddCluster_UnchangedKubeconfigDoesNotRebuild_BoundedGrowth
=== RUN   TestAddCluster_ChangedKubeconfigStillRebuilds
--- PASS
=== RUN   TestAddCluster_PrebuiltClientRefStillRebuilds
--- PASS
```

25 calls -> 25 retained informer sets is linear in N; with the gate it is 1. The two opposite-direction tests keep the guard from passing vacuously — a "never rebuild" implementation fails them. The pprof guard was vacuity-checked the same way (neutering `requireLoopback` fails all five rejection cases).

## What was ruled out, so nobody re-treads it

- **Reflector churn on absent GVRs** — the #5352 premise that a reflector hot-looping on a 404 GVR "leaks memory until OOMKill". Refuted by a controlled experiment against a fake apiserver on the same client-go v0.36: 60s window, `absent` mode (404 LIST) `heapAlloc delta +0.00MB, live objects +11`; `listonly` mode (200 LIST + 405 WATCH, 200 items, 1200 handler calls) `heapAlloc delta +0.00MB, live objects +21`. The backoff is exponential, not a hot loop — 2 LISTs in 60s. The churn on hw292 is real and worth its own cleanup, but it is not this OOM.
- **Goroutine leak as a standalone cause** — goroutines are flat between rebuilds; they step only on a rebuild.
- **Prometheus label cardinality** — series count flat at 1735 / 1731 / 1731 across samples.
- **Informer Indexer growth** — `catalyst_k8scache_informer_cache_size` sum flat at 6531.
- **SSE subscriber leak** — `catalyst_k8scache_sse_clients_connected` flat at 2; the fanout is bounded drop-oldest.
- **File-descriptor / connection leak** — `process_open_fds` flat at 15-16.
- **Page cache / tmpfs accounting** — kubelet `stats/summary` reports `rssBytes` 634MB against `workingSetBytes` 665MB and `process_count: 1`; no memory-backed emptyDir, no child processes.

## Merger should know

- The observable that confirms this live is the **absence** of repeated `k8scache: cluster registered + informers started (runtime add)` lines for one cluster id. After deploy, that line should appear once per cluster per Pod lifetime, not twice per 5 minutes.
- No chart change, so no five-site lockstep and no `build-catalog.mjs` regeneration. The loopback listener needs no Service port.
- The teardown residue itself (~12 goroutines not unwinding per superseded informer set) is a second-order defect this PR removes the *driver* for rather than fixing directly. Worth a follow-up if `go_goroutines` still drifts after this lands.
- hw292 was treated as strictly read-only throughout: `get` / `describe` / `logs` / `top`, kubelet `stats/summary` via `--raw`, and `port-forward` for `/metrics`. Nothing was applied, patched, scaled or restarted.

Refs #5642
