### PR TITLE
fix(bp-newapi): cross-region singleton — one newapi, one Postgres, one OAuth code (Refs #5599)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -313,7 +313,14 @@ spec:
       #   ExternalSecret above resolves in region-B too (catalyst-api's #4477
       #   seed is primary-only; each region runs its own OpenBao). Pairs with
       #   bp-openbao 1.2.64 (external-secrets-push policy).
-      version: 1.4.150
+      # 1.4.151 — #5599 (UAT row 37): cross-region singleton. This slot installs
+      #   on EVERY region, so a 2-region Sovereign ran TWO newapi Deployments
+      #   over TWO INDEPENDENT CNPG Clusters behind ONE newapi.<fqdn>. An OAuth
+      #   authorization code is single-use and SERVER-SIDE, so the callback
+      #   landing on the other region met a database that had never seen the
+      #   code → a VALID Keycloak code answered 403 x3 and the app rendered
+      #   signed-out. See `crossRegion` in spec.values below.
+      version: 1.4.151
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -361,6 +368,37 @@ spec:
     # REQUIRED. Empty default = verbatim ghcr.io (byte-identical pre-cutover).
     global:
       imageRegistry: ''
+    # ── Cross-region singleton (#5599) ─────────────────────────────────
+    # This slot installs on EVERY region's control plane, so a 2-region
+    # Sovereign ran TWO complete newapi stacks — two Deployments AND two
+    # INDEPENDENT CNPG Cluster objects (not a replicated pair) — behind ONE
+    # `newapi.<fqdn>` whose shared VIP fans a browser's parallel connections
+    # across both gateways (#5459). An OAuth authorization code is single-use
+    # and stored SERVER-SIDE, so the leg that minted the exchange wrote into
+    # region-A's Postgres while `/api/oauth/sovereign` landed on region-B,
+    # whose database had never seen that code: a VALID Keycloak code answered
+    # 403 (x3 = the client retrying and losing the coin flip again) and newapi
+    # rendered signed-out. Measured live on hw292 (dep 1c56518035a83e03) in
+    # BOTH regions. #5414 fixed the SESSION_SECRET split at the secret seam;
+    # the datastore split underneath it was never addressed.
+    #
+    # Same seam bp-guacamole (52) and bp-cilium (01) use. `enabled` follows
+    # SOVEREIGN_ENABLE_CNPG_PAIR — a single-region prov leaves it false and the
+    # render is byte-identical to 1.4.150.
+    crossRegion:
+      enabled: ${SOVEREIGN_ENABLE_CNPG_PAIR:=false}
+      # Per-region cloud-init substitute (primary on region-A + on every
+      # single-region prov, secondary on region-B). `secondary` renders the
+      # ClusterMesh Service stubs ONLY — no Deployment, no CNPG Cluster, no
+      # DSN-sync/seed hook Jobs — so the stubs have zero local backends and
+      # every dial falls through the mesh to region-A's singleton. The
+      # HTTPRoute still renders there: the shared VIP fans TCP across BOTH
+      # regions' gateways, so region-B must keep answering for the hostname.
+      role: ${SOVEREIGN_REGION_ROLE:=primary}
+      # Peer ClusterMesh cluster name(s) — the SAME source var bp-guacamole
+      # (52), bp-harbor (19), bp-postgres (16a/16c/16d) and bp-cnpg-pair (16b)
+      # consume. EMPTY (single-region) → no CiliumNetworkPolicy is rendered.
+      peerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:=[]}
     database:
       # #4291 DE-VCLUSTER — newapi OWNS its CNPG natively in host ns `newapi`
       # (cnpg.enabled below), and the chart's own DSN-sync Job writes exactly

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.150 # lockstep with chart/Chart.yaml (#5612: Exact /login recovery-path match on the sandbox-bridge — fixes the inert "Continue with OpenOva SSO" button on /login?expired=true)
+  version: 1.4.151 # lockstep with chart/Chart.yaml (#5599: cross-region singleton — a secondary region renders no newapi Deployment and no CNPG Cluster, so one browser's single-use OAuth authorization code can no longer land on a database that never saw it)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,51 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.151 (#5599, 2026-08-06): a VALID Keycloak authorization code answered
+# 403 x3 on `/api/oauth/sovereign`, and the app rendered signed-out.
+#
+# ROOT CAUSE — not a token/nonce defect and not cutover-specific. An OAuth
+# authorization code is SINGLE-USE and stored SERVER-SIDE. Bootstrap-kit slot
+# 80 installs this chart on EVERY region's control plane, so a 2-region
+# Sovereign ran TWO complete newapi stacks — two Deployments AND two
+# INDEPENDENT CNPG `Cluster` objects, not a replicated pair — behind ONE
+# `newapi.<fqdn>` hostname whose shared VIP fans a browser's parallel
+# connections across both gateways (#5459). The leg that initiated the
+# exchange wrote its state into region-A's Postgres, the callback landed on
+# region-B, whose database had never seen that code, and region-B correctly
+# rejected it. The `x3` is the client retrying and losing the coin flip again.
+#
+# Measured live on hw292 (dep 1c56518035a83e03), BOTH regions sampled:
+# region-a and region-b each carried `deployment.apps/newapi-bp-newapi` 1/1,
+# `cluster.postgresql.cnpg.io/newapi-bp-newapi-newapi-pg` with 2 ready
+# instances, and `httproute newapi-bp-newapi-public` for the SAME hostname.
+#
+# #5414 already fixed newapi's SESSION_SECRET/CRYPTO_SECRET split at the
+# SECRET seam ("~60% bounce to /login?expired=true"). The DATASTORE split
+# underneath it was never addressed, so the component still could not hold a
+# server-side OAuth exchange across regions.
+#
+# FIX (the bp-guacamole 0.2.36 / #5358 and bp-cilium 1.4.19 / #5602 idiom):
+# a new `crossRegion` seam anchors the Sovereign's ONE newapi in the PRIMARY
+# region and reaches it from the secondary over ClusterMesh.
+#   role=primary   — Deployment + CNPG Cluster + DSN-sync/seed hooks render
+#     here, and BOTH Services (the main one and the `-bridge` one the
+#     HTTPRoute's Exact `/` + `/login` rules target) export their backends as
+#     global ClusterMesh services.
+#   role=secondary — NO Deployment, NO CNPG Cluster, NO hook Jobs. The
+#     Services and the HTTPRoute still render (Cilium merges global Services
+#     by name+namespace, and this region's envoy still has to answer for
+#     `newapi.<fqdn>` because the shared VIP fans TCP across both gateways)
+#     but match ZERO local Pods, so `service.cilium.io/affinity: local` falls
+#     through the mesh to the primary's singleton.
+#   crossRegion.enabled=false (DEFAULT, and every single-region Sovereign) —
+#     render is byte-identical to 1.4.150, proven by a full `helm template`
+#     diff. Guarded by tests/crossregion-render.sh, whose Case 3 FAILS against
+#     the 1.4.150 chart and whose Case 1 passes on both.
+# Also adds templates/crossregion-netpol.yaml: the `newapi` namespace is
+# default-deny and `policy-default-local-cluster: "true"` on hw292, so the
+# peer region's hostNetwork cilium-envoy hop (`remote-node`) and its
+# catalyst-system callers (peer-cluster pod endpoints) need an identity-based
+# CNP on the primary side — a k8s NetworkPolicy can never express either.
 # 1.4.149 (#5612, 2026-08-05): the inert "Continue with OpenOva SSO" RECOVERY
 # button. newapi's own session TTL is under an hour; when it lapses mid-visit
 # the embedded SPA client-routes to `/login?expired=true` and offers a
@@ -1030,7 +1076,7 @@ name: bp-newapi
 #   0.2.27. Render seam guarded by tests/5466-credentials-region-
 #   consistency-render.sh (fails on the pre-#5466 shape, plus a fallback
 #   vacuity control).
-version: 1.4.150
+version: 1.4.151
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -118,6 +118,133 @@ Helm has no boolean return; these emit the strings "true"/"false". Test with
 {{- end -}}
 
 {{/*
+Cross-region singleton gates (#5599).
+
+THE DEFECT. Bootstrap-kit slot 80 installs this chart on EVERY region's control
+plane, so a 2-region Sovereign ran TWO complete newapi stacks — two Deployments
+AND two INDEPENDENT CNPG `Cluster` objects (NOT a replicated pair) — behind ONE
+`newapi.<fqdn>` hostname whose shared VIP fans a browser's parallel connections
+across both gateways (#5459: a browser can never be assumed to pin one backend).
+
+An OAuth **authorization code is single-use and stored SERVER-SIDE**. The leg
+that mints the exchange state writes it into region-A's Postgres; the
+`/api/oauth/sovereign` callback lands on region-B, whose database has never seen
+that code, and region-B CORRECTLY rejects it — a *valid* Keycloak code answered
+403, three times as the client retries and loses the coin flip again (#5599,
+measured live on hw292 dep 1c56518035a83e03: region-a
+`newapi-bp-newapi-newapi-pg` instances=2 AND region-b
+`newapi-bp-newapi-newapi-pg` instances=2, both Ready, both fronted by
+httproute `newapi-bp-newapi-public` → ["newapi.hw292.omani.works"]).
+
+#5414 already fixed the SESSION_SECRET/CRYPTO_SECRET split at the SECRET seam
+(#5466's credsBridgeSynced above). The DATASTORE split underneath it was never
+addressed, so the component still could not hold a server-side OAuth exchange
+across regions.
+
+THE FIX — the bp-guacamole 0.2.36 (#5358) / bp-cilium 1.4.19 (#5602) idiom:
+  role=primary   — keeps the Deployment + its CNPG store and EXPORTS its
+                   Services as global ClusterMesh services.
+  role=secondary — renders NO Deployment, NO CNPG Cluster, NO DSN-sync /
+                   seed Jobs. Its Services still render (Cilium merges global
+                   Services by name+namespace, the HTTPRoute backendRef must
+                   resolve, and this region's envoy still has to answer for
+                   `newapi.<fqdn>` because the shared VIP fans TCP across BOTH
+                   gateways) but match ZERO local Pods, so
+                   `service.cilium.io/affinity: local` falls through the mesh
+                   to the primary's singleton.
+
+crossRegion.enabled=false (the DEFAULT, and every single-region Sovereign)
+renders byte-identically to 1.4.150 — both gates below are no-ops.
+
+Two SEPARATE gates because the two placement axes are orthogonal: under the
+#3831 host/vCluster split the workload and the datastore live in DIFFERENT
+clusters, so the cross-region suppression has to compose with whichever axis
+this install is on rather than replace it.
+*/}}
+{{- define "bp-newapi.crossRegionRole" -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- $role := $cr.role | default "primary" -}}
+{{- if not (has $role (list "primary" "secondary")) -}}
+{{- fail (printf "bp-newapi: invalid crossRegion.role %q — must be \"primary\" (owns the singleton newapi + its Postgres) or \"secondary\" (ClusterMesh Service stub only)" $role) -}}
+{{- end -}}
+{{- $role -}}
+{{- end -}}
+
+{{/*
+Mesh-secondary predicate (#5599). "true" when this region must run NO newapi
+workload and NO newapi Postgres. Empty string otherwise.
+
+Deliberately independent of `.Values.newapi.enabled` and of placement.role so
+each caller keeps composing its OWN existing gate set — this only ever REMOVES
+render, never adds it.
+*/}}
+{{- define "bp-newapi.isMeshSecondary" -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- if and $cr.enabled (eq (include "bp-newapi.crossRegionRole" .) "secondary") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Workload render gate (#5599). Composes the #3831 placement gate
+(`bp-newapi.renderApp`) with the cross-region singleton gate: "true" only when
+this install renders the app AND this region is not the mesh secondary.
+
+Consumers: the Deployment (whose own DSN/credentials precedence chain still
+applies ON TOP of this — see deployment.yaml), the admin-sso-seed Job/CronJob
+and the channel-seed Job (both are post-install/post-upgrade HOOKS that talk to
+the migrated DB schema and rollout-restart the Deployment; on a secondary with
+neither present they would fail the HelmRelease and the mesh-stub Services
+would never install).
+
+The Services, HTTPRoute, ConfigMap, ServiceAccount and the region-local
+token-signing-key Secret + its #5375 admin-token PushSecret deliberately stay
+on plain `renderApp` — the Services ARE the mesh stub, and #5375's DR contract
+requires every region to keep seeding its OWN OpenBao with its OWN bridge
+ADMIN_SECRET so a promote finds a bearer.
+*/}}
+{{- define "bp-newapi.renderWorkloads" -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") (not (include "bp-newapi.isMeshSecondary" .)) -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+Datastore render gate (#5599). Composes the #3831 seams gate
+(`bp-newapi.renderSeams`) with the cross-region singleton gate.
+
+Consumers: cnpg-cluster.yaml (the `Cluster` CR **and** its DSN-placeholder
+Secret) and database-secret-sync-job.yaml. The sync Job is a post-install/
+post-upgrade hook that polls CNPG's `<cluster>-app` Secret until it exists —
+on a secondary with no Cluster it would poll to its budget, exit non-zero and
+wedge the release, so the Job must go wherever the Cluster goes.
+*/}}
+{{- define "bp-newapi.renderDataStore" -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") (not (include "bp-newapi.isMeshSecondary" .)) -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+ClusterMesh global-Service annotations (#5599). Emitted by BOTH Services in
+service.yaml (the main one and the `-bridge` one the HTTPRoute's Exact `/` and
+`/login` rules target — annotating only one would leave the other path split,
+which is the same bug in a narrower window).
+
+`shared` is "true" ONLY on the primary: the secondary must never export a
+backend set of its own, or the primary could land a session in the secondary
+region and the exchange splits again in the other direction.
+`affinity: local` prefers local backends and falls through to the peer only
+when there are none — so the primary never bounces a request to the secondary,
+and the secondary (zero local backends by design) always reaches the primary.
+Nothing renders when crossRegion.enabled=false.
+*/}}
+{{- define "bp-newapi.crossRegionServiceAnnotations" -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- if $cr.enabled }}
+service.cilium.io/global: "true"
+service.cilium.io/shared: {{ eq (include "bp-newapi.crossRegionRole" .) "primary" | quote }}
+service.cilium.io/affinity: {{ $cr.affinity | default "local" | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 #5466 / #5480 (A16 class) — is the region-consistent SESSION_SECRET/
 CRYPTO_SECRET bridge carrier ACTIVE for this install?
 

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -235,9 +235,13 @@ when there are none — so the primary never bounces a request to the secondary,
 and the secondary (zero local backends by design) always reaches the primary.
 Nothing renders when crossRegion.enabled=false.
 */}}
+The `-}}` on the `if` is load-bearing: without it the block opens with an empty
+line, and `nindent` turns that into a whitespace-only line under
+`annotations:`.
+*/}}
 {{- define "bp-newapi.crossRegionServiceAnnotations" -}}
 {{- $cr := .Values.crossRegion | default dict -}}
-{{- if $cr.enabled }}
+{{- if $cr.enabled -}}
 service.cilium.io/global: "true"
 service.cilium.io/shared: {{ eq (include "bp-newapi.crossRegionRole" .) "primary" | quote }}
 service.cilium.io/affinity: {{ $cr.affinity | default "local" | quote }}

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -234,9 +234,9 @@ region and the exchange splits again in the other direction.
 when there are none — so the primary never bounces a request to the secondary,
 and the secondary (zero local backends by design) always reaches the primary.
 Nothing renders when crossRegion.enabled=false.
-*/}}
-The `-}}` on the `if` is load-bearing: without it the block opens with an empty
-line, and `nindent` turns that into a whitespace-only line under
+
+The `-}}` on the `if` below is load-bearing: without it the returned block opens
+with an empty line, and `nindent` turns that into a whitespace-only line under
 `annotations:`.
 */}}
 {{- define "bp-newapi.crossRegionServiceAnnotations" -}}

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -97,8 +97,16 @@ nothing.
    because vcluster-app ships cnpg.enabled=false (the CNPG Cluster is host-rendered
    by the host-seams HR); the Job needs only the MIRRORED `-app` Secret, not the
    Cluster CR. role=all keeps both gates "true" so standalone/host-placed installs
-   are byte-identical. */ -}}
-{{- if and (eq (include "bp-newapi.renderApp" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.sovereignFQDN -}}
+   are byte-identical.
+
+   #5599 layers the cross-region singleton gate ON TOP of the same reasoning:
+   `bp-newapi.renderWorkloads` = `renderApp AND NOT crossRegion-secondary`. A
+   secondary region runs no Deployment to rollout-restart and owns no CNPG
+   store whose `public.users` table could ever appear, so this hook would hit
+   the SAME wait_for_users_table deadline described above and fail the release.
+   The Sovereign's ONE seed/promote pair belongs with the ONE workload.
+   crossRegion.enabled=false (the default) → unchanged. */ -}}
+{{- if and (eq (include "bp-newapi.renderWorkloads" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.sovereignFQDN -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -79,7 +79,13 @@ Issue #915, 2026-05-05.
 {{- $vllmReady := and $vllm.enabled (ne (default "" $vllm.endpoint) "") -}}
 {{- $hasDefaults := or $qpReady $vllmReady -}}
 {{- $masterKeySecret := .Values.auth.adminUI.masterKeySecret | default "" -}}
-{{- if and (eq (include "bp-newapi.renderApp" .) "true") $cs.enabled $hasDefaults $masterKeySecret -}}
+{{- /* #5599 cross-region singleton: this post-install/post-upgrade hook writes
+   channel rows through the running app into the app's OWN Postgres.
+   `bp-newapi.renderWorkloads` = `renderApp AND NOT crossRegion-secondary`, so a
+   secondary region — which by design runs neither — no longer renders a hook
+   that would fail the release. The Sovereign's ONE channel set is seeded once,
+   into the ONE surviving datastore. crossRegion.enabled=false → unchanged. */ -}}
+{{- if and (eq (include "bp-newapi.renderWorkloads" .) "true") $cs.enabled $hasDefaults $masterKeySecret -}}
 {{- $jobName := include "bp-newapi.channelSeedJobName" . -}}
 ---
 {{- /*

--- a/platform/newapi/chart/templates/cnpg-cluster.yaml
+++ b/platform/newapi/chart/templates/cnpg-cluster.yaml
@@ -50,7 +50,16 @@ Without the gate, a cold install fails with "no matches for kind
 Cluster". Same pattern the bp-external-dns chart uses (issue #190) and
 the platform/powerdns/chart/templates/cnpg-cluster.yaml mirror.
 */}}
-{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.cnpg.enabled -}}
+{{- /* #5599 cross-region singleton: an OAuth authorization code is single-use
+   and stored SERVER-SIDE, so the Sovereign may hold exactly ONE newapi
+   datastore. `bp-newapi.renderDataStore` = `renderSeams AND NOT
+   crossRegion-secondary` — it COMPOSES with the #3831 placement gate rather
+   than replacing it, and with crossRegion.enabled=false (the default) it is a
+   no-op. A secondary region renders neither the Cluster CR nor the DSN
+   placeholder Secret below; database-secret-sync-job.yaml carries the same
+   gate so its post-install hook cannot poll forever for a `<cluster>-app`
+   Secret that will never exist. */ -}}
+{{- if and (eq (include "bp-newapi.renderDataStore" .) "true") .Values.cnpg.enabled -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $dsnSecretName := default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName -}}
 {{- $database := .Values.cnpg.database | default "newapi" -}}

--- a/platform/newapi/chart/templates/crossregion-netpol.yaml
+++ b/platform/newapi/chart/templates/crossregion-netpol.yaml
@@ -1,0 +1,148 @@
+{{- /*
+Cross-region reachability CiliumNetworkPolicy (#5599).
+
+Once crossRegion anchors the ONE newapi workload in the primary region, every
+dial that used to be satisfied region-locally has to cross the ClusterMesh —
+and the `newapi` namespace is default-deny (verified live on hw292: the
+`newapi-default-deny` NetworkPolicy from bp-plane-isolation sits alongside this
+chart's own `newapi-bp-newapi` NetworkPolicy in BOTH regions).
+
+A plain k8s NetworkPolicy can NEVER admit a ClusterMesh peer. Cilium
+AND-injects `io.cilium.k8s.policy.cluster=<local>` into every selector it
+derives from a k8s NetworkPolicy — confirmed on hw292 by the agent config
+itself, `policy-default-local-cluster: "true"` in the kube-system
+`cilium-config` ConfigMap (cluster-name `hw292-mesh`, id 219; the peer is
+`hw292-me-east-b`, id 220). An `ipBlock` is equally inert: a ClusterMesh remote
+Pod is a KNOWN endpoint carrying its own identity, never a CIDR identity
+(#4656 / #4846 / #4854). So the peer-region legs need an identity-based CNP on
+the primary side. Cilium evaluates the UNION of every policy selecting an
+endpoint, so this is purely ADDITIVE to the default-deny, to
+`networkpolicy.yaml` and to `cilium-ingress-networkpolicy.yaml` — it opens the
+newapi ports ONLY, to peer-cluster identities ONLY, and does not widen the
+local-cluster surface by one byte.
+
+TWO legs, because two different identity classes reach newapi from the peer:
+
+  1. The peer region's GATEWAY. `cilium-envoy` is a hostNetwork DaemonSet
+     (verified on hw292: `spec.template.spec.hostNetwork=true`, per §854 the
+     gateway is served direct on the host ports, never a nodePort), so a
+     hostNetwork Pod carries the node's identity and its cross-mesh forward
+     arrives as `remote-node` — NOT as a pod endpoint any `fromEndpoints`
+     selector could name. This is the leg that carries a real User's browser
+     request from the secondary region's VIP to the primary's Pod, so without
+     it the fix would trade a 403 for a timeout. bp-plane-isolation's
+     `newapi-allow-gateway-ingress` happens to admit
+     `fromEntities: [ingress, host, remote-node]` on this namespace today, but
+     a chart must not depend on a sibling chart's policy for its own datapath.
+
+  2. The peer region's in-cluster CALLERS — `sandbox-controller` +
+     catalyst-api's admin-API client in `catalyst-system`, and whatever else
+     `networkPolicy.ingress.allowedFromNamespaces` /
+     `networkPolicy.ingress.fromNamespaceLabels` name. Those ARE pod endpoints
+     and used to be served by their own region's local newapi; with the
+     singleton they must reach across, and only a CNP naming both the peer
+     cluster and the namespace can express that.
+
+ANY-NAMESPACE note (the #4854 row 67 L2 trap, mirrored from
+platform/harbor/chart/templates/redis-crossregion-netpol.yaml and
+platform/guacamole/chart/templates/crossregion-netpol.yaml): a namespaced CNP's
+`fromEndpoints` is implicitly ANDed with BOTH
+`io.cilium.k8s.policy.cluster=<local>` AND
+`k8s:io.kubernetes.pod.namespace=<this policy's namespace>`. The callers live in
+`catalyst-system` / `traefik`, NOT in `newapi`, so the namespace key MUST be
+named explicitly — otherwise the rule is silently narrowed to peer-region Pods
+that happen to sit in a same-named `newapi` namespace and matches nothing.
+
+Rendered on BOTH regions so a role flip needs no policy change and has no
+ordering hazard: on the secondary it selects zero local newapi Pods and is
+therefore inert.
+
+Gated on `crossRegion.enabled` AND a non-empty `crossRegion.peerClusters` AND
+the cilium.io/v2 Capabilities check (the #2988/#3102 idiom, so the chart still
+installs on CRD-less clusters such as kind CI). EMPTY peer list (single-region)
+→ NO policy → the default render is byte-identical to 1.4.150.
+*/ -}}
+{{- $cr := .Values.crossRegion | default dict -}}
+{{- $peers := $cr.peerClusters | default list -}}
+{{- $np := .Values.networkPolicy | default dict -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled $np.enabled $cr.enabled (gt (len $peers) 0) (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
+{{- $npIngress := $np.ingress | default dict -}}
+{{- /* Caller namespaces: the `kubernetes.io/metadata.name` of the primary
+   fromNamespaceLabels selector (traefik by default) plus every entry of
+   allowedFromNamespaces (catalyst-system by default) — the SAME caller set
+   networkpolicy.yaml admits locally, re-expressed so it also resolves across
+   the mesh. */ -}}
+{{- $callerNs := list -}}
+{{- with (($npIngress.fromNamespaceLabels | default dict))  }}
+{{- $n := index . "kubernetes.io/metadata.name" | default "" -}}
+{{- if $n }}{{- $callerNs = append $callerNs $n -}}{{- end }}
+{{- end }}
+{{- range ($npIngress.allowedFromNamespaces | default list) -}}
+{{- $callerNs = append $callerNs . -}}
+{{- end -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-crossregion-ingress" (include "bp-newapi.fullname" .) | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    {{- /* `bp-newapi.labels` already sets catalyst.openova.io/blueprint;
+         re-emitting a key Helm has already written is inert AND fails
+         helm-controller's post-render unmarshal with `mapping key already
+         defined`, so use a distinct key (the #5406 lesson). */}}
+    catalyst.openova.io/subcomponent: newapi-crossregion-netpol
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "bp-newapi.selectorLabels" . | nindent 6 }}
+  ingress:
+    {{- /* Leg 1 — the peer region's hostNetwork cilium-envoy forwarding a
+       browser request across the mesh. Entity selectors cannot be qualified by
+       cluster (a reserved identity is not a pod endpoint), so this is scoped
+       instead by opening ONLY the newapi ports. */}}
+    - fromEntities:
+        - remote-node
+      toPorts:
+        - ports:
+            - port: {{ .Values.newapi.port | quote }}
+              protocol: TCP
+            {{- if .Values.meteringSidecar.enabled }}
+            - port: {{ .Values.meteringSidecar.port | quote }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.sandboxBridge.enabled }}
+            - port: {{ .Values.sandboxBridge.port | quote }}
+              protocol: TCP
+            {{- end }}
+    {{- /* Leg 2 — the peer region's in-cluster callers. */}}
+    {{- if gt (len $callerNs) 0 }}
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peers }}
+                - {{ . | quote }}
+                {{- end }}
+            # Named explicitly — see the ANY-NAMESPACE note above.
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values:
+                {{- range $callerNs }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.newapi.port | quote }}
+              protocol: TCP
+            {{- if .Values.meteringSidecar.enabled }}
+            - port: {{ .Values.meteringSidecar.port | quote }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.sandboxBridge.enabled }}
+            - port: {{ .Values.sandboxBridge.port | quote }}
+              protocol: TCP
+            {{- end }}
+    {{- end }}
+{{- end }}

--- a/platform/newapi/chart/templates/database-secret-sync-job.yaml
+++ b/platform/newapi/chart/templates/database-secret-sync-job.yaml
@@ -1,4 +1,10 @@
-{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.cnpg.enabled }}
+{{- /* #5599: this post-install/post-upgrade hook polls CNPG's `<cluster>-app`
+   Secret until it exists, so it MUST go wherever the Cluster goes. Under
+   `bp-newapi.renderDataStore` (= renderSeams AND NOT crossRegion-secondary) a
+   secondary region renders neither — otherwise the hook would poll to its full
+   budget, exit non-zero and wedge the release, and the mesh-stub Services
+   would never install. crossRegion.enabled=false → unchanged. */ -}}
+{{- if and (eq (include "bp-newapi.renderDataStore" .) "true") .Values.cnpg.enabled }}
 {{- /*
 Helm post-install/post-upgrade Job that composes the canonical SQL_DSN
 string from the CNPG-emitted `<cluster>-app` Secret (which holds the

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -62,8 +62,22 @@ the configmap mirrors this gate.
 {{- /* #3831: the app Deployment renders ONLY under placement.role all|vcluster-app
    (the seams + CNPG render host-side under host-seams). In vcluster-app the slot
    suppresses cnpg.enabled and wires database.existingSecret to the mirrored DSN
-   Secret, so $effDbSecret still resolves non-empty above. */ -}}
-{{- $deployReady := and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled $effDbSecret $effCredsSecret -}}
+   Secret, so $effDbSecret still resolves non-empty above.
+
+   #5599 COMPOSES with — never replaces — that gate and the DSN/credentials
+   precedence chain resolved above. `bp-newapi.renderWorkloads` is
+   `renderApp AND NOT crossRegion-secondary`, so:
+     - crossRegion.enabled=false (default)      → identical to pre-1.4.151.
+     - crossRegion secondary                    → NO Deployment, so the
+       Services rendered by service.yaml have ZERO local backends and
+       `service.cilium.io/affinity: local` falls through the ClusterMesh to the
+       primary's singleton. That is the whole fix: an OAuth authorization code
+       is single-use and stored server-side, so two Deployments over two
+       independent Postgres clusters behind one VIP answered a VALID Keycloak
+       code with 403 (#5599, measured live on hw292 in BOTH regions).
+     - the $effDbSecret / $effCredsSecret / $kcConfigured conditions below are
+       UNCHANGED and still decide the primary's render exactly as before. */ -}}
+{{- $deployReady := and (eq (include "bp-newapi.renderWorkloads" .) "true") .Values.newapi.enabled $effDbSecret $effCredsSecret -}}
 {{- if and $kcMode (not $kcConfigured) -}}
 {{- $deployReady = false -}}
 {{- end -}}

--- a/platform/newapi/chart/templates/service.yaml
+++ b/platform/newapi/chart/templates/service.yaml
@@ -1,3 +1,15 @@
+{{- /*
+#5599 — this Service is deliberately still gated on plain `renderApp`, NOT on
+`renderWorkloads`: on a crossRegion SECONDARY it MUST render even though the
+Deployment does not. Cilium merges ClusterMesh global Services BY name +
+namespace, so the name has to exist in every participating cluster; the
+HTTPRoute's backendRef has to resolve; and this region's envoy still has to
+answer for `newapi.<fqdn>` because the shared VIP fans TCP across BOTH regions'
+gateways. With no local Pod the selector matches ZERO backends, so
+`service.cilium.io/affinity: local` falls through the mesh to the primary's
+singleton — which is exactly what stops one browser's OAuth code exchange from
+splitting across two independent Postgres clusters (the 403-on-a-valid-code).
+*/ -}}
 {{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled }}
 apiVersion: v1
 kind: Service
@@ -5,6 +17,10 @@ metadata:
   name: {{ include "bp-newapi.fullname" . }}
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
+  {{- with (include "bp-newapi.crossRegionServiceAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -75,6 +91,18 @@ metadata:
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
     catalyst.openova.io/component: newapi-bridge
+  {{- /* #5599 — the bridge Service needs the SAME ClusterMesh treatment as the
+     main one. The HTTPRoute sends Exact `/` AND Exact `/login` here (the
+     zero-click landing page + the #5612 recovery path), and BOTH of those
+     initiate the OIDC round-trip whose authorization code the main Service's
+     backend must later be able to redeem. Annotating only the main Service
+     would leave the entry leg free to land in the secondary region while the
+     callback leg went to the primary — the same defect through a narrower
+     window. */}}
+  {{- with (include "bp-newapi.crossRegionServiceAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   # Publish the bridge endpoint even while the Pod is NotReady (the `newapi`

--- a/platform/newapi/chart/tests/crossregion-render.sh
+++ b/platform/newapi/chart/tests/crossregion-render.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# bp-newapi — cross-region singleton render audit (#5599).
+#
+# THE DEFECT THIS GUARDS
+# ──────────────────────────────────────────────────────────────────────────
+# An OAuth authorization code is SINGLE-USE and stored SERVER-SIDE. Until
+# 1.4.151 the bootstrap-kit installed this chart identically on EVERY region's
+# control plane, so a 2-region Sovereign ran TWO complete newapi stacks — two
+# Deployments AND two INDEPENDENT CNPG `Cluster` objects, not a replicated
+# pair — behind ONE `newapi.<fqdn>` hostname whose shared VIP fans a browser's
+# parallel connections across both gateways (#5459: a browser can never be
+# assumed to pin one backend).
+#
+# So the flow split: the leg that initiated the exchange wrote its state into
+# region-A's Postgres, the `/api/oauth/sovereign` callback landed on region-B,
+# whose database had never seen that code, and region-B CORRECTLY rejected it.
+# A VALID Keycloak authorization code answered `403 Forbidden` — three times,
+# the client retrying and losing the coin flip again — and newapi rendered
+# signed-out with `/api/user/self` 401 (UAT row 37).
+#
+# Measured live on hw292 (dep 1c56518035a83e03), BOTH regions sampled:
+#   region-a  deployment.apps/newapi-bp-newapi                        1/1
+#             cluster.postgresql.cnpg.io/newapi-bp-newapi-newapi-pg   2 ready
+#             httproute newapi-bp-newapi-public -> ["newapi.hw292.omani.works"]
+#   region-b  deployment.apps/newapi-bp-newapi                        1/1
+#             cluster.postgresql.cnpg.io/newapi-bp-newapi-newapi-pg   2 ready
+#             httproute newapi-bp-newapi-public -> ["newapi.hw292.omani.works"]
+#
+# #5414 already fixed the SESSION_SECRET/CRYPTO_SECRET split at the SECRET
+# seam. The DATASTORE split underneath it was never addressed — this guard
+# asserts it is now closed.
+#
+# THE LOAD-BEARING ASSERTION is CASE 3: a `secondary` region must render NO
+# Deployment AND NO CNPG Cluster, so both its Services have ZERO local backends
+# and `service.cilium.io/affinity: local` falls through the ClusterMesh to the
+# primary's singleton. A per-region property has to be asserted PER REGION.
+#
+# VACUITY — checked in BOTH directions
+# ──────────────────────────────────────────────────────────────────────────
+# Case 3 FAILS against the pre-fix chart: origin/main has no `crossRegion` seam
+# at all, so `--set crossRegion.role=secondary` is inert there and the
+# secondary renders a full Deployment + its own CNPG Cluster + annotation-free
+# Services, i.e. the two-stack split this issue is about. Run it against a
+# checkout of 1.4.150 to see that.
+#
+# Case 1 is the paired non-regression check that PASSES ON BOTH TREES: the
+# default render must carry NO mesh annotations AND must still contain the
+# Deployment and the CNPG Cluster. That is what stops the guard from being
+# satisfied by blanket suppression or by blanket annotation.
+#
+# Cases:
+#   1. Default (crossRegion absent)   — no mesh annotations; Deployment + CNPG
+#                                       Cluster present.   [PASSES ON BOTH]
+#   2. enabled + role=primary         — global=true / shared=true / affinity on
+#                                       BOTH Services; workloads + CNPG present;
+#                                       cross-region CNP present.
+#   3. enabled + role=secondary       — NO Deployment, NO CNPG Cluster, NO
+#                                       DSN-sync or seed Jobs; BOTH Services
+#                                       present with shared=false. [VACUITY-BREAKER]
+#   4. enabled + empty peerClusters   — no CiliumNetworkPolicy.
+#   5. invalid role                   — render FAILS fast.
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+base=(
+  --set newapi.enabled=true
+  --set sovereignFQDN=smoke.omani.works
+  --set auth.adminUI.mode=keycloak
+  --set auth.adminUI.keycloak.issuer=https://auth.smoke.omani.works/realms/sovereign
+  --set auth.adminUI.keycloak.existingSecret=newapi-oidc
+  # The public HTTPRoute is what makes this a 2-region problem at all (one
+  # hostname, both gateways), so every case renders it — as slot 80 does live.
+  --set ingress.httpRoute.enabled=true
+  --api-versions cilium.io/v2
+  --api-versions postgresql.cnpg.io/v1
+)
+
+# Extract the block a given template produced. Uses herestrings throughout — a
+# `grep -q` on a pipe closes it and kills the producer with SIGPIPE 141, which
+# `set -o pipefail` turns into a false FAIL (the #5531/#5537 catalog-wide class).
+src_block() { # <render> <template-file>
+  awk -v pat="^# Source: bp-newapi/templates/$2\$" \
+      '$0 ~ pat {f=1; print; next} /^# Source: /{f=0} f' <<<"$1"
+}
+
+# Strip YAML comments so the templates' own prose — which names every
+# annotation and the words Deployment and Cluster — can never satisfy an
+# assertion.
+uncomment() { sed 's/[[:space:]]*#.*$//'; }
+
+render() { "$helm" template newapi "$chart_dir" "${base[@]}" "$@" 2>&1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# ── Case 1: default render is untouched (PASSES ON BOTH TREES) ──────────────
+echo "[bp-newapi] Case 1: default (crossRegion off) — no mesh annotations, full stack"
+out=$(uncomment <<<"$(render)")
+if grep -q "service.cilium.io/" <<<"$out"; then
+  fail "default render carries service.cilium.io/* — single-region Sovereigns must be untouched"
+fi
+grep -q "^kind: Deployment$" <<<"$out" || fail "default render is missing the newapi Deployment"
+grep -q "^kind: Cluster$"    <<<"$out" || fail "default render is missing the CNPG Cluster"
+echo "[bp-newapi] Case 1: PASS"
+
+# ── Case 2: primary exports its backends and keeps the full stack ───────────
+echo "[bp-newapi] Case 2: crossRegion primary — global+shared on BOTH Services, stack present"
+raw=$(render --set crossRegion.enabled=true --set crossRegion.role=primary \
+  --set 'crossRegion.peerClusters={hw292-me-east-b}')
+out=$(uncomment <<<"$raw")
+svc=$(uncomment <<<"$(src_block "$raw" service.yaml)")
+for want in 'service.cilium.io/global: "true"' 'service.cilium.io/shared: "true"' 'service.cilium.io/affinity: "local"'; do
+  # BOTH the main Service and the `-bridge` Service must carry it — the
+  # HTTPRoute's Exact `/` and `/login` rules target the bridge, and annotating
+  # only one leaves the entry leg free to land in the other region.
+  n=$(grep -cF -- "$want" <<<"$svc" || true)
+  [ "$n" -eq 2 ] || fail "primary: expected [$want] on BOTH Services, found $n"
+done
+grep -q "^kind: Deployment$" <<<"$out" || fail "primary region must still run the newapi Deployment"
+grep -q "^kind: Cluster$"    <<<"$out" || fail "primary region must still own the CNPG Cluster"
+grep -q "kind: CiliumNetworkPolicy" <<<"$out" || fail "primary did not render the cross-region CiliumNetworkPolicy"
+cnp=$(uncomment <<<"$(src_block "$raw" crossregion-netpol.yaml)")
+# The CNP must name the PEER cluster and the callers' OWN namespaces — a rule
+# that omits either is silently narrowed to nothing (#4854 row 67 L2), and it
+# must admit remote-node for the peer's hostNetwork cilium-envoy hop.
+for want in 'io.cilium.k8s.policy.cluster' '- "hw292-me-east-b"' '- "catalyst-system"' '- remote-node'; do
+  grep -qF -- "$want" <<<"$cnp" || fail "cross-region CNP missing [$want]"
+done
+echo "[bp-newapi] Case 2: PASS"
+
+# ── Case 3: THE LOAD-BEARING ONE — secondary renders no stack ───────────────
+echo "[bp-newapi] Case 3: crossRegion secondary — zero local backends, zero local datastore"
+raw=$(render --set crossRegion.enabled=true --set crossRegion.role=secondary \
+  --set 'crossRegion.peerClusters={hw292-mesh}')
+out=$(uncomment <<<"$raw")
+
+# (a) NO Deployment.
+if grep -q "^kind: Deployment$" <<<"$out"; then
+  echo "FAIL: the secondary region rendered a Deployment. Its newapi Services" >&2
+  echo "      must have ZERO local backends, otherwise the shared VIP again" >&2
+  echo "      splits one browser's OAuth exchange across two regions and a" >&2
+  echo "      VALID authorization code comes back 403 (#5599)." >&2
+  grep -B4 -A2 "^kind: Deployment$" <<<"$out" | head -20 >&2
+  exit 1
+fi
+# (b) NO second datastore — this is the piece #5414 never addressed.
+if grep -q "^kind: Cluster$" <<<"$out"; then
+  echo "FAIL: the secondary region rendered its OWN CNPG Cluster. An OAuth" >&2
+  echo "      authorization code is single-use and stored SERVER-SIDE, so the" >&2
+  echo "      Sovereign may hold exactly ONE newapi datastore (#5599)." >&2
+  exit 1
+fi
+# (c) NO hook Job that would poll a datastore that does not exist and wedge the
+#     release before the mesh stubs ever install.
+if grep -q "^kind: Job$" <<<"$out"; then
+  echo "FAIL: the secondary rendered a Job. The DSN-sync / seed hooks poll the" >&2
+  echo "      CNPG '-app' Secret and rollout-restart the Deployment — neither" >&2
+  echo "      exists here, so the post-install hook would fail the release." >&2
+  grep -B4 -A2 "^kind: Job$" <<<"$out" | head -20 >&2
+  exit 1
+fi
+# (d) but BOTH Services MUST exist — they are the mesh stubs the peer merges
+#     with, and this region's envoy still answers for newapi.<fqdn>.
+svc=$(uncomment <<<"$(src_block "$raw" service.yaml)")
+[ -n "$svc" ] || fail "the secondary must still render the newapi Services — Cilium merges global Services by name+namespace"
+n=$(grep -cE "^  name: newapi-bp-newapi(-bridge)?$" <<<"$svc" || true)
+[ "$n" -eq 2 ] || fail "secondary: expected BOTH the main and the -bridge Service, found $n"
+for want in 'service.cilium.io/global: "true"' 'service.cilium.io/shared: "false"'; do
+  n=$(grep -cF -- "$want" <<<"$svc" || true)
+  [ "$n" -eq 2 ] || fail "secondary: expected [$want] on BOTH Services, found $n"
+done
+# (e) and the HTTPRoute MUST still render — the shared VIP fans TCP across both
+#     regions' gateways, so this region has to answer for the hostname.
+grep -q "^kind: HTTPRoute$" <<<"$out" || fail "the secondary must still render the HTTPRoute — the shared VIP fans TCP across BOTH gateways"
+echo "[bp-newapi] Case 3: PASS"
+
+# ── Case 4: no peers → no CNP (single-region byte-identity) ─────────────────
+echo "[bp-newapi] Case 4: empty peerClusters — no CiliumNetworkPolicy"
+out=$(uncomment <<<"$(render --set crossRegion.enabled=true --set crossRegion.role=primary)")
+grep -q "^kind: CiliumNetworkPolicy$" <<<"$(src_block "$out" crossregion-netpol.yaml)" \
+  && fail "rendered a cross-region CNP with an empty peerClusters list"
+echo "[bp-newapi] Case 4: PASS"
+
+# ── Case 5: an unknown role must fail the render, never render silently ─────
+echo "[bp-newapi] Case 5: invalid crossRegion.role fails fast"
+if "$helm" template newapi "$chart_dir" "${base[@]}" \
+    --set crossRegion.enabled=true --set crossRegion.role=standby >/dev/null 2>&1; then
+  fail "crossRegion.role=standby rendered instead of failing — a typo'd role would silently fall back to a full second newapi stack"
+fi
+echo "[bp-newapi] Case 5: PASS"
+
+echo "[bp-newapi] cross-region render audit: ALL PASS"

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -47,6 +47,59 @@ imagePullSecrets:
 #                sync.fromHost.secrets `newapi/*` mirror + replicateServices.
 placement:
   role: all
+# ─── Cross-region singleton (#5599) ───────────────────────────────────────
+# Bootstrap-kit slot 80 installs this chart on EVERY region's control plane, so
+# a 2-region Sovereign ran TWO complete newapi stacks — two Deployments AND two
+# INDEPENDENT CNPG `Cluster` objects (not a replicated pair) — behind ONE
+# `newapi.<fqdn>` hostname whose shared VIP fans a browser's parallel
+# connections across both gateways (#5459).
+#
+# Measured live on hw292 (dep 1c56518035a83e03), BOTH regions sampled:
+#   region-a  deployment.apps/newapi-bp-newapi                 1/1
+#             cluster.postgresql.cnpg.io/newapi-bp-newapi-newapi-pg  2 ready
+#             httproute newapi-bp-newapi-public -> ["newapi.hw292.omani.works"]
+#   region-b  deployment.apps/newapi-bp-newapi                 1/1
+#             cluster.postgresql.cnpg.io/newapi-bp-newapi-newapi-pg  2 ready
+#             httproute newapi-bp-newapi-public -> ["newapi.hw292.omani.works"]
+#
+# An OAuth authorization code is single-use and stored SERVER-SIDE, so the leg
+# that mints the exchange state writes it into region-A's Postgres while the
+# `/api/oauth/sovereign` callback lands on region-B, whose database has never
+# seen that code — a VALID Keycloak code answered 403 (x3 = the client retrying
+# and losing the coin flip again) and newapi rendered signed-out.
+#
+# #5414 fixed the SESSION_SECRET/CRYPTO_SECRET split at the SECRET seam; the
+# DATASTORE split underneath was never addressed. Same idiom as bp-guacamole
+# 0.2.36 (#5358) and bp-cilium 1.4.19 (#5602), both landed 2026-08-06.
+crossRegion:
+  # Render the ClusterMesh global-Service annotations + the cross-region
+  # CiliumNetworkPolicy, and honour `role`. Default OFF — a single-region
+  # Sovereign renders byte-identically to 1.4.150.
+  enabled: false
+  # This region's role in the pair: primary | secondary. Slot 80 stamps it from
+  # the per-region ${SOVEREIGN_REGION_ROLE} cloud-init substitute — the SAME
+  # var bp-guacamole (52) and bp-cilium (01) consume.
+  #   primary   — the Deployment + the CNPG store + the seed Jobs render here,
+  #               and both Services export their backends to the peer.
+  #   secondary — NO Deployment, NO CNPG Cluster, NO DSN-sync/seed Jobs. The
+  #               Services still render (Cilium merges global Services by
+  #               name+namespace, the HTTPRoute backendRef must resolve, and
+  #               this region's envoy still answers for `newapi.<fqdn>`) but
+  #               match zero local Pods, so `affinity: local` falls through the
+  #               mesh to the primary's singleton.
+  # Any other value FAILS the render — a typo must never silently degrade back
+  # to a second full stack, which is the exact split being removed.
+  role: primary
+  # Peer ClusterMesh cluster name(s) — the SAME source var bp-guacamole (52),
+  # bp-harbor (19), bp-postgres (16a/16c/16d) and bp-cnpg-pair (16b) consume,
+  # ${SOVEREIGN_PEER_CLUSTERMESH_NAMES}. EMPTY (single-region) → NO
+  # CiliumNetworkPolicy is rendered. On hw292 these are `hw292-mesh` (region-a,
+  # cluster-id 219) and `hw292-me-east-b` (region-b, cluster-id 220).
+  peerClusters: []
+  # Cilium global-service backend preference. `local` prefers backends in this
+  # cluster and falls through to the peer only when there are none. Same value
+  # bp-guacamole's guacamole-server and bp-openbao's openbao-active-mesh use.
+  affinity: local
 # ─── Global registry rewrite (matches catalyst / continuum chart pattern) ──
 # When set, the openova-io images (newapi-mirror, newapi-sandbox-bridge,
 # services-metering-sidecar) route through this registry instead of ghcr.io.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T19:51:04.829Z",
+  "generatedAt": "2026-08-05T21:22:55.455Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -3482,7 +3482,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.150",
+      "version": "1.4.151",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3617,7 +3617,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.150",
+    "version": "1.4.151",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2326,7 +2326,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.150"
+  version: "1.4.151"
   visibility: listed
   card:
     title: "NewAPI"
@@ -2371,7 +2371,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.150"
+    version: "1.4.151"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## newapi rejected a VALID Keycloak authorization code with 403 x3 — because there were two newapi databases

`Refs #5599` (also `Refs #5358 #5414 #5602 #5459`). Not a close — merged is not delivered; #5599 stays open for the runtime walk.

### Root cause (measured live, BOTH regions sampled)

An OAuth **authorization code is single-use and stored SERVER-SIDE**. Bootstrap-kit slot 80 installs this chart on **every** region's control plane, so a 2-region Sovereign ran TWO complete newapi stacks — two Deployments **and two INDEPENDENT CNPG `Cluster` objects**, not a replicated pair — behind ONE hostname whose shared VIP fans a browser's parallel connections across both gateways (#5459).

hw292, dep `1c56518035a83e03`, read-only, nothing mutated:

```
region-a  deployment.apps/newapi-bp-newapi                        1/1
          cluster.postgresql.cnpg.io/newapi-bp-newapi-newapi-pg   2 ready
          httproute newapi-bp-newapi-public -> ["newapi.hw292.omani.works"]
region-b  deployment.apps/newapi-bp-newapi                        1/1
          cluster.postgresql.cnpg.io/newapi-bp-newapi-newapi-pg   2 ready
          httproute newapi-bp-newapi-public -> ["newapi.hw292.omani.works"]
```

The leg that minted the exchange wrote its state into region-a's Postgres; the `/api/oauth/sovereign` callback landed on region-b, whose database had never seen that code, and region-b **correctly** rejected it. The `x3` is the client retrying and losing the coin flip again.

#5414 already fixed newapi's SESSION_SECRET/CRYPTO_SECRET split at the **secret** seam. The **datastore** split underneath it was never addressed.

### Design — the established idiom, no third variant

Follows the two references merged today: **bp-guacamole 0.2.36** (#5358, PR #5697) and **bp-cilium 1.4.19** (#5602, PR #5704).

| | primary | secondary |
|---|---|---|
| Deployment | yes | **no** |
| CNPG `Cluster` + DSN placeholder | yes | **no** |
| DSN-sync / admin-sso-seed / channel-seed hook Jobs | yes | **no** |
| Service (main) + Service (`-bridge`) | yes, `global=true shared=true affinity=local` | **yes**, `global=true shared=false affinity=local` |
| HTTPRoute | yes | **yes** |
| cross-region CNP | yes (rendered on both; inert on the secondary) | yes |

The secondary's Services match zero local Pods, so `service.cilium.io/affinity: local` falls through the mesh to the primary's singleton. Its HTTPRoute still renders because the shared VIP fans TCP across **both** regions' gateways — that region must keep answering for the hostname.

**Both** Services carry the annotations. The HTTPRoute sends Exact `/` and Exact `/login` to the `-bridge` Service (#3374 / #5612) and those legs initiate the very OIDC round-trip whose code the main Service's backend must later redeem — annotating only one would leave the same defect through a narrower window.

`crossRegion.enabled=false` (default) renders **byte-identically**.

### Composing with the existing gates, not replacing them

`deployment.yaml` already carries the three-way #943 skip-render gate (DSN precedence `database.existingSecret` > auto-provisioned CNPG DSN > skip, plus the credentials and `$kcConfigured` gates) and the #3831 placement split. The new gates are strictly conjunctive:

- `renderWorkloads` = `renderApp` AND NOT mesh-secondary → the Deployment plus the two seed hooks
- `renderDataStore` = `renderSeams` AND NOT mesh-secondary → the CNPG `Cluster`, its DSN placeholder Secret, and the DSN-sync hook

Every pre-existing condition still decides the primary's render exactly as before.

The hook Jobs had to move with their subject: they are `post-install,post-upgrade` hooks that poll the CNPG `<cluster>-app` Secret and rollout-restart the Deployment. Left on a secondary that has neither, they would fail the release and the mesh stubs would never install.

Deliberately **left** on plain `renderApp`: the two Services (they ARE the mesh stub), the HTTPRoute, and the region-local token-signing-key Secret with its #5375 admin-token PushSecret — #5375's DR contract requires every region to keep seeding its OWN OpenBao with its OWN bridge `ADMIN_SECRET` so a promote finds a bearer.

### New `templates/crossregion-netpol.yaml`

The `newapi` namespace is default-deny (`newapi-default-deny` from bp-plane-isolation, live in both regions) and `policy-default-local-cluster: "true"` in hw292's `cilium-config`, so a k8s NetworkPolicy can **never** admit a ClusterMesh peer and an `ipBlock` is equally inert (#4656 / #4846 / #4854). Two legs, two identity classes:

1. `fromEntities: [remote-node]` — `cilium-envoy` is a hostNetwork DaemonSet (verified: `hostNetwork=true`; per §854 the gateway is served direct on the host ports), so the peer's gateway hop arrives as a node identity, not as any pod endpoint a selector could name. Without it the fix would trade a 403 for a timeout.
2. `fromEndpoints` naming the peer cluster **and** the caller namespaces explicitly (`traefik`, `catalyst-system` — the same set `networkpolicy.yaml` admits locally) — the #4854 row 67 L2 any-namespace trap.

Scoped to the newapi ports only; purely additive to the union Cilium already evaluates.

### Guard — vacuity-checked in BOTH directions, with real output

`platform/newapi/chart/tests/crossregion-render.sh`.

**Case 3 against `origin/main`'s 1.4.150 chart** (same guard file, same inputs):

```
[bp-newapi] Case 3: crossRegion secondary — zero local backends, zero local datastore
FAIL: the secondary region rendered a Deployment. Its newapi Services
      must have ZERO local backends, otherwise the shared VIP again
      splits one browser's OAuth exchange across two regions and a
      VALID authorization code comes back 403 (#5599).
PREFIX-CASE3-EXIT=1
```

The pre-fix secondary render inventory, `--set crossRegion.role=secondary` (inert there — no seam exists):

```
kind: Deployment  x1
kind: Cluster     x1
kind: Job         x2
service.cilium.io x0
```

**Same input, this branch:**

```
kind: Deployment  x0     kind: Service    x2
kind: Cluster     x0     kind: HTTPRoute  x1
kind: Job         x0     service.cilium.io x6   (3 annotations on each Service)
```

**Full guard, this branch:**

```
[bp-newapi] Case 1: PASS   default — no mesh annotations, Deployment + CNPG present
[bp-newapi] Case 2: PASS   primary — global/shared/affinity on BOTH Services, CNP names peer + caller ns + remote-node
[bp-newapi] Case 3: PASS   secondary — no Deployment, no Cluster, no Jobs; both Services + HTTPRoute present, shared=false
[bp-newapi] Case 4: PASS   empty peerClusters — no CiliumNetworkPolicy
[bp-newapi] Case 5: PASS   invalid role fails the render
[bp-newapi] cross-region render audit: ALL PASS
```

Case 1 **passes on both trees** — that is what stops the guard from being satisfied by blanket suppression or blanket annotation. Case 5 exists because a typo'd role must never silently degrade back to a second full stack, which is the exact split being removed.

### Default render unchanged

Full `helm template` diff, this branch vs `origin/main`, `crossRegion.enabled=false`, `--api-versions cilium.io/v2 --api-versions postgresql.cnpg.io/v1`: **zero differences** apart from the four `randAlphaNum` values that differ on every render by construction (`SESSION_SECRET`, `CRYPTO_SECRET`, `SIGNING_KEY`, `ADMIN_SECRET`). Normalising those four lines:

```
DEFAULT RENDER BYTE-IDENTICAL (modulo per-render randAlphaNum secrets)
```

### Checks run

- All 8 pre-existing `platform/newapi/chart/tests/*.sh` — PASS (5466-credentials-region-consistency, admin-promote-rbac, admin-token-pushsecret, bridge-readiness, dsn-secret-preserve, httproute, imagepullsecrets, startup-probe)
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs in sync)
- `scripts/check-bootstrap-deps.sh` — PASS (drift 0, cycles 0)
- NodePorts: zero in the rendered output for either role; both Services stay `type: ClusterIP`. The only `nodePort` string added anywhere is the word inside a §854 explanatory comment.
- `helm lint` reports one pre-existing `admin-sso-seed-job.yaml` parse complaint that reproduces identically on `origin/main` — untouched by this PR.

### Lockstep (#817) — five sites

`Chart.yaml` 1.4.151 = `blueprint.yaml` `spec.version` = catalog-seed `spec.version` + `source.version` = `build-catalog.mjs` artifacts (`blueprints.json`, `catalog.generated.ts`) = bootstrap-kit slot 80 pin. Slot 80 also gains the `crossRegion` wiring off the existing `SOVEREIGN_ENABLE_CNPG_PAIR` / `SOVEREIGN_REGION_ROLE` / `SOVEREIGN_PEER_CLUSTERMESH_NAMES` substitutes — the same three bp-guacamole slot 52 consumes.

`ghcr-pin-existence` will fail: structural on every chart bump, the tag publishes on merge.

### What the next walker has to prove — #5599 stays OPEN

Merged is not delivered. On a fresh 2-region prov carrying bp-newapi >= 1.4.151, falsifiable:

1. `kubectl -n newapi get deploy,cluster.postgresql.cnpg.io` in **both** regions returns the workload and the Cluster in exactly ONE of them. A single-region sample proves nothing — that is how #5602 nearly got mis-diagnosed.
2. Both regions carry `service/newapi-bp-newapi` and `service/newapi-bp-newapi-bridge` with `service.cilium.io/global=true`, `shared` true on the primary and false on the secondary.
3. The secondary's `newapi-bp-newapi` EndpointSlice has zero local addresses, and its Gateway-API envoy cluster for that Service carries the primary's pod IP.
4. Walking `https://newapi.<fqdn>/` with an authenticated owner session lands signed-in: `/api/oauth/sovereign` returns a redirect, **not** 403, and `/api/user/self` returns 200 — repeated on fresh TCP connections, not a browser repeat-count (#5459: HTTP/2 pins one backend and cannot sample a round-robin).
5. UAT row 37 (newapi SSO) re-stamped with env + date + evidence, all three cells per the re-walk stamp rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
