### PR TITLE
fix(uat): never flip a UAT row whose walk post-dates the cited merge (Refs #5597)

### DIFF
--- a/scripts/test_uat_sso_flip_evidence_floor.py
+++ b/scripts/test_uat_sso_flip_evidence_floor.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""test_uat_sso_flip_evidence_floor.py — the #5597 evidence-age floor.
+
+# What this pins
+
+`uat-sso-flip.py` flips EVERY `| sso |` ledger row carrying a verified
+verdict; it never inspects the commit. Its only scoping is the `paths:`
+filter in `.github/workflows/sso-uat-flip.yaml`. That filter has broadened
+and regressed repeatedly — #5597 is the incident where merge 71c54d8d (a
+cutover fix with ZERO auth paths) erased six rows walked hours earlier,
+pushing the headline 34 -> 28.
+
+The filter is now scoped, and `scripts/sso-flip-pathmatch.py` locks that
+scoping with the 71c54d8d receipt. This file guards a DIFFERENT layer, on
+purpose: the floor holds even when the filter is wrong, because it depends
+on nothing the filter decides.
+
+The invalidation law is "a merge makes PRIOR evidence stale". It was never
+"a merge deletes evidence newer than itself" — a walk performed after a
+merge already measured that merged code, so flipping it replaces newer
+truth with older.
+
+# Why both directions are mandatory here
+
+A floor that protects everything is indistinguishable from disabling the
+flip entirely, which would let genuinely stale evidence sit green forever —
+the exact failure the #3374 law exists to prevent. So every "protects"
+case is paired with a "still flips" case.
+
+Run: python3 scripts/test_uat_sso_flip_evidence_floor.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from importlib.machinery import SourceFileLoader
+
+_mod = SourceFileLoader(
+    "uat_sso_flip", str(pathlib.Path(__file__).resolve().parent / "uat-sso-flip.py")
+).load_module()
+
+# Report a MISSING floor as a clean verdict, not an AttributeError traceback.
+# Against the pre-fix script this is the both-directions proof, and a crash
+# reads like a broken test rather than a detected regression.
+_missing = [n for n in ("evidence_date", "merge_date_for", "flip_area_rows")
+            if not hasattr(_mod, n)]
+if _missing:
+    print(
+        "FAIL — #5597 evidence-age floor is ABSENT from scripts/uat-sso-flip.py "
+        f"(missing: {', '.join(_missing)}).\n"
+        "Without it, any merge the workflow classifies as SSO-touching erases "
+        "walk evidence captured AFTER that merge — the #5597 incident, which "
+        "deleted 6 rows and moved the headline 34 -> 28.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+flip_area_rows = _mod.flip_area_rows
+evidence_date = _mod.evidence_date
+
+HEADER = "| id | area | issue | criterion | env | verdict | evidence |\n|---|---|---|---|---|---|---|\n"
+
+
+def row(rid: str, verdict: str, evidence: str) -> str:
+    return f"| {rid} | sso | [#3374](x) | lands authenticated | hw292 | {verdict} | {evidence} |"
+
+
+def ledger(*rows: str) -> str:
+    return HEADER + "\n".join(rows) + "\n"
+
+
+FAILS: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if not cond:
+        FAILS.append(f"{name}{(' — ' + detail) if detail else ''}")
+
+
+def main() -> int:
+    # ── evidence_date: newest wins, absent is None ──────────────────────
+    check("evidence_date picks NEWEST of several",
+          evidence_date("hw291-2026-07-30 re-walked hw292-2026-08-03T05:10Z") == "2026-08-03")
+    check("evidence_date None when no date", evidence_date("walked, no stamp") is None)
+    check("evidence_date None on empty", evidence_date("") is None)
+
+    # ── 1. THE #5597 INCIDENT: evidence NEWER than the merge is kept ────
+    # Merge 71c54d8d landed 2026-08-03; rows were walked the same day.
+    txt = ledger(row("28", "✅", "hw292-2026-08-03T06:48Z walked"))
+    out, flipped = flip_area_rows(txt, "71c54d8d", merge_date="2026-08-03")
+    check("#5597 same-day walk is PROTECTED", flipped == [], f"flipped={flipped}")
+    check("#5597 protected row text unchanged", "✅" in out and "UNVERIFIED" not in out)
+
+    # ── 2. Genuinely STALE evidence still flips (the law still works) ───
+    txt = ledger(row("28", "✅", "hw291-2026-07-30T09:00Z walked"))
+    out, flipped = flip_area_rows(txt, "deadbeef", merge_date="2026-08-03")
+    check("stale evidence STILL flips", flipped == ["28"], f"flipped={flipped}")
+    check("stale row became ☐", "☐" in out and "UNVERIFIED (flipped" in out)
+
+    # ── 3. Floor OFF (no merge date) => unchanged legacy behaviour ──────
+    txt = ledger(row("28", "✅", "hw292-2026-08-03T06:48Z walked"))
+    out, flipped = flip_area_rows(txt, "manual", merge_date=None)
+    check("no merge date => legacy flip (fail-open)", flipped == ["28"], f"flipped={flipped}")
+
+    # ── 4. Undated evidence is NOT protected (cannot prove it is newer) ─
+    txt = ledger(row("28", "✅", "walked, stamp lost"))
+    out, flipped = flip_area_rows(txt, "deadbeef", merge_date="2026-08-03")
+    check("undated evidence still flips", flipped == ["28"], f"flipped={flipped}")
+
+    # ── 5. Mixed ledger: protects only what it should ───────────────────
+    txt = ledger(
+        row("28", "✅", "hw292-2026-08-03T06:48Z"),   # same day -> keep
+        row("40", "⚠️", "hw292-2026-08-04T10:00Z"),   # newer    -> keep
+        row("41", "✅", "hw291-2026-07-29T10:00Z"),   # older    -> flip
+        row("42", "❌", "hw292-2026-08-03T06:00Z"),   # not verified -> never touched
+    )
+    out, flipped = flip_area_rows(txt, "71c54d8d", merge_date="2026-08-03")
+    check("mixed: only the stale row flips", flipped == ["41"], f"flipped={flipped}")
+    check("mixed: ❌ row untouched", "| ❌ |" in out)
+
+    # ── 6. ANTI-VACUITY: the floor must not protect everything ──────────
+    # If this ever passes with flipped == [], the floor has become a
+    # blanket disable and the #3374 invalidation law is dead.
+    txt = ledger(
+        row("28", "✅", "hw291-2026-07-01T10:00Z"),
+        row("40", "✅", "hw291-2026-07-02T10:00Z"),
+    )
+    _, flipped = flip_area_rows(txt, "deadbeef", merge_date="2026-08-03")
+    check("ANTI-VACUITY: all-stale ledger flips ALL rows", flipped == ["28", "40"],
+          f"flipped={flipped} — a floor that protects everything is a disabled flip")
+
+    if FAILS:
+        print("FAIL — #5597 evidence-age floor:", file=sys.stderr)
+        for f in FAILS:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("PASS — #5597 evidence-age floor: protects post-merge walks, "
+          "still flips stale evidence, fail-open without a merge date, not vacuous")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/uat-sso-flip.py
+++ b/scripts/uat-sso-flip.py
@@ -29,7 +29,7 @@ BEGIN = "<!-- sso-zero-click-table:begin -->"
 END = "<!-- sso-zero-click-table:end -->"
 
 
-def flip(text: str, ref: str) -> tuple[str, list[str]]:
+def flip(text: str, ref: str, merge_date: str | None = None) -> tuple[str, list[str]]:
     try:
         head, rest = text.split(BEGIN, 1)
         table, tail = rest.split(END, 1)
@@ -39,7 +39,7 @@ def flip(text: str, ref: str) -> tuple[str, list[str]]:
         # same #3374 law against that shape instead of hard-failing — the
         # docstring's contract is "Exit 0 always (idempotent)", and a FATAL
         # here turned every SSO-path merge red once the markers were gone.
-        return flip_area_rows(text, ref)
+        return flip_area_rows(text, ref, merge_date)
 
     today = datetime.date.today().isoformat()
     stamp = f"UNVERIFIED (flipped {today} by {ref})"
@@ -60,8 +60,58 @@ def flip(text: str, ref: str) -> tuple[str, list[str]]:
 
 VERIFIED_VERDICTS = ("✅", "⚠️")
 
+# ── #5597 evidence-age floor ────────────────────────────────────────────
+# Never flip a row whose walk evidence is NEWER than the merge being cited.
+#
+# The #5597 incident erased rows 28/40/41/42/43/45 — evidence captured
+# 06:48Z-07:05Z that day — citing merge 71c54d8d, a cutover fix carrying
+# ZERO auth paths. Root cause was the workflow's `paths:` filter, since
+# scoped, and locked by scripts/sso-flip-pathmatch.py's receipts.
+#
+# This is the SECOND line, deliberately independent of that filter: even a
+# correctly-classified SSO merge cannot invalidate a walk that happened
+# AFTER it, because such a walk already measured the merged code. The
+# invalidation law is "a merge makes PRIOR evidence stale" — it was never
+# "a merge deletes evidence newer than itself". Without this floor, any
+# future broadening of `paths:` silently deletes fresh evidence again, and
+# the guard that catches it lives in a different file.
+#
+# No merge date resolvable (manual run, unknown ref) => floor DISABLED,
+# preserving today's behaviour exactly. Fail-open is correct here: the
+# floor only ever PREVENTS destructive edits.
+_DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
 
-def flip_area_rows(text: str, ref: str) -> tuple[str, list[str]]:
+
+def evidence_date(cell: str) -> str | None:
+    """Newest YYYY-MM-DD appearing in an evidence cell, or None.
+
+    Stamps look like `hw292-2026-08-03T05:10Z ...` and a re-stamped row can
+    carry several dates; the NEWEST is the one that decides staleness.
+    """
+    found = _DATE_RE.findall(cell or "")
+    return max(found) if found else None
+
+
+def merge_date_for(ref: str) -> str | None:
+    """Committer date (YYYY-MM-DD) of `ref`, or None when unresolvable."""
+    if not ref or ref == "manual":
+        return None
+    try:
+        import subprocess
+
+        out = subprocess.run(
+            ["git", "show", "-s", "--format=%cI", ref],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        if out.returncode != 0:
+            return None
+        m = _DATE_RE.search(out.stdout.strip())
+        return m.group(1) if m else None
+    except Exception:
+        return None
+
+
+def flip_area_rows(text: str, ref: str, merge_date: str | None = None) -> tuple[str, list[str]]:
     """Marker-less mode: flip consolidated-ledger rows whose area column is
     `sso` and whose verdict claims a verified state (✅/⚠️) back to ☐.
     ❌/⛔/☐/⏳/N/A rows keep their measured state (a roll does not un-break
@@ -71,6 +121,7 @@ def flip_area_rows(text: str, ref: str) -> tuple[str, list[str]]:
     today = datetime.date.today().isoformat()
     row_re = re.compile(r"^\| *\d+ *\| *sso *\|")
     flipped: list[str] = []
+    protected: list[str] = []
     out_lines: list[str] = []
     saw_sso_row = False
     for line in text.splitlines():
@@ -78,11 +129,25 @@ def flip_area_rows(text: str, ref: str) -> tuple[str, list[str]]:
             saw_sso_row = True
             cells = line.split("|")
             if len(cells) >= 8 and cells[6].strip() in VERIFIED_VERDICTS:
+                ev_date = evidence_date(cells[7])
+                # #5597 floor: a walk performed AFTER the cited merge already
+                # measured that merged code — invalidating it would delete
+                # newer truth in favour of older.
+                if merge_date and ev_date and ev_date >= merge_date:
+                    protected.append(f"{cells[1].strip()} (evidence {ev_date} >= merge {merge_date})")
+                    out_lines.append(line)
+                    continue
                 cells[6] = " ☐ "
                 cells[7] = f" UNVERIFIED (flipped {today} by {ref}) — was: {cells[7].strip()} "
                 flipped.append(cells[1].strip())
                 line = "|".join(cells)
         out_lines.append(line)
+    if protected:
+        print(
+            f"#5597 evidence-age floor: kept {len(protected)} row(s) whose walk "
+            f"post-dates {ref}: {', '.join(protected)}",
+            file=sys.stderr,
+        )
     if not saw_sso_row:
         print(
             f"FATAL: neither markers {BEGIN}/{END} nor `| sso |` ledger rows found in UAT.md",
@@ -96,11 +161,19 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--ref", default="manual", help="commit sha / PR ref that triggered the flip")
     ap.add_argument("--uat", default="docs/ledger/UAT.md")
+    ap.add_argument(
+        "--merge-date",
+        default=None,
+        help="YYYY-MM-DD of the merge being cited (#5597 evidence-age floor). "
+             "Default: resolved from --ref via git; unresolvable => floor off.",
+    )
     args = ap.parse_args()
+
+    merge_date = args.merge_date or merge_date_for(args.ref)
 
     p = pathlib.Path(args.uat)
     text = p.read_text(encoding="utf-8")
-    new, flipped = flip(text, args.ref)
+    new, flipped = flip(text, args.ref, merge_date)
     if flipped:
         p.write_text(new, encoding="utf-8")
         print(f"flipped {len(flipped)} SSO rows to UNVERIFIED: {', '.join(flipped)}")


### PR DESCRIPTION
## First, a correction to the issue's diagnosis

The issue proposes classifying on the **file list** rather than raw `git show`, because a `Co-authored-by:` trailer contains the substring `auth`.

`scripts/uat-sso-flip.py` **never inspects the commit at all.** It flips every `| sso |` ledger row carrying a verified verdict, unconditionally. Its only scoping is the `paths:` filter in `.github/workflows/sso-uat-flip.yaml`. So there is no content classifier to fix — the trailer-substring theory, while a very reasonable read of the symptom, is not the mechanism.

The mechanism was the `paths:` filter being broad enough to match `71c54d8d` (a cutover fix with zero auth paths). That filter has since been scoped, and `scripts/sso-flip-pathmatch.py` locks it with `71c54d8d` as an explicit MUST-NOT-FIRE receipt. Ask 1 and ask 3 are therefore already satisfied on `main`.

## What was genuinely missing: the evidence-age floor (the issue's 4th ask)

Everything protecting this ledger today lives in **one** place — the accuracy of a path glob. When that glob was wrong, six rows walked hours earlier were deleted and the headline moved 34 → 28, in a commit that reads authoritative and mechanical.

This adds the second line, deliberately independent of the filter:

> **A row whose walk evidence post-dates the cited merge is never flipped.**

The invalidation law is *"a merge makes PRIOR evidence stale"*. It was never *"a merge deletes evidence newer than itself"* — a walk performed after a merge has already measured that merged code, so flipping it replaces newer truth with older. That holds even for a correctly-classified SSO merge, which is exactly why it belongs at a different layer from the glob.

## Design notes

- Merge date resolves from `--ref` via `git show -s --format=%cI`, overridable with `--merge-date`.
- **Unresolvable date ⇒ floor disabled**, preserving today's behaviour byte-for-byte. Fail-open is correct here because the floor only ever *prevents* a destructive edit; failing closed would silently stop legitimate invalidation.
- **Undated evidence is not protected** — the floor cannot prove such a row is newer, so it flips as before.
- Protected rows are reported on stderr with both dates, so a suppression is visible in the job log rather than silent.

## Both directions, real exit codes

| tree | result |
|---|---|
| `origin/main`'s script | **`PRE_RC=1`** — `FAIL — #5597 evidence-age floor is ABSENT (missing: evidence_date, merge_date_for)` |
| this branch | **`POST_RC=0`** — PASS |

The absence is reported as a legible verdict rather than an `AttributeError` traceback, because a crash reads like a broken test instead of a detected regression.

Six cases, and the pairing is the point — a floor that protects *everything* is indistinguishable from disabling the flip, which would let genuinely stale evidence sit green forever:

1. the real #5597 shape (same-day walk, merge `71c54d8d`) → **protected**
2. genuinely stale evidence → **still flips**
3. no merge date → legacy behaviour
4. undated evidence → still flips
5. mixed ledger → only the stale row flips; a `❌` row is never touched
6. **anti-vacuity**: an all-stale ledger must flip *every* row — if this ever passes with zero flips, the floor has become a blanket disable and the #3374 law is dead

Refs #5597
