### PR TITLE
fix(funnel): honest provisioning timeline — progress never 100 on a failed run, declared-order steps, recovered record supersedes its failure (Refs #5646)

### DIFF
--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -1894,6 +1894,14 @@ func (h *Handler) failProvision(ctx context.Context, provisionID, tenantID strin
 	}
 
 	p.Status = "failed"
+	// #5646 — progress must never read 100 on a run that failed. A concurrent
+	// pod-truth reconcile (or an earlier step-completion roll-up) can have left
+	// Progress at 100 just before this failure lands; without recomputing it the
+	// customer sees a FULL progress bar sitting above "Provisioning didn't
+	// finish". Recompute from the steps that ACTUALLY completed — the failed /
+	// still-pending steps are excluded, so on a failed run this is always < 100.
+	// The invariant the funnel UI relies on: progress == 100 ⟺ status == completed.
+	p.Progress = completedStepProgress(p.Steps)
 	if err := h.Store.UpdateProvision(ctx, provisionID, p); err != nil {
 		slog.Error("failed to mark provision as failed", "error", err)
 	}
@@ -1904,6 +1912,24 @@ func (h *Handler) failProvision(ctx context.Context, provisionID, tenantID strin
 	})
 
 	slog.Error("provisioning failed", "provision_id", provisionID, "step", stepIndex, "error", message)
+}
+
+// completedStepProgress returns the percent of steps that are in the terminal
+// "completed" state. Because a failing (or still-running) provision always has
+// at least one non-completed step, the result is guaranteed < 100 — which is
+// exactly the property #5646's failProvision relies on to enforce the
+// progress == 100 ⟺ status == "completed" invariant. Empty step list → 0.
+func completedStepProgress(steps []store.ProvisionStep) int {
+	if len(steps) == 0 {
+		return 0
+	}
+	completed := 0
+	for _, s := range steps {
+		if s.Status == "completed" {
+			completed++
+		}
+	}
+	return (completed * 100) / len(steps)
 }
 
 func (h *Handler) updateProgress(ctx context.Context, provisionID string, progress int) {

--- a/core/services/provisioning/handlers/pod_truth_reconciler.go
+++ b/core/services/provisioning/handlers/pod_truth_reconciler.go
@@ -53,9 +53,16 @@ func (h *Handler) reconcilePodTruth(ctx context.Context) {
 	}
 	for i := range all {
 		p := &all[i]
-		// Ignore terminal states — failed is user-visible and intentionally
-		// frozen; completed has nothing to advance.
-		if p.Status != "provisioning" {
+		// #5646 — a `failed` record is NOT frozen. The workload can recover on
+		// its own after the record was written (e.g. a dependency that crossed
+		// the 10-minute readiness budget but came up moments later — mysql was
+		// 1/1 Running for half a day while the funnel still showed a permanent
+		// failure). The record must RE-OBSERVE reality and supersede the earlier
+		// failure stamp, not carry a final verdict forever. So we reconcile both
+		// in-flight (`provisioning`) AND `failed` records here; only the terminal
+		// SUCCESS state (`completed`) is skipped — it has nothing left to advance.
+		// Level-triggered, not write-once.
+		if p.Status != "provisioning" && p.Status != "failed" {
 			continue
 		}
 		if p.Subdomain == "" {
@@ -167,17 +174,40 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 	_ = advanced
 	stepAdvanced := map[int]bool{}
 	for i, step := range p.Steps {
-		if step.Status == "completed" || step.Status == "failed" {
+		// Skip only steps already at their happy terminal state. A `failed`
+		// step is NOT skipped — #5646: if its workload is now Ready the failure
+		// was transient (crossed a readiness budget then recovered) and must be
+		// SUPERSEDED, level-triggered, so the timeline reflects the healthy Org
+		// rather than a permanent verdict.
+		if step.Status == "completed" {
 			continue
 		}
 		slug := slugFromStepName(step.Name)
 		if slug == "" || !ready[slug] {
 			continue
 		}
-		slog.Warn("pod-truth: advancing stuck step — pod is Ready",
-			"tenant", p.Subdomain, "step", step.Name, "slug", slug)
-		h.markStep(ctx, p.ID, i, step.Name, "running")  // running first if was pending
+		// #5646 — respect the DECLARED phase order. Never mark a step completed
+		// while an EARLIER step is still pending/running/failed, or the timeline
+		// shows a later stage green above an unresolved earlier one (the
+		// "Running health checks completed before the dependency it depends on
+		// failed" defect). Advancing strictly in declared order keeps the record
+		// monotonic and honest; a later pass completes step i once its
+		// predecessors have.
+		if !priorStepsComplete(p.Steps, i) {
+			continue
+		}
+		if step.Status == "failed" {
+			slog.Warn("pod-truth: superseding failed step — pod is now Ready",
+				"tenant", p.Subdomain, "step", step.Name, "slug", slug)
+		} else {
+			slog.Warn("pod-truth: advancing stuck step — pod is Ready",
+				"tenant", p.Subdomain, "step", step.Name, "slug", slug)
+		}
+		h.markStep(ctx, p.ID, i, step.Name, "running")  // running first if was pending/failed
 		h.completeStep(ctx, p.ID, p.TenantID, i, step.Name, len(p.Steps))
+		// Keep the in-memory snapshot consistent so priorStepsComplete + the
+		// allDone roll-up below see this completion within the same pass.
+		p.Steps[i].Status = "completed"
 		stepAdvanced[i] = true
 		advanced = true
 		// Publish provision.app_ready so the tenant service clears the
@@ -213,16 +243,26 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 			"Provisioning vCluster":        true, // in case orphan left this mid-way
 		}
 		for i, step := range p.Steps {
-			if step.Status == "completed" || step.Status == "failed" {
+			// As with the per-app loop, a `failed` tail step is re-observable
+			// (#5646): once every app is Ready the tail condition it gates on is
+			// satisfied, so a transient failure must be superseded. Only an
+			// already-`completed` step is skipped.
+			if step.Status == "completed" {
 				continue
 			}
 			if !tailNames[step.Name] {
+				continue
+			}
+			// Declared-phase order (#5646): never green a tail step above an
+			// earlier step that is still unresolved.
+			if !priorStepsComplete(p.Steps, i) {
 				continue
 			}
 			slog.Warn("pod-truth: auto-completing tail step — all apps Ready",
 				"tenant", p.Subdomain, "step", step.Name)
 			h.markStep(ctx, p.ID, i, step.Name, "running")
 			h.completeStep(ctx, p.ID, p.TenantID, i, step.Name, len(p.Steps))
+			p.Steps[i].Status = "completed"
 			advanced = true
 		}
 	}
@@ -328,6 +368,12 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 	// finalize. Without this unconditional check the status would stay
 	// 'provisioning' forever and the UI shows 'Running 9/9' (exactly
 	// what the user saw on emrah5). Issue #119.
+	//
+	// #5646 — this is ALSO the recovery path for a record previously written
+	// `failed`: once the superseding above has flipped the last failed step to
+	// completed, every step is completed and the overall verdict flips from
+	// failed back to completed with progress 100, and a fresh provision.completed
+	// is emitted so downstream state reflects the recovered Organization.
 	allDone := true
 	for _, s := range p.Steps {
 		if s.Status != "completed" {
@@ -335,9 +381,9 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 			break
 		}
 	}
-	if allDone {
+	if allDone && p.Status != "completed" {
 		slog.Info("pod-truth: all steps completed — marking provision succeeded",
-			"tenant", p.Subdomain, "provision_id", p.ID)
+			"tenant", p.Subdomain, "provision_id", p.ID, "prior_status", p.Status)
 		p.Status = "completed"
 		p.Progress = 100
 		if err := h.Store.UpdateProvision(ctx, p.ID, p); err == nil {
@@ -347,6 +393,24 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 			})
 		}
 	}
+}
+
+// priorStepsComplete reports whether every step BEFORE index i is in the
+// terminal "completed" state. The pod-truth reconciler uses it to advance the
+// timeline strictly in DECLARED phase order (#5646): a step is only greened
+// once all of its predecessors are, so the customer never sees a later stage
+// completed above an earlier one that is still pending, running, or failed.
+// i <= 0 has no predecessors and is trivially true.
+func priorStepsComplete(steps []store.ProvisionStep, i int) bool {
+	if i > len(steps) {
+		i = len(steps)
+	}
+	for j := 0; j < i; j++ {
+		if steps[j].Status != "completed" {
+			return false
+		}
+	}
+	return true
 }
 
 // slugFromStepName extracts the app slug from step names like:

--- a/core/services/provisioning/handlers/provision_timeline_honest_5646_test.go
+++ b/core/services/provisioning/handlers/provision_timeline_honest_5646_test.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/core/services/provisioning/store"
+)
+
+// steps is a tiny helper to build a []store.ProvisionStep from (name,status)
+// pairs so the tables below read like the live timeline.
+func steps(pairs ...[2]string) []store.ProvisionStep {
+	out := make([]store.ProvisionStep, 0, len(pairs))
+	for _, p := range pairs {
+		out = append(out, store.ProvisionStep{Name: p[0], Status: p[1]})
+	}
+	return out
+}
+
+// TestCompletedStepProgress_NeverHundredOnFailedRun pins the #5646 progress
+// invariant: progress reaches 100 ONLY when every step is completed. The exact
+// live record that filed the issue — "Installing mysql (dependency)" failed
+// while WordPress/TLS/Health completed — must compute BELOW 100 so the customer
+// never sees a full progress bar above "Provisioning didn't finish".
+func TestCompletedStepProgress_NeverHundredOnFailedRun(t *testing.T) {
+	cases := []struct {
+		name  string
+		steps []store.ProvisionStep
+		want  int
+	}{
+		{
+			// The verbatim hw292 / UAT-row-86 record: 6 of 7 steps completed,
+			// the mysql dependency failed. Old code left Progress at 100; the
+			// honest value is 6*100/7 = 85, and crucially NOT 100.
+			name: "hw292 failed-mysql record is 85, not 100",
+			steps: steps(
+				[2]string{"Creating Organization", "completed"},
+				[2]string{"Committing manifests to Git", "completed"},
+				[2]string{"Provisioning vCluster", "completed"},
+				[2]string{"Installing mysql (dependency)", "failed"},
+				[2]string{"Deploying WordPress", "completed"},
+				[2]string{"Configuring TLS certificates", "completed"},
+				[2]string{"Running health checks", "completed"},
+			),
+			want: 85,
+		},
+		{
+			name: "all completed is exactly 100",
+			steps: steps(
+				[2]string{"Creating Organization", "completed"},
+				[2]string{"Deploying WordPress", "completed"},
+				[2]string{"Running health checks", "completed"},
+			),
+			want: 100,
+		},
+		{
+			name: "a single failed step among otherwise-complete is below 100",
+			steps: steps(
+				[2]string{"Creating Organization", "completed"},
+				[2]string{"Deploying WordPress", "completed"},
+				[2]string{"Running health checks", "failed"},
+			),
+			want: 66,
+		},
+		{
+			name: "a still-pending step keeps progress below 100",
+			steps: steps(
+				[2]string{"Creating Organization", "completed"},
+				[2]string{"Deploying WordPress", "completed"},
+				[2]string{"Running health checks", "pending"},
+			),
+			want: 66,
+		},
+		{
+			name:  "empty step list is 0, not a divide-by-zero",
+			steps: nil,
+			want:  0,
+		},
+		{
+			name: "nothing completed is 0",
+			steps: steps(
+				[2]string{"Creating Organization", "running"},
+				[2]string{"Deploying WordPress", "pending"},
+			),
+			want: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := completedStepProgress(tc.steps)
+			if got != tc.want {
+				t.Fatalf("completedStepProgress = %d, want %d", got, tc.want)
+			}
+			// The load-bearing invariant, asserted directly: 100 iff every step
+			// is completed. Any failed/pending/running step must yield < 100.
+			allCompleted := len(tc.steps) > 0
+			for _, s := range tc.steps {
+				if s.Status != "completed" {
+					allCompleted = false
+					break
+				}
+			}
+			if got == 100 && !allCompleted {
+				t.Fatalf("progress reported 100 on a run that is not fully completed: %+v", tc.steps)
+			}
+			if allCompleted && got != 100 {
+				t.Fatalf("progress must be 100 when every step is completed, got %d", got)
+			}
+		})
+	}
+}
+
+// TestPriorStepsComplete_EnforcesDeclaredOrder pins the #5646 ordering
+// invariant the pod-truth reconciler leans on: a step may be greened only when
+// EVERY earlier step is already completed. This is what stops the reconciler
+// from marking "Running health checks" completed while the earlier
+// "Installing mysql (dependency)" step is still unresolved (the out-of-order
+// timeline defect).
+func TestPriorStepsComplete_EnforcesDeclaredOrder(t *testing.T) {
+	base := steps(
+		[2]string{"Creating Organization", "completed"},     // 0
+		[2]string{"Committing manifests to Git", "completed"}, // 1
+		[2]string{"Provisioning vCluster", "completed"},       // 2
+		[2]string{"Installing mysql (dependency)", "running"}, // 3
+		[2]string{"Deploying WordPress", "completed"},         // 4 (pod ready ahead of the dep)
+		[2]string{"Configuring TLS certificates", "pending"},  // 5
+		[2]string{"Running health checks", "pending"},         // 6
+	)
+
+	cases := []struct {
+		name string
+		i    int
+		want bool
+	}{
+		{"index 0 has no predecessors — trivially true", 0, true},
+		{"first three infra steps done — dep step may advance", 3, true},
+		{"WordPress (idx 4) is BLOCKED while mysql (idx 3) is unresolved", 4, false},
+		{"TLS (idx 5) is BLOCKED while an earlier step is unresolved", 5, false},
+		{"health checks (idx 6) is BLOCKED while an earlier step is unresolved", 6, false},
+		{"len(steps) is treated as the whole slice", len(base), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := priorStepsComplete(base, tc.i); got != tc.want {
+				t.Fatalf("priorStepsComplete(i=%d) = %v, want %v", tc.i, got, tc.want)
+			}
+		})
+	}
+
+	// Positive direction: once the dep is completed, every downstream step is
+	// unblocked in declared order — the reconciler can green them one pass at a
+	// time without ever showing a later stage above an earlier unresolved one.
+	healed := steps(
+		[2]string{"Creating Organization", "completed"},
+		[2]string{"Committing manifests to Git", "completed"},
+		[2]string{"Provisioning vCluster", "completed"},
+		[2]string{"Installing mysql (dependency)", "completed"},
+		[2]string{"Deploying WordPress", "completed"},
+		[2]string{"Configuring TLS certificates", "running"},
+		[2]string{"Running health checks", "pending"},
+	)
+	if !priorStepsComplete(healed, 5) {
+		t.Fatalf("TLS step should be unblocked once every earlier step is completed")
+	}
+
+	// A FAILED earlier step also blocks — a later step must never green above a
+	// failed predecessor (that failed step is separately re-observed and, if its
+	// workload recovered, superseded to completed first — #5646).
+	withFailed := steps(
+		[2]string{"Creating Organization", "completed"},
+		[2]string{"Installing mysql (dependency)", "failed"},
+		[2]string{"Deploying WordPress", "completed"},
+	)
+	if priorStepsComplete(withFailed, 2) {
+		t.Fatalf("a step must be blocked while an earlier step is failed")
+	}
+}


### PR DESCRIPTION
## What

The customer-facing provisioning launching timeline (the page a paying customer watches right after checkout) carried defects that survive whether or not provisioning succeeds, and are only visible while something is failing — exactly when the customer is paying the most attention. This makes the timeline honest at the producer.

All defects live in the provisioning service that emits the record; the three funnel UI renderers (LaunchingStep, ProvisioningTimeline, CheckoutStep) already render the payload faithfully — no numeric progress bar of their own, steps drawn in array order, no hardcoded step label — so fixing the payload fixes every surface at once. No UI change was warranted.

## The four defects and their source fixes

1. Banned term Creating tenant on the first step. Already corrected at source to Creating Organization in commit c93634751 — `core/services/provisioning/handlers/consumer.go:1313`. Confirmed the only other step producer (`core/marketplace-api/handlers/handlers.go`) uses Creating virtual cluster, and no funnel UI hardcodes the term.

2. Steps completing out of order — the timeline showed Running health checks green above an earlier dependency step that had not resolved. Cause: the pod-truth reconciler advanced downstream steps independently of the declared order. Fix: it now advances strictly in declared phase order — a step is greened only when every earlier step is completed. `core/services/provisioning/handlers/pod_truth_reconciler.go:196` and `:258` (guard), `:404` (new priorStepsComplete helper).

3. progress 100 on a status failed record — a full progress bar above Provisioning didnt finish. A concurrent completion roll-up could leave progress at 100 just before a failure landed, and failProvision never reset it. Fix: failProvision recomputes progress from the steps that actually completed, guaranteed below 100 on a failed run. Invariant enforced: progress 100 iff status completed. `core/services/provisioning/handlers/consumer.go:1904` (recompute) and `:1922` (new completedStepProgress helper).

4. Write-once terminal record that can never re-observe recovery. A workload that recovered on its own — a dependency that crossed the 10-minute readiness budget then came up 1/1 Running — left a permanent failure for a healthy Organization, because the reconciler skipped every non-provisioning record. Fix: the reconciler now re-observes failed records level-triggered and supersedes a failed step whose pod is now Ready, healing the record back to completed with progress 100 and emitting a fresh provision.completed. `core/services/provisioning/handlers/pod_truth_reconciler.go:65` (scan failed records too) and `:182` / `:199` (supersede a failed step).

## Tests

New `core/services/provisioning/handlers/provision_timeline_honest_5646_test.go`, both directions:

- completedStepProgress: the verbatim hw292 record (mysql dependency failed among six completed steps) computes 85, not 100; all-completed is exactly 100; any failed or pending step yields below 100; empty list is 0 with no divide-by-zero.
- priorStepsComplete: a later step is blocked while an earlier one is pending, running, or failed, and unblocked only once every predecessor is completed.

Gate: `go build ./...` and `go test ./...` both green in `core/services/provisioning`.

Refs #5646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
