### PR TITLE
feat(cutover): post-cutover delivery that can actually deliver — inverse-mapped source, operator-gated one-shot request mode, fail-closed readiness (Refs #5640)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1049,7 +1049,7 @@ spec:
       # default", which detect holds literally, and shipping it off left the
       # gap as silent as the issue describes. Step count stays 11; no RBAC
       # change. New chart test tests/daytwo-image-leg.sh + contract Case 75.
-      version: 0.1.164
+      version: 0.1.165
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.164
+  version: 0.1.165
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,75 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.165 (#5640 round 2, Refs #5644 #5265 #4975 #960) — the Day-2 delivery path
+# becomes one that can ACTUALLY deliver, and an unpullable pin becomes a FAILING
+# condition instead of a silent freeze.
+#
+# THREE findings, measured against the shipped 0.1.164 template, not inferred.
+#
+# 1. THE DELIVERY PATH COULD NOT DELIVER THE DEFECT IT WAS BUILT FOR. step-07's
+#    pod-spec sweep (sweep_one_workload -> podspec_pivot_ref) rewrites every
+#    workload image to `registry.<fqdn>/<local-path>`. Post-cutover, therefore,
+#    every ref the Day-2 loop reads off the LIVE cluster already carries the
+#    LOCAL host — which is the only shape the hw292 defect takes. 0.1.164 passed
+#    that ref straight to skopeo as the SOURCE, so `mode=warm` asked skopeo to
+#    copy the local registry to ITSELF for an artifact local Harbor had just
+#    404'd. It could never have delivered anything, and it would have failed as
+#    "copy error" rather than "unknown upstream". FIX: `offlinemirror_upstream_ref`
+#    in the SHARED 03a resolver — the exact inverse of `offlinemirror_local_paths`,
+#    one function in one place — plus a same-registry refusal so a self-copy can
+#    never be attempted or mistaken for a transient failure.
+#
+# 2. `warm` IS A STANDING TETHER, so it is the wrong thing to reach for. It runs
+#    every cycle, forever, unbounded in scope, with a standing credential, and
+#    the only record is a rotating Pod log. Turning it on to fix one stale image
+#    re-tethers the Sovereign permanently. NEW `mode: request` (now the DEFAULT):
+#    detect's behaviour exactly — zero external egress, no upstream host dialled,
+#    skopeo never downloaded, the upstream `helm registry login` made LAZY so
+#    even it cannot fire at start-up — until an operator files ONE delivery
+#    request. That request is initiated (a ConfigMap the operator creates),
+#    scope-bounded (only the refs it names, or ALL_MISSING; an over-size scope is
+#    REFUSED, never truncated), credential-scoped (step-06 strips the cutover's
+#    own ghcr auth, so the credential can only be one the operator provisioned
+#    and can revoke), audited (timestamp, requestId, requestedBy, source,
+#    destination, outcome, to a durable ConfigMap) and ONE-SHOT (the consumed
+#    requestId is recorded durably, so re-applying the same request does not
+#    re-open the window; a new window needs a new requestId). Because a
+#    request-less cycle dials nothing, this is safe as a DEFAULT in a way `warm`
+#    is not. `warm` is kept and documented as the always-on posture it is.
+#
+# 3. THE MISSING SET WAS STILL A SILENT FREEZE. 0.1.164 wrote it to a ConfigMap
+#    and to logs; nothing turned it into a failing condition, so the operator
+#    still found out when a UAT row would not go green. The loop now writes a
+#    readiness verdict from the MEASURED cycle outcome and the container carries
+#    a readinessProbe on it: READY requires every enabled leg to have completed
+#    AND zero missing artifacts, and "I could not check" is NOT-READY, never
+#    all-clear. `kubectl get deploy cutover-daytwo-harbor-reconciler` reading 0/1
+#    IS the statement "this Sovereign holds a pin its registry cannot serve".
+#    Deliberately no livenessProbe — the correct response is not-ready, never a
+#    restart loop.
+#
+# Also fixed: the operator-supplied warm credential was hard-wired to ghcr.io
+# (`&& [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]`), so an operator mirroring the
+# catalog into their OWN registry — the posture values.yaml explicitly documents
+# — had their credential silently ignored and every private ref fell back to
+# anonymous, which reads as "the image is missing". It now binds to
+# warm.registryHost.
+#
+# PROVEN, NOT ASSERTED. tests/daytwo-image-leg.sh grows from 4 scenarios to 12,
+# all EXECUTING the rendered script against stub kubectl/curl/skopeo: the
+# shipped default with no request makes zero egress while still reporting the
+# full missing set; an open request copies the ref it names and NOT the missing
+# ref it omits (the bounded-window control); a step-07-pivoted ref is copied
+# FROM ghcr.io with no self-copy; an un-invertible local ref is refused before
+# any copy; a consumed requestId and an identity-less request both deliver
+# nothing; and the readiness verdict is walked in BOTH directions — NOT-READY on
+# a missing pin, READY on a clean measured cycle, NOT-READY on a broken read.
+#
+# New values: daytwoReconciler.mode=request (default) and
+# daytwoReconciler.request.{configMapName,auditConfigMapName,maxRefsPerRequest,
+# auditMaxLines}. No RBAC change (the runner ClusterRole already grants
+# configmaps create + get/list/watch + update/patch). Step count unchanged at 11.
+#
 # 0.1.164 (#5359 Refs #5650 #5379 #3379 #960) — the sovereignty gate becomes a
 # FLEET assertion, and step-05's secondary readiness starts asserting
 # convergence instead of a stale status field.
@@ -3099,7 +3169,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.164
+version: 0.1.165
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03a-offline-mirror-resolver.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03a-offline-mirror-resolver.yaml
@@ -115,3 +115,62 @@ data:
         esac
       fi
     }
+
+    # offlinemirror_upstream_ref REF -> the UPSTREAM ref a local-registry ref
+    # came from, or EMPTY (exit 1) when the map cannot name one.
+    #
+    # WHY THIS EXISTS (#5640). step-07's pod-spec sweep rewrites every workload
+    # image to `registry.<fqdn>/<local-path>` (sweep_one_workload ->
+    # podspec_pivot_ref). Post-cutover, therefore, the refs a Day-2 loop reads
+    # off the LIVE cluster no longer carry an upstream host at all. Handing such
+    # a ref to a copy as the SOURCE asks skopeo to copy the local registry to
+    # itself — for an artifact the local registry has just 404'd, which can never
+    # deliver anything. Recovering the upstream is not guesswork: the forward map
+    # is injective on the classes that exist, so it inverts.
+    #
+    #   registry.<fqdn>/openova-io/openova/catalyst-api:e3342f9
+    #       -> ghcr.io/openova-io/openova/catalyst-api:e3342f9   (host-drop inverse)
+    #   registry.<fqdn>/proxy-dockerhub/library/redis:7
+    #       -> docker.io/library/redis:7                         (project inverse)
+    #
+    # A mothership host-swapped path (project "" in the map) already carries its
+    # `proxy-<x>` segment, so the project inverse below resolves it to the ORIGIN
+    # host rather than back to harbor.openova.io — which is both correct and the
+    # source #5095's DIRECT fallback prefers anyway. No separate branch needed.
+    #
+    # A ref that already carries a real registry host is returned unchanged: it
+    # is an upstream ref, and there is nothing to invert.
+    offlinemirror_upstream_ref() {
+      _ur=$(offlinemirror_normalize_ref "$1")
+      case "${_ur}" in
+        "${LOCAL_REGISTRY_HOST}"/*) _ur_path="${_ur#*/}" ;;
+        */*)
+          _ur_h="${_ur%%/*}"
+          case "${_ur_h}" in
+            *.*|*:*|localhost) printf '%s\n' "${_ur}"; return 0 ;;
+            *) _ur_path="${_ur}" ;;
+          esac ;;
+        *) _ur_path="${_ur}" ;;
+      esac
+      case "${_ur_path}" in
+        */*) _ur_proj="${_ur_path%%/*}"; _ur_rest="${_ur_path#*/}" ;;
+        *) return 1 ;;
+      esac
+      # (1) project -> host: the exact inverse of the coverage-map lookup above.
+      for _ur_pair in ${HOST_PROJECT_MAP}; do
+        _ur_ph="${_ur_pair%%:*}"
+        case "${_ur_pair}" in *:*) _ur_pp="${_ur_pair#*:}" ;; *) _ur_pp="" ;; esac
+        if [ -n "${_ur_pp}" ] && [ "${_ur_pp}" = "${_ur_proj}" ]; then
+          printf '%s/%s\n' "${_ur_ph}" "${_ur_rest}"
+          return 0
+        fi
+      done
+      # (2) the openova-io host-drop DUAL dest, inverted. Same literal the
+      # forward branch above emits, so the two can never drift apart.
+      case "${_ur_path}" in
+        openova-io/*) printf 'ghcr.io/%s\n' "${_ur_path}"; return 0 ;;
+      esac
+      # Undecidable. Return EMPTY and let the caller fail loudly — a caller that
+      # guessed would produce the self-copy this function exists to prevent.
+      return 1
+    }

--- a/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
@@ -96,20 +96,64 @@ Sovereignty — this NEVER weakens the Pillar-5 guarantee
     strand into a visible, actionable signal — the #5640 "today nothing
     notices" defect, closed.
 
-  • mode=warm — additionally fetches each missing artifact from the operator-
-    nominated upstream (`helm pull`/`helm push` for charts, `skopeo copy` for
-    images, authenticating with the operator-SUPPLIED credential Secret; the
-    cutover's own ghcr auth is stripped by step-06, by design) and re-checks.
-    Only this mode reaches upstream, and only on the operator's schedule — the
-    exact companion of the Git mirror reaching github.com on that schedule. A
-    warm failure is fail-SOFT (logged, left in the missing manifest) so the
-    loop never crash-loops and workloads keep running on the installed version.
+  • mode=request (THE DEFAULT) — detect's behaviour EXACTLY until an operator
+    files a delivery request, and detect's behaviour again the moment that one
+    request is consumed. This is the shape the sovereignty argument actually
+    wants: an explicitly operator-INITIATED, scope-BOUNDED, credential-SCOPED,
+    AUDITED, ONE-SHOT pull is a different object from a standing mirror.
+      – initiated: nothing happens without a ConfigMap the operator creates.
+      – bounded: only the refs that request names (or ALL_MISSING), capped at
+        request.maxRefsPerRequest; an over-size scope is REFUSED, not truncated.
+      – credential-scoped: step-06 strips the cutover's own ghcr auth, so the
+        credential can only be one the operator provisioned and can revoke.
+      – audited: every attempt appends to the delivery ConfigMap with
+        timestamp, requestId, requestedBy, source, destination and outcome.
+      – one-shot: the consumed requestId is recorded durably, so re-applying
+        the same request does NOT re-open the window. A new window needs a new
+        requestId — the window cannot stay open because someone forgot.
+    Because a request-less cycle dials nothing, this is safe as a DEFAULT in a
+    way `warm` is not, and an operator needing one stale image does not have to
+    edit the chart, roll the reconciler, and remember to turn it off again.
+
+  • mode=warm — an ALWAYS-ON mirror: every cycle, forever, unbounded in scope,
+    with a standing credential. Legitimate for an operator who has chosen to
+    track upstream continuously, but it IS a standing outbound tether and is
+    NOT the sovereignty-preserving option. Kept, documented as such, not the
+    default.
+
+Both delivery modes are fail-SOFT (a failed fetch is logged and left in the
+missing manifest) so the loop never crash-loops and workloads keep running on
+the installed version.
 
 #5640 flips `daytwoReconciler.enabled` to TRUE by default. The severance-safe
 property that mattered was never "no Deployment" — it was "no upstream egress
-by default", and mode=detect holds that with zero egress. Shipping the loop
-OFF would have shipped a knob nobody turns on, leaving the failure exactly as
-silent as the issue describes.
+by default", and detect/request both hold that with zero egress. Shipping the
+loop OFF would have shipped a knob nobody turns on, leaving the failure exactly
+as silent as the issue describes.
+
+Why the enumerated ref must be INVERTED before it is copied (#5640)
+───────────────────────────────────────────────────────────────────
+step-07's pod-spec sweep (sweep_one_workload -> podspec_pivot_ref) rewrites
+every workload image to `registry.<fqdn>/<local-path>`. Post-cutover, therefore,
+the refs this loop reads off the LIVE cluster carry NO upstream host — which is
+the ONLY shape the hw292 defect appears in. Handing such a ref to skopeo as the
+SOURCE copies the local registry to itself, for an artifact the local registry
+just 404'd: it can never deliver, and it fails as "copy error" rather than as
+"I do not know where this came from". The copy therefore inverts the SHARED 03a
+map first (`offlinemirror_upstream_ref`, the exact inverse of
+`offlinemirror_local_paths` — one function, one place) and REFUSES the copy
+outright when the map cannot name an upstream.
+
+The FAIL-CLOSED surface (#5640)
+───────────────────────────────
+A missing pin used to be a log line plus a ConfigMap, i.e. still a silent
+freeze — the operator found out when a UAT row would not go green. The loop now
+writes a readiness verdict from the MEASURED cycle outcome, and the container
+carries a readinessProbe on it. READY requires every enabled leg to have
+completed AND zero missing artifacts; "I could not check" is NOT-READY, never
+all-clear. `kubectl get deploy cutover-daytwo-harbor-reconciler` reading 0/1 is
+then the visible statement "this Sovereign holds a pin its registry cannot
+serve". No livenessProbe: the correct response is to go not-ready, not restart.
 
 NOT a cutover-step ConfigMap: no `bp.openova.io/cutover-order` label, so it does
 NOT count toward the 11-step contract (tests/cutover-contract.sh Case 2/4).
@@ -196,11 +240,22 @@ spec:
             # ── loop policy ──
             - name: RECONCILE_INTERVAL_SECONDS
               value: {{ .Values.daytwoReconciler.intervalSeconds | quote }}
-            # detect (default; zero egress) | warm (opt-in upstream fetches)
+            # detect (zero egress) | request (default; zero egress until the
+            # operator files ONE scoped, audited, one-shot request) | warm
+            # (always-on upstream mirror)
             - name: RECONCILE_MODE
               value: {{ .Values.daytwoReconciler.mode | quote }}
             - name: MISSING_MANIFEST_CM
               value: {{ .Values.daytwoReconciler.missingManifestConfigMapName | quote }}
+            # ── #5640 operator-gated delivery (mode=request) ──
+            - name: REQUEST_CM
+              value: {{ .Values.daytwoReconciler.request.configMapName | quote }}
+            - name: DELIVERY_AUDIT_CM
+              value: {{ .Values.daytwoReconciler.request.auditConfigMapName | quote }}
+            - name: REQUEST_MAX_REFS
+              value: {{ .Values.daytwoReconciler.request.maxRefsPerRequest | quote }}
+            - name: AUDIT_MAX_LINES
+              value: {{ .Values.daytwoReconciler.request.auditMaxLines | quote }}
             - name: RELEASE_NAMESPACE
               value: {{ .Release.Namespace | quote }}
             # Per-leg switches. Both default true; an operator debugging one
@@ -272,12 +327,26 @@ spec:
               export HOME=/tmp
               : "${HARBOR_USERNAME:=admin}"
               : "${RECONCILE_INTERVAL_SECONDS:=300}"
-              : "${RECONCILE_MODE:=detect}"
+              : "${RECONCILE_MODE:=request}"
               : "${CHART_LEG_ENABLED:=true}"
               : "${IMAGE_LEG_ENABLED:=true}"
               : "${IMAGE_SCAN_MAX:=400}"
+              : "${REQUEST_MAX_REFS:=50}"
+              : "${AUDIT_MAX_LINES:=500}"
               WORK=/tmp/daytwo-work
               mkdir -p "${WORK}"
+              # #5640 FAIL-CLOSED readiness surface. The reconciler is READY iff
+              # its last completed cycle proved every pinned artifact is
+              # servable by the registry this Sovereign is allowed to use.
+              # Anything else — a missing pin, a leg that could not run, no
+              # cycle yet — is NOT-READY, which shows up as 0/1 on
+              # `kubectl get deploy` and in every dashboard already watching
+              # workload readiness. Before #5640 the identical condition was a
+              # log line and a ConfigMap nobody was watching: a SILENT freeze.
+              # Seeded NOT-READY so the pre-first-cycle state can never read as
+              # an all-clear.
+              HEALTH_FILE="${WORK}/health"
+              echo "NOTREADY no-cycle-completed-yet" > "${HEALTH_FILE}"
 
               # Bare host of the local Harbor (registry.<fqdn>) — the helm
               # registry login + push target in warm mode. Post-cutover its
@@ -301,9 +370,129 @@ spec:
               echo "[daytwo] post-cutover local-Harbor reconciler starting (mode=${RECONCILE_MODE}, interval=${RECONCILE_INTERVAL_SECONDS}s, charts=${CHART_LEG_ENABLED}, images=${IMAGE_LEG_ENABLED}; #5265 #5640)"
               echo "[daytwo] local Gitea mirror=${GITEA_INTERNAL_URL} (${GITEA_ORG}/${GITEA_REPO}@${UPSTREAM_BRANCH}); local Harbor=${HARBOR_INTERNAL_URL} (${HARBOR_HOST})"
               case "${RECONCILE_MODE}" in
-                warm) echo "[daytwo] mode=warm — missing chart OCI artifacts are helm-pulled from ${WARM_UPSTREAM_OCI_PREFIX} and missing IMAGES are skopeo-copied from their recorded upstream (operator-scheduled; the Git-mirror companion), then pushed to local Harbor" ;;
-                *)    echo "[daytwo] mode=detect — reaching ONLY the local Gitea mirror + local Harbor (zero external egress; skopeo is never downloaded); missing artifacts are reported to ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} as the offline-media manifest" ;;
+                warm)    echo "[daytwo] mode=warm — ALWAYS-ON upstream mirror: every cycle helm-pulls missing charts from ${WARM_UPSTREAM_OCI_PREFIX} and skopeo-copies missing IMAGES from their upstream into local Harbor. This is a STANDING outbound tether; mode=request is the sovereignty-preserving alternative (#5640)" ;;
+                request) echo "[daytwo] mode=request — detect behaviour (zero external egress) UNTIL an operator files a delivery request in ConfigMap ${RELEASE_NAMESPACE}/${REQUEST_CM}; each requestId is consumed ONCE, bounded to its own scope (max ${REQUEST_MAX_REFS} refs), and audited to ${RELEASE_NAMESPACE}/${DELIVERY_AUDIT_CM} (#5640)" ;;
+                *)       echo "[daytwo] mode=detect — reaching ONLY the local Gitea mirror + local Harbor (zero external egress; skopeo is never downloaded); missing artifacts are reported to ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} as the offline-media manifest" ;;
               esac
+
+              # ── #5640 OPERATOR-GATED DELIVERY ────────────────────────────────
+              # The whole point: an explicitly operator-initiated, scope-bounded,
+              # credential-scoped, audited, ONE-SHOT pull is a different object
+              # from an always-on mirror. `warm` is the latter and re-tethers the
+              # Sovereign for as long as it is set. `request` opens the window
+              # only for the refs one named request lists, then closes it.
+              REQ_ID=""; REQ_BY=""; REQ_SCOPE_FILE="${WORK}/request-scope.txt"
+              REQ_ACTIVE=0; REQ_DELIVERED=0; REQ_FAILED=0
+              AUDIT_FILE="${WORK}/audit.log"
+              : > "${AUDIT_FILE}"
+
+              # daytwo_audit LINE — append to the durable delivery audit trail
+              # AND the Pod log. Read-modify-write so history is preserved
+              # across cycles and Pod restarts; capped so the ConfigMap cannot
+              # grow past the apiserver's 1 MiB object limit.
+              daytwo_audit() {
+                _au_line="$(date -u +%Y-%m-%dT%H:%M:%SZ)\t$*"
+                printf '%b\n' "${_au_line}" >> "${AUDIT_FILE}"
+                echo "[daytwo][audit] $*"
+              }
+
+              daytwo_audit_flush() {
+                [ -s "${AUDIT_FILE}" ] || return 0
+                _af_prev=$(kubectl -n "${RELEASE_NAMESPACE}" get configmap "${DELIVERY_AUDIT_CM}" \
+                  -o "jsonpath={.data['audit\.log']}" 2>/dev/null || true)
+                _af_all="${WORK}/audit-all.log"
+                { [ -n "${_af_prev}" ] && printf '%s\n' "${_af_prev}"; cat "${AUDIT_FILE}"; } \
+                  | grep -v '^$' | tail -n "${AUDIT_MAX_LINES}" > "${_af_all}"
+                kubectl -n "${RELEASE_NAMESPACE}" create configmap "${DELIVERY_AUDIT_CM}" \
+                  --from-file=audit.log="${_af_all}" \
+                  --from-literal=lastConsumedRequestId="${LAST_CONSUMED_ID:-}" \
+                  --dry-run=client -o yaml 2>/dev/null \
+                  | kubectl -n "${RELEASE_NAMESPACE}" apply -f - >/dev/null 2>&1 \
+                  || echo "[daytwo] WARN: could not update the delivery audit ConfigMap ${RELEASE_NAMESPACE}/${DELIVERY_AUDIT_CM} (the Pod log still carries every audit line)"
+                : > "${AUDIT_FILE}"
+              }
+
+              # daytwo_load_request — read the operator's request, if any, and
+              # decide whether THIS cycle may deliver. Sets REQ_ACTIVE=1 only for
+              # a request whose requestId has never been consumed.
+              LAST_CONSUMED_ID=""
+              daytwo_load_request() {
+                REQ_ACTIVE=0; REQ_ID=""; REQ_BY=""; : > "${REQ_SCOPE_FILE}"
+                [ "${RECONCILE_MODE}" = "request" ] || return 0
+                _lr_json=$(kubectl -n "${RELEASE_NAMESPACE}" get configmap "${REQUEST_CM}" -o json 2>/dev/null || true)
+                if [ -z "${_lr_json}" ]; then
+                  echo "[daytwo] mode=request: no delivery request in ${RELEASE_NAMESPACE}/${REQUEST_CM} — this cycle makes ZERO external egress (detect-equivalent)"
+                  return 0
+                fi
+                REQ_ID=$(printf '%s' "${_lr_json}" | jq -r '.data.requestId // ""' 2>/dev/null || true)
+                REQ_BY=$(printf '%s' "${_lr_json}" | jq -r '.data.requestedBy // "unattributed"' 2>/dev/null || true)
+                printf '%s' "${_lr_json}" | jq -r '.data.scope // ""' 2>/dev/null \
+                  | grep -Ev '^[[:space:]]*(#|$)' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+                  | sort -u > "${REQ_SCOPE_FILE}" 2>/dev/null || true
+                if [ -z "${REQ_ID}" ]; then
+                  echo "[daytwo] mode=request: ${REQUEST_CM} carries no requestId — REFUSING to deliver. A request without an identity cannot be consumed once, so it would re-fire every cycle and become the always-on mirror this mode exists to avoid (#5640)"
+                  return 0
+                fi
+                LAST_CONSUMED_ID=$(kubectl -n "${RELEASE_NAMESPACE}" get configmap "${DELIVERY_AUDIT_CM}" \
+                  -o "jsonpath={.data.lastConsumedRequestId}" 2>/dev/null || true)
+                if [ -n "${LAST_CONSUMED_ID}" ] && [ "${LAST_CONSUMED_ID}" = "${REQ_ID}" ]; then
+                  echo "[daytwo] mode=request: requestId '${REQ_ID}' was already consumed — the delivery window is CLOSED and this cycle makes ZERO external egress. File a new requestId to open another."
+                  return 0
+                fi
+                _lr_n=$(grep -c . "${REQ_SCOPE_FILE}" 2>/dev/null || true)
+                if [ "${_lr_n}" -eq 0 ]; then
+                  echo "[daytwo] mode=request: requestId '${REQ_ID}' has an EMPTY scope — refusing. An empty scope is a malformed request, never an implicit ALL_MISSING (#5640)"
+                  return 0
+                fi
+                if ! grep -qx 'ALL_MISSING' "${REQ_SCOPE_FILE}" && [ "${_lr_n}" -gt "${REQUEST_MAX_REFS}" ]; then
+                  echo "[daytwo] mode=request: requestId '${REQ_ID}' lists ${_lr_n} refs, over request.maxRefsPerRequest=${REQUEST_MAX_REFS} — REFUSING rather than truncating (a silently truncated bound is how a bounded window becomes an unbounded one)"
+                  return 0
+                fi
+                REQ_ACTIVE=1
+                daytwo_audit "REQUEST\topen\t${REQ_ID}\t${REQ_BY}\trefs=${_lr_n}"
+                echo "[daytwo] mode=request: delivery window OPEN for requestId '${REQ_ID}' (requestedBy=${REQ_BY}, ${_lr_n} scope line(s)); it will be consumed at the end of this cycle"
+              }
+
+              # daytwo_in_scope REF UPSTREAM_REF LOCAL_PATH -> 0 iff this artifact
+              # is inside the OPEN request's scope. Matches the enumerated ref,
+              # the inverse-mapped upstream, the bare local path AND the fully
+              # qualified local ref, so an operator can paste back whichever form
+              # the missing manifest showed them.
+              daytwo_in_scope() {
+                [ "${REQ_ACTIVE}" = "1" ] || return 1
+                grep -qx 'ALL_MISSING' "${REQ_SCOPE_FILE}" 2>/dev/null && return 0
+                grep -qxF "$1" "${REQ_SCOPE_FILE}" 2>/dev/null && return 0
+                [ -n "$2" ] && grep -qxF "$2" "${REQ_SCOPE_FILE}" 2>/dev/null && return 0
+                grep -qxF "$3" "${REQ_SCOPE_FILE}" 2>/dev/null && return 0
+                grep -qxF "${LOCAL_REGISTRY_HOST}/$3" "${REQ_SCOPE_FILE}" 2>/dev/null && return 0
+                return 1
+              }
+
+              # daytwo_delivery_allowed REF UPSTREAM_REF LOCAL_PATH -> 0 iff this
+              # cycle may reach upstream for THIS artifact. THE single gate every
+              # egress-bearing call sits behind; detect can never pass it, and
+              # request passes it only inside an open, in-scope, unconsumed
+              # window. Every mode other than warm/request falls through to the
+              # closed default, so an unrecognised mode value fails CLOSED.
+              daytwo_delivery_allowed() {
+                case "${RECONCILE_MODE}" in
+                  warm) return 0 ;;
+                  request) daytwo_in_scope "$1" "$2" "$3" && return 0; return 1 ;;
+                  *) return 1 ;;
+                esac
+              }
+
+              # daytwo_consume_request — close the window. Recording consumption
+              # in the AUDIT ConfigMap (not the request ConfigMap) means it
+              # survives a Pod restart and cannot be undone by re-applying the
+              # request unchanged; a new window needs a NEW requestId.
+              daytwo_consume_request() {
+                [ "${REQ_ACTIVE}" = "1" ] || return 0
+                LAST_CONSUMED_ID="${REQ_ID}"
+                daytwo_audit "REQUEST\tconsumed\t${REQ_ID}\t${REQ_BY}\tdelivered=${REQ_DELIVERED}\tfailed=${REQ_FAILED}"
+                echo "[daytwo] mode=request: requestId '${REQ_ID}' CONSUMED (delivered=${REQ_DELIVERED} failed=${REQ_FAILED}); the delivery window is now CLOSED and subsequent cycles make zero external egress until a new requestId is filed"
+                REQ_ACTIVE=0
+              }
 
               # Read the catalyst-gitea-token PAT (never echoed; sent only via
               # the Authorization header). Bounded per-call so a rotation heals.
@@ -331,9 +520,37 @@ spec:
               # warm ONE missing chart: helm pull upstream (operator cred if
               # supplied) -> helm push local. Fail-SOFT (returns non-zero, the
               # caller keeps it in the missing manifest; never crashes the loop).
+              # #5640 — the upstream `helm registry login` is itself an EGRESS
+              # call, so it is LAZY: performed on the first allowed chart
+              # delivery, never at startup. detect (and request with no open
+              # window) therefore dials nothing at all, which is the property the
+              # zero-egress contract actually needs.
               WARM_LOGIN_DONE=0
+              daytwo_helm_login_once() {
+                [ "${WARM_LOGIN_DONE}" = "1" ] && return 0
+                WARM_LOGIN_DONE=1
+                export HELM_CACHE_HOME=/tmp/.helm-cache HELM_CONFIG_HOME=/tmp/.helm-config HELM_DATA_HOME=/tmp/.helm-data
+                if [ -n "${WARM_CRED_SECRET_NAME}" ]; then
+                  _lu=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_USERNAME_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+                  _lp2=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_PASSWORD_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+                  if [ -n "${_lu}" ] && [ -n "${_lp2}" ]; then
+                    helm registry login "${WARM_REGISTRY_HOST}" -u "${_lu}" -p "${_lp2}" >/dev/null 2>&1 \
+                      && echo "[daytwo] delivery: authenticated to upstream ${WARM_REGISTRY_HOST}" \
+                      || echo "[daytwo] delivery: upstream ${WARM_REGISTRY_HOST} login failed (anonymous pulls only; private charts stay in the missing manifest)"
+                  else
+                    echo "[daytwo] delivery: credential Secret ${WARM_CRED_SECRET_NAMESPACE}/${WARM_CRED_SECRET_NAME} has no usable ${WARM_CRED_USERNAME_KEY}/${WARM_CRED_PASSWORD_KEY} — anonymous pulls only"
+                  fi
+                else
+                  echo "[daytwo] delivery: no credentialSecret configured — anonymous pulls only (openova-io charts are PRIVATE; supply daytwoReconciler.warm.credentialSecret to fetch them)"
+                fi
+                helm registry login "${HARBOR_HOST}" -u "${HARBOR_USERNAME}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
+                  && echo "[daytwo] delivery: authenticated to local Harbor ${HARBOR_HOST}" \
+                  || echo "[daytwo] delivery: local Harbor ${HARBOR_HOST} login failed — pushes will retry per cycle"
+              }
+
               warm_chart() {
                 _wc="$1"; _wv="$2"
+                daytwo_helm_login_once
                 mkdir -p /tmp/daytwo-pull
                 rm -f /tmp/daytwo-pull/*.tgz 2>/dev/null || true
                 if ! helm pull "${WARM_UPSTREAM_OCI_PREFIX}/${_wc}" --version "${_wv}" -d /tmp/daytwo-pull >/tmp/daytwo-pull/pull.log 2>&1; then
@@ -387,6 +604,7 @@ spec:
               _creds_loaded=0
               _ghcr_user=""; _ghcr_pat=""
               _moth_user=""; _moth_pat=""
+              _warm_user=""; _warm_pat=""
               daytwo_load_creds() {
                 [ "${_creds_loaded}" = "1" ] && return 0
                 _creds_loaded=1
@@ -408,14 +626,23 @@ spec:
                   _moth_user=$(printf '%s' "${_ma}" | base64 -d | awk -F: '{print $1}')
                   _moth_pat=$(printf '%s' "${_ma}" | base64 -d | cut -d: -f2-)
                 fi
-                # An operator-supplied warm credential OVERRIDES the (possibly
+                # An operator-supplied credential OVERRIDES the (possibly
                 # stripped) cutover one for the upstream registry host.
+                # #5640: bound to WARM_REGISTRY_HOST, NOT hard-wired to ghcr.io.
+                # The previous `&& [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]` meant
+                # an operator who mirrors the catalog into their own registry —
+                # the posture values.yaml explicitly documents — had their
+                # credential silently ignored and every private ref fell back to
+                # anonymous, which reads as "the image is missing".
                 if [ -n "${WARM_CRED_SECRET_NAME}" ]; then
                   _wu=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_USERNAME_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
                   _wp=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_PASSWORD_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
-                  if [ -n "${_wu}" ] && [ -n "${_wp}" ] && [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]; then
-                    _ghcr_user="${_wu}"; _ghcr_pat="${_wp}"
-                    echo "[daytwo] image warm: using the operator-supplied credential Secret ${WARM_CRED_SECRET_NAMESPACE}/${WARM_CRED_SECRET_NAME} for ${WARM_REGISTRY_HOST}"
+                  if [ -n "${_wu}" ] && [ -n "${_wp}" ]; then
+                    _warm_user="${_wu}"; _warm_pat="${_wp}"
+                    if [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]; then
+                      _ghcr_user="${_wu}"; _ghcr_pat="${_wp}"
+                    fi
+                    echo "[daytwo] image delivery: using the operator-supplied credential Secret ${WARM_CRED_SECRET_NAMESPACE}/${WARM_CRED_SECRET_NAME} for ${WARM_REGISTRY_HOST}"
                   fi
                 fi
               }
@@ -424,6 +651,7 @@ spec:
                 case "$1" in
                   ghcr.io) [ -n "${_ghcr_user}" ] && printf '%s:%s' "${_ghcr_user}" "${_ghcr_pat}" || printf '' ;;
                   "${MOTHERSHIP_HOST}") [ -n "${_moth_user}" ] && printf '%s:%s' "${_moth_user}" "${_moth_pat}" || printf '' ;;
+                  "${WARM_REGISTRY_HOST}") [ -n "${_warm_user}" ] && printf '%s:%s' "${_warm_user}" "${_warm_pat}" || printf '' ;;
                   *) printf '' ;;
                 esac
               }
@@ -462,9 +690,38 @@ spec:
               daytwo_warm_image() {
                 _wi_up=$(offlinemirror_normalize_ref "$1")
                 _wi_lp="$2"
+                _wi_lref="${LOCAL_REGISTRY_HOST}/${_wi_lp}"
+                # ── #5640 SOURCE INVERSION ────────────────────────────────────
+                # Post-cutover, step-07's pod-spec sweep has ALREADY rewritten
+                # this workload's image to registry.<fqdn>/<local-path>, so the
+                # ref enumerated off the live cluster carries NO upstream host.
+                # Copying it as the SOURCE asks skopeo to copy the local registry
+                # to itself, for an artifact the local registry just 404'd — it
+                # can never deliver anything, and it would report "copy failed"
+                # rather than "I do not know where this came from". That is the
+                # hw292 class exactly: catalyst-ui was pinned to a tag published
+                # after cutover, and its live ref was the pivoted one. Invert the
+                # SHARED 03a map (offlinemirror_upstream_ref) to recover the true
+                # upstream before copying.
+                case "${_wi_up}" in
+                  "${LOCAL_REGISTRY_HOST}"/*)
+                    _wi_inv=$(offlinemirror_upstream_ref "${_wi_up}" 2>/dev/null || true)
+                    if [ -z "${_wi_inv}" ]; then
+                      echo "[daytwo] image delivery REFUSED ${_wi_up}: already on the local registry and the shared 03a inverse map cannot name its upstream. Copying it would be a local->local self-copy of an artifact local Harbor does not have. Side-load it from the manifest instead (#5640)"
+                      return 1
+                    fi
+                    echo "[daytwo] image delivery: ${_wi_up} is a step-07 pivoted ref; inverse-mapped upstream = ${_wi_inv} (#5640)"
+                    _wi_up="${_wi_inv}"
+                    ;;
+                esac
+                # FAIL-CLOSED belt-and-braces: whatever the inversion produced,
+                # never let source and destination be the same registry.
+                if [ "${_wi_up%%/*}" = "${LOCAL_REGISTRY_HOST}" ]; then
+                  echo "[daytwo] image delivery REFUSED ${_wi_up} -> ${_wi_lref}: source and destination are the SAME registry — a self-copy can only ever fail, and reporting it as a copy failure would hide the real defect (#5640)"
+                  return 1
+                fi
                 daytwo_ensure_skopeo || return 1
                 daytwo_load_creds
-                _wi_lref="${LOCAL_REGISTRY_HOST}/${_wi_lp}"
                 _wi_srchost="${_wi_up%%/*}"
                 case "${_wi_srchost}" in *.*|*:*|localhost) : ;; *) _wi_srchost="docker.io" ;; esac
                 _wi_sc=$(daytwo_src_creds_for "${_wi_srchost}")
@@ -610,10 +867,20 @@ spec:
                       continue
                     fi
                     _code="${DAYTWO_LAST_CODE:-000}"
-                    if [ "${RECONCILE_MODE}" = "warm" ] && daytwo_warm_image "${_img}" "${_lp}" && daytwo_manifest_present "${_lp}"; then
-                      IMAGE_WARMED=$((IMAGE_WARMED+1))
-                      echo "[daytwo] image warm restored ${LOCAL_REGISTRY_HOST}/${_lp}"
-                      continue
+                    # The upstream this local path came from — needed BOTH for
+                    # scope matching (so an operator can name the artifact in
+                    # upstream form) and for the copy itself.
+                    _upref=$(offlinemirror_upstream_ref "${_img}" 2>/dev/null || true)
+                    if daytwo_delivery_allowed "${_img}" "${_upref}" "${_lp}"; then
+                      if daytwo_warm_image "${_img}" "${_lp}" && daytwo_manifest_present "${_lp}"; then
+                        IMAGE_WARMED=$((IMAGE_WARMED+1))
+                        REQ_DELIVERED=$((REQ_DELIVERED+1))
+                        [ "${REQ_ACTIVE}" = "1" ] && daytwo_audit "IMAGE\tdelivered\t${REQ_ID}\t${REQ_BY}\t${_upref:-${_img}}\t${LOCAL_REGISTRY_HOST}/${_lp}"
+                        echo "[daytwo] image delivery restored ${LOCAL_REGISTRY_HOST}/${_lp}"
+                        continue
+                      fi
+                      REQ_FAILED=$((REQ_FAILED+1))
+                      [ "${REQ_ACTIVE}" = "1" ] && daytwo_audit "IMAGE\tfailed\t${REQ_ID}\t${REQ_BY}\t${_upref:-${_img}}\t${LOCAL_REGISTRY_HOST}/${_lp}"
                     fi
                     printf 'IMAGE\t%s\t%s\t%s\n' "${_img}" "${_lp}" "${_code}" >> "${MISSING_IMAGES_FILE}"
                     IMAGE_MISS=$((IMAGE_MISS+1))
@@ -687,9 +954,18 @@ spec:
                   if harbor_has "${_c}" "${_v}"; then
                     CHART_PRESENT=$((CHART_PRESENT+1)); continue
                   fi
-                  # Missing. In warm mode, try to fetch it; re-check after.
-                  if [ "${RECONCILE_MODE}" = "warm" ] && warm_chart "${_c}" "${_v}" && harbor_has "${_c}" "${_v}"; then
-                    CHART_WARMED=$((CHART_WARMED+1)); continue
+                  # Missing. Only an ALLOWED delivery may reach upstream — warm
+                  # always, request only for a chart this open window names as
+                  # `<chart>:<version>`. Re-check after.
+                  if daytwo_delivery_allowed "${_c}:${_v}" "" "${_c}:${_v}"; then
+                    if warm_chart "${_c}" "${_v}" && harbor_has "${_c}" "${_v}"; then
+                      CHART_WARMED=$((CHART_WARMED+1))
+                      REQ_DELIVERED=$((REQ_DELIVERED+1))
+                      [ "${REQ_ACTIVE}" = "1" ] && daytwo_audit "CHART\tdelivered\t${REQ_ID}\t${REQ_BY}\t${WARM_UPSTREAM_OCI_PREFIX}/${_c}:${_v}\toci://${HARBOR_HOST}/openova-io/${_c}:${_v}"
+                      continue
+                    fi
+                    REQ_FAILED=$((REQ_FAILED+1))
+                    [ "${REQ_ACTIVE}" = "1" ] && daytwo_audit "CHART\tfailed\t${REQ_ID}\t${REQ_BY}\t${WARM_UPSTREAM_OCI_PREFIX}/${_c}:${_v}\toci://${HARBOR_HOST}/openova-io/${_c}:${_v}"
                   fi
                   printf 'CHART\t%s\t%s\n' "${_c}" "${_v}" >> "${MISSING_CHARTS_FILE}"
                   CHART_MISS=$((CHART_MISS+1))
@@ -730,46 +1006,52 @@ spec:
                   || echo "[daytwo] WARN: could not update ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} (logs still carry the manifest)"
               }
 
+              # #5640 FAIL-CLOSED readiness verdict. Written from the MEASURED
+              # cycle outcome, never from a knob: READY requires every enabled
+              # leg to have completed (status=ok) AND zero missing artifacts. A
+              # leg that could not run is NOT-READY — "I could not check" must
+              # never present as "all clear", which is the exact laundering that
+              # kept #5640 invisible.
+              publish_health() {
+                _ph_reason=""
+                if [ "${CHART_LEG_ENABLED}" = "true" ] && [ "${CHART_STATUS}" != "ok" ]; then
+                  _ph_reason="chart-leg-${CHART_STATUS}"
+                fi
+                if [ "${IMAGE_LEG_ENABLED}" = "true" ] && [ "${IMAGE_STATUS}" != "ok" ]; then
+                  _ph_reason="${_ph_reason:+${_ph_reason},}image-leg-${IMAGE_STATUS}"
+                fi
+                if [ "$((CHART_MISS + IMAGE_MISS))" -gt 0 ]; then
+                  _ph_reason="${_ph_reason:+${_ph_reason},}unpullable-pins=$((CHART_MISS + IMAGE_MISS))"
+                fi
+                if [ -n "${_ph_reason}" ]; then
+                  echo "NOTREADY ${_ph_reason}" > "${HEALTH_FILE}"
+                  echo "[daytwo] readiness: NOT-READY (${_ph_reason}) — this Deployment now reports 0/1 READY. On a post-cutover Sovereign that is the visible form of 'this cluster holds a pin its registry cannot serve' (#5640)"
+                else
+                  echo "READY" > "${HEALTH_FILE}"
+                fi
+              }
+
               reconcile_once() {
                 _rc=0
                 CHART_STATUS="disabled"; IMAGE_STATUS="disabled"
                 : > "${MISSING_CHARTS_FILE}"; : > "${MISSING_IMAGES_FILE}"
                 CHART_PINS=0; CHART_PRESENT=0; CHART_WARMED=0; CHART_MISS=0
                 IMAGE_REFS=0; IMAGE_PRESENT=0; IMAGE_WARMED=0; IMAGE_MISS=0
+                REQ_DELIVERED=0; REQ_FAILED=0
+                daytwo_load_request
                 if [ "${CHART_LEG_ENABLED}" = "true" ]; then
                   reconcile_charts_once || _rc=1
                 fi
                 if [ "${IMAGE_LEG_ENABLED}" = "true" ]; then
                   reconcile_images_once || _rc=1
                 fi
+                daytwo_consume_request
+                daytwo_audit_flush
                 publish_manifest
+                publish_health
                 echo "[daytwo] cycle complete: charts(${CHART_STATUS}) missing=${CHART_MISS} | images(${IMAGE_STATUS}) missing=${IMAGE_MISS} (manifest -> ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM})"
                 return "${_rc}"
               }
-
-              # warm-mode one-time upstream + local registry logins for the CHART
-              # leg (best-effort; login failure falls through to per-chart
-              # fail-soft handling). The image leg authenticates per-copy via
-              # skopeo --src-creds/--dest-creds, so it needs no login here.
-              if [ "${RECONCILE_MODE}" = "warm" ]; then
-                export HELM_CACHE_HOME=/tmp/.helm-cache HELM_CONFIG_HOME=/tmp/.helm-config HELM_DATA_HOME=/tmp/.helm-data
-                if [ -n "${WARM_CRED_SECRET_NAME}" ]; then
-                  _wu=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_USERNAME_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
-                  _wp=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_PASSWORD_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
-                  if [ -n "${_wu}" ] && [ -n "${_wp}" ]; then
-                    helm registry login "${WARM_REGISTRY_HOST}" -u "${_wu}" -p "${_wp}" >/dev/null 2>&1 \
-                      && echo "[daytwo] warm: authenticated to upstream ${WARM_REGISTRY_HOST}" \
-                      || echo "[daytwo] warm: upstream ${WARM_REGISTRY_HOST} login failed (anonymous pulls only; private charts stay in the missing manifest)"
-                  else
-                    echo "[daytwo] warm: credential Secret ${WARM_CRED_SECRET_NAMESPACE}/${WARM_CRED_SECRET_NAME} has no usable ${WARM_CRED_USERNAME_KEY}/${WARM_CRED_PASSWORD_KEY} — anonymous pulls only"
-                  fi
-                else
-                  echo "[daytwo] warm: no credentialSecret configured — anonymous pulls only (openova-io charts are PRIVATE; supply daytwoReconciler.warm.credentialSecret to fetch them)"
-                fi
-                helm registry login "${HARBOR_HOST}" -u "${HARBOR_USERNAME}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
-                  && echo "[daytwo] warm: authenticated to local Harbor ${HARBOR_HOST}" \
-                  || echo "[daytwo] warm: local Harbor ${HARBOR_HOST} login failed — pushes will retry per cycle"
-              fi
 
               # The Day-2 loop. Never exit on a transient cycle failure — a wedge
               # in one cycle must not stop the reconciler (region-kill canon: the
@@ -779,6 +1061,22 @@ spec:
                 echo "[daytwo] sleeping ${RECONCILE_INTERVAL_SECONDS}s"
                 sleep "${RECONCILE_INTERVAL_SECONDS}"
               done
+          # #5640 FAIL-CLOSED SURFACE. The loop writes READY into the health file
+          # only when its last cycle MEASURED every pinned chart + image as
+          # servable by the registry this Sovereign is permitted to use. So
+          # `kubectl get deploy cutover-daytwo-harbor-reconciler` reading 0/1 IS
+          # the statement "this Sovereign holds a pin it cannot pull" — a normal,
+          # alertable, non-silent condition instead of a log line and a ConfigMap
+          # nobody was watching. There is deliberately NO livenessProbe: a
+          # Sovereign that is missing an image must go NOT-READY, not restart.
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "grep -qx READY /tmp/daytwo-work/health"]
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 2
           resources:
             requests: { cpu: 25m, memory: 128Mi }
             limits:   { memory: 512Mi }

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3560,11 +3560,18 @@ if ! grep -q 'MISSING_MANIFEST_CM' "$DT_F"; then
   echo "FAIL: Day-2 reconciler does not publish the missing-artifact manifest ConfigMap (the air-gap offline-media list + the actionable signal) (#5265)" >&2
   c70_fail=1
 fi
-# (g) DETECT is the default mode when enabled (the zero-egress posture). Capture
-#     the RECONCILE_MODE env pair to a file (no pipe) then assert its value.
+# (g) The default mode must make ZERO external egress in steady state. #5640
+#     round 2 moved the default from `detect` to `request`, which is detect's
+#     behaviour exactly until an operator files a one-shot delivery request —
+#     so the zero-egress-by-default property is preserved while a delivery path
+#     exists. `warm` (the always-on mirror) must NEVER be the default.
 grep -A1 'name: RECONCILE_MODE' "$DT_F" > "$TMP/dt-mode.txt" || true
-if ! grep -q 'value: "detect"' "$TMP/dt-mode.txt"; then
-  echo "FAIL: Day-2 reconciler default mode is not detect — the zero-egress mode MUST be the default when enabled (#5265)" >&2
+if ! grep -qE 'value: "(detect|request)"' "$TMP/dt-mode.txt"; then
+  echo "FAIL: Day-2 reconciler default mode is neither detect nor request — the default MUST be a mode that makes zero external egress in steady state (#5265 #5640)" >&2
+  c70_fail=1
+fi
+if grep -q 'value: "warm"' "$TMP/dt-mode.txt"; then
+  echo "FAIL: Day-2 reconciler defaults to warm — an ALWAYS-ON upstream mirror is a standing outbound tether and can never be the default posture (#5640 Refs Principle #11)" >&2
   c70_fail=1
 fi
 # (h) WARM mode contains the helm pull upstream + helm push local, gated behind mode=warm.
@@ -3581,14 +3588,97 @@ if ! grep -q 'helm push' "$DT_W"; then
   echo "FAIL: warm mode reconciler does not helm-push local (#5265)" >&2
   c70_fail=1
 fi
-# The warm helm pull/push must be RUNTIME-gated on mode=warm, not always-on
-# (the script branches `if [ "${RECONCILE_MODE}" = "warm" ]`).
-if ! grep -q '"${RECONCILE_MODE}" = "warm"' "$DT_W"; then
-  echo "FAIL: the warm upstream pull is not runtime-gated on mode=warm — detect must never reach upstream (#5265)" >&2
+# Every upstream fetch must be RUNTIME-gated by ONE decision function, so there
+# is a single place where "may this cycle reach upstream" is answered. Before
+# #5640 round 2 each call site carried its own `[ "${RECONCILE_MODE}" = "warm" ]`
+# literal, which is how the operator-gated mode could have been added to one
+# call site and forgotten at another.
+if ! grep -q 'daytwo_delivery_allowed()' "$DT_W"; then
+  echo "FAIL: the Day-2 reconciler has no daytwo_delivery_allowed() gate — every upstream fetch must sit behind ONE decision function, not a per-call-site mode literal (#5640)" >&2
+  c70_fail=1
+fi
+# That function must FAIL CLOSED: only warm and an in-scope request may pass, and
+# any other RECONCILE_MODE value (including a typo) falls through to closed.
+if ! grep -qF 'request) daytwo_in_scope "$1" "$2" "$3" && return 0; return 1 ;;' "$DT_W"; then
+  echo "FAIL: daytwo_delivery_allowed does not require an in-scope request in request mode — the delivery window would not be scope-bounded (#5640)" >&2
+  c70_fail=1
+fi
+if ! grep -qF '*) return 1 ;;' "$DT_W"; then
+  echo "FAIL: daytwo_delivery_allowed has no closed default branch — an unrecognised RECONCILE_MODE would fail OPEN (#5640)" >&2
+  c70_fail=1
+fi
+if ! grep -q 'warm_chart "${_c}" "${_v}"' "$DT_W"; then
+  echo "FAIL: the chart leg no longer routes its upstream pull through warm_chart (#5265)" >&2
+  c70_fail=1
+fi
+# The upstream `helm registry login` is itself egress, so it must be LAZY — never
+# performed at container start, where detect/request would dial upstream before
+# any delivery decision was made.
+if ! grep -q 'daytwo_helm_login_once' "$DT_W"; then
+  echo "FAIL: the upstream helm registry login is not deferred into daytwo_helm_login_once — a start-up login dials upstream before any delivery decision, breaking the zero-egress contract of detect/request (#5640)" >&2
+  c70_fail=1
+fi
+# (i) #5640 round 2 — the operator-gated delivery contract, asserted on the
+#     DEFAULT render (the posture a fresh prov actually gets).
+for c70_env in REQUEST_CM DELIVERY_AUDIT_CM REQUEST_MAX_REFS; do
+  if ! grep -qF "name: ${c70_env}" "$DT_F"; then
+    echo "FAIL: Day-2 reconciler does not project ${c70_env} — the operator-gated delivery path cannot be configured (#5640)" >&2
+    c70_fail=1
+  fi
+done
+# One-shot: consumption is recorded in the AUDIT ConfigMap, so re-applying the
+# same request cannot re-open the window and a Pod restart cannot forget it.
+if ! grep -q 'lastConsumedRequestId' "$DT_F"; then
+  echo "FAIL: the delivery request is not consumed durably (no lastConsumedRequestId) — the same request would re-fire every cycle, which IS the always-on mirror this mode exists to avoid (#5640)" >&2
+  c70_fail=1
+fi
+# Audited: every attempt records who asked, for what, and what happened.
+if ! grep -q 'daytwo_audit ' "$DT_F"; then
+  echo "FAIL: delivery attempts are not written to the durable audit trail (#5640)" >&2
+  c70_fail=1
+fi
+# Bounded: an over-size scope is REFUSED, never truncated.
+if ! grep -qF 'REFUSING rather than truncating' "$DT_F"; then
+  echo "FAIL: an over-size delivery scope is not refused — silent truncation turns a bounded window into an unbounded one nobody notices (#5640)" >&2
+  c70_fail=1
+fi
+# (j) #5640 round 2 — the FAIL-CLOSED readiness surface. A missing pin must be a
+#     visible NOT-READY Deployment, not a log line plus a ConfigMap nobody reads.
+if ! grep -q 'readinessProbe' "$DT_F"; then
+  echo "FAIL: the Day-2 reconciler has no readinessProbe — a Sovereign holding an unpullable pin would stay silently 1/1 READY, which is the #5640 silent freeze restored" >&2
+  c70_fail=1
+fi
+if ! grep -qF 'grep -qx READY /tmp/daytwo-work/health' "$DT_F"; then
+  echo "FAIL: the readinessProbe does not read the health verdict the loop writes — it would report readiness of something other than the measured cycle outcome (#5640)" >&2
+  c70_fail=1
+fi
+if ! grep -qF 'echo "NOTREADY no-cycle-completed-yet" > "${HEALTH_FILE}"' "$DT_F"; then
+  echo "FAIL: the health file is not seeded NOT-READY — before the first cycle the probe would read a missing file rather than an explicit not-ready verdict (#5640)" >&2
+  c70_fail=1
+fi
+if ! grep -qF 'unpullable-pins=$((CHART_MISS + IMAGE_MISS))' "$DT_F"; then
+  echo "FAIL: the readiness verdict is not computed from the MEASURED missing count — a probe that does not read the measurement is a knob, not a gate (#5640)" >&2
+  c70_fail=1
+fi
+# Anchored on the rendered YAML key, not the substring: the template's own
+# comment explains WHY there is no liveness probe and would false-positive here.
+if grep -qE '^[[:space:]]+livenessProbe:' "$DT_F"; then
+  echo "FAIL: the Day-2 reconciler carries a livenessProbe — a Sovereign missing an image must go NOT-READY, never restart-loop (#5640)" >&2
+  c70_fail=1
+fi
+# (k) #5640 round 2 — the copy must INVERT a step-07-pivoted ref before using it
+#     as a source. Without this the delivery path is a local->local self-copy for
+#     the exact hw292 shape and can never deliver anything.
+if ! grep -q 'offlinemirror_upstream_ref' "$DT_W"; then
+  echo "FAIL: the Day-2 image delivery never calls offlinemirror_upstream_ref — post-cutover every enumerated ref is already registry.<fqdn>/... (step-07 podspec sweep), so the copy would ask skopeo to copy the local registry to ITSELF (#5640)" >&2
+  c70_fail=1
+fi
+if ! grep -qF 'source and destination are the SAME registry' "$DT_W"; then
+  echo "FAIL: the Day-2 image delivery has no same-registry refusal — a self-copy would be reported as a copy failure rather than as an unknown upstream (#5640)" >&2
   c70_fail=1
 fi
 if [ "$c70_fail" -ne 0 ]; then exit 1; fi
-echo "  PASS (#5265/#5640: Day-2 local-Harbor reconciler is a Deployment [region-kill canon], PRESENT by default with enabled=false still rendering nothing, reuses the 03b bootstrapkit_pins extractor + the durable artifact-API probe, publishes the offline-media missing manifest, defaults to zero-egress detect mode, and gates the upstream helm-pull/push behind opt-in warm mode; step count unchanged at 11)"
+echo "  PASS (#5265/#5640: Day-2 local-Harbor reconciler is a Deployment [region-kill canon], PRESENT by default with enabled=false still rendering nothing, reuses the 03b bootstrapkit_pins extractor + the durable artifact-API probe, publishes the offline-media missing manifest, defaults to a zero-egress-in-steady-state mode and never to warm, routes EVERY upstream fetch through one fail-closed daytwo_delivery_allowed gate with a lazy upstream login, carries the one-shot/audited/bounded operator-gated delivery contract, inverts a step-07-pivoted ref before copying and refuses a same-registry self-copy, and exposes the measured missing count as a fail-closed readinessProbe with no livenessProbe; step count unchanged at 11)"
 
 echo "[cutover-contract] Case 71: #5359 secondary-region legs — steps 05/06/08 mount the optional cutover-secondary-kubeconfigs Secret and run fail-loud region-B pivot/hold legs; single-region renders inert; step count stays 11"
 # hw288 (dep 027f07559af1f9f7): cc=true with region-B still on github/ghcr/quay
@@ -3961,8 +4051,16 @@ fi
 # (f) SOVEREIGNTY. detect must never download skopeo nor dial upstream: every
 #     egress-bearing call sits behind a mode=warm runtime branch. Assert the
 #     warm-gate is what guards the image copy, not merely present somewhere.
-if ! grep -qF '[ "${RECONCILE_MODE}" = "warm" ] && daytwo_warm_image' "$DT_F"; then
-  echo "FAIL: the Day-2 image copy is not runtime-gated on mode=warm — detect mode would reach upstream and break the zero-egress contract (#5640 Refs #5265)" >&2
+if ! grep -qF 'if daytwo_delivery_allowed "${_img}" "${_upref}" "${_lp}"; then' "$DT_F"; then
+  echo "FAIL: the Day-2 image copy is not runtime-gated by daytwo_delivery_allowed — detect (and request with no open window) would reach upstream and break the zero-egress contract (#5640 Refs #5265)" >&2
+  c75_fail=1
+fi
+# The gate must be REACHED before the copy, i.e. daytwo_warm_image may only ever
+# be called from inside it. A second, ungated call site is how the zero-egress
+# contract would quietly stop holding.
+c75_calls=$(grep -c 'daytwo_warm_image "' "$DT_F" || true)
+if [ "${c75_calls}" -ne 1 ]; then
+  echo "FAIL: daytwo_warm_image is invoked from ${c75_calls} call site(s); exactly ONE is allowed so every copy is behind the single delivery gate (#5640)" >&2
   c75_fail=1
 fi
 if ! grep -qF 'daytwo_ensure_skopeo || return 1' "$DT_F"; then

--- a/platform/self-sovereign-cutover/chart/tests/daytwo-image-leg.sh
+++ b/platform/self-sovereign-cutover/chart/tests/daytwo-image-leg.sh
@@ -20,8 +20,26 @@
 #   S3  the enumeration returns nothing → status is `enumeration-empty` and the
 #       manifest must NOT claim ALL_PINS_PRESENT. A guard that treats a broken
 #       read as an all-clear is the exact shape that let #5640 stay invisible.
-#   S4  detect mode never dials an upstream registry: the stub records every
-#       host curl/skopeo is asked for, and only the local Harbor may appear.
+#   S4  no open delivery request → never dials an upstream registry: the stub
+#       records every host curl/skopeo is asked for, and only the local Harbor
+#       may appear.
+#
+# #5640 round 2 — the operator-gated delivery path and its fail-closed surface:
+#   S5  mode=request with NO request ConfigMap → detect-equivalent. Zero egress,
+#       and the missing set is still reported. This is the DEFAULT posture, so
+#       it is the one that must be proven, not assumed.
+#   S6  mode=request with an in-scope request → the copy fires for the named ref
+#       and NOT for the ref the request omits. The omitted ref is the CONTROL:
+#       without it, "delivery happened" would not prove delivery was BOUNDED.
+#   S7  a step-07-PIVOTED ref (registry.<fqdn>/openova-io/...) — the only shape
+#       the hw292 defect appears in post-cutover — must be copied FROM ghcr.io,
+#       never from the local registry. Before the inverse map this was a
+#       local→local self-copy that could not deliver anything, ever.
+#   S8  a request whose id was already consumed → zero egress. One-shot means
+#       the window closes; re-applying the same request must not re-open it.
+#   S9  the fail-closed readiness verdict: NOT-READY with a missing pin,
+#       NOT-READY on a broken enumeration, READY only when the cycle MEASURED
+#       everything present. Both directions, or it is not known to be a gate.
 #
 # Usage: bash tests/daytwo-image-leg.sh [CHART_DIR]
 set -euo pipefail
@@ -69,7 +87,8 @@ grep -q '^HOST_PROJECT_MAP=' "$TMP/env.txt" || fail "render does not project HOS
 # ── Stubs ─────────────────────────────────────────────────────────────────────
 mkdir -p "$TMP/bin"
 
-# kubectl: workload enumeration + the manifest ConfigMap write.
+# kubectl: workload enumeration, the delivery-request read, the consumed-id read
+# and the ConfigMap writes.
 cat > "$TMP/bin/kubectl" <<'KSTUB'
 #!/usr/bin/env bash
 args="$*"
@@ -78,6 +97,14 @@ case "$args" in
   *"get pods -A"*)                             echo '{"items":[]}' ;;
   *"get cronjobs"*)                            echo '{"items":[]}' ;;
   *"get jobs"*)                                echo '{"items":[]}' ;;
+  # The operator's delivery request. Absent file => the ConfigMap does not
+  # exist, which is the DEFAULT posture (no request filed).
+  *"get configmap self-sovereign-cutover-daytwo-request"*)
+      [ -s "${STUB_REQUEST_JSON:-/nonexistent}" ] || exit 1
+      cat "${STUB_REQUEST_JSON}" ;;
+  # Durable one-shot state + prior audit trail.
+  *"lastConsumedRequestId"*)                   printf '%s' "${STUB_CONSUMED_ID:-}" ;;
+  *"get configmap self-sovereign-cutover-daytwo-delivery"*) printf '' ;;
   *"create configmap"*)                        echo 'apiVersion: v1'; echo 'kind: ConfigMap' ;;
   *"apply -f -"*)                              cat > /dev/null ;;
   *)                                           exit 0 ;;
@@ -100,14 +127,26 @@ fi
 CSTUB
 chmod +x "$TMP/bin/curl"
 
-# skopeo / nslookup: presence-only witnesses. detect mode must never invoke skopeo.
+# skopeo / nslookup: witnesses. A mode with no open delivery window must never
+# invoke skopeo at all; when it IS invoked, the recorded argv is what proves
+# WHICH source the copy was pointed at (the S7 assertion).
 cat > "$TMP/bin/skopeo" <<'SSTUB'
 #!/usr/bin/env bash
 echo "SKOPEO_INVOKED $*" >> "${STUB_CURL_LOG}"
-exit 1
+exit "${STUB_SKOPEO_RC:-1}"
 SSTUB
 chmod +x "$TMP/bin/skopeo"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/nslookup"; chmod +x "$TMP/bin/nslookup"
+# The rendered script sleeps between probe retries and copy attempts. Those
+# sleeps are real behaviour but pure latency here, and 12 scenarios' worth of
+# them turns a 20-second gate into a multi-minute one nobody runs. Stub it.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/sleep"; chmod +x "$TMP/bin/sleep"
+
+# The local registry host is a RENDER value (registry.<fqdn>); the pivoted-ref
+# scenarios must use the SAME one the resolver was given, or every pivoted ref
+# reads as an UNMAPPED foreign host and the inverse map is never exercised.
+LOCALREG=$(sed -n 's/^LOCAL_REGISTRY_HOST=//p' "$TMP/env.txt")
+[ -n "${LOCALREG}" ] || fail "render does not project LOCAL_REGISTRY_HOST — the pivoted-ref scenarios cannot be built"
 
 # Two declared images: catalyst-ui on the tag deployed at cutover (present) and
 # on the tag deploy-bot pinned afterwards (missing) — the hw292 pair verbatim.
@@ -122,6 +161,11 @@ cat > "$TMP/declared-empty.json" <<'JSON'
 {"items":[]}
 JSON
 
+RUN_EXTRA_ENV=""       # shell lines appended AFTER the render env (per-scenario)
+STUB_REQUEST_JSON=""   # the operator's delivery request, or "" for none
+STUB_CONSUMED_ID=""    # durable one-shot state
+STUB_SKOPEO_RC=1       # copy outcome the skopeo stub reports
+
 run_leg() {   # run_leg <declared-json> <present-regex> -> writes $TMP/out.txt
   : > "$TMP/curl.log"
   {
@@ -129,14 +173,35 @@ run_leg() {   # run_leg <declared-json> <present-regex> -> writes $TMP/out.txt
     while IFS= read -r line; do printf 'export %q\n' "$line"; done < "$TMP/env.txt"
     # Secret-backed env has no .value in the render; supply harness values.
     echo 'export HARBOR_USERNAME=admin HARBOR_PASSWORD=stub GHCR_DOCKERCONFIG='
+    [ -n "${RUN_EXTRA_ENV}" ] && printf '%s\n' "${RUN_EXTRA_ENV}"
     cat "$TMP/script.sh"
+    # The real loop runs these in this order inside reconcile_once; the harness
+    # reproduces that order so request handling, delivery and the readiness
+    # verdict are exercised exactly as they run in the cluster.
+    echo 'daytwo_load_request'
     echo 'reconcile_images_once'
     echo 'echo "RESULT status=${IMAGE_STATUS} refs=${IMAGE_REFS} present=${IMAGE_PRESENT} warmed=${IMAGE_WARMED} missing=${IMAGE_MISS}"'
     echo 'echo "---MISSING---"; cat "${MISSING_IMAGES_FILE}" 2>/dev/null'
     echo 'echo "---MANIFEST---"; publish_manifest; cat "${WORK}/manifest.txt"'
+    echo 'daytwo_consume_request'
+    echo 'publish_health'
+    echo 'echo "---HEALTH---"; cat "${HEALTH_FILE}"'
+    echo 'echo "---AUDIT---"; cat "${WORK}/audit-all.log" 2>/dev/null'
+    echo 'exit 0'
   } > "$TMP/harness.sh"
   STUB_DECLARED="$1" STUB_PRESENT_RE="$2" STUB_CURL_LOG="$TMP/curl.log" \
-    PATH="$TMP/bin:$PATH" sh "$TMP/harness.sh" > "$TMP/out.txt" 2>&1
+    STUB_REQUEST_JSON="${STUB_REQUEST_JSON}" STUB_CONSUMED_ID="${STUB_CONSUMED_ID}" \
+    STUB_SKOPEO_RC="${STUB_SKOPEO_RC}" \
+    PATH="$TMP/bin:$PATH" sh "$TMP/harness.sh" > "$TMP/out.txt" 2>&1 || true
+}
+
+# request_cm <requestId> <scope-lines> -> writes a request ConfigMap JSON and
+# points the stub at it.
+request_cm() {
+  jq -n --arg id "$1" --arg scope "$2" \
+    '{data:{requestId:$id, requestedBy:"ops@customer.example", scope:$scope}}' \
+    > "$TMP/request.json"
+  STUB_REQUEST_JSON="$TMP/request.json"
 }
 
 # ── S1: one present, one missing ──────────────────────────────────────────────
@@ -168,19 +233,156 @@ grep -q 'ALL_PINS_PRESENT' "$TMP/out.txt" \
   && fail "S3 published ALL_PINS_PRESENT on a ZERO-ref enumeration — a broken read laundered into an all-clear (#5640)"
 echo "  PASS (status=enumeration-empty, no all-clear published)"
 
-# ── S4: detect mode reaches only the local Harbor ─────────────────────────────
-echo "[daytwo-image-leg] S4: detect mode must not dial any upstream registry"
+# ── S4: no open delivery window reaches only the local Harbor ─────────────────
+echo "[daytwo-image-leg] S4: with no open delivery request, nothing may dial an upstream registry"
 run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
 if grep -q 'SKOPEO_INVOKED' "$TMP/curl.log"; then
-  fail "S4 detect mode invoked skopeo — the zero-external-egress contract is broken (#5640 Refs #5265)"
+  fail "S4 invoked skopeo with no delivery window open — the zero-external-egress contract is broken (#5640 Refs #5265)"
 fi
 offhost=$(grep -Ev '^https?://registry\.' "$TMP/curl.log" | grep -E '^https?://' || true)
 if [ -n "${offhost}" ]; then
   printf '%s\n' "${offhost}" | sed 's/^/    /'
-  fail "S4 detect mode dialled a non-local host — every URL must be the local Harbor"
+  fail "S4 dialled a non-local host — every URL must be the local Harbor"
 fi
 probes=$(grep -c '^https\?://' "$TMP/curl.log" || true)
 [ "${probes}" -ge 4 ] || fail "S4 vacuity control — only ${probes} URL(s) recorded; the leg did not actually probe, so 'no upstream' is meaningless"
 echo "  PASS (${probes} probes, all against the local Harbor; skopeo never invoked)"
+
+# ── S5: the DEFAULT posture (mode=request, no request filed) is zero-egress ────
+# The render already carries the shipped default, so this asserts the posture a
+# fresh prov actually gets rather than a mode the test itself selected.
+echo "[daytwo-image-leg] S5: shipped default mode with NO delivery request — detect-equivalent"
+shipped_mode=$(sed -n 's/^RECONCILE_MODE=//p' "$TMP/env.txt")
+[ "${shipped_mode}" = "request" ] || fail "S5 expected the shipped default mode to be request, got '${shipped_mode}' — the rest of the #5640 delivery contract is not what ships"
+STUB_REQUEST_JSON=""; STUB_CONSUMED_ID=""
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+grep -q 'no delivery request' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S5 did not report the absent request — the operator gets no statement of the current posture"; }
+grep -q 'SKOPEO_INVOKED' "$TMP/curl.log" \
+  && fail "S5 mode=request made an upstream copy with NO request filed — the default posture is not zero-egress (#5640)"
+grep -q 'RESULT status=ok refs=4 present=0 warmed=0 missing=4' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S5 stopped DETECTING while gating delivery — request mode must keep detect's full reporting"; }
+echo "  PASS (zero egress, full missing set still reported)"
+
+# ── S6: an in-scope request delivers exactly its scope ────────────────────────
+# CONTROL: catalyst-ui:fad88bd is missing too but is NOT named by the request.
+# Without that control, "a copy happened" would not prove the window is BOUNDED.
+echo "[daytwo-image-leg] S6: an open request delivers ONLY the refs it names"
+request_cm "req-2026-08-04-a" "ghcr.io/openova-io/openova/catalyst-ui:d674a94"
+STUB_CONSUMED_ID=""
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+grep -q 'delivery window OPEN' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S6 did not open the delivery window for a valid request"; }
+grep -q 'SKOPEO_INVOKED.*d674a94' "$TMP/curl.log" \
+  || { sed 's/^/    /' "$TMP/curl.log"; fail "S6 never attempted the copy the request named — the delivery path is inert"; }
+grep -q 'SKOPEO_INVOKED.*fad88bd' "$TMP/curl.log" \
+  && { sed 's/^/    /' "$TMP/curl.log"; fail "S6 copied a ref the request did NOT name — the window is not scope-bounded, which makes it an always-on mirror with extra steps (#5640)"; }
+grep -q 'CONSUMED' "$TMP/out.txt" \
+  || fail "S6 did not consume the requestId — the window would stay open every cycle"
+grep -q 'REQUEST.*consumed.*req-2026-08-04-a' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S6 wrote no audit record for the consumed request — delivery is unaudited"; }
+echo "  PASS (named ref copied, unnamed control ref untouched, request consumed + audited)"
+
+# ── S7: a step-07 PIVOTED ref must be copied FROM ghcr.io, not from itself ────
+# This is the ONLY shape the hw292 defect takes post-cutover, because step-07's
+# pod-spec sweep has already rewritten every workload image to the local
+# registry. A copy that uses that ref as its SOURCE is a local->local self-copy
+# of an artifact the local registry has just 404'd: it can never deliver.
+echo "[daytwo-image-leg] S7: a pivoted registry.<fqdn>/... ref is inverse-mapped to its upstream before copying"
+jq -n --arg img "${LOCALREG}/openova-io/openova/catalyst-api:e3342f9" \
+  '{items:[{spec:{template:{spec:{containers:[{image:$img}]}}}}]}' > "$TMP/declared-pivoted.json"
+request_cm "req-2026-08-04-b" "ALL_MISSING"
+STUB_CONSUMED_ID=""
+run_leg "$TMP/declared-pivoted.json" 'MATCHES_NOTHING_XyZ'
+grep -q 'inverse-mapped upstream = ghcr.io/openova-io/openova/catalyst-api:e3342f9' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S7 did not inverse-map the pivoted ref to its ghcr.io upstream (#5640)"; }
+src=$(grep -o 'docker://[^ ]*' "$TMP/curl.log" | head -1 || true)
+[ "${src}" = "docker://ghcr.io/openova-io/openova/catalyst-api:e3342f9" ] \
+  || { sed 's/^/    /' "$TMP/curl.log"; fail "S7 copy SOURCE was '${src}', not the inverse-mapped ghcr.io upstream — a local->local self-copy can never deliver (#5640)"; }
+grep -q "SKOPEO_INVOKED.*docker://${LOCALREG}[^ ]* docker://${LOCALREG}" "$TMP/curl.log" \
+  && { sed 's/^/    /' "$TMP/curl.log"; fail "S7 asked skopeo to copy the local registry to ITSELF — the exact no-op #5640 round 2 exists to prevent"; }
+echo "  PASS (source inverted to ghcr.io; no self-copy)"
+
+# ── S7b: an un-invertible local ref is REFUSED, not attempted ─────────────────
+echo "[daytwo-image-leg] S7b: a local ref the map cannot invert is refused, never attempted"
+jq -n --arg img "${LOCALREG}/some-unmapped-project/thing:v1" \
+  '{items:[{spec:{template:{spec:{containers:[{image:$img}]}}}}]}' > "$TMP/declared-uninvertible.json"
+request_cm "req-2026-08-04-c" "ALL_MISSING"
+STUB_CONSUMED_ID=""
+run_leg "$TMP/declared-uninvertible.json" 'MATCHES_NOTHING_XyZ'
+grep -q 'REFUSED' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S7b did not refuse an un-invertible local ref — it would self-copy and report a copy failure instead of an unknown upstream"; }
+grep -q 'SKOPEO_INVOKED' "$TMP/curl.log" \
+  && { sed 's/^/    /' "$TMP/curl.log"; fail "S7b invoked skopeo on a ref whose upstream is unknown (#5640)"; }
+echo "  PASS (refused before any copy attempt)"
+
+# ── S8: one-shot — an already-consumed requestId must not re-open the window ──
+echo "[daytwo-image-leg] S8: re-applying a consumed requestId delivers nothing"
+request_cm "req-2026-08-04-a" "ALL_MISSING"
+STUB_CONSUMED_ID="req-2026-08-04-a"
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+grep -q 'already consumed' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S8 did not recognise the consumed requestId"; }
+grep -q 'SKOPEO_INVOKED' "$TMP/curl.log" \
+  && fail "S8 re-delivered on a consumed requestId — the window never closes, which is the always-on mirror this mode exists to avoid (#5640)"
+echo "  PASS (window stayed closed; zero egress)"
+
+# ── S8b: a request with no requestId is refused (it could never be consumed) ──
+echo "[daytwo-image-leg] S8b: a request without a requestId is refused"
+jq -n '{data:{scope:"ALL_MISSING"}}' > "$TMP/request.json"
+STUB_REQUEST_JSON="$TMP/request.json"; STUB_CONSUMED_ID=""
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+grep -q 'carries no requestId' "$TMP/out.txt" \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S8b accepted an identity-less request — it would re-fire every cycle forever"; }
+grep -q 'SKOPEO_INVOKED' "$TMP/curl.log" \
+  && fail "S8b delivered on a request that can never be consumed (#5640)"
+echo "  PASS (refused; zero egress)"
+
+# ── S8c: an UNRECOGNISED mode must fail CLOSED ───────────────────────────────
+# Found by mutating daytwo_delivery_allowed's default branch to `return 0` and
+# watching every gate stay green: the shipped modes all match a named branch, so
+# nothing exercised the fallthrough. A typo in daytwoReconciler.mode would have
+# silently decided whether the Sovereign egresses. It is a guard only once
+# something drives it.
+echo "[daytwo-image-leg] S8c: an unrecognised RECONCILE_MODE delivers nothing"
+request_cm "req-2026-08-04-d" "ALL_MISSING"
+STUB_CONSUMED_ID=""
+RUN_EXTRA_ENV='export RECONCILE_MODE=warmm'
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+RUN_EXTRA_ENV=""
+grep -q 'SKOPEO_INVOKED' "$TMP/curl.log" \
+  && { sed 's/^/    /' "$TMP/curl.log"; fail "S8c an unrecognised mode reached upstream — daytwo_delivery_allowed failed OPEN, so a typo in daytwoReconciler.mode decides whether this Sovereign egresses (#5640)"; }
+echo "  PASS (unrecognised mode made zero external egress)"
+
+# ── S9: the fail-closed readiness verdict, in BOTH directions ────────────────
+# A guard only ever observed passing is not yet known to be a guard, and one
+# only ever observed failing may simply be broken. Both directions, same run.
+echo "[daytwo-image-leg] S9: readiness is NOT-READY on a missing pin and READY only when the cycle measured everything present"
+STUB_REQUEST_JSON=""; STUB_CONSUMED_ID=""
+RUN_EXTRA_ENV='export CHART_LEG_ENABLED=false'   # isolate the image leg's verdict
+
+run_leg "$TMP/declared.json" 'MATCHES_NOTHING_XyZ'
+health=$(sed -n '/^---HEALTH---$/,$p' "$TMP/out.txt" | sed -n '2p')
+case "${health}" in
+  NOTREADY*unpullable-pins=4*) : ;;
+  *) sed 's/^/    /' "$TMP/out.txt"; fail "S9 direction A: 4 missing images produced health '${health}', expected NOTREADY with the measured count — a Sovereign holding unpullable pins would stay silently READY (#5640)" ;;
+esac
+echo "  A: 4 missing -> '${health}'"
+
+run_leg "$TMP/declared.json" 'manifests/'      # every probe answers present
+health=$(sed -n '/^---HEALTH---$/,$p' "$TMP/out.txt" | sed -n '2p')
+[ "${health}" = "READY" ] \
+  || { sed 's/^/    /' "$TMP/out.txt"; fail "S9 direction B: with every image present the verdict was '${health}', not READY — a probe that never passes is not a gate, it is an outage"; }
+echo "  B: 0 missing -> '${health}'"
+
+run_leg "$TMP/declared-empty.json" 'manifests/'
+health=$(sed -n '/^---HEALTH---$/,$p' "$TMP/out.txt" | sed -n '2p')
+case "${health}" in
+  NOTREADY*image-leg-enumeration-empty*) : ;;
+  *) sed 's/^/    /' "$TMP/out.txt"; fail "S9 direction C: a BROKEN enumeration produced health '${health}', expected NOTREADY — 'I could not check' must never present as all-clear (#5640)" ;;
+esac
+echo "  C: broken enumeration -> '${health}'"
+RUN_EXTRA_ENV=""
+echo "  PASS (NOT-READY on a missing pin, READY on a clean measured cycle, NOT-READY on a broken read)"
 
 echo "[daytwo-image-leg] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2050,22 +2050,70 @@ daytwoReconciler:
   # Reconcile loop interval (seconds). 300 = 5 min, matching the mirrorResync
   # cadence so a Git pin bump and its Harbor artifact land in the same window.
   intervalSeconds: 300
-  # detect | warm.
-  #   detect (DEFAULT when enabled) — reaches ONLY the local Gitea mirror +
-  #     local Harbor (ZERO external egress). Reports the exact pinned
-  #     (chart, version) artifacts MISSING from local Harbor to the manifest
+  # detect | request | warm.
+  #
+  #   detect — reaches ONLY the local Gitea mirror + local Harbor (ZERO
+  #     external egress). Reports the exact pinned (chart, version) artifacts
+  #     and declared IMAGE refs MISSING from local Harbor to the manifest
   #     ConfigMap + logs. That set IS the air-gapped Sovereign's offline-media
   #     side-load list, and it turns the previously-SILENT strand into a
-  #     visible, actionable signal.
-  #   warm — additionally `helm pull`s each missing chart from
-  #     warm.upstreamOciPrefix (operator credential) and `helm push`es it into
-  #     local Harbor, and `skopeo copy`s each missing IMAGE from its recorded
-  #     upstream into local Harbor, then re-checks. Only this mode reaches
-  #     upstream, and only on the operator's schedule (the exact companion of
-  #     the Git mirror reaching github.com on that schedule). Fail-SOFT: a warm
-  #     miss is logged + left in the manifest; the loop never crash-loops and
-  #     workloads keep running on the installed version.
-  mode: detect
+  #     visible, actionable signal. It delivers NOTHING.
+  #
+  #   request (DEFAULT, #5640) — detect's behaviour EXACTLY, plus a delivery
+  #     path the operator opens deliberately, one request at a time. With no
+  #     request present the mode is byte-for-byte detect: no upstream host is
+  #     dialled, skopeo is never downloaded, the step-08 deny-egress proof and
+  #     the no-automatic-tether contract are untouched. It is therefore a safe
+  #     DEFAULT in a way `warm` is not — and it means an operator who needs one
+  #     stale image does NOT have to edit the chart, roll the reconciler, and
+  #     remember to turn it off again.
+  #
+  #     To deliver, the operator creates ONE ConfigMap naming the exact refs:
+  #
+  #       kubectl -n <release-ns> create configmap \
+  #         self-sovereign-cutover-daytwo-request \
+  #         --from-literal=requestId=2026-08-04-catalyst-api-leak-fix \
+  #         --from-literal=requestedBy=ops@customer.example \
+  #         --from-literal=scope='ghcr.io/openova-io/openova/catalyst-api:e3342f9'
+  #
+  #     The loop consumes that requestId ONCE — scope-bounded (only the listed
+  #     refs, capped at request.maxRefsPerRequest), audited (every attempt is
+  #     appended to the delivery ConfigMap with timestamp, requestId,
+  #     requestedBy, source, destination and outcome), and then CLOSED: the
+  #     same requestId never fires again, so the egress window does not stay
+  #     open because someone forgot. `scope=ALL_MISSING` delivers the whole
+  #     current missing set for operators who want that, and is still one-shot.
+  #
+  #   warm — an ALWAYS-ON managed-update posture: every cycle, forever,
+  #     unbounded in scope, with a standing credential. It is a legitimate
+  #     choice for an operator who has decided to track upstream continuously,
+  #     but be clear-eyed that it IS a standing outbound tether and is NOT the
+  #     sovereignty-preserving option. Prefer `request` unless you specifically
+  #     want continuous tracking.
+  #
+  # Both delivery modes are fail-SOFT: a failed fetch is logged + left in the
+  # missing manifest; the loop never crash-loops and workloads keep running on
+  # the installed version.
+  mode: request
+  # #5640 — the operator-gated delivery request (mode=request only).
+  request:
+    # ConfigMap the operator creates to open ONE delivery window. Absent =>
+    # zero egress. Keys: requestId (required, the one-shot key), requestedBy
+    # (recorded in the audit trail), scope (newline-separated refs, or the
+    # literal ALL_MISSING).
+    configMapName: "self-sovereign-cutover-daytwo-request"
+    # Durable append-only audit + one-shot state. `state` carries the last
+    # consumed requestId (so consumption survives a Pod restart); `audit.log`
+    # carries the per-ref outcome lines. Never deleted by the loop.
+    auditConfigMapName: "self-sovereign-cutover-daytwo-delivery"
+    # Upper bound on refs ONE request may deliver. A scope this size is an
+    # operator mistake, not an intent; the request is refused rather than
+    # silently truncated (truncation is how a bounded window becomes an
+    # unbounded one nobody notices).
+    maxRefsPerRequest: 50
+    # Audit lines retained in the ConfigMap (it is capped at 1 MiB by the
+    # apiserver). Oldest lines roll off; the Pod log keeps the full history.
+    auditMaxLines: 500
   # Durable ConfigMap (release namespace) the loop writes the missing-artifact
   # manifest into each cycle. An empty manifest (ALL_PINS_PRESENT) is the
   # all-clear. Air-gapped operators consume this as the offline-media manifest.
@@ -2103,12 +2151,20 @@ daytwoReconciler:
     upstreamOciPrefix: "oci://ghcr.io/openova-io"
     # Bare host of upstreamOciPrefix — the `helm registry login` target.
     registryHost: "ghcr.io"
-    # OPERATOR-SUPPLIED upstream credential for warm mode. The cutover strips
-    # its own ghcr auth from ghcr-pull (step-06 mothershipAuthsToStrip, by
-    # design), so warm mode needs a credential the operator provisions when they
-    # choose a managed-update posture. Empty name => anonymous pulls only
-    # (openova-io charts are PRIVATE, so they stay in the missing manifest until
-    # a credential is supplied or the operator side-loads via the manifest).
+    # OPERATOR-SUPPLIED upstream credential for the delivery modes (request and
+    # warm). The cutover strips its own ghcr auth from ghcr-pull (step-06
+    # mothershipAuthsToStrip lists ghcr.io / harbor.openova.io / xpkg.upbound.io,
+    # by design), so on a cutover Sovereign there is NO inherited credential and
+    # NO path for one to appear without the operator provisioning it. That is
+    # the intended shape: delivery is credential-scoped to something the
+    # operator owns, chose to create, and can revoke by deleting this Secret.
+    # Empty name => anonymous pulls only (openova-io packages are PRIVATE, so
+    # they stay in the missing manifest until a credential is supplied or the
+    # operator side-loads via that manifest).
+    # The credential applies to warm.registryHost — it is NOT hard-wired to
+    # ghcr.io, so an operator mirroring the catalog into their OWN registry
+    # points registryHost + upstreamOciPrefix there and this Secret authenticates
+    # BOTH the chart leg and the image leg against it.
     credentialSecret:
       name: ""
       # Defaults to the release namespace when empty (the reconciler Pod's own

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.164",
+      "version": "0.1.165",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.164",
+    "version": "0.1.165",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.164"
+  version: "0.1.165"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.164"
+    version: "0.1.165"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What #5644 left open

PR #5644 is merged and is not re-implemented here. This closes the gap it leaves. Three findings, all read out of the shipped `0.1.164` template rather than inferred from the issue text.

### Finding 1 — the delivery path could not deliver the defect it was built for

`platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml` runs `sweep_workload_podspec_images` → `sweep_one_workload` → `podspec_pivot_ref`, which rewrites **every** workload container/initContainer image to `registry.<fqdn>/<local-path>`. So on a cutover Sovereign, the refs the Day-2 loop enumerates off the live cluster no longer carry an upstream host at all — and that is the **only** shape the hw292 defect appears in.

`0.1.164`'s `daytwo_warm_image` opened with `_wi_up=$(offlinemirror_normalize_ref "$1")` and used that as the copy **source**. For a pivoted ref that is `skopeo copy docker://registry.<fqdn>/X docker://registry.<fqdn>/X` — the local registry to itself, for an artifact the local registry had just 404'd. It could never have delivered anything, and it would have surfaced as "copy failed after 3 attempts" rather than "I do not know where this came from".

**Fix:** `offlinemirror_upstream_ref` added to the **shared** 03a resolver — the exact inverse of `offlinemirror_local_paths`, in the same file, so the two cannot drift. `registry.<fqdn>/openova-io/openova/catalyst-api:e3342f9` → `ghcr.io/openova-io/openova/catalyst-api:e3342f9`; `registry.<fqdn>/proxy-dockerhub/library/redis:7` → `docker.io/library/redis:7`. A mothership host-swapped path inverts to the **origin** host (which is also the source #5095's DIRECT fallback prefers), so no separate branch is needed. When the map cannot name an upstream the copy is **refused**, not guessed, plus a belt-and-braces same-registry refusal.

### Finding 2 — `warm` is a standing tether, so it is the wrong thing to reach for

Honest description of what the two shipped modes do:

| | detect (was default) | warm |
|---|---|---|
| upstream egress | none | every cycle, forever |
| scope | n/a | every pin, unbounded |
| credential | n/a | standing |
| record | ConfigMap + rotating pod log | rotating pod log |
| delivers | **nothing** | yes |

Confirmed on the credential question: step-06 `harbor.mothershipAuthsToStrip` strips `ghcr.io`, `harbor.openova.io` and `xpkg.upbound.io` from `flux-system/ghcr-pull`, and `daytwoReconciler.warm.credentialSecret.name` defaults to `""`. **There is no path for a warm credential to exist on a cutover Sovereign without an operator provisioning one**, and `openova-io` packages are private so anonymous warm cannot deliver them. That is correct and deliberate — but it means the delivery half was gated on an operator action either way, while the *mode* that used it was an always-on mirror.

**New `mode: request`, and it is now the default.** With no request filed it is byte-for-byte detect: no upstream host dialled, skopeo never downloaded, and the upstream `helm registry login` moved out of container start-up into a lazy `daytwo_helm_login_once` so even *that* cannot fire. To deliver, the operator creates one ConfigMap:

    kubectl -n <release-ns> create configmap self-sovereign-cutover-daytwo-request \
      --from-literal=requestId=2026-08-04-catalyst-api-leak-fix \
      --from-literal=requestedBy=ops@customer.example \
      --from-literal=scope='ghcr.io/openova-io/openova/catalyst-api:e3342f9'

- **initiated** — nothing happens without that object.
- **bounded** — only the refs it names (or `ALL_MISSING`), capped at `request.maxRefsPerRequest`; an over-size scope is **refused, never truncated**, because silent truncation is how a bounded window becomes an unbounded one nobody notices.
- **credential-scoped** — the credential can only be one the operator provisioned and can revoke by deleting the Secret.
- **audited** — every attempt appends timestamp / requestId / requestedBy / source / destination / outcome to a durable ConfigMap.
- **one-shot** — the consumed `requestId` is recorded in the *audit* ConfigMap, so it survives a Pod restart and re-applying the same request does **not** re-open the window. A new window needs a new `requestId`.

**Why this does not re-tether a sovereign Sovereign.** The steady state is provably zero-egress (S5/S8/S8b/S8c below), so the step-08 deny-egress proof and the ADR-0002 no-automatic-tether contract are untouched. Egress exists only inside a window the operator opened, for artifacts the operator named, with a credential the operator owns, and it closes itself. That is the same shape as the Git mirror reaching github.com on the operator's schedule — except revocable and auditable. `warm` is **kept**, and values.yaml now says plainly that it is a standing outbound tether and not the sovereignty-preserving option.

I want to be explicit that this is operator-gated by conclusion, not by convenience: a Sovereign that pulls new images automatically is one the mothership can push code into, which is the inverse of Pillar 5. There is no correct fully-automatic version.

### Finding 3 — the missing set was still a silent freeze

`0.1.164` wrote the missing set to a ConfigMap and to logs. Nothing turned it into a failing condition, so the operator still finds out when a UAT row will not go green.

The loop now writes a readiness verdict **from the measured cycle outcome** and the container carries a `readinessProbe` on it. `READY` requires every enabled leg to have completed *and* zero missing artifacts; a leg that could not run is `NOTREADY`, so "I could not check" can never present as all-clear. `kubectl get deploy cutover-daytwo-harbor-reconciler` reading `0/1` **is** the statement "this Sovereign holds a pin its registry cannot serve". Deliberately **no** `livenessProbe` — the correct response to a missing image is not-ready, never a restart loop. The health file is seeded `NOTREADY no-cycle-completed-yet` so the pre-first-cycle state fails closed.

### Also fixed

`daytwo_load_creds` gated the operator credential on `&& [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]`, and `daytwo_src_creds_for` only knew `ghcr.io` and `${MOTHERSHIP_HOST}`. An operator who mirrors the catalog into their own registry — the posture values.yaml explicitly documents — had their credential **silently ignored**, and every private ref fell back to anonymous, which reads as "the image is missing". Now bound to `warm.registryHost`.

---

## Diff summary

| File | Change |
|---|---|
| `templates/03a-offline-mirror-resolver.yaml` | `+59` — `offlinemirror_upstream_ref`, the inverse map |
| `templates/12-daytwo-harbor-pin-reconciler.yaml` | `+400` — request lifecycle, audit trail, source inversion, same-registry refusal, lazy login, credential fix, readiness verdict + probe |
| `values.yaml` | `mode: request` default + `request.*` block + honest `warm` docs |
| `tests/daytwo-image-leg.sh` | 4 → **12** executing scenarios (14 rendered-script runs) |
| `tests/cutover-contract.sh` | Case 70 + Case 75 re-keyed to the single delivery gate; 14 new assertions |
| 6 lockstep sites | `bp-self-sovereign-cutover` 0.1.164 → **0.1.165** |

`catalog.generated.ts` was regenerated by `node scripts/build-catalog.mjs` from `products/catalyst/bootstrap/ui/`, never hand-edited.

No RBAC change (the runner ClusterRole already grants configmaps `create` + `get/list/watch` + `update/patch`). Step count unchanged at **11**. **Zero NodePorts** — the diff adds no Service of any kind.

---

## Vacuity — both directions

A guard only ever observed passing is not yet known to be a guard. Eleven deliberate mutations of the fix itself, each run against the gates, then restored and re-run.

### Direction 1 — every guard goes RED when its subject is broken

| # | Mutation | Gate | Result |
|---|---|---|---|
| M1 | neuter the inverse map, keep the same-registry refusal | daytwo-image-leg | **exit 1** — `S7 did not inverse-map the pivoted ref to its ghcr.io upstream` |
| M2 | neuter inverse map **and** refusal (= shipped 0.1.164 behaviour) | daytwo-image-leg | **exit 1** — same, i.e. the new gate catches the defect that shipped |
| M3 | `daytwo_delivery_allowed` default branch fails OPEN | daytwo-image-leg | **exit 1** — `S8c an unrecognised mode reached upstream` |
| M4 | `daytwo_in_scope` always answers yes | daytwo-image-leg | **exit 1** — `S6 copied a ref the request did NOT name` |
| M5 | one-shot consumption ignored | daytwo-image-leg | **exit 1** — `S8 did not recognise the consumed requestId` |
| M6 | readiness verdict always READY | daytwo-image-leg | **exit 1** — `S9 direction A: 4 missing images produced health 'READY'` |
| M7 | broken enumeration no longer contributes to the verdict | daytwo-image-leg | **exit 1** — `S9 direction C: a BROKEN enumeration produced health 'READY'` |
| M8 | remove `offlinemirror_upstream_ref` from the shared 03a resolver | daytwo-image-leg | **exit 1** — `S7 did not inverse-map the pivoted ref` |
| M9 | delete the `readinessProbe` block | cutover-contract | **exit 1** — `the Day-2 reconciler has no readinessProbe` |
| M10 | default the chart to `warm` | cutover-contract | **exit 1** — `Day-2 reconciler defaults to warm` |
| M11 | add a second, ungated `daytwo_warm_image` call site | cutover-contract | **exit 1** — `daytwo_warm_image is invoked from 2 call site(s); exactly ONE is allowed` |

**M3 was initially VACUOUS and that is the most useful thing this harness produced.** The first run of M3 left every gate green: all shipped modes match a named `case` branch, so nothing ever drove the fail-closed fallthrough — a typo in `daytwoReconciler.mode` would have silently decided whether the Sovereign egresses, and the contract test's assertion on the literal `*) return 1 ;;` proved only that the text was present. Scenario **S8c** was added to drive it, and M3 then went red. That gap would not have been visible from a passing test run.

### Direction 2 — restored, green again, byte-identical

    sha256 template : de86c7da458af712519b3a80c05d2d2cd207ceb34164880e0977cbaf763db875  (baseline de86c7da458af712519b3a80c05d2d2cd207ceb34164880e0977cbaf763db875)
    sha256 resolver : 0de8de9846db6854057d3f0114ee620e1118419bcfd6dbf518eaea65c5913b4f  (baseline 0de8de9846db6854057d3f0114ee620e1118419bcfd6dbf518eaea65c5913b4f)
    daytwo-image-leg  exit=0
    cutover-contract  exit=0

The readiness gate specifically is walked in **both** directions inside one run, because a probe that only ever fails is an outage rather than a gate:

    A: 4 missing            -> 'NOTREADY unpullable-pins=4'
    B: 0 missing            -> 'READY'
    C: broken enumeration   -> 'NOTREADY image-leg-enumeration-empty'

---

## Gates run locally

| Gate | Result |
|---|---|
| `tests/daytwo-image-leg.sh` (12 scenarios / 14 runs) | exit 0 |
| `tests/cutover-contract.sh` | exit 0 — All gates green |
| other 8 cutover chart tests | exit 0 each |
| `helm lint` | 0 failed |
| POSIX `sh -n` on the full 739-line rendered script + the rendered resolver | OK |
| `scripts/check-bootstrap-kit-pin-sync.sh` | exit 0 — 67 pairs |
| `scripts/check-catalog-seed-lockstep.sh` | exit 0 — 68 checked |
| `scripts/check-no-banned-words.sh` | exit 0 |
| `scripts/check-chart-annotations.sh` | cutover chart PASSES both guards (`no-upstream:true`, 13640-line render OK). The local run then aborts on `platform/temporal` missing its vendored `tempo` dependency — a local vendoring artefact, not this diff; **CI's `Chart-annotations guard` is green** |
| `go test ./...` in `tests/e2e/bootstrap-kit` | ok |
| `go test ./...` in `products/catalyst/bootstrap/api` | ok |
| `scripts/check-no-nodeports.sh` | full-repo scan **exit 0**; this diff adds no Service of any kind |

`ghcr-pin-existence` is expected RED until 0.1.165 publishes on merge.

---

## What I could NOT verify — please read this part

**Everything above is "renders correctly" and "the rendered shell behaves correctly when executed against stubs". None of it is "proven live."** No fresh prov was available and hw292 was treated read-only.

Specifically **not** verified:

1. **No live run of the reconciler.** The behavioural gate executes the rendered `args[0]` against stub `kubectl`/`curl`/`skopeo`. It has never talked to a real Harbor, a real apiserver, or a real GHCR.
2. **The readinessProbe has never been observed flipping a real Deployment to 0/1.** The verdict logic is proven; the kubelet wiring is asserted only from the render.
3. **No real `skopeo copy` was performed.** S7 proves the *source argument* is the inverse-mapped upstream. It does not prove that copy succeeds against real GHCR + real Harbor, nor that the artifact is servable afterwards.
4. **The audit / one-shot ConfigMap round-trip is stubbed.** `daytwo_audit_flush`'s read-modify-write and the `lastConsumedRequestId` read are exercised against a stub `kubectl`, not a real apiserver. In particular the 1 MiB ConfigMap cap is handled by `auditMaxLines` but has not been driven to the limit.
5. **The inverse map is proven for the two classes that exist in the coverage map** (project-prefixed and the `openova-io` host-drop) plus the refusal path. It is not proven against a hostProjects overlay a customer might add.
6. **hw292 still does not heal from this.** It runs cutover chart `0.1.159` and pulls charts from its own local Harbor, so `0.1.165` cannot reach it by the very mechanism being fixed. This lands for provs from 0.1.165 onward, or needs a side-load. UAT rows W1, W2, 35, 57, 115, R17 stay red there.
7. **I did not inspect hw292 live at all** — no kubeconfig for it exists on this host (`~/.kube/sovereigns/` holds hw126/hw291 only). Every hw292 fact in this PR is quoted from the issue's own measurements, not re-measured by me.

Refs #5640 #5644 #5265 #4975 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
