### PR TITLE
fix(cutover): stop harbor-prewarm printing the GHCR PAT prefix in pod logs (Refs #5467)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1061,7 +1061,7 @@ spec:
       # index.yaml HelmRepository off charts.loft.sh into local Harbor +
       # suspends bp-vcluster-helmrepo so it holds; the step-08 fluxSourceHostLint
       # exception for charts.loft.sh is removed (empty allowHosts).
-      version: 0.1.168
+      version: 0.1.169
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1322,7 +1322,7 @@ spec:
       #   create-side reconcile; deleted Orgs converge to fully-deleted in
       #   every region.
       #   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
-      version: 1.4.1294
+      version: 1.4.1295
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.168
+  version: 0.1.169
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,10 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.169 (#5467) — SECURITY: step-03 harbor-prewarm no longer prints any prefix
+# of the GHCR PAT. The old `pat=${ghcr_pat:0:8}...` disclosed 4 real secret chars
+# (after the `ghp_` type prefix) + the token type + exact length + owning account
+# into pod logs on every cutover; the line now matches the mothership branch
+# (user + length only). Platform rule: secret values are never printed.
 # 0.1.168 (#5650) — INSTANCE FIX for the residual charts.loft.sh tether. Step-06
 # gains Phase-2c (helmRepositories.vclusterLoftPivot): it mirrors the upstream
 # vcluster chart into local Harbor while egress is still open, repoints the
@@ -3272,7 +3277,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.168
+version: 0.1.169
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -413,7 +413,13 @@ data:
     fi
     ghcr_user=$(printf '%s' "${ghcr_auth_b64}" | base64 -d | awk -F: '{print $1}')
     ghcr_pat=$(printf '%s' "${ghcr_auth_b64}" | base64 -d | awk -F: '{print $2}')
-    echo "[harbor-prewarm] ghcr.io auth extracted: user=${ghcr_user} pat=${ghcr_pat:0:8}... (len=${#ghcr_pat})"
+    # #5467 — NEVER print any prefix of the PAT. The `${ghcr_pat:0:8}` disclosed
+    # 4 real secret chars (after the `ghp_` type prefix) + the token type + exact
+    # length + owning account into pod logs, which are read by operators, shipped
+    # by log aggregators, and pasted into issues on a failed cutover. Match the
+    # mothership branch below: user + length only (platform rule — secret values
+    # are never printed; lengths/hashes only).
+    echo "[harbor-prewarm] ghcr.io auth extracted: user=${ghcr_user} (len=${#ghcr_pat})"
 
     # #4975 — OPTIONAL mothership-Harbor source auth. Phase A3 mirrors
     # `harbor.openova.io/proxy-<x>/...` refs (the dominant bootstrap-kit

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T23:19:26.130Z",
+  "generatedAt": "2026-08-05T01:25:58.840Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.168",
+      "version": "0.1.169",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.168",
+    "version": "0.1.169",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3659,7 +3659,10 @@ name: bp-catalyst-platform
 #   surface are excluded by CR-list + FQDN guards. Refs #5364 #5649.
 #   (1.4.1283 was consumed by the TBD-A6 auto re-publish mid-branch.)
 #   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
-version: 1.4.1294
+# 1.4.1295 — #5467: bp-self-sovereign-cutover 0.1.168 -> 0.1.169 (harbor-prewarm
+#   GHCR-PAT log-leak fix). Bootstrap-kit slot-06a + catalog-seed pins lockstep.
+#   (re-serialized past main 1.4.1294 at rebase.)
+version: 1.4.1295
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5072,7 +5072,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.168"
+  version: "0.1.169"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5089,7 +5089,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.168"
+    version: "0.1.169"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Refs #5467

### Defect
`platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml` printed the first 8 characters of the GHCR PAT into pod logs on every cutover, on every Sovereign:

    echo "[harbor-prewarm] ghcr.io auth extracted: user=${ghcr_user} pat=${ghcr_pat:0:8}... (len=${#ghcr_pat})"

The `ghp_` type prefix is 4 of those 8 chars, so 4 characters of real secret material were disclosed — plus the token type, exact length, and owning account. Pod logs are read by operators, shipped by log aggregators, and pasted into issues on a failed cutover. This violates the platform rule that secret values are never printed (lengths/hashes only).

### Fix
The line now matches the mothership branch 14 lines below (which already did it correctly) — `user` + `(len=…)`, no PAT prefix. Full diagnostic value preserved (did we extract a credential, correct length, which account).

### Lockstep + gates
bp-self-sovereign-cutover 0.1.168 → 0.1.169 across all five lockstep sites (chart Chart.yaml, blueprint.yaml, bootstrap-kit slot 06a, catalog-seed spec.version + source.version) + regenerated blueprints.json / catalog.generated.ts + umbrella 1.4.1293 → 1.4.1294. `tests/e2e/bootstrap-kit` go guards green (lockstep + catalog-seed drift + regenerate-no-diff); grep confirms zero PAT-prefix disclosure remains in the template.

### Note
`ghcr-pin-existence` will fail until the post-merge blueprint-release run publishes 0.1.169 to ghcr — the one tolerable check.
