### PR TITLE
fix(netpol): cluster DNS for every constrained workload + a fail-closed class gate (Refs #5617)

### DIFF
--- a/.github/workflows/check-netpol-egress-completeness.yaml
+++ b/.github/workflows/check-netpol-egress-completeness.yaml
@@ -1,0 +1,69 @@
+name: check — network-policy egress completeness (#5617)
+
+# The #5617 / #4437 CLASS gate.
+#
+# Twice a chart has shipped a policy that constrains a workload and named only
+# the INGRESS half. #4437: bp-sso-bridge's egress CNP omitted openbao. #5617:
+# the per-Org bp-oidc-gate companion shipped `oidc-gate-<cid>-gateway-ingress`
+# and no egress counterpart, so under the per-Org namespace's default-deny the
+# gate pod could not resolve cluster DNS and EVERY OAuth callback returned 500
+# AFTER a successful login (live hw292, Org uatco).
+#
+# scripts/check-netpol-egress-completeness.py renders every policy-bearing
+# chart and asserts, per selected endpoint, that the UNION of its egress rules
+# allows 53/UDP + 53/TCP to cluster DNS. It asserts on the parsed VALUES, never
+# on the presence of an `egress` key — a hollow `egress: []` is a FAIL, which is
+# the #5639/#5641 lesson applied here. Phase 0 proves the classifier still bites
+# five known-broken shapes before any verdict is trusted; a chart that renders
+# zero policy documents, or fails to render at all, is a blind spot and FAILS.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'clusters/_template/bootstrap-kit/**'
+      - 'core/controllers/organization/**'
+      - 'scripts/check-netpol-egress-completeness.py'
+      - '.github/workflows/check-netpol-egress-completeness.yaml'
+  pull_request:
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'clusters/_template/bootstrap-kit/**'
+      - 'core/controllers/organization/**'
+      - 'scripts/check-netpol-egress-completeness.py'
+      - '.github/workflows/check-netpol-egress-completeness.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  netpol-egress-completeness:
+    name: Every constrained workload keeps cluster DNS
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          # >= 3.16.2 for the same dependency-resolution reasons documented in
+          # check-no-nodeports.yaml — 3.16.0 cannot fetch a subchart on a clean
+          # checkout, which would read as a policy blind spot rather than the
+          # helm bug it is.
+          version: v3.16.3
+
+      - name: Run the egress-completeness class gate
+        run: python3 scripts/check-netpol-egress-completeness.py --table

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -87,7 +87,17 @@ spec:
       # `/app/?token=<sentinel>` so the SPA seeds the token and lands
       # authenticated with NO paste (the durable path — the daemon's `oidc`
       # authMode is a non-functional upstream scaffold, #128).
-      version: 0.1.8
+      # 0.1.9 (#5617, 2026-08-04): the gate ships its OWN policy halves per
+      # instance — gateway-ingress (reserved `ingress` entity → :4180) and
+      # egress (kube-dns 53 UDP+TCP, the Keycloak backchannel on the Service
+      # port AND pod port 8080, and each instance's upstream derived from its
+      # `upstream` URL). Before this the gate carried no policy at all and
+      # worked only because bp-plane-isolation (slot 26b) leaves this
+      # namespace's egress unconstrained — the same implicit dependency that,
+      # absent in a per-Org namespace, 500'd every OAuth callback on hw292.
+      # Additive: Cilium unions policies, so the effective egress set here is
+      # unchanged while slot 26b is installed.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate

--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -686,6 +686,45 @@ spec:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: flux-system
   egress:
+    # CLUSTER DNS — 53 UDP + TCP to kube-system CoreDNS.
+    #
+    # #5617 ROOT CAUSE. This policy carries an egress section under
+    # endpointSelector {}, and in Cilium the moment ANY policy selecting an
+    # endpoint declares egress, that endpoint's egress becomes deny-by-default
+    # outside the union of every such policy. So this one rule set decides
+    # egress for EVERY pod in the Org namespace. It used to name kube-apiserver
+    # and same-namespace endpoints and NOTHING else — no DNS — which left every
+    # workload that ships no DNS egress of its own unable to resolve a single
+    # name. Measured live on hw292 Org uatco: the bp-oidc-gate companion
+    # (ingress-only CNP) 500'd every OAuth callback AFTER a successful login —
+    # oauthproxy.go:881, lookup keycloak.keycloak.svc.cluster.local on
+    # 10.96.0.10:53 i/o timeout — while the sibling agenity pod in the SAME
+    # namespace resolved fine because its chart ships an egress CNP with DNS.
+    #
+    # Fixing it per-chart is a per-instance patch that the NEXT per-Org chart
+    # re-breaks (#4437 was the first recurrence, #5617 the second). DNS belongs
+    # in the namespace baseline: it is required by every workload without
+    # exception, and admitting it weakens no isolation boundary — CoreDNS is a
+    # read-only name service, and cross-Org/cross-Environment denial is
+    # unchanged because this grants nothing but :53 to kube-system.
+    #
+    # toEndpoints, NEVER toCIDR/ipBlock: a CIDR rule cannot match an in-cluster
+    # pod identity under Cilium (#4360) and never matches a ClusterMesh remote
+    # identity (#4656), so a CIDR-shaped DNS allow would be inert here and
+    # silently re-break the second region of a 2-region Sovereign.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
     # Admit egress to the cluster API (the reserved kube-apiserver entity) so an
     # in-vcluster Org app pod / in-cluster client can reach :443/:6443.
     - toEntities:

--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -712,6 +712,12 @@ spec:
     # pod identity under Cilium (#4360) and never matches a ClusterMesh remote
     # identity (#4656), so a CIDR-shaped DNS allow would be inert here and
     # silently re-break the second region of a 2-region Sovereign.
+    #
+    # L3/L4 ONLY — deliberately no L7 dns rule here. An L7 DNS rule would put
+    # EVERY pod in the Organization namespace behind the cilium-agent DNS proxy,
+    # which is a datapath and latency change this policy has no reason to make:
+    # the goal is to stop denying DNS, not to filter it. A per-workload chart CNP
+    # may still add an L7 DNS rule for its own pods; Cilium unions the two.
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: kube-system
@@ -722,9 +728,6 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
-          rules:
-            dns:
-              - matchPattern: "*"
     # Admit egress to the cluster API (the reserved kube-apiserver entity) so an
     # in-vcluster Org app pod / in-cluster client can reach :443/:6443.
     - toEntities:

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -609,3 +609,97 @@ func TestBoundaryIsVcluster_FlippableGate(t *testing.T) {
 		}
 	}
 }
+
+// TestRender_CiliumNetworkPolicyCarriesClusterDNSEgress is the #5617 regression
+// gate, asserted on the VALUE not the key.
+//
+// The per-Org host-side CNP selects every endpoint in the Org namespace
+// (endpointSelector {}) AND declares egress. Under Cilium that makes egress
+// deny-by-default for every pod in the namespace, so whatever this rule set
+// omits is unreachable for the whole Org. It used to omit cluster DNS: the
+// bp-oidc-gate companion (which ships an ingress-only CNP) could not resolve
+// keycloak.keycloak.svc.cluster.local and 500'd every OAuth callback AFTER a
+// successful login (live hw292, Org uatco, oauthproxy.go:881).
+//
+// A `strings.Contains(s, "53")` here would pass on a port number appearing
+// anywhere in the document, so this walks the parsed structure and requires a
+// rule that pairs kube-system/kube-dns with BOTH 53/UDP and 53/TCP.
+func TestRender_CiliumNetworkPolicyCarriesClusterDNSEgress(t *testing.T) {
+	t.Parallel()
+	for _, slug := range []string{"m", "s"} {
+		out, err := Render(Inputs{Slug: "acme", DisplayName: "Acme", Tier: "org",
+			PlanSlug: slug, SovereignFQDN: "x.example", HostCluster: "hz", VClusterChartVersion: "0.33.*"})
+		if err != nil {
+			t.Fatalf("Render(%s): %v", slug, err)
+		}
+		raw, ok := out["vcluster/host-apps/ciliumnetworkpolicy.yaml"]
+		if !ok {
+			t.Fatalf("plan %s: missing host-apps/ciliumnetworkpolicy.yaml", slug)
+		}
+		var doc struct {
+			Spec struct {
+				Egress []struct {
+					ToEndpoints []map[string]map[string]string `json:"toEndpoints"`
+					ToCIDR      []string                       `json:"toCIDR"`
+					ToCIDRSet   []map[string]string            `json:"toCIDRSet"`
+					ToPorts     []struct {
+						Ports []struct {
+							Port     string `json:"port"`
+							Protocol string `json:"protocol"`
+						} `json:"ports"`
+					} `json:"toPorts"`
+				} `json:"egress"`
+			} `json:"spec"`
+		}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("plan %s: CNP did not parse: %v", slug, err)
+		}
+		if len(doc.Spec.Egress) == 0 {
+			t.Fatalf("plan %s: CNP declares no egress rules at all", slug)
+		}
+		var udp, tcp bool
+		for _, rule := range doc.Spec.Egress {
+			// The destination must be cluster DNS itself. A port-53 allow aimed
+			// at the Org's own namespace is not DNS coverage.
+			toDNS := false
+			for _, ep := range rule.ToEndpoints {
+				ml := ep["matchLabels"]
+				if ml["k8s:io.kubernetes.pod.namespace"] == "kube-system" && ml["k8s-app"] == "kube-dns" {
+					toDNS = true
+				}
+			}
+			if !toDNS {
+				continue
+			}
+			for _, tp := range rule.ToPorts {
+				for _, p := range tp.Ports {
+					if p.Port != "53" {
+						continue
+					}
+					switch p.Protocol {
+					case "UDP":
+						udp = true
+					case "TCP":
+						tcp = true
+					}
+				}
+			}
+		}
+		if !udp || !tcp {
+			t.Errorf("plan %s: #5617 — the per-Org CNP constrains egress for EVERY pod in the "+
+				"Org namespace but does not allow 53/UDP+53/TCP to kube-system/kube-dns "+
+				"(udp=%v tcp=%v). Every workload that ships no DNS egress of its own is mute.\n%s",
+				slug, udp, tcp, string(raw))
+		}
+		// #4360/#4656: a CIDR rule matches neither an in-cluster pod identity nor
+		// a ClusterMesh remote identity, so a CIDR-shaped DNS allow would be inert
+		// and would silently re-break the peer region.
+		for _, rule := range doc.Spec.Egress {
+			if len(rule.ToCIDR) > 0 || len(rule.ToCIDRSet) > 0 {
+				t.Errorf("plan %s: the per-Org CNP must express destinations as toEndpoints/"+
+					"toEntities — a toCIDR/ipBlock never matches a ClusterMesh remote identity "+
+					"(#4360/#4656)\n%s", slug, string(raw))
+			}
+		}
+	}
+}

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -386,6 +386,19 @@ These are OpenOva-platform-specific anti-patterns — concrete PR / issue receip
 
 **Proving it:** render the template twice (each render = one region's Helm run) and hash. Pre-fix yields two values; post-fix the chart should render **zero** literals for that key. Verify live by hash only — never print secret values, this repo is public. A digest of `e3b0c442` everywhere means your jsonpath matched nothing (sha256 of empty input), not that the values match.
 
+### A17 — Ingress-only policy shipped into a namespace whose egress is already constrained
+
+| | |
+|---|---|
+| **Receipt** | #4437 (bp-sso-bridge's egress CNP omitted openbao), #5617 (the per-Org bp-oidc-gate companion shipped `oidc-gate-<cid>-gateway-ingress` and no egress counterpart) — the second recurrence, 2026-08-04 |
+| **Shape** | A chart writes the policy half that makes its pod **reachable** and stops there. The pod is Running, its HTTPRoute resolves, the browser reaches it — and its first outbound name lookup is dropped, because something ELSE in that namespace already declared egress. |
+| **Why this is wrong** | Cilium evaluates the **union** of every policy selecting an endpoint, and the moment ANY of them declares `egress` that endpoint is deny-by-default outside the union. On this platform a per-Organization `<slug>` namespace always carries such a policy (`allow-gateway-and-apiserver`, `endpointSelector: {}`). So "my chart only adds an ingress allow" is never true there. The symptom is maximally misleading: on #5617 the whole OAuth round-trip succeeded and the callback then 500'd after a 48–60 s DNS timeout, which reads as a Keycloak or token problem, not a policy one. The control that settles it is a **sibling pod in the same namespace** — on hw292 the agenity pod resolved the identical name because its chart ships an egress CNP. |
+| **Right fix shape** | Fix at the seam that decides egress for the whole namespace, not per consumer. #5617's durable fix put cluster DNS in the per-Org baseline CNP (`core/controllers/organization/internal/gitops/manifests.go`) so every current and future per-Org workload has it, and made the chart carry its own halves so it is correct wherever it is installed. Destinations are `toEndpoints`/`toEntities`, **never** `toCIDR`/`ipBlock` — a CIDR matches neither an in-cluster pod identity (#4360) nor a ClusterMesh remote identity (#4656), so a CIDR-shaped DNS allow is inert and silently strands the peer region. |
+
+**The port trap (#4437, still live):** allowing only the Service port drops the traffic. Cilium's verdict runs **after** the Service DNAT, so the **Pod** target port is the load-bearing one — a Keycloak allow must name 80 **and** 8080.
+
+**Guard:** `scripts/check-netpol-egress-completeness.py` renders every policy-bearing chart and asserts, per selected endpoint, that the union of its egress rules allows 53/UDP + 53/TCP to cluster DNS. It asserts on parsed **values** — a hollow `egress: []`, a `port: 53` aimed at the workload's own namespace, and a UDP-only rule are all FAIL — and its Phase 0 proves the classifier still bites five known-broken shapes before any verdict is trusted.
+
 ---
 
 ## Cross-cutting flags that trigger a "stop and investigate" pass
@@ -540,6 +553,7 @@ Mapping (Anti-pattern → Principle it violates):
 | A14 (bulk-template closure overrides evidence) | §6, §7 |
 | A15 (stable-state walk passed off as fresh-prov) | §7, Part IV rule 7 + [`DOD.md`](DOD.md) (operator-walked fresh-prov evidence) |
 | A16 (per-region secret on a shared VIP) | §2 (no workarounds), §7, Part III.4 (repo-wide enumeration on class recurrence) |
+| A17 (ingress-only policy in an egress-constrained namespace) | §2 (no workarounds), §7, Part III.4 (repo-wide enumeration on class recurrence) |
 
 When you catch a new shape of failure in a PR review, add an A16+ entry here with the PR / issue number, the shape, why it's wrong, and the right fix shape. The catalog grows so the next session catches the same shape sooner.
 

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -9,7 +9,12 @@ spec:
   # 0.1.6 (#4556): spaTokenSeed — TRUE zero-click for a token-paste SPA
   # (agenity/chepherd). 302s the bare root, post-SSO, to /app/?token=<sentinel>
   # so the SPA seeds localStorage and lands authenticated with NO paste.
-  version: 0.1.8
+  # 0.1.9 (#5617): the chart ships its own per-instance CiliumNetworkPolicy
+  # pair (gateway-ingress + egress with kube-dns / Keycloak backchannel /
+  # upstream) instead of relying on bp-plane-isolation leaving the oidc-gate
+  # namespace's egress open. Lockstep with platform/oidc-gate/chart +
+  # the bootstrap-kit slot 13c pin.
+  version: 0.1.9
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -147,7 +147,30 @@ name: bp-oidc-gate
 # has used since #2807) and the per-instance ExternalSecret now pulls BOTH
 # properties into the one `oidc-gate-<name>-oidc` Secret. Requires
 # bp-sso-bridge >= 0.2.26.
-version: 0.1.8
+#
+# 0.1.9 (#5617, 2026-08-04): the gate finally ships its OWN network policy.
+# Until now this chart rendered NONE, and the gate pods were reachable — and
+# able to dial out — only because a DIFFERENT chart left the door open:
+# bp-plane-isolation (slot 26b) covers the `oidc-gate` namespace with a
+# gateway-ingress CNP plus a default-deny whose EGRESS half is deliberately
+# unconstrained (`namespaceSelector: {}` + `ipBlock 0.0.0.0/0`); its values
+# file says so verbatim ("It egresses to keycloak … both covered by the open
+# egress rule"). That cross-chart implicit dependency IS the #5617 class: the
+# byte-equivalent gate resource set rendered by bp-agenity into a per-Org
+# namespace, where nothing leaves egress open, could not resolve cluster DNS
+# and 500'd EVERY OAuth callback after a successful login (live hw292, Org
+# uatco). templates/networkpolicy.yaml now renders both halves per instance —
+# `<gate>-gateway-ingress` (reserved `ingress` entity → :4180) and
+# `<gate>-egress` (kube-dns 53 UDP+TCP · the Keycloak backchannel on the
+# Service port AND pod port 8080 per the #4437 port trap · the instance's own
+# upstream, derived from its `upstream` URL so the policy cannot drift · and
+# world:443 only in #3844 public-discovery mode). Destinations are
+# toEndpoints/toEntities, never toCIDR — a CIDR matches neither an in-cluster
+# pod identity (#4360) nor a ClusterMesh remote identity (#4656). ADDITIVE:
+# Cilium unions every policy selecting an endpoint, so while
+# bp-plane-isolation's open-egress rule is present the effective union is
+# unchanged and no working gate can be severed.
+version: 0.1.9
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/networkpolicy.yaml
+++ b/platform/oidc-gate/chart/templates/networkpolicy.yaml
@@ -1,0 +1,172 @@
+{{- /*
+bp-oidc-gate per-instance NETWORK POLICY pair (#5617).
+
+WHY THIS EXISTS
+───────────────────────────────────────────────────────────────────────
+Until 0.1.9 this chart shipped NO policy at all. The gate pods were
+reachable, and could dial out, only because a DIFFERENT chart happened to
+leave the door open: bp-plane-isolation (slot 26b) renders the `oidc-gate`
+namespace's default-deny with `gatewayIngress: true` for the ingress half
+and an egress half that is deliberately unconstrained
+(`namespaceSelector: {}` + `ipBlock 0.0.0.0/0`). Its own values file says
+so, verbatim: "It egresses to keycloak (backchannel OIDC) + its upstream
+app — both covered by the open egress rule".
+
+That cross-chart implicit dependency IS the #5617 class. The identical gate
+resource set, rendered by bp-agenity into a per-Organization namespace where
+NOTHING leaves egress open, could not resolve cluster DNS and 500'd every
+OAuth callback AFTER a successful login (live hw292, Org uatco,
+oauthproxy.go:881: lookup keycloak.keycloak.svc.cluster.local on
+10.96.0.10:53 i/o timeout). Same chart shape, different namespace, silently
+broken — because the policy lived somewhere else. So the gate now carries
+its own two halves and is correct wherever it is installed.
+
+ADDITIVE, NOT A TIGHTENING OF TODAY'S BEHAVIOUR
+───────────────────────────────────────────────────────────────────────
+Cilium evaluates the UNION of every policy selecting an endpoint. While
+bp-plane-isolation's open-egress rule is present the union is unchanged, so
+this cannot sever a gate that works today; it only removes the dependency on
+that rule still being there tomorrow.
+
+DESTINATIONS ARE toEndpoints/toEntities, NEVER toCIDR
+───────────────────────────────────────────────────────────────────────
+An ipBlock/toCIDR rule matches neither an in-cluster pod identity (#4360)
+nor a ClusterMesh remote pod identity (#4656), so on a 2-region Sovereign a
+CIDR-shaped allow silently drops the region whose Keycloak backend is
+remote. Every rule below names identities.
+*/ -}}
+{{- $root := . -}}
+{{- $np := .Values.networkPolicy | default dict -}}
+{{- if and (ne (toString $np.enabled) "false") ($root.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- $egressCfg := $np.egress | default dict -}}
+{{- $kcNamespace := $egressCfg.keycloakNamespace | default "keycloak" -}}
+{{- $kcPort := $egressCfg.keycloakPort | default 80 -}}
+{{- $kcInternal := trimSuffix "/" ($root.Values.keycloakInternalURL | default "") -}}
+{{- range $inst := .Values.instances }}
+{{- if ne (toString $inst.enabled | default "true") "false" }}
+{{- $hostname := include "bp-oidc-gate.instanceHostname" (dict "root" $root "inst" $inst) }}
+{{- if $hostname }}
+{{- $gateName := printf "oidc-gate-%s" $inst.name }}
+{{- /*
+Upstream identity, derived from the instance's own `upstream` URL — the one
+place the dial target is already declared, so the policy can never drift from
+what oauth2-proxy actually proxies to. Shape:
+  http://<service>.<namespace>.svc.cluster.local:<port>
+A bare single-label host (http://svc:8080) is read as this release's own
+namespace, which is what a bare service name means. An empty upstream is a
+chart-authoring error and fails the render (Inviolable Principle #4).
+*/ -}}
+{{- $raw := $inst.upstream | default "" }}
+{{- if not $raw }}
+{{- fail (printf "bp-oidc-gate: instance %q has no `upstream` — the egress policy cannot name a destination it was never told about" $inst.name) }}
+{{- end }}
+{{- $isTLS := hasPrefix "https://" $raw }}
+{{- $noScheme := regexReplaceAll "^https?://" $raw "" }}
+{{- $hostPort := first (splitList "/" $noScheme) }}
+{{- $hpParts := splitList ":" $hostPort }}
+{{- $upHost := index $hpParts 0 }}
+{{- $upPort := ternary "443" "80" $isTLS }}
+{{- if gt (len $hpParts) 1 }}{{- $upPort = index $hpParts 1 }}{{- end }}
+{{- $hostLabels := splitList "." $upHost }}
+{{- $upNamespace := $root.Release.Namespace }}
+{{- if gt (len $hostLabels) 1 }}{{- $upNamespace = index $hostLabels 1 }}{{- end }}
+---
+# ── CiliumNetworkPolicy — admit the Cilium Gateway Envoy to the gate pod ──
+# The gate's HTTPRoute owns the app's public hostname; gateway traffic carries
+# the reserved `ingress` ENTITY identity that NO K8s NetworkPolicy selector can
+# match, so under any default-deny the gateway→gate hop is dropped and the
+# browser sees envoy 503 (the #4180/#3785/#3374 class).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-gateway-ingress" $gateName | quote }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "bp-oidc-gate.labels" $root | nindent 4 }}
+    catalyst.openova.io/component: {{ printf "%s-netpol" $gateName | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bp-oidc-gate
+      catalyst.openova.io/component: {{ $gateName }}
+  ingress:
+    - fromEntities:
+        - ingress
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+---
+# ── CiliumNetworkPolicy — the gate's EGRESS half (#5617) ──────────────────
+# Exactly the gate's dial surface, nothing wider:
+#   1. kube-dns :53 UDP+TCP — LOAD-BEARING. Once ANY policy constrains this
+#      endpoint's egress, an unnamed DNS is a denied DNS, and oauth2-proxy's
+#      first act on a callback is to resolve the Keycloak backchannel host.
+#   2. the Keycloak backchannel (redeem / jwks / userinfo) — the Service port
+#      AND the Pod target port 8080, because Cilium's verdict runs AFTER the
+#      Service DNAT so the POD port is the load-bearing one (#4437's port trap:
+#      allowing only 80 drops the traffic).
+#   3. the proxied upstream, derived from this instance's own `upstream` URL.
+#   4. world:443 ONLY when keycloakInternalURL is unset (#3844 public-discovery
+#      mode) — an off-cluster hop nothing but `toEntities: [world]` can name.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" $gateName | quote }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "bp-oidc-gate.labels" $root | nindent 4 }}
+    catalyst.openova.io/component: {{ printf "%s-netpol" $gateName | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bp-oidc-gate
+      catalyst.openova.io/component: {{ $gateName }}
+  egress:
+    # 1. Cluster DNS.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    # 2. Keycloak backchannel — Service port AND Pod port 8080.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $kcNamespace }}
+      toPorts:
+        - ports:
+            - port: {{ $kcPort | quote }}
+              protocol: TCP
+            - port: "8080"
+              protocol: TCP
+    # 3. The proxied upstream ({{ $raw }}).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $upNamespace }}
+      toPorts:
+        - ports:
+            - port: {{ $upPort | quote }}
+              protocol: TCP
+{{- if not $kcInternal }}
+    # 4. Public-issuer discovery fallback (#3844 public-discovery mode).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/oidc-gate/chart/tests/netpol-render.sh
+++ b/platform/oidc-gate/chart/tests/netpol-render.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# bp-oidc-gate — #5617 network-policy render audit.
+#
+# Until 0.1.9 this chart shipped NO policy at all. Its gate pods worked only
+# because a DIFFERENT chart left the door open: bp-plane-isolation (slot 26b)
+# renders the `oidc-gate` namespace's default-deny with an EGRESS half that is
+# deliberately unconstrained. The identical resource set, rendered by bp-agenity
+# into a per-Organization namespace where nothing leaves egress open, could not
+# resolve cluster DNS and 500'd every OAuth callback AFTER a successful login
+# (live hw292, Org uatco, oauthproxy.go:881: lookup
+# keycloak.keycloak.svc.cluster.local on 10.96.0.10:53 i/o timeout).
+#
+# The assertions below run against the PARSED egress document, PER RULE, so a
+# port number appearing anywhere else in the render cannot satisfy them — the
+# #5639 lesson (a grep for `key: openova.io/region` passed on an EMPTY value).
+#
+# This test asserts:
+#   1. both halves render per instance: <gate>-gateway-ingress (reserved
+#      `ingress` entity on 4180) and <gate>-egress;
+#   2. the egress document allows 53/UDP AND 53/TCP to kube-system/kube-dns —
+#      asserted on the rule that names kube-dns, not on the document as a whole;
+#   3. it allows the Keycloak backchannel on the Service port AND the Pod port
+#      8080 (#4437's port trap: allowing only 80 drops it post-DNAT);
+#   4. it allows the instance's own upstream namespace + port, derived from the
+#      `upstream` URL so the policy cannot drift from what the proxy dials;
+#   5. NO toCIDR / ipBlock anywhere — a CIDR matches neither an in-cluster pod
+#      identity (#4360) nor a ClusterMesh remote identity (#4656);
+#   6. the world:443 discovery fallback renders ONLY when keycloakInternalURL is
+#      cleared (#3844 public-discovery mode);
+#   7. networkPolicy.enabled=false suppresses BOTH halves while the rest of the
+#      instance set still renders — the vacuity check in the other direction, so
+#      a green run cannot mean "the template produced nothing under every input".
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+fqdn="smoke.example.com"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+cat >"$work/values.yaml" <<YAML
+sovereignFQDN: ${fqdn}
+realm: sovereign
+instances:
+  - name: openova-flow
+    enabled: true
+    clientId: openova-flow
+    upstream: http://openova-flow-server.catalyst-system.svc.cluster.local:8080
+YAML
+
+cat >"$work/assert.py" <<'PY'
+"""Structural assertions on a rendered policy document.
+
+  assert.py rule   <render> <policy-name> <dest-namespace> <port> <protocol>
+  assert.py absent <render> <policy-name> <substring>
+  assert.py present <render> <policy-name> <substring>
+
+`rule` requires ONE egress rule to name BOTH the destination namespace AND the
+port/protocol. Asserting them separately would pass on a policy that allows :53
+to the upstream and :8080 to CoreDNS — the exact shape of a broken policy.
+"""
+import sys, yaml
+
+mode, path, name = sys.argv[1], sys.argv[2], sys.argv[3]
+doc = None
+for d in yaml.safe_load_all(open(path).read()):
+    if isinstance(d, dict) and (d.get("metadata") or {}).get("name") == name:
+        doc = d
+        break
+if doc is None:
+    print(f"FAIL: no rendered document named {name}", file=sys.stderr)
+    sys.exit(1)
+body = yaml.safe_dump(doc, sort_keys=False)
+
+if mode == "rule":
+    ns, port, proto = sys.argv[4], sys.argv[5], sys.argv[6]
+    for rule in (doc.get("spec") or {}).get("egress") or []:
+        if not any(
+            (ep.get("matchLabels") or {}).get("k8s:io.kubernetes.pod.namespace") == ns
+            for ep in rule.get("toEndpoints") or []
+        ):
+            continue
+        for tp in rule.get("toPorts") or []:
+            for p in tp.get("ports") or []:
+                if str(p.get("port")) == port and str(p.get("protocol")) == proto:
+                    sys.exit(0)
+    print(f"FAIL: {name} has no egress rule allowing {port}/{proto} to namespace {ns}", file=sys.stderr)
+    print(body, file=sys.stderr)
+    sys.exit(1)
+
+needle = sys.argv[4]
+found = needle in body
+if mode == "present" and not found:
+    print(f"FAIL: {name} does not contain {needle!r}", file=sys.stderr)
+    print(body, file=sys.stderr)
+    sys.exit(1)
+if mode == "absent" and found:
+    print(f"FAIL: {name} contains {needle!r} and must not", file=sys.stderr)
+    print(body, file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+
+render() { "$helm" template oidc-gate "$chart_dir" -a cilium.io/v2 -f "$work/values.yaml" "$@"; }
+assert() { python3 "$work/assert.py" "$@"; }
+
+ing="oidc-gate-openova-flow-gateway-ingress"
+egr="oidc-gate-openova-flow-egress"
+
+# ── Case 1: both halves render, and the egress half is complete ─────────────
+echo "[netpol] Case 1: both policy halves render with a complete dial surface"
+render >"$work/on.yaml" 2>/dev/null
+
+assert present "$work/on.yaml" "$ing" "fromEntities"
+assert present "$work/on.yaml" "$ing" "4180"
+if ! python3 - "$work/on.yaml" "$egr" <<'PY'
+import sys, yaml
+path, name = sys.argv[1], sys.argv[2]
+for d in yaml.safe_load_all(open(path).read()):
+    if isinstance(d, dict) and (d.get("metadata") or {}).get("name") == name:
+        sys.exit(0)
+sys.exit(1)
+PY
+then
+  echo "FAIL: #5617 — the gate rendered NO egress policy. Under a default-deny" >&2
+  echo "      namespace its DNS is denied and every OAuth callback 500s after a" >&2
+  echo "      successful login." >&2
+  exit 1
+fi
+
+# 2. cluster DNS — both protocols, aimed at kube-system.
+assert rule "$work/on.yaml" "$egr" kube-system 53 UDP
+assert rule "$work/on.yaml" "$egr" kube-system 53 TCP
+# 3. Keycloak backchannel — Service port AND Pod port.
+assert rule "$work/on.yaml" "$egr" keycloak 80 TCP
+assert rule "$work/on.yaml" "$egr" keycloak 8080 TCP
+# 4. the instance's own upstream, taken from the upstream URL.
+assert rule "$work/on.yaml" "$egr" catalyst-system 8080 TCP
+echo "  PASS"
+
+# ── Case 2: no CIDR-shaped destinations anywhere ────────────────────────────
+echo "[netpol] Case 2: destinations are identities, never CIDRs (#4360/#4656)"
+assert absent "$work/on.yaml" "$egr" "toCIDR"
+assert absent "$work/on.yaml" "$egr" "ipBlock"
+echo "  PASS"
+
+# ── Case 3: the world:443 fallback is conditional, not unconditional ────────
+echo "[netpol] Case 3: world:443 renders only in public-discovery mode (#3844)"
+assert absent "$work/on.yaml" "$egr" "world"
+render --set keycloakInternalURL="" >"$work/public.yaml" 2>/dev/null
+assert present "$work/public.yaml" "$egr" "world"
+echo "  PASS"
+
+# ── Case 4: vacuity — the gate CAN be turned off, and only the policies go ──
+echo "[netpol] Case 4: networkPolicy.enabled=false suppresses both halves"
+render --set networkPolicy.enabled=false >"$work/off.yaml" 2>/dev/null
+if grep -qE "name: \"($ing|$egr)\"" "$work/off.yaml"; then
+  echo "FAIL: networkPolicy.enabled=false still rendered a policy" >&2
+  exit 1
+fi
+# …and the rest of the instance set is untouched, so Case 4 cannot pass merely
+# because the whole chart went silent.
+grep -qF 'name: "oidc-gate-openova-flow"' "$work/off.yaml" || {
+  echo "FAIL: networkPolicy.enabled=false suppressed the whole instance set — Case 4" >&2
+  echo "      would then pass vacuously." >&2
+  exit 1
+}
+echo "  PASS"
+
+echo "[netpol] ALL CASES PASS"

--- a/platform/oidc-gate/chart/values.yaml
+++ b/platform/oidc-gate/chart/values.yaml
@@ -71,6 +71,34 @@ resources:
     cpu: 100m
     memory: 64Mi
 
+# ── Network policy (#5617) ───────────────────────────────────────────
+# The gate renders its OWN two policy halves per instance instead of
+# depending on another chart leaving the namespace open. Until 0.1.9 it
+# shipped none: on a Sovereign the `oidc-gate` namespace happened to be
+# covered by bp-plane-isolation (slot 26b) — gateway-ingress CNP for the
+# ingress half, and a default-deny whose EGRESS half is deliberately
+# unconstrained. The identical resource set rendered by bp-agenity into a
+# per-Organization namespace, where nothing leaves egress open, could not
+# resolve cluster DNS and 500'd every OAuth callback after a successful
+# login (#5617, live hw292 Org uatco).
+#
+# ADDITIVE while bp-plane-isolation's open-egress rule is present (Cilium
+# unions every policy selecting an endpoint), so enabling this cannot sever
+# a gate that works today.
+networkPolicy:
+  # Master gate. Default ON — a workload that constrains its own traffic is
+  # the canonical Sovereign posture. Set false only for a cluster with no
+  # cilium.io/v2 CRD or an operator-authored policy bundle of its own.
+  enabled: true
+  egress:
+    # The namespace the Keycloak backchannel (redeem / jwks / userinfo)
+    # resolves to. MUST stay in lockstep with keycloakInternalURL above.
+    keycloakNamespace: keycloak
+    # The Keycloak SERVICE port. The POD target port 8080 is always allowed
+    # alongside it: Cilium's policy verdict runs AFTER the Service DNAT, so
+    # allowing only the Service port drops the traffic (#4437's port trap).
+    keycloakPort: 80
+
 # ── Gated app instances ──────────────────────────────────────────────
 # instances:
 #   - name: openova-flow            # instance name (DNS-safe)

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T22:43:19.703Z",
+  "generatedAt": "2026-08-04T04:31:50.589Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -3552,7 +3552,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-cilium",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3687,7 +3687,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-cilium",

--- a/scripts/check-netpol-egress-completeness.py
+++ b/scripts/check-netpol-egress-completeness.py
@@ -88,6 +88,7 @@ POLICY_KINDS = {"NetworkPolicy", "CiliumNetworkPolicy"}
 # not a per-workload policy a chart author owns.
 
 HELM_TIMEOUT = os.environ.get("HELM_TIMEOUT", "60s")
+DEP_TIMEOUT = os.environ.get("DEP_TIMEOUT", "180s")
 
 # ── Per-chart render overlay ─────────────────────────────────────────────
 # Policies that are values-gated render as NOTHING under default values, and a
@@ -183,7 +184,8 @@ RENDER_SKIP_ALLOWLIST: dict[str, str] = {
 POLICY_OFF_BY_DESIGN: dict[str, str] = {
     "platform/cilium-policies/chart": (
         "scaffold chart — `policies: {}` by default and the placeholder CNP carries an "
-        "EMPTY endpointSelector (a namespace baseline, out of scope) even when enabled"
+        "EMPTY endpointSelector — a namespace baseline, which this invariant does not "
+        "govern — even when enabled"
     ),
 }
 
@@ -402,13 +404,28 @@ def render(chart_dir: str, namespace: str) -> tuple[list[dict], str]:
         cmd += ["--api-versions", a]
     for v in vals:
         cmd += ["--set", v]
-    try:
-        r = subprocess.run(
-            ["timeout", HELM_TIMEOUT] + cmd,
-            cwd=REPO,
-            capture_output=True,
-            text=True,
+    def run(argv: list[str], timeout: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["timeout", timeout] + argv, cwd=REPO, capture_output=True, text=True
         )
+
+    try:
+        r = run(cmd, HELM_TIMEOUT)
+        # Missing-dependency recovery, narrow on purpose (the check-no-nodeports.sh
+        # idiom). `.gitignore` excludes platform/*/chart/charts/ and no Chart.lock
+        # is committed, so a CLEAN checkout has neither — which is why a sweep can
+        # pass on a dev machine off a stale cached tarball and fail on the runner
+        # with "missing in charts/ directory". Recover ONLY from that failure; a
+        # chart failing for any other reason must still reach the ratchet rather
+        # than be masked by a network round-trip. NO_NETWORK=1 suppresses it.
+        if r.returncode != 0 and os.environ.get("NO_NETWORK") != "1" \
+                and "missing in charts/ directory" in (r.stderr or ""):
+            dep = run(["helm", "dependency", "update", chart_dir], DEP_TIMEOUT)
+            if dep.returncode == 0:
+                r = run(cmd, HELM_TIMEOUT)
+            else:
+                tail = (dep.stderr or dep.stdout or "").strip().splitlines()
+                return [], "helm dependency update failed: " + (tail[-1][:200] if tail else "?")
     except Exception as exc:  # pragma: no cover
         return [], str(exc)
     if r.returncode != 0:
@@ -570,7 +587,7 @@ def phase0(dns_ns: str, n_charts: int, n_policy_charts: int) -> None:
             )
             sys.exit(2)
         if not in_scope:
-            print(f"  self-test OK  [out of scope] {label}")
+            print(f"  self-test OK  [not a workload policy] {label}")
             continue
         ok, reason = group_allows_dns(
             [(doc.get("kind"), r) for r in ((doc.get("spec") or {}).get("egress") or [])],
@@ -783,7 +800,7 @@ def main() -> int:
                 baselines[r[0]] = baselines.get(r[0], 0) + 1
         if baselines:
             print("Namespace-baseline policies (empty selector — the namespace author's "
-                  "posture, not a per-workload policy, so out of scope for this invariant):")
+                  "posture, not a per-workload policy, so this invariant does not apply):")
             for c, n in sorted(baselines.items()):
                 print(f"  - `{c}`: {n}")
             print()

--- a/scripts/check-netpol-egress-completeness.py
+++ b/scripts/check-netpol-egress-completeness.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+"""check-netpol-egress-completeness.py — the #5617 / #4437 CLASS guard.
+
+WHAT THIS STOPS SHIPPING
+------------------------
+Twice now a chart has shipped a policy that constrains a workload's traffic
+and named only the INGRESS half:
+
+  * #4437 — bp-sso-bridge's egress CNP omitted openbao.
+  * #5617 — the per-Org bp-oidc-gate companion shipped
+    `oidc-gate-<cid>-gateway-ingress` and NO egress counterpart. Under the
+    per-Org namespace's default-deny the gate pod could not resolve cluster
+    DNS, so the Keycloak token exchange timed out and EVERY OAuth callback
+    returned 500 AFTER a successful login (live on hw292, Org `uatco`,
+    oauthproxy.go:881: `lookup keycloak.keycloak.svc.cluster.local on
+    10.96.0.10:53: i/o timeout`).
+
+Per docs/PRINCIPLES.md III.4 the second recurrence of a class gets ONE
+fail-closed class gate, not another per-instance patch. This is that gate.
+
+THE INVARIANT
+-------------
+Cilium computes the UNION of every policy selecting an endpoint, and the
+moment ANY of them carries an `egress` section that endpoint's egress becomes
+deny-by-default outside that union. Cluster DNS is therefore LOAD-BEARING: a
+workload whose selector group is constrained at all — including an
+ingress-only policy in a namespace where a sibling policy constrains egress —
+must have cluster DNS in the union or its very first name lookup times out.
+
+So, for every chart-rendered workload policy, grouped by the endpoint it
+selects:
+
+    the UNION of that group's egress rules MUST allow 53/UDP *and* 53/TCP
+    to cluster DNS.
+
+`grep -q egress` is explicitly NOT the assertion (an empty `egress: []` list
+would satisfy it — the #5639/#5641 shape where `grep -q 'key:
+openova.io/region'` passed on an empty value). The check parses the RENDERED
+document and asserts on the ports and the destination selector.
+
+SCOPE + WHY IT IS FAIL-CLOSED
+-----------------------------
+A group is exempt ONLY when its namespace is one where bp-plane-isolation
+renders a default-deny whose egress half is deliberately left OPEN
+(`namespaceSelector: {}` + `ipBlock 0.0.0.0/0` + DNS). That exemption set is
+COMPUTED at runtime from platform/plane-isolation/chart — never hand-kept —
+and the open-egress property is re-verified against the rendered template on
+every run. If plane-isolation ever tightens egress, every exemption evaporates
+and this guard goes red on its own, which is the point.
+
+Charts with NO bootstrap-kit slot install per-Organization, into the `<slug>`
+namespace, which carries:
+  * NetworkPolicy `default-deny-all`   (Ingress + Egress),
+  * NetworkPolicy `allow-same-org`,
+  * CiliumNetworkPolicy `allow-gateway-and-apiserver` — `endpointSelector: {}`
+    with an EGRESS section (kube-apiserver + same-namespace endpoints, and
+    NOTHING ELSE — no DNS).
+(core/controllers/organization/internal/gitops/manifests.go). That last one is
+why #5617 bit: it constrains the egress of every pod in the namespace while
+naming no DNS, so a workload that ships no DNS egress of its own is mute.
+Those charts are always enforced.
+
+Usage:  python3 scripts/check-netpol-egress-completeness.py [--table]
+Exit:   0 clean · 1 a violation · 2 the guard itself is broken/vacuous
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    print("GUARD BROKEN: PyYAML is not installed (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+POLICY_KINDS = {"NetworkPolicy", "CiliumNetworkPolicy"}
+# CiliumClusterwideNetworkPolicy is deliberately NOT in the set: it is a
+# cluster-scoped baseline (bp-network-policies' default-deny / allow pair),
+# not a per-workload policy a chart author owns.
+
+HELM_TIMEOUT = os.environ.get("HELM_TIMEOUT", "60s")
+
+# ── Per-chart render overlay ─────────────────────────────────────────────
+# Policies that are values-gated render as NOTHING under default values, and a
+# guard that only sees default renders is a guard that inspects nothing. Each
+# entry turns a chart's policy templates ON so the RENDERED content can be
+# asserted. Keep entries minimal and reviewable — they are test inputs, never
+# shipped values.
+RENDER_VALUES: dict[str, list[str]] = {
+    "platform/bp-dmz-vcluster/chart": [
+        "dmzVcluster.enabled=true",
+        "dmzVcluster.networkPolicy.enabled=true",
+    ],
+    "platform/cluster-autoscaler-hcloud/chart": [
+        "clusterAutoscalerHcloud.networkPolicy.enabled=true",
+    ],
+    "platform/cnpg-pair/chart": [
+        "cnpgPair.enabled=true",
+        "cnpgPair.networkPolicy.enabled=true",
+        "cnpgPair.primary.region=rtz-a",
+        "cnpgPair.replica.region=rtz-b",
+        "cnpgPair.image.tag=16.4",
+    ],
+    "platform/guacamole/chart": [
+        "guacamole.enabled=true",
+        "guacamole.networkPolicy.enabled=true",
+    ],
+    "platform/harbor/chart": ["harborOverlay.networkPolicy.enabled=true"],
+    "platform/kserve/chart": ["kserveOverlay.networkPolicy.enabled=true"],
+    "platform/llm-gateway/chart": ["catalystOverlay.networkPolicy.enabled=true"],
+    "platform/netbird/chart": [
+        "netbird.enabled=true",
+        "netbird.networkPolicy.enabled=true",
+        "netbird.management.domain=netbird.t99.omani.works",
+        "netbird.oidc.issuer=https://auth.t99.omani.works/realms/sovereign",
+    ],
+    "platform/oidc-gate/chart": [
+        "sovereignFQDN=t99.omani.works",
+        "instances[0].name=openova-flow",
+        "instances[0].clientId=openova-flow",
+        "instances[0].upstream=http://openova-flow-server.catalyst-system.svc.cluster.local:80",
+    ],
+    "platform/newapi/chart": [
+        "networkPolicy.enabled=true",
+        "catalystIntegration.externalSecret.remoteRef.key=catalyst/newapi/admin-token",
+    ],
+    "platform/plane-isolation/chart": ["enabled=true", "renderUnconditional=true"],
+    "platform/postgres/chart": ["topology.networkPolicy.enabled=true"],
+    "platform/seaweedfs/chart": ["seaweedfsOverlay.networkPolicy.enabled=true"],
+    "platform/stunner/chart": ["stunnerOverlay.networkPolicy.enabled=true"],
+    "platform/temporal/chart": ["catalystOverlay.networkPolicy.enabled=true"],
+    "platform/vpa/chart": ["vpaOverlay.networkPolicy.enabled=true"],
+    "products/agenity/chart": [
+        "networkPolicy.enabled=true",
+        "sovereignFqdn=t99.omani.works",
+        "oidcGate.enabled=true",
+    ],
+    "products/continuum/chart": ["continuum.enabled=true", "networkPolicy.enabled=true"],
+    "products/dmz-vcluster/chart": ["dmz.enabled=true", "dmz.networkPolicy.enabled=true"],
+    "products/openova-mcp/chart": [
+        "networkPolicy.enabled=true",
+        "networkPolicy.egress.enabled=true",
+    ],
+}
+DEFAULT_RENDER_VALUES = ["networkPolicy.enabled=true"]
+
+# CRDs the policy templates gate on via `.Capabilities.APIVersions.Has`. Without
+# these, `helm template` reports the CRD absent and the policy silently renders
+# as NOTHING — a chart would read clean while shipping nothing at all. That is
+# the same vacuity the blind-spot ratchet below refuses.
+API_VERSIONS = [
+    "cilium.io/v2",
+    "external-secrets.io/v1beta1",
+    "postgresql.cnpg.io/v1",
+    "gateway.networking.k8s.io/v1",
+    "monitoring.coreos.com/v1",
+]
+
+# ── Ratcheted render-skip allowlist ──────────────────────────────────────
+# Charts that carry policy templates but cannot be rendered offline. Every
+# entry needs a reason. A chart OUTSIDE this list that fails to render is a NEW
+# blind spot and FAILS the guard; a chart INSIDE it that now renders is
+# reported so the list cannot rot.
+RENDER_SKIP_ALLOWLIST: dict[str, str] = {
+    "platform/anthropic-adapter/chart": "image.tag MUST be SHA-pinned by the per-cluster overlay (fail-loud, same entry as check-no-nodeports.sh)",
+    "platform/knative/chart": "fail-loud required-values guard (same entry as check-no-nodeports.sh)",
+    "platform/librechat/chart": "fail-loud required-values guard (same entry as check-no-nodeports.sh)",
+}
+
+# ── Charts whose policy templates legitimately render nothing ────────────
+# A chart that renders but emits ZERO policy documents is a blind spot: the
+# guard would be inspecting nothing while reporting the chart clean. Every
+# such chart must say why here.
+POLICY_OFF_BY_DESIGN: dict[str, str] = {
+    "platform/cilium-policies/chart": (
+        "scaffold chart — `policies: {}` by default and the placeholder CNP carries an "
+        "EMPTY endpointSelector (a namespace baseline, out of scope) even when enabled"
+    ),
+}
+
+# ── Documented per-group exemptions ──────────────────────────────────────
+# Keyed by "<chart>::<policy names, sorted, +-joined>". Every entry states WHY
+# the selected endpoints legitimately need no DNS egress of their own. Anything
+# not listed here and not in an open-egress namespace FAILS.
+EXEMPT: dict[str, str] = {}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Classifier — the part that must be able to go red.
+# ─────────────────────────────────────────────────────────────────────────
+def selector_of(doc: dict) -> dict | None:
+    """The endpoint selector a policy constrains, or None if it selects the
+    whole namespace (a baseline, not a per-workload policy)."""
+    spec = doc.get("spec") or {}
+    sel = spec.get("endpointSelector")
+    if sel is None:
+        sel = spec.get("podSelector")
+    if not isinstance(sel, dict):
+        return None
+    if not sel.get("matchLabels") and not sel.get("matchExpressions"):
+        return None  # empty selector == namespace baseline
+    return sel
+
+
+def _ports_of(rule: dict) -> list[dict]:
+    """Every port entry a rule names, in either the K8s or the Cilium shape."""
+    out: list[dict] = []
+    for p in rule.get("ports") or []:  # K8s NetworkPolicy
+        if isinstance(p, dict):
+            out.append(p)
+    for tp in rule.get("toPorts") or []:  # CiliumNetworkPolicy
+        if not isinstance(tp, dict):
+            continue
+        for p in tp.get("ports") or []:
+            if isinstance(p, dict):
+                out.append(p)
+    return out
+
+
+def _has_port(rule: dict, number: int, protocol: str) -> bool:
+    """True when the rule permits <number>/<protocol>.
+
+    Assert on the value, never the key (#5639): a rule that carries a `ports`
+    key holding an empty list, or `port: 53` with no protocol under a policy
+    whose default protocol is TCP-only, must NOT read as DNS coverage.
+
+    A rule that names NO ports at all is unrestricted on ports, so it does
+    permit 53 — `egress: [{}]` really is an allow-all-egress rule.
+    """
+    declared = _ports_of(rule)
+    has_port_key = bool(rule.get("ports")) or bool(rule.get("toPorts"))
+    if not declared:
+        # No port restriction => every port, including 53. But a `toPorts`
+        # key holding an empty/none port list restricts to NOTHING and must
+        # not read as coverage.
+        return not has_port_key
+    for p in declared:
+        raw = p.get("port")
+        if raw is None:
+            continue
+        try:
+            if int(str(raw)) != number:
+                continue
+        except ValueError:
+            continue  # a named port cannot be proven to be DNS
+        proto = str(p.get("protocol", "TCP")).upper()
+        if proto == "ANY":
+            return True
+        if proto == protocol.upper():
+            return True
+    return False
+
+
+def _destination_reaches_dns(kind: str, rule: dict, dns_namespace: str) -> bool:
+    """True when the rule's DESTINATION can actually be cluster DNS.
+
+    A `port: 53` allow pointed at the workload's own namespace is not DNS
+    coverage — that is the failure shape this guard exists to catch, so the
+    destination is asserted, not assumed.
+    """
+    if kind == "NetworkPolicy":
+        # K8s semantics: an absent or empty `to` means "every destination".
+        tos = rule.get("to")
+        if not tos:
+            return True
+        for t in tos:
+            if not isinstance(t, dict):
+                continue
+            nsel = t.get("namespaceSelector")
+            if isinstance(nsel, dict):
+                ml = nsel.get("matchLabels") or {}
+                if not ml:
+                    return True  # every namespace
+                if ml.get("kubernetes.io/metadata.name") == dns_namespace:
+                    return True
+            if t.get("ipBlock", {}).get("cidr") == "0.0.0.0/0":
+                # A CIDR NEVER matches an in-cluster pod identity under Cilium
+                # (#4360) — CoreDNS is a pod, so this is NOT DNS coverage.
+                continue
+        return False
+
+    # Cilium: toEndpoints / toEntities / toServices. An egress rule naming NO
+    # destination at all selects nothing, so it is never DNS coverage.
+    for ep in rule.get("toEndpoints") or []:
+        if not isinstance(ep, dict):
+            continue
+        ml = ep.get("matchLabels") or ep
+        ns = (
+            ml.get("k8s:io.kubernetes.pod.namespace")
+            or ml.get("io.kubernetes.pod.namespace")
+        )
+        if ns == dns_namespace:
+            return True
+        if not ml:
+            # `toEndpoints: [{}]` in a NAMESPACED CNP is scoped to the policy's
+            # own namespace by Cilium — never kube-system. Not DNS coverage.
+            continue
+    for ent in rule.get("toEntities") or []:
+        if str(ent) in ("all", "cluster", "world"):
+            # `world` alone is not DNS (CoreDNS is a cluster identity), but
+            # `all`/`cluster` do cover it.
+            if str(ent) in ("all", "cluster"):
+                return True
+    if rule.get("toServices"):
+        return True
+    return False
+
+
+def group_allows_dns(rules: list[tuple[str, dict]], dns_namespace: str) -> tuple[bool, str]:
+    """(ok, reason) — does the union of these (kind, egress-rule) pairs reach
+    cluster DNS on both 53/UDP and 53/TCP?"""
+    if not rules:
+        return False, "no egress rule at all (ingress-only policy — the #5617 shape)"
+    udp = any(
+        _has_port(r, 53, "UDP") and _destination_reaches_dns(k, r, dns_namespace)
+        for k, r in rules
+    )
+    tcp = any(
+        _has_port(r, 53, "TCP") and _destination_reaches_dns(k, r, dns_namespace)
+        for k, r in rules
+    )
+    if udp and tcp:
+        return True, "53/UDP + 53/TCP to cluster DNS"
+    missing = []
+    if not udp:
+        missing.append("53/UDP")
+    if not tcp:
+        missing.append("53/TCP")
+    return False, "egress declared but no " + " and no ".join(missing) + " to cluster DNS"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Repo facts — computed, never hand-kept.
+# ─────────────────────────────────────────────────────────────────────────
+def bootstrap_slot_namespaces() -> dict[str, str]:
+    """chart name -> bootstrap-kit targetNamespace. A chart absent from this
+    map has no slot, so it installs per-Organization into `<slug>`."""
+    out: dict[str, str] = {}
+    for f in sorted(glob.glob(os.path.join(REPO, "clusters/_template/bootstrap-kit/*.yaml"))):
+        txt = open(f).read()
+        tns = re.findall(r"^\s+targetNamespace:\s*(\S+)", txt, re.M)
+        for chart in re.findall(r"^      chart:\s*(\S+)", txt, re.M):
+            out[chart] = tns[0] if tns else "?"
+    return out
+
+
+def open_egress_namespaces() -> set[str]:
+    """Namespaces where bp-plane-isolation's default-deny leaves egress OPEN.
+
+    Re-derived on every run from the chart itself AND re-verified against the
+    template: the exemption exists only while the template really emits the
+    open-egress pair. Tighten plane-isolation and every exemption below
+    evaporates — that is the fail-closed hinge of this guard.
+    """
+    tmpl = os.path.join(REPO, "platform/plane-isolation/chart/templates/default-deny-networkpolicy.yaml")
+    body = open(tmpl).read()
+    egress = body.split("  egress:", 1)[-1]
+    open_to_all_pods = re.search(r"^\s*-\s*namespaceSelector:\s*\{\}\s*$", egress, re.M)
+    open_to_world = re.search(r"cidr:\s*0\.0\.0\.0/0", egress)
+    if not (open_to_all_pods and open_to_world):
+        return set()  # plane-isolation tightened — nothing is exempt any more
+    values = open(os.path.join(REPO, "platform/plane-isolation/chart/values.yaml")).read()
+    return set(re.findall(r"^  - namespace:\s*(\S+)", values, re.M))
+
+
+def dns_namespace() -> str:
+    values = open(os.path.join(REPO, "platform/network-policies/chart/values.yaml")).read()
+    m = re.search(r"^dnsNamespace:\s*(\S+)", values, re.M)
+    return m.group(1) if m else "kube-system"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Render sweep
+# ─────────────────────────────────────────────────────────────────────────
+def chart_name(chart_dir: str) -> str:
+    p = os.path.join(REPO, chart_dir, "Chart.yaml")
+    if os.path.exists(p):
+        for line in open(p):
+            m = re.match(r"^name:\s*(\S+)", line)
+            if m:
+                return m.group(1)
+    return os.path.basename(chart_dir)
+
+
+def render(chart_dir: str, namespace: str) -> tuple[list[dict], str]:
+    vals = RENDER_VALUES.get(chart_dir, DEFAULT_RENDER_VALUES)
+    # Render INTO the namespace the chart really installs into, so every
+    # Release.Namespace-derived selector in the templates resolves to the
+    # namespace whose policy posture this guard is reasoning about.
+    cmd = ["helm", "template", os.path.basename(chart_dir), chart_dir,
+           "--namespace", namespace]
+    for a in API_VERSIONS:
+        cmd += ["--api-versions", a]
+    for v in vals:
+        cmd += ["--set", v]
+    try:
+        r = subprocess.run(
+            ["timeout", HELM_TIMEOUT] + cmd,
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as exc:  # pragma: no cover
+        return [], str(exc)
+    if r.returncode != 0:
+        return [], (r.stderr or "helm template failed").strip().splitlines()[-1][:200]
+    # Parse document-by-document. A vendored upstream subchart can emit a doc
+    # this parser chokes on (harbor's templates carry a literal tab); that must
+    # not blind the guard to the SIBLING documents, but a policy document that
+    # fails to parse is a hard error — it is exactly what we came to inspect.
+    docs = []
+    for chunk in re.split(r"^---\s*$", r.stdout, flags=re.M):
+        if not chunk.strip():
+            continue
+        looks_like_policy = re.search(
+            r"^kind:\s*(CiliumNetworkPolicy|NetworkPolicy)\s*$", chunk, re.M
+        )
+        try:
+            d = yaml.safe_load(chunk)
+        except yaml.YAMLError as exc:
+            if looks_like_policy:
+                return [], f"a rendered policy document did not parse: {exc}"
+            continue
+        if isinstance(d, dict) and d.get("kind") in POLICY_KINDS:
+            docs.append(d)
+    return docs, ""
+
+
+def chart_dirs() -> list[str]:
+    out = []
+    for pat in ("platform/*/chart", "products/*/chart", "products/*/charts/*"):
+        for d in sorted(glob.glob(os.path.join(REPO, pat))):
+            if os.path.exists(os.path.join(d, "Chart.yaml")):
+                out.append(os.path.relpath(d, REPO))
+    return out
+
+
+def has_policy_templates(chart_dir: str) -> bool:
+    for root, _, files in os.walk(os.path.join(REPO, chart_dir, "templates")):
+        for f in files:
+            if not f.endswith((".yaml", ".yml", ".tpl")):
+                continue
+            body = open(os.path.join(root, f), errors="ignore").read()
+            if re.search(r"kind:\s*(CiliumNetworkPolicy|NetworkPolicy)\b", body):
+                return True
+    return False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Phase 0 — vacuity self-test. A guard that has never been seen red is a
+# guard nobody has proven can go red (#5473 / #5517).
+# ─────────────────────────────────────────────────────────────────────────
+GOOD_CNP = """
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata: {name: good}
+spec:
+  endpointSelector: {matchLabels: {app.kubernetes.io/name: bp-oidc-gate}}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - {port: "53", protocol: UDP}
+            - {port: "53", protocol: TCP}
+"""
+INGRESS_ONLY_CNP = """
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata: {name: gateway-ingress}
+spec:
+  endpointSelector: {matchLabels: {app.kubernetes.io/name: bp-oidc-gate}}
+  ingress:
+    - fromEntities: [ingress]
+      toPorts:
+        - ports:
+            - {port: "4180", protocol: TCP}
+"""
+EMPTY_EGRESS_LIST_CNP = """
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata: {name: hollow}
+spec:
+  endpointSelector: {matchLabels: {app.kubernetes.io/name: bp-oidc-gate}}
+  egress: []
+"""
+WRONG_DESTINATION_CNP = """
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata: {name: wrong-dest}
+spec:
+  endpointSelector: {matchLabels: {app.kubernetes.io/name: bp-oidc-gate}}
+  egress:
+    - toEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - {port: "53", protocol: UDP}
+            - {port: "53", protocol: TCP}
+"""
+UDP_ONLY_CNP = """
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata: {name: udp-only}
+spec:
+  endpointSelector: {matchLabels: {app.kubernetes.io/name: bp-oidc-gate}}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - {port: "53", protocol: UDP}
+"""
+CIDR_ONLY_NP = """
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: cidr-only}
+spec:
+  podSelector: {matchLabels: {app: x}}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - ipBlock: {cidr: 0.0.0.0/0}
+      ports:
+        - {protocol: UDP, port: 53}
+        - {protocol: TCP, port: 53}
+"""
+BASELINE_NP = """
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: default-deny-all}
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+"""
+
+SELF_TEST = [
+    ("complete DNS egress", GOOD_CNP, True, True),
+    ("ingress-only (the #5617 shape)", INGRESS_ONLY_CNP, True, False),
+    ("hollow `egress: []` (the #5639 shape)", EMPTY_EGRESS_LIST_CNP, True, False),
+    ("port 53 pointed at own namespace", WRONG_DESTINATION_CNP, True, False),
+    ("53/UDP only, no TCP fallback", UDP_ONLY_CNP, True, False),
+    ("53 via ipBlock 0.0.0.0/0 (#4360)", CIDR_ONLY_NP, True, False),
+    ("namespace baseline (empty selector)", BASELINE_NP, False, None),
+]
+
+
+def phase0(dns_ns: str, n_charts: int, n_policy_charts: int) -> None:
+    print("== Phase 0: guard self-test (vacuity) ==")
+    for label, doc_yaml, in_scope, expect_ok in SELF_TEST:
+        doc = yaml.safe_load(doc_yaml)
+        sel = selector_of(doc)
+        if (sel is not None) != in_scope:
+            print(
+                f"GUARD BROKEN: scope classification wrong for {label!r} "
+                f"(selector={'found' if sel else 'none'}, expected in_scope={in_scope})",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if not in_scope:
+            print(f"  self-test OK  [out of scope] {label}")
+            continue
+        ok, reason = group_allows_dns(
+            [(doc.get("kind"), r) for r in ((doc.get("spec") or {}).get("egress") or [])],
+            dns_ns,
+        )
+        if ok != expect_ok:
+            print(
+                f"GUARD BROKEN: classifier returned {ok} for {label!r}, expected "
+                f"{expect_ok} ({reason})",
+                file=sys.stderr,
+            )
+            print("  A verdict from this run would prove nothing.", file=sys.stderr)
+            sys.exit(2)
+        print(f"  self-test OK  [{'PASS' if ok else 'FAIL'} as designed] {label}")
+
+    if n_charts < 60:
+        print(
+            f"GUARD VACUOUS: the render sweep found only {n_charts} charts — expected >=60. "
+            "A chart root was renamed/moved, so a 'clean' verdict would prove nothing.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if n_policy_charts < 20:
+        print(
+            f"GUARD VACUOUS: only {n_policy_charts} charts carry policy templates — "
+            "expected >=20. The policy detector has rotted.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    print(
+        f"  self-test OK: classifier bites 5/5 broken shapes, passes 1/1 correct shape, "
+        f"{n_policy_charts} policy-bearing charts of {n_charts} in scope"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--table", action="store_true", help="print the full enumeration table")
+    args = ap.parse_args()
+
+    dns_ns = dns_namespace()
+    slots = bootstrap_slot_namespaces()
+    open_egress = open_egress_namespaces()
+
+    charts = chart_dirs()
+    policy_charts = [c for c in charts if has_policy_templates(c)]
+
+    phase0(dns_ns, len(charts), len(policy_charts))
+
+    print()
+    print("== Phase 1: render sweep ==")
+    if not open_egress:
+        print(
+            "  NOTE: bp-plane-isolation no longer leaves egress open — every "
+            "platform-slot chart is now ENFORCED."
+        )
+    rendered: dict[str, list[dict]] = {}
+    skipped: list[tuple[str, str]] = []
+    unexpectedly_renderable: list[str] = []
+    empty_by_design: list[str] = []
+    blind_spots: list[str] = []
+    unrenderable: list[tuple[str, str]] = []
+    for c in policy_charts:
+        _ns = slots.get(chart_name(c)) or "org-slug"
+        docs, err = render(c, _ns)
+        if err:
+            if c in RENDER_SKIP_ALLOWLIST:
+                skipped.append((c, err))
+                continue
+            unrenderable.append((c, err))
+            continue
+        if c in RENDER_SKIP_ALLOWLIST:
+            unexpectedly_renderable.append(c)
+        if not docs:
+            # The chart rendered, but its policy templates produced NOTHING —
+            # a values gate is off. Inspecting zero documents and calling the
+            # chart clean is the vacuity this guard refuses to commit
+            # (#5639/#5641). Give it render values or an explicit reason.
+            if c in POLICY_OFF_BY_DESIGN:
+                empty_by_design.append(c)
+            else:
+                blind_spots.append(c)
+            continue
+        rendered[c] = docs
+    print(
+        f"  rendered {len(rendered)}/{len(policy_charts)} policy-bearing charts "
+        f"({len(skipped)} allowlisted as unrenderable, "
+        f"{len(empty_by_design)} policy-off by design)"
+    )
+    if unrenderable:
+        for c, err in unrenderable:
+            print(f"FAIL: {c} carries policy templates but does not render: {err}", file=sys.stderr)
+        print(
+            "      A chart this guard cannot render is a blind spot. Add render values to "
+            "RENDER_VALUES, or an entry with a reason to RENDER_SKIP_ALLOWLIST.",
+            file=sys.stderr,
+        )
+        return 1
+    if blind_spots:
+        for c in blind_spots:
+            print(
+                f"FAIL: {c} carries policy templates but rendered ZERO policy documents.",
+                file=sys.stderr,
+            )
+        print(
+            "      A values gate is off, so a 'clean' verdict for those charts would prove "
+            "nothing (#5639 vacuity). Add the enabling values to RENDER_VALUES, or an entry "
+            "with a reason to POLICY_OFF_BY_DESIGN.",
+            file=sys.stderr,
+        )
+        return 1
+    for c, why in skipped:
+        print(f"  skip (allowlisted): {c} — {why}")
+    for c in unexpectedly_renderable:
+        print(
+            f"  NOTE: {c} now renders — drop its RENDER_SKIP_ALLOWLIST entry "
+            f"({RENDER_SKIP_ALLOWLIST[c]})"
+        )
+
+    print()
+    print("== Phase 2: per-selector egress completeness ==")
+    rows = []
+    violations = []
+    for chart_dir, docs in sorted(rendered.items()):
+        cn = chart_name(chart_dir)
+        ns = slots.get(cn)
+        install = "bootstrap-kit slot" if ns else "per-Organization"
+        target_ns = ns or "<org-slug>"
+
+        # Cilium (and K8s NP) compute the UNION of every policy selecting an
+        # endpoint. A namespace-BASELINE policy (empty selector) therefore
+        # covers every pod in its namespace, so its egress rules count toward
+        # every workload group in that same namespace. Namespace comes from the
+        # rendered document, never from the slot's targetNamespace — a chart
+        # routinely policies namespaces other than its release namespace.
+        groups: dict[tuple[str, str], dict] = {}
+        baseline_egress: dict[str, list[dict]] = {}
+        for d in docs:
+            dns_ = (d.get("metadata") or {}).get("namespace") or target_ns
+            spec = d.get("spec") or {}
+            if selector_of(d) is None:
+                baseline_egress.setdefault(dns_, []).extend(
+                    (d.get("kind"), r) for r in (spec.get("egress") or [])
+                )
+
+        for d in docs:
+            doc_ns = (d.get("metadata") or {}).get("namespace") or target_ns
+            sel = selector_of(d)
+            if sel is None:
+                rows.append(
+                    (chart_dir, cn, install, doc_ns, d["metadata"]["name"],
+                     "namespace-baseline", "-", "n/a (baseline)")
+                )
+                continue
+            key = (doc_ns, json.dumps(sel, sort_keys=True))
+            g = groups.setdefault(key, {"names": [], "egress": [], "ingress": False})
+            g["names"].append(d["metadata"]["name"])
+            spec = d.get("spec") or {}
+            g["egress"].extend((d.get("kind"), r) for r in (spec.get("egress") or []))
+            if spec.get("ingress"):
+                g["ingress"] = True
+
+        for (doc_ns, _key), g in sorted(groups.items(), key=lambda kv: kv[1]["names"][0]):
+            union = list(g["egress"]) + baseline_egress.get(doc_ns, [])
+            ok, reason = group_allows_dns(union, dns_ns)
+            names = "+".join(sorted(g["names"]))
+            exempt_key = f"{chart_dir}::{names}"
+            covered_by_baseline = (
+                not group_allows_dns(g["egress"], dns_ns)[0] and ok
+            )
+            # Cilium only turns an endpoint's egress deny-by-default when SOME
+            # policy selecting it declares egress. So an ingress-only policy is
+            # inert on egress — UNLESS the namespace itself constrains egress,
+            # which is exactly what a per-Organization `<slug>` namespace does
+            # (`allow-gateway-and-apiserver`, endpointSelector {} + an egress
+            # section with kube-apiserver and NOTHING else). That asymmetry is
+            # why #5617 bit a per-Org chart and not a platform one.
+            ns_constrains_egress = install == "per-Organization"
+            if ok:
+                verdict = "OK (via namespace baseline)" if covered_by_baseline else "OK"
+            elif exempt_key in EXEMPT:
+                verdict = f"EXEMPT — {EXEMPT[exempt_key]}"
+            elif doc_ns in open_egress:
+                verdict = f"exempt — ns `{doc_ns}` egress left open by bp-plane-isolation"
+            elif not union and not ns_constrains_egress:
+                verdict = "n/a — ingress-only, and nothing constrains egress in this namespace"
+            else:
+                verdict = f"VIOLATION — {reason}"
+                violations.append((chart_dir, cn, doc_ns, names, reason))
+            rows.append(
+                (chart_dir, cn, install, doc_ns, names,
+                 "ingress+egress" if (g["ingress"] and g["egress"]) else
+                 ("ingress-only" if g["ingress"] else "egress-only"),
+                 "Y" if ok else "-", verdict)
+            )
+
+    if args.table:
+        print()
+        hdr = ("chart", "blueprint", "install", "namespace", "policy", "halves", "dns", "verdict")
+        print("| " + " | ".join(hdr) + " |")
+        print("|" + "|".join(["---"] * len(hdr)) + "|")
+        workload = [r for r in rows if r[5] != "namespace-baseline"]
+        for r in workload:
+            print("| " + " | ".join(f"`{x}`" if i < 5 else str(x) for i, x in enumerate(r)) + " |")
+        print()
+        baselines: dict[str, int] = {}
+        for r in rows:
+            if r[5] == "namespace-baseline":
+                baselines[r[0]] = baselines.get(r[0], 0) + 1
+        if baselines:
+            print("Namespace-baseline policies (empty selector — the namespace author's "
+                  "posture, not a per-workload policy, so out of scope for this invariant):")
+            for c, n in sorted(baselines.items()):
+                print(f"  - `{c}`: {n}")
+            print()
+
+    if violations:
+        print()
+        for chart_dir, cn, ns, names, reason in violations:
+            print(f"FAIL: {chart_dir} ({cn}) policy `{names}` -> ns `{ns}`: {reason}", file=sys.stderr)
+        print(
+            "\nEvery workload policy in a default-deny namespace needs cluster DNS in its "
+            "egress union (#5617/#4437). Add a toEndpoints rule for "
+            f"`{dns_ns}`/kube-dns on 53 UDP+TCP — never an ipBlock/toCIDR, which cannot "
+            "match a ClusterMesh remote identity (#4360/#4656).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"  OK — {len(rows)} rendered policies, 0 workload groups without cluster DNS egress.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two charts have now shipped a policy that names only the **ingress** half — #4437 (bp-sso-bridge's egress CNP omitted openbao) and #5617 (the per-Org `bp-oidc-gate` companion shipped `oidc-gate-<cid>-gateway-ingress` and no egress counterpart, so under the per-Org namespace's default-deny the gate could not resolve cluster DNS and **every OAuth callback returned 500 after a successful login**, live on hw292 Org `uatco`).

Per `docs/PRINCIPLES.md` III.4 the second recurrence gets a repo-wide enumeration and ONE fail-closed class gate, not a third per-instance patch.

### Why an ingress-only policy is never harmless

Cilium evaluates the **union** of every policy selecting an endpoint, and the moment ANY of them declares `egress` that endpoint is deny-by-default outside the union. A per-Organization `<slug>` namespace always carries such a policy — `allow-gateway-and-apiserver` (`core/controllers/organization/internal/gitops/manifests.go`), `endpointSelector: {}` with an egress section naming kube-apiserver and same-namespace endpoints **and nothing else**. That is why the same gate resource set works in the platform `oidc-gate` namespace (bp-plane-isolation leaves egress open there, its values file says so verbatim) and fails in an Org namespace. The in-repo control is the sibling agenity pod on hw292: same namespace, resolves the same name, because its chart ships an egress CNP.

`bp-network-policies` (slot 26) ships `enabled: false` on every fresh prov, so its cluster-wide `30-allow-egress-dns` CCNP does not exist and cannot cover for a missing per-workload rule.

## 1. Enumeration — every chart-rendered policy, swept

Produced by the new gate itself (`--table`), so the table and the enforcement cannot drift. 33 workload selector-groups across 36 policy-bearing charts; the remaining 76 rendered documents are namespace baselines (empty selector — the namespace author's posture, which this invariant does not govern), counted per chart below the table.

`dns` = the union of that selector-group's egress rules allows 53/UDP **and** 53/TCP to cluster DNS.

| chart | blueprint | install | namespace | policy | halves | dns | verdict |
|---|---|---|---|---|---|---|---|
| `platform/bge/chart` | `bp-bge` | `per-Organization` | `org-slug` | `chart-bp-bge` | ingress+egress | Y | OK |
| `platform/cluster-autoscaler-hcloud/chart` | `bp-cluster-autoscaler-hcloud` | `bootstrap-kit slot` | `cluster-autoscaler` | `bp-cluster-autoscaler-hcloud` | egress-only | Y | OK |
| `platform/cnpg-pair/chart` | `bp-cnpg-pair` | `bootstrap-kit slot` | `cnpg` | `chart-bp-cnpg-pair-allow-replication-to-primary` | ingress-only | - | n/a — ingress-only, and nothing constrains egress in this namespace |
| `platform/external-dns/chart` | `bp-external-dns` | `bootstrap-kit slot` | `external-dns` | `bp-external-dns+bp-external-dns-apiserver` | ingress+egress | Y | OK |
| `platform/guacamole/chart` | `bp-guacamole` | `bootstrap-kit slot` | `guacamole` | `guacamole-server-egress+guacamole-server-ingress` | ingress+egress | Y | OK |
| `platform/harbor/chart` | `bp-harbor` | `bootstrap-kit slot` | `harbor` | `bp-harbor` | ingress+egress | Y | OK |
| `platform/kserve/chart` | `bp-kserve` | `per-Organization` | `org-slug` | `bp-kserve` | ingress+egress | Y | OK |
| `platform/livekit/chart` | `bp-livekit` | `per-Organization` | `org-slug` | `bp-livekit` | ingress+egress | Y | OK |
| `platform/llm-gateway/chart` | `bp-llm-gateway` | `per-Organization` | `org-slug` | `chart-bp-llm-gateway` | ingress+egress | Y | OK |
| `platform/matrix/chart` | `bp-matrix` | `per-Organization` | `org-slug` | `bp-matrix` | ingress+egress | Y | OK |
| `platform/nemo-guardrails/chart` | `bp-nemo-guardrails` | `per-Organization` | `org-slug` | `chart-bp-nemo-guardrails` | ingress+egress | Y | OK |
| `platform/netbird/chart` | `bp-netbird` | `per-Organization` | `org-slug` | `chart-bp-netbird-management-egress` | egress-only | Y | OK |
| `platform/newapi/chart` | `bp-newapi` | `bootstrap-kit slot` | `newapi` | `chart-bp-newapi+chart-bp-newapi-gateway-ingress` | ingress+egress | Y | OK |
| `platform/oidc-gate/chart` | `bp-oidc-gate` | `bootstrap-kit slot` | `oidc-gate` | `oidc-gate-openova-flow-egress+oidc-gate-openova-flow-gateway-ingress` | ingress+egress | Y | OK |
| `platform/openclaw/chart` | `bp-openclaw` | `per-Organization` | `<org-slug>` | `chart-bp-openclaw-controller+chart-bp-openclaw-controller-gateway-ingress` | ingress+egress | Y | OK |
| `platform/openmeter/chart` | `bp-openmeter` | `per-Organization` | `org-slug` | `bp-openmeter` | ingress+egress | Y | OK |
| `platform/plane-isolation/chart` | `bp-plane-isolation` | `bootstrap-kit slot` | `opentelemetry` | `opentelemetry-allow-apiserver-webhook-ingress` | ingress-only | Y | OK (via namespace baseline) |
| `platform/postgres/chart` | `bp-postgres` | `bootstrap-kit slot` | `shared-data` | `postgres-allow-cnpg-operator-probe` | ingress-only | - | n/a — ingress-only, and nothing constrains egress in this namespace |
| `platform/seaweedfs/chart` | `bp-seaweedfs` | `bootstrap-kit slot` | `seaweedfs` | `bp-seaweedfs` | ingress+egress | Y | OK |
| `platform/sso-bridge/chart` | `bp-sso-bridge` | `bootstrap-kit slot` | `sso-bridge` | `bp-sso-bridge` | egress-only | Y | OK |
| `platform/sso-bridge/chart` | `bp-sso-bridge` | `bootstrap-kit slot` | `sso-bridge` | `sso-bridge-reconciler-apiserver` | egress-only | Y | OK |
| `platform/stalwart-sovereign/chart` | `bp-stalwart-sovereign` | `per-Organization` | `<org-slug>` | `chart-bp-stalwart-sovereign` | ingress+egress | Y | OK |
| `platform/stalwart-tenant/chart` | `bp-stalwart-tenant` | `per-Organization` | `<org-slug>` | `chart-bp-stalwart-tenant+chart-bp-stalwart-tenant-gateway-ingress` | ingress+egress | Y | OK |
| `platform/stunner/chart` | `bp-stunner` | `per-Organization` | `org-slug` | `bp-stunner` | ingress+egress | Y | OK |
| `platform/temporal/chart` | `bp-temporal` | `per-Organization` | `<org-slug>` | `bp-temporal-default` | ingress+egress | Y | OK |
| `platform/vllm/chart` | `bp-vllm` | `bootstrap-kit slot` | `vllm` | `chart-bp-vllm` | ingress+egress | Y | OK |
| `platform/vpa/chart` | `bp-vpa` | `bootstrap-kit slot` | `vpa` | `bp-vpa` | ingress+egress | Y | OK |
| `platform/wordpress-tenant/chart` | `bp-wordpress-tenant` | `per-Organization` | `<org-slug>` | `chart-bp-wordpress-tenant+chart-bp-wordpress-tenant-gateway-ingress` | ingress+egress | Y | OK |
| `products/agenity/chart` | `bp-agenity` | `per-Organization` | `<org-slug>` | `chart-bp-agenity-external-egress+chart-bp-agenity-gateway-ingress` | ingress+egress | Y | OK |
| `products/agenity/chart` | `bp-agenity` | `per-Organization` | `<org-slug>` | `oidc-gate-agenity-t99-egress+oidc-gate-agenity-t99-gateway-ingress` | ingress+egress | Y | OK |
| `products/catalyst/chart` | `bp-catalyst-platform` | `bootstrap-kit slot` | `kube-system` | `baseline-cilium-gateway-allow` | ingress+egress | Y | OK |
| `products/continuum/chart` | `bp-continuum` | `bootstrap-kit slot` | `catalyst-system` | `continuum-controller` | ingress+egress | Y | OK |
| `products/openova-mcp/chart` | `bp-openova-mcp` | `bootstrap-kit slot` | `catalyst-system` | `chart-bp-openova-mcp-egress+chart-bp-openova-mcp-ingress` | ingress+egress | Y | OK |

Namespace-baseline policies (empty selector — the namespace author's posture, not a per-workload policy, so this invariant does not apply):
  - `platform/bp-dmz-vcluster/chart`: 1
  - `platform/bp-mgmt-vcluster/chart`: 2
  - `platform/bp-rtz-vcluster/chart`: 1
  - `platform/plane-isolation/chart`: 66
  - `platform/self-sovereign-cutover/chart`: 3
  - `products/catalyst/chart`: 1
  - `products/dmz-vcluster/chart`: 2

**Charts that carry policy templates but were not rendered** (each would otherwise be a silent blind spot, so the guard fails on any chart not listed with a reason):

| chart | why |
|---|---|
| `platform/anthropic-adapter/chart` | fail-loud values guard — `image.tag` must be SHA-pinned by the per-cluster overlay (same entry as `check-no-nodeports.sh`) |
| `platform/knative/chart` | fail-loud required-values guard (same entry as `check-no-nodeports.sh`) |
| `platform/librechat/chart` | fail-loud required-values guard (same entry as `check-no-nodeports.sh`) |
| `platform/cilium-policies/chart` | renders zero policies by design — `policies: {}` scaffold, and its placeholder CNP carries an empty `endpointSelector` (a namespace baseline) even when enabled |

**Two rows are `n/a`, not passes** — `bp-cnpg-pair`'s replication carve-out (ns `cnpg`) and `bp-postgres`'s CNPG operator-probe carve-out (ns `shared-data`) are `policyTypes: [Ingress]` only, and nothing constrains egress in those namespaces today, so they cannot strand anything. Note `bp-postgres` **can** land in a per-Org namespace (#4398) — there its pod's egress is constrained by the per-Org CNP, and the fix in part 2 is what gives it DNS.

## 2. Fix

### 2a. Root cause — the per-Org namespace baseline (`core/controllers/organization/internal/gitops/manifests.go`)

`allow-gateway-and-apiserver` now allows 53/UDP + 53/TCP to `kube-system`/`kube-dns`, at **L3/L4 only** — deliberately no L7 `dns` rule, because this selector is every pod in the namespace and an L7 rule would route all of their lookups through the cilium-agent DNS proxy; the goal is to stop denying DNS, not to filter it (a chart CNP may still add an L7 rule for its own pods, and Cilium unions the two). One change, every current and future per-Org workload, purely additive — it grants nothing but `:53` to kube-system, so cross-Org/cross-Environment denial is unchanged. `toEndpoints`, never `toCIDR`: a CIDR matches neither an in-cluster pod identity (#4360) nor a ClusterMesh remote identity (#4656), so a CIDR-shaped DNS allow would be inert and would silently strand the peer region of a 2-region Sovereign.

### 2b. `bp-oidc-gate` 0.1.8 -> 0.1.9

This chart shipped **no policy at all**. Its gate pods were reachable, and could dial out, only because bp-plane-isolation (slot 26b) covers the `oidc-gate` namespace with a gateway-ingress CNP plus a default-deny whose egress half is deliberately unconstrained. That cross-chart implicit dependency IS the class. `templates/networkpolicy.yaml` now renders both halves per instance:

- `<gate>-gateway-ingress` — reserved `ingress`/`host`/`remote-node` entities to :4180 (no K8s NetworkPolicy selector can match those).
- `<gate>-egress` — kube-dns 53 UDP+TCP; the Keycloak backchannel on the Service port **and** pod port 8080 (#4437's port trap: Cilium's verdict runs after the Service DNAT, so allowing only 80 drops it); the instance's own upstream namespace + port **derived from its `upstream` URL** so the policy cannot drift from what oauth2-proxy actually dials; and `toEntities: [world]:443` only in #3844 public-discovery mode.

**Additive, not a tightening of today's behaviour** — while bp-plane-isolation's open-egress rule is present, the union is unchanged, so this cannot sever a gate that works today. It only removes the dependency on that rule still being there tomorrow.

### 2c. Already landed

The per-Org `bp-agenity` oidc-gate companion — the actual #5617 symptom — was fixed by #5624 (merged, chart 0.5.22). No other chart in the enumeration is missing an egress rule; that is the sweep result, not an assumption.

## 3. The gate — `scripts/check-netpol-egress-completeness.py`

Renders every policy-bearing chart into the namespace it really installs into and asserts, per selected endpoint:

> the UNION of that group's egress rules MUST allow 53/UDP **and** 53/TCP to cluster DNS.

**It asserts on parsed values, never on a key.** `grep -q egress` would pass on `egress: []` — the exact #5639/#5641 shape where `grep -q 'key: openova.io/region'` passed on an empty value. The classifier walks the document and rejects:

- a hollow `egress: []`,
- `port: 53` whose destination is the workload's own namespace (`toEndpoints: [{}]` is namespace-scoped in a namespaced CNP — never kube-system),
- 53/UDP with no TCP fallback,
- 53 reached only via `ipBlock: 0.0.0.0/0` (#4360 — a CIDR never matches CoreDNS's pod identity).

**Fail-closed by construction.** The exemption set is *computed*, never hand-kept: a group is excused only when its namespace is one where bp-plane-isolation renders an open-egress default-deny, and that property is re-verified against the template on every run. Tighten plane-isolation and every exemption evaporates and the gate goes red on its own. Charts with no bootstrap-kit slot install per-Organization and are always enforced. A chart that fails to render, or renders zero policy documents, is a blind spot and fails the run — it must earn a `RENDER_SKIP_ALLOWLIST` / `POLICY_OFF_BY_DESIGN` entry with a reason.

Companions: `platform/oidc-gate/chart/tests/netpol-render.sh` (per-rule structural assertions on the rendered document) and a Go regression test on the generator, `TestRender_CiliumNetworkPolicyCarriesClusterDNSEgress`, which walks the parsed CNP rather than substring-matching "53".

## 4. Vacuity check — the gate red, then green

A guard that has only ever been seen green is a guard nobody has proven can fail.

### 4a. Phase 0 self-test (runs on every invocation, before any verdict)

```
== Phase 0: guard self-test (vacuity) ==
  self-test OK  [PASS as designed] complete DNS egress
  self-test OK  [FAIL as designed] ingress-only (the #5617 shape)
  self-test OK  [FAIL as designed] hollow `egress: []` (the #5639 shape)
  self-test OK  [FAIL as designed] port 53 pointed at own namespace
  self-test OK  [FAIL as designed] 53/UDP only, no TCP fallback
  self-test OK  [FAIL as designed] 53 via ipBlock 0.0.0.0/0 (#4360)
  self-test OK  [not a workload policy] namespace baseline (empty selector)
  self-test OK: classifier bites 5/5 broken shapes, passes 1/1 correct shape, 40 policy-bearing charts of 95 in scope
```

### 4b. Reverted the real #5624 fix (i.e. reconstructed the #5617 defect) — gate RED

Deleted the egress CNP block from `products/agenity/chart/templates/oidc-gate.yaml`, restoring the exact pre-#5624 shape that 500'd on hw292:

```
$ python3 scripts/check-netpol-egress-completeness.py
FAIL: products/agenity/chart (bp-agenity) policy `oidc-gate-agenity-t99-gateway-ingress` -> ns `<org-slug>`: no egress rule at all (ingress-only policy — the #5617 shape)

Every workload policy in a default-deny namespace needs cluster DNS in its egress union (#5617/#4437). Add a toEndpoints rule for `kube-system`/kube-dns on 53 UDP+TCP — never an ipBlock/toCIDR, which cannot match a ClusterMesh remote identity (#4360/#4656).
$ echo $?
1
```

### 4c. Broke this PR's own new chart template — gate + chart test both RED

Deleted the kube-dns rule from `platform/oidc-gate/chart/templates/networkpolicy.yaml`:

```
$ bash platform/oidc-gate/chart/tests/netpol-render.sh
[netpol] Case 1: both policy halves render with a complete dial surface
FAIL: oidc-gate-openova-flow-egress has no egress rule allowing 53/UDP to namespace kube-system
$ echo $?
1

$ python3 scripts/check-netpol-egress-completeness.py
FAIL: platform/oidc-gate/chart (bp-oidc-gate) policy `oidc-gate-openova-flow-egress+oidc-gate-openova-flow-gateway-ingress` -> ns `oidc-gate`: egress declared but no 53/UDP and no 53/TCP to cluster DNS
```

### 4d. Removed the DNS rule from the per-Org generator — Go test RED

```
$ go test ./internal/gitops/... -run CarriesClusterDNS
--- FAIL: TestRender_CiliumNetworkPolicyCarriesClusterDNSEgress (0.00s)
    manifests_test.go:689: plan m: #5617 — the per-Org CNP constrains egress for EVERY pod in
    the Org namespace but does not allow 53/UDP+53/TCP to kube-system/kube-dns (udp=false
    tcp=false). Every workload that ships no DNS egress of its own is mute.
```

### 4e. All three restored — GREEN

```
  - `products/dmz-vcluster/chart`: 2

  OK — 109 rendered policies, 0 workload groups without cluster DNS egress.

$ bash platform/oidc-gate/chart/tests/netpol-render.sh
[netpol] ALL CASES PASS
$ go test ./internal/gitops/... -count=1
ok  github.com/openova-io/openova/core/controllers/organization/internal/gitops
```

## Lockstep (bp-oidc-gate 0.1.8 -> 0.1.9)

- `platform/oidc-gate/chart/Chart.yaml` -> 0.1.9 (+ changelog)
- `platform/oidc-gate/blueprint.yaml` -> 0.1.9
- `clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml` pin -> 0.1.9 (the 5th site the shell gates miss)
- `blueprints.json` + `catalog.generated.ts` regenerated via `build-catalog.mjs`
- catalog-seed `blueprints.yaml`: bp-oidc-gate is **not** seeded there (unlisted, bootstrap-kit-only) — `check-catalog-seed-lockstep.sh` confirms 68 checked / 0 fail

## Gates run locally

| gate | result |
|---|---|
| `python3 scripts/check-netpol-egress-completeness.py --table` | PASS — 109 rendered policies, 0 workload groups without DNS egress |
| `bash platform/oidc-gate/chart/tests/netpol-render.sh` | PASS (4/4 cases) |
| `bash platform/oidc-gate/chart/tests/{internal-discovery,root-redirect,spa-token-seed}-render.sh` | PASS |
| `bash products/agenity/chart/tests/oidc-gate-companion-render.sh` | PASS |
| `helm lint platform/oidc-gate/chart` | PASS (0 failed) |
| `core/controllers/organization`: `go build ./... && go test ./...` | PASS (incl. the new DNS regression test) |
| `tests/e2e/bootstrap-kit`: `go test ./... -count=1` | PASS |
| `bash scripts/check-bootstrap-kit-pin-sync.sh` | PASS — 67 pairs in sync |
| `bash scripts/check-catalog-seed-lockstep.sh` | PASS — 68 checked, 0 fail |
| `bash scripts/check-chart-annotations.sh` | PASS — 95 charts, 0 hollow / 0 empty-render / 0 render-fail |
| `bash scripts/check-no-nodeports.sh` | PASS — zero NodePorts, 72 charts rendered and scanned |

No Service or port change anywhere in the diff outside 53 / 80 / 443 / 4180 / 6443 / 8080 — nothing NodePort-shaped (§854).

## What is NOT claimed

**This is a renders-correctly claim, not a works-live claim.** Nothing in this PR was exercised against a running Sovereign: no fresh prov, no per-Org install, no browser round-trip through a gate. The live evidence in this PR is the hw292 repro recorded on #5617 itself. Runtime proof is owed on the next prov — a per-Org app behind `bp-oidc-gate` reaching an authenticated landing, plus `cilium-dbg endpoint get` (or a Hubble flow) showing the gate pod's DNS egress allowed.

Two further things I could not verify:

1. **The precise Cilium translation of `allow-same-org`'s DNS rule under the vcluster syncer.** The per-Org K8s NetworkPolicy carries a `to`-less port-53 egress rule which in isolation reads as allow-all-destinations, yet the hw292 pod still timed out. The syncer rewrites the synced policy's `podSelector`, so a host-created pod may fall outside it — consistent with the observation, but I did not confirm it on a live cluster. It does not change the fix: the host-side CNP constrains egress for every pod in the namespace regardless, and that is where DNS now lives.
2. **Whether adding the egress CNP to `platform/oidc-gate` changes any live behaviour.** The reasoning that it cannot (Cilium unions policies, bp-plane-isolation's open-egress rule is still present) is from the policy model and the rendered manifests, not from a live cluster.

Refs #5617 #4437 #4360 #4656 #3374
