### PR TITLE
fix(catalyst-api): reconcile the per-Org console gateway surface from the Organization CRs, in every region (Refs #5635)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1082,6 +1082,22 @@ func main() {
 	// on a ticker, and a no-op when the registry/dynamic-client isn't wired.
 	go h.ReconcileTenantRegistryFromOrgCRs(context.Background())
 
+	// #5635 — the SAME consolidation for the per-Org console GATEWAY surface
+	// (wildcard Certificate + console-https-<slug>/console-http-<slug>
+	// listener pair + the console HTTPRoute). That surface also has two
+	// producers, and only the BSS door (provisionOrgConsoleTLS) fans it out to
+	// every region — the marketplace-funnel Org's surface is written by the
+	// org-controller, which has no per-region client and never converges the
+	// second region. One shared EIP round-robins every region's envoy, so a
+	// host only one region can serve resets ~1/N of all customer connections
+	// (the split-write class #5394/#5406/#5414/#5416/#5511). This loop lists
+	// the Organization CRs — the one object BOTH doors create — and re-runs
+	// the multi-region emitter for each, making the fan-out unconditional
+	// (creation-path independent) and reconciled (an Org missing from a region
+	// converges rather than staying however it was first written). Every write
+	// is idempotent, so a healthy Sovereign sees zero object churn.
+	go h.ReconcileOrgConsoleTLSFromOrgCRs(context.Background())
+
 	// #4877 — level-triggered self-heal for the three OpenBao seed seams
 	// (newapi-admin-token / anthropic / per-Org mcp-bearer). Those seeds fire
 	// from EXACTLY ONE place (runOrganizationPipeline, once per HTTP Org-create,

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
@@ -199,6 +199,29 @@ type orgConsoleTLSNames struct {
 	HTTPSName    string // console-https-<slug> — listener name
 	HTTPName     string // console-http-<slug>  — listener name
 	RouteName    string // catalyst-ui-<slug>-<parent-dashed>
+
+	// RouteNameOrgController is the name the OTHER producer of this exact
+	// surface — the org-controller's reconcileTenantRoute
+	// (core/controllers/organization/internal/controller/tenant_route.go:141)
+	// — gives the console HTTPRoute for the SAME ConsoleHost:
+	// `catalyst-ui-<console-host-dashed>`, e.g.
+	// `catalyst-ui-console-uatco-omani-homes`.
+	//
+	// #5635: the two producers agree byte-for-byte on the Certificate name and
+	// on BOTH listener names (#4241 consolidated those) but they NEVER agreed
+	// on the HTTPRoute name — this emitter dashes the ORG ZONE, the
+	// org-controller dashes the CONSOLE HOST. Live on hw292: `uatco` (funnel
+	// door → org-controller) carried `catalyst-ui-console-uatco-omani-homes`
+	// while `r17probe` (BSS door → this emitter) carried
+	// `catalyst-ui-r17probe-omani-homes`. Creating ours on top of an existing
+	// org-controller route would attach a SECOND HTTPRoute to the same
+	// hostname on the same Gateway, whose overlapping `/` match is resolved by
+	// Gateway-API creation-timestamp precedence — deterministic but a
+	// duplicated surface that only one of the two teardown paths reaps
+	// (teardownTenantRoute targets the org-controller name only). So the
+	// emitter ADOPTS an existing org-controller route in a region instead of
+	// duplicating it — see ensureOrgConsoleHTTPRoute.
+	RouteNameOrgController string
 }
 
 // resolveOrgConsoleTLSNames computes the deterministic names/hosts from a
@@ -224,16 +247,18 @@ func resolveOrgConsoleTLSNames(rec store.OrganizationProvisionRecord) (orgConsol
 		return orgConsoleTLSNames{}, false
 	}
 	parentDashed := strings.ReplaceAll(parent, ".", "-")
+	consoleHost := "console." + slug + "." + parent
 	return orgConsoleTLSNames{
-		Slug:         slug,
-		ParentDomain: parent,
-		WildcardHost: "*." + slug + "." + parent,
-		OrgZone:      slug + "." + parent,
-		ConsoleHost:  "console." + slug + "." + parent,
-		CertName:     "org-wildcard-tls-" + slug + "-" + parentDashed,
-		HTTPSName:    "console-https-" + slug,
-		HTTPName:     "console-http-" + slug,
-		RouteName:    "catalyst-ui-" + slug + "-" + parentDashed,
+		Slug:                   slug,
+		ParentDomain:           parent,
+		WildcardHost:           "*." + slug + "." + parent,
+		OrgZone:                slug + "." + parent,
+		ConsoleHost:            consoleHost,
+		CertName:               "org-wildcard-tls-" + slug + "-" + parentDashed,
+		HTTPSName:              "console-https-" + slug,
+		HTTPName:               "console-http-" + slug,
+		RouteName:              "catalyst-ui-" + slug + "-" + parentDashed,
+		RouteNameOrgController: "catalyst-ui-" + strings.ReplaceAll(consoleHost, ".", "-"),
 	}, true
 }
 
@@ -773,13 +798,55 @@ func ensureOrgConsoleListener(ctx context.Context, dyn dynamic.Interface, names 
 	return nil
 }
 
+// orgConsoleRouteAlreadyServed reports whether THIS region already carries the
+// org-controller's console HTTPRoute for the same ConsoleHost
+// (names.RouteNameOrgController). #5635: both producers emit an equivalent
+// route under different names, so creating ours on top would duplicate the
+// surface for one hostname. `true` means adopt-and-skip; any read error is
+// reported as `false` so a transient apiserver failure degrades to the
+// pre-#5635 behaviour (write our own route) rather than to no route at all.
+func orgConsoleRouteAlreadyServed(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames) bool {
+	if names.RouteNameOrgController == "" || names.RouteNameOrgController == names.RouteName {
+		return false
+	}
+	existing, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Get(ctx, names.RouteNameOrgController, metav1.GetOptions{})
+	if err != nil || existing == nil {
+		return false
+	}
+	// Presence alone is not enough — assert it actually serves OUR console
+	// host, so a same-named route for a different host never suppresses ours.
+	hosts, found, err := unstructured.NestedStringSlice(existing.Object, "spec", "hostnames")
+	if err != nil || !found {
+		return false
+	}
+	for _, h := range hosts {
+		if strings.EqualFold(strings.TrimSpace(h), names.ConsoleHost) {
+			return true
+		}
+	}
+	return false
+}
+
 // ensureOrgConsoleHTTPRoute Creates the per-Org console HTTPRoute (idempotent
 // — AlreadyExists = success). A faithful clone of the canonical catalyst-ui
 // HTTPRoute (catalyst-api for /readyz, /healthz, /auth/handover, /api/,
 // /catalyst/; catalyst-ui for /), re-hostnamed to console.<slug>.<parent> and
 // parented on cilium-gateway-console. Lands in catalyst-system alongside the
 // catalyst-ui/catalyst-api Services it references (no ReferenceGrant needed).
+//
+// #5635: skipped in a region that already carries the org-controller's
+// equivalent route for the same ConsoleHost (see orgConsoleRouteAlreadyServed)
+// — the region is served, and a second route for one hostname is a duplicated
+// surface only one teardown path reaps.
 func ensureOrgConsoleHTTPRoute(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
+	if orgConsoleRouteAlreadyServed(ctx, dyn, names) {
+		return nil
+	}
+	return createOrgConsoleHTTPRoute(ctx, dyn, names, rec)
+}
+
+func createOrgConsoleHTTPRoute(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
 	apiBackend := func() []any {
 		return []any{map[string]any{
 			"group": "", "kind": "Service",

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_dupe_5635_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_dupe_5635_test.go
@@ -1,0 +1,178 @@
+// org_console_tls_dupe_5635_test.go — #5635, producer-parity half.
+//
+// The per-Org console gateway surface has TWO producers that agree on the
+// Certificate name and on BOTH listener names but NOT on the console
+// HTTPRoute's name:
+//
+//	catalyst-api  org_console_tls.go:resolveOrgConsoleTLSNames
+//	              → catalyst-ui-<slug>-<parent-dashed>
+//	                e.g. catalyst-ui-r17probe-omani-homes
+//	org-controller core/controllers/organization/internal/controller/
+//	              tenant_route.go:141 → "catalyst-ui-" + dnsDashed(hostname)
+//	              → catalyst-ui-console-<slug>-<parent-dashed>
+//	                e.g. catalyst-ui-console-uatco-omani-homes
+//
+// Both were observed live in ONE catalyst-system on hw292 (dep
+// 1c56518035a83e03, 2026-08-03), distinguishable by their labels
+// (`app.kubernetes.io/managed-by` = catalyst-api vs catalyst). Once
+// catalyst-api reconciles the surface for EVERY Org (org_console_tls_reconcile.go)
+// it necessarily meets Orgs the org-controller already wrote a route for, and
+// creating its own on top would attach a SECOND HTTPRoute to the same hostname
+// on the same Gateway — a duplicated surface that only one of the two teardown
+// paths reaps (teardownTenantRoute targets the org-controller name only, which
+// is exactly why hw292's region-A still carried an orphan
+// catalyst-ui-r17probe-omani-homes after that Org was deleted).
+//
+// This file deliberately uses ONLY symbols that predate the #5635 fix, so it
+// compiles against the unfixed tree and fails there at RUNTIME (two routes for
+// one console host) rather than at build time.
+
+package handler
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgControllerConsoleRoute builds the console HTTPRoute exactly as the
+// org-controller's reconcileTenantRoute renders it: name
+// `catalyst-ui-<console-host-dashed>`, namespace catalyst-system, the same
+// hostname, and the org-controller's own managed-by labels. Hand-written from
+// tenant_route.go rather than derived from a shared helper so the test pins
+// the CROSS-PROCESS contract literally — a rename on either side must break it.
+func orgControllerConsoleRoute(name, host string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": catalystConsoleNamespace,
+			"labels": map[string]any{
+				"app.kubernetes.io/managed-by": "catalyst",
+				"openova.io/managed-by":        "organization-controller",
+			},
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{
+				"name": consoleGatewayName, "namespace": consoleGatewayNamespace,
+			}},
+			"hostnames": []any{host},
+			"rules": []any{map[string]any{
+				"matches": []any{map[string]any{
+					"path": map[string]any{"type": "PathPrefix", "value": "/"},
+				}},
+				"backendRefs": []any{map[string]any{"name": catalystUIServiceName, "port": int64(80)}},
+			}},
+		},
+	}}
+}
+
+// TestProvisionOrgConsoleTLS_AdoptsOrgControllerRoute_NoDuplicateSurface —
+// #5635. When a region ALREADY carries the org-controller's console route for
+// this Org's console host, the catalyst-api emitter must ADOPT it (leave the
+// region served by exactly ONE route), not add a second route for the same
+// hostname on the same Gateway.
+//
+// Fails on the unfixed tree: ensureOrgConsoleHTTPRoute created
+// `catalyst-ui-acme-omani-homes` unconditionally, so the host ended up with 2
+// routes.
+func TestProvisionOrgConsoleTLS_AdoptsOrgControllerRoute_NoDuplicateSurface(t *testing.T) {
+	dyn := fakeDynForConsoleTLS(t)
+	h := newConsoleTLSHandler(t, dyn)
+	ctx := context.Background()
+
+	const (
+		host          = "console.acme.omani.homes"
+		orgCtrlRoute  = "catalyst-ui-console-acme-omani-homes" // tenant_route.go:141
+		catalystRoute = "catalyst-ui-acme-omani-homes"         // org_console_tls.go RouteName
+	)
+
+	// The funnel door got here first: the org-controller's route is live.
+	if _, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Create(ctx, orgControllerConsoleRoute(orgCtrlRoute, host), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed org-controller console route: %v", err)
+	}
+
+	h.provisionOrgConsoleTLS(ctx, store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		OTECHFQDN:      "hw292.omani.works",
+	})
+
+	list, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HTTPRoutes: %v", err)
+	}
+	serving := []string{}
+	for i := range list.Items {
+		hosts, _, _ := unstructured.NestedStringSlice(list.Items[i].Object, "spec", "hostnames")
+		for _, hh := range hosts {
+			if hh == host {
+				serving = append(serving, list.Items[i].GetName())
+				break
+			}
+		}
+	}
+	if len(serving) != 1 {
+		t.Fatalf("console host %s is served by %d HTTPRoutes %v, want exactly 1 (the org-controller's %s adopted, not duplicated by %s)",
+			host, len(serving), serving, orgCtrlRoute, catalystRoute)
+	}
+	if serving[0] != orgCtrlRoute {
+		t.Errorf("surviving route = %q, want the pre-existing org-controller route %q", serving[0], orgCtrlRoute)
+	}
+
+	// Vacuity guard, the other direction: with NO org-controller route present
+	// the emitter MUST still write its own — adoption may never degrade into
+	// "never emit a route".
+	dyn2 := fakeDynForConsoleTLS(t)
+	h2 := newConsoleTLSHandler(t, dyn2)
+	h2.provisionOrgConsoleTLS(ctx, store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		OTECHFQDN:      "hw292.omani.works",
+	})
+	if _, err := dyn2.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Get(ctx, catalystRoute, metav1.GetOptions{}); err != nil {
+		t.Fatalf("vacuity: with no org-controller route the emitter must create %s, got: %v", catalystRoute, err)
+	}
+}
+
+// TestProvisionOrgConsoleTLS_DoesNotAdoptRouteForAnotherHost — presence of a
+// same-named route is not enough; it must actually serve THIS Org's console
+// host. A stale/foreign route under the org-controller's name must NOT
+// suppress the emitter's own route, or a single misnamed object would silently
+// close the customer door.
+func TestProvisionOrgConsoleTLS_DoesNotAdoptRouteForAnotherHost(t *testing.T) {
+	dyn := fakeDynForConsoleTLS(t)
+	h := newConsoleTLSHandler(t, dyn)
+	ctx := context.Background()
+
+	if _, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Create(ctx, orgControllerConsoleRoute("catalyst-ui-console-acme-omani-homes",
+			"console.somebodyelse.omani.homes"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed foreign-host route: %v", err)
+	}
+
+	h.provisionOrgConsoleTLS(ctx, store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		OTECHFQDN:      "hw292.omani.works",
+	})
+
+	if _, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Get(ctx, "catalyst-ui-acme-omani-homes", metav1.GetOptions{}); err != nil {
+		t.Fatalf("emitter must still write its own route when the same-named route serves a different host: %v", err)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
@@ -1,0 +1,219 @@
+// org_console_tls_reconcile.go — #5635. Reconcile the per-Org console gateway
+// surface from the Organization CRs, in EVERY region, for EVERY Org.
+//
+// THE GAP this file closes.
+//
+// The per-Org console gateway surface (wildcard Certificate + the
+// `console-https-<slug>`/`console-http-<slug>` listener pair on
+// cilium-gateway-console + the console HTTPRoute for
+// `console.<slug>.<parent>`) has TWO producers, and only one of them fans the
+// surface out to every region:
+//
+//   - BSS door — catalyst-api `provisionOrgConsoleTLS` (org_console_tls.go),
+//     multi-region since #5511/PR #5524. Fires from
+//     runOrganizationPipeline step 7 and HandleReconcileOrganization ONLY,
+//     both keyed on catalyst-api's OWN OrganizationProvisionRecord store.
+//   - MARKETPLACE-funnel door — the org-controller's reconcileTenantConsoleTLS
+//     + reconcileTenantRoute (core/controllers/organization/…), which run on
+//     every Organization-CR reconcile but write to the org-controller's OWN
+//     cluster only. There is no per-region client seam in that process.
+//
+// A funnel Org never runs the catalyst-api pipeline (tenant-service →
+// `tenant.created` → provisioning-service `createOrganizationCR`, which stamps
+// `openova.io/source: tenant-created-event` on the CR — organization_create.go:162).
+// So its surface is written by the single-region producer and NOTHING ever
+// converges it into the second region. Proven live on hw292
+// (dep 1c56518035a83e03, 2026-08-03):
+//
+//	catalyst-system HTTPRoutes        region-A                     region-B
+//	console.uatco.omani.homes    catalyst-ui-console-uatco-…     ABSENT
+//	                             (managed-by=catalyst,
+//	                              openova.io/managed-by=
+//	                              organization-controller)
+//	console.r17probe.omani.homes catalyst-ui-r17probe-…          PRESENT
+//	                             (managed-by=catalyst-api)
+//
+// One shared EIP round-robins both regions' cilium-envoy, so a per-Org console
+// host that only one region can serve resets ~1/N of all customer connections
+// — the per-region split-write class (#5394/#5406/#5414/#5416/#5511), reached
+// here through a PRODUCER SPLIT rather than through a missing fan-out.
+//
+// THE FIX — the #4179 consolidation, applied to the gateway surface. The
+// Organization CR is the ONE object both doors create. catalyst-api is the ONE
+// process that holds a per-region client for every region (h.k8sCache, the
+// seam #5524 already wired into orgConsoleTLSTargets). So catalyst-api
+// reconciles the surface FROM the Organization CRs: list every Org CR, derive
+// the same free-subdomain provisioning record either door would have produced,
+// and run the existing multi-region provisionOrgConsoleTLS. That makes the
+// fan-out
+//
+//	UNCONDITIONAL — keyed on the CR, so the funnel door and the BSS door are
+//	                covered by one seam, and
+//	RECONCILED    — re-run on a ticker, so an Org whose surface is missing
+//	                from a region CONVERGES instead of staying however it was
+//	                first written (the backfill direction; write-once was the
+//	                defect shape).
+//
+// Every write it performs is idempotent: the Certificate is Create/
+// AlreadyExists, the listener pair is a per-Org-field-manager SSA whose merge
+// is a no-op when the spec matches, the HTTPRoute is Create/AlreadyExists and
+// is ADOPTED rather than duplicated when the org-controller's equivalent route
+// already serves that region (#5635, orgConsoleRouteAlreadyServed). A healthy
+// Sovereign therefore sees zero object churn from this loop.
+//
+// Best-effort throughout: a List failure logs and retries on the next tick; a
+// per-Org failure is logged inside provisionOrgConsoleTLS and never starves
+// the remaining Orgs; out-of-cluster / CI (no dynamic client) is a logged skip.
+// RBAC is already granted — the ClusterRole carries organizations get/list/
+// watch, certificates get/list/watch+create, gateways get/list/watch+patch and
+// httproutes get/list/watch+create (products/catalyst/chart/templates/
+// clusterrole-cutover-driver.yaml), so this adds no chart surface.
+
+package handler
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgConsoleTLSReconcileInterval is the steady-state cadence at which
+// catalyst-api re-converges every Org's console gateway surface across every
+// region. Deliberately slower than the 60s tenant-registry loop: each Org's
+// pass ends in the #5511 listener-admission read-back, which is near-instant
+// on a healthy Gateway but is bounded by orgConsoleListenerAdmitBudget (60s)
+// when a region's cilium-operator has missed the append. Five minutes keeps a
+// missing region's console door closed for at most one interval while leaving
+// the apiserver load negligible (one List + a handful of no-op Gets per Org).
+// A package var, not a const, so tests shrink it.
+var orgConsoleTLSReconcileInterval = 5 * time.Minute
+
+// ReconcileOrgConsoleTLSFromOrgCRs runs the per-Org console gateway surface
+// reconcile loop until ctx is cancelled. It performs one pass immediately (so
+// a catalyst-api restart re-converges every existing Org — including every
+// funnel Org the BSS pipeline never saw — before the first tick) and then
+// re-converges on a ticker. Wired from main.go as a background goroutine,
+// mirroring ReconcileTenantRegistryFromOrgCRs's async-startup idiom.
+func (h *Handler) ReconcileOrgConsoleTLSFromOrgCRs(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	h.reconcileOrgConsoleTLSOnce(ctx)
+	ticker := time.NewTicker(orgConsoleTLSReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.reconcileOrgConsoleTLSOnce(ctx)
+		}
+	}
+}
+
+// reconcileOrgConsoleTLSOnce lists every Organization CR and re-ensures each
+// pool-parent Org's console gateway surface in EVERY region. Idempotent +
+// best-effort: a CR that cannot produce a free-subdomain surface is skipped
+// (BYO / no pool parent / invalid slug — resolveOrgConsoleTLSNames decides,
+// so this loop and the two doors can never drift onto different criteria), a
+// List failure is logged and the next tick retries.
+func (h *Handler) reconcileOrgConsoleTLSOnce(ctx context.Context) {
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		// Out-of-cluster / CI: no apiserver to list from. On a real Sovereign
+		// this branch never fires.
+		h.log.Info("org-console-tls-reconcile: skipped — no in-cluster dynamic client",
+			"err", err)
+		return
+	}
+
+	list, err := deps.dyn.Resource(organizationGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("org-console-tls-reconcile: list Organizations failed — will retry next tick",
+			"err", err)
+		return
+	}
+
+	sovereignFQDN := strings.TrimSpace(h.orgTenantDeps.OTECHFQDN)
+	reconciled, skipped := 0, 0
+	for i := range list.Items {
+		rec, ok := orgConsoleTLSRecordFromOrgCR(&list.Items[i], sovereignFQDN)
+		if !ok {
+			skipped++
+			continue
+		}
+		// The SAME multi-region emitter the BSS door runs — host region plus
+		// every secondary registered in h.k8sCache (orgConsoleTLSTargets),
+		// with the #5511 per-region listener-admission read-back. Nothing
+		// about it is create-time-only, which is precisely why re-running it
+		// here backfills a region the Org's original producer never reached.
+		h.provisionOrgConsoleTLS(ctx, rec)
+		reconciled++
+	}
+	if reconciled > 0 {
+		h.log.Info("org-console-tls-reconcile: pass complete — per-Org console gateway surface re-ensured in every region (#5635)",
+			"orgs", len(list.Items), "reconciled", reconciled, "skipped", skipped)
+	}
+}
+
+// orgConsoleTLSRecordFromOrgCR builds the free-subdomain provisioning record
+// for an Organization CR — the input resolveOrgConsoleTLSNames consumes — so
+// an Org minted by EITHER door yields byte-identical resource names.
+//
+// Mirrors tenantRegistrationFromOrgCR's derivation (tenant_registry_reconcile.go)
+// field-for-field: slug from `spec.slug` falling back to the CR name, pool
+// parent from `spec.tenantPublic.parentDomain`, subdomain from
+// `spec.tenantPublic.subdomain` falling back to the slug — the same three
+// fields the org-controller's own orgConsoleTLSNamesForOrg reads.
+//
+// Returns (zero, false) when the CR cannot produce a pool-parent console
+// surface: no parentDomain (a single-domain Org rides the Sovereign apex
+// wildcard, which already covers console.<slug>.<sovFQDN> — no per-Org
+// resource applies) or a slug that fails orgSlugRE. DomainMode is set to
+// free-subdomain because a pool parentDomain on the CR IS the free-subdomain
+// case; a BYO Org carries its own per-host Certificate and a CNAME and never
+// sets tenantPublic.parentDomain.
+func orgConsoleTLSRecordFromOrgCR(obj *unstructured.Unstructured, sovereignFQDN string) (store.OrganizationProvisionRecord, bool) {
+	slug := strings.ToLower(strings.TrimSpace(nestedString(obj.Object, "spec", "slug")))
+	if slug == "" {
+		slug = strings.ToLower(strings.TrimSpace(obj.GetName()))
+	}
+
+	parentDomain := strings.ToLower(strings.TrimSpace(
+		nestedString(obj.Object, "spec", "tenantPublic", "parentDomain")))
+	if parentDomain == "" {
+		return store.OrganizationProvisionRecord{}, false
+	}
+
+	subdomain := strings.ToLower(strings.TrimSpace(
+		nestedString(obj.Object, "spec", "tenantPublic", "subdomain")))
+	if subdomain == "" {
+		subdomain = slug
+	}
+
+	organizationID := strings.TrimSpace(obj.GetLabels()["openova.io/tenant-id"])
+	if organizationID == "" {
+		organizationID = slug
+	}
+
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID: organizationID,
+		Subdomain:      subdomain,
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   parentDomain,
+		OTECHFQDN:      sovereignFQDN,
+		CompanyName:    strings.TrimSpace(nestedString(obj.Object, "spec", "displayName")),
+	}
+	// Single decision point: the emitter's own resolver decides whether this
+	// Org gets a surface, so the reconcile loop can never accept an Org the
+	// emitter would then skip (or vice versa).
+	if _, ok := resolveOrgConsoleTLSNames(rec); !ok {
+		return store.OrganizationProvisionRecord{}, false
+	}
+	return rec, true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile_5635_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile_5635_test.go
@@ -1,0 +1,348 @@
+// org_console_tls_reconcile_5635_test.go — #5635, the two locks the issue asks
+// for:
+//
+//  1. the per-Org console gateway surface is emitted for BOTH creation paths
+//     (marketplace funnel and BSS/direct), in EVERY region; and
+//  2. a SECOND reconcile of an Org whose region-B surface is missing ADDS it
+//     — the backfill direction, which is what "reconciled, not write-once"
+//     means.
+//
+// Both drive the CR-keyed reconcile pass, because the defect is at the trigger
+// level: provisionOrgConsoleTLS already fans out to every region (#5511 / PR
+// #5524), but it only ever ran for Orgs in catalyst-api's OWN provisioning
+// store. A funnel Org has no such record — its CR is minted by the
+// provisioning service (`openova.io/source: tenant-created-event`,
+// core/services/provisioning/handlers/organization_create.go:162) and its
+// surface is written by the org-controller, which has no per-region client.
+
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+)
+
+// fakeDynForOrgConsoleReconcile is fakeDynForConsoleTLSWithApexPorts plus the
+// Organization GVR, so the reconcile pass can List Organization CRs off the
+// same fake the surface is written to. The Gateway is seeded through an
+// explicit-GVR Create for the "gatewaies" pluralizer reason documented on
+// fakeDynForConsoleTLSWithApexPorts.
+func fakeDynForOrgConsoleReconcile(t *testing.T, orgs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		certificateGVR:    "CertificateList",
+		consoleGatewayGVR: "GatewayList",
+		httpRouteGVR:      "HTTPRouteList",
+		organizationGVR(): "OrganizationList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+	ctx := context.Background()
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name":      consoleGatewayName,
+			"namespace": consoleGatewayNamespace,
+		},
+		"spec": map[string]any{
+			"gatewayClassName": "cilium",
+			"listeners": []any{
+				map[string]any{"name": "console-https", "port": int64(8443), "protocol": "HTTPS", "hostname": "*.hw292.omani.works"},
+				map[string]any{"name": "console-http", "port": int64(8080), "protocol": "HTTP", "hostname": "*.hw292.omani.works"},
+			},
+		},
+	}}
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Create(ctx, gw, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed console gateway: %v", err)
+	}
+	for _, o := range orgs {
+		if _, err := dyn.Resource(organizationGVR()).Create(ctx, o, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed Organization CR %s: %v", o.GetName(), err)
+		}
+	}
+	return dyn
+}
+
+// funnelOrgCR — an Organization CR shaped exactly like the marketplace-funnel
+// door produces (organization_create.go:162 stamps
+// `openova.io/source: tenant-created-event`; hw292's `uatco` carried precisely
+// this). No catalyst-api provisioning record exists for such an Org.
+func funnelOrgCR(slug, parentDomain string) *unstructured.Unstructured {
+	return orgCRWithSource(slug, parentDomain, "tenant-created-event")
+}
+
+// bssOrgCR — an Organization CR shaped like the BSS/direct door produces
+// (createOrgOrganizationCR). hw292's `r17probe` came through this door.
+func bssOrgCR(slug, parentDomain string) *unstructured.Unstructured {
+	return orgCRWithSource(slug, parentDomain, "org-tenant-pipeline")
+}
+
+func orgCRWithSource(slug, parentDomain, source string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "orgs.openova.io/v1",
+		"kind":       "Organization",
+		"metadata": map[string]any{
+			"name": slug,
+			"labels": map[string]any{
+				"openova.io/source":    source,
+				"openova.io/tenant-id": "tid-" + slug,
+			},
+		},
+		"spec": map[string]any{
+			"slug":         slug,
+			"displayName":  slug + " Co",
+			"sovereignRef": "hw292.omani.works",
+			"tenantPublic": map[string]any{
+				"parentDomain": parentDomain,
+				"subdomain":    slug,
+			},
+		},
+	}}
+}
+
+// consoleSurfacePresent reports whether a region cluster carries BOTH halves of
+// an Org's console gateway surface: a Gateway listener SSA patch was issued for
+// this Org's listener pair, and an HTTPRoute in catalyst-system serves the Org's
+// console host (under EITHER producer's name — the gateway edge does not care
+// which name serves the host, only that one does).
+func consoleSurfacePresent(t *testing.T, dyn *dynamicfake.FakeDynamicClient, consoleHost string) (listener bool, route string) {
+	t.Helper()
+	for _, a := range dyn.Actions() {
+		if a.GetResource() == consoleGatewayGVR && a.GetVerb() == "patch" {
+			if pa, ok := a.(interface{ GetName() string }); ok && pa.GetName() == consoleGatewayName {
+				listener = true
+			}
+		}
+	}
+	list, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HTTPRoutes: %v", err)
+	}
+	for i := range list.Items {
+		hosts, _, _ := unstructured.NestedStringSlice(list.Items[i].Object, "spec", "hostnames")
+		for _, h := range hosts {
+			if h == consoleHost {
+				return listener, list.Items[i].GetName()
+			}
+		}
+	}
+	return listener, ""
+}
+
+// newReconcileHandler wires a Handler whose host region is hostDyn/hostCore and
+// whose k8sCache registers one secondary region (secDyn/secCore) on a chroot,
+// which is the shape orgConsoleTLSTargets fans out over.
+func newReconcileHandler(t *testing.T,
+	hostDyn, secDyn *dynamicfake.FakeDynamicClient,
+	hostCore, secCore *k8sfake.Clientset,
+) *Handler {
+	t.Helper()
+	h := newConsoleTLSHandlerWithCore(t, hostDyn, hostCore)
+	h.SetOrganizationDeps(OrganizationDeps{OTECHFQDN: "hw292.omani.works"})
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clusters: []k8scache.ClusterRef{
+			{ID: "dep292", DynamicClient: hostDyn, CoreClient: hostCore},
+			{ID: "dep292-me-east-215-b-1", DynamicClient: secDyn, CoreClient: secCore},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+	return h
+}
+
+func issuedOrgWildcardSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: consoleCertNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("issued"), "tls.key": []byte("key")},
+	}
+}
+
+// TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths — #5635 lock 1.
+//
+// Two Orgs, one per creation path, exist ONLY as Organization CRs (no
+// catalyst-api provisioning record for either — that is the whole point: the
+// funnel door never writes one). After a single reconcile pass BOTH Orgs' console
+// surface must be present in BOTH regions.
+//
+// On the unfixed tree there is no CR-keyed trigger at all, so a funnel Org's
+// surface is never emitted by catalyst-api in ANY region.
+func TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works") // chroot gate for the fan-out
+
+	funnel := funnelOrgCR("uatco", "omani.homes")
+	direct := bssOrgCR("r17probe", "omani.homes")
+
+	hostDyn := fakeDynForOrgConsoleReconcile(t, funnel, direct)
+	secDyn := fakeDynForOrgConsoleReconcile(t)
+	hostCore := k8sfake.NewSimpleClientset(
+		issuedOrgWildcardSecret("org-wildcard-tls-uatco-omani-homes"),
+		issuedOrgWildcardSecret("org-wildcard-tls-r17probe-omani-homes"),
+	)
+	secCore := k8sfake.NewSimpleClientset()
+
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	for _, tc := range []struct{ path, host, cert string }{
+		{"marketplace-funnel", "console.uatco.omani.homes", "org-wildcard-tls-uatco-omani-homes"},
+		{"bss-direct", "console.r17probe.omani.homes", "org-wildcard-tls-r17probe-omani-homes"},
+	} {
+		for regionName, dyn := range map[string]*dynamicfake.FakeDynamicClient{
+			"region-a-host": hostDyn, "region-b-secondary": secDyn,
+		} {
+			listener, route := consoleSurfacePresent(t, dyn, tc.host)
+			if !listener {
+				t.Errorf("[%s/%s] no Gateway listener apply for %s", tc.path, regionName, tc.host)
+			}
+			if route == "" {
+				t.Errorf("[%s/%s] no HTTPRoute serves %s", tc.path, regionName, tc.host)
+			}
+		}
+		// The issued cert secret must be mirrored into the secondary region —
+		// a listener whose certificateRef resolves to nothing still closes the
+		// door (per-region secret-split class #5394/#5406/#5414/#5416).
+		if _, err := secCore.CoreV1().Secrets(consoleCertNamespace).
+			Get(context.Background(), tc.cert, metav1.GetOptions{}); err != nil {
+			t.Errorf("[%s] cert secret %s not mirrored into the secondary region: %v", tc.path, tc.cert, err)
+		}
+	}
+}
+
+// TestReconcileOrgConsoleTLSFromOrgCRs_BackfillsMissingSecondaryRegion —
+// #5635 lock 2, the backfill direction.
+//
+// This is hw292's `uatco` exactly: region-A already carries the full surface
+// written by the ORG-CONTROLLER (its own route name, its listener pair, the
+// issued cert), region-B carries nothing, and the Org has no catalyst-api
+// provisioning record. A reconcile pass over an ALREADY-EXISTING Org must ADD
+// the missing region-B surface — write-once is the defect shape.
+//
+// It also asserts the pass does not duplicate region-A's surface: the region
+// keeps exactly the one route it already had.
+func TestReconcileOrgConsoleTLSFromOrgCRs_BackfillsMissingSecondaryRegion(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+
+	const (
+		host         = "console.uatco.omani.homes"
+		orgCtrlRoute = "catalyst-ui-console-uatco-omani-homes" // tenant_route.go:141
+		certName     = "org-wildcard-tls-uatco-omani-homes"
+	)
+	ctx := context.Background()
+
+	hostDyn := fakeDynForOrgConsoleReconcile(t, funnelOrgCR("uatco", "omani.homes"))
+	secDyn := fakeDynForOrgConsoleReconcile(t)
+
+	// Region-A pre-state: the org-controller already served this Org.
+	if _, err := hostDyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Create(ctx, orgControllerConsoleRoute(orgCtrlRoute, host), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed org-controller console route: %v", err)
+	}
+	hostCore := k8sfake.NewSimpleClientset(issuedOrgWildcardSecret(certName))
+	secCore := k8sfake.NewSimpleClientset()
+
+	// Region-B pre-state assertion — the gap must actually be there, or the
+	// backfill claim is vacuous.
+	if _, route := consoleSurfacePresent(t, secDyn, host); route != "" {
+		t.Fatalf("vacuity: secondary region already served %s before the reconcile (route %s)", host, route)
+	}
+
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+	h.reconcileOrgConsoleTLSOnce(ctx)
+
+	listener, route := consoleSurfacePresent(t, secDyn, host)
+	if !listener {
+		t.Errorf("backfill: no Gateway listener apply reached the secondary region for %s", host)
+	}
+	if route == "" {
+		t.Fatalf("backfill: secondary region still has NO HTTPRoute serving %s after a reconcile pass", host)
+	}
+	if _, err := secCore.CoreV1().Secrets(consoleCertNamespace).Get(ctx, certName, metav1.GetOptions{}); err != nil {
+		t.Errorf("backfill: cert secret %s not mirrored into the secondary region: %v", certName, err)
+	}
+
+	// Region-A must be converged, not duplicated.
+	list, err := hostDyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list host-region HTTPRoutes: %v", err)
+	}
+	serving := []string{}
+	for i := range list.Items {
+		hosts, _, _ := unstructured.NestedStringSlice(list.Items[i].Object, "spec", "hostnames")
+		for _, hh := range hosts {
+			if hh == host {
+				serving = append(serving, list.Items[i].GetName())
+				break
+			}
+		}
+	}
+	if len(serving) != 1 || serving[0] != orgCtrlRoute {
+		t.Errorf("host region routes for %s = %v, want exactly [%s] (adopted, not duplicated)", host, serving, orgCtrlRoute)
+	}
+}
+
+// TestOrgConsoleTLSRecordFromOrgCR_SkipCases — the CR→record derivation must
+// refuse exactly what the emitter would refuse, so the loop can never accept an
+// Org the emitter then skips. No pool parentDomain (single-domain Org, covered
+// by the Sovereign apex wildcard) and a slug that fails orgSlugRE both yield
+// no record.
+func TestOrgConsoleTLSRecordFromOrgCR_SkipCases(t *testing.T) {
+	noParent := funnelOrgCR("acme", "")
+	unstructured.RemoveNestedField(noParent.Object, "spec", "tenantPublic", "parentDomain")
+	cases := []struct {
+		name string
+		obj  *unstructured.Unstructured
+	}{
+		{"no-pool-parent", noParent},
+		{"invalid-slug-too-short", funnelOrgCR("ab", "omani.homes")},
+		{"invalid-slug-leading-digit", funnelOrgCR("1acme", "omani.homes")},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := orgConsoleTLSRecordFromOrgCR(tc.obj, "hw292.omani.works"); ok {
+				t.Errorf("expected skip for %s, got a provisioning record", tc.name)
+			}
+		})
+	}
+	// Positive control — a well-formed funnel Org DOES produce a record whose
+	// names match what the org-controller emits for the same CR.
+	rec, ok := orgConsoleTLSRecordFromOrgCR(funnelOrgCR("uatco", "omani.homes"), "hw292.omani.works")
+	if !ok {
+		t.Fatal("well-formed funnel Org produced no record")
+	}
+	names, ok := resolveOrgConsoleTLSNames(rec)
+	if !ok {
+		t.Fatal("record did not resolve to console TLS names")
+	}
+	if names.ConsoleHost != "console.uatco.omani.homes" {
+		t.Errorf("ConsoleHost = %q, want console.uatco.omani.homes", names.ConsoleHost)
+	}
+	if names.CertName != "org-wildcard-tls-uatco-omani-homes" {
+		t.Errorf("CertName = %q, want org-wildcard-tls-uatco-omani-homes", names.CertName)
+	}
+	if names.HTTPSName != "console-https-uatco" || names.HTTPName != "console-http-uatco" {
+		t.Errorf("listener names = %q/%q, want console-https-uatco/console-http-uatco", names.HTTPSName, names.HTTPName)
+	}
+	if names.RouteNameOrgController != "catalyst-ui-console-uatco-omani-homes" {
+		t.Errorf("RouteNameOrgController = %q, want catalyst-ui-console-uatco-omani-homes (tenant_route.go:141)", names.RouteNameOrgController)
+	}
+}


### PR DESCRIPTION
Refs #5635 #5511 #4991 #960

## Which explanation it is: BOTH — (a) is primary, (b) is why it never healed

The issue named two competing explanations. The code and the live cluster say both are true, and they compound.

### (a) PRODUCER SPLIT — primary, proven from the code AND from the live label

There are **two** producers of the per-Org console gateway surface, with **different HTTPRoute names**:

| producer | file:line | route name | fans out to every region? |
|---|---|---|---|
| catalyst-api (BSS / direct door) | `products/catalyst/bootstrap/api/internal/handler/org_console_tls.go:236` — `"catalyst-ui-" + slug + "-" + parentDashed` | `catalyst-ui-r17probe-omani-homes` | **yes**, since #5511 / PR #5524 (`orgConsoleTLSTargets`, `org_console_tls.go:316`) |
| org-controller (marketplace-funnel door) | `core/controllers/organization/internal/controller/tenant_route.go:141` — `"catalyst-ui-" + dnsDashed(hostname)` | `catalyst-ui-console-uatco-omani-homes` | **no** — writes through `r.Client`, its own cluster only; that process has no per-region client seam at all |

The live objects on hw292 carry the producers' own labels, so this is not inference:

```
region-A catalyst-system:
  catalyst-ui-console-uatco-omani-homes  openova.io/managed-by=organization-controller
                                         app.kubernetes.io/managed-by=catalyst
  catalyst-ui-r17probe-omani-homes       catalyst.openova.io/managed-by=catalyst-api
region-B catalyst-system:
  catalyst-ui-r17probe-omani-homes       (only)
```

Same for the rest of uatco's surface — `kube-system/org-wildcard-tls-uatco-omani-homes` carries `openova.io/managed-by: organization-controller`, and the region-A console Gateway's `managedFields` shows `organization-controller op=Update t=14:47:44Z` owning uatco's listeners while region-B's Gateway shows `catalyst-api-org-console-tls-r17probe op=Apply t=18:17:00Z`. **catalyst-api's emitter produced nothing at all for uatco, in either region.**

Why: uatco's Organization CR is labelled `openova.io/source: tenant-created-event`, i.e. minted by `core/services/provisioning/handlers/organization_create.go:162` off the `tenant.created` event. That path **never runs the catalyst-api provisioning pipeline**, so no `OrganizationProvisionRecord` exists, and `provisionOrgConsoleTLS` is only ever called from `organization_provisioning.go:1345` (pipeline step 7) and `:978` (operator reconcile) — both keyed on that store. This is the same door-split `tenant_registry_reconcile.go:15-21` already documents for the tenant registry.

### (b) NO RECONCILE INTO A MISSING REGION — true, and it is why hours of the fixed binary running changed nothing

Neither producer converges an Org that is already missing from a region:

- the org-controller **is** level-triggered and re-reconciles uatco continuously — but single-region, so it can never reach region-B;
- catalyst-api **does** fan out — but is create-time / operator-triggered and store-keyed, so it never revisits a funnel Org.

`fad88bd` (containing #5524) had been live for ~5.5h when the measurement was taken; uatco's region-B surface never appeared. Write-once is the defect shape, exactly as the issue framed it.

## Fix — the #4179 consolidation, applied to the gateway surface

The Organization CR is the **one object both doors create**, and catalyst-api is the **one process holding a per-region client for every region** (`h.k8sCache`, the seam #5524 already wired into `orgConsoleTLSTargets`). So:

**`products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go`** (new)
- `ReconcileOrgConsoleTLSFromOrgCRs` — ticker loop, one pass immediately on start (so a restart converges every existing Org before the first tick), then every `orgConsoleTLSReconcileInterval` (5 min; slower than the 60s registry loop because each Org's pass ends in the #5511 listener-admission read-back).
- `reconcileOrgConsoleTLSOnce` — lists every Organization CR and runs the **existing** multi-region `provisionOrgConsoleTLS` for each.
- `orgConsoleTLSRecordFromOrgCR` — CR to free-subdomain record, mirroring `tenantRegistrationFromOrgCR`'s derivation field-for-field, and delegating the final accept/skip to `resolveOrgConsoleTLSNames` so the loop can never accept an Org the emitter would then skip.

That makes the fan-out **unconditional** (keyed on the CR, so creation-path independent) and **reconciled** (an Org missing from a region converges).

**`org_console_tls.go`** — the two producers agree byte-for-byte on the Certificate name and on BOTH listener names (#4241 consolidated those) but never agreed on the HTTPRoute name. Rather than attach a second HTTPRoute to one hostname on one Gateway, the emitter now **adopts** an existing org-controller route for the same `ConsoleHost` in that region (`orgConsoleRouteAlreadyServed`), asserting the route actually serves our host so a same-named route for a different host can never suppress ours, and failing open (write our own route) on any read error.

**`cmd/api/main.go`** — wires the loop next to `ReconcileTenantRegistryFromOrgCRs`.

**No chart change.** The ClusterRole already grants `organizations` get/list/watch (`clusterrole-cutover-driver.yaml:456-459`), `certificates` get/list/watch+create, `gateways` get/list/watch+patch, `httproutes` get/list/watch+create (`:206-213`, `:598-610`, `:705-716`). No new RBAC, no lockstep sites, no catalog rebuild. **No NodePorts anywhere** — the gateway stays DIRECT (cilium LB-IPAM VIP / hostPort on hostNetwork envoy); nothing in this change touches a Service type or a port literal.

Every write stays idempotent — Certificate Create/AlreadyExists, listener pair per-Org-field-manager SSA (no-op when the spec matches), HTTPRoute Create/AlreadyExists-or-adopt — so a healthy Sovereign sees **zero object churn** from the loop.

## The per-Org APP surface half — NOT fixed here, and why

`app-wordpress-hostroute` is a different animal and I am not going to guess at it.

It is emitted by `core/services/provisioning/gitops/gitops.go:2129-2170` (`generateHostNativeAppRoute`) into the per-Org **GitOps overlay** at `vcluster/host-apps/`, applied by Flux, into namespace `<slug>`, with `backendRefs` pointing at `<app>-x-<slug>-x-vcluster` — the Service the vcluster syncer reflects host-side. On hw292 namespace `uatco` **does not exist in region-B at all**, and the app is placed `rtz-a` **by design** — single-region placement is intentional, so replicating the namespace and workload into region-B is a placement change, not a routing fix. The issue already refuted the host-aware-ingress branch (`console.hw292.omani.works` is 12/12 on the same VIP `212.72.24.85`).

That leaves one architecturally consistent option — region-B serves the host and forwards cross-region — and this repo already has the mechanism for it (`platform/openbao/chart/templates/cross-region-mesh-service.yaml`, `platform/postgres/chart/templates/replica-mesh-service.yaml`: same name+namespace in both clusters, each annotated `service.cilium.io/global: "true"`). Applying it here needs **four** things decided together:

1. the Org namespace created in region-B (the org-controller creates it in its own cluster only);
2. the region-A `<app>-x-<slug>-x-vcluster` Service — **owned by the vcluster syncer** — annotated `service.cilium.io/global: "true"`, which means teaching the syncer config or reconciling the annotation against its owner;
3. a selectorless mesh Service + the app HTTPRoute in region-B;
4. the cross-cluster gateway-to-backend hop admitted by the per-Org CNP. Today that CNP is `endpointSelector:{} fromEntities:[ingress,host,remote-node]`, which does not cover a remote-cluster envoy identity — and `ipBlock` never matches ClusterMesh remote pod identities, so this needs `fromEndpoints` with cluster awareness.

Plus a product call on DR semantics: with the mesh Service in place, a region-A outage turns the region-B half of the round-robin from `000` into `503` rather than into a working app.

Four moving parts and a DR-semantics call is a design decision, not a code detail. The console half is shipped; the app half is written up on #5635 for the design call.

## Also worth the merger's attention (found while measuring, not fixed here)

**Teardown is single-region AND name-split.** `r17probe` was created at 18:17 and deleted minutes later; on hw292 today region-A carries an **orphan** `catalyst-ui-r17probe-omani-homes` with no listeners, and region-B carries the orphan route **and** its listener pair, for an Org that no longer exists. `teardownTenantRoute` (`tenant_route.go:255-266`) targets only the org-controller's name, and `teardownTenantConsoleTLS` runs in one cluster. This reconcile loop does not resurrect deleted Orgs (it lists live CRs) but it also does not reap those orphans. A reap needs `httproutes: delete` RBAC (a chart change) and careful scoping, so it is deliberately left out of this diff.

## Tests — both confirmed failing against unfixed code

`products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile_5635_test.go`

- **`TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths`** — two Orgs, one per creation path (`openova.io/source: tenant-created-event` vs the BSS shape), existing **only** as Organization CRs with no provisioning record. After one pass, both Orgs' listener apply + a route serving their console host must be present in **both** regions, and the issued cert secret mirrored into the secondary.
- **`TestReconcileOrgConsoleTLSFromOrgCRs_BackfillsMissingSecondaryRegion`** — hw292's uatco exactly: region-A already fully served by the **org-controller's** route, region-B empty, no provisioning record. One pass must ADD region-B's surface, and must leave region-A with exactly the one route it already had. Carries a pre-state vacuity assertion so the backfill claim cannot pass on an already-served region.
- `TestOrgConsoleTLSRecordFromOrgCR_SkipCases` — the CR-to-record derivation refuses exactly what the emitter refuses, plus a positive control pinning every derived name.

Confirmed failure on the unfixed tree (production files reverted, test files kept):

```
internal/handler/org_console_tls_reconcile_5635_test.go:203:4: h.reconcileOrgConsoleTLSOnce undefined
internal/handler/org_console_tls_reconcile_5635_test.go:269:4: h.reconcileOrgConsoleTLSOnce undefined
internal/handler/org_console_tls_reconcile_5635_test.go:321:16: undefined: orgConsoleTLSRecordFromOrgCR
internal/handler/org_console_tls_reconcile_5635_test.go:345:11: names.RouteNameOrgController undefined
FAIL  .../internal/handler [build failed]
```

That is a build failure, not a runtime one, and I am not dressing it up as more: the defect is at the **trigger** level — `provisionOrgConsoleTLS` already fanned out correctly, it was simply never called for a funnel Org — so there is no pre-existing symbol for the test to fail against. To get a red-to-green at runtime as well, the second test file uses **only** symbols that predate this fix:

`products/catalyst/bootstrap/api/internal/handler/org_console_tls_dupe_5635_test.go`

- **`TestProvisionOrgConsoleTLS_AdoptsOrgControllerRoute_NoDuplicateSurface`** — compiles against the unfixed tree and fails there at runtime:

```
=== RUN   TestProvisionOrgConsoleTLS_AdoptsOrgControllerRoute_NoDuplicateSurface
    org_console_tls_dupe_5635_test.go:125: console host console.acme.omani.homes is served by 2 HTTPRoutes
      [catalyst-ui-acme-omani-homes catalyst-ui-console-acme-omani-homes], want exactly 1
      (the org-controller's catalyst-ui-console-acme-omani-homes adopted, not duplicated by catalyst-ui-acme-omani-homes)
--- FAIL: TestProvisionOrgConsoleTLS_AdoptsOrgControllerRoute_NoDuplicateSurface (0.05s)
```

  It carries a vacuity guard in the other direction (with no org-controller route present the emitter MUST still write its own), and `TestProvisionOrgConsoleTLS_DoesNotAdoptRouteForAnotherHost` pins that a same-named route for a different host never suppresses ours.

## Gates

- `go build ./...` — `products/catalyst/bootstrap/api` — clean
- `go test ./...` — `products/catalyst/bootstrap/api` — whole module, exit 0, zero failures
- targeted run — all 5 new tests green post-fix
- `scripts/check-no-nodeports.sh` — Phase 0 self-test OK (4/4 banned forms matched, 2/2 allowed forms rejected, 2764 files in scope), Phase 1 `OK — no NodePort field/literal in platform products clusters infra core sources.`, Phase 1b `OK — no nodePort-range port literal in infra HCL.`
- lockstep / catalog gates — **not applicable**, no chart changed

## Verification still owed

This has **not** been walked on a live Sovereign. The proof is `console.uatco.omani.homes` answering N/N on fresh-TCP from both regions after the loop's first pass, plus a route serving that host present in region-B's `catalyst-system`. That needs a catalyst-api roll on hw292, which is under merge-freeze rules.
