### PR TITLE
fix(cutover): secondary-region pivot target defaults to the Sovereign's own Gitea door — retire the headless-doomed mesh candidate (0.1.166)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1049,7 +1049,12 @@ spec:
       # default", which detect holds literally, and shipping it off left the
       # gap as silent as the issue describes. Step count stays 11; no RBAC
       # change. New chart test tests/daytwo-image-leg.sh + contract Case 75.
-      version: 0.1.165
+      # 0.1.166 (#5359): the step-05 secondary-region pivot target defaults to
+      # the Sovereign's OWN external Gitea door (https://gitea.<fqdn>) — the
+      # in-cluster mesh candidate is retired (headless gitea-http cannot be
+      # mesh-shared and the secondary's own empty Gitea answers that name, the
+      # hw292 gen=2/obs=1 stick), and an empty candidate chain fails loud.
+      version: 0.1.166
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1308,7 +1308,12 @@ spec:
       #   API_SESSION_TIMEOUT aligned to the oidc-gate session so >60-min
       #   revisits stop 403-wedging on a dead cached token; lockstep w/
       #   slot-52 pin 0.2.34 (pin-sync gate).
-      version: 1.4.1282
+      # 1.4.1283 (#5359): catalog-seed bp-self-sovereign-cutover 0.1.165 ->
+      #   0.1.166 — secondary-region pivot target defaults to the Sovereign's
+      #   own external Gitea door; the headless-doomed in-cluster mesh
+      #   candidate is retired. Lockstep w/ slot-06a pin 0.1.166 (pin-sync
+      #   gate).
+      version: 1.4.1283
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.165
+  version: 0.1.166
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,59 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.166 (#5359, Refs #5656 #5650 #5591 #5511 #960) — the secondary-region pivot
+# target defaults to the Sovereign's OWN external Gitea door, and the doomed
+# in-cluster mesh candidate is retired from the default chain.
+#
+# WHY (hw292, dep 1c56518035a83e03, code-anchored). The 0.1.151..0.1.165 default
+# chain tried `gitea-http.gitea.svc` first, expecting the step-05 ClusterMesh
+# global-Service leg to carry the dial to region-A. It structurally cannot:
+# both regions' gitea-http Services are HEADLESS (clusterIP: None), which
+# Cilium global-services do not span (CoreDNS answers a headless name from the
+# LOCAL EndpointSlice), and the secondary runs its OWN empty bp-gitea behind
+# the same name — so region-b fetched its own zero-ref Gitea, failed every
+# fetch with "pkt-line 3: EOF", and sat at generation=2/observedGeneration=1
+# for 22h. The stick is source-controller v1.4.1 semantics, not a status bug:
+# ComputeReconcileResult adds patch.WithStatusObservedGeneration ONLY on the
+# nil-error / Stalling / Generic-Ignore branches, so a permanently-failing
+# fetch NEVER advances observedGeneration — which is exactly why 0.1.164's
+# convergence predicate is the sound one, and why the doomed candidate burned
+# a full gitRepositoryReadySeconds window per region per cutover before the
+# chain even reached a viable URL.
+#
+# THE CHANGE.
+# 1. DEFAULT secondary chain = https://gitea.<fqdn>/<org>/<repo> — the door is
+#    ON-Sovereign (its own gateway VIP, served DIRECT per §854 — never a
+#    NodePort), needs no cross-region Service-DNS assumption, satisfies the
+#    step-08 source-host lint's *.<fqdn> exemption, and is the only target
+#    live-proven to serve the PIVOTED revision from a secondary (hw292
+#    region-b: HEAD 7bcd1d59..., byte-identical to region-A's Gitea).
+#    secondaryRegions.giteaURL still pins one explicit URL (the qaTestEnabled
+#    LE-staging path); giteaFallbackURL/giteaFallbackToPublicDoor keep their
+#    key names (#5323 key-rename class) but now define the DEFAULT target.
+# 2. The mesh leg (annotate region-A's gitea-http global + same-named alias
+#    Service applied into the secondary) is DELETED, with its now-unused
+#    gitea-http services patch/update RBAC rule. The alias apply also fought
+#    the secondary's own bp-gitea for the Service name — live drift, not just
+#    dead code.
+# 3. An EMPTY chain (door disabled, nothing pinned) fails LOUD at the first
+#    secondary region with result=failed + an actionable lastError, instead of
+#    leaving the region tethered or pivoting it to an unreachable URL.
+#
+# PROVEN BOTH DIRECTIONS. tests/step05-secondary-chain.sh drives the rendered
+# leg under sh/dash/bash with set -eu: door-default converge, stale-Ready
+# (gen!=obs) rejection, operator pin, empty-chain FATAL + status stamp, and
+# two render discriminators (door-first chain; mesh machinery absent) each
+# mutation-proven against the verbatim pre-0.1.166 shape. The full suite run
+# against the 0.1.165 template exits 1 with 6 assertions red (the two
+# discriminators, the empty-chain diagnosis under all three shells, and the
+# empty-chain status stamp); against 0.1.166 it is 20/20 green.
+#
+# NOT COVERED (recorded, not swept): step-04's secondary node-layer containerd
+# pivot (the tracked #5379 remainder), and the secondary's own Gitea stays
+# empty — the door routes every secondary to region-A's Gitea, so a region-A
+# loss leaves secondaries without a git source until the per-region mirror
+# lands (the #5359-thread DR gap). Step count unchanged at 11; no new values.
+#
 # 0.1.165 (#5640 round 2, Refs #5644 #5265 #4975 #960) — the Day-2 delivery path
 # becomes one that can ACTUALLY deliver, and an unpullable pin becomes a FAILING
 # condition instead of a silent freeze.
@@ -3169,7 +3223,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.165
+version: 0.1.166
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -35,22 +35,36 @@ patch this Job iterates every kubeconfig in /secondary-kubeconfigs
 at run start from its on-PVC secondary kubeconfig store; mounted
 optional:true so a single-region Sovereign renders the leg inert) and:
 
-  1. establishes the ClusterMesh global-Service path to the local
-     Gitea (the bp-cnpg-pair / bp-openbao cross-region-mesh idiom):
-     annotates region-A's gitea-http Service `service.cilium.io/
-     global=true` + creates the same-named zero-backend alias Service
-     in the secondary's `gitea` namespace, so `gitea-http.gitea.svc`
-     resolves there and the dial crosses the mesh to region-A;
-  2. mirrors the basic-auth Secret into the secondary's flux-system;
-  3. applies the SAME url/branch/secretRef/ignore patch to the
-     secondary's GitRepository (secondaryRegions.giteaURL overrides
-     the URL; empty = the same in-cluster URL region-A uses);
-  4. FAIL-LOUD waits for the secondary GitRepository to reach
-     Ready=True on the pivoted URL (secondaryRegions.
-     gitRepositoryReadySeconds) — succeeding without region-B
-     reconciling local Gitea would re-mint the #5359 false positive;
-  5. records `step.flux-gitrepository-patch.region.<key>.result` on
+  1. mirrors the basic-auth Secret into the secondary's flux-system;
+  2. applies the SAME branch/secretRef/ignore patch to the secondary's
+     GitRepository with the URL from the candidate chain — DEFAULT is
+     the Sovereign's OWN external Gitea door https://gitea.<fqdn>/...
+     (the only target live-proven reachable from a secondary; hw292);
+     secondaryRegions.giteaURL pins one explicit URL instead;
+  3. FAIL-LOUD waits for the secondary GitRepository to CONVERGE —
+     observedGeneration == generation with Ready=True (secondaryRegions.
+     gitRepositoryReadySeconds per candidate); succeeding without
+     region-B reconciling the pivoted URL would re-mint the #5359
+     false positive;
+  4. records `step.flux-gitrepository-patch.region.<key>.result` on
      the status ConfigMap (the per-region tracking #5359 asks for).
+
+The 0.1.151..0.1.165 ClusterMesh global-Service leg (annotate region-A's
+gitea-http + a same-named alias Service in the secondary) is DELETED,
+not parked: both regions' gitea-http Services are HEADLESS (clusterIP:
+None), which Cilium global-services cannot span — CoreDNS answers a
+headless name straight from the LOCAL EndpointSlice — and the secondary
+runs its OWN (empty, never-mirrored) bp-gitea behind that same name, so
+from a secondary the in-cluster URL can never converge; even a
+non-headless global pair would MERGE the empty local backend into the
+pool. hw292 measured the consequence: region-b resolved the name to its
+own zero-ref Gitea (10.43.3.228), source-controller failed every fetch
+with "pkt-line 3: EOF", and — because source-controller v1.4.1 advances
+status.observedGeneration only on a SUCCESSFUL reconcile
+(ComputeReconcileResult adds WithStatusObservedGeneration on the nil /
+Stalling / Generic-Ignore branches only) — the object sat at
+generation=2 / observedGeneration=1 for 22h, serving the pre-pivot
+github.com artifact behind a result=success stamp.
 
 Image phase: post.
 */ -}}
@@ -105,20 +119,24 @@ data:
             value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
           - name: GIT_AUTH_USERNAME
             value: {{ .Values.gitRepositorySecretRef.username | quote }}
-          # #5359 — secondary-region leg inputs. SECONDARY_GITEA_URL empty =
-          # reuse LOCAL_GITEA_URL (the in-cluster Service URL, reachable from
-          # the secondary via the ClusterMesh global-Service alias this leg
-          # establishes). STATUS_CONFIGMAP receives the per-region
+          # #5359 — secondary-region leg inputs. SECONDARY_GITEA_URL non-empty
+          # pins the candidate chain to exactly that URL (explicit operator
+          # intent, e.g. the qaTestEnabled LE-staging case where the public
+          # door is x509-hostile). Empty (default) = the chain is the door
+          # below. STATUS_CONFIGMAP receives the per-region
           # step.<step>.region.<key>.* tracking keys.
           - name: SECONDARY_GITEA_URL
             value: {{ if .Values.secondaryRegions.giteaURL }}{{ printf "%s/%s/%s" (.Values.secondaryRegions.giteaURL | trimSuffix "/") .Values.gitea.org .Values.gitea.repo | quote }}{{ else }}""{{ end }}
-          # #5359 — the fallback candidate, tried only if the in-cluster mesh
-          # URL fails to CONVERGE in the secondary. Defaults to the Sovereign's
-          # OWN external Gitea door, which is on-Sovereign (it satisfies the
-          # step-08 source-host lint's *.<fqdn> exemption) and is the only path
-          # live-proven to serve region-A's pivoted repo from region-B on hw292.
-          # Set secondaryRegions.giteaFallbackURL to "" to disable the fallback
-          # and make a mesh failure immediately fatal.
+          # #5359 — the DEFAULT pivot target for secondaries: the Sovereign's
+          # OWN external Gitea door. On-Sovereign (its own gateway VIP — it
+          # satisfies the step-08 source-host lint's *.<fqdn> exemption, and
+          # the step-08 secondary hold carves out that gateway's public IPs)
+          # and the only path live-proven to serve region-A's pivoted repo
+          # from region-B (hw292: HEAD 7bcd1d59..., byte-identical to
+          # region-A's in-cluster Gitea). The in-cluster mesh URL is retired
+          # from the default chain — see the leg header. The env name keeps
+          # its historical FALLBACK spelling so pinned values files and the
+          # contract tests stay stable across the 0.1.166 default flip.
           - name: SECONDARY_GITEA_FALLBACK_URL
             value: {{ if .Values.secondaryRegions.giteaFallbackURL }}{{ printf "%s/%s/%s" (.Values.secondaryRegions.giteaFallbackURL | trimSuffix "/") .Values.gitea.org .Values.gitea.repo | quote }}{{ else if .Values.secondaryRegions.giteaFallbackToPublicDoor }}{{ printf "https://gitea.%s/%s/%s" .Values.sovereign.fqdn .Values.gitea.org .Values.gitea.repo | quote }}{{ else }}""{{ end }}
           - name: SECONDARY_GITREPO_READY_SECONDS
@@ -230,43 +248,48 @@ data:
             # Empty/absent = single-region Sovereign = this whole block
             # no-ops (pre-#5359 behavior byte-identical).
             #
-            # #5359 CANDIDATE URL CHAIN (hw292, dep 1c56518035a83e03). The leg
-            # used to pivot the secondary to LOCAL_GITEA_URL unconditionally —
-            # `http://gitea-http.gitea.svc.cluster.local:3000`. That name does
-            # NOT reach region-A from a secondary region, and the mesh alias
-            # below cannot make it: a 2-region Sovereign installs bp-gitea in
-            # BOTH regions from the bootstrap-kit, so the secondary already runs
-            # its own `gitea/gitea-http` Service whose selector matches its own
-            # (empty, never mirrored) Gitea pod; and BOTH Services are HEADLESS
-            # (clusterIP: None), which Cilium ClusterMesh global-services cannot
-            # span at all — a headless Service is resolved by CoreDNS straight
-            # from the LOCAL EndpointSlice, so `service.cilium.io/global` is
-            # inert on it. Live on hw292: region-b resolved that name to
-            # 10.43.3.228, its OWN gitea pod, whose openova/openova advertises
-            # zero refs, giving source-controller "pkt-line 3: EOF" on every
-            # fetch from 07:39:48Z onward.
+            # #5359 CANDIDATE URL CHAIN (hw292, dep 1c56518035a83e03). The
+            # DEFAULT chain for a secondary is the Sovereign's OWN external
+            # Gitea door (SECONDARY_GITEA_FALLBACK_URL,
+            # https://gitea.<fqdn>/...): on-Sovereign, world-reachable through
+            # the Sovereign's own gateway VIP with no cross-region Service-DNS
+            # assumption, and the only target live-proven to serve region-A's
+            # pivoted repo from a secondary — hw292 region-b fetched HEAD
+            # 7bcd1d59... through it, byte-identical to region-A's in-cluster
+            # Gitea, while the in-cluster name served zero refs.
             #
-            # So the URL is a candidate, not a certainty, and the only honest
-            # prober is the secondary's OWN source-controller: it dials the exact
-            # URL, from the right cluster, with the right credential. Each
-            # candidate is patched in and given a bounded window to CONVERGE
-            # (below); the first that converges wins, and exhausting the chain is
-            # fatal. The fallback is the Sovereign's own external Gitea door,
-            # which is on-Sovereign (it satisfies the step-08 source-host lint's
-            # *.<SOVEREIGN_FQDN> exemption, and the step-08 secondary hold
-            # already carves out that gateway's public IPs) and was
-            # live-verified reachable from hw292 region-b, serving the pivoted
-            # revision 7bcd1d59... byte-identical to region-A's in-cluster Gitea.
+            # LOCAL_GITEA_URL (gitea-http.gitea.svc) is region-A's OWN patch
+            # target only — it is NOT in the default secondary chain any more.
+            # From a secondary that name resolves to the secondary's own empty
+            # bp-gitea (both Services headless, so the ClusterMesh
+            # global-Service annotation is inert — see the leg header), proven
+            # on hw292 as "pkt-line 3: EOF" on every fetch, generation=2 /
+            # observedGeneration=1 for 22h behind a result=success stamp.
+            # Keeping it as a leading candidate would burn
+            # gitRepositoryReadySeconds per region on a target that
+            # structurally cannot converge there.
+            #
+            # The only honest prober is the secondary's OWN source-controller:
+            # it dials the exact URL, from the right cluster, with the right
+            # credential. Each candidate is patched in and given a bounded
+            # window to CONVERGE (below); the first that converges wins, and
+            # exhausting the chain — or having NO candidate configured — is
+            # fatal, never a soft skip.
             sec_url_chain="${SECONDARY_GITEA_URL:-}"
             if [ -z "${sec_url_chain}" ]; then
-              sec_url_chain="${LOCAL_GITEA_URL}"
-              [ -n "${SECONDARY_GITEA_FALLBACK_URL:-}" ] && sec_url_chain="${sec_url_chain} ${SECONDARY_GITEA_FALLBACK_URL}"
+              sec_url_chain="${SECONDARY_GITEA_FALLBACK_URL:-}"
             fi
-            echo "[flux-gitrepository-patch] #5359 secondary candidate URL chain: ${sec_url_chain}"
+            echo "[flux-gitrepository-patch] #5359 secondary candidate URL chain: ${sec_url_chain:-<none configured>}"
             for skc in /secondary-kubeconfigs/*.yaml; do
               [ -e "${skc}" ] || continue
               region=$(basename "${skc}" .yaml)
-              # ${sec_url_chain}, NOT ${sec_url}: the single-URL variable now
+              if [ -z "${sec_url_chain}" ]; then
+                echo "[flux-gitrepository-patch] FATAL: secondary region ${region} has NO candidate pivot URL — secondaryRegions.giteaURL and .giteaFallbackURL are empty and .giteaFallbackToPublicDoor=false. An unpivoted secondary keeps reconciling its pre-cutover github.com source and reverts every per-region pivot on its next Kustomization interval (#5359); set one of those values — refusing to succeed (#5359)" >&2
+                kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                  -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"failed\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.flux-gitrepository-patch.region.${region}.lastError\":\"no candidate pivot URL configured\"}}" || true
+                exit 1
+              fi
+              # ${sec_url_chain}, NOT ${sec_url}: the single-URL variable
               # exists only inside the candidate loop below, and this line runs
               # before it. Under the Job's `set -u` a stale reference here is
               # not a cosmetic log bug — it aborts the leg on the FIRST
@@ -274,53 +297,14 @@ data:
               # Sovereign.
               echo "[flux-gitrepository-patch] #5359 secondary region ${region}: pivoting its GitRepository, candidates -> ${sec_url_chain}"
 
-              # 1a. Share region-A's gitea-http endpoints into the mesh (the
-              # bp-cnpg-pair global-Service idiom). Annotating the LIVE
-              # Service is additive + idempotent; the durable bp-gitea-side
-              # annotation is tracked on #5359.
-              kubectl -n gitea annotate --overwrite service gitea-http \
-                "service.cilium.io/global=true" "service.cilium.io/shared=true" \
-                || echo "[flux-gitrepository-patch] WARN: could not annotate gitea/gitea-http global (mesh share) — secondary clone will fail if the alias has no reachable backend"
-
-              # 1b. Same-named zero-backend alias Service in the SECONDARY
-              # cluster so gitea-http.gitea.svc resolves there and the dial
-              # crosses the mesh to region-A (bp-openbao
-              # cross-region-mesh-service.yaml is the reference shape).
-              cat >/tmp/gitea-mesh-alias.yaml <<EOF
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-              name: gitea
-            ---
-            apiVersion: v1
-            kind: Service
-            metadata:
-              name: gitea-http
-              namespace: gitea
-              labels:
-                app.kubernetes.io/managed-by: self-sovereign-cutover
-                catalyst.openova.io/component: cutover-secondary-gitea-mesh-alias
-              annotations:
-                service.cilium.io/global: "true"
-                catalyst.openova.io/mirrored-from: region-a/gitea/gitea-http
-            spec:
-              type: ClusterIP
-              selector:
-                app.kubernetes.io/name: gitea
-              ports:
-                - name: http
-                  port: 3000
-                  targetPort: 3000
-                  protocol: TCP
-            EOF
-              kubectl --kubeconfig "${skc}" apply -f /tmp/gitea-mesh-alias.yaml
-
-              # 2. Basic-auth Secret in the secondary's flux-system (same PAT
-              # bytes written to /tmp/git-auth-secret.yaml above).
+              # 1. Basic-auth Secret in the secondary's flux-system (same PAT
+              # bytes written to /tmp/git-auth-secret.yaml above). The door
+              # terminates on the same Gitea behind the same
+              # REQUIRE_SIGNIN_VIEW=true, so the same PAT authenticates it.
               kubectl --kubeconfig "${skc}" apply -f /tmp/git-auth-secret.yaml
 
-              # 3. Same patch shape as region-A (URL may differ via
-              # secondaryRegions.giteaURL).
+              # 2. Same patch shape as region-A (URL from the candidate
+              # chain; secondaryRegions.giteaURL pins it).
               if ! kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" >/dev/null 2>&1; then
                 echo "[flux-gitrepository-patch] #5359 secondary ${region}: GitRepository ${GITREPO_NAMESPACE}/${GITREPO_NAME} absent — no flux git tether to pivot in this region; recording skipped"
                 kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
@@ -353,7 +337,7 @@ data:
                   -n "${GITREPO_NAMESPACE}" \
                   "reconcile.fluxcd.io/requestedAt=$(date +%s)"
 
-                # 4. FAIL-LOUD readiness. #5359 (hw292): the predicate here USED
+                # 3. FAIL-LOUD readiness. #5359 (hw292): the predicate here USED
                 # to be `Ready == True && spec.url == sec_url`, and both halves
                 # were unsound.
                 #
@@ -404,7 +388,7 @@ data:
                 exit 1
               fi
 
-              # 5. Per-region durable tracking (#5359). giteaURL records WHICH
+              # 4. Per-region durable tracking (#5359). giteaURL records WHICH
               # candidate converged, so an operator can see from the status
               # ConfigMap alone whether the secondary took the in-cluster mesh
               # path or the Sovereign's external Gitea door.

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -147,10 +147,6 @@ rules:
   - apiGroups: [""]
     resources: ["services"]   # #4639 (Refs #4637): registry-pivot DaemonSet resolves the cilium-gateway Service ClusterIP (node-routable, serves registry.<fqdn> wildcard TLS + token realm) for the dfdaemon hostAlias instead of the un-hairpinnable public gateway EIP
     verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["services"]   # #5359 step-05 secondary leg: annotate gitea-http with service.cilium.io/global+shared so the region-B zero-backend alias resolves it over ClusterMesh; without patch the annotate 403s and every 2-region cutover dies at the step-05 Ready wait
-    resourceNames: ["gitea-http"]
-    verbs: ["patch", "update"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]   # step 06 Phase -1 (#1871, chart 0.1.32): wait for cilium-gateway Programmed=True before URL rewrite
     verbs: ["get", "list", "watch"]

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -3709,11 +3709,21 @@ for s in "$S05" "$S06" "$S08"; do
     c71_fail=1
   fi
 done
-# (b) Step-05 leg: mesh global-Service path + FAIL-LOUD Ready wait + per-region
-# status keys. A leg that silently skipped an unready region-B would re-mint
-# the exact hw288 false positive.
-if ! grep -q 'service.cilium.io/global' "$S05"; then
-  echo "FAIL: step-05 leg does not establish the ClusterMesh global-Service path to the local Gitea (#5359)" >&2
+# (b) Step-05 leg: FAIL-LOUD convergence wait + per-region status keys. A leg
+# that silently skipped an unready region-B would re-mint the exact hw288
+# false positive.
+# 0.1.166: the ClusterMesh global-Service path (annotate gitea-http +
+# same-named alias Service in the secondary) is RETIRED — both gitea-http
+# Services are headless, which Cilium global-services cannot span, and the
+# secondary's own empty bp-gitea sits behind the same name (hw292:
+# "pkt-line 3: EOF", gen=2/obs=1 for 22h). Its REAPPEARANCE in step-05 is the
+# regression this now guards against.
+if grep -q 'service.cilium.io/global' "$S05"; then
+  echo "FAIL: step-05 re-grew the retired ClusterMesh global-Service leg — a headless gitea-http cannot be mesh-shared and the secondary's own empty Gitea answers that name; the secondary pivot target is the Sovereign's own Gitea door (#5359)" >&2
+  c71_fail=1
+fi
+if grep -q 'gitea-mesh-alias' "$S05"; then
+  echo "FAIL: step-05 re-grew the retired secondary gitea-http alias Service apply — it fights the secondary's own bp-gitea for the same Service name and cannot carry the dial (#5359)" >&2
   c71_fail=1
 fi
 if ! grep -q 'SECONDARY_GITREPO_READY_SECONDS' "$S05"; then
@@ -3788,7 +3798,7 @@ if [ "${c71_steps}" -ne 11 ]; then
   c71_fail=1
 fi
 if [ "$c71_fail" -ne 0 ]; then exit 1; fi
-echo "  PASS (#5359: steps 05/06/08 mount cutover-secondary-kubeconfigs optional:true [single-region inert]; step-05 pivots + FAIL-LOUD Ready-waits every secondary GitRepository over the mesh global-Service path; step-06 pivots every secondary HR with a zero-upstream read-back assert + re-syncs the STRIPPED auth bytes post-Phase-3b; step-08 extends the deny-egress hold to every region [region-A manifest inherited + mesh toEndpoints + own-gateway IPs] with teardown + per-region verdicts; step count unchanged at 11)"
+echo "  PASS (#5359: steps 05/06/08 mount cutover-secondary-kubeconfigs optional:true [single-region inert]; step-05 pivots + FAIL-LOUD convergence-waits every secondary GitRepository against the Sovereign's own Gitea door [the retired mesh global-Service leg stays absent]; step-06 pivots every secondary HR with a zero-upstream read-back assert + re-syncs the STRIPPED auth bytes post-Phase-3b; step-08 extends the deny-egress hold to every region [region-A manifest inherited + mesh toEndpoints + own-gateway IPs] with teardown + per-region verdicts; step count unchanged at 11)"
 
 # ── Case 72 (#5443): the marketplace's chart set is mirrored + asserted ──────
 # Step-06 pivots `openova-catalog` — the HelmRepository every per-Org

--- a/platform/self-sovereign-cutover/chart/tests/step05-secondary-chain.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step05-secondary-chain.sh
@@ -14,14 +14,22 @@
 # Only EXECUTING the extracted script under the same shell options exposes it.
 #
 # So this suite drives the real chain, extracted from the render, against a
-# stub kubectl, under `set -eu` — and asserts the three outcomes that matter:
-# converge on the first candidate, fall through to the second, and fail loud
-# when the chain is exhausted.
+# stub kubectl, under `set -eu`.
 #
-# The scenario is the live hw292 one (dep 1c56518035a83e03): the in-cluster
-# Gitea URL never converges from region-b (generation=2, observedGeneration=1,
-# "pkt-line 3: EOF" — its own empty Gitea answers that name), so the leg must
-# fall through to the Sovereign's own external Gitea door.
+# 0.1.166 (#5359): the DEFAULT pivot target for a secondary is the Sovereign's
+# OWN external Gitea door. The 0.1.151..0.1.165 default tried the in-cluster
+# mesh URL first, and hw292 (dep 1c56518035a83e03) proved that candidate can
+# NEVER converge from a secondary: both gitea-http Services are headless
+# (Cilium global-services cannot span them) and the secondary's own empty
+# bp-gitea answers the name — "pkt-line 3: EOF" on every fetch, generation=2 /
+# observedGeneration=1 for 22h behind a result=success stamp. The suite pins:
+#   * the default chain is the door, and the mesh URL is NOT in it;
+#   * the retired mesh-alias machinery stays out of the step;
+#   * a stale Ready=True (gen!=obs) is rejected — convergence predicate;
+#   * secondaryRegions.giteaURL still pins an explicit single-URL chain;
+#   * an empty chain and an exhausted chain both fail LOUD, never soft-skip.
+# Each render-level check is mutation-proven against the verbatim pre-0.1.166
+# shape, so a check that cannot fail cannot pass vacuously.
 set -uo pipefail
 
 CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -35,6 +43,7 @@ pass() { echo "  ok   — $*"; }
 
 MESH_URL="http://gitea-http.gitea.svc.cluster.local:3000/openova/openova"
 DOOR_URL="https://gitea.${FQDN}/openova/openova"
+PIN_URL="https://gitea.pinned.example/openova/openova"
 
 helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
   echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
@@ -56,44 +65,90 @@ if ! grep -q 'flux-gitrepository-patch] done' "${TMP}/chain.sh"; then
   exit 1
 fi
 
+# The default candidate is read OUT OF THE RENDER, not hardcoded here. A suite
+# that supplied its own SECONDARY_GITEA_FALLBACK_URL would keep passing after
+# the chart stopped rendering one. Mutation-checked: setting
+# secondaryRegions.giteaFallbackToPublicDoor=false must turn this red.
+RENDERED_DOOR=$(grep -A1 'name: SECONDARY_GITEA_FALLBACK_URL' "${TMP}/render.yaml" \
+  | grep 'value:' | head -1 | sed 's/.*value: *//' | tr -d '"')
+if [ -z "${RENDERED_DOOR}" ]; then
+  echo "FAIL — the chart renders no SECONDARY_GITEA_FALLBACK_URL, so the default"
+  echo "       secondary chain is EMPTY and every 2-region cutover dies at the"
+  echo "       no-candidate FATAL (secondaryRegions.giteaFallbackToPublicDoor /"
+  echo "       giteaFallbackURL)."
+  exit 1
+fi
+if [ "${RENDERED_DOOR}" != "${DOOR_URL}" ]; then
+  echo "FAIL — SECONDARY_GITEA_FALLBACK_URL renders '${RENDERED_DOOR}',"
+  echo "       expected the Sovereign's own door '${DOOR_URL}'."
+  exit 1
+fi
+echo "[step05-secondary-chain] default candidate from the render: ${RENDERED_DOOR}"
+
+# ── Render-level discriminators, each mutation-proven both directions ────────
+# check_door_default: the default branch must seed the chain from the DOOR env
+# and must never seed it from LOCAL_GITEA_URL (the pre-0.1.166 mesh-first
+# shape that hw292 proved structurally unable to converge).
+check_door_default() {
+  grep -qF 'sec_url_chain="${SECONDARY_GITEA_FALLBACK_URL:-}"' "$1" || return 1
+  grep -qF 'sec_url_chain="${LOCAL_GITEA_URL}"' "$1" && return 1
+  return 0
+}
+# check_mesh_retired: the retired ClusterMesh machinery must stay out of the
+# leg — the global annotate is inert on a headless Service and the alias apply
+# fights the secondary's own bp-gitea for the Service name.
+check_mesh_retired() {
+  grep -q 'service.cilium.io/global' "$1" && return 1
+  grep -q 'gitea-mesh-alias' "$1" && return 1
+  return 0
+}
+
+if check_door_default "${TMP}/chain.sh"; then
+  pass "default chain seeds from the Sovereign door, not LOCAL_GITEA_URL"
+else
+  fail "the default secondary chain is not door-first (LOCAL_GITEA_URL seeded, or the door assignment is gone)"
+fi
+if check_mesh_retired "${TMP}/chain.sh"; then
+  pass "the retired mesh-alias machinery is absent from the secondary leg"
+else
+  fail "step-05 still carries service.cilium.io/global / gitea-mesh-alias machinery"
+fi
+
+# VACUITY CONTROL — both checks must FAIL on the verbatim pre-0.1.166 shape.
+# A discriminator that passes on the defect it exists to catch proves nothing.
+sed 's|sec_url_chain="${SECONDARY_GITEA_FALLBACK_URL:-}"|sec_url_chain="${LOCAL_GITEA_URL}"\n  [ -n "${SECONDARY_GITEA_FALLBACK_URL:-}" ] \&\& sec_url_chain="${sec_url_chain} ${SECONDARY_GITEA_FALLBACK_URL}"|' \
+  "${TMP}/chain.sh" >"${TMP}/chain-prefix-shape.sh"
+if check_door_default "${TMP}/chain-prefix-shape.sh"; then
+  fail "vacuity: check_door_default PASSES on the pre-0.1.166 mesh-first chain — the discriminator cannot fail"
+else
+  pass "vacuity: check_door_default goes red on the pre-0.1.166 mesh-first chain"
+fi
+{ cat "${TMP}/chain.sh"; printf '%s\n' 'kubectl -n gitea annotate --overwrite service gitea-http "service.cilium.io/global=true" "service.cilium.io/shared=true"'; } \
+  >"${TMP}/chain-mesh-shape.sh"
+if check_mesh_retired "${TMP}/chain-mesh-shape.sh"; then
+  fail "vacuity: check_mesh_retired PASSES with the pre-0.1.166 global-annotate present — the discriminator cannot fail"
+else
+  pass "vacuity: check_mesh_retired goes red when the global-annotate reappears"
+fi
+
 mkdir -p "${TMP}/skc"
 : >"${TMP}/skc/me-east-215-b-1.yaml"
 sed -i "s#/secondary-kubeconfigs#${TMP}/skc#g" "${TMP}/chain.sh"
 
-# The fallback URL is read OUT OF THE RENDER, not hardcoded here. A suite that
-# supplied its own SECONDARY_GITEA_FALLBACK_URL would keep passing after the
-# chart stopped rendering one — it would be proving that a two-element chain
-# behaves correctly while shipping a one-element chain. Mutation-checked:
-# setting secondaryRegions.giteaFallbackToPublicDoor=false must turn this red.
-RENDERED_FALLBACK=$(grep -A1 'name: SECONDARY_GITEA_FALLBACK_URL' "${TMP}/render.yaml" \
-  | grep 'value:' | head -1 | sed 's/.*value: *//' | tr -d '"')
-if [ -z "${RENDERED_FALLBACK}" ]; then
-  echo "FAIL — the chart renders no SECONDARY_GITEA_FALLBACK_URL, so a secondary"
-  echo "       that cannot reach the in-cluster Gitea name has no second candidate"
-  echo "       and the #5359 pivot stays cosmetic (secondaryRegions."
-  echo "       giteaFallbackToPublicDoor / giteaFallbackURL)."
-  exit 1
-fi
-if [ "${RENDERED_FALLBACK}" != "${DOOR_URL}" ]; then
-  echo "FAIL — SECONDARY_GITEA_FALLBACK_URL renders '${RENDERED_FALLBACK}',"
-  echo "       expected the Sovereign's own door '${DOOR_URL}'."
-  exit 1
-fi
-echo "[step05-secondary-chain] fallback candidate from the render: ${RENDERED_FALLBACK}"
-
 # ── Harness ─────────────────────────────────────────────────────────────────
-# The stub kubectl answers the two reads the leg makes. CONVERGE_ON names the
-# URL whose fetch "succeeds": for that one it reports generation ==
+# The stub kubectl answers the reads the leg makes. CONVERGE_ON names the URL
+# whose fetch "succeeds": for that one it reports generation ==
 # observedGeneration; for every other candidate it reports the hw292 shape
 # (generation=2, observedGeneration=1) with Ready=True — deliberately Ready,
 # because a stale Ready=True is exactly what the old predicate accepted and
-# this suite must prove the new one is not fooled by it.
+# this suite must prove the current one is not fooled by it.
 make_harness() {
+  local sec_url="$1" sec_fallback="$2"
   cat >"${TMP}/hdr.sh" <<HDR
 set -eu
 LOCAL_GITEA_URL="${MESH_URL}"
-SECONDARY_GITEA_URL=""
-SECONDARY_GITEA_FALLBACK_URL="${RENDERED_FALLBACK}"
+SECONDARY_GITEA_URL="${sec_url}"
+SECONDARY_GITEA_FALLBACK_URL="${sec_fallback}"
 SECONDARY_GITREPO_READY_SECONDS=1
 GITREPO_NAME=openova
 GITREPO_NAMESPACE=flux-system
@@ -134,14 +189,18 @@ HDR
 
 # Runs the leg under a given shell; echoes "<exit> <chosen-url-or-none>".
 run_chain() {
-  local shell="$1" converge_on="$2"
-  make_harness
+  # ${4-...} (no colon): an EXPLICIT empty 4th argument must stay empty —
+  # case 4 drives the no-candidate path with sec_fallback="" and a :- default
+  # would silently re-substitute the door and test the wrong branch.
+  local shell="$1" converge_on="$2" sec_url="${3:-}" sec_fallback="${4-${RENDERED_DOOR}}"
+  make_harness "${sec_url}" "${sec_fallback}"
   local out rc
   out=$("${shell}" "${TMP}/run.sh" "${converge_on}" 2>&1); rc=$?
   printf '%s\n' "${out}" >"${TMP}/out.txt"
   local chosen="none"
   case "${out}" in
     *"CONVERGED on ${DOOR_URL} "*) chosen="${DOOR_URL}" ;;
+    *"CONVERGED on ${PIN_URL} "*)  chosen="${PIN_URL}" ;;
     *"CONVERGED on ${MESH_URL} "*) chosen="${MESH_URL}" ;;
   esac
   echo "${rc} ${chosen}"
@@ -155,40 +214,57 @@ echo "[step05-secondary-chain] #5359 — the secondary leg must execute under se
 for SH in sh dash bash; do
   command -v "${SH}" >/dev/null 2>&1 || { echo "  (skip ${SH}: not installed)"; continue; }
 
-  # 1. THE REGRESSION. Before the fix this aborted with "sec_url: parameter not
-  #    set" the moment the leg entered its per-region loop — no pivot attempted,
-  #    on every 2-region Sovereign. Any outcome other than a clean walk of the
-  #    chain means an unset variable or an early -e exit crept back in.
-  got=$(run_chain "${SH}" "${MESH_URL}")
-  if [ "${got}" = "0 ${MESH_URL}" ]; then
-    pass "${SH}: first candidate converges -> exit 0 on the mesh URL"
-  else
-    fail "${SH}: first-candidate case returned '${got}', expected '0 ${MESH_URL}'"
-    sed 's/^/        /' "${TMP}/out.txt"
-  fi
-
-  # 2. THE LIVE hw292 PATH. The mesh URL reports a STALE Ready=True (gen 2 /
-  #    obs 1) — the exact state the old predicate accepted — so the leg must
-  #    reject it and fall through to the Sovereign's own door.
+  # 1. THE DEFAULT PATH. The chain is the Sovereign's own door and it
+  #    converges -> exit 0. This also re-proves the set -eu regression: any
+  #    unset variable or early -e exit aborts before the CONVERGED line.
   got=$(run_chain "${SH}" "${DOOR_URL}")
   if [ "${got}" = "0 ${DOOR_URL}" ]; then
-    pass "${SH}: stale Ready=True on candidate 1 is rejected, chain falls through to the Sovereign door"
+    pass "${SH}: default chain converges on the Sovereign door -> exit 0"
   else
-    fail "${SH}: fallthrough case returned '${got}', expected '0 ${DOOR_URL}'"
+    fail "${SH}: default-door case returned '${got}', expected '0 ${DOOR_URL}'"
     sed 's/^/        /' "${TMP}/out.txt"
   fi
 
-  # 3. FAIL-LOUD. No candidate converges -> non-zero, so the step fails and
-  #    cutoverComplete stays false. A soft skip here IS the #5359 defect.
+  # 2. THE hw292 PREDICATE PROOF. The door reports a STALE Ready=True (gen 2 /
+  #    obs 1) — the exact state the pre-0.1.164 predicate accepted — so the leg
+  #    must reject it, exhaust the chain, and fail LOUD (exit 1). Convergence,
+  #    not Ready, is the predicate.
   got=$(run_chain "${SH}" "no-candidate-matches-this")
   case "${got}" in
-    "1 none") pass "${SH}: exhausted chain exits 1 (cutoverComplete stays false)" ;;
-    *) fail "${SH}: exhausted-chain case returned '${got}', expected '1 none'"
+    "1 none") pass "${SH}: stale Ready=True (gen!=obs) is rejected and the exhausted chain exits 1" ;;
+    *) fail "${SH}: stale-Ready case returned '${got}', expected '1 none'"
+       sed 's/^/        /' "${TMP}/out.txt" ;;
+  esac
+
+  # 3. OPERATOR PIN. secondaryRegions.giteaURL pins the chain to exactly one
+  #    explicit URL (the qaTestEnabled LE-staging path) — the leg must pivot
+  #    to it and converge there, not on the door.
+  got=$(run_chain "${SH}" "${PIN_URL}" "${PIN_URL}")
+  if [ "${got}" = "0 ${PIN_URL}" ]; then
+    pass "${SH}: secondaryRegions.giteaURL pins the chain to the operator URL"
+  else
+    fail "${SH}: operator-pin case returned '${got}', expected '0 ${PIN_URL}'"
+    sed 's/^/        /' "${TMP}/out.txt"
+  fi
+
+  # 4. EMPTY CHAIN. giteaURL and the door both disabled -> the leg must fail
+  #    LOUD at the first region, not soft-skip an unpivoted secondary — a
+  #    soft skip here IS the #5359 defect.
+  got=$(run_chain "${SH}" "irrelevant" "" "")
+  case "${got}" in
+    "1 none")
+      if grep -q 'has NO candidate pivot URL' "${TMP}/out.txt"; then
+        pass "${SH}: an empty candidate chain fails loud naming the values keys"
+      else
+        fail "${SH}: empty-chain case exited 1 but without the no-candidate diagnosis"
+        sed 's/^/        /' "${TMP}/out.txt"
+      fi ;;
+    *) fail "${SH}: empty-chain case returned '${got}', expected '1 none'"
        sed 's/^/        /' "${TMP}/out.txt" ;;
   esac
 done
 
-# 4. The FATAL must name the diagnosis, not just the verdict — an operator
+# 5. The FATAL must name the diagnosis, not just the verdict — an operator
 #    reading the Job log has to know region-b is serving pre-cutover content.
 run_chain sh "no-candidate-matches-this" >/dev/null
 if grep -q 'still serving its pre-cutover artifact' "${TMP}/out.txt"; then
@@ -197,7 +273,7 @@ else
   fail "the exhausted-chain FATAL does not explain what being unconverged means"
 fi
 
-# 5. The per-region status keys must record the FAILURE, not silently vanish.
+# 6. The per-region status keys must record the FAILURE, not silently vanish.
 if grep -q 'step.flux-gitrepository-patch.region.me-east-215-b-1.result.*failed' "${TMP}/status.log"; then
   pass "a failed region stamps result=failed on the status ConfigMap"
 else
@@ -205,9 +281,19 @@ else
   sed 's/^/        /' "${TMP}/status.log"
 fi
 
-# 6. VACUITY CONTROL for case 5 — a SUCCEEDING run must stamp success plus the
-#    URL that won, or case 5 would also pass for a leg that always writes
-#    'failed'.
+# 7. The empty-chain FATAL must also stamp result=failed + a lastError an
+#    operator can act on from the status ConfigMap alone.
+run_chain sh "irrelevant" "" "" >/dev/null
+if grep -q 'result.*failed' "${TMP}/status.log" && grep -q 'no candidate pivot URL configured' "${TMP}/status.log"; then
+  pass "the empty-chain FATAL stamps result=failed with an actionable lastError"
+else
+  fail "the empty-chain FATAL did not stamp result=failed + lastError on the status ConfigMap"
+  sed 's/^/        /' "${TMP}/status.log"
+fi
+
+# 8. VACUITY CONTROL for cases 6/7 — a SUCCEEDING run must stamp success plus
+#    the URL that won, or those cases would also pass for a leg that always
+#    writes 'failed'.
 run_chain sh "${DOOR_URL}" >/dev/null
 if grep -q 'result.*success' "${TMP}/status.log" && grep -qF "giteaURL" "${TMP}/status.log"; then
   pass "a converged region stamps result=success and records which candidate won"
@@ -221,4 +307,4 @@ if [ "${FAILURES}" -ne 0 ]; then
   echo "[step05-secondary-chain] ${FAILURES} assertion(s) FAILED"
   exit 1
 fi
-echo "[step05-secondary-chain] all assertions passed — the secondary leg executes cleanly under set -eu, rejects a stale Ready=True, falls through to the Sovereign's own Gitea door, and fails loud when no candidate converges"
+echo "[step05-secondary-chain] all assertions passed — the secondary leg executes cleanly under set -eu, defaults to the Sovereign's own Gitea door (mesh machinery retired, mutation-proven), rejects a stale Ready=True, honours the operator pin, and fails loud on an exhausted or empty chain"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2337,16 +2337,18 @@ stepTimeouts:
   # census itself is still the ~105-min slow path this ceiling was sized for, and
   # a slow-but-reachable-egress run needs the same headroom regardless.
   harborPrewarmSeconds: 9600
-  # #5359 — raised 600 -> 1800. The step-05 secondary leg now walks a CANDIDATE
+  # #5359 — raised 600 -> 1800. The step-05 secondary leg walks a CANDIDATE
   # URL CHAIN, giving each candidate its own secondaryRegions.
-  # gitRepositoryReadySeconds (300s) window to converge. Worst case is
-  # regions x candidates x 300s (a 2-region Sovereign: 1 x 2 x 300 = 600s) on
-  # top of the region-A patch, and the ceiling must exceed the sum or the Job is
-  # killed mid-chain and the failure reads as a deadline rather than as the
-  # unreachable-Gitea diagnosis the leg was about to print. 1800 leaves headroom
-  # for a 3-region topology. The step stays event-driven (catalyst-api watches
-  # to completion), so a converging run still returns in seconds and never waits
-  # out the ceiling.
+  # gitRepositoryReadySeconds (300s) window to converge. The 0.1.166 default
+  # chain is ONE candidate (the Sovereign's own external Gitea door — the
+  # doomed in-cluster mesh candidate is retired), so the default worst case is
+  # regions x 1 x 300s on top of the region-A patch; the ceiling must exceed
+  # that sum or the Job is killed mid-chain and the failure reads as a deadline
+  # rather than as the unreachable-Gitea diagnosis the leg was about to print.
+  # 1800 keeps headroom for a 3-region topology AND for an operator-supplied
+  # multi-candidate chain. The step stays event-driven (catalyst-api watches
+  # to completion), so a converging run still returns in seconds and never
+  # waits out the ceiling.
   fluxGitRepositoryPatchSeconds: 1800
   # Step 06 (helmrepository-patches) activeDeadlineSeconds. This step now
   # has FOUR potentially-slow waits inside one Job and the deadline must
@@ -2760,38 +2762,46 @@ secondaryRegions:
   # it still describes the previous spec.
   gitRepositoryReadySeconds: 300
   # Git URL the SECONDARY regions' GitRepository is pivoted to. Empty
-  # (default) = try the same in-cluster URL region-A uses
-  # (sovereign.giteaInternalURL + gitea.org/gitea.repo) FIRST, then fall
-  # back to giteaFallbackURL / the public door below. Setting this
-  # pins the chain to exactly one URL (explicit operator intent).
+  # (default) = the chain is the Sovereign's OWN external Gitea door
+  # (giteaFallbackURL / giteaFallbackToPublicDoor below). Setting this
+  # pins the chain to exactly one URL (explicit operator intent — e.g.
+  # the qaTestEnabled LE-staging case where the public door is
+  # x509-hostile and the operator must name a reachable path).
   #
-  # #5359 — why the in-cluster URL is a candidate and not a certainty.
-  # `gitea-http.gitea.svc.cluster.local` resolves LOCALLY in the
-  # secondary: a 2-region Sovereign installs bp-gitea in both regions, so
-  # the secondary has its own same-named Service selecting its own
-  # (empty, never mirrored) Gitea. The step-05 mesh alias cannot override
-  # that, because BOTH Services are HEADLESS (clusterIP: None) and Cilium
+  # #5359 — why the in-cluster URL is NOT in the default chain (0.1.166;
+  # 0.1.151..0.1.165 tried it first and every 2-region cutover burned a
+  # gitRepositoryReadySeconds window on it). `gitea-http.gitea.svc.
+  # cluster.local` resolves LOCALLY in the secondary: a 2-region
+  # Sovereign installs bp-gitea in both regions, so the secondary has
+  # its own same-named Service selecting its own (empty, never mirrored)
+  # Gitea. The retired step-05 mesh alias could not override that,
+  # because BOTH Services are HEADLESS (clusterIP: None) and Cilium
   # ClusterMesh global-services do not span headless Services at all —
   # CoreDNS answers straight from the local EndpointSlice, making
-  # `service.cilium.io/global` inert. Live on hw292 region-b that name
-  # resolved to 10.43.3.228 (its own gitea pod), whose openova/openova
-  # advertises zero refs → "pkt-line 3: EOF" on every fetch.
+  # `service.cilium.io/global` inert — and even a non-headless global
+  # pair would MERGE the empty local backend into the pool. Live on
+  # hw292 region-b that name resolved to 10.43.3.228 (its own gitea
+  # pod), whose openova/openova advertises zero refs → "pkt-line 3: EOF"
+  # on every fetch, generation=2/observedGeneration=1 for 22h.
   giteaURL: ""
-  # #5359 — fallback candidate tried when the in-cluster URL does not
-  # converge. Empty + giteaFallbackToPublicDoor=true (the default) means
+  # #5359 — the DEFAULT secondary pivot target. Empty +
+  # giteaFallbackToPublicDoor=true (the default) means
   # `https://gitea.<sovereign.fqdn>/<org>/<repo>`: the Sovereign's OWN
   # external Gitea door. That is ON-Sovereign, not a tether — it is the
-  # Sovereign's own gateway VIP, it satisfies the step-08 source-host
+  # Sovereign's own gateway VIP (served DIRECT per §854: LB-IPAM VIP /
+  # hostPort, never a NodePort), it satisfies the step-08 source-host
   # lint's *.<fqdn> exemption, and the step-08 secondary deny-egress leg
   # already carves out that gateway's public IPs so the hold does not cut
   # it. Live-verified on hw292: from region-b this door served HEAD
   # 7bcd1d59… — byte-identical to region-A's in-cluster Gitea, i.e. the
   # PIVOTED content — while the in-cluster name served zero refs.
   #
-  # The old caveat about LE-STAGING certs making the public door
-  # x509-hostile still holds for qaTestEnabled provs; those set
-  # giteaFallbackToPublicDoor=false and must supply a mesh path that
-  # actually works, rather than silently pivoting to an unreachable URL.
+  # The key keeps its historical FALLBACK spelling so pinned values files
+  # survive the 0.1.166 default flip unchanged (#5323 key-rename class).
+  # giteaFallbackToPublicDoor=false with giteaURL and giteaFallbackURL
+  # both empty leaves a secondary with NO candidate: the leg fails LOUD
+  # at its first region (stamping result=failed) instead of silently
+  # pivoting to an unreachable URL or leaving the region tethered.
   giteaFallbackURL: ""
   giteaFallbackToPublicDoor: true
   # Extra CIDRs allowed by the SECONDARY regions' deny-egress hold, ON

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T16:31:38.254Z",
+  "generatedAt": "2026-08-04T17:02:33.541Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -3482,7 +3482,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.147",
+      "version": "1.4.148",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.165",
+      "version": "0.1.166",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3617,7 +3617,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.147",
+    "version": "1.4.148",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.165",
+    "version": "0.1.166",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3625,7 +3625,17 @@ name: bp-catalyst-platform
 #   cause of the "An error has occurred" 403-PERMISSION_DENIED page on every
 #   >60-min revisit (UAT rows 35/115 on hw292). Bootstrap-kit slot-52 pin
 #   bumped in lockstep (pin-sync gate).
-version: 1.4.1282
+# 1.4.1283 — #5359: catalog-seed bp-self-sovereign-cutover pin 0.1.165 ->
+#   0.1.166. The step-05 secondary-region pivot target defaults to the
+#   Sovereign's OWN external Gitea door (https://gitea.<fqdn>); the in-cluster
+#   mesh candidate is retired from the default chain (headless gitea-http
+#   cannot be mesh-shared and the secondary's own empty Gitea answers that
+#   name — the hw292 gen=2/obs=1 observedGeneration stick), and an empty
+#   candidate chain fails loud with a per-region result=failed stamp.
+#   Bootstrap-kit slot-06a pin bumped in lockstep (pin-sync gate).
+#   (1.4.1281 and 1.4.1282 were taken on main by the #5666 merge and the
+#   045477c image-deploy cycle while this PR was in flight.)
+version: 1.4.1283
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2326,7 +2326,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.147"
+  version: "1.4.148"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2371,7 +2371,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.147"
+    version: "1.4.148"
   topology:
     supported:
     - active-passive
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.165"
+  version: "0.1.166"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.165"
+    version: "0.1.166"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

`bp-self-sovereign-cutover` 0.1.165 -> 0.1.166 (+ umbrella `bp-catalyst-platform` 1.4.1283 — 1.4.1281 and 1.4.1282 were taken on main by the #5666 merge and the 045477c image-deploy cycle while this PR was in flight): the step-05 SECONDARY-REGION pivot target defaults to the Sovereign's OWN external Gitea door (`https://gitea.<fqdn>/<org>/<repo>`), the structurally-doomed in-cluster mesh candidate is retired from the default chain, and an empty candidate chain fails loud instead of leaving a region tethered.

## Why — the hw292 measurement, code-anchored

On hw292 (dep `1c56518035a83e03`, `cutoverComplete=true`) the #5379 secondary leg patched region-b's GitRepository to `gitea-http.gitea.svc`, stamped `result=success`, and region-b's own Flux kept reconciling public github.com for 22h at `generation=2 / observedGeneration=1`:

- `gitea-http.gitea.svc` in region-b resolves to region-b's OWN empty bp-gitea (a 2-region Sovereign installs bp-gitea in both regions), and the ClusterMesh global-Service annotation is inert because BOTH `gitea-http` Services are headless (`clusterIP: None`) — CoreDNS answers a headless name from the local EndpointSlice. Every fetch failed with `pkt-line 3: EOF`.
- The observedGeneration stick is pinned-controller semantics, not a status bug: source-controller v1.4.1 `ComputeReconcileResult` (internal/reconcile/reconcile.go) appends `patch.WithStatusObservedGeneration{}` only on the nil-error / Stalling / Generic-Ignore branches — a failing fetch takes the default branch and NEVER advances `status.observedGeneration`. So `obs == gen` means exactly "this spec has been reconciled to completion at least once", which is why the 0.1.164 convergence predicate is sound and why a doomed candidate can never satisfy it.
- Even a non-headless global pair could not rescue the mesh path: it would MERGE the secondary's empty local backend into the endpoint pool. The candidate is not flaky — it is impossible on the canonical topology.

Full cause-by-cause table (5 refuted, 1 supported) on the issue: https://github.com/openova-io/openova/issues/5359#issuecomment-5182048387

The door is on-Sovereign (its own gateway VIP, served DIRECT per the no-NodePort canon), needs no cross-region Service-DNS assumption, satisfies the step-08 source-host lint `*.<fqdn>` exemption, sits inside the step-08 secondary hold's own-gateway carve-outs, and is the only target live-proven from a secondary — hw292 region-b fetched the PIVOTED revision `7bcd1d59` through it, byte-identical to region-A's Gitea.

## Changes

- `templates/05-flux-gitrepository-patch-job.yaml` — default secondary chain = the door; `secondaryRegions.giteaURL` still pins one explicit URL (the qaTestEnabled LE-staging path); the mesh leg (global annotate + same-named alias Service applied into the secondary) is deleted — the alias apply also fought the secondary's own bp-gitea Helm ownership for the `gitea/gitea-http` Service; an empty chain fails LOUD at the first secondary region with `result=failed` + actionable `lastError`.
- `templates/rbac.yaml` — the now-unused `gitea-http` services patch/update rule is removed.
- `values.yaml` — `giteaFallbackURL` / `giteaFallbackToPublicDoor` keep their key names (#5323 key-rename class) and now define the DEFAULT target; comments rewritten to the measured reality.
- `tests/step05-secondary-chain.sh` — drives the rendered leg under sh/dash/bash with `set -eu`: door-default converge, stale-Ready (gen!=obs) rejection, operator pin, empty-chain FATAL + status stamp; two render discriminators (door-first chain, mesh machinery absent) each mutation-proven inside the suite against the verbatim pre-0.1.166 shape.
- `tests/cutover-contract.sh` Case 71 — the mesh machinery is now guarded ABSENT (its reappearance is the regression).
- Lockstep 0.1.166: `blueprint.yaml`, catalog-seed `blueprints.yaml` (umbrella Chart.yaml 1.4.1283 + bootstrap-kit slot-13 pin), api `blueprints.json`, ui `catalog.generated.ts` (regenerated via build-catalog.mjs), bootstrap-kit slot 06a.

## Proof — both directions

Suite vs the 0.1.165 template: exit 1, 6 assertions red (both discriminators, the empty-chain diagnosis under all three shells, the empty-chain status stamp).
Suite vs 0.1.166: 20/20 green under sh, dash, and bash.

Gates run locally, all green: cutover-contract.sh (Cases 71/76 included), flux-source-host-lint.sh, arg-strlen-guard.sh, step06-pivot-readback.sh, catalog-chart-set.sh, daytwo-image-leg.sh, image-registry-coverage.sh, offline-mirror-host-projects.sh, single-platform-copy.sh, check-bootstrap-kit-pin-sync.sh, check-catalog-seed-lockstep.sh, bootstrap/api go build + catalog-consuming handler tests.

## Not covered (recorded on the issue, not swept)

1. Step-04's secondary node-layer containerd/Dragonfly pivot — the tracked #5379 remainder.
2. The secondary's own Gitea stays empty: the door routes secondaries to region-A's Gitea, so a region-A loss leaves them sourceless until a per-region mirror lands (the recorded DR gap).
3. hw292 is NOT remediated by this PR (no live mutation). The issue's close bar stands: a two-region readback on a live `cutoverComplete=true` Sovereign with 0 external Flux sources in BOTH regions, on the next fresh 2-region prov + cutover.

This PR must NOT close the issue.

Refs #5359 #5656 #5650 #5591 #5511 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
