### PR TITLE
fix(#5358): guacamole blank page — ONE Guacamole per Sovereign over ClusterMesh (bp-guacamole 0.2.36 + bp-oidc-gate 0.1.10)

### DIFF
--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -97,7 +97,7 @@ spec:
       # absent in a per-Org namespace, 500'd every OAuth callback on hw292.
       # Additive: Cilium unions policies, so the effective egress set here is
       # unchanged while slot 26b is installed.
-      version: 0.1.9
+      version: 0.1.10
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate
@@ -126,6 +126,18 @@ spec:
     # inside the cluster on Huawei/kom4dc). KC_HOSTNAME is pinned public by
     # bp-keycloak so the token `iss` still matches the public issuer.
     keycloakInternalURL: http://keycloak.keycloak.svc.cluster.local
+    # #5358 — an upstream may be a ClusterMesh SINGLETON: bp-guacamole 0.2.36
+    # anchors the Guacamole webapp in the primary region (Guacamole's REST
+    # session lives in a per-Pod in-memory map, so one instance per region
+    # behind a shared VIP 403'd half of every page load and rendered a blank
+    # page). The secondary region's gate then reaches that webapp across the
+    # mesh — a dial the gate's own egress policy cannot authorise by namespace
+    # alone, because Cilium AND-injects `io.cilium.k8s.policy.cluster=<local>`
+    # into every selector derived from a namespaced CNP. Naming the peer
+    # cluster(s) here is what keeps that hop open. EMPTY on a single-region
+    # prov → no extra rule, policy byte-identical to 0.1.9.
+    crossRegion:
+      peerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:=[]}
     instances:
       # openova-flow (#3374 §3 row 9). Upstream is the slot-56 Service
       # in catalyst-system; the gate proxies it at the public hostname.

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -198,7 +198,7 @@ spec:
       # dead cached GUAC_AUTH token → 403 PERMISSION_DENIED on every
       # session API call → bare "An error has occurred" page (UAT rows
       # 35/115 on hw292). Session lifetime now matches the gate cookie.
-      version: 0.2.35
+      version: 0.2.36
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole
@@ -228,6 +228,36 @@ spec:
     # REQUIRED. Empty default = verbatim ghcr.io (byte-identical pre-cutover).
     global:
       imageRegistry: ''
+    # ── Cross-region singleton (#5358) ─────────────────────────────────
+    # ADR-0001 §11 says ONE Guacamole per Sovereign, but this slot installs on
+    # EVERY region's control plane, so a 2-region Sovereign ran TWO independent
+    # Guacamoles behind ONE shared wildcard VIP. Guacamole keeps its REST
+    # session in a per-Pod in-memory HashTokenSessionMap, so `POST /api/tokens`
+    # minted by whichever region answered was UNKNOWN to the other, which
+    # returned 403 PERMISSION_DENIED — and the SPA's only handler for that call
+    # is requestService.DIE, leaving the page stuck in `.view.loading`
+    # (`.loading * { visibility: hidden }`) = the #5358 BLANK page.
+    #
+    # Measured live on hw292 (dep 1c56518035a83e03): ONE token minted on
+    # region-A returned 200 on region-A's Pod and 403 on region-B's Pod, and the
+    # webapp access logs show a single page-load split across both regions in
+    # the SAME second.
+    #
+    # Same seam bp-harbor (19) uses for the identical Redis session split
+    # (#5406). `enabled` follows SOVEREIGN_ENABLE_CNPG_PAIR — a single-region
+    # prov leaves it false and the render is byte-identical to 0.2.35.
+    crossRegion:
+      enabled: ${SOVEREIGN_ENABLE_CNPG_PAIR:=false}
+      # Per-region cloud-init substitute (primary on region-A + on every
+      # single-region prov, secondary on region-B). `secondary` renders the
+      # ClusterMesh Service stub ONLY — no webapp, no guacd, no CNPG store — so
+      # the stub has zero local backends and every dial falls through the mesh
+      # to region-A's singleton.
+      role: ${SOVEREIGN_REGION_ROLE:=primary}
+      # Peer ClusterMesh cluster name(s) — the SAME source var bp-harbor (19),
+      # bp-postgres (16a/16c/16d) and bp-cnpg-pair (16b) consume. EMPTY
+      # (single-region) → no CiliumNetworkPolicy is rendered.
+      peerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:=[]}
     # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
     # The chart self-registers the Application CR for guacamole (the
     # canonical instance representation every console surface reads),

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.35
+  version: 0.2.36
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -245,7 +245,63 @@ name: bp-guacamole
 # were proven INTACT on the same env (fresh-login effectivePermissions
 # carried ADMINISTER + 5 CREATE_*), so the session lifetime, not the JDBC
 # permission chain, was the operator-visible failure.
-version: 0.2.35
+# 0.2.36 (#5358): ONE Guacamole per Sovereign, enforced on the wire. ADR-0001
+# §11 has always said "one Guacamole per Sovereign" and the chart's own
+# Application CR claims `placement: singleton`, but the bootstrap-kit installs
+# slot 52 on EVERY region's control plane — so a 2-region Sovereign actually ran
+# TWO fully independent Guacamoles (own webapp, own guacd, own CNPG permission
+# store) behind ONE shared wildcard VIP. Guacamole keeps its REST session in a
+# per-Pod IN-MEMORY HashTokenSessionMap (no shared-session option exists
+# upstream), so a token minted by whichever region answered `POST /api/tokens`
+# is UNKNOWN to the other region's Pod, which answers 403 PERMISSION_DENIED.
+# A browser opens several parallel HTTP/1.1 connections per page load and the
+# VIP spreads them across both regions, so a SINGLE page load is routinely
+# served by both instances.
+#   Live proof, hw292 (dep 1c56518035a83e03) webapp access logs, one page load
+#   in the SAME second:
+#     region-A  POST /guacamole/api/tokens                         200  ← minted
+#     region-B  GET  …/postgresql/self/effectivePermissions         403
+#     region-B  GET  …/postgresql-shared/connectionGroups/ROOT/tree 403
+#     region-B  GET  /guacamole/images/warning.svg                  200
+#   and as a CONTROL: the SAME token replayed in the same instant returned 200
+#   on region-A's Pod and 403 PERMISSION_DENIED on region-B's.
+# The 403 is fatal to the SPA because homeController's only error handler for
+# the connection-tree call is `requestService.DIE`: `rootConnectionGroups` stays
+# null, `isLoaded()` never turns true, and home.html keeps
+# `class="home-view view loading"` whose CSS is `.loading * { visibility:
+# hidden }` — every element stays in the DOM but invisible. That is exactly the
+# reported BLANK page whose innerText is pure whitespace (UAT rows 35 / R9), and
+# the same 403 cascade paints the generic "An error has occurred" banner on the
+# runs where the DIE broadcast wins the race — one cause, both reported
+# symptoms. NOTE this is a DIFFERENT defect from the 0.2.34 session-lifetime fix
+# (#5598): that one needed >60 min idle, this one reproduces on a cold first
+# load and is the reason #5358 kept reopening after #5378 moved SSO server-side.
+# FIX (the idiom bp-harbor 1.2.45 used for the identical Redis session split,
+# #5406, and bp-openbao / bp-cnpg-pair / bp-catalyst-edge-routes use for their
+# singletons): a new top-level `crossRegion` block anchors the workload in the
+# PRIMARY region and lets the secondary reach it over Cilium ClusterMesh.
+#   - crossRegion.enabled=false (DEFAULT, every single-region Sovereign) →
+#     render is BYTE-IDENTICAL to 0.2.35 (verified by diffing the full
+#     `helm template` output against origin/main).
+#   - role=primary  → full workload set; the guacamole-server Service gains
+#     `service.cilium.io/global|shared: "true"` + `affinity: local`, plus a
+#     CiliumNetworkPolicy admitting the PEER region's oidc-gate Pods to :8080.
+#     A plain k8s NetworkPolicy can never do this: Cilium AND-injects
+#     `io.cilium.k8s.policy.cluster=<local>` into every selector derived from
+#     one (`policy-default-local-cluster: "true"`, read live from hw292's
+#     cilium-config), and an ipBlock is equally inert (#4656/#4846/#4854).
+#   - role=secondary → NO webapp / guacd / CNPG Cluster / seed Job / enroll
+#     CronJob / Application CR at all; only the guacamole-server Service renders,
+#     as a ZERO-backend mesh stub with `shared: "false"` so the secondary can
+#     never export a webapp of its own. Zero local backends is what makes
+#     `affinity: local` fall through to the primary.
+# Lockstep: 52-bp-guacamole.yaml pin + values + blueprint.yaml + catalog-seed
+# source.version → 0.2.36. Paired with bp-oidc-gate 0.1.10, whose egress policy
+# must name the peer cluster or it silently re-breaks this hop. New guard:
+# chart/tests/crossregion-render.sh (Case 3 fails against the pre-fix chart —
+# role=secondary there still renders 2 Deployments + 1 CNPG Cluster).
+# Refs #5358.
+version: 0.2.36
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/_helpers.tpl
+++ b/platform/guacamole/chart/templates/_helpers.tpl
@@ -135,6 +135,52 @@ guacamole-auth-sso-openid implicit flow (fragment-replay-broken upstream
 {{- end }}
 
 {{/*
+Cross-region role (#5358 region-split). `primary` (default) = this region
+owns the ONE Guacamole the Sovereign runs (ADR-0001 §11); `secondary` = this
+region renders the ClusterMesh Service stub ONLY and reaches the primary's
+webapp over the mesh. Any other value fails the render.
+*/}}
+{{- define "bp-guacamole.crossRegionRole" -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- $role := $cr.role | default "primary" -}}
+{{- if not (has $role (list "primary" "secondary")) -}}
+{{- fail (printf "bp-guacamole: invalid crossRegion.role %q — must be \"primary\" (owns the singleton webapp) or \"secondary\" (mesh stub only)" $role) -}}
+{{- end -}}
+{{- $role -}}
+{{- end }}
+
+{{/*
+Mesh-secondary predicate (#5358 region-split). Emits "true" when this region is
+the ClusterMesh SECONDARY — i.e. the region that must run NO Guacamole workload
+so its `guacamole-server` Service has ZERO local backends and
+`service.cilium.io/affinity: local` falls through the mesh to the primary's
+singleton. Empty string otherwise.
+
+Deliberately independent of `.Values.guacamole.enabled` so callers that do not
+gate on that value (application-cr.yaml) keep their existing semantics.
+*/}}
+{{- define "bp-guacamole.isMeshSecondary" -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- if and $cr.enabled (eq (include "bp-guacamole.crossRegionRole" .) "secondary") -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Workload render gate (#5358 region-split). Emits "true" when this region must
+run the Guacamole workload set (webapp + guacd + JDBC store), empty otherwise.
+
+crossRegion.enabled=false (the default, and every single-region Sovereign)
+always renders the workloads, so the default render is byte-identical to
+pre-0.2.36.
+*/}}
+{{- define "bp-guacamole.renderWorkloads" -}}
+{{- if and .Values.guacamole.enabled (not (include "bp-guacamole.isMeshSecondary" .)) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 OIDC issuer fail-fast — Guacamole won't authenticate without it.
 */}}
 {{- define "bp-guacamole.oidcIssuer" -}}

--- a/platform/guacamole/chart/templates/application-cr.yaml
+++ b/platform/guacamole/chart/templates/application-cr.yaml
@@ -20,7 +20,9 @@ false; the slot opts in) AND the Capabilities apps.openova.io/v1 gate
 (benign skip pre-CRD; CR materialises on the first post-CRD upgrade).
 Leaf platform app — no shareable Context, so spec.parameters is empty.
 */ -}}
-{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+{{- /* #5358: the Application CR represents the ONE Guacamole instance; only the
+   crossRegion `primary` region self-registers it (no double-carding). */ -}}
+{{- if and .Values.bootstrapOwned.enabled (not (include "bp-guacamole.isMeshSecondary" .)) (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
 apiVersion: apps.openova.io/v1
 kind: Application
 metadata:

--- a/platform/guacamole/chart/templates/cnpg-cluster.yaml
+++ b/platform/guacamole/chart/templates/cnpg-cluster.yaml
@@ -28,7 +28,9 @@ template until the CRD is registered (bootstrap order lands bp-cnpg first).
    value directly — the same idiom newapi's httproute.yaml uses for ssoInit. */ -}}
 {{- $dbOn := or (not (hasKey $db "enabled")) $db.enabled -}}
 {{- $clOn := or (not (hasKey $cl "enabled")) $cl.enabled -}}
-{{- if and .Values.guacamole.enabled $dbOn $clOn (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- /* #5358: the permission store belongs to the ONE webapp (ADR-0001 §11), so
+   a crossRegion `secondary` region renders no CNPG Cluster of its own. */ -}}
+{{- if and (include "bp-guacamole.renderWorkloads" .) $dbOn $clOn (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
 {{- $name := $cl.name | default "guacamole-pg" -}}
 {{- $ns := $cl.namespace | default .Release.Namespace -}}
 {{- $owner := $cl.owner | default "guacamole" -}}

--- a/platform/guacamole/chart/templates/crossregion-netpol.yaml
+++ b/platform/guacamole/chart/templates/crossregion-netpol.yaml
@@ -1,0 +1,84 @@
+{{- /*
+Cross-region webapp reachability CiliumNetworkPolicy (#5358).
+
+The `guacamole` namespace carries bp-plane-isolation's `guacamole-default-deny`
+NetworkPolicy, and in sso.mode=header this chart adds its own
+`guacamole-server-ingress` k8s NetworkPolicy admitting ONLY the oidc-gate Pods.
+
+A plain k8s NetworkPolicy can NEVER admit a ClusterMesh peer. Cilium
+AND-injects `io.cilium.k8s.policy.cluster=<local>` into every selector it
+derives from a k8s NetworkPolicy — confirmed on hw292 by the agent config
+itself, `policy-default-local-cluster: "true"` in the kube-system
+`cilium-config` ConfigMap. (An `ipBlock` is equally inert: a ClusterMesh remote
+Pod is a KNOWN endpoint carrying its own identity, never a CIDR identity —
+#4656 / #4846 / #4854.)
+
+So once crossRegion anchors the webapp in the primary region, the SECONDARY
+region's oidc-gate Pod dialling across the mesh needs an identity-based
+CiliumNetworkPolicy on the primary side. Cilium evaluates the UNION of every
+policy selecting an endpoint, so this is purely ADDITIVE to the default-deny
+and to the header-mode ingress guard: it grants peer-region reachability on the
+webapp port ONLY, from peer-cluster oidc-gate identities ONLY — no `world`, no
+extra ports, and it does NOT widen the local-cluster surface.
+
+Rendered on BOTH regions so a role flip needs no policy change and has no
+ordering hazard: on the secondary it selects zero local webapp Pods and is
+therefore inert.
+
+ANY-NAMESPACE note (the #4854 row 67 L2 trap, mirrored from
+platform/harbor/chart/templates/redis-crossregion-netpol.yaml): a namespaced
+CNP's fromEndpoints is implicitly ANDed with BOTH
+`io.cilium.k8s.policy.cluster=<local>` AND
+`k8s:io.kubernetes.pod.namespace=<this policy's namespace>`. The gate lives in
+namespace `oidc-gate`, NOT in `guacamole`, so the namespace key MUST be named
+explicitly — otherwise the rule is silently narrowed to peer-region Pods that
+happen to sit in a same-named `guacamole` namespace and matches nothing.
+
+Gated on `crossRegion.enabled` AND a non-empty `crossRegion.peerClusters` AND
+the cilium.io/v2 Capabilities check (the #2988/#3102 idiom, so the chart still
+installs on CRD-less clusters such as kind CI). EMPTY peer list (single-region)
+→ NO policy → the default render is byte-identical to 0.2.35.
+*/ -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- $peers := $cr.peerClusters | default list -}}
+{{- if and .Values.guacamole.enabled $cr.enabled (gt (len $peers) 0) (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
+{{- $sso := .Values.guacamole.sso | default dict -}}
+{{- $gate := $sso.gate | default dict -}}
+{{- $gateNs := $gate.namespace | default "oidc-gate" -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-crossregion-ingress" (include "bp-guacamole.webappName" .) | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    {{- /* `bp-guacamole.labels` already sets catalyst.openova.io/blueprint;
+         re-emitting a key Helm has already written is inert AND fails
+         helm-controller's post-render unmarshal with `mapping key already
+         defined`, so use a distinct key (the #5406 lesson). */}}
+    catalyst.openova.io/subcomponent: guacamole-crossregion-netpol
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "bp-guacamole.webappSelectorLabels" . | nindent 6 }}
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peers }}
+                - {{ . | quote }}
+                {{- end }}
+            # Named explicitly — see the ANY-NAMESPACE note above.
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values:
+                - {{ $gateNs | quote }}
+          matchLabels:
+            {{- $gate.podSelector | default (dict "app.kubernetes.io/name" "bp-oidc-gate") | toYaml | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.guacamole.webapp.port | quote }}
+              protocol: TCP
+{{- end }}

--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.guacamole.enabled -}}
+{{- /* #5358: `renderWorkloads` is empty on a crossRegion `secondary` region —
+   that region must run NO webapp Pod so its guacamole-server Service has zero
+   local backends and falls through the ClusterMesh to the primary singleton. */ -}}
+{{- if include "bp-guacamole.renderWorkloads" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/platform/guacamole/chart/templates/guacamole-service.yaml
+++ b/platform/guacamole/chart/templates/guacamole-service.yaml
@@ -1,4 +1,28 @@
+{{- /*
+Guacamole webapp Service — and, on a 2-region Sovereign, the ClusterMesh
+global Service that makes ADR-0001 §11 ("ONE Guacamole per Sovereign") true
+on the wire (#5358).
+
+Cilium merges ClusterMesh global Services BY name+namespace, so this Service
+must exist under the SAME name in EVERY participating cluster — which it
+does, because the bootstrap-kit installs slot 52 on every region.
+
+  PRIMARY   — the selector matches the local webapp Pod (guacamole-deployment
+              .yaml renders it here), and `shared: "true"` EXPORTS those
+              backends to the peer region.
+  SECONDARY — `bp-guacamole.renderWorkloads` suppresses the webapp Deployment,
+              so this selector matches ZERO local Pods and `affinity: local`
+              falls through the mesh to the primary's singleton. `shared:
+              "false"` keeps the secondary from ever exporting a webapp of its
+              own, so the primary can never land a session in the secondary
+              region — which is the entire bug (see values.yaml `crossRegion`
+              for the live hw292 measurement).
+
+crossRegion.enabled=false → no annotations at all, byte-identical to 0.2.35.
+*/ -}}
 {{- if .Values.guacamole.enabled -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- $role := include "bp-guacamole.crossRegionRole" . -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,6 +31,13 @@ metadata:
   labels:
     {{- include "bp-guacamole.labels" . | nindent 4 }}
     catalyst.openova.io/component: webapp
+  {{- if $cr.enabled }}
+  annotations:
+    service.cilium.io/global: "true"
+    # Only the primary exports backends; see the header comment.
+    service.cilium.io/shared: {{ eq $role "primary" | quote }}
+    service.cilium.io/affinity: {{ (($cr.webapp | default dict).affinity | default "local") | quote }}
+  {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/platform/guacamole/chart/templates/guacd-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacd-deployment.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.guacamole.enabled -}}
+{{- /* #5358: guacd exists only to serve the local webapp; a crossRegion
+   `secondary` region runs neither. */ -}}
+{{- if include "bp-guacamole.renderWorkloads" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/platform/guacamole/chart/templates/guacd-service.yaml
+++ b/platform/guacamole/chart/templates/guacd-service.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.guacamole.enabled -}}
+{{- /* #5358: no guacd Deployment on a crossRegion `secondary` region, so no
+   Service either (unlike guacamole-server, guacd is never dialled across the
+   mesh — each region's webapp uses its own). */ -}}
+{{- if include "bp-guacamole.renderWorkloads" . -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
+++ b/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
@@ -47,7 +47,9 @@ postgresql.cnpg.io CRD absent.
 */ -}}
 {{- $db := .Values.guacamole.database | default dict -}}
 {{- $cl := $db.cluster | default dict -}}
-{{- if and .Values.guacamole.enabled (default true $db.enabled) (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- /* #5358: seeds + enrols against the local CNPG store, which only the
+   crossRegion `primary` region renders. */ -}}
+{{- if and (include "bp-guacamole.renderWorkloads" .) (default true $db.enabled) (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
 {{- $name := $cl.name | default "guacamole-pg" -}}
 {{- $appSecret := $db.appSecretName | default (printf "%s-app" $name) -}}
 {{- $adminGroup := $db.adminGroup | default "sovereign-admins" -}}

--- a/platform/guacamole/chart/templates/recordings-pvc-migrate-hook.yaml
+++ b/platform/guacamole/chart/templates/recordings-pvc-migrate-hook.yaml
@@ -57,7 +57,7 @@ Pairs with:
 {{- end -}}
 {{- /* #3374: no recordings PVC exists when persistence=false (emptyDir) — the
    storageClass-migration hook is then a no-op, so skip it entirely. */ -}}
-{{- if and .Values.guacamole.enabled $migrate .Values.guacamole.recordings.persistence -}}
+{{- if and (include "bp-guacamole.renderWorkloads" .) $migrate .Values.guacamole.recordings.persistence -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/platform/guacamole/chart/templates/recordings-pvc-rbac.yaml
+++ b/platform/guacamole/chart/templates/recordings-pvc-rbac.yaml
@@ -14,7 +14,7 @@ Pairs with templates/recordings-pvc-migrate-hook.yaml.
 {{- end -}}
 {{- /* #3374: the migration RBAC is only needed when the recordings PVC exists
    (persistence=true); skip it for the default emptyDir path. */ -}}
-{{- if and .Values.guacamole.enabled $migrate .Values.guacamole.recordings.persistence -}}
+{{- if and (include "bp-guacamole.renderWorkloads" .) $migrate .Values.guacamole.recordings.persistence -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/platform/guacamole/chart/templates/seaweedfs-pvc.yaml
+++ b/platform/guacamole/chart/templates/seaweedfs-pvc.yaml
@@ -1,7 +1,7 @@
 {{- /* #3374: only provision the recordings PVC when persistence is enabled.
    Default is emptyDir (see guacamole-deployment.yaml volumes note) so the
    webapp Pod is not node-pinned to a local-path PV on a CPU-saturated node. */ -}}
-{{- if and .Values.guacamole.enabled .Values.guacamole.recordings.persistence -}}
+{{- if and (include "bp-guacamole.renderWorkloads" .) .Values.guacamole.recordings.persistence -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/platform/guacamole/chart/tests/crossregion-render.sh
+++ b/platform/guacamole/chart/tests/crossregion-render.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# bp-guacamole — cross-region singleton render audit (#5358).
+#
+# THE DEFECT THIS GUARDS
+# ──────────────────────────────────────────────────────────────────────────
+# Guacamole keeps its REST session in a per-Pod IN-MEMORY HashTokenSessionMap
+# (there is no shared-session option upstream). Until 0.2.36 the bootstrap-kit
+# installed this chart identically on EVERY region's control plane, so a
+# 2-region Sovereign ran TWO independent Guacamoles behind ONE shared wildcard
+# VIP. A browser opens several parallel HTTP/1.1 connections per page load and
+# the VIP spreads them across both regions, so `POST /api/tokens` was minted by
+# one region's Pod and the very next `GET …/connectionGroups/ROOT/tree` landed
+# on the other, which had never seen the token → 403 PERMISSION_DENIED.
+#
+# The SPA's only error handler for that call is `requestService.DIE`, so
+# `rootConnectionGroups` stays null, `isLoaded()` never turns true, and
+# home.html keeps `class="home-view view loading"` — whose CSS is
+# `.loading * { visibility: hidden }`. Every element stays in the DOM but
+# invisible: the reported BLANK page whose innerText is pure whitespace
+# (UAT rows 35 / R9).
+#
+# Proven live on hw292 (dep 1c56518035a83e03) as a control: ONE token minted on
+# region-A's Pod returned 200 on region-A and 403 PERMISSION_DENIED on
+# region-B's Pod in the same instant.
+#
+# The load-bearing assertion is CASE 3: a `secondary` region must render NO
+# webapp Deployment, so its `guacamole-server` Service has ZERO local backends
+# and `service.cilium.io/affinity: local` falls through the ClusterMesh to the
+# primary's singleton (ADR-0001 §11 — ONE Guacamole per Sovereign).
+#
+# VACUITY
+# ──────────────────────────────────────────────────────────────────────────
+# Case 3 fails against the pre-fix chart: origin/main has no `crossRegion`
+# seam at all, so `--set crossRegion.role=secondary` is inert there and the
+# webapp Deployment renders anyway. Case 1 is the paired non-regression check
+# (the default render must carry NO mesh annotations), so the guard cannot be
+# satisfied by simply always-suppressing or always-annotating.
+#
+# Cases:
+#   1. Default (crossRegion.enabled=false) — NO mesh annotations, workloads present
+#   2. enabled + role=primary  — global/shared=true, workloads present, CNP present
+#   3. enabled + role=secondary — webapp/guacd/CNPG ABSENT, Service present, shared=false
+#   4. peerClusters empty      — no CiliumNetworkPolicy rendered
+#   5. invalid role            — render fails fast
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+base=(
+  --set guacamole.enabled=true
+  --set guacamole.httproute.hostname=guac.smoke.omani.works
+  --set guacamole.oidc.issuer=https://keycloak.smoke.omani.works/realms/ops
+  --api-versions cilium.io/v2
+  --api-versions postgresql.cnpg.io/v1
+)
+
+# Extract the resource block for `kind: <k>` named <n> from a render.
+# Uses herestrings throughout — a `grep -q` on a pipe closes it and kills the
+# producer with SIGPIPE 141, which `set -o pipefail` turns into a false FAIL
+# (the #5531/#5537 catalog-wide class).
+svc_block() {
+  awk '/^---$/{f=0} /^# Source: bp-guacamole\/templates\/guacamole-service.yaml$/{f=1} f' <<<"$1"
+}
+
+# ── Case 1: default render carries NO mesh annotations ──────────────────────
+echo "[bp-guacamole] Case 1: default (crossRegion off) — no mesh annotations"
+out=$("$helm" template smoke "$chart_dir" "${base[@]}" 2>&1)
+if grep -q "service.cilium.io/global" <<<"$out"; then
+  echo "FAIL: default render carries service.cilium.io/global — single-region Sovereigns must be untouched"
+  exit 1
+fi
+if ! grep -qE "^  name: guacamole-server$" <<<"$(awk '/^kind: Deployment$/{f=1} /^---$/{f=0} f' <<<"$out")"; then
+  echo "FAIL: default render is missing the guacamole-server Deployment"
+  exit 1
+fi
+echo "[bp-guacamole] Case 1: PASS"
+
+# ── Case 2: primary exports its backends and keeps the full workload set ────
+echo "[bp-guacamole] Case 2: crossRegion primary — global+shared, workloads present"
+out=$("$helm" template smoke "$chart_dir" "${base[@]}" \
+  --set crossRegion.enabled=true --set crossRegion.role=primary \
+  --set 'crossRegion.peerClusters={peer-mesh-b}' 2>&1)
+svc=$(svc_block "$out")
+for want in 'service.cilium.io/global: "true"' 'service.cilium.io/shared: "true"' 'service.cilium.io/affinity: "local"'; do
+  if ! grep -qF -- "$want" <<<"$svc"; then
+    echo "FAIL: primary guacamole-server Service missing [$want]"
+    exit 1
+  fi
+done
+if ! grep -qE "^  name: guacamole-server$" <<<"$(awk '/^kind: Deployment$/{f=1} /^---$/{f=0} f' <<<"$out")"; then
+  echo "FAIL: primary region must still run the webapp Deployment"
+  exit 1
+fi
+if ! grep -q "kind: CiliumNetworkPolicy" <<<"$out"; then
+  echo "FAIL: primary region did not render the cross-region CiliumNetworkPolicy"
+  exit 1
+fi
+# The CNP must name the PEER cluster and the gate's own namespace — a rule that
+# omits either is silently narrowed to nothing (the #4854 row 67 L2 trap).
+cnp=$(awk '/^---$/{f=0} /^# Source: bp-guacamole\/templates\/crossregion-netpol.yaml$/{f=1} f' <<<"$out")
+for want in 'io.cilium.k8s.policy.cluster' '- "peer-mesh-b"' '- "oidc-gate"' 'app.kubernetes.io/name: bp-oidc-gate'; do
+  if ! grep -qF -- "$want" <<<"$cnp"; then
+    echo "FAIL: cross-region CNP missing [$want]"
+    exit 1
+  fi
+done
+echo "[bp-guacamole] Case 2: PASS"
+
+# ── Case 3: THE LOAD-BEARING ONE — secondary renders no serving workload ────
+echo "[bp-guacamole] Case 3: crossRegion secondary — zero local backends"
+out=$("$helm" template smoke "$chart_dir" "${base[@]}" \
+  --set crossRegion.enabled=true --set crossRegion.role=secondary \
+  --set 'crossRegion.peerClusters={peer-mesh-a}' 2>&1)
+
+# (a) NO Deployment of any kind — neither webapp nor guacd.
+if grep -q "^kind: Deployment$" <<<"$out"; then
+  echo "FAIL: the secondary region rendered a Deployment. Its guacamole-server"
+  echo "      Service must have ZERO local backends, otherwise the shared VIP"
+  echo "      again splits one browser session across two in-memory"
+  echo "      HashTokenSessionMaps and the SPA renders the #5358 blank page."
+  grep -B2 -A4 "^kind: Deployment$" <<<"$out" | head -20
+  exit 1
+fi
+# (b) NO second permission store.
+if grep -q "^kind: Cluster$" <<<"$out"; then
+  echo "FAIL: the secondary region rendered its own CNPG permission store —"
+  echo "      ADR-0001 §11 allows exactly ONE Guacamole per Sovereign."
+  exit 1
+fi
+# (c) but the Service MUST exist — it is the mesh stub the peer merges with.
+svc=$(svc_block "$out")
+if [ -z "$svc" ]; then
+  echo "FAIL: the secondary region must still render the guacamole-server Service —"
+  echo "      Cilium merges ClusterMesh global Services by name+namespace, so the"
+  echo "      name has to exist in every participating cluster."
+  exit 1
+fi
+for want in 'service.cilium.io/global: "true"' 'service.cilium.io/shared: "false"'; do
+  if ! grep -qF -- "$want" <<<"$svc"; then
+    echo "FAIL: secondary guacamole-server Service missing [$want]"
+    exit 1
+  fi
+done
+echo "[bp-guacamole] Case 3: PASS"
+
+# ── Case 4: no peers → no CNP (single-region byte-identity) ─────────────────
+echo "[bp-guacamole] Case 4: empty peerClusters — no CiliumNetworkPolicy"
+out=$("$helm" template smoke "$chart_dir" "${base[@]}" \
+  --set crossRegion.enabled=true --set crossRegion.role=primary 2>&1)
+if grep -q "kind: CiliumNetworkPolicy" <<<"$out"; then
+  echo "FAIL: rendered a cross-region CNP with an empty peerClusters list"
+  exit 1
+fi
+echo "[bp-guacamole] Case 4: PASS"
+
+# ── Case 5: an unknown role must fail the render, never render silently ─────
+echo "[bp-guacamole] Case 5: invalid crossRegion.role fails fast"
+if "$helm" template smoke "$chart_dir" "${base[@]}" \
+    --set crossRegion.enabled=true --set crossRegion.role=standby >/dev/null 2>&1; then
+  echo "FAIL: crossRegion.role=standby rendered instead of failing — a typo'd role"
+  echo "      would silently fall back to a full second Guacamole."
+  exit 1
+fi
+echo "[bp-guacamole] Case 5: PASS"
+
+echo "[bp-guacamole] cross-region render audit: ALL PASS"

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -30,6 +30,71 @@ catalystBlueprint:
 # openova-io so they carry their own registry and are untouched.
 global:
   imageRegistry: ""
+# ── Cross-region singleton discipline (#5358) ────────────────────────────
+# ADR-0001 §11 mandates ONE Guacamole per Sovereign. Until 0.2.36 the
+# bootstrap-kit installed this chart identically on EVERY region's control
+# plane, so a 2-region Sovereign ran TWO fully independent Guacamoles — each
+# with its own webapp Pod, its own guacd, and its own CNPG permission store —
+# while ONE shared wildcard VIP fanned `guacamole.<fqdn>` at BOTH regions'
+# envoys.
+#
+# Guacamole keeps its REST session in a per-Pod IN-MEMORY HashTokenSessionMap
+# (o.a.g.rest.auth.HashTokenSessionMap — there is no shared-session option
+# upstream), so a token minted by whichever region answered `POST /api/tokens`
+# is UNKNOWN to the other region's Pod, which answers 403 PERMISSION_DENIED.
+# The browser opens several parallel HTTP/1.1 connections per page load and
+# the shared VIP spreads them across both regions, so a SINGLE page load is
+# routinely served by both instances.
+#
+# Measured live on hw292 (dep 1c56518035a83e03, webapp access logs, one page
+# load in the SAME second):
+#     region-A  POST /guacamole/api/tokens                        200  ← minted
+#     region-B  GET  …/postgresql/self/effectivePermissions        403
+#     region-B  GET  …/postgresql-shared/connectionGroups/ROOT/tree 403
+#     region-B  GET  /guacamole/images/warning.svg                 200  ← error icon
+# and reproduced as a control: the SAME token replayed against region-A's Pod
+# returns 200 while region-B's Pod returns 403 PERMISSION_DENIED.
+#
+# The 403 is fatal to the SPA: homeController's only error handler is
+# `requestService.DIE`, so `rootConnectionGroups` stays null, `isLoaded()`
+# never turns true, and home.html keeps `class="home-view view loading"` —
+# whose CSS is `.loading * { visibility: hidden }`. Every element stays in the
+# DOM but invisible, which is exactly the reported BLANK page whose innerText
+# is pure whitespace (UAT rows 35 / R9).
+#
+# The fix is the SAME idiom bp-harbor 1.2.45 (#5406) used for the identical
+# Redis-backed session split, and bp-openbao / bp-cnpg-pair / bp-catalyst-
+# edge-routes use for their singletons: anchor the workload in the PRIMARY
+# region and let the secondary reach it over Cilium ClusterMesh.
+#
+#   enabled=false (DEFAULT, and every single-region Sovereign)
+#     → renders exactly what 0.2.35 rendered. Byte-identical.
+#   enabled=true, role=primary
+#     → full workload set + `service.cilium.io/global|shared` on the webapp
+#       Service so the peer can dial it, + a CiliumNetworkPolicy admitting the
+#       peer region's oidc-gate Pods to :8080.
+#   enabled=true, role=secondary
+#     → NO webapp/guacd/JDBC workloads at all; the webapp Service renders as a
+#       ZERO-backend ClusterMesh stub so every dial falls through to primary.
+crossRegion:
+  # Render the ClusterMesh global-Service annotations + the cross-region
+  # CiliumNetworkPolicy, and honour `role`. Default OFF.
+  enabled: false
+  # This region's role in the pair: primary | secondary. Slot 52 stamps it
+  # from the per-region ${SOVEREIGN_REGION_ROLE} cloud-init substitute.
+  role: primary
+  # Peer ClusterMesh cluster name(s) — the SAME source var bp-harbor (19),
+  # bp-postgres (16a/16c/16d) and bp-cnpg-pair (16b) consume,
+  # ${SOVEREIGN_PEER_CLUSTERMESH_NAMES}. EMPTY (single-region) → NO
+  # CiliumNetworkPolicy is rendered.
+  peerClusters: []
+  webapp:
+    # Cilium global-service backend preference. `local` prefers backends in
+    # this cluster and falls through to the peer only when there are none —
+    # so the primary never bounces a request to the secondary, and the
+    # secondary (which has no local backends by design) always reaches the
+    # primary. Same value bp-openbao's openbao-active-mesh uses.
+    affinity: local
 # Top-level enable gate. When false, NO resources render. Verified by
 # `helm template` test in tests/.
 guacamole:

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -14,7 +14,7 @@ spec:
   # upstream) instead of relying on bp-plane-isolation leaving the oidc-gate
   # namespace's egress open. Lockstep with platform/oidc-gate/chart +
   # the bootstrap-kit slot 13c pin.
-  version: 0.1.9
+  version: 0.1.10
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -170,7 +170,43 @@ name: bp-oidc-gate
 # Cilium unions every policy selecting an endpoint, so while
 # bp-plane-isolation's open-egress rule is present the effective union is
 # unchanged and no working gate can be severed.
-version: 0.1.9
+# 0.1.10 (#5358): the egress half learns about ClusterMesh singletons and about
+# the post-DNAT port. Two independent gaps, both of which silently break a gate
+# whose upstream is not a plain local Service on its own pod port:
+#   (1) POD PORT. Rule 3 derived its allowed port from the `upstream` URL, which
+#       names the SERVICE port — but Cilium's egress verdict runs AFTER the
+#       Service DNAT, so the load-bearing port is the BACKEND POD's. This is the
+#       exact #4437 trap rule 2 already documented for the Keycloak hop and rule
+#       3 did not apply. Every real gate upstream on a Sovereign is an :80
+#       Service in front of an :8080 Pod (guacamole-server, openova-flow-server,
+#       powerdns-admin), so rule 3 allowed :80 and dropped the actual dial —
+#       masked today ONLY by bp-plane-isolation's open-egress rule, i.e. the very
+#       cross-chart dependency #5617 set out to remove, and ABSENT in the
+#       per-Organization namespaces bp-agenity installs this same gate into.
+#       Rule 3 now allows the Service port AND the Pod port (new per-instance
+#       `upstreamPodPort`, default 8080; when it equals the Service port only one
+#       port is emitted, so the existing single-port renders are unchanged).
+#   (2) PEER CLUSTER. bp-guacamole 0.2.36 anchors the Guacamole webapp in ONE
+#       region and lets the other region's gate reach it through a zero-backend
+#       ClusterMesh global Service — because Guacamole's REST session lives in a
+#       per-Pod in-memory HashTokenSessionMap and one instance per region behind
+#       a shared VIP 403'd half of every page load (#5358's blank page). Rule 3
+#       can NEVER authorise that dial: Cilium AND-injects
+#       `io.cilium.k8s.policy.cluster=<local>` into every selector derived from a
+#       namespaced CNP (`policy-default-local-cluster: "true"`, read live from
+#       hw292's cilium-config). New `crossRegion.peerClusters` (same source var
+#       bp-guacamole/bp-harbor/bp-postgres/bp-cnpg-pair consume,
+#       ${SOVEREIGN_PEER_CLUSTERMESH_NAMES}) emits rule 3b: the SAME upstream
+#       namespace + ports in the NAMED peer cluster(s) only — no `world`, no
+#       extra ports, no widening of the local surface. Without it the gate's own
+#       policy would silently undo the #5358 fix the moment slot 13c rolled.
+# EMPTY peerClusters (the default, and every single-region Sovereign) → no rule
+# 3b, and the rendered policy is byte-identical to 0.1.9. Lockstep:
+# 13c-bp-oidc-gate.yaml pin + crossRegion.peerClusters + blueprint.yaml.
+# Guard: chart/tests/netpol-render.sh Cases 5 + 6 (Case 5 FAILS against the
+# pre-fix chart, which allows only :80 to the guacamole namespace).
+# Refs #5358 #5617 #4437.
+version: 0.1.10
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/networkpolicy.yaml
+++ b/platform/oidc-gate/chart/templates/networkpolicy.yaml
@@ -39,6 +39,9 @@ remote. Every rule below names identities.
 {{- $np := .Values.networkPolicy | default dict -}}
 {{- if and (ne (toString $np.enabled) "false") ($root.Capabilities.APIVersions.Has "cilium.io/v2") }}
 {{- $egressCfg := $np.egress | default dict -}}
+{{- /* #5358 — peer ClusterMesh cluster names; EMPTY (single-region) renders no
+     extra egress rule, so the policy stays byte-identical to 0.1.9. */ -}}
+{{- $peerClusters := (($root.Values.crossRegion | default dict).peerClusters | default list) -}}
 {{- $kcNamespace := $egressCfg.keycloakNamespace | default "keycloak" -}}
 {{- $kcPort := $egressCfg.keycloakPort | default 80 -}}
 {{- $kcInternal := trimSuffix "/" ($root.Values.keycloakInternalURL | default "") -}}
@@ -70,6 +73,23 @@ chart-authoring error and fails the render (Inviolable Principle #4).
 {{- $hostLabels := splitList "." $upHost }}
 {{- $upNamespace := $root.Release.Namespace }}
 {{- if gt (len $hostLabels) 1 }}{{- $upNamespace = index $hostLabels 1 }}{{- end }}
+{{- /*
+The upstream's POD port, which is what the policy verdict actually sees.
+`upstream` names the SERVICE port, but Cilium's egress verdict runs AFTER the
+Service DNAT, so the load-bearing port is the backend Pod's — the exact
+#4437 trap rule 2 already documents for the Keycloak hop. Every gate upstream
+on a Sovereign today is an :80 Service in front of an :8080 Pod
+(guacamole-server, openova-flow-server, powerdns-admin), so 8080 is the
+default; override per instance with `upstreamPodPort` when it differs.
+Emitting both is a negligible widening (same namespace, same identity) and
+removes a silent-drop failure mode that is otherwise masked only by
+bp-plane-isolation's open-egress rule — the very cross-chart dependency #5617
+set out to remove, and one that is ABSENT in the per-Organization namespaces
+bp-agenity installs this same gate into.
+*/ -}}
+{{- $upPodPort := ($inst.upstreamPodPort | default "8080") | toString }}
+{{- $upPorts := list $upPort }}
+{{- if ne $upPodPort $upPort }}{{- $upPorts = append $upPorts $upPodPort }}{{- end }}
 ---
 # ── CiliumNetworkPolicy — admit the Cilium Gateway Envoy to the gate pod ──
 # The gate's HTTPRoute owns the app's public hostname; gateway traffic carries
@@ -149,14 +169,46 @@ spec:
               protocol: TCP
             - port: "8080"
               protocol: TCP
-    # 3. The proxied upstream ({{ $raw }}).
+    # 3. The proxied upstream ({{ $raw }}) — Service port AND Pod port; see the
+    #    $upPodPort note above (#4437 post-DNAT trap).
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: {{ $upNamespace }}
       toPorts:
         - ports:
-            - port: {{ $upPort | quote }}
+            {{- range $upPorts }}
+            - port: {{ . | quote }}
               protocol: TCP
+            {{- end }}
+{{- if gt (len $peerClusters) 0 }}
+    # 3b. The SAME upstream in a peer ClusterMesh cluster (#5358). Rule 3
+    #     above can only ever match a LOCAL Pod: Cilium AND-injects
+    #     `io.cilium.k8s.policy.cluster=<local>` into every selector derived
+    #     from a namespaced CNP. When the upstream is a mesh singleton (one
+    #     region owns the workload, the other reaches it through a
+    #     zero-backend global Service — bp-guacamole 0.2.36) the local-only
+    #     rule denies the dial and the gate 502s. Scoped to the upstream's own
+    #     namespace + port in the named peer cluster(s) only — no `world`, no
+    #     extra ports, no widening of the local surface.
+    - toEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values:
+                - {{ $upNamespace | quote }}
+      toPorts:
+        - ports:
+            {{- range $upPorts }}
+            - port: {{ . | quote }}
+              protocol: TCP
+            {{- end }}
+{{- end }}
 {{- if not $kcInternal }}
     # 4. Public-issuer discovery fallback (#3844 public-discovery mode).
     - toEntities:

--- a/platform/oidc-gate/chart/tests/netpol-render.sh
+++ b/platform/oidc-gate/chart/tests/netpol-render.sh
@@ -91,6 +91,50 @@ if mode == "rule":
     print(body, file=sys.stderr)
     sys.exit(1)
 
+if mode == "peerrule":
+    # #5358 — the cross-region half. Requires ONE egress rule whose
+    # toEndpoints names BOTH the peer ClusterMesh cluster AND the upstream
+    # namespace via matchExpressions, AND allows port/proto. Asserting the
+    # cluster key alone would pass on a rule scoped to the wrong namespace,
+    # which Cilium silently narrows to nothing (#4854 row 67 L2).
+    peer, ns, port, proto = sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7]
+
+    def expr_has(ep, key, value):
+        for e in ep.get("matchExpressions") or []:
+            if e.get("key") == key and value in (e.get("values") or []):
+                return True
+        return False
+
+    for rule in (doc.get("spec") or {}).get("egress") or []:
+        eps = rule.get("toEndpoints") or []
+        if not any(
+            expr_has(ep, "io.cilium.k8s.policy.cluster", peer)
+            and expr_has(ep, "k8s:io.kubernetes.pod.namespace", ns)
+            for ep in eps
+        ):
+            continue
+        for tp in rule.get("toPorts") or []:
+            for p in tp.get("ports") or []:
+                if str(p.get("port")) == port and str(p.get("protocol")) == proto:
+                    sys.exit(0)
+    print(
+        f"FAIL: {name} has no egress rule allowing {port}/{proto} to namespace "
+        f"{ns} in peer cluster {peer}",
+        file=sys.stderr,
+    )
+    print(body, file=sys.stderr)
+    sys.exit(1)
+
+if mode == "nopeer":
+    for rule in (doc.get("spec") or {}).get("egress") or []:
+        for ep in rule.get("toEndpoints") or []:
+            for e in ep.get("matchExpressions") or []:
+                if e.get("key") == "io.cilium.k8s.policy.cluster":
+                    print(f"FAIL: {name} rendered a peer-cluster rule with no peerClusters set", file=sys.stderr)
+                    print(body, file=sys.stderr)
+                    sys.exit(1)
+    sys.exit(0)
+
 needle = sys.argv[4]
 found = needle in body
 if mode == "present" and not found:
@@ -168,6 +212,47 @@ grep -qF 'name: "oidc-gate-openova-flow"' "$work/off.yaml" || {
   echo "      would then pass vacuously." >&2
   exit 1
 }
+echo "  PASS"
+
+# ── Case 5: the upstream's POD port is allowed, not just the Service port ───
+# #5358/#4437. `upstream` names the SERVICE port, but Cilium's egress verdict
+# runs AFTER the Service DNAT, so the load-bearing port is the backend Pod's.
+# Every real gate upstream on a Sovereign is an :80 Service in front of an
+# :8080 Pod (guacamole-server, openova-flow-server, powerdns-admin), so a
+# policy that allows only :80 drops every proxied request the moment
+# bp-plane-isolation's open-egress rule is not there to mask it — which is
+# exactly the per-Organization namespace bp-agenity installs this gate into.
+echo "[netpol] Case 5: upstream Pod port allowed alongside the Service port (#4437)"
+cat >"$work/svcport.yaml" <<YAML
+sovereignFQDN: ${fqdn}
+realm: sovereign
+instances:
+  - name: guacamole
+    enabled: true
+    clientId: guacamole-gate
+    upstream: http://guacamole-server.guacamole.svc.cluster.local:80
+YAML
+"$helm" template oidc-gate "$chart_dir" -a cilium.io/v2 -f "$work/svcport.yaml" >"$work/svcport-render.yaml" 2>/dev/null
+gegr="oidc-gate-guacamole-egress"
+assert rule "$work/svcport-render.yaml" "$gegr" guacamole 80 TCP
+assert rule "$work/svcport-render.yaml" "$gegr" guacamole 8080 TCP
+echo "  PASS"
+
+# ── Case 6: the cross-region peer rule (#5358) ──────────────────────────────
+# bp-guacamole 0.2.36 anchors the Guacamole webapp in ONE region; the other
+# region's gate reaches it through a zero-backend ClusterMesh global Service.
+# Rule 3 can never authorise that dial — Cilium AND-injects
+# `io.cilium.k8s.policy.cluster=<local>` into every selector derived from a
+# namespaced CNP (`policy-default-local-cluster: "true"`, read live from hw292's
+# cilium-config). Without this rule the policy silently undoes the #5358 fix.
+echo "[netpol] Case 6: crossRegion.peerClusters renders a peer-cluster egress rule"
+"$helm" template oidc-gate "$chart_dir" -a cilium.io/v2 -f "$work/svcport.yaml" \
+  --set 'crossRegion.peerClusters={peer-mesh-b}' >"$work/peer.yaml" 2>/dev/null
+assert peerrule "$work/peer.yaml" "$gegr" peer-mesh-b guacamole 80 TCP
+assert peerrule "$work/peer.yaml" "$gegr" peer-mesh-b guacamole 8080 TCP
+# Vacuity in the other direction: with NO peers the rule must be absent, so a
+# green Case 6 cannot mean "the template always emits a peer rule".
+assert nopeer "$work/svcport-render.yaml" "$gegr"
 echo "  PASS"
 
 echo "[netpol] ALL CASES PASS"

--- a/platform/oidc-gate/chart/values.yaml
+++ b/platform/oidc-gate/chart/values.yaml
@@ -99,6 +99,30 @@ networkPolicy:
     # allowing only the Service port drops the traffic (#4437's port trap).
     keycloakPort: 80
 
+# ── Cross-region upstream reachability (#5358) ───────────────────────
+# An upstream may be a ClusterMesh SINGLETON: one region owns the workload and
+# the other region's gate reaches it over the mesh through a zero-backend
+# global Service. bp-guacamole 0.2.36 is the first such upstream — Guacamole
+# keeps its REST session in a per-Pod in-memory HashTokenSessionMap, so running
+# one per region behind a shared VIP made a single browser page-load hit two
+# session maps and 403 (the #5358 blank page).
+#
+# The egress half of networkpolicy.yaml names the upstream by
+# `k8s:io.kubernetes.pod.namespace`, and Cilium AND-injects
+# `io.cilium.k8s.policy.cluster=<local>` into every selector derived from a
+# namespaced CNP (`policy-default-local-cluster: "true"`). So WITHOUT the
+# block below the gate on the secondary region is denied its own upstream the
+# moment that upstream stops being local — the policy would silently undo the
+# #5358 fix.
+#
+# EMPTY peerClusters (the default, and every single-region Sovereign) → NO
+# extra rule is rendered and the egress policy is byte-identical to 0.1.9.
+crossRegion:
+  # Peer ClusterMesh cluster name(s) — the SAME source var bp-guacamole (52),
+  # bp-harbor (19), bp-postgres (16a/16c/16d) and bp-cnpg-pair (16b) consume,
+  # ${SOVEREIGN_PEER_CLUSTERMESH_NAMES}.
+  peerClusters: []
+
 # ── Gated app instances ──────────────────────────────────────────────
 # instances:
 #   - name: openova-flow            # instance name (DNS-safe)

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T13:11:15.796Z",
+  "generatedAt": "2026-08-05T18:43:15.723Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -1817,7 +1817,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.35",
+      "version": "0.2.36",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",
@@ -3552,7 +3552,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-cilium",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1952,7 +1952,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.35",
+    "version": "0.2.36",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",
@@ -3687,7 +3687,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-cilium",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1727,7 +1727,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.35"
+  version: "0.2.36"
   visibility: listed
   card:
     title: "Apache Guacamole"
@@ -1745,7 +1745,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.35"
+    version: "0.2.36"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## Root cause — live-proven on hw292 (dep `1c56518035a83e03`), not inferred

ADR-0001 §11 says **one Guacamole per Sovereign**, and this chart's own Application CR claims `placement: singleton`. But bootstrap-kit slot 52 installs on **every** region's control plane, so a 2-region Sovereign actually ran **two fully independent Guacamoles** — own webapp, own guacd, own CNPG permission store — behind **one** shared wildcard VIP.

Guacamole keeps its REST session in a per-Pod **in-memory `HashTokenSessionMap`** (no shared-session option exists upstream). A token minted by whichever region answered `POST /api/tokens` is unknown to the other region's Pod, which answers **403 PERMISSION_DENIED**. A browser opens several parallel HTTP/1.1 connections per page load and the VIP spreads them across both regions, so a single page load is routinely served by both instances.

Webapp access logs, one page load in the **same second**:

```
region-A  POST /guacamole/api/tokens                          200   <- token minted here
region-B  GET  .../postgresql/self/effectivePermissions       403
region-B  GET  .../postgresql-shared/connectionGroups/ROOT/tree 403
region-B  GET  /guacamole/images/warning.svg                  200   <- the error icon
```

**Control experiment** (per the "test a root cause with a control" rule) — one token, replayed in the same instant against each region's Pod:

```
token minted on REGION A
  replay on REGION A -> code=200  {"name":"ROOT","identifier":"ROOT",...}
  replay on REGION B -> code=403  {"message":"Permission Denied.","type":"PERMISSION_DENIED"}
```

### Why the page renders BLANK rather than an error

`homeController`'s only error handler for the connection-tree call is `requestService.DIE`, so `rootConnectionGroups` stays `null` and `isLoaded()` never turns true. `home.html` therefore keeps `class="home-view view loading"`, and `app/index/styles/loading.css` says:

```css
.loading * { visibility: hidden; }
```

Every element stays in the DOM but invisible — which is exactly the reported blank page whose `innerText` is pure whitespace. The same 403 cascade paints the generic "An error has occurred" banner on runs where the DIE broadcast wins the race. **One cause, both reported symptoms.**

### What this is NOT

- Not the implicit-flow nonce replay (#5378) — zero nonce rejections in the logs; header auth is healthy (`POST /api/tokens` with `X-Forwarded-Email` returns 200, and `self/effectivePermissions` carries `ADMINISTER` + 5 `CREATE_*`).
- Not the session-lifetime wedge (#5598 / 0.2.34) — that one needs >60 min idle; this reproduces on a cold first load.

That is why #5358 kept reopening after SSO moved server-side.

## Fix

The idiom **bp-harbor 1.2.45 already used for the identical Redis session split (#5406)**, and bp-openbao / bp-cnpg-pair / bp-catalyst-edge-routes use for their singletons: anchor the workload in the primary region, reach it from the secondary over Cilium ClusterMesh.

**bp-guacamole 0.2.36** — new top-level `crossRegion` block:

| mode | render |
|---|---|
| `enabled=false` (default, every single-region Sovereign) | **byte-identical to 0.2.35** — verified by diffing the full `helm template` output against `origin/main` |
| `role=primary` | full workload set; webapp Service gains `service.cilium.io/global\|shared="true"` + `affinity=local`; adds a CiliumNetworkPolicy admitting the **peer** region's oidc-gate Pods to `:8080` |
| `role=secondary` | **no** webapp / guacd / CNPG Cluster / seed Job / enroll CronJob / Application CR — only `guacamole-server` renders, as a zero-backend mesh stub with `shared="false"` |

Zero local backends is what makes `affinity: local` fall through to the primary. A plain k8s NetworkPolicy could never admit the peer: Cilium AND-injects `io.cilium.k8s.policy.cluster=<local>` into every selector derived from one — `policy-default-local-cluster: "true"`, read live from hw292's `cilium-config` — and an `ipBlock` is equally inert (#4656/#4846/#4854).

**bp-oidc-gate 0.1.10** — two gaps that would have silently re-broken the hop:

1. **Peer cluster.** New `crossRegion.peerClusters` emits egress rule 3b (same upstream namespace + ports, named peer cluster(s) only). Without it the gate's own policy denies the cross-mesh dial the moment slot 13c rolls.
2. **Pod port.** Rule 3 derived its port from the `upstream` URL, which names the **Service** port — but Cilium's verdict runs **after** the Service DNAT. That is the exact #4437 trap rule 2 already documents and rule 3 did not apply. Every real gate upstream is an `:80` Service in front of an `:8080` Pod (`guacamole-server`, `openova-flow-server`, `powerdns-admin`), so rule 3 allowed `:80` and dropped the actual dial — masked today only by bp-plane-isolation's open-egress rule, i.e. the very cross-chart dependency #5617 set out to remove, and **absent** in the per-Organization namespaces bp-agenity installs this same gate into.

## Guards — vacuity-checked in both directions

`platform/guacamole/chart/tests/crossregion-render.sh` (5 cases) and `platform/oidc-gate/chart/tests/netpol-render.sh` (Cases 5 + 6).

Run against the **pre-fix** chart at `origin/main`:

```
[bp-guacamole] Case 2: FAIL: primary guacamole-server Service missing [service.cilium.io/global: "true"]
  pre-fix chart, role=secondary: Deployments rendered: 2   CNPG Clusters rendered: 1   <- Case 3 target
  fixed  chart, role=secondary: Deployments rendered: 0   CNPG Clusters rendered: 0

[netpol] Case 5: FAIL: oidc-gate-guacamole-egress has no egress rule allowing 8080/TCP to namespace guacamole
```

Case 1 (default render carries no mesh annotations) and Cases 1–4 of the netpol suite pass on **both** trees, so neither guard can be satisfied by blanket suppression or blanket annotation.

## End-to-end render with the real slot-52 values (envsubst simulated)

```
single-region  crossRegion={enabled:false, role:primary,   peerClusters:[]}   -> Application, Cluster, CronJob, 2 Deployment, Job, 2 NetworkPolicy, 2 Service
2-region-A     crossRegion={enabled:true,  role:primary,   peerClusters:[b]}  -> ... + 1 CiliumNetworkPolicy
2-region-B     crossRegion={enabled:true,  role:secondary, peerClusters:[a]}  -> 1 Service + 2 NetworkPolicy + 1 CiliumNetworkPolicy   (no workload at all)
```

## Gates run locally

`helm lint` x2 · 4 bp-guacamole + 4 bp-oidc-gate chart tests · bootstrap-kit e2e `go test` · `check-bootstrap-kit-pin-sync` · `check-catalog-seed-lockstep` · `check-no-nodeports` · `check-netpol-egress-completeness` · `check-chart-annotations` · `check-bootstrap-deps` · `check-region-selector-fail-closed` · `check-no-banned-words` · `go build`/`vet` of the catalyst bootstrap api — all green.

Lockstep: slot 52 pin + values, slot 13c pin + values, both `blueprint.yaml`, catalog-seed `source.version`, and the two generated catalog artifacts via `build-catalog.mjs`.

## Not claimed

Delivery to the running hw292 is **not** part of this PR — it runs bp-guacamole 0.2.33 and no live cluster was patched. Runtime proof is a zero-click Guacamole landing on the next fresh **2-region** prov (UAT rows 35 / R9); a single-region prov cannot exercise this path at all.

Refs #5358 #5406 #5617 #4437
