### PR TITLE
fix(qa-fixtures): QA CNPG Clusters pinned a Hetzner region on every Huawei Sovereign — fail closed + a #5639 class gate rendered both directions

### DIFF
--- a/.github/workflows/check-region-selector-fail-closed.yaml
+++ b/.github/workflows/check-region-selector-fail-closed.yaml
@@ -1,0 +1,59 @@
+name: check — region nodeAffinity selectors fail closed (#5639)
+
+# Permanent guard that every REQUIRED `openova.io/region` nodeAffinity in the
+# catalog refuses to render a region it cannot resolve.
+#
+# A required nodeAffinity whose value no node carries is not a scheduling
+# delay — it is unschedulable FOREVER, and nothing downstream notices: Helm
+# renders valid YAML, the API server accepts it, and the HelmRelease reports
+# "install succeeded" over a Pod that never starts. On hw292 a per-Org
+# bp-postgres primary sat Pending for 7+ hours behind exactly that green badge
+# because the chart emitted `openova.io/region In [""]` (#5639).
+#
+# The gate has two phases and both are load-bearing. Phase 1 enumerates every
+# template in the repo that emits the selector and fails on any that is not
+# registered — so adding a region-pinned workload forces the author to say how
+# it fails closed. Phase 2 renders each registered chart TWICE: with the region
+# supplied (must succeed, and the rendered VALUE must be that region) and with
+# it withheld (must fail the render). Asserting on the KEY is what let #5639
+# survive; asserting in only one direction is what lets a guard rot.
+#
+# Per docs/PRINCIPLES.md #4a this workflow renders templates locally — it does
+# not deploy anything or call cloud APIs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/postgres/chart/**'
+      - 'platform/cnpg-pair/chart/**'
+      - 'platform/wordpress-tenant/chart/**'
+      - 'products/catalyst/chart/**'
+      - 'scripts/check-region-selector-fail-closed.sh'
+      - '.github/workflows/check-region-selector-fail-closed.yaml'
+  pull_request:
+    paths:
+      - 'platform/postgres/chart/**'
+      - 'platform/cnpg-pair/chart/**'
+      - 'platform/wordpress-tenant/chart/**'
+      - 'products/catalyst/chart/**'
+      - 'scripts/check-region-selector-fail-closed.sh'
+      - '.github/workflows/check-region-selector-fail-closed.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  region-selector-fail-closed:
+    name: Every region selector fails closed
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run region-selector fail-closed gate
+        run: bash scripts/check-region-selector-fail-closed.sh

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1836,8 +1836,29 @@ spec:
       # cross-region NodePort 32379 filtered").
       cnpgPrimaryClusterName: ${QA_CNPG_PRIMARY_CLUSTER:-cluster-primary}
       cnpgReplicaClusterName: ${QA_CNPG_REPLICA_CLUSTER:-cluster-replica}
-      cnpgPrimaryRegion: ${QA_CNPG_PRIMARY_REGION:-hz-fsn-rtz-prod}
-      cnpgReplicaRegion: ${QA_CNPG_REPLICA_REGION:-hz-fsn-rtz-prod}
+      # #5639 CLASS — was `${QA_CNPG_PRIMARY_REGION:-hz-fsn-rtz-prod}`.
+      # NOTHING in this repo has ever defined QA_CNPG_PRIMARY_REGION (verified
+      # live on hw292: the bootstrap-kit Kustomization's postBuild.substitute
+      # has no such key), so the literal ALWAYS won — every QA Sovereign on
+      # Huawei pinned a HETZNER node label on both fixture Clusters' REQUIRED
+      # nodeAffinity, and both sat Pending forever while the HelmRelease still
+      # reported install succeeded. A near-miss region is exactly as
+      # unschedulable as the empty one #5639 was filed for. The neighbouring
+      # Continuum fixture at qaFixtures.primaryRegion was already threaded off
+      # a real substitute; the CNPG Cluster fixture — the only one of the two
+      # that actually affects SCHEDULING — was missed.
+      #
+      # SOVEREIGN_REGION_CANONICAL_LABEL, not SOVEREIGN_PRIMARY_REGION: it is
+      # the LOCAL cluster's own openova.io/region label (region-b's kustomize
+      # carries `hw-...-b-rtz-prod` where SOVEREIGN_PRIMARY_REGION still names
+      # region-a), so the fixture pins a label the nodes it lands on provably
+      # carry, without depending on slot 13 staying suspended on secondaries.
+      # Empty replica ⇒ the chart falls back to the primary region: this
+      # fixture is single-region by design (the cross-region drill belongs to
+      # bp-cnpg-pair + Continuum). Both empty ⇒ the chart's `required` fires
+      # and names the key instead of emitting an unsatisfiable selector.
+      cnpgPrimaryRegion: ${SOVEREIGN_REGION_CANONICAL_LABEL:-}
+      cnpgReplicaRegion: ${QA_CNPG_REPLICA_REGION:-}
       cnpgImage: ${QA_CNPG_IMAGE:-ghcr.io/cloudnative-pg/postgresql:16.4-1}
       # #4057/#3971 — empty default ⇒ the qaFixtures CNPG Cluster CR OMITS
       # storageClass (the chart's `{{- with .Values.qaFixtures.cnpgStorageClass }}`

--- a/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
@@ -212,6 +212,45 @@ spec:
   overridable. Per #4a the postgres image carries an explicit version
   tag (16.4-1) — production overlays should pin a digest.
 */ -}}
+{{- /*
+  #5639 CLASS — FAIL CLOSED on a region this fixture cannot resolve.
+
+  Both Cluster CRs below carry a REQUIRED nodeAffinity on the
+  `openova.io/region` NODE LABEL. Until now both the label and the
+  selector read `.Values.qaFixtures.cnpgPrimaryRegion | default
+  "hz-fsn-rtz-prod"` — a HETZNER label baked into the chart — and the
+  bootstrap-kit slot passed `${QA_CNPG_PRIMARY_REGION:-hz-fsn-rtz-prod}`
+  for a substitution variable NOTHING in this repo has ever defined.
+
+  On every Huawei Sovereign that resolves to `hz-fsn-rtz-prod`, which no
+  node carries (`openova.io/region=hw-<region>-rtz-prod`), so both
+  fixture Clusters are unschedulable FOREVER while the HelmRelease still
+  reports install succeeded. That is #5639's outcome exactly — the value
+  is merely wrong instead of empty, and a near-miss region is precisely
+  as unschedulable as an empty one.
+
+  So: `required`, naming the key, instead of a provider-specific literal.
+  The bootstrap-kit now supplies `${SOVEREIGN_REGION_CANONICAL_LABEL}` —
+  the LOCAL cluster's own openova.io/region label, stamped by cloud-init on
+  every node on every provider. Deliberately not SOVEREIGN_PRIMARY_REGION:
+  on a secondary cluster that still names region-a, so the fixture would pin
+  a label the local nodes do not carry.
+
+  The replica fixture falls back to the PRIMARY region rather than to a
+  second literal: this fixture is documented single-region by default
+  (the cross-region drill belongs to bp-cnpg-pair / Continuum), and
+  `SOVEREIGN_REPLICA_REGION` is empty on a single-region Sovereign. The
+  fallback is therefore always a real, resolvable node label — never "",
+  never another provider's.
+
+  Blast radius is bounded by the `qaFixtures.enabled` gate at line 1: a
+  production Sovereign (enabled=false) never renders this file, so the
+  umbrella render cannot fail on it. It fails only on a QA Sovereign that
+  turns the fixtures on without a region — which is exactly the case that
+  today yields two permanently-Pending Pods behind a green HelmRelease.
+*/ -}}
+{{- $qaPrimaryRegion := required "qaFixtures.cnpgPrimaryRegion is REQUIRED when qaFixtures.enabled=true. It is the canonical openova.io/region NODE LABEL both QA CNPG fixture Clusters pin a required nodeAffinity on — set it from this cluster's SOVEREIGN_REGION_CANONICAL_LABEL (e.g. hw-me-east-215-a-rtz-prod). A wrong or empty value emits a selector no node can satisfy, so the fixture primary is unschedulable forever while the HelmRelease still reports install succeeded (#5639)." .Values.qaFixtures.cnpgPrimaryRegion -}}
+{{- $qaReplicaRegion := .Values.qaFixtures.cnpgReplicaRegion | default $qaPrimaryRegion -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -221,7 +260,7 @@ metadata:
     openova.io/managed-by: qa-fixtures
     openova.io/application: {{ .Values.qaFixtures.appName | default "qa-wp" }}
     openova.io/cnpg-role: primary
-    openova.io/region: {{ .Values.qaFixtures.cnpgPrimaryRegion | default "hz-fsn-rtz-prod" }}
+    openova.io/region: {{ $qaPrimaryRegion }}
     catalyst.openova.io/cnpg-pair: {{ .Values.qaFixtures.cnpgPairName | default "qa-cnpg" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -257,7 +296,7 @@ spec:
               - key: openova.io/region
                 operator: In
                 values:
-                  - {{ .Values.qaFixtures.cnpgPrimaryRegion | default "hz-fsn-rtz-prod" }}
+                  - {{ $qaPrimaryRegion }}
     podAntiAffinityType: preferred
   postgresql:
     parameters:
@@ -301,7 +340,7 @@ metadata:
     openova.io/managed-by: qa-fixtures
     openova.io/application: {{ .Values.qaFixtures.appName | default "qa-wp" }}
     openova.io/cnpg-role: replica
-    openova.io/region: {{ .Values.qaFixtures.cnpgReplicaRegion | default "hz-fsn-rtz-prod" }}
+    openova.io/region: {{ $qaReplicaRegion }}
     catalyst.openova.io/cnpg-pair: {{ .Values.qaFixtures.cnpgPairName | default "qa-cnpg" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -337,7 +376,7 @@ spec:
               - key: openova.io/region
                 operator: In
                 values:
-                  - {{ .Values.qaFixtures.cnpgReplicaRegion | default "hz-fsn-rtz-prod" }}
+                  - {{ $qaReplicaRegion }}
     podAntiAffinityType: preferred
   postgresql:
     parameters:

--- a/products/catalyst/chart/tests/qa-cnpg-region-fail-closed.sh
+++ b/products/catalyst/chart/tests/qa-cnpg-region-fail-closed.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — qa-fixtures CNPG region fail-closed gate (#5639 class).
+#
+# WHAT THIS ENCODES
+# -----------------
+# templates/qa-fixtures/cnpg-clusters-qa.yaml renders TWO postgresql.cnpg.io
+# Cluster CRs, each with a REQUIRED nodeAffinity on the `openova.io/region`
+# NODE LABEL. A required nodeAffinity whose value no node carries is not a
+# scheduling delay — it is unschedulable FOREVER, and CNPG/Helm never notice:
+# the render is valid YAML, the API server accepts it, and the HelmRelease
+# reports "install succeeded" over two permanently-Pending Pods. That is the
+# #5639 failure mode, found live on hw292 where a per-Org bp-postgres primary
+# sat Pending for 7+ hours behind a green HelmRelease.
+#
+# These fixtures previously defaulted BOTH regions to the literal
+# `hz-fsn-rtz-prod` — a Hetzner label — in the chart AND in the bootstrap-kit
+# slot (`${QA_CNPG_PRIMARY_REGION:-hz-fsn-rtz-prod}`, for a substitution
+# variable nothing in this repo has ever defined). On every Huawei Sovereign
+# that literal won and pinned a region no node carries. A near-miss region is
+# exactly as unschedulable as an empty one.
+#
+# WHY THIS TEST IS SHAPED THE WAY IT IS
+# -------------------------------------
+# The defect #5639 fixed survived because the pre-existing bp-postgres render
+# assertion was `grep -q 'key: openova.io/region'` — the KEY renders whether
+# the value is the real region or `""`, so the assertion passed on the broken
+# output. Every assertion below therefore pins the rendered **VALUE**, and the
+# suite is vacuity-checked in BOTH directions: the negative cases are required
+# to FAIL the render, the positive cases are required to carry the exact
+# region string. A guard observed only passing is not yet known to be a guard.
+#
+# Test framework: pure `helm template` + grep on rendered YAML, matching the
+# established tests/api-single-writer-dr-contract.sh pattern. Picked up
+# automatically by .github/workflows/blueprint-release.yaml ("Run chart
+# integration tests (chart/tests/*.sh)").
+#
+# Usage: bash tests/qa-cnpg-region-fail-closed.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+ONLY="templates/qa-fixtures/cnpg-clusters-qa.yaml"
+PRIMARY="hw-me-east-215-a-rtz-prod"
+REPLICA="hw-me-east-215-b-rtz-prod"
+
+fails=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; fails=$((fails + 1)); }
+
+render() { # render <outfile> <extra helm --set args...>
+  local out="$1"
+  shift
+  helm template qa . --set qaFixtures.enabled=true -s "$ONLY" "$@" >"$out" 2>&1
+}
+
+echo "── #5639 class — qa-fixtures CNPG region fail-closed ──"
+
+# ─────────────────────────────────────────────────────────────────────────
+# NEGATIVE 1 — no region supplied at all ⇒ the render MUST FAIL.
+# This is the case the bootstrap-kit produced on every Huawei Sovereign.
+# ─────────────────────────────────────────────────────────────────────────
+if render "$TMP/neg-unset.out"; then
+  fail "region unset: render SUCCEEDED — the guard is gone (this is #5639)"
+  grep -n 'openova.io/region' "$TMP/neg-unset.out" | head -4 | sed 's/^/        /'
+else
+  if grep -q 'qaFixtures.cnpgPrimaryRegion is REQUIRED' "$TMP/neg-unset.out"; then
+    pass "region unset: render FAILS and names the missing key"
+  else
+    fail "region unset: render failed but NOT on the region guard — check the message"
+    head -5 "$TMP/neg-unset.out" | sed 's/^/        /'
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+# NEGATIVE 2 — region explicitly empty ⇒ the render MUST FAIL.
+# Emitting `openova.io/region In [""]` is the literal #5639 defect.
+# ─────────────────────────────────────────────────────────────────────────
+if render "$TMP/neg-empty.out" --set qaFixtures.cnpgPrimaryRegion=""; then
+  fail "region=\"\": render SUCCEEDED — an empty selector matches no node, ever"
+  grep -n 'openova.io/region' "$TMP/neg-empty.out" | head -4 | sed 's/^/        /'
+else
+  pass "region=\"\": render FAILS instead of emitting an empty selector"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+# POSITIVE 1 — real region ⇒ renders, and the VALUE is that exact region.
+# This is the control: it proves the guard does not simply always fire.
+# ─────────────────────────────────────────────────────────────────────────
+if render "$TMP/pos-single.out" --set qaFixtures.cnpgPrimaryRegion="$PRIMARY"; then
+  pass "region=$PRIMARY: render succeeds (guard does not over-fire)"
+
+  # The nodeAffinity VALUE — not the key. `values:` is a block list, so the
+  # region is on the line after it inside the matchExpressions term.
+  got_aff="$(grep -A3 'key: openova.io/region' "$TMP/pos-single.out" |
+    grep -E '^[[:space:]]+- [a-z0-9-]+$' | awk '{print $2}' | sort -u | tr '\n' ' ')"
+  if [ "$(echo "$got_aff" | tr -d ' ')" = "$PRIMARY" ]; then
+    pass "nodeAffinity VALUE on both Clusters == $PRIMARY (replica falls back to primary)"
+  else
+    fail "nodeAffinity VALUE is [$got_aff], expected only $PRIMARY"
+  fi
+
+  got_lbl="$(grep -E '^\s+openova\.io/region:' "$TMP/pos-single.out" |
+    awk '{print $2}' | tr -d '"' | sort -u | tr '\n' ' ')"
+  if [ "$(echo "$got_lbl" | tr -d ' ')" = "$PRIMARY" ]; then
+    pass "Cluster LABEL openova.io/region == $PRIMARY on both halves"
+  else
+    fail "Cluster LABEL is [$got_lbl], expected only $PRIMARY"
+  fi
+
+  if grep -qE 'openova\.io/region: *""|- *""' "$TMP/pos-single.out"; then
+    fail "an EMPTY region string reached the render despite the guard"
+  else
+    pass "no empty region string anywhere in the successful render"
+  fi
+else
+  fail "region=$PRIMARY: render FAILED — the guard over-fires on a valid region"
+  head -5 "$TMP/pos-single.out" | sed 's/^/        /'
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+# POSITIVE 2 — distinct primary/replica regions are both honoured VERBATIM.
+# Proves the replica half reads its own knob rather than silently reusing
+# the primary when one IS supplied.
+# ─────────────────────────────────────────────────────────────────────────
+if render "$TMP/pos-pair.out" \
+  --set qaFixtures.cnpgPrimaryRegion="$PRIMARY" \
+  --set qaFixtures.cnpgReplicaRegion="$REPLICA"; then
+  ok=1
+  grep -q "cnpg-role: primary" "$TMP/pos-pair.out" || ok=0
+  # primary Cluster block ends where the replica Cluster block begins
+  awk '/cnpg-role: replica/{r=1} {if(r) print}' "$TMP/pos-pair.out" >"$TMP/replica-half.out"
+  awk '/cnpg-role: replica/{exit} {print}' "$TMP/pos-pair.out" >"$TMP/primary-half.out"
+  grep -q "$PRIMARY" "$TMP/primary-half.out" || ok=0
+  grep -q "$REPLICA" "$TMP/replica-half.out" || ok=0
+  grep -q "$REPLICA" "$TMP/primary-half.out" && ok=0
+  if [ "$ok" = "1" ]; then
+    pass "distinct regions: primary half carries $PRIMARY, replica half carries $REPLICA"
+  else
+    fail "distinct regions: the two halves did not carry their own region values"
+  fi
+else
+  fail "distinct regions: render FAILED unexpectedly"
+  head -5 "$TMP/pos-pair.out" | sed 's/^/        /'
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+# SOURCE GUARD — no provider-specific region literal may come back as a
+# default. The whole defect was a Hetzner label hardcoded as the fallback
+# on a chart that installs on Huawei, Hetzner and Contabo alike.
+# ─────────────────────────────────────────────────────────────────────────
+if grep -nE 'cnpg(Primary|Replica)Region[^#]*\|[[:space:]]*default[[:space:]]*"(hz|hw)-' "$ONLY"; then
+  fail "a provider-specific region literal is back as a chart default"
+else
+  pass "no provider-specific region literal defaulted in $ONLY"
+fi
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "qa-cnpg-region-fail-closed: $fails FAILED"
+  exit 1
+fi
+echo "qa-cnpg-region-fail-closed: all checks passed"

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -2523,8 +2523,17 @@ qaFixtures:
   # replacement + Hetzner cross-region NodePort filtering are resolved.
   cnpgPrimaryClusterName: cluster-primary
   cnpgReplicaClusterName: cluster-replica
-  cnpgPrimaryRegion: hz-fsn-rtz-prod
-  cnpgReplicaRegion: hz-fsn-rtz-prod
+  # #5639 CLASS — NO provider-specific default. Both Cluster CRs pin a
+  # REQUIRED nodeAffinity on this exact `openova.io/region` NODE LABEL, so
+  # the old `hz-fsn-rtz-prod` default made every QA fixture on a Huawei
+  # Sovereign unschedulable forever behind a green HelmRelease. Empty here
+  # ⇒ the chart's `required` fires and names the key; the bootstrap-kit
+  # supplies ${SOVEREIGN_REGION_CANONICAL_LABEL}, the local cluster's own label
+  # cloud-init stamps on every node. cnpgReplicaRegion empty ⇒ falls back
+  # to the primary (this fixture is single-region by design; the cross-
+  # region drill belongs to bp-cnpg-pair + Continuum).
+  cnpgPrimaryRegion: ""
+  cnpgReplicaRegion: ""
   cnpgInstances: 1
   cnpgImage: ghcr.io/cloudnative-pg/postgresql:16.4-1
   cnpgStorageSize: 1Gi

--- a/scripts/check-region-selector-fail-closed.sh
+++ b/scripts/check-region-selector-fail-closed.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# #5639 CLASS GATE — every REQUIRED `openova.io/region` nodeAffinity in this
+# repo must FAIL CLOSED on a region it cannot resolve.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# THE DEFECT THIS EXISTS TO PREVENT
+# ---------------------------------
+# `platform/postgres/chart` rendered
+#
+#     nodeAffinity required: openova.io/region In [""]
+#
+# for a per-Org Postgres on hw292 because the HelmRelease values carried
+# `topology.mode: active-hot-standby` and no `topology.primary.region`. No node
+# carries an empty region label, so the primary was unschedulable FOREVER — and
+# nothing noticed: Helm rendered valid YAML, the API server accepted it, and the
+# HelmRelease reported "install succeeded" over a Pod that had been Pending for
+# seven hours. Merged, delivered, green, and never once running.
+#
+# WHY A GATE AND NOT JUST A FIX
+# -----------------------------
+# bp-postgres was DRIFT, not a new class: `bp-cnpg-pair` and
+# `bp-wordpress-tenant` already carried this guard. One chart fell out of an
+# existing standard and no gate noticed for as long as it took a customer-facing
+# Organization to sit dark. The same shape recurs every time someone adds a
+# region-pinned workload, so the standard needs teeth.
+#
+# WHY THE ASSERTIONS LOOK LIKE THIS
+# ---------------------------------
+# The bp-postgres render test that should have caught this asserted
+# `grep -q 'key: openova.io/region'`. The KEY renders whether the value is the
+# real region or the empty string, so the assertion passed on the broken output
+# for as long as the defect existed. Two consequences, both load-bearing here:
+#
+#   1. NEVER assert on the key. Every positive case below pins the rendered
+#      VALUE and rejects an empty one explicitly.
+#   2. A negative case that passes because the guarded template never rendered
+#      at all is worthless. Rendering bp-postgres in active-hot-standby WITHOUT
+#      `--api-versions postgresql.cnpg.io/v1` exits 0 and emits one NetworkPolicy
+#      — the Cluster CR is gated on the CNPG CRD being present, so the guard is
+#      never reached. Every entry therefore proves the POSITIVE render actually
+#      CONTAINS the selector before its negative counterpart is believed.
+#
+# WHAT IT CHECKS
+# --------------
+#   Phase 1 (registry)  — enumerate every chart template in the repo that emits
+#                         a `key: openova.io/region` matchExpression. Each must
+#                         be registered below. A NEW unregistered one fails the
+#                         gate, so adding a region-pinned workload forces the
+#                         author to state how it fails closed. A registered file
+#                         that no longer emits one also fails, so the registry
+#                         cannot rot into a rubber stamp.
+#   Phase 2 (behavior)  — for each registered chart, render it twice:
+#                           positive: region supplied  ⇒ MUST succeed, MUST
+#                                     contain the selector, and the selector's
+#                                     VALUE must be exactly the supplied region
+#                           negative: region withheld   ⇒ MUST fail the render
+#                         Both directions, every time. A guard observed only
+#                         passing is not yet known to be a guard.
+#
+# Usage: bash scripts/check-region-selector-fail-closed.sh
+# Refs #5639
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+A="hw-me-east-215-a-rtz-prod"
+B="hw-me-east-215-b-rtz-prod"
+
+fails=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() {
+  printf '  FAIL  %s\n' "$1"
+  fails=$((fails + 1))
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# REGISTRY — every chart template that emits a required openova.io/region
+# selector, and the chart-level guard that makes it fail closed.
+#
+# Format: <template path>|<chart dir>|<guard symbol>
+# The guard symbol is informational for a human reading a failure; the gate's
+# teeth are Phase 2, which renders the chart and checks behavior.
+# ─────────────────────────────────────────────────────────────────────────────
+REGISTRY="
+platform/postgres/chart/templates/cluster.yaml|platform/postgres/chart|bp-postgres.primaryRegion
+platform/postgres/chart/templates/replica-cluster.yaml|platform/postgres/chart|bp-postgres.replicaRegion
+platform/cnpg-pair/chart/templates/primary-cluster.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions
+platform/cnpg-pair/chart/templates/replica-cluster.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions
+platform/cnpg-pair/chart/templates/dr-failback.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions (transitive — failbackActive requires enabled+isPrimarySide, so primary-cluster.yaml co-renders)
+platform/cnpg-pair/chart/templates/dr-promoter.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions (transitive — autoPromoteActive requires enabled+isReplicaSide, so replica-cluster.yaml co-renders)
+platform/cnpg-pair/chart/templates/failover-readiness.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions (transitive — same enabled+isReplicaSide gate as replica-cluster.yaml)
+platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml|platform/wordpress-tenant/chart|bp-wordpress-tenant.validateActiveHotStandbyRegions
+products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml|products/catalyst/chart|inline required on qaFixtures.cnpgPrimaryRegion
+"
+
+echo "══ Phase 1 — registry completeness ══"
+
+# Every template in the repo that emits the selector.
+mapfile -t FOUND < <(
+  grep -rl --include='*.yaml' --include='*.tpl' -E '^[[:space:]]*-?[[:space:]]*key:[[:space:]]*"?openova\.io/region"?' \
+    platform products 2>/dev/null | sort
+)
+
+registered_paths="$(echo "$REGISTRY" | awk -F'|' 'NF{print $1}' | sort)"
+
+for f in "${FOUND[@]}"; do
+  if echo "$registered_paths" | grep -qxF "$f"; then
+    continue
+  fi
+  fail "UNREGISTERED region selector: $f
+        This template pins a node selector on openova.io/region. State how it
+        fails closed on an unresolvable region (a Helm \`required\` naming the
+        key — see platform/postgres/chart/templates/_helpers.tpl), then add it
+        to the REGISTRY in this script with a render case in Phase 2."
+done
+[ "${#FOUND[@]}" -gt 0 ] || fail "found ZERO region selectors — the enumeration itself broke"
+
+while IFS='|' read -r tpl chart guard; do
+  [ -n "${tpl:-}" ] || continue
+  if [ ! -f "$tpl" ]; then
+    fail "STALE registry entry: $tpl no longer exists — drop the row"
+  elif ! printf '%s\n' "${FOUND[@]}" | grep -qxF "$tpl"; then
+    fail "STALE registry entry: $tpl no longer emits a region selector — drop the row"
+  fi
+done <<<"$REGISTRY"
+
+[ "$fails" -eq 0 ] && pass "all ${#FOUND[@]} region-selector templates registered, no stale rows"
+
+echo
+echo "══ Phase 2 — fail-closed behavior, both directions ══"
+
+# case <label> <chart dir> <expect-selector-count> -- <positive args...> -- <negative args...>
+#   positive MUST render, MUST contain >=1 selector, and every selector VALUE
+#   must be one of $A/$B and never empty.
+#   negative MUST fail the render.
+run_case() {
+  local label="$1" chart="$2" want_region="$3"
+  shift 3
+  local pos=() neg=() bucket=pos
+  for a in "$@"; do
+    if [ "$a" = "--NEG--" ]; then
+      bucket=neg
+      continue
+    fi
+    if [ "$bucket" = "pos" ]; then pos+=("$a"); else neg+=("$a"); fi
+  done
+
+  local po="$TMP/${label//\//_}.pos" no="$TMP/${label//\//_}.neg"
+
+  if ! (cd "$chart" && helm template gate . "${pos[@]}") >"$po" 2>&1; then
+    fail "$label POSITIVE render failed — the guard over-fires on a valid region"
+    head -3 "$po" | sed 's/^/        /'
+    return
+  fi
+
+  local n
+  n="$(grep -cE '^[[:space:]]*-?[[:space:]]*key:[[:space:]]*"?openova\.io/region"?' "$po" || true)"
+  if [ "$n" -lt 1 ]; then
+    fail "$label POSITIVE render emitted NO region selector — the negative case
+        below would pass vacuously against a template that never rendered.
+        Fix the render args (a missing --api-versions is the usual cause)."
+    return
+  fi
+  pass "$label positive renders $n region selector(s)"
+
+  # Assert on the VALUE. Both the `values: ["x"]` flow form and the block form
+  # `values:\n  - x` are in use across these charts, and bp-postgres carries a
+  # three-line comment between the key and its values — hence the wide window
+  # and the comment-tolerant extraction.
+  local vals
+  vals="$(grep -A8 -E 'key:[[:space:]]*"?openova\.io/region"?' "$po" |
+    grep -v '^[[:space:]]*#' |
+    grep -oE 'values:[[:space:]]*\[[^]]*\]|^[[:space:]]+- [A-Za-z0-9._-]+$' |
+    sed -E 's/values:[[:space:]]*\[//; s/\]//; s/^[[:space:]]*-[[:space:]]*//' |
+    tr -d '"' | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' |
+    grep -v '^$' | sort -u)"
+  if [ -z "$vals" ]; then
+    fail "$label could not extract any selector VALUE from the positive render"
+    return
+  fi
+  local bad=0
+  while read -r v; do
+    case "$v" in
+    "$A" | "$B") ;;
+    *)
+      bad=1
+      fail "$label selector VALUE is '$v' — expected only the supplied region(s)"
+      ;;
+    esac
+  done <<<"$vals"
+  [ "$bad" = "0" ] && pass "$label selector VALUE(s) == [$(echo "$vals" | tr '\n' ' ')]"
+
+  if grep -qE 'openova\.io/region:[[:space:]]*""|values:[[:space:]]*\[""\]' "$po"; then
+    fail "$label an EMPTY region reached the positive render — this IS #5639"
+  fi
+
+  if (cd "$chart" && helm template gate . "${neg[@]}") >"$no" 2>&1; then
+    fail "$label NEGATIVE render SUCCEEDED with the region withheld — it emits an
+        unsatisfiable selector instead of failing. This is the #5639 defect."
+    grep -n -E 'openova\.io/region' "$no" | head -3 | sed 's/^/        /'
+  else
+    pass "$label negative (region withheld) FAILS the render"
+  fi
+  : "${want_region:=}"
+}
+
+# bp-postgres — the chart the defect was found in. `--api-versions` is
+# load-bearing: without the CNPG CRD the Cluster template never renders and the
+# negative case passes on an empty output.
+run_case "bp-postgres/primary" platform/postgres/chart "$A" \
+  --api-versions postgresql.cnpg.io/v1 \
+  --set topology.mode=active-hot-standby --set topology.primary.region="$A" \
+  --NEG-- \
+  --api-versions postgresql.cnpg.io/v1 \
+  --set topology.mode=active-hot-standby
+
+run_case "bp-postgres/replica" platform/postgres/chart "$B" \
+  --api-versions postgresql.cnpg.io/v1 \
+  --set topology.mode=active-hot-standby --set topology.side=replica \
+  --set topology.primary.region="$A" --set topology.replica.region="$B" \
+  --NEG-- \
+  --api-versions postgresql.cnpg.io/v1 \
+  --set topology.mode=active-hot-standby --set topology.side=replica \
+  --set topology.primary.region="$A"
+
+# bp-cnpg-pair — covers primary-cluster.yaml + (transitively) dr-failback.yaml.
+run_case "bp-cnpg-pair/primary" platform/cnpg-pair/chart "$A" \
+  --set cnpgPair.enabled=true --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.primary.region="$A" --set cnpgPair.replica.region="$B" \
+  --NEG-- \
+  --set cnpgPair.enabled=true --set cnpgPair.image.tag=16.3-23
+
+# bp-cnpg-pair replica side — covers replica-cluster.yaml + (transitively)
+# dr-promoter.yaml and failover-readiness.yaml.
+run_case "bp-cnpg-pair/replica" platform/cnpg-pair/chart "$B" \
+  --set cnpgPair.enabled=true --set cnpgPair.side=replica --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.primary.region="$A" --set cnpgPair.replica.region="$B" \
+  --NEG-- \
+  --set cnpgPair.enabled=true --set cnpgPair.side=replica --set cnpgPair.image.tag=16.3-23
+
+# bp-wordpress-tenant — has a `common` subchart dependency. Build it; a build
+# failure is a HARD failure, never a skip: a gate that can silently opt out of
+# a chart is the fail-open shape that hid four defects for two months.
+if [ ! -f platform/wordpress-tenant/chart/charts/common-0.1.3.tgz ]; then
+  if ! (cd platform/wordpress-tenant/chart && helm dependency build) >"$TMP/wpdep.log" 2>&1; then
+    fail "bp-wordpress-tenant: helm dependency build failed — cannot render the chart"
+    tail -3 "$TMP/wpdep.log" | sed 's/^/        /'
+  fi
+fi
+if [ -d platform/wordpress-tenant/chart/charts ]; then
+  run_case "bp-wordpress-tenant" platform/wordpress-tenant/chart "$A" \
+    --api-versions postgresql.cnpg.io/v1 \
+    --set pg.activeHotStandby.enabled=true \
+    --set pg.activeHotStandby.primaryRegion="$A" \
+    --set pg.activeHotStandby.replicaRegion="$B" \
+    --NEG-- \
+    --api-versions postgresql.cnpg.io/v1 \
+    --set pg.activeHotStandby.enabled=true
+fi
+
+# bp-catalyst-platform qa-fixtures — the sibling this sweep found still pinning
+# a Hetzner literal on every Huawei Sovereign (#5639 class, wrong-value variant).
+run_case "bp-catalyst-platform/qa-fixtures" products/catalyst/chart "$A" \
+  --set qaFixtures.enabled=true --set qaFixtures.cnpgPrimaryRegion="$A" \
+  -s templates/qa-fixtures/cnpg-clusters-qa.yaml \
+  --NEG-- \
+  --set qaFixtures.enabled=true \
+  -s templates/qa-fixtures/cnpg-clusters-qa.yaml
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "check-region-selector-fail-closed: $fails FAILED"
+  exit 1
+fi
+echo "check-region-selector-fail-closed: OK — every region selector fails closed"


### PR DESCRIPTION
## What this is

A verification-and-sweep pass over #5641's fix, plus the one sibling the sweep found and a class gate so the next one cannot land silently.

Three parts, in the order they were done: verify the merged guard on the **deployed** artifacts rather than on `main`; enumerate every other chart with the same shape; fix what the enumeration turned up.

---

## 1. Live verification — the guard is published but NOT delivered, and hw292 is still broken

| Question | Answer | Evidence |
|---|---|---|
| Does the guard exist on `main`? | Yes | `_helpers.tpl:192/204`, merge commit `67dfb94fa` |
| Is it **published**? | Yes | `ghcr.io/openova-io/bp-postgres:0.2.17`, ghcr `updated_at 2026-08-03T22:39:08Z`. Pulled the tarball and read it: `required` present at `_helpers.tpl:192/204`, call sites `cluster.yaml:49/73` + `replica-cluster.yaml:51/77`. Digest `sha256:c85a0a15…` |
| Is it **delivered to hw292**? | **No** | HelmRelease `hw292-omani-works/uat-ahs-pg-rtz-a` pins `bp-postgres 0.2.16`; `Blueprint/bp-postgres` on the cluster advertises `0.2.16`; post-cutover every HelmRepository points at `oci://registry.hw292.omani.works/openova-io`, so 0.2.17 has no path in without a re-prewarm or a fresh prov |
| Is a per-Org Postgres still mis-rendered right now? | **Yes** | see below |

```
Cluster hw292-omani-works/postgres
  label   openova.io/region = ''
  nodeAff {"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":
          [{"matchExpressions":[{"key":"openova.io/region","operator":"In","values":[""]}]}]}}
  phase   Setting up primary   instances 1   readyInstances None
  pod     postgres-1-initdb-z2szh   0/1 Pending   18h

CONTROL, same cluster, same key, working:
  cnpg/cnpg-pair-bp-cnpg-pair-primary   values ["hw-me-east-215-a-rtz-prod"]   3/3 Ready
  shared-data/shared-pg{,-b,-c}         values ["hw-me-east-215-a-rtz-prod"]   3/3 Ready
```

All four region-a nodes carry `openova.io/region=hw-me-east-215-a-rtz-prod`.

**The merged guard does fire on the exact live input.** Rendering 0.2.17 with hw292's verbatim HelmRelease values (`{"topology":{"mode":"active-hot-standby"}}`):

```
Error: execution error at (bp-postgres/templates/cluster.yaml:49:26): bp-postgres:
topology.primary.region is REQUIRED in active-hot-standby mode ...
```

with one caveat that matters for how the gate below is built: **without `--api-versions postgresql.cnpg.io/v1` that same render exits 0** and emits a single NetworkPolicy. The Cluster CR is gated on the CNPG CRD being present, so a negative test run without it passes on a template that never rendered.

Also observed, not in scope here: region-b has **no** per-Org replica half at all — only `cnpg-pair` and `shared-pg` replicas. Consistent with the known "region-b never receives the GitOps stream" defect (#5511/#5649/#5591/#5359).

---

## 2. Sibling enumeration — method and result

Method, run repo-wide and excluding `docs/`:

```
grep -rn --include='*.yaml' --include='*.yml' --include='*.tpl' --include='*.json' \
         --include='*.go' --include='*.tftpl' \
  -E '^\s*-?\s*key:\s*"?(openova\.io/region|topology\.kubernetes\.io/(region|zone))"?' .
```

plus a second pass for templated `nodeSelector` / `topologySpreadConstraints` blocks with no enclosing `with`/`if`, and a third for Flux `${VAR}` substitution into a placement selector in raw (non-Helm) manifests.

**Exactly 11 required region-selector sites, across 6 templates in 5 charts.** Every one classified:

| Site | Value expression | Guard | Verdict |
|---|---|---|---|
| `cnpg-pair/primary-cluster.yaml:155` | `.Values.cnpgPair.primary.region` | `cnpg-pair.validateRegions` included at `:48` | guarded |
| `cnpg-pair/replica-cluster.yaml:96` | `.Values.cnpgPair.replica.region` | same, included at `:37` | guarded |
| `cnpg-pair/dr-failback.yaml:475` | `.Values.cnpgPair.primary.region` | **no direct include** — but gated on `failbackActive` ⇒ `enabled AND isPrimarySide`, which is `primary-cluster.yaml`'s own gate, so that file co-renders and its `required` aborts the whole render | guarded, transitively |
| `cnpg-pair/dr-promoter.yaml:382` | `.Values.cnpgPair.replica.region` | same via `autoPromoteActive` ⇒ `enabled AND isReplicaSide` | guarded, transitively |
| `cnpg-pair/failover-readiness.yaml:91` | `.Values.cnpgPair.replica.region` | gated on `enabled AND isReplicaSide`, byte-identical to `replica-cluster.yaml`'s gate | guarded, transitively |
| `postgres/cluster.yaml:73` | `include "bp-postgres.primaryRegion"` | `required` `_helpers.tpl:192` | guarded (0.2.17) |
| `postgres/replica-cluster.yaml:77` | `include "bp-postgres.replicaRegion"` | `required` `_helpers.tpl:204` | guarded (0.2.17) |
| `wordpress-tenant/cnpg-cluster.yaml:191` | `.Values.pg.activeHotStandby.primaryRegion` | `validateActiveHotStandbyRegions` at `:54`, same `$haEnabled` branch | guarded |
| `wordpress-tenant/cnpg-cluster.yaml:296` | `.Values.pg.activeHotStandby.replicaRegion` | same | guarded |
| `catalyst/qa-fixtures/cnpg-clusters-qa.yaml:260` | `.Values.qaFixtures.cnpgPrimaryRegion \| default "hz-fsn-rtz-prod"` | none — a **provider-specific literal** | **GAP** |
| `catalyst/qa-fixtures/cnpg-clusters-qa.yaml:340` | `.Values.qaFixtures.cnpgReplicaRegion \| default "hz-fsn-rtz-prod"` | none | **GAP** |

So #5639's own claim checks out with one correction worth stating: `bp-cnpg-pair` has **six** selector sites and `validateRegions` is included from only three of them. It is still airtight, because Helm aborts the whole render on any `required`, and the three unguarded files can never render without a guarded one co-rendering — but that is a transitive property of the gating helpers, not a per-file guard, and it is now written down in the gate's registry rather than left to be re-derived.

Zero unguarded templated `nodeSelector` blocks (all `with`/`if`). Zero `${VAR}` substitutions into a placement selector in raw manifests. The `topologyKey` sites all carry a non-empty `| default`, and `sprig`'s `default` fires on `""`, so none can render empty.

**Not fixed, flagged only:** `bp-rtz-vcluster` and `bp-dmz-vcluster` declare `nodeSelector.regionLabelKey/Value` that zero templates consume, and `bp-mgmt-vcluster` defines a `nodeSelector` helper never invoked — dead knobs, and the opposite failure mode (no constraint, not an impossible one). `continuum-qa.yaml` hardcodes `hz-fsn-rtz-prod`/`hz-hel-rtz-prod` too, and `QA_STANDBY_REGION` is likewise absent from hw292's substitute map — but a Continuum CR's region is read-path data, not a scheduling selector, so no Pod hangs on it.

---

## 3. The gap, and why it is the same defect

`qaFixtures.cnpgPrimaryRegion` defaulted to `hz-fsn-rtz-prod` in the chart, and the bootstrap-kit slot passed `${QA_CNPG_PRIMARY_REGION:-hz-fsn-rtz-prod}`. **Verified live on hw292** — the bootstrap-kit Kustomization's `postBuild.substitute` map:

```
QA_CNPG_PRIMARY_REGION          = <<ABSENT>>
QA_CNPG_REPLICA_REGION          = <<ABSENT>>
SOVEREIGN_PRIMARY_REGION        = 'hw-me-east-215-a-rtz-prod'
SOVEREIGN_REGION_CANONICAL_LABEL= 'hw-me-east-215-a-rtz-prod'   (region-b: '…-b-rtz-prod')
QA_FIXTURES_ENABLED             = 'false'
```

The override variable has never existed, so the Hetzner literal always won. On any Huawei Sovereign that turns the fixtures on, both fixture Clusters pin a label no node carries and sit Pending forever behind `install succeeded`. Latent on hw292 only because `QA_FIXTURES_ENABLED=false` there.

The neighbouring Continuum fixture at slot line 1808 was already threaded off a real substitute (`QA_PRIMARY_REGION`, present and correct live). The CNPG Cluster fixture — the only one of the two that affects **scheduling** — was the one missed.

Fix: `SOVEREIGN_REGION_CANONICAL_LABEL`, not `SOVEREIGN_PRIMARY_REGION`. On region-b the former carries the `-b` label while the latter still names region-a, so the canonical label pins something the local nodes provably carry without depending on slot 13 staying suspended on secondaries. The replica knob falls back to the primary region rather than a second literal (this fixture is single-region by design). The chart's `required` sits inside the `qaFixtures.enabled` gate, so a production Sovereign's umbrella render cannot fail on it.

---

## 4. Vacuity — both directions, both new tests

### `products/catalyst/chart/tests/qa-cnpg-region-fail-closed.sh`

**Against the fix (green):**

```
── #5639 class — qa-fixtures CNPG region fail-closed ──
  PASS  region unset: render FAILS and names the missing key
  PASS  region="": render FAILS instead of emitting an empty selector
  PASS  region=hw-me-east-215-a-rtz-prod: render succeeds (guard does not over-fire)
  PASS  nodeAffinity VALUE on both Clusters == hw-me-east-215-a-rtz-prod (replica falls back to primary)
  PASS  Cluster LABEL openova.io/region == hw-me-east-215-a-rtz-prod on both halves
  PASS  no empty region string anywhere in the successful render
  PASS  distinct regions: primary half carries hw-me-east-215-a-rtz-prod, replica half carries hw-me-east-215-b-rtz-prod
  PASS  no provider-specific region literal defaulted in templates/qa-fixtures/cnpg-clusters-qa.yaml
qa-cnpg-region-fail-closed: all checks passed
```

**Against `origin/main`'s unfixed template + values, same test file (red — 5 of 8):**

```
  FAIL  region unset: render SUCCEEDED — the guard is gone (this is #5639)
        303:    openova.io/region: hz-fsn-rtz-prod
  FAIL  region="": render SUCCEEDED — an empty selector matches no node, ever
  PASS  region=hw-me-east-215-a-rtz-prod: render succeeds (guard does not over-fire)
  FAIL  nodeAffinity VALUE is [hw-me-east-215-a-rtz-prod hz-fsn-rtz-prod ], expected only hw-me-east-215-a-rtz-prod
  FAIL  Cluster LABEL is [hw-me-east-215-a-rtz-prod hz-fsn-rtz-prod ], expected only hw-me-east-215-a-rtz-prod
  PASS  no empty region string anywhere in the successful render
  PASS  distinct regions: primary half carries …-a…, replica half carries …-b…
  FAIL  a provider-specific region literal is back as a chart default
qa-cnpg-region-fail-closed: 5 FAILED
```

The three surviving PASSes are the control — the suite is not simply always-red. Note what the red run exposes that a key-presence assertion never would: even with a correct primary supplied, the **replica** half still rendered `hz-fsn-rtz-prod`.

### `scripts/check-region-selector-fail-closed.sh`

**Against the fix (green, 9 registered templates, 5 charts):**

```
══ Phase 1 — registry completeness ══
  PASS  all 9 region-selector templates registered, no stale rows
══ Phase 2 — fail-closed behavior, both directions ══
  PASS  bp-postgres/primary positive renders 1 region selector(s)
  PASS  bp-postgres/primary selector VALUE(s) == [hw-me-east-215-a-rtz-prod ]
  PASS  bp-postgres/primary negative (region withheld) FAILS the render
  PASS  bp-postgres/replica … VALUE(s) == [hw-me-east-215-b-rtz-prod ] … negative FAILS
  PASS  bp-cnpg-pair/primary … VALUE(s) == [hw-me-east-215-a-rtz-prod ] … negative FAILS
  PASS  bp-cnpg-pair/replica positive renders 3 region selector(s) … negative FAILS
  PASS  bp-wordpress-tenant … VALUE(s) == [hw-me-east-215-a-rtz-prod hw-me-east-215-b-rtz-prod ] … negative FAILS
  PASS  bp-catalyst-platform/qa-fixtures … VALUE(s) == [hw-me-east-215-a-rtz-prod ] … negative FAILS
check-region-selector-fail-closed: OK — every region selector fails closed
```

**Against pre-#5641 `bp-postgres` (`67dfb94fa^`, chart 0.2.16) — it reproduces #5639 verbatim:**

```
  PASS  bp-postgres/primary positive renders 1 region selector(s)
  PASS  bp-postgres/primary selector VALUE(s) == [hw-me-east-215-a-rtz-prod ]
  FAIL  bp-postgres/primary NEGATIVE render SUCCEEDED with the region withheld — it emits an
        unsatisfiable selector instead of failing. This is the #5639 defect.
        102:    openova.io/region: ""
  FAIL  bp-postgres/replica NEGATIVE render SUCCEEDED …
        65:    openova.io/region: ""
check-region-selector-fail-closed: 2 FAILED
```

Every other chart stayed green in that run — the gate would have caught #5639 on the PR that introduced it, and only that.

**Against the unfixed qa-fixtures:** 2 FAILED, naming `hz-fsn-rtz-prod` and printing the surviving selector.

**Phase 1 vacuity:** deleting the `postgres/cluster.yaml` registry row turns the gate red with `UNREGISTERED region selector: platform/postgres/chart/templates/cluster.yaml`. The registry cannot be silently shrunk, and a stale row whose file no longer emits a selector fails too.

---

## Gates

`helm lint products/catalyst/chart` 0 failed · all 8 `products/catalyst/chart/tests/*.sh` green (7 pre-existing + the new one) · `check-bootstrap-kit-pin-sync.sh` PASS · `check-catalog-seed-lockstep.sh` PASS · `check-tofu-flux-envsubst.sh` OK · `check-region-selector-fail-closed.sh` OK.

No chart version bump: `products/catalyst/chart/Chart.yaml` auto-increments on the deploybot's `deploy:` commits, and template-only commits to this chart do not bump it (confirmed against the last four such commits). No new substitution variables — `SOVEREIGN_REGION_CANONICAL_LABEL` and `QA_CNPG_REPLICA_REGION` both already appear in this slot's namespace. Zero nodeport occurrences in the diff.

`check-no-nodeports.sh` Phase 2 did not complete in this sandbox (it fetches chart dependencies over the network and was killed at the 560s ceiling — the same environment limit noted on #5641). Scanned the touched files directly instead: the only `NodePort` string in the diff's neighbourhood is a pre-existing prose comment in `cnpg-clusters-qa.yaml:191`, and `git diff` adds no port literal at all.

## What is NOT proven here

- **No walk.** hw292 was read-only for all of this; nothing was patched, restarted or rolled. Every claim above is either "renders correctly" (helm template) or "read live off hw292" — none is "proven live end-to-end".
- The qa-fixtures fix is **not** live-verified, because `QA_FIXTURES_ENABLED=false` on hw292. It closes on a QA Sovereign that renders the fixtures and shows two Running fixture Clusters carrying the local region.
- **#5639 itself stays open.** The delivery leg is unfinished: hw292 runs 0.2.16, its Blueprint CR advertises 0.2.16, and `hw292-omani-works/postgres` is still Pending with `values: [""]` as of this writing. The row closes on a fresh prov that installs a per-Org bp-postgres in active-hot-standby and shows a Running primary with the real region in both the label and the nodeAffinity.
- Whether the local Harbor on hw292 holds a `bp-postgres:0.2.17` artifact is **unverified** — its registry API requires credentials I did not extract. It is moot for delivery either way: the on-cluster Blueprint CR advertises 0.2.16, so nothing on that Sovereign will request 0.2.17.

Refs #5639
