### PR TITLE
fix(console): summary inline editor opens pre-filled with the visible summary, not blank (Refs #5610)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
@@ -215,6 +215,33 @@ describe('CatalogDetail per-field inline editing (#3668 §5A)', () => {
     expect(Object.keys(patch)).toEqual(['tagline'])
   })
 
+  it('#5610 — the summary editor opens PRE-FILLED with the visible summary, never blank (wipe hazard)', async () => {
+    // A card whose visible summary comes ONLY from `description` (no tagline,
+    // no summary) — the live hw292 shape. The hero renders `description`; the
+    // editor must open showing that same text, not "". Opening blank is one
+    // Save away from writing "" over a non-empty summary.
+    const DESC_ONLY = {
+      ...GRAFANA_CATALOG,
+      card: { title: 'Alloy', summary: '', description: 'Node agent for logs, metrics, and traces' },
+    }
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/instances')) return jsonRes({ items: [] })
+      if (url.includes('/catalog/')) return jsonRes(DESC_ONLY)
+      return jsonRes({})
+    }) as typeof fetch
+
+    renderCatalog()
+    // Hero shows the description-sourced summary.
+    expect((await screen.findByTestId('catalog-summary')).textContent).toBe(
+      'Node agent for logs, metrics, and traces',
+    )
+    // Open the inline editor — it must be pre-filled, not empty.
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    const input = screen.getByTestId('cif-summary-input') as HTMLTextAreaElement
+    expect(input.value).toBe('Node agent for logs, metrics, and traces')
+  })
+
   it('editing SUPPORTED TOPOLOGIES toggles a mode and sends only that set', async () => {
     renderCatalog()
     fireEvent.click(await screen.findByTestId('cif-topologies-edit'))

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -308,6 +308,16 @@ export function CatalogDetail() {
     light: card.iconLight || bundledLogo || '',
     dark: card.iconDark || '',
   }
+  // #5610 — the summary editor's initial DRAFT: the summary the hero is CURRENTLY
+  // rendering, so the pencil opens pre-filled instead of blank. Mirrors iconDraft
+  // (and the icon field's initialDraft) exactly. The former `initialDraft=
+  // {iacSeed.tagline}` used a narrower chain (tagline||summary, NO description)
+  // than the hero's renderDisplay (tagline||summary||description), so a card whose
+  // visible summary came from `description` opened the editor EMPTY — one Save away
+  // from writing "" over a non-empty summary. Like iconDraft this only affects what
+  // the editor OPENS showing; `createSeed` stays iacSeed and only an explicit Save
+  // persists it (the #5510 merge-base guard prevents sibling reverts).
+  const summaryDraft = card.tagline || card.summary || card.description || ''
   // Refetch the catalog item after any per-field save so the new value renders
   // live (and the next field's create-seed picks up the saved sibling).
   //
@@ -475,7 +485,7 @@ export function CatalogDetail() {
                 label="Summary"
                 createSeed={iacSeed}
                 editable={isAdmin && !editingIaC}
-                initialDraft={iacSeed.tagline}
+                initialDraft={summaryDraft}
                 renderDisplay={() => (
                   <span data-testid="catalog-summary">
                     {card.tagline || card.summary || card.description || (


### PR DESCRIPTION
## Refs #5610 (Facet A — the wipe hazard)

### Defect
On any Catalog Blueprint detail, clicking the summary pencil (`cif-summary-edit`) opened `cif-summary-input` **empty** — even when the hero was displaying a non-empty summary. A sovereign-admin who clicks to make a small wording change then Saves writes an empty `spec.card.summary` over the existing one. The name and icon editors pre-fill correctly, so it was specific to summary.

### Root cause
`CatalogDetail.tsx` seeded the summary editor from `iacSeed.tagline` = `card.tagline || card.summary` — a **narrower** chain than the hero's `renderDisplay` (`card.tagline || card.summary || card.description`). A card whose visible summary comes from `description` (the live hw292 shape) therefore opened the editor blank.

### Fix
Mirror the existing `iconDraft` pattern (#3668 §5B): a separate `summaryDraft = card.tagline || card.summary || card.description || ''` — the value the hero is currently rendering — is passed as the editor's `initialDraft`. `createSeed` stays `iacSeed`, so this only changes what the editor OPENS showing; the #5510 merge-base guard still prevents sibling reverts, and it respects the #5510 rule against materializing a console default into IaC (nothing persists without an explicit Save).

### Test
New `#5610` case in `CatalogDetail.edit.test.tsx`: a card with summary only in `description` opens the editor pre-filled with that text. Falsifiable — reverting to `iacSeed.tagline` makes it fail (`expected '' to be 'Node agent…'`). Full CatalogDetail.edit + merge-base-5510 suites green (14/14 + 17/17).

### Not in this PR
Facet B (YamlEditor keeps "unsaved changes" after a successful commit) — a separate, non-data-loss state bug; tracked on the issue.
