### PR TITLE
fix(catalyst-api): serve per-Org app hosts from every region via ClusterMesh stubs (#5635)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1322,7 +1322,7 @@ spec:
       #   create-side reconcile; deleted Orgs converge to fully-deleted in
       #   every region.
       #   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
-      version: 1.4.1311
+      version: 1.4.1312
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh.go
@@ -1,0 +1,449 @@
+// org_app_surface_mesh.go — #5635, the APP half of the per-Org two-region
+// gateway surface. The console half shipped in PR #5647; this file closes the
+// remainder the issue explicitly left open.
+//
+// THE MEASUREMENT that defines the gap. hw292 (dep 1c56518035a83e03, 2 regions,
+// cutoverComplete=true), 20 FRESH TCP connections to a funnel Org's purchased
+// app FQDN — separate `curl --no-keepalive` invocations, because HTTP/2
+// connection pinning makes a browser loop or a keepalive curl report 100%
+// success against a round-robin (#5459):
+//
+//	https://wordpress.uatco.omani.homes/   ok=9  fail=11  of 20
+//	  ok   -> HTTP 302 (into the WordPress installer), ssl_verify_result=0
+//	  fail -> curl exit 35, TLS handshake reset, no HTTP status at all
+//	https://console.hw292.omani.works/     ok=10 fail=0   of 10   (control)
+//
+// Both hosts resolve to the SAME shared EIP 212.72.24.85, which round-robins
+// both regions' cilium-envoy. The control is the decisive part: the VIP is
+// fine. What differs is whether the region the connection landed on can serve
+// the Host header.
+//
+// FAILURE LAYER, established rather than inferred. A gateway with a listener
+// but no healthy upstream answers HTTP 503. A TLS handshake RESET means envoy
+// matched no listener for that SNI at all. Enumerating both regions'
+// cilium-gateway-console:
+//
+//	region-a  console-https-uatco / console-http-uatco   hostname *.uatco.omani.homes
+//	region-b  (no listener for *.uatco.omani.homes)
+//
+// and one layer up, namespace `uatco` does not exist in region-b at all (the
+// per-Org Flux loop — GitRepository catalyst-tenant-<slug> plus its three
+// Kustomizations — is created by the org-controller through its own
+// single-cluster client, so region-b has neither the source nor the tree).
+//
+// WHY THIS IS NOT #5359 (the root cause previously recorded on the issue).
+// #5359 is about region-b's Flux still pulling from an external source. The
+// per-Org listener is NOT a GitOps artifact: `console-https-<slug>` exists
+// only in Go — this package's ensureOrgConsoleListener and the org-controller's
+// reconcileTenantConsoleTLS — and appears in no kustomize tree under
+// clusters/. Repairing region-b's GitRepository therefore cannot produce it,
+// and the recorded falsifiable prediction ("fixing #5359 resolves this with no
+// gateway or placement change") is refuted by that alone. Region-b's Flux is
+// separately unhealthy — `openova` GitRepository Ready=False, GitOperationFailed
+// `pkt-line 3: EOF` against the local Gitea, generation 2 / observedGeneration
+// 1 — which is a real defect and is exactly why NO GitOps-delivered fix can
+// land in region-b today either. The only process that can write to a secondary
+// region is catalyst-api, which is where the console half went and where this
+// half goes.
+//
+// THE IDIOM — not invented here; copied from the platform surface that already
+// works on this very cluster. bp-catalyst-platform 1.4.1190 annotates the
+// region-a control-plane Services `service.cilium.io/global: "true"` +
+// `.../shared: "true"`, and bp-catalyst-edge-routes (bootstrap-kit slot 13b)
+// renders into region-b the SAME-name+namespace Services with ZERO local
+// backends plus mirrored HTTPRoutes, so Cilium ClusterMesh merges the pair and
+// region-b's envoy PROXIES to region-a's singleton instead of 404-ing (#5289).
+// That is why every `*.hw292.omani.works` host is a 10/10 control above. The
+// same shape backs bp-openbao's cross-region-mesh-service.yaml and
+// bp-cnpg-pair's replica-mesh-service.yaml.
+//
+// A static chart cannot cover the per-Org surface: Orgs and their purchased
+// apps are created at runtime, so the host set is not knowable at render time.
+// This file is therefore the runtime emitter of exactly what slot 13b renders
+// statically — same annotations, same zero-backend stub, same route mirror —
+// driven from the Organization CRs on the #5635 ticker so it is creation-path
+// independent and self-healing for Orgs that already exist.
+//
+// WHAT IT DOES, per Org, per pass:
+//
+//	host region      — every Service backing a per-Org app HTTPRoute is
+//	                   EXPORTED to the mesh (global+shared annotations added
+//	                   if absent; the Service itself is left otherwise
+//	                   untouched, including its selector and ports).
+//	secondary region — the org boundary Namespace, a zero-backend global
+//	                   Service STUB per backend (same name+namespace+ports+
+//	                   selector, matching no local Pod because no workload
+//	                   runs there), and a mirror of each app HTTPRoute.
+//
+// SINGLE-REGION IS A NO-OP. With no secondary registered in h.k8sCache the
+// function returns before it reads anything, so a single-region Sovereign
+// issues zero additional API calls and its object graph is byte-identical.
+//
+// SAFETY. Only positively-identified per-Org app objects are candidates:
+// the route must live in the Org's OWN boundary namespace `<slug>` and EVERY
+// one of its hostnames must sit inside that Org's own zone `<slug>.<parent>`.
+// A route with no hostnames, a hostname outside the zone, or the console host
+// (which lives in catalyst-system and is owned by the console half) is skipped.
+// Every write is create-if-absent or an additive annotation patch; nothing is
+// deleted and no existing spec is overwritten.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// Cilium ClusterMesh global-service annotations. Byte-identical to the pair
+// bp-catalyst-platform 1.4.1190 puts on the region-a control-plane Services and
+// bp-catalyst-edge-routes puts on the region-b stubs — the merge is keyed on
+// name+namespace, so both sides must agree.
+const (
+	ciliumGlobalServiceAnnotation = "service.cilium.io/global"
+	ciliumSharedServiceAnnotation = "service.cilium.io/shared"
+)
+
+// orgAppSurfaceComponent labels every object this emitter writes, so an
+// operator (and any future reaper) can tell the projection apart from the
+// GitOps-delivered original in the host region.
+const orgAppSurfaceComponent = "org-app-crossregion"
+
+// orgAppSurfaceServicesGVR is the core/v1 Service resource, addressed through
+// the dynamic client for the same reason namespacesGVR is (every seam in this
+// package already holds a dynamic.Interface).
+func orgAppSurfaceServicesGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+}
+
+// reconcileOrgAppSurfaceAcrossRegions projects one Org's per-Org APP gateway
+// surface from the host region into every secondary region, and exports the
+// host region's backing Services to the ClusterMesh so the projection resolves.
+//
+// Best-effort and non-gating throughout, matching provisionOrgConsoleTLS: a
+// failure is logged with the region that failed and the next ticker pass
+// retries. Never returns an error — the caller is a reconcile loop over every
+// Org and one bad Org must not starve the rest.
+func (h *Handler) reconcileOrgAppSurfaceAcrossRegions(ctx context.Context, deps *sovereignDeps, rec store.OrganizationProvisionRecord) {
+	if h == nil || deps == nil || deps.dyn == nil {
+		return
+	}
+	names, ok := resolveOrgConsoleTLSNames(rec)
+	if !ok {
+		return
+	}
+
+	targets := h.orgConsoleTLSTargets(deps)
+	if len(targets) < 2 {
+		// Single-region Sovereign (or a mothership, where orgConsoleTLSTargets
+		// deliberately refuses to fan out). Nothing to mirror and nothing to
+		// export — return before any read so the single-region object graph and
+		// API-call profile are unchanged.
+		return
+	}
+	host := targets[0]
+
+	routes := listOrgAppRoutes(ctx, host.dyn, names)
+	if len(routes) == 0 {
+		// No purchased app has a host-native route yet. The console half still
+		// gives this Org a working console in every region; app hosts simply do
+		// not exist yet.
+		return
+	}
+
+	// ── host region: export every backing Service to the mesh ──────────────
+	backends := orgAppRouteBackends(routes, names.Slug)
+	exported := make([]*unstructured.Unstructured, 0, len(backends))
+	for _, svcName := range backends {
+		svc, err := ensureOrgAppServiceExported(ctx, host.dyn, names.Slug, svcName)
+		if err != nil {
+			h.log.Error("org-app-surface: could not export the per-Org app Service to the ClusterMesh — the secondary region's stub cannot resolve until this succeeds (#5635)",
+				"org_tenant_id", rec.OrganizationID,
+				"namespace", names.Slug, "service", svcName, "err", err)
+			continue
+		}
+		exported = append(exported, svc)
+	}
+	if len(exported) == 0 {
+		return
+	}
+
+	// ── every secondary region: namespace + zero-backend stubs + routes ────
+	for _, tgt := range targets[1:] {
+		if err := ensureOrgBoundaryNamespaceForApps(ctx, tgt.dyn, names, rec); err != nil {
+			h.log.Error("org-app-surface: could not ensure the Org boundary namespace in a secondary region — its per-Org app hosts stay unserved there (#5635)",
+				"org_tenant_id", rec.OrganizationID,
+				"region", tgt.region, "clusterID", tgt.clusterID,
+				"namespace", names.Slug, "err", err)
+			continue
+		}
+		for _, svc := range exported {
+			if err := ensureOrgAppMeshStub(ctx, tgt.dyn, names, rec, svc); err != nil {
+				h.log.Error("org-app-surface: could not ensure the ClusterMesh Service stub in a secondary region (#5635)",
+					"org_tenant_id", rec.OrganizationID,
+					"region", tgt.region, "clusterID", tgt.clusterID,
+					"namespace", names.Slug, "service", svc.GetName(), "err", err)
+			}
+		}
+		for i := range routes {
+			if err := ensureOrgAppRouteMirror(ctx, tgt.dyn, names, rec, &routes[i]); err != nil {
+				h.log.Error("org-app-surface: could not mirror the per-Org app HTTPRoute into a secondary region — that region still resets/404s this host (#5635)",
+					"org_tenant_id", rec.OrganizationID,
+					"region", tgt.region, "clusterID", tgt.clusterID,
+					"namespace", names.Slug, "route", routes[i].GetName(), "err", err)
+			}
+		}
+	}
+
+	h.log.Info("org-app-surface: per-Org app hosts projected into every secondary region via ClusterMesh stubs (#5635)",
+		"org_tenant_id", rec.OrganizationID,
+		"namespace", names.Slug,
+		"routes", len(routes),
+		"backends", len(exported),
+		"secondary_regions", len(targets)-1,
+	)
+}
+
+// listOrgAppRoutes returns the HTTPRoutes in the Org's OWN boundary namespace
+// that serve a host inside the Org's OWN zone. Both conditions are required —
+// that pair is what makes an object positively identifiable as this Org's app
+// surface rather than something else that happens to live nearby.
+//
+// The console host is excluded: its route lives in catalyst-system and is owned
+// by the console half (provisionOrgConsoleTLS), which already writes it to every
+// region. A route with zero hostnames is excluded because a hostname-less route
+// matches every host on its listener — mirroring one would hand a secondary
+// region a catch-all it was never meant to serve.
+func listOrgAppRoutes(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames) []unstructured.Unstructured {
+	list, err := dyn.Resource(httpRouteGVR).Namespace(names.Slug).List(ctx, metav1.ListOptions{})
+	if err != nil || list == nil {
+		return nil
+	}
+	out := make([]unstructured.Unstructured, 0, len(list.Items))
+	for i := range list.Items {
+		if orgAppRouteServesOwnZone(&list.Items[i], names) {
+			out = append(out, list.Items[i])
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].GetName() < out[j].GetName() })
+	return out
+}
+
+// orgAppRouteServesOwnZone is the structural identity test: EVERY hostname must
+// be a strict subdomain of `<slug>.<parent>`, there must be at least one, and
+// none may be the console host. "Every", not "any" — a route that also serves an
+// unrelated host would have that host projected too.
+func orgAppRouteServesOwnZone(route *unstructured.Unstructured, names orgConsoleTLSNames) bool {
+	hosts, _, _ := unstructured.NestedStringSlice(route.Object, "spec", "hostnames")
+	if len(hosts) == 0 {
+		return false
+	}
+	suffix := "." + names.OrgZone
+	for _, h := range hosts {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == names.ConsoleHost {
+			return false
+		}
+		if !strings.HasSuffix(h, suffix) || len(h) <= len(suffix) {
+			return false
+		}
+	}
+	return true
+}
+
+// orgAppRouteBackends collects the distinct same-namespace Service backends of
+// the given routes. A backendRef naming another namespace is skipped: mirroring
+// it would need a ReferenceGrant in the secondary region that nothing creates,
+// and the per-Org app model (a vcluster-syncer-reflected `<app>-x-<slug>-x-vcluster`
+// Service in the Org's own namespace) never produces one.
+func orgAppRouteBackends(routes []unstructured.Unstructured, ns string) []string {
+	seen := map[string]struct{}{}
+	for i := range routes {
+		rules, _, _ := unstructured.NestedSlice(routes[i].Object, "spec", "rules")
+		for _, r := range rules {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			refs, _, _ := unstructured.NestedSlice(rm, "backendRefs")
+			for _, b := range refs {
+				bm, ok := b.(map[string]any)
+				if !ok {
+					continue
+				}
+				if kind, _, _ := unstructured.NestedString(bm, "kind"); kind != "" && kind != "Service" {
+					continue
+				}
+				if group, _, _ := unstructured.NestedString(bm, "group"); group != "" {
+					continue
+				}
+				if bns, _, _ := unstructured.NestedString(bm, "namespace"); bns != "" && bns != ns {
+					continue
+				}
+				name, _, _ := unstructured.NestedString(bm, "name")
+				if name = strings.TrimSpace(name); name != "" {
+					seen[name] = struct{}{}
+				}
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ensureOrgAppServiceExported reads the host region's backing Service and adds
+// the two ClusterMesh annotations if either is missing, returning the Service
+// as it now stands (the caller copies its ports + selector into the stub).
+//
+// ADDITIVE ONLY. The Service in the host region is owned by the vcluster syncer
+// (`vcluster.loft.sh/managed-by: vcluster`); this touches nothing but the two
+// annotations, and because the reconcile is level-triggered an owner that
+// strips them is corrected on the next pass rather than fought over.
+func ensureOrgAppServiceExported(ctx context.Context, dyn dynamic.Interface, ns, name string) (*unstructured.Unstructured, error) {
+	svc, err := dyn.Resource(orgAppSurfaceServicesGVR()).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get Service %s/%s: %w", ns, name, err)
+	}
+	ann := svc.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	if ann[ciliumGlobalServiceAnnotation] == "true" && ann[ciliumSharedServiceAnnotation] == "true" {
+		return svc, nil
+	}
+	ann[ciliumGlobalServiceAnnotation] = "true"
+	ann[ciliumSharedServiceAnnotation] = "true"
+	svc.SetAnnotations(ann)
+	updated, err := dyn.Resource(orgAppSurfaceServicesGVR()).Namespace(ns).Update(ctx, svc, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("annotate Service %s/%s for ClusterMesh export: %w", ns, name, err)
+	}
+	return updated, nil
+}
+
+// ensureOrgBoundaryNamespaceForApps creates the Org's boundary namespace in a
+// secondary region. The org-controller creates it in its own cluster only, so
+// on a secondary it is simply absent — which is one layer ABOVE the missing
+// route, and why no amount of gateway fan-out alone could have helped.
+//
+// The labels are the same org-identity labels the #5364/#5649 reap keys on, so
+// a namespace this emitter creates is reaped with the rest of the Org's surface
+// when the Org is deleted rather than becoming a new orphan class.
+func ensureOrgBoundaryNamespaceForApps(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
+	labels := orgConsoleTLSStringLabels(names, rec, orgAppSurfaceComponent)
+	labels["openova.io/organization"] = names.Slug
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   names.Slug,
+			"labels": toAnyMap(labels),
+		},
+	}}
+	if _, err := dyn.Resource(namespacesGVR()).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create Namespace %s: %w", names.Slug, err)
+	}
+	return nil
+}
+
+// ensureOrgAppMeshStub creates the zero-backend ClusterMesh Service stub in a
+// secondary region: same name, same namespace, same ports and same selector as
+// the host region's Service, carrying the same global+shared annotations.
+//
+// The selector is copied deliberately rather than dropped. Cilium merges the two
+// same-named global Services into one; on the secondary the selector matches
+// ZERO local Pods (the workload is placed in the host region), so every dial
+// falls through the mesh to the host region's endpoints. That is the same
+// arrangement bp-catalyst-edge-routes uses for catalyst-api/catalyst-ui and
+// bp-openbao uses for its active member. A selectorless Service would instead
+// require someone to author EndpointSlices, which nothing does.
+func ensureOrgAppMeshStub(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord, src *unstructured.Unstructured) error {
+	ports, _, _ := unstructured.NestedSlice(src.Object, "spec", "ports")
+	selector, _, _ := unstructured.NestedMap(src.Object, "spec", "selector")
+
+	spec := map[string]any{"type": "ClusterIP"}
+	if len(ports) > 0 {
+		spec["ports"] = ports
+	}
+	if len(selector) > 0 {
+		spec["selector"] = selector
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata": map[string]any{
+			"name":      src.GetName(),
+			"namespace": names.Slug,
+			"labels":    orgConsoleTLSLabels(names, rec, orgAppSurfaceComponent),
+			"annotations": map[string]any{
+				ciliumGlobalServiceAnnotation: "true",
+				ciliumSharedServiceAnnotation: "true",
+			},
+		},
+		"spec": spec,
+	}}
+	if _, err := dyn.Resource(orgAppSurfaceServicesGVR()).Namespace(names.Slug).
+		Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create ClusterMesh Service stub %s/%s: %w", names.Slug, src.GetName(), err)
+	}
+	return nil
+}
+
+// ensureOrgAppRouteMirror creates a copy of a per-Org app HTTPRoute in a
+// secondary region: same name, same namespace, spec copied verbatim so the
+// hostname, the parentRef onto cilium-gateway-console and the backendRefs all
+// match the host region's. Create-if-absent — an existing route in that region
+// (whatever produced it) is left exactly as it is.
+func ensureOrgAppRouteMirror(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord, src *unstructured.Unstructured) error {
+	spec, found, err := unstructured.NestedMap(src.Object, "spec")
+	if err != nil || !found {
+		return fmt.Errorf("read spec of HTTPRoute %s/%s", names.Slug, src.GetName())
+	}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      src.GetName(),
+			"namespace": names.Slug,
+			"labels":    orgConsoleTLSLabels(names, rec, orgAppSurfaceComponent),
+		},
+		"spec": spec,
+	}}
+	if _, err := dyn.Resource(httpRouteGVR).Namespace(names.Slug).
+		Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create HTTPRoute mirror %s/%s: %w", names.Slug, src.GetName(), err)
+	}
+	return nil
+}
+
+// toAnyMap widens a string label map for unstructured metadata.
+func toAnyMap(in map[string]string) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh_5635_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh_5635_test.go
@@ -1,0 +1,305 @@
+// org_app_surface_mesh_5635_test.go — #5635 APP half.
+//
+// Both tests drive ONLY pre-existing entry points (reconcileOrgConsoleTLSOnce,
+// newReconcileHandler, newConsoleTLSHandlerWithCore) and assert on OUTCOMES, so
+// this file compiles unchanged against origin/main and the failure it reports
+// there is a RUNTIME failure describing the live defect — not a build error
+// about a symbol the fix introduces.
+//
+//	lock 1  TestReconcileOrgAppSurface_SecondaryRegionServesPerOrgAppHost
+//	        FAILS on origin/main  — the secondary region carries no route and
+//	        no mesh stub for the Org's app host, which is the ~50% reset.
+//	        PASSES with the fix.
+//
+//	lock 2  TestReconcileOrgAppSurface_SingleRegionWritesNothingExtra
+//	        PASSES on BOTH trees. It pins the two properties a blanket
+//	        suppression would have to break in order to satisfy lock 1:
+//	        the console surface is still produced, and a single-region
+//	        Sovereign gains no app-surface objects at all.
+package handler
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// appSurfaceServicesGVR is declared locally, NOT imported from the fix, so this
+// file has no compile-time dependency on anything the fix adds.
+var appSurfaceServicesGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+
+// fakeDynForOrgAppSurface is fakeDynForOrgConsoleReconcile plus the Service and
+// Namespace GVRs, so a region cluster can hold a per-Org app surface.
+func fakeDynForOrgAppSurface(t *testing.T, orgs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			certificateGVR:        "CertificateList",
+			consoleGatewayGVR:     "GatewayList",
+			httpRouteGVR:          "HTTPRouteList",
+			organizationGVR():     "OrganizationList",
+			appSurfaceServicesGVR: "ServiceList",
+			namespacesGVR():       "NamespaceList",
+		})
+	ctx := context.Background()
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name":      consoleGatewayName,
+			"namespace": consoleGatewayNamespace,
+		},
+		"spec": map[string]any{
+			"gatewayClassName": "cilium",
+			"listeners": []any{
+				map[string]any{"name": "console-https", "port": int64(8443), "protocol": "HTTPS", "hostname": "*.hw292.omani.works"},
+				map[string]any{"name": "console-http", "port": int64(8080), "protocol": "HTTP", "hostname": "*.hw292.omani.works"},
+			},
+		},
+	}}
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Create(ctx, gw, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed console gateway: %v", err)
+	}
+	for _, o := range orgs {
+		if _, err := dyn.Resource(organizationGVR()).Create(ctx, o, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed Organization CR %s: %v", o.GetName(), err)
+		}
+	}
+	return dyn
+}
+
+// seedPerOrgAppSurface writes into a region cluster exactly what hw292's
+// region-a carries for the funnel Org `uatco`: the boundary Namespace, the
+// vcluster-syncer-reflected backing Service, and the host-native app HTTPRoute
+// the per-Org GitOps tree delivers (gitops.generateHostNativeAppRoute).
+func seedPerOrgAppSurface(t *testing.T, dyn *dynamicfake.FakeDynamicClient, slug, appHost, svcName string) {
+	t.Helper()
+	ctx := context.Background()
+
+	ns := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "Namespace",
+		"metadata": map[string]any{"name": slug},
+	}}
+	if _, err := dyn.Resource(namespacesGVR()).Create(ctx, ns, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed namespace %s: %v", slug, err)
+	}
+
+	svc := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "Service",
+		"metadata": map[string]any{
+			"name": svcName, "namespace": slug,
+			// The live Service is syncer-owned and carries NO cilium
+			// annotations — that is the export half of the defect.
+			"labels": map[string]any{"vcluster.loft.sh/managed-by": "vcluster"},
+		},
+		"spec": map[string]any{
+			"type":     "ClusterIP",
+			"selector": map[string]any{"vcluster.loft.sh/owner-set-kind": "Deployment"},
+			"ports":    []any{map[string]any{"port": int64(80), "targetPort": int64(80), "protocol": "TCP"}},
+		},
+	}}
+	if _, err := dyn.Resource(appSurfaceServicesGVR).Namespace(slug).
+		Create(ctx, svc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed backing Service %s/%s: %v", slug, svcName, err)
+	}
+
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1", "kind": "HTTPRoute",
+		"metadata": map[string]any{"name": "app-wordpress-hostroute", "namespace": slug},
+		"spec": map[string]any{
+			"hostnames": []any{appHost},
+			"parentRefs": []any{map[string]any{
+				"group": "gateway.networking.k8s.io", "kind": "Gateway",
+				"name": consoleGatewayName, "namespace": consoleGatewayNamespace,
+			}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{
+					"group": "", "kind": "Service",
+					"name": svcName, "port": int64(80), "weight": int64(1),
+				}},
+				"matches": []any{map[string]any{
+					"path": map[string]any{"type": "PathPrefix", "value": "/"},
+				}},
+			}},
+		},
+	}}
+	if _, err := dyn.Resource(httpRouteGVR).Namespace(slug).
+		Create(ctx, route, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed app HTTPRoute %s/%s: %v", slug, appHost, err)
+	}
+}
+
+// regionServesHost reports whether a region cluster has an HTTPRoute in ns
+// serving host — the property an envoy needs in order to answer instead of
+// resetting or 404-ing.
+func regionServesHost(t *testing.T, dyn *dynamicfake.FakeDynamicClient, ns, host string) bool {
+	t.Helper()
+	list, err := dyn.Resource(httpRouteGVR).Namespace(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false
+	}
+	for i := range list.Items {
+		hosts, _, _ := unstructured.NestedStringSlice(list.Items[i].Object, "spec", "hostnames")
+		for _, h := range hosts {
+			if h == host {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func serviceAnnotation(t *testing.T, dyn *dynamicfake.FakeDynamicClient, ns, name, key string) (string, bool) {
+	t.Helper()
+	svc, err := dyn.Resource(appSurfaceServicesGVR).Namespace(ns).
+		Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", false
+	}
+	v, ok := svc.GetAnnotations()[key]
+	return v, ok
+}
+
+// TestReconcileOrgAppSurface_SecondaryRegionServesPerOrgAppHost — #5635 lock 1.
+//
+// hw292's exact shape: a marketplace-funnel Org whose purchased app surface was
+// written to region-a only, while a shared EIP round-robins both regions'
+// envoy. Ten fresh-TCP samples against the real host measured 9/20 reachable;
+// the failures were TLS handshake resets, i.e. region-b matched no listener and
+// carries no route for the host.
+//
+// After one reconcile pass region-b must be able to SERVE that host: a route in
+// the Org's namespace, and a same-name ClusterMesh Service stub so the route's
+// backend resolves across the mesh to region-a's singleton. The host region's
+// backing Service must be exported (global+shared) or the stub resolves to
+// nothing.
+//
+// On origin/main every assertion below fails: region-b's namespace, Service and
+// route are all absent, and region-a's Service carries no cilium annotation.
+func TestReconcileOrgAppSurface_SecondaryRegionServesPerOrgAppHost(t *testing.T) {
+	const (
+		slug    = "uatco"
+		parent  = "omani.homes"
+		appHost = "wordpress.uatco.omani.homes"
+		svcName = "wordpress-x-uatco-x-vcluster"
+	)
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works") // chroot gate for the fan-out
+
+	org := funnelOrgCR(slug, parent)
+	hostDyn := fakeDynForOrgAppSurface(t, org)
+	secDyn := fakeDynForOrgAppSurface(t, org)
+	hostCore := k8sfake.NewSimpleClientset(issuedOrgWildcardSecret("org-wildcard-tls-uatco-omani-homes"))
+	secCore := k8sfake.NewSimpleClientset()
+
+	// region-a carries the full per-Org app surface; region-b carries none of
+	// it — the live hw292 split.
+	seedPerOrgAppSurface(t, hostDyn, slug, appHost, svcName)
+
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	// 1. the host region's backing Service is EXPORTED to the mesh.
+	if v, ok := serviceAnnotation(t, hostDyn, slug, svcName, "service.cilium.io/global"); !ok || v != "true" {
+		t.Errorf("#5635: host-region Service %s/%s is not exported to the ClusterMesh "+
+			"(service.cilium.io/global=%q present=%v, want \"true\") — a secondary-region stub "+
+			"for it can never resolve", slug, svcName, v, ok)
+	}
+
+	// 2. the secondary region carries a same-name mesh stub.
+	if v, ok := serviceAnnotation(t, secDyn, slug, svcName, "service.cilium.io/global"); !ok || v != "true" {
+		t.Errorf("#5635: secondary region has no ClusterMesh Service stub %s/%s "+
+			"(service.cilium.io/global=%q present=%v, want \"true\") — its envoy has no backend "+
+			"for the app host", slug, svcName, v, ok)
+	}
+
+	// 3. and it SERVES the app host. This is the customer-visible assertion:
+	//    without it ~half of all fresh connections to the host fail.
+	if !regionServesHost(t, secDyn, slug, appHost) {
+		t.Errorf("#5635: secondary region serves NO route for %q — half of all fresh TCP "+
+			"connections to that host land on this region and fail (measured 9/20 reachable "+
+			"on hw292, failures = TLS handshake reset)", appHost)
+	}
+
+	// 4. the host region is untouched apart from the annotation: its route is
+	//    still the single authority for the host there.
+	if !regionServesHost(t, hostDyn, slug, appHost) {
+		t.Fatalf("#5635: host region stopped serving %q — the projection must be additive", appHost)
+	}
+}
+
+// TestReconcileOrgAppSurface_SingleRegionWritesNothingExtra — #5635 lock 2, the
+// anti-suppression control. PASSES on origin/main AND with the fix.
+//
+// It pins the two things a blanket "do nothing" could not satisfy alongside
+// lock 1: on a Sovereign with NO secondary region registered, the pass must add
+// no app-surface objects (no stub Service, no extra route, and the backing
+// Service must not be dragged into a mesh that does not exist) — while STILL
+// producing the Org's console surface. A patch that disabled the emitter
+// outright would pass this and fail lock 1; a patch that projected
+// unconditionally would pass lock 1 and fail this.
+func TestReconcileOrgAppSurface_SingleRegionWritesNothingExtra(t *testing.T) {
+	const (
+		slug        = "uatco"
+		parent      = "omani.homes"
+		appHost     = "wordpress.uatco.omani.homes"
+		svcName     = "wordpress-x-uatco-x-vcluster"
+		consoleHost = "console.uatco.omani.homes"
+	)
+	// A real single-region Sovereign IS a chroot — so the no-op below is
+	// attributable to "no secondary region registered", not to the chroot gate
+	// happening to be closed.
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+
+	org := funnelOrgCR(slug, parent)
+	dyn := fakeDynForOrgAppSurface(t, org)
+	core := k8sfake.NewSimpleClientset(issuedOrgWildcardSecret("org-wildcard-tls-uatco-omani-homes"))
+	seedPerOrgAppSurface(t, dyn, slug, appHost, svcName)
+
+	// No k8sCache => orgConsoleTLSTargets yields the host region only.
+	h := newConsoleTLSHandlerWithCore(t, dyn, core)
+	h.SetOrganizationDeps(OrganizationDeps{OTECHFQDN: "hw292.omani.works"})
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	// a. the console surface is still produced — the property a blanket
+	//    suppression of the reconcile pass would destroy.
+	if _, route := consoleSurfacePresent(t, dyn, consoleHost); route == "" {
+		t.Errorf("#5635: single-region pass produced no console HTTPRoute for %q — "+
+			"the app half must not disable the console half", consoleHost)
+	}
+
+	// b. exactly ONE route in the Org namespace: the seeded one. No mirror.
+	routes, err := dyn.Resource(httpRouteGVR).Namespace(slug).
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HTTPRoutes in %s: %v", slug, err)
+	}
+	if len(routes.Items) != 1 {
+		t.Errorf("#5635: single-region Sovereign has %d HTTPRoutes in ns %s, want exactly 1 "+
+			"(the GitOps-delivered original) — the cross-region projection must be a no-op "+
+			"without a secondary region", len(routes.Items), slug)
+	}
+
+	// c. exactly ONE Service, and it is NOT dragged into a nonexistent mesh.
+	svcs, err := dyn.Resource(appSurfaceServicesGVR).Namespace(slug).
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list Services in %s: %v", slug, err)
+	}
+	if len(svcs.Items) != 1 {
+		t.Errorf("#5635: single-region Sovereign has %d Services in ns %s, want exactly 1",
+			len(svcs.Items), slug)
+	}
+	if _, ok := serviceAnnotation(t, dyn, slug, svcName, "service.cilium.io/global"); ok {
+		t.Errorf("#5635: single-region Sovereign annotated %s/%s for ClusterMesh export — "+
+			"there is no mesh to export into; single-region output must be unchanged",
+			slug, svcName)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
@@ -153,6 +153,15 @@ func (h *Handler) reconcileOrgConsoleTLSOnce(ctx context.Context) {
 		// about it is create-time-only, which is precisely why re-running it
 		// here backfills a region the Org's original producer never reached.
 		h.provisionOrgConsoleTLS(ctx, rec)
+		// #5635 APP half. The console half above gives every region the
+		// `*.<slug>.<parent>` listener pair, which makes the TLS handshake
+		// succeed for EVERY per-Org host — but a secondary region still has no
+		// route for `wordpress.<slug>.<parent>`, so the reset merely becomes a
+		// 404. This projects the Org's app routes (and the ClusterMesh Service
+		// stubs they need) into every secondary, using the same idiom
+		// bp-catalyst-edge-routes uses for the platform hosts. No-op on a
+		// single-region Sovereign. See org_app_surface_mesh.go.
+		h.reconcileOrgAppSurfaceAcrossRegions(ctx, deps, rec)
 		reconciled++
 	}
 	if reconciled > 0 {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,29 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1312 — #5635 (APP half): grant catalyst-api `namespaces: create` +
+#   `services: create` so reconcileOrgAppSurfaceAcrossRegions can make a
+#   SECONDARY region serve the per-Org purchased-app hosts instead of
+#   resetting ~half of all fresh connections. Measured on hw292 (2 regions,
+#   cutoverComplete=true) with 20 separate `curl --no-keepalive`
+#   invocations, because HTTP/2 connection pinning hides a round-robin:
+#     wordpress.uatco.omani.homes  ok=9  fail=11  (failures = curl 35, TLS
+#                                                  handshake reset, no HTTP
+#                                                  status)
+#     console.hw292.omani.works    ok=10 fail=0   (control, SAME shared EIP)
+#   The reset — not a 503 — places the failure at listener match, and
+#   region-b indeed carries no `*.uatco.omani.homes` listener and no `uatco`
+#   namespace at all. The console half (#5647) gives every region the
+#   wildcard listener pair, which turns the reset into a 404; this half adds
+#   the route mirror + zero-backend Cilium ClusterMesh Service stub that
+#   makes region-b PROXY to region-a's pod — the exact idiom
+#   bp-catalyst-edge-routes (slot 13b) uses for the platform hosts and
+#   bp-openbao / bp-cnpg-pair use for their cross-region delivery. A chart
+#   cannot enumerate per-Org hosts (Orgs and apps are runtime objects), so
+#   the emitter is in catalyst-api and only these two verbs are new; the
+#   host-side export annotation rides the existing services update grant and
+#   the route mirror rides the existing httproutes create grant. Single-region
+#   Sovereigns are a no-op — the emitter returns before any read when no
+#   secondary region is registered. Refs #5635.
 # 1.4.1190 — #5289 (2-region api./console./marketplace. steady-state 200↔404
 #   flap): the PRIMARY (region-a) half of the ClusterMesh global-Service
 #   proxy fix. When the new `multiRegion.enabled` value is true, the
@@ -3662,7 +3686,7 @@ name: bp-catalyst-platform
 # 1.4.1295 — #5467: bp-self-sovereign-cutover 0.1.168 -> 0.1.169 (harbor-prewarm
 #   GHCR-PAT log-leak fix). Bootstrap-kit slot-06a + catalog-seed pins lockstep.
 #   (re-serialized past main 1.4.1294 at rebase.)
-version: 1.4.1311
+version: 1.4.1312
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -769,3 +769,43 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["delete"]
+
+  # ───────────────────────────────────────────────────────────────
+  # Issue #5635 (APP half) — PER-ORG APP SURFACE CROSS-REGION PROJECTION.
+  # reconcileOrgAppSurfaceAcrossRegions (org_app_surface_mesh.go), run inside
+  # the same reconcileOrgConsoleTLSOnce ticker pass as the console half,
+  # makes a secondary region able to SERVE the Org's purchased-app hosts
+  # instead of resetting/404-ing roughly half of all fresh connections
+  # (measured on hw292: wordpress.uatco.omani.homes 9/20 reachable, the
+  # failures TLS handshake resets; every *.<sovereignFQDN> host on the SAME
+  # shared EIP 4/4). It is the runtime equivalent of what
+  # bp-catalyst-edge-routes renders statically at bootstrap-kit slot 13b for
+  # the platform hosts — per-Org hosts cannot be enumerated at chart-render
+  # time because Orgs and their apps are created at runtime.
+  #
+  # The two verbs added here are the ones that pass could not already do:
+  #   1. NAMESPACES CREATE — the Org boundary namespace `<slug>` exists only
+  #      in the host region (the org-controller's per-Org Flux loop writes
+  #      through its own single-cluster client), so on a secondary the whole
+  #      namespace is absent and every per-Org object inside it is
+  #      necessarily missing. get/list/watch and delete are already granted
+  #      above; only create was missing.
+  #   2. SERVICES CREATE — the zero-backend Cilium ClusterMesh Service stub
+  #      (same name + namespace + ports + selector as the host region's, so
+  #      the mesh merges the pair and the secondary's dial falls through to
+  #      the host region's singleton pod). update/patch/delete on services
+  #      are already granted above — the host-side export annotation
+  #      (service.cilium.io/global + /shared) rides that existing update; only
+  #      create was missing.
+  # httproutes create (the route mirror) is already granted by the #5511
+  # block above. In-code scope guard: the emitter only touches an HTTPRoute
+  # that lives in the Org's OWN namespace `<slug>` AND whose every hostname
+  # is inside that Org's OWN zone `<slug>.<parent>`; it creates nothing when
+  # no secondary region is registered, and it deletes nothing ever.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create"]


### PR DESCRIPTION
## Shape: CONFIRMED — but the root cause recorded on the issue is REFUTED

`#5635` currently records the root cause as `#5359` (region-b's Flux still pulling from an external source), with the falsifiable prediction that *"fixing #5359 resolves this failure rate with no change to gateway or workload-placement code."* That prediction is wrong, and the evidence is cheap to check.

**The per-Org gateway listener is not a GitOps artifact.** `console-https-<slug>` exists only in Go — `products/catalyst/bootstrap/api/internal/handler/org_console_tls.go` and the org-controller's `reconcileTenantConsoleTLS` — and appears in **no** kustomize tree under `clusters/`. Repairing region-b's `GitRepository` cannot produce an object that no Flux tree contains.

Region-b's Flux **is** separately broken, just not in the way recorded:

```
region-b  flux-system/openova GitRepository
  url   http://gitea-http.gitea.svc.cluster.local:3000/openova/openova   <- already pivoted, NOT github.com
  gen=2 obs=1
  Ready=False  GitOperationFailed
    failed to checkout and determine revision: unable to list remote for
    '...gitea-http.gitea.svc.cluster.local:3000/openova/openova': pkt-line 3: EOF
```

That matters, but as a *constraint*: it is precisely why no GitOps-delivered fix can land in region-b either. The only process that can write to a secondary region is catalyst-api — which is where the console half went, and where this half goes.

## Measurement

20 **separate** `curl --no-keepalive` invocations. Per #5459 a browser loop or a keepalive curl pins one backend over HTTP/2 and reports 100% success against a round-robin, so fresh TCP per sample is mandatory:

```
s1  rc=35 000        s2  rc=0 302       s3  rc=35 000      s4  rc=35 000
s5  rc=0 302         s6  rc=0 302       s7  rc=0 302       s8  rc=35 000
s9  rc=35 000        s10 rc=0 302       s11 rc=35 000      s12 rc=35 000
s13 rc=0 302         s14 rc=0 302       s15 rc=0 302       s16 rc=35 000
s17 rc=35 000        s18 rc=0 302       s19 rc=35 000      s20 rc=35 000
SUMMARY wordpress.uatco.omani.homes ok=9 fail=11 of 20

SUMMARY console.hw292.omani.works   ok=10 fail=0 of 10     (control)
```

Both hosts resolve to the **same** shared EIP `212.72.24.85`. The control is the decisive part: the VIP is fine.

## Failure layer, established with a control rather than inferred

`curl` exit 35 is a TLS handshake reset — **no HTTP status exists**. A gateway with a listener but no healthy upstream answers `503`. So the failure is at listener match, and the enumeration agrees:

| | region-a | region-b |
|---|---|---|
| listeners for `*.uatco.omani.homes` on `kube-system/cilium-gateway-console` | `console-https-uatco`, `console-http-uatco` | **none** |
| namespace `uatco` | Active | **NotFound** |
| HTTPRoutes mentioning `uatco` | 3 | **0** (17 routes exist in other namespaces — the probe can return non-empty) |
| Flux Kustomizations | 13, incl. `catalyst-tenant-uatco-{vcluster,apps,host-apps}` | 3, none per-Org |

The per-Org Flux loop is created by the org-controller's `reconcilePerOrgFlux` through `r.Client` — its own cluster only. So region-b has neither the source nor the tree, one layer *above* the missing route.

## The fix — the idiom already proven live on this cluster

Not invented here. `bp-catalyst-platform` 1.4.1190 annotates region-a's control-plane Services `service.cilium.io/global: "true"` + `.../shared: "true"`, and **`bp-catalyst-edge-routes`** (bootstrap-kit slot 13b) renders into region-b the same-name **zero-backend** Services plus mirrored HTTPRoutes, so Cilium ClusterMesh merges the pair and region-b's envoy proxies to region-a's singleton instead of 404-ing (#5289). That is exactly why every `*.hw292.omani.works` host is a 10/10 control above. Same shape backs `platform/openbao/chart/templates/cross-region-mesh-service.yaml` and `bp-cnpg-pair`'s `replica-mesh-service.yaml`.

A chart cannot cover the per-Org surface — Orgs and their purchased apps are runtime objects, so the host set is unknowable at render time. So this is the **runtime** emitter of what slot 13b renders statically, on the existing #5635 Organization-CR ticker (creation-path independent, self-healing for Orgs that already exist):

- **host region** — every Service backing a per-Org app HTTPRoute is exported to the mesh (annotations added if absent; selector, ports and everything else untouched).
- **each secondary** — the Org boundary Namespace, a zero-backend global Service stub per backend (same name+namespace+ports+selector, matching no local Pod), and a mirror of each app HTTPRoute.

The console half (#5647) already gives every region the `*.<slug>.<parent>` listener pair, which alone turns the reset into a **404**; this half is what makes the region actually answer.

**Single-region is a no-op.** With no secondary registered the emitter returns before it reads anything — zero extra API calls, unchanged object graph.

**Scope guard.** Only an HTTPRoute in the Org's **own** namespace `<slug>` whose **every** hostname sits inside that Org's **own** zone `<slug>.<parent>` is a candidate. Hostname-less routes, out-of-zone hostnames and the console host are all skipped. Every write is create-if-absent or an additive annotation patch; nothing is deleted, no existing spec is overwritten.

## Guard — vacuity-checked in BOTH directions, real output

Both tests drive only pre-existing entry points, so the file compiles unchanged against `origin/main` and the failure there is a **runtime** failure describing the live defect, not a build error about a symbol the fix adds.

**Against `origin/main`** (production file removed, wire-in reverted, test file identical):

```
=== RUN   TestReconcileOrgAppSurface_SecondaryRegionServesPerOrgAppHost
    #5635: host-region Service uatco/wordpress-x-uatco-x-vcluster is not exported to the
      ClusterMesh (service.cilium.io/global="" present=false, want "true")
    #5635: secondary region has no ClusterMesh Service stub uatco/wordpress-x-uatco-x-vcluster
    #5635: secondary region serves NO route for "wordpress.uatco.omani.homes" — half of all
      fresh TCP connections to that host land on this region and fail
--- FAIL: TestReconcileOrgAppSurface_SecondaryRegionServesPerOrgAppHost (0.05s)
=== RUN   TestReconcileOrgAppSurface_SingleRegionWritesNothingExtra
--- PASS: TestReconcileOrgAppSurface_SingleRegionWritesNothingExtra (0.05s)
FAIL    .../internal/handler   0.124s
EXIT=1
```

**With the fix:**

```
=== RUN   TestReconcileOrgAppSurface_SecondaryRegionServesPerOrgAppHost
--- PASS: TestReconcileOrgAppSurface_SecondaryRegionServesPerOrgAppHost (0.05s)
=== RUN   TestReconcileOrgAppSurface_SingleRegionWritesNothingExtra
--- PASS: TestReconcileOrgAppSurface_SingleRegionWritesNothingExtra (0.05s)
PASS
ok      .../internal/handler   0.124s
EXIT=0
```

Lock 2 passes on **both** trees by design — it pins the console surface and the single-region no-op, so a blanket suppression cannot satisfy lock 1: disable the emitter and lock 1 fails; project unconditionally and lock 2 fails.

## Verification run

| gate | exit | result |
|---|---|---|
| `go test ./internal/handler/` (full package) | `0` | `ok ... 256.377s` |
| `go vet ./...` | `0` | clean |
| `gofmt -l` on the two new/changed files | — | 0 unformatted |
| `helm lint products/catalyst/chart` | `0` | clean |
| `helm template products/catalyst/chart` | `0` | 11067 lines, **zero** `nodePort` occurrences |
| `scripts/check-catalog-seed-lockstep.sh` | `0` | `checked: 68 fail: 0` |
| `scripts/check-bootstrap-kit-pin-sync.sh` | `0` | `bp-catalyst-platform: chart=1.4.1312 pin=1.4.1312` |

`ghcr-pin-existence` fails structurally on every chart bump — noted, not chased.

## Lockstep

`bp-catalyst-platform` has exactly two pin sites (verified by grepping the whole tree for the old version): `products/catalyst/chart/Chart.yaml` and `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`. Both moved `1.4.1311 -> 1.4.1312`; it carries no `blueprint.yaml` and no catalog-seed row, and both lockstep gates confirm the tree is consistent.

Only two verbs are new — `namespaces: create` and `services: create` — the ones the pass could not already do. The host-side export annotation rides the existing `services` update grant and the route mirror rides the existing `httproutes` create grant.

## Not claimed — what the next walker owes

This is **not walked live**. It needs a catalyst-api roll carrying this build. Falsifiable assertions, both regions:

1. `kubectl -n <slug> get httproute` returns the app route in **both** regions, and `kubectl -n <slug> get svc <app>-x-<slug>-x-vcluster -o jsonpath='{.metadata.annotations}'` shows `service.cilium.io/global: "true"` in both.
2. 20 separate `curl --no-keepalive` invocations against `https://<app>.<slug>.<parent>/` return **20/20** non-`35` exits.

One runtime unknown stated rather than glossed: the cross-cluster hop lands on region-a's per-Org CNP `allow-gateway-and-apiserver` (`fromEntities: [ingress, host, remote-node]`). With hostNetwork `cilium-envoy` the source should present as `remote-node`, but that is reasoning, not a measurement — assertion 2 is what settles it, and if it returns `503` rather than `302` the CNP is the next layer.

Two live findings recorded here rather than patched: region-b's `openova` GitRepository cannot reach the local Gitea (`pkt-line 3: EOF`), and `auth.<slug>.<parent>` still has no HTTPRoute from any producer.

Refs #5635 #5647 #5511 #5289 #5359 #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
