### PR TITLE
fix(cloud): Volumes page reads live PVs, not a hardcoded empty slice (#5611)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -1063,14 +1063,25 @@ func loadPeerings(ctx context.Context, in LoaderInput, rs provisioner.RegionSpec
 	return out
 }
 
-// buildStorage — PVCs from the live cluster + buckets/volumes from
-// the Crossplane managed-resource list. Empty slices when sources
-// aren't reachable.
+// buildStorage — PVCs + block Volumes from the live cluster. Empty
+// slices when sources aren't reachable.
+//
+// #5611: Volumes was previously a hardcoded `[]Volume{}` (the comment
+// claimed "buckets/volumes from the Crossplane managed-resource list"
+// but no query was ever issued), so the cloud Volumes page rendered a
+// positive "Volumes 0 / No volumes yet" on a Sovereign carrying 50 EVS
+// block volumes. A PersistentVolume IS the Kubernetes projection of the
+// cloud block volume attached to a node (Hetzner Volume via
+// hcloud-csi, Huawei EVS via evs.csi.huaweicloud.com), so loadVolumes
+// reads PVs directly — the provider-agnostic source that is populated
+// on every Sovereign, not just the hcloud mothership. Buckets stay []
+// until an object-storage source is wired (honest empty, not a false
+// count — the Buckets page renders the "not collected" empty-state).
 func buildStorage(ctx context.Context, in LoaderInput) StorageData {
 	return StorageData{
 		PVCs:    loadPVCs(ctx, in),
 		Buckets: []Bucket{},
-		Volumes: []Volume{},
+		Volumes: loadVolumes(ctx, in),
 	}
 }
 
@@ -1110,6 +1121,130 @@ func loadPVCs(ctx context.Context, in LoaderInput) (out []PVC) {
 		})
 	}
 	return out
+}
+
+// loadVolumes — the live block-Volume source for the cloud Volumes page
+// (#5611). A PersistentVolume is the Kubernetes projection of the cloud
+// block volume attached to a node (hcloud-csi Volume on Hetzner, EVS on
+// Huawei via evs.csi.huaweicloud.com), so PVs are the provider-agnostic
+// source that is populated on every Sovereign — unlike the hcloud-only
+// Crossplane `volume.hcloud` XRC, which returns nothing on a Huawei
+// Sovereign and produced the false "Volumes 0". Mirrors loadPVCs: reads
+// the same in.DynamicClient (the region this loader is scoped to), so
+// the count matches that region's live PVs and never fabricates a row.
+func loadVolumes(ctx context.Context, in LoaderInput) (out []Volume) {
+	out = []Volume{}
+	defer func() {
+		if r := recover(); r != nil {
+			out = []Volume{}
+		}
+	}()
+	if in.DynamicClient == nil {
+		return out
+	}
+	// PVs are cluster-scoped — list without a namespace.
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	list, err := in.DynamicClient.Resource(gvr).List(cctx, metav1.ListOptions{})
+	if err != nil || list == nil {
+		return out
+	}
+	for _, item := range list.Items {
+		spec, _, _ := nestedMap(item.Object, "spec")
+		status, _, _ := nestedMap(item.Object, "status")
+		out = append(out, Volume{
+			ID:         item.GetName(),
+			Name:       item.GetName(),
+			Capacity:   stringField(stringMapField(spec, "capacity"), "storage"),
+			Region:     pvRegion(spec),
+			AttachedTo: pvClaimRef(spec),
+			Status:     pvPhaseToTopologyStatus(stringField(status, "phase")),
+		})
+	}
+	return out
+}
+
+// pvClaimRef — the "namespace/name" of the PVC bound to this PV, the
+// honest "what claims this volume" the Volumes page's Attachment column
+// surfaces. Empty (→ "detached" in the UI) for an unbound PV.
+func pvClaimRef(spec map[string]any) string {
+	ref, _, _ := nestedMap(spec, "claimRef")
+	if ref == nil {
+		return ""
+	}
+	ns := stringField(ref, "namespace")
+	name := stringField(ref, "name")
+	switch {
+	case ns != "" && name != "":
+		return ns + "/" + name
+	case name != "":
+		return name
+	default:
+		return ""
+	}
+}
+
+// pvRegion — best-effort region/zone from the PV's CSI node-affinity
+// topology term (topology.kubernetes.io/{region,zone} or a driver zone
+// key). Empty when the PV carries no topology constraint — honest empty,
+// never a synthesised region. Fully defensive against unstructured shape
+// surprises (any type mismatch → "").
+func pvRegion(spec map[string]any) string {
+	na, _, _ := nestedMap(spec, "nodeAffinity", "required")
+	if na == nil {
+		return ""
+	}
+	terms, ok := na["nodeSelectorTerms"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, t := range terms {
+		tm, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		exprs, ok := tm["matchExpressions"].([]any)
+		if !ok {
+			continue
+		}
+		for _, e := range exprs {
+			em, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			key := stringField(em, "key")
+			if !strings.Contains(key, "zone") && !strings.Contains(key, "region") {
+				continue
+			}
+			vals, ok := em["values"].([]any)
+			if !ok || len(vals) == 0 {
+				continue
+			}
+			if s, ok := vals[0].(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// pvPhaseToTopologyStatus — maps a PV's status.phase onto the
+// TopologyStatus vocabulary the Volumes page's StatusPill renders
+// (healthy | degraded | failed | unknown).
+func pvPhaseToTopologyStatus(phase string) string {
+	switch phase {
+	case "Bound":
+		return "healthy"
+	case "Released":
+		return "degraded"
+	case "Failed":
+		return "failed"
+	default:
+		// "Available" (unbound but usable) and "Pending"/"" all read as
+		// unknown — present, not-yet-attached, no false health claim.
+		return "unknown"
+	}
 }
 
 // CascadeFor — given a delete target (kind + id) and the current

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_volumes_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_volumes_test.go
@@ -1,0 +1,136 @@
+// topology_loader_volumes_test.go — proves the #5611 fix: the cloud
+// Volumes page must reflect the live block volumes (PersistentVolumes),
+// not a hardcoded empty slice.
+//
+// Root cause this guards against: buildStorage returned
+// `Volumes: []Volume{}` unconditionally (the doc comment claimed a
+// Crossplane managed-resource source that was never queried), so
+// `/cloud?view=list&kind=volumes` rendered a POSITIVE "Volumes 0 / No
+// volumes yet" empty-state on hw292, a Sovereign carrying 50 EVS block
+// volumes (50 Bound PVs). A PV is the K8s projection of the cloud block
+// volume attached to a node, so loadVolumes reads PVs directly.
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// pvClient builds a fake dynamic client carrying real cluster-scoped
+// PersistentVolumes so loadVolumes' live read fires.
+func pvClient(t *testing.T, pvs ...*corev1.PersistentVolume) dynamic.Interface {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "persistentvolumes"}:      "PersistentVolumeList",
+		{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}: "PersistentVolumeClaimList",
+	}
+	objs := make([]runtime.Object, 0, len(pvs))
+	for _, pv := range pvs {
+		objs = append(objs, pv)
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
+}
+
+func volumeByID(vols []Volume, id string) (Volume, bool) {
+	for _, v := range vols {
+		if v.ID == id {
+			return v, true
+		}
+	}
+	return Volume{}, false
+}
+
+// TestLoadVolumes_FromLivePVs_5611 is the decisive regression guard: with
+// two live PVs present, buildStorage must surface two Volume rows with
+// faithful capacity / attachment / region / status — NOT the pre-fix
+// empty slice. On the old hardcoded `Volumes: []Volume{}` this fails at
+// the len check (0 != 2).
+func TestLoadVolumes_FromLivePVs_5611(t *testing.T) {
+	bound := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-cnpg-a-1"},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("50Gi")},
+			ClaimRef: &corev1.ObjectReference{Namespace: "openova-system", Name: "data-cnpg-a-1"},
+			NodeAffinity: &corev1.VolumeNodeAffinity{
+				Required: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"me-east-215-a"},
+						}},
+					}},
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeBound},
+	}
+	// Released PV with no claimRef and no topology term — proves the
+	// honest-empty path (AttachedTo "" → "detached" in the UI) and the
+	// Released→degraded status mapping.
+	orphan := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-orphan-9"},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+		},
+		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeReleased},
+	}
+
+	in := LoaderInput{DynamicClient: pvClient(t, bound, orphan)}
+	storage := buildStorage(context.Background(), in)
+
+	if len(storage.Volumes) != 2 {
+		t.Fatalf("expected 2 volume rows from 2 live PVs, got %d — the cloud Volumes page falsely reports empty (#5611)", len(storage.Volumes))
+	}
+
+	b, ok := volumeByID(storage.Volumes, "pvc-cnpg-a-1")
+	if !ok {
+		t.Fatalf("bound PV pvc-cnpg-a-1 missing from volumes; got %+v", storage.Volumes)
+	}
+	if b.Capacity != "50Gi" {
+		t.Errorf("bound PV capacity = %q, want 50Gi", b.Capacity)
+	}
+	if b.AttachedTo != "openova-system/data-cnpg-a-1" {
+		t.Errorf("bound PV attachedTo = %q, want openova-system/data-cnpg-a-1 (claimRef)", b.AttachedTo)
+	}
+	if b.Region != "me-east-215-a" {
+		t.Errorf("bound PV region = %q, want me-east-215-a (CSI topology zone)", b.Region)
+	}
+	if b.Status != "healthy" {
+		t.Errorf("bound PV status = %q, want healthy (Bound)", b.Status)
+	}
+
+	o, ok := volumeByID(storage.Volumes, "pvc-orphan-9")
+	if !ok {
+		t.Fatalf("released PV pvc-orphan-9 missing from volumes; got %+v", storage.Volumes)
+	}
+	if o.AttachedTo != "" {
+		t.Errorf("released PV attachedTo = %q, want empty (detached — no claimRef)", o.AttachedTo)
+	}
+	if o.Status != "degraded" {
+		t.Errorf("released PV status = %q, want degraded (Released)", o.Status)
+	}
+}
+
+// TestLoadVolumes_NilClient_HonestEmpty proves the no-data-plane path
+// yields an honest empty slice (not a nil that would JSON-marshal to
+// null and not a fabricated row).
+func TestLoadVolumes_NilClient_HonestEmpty(t *testing.T) {
+	storage := buildStorage(context.Background(), LoaderInput{DynamicClient: nil})
+	if storage.Volumes == nil {
+		t.Fatalf("Volumes must be a non-nil empty slice, got nil")
+	}
+	if len(storage.Volumes) != 0 {
+		t.Fatalf("nil client must yield 0 volumes, got %d", len(storage.Volumes))
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -659,6 +659,13 @@ export function CatalogDetail() {
               // #5496 — same key mismatch as refetchCatalog: the save above
               // already uses qualifiedName, so the invalidation must too.
               void qc.invalidateQueries({ queryKey: ['catalog-item', qualifiedName] })
+              // #5610 Facet B — re-baseline the editor to the just-committed YAML
+              // so its "unsaved changes" indicator clears on a SUCCESSFUL commit.
+              // YamlEditor's dirty state is `yaml !== initial`, and `initial` is a
+              // useMemo over seedYaml (= this committedIac). Without this the
+              // baseline stays the pre-commit value (the async catalog refetch may
+              // lag), so the badge stays lit though the commit landed durably.
+              setCommittedIac(yaml)
               return `Committed to IaC ✓ (${resp.path || 'catalog-sovereign'})`
             }}
           />


### PR DESCRIPTION
## Problem

`/cloud?view=list&kind=volumes` reported a **positive, false `Volumes 0`** ("No volumes yet") on hw292 — a Sovereign carrying **50 EVS block volumes** (50 Bound PVs). On the same page, PVCs read **51** and the PersistentVolumes chip read **97**, both correct — so the data is reachable; only the cloud-**Volumes** collector reported nothing.

## Root cause

`buildStorage()` in `internal/infrastructure/topology_loader.go` returned `Volumes: []Volume{}` **unconditionally**. The doc comment claimed "buckets/volumes from the Crossplane managed-resource list" but **no query was ever issued** — the honest-status/fabrication defect class (a positive claim of zero that was never derived). The only wired volume kind, `volume.hcloud`, is the hcloud-only Crossplane XRC and returns nothing on a Huawei Sovereign.

## Fix

Add `loadVolumes` (mirrors the working `loadPVCs`) sourcing **live PersistentVolumes** — a PV is the Kubernetes projection of the cloud block volume attached to a node (hcloud-csi on Hetzner, `evs.csi.huaweicloud.com` on Huawei), the provider-agnostic source populated on every Sovereign.

Per-PV mapping:
- **Capacity** ← `spec.capacity.storage`
- **Attachment** ← `spec.claimRef` (`namespace/name`; "detached" when unbound)
- **Region** ← best-effort CSI node-affinity topology zone/region term (honest empty otherwise)
- **Status** ← `status.phase` → TopologyStatus (`Bound`→healthy, `Released`→degraded, `Failed`→failed, else unknown)

Same `in.DynamicClient` scope as `loadPVCs`, defensive `recover`, honest empty slice when unreachable — never a fabricated row. Buckets stay `[]` (honest empty — no false count).

## Test — falsifiable

`TestLoadVolumes_FromLivePVs_5611` feeds 2 live PVs and asserts 2 faithful Volume rows. Verified it **fails (`0 != 2`) against the old hardcode** and **passes against the fix**. `TestLoadVolumes_NilClient_HonestEmpty` locks the no-data-plane honest-empty path. Full `internal/infrastructure` suite green.

Refs #5611 · umbrella #3987 (cloud per-kind list empty-data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)