### PR TITLE
fix(ui): TopologyTab consumes healthGates — unverified lag renders unknown, never 0.0 s green (Refs #5508)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -809,6 +809,208 @@ describe('TopologyTab — #4886 bootstrap-HR DR off the live Continuum CR', () =
     expect(screen.getByTestId('topology-tab-dr-switchover').textContent).toContain('nothing to promote')
   })
 
+  it('#5508: an UNVERIFIED lag (streaming-replication + standby-available gates Warn) renders as unknown, never 0.0 s green', async () => {
+    // The live hw291 shape (dep 2c2d746b578c636b): the API returns
+    // walLagSeconds:0 WITH the two Warn gates saying the measurement is
+    // unverified — and the tab rendered "Replication lag 0.0 s" behind a
+    // green pill, surfacing neither gate. The reductio on the same env:
+    // dr-spine-openbao (a raft store with no PostgreSQL at all) reported a
+    // PostgreSQL lag of 0 through the identical shape.
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: true,
+    })
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0,
+      streamingState: 'streaming',
+      replicas: [{ region: 'me-east-215-b', role: 'replica', lagSeconds: 0 }],
+      healthGates: [
+        {
+          name: 'streaming-replication',
+          status: 'Warn',
+          severity: 'warning',
+          message: 'replication health not reported by the Continuum CR; unverified',
+        },
+        { name: 'wal-lag-under-rpo', status: 'Pass', severity: 'info' },
+        {
+          name: 'standby-available',
+          status: 'Warn',
+          severity: 'warning',
+          message:
+            'standby leg not verifiable from live cluster state (no cnpg pair resolvable); reporting unknown, not healthy',
+        },
+      ],
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-hw291" applicationName="shared-pg" namespace="shared-data" />))
+
+    // POSITIVE CONTROL (vacuity check) — the DR panel AND the lag cell really
+    // rendered; the negative assertions below cannot pass on an empty render.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    const lagCell = await screen.findByTestId('topology-tab-dr-lag-value')
+
+    // THE regression: an unverified lag must read as unknown, never a
+    // numeric zero…
+    expect(lagCell.textContent).toContain('—')
+    expect(lagCell.textContent).not.toContain('0.0 s')
+    expect(document.body.textContent).not.toContain('0.0 s')
+    // …and a Warn gate can NEVER sit behind a green pill.
+    expect(lagCell.className).not.toContain('text-green-400')
+    // The unverified qualifier is stated in plain text.
+    expect(screen.getByTestId('topology-tab-dr-lag-unverified')).toBeTruthy()
+    // BOTH Warn gates are surfaced next to the reading they qualify.
+    expect(screen.getByTestId('topology-tab-dr-gate-streaming-replication').textContent).toContain('unverified')
+    expect(screen.getByTestId('topology-tab-dr-gate-standby-available').textContent).toContain('not verifiable')
+  })
+
+  it('#5508 CONTROL: all-Pass gates keep the verified numeric lag + green pill unchanged (the guard must not swallow real data)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: true,
+    })
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 1.7,
+      streamingState: 'streaming',
+      syncState: 'async',
+      healthGates: [
+        { name: 'streaming-replication', status: 'Pass', severity: 'info' },
+        { name: 'wal-lag-under-rpo', status: 'Pass', severity: 'info' },
+        { name: 'standby-available', status: 'Pass', severity: 'info', message: 'hot-standby in me-east-215-b is reachable' },
+      ],
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    const lagCell = await screen.findByTestId('topology-tab-dr-lag-value')
+    // Verified reading renders EXACTLY as before: the number, green bucket.
+    await waitFor(() => {
+      expect(lagCell.textContent).toContain('1.7 s')
+    })
+    expect(lagCell.className).toContain('text-green-400')
+    // No unverified qualifier, no degraded-gate rows.
+    expect(screen.queryByTestId('topology-tab-dr-lag-unverified')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-gates')).toBeNull()
+  })
+
+  it('#5508: a Fail gate is a VERIFIED fault — the real number stays but the pill degrades to red, never green', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: true,
+    })
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 3.2,
+      streamingState: 'catchup',
+      healthGates: [
+        {
+          name: 'streaming-replication',
+          status: 'Fail',
+          severity: 'critical',
+          message: 'replication reported unhealthy on the Continuum CR',
+        },
+        { name: 'wal-lag-under-rpo', status: 'Pass', severity: 'info' },
+      ],
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    const lagCell = await screen.findByTestId('topology-tab-dr-lag-value')
+    await waitFor(() => {
+      expect(lagCell.textContent).toContain('3.2 s')
+    })
+    expect(lagCell.className).toContain('text-red-400')
+    expect(lagCell.className).not.toContain('text-green-400')
+    // The verified fault is surfaced as an explicit gate row.
+    expect(screen.getByTestId('topology-tab-dr-gate-streaming-replication').textContent).toContain('unhealthy')
+  })
+
+  it('#5508: an OVER-THRESHOLD wal-lag Warn keeps its genuine numeric reading (only the not-reported branch reads unknown)', async () => {
+    // The other Warn cause on the same gate: lag 45s > the 30s promotability
+    // threshold. That number is a REAL measurement the operator needs — a
+    // blanket gates-warn→dash overcorrection would hide it. The backend's
+    // not-reported branch is only reachable with the zero-value lag (<=30),
+    // which is how the component discriminates structurally.
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: true,
+    })
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 45,
+      streamingState: 'streaming',
+      healthGates: [
+        { name: 'streaming-replication', status: 'Pass', severity: 'info' },
+        {
+          name: 'wal-lag-under-rpo',
+          status: 'Warn',
+          severity: 'warning',
+          message: 'replication lag 45s exceeds the 30s promotability threshold',
+        },
+        { name: 'standby-available', status: 'Pass', severity: 'info' },
+      ],
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    const lagCell = await screen.findByTestId('topology-tab-dr-lag-value')
+    await waitFor(() => {
+      expect(lagCell.textContent).toContain('45.0 s')
+    })
+    // Not green (the gate warns), and the number is NOT swallowed.
+    expect(lagCell.className).not.toContain('text-green-400')
+    expect(screen.queryByTestId('topology-tab-dr-lag-unverified')).toBeNull()
+    expect(screen.getByTestId('topology-tab-dr-gate-wal-lag-under-rpo').textContent).toContain('exceeds')
+  })
+
   it('does NOT render DR for a SINGLETON bootstrap app (synthesized fallback is never passed off as live)', async () => {
     getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
     getApplicationPlacement.mockResolvedValue({

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -32,6 +32,7 @@ import {
 import {
   getContinuumReplicationStatus,
   lagBucket,
+  type ContinuumHealthGate,
   type LagBucket,
 } from '@/lib/continuum.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
@@ -330,6 +331,69 @@ export function TopologyTab({
     [drStatus],
   )
   const lagColor: LagBucket = useMemo(() => lagBucket(lagSeconds), [lagSeconds])
+
+  // ── #5508 — the healthGates verdict QUALIFIES the lag reading ─────
+  //
+  // The API already says when the measurement is unverified (hw291:
+  // walLagSeconds:0 alongside streaming-replication=Warn "unverified" +
+  // standby-available=Warn "not verifiable") — this tab used to render the
+  // number behind a green pill and throw both gates away, making the one
+  // surface an operator reads during a DR decision strictly LESS honest
+  // than the API behind it. Same defect class as the #5478 controller
+  // guard: a control that reports instead of measuring. Two rules:
+  //
+  //   • degradedGates — every Warn/Fail gate renders as an explicit row
+  //     under the lag line, and the lag pill can never render green while
+  //     any is present (a Fail forces red, a Warn caps the bucket at
+  //     yellow).
+  //   • lagUnverified — the gates that qualify the MEASUREMENT chain mark
+  //     the number itself meaningless; render "— unverified", never a
+  //     numeric zero. Derived structurally, no message-text matching:
+  //       - streaming-replication Warn → replication health unverified.
+  //       - standby-available    Warn → the standby leg is unverifiable; a
+  //         lag against an unverifiable leg is not a measurement (the
+  //         reductio on hw291: dr-spine-openbao, a raft store with no
+  //         PostgreSQL at all, reported a PostgreSQL lag of 0).
+  //       - wal-lag-under-rpo    Warn with lag <= 30 → the backend's
+  //         not-reported branch (walLagHealthGate's over-threshold branch
+  //         requires lag > 30, and THAT genuine reading must keep
+  //         rendering numerically).
+  //     A Fail is a VERIFIED fault: the number stays (a real reading of a
+  //     broken state) behind a red pill.
+  //
+  // An absent/empty healthGates list (older backend) leaves every render
+  // exactly as before — verified readings are untouched.
+  const healthGates: ContinuumHealthGate[] = useMemo(() => {
+    const g = drStatus?.healthGates
+    return Array.isArray(g) ? g : []
+  }, [drStatus])
+  const degradedGates = useMemo(
+    () =>
+      healthGates.filter((g) => {
+        const s = (g.status ?? '').toLowerCase()
+        return s === 'warn' || s === 'fail'
+      }),
+    [healthGates],
+  )
+  const anyGateFail = useMemo(
+    () => degradedGates.some((g) => (g.status ?? '').toLowerCase() === 'fail'),
+    [degradedGates],
+  )
+  const lagUnverified = useMemo(
+    () =>
+      healthGates.some((g) => {
+        if ((g.status ?? '').toLowerCase() !== 'warn') return false
+        if (g.name === 'streaming-replication' || g.name === 'standby-available') return true
+        return g.name === 'wal-lag-under-rpo' && (lagSeconds == null || lagSeconds <= 30)
+      }),
+    [healthGates, lagSeconds],
+  )
+  const effectiveLagColor: LagBucket = useMemo(() => {
+    if (lagUnverified) return 'unknown'
+    if (anyGateFail) return 'red'
+    if (degradedGates.length > 0 && lagColor === 'green') return 'yellow'
+    return lagColor
+  }, [lagUnverified, anyGateFail, degradedGates, lagColor])
 
   // #4886 / #4552 — the DR section renders for App-CR apps with a Standby
   // placement target (the existing #3375 hasStandby path) AND for ANY app whose
@@ -773,11 +837,11 @@ export function TopologyTab({
                 <span className="text-[var(--color-text-dim)]">Replication lag</span>
                 <span
                   className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-semibold tabular-nums ${
-                    lagColor === 'green'
+                    effectiveLagColor === 'green'
                       ? 'bg-green-500/10 text-green-400'
-                      : lagColor === 'yellow'
+                      : effectiveLagColor === 'yellow'
                         ? 'bg-yellow-500/10 text-yellow-400'
-                        : lagColor === 'red'
+                        : effectiveLagColor === 'red'
                           ? 'bg-red-500/10 text-red-400'
                           : 'bg-[var(--color-bg)] text-[var(--color-text-dim)]'
                   }`}
@@ -786,11 +850,24 @@ export function TopologyTab({
                   {/* #5514 — a lag NUMBER is a claim that a standby is being
                       measured. On a VERIFIED-absent standby (#4901) the backend
                       keeps reporting 0, which reads as perfect health during an
-                      outage; render "—" instead of that false zero. */}
-                  {lagSeconds == null || standbyAbsent ? '—' : `${lagSeconds.toFixed(1)} s`}
+                      outage; render "—" instead of that false zero.
+                      #5508 — same for an UNVERIFIED measurement: when the
+                      health gates say the reading is unverified, the zero is a
+                      report, not a measurement. */}
+                  {lagSeconds == null || standbyAbsent || lagUnverified
+                    ? '—'
+                    : `${lagSeconds.toFixed(1)} s`}
                 </span>
                 {standbyAbsent ? (
                   <span className="text-[10px] text-red-400">no standby leg to measure</span>
+                ) : null}
+                {!standbyAbsent && lagUnverified ? (
+                  <span
+                    className="text-[10px] text-yellow-400"
+                    data-testid="topology-tab-dr-lag-unverified"
+                  >
+                    unverified — the health gates below report no live measurement
+                  </span>
                 ) : null}
                 {lagSeconds == null && drQ.isLoading ? (
                   <span className="text-[10px] text-[var(--color-text-dim)]">measuring…</span>
@@ -801,6 +878,27 @@ export function TopologyTab({
                   </span>
                 ) : null}
               </div>
+
+              {/* #5508 — every Warn/Fail health gate renders next to the
+                  reading it qualifies. The hw291 defect was precisely that the
+                  API returned these and the tab surfaced neither. */}
+              {degradedGates.length > 0 ? (
+                <ul className="mt-2 space-y-0.5" data-testid="topology-tab-dr-gates">
+                  {degradedGates.map((g) => {
+                    const failed = (g.status ?? '').toLowerCase() === 'fail'
+                    return (
+                      <li
+                        key={g.name}
+                        className={`text-[10px] ${failed ? 'text-red-400' : 'text-yellow-400'}`}
+                        data-testid={`topology-tab-dr-gate-${g.name}`}
+                      >
+                        {failed ? '✕' : '⚠'} {g.name}
+                        {g.message ? ` — ${g.message}` : ''}
+                      </li>
+                    )
+                  })}
+                </ul>
+              ) : null}
 
               {/* Armed manual Switchover (#4552). The button opens a confirm
                   dialog that runs a read-only RPO/health preflight and only


### PR DESCRIPTION
Refs #5508

## Problem

The Topology tab's DR panel rendered `Replication lag 0.0 s` behind a green pill while the same replication-status response carried `streaming-replication: Warn "unverified"` and `standby-available: Warn "not verifiable"` — `drStatus.healthGates` (typed on the wire since #4923, `src/lib/continuum.api.ts:236`) was never read anywhere in `TopologyTab.tsx`. The one surface an operator reads during a DR decision was strictly less honest than the API behind it. Independent of the #5478 controller guard by design: the controller decides whether to emit, the UI decides whether to qualify.

## Fix — `TopologyTab.tsx`, one file

- **Gates consumed, pill degraded** (`TopologyTab.tsx:335-397` + the lag row): `effectiveLagColor` replaces the raw `lagBucket` color — any `Fail` gate forces red, any `Warn` caps at yellow; a Warn/Fail gate can never sit behind a green pill. Every Warn/Fail gate renders as an explicit row under the lag line (`topology-tab-dr-gates`, per-gate `topology-tab-dr-gate-<name>`), so neither gate is thrown away anymore.
- **Unverified lag renders unknown, never a numeric zero**: `lagUnverified` is derived structurally from the gates that qualify the measurement chain — `streaming-replication` Warn, `standby-available` Warn (also fixes the reductio: `dr-spine-openbao`, a raft store with no PostgreSQL, reporting a PostgreSQL lag of 0), or `wal-lag-under-rpo` Warn with lag <= 30, which is exactly the backend's not-reported branch (`walLagHealthGate` only reaches its over-threshold Warn with lag > 30, so a genuine over-threshold reading keeps rendering numerically). Unverified renders as an em-dash with a plain "unverified" qualifier. A `Fail` is a verified fault: the real number stays, behind a red pill.
- **Verified rendering unchanged**: an all-Pass or absent/empty `healthGates` list (older backend) reduces every branch to the pre-fix behavior.

## Test proof — both directions, vacuity-checked

`TopologyTab.test.tsx:812` reproduces the hw291 shape (live source, `walLagSeconds:0`, the two Warn gates). It first asserts the DR panel and the lag cell actually rendered (positive control), then: em-dash shown, `0.0 s` absent from the whole document, no `text-green-400` class, both gates surfaced with their messages.

Confirmed FAILING on the pre-fix component before the fix was written:

    FAIL  TopologyTab.test.tsx > #5508: an UNVERIFIED lag ... renders as unknown, never 0.0 s green
    AssertionError: expected '0.0 s' to contain '—'

The other direction, `TopologyTab.test.tsx:878`: all-Pass gates with `walLagSeconds:1.7` keep the unchanged `1.7 s` numeric green rendering, no unverified qualifier, no gate rows — the guard cannot swallow real data. Two more locks: a `Fail` gate keeps the verified number behind a red pill (`:920`); an over-threshold `wal-lag-under-rpo` Warn keeps its genuine `45.0 s` reading (`:964`).

## Gates

- `npx tsc -b --noEmit` — clean
- `npm run build` — clean
- `npx vitest run` — 2014/2014 tests, 211 files (full suite, includes the 4 new cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
