### PR TITLE
fix(cutover): make the sovereignty gate a per-region assertion and stop step-05 accepting a stale Ready (#5359)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1049,7 +1049,7 @@ spec:
       # default", which detect holds literally, and shipping it off left the
       # gap as silent as the issue describes. Step count stays 11; no RBAC
       # change. New chart test tests/daytwo-image-leg.sh + contract Case 75.
-      version: 0.1.163
+      version: 0.1.164
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.163
+  version: 0.1.164
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,99 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.164 (#5359 Refs #5650 #5379 #3379 #960) — the sovereignty gate becomes a
+# FLEET assertion, and step-05's secondary readiness starts asserting
+# convergence instead of a stale status field.
+#
+# THE LIVE FAILURE. hw292 (dep 1c56518035a83e03) set cutoverComplete=true,
+# progressPercent=100, failedStep and lastError both empty, at
+# 2026-08-03T08:12:04Z. Measured on it 2026-08-04:
+#
+#   region-a: 69 HelmRepositories -> local Harbor, 0 -> ghcr.io
+#   region-b:  0 HelmRepositories -> local Harbor, 64 -> ghcr.io
+#   control (same object, both regions):
+#     bp-cilium  region-a  oci://registry.hw292.omani.works/openova-io
+#     bp-cilium  region-b  oci://ghcr.io/openova-io
+#
+# #5379's per-secondary-region legs were PRESENT in the deployed chart
+# (0.1.159) and had recorded region.me-east-215-b-1.result=success for steps
+# 05, 06 AND 08. They ran; they did not work; and nothing said so.
+#
+# ROOT CAUSE, in two parts.
+#
+# (1) The URL region-b was pivoted TO is not reachable from region-b. Step-05
+# patched its GitRepository to `http://gitea-http.gitea.svc.cluster.local:3000`
+# and relied on a ClusterMesh global-Service alias to carry the dial to
+# region-a. It cannot. A 2-region Sovereign installs bp-gitea in BOTH regions
+# from the bootstrap-kit, so region-b already had a same-named Service
+# selecting its OWN Gitea — which no step ever mirrors, and whose
+# /data/git/repositories does not exist. And even with no local backend the
+# alias could not work: both Services are HEADLESS (clusterIP: None), and
+# Cilium global-services do not span a headless Service at all — CoreDNS
+# answers straight from the local EndpointSlice, so `service.cilium.io/global`
+# is inert on it. Live: region-b resolved that name to 10.43.3.228, its own
+# gitea pod, whose openova/openova advertises zero refs, giving
+# source-controller "pkt-line 3: EOF" on every fetch from 07:39:48Z onward.
+#
+# (2) The readiness wait could not see that, because it asserted on a STATUS
+# field immediately after mutating the SPEC. The predicate was
+# `Ready == True && spec.url == sec_url`. The url half is a tautology — the leg
+# wrote that value one line earlier. The Ready half still described the
+# PREVIOUS spec: region-b carried Ready=True from its last successful clone of
+# PUBLIC github.com, so the first loop iteration matched and the leg recorded
+# result=success at 07:39:48Z — the same second Ready actually flipped to
+# False. source-controller never advanced observedGeneration past 1 against
+# generation 2, kept serving the github.com artifact (main@sha1:4cc85ad9...,
+# stored 07:31:11Z), and region-b's kustomize-controller re-applied that
+# pre-cutover content every 5m — reverting all 64 HelmRepositories the step-06
+# leg had pivoted and read-back-asserted three minutes later. 22h after
+# cc=true, generation was still 2 and observedGeneration still 1.
+#
+# WHAT CHANGES.
+#
+# * Step-05's secondary leg walks a CANDIDATE URL CHAIN and its success
+#   predicate is CONVERGENCE — observedGeneration == generation on a Ready
+#   source. Nothing else distinguishes "fetched from the new URL" from "still
+#   holding what it fetched from the old one". The candidates are the
+#   in-cluster mesh URL first, then the Sovereign's OWN external Gitea door
+#   (secondaryRegions.giteaFallbackToPublicDoor, default on) — on-Sovereign,
+#   already carved out of the step-08 secondary hold, and live-verified from
+#   hw292 region-b serving HEAD 7bcd1d59..., byte-identical to region-a's
+#   in-cluster Gitea. Exhausting the chain is FATAL. The only honest prober of
+#   a URL is the secondary's own source-controller, so each candidate is
+#   patched in and given a bounded window rather than probed synthetically.
+#   stepTimeouts.fluxGitRepositoryPatchSeconds 600 -> 1800 to fit the chain.
+#
+# * The #5650 fluxSourceHostLint becomes PER-REGION. It shipped measuring one
+#   cluster, which is the same shape as the defect it exists to catch: a fleet
+#   property asserted from a single-region sample. Both lints now take a
+#   region label + kubeconfig, the driver fans out over every
+#   /secondary-kubeconfigs entry, every region is evaluated (no short-circuit,
+#   so one run names every offender), and the verdict is an AND. Enumeration is
+#   FAIL-CLOSED: the old `kubectl ... 2>/dev/null` pipe turned an unreadable
+#   secondary into zero rows, zero offenders and a PASS for a region that was
+#   never measured — against a secondary cluster that is the single most likely
+#   failure mode. A kind that is merely not INSTALLED stays zero rows.
+#
+# * New egressTest.fluxSourceHealthLint. The host lint reads spec.url, and
+#   hw292 proved a URL can be cosmetic. This asserts the controller CONVERGED
+#   on it. Scope was MEASURED, not assumed: `type: oci` HelmRepositories carry
+#   `status: {}` with no observedGeneration (70/70 in region-a, 65/65 in
+#   region-b), so they are exempt — including them would fail every region of
+#   every Sovereign (#5505 blast-radius shape). Scoped to GitRepository +
+#   OCIRepository, the live blast radius on hw292 is exactly ONE object:
+#   region-b's flux-system/openova GitRepository. The defect itself, and
+#   nothing else.
+#
+# Templates 05 + 08 and values only; no step-count / RBAC change (still 11
+# steps). tests/flux-source-host-lint.sh proves both lints in BOTH directions
+# (24 assertions) and contract Case 76 pins the wiring; both suites were
+# mutation-checked — reverting the observedGeneration half, the fail-closed
+# enumeration, the kubeconfig plumbing, the driver fan-out or the health-lint
+# scope each turns exactly one intended assertion red. Slot-06a pin +
+# blueprint.yaml + catalog-seed source.version + spec.version + the API
+# blueprints.json + the generated UI catalog move to 0.1.164 in lockstep
+# (Inviolable Principle #13).
+# ── prior ──
 # 0.1.160 (#5527 Refs #3379 #5529 #960 — step-07 Phase 3d: stamp the per-Org
 # GitOps tree generator with the local OCI base. The org-services provisioning
 # Deployment (core/services/provisioning) regenerates the per-Org trees —
@@ -3005,7 +3099,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.163
+version: 0.1.164
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -266,7 +266,13 @@ data:
             for skc in /secondary-kubeconfigs/*.yaml; do
               [ -e "${skc}" ] || continue
               region=$(basename "${skc}" .yaml)
-              echo "[flux-gitrepository-patch] #5359 secondary region ${region}: pivoting its GitRepository -> ${sec_url}"
+              # ${sec_url_chain}, NOT ${sec_url}: the single-URL variable now
+              # exists only inside the candidate loop below, and this line runs
+              # before it. Under the Job's `set -u` a stale reference here is
+              # not a cosmetic log bug — it aborts the leg on the FIRST
+              # secondary region, before any pivot, for every 2-region
+              # Sovereign.
+              echo "[flux-gitrepository-patch] #5359 secondary region ${region}: pivoting its GitRepository, candidates -> ${sec_url_chain}"
 
               # 1a. Share region-A's gitea-http endpoints into the mesh (the
               # bp-cnpg-pair global-Service idiom). Annotating the LIVE

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -112,6 +112,15 @@ data:
           # step.<step>.region.<key>.* tracking keys.
           - name: SECONDARY_GITEA_URL
             value: {{ if .Values.secondaryRegions.giteaURL }}{{ printf "%s/%s/%s" (.Values.secondaryRegions.giteaURL | trimSuffix "/") .Values.gitea.org .Values.gitea.repo | quote }}{{ else }}""{{ end }}
+          # #5359 — the fallback candidate, tried only if the in-cluster mesh
+          # URL fails to CONVERGE in the secondary. Defaults to the Sovereign's
+          # OWN external Gitea door, which is on-Sovereign (it satisfies the
+          # step-08 source-host lint's *.<fqdn> exemption) and is the only path
+          # live-proven to serve region-A's pivoted repo from region-B on hw292.
+          # Set secondaryRegions.giteaFallbackURL to "" to disable the fallback
+          # and make a mesh failure immediately fatal.
+          - name: SECONDARY_GITEA_FALLBACK_URL
+            value: {{ if .Values.secondaryRegions.giteaFallbackURL }}{{ printf "%s/%s/%s" (.Values.secondaryRegions.giteaFallbackURL | trimSuffix "/") .Values.gitea.org .Values.gitea.repo | quote }}{{ else if .Values.secondaryRegions.giteaFallbackToPublicDoor }}{{ printf "https://gitea.%s/%s/%s" .Values.sovereign.fqdn .Values.gitea.org .Values.gitea.repo | quote }}{{ else }}""{{ end }}
           - name: SECONDARY_GITREPO_READY_SECONDS
             value: {{ .Values.secondaryRegions.gitRepositoryReadySeconds | quote }}
           - name: STATUS_CONFIGMAP
@@ -220,8 +229,40 @@ data:
             # secondary region, materialised by catalyst-api at run start).
             # Empty/absent = single-region Sovereign = this whole block
             # no-ops (pre-#5359 behavior byte-identical).
-            sec_url="${SECONDARY_GITEA_URL:-}"
-            [ -n "${sec_url}" ] || sec_url="${LOCAL_GITEA_URL}"
+            #
+            # #5359 CANDIDATE URL CHAIN (hw292, dep 1c56518035a83e03). The leg
+            # used to pivot the secondary to LOCAL_GITEA_URL unconditionally —
+            # `http://gitea-http.gitea.svc.cluster.local:3000`. That name does
+            # NOT reach region-A from a secondary region, and the mesh alias
+            # below cannot make it: a 2-region Sovereign installs bp-gitea in
+            # BOTH regions from the bootstrap-kit, so the secondary already runs
+            # its own `gitea/gitea-http` Service whose selector matches its own
+            # (empty, never mirrored) Gitea pod; and BOTH Services are HEADLESS
+            # (clusterIP: None), which Cilium ClusterMesh global-services cannot
+            # span at all — a headless Service is resolved by CoreDNS straight
+            # from the LOCAL EndpointSlice, so `service.cilium.io/global` is
+            # inert on it. Live on hw292: region-b resolved that name to
+            # 10.43.3.228, its OWN gitea pod, whose openova/openova advertises
+            # zero refs, giving source-controller "pkt-line 3: EOF" on every
+            # fetch from 07:39:48Z onward.
+            #
+            # So the URL is a candidate, not a certainty, and the only honest
+            # prober is the secondary's OWN source-controller: it dials the exact
+            # URL, from the right cluster, with the right credential. Each
+            # candidate is patched in and given a bounded window to CONVERGE
+            # (below); the first that converges wins, and exhausting the chain is
+            # fatal. The fallback is the Sovereign's own external Gitea door,
+            # which is on-Sovereign (it satisfies the step-08 source-host lint's
+            # *.<SOVEREIGN_FQDN> exemption, and the step-08 secondary hold
+            # already carves out that gateway's public IPs) and was
+            # live-verified reachable from hw292 region-b, serving the pivoted
+            # revision 7bcd1d59... byte-identical to region-A's in-cluster Gitea.
+            sec_url_chain="${SECONDARY_GITEA_URL:-}"
+            if [ -z "${sec_url_chain}" ]; then
+              sec_url_chain="${LOCAL_GITEA_URL}"
+              [ -n "${SECONDARY_GITEA_FALLBACK_URL:-}" ] && sec_url_chain="${sec_url_chain} ${SECONDARY_GITEA_FALLBACK_URL}"
+            fi
+            echo "[flux-gitrepository-patch] #5359 secondary candidate URL chain: ${sec_url_chain}"
             for skc in /secondary-kubeconfigs/*.yaml; do
               [ -e "${skc}" ] || continue
               region=$(basename "${skc}" .yaml)
@@ -280,7 +321,12 @@ data:
                   -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"skipped\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
                 continue
               fi
-              cat >/tmp/patch-secondary.yaml <<EOF
+              sg_ready=""
+              sg_chosen=""
+              sg_msg=""
+              for sec_url in ${sec_url_chain}; do
+                echo "[flux-gitrepository-patch] #5359 secondary ${region}: trying candidate ${sec_url}"
+                cat >/tmp/patch-secondary.yaml <<EOF
             spec:
               url: ${sec_url}
               ref:
@@ -294,44 +340,71 @@ data:
                 !/platform
                 !/products
             EOF
-              kubectl --kubeconfig "${skc}" patch gitrepository "${GITREPO_NAME}" \
-                -n "${GITREPO_NAMESPACE}" \
-                --type=merge --patch-file /tmp/patch-secondary.yaml
-              kubectl --kubeconfig "${skc}" annotate --overwrite gitrepository "${GITREPO_NAME}" \
-                -n "${GITREPO_NAMESPACE}" \
-                "reconcile.fluxcd.io/requestedAt=$(date +%s)"
+                kubectl --kubeconfig "${skc}" patch gitrepository "${GITREPO_NAME}" \
+                  -n "${GITREPO_NAMESPACE}" \
+                  --type=merge --patch-file /tmp/patch-secondary.yaml
+                kubectl --kubeconfig "${skc}" annotate --overwrite gitrepository "${GITREPO_NAME}" \
+                  -n "${GITREPO_NAMESPACE}" \
+                  "reconcile.fluxcd.io/requestedAt=$(date +%s)"
 
-              # 4. FAIL-LOUD readiness: the secondary MUST reconcile the
-              # local Gitea within the bounded window, or the step fails and
-              # cutoverComplete stays false — a silent skip here IS the
-              # #5359 false positive.
-              sg_deadline=$(( $(date +%s) + ${SECONDARY_GITREPO_READY_SECONDS} ))
-              sg_ready=""
-              while [ "$(date +%s)" -lt "${sg_deadline}" ]; do
-                sg_status=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
-                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
-                sg_url=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
-                  -o jsonpath='{.spec.url}' 2>/dev/null || echo "")
-                if [ "${sg_status}" = "True" ] && [ "${sg_url}" = "${sec_url}" ]; then
-                  sg_ready="yes"
-                  break
-                fi
-                echo "[flux-gitrepository-patch] #5359 secondary ${region}: Ready=${sg_status:-<none>} url=${sg_url:-<none>} — re-checking in 10s"
-                sleep 10
-              done
-              if [ -z "${sg_ready}" ]; then
+                # 4. FAIL-LOUD readiness. #5359 (hw292): the predicate here USED
+                # to be `Ready == True && spec.url == sec_url`, and both halves
+                # were unsound.
+                #
+                #   * `spec.url` is the value this leg had just WRITTEN one line
+                #     earlier, so that half is a tautology — it can never be
+                #     false and it proves nothing about the fetch.
+                #   * `Ready` is a STATUS field, and immediately after a patch it
+                #     still describes the PREVIOUS spec. On hw292 the object went
+                #     into the loop carrying Ready=True from its last successful
+                #     clone of PUBLIC github.com, so the very first iteration
+                #     matched and the leg recorded result=success at 07:39:48Z —
+                #     the same second the Ready condition actually flipped to
+                #     False. The controller then never advanced past
+                #     observedGeneration=1 while metadata.generation stayed 2,
+                #     and 22h later it was still serving that pre-pivot GitHub
+                #     artifact.
+                #
+                # The sound predicate is CONVERGENCE: source-controller has
+                # processed THIS generation (observedGeneration == generation)
+                # and the outcome was success (Ready=True). Nothing else can
+                # distinguish "fetched from the new URL" from "still holding what
+                # it fetched from the old one".
+                sg_deadline=$(( $(date +%s) + ${SECONDARY_GITREPO_READY_SECONDS} ))
+                while [ "$(date +%s)" -lt "${sg_deadline}" ]; do
+                  sg_json=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
+                    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}|{.metadata.generation}|{.status.observedGeneration}|{.spec.url}' 2>/dev/null || echo "")
+                  sg_status=$(printf '%s' "${sg_json}" | cut -d'|' -f1)
+                  sg_gen=$(printf '%s' "${sg_json}" | cut -d'|' -f2)
+                  sg_obs=$(printf '%s' "${sg_json}" | cut -d'|' -f3)
+                  sg_url=$(printf '%s' "${sg_json}" | cut -d'|' -f4)
+                  if [ "${sg_status}" = "True" ] && [ -n "${sg_gen}" ] && [ "${sg_obs}" = "${sg_gen}" ] && [ "${sg_url}" = "${sec_url}" ]; then
+                    sg_ready="yes"
+                    sg_chosen="${sec_url}"
+                    break
+                  fi
+                  echo "[flux-gitrepository-patch] #5359 secondary ${region}: Ready=${sg_status:-<none>} generation=${sg_gen:-<none>} observedGeneration=${sg_obs:-<none>} (need observedGeneration==generation on a Ready source) — re-checking in 10s"
+                  sleep 10
+                done
+                [ -n "${sg_ready}" ] && break
                 sg_msg=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
                   -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || echo "")
-                echo "[flux-gitrepository-patch] FATAL: secondary region ${region} GitRepository did not reach Ready=True on ${sec_url} within ${SECONDARY_GITREPO_READY_SECONDS}s: ${sg_msg} — region-B is still git-tethered; refusing to succeed (#5359)" >&2
+                echo "[flux-gitrepository-patch] #5359 secondary ${region}: candidate ${sec_url} did not converge within ${SECONDARY_GITREPO_READY_SECONDS}s: ${sg_msg}"
+              done
+              if [ -z "${sg_ready}" ]; then
+                echo "[flux-gitrepository-patch] FATAL: secondary region ${region} GitRepository did not CONVERGE (observedGeneration==generation with Ready=True) on any candidate URL in [${sec_url_chain}] — last error: ${sg_msg}. region-B is still serving its pre-cutover artifact and every HelmRepository this cutover pivots there will be reverted on the next Kustomization interval; refusing to succeed (#5359)" >&2
                 kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
-                  -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"failed\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                  -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"failed\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.flux-gitrepository-patch.region.${region}.lastError\":\"$(printf '%s' "${sg_msg}" | tr -d '\"' | cut -c1-200)\"}}" || true
                 exit 1
               fi
 
-              # 5. Per-region durable tracking (#5359).
+              # 5. Per-region durable tracking (#5359). giteaURL records WHICH
+              # candidate converged, so an operator can see from the status
+              # ConfigMap alone whether the secondary took the in-cluster mesh
+              # path or the Sovereign's external Gitea door.
               kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
-                -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"success\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
-              echo "[flux-gitrepository-patch] #5359 secondary region ${region}: GitRepository Ready on local Gitea"
+                -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"success\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.flux-gitrepository-patch.region.${region}.giteaURL\":\"${sg_chosen}\"}}" || true
+              echo "[flux-gitrepository-patch] #5359 secondary region ${region}: GitRepository CONVERGED on ${sg_chosen} (observedGeneration==generation, Ready=True)"
             done
             echo "[flux-gitrepository-patch] done"
         resources:

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -125,6 +125,11 @@ data:
             value: {{ .Values.sovereign.fqdn | quote }}
           - name: STATUS_CONFIGMAP
             value: {{ .Values.status.configMapName | quote }}
+          # #5359 — the per-region lint driver stamps
+          # step.egress-block-test.region.<key>.fluxSourceLint on the status
+          # ConfigMap, which lives in the cutover release namespace.
+          - name: CUTOVER_NAMESPACE
+            value: {{ .Release.Namespace | quote }}
           # #3678 — active call-home assertion knobs. During the hold, curl
           # each CALL_HOME_HOSTS entry FROM this pod (under the policy); any
           # that connects fails the proof.
@@ -213,6 +218,15 @@ data:
             value: {{ eq (toString .Values.egressTest.fluxSourceHostLint.enabled) "true" | quote }}
           - name: FLUX_SOURCE_HOST_ALLOW
             value: {{ .Values.egressTest.fluxSourceHostLint.allowHosts | default (list) | join " " | quote }}
+          # #5359 — pre-hold Flux SOURCE HEALTH lint. The host lint reads
+          # spec.url; this reads whether the controller ever converged on it.
+          # hw292 region-b carried a Sovereign-local GitRepository URL that
+          # source-controller had never once fetched (generation=2,
+          # observedGeneration=1, Ready=False), so it kept serving the
+          # pre-cutover github.com artifact and reverted all 64 pivoted
+          # HelmRepositories every 5m. A host-only lint passes over that.
+          - name: FLUX_SOURCE_HEALTH_LINT
+            value: {{ eq (toString .Values.egressTest.fluxSourceHealthLint.enabled) "true" | quote }}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
@@ -829,8 +843,27 @@ data:
             # traverses containerd, so a certs.d redirect cannot cover it. The
             # exemption set here is therefore strictly the Sovereign's OWN
             # hosts plus in-cluster DNS — anything else is a live tether.
+            # #5359 (hw292, dep 1c56518035a83e03) — the lint MUST run PER REGION.
+            # It shipped in 0.1.162 measuring ONE cluster, which is the same
+            # shape as the defect it exists to catch: on hw292 region-a held 69
+            # HelmRepositories on the local Harbor and 0 on ghcr, while region-b
+            # held 0 local and 64 on ghcr, and cutoverComplete=true was set from
+            # the region-a measurement alone. A fleet property asserted from a
+            # single-region sample is not asserted at all.
+            #
+            # ARGS: $1 = region label (for the operator-facing message), $2 =
+            # kubeconfig path ("" = this Job's own in-cluster context = the
+            # primary). The `_fs_kubectl` shim is written on ONE line on purpose:
+            # chart/tests/flux-source-host-lint.sh extracts this function out of
+            # the RENDER with an awk range that terminates on the first bare `}`
+            # line, so a nested multi-line function definition would silently
+            # truncate the function under test and leave the suite validating a
+            # fragment (the #5646 drift shape).
             run_flux_source_host_lint() {
-              echo "[egress-block-test] #5650: PRE-HOLD Flux source-host lint — every HelmRepository/GitRepository/OCIRepository URL must resolve to a Sovereign-local host (registry./gitea./harbor.${SOVEREIGN_FQDN}, in-cluster DNS, or an explicit FLUX_SOURCE_HOST_ALLOW entry). containerd redirects do NOT cover these: source-controller dials them directly."
+              _fs_region="${1:-primary}"
+              _FS_KUBECONFIG="${2:-}"
+              _fs_kubectl() { if [ -n "${_FS_KUBECONFIG:-}" ]; then kubectl --kubeconfig="${_FS_KUBECONFIG}" "$@"; else kubectl "$@"; fi; }
+              echo "[egress-block-test] #5650/#5359: PRE-HOLD Flux source-host lint [region=${_fs_region}] — every HelmRepository/GitRepository/OCIRepository URL must resolve to a Sovereign-local host (registry./gitea./harbor.${SOVEREIGN_FQDN}, in-cluster DNS, or an explicit FLUX_SOURCE_HOST_ALLOW entry). containerd redirects do NOT cover these: source-controller dials them directly."
               # WORK_DIR defaults to the Job's /work emptyDir; overridable so the
               # function is drivable from chart/tests/flux-source-host-lint.sh.
               # The `: >` MUST be checked: if the scratch file cannot be created
@@ -843,10 +876,32 @@ data:
                 echo "  FAIL — cannot create ${_fs_off}; refusing to report PASS from a lint that cannot record an offender (fail-closed)"
                 return 1
               fi
+              _fs_raw="${WORK_DIR:-/work}/fluxsrc-raw.$$"
+              _fs_err="${WORK_DIR:-/work}/fluxsrc-err.$$"
               for _fk in helmrepositories gitrepositories ocirepositories; do
-                kubectl get "${_fk}" -A \
-                  -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.url}{" "}{.spec.suspend}{"\n"}{end}' 2>/dev/null \
-                | while IFS=' ' read -r _fns _fname _furl _fsusp; do
+                # #5359 FAIL-CLOSED ENUMERATION. This used to be a bare
+                # `kubectl … 2>/dev/null` piped into the reader: when the get
+                # FAILED (unreadable secondary kubeconfig, unreachable API,
+                # expired cert) the pipe carried zero rows, no offender was
+                # recorded, and the lint returned PASS for a region it had never
+                # measured. Against a secondary cluster that is not a hypothetical
+                # — it is the single most likely failure mode, and it would
+                # re-mint exactly the false positive this issue is about.
+                if ! _fs_kubectl get "${_fk}" -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.url}{" "}{.spec.suspend}{"\n"}{end}' >"${_fs_raw}" 2>"${_fs_err}"; then
+                  # A kind that is not INSTALLED is zero rows, not a tether: a
+                  # Sovereign with no OCIRepository CRD legitimately has none.
+                  # Anything else (auth, TLS, connection) means the region could
+                  # not be measured and the verdict must be FAIL.
+                  if grep -qiE "server doesn't have a resource type|could not find the requested resource|no matches for kind|the server could not find the requested resource" "${_fs_err}" 2>/dev/null; then
+                    : > "${_fs_raw}"
+                  else
+                    echo "  FAIL — region ${_fs_region}: cannot enumerate ${_fk} ($(head -1 "${_fs_err}" 2>/dev/null)). Refusing to report PASS for a region that could not be measured (fail-closed, #5359)"
+                    rm -f "${_fs_off}" "${_fs_raw}" "${_fs_err}"
+                    return 1
+                  fi
+                fi
+                while IFS=' ' read -r _fns _fname _furl _fsusp; do
                     [ -n "${_fns}" ] && [ -n "${_furl}" ] || continue
                     # Strip scheme, then any path/port, leaving the bare host.
                     _fh="${_furl#*://}"; _fh="${_fh%%/*}"; _fh="${_fh%%:*}"
@@ -874,21 +929,120 @@ data:
                       continue
                     fi
                     printf '%s/%s [%s] %s (host:%s)\n' "${_fns}" "${_fname}" "${_fk}" "${_furl}" "${_fh}" >> "${_fs_off}"
-                  done
+                done <"${_fs_raw}"
               done
+              rm -f "${_fs_raw}" "${_fs_err}"
               if [ -s "${_fs_off}" ]; then
-                echo "  FAIL — these Flux source objects still point at a NON-Sovereign host. Each is a live tether that the deny-egress hold cannot detect, because the hold is time-boxed and torn down while these keep reconciling on their own interval (fix = mirror the upstream into the local Harbor/Gitea and repoint the source, or declare a reviewed exception in egressTest.fluxSourceHostLint.allowHosts):"
-                sort -u "${_fs_off}" | while IFS= read -r _o; do echo "    EXTERNAL-SOURCE ${_o}"; done
+                echo "  FAIL — region ${_fs_region}: these Flux source objects still point at a NON-Sovereign host. Each is a live tether that the deny-egress hold cannot detect, because the hold is time-boxed and torn down while these keep reconciling on their own interval (fix = mirror the upstream into the local Harbor/Gitea and repoint the source, or declare a reviewed exception in egressTest.fluxSourceHostLint.allowHosts):"
+                sort -u "${_fs_off}" | while IFS= read -r _o; do echo "    EXTERNAL-SOURCE [${_fs_region}] ${_o}"; done
                 rm -f "${_fs_off}"
                 return 1
               fi
               rm -f "${_fs_off}"
-              echo "  PASS — every non-suspended Flux source resolves to a Sovereign-local host; no external dependency remains in the object graph (#5650)"
+              echo "  PASS — region ${_fs_region}: every non-suspended Flux source resolves to a Sovereign-local host; no external dependency remains in the object graph (#5650)"
               return 0
             }
-            if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ]; then
-              if ! run_flux_source_host_lint; then
-                echo "[egress-block-test] Flux source-host lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). This is the dependency half of Pillar 5: surviving a 600s isolation window is necessary but not sufficient when a source keeps fetching from the public internet on its own interval once the policy is gone (#5650)"
+            # ── #5359 FLUX SOURCE HEALTH LINT ──────────────────────────────
+            # The host lint above reads spec.url. A URL is a DECLARATION, and
+            # hw292 proved a declaration can be cosmetic: step-05's secondary leg
+            # patched region-b's GitRepository url to the local Gitea and reported
+            # success, but source-controller never once fetched from it —
+            # generation=2, observedGeneration=1, Ready=False
+            # ("pkt-line 3: EOF") from 07:39:48Z onward. source-controller
+            # therefore kept SERVING the last artifact it had, which was
+            # main@sha1:4cc85ad9…, fetched from PUBLIC github.com at 07:31:11Z
+            # before the pivot. region-b's kustomize-controller then re-applied
+            # that pre-cutover GitHub content every 5m, reverting all 64
+            # HelmRepositories the step-06 leg had just patched.
+            #
+            # So a host-only lint can pass over a region whose real source of
+            # truth is still the public internet. What discriminates the two is
+            # not the URL but whether the controller has CONVERGED on it:
+            # observedGeneration == generation AND Ready=True.
+            #
+            # SCOPE — why `type: oci` HelmRepositories are exempt, measured not
+            # assumed. source-controller does not reconcile them (they are static
+            # config consumed by helm-controller), so they carry `status: {}` with
+            # no conditions and no observedGeneration at all. Live on hw292 that
+            # is 70/70 HelmRepositories in region-a and 65/65 in region-b —
+            # asserting health over them would fail every region of every
+            # Sovereign and wedge the flow this guard protects (#5505 shape).
+            # Restricted to the kinds a controller actually drives, the live
+            # blast radius on hw292 is exactly ONE object: region-b's
+            # flux-system/openova GitRepository — the defect itself.
+            run_flux_source_health_lint() {
+              _fh_region="${1:-primary}"
+              _FS_KUBECONFIG="${2:-}"
+              _fs_kubectl() { if [ -n "${_FS_KUBECONFIG:-}" ]; then kubectl --kubeconfig="${_FS_KUBECONFIG}" "$@"; else kubectl "$@"; fi; }
+              echo "[egress-block-test] #5359: PRE-HOLD Flux source-health lint [region=${_fh_region}] — every non-suspended reconciled source (GitRepository/OCIRepository) must have observedGeneration == generation AND Ready=True, or its pivoted URL is a declaration the controller never honoured and the region is still served from its pre-cutover artifact."
+              _fh_off="${WORK_DIR:-/work}/fluxhealth-offenders.$$"
+              if ! : > "${_fh_off}" 2>/dev/null; then
+                echo "  FAIL — cannot create ${_fh_off}; refusing to report PASS from a lint that cannot record an offender (fail-closed)"
+                return 1
+              fi
+              _fh_raw="${WORK_DIR:-/work}/fluxhealth-raw.$$"
+              _fh_err="${WORK_DIR:-/work}/fluxhealth-err.$$"
+              for _hk in gitrepositories ocirepositories; do
+                if ! _fs_kubectl get "${_hk}" -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}{"|"}{.metadata.name}{"|"}{.spec.suspend}{"|"}{.metadata.generation}{"|"}{.status.observedGeneration}{"|"}{.status.conditions[?(@.type=="Ready")].status}{"|"}{.status.conditions[?(@.type=="Ready")].message}{"\n"}{end}' >"${_fh_raw}" 2>"${_fh_err}"; then
+                  if grep -qiE "server doesn't have a resource type|could not find the requested resource|no matches for kind|the server could not find the requested resource" "${_fh_err}" 2>/dev/null; then
+                    : > "${_fh_raw}"
+                  else
+                    echo "  FAIL — region ${_fh_region}: cannot enumerate ${_hk} ($(head -1 "${_fh_err}" 2>/dev/null)). Refusing to report PASS for a region that could not be measured (fail-closed, #5359)"
+                    rm -f "${_fh_off}" "${_fh_raw}" "${_fh_err}"
+                    return 1
+                  fi
+                fi
+                # `|`-separated on purpose: observedGeneration and the Ready
+                # condition are ABSENT on an unreconciled object, and with a
+                # space separator an empty middle field collapses and every later
+                # field shifts left — the reader would then compare the wrong two
+                # values and pass. The separator is load-bearing.
+                while IFS='|' read -r _hns _hname _hsusp _hgen _hobs _hready _hmsg; do
+                  [ -n "${_hns}" ] && [ -n "${_hname}" ] || continue
+                  [ "${_hsusp}" = "true" ] && continue
+                  if [ "${_hready}" = "True" ] && [ -n "${_hgen}" ] && [ "${_hobs}" = "${_hgen}" ]; then
+                    continue
+                  fi
+                  printf '%s/%s [%s] Ready=%s generation=%s observedGeneration=%s %s\n' \
+                    "${_hns}" "${_hname}" "${_hk}" "${_hready:-<none>}" "${_hgen:-<none>}" "${_hobs:-<none>}" "${_hmsg}" >> "${_fh_off}"
+                done <"${_fh_raw}"
+              done
+              rm -f "${_fh_raw}" "${_fh_err}"
+              if [ -s "${_fh_off}" ]; then
+                echo "  FAIL — region ${_fh_region}: these Flux sources have NOT converged on their declared URL. Until observedGeneration catches up with generation on a Ready source, the controller is still serving the artifact it fetched BEFORE the pivot — which on a cutover is the public upstream. The declared URL is Sovereign-local; the content being applied is not:"
+                sort -u "${_fh_off}" | while IFS= read -r _o; do echo "    STALE-SOURCE [${_fh_region}] ${_o}"; done
+                rm -f "${_fh_off}"
+                return 1
+              fi
+              rm -f "${_fh_off}"
+              echo "  PASS — region ${_fh_region}: every non-suspended reconciled Flux source has converged on its declared Sovereign-local URL (#5359)"
+              return 0
+            }
+            # ── #5359 PER-REGION DRIVER ────────────────────────────────────
+            # Every region is evaluated — no short-circuit — so one run names
+            # every offender in the fleet instead of stopping at the first. The
+            # verdict is an AND across regions, and an unreadable region is a
+            # FAIL, not a skip: `cutoverComplete=true` must be structurally
+            # unable to be set while ANY region has an off-Sovereign or
+            # unconverged Flux source.
+            if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ] || [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ]; then
+              _fs_verdict=0
+              for _fs_target in "primary=" $(for _k in /secondary-kubeconfigs/*.yaml; do [ -e "${_k}" ] && printf '%s=%s ' "$(basename "${_k}" .yaml)" "${_k}"; done); do
+                _fs_rlabel="${_fs_target%%=*}"
+                _fs_rkc="${_fs_target#*=}"
+                _fs_rstate="pass"
+                if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ]; then
+                  run_flux_source_host_lint "${_fs_rlabel}" "${_fs_rkc}" || { _fs_verdict=1; _fs_rstate="failed"; }
+                fi
+                if [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ]; then
+                  run_flux_source_health_lint "${_fs_rlabel}" "${_fs_rkc}" || { _fs_verdict=1; _fs_rstate="failed"; }
+                fi
+                [ "${_fs_rlabel}" = "primary" ] || kubectl -n "${CUTOVER_NAMESPACE:-catalyst}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                  -p "{\"data\":{\"step.egress-block-test.region.${_fs_rlabel}.fluxSourceLint\":\"${_fs_rstate}\"}}" >/dev/null 2>&1 || true
+              done
+              if [ "${_fs_verdict}" != "0" ]; then
+                echo "[egress-block-test] Flux source lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). This is the dependency half of Pillar 5: surviving a 600s isolation window is necessary but not sufficient when a source keeps fetching from the public internet on its own interval once the policy is gone (#5650), and it proves nothing at all about a region the hold never measured (#5359)"
                 exit 1
               fi
             fi

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3630,8 +3630,16 @@ if ! grep -q 'SECONDARY_GITREPO_READY_SECONDS' "$S05"; then
   echo "FAIL: step-05 leg has no bounded secondary GitRepository Ready wait (#5359)" >&2
   c71_fail=1
 fi
-if ! grep -q 'region-B is still git-tethered' "$S05"; then
-  echo "FAIL: step-05 leg lost its fail-loud secondary-not-Ready FATAL (#5359)" >&2
+# The FATAL's WORDING changed in 0.1.164 (the predicate moved from a stale
+# Ready=True to convergence, and the leg now exhausts a candidate URL chain
+# before giving up), so this asserts the two invariants rather than the old
+# sentence: the branch is reached and it is fatal. Case 76 pins the predicate.
+if ! grep -q 'refusing to succeed (#5359)' "$S05"; then
+  echo "FAIL: step-05 leg lost its fail-loud secondary-not-converged FATAL (#5359)" >&2
+  c71_fail=1
+fi
+if ! grep -q 'region-B is still serving its pre-cutover artifact' "$S05"; then
+  echo "FAIL: step-05's FATAL no longer names the consequence (region-B serving its pre-cutover artifact, reverting every pivoted HelmRepository) — the operator gets a verdict with no diagnosis (#5359)" >&2
   c71_fail=1
 fi
 if ! grep -q 'step.flux-gitrepository-patch.region.' "$S05"; then
@@ -3995,5 +4003,168 @@ if [ "${c75_lines}" -lt 200 ] || ! grep -qF 'kind: Deployment' "$DT_F"; then
 fi
 if [ "$c75_fail" -ne 0 ]; then exit 1; fi
 echo "  PASS (#5640: the Day-2 IMAGE leg mounts+sources the shared 03a resolver and its coverage-map env, enumerates declared workload templates as well as running Pods, proves presence with step-08's local-Harbor /v2 manifest probe, copies with step-03's exact skopeo invocation plus the #5095 and #5525 secondary-source fallbacks, keeps every upstream reach behind a mode=warm runtime branch, and refuses to report a zero-ref enumeration as an all-clear; render vacuity control: ${c75_lines}-line Deployment)"
+
+# ── Case 76 (#5359): the Flux source lint is PER-REGION and fail-closed, and
+#    step-05's secondary readiness asserts CONVERGENCE, not a stale Ready ──────
+#
+# hw292 (dep 1c56518035a83e03) set cutoverComplete=true, progressPercent=100,
+# failedStep empty, with region-b holding 64/64 HelmRepositories on ghcr.io and
+# 0 on the local Harbor. The #5379 per-secondary-region legs WERE in the
+# deployed chart (0.1.159) and reported region.me-east-215-b-1.result=success
+# for steps 05, 06 and 08. What actually happened:
+#
+#   step-05 patched region-b's GitRepository url -> the in-cluster Gitea Service
+#   name, which in a secondary region resolves to that region's OWN bp-gitea
+#   (empty, never mirrored) because both Services are headless and Cilium
+#   global-services cannot span a headless Service. Every fetch then failed
+#   ("pkt-line 3: EOF"), observedGeneration froze at 1 against generation 2, and
+#   source-controller kept serving the artifact it had cached from PUBLIC
+#   github.com minutes earlier. The readiness wait had already passed, because
+#   it accepted the Ready=True left over from that github.com fetch. region-b's
+#   kustomize-controller re-applied the pre-cutover content every 5m, reverting
+#   all 64 HelmRepositories step-06 had just pivoted and read-back-asserted.
+#
+# The behavioural proof of the two lints lives in tests/flux-source-host-lint.sh
+# (verdicts in both directions against stubbed inventories, plus mutation
+# coverage). THIS case pins the wiring those functions need in order to be
+# reached at all: the per-region driver, the fail-closed enumeration, and
+# step-05's convergence predicate.
+echo "[cutover-contract] Case 76: #5359 per-region Flux source lint (host + health, fail-closed) and step-05 convergence-based secondary readiness"
+c76_fail=0
+C76_08="$TMP/c76-08.yaml"
+C76_05="$TMP/c76-05.yaml"
+awk '/stepName: egress-block-test/,/^---/' "$TMP/render.yaml" >"$C76_08"
+awk '/stepName: flux-gitrepository-patch/,/^---/' "$TMP/render.yaml" >"$C76_05"
+
+# (a) VACUITY CONTROL FIRST. Every assertion below is a grep for a string; if
+#     either capture is empty the negative ones pass on nothing.
+c76_l08=$(wc -l < "$C76_08"); c76_l05=$(wc -l < "$C76_05")
+if [ "${c76_l08}" -lt 200 ] || [ "${c76_l05}" -lt 100 ]; then
+  echo "FAIL: vacuity control — captured step-08 is ${c76_l08} lines and step-05 is ${c76_l05}; Case 76 would be asserting over nothing (#5359)" >&2
+  c76_fail=1
+fi
+
+# (b) Both lint functions exist and take a region + kubeconfig.
+for c76_fn in 'run_flux_source_host_lint() {' 'run_flux_source_health_lint() {'; do
+  if ! grep -qF "$c76_fn" "$C76_08"; then
+    echo "FAIL: step-08 does not define ${c76_fn%% *} — the #5359 gate is absent" >&2
+    c76_fail=1
+  fi
+done
+if ! grep -qF '_FS_KUBECONFIG="${2:-}"' "$C76_08"; then
+  echo "FAIL: the source lints do not accept a kubeconfig argument, so they can only ever measure the primary region — the exact shape of #5359" >&2
+  c76_fail=1
+fi
+if ! grep -qF 'kubectl --kubeconfig="${_FS_KUBECONFIG}"' "$C76_08"; then
+  echo "FAIL: the lints never pass --kubeconfig to kubectl; a per-region verdict would be a second measurement of the primary (#5359)" >&2
+  c76_fail=1
+fi
+
+# (c) The driver fans out over EVERY region and ANDs the verdict. A short-circuit
+#     would stop at the first offender and hide the rest of the fleet.
+if ! grep -qF 'for _k in /secondary-kubeconfigs/*.yaml' "$C76_08"; then
+  echo "FAIL: the source-lint driver does not iterate the secondary kubeconfigs — the gate stays single-region (#5359)" >&2
+  c76_fail=1
+fi
+if ! grep -qF '_fs_verdict=1' "$C76_08"; then
+  echo "FAIL: the driver has no across-region verdict accumulator; one region's failure would not fail the step (#5359)" >&2
+  c76_fail=1
+fi
+# The exit must be INSIDE the verdict branch: a lint whose failure does not
+# stop the step leaves cutoverComplete free to be set anyway.
+if ! grep -A3 'if \[ "${_fs_verdict}" != "0" \]; then' "$C76_08" | grep -qF 'exit 1'; then
+  echo "FAIL: a failing per-region source lint does not exit non-zero — cutoverComplete could still be set over a tethered region (#5359)" >&2
+  c76_fail=1
+fi
+
+# (d) FAIL-CLOSED enumeration. The pre-#5359 code piped `kubectl … 2>/dev/null`
+#     into the reader, so an unreadable secondary produced zero rows, zero
+#     offenders and a PASS for a region that was never measured.
+# Anchored on a leading space, NOT a bare substring: `_fs_kubectl get …`
+# CONTAINS `kubectl get …`, so a plain -F match here reports the pre-#5359 form
+# for the fixed code and this assertion would fail forever on a correct chart.
+if grep -qE '(^|[[:space:]])kubectl get "\$\{_fk\}" -A' "$C76_08"; then
+  echo "FAIL: step-08 still enumerates sources without a kubeconfig shim (pre-#5359 single-cluster form)" >&2
+  c76_fail=1
+fi
+# ... and the shim must actually be the thing doing the enumerating.
+if ! grep -qF '_fs_kubectl get "${_fk}" -A' "$C76_08"; then
+  echo "FAIL: the host lint does not enumerate through the kubeconfig shim — it cannot reach a secondary region (#5359)" >&2
+  c76_fail=1
+fi
+if ! grep -qF 'Refusing to report PASS for a region that could not be measured' "$C76_08"; then
+  echo "FAIL: enumeration failure is not fail-closed — an unreadable secondary kubeconfig would read as a clean region (#5359)" >&2
+  c76_fail=1
+fi
+# ... but a kind that is merely NOT INSTALLED is zero rows, not a tether.
+if ! grep -qF "server doesn't have a resource type" "$C76_08"; then
+  echo "FAIL: no carve-out for an uninstalled source kind — a Sovereign without the OCIRepository CRD would be wedged (#5359)" >&2
+  c76_fail=1
+fi
+
+# (e) The HEALTH lint's scope was measured, not guessed: `type: oci`
+#     HelmRepositories carry no status at all (70/70 in hw292 region-a), so
+#     including them would fail every region of every Sovereign.
+if grep -qE 'for _hk in [a-z ]*helmrepositories' "$C76_08"; then
+  echo "FAIL: the health lint includes HelmRepositories, which carry no observedGeneration for type:oci — it would fail every region of every Sovereign (#5359, #5505 blast-radius shape)" >&2
+  c76_fail=1
+fi
+if ! grep -qF 'for _hk in gitrepositories ocirepositories; do' "$C76_08"; then
+  echo "FAIL: the health lint does not cover the reconciled source kinds (#5359)" >&2
+  c76_fail=1
+fi
+# The `|` separator is load-bearing: observedGeneration is ABSENT on an
+# unreconciled object and a space separator would collapse the field, shifting
+# every later value left so the reader compares the wrong two and passes.
+if ! grep -qF '{"|"}{.status.observedGeneration}{"|"}' "$C76_08"; then
+  echo "FAIL: the health lint's jsonpath is not pipe-separated — an absent observedGeneration would collapse the row and the comparison would silently read the wrong fields (#5359)" >&2
+  c76_fail=1
+fi
+
+# (f) Step-05's secondary readiness must assert CONVERGENCE. The old predicate
+#     was `Ready == True && spec.url == sec_url`: the url half is a tautology
+#     (the leg wrote that value one line earlier) and the Ready half still
+#     describes the PREVIOUS spec immediately after a patch.
+if ! grep -qF '[ "${sg_obs}" = "${sg_gen}" ]' "$C76_05"; then
+  echo "FAIL: step-05's secondary readiness does not require observedGeneration == generation — it would accept the stale Ready=True left over from the pre-pivot github.com fetch, which is precisely how hw292 recorded success at the same second the fetch started failing (#5359)" >&2
+  c76_fail=1
+fi
+if ! grep -qF 'sec_url_chain' "$C76_05"; then
+  echo "FAIL: step-05 has no secondary candidate-URL chain — a secondary that cannot reach the in-cluster Gitea name has no other path and the pivot is cosmetic (#5359)" >&2
+  c76_fail=1
+fi
+# Exhausting the chain must be FATAL, never a soft skip.
+if ! grep -qF 'did not CONVERGE (observedGeneration==generation with Ready=True) on any candidate URL' "$C76_05"; then
+  echo "FAIL: step-05 does not fail loudly when no candidate URL converges (#5359)" >&2
+  c76_fail=1
+fi
+if ! grep -A8 'if \[ -z "${sg_ready}" \]; then' "$C76_05" | grep -qF 'exit 1'; then
+  echo "FAIL: step-05's no-candidate-converged branch does not exit 1 (#5359)" >&2
+  c76_fail=1
+fi
+# The fallback candidate must be ON-Sovereign, or the "fix" would trade a dead
+# URL for a real tether.
+c76_fb=$(grep -A1 'name: SECONDARY_GITEA_FALLBACK_URL' "$C76_05" | grep 'value:' | head -1)
+case "${c76_fb}" in
+  *'gitea.'*) : ;;
+  *) echo "FAIL: SECONDARY_GITEA_FALLBACK_URL does not render the Sovereign's own gitea door (got: ${c76_fb}) (#5359)" >&2; c76_fail=1 ;;
+esac
+case "${c76_fb}" in
+  *github.com*|*ghcr.io*|*openova.io*)
+    echo "FAIL: SECONDARY_GITEA_FALLBACK_URL renders an OFF-Sovereign host (${c76_fb}) — that is a tether, not a fallback (#5359)" >&2; c76_fail=1 ;;
+esac
+
+# (g) The step-05 ceiling must exceed the worst-case candidate chain, or the Job
+#     is killed mid-chain and the failure reads as a deadline instead of as the
+#     unreachable-Gitea diagnosis.
+c76_dl=$(grep -m1 'activeDeadlineSeconds' "$C76_05" | tr -dc '0-9')
+c76_rdy=$(grep -A1 'name: SECONDARY_GITREPO_READY_SECONDS' "$C76_05" | grep 'value:' | tr -dc '0-9')
+if [ -n "${c76_dl}" ] && [ -n "${c76_rdy}" ] && [ "${c76_dl}" -le $((c76_rdy * 2)) ]; then
+  echo "FAIL: step-05 activeDeadlineSeconds (${c76_dl}) does not exceed two candidate windows (2 x ${c76_rdy}); the chain would be truncated by the deadline (#5359)" >&2
+  c76_fail=1
+fi
+
+if [ "$c76_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#5359: both source lints take a region+kubeconfig and dial it, the driver fans out across every secondary and ANDs the verdict with an unreadable region counted as FAIL, the health lint is scoped to reconciled kinds only and reads pipe-separated fields, and step-05's secondary leg walks a candidate URL chain whose success predicate is observedGeneration==generation on a Ready source, fatal when exhausted; vacuity control: step-08 ${c76_l08} lines / step-05 ${c76_l05} lines)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/tests/flux-source-host-lint.sh
+++ b/platform/self-sovereign-cutover/chart/tests/flux-source-host-lint.sh
@@ -35,19 +35,55 @@ helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.
 
 awk '/^ *run_flux_source_host_lint\(\) \{/,/^ *\}$/' "${TMP}/render.yaml" \
   | sed 's/^ *//' >"${TMP}/fn.sh"
+# #5359 — the SOURCE-HEALTH lint is a second function in the same Job and is
+# extracted the same way, from the render, for the same #5646 reason.
+awk '/^ *run_flux_source_health_lint\(\) \{/,/^ *\}$/' "${TMP}/render.yaml" \
+  | sed 's/^ *//' >"${TMP}/fn-health.sh"
 
 if ! grep -q 'run_flux_source_host_lint()' "${TMP}/fn.sh"; then
   echo "FAIL — could not extract run_flux_source_host_lint from the rendered Job."
   echo "       The lint is missing from the chart, or the function name changed."
   exit 1
 fi
+if ! grep -q 'run_flux_source_health_lint()' "${TMP}/fn-health.sh"; then
+  echo "FAIL — could not extract run_flux_source_health_lint from the rendered Job (#5359)."
+  exit 1
+fi
+# Both extractions terminate on the first bare `}` line. If a nested multi-line
+# function definition is ever added inside either lint, the awk range truncates
+# and every case below would then be driving a FRAGMENT — which would still
+# `.`-source cleanly and could still return 0. Pin the tail explicitly so that
+# truncation is a test failure rather than a silent change of subject.
+for _f in "${TMP}/fn.sh" "${TMP}/fn-health.sh"; do
+  if ! grep -q '^return 0$' "${_f}"; then
+    echo "FAIL — ${_f##*/} was truncated during extraction (no trailing 'return 0')."
+    echo "       A nested function or a bare '}' line inside the lint breaks the awk range."
+    exit 1
+  fi
+done
 
 # ── Harness: stub kubectl feeds the source inventory under test ─────────────
+# #5359 — the stub now scans for the `get` verb rather than assuming argv[2],
+# because the lint may prepend `--kubeconfig=<path>` when it measures a
+# SECONDARY region. STUB_FAIL_KIND makes a named kind's enumeration fail, which
+# is how the fail-closed cases below are driven.
 mkdir -p "${TMP}/bin"
 cat >"${TMP}/bin/kubectl" <<'STUB'
 #!/usr/bin/env bash
-# args: get <kind> -A -o jsonpath=...
-kind="$2"
+# args: [--kubeconfig=<p>] get <kind> -A -o jsonpath=...
+kind=""
+want=0
+for a in "$@"; do
+  if [ "$want" = "1" ]; then kind="$a"; break; fi
+  [ "$a" = "get" ] && want=1
+done
+# Record argv so a case can assert the lint actually TARGETED the region it was
+# asked to measure, rather than silently reading the local cluster.
+[ -n "${STUB_ARGV_LOG:-}" ] && printf '%s\n' "$*" >>"${STUB_ARGV_LOG}"
+if [ -n "${STUB_FAIL_KIND:-}" ] && [ "${kind}" = "${STUB_FAIL_KIND}" ]; then
+  echo "${STUB_FAIL_MSG:-error: You must be logged in to the server (Unauthorized)}" >&2
+  exit 1
+fi
 f="${STUB_DIR}/${kind}.txt"
 [ -f "$f" ] && cat "$f"
 exit 0
@@ -77,6 +113,31 @@ run_case() {
     # shellcheck disable=SC1090
     . "${TMP}/fn.sh"
     if run_flux_source_host_lint >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+  )
+}
+
+# #5359 — same harness, driving the SOURCE-HEALTH lint. Rows are `|`-separated
+# (ns|name|suspend|generation|observedGeneration|readyStatus|readyMessage)
+# because the empty-middle-field collapse is exactly what the separator choice
+# in the lint exists to prevent, and the test must feed the real shape.
+run_health_case() {
+  local desc="$1"; shift
+  local case_dir="${TMP}/hcase"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/gitrepositories.txt"
+  : >"${case_dir}/ocirepositories.txt"
+  for spec in "$@"; do
+    local kind="${spec%%@*}" row="${spec#*@}"
+    printf '%s\n' "${row}" >>"${case_dir}/${kind}.txt"
+  done
+  mkdir -p "${TMP}/work"
+  (
+    export PATH="${TMP}/bin:${PATH}"
+    export STUB_DIR="${case_dir}"
+    export WORK_DIR="${TMP}/work"
+    cd "${TMP}"
+    # shellcheck disable=SC1090
+    . "${TMP}/fn-health.sh"
+    if run_flux_source_health_lint "${REGION_LABEL:-primary}" "" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
   )
 }
 
@@ -156,9 +217,161 @@ got=$(
 )
 expect "unwritable scratch dir" FAIL "${got}"
 
+# ── #5359 — the lint must be PER-REGION and fail closed on an unmeasurable one ──
+echo
+echo "[flux-source-host-lint] #5359 — per-region targeting + fail-closed enumeration"
+
+# 9. The lint must DIAL the region it was handed. Before #5359 the function
+#    always read the local cluster, so a "region-b" verdict was really a
+#    second measurement of region-a — a per-region report that is not
+#    per-region is worse than no report, because it reads as coverage.
+argv_log="${TMP}/argv.log"; : >"${argv_log}"
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  printf 'flux-system bp-cilium oci://registry.%s/openova-io \n' "${FQDN}" >"${case_dir}/helmrepositories.txt"
+  : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}" STUB_ARGV_LOG="${argv_log}"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export FLUX_SOURCE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_flux_source_host_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "secondary region with all-local sources" PASS "${got}"
+if grep -q -- '--kubeconfig=/secondary-kubeconfigs/me-east-215-b-1.yaml' "${argv_log}"; then
+  pass "lint dialled the SECONDARY kubeconfig (not the local cluster)"
+else
+  fail "lint did not pass --kubeconfig to kubectl; it measured the local cluster and labelled the verdict 'me-east-215-b-1'"
+  sed 's/^/        /' "${argv_log}"
+fi
+
+# 10. THE LIVE hw292 SHAPE — region-b holds 64 HelmRepositories on ghcr.io
+#     while region-a holds 0. The same function, handed region-b's inventory,
+#     must go RED. This is the assertion whose absence let cutoverComplete=true
+#     be set from a region-a-only measurement.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  { printf 'flux-system bp-cilium oci://ghcr.io/openova-io \n'
+    printf 'flux-system bp-keycloak oci://ghcr.io/openova-io \n'; } >"${case_dir}/helmrepositories.txt"
+  : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export FLUX_SOURCE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_flux_source_host_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "secondary region still on ghcr.io (the live hw292 finding)" FAIL "${got}"
+if grep -q 'EXTERNAL-SOURCE \[me-east-215-b-1\]' "${TMP}/out.txt"; then
+  pass "offender lines name the REGION, so an operator can tell which cluster is tethered"
+else
+  fail "offender lines do not carry the region label"; sed 's/^/        /' "${TMP}/out.txt"
+fi
+
+# 11. FAIL-CLOSED. An unreadable secondary kubeconfig used to yield zero rows
+#     through `2>/dev/null`, zero offenders, and a PASS — a verdict rendered
+#     over a region that was never measured. Against a secondary cluster that
+#     is the single most likely failure mode.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/helmrepositories.txt"; : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export STUB_FAIL_KIND="helmrepositories"
+  export STUB_FAIL_MSG="error: unable to load kubeconfig: no such file or directory"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export FLUX_SOURCE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_flux_source_host_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "unreadable secondary (enumeration error)" FAIL "${got}"
+
+# 12. VACUITY THE OTHER WAY for case 11 — a kind that is merely NOT INSTALLED
+#     is zero rows, not a tether, and must NOT fail. Without this, case 11
+#     would also pass for a lint that failed on every kubectl non-zero exit,
+#     which would wedge any Sovereign lacking the OCIRepository CRD.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  printf 'flux-system bp-cilium oci://registry.%s/openova-io \n' "${FQDN}" >"${case_dir}/helmrepositories.txt"
+  : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export STUB_FAIL_KIND="ocirepositories"
+  export STUB_FAIL_MSG="error: the server doesn't have a resource type \"ocirepositories\""
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export FLUX_SOURCE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_flux_source_host_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "uninstalled source kind (not a tether)" PASS "${got}"
+
+# ── #5359 — the SOURCE-HEALTH lint ──────────────────────────────────────────
+# The host lint reads a DECLARATION. hw292 proved a declaration can be
+# cosmetic: region-b's GitRepository url said local Gitea while
+# source-controller had never fetched from it (generation=2,
+# observedGeneration=1, Ready=False) and kept serving the github.com artifact
+# it had cached before the pivot. These cases pin the discriminator.
+echo
+echo "[flux-source-host-lint] #5359 — source-HEALTH lint (converged vs cosmetically-pivoted)"
+
+# 13. POSITIVE CONTROL — a converged source. Must PASS, or case 14 proves
+#     nothing (a lint that always failed would look correct there).
+got=$(run_health_case "converged" \
+  "gitrepositories@flux-system|openova|false|2|2|True|stored artifact for revision main@sha1:7bcd1d59")
+expect "converged GitRepository (observedGeneration==generation, Ready=True)" PASS "${got}"
+
+# 14. THE LIVE hw292 OBJECT, field for field. Must FAIL.
+got=$(run_health_case "hw292-region-b" \
+  "gitrepositories@flux-system|openova|false|2|1|False|failed to checkout and determine revision: unable to list remote for 'http://gitea-http.gitea.svc.cluster.local:3000/openova/openova': pkt-line 3: EOF")
+expect "hw292 region-b GitRepository (gen=2 obs=1 Ready=False)" FAIL "${got}"
+if grep -q 'STALE-SOURCE' "${TMP}/out.txt"; then
+  pass "verdict names the object as a STALE-SOURCE"
+else
+  fail "verdict did not name the stale source"; sed 's/^/        /' "${TMP}/out.txt"
+fi
+
+# 15. DISCRIMINATION — the generation lag ALONE must fail, even with Ready=True.
+#     This is the exact state the old step-05 wait accepted: the Ready condition
+#     still described the PREVIOUS spec. Without this case, cases 13/14 would
+#     both be explained by the Ready field alone and the observedGeneration
+#     half of the predicate would be untested.
+got=$(run_health_case "stale-ready-true" \
+  "gitrepositories@flux-system|openova|false|2|1|True|stored artifact for revision main@sha1:4cc85ad9")
+expect "Ready=True but observedGeneration behind generation" FAIL "${got}"
+
+# 16. And the Ready half alone must fail too, with generations in step.
+got=$(run_health_case "ready-false-in-step" \
+  "gitrepositories@flux-system|openova|false|3|3|False|auth required")
+expect "converged generations but Ready=False" FAIL "${got}"
+
+# 17. A SUSPENDED source cannot reconcile — reported by the host lint, not
+#     failed by the health lint (same treatment, so the two lints agree).
+got=$(run_health_case "suspended" \
+  "gitrepositories@flux-system|openova|true|2|1|False|suspended")
+expect "suspended source" PASS "${got}"
+
+# 18. VACUITY — an empty inventory must not be read as health. A lint that
+#     examined nothing and returned 0 is the fail-open shape (#5633).
+got=$(
+  case_dir="${TMP}/hcase"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export STUB_FAIL_KIND="gitrepositories"
+  export STUB_FAIL_MSG="error: Unauthorized"
+  export WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn-health.sh"
+  if run_flux_source_health_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "health lint on an unmeasurable region" FAIL "${got}"
+
+# 19. The `|` separator is load-bearing: with a space separator an ABSENT
+#     observedGeneration collapses the field and every later value shifts left,
+#     so the reader compares the wrong two things and passes. Feed the shape a
+#     never-reconciled object actually has — generation set, observedGeneration
+#     and Ready both empty — and require FAIL.
+got=$(run_health_case "never-reconciled" \
+  "gitrepositories@flux-system|openova|false|1|||")
+expect "never-reconciled source (empty observedGeneration and Ready)" FAIL "${got}"
+
 echo
 if [ "${FAILURES}" -ne 0 ]; then
   echo "[flux-source-host-lint] ${FAILURES} assertion(s) FAILED"
   exit 1
 fi
-echo "[flux-source-host-lint] all assertions passed — lint proven to fail on a tether AND pass on a local source"
+echo "[flux-source-host-lint] all assertions passed — host lint proven to fail on a tether AND pass on a local source, per-region and fail-closed; health lint proven to fail on the live hw292 cosmetic pivot AND pass on a converged source"

--- a/platform/self-sovereign-cutover/chart/tests/step05-secondary-chain.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step05-secondary-chain.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# #5359 — behavioural test for step-05's SECONDARY-REGION candidate URL chain.
+#
+# WHY this exists, and why a render grep would not have been enough.
+#
+# While building the #5359 fix, a `helm template` render that was structurally
+# perfect — every assertion in cutover-contract.sh Case 76 green, every step
+# script clean under `sh -n`/`bash -n`/`dash -n` — still contained a log line
+# referencing ${sec_url} from BEFORE the candidate loop that defines it. The
+# Job runs under `set -eu`, so that unset reference did not print a wrong URL:
+# it ABORTED the secondary leg on the first region, before any pivot, on every
+# 2-region Sovereign. Syntax checks cannot see it (the syntax is valid) and
+# render greps cannot see it (the string is present, just in the wrong scope).
+# Only EXECUTING the extracted script under the same shell options exposes it.
+#
+# So this suite drives the real chain, extracted from the render, against a
+# stub kubectl, under `set -eu` — and asserts the three outcomes that matter:
+# converge on the first candidate, fall through to the second, and fail loud
+# when the chain is exhausted.
+#
+# The scenario is the live hw292 one (dep 1c56518035a83e03): the in-cluster
+# Gitea URL never converges from region-b (generation=2, observedGeneration=1,
+# "pkt-line 3: EOF" — its own empty Gitea answers that name), so the leg must
+# fall through to the Sovereign's own external Gitea door.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw292.omani.works"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+fail() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok   — $*"; }
+
+MESH_URL="http://gitea-http.gitea.svc.cluster.local:3000/openova/openova"
+DOOR_URL="https://gitea.${FQDN}/openova/openova"
+
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+# Extract the secondary leg from the RENDER (never a copy pasted here — #5646
+# showed a suite validating a hand-kept copy that had drifted from the source).
+awk '/#5359 CANDIDATE URL CHAIN/,/echo "\[flux-gitrepository-patch\] done"/' "${TMP}/render.yaml" \
+  | sed 's/^            //' >"${TMP}/chain.sh"
+
+if ! grep -q 'for skc in /secondary-kubeconfigs/\*.yaml; do' "${TMP}/chain.sh"; then
+  echo "FAIL — could not extract the step-05 secondary leg from the render."
+  echo "       The leg is missing, or the candidate-chain marker comment changed."
+  exit 1
+fi
+if ! grep -q 'flux-gitrepository-patch] done' "${TMP}/chain.sh"; then
+  echo "FAIL — the extracted leg is truncated (no trailing done marker); every"
+  echo "       case below would be driving a fragment."
+  exit 1
+fi
+
+mkdir -p "${TMP}/skc"
+: >"${TMP}/skc/me-east-215-b-1.yaml"
+sed -i "s#/secondary-kubeconfigs#${TMP}/skc#g" "${TMP}/chain.sh"
+
+# The fallback URL is read OUT OF THE RENDER, not hardcoded here. A suite that
+# supplied its own SECONDARY_GITEA_FALLBACK_URL would keep passing after the
+# chart stopped rendering one — it would be proving that a two-element chain
+# behaves correctly while shipping a one-element chain. Mutation-checked:
+# setting secondaryRegions.giteaFallbackToPublicDoor=false must turn this red.
+RENDERED_FALLBACK=$(grep -A1 'name: SECONDARY_GITEA_FALLBACK_URL' "${TMP}/render.yaml" \
+  | grep 'value:' | head -1 | sed 's/.*value: *//' | tr -d '"')
+if [ -z "${RENDERED_FALLBACK}" ]; then
+  echo "FAIL — the chart renders no SECONDARY_GITEA_FALLBACK_URL, so a secondary"
+  echo "       that cannot reach the in-cluster Gitea name has no second candidate"
+  echo "       and the #5359 pivot stays cosmetic (secondaryRegions."
+  echo "       giteaFallbackToPublicDoor / giteaFallbackURL)."
+  exit 1
+fi
+if [ "${RENDERED_FALLBACK}" != "${DOOR_URL}" ]; then
+  echo "FAIL — SECONDARY_GITEA_FALLBACK_URL renders '${RENDERED_FALLBACK}',"
+  echo "       expected the Sovereign's own door '${DOOR_URL}'."
+  exit 1
+fi
+echo "[step05-secondary-chain] fallback candidate from the render: ${RENDERED_FALLBACK}"
+
+# ── Harness ─────────────────────────────────────────────────────────────────
+# The stub kubectl answers the two reads the leg makes. CONVERGE_ON names the
+# URL whose fetch "succeeds": for that one it reports generation ==
+# observedGeneration; for every other candidate it reports the hw292 shape
+# (generation=2, observedGeneration=1) with Ready=True — deliberately Ready,
+# because a stale Ready=True is exactly what the old predicate accepted and
+# this suite must prove the new one is not fooled by it.
+make_harness() {
+  cat >"${TMP}/hdr.sh" <<HDR
+set -eu
+LOCAL_GITEA_URL="${MESH_URL}"
+SECONDARY_GITEA_URL=""
+SECONDARY_GITEA_FALLBACK_URL="${RENDERED_FALLBACK}"
+SECONDARY_GITREPO_READY_SECONDS=1
+GITREPO_NAME=openova
+GITREPO_NAMESPACE=flux-system
+BRANCH=main
+SOVEREIGN_FQDN=${FQDN}
+GIT_AUTH_SECRET_NAME=cutover-gitea-git-auth
+CUTOVER_NAMESPACE=catalyst
+STATUS_CONFIGMAP=self-sovereign-cutover-status
+CONVERGE_ON="\$1"
+CUR=""
+STATUS_LOG="${TMP}/status.log"
+: > "\${STATUS_LOG}"
+# The leg re-checks every 10s inside each candidate window. This suite is
+# testing the DECISION, not the timing, so sleep is a no-op — otherwise the
+# non-converging cases would take minutes of real wall-clock and the suite
+# would be too slow to keep in the per-PR gate. The bounded window itself is
+# still honoured: SECONDARY_GITREPO_READY_SECONDS above closes it.
+sleep() { return 0; }
+kubectl() {
+  case "\$*" in
+    *"patch gitrepository"*)
+      CUR=\$(grep -m1 '^  url:' /tmp/patch-secondary.yaml | sed 's/^  url: //')
+      return 0 ;;
+    *"patch configmap"*)
+      printf '%s\n' "\$*" >> "\${STATUS_LOG}"; return 0 ;;
+    *observedGeneration*)
+      if [ "\${CUR}" = "\${CONVERGE_ON}" ]; then printf 'True|2|2|%s' "\${CUR}"
+      else printf 'True|2|1|%s' "\${CUR}"; fi
+      return 0 ;;
+    *'.message}'*)
+      echo "unable to list remote for '\${CUR}': pkt-line 3: EOF"; return 0 ;;
+  esac
+  return 0
+}
+HDR
+  cat "${TMP}/hdr.sh" "${TMP}/chain.sh" >"${TMP}/run.sh"
+}
+
+# Runs the leg under a given shell; echoes "<exit> <chosen-url-or-none>".
+run_chain() {
+  local shell="$1" converge_on="$2"
+  make_harness
+  local out rc
+  out=$("${shell}" "${TMP}/run.sh" "${converge_on}" 2>&1); rc=$?
+  printf '%s\n' "${out}" >"${TMP}/out.txt"
+  local chosen="none"
+  case "${out}" in
+    *"CONVERGED on ${DOOR_URL} "*) chosen="${DOOR_URL}" ;;
+    *"CONVERGED on ${MESH_URL} "*) chosen="${MESH_URL}" ;;
+  esac
+  echo "${rc} ${chosen}"
+}
+
+echo "[step05-secondary-chain] #5359 — the secondary leg must execute under set -eu and walk its candidate chain"
+
+# Every case runs under all three shells the Job image might provide. The
+# regression this suite was written for was shell-option-dependent, not
+# syntax-dependent, so a single-shell run would not have caught it.
+for SH in sh dash bash; do
+  command -v "${SH}" >/dev/null 2>&1 || { echo "  (skip ${SH}: not installed)"; continue; }
+
+  # 1. THE REGRESSION. Before the fix this aborted with "sec_url: parameter not
+  #    set" the moment the leg entered its per-region loop — no pivot attempted,
+  #    on every 2-region Sovereign. Any outcome other than a clean walk of the
+  #    chain means an unset variable or an early -e exit crept back in.
+  got=$(run_chain "${SH}" "${MESH_URL}")
+  if [ "${got}" = "0 ${MESH_URL}" ]; then
+    pass "${SH}: first candidate converges -> exit 0 on the mesh URL"
+  else
+    fail "${SH}: first-candidate case returned '${got}', expected '0 ${MESH_URL}'"
+    sed 's/^/        /' "${TMP}/out.txt"
+  fi
+
+  # 2. THE LIVE hw292 PATH. The mesh URL reports a STALE Ready=True (gen 2 /
+  #    obs 1) — the exact state the old predicate accepted — so the leg must
+  #    reject it and fall through to the Sovereign's own door.
+  got=$(run_chain "${SH}" "${DOOR_URL}")
+  if [ "${got}" = "0 ${DOOR_URL}" ]; then
+    pass "${SH}: stale Ready=True on candidate 1 is rejected, chain falls through to the Sovereign door"
+  else
+    fail "${SH}: fallthrough case returned '${got}', expected '0 ${DOOR_URL}'"
+    sed 's/^/        /' "${TMP}/out.txt"
+  fi
+
+  # 3. FAIL-LOUD. No candidate converges -> non-zero, so the step fails and
+  #    cutoverComplete stays false. A soft skip here IS the #5359 defect.
+  got=$(run_chain "${SH}" "no-candidate-matches-this")
+  case "${got}" in
+    "1 none") pass "${SH}: exhausted chain exits 1 (cutoverComplete stays false)" ;;
+    *) fail "${SH}: exhausted-chain case returned '${got}', expected '1 none'"
+       sed 's/^/        /' "${TMP}/out.txt" ;;
+  esac
+done
+
+# 4. The FATAL must name the diagnosis, not just the verdict — an operator
+#    reading the Job log has to know region-b is serving pre-cutover content.
+run_chain sh "no-candidate-matches-this" >/dev/null
+if grep -q 'still serving its pre-cutover artifact' "${TMP}/out.txt"; then
+  pass "the exhausted-chain FATAL explains the consequence, not just the failure"
+else
+  fail "the exhausted-chain FATAL does not explain what being unconverged means"
+fi
+
+# 5. The per-region status keys must record the FAILURE, not silently vanish.
+if grep -q 'step.flux-gitrepository-patch.region.me-east-215-b-1.result.*failed' "${TMP}/status.log"; then
+  pass "a failed region stamps result=failed on the status ConfigMap"
+else
+  fail "no result=failed status key was written for the failed region"
+  sed 's/^/        /' "${TMP}/status.log"
+fi
+
+# 6. VACUITY CONTROL for case 5 — a SUCCEEDING run must stamp success plus the
+#    URL that won, or case 5 would also pass for a leg that always writes
+#    'failed'.
+run_chain sh "${DOOR_URL}" >/dev/null
+if grep -q 'result.*success' "${TMP}/status.log" && grep -qF "giteaURL" "${TMP}/status.log"; then
+  pass "a converged region stamps result=success and records which candidate won"
+else
+  fail "a converged region did not stamp success + giteaURL"
+  sed 's/^/        /' "${TMP}/status.log"
+fi
+
+echo
+if [ "${FAILURES}" -ne 0 ]; then
+  echo "[step05-secondary-chain] ${FAILURES} assertion(s) FAILED"
+  exit 1
+fi
+echo "[step05-secondary-chain] all assertions passed — the secondary leg executes cleanly under set -eu, rejects a stale Ready=True, falls through to the Sovereign's own Gitea door, and fails loud when no candidate converges"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1791,6 +1791,32 @@ egressTest:
     # that lands, delete the entry and the lint proves the tether is gone.
     allowHosts:
       - charts.loft.sh
+  # #5359 — the SOURCE-HEALTH half of the same gate. fluxSourceHostLint above
+  # asserts what every Flux source DECLARES (spec.url); this asserts whether the
+  # controller ever CONVERGED on that declaration (observedGeneration ==
+  # generation on a Ready source).
+  #
+  # Why both are needed, from the live hw292 failure. Step-05's secondary leg
+  # patched region-b's GitRepository url to the local Gitea and recorded
+  # result=success. source-controller then failed every fetch from that URL
+  # ("pkt-line 3: EOF") and never advanced observedGeneration past 1, so it kept
+  # serving main@sha1:4cc85ad9... — the artifact it had fetched from PUBLIC
+  # github.com minutes earlier. region-b's kustomize-controller re-applied that
+  # pre-cutover content every 5m and reverted all 64 HelmRepositories the
+  # step-06 leg had pivoted. A host lint reading spec.url sees a clean local URL
+  # and passes; only the convergence check separates a real pivot from a
+  # cosmetic one.
+  #
+  # SCOPE is deliberately narrow and was MEASURED, not assumed: only kinds a
+  # controller actually reconciles (GitRepository, OCIRepository). `type: oci`
+  # HelmRepositories are static config for helm-controller and carry `status: {}`
+  # with no observedGeneration at all — 70/70 in hw292 region-a and 65/65 in
+  # region-b — so including them would fail every region of every Sovereign and
+  # wedge the flow this guard protects (the #5505 blast-radius shape). With that
+  # scope the live blast radius on hw292 is exactly one object: region-b's
+  # flux-system/openova GitRepository, i.e. the defect itself.
+  fluxSourceHealthLint:
+    enabled: true
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated
@@ -2255,7 +2281,17 @@ stepTimeouts:
   # census itself is still the ~105-min slow path this ceiling was sized for, and
   # a slow-but-reachable-egress run needs the same headroom regardless.
   harborPrewarmSeconds: 9600
-  fluxGitRepositoryPatchSeconds: 600
+  # #5359 — raised 600 -> 1800. The step-05 secondary leg now walks a CANDIDATE
+  # URL CHAIN, giving each candidate its own secondaryRegions.
+  # gitRepositoryReadySeconds (300s) window to converge. Worst case is
+  # regions x candidates x 300s (a 2-region Sovereign: 1 x 2 x 300 = 600s) on
+  # top of the region-A patch, and the ceiling must exceed the sum or the Job is
+  # killed mid-chain and the failure reads as a deadline rather than as the
+  # unreachable-Gitea diagnosis the leg was about to print. 1800 leaves headroom
+  # for a 3-region topology. The step stays event-driven (catalyst-api watches
+  # to completion), so a converging run still returns in seconds and never waits
+  # out the ceiling.
+  fluxGitRepositoryPatchSeconds: 1800
   # Step 06 (helmrepository-patches) activeDeadlineSeconds. This step now
   # has FOUR potentially-slow waits inside one Job and the deadline must
   # cover their SUM in the worst case:
@@ -2655,21 +2691,53 @@ secondaryRegions:
   # region) renders the legs inert. Must match catalyst-api's
   # CATALYST_CUTOVER_SECONDARY_KUBECONFIGS_SECRET (default identical).
   kubeconfigSecretName: "cutover-secondary-kubeconfigs"
-  # Step 05 region-B leg: bounded wait for the secondary GitRepository
-  # to reach Ready=True on the pivoted local-Gitea URL. FAIL-LOUD: a
-  # secondary that cannot reconcile the local Gitea fails the step —
-  # succeeding anyway would re-mint the #5359 false positive.
+  # Step 05 region-B leg: bounded wait, PER CANDIDATE URL, for the
+  # secondary GitRepository to CONVERGE — observedGeneration ==
+  # generation with Ready=True, not merely Ready=True. FAIL-LOUD: a
+  # secondary that cannot converge on any candidate fails the step.
+  #
+  # #5359 (hw292): the old predicate accepted a stale Ready=True left
+  # over from the object's last successful clone of PUBLIC github.com,
+  # so the leg recorded success at 07:39:48Z — the same second Ready
+  # actually flipped to False — and the region stayed on its pre-pivot
+  # artifact for 22h. Ready is a status field; immediately after a patch
+  # it still describes the previous spec.
   gitRepositoryReadySeconds: 300
   # Git URL the SECONDARY regions' GitRepository is pivoted to. Empty
-  # (default) = the same in-cluster URL region-A uses
-  # (sovereign.giteaInternalURL + gitea.org/gitea.repo), reachable from
-  # the secondary via the ClusterMesh global-Service alias the step-05
-  # leg establishes (gitea-http.gitea.svc, the bp-cnpg-pair idiom the
-  # #5359 design note names). Override per-Sovereign if a topology
-  # needs the public https://gitea.<fqdn> door instead (note: LE-staging
-  # certs on fresh provs make the public door x509-hostile; the mesh
-  # alias is the canonical path).
+  # (default) = try the same in-cluster URL region-A uses
+  # (sovereign.giteaInternalURL + gitea.org/gitea.repo) FIRST, then fall
+  # back to giteaFallbackURL / the public door below. Setting this
+  # pins the chain to exactly one URL (explicit operator intent).
+  #
+  # #5359 — why the in-cluster URL is a candidate and not a certainty.
+  # `gitea-http.gitea.svc.cluster.local` resolves LOCALLY in the
+  # secondary: a 2-region Sovereign installs bp-gitea in both regions, so
+  # the secondary has its own same-named Service selecting its own
+  # (empty, never mirrored) Gitea. The step-05 mesh alias cannot override
+  # that, because BOTH Services are HEADLESS (clusterIP: None) and Cilium
+  # ClusterMesh global-services do not span headless Services at all —
+  # CoreDNS answers straight from the local EndpointSlice, making
+  # `service.cilium.io/global` inert. Live on hw292 region-b that name
+  # resolved to 10.43.3.228 (its own gitea pod), whose openova/openova
+  # advertises zero refs → "pkt-line 3: EOF" on every fetch.
   giteaURL: ""
+  # #5359 — fallback candidate tried when the in-cluster URL does not
+  # converge. Empty + giteaFallbackToPublicDoor=true (the default) means
+  # `https://gitea.<sovereign.fqdn>/<org>/<repo>`: the Sovereign's OWN
+  # external Gitea door. That is ON-Sovereign, not a tether — it is the
+  # Sovereign's own gateway VIP, it satisfies the step-08 source-host
+  # lint's *.<fqdn> exemption, and the step-08 secondary deny-egress leg
+  # already carves out that gateway's public IPs so the hold does not cut
+  # it. Live-verified on hw292: from region-b this door served HEAD
+  # 7bcd1d59… — byte-identical to region-A's in-cluster Gitea, i.e. the
+  # PIVOTED content — while the in-cluster name served zero refs.
+  #
+  # The old caveat about LE-STAGING certs making the public door
+  # x509-hostile still holds for qaTestEnabled provs; those set
+  # giteaFallbackToPublicDoor=false and must supply a mesh path that
+  # actually works, rather than silently pivoting to an unreachable URL.
+  giteaFallbackURL: ""
+  giteaFallbackToPublicDoor: true
   # Extra CIDRs allowed by the SECONDARY regions' deny-egress hold, ON
   # TOP of egressTest.allowIntraClusterCIDRs + allowProviderCIDRs (both
   # inherited verbatim) + the auto-resolved public IPs of the

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.163",
+      "version": "0.1.164",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.163",
+    "version": "0.1.164",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.163"
+  version: "0.1.164"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.163"
+    version: "0.1.164"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Root cause — the #5379 legs ran, reported success, and did not work

The reopen comment guessed the per-region status keys were absent. They are **present**, and they say `success`:

```
step.flux-gitrepository-patch.region.me-east-215-b-1.result=success   (finishedAt 2026-08-03T07:39:48Z)
step.helmrepository-patches.region.me-east-215-b-1.result=success     (finishedAt 2026-08-03T07:41:13Z)
step.egress-block-test.region.me-east-215-b-1.result=success
```

So the question is not "did the leg run". It ran, patched, read-back-asserted, and passed. Here is what actually happened, in two parts.

### Part 1 — the URL region-b was pivoted TO cannot serve region-b

Region-b's GitRepository, live today:

```
spec.url                    http://gitea-http.gitea.svc.cluster.local:3000/openova/openova   (pivoted, "clean")
metadata.generation         2
status.observedGeneration   1
Ready                       False / GitOperationFailed, since 2026-08-03T07:39:48Z
  "failed to checkout and determine revision: unable to list remote for
   'http://gitea-http.gitea.svc.cluster.local:3000/openova/openova': pkt-line 3: EOF"
status.artifact.revision    main@sha1:4cc85ad9933c930e7a99a41c1dd117c1ea403775  (stored 07:31:11Z)
```

That artifact SHA is a real commit in the **public GitHub repo** (`docs(tracker): auto-refresh 2026-08-03T07:30:02Z`). Region-a's artifact SHA, `7bcd1d59...`, does **not** exist in GitHub — it is locally authored, i.e. the pivoted content. So the two regions are applying content from two different worlds.

Why the clone fails, discriminated rather than reasoned:

```
# region-b, from source-controller's own netns
getent hosts gitea-http.gitea.svc.cluster.local  ->  10.43.3.228     # region-b pod CIDR = its OWN gitea
# region-a's gitea pod is 10.42.1.191, never reached
kubectl -n gitea exec <region-b gitea> -- ls -la /data/git
  drwxrwsr-x  .ssh          # /data/git/repositories does not exist. Zero repos.
```

A 2-region Sovereign installs **bp-gitea in both regions** from the bootstrap-kit, so region-b already had a `gitea/gitea-http` Service selecting its own, never-mirrored Gitea. The step-05 leg's ClusterMesh alias cannot override that, and could not have worked even against zero local backends: **both Services are headless (`clusterIP: None`)**, and Cilium global-services do not span a headless Service — CoreDNS answers straight from the local EndpointSlice, so `service.cilium.io/global` is inert on it. The leg's own log line anticipated a backend problem and then didn't check for one.

Region-b's `bootstrap-kit` Kustomization (interval 5m) is meanwhile `Ready=True`, cheerfully re-applying `main@sha1:4cc85ad9…` — the pre-cutover GitHub content, which declares `oci://ghcr.io/openova-io`. That is what reverts all 64 HelmRepositories the step-06 leg patched at 07:41:13Z. Step-08 started at 07:44:42Z, ~3 minutes later.

### Part 2 — why it reported success: an assertion on a status field, taken immediately after mutating the spec

`platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml`, the leg's step 4:

```sh
sg_status=$(kubectl … -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
sg_url=$(kubectl … -o jsonpath='{.spec.url}')
if [ "${sg_status}" = "True" ] && [ "${sg_url}" = "${sec_url}" ]; then
```

Both halves are unsound. `sg_url` reads back the value the leg **itself wrote one line earlier** — a tautology that can never be false. And `Ready` is a *status* field: immediately after a patch it still describes the *previous* spec. Region-b entered that loop carrying `Ready=True` from its last successful clone of public github.com, so the **first pass of the loop matched**. The leg recorded `result=success` at `07:39:48Z` — the same second the Ready condition flipped to `False`.

`generation=2 / observedGeneration=1` is the discriminator, and it is the reason I can rule out the alternatives: this is not a soft skip (the leg ran and stamped keys), not a missing kubeconfig (`cutover-secondary-kubeconfigs` exists with `me-east-215-b-1.yaml`, materialized 07:44:24Z), and not "Flux reverted a correct patch from a correct source" — the source itself never once fetched from the URL it advertises.

## Fix

**Step-05 — assert convergence, and stop assuming one URL.** The success predicate is now `observedGeneration == generation` **and** `Ready=True`; nothing else distinguishes "fetched from the new URL" from "still holding what it fetched from the old one". Since a URL's reachability from a secondary is a fact and not an assumption, the leg walks a **candidate chain**: the in-cluster mesh URL first, then the Sovereign's own external Gitea door. Each candidate is patched in and given a bounded window — the secondary's own source-controller is the only honest prober, dialing the exact URL from the right cluster with the right credential. Exhausting the chain is fatal.

The fallback is live-verified, not assumed. From region-b's source-controller, with a same-command control from region-a:

```
region-A -> its own in-cluster gitea (known good):     001e# service=git-upload-pack .. 0000 0146 7bcd1d5957...HEAD
region-B -> https://gitea.hw292.omani.works/…:         001e# service=git-upload-pack .. 0000 0146 7bcd1d5957...HEAD
```

Byte-identical, and it is the **pivoted** revision. That door is on-Sovereign (its own gateway VIP, satisfies the source-host lint's `*.<fqdn>` exemption, already carved out of the step-08 secondary hold), so this trades a dead URL for a working one, not for a tether — and Case 76 asserts it never renders `github.com`/`ghcr.io`/`openova.io`.

**Step-08 — the gate, per-region and fail-closed.** `fluxSourceHostLint` shipped in 0.1.162 measuring one cluster, which is the same shape as the defect: a fleet property asserted from a single-region sample. It now takes a region label + kubeconfig; the driver fans out over every `/secondary-kubeconfigs` entry; **every** region is evaluated (no short-circuit, so one run names every offender) and the verdict is an AND. Enumeration is now fail-closed — the old `kubectl … 2>/dev/null` pipe turned an unreadable secondary into zero rows, zero offenders and a **PASS for a region never measured**, which against a secondary cluster is the single most likely failure mode. A kind that is merely *not installed* still counts as zero rows.

**New `fluxSourceHealthLint`.** The host lint reads `spec.url`; hw292 proves a URL can be cosmetic. This asserts the controller converged on it. Scope was **measured, not assumed** — `type: oci` HelmRepositories carry `status: {}` with no `observedGeneration` (70/70 region-a, 65/65 region-b), so including them would fail every region of every Sovereign, the #5505 blast-radius shape. Restricted to GitRepository + OCIRepository, the live blast radius on hw292 is **exactly one object**: region-b's `flux-system/openova` GitRepository. The defect itself, nothing else.

## Vacuity — the gate proven RED and GREEN

Full suite, 24 assertions (`PASS`/`FAIL` in parentheses is the lint's own verdict; `ok` is the expectation matching):

```
[flux-source-host-lint] #5359 — per-region targeting + fail-closed enumeration
  ok   — secondary region with all-local sources (PASS)                        <- GREEN on a pivoted region
  ok   — lint dialled the SECONDARY kubeconfig (not the local cluster)
  ok   — secondary region still on ghcr.io (the live hw292 finding) (FAIL)     <- RED on an unpivoted region
  ok   — offender lines name the REGION, so an operator can tell which cluster is tethered
  ok   — unreadable secondary (enumeration error) (FAIL)                       <- RED, fail-closed
  ok   — uninstalled source kind (not a tether) (PASS)                         <- GREEN, not over-broad

[flux-source-host-lint] #5359 — source-HEALTH lint (converged vs cosmetically-pivoted)
  ok   — converged GitRepository (observedGeneration==generation, Ready=True) (PASS)
  ok   — hw292 region-b GitRepository (gen=2 obs=1 Ready=False) (FAIL)
  ok   — verdict names the object as a STALE-SOURCE
  ok   — Ready=True but observedGeneration behind generation (FAIL)
  ok   — converged generations but Ready=False (FAIL)
  ok   — suspended source (PASS)
  ok   — health lint on an unmeasurable region (FAIL)
  ok   — never-reconciled source (empty observedGeneration and Ready) (FAIL)
```

A guard seen passing only alongside its own fix is not yet known to be a guard, so each half was **mutation-checked** — break the fix, confirm exactly the intended assertion goes red:

```
revert observedGeneration half   -> FAIL — Ready=True but observedGeneration behind generation: expected FAIL, got PASS
restore fail-OPEN enumeration    -> FAIL — unreadable secondary (enumeration error): expected FAIL, got PASS
ignore the kubeconfig argument   -> FAIL — lint did not pass --kubeconfig to kubectl; it measured the local cluster
                                           and labelled the verdict 'me-east-215-b-1'
```

and against contract Case 76:

```
kubeconfig-arg   -> FAIL: the source lints do not accept a kubeconfig argument …
driver-fanout    -> FAIL: the source-lint driver does not iterate the secondary kubeconfigs …
health-scope     -> FAIL: the health lint includes HelmRepositories, which carry no observedGeneration for type:oci …
convergence      -> FAIL: step-05's secondary readiness does not require observedGeneration == generation …
```

The per-region **driver** is behaviourally verified too (stubbed lints, temp kubeconfig dir): fan-out over primary + 2 secondaries; single-region renders inert (primary only, exit 0 — pre-change behaviour); one red region still evaluates the rest and exits 1.


## Follow-up commit — a bug in this PR that only executing the code could find

While building the fix I renamed `sec_url` to `sec_url_chain`, and the per-region log line **above** the candidate loop kept referencing `${sec_url}` — a variable that now exists only *inside* the loop. The Job runs under `set -eu`, so this did not print a wrong URL:

```
run.sh: 56: sec_url: parameter not set
```

It **aborted the secondary leg on the first region, before any pivot, on every 2-region Sovereign** — i.e. it would have turned this fix into a worse version of the defect.

Nothing already in the tree could see it. `helm template` rendered fine, `sh`/`bash`/`dash -n` were clean (the syntax is valid), and contract Case 76 passed (the string is present, just in the wrong scope). It surfaced only from *running* the extracted leg under the same shell options the Job uses.

New `tests/step05-secondary-chain.sh` closes that gap permanently — it drives the real leg, extracted from the render, against a stub kubectl under `set -eu` in **sh, dash and bash**:

```
  ok   — sh:   first candidate converges -> exit 0 on the mesh URL
  ok   — sh:   stale Ready=True on candidate 1 is rejected, chain falls through to the Sovereign door
  ok   — sh:   exhausted chain exits 1 (cutoverComplete stays false)
  ok   — dash: (same three)
  ok   — bash: (same three)
  ok   — the exhausted-chain FATAL explains the consequence, not just the failure
  ok   — a failed region stamps result=failed on the status ConfigMap
  ok   — a converged region stamps result=success and records which candidate won
```

Case 2 is the live hw292 path end to end: candidate 1 reports the exact stale shape (`generation=2, observedGeneration=1`, `Ready=True`, `pkt-line 3: EOF`) and is rejected; the chain falls through to the Sovereign's own door and converges. The fallback URL is read **out of the render** rather than supplied by the harness — a suite that supplied its own would keep passing after the chart stopped rendering one.

Mutation-checked, three ways:

```
reintroduce the ${sec_url} reference     -> FAIL — sh: first-candidate case returned '2 none', expected '0 http://gitea-http…'
revert to the old stale-Ready predicate  -> FAIL — sh: fallthrough case returned '0 http://gitea-http…', expected '0 https://gitea.hw292…'
giteaFallbackToPublicDoor=false          -> FAIL — the chart renders no SECONDARY_GITEA_FALLBACK_URL …
```

This also upgrades one claim below: the candidate chain's decision logic is now **behaviourally proven**, not merely rendered. What stays unproven live is unchanged — the real cutover against a real region-b.

## Gates

```
tests/cutover-contract.sh                All gates green (Case 76 added)
tests/step05-secondary-chain.sh          12/12 (new)
tests/flux-source-host-lint.sh           24/24
8 other cutover chart tests              green
scripts/check-bootstrap-kit-pin-sync.sh  PASS — bp-self-sovereign-cutover chart=0.1.164 pin=0.1.164
tests/e2e/bootstrap-kit go test          ok
sh/bash/dash -n on every rendered step   clean
```

Chart 0.1.163 -> 0.1.164 across all six lockstep sites; `catalog.generated.ts` written only by `node scripts/build-catalog.mjs`. No Service and no nodePort anywhere in the diff (the render contains zero Services; the three `NodePort` hits are comments asserting absence).

## What is claimed, and what is not

**Proven live (read-only, against hw292 both regions):** the root cause — the DNS answer, the empty region-b Gitea, the headless Services, the `generation`/`observedGeneration` split, the stale GitHub artifact SHA, and the reachability of the fallback door with a same-command control from region-a.

**Proven by test:** every behaviour of both lints in both directions, the driver's fan-out and AND verdict, and the step-05 convergence predicate — all mutation-checked.

**Renders correctly, NOT proven live:** the fix's end-to-end effect. Validating that requires a fresh 2-region cutover, which I was not to fire. Concretely unverified: that the fallback door converges region-b's GitRepository under the real cutover's step-08 deny-egress policy; that one candidate window (300s) suffices on a slow region; and that region-b's 64 HelmRepositories stay pivoted once its source of truth is genuinely local — that last one is the acceptance bar this issue has never met, and it should be the bar for closing it.

**Next actions, as follow-up PRs:** step-04's region-B node-layer containerd pivot (region-b node images still pull quay/ghcr), tracked as the remainder from #5379; and region-b's Gitea is still empty — this PR routes region-b to region-a's Gitea rather than mirroring into region-b's own, so a region-a loss leaves region-b without a git source. That is a DR gap worth its own issue.

Refs #5359 #5650 #5379 #3379 #960
