### PR TITLE
fix(#5602): hubble UI 400 — ONE Hubble UI per Sovereign over ClusterMesh (bp-cilium 1.4.19)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -141,7 +141,16 @@ spec:
       # 1370 → 1420 (WG-only). Layers on the 1.4.9/1.4.10 zero-nodeport +
       # authMode=legacy work. Cross-region ClusterMesh pod path needs a fresh
       # 2-region prov to verify (datapath change). Refs #4656.
-      version: 1.4.18
+      # 1.4.19 (#5602, 2026-08-06): ONE Hubble UI per Sovereign over
+      # ClusterMesh. Hubble UI's flow/control streams are a long-poll whose
+      # channel state lives in the hubble-ui backend PROCESS, so the two
+      # backends this slot installs on a 2-region Sovereign — behind ONE
+      # hubble.<fqdn> whose shared ELB fans TCP across both gateways —
+      # answered every cross-region poll HTTP 400 ("Requested events are
+      # empty"), which the SPA paints as a permanent "Idle / Data streams are
+      # reconnecting…". crossRegion below anchors the singleton in the primary
+      # region; the secondary keeps only a zero-backend mesh stub. Refs #5602.
+      version: 1.4.19
       sourceRef:
         kind: HelmRepository
         name: bp-cilium
@@ -537,6 +546,34 @@ spec:
           # restart (hw250 #5059). --oidc-issuer-url + --login-url stay PUBLIC.
           # Verified live: this URL answers the discovery doc 200 in-cluster.
           keycloakInternalURL: http://keycloak.keycloak.svc.cluster.local
+        # ── #5602 — ONE Hubble UI per Sovereign over ClusterMesh ─────────
+        # This slot installs bp-cilium on EVERY region, so a 2-region
+        # Sovereign ran TWO independent hubble-ui backends behind ONE
+        # `hubble.${SOVEREIGN_FQDN}` whose shared Huawei ELB fans TCP across
+        # both regions' gateways. Hubble UI's `/api/service-map-stream` +
+        # `/api/control-stream` are a long-poll whose channel state lives in
+        # the hubble-ui backend PROCESS — only the OPENING message carries the
+        # GetEventsRequest, every follow-up poll is EMPTY — so a poll that
+        # crossed regions hit an unknown channel and hubble-ui answered
+        # HTTP 400 "Requested events are empty, terminating...". The SPA
+        # renders that as a permanent "Idle / Data streams are reconnecting…".
+        # Measured on hw292 (dep 1c56518035a83e03): region-b nginx logged
+        # `POST /api/service-map-stream" 400 62` and the backend logged
+        # `GetEventsRequest parsed ... req=` (empty) at the SAME second, while
+        # sibling polls carried the full req= and returned 200.
+        #
+        # Same seam bp-guacamole (52) uses for the identical per-Pod session
+        # split (#5358) and bp-harbor (19) for its Redis split (#5406).
+        # `enabled` follows SOVEREIGN_ENABLE_CNPG_PAIR — a single-region prov
+        # leaves it false and the render is byte-identical to 1.4.18.
+        crossRegion:
+          enabled: ${SOVEREIGN_ENABLE_CNPG_PAIR:=false}
+          # Per-region cloud-init substitute (primary on region-A + on every
+          # single-region prov, secondary on region-B). `secondary` renders NO
+          # oauth2-proxy Deployment — only the ClusterMesh Service stub — so
+          # the stub has zero local backends and every dial falls through the
+          # mesh to region-A's singleton Hubble UI.
+          role: ${SOVEREIGN_REGION_ROLE:=primary}
 
       # ── #4656/#4854 — per-node pod-CIDR VPC route reconciler ───────────
       # #4807's whole-/16 pod-CIDR peering routes only carry native-routed

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.18
+  version: 1.4.19
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -327,7 +327,50 @@ name: bp-cilium
 #   `unauthorized_client` callback failure if ssoBridgeSync is ever flipped
 #   off. Now there is exactly ONE client secret + ONE cookie secret per gate,
 #   both bridge-published and region-consistent. Refs #5416.
-version: 1.4.18
+# 1.4.19 (#5602, 2026-08-06): ONE Hubble UI per Sovereign over ClusterMesh.
+#   Hubble UI's data plane is NOT a stateless REST API. `/api/service-map-
+#   stream` + `/api/control-stream` speak hubble-ui's own `customprotocol`
+#   long-poll: the OPENING POST carries the serialized GetEventsRequest and
+#   mints a channel held in an IN-PROCESS map
+#   (backend/internal/customprotocol/route/route.go `getChannel` ->
+#   `r.channels.GetByIdUnsafe(cid)`); every FOLLOW-UP poll carries an EMPTY
+#   body and only drains it. A poll that lands on a DIFFERENT backend process
+#   finds no channel, mints a new one from the empty body, and
+#   backend/internal/apiserver/service_map_stream.go answers
+#   `len(req.GetEventTypes()) == 0` with `ch.TerminateStatus(
+#   http.StatusBadRequest)` — the persistent HTTP 400 the SPA paints as
+#   "Idle / Data streams are reconnecting…". Bootstrap-kit slot 01 installs
+#   bp-cilium on EVERY region, so a 2-region Sovereign ran TWO independent
+#   hubble-ui backends behind ONE `hubble.<fqdn>` hostname whose shared Huawei
+#   ELB fans TCP across both regions' gateways — no affinity anywhere.
+#   Live-proven on hw292 (dep 1c56518035a83e03), region-b hubble-ui:
+#     nginx    POST /api/service-map-stream HTTP/1.1" 400 62   (12:54:13Z)
+#     backend  msg="GetEventsRequest parsed" ... req=          <- EMPTY body
+#     backend  msg="Requested events are empty, terminating..."
+#   with the SAME second's sibling polls carrying the full req= and returning
+#   200. Four 400s, and the backend logged the empty-body pair at each one.
+#   FIX = the bp-guacamole 0.2.36 (#5358) / bp-harbor 1.2.45 (#5406) idiom:
+#   new `catalystOverlay.hubbleUI.crossRegion` block. enabled=false (DEFAULT
+#   and every single-region Sovereign) renders byte-identically to 1.4.18.
+#   role=primary keeps the oauth2-proxy Deployment and exports its Service as
+#   a global ClusterMesh service; role=secondary renders NO Deployment, so the
+#   Service it still needs (the HTTPRoute backendRef must resolve, and this
+#   region's envoy must keep answering for `hubble.<fqdn>`) has ZERO local
+#   backends and `service.cilium.io/affinity: local` falls through the mesh to
+#   the primary's singleton. That Cilium surfaces remote-cluster backends
+#   inside Gateway-API envoy clusters was verified live rather than assumed:
+#   on hw292 region-b the envoy cluster `gitea:gitea-http:3000` (a global
+#   Service) carries 10.42.1.191:3000 from region-A alongside its local
+#   10.43.3.228:3000, while the local Endpoints object lists only the latter.
+#   Deliberately NO CiliumNetworkPolicy: unlike bp-guacamole's namespaces,
+#   kube-system on hw292 has zero NetworkPolicies and one CNP that selects
+#   only `reserved:ingress`, so the oauth2-proxy Pod is default-ALLOW — adding
+#   a policy that selects it would flip it to default-deny and regress the
+#   working legs. Only meaningful with auth=oidc (the Catalyst default); under
+#   auth=none the HTTPRoute targets the UPSTREAM hubble-ui Service, which this
+#   chart does not own, so crossRegion is a documented no-op there.
+#   Refs #5602 #5358 #5406.
+version: 1.4.19
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/templates/_hubble-crossregion.tpl
+++ b/platform/cilium/chart/templates/_hubble-crossregion.tpl
@@ -1,0 +1,60 @@
+{{/*
+#5602 — Hubble UI cross-region singleton helpers.
+
+Hubble UI's `/api/service-map-stream` + `/api/control-stream` are a long-poll
+protocol whose channel state lives in an IN-PROCESS map inside the hubble-ui
+BACKEND. Only the OPENING message carries the GetEventsRequest; every follow-up
+poll has an EMPTY body. A poll that reaches a different backend process mints a
+fresh channel from that empty body and hubble-ui answers HTTP 400
+("Requested events are empty, terminating..."), which the SPA renders as a
+permanent "Idle / Data streams are reconnecting…" surface.
+
+A 2-region Sovereign therefore MUST run exactly ONE hubble-ui behind the one
+`hubble.<fqdn>` hostname. These helpers implement the same ClusterMesh idiom
+bp-guacamole 0.2.36 (#5358) and bp-harbor 1.2.45 (#5406) use.
+
+See values.yaml `catalystOverlay.hubbleUI.crossRegion` for the full rationale
+and the live evidence.
+*/}}
+
+{{/*
+Cross-region role. `primary` (default) = this region owns the Sovereign's ONE
+Hubble UI; `secondary` = this region renders the ClusterMesh Service stub only.
+Any other value fails the render rather than silently degrading to primary —
+two primaries is exactly the split this fix removes.
+*/}}
+{{- define "bp-cilium.hubbleUI.crossRegionRole" -}}
+{{- $cr := (.Values.catalystOverlay.hubbleUI.crossRegion | default dict) -}}
+{{- $role := ($cr.role | default "primary") -}}
+{{- if not (has $role (list "primary" "secondary")) -}}
+{{- fail (printf "bp-cilium: invalid catalystOverlay.hubbleUI.crossRegion.role %q — must be \"primary\" (owns the singleton Hubble UI) or \"secondary\" (ClusterMesh stub only)" $role) -}}
+{{- end -}}
+{{- $role -}}
+{{- end }}
+
+{{/*
+Mesh-enabled predicate. Emits "true" only when the ClusterMesh singleton
+treatment actually applies: crossRegion.enabled AND auth=oidc (under auth=none
+the HTTPRoute targets the UPSTREAM hubble-ui Service, which this chart does not
+own and cannot annotate — see values.yaml). Empty string otherwise, so the
+default render is byte-identical to pre-1.4.19.
+*/}}
+{{- define "bp-cilium.hubbleUI.meshEnabled" -}}
+{{- $ov := .Values.catalystOverlay.hubbleUI -}}
+{{- $cr := ($ov.crossRegion | default dict) -}}
+{{- if and $cr.enabled (eq $ov.auth "oidc") -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Mesh-secondary predicate. Emits "true" when this region must run NO
+oauth2-proxy workload, so its `hubble-ui-oauth2-proxy` Service has ZERO local
+backends and `service.cilium.io/affinity: local` falls through the mesh to the
+primary's singleton. Empty string otherwise.
+*/}}
+{{- define "bp-cilium.hubbleUI.isMeshSecondary" -}}
+{{- if and (include "bp-cilium.hubbleUI.meshEnabled" .) (eq (include "bp-cilium.hubbleUI.crossRegionRole" .) "secondary") -}}
+true
+{{- end -}}
+{{- end }}

--- a/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml
@@ -29,7 +29,14 @@ Gated by auth=oidc AND enabled AND a resolvable hostname.
 {{- $hostname = printf "hubble.%s" $ov.sovereignFQDN -}}
 {{- end -}}
 {{- $proxy := $ov.oauth2Proxy -}}
-{{- if and $ov.enabled $hostname (eq $ov.auth "oidc") -}}
+{{- /* #5602 — on the ClusterMesh SECONDARY region this Deployment is
+   deliberately NOT rendered. Hubble UI's flow/control streams keep their
+   channel state in the hubble-ui backend PROCESS, so a Sovereign must run
+   exactly ONE of them behind the one `hubble.<fqdn>` hostname; suppressing the
+   secondary's proxy is what leaves its Service with ZERO local backends, which
+   is in turn what makes `service.cilium.io/affinity: local` fall through the
+   mesh to the primary. See templates/_hubble-crossregion.tpl. */ -}}
+{{- if and $ov.enabled $hostname (eq $ov.auth "oidc") (not (include "bp-cilium.hubbleUI.isMeshSecondary" .)) -}}
 {{- $sovFQDN := $ov.sovereignFQDN -}}
 {{- if and (not $sovFQDN) $ov.hostname -}}
 {{- $sovFQDN = trimPrefix "hubble." $ov.hostname -}}

--- a/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-service.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-service.yaml
@@ -10,12 +10,30 @@ OIDC-authenticated before reaching the upstream hubble-ui Service.
 {{- if and (not $hostname) $ov.sovereignFQDN -}}
 {{- $hostname = printf "hubble.%s" $ov.sovereignFQDN -}}
 {{- end -}}
+{{- $meshEnabled := (include "bp-cilium.hubbleUI.meshEnabled" .) -}}
+{{- $isSecondary := (include "bp-cilium.hubbleUI.isMeshSecondary" .) -}}
 {{- if and $ov.enabled $hostname (eq $ov.auth "oidc") -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: hubble-ui-oauth2-proxy
   namespace: {{ $ov.serviceRef.namespace | quote }}
+{{- if $meshEnabled }}
+  {{- /* #5602 — ClusterMesh singleton. `global` makes this region CONSUME the
+     peer region's backends for this Service; `affinity: local` keeps a region
+     with local backends (the PRIMARY) on its own Pod and lets a region with
+     NONE (the SECONDARY, whose Deployment is suppressed) fall through the mesh
+     to the primary's singleton. `shared` is true only on the primary — the
+     secondary must never EXPORT its zero-backend stub back to the primary.
+     Cilium surfaces these remote backends inside Gateway-API envoy clusters:
+     verified live on hw292 region-b, where the envoy cluster
+     `gitea:gitea-http:3000` (global Service) carries 10.42.1.191:3000 from
+     region-A alongside its local 10.43.3.228:3000. */}}
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: {{ if $isSecondary }}"false"{{ else }}"true"{{ end }}
+    service.cilium.io/affinity: "local"
+{{- end }}
   labels:
     app.kubernetes.io/name: bp-cilium
     app.kubernetes.io/component: hubble-ui-oauth2-proxy

--- a/platform/cilium/chart/tests/hubble-crossregion-singleton.sh
+++ b/platform/cilium/chart/tests/hubble-crossregion-singleton.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# bp-cilium — #5602 Hubble UI cross-region singleton guard.
+#
+# WHAT THIS PROTECTS
+#
+# Hubble UI's `/api/service-map-stream` + `/api/control-stream` are NOT a
+# stateless REST API. They speak hubble-ui's own `customprotocol` long-poll:
+# the OPENING POST carries the serialized GetEventsRequest and mints a channel
+# held in an IN-PROCESS map (hubble-ui
+# backend/internal/customprotocol/route/route.go `getChannel` ->
+# `r.channels.GetByIdUnsafe(cid)`); every FOLLOW-UP poll for that channel
+# carries an EMPTY body and only drains it. A poll that lands on a DIFFERENT
+# backend process finds no channel, mints a fresh one from the empty body, and
+# backend/internal/apiserver/service_map_stream.go answers
+# `len(req.GetEventTypes()) == 0` with `ch.TerminateStatus(
+# http.StatusBadRequest)` — HTTP 400, which the SPA paints as a permanent
+# "Idle / Data streams are reconnecting…" surface.
+#
+# Bootstrap-kit slot 01 installs bp-cilium on EVERY region, so a 2-region
+# Sovereign ran TWO hubble-ui backends behind ONE `hubble.<fqdn>` hostname
+# whose shared ELB fans TCP across both gateways. The fix anchors the workload
+# in the PRIMARY region; the SECONDARY keeps only a zero-backend ClusterMesh
+# stub so `service.cilium.io/affinity: local` falls through to the primary.
+#
+# Cases:
+#   1. DEFAULT (crossRegion absent/disabled) → NO mesh annotations anywhere and
+#      the oauth2-proxy Deployment still renders. Proves the fix cannot be
+#      satisfied by blanket suppression and that single-region is untouched.
+#   2. crossRegion.enabled + role=primary → Deployment renders; Service carries
+#      global=true, shared=true, affinity=local.
+#   3. crossRegion.enabled + role=secondary → NO Deployment (the zero-local-
+#      backend precondition), Service still renders with global=true,
+#      shared=FALSE, affinity=local.
+#      >>> THIS IS THE VACUITY-BREAKING CASE: against the pre-fix chart the
+#          secondary renders a full oauth2-proxy Deployment and an
+#          annotation-free Service, i.e. two live Hubble UIs. <<<
+#   4. auth=none + crossRegion.enabled → documented no-op (the HTTPRoute
+#      targets the UPSTREAM hubble-ui Service, which this chart does not own),
+#      so NO mesh annotations may appear and nothing may be suppressed.
+#   5. invalid role → render FAILS (a typo must never silently degrade to a
+#      second primary, which is the exact split being removed).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+fqdn="smoke.example.com"
+common=(
+  --set catalystOverlay.hubbleUI.enabled=true
+  --set "catalystOverlay.hubbleUI.sovereignFQDN=${fqdn}"
+  --set cilium.clustermesh.apiserver.service.lbIpam.enabled=false
+)
+
+show() {
+  local tmpl="$1"; shift
+  "$helm" template smoke "$chart_dir" "${common[@]}" "$@" --show-only "templates/${tmpl}" 2>/dev/null || true
+}
+
+# Strip YAML comments so the templates' own prose (which names the annotations
+# and the word Deployment) can never satisfy an assertion.
+uncomment() { sed 's/[[:space:]]*#.*$//'; }
+
+has_deployment() { grep -q "^kind: Deployment" <<<"$(uncomment <<<"$1")"; }
+
+assert_ann() { # haystack key value label
+  local got
+  got="$(uncomment <<<"$1" | awk -v k="$2" '$1 == k":" {v=$2; gsub(/"/,"",v); print v; exit}')"
+  if [ "$got" != "$3" ]; then
+    echo "FAIL: $4 — $2 is '${got:-<absent>}' (expected '$3')" >&2; exit 1
+  fi
+}
+
+assert_no_ann() { # haystack label
+  if uncomment <<<"$1" | grep -q "service.cilium.io/"; then
+    echo "FAIL: $2 — ClusterMesh annotations rendered where they must not be" >&2; exit 1
+  fi
+}
+
+oidc=(--set catalystOverlay.hubbleUI.auth=oidc)
+
+# ── Case 1: default render is untouched ───────────────────────────────────
+echo "[hubble-crossregion] Case 1: default (crossRegion off) — no mesh, proxy present"
+dep_def="$(show hubble-ui-oauth2-proxy-deployment.yaml "${oidc[@]}")"
+svc_def="$(show hubble-ui-oauth2-proxy-service.yaml "${oidc[@]}")"
+has_deployment "$dep_def" || { echo "FAIL: default render lost the oauth2-proxy Deployment" >&2; exit 1; }
+assert_no_ann "$svc_def" "default render"
+echo "  PASS (Deployment renders, Service annotation-free)"
+
+# ── Case 2: primary owns the singleton ────────────────────────────────────
+echo "[hubble-crossregion] Case 2: crossRegion primary — proxy present, Service exported"
+prim=("${oidc[@]}" --set catalystOverlay.hubbleUI.crossRegion.enabled=true --set catalystOverlay.hubbleUI.crossRegion.role=primary)
+dep_p="$(show hubble-ui-oauth2-proxy-deployment.yaml "${prim[@]}")"
+svc_p="$(show hubble-ui-oauth2-proxy-service.yaml "${prim[@]}")"
+has_deployment "$dep_p" || { echo "FAIL: primary lost the oauth2-proxy Deployment" >&2; exit 1; }
+assert_ann "$svc_p" "service.cilium.io/global"   "true"  "primary"
+assert_ann "$svc_p" "service.cilium.io/shared"   "true"  "primary"
+assert_ann "$svc_p" "service.cilium.io/affinity" "local" "primary"
+echo "  PASS (global=true shared=true affinity=local, Deployment present)"
+
+# ── Case 3: secondary is a zero-backend mesh stub (VACUITY-BREAKING) ──────
+echo "[hubble-crossregion] Case 3: crossRegion secondary — NO proxy, Service is a mesh stub"
+sec=("${oidc[@]}" --set catalystOverlay.hubbleUI.crossRegion.enabled=true --set catalystOverlay.hubbleUI.crossRegion.role=secondary)
+dep_s="$(show hubble-ui-oauth2-proxy-deployment.yaml "${sec[@]}")"
+svc_s="$(show hubble-ui-oauth2-proxy-service.yaml "${sec[@]}")"
+if has_deployment "$dep_s"; then
+  echo "FAIL: #5602 — the SECONDARY region still renders an oauth2-proxy Deployment." >&2
+  echo "      Its Service then has LOCAL backends, affinity=local never falls through" >&2
+  echo "      the mesh, and the Sovereign runs TWO stateful hubble-ui backends behind" >&2
+  echo "      one hostname — every cross-region poll answers HTTP 400." >&2
+  exit 1
+fi
+grep -q "^kind: Service" <<<"$(uncomment <<<"$svc_s")" || {
+  echo "FAIL: secondary dropped the Service — the HTTPRoute backendRef would not resolve" >&2; exit 1; }
+assert_ann "$svc_s" "service.cilium.io/global"   "true"  "secondary"
+assert_ann "$svc_s" "service.cilium.io/shared"   "false" "secondary"
+assert_ann "$svc_s" "service.cilium.io/affinity" "local" "secondary"
+echo "  PASS (no Deployment; Service global=true shared=false affinity=local)"
+
+# ── Case 4: auth=none is a documented no-op ───────────────────────────────
+echo "[hubble-crossregion] Case 4: auth=none + crossRegion — documented no-op"
+none_sec=(--set catalystOverlay.hubbleUI.auth=none --set catalystOverlay.hubbleUI.crossRegion.enabled=true --set catalystOverlay.hubbleUI.crossRegion.role=secondary)
+svc_n="$(show hubble-ui-oauth2-proxy-service.yaml "${none_sec[@]}")"
+dep_n="$(show hubble-ui-oauth2-proxy-deployment.yaml "${none_sec[@]}")"
+assert_no_ann "$svc_n" "auth=none"
+# auth=none never renders the proxy at all (pre-existing behaviour) — assert the
+# route still points at the upstream Service so nothing regressed.
+route_n="$(show hubble-ui-httproute.yaml "${none_sec[@]}")"
+grep -q "name: \"hubble-ui\"" <<<"$route_n" || {
+  echo "FAIL: auth=none HTTPRoute no longer targets the upstream hubble-ui Service" >&2; exit 1; }
+if has_deployment "$dep_n"; then
+  echo "FAIL: auth=none rendered an oauth2-proxy Deployment" >&2; exit 1
+fi
+echo "  PASS (no annotations, route unchanged)"
+
+# ── Case 5: an invalid role must fail the render, not degrade ─────────────
+echo "[hubble-crossregion] Case 5: invalid crossRegion.role fails the render"
+if "$helm" template smoke "$chart_dir" "${common[@]}" "${oidc[@]}" \
+     --set catalystOverlay.hubbleUI.crossRegion.enabled=true \
+     --set catalystOverlay.hubbleUI.crossRegion.role=replica \
+     --show-only templates/hubble-ui-oauth2-proxy-service.yaml >/dev/null 2>&1; then
+  echo "FAIL: crossRegion.role=replica rendered instead of failing — a typo would" >&2
+  echo "      silently produce a SECOND primary, the exact split this guard covers." >&2
+  exit 1
+fi
+echo "  PASS (render fails closed)"
+
+echo "[bp-cilium #5602 hubble cross-region singleton] All cases PASS"

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -500,6 +500,60 @@ catalystOverlay:
         limits:
           cpu: 100m
           memory: 64Mi
+    # ── #5602 — ONE Hubble UI per Sovereign over Cilium ClusterMesh ──────
+    #
+    # Hubble UI's data plane is NOT a stateless REST API. `/api/service-map-
+    # stream` and `/api/control-stream` speak hubble-ui's own `customprotocol`
+    # long-poll: the FIRST POST carries the serialized GetEventsRequest and
+    # mints a channel that lives in an IN-PROCESS map
+    # (backend/internal/customprotocol/route/route.go `getChannel` ->
+    # `r.channels.GetByIdUnsafe(cid)`); every FOLLOW-UP poll for that channel
+    # carries an EMPTY body and only drains it. A poll that lands on a
+    # DIFFERENT backend process finds no such channel, mints a fresh one from
+    # the empty body, and backend/internal/apiserver/service_map_stream.go
+    # answers `len(req.GetEventTypes()) == 0` with
+    # `ch.TerminateStatus(http.StatusBadRequest)` — HTTP 400. The SPA drops the
+    # stream and paints "Idle / Data streams are reconnecting…" forever.
+    #
+    # Live-proven on hw292 (dep 1c56518035a83e03), region-b hubble-ui:
+    #   nginx    POST /api/service-map-stream HTTP/1.1" 400 62   (12:54:13Z)
+    #   backend  msg="GetEventsRequest parsed" ... req=          <- EMPTY body
+    #   backend  msg="Requested events are empty, terminating..."
+    # while the SAME second's other polls carry the full req= and return 200.
+    #
+    # The Sovereign runs ONE `hubble.<fqdn>` hostname but bootstrap-kit slot 01
+    # installs bp-cilium on EVERY region, so a 2-region Sovereign ran TWO
+    # independent hubble-ui backends behind ONE shared VIP with no affinity.
+    #
+    # FIX (the bp-guacamole 0.2.36 / #5358 idiom): anchor the workload in the
+    # PRIMARY region and reach it from the secondary over ClusterMesh.
+    #   enabled=false (DEFAULT, and every single-region Sovereign) — render is
+    #     byte-identical to pre-1.4.19.
+    #   role=primary   — full oauth2-proxy Deployment; its Service is exported
+    #     as a global ClusterMesh service (affinity local keeps region-A traffic
+    #     on region-A's Pod).
+    #   role=secondary — NO oauth2-proxy Deployment. The Service still renders
+    #     (the HTTPRoute backendRef must resolve, and this region's envoy must
+    #     still answer for `hubble.<fqdn>` — the shared ELB fans TCP across BOTH
+    #     regions' gateways) but has ZERO local backends, so
+    #     `service.cilium.io/affinity: local` falls through the mesh to the
+    #     primary's singleton.
+    #
+    # Cilium DOES surface remote-cluster backends inside Gateway-API envoy
+    # clusters — verified live on hw292 region-b, where the envoy cluster
+    # `gitea:gitea-http:3000` (a global Service) carries BOTH 10.43.3.228:3000
+    # (local) and 10.42.1.191:3000 (region-A) while the local Endpoints object
+    # lists only the former.
+    #
+    # Only meaningful with auth=oidc (the Catalyst default): under auth=none
+    # the HTTPRoute targets the UPSTREAM `hubble-ui` Service, which this chart
+    # does not own and therefore cannot annotate. auth=none + crossRegion is a
+    # no-op — behaviour is unchanged, never a new failure mode.
+    crossRegion:
+      enabled: false
+      # `primary` owns the Sovereign's ONE Hubble UI; `secondary` renders the
+      # mesh stub only. Any other value fails the render.
+      role: primary
 
   # #4656/#4854 — vpc-podcidr-route-reconciler: per-node pod-CIDR VPC routes
   # on no-CCM Huawei. #4807's whole-/16 peering routes only carry pod traffic

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T19:12:29.430Z",
+  "generatedAt": "2026-08-05T19:51:04.829Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -590,7 +590,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.18",
+      "version": "1.4.19",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -725,7 +725,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.18",
+    "version": "1.4.19",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3837,7 +3837,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.18"
+  version: "1.4.19"
   visibility: unlisted
   card:
     title: "Cilium"
@@ -3854,7 +3854,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cilium
-    version: "1.4.18"
+    version: "1.4.19"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
fix(#5602): hubble UI 400 — ONE Hubble UI per Sovereign over ClusterMesh (bp-cilium 1.4.19)

ROOT CAUSE (live-proven on hw292, dep 1c56518035a83e03)

Hubble UI's data plane is NOT a stateless REST API. `/api/service-map-stream`
and `/api/control-stream` speak hubble-ui's own `customprotocol` long-poll: the
OPENING POST carries the serialized GetEventsRequest and mints a channel held in
an IN-PROCESS map (hubble-ui v0.13.3
backend/internal/customprotocol/route/route.go `getChannel` ->
`r.channels.GetByIdUnsafe(cid)`), and every FOLLOW-UP poll for that channel
carries an EMPTY body and only drains it. A poll that lands on a DIFFERENT
backend process finds no channel, mints a fresh one from the empty body, and
backend/internal/apiserver/service_map_stream.go answers

    if len(req.GetEventTypes()) == 0 {
        log.Info("Requested events are empty, terminating...")
        return ch.TerminateStatus(http.StatusBadRequest)
    }

That is the reported HTTP 400. The SPA drops the stream and paints
"Idle / Data streams are reconnecting..." permanently.

Bootstrap-kit slot 01 installs bp-cilium on EVERY region, so a 2-region
Sovereign runs TWO independent hubble-ui backends behind ONE
`hubble.<fqdn>` hostname whose shared Huawei ELB (EIP 212.72.24.74, private
10.72.1.247) fans TCP across BOTH regions' gateways — no affinity anywhere.

EVIDENCE — region-b hubble-ui, the four 400s and the matching backend pair:

    nginx    12:54:13Z  "POST /api/service-map-stream HTTP/1.1" 400 62
    backend  12:54:13Z  msg="GetEventsRequest parsed" ... req=          <- EMPTY
    backend  12:54:13Z  msg="Requested events are empty, terminating..."

    (same at 12:59:15Z, 13:00:53Z, 22:18:51Z; the walk that filed #5602 was
     12:45Z)

while sibling polls in the SAME second carry the full
`req="event_types:FLOWS event_types:SERVICE_STATE ..."` and return 200.
region-a nginx: 116 requests, zero 400. region-b nginx: 1459 requests, 4x 400 —
one browser session split across both regions' backends.

Layers ELIMINATED by the earlier narrowing and re-confirmed here: relay
reachability (streams establish), the oauth2-proxy (its own logs show a clean
401-on-/api under `--api-route`, verified live:
`POST https://hubble.hw292.omani.works/api/ui.UI/GetEvents` -> 401
`grpc-status: 16`, `server: envoy`), and envoy/Gateway timeouts (the vhost route
carries `maxStreamDuration: 0s` and every 400 has a matching backend log line).

FIX — the bp-guacamole 0.2.36 (#5358) / bp-harbor 1.2.45 (#5406) idiom: anchor
the singleton in the PRIMARY region, reach it from the secondary over Cilium
ClusterMesh.

bp-cilium 1.4.19 — new `catalystOverlay.hubbleUI.crossRegion` block
  * enabled=false (DEFAULT, every single-region Sovereign): render is IDENTICAL
    to 1.4.18 — proven by diffing the full `helm template` output against
    origin/main (2202 lines, zero structural difference; the only delta is the
    per-run Hubble TLS material the upstream subchart regenerates each render).
  * role=primary: full oauth2-proxy Deployment; its Service gains
    `service.cilium.io/global|shared="true"` + `affinity: local`, so region-A
    traffic stays on region-A's Pod.
  * role=secondary: NO oauth2-proxy Deployment. The Service still renders — the
    HTTPRoute backendRef must resolve, and this region's envoy must keep
    answering for `hubble.<fqdn>` because the shared ELB fans TCP at both
    gateways — but with `shared="false"` and ZERO local backends, which is what
    makes `affinity: local` fall through the mesh to the primary's singleton.

That Cilium surfaces remote-cluster backends inside Gateway-API envoy clusters
was VERIFIED LIVE, not assumed: on hw292 region-b,
`cilium-dbg envoy admin clusters` shows

    .../gitea:gitea-http:3000::10.43.3.228:3000::cx_active::0   (local)
    .../gitea:gitea-http:3000::10.42.1.191:3000::cx_active::0   (region-A)

for the global `gitea-http` Service, while the local Endpoints object lists only
10.43.3.228:3000. The non-global `hubble-ui-oauth2-proxy` cluster carries only
its local 10.43.1.15:4180 — the control.

Deliberately NO CiliumNetworkPolicy, unlike bp-guacamole: kube-system on hw292
has zero NetworkPolicies, zero CCNPs, and one CNP that selects only
`reserved:ingress`, so the oauth2-proxy Pod is default-ALLOW. Adding a policy
that selects it would flip it to default-deny and regress the legs that work
today.

Only meaningful with auth=oidc (the Catalyst default). Under auth=none the
HTTPRoute targets the UPSTREAM `hubble-ui` Service, which this chart does not
own and cannot annotate, so crossRegion is a documented no-op there — never a
new failure mode. Case 4 of the guard pins that.

Wiring is ARMED, not inert (the #5341/#5399 trap): hw292's live Flux
Kustomization substitutes already carry
`SOVEREIGN_REGION_ROLE=primary` (region-a) / `secondary` (region-b) and
`SOVEREIGN_ENABLE_CNPG_PAIR=true` on both.

GUARD (vacuity-checked in BOTH directions)
  platform/cilium/chart/tests/hubble-crossregion-singleton.sh — 5 cases.
  * Case 3 (secondary renders NO Deployment and a shared="false" mesh Service)
    FAILS against the pre-fix chart, which under the same input renders a full
    oauth2-proxy Deployment and an annotation-free Service — i.e. two live
    Hubble UIs. Demonstrated: pre-fix `kind: Deployment` +
    0 `service.cilium.io/` annotations; post-fix no Deployment + 3 annotations.
  * Case 1 (default render carries no mesh annotations AND still renders the
    Deployment) PASSES on both charts, so the guard cannot be satisfied by
    blanket suppression.
  * Case 5 pins the invalid-role render to fail closed — a typo must never
    silently produce a SECOND primary, which is the exact split being removed.

Local gates green: helm lint, all 5 bp-cilium chart tests (incl. the pre-existing
g117 oauth2-proxy + decorative-gate suites), check-bootstrap-kit-pin-sync (67
pairs), check-catalog-seed-lockstep, check-no-nodeports (platform/cilium/chart
renders zero), check-chart-annotations, check-bootstrap-deps,
check-region-selector-fail-closed, check-no-banned-words, and
go build + go test ./internal/provisioner/... of the catalyst bootstrap api.

Lockstep: Chart.yaml, blueprint.yaml, catalog-seed spec.version + source.version,
both generated catalog artifacts (build-catalog.mjs), and the bootstrap-kit slot
01 pin. Runtime proof = a non-empty Hubble service map on the next fresh
2-region prov (UAT row 39).

Refs #5602 #5358 #5406

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
