### PR TITLE
fix(catalyst-api): re-derive the per-region HelmRelease census from LIVE cluster state — the Phase-1 snapshot is frozen (Refs #5600)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -1746,6 +1746,22 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 		Level:   "info",
 		Message: "Self-Sovereignty Cutover completed successfully",
 	})
+
+	// #5600 — the cutover is the single biggest post-Phase-1 churn of
+	// HelmReleases there is: it SUSPENDS bp-catalyst-platform, bp-continuum,
+	// bp-openova-mcp, bp-self-sovereign-cutover and bp-velero on the secondary
+	// and installs/patches HRs in BOTH regions. Every one of those changes is
+	// invisible to the Phase-1-terminal census stamped on Result.Regions, which
+	// is exactly why a fully-converged hw292 advertised "Degraded" the moment
+	// it reached cutoverComplete=true. Force a live re-derivation now (bypassing
+	// the poll TTL) so the very first console load after the cutover shows the
+	// cluster as it is, not as it was when Phase 1 ended.
+	if dep := h.resolveCutoverDeployment(); dep != nil {
+		if h.forceRefreshLiveRegionCensus(ctx, dep) {
+			h.log.Info("cutover: per-region HelmRelease census re-derived from live cluster state post-completion (#5600)",
+				"deploymentID", dep.ID)
+		}
+	}
 }
 
 // forceRerun (#5437): the engine has decided this step must produce a FRESH

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -215,6 +215,38 @@ type Deployment struct {
 	// 200 response used to return directly. Nil until the first wipe
 	// completes.
 	lastWipeReport *wipeResponse
+
+	// liveRegionCensus / liveRegionCensusDegraded / liveRegionCensusAt —
+	// #5600. The most recent per-region HelmRelease census RE-DERIVED FROM
+	// LIVE CLUSTER STATE after the Phase-1 watchers were torn down, plus
+	// the wall-clock instant it was derived.
+	//
+	// Result.Regions / Result.ComponentStates are written EXACTLY ONCE, by
+	// markPhase1Done, and never refreshed — so for the whole post-handover
+	// lifetime the census described the cluster as it was the moment Phase 1
+	// ended. Everything after that is invisible to it, including all 11
+	// cutover steps (which suspend bp-catalyst-platform / bp-continuum /
+	// bp-openova-mcp / bp-self-sovereign-cutover / bp-velero on the
+	// secondary and install/patch HRs in BOTH regions). hw292 read
+	// "region-b 57/65, degraded" off that frozen map while the live cluster
+	// had 67 HRs with ZERO un-suspended non-Ready ones.
+	//
+	// These fields are the live re-derivation refreshLiveRegionCensus
+	// publishes. Deliberately IN-MEMORY ONLY (never persisted via
+	// toRecord/fromRecord): a rehydrated record must re-read the cluster
+	// rather than inherit yet another frozen number.
+	liveRegionCensus         []provisioner.RegionHealth
+	liveRegionCensusDegraded bool
+	liveRegionCensusAt       time.Time
+
+	// liveRegionCensusAttemptAt / liveRegionCensusRefreshing gate how often
+	// the live re-derivation runs: at most one attempt per
+	// liveRegionCensusTTL per deployment, and never two concurrently. The
+	// ATTEMPT (not the success) is what the TTL throttles, so an
+	// unreachable cluster cannot turn every poll into a bounded-but-real
+	// apiserver round trip.
+	liveRegionCensusAttemptAt  time.Time
+	liveRegionCensusRefreshing bool
 }
 
 // SlimForHandover returns a copy of the receiver retaining ONLY the
@@ -1026,13 +1058,30 @@ func (d *Deployment) State() map[string]any {
 		// result. While the Phase-1 watchers are still attached (the
 		// pre-handover polling window) we RECOMPUTE the census live off
 		// the in-memory informer caches so the counts track convergence;
-		// once the watchers are torn down at handover we fall back to the
-		// snapshot markPhase1Done persisted onto Result.Regions. Both
-		// paths are surface-only — neither changes d.Status.
-		regions, secondaryDegraded := d.regionHealthForStateLocked()
+		// once the watchers are torn down at handover we serve the live
+		// one-shot re-derivation (#5600) and, only when even that is
+		// unavailable, the frozen snapshot markPhase1Done persisted onto
+		// Result.Regions. Every path is surface-only — none changes
+		// d.Status.
+		regions, secondaryDegraded, censusSource, censusAt := d.regionHealthForStateLocked()
 		if len(regions) > 0 {
 			out["regions"] = regions
 			out["secondaryDegraded"] = secondaryDegraded
+			// #5600 — provenance, always. An operator (and a UAT walker)
+			// must be able to tell a live number from a Phase-1 relic:
+			// the frozen snapshot is what made hw292 advertise Degraded
+			// on a fully-converged, cut-over Sovereign. When the live
+			// re-derivation is unavailable we still serve the snapshot,
+			// but we say so instead of presenting it as current.
+			if censusSource != "" {
+				out["regionCensusSource"] = censusSource
+			}
+			if !censusAt.IsZero() {
+				out["regionCensusAt"] = censusAt.UTC().Format(time.RFC3339)
+			}
+			if regionCensusIsStale(censusSource, censusAt) {
+				out["regionCensusStale"] = true
+			}
 		}
 	}
 	// adoptedAt — handover-finalisation flag (issue #317) lifted to the
@@ -1058,28 +1107,56 @@ func (d *Deployment) State() map[string]any {
 }
 
 // regionHealthForStateLocked returns the per-region HelmRelease health
-// census + the secondaryDegraded roll-up for State() (#3611). The CALLER
-// MUST hold d.mu.
+// census + the secondaryDegraded roll-up for State() (#3611), together with
+// the SOURCE the numbers came from and the instant they were derived
+// (#5600). The CALLER MUST hold d.mu.
 //
-// While the Phase-1 watchers are still attached (liveWatcher for the
-// primary, secondaryWatchers for the rest) it recomputes the census LIVE
-// off the in-memory informer caches so a poll during convergence tracks
-// the real counts. Once the watchers are torn down (handover, or a record
-// restored from disk where no watcher is attached) it returns the snapshot
-// markPhase1Done persisted onto Result.Regions. Both paths are surface-
-// only — this never touches d.Status.
+// Source preference, best first:
+//
+//	(1) live-watchers   — while the Phase-1 watchers are still attached
+//	                     (liveWatcher for the primary, secondaryWatchers for
+//	                     the rest) the census is recomputed off the in-memory
+//	                     informer caches, so a poll during convergence tracks
+//	                     the real counts.
+//	(2) live-list       — once the watchers are torn down (handover, or a
+//	                     record restored from disk), the census published by
+//	                     refreshLiveRegionCensus — a one-shot live list of
+//	                     every region's bp-* HelmReleases (#5600).
+//	(3) phase1-snapshot — the census markPhase1Done stamped onto
+//	                     Result.Regions. LAST RESORT. It is written exactly
+//	                     once, at Phase-1 termination, and never refreshed, so
+//	                     post-cutover it is provably not current — callers
+//	                     surface regionCensusStale=true alongside it rather
+//	                     than presenting it as live.
+//
+// All three paths are surface-only — this never touches d.Status.
 //
 // SnapshotComponents() on each watcher takes only that watcher's own lock,
 // never d.mu, so calling it under d.mu is safe.
-func (d *Deployment) regionHealthForStateLocked() (regions []provisioner.RegionHealth, secondaryDegraded bool) {
+func (d *Deployment) regionHealthForStateLocked() (regions []provisioner.RegionHealth, secondaryDegraded bool, source string, derivedAt time.Time) {
 	primaryAttached := d.liveWatcher != nil
 	secondariesAttached := len(d.secondaryWatchers) > 0
 	if !primaryAttached && !secondariesAttached {
-		// No live watchers — surface the persisted snapshot verbatim.
-		if d.Result == nil {
-			return nil, false
+		// #5600 — prefer the LIVE re-derivation over the frozen Phase-1
+		// snapshot. Result.Regions describes the cluster as it was when
+		// Phase 1 ended; every HelmRelease the 11-step cutover suspended,
+		// installed or patched afterwards is invisible to it.
+		if len(d.liveRegionCensus) > 0 {
+			return d.liveRegionCensus, d.liveRegionCensusDegraded,
+				regionCensusSourceLiveList, d.liveRegionCensusAt
 		}
-		return d.Result.Regions, d.Result.SecondaryDegraded
+		// No live census available (no readable kubeconfig, unreachable
+		// apiserver, or the first poll of a freshly-restarted process) —
+		// surface the persisted snapshot, labelled as the relic it is.
+		if d.Result == nil {
+			return nil, false, "", time.Time{}
+		}
+		var snapAt time.Time
+		if d.Result.Phase1FinishedAt != nil {
+			snapAt = *d.Result.Phase1FinishedAt
+		}
+		return d.Result.Regions, d.Result.SecondaryDegraded,
+			regionCensusSourcePhase1Snapshot, snapAt
 	}
 
 	// Primary states: prefer the live informer cache; fall back to the
@@ -1100,7 +1177,28 @@ func (d *Deployment) regionHealthForStateLocked() (regions []provisioner.RegionH
 	// hcloud control-plane HRs on a Huawei Sovereign, which are suspended and
 	// never go Ready) are excluded from the census, instead of permanently
 	// degrading a healthy non-Hetzner Sovereign.
-	return provisioner.ComputeRegionHealth(d.Request.Provider, primaryRegion, primaryStates, snapshotSecondaryStatesLocked(d))
+	regions, secondaryDegraded = provisioner.ComputeRegionHealth(d.Request.Provider, primaryRegion, primaryStates, snapshotSecondaryStatesLocked(d))
+	return regions, secondaryDegraded, regionCensusSourceWatchers, time.Now()
+}
+
+// regionCensusIsStale reports whether a census from `source` derived at
+// `derivedAt` must be advertised to the console as NOT-CURRENT (#5600).
+//
+// The Phase-1 snapshot is ALWAYS stale — it is written once at Phase-1
+// termination and never refreshed, so by the time anything reads it the
+// cluster has moved on (on hw292 by an entire 11-step cutover). A live-list
+// census goes stale only after liveRegionCensusStaleAfter, which is several
+// refresh TTLs, so one failed refresh does not flap the flag. The watcher
+// path is never stale — it IS the informer cache.
+func regionCensusIsStale(source string, derivedAt time.Time) bool {
+	switch source {
+	case regionCensusSourcePhase1Snapshot:
+		return true
+	case regionCensusSourceLiveList:
+		return derivedAt.IsZero() || time.Since(derivedAt) > liveRegionCensusStaleAfter
+	default:
+		return false
+	}
 }
 
 func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
@@ -1670,7 +1768,7 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 		// #3611 — roll-up the per-region census so the list can badge a
 		// degraded secondary on a "ready" deployment. Same live-or-
 		// persisted source as State(); surface-only.
-		_, entry.SecondaryDegraded = dep.regionHealthForStateLocked()
+		_, entry.SecondaryDegraded, _, _ = dep.regionHealthForStateLocked()
 		if !dep.StartedAt.IsZero() {
 			entry.StartedAt = dep.StartedAt.UTC().Format(time.RFC3339)
 		}
@@ -1683,6 +1781,15 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 		}
 		owner := strings.TrimSpace(strings.ToLower(dep.OwnerEmail))
 		dep.mu.Unlock()
+
+		// #5600 — keep the roll-up honest without paying for it inline.
+		// GET /deployments Ranges the whole fleet, so a SYNCHRONOUS live
+		// re-derivation here would multiply the per-deployment budget by
+		// the fleet size; the kick is TTL-gated and fire-and-forget, and
+		// the next list poll serves the refreshed number. GET
+		// /deployments/{id} — the single surface the readiness pill reads
+		// — refreshes synchronously instead.
+		h.kickLiveRegionCensusRefresh(dep)
 
 		// Owner filter — when an effective owner is set, only emit
 		// deployments whose OwnerEmail matches case-insensitively.
@@ -1784,6 +1891,16 @@ func (h *Handler) GetDeployment(w http.ResponseWriter, r *http.Request) {
 	// freshly-signed. Best-effort: on mint failure, leave the existing
 	// URL in place so a transient signer error doesn't break polling.
 	h.remintHandoverURLForReadyDeployment(dep)
+	// #5600 — re-derive the per-region HelmRelease census from LIVE cluster
+	// state before serving it. Result.Regions is written exactly once, by
+	// markPhase1Done, and never refreshed: post-cutover it describes a cluster
+	// that no longer exists, which is how hw292 advertised "Degraded /
+	// region-b 57/65" while the live secondary had 67 HRs and ZERO
+	// un-suspended non-Ready ones. TTL-gated (liveRegionCensusTTL) and
+	// budget-bounded, so at most one poll per window pays for it and an
+	// unreachable cluster degrades to the labelled fallback instead of
+	// hanging the response.
+	h.refreshLiveRegionCensusIfStale(r.Context(), dep)
 	state := dep.State()
 	// #3925 surface D — enrich with `operationInProgress` so the
 	// Convergence-Monitor top-bar chip can render OPERATION-IN-PROGRESS

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1178,7 +1178,12 @@ func (d *Deployment) regionHealthForStateLocked() (regions []provisioner.RegionH
 	// never go Ready) are excluded from the census, instead of permanently
 	// degrading a healthy non-Hetzner Sovereign.
 	regions, secondaryDegraded = provisioner.ComputeRegionHealth(d.Request.Provider, primaryRegion, primaryStates, snapshotSecondaryStatesLocked(d))
-	return regions, secondaryDegraded, regionCensusSourceWatchers, time.Now()
+	// Zero derivedAt on purpose: this census IS this instant, so a timestamp
+	// would carry no information — and stamping time.Now() would make the
+	// payload differ on every poll of a completely unchanged deployment.
+	// "live-watchers" already says "as of right now"; callers omit the
+	// regionCensusAt key for a zero time.
+	return regions, secondaryDegraded, regionCensusSourceWatchers, time.Time{}
 }
 
 // regionCensusIsStale reports whether a census from `source` derived at

--- a/products/catalyst/bootstrap/api/internal/handler/region_health_live.go
+++ b/products/catalyst/bootstrap/api/internal/handler/region_health_live.go
@@ -104,9 +104,10 @@ const liveRegionCensusListTimeout = 3 * time.Second
 // once per liveRegionCensusTTL; every other poll in the window is free.
 const liveRegionCensusBudget = 8 * time.Second
 
-// regionCensusReadable reports whether a live re-derivation is even meaningful
-// for dep: it is, exactly when Phase 1 has TERMINATED (so the watchers are
-// gone and Result.Regions is frozen) and a Result exists to fall back to.
+// regionCensusRefreshApplicable reports whether a live re-derivation is even
+// meaningful for dep: it is, exactly when Phase 1 has TERMINATED (so the
+// watchers are gone and Result.Regions is frozen) and a Result exists to fall
+// back to.
 // While Phase 1 is still running the watcher path already serves live numbers.
 // The CALLER MUST NOT hold dep.mu.
 func regionCensusRefreshApplicable(dep *Deployment) bool {

--- a/products/catalyst/bootstrap/api/internal/handler/region_health_live.go
+++ b/products/catalyst/bootstrap/api/internal/handler/region_health_live.go
@@ -1,0 +1,354 @@
+// region_health_live.go — #5600: the per-region HelmRelease census must
+// reflect the cluster NOW, not the cluster as it was when Phase 1 ended.
+//
+// ROOT CAUSE (one-line grep). `Result.ComponentStates` is written in exactly
+// ONE place in the whole API — phase1_watch.go markPhase1Done — and the
+// per-region roll-up `Result.Regions` / `Result.SecondaryDegraded` is stamped
+// in the same statement block. Nothing ever refreshes either. Since
+// provisioner.ComputeRegionHealth is a PURE function over those maps, the
+// console's region census froze at Phase-1-terminal time and stayed frozen for
+// the entire post-handover lifetime of the Sovereign.
+//
+// Both symptoms filed on #5600 are that one defect:
+//
+//   - "suspended counted as not-ready" — at snapshot time the by-design-
+//     suspended secondary HRs (bp-catalyst-platform, bp-continuum,
+//     bp-openova-mcp, bp-self-sovereign-cutover, bp-velero) were not yet
+//     suspended and not yet Ready, so they froze as non-installed. They are
+//     NOT being mis-classified today: helmwatch already coerces
+//     `spec.suspend: true` → StateInstalled on live observation (Wave 5.103 /
+//     #2447, and again in ListAndSnapshotHelmReleases). The stored map simply
+//     predates the suspends.
+//   - "stale denominator 65 vs live 67" — same cause, directly: the 2 HRs the
+//     cutover installed arrived after the snapshot.
+//
+// WHY A CENSUS FILTER CANNOT FIX IT. `Result.ComponentStates` is
+// map[componentID]stateString. It carries no suspend information and never
+// will. Adding a `spec.suspend` exclusion to ComputeRegionHealth would pass a
+// synthetic unit test and leave the false Degraded exactly where it is.
+// ComputeRegionHealth needs NO change — it is pure and its ratio math is sound
+// (regionDegraded requires BOTH an absolute shortfall floor AND the 9/10 ratio
+// gate). The defect is entirely in WHAT IT IS FED.
+//
+// THE FIX. Re-derive the census from live cluster state and prefer it over the
+// Phase-1 snapshot. Source preference, best first:
+//
+//	(1) live-watchers   — an attached helmwatch informer cache (the pre-handover
+//	                     window). Free, no I/O; already implemented.
+//	(2) live-list       — a stateless ONE-SHOT list of every region's bp-* HRs
+//	                     via helmwatch.ListAndSnapshotHelmReleases, using the
+//	                     kubeconfigs already on the PVC. THIS FILE.
+//	(3) phase1-snapshot — the frozen Result.Regions. Last resort ONLY, and the
+//	                     payload says so (regionCensusSource + regionCensusStale)
+//	                     instead of presenting stale data as current.
+//
+// This is a SOVEREIGN-SIDE recompute by construction: post-handover the chroot
+// catalyst-api is the process that serves GET /deployments/{id} to the console,
+// and it reads its own cluster (plus each secondary via the kubeconfigs the
+// secondary control-planes deposited). No mothership re-poll is introduced, so
+// ADR-0002 / Principle #11 are untouched — on the mothership the live read
+// simply fails after cutover and the payload falls back, honestly labelled.
+//
+// The real-fault guarantee (region_health.go:69) is PRESERVED, and in fact
+// strengthened: a genuinely non-Ready, un-suspended HelmRelease is read LIVE
+// and still degrades the region. Nothing is added to
+// providerInapplicableComponents.
+package handler
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// regionCensusSource values surfaced on the deployment payload so an operator
+// (and a UAT walker) can tell a live number from a Phase-1 relic.
+const (
+	// regionCensusSourceWatchers — recomputed from the in-memory helmwatch
+	// informer caches of the still-attached Phase-1 watchers.
+	regionCensusSourceWatchers = "live-watchers"
+	// regionCensusSourceLiveList — re-derived by a one-shot live list of
+	// every region's bp-* HelmReleases (post-handover path, #5600).
+	regionCensusSourceLiveList = "live-list"
+	// regionCensusSourcePhase1Snapshot — the FROZEN Phase-1-terminal census.
+	// Always reported as stale: by construction it describes the cluster as
+	// it was when Phase 1 ended, which post-cutover is provably not now.
+	regionCensusSourcePhase1Snapshot = "phase1-snapshot"
+)
+
+// liveRegionCensusTTL throttles the live re-derivation to at most one ATTEMPT
+// per deployment per window. The console polls GET /deployments/{id} every few
+// seconds; without this every poll would fan out one HelmRelease List per
+// region. 30s is well inside "operator perceives it as current" while keeping
+// the apiserver load to ~2 list calls/minute on a 2-region Sovereign.
+const liveRegionCensusTTL = 30 * time.Second
+
+// liveRegionCensusStaleAfter is how old a successfully-derived live census may
+// get before the payload starts flagging it stale. It is deliberately several
+// TTLs so a single failed refresh does not flap the flag — but a cluster that
+// has been unreadable for minutes stops claiming its numbers are current.
+const liveRegionCensusStaleAfter = 5 * time.Minute
+
+// liveRegionCensusListTimeout bounds ONE region's HelmRelease list. A slow or
+// unreachable apiserver must degrade to "could not refresh", never hang the
+// synchronous GET path.
+const liveRegionCensusListTimeout = 3 * time.Second
+
+// liveRegionCensusBudget bounds the WHOLE refresh (primary + every secondary)
+// on the synchronous GET path. Worst case a GET /deployments/{id} pays this
+// once per liveRegionCensusTTL; every other poll in the window is free.
+const liveRegionCensusBudget = 8 * time.Second
+
+// regionCensusReadable reports whether a live re-derivation is even meaningful
+// for dep: it is, exactly when Phase 1 has TERMINATED (so the watchers are
+// gone and Result.Regions is frozen) and a Result exists to fall back to.
+// While Phase 1 is still running the watcher path already serves live numbers.
+// The CALLER MUST NOT hold dep.mu.
+func regionCensusRefreshApplicable(dep *Deployment) bool {
+	if dep == nil {
+		return false
+	}
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Result == nil || dep.Result.Phase1FinishedAt == nil {
+		return false
+	}
+	// A still-attached watcher is a strictly better source — regionHealth-
+	// ForStateLocked prefers it and no list is needed.
+	if dep.liveWatcher != nil || len(dep.secondaryWatchers) > 0 {
+		return false
+	}
+	return true
+}
+
+// claimLiveRegionCensusRefresh is the TTL + single-flight gate. It returns true
+// exactly once per liveRegionCensusTTL per deployment, and never concurrently;
+// the winner MUST call releaseLiveRegionCensusRefresh when done.
+//
+// The stamp is taken on the ATTEMPT, not on success, so a Sovereign whose
+// apiserver is unreachable costs at most one bounded round trip per window
+// rather than one per poll.
+func claimLiveRegionCensusRefresh(dep *Deployment, force bool) bool {
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.liveRegionCensusRefreshing {
+		return false
+	}
+	if !force && !dep.liveRegionCensusAttemptAt.IsZero() &&
+		time.Since(dep.liveRegionCensusAttemptAt) < liveRegionCensusTTL {
+		return false
+	}
+	dep.liveRegionCensusRefreshing = true
+	dep.liveRegionCensusAttemptAt = time.Now()
+	return true
+}
+
+func releaseLiveRegionCensusRefresh(dep *Deployment) {
+	dep.mu.Lock()
+	dep.liveRegionCensusRefreshing = false
+	dep.mu.Unlock()
+}
+
+// invalidateLiveRegionCensusLocked drops any cached live census. Called on wipe
+// so a re-provisioned deployment id can never serve the previous cluster's
+// numbers. The CALLER MUST hold dep.mu.
+func invalidateLiveRegionCensusLocked(dep *Deployment) {
+	dep.liveRegionCensus = nil
+	dep.liveRegionCensusDegraded = false
+	dep.liveRegionCensusAt = time.Time{}
+	dep.liveRegionCensusAttemptAt = time.Time{}
+}
+
+// refreshLiveRegionCensusIfStale is the SYNCHRONOUS entry point used by
+// GET /deployments/{id} — the endpoint whose payload drives the console's
+// readiness pill. TTL-gated, so at most one poll per window pays for the
+// re-derivation and it is bounded by liveRegionCensusBudget.
+//
+// Returns true when a fresh live census was published.
+func (h *Handler) refreshLiveRegionCensusIfStale(ctx context.Context, dep *Deployment) bool {
+	if !regionCensusRefreshApplicable(dep) {
+		return false
+	}
+	if !claimLiveRegionCensusRefresh(dep, false) {
+		return false
+	}
+	defer releaseLiveRegionCensusRefresh(dep)
+	budgetCtx, cancel := context.WithTimeout(ctx, liveRegionCensusBudget)
+	defer cancel()
+	return h.refreshLiveRegionCensus(budgetCtx, dep)
+}
+
+// kickLiveRegionCensusRefresh is the ASYNCHRONOUS entry point used by
+// GET /deployments (the list). The list Ranges over every deployment, so a
+// synchronous refresh there would multiply the budget by the fleet size. The
+// kick returns immediately; the NEXT list poll serves the refreshed roll-up.
+func (h *Handler) kickLiveRegionCensusRefresh(dep *Deployment) {
+	if !regionCensusRefreshApplicable(dep) {
+		return
+	}
+	if !claimLiveRegionCensusRefresh(dep, false) {
+		return
+	}
+	go func() {
+		defer releaseLiveRegionCensusRefresh(dep)
+		ctx, cancel := context.WithTimeout(context.Background(), liveRegionCensusBudget)
+		defer cancel()
+		h.refreshLiveRegionCensus(ctx, dep)
+	}()
+}
+
+// forceRefreshLiveRegionCensus bypasses the TTL. Fired when an operation is
+// KNOWN to have churned HelmReleases in both regions — today that is cutover
+// completion, which is precisely the event that suspends the by-design
+// secondary HRs and installs the 2 extra HRs #5600 saw missing from the
+// denominator. Without this hook the first post-cutover console load would
+// still show the Phase-1 relic until the next poll's TTL expiry.
+func (h *Handler) forceRefreshLiveRegionCensus(ctx context.Context, dep *Deployment) bool {
+	if !regionCensusRefreshApplicable(dep) {
+		return false
+	}
+	if !claimLiveRegionCensusRefresh(dep, true) {
+		return false
+	}
+	defer releaseLiveRegionCensusRefresh(dep)
+	return h.refreshLiveRegionCensus(ctx, dep)
+}
+
+// refreshLiveRegionCensus re-derives the per-region census from LIVE cluster
+// state and publishes it onto dep. Returns true on publish.
+//
+// Completeness contract — the refresh publishes ONLY when every region the
+// deployment declares was actually read:
+//
+//   - the primary MUST be readable (an empty primary map would give priReady=0,
+//     which makes regionDegraded structurally incapable of flagging anything —
+//     a fabricated all-green);
+//   - the number of resolvable secondary kubeconfigs MUST cover the declared
+//     secondary count, and every one of them MUST list successfully.
+//
+// A partial read is discarded, NOT published: half a census is a lie in both
+// directions (it can hide a real fault and it can invent one). The caller then
+// serves the previous live census (if any) or the Phase-1 snapshot, and the
+// payload flags the source — the operator sees "this number is not current"
+// rather than a confident wrong number.
+//
+// READ-ONLY with respect to the persisted record: it never writes
+// dep.Result.Regions / dep.Result.ComponentStates. Deployment.State() hands the
+// *Result pointer to writeJSON, which marshals it OUTSIDE dep.mu, so a write
+// here would race that marshal (the same -race contract
+// resolvePrimaryKubeconfigPath documents). The live census lives in its own
+// in-memory fields instead.
+func (h *Handler) refreshLiveRegionCensus(ctx context.Context, dep *Deployment) bool {
+	dep.mu.Lock()
+	provider := dep.Request.Provider
+	primaryRegion := primaryRegionKey(&dep.Request)
+	dep.mu.Unlock()
+
+	primaryStates, ok := h.liveRegionStates(ctx, "", dep)
+	if !ok {
+		h.log.Debug("region census: live re-derivation skipped — primary HelmRelease list unavailable; serving the previous census (#5600)",
+			"id", dep.ID)
+		return false
+	}
+
+	// Secondary kubeconfig discovery reuses the SAME union the cutover's
+	// region-B legs (#5359) and the ClusterMesh establish trust: the
+	// process-local dep.secondaryKubeconfigPaths map ∪ the on-disk
+	// `<depID>-<regionKey>.yaml` files. That union is immune to the
+	// in-memory loss a catalyst-api restart causes (#4000/#5488), which
+	// matters here because the post-handover chroot is exactly the process
+	// that restarts most often.
+	res := secondaryKubeconfigsForCutover(dep)
+	if res.expected > len(res.paths) {
+		h.log.Debug("region census: live re-derivation skipped — fewer secondary kubeconfigs resolvable than the spec declares (#5600)",
+			"id", dep.ID, "expected", res.expected, "resolved", len(res.paths))
+		return false
+	}
+
+	secondaryStates := make(map[string]map[string]string, len(res.paths))
+	for region, path := range res.paths {
+		states, sok := h.liveRegionStates(ctx, path, nil)
+		if !sok {
+			h.log.Debug("region census: live re-derivation skipped — a declared secondary region could not be listed; refusing to publish a partial census (#5600)",
+				"id", dep.ID, "region", region)
+			return false
+		}
+		secondaryStates[region] = states
+	}
+
+	regions, secondaryDegraded := provisioner.ComputeRegionHealth(
+		provider, primaryRegion, primaryStates, secondaryStates)
+
+	dep.mu.Lock()
+	dep.liveRegionCensus = regions
+	dep.liveRegionCensusDegraded = secondaryDegraded
+	dep.liveRegionCensusAt = time.Now()
+	dep.mu.Unlock()
+	return true
+}
+
+// liveRegionStates lists one region's bp-* HelmReleases and projects them into
+// the componentID → helmwatch-state map ComputeRegionHealth consumes.
+//
+// Exactly one of the two selectors is used: a non-empty kubeconfigPath reads
+// that file (the secondary-region path); an empty one resolves dep's PRIMARY
+// kubeconfig through resolvePrimaryKubeconfigPath (which carries the #3153
+// conventional fallback and the #5131 chroot self-materialize, so a chroot
+// whose primary kubeconfig was never posted back still resolves).
+//
+// The projection goes through helmwatch.ListAndSnapshotHelmReleases, which is
+// where the `spec.suspend: true` → StateInstalled coercion lives (Wave 5.103 /
+// #2447). That is what makes a by-design-suspended secondary read as converged
+// instead of as a shortfall — the coercion was always correct, it just never
+// reached the census because the census never re-read the cluster.
+func (h *Handler) liveRegionStates(ctx context.Context, kubeconfigPath string, dep *Deployment) (map[string]string, bool) {
+	if kubeconfigPath == "" {
+		if dep == nil {
+			return nil, false
+		}
+		resolved, ok := h.resolvePrimaryKubeconfigPath(dep)
+		if !ok {
+			return nil, false
+		}
+		kubeconfigPath = resolved
+	}
+	raw, err := os.ReadFile(kubeconfigPath)
+	if err != nil || len(raw) == 0 {
+		return nil, false
+	}
+	// Honour the test dynamicFactory injection (same pattern as
+	// liveComponentsSnapshot / sovereignDynamicClient); production builds the
+	// real client from the kubeconfig on the PVC.
+	var dyn dynamic.Interface
+	if h.dynamicFactory != nil {
+		dyn, err = h.dynamicFactory(string(raw))
+	} else {
+		dyn, err = helmwatch.NewDynamicClientFromKubeconfig(string(raw))
+	}
+	if err != nil || dyn == nil {
+		return nil, false
+	}
+	listCtx, cancel := context.WithTimeout(ctx, liveRegionCensusListTimeout)
+	defer cancel()
+	snap, err := helmwatch.ListAndSnapshotHelmReleases(listCtx, dyn)
+	if err != nil {
+		return nil, false
+	}
+	// An EMPTY list is not a successful read of a converged cluster — it is
+	// what an apiserver that answers but has no Flux CRD content returns, and
+	// feeding 0/0 into the census would silently zero the primary baseline.
+	// Treat it as "no live truth available" and let the caller fall back.
+	if len(snap) == 0 {
+		return nil, false
+	}
+	states := make(map[string]string, len(snap))
+	for _, cs := range snap {
+		states[cs.AppID] = cs.Status
+	}
+	return states, true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/region_health_live_5600_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/region_health_live_5600_test.go
@@ -1,0 +1,515 @@
+// region_health_live_5600_test.go — falsifiable guards for #5600: the
+// per-region HelmRelease census served to the console must describe the
+// cluster NOW, not the cluster as it was when Phase 1 terminated.
+//
+// ── WHY THE EXISTING TESTS MISSED THIS ────────────────────────────────────
+// provisioner.ComputeRegionHealth already had thorough table tests
+// (region_health_test.go) and State() already had census tests
+// (deployments_region_health_test.go). Every one of them FEEDS THE CENSUS A
+// SYNTHETIC MAP — either directly to the pure function, or by hand-writing
+// Result.Regions onto the deployment record. Neither shape can observe
+// staleness: the pure function is correct for whatever it is handed, and a
+// hand-written Result.Regions is by definition in agreement with itself. So
+// the whole class "the map handed to ComputeRegionHealth is a frozen Phase-1
+// relic" was invisible, and stayed invisible for the entire post-handover
+// lifetime of every 2-region Sovereign.
+//
+// The guards below therefore do the one thing those tests structurally could
+// not: they put a LIVE cluster (fake dynamic client) BEHIND the deployment
+// and assert the served payload tracks the cluster, not the stored snapshot.
+// Each fixture's stored snapshot deliberately DISAGREES with the live cluster,
+// so a regression to snapshot-serving fails loudly.
+//
+// ── VACUITY CHECK — BOTH DIRECTIONS ───────────────────────────────────────
+// A guard that can only ever go one way proves nothing. These four cover:
+//
+//	A. snapshot says DEGRADED, cluster is converged  → must report NOT degraded
+//	B. the literal hw292 shape (7 by-design-suspended secondary HRs)
+//	                                                 → must report NOT degraded
+//	C. snapshot says CONVERGED, cluster has 12 genuinely non-Ready,
+//	   UN-suspended HRs on the secondary             → must report DEGRADED
+//	D. no live read possible                         → must serve the snapshot
+//	                                                    LABELLED as stale
+//
+// C is the one that matters most: it proves the fix did not simply teach the
+// census to answer "false". A real fault still degrades the region, which is
+// the constraint region_health.go:69 states explicitly.
+//
+// Refs #5600.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// hrSpec describes one HelmRelease in a fixture cluster.
+type hrSpec struct {
+	name string
+	// ready=true  → status.conditions Ready=True             (installed)
+	// suspended   → spec.suspend=true, no Ready=True         (installed, via
+	//               the Wave 5.103 / #2447 coercion in ListAndSnapshotHelmReleases)
+	// otherwise   → Ready=False reason=InstallFailed         (failed)
+	ready     bool
+	suspended bool
+}
+
+// newHRFixtureCluster builds a fake dynamic client serving the supplied
+// HelmReleases in flux-system, with the same GVR/list-kind registration the
+// helmwatch package's own fixtures use.
+func newHRFixtureCluster(t *testing.T, hrs []hrSpec) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group:   "helm.toolkit.fluxcd.io",
+		Version: "v2",
+		Kind:    "HelmReleaseList",
+	}, &unstructured.UnstructuredList{})
+
+	objs := make([]runtime.Object, 0, len(hrs))
+	for _, hr := range hrs {
+		spec := map[string]any{}
+		var cond map[string]any
+		switch {
+		case hr.suspended:
+			spec["suspend"] = true
+			// A suspended HR is never marked Ready by Flux — this is the
+			// exact live shape that froze as "non-installed" in the Phase-1
+			// snapshot on hw292.
+			cond = map[string]any{
+				"type":               "Ready",
+				"status":             string(metav1.ConditionFalse),
+				"reason":             "InstallFailed",
+				"message":            "suspended",
+				"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+			}
+		case hr.ready:
+			cond = map[string]any{
+				"type":               "Ready",
+				"status":             string(metav1.ConditionTrue),
+				"reason":             "ReconciliationSucceeded",
+				"message":            "Helm install succeeded",
+				"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+			}
+		default:
+			cond = map[string]any{
+				"type":               "Ready",
+				"status":             string(metav1.ConditionFalse),
+				"reason":             "InstallFailed",
+				"message":            "Helm install failed: timed out waiting for the condition",
+				"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+			}
+		}
+		u := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "helm.toolkit.fluxcd.io/v2",
+				"kind":       "HelmRelease",
+				"metadata": map[string]any{
+					"name":      hr.name,
+					"namespace": helmwatch.FluxNamespace,
+				},
+				"spec":   spec,
+				"status": map[string]any{"conditions": []any{cond}},
+			},
+		}
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "helm.toolkit.fluxcd.io",
+			Version: "v2",
+			Kind:    "HelmRelease",
+		})
+		objs = append(objs, u)
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{helmwatch.HelmReleaseGVR: "HelmReleaseList"},
+		objs...,
+	)
+}
+
+const (
+	census5600PrimaryRegion   = "me-east-215-a"
+	census5600SecondaryRegion = "me-east-215-b-1"
+	census5600PrimaryKC       = "kubeconfig-fixture:primary"
+	census5600SecondaryKC     = "kubeconfig-fixture:secondary"
+)
+
+// census5600Env wires a post-handover 2-region deployment: NO Phase-1
+// watchers attached (so the census takes the post-handover path), a FROZEN
+// Result.Regions snapshot, a primary kubeconfig at <dir>/<id>.yaml and a
+// secondary at <dir>/<id>-<region>.yaml, and a dynamicFactory that routes each
+// kubeconfig to its own fixture cluster.
+//
+// The two kubeconfig locations are the real ones: resolvePrimaryKubeconfigPath
+// reads h.kubeconfigsDir; secondaryKubeconfigsForCutover reads the
+// CATALYST_K8SCACHE_KUBECONFIGS_DIR-backed secondaryKubeconfigsDir(). Both are
+// pointed at the same t.TempDir() here, exactly as they are on a live PVC.
+func census5600Env(t *testing.T, depID string, snapshot *provisioner.Result, primary, secondary []hrSpec) (*Handler, *Deployment) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	if primary != nil {
+		if err := os.WriteFile(filepath.Join(dir, depID+".yaml"), []byte(census5600PrimaryKC), 0o600); err != nil {
+			t.Fatalf("write primary kubeconfig: %v", err)
+		}
+	}
+	if secondary != nil {
+		p := filepath.Join(dir, depID+"-"+census5600SecondaryRegion+".yaml")
+		if err := os.WriteFile(p, []byte(census5600SecondaryKC), 0o600); err != nil {
+			t.Fatalf("write secondary kubeconfig: %v", err)
+		}
+	}
+
+	primaryDyn := newHRFixtureCluster(t, primary)
+	secondaryDyn := newHRFixtureCluster(t, secondary)
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.kubeconfigsDir = dir
+	h.dynamicFactory = func(kubeconfig string) (dynamic.Interface, error) {
+		switch kubeconfig {
+		case census5600PrimaryKC:
+			return primaryDyn, nil
+		case census5600SecondaryKC:
+			return secondaryDyn, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	dep := &Deployment{
+		ID:        depID,
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "t99.omani.works",
+			Provider:      "huawei",
+			Region:        census5600PrimaryRegion,
+			Regions: []provisioner.RegionSpec{
+				{CloudRegion: census5600PrimaryRegion},
+				{CloudRegion: census5600SecondaryRegion},
+			},
+		},
+		Result: snapshot,
+	}
+	close(dep.eventsCh)
+	close(dep.done)
+	h.deployments.Store(dep.ID, dep)
+	return h, dep
+}
+
+// getDeployment5600 drives the real GET /api/v1/deployments/{id} handler —
+// the exact endpoint the sovereign-admin console's readiness pill reads — and
+// returns the decoded payload.
+func getDeployment5600(t *testing.T, h *Handler, depID string) map[string]any {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/"+depID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", depID)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	h.GetDeployment(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /deployments/%s = %d, want 200; body=%s", depID, w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	return got
+}
+
+// regionRow pulls one region entry out of the decoded payload.
+func regionRow(t *testing.T, payload map[string]any, idx int) map[string]any {
+	t.Helper()
+	raw, ok := payload["regions"].([]any)
+	if !ok {
+		t.Fatalf("regions missing or wrong type: %T %v", payload["regions"], payload["regions"])
+	}
+	if idx >= len(raw) {
+		t.Fatalf("regions has %d entries, wanted index %d: %v", len(raw), idx, raw)
+	}
+	row, ok := raw[idx].(map[string]any)
+	if !ok {
+		t.Fatalf("regions[%d] wrong type: %T", idx, raw[idx])
+	}
+	return row
+}
+
+func regionInt(t *testing.T, row map[string]any, key string) int {
+	t.Helper()
+	f, ok := row[key].(float64)
+	if !ok {
+		t.Fatalf("region field %q missing or wrong type: %T %v", key, row[key], row[key])
+	}
+	return int(f)
+}
+
+// readyHRs builds n Ready HelmReleases named bp-comp-<i>.
+func readyHRs(n int) []hrSpec {
+	out := make([]hrSpec, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, hrSpec{name: "bp-comp-" + itoa2(i), ready: true})
+	}
+	return out
+}
+
+// itoa2 formats a small int with a stable 2-digit width so component ids sort
+// predictably in failure output.
+func itoa2(n int) string {
+	const digits = "0123456789"
+	if n < 10 {
+		return "0" + string(digits[n])
+	}
+	return string(digits[(n/10)%10]) + string(digits[n%10])
+}
+
+// ── A. the staleness pin ─────────────────────────────────────────────────
+//
+// TestRegionCensus_IsNotFrozenAtPhase1 is the direct #5600 root-cause guard.
+// The stored Phase-1 snapshot says the secondary is 55/63 and DEGRADED. The
+// live cluster says both regions are fully converged. The served payload must
+// follow the CLUSTER.
+//
+// On the pre-fix tree regionHealthForStateLocked returned d.Result.Regions
+// verbatim whenever no watcher was attached — which, post-handover, is always
+// — so this test fails with secondaryDegraded=true and hrReady=55.
+func TestRegionCensus_IsNotFrozenAtPhase1(t *testing.T) {
+	finished := time.Now().Add(-48 * time.Hour).UTC()
+	snapshot := &provisioner.Result{
+		SovereignFQDN:    "t99.omani.works",
+		Phase1FinishedAt: &finished,
+		// The frozen relic: at Phase-1-terminal time the secondary was
+		// genuinely behind. Two days and one 11-step cutover later it is not.
+		Regions: []provisioner.RegionHealth{
+			{Region: census5600PrimaryRegion, Primary: true, HRReady: 63, HRTotal: 63},
+			{Region: census5600SecondaryRegion, Primary: false, HRReady: 55, HRTotal: 63, Degraded: true},
+		},
+		SecondaryDegraded: true,
+	}
+	h, _ := census5600Env(t, "dep5600-stale", snapshot, readyHRs(20), readyHRs(20))
+
+	got := getDeployment5600(t, h, "dep5600-stale")
+
+	if deg, _ := got["secondaryDegraded"].(bool); deg {
+		t.Errorf("secondaryDegraded = true on a live-converged 2-region Sovereign — the census is still being served from the frozen Phase-1 snapshot (#5600)")
+	}
+	if src, _ := got["regionCensusSource"].(string); src != "live-list" {
+		t.Errorf("regionCensusSource = %q, want %q — the payload must say where the numbers came from", src, "live-list")
+	}
+	if stale, ok := got["regionCensusStale"]; ok {
+		t.Errorf("regionCensusStale = %v on a freshly re-derived census, want the key absent", stale)
+	}
+	sec := regionRow(t, got, 1)
+	if ready, total := regionInt(t, sec, "hrReady"), regionInt(t, sec, "hrTotal"); ready != 20 || total != 20 {
+		t.Errorf("secondary census = %d/%d, want 20/20 (live) — got the frozen 55/63 shape instead", ready, total)
+	}
+	pri := regionRow(t, got, 0)
+	if ready, total := regionInt(t, pri, "hrReady"), regionInt(t, pri, "hrTotal"); ready != 20 || total != 20 {
+		t.Errorf("primary census = %d/%d, want 20/20 (live)", ready, total)
+	}
+}
+
+// ── B. the hw292 shape ───────────────────────────────────────────────────
+//
+// TestRegionCensus_SuspendedByDesignSecondary_NotDegraded reproduces the
+// filed symptom exactly: a converged, cut-over 2-region Sovereign whose
+// secondary carries the seven by-design-suspended HelmReleases named in the
+// issue. It must read secondaryDegraded=false.
+//
+// Note WHY it passes after the fix, because it is not a new exclusion rule:
+// helmwatch.ListAndSnapshotHelmReleases already coerces spec.suspend=true to
+// StateInstalled (Wave 5.103 / #2447). That coercion was always correct — it
+// simply never reached the census, because the census never re-read the
+// cluster. Nothing was added to providerInapplicableComponents and
+// ComputeRegionHealth is untouched.
+func TestRegionCensus_SuspendedByDesignSecondary_NotDegraded(t *testing.T) {
+	finished := time.Now().Add(-72 * time.Hour).UTC()
+	snapshot := &provisioner.Result{
+		SovereignFQDN:    "t99.omani.works",
+		Phase1FinishedAt: &finished,
+		// The numbers hw292 actually served on 2026-08-03 with
+		// cutoverComplete=true: "region primary=false hrReady 57/65 degraded=true".
+		Regions: []provisioner.RegionHealth{
+			{Region: census5600PrimaryRegion, Primary: true, HRReady: 65, HRTotal: 65},
+			{Region: census5600SecondaryRegion, Primary: false, HRReady: 57, HRTotal: 65, Degraded: true},
+		},
+		SecondaryDegraded: true,
+	}
+
+	// Live region-a: 67 HRs, 4 suspended (2 of them the Huawei-gated hcloud
+	// pair, which filterApplicable drops from the census under #4086).
+	primary := append(readyHRs(63),
+		hrSpec{name: "bp-cluster-autoscaler-hcloud", suspended: true},
+		hrSpec{name: "bp-hcloud-ccm", suspended: true},
+		hrSpec{name: "bp-velero", suspended: true},
+		hrSpec{name: "bp-self-sovereign-cutover", suspended: true},
+	)
+	// Live region-b: 67 HRs, 60 Ready, and exactly the by-design-suspended
+	// set the issue enumerates. ZERO un-suspended non-Ready HRs.
+	secondary := append(readyHRs(60),
+		hrSpec{name: "bp-catalyst-platform", suspended: true},
+		hrSpec{name: "bp-cluster-autoscaler-hcloud", suspended: true},
+		hrSpec{name: "bp-continuum", suspended: true},
+		hrSpec{name: "bp-hcloud-ccm", suspended: true},
+		hrSpec{name: "bp-openova-mcp", suspended: true},
+		hrSpec{name: "bp-self-sovereign-cutover", suspended: true},
+		hrSpec{name: "bp-velero", suspended: true},
+	)
+
+	h, _ := census5600Env(t, "dep5600-hw292", snapshot, primary, secondary)
+	got := getDeployment5600(t, h, "dep5600-hw292")
+
+	if deg, _ := got["secondaryDegraded"].(bool); deg {
+		t.Errorf("secondaryDegraded = true on a converged cut-over Sovereign whose only non-Ready secondary HRs are suspended-by-design — this is the #5600 false Degraded")
+	}
+	sec := regionRow(t, got, 1)
+	if deg, _ := sec["degraded"].(bool); deg {
+		t.Errorf("regions[1].degraded = true, want false")
+	}
+	// 67 live HRs minus the 2 Huawei-inapplicable hcloud components = 65,
+	// all of them installed once the suspend coercion is applied.
+	if ready, total := regionInt(t, sec, "hrReady"), regionInt(t, sec, "hrTotal"); ready != 65 || total != 65 {
+		t.Errorf("secondary census = %d/%d, want 65/65 — the frozen record said 57/65 while the cluster had ZERO un-suspended non-Ready HRs", ready, total)
+	}
+}
+
+// ── C. the vacuity check — the census must still be able to say DEGRADED ──
+//
+// TestRegionCensus_LiveFault_StillDegrades runs the fixture in the OPPOSITE
+// direction: the stored snapshot claims the secondary is fully converged,
+// while the live cluster has 12 genuinely non-Ready, UN-suspended
+// HelmReleases on it. The payload must flip to degraded.
+//
+// Without this, guard A and B would be satisfied by a census that always
+// answers "false" — which would be a worse defect than the one being fixed,
+// because it would mask a real secondary-region cascade (the hw145 shape
+// #3611 exists to catch). This also proves the fix does NOT weaken
+// providerInapplicableComponents: the 12 failures are ordinary components on
+// the correct provider and they degrade the region exactly as before.
+func TestRegionCensus_LiveFault_StillDegrades(t *testing.T) {
+	finished := time.Now().Add(-24 * time.Hour).UTC()
+	snapshot := &provisioner.Result{
+		SovereignFQDN:    "t99.omani.works",
+		Phase1FinishedAt: &finished,
+		// The frozen relic here is optimistic — at Phase-1-terminal time
+		// both regions were green. The cascade happened afterwards.
+		Regions: []provisioner.RegionHealth{
+			{Region: census5600PrimaryRegion, Primary: true, HRReady: 65, HRTotal: 65},
+			{Region: census5600SecondaryRegion, Primary: false, HRReady: 65, HRTotal: 65},
+		},
+		SecondaryDegraded: false,
+	}
+
+	primary := readyHRs(65)
+	secondary := readyHRs(53)
+	for i := 53; i < 65; i++ {
+		// Ready=False / InstallFailed, NOT suspended — a real fault.
+		secondary = append(secondary, hrSpec{name: "bp-comp-" + itoa2(i)})
+	}
+
+	h, _ := census5600Env(t, "dep5600-realfault", snapshot, primary, secondary)
+	got := getDeployment5600(t, h, "dep5600-realfault")
+
+	if deg, _ := got["secondaryDegraded"].(bool); !deg {
+		t.Errorf("secondaryDegraded = false while the live secondary has 12 genuinely non-Ready un-suspended HelmReleases — a live census that can only answer 'not degraded' would hide the exact hw145 cascade #3611 exists to catch")
+	}
+	sec := regionRow(t, got, 1)
+	if ready, total := regionInt(t, sec, "hrReady"), regionInt(t, sec, "hrTotal"); ready != 53 || total != 65 {
+		t.Errorf("secondary census = %d/%d, want 53/65 (live)", ready, total)
+	}
+	if src, _ := got["regionCensusSource"].(string); src != "live-list" {
+		t.Errorf("regionCensusSource = %q, want %q", src, "live-list")
+	}
+}
+
+// ── D. honest fallback ───────────────────────────────────────────────────
+//
+// TestRegionCensus_NoLiveRead_FallsBackLabelledStale covers the case where no
+// live read is possible at all (no kubeconfig on the PVC — a mothership record
+// after the Sovereign cut over, or a wiped env). The snapshot is still served
+// so the console does not go blank, but it is LABELLED: regionCensusSource
+// names it as the Phase-1 relic and regionCensusStale flags it.
+//
+// This is the difference between "we don't know" and "we know, and it's this"
+// — presenting a frozen number as current is what let hw292's false Degraded
+// go unchallenged for three days.
+func TestRegionCensus_NoLiveRead_FallsBackLabelledStale(t *testing.T) {
+	finished := time.Now().Add(-6 * time.Hour).UTC()
+	snapshot := &provisioner.Result{
+		SovereignFQDN:    "t99.omani.works",
+		Phase1FinishedAt: &finished,
+		Regions: []provisioner.RegionHealth{
+			{Region: census5600PrimaryRegion, Primary: true, HRReady: 65, HRTotal: 65},
+			{Region: census5600SecondaryRegion, Primary: false, HRReady: 57, HRTotal: 65, Degraded: true},
+		},
+		SecondaryDegraded: true,
+	}
+	// nil/nil → no kubeconfig files written, so every live read misses.
+	h, _ := census5600Env(t, "dep5600-nolive", snapshot, nil, nil)
+
+	got := getDeployment5600(t, h, "dep5600-nolive")
+
+	if src, _ := got["regionCensusSource"].(string); src != "phase1-snapshot" {
+		t.Errorf("regionCensusSource = %q, want %q — a served snapshot must name itself", src, "phase1-snapshot")
+	}
+	if stale, _ := got["regionCensusStale"].(bool); !stale {
+		t.Errorf("regionCensusStale = %v, want true — the Phase-1 snapshot is by construction not current", got["regionCensusStale"])
+	}
+	// The numbers themselves are still surfaced (blank is worse than labelled).
+	sec := regionRow(t, got, 1)
+	if ready, total := regionInt(t, sec, "hrReady"), regionInt(t, sec, "hrTotal"); ready != 57 || total != 65 {
+		t.Errorf("fallback census = %d/%d, want the persisted 57/65", ready, total)
+	}
+}
+
+// ── E. partial reads are discarded, never published ──────────────────────
+//
+// TestRegionCensus_PartialRead_NotPublished proves the completeness contract:
+// when a DECLARED secondary region cannot be listed, the refresh publishes
+// NOTHING rather than a census missing that region. A census built from the
+// primary alone would report a single fully-green region and structurally
+// could not flag a shortfall — an invented all-clear, which is precisely the
+// failure mode this issue is about, only inverted.
+func TestRegionCensus_PartialRead_NotPublished(t *testing.T) {
+	finished := time.Now().Add(-6 * time.Hour).UTC()
+	snapshot := &provisioner.Result{
+		SovereignFQDN:    "t99.omani.works",
+		Phase1FinishedAt: &finished,
+		Regions: []provisioner.RegionHealth{
+			{Region: census5600PrimaryRegion, Primary: true, HRReady: 65, HRTotal: 65},
+			{Region: census5600SecondaryRegion, Primary: false, HRReady: 57, HRTotal: 65, Degraded: true},
+		},
+		SecondaryDegraded: true,
+	}
+	// Primary kubeconfig present, secondary absent → the declared secondary
+	// count (1) exceeds the resolvable paths (0).
+	h, _ := census5600Env(t, "dep5600-partial", snapshot, readyHRs(65), nil)
+
+	got := getDeployment5600(t, h, "dep5600-partial")
+
+	if src, _ := got["regionCensusSource"].(string); src != "phase1-snapshot" {
+		t.Errorf("regionCensusSource = %q, want %q — a half-read census must not be published", src, "phase1-snapshot")
+	}
+	raw, _ := got["regions"].([]any)
+	if len(raw) != 2 {
+		t.Errorf("regions has %d entries, want 2 — the fallback snapshot must keep BOTH declared regions visible", len(raw))
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -608,6 +608,10 @@ func (h *Handler) runWipePurge(dep *Deployment, id string, body wipeRequest, pre
 	// phase1_watch goroutine clearing it on its terminal exit.
 	dep.mu.Lock()
 	live := dep.liveWatcher
+	// #5600 — drop the cached LIVE region census too. It is derived from a
+	// cluster that is about to be destroyed; a re-provision under the same
+	// deployment id must re-read, never inherit the previous cluster's counts.
+	invalidateLiveRegionCensusLocked(dep)
 	dep.mu.Unlock()
 	if live != nil {
 		live.Cancel()


### PR DESCRIPTION
## Root cause — one grep, one write site

`Result.ComponentStates` is written in exactly ONE place in the whole API:

```
products/catalyst/bootstrap/api/internal/handler/phase1_watch.go:1140
    dep.Result.ComponentStates = finalStates
```

(the only other reference is `kubeconfig.go:662`, which nils it). The per-region
roll-up `Result.Regions` / `Result.SecondaryDegraded` is stamped in the same
statement block. Nothing ever refreshes either. `provisioner.ComputeRegionHealth`
is a **pure function over those maps**, so the console's region census froze at
Phase-1-terminal time and stayed frozen for the whole post-handover lifetime of
the Sovereign.

Everything after Phase 1 is invisible to it — including all 11 cutover steps,
which are precisely what suspends `bp-catalyst-platform`, `bp-continuum`,
`bp-openova-mcp`, `bp-self-sovereign-cutover` and `bp-velero` on the secondary
and installs/patches HRs in both regions.

Both symptoms filed on #5600 are that one defect:

| filed as | actually |
|---|---|
| "suspended counted as not-ready" | at snapshot time those HRs were not yet suspended **and** not yet Ready, so they froze as non-installed. They are not being mis-classified today. |
| "stale denominator 65 vs live 67" | same cause, directly: the 2 HRs the cutover added arrived after the snapshot. |

## Why ask #1 as filed was not implemented

Excluding `spec.suspend: true` HRs from the accounting **cannot work**. The
frozen map is `map[componentID]stateString` and carries no suspend information
at all. A suspend filter in `ComputeRegionHealth` would pass a synthetic unit
test and leave the false Degraded exactly where it is.

The live coercion is already correct and is not the bug — `spec.suspend` →
`StateInstalled` is applied at four sites in helmwatch (Wave 5.103 / #2447) and
again in `ListAndSnapshotHelmReleases`. It simply never reached the census,
because the census never re-read the cluster.

## What changed

`ComputeRegionHealth` is **UNCHANGED** — it is pure and its ratio math is sound
(`regionDegraded` correctly requires BOTH the absolute shortfall floor AND the
9/10 ratio gate). `providerInapplicableComponents` is **UNCHANGED** — nothing
was added to it. Only what feeds them changed.

Census source preference, best first:

| # | source | when |
|---|---|---|
| 1 | `live-watchers` | attached helmwatch informer caches (pre-handover). Free, no I/O. Pre-existing. |
| 2 | `live-list` | one-shot `ListAndSnapshotHelmReleases` per region via the kubeconfigs already on the PVC. **NEW.** |
| 3 | `phase1-snapshot` | the frozen `Result.Regions`. Last resort only — and the payload now says so. |

The payload gained `regionCensusSource`, `regionCensusAt` and
`regionCensusStale`, so a fallback is advertised as a Phase-1 relic instead of
being presented as current. That difference between "we don't know" and "we
know, and it's this" is what let hw292's false Degraded go unchallenged.

**Sovereign-side by construction.** Post-handover the chroot catalyst-api is the
process serving `GET /deployments/{id}` to the console; it reads its own cluster
plus each secondary via the kubeconfig union (`dep.secondaryKubeconfigPaths` ∪
on-disk `<depID>-<regionKey>.yaml`) that the #5359 cutover region-B legs and the
ClusterMesh establish already trust — no new credential contract, and immune to
the in-memory loss a catalyst-api restart causes (#4000 / #5488). No mothership
re-poll is introduced, so ADR-0002 / Principle #11 are untouched.

**Refresh triggers.**

- `GET /deployments/{id}` — synchronous, TTL-gated at 30s, budget-bounded at 8s
  (per-region list capped at 3s). At most one poll per window pays for it.
- `GET /deployments` — asynchronous kick. The list Ranges the whole fleet, so a
  synchronous refresh there would multiply the budget by the fleet size.
- **Cutover completion** — forced, bypassing the TTL. It is the single biggest
  post-Phase-1 HelmRelease churn there is, so the very first console load after
  `cutoverComplete=true` shows the cluster as it is.
- Wipe invalidates the cache, so a re-prov under the same id can never inherit
  the previous cluster's counts.

**Completeness contract.** The refresh publishes only when the primary AND every
declared secondary were actually read. A partial read is discarded, not
published: a census built from the primary alone reports one fully-green region
and is structurally incapable of flagging a shortfall — an invented all-clear,
the same failure mode inverted.

## Guards — vacuity-checked in BOTH directions

`internal/handler/region_health_live_5600_test.go` puts a live fake cluster
BEHIND the deployment and drives the real `GET /api/v1/deployments/{id}`
handler. Each fixture's stored snapshot deliberately **disagrees** with the live
cluster.

**Why the existing tests missed this** (noted in the file header): every prior
census test feeds `ComputeRegionHealth` a synthetic map, or hand-writes
`Result.Regions` onto the record. Neither shape can observe staleness — the pure
function is correct for whatever it is handed, and a hand-written
`Result.Regions` agrees with itself by definition. The whole class was invisible.

| test | snapshot says | live cluster says | asserts |
|---|---|---|---|
| A `IsNotFrozenAtPhase1` | secondary 55/63, degraded | both regions converged | not degraded, 20/20, source `live-list` |
| B `SuspendedByDesignSecondary_NotDegraded` | 57/65, degraded (the literal hw292 numbers) | 67 HRs, 7 by-design-suspended, ZERO un-suspended non-Ready | not degraded, 65/65 |
| C `LiveFault_StillDegrades` | **converged** | 12 genuinely non-Ready, **un-suspended** HRs on the secondary | **degraded = true**, 53/65 |
| D `NoLiveRead_FallsBackLabelledStale` | 57/65, degraded | no kubeconfig — no live read possible | snapshot served, `regionCensusSource=phase1-snapshot`, `regionCensusStale=true` |
| E `PartialRead_NotPublished` | 57/65, degraded | primary readable, secondary absent | nothing published; falls back labelled |

C is the load-bearing one: it proves the fix did not simply teach the census to
answer "false". A real fault on the correct provider still degrades the region —
the constraint `region_health.go:69` states explicitly — and it would still catch
the hw145 cascade #3611 exists for.

### Falsification run — all five FAIL pre-fix, PASS after

The test file deliberately uses only pre-existing symbols and pins the **wire
values** (`"live-list"`, `"phase1-snapshot"`) rather than the new constants, so
it compiles and runs against the unpatched tree.

Pre-fix (source changes reverted, test file kept):

```
--- FAIL: TestRegionCensus_IsNotFrozenAtPhase1 (0.00s)
    secondaryDegraded = true on a live-converged 2-region Sovereign
    regionCensusSource = "", want "live-list"
    secondary census = 55/63, want 20/20 (live) — got the frozen 55/63 shape instead
    primary census = 63/63, want 20/20 (live)
--- FAIL: TestRegionCensus_SuspendedByDesignSecondary_NotDegraded (0.00s)
    secondaryDegraded = true on a converged cut-over Sovereign ...
    secondary census = 57/65, want 65/65
--- FAIL: TestRegionCensus_LiveFault_StillDegrades (0.00s)
    secondaryDegraded = false while the live secondary has 12 genuinely non-Ready un-suspended HelmReleases
    secondary census = 65/65, want 53/65 (live)
--- FAIL: TestRegionCensus_NoLiveRead_FallsBackLabelledStale (0.00s)
    regionCensusSource = "", want "phase1-snapshot"
    regionCensusStale = <nil>, want true
--- FAIL: TestRegionCensus_PartialRead_NotPublished (0.00s)
    regionCensusSource = "", want "phase1-snapshot"
FAIL
```

The pre-fix failures reproduce the issue's own numbers (55/63 and 57/65) from a
live cluster that disagrees — that is the staleness, demonstrated.

Post-fix:

```
--- PASS: TestRegionCensus_IsNotFrozenAtPhase1 (0.00s)
--- PASS: TestRegionCensus_SuspendedByDesignSecondary_NotDegraded (0.00s)
--- PASS: TestRegionCensus_LiveFault_StillDegrades (0.00s)
--- PASS: TestRegionCensus_NoLiveRead_FallsBackLabelledStale (0.00s)
--- PASS: TestRegionCensus_PartialRead_NotPublished (0.00s)
PASS
```

## Full suite — real output

`products/catalyst/bootstrap/api`, after merging `origin/main`:

```
$ go build ./... && go vet ./...
(clean, no output)

$ go test ./...
ok  .../internal/handler                255.167s
ok  .../internal/helmwatch               20.276s
ok  .../internal/provisioner              0.445s
ok  .../internal/k8scache                26.362s
ok  .../internal/jobs                     6.715s
... 28 packages ok, 0 FAIL
```

`go test -race ./internal/handler/ -run 'TestRegionCensus|TestGetDeployment|TestState_'`
and `-run 'TestListDeployments|TestWipe|TestPhase1|TestDeployments'` are both
race-clean — relevant because the async list-path kick runs off `dep.mu` while
`State()` marshals `*Result` outside it. The live census is kept in its own
in-memory fields and the refresh never writes `dep.Result`, preserving the
`resolvePrimaryKubeconfigPath` -race contract.

## Not in scope here

No UI change. `ReadinessChip` already renders `degraded` off `secondaryDegraded`;
that value is now live-derived, so the pill self-corrects. The new
`regionCensusStale` / `regionCensusSource` fields are additive and available for
a later "census not current" affordance.

No live cluster was patched. No NodePort anywhere near this.

Refs #5600 #5485 #3611 #4086
