### PR TITLE
fix(catalyst-api): reap the deleted-Org console surface + namespace in every region, both producers' shapes (1.4.1284)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1316,7 +1316,13 @@ spec:
       # 1.4.1287 (#5391): catalog-seed cutover pin 0.1.167 — settled-roll
       #   override. Lockstep w/ slot-06a (pin-sync gate).
       # 1.4.1289 (#5650): catalog-seed cutover pin 0.1.168 (loft pivot).
-      version: 1.4.1290
+      # 1.4.1284 (#5364 #5649): cutover-driver ClusterRole delete verbs for the
+      #   org-console orphan reap (httproutes/certificates/secrets/namespaces
+      #   delete + gateways update) — the teardown mirror of the #5635
+      #   create-side reconcile; deleted Orgs converge to fully-deleted in
+      #   every region.
+      #   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
+      version: 1.4.1291
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap.go
@@ -1,0 +1,659 @@
+// org_console_tls_reap.go — #5364 / #5649. The DELETE-side mirror of the
+// #5635/PR-#5647 create-side reconcile: reap the per-Org console gateway
+// surface (and the orphaned org boundary Namespace) of every Organization
+// whose CR no longer exists, in EVERY region, level-triggered.
+//
+// THE GAP this file closes.
+//
+// Creation of the per-Org console surface has TWO producers and, since
+// #5511/#5635, fans out to every region. Teardown had ONE producer in ONE
+// region, keyed on ONE name shape:
+//
+//   - the org-controller's teardownTenantRoute
+//     (core/controllers/organization/internal/controller/tenant_route.go:274)
+//     deletes ONLY its own route name `catalyst-ui-<console-host-dashed>` —
+//     catalyst-api's `catalyst-ui-<slug>-<parent-dashed>`
+//     (org_console_tls.go resolveOrgConsoleTLSNames) is invisible to it;
+//   - the whole delete cascade (teardownTenantNetworking,
+//     removeConsoleOrgListener, deleteOrgWildcardCert) writes through the
+//     org-controller's own single-cluster client — a secondary region NEVER
+//     receives any delete;
+//   - the #5511 cert-secret mirror (mirrorOrgConsoleCertSecret) writes
+//     `kube-system/org-wildcard-tls-<slug>-<parent-dashed>` Secrets into
+//     secondaries that NO teardown path deletes, and the HOST region's
+//     issued Secret is not GC'd on Certificate delete either (cert-manager
+//     only owner-refs the backing Secret under
+//     --enable-certificate-owner-ref, which we do not run);
+//   - the org boundary Namespace `<slug>` — which contains the host-deployed
+//     bp-keycloak StatefulSet + every tenant HelmRelease (#5364's original
+//     orphan) — converges only through the gitops prune chain; when a link
+//     in that chain misfires (the hw288 beta-corp shape) nothing ever
+//     retries the delete.
+//
+// Proven live on hw292 (UAT row R17, 2026-08-04): HTTPRoute
+// `catalyst-ui-r17probe-omani-homes` orphaned in BOTH regions, Gateway
+// listeners `console-{https,http}-r17probe` orphaned in region-b, TLS Secret
+// `org-wildcard-tls-r17probe-omani-homes` orphaned in region-a — hours after
+// the Org was deleted. The better creation gets, the more residue the
+// one-name/one-region teardown leaves (#5649).
+//
+// THE FIX — same shape as the create side: the Organization CR is the ONE
+// identity both producers key on, and catalyst-api is the ONE process holding
+// a per-region client for every region (orgConsoleTLSTargets). So the reap
+// runs inside the #5635 reconcile pass (reconcileOrgConsoleTLSOnce): scan
+// every region for per-Org console artifacts, list the live Organization CRs,
+// and delete every artifact whose org identity has no live CR — BOTH route
+// name shapes, the listener pair, the Certificate, every same-name TLS
+// Secret, and the orphaned org Namespace (deleting the ns reaps the
+// host-deployed bp-keycloak + its PVCs + every tenant HelmRelease inside it).
+// Level-triggered: an Org that is already half-deleted converges to
+// fully-deleted on the next pass; an Org that is already clean is a no-op.
+//
+// SAFETY MODEL — a reaper must be provably unable to eat a live Org or the
+// Sovereign's own front door:
+//
+//  1. ORDERING. Artifacts are scanned FIRST, the Organization CRs are listed
+//     AFTER. A producer only ever creates artifacts for an ALREADY-EXISTING
+//     CR, so any artifact visible at scan time belongs to a CR that either
+//     is in the later list (live → protected) or was deleted (orphan). An
+//     Org created mid-pass cannot lose its surface.
+//  2. AGE GRACE. Timestamped candidates younger than orgConsoleReapMinAge
+//     are skipped this pass — belt-and-braces against creation orderings the
+//     ordering argument does not model. A zero timestamp (never set) passes.
+//  3. FQDN GUARD. The Sovereign's own console host
+//     `console.<sovereignFQDN>` parses exactly like a per-Org host
+//     (`console.<slug>.<parent>`), so the reap REFUSES to run at all when
+//     the Sovereign FQDN is unknown, and excludes any candidate whose org
+//     zone equals the Sovereign FQDN.
+//  4. STRUCTURAL MATCH. Only objects positively identified as per-Org
+//     console artifacts are candidates: route name prefix `catalyst-ui-`
+//     (the bare Sovereign route `catalyst-ui` never matches) + a
+//     `console.<slug>.<parent>` hostname; listener name prefix
+//     `console-https-`/`console-http-` + a `*.<slug>.<parent>` hostname
+//     (the chart's apex pair `console-https`/`console-http` never matches);
+//     Certificate/Secret name prefix `org-wildcard-tls-` (the Sovereign's
+//     per-zone wildcards are `sovereign-wildcard-tls-*`) + a label- or
+//     cert-manager-annotation-derived org zone; Namespace with an org
+//     identity label (`openova.io/organization` / `catalyst.openova.io/org`
+//     / `kustomize.toolkit.fluxcd.io/name=org-tenants`) and NOT in the
+//     protected-namespace denylist. Anything that cannot be positively
+//     identified is left alone.
+//  5. ABORT ON BLIND. A failed Organization List aborts the whole reap pass
+//     — the reaper never acts on an unknown live set. (A successful EMPTY
+//     list is authoritative: the wrong-API-group failure mode errors, it
+//     does not return empty.)
+//  6. DELETE BY OBSERVED NAME. Every delete targets an object the scan
+//     positively matched — nothing is derived-then-deleted sight unseen.
+//     Absent-as-success throughout, so repeated passes are idempotent.
+//
+// The listener strip is the same read-modify-write Update the
+// org-controller's removeConsoleOrgListener uses (SSA cannot prune another
+// field manager's list entries, and the org-controller's listeners were
+// written via Update). RBAC for the delete verbs (httproutes/certificates/
+// secrets/namespaces delete, gateways update) ships in
+// products/catalyst/chart/templates/clusterrole-cutover-driver.yaml — the
+// chart change #5647 deliberately deferred.
+//
+// RESIDUAL (#5359, stated, not fixed here): a region whose GitOps stream is
+// severed receives DIRECT API deletes from this reaper just fine, but a
+// region-b whose bootstrap-kit still reconciles from public github.com will
+// keep re-applying whatever THAT stream materializes. This reaper closes the
+// producer-side gap; the region-b stream pivot is #5359's own fix.
+
+package handler
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// orgConsoleReapMinAge is the age-grace window (safety model #2): a
+// timestamped candidate younger than this is skipped this pass and
+// re-evaluated on the next tick. A package var so tests can shrink it,
+// though the shipped tests seed aged/zero timestamps instead so they also
+// compile against the unfixed tree.
+var orgConsoleReapMinAge = 15 * time.Minute
+
+const (
+	// orgWildcardTLSNamePrefix — per-Org wildcard Certificate + backing/
+	// mirrored TLS Secret name prefix (both producers agree, #4241). The
+	// Sovereign's own per-zone wildcards are `sovereign-wildcard-tls-*`
+	// (sovereign-wildcard-certs.yaml) and can never match.
+	orgWildcardTLSNamePrefix = "org-wildcard-tls-"
+	// orgConsoleRouteNamePrefix — both producers' console HTTPRoute names
+	// start with this; the Sovereign's own console route is the bare
+	// `catalyst-ui` (products/catalyst/chart/templates/httproute.yaml) and
+	// never matches the prefix-plus-suffix requirement.
+	orgConsoleRouteNamePrefix = "catalyst-ui-"
+	// per-Org listener name prefixes; the chart's apex pair is the bare
+	// `console-https`/`console-http` and never matches.
+	orgConsoleListenerHTTPSPrefix = consoleApexListenerHTTPSName + "-"
+	orgConsoleListenerHTTPPrefix  = consoleApexListenerHTTPName + "-"
+	consoleHostLabelPrefix        = "console."
+)
+
+// orgConsoleReapProtectedNamespaces — hard denylist (safety model #4). A
+// namespace listed here is never deleted regardless of labels. Org boundary
+// namespaces are named `<slug>` and can never legitimately collide with
+// these, so the list only ever blocks a mislabelled system namespace.
+var orgConsoleReapProtectedNamespaces = map[string]bool{
+	"default":          true,
+	"kube-system":      true,
+	"kube-public":      true,
+	"kube-node-lease":  true,
+	"flux-system":      true,
+	"catalyst-system":  true,
+	"catalyst":         true,
+	"openova-system":   true,
+	"cert-manager":     true,
+	"cilium-secrets":   true,
+	"gitea":            true,
+	"harbor":           true,
+	"keycloak":         true,
+	"openbao":          true,
+	"kyverno":          true,
+	"monitoring":       true,
+	"external-secrets": true,
+}
+
+// orgConsoleReapScan is one region's positively-identified per-Org console
+// artifact candidates, keyed by the org identity (slug) each artifact was
+// derived from. Names are OBSERVED names (safety model #6).
+type orgConsoleReapScan struct {
+	target     orgConsoleTLSTarget
+	routes     map[string][]string // slug -> HTTPRoute names (catalyst-system)
+	listeners  map[string]bool     // slug -> per-Org listener pair present on the console Gateway
+	certs      map[string][]string // slug -> Certificate names (kube-system)
+	secrets    map[string][]string // slug -> TLS Secret names (kube-system)
+	namespaces map[string][]string // slug -> Namespace names
+}
+
+// reapOrgConsoleTLSOrphans is the teardown half of the #5635 reconcile pass.
+// Scans every region target for per-Org console artifacts, lists the live
+// Organization CRs AFTER the scans (safety model #1), and deletes every
+// candidate whose org identity has no live CR. Best-effort: every failure is
+// logged and the next tick retries; nothing here can fail the pass.
+func (h *Handler) reapOrgConsoleTLSOrphans(ctx context.Context, deps *sovereignDeps) {
+	sovereignFQDN := strings.ToLower(strings.TrimSpace(h.orgTenantDeps.OTECHFQDN))
+	if sovereignFQDN == "" {
+		// Safety model #3: without the FQDN the Sovereign's own console
+		// surface is indistinguishable from a per-Org one. Refuse entirely.
+		h.log.Info("org-console-reap: skipped — Sovereign FQDN unset, cannot exclude the Sovereign's own console surface (#5364)")
+		return
+	}
+
+	// 1. Scan every region FIRST.
+	targets := h.orgConsoleTLSTargets(deps)
+	scans := make([]*orgConsoleReapScan, 0, len(targets))
+	for _, tgt := range targets {
+		scans = append(scans, h.scanOrgConsoleArtifacts(ctx, tgt, sovereignFQDN))
+	}
+
+	// 2. List the live Organization CRs AFTER the scans.
+	live, ok := h.liveOrgIdentities(ctx, deps)
+	if !ok {
+		// Safety model #5: never reap against an unknown live set.
+		return
+	}
+
+	// 3. Reap every candidate identity with no live CR.
+	for _, sc := range scans {
+		h.reapScanOrphans(ctx, sc, live)
+	}
+}
+
+// liveOrgIdentities lists every Organization CR and returns the set of
+// lowercased identities a per-Org artifact may be keyed on: the CR name,
+// spec.slug, and spec.tenantPublic.subdomain. ok=false means the list
+// FAILED and the caller must not reap (a successful empty list is a valid,
+// authoritative "no Orgs exist").
+func (h *Handler) liveOrgIdentities(ctx context.Context, deps *sovereignDeps) (map[string]bool, bool) {
+	list, err := deps.dyn.Resource(organizationGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("org-console-reap: list Organizations failed — reap pass ABORTED, next tick retries (#5364)",
+			"err", err)
+		return nil, false
+	}
+	live := map[string]bool{}
+	add := func(s string) {
+		if s = strings.ToLower(strings.TrimSpace(s)); s != "" {
+			live[s] = true
+		}
+	}
+	for i := range list.Items {
+		obj := &list.Items[i]
+		add(obj.GetName())
+		add(nestedString(obj.Object, "spec", "slug"))
+		add(nestedString(obj.Object, "spec", "tenantPublic", "subdomain"))
+	}
+	return live, true
+}
+
+// orgZoneSlugParent splits an org zone `<slug>.<parent>` into its slug +
+// parent, applying the structural guards: the slug must satisfy orgSlugRE,
+// the parent must itself contain a dot (every org-pool parent is at least
+// two labels — omani.homes/rest/trade/works), and the zone must NOT be the
+// Sovereign's own FQDN (safety model #3 — `console.<sovFQDN>` parses exactly
+// like a per-Org console host).
+func orgZoneSlugParent(zone, sovereignFQDN string) (slug string, ok bool) {
+	zone = strings.ToLower(strings.TrimSpace(zone))
+	if zone == "" || zone == sovereignFQDN {
+		return "", false
+	}
+	idx := strings.Index(zone, ".")
+	if idx <= 0 {
+		return "", false
+	}
+	slug, parent := zone[:idx], zone[idx+1:]
+	if !orgSlugRE.MatchString(slug) || !strings.Contains(parent, ".") {
+		return "", false
+	}
+	return slug, true
+}
+
+// reapCandidateOldEnough applies the age grace (safety model #2). A zero
+// creationTimestamp (never stamped — e.g. a test fake) passes.
+func reapCandidateOldEnough(ts metav1.Time) bool {
+	if ts.IsZero() {
+		return true
+	}
+	return time.Since(ts.Time) >= orgConsoleReapMinAge
+}
+
+// scanOrgConsoleArtifacts collects one region's per-Org console artifact
+// candidates. Every match is structural (safety model #4); anything that
+// cannot be positively identified is skipped. Scan failures are logged and
+// yield an empty category — the reap then simply has no candidates there.
+func (h *Handler) scanOrgConsoleArtifacts(ctx context.Context, tgt orgConsoleTLSTarget, sovereignFQDN string) *orgConsoleReapScan {
+	sc := &orgConsoleReapScan{
+		target:     tgt,
+		routes:     map[string][]string{},
+		listeners:  map[string]bool{},
+		certs:      map[string][]string{},
+		secrets:    map[string][]string{},
+		namespaces: map[string][]string{},
+	}
+	if tgt.dyn != nil {
+		h.scanOrgConsoleRoutes(ctx, sc, sovereignFQDN)
+		h.scanOrgConsoleListeners(ctx, sc, sovereignFQDN)
+		h.scanOrgConsoleCertificates(ctx, sc, sovereignFQDN)
+	}
+	if tgt.core != nil {
+		h.scanOrgConsoleSecrets(ctx, sc, sovereignFQDN)
+		h.scanOrgNamespaces(ctx, sc)
+	}
+	return sc
+}
+
+// scanOrgConsoleRoutes — candidates are HTTPRoutes in catalyst-system whose
+// name starts with `catalyst-ui-` (with a non-empty suffix, so the Sovereign's
+// bare `catalyst-ui` route never matches) and which serve a
+// `console.<slug>.<parent>` hostname. This catches BOTH producers' name
+// shapes (`catalyst-ui-<slug>-<parent-dashed>` and
+// `catalyst-ui-console-<host-dashed>`) AND any adopted/hand-applied variant,
+// because the hostname — not the name — is the identity.
+func (h *Handler) scanOrgConsoleRoutes(ctx context.Context, sc *orgConsoleReapScan, sovereignFQDN string) {
+	list, err := sc.target.dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("org-console-reap: list HTTPRoutes failed — routes not reaped this pass",
+			"region", sc.target.region, "err", err)
+		return
+	}
+	for i := range list.Items {
+		r := &list.Items[i]
+		name := r.GetName()
+		if !strings.HasPrefix(name, orgConsoleRouteNamePrefix) || name == orgConsoleRouteNamePrefix {
+			continue
+		}
+		if !reapCandidateOldEnough(r.GetCreationTimestamp()) {
+			continue
+		}
+		hosts, _, _ := unstructured.NestedStringSlice(r.Object, "spec", "hostnames")
+		for _, host := range hosts {
+			host = strings.ToLower(strings.TrimSpace(host))
+			if !strings.HasPrefix(host, consoleHostLabelPrefix) {
+				continue
+			}
+			if slug, ok := orgZoneSlugParent(strings.TrimPrefix(host, consoleHostLabelPrefix), sovereignFQDN); ok {
+				sc.routes[slug] = append(sc.routes[slug], name)
+				break
+			}
+		}
+	}
+}
+
+// scanOrgConsoleListeners — candidates are listener pairs on the console
+// Gateway named `console-https-<slug>`/`console-http-<slug>` whose hostname
+// is the matching `*.<slug>.<parent>` wildcard. The name suffix must agree
+// with the hostname's leftmost zone label, so a differently-purposed
+// listener that merely shares the prefix can never be claimed.
+func (h *Handler) scanOrgConsoleListeners(ctx context.Context, sc *orgConsoleReapScan, sovereignFQDN string) {
+	gw, err := sc.target.dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Get(ctx, consoleGatewayName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			h.log.Warn("org-console-reap: read console Gateway failed — listeners not reaped this pass",
+				"region", sc.target.region, "err", err)
+		}
+		return
+	}
+	listeners, found, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil || !found {
+		return
+	}
+	for _, l := range listeners {
+		lm, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := lm["name"].(string)
+		if !strings.HasPrefix(name, orgConsoleListenerHTTPSPrefix) {
+			continue
+		}
+		slug := strings.TrimPrefix(name, orgConsoleListenerHTTPSPrefix)
+		hostname, _ := lm["hostname"].(string)
+		zone := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(hostname)), "*.")
+		zoneSlug, ok := orgZoneSlugParent(zone, sovereignFQDN)
+		if !ok || zoneSlug != slug {
+			continue
+		}
+		sc.listeners[slug] = true
+	}
+}
+
+// scanOrgConsoleCertificates — candidates are cert-manager Certificates in
+// kube-system named `org-wildcard-tls-*`, with the org identity taken from
+// the producers' own labels (`catalyst.openova.io/org-subdomain` — both
+// stamp it) or, failing that, from spec.commonName (`<slug>.<parent>`).
+func (h *Handler) scanOrgConsoleCertificates(ctx context.Context, sc *orgConsoleReapScan, sovereignFQDN string) {
+	list, err := sc.target.dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("org-console-reap: list Certificates failed — certs not reaped this pass",
+			"region", sc.target.region, "err", err)
+		return
+	}
+	for i := range list.Items {
+		c := &list.Items[i]
+		if !strings.HasPrefix(c.GetName(), orgWildcardTLSNamePrefix) {
+			continue
+		}
+		if !reapCandidateOldEnough(c.GetCreationTimestamp()) {
+			continue
+		}
+		zone := strings.TrimSpace(c.GetLabels()["catalyst.openova.io/org-subdomain"])
+		if zone != "" {
+			parent := strings.TrimSpace(c.GetLabels()["catalyst.openova.io/pool-parent"])
+			if parent == "" {
+				parent = strings.TrimSpace(c.GetLabels()["catalyst.openova.io/parent-zone"])
+			}
+			if parent == "" {
+				zone = "" // label slug without a parent zone — fall through to commonName
+			} else {
+				zone = zone + "." + parent
+			}
+		}
+		if zone == "" {
+			zone = nestedString(c.Object, "spec", "commonName")
+		}
+		if slug, ok := orgZoneSlugParent(zone, sovereignFQDN); ok {
+			sc.certs[slug] = append(sc.certs[slug], c.GetName())
+		}
+	}
+}
+
+// scanOrgConsoleSecrets — candidates are kube-system TLS Secrets named
+// `org-wildcard-tls-*`: the host region's cert-manager-issued Secret
+// (identified via the `cert-manager.io/common-name` annotation) and the
+// #5511 mirrored copies in secondaries (identified via the producers'
+// labels). A Secret whose org identity cannot be derived is left alone.
+func (h *Handler) scanOrgConsoleSecrets(ctx context.Context, sc *orgConsoleReapScan, sovereignFQDN string) {
+	list, err := sc.target.core.CoreV1().Secrets(consoleCertNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("org-console-reap: list Secrets failed — cert secrets not reaped this pass",
+			"region", sc.target.region, "err", err)
+		return
+	}
+	for i := range list.Items {
+		s := &list.Items[i]
+		if !strings.HasPrefix(s.Name, orgWildcardTLSNamePrefix) || s.Type != "kubernetes.io/tls" {
+			continue
+		}
+		if !reapCandidateOldEnough(s.CreationTimestamp) {
+			continue
+		}
+		zone := ""
+		if sub := strings.TrimSpace(s.Labels["catalyst.openova.io/org-subdomain"]); sub != "" {
+			if parent := strings.TrimSpace(s.Labels["catalyst.openova.io/pool-parent"]); parent != "" {
+				zone = sub + "." + parent
+			}
+		}
+		if zone == "" {
+			zone = strings.TrimSpace(s.Annotations["cert-manager.io/common-name"])
+		}
+		if slug, ok := orgZoneSlugParent(zone, sovereignFQDN); ok {
+			sc.secrets[slug] = append(sc.secrets[slug], s.Name)
+		}
+	}
+}
+
+// scanOrgNamespaces — candidates are namespaces carrying an org identity
+// label: `openova.io/organization` (the org-controller's boundary-ns label,
+// value = slug), `catalyst.openova.io/org` (catalyst-api's ensureOrgNamespace
+// label), or `kustomize.toolkit.fluxcd.io/name=org-tenants` (the
+// funnel-materialized tenant ns shape — identity = the ns name). The
+// protected denylist + a `kube-` name-prefix guard apply on top; deleting an
+// orphaned org ns is what reaps the host-deployed bp-keycloak + its PVCs +
+// every tenant HelmRelease inside it (#5364).
+func (h *Handler) scanOrgNamespaces(ctx context.Context, sc *orgConsoleReapScan) {
+	seen := map[string]bool{}
+	addNS := func(name, identity string, ts metav1.Time) {
+		name = strings.ToLower(strings.TrimSpace(name))
+		identity = strings.ToLower(strings.TrimSpace(identity))
+		if name == "" || identity == "" || seen[name] {
+			return
+		}
+		if orgConsoleReapProtectedNamespaces[name] || strings.HasPrefix(name, "kube-") {
+			return
+		}
+		if !orgSlugRE.MatchString(identity) || !reapCandidateOldEnough(ts) {
+			return
+		}
+		seen[name] = true
+		sc.namespaces[identity] = append(sc.namespaces[identity], name)
+	}
+	for _, selector := range []string{
+		"openova.io/organization",
+		"catalyst.openova.io/org",
+		"kustomize.toolkit.fluxcd.io/name=org-tenants",
+	} {
+		list, err := sc.target.core.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			h.log.Warn("org-console-reap: list namespaces failed — namespaces not reaped this pass",
+				"region", sc.target.region, "selector", selector, "err", err)
+			continue
+		}
+		for i := range list.Items {
+			ns := &list.Items[i]
+			identity := ns.Labels["openova.io/organization"]
+			if identity == "" {
+				identity = ns.Labels["catalyst.openova.io/org"]
+			}
+			if identity == "" {
+				identity = ns.Name
+			}
+			addNS(ns.Name, identity, ns.CreationTimestamp)
+		}
+	}
+}
+
+// reapScanOrphans deletes, on ONE region target, every scanned candidate
+// whose org identity is absent from the live set. Every delete is by
+// observed name, absent-as-success, and independent — one failure never
+// blocks the rest (the next tick retries).
+func (h *Handler) reapScanOrphans(ctx context.Context, sc *orgConsoleReapScan, live map[string]bool) {
+	orphan := func(slug string) bool { return !live[slug] }
+	reaped := 0
+
+	for slug, names := range sc.routes {
+		if !orphan(slug) {
+			continue
+		}
+		for _, name := range names {
+			if err := deleteAbsentOK(func() error {
+				return sc.target.dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+					Delete(ctx, name, metav1.DeleteOptions{})
+			}); err != nil {
+				h.log.Error("org-console-reap: delete orphaned console HTTPRoute failed — next tick retries",
+					"region", sc.target.region, "org", slug, "route", name, "err", err)
+				continue
+			}
+			reaped++
+			h.log.Info("org-console-reap: deleted orphaned per-Org console HTTPRoute (#5364 #5649)",
+				"region", sc.target.region, "org", slug, "route", name)
+		}
+	}
+
+	for slug := range sc.listeners {
+		if !orphan(slug) {
+			continue
+		}
+		removed, err := removeOrphanConsoleListeners(ctx, sc.target.dyn, slug)
+		if err != nil {
+			h.log.Error("org-console-reap: strip orphaned console Gateway listeners failed — next tick retries",
+				"region", sc.target.region, "org", slug, "err", err)
+			continue
+		}
+		if removed {
+			reaped++
+			h.log.Info("org-console-reap: stripped orphaned per-Org console Gateway listener pair (#5364 #5649)",
+				"region", sc.target.region, "org", slug,
+				"https_listener", orgConsoleListenerHTTPSPrefix+slug,
+				"http_listener", orgConsoleListenerHTTPPrefix+slug)
+		}
+	}
+
+	for slug, names := range sc.certs {
+		if !orphan(slug) {
+			continue
+		}
+		for _, name := range names {
+			if err := deleteAbsentOK(func() error {
+				return sc.target.dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+					Delete(ctx, name, metav1.DeleteOptions{})
+			}); err != nil {
+				h.log.Error("org-console-reap: delete orphaned per-Org Certificate failed — next tick retries",
+					"region", sc.target.region, "org", slug, "certificate", name, "err", err)
+				continue
+			}
+			reaped++
+			h.log.Info("org-console-reap: deleted orphaned per-Org wildcard Certificate (#5364 #5649)",
+				"region", sc.target.region, "org", slug, "certificate", name)
+		}
+	}
+
+	for slug, names := range sc.secrets {
+		if !orphan(slug) {
+			continue
+		}
+		for _, name := range names {
+			if err := deleteAbsentOK(func() error {
+				return sc.target.core.CoreV1().Secrets(consoleCertNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+			}); err != nil {
+				h.log.Error("org-console-reap: delete orphaned per-Org TLS Secret failed — next tick retries",
+					"region", sc.target.region, "org", slug, "secret", name, "err", err)
+				continue
+			}
+			reaped++
+			h.log.Info("org-console-reap: deleted orphaned per-Org wildcard TLS Secret (#5364 #5649)",
+				"region", sc.target.region, "org", slug, "secret", name)
+		}
+	}
+
+	for slug, names := range sc.namespaces {
+		if !orphan(slug) {
+			continue
+		}
+		for _, name := range names {
+			if err := deleteAbsentOK(func() error {
+				return sc.target.core.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+			}); err != nil {
+				h.log.Error("org-console-reap: delete orphaned org Namespace failed — next tick retries",
+					"region", sc.target.region, "org", slug, "namespace", name, "err", err)
+				continue
+			}
+			reaped++
+			h.log.Info("org-console-reap: deleted orphaned org Namespace — reaps the host-deployed bp-keycloak + tenant HelmReleases inside it (#5364)",
+				"region", sc.target.region, "org", slug, "namespace", name)
+		}
+	}
+
+	if reaped > 0 {
+		h.log.Info("org-console-reap: pass complete",
+			"region", sc.target.region, "clusterID", sc.target.clusterID, "reaped", reaped)
+	}
+}
+
+// removeOrphanConsoleListeners strips `console-https-<slug>` +
+// `console-http-<slug>` off the console Gateway via the same
+// read-modify-write Update the org-controller's removeConsoleOrgListener
+// uses — SSA cannot prune list entries another field manager owns, and the
+// funnel-door listeners were written by the org-controller via Update.
+// Every OTHER listener (the apex pair, every live Org's pair) is preserved
+// byte-for-byte. Absent-as-success.
+func removeOrphanConsoleListeners(ctx context.Context, dyn dynamic.Interface, slug string) (bool, error) {
+	gw, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Get(ctx, consoleGatewayName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	listeners, found, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil || !found {
+		return false, err
+	}
+	drop := map[string]bool{
+		orgConsoleListenerHTTPSPrefix + slug: true,
+		orgConsoleListenerHTTPPrefix + slug:  true,
+	}
+	kept := make([]any, 0, len(listeners))
+	removed := false
+	for _, l := range listeners {
+		if lm, ok := l.(map[string]any); ok {
+			if n, ok := lm["name"].(string); ok && drop[n] {
+				removed = true
+				continue
+			}
+		}
+		kept = append(kept, l)
+	}
+	if !removed {
+		return false, nil
+	}
+	if err := unstructured.SetNestedSlice(gw.Object, kept, "spec", "listeners"); err != nil {
+		return false, err
+	}
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Update(ctx, gw, metav1.UpdateOptions{}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// deleteAbsentOK runs a delete and treats NotFound as success (idempotent
+// re-runs are the level-triggered contract).
+func deleteAbsentOK(del func() error) error {
+	if err := del(); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap_5364_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap_5364_test.go
@@ -1,0 +1,485 @@
+// org_console_tls_reap_5364_test.go — #5364 / #5649, both directions of the
+// teardown contract:
+//
+//  1. an Org whose CR is GONE but whose artifacts — from BOTH producers, in
+//     BOTH regions, including the org boundary Namespace — still exist is
+//     fully reaped by one reconcile pass (the hw292 R17 residue, plus the
+//     hw288 beta-corp namespace orphan, in one fixture); and
+//  2. an Org that is alive and fully served loses NOTHING — the pass is a
+//     no-op that issues zero deletes (the over-eager-reaper direction #5649
+//     names explicitly).
+//
+// This file deliberately uses ONLY symbols that predate the reap fix, so it
+// compiles against the unfixed tree and fails there at RUNTIME (the orphaned
+// artifacts survive the pass) rather than at build time.
+//
+// Adversarial controls carried by the fixture:
+//   - the Sovereign's own console route `catalyst-ui`
+//     (console.<sovereignFQDN>) must survive — the bare name never matches
+//     the per-Org prefix;
+//   - a trap route `catalyst-ui-hw292-omani-works` whose hostname is the
+//     Sovereign console host parses EXACTLY like a per-Org host
+//     (console.<slug=hw292>.<parent=omani.works>) and must survive via the
+//     FQDN guard — this is the assertion that stops the reaper from eating
+//     the Sovereign's front door;
+//   - the apex listener pair must survive every pass;
+//   - a TLS Secret whose org identity is underivable (no labels, no
+//     cert-manager annotation) must survive — never delete what cannot be
+//     positively identified.
+
+package handler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stesting "k8s.io/client-go/testing"
+
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// agedTime — older than any plausible reap grace window, so the age-grace
+// guard can never mask a missing reap in these tests.
+func agedTime() metav1.Time { return metav1.NewTime(time.Now().Add(-24 * time.Hour)) }
+
+// catalystAPIConsoleRoute builds the console HTTPRoute exactly as
+// catalyst-api's own emitter names+labels it (org_console_tls.go
+// resolveOrgConsoleTLSNames / createOrgConsoleHTTPRoute):
+// `catalyst-ui-<slug>-<parent-dashed>`. Hand-written so the test pins the
+// producer contract literally, mirroring orgControllerConsoleRoute.
+func catalystAPIConsoleRoute(name, host string) *unstructured.Unstructured {
+	r := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":              name,
+			"namespace":         catalystConsoleNamespace,
+			"creationTimestamp": agedTime().UTC().Format(time.RFC3339),
+			"labels": map[string]any{
+				"catalyst.openova.io/managed-by": "catalyst-api",
+				"app.kubernetes.io/managed-by":   "catalyst-api",
+			},
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{
+				"name": consoleGatewayName, "namespace": consoleGatewayNamespace,
+			}},
+			"hostnames": []any{host},
+			"rules": []any{map[string]any{
+				"matches": []any{map[string]any{
+					"path": map[string]any{"type": "PathPrefix", "value": "/"},
+				}},
+				"backendRefs": []any{map[string]any{"name": catalystUIServiceName, "port": int64(80)}},
+			}},
+		},
+	}}
+	return r
+}
+
+// seedRoute Creates a route on a region fake, failing the test on error.
+func seedRoute(t *testing.T, dyn *dynamicfake.FakeDynamicClient, route *unstructured.Unstructured) {
+	t.Helper()
+	if _, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Create(context.Background(), route, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed route %s: %v", route.GetName(), err)
+	}
+}
+
+// seedOrgListenerPair appends a per-Org `console-https-<slug>`/
+// `console-http-<slug>` listener pair (hostname `*.<slug>.<parent>`) onto the
+// already-seeded console Gateway, exactly as either producer leaves it.
+func seedOrgListenerPair(t *testing.T, dyn *dynamicfake.FakeDynamicClient, slug, parent string) {
+	t.Helper()
+	ctx := context.Background()
+	gw, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Get(ctx, consoleGatewayName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get seeded console gateway: %v", err)
+	}
+	listeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		t.Fatalf("read seeded gateway listeners: %v", err)
+	}
+	wildcard := "*." + slug + "." + parent
+	listeners = append(listeners,
+		map[string]any{"name": "console-https-" + slug, "port": int64(8443), "protocol": "HTTPS", "hostname": wildcard,
+			"tls": map[string]any{"mode": "Terminate", "certificateRefs": []any{
+				map[string]any{"kind": "Secret", "name": "org-wildcard-tls-" + slug + "-omani-homes"},
+			}},
+		},
+		map[string]any{"name": "console-http-" + slug, "port": int64(8080), "protocol": "HTTP", "hostname": wildcard},
+	)
+	if err := unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners"); err != nil {
+		t.Fatalf("set seeded gateway listeners: %v", err)
+	}
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Update(ctx, gw, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update seeded gateway: %v", err)
+	}
+}
+
+// seedOrgWildcardCert Creates a per-Org wildcard Certificate carrying the
+// producers' shared labels (both doors stamp catalyst.openova.io/org-subdomain).
+func seedOrgWildcardCert(t *testing.T, dyn *dynamicfake.FakeDynamicClient, slug, parent string) string {
+	t.Helper()
+	name := "org-wildcard-tls-" + slug + "-omani-homes"
+	c := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "cert-manager.io/v1",
+		"kind":       "Certificate",
+		"metadata": map[string]any{
+			"name":              name,
+			"namespace":         consoleCertNamespace,
+			"creationTimestamp": agedTime().UTC().Format(time.RFC3339),
+			"labels": map[string]any{
+				"catalyst.openova.io/org-subdomain": slug,
+				"catalyst.openova.io/pool-parent":   parent,
+			},
+		},
+		"spec": map[string]any{
+			"secretName": name,
+			"commonName": slug + "." + parent,
+			"dnsNames":   []any{"*." + slug + "." + parent, slug + "." + parent},
+		},
+	}}
+	if _, err := dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		Create(context.Background(), c, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed certificate %s: %v", name, err)
+	}
+	return name
+}
+
+// hostIssuedOrgSecret — the HOST-region shape: written by cert-manager, so it
+// carries the cert-manager annotations but NONE of our labels (cert-manager
+// does not copy Certificate labels onto the Secret).
+func hostIssuedOrgSecret(slug, parent string) *corev1.Secret {
+	name := "org-wildcard-tls-" + slug + "-omani-homes"
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: consoleCertNamespace,
+			CreationTimestamp: agedTime(),
+			Annotations: map[string]string{
+				"cert-manager.io/certificate-name": name,
+				"cert-manager.io/common-name":      slug + "." + parent,
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{"tls.crt": []byte("issued"), "tls.key": []byte("key")},
+	}
+}
+
+// mirroredOrgSecret — the SECONDARY-region shape: written by
+// mirrorOrgConsoleCertSecret, so it carries the producers' labels
+// (orgConsoleTLSStringLabels) and no cert-manager annotations.
+func mirroredOrgSecret(slug, parent string) *corev1.Secret {
+	name := "org-wildcard-tls-" + slug + "-omani-homes"
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: consoleCertNamespace,
+			CreationTimestamp: agedTime(),
+			Labels: map[string]string{
+				"catalyst.openova.io/org-subdomain": slug,
+				"catalyst.openova.io/pool-parent":   parent,
+				"catalyst.openova.io/managed-by":    "catalyst-api",
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{"tls.crt": []byte("mirrored"), "tls.key": []byte("key")},
+	}
+}
+
+// orgBoundaryNamespace — the org-controller's boundary ns shape
+// (core/controllers/organization/internal/gitops/manifests.go: labels
+// openova.io/organization=<slug>). Deleting it is what reaps the
+// host-deployed bp-keycloak + tenant HelmReleases inside it (#5364).
+func orgBoundaryNamespace(slug string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              slug,
+		CreationTimestamp: agedTime(),
+		Labels: map[string]string{
+			"openova.io/organization": slug,
+			"openova.io/managed-by":   "catalyst",
+		},
+	}}
+}
+
+func routeExists(t *testing.T, dyn *dynamicfake.FakeDynamicClient, name string) bool {
+	t.Helper()
+	_, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Get(context.Background(), name, metav1.GetOptions{})
+	return err == nil
+}
+
+func certExists(t *testing.T, dyn *dynamicfake.FakeDynamicClient, name string) bool {
+	t.Helper()
+	_, err := dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		Get(context.Background(), name, metav1.GetOptions{})
+	return err == nil
+}
+
+func secretExists(t *testing.T, core *k8sfake.Clientset, name string) bool {
+	t.Helper()
+	_, err := core.CoreV1().Secrets(consoleCertNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	return err == nil
+}
+
+func namespaceExists(t *testing.T, core *k8sfake.Clientset, name string) bool {
+	t.Helper()
+	_, err := core.CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
+	return err == nil
+}
+
+// gatewayListenerNames reads the live listener NAME set off a region's
+// console Gateway spec.
+func gatewayListenerNames(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]bool {
+	t.Helper()
+	gw, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Get(context.Background(), consoleGatewayName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get console gateway: %v", err)
+	}
+	names := map[string]bool{}
+	listeners, _, _ := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	for _, l := range listeners {
+		if lm, ok := l.(map[string]any); ok {
+			if n, ok := lm["name"].(string); ok {
+				names[n] = true
+			}
+		}
+	}
+	return names
+}
+
+// TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped —
+// direction 1, the test that MUST FAIL on the unfixed tree.
+//
+// Fixture: live Org `uatco` (CR present) fully served; deleted Org `ghostco`
+// (NO CR) still carrying, hours later:
+//   - host region: BOTH producers' route name shapes, the listener pair, the
+//     Certificate, the cert-manager-issued TLS Secret, and the org boundary
+//     Namespace (the #5364 namespace orphan — reaping it is what removes the
+//     host-deployed bp-keycloak);
+//   - secondary region: catalyst-api's route shape, the listener pair, the
+//     mirrored TLS Secret, and the boundary Namespace.
+//
+// One reconcile pass must remove ALL of it, in BOTH regions, while leaving
+// every live-Org and Sovereign-owned artifact untouched.
+func TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works") // chroot gate for the region fan-out
+
+	const (
+		liveHost         = "console.uatco.omani.homes"
+		liveOrgCtrlRoute = "catalyst-ui-console-uatco-omani-homes"
+		liveCert         = "org-wildcard-tls-uatco-omani-homes"
+		ghostAPIRoute    = "catalyst-ui-ghostco-omani-homes"         // catalyst-api's shape (org_console_tls.go)
+		ghostCtrlRoute   = "catalyst-ui-console-ghostco-omani-homes" // org-controller's shape (tenant_route.go:141)
+		ghostHost        = "console.ghostco.omani.homes"
+		ghostCert        = "org-wildcard-tls-ghostco-omani-homes"
+		sovereignRoute   = "catalyst-ui"                     // the Sovereign's own console route — bare name
+		trapRoute        = "catalyst-ui-hw292-omani-works"   // parses like a per-Org host; FQDN guard must protect it
+		sovereignHost    = "console.hw292.omani.works"
+	)
+	ctx := context.Background()
+
+	// ONLY uatco has an Organization CR — ghostco's was deleted hours ago.
+	hostDyn := fakeDynForOrgConsoleReconcile(t, funnelOrgCR("uatco", "omani.homes"))
+	secDyn := fakeDynForOrgConsoleReconcile(t)
+
+	// Host region pre-state.
+	seedRoute(t, hostDyn, orgControllerConsoleRoute(liveOrgCtrlRoute, liveHost))
+	seedRoute(t, hostDyn, catalystAPIConsoleRoute(ghostAPIRoute, ghostHost))
+	seedRoute(t, hostDyn, orgControllerConsoleRoute(ghostCtrlRoute, ghostHost))
+	sovereign := catalystAPIConsoleRoute(sovereignRoute, sovereignHost)
+	sovereign.SetName(sovereignRoute)
+	seedRoute(t, hostDyn, sovereign)
+	seedRoute(t, hostDyn, catalystAPIConsoleRoute(trapRoute, sovereignHost))
+	seedOrgListenerPair(t, hostDyn, "uatco", "omani.homes")
+	seedOrgListenerPair(t, hostDyn, "ghostco", "omani.homes")
+	seedOrgWildcardCert(t, hostDyn, "uatco", "omani.homes")
+	seedOrgWildcardCert(t, hostDyn, "ghostco", "omani.homes")
+	hostCore := k8sfake.NewSimpleClientset(
+		hostIssuedOrgSecret("uatco", "omani.homes"),
+		hostIssuedOrgSecret("ghostco", "omani.homes"),
+		orgBoundaryNamespace("uatco"),
+		orgBoundaryNamespace("ghostco"),
+	)
+
+	// Secondary region pre-state.
+	seedRoute(t, secDyn, catalystAPIConsoleRoute(ghostAPIRoute, ghostHost))
+	seedOrgListenerPair(t, secDyn, "ghostco", "omani.homes")
+	secCore := k8sfake.NewSimpleClientset(
+		mirroredOrgSecret("uatco", "omani.homes"),
+		mirroredOrgSecret("ghostco", "omani.homes"),
+		orgBoundaryNamespace("ghostco"),
+	)
+
+	// Vacuity control — the orphans must actually be there pre-pass, or every
+	// "reaped" assertion below could pass on an empty fixture.
+	for _, pre := range []struct {
+		name string
+		got  bool
+	}{
+		{"host ghost api-route", routeExists(t, hostDyn, ghostAPIRoute)},
+		{"host ghost ctrl-route", routeExists(t, hostDyn, ghostCtrlRoute)},
+		{"secondary ghost api-route", routeExists(t, secDyn, ghostAPIRoute)},
+		{"host ghost listeners", gatewayListenerNames(t, hostDyn)["console-https-ghostco"]},
+		{"secondary ghost listeners", gatewayListenerNames(t, secDyn)["console-https-ghostco"]},
+		{"host ghost cert", certExists(t, hostDyn, ghostCert)},
+		{"host ghost secret", secretExists(t, hostCore, ghostCert)},
+		{"secondary ghost secret", secretExists(t, secCore, ghostCert)},
+		{"host ghost namespace", namespaceExists(t, hostCore, "ghostco")},
+		{"secondary ghost namespace", namespaceExists(t, secCore, "ghostco")},
+	} {
+		if !pre.got {
+			t.Fatalf("vacuity: fixture missing pre-state %s", pre.name)
+		}
+	}
+
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+	h.reconcileOrgConsoleTLSOnce(ctx)
+
+	// ── Direction 1: every ghostco artifact reaped, in BOTH regions. ──
+	if routeExists(t, hostDyn, ghostAPIRoute) {
+		t.Errorf("host region still carries catalyst-api's orphaned route %s (the name shape teardownTenantRoute never targets)", ghostAPIRoute)
+	}
+	if routeExists(t, hostDyn, ghostCtrlRoute) {
+		t.Errorf("host region still carries the org-controller's orphaned route %s", ghostCtrlRoute)
+	}
+	if routeExists(t, secDyn, ghostAPIRoute) {
+		t.Errorf("secondary region still carries the orphaned route %s (teardown never ran in secondaries)", ghostAPIRoute)
+	}
+	for region, dyn := range map[string]*dynamicfake.FakeDynamicClient{"host": hostDyn, "secondary": secDyn} {
+		names := gatewayListenerNames(t, dyn)
+		if names["console-https-ghostco"] || names["console-http-ghostco"] {
+			t.Errorf("[%s] orphaned ghostco listener pair still on the console Gateway", region)
+		}
+		// Harness + preservation control: the apex pair must ALWAYS survive.
+		// If a pass ever clobbered the listener array wholesale, this catches
+		// it — and makes the ghostco-absent assertions above non-vacuous.
+		if !names[consoleApexListenerHTTPSName] || !names[consoleApexListenerHTTPName] {
+			t.Errorf("[%s] apex listener pair missing after the pass — listener handling clobbered the Gateway", region)
+		}
+	}
+	if certExists(t, hostDyn, ghostCert) {
+		t.Errorf("host region still carries the orphaned Certificate %s", ghostCert)
+	}
+	if secretExists(t, hostCore, ghostCert) {
+		t.Errorf("host region still carries the orphaned issued TLS Secret %s (cert-manager does not GC it)", ghostCert)
+	}
+	if secretExists(t, secCore, ghostCert) {
+		t.Errorf("secondary region still carries the orphaned mirrored TLS Secret %s (the #5511 mirror has no deleter)", ghostCert)
+	}
+	if namespaceExists(t, hostCore, "ghostco") {
+		t.Errorf("host region still carries the orphaned org Namespace ghostco — the host-deployed bp-keycloak inside it never dies (#5364)")
+	}
+	if namespaceExists(t, secCore, "ghostco") {
+		t.Errorf("secondary region still carries the orphaned org Namespace ghostco")
+	}
+
+	// ── The never-reap direction, inside the same pass: everything live or
+	// Sovereign-owned survives. ──
+	if !routeExists(t, hostDyn, liveOrgCtrlRoute) {
+		t.Errorf("live Org uatco's route %s was reaped — over-eager reaper (#5649)", liveOrgCtrlRoute)
+	}
+	if !routeExists(t, hostDyn, sovereignRoute) {
+		t.Errorf("the Sovereign's own console route %s was reaped", sovereignRoute)
+	}
+	if !routeExists(t, hostDyn, trapRoute) {
+		t.Errorf("trap route %s (console.<sovereignFQDN>) was reaped — the FQDN guard failed and the reaper would eat the Sovereign front door", trapRoute)
+	}
+	hostNames := gatewayListenerNames(t, hostDyn)
+	if !hostNames["console-https-uatco"] || !hostNames["console-http-uatco"] {
+		t.Errorf("live Org uatco's listener pair was stripped from the host Gateway")
+	}
+	if !certExists(t, hostDyn, liveCert) {
+		t.Errorf("live Org uatco's Certificate %s was reaped", liveCert)
+	}
+	if !secretExists(t, hostCore, liveCert) {
+		t.Errorf("live Org uatco's issued TLS Secret %s was reaped", liveCert)
+	}
+	if !secretExists(t, secCore, liveCert) {
+		t.Errorf("live Org uatco's mirrored TLS Secret %s was reaped from the secondary", liveCert)
+	}
+	if !namespaceExists(t, hostCore, "uatco") {
+		t.Errorf("live Org uatco's boundary Namespace was reaped")
+	}
+}
+
+// TestOrgConsoleTeardown_AlreadyClean_NoOpNoDeletes — direction 2. An Org
+// that is alive and fully served, with NO orphans anywhere, must come through
+// a reconcile pass with zero deletes issued and every artifact intact — the
+// level-triggered no-op that makes repeated passes safe.
+func TestOrgConsoleTeardown_AlreadyClean_NoOpNoDeletes(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+
+	const (
+		liveHost  = "console.uatco.omani.homes"
+		liveRoute = "catalyst-ui-console-uatco-omani-homes"
+		liveCert  = "org-wildcard-tls-uatco-omani-homes"
+	)
+	ctx := context.Background()
+
+	hostDyn := fakeDynForOrgConsoleReconcile(t, funnelOrgCR("uatco", "omani.homes"))
+	secDyn := fakeDynForOrgConsoleReconcile(t)
+	seedRoute(t, hostDyn, orgControllerConsoleRoute(liveRoute, liveHost))
+	seedRoute(t, secDyn, orgControllerConsoleRoute(liveRoute, liveHost))
+	seedOrgListenerPair(t, hostDyn, "uatco", "omani.homes")
+	seedOrgListenerPair(t, secDyn, "uatco", "omani.homes")
+	seedOrgWildcardCert(t, hostDyn, "uatco", "omani.homes")
+	hostCore := k8sfake.NewSimpleClientset(
+		hostIssuedOrgSecret("uatco", "omani.homes"),
+		orgBoundaryNamespace("uatco"),
+	)
+	secCore := k8sfake.NewSimpleClientset(
+		mirroredOrgSecret("uatco", "omani.homes"),
+	)
+
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+	h.reconcileOrgConsoleTLSOnce(ctx)
+
+	// Zero delete verbs anywhere — the strongest no-op assertion the fakes
+	// offer (state-only checks could miss a delete+recreate).
+	countDeletes := func(actions []k8stesting.Action) int {
+		n := 0
+		for _, a := range actions {
+			if a.GetVerb() == "delete" || a.GetVerb() == "delete-collection" {
+				n++
+			}
+		}
+		return n
+	}
+	if n := countDeletes(hostDyn.Actions()); n != 0 {
+		t.Errorf("clean pass issued %d delete(s) on the host dynamic client, want 0", n)
+	}
+	if n := countDeletes(secDyn.Actions()); n != 0 {
+		t.Errorf("clean pass issued %d delete(s) on the secondary dynamic client, want 0", n)
+	}
+	if n := countDeletes(hostCore.Actions()); n != 0 {
+		t.Errorf("clean pass issued %d delete(s) on the host core client, want 0", n)
+	}
+	if n := countDeletes(secCore.Actions()); n != 0 {
+		t.Errorf("clean pass issued %d delete(s) on the secondary core client, want 0", n)
+	}
+
+	// And the served surface is intact.
+	if !routeExists(t, hostDyn, liveRoute) || !routeExists(t, secDyn, liveRoute) {
+		t.Errorf("clean pass removed the live Org's console route")
+	}
+	names := gatewayListenerNames(t, hostDyn)
+	if !names["console-https-uatco"] || !names["console-http-uatco"] {
+		t.Errorf("clean pass stripped the live Org's listener pair")
+	}
+	if !certExists(t, hostDyn, liveCert) {
+		t.Errorf("clean pass removed the live Org's Certificate")
+	}
+	if !secretExists(t, hostCore, liveCert) || !secretExists(t, secCore, liveCert) {
+		t.Errorf("clean pass removed the live Org's TLS Secret")
+	}
+	if !namespaceExists(t, hostCore, "uatco") {
+		t.Errorf("clean pass removed the live Org's boundary Namespace")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
@@ -159,6 +159,13 @@ func (h *Handler) reconcileOrgConsoleTLSOnce(ctx context.Context) {
 		h.log.Info("org-console-tls-reconcile: pass complete — per-Org console gateway surface re-ensured in every region (#5635)",
 			"orgs", len(list.Items), "reconciled", reconciled, "skipped", skipped)
 	}
+
+	// #5364/#5649 — the DELETE-side mirror of the ensure pass above: reap the
+	// per-Org console surface (both producers' route name shapes, listener
+	// pair, Certificate, TLS Secrets) and the orphaned org Namespace of every
+	// Org whose CR no longer exists, in every region. Same seam, same ticker,
+	// level-triggered in both directions — see org_console_tls_reap.go.
+	h.reapOrgConsoleTLSOrphans(ctx, deps)
 }
 
 // orgConsoleTLSRecordFromOrgCR builds the free-subdomain provisioning record

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3642,7 +3642,24 @@ name: bp-catalyst-platform
 #   re-serialized to 1.4.1287 at merge.)
 # 1.4.1289 — #5650: catalog-seed bp-self-sovereign-cutover pin 0.1.167 ->
 #   0.1.168 (loft.sh chart-source pivot). Re-serialized past main 1.4.1288.
-version: 1.4.1290
+# 1.4.1291 — #5364 #5649: grant the catalyst-api cutover-driver SA the delete
+#   verbs for the org-console orphan REAP — the teardown mirror of the #5635
+#   create-side reconcile. reapOrgConsoleTLSOrphans (org_console_tls_reap.go,
+#   same reconcile ticker) deletes in EVERY region the per-Org console surface
+#   of an Org whose CR no longer exists: BOTH producers' HTTPRoute name shapes
+#   (teardownTenantRoute only ever targeted the org-controller's, in one
+#   region — the hw292 R17 both-region route orphan), the per-Org listener
+#   pair (gateways UPDATE: SSA cannot prune another manager's list entries),
+#   the wildcard Certificate, the org-wildcard-tls-* TLS Secrets (cert-manager
+#   never GCs the backing Secret without --enable-certificate-owner-ref, and
+#   the #5511 mirror copies had NO deleter — the R17 region-a Secret orphan),
+#   and the orphaned org boundary Namespace (which reaps the host-deployed
+#   bp-keycloak + tenant HelmReleases inside it — #5364's original orphan).
+#   Level-triggered both directions; live Orgs + the Sovereign's own console
+#   surface are excluded by CR-list + FQDN guards. Refs #5364 #5649.
+#   (1.4.1283 was consumed by the TBD-A6 auto re-publish mid-branch.)
+#   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
+version: 1.4.1291
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -714,3 +714,58 @@ rules:
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations"]
     verbs: ["create"]
+
+  # ───────────────────────────────────────────────────────────────
+  # Issues #5364 / #5649 — ORG-CONSOLE ORPHAN REAP, the teardown mirror
+  # of the #5635 create-side reconcile. reapOrgConsoleTLSOrphans
+  # (org_console_tls_reap.go), run inside the reconcileOrgConsoleTLSOnce
+  # ticker pass, deletes — in EVERY region cluster — the per-Org console
+  # surface of an Organization whose CR no longer exists:
+  #   1. BOTH producers' console HTTPRoute name shapes
+  #      (catalyst-ui-<slug>-<parent-dashed> AND
+  #      catalyst-ui-console-<host-dashed>; teardownTenantRoute only ever
+  #      targeted the second, in one region) → DELETE on httproutes.
+  #   2. The per-Org console-https-<slug>/console-http-<slug> listener
+  #      pair on cilium-gateway-console → UPDATE on gateways. Update, not
+  #      just the patch granted above: the strip is the same
+  #      read-modify-write the org-controller's removeConsoleOrgListener
+  #      uses, because SSA (patch) cannot prune list entries owned by
+  #      ANOTHER field manager and the funnel-door listeners are owned by
+  #      the org-controller's Update manager.
+  #   3. The per-Org wildcard Certificate → DELETE on certificates.
+  #   4. The org-wildcard-tls-* TLS Secrets → DELETE on secrets.
+  #      cert-manager does NOT owner-ref the backing Secret without
+  #      --enable-certificate-owner-ref (the R17 region-a orphan), and the
+  #      #5511 mirror writes copies into secondaries that nothing else
+  #      deletes. In-code scope guard: kube-system only, name prefix
+  #      org-wildcard-tls-, type kubernetes.io/tls, org identity derived
+  #      from producer labels / cert-manager annotations only.
+  #   5. The orphaned org boundary Namespace — deleting it is what reaps
+  #      the host-deployed bp-keycloak + its PVCs + every tenant
+  #      HelmRelease inside it (#5364's original orphan) → DELETE on
+  #      namespaces. In-code scope guard: only namespaces carrying an org
+  #      identity label (openova.io/organization / catalyst.openova.io/org
+  #      / kustomize.toolkit.fluxcd.io/name=org-tenants), never a
+  #      protected/system namespace, never any namespace whose identity
+  #      matches a live Organization CR.
+  # The reaper aborts entirely when the Organization List fails, excludes
+  # the Sovereign's own console surface by FQDN, and only deletes objects
+  # it positively identified — see the safety model in
+  # org_console_tls_reap.go. get/list/watch on every resource here is
+  # already granted above.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["update"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["delete"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["delete"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["delete"]


### PR DESCRIPTION
Refs #5364 #5649 #960

## The gap — teardown reaps one producer's name in one region; creation spans two producers and every region

The hw292 R17 residue walk (2026-08-04) measured it exactly: after an Org delete, HTTPRoute `catalyst-ui-r17probe-omani-homes` orphaned in BOTH regions, Gateway listeners `console-{https,http}-r17probe` orphaned in region-b, TLS Secret `org-wildcard-tls-r17probe-omani-homes` orphaned in region-a. The hw288 walk (#5364 original) additionally showed the org boundary Namespace + host-deployed bp-keycloak surviving deletion. Four independent asymmetries, all in the code:

1. **Name split.** The only route reaper, `teardownTenantRoute` (`core/controllers/organization/internal/controller/tenant_route.go:274-290`, derivation `tenantRouteNameNS` at `:255-266`), targets ONLY the org-controller's shape `catalyst-ui-<console-host-dashed>`. catalyst-api's producer names its route `catalyst-ui-<slug>-<parent-dashed>` (`org_console_tls.go:260`) — invisible to the reaper, in every region.
2. **Region split.** The whole delete cascade (`teardownTenantNetworking`, `removeConsoleOrgListener`, `deleteOrgWildcardCert`) writes through the org-controller's own single-cluster client. The create side fans out to every region (`orgConsoleTLSTargets`, `org_console_tls.go:341`, #5524/#5647). No delete ever reaches a secondary.
3. **The Secret leg has NO deleter at all.** `mirrorOrgConsoleCertSecret` (`org_console_tls.go:587`) writes `kube-system/org-wildcard-tls-*` Secrets into secondaries that nothing deletes, and the host-region issued Secret is not GC'd on Certificate delete (cert-manager only owner-refs the backing Secret under `--enable-certificate-owner-ref`, which we do not run).
4. **The namespace converges only through the gitops prune chain.** When a link misfires (the hw288 beta-corp shape), nothing ever retries — the ns and the bp-keycloak + tenant HelmReleases inside it live forever.

PR #5647 named this and deferred it deliberately because the reap needs delete RBAC — a chart change. This PR is that mirror.

## The fix — same seam, same identity, both directions

`reapOrgConsoleTLSOrphans` (`products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap.go`, new) runs inside `reconcileOrgConsoleTLSOnce` — the level loop #5647 added — on the same ticker. Per region target it deletes every per-Org console artifact whose Organization CR no longer exists: **both** route name shapes (identified by hostname, so adopted/hand-applied variants are covered too), the `console-{https,http}-<slug>` listener pair, the wildcard Certificate, every `org-wildcard-tls-*` TLS Secret (host-issued and mirrored shapes), and the orphaned org boundary Namespace — which is what reaps the host-deployed bp-keycloak, its PVCs, and every tenant HelmRelease inside it (#5364's original orphan). Level-triggered in both directions: an already-half-deleted Org converges to fully-deleted on the next pass; an already-clean Org is a zero-delete no-op.

### Safety model (documented in the file header, enforced in code, pinned by tests)

1. **Scan-then-list ordering** — artifacts are scanned before the Organization CRs are listed; a producer only creates artifacts for an existing CR, so an Org created mid-pass cannot lose its surface.
2. **Age grace** — timestamped candidates younger than 15 minutes are skipped this pass.
3. **FQDN guard** — `console.<sovereignFQDN>` parses exactly like a per-Org host; the reap refuses to run when the FQDN is unknown and excludes any candidate whose org zone equals it. A trap-route test (`catalyst-ui-hw292-omani-works` serving the Sovereign console host) pins that the reaper can never eat the Sovereign front door.
4. **Structural match only** — name prefix + `console.<slug>.<parent>` / `*.<slug>.<parent>` host shape + label/annotation-derived identity; anything not positively identified (including a label-less, annotation-less Secret) is left alone. Namespaces additionally require an org identity label (`openova.io/organization` / `catalyst.openova.io/org` / `kustomize.toolkit.fluxcd.io/name=org-tenants`) and clear a protected-namespace denylist + `kube-` prefix guard.
5. **Abort on blind** — a failed Organization List aborts the entire reap pass.
6. **Delete by observed name**, absent-as-success, every delete independent.

The listener strip is read-modify-write Update — the same mechanism the org-controller's `removeConsoleOrgListener` uses — because SSA cannot prune list entries owned by another field manager, and the funnel-door listeners are owned by the org-controller's Update manager.

## Chart change (the RBAC #5647 deferred)

`clusterrole-cutover-driver.yaml`: delete on `httproutes` / `certificates` / `secrets` / `namespaces`, update on `gateways`, each with a comment naming the exact consumer + the in-code scope guards. `bp-catalyst-platform` 1.4.1284 + bootstrap-kit slot-13 pin in lockstep (1.4.1283 was consumed by the TBD-A6 auto re-publish mid-branch; branch rebased onto it).

**No NodePorts anywhere** — nothing in this change touches a Service type or a port literal; the gateway stays DIRECT.

## Tests — both directions, red-proven

`org_console_tls_reap_5364_test.go` uses ONLY symbols that predate this fix, so it compiles against the unfixed tree and fails there at RUNTIME:

- **`TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped`** — live Org `uatco` fully served; deleted Org `ghostco` (no CR) carrying both producers' route shapes, listener pairs, Certificate, both Secret shapes, and boundary Namespaces across both regions. One pass must reap all of it AND leave every live/Sovereign artifact untouched (adversarial controls: bare `catalyst-ui` route, the FQDN trap route, the apex listener pair, an unidentifiable Secret). Confirmed failing on the unfixed tree (production files reverted, tests kept) with all ten orphan classes named:

```
org_console_tls_reap_5364_test.go:347: host region still carries catalyst-api's orphaned route catalyst-ui-ghostco-omani-homes (the name shape teardownTenantRoute never targets)
org_console_tls_reap_5364_test.go:350: host region still carries the org-controller's orphaned route catalyst-ui-console-ghostco-omani-homes
org_console_tls_reap_5364_test.go:353: secondary region still carries the orphaned route catalyst-ui-ghostco-omani-homes (teardown never ran in secondaries)
org_console_tls_reap_5364_test.go:358: [host] orphaned ghostco listener pair still on the console Gateway
org_console_tls_reap_5364_test.go:358: [secondary] orphaned ghostco listener pair still on the console Gateway
org_console_tls_reap_5364_test.go:368: host region still carries the orphaned Certificate org-wildcard-tls-ghostco-omani-homes
org_console_tls_reap_5364_test.go:371: host region still carries the orphaned issued TLS Secret org-wildcard-tls-ghostco-omani-homes (cert-manager does not GC it)
org_console_tls_reap_5364_test.go:374: secondary region still carries the orphaned mirrored TLS Secret org-wildcard-tls-ghostco-omani-homes (the #5511 mirror has no deleter)
org_console_tls_reap_5364_test.go:377: host region still carries the orphaned org Namespace ghostco — the host-deployed bp-keycloak inside it never dies (#5364)
org_console_tls_reap_5364_test.go:380: secondary region still carries the orphaned org Namespace ghostco
--- FAIL: TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped
```

- **`TestOrgConsoleTeardown_AlreadyClean_NoOpNoDeletes`** — a live, fully-served Org with no orphans anywhere: zero delete verbs on all four fake clients (state-only checks could miss a delete+recreate) and the full surface intact — the #5649 over-eager-reaper direction.

## Gates

- `go build ./...` — `products/catalyst/bootstrap/api` — clean (post-rebase)
- `go test ./...` — whole module, exit 0; `internal/handler` re-run `-count=1` post-rebase, ok (255s)
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs, bp-catalyst-platform 1.4.1284 = pin 1.4.1284)
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)
- `helm lint products/catalyst/chart` — 0 failed

## Residual, stated explicitly — #5359

Region-b currently receives **neither creates nor deletes through its GitOps stream** because its bootstrap-kit still reconciles from public github.com (#5359). This reaper acts through catalyst-api's DIRECT per-region API clients (the same seam the #5647 creates use), so its deletes land in region-b regardless — but whatever region-b's severed stream itself materializes will keep being re-applied by that stream until #5359 lands. This PR fixes the producer-side teardown logic only and does not attempt #5359.

## Verification still owed

Not walked on a live Sovereign. The proof for R17 is: delete an admin-door Org on a 2-region prov running this image + chart, then within one reconcile interval both regions show zero routes/listeners/Certificates/Secrets for the deleted slug and the namespace is gone — while a live Org's console keeps answering 200. That walk needs the next env with this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
