### PR TITLE
feat(bp-postgres): region-B auto DR promoter for the shared-pg pairs (Refs #5623)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -161,7 +161,13 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.17
+      # 0.2.18 (#5623): region-B AUTOMATIC DR promotion — the ported bp-cnpg-pair
+      # dr-promoter + failover-readiness probe + topology.promoted HR-value seam on
+      # the active-hot-standby replica half. On the hw292 G12 region-kill this
+      # instance's region-B replica stayed read-only for the whole outage (keycloak
+      # unrecoverable in region-B) because ONLY bp-cnpg-pair shipped a promoter. sync-
+      # only fence; autoPromote.hr.name above targets THIS HR. Lockstep 16a/16c/16d.
+      version: 0.2.18
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -236,6 +242,14 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      # ── Region-B automatic DR promotion (#5623) ─────────────────────────
+      # The side=replica dr-promoter patches THIS instance's HR DESIRED state
+      # (spec.values.topology.promoted=true) on a region-A kill, so hr.name MUST
+      # be this slot's own HelmRelease (this equals the chart default; pinned
+      # explicitly so 16c/16d — which override it to -b/-c — stay symmetrical).
+      autoPromote:
+        hr:
+          name: bp-postgres-shared
       # #4442 — HOST shared-data instance: the singleton operator-probe NP
       # (networkpolicy-singleton-operator-probe.yaml) default-denies 5432 to
       # cross-namespace consumers (keycloak/gitea/harbor in OTHER namespaces,

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -99,7 +99,11 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.17
+      # 0.2.18 (#5623): region-B AUTOMATIC DR promotion — ported bp-cnpg-pair
+      # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
+      # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
+      # bp-postgres-shared-b). sync-only fence. Lockstep 16a/16c/16d.
+      version: 0.2.18
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -141,6 +145,13 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      # ── Region-B automatic DR promotion (#5623) ─────────────────────────
+      # The side=replica dr-promoter patches THIS instance's HR DESIRED state
+      # (spec.values.topology.promoted=true) on a region-A kill, so hr.name MUST
+      # be this slot's own HelmRelease (the chart default is bp-postgres-shared).
+      autoPromote:
+        hr:
+          name: bp-postgres-shared-b
       # #4442 — HOST shared-data instance: open 5432 to cross-namespace
       # consumers (the singleton operator-probe NP otherwise default-denies
       # them). See slot 16a for the full rationale.

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -87,7 +87,11 @@ spec:
       # region-A. Lockstep with the other 16* bp-postgres slots.
       # 0.2.14 (#5473): replication-source Service selectorType r -> rw —
       # `r` matched every instance, so a standby could serve as DR source.
-      version: 0.2.17
+      # 0.2.18 (#5623): region-B AUTOMATIC DR promotion — ported bp-cnpg-pair
+      # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
+      # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
+      # bp-postgres-shared-c). sync-only fence. Lockstep 16a/16c/16d.
+      version: 0.2.18
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -129,6 +133,13 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      # ── Region-B automatic DR promotion (#5623) ─────────────────────────
+      # The side=replica dr-promoter patches THIS instance's HR DESIRED state
+      # (spec.values.topology.promoted=true) on a region-A kill, so hr.name MUST
+      # be this slot's own HelmRelease (the chart default is bp-postgres-shared).
+      autoPromote:
+        hr:
+          name: bp-postgres-shared-c
       # #4442 — HOST shared-data instance: open 5432 to cross-namespace
       # consumers (the singleton operator-probe NP otherwise default-denies
       # them). See slot 16a for the full rationale.

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -24,7 +24,13 @@ spec:
   # unsatisfiable nodeAffinity that left hw292's per-Org primary unschedulable
   # for 7h behind an `install succeeded` HelmRelease. configSchema gains
   # topology.primary.region, which the per-Org install door now emits.
-  version: 0.2.17
+  # 0.2.18 (#5623): region-B AUTOMATIC DR promotion for the shared-pg pairs — a
+  # ported bp-cnpg-pair dr-promoter + failover-readiness probe + topology.promoted
+  # HR-value seam on the active-hot-standby replica half, so a region-A kill
+  # auto-promotes the survivor (keycloak et al. writable in region-B) instead of
+  # leaving it pg_is_in_recovery()=t for the whole outage (hw292 G12). sync-only
+  # data fence; default-OFF preserved for singleton/primary/async.
+  version: 0.2.18
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,42 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.18 — #5623 (Refs #5137 #5178 #5218 #5220 #5133 #5157): region-B AUTOMATIC DR
+#   promotion for the shared-pg pairs. The three shared-pg instances render the EXACT
+#   bp-cnpg-pair split-side replica shape but shipped NO region-local promoter, so on
+#   the hw292 G12 region-kill (2026-08-03, dep 1c56518035a83e03, cutoverComplete=true)
+#   bp-cnpg-pair's own region-B dr-promoter auto-promoted at T0+2m16s (RPO=0) while all
+#   three shared-pg replicas stayed pg_is_in_recovery()=t for the WHOLE outage —
+#   keycloak (a shared-pg consumer) and every platform database read-only, the auth
+#   path unrecoverable in region-B (the gateway 503'd on four fresh-TCP samples). This
+#   ports the PROVEN bp-cnpg-pair dr-promoter (chart 0.2.17) onto the shared-pg replica
+#   half, templated with bp-postgres's own naming helpers + the shared-pg HR-value seam:
+#     - templates/dr-promoter.yaml — a side=replica-gated Deployment (NOT a CronJob,
+#       #5157) whose signals container watches the LOCAL replica's WAL receiver AND
+#       POSITIVELY probes region-A liveness (pg_isready of the -mesh endpoint over the
+#       ClusterMesh — #5178), and whose actor promotes via the topology.promoted
+#       HR-value seam + a durable spec.suspend latch (#5218, custom field-manager) only
+#       after the region-A-loss clock held primaryDownHoldSeconds AND the pair reached
+#       streaming steady-state (steadyStateArmSeconds — #5220) AND the failover-readiness
+#       probe is Ready (#5133). Anti-flap: never re-promote an already-diverged cluster.
+#     - templates/failover-readiness.yaml — the #5133 LSN apply==receive promotability
+#       probe (streaming_replica mutual-TLS).
+#     - replica-cluster.yaml now drives replica.enabled from the topology.promoted VALUE
+#       (mirror of bp-cnpg-pair 0.2.12 / #5125-D1) so the promotion is the DESIRED state
+#       flux drift-correction RE-AFFIRMS, never a live-object patch it reverts mid-outage.
+#     - networkpolicy.yaml admits the promoter signals + probe to the replica 5432 and
+#       adds the probe egress; dr-promoter.yaml carries its own egress CNP (apiserver +
+#       kube-dns + replica 5432 + the region-A liveness probe by peer identity).
+#   DATA FENCE: rendered ONLY when replication.mode=sync (the old primary cannot commit
+#   while its sync standby is unreachable — automatic promotion can never lose or fork
+#   committed data). Default-OFF preserved: singleton / primary / async / autoPromote-off
+#   render ZERO promoter resources (byte-identical to 0.2.17). The #5245 durable-substitute
+#   handoff, TL-ahead re-promote and region-A dr-failback leg bp-cnpg-pair added on top
+#   (0.2.18-0.2.23) are NOT ported (follow-up); as with bp-cnpg-pair 0.2.14-0.2.17 the
+#   suspend latch holds the survivor writable through the outage and the operator lifts it
+#   on region-A recovery (RUNBOOKS §6.1). New values under topology: promoted, walStreaming,
+#   autoPromote.*. tests/postgres-render.sh Cases 20a-20d added. LIVE region-kill proof on
+#   the shared-pg pairs is owed on the next 2-region G12 walk. Lockstep: 16a/16c/16d HR
+#   pins + blueprint.yaml + catalog-seed → 0.2.18.
 # 0.2.17 — #5639 (Refs #960 #3986): FAIL CLOSED on an unresolvable region. Both
 #   active-hot-standby Cluster halves pin a REQUIRED nodeAffinity on the
 #   `openova.io/region` node label, and both read the value straight off
@@ -254,7 +291,7 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.17
+version: 0.2.18
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/_helpers.tpl
+++ b/platform/postgres/chart/templates/_helpers.tpl
@@ -83,6 +83,42 @@ replica side renders ONLY the follower Cluster + its mesh stub + netpol.
 {{- end -}}
 
 {{/*
+Region-B automatic DR promotion — active? (chart 0.2.18, #5623)
+
+The shared-pg data instances render the EXACT bp-cnpg-pair split-side replica
+shape but shipped NO region-local promoter, so on a region-A kill their region-B
+replicas stayed `pg_is_in_recovery()=t` for the whole outage — keycloak and every
+other platform database read-only, the auth path unrecoverable in region-B (hw292
+G12, 2026-08-03). This gate renders the SAME proven bp-cnpg-pair dr-promoter shape
+(templates/dr-promoter.yaml + the shared _dr-promoter-scripts.tpl partials) on this
+side, so the survivor auto-promotes RPO=0 with the same false-promote guards.
+
+TRUE only when ALL of (mirrors bp-cnpg-pair.autoPromoteActive exactly):
+  - renderReplicaHalf            (active-hot-standby AND side=replica|secondary —
+                                  the actor runs ON cluster-B, the half that
+                                  survives a region-A kill)
+  - autoPromote.enabled          (operator gate; default TRUE — absent key ⇒
+                                  enabled, hasKey-guarded because sprig `default`
+                                  swallows a literal `false`)
+  - replication.mode == sync     (the anti-split-brain DATA FENCE: with
+                                  synchronous_commit=remote_apply + FIRST 1 pinned
+                                  to the cross-region replica, the old primary
+                                  CANNOT durably commit while its sync standby is
+                                  unreachable or diverged, so an automatic promote
+                                  can never lose or fork committed data. async has
+                                  no fence → the promoter does NOT render there.)
+renderReplicaHalf is already false when the whole chart is disabled or singleton;
+dr-promoter.yaml additionally guards on `ne (toString .Values.enabled) "false"`.
+*/}}
+{{- define "bp-postgres.autoPromoteActive" -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- $ap := dig "autoPromote" dict $topology -}}
+{{- $apEnabled := true -}}
+{{- if hasKey $ap "enabled" }}{{- $apEnabled = $ap.enabled -}}{{- end -}}
+{{- if and (include "bp-postgres.renderReplicaHalf" .) $apEnabled (eq (dig "replication" "mode" "sync" $topology) "sync") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Whether this install publishes the ClusterMesh-global `-mesh` (read) +
 `-mesh-rw` (write) Service aliases — gated on `topology.clusterMesh.enabled`
 + a MULTI-REGION signal, deliberately DECOUPLED from `activeHotStandby` (#4460).

--- a/platform/postgres/chart/templates/dr-promoter.yaml
+++ b/platform/postgres/chart/templates/dr-promoter.yaml
@@ -1,0 +1,679 @@
+{{- /*
+Region-B DR auto-promoter for the shared-pg pairs (#5623 — chart 0.2.18).
+
+WHY THIS EXISTS
+---------------
+The three shared-pg data instances (bp-postgres-shared{,-b,-c}) render the EXACT
+bp-cnpg-pair split-side replica shape but shipped NO region-local promoter. On the
+hw292 G12 region-kill (2026-08-03, dep 1c56518035a83e03, cutoverComplete=true)
+bp-cnpg-pair's own region-B dr-promoter auto-promoted at T0+2m16s (RPO=0), but the
+three shared-pg replicas each stayed `pg_is_in_recovery()=t` for the WHOLE outage —
+keycloak (a shared-pg consumer) and every other platform database read-only, so the
+auth path could not recover in region-B even in principle (the gateway answered 503
+throughout — a real availability gap behind a correct-looking HTTP layer).
+
+This Deployment is a FAITHFUL PORT of bp-cnpg-pair's dr-promoter (chart 0.2.17): the
+same region-B-local actor that survives the loss of region-A, the same signals/actor
+split, the same false-promote guards. It is templated with bp-postgres's own naming
+helpers + the shared-pg HR-value seam. The #5245 durable-substitute handoff, TL-ahead
+re-promote and region-A dr-failback leg that bp-cnpg-pair added on top (0.2.18–0.2.23)
+are deliberately NOT ported here (tracked as follow-up) — as with bp-cnpg-pair
+0.2.14–0.2.17, the suspend latch keeps the survivor writable through the outage and
+the operator lifts it on region-A recovery (RUNBOOKS §6.1). Live region-kill proof on
+the shared-pg pairs is owed on the next 2-region G12 walk.
+
+WHY A DEPLOYMENT, NOT A CronJob (#5157)
+---------------------------------------
+A region-local actor that must run DURING a region outage is a continuous Deployment
+loop: a CronJob's scheduler is the (regional) control plane and does not reliably
+resume after recovery. side=replica-gated so it runs ON cluster-B with zero
+dependency on anything in region-A.
+
+WHY IT PATCHES THE HELMRELEASE, NEVER THE LIVE Cluster CR (#5125-D1)
+--------------------------------------------------------------------
+A live `kubectl patch spec.replica.enabled=false` is reverted by flux drift-
+correction mid-outage (hw256 G12), silently re-demoting the promoted survivor. The
+chart drives `replica.enabled` from the `topology.promoted` VALUE, so the actor flips
+the region-B HelmRelease DESIRED state (`spec.values.topology.promoted: true`) and
+helm renders `replica.enabled:false` → CNPG promotes.
+
+DURABILITY — the SUSPEND latch (#5178 Defect-B / #5218)
+-------------------------------------------------------
+`spec.values` on a HelmRelease is an ATOMIC RawExtension owned by the applying flux
+Kustomization; its next SSA re-apply drops the actor's nested `promoted` key → helm
+re-renders `replica.enabled:true` → CNPG re-demotes. The actor makes the promotion
+durable by SUSPENDING the HR (`spec.suspend: true`) once helm has rendered the
+promotion — a field the Kustomization does not own, so drift-correction cannot remove
+it, and a suspended HR freezes helm-controller so the promoted survivor stays
+writable. Every write uses a CUSTOM `--field-manager=dr-promoter` so kustomize-
+controller's managed-fields cleanup (which claims `kubectl`-prefixed managers on every
+reconcile) cannot strip the latch.
+
+HOW IT DECIDES (region-B-local signals + a POSITIVE region-A probe)
+-------------------------------------------------------------------
+1. PRIMARY LOSS (#5178) — the signals container arms the promote clock ONLY when
+   BOTH hold: (a) the LOCAL WAL receiver is ABSENT (catchup/starting/waiting/streaming
+   all count as ALIVE), AND (b) a DIRECT pg_isready of the region-A primary over the
+   ClusterMesh (`-mesh`:5432 — the exact endpoint the replica streams from) returns
+   "no response" (rc=2). region-A REACHABLE + local stream stalled ⇒ replication fault
+   ⇒ do NOT promote. A startup grace holds the clock clear while a fresh replica
+   finishes its first catchup. FAIL-SAFE: no cross-region liveness path wired ⇒ observe
+   only, NEVER promote.
+2. STEADY-STATE ARM (#5220) — the actor is INELIGIBLE to promote until the signals
+   container has OBSERVED the replica actively STREAMING (a live pg_stat_wal_receiver
+   row + a set receive-LSN — the #5239 non-privileged signal) CONTINUOUSLY for
+   steadyStateArmSeconds. A region-A-down signal before the first stable stream is a
+   convergence-time transient, never a real kill.
+3. PROMOTABILITY (#5133) — the failover-readiness Pod's Ready condition (LSN
+   apply==receive: the standby has APPLIED everything it RECEIVED).
+4. ANTI-FLAP (#5178) — never re-promote a cluster that has ALREADY left the source
+   timeline; once promoted it latches (suspend) so it can neither re-demote nor
+   re-promote.
+
+ANTI-SPLIT-BRAIN (sync-only fence) — the pair runs synchronous replication
+(remote_apply + FIRST 1 pinned to the cross-region replica), so the region-A primary
+CANNOT COMMIT while its only synchronous standby is unreachable: nothing committed on
+A that B lacks (RPO=0), no committed-data fork on a mere partition, and after recovery
+the stale primary stays write-fenced. The promoter therefore renders ONLY when
+replication.mode=sync (see bp-postgres.autoPromoteActive) — async has no fence.
+*/ -}}
+{{- if (include "bp-postgres.autoPromoteActive" .) }}
+{{- $ap := .Values.topology.autoPromote | default dict }}
+{{- $hr := $ap.hr | default dict }}
+{{- $hrName := $hr.name | default "bp-postgres-shared" }}
+{{- $hrNamespace := $hr.namespace | default "flux-system" }}
+{{- $kimg := $ap.kubectlImage | default dict }}
+{{- $krepo := $kimg.repository | default "harbor.openova.io/proxy-dockerhub/alpine/k8s" }}
+{{- $ktag := $kimg.tag | default "1.30.0" }}
+{{- $kpull := $kimg.pullPolicy | default "IfNotPresent" }}
+{{- $interval := $ap.intervalSeconds | default 10 }}
+{{- $hold := $ap.primaryDownHoldSeconds | default 120 }}
+{{- $startupGrace := $ap.startupGraceSeconds | default 300 }}
+{{- $probeTimeout := $ap.livenessProbeTimeoutSeconds | default 5 }}
+{{- $renderWait := $ap.promoteRenderWaitSeconds | default 90 }}
+{{- $armSeconds := $ap.steadyStateArmSeconds | default 180 }}
+{{- $peerClusters := .Values.topology.networkPolicy.crossRegionPeerClusters | default list }}
+{{- /* #5178 — the region-A liveness gate is meaningful ONLY when the mesh egress to
+       region-A can be wired: clusterMesh on AND at least one peer ClusterMesh name.
+       Without it the actor observes but NEVER promotes (fail-safe), because it has no
+       way to POSITIVELY prove region-A is gone. */ -}}
+{{- $livenessEnabled := and (ne (toString (dig "clusterMesh" "enabled" true .Values.topology)) "false") (gt (len $peerClusters) 0) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: dr-promoter
+---
+# Local-namespace reads: failover-readiness Pod Ready condition + the replica
+# Cluster CR's replica.enabled state.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+rules:
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  - apiGroups: [postgresql.cnpg.io]
+    resources: [clusters]
+    verbs: [get]
+    resourceNames: [{{ include "bp-postgres.replicaName" . }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+    namespace: {{ include "bp-postgres.namespace" . }}
+---
+# The promotion surface: get (idempotence + suspend-state read) + patch (merge-patch
+# of spec.values.topology.promoted AND, for the #5218 durable latch, spec.suspend) on
+# EXACTLY this instance's HelmRelease — resourceNames-pinned, no list/create/delete.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+rules:
+  - apiGroups: [helm.toolkit.fluxcd.io]
+    resources: [helmreleases]
+    verbs: [get, patch]
+    resourceNames: [{{ $hrName }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+    namespace: {{ include "bp-postgres.namespace" . }}
+---
+# Egress for the promoter Pod. The kube-apiserver is a reserved Cilium entity a vanilla
+# k8s NetworkPolicy cannot express (#4428 idiom), so the whole egress allow-list lives
+# in ONE CiliumNetworkPolicy: apiserver (kubectl) + kube-dns (service-name resolution)
+# + the replica cluster's 5432 (the signals psql) + (#5178) the region-A primary's 5432
+# across the ClusterMesh (the signals pg_isready liveness probe). Everything else stays
+# denied.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter-egress
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      catalyst.openova.io/role: dr-promoter
+      catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- if $livenessEnabled }}
+    # #5178 region-A liveness probe path — the signals container pg_isready's the
+    # region-A primary over the mesh (the SAME `-mesh`:5432 the replica streams from) to
+    # POSITIVELY confirm region-A is gone before arming the promote clock. Cross-region
+    # ClusterMesh endpoints carry their OWN pod identity; a plain local `toEndpoints` is
+    # implicitly ANDed with the LOCAL cluster and never matches the remote primary
+    # (#4846), so admit the peer cluster(s) by identity. EMPTY crossRegionPeerClusters
+    # (or clusterMesh off) → this rule is absent AND $livenessEnabled=false → the actor
+    # fail-safes to observe-only (never promotes).
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+          matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: dr-promoter
+  annotations:
+    catalyst.openova.io/blueprint: bp-postgres
+spec:
+  replicas: 1
+  # Single actor; never two promotion loops at once (#5157 shape).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      catalyst.openova.io/role: dr-promoter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/role: dr-promoter
+        catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+        # kyverno cilium-l7-mtls (Enforce) — required on the Pod template or the
+        # Deployment is DENIED at admission (#3238).
+        policy.cilium.io/enforced: "true"
+    spec:
+      # The actor runs in the replica region — the half that survives a region-A
+      # kill (same pin as failover-readiness).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: openova.io/region
+                    operator: In
+                    values: [{{ include "bp-postgres.replicaRegion" . | quote }}]
+      serviceAccountName: {{ include "bp-postgres.instanceName" . }}-dr-promoter
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 26
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        # ── signals — PRIMARY-LOSS detector (#5178 liveness-gated, #5220 arm) ──
+        # psql (streaming_replica client cert, #5133 auth) against the LOCAL replica
+        # `-rw` for pg_stat_wal_receiver state, PLUS a POSITIVE region-A liveness probe
+        # (pg_isready of the `-mesh` endpoint over the ClusterMesh). The promote clock
+        # is armed ONLY when the LOCAL WAL receiver is ABSENT (catchup/starting/waiting/
+        # streaming all count as ALIVE) AND region-A is genuinely UNREACHABLE, and never
+        # during the startup grace. It is CLEARED the moment the receiver returns,
+        # region-A answers, the replica leaves recovery, psql itself fails (fail-safe),
+        # or no liveness path is wired.
+        - name: signals
+          image: {{ include "bp-postgres.imageRef" . | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              CONN="host={{ include "bp-postgres.replicaName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              # STATE classification, from signals the streaming_replica role can READ on
+              # a standby (#5239 — it lacks pg_read_all_stats, so the privileged columns
+              # of pg_stat_wal_receiver are NULLed for it; detect streaming with objects
+              # every role can read):
+              #   'promoted'   — NOT in recovery: the local cluster is writable
+              #                  (already promoted / diverged off the source TL).
+              #   'streaming'  — a live pg_stat_wal_receiver ROW (its pid, hence EXISTS,
+              #                  is visible to all) AND pg_last_wal_receive_lsn() set —
+              #                  genuinely streaming right now (both required; the LSN
+              #                  persists after a receiver stops, but the ROW is present
+              #                  ONLY while a walreceiver process is live).
+              #   'receiving'  — a WAL receiver row EXISTS but no WAL received yet (the
+              #                  brief connect/handshake window) — region-A ALIVE.
+              #   'noreceiver' — no WAL receiver row at all → POTENTIAL loss.
+              Q="SELECT CASE
+                WHEN NOT pg_is_in_recovery() THEN 'promoted'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) AND pg_last_wal_receive_lsn() IS NOT NULL THEN 'streaming'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'
+                ELSE 'noreceiver'
+              END"
+              STARTED=$(date -u +%s)
+              echo "[dr-promoter/signals] loop started (interval=${INTERVAL_SECONDS}s startupGrace=${STARTUP_GRACE_SECONDS}s primaryLiveness=${PRIMARY_LIVENESS_ENABLED} primaryMeshHost=${PRIMARY_MESH_HOST})"
+              clear_clock() {
+                if [ -f /shared/primary-wal-down-since ]; then
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/signals] $1 — hold clock cleared"
+                fi
+                rm -f /shared/primary-wal-down-since
+              }
+              while true; do
+                : > /shared/signals-alive
+                STATE=$(psql "${CONN}" -tAXc "${Q}" 2>/dev/null || echo "unknown")
+                NOW=$(date -u +%s)
+                # ── #5220 steady-state ARM gate ──────────────────────────────────
+                # The promoter must OBSERVE the pair reach a stable STREAMING steady-
+                # state before ANY region-A-death is believable. A convergence-time
+                # transient (a primary restart-storm, or a replica that has not streamed
+                # even once) must never arm the promoter → never promote. Once armed it
+                # STAYS armed for the pod's life; a brief non-streaming blip only
+                # RESTARTS the arm window, never un-arms.
+                if [ "${STATE}" = "streaming" ]; then
+                  if [ ! -f /shared/armed ]; then
+                    if [ ! -f /shared/streaming-since ]; then
+                      echo "${NOW}" > /shared/streaming-since
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/signals] first stable stream observed — arm window ${STEADY_STATE_ARM_SECONDS}s started; promoter stays DISARMED until continuous streaming holds (#5220)"
+                    else
+                      SSINCE=$(cat /shared/streaming-since 2>/dev/null || echo "${NOW}")
+                      if [ "$((NOW - SSINCE))" -ge "${STEADY_STATE_ARM_SECONDS}" ]; then
+                        : > /shared/armed
+                        echo "$(date -u +"%FT%TZ") [dr-promoter/signals] ARMED — streaming steady-state held $((NOW - SSINCE))s (>=${STEADY_STATE_ARM_SECONDS}s); region-A-death detection is now live (#5220)"
+                      fi
+                    fi
+                  fi
+                else
+                  rm -f /shared/streaming-since
+                fi
+                # STARTUP GRACE — a fresh replica still doing its first catchup must never
+                # arm the clock (#5178).
+                if [ "$((NOW - STARTED))" -lt "${STARTUP_GRACE_SECONDS}" ]; then
+                  clear_clock "startup grace ($((NOW - STARTED))s<${STARTUP_GRACE_SECONDS}s, state=${STATE})"
+                  sleep "${INTERVAL_SECONDS}"; continue
+                fi
+                case "${STATE}" in
+                  promoted)
+                    # Left recovery → already promoted/diverged. Mark it so the actor
+                    # never re-promotes (anti-flap #5178).
+                    : > /shared/diverged
+                    clear_clock "state=promoted (local cluster writable)"
+                    ;;
+                  streaming|receiving)
+                    clear_clock "state=${STATE} (WAL receiver alive)"
+                    ;;
+                  unknown)
+                    clear_clock "state=unknown (local replica probe failed — fail-safe)"
+                    ;;
+                  noreceiver)
+                    # LOCAL WAL stream absent — require a POSITIVE region-A-unreachable
+                    # proof before arming (#5178: the LOCAL signal alone false-promoted a
+                    # healthy replica against a live region-A on hw266).
+                    if [ "${PRIMARY_LIVENESS_ENABLED}" != "true" ]; then
+                      clear_clock "state=noreceiver but NO region-A liveness path (clusterMesh off / crossRegionPeerClusters empty) — auto-promote inert, fail-safe"
+                    elif pg_isready -h "${PRIMARY_MESH_HOST}" -p 5432 -t "${PROBE_TIMEOUT}" -q; then
+                      # region-A REACHABLE + local WAL absent ⇒ replication fault, NOT a
+                      # region kill. Clear the promote clock; DO NOT promote.
+                      clear_clock "state=noreceiver but region-A REACHABLE (pg_isready ok @ ${PRIMARY_MESH_HOST}) — replication fault, data safety: NOT promoting"
+                    else
+                      RC=$?
+                      if [ "${RC}" -eq 2 ]; then
+                        if [ ! -f /shared/primary-wal-down-since ]; then
+                          echo "${NOW}" > /shared/primary-wal-down-since
+                          echo "$(date -u +"%FT%TZ") [dr-promoter/signals] WAL receiver ABSENT and region-A UNREACHABLE (pg_isready rc=2 @ ${PRIMARY_MESH_HOST}) — primary loss; hold clock started"
+                        fi
+                      else
+                        clear_clock "state=noreceiver, region-A probe ambiguous (pg_isready rc=${RC}) — fail-safe, NOT arming"
+                      fi
+                    fi
+                    ;;
+                esac
+                sleep "${INTERVAL_SECONDS}"
+              done
+          env:
+            - name: PGCONNECT_TIMEOUT
+              value: "5"
+            # #5178 region-A liveness probe target — the SAME ClusterMesh `-mesh`
+            # endpoint the replica streams from (templated from replicationServiceName,
+            # never hardcoded).
+            - name: PRIMARY_MESH_HOST
+              value: {{ include "bp-postgres.replicationServiceName" . | quote }}
+            - name: PRIMARY_LIVENESS_ENABLED
+              value: {{ if $livenessEnabled }}"true"{{ else }}"false"{{ end }}
+            - name: PROBE_TIMEOUT
+              value: {{ $probeTimeout | quote }}
+            - name: STARTUP_GRACE_SECONDS
+              value: {{ $startupGrace | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+            - name: STEADY_STATE_ARM_SECONDS
+              value: {{ $armSeconds | quote }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/signals-alive && test -z \"$(find /shared/signals-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/signals-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsUser: 26   # postgres in upstream cnpg image
+            runAsGroup: 26
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+            - name: replication-cert
+              mountPath: /tls/client
+              readOnly: true
+        # ── actor — the PROMOTER + durable SUSPEND LATCH (#5178 / #5218) ──
+        # Each tick runs in a subshell (a persistent fault retries next tick instead of
+        # crashing the pod — #5157 shape). A `suspend_hr` helper sets spec.suspend=true,
+        # READBACK-VERIFIES it landed, and logs loudly on failure. Ordering:
+        #   1. SELF-HEAL LATCH (every tick) — if the promotion is DRIVEN + RENDERED (HR
+        #      promoted=true AND local replica.enabled=false) OR the local cluster has
+        #      already left recovery (/shared/diverged), and the HR is NOT suspended,
+        #      RE-ASSERT spec.suspend=true. Both arms require POSITIVE render evidence,
+        #      so it can never freeze a pre-render HR and strand an un-rendered promotion.
+        #   2. ANTI-FLAP — already suspended (latched) ⇒ done. HR promoted but not yet
+        #      rendered ⇒ WAIT for the render (never suspend a pre-render HR — a suspended
+        #      HR is not reconciled by helm, so the promotion would never land).
+        #   3. PROMOTE — armed → hold expired → NOT already diverged → local Cluster
+        #      still a replica → failover-readiness Ready. Flip the HR desired state,
+        #      then STAY IN THE SAME TICK (#5218): poll until helm renders
+        #      replica.enabled=false and suspend IMMEDIATELY.
+        - name: actor
+          image: {{ printf "%s:%s" $krepo $ktag | quote }}
+          imagePullPolicy: {{ $kpull | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              # #5218/#5245 — EVERY write uses a CUSTOM field manager. kustomize-
+              # controller's managed-fields cleanup REPLACES every manager matching the
+              # `kubectl` prefix with itself on each reconcile of the applying
+              # Kustomization and drops the claimed fields absent from its manifest, which
+              # would strip spec.suspend every reconcile. A custom manager is NOT in that
+              # cleanup list, so the latch survives (live precedent: catalyst-api's
+              # substitute flips persist under manager `catalyst-api`).
+              FM="--field-manager=dr-promoter"
+              # suspend_hr <reason> — patch spec.suspend=true (+ latched-at annotation),
+              # then READBACK-VERIFY it landed. Returns non-zero (logged) on RBAC/conflict
+              # so the caller re-asserts next tick.
+              suspend_hr() {
+                _reason="$1"
+                if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promote-latched-at\":\"$(date -u +"%FT%TZ")\"}},\"spec\":{\"suspend\":true}}" >/dev/null 2>&1; then
+                  _v=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
+                  if [ "${_v}" = "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] LATCHED (${_reason}): HR ${HR_NAMESPACE}/${HR_NAME} spec.suspend=true VERIFIED — promotion durable; flux drift-correction can no longer revert spec.values and re-demote the survivor (#5178 Defect-B / #5218)"
+                    return 0
+                  fi
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] ERROR (${_reason}): spec.suspend patch accepted but readback='${_v}' (expected true) — HR NOT frozen; re-asserting next tick (#5218)"
+                  return 1
+                fi
+                echo "$(date -u +"%FT%TZ") [dr-promoter/actor] ERROR (${_reason}): spec.suspend patch FAILED (RBAC/conflict?) — HR NOT frozen; re-asserting next tick (#5218)"
+                return 1
+              }
+              echo "[dr-promoter/actor] loop started (hold=${HOLD_SECONDS}s interval=${INTERVAL_SECONDS}s renderWait=${PROMOTE_RENDER_WAIT_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME})"
+              while true; do
+                : > /shared/actor-alive
+                (
+                  set -eu
+                  SUSPENDED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
+                  HR_PROMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.topology.promoted}' 2>/dev/null || echo "")
+                  REPLICA_ENABLED=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}' 2>/dev/null || echo "")
+                  DIVERGED=""; [ -f /shared/diverged ] && DIVERGED="true"
+
+                  # 1. SELF-HEAL LATCH — keep an already-rendered promotion durable. Fires
+                  #    on the post-promote tick AND re-freezes the HR if anything ever
+                  #    un-suspends it. Both arms require POSITIVE render evidence
+                  #    (replica.enabled=false OR the cluster already left recovery) so it
+                  #    can never freeze a pre-render HR and strand the promotion.
+                  if [ "${SUSPENDED}" != "true" ] && { { [ "${HR_PROMOTED}" = "true" ] && [ "${REPLICA_ENABLED}" = "false" ]; } || [ "${DIVERGED}" = "true" ]; }; then
+                    suspend_hr "self-heal" || true
+                    exit 0
+                  fi
+                  # 2. ANTI-FLAP — latched ⇒ done.
+                  if [ "${SUSPENDED}" = "true" ]; then
+                    exit 0
+                  fi
+                  # Promote driven but not yet rendered (replica.enabled still true, not
+                  # diverged) — WAIT for helm; never suspend now (a suspended HR is not
+                  # reconciled, the promote would never land) and never re-promote.
+                  if [ "${HR_PROMOTED}" = "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] HR promoted=true but not yet rendered (replica.enabled='${REPLICA_ENABLED}') — waiting for helm-controller; self-heal latch suspends the instant it renders (#5218)"
+                    exit 0
+                  fi
+
+                  # 3. PROMOTE decision (not promoted, not suspended).
+                  # #5220 ARM GATE — never promote until the pair has OBSERVED a stable
+                  # streaming steady-state (the signals container sets /shared/armed). A
+                  # region-A-down signal BEFORE the first stable stream is a convergence-
+                  # time transient, NEVER a real kill; a pair that never reached steady-
+                  # state can never promote, so the suspend latch can never cement a false
+                  # positive.
+                  if [ ! -f /shared/armed ]; then
+                    if [ -f /shared/primary-wal-down-since ]; then
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/actor] REFUSING promote: region-A-down signal present but the DR pair never reached streaming steady-state (UNARMED) — convergence-time transient, not a real kill; holding (#5220)"
+                    fi
+                    exit 0
+                  fi
+                  [ -f /shared/primary-wal-down-since ] || exit 0
+                  DOWN_SINCE=$(cat /shared/primary-wal-down-since)
+                  NOW=$(date -u +%s)
+                  DOWN_FOR=$((NOW - DOWN_SINCE))
+                  if [ "${DOWN_FOR}" -lt "${HOLD_SECONDS}" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] region-A unreachable ${DOWN_FOR}s < hold ${HOLD_SECONDS}s — waiting"
+                    exit 0
+                  fi
+                  # ANTI-FLAP: never re-promote a cluster that already left the source
+                  # timeline — that IS the runaway (hw266 TL2→TL25).
+                  if [ -f /shared/diverged ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] REFUSING promote: local cluster already diverged (left the source timeline) — re-clone required, NOT re-promote (RUNBOOKS §6.1 / #5178 anti-flap)"
+                    exit 0
+                  fi
+                  if [ "${REPLICA_ENABLED}" != "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] local Cluster CR replica.enabled=${REPLICA_ENABLED} — not a replica; nothing to promote"
+                    exit 0
+                  fi
+                  READY=$(kubectl -n "${NAMESPACE}" get pod -l "${READY_SELECTOR}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}')
+                  if ! echo "${READY}" | grep -qw True; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] failover-readiness NOT Ready (got: '${READY}') — standby not promotable; holding (data safety over RTO)"
+                    exit 0
+                  fi
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTING: region-A WAL stream absent AND region-A unreachable ${DOWN_FOR}s >= ${HOLD_SECONDS}s AND failover-readiness Ready — patching HR desired state (#5125-D1 seam)"
+                  kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-auto-promoted-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-auto-promote-reason\":\"region-A WAL stream absent and region-A unreachable ${DOWN_FOR}s; failover-readiness Ready (#5623/#5178)\"}},\"spec\":{\"values\":{\"topology\":{\"promoted\":true}}}}"
+                  echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTED (step 1/2): HR ${HR_NAMESPACE}/${HR_NAME} spec.values.topology.promoted=true — helm-controller renders replica.enabled:false → CNPG promotes"
+                  # 3b. SAME-TICK DURABLE LATCH (#5218) — do NOT wait for the next tick.
+                  #     Poll until helm renders replica.enabled=false (the promotion has
+                  #     LANDED), then suspend IMMEDIATELY so kustomize cannot reclaim the
+                  #     atomic spec.values and re-demote in the gap. Bounded; the step-1
+                  #     self-heal is the backstop if the render outlasts the ceiling.
+                  RE=""
+                  i=0
+                  while [ "${i}" -lt "${PROMOTE_RENDER_WAIT_SECONDS}" ]; do
+                    RE=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${REPLICA_CLUSTER}" -o jsonpath='{.spec.replica.enabled}' 2>/dev/null || echo "")
+                    if [ "${RE}" = "false" ]; then
+                      echo "$(date -u +"%FT%TZ") [dr-promoter/actor] PROMOTION RENDERED (step 2/2): replica.enabled=false after ${i}s — suspending HR now (#5218)"
+                      suspend_hr "post-promote same-tick" || true
+                      break
+                    fi
+                    i=$((i + 1))
+                    sleep 1
+                  done
+                  if [ "${RE}" != "false" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-promoter/actor] NOTE: helm has not rendered replica.enabled=false within ${PROMOTE_RENDER_WAIT_SECONDS}s of the promote patch (replica.enabled='${RE}') — the per-tick self-heal latch will suspend the instant it renders (#5218)"
+                  fi
+                ) || echo "[dr-promoter/actor] tick returned non-zero — retry in ${INTERVAL_SECONDS}s"
+                sleep "${INTERVAL_SECONDS}"
+              done
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HR_NAME
+              value: {{ $hrName | quote }}
+            - name: HR_NAMESPACE
+              value: {{ $hrNamespace | quote }}
+            - name: HOLD_SECONDS
+              value: {{ $hold | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+            # #5218 — ceiling on the same-tick post-promote poll that waits for helm to
+            # render replica.enabled=false before suspending.
+            - name: PROMOTE_RENDER_WAIT_SECONDS
+              value: {{ $renderWait | quote }}
+            - name: REPLICA_CLUSTER
+              value: {{ include "bp-postgres.replicaName" . | quote }}
+            - name: READY_SELECTOR
+              value: "catalyst.openova.io/role=failover-readiness-probe,catalyst.openova.io/cnpg-pair={{ include "bp-postgres.instanceName" . }}"
+            # kubectl writes its discovery/http cache under $HOME.
+            - name: HOME
+              value: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/actor-alive && test -z \"$(find /shared/actor-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/actor-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: shared
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        # THIS replica cluster's own CNPG-issued streaming_replica client cert (exists
+        # locally on cluster-B, no cross-cluster sync) — 0440 root:26, the perms libpq
+        # requires for an sslkey (#5133).
+        - name: replication-cert
+          secret:
+            secretName: {{ include "bp-postgres.replicaName" . }}-replication
+            defaultMode: 0440
+{{- end }}

--- a/platform/postgres/chart/templates/failover-readiness.yaml
+++ b/platform/postgres/chart/templates/failover-readiness.yaml
@@ -1,0 +1,168 @@
+{{- /*
+Failover-readiness probe Pod (#5623 — chart 0.2.18).
+
+A faithful port of bp-cnpg-pair's failover-readiness.yaml for the shared-pg
+active-hot-standby replica half. Polls the replica cluster's designated primary
+(its CNPG `-rw` Service) for the WAL APPLY lag and, when that lag falls below
+`topology.walStreaming.targetLagSeconds`, flips the Pod's Ready condition true so
+the region-B dr-promoter (dr-promoter.yaml) treats the replica as PROMOTABLE.
+
+Lag measure (#5133): compare the standby's `pg_last_wal_replay_lsn()` against its
+`pg_last_wal_receive_lsn()`. When the standby has REPLAYED everything its WAL
+receiver has RECEIVED the apply lag is zero — idle-safe (a caught-up SYNCHRONOUS
+standby of an idle primary reads 0, NOT an ever-growing
+`now() - pg_last_xact_replay_timestamp()` clock skew) AND region-kill-safe (during
+a region-A kill the receiver freezes and replay catches up to it → 0 → promotable,
+with no dependency on the dead primary being reachable). Only a genuinely-behind
+(async) standby falls through to a seconds-based apply lag the threshold gates.
+
+AUTH (#5133): the probe authenticates as the `streaming_replica` role via its
+CNPG-issued client cert (CNPG pg_hba admits `hostssl postgres streaming_replica
+all cert`). The shared-pg Cluster CRs run with the postgres superuser usable, but
+`streaming_replica` mutual-TLS is the region-kill-safe path (it needs no reachable
+primary and no password) and matches the externalCluster streaming connection.
+The cert lives in this replica cluster's own CNPG-generated
+`<replica>-replication` Secret.
+
+Side + gating: renders ONLY when the dr-promoter itself renders
+(`bp-postgres.autoPromoteActive` — active-hot-standby AND side=replica AND sync
+AND autoPromote.enabled) so autoPromote-off / async / singleton / primary-side
+renders are byte-identical. Its region-B node-affinity pins the replica region
+(fail-closed via bp-postgres.replicaRegion).
+*/ -}}
+{{- if and (ne (toString .Values.enabled) "false") (include "bp-postgres.autoPromoteActive" .) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-failover-readiness
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: failover-readiness-probe
+  annotations:
+    catalyst.openova.io/blueprint: bp-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      catalyst.openova.io/role: failover-readiness-probe
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/role: failover-readiness-probe
+        catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+        # kyverno cilium-l7-mtls (Enforce) — required on the Pod template or the
+        # Deployment is DENIED at admission (#3238).
+        policy.cilium.io/enforced: "true"
+    spec:
+      # Probe runs in the replica region — the half that survives a region-A
+      # kill (same pin as the dr-promoter).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: openova.io/region
+                    operator: In
+                    values: [{{ include "bp-postgres.replicaRegion" . | quote }}]
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 26   # postgres in upstream cnpg image
+        runAsGroup: 26
+        fsGroup: 26
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: probe
+          image: {{ include "bp-postgres.imageRef" . | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              REPLICA_HOST="{{ include "bp-postgres.replicaName" . }}-rw"
+              THRESHOLD={{ .Values.topology.walStreaming.targetLagSeconds }}
+              # streaming_replica mutual-TLS: sslmode=require + the CNPG-issued
+              # client cert (server-side `cert` pg_hba verifies it against the
+              # cluster CA) — the region-kill-safe auth the externalCluster uses.
+              CONN="host=${REPLICA_HOST} port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              # Apply lag in seconds. CASE ladder (#5133):
+              #  1. NOT in recovery → already promoted → 0 (ready).
+              #  2. replay_lsn caught up to receive_lsn → applied all received
+              #     WAL → 0 (idle-safe + region-kill-safe: no dead-primary dep).
+              #  3. otherwise (genuinely behind) → seconds since last replayed
+              #     xact, so targetLagSeconds gates async lag.
+              LAG_SQL="SELECT CASE
+                WHEN NOT pg_is_in_recovery() THEN 0
+                WHEN pg_last_wal_receive_lsn() IS NOT NULL
+                     AND pg_last_wal_replay_lsn() >= pg_last_wal_receive_lsn() THEN 0
+                ELSE COALESCE(GREATEST(0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::bigint), 2147483647)
+              END"
+              while true; do
+                # Heartbeat first — the livenessProbe reads /tmp/alive's mtime to
+                # detect a WEDGED loop; /tmp/ready is the SEPARATE promotability
+                # signal the readinessProbe surfaces (alive vs promotable).
+                : > /tmp/alive
+                LAG=$(psql "${CONN}" -tAXc "${LAG_SQL}" 2>/dev/null || echo "999999")
+                case "${LAG}" in ''|*[!0-9]*) LAG=999999 ;; esac
+                if [ "${LAG}" -lt "${THRESHOLD}" ]; then
+                  date -u +"%FT%TZ replica lag=${LAG}s < threshold=${THRESHOLD}s — promotable" > /tmp/ready
+                else
+                  rm -f /tmp/ready
+                  date -u +"%FT%TZ replica lag=${LAG}s >= threshold=${THRESHOLD}s — NOT promotable"
+                fi
+                sleep 10
+              done
+          env:
+            - name: PGCONNECT_TIMEOUT
+              value: "5"
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /tmp/alive && test -z \"$(find /tmp/alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/tmp/ready"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: {{ .Values.topology.walStreaming.timeoutSeconds }}
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            # streaming_replica client cert + key (CNPG-issued for THIS replica
+            # cluster) — 0440 root:26 so libpq (uid 26) accepts the key.
+            - name: replication-cert
+              mountPath: /tls/client
+              readOnly: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: replication-cert
+          secret:
+            secretName: {{ include "bp-postgres.replicaName" . }}-replication
+            defaultMode: 0440
+{{- end }}

--- a/platform/postgres/chart/templates/networkpolicy.yaml
+++ b/platform/postgres/chart/templates/networkpolicy.yaml
@@ -168,6 +168,30 @@ spec:
       cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
   policyTypes: [Ingress]
   ingress:
+{{- if (include "bp-postgres.autoPromoteActive" .) }}
+    # #5623 failover-readiness probe — polls the replica's -rw for the WAL apply
+    # lag. Same intra-cluster 5432 path as the dr-promoter signals container.
+    - from:
+        - podSelector:
+            matchLabels:
+              catalyst.openova.io/role: failover-readiness-probe
+              catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # #5623 dr-promoter signals container — polls the replica's -rw for
+    # pg_stat_wal_receiver (primary-loss detection). This netpol selects the
+    # replica Pods and default-denies every ingress it does not list, so the
+    # promoter's psql would otherwise time out.
+    - from:
+        - podSelector:
+            matchLabels:
+              catalyst.openova.io/role: dr-promoter
+              catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+{{- end }}
     # OWN-cluster pods (#3322 carve-out): the replica Cluster's instance-2
     # joins instance-1 via the replica's -rw Service on 5432; without an
     # explicit allow for the replica's OWN cnpg.io/cluster label it
@@ -190,6 +214,49 @@ spec:
           protocol: TCP
         - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+{{- if (include "bp-postgres.autoPromoteActive" .) }}
+---
+# #5623 Egress carve-out for the failover-readiness probe Pod — it must resolve
+# DNS and reach the replica's -rw Service on 5432. (The dr-promoter Pod carries
+# its OWN egress CiliumNetworkPolicy in dr-promoter.yaml, which additionally
+# admits the kube-apiserver entity + the region-A liveness probe.)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-probe-egress
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      catalyst.openova.io/role: failover-readiness-probe
+      catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+  policyTypes: [Egress]
+  egress:
+    # DNS to kube-dns
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Replica CR Pods on 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+      ports:
+        - port: 5432
+          protocol: TCP
+{{- end }}
 {{- if gt (len .Values.topology.networkPolicy.crossRegionPeerClusters) 0 }}
 ---
 # CROSS-REGION DR (#4846): the PRIMARY region's Pods (the primary Cluster

--- a/platform/postgres/chart/templates/replica-cluster.yaml
+++ b/platform/postgres/chart/templates/replica-cluster.yaml
@@ -78,13 +78,22 @@ spec:
     podAntiAffinityType: preferred
 
   # ── Replica-cluster mode ─────────────────────────────────────────
-  # `replica.enabled: true` configures this Cluster as a CNPG replica
-  # cluster: instances bootstrap via streaming replication from the named
-  # externalCluster source. bp-continuum's switchover path patches
+  # `replica.enabled` configures this Cluster as a CNPG replica cluster:
+  # instances bootstrap via streaming replication from the named
+  # externalCluster source. bp-continuum's switchover path drives
   # `replica.enabled: false` here (and flips the primary CR to the inverse)
   # to promote/demote atomically.
+  #
+  # DR-durability (#5623, mirror of bp-cnpg-pair 0.2.12 / #5125 Defect-1):
+  # `replica.enabled` is DRIVEN by the `topology.promoted` VALUE, NOT a
+  # hard-coded `true`. Default/absent promoted (false) → `enabled: true`
+  # (normal replica); promoted:true → `enabled: false` (CNPG promotes it to a
+  # writable primary). Region-kill failover MUST flip the region-B HelmRelease
+  # DESIRED state (`spec.values.topology.promoted: true`) — the exact seam the
+  # dr-promoter actor patches — so flux drift-correction RE-AFFIRMS the
+  # promotion instead of a live-object patch it reverts mid-outage (hw256 G12).
   replica:
-    enabled: true
+    enabled: {{ not (.Values.topology.promoted | default false) }}
     source: {{ include "bp-postgres.instanceName" . }}
 
   # ── Bootstrap from primary ──────────────────────────────────────

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -425,6 +425,11 @@ topology:
   replica: { region: hz-hel-rtz-prod }
   networkPolicy:
     crossRegionPeerClusters: [hw228-mesh]
+  # Isolate this case to the #4846 crossregion admission — the #5623 dr-promoter
+  # (default-ON) carries its OWN dr-promoter-egress CiliumNetworkPolicy, asserted
+  # separately in Cases 20a-20c below; disabling it here keeps the "exactly 1 CNP"
+  # crossregion-dr assertion focused.
+  autoPromote: { enabled: false }
 databases:
   - name: registry
     owner: harbor
@@ -1122,3 +1127,140 @@ fi
 echo "  PASS (= singleton renders with NO region key and NO region pin)"
 
 rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"
+
+# ── Case 20a: #5623 — region-B AUTOMATIC DR promotion (dr-promoter) ───────────
+# The shared-pg pairs render the EXACT bp-cnpg-pair replica shape but shipped NO
+# region-local promoter, so on the hw292 G12 region-kill (2026-08-03) their
+# region-B replicas stayed pg_is_in_recovery()=t for the WHOLE outage (keycloak
+# read-only). This ports the proven bp-cnpg-pair dr-promoter onto the shared-pg
+# replica half: signals/actor split, #5178 liveness gate + startup grace, #5220
+# steady-state arm gate, #5133 failover-readiness Ready gate, #5218 same-tick
+# durable suspend latch, anti-flap, sync-only fence, HR-value promote seam.
+echo "[render] Case 20a: #5623 dr-promoter — side-gating, #5157 Deployment shape, HR-desired-state promotion, guards"
+cat > "$TMP/promoter.values.yaml" <<'YAML'
+instance: { name: shared-pg, namespace: shared-data }
+topology:
+  mode: active-hot-standby
+  side: secondary
+  instances: 1
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+  networkPolicy:
+    crossRegionPeerClusters: [peer-mesh-a]
+YAML
+helm template shared-pg . -f "$TMP/promoter.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/promoter.yaml" 2>"$TMP/promoter.err" \
+  || { cat "$TMP/promoter.err" >&2; fail "#5623 dr-promoter render errored"; }
+
+# 1. side=replica renders the promoter + the failover-readiness probe.
+grep -q 'catalyst.openova.io/role: dr-promoter' "$TMP/promoter.yaml" \
+  || fail "#5623 side=replica default render missing the dr-promoter"
+grep -q 'catalyst.openova.io/role: failover-readiness-probe' "$TMP/promoter.yaml" \
+  || fail "#5623 side=replica render missing the failover-readiness probe (the promotability signal)"
+# 2. #5157 Deployment (NOT CronJob) with strategy Recreate (single actor).
+if grep -q '^kind: CronJob$' "$TMP/promoter.yaml"; then
+  fail "#5623 dr-promoter must NOT be a CronJob (#5157: a CronJob scheduler dies with the region)"; fi
+awk '/^kind: Deployment$/{d=1} d&&/name: shared-pg-dr-promoter$/{f=1} f&&/type: Recreate/{print "RECREATE"; exit}' "$TMP/promoter.yaml" | grep -q RECREATE \
+  || fail "#5623 dr-promoter must be a Deployment with strategy Recreate (single actor, #5157 shape)"
+# 3. The promotion is an HR-DESIRED-STATE flip of spec.values.topology.promoted,
+#    NEVER a live Cluster-CR patch (the #5125-D1 seam).
+grep -qF '\"spec\":{\"values\":{\"topology\":{\"promoted\":true}}}' "$TMP/promoter.yaml" \
+  || fail "#5623 actor does not promote via the spec.values.topology.promoted HR-value seam (the #5125-D1 durable path)"
+grep -q '.spec.values.topology.promoted' "$TMP/promoter.yaml" \
+  || fail "#5623 actor does not read HR spec.values.topology.promoted for idempotence"
+if grep -qE 'patch +clusters.postgresql.cnpg.io' "$TMP/promoter.yaml"; then
+  fail "#5623 actor must NEVER patch the live Cluster CR (flux reverts it mid-outage — hw256 G12)"; fi
+# 4. Promotability gate reads the failover-readiness probe's Ready signal.
+grep -q 'catalyst.openova.io/role=failover-readiness-probe' "$TMP/promoter.yaml" \
+  || fail "#5623 actor does not gate on the failover-readiness Ready condition (#5133 promotability signal)"
+# 5. #5178 POSITIVE region-A liveness gate (pg_isready of the -mesh endpoint) + grace.
+grep -q 'pg_isready -h "${PRIMARY_MESH_HOST}"' "$TMP/promoter.yaml" \
+  || fail "#5623 signals container missing the #5178 pg_isready region-A liveness probe"
+grep -q 'startup grace' "$TMP/promoter.yaml" \
+  || fail "#5623 signals container missing the #5178 startup grace"
+# 6. #5220 steady-state ARM gate — and it must PRECEDE the promote merge-patch.
+grep -q '/shared/armed' "$TMP/promoter.yaml" \
+  || fail "#5623 actor missing the #5220 steady-state arm gate (/shared/armed)"
+arm_line=$(grep -n 'never reached streaming steady-state' "$TMP/promoter.yaml" | head -1 | cut -d: -f1)
+promote_line=$(grep -n 'PROMOTING: region-A WAL stream absent' "$TMP/promoter.yaml" | head -1 | cut -d: -f1)
+[ -n "$arm_line" ] && [ -n "$promote_line" ] && [ "$arm_line" -lt "$promote_line" ] \
+  || fail "#5623 the #5220 arm gate (REFUSING while UNARMED) must precede the promote merge-patch"
+# 7. #5218 durable suspend LATCH + self-heal + readback-verify + same-tick.
+grep -qF '\"spec\":{\"suspend\":true}' "$TMP/promoter.yaml" \
+  || fail "#5623 actor missing the durable suspend LATCH (spec.suspend=true) — the HR-value patch alone is reverted by flux"
+grep -q 'suspend_hr()' "$TMP/promoter.yaml" || fail "#5623 actor missing the suspend_hr helper"
+grep -q 'VERIFIED' "$TMP/promoter.yaml" || fail "#5623 suspend_hr must READBACK-VERIFY spec.suspend after patching"
+grep -q 'suspend_hr "post-promote same-tick"' "$TMP/promoter.yaml" \
+  || fail "#5623 actor missing the #5218 same-tick post-promote suspend call"
+grep -q 'suspend_hr "self-heal"' "$TMP/promoter.yaml" \
+  || fail "#5623 actor missing the per-loop self-heal suspend re-assert"
+# 8. Custom field-manager so kustomize managed-fields cleanup cannot strip the latch.
+grep -q 'field-manager=dr-promoter' "$TMP/promoter.yaml" \
+  || fail "#5623 actor writes must use --field-manager=dr-promoter (kustomize strips kubectl-managed fields)"
+# 9. Anti-flap: never re-promote an already-diverged cluster.
+grep -q 'already diverged' "$TMP/promoter.yaml" \
+  || fail "#5623 actor missing the anti-flap 'already diverged' guard (#5178 — the hw266 TL runaway)"
+# 10. RBAC minimal + resourceNames-pinned: helmreleases get/patch on THIS HR only,
+#     NO kustomizations verbs (the #5245 handoff is not ported).
+grep -q 'resourceNames: \[bp-postgres-shared\]' "$TMP/promoter.yaml" \
+  || fail "#5623 dr-promoter HR Role must be resourceNames-pinned to bp-postgres-shared"
+if grep -q 'kustomizations' "$TMP/promoter.yaml"; then
+  fail "#5623 dr-promoter must NOT grant kustomizations verbs (the #5245 durable-substitute handoff is a follow-up, not ported)"; fi
+# 11. dr-promoter-egress CNP admits the kube-apiserver entity (kubectl egress).
+grep -q 'kube-apiserver' "$TMP/promoter.yaml" \
+  || fail "#5623 dr-promoter-egress CNP missing the kube-apiserver entity — kubectl egress would be default-denied"
+# 12. The failover-readiness probe egress NetworkPolicy renders.
+grep -q 'shared-pg-probe-egress' "$TMP/promoter.yaml" \
+  || fail "#5623 missing the failover-readiness probe egress NetworkPolicy"
+# 13. NO NodePort — ever.
+if grep -q 'NodePort' "$TMP/promoter.yaml"; then fail "#5623 render leaked a NodePort (ABSOLUTELY FORBIDDEN)"; fi
+echo "  PASS (dr-promoter Deployment/Recreate; HR-value promote seam; failover-readiness gate; #5178 liveness+grace; #5220 arm-before-promote; #5218 latch+self-heal+verify; anti-flap; pinned RBAC; egress CNP)"
+
+# ── Case 20b: #5623 — negative gates (no promoter off the sync replica path) ──
+echo "[render] Case 20b: #5623 dr-promoter absent for primary / async / autoPromote-off / singleton"
+helm template shared-pg . -f "$TMP/promoter.values.yaml" --set topology.side=primary \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/prom-primary.yaml" 2>&1 || fail "#5623 primary render errored"
+if grep -qE 'role: dr-promoter|role: failover-readiness-probe|shared-pg-probe-egress' "$TMP/prom-primary.yaml"; then
+  fail "#5623 side=primary must render ZERO dr-promoter/probe resources (the actor must survive a region-A kill on cluster-B)"; fi
+helm template shared-pg . -f "$TMP/promoter.values.yaml" --set topology.replication.mode=async \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/prom-async.yaml" 2>&1 || fail "#5623 async render errored"
+if grep -q 'role: dr-promoter' "$TMP/prom-async.yaml"; then
+  fail "#5623 replication.mode=async must render ZERO dr-promoter resources (no sync-rep data fence)"; fi
+helm template shared-pg . -f "$TMP/promoter.values.yaml" --set topology.autoPromote.enabled=false \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/prom-off.yaml" 2>&1 || fail "#5623 autoPromote-off render errored"
+if grep -qE 'role: dr-promoter|role: failover-readiness-probe|shared-pg-probe-egress' "$TMP/prom-off.yaml"; then
+  fail "#5623 autoPromote.enabled=false must render ZERO dr-promoter/probe resources"; fi
+if grep -qE 'role: dr-promoter|role: failover-readiness-probe|shared-pg-probe-egress' "$TMP/shared.yaml"; then
+  fail "#5623 singleton render leaked dr-promoter/probe resources (active-hot-standby replica only)"; fi
+echo "  PASS (no promoter/probe on primary / async / autoPromote-off / singleton)"
+
+# ── Case 20c: #5623 — fail-safe observe-only WITHOUT a cross-region liveness path ─
+echo "[render] Case 20c: #5623 fail-safe — no peer clusters => observe-only (PRIMARY_LIVENESS_ENABLED=false, no region-A egress rule)"
+cat > "$TMP/promoter-nopeer.values.yaml" <<'YAML'
+instance: { name: shared-pg, namespace: shared-data }
+topology:
+  mode: active-hot-standby
+  side: secondary
+  instances: 1
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+YAML
+helm template shared-pg . -f "$TMP/promoter-nopeer.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/promoter-nopeer.yaml" 2>&1 || fail "#5623 no-peer render errored"
+grep -q 'role: dr-promoter' "$TMP/promoter-nopeer.yaml" \
+  || fail "#5623 the promoter still renders without peers (observe-only), so it can auto-arm once the mesh is wired"
+awk '/name: PRIMARY_LIVENESS_ENABLED/{getline; if ($0 ~ /"false"/) f=1} END{exit f?0:1}' "$TMP/promoter-nopeer.yaml" \
+  || fail "#5623 no-peer render must set PRIMARY_LIVENESS_ENABLED=false (fail-safe observe-only)"
+if grep -q 'io.cilium.k8s.policy.cluster' "$TMP/promoter-nopeer.yaml"; then
+  fail "#5623 no-peer render must NOT emit the region-A liveness egress rule (nothing proves region-A gone)"; fi
+echo "  PASS (observe-only fail-safe: PRIMARY_LIVENESS_ENABLED=false, no region-A egress rule)"
+
+# ── Case 20d: #5623 — the promoted VALUE drives replica.enabled (both directions) ─
+echo "[render] Case 20d: #5623 replica.enabled follows topology.promoted (default replica, promoted->primary)"
+awk '/^kind: Cluster$/{c=1} c&&/^  name: shared-pg-replica$/{r=1} r&&/^    enabled: /{print; exit}' "$TMP/promoter.yaml" | grep -q 'enabled: true' \
+  || fail "#5623 default (promoted absent/false) replica half must render replica.enabled: true"
+helm template shared-pg . -f "$TMP/promoter.values.yaml" --set topology.promoted=true \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/prom-promoted.yaml" 2>&1 || fail "#5623 promoted render errored"
+awk '/^kind: Cluster$/{c=1} c&&/^  name: shared-pg-replica$/{r=1} r&&/^    enabled: /{print; exit}' "$TMP/prom-promoted.yaml" | grep -q 'enabled: false' \
+  || fail "#5623 topology.promoted=true must render replica.enabled: false (CNPG promotes the survivor)"
+echo "  PASS (promoted:false -> replica.enabled:true; promoted:true -> replica.enabled:false)"

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -162,6 +162,95 @@ topology:
     sync:
       commit: remote_apply  # on | remote_write | remote_apply
       numSync: 1
+
+  # ── DR failover promotion seam (#5623, mirror of bp-cnpg-pair 0.2.12) ──
+  # When true, the REPLICA half's Cluster CR renders `replica.enabled: false`
+  # → CNPG promotes it to a writable primary. Region-kill failover MUST flip
+  # this on the region-B HelmRelease DESIRED state
+  # (`spec.values.topology.promoted: true`) — NEVER a `kubectl patch` of the
+  # live Cluster CR, which flux/kustomize reverts mid-outage (the hw256 G12
+  # lesson, #5125). The dr-promoter actor (below) drives exactly this value
+  # and then suspend-latches the HR so drift-correction cannot re-demote the
+  # survivor. Default/absent ⇒ replica mode (backward-safe; only consulted on
+  # the active-hot-standby replica half). See replica-cluster.yaml.
+  promoted: false
+
+  # ── Failover-readiness probe threshold (#5623 / #5133) ────────────────
+  # The failover-readiness probe Pod (failover-readiness.yaml, side=replica)
+  # flips its Ready condition when the standby's WAL APPLY lag falls below
+  # targetLagSeconds; the dr-promoter actor gates promotion on that Ready
+  # signal (a lagging standby is never promoted — data safety over RTO).
+  # Only consulted on the active-hot-standby replica half.
+  walStreaming:
+    targetLagSeconds: 30
+    timeoutSeconds: 60
+
+  # ── Region-B AUTOMATIC DR promotion (#5623) ───────────────────────────
+  # The shared-pg pairs render the EXACT bp-cnpg-pair replica shape but had
+  # NO region-local promoter, so on the hw292 G12 region-kill (2026-08-03)
+  # their region-B replicas stayed read-only for the WHOLE outage while
+  # bp-cnpg-pair's own dr-promoter auto-promoted at T0+2m16s — keycloak (a
+  # shared-pg consumer) unrecoverable in region-B. This ships the SAME proven
+  # promoter shape on the shared-pg replica half: a region-B-local Deployment
+  # (Deployment NOT CronJob — #5157: a CronJob scheduler dies with the region)
+  # whose signals container watches the LOCAL replica's WAL receiver AND
+  # POSITIVELY probes region-A liveness (pg_isready of the `-mesh` primary
+  # endpoint over the ClusterMesh — #5178), and whose actor promotes via the
+  # `topology.promoted` HR-value seam + a durable suspend latch (#5218) only
+  # after the region-A-loss clock has held primaryDownHoldSeconds AND the pair
+  # reached streaming steady-state (steadyStateArmSeconds — #5220) AND the
+  # failover-readiness probe is Ready. DATA FENCE: rendered ONLY when
+  # replication.mode=sync (remote_apply + FIRST 1 pinned to the cross-region
+  # replica means the old primary cannot COMMIT while its sync standby is
+  # unreachable/diverged — automatic promotion can never lose or fork
+  # committed data). The full #5245 durable-substitute handoff, TL-ahead
+  # re-promote and region-A dr-failback leg are deliberately NOT ported here
+  # (follow-up); as with bp-cnpg-pair 0.2.14–0.2.17 the operator lifts the
+  # suspend latch on region-A recovery (RUNBOOKS §6.1).
+  autoPromote:
+    enabled: true
+    # Poll cadence for both containers.
+    intervalSeconds: 10
+    # The region-A-loss clock (local WAL stream absent AND region-A
+    # unreachable) must hold CONTINUOUSLY this long before the actor promotes.
+    # An intra-region primary restart/switchover reconnects in seconds and
+    # clears the clock; 120s auto-recovers a real region kill in ~2-4 min.
+    primaryDownHoldSeconds: 120
+    # #5178 startup grace — a freshly-(re)started replica still completing its
+    # first catchup must NEVER trip the promote clock. Must exceed a normal
+    # basebackup+catchup.
+    startupGraceSeconds: 300
+    # #5178 region-A liveness probe timeout (seconds) for the pg_isready of the
+    # `-mesh` primary endpoint. Only rc=2 (no response) counts as unreachable;
+    # every other result fail-safes to "region-A alive" (do NOT promote).
+    livenessProbeTimeoutSeconds: 5
+    # #5218 same-tick durable latch — after flipping the HR promoted value the
+    # actor polls (bounded by this) until helm renders replica.enabled=false,
+    # then IMMEDIATELY suspends the HR so kustomize's SSA re-apply of the atomic
+    # spec.values cannot reclaim the nested `promoted` key and re-demote in the
+    # gap. A ceiling on the fast path (the per-tick self-heal is the backstop),
+    # never a correctness dependency.
+    promoteRenderWaitSeconds: 90
+    # #5220 steady-state ARM gate — the promoter is INELIGIBLE to promote until
+    # the signals container has OBSERVED the replica actively STREAMING from
+    # region-A held CONTINUOUSLY this long. A convergence-time transient (a
+    # primary restart-storm, or a replica that never streamed) must never look
+    # like a region kill. Once armed it stays armed for the pod's life.
+    steadyStateArmSeconds: 180
+    # The flux HelmRelease whose DESIRED state (spec.values.topology.promoted)
+    # carries the promotion. Per-instance: the bootstrap-kit slots 16a/16c/16d
+    # stamp bp-postgres-shared / -shared-b / -shared-c respectively.
+    hr:
+      name: bp-postgres-shared
+      namespace: flux-system
+    # kubectl-bearing image for the actor container. Same harbor-proxy-pull-
+    # compliant (`*/proxy-*/*`) prefix as the signals/postgres image so the
+    # whole Pod matches ONE kyverno anyPattern glob.
+    kubectlImage:
+      repository: harbor.openova.io/proxy-dockerhub/alpine/k8s
+      tag: "1.30.0"
+      pullPolicy: IfNotPresent
+
   # ── Cilium ClusterMesh — the canonical inter-region replication transport
   # (ADR-0001 §9). The primary's `-mesh` global Service publishes its read
   # endpoint across the mesh; the replica's externalCluster dials it. OFF

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T21:08:30.061Z",
+  "generatedAt": "2026-08-04T23:19:26.130Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4083,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.17",
+    "version": "0.2.18",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5760,7 +5760,9 @@ spec:
   # 0.2.13 (#5224): role-secrets side-gate — replica-role region never mints
   # role/hub Secrets; pair password set single-sourced from the primary region.
   # 0.2.14 (#5473): replication-source Service selectorType r -> rw (primary only).
-  version: "0.2.17"
+  # 0.2.18 (#5623): region-B AUTOMATIC DR promotion — ported bp-cnpg-pair dr-promoter
+  # + failover-readiness + topology.promoted HR-value seam on the AHS replica half.
+  version: "0.2.18"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5880,7 +5882,9 @@ spec:
     # 0.2.12 (#4986): active-hot-standby emits the dr-<instance> Continuum CR so
     # the per-app Topology DR panel renders (shared-pg #3375 rows 51/52/56/57/64).
     # 0.2.13 (#5224): role-secrets side-gate (replica-role region mints nothing).
-    version: "0.2.17"
+    # 0.2.18 (#5623): region-B automatic DR promotion (dr-promoter + failover-readiness
+    # + topology.promoted seam) on the active-hot-standby replica half.
+    version: "0.2.18"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the

--- a/scripts/check-region-selector-fail-closed.sh
+++ b/scripts/check-region-selector-fail-closed.sh
@@ -90,6 +90,8 @@ fail() {
 REGISTRY="
 platform/postgres/chart/templates/cluster.yaml|platform/postgres/chart|bp-postgres.primaryRegion
 platform/postgres/chart/templates/replica-cluster.yaml|platform/postgres/chart|bp-postgres.replicaRegion
+platform/postgres/chart/templates/dr-promoter.yaml|platform/postgres/chart|bp-postgres.replicaRegion (#5623 — autoPromoteActive requires renderReplicaHalf, so replica-cluster.yaml co-renders; the Deployment nodeAffinity pins bp-postgres.replicaRegion directly)
+platform/postgres/chart/templates/failover-readiness.yaml|platform/postgres/chart|bp-postgres.replicaRegion (#5623 — same autoPromoteActive gate; the Deployment nodeAffinity pins bp-postgres.replicaRegion directly)
 platform/cnpg-pair/chart/templates/primary-cluster.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions
 platform/cnpg-pair/chart/templates/replica-cluster.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions
 platform/cnpg-pair/chart/templates/dr-failback.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions (transitive — failbackActive requires enabled+isPrimarySide, so primary-cluster.yaml co-renders)


### PR DESCRIPTION
## Region-B automatic DR promotion for the three shared-pg pairs (Refs #5623)

### The gap
The three `bp-postgres` shared-pg instances (`shared-pg`, `shared-pg-b`, `shared-pg-c`)
render the EXACT `bp-cnpg-pair` split-side replica shape but shipped **no region-local
promoter**. On the hw292 G12 region-kill walk (2026-08-03, dep `1c56518035a83e03`,
`cutoverComplete=true`) `bp-cnpg-pair`'s own region-B `dr-promoter` auto-promoted at
T0+2m16s (RPO=0), but each shared-pg replica stayed `pg_is_in_recovery()=t` for the whole
outage. shared-pg carries the platform databases — **keycloak** among them — so the auth
path could not recover in region-B even in principle (the gateway answered 503 on four
independent fresh-TCP samples throughout).

### The fix — port the proven promoter, don't re-invent it
This brings the SAME `bp-cnpg-pair` dr-promoter mechanism (chart 0.2.17) onto the shared-pg
replica half, templated with bp-postgres's own naming helpers + the shared-pg HR-value seam.
Every false-promote guard is preserved:

| Guard | Where |
|---|---|
| signals/actor split; region-B-local Deployment, **not** a CronJob (#5157) | `dr-promoter.yaml` |
| #5178 POSITIVE region-A liveness gate (`pg_isready` of `-mesh` over ClusterMesh) + startup grace + fail-safe observe-only when no peer wired | signals container |
| #5220 steady-state ARM gate (continuous streaming before eligible) — **precedes** the promote patch | actor |
| #5133 failover-readiness Ready gate (LSN apply==receive) | `failover-readiness.yaml` + actor |
| HR-desired-state promote via `spec.values.topology.promoted` (#5125-D1 seam) — never a live Cluster-CR patch | actor |
| #5218 same-tick durable `spec.suspend` latch + per-loop self-heal + readback-verify, custom `--field-manager=dr-promoter` | actor |
| anti-flap: never re-promote an already-diverged cluster | signals + actor |
| sync-only data fence (renders only when `replication.mode=sync`) | `bp-postgres.autoPromoteActive` |

`replica-cluster.yaml` now drives `replica.enabled` from the `topology.promoted` VALUE
(mirror of `bp-cnpg-pair` 0.2.12), so the promotion is the DESIRED state flux
drift-correction re-affirms instead of a live-object patch it reverts mid-outage.

### Scope deliberately deferred (follow-up)
The `#5245` durable-substitute handoff, TL-ahead re-promote, and the region-A `dr-failback`
leg that `bp-cnpg-pair` added on top (0.2.18-0.2.23) are **not** ported here. As with
`bp-cnpg-pair` 0.2.14-0.2.17, the suspend latch keeps the survivor writable through the
outage and the operator lifts it on region-A recovery (RUNBOOKS 6.1).

### Default-OFF preserved (byte-identical when not a sync AHS replica)
`singleton` / `side=primary` / `replication.mode=async` / `autoPromote.enabled=false` all
render ZERO promoter + probe resources. Verified by render.

### Gates run locally (all green)
- `helm lint platform/postgres/chart` — 0 failed
- `bash platform/postgres/chart/tests/postgres-render.sh` — existing cases + new Cases 20a-20d
- `bash scripts/check-bootstrap-kit-pin-sync.sh` — PASS
- `bash scripts/check-catalog-seed-lockstep.sh` — PASS
- `cd tests/e2e/bootstrap-kit && go test .` — ok

### Lockstep (five sites → chart 0.2.18)
`platform/postgres/chart/Chart.yaml` · `platform/postgres/blueprint.yaml` ·
`products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (display + `source.version`) ·
slots `16a`/`16c`/`16d` — each slot's `autoPromote.hr.name` pinned to its OWN HelmRelease.

### Residual owed
LIVE region-kill proof on the shared-pg pairs is owed on the next 2-region G12 walk (the
promoter's runtime behavior only reproduces via a real region-kill + os-start recovery).
This PR is repo-only.

Refs #5623 #5137 #5178 #5218 #5220 #5133 #5157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
