### PR TITLE
fix(marketplace,billing): carry the real 429 retry window into the funnel notice

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -185,7 +185,17 @@
           console.error('[checkout] getCreditBalance failed — voucher credit will not apply:', e);
           return 0;
         }),
-      code ? redeemVoucherPreview(code).then(p => p?.credit_baisa ?? 0).catch(() => 0) : Promise.resolve(0),
+      // #5634: an unknown/expired code resolves to null and quietly contributes
+      // 0. A THROTTLED preview rejects instead — say so, rather than showing a
+      // silently reduced total the customer cannot explain.
+      code
+        ? redeemVoucherPreview(code)
+            .then(p => p?.credit_baisa ?? 0)
+            .catch((e) => {
+              creditError = e instanceof Error ? e.message : String(e);
+              return 0;
+            })
+        : Promise.resolve(0),
     ]).then(([ledger, voucher]) => { creditBaisa = ledger + voucher; });
   });
 

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -1,4 +1,9 @@
-import { parseRateLimitBody, rateLimitMessage } from './rateLimitNotice';
+import {
+  parseRateLimitBody,
+  rateLimitMessage,
+  retryAfterSeconds,
+  type HeaderBag,
+} from './rateLimitNotice';
 
 const API_BASE = '/api';
 
@@ -82,29 +87,75 @@ async function request<T>(path: string, opts?: RequestInit): Promise<T> {
       const retry = await fetch(`${API_BASE}${path}`, { ...opts, headers: retryHeaders });
       if (!retry.ok) {
         const body = await retry.text();
-        throw new Error(requestErrorMessage(retry.status, body));
+        throw requestError(retry.status, body, retry.headers);
       }
       return retry.json();
     }
   }
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(requestErrorMessage(res.status, body));
+    throw requestError(res.status, body, res.headers);
   }
   return res.json();
+}
+
+/**
+ * A 429 raised anywhere in the funnel. Carries the server's own retry window so
+ * a caller can decide what to do with a THROTTLE specifically, instead of having
+ * to pattern-match the customer-facing string. `message` is that customer-facing
+ * string, because most callers do just surface `e.message`.
+ */
+export class RateLimitError extends Error {
+  readonly status = 429;
+  readonly retryAfterSec: number;
+  constructor(message: string, retryAfterSec: number) {
+    super(message);
+    this.name = 'RateLimitError';
+    this.retryAfterSec = retryAfterSec;
+  }
 }
 
 /**
  * #5634 (UAT row 92): callers surface `e.message` straight to the customer
  * (CheckoutStep puts it in `provisionError`), so a throttled checkout used to
  * read as a raw status code joined to a raw JSON blob. A 429 becomes the plain
- * wait-and-retry notice instead, carrying the gateway's own `retry_after`.
- * Every other status keeps the existing `<status>: <body>` shape that other
- * call sites already match on.
+ * wait-and-retry notice instead, carrying the server's own retry window from
+ * whichever place the response put it — the `Retry-After` header (what the
+ * gateway/CDN sends) or the body's `retry_after` (what our services send).
+ *
+ * Every other status keeps the existing `<status>: <body>` shape ON PURPOSE:
+ * `CheckoutStep.svelte` matches on it (`msg.startsWith('409')` at the
+ * slug-collision retry), so this shape is load-bearing, not incidental.
  */
-function requestErrorMessage(status: number, body: string): string {
-  if (status === 429) return rateLimitMessage(parseRateLimitBody(body), 'checkout');
+export function requestErrorMessage(status: number, body: string, headers?: HeaderBag): string {
+  if (status === 429) return rateLimitMessage(parseRateLimitBody(body), 'checkout', headers);
   return `${status}: ${body}`;
+}
+
+function requestError(status: number, body: string, headers?: HeaderBag): Error {
+  const message = requestErrorMessage(status, body, headers);
+  if (status === 429) {
+    return new RateLimitError(message, retryAfterSeconds(parseRateLimitBody(body), headers));
+  }
+  return new Error(message);
+}
+
+/**
+ * #5634 sibling: a refresh that fails must only end the session when the server
+ * actually REJECTED the credentials. This used to clear the tokens on ANY
+ * non-ok status and on any network error, so a 429 — which is exactly what a
+ * rapid-retry storm produces, i.e. UAT row 92's own scenario — silently signed
+ * the customer out mid-checkout. So did a 503 during a rolling restart. Both are
+ * recoverable; only 401/403 mean "these credentials are no longer good".
+ */
+function isAuthRejection(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+function clearAuthTokens(): void {
+  localStorage.removeItem('org-token');
+  localStorage.removeItem('org-refresh-token');
+  notifyAuthChanged();
 }
 
 async function tryRefresh(): Promise<void> {
@@ -119,16 +170,13 @@ async function tryRefresh(): Promise<void> {
     if (res.ok) {
       const data = await res.json();
       setAuthTokens(data.token, data.refresh_token);
-    } else {
-      localStorage.removeItem('org-token');
-      localStorage.removeItem('org-refresh-token');
-      notifyAuthChanged();
+    } else if (isAuthRejection(res.status)) {
+      clearAuthTokens();
     }
+    // Any other status (429, 5xx) is transient: keep the session and let the
+    // caller surface the original failure so the customer can retry.
   } catch {
-    // Refresh failed — clear tokens.
-    localStorage.removeItem('org-token');
-    localStorage.removeItem('org-refresh-token');
-    notifyAuthChanged();
+    // Network error — transient by definition. Keep the session.
   }
 }
 
@@ -326,6 +374,12 @@ export type VoucherPreview = {
 // commit (the redeem itself commits at checkout). Returns null on unknown/invalid
 // (404) or non-redeemable/capped (410) codes — only a live, redeemable voucher's
 // credit should pre-apply. credit_omr is whole OMR; normalised to baisa per #85.
+//
+// #5634 sibling: a 429 is RE-THROWN rather than folded into that same null. This
+// path is behind the same burst limiter as /redeem, and the blanket catch made a
+// throttled preview indistinguishable from an invalid code — the cart silently
+// dropped the voucher's credit to zero with nothing said. Null still means "the
+// code does not apply"; a throw means "we could not find out right now".
 export const redeemVoucherPreview = async (code: string): Promise<VoucherPreview | null> => {
   try {
     const raw = await request<{
@@ -346,7 +400,8 @@ export const redeemVoucherPreview = async (code: string): Promise<VoucherPreview
       active: raw.active ?? false,
       accepting_redemptions: raw.accepting_redemptions ?? false,
     };
-  } catch {
+  } catch (e) {
+    if (e instanceof RateLimitError) throw e;
     return null;
   }
 };

--- a/core/marketplace/src/lib/rateLimitNotice.test.ts
+++ b/core/marketplace/src/lib/rateLimitNotice.test.ts
@@ -1,0 +1,279 @@
+// #5634 (UAT row 92) — the CHECKOUT half of the funnel's 429 handling, plus the
+// two siblings in `api.ts` that swallow the same response in other ways.
+//
+// `redeemPreview.test.ts` covers the /redeem landing. Nothing covered the
+// checkout submit path: `requestErrorMessage` was module-private and every
+// assertion went through `rateLimitMessage` directly, so deleting the 429 branch
+// in `api.ts` left the whole suite green. These tests drive the REAL exported
+// call sites (`createCheckout`, `redeemVoucherPreview`) through a mocked fetch,
+// so the wiring is what is under test, not a re-implementation of it.
+//
+// Every throttle assertion is paired with its negative. A guard that only proves
+// "429 shows the notice" is equally satisfied by relabelling every failure as a
+// rate limit, which would be a worse defect than the one being fixed.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createCheckout,
+  redeemVoucherPreview,
+  requestErrorMessage,
+  RateLimitError,
+} from './api';
+import {
+  DEFAULT_RETRY_AFTER_SEC,
+  retryAfterFromHeader,
+  retryAfterSeconds,
+} from './rateLimitNotice';
+
+// The body the billing service sends once #5634's server half is in
+// (`core/services/billing/handlers/handlers.go` — 5 checkouts per 60s per User).
+const BILLING_CHECKOUT_429 = JSON.stringify({
+  error: 'checkout rate-limit exceeded — please wait before retrying',
+  retry_after: 60,
+});
+
+// The body the gateway's global limiter sends (`core/services/gateway/ratelimit.go`).
+const GATEWAY_GLOBAL_429 = JSON.stringify({ error: 'rate limit exceeded', retry_after: 37 });
+
+function res(status: number, body: string, headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+/** Answer each successive fetch with the next queued response. */
+function mockFetch(...responses: Response[]): ReturnType<typeof vi.fn> {
+  const fn = vi.fn();
+  for (const r of responses) fn.mockResolvedValueOnce(r);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+const CHECKOUT_BODY = { plan_id: 'plan-m', tenant_id: 'org-1', apps: [], subdomain: 'acme' } as any;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('a throttled checkout submit tells the customer to wait', () => {
+  it('turns the billing 429 into the wait-and-retry notice, not a raw status blob', async () => {
+    mockFetch(res(429, BILLING_CHECKOUT_429, { 'Retry-After': '60' }));
+
+    await expect(createCheckout(CHECKOUT_BODY)).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it('renders what happened, how long to wait, and that nothing was charged', async () => {
+    mockFetch(res(429, BILLING_CHECKOUT_429, { 'Retry-After': '60' }));
+
+    const err = await createCheckout(CHECKOUT_BODY).catch(e => e as Error);
+    const msg = err.message;
+
+    expect(msg).toMatch(/submitted checkout several times in a few seconds/i);
+    expect(msg).toContain('Wait 60 seconds');
+    expect(msg).toMatch(/nothing has been charged/i);
+    // Not the pre-fix shape: a raw status code joined to a raw JSON blob.
+    expect(msg).not.toContain('429');
+    expect(msg).not.toContain('retry_after');
+    expect(msg).not.toContain('{');
+    // Copy rules: no apology, no vagueness.
+    expect(msg).not.toMatch(/sorry|apolog|something went wrong|oops/i);
+    expect(msg).not.toMatch(/NaN|undefined|null/);
+  });
+
+  it('carries the machine-readable window so a caller can act on it', async () => {
+    mockFetch(res(429, BILLING_CHECKOUT_429, { 'Retry-After': '60' }));
+    const err = (await createCheckout(CHECKOUT_BODY).catch(e => e)) as RateLimitError;
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.status).toBe(429);
+    expect(err.retryAfterSec).toBe(60);
+  });
+
+  it('honours a Retry-After header when the 429 carries NO body at all', async () => {
+    // What an intermediary (the Cilium/Envoy gateway, a CDN) answers with.
+    mockFetch(res(429, '', { 'Retry-After': '45' }));
+    const err = (await createCheckout(CHECKOUT_BODY).catch(e => e)) as Error;
+    expect(err.message).toContain('Wait 45 seconds');
+  });
+
+  it('never advises a shorter wait than the response asked for', async () => {
+    // Header and body disagree — taking the smaller one guarantees the retry
+    // re-trips the limiter, which is the harm this whole issue is about.
+    mockFetch(res(429, GATEWAY_GLOBAL_429, { 'Retry-After': '60' }));
+    const err = (await createCheckout(CHECKOUT_BODY).catch(e => e)) as Error;
+    expect(err.message).toContain('Wait 60 seconds');
+    expect(err.message).not.toContain('Wait 37 seconds');
+  });
+
+  it('still gives a usable wait when neither the header nor the body carries one', async () => {
+    mockFetch(res(429, JSON.stringify({ error: 'rate limit exceeded' })));
+    const err = (await createCheckout(CHECKOUT_BODY).catch(e => e)) as Error;
+    expect(err.message).toContain(`Wait ${DEFAULT_RETRY_AFTER_SEC} seconds`);
+    expect(err.message).not.toMatch(/NaN|undefined/);
+  });
+});
+
+describe('a genuine failure is NOT relabelled as a rate limit', () => {
+  it('keeps a 500 on the generic status shape', async () => {
+    mockFetch(res(500, JSON.stringify({ error: 'failed to look up customer' })));
+    const err = (await createCheckout(CHECKOUT_BODY).catch(e => e)) as Error;
+
+    expect(err).not.toBeInstanceOf(RateLimitError);
+    expect(err.message).toContain('500');
+    expect(err.message).not.toMatch(/several times in a few seconds|Wait \d+ second/i);
+  });
+
+  it('keeps a 503 on the generic status shape', async () => {
+    mockFetch(res(503, JSON.stringify({ error: 'payment processor not configured' })));
+    const err = (await createCheckout(CHECKOUT_BODY).catch(e => e)) as Error;
+    expect(err).not.toBeInstanceOf(RateLimitError);
+    expect(err.message).toContain('503');
+    expect(err.message).not.toMatch(/Wait \d+ second/i);
+  });
+
+  it('keeps the `409: ...` prefix CheckoutStep matches on for slug collisions', async () => {
+    // `CheckoutStep.svelte` retries a taken slug via `msg.startsWith('409')`.
+    // The 429 branch must not have disturbed that shape.
+    mockFetch(res(409, JSON.stringify({ error: 'slug is already taken' })));
+    const err = (await createCheckout(CHECKOUT_BODY).catch(e => e)) as Error;
+    expect(err.message.startsWith('409')).toBe(true);
+    expect(err.message).toContain('slug is already taken');
+  });
+
+  it('a healthy 200 throws nothing and shows no notice', async () => {
+    mockFetch(res(200, JSON.stringify({ order_id: 'ord-1', paid_by_credit: true })));
+    await expect(createCheckout(CHECKOUT_BODY)).resolves.toMatchObject({ order_id: 'ord-1' });
+  });
+});
+
+describe('a throttled voucher preview does not masquerade as an invalid code', () => {
+  it('rejects on 429 instead of silently contributing zero credit', async () => {
+    mockFetch(res(429, BILLING_CHECKOUT_429, { 'Retry-After': '60' }));
+    const err = (await redeemVoucherPreview('OMANI-WELCOME-25').catch(e => e)) as RateLimitError;
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.retryAfterSec).toBe(60);
+  });
+
+  it('still resolves to null on a genuinely unknown code', async () => {
+    // 404/410 mean "this code does not apply" — unchanged, and deliberately NOT
+    // an error, so the cart shows no alarm for a typo.
+    mockFetch(res(404, JSON.stringify({ error: 'voucher not found' })));
+    await expect(redeemVoucherPreview('NOPE')).resolves.toBeNull();
+  });
+
+  it('still resolves to null on a retired campaign', async () => {
+    mockFetch(res(410, JSON.stringify({ error: 'campaign ended' })));
+    await expect(redeemVoucherPreview('OLD')).resolves.toBeNull();
+  });
+});
+
+describe('a throttled token refresh does not end the session', () => {
+  const seedSession = () => {
+    localStorage.setItem('org-token', 'tok-old');
+    localStorage.setItem('org-refresh-token', 'refresh-old');
+  };
+
+  it('keeps the customer signed in when /auth/refresh is rate-limited', async () => {
+    seedSession();
+    // The original call 401s, so the funnel tries a refresh; the refresh itself
+    // is throttled — exactly what UAT row 92's rapid-retry burst produces.
+    mockFetch(res(401, JSON.stringify({ error: 'token expired' })), res(429, GATEWAY_GLOBAL_429));
+
+    await createCheckout(CHECKOUT_BODY).catch(() => undefined);
+
+    expect(localStorage.getItem('org-token')).toBe('tok-old');
+    expect(localStorage.getItem('org-refresh-token')).toBe('refresh-old');
+  });
+
+  it('keeps the customer signed in when /auth/refresh is briefly unavailable', async () => {
+    seedSession();
+    mockFetch(res(401, '{}'), res(503, JSON.stringify({ error: 'upstream unavailable' })));
+
+    await createCheckout(CHECKOUT_BODY).catch(() => undefined);
+
+    expect(localStorage.getItem('org-token')).toBe('tok-old');
+  });
+
+  it('STILL ends the session when the refresh credentials are actually rejected', async () => {
+    // The negative direction: this fix must not become "never sign anyone out".
+    seedSession();
+    mockFetch(res(401, '{}'), res(401, JSON.stringify({ error: 'invalid refresh token' })));
+
+    await createCheckout(CHECKOUT_BODY).catch(() => undefined);
+
+    expect(localStorage.getItem('org-token')).toBeNull();
+    expect(localStorage.getItem('org-refresh-token')).toBeNull();
+  });
+
+  it('STILL ends the session on a 403 refresh rejection', async () => {
+    seedSession();
+    mockFetch(res(401, '{}'), res(403, JSON.stringify({ error: 'refresh token revoked' })));
+
+    await createCheckout(CHECKOUT_BODY).catch(() => undefined);
+
+    expect(localStorage.getItem('org-token')).toBeNull();
+  });
+});
+
+describe('retryAfterFromHeader', () => {
+  const bag = (v: string | null) => ({ get: () => v });
+
+  it('reads delta-seconds', () => {
+    expect(retryAfterFromHeader(bag('60'))).toBe(60);
+    expect(retryAfterFromHeader(bag(' 45 '))).toBe(45);
+  });
+
+  it('reads an HTTP-date', () => {
+    const now = Date.parse('2026-08-06T07:00:00Z');
+    expect(retryAfterFromHeader(bag('Thu, 06 Aug 2026 07:00:30 GMT'), now)).toBe(30);
+  });
+
+  it('returns null when absent, empty, past, or nonsense', () => {
+    const now = Date.parse('2026-08-06T07:00:00Z');
+    expect(retryAfterFromHeader(undefined)).toBeNull();
+    expect(retryAfterFromHeader(bag(null))).toBeNull();
+    expect(retryAfterFromHeader(bag(''))).toBeNull();
+    expect(retryAfterFromHeader(bag('0'))).toBeNull();
+    expect(retryAfterFromHeader(bag('-5'))).toBeNull();
+    expect(retryAfterFromHeader(bag('soon'))).toBeNull();
+    // Already elapsed — no wait to advise.
+    expect(retryAfterFromHeader(bag('Thu, 06 Aug 2026 06:59:00 GMT'), now)).toBeNull();
+  });
+});
+
+describe('retryAfterSeconds combines both carriers', () => {
+  const bag = (v: string | null) => ({ get: () => v });
+
+  it('uses the header when the body has none', () => {
+    expect(retryAfterSeconds({}, bag('30'))).toBe(30);
+  });
+
+  it('uses the body when there is no header', () => {
+    expect(retryAfterSeconds({ retry_after: 30 })).toBe(30);
+    expect(retryAfterSeconds({ retry_after: 30 }, bag(null))).toBe(30);
+  });
+
+  it('takes the larger when both are present', () => {
+    expect(retryAfterSeconds({ retry_after: 10 }, bag('60'))).toBe(60);
+    expect(retryAfterSeconds({ retry_after: 60 }, bag('10'))).toBe(60);
+  });
+
+  it('falls back only when neither carrier is usable', () => {
+    expect(retryAfterSeconds(null, bag('nope'))).toBe(DEFAULT_RETRY_AFTER_SEC);
+    expect(retryAfterSeconds({ retry_after: 'soon' })).toBe(DEFAULT_RETRY_AFTER_SEC);
+  });
+});
+
+describe('requestErrorMessage', () => {
+  it('maps 429 to the notice and everything else to the status shape', () => {
+    expect(requestErrorMessage(429, BILLING_CHECKOUT_429)).toContain('Wait 60 seconds');
+    expect(requestErrorMessage(500, 'boom')).toBe('500: boom');
+    expect(requestErrorMessage(409, 'slug is already taken')).toBe('409: slug is already taken');
+  });
+});

--- a/core/marketplace/src/lib/rateLimitNotice.ts
+++ b/core/marketplace/src/lib/rateLimitNotice.ts
@@ -14,8 +14,9 @@
 // voucher was invalid. These helpers keep the server's own retry window and turn
 // it into a notice that names what happened and how long to wait.
 
-/** Fallback wait when the server sends no usable `retry_after` — matches the
- *  gateway's own `redeemWindowSec` default. */
+/** Fallback wait when the response carries no usable window at all — matches the
+ *  gateway's own `redeemWindowSec` default. Only ever used when BOTH the
+ *  `Retry-After` header and the body's `retry_after` are absent or unusable. */
 export const DEFAULT_RETRY_AFTER_SEC = 10;
 
 /** The subject of the throttled submit, so the notice can name the right thing. */
@@ -23,16 +24,58 @@ export type RateLimitSubject = 'redeem' | 'checkout';
 
 type RateLimitBody = { error?: unknown; retry_after?: unknown };
 
-/**
- * Read the server's retry window. Tolerates the field being absent, a string, or
- * nonsense — a customer-facing wait must never render as `NaN` or `undefined`.
- * Fractional windows round up so we never advise a wait shorter than the server's.
- */
-export function retryAfterSeconds(body: unknown): number {
-  const raw = (body as RateLimitBody | null | undefined)?.retry_after;
+/** Just enough of `Headers` to read one field — so callers can hand us a real
+ *  `Response.headers`, a plain `new Headers({...})`, or nothing at all. */
+export type HeaderBag = { get(name: string): string | null } | null | undefined;
+
+/** Parse one candidate window. Returns null when it is absent or unusable. */
+function usableSeconds(raw: unknown): number | null {
   const seconds = typeof raw === 'number' ? raw : Number(raw);
-  if (!Number.isFinite(seconds) || seconds <= 0) return DEFAULT_RETRY_AFTER_SEC;
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
   return Math.ceil(seconds);
+}
+
+/**
+ * Read the standard `Retry-After` response header (RFC 9110 §10.2.3).
+ *
+ * Our own services put the window in the JSON body, but a 429 does not always
+ * come from our own services — the Cilium/Envoy gateway in front of them, or any
+ * CDN, answers with the header and frequently with no JSON body at all. Reading
+ * only the body meant those responses fell back to the 10s default no matter how
+ * long the real window was.
+ *
+ * Both wire forms are accepted: delta-seconds (`Retry-After: 60`) and an
+ * HTTP-date (`Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`).
+ */
+export function retryAfterFromHeader(headers: HeaderBag, now: number = Date.now()): number | null {
+  const raw = headers?.get('Retry-After');
+  if (raw == null) return null;
+  const trimmed = String(raw).trim();
+  if (trimmed === '') return null;
+  const delta = usableSeconds(trimmed);
+  if (delta !== null) return delta;
+  const at = Date.parse(trimmed);
+  if (!Number.isFinite(at)) return null;
+  return usableSeconds((at - now) / 1000);
+}
+
+/**
+ * Read the server's retry window from the response.
+ *
+ * When the header and the body both carry a window we take the LARGER of the
+ * two. Advising a shorter wait than the server actually enforces is the specific
+ * harm here: the customer retries too early, re-trips the limiter, and the
+ * throttling gets worse. Overshooting costs a few seconds and nothing else.
+ *
+ * Tolerates every field being absent, a string, or nonsense — a customer-facing
+ * wait must never render as `NaN` or `undefined`. Fractional windows round up.
+ */
+export function retryAfterSeconds(body: unknown, headers?: HeaderBag): number {
+  const fromBody = usableSeconds((body as RateLimitBody | null | undefined)?.retry_after);
+  const fromHeader = retryAfterFromHeader(headers);
+  const candidates = [fromBody, fromHeader].filter((n): n is number => n !== null);
+  if (candidates.length === 0) return DEFAULT_RETRY_AFTER_SEC;
+  return Math.max(...candidates);
 }
 
 /**
@@ -41,8 +84,8 @@ export function retryAfterSeconds(body: unknown): number {
  * code. For the redeem path it also says the code itself is still good, because
  * the defect this fixes told throttled customers their voucher was invalid.
  */
-export function rateLimitMessage(body: unknown, subject: RateLimitSubject): string {
-  const seconds = retryAfterSeconds(body);
+export function rateLimitMessage(body: unknown, subject: RateLimitSubject, headers?: HeaderBag): string {
+  const seconds = retryAfterSeconds(body, headers);
   const wait = seconds === 1 ? '1 second' : `${seconds} seconds`;
   if (subject === 'redeem') {
     return `You have submitted this voucher several times in a few seconds. `

--- a/core/marketplace/src/lib/redeemPreview.test.ts
+++ b/core/marketplace/src/lib/redeemPreview.test.ts
@@ -62,8 +62,8 @@ function notValidText(): string {
 }
 
 /** Drive the page's decision the way `validate()` does: classify, then apply. */
-function submit(status: number, body: unknown): RedeemPanelId {
-  const outcome = classifyRedeemPreview(status, body);
+function submit(status: number, body: unknown, headers?: Headers): RedeemPanelId {
+  const outcome = classifyRedeemPreview(status, body, headers);
   applyRedeemOutcome(document, outcome);
   return outcome.panel;
 }
@@ -115,6 +115,27 @@ describe('a rate-limited redeem submit IS surfaced', () => {
   it('still renders a usable wait when the 429 carries no body at all', () => {
     expect(submit(429, null)).toBe('redeem-throttled');
     expect(throttleText()).toContain(`Wait ${DEFAULT_RETRY_AFTER_SEC} seconds`);
+  });
+
+  // #5634 second pass: the gateway/CDN answers some 429s itself, with the
+  // standard `Retry-After` header and no JSON body. Reading only the body meant
+  // those fell back to the 10s default however long the real window was.
+  it('takes the wait from the Retry-After header when the body has none', () => {
+    expect(submit(429, null, new Headers({ 'Retry-After': '45' }))).toBe('redeem-throttled');
+    expect(throttleText()).toContain('Wait 45 seconds');
+  });
+
+  it('never advises a shorter wait than the response asked for', () => {
+    submit(429, GATEWAY_REDEEM_429, new Headers({ 'Retry-After': '60' }));
+    expect(throttleText()).toContain('Wait 60 seconds');
+    expect(throttleText()).not.toContain('Wait 10 seconds');
+  });
+
+  it('ignores an absent or unusable Retry-After and keeps the body window', () => {
+    submit(429, GATEWAY_REDEEM_429, new Headers());
+    expect(throttleText()).toContain('Wait 10 seconds');
+    submit(429, GATEWAY_REDEEM_429, new Headers({ 'Retry-After': 'soon' }));
+    expect(throttleText()).toContain('Wait 10 seconds');
   });
 });
 

--- a/core/marketplace/src/lib/redeemPreview.ts
+++ b/core/marketplace/src/lib/redeemPreview.ts
@@ -7,7 +7,7 @@
 // the "Voucher not valid" panel. A rate-limited customer was therefore told their
 // code was bad. 429 now gets its own panel and carries the server's retry window.
 
-import { rateLimitMessage } from './rateLimitNotice';
+import { rateLimitMessage, type HeaderBag } from './rateLimitNotice';
 
 export const REDEEM_PANELS = [
   'redeem-loading',
@@ -37,15 +37,17 @@ export type RedeemOutcome =
 /**
  * Map a redeem-preview response onto the panel the customer should see.
  * `status` is the HTTP status; `body` is the parsed JSON body, or null when the
- * response carried none.
+ * response carried none; `headers` is the response's own header bag, which is
+ * where an intermediary (the Cilium/Envoy gateway, a CDN) puts its retry window
+ * when it answers the 429 itself and sends no JSON at all.
  */
-export function classifyRedeemPreview(status: number, body: unknown): RedeemOutcome {
+export function classifyRedeemPreview(status: number, body: unknown, headers?: HeaderBag): RedeemOutcome {
   if (status === 404) return { panel: 'redeem-not-valid', detail: NOT_VALID_DEFAULT_DETAIL };
   if (status === 410) return { panel: 'redeem-ended' };
   // #5634: 429 is answered by the gateway limiter, not by the voucher store —
   // it says nothing about whether the code is valid, so it must not reach the
   // "Voucher not valid" panel.
-  if (status === 429) return { panel: 'redeem-throttled', detail: rateLimitMessage(body, 'redeem') };
+  if (status === 429) return { panel: 'redeem-throttled', detail: rateLimitMessage(body, 'redeem', headers) };
   // Everything else non-2xx keeps the previous generic treatment (`!res.ok`).
   if (status < 200 || status >= 300) {
     return { panel: 'redeem-not-valid', detail: GENERIC_VALIDATE_DETAIL };

--- a/core/marketplace/src/pages/redeem.astro
+++ b/core/marketplace/src/pages/redeem.astro
@@ -180,7 +180,9 @@ import Layout from '../layouts/Layout.astro';
         let body: any = null;
         try { body = await res.json(); } catch { body = null; }
 
-        const outcome = classifyRedeemPreview(res.status, body);
+        // Headers go in too: a 429 raised by the gateway itself carries its
+        // window in the standard `Retry-After` header and no JSON body.
+        const outcome = classifyRedeemPreview(res.status, body, res.headers);
 
         if (outcome.panel === 'redeem-ended') {
           // Campaign ended — body still has credit + description.

--- a/core/services/billing/handlers/checkout_test.go
+++ b/core/services/billing/handlers/checkout_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -422,21 +423,100 @@ func TestCheckoutRateLimiter_2941(t *testing.T) {
 		window:  60 * time.Second,
 	}
 	for i := 0; i < 5; i++ {
-		if !rl.Allow("user-A") {
+		allowed, retryAfter := rl.Allow("user-A")
+		if !allowed {
 			t.Fatalf("request %d for user-A should be allowed (under cap)", i+1)
+		}
+		// #5634: an ALLOWED request must not advertise a wait. A limiter that
+		// always hands back a window would satisfy the throttle assertions below
+		// while telling every healthy customer to go away and come back.
+		if retryAfter != 0 {
+			t.Errorf("request %d for user-A allowed but advertised retryAfter=%d, want 0", i+1, retryAfter)
 		}
 	}
 	// 6th request must be rejected.
-	if rl.Allow("user-A") {
+	allowed, retryAfter := rl.Allow("user-A")
+	if allowed {
 		t.Errorf("6th request for user-A should be REJECTED (over cap)")
 	}
+	// #5634: and it must say how long to wait, within the real 60s window. The
+	// marketplace renders this verbatim as "Wait N seconds"; when the handler
+	// sent nothing the funnel guessed 10s into a 60s window, so the customer's
+	// retry re-tripped this same limiter.
+	if retryAfter < 55 || retryAfter > 60 {
+		t.Errorf("rejected request should report the remaining 60s window, got retryAfter=%d", retryAfter)
+	}
 	// Different user — independent bucket, should pass.
-	if !rl.Allow("user-B") {
+	if allowed, _ := rl.Allow("user-B"); !allowed {
 		t.Errorf("user-B should be allowed (independent bucket)")
 	}
 	// Empty userID — should pass (auth middleware handles 401).
-	if !rl.Allow("") {
+	if allowed, _ := rl.Allow(""); !allowed {
 		t.Errorf("empty userID should pass through (handled by auth layer)")
+	}
+}
+
+// TestCheckout_RateLimited429_CarriesRetryWindow_5634 is the wire-level half of
+// the #5634 (UAT row 92) guard: the throttled checkout response must carry its
+// retry window in BOTH places a caller looks — the standard `Retry-After` header
+// and the JSON body's `retry_after` — because `core/marketplace` renders it as
+// the "wait N seconds" notice the customer acts on.
+//
+// Pre-fix this handler answered `respond.Error(...)`, i.e. `{"error": "..."}`
+// with no window and no header, so the funnel fell back to its 10s default
+// against a 60s window.
+func TestCheckout_RateLimited429_CarriesRetryWindow_5634(t *testing.T) {
+	const userID = "user-5634-throttled"
+
+	// Drive the limiter straight into its rejected state so the handler
+	// short-circuits before any store access.
+	globalCheckoutRateLimiter.mu.Lock()
+	globalCheckoutRateLimiter.buckets[userID] = &checkoutBucket{count: 99, windowStart: time.Now()}
+	globalCheckoutRateLimiter.mu.Unlock()
+	t.Cleanup(func() {
+		globalCheckoutRateLimiter.mu.Lock()
+		delete(globalCheckoutRateLimiter.buckets, userID)
+		globalCheckoutRateLimiter.mu.Unlock()
+	})
+
+	h := &Handler{}
+	body, _ := json.Marshal(checkoutRequest{PlanID: "plan-starter", TenantID: "tenant-5634"})
+	req := httptest.NewRequest(http.MethodPost, "/billing/checkout", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withCustomerClaims(req, userID, "walk@t99.omani.works")
+
+	rec := httptest.NewRecorder()
+	h.Checkout(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		raw, _ := io.ReadAll(rec.Body)
+		t.Fatalf("want 429, got %d (body=%s)", rec.Code, string(raw))
+	}
+
+	hdr := rec.Header().Get("Retry-After")
+	if hdr == "" {
+		t.Fatalf("429 carries no Retry-After header — an intermediary-agnostic client has no window to show")
+	}
+	hdrSec, err := strconv.Atoi(hdr)
+	if err != nil {
+		t.Fatalf("Retry-After header %q is not delta-seconds: %v", hdr, err)
+	}
+	if hdrSec < 1 || hdrSec > 60 {
+		t.Errorf("Retry-After=%d outside the limiter's 60s window", hdrSec)
+	}
+
+	var payload struct {
+		Error      string `json:"error"`
+		RetryAfter int    `json:"retry_after"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("429 body is not JSON: %v", err)
+	}
+	if payload.RetryAfter != hdrSec {
+		t.Errorf("body retry_after=%d disagrees with Retry-After header=%d", payload.RetryAfter, hdrSec)
+	}
+	if payload.Error == "" {
+		t.Errorf("429 body carries no error message")
 	}
 }
 

--- a/core/services/billing/handlers/handlers.go
+++ b/core/services/billing/handlers/handlers.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -58,11 +60,18 @@ var globalCheckoutRateLimiter = &checkoutRateLimiter{
 	window:  60 * time.Second,
 }
 
-// Allow returns true when the userID is within the budget. Should be
-// called once per checkout request. Concurrent-safe.
-func (rl *checkoutRateLimiter) Allow(userID string) bool {
+// Allow returns whether the userID is within the budget, and — when it is NOT —
+// how many whole seconds remain before the window rolls over.
+//
+// #5634 (UAT row 92): the retry window is returned rather than kept private
+// because the funnel has to TELL the customer how long to wait. Before this the
+// handler answered 429 with no window at all, the marketplace fell back to its
+// 10s default, and the customer was advised to retry ~50s early into a 60s
+// window — which re-trips this very limiter and makes the throttling worse.
+// Should be called once per checkout request. Concurrent-safe.
+func (rl *checkoutRateLimiter) Allow(userID string) (bool, int) {
 	if userID == "" {
-		return true // unauth requests get blocked elsewhere (401)
+		return true, 0 // unauth requests get blocked elsewhere (401)
 	}
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
@@ -70,10 +79,19 @@ func (rl *checkoutRateLimiter) Allow(userID string) bool {
 	b, ok := rl.buckets[userID]
 	if !ok || now.Sub(b.windowStart) > rl.window {
 		rl.buckets[userID] = &checkoutBucket{count: 1, windowStart: now}
-		return true
+		return true, 0
 	}
 	b.count++
-	return b.count <= rl.max
+	if b.count <= rl.max {
+		return true, 0
+	}
+	// Round UP the remaining window: advising a shorter wait than the limiter
+	// enforces guarantees the next attempt is rejected too.
+	remaining := int(math.Ceil((rl.window - now.Sub(b.windowStart)).Seconds()))
+	if remaining < 1 {
+		remaining = 1
+	}
+	return false, remaining
 }
 
 // Handler holds dependencies for billing HTTP handlers.
@@ -196,9 +214,18 @@ func (h *Handler) Checkout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// #2941 (2026-06-03): per-customer rate-limit (5 req/60s).
-	if !globalCheckoutRateLimiter.Allow(userID) {
-		slog.Warn("checkout: rate-limit exceeded", "userID", userID)
-		respond.Error(w, http.StatusTooManyRequests, "checkout rate-limit exceeded — please wait before retrying")
+	// #5634 (UAT row 92): answer with the retry window in BOTH places a caller
+	// may look — the standard `Retry-After` header (RFC 9110 §10.2.3, which is
+	// also what any intermediary in front of us would send) and the JSON body,
+	// matching the gateway limiter's `retry_after` shape. The marketplace funnel
+	// renders it as "wait N seconds"; with no window it guessed, and guessed low.
+	if allowed, retryAfter := globalCheckoutRateLimiter.Allow(userID); !allowed {
+		slog.Warn("checkout: rate-limit exceeded", "userID", userID, "retryAfter", retryAfter)
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		respond.JSON(w, http.StatusTooManyRequests, map[string]any{
+			"error":       "checkout rate-limit exceeded — please wait before retrying",
+			"retry_after": retryAfter,
+		})
 		return
 	}
 

--- a/core/services/gateway/ratelimit.go
+++ b/core/services/gateway/ratelimit.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,6 +68,12 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 
 		if int(count) > rl.rpm {
 			retryAfter := 60 - now.Second()
+			if retryAfter < 1 {
+				retryAfter = 1
+			}
+			// #5634: the standard header too, not only the body — it is what an
+			// intermediary would send and what a generic client reads.
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			respond.JSON(w, http.StatusTooManyRequests, map[string]any{
 				"error":       "rate limit exceeded",
 				"retry_after": retryAfter,
@@ -92,6 +99,7 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 					rl.client.Do(ctx, rl.client.B().Expire().Key(rkey).Seconds(int64(win)).Build())
 				}
 				if int(rcount) > rl.redeemLimit {
+					w.Header().Set("Retry-After", strconv.Itoa(win))
 					respond.JSON(w, http.StatusTooManyRequests, map[string]any{
 						"error":       "too many redeem attempts — please wait a few seconds and try again",
 						"retry_after": win,


### PR DESCRIPTION
## What this is

The residual half of #5634 (UAT row 92). PR #5636 stopped the `/redeem` landing
telling a throttled customer their voucher was invalid — that part is correct and
untouched here. What #5636 did not close is the **retry window**: the number the
customer actually acts on. Three paths still got it wrong or lost it entirely.

Verified against all four front-end trees. `core/console/src`,
`products/catalyst/console/src` and `products/catalyst/bootstrap/ui/src` contain
zero `vouchers/redeem` or `billing/checkout` call sites; every one is in
`core/marketplace/` (the funnel storefront), as #5634 states.

## Where the window was lost

**1. `core/services/billing/handlers/handlers.go:201` — a second 429 producer the
issue never examined.** #5634 says "Server (correct — no change needed)", and that
is true of `core/services/gateway/ratelimit.go`. But the billing service runs its
own per-User checkout limiter (5 requests / 60s, #2941) on the same submit path,
and it answered with `respond.Error(...)` — `{"error": "..."}`, no `retry_after`,
no header. The funnel therefore fell back to `DEFAULT_RETRY_AFTER_SEC = 10`
against a **60-second** window and told the customer:

> Wait 10 seconds, then try again — nothing has been charged.

The customer waits 10s, retries, and re-trips the same limiter. That is the exact
harm the issue is about, produced by the fix meant to prevent it. It now answers
with `retry_after` **and** the standard `Retry-After` header; `Allow` returns the
remaining window, rounded up so we never advise short.

**2. The funnel read only the JSON body.** `retryAfterSeconds` looked at
`body.retry_after` and nothing else. A 429 raised by the Cilium/Envoy gateway
itself, or any CDN, carries its window in the `Retry-After` header and frequently
no JSON body at all — every one of those rendered the 10s default no matter how
long the real window was. Both carriers are read now (delta-seconds and HTTP-date),
taking the **larger** when both are present, because overshooting costs seconds and
undershooting re-trips the limiter. `core/services/gateway/ratelimit.go` now sends
the header alongside its body at both 429 sites.

## Siblings swallowing the same response

Asked deliberately rather than stumbled into. Two more, both in
`core/marketplace/src/lib/api.ts`, both shipped here because they are the same
defect one layer down and are small:

- **`tryRefresh` ended the session on any non-ok status.** A 429 on `/auth/refresh`
  — which is precisely what row 92's rapid-retry burst produces — cleared the auth
  tokens and silently signed the customer out mid-checkout. So did a 503 during a
  rolling restart. Only 401/403 mean the credentials are actually rejected; those
  still clear.
- **`redeemVoucherPreview` folded a throttle into the same `null` it uses for an
  unknown code.** The cart's `.catch(() => 0)` then dropped the voucher credit to
  zero with nothing said — a money-visible change the customer cannot explain. A
  429 now rejects (`RateLimitError`) and surfaces through the existing
  `creditError` panel; 404/410 still resolve `null`, so a typo raises no alarm.

**Deliberately not changed:** the generic `<status>: <body>` message shape for
every non-429 status. `CheckoutStep.svelte:326` matches on it
(`msg.startsWith('409')`) to retry a taken slug, so that shape is load-bearing.
Rewriting the whole error taxonomy is a separate job, not a side effect of this one.

## Copy

Old, on a throttled checkout — the raw status joined to the raw body:

```
429: {"error":"checkout rate-limit exceeded — please wait before retrying"}
```

New:

> You have submitted checkout several times in a few seconds. Wait 60 seconds,
> then try again — nothing has been charged.

Says what happened and what to do, active voice, no apology, no status code, and
the number is now the server's real window instead of a guess. Checked against
`docs/GLOSSARY.md` §Banned-terms; `scripts/check-no-banned-words.sh` returns
`OK: no banned-word violations`.

## Guard — vacuity-checked in both directions

New `core/marketplace/src/lib/rateLimitNotice.test.ts` drives the **real** exported
call sites (`createCheckout`, `redeemVoucherPreview`) through a mocked fetch, so
the wiring is what is under test. Plus a wire-level Go test on the billing handler.

`npx vitest run` on this branch — 47/47:

```
 Test Files  3 passed (3)
      Tests  47 passed (47)
```

Same tests with the three client source files reverted to `origin/main` — 17 fail,
and they fail on **values**, not missing imports:

```
 FAIL > keeps the customer signed in when /auth/refresh is rate-limited
 AssertionError: expected null to be 'tok-old'
 FAIL > uses the header when the body has none
 AssertionError: expected 10 to be 30
 FAIL > takes the larger when both are present
 AssertionError: expected 10 to be 60
 FAIL > takes the wait from the Retry-After header when the body has none
 AssertionError: expected 'You have submitted this voucher sever…' to contain 'Wait 45 seconds'
 Test Files  2 failed | 1 passed (3)
      Tests  17 failed | 30 passed (47)
```

Go, with only the pre-fix 429 write restored (new `Allow` signature kept, so the
failure is behavioural rather than a compile error):

```
=== RUN   TestCheckout_RateLimited429_CarriesRetryWindow_5634
    checkout_test.go:498: 429 carries no Retry-After header — an intermediary-agnostic client has no window to show
--- FAIL: TestCheckout_RateLimited429_CarriesRetryWindow_5634 (0.00s)
```

Restored:

```
--- PASS: TestCheckoutRateLimiter_2941 (0.00s)
--- PASS: TestCheckout_RateLimited429_CarriesRetryWindow_5634 (0.00s)
```

**The negatives pass in BOTH directions**, which is what stops this being a blanket
relabel: 500 and 503 keep the generic shape, `409: …` keeps its prefix, a healthy
200 resolves, 404/410 still resolve `null`, 401/403 still end the session, and an
allowed request advertises no wait at all.

## Gates

```
core/marketplace   npx vitest run          47 passed (47)
core/marketplace   npm run build           11 page(s) built; [domain-hygiene] OK — 37 served file(s) scanned
core/services/billing   go build ./...     clean
core/services/billing   go vet ./...       clean
core/services/billing   go test ./...      ok handlers 0.028s, ok store 0.004s
core/services/gateway   go build/vet/test  ok 0.003s
scripts/check-no-banned-words.sh           OK: no banned-word violations
```

`astro check` is not a gate this package defines (`build` / `test` / `test:e2e`)
and wants an uninstalled `@astrojs/check`; not run.

## Not closing #5634

Merge is not delivery. The falsifiable assertion for UAT row 92 stays open:
drive the live funnel into a 429 — rapid re-submit past 5 in a few seconds, on
both `/redeem` and checkout — and read the rendered copy. It must name the wait
the server actually enforces (60s from the billing limiter, not 10s), and a single
legitimate redeem must stay unaffected. Repo changes only here; no live cluster
was touched.

Refs #5634
