### PR TITLE
fix(crd): reject unimplemented hostnameTemplate tokens at admission (Refs #5389)

### DIFF
--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -605,6 +605,17 @@ spec:
                             placement: *PLACEMENT_SPEC
                 endpoints:
                   type: array
+                  # Bounded so the apiserver can cost-estimate the per-item CEL
+                  # rules below (#5389). An unbounded array makes any rule on an
+                  # item field appear astronomically expensive: the
+                  # hostnameTemplate check alone measured 96.5x its per-rule
+                  # budget as a regex, and even as four cheap contains() calls it
+                  # pushed the WHOLE schema 8.7x over its total — which rejects
+                  # the pre-existing topology rules too and leaves the CRD
+                  # uninstallable. Measured live: the largest endpoints[] across
+                  # all 99 Blueprints in this repo is 3 (platform/stalwart-tenant),
+                  # so 16 is generous headroom and constrains nothing real.
+                  maxItems: 16
                   description: |
                     Named external endpoints surfaced by this Blueprint.
                     The Endpoints tab UI (G117.3) renders one card per
@@ -667,10 +678,22 @@ spec:
                         # and one layer in by the resolver itself failing closed.
                         # This rule closes the specific hole that actually shipped.
                         #
-                        # Character classes instead of backslash escapes so the
-                        # expression survives YAML quoting unchanged.
+                        # Uses contains(), NOT matches(). A regex here was
+                        # measured at 96.5x the per-rule CEL cost budget, because
+                        # endpoints[] declares no maxItems so the apiserver
+                        # estimates the rule over an unbounded array — and it
+                        # pushed the ENTIRE schema 9.7x over its total budget,
+                        # which rejects the pre-existing topology rules too and
+                        # leaves the CRD uninstallable. Four contains() calls are
+                        # cheap and stay inside budget.
+                        #
+                        # Two spellings per token is exact coverage, not an
+                        # approximation: resolveHostnameTemplate's own replacer
+                        # handles only `{{.X}}` and `{{ .X }}`, so any other
+                        # spacing is unresolvable regardless of this rule and is
+                        # caught by the resolver failing closed.
                         x-kubernetes-validations:
-                          - rule: "!self.matches('[{][{][ ]*[.](InstanceID|ClusterID)')"
+                          - rule: "!self.contains('{{.InstanceID}}') && !self.contains('{{ .InstanceID }}') && !self.contains('{{.ClusterID}}') && !self.contains('{{ .ClusterID }}')"
                             message: "endpoints[].hostnameTemplate references {{.InstanceID}} or {{.ClusterID}}, which the resolver has never implemented — it substitutes only SovereignFQDN, OrgSlug, AppName and OrgDomain. For a per-instance host use {{.AppName}}: multiInstance.namingTemplate already makes the Application CR name instance-unique."
                       port:
                         type: integer

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -647,6 +647,31 @@ spec:
                           FAILURE: the endpoint reports status Unresolved with
                           no hostname and no launchURL, rather than emitting a
                           URL with the literal braces still in it.
+                        # Reject the two documented-but-never-implemented tokens
+                        # at ADMISSION rather than at resolve time (#5389).
+                        #
+                        # Without this a Blueprint authored through the Git
+                        # surface is admitted happily and only degrades later —
+                        # the endpoint goes Unresolved and its Open button dies,
+                        # far from the edit that caused it. platform/sandbox
+                        # shipped `sandbox-{{.InstanceID}}.{{.OrgDomain}}` on a
+                        # `visibility: listed` Blueprint exactly this way.
+                        #
+                        # Deliberately a DENYLIST of the two named tokens, not an
+                        # allowlist: RE2 has no negative lookahead and CEL cannot
+                        # iterate regex matches, so "every {{...}} is one of the
+                        # four" is not expressible here. The general case is
+                        # covered one layer out by
+                        # TestEveryBlueprintHostnameTemplateResolves_5389, which
+                        # feeds every on-disk template through the real resolver,
+                        # and one layer in by the resolver itself failing closed.
+                        # This rule closes the specific hole that actually shipped.
+                        #
+                        # Character classes instead of backslash escapes so the
+                        # expression survives YAML quoting unchanged.
+                        x-kubernetes-validations:
+                          - rule: "!self.matches('[{][{][ ]*[.](InstanceID|ClusterID)')"
+                            message: "endpoints[].hostnameTemplate references {{.InstanceID}} or {{.ClusterID}}, which the resolver has never implemented — it substitutes only SovereignFQDN, OrgSlug, AppName and OrgDomain. For a per-instance host use {{.AppName}}: multiInstance.namingTemplate already makes the Application CR name instance-unique."
                       port:
                         type: integer
                         minimum: 1

--- a/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
@@ -148,3 +148,29 @@ spec:
       singleton:
         placement:
           tier: rtz
+---
+# hostnameTemplate names {{.InstanceID}}, which resolveHostnameTemplate has
+# NEVER implemented — it substitutes only SovereignFQDN / OrgSlug / AppName /
+# OrgDomain (#5389). Everything else in this document is deliberately VALID so
+# the rejection is attributable to the hostnameTemplate CEL rule alone and not
+# to some incidental schema error.
+#
+# This is the shape that actually shipped: platform/sandbox carried
+# `sandbox-{{.InstanceID}}.{{.OrgDomain}}` on a visibility:listed Blueprint,
+# was admitted without complaint, and only degraded later — the endpoint went
+# Unresolved and its Open button died far from the edit that caused it.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-hostname-token
+spec:
+  version: 1.0.0
+  visibility: listed
+  card:
+    title: hostnameTemplate uses an unimplemented token
+  endpoints:
+    - name: ui
+      hostnameTemplate: 'sandbox-{{.InstanceID}}.{{.OrgDomain}}'
+      port: 443
+      protocol: https
+      tls: true


### PR DESCRIPTION
## The remaining hole

#5705 made the resolver fail closed on an unimplemented `hostnameTemplate` token, and added a repo-level guard that walks every on-disk `blueprint.yaml`. Both are merged.

Neither covers a Blueprint authored through the **Git surface** on a live Sovereign. That path never touches this repo, so it is admitted happily and only degrades later — the endpoint goes `Unresolved`, its Open button dies, and the failure surfaces far from the edit that caused it.

That is exactly how `platform/sandbox` shipped `sandbox-{{.InstanceID}}.{{.OrgDomain}}` on a `visibility: listed` Blueprint. The CRD *documented* the correct four tokens the whole time; documentation does not reject anything.

## The rule

One `x-kubernetes-validations` entry on `endpoints[].hostnameTemplate`, matching the CEL idiom already used for `topology.defaults` in this file:

```
!self.matches('[{][{][ ]*[.](InstanceID|ClusterID)')
```

Character classes rather than backslash escapes, so the expression survives YAML quoting unchanged.

## Deliberately a denylist — stated, not hidden

An allowlist ("every `{{...}}` is one of the four") is **not expressible here**: RE2 has no negative lookahead and CEL cannot iterate regex matches. So this names the two documented-but-never-implemented tokens rather than pretending to be exhaustive.

The general case is covered on both sides of it — `TestEveryBlueprintHostnameTemplateResolves_5389` feeds every on-disk template through the real resolver one layer out, and the resolver itself fails closed one layer in. This rule closes the specific hole that actually shipped, at the earliest seam.

## Verification, both directions

CRD parses; rule extracted from the parsed document and exercised against the live regex:

| template | rejected | expected |
|---|---|---|
| `sandbox-{{.InstanceID}}.{{.OrgDomain}}` | yes | yes |
| `{{ .ClusterID }}.example` | yes | yes |
| `{{.AppName}}.{{.OrgDomain}}` | no | no |
| `auth.{{.SovereignFQDN}}` | no | no |
| `{{.AppName}}.{{.OrgSlug}}.{{.SovereignFQDN}}` | no | no |
| `{{ .OrgDomain }}` | no | no |

0 failures, and the vacuity check confirms the rule matches some inputs and not others — it is neither always-true nor always-false.

Existing CRD test fixtures are unaffected: `blueprint-sample-valid.yaml` uses `{{.AppName}}.{{.OrgSlug}}.{{.SovereignFQDN}}` (passes), and `blueprint-sample-invalid.yaml` uses `''` (still caught by `minLength: 1`, unchanged). A repo-wide scan finds zero remaining Blueprints using either token in a `hostnameTemplate` — the only textual hit is this rule's own error message.

The `Blueprint CRD CEL admission on real apiserver` check exercises this against a real API server.

Refs #5389
