### PR TITLE
feat(cutover): assert Flux sources are Sovereign-local, not merely unreachable during the timed hold

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1049,7 +1049,7 @@ spec:
       # default", which detect holds literally, and shipping it off left the
       # gap as silent as the issue describes. Step count stays 11; no RBAC
       # change. New chart test tests/daytwo-image-leg.sh + contract Case 75.
-      version: 0.1.161
+      version: 0.1.162
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/docs/sessions/2026-08-04/cutover-residual-tether/README.md
+++ b/docs/sessions/2026-08-04/cutover-residual-tether/README.md
@@ -2,76 +2,98 @@
 
 > Env: `hw292.omani.works`, dep `1c56518035a83e03`, `cutoverComplete=true` since 08:12:30Z.
 > Found 2026-08-04 while verifying #5527 (per-Org HelmRepositories cutover-aware, PR #5629).
-> Filed as **#5650**.
+> Filed as **#5650**; fix ships in `bp-self-sovereign-cutover` 0.1.162.
+
+## Correction notice
+
+The first version of this document and of #5650 claimed step-08's deny-egress hold "blocks a named
+list, so it cannot detect any unenumerated tether." **That was wrong**, and acting on it would have
+meant rewriting a mechanism that is already correct. The live Job spec:
+
+    DEFAULT_DENY_EGRESS=true
+    ENFORCE_CIDR_BLOCK=true
+
+`defaultDenyEgress: true` has shipped since #3678. It emits a cluster-wide CCNP with
+`endpointSelector: {}`, `enableDefaultDeny.egress: true`, and an allow-list of only the Sovereign's
+own CIDRs plus the IaaS provider API. Every public destination is black-holed, `charts.loft.sh`
+included. `blockedDomains` survives only as the active call-home assertion — the hosts we positively
+prove unreachable from inside the policy. I read the legacy subtractive branch and generalised from
+it without checking which branch ships. The corrected finding below is narrower and more useful.
 
 ## What #5527 proves, stated exactly
 
-Of **70** HelmRepositories on the Sovereign, **69** point at the local Harbor and **0** point at
-ghcr. The generator fix holds; #5527's own claim is verified.
+Of **70** HelmRepositories, **69** point at the local Harbor and **0** at ghcr. The generator fix
+holds; #5527's own claim is verified.
 
-    { "ghcr": 0, "local": 69, "total": 70 }
-    CONTROL: cutoverComplete === true
-
-## The 70th
+## The 70th, and the real gap
 
     vcluster-system/loft   url: https://charts.loft.sh   type: default   managed-by: Helm
 
-It is **not inert**, which is the part that matters:
-
 | Probe | Reading |
 |---|---|
-| HelmReleases referencing `loft` | **1** |
-| Status conditions | `Ready=True`, `ArtifactInStorage=True` |
-| Artifact `lastUpdateTime` | **2026-08-03T18:36:28Z** — ~10h *after* cutover completed |
-| Control (a pivoted repo) | `bp-cilium` → `type=oci`, `oci://registry.hw292.omani.works/openova-io` |
+| Referenced by | 1 HelmRelease |
+| Status | `Ready=True`, `ArtifactInStorage=True` |
+| `spec.interval` | **15m**, `suspend` unset |
+| Artifact fetched | **2026-08-03T18:36:28Z** |
+| `ccnp/cutover-egress-block` now | **ABSENT — torn down after the hold, by design** |
+| Control (a pivoted repo) | `bp-cilium` → `oci://registry.hw292.omani.works/openova-io` |
 
-So a Sovereign that reports `cutoverComplete=true` reached the public internet for a chart, after
-cutover, and its Flux status reports that as healthy.
+Both of these are true at once, and that is the whole finding:
 
-Pillar 5 / ADR-0002 claim that post-cutover every Flux reconcile pulls exclusively from the local
-Gitea and Harbor. This is one object away from that being true.
+- nothing external was reachable for the 600 seconds of the hold, and
+- this Sovereign fetches from `charts.loft.sh` every 15 minutes.
 
-## Why the sovereignty proof cannot see it — the finding worth more than the tether
+The hold is **time-boxed and then removed**. It proves the Sovereign *survives* 600s of isolation.
+It does not prove the Sovereign has *no external dependency*, and ADR-0002 asserts the second. A
+15-minute reconcile interval can straddle a 10-minute window entirely — the tether need never fire
+while anyone is watching, and it resumes the moment the policy is gone.
 
-Step-08's deny-egress hold, the sovereignty proof itself, blocks a **named list** of hosts:
+**Reachability-during-a-window and dependency-in-the-object-graph are different properties.** Only
+the first was tested.
 
-    docker.io, ghcr.io, github.com, harbor.openova.io, k8s.io, quay.io, openova.io
+## Why the pivot missed this object
 
-`charts.loft.sh` is not on it. The proof therefore returns green while an unblocked external host
-is actively being fetched from — and it would return green for **any** future tether to a host
-nobody enumerated. The check is allowlist-shaped where the claim is property-shaped.
+Step-06 rewrites HelmRepository URLs; step-10 pivots the vcluster **image** reference. Step-10's own
+header records that it exists precisely because step-06 "only rewrites HelmRepository" URLs. Between
+them the image is pivoted and the loft chart source is not: it lives in `vcluster-system` as a
+`managed-by: Helm` object rather than a Flux-owned repo in `flux-system`. Neither step is wrong about
+its own scope; the gap is between their scopes, and nothing asserted over the union.
 
-This is the same failure mode this repo has now paid for three times in one week:
+## The fix (0.1.162)
+
+A pre-hold **Flux source host lint**, modelled on the ref-host lint step-08 already runs for pod-spec
+image hosts (#5026/#5036) — a static assertion over the object graph, independent of timing. Every
+non-suspended `HelmRepository` / `GitRepository` / `OCIRepository` must resolve to a Sovereign-local
+host. `allowHosts` defaults **empty**, so an external host is a tether until a human declares an
+exception in Git under review.
+
+Its exemption set is deliberately narrower than the pod-spec lint's. That one exempts step-04
+`HOST_PROJECT_MAP` hosts because containerd rewrites image pulls via `certs.d`. Flux's
+source-controller fetches these URLs itself and never traverses containerd, so a `certs.d` redirect
+cannot cover a source object — `harbor.openova.io` as a source URL stays a failure.
+
+## The test, and what it caught
+
+`chart/tests/flux-source-host-lint.sh` extracts the shell function from the **render** rather than a
+hand-kept copy (per #5646, where a suite validated a copy that had silently drifted) and drives it
+against a stub `kubectl` in both directions: external source fails, local source passes, and the
+*same* source with an `allowHosts` entry passes — that last case being the vacuity control proving
+the failure keyed on the host rather than on something incidental.
+
+It earned itself immediately. The first draft **failed open**: when the scratch file could not be
+created, every append silently no-op'd, `-s` was false, and the lint returned PASS having examined
+nothing. A guard reporting success from an empty measurement is the exact defect this lint exists to
+eliminate, and it would have shipped unnoticed had the suite only ever been run in the passing
+direction. Now fail-closed, with case 8 pinning it.
+
+That makes four instances this week of the same underlying error — checking that something is
+present instead of checking what it says:
 
 | Instance | Shape |
 |---|---|
 | `npm test \|\| echo WARN` (#5633/#5626) | a gate that could not go red for two months |
-| `grep -q 'key: openova.io/region'` (#5639/#5641) | an assertion on the KEY that passes on an empty VALUE |
-| step-08 host allowlist (**#5650**) | a proof that enumerates instances of the thing it claims to exclude |
+| `grep -q 'key: openova.io/region'` (#5639/#5641) | an assertion on the KEY, passing on an empty VALUE |
+| step-08 covers reachability only (**#5650**) | a proof of the wrong property, correct as far as it went |
+| the new lint's first draft (**caught pre-merge**) | PASS returned from a measurement that never ran |
 
-Per PRINCIPLES III.4, the second recurrence of a class calls for one fail-closed class fix rather
-than another per-instance patch. The class fix here is **deny-all egress except the Sovereign's own
-endpoints**, which converts step-08 from "these seven hosts are unreachable" into "nothing external
-is reachable" — which is what Pillar 5 actually asserts.
-
-## Why the pivot missed this specific object
-
-Step-06 rewrites HelmRepository URLs. Step-10 pivots the vcluster **image** reference
-(`harbor.openova.io/proxy-ghcr/loft-sh/vcluster` → local Harbor); its own header records that it
-exists precisely because step-06 "only rewrites HelmRepository" URLs. Between the two, the vcluster
-*image* is pivoted and the loft *chart source* is not: it lives in `vcluster-system` as a
-`managed-by: Helm` object rather than a Flux-owned repo in `flux-system`, so it falls outside the
-set step-06 walks. Neither step is wrong about its own scope; the gap is between their scopes, and
-nothing asserts over the union.
-
-## Fixes, in the order that matters
-
-1. **Class fix** — make step-08 deny-all-except-local rather than deny-a-list. Without this the
-   next unenumerated host repeats the defect silently and the proof keeps certifying a false claim.
-2. **Instance fix** — mirror `charts.loft.sh` into the local Harbor and repoint
-   `vcluster-system/loft`.
-3. **Standing gate** — after cutover, assert that *every* HelmRepository and *every* image
-   reference on the Sovereign resolves to a Sovereign-local host, failing closed on the first that
-   does not. A property check, which would have caught this on the first fresh prov.
-
-Refs #5650 #5527 #3379 #960
+Refs #5650 #5527 #3379 #3678 #960

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.161
+  version: 0.1.162
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2889,6 +2889,38 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
+# 0.1.162 (#5650 Refs #5527 #3379 #3678) — step-08 gains a Flux SOURCE host
+# lint, the timing-independent half of the Pillar-5 proof.
+#
+# The deny-egress hold applies a cluster-wide default-deny CCNP, holds for
+# durationSeconds, and is then TORN DOWN. It therefore proves that nothing
+# external was REACHABLE during the window. It cannot prove the Sovereign has
+# no external DEPENDENCY, and ADR-0002 asserts the second. Live hw292:
+# HelmRepository vcluster-system/loft -> https://charts.loft.sh, interval 15m,
+# not suspended, referenced by a live HelmRelease. A 15m interval can straddle
+# a 600s hold entirely, so it never dialled while the policy was up; its
+# artifact was re-fetched from the public internet ~10h AFTER
+# cutoverComplete=true was set. The hold passed and was right to pass — nothing
+# asserted over the object graph.
+#
+# The new lint asserts the property directly: every non-suspended
+# HelmRepository / GitRepository / OCIRepository must resolve to a
+# Sovereign-local host, failing closed (allowHosts defaults empty, so an
+# external host is a tether until a human declares an exception in Git under
+# review). Its exemption set is deliberately NARROWER than
+# podspecRefHostLint's: that lint exempts step-04 HOST_PROJECT_MAP hosts
+# because containerd rewrites IMAGE pulls via certs.d, but source-controller
+# fetches these URLs itself and never traverses containerd, so a certs.d
+# redirect cannot cover a source object.
+#
+# New chart/tests/flux-source-host-lint.sh extracts the shell function from
+# the RENDER (not a hand-kept copy, per #5646) and drives it against a stub
+# kubectl in BOTH directions — external source fails, local source passes,
+# same source with an allowHosts entry passes. That last case is the vacuity
+# control proving the failure keyed on the HOST. The suite immediately earned
+# itself by catching a fail-OPEN bug in the first draft: when the scratch file
+# could not be created, every append no-op'd and the lint returned PASS having
+# examined nothing. Now fail-closed, with a regression case pinning it.
 # 0.1.161 (#5640 Refs #5265 #4975 #5095 #5525 #3944) — the Day-2 reconciler
 # gains an IMAGE leg, and ships ON by default in zero-egress detect mode.
 #
@@ -2955,7 +2987,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.161
+version: 0.1.162
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -201,6 +201,18 @@ data:
           # #5026 — pre-hold ref-host lint toggle (treadmill-breaker).
           - name: PODSPEC_REFHOST_LINT
             value: {{ eq (toString .Values.egressTest.podspecRefHostLint.enabled) "true" | quote }}
+          # #5650 — pre-hold Flux SOURCE host lint. The deny-egress hold below
+          # proves nothing external is REACHABLE for 600s; it cannot prove
+          # nothing external is DEPENDED UPON, because the policy is torn down
+          # when the hold ends and a source whose reconcile interval straddles
+          # the window never dials during it. Live hw292: vcluster-system/loft
+          # (charts.loft.sh, interval 15m) sat Ready through a passing hold and
+          # re-fetched from the public internet ~10h after cutoverComplete=true.
+          # This lint is the timing-independent half of the proof.
+          - name: FLUX_SOURCE_HOST_LINT
+            value: {{ eq (toString .Values.egressTest.fluxSourceHostLint.enabled) "true" | quote }}
+          - name: FLUX_SOURCE_HOST_ALLOW
+            value: {{ .Values.egressTest.fluxSourceHostLint.allowHosts | default (list) | join " " | quote }}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
@@ -788,6 +800,95 @@ data:
             if [ "${PODSPEC_REFHOST_LINT}" = "true" ]; then
               if ! run_podspec_refhost_lint; then
                 echo "[egress-block-test] ref-host lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false; every offender above must be pivoted to ${LOCAL_REGISTRY_HOST} — fix the step-07 sweep coverage or the workload chart's default image host)"
+                exit 1
+              fi
+            fi
+
+            # ── #5650 FLUX SOURCE HOST LINT ────────────────────────────────
+            # WHY this exists as a SEPARATE assertion from the hold. The hold
+            # applies a cluster-wide default-deny egress CCNP, runs for
+            # ${DURATION}s, and is then TORN DOWN. It therefore proves exactly
+            # one thing: nothing external was REACHABLE during that window. It
+            # cannot prove the Sovereign has no external DEPENDENCY, and those
+            # are different claims — Pillar 5 / ADR-0002 assert the second.
+            #
+            # The concrete miss (hw292, dep 1c56518035a83e03): HelmRepository
+            # vcluster-system/loft -> https://charts.loft.sh, spec.interval 15m,
+            # not suspended, referenced by a live HelmRelease. A 15m interval can
+            # straddle a 600s hold entirely, so the tether need never fire while
+            # the policy is up; its artifact was then re-fetched from the public
+            # internet at 18:36:28Z, ~10h AFTER cutoverComplete=true was set.
+            # The hold passed and was correct to pass. The gap is that nothing
+            # asserted over the object graph.
+            #
+            # SCOPE NOTE — why the step-04 redirect exemption does NOT apply
+            # here. run_podspec_refhost_lint exempts HOST_PROJECT_MAP hosts
+            # because containerd rewrites IMAGE pulls via certs.d/<host>/
+            # hosts.toml. Flux's source-controller fetches HelmRepository /
+            # GitRepository / OCIRepository URLs itself over HTTPS and never
+            # traverses containerd, so a certs.d redirect cannot cover it. The
+            # exemption set here is therefore strictly the Sovereign's OWN
+            # hosts plus in-cluster DNS — anything else is a live tether.
+            run_flux_source_host_lint() {
+              echo "[egress-block-test] #5650: PRE-HOLD Flux source-host lint — every HelmRepository/GitRepository/OCIRepository URL must resolve to a Sovereign-local host (registry./gitea./harbor.${SOVEREIGN_FQDN}, in-cluster DNS, or an explicit FLUX_SOURCE_HOST_ALLOW entry). containerd redirects do NOT cover these: source-controller dials them directly."
+              # WORK_DIR defaults to the Job's /work emptyDir; overridable so the
+              # function is drivable from chart/tests/flux-source-host-lint.sh.
+              # The `: >` MUST be checked: if the scratch file cannot be created
+              # (missing or read-only mount) every later append silently no-ops,
+              # `-s` is false, and the lint returns PASS having examined nothing.
+              # That is a fail-OPEN guard — the exact shape this lint exists to
+              # eliminate — and the test suite caught it here before it shipped.
+              _fs_off="${WORK_DIR:-/work}/fluxsrc-offenders.$$"
+              if ! : > "${_fs_off}" 2>/dev/null; then
+                echo "  FAIL — cannot create ${_fs_off}; refusing to report PASS from a lint that cannot record an offender (fail-closed)"
+                return 1
+              fi
+              for _fk in helmrepositories gitrepositories ocirepositories; do
+                kubectl get "${_fk}" -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.url}{" "}{.spec.suspend}{"\n"}{end}' 2>/dev/null \
+                | while IFS=' ' read -r _fns _fname _furl _fsusp; do
+                    [ -n "${_fns}" ] && [ -n "${_furl}" ] || continue
+                    # Strip scheme, then any path/port, leaving the bare host.
+                    _fh="${_furl#*://}"; _fh="${_fh%%/*}"; _fh="${_fh%%:*}"
+                    [ -n "${_fh}" ] || continue
+                    # Sovereign-local: the local registry, the local Gitea, the
+                    # local Harbor, any *.<SOVEREIGN_FQDN>, in-cluster service
+                    # DNS, and loopback.
+                    case "${_fh}" in
+                      "${LOCAL_REGISTRY_HOST}"|"gitea.${SOVEREIGN_FQDN}"|"harbor.${SOVEREIGN_FQDN}"|*".${SOVEREIGN_FQDN}") continue ;;
+                      *.svc|*.svc.cluster.local|localhost|127.0.0.1) continue ;;
+                    esac
+                    # Explicit operator-declared exceptions (default EMPTY, so
+                    # this lint fails closed: a host is a tether until someone
+                    # states otherwise in values, in Git, under review).
+                    _fex=0
+                    for _fa in ${FLUX_SOURCE_HOST_ALLOW:-}; do
+                      [ "${_fh}" = "${_fa}" ] && { _fex=1; break; }
+                    done
+                    [ "${_fex}" = "1" ] && continue
+                    # A suspended source cannot reconcile, so it is reported
+                    # distinctly — still a declared dependency worth seeing, but
+                    # not a live fetch. It does NOT fail the lint.
+                    if [ "${_fsusp}" = "true" ]; then
+                      echo "    SUSPENDED (not failing) ${_fns}/${_fname} [${_fk}] ${_furl} (host:${_fh})"
+                      continue
+                    fi
+                    printf '%s/%s [%s] %s (host:%s)\n' "${_fns}" "${_fname}" "${_fk}" "${_furl}" "${_fh}" >> "${_fs_off}"
+                  done
+              done
+              if [ -s "${_fs_off}" ]; then
+                echo "  FAIL — these Flux source objects still point at a NON-Sovereign host. Each is a live tether that the deny-egress hold cannot detect, because the hold is time-boxed and torn down while these keep reconciling on their own interval (fix = mirror the upstream into the local Harbor/Gitea and repoint the source, or declare a reviewed exception in egressTest.fluxSourceHostLint.allowHosts):"
+                sort -u "${_fs_off}" | while IFS= read -r _o; do echo "    EXTERNAL-SOURCE ${_o}"; done
+                rm -f "${_fs_off}"
+                return 1
+              fi
+              rm -f "${_fs_off}"
+              echo "  PASS — every non-suspended Flux source resolves to a Sovereign-local host; no external dependency remains in the object graph (#5650)"
+              return 0
+            }
+            if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ]; then
+              if ! run_flux_source_host_lint; then
+                echo "[egress-block-test] Flux source-host lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). This is the dependency half of Pillar 5: surviving a 600s isolation window is necessary but not sufficient when a source keeps fetching from the public internet on its own interval once the policy is gone (#5650)"
                 exit 1
               fi
             fi

--- a/platform/self-sovereign-cutover/chart/tests/flux-source-host-lint.sh
+++ b/platform/self-sovereign-cutover/chart/tests/flux-source-host-lint.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# #5650 — behavioural test for step-08's Flux SOURCE host lint.
+#
+# WHY a behavioural test and not a render grep. The defect class this lint
+# exists to catch was itself created by assertions that check a KEY exists
+# rather than what it SAYS (#5639/#5641), and by a CI gate that could not go
+# red for two months (#5633/#5626). So this test extracts the real shell
+# function out of the rendered Job and drives it against a stub `kubectl`,
+# asserting the VERDICT in both directions. A guard that has only ever been
+# observed passing is not yet known to be a guard.
+#
+# The lint's job: after cutover, every non-suspended HelmRepository /
+# GitRepository / OCIRepository must resolve to a Sovereign-local host. The
+# deny-egress hold cannot cover this, because it is time-boxed and torn down
+# while a source keeps reconciling on its own interval.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw292.omani.works"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+fail() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok   — $*"; }
+
+# ── Extract the function under test straight from the rendered chart ────────
+# Taking it from the RENDER (not from a copy pasted into this file) is
+# deliberate: #5646 showed a test suite validating a hand-kept copy that had
+# silently drifted from the shipped source, so it went on passing after the
+# real thing changed.
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+awk '/^ *run_flux_source_host_lint\(\) \{/,/^ *\}$/' "${TMP}/render.yaml" \
+  | sed 's/^ *//' >"${TMP}/fn.sh"
+
+if ! grep -q 'run_flux_source_host_lint()' "${TMP}/fn.sh"; then
+  echo "FAIL — could not extract run_flux_source_host_lint from the rendered Job."
+  echo "       The lint is missing from the chart, or the function name changed."
+  exit 1
+fi
+
+# ── Harness: stub kubectl feeds the source inventory under test ─────────────
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/kubectl" <<'STUB'
+#!/usr/bin/env bash
+# args: get <kind> -A -o jsonpath=...
+kind="$2"
+f="${STUB_DIR}/${kind}.txt"
+[ -f "$f" ] && cat "$f"
+exit 0
+STUB
+chmod +x "${TMP}/bin/kubectl"
+
+# Runs the lint over a given inventory; echoes PASS or FAIL.
+run_case() {
+  local desc="$1" allow="$2"; shift 2
+  local case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/helmrepositories.txt"
+  : >"${case_dir}/gitrepositories.txt"
+  : >"${case_dir}/ocirepositories.txt"
+  for spec in "$@"; do
+    local kind="${spec%%|*}" row="${spec#*|}"
+    printf '%s\n' "${row}" >>"${case_dir}/${kind}.txt"
+  done
+  mkdir -p "${TMP}/work"
+  (
+    export PATH="${TMP}/bin:${PATH}"
+    export STUB_DIR="${case_dir}"
+    export SOVEREIGN_FQDN="${FQDN}"
+    export LOCAL_REGISTRY_HOST="registry.${FQDN}"
+    export FLUX_SOURCE_HOST_ALLOW="${allow}"
+    export WORK_DIR="${TMP}/work"
+    cd "${TMP}"
+    # shellcheck disable=SC1090
+    . "${TMP}/fn.sh"
+    if run_flux_source_host_lint >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+  )
+}
+
+expect() {
+  local desc="$1" want="$2" got="$3"
+  if [ "${got}" = "${want}" ]; then pass "${desc} (${got})"
+  else fail "${desc}: expected ${want}, got ${got}"; sed 's/^/        /' "${TMP}/out.txt"; fi
+}
+
+echo "[flux-source-host-lint] #5650 — the lint must fail on an external source and pass on a local one"
+
+# 1. POSITIVE CONTROL — all sources local. Must PASS.
+#    Without this case a lint that always failed would look correct in case 2.
+got=$(run_case "all-local" "" \
+  "helmrepositories|flux-system bp-cilium oci://registry.${FQDN}/openova-io " \
+  "helmrepositories|flux-system bp-agenity oci://registry.${FQDN}/openova-io " \
+  "gitrepositories|flux-system catalog https://gitea.${FQDN}/catalog/openova ")
+expect "all-local sources" PASS "${got}"
+
+# 2. THE REAL DEFECT — the live hw292 finding. Must FAIL.
+got=$(run_case "loft-tether" "" \
+  "helmrepositories|flux-system bp-cilium oci://registry.${FQDN}/openova-io " \
+  "helmrepositories|vcluster-system loft https://charts.loft.sh ")
+expect "external charts.loft.sh source" FAIL "${got}"
+
+# 3. VACUITY, THE OTHER DIRECTION — same inventory, host declared as a
+#    reviewed exception. Must PASS, proving case 2 failed on the HOST and not
+#    on something incidental like the namespace or the extra row.
+got=$(run_case "loft-allowed" "charts.loft.sh" \
+  "helmrepositories|flux-system bp-cilium oci://registry.${FQDN}/openova-io " \
+  "helmrepositories|vcluster-system loft https://charts.loft.sh ")
+expect "same source with an explicit allowHosts entry" PASS "${got}"
+
+# 4. A suspended source cannot reconcile — reported, but must not fail.
+got=$(run_case "loft-suspended" "" \
+  "helmrepositories|vcluster-system loft https://charts.loft.sh true")
+expect "suspended external source" PASS "${got}"
+
+# 5. Other Flux source kinds are covered too, not just HelmRepository.
+got=$(run_case "git-tether" "" \
+  "gitrepositories|flux-system upstream https://github.com/openova-io/openova ")
+expect "external GitRepository" FAIL "${got}"
+got=$(run_case "oci-tether" "" \
+  "ocirepositories|flux-system up oci://ghcr.io/openova-io/bp-x ")
+expect "external OCIRepository" FAIL "${got}"
+
+# 6. The exemption set must NOT inherit podspecRefHostLint's containerd
+#    redirect logic. source-controller dials these URLs itself and never
+#    traverses containerd, so a HOST_PROJECT_MAP entry cannot cover a source
+#    object — harbor.openova.io is the mothership and must stay a failure.
+got=$(run_case "mothership-harbor" "" \
+  "helmrepositories|flux-system bp-x oci://harbor.openova.io/openova-io ")
+expect "mothership harbor.openova.io source (no containerd redirect applies)" FAIL "${got}"
+
+# 7. Port-bearing and path-bearing URLs must parse to the bare host.
+got=$(run_case "port-parse" "" \
+  "helmrepositories|flux-system bp-x oci://registry.${FQDN}:5000/openova-io/deep/path ")
+expect "local host with port and path" PASS "${got}"
+
+# 8. REGRESSION PIN for a fail-open bug this suite caught during development.
+#    The lint records offenders in a scratch file. When that file could not be
+#    created, every append silently no-op'd, `-s` was false, and the lint
+#    returned PASS having examined nothing — a guard that reported success from
+#    an empty measurement. It must fail CLOSED instead.
+echo "  (fail-closed: an unwritable scratch dir must not be reported as PASS)"
+got=$(
+  export PATH="${TMP}/bin:${PATH}"
+  export STUB_DIR="${TMP}/case"
+  export SOVEREIGN_FQDN="${FQDN}"
+  export LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export FLUX_SOURCE_HOST_ALLOW=""
+  export WORK_DIR="${TMP}/definitely-not-a-real-dir"
+  cd "${TMP}"
+  # shellcheck disable=SC1090
+  . "${TMP}/fn.sh"
+  if run_flux_source_host_lint >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "unwritable scratch dir" FAIL "${got}"
+
+echo
+if [ "${FAILURES}" -ne 0 ]; then
+  echo "[flux-source-host-lint] ${FAILURES} assertion(s) FAILED"
+  exit 1
+fi
+echo "[flux-source-host-lint] all assertions passed — lint proven to fail on a tether AND pass on a local source"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1738,6 +1738,35 @@ egressTest:
   # them by design). Default ON — the class-breaker for #5026.
   podspecRefHostLint:
     enabled: true
+  # #5650 — Flux SOURCE host lint. The companion to podspecRefHostLint, and the
+  # timing-independent half of the Pillar-5 proof.
+  #
+  # The deny-egress hold below applies a cluster-wide default-deny CCNP, holds
+  # for durationSeconds, and is then TORN DOWN. That proves nothing external was
+  # REACHABLE during the window. It does NOT prove the Sovereign has no external
+  # DEPENDENCY, and ADR-0002 asserts the second. Live hw292 (2026-08-04):
+  # HelmRepository vcluster-system/loft -> https://charts.loft.sh, interval 15m,
+  # not suspended, referenced by a live HelmRelease. A 15m interval can straddle
+  # a 600s hold entirely, so it never dialled while the policy was up; its
+  # artifact was then re-fetched from the public internet ~10h AFTER
+  # cutoverComplete=true. The hold passed, and was right to pass — nothing
+  # asserted over the object graph.
+  #
+  # This lint asserts the property directly: every non-suspended HelmRepository,
+  # GitRepository and OCIRepository must resolve to a Sovereign-local host.
+  #
+  # NOTE the exemption set is deliberately NARROWER than podspecRefHostLint's.
+  # That lint exempts step-04 HOST_PROJECT_MAP hosts because containerd rewrites
+  # IMAGE pulls via certs.d. Flux's source-controller fetches these URLs itself
+  # and never traverses containerd, so a certs.d redirect cannot cover a source
+  # object — only genuinely local hosts count.
+  #
+  # allowHosts is EMPTY by default so the lint fails closed: an external host is
+  # a tether until a human declares otherwise here, in Git, under review. Adding
+  # an entry is a reviewable sovereignty exception, not a config tweak.
+  fluxSourceHostLint:
+    enabled: true
+    allowHosts: []
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.161",
+      "version": "0.1.162",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.161",
+    "version": "0.1.162",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.161"
+  version: "0.1.162"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.161"
+    version: "0.1.162"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The gap

Step-08's deny-egress hold applies a cluster-wide default-deny CCNP, holds for `durationSeconds`, and is then **torn down**. That proves exactly one thing: nothing external was *reachable* during the window. It cannot prove the Sovereign has no external *dependency*, and ADR-0002 asserts the second.

Live on hw292 (`cutoverComplete=true` since 08:12:30Z):

| Probe | Reading |
|---|---|
| `vcluster-system/loft` | `https://charts.loft.sh`, `type: default`, `managed-by: Helm` |
| Referenced by | 1 HelmRelease |
| Status | `Ready=True`, `ArtifactInStorage=True` |
| `spec.interval` | **15m**, `suspend` unset |
| Artifact fetched | **2026-08-03T18:36:28Z**, ~10h after cutover |
| `ccnp/cutover-egress-block` now | **ABSENT** — torn down after the hold, by design |
| Control | `bp-cilium` → `oci://registry.hw292.omani.works/openova-io` |

Both statements are true at once: nothing external was reachable for 600 seconds, **and** this Sovereign fetches from `charts.loft.sh` every 15 minutes. A 15m interval can straddle a 600s hold entirely, so the tether need never fire while the policy is up, and it resumes the moment the policy is gone.

## Correcting the record

I first filed #5650 claiming step-08 "blocks a named list, so it cannot detect any unenumerated tether." **That was wrong.** `defaultDenyEgress: true` has shipped since #3678 and genuinely black-holes every public destination including `charts.loft.sh`; `blockedDomains` survives only as the call-home assertion. I had read the legacy subtractive branch and generalised without checking which one ships. Corrected publicly on the issue before writing any code — acting on the original claim would have meant rewriting a mechanism that is already correct.

## The fix

A pre-hold **Flux source host lint**, modelled on the pod-spec ref-host lint step-08 already runs (#5026/#5036) — a static assertion over the object graph, independent of timing. Every non-suspended `HelmRepository` / `GitRepository` / `OCIRepository` must resolve to a Sovereign-local host.

- `allowHosts` defaults **empty**, so the lint fails closed: an external host is a tether until a human declares an exception in Git, under review.
- A suspended source is reported but does not fail — it cannot reconcile.
- The exemption set is deliberately **narrower** than the pod-spec lint's. That one exempts step-04 `HOST_PROJECT_MAP` hosts because containerd rewrites image pulls via `certs.d`. Flux's source-controller fetches these URLs itself and never traverses containerd, so a `certs.d` redirect cannot cover a source object — `harbor.openova.io` as a *source* URL stays a failure, and there is a test case for exactly that.

## The test, and the bug it caught

`chart/tests/flux-source-host-lint.sh` extracts the shell function from the **render** rather than a hand-kept copy (per #5646, where a suite validated a copy that had drifted) and drives it against a stub `kubectl`:

```
  ok   — all-local sources (PASS)
  ok   — external charts.loft.sh source (FAIL)
  ok   — same source with an explicit allowHosts entry (PASS)
  ok   — suspended external source (PASS)
  ok   — external GitRepository (FAIL)
  ok   — external OCIRepository (FAIL)
  ok   — mothership harbor.openova.io source (no containerd redirect applies) (FAIL)
  ok   — local host with port and path (PASS)
  ok   — unwritable scratch dir (FAIL)
```

Case 3 is the vacuity control: the *same* inventory as case 2, differing only by the allow entry, proving the failure keyed on the host rather than on the namespace or the extra row.

**Case 9 exists because the suite caught a fail-open bug in the first draft.** When the scratch file could not be created, every append silently no-op'd, `-s` was false, and the lint returned `PASS` having examined nothing — a guard reporting success from an empty measurement, which is precisely the defect class this lint exists to eliminate. It would have shipped unnoticed had the suite only ever been run in the passing direction. Now fail-closed, pinned.

## Gates

| gate | result |
|---|---|
| `scripts/check-bootstrap-kit-pin-sync.sh` | PASS — 67 chart→pin pairs in sync |
| `chart/tests/cutover-contract.sh` | all gates green (75 cases) |
| `chart/tests/flux-source-host-lint.sh` | 9/9, both directions |
| `helm template` | renders; both new env vars present |

Five-site lockstep bumped to `0.1.162`: `Chart.yaml`, `blueprint.yaml`, `clusters/_template/bootstrap-kit/06a-…`, the catalog seed, and `blueprints.json`.

## What this does NOT do

It does not close the `charts.loft.sh` tether itself — mirroring loft into the local Harbor and repointing the source is the instance fix and is still open on #5650. This PR makes the *next* fresh prov refuse to report `cutoverComplete=true` while any such source exists, which is what stops the class from recurring silently.

Refs #5650 #5527 #3379 #3678
