### PR TITLE
fix(console): clear catalog IaC editor 'unsaved changes' after a successful commit (Refs #5610)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -659,6 +659,13 @@ export function CatalogDetail() {
               // #5496 — same key mismatch as refetchCatalog: the save above
               // already uses qualifiedName, so the invalidation must too.
               void qc.invalidateQueries({ queryKey: ['catalog-item', qualifiedName] })
+              // #5610 Facet B — re-baseline the editor to the just-committed YAML
+              // so its "unsaved changes" indicator clears on a SUCCESSFUL commit.
+              // YamlEditor's dirty state is `yaml !== initial`, and `initial` is a
+              // useMemo over seedYaml (= this committedIac). Without this the
+              // baseline stays the pre-commit value (the async catalog refetch may
+              // lag), so the badge stays lit though the commit landed durably.
+              setCommittedIac(yaml)
               return `Committed to IaC ✓ (${resp.path || 'catalog-sovereign'})`
             }}
           />


### PR DESCRIPTION
## Refs #5610 (Facet B — the residual after #5682 fixed Facet A)

### Defect
On Catalog → any Blueprint → **Edit IaC** → change a line → **Commit IaC**: the commit lands durably (`yaml-editor-apply-ok` shows "Committed to IaC ✓", `GET .../iac` returns `source: committed`), but the editor keeps its **"• unsaved changes"** badge lit. Reported as a wipe-anxiety surface — the operator can't tell the commit took.

### Root cause
`CatalogDetail.tsx` feeds the editor its baseline via `seedYaml={committedIac}`. YamlEditor's dirty state is `yaml.trim() !== initial.trim()` where `initial = useMemo(() => seedYaml || ..., [seedYaml])`. The `onCommit` handler invalidated the catalog query but **never updated `committedIac` to the just-committed YAML**, so the baseline stayed pre-commit and `yaml !== initial` kept the badge lit (the async catalog refetch that would eventually reset it may lag or not re-run its effect).

### Fix
`setCommittedIac(yaml)` in `onCommit` after a successful commit. This re-baselines `seedYaml` to the committed value → `initial` recomputes to it → since the editor's `yaml` already equals what was committed, `dirty` flips to false and the badge clears immediately. Traced through YamlEditor.tsx (`initial` useMemo:186, `dirty`:213, the seedYaml re-seed effect:199-203) to confirm it clears without stomping a genuine post-commit edit (the re-seed effect only replaces `yaml` when it still equals the prior seed).

### Verify
`tsc --noEmit` clean; `CatalogDetail.edit` + `CatalogDetail.merge-base-5510` suites green (18/18) — no regression to Facet A (#5682) or the #5510 merge-base. Live proof rides the next fresh-prov console bundle (commit an IaC edit, confirm the badge clears).
