### PR TITLE
fix(stalwart-sovereign): explicit nodePort:0 on mail LoadBalancer (§854/#5348)

### DIFF
--- a/platform/stalwart-sovereign/blueprint.yaml
+++ b/platform/stalwart-sovereign/blueprint.yaml
@@ -24,8 +24,9 @@ spec:
   #     `catalyst-openova-kc-credentials` chart-rendered Secret via
   #     Helm `lookup`). NO Keycloak OIDC — Console is the only client.
   #
+  # 0.1.1 (#5690) — §854/#5348 mail-LoadBalancer nodePort:0 hardening.
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: Stalwart (Sovereign Console mail)
     summary: |

--- a/platform/stalwart-sovereign/chart/Chart.yaml
+++ b/platform/stalwart-sovereign/chart/Chart.yaml
@@ -32,8 +32,14 @@ name: bp-stalwart-sovereign
 #   has not yet rendered (e.g. operator opted out or a Sovereign was
 #   provisioned before this slot existed).
 #
+# 0.1.1 (#5690) — §854/#5348 hardening: the public mail LoadBalancer Service
+# (service-mail.yaml) now states allocateLoadBalancerNodePorts:false + an
+# explicit nodePort:0 on every port, and hard-fails on service.mail.type=
+# NodePort — mirroring the bp-stalwart-tenant guard. Prevents the apiserver
+# from silently auto-allocating a nodePort per mail port on apply.
+#
 # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.16.3"
 description: |
   Catalyst Blueprint scratch chart for the Sovereign-local Stalwart

--- a/platform/stalwart-sovereign/chart/templates/service-mail.yaml
+++ b/platform/stalwart-sovereign/chart/templates/service-mail.yaml
@@ -25,7 +25,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.mail.type }}
+  {{- $svcType := .Values.service.mail.type | default "LoadBalancer" }}
+  {{- if eq $svcType "NodePort" }}
+  {{- fail "bp-stalwart-sovereign: service.mail.type=NodePort is FORBIDDEN (§854, #5348) — use LoadBalancer (cloud-LB / Cilium LB-IPAM shared VIP) or ClusterIP" }}
+  {{- end }}
+  type: {{ $svcType }}
+  {{- if eq $svcType "LoadBalancer" }}
+  # 🛑 zero nodePorts, ever (§854, #5348): the LB VIP is served directly by
+  # the cloud-LB / Cilium LB-IPAM datapath — node:3xxxx must not exist.
+  # Without this field the apiserver silently allocates a nodePort per port
+  # and the Kyverno forbid-nodeport-service guard denies the install.
+  allocateLoadBalancerNodePorts: false
+  {{- end }}
   externalTrafficPolicy: {{ .Values.service.mail.externalTrafficPolicy }}
   selector:
     {{- include "bp-stalwart-sovereign.selectorLabels" . | nindent 4 }}
@@ -34,20 +45,39 @@ spec:
       port: {{ .Values.service.mail.ports.smtp }}
       targetPort: smtp
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      # 🛑 #5348: state ZERO explicitly — omitting nodePort is NOT enough.
+      # allocateLoadBalancerNodePorts:false only stops NEW allocations; an
+      # apply that OMITS nodePort leaves an existing allocation in place.
+      # `nodePort: 0` is the release sentinel the apiserver clears on apply.
+      nodePort: 0
+      {{- end }}
     - name: submission
       port: {{ .Values.service.mail.ports.submission }}
       targetPort: submission
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
     - name: submissions
       port: {{ .Values.service.mail.ports.submissions }}
       targetPort: submissions
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
     - name: imap
       port: {{ .Values.service.mail.ports.imap }}
       targetPort: imap
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
     - name: imaps
       port: {{ .Values.service.mail.ports.imaps }}
       targetPort: imaps
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
 {{- end }}

--- a/platform/stalwart-sovereign/chart/tests/sovereign-render.sh
+++ b/platform/stalwart-sovereign/chart/tests/sovereign-render.sh
@@ -67,6 +67,24 @@ grep -q "name: smtp" <<<"$out" \
 grep -q "name: submission" <<<"$out" \
   || { echo "FAIL: no submission port name"; exit 1; }
 
+# §854 / #5348: the public mail LoadBalancer MUST carry the explicit
+# nodePort:0 guard on every port + allocateLoadBalancerNodePorts:false on the
+# spec — a clean render is NOT platform-clean (the apiserver silently
+# auto-allocates a nodePort per port otherwise, exactly the powerdns-anycast
+# violation #5348 caught). Assert BOTH directions: the positive checks prove
+# the LB path actually rendered the guard (a bare "no 3xxxx" would pass
+# vacuously on a ClusterIP-only render), and the negative check proves no
+# auto-allocated nodePort leaked into the 30000-32767 range.
+grep -q "allocateLoadBalancerNodePorts: false" <<<"$out" \
+  || { echo "FAIL: mail LoadBalancer missing allocateLoadBalancerNodePorts:false (§854/#5348)"; exit 1; }
+np0=$(grep -cE '^[[:space:]]*nodePort: 0[[:space:]]*$' <<<"$out" || true)
+[[ "$np0" -eq 5 ]] \
+  || { echo "FAIL: expected 5 explicit 'nodePort: 0' (one per mail port), got $np0 (§854/#5348)"; exit 1; }
+if grep -qE 'nodePort: 3[0-2][0-9]{3}' <<<"$out"; then
+  echo "FAIL: mail Service leaked an auto-allocated nodePort in 30000-32767 (§854)"; exit 1
+fi
+echo "[stalwart-sovereign] §854 nodePort:0 guard: PASS"
+
 # ClusterIP for admin API
 grep -q "stalwart-sovereign-http" <<<"$out" \
   || { echo "FAIL: no http ClusterIP Service"; exit 1; }

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T07:16:26.285Z",
+  "generatedAt": "2026-08-05T13:11:15.796Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4920,7 +4920,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-cert-manager",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5055,7 +5055,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-cert-manager",


### PR DESCRIPTION
## Problem
`platform/stalwart-sovereign/chart/templates/service-mail.yaml` renders a public `type: LoadBalancer` Service (5 mail ports) but omitted any explicit `nodePort: 0` and carried no `allocateLoadBalancerNodePorts: false`. Per §854 / #5348, a clean render is **not** platform-clean: on apply the cloud-LB controller (k3s ServiceLB / hcloud CCM) silently auto-allocates a nodePort per port in the 30000-32767 range — the exact latent NodePort violation #5348 caught on `powerdns-anycast`. The sibling `bp-stalwart-tenant` smtp/imap Services already carry the guard; this chart (0.1.0, #924) predated the hardening and was missed.

## Fix
Mirrors the `bp-stalwart-tenant` idiom exactly on the mail Service:
- `$svcType` resolve (default LoadBalancer) + hard-`fail` on `service.mail.type=NodePort`
- `allocateLoadBalancerNodePorts: false` under LoadBalancer
- explicit `nodePort: 0` on all 5 ports under LoadBalancer

## Test (falsifiable, both-directions)
`tests/sovereign-render.sh` Case 2 now asserts **exactly 5** `nodePort: 0` + `allocateLoadBalancerNodePorts:false` present (positive — cannot pass vacuously on a ClusterIP render) **AND** zero nodePorts in the 3xxxx range (negative). Verified locally: guard renders, zero auto-allocated nodePorts, all 3 cases PASS.

## Lockstep (#817)
Chart.yaml + blueprint.yaml `0.1.0 → 0.1.1`; regenerated `blueprints.json` + `catalog.generated.ts` via `build-catalog.mjs` (version-only diff — no stale-seed churn).

Deploy-gated: PR-merge ≠ shipped; the live proof (Service with zero nodePorts) rides the next fresh prov / catalog install.

Refs #5690

🤖 Generated with [Claude Code](https://claude.com/claude-code)
