### PR TITLE
fix(auth): accept the handover issuer SET, not a single value (Refs #5614)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -96,6 +96,68 @@ type authHandoverClaims struct {
 	InitiatedBy      string `json:"initiated_by"`
 }
 
+// acceptedHandoverIssuers returns the exact set of `iss` values this
+// catalyst-api will honour on a handover token (#5614).
+//
+// The set has two members because ONE endpoint redeems THREE mint paths:
+//
+//   - the Sovereign's own console (handoverjwt.DefaultIssuer(), i.e.
+//     CATALYST_HANDOVER_JWT_ISSUER — https://console.<own-fqdn> after the
+//     cutover step-07 env pivot);
+//   - the MOTHERSHIP's post-provisioning handover, minted by Catalyst-Zero
+//     (which leaves the override unset) as https://console.openova.io and
+//     redeemed here against the cloud-init-mounted mothership public key;
+//   - the "Enter org" support session (#3378 B2, org_enter_org.go), minted and
+//     redeemed by this same pod.
+//
+// A cut-over Sovereign has the override SET, so any single-value comparison
+// necessarily refuses one group or the other. Pre-cutover the override is
+// unset, DefaultIssuer() already IS the mothership origin, and the set
+// collapses to one element — Catalyst-Zero behaviour is byte-unchanged.
+//
+// FAIL-CLOSED contract, in order of how each could turn authn into a hole:
+//   - the returned slice is NEVER empty (the mothership origin is an
+//     unconditional member), so no caller can degenerate into "nothing to
+//     check, therefore allow";
+//   - the empty string is NEVER a member, so a token with no `iss` claim —
+//     which jwt/v5 surfaces as ("", nil), not an error — can never match;
+//   - membership is exact string equality only. No prefix, suffix, wildcard or
+//     substring matching, so a configured issuer of "*" or "" widens nothing.
+//
+// Widening the set is safe only because `iss` is defence-in-depth here, not the
+// primary gate: the RS256 signature is verified against the mounted mothership
+// key or this pod's own signer key BEFORE this runs, and the audience /
+// support-session host check runs after. This function must never become the
+// place where an unsigned or foreign-signed token gains trust.
+func acceptedHandoverIssuers() []string {
+	out := make([]string, 0, 2)
+	if cfg := strings.TrimSpace(handoverjwt.DefaultIssuer()); cfg != "" {
+		out = append(out, cfg)
+	}
+	if ms := strings.TrimSpace(handoverjwt.MothershipIssuer()); ms != "" {
+		if len(out) == 0 || out[0] != ms {
+			out = append(out, ms)
+		}
+	}
+	return out
+}
+
+// handoverIssuerAccepted reports whether iss is a member of the accepted set.
+// Empty / whitespace issuers are refused before the comparison so an absent
+// `iss` claim can never authenticate.
+func handoverIssuerAccepted(iss string) bool {
+	iss = strings.TrimSpace(iss)
+	if iss == "" {
+		return false
+	}
+	for _, want := range acceptedHandoverIssuers() {
+		if iss == want {
+			return true
+		}
+	}
+	return false
+}
+
 // AuthHandover handles GET /auth/handover?token=<jwt>.
 func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 	raw := r.URL.Query().Get("token")
@@ -230,18 +292,18 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── 3. Validate claims ──────────────────────────────────────────────
-	// #5614 — resolve the expected issuer through the SAME single source the
-	// minter uses (handoverjwt.DefaultIssuer(), which reads
-	// CATALYST_HANDOVER_JWT_ISSUER and falls back to the Catalyst-Zero
-	// mothership origin). The former hardcoded `const expectedIss =
-	// "https://console.openova.io"` was the verify-side survivor of the #2940
-	// duplicate-tether literal: a cut-over Sovereign mints a token with its OWN
-	// console as `iss` and this verifier then 401'd it as "invalid issuer",
-	// rejecting the Sovereign's own handover (hw292, cc=true). One resolver, both
-	// sides — the mint and verify issuers can never drift again.
-	expectedIss := handoverjwt.DefaultIssuer()
+	// #5614 — the expected issuer is a SET, not a single value, because this
+	// one endpoint redeems tokens from three mint paths carrying two different
+	// `iss` values (see acceptedHandoverIssuers). The original hardcoded
+	// `const expectedIss = "https://console.openova.io"` rejected a cut-over
+	// Sovereign's OWN token (hw292, cc=true → 401 "invalid issuer"); the first
+	// remedy swapped it for a bare `handoverjwt.DefaultIssuer()` compare, which
+	// on the very same pod then rejected the MOTHERSHIP's token instead —
+	// trading one broken leg for two. Membership in the accepted set is what
+	// serves all three legs at once.
 	iss, err := claims.GetIssuer()
-	if err != nil || iss != expectedIss {
+	if err != nil || !handoverIssuerAccepted(iss) {
+		h.log.Warn("auth_handover: issuer rejected", "iss", iss)
 		writeAuthError(w, "invalid issuer")
 		return
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover_issuer_set_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover_issuer_set_test.go
@@ -1,0 +1,229 @@
+// auth_handover_issuer_set_test.go — the ACCEPTED-ISSUER SET guard for
+// GET /auth/handover (#5614).
+//
+// # Why this file exists, and why the negative rows are the important ones
+//
+// The handover verifier decides whether to establish a sovereign-admin session
+// from a token's `iss` claim. Any change here moves an authn boundary, so a test
+// that only proves "the token we wanted now works" is worthless: a fix that
+// simply WIDENS acceptance is indistinguishable from an authn HOLE unless the
+// same table also pins what must still be REFUSED. Rows 5-8 below are that pin.
+// Delete them and this file stops being a guard and becomes a rubber stamp.
+//
+// # The three legs that must all keep working
+//
+// catalyst-api both MINTS and VERIFIES handover tokens, and there are three
+// distinct mint paths with two different `iss` values:
+//
+//   - Leg A — the Sovereign's own console mints a handover for itself
+//     (deployments/{id}/mint-handover-token). Post-cutover its signer issuer is
+//     handoverjwt.DefaultIssuer() == CATALYST_HANDOVER_JWT_ISSUER ==
+//     https://console.<own-fqdn>. This is the leg #5614 reported broken.
+//   - Leg B — the MOTHERSHIP (Catalyst-Zero, which leaves
+//     CATALYST_HANDOVER_JWT_ISSUER unset) mints the post-provisioning handover
+//     with iss=https://console.openova.io, aud=https://console.<sov-fqdn>, and
+//     the SOVEREIGN redeems it here (handoverjwt package doc; signed with the
+//     mothership key mounted by cloud-init).
+//   - Leg C — the "Enter org" support session (#3378 B2, org_enter_org.go).
+//     Minted AND redeemed by the same Sovereign pod, historically stamping the
+//     mothership literal as `iss`.
+//
+// A post-cutover Sovereign has CATALYST_HANDOVER_JWT_ISSUER set, so a verifier
+// that accepts EXACTLY ONE issuer can serve Leg A or Legs B+C — never all three.
+// That is why the expected issuer is a SET {configured, mothership}, not a
+// single value.
+//
+// # Falsifiability (run both directions before trusting this file)
+//
+//   - Against the pre-#5614 tree (`const expectedIss = mothership`): row 1 fails.
+//   - Against the #5681 tree (`expectedIss := handoverjwt.DefaultIssuer()`, a
+//     single-value compare): rows 2 and 3b fail — that tree swapped which leg is
+//     broken rather than fixing it.
+//   - Against a naive "accept anything" fix: rows 5-8 fail.
+//
+// Only a fix that accepts the two-element set passes every row.
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+)
+
+// TestAuthHandover_AcceptedIssuerSet_5614 is the table-driven authn boundary for
+// the handover `iss` claim.
+func TestAuthHandover_AcceptedIssuerSet_5614(t *testing.T) {
+	const (
+		sovIssuer      = "https://console.hw292.omani.works"
+		mothership     = "https://console.openova.io"
+		attackerIssuer = "https://console.evil.example.com"
+	)
+
+	cases := []struct {
+		name string
+		// envIssuer is CATALYST_HANDOVER_JWT_ISSUER. setEnv=false leaves it
+		// unset (Catalyst-Zero / a pre-cutover Sovereign).
+		setEnv    bool
+		envIssuer string
+		// tokenIss is the `iss` claim stamped into the presented token.
+		tokenIss string
+		// wantAccept: true → 302 to /dashboard; false → 401 "invalid issuer".
+		wantAccept bool
+		why        string
+	}{
+		{
+			name: "1_own_issuer_on_cutover_sovereign_ACCEPTED",
+			// #5614 itself: hw292 (cc=true) minted a handover for ITSELF and
+			// its own verifier 401'd it. FAILS on the pre-#5614 hardcode.
+			setEnv: true, envIssuer: sovIssuer, tokenIss: sovIssuer,
+			wantAccept: true,
+			why:        "Leg A — a Sovereign must accept the token it minted itself",
+		},
+		{
+			name: "2_mothership_issuer_on_cutover_sovereign_ACCEPTED",
+			// Legs B and C. FAILS on the #5681 single-value compare, which
+			// narrowed the accepted set to {configured} and so rejected both
+			// the mothership post-provisioning handover and the Enter-org
+			// support session on every cut-over Sovereign.
+			setEnv: true, envIssuer: sovIssuer, tokenIss: mothership,
+			wantAccept: true,
+			why:        "Legs B+C — mothership handover + Enter-org must survive cutover",
+		},
+		{
+			name: "3a_mothership_issuer_unconfigured_ACCEPTED",
+			// Catalyst-Zero and every pre-cutover Sovereign: env unset, so the
+			// accepted set is {mothership} alone. Byte-unchanged behaviour.
+			setEnv: false, tokenIss: mothership,
+			wantAccept: true,
+			why:        "Catalyst-Zero unchanged when the override env is absent",
+		},
+		{
+			name: "3b_own_issuer_unconfigured_REJECTED",
+			// FAIL-CLOSED. An unconfigured pod must NOT infer a per-Sovereign
+			// issuer from the token. If this row ever flips to accept, the
+			// verifier has started trusting the attacker-controlled claim to
+			// define its own expectation.
+			setEnv: false, tokenIss: sovIssuer,
+			wantAccept: false,
+			why:        "unset env must not silently trust a per-Sovereign issuer",
+		},
+		{
+			name: "4_empty_env_attacker_issuer_REJECTED",
+			// Explicitly-empty env must fall back to {mothership}, never to a
+			// wildcard. This is the row that stops "configured issuer empty"
+			// from becoming "accept anything".
+			setEnv: true, envIssuer: "", tokenIss: attackerIssuer,
+			wantAccept: false,
+			why:        "empty configured issuer is NOT a wildcard",
+		},
+		{
+			name: "5_attacker_issuer_on_cutover_sovereign_REJECTED",
+			setEnv: true, envIssuer: sovIssuer, tokenIss: attackerIssuer,
+			wantAccept: false,
+			why:        "a foreign issuer stays foreign after the widening",
+		},
+		{
+			name: "6_attacker_issuer_unconfigured_REJECTED",
+			setEnv: false, tokenIss: attackerIssuer,
+			wantAccept: false,
+			why:        "the pre-existing negative must not regress",
+		},
+		{
+			name: "7_empty_token_issuer_REJECTED",
+			// jwt/v5 GetIssuer() returns ("", nil) for a missing claim, so a
+			// membership test written with a nil-guard alone would let an
+			// issuer-less token through if the accepted set ever contained "".
+			setEnv: true, envIssuer: sovIssuer, tokenIss: "",
+			wantAccept: false,
+			why:        "a token with no iss claim must never authenticate",
+		},
+		{
+			name: "8_empty_token_issuer_unconfigured_REJECTED",
+			setEnv: false, tokenIss: "",
+			wantAccept: false,
+			why:        "same, on an unconfigured pod",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv forbids parallel subtests — keep these sequential.
+			if tc.setEnv {
+				t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", tc.envIssuer)
+			} else {
+				// Guarantee the override is genuinely ABSENT (not merely
+				// empty) even if the ambient environment set it. t.Setenv
+				// registers the restore-on-cleanup, so the following
+				// Unsetenv is undone when the subtest ends.
+				t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "")
+				if err := os.Unsetenv("CATALYST_HANDOVER_JWT_ISSUER"); err != nil {
+					t.Fatalf("unset override: %v", err)
+				}
+			}
+
+			// Fresh handler per row: the jti store is single-use, so reusing
+			// one handler across rows would turn a genuine accept into a
+			// replay 401 and silently weaken the table.
+			h, privKey, _ := testHandoverSetup(t)
+
+			c := validClaims("sov.test")
+			c.Issuer = tc.tokenIss
+			c.ID = fmt.Sprintf("jti-issuer-set-%d", i)
+			tok := signClaims(t, privKey, c)
+
+			req := httptest.NewRequest(http.MethodGet, "/auth/handover?token="+tok, nil)
+			w := httptest.NewRecorder()
+			h.AuthHandover(w, req)
+
+			if tc.wantAccept {
+				if w.Code != http.StatusFound {
+					t.Fatalf("%s\nenv=%q token.iss=%q: got %d %q, want 302 (accepted)",
+						tc.why, tc.envIssuer, tc.tokenIss, w.Code, w.Body.String())
+				}
+				return
+			}
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("%s\nAUTHN HOLE: env=%q token.iss=%q was ACCEPTED (%d) but must be refused",
+					tc.why, tc.envIssuer, tc.tokenIss, w.Code)
+			}
+			if body := w.Body.String(); !strings.Contains(body, "invalid issuer") {
+				t.Fatalf("%s\nenv=%q token.iss=%q: rejected with %q, want the issuer check to be the thing that refused it",
+					tc.why, tc.envIssuer, tc.tokenIss, body)
+			}
+		})
+	}
+}
+
+// TestAcceptedHandoverIssuers_NeverEmpty pins the resolver itself: the accepted
+// set must never be empty (an empty set with a `len(set)==0 → allow` bug reads
+// as "accept anything") and must never contain the empty string.
+func TestAcceptedHandoverIssuers_NeverEmpty(t *testing.T) {
+	for _, env := range []string{"", "   ", "https://console.hw292.omani.works"} {
+		t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", env)
+		got := acceptedHandoverIssuers()
+		if len(got) == 0 {
+			t.Fatalf("env=%q: accepted issuer set is EMPTY — fail-open risk", env)
+		}
+		for _, v := range got {
+			if v == "" {
+				t.Fatalf("env=%q: accepted set contains the empty string %v — an iss-less token would authenticate", env, got)
+			}
+		}
+		// The mothership origin is the invariant member: it is what keeps
+		// Legs B and C alive on a cut-over Sovereign.
+		found := false
+		for _, v := range got {
+			if v == handoverjwt.MothershipIssuer() {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("env=%q: accepted set %v drops the mothership issuer — Legs B+C break", env, got)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_enter_org.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_enter_org.go
@@ -40,6 +40,7 @@ import (
 	"github.com/google/uuid"
 
 	auth "github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 )
 
 // enterOrgMaxTTL caps the support session at 60 minutes (§6 B2: "TTL ≤
@@ -160,11 +161,21 @@ func (h *Handler) HandleEnterOrg(w http.ResponseWriter, r *http.Request) {
 	// Mint the handover token targeting the ORG's console (aud =
 	// console.<org>.<sov>). The org's catalyst-api redeems it at
 	// /auth/handover with the SAME validation the Sovereign uses for the
-	// mothership's token (iss=console.openova.io, role=sovereign-admin,
-	// email_verified). The support_session marker drives the in-console
-	// banner; impersonated_org records which org was entered.
+	// mothership's token (role=sovereign-admin, email_verified). The
+	// support_session marker drives the in-console banner; impersonated_org
+	// records which org was entered.
+	//
+	// #5614: `iss` was the bare literal "https://console.openova.io" — a
+	// Pillar-5 mothership tether stamped by a Sovereign into its OWN token,
+	// and the last unconditional duplicate of the #2940 seam in the auth
+	// path. It now resolves through handoverjwt.DefaultIssuer(), the same
+	// single source the signer uses, so a cut-over Sovereign stamps its own
+	// console. Safe in both directions because the redeemer
+	// (acceptedHandoverIssuers, auth_handover.go) accepts the configured
+	// issuer AND the mothership origin — and this token is minted and
+	// redeemed by the same pod, so there is no version-skew window.
 	tokenClaims := jwt.MapClaims{
-		"iss":            "https://console.openova.io",
+		"iss":            handoverjwt.DefaultIssuer(),
 		"sub":            supportPrincipal,
 		"email":          supportPrincipal,
 		"email_verified": true,

--- a/products/catalyst/bootstrap/api/internal/handoverjwt/signer.go
+++ b/products/catalyst/bootstrap/api/internal/handoverjwt/signer.go
@@ -98,6 +98,20 @@ func DefaultIssuer() string {
 	return mothershipIssuer
 }
 
+// MothershipIssuer exposes the Catalyst-Zero origin so VERIFIERS can keep
+// accepting a mothership-minted token after the per-Sovereign override has
+// pivoted DefaultIssuer() away from it.
+//
+// #5614: a cut-over Sovereign sets CATALYST_HANDOVER_JWT_ISSUER, so
+// DefaultIssuer() no longer returns this value — but the Sovereign must still
+// redeem the mothership's post-provisioning handover (package doc above) and
+// the "Enter org" support session (#3378 B2). A verifier that compares against
+// DefaultIssuer() ALONE therefore trades one broken leg for another. The
+// accessor exists so the accepted-issuer SET can be assembled without any
+// caller re-typing the literal — the #2940 rule is "the mothership URL is
+// written once", not "the mothership URL is never read".
+func MothershipIssuer() string { return mothershipIssuer }
+
 // Claims is the exact JWT claim shape Agent C must accept.
 // Custom fields use lowercase JSON keys per RFC 7519 §4 convention.
 type Claims struct {


### PR DESCRIPTION
## What this fixes

`#5614` reported that a cut-over Sovereign mints a handover token for **itself** and then
rejects it with `{"error":"invalid issuer"}`, because `auth_handover.go` held a hardcoded
mothership issuer. That report is **CONFIRMED** — and the fix that landed for it in
`a6fa81416` (PR #5681) **only rotated which leg was broken**.

`a6fa81416` replaced the hardcode with a single-value compare:

```go
expectedIss := handoverjwt.DefaultIssuer()
if err != nil || iss != expectedIss { /* 401 */ }
```

`DefaultIssuer()` returns the configured issuer **OR** the mothership origin — never both.
On a cut-over Sovereign the override *is* set, so the accepted set narrowed to the
Sovereign's own origin and the verifier began rejecting mothership-issued tokens instead.

## The three legs, and why one value can never serve them

One endpoint (`GET /auth/handover`) redeems three mint paths carrying two `iss` values:

| Leg | Minter | `iss` stamped | Source |
|---|---|---|---|
| A | the Sovereign's own console | `DefaultIssuer()` = `console.<own-fqdn>` | `cmd/api/main.go:224` |
| B | the MOTHERSHIP, post-provisioning | mothership origin | `internal/handoverjwt/signer.go` package doc |
| C | "Enter org" support session (#3378 B2) | mothership origin (was an unconditional literal) | `internal/handler/org_enter_org.go:167` |

Legs B and C are load-bearing, established from the code before asserting it: the
`handoverjwt` package doc specifies the mothership mints and the **Sovereign** redeems at
`/auth/handover` against the cloud-init-mounted mothership public key; and
`org_enter_org.go`'s own comment says the org's catalyst-api redeems it "with the SAME
validation the Sovereign uses for the mothership's token".

**Live confirmation, read-only, 2026-08-06:**

- mothership `catalyst-api` (ns `catalyst`) carries **neither** `CATALYST_PIN_ISSUER` nor
  `CATALYST_HANDOVER_JWT_ISSUER` across its 82 env vars, so `DefaultIssuer()` resolves to the
  mothership origin and it mints Leg B with that value.
- hw292 region-a `catalyst-api` (ns `catalyst-system`, dep `1c56518035a83e03`, cc=true)
  carries `CATALYST_HANDOVER_JWT_ISSUER = https://console.hw292.omani.works`, set by cutover
  step-07 (`platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml:897`).
- hw292 region-b runs no `catalyst-api` at all, so the verifier is region-a only — both
  regions were sampled and only one is relevant.

Those two facts are jointly unsatisfiable under a single-value compare.

## The fix

- **`handoverjwt`** — export `MothershipIssuer()` so verifiers can *read* the origin without
  re-typing it. The #2940 rule is "the literal is written once", not "never read".
- **`auth_handover.go`** — `acceptedHandoverIssuers()` returns the two-member set;
  `handoverIssuerAccepted()` does exact-equality membership. Pre-cutover the override is
  unset, `DefaultIssuer()` already *is* the mothership origin, and the set collapses to one
  element, so Catalyst-Zero behaviour is byte-unchanged.
- **`org_enter_org.go`** — the last unconditional mothership literal in the auth path now
  resolves via `DefaultIssuer()`. Safe in both directions because the redeemer accepts both
  values and the same pod mints and redeems, so there is no version-skew window.

### Fail-closed, stated explicitly

Widening an authn check is where holes come from, so the contract is pinned in code and in
tests:

- the accepted set is **never empty** — the mothership origin is an unconditional member — so
  no caller can degenerate into "nothing to check, therefore allow";
- the empty string is **never a member**, so an `iss`-less token, which `jwt/v5` surfaces as
  `("", nil)` rather than an error, can never match;
- membership is **exact string equality only** — no prefix, suffix, substring or wildcard —
  so a configured issuer of `""` or `"*"` widens nothing.

`iss` is defence-in-depth here, not the primary gate: the RS256 signature is verified against
the mounted mothership key or this pod's own signer key *before* this runs, and the audience /
support-session host check runs *after*. #5175's MCP facade forward-identity is untouched —
that path verifies session bearers against `pinIssuer` (`CATALYST_PIN_ISSUER`, `auth.go:66`),
a separate seam from the handover verifier.

## Guard — vacuity-checked in BOTH directions

`TestAuthHandover_AcceptedIssuerSet_5614`, 8 table rows. Real output:

**Direction 1 — against the current tree's single-value compare, row 2 must fail:**

```
--- FAIL: TestAuthHandover_AcceptedIssuerSet_5614/2_mothership_issuer_on_cutover_sovereign_ACCEPTED
    Legs B+C - mothership handover + Enter-org must survive cutover
    env="https://console.hw292.omani.works" token.iss="https://console.openova.io":
    got 401 "{\"error\":\"invalid issuer\"}\n", want 302 (accepted)
```

**Direction 2 — against a naive accept-anything stub, the negatives must fail:**

```
--- PASS: .../1_own_issuer_on_cutover_sovereign_ACCEPTED
--- PASS: .../2_mothership_issuer_on_cutover_sovereign_ACCEPTED
--- PASS: .../3a_mothership_issuer_unconfigured_ACCEPTED
--- FAIL: .../3b_own_issuer_unconfigured_REJECTED
--- FAIL: .../4_empty_env_attacker_issuer_REJECTED
--- FAIL: .../5_attacker_issuer_on_cutover_sovereign_REJECTED
--- FAIL: .../6_attacker_issuer_unconfigured_REJECTED
--- FAIL: .../7_empty_token_issuer_REJECTED
--- FAIL: .../8_empty_token_issuer_unconfigured_REJECTED
```

Six negative rows bite. That is what makes this distinguishable from an authn hole — a fix
that merely widens acceptance passes rows 1-3a and fails everything else.

**With the fix — all 8 rows plus the resolver invariant:**

```
--- PASS: TestAuthHandover_AcceptedIssuerSet_5614 (0.76s)
    --- PASS: .../1_own_issuer_on_cutover_sovereign_ACCEPTED
    --- PASS: .../2_mothership_issuer_on_cutover_sovereign_ACCEPTED
    --- PASS: .../3a_mothership_issuer_unconfigured_ACCEPTED
    --- PASS: .../3b_own_issuer_unconfigured_REJECTED
    --- PASS: .../4_empty_env_attacker_issuer_REJECTED
    --- PASS: .../5_attacker_issuer_on_cutover_sovereign_REJECTED
    --- PASS: .../6_attacker_issuer_unconfigured_REJECTED
    --- PASS: .../7_empty_token_issuer_REJECTED
    --- PASS: .../8_empty_token_issuer_unconfigured_REJECTED
--- PASS: TestAcceptedHandoverIssuers_NeverEmpty (0.00s)
```

## Verification

In `products/catalyst/bootstrap/api`:

```
go build ./...   -> exit 0, no output
go vet ./...     -> exit 0, no output
go test ./...    -> exit 0, 28 packages ok, 0 FAIL
                    (internal/handler 261.373s, internal/handoverjwt 0.367s)
```

## Not delivered — runtime proof

Merge is not delivery. This is repo-side only; no live cluster was mutated. The runtime
assertion the next walker needs is in the issue thread: on a Sovereign running a
catalyst-api image that carries this commit, a freshly-minted handover URL must land
`302 -> /dashboard` signed-in for **both** an own-issuer token and a mothership-issuer
token. UAT rows **96 / 123 / 178** are stamped BLOCKED against hw292 with the #5614
evidence and stay that way until that walk lands.

Refs #5614 #2940 #3378 #4101 #5175 #960
