### PR TITLE
ci(uat): lock the SSO-flip trigger surface against evidence-erasing broadening (#5597)

### DIFF
--- a/.github/workflows/sso-flip-guard.yaml
+++ b/.github/workflows/sso-flip-guard.yaml
@@ -1,0 +1,49 @@
+# sso-flip-guard.yaml — protect the SSO-flip trigger surface (#5597).
+#
+# THE PROBLEM: .github/workflows/sso-uat-flip.yaml flips walked SSO UAT rows to
+# UNVERIFIED on any push to main touching the SSO chain. Its `paths:` filter
+# broadened-and-regressed THREE times (71c54d8d, a031424a, bee6695e — 31
+# live-walked rows erased in one day, 7 un-re-walkable behind a PIN). Each was
+# hand-narrowed after the fact; nothing LOCKED the receipts, so the next
+# broadening silently re-opened the hole.
+#
+# THIS GUARD runs scripts/sso-flip-pathmatch.py --self-test — a faithful mirror
+# of GitHub's `paths:` semantics that parses the flip workflow's OWN path list
+# (single source of truth) and asserts the three receipt commits stay unflipped
+# while genuine SSO-chain changes still flip. It fires whenever the trigger
+# surface itself changes, so a future re-broadening fails CI instead of erasing
+# evidence in production. Self-test is included so the guard's own logic is
+# continuously protected (uat-drift-guard.yaml idiom).
+name: sso-flip-guard
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/sso-uat-flip.yaml"
+      - ".github/workflows/sso-flip-guard.yaml"
+      - "scripts/sso-flip-pathmatch.py"
+      - "scripts/uat-sso-flip.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/sso-uat-flip.yaml"
+      - ".github/workflows/sso-flip-guard.yaml"
+      - "scripts/sso-flip-pathmatch.py"
+      - "scripts/uat-sso-flip.py"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+      - name: Guard the SSO-flip trigger surface (#5597 receipts)
+        run: python3 scripts/sso-flip-pathmatch.py --self-test

--- a/platform/stalwart-sovereign/blueprint.yaml
+++ b/platform/stalwart-sovereign/blueprint.yaml
@@ -24,8 +24,9 @@ spec:
   #     `catalyst-openova-kc-credentials` chart-rendered Secret via
   #     Helm `lookup`). NO Keycloak OIDC — Console is the only client.
   #
+  # 0.1.1 (#5690) — §854/#5348 mail-LoadBalancer nodePort:0 hardening.
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: Stalwart (Sovereign Console mail)
     summary: |

--- a/platform/stalwart-sovereign/chart/Chart.yaml
+++ b/platform/stalwart-sovereign/chart/Chart.yaml
@@ -32,8 +32,14 @@ name: bp-stalwart-sovereign
 #   has not yet rendered (e.g. operator opted out or a Sovereign was
 #   provisioned before this slot existed).
 #
+# 0.1.1 (#5690) — §854/#5348 hardening: the public mail LoadBalancer Service
+# (service-mail.yaml) now states allocateLoadBalancerNodePorts:false + an
+# explicit nodePort:0 on every port, and hard-fails on service.mail.type=
+# NodePort — mirroring the bp-stalwart-tenant guard. Prevents the apiserver
+# from silently auto-allocating a nodePort per mail port on apply.
+#
 # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.16.3"
 description: |
   Catalyst Blueprint scratch chart for the Sovereign-local Stalwart

--- a/platform/stalwart-sovereign/chart/templates/service-mail.yaml
+++ b/platform/stalwart-sovereign/chart/templates/service-mail.yaml
@@ -25,7 +25,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.mail.type }}
+  {{- $svcType := .Values.service.mail.type | default "LoadBalancer" }}
+  {{- if eq $svcType "NodePort" }}
+  {{- fail "bp-stalwart-sovereign: service.mail.type=NodePort is FORBIDDEN (§854, #5348) — use LoadBalancer (cloud-LB / Cilium LB-IPAM shared VIP) or ClusterIP" }}
+  {{- end }}
+  type: {{ $svcType }}
+  {{- if eq $svcType "LoadBalancer" }}
+  # 🛑 zero nodePorts, ever (§854, #5348): the LB VIP is served directly by
+  # the cloud-LB / Cilium LB-IPAM datapath — node:3xxxx must not exist.
+  # Without this field the apiserver silently allocates a nodePort per port
+  # and the Kyverno forbid-nodeport-service guard denies the install.
+  allocateLoadBalancerNodePorts: false
+  {{- end }}
   externalTrafficPolicy: {{ .Values.service.mail.externalTrafficPolicy }}
   selector:
     {{- include "bp-stalwart-sovereign.selectorLabels" . | nindent 4 }}
@@ -34,20 +45,39 @@ spec:
       port: {{ .Values.service.mail.ports.smtp }}
       targetPort: smtp
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      # 🛑 #5348: state ZERO explicitly — omitting nodePort is NOT enough.
+      # allocateLoadBalancerNodePorts:false only stops NEW allocations; an
+      # apply that OMITS nodePort leaves an existing allocation in place.
+      # `nodePort: 0` is the release sentinel the apiserver clears on apply.
+      nodePort: 0
+      {{- end }}
     - name: submission
       port: {{ .Values.service.mail.ports.submission }}
       targetPort: submission
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
     - name: submissions
       port: {{ .Values.service.mail.ports.submissions }}
       targetPort: submissions
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
     - name: imap
       port: {{ .Values.service.mail.ports.imap }}
       targetPort: imap
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
     - name: imaps
       port: {{ .Values.service.mail.ports.imaps }}
       targetPort: imaps
       protocol: TCP
+      {{- if eq $svcType "LoadBalancer" }}
+      nodePort: 0
+      {{- end }}
 {{- end }}

--- a/platform/stalwart-sovereign/chart/tests/sovereign-render.sh
+++ b/platform/stalwart-sovereign/chart/tests/sovereign-render.sh
@@ -67,6 +67,24 @@ grep -q "name: smtp" <<<"$out" \
 grep -q "name: submission" <<<"$out" \
   || { echo "FAIL: no submission port name"; exit 1; }
 
+# §854 / #5348: the public mail LoadBalancer MUST carry the explicit
+# nodePort:0 guard on every port + allocateLoadBalancerNodePorts:false on the
+# spec — a clean render is NOT platform-clean (the apiserver silently
+# auto-allocates a nodePort per port otherwise, exactly the powerdns-anycast
+# violation #5348 caught). Assert BOTH directions: the positive checks prove
+# the LB path actually rendered the guard (a bare "no 3xxxx" would pass
+# vacuously on a ClusterIP-only render), and the negative check proves no
+# auto-allocated nodePort leaked into the 30000-32767 range.
+grep -q "allocateLoadBalancerNodePorts: false" <<<"$out" \
+  || { echo "FAIL: mail LoadBalancer missing allocateLoadBalancerNodePorts:false (§854/#5348)"; exit 1; }
+np0=$(grep -cE '^[[:space:]]*nodePort: 0[[:space:]]*$' <<<"$out" || true)
+[[ "$np0" -eq 5 ]] \
+  || { echo "FAIL: expected 5 explicit 'nodePort: 0' (one per mail port), got $np0 (§854/#5348)"; exit 1; }
+if grep -qE 'nodePort: 3[0-2][0-9]{3}' <<<"$out"; then
+  echo "FAIL: mail Service leaked an auto-allocated nodePort in 30000-32767 (§854)"; exit 1
+fi
+echo "[stalwart-sovereign] §854 nodePort:0 guard: PASS"
+
 # ClusterIP for admin API
 grep -q "stalwart-sovereign-http" <<<"$out" \
   || { echo "FAIL: no http ClusterIP Service"; exit 1; }

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T07:16:26.285Z",
+  "generatedAt": "2026-08-05T13:11:15.796Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4920,7 +4920,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-cert-manager",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5055,7 +5055,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-cert-manager",

--- a/scripts/sso-flip-pathmatch.py
+++ b/scripts/sso-flip-pathmatch.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""sso-flip-pathmatch.py — guard the SSO-flip trigger surface (#5597).
+
+`.github/workflows/sso-uat-flip.yaml` flips walked SSO UAT rows to UNVERIFIED
+on any push to main that touches the SSO chain. Its `paths:` filter has
+broadened-and-regressed THREE times, each erasing FRESH walk evidence a merge
+could not possibly invalidate:
+
+  71c54d8d  #5535 cutover secondary-kubeconfigs fix (handler/*.go, zero auth)
+            -> erased rows 28/40/41/42/43/45, headline 34 -> 28
+  a031424a  a CI-workflow + README + SECURITY.md + two shell scripts
+            -> matched `platform/cilium/**` on platform/cilium/README.md, 5 rows
+  bee6695e  the #5652 cutover Flux-source lint touching the catalog lockstep
+            site blueprints.json -> 12 rows (7 un-re-walkable, behind a PIN)
+
+Total: 31 live-walked rows erased in one day. The workflow `paths:` were scoped
+(#5597) and `!`-excluded (#5648) to stop each, but nothing LOCKS those receipts,
+so the next broadening silently re-opens the hole. This is that lock.
+
+The module is a faithful mirror of GitHub Actions' `paths:` semantics: patterns
+are evaluated top-to-bottom, LAST MATCH WINS; a `!`-prefixed pattern excludes, a
+plain pattern includes; glob `*` = a run of non-`/` chars, `**` = any run incl
+`/`, a leading `**/` = zero-or-more leading dirs; the workflow fires iff AT LEAST
+ONE changed file is net-included. It PARSES the workflow's own `paths:` list
+(single source of truth), so a future broadening is exercised by --self-test —
+the mirror cannot silently drift from the real trigger.
+
+Run: python3 scripts/sso-flip-pathmatch.py --self-test
+     python3 scripts/sso-flip-pathmatch.py --files a/b.go c/d.yaml   # -> FIRE / no-fire
+"""
+
+import argparse
+import pathlib
+import re
+import sys
+
+import yaml
+
+WORKFLOW = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / ".github/workflows/sso-uat-flip.yaml"
+)
+
+
+def load_patterns(path: pathlib.Path = WORKFLOW) -> list[str]:
+    """Return the ordered `on.push.paths` list from the flip workflow.
+
+    Note the YAML 1.1 gotcha: the bare key `on:` is parsed as the boolean
+    `True`, not the string "on" — so the trigger block lives under doc[True].
+    """
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    on = doc.get("on")
+    if on is None:
+        on = doc.get(True)
+    if not isinstance(on, dict) or "push" not in on or "paths" not in on["push"]:
+        raise SystemExit(f"FATAL: {path} has no on.push.paths block")
+    return list(on["push"]["paths"])
+
+
+def _translate(glob: str) -> tuple[bool, re.Pattern]:
+    """Compile one GitHub `paths` glob to (is_negation, full-path regex)."""
+    neg = glob.startswith("!")
+    g = glob[1:] if neg else glob
+    out = ["^"]
+    i, n = 0, len(g)
+    while i < n:
+        if g[i] == "*":
+            if g[i : i + 3] == "**/":
+                out.append("(?:.*/)?")  # zero-or-more leading dirs
+                i += 3
+                continue
+            if g[i : i + 2] == "**":
+                out.append(".*")  # any run, including `/`
+                i += 2
+                continue
+            out.append("[^/]*")  # a run of non-`/`
+            i += 1
+            continue
+        if g[i] == "?":
+            out.append("[^/]")
+            i += 1
+            continue
+        out.append(re.escape(g[i]))
+        i += 1
+    out.append("$")
+    return neg, re.compile("".join(out))
+
+
+def _compile(patterns: list[str]) -> list[tuple[bool, re.Pattern]]:
+    return [_translate(p) for p in patterns]
+
+
+def path_included(path: str, compiled: list[tuple[bool, re.Pattern]]) -> bool:
+    """Net inclusion of a single path under last-match-wins semantics."""
+    included = False
+    for neg, rx in compiled:
+        if rx.match(path):
+            included = not neg
+    return included
+
+
+def would_fire(changed_files: list[str], patterns: list[str] | None = None) -> bool:
+    """True iff at least one changed file is net-included by the filter."""
+    compiled = _compile(load_patterns() if patterns is None else patterns)
+    return any(path_included(f, compiled) for f in changed_files)
+
+
+# ── the receipts (#5597 / #5648): commits that MUST NOT fire the flip ─────────
+MUST_NOT_FIRE = {
+    "71c54d8d (#5535 cutover secondary-kubeconfigs — zero auth code)": [
+        "products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go",
+        "products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_5488_test.go",
+        "products/catalyst/bootstrap/api/internal/handler/jobs.go",
+    ],
+    "a031424a (CI workflow + README + SECURITY.md + shell scripts)": [
+        "platform/cilium/README.md",
+        "docs/SECURITY.md",
+        ".github/workflows/some-ci.yaml",
+        "scripts/a.sh",
+        "scripts/b.sh",
+    ],
+    "bee6695e (#5652 cutover Flux-source lint — catalog lockstep site)": [
+        "products/catalyst/bootstrap/api/internal/catalog/blueprints.json",
+    ],
+}
+
+# ── positive controls: genuine SSO-chain changes that MUST fire ───────────────
+MUST_FIRE = {
+    "keycloak chart change (the IdP)": ["platform/keycloak/chart/values.yaml"],
+    "catalyst-api auth handler": [
+        "products/catalyst/bootstrap/api/internal/handler/auth_handover.go",
+    ],
+    "console auth surface": ["core/console/src/pages/login.astro"],
+    "real cilium chart change (SSO datapath, not a .md)": [
+        "platform/cilium/chart/templates/hubble-ui-oauth2-proxy-service.yaml",
+    ],
+    "mixed: a real SSO file alongside a doc still nets a fire": [
+        "platform/keycloak/chart/values.yaml",
+        "platform/keycloak/README.md",
+    ],
+}
+
+
+def self_test() -> int:
+    patterns = load_patterns()
+    compiled = _compile(patterns)
+    fails: list[str] = []
+
+    for name, files in MUST_NOT_FIRE.items():
+        if any(path_included(f, compiled) for f in files):
+            hit = [f for f in files if path_included(f, compiled)]
+            fails.append(f"MUST NOT FIRE but did: {name}\n    triggered by: {hit}")
+
+    for name, files in MUST_FIRE.items():
+        if not any(path_included(f, compiled) for f in files):
+            fails.append(f"MUST FIRE but did not: {name}\n    files: {files}")
+
+    # Vacuity guard: the matcher must be capable of BOTH answers, so a
+    # degenerate always-False (or always-True) implementation cannot pass.
+    all_receipts = [f for files in MUST_NOT_FIRE.values() for f in files]
+    all_controls = [f for files in MUST_FIRE.values() for f in files]
+    if all(path_included(f, compiled) for f in all_receipts):
+        fails.append("VACUITY: every receipt path matched — matcher is always-True")
+    if not any(path_included(f, compiled) for f in all_controls):
+        fails.append("VACUITY: no control path matched — matcher is always-False")
+
+    # Discrimination guard: prove the matcher would CATCH the exact broadening
+    # that caused 71c54d8d. With the pre-#5597 broad glob restored, that
+    # receipt's handler/*.go files MUST net-include — otherwise the matcher is
+    # too permissive to detect a real regression (a green self-test would then
+    # mean nothing).
+    broad = _compile(patterns + ["products/catalyst/bootstrap/api/**"])
+    key = "71c54d8d (#5535 cutover secondary-kubeconfigs — zero auth code)"
+    if not any(path_included(f, broad) for f in MUST_NOT_FIRE[key]):
+        fails.append(
+            "DISCRIMINATION: with the pre-#5597 broad glob restored the 71c54d8d "
+            "receipt is still no-fire — the matcher is too permissive to detect a "
+            "broadening regression, so a passing self-test proves nothing"
+        )
+
+    if fails:
+        print("sso-flip-pathmatch self-test: FAIL", file=sys.stderr)
+        for f in fails:
+            print(f"  - {f}", file=sys.stderr)
+        print(
+            "\nThe SSO-flip trigger surface regressed: a merge that cannot affect an\n"
+            "SSO landing would erase freshly-walked UAT evidence (#5597/#5648).\n"
+            f"Re-scope the `paths:` in {WORKFLOW.name} so the receipts above stay green.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"sso-flip-pathmatch self-test: PASS "
+        f"({len(MUST_NOT_FIRE)} receipts stay unflipped, {len(MUST_FIRE)} controls still flip)"
+    )
+    return 0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="run the receipt/control guard")
+    ap.add_argument("--files", nargs="*", help="changed file paths to classify")
+    args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+    if args.files is not None:
+        fire = would_fire(args.files)
+        print("FIRE" if fire else "no-fire")
+        sys.exit(0)
+    ap.print_help()
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem
`.github/workflows/sso-uat-flip.yaml` flips walked SSO UAT rows to UNVERIFIED on any push to main touching the SSO chain. Its `paths:` filter has **broadened-and-regressed three times**, each erasing *fresh* walk evidence a merge could not affect:

| commit | what it was | rows erased |
|---|---|---|
| `71c54d8d` | #5535 cutover secondary-kubeconfigs (`handler/*.go`, zero auth code) | 28/40/41/42/43/45 (headline 34→28) |
| `a031424a` | a CI/README/SECURITY.md/shell commit — matched `platform/cilium/**` on `platform/cilium/README.md` | 5 |
| `bee6695e` | #5652 cutover Flux-source lint touched the catalog lockstep site `blueprints.json` | 12 (7 un-re-walkable, behind a PIN) |

31 live-walked rows erased in one day. The workflow paths were scoped (#5597) and `!`-excluded (#5648) after each, but **nothing locked the receipts**, so the next broadening silently re-opens the hole. This PR is #5597's open ask #3 — the missing guard test.

## Fix
`scripts/sso-flip-pathmatch.py` — a faithful mirror of GitHub's `paths:` semantics (patterns top-to-bottom, last-match-wins; `!` excludes; `*`=non-`/` run, `**`=any run, `**/`=zero-or-more leading dirs; fires iff ≥1 changed file is net-included). It **parses the flip workflow's own path list** (single source of truth), so a future broadening is exercised by the same `--self-test` and cannot drift.

`--self-test` asserts:
- the **3 receipt commits stay NO-FIRE** (would not erase evidence);
- **5 genuine SSO-chain changes still FIRE** (keycloak / auth-handler / console / cilium-chart / mixed — non-vacuous positive controls);
- a **vacuity guard** (matcher can produce both answers);
- a **discrimination guard** (restoring the pre-#5597 broad glob *does* re-fire 71c54d8d — proving the guard catches the exact regression, so a green self-test means something).

`.github/workflows/sso-flip-guard.yaml` runs the self-test whenever the trigger surface itself changes (the `uat-drift-guard.yaml` idiom) → a re-broadening fails CI instead of erasing rows in production.

## Verification (local)
- `--self-test` → PASS (3 receipts unflipped, 5 controls flip);
- the exact `71c54d8d` file list → `no-fire`; a keycloak chart change → `FIRE`;
- this PR's own files (`sso-flip-guard.yaml`, `sso-flip-pathmatch.py`) → `no-fire` (no self-inflicted erasure on merge).

Refs #5597 #5648 #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
