### PR TITLE
fix(ui-test): ExecPanel waits for the socket, not just the DOM — unblock catalyst image publication

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/ExecPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/ExecPanel.test.tsx
@@ -13,6 +13,17 @@
  * (ExecPanel.tsx:289). The old iframe-first assertions were therefore
  * asserting a path the shipped code no longer takes.
  *
+ * ORDERING NOTE (#5633)
+ * ---------------------
+ * `phase === 'fallback-loading'` and `phase === 'fallback-ready'` render
+ * byte-identical markup, and the WebSocket is dialled in the passive effect
+ * (ExecPanel.tsx:129-148) that React flushes in a scheduler task AFTER the
+ * one that commits that markup. So no `waitFor` on a DOM node alone can
+ * imply that the socket exists — under CPU pressure the scheduler yields
+ * between the two and the DOM-only wait resolves first. Every wait in this
+ * file that precedes a `wsInstance` assertion therefore names `wsInstance`
+ * in the wait condition itself.
+ *
  * Vitest coverage for the shipped contract:
  *   - Open Shell button → POST /session → WS+xterm mounts immediately
  *   - No Guacamole iframe and no "Recording: ON" claim on the WS path
@@ -116,12 +127,24 @@ describe('ExecPanel', () => {
       />,
     )
     fireEvent.click(screen.getByTestId('exec-panel-open'))
+    // #5633 — the wait condition has to cover the socket, not just the DOM.
+    // React COMMITS the `fallback-loading` markup (banner + terminal <div>)
+    // in one scheduler task and dials the WebSocket in the passive effect
+    // (ExecPanel.tsx:129-148) that it flushes in a LATER one. Nothing in the
+    // DOM distinguishes `fallback-loading` from `fallback-ready`, so a
+    // DOM-only wait is satisfied strictly BEFORE the socket exists. Whenever
+    // a render overruns React's 5ms frame budget the scheduler yields
+    // between commit and passive-effect flush, the MutationObserver driving
+    // waitFor fires in the intervening microtask checkpoint, and the wait
+    // resolves with `wsInstance` still null. Waiting on both is not a weaker
+    // assertion: a socket that is never dialled still fails the test, on the
+    // waitFor timeout. Do NOT move this back out of the waitFor.
     await waitFor(() => {
       expect(screen.getByTestId('exec-panel-fallback-terminal')).toBeTruthy()
+      expect(wsInstance).not.toBeNull()
     })
     // The WS is dialled against the server-supplied fallback URL
     // (ExecPanel.tsx:131-140).
-    expect(wsInstance).not.toBeNull()
     expect(wsInstance!.url).toBe(HAPPY_SESSION.fallbackWebSocketUrl)
     // …and the Guacamole iframe never mounts: ExecPanel.tsx:289 gates it on
     // the `iframe-*` phases and openShell no longer enters them
@@ -158,10 +181,13 @@ describe('ExecPanel', () => {
       />,
     )
     fireEvent.click(screen.getByTestId('exec-panel-open'))
+    // #5633 — same commit-before-effect ordering as the happy-path test
+    // above: the banner is committed a scheduler task before the socket is
+    // dialled, so the wait has to name the socket too.
     await waitFor(() => {
       expect(screen.getByTestId('exec-panel-fallback-banner')).toBeTruthy()
+      expect(wsInstance).not.toBeNull()
     })
-    expect(wsInstance).not.toBeNull()
     expect(wsInstance!.url).toContain('/k8s/exec/default/wp-1/web')
     // Draining well past the iframe-load timeout must not disturb the live
     // shell — that timer is only armed in the `iframe-loading` phase


### PR DESCRIPTION
## What this unblocks

`build-ui` gates `deploy` (`.github/workflows/catalyst-build.yaml:517` —
`needs: [build-ui, build-api]`). A red `build-ui` skips `deploy`, and **no
catalyst image publishes at all**. Since the vitest gate stopped failing open
(#5553 removed `npm test || echo WARN`, #5595 fixed the ANSI stripping, #5626
fixed the four source defects it had been hiding), `ExecPanel.test.tsx` has
been the **only** failing file on 8 of the last 12 pushes to `main`, and
`deploy` was `skipped` on every one of them:

| run | head | build-ui | deploy | failing file |
|---|---|---|---|---|
| 30866269754 | `e5fc892` | FAILURE | skipped | `ExecPanel.test.tsx` |
| 30859382419 | `67dfb94` | FAILURE | skipped | `ExecPanel.test.tsx` |
| 30856590522 | `f40f95d` | FAILURE | skipped | `ExecPanel.test.tsx` |
| 30855587277 | `9508347` | FAILURE | skipped | `ExecPanel.test.tsx` |
| 30852698474 | `e83561a` | FAILURE | skipped | `ExecPanel.test.tsx` |
| 30852636626 | `935d238` | FAILURE | skipped | `ExecPanel.test.tsx` |
| 30851068468 | `2e70716` | FAILURE | skipped | `ExecPanel.test.tsx` |
| 30850983356 | `3396445` | FAILURE | skipped | `ExecPanel.test.tsx` |

The last image to publish is `e3342f9` (run 30863517667). The observed CI
failure rate is ~8-in-12, not the ~1-in-5 seen on an idle workstation — the
reason is in the mechanism below.

## Interference or intrinsic

**Intrinsic to `ExecPanel.test.tsx`.** The cross-file-leakage hypothesis is
refuted two ways:

- vitest 4 runs with its defaults here (`pool: 'forks'`, `isolate: true`; the
  `test` block in `vite.config.ts` overrides neither), so every file already
  gets a fresh module registry and globals. There is no channel for a stubbed
  global or a module singleton to cross files.
- The failure reproduces **with only `ExecPanel.test.tsx` in the run** — 8 out
  of 8 — once the box is CPU-starved. No other test file is present.

What the full suite contributes is CPU contention, nothing else.

## The leak

`products/catalyst/bootstrap/ui/src/widgets/cloud-list/ExecPanel.test.tsx:118-124`
(pre-fix line numbers), against
`products/catalyst/bootstrap/ui/src/widgets/cloud-list/ExecPanel.tsx:129-148`.

`ExecPanel` renders byte-identical markup for `phase === 'fallback-loading'`
and `phase === 'fallback-ready'` (`ExecPanel.tsx:308-320`), and constructs the
WebSocket inside the passive effect at `ExecPanel.tsx:130-148` (the dial itself
is `ExecPanel.tsx:140`). React **commits
that markup in one scheduler task and flushes the passive effect in a later
one**, so:

> `await waitFor(() => expect(screen.getByTestId('exec-panel-fallback-terminal')).toBeTruthy())`
> is satisfiable strictly BEFORE `websocketFactory` has ever been called.

Whenever a render overruns React's 5 ms frame budget the scheduler yields
between commit and passive-effect flush. Yielding empties the JS stack, which
runs the microtask checkpoint, which fires the `MutationObserver` that drives
`waitFor` — so `waitFor` resolves in the gap, and the very next line,
`expect(wsInstance).not.toBeNull()`, asserts against a socket that does not
exist yet. Warm and unloaded, the flush lands in the same scheduler task as the
commit and the test passes; that is exactly why the file is 6/6 deterministic
in isolation and unreliable on a busy CI runner.

Direct measurement of the ordering, probing `wsInstance` at the exact assertion
point:

```
unloaded : PROBE wsNull=false   (effect flushed in the commit's task)
CPU-bound: PROBE wsNull=true    (scheduler yielded; assertion sees null)
```

The same defect is present twice — the happy-path test and the
iframe-timeout-guard test — and both fail together under load.

## The fix

Name `wsInstance` in the wait condition of both tests, so the wait covers the
state the assertions depend on instead of a DOM node that appears earlier.

This is not a loosened assertion: `waitFor` re-runs its callback until it
passes or times out, so a socket that is never dialled still fails the test.
No retry wrapper, no `KNOWN_RED` entry, no `setTimeout` sleep, no weakened or
skipped expectation. A docblock note and an inline comment record the ordering
contract so the assertions do not get hoisted back out.

## Proof

Repro harness — `ExecPanel.test.tsx` **alone**, 24 busy-loop processes on 8
cores, identical before and after:

```
before: FAILED_RUNS=8 of 8     (AssertionError: expected null not to be null,
                                at ExecPanel.test.tsx:124 and :164)
after : FAILED_RUNS=0 of 12
```

Vacuity check, so the new wait is not passing on nothing — with
`ExecPanel.tsx:137` altered to ignore the injected `websocketFactory` (a real
regression that still lets the DOM render), the fixed wait times out after
~1 s and fails with `expected null not to be null`. Restored before commit;
the diff touches only the test file.

Gates, from `products/catalyst/bootstrap/ui`:

```
npx vitest run   x10  -> 10/10 green, 211 test files / 2010 tests each run
npm run build         -> exit 0
npx tsc -b            -> exit 0
npx eslint <file>     -> exit 0
```

Refs #5633 #5553 #5595 #5626
