### PR TITLE
fix(auth): verify handover issuer via DefaultIssuer(), not a hardcoded mothership literal (Refs #5614)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -40,6 +40,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jtistore"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
 )
@@ -229,7 +230,16 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── 3. Validate claims ──────────────────────────────────────────────
-	const expectedIss = "https://console.openova.io"
+	// #5614 — resolve the expected issuer through the SAME single source the
+	// minter uses (handoverjwt.DefaultIssuer(), which reads
+	// CATALYST_HANDOVER_JWT_ISSUER and falls back to the Catalyst-Zero
+	// mothership origin). The former hardcoded `const expectedIss =
+	// "https://console.openova.io"` was the verify-side survivor of the #2940
+	// duplicate-tether literal: a cut-over Sovereign mints a token with its OWN
+	// console as `iss` and this verifier then 401'd it as "invalid issuer",
+	// rejecting the Sovereign's own handover (hw292, cc=true). One resolver, both
+	// sides — the mint and verify issuers can never drift again.
+	expectedIss := handoverjwt.DefaultIssuer()
 	iss, err := claims.GetIssuer()
 	if err != nil || iss != expectedIss {
 		writeAuthError(w, "invalid issuer")

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover_test.go
@@ -488,6 +488,36 @@ func TestAuthHandover_WrongIssuer(t *testing.T) {
 	assertAuthError(t, w, http.StatusUnauthorized, "invalid issuer")
 }
 
+// TestAuthHandover_PerSovereignIssuer_5614 — a cut-over Sovereign mints a handover
+// token with its OWN console as `iss`; the verifier must resolve the expected
+// issuer through handoverjwt.DefaultIssuer() (which honours
+// CATALYST_HANDOVER_JWT_ISSUER, the SAME single source the minter uses) and ACCEPT
+// it. The former hardcoded `const expectedIss = "https://console.openova.io"`
+// 401'd the Sovereign's own token as "invalid issuer" (the #2940 duplicate-literal
+// drift surviving on the verify side) — this test FAILS on that hardcode and
+// passes only when both sides share one resolver.
+func TestAuthHandover_PerSovereignIssuer_5614(t *testing.T) {
+	const sovIssuer = "https://console.hw292.omani.works"
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", sovIssuer)
+
+	h, privKey, _ := testHandoverSetup(t)
+
+	c := validClaims("sov.test")
+	c.Issuer = sovIssuer // the Sovereign's OWN console — what its minter emits post-cutover
+	tok := signClaims(t, privKey, c)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/handover?token="+tok, nil)
+	w := httptest.NewRecorder()
+	h.AuthHandover(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Fatalf("#5614 regression: Sovereign rejected its OWN handover token — got 401 %q", w.Body.String())
+	}
+	if w.Code != http.StatusFound {
+		t.Fatalf("status: got %d want 302 (own token accepted → dashboard redirect)", w.Code)
+	}
+}
+
 func TestAuthHandover_WrongRole(t *testing.T) {
 	h, privKey, _ := testHandoverSetup(t)
 


### PR DESCRIPTION
## Refs #5614

### Defect
A cut-over Sovereign minted a handover URL for **itself** and then **rejected its own token** with 401 `{"error":"invalid issuer"}`. The verify side hardcoded the mothership origin while the minter honours the per-Sovereign override:

`products/catalyst/bootstrap/api/internal/handler/auth_handover.go`

    const expectedIss = "https://console.openova.io"   // hardcoded
    if iss != expectedIss { writeAuthError(w, "invalid issuer"); return }

The mint side (`cmd/api/main.go`) resolves `handoverjwt.DefaultIssuer()` — the single source that reads `CATALYST_HANDOVER_JWT_ISSUER` and falls back to the Catalyst-Zero mothership. This was the exact duplicate-literal drift #2940 was written to eliminate, surviving on the verify side. Observed live on hw292 (cc=true, 2026-08-03): a freshly-minted token with `iss = https://console.hw292.omani.works`, valid for 250 more seconds, distinct jti, 401'd.

### Fix
`expectedIss := handoverjwt.DefaultIssuer()` — mint and verify now share one resolver, so their issuers can never drift again. Pillar-5 anti-tether: a Sovereign accepts its own handover post-cutover.

### Test
New `TestAuthHandover_PerSovereignIssuer_5614`: sets `CATALYST_HANDOVER_JWT_ISSUER` to a Sovereign origin, mints a token with that `iss`, asserts the handler does NOT 401 and redirects (302). Falsifiable — it fails on the old hardcode (the token's Sovereign issuer != the mothership literal → 401). `TestAuthHandover_WrongIssuer` still passes (a genuinely-foreign issuer with no override still 401s via the DefaultIssuer fallback). Full handler suite green; `go build ./...` clean.

### Unblocks
The handover-URL UAT rows (96/123/178) — a franchised Sovereign's owner can follow its own minted handover link.
