### PR TITLE
fix(newapi): one SESSION_SECRET/CRYPTO_SECRET per KC client, not one per region (A16)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -170,7 +170,7 @@ spec:
       #   policy-dropped → `no OpenBao token` every tick → grafana/hubble 503,
       #   gitea 500. Fix: CNP egress now also names kube-dns + keycloak + openbao.
       #   #4449 fixed the INGRESS side; this is the EGRESS side. Refs #4458 #4449.
-      version: 0.2.26
+      version: 0.2.27
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -313,7 +313,7 @@ spec:
       #   ExternalSecret above resolves in region-B too (catalyst-api's #4477
       #   seed is primary-only; each region runs its own OpenBao). Pairs with
       #   bp-openbao 1.2.64 (external-secrets-push policy).
-      version: 1.4.146
+      version: 1.4.147
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.146 # lockstep with chart/Chart.yaml (#5374 Guaranteed QoS; #5375: region-local admin-token PushSecret closes the M2 region-B SecretSyncedError / DR gap)
+  version: 1.4.147 # lockstep with chart/Chart.yaml (#5466: SESSION_SECRET/CRYPTO_SECRET off the per-region lookup-or-generate onto the bp-sso-bridge OpenBao carrier — A16 class #5480; requires bp-sso-bridge >= 0.2.27)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -964,7 +964,37 @@ name: bp-newapi
 #   gap). Cross-region replication would be WRONG (the bearer must byte-match
 #   the REGION-LOCAL bridge ADMIN_SECRET), so the fix is the region-local
 #   producer. Pairs with bp-openbao 1.2.64 (external-secrets-push policy grant).
-version: 1.4.146
+# 1.4.147 (#5466 #5480, 2026-08-05): SESSION_SECRET/CRYPTO_SECRET stop being
+#   minted per region — the A16 class, the newapi instance PROVEN split live
+#   on hw291. credentials-secret.yaml generates them with `lookup`-or-
+#   `randAlphaNum 64`; on a 2-region Sovereign each region's own Flux/Helm
+#   misses the lookup and mints a DIFFERENT pair, and newapi.<fqdn> is fanned
+#   at BOTH regions' pods by one shared VIP — so the SSO code exchange
+#   SUCCEEDS in one region (region-B: GET /api/oauth/sovereign 200, user
+#   sovereign_2 created + promoted to role 100, verified in the region-B DB)
+#   and the SAME page load then hits region-A, which logs `[sessions] ERROR!
+#   securecookie: the value is not valid`, 401s /api/user/self, and dumps the
+#   user on /login?expired=true (UAT rows 37/38; #5466's filed premise of a
+#   KC-side 403 was falsified by the 2026-07-29 re-walk). FIX: carry both
+#   values on the SAME seam the sibling OIDC_CLIENT_SECRET has used since
+#   #3374 and the oauth2-proxy cookie secret since #5416 — bp-sso-bridge
+#   0.2.27 publishes `crypto_secret` (derived once per KC client, tag
+#   `crypto`) next to the pre-existing `session_secret` (#2807) in the
+#   OpenBao sso/sovereign/<cid> bundle, and the new templates/credentials-
+#   externalsecret.yaml (creationPolicy Owner, Secret `-app-creds-oidc`)
+#   delivers BOTH into every region; the Deployment reads them from it under
+#   bp-newapi.credsBridgeSynced (placement.role=all + kc mode + ssoBridgeSync
+#   + sovereign realm + no operator override + ESO capability). Everywhere
+#   the carrier is absent (vcluster-app — no ESO in the vCluster, per-Org
+#   issuer, masterKey mode, BYO existingSecret, sync off) the chart-generated
+#   fallback renders exactly as before. UPGRADE: until bp-sso-bridge 0.2.27's
+#   next tick lands crypto_secret in the bundle, a rolled Pod waits in
+#   CreateContainerConfigError, then starts on its own (#5416 hubble
+#   precedent; both pins bump in this commit). Requires bp-sso-bridge >=
+#   0.2.27. Render seam guarded by tests/5466-credentials-region-
+#   consistency-render.sh (fails on the pre-#5466 shape, plus a fallback
+#   vacuity control).
+version: 1.4.147
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -118,6 +118,63 @@ Helm has no boolean return; these emit the strings "true"/"false". Test with
 {{- end -}}
 
 {{/*
+#5466 / #5480 (A16 class) — is the region-consistent SESSION_SECRET/
+CRYPTO_SECRET bridge carrier ACTIVE for this install?
+
+credentials-secret.yaml's `lookup`-or-`randAlphaNum 64` is PER-CLUSTER: on a
+2-region Sovereign each region's own Flux/Helm hits its own apiserver, the
+lookup misses in the second region, and each region mints a DIFFERENT
+SESSION_SECRET/CRYPTO_SECRET pair. newapi.<fqdn> is fanned at BOTH regions'
+pods by one shared VIP, so a session cookie set by one region is rejected by
+the other (`[sessions] ERROR! securecookie: the value is not valid`, hw291,
+UAT rows 37/38). The fix rides the SAME carrier the sibling OIDC client
+secret already uses (#3374): bp-sso-bridge publishes derived, per-KC-client
+`session_secret`/`crypto_secret` properties into the OpenBao
+sso/sovereign/<clientId> bundle (0.2.27), and every region's ExternalSecret
+resolves that ONE bundle — never generated twice. Mirrors the #5416 fix for
+the oauth2-proxy cookie secret (bp-oidc-gate 0.1.8 / bp-cilium 1.4.18).
+
+"true" only when EVERY leg of the carrier is present for THIS install:
+  - placement.role == all — the sovereign-admin install (slot 80, #4291
+    de-vclustered): seams + app render in the SAME host cluster, so the
+    ExternalSecret lands next to the Pod. host-seams renders no Pod;
+    vcluster-app renders the Pod where ESO does NOT exist (the in-vCluster
+    placeholder path is unchanged — same scoping as keycloak-client-secret).
+  - adminUI keycloak mode + ssoBridgeSync.enabled + sovereignFQDN + a
+    sovereign-realm issuer — the EXACT gate set under which
+    sso-app-registration.yaml registers the KC client, which is what makes
+    bp-sso-bridge mint the client and publish the bundle this consumes.
+    A per-Org overlay (issuer realm org-<sub>, #4169) is excluded.
+  - no operator credentials.existingSecret override (Principle #4 — BYO
+    bytes always win).
+  - the ESO CRD capability — without it the ExternalSecret cannot render
+    and pointing the Pod at the bridge Secret would wedge it forever.
+When "false" everything renders exactly as pre-#5466.
+*/}}
+{{- define "bp-newapi.credsBridgeSynced" -}}
+{{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
+{{- $sync := .Values.auth.adminUI.keycloak.ssoBridgeSync -}}
+{{- $issuer := .Values.auth.adminUI.keycloak.issuer | default "" -}}
+{{- $issuerRealm := "" -}}
+{{- if $issuer -}}
+{{- $issuerRealm = regexReplaceAll ".*/realms/([^/?#]+).*" $issuer "${1}" -}}
+{{- end -}}
+{{- $issuerIsSovereign := or (not $issuer) (eq $issuerRealm "sovereign") -}}
+{{- if and (eq (include "bp-newapi.placementRole" .) "all") $kcMode $sync.enabled .Values.sovereignFQDN $issuerIsSovereign (not .Values.credentials.existingSecret) (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+#5466 — name of the bridge-published app-credentials Secret (ExternalSecret
+target, creationPolicy Owner). Distinct from the chart-generated
+`<fullname>-app-creds` (helm.sh/resource-policy: keep) so ESO needs no
+ownership takeover of a helm-kept object — the same reasoning #5416 used
+for the oidc-gate `-oidc` Secret.
+*/}}
+{{- define "bp-newapi.credsBridgeSecretName" -}}
+{{- printf "%s-app-creds-oidc" (include "bp-newapi.fullname" .) -}}
+{{- end -}}
+
+{{/*
 ServiceAccount name.
 */}}
 {{- define "bp-newapi.serviceAccountName" -}}

--- a/platform/newapi/chart/templates/credentials-externalsecret.yaml
+++ b/platform/newapi/chart/templates/credentials-externalsecret.yaml
@@ -1,0 +1,86 @@
+{{- /*
+#5466 / #5480 (2026-08-05) — region-consistent SESSION_SECRET + CRYPTO_SECRET
+via the bp-sso-bridge → OpenBao → ExternalSecret carrier.
+
+THE DEFECT THIS CLOSES (measured live on hw291, UAT rows 37/38): the app
+credentials were minted by credentials-secret.yaml's `lookup`-or-
+`randAlphaNum 64`. On a 2-region Sovereign each region runs its own
+Flux/Helm against its own apiserver, so the lookup misses in the second
+region and a DIFFERENT SESSION_SECRET/CRYPTO_SECRET pair is generated
+there. One shared VIP fans newapi.<fqdn> at BOTH regions' pods, so the SSO
+login's code exchange succeeded in region-B (`GET /api/oauth/sovereign`
+200, user `sovereign_2` created and promoted to role 100) while the SAME
+page load's next request hit region-A, which logged
+
+  [sessions] ERROR! securecookie: the value is not valid
+
+and returned 401 — the user lands on /login?expired=true signed out.
+(#5466 originally blamed a KC-side 403 on the exchange; the 2026-07-29
+re-walk falsified that — the exchange works, the SESSION_SECRET is split.
+This is the A16 class, swept in #5480.)
+
+WHY THIS CARRIER: the sibling OIDC_CLIENT_SECRET was ALREADY identical in
+both regions, and not by luck — it is never generated per region at all.
+Keycloak owns it (one DB shared by both regions, #4915); bp-sso-bridge
+(fed by sso-app-registration.yaml) publishes it to OpenBao
+`sso/sovereign/<clientId>`; each region's ExternalSecret resolves that ONE
+bundle through the ClusterSecretStore. bp-sso-bridge 0.2.27 adds
+`crypto_secret` to the bundle (derived deterministically per KC client —
+the idiom `session_secret` has used since #2807 and `cookie_secret` since
+#5416), so the app credentials now ride the proven carrier instead of
+being minted twice. No second synchronisation path is introduced.
+
+SEPARATE ExternalSecret from the sibling `-oidc-sync` (which Merge-targets
+the `newapi-oidc` placeholder) BY DESIGN: on an old-bridge/new-chart skew a
+bundle still missing `crypto_secret` fails THIS ExternalSecret only — the
+established OIDC_CLIENT_SECRET merge keeps converging. creationPolicy
+Owner on a NEW `-app-creds-oidc` Secret rather than merging into the
+chart-kept `-app-creds`: ESO never has to take over a helm-kept object
+(the #5416 `-oidc` reasoning), and the Pod's env only ever resolves from a
+Secret whose keys are ALREADY the region-consistent values — a Merge into
+the per-region placeholder would let each region's Pod start on its own
+split bytes and hold them (env vars never reload) until an unrelated roll.
+
+UPGRADE WINDOW (the #5416 hubble precedent): until bp-sso-bridge reaches
+0.2.27 and its next tick lands `crypto_secret` in the bundle, this
+ExternalSecret stays unsynced and a freshly rolled Pod waits in
+CreateContainerConfigError, then starts on its own. Both pins bump in the
+same commit. Existing sessions/encrypted tokens minted under the split
+per-region bytes are invalidated ONCE on the pivot — on the 2-region envs
+this fixes, they were already broken cross-region.
+
+Render gate == bp-newapi.credsBridgeSynced (_helpers.tpl): the exact
+sso-app-registration.yaml gate set (that is what guarantees the bundle
+exists) + placement.role=all + no operator override + the ESO capability.
+*/ -}}
+{{- if and (eq (include "bp-newapi.credsBridgeSynced" .) "true") .Values.newapi.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "bp-newapi.fullname" . }}-app-creds-sync
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    bp-sso-bridge.openova.io/consumer: bp-newapi
+spec:
+  refreshInterval: {{ .Values.auth.adminUI.keycloak.ssoBridgeSync.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.auth.adminUI.keycloak.ssoBridgeSync.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "bp-newapi.credsBridgeSecretName" . }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        SESSION_SECRET: "{{ "{{ .session_secret }}" }}"
+        CRYPTO_SECRET: "{{ "{{ .crypto_secret }}" }}"
+  data:
+    - secretKey: session_secret
+      remoteRef:
+        key: sso/sovereign/{{ .Values.auth.adminUI.keycloak.clientId }}
+        property: session_secret
+    - secretKey: crypto_secret
+      remoteRef:
+        key: sso/sovereign/{{ .Values.auth.adminUI.keycloak.clientId }}
+        property: crypto_secret
+{{- end }}

--- a/platform/newapi/chart/templates/credentials-secret.yaml
+++ b/platform/newapi/chart/templates/credentials-secret.yaml
@@ -24,11 +24,44 @@ autoProvision=true AND existingSecret is empty.
 
 helm.sh/resource-policy: keep so a `helm uninstall` + reinstall recovers
 the same bytes (otherwise an upgrade would silently rotate the keys).
+
+🛑 #5466 / #5480 — THIS TEMPLATE NO LONGER RENDERS ON THE SOVEREIGN-ADMIN
+DEFAULT PATH (placement.role=all + keycloak mode + ssoBridgeSync on).
+
+`lookup`-or-generate is PER-CLUSTER — the A16 class. On a 2-region Sovereign
+each region runs its own Flux/Helm against its own apiserver, so the lookup
+misses in the second region and a DIFFERENT SESSION_SECRET/CRYPTO_SECRET
+pair is minted there. newapi.<fqdn> is fanned at BOTH regions' pods by one
+shared VIP, so the SSO code exchange SUCCEEDS in one region (hw291 region-B:
+`GET /api/oauth/sovereign` 200, user created + promoted) and the SAME page
+load then hits the peer region, which cannot validate the cookie —
+region-A logged `[sessions] ERROR! securecookie: the value is not valid`
+and 401'd (#5466, UAT rows 37/38; #5466's filed premise of a KC-side 403
+was falsified by that walk).
+
+Under bp-newapi.credsBridgeSynced (see _helpers.tpl) the Deployment reads
+BOTH keys from the bp-sso-bridge-published `<fullname>-app-creds-oidc`
+Secret instead: bp-sso-bridge (>= 0.2.27) derives `session_secret` +
+`crypto_secret` once per KC client into the OpenBao sso/sovereign/<cid>
+bundle and templates/credentials-externalsecret.yaml delivers them
+identically to every region — the same carrier the sibling
+OIDC_CLIENT_SECRET has used since #3374, extended exactly the way #5416
+extended it for the oauth2-proxy cookie secret.
+
+This template remains the fallback for every shape where the carrier is
+absent: ssoBridgeSync off, masterKey mode, no sovereignFQDN, per-Org
+issuer, operator existingSecret, no ESO CRD, and placement.role
+vcluster-app (ESO does not exist inside the vCluster; the in-vCluster
+placeholder path is unchanged, #3831).
+
+NOTE on upgrade: an existing `<fullname>-app-creds` carries
+helm.sh/resource-policy: keep, so it stays behind un-consumed on the
+synced path — housekeeping, not correctness (#5416 precedent).
 */}}
 {{- /* #3831: SESSION_SECRET/CRYPTO_SECRET is a chart-generated random Secret the
    Pod reads — it renders WITH the app (placement.role all|vcluster-app), never
    host-side (a host copy would diverge from the in-vCluster random bytes). */ -}}
-{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.credentials.autoProvision (not .Values.credentials.existingSecret) -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.credentials.autoProvision (not .Values.credentials.existingSecret) (ne (include "bp-newapi.credsBridgeSynced" .) "true") -}}
 {{- $secretName := default (printf "%s-app-creds" (include "bp-newapi.fullname" .)) .Values.credentials.autoSecretName -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- $sessionSecret := "" -}}

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -39,9 +39,19 @@ the configmap mirrors this gate.
 {{- if and (not $effDbSecret) .Values.cnpg.enabled -}}
 {{- $effDbSecret = default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName -}}
 {{- end -}}
-{{- /* Resolve credentials secret: explicit override > chart auto-provision */ -}}
+{{- /* Resolve credentials secret: explicit override > bridge-synced (#5466) >
+   chart auto-provision. Under bp-newapi.credsBridgeSynced (placement.role=all
+   + keycloak mode + ssoBridgeSync + sovereign realm + ESO capability — see
+   _helpers.tpl) SESSION_SECRET/CRYPTO_SECRET come from the bp-sso-bridge-
+   published `-app-creds-oidc` Secret, whose values are derived ONCE per KC
+   client into the OpenBao sso/sovereign/<cid> bundle and delivered
+   identically to EVERY region — the chart-local `lookup`-or-randAlphaNum
+   generator minted a DIFFERENT pair per region behind the one shared VIP
+   (the hw291 `securecookie: the value is not valid` 401, A16 class #5480). */ -}}
 {{- $effCredsSecret := .Values.credentials.existingSecret -}}
-{{- if and (not $effCredsSecret) .Values.credentials.autoProvision -}}
+{{- if and (not $effCredsSecret) (eq (include "bp-newapi.credsBridgeSynced" .) "true") -}}
+{{- $effCredsSecret = include "bp-newapi.credsBridgeSecretName" . -}}
+{{- else if and (not $effCredsSecret) .Values.credentials.autoProvision -}}
 {{- $effCredsSecret = default (printf "%s-app-creds" (include "bp-newapi.fullname" .)) .Values.credentials.autoSecretName -}}
 {{- end -}}
 {{- /* Resolve sandbox token signing key secret: explicit override > chart auto-provision */ -}}
@@ -317,9 +327,15 @@ spec:
             {{- end }}
 
             # ── App credentials (NewAPI-internal) ─────────────────────
-            # Secret name resolution (issue #943):
+            # Secret name resolution (issue #943, #5466):
             #   1. .Values.credentials.existingSecret (operator override)
-            #   2. else chart-emitted credentials-secret.yaml output
+            #   2. else the bp-sso-bridge-published `-app-creds-oidc`
+            #      Secret when bp-newapi.credsBridgeSynced (#5466) —
+            #      SESSION_SECRET/CRYPTO_SECRET derived once per KC client
+            #      in the OpenBao bundle, so BOTH regions of a 2-region
+            #      Sovereign resolve ONE value and a session set behind
+            #      either region validates on the other (A16, #5480)
+            #   3. else chart-emitted credentials-secret.yaml output
             #      when .Values.credentials.autoProvision (DEFAULT true)
             - name: SESSION_SECRET
               valueFrom:

--- a/platform/newapi/chart/tests/5466-credentials-region-consistency-render.sh
+++ b/platform/newapi/chart/tests/5466-credentials-region-consistency-render.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# bp-newapi — #5466 / #5480 (A16 class): SESSION_SECRET/CRYPTO_SECRET must be
+# region-consistent on the sovereign-admin default path.
+#
+# THE DEFECT (hw291, UAT rows 37/38): credentials-secret.yaml minted the pair
+# with `lookup`-or-`randAlphaNum 64`. Each region's own Flux/Helm hits its own
+# apiserver, so the lookup misses in the second region and a DIFFERENT pair is
+# generated there — behind the one shared VIP the SSO code exchange succeeded
+# in region-B while region-A logged `[sessions] ERROR! securecookie: the value
+# is not valid` and 401'd the same page load. The fix rides the bp-sso-bridge
+# → OpenBao → ExternalSecret carrier (#3374 client secret, #5416 cookie
+# secret, now session/crypto): bp-sso-bridge >= 0.2.27 derives both once per
+# KC client into sso/sovereign/<cid> and every region resolves that ONE bundle.
+#
+# Cases (assert on VALUES, not key presence — the #5639 lesson):
+#   1.  Sovereign shape (role=all + kc + sync + ESO capability): the per-region
+#       generator renders NOTHING. This case FAILS on the pre-#5466 chart.
+#   1b. Same shape WITHOUT the ESO capability: the generator DOES render — the
+#       capability leg of the gate cannot wedge a cluster with no ESO CRD
+#       (and proves Case 1's empty render is the gate, not a broken template).
+#   2.  Deployment SESSION_SECRET + CRYPTO_SECRET secretKeyRefs pivot to the
+#       bridge-published `-app-creds-oidc` Secret. FAILS pre-#5466.
+#   3.  credentials-externalsecret.yaml delivers BOTH properties from
+#       sso/sovereign/<clientId> into that exact Secret (Owner).
+#   4.  Fallback (sync off) — vacuity control: the chart-managed Secret still
+#       renders with NON-EMPTY values for both keys and the Deployment
+#       references `-app-creds`; the ExternalSecret does NOT render.
+#   5.  Divergence control — two renders of the fallback generator (each
+#       render == one region's Helm run with an empty lookup) yield DIFFERENT
+#       SESSION_SECRET values: the exact per-region divergence mechanism the
+#       default path abandoned, reproduced in-test so Case 1/2 can never pass
+#       vacuously against a generator that was never divergent.
+#   6.  vcluster-app (no ESO inside the vCluster): the in-vCluster placeholder
+#       path is UNCHANGED — generator renders, no ExternalSecret, Deployment
+#       references `-app-creds`.
+#   7.  Operator override (credentials.existingSecret) beats the bridge path
+#       (Principle #4): Deployment references the BYO name, no ExternalSecret,
+#       no chart-managed Secret.
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+eso_api=(--api-versions external-secrets.io/v1beta1 --api-versions postgresql.cnpg.io/v1)
+no_eso_api=(--api-versions postgresql.cnpg.io/v1)
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# Release name `newapi` == bootstrap-kit slot 80's releaseName, so
+# bp-newapi.fullname renders `newapi-bp-newapi` exactly as live.
+release="newapi"
+creds_fallback="newapi-bp-newapi-app-creds"
+creds_bridge="newapi-bp-newapi-app-creds-oidc"
+
+sovereign_values=$(mktemp)
+trap 'rm -f "$sovereign_values"' EXIT
+cat > "$sovereign_values" <<'EOF'
+placement:
+  role: all
+cnpg:
+  enabled: true
+sovereignFQDN: t00.omani.works
+auth:
+  adminUI:
+    mode: keycloak
+    keycloak:
+      issuer: https://auth.t00.omani.works/realms/sovereign
+      existingSecret: newapi-oidc
+# The admin-token ExternalSecret hard-fails the WHOLE render when enabled
+# without its OpenBao path (#4477) — supply the canonical value the
+# bootstrap-kit overlay ships so every case renders the full chart.
+catalystIntegration:
+  externalSecret:
+    remoteRef:
+      key: catalyst/newapi/admin-token
+EOF
+
+# --show-only against a template whose render is empty makes helm exit
+# non-zero — capture output, tolerate THAT exit code, assert on content.
+# But a full-chart EXECUTION error also exits non-zero with no manifests,
+# which would make every renders-NOTHING assertion pass vacuously (this
+# exact trap fired during authoring: a missing required value failed the
+# whole render and Case 1 "passed" on the error text) — so hard-fail on it.
+show() { # show <template> <api-array-name> [extra helm args...]
+  local tpl="$1" apiname="$2"; shift 2
+  local -n api="$apiname"
+  local out
+  out=$("$helm" template "$release" "$chart_dir" -f "$sovereign_values" "${api[@]}" \
+    --show-only "templates/${tpl}" "$@" 2>&1) || true
+  if grep -qE "execution error|parse error|YAML parse" <<<"$out"; then
+    echo "FAIL: helm render ERRORED while showing ${tpl} — an empty-render assertion against this output would be vacuous:" >&2
+    echo "$out" | head -3 >&2
+    exit 1
+  fi
+  printf '%s' "$out"
+}
+
+# Secret-name backing a given env var in a rendered Deployment (VALUE assert).
+env_secret() { # env_secret <rendered> <ENV_NAME>
+  awk -v want="$2" '
+    $0 ~ ("- name: " want "$") {hit=1; next}
+    hit && /name:/ { v=$0; sub(/.*name:[ \t]*/,"",v); gsub(/["[:space:]]/,"",v); print v; exit }
+  ' <<<"$1"
+}
+
+# b64 value of a data key in a rendered Secret (VALUE assert).
+secret_value() { # secret_value <rendered> <KEY>
+  awk -v want="^[ \t]*$2:" '
+    $0 ~ want { v=$0; sub(/^[^:]*:[ \t]*/,"",v); gsub(/"/,"",v); print v; exit }
+  ' <<<"$1"
+}
+
+# ── Case 1: sovereign default — the per-region generator is GONE ─────────
+echo "[5466] Case 1: sovereign shape renders NO chart-managed credentials Secret"
+gen=$(show credentials-secret.yaml eso_api)
+if grep -q "kind: Secret" <<<"$gen"; then
+  echo "FAIL: #5466 — per-region lookup-or-generate credentials Secret still renders under the bridge-synced default" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 1b: no ESO capability → generator returns (no wedge) ────────────
+echo "[5466] Case 1b: without the ESO CRD capability the generator still renders"
+gen_noeso=$(show credentials-secret.yaml no_eso_api)
+if ! grep -q "kind: Secret" <<<"$gen_noeso"; then
+  echo "FAIL: capability leg — a cluster without ESO would get NO credentials Secret at all (Pod wedged forever)" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: Deployment env pivots to the bridge-published Secret ─────────
+echo "[5466] Case 2: SESSION_SECRET/CRYPTO_SECRET resolve from ${creds_bridge}"
+dep=$("$helm" template "$release" "$chart_dir" -f "$sovereign_values" "${eso_api[@]}" \
+  --show-only templates/deployment.yaml 2>&1)
+grep -q "kind: Deployment" <<<"$dep" || { echo "FAIL: Deployment did not render under the sovereign shape" >&2; exit 1; }
+for var in SESSION_SECRET CRYPTO_SECRET; do
+  src=$(env_secret "$dep" "$var")
+  if [ "$src" != "$creds_bridge" ]; then
+    echo "FAIL: #5466 — ${var} sourced from '${src}' (expected ${creds_bridge})" >&2
+    exit 1
+  fi
+done
+echo "  PASS"
+
+# ── Case 3: the ExternalSecret delivers BOTH bundle properties ───────────
+echo "[5466] Case 3: credentials-externalsecret.yaml maps session_secret + crypto_secret"
+es=$(show credentials-externalsecret.yaml eso_api)
+grep -q "kind: ExternalSecret" <<<"$es" || { echo "FAIL: credentials ExternalSecret did not render" >&2; exit 1; }
+grep -qE "name:[ \t]*${creds_bridge}$" <<<"$es" || { echo "FAIL: ExternalSecret target is not ${creds_bridge}" >&2; exit 1; }
+grep -q "creationPolicy: Owner" <<<"$es" || { echo "FAIL: ExternalSecret is not creationPolicy Owner" >&2; exit 1; }
+# VALUE asserts: the exact remoteRef bundle path + both properties + the
+# exact template mappings (an empty property or a renamed key must fail).
+[ "$(grep -c "key: sso/sovereign/newapi-admin" <<<"$es")" -eq 2 ] \
+  || { echo "FAIL: expected exactly 2 remoteRefs to sso/sovereign/newapi-admin" >&2; exit 1; }
+grep -q "property: session_secret" <<<"$es" || { echo "FAIL: remoteRef property session_secret missing" >&2; exit 1; }
+grep -q "property: crypto_secret"  <<<"$es" || { echo "FAIL: remoteRef property crypto_secret missing" >&2; exit 1; }
+grep -qE 'SESSION_SECRET:[ \t]*"\{\{ \.session_secret \}\}"' <<<"$es" \
+  || { echo "FAIL: template does not map SESSION_SECRET from .session_secret" >&2; exit 1; }
+grep -qE 'CRYPTO_SECRET:[ \t]*"\{\{ \.crypto_secret \}\}"' <<<"$es" \
+  || { echo "FAIL: template does not map CRYPTO_SECRET from .crypto_secret" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 4: sync off — chart-managed fallback intact (vacuity control) ───
+echo "[5466] Case 4: ssoBridgeSync=false keeps the chart-managed path byte-for-byte"
+off=(--set auth.adminUI.keycloak.ssoBridgeSync.enabled=false)
+gen_off=$(show credentials-secret.yaml eso_api "${off[@]}")
+grep -q "kind: Secret" <<<"$gen_off" || { echo "FAIL: fallback Secret missing with sync off" >&2; exit 1; }
+for key in SESSION_SECRET CRYPTO_SECRET; do
+  val=$(secret_value "$gen_off" "$key")
+  if [ -z "$val" ]; then
+    echo "FAIL: fallback Secret ${key} rendered EMPTY — the grep would pass on a hollow key (#5639 class)" >&2
+    exit 1
+  fi
+done
+dep_off=$("$helm" template "$release" "$chart_dir" -f "$sovereign_values" "${eso_api[@]}" "${off[@]}" \
+  --show-only templates/deployment.yaml 2>&1)
+for var in SESSION_SECRET CRYPTO_SECRET; do
+  src=$(env_secret "$dep_off" "$var")
+  if [ "$src" != "$creds_fallback" ]; then
+    echo "FAIL: sync off — ${var} sourced from '${src}' (expected ${creds_fallback})" >&2
+    exit 1
+  fi
+done
+es_off=$(show credentials-externalsecret.yaml eso_api "${off[@]}")
+if grep -q "kind: ExternalSecret" <<<"$es_off"; then
+  echo "FAIL: credentials ExternalSecret rendered with sync off" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 5: divergence control — the generator IS per-render divergent ───
+echo "[5466] Case 5: two fallback renders mint DIFFERENT SESSION_SECRETs (the A16 mechanism)"
+gen_off2=$(show credentials-secret.yaml eso_api "${off[@]}")
+v1=$(secret_value "$gen_off" SESSION_SECRET)
+v2=$(secret_value "$gen_off2" SESSION_SECRET)
+if [ -z "$v1" ] || [ -z "$v2" ]; then
+  echo "FAIL: divergence control extracted an empty value — control is vacuous" >&2
+  exit 1
+fi
+if [ "$v1" = "$v2" ]; then
+  echo "FAIL: two independent renders produced the SAME SESSION_SECRET — the generator is not the per-region divergence source this test exists to fence off; re-examine the template" >&2
+  exit 1
+fi
+echo "  PASS (render1 != render2 — exactly what two regions' Helm runs do)"
+
+# ── Case 6: vcluster-app placeholder path unchanged ──────────────────────
+echo "[5466] Case 6: vcluster-app keeps the in-vCluster placeholder (no ESO there)"
+vc=(--set placement.role=vcluster-app --set cnpg.enabled=false --set database.existingSecret=bp-newapi-newapi-db-dsn)
+gen_vc=$(show credentials-secret.yaml eso_api "${vc[@]}")
+grep -q "kind: Secret" <<<"$gen_vc" || { echo "FAIL: vcluster-app credentials placeholder no longer renders" >&2; exit 1; }
+es_vc=$(show credentials-externalsecret.yaml eso_api "${vc[@]}")
+if grep -q "kind: ExternalSecret" <<<"$es_vc"; then
+  echo "FAIL: credentials ExternalSecret rendered under vcluster-app (ESO does not exist in the vCluster)" >&2
+  exit 1
+fi
+dep_vc=$("$helm" template "$release" "$chart_dir" -f "$sovereign_values" "${eso_api[@]}" "${vc[@]}" \
+  --show-only templates/deployment.yaml 2>&1)
+src=$(env_secret "$dep_vc" SESSION_SECRET)
+if [ "$src" != "$creds_fallback" ]; then
+  echo "FAIL: vcluster-app SESSION_SECRET sourced from '${src}' (expected ${creds_fallback})" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 7: operator BYO override beats the bridge path ──────────────────
+echo "[5466] Case 7: credentials.existingSecret wins over the bridge carrier"
+byo=(--set credentials.existingSecret=my-byo-creds)
+dep_byo=$("$helm" template "$release" "$chart_dir" -f "$sovereign_values" "${eso_api[@]}" "${byo[@]}" \
+  --show-only templates/deployment.yaml 2>&1)
+src=$(env_secret "$dep_byo" SESSION_SECRET)
+if [ "$src" != "my-byo-creds" ]; then
+  echo "FAIL: BYO override — SESSION_SECRET sourced from '${src}' (expected my-byo-creds)" >&2
+  exit 1
+fi
+es_byo=$(show credentials-externalsecret.yaml eso_api "${byo[@]}")
+if grep -q "kind: ExternalSecret" <<<"$es_byo"; then
+  echo "FAIL: credentials ExternalSecret rendered despite operator existingSecret" >&2
+  exit 1
+fi
+gen_byo=$(show credentials-secret.yaml eso_api "${byo[@]}")
+if grep -q "kind: Secret" <<<"$gen_byo"; then
+  echo "FAIL: chart-managed credentials Secret rendered despite operator existingSecret" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[5466] ALL CASES PASS"

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -333,6 +333,21 @@ valkey:
 # Operator may bring their own bytes via per-Sovereign overlay setting
 # `existingSecret` — when non-empty it takes precedence and the chart-
 # emitted Secret is NOT rendered.
+#
+# #5466 / #5480 (A16 class): on the sovereign-admin default path
+# (placement.role=all + adminUI keycloak mode + ssoBridgeSync on +
+# sovereignFQDN + sovereign-realm issuer + ESO CRD present) the chart-
+# generated Secret is NOT rendered either — `lookup`-or-generate is
+# per-cluster, so each region of a 2-region Sovereign minted a DIFFERENT
+# SESSION_SECRET/CRYPTO_SECRET pair behind the one shared VIP and the
+# peer region 401'd every session it did not mint (hw291 `[sessions]
+# ERROR! securecookie: the value is not valid`, UAT rows 37/38). Instead
+# templates/credentials-externalsecret.yaml resolves both values from
+# the bp-sso-bridge-published OpenBao bundle sso/sovereign/<clientId>
+# (session_secret #2807 / crypto_secret 0.2.27 — derived once per KC
+# client), so EVERY region gets the same bytes — the identical carrier
+# the OIDC client secret (#3374) and the oauth2-proxy cookie secret
+# (#5416) already ride. Requires bp-sso-bridge >= 0.2.27.
 credentials:
   existingSecret: "" # operator-supplied (e.g. "newapi-app-creds")
   autoProvision: true

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.26
+  version: 0.2.27
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,22 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.26
+version: 0.2.27
+# 0.2.27 (#5466 #5480, 2026-08-05): PUBLISH `crypto_secret` in the
+# sso/<realm>/<cid> bundle — same A16-class extension as 0.2.26's
+# cookie_secret, this time for bp-newapi. newapi's chart minted
+# SESSION_SECRET + CRYPTO_SECRET with a `lookup`-or-`randAlphaNum 64`
+# template; on a 2-region Sovereign each region's own Flux/Helm misses the
+# lookup and mints a DIFFERENT pair behind the one shared VIP, so the
+# region that did not set the session cookie rejects it (`[sessions]
+# ERROR! securecookie: the value is not valid` on hw291 region-A after
+# region-B's exchange succeeded — the falsified-premise of #5466).
+# SESSION_SECRET consumes the bundle's EXISTING `session_secret` (#2807
+# idiom, tag `session`); `crypto_secret` is the same derivation with its
+# own domain-separation tag `crypto` (full 64-hex digest — newapi reads
+# the value as an opaque string, no base64url length constraint like
+# oauth2-proxy's cookie secret). Bundle-only change: consumers that don't
+# reference the key ignore it; every pre-0.2.27 ExternalSecret resolves
+# byte-identically.
 # 0.2.26 (#5416, 2026-07-27): PUBLISH `cookie_secret` in the sso/<realm>/<cid>
 # bundle + accept a MULTI-key `externalSecret.json` declaration.
 # WHY: every oauth2-proxy gate chart (bp-oidc-gate's three instances,

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -982,20 +982,43 @@ data:
       # is REJECTED at startup ("cookie_secret must be 16, 24, or 32 bytes").
       # Distinct from session_secret (different domain-separation tag) so a
       # consumer of one never gains the other.
-      local issuer session_secret cookie_secret
+      #
+      # #5466 (2026-08-05) — `crypto_secret`, the SAME derivation idiom, for
+      # bp-newapi's CRYPTO_SECRET (token-at-rest encryption key, read next to
+      # SESSION_SECRET by upstream's controller/auth.go).
+      #
+      # WHY IT BELONGS IN THIS BUNDLE: bp-newapi minted SESSION_SECRET +
+      # CRYPTO_SECRET with a `lookup`-or-`randAlphaNum 64` chart template
+      # (credentials-secret.yaml) — the exact A16 shape (#5480). On a 2-region
+      # Sovereign each region's own Flux/Helm misses the lookup and mints a
+      # DIFFERENT pair, and newapi.<fqdn> is fanned at BOTH regions' pods by
+      # one shared VIP, so the region that did not set the session cookie
+      # rejects it — measured live on hw291: region-B `GET
+      # /api/oauth/sovereign` 200 creates + promotes the SSO user, then the
+      # SAME page load hits region-A which logs `[sessions] ERROR!
+      # securecookie: the value is not valid` and 401s (UAT rows 37/38).
+      # SESSION_SECRET maps onto the bundle's existing `session_secret`
+      # (64-hex digest, tag `session`); CRYPTO_SECRET gets its own
+      # domain-separation tag `crypto`, full 64-hex digest (newapi consumes
+      # the value as an opaque string, no base64url length constraint), so a
+      # consumer of one never gains the other. Consumers that don't
+      # reference the key just ignore it, as with session/cookie.
+      local issuer session_secret cookie_secret crypto_secret
       issuer="https://auth.$(sovereign_fqdn)/realms/${realm}"
       session_secret="$(printf '%s|session|%s|%s' "${cid}" "${realm}" "${secret}" | sha256sum | awk '{print $1}')"
       cookie_secret="$(printf '%s|cookie|%s|%s' "${cid}" "${realm}" "${secret}" | sha256sum | awk '{print substr($1,1,32)}')"
+      crypto_secret="$(printf '%s|crypto|%s|%s' "${cid}" "${realm}" "${secret}" | sha256sum | awk '{print $1}')"
       local bundle
       bundle="$(jq -nc \
         --arg cid "${cid}" \
         --arg secret "${secret}" \
         --arg session "${session_secret}" \
         --arg cookie "${cookie_secret}" \
+        --arg crypto "${crypto_secret}" \
         --arg issuer "${issuer}" \
         --arg realm "${realm}" \
         '{client_id:$cid, client_secret:$secret, session_secret:$session,
-          cookie_secret:$cookie,
+          cookie_secret:$cookie, crypto_secret:$crypto,
           issuer_url:$issuer, realm:$realm,
           authorize_url:($issuer+"/protocol/openid-connect/auth"),
           token_url:($issuer+"/protocol/openid-connect/token"),

--- a/platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh
+++ b/platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh
@@ -66,4 +66,47 @@ if [ "$computed_session" != "$computed_session2" ]; then
 fi
 echo "PASS 5: derivation is render-stable (idempotent)"
 
+# ── #5466 — crypto_secret joins the bundle (bp-newapi CRYPTO_SECRET) ──────
+# Same derivation idiom, its own domain-separation tag `crypto`, full 64-hex
+# digest (newapi consumes an opaque string — no oauth2-proxy-style base64url
+# length constraint, so NO substr truncation like cookie_secret's).
+
+# Test 6: crypto_secret derivation present with the |crypto| tag
+if ! grep -q 'crypto_secret="\$(' <<<"$RENDERED"; then
+  echo "FAIL 6: crypto_secret derivation not found in rendered reconciler"
+  exit 1
+fi
+if ! grep -q '|crypto|' <<<"$RENDERED"; then
+  echo "FAIL 6: |crypto| domain-separation tag not in derivation"
+  exit 1
+fi
+echo "PASS 6: crypto_secret derivation present with |crypto| tag"
+
+# Test 7: jq bundle includes crypto_secret:$crypto
+if ! grep -q 'crypto_secret:\$crypto' <<<"$RENDERED"; then
+  echo "FAIL 7: jq bundle expression missing crypto_secret:\$crypto"
+  exit 1
+fi
+echo "PASS 7: jq bundle includes crypto_secret"
+
+# Test 8: crypto_secret is full-length 64-hex AND distinct from BOTH
+# session_secret and client_secret for the same inputs (value assert — a
+# tag typo collapsing crypto onto session must fail here).
+computed_crypto="$(printf '%s|crypto|%s|%s' "$test_cid" "$test_realm" "$test_client_secret" | sha256sum | awk '{print $1}')"
+if [ ${#computed_crypto} -ne 64 ]; then
+  echo "FAIL 8: crypto_secret not a full sha256 hex digest (len=${#computed_crypto})"
+  exit 1
+fi
+if [ "$computed_crypto" = "$computed_session" ] || [ "$computed_crypto" = "$test_client_secret" ]; then
+  echo "FAIL 8: crypto_secret collides with session_secret or client_secret"
+  exit 1
+fi
+# The rendered script must NOT truncate crypto_secret (that is cookie_secret's
+# constraint, not newapi's): the crypto_secret line must not contain substr.
+if grep 'crypto_secret=' <<<"$RENDERED" | grep -q 'substr'; then
+  echo "FAIL 8: crypto_secret derivation truncates the digest — newapi expects the full 64-hex string"
+  exit 1
+fi
+echo "PASS 8: crypto_secret is full 64-hex, domain-separated, untruncated"
+
 echo "=== ALL TESTS PASS ==="

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T04:31:50.589Z",
+  "generatedAt": "2026-08-04T16:31:38.254Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -3482,7 +3482,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.146",
+      "version": "1.4.147",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -4852,7 +4852,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3617,7 +3617,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.146",
+    "version": "1.4.147",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -4987,7 +4987,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.26",
+    "version": "0.2.27",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2326,7 +2326,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.146"
+  version: "1.4.147"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2371,7 +2371,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.146"
+    version: "1.4.147"
   topology:
     supported:
     - active-passive
@@ -5177,7 +5177,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.26"
+  version: "0.2.27"
   visibility: unlisted
   card:
     title: "SSO Bridge"
@@ -5194,7 +5194,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-sso-bridge
-    version: "0.2.26"
+    version: "0.2.27"
   topology:
     supported:
       - active-passive


### PR DESCRIPTION
Refs #5466 #5480 #960

## The defect

bp-newapi minted `SESSION_SECRET` + `CRYPTO_SECRET` with a `lookup`-or-`randAlphaNum 64` template (`credentials-secret.yaml`). On a 2-region Sovereign each region runs its own Flux/Helm against its own apiserver, so the same-cluster `lookup` misses in the second region and each region carries a DIFFERENT pair — the A16 class (#5480), the newapi instance PROVEN split live on hw291. One shared VIP fans `newapi.<fqdn>` at both regions' pods, so the SSO login's code exchange succeeds in the region that serves it (region-B: `GET /api/oauth/sovereign` 200, user `sovereign_2` created + promoted to role 100, verified in the region-B DB) and the SAME page load's next request hits region-A, which logs

```
[sessions] ERROR! securecookie: the value is not valid
```

401s `/api/user/self`, and dumps the user on `/login?expired=true` — UAT rows 37/38. (#5466's filed premise of a KC-side 403 on the exchange was falsified by the 2026-07-29 re-walk recorded on the issue; the user-visible symptom it names is real.)

## The mechanism reused — #5416's carrier, extended, not a new one

The sibling `OIDC_CLIENT_SECRET` was already region-consistent, and not by luck: it is never generated per region. Keycloak owns it (one DB shared by both regions, #4915), `bp-sso-bridge` publishes it to the OpenBao `sso/sovereign/<clientId>` bundle, and each region's ExternalSecret resolves that ONE bundle. PR #5428 moved the oauth2-proxy cookie secret onto that carrier for the same defect class; this PR does the identical move for newapi's app credentials:

| Chart | Change |
|---|---|
| `bp-sso-bridge` 0.2.27 | publishes `crypto_secret` in the bundle — the `session_secret` (#2807) / `cookie_secret` (#5416) derivation idiom with its own domain-separation tag `crypto`, full 64-hex (newapi consumes an opaque string; no oauth2-proxy base64url 16/24/32-byte constraint, hence no truncation) |
| `bp-newapi` 1.4.147 | `SESSION_SECRET` consumes the bundle's pre-existing `session_secret`; `CRYPTO_SECRET` consumes the new `crypto_secret`. New `credentials-externalsecret.yaml` (creationPolicy **Owner**, Secret `<fullname>-app-creds-oidc`) delivers both; the Deployment reads both from it; the per-region generator no longer renders on that path |

The switch (`bp-newapi.credsBridgeSynced`, `_helpers.tpl`) is ON only when every leg of the carrier is present: `placement.role=all` (the sovereign-admin slot-80 shape, #4291 — seams + app in the same host cluster), keycloak mode + `ssoBridgeSync.enabled` + `sovereignFQDN` + sovereign-realm issuer (the exact gate set under which `sso-app-registration.yaml` makes the bridge mint the client and publish the bundle; a per-Org `org-<sub>` issuer is excluded, #4169), no operator `credentials.existingSecret` (Principle #4 — BYO wins), and the ESO CRD capability. Everywhere the carrier is absent — `vcluster-app` (no ESO inside the vCluster, #3831), sync off, masterKey mode, BYO — the chart-generated fallback renders byte-for-byte as before.

Two deliberate divergences from a naive port of #5428, both defensive:

- **Separate ExternalSecret** from the existing `-oidc-sync` (which Merge-targets the `newapi-oidc` placeholder): on an old-bridge/new-chart skew, a bundle still missing `crypto_secret` fails only the new ES — the established `OIDC_CLIENT_SECRET` merge keeps converging.
- **Owner on a new Secret** rather than Merge into the chart-kept `-app-creds`: ESO never has to take over a `helm.sh/resource-policy: keep` object (the #5416 `-oidc` reasoning), and the Pod's env only ever resolves from a Secret whose keys are ALREADY the region-consistent values — a Merge into the per-region placeholder would let each region's Pod start on its own split bytes and hold them (env never reloads) until an unrelated roll.

## Verification — the test fails on the pre-fix shape, both directions

`platform/newapi/chart/tests/5466-credentials-region-consistency-render.sh`:

- **Pre-fix chart** (`origin/main` `platform/newapi` extracted verbatim, same test): `FAIL: #5466 — per-region lookup-or-generate credentials Secret still renders under the bridge-synced default`, exit 1.
- **This branch**: all 7 cases pass — generator gone under the default (Case 1); no-ESO capability keeps the generator so a cluster without ESO can never wedge (1b); both env `secretKeyRef`s pivot to `newapi-bp-newapi-app-creds-oidc`, asserted on the VALUE (2); the ES maps exactly 2 remoteRefs to `sso/sovereign/newapi-admin` with properties `session_secret` + `crypto_secret` (3); fallback vacuity control — sync off renders both keys with NON-empty values and `-app-creds` consumption, no ES (4); **divergence control** — two renders of the fallback generator mint DIFFERENT `SESSION_SECRET`s, reproducing the exact per-region mechanism in-test so Cases 1/2 can never pass vacuously against a generator that was never divergent (5); `vcluster-app` placeholder path unchanged (6); BYO `existingSecret` beats the bridge (7).
- The test's `show()` hard-fails on helm execution errors: during authoring, a missing required value failed the WHOLE render and the renders-nothing assertion "passed" on the error text — the guard turns that trap into a loud failure.

`platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh` extended (Tests 6–8: derivation present with `|crypto|` tag, jq bundle includes `crypto_secret:$crypto`, full 64-hex, untruncated, distinct from session/client by value). Pre-fix reconciler: `FAIL 6`, exit 1. This branch: 8/8 pass.

Green locally: all 8 bp-newapi chart tests · all 9 bp-sso-bridge chart tests · `helm lint` ×2 · `bash -n` on the RENDERED `reconcile.sh` (1224 lines, extracted from the rendered ConfigMap) · `check-catalog-seed-lockstep.sh` (68 checked, 0 fail) · `check-bootstrap-kit-pin-sync.sh` (67 pairs, PASS) · `tests/e2e/bootstrap-kit` go test. No Service/port surface is touched anywhere in the diff (nodeport canon unaffected).

## Lockstep sites

- `platform/newapi/chart/Chart.yaml` 1.4.147 + `platform/newapi/blueprint.yaml`
- `platform/sso-bridge/chart/Chart.yaml` 0.2.27 + `platform/sso-bridge/blueprint.yaml`
- `clusters/_template/bootstrap-kit/80-newapi.yaml` → 1.4.147, `13b-bp-sso-bridge.yaml` → 0.2.27
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (both charts, both pin sites each)
- `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` + `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` — regenerated via `build-catalog.mjs`, version-only diff

## Rollout note (the #5416 hubble precedent)

`bp-newapi` 1.4.147 requires `bp-sso-bridge` >= 0.2.27 for `crypto_secret` to exist in the bundle. Both pins bump in this commit; between the two upgrades a rolled newapi Pod waits in `CreateContainerConfigError`, then starts once the bridge's next tick lands the property. Sessions/encrypted tokens minted under the split per-region bytes are invalidated ONCE on the pivot — on the 2-region envs this fixes they were already broken cross-region. The old `-app-creds` Secret carries `helm.sh/resource-policy: keep` and stays behind unconsumed on the synced path (housekeeping, not correctness).

## Runtime proof owed (next 2-region walk)

1. `SESSION_SECRET`/`CRYPTO_SECRET` hashes match across regions (fresh-TCP curl sampling, not a browser loop — HTTP/2 pins one backend).
2. Rows 37/38: bare `newapi.<fqdn>` lands on `/console` signed in on the first hit and on re-entry, with the `users` table showing the SSO-bound root — through the VIP, whichever region serves each leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
