### PR TITLE
fix(cutover): step-06 secondary leg must prove the pivot DURABLE, not merely applied (Refs #5596)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1061,7 +1061,7 @@ spec:
       # index.yaml HelmRepository off charts.loft.sh into local Harbor +
       # suspends bp-vcluster-helmrepo so it holds; the step-08 fluxSourceHostLint
       # exception for charts.loft.sh is removed (empty allowHosts).
-      version: 0.1.170
+      version: 0.1.171
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.170
+  version: 0.1.171
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,51 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.171 (#5596) — THE SECONDARY-REGION PIVOT IS NOW PROVEN DURABLE, NOT MERELY
+# APPLIED. Step-06's #5359 secondary read-back was SINGLE-SHOT and fired within
+# seconds of the patch loop, so it measured the PATCH and never the PIVOT.
+# region-B runs its OWN kustomize-controller against its OWN artifact of the
+# gitops repo; when that artifact is the pre-cutover one, the next re-apply puts
+# every URL back on oci://ghcr.io/openova-io — after the step recorded success.
+#
+# Measured read-only on hw292 (dep 1c56518035a83e03, 2-region me-east-215-a/-b-1)
+# on 2026-08-06, three days after the run:
+#   07:31:11Z  region-b GitRepository artifact frozen at main@sha1:4cc85ad9…
+#              (Ready=False GitOperationFailed, "unable to list remote … EOF")
+#   07:41:13Z  step.helmrepository-patches.region.me-east-215-b-1.result=success
+#   07:42:08Z  region-b kustomize-controller Apply — sole field manager,
+#              generation 3, all 64 HelmRepositories back on ghcr.io
+#   08:12:30Z  cutoverComplete=true
+#   +3d        region-a 69/69 on oci://registry.hw292.omani.works, region-b
+#              64/65 on oci://ghcr.io/openova-io (the 65th is the third-party
+#              vcluster-system/loft, out of scope in both regions).
+# 55 seconds is the entire width of the window the old assert could see. It was
+# a guard aimed at something that cannot fail.
+#
+# THE FIX — assert_secondary_pivot_durable() makes the reverting actor run
+# INSIDE the assert: it pokes the secondary's own GitRepository + HR-owning
+# Kustomizations with a reconcile token and refuses to certify until one of
+# those Kustomizations reports status.lastHandledReconcileAt == that token
+# (proof the re-apply HAPPENED, not merely that we asked), with the read-back
+# clean on every sample up to that point. Any offender at any sample fails the
+# leg; a poke never handled inside secondaryRegions.pivotReadbackSeconds also
+# fails it, because the revert would then land after the Job exits and nothing
+# downstream re-reads region-B. Offender scope and tolerations are identical to
+# region-A's assert (upstream prefix only, in helmRepositories.namespace, minus
+# readbackExcludeNames), so this can never be STRICTER than the step-08 gate.
+#
+# Two sibling no-op paths closed in the same leg: a FAILED HelmRepository
+# enumeration used to be `2>/dev/null || true` and therefore indistinguishable
+# from a region that genuinely has none — it recorded `skipped` and moved on;
+# it now fails loud (a region we could not read is not a region we pivoted).
+# And "no secondary kubeconfigs mounted" now says so explicitly, so a
+# single-region Sovereign's legitimate inert leg reads differently from a
+# multi-region one that skipped its pivot. Single-region behaviour is unchanged.
+#
+# Guarded by tests/step06-secondary-durable.sh, vacuity-checked BOTH ways:
+# against 0.1.170's chart C5 (revert-on-re-apply), C6 (unreadable region) and
+# C7 (poke never handled) all exit 0 — the defect — while C1/C2/C3/C4/C8 pass on
+# both trees, so the guard cannot be satisfied by blanket failure.
+#
 # 0.1.170 (#5640) — THE HEAD OF THE DELIVERY CHAIN. The Day-2 reconciler gains a
 # CATALOG (git) leg, and it runs FIRST in each cycle.
 #
@@ -3324,7 +3370,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.170
+version: 0.1.171
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -290,6 +290,26 @@ data:
             value: {{ join " " .Values.helmRepositories.readbackReconcileKustomizations | quote }}
           - name: HELMREPO_READBACK_BUDGET_SECONDS
             value: {{ .Values.stepTimeouts.pivotReadbackSeconds | quote }}
+          # #5596 — SECONDARY-region DURABLE pivot assert inputs. The #5359
+          # read-back was single-shot and fired seconds after the patch loop,
+          # so it measured the PATCH and never the PIVOT: region-B's own
+          # kustomize-controller re-applied its (pre-cutover) artifact ~55s
+          # later and put all 64 HelmRepositories back on ghcr.io while the
+          # step had already recorded success. The assert now POKES the
+          # secondary's own GitRepository + HR-owning Kustomizations and will
+          # not certify until one of them has HANDLED that poke — i.e. the
+          # actor that would revert the pivot has already run. See
+          # assert_secondary_pivot_durable in args: below.
+          - name: GITOPS_REPO_NAME
+            value: {{ .Values.gitopsRepository.name | quote }}
+          - name: GITOPS_REPO_NAMESPACE
+            value: {{ .Values.gitopsRepository.namespace | quote }}
+          - name: SECONDARY_READBACK_BUDGET_SECONDS
+            value: {{ .Values.secondaryRegions.pivotReadbackSeconds | quote }}
+          - name: SECONDARY_READBACK_SETTLE_SAMPLES
+            value: {{ .Values.secondaryRegions.pivotReadbackSettleSamples | quote }}
+          - name: SECONDARY_READBACK_INTERVAL_SECONDS
+            value: {{ .Values.secondaryRegions.pivotReadbackIntervalSeconds | quote }}
           # #5650 — vcluster loft chart-source pivot (Phase-2c). Mirrors the
           # upstream vcluster chart into local Harbor + repoints the
           # index.yaml loft HelmRepository (vcluster-system) to the local OCI
@@ -732,10 +752,13 @@ data:
             # still-tethered environment — the sovereignty claim would be
             # false while the evidence trail said otherwise.
             #
-            # The SECONDARY-region leg has had exactly this read-back since
-            # #5359 (see pivot_secondary_regions below, "Read-back assert:
-            # ZERO upstream-prefixed HRs may remain"). Region-A never did.
-            # This is that same assertion, for the region that matters most.
+            # The SECONDARY-region leg has had a read-back of this SHAPE since
+            # #5359 — but a SINGLE-SHOT one, with no convergence budget and no
+            # reconcile re-poke, so it could only ever sample the seconds
+            # between the patch and region-B's next Kustomization re-apply
+            # (#5596; see assert_secondary_pivot_durable below). Region-A never
+            # had one at all. This is that assertion, with a budget, for the
+            # region that matters most.
             #
             # Scope: HELMREPO_NAMESPACE (the namespace Phase-1 patches) —
             # the same scope the #5359 secondary read-back uses, and where
@@ -1535,7 +1558,197 @@ data:
               return 0
             }
 
+            # ---- #5596: secondary-region DURABLE pivot assert ----
+            #
+            # THE DEFECT THIS CLOSES. #5359's read-back re-read the secondary's
+            # HelmRepository set ONCE, immediately after the patch loop. It
+            # therefore measured the PATCH, never the PIVOT. region-B runs its
+            # OWN kustomize-controller against its OWN artifact of the gitops
+            # repo; if that artifact is the PRE-cutover one — its GitRepository
+            # frozen on a stale revision, which #5359's step-05 convergence gate
+            # catches at step-05 time but which can also go stale AFTER that
+            # gate passed — the next re-apply puts every URL back on the
+            # upstream prefix, minutes after this step recorded success.
+            #
+            # Live on hw292 (dep 1c56518035a83e03, 2-region me-east-215-a/-b-1):
+            #   07:31:11Z  region-b GitRepository artifact frozen at
+            #              main@sha1:4cc85ad9… (Ready=False GitOperationFailed,
+            #              "unable to list remote … pkt-line 3: EOF")
+            #   07:41:13Z  step.helmrepository-patches.region.me-east-215-b-1
+            #              .result=success — single-shot read-back saw 0 left
+            #   07:42:08Z  region-b kustomize-controller Apply (sole field
+            #              manager, generation 3) — all 64 HelmRepositories back
+            #              on oci://ghcr.io/openova-io
+            #   08:12:30Z  cutoverComplete=true
+            #   +3d        region-b: 64/65 HelmRepositories still on ghcr.io.
+            # 55 seconds is the entire width of the window the old assert
+            # sampled in. It was a guard aimed at something that cannot fail.
+            #
+            # THE FIX: make the reverting actor run INSIDE the assert. Poke the
+            # secondary's own GitRepository + the HR-owning Kustomizations with
+            # a reconcile token, and refuse to certify until one of those
+            # Kustomizations has HANDLED that exact token
+            # (status.lastHandledReconcileAt == token — proof the re-apply
+            # HAPPENED, not merely that we asked for it), with the read-back
+            # clean on every sample up to and including that point. Any
+            # offender at ANY sample fails the leg; a poke that is never handled
+            # inside the budget also fails it, because a revert would then land
+            # after this Job exits and nothing downstream re-reads region-B.
+            #
+            # Offender scope + tolerations are IDENTICAL to region-A's
+            # assert_region_a_pivot: the upstream prefix only, in
+            # HELMREPO_NAMESPACE, minus HELMREPO_READBACK_EXCLUDE (which mirrors
+            # step-08's whitelist). Third-party sources outside the namespace
+            # (vcluster-system/loft) were never in scope and still are not.
+            #
+            # NB: offenders go to a FILE and are grepped from the file — never
+            # `printf | grep -q` (the #5370/#5406/#4969 SIGPIPE shape).
+            secondary_offenders() {
+              # $1 = kubeconfig. Writes offenders to /tmp/.sd-offenders.txt.
+              # Returns non-zero when the ENUMERATION ITSELF failed — an
+              # unreadable region is NOT "zero offenders", and conflating the
+              # two is how a leg certifies a region it never saw.
+              so_kc="$1"
+              if ! kubectl --kubeconfig "${so_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
+                  -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' \
+                  > /tmp/.sd-hrs.txt 2>/tmp/.sd-hrs.err; then
+                return 1
+              fi
+              : > /tmp/.sd-offenders.txt
+              while IFS= read -r so_line; do
+                [ -n "${so_line}" ] || continue
+                so_name="${so_line%%=*}"
+                so_url="${so_line#*=}"
+                case "${so_url}" in
+                  "${UPSTREAM_PREFIX}"*) : ;;
+                  *) continue ;;
+                esac
+                case ",${HELMREPO_READBACK_EXCLUDE:-}," in
+                  *",${so_name},"*) continue ;;
+                esac
+                printf '%s=%s\n' "${so_name}" "${so_url}" >> /tmp/.sd-offenders.txt
+              done < /tmp/.sd-hrs.txt
+              return 0
+            }
+
+            secondary_source_diagnosis() {
+              # Best-effort operator context for a failure message: WHY the
+              # secondary would revert (its gitops source state).
+              sg_kc="$1"
+              sg_ready=$(kubectl --kubeconfig "${sg_kc}" get gitrepository "${GITOPS_REPO_NAME}" \
+                -n "${GITOPS_REPO_NAMESPACE}" \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+              sg_msg=$(kubectl --kubeconfig "${sg_kc}" get gitrepository "${GITOPS_REPO_NAME}" \
+                -n "${GITOPS_REPO_NAMESPACE}" \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || echo "")
+              sg_rev=$(kubectl --kubeconfig "${sg_kc}" get gitrepository "${GITOPS_REPO_NAME}" \
+                -n "${GITOPS_REPO_NAMESPACE}" \
+                -o jsonpath='{.status.artifact.revision}' 2>/dev/null || echo "")
+              printf 'GitRepository %s/%s Ready=%s revision=%s%s' \
+                "${GITOPS_REPO_NAMESPACE}" "${GITOPS_REPO_NAME}" \
+                "${sg_ready:-<none>}" "${sg_rev:-<none>}" \
+                "${sg_msg:+ (${sg_msg})}"
+            }
+
+            assert_secondary_pivot_durable() {
+              sd_kc="$1"; sd_region="$2"
+              sd_budget="${SECONDARY_READBACK_BUDGET_SECONDS:-300}"
+              sd_samples="${SECONDARY_READBACK_SETTLE_SAMPLES:-2}"
+              sd_interval="${SECONDARY_READBACK_INTERVAL_SECONDS:-10}"
+              sd_deadline=$(( $(date +%s) + sd_budget ))
+              sd_token=$(date +%s)
+
+              # Which HR-owning Kustomizations actually EXIST in this region —
+              # only those can revert the pivot, and only those can be required
+              # to handle the poke. A region with none of them has nothing that
+              # re-applies HelmRepositories from a durable source, so the plain
+              # read-back is already the whole truth there (single-region-shaped
+              # secondaries, and any topology where the operator moved the slot
+              # Kustomizations, must not fail on an absence).
+              : > /tmp/.sd-ks.txt
+              for sd_ks in ${HELMREPO_READBACK_KUSTOMIZATIONS:-}; do
+                if kubectl --kubeconfig "${sd_kc}" get kustomization "${sd_ks}" \
+                    -n "${HELMREPO_NAMESPACE}" >/dev/null 2>&1; then
+                  printf '%s\n' "${sd_ks}" >> /tmp/.sd-ks.txt
+                fi
+              done
+              sd_ks_count=$(grep -c . /tmp/.sd-ks.txt || true)
+
+              # Poke: force the durable source + every HR-owning Kustomization
+              # to re-apply NOW, so a revert lands inside this window instead of
+              # 55 seconds after the Job exits (the hw292 shape).
+              kubectl --kubeconfig "${sd_kc}" annotate --overwrite gitrepository "${GITOPS_REPO_NAME}" \
+                -n "${GITOPS_REPO_NAMESPACE}" \
+                "reconcile.fluxcd.io/requestedAt=${sd_token}" >/dev/null 2>&1 || true
+              while IFS= read -r sd_ks; do
+                [ -n "${sd_ks}" ] || continue
+                kubectl --kubeconfig "${sd_kc}" annotate --overwrite kustomization "${sd_ks}" \
+                  -n "${HELMREPO_NAMESPACE}" \
+                  "reconcile.fluxcd.io/requestedAt=${sd_token}" >/dev/null 2>&1 || true
+              done < /tmp/.sd-ks.txt
+              echo "[helmrepository-patches] #5596 secondary ${sd_region}: poked ${sd_ks_count} HR-owning Kustomization(s) + ${GITOPS_REPO_NAMESPACE}/${GITOPS_REPO_NAME} with reconcile token ${sd_token}; the pivot must survive their re-apply"
+
+              sd_clean=0
+              sd_handled=0
+              # NB: `[ … ] && sd_handled=1` would exit the whole step under the
+              # script's `set -e` whenever the test is false. Use an if.
+              if [ "${sd_ks_count}" -eq 0 ]; then
+                echo "[helmrepository-patches] #5596 secondary ${sd_region}: none of the HR-owning Kustomizations (${HELMREPO_READBACK_KUSTOMIZATIONS:-<none>}) exist here — nothing in this region re-applies HelmRepositories from a durable source, so the read-back alone is the whole truth"
+                sd_handled=1
+              fi
+              while : ; do
+                if ! secondary_offenders "${sd_kc}"; then
+                  echo "[helmrepository-patches] FATAL: #5596 secondary ${sd_region}: cannot enumerate its HelmRepositories in ${HELMREPO_NAMESPACE} — an unreadable region is NOT a pivoted region; refusing to record success" >&2
+                  sed 's/^/  KUBECTL-STDERR /' /tmp/.sd-hrs.err >&2 || true
+                  return 1
+                fi
+                sd_left=$(grep -c . /tmp/.sd-offenders.txt || true)
+                if [ "${sd_left}" -ne 0 ]; then
+                  echo "[helmrepository-patches] FATAL: #5596 secondary ${sd_region}: ${sd_left} HelmRepository(ies) on ${UPSTREAM_PREFIX} after the pivot — region ${sd_region} would resolve those charts from the public upstream on its next reconcile; refusing to record success. $(secondary_source_diagnosis "${sd_kc}")" >&2
+                  sed 's/^/  STILL-UPSTREAM /' /tmp/.sd-offenders.txt >&2 || true
+                  return 1
+                fi
+                sd_clean=$((sd_clean+1))
+                if [ "${sd_handled}" -eq 0 ]; then
+                  while IFS= read -r sd_ks; do
+                    [ -n "${sd_ks}" ] || continue
+                    sd_h=$(kubectl --kubeconfig "${sd_kc}" get kustomization "${sd_ks}" \
+                      -n "${HELMREPO_NAMESPACE}" \
+                      -o jsonpath='{.status.lastHandledReconcileAt}' 2>/dev/null || echo "")
+                    if [ "${sd_h}" = "${sd_token}" ]; then
+                      sd_handled=1
+                      echo "[helmrepository-patches] #5596 secondary ${sd_region}: Kustomization ${sd_ks} handled reconcile token ${sd_token} — its re-apply has run"
+                      break
+                    fi
+                  done < /tmp/.sd-ks.txt
+                fi
+                if [ "${sd_handled}" -eq 1 ] && [ "${sd_clean}" -ge "${sd_samples}" ]; then
+                  echo "[helmrepository-patches] #5596 secondary ${sd_region}: pivot is DURABLE — zero HelmRepositories on ${UPSTREAM_PREFIX} across ${sd_clean} sample(s) spanning its own re-apply (tolerated: ${HELMREPO_READBACK_EXCLUDE:-<none>})"
+                  return 0
+                fi
+                if [ "$(date +%s)" -ge "${sd_deadline}" ]; then break; fi
+                sleep "${sd_interval}"
+              done
+              echo "[helmrepository-patches] FATAL: #5596 secondary ${sd_region}: the pivot read back CLEAN but could not be proven DURABLE within ${sd_budget}s — none of its HR-owning Kustomizations ($(tr '\n' ' ' < /tmp/.sd-ks.txt)) handled reconcile token ${sd_token}, so their next re-apply lands AFTER this Job exits and nothing downstream re-reads region ${sd_region}. That is exactly the hw292 shape (clean at 07:41:13Z, all 64 reverted at 07:42:08Z). $(secondary_source_diagnosis "${sd_kc}"). Refusing to record success (#5596)" >&2
+              return 1
+            }
+
             pivot_secondary_regions() {
+              pv_regions=0
+              for pv_probe in /secondary-kubeconfigs/*.yaml; do
+                [ -e "${pv_probe}" ] || continue
+                pv_regions=$((pv_regions+1))
+              done
+              # #5596 — say WHICH of the two zero-work states this is. "No
+              # secondary regions exist" (single-region Sovereign) is a
+              # legitimate no-op; "secondary regions exist and were not
+              # pivoted" is the false positive this leg exists to prevent, and
+              # every path below now has to record a per-region verdict.
+              if [ "${pv_regions}" -eq 0 ]; then
+                echo "[helmrepository-patches] #5359 no secondary-region kubeconfigs mounted — single-region Sovereign, secondary leg is inert (not a skipped pivot)"
+                return 0
+              fi
+              echo "[helmrepository-patches] #5359 secondary regions to pivot: ${pv_regions}"
               for pv_kc in /secondary-kubeconfigs/*.yaml; do
                 [ -e "${pv_kc}" ] || continue
                 pv_region=$(basename "${pv_kc}" .yaml)
@@ -1556,11 +1769,30 @@ data:
 
                 # Enumerate the secondary's LIVE HR set (drift-proof — its own
                 # set is authoritative, exactly the Phase-0.9 union discipline).
-                kubectl --kubeconfig "${pv_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
-                  -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' 2>/dev/null \
-                  > /tmp/sec_hrs.txt || true
+                #
+                # #5596 — the enumeration's EXIT STATUS is load-bearing. It used
+                # to be `2>/dev/null || true`, which made "the API call failed"
+                # (unreachable region, expired credential, CRD absent) produce
+                # the SAME empty file as "this region genuinely has no
+                # HelmRepositories" — and the empty file recorded `skipped` and
+                # moved on. A region we could not read is not a region we
+                # pivoted; only a SUCCESSFUL listing that is empty may skip.
+                if kubectl --kubeconfig "${pv_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
+                    -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' \
+                    > /tmp/sec_hrs.txt 2>/tmp/sec_hrs.err; then
+                  pv_enum_ok=1
+                else
+                  pv_enum_ok=0
+                fi
+                if [ "${pv_enum_ok}" -eq 0 ]; then
+                  echo "[helmrepository-patches] FATAL: #5596 secondary ${pv_region}: enumerating HelmRepositories in ${HELMREPO_NAMESPACE} FAILED — refusing to record skipped on a region this Job could not read (that is indistinguishable from a pivoted region only in the log)" >&2
+                  sed 's/^/  KUBECTL-STDERR /' /tmp/sec_hrs.err >&2 || true
+                  kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
+                    -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"failed\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.helmrepository-patches.region.${pv_region}.lastError\":\"helmrepository enumeration failed\"}}" || true
+                  return 1
+                fi
                 if ! grep -q . /tmp/sec_hrs.txt; then
-                  echo "[helmrepository-patches] #5359 secondary ${pv_region}: no HelmRepositories found — recording skipped"
+                  echo "[helmrepository-patches] #5359 secondary ${pv_region}: listed successfully, zero HelmRepositories in ${HELMREPO_NAMESPACE} — nothing to pivot, recording skipped"
                   kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
                     -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"skipped\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
                   continue
@@ -1602,18 +1834,15 @@ data:
                   return 1
                 fi
 
-                # Read-back assert: ZERO upstream-prefixed HRs may remain — a
+                # Read-back assert (#5359, made DURABLE by #5596): ZERO
+                # upstream-prefixed HRs may remain — and they must still be zero
+                # after the secondary's own HR-owning Kustomizations have
+                # re-applied, which the assert forces rather than waits for. A
                 # partially-pivoted secondary succeeding anyway IS the #5359
-                # false positive.
-                kubectl --kubeconfig "${pv_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
-                  -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' 2>/dev/null \
-                  > /tmp/sec_hrs_after.txt || true
-                pv_left=$(grep -cF -- "=${UPSTREAM_PREFIX}" /tmp/sec_hrs_after.txt || true)
-                if [ "${pv_left}" -ne 0 ]; then
-                  echo "[helmrepository-patches] FATAL: #5359 secondary ${pv_region}: ${pv_left} HelmRepository(ies) still on ${UPSTREAM_PREFIX} after the pivot:" >&2
-                  grep -F -- "=${UPSTREAM_PREFIX}" /tmp/sec_hrs_after.txt | sed 's/^/  STILL-UPSTREAM /' >&2 || true
+                # false positive; a fully-pivoted-then-reverted one is #5596.
+                if ! assert_secondary_pivot_durable "${pv_kc}" "${pv_region}"; then
                   kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
-                    -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"failed\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" || true
+                    -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"failed\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.helmrepository-patches.region.${pv_region}.lastError\":\"pivot not durable — see Job log\"}}" || true
                   return 1
                 fi
 

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -1560,48 +1560,25 @@ data:
 
             # ---- #5596: secondary-region DURABLE pivot assert ----
             #
-            # THE DEFECT THIS CLOSES. #5359's read-back re-read the secondary's
-            # HelmRepository set ONCE, immediately after the patch loop. It
-            # therefore measured the PATCH, never the PIVOT. region-B runs its
-            # OWN kustomize-controller against its OWN artifact of the gitops
-            # repo; if that artifact is the PRE-cutover one — its GitRepository
-            # frozen on a stale revision, which #5359's step-05 convergence gate
-            # catches at step-05 time but which can also go stale AFTER that
-            # gate passed — the next re-apply puts every URL back on the
-            # upstream prefix, minutes after this step recorded success.
+            # #5359's read-back re-read the secondary's HR set ONCE, right after
+            # the patch loop: it measured the PATCH, never the PIVOT. region-B
+            # re-applies its OWN artifact of the gitops repo, and if that
+            # artifact is the PRE-cutover one every URL goes back upstream
+            # minutes after this step recorded success. hw292: clean read-back
+            # + result=success at 07:41:13Z, region-b kustomize-controller Apply
+            # at 07:42:08Z put all 64 HRs back on ghcr.io, cc=true at 08:12:30Z,
+            # still 64/65 on ghcr 3 days later. 55s is the whole window the old
+            # assert could see. Full forensics in Chart.yaml 0.1.171.
             #
-            # Live on hw292 (dep 1c56518035a83e03, 2-region me-east-215-a/-b-1):
-            #   07:31:11Z  region-b GitRepository artifact frozen at
-            #              main@sha1:4cc85ad9… (Ready=False GitOperationFailed,
-            #              "unable to list remote … pkt-line 3: EOF")
-            #   07:41:13Z  step.helmrepository-patches.region.me-east-215-b-1
-            #              .result=success — single-shot read-back saw 0 left
-            #   07:42:08Z  region-b kustomize-controller Apply (sole field
-            #              manager, generation 3) — all 64 HelmRepositories back
-            #              on oci://ghcr.io/openova-io
-            #   08:12:30Z  cutoverComplete=true
-            #   +3d        region-b: 64/65 HelmRepositories still on ghcr.io.
-            # 55 seconds is the entire width of the window the old assert
-            # sampled in. It was a guard aimed at something that cannot fail.
+            # THE FIX: make the reverting actor run INSIDE the assert — poke the
+            # secondary's GitRepository + HR-owning Kustomizations and refuse to
+            # certify until one of them HANDLED that exact token
+            # (status.lastHandledReconcileAt == token: the re-apply HAPPENED,
+            # not merely that we asked), read-back clean on every sample up to
+            # that point. Offender scope + tolerations are IDENTICAL to
+            # assert_region_a_pivot, so this is never stricter than step-08.
             #
-            # THE FIX: make the reverting actor run INSIDE the assert. Poke the
-            # secondary's own GitRepository + the HR-owning Kustomizations with
-            # a reconcile token, and refuse to certify until one of those
-            # Kustomizations has HANDLED that exact token
-            # (status.lastHandledReconcileAt == token — proof the re-apply
-            # HAPPENED, not merely that we asked for it), with the read-back
-            # clean on every sample up to and including that point. Any
-            # offender at ANY sample fails the leg; a poke that is never handled
-            # inside the budget also fails it, because a revert would then land
-            # after this Job exits and nothing downstream re-reads region-B.
-            #
-            # Offender scope + tolerations are IDENTICAL to region-A's
-            # assert_region_a_pivot: the upstream prefix only, in
-            # HELMREPO_NAMESPACE, minus HELMREPO_READBACK_EXCLUDE (which mirrors
-            # step-08's whitelist). Third-party sources outside the namespace
-            # (vcluster-system/loft) were never in scope and still are not.
-            #
-            # NB: offenders go to a FILE and are grepped from the file — never
+            # NB: offenders go to a FILE and are grepped from it — never
             # `printf | grep -q` (the #5370/#5406/#4969 SIGPIPE shape).
             secondary_offenders() {
               # $1 = kubeconfig. Writes offenders to /tmp/.sd-offenders.txt.

--- a/platform/self-sovereign-cutover/chart/tests/step06-secondary-durable.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step06-secondary-durable.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# bp-self-sovereign-cutover — step-06 SECONDARY-region DURABLE pivot guard (#5596).
+#
+# THE DEFECT THIS LOCKS OUT
+# ─────────────────────────
+# #5359 gave the secondary leg a read-back ("ZERO upstream-prefixed HRs may
+# remain"). It was SINGLE-SHOT and fired within seconds of the patch loop, so
+# it measured the PATCH and never the PIVOT. region-B runs its OWN
+# kustomize-controller against its OWN artifact of the gitops repo; when that
+# artifact is the pre-cutover one, the next re-apply puts every URL back on
+# oci://ghcr.io/openova-io — minutes after the step recorded success.
+#
+# Live on hw292 (dep 1c56518035a83e03, 2-region me-east-215-a/-b-1), all
+# read-only from the cluster on 2026-08-06:
+#   07:31:11Z  region-b GitRepository artifact frozen at main@sha1:4cc85ad9…
+#              (Ready=False GitOperationFailed, "unable to list remote … EOF")
+#   07:41:13Z  step.helmrepository-patches.region.me-east-215-b-1.result=success
+#   07:42:08Z  region-b kustomize-controller Apply (sole field manager,
+#              generation 3) — all 64 HelmRepositories back on ghcr.io
+#   08:12:30Z  cutoverComplete=true
+#   +3d        region-b: 64/65 HelmRepositories still on oci://ghcr.io/openova-io
+# 55 seconds is the entire width of the window the old assert sampled in.
+#
+# WHY THIS TEST EXECUTES THE SCRIPT INSTEAD OF GREPPING THE RENDER
+# ───────────────────────────────────────────────────────────────
+# The rendered log text was ALREADY correct before the fix — the leg printed
+# "all HelmRepositories on <local>" and recorded result=success. Log text is
+# exactly what made this ship. So the assertions are on the SCRIPT'S EXIT CODE,
+# driven by a fake kubectl that reproduces the live shape: the patches land,
+# and then the region's Kustomization re-applies its stale artifact.
+#
+# WHAT IS EXECUTED
+# ────────────────
+# The REAL rendered step-06 script bytes, sliced from `sync_secondary_ghcr_pull`
+# through the `if ! pivot_secondary_regions` call site — the whole secondary
+# leg, verbatim, including whatever read-back the tree under test carries. The
+# ambient variables the earlier phases would have set (harbor_host,
+# local_prefix, trust_secret) and the `read_secret_key` helper are supplied by
+# a preamble; /secondary-kubeconfigs is relocated into the test tmpdir.
+#
+# BOTH-DIRECTIONS CONTRACT (vacuity)
+# ──────────────────────────────────
+#   C1/C2 must PASS on origin/main AND on the fixed tree (no blanket failure).
+#   C5    must FAIL on origin/main only — it is the #5596 revert.
+#   C6    must FAIL on origin/main only — an unreadable region recorded skipped.
+#   C3/C4 are the pre-existing #5359 signals and must hold on both trees.
+#
+# Usage: bash tests/step06-secondary-durable.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+CHART_DIR="$(cd "${CHART_DIR}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+pass=0; fail=0
+ok()  { echo "  ok: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+mkdir -p "${TMP}/bin" "${TMP}/fake" "${TMP}/kc"
+
+echo "[step06-secondary-durable] rendering chart: ${CHART_DIR}"
+helm template smoke "${CHART_DIR}" > "${TMP}/render.yaml"
+
+# ── Extract the step-06 script + its rendered env ─────────────────────────
+python3 - "${TMP}/render.yaml" "${TMP}/step06.sh" "${TMP}/step06.env" <<'PY'
+import sys, yaml
+render, out_sh, out_env = sys.argv[1], sys.argv[2], sys.argv[3]
+for d in yaml.safe_load_all(open(render)):
+    if not d or d.get("kind") != "ConfigMap":
+        continue
+    if d["metadata"]["name"] != "cutover-step-06-helmrepository-patches":
+        continue
+    spec = yaml.safe_load(d["data"]["podSpec"])
+    c = [x for x in spec["containers"] if x["name"] == "helmrepository-patches"][0]
+    open(out_sh, "w").write(c["args"][0])
+    def shquote(v):
+        return "'" + str(v).replace("'", "'\\''") + "'"
+    with open(out_env, "w") as fh:
+        for e in c.get("env", []):
+            if "value" in e:
+                fh.write("export %s=%s\n" % (e["name"], shquote(e["value"])))
+    sys.exit(0)
+sys.exit("step-06 ConfigMap not found in render")
+PY
+
+[ -s "${TMP}/step06.sh" ] && ok "extracted the rendered step-06 script" \
+                          || bad "could not extract the step-06 script"
+
+# ── Slice the secondary leg out of the real script ────────────────────────
+start_ln=$(awk 'index($0,"sync_secondary_ghcr_pull() {"){print NR; exit}' "${TMP}/step06.sh")
+call_ln=$(awk 'index($0,"if ! pivot_secondary_regions; then"){print NR; exit}' "${TMP}/step06.sh")
+if [ -z "${start_ln}" ] || [ -z "${call_ln}" ]; then
+  bad "cannot locate the secondary leg (sync_secondary_ghcr_pull / pivot_secondary_regions call site)"
+  echo; echo "RESULT: ${pass} passed, ${fail} failed"; [ "${fail}" -eq 0 ]; exit
+fi
+end_ln=$(awk -v s="${call_ln}" 'NR>s && $1=="fi" {print NR; exit}' "${TMP}/step06.sh")
+[ -n "${end_ln}" ] || end_ln=$((call_ln+3))
+sed -n "${start_ln},${end_ln}p" "${TMP}/step06.sh" > "${TMP}/leg.body.sh"
+ok "sliced the secondary leg (lines ${start_ln}-${end_ln} of the rendered script)"
+
+# The slice must still contain the pivot loop, or the harness is testing air.
+if grep -q 'pivot_secondary_regions() {' "${TMP}/leg.body.sh"; then
+  ok "slice contains pivot_secondary_regions"
+else
+  bad "slice lost pivot_secondary_regions — the harness boundaries are stale"
+fi
+
+# Relocate the container mount path; assert the substitution applied so a
+# template rename cannot silently turn this into a no-op test.
+mount_hits=$(grep -c '/secondary-kubeconfigs/\*.yaml' "${TMP}/leg.body.sh" || true)
+if [ "${mount_hits}" -lt 1 ]; then
+  bad "the leg no longer globs /secondary-kubeconfigs/*.yaml — harness mount relocation is stale"
+fi
+sed -i "s,/secondary-kubeconfigs/,${TMP}/kc/,g" "${TMP}/leg.body.sh"
+
+# ── Preamble: what the earlier phases would have set ──────────────────────
+cat > "${TMP}/preamble.sh" <<'PRE'
+set -eu
+harbor_host="registry.hw292.omani.works"
+local_prefix="oci://registry.hw292.omani.works/openova-io"
+trust_secret=""
+# Phase-0's reader — the secondary ghcr-pull sync calls it. Not under test here.
+read_secret_key() { printf '%s' "ZmFrZS1kb2NrZXJjb25maWc="; }
+# Keep the guard fast: a real region converges in seconds, and the cases that
+# must FAIL do so on their first or second sample.
+export SECONDARY_READBACK_BUDGET_SECONDS=4
+export SECONDARY_READBACK_INTERVAL_SECONDS=1
+PRE
+
+# ── fake kubectl ──────────────────────────────────────────────────────────
+# Models the live shape per region:
+#   state-<region>.txt   name=url, one per line
+#   token-<region>       status.lastHandledReconcileAt of every Kustomization
+# FAKE_REVERT_ON_POKE   a Kustomization annotate re-applies the region's STALE
+#                       artifact: every HelmRepository goes back upstream.
+#                       This is hw292 07:42:08Z.
+# FAKE_KS_HANDLES=0     the poke is accepted but never handled (kustomize-
+#                       controller wedged) — durability is unprovable.
+# FAKE_KS_ABSENT=1      the region has no HR-owning Kustomizations at all.
+# FAKE_LIST_FAIL=1      `get helmrepository` fails (unreachable region).
+cat > "${TMP}/bin/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+region="region-a"
+if [ "${1:-}" = "--kubeconfig" ]; then
+  region="$(basename "$2" .yaml)"
+  shift 2
+fi
+state="${FAKE_DIR}/state-${region}.txt"
+tokenf="${FAKE_DIR}/token-${region}"
+verb="${1:-}"; shift || true
+args="$*"
+
+case "${verb}" in
+  get)
+    res="${1:-}"
+    case "${res}" in
+      helmrepository|helmrepositories|helmrepositories.source.toolkit.fluxcd.io)
+        if [ "${FAKE_LIST_FAIL:-0}" = "1" ] && [ "${region}" != "region-a" ]; then
+          echo "Unable to connect to the server: dial tcp 10.0.0.1:6443: i/o timeout" >&2
+          exit 1
+        fi
+        [ -f "${state}" ] && cat "${state}"
+        exit 0 ;;
+      kustomization|kustomizations)
+        [ "${FAKE_KS_ABSENT:-0}" = "1" ] && exit 1
+        case "${args}" in
+          *lastHandledReconcileAt*)
+            [ -f "${tokenf}" ] && cat "${tokenf}"
+            exit 0 ;;
+        esac
+        exit 0 ;;
+      gitrepository|gitrepositories)
+        case "${args}" in
+          *'@.type=="Ready"'*) printf 'False' ;;
+          *revision*) printf 'main@sha1:4cc85ad9' ;;
+        esac
+        exit 0 ;;
+      secret) exit 1 ;;
+      *) exit 0 ;;
+    esac ;;
+  patch)
+    res="${1:-}"
+    case "${res}" in
+      helmrepository)
+        name="$2"
+        newurl=$(printf '%s' "${args}" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
+        case " ${FAKE_PATCH_ERRORS:-} " in *" ${name} "*) exit 1 ;; esac
+        case " ${FAKE_STUBBORN:-} " in *" ${name} "*) exit 0 ;; esac
+        if [ -n "${newurl}" ] && [ -f "${state}" ]; then
+          grep -v "^${name}=" "${state}" > "${state}.n" || true
+          printf '%s=%s\n' "${name}" "${newurl}" >> "${state}.n"
+          sort -o "${state}" "${state}.n"
+        fi
+        exit 0 ;;
+      *) exit 0 ;;   # configmap status writes
+    esac ;;
+  annotate)
+    # kubectl annotate --overwrite <kind> <name> -n <ns> key=value
+    kind=""
+    for a in "$@"; do
+      case "${a}" in
+        --overwrite) continue ;;
+        kustomization|gitrepository|helmrepository) kind="${a}"; break ;;
+      esac
+    done
+    tok=$(printf '%s' "${args}" | sed -n 's/.*reconcile\.fluxcd\.io\/requestedAt=\([0-9]*\).*/\1/p')
+    if [ "${kind}" = "kustomization" ] && [ -n "${tok}" ]; then
+      [ "${FAKE_KS_ABSENT:-0}" = "1" ] && exit 0
+      if [ "${FAKE_REVERT_ON_POKE:-0}" = "1" ] && [ -f "${state}" ]; then
+        # The region re-applies its PRE-CUTOVER artifact.
+        sed -e "s,=.*,=${UPSTREAM_PREFIX}," "${state}" > "${state}.n"
+        mv "${state}.n" "${state}"
+      fi
+      [ "${FAKE_KS_HANDLES:-1}" = "1" ] && printf '%s' "${tok}" > "${tokenf}"
+    fi
+    exit 0 ;;
+  apply|delete|create) exit 0 ;;
+  *) exit 0 ;;
+esac
+FAKE
+chmod +x "${TMP}/bin/kubectl"
+
+UP="oci://ghcr.io/openova-io"
+
+run_case() {
+  # $1 label  $2 expected exit (0|1)  $3 region state (empty = single-region)
+  # env knobs are passed through the environment by the caller.
+  local label="$1" expect="$2" state="$3"
+  rm -f "${TMP}/kc"/*.yaml "${TMP}/fake"/* 2>/dev/null || true
+  if [ -n "${state}" ]; then
+    printf 'apiVersion: v1\nkind: Config\n' > "${TMP}/kc/me-east-215-b-1.yaml"
+    printf '%s\n' "${state}" | grep -v '^$' > "${TMP}/fake/state-me-east-215-b-1.txt"
+  fi
+  : > "${TMP}/fake/state-region-a.txt"
+  cat "${TMP}/preamble.sh" "${TMP}/leg.body.sh" > "${TMP}/run.sh"
+  local rc=0
+  set +e
+  env -i \
+    PATH="${TMP}/bin:${PATH}" HOME="${TMP}" \
+    FAKE_DIR="${TMP}/fake" \
+    FAKE_REVERT_ON_POKE="${FAKE_REVERT_ON_POKE:-0}" \
+    FAKE_KS_HANDLES="${FAKE_KS_HANDLES:-1}" \
+    FAKE_KS_ABSENT="${FAKE_KS_ABSENT:-0}" \
+    FAKE_LIST_FAIL="${FAKE_LIST_FAIL:-0}" \
+    FAKE_STUBBORN="${FAKE_STUBBORN:-}" \
+    FAKE_PATCH_ERRORS="${FAKE_PATCH_ERRORS:-}" \
+    bash -c "set -a; . '${TMP}/step06.env'; set +a; bash '${TMP}/run.sh'" \
+    > "${TMP}/out.log" 2>&1
+  rc=$?
+  set -e
+  if [ "${expect}" = "0" ]; then
+    if [ "${rc}" -eq 0 ]; then ok "${label}: exit ${rc} (expected 0)"
+    else bad "${label}: exit ${rc} (expected 0)"; sed 's/^/      /' "${TMP}/out.log" | tail -15; fi
+  else
+    if [ "${rc}" -ne 0 ]; then ok "${label}: exit ${rc} (expected non-zero)"
+    else bad "${label}: exit 0 — the secondary leg reported SUCCESS without a durable pivot (#5596)"; sed 's/^/      /' "${TMP}/out.log" | tail -15; fi
+  fi
+}
+
+echo "== exit-code cases against a fake kubectl =="
+
+# C1 — single-region: no kubeconfigs mounted. MUST pass on both trees.
+run_case "C1 single-region (no secondary kubeconfigs) is a legitimate no-op" 0 ""
+
+# C2 — happy path: the pivot lands and SURVIVES the region's re-apply.
+#      MUST pass on both trees (proves the guard is not a blanket fail).
+run_case "C2 secondary pivots and the pivot survives its Kustomization re-apply" 0 \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}
+bp-agenity=${UP}"
+
+# C3 — #5359 regression anchor: a patch the API rejects still fails.
+FAKE_PATCH_ERRORS="bp-keycloak" run_case "C3 kubectl patch returns non-zero (#5359 fail counter)" 1 \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}"
+
+# C4 — #5359 regression anchor: patch accepted, object unchanged. The
+#      immediate read-back catches this on BOTH trees.
+FAKE_STUBBORN="bp-agenity" run_case "C4 patch accepted but the HelmRepository does not change" 1 \
+  "bp-cilium=${UP}
+bp-agenity=${UP}"
+
+# C5 — THE #5596 CASE. Every patch lands; the region's own kustomize-controller
+#      then re-applies its stale pre-cutover artifact and every URL goes back
+#      upstream. origin/main exits 0 here (single-shot read-back sampled the
+#      55-second window); the fixed tree pokes that re-apply into its own
+#      window and fails loud.
+FAKE_REVERT_ON_POKE=1 run_case "C5 pivot reverted by the region's own re-apply (hw292 07:42:08Z)" 1 \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}
+bp-agenity=${UP}"
+
+# C6 — the region cannot be read at all. origin/main records `skipped` and
+#      exits 0; an unreadable region is not a pivoted region.
+FAKE_LIST_FAIL=1 run_case "C6 secondary HelmRepository enumeration fails (recorded skipped on main)" 1 \
+  "bp-cilium=${UP}"
+
+# C7 — the poke is accepted but never handled (wedged kustomize-controller).
+#      Durability is unprovable, so the leg must not certify. On main this is
+#      indistinguishable from success.
+FAKE_KS_HANDLES=0 run_case "C7 reconcile poke never handled — durability unprovable" 1 \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}"
+
+# C8 — a region with NO HR-owning Kustomizations: nothing there re-applies
+#      HelmRepositories, so a clean read-back IS the whole truth. MUST pass on
+#      both trees — the fix must not fail a topology that cannot revert.
+FAKE_KS_ABSENT=1 run_case "C8 region has no HR-owning Kustomizations (nothing can revert)" 0 \
+  "bp-cilium=${UP}
+bp-keycloak=${UP}"
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2894,6 +2894,39 @@ secondaryRegions:
   # artifact for 22h. Ready is a status field; immediately after a patch
   # it still describes the previous spec.
   gitRepositoryReadySeconds: 300
+  # Step 06 secondary leg: DURABLE pivot assert (#5596). After patching a
+  # secondary region's HelmRepositories, the leg pokes that region's own
+  # GitRepository + HR-owning Kustomizations (helmRepositories.
+  # readbackReconcileKustomizations) with a reconcile token and refuses to
+  # record success until one of those Kustomizations reports
+  # status.lastHandledReconcileAt == that token — i.e. the actor that would
+  # REVERT the pivot has already run — with the read-back clean on every
+  # sample up to that point.
+  #
+  # #5596 (hw292, dep 1c56518035a83e03): the pre-0.1.171 read-back was
+  # single-shot and fired seconds after the patch loop, so it sampled the
+  # PATCH and never the PIVOT. The step recorded
+  # step.helmrepository-patches.region.me-east-215-b-1.result=success at
+  # 07:41:13Z; region-b's kustomize-controller re-applied its FROZEN
+  # pre-cutover artifact at 07:42:08Z and put all 64 HelmRepositories back
+  # on oci://ghcr.io/openova-io. cutoverComplete=true landed at 08:12:30Z
+  # and 3 days later region-b was still 64/65 on ghcr.io. 55 seconds was
+  # the entire width of the window the old assert could see.
+  #
+  # A converged secondary handles the poke in seconds, so a healthy region
+  # costs ~2 samples of wall-clock and never waits the budget out; the
+  # budget is only spent on a region that genuinely cannot prove durability,
+  # where failing loud after 5 minutes is exactly the right trade. Inside
+  # stepTimeouts.helmRepositoryPatchesSeconds (2400s) alongside the region-A
+  # read-back + Phase-3a strip-readiness worst case.
+  pivotReadbackSeconds: 300
+  # Consecutive clean read-backs required (the last of which must land at or
+  # after the poked re-apply). 2 keeps a healthy region fast while still
+  # spanning one interval of live observation.
+  pivotReadbackSettleSamples: 2
+  # Seconds between read-back samples. Same 10s cadence step-05's secondary
+  # convergence poll uses.
+  pivotReadbackIntervalSeconds: 10
   # Git URL the SECONDARY regions' GitRepository is pivoted to. Empty
   # (default) = the chain is the Sovereign's OWN external Gitea door
   # (giteaFallbackURL / giteaFallbackToPublicDoor below). Setting this

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.170",
+      "version": "0.1.171",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.170",
+    "version": "0.1.171",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5088,7 +5088,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.170"
+  version: "0.1.171"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5105,7 +5105,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.170"
+    version: "0.1.171"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Root cause — the secondary read-back is a guard aimed at something that cannot fail

Re-measured read-only on **hw292** (dep `1c56518035a83e03`, 2-region `me-east-215-a` / `-b-1`) on 2026-08-06, three days after the run:

| surface | region-a | region-b |
|---|---|---|
| flux-system HelmRepositories on `oci://registry.hw292.omani.works/openova-io` | **69** | 0 |
| flux-system HelmRepositories on `oci://ghcr.io/openova-io` | 0 | **64** |
| third-party source this step never rewrites (`vcluster-system/loft`, `https://charts.loft.sh`) | 1 | 1 |

None of the three "exit 0 having changed nothing" paths fired. The leg ran, reached region-B and patched:

- `step.helmrepository-patches.region.me-east-215-b-1.result=success` at **07:41:13Z** — so the glob matched and the enumeration was non-empty (an empty one records `skipped`).
- region-B's `flux-system/ghcr-pull` carries `catalyst.openova.io/mirrored-from: region-a/flux-system/ghcr-pull` — the cross-cluster kubeconfig works; the credential path is sound.

What actually happened is one layer further out:

- **07:31:11Z** — region-B's `GitRepository/openova` artifact freezes at `main@sha1:4cc85ad9…`, `Ready=False GitOperationFailed: unable to list remote for 'http://gitea-http.gitea.svc.cluster.local:3000/openova/openova': pkt-line 3: EOF`.
- **07:41:13Z** — step-06's secondary leg patches all 64 HRs to local Harbor and its **single-shot** read-back sees zero offenders. `result=success`.
- **07:42:08Z** — region-B's `kustomize-controller` re-applies that frozen **pre-cutover** artifact. `managedFields` on every HR now shows kustomize-controller as the sole field manager at that timestamp, `generation: 3` (created → pivoted → reverted), and `spec.url` back to `oci://ghcr.io/openova-io`.
- **08:12:30Z** — `cutoverComplete=true`.

**55 seconds** is the entire width of the window the old read-back sampled in. It measured the *patch*, never the *pivot*. Region-A's `assert_region_a_pivot` was given a bounded convergence budget with reconcile re-pokes for exactly this revert race (#5436); the secondary leg got the assertion in name only — the header comment at line ~735 claiming it "has had exactly this read-back since #5359" was true only in shape, not in strength. That claim is corrected in this PR.

## The fix

`assert_secondary_pivot_durable()` makes the reverting actor run **inside** the assert instead of 55 seconds after the Job exits:

1. Poke the secondary's own `GitRepository` + the HR-owning Kustomizations (`helmRepositories.readbackReconcileKustomizations`) with a reconcile token.
2. Refuse to certify until one of those Kustomizations reports `status.lastHandledReconcileAt == that token` — proof the re-apply **happened**, not merely that we asked for it.
3. Read back on every sample up to and including that point; **any** offender at **any** sample fails the leg (fail-loud, with the region's GitRepository Ready/revision in the message so the operator gets the real diagnosis).
4. A poke never handled inside `secondaryRegions.pivotReadbackSeconds` also fails — durability is unprovable, and nothing downstream re-reads region-B.

Offender scope and tolerations are identical to region-A's assert (upstream prefix only, in `helmRepositories.namespace`, minus `readbackExcludeNames`), so this leg can never be **stricter** than the step-08 gate that follows it. `vcluster-system/loft` sits outside `helmRepositories.namespace` and this step never rewrote it, in either region, before or after.

Two sibling no-op paths in the same leg are closed:

- The HelmRepository enumeration was `2>/dev/null || true`, so **"the API call failed"** produced the same empty file as **"this region genuinely has none"** — and the empty file recorded `skipped` and moved on. Only a *successful* empty listing may skip now; a region we could not read fails loud.
- "No secondary kubeconfigs mounted" is now stated explicitly, so a single-region Sovereign's legitimate inert leg reads differently from a multi-region one that skipped its pivot. **Single-region behaviour is unchanged** (C1 below).

## Guard — vacuity-checked BOTH directions

`platform/self-sovereign-cutover/chart/tests/step06-secondary-durable.sh` renders the chart, slices the **real** secondary leg out of the step-06 ConfigMap (`sync_secondary_ghcr_pull` → the `pivot_secondary_regions` call site, verbatim) and executes it against a fake kubectl that models the live shape. CI picks it up automatically via `blueprint-release.yaml`'s `chart/tests/*.sh` gate.

Against **this branch**:

```
  ok: C1 single-region (no secondary kubeconfigs) is a legitimate no-op: exit 0 (expected 0)
  ok: C2 secondary pivots and the pivot survives its Kustomization re-apply: exit 0 (expected 0)
  ok: C3 kubectl patch returns non-zero (#5359 fail counter): exit 1 (expected non-zero)
  ok: C4 patch accepted but the HelmRepository does not change: exit 1 (expected non-zero)
  ok: C5 pivot reverted by the region's own re-apply (hw292 07:42:08Z): exit 1 (expected non-zero)
  ok: C6 secondary HelmRepository enumeration fails (recorded skipped on main): exit 1 (expected non-zero)
  ok: C7 reconcile poke never handled - durability unprovable: exit 1 (expected non-zero)
  ok: C8 region has no HR-owning Kustomizations (nothing can revert): exit 0 (expected 0)

RESULT: 11 passed, 0 failed        (exit 0)
```

Against **origin/main's chart** (`git archive origin/main` into a tmpdir, same guard):

```
  FAIL: C5 pivot reverted by the region's own re-apply (hw292 07:42:08Z): exit 0
      [helmrepository-patches] #5359 secondary me-east-215-b-1: pivot ok=3 skip=0 fail=0
      [helmrepository-patches] #5359 secondary region me-east-215-b-1: all HelmRepositories on oci://registry.hw292.omani.works/openova-io
  FAIL: C6 secondary HelmRepository enumeration fails (recorded skipped on main): exit 0
      [helmrepository-patches] #5359 secondary me-east-215-b-1: no HelmRepositories found - recording skipped
  FAIL: C7 reconcile poke never handled - durability unprovable: exit 0

RESULT: 8 passed, 3 failed          (exit 1)
```

Note main's C5 log line: it prints *"all HelmRepositories on oci://registry.hw292.omani.works/openova-io"* over a state that had already been reverted — the exact hw292 lie, reproduced in a harness.

C1 / C2 / C3 / C4 / C8 pass on **both** trees, so the guard cannot be satisfied by blanket failure. C8 in particular proves the fix does not fail a topology that has nothing capable of reverting.

## Sibling guards + lockstep

- `tests/step06-pivot-readback.sh` — 13 passed, 0 failed
- `tests/step05-secondary-chain.sh` — all assertions passed
- `tests/cutover-contract.sh` — All gates green (77 cases)
- `helm lint` — 0 charts failed
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail)
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs in sync)
- Chart 0.1.170 → **0.1.171** across all five lockstep sites: `Chart.yaml`, `blueprint.yaml` `spec.version`, catalog-seed `spec.version` + `source.version`, the generated `blueprints.json` artifact, and the `clusters/_template/bootstrap-kit/06a` slot pin.
- No Service objects added or touched; zero nodePort literals in the diff (§854).
- `ghcr-pin-existence` fails structurally on every chart bump — the `0.1.171` tag publishes on merge. Not chased.

## Falsifiable re-verification (issue stays OPEN)

`#5596` is **not** closed by this merge. On the next fresh 2-region prov: at `cutoverComplete=true`, region-b's ghcr-pointing `flux-system` HelmRepositories must be **0**, and `step.helmrepository-patches.region.<key>.result` must be `success` only alongside a Job log line reading `pivot is DURABLE — zero HelmRepositories on oci://ghcr.io/openova-io across N sample(s) spanning its own re-apply`.

Note for that walk: on hw292 the underlying reason region-B's re-apply was poisonous is that its `GitRepository` could not fetch the local Gitea at all (`pkt-line 3: EOF` — region-B resolves `gitea-http.gitea.svc.cluster.local` to its **own** empty Gitea, the failure mode `secondaryRegions.giteaURL`'s comment block already documents). Step-05's convergence gate now targets that directly; this PR makes step-06 refuse to certify **whenever** the durable pivot cannot be proven, whatever the upstream reason.

Refs #5596 #5359 #5436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
