### PR TITLE
fix(placement): derivedFromRuntime false on the no-data-plane path — no runtime, no claim (Refs #5568)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -59,9 +59,17 @@ import (
 // runtimePlacementResponse is the body of GET
 // /applications/{name}/placement. `Targets` is the #3969 PlacementTarget
 // list derived from the live runtime; the FE feeds it straight into
-// derivePattern. `DerivedFromRuntime` is always true here — it lets the FE
-// distinguish "real, observed placement" from the legacy spec/status
-// projection it falls back to when this endpoint is unavailable.
+// derivePattern. `DerivedFromRuntime` lets the FE distinguish "real,
+// observed placement" from the legacy spec/status projection it falls back
+// to when this endpoint could not consult the runtime.
+//
+// #5568 — it is true ONLY when the live k8s cache was actually queried (a
+// genuine runtime observation, even if that query legitimately found zero
+// targets). It MUST be false on the no-data-plane path (k8sCache == nil),
+// where no runtime is consulted: pairing `targets: []` with
+// `derivedFromRuntime: true` there falsely asserts the empty list was
+// runtime-observed, when the branch is taken precisely because it was not —
+// the exact fabrication UAT row 55 leans on this flag to rule out.
 type runtimePlacementResponse struct {
 	Targets            []bpv1.PlacementTarget `json:"targets"`
 	DerivedFromRuntime bool                   `json:"derivedFromRuntime"`
@@ -81,9 +89,12 @@ func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if h.k8sCache == nil {
-		// No data plane (pre-handover mothership / CI) — honest empty
-		// placement; the FE keeps its legacy spec/status fallback.
-		writeJSON(w, http.StatusOK, runtimePlacementResponse{Targets: []bpv1.PlacementTarget{}, DerivedFromRuntime: true})
+		// No data plane (pre-handover mothership / CI) — no runtime is
+		// consulted on this path, so DerivedFromRuntime MUST be false (#5568):
+		// the empty list is NOT a runtime observation, and the honest signal
+		// tells the FE to keep its legacy spec/status fallback rather than
+		// treat `targets: []` as an authoritative "no placement" verdict.
+		writeJSON(w, http.StatusOK, runtimePlacementResponse{Targets: []bpv1.PlacementTarget{}, DerivedFromRuntime: false})
 		return
 	}
 

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_test.go
@@ -381,3 +381,21 @@ func TestPlacementRuntime_Unknown_EmptyTargets(t *testing.T) {
 		t.Fatalf("derivedFromRuntime must be true even when empty")
 	}
 }
+
+// #5568 — the no-data-plane path (k8sCache == nil, pre-handover mothership / CI)
+// consults NO runtime, so it must report derivedFromRuntime=FALSE. Pairing an
+// empty target list with true there falsely asserts the emptiness was
+// runtime-observed. Distinct from Unknown_EmptyTargets above, where the cache IS
+// present and genuinely-empty → true is correct. Falsifiable: fails on the old
+// hardcoded `true`.
+func TestPlacementRuntime_NoDataPlane_NotDerived_5568(t *testing.T) {
+	// No SetK8sCache call → h.k8sCache stays nil.
+	h := NewWithPDM(quietHandlerLogger(), &fakePDM{})
+	resp := callPlacement(t, h, "dep-no-dataplane", "any-component")
+	if len(resp.Targets) != 0 {
+		t.Fatalf("no data plane: got %d targets want 0 (%+v)", len(resp.Targets), resp.Targets)
+	}
+	if resp.DerivedFromRuntime {
+		t.Fatalf("#5568: derivedFromRuntime must be FALSE when no runtime was consulted (k8sCache==nil), got true")
+	}
+}


### PR DESCRIPTION
## Refs #5568

### Defect
`GET /applications/{name}/placement` hardcoded `derivedFromRuntime: true` on **every** return path — including the `k8sCache == nil` path (pre-handover mothership / CI), which consults no runtime at all. Pairing `targets: []` with `derivedFromRuntime: true` there falsely asserts the empty list was runtime-observed, when the branch is taken precisely because it was not. The flag exists to let the FE distinguish real observed placement from the legacy spec/status fallback — and it could not fail. UAT row 55 leans on exactly this flag ("runtime-derived, not a build-time constant").

### Fix
The no-data-plane path (`applications_placement_runtime.go`, the `k8sCache == nil` branch) now returns `derivedFromRuntime: false` — honest: no runtime consulted, FE keeps its legacy fallback. The real path (cache present, live query) keeps `true`, **including when the query legitimately finds zero targets** — that IS a runtime observation. Struct comment corrected (it claimed "always true here").

### Test
New `TestPlacementRuntime_NoDataPlane_NotDerived_5568` (nil-cache handler → false). Falsifiable: fails on the old hardcoded `true` with the #5568 message. `TestPlacementRuntime_Unknown_EmptyTargets` (cache present, genuinely empty → true) still passes — the two cases are now correctly distinguished. Full placement suite + `go build ./...` green.
