### PR TITLE
fix(wizard): thread the Single-region topology choice to the wire as bcpTopology

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
@@ -607,6 +607,14 @@ export function StepReview() {
     workerCount:      r.workerCount,
   }))
   const totalHourly = regionRows.reduce((acc, r) => acc + r.hourlyCost, 0)
+  // #4706 admission floor (#5661) — multi-region is the BCP default; a
+  // single-region prov must DECLARE itself or CreateDeployment rejects the
+  // body with HTTP 400 before Validate ever runs. The operator picking a
+  // one-region topology card on StepTopology IS the deliberate, declared
+  // act the floor demands — thread it to the wire. Multi-region topologies
+  // leave the field unset (JSON.stringify drops undefined), preserving the
+  // server's multi-region default semantics unchanged.
+  const bcpTopology = regionsPayload.length < 2 ? 'single-region' : undefined
   const r0 = regionsPayload[0] ?? {
     provider: '',
     cloudRegion: '',
@@ -762,6 +770,9 @@ export function StepReview() {
           // full array now means nothing changes when the multi-region
           // apply path activates.
           regions: regionsPayload,
+          // #4706/#5661 — deliberate single-region declaration; undefined
+          // (and therefore absent from the wire) for multi-region.
+          bcpTopology,
           // SSH key
           sshPublicKey: store.sshPublicKey,
           // Hetzner Object Storage credentials (issue #371) — Phase 0b.
@@ -906,6 +917,7 @@ export function StepReview() {
             />
             <Field label="HA"      value={store.haEnabled ? 'Enabled — 3-node etcd quorum per region' : 'Disabled — single CP node'} />
             <Field label="AIR-GAP" value={store.airgap ? 'Enabled — isolated forensic / DR region' : 'Disabled'} />
+            <Field label="BCP topology" value={bcpTopology ?? 'multi-region (default)'} />
           </FieldGrid>
         </Section>
 


### PR DESCRIPTION
## What

StepReview.tsx (the wizard's single source of truth for the POST body) now derives `bcpTopology: "single-region"` when the canonical regions payload carries exactly one region, sends it on the wire, and renders it in the on-screen Topology section per the file's body-mirror contract. Multi-region topologies leave the field unset — JSON.stringify drops the undefined, so the wire and the server's multi-region default semantics are byte-identical to before.

## Why

The catalyst-api's #4706 admission floor (`deployments.go:1377`) rejects any body with empty `bcpTopology` and fewer than 2 regions — HTTP 400 before Validate runs. `StepTopology` offers a "Single region" card, but no UI path ever set the field (zero `bcpTopology` hits in `bootstrap/ui/src/`), so the wizard structurally could not fire a single-region prov. The operator explicitly picking the one-region card IS the deliberate, declared act the floor demands — this PR threads that declaration faithfully rather than bypassing the floor.

Unblocks the mothership-pivot fire (single-region Hetzner on the openova.io domain, task #960) from the wizard UI, per founder direction 2026-08-04 that the fire happens from the mothership console, not via API scripting.

## Gates

- `npx tsc -b --noEmit` — clean
- `npm run build` — ✓ built
- vitest wizard step suites — 30/30 pass

Refs #5661 #4706 #960
