### PR TITLE
fix(marketplace): redeem consults the cookie session, not the per-origin token (#5421)

### DIFF
--- a/core/marketplace/src/lib/redeemOwnerGate.test.ts
+++ b/core/marketplace/src/lib/redeemOwnerGate.test.ts
@@ -1,0 +1,30 @@
+// redeemOwnerGate.test.ts — #5421 (UAT row 3).
+//
+// The decisive assertion is the cookie-only owner: token ABSENT + not
+// opted out must still consult the server. Against the pre-fix gate
+// (`funnel when !token || skip`) this case returned 'funnel' — the exact
+// bug that showed an authed owner the anonymous signup funnel. Both the
+// opt-out and the token-present paths are asserted too, so a gate that
+// unconditionally returns 'consult-server' would not pass either.
+
+import { describe, expect, it } from 'vitest';
+
+import { redeemOwnerGate } from './redeemOwnerGate';
+
+describe('redeemOwnerGate', () => {
+  it('consults the server for a cookie-only owner (no marketplace-origin token) — #5421', () => {
+    // The #5421 owner: authed on the console origin, so the marketplace
+    // origin has no org-token, but the catalyst_session cookie is present.
+    // Pre-fix this returned 'funnel' (owner trapped on the anonymous funnel).
+    expect(redeemOwnerGate({ token: '', skipConsoleRedirect: false })).toBe('consult-server');
+  });
+
+  it('bails to the funnel for a demo/partner opt-out tenant regardless of session', () => {
+    expect(redeemOwnerGate({ token: 'a-real-token', skipConsoleRedirect: true })).toBe('funnel');
+    expect(redeemOwnerGate({ token: '', skipConsoleRedirect: true })).toBe('funnel');
+  });
+
+  it('consults the server when a token IS present and not opted out (unchanged owner path)', () => {
+    expect(redeemOwnerGate({ token: 'a-real-token', skipConsoleRedirect: false })).toBe('consult-server');
+  });
+});

--- a/core/marketplace/src/lib/redeemOwnerGate.ts
+++ b/core/marketplace/src/lib/redeemOwnerGate.ts
@@ -1,0 +1,52 @@
+// redeemOwnerGate — the ownership pre-check gate for the voucher redeem
+// page (#5421, UAT row 3).
+//
+// The bug this fixes: the redeem page decided "am I a returning owner?"
+// from the marketplace-origin `localStorage['org-token']` alone, bailing
+// straight to the anonymous signup funnel when that token was absent.
+// But an owner authenticates on the CONSOLE origin
+// (`console.<slug>.<sov>`), so the MARKETPLACE origin
+// (`marketplace.<sov>`) legitimately has no `org-token` in its per-origin
+// localStorage — no matter how valid the session is. The session that
+// actually spans both subdomains is the `catalyst_session` cookie
+// (scoped to `.<sov>` path `/`), which the same-origin `/api/tenant/orgs`
+// request carries by default. Gating on the token therefore made the
+// page structurally unable to see a cookie-borne owner, so an authed
+// owner opening a redeem link was shown the anonymous funnel instead of
+// being handed to their dashboard.
+//
+// The fix: the gate must NOT depend on the localStorage token. It only
+// bails to the funnel for the demo/partner opt-out (skipConsoleRedirect
+// tenants deliberately keep returning visitors ON the marketplace).
+// Otherwise it returns 'consult-server' so init() asks getMyOrgs()
+// (which carries the cookie) — and only falls back to the funnel when the
+// server confirms no live Organization (unauthenticated / mid-signup) or
+// the call errors. Anonymous visitors thus incur one extra /tenant/orgs
+// probe that 401s and funnels; an owner is never trapped on the funnel.
+
+export type RedeemGate = 'funnel' | 'consult-server';
+
+export interface RedeemGateInput {
+  /**
+   * The marketplace-origin `org-token`. Deliberately NOT used to decide
+   * the gate (see module doc) — it is accepted only so the call site and
+   * this contract document that its absence must NOT short-circuit to the
+   * funnel.
+   */
+  token: string;
+  /** Demo/partner tenants that opt out of the console redirect entirely. */
+  skipConsoleRedirect: boolean;
+}
+
+export function redeemOwnerGate(input: RedeemGateInput): RedeemGate {
+  // Honour the same opt-out the shared Layout redirect respects: these
+  // tenants deliberately keep returning visitors on the marketplace, so
+  // never bounce them to a console — regardless of session.
+  if (input.skipConsoleRedirect) return 'funnel';
+
+  // #5421: do NOT gate on input.token. A cookie-only owner has no
+  // marketplace-origin token yet must still be detected server-side, so
+  // always consult the server. The caller runs the funnel only if the
+  // server confirms no live Org (or the call errors).
+  return 'consult-server';
+}

--- a/core/marketplace/src/pages/redeem.astro
+++ b/core/marketplace/src/pages/redeem.astro
@@ -145,6 +145,10 @@ import Layout from '../layouts/Layout.astro';
     // imports resolve. No new session mechanism is introduced.
     import { getMyOrgs, setActiveOrgConsoleHost } from '../lib/api';
     import { consoleLaunchHref } from '../lib/config';
+    // #5421 (UAT row 3): the owner pre-check gate lives in a plain module so it
+    // can be unit-tested. Ownership must NOT be gated on the marketplace-origin
+    // localStorage token — a cookie-borne owner has none there.
+    import { redeemOwnerGate } from '../lib/redeemOwnerGate';
     // #5634 (UAT row 92): the response-to-panel decision lives in a plain module
     // so it can be unit-tested; this page keeps only the DOM writes that need the
     // response body.
@@ -239,13 +243,16 @@ import Layout from '../layouts/Layout.astro';
     // AUTHORITATIVELY and performs the redirect itself, so an owner is never
     // trapped on the funnel regardless of the shared script's timing.
     //
-    // Personas (identical gate to Layout's returning-user redirect):
-    //   - no org-token                 → unauthenticated → public funnel (unchanged)
-    //   - org-token + >=1 live Org      → OWNER → hand off to console, NEVER funnel
-    //   - org-token + 0 live Orgs       → signed-in mid-signup (no workspace yet)
+    // #5421 (UAT row 3): ownership is decided by the SERVER (getMyOrgs, which
+    // carries the cross-subdomain `catalyst_session` cookie), NOT by the
+    // marketplace-origin localStorage token — an owner authenticates on the
+    // console origin, so that token is legitimately absent here. Personas:
+    //   - skipConsoleRedirect tenant   → funnel (demo/partner opt-out, unchanged)
+    //   - session with >=1 live Org     → OWNER → hand off to console, NEVER funnel
+    //   - session with 0 live Orgs      → signed-in mid-signup (no workspace yet)
     //                                     → funnel, so they can still redeem
-    //   - org-token but /tenant/orgs errors (expired / API down) → cannot confirm
-    //                                     ownership → funnel, so they are not trapped
+    //   - no session / /tenant/orgs errors (anon / expired / API down) → cannot
+    //                                     confirm ownership → funnel (401 lands here)
     async function init() {
       // Honour the same demo/partner opt-out the Layout redirect respects: those
       // tenants deliberately keep returning visitors ON the marketplace, so we
@@ -256,16 +263,21 @@ import Layout from '../layouts/Layout.astro';
 
       var token = '';
       try { token = localStorage.getItem('org-token') || ''; } catch (_) {}
-      if (!token || skipConsoleRedirect) {
+      // Gate on the opt-out only — NEVER on token presence (#5421). A cookie-borne
+      // owner has no marketplace-origin token; bailing on `!token` is exactly the
+      // bug that showed authed owners the anonymous funnel.
+      if (redeemOwnerGate({ token: token, skipConsoleRedirect: skipConsoleRedirect }) === 'funnel') {
         runFunnel();
         return;
       }
 
-      // Signed in: show a neutral "redirecting…" shim (never the funnel) while
-      // we confirm ownership, suppressing any funnel flash.
+      // Consult the server: show a neutral shim (never the funnel) while we
+      // confirm ownership from the cookie-borne session, suppressing any funnel
+      // flash for an owner. A genuinely anonymous visitor 401s below and falls
+      // through to the funnel.
       show('redeem-loading');
       var loadingCopy = document.querySelector('#redeem-loading p');
-      if (loadingCopy) loadingCopy.textContent = 'Taking you to your dashboard…';
+      if (loadingCopy) loadingCopy.textContent = 'One moment…';
 
       let orgs;
       try {


### PR DESCRIPTION
## Problem (UAT row 3, hw290)

An authenticated **owner** opening `https://marketplace.<sov>/redeem/?code=…` was shown the **anonymous signup funnel** instead of being handed to their dashboard. Same browser context: console `whoami` returns `tier=owner` and the `catalyst_session` cookie is present and in scope for the marketplace host — so the session **is** there; the page just never asks the server about it.

## Root cause

`redeem.astro`'s `init()` decided ownership from the marketplace-origin `localStorage['org-token']` and returned to `runFunnel()` when it was absent — *before* `getMyOrgs()` (the call that would actually establish ownership) was ever reached. Two facts make that probe structurally unable to see the owner:

1. **`localStorage` is per-origin.** The owner authenticates at `console.<slug>.<sov>`; the redeem page runs at `marketplace.<sov>`. Separate origins → separate localStorage → `org-token` legitimately absent.
2. **The session that spans both is the cookie.** `catalyst_session` is scoped to `.<sov>` path `/`, which the same-origin `/api/tenant/orgs` request carries by default — but the page short-circuited before making it.

## Fix

Extract the pre-check into a unit-testable `redeemOwnerGate` helper that bails to the funnel **only** for the demo/partner opt-out (`skipConsoleRedirect`) — **never** on token presence. `init()` otherwise shows a neutral shim and consults `getMyOrgs()` (cookie-borne), running the funnel only when the server confirms **no live Org** (unauthenticated / mid-signup) or the call errors. Anonymous visitors incur one extra `/tenant/orgs` probe that 401s and funnels; an owner is never trapped on the funnel. No new session mechanism, no server change — the cookie was already sent; the client just needed to stop pre-empting it.

## Test — falsifiable

`redeemOwnerGate.test.ts` asserts the cookie-only-owner case (`token:''`, not opted out) returns `'consult-server'`. Verified it **fails against the pre-fix gate** (`funnel when !token || skip`) and **passes against the fix**. Opt-out + token-present paths asserted too (so an always-`consult-server` stub wouldn't pass). Full marketplace vitest (19) + `astro build` + domain-hygiene postbuild all green.

Refs #5421 (Pillar 1 — marketplace onboarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)