### PR TITLE
fix(catalyst-api): chroot secondary regions no longer drop out of /k8s/stream fan-out

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/k8s.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s.go
@@ -97,9 +97,9 @@ func (h *Handler) HandleK8sList(w http.ResponseWriter, r *http.Request) {
 		// Helpful 404 lists every registered kind. Shaped this
 		// way so `curl /...invalid` self-documents the registry.
 		writeJSON(w, http.StatusNotFound, map[string]any{
-			"error":            "unknown kind",
-			"kind":             kindName,
-			"availableKinds":   h.k8sCache.Registry().Names(),
+			"error":          "unknown kind",
+			"kind":           kindName,
+			"availableKinds": h.k8sCache.Registry().Names(),
 		})
 		return
 	}
@@ -945,13 +945,47 @@ func (h *Handler) k8sCacheHasCluster(id string) bool {
 // hw136 + two already-wiped deployments whose stale cluster IDs had not
 // been evicted. Scoping the fan-out to the requested deployment's own
 // cluster-id prefix fixes the cross-deployment leak at the read tier
-// (the eviction half is fixed in k8scache's rescan-prune loop). The
-// chroot post-cutover case is unaffected: there every registered cluster
-// IS this Sovereign's (one primary + its secondaries, all sharing the
-// resolved id prefix), so the same prefix scope keeps the full set.
+// (the eviction half is fixed in k8scache's rescan-prune loop).
+//
+// #5571 — the doc comment above previously claimed "the chroot post-
+// cutover case is unaffected: there every registered cluster IS this
+// Sovereign's ... all sharing the resolved id prefix". That assumption is
+// FALSE whenever buildChrootClusterRef falls back to the
+// SOVEREIGN_FQDN-derived alias ("sovereign-<fqdn>") for the self-
+// registered primary — documented there as the TYPICAL post-cutover case,
+// since CATALYST_SELF_DEPLOYMENT_ID is usually never stamped on the
+// chroot. Every secondary kubeconfig FILE on disk keeps the real
+// deployment-id convention ("<depID>-<region>.yaml",
+// k8scache.LoadClustersFromDir stem), so "sovereign-<fqdn>" shares no
+// prefix with "<depID>-<region>" and the loop below silently excluded
+// EVERY secondary region — the "one region only, no region label" read
+// this issue reports (hw291: NetworkPolicies/CiliumNetworkPolicies
+// streams/lists silently returning exactly one region's count instead of
+// the Sovereign-wide set).
+//
+// Chroot mode has no cross-deployment leak risk to guard against in the
+// first place: a chroot's k8sCache is only EVER populated by (a) this
+// same Sovereign's self-registration and (b) this same Sovereign's own
+// posted-back secondary kubeconfigs (SelfHealSecondaryKubeconfigsOnDisk /
+// HandleSovereignSecondaryKubeconfig) — no other code path adds a cluster
+// to a chroot's cache. The #3987 leak is a MOTHERSHIP-ONLY problem (one
+// process manages MANY deployments' clusters at once), so on the chroot
+// we return every registered cluster unconditionally instead of relying
+// on a prefix match that the alias-vs-depID naming mismatch can break.
 func (h *Handler) deploymentScopedClusterIDs(resolvedID string) []string {
 	out := []string{resolvedID}
 	if h.k8sCache == nil {
+		return out
+	}
+	if isChroot() {
+		seen := map[string]struct{}{resolvedID: {}}
+		for _, cid := range h.k8sCache.Clusters() {
+			if _, ok := seen[cid]; ok {
+				continue
+			}
+			seen[cid] = struct{}{}
+			out = append(out, cid)
+		}
 		return out
 	}
 	prefix := resolvedID + "-"

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_scope_test.go
@@ -84,3 +84,54 @@ func TestDeploymentScopedClusterIDs_ExcludesSiblingAndWipedDeployments(t *testin
 		}
 	}
 }
+
+// TestDeploymentScopedClusterIDs_ChrootAliasMismatchStillIncludesSecondary
+// — #5571.
+//
+// On the CHROOT (SOVEREIGN_FQDN set), buildChrootClusterRef self-registers
+// the primary cluster under a "sovereign-<fqdn>" alias whenever
+// CATALYST_SELF_DEPLOYMENT_ID isn't stamped — documented in
+// buildChrootClusterRef as the TYPICAL post-cutover case. Secondary
+// kubeconfig FILES on disk keep the real deployment-id convention
+// ("<depID>-<region>", k8scache.LoadClustersFromDir stem). Neither string
+// is a prefix of the other, so a pure prefix-based scope silently drops
+// the secondary region — exactly the "one region only, no region label"
+// defect this issue reports (hw291 NetworkPolicies/CiliumNetworkPolicies
+// streams returning exactly one region's count).
+//
+// Chroot mode carries none of #3987's cross-deployment leak risk (a
+// chroot's k8sCache is only ever populated by this ONE Sovereign's own
+// self-registration + its own posted-back secondaries), so scoping to
+// "every registered cluster" is correct by construction there.
+func TestDeploymentScopedClusterIDs_ChrootAliasMismatchStillIncludesSecondary(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	const (
+		selfAlias   = "sovereign-t99.omani.works"    // buildChrootClusterRef fallback id
+		realDepID   = "7bb723da8da06047"             // the mothership-issued deployment id
+		secondaryID = realDepID + "-me-east-215-b-1" // on-disk secondary kubeconfig stem
+	)
+
+	cache := newK8sCacheWithClusters(t, map[string]*dynamicfake.FakeDynamicClient{
+		selfAlias:   fakeHRDynamicClient(t),
+		secondaryID: fakeHRDynamicClient(t),
+	})
+
+	h := &Handler{
+		log:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		k8sCache: cache,
+	}
+
+	got := h.deploymentScopedClusterIDs(selfAlias)
+	sort.Strings(got)
+	want := []string{secondaryID, selfAlias}
+
+	if len(got) != len(want) {
+		t.Fatalf("chroot alias-mismatch scope dropped the secondary region: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chroot alias-mismatch scope mismatch: got %v, want %v", got, want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_test.go
@@ -317,6 +317,145 @@ func TestHandleK8sStream_EmitsEvent(t *testing.T) {
 	}
 }
 
+// TestHandleK8sStream_ChrootFanOutAcrossAliasMismatchedSecondary — #5571.
+//
+// End-to-end proof that /k8s/stream fans the SSE initial-state snapshot
+// out across EVERY registered cluster on a chroot, even when the
+// self-registered primary carries the "sovereign-<fqdn>" alias
+// (buildChrootClusterRef's fallback when CATALYST_SELF_DEPLOYMENT_ID
+// isn't stamped — documented there as the TYPICAL post-cutover shape) and
+// the secondary kubeconfig is registered under the unrelated real-depID
+// convention ("<depID>-<region>"). Before the #5571 fix,
+// deploymentScopedClusterIDs prefix-matched "<resolvedID>-" against the
+// registered cluster ids; "sovereign-<fqdn>-" never matches
+// "<depID>-<region>", so the secondary region's objects never reached the
+// stream — the Cloud NetworkPolicy/CiliumNetworkPolicy pages silently
+// rendered one region's set with no region label to reveal the omission.
+func TestHandleK8sStream_ChrootFanOutAcrossAliasMismatchedSecondary(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	const (
+		selfAlias   = "sovereign-t99.omani.works"
+		realDepID   = "7bb723da8da06047"
+		secondaryID = realDepID + "-me-east-215-b-1"
+	)
+
+	podA := newPod("default", "region-a-pod")
+	podB := newPod("default", "region-b-pod")
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "PodList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, &unstructured.Unstructured{})
+	gvrList := map[schema.GroupVersionResource]string{
+		{Version: "v1", Resource: "pods"}: "PodList",
+	}
+	dynA := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrList, podA)
+	dynB := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrList, podB)
+
+	cfg := k8scache.Config{
+		Logger:   quietLog(),
+		Registry: minimalRegistry(),
+		Clusters: []k8scache.ClusterRef{
+			{ID: selfAlias, DynamicClient: dynA, CoreClient: kfake.NewSimpleClientset()},
+			{ID: secondaryID, DynamicClient: dynB, CoreClient: kfake.NewSimpleClientset()},
+		},
+	}
+	f, err := k8scache.NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(f.Stop)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ia, _, _ := f.List(selfAlias, "pod", nil)
+		ib, _, _ := f.List(secondaryID, "pod", nil)
+		if len(ia) == 1 && len(ib) == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	h := &Handler{log: quietLog()}
+	h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
+	r := newRouter(h)
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// The URL id doesn't have to match either registered cluster — the
+	// chroot path aliases any unresolved id onto the self-registered
+	// cluster (resolveChrootClusterID), same as a real browser hitting
+	// /sovereigns/<mother-issued-id>/k8s/stream post-cutover.
+	resp, err := http.Get(srv.URL + "/api/v1/sovereigns/anything/k8s/stream?kinds=pod&initialState=1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	seenClusters := map[string]bool{}
+	seenNames := map[string]bool{}
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		br := bufio.NewReader(resp.Body)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+			var ev struct {
+				Cluster string `json:"cluster"`
+				Kind    string `json:"kind"`
+				Type    string `json:"type"`
+				Object  struct {
+					Metadata struct {
+						Name string `json:"name"`
+					} `json:"metadata"`
+				} `json:"object"`
+			}
+			if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+				continue
+			}
+			if ev.Kind != "pod" || ev.Type != "ADDED" {
+				continue
+			}
+			seenClusters[ev.Cluster] = true
+			seenNames[ev.Object.Metadata.Name] = true
+			if seenClusters[selfAlias] && seenClusters[secondaryID] {
+				return
+			}
+		}
+	}()
+	select {
+	case <-doneCh:
+	case <-time.After(3 * time.Second):
+		_ = resp.Body.Close()
+	}
+
+	if !seenClusters[selfAlias] {
+		t.Fatalf("expected an event from the self-registered alias cluster %q; got clusters=%v names=%v",
+			selfAlias, seenClusters, seenNames)
+	}
+	if !seenClusters[secondaryID] {
+		t.Fatalf("#5571 REGRESSION: no event from the alias-mismatched secondary cluster %q — "+
+			"the stream fanned out to only ONE region; got clusters=%v names=%v",
+			secondaryID, seenClusters, seenNames)
+	}
+	if !seenNames["region-a-pod"] || !seenNames["region-b-pod"] {
+		t.Fatalf("expected both region-a-pod and region-b-pod; got names=%v", seenNames)
+	}
+}
+
 // keep metav1 imported even if a future test refactor drops the
 // explicit reference.
 var _ = metav1.GetOptions{}


### PR DESCRIPTION
## Summary

`GET /api/v1/sovereigns/{id}/k8s/stream` (and its List sibling) on a
post-cutover chroot Sovereign can silently drop every secondary region from
the fan-out, so the Cloud NetworkPolicies / CiliumNetworkPolicies pages (and
any other `/k8s/{kind}` or `/k8s/stream` consumer) present one region's set
as the whole Sovereign estate with no region label to reveal the omission.

## What I found (correcting the issue's premise)

#5571's evidence quoted `grep -cE 'secondaryKubeconfig|forEachCluster|allClusters|clusterIDs' k8s.go` returning `0` and concluded there is no fan-out at
all. That grep is a false negative: it's case-sensitive and the actual helper
is `deploymentScopedClusterIDs` (capital `C`), which already drives a
multi-region fan-out in **both** `HandleK8sList` and `HandleK8sStream`,
shipped by #4042 back on 2026-06-21 — well before this issue was filed. The
SSE `k8scache.Event` wire shape also already carries a `cluster` field
per-event, and `HandleK8sList`'s flatten step already stamps a `cluster` key
onto each row when more than one cluster contributes.

So item (1) of the issue's proposed fix ("fan the stream out, tag each event
with its region") is **already implemented**. Re-shipping it would be theater.

## The actual remaining gap

`deploymentScopedClusterIDs(resolvedID)` scopes the fan-out by requiring
every other registered cluster id to be prefixed `"<resolvedID>-"`. On the
chroot (`SOVEREIGN_FQDN` set), `buildChrootClusterRef` self-registers the
primary under a `"sovereign-<fqdn>"` alias whenever
`CATALYST_SELF_DEPLOYMENT_ID` isn't stamped — documented in that function as
the **typical** post-cutover case. Secondary kubeconfig **files** on disk
keep the real deployment-id convention (`"<depID>-<region>"`,
`k8scache.LoadClustersFromDir` stem). Neither string is a prefix of the
other, so the prefix match silently excludes every secondary region — the
exact "one region only, no region label" symptom reported on hw291
(NetworkPolicies stream returning 25 vs 31 live; CiliumNetworkPolicies 40 vs
47), independent of which physical region ends up excluded.

`deploymentScopedClusterIDs`'s own doc comment claimed the chroot case was
"unaffected... every registered cluster IS this Sovereign's... all sharing
the resolved id prefix" — that assumption is what breaks. It also doesn't
need to hold: chroot mode carries none of #3987's cross-deployment leak risk
(a chroot's k8sCache is only ever populated by this one Sovereign's own
self-registration + its own posted-back secondary kubeconfigs — no other
code path adds a cluster to a chroot's cache). So on the chroot (guarded by
the existing `isChroot()` helper) we now return every registered cluster
unconditionally; the mothership path (one process, many deployments sharing
the cache) keeps the prior prefix-scoped behavior unchanged, preserving the
#3987 sibling-leak guard there.

## Changes

- `products/catalyst/bootstrap/api/internal/handler/k8s.go` —
  `deploymentScopedClusterIDs`: chroot branch returns every registered
  cluster; mothership branch unchanged.
- `products/catalyst/bootstrap/api/internal/handler/k8s_scope_test.go` —
  `TestDeploymentScopedClusterIDs_ChrootAliasMismatchStillIncludesSecondary`.
- `products/catalyst/bootstrap/api/internal/handler/k8s_test.go` —
  `TestHandleK8sStream_ChrootFanOutAcrossAliasMismatchedSecondary` (SSE
  end-to-end: `initialState=1` must emit ADDED events from both the
  alias-registered primary and the depID-registered secondary).

## Falsifiability

Both new tests **FAIL** against the pre-fix code (verified by reverting
`k8s.go` only, keeping the tests, and re-running) and **PASS** against the
fix:

```
=== RUN   TestDeploymentScopedClusterIDs_ChrootAliasMismatchStillIncludesSecondary
    k8s_scope_test.go:130: chroot alias-mismatch scope dropped the secondary region: got [sovereign-t99.omani.works], want [7bb723da8da06047-me-east-215-b-1 sovereign-t99.omani.works]
--- FAIL: TestDeploymentScopedClusterIDs_ChrootAliasMismatchStillIncludesSecondary (0.00s)
=== RUN   TestHandleK8sStream_ChrootFanOutAcrossAliasMismatchedSecondary
    k8s_test.go:450: #5571 REGRESSION: no event from the alias-mismatched secondary cluster "7bb723da8da06047-me-east-215-b-1" — the stream fanned out to only ONE region; got clusters=map[sovereign-t99.omani.works:true] names=map[region-a-pod:true]
--- FAIL: TestHandleK8sStream_ChrootFanOutAcrossAliasMismatchedSecondary (3.02s)
```

## Gates

- `go build ./...` — green
- `go vet ./internal/handler/` — clean
- `go test ./internal/handler/ -count=1` — `ok` (full package, 253.6s)

## Scope note — deferred UI work

The issue also asks for (2) a region column/filter on the Cloud
NetworkPolicies/CiliumNetworkPolicies pages and (3) an explicit
partial-result marker as a fallback. This PR fixes the server-side
correctness bug (the read path was actually dropping data, not just failing
to label it). The region **data** is now present and already stamped
(`cluster`/`region` keys) on both the List and Stream wire shapes for any
Sovereign hitting this exact chroot-alias scenario. Wiring an explicit
region column into
`products/catalyst/bootstrap/ui/src/pages/sovereign/` for the
NetworkPolicies/CiliumNetworkPolicies pages specifically is left as a
follow-up — it's a UI-only change independent of this fix and shouldn't
block landing the correctness fix.

Refs #5571
