### PR TITLE
fix(controllers): AHS status reports materialised regions + not Ready over unrecoverable CNPG (Refs #5513)

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -175,6 +175,14 @@ const (
 	ReasonOrgGiteaMissing     = "GiteaOrgMissing"
 	ReasonAwaitingDrain       = "AwaitingFluxDrain"
 
+	// ReasonBackingUnrecoverable — #5513. Stamped on
+	// Application.status.conditions[type=Ready,status=False] when a
+	// downstream HelmRelease is Ready (manifests applied) but the
+	// Application's backing CNPG Cluster CR is in CNPG's terminal
+	// `unrecoverable` phase. Prevents the Application reporting Ready over a
+	// database that has zero pods and needs manual intervention.
+	ReasonBackingUnrecoverable = "BackingClusterUnrecoverable"
+
 	// ReasonInvalidTopology — G117.6 (W2.C1, Refs #2745). Stamped on
 	// `Application.status.conditions[type=Ready,status=False]` when the
 	// resolved BCP topology (from Application.spec.topology override
@@ -1506,7 +1514,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	finalPhase := hrPhase
 	finalReady := "True"
 	finalReason := ReasonReconciled
-	finalMessage := fmt.Sprintf("Application %s/%s reconciled into %d region(s)", app.GetNamespace(), app.GetName(), len(plan.Regions))
+	// #5513 — the region count in the status message MUST derive from the
+	// EFFECTIVE materialised per-cluster set, NEVER from the DECLARED
+	// plan.Regions. An active-hot-standby provision whose fan-out collapses
+	// to a single cluster (e.g. an empty region label — root cause tracked
+	// in the placement/object-model chain, #5476) materialises ONE
+	// HelmRelease while spec.placement still names two regions. The old code
+	// read len(plan.Regions)=2 and fabricated "installed across 2 region(s)"
+	// over a single HelmRelease — a DR posture that does not exist. When the
+	// topology fan-out owns the install, perClusterStatus carries exactly the
+	// HRs that were actually rendered (one row per materialised cluster), so
+	// it is the same source the per-cluster table renders — the claim can
+	// never exceed reality. The legacy single-HR host path (no fan-out) keeps
+	// len(plan.Regions), byte-identical to before.
+	effectiveRegions := len(plan.Regions)
+	if fanoutOwnsInstall {
+		effectiveRegions = len(perClusterStatus)
+	}
+	finalMessage := fmt.Sprintf("Application %s/%s reconciled into %d region(s)", app.GetNamespace(), app.GetName(), effectiveRegions)
 	if finalPhase == "" {
 		finalPhase = PhaseProvisioning
 	}
@@ -1528,7 +1553,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 		finalReady = "True"
 		finalReason = ReasonReconciled
 		finalMessage = fmt.Sprintf("Application %s/%s installed across %d region(s); Ready=True from downstream HelmRelease(s)",
-			app.GetNamespace(), app.GetName(), len(plan.Regions))
+			app.GetNamespace(), app.GetName(), effectiveRegions)
+	}
+
+	// #5513 — a downstream HelmRelease Ready=True means "Helm applied the
+	// manifests", NOT "the workload came up". A CNPG-backed Application can
+	// carry a Ready HelmRelease while its backing CNPG Cluster sits in the
+	// terminal `unrecoverable` state (0 pods, ConsistentSystemID=False,
+	// "needs manual intervention"). Reporting the Application Ready over that
+	// is the fabricated DR posture #5513 walked live. Observe the backing
+	// CNPG Cluster CR(s) — matched by the chart-stamped
+	// app.kubernetes.io/instance label (= each per-cluster HR name) — and
+	// downgrade to Degraded when any is unrecoverable, so the reported Ready
+	// condition matches the workload reality. Read-only + failure-tolerant:
+	// a missing CNPG CRD (no Postgres in this Sovereign) or a transient list
+	// error NEVER fabricates a downgrade — the HR-derived phase stands.
+	if finalReady == "True" {
+		if cnpgNs, cnpgName, unrecoverable := r.backingCNPGUnrecoverable(ctx, app, perClusterStatus); unrecoverable {
+			finalPhase = PhaseDegraded
+			finalReady = "False"
+			finalReason = ReasonBackingUnrecoverable
+			finalMessage = fmt.Sprintf(
+				"Application %s/%s: backing CNPG cluster %s/%s is in an unrecoverable state and needs manual intervention; not reporting Ready",
+				app.GetNamespace(), app.GetName(), cnpgNs, cnpgName)
+		}
 	}
 	su := statusUpdate{
 		Phase:         finalPhase,

--- a/core/controllers/application/internal/controller/application_controller_5513_test.go
+++ b/core/controllers/application/internal/controller/application_controller_5513_test.go
@@ -1,0 +1,241 @@
+// application_controller_5513_test.go — #5513.
+//
+// active-hot-standby renders/reports a 2-region pair over a singleton:
+//
+//  1. Task 2 — the Ready status message must derive the region count from the
+//     EFFECTIVE materialised per-cluster set (perClusterStatus), never from the
+//     DECLARED plan.Regions. A fan-out that collapses to one cluster while
+//     spec.placement names two regions must report "installed across 1
+//     region(s)", not "2 region(s)".
+//
+//  2. Task 5 — a downstream HelmRelease Ready=True means "manifests applied",
+//     not "workload up". An Application whose backing CNPG Cluster is in the
+//     terminal `unrecoverable` state must NOT report Ready.
+//
+// Both are asserted BOTH directions: the collapsed/broken case (fails pre-fix)
+// and the genuinely-healthy case (must stay correct).
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeCNPGCluster returns a CNPG Cluster CR (postgresql.cnpg.io/v1) carrying
+// the standard app.kubernetes.io/instance label (the Helm release name that
+// installed it) and the given status.phase.
+func makeCNPGCluster(namespace, name, instance, phase string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("postgresql.cnpg.io/v1")
+	u.SetKind("Cluster")
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetLabels(map[string]string{InstanceLabel: instance})
+	u.Object["status"] = map[string]interface{}{"phase": phase}
+	return u
+}
+
+// TestReconcile_5513_CollapsedFanout_ReportsMaterialisedRegionCount — Task 2,
+// the failing-pre-fix direction. A Blueprint whose active-hot-standby variant
+// declares ONE cluster (the collapse shape) while the Application declares TWO
+// regions materialises a single HelmRelease. When that HR is Ready, the Ready
+// message must say "installed across 1 region(s)" — deriving from the
+// materialised perCluster set — not "2 region(s)" from the declared plan.
+func TestReconcile_5513_CollapsedFanout_ReportsMaterialisedRegionCount(t *testing.T) {
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-postgres", "0.2.6", "mgmt",
+		[]string{"mgmt-A"}, // AHS variant collapsed to ONE cluster
+	)
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod") // 2 regions declared
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6",
+		"active-hotstandby",
+		[]string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"}, // plan.Regions = 2
+		nil,
+	)
+	// The single materialised HR (fan-out names it <app>-<cluster>), Ready.
+	hr := readyHR("obs-mgmt-a", "mgmt", "True")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, hr)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, _, msg := readPhaseAndReason(t, got)
+	if phase != PhaseReady {
+		t.Fatalf("phase = %q, want %q (the single per-cluster HR is Ready)", phase, PhaseReady)
+	}
+	if !strings.Contains(msg, "installed across 1 region(s)") {
+		t.Errorf("Ready message = %q, want it to claim 1 region (the materialised count)", msg)
+	}
+	if strings.Contains(msg, "2 region(s)") {
+		t.Errorf("Ready message = %q, still claims 2 region(s) over a single HelmRelease — the #5513 fabricated DR posture", msg)
+	}
+	// The per-cluster table must carry exactly the one materialised cluster.
+	rows, _, _ := unstructured.NestedSlice(got.Object, "status", "perCluster")
+	if len(rows) != 1 {
+		t.Errorf("status.perCluster has %d rows, want 1 (the single materialised cluster)", len(rows))
+	}
+}
+
+// TestReconcile_5513_HealthyTwoRegion_ReportsTwoRegions — Task 2, the healthy
+// direction. A genuine 2-cluster active-hot-standby whose BOTH HRs are Ready
+// must still report "installed across 2 region(s)". Guards the fix from
+// under-counting a real multi-region install.
+func TestReconcile_5513_HealthyTwoRegion_ReportsTwoRegions(t *testing.T) {
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-postgres", "0.2.6", "mgmt",
+		[]string{"mgmt-A", "mgmt-B"}, // genuine 2-cluster variant
+	)
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6",
+		"active-hotstandby",
+		[]string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"},
+		nil,
+	)
+	// Both per-cluster HRs materialised + Ready (fan-out authors both in mgmt).
+	hrA := readyHR("obs-mgmt-a", "mgmt", "True")
+	hrB := readyHR("obs-mgmt-b", "mgmt", "True")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, hrA, hrB)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, _, msg := readPhaseAndReason(t, got)
+	if phase != PhaseReady {
+		t.Fatalf("phase = %q, want %q (both per-cluster HRs are Ready)", phase, PhaseReady)
+	}
+	if !strings.Contains(msg, "installed across 2 region(s)") {
+		t.Errorf("Ready message = %q, want it to claim 2 region(s) (both clusters materialised)", msg)
+	}
+}
+
+// TestReconcile_5513_ReadyHR_UnrecoverableCNPG_NotReady — Task 5, the
+// failing-pre-fix direction. An Application whose HelmRelease is Ready
+// (manifests applied) but whose backing CNPG Cluster is in the terminal
+// `unrecoverable` state must NOT report Ready — it downgrades to Degraded with
+// reason BackingClusterUnrecoverable.
+func TestReconcile_5513_ReadyHR_UnrecoverableCNPG_NotReady(t *testing.T) {
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-postgres", "0.2.6", "mgmt",
+		[]string{"mgmt-A"},
+	)
+	env := makeEnv("acme-prod", "acme", "prod") // single-region → singleton
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6",
+		"single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		nil,
+	)
+	// HelmRelease Ready=True (Helm applied the chart) ...
+	hr := readyHR("obs-mgmt-a", "mgmt", "True")
+	// ... but the backing CNPG Cluster it installed is unrecoverable. The
+	// chart stamps app.kubernetes.io/instance = the HR/release name.
+	cnpg := makeCNPGCluster("mgmt", "postgres", "obs-mgmt-a",
+		"Cluster is unrecoverable and needs manual intervention")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, hr, cnpg)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if phase == PhaseReady {
+		t.Fatalf("phase = Ready over an unrecoverable backing CNPG — the #5513 fabricated posture (msg=%q)", msg)
+	}
+	if phase != PhaseDegraded {
+		t.Fatalf("phase = %q, want %q (backing CNPG unrecoverable)", phase, PhaseDegraded)
+	}
+	if reason != ReasonBackingUnrecoverable {
+		t.Errorf("Ready-condition reason = %q, want %q", reason, ReasonBackingUnrecoverable)
+	}
+	// And the Ready condition must be False, not True.
+	if readyStatus := readyConditionStatus(t, got); readyStatus == "True" {
+		t.Errorf("Ready condition status = True over an unrecoverable CNPG; want False")
+	}
+}
+
+// TestReconcile_5513_ReadyHR_HealthyCNPG_StaysReady — Task 5, the healthy
+// direction. The same shape but with a healthy backing CNPG must report Ready.
+// Guards the guard from over-rotating every CNPG-backed app to Degraded.
+func TestReconcile_5513_ReadyHR_HealthyCNPG_StaysReady(t *testing.T) {
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-postgres", "0.2.6", "mgmt",
+		[]string{"mgmt-A"},
+	)
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6",
+		"single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		nil,
+	)
+	hr := readyHR("obs-mgmt-a", "mgmt", "True")
+	cnpg := makeCNPGCluster("mgmt", "postgres", "obs-mgmt-a", "Cluster in healthy state")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, hr, cnpg)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, _, msg := readPhaseAndReason(t, got)
+	if phase != PhaseReady {
+		t.Fatalf("phase = %q, want %q (backing CNPG is healthy — Ready must not be suppressed) msg=%q", phase, PhaseReady, msg)
+	}
+}
+
+// TestCNPGClusterUnrecoverable_BothDirections — the phase classifier in
+// isolation. Terminal `unrecoverable` phrasings trip; transient/healthy phases
+// and an absent status do not.
+func TestCNPGClusterUnrecoverable_BothDirections(t *testing.T) {
+	cases := []struct {
+		phase string
+		want  bool
+	}{
+		{"Cluster is unrecoverable and needs manual intervention", true},
+		{"Cluster in unrecoverable state", true},
+		{"Cluster in healthy state", false},
+		{"Setting up primary", false},
+		{"Waiting for the instances to become active", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		cr := makeCNPGCluster("mgmt", "postgres", "obs-mgmt-a", c.phase)
+		if got := cnpgClusterUnrecoverable(cr); got != c.want {
+			t.Errorf("cnpgClusterUnrecoverable(phase=%q) = %v, want %v", c.phase, got, c.want)
+		}
+	}
+	if cnpgClusterUnrecoverable(nil) {
+		t.Errorf("cnpgClusterUnrecoverable(nil) = true, want false")
+	}
+}
+
+// readyConditionStatus returns the status ("True"/"False"/…) of the Ready
+// condition on an Application.
+func readyConditionStatus(t *testing.T, app *unstructured.Unstructured) string {
+	t.Helper()
+	conds, _, _ := unstructured.NestedSlice(app.Object, "status", "conditions")
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if typ, _ := cm["type"].(string); typ == "Ready" {
+			status, _ := cm["status"].(string)
+			return status
+		}
+	}
+	return ""
+}

--- a/core/controllers/application/internal/controller/application_controller_backing_health.go
+++ b/core/controllers/application/internal/controller/application_controller_backing_health.go
@@ -1,0 +1,131 @@
+// application_controller_backing_health.go — #5513 backing-workload health.
+//
+// A downstream Flux HelmRelease reporting Ready=True means only that Helm
+// applied the chart's manifests — NOT that the workload the chart installs
+// actually came up. For a CNPG-backed Application the load-bearing workload is
+// the CNPG Cluster CR, and CNPG has a terminal `unrecoverable` phase ("Cluster
+// is unrecoverable and needs manual intervention") in which the database has
+// zero pods and cannot serve. Reporting the Application Ready over that state
+// is the fabricated DR posture walked live on hw291 (#5513).
+//
+// This file adds a read-only, failure-tolerant observation the reconcile status
+// rollup consults before it lets an Application settle on Ready=True. It never
+// writes and never fabricates a downgrade: a missing CNPG CRD (no Postgres in
+// this Sovereign) or a transient list error leaves the HR-derived phase intact.
+package controller
+
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// CNPGClusterGVR is the CloudNativePG Cluster CR GVR (postgresql.cnpg.io/v1).
+// Namespaced. Read via the dynamic client + Unstructured — the controller
+// never depends on a generated CNPG client (mirrors the continuum-controller's
+// ADR-0001 §2.7 convention).
+var CNPGClusterGVR = schema.GroupVersionResource{
+	Group:    "postgresql.cnpg.io",
+	Version:  "v1",
+	Resource: "clusters",
+}
+
+// InstanceLabel is the standard Helm/Kubernetes label a chart stamps on the
+// resources it renders, carrying the Helm release name. The bp-postgres /
+// cnpg-pair chart stamps it on each CNPG Cluster it creates, so it is the
+// stable link from an Application's per-cluster HelmRelease (whose name is the
+// release name) back to the CNPG Cluster CR that HelmRelease installed. Walked
+// live on hw291: the collapsed CNPG carried
+// `app.kubernetes.io/instance=uatwalk-ahs-07300830-rtz-a` (= the HR name).
+const InstanceLabel = "app.kubernetes.io/instance"
+
+// backingCNPGUnrecoverable reports whether any CNPG Cluster CR backing this
+// Application is in CNPG's terminal `unrecoverable` phase. It returns the
+// namespace + name of the first such Cluster and true; ("", "", false) when
+// none is unrecoverable (including when there is no CNPG backing at all).
+//
+// Discovery: the backing CNPG Cluster carries `app.kubernetes.io/instance` set
+// to the Helm release name of the HelmRelease that installed it — i.e. each
+// per-cluster HR name (the fan-out path) or the bare Application name (the
+// legacy single-HR host path). We search that label across the namespaces the
+// HRs were authored in, plus the Application's own namespace, so a CNPG routed
+// host-side (#4398) or landed in a vCluster host-ns is found either way.
+//
+// Read-only + failure-tolerant: a List error (CNPG CRD absent → the fake/real
+// dynamic client returns a no-kind error; or a transient API error) is skipped,
+// never surfaced as an unrecoverable verdict. The caller only downgrades on a
+// POSITIVE match, so a read failure can never manufacture a false Degraded.
+func (r *Reconciler) backingCNPGUnrecoverable(
+	ctx context.Context,
+	app *unstructured.Unstructured,
+	perClusterStatus []map[string]interface{},
+) (namespace, name string, unrecoverable bool) {
+	if r == nil || r.Dynamic == nil || app == nil {
+		return "", "", false
+	}
+
+	// Build the (namespace, instance-label) work list from the materialised
+	// per-cluster HRs. Fall back to the bare Application identity when no
+	// fan-out ran (legacy single-HR host path).
+	type target struct{ ns, instance string }
+	nsSet := map[string]struct{}{app.GetNamespace(): {}}
+	var instances []string
+	for _, pcs := range perClusterStatus {
+		hrName, _ := pcs["hr"].(string)
+		if hrName == "" {
+			continue
+		}
+		instances = append(instances, hrName)
+		if ns, _ := pcs["namespace"].(string); ns != "" {
+			nsSet[ns] = struct{}{}
+		}
+	}
+	if len(instances) == 0 {
+		instances = append(instances, app.GetName())
+	}
+
+	// De-dup (namespace × instance) probes.
+	seen := map[target]struct{}{}
+	for ns := range nsSet {
+		for _, inst := range instances {
+			t := target{ns: ns, instance: inst}
+			if _, ok := seen[t]; ok {
+				continue
+			}
+			seen[t] = struct{}{}
+
+			list, err := r.Dynamic.Resource(CNPGClusterGVR).Namespace(t.ns).List(ctx, metav1.ListOptions{
+				LabelSelector: InstanceLabel + "=" + t.instance,
+			})
+			if err != nil {
+				// CNPG CRD absent or transient list error — never fabricate
+				// a downgrade on a read failure.
+				continue
+			}
+			for i := range list.Items {
+				if cnpgClusterUnrecoverable(&list.Items[i]) {
+					return t.ns, list.Items[i].GetName(), true
+				}
+			}
+		}
+	}
+	return "", "", false
+}
+
+// cnpgClusterUnrecoverable reports whether a CNPG Cluster CR is in CNPG's
+// terminal `unrecoverable` phase. CNPG sets status.phase to a human string
+// (e.g. "Cluster in unrecoverable state" / "... unrecoverable and needs manual
+// intervention"); a case-insensitive substring match on "unrecoverable" is
+// robust across CNPG phrasings while staying specific to the terminal,
+// manual-intervention state (it does NOT trip on transient phases like
+// "Setting up primary" or "Cluster in healthy state").
+func cnpgClusterUnrecoverable(cr *unstructured.Unstructured) bool {
+	if cr == nil {
+		return false
+	}
+	phase, _, _ := unstructured.NestedString(cr.Object, "status", "phase")
+	return strings.Contains(strings.ToLower(phase), "unrecoverable")
+}

--- a/core/controllers/application/internal/controller/application_controller_test.go
+++ b/core/controllers/application/internal/controller/application_controller_test.go
@@ -192,6 +192,9 @@ func newScheme() *runtime.Scheme {
 		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"},
 		// #3375 DoD-3 — the per-app Continuum DR contract the fan-out mints.
 		{Group: ContinuumGroup, Version: ContinuumVersion, Kind: ContinuumKind},
+		// #5513 — backing CNPG Cluster health observation for the Ready
+		// rollup (a Ready HR over an unrecoverable CNPG must not be Ready).
+		{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"},
 	} {
 		s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
 		listGVK := schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List"}
@@ -212,6 +215,8 @@ func listKindMap() map[schema.GroupVersionResource]string {
 		FluxHelmReleaseGVR:   "HelmReleaseList",
 		// #3375 DoD-3 — per-app Continuum DR contract.
 		ContinuumGVR: "ContinuumList",
+		// #5513 — backing CNPG Cluster health observation.
+		CNPGClusterGVR: "ClusterList",
 	}
 }
 


### PR DESCRIPTION
## What

Fixes two controller-side status lies behind #5513, where an
`active-hot-standby` provision reported a healthy two-region pair over a
runtime that had one region and an unrecoverable database. Pure-Go, in the
application-controller status rollup — **no chart, blueprint.yaml,
catalog-seed, or umbrella version touched**.

### Task 2 — region count from the materialised set, not the declared plan

`Application.status` claimed `installed across 2 region(s)` with a single
HelmRelease because the message read `len(plan.Regions)` (the DECLARED
placement) rather than the effective materialised per-cluster set. It now
derives from `perClusterStatus` whenever the topology fan-out owns the
install, so the claim can never exceed the HRs that actually rendered. The
legacy single-HR host path keeps `plan.Regions`, byte-identical.

### Task 5 — do not report Ready over an unrecoverable CNPG

A downstream HelmRelease `Ready=True` means "Helm applied the manifests",
not "the workload came up". A CNPG-backed Application carried a Ready
HelmRelease while its backing CNPG Cluster sat in CNPG's terminal
`unrecoverable` state (0 pods, needs manual intervention). The rollup now
observes the backing CNPG Cluster CR(s) — matched by the chart-stamped
`app.kubernetes.io/instance` label (= each per-cluster HR name, exactly the
link the live walk showed) — and downgrades to `Degraded`
(reason `BackingClusterUnrecoverable`) when any is unrecoverable. Read-only
and failure-tolerant: a missing CNPG CRD or a transient list error never
fabricates a downgrade.

## Files

- `application_controller.go` — effective-region-count derivation +
  unrecoverable-CNPG guard in the status rollup; new reason constant.
- `application_controller_backing_health.go` (new) — CNPG Cluster GVR +
  `backingCNPGUnrecoverable` / `cnpgClusterUnrecoverable`.
- `application_controller_5513_test.go` (new) + `application_controller_test.go`
  (registers the CNPG GVR in the shared fake-client scheme).

## Tests — both directions

- Collapsed AHS (1 materialised region, 2 declared) reports
  `installed across 1 region(s)` — **fails pre-fix** (reported 2).
- Genuine 2-region AHS still reports `installed across 2 region(s)`.
- Ready HR over an unrecoverable CNPG is `Degraded` /
  `BackingClusterUnrecoverable` — **fails pre-fix** (reported Ready).
- Ready HR over a healthy CNPG stays Ready.
- Direct classifier table for the phase match.

`go build ./...` + `go test ./...` green in `core/controllers` (full module,
no regressions).

## Scope of the remaining #5513 tasks

- Switch-over gating on an actually-present standby (console) landed in
  merged #5538 / #5519.
- The empty `openova.io/region` fan-out-collapse root and the missing
  `spec.organizationRef` are create / object-model concerns tracked on the
  #5476 chain — intentionally left to that lane to avoid a collision on the
  same files.

Refs #5513

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
