### PR TITLE
fix(cutover): declare the known loft tether so 0.1.162's source lint cannot wedge every fresh prov

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1049,7 +1049,7 @@ spec:
       # default", which detect holds literally, and shipping it off left the
       # gap as silent as the issue describes. Step count stays 11; no RBAC
       # change. New chart test tests/daytwo-image-leg.sh + contract Case 75.
-      version: 0.1.162
+      version: 0.1.163
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.162
+  version: 0.1.163
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -2889,6 +2889,24 @@ name: bp-self-sovereign-cutover
 # step-count / RBAC / deadline change (still 11 steps). New contract Case 62
 # asserts the self-heal warm + re-HEAD path is present in the rendered
 # script.
+# 0.1.163 (#5650 Refs #5505) — declare the one KNOWN Flux-source tether so the
+# 0.1.162 lint cannot wedge the flow it protects.
+#
+# 0.1.162 shipped fluxSourceHostLint with allowHosts EMPTY. But
+# clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml installs
+# HelmRepository vcluster-system/loft at https://charts.loft.sh on EVERY
+# Sovereign — that slot's own comment marks the URL an optional operator
+# overlay for a Harbor proxy cache (Principle #4a), and nothing in the cutover
+# drives it. So an empty allowHosts would have failed step-08 on every fresh
+# prov and held cutoverComplete=false: a guard that wedges the very flow it
+# protects, which is the #5505 shape and worse than the tether it reports.
+#
+# allowHosts now ships ["charts.loft.sh"]. This is not a weakening — it turns
+# an UNKNOWN residual tether into a DECLARED one, in Git, diffable and
+# reviewable, which is what the key exists for. Every undeclared host still
+# fails closed. Deleting this entry is the definition of done for the #5650
+# instance fix (mirror the loft chart locally, repoint slot 60), at which
+# point the lint proves the tether is gone rather than tolerating it.
 # 0.1.162 (#5650 Refs #5527 #3379 #3678) — step-08 gains a Flux SOURCE host
 # lint, the timing-independent half of the Pillar-5 proof.
 #
@@ -2987,7 +3005,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.162
+version: 0.1.163
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1766,7 +1766,31 @@ egressTest:
   # an entry is a reviewable sovereignty exception, not a config tweak.
   fluxSourceHostLint:
     enabled: true
-    allowHosts: []
+    # SHIPPED EXCEPTION, and the reason it is not empty.
+    #
+    # `clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml` installs
+    # HelmRepository vcluster-system/loft at https://charts.loft.sh on every
+    # Sovereign. That slot's own comment says an operator MAY swap the URL for
+    # a Harbor proxy cache per Principle #4a (mirror-everything) — it is an
+    # optional overlay, and nothing in the cutover drives it. So the tether is
+    # present on every fresh prov by construction.
+    #
+    # With an empty allowHosts this lint would therefore fail step-08 on EVERY
+    # fresh prov and hold cutoverComplete=false — a guard that wedges the very
+    # flow it protects. That is the #5505 shape (a flip whose blast radius was
+    # wider than intended) and shipping it would be worse than the tether.
+    #
+    # Declaring the host here is not a weakening: it converts an UNKNOWN
+    # residual tether into a DECLARED one, visible in Git, diffable, and
+    # reviewable — which is exactly what this key is for. Every host nobody has
+    # declared still fails closed, which is the property the lint exists to
+    # enforce.
+    #
+    # Removing this entry is the definition of done for the #5650 instance fix
+    # (mirror the loft chart into the local Harbor and repoint slot 60). When
+    # that lands, delete the entry and the lint proves the tether is gone.
+    allowHosts:
+      - charts.loft.sh
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.162",
+      "version": "0.1.163",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.162",
+    "version": "0.1.163",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.162"
+  version: "0.1.163"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.162"
+    version: "0.1.163"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## I shipped a gate that would have wedged every fresh prov. This fixes it before it could.

`0.1.162` (PR #5652) added `fluxSourceHostLint` with `allowHosts` **empty**, so any Flux source on a non-Sovereign host fails step-08 closed.

The problem: `clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml` installs `HelmRepository vcluster-system/loft` at `https://charts.loft.sh` on **every** Sovereign. That slot's own comment says so plainly:

> Per-Sovereign overlay surface — operators MAY swap the upstream URL for a Harbor proxy cache (MIRROR-EVERYTHING per Principle #4a)

An *optional* overlay that nothing in the cutover drives. So the tether is present on every fresh prov **by construction** — and `0.1.162` as shipped would have failed step-08 on all of them and held `cutoverComplete=false`.

That is a guard that wedges the very flow it protects. It is the #5505 shape — a flip whose blast radius was wider than the author checked — and shipping it would have been strictly worse than the tether it reports, because a Sovereign that cannot complete cutover has no sovereignty proof at all.

## The fix, and why it is not a weakening

`allowHosts` now ships `["charts.loft.sh"]`.

The lint's purpose was never "no host may be external" — it was **"no external host may be undeclared"**. An empty list and a one-entry list enforce the same property; the difference is only whether the one host everybody already ships is written down. This change converts an **unknown** residual tether into a **declared** one: in Git, in a diff, in review, with a comment naming the issue that closes it. Every host nobody has declared still fails closed, which is the whole point.

Deleting this entry is the **definition of done for the #5650 instance fix** — mirror the loft chart into the local Harbor and repoint slot 60. At that moment the lint stops tolerating the tether and starts proving it is gone. The entry is therefore self-retiring, not permanent.

## Gates

| gate | result |
|---|---|
| `scripts/check-bootstrap-kit-pin-sync.sh` | PASS — 67/67 chart→pin pairs |
| `chart/tests/flux-source-host-lint.sh` | 9/9, both directions, including the fail-closed regression case |
| `helm template` | renders `FLUX_SOURCE_HOST_ALLOW = "charts.loft.sh"` |
| catalog regenerated | `node scripts/build-catalog.mjs`, no manual edit |

Six lockstep sites bumped to `0.1.163`: `Chart.yaml`, `blueprint.yaml`, `clusters/_template/bootstrap-kit/06a-…`, the catalog seed, `blueprints.json`, and `catalog.generated.ts` — that last one is the site a manual bump misses and only the generator writes.

Refs #5650 #5505 #3379
