### PR TITLE
fix(placement): reject a region-less placement target instead of rendering an empty node selector

### DIFF
--- a/core/controllers/blueprint/internal/validate/placement_vocabulary_drift_test.go
+++ b/core/controllers/blueprint/internal/validate/placement_vocabulary_drift_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 
 	"github.com/openova-io/openova/core/controllers/internal/placement"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 )
 
 func TestPlacementVocabulary_CanonicalModesAreFour(t *testing.T) {
@@ -115,6 +116,51 @@ func TestPlacementVocabulary_BootstrapUIAllModesIsCanonical(t *testing.T) {
 		if strings.Contains(allModesLine, legacy) {
 			t.Errorf("ALL_MODES must NOT carry the legacy spelling %s", legacy)
 		}
+	}
+}
+
+// #5639 — the placement VALIDATION reasons must agree across the two gates
+// as strictly as the mode vocabulary does. The frontend `validatePlacement`
+// (shared/lib/placement.ts) declares itself "the FE gate, mirroring Go
+// ValidatePlacement"; before #5639 neither side inspected Target.Region, so
+// a region-less target passed both and rendered `openova.io/region In [""]`
+// — a constraint no node can satisfy, which left hw292's per-Org bp-postgres
+// unschedulable for 2d9h under a green "install succeeded".
+//
+// If one side is renamed or the check is dropped, the console and the API
+// disagree about what a valid placement is and the operator gets an
+// unactionable reason string (or none). Pin the literal.
+func TestPlacementValidation_5639_MissingRegionReasonMatchesFE(t *testing.T) {
+	root := findRepoRoot(t)
+	fe := mustReadRepoFile(t, root, "products", "catalyst", "bootstrap", "ui", "src", "shared", "lib", "placement.ts")
+
+	want := bpv1alpha1.TargetMissingRegionReason
+	if !strings.Contains(fe, "'"+want+"'") {
+		t.Errorf("FE placement.ts does not carry the Go reason %q — the two placement gates have drifted", want)
+	}
+	// The FE must actually GATE on the region, not merely export the
+	// constant. A dropped check with a surviving constant is the exact shape
+	// #5639 was: the vocabulary present, the assertion absent.
+	if !strings.Contains(fe, "TARGET_MISSING_REGION") {
+		t.Errorf("FE placement.ts exports no TARGET_MISSING_REGION reason")
+	}
+	if !strings.Contains(fe, "t.region") {
+		t.Errorf("FE validatePlacement never reads t.region — the empty-region gate is missing")
+	}
+
+	// Both directions of the Go gate itself, so this file fails if the check
+	// is deleted even when the constant survives.
+	withRegion := bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+		{Region: "hw-me-east-215-a-rtz-prod", Cluster: "c-a", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+	}}
+	if err := bpv1alpha1.ValidatePlacement(withRegion, bpv1alpha1.CapabilityPrimaryStandby); err != nil {
+		t.Errorf("a target with a real region must validate, got %v", err)
+	}
+	withoutRegion := bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+		{Region: "", Cluster: "c-a", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+	}}
+	if err := bpv1alpha1.ValidatePlacement(withoutRegion, bpv1alpha1.CapabilityPrimaryStandby); err == nil {
+		t.Errorf("a target with no region must be rejected (#5639)")
 	}
 }
 

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/placement_region_5639_test.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/placement_region_5639_test.go
@@ -1,0 +1,154 @@
+// placement_region_5639_test.go — #5639 guard on the SERVER side of the
+// same gate, both directions.
+//
+// The frontend `validatePlacement` in
+// products/catalyst/bootstrap/ui/src/shared/lib/placement.ts documents
+// itself as "the FE gate, mirroring Go ValidatePlacement". Before #5639
+// NEITHER side looked at Target.Region, so a placement target with an empty
+// region passed admission AND the reconciler and landed as
+//
+//	openova.io/region: ""
+//	nodeAffinity ... values: [""]
+//
+// which is what left hw292's per-Org bp-postgres Pending for 2d9h while the
+// HelmRelease reported install succeeded. A region no node carries is not a
+// slow schedule, it is an impossible one — and the install still reports
+// success, so every status surface stays green over a dark database.
+//
+// Fixing only the console leaves the API accepting the same object from Git
+// or a direct PUT, so the gate has to live here as well.
+package v1alpha1
+
+import (
+	"errors"
+	"testing"
+)
+
+func reasonOf(t *testing.T, err error) string {
+	t.Helper()
+	if err == nil {
+		return ""
+	}
+	var pe *PlacementError
+	if !errors.As(err, &pe) {
+		t.Fatalf("error %v is not a *PlacementError", err)
+	}
+	return pe.Reason
+}
+
+// The defect direction: a declared target with no region is REJECTED, with a
+// stable reason naming the offending target.
+func TestValidatePlacement_5639_EmptyRegionRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		targets []PlacementTarget
+	}{
+		{
+			name: "sole Primary carries no region",
+			targets: []PlacementTarget{
+				{Region: "", Cluster: "c-a", VCluster: "mgmt", Role: DataRolePrimary},
+			},
+		},
+		{
+			name: "whitespace-only region is not a region",
+			targets: []PlacementTarget{
+				{Region: "   ", Cluster: "c-a", VCluster: "mgmt", Role: DataRolePrimary},
+			},
+		},
+		{
+			// The hw292 shape exactly: a good Primary and a Hot Standby that
+			// the editor could not assign a second region to.
+			name: "active-hot-standby standby carries no region",
+			targets: []PlacementTarget{
+				{Region: "hw-me-east-215-a-rtz-prod", Cluster: "c-a", VCluster: "mgmt", Role: DataRolePrimary},
+				{Region: "", Cluster: "c-b", VCluster: "mgmt", Role: DataRoleStandby, StandbyType: StandbyHot},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePlacement(Placement{Targets: tc.targets}, CapabilityPrimaryStandby)
+			if err == nil {
+				t.Fatalf("ValidatePlacement accepted a target with no region — that renders "+
+					"openova.io/region In [\"\"], which no node can satisfy (#5639); targets=%+v", tc.targets)
+			}
+			if got := reasonOf(t, err); got != TargetMissingRegionReason {
+				t.Errorf("reason = %q, want %q", got, TargetMissingRegionReason)
+			}
+		})
+	}
+}
+
+// NON-VACUITY. Everything below must stay green: a gate that rejected every
+// placement would satisfy the assertions above while breaking placement
+// entirely. These are the cases an operator legitimately relies on.
+func TestValidatePlacement_5639_RealRegionsStillAccepted(t *testing.T) {
+	cases := []struct {
+		name    string
+		targets []PlacementTarget
+		cap     PlacementCapability
+	}{
+		{
+			// singleton on a single-region Sovereign — the case the fix must
+			// never block.
+			name: "singleton with one real region",
+			targets: []PlacementTarget{
+				{Region: "hw-me-east-215-a-rtz-prod", Cluster: "c-a", VCluster: "mgmt", Role: DataRolePrimary},
+			},
+			cap: CapabilityPrimaryStandby,
+		},
+		{
+			name: "active-hot-standby with two real regions",
+			targets: []PlacementTarget{
+				{Region: "hw-me-east-215-a-rtz-prod", Cluster: "c-a", VCluster: "mgmt", Role: DataRolePrimary},
+				{Region: "hw-me-east-215-b-rtz-prod", Cluster: "c-b", VCluster: "mgmt", Role: DataRoleStandby, StandbyType: StandbyHot},
+			},
+			cap: CapabilityPrimaryStandby,
+		},
+		{
+			name: "active-active with two Primary targets on a multi-primary blueprint",
+			targets: []PlacementTarget{
+				{Region: "hw-me-east-215-a-rtz-prod", Cluster: "c-a", VCluster: "mgmt", Role: DataRolePrimary},
+				{Region: "hw-me-east-215-b-rtz-prod", Cluster: "c-b", VCluster: "mgmt", Role: DataRolePrimary},
+			},
+			cap: CapabilityMultiPrimary,
+		},
+		{
+			// The bootstrap-owned host placement uses a non-region-shaped
+			// token; it is still a NON-EMPTY region and must stay accepted.
+			name: "platform-bootstrap-owned-host token is a region for this gate",
+			targets: []PlacementTarget{
+				{Region: "platform-bootstrap-owned-host", Cluster: "host", VCluster: "host", Role: DataRolePrimary},
+			},
+			cap: CapabilityPrimaryStandby,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidatePlacement(Placement{Targets: tc.targets}, tc.cap); err != nil {
+				t.Fatalf("ValidatePlacement rejected a valid placement: %v", err)
+			}
+		})
+	}
+}
+
+// An EMPTY target list stays a no-op — the legacy posture-string path drives
+// the fan-out unchanged, and admission short-circuits on it. Turning "no
+// targets" into an error here would reject every Application that has not
+// adopted the #3969 target model.
+func TestValidatePlacement_5639_NoTargetsIsStillANoOp(t *testing.T) {
+	if err := ValidatePlacement(Placement{Targets: nil}, CapabilityPrimaryStandby); err != nil {
+		t.Fatalf("an empty target list must remain valid, got %v", err)
+	}
+}
+
+// The reason must be distinguishable from the pre-existing ones, otherwise a
+// caller mapping it onto an Application condition cannot tell an unschedulable
+// region from a multi-Primary violation.
+func TestValidatePlacement_5639_ReasonIsDistinct(t *testing.T) {
+	for _, other := range []string{"InvalidRole", "PrimaryHasStandbyType", "StandbyMissingType", "NoPrimary", MultiPrimaryNotSupportedReason} {
+		if TargetMissingRegionReason == other {
+			t.Errorf("TargetMissingRegionReason collides with the existing reason %q", other)
+		}
+	}
+}

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go
@@ -213,12 +213,31 @@ func DerivePattern(targets []PlacementTarget, _ PlacementCapability) Pattern {
 // editor surfaces it as a disabled radio + inline reason.
 const MultiPrimaryNotSupportedReason = "MultiPrimaryNotSupported"
 
+// TargetMissingRegionReason is the canonical validation reason emitted when
+// a DECLARED placement target carries no region (#5639).
+//
+// A target with an empty region is not "unspecified, fill in a default" — it
+// renders literally, as `openova.io/region: ""` on the workload and
+// `nodeAffinity ... values: [""]` in its required node selector. No node ever
+// carries the empty-string region, so the Pod is unschedulable FOREVER while
+// the HelmRelease still reports install succeeded. hw292's per-Org
+// bp-postgres sat that way for 2d9h in `Setting up primary`, 0 ready, with a
+// green badge on every status surface.
+//
+// So the placement gate fails CLOSED on it: an empty region is rejected here,
+// naming the target, rather than accepted and rendered into an impossible
+// constraint downstream. The frontend mirrors this in
+// products/catalyst/bootstrap/ui/src/shared/lib/placement.ts.
+const TargetMissingRegionReason = "TargetMissingRegion"
+
 // ValidatePlacement enforces the capability gate + the role/standbyType
 // invariants (#3969 §7.1, §7.3). It returns a non-nil *PlacementError with
 // a stable Reason the caller maps onto the Application condition / API
 // response. It does NOT mutate the inputs.
 //
 // Invariants enforced:
+//   - every target names a region (#5639 — an empty one is unschedulable,
+//     not "default", see TargetMissingRegionReason);
 //   - every target has a valid Role;
 //   - a Standby target has a valid StandbyType; a Primary target has none;
 //   - at least one Primary (when any targets are declared);
@@ -228,6 +247,19 @@ func ValidatePlacement(p Placement, capability PlacementCapability) error {
 	cap := NormalizeCapability(capability)
 	var primaries int
 	for i, t := range p.Targets {
+		// #5639 — checked FIRST because it is the invariant that decides
+		// whether the target can run at all. A target that names no region
+		// renders `openova.io/region In [""]`; no node carries the empty
+		// string, so the workload never schedules while the install still
+		// reports success.
+		if strings.TrimSpace(t.Region) == "" {
+			return &PlacementError{
+				Reason: TargetMissingRegionReason,
+				Msg: "target[" + itoa(i) + "] declares no region; an empty region renders " +
+					"openova.io/region In [\"\"], which no node can satisfy, so the workload is " +
+					"unschedulable forever while the install still reports success (#5639)",
+			}
+		}
 		if !t.Role.IsValid() {
 			return &PlacementError{
 				Reason: "InvalidRole",

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.region-5639.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.region-5639.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * InstancesSection.region-5639.test.tsx — #5639 guard on the CREATE door.
+ *
+ * #5639 is titled "renders an EMPTY region selector". Two operator surfaces
+ * can produce a region-less placement, and they behave DIFFERENTLY — so this
+ * file pins the create dialog and PlacementEditor.region-5639.test.tsx pins
+ * the edit path. Recording both is the point: a walker who checks only one
+ * draws the wrong conclusion about the other.
+ *
+ * WHAT IS TRUE OF THIS DOOR (and was already true pre-fix — these assertions
+ * are the REFUTATION, kept so a regression flips them):
+ *
+ *   • The selector is POPULATED from the live infrastructure topology. Live
+ *     confirmation on hw292: `uat-ahs-pg` carries
+ *     `spec.placement = {mode: active-hot-standby, regions: [me-east-215-a,
+ *     me-east-215-b]}` — the operator picked two real regions here and they
+ *     reached the CR. The empty region on that Organization's CNPG Cluster
+ *     came from the CHART consuming an unset `topology.primary.region`
+ *     (#5641), not from this control.
+ *   • An empty region set is ALREADY unsubmittable for a multi-region mode:
+ *     `placementValid` requires ≥2 regions (#3599).
+ *
+ * WHAT WAS WRONG HERE: when the topology reports NO regions at all, the
+ * fieldset told the operator
+ *
+ *     "the server will place the instance in its default region"
+ *
+ * for EVERY mode — including active-hot-standby, where it is false twice
+ * over. There is no server-side default second region, and the Create button
+ * is simultaneously disabled by the ≥2 rule. The operator got a reassurance
+ * and a dead button and no way to reconcile them. That copy is the same
+ * false-default assumption that produced `openova.io/region: ""` downstream,
+ * so it is corrected to name the real condition.
+ *
+ * The singleton case below is the NEGATIVE CONTROL and must stay green: a
+ * mode that legitimately needs no region choice has to remain creatable, or
+ * the fix is a blanket block.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { InstancesSection } from './InstancesSection'
+
+const SELF = { deploymentId: 'd-1', sovereignFQDN: 'hw292.omani.works' }
+const ORG_ROWS = {
+  items: [
+    {
+      org_tenant_id: 't-uatco',
+      subdomain: 'uatco',
+      company_name: 'UAT Co',
+      tenant_namespace: 'uatco',
+      state: 'ready',
+    },
+  ],
+}
+
+/** The two regions hw292 actually reports (node label vocabulary elided —
+ *  this is the catalyst region id the topology tree serves). */
+const TWO_REGIONS = {
+  topology: {
+    pattern: 'multi-region',
+    regions: [
+      { id: 'r-a', name: 'me-east-215-a', provider: 'huawei', providerRegion: 'me-east-215-a', clusters: [] },
+      { id: 'r-b', name: 'me-east-215-b', provider: 'huawei', providerRegion: 'me-east-215-b', clusters: [] },
+    ],
+  },
+  cloud: [],
+  storage: { pvcs: [], buckets: [], volumes: [] },
+}
+
+/** The degraded case: the topology endpoint answers, but reports no regions. */
+const NO_REGIONS = {
+  topology: { pattern: 'solo', regions: [] },
+  cloud: [],
+  storage: { pvcs: [], buckets: [], volumes: [] },
+}
+
+let captured: Array<Record<string, unknown>> = []
+
+function json(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status < 400,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response)
+}
+
+/**
+ * bp-postgres ships `topology.supported: [singleton, active-hot-standby]` —
+ * verified cell-for-cell against the live hw292 catalog in #5708. Using the
+ * real declared set keeps this test honest about what the operator can pick.
+ */
+function installFetch(topologyBody: unknown, supported = ['singleton', 'active-hot-standby']) {
+  captured = []
+  const catalogItem = {
+    name: 'postgres',
+    version: '0.2.17',
+    card: { title: 'postgres' },
+    origin: 'upstream',
+    source: 'gitea',
+    raw: { spec: { multiInstance: { enabled: true }, topology: { supported } } },
+  }
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.includes('/catalyst/v1/apps/instances') && init?.method === 'POST') {
+      captured.push(JSON.parse(String(init.body)))
+      return json({ id: 'new-uid', name: 'pg-1', blueprint: 'postgres', org: 'uatco' }, 201)
+    }
+    if (url.includes('/instances')) return json({ items: [] })
+    if (url.includes('/sovereign/self')) return json(SELF)
+    if (url.includes('/v1/organizations')) return json(ORG_ROWS)
+    if (url.includes('/infrastructure/topology')) return json(topologyBody)
+    if (url.includes('/catalog/')) return json(catalogItem)
+    return json({})
+  }) as typeof fetch
+}
+
+async function openDialog() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/catalog/$blueprintName',
+    component: () => <InstancesSection blueprint="bp-postgres" />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([route]),
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/catalog/bp-postgres'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+  fireEvent.click(await screen.findByTestId('btn-new-instance'))
+  await screen.findByTestId('dialog-new-instance')
+  return (await screen.findByTestId('select-instance-topology')) as HTMLSelectElement
+}
+
+const submitBtn = async () =>
+  (await screen.findByTestId('btn-submit-instance')) as HTMLButtonElement
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('#5639 — the create dialog selector IS populated from the live topology', () => {
+  beforeEach(() => installFetch(TWO_REGIONS))
+
+  it('offers every region the Sovereign reports for active-hot-standby', async () => {
+    const sel = await openDialog()
+    fireEvent.change(sel, { target: { value: 'active-hot-standby' } })
+    // The assertion #5639's title predicts would fail. It does not — on this
+    // door. Kept so a real derivation regression here is caught.
+    expect(await screen.findByTestId('region-checkbox-me-east-215-a')).toBeTruthy()
+    expect(await screen.findByTestId('region-checkbox-me-east-215-b')).toBeTruthy()
+    expect(screen.queryByTestId('instance-regions-empty')).toBeNull()
+  })
+
+  it('active-hot-standby with NO region picked cannot be submitted', async () => {
+    const sel = await openDialog()
+    fireEvent.change(await screen.findByTestId('input-instance-name'), { target: { value: 'pg-1' } })
+    fireEvent.change(await screen.findByTestId('select-instance-org'), { target: { value: 'uatco' } })
+    fireEvent.change(sel, { target: { value: 'active-hot-standby' } })
+
+    await waitFor(async () => expect((await submitBtn()).disabled).toBe(true))
+    expect(screen.getByTestId('instance-regions-validation').textContent).toContain(
+      'at least 2 regions',
+    )
+    // One region is still not enough — the half-filled case.
+    fireEvent.click(await screen.findByTestId('region-checkbox-me-east-215-a'))
+    await waitFor(async () => expect((await submitBtn()).disabled).toBe(true))
+
+    // ...and two IS enough. Without this the assertion above is satisfied by
+    // a permanently-disabled button.
+    fireEvent.click(await screen.findByTestId('region-checkbox-me-east-215-b'))
+    await waitFor(async () => expect((await submitBtn()).disabled).toBe(false))
+
+    fireEvent.click(await submitBtn())
+    await waitFor(() => expect(captured.length).toBe(1))
+    expect(captured[0].placement).toEqual({ regions: ['me-east-215-a', 'me-east-215-b'] })
+  })
+})
+
+describe('#5639 — a Sovereign reporting NO regions says so honestly', () => {
+  beforeEach(() => installFetch(NO_REGIONS))
+
+  it('does NOT promise a server-side default for a multi-region mode', async () => {
+    const sel = await openDialog()
+    fireEvent.change(sel, { target: { value: 'active-hot-standby' } })
+
+    const note = await screen.findByTestId('instance-regions-empty')
+    const text = note.textContent ?? ''
+    // Pre-fix this read "the server will place the instance in its default
+    // region" for EVERY mode. For active-hot-standby there is no such
+    // default — that assumption is exactly what rendered
+    // `openova.io/region: ""` on hw292.
+    expect(text).not.toContain('default region')
+    expect(text.toLowerCase()).toContain('active-hot-standby')
+    // And the operator is not left guessing why Create is dead.
+    await waitFor(async () => expect((await submitBtn()).disabled).toBe(true))
+  })
+
+  it('NEGATIVE CONTROL — singleton with no regions is still creatable', async () => {
+    // A mode that genuinely needs no region choice must stay submittable, or
+    // the fix above is a blanket block dressed up as validation.
+    const sel = await openDialog()
+    expect(sel.value).toBe('singleton')
+    fireEvent.change(await screen.findByTestId('input-instance-name'), { target: { value: 'pg-1' } })
+    fireEvent.change(await screen.findByTestId('select-instance-org'), { target: { value: 'uatco' } })
+
+    // The singleton copy DOES legitimately fall back to the server default.
+    expect((await screen.findByTestId('instance-regions-empty')).textContent).toContain(
+      'default region',
+    )
+
+    await waitFor(async () => expect((await submitBtn()).disabled).toBe(false))
+    fireEvent.click(await submitBtn())
+    await waitFor(() => expect(captured.length).toBe(1))
+    expect(captured[0].topology).toBe('singleton')
+    // No placement is sent, so the server applies the Blueprint default —
+    // which is a real default, unlike the multi-region case.
+    expect(captured[0].placement).toBeUndefined()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -826,10 +826,23 @@ export function NewInstanceDialog({
           ) : availableRegions.length === 0 ? (
             <p
               data-testid="instance-regions-empty"
-              style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}
+              style={{
+                fontSize: '0.78rem',
+                margin: 0,
+                color: requiresMultiRegion ? 'var(--color-danger)' : 'var(--color-text-dim)',
+              }}
             >
-              No cluster regions reported for this Sovereign — the server will
-              place the instance in its default region.
+              {/* #5639 — the fall-back-to-a-server-default promise is TRUE
+                  for singleton and FALSE for every multi-region class: there
+                  is no default second region, and Create is simultaneously
+                  disabled by the ≥2 rule below. Telling the operator both at
+                  once left them with a reassurance and a dead button. The
+                  same "an unset region will be defaulted" assumption is what
+                  rendered `openova.io/region: ""` onto hw292's per-Org
+                  Cluster, so it is named, not papered over. */}
+              {requiresMultiRegion
+                ? `No cluster regions reported for this Sovereign, so ${topology} cannot be placed — it needs 2 regions and there is no default second region to fall back to. Check the infrastructure topology for this Sovereign first.`
+                : 'No cluster regions reported for this Sovereign — the server will place the instance in its default region.'}
             </p>
           ) : (
             availableRegions.map((region) => (

--- a/products/catalyst/bootstrap/ui/src/shared/lib/placement.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/placement.ts
@@ -154,6 +154,22 @@ export function normalizeCapability(raw: string | null | undefined): Capability 
  */
 export const MULTI_PRIMARY_NOT_SUPPORTED = 'MultiPrimaryNotSupported'
 
+/**
+ * The canonical reason emitted when a DECLARED placement target carries no
+ * region (#5639). Mirrors Go `TargetMissingRegionReason` in
+ * core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go — the Go
+ * drift gate pins the two spellings together.
+ *
+ * An empty region is not "unspecified, server picks a default". It renders
+ * literally: `openova.io/region: ""` on the workload and
+ * `nodeAffinity ... values: [""]` in its REQUIRED node selector. No node
+ * carries the empty-string region, so the Pod is unschedulable forever while
+ * the HelmRelease still reports install succeeded — hw292's per-Org
+ * bp-postgres sat exactly that way for 2d9h, 0 ready, green on every status
+ * surface. So the editor fails CLOSED rather than writing it.
+ */
+export const TARGET_MISSING_REGION = 'TargetMissingRegion'
+
 /** Count Primary targets. */
 export function primaryCount(targets: PlacementTarget[]): number {
   return targets.filter((t) => t.role === 'Primary').length
@@ -182,6 +198,15 @@ export function validatePlacement(
   let primaries = 0
   for (let i = 0; i < targets.length; i++) {
     const t = targets[i]
+    // #5639 — checked FIRST: whether the target names a region decides
+    // whether it can run at all. Blank (or whitespace-only) is rejected, not
+    // defaulted.
+    if (!(t.region ?? '').trim()) {
+      return {
+        reason: TARGET_MISSING_REGION,
+        message: `target ${i + 1} declares no region — an empty region pins the workload to a node label no node carries, so it would never schedule. Pick a region.`,
+      }
+    }
     if (t.role !== 'Primary' && t.role !== 'Standby') {
       return { reason: 'InvalidRole', message: `target ${i + 1} role "${t.role}" is not Primary|Standby` }
     }

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.region-5639.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.region-5639.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * PlacementEditor.region-5639.test.tsx — #5639 guard, BOTH directions.
+ *
+ * THE DEFECT THIS PINS. hw292 (dep 1c56518035a83e03) ran a per-Org
+ * `bp-postgres` whose CNPG Cluster carried
+ *
+ *     openova.io/region: ""
+ *     nodeAffinity ... values: [""]
+ *
+ * for 2d9h in `Setting up primary`, 0 ready, while the HelmRelease reported
+ * install succeeded. No node can ever carry the empty-string region, so that
+ * pod is unschedulable FOREVER — not slow, broken.
+ *
+ * #5641 fixed the CHART (a Helm `required` on `topology.primary.region`) and
+ * the per-Org producer. This file pins the OTHER producer of the identical
+ * shape, which no prior PR touched: the operator-facing placement editor.
+ *
+ * TWO STACKED DEFECTS, and the second is the load-bearing one:
+ *
+ *  1. DERIVATION — the Region <select> renders its options as
+ *     `[t.region, ...availableRegions].filter(Boolean)`. When the infra
+ *     topology query returns nothing (it is `enabled: !!sovereignId`, it
+ *     401s without a session, and it throws on any non-2xx) AND the
+ *     Application has no targets yet, `availableRegions` is `[]` and the
+ *     seeded target is `region: availableRegions[0] ?? ''`. Both halves are
+ *     falsy, so the control renders ZERO options: a blank box with no
+ *     explanation of why it is blank.
+ *
+ *  2. VALIDATION — `validatePlacement` checked role, standbyType and the
+ *     Primary count, and NEVER the region. So the empty selector was
+ *     SUBMITTABLE: Apply was enabled, and it PUT
+ *     `targets: [{ region: '', ... }]` — a placement with no region, which
+ *     is exactly the live hw292 shape. Fixing only (1) leaves this armed for
+ *     every future case where the list is legitimately empty.
+ *
+ * THE NEGATIVE CONTROL IS NOT OPTIONAL. A "fix" that simply refused to apply
+ * any placement would satisfy the two positive assertions above. So the
+ * singleton-on-a-single-region-Sovereign case below MUST stay green: it is
+ * the control proving the gate rejects the empty region specifically and not
+ * placement editing in general.
+ *
+ * Confirmed RED against the pre-fix tree — see the PR body for real output.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+
+import { PlacementEditor } from './PlacementEditor'
+import type { PlacementTarget } from '@/shared/lib/placement'
+
+// Capture what actually reaches the wire. A "the button was disabled"
+// assertion alone cannot tell an empty region from a real one; this can.
+const updateApplicationMock = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve({}),
+)
+vi.mock('@/lib/catalog.api', () => ({
+  updateApplication: (...args: unknown[]) => updateApplicationMock(...args),
+}))
+
+/** The body PlacementEditor PUTs — third positional arg of updateApplication. */
+type AppliedBody = { placement: { targets: Array<{ region: string }> } }
+const appliedBody = (call: number): AppliedBody =>
+  updateApplicationMock.mock.calls[call][2] as AppliedBody
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderEditor(overrides: Partial<React.ComponentProps<typeof PlacementEditor>> = {}) {
+  return render(
+    <PlacementEditor
+      sovereignId="s"
+      applicationName="postgres"
+      initialTargets={[]}
+      capability="primary+standby"
+      availableRegions={[]}
+      availableClusters={[]}
+      {...overrides}
+    />,
+  )
+}
+
+const applyBtn = () => screen.getByTestId('placement-editor-apply') as HTMLButtonElement
+
+describe('#5639 (1) — an unresolvable region list is VISIBLE, not a blank box', () => {
+  it('renders a legible empty-state instead of a <select> with zero options', () => {
+    renderEditor()
+    const sel = screen.getByTestId('placement-editor-target-0-region') as HTMLSelectElement
+    const options = Array.from(sel.querySelectorAll('option'))
+
+    // Pre-fix this array was EMPTY — the operator saw a blank control and
+    // had no way to tell "no regions reported" from "still loading".
+    expect(options.length).toBeGreaterThan(0)
+    expect(screen.getByTestId('placement-editor-target-0-region-empty')).toBeTruthy()
+    expect(sel.textContent?.toLowerCase()).toContain('no regions reported')
+  })
+
+  it('the empty-state is ABSENT when regions ARE reported (non-vacuity)', () => {
+    renderEditor({ availableRegions: ['hw-me-east-215-a-rtz-prod'] })
+    // A guard that always rendered the empty-state would pass the test above
+    // on every input. This is the direction that catches it.
+    expect(screen.queryByTestId('placement-editor-target-0-region-empty')).toBeNull()
+  })
+})
+
+describe('#5639 (2) — an empty region CANNOT be submitted', () => {
+  it('disables Apply and names the reason when the seeded target has no region', () => {
+    renderEditor()
+    // Pre-fix: validatePlacement returned null, so Apply was ENABLED.
+    expect(applyBtn().disabled).toBe(true)
+
+    const reason = screen.getByTestId('placement-editor-validation').textContent ?? ''
+    // "Legible" means it names the field and the consequence — not a code.
+    expect(reason.toLowerCase()).toContain('region')
+    expect(reason).toMatch(/target 1/i)
+  })
+
+  it('no empty-region placement reaches the wire even if Apply is clicked', async () => {
+    renderEditor()
+    fireEvent.click(applyBtn())
+    // Pre-fix this PUT `targets: [{ region: '', ... }]` — the live hw292
+    // shape, produced from the console.
+    await waitFor(() => expect(updateApplicationMock).not.toHaveBeenCalled())
+  })
+
+  it('a Standby added with no region left to assign is caught too', () => {
+    // The second half of the same expression: addTarget() falls back to
+    // `availableRegions[1] ?? availableRegions[0] ?? ''`, so a 2-target
+    // active-hot-standby on a topology that reports ONE region silently gave
+    // the standby an empty (pre-fix) region.
+    renderEditor({
+      availableRegions: ['hw-me-east-215-a-rtz-prod'],
+      availableClusters: ['hw-me-east-215-a-rtz-prod'],
+      initialTargets: [
+        { region: 'hw-me-east-215-a-rtz-prod', cluster: 'c-a', vcluster: 'mgmt', role: 'Primary' },
+        { region: '', cluster: '', vcluster: 'mgmt', role: 'Standby', standbyType: 'Hot' },
+      ] as PlacementTarget[],
+    })
+    expect(applyBtn().disabled).toBe(true)
+    expect((screen.getByTestId('placement-editor-validation').textContent ?? '')).toMatch(/target 2/i)
+  })
+})
+
+describe('#5639 negative control — placements that DO carry a region still apply', () => {
+  it('singleton on a SINGLE-region Sovereign is still applicable', async () => {
+    // The case the fix must not break: one region reported, one Primary
+    // target, no standby. If this ever goes red the gate has become a
+    // blanket block and the two assertions above are satisfied by breaking
+    // placement editing outright.
+    renderEditor({
+      availableRegions: ['hw-me-east-215-a-rtz-prod'],
+      availableClusters: ['hw-me-east-215-a-rtz-prod'],
+    })
+    expect(screen.getByTestId('placement-editor-derived-pattern').textContent).toContain('singleton')
+    expect(applyBtn().disabled).toBe(false)
+
+    fireEvent.click(applyBtn())
+    await waitFor(() => expect(updateApplicationMock).toHaveBeenCalledTimes(1))
+
+    // Assert on the VALUE that reached the wire, not merely that a call
+    // happened — an empty region would also have produced one call.
+    expect(appliedBody(0).placement.targets[0].region).toBe('hw-me-east-215-a-rtz-prod')
+  })
+
+  it('a two-region active-hot-standby still applies with both real regions', async () => {
+    renderEditor({
+      availableRegions: ['hw-me-east-215-a-rtz-prod', 'hw-me-east-215-b-rtz-prod'],
+      availableClusters: ['c-a', 'c-b'],
+      initialTargets: [
+        { region: 'hw-me-east-215-a-rtz-prod', cluster: 'c-a', vcluster: 'mgmt', role: 'Primary' },
+        {
+          region: 'hw-me-east-215-b-rtz-prod',
+          cluster: 'c-b',
+          vcluster: 'mgmt',
+          role: 'Standby',
+          standbyType: 'Hot',
+        },
+      ] as PlacementTarget[],
+    })
+    expect(screen.getByTestId('placement-editor-derived-pattern').textContent).toContain(
+      'active-hot-standby',
+    )
+    expect(applyBtn().disabled).toBe(false)
+
+    fireEvent.click(applyBtn())
+    await waitFor(() => expect(updateApplicationMock).toHaveBeenCalledTimes(1))
+    expect(appliedBody(0).placement.targets.map((t) => t.region)).toEqual([
+      'hw-me-east-215-a-rtz-prod',
+      'hw-me-east-215-b-rtz-prod',
+    ])
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
@@ -226,6 +226,17 @@ export function PlacementEditor({
           // NOT Primary when the capability already has its one Primary
           // (primary+standby gate). A target already Primary stays selectable.
           const primaryDisabled = t.role !== 'Primary' && !canAddPrimary(targets, capability)
+          // #5639 — the option list is `[current, ...available]` minus
+          // falsy entries. When the infra topology query returned nothing
+          // (it is gated on sovereignId, 401s without a session, and throws
+          // on any non-2xx) AND the target carries no region, BOTH halves
+          // are falsy and this renders a <select> with ZERO options: a blank
+          // box that reads identically to "still loading". Compute it once
+          // so the empty case can say so out loud instead.
+          const regionOptions = [
+            t.region,
+            ...availableRegions.filter((r) => r !== t.region),
+          ].filter(Boolean)
           return (
             <li
               key={i}
@@ -241,7 +252,12 @@ export function PlacementEditor({
                     onChange={(e) => setTarget(i, { region: e.target.value })}
                     data-testid={`placement-editor-target-${i}-region`}
                   >
-                    {[t.region, ...availableRegions.filter((r) => r !== t.region)].filter(Boolean).map((r) => (
+                    {regionOptions.length === 0 ? (
+                      <option value="" data-testid={`placement-editor-target-${i}-region-empty`}>
+                        — no regions reported —
+                      </option>
+                    ) : null}
+                    {regionOptions.map((r) => (
                       <option key={r} value={r}>
                         {r}
                       </option>


### PR DESCRIPTION
## What I confirmed, and what I refuted

The brief predicted two stacked defects on the create dialog: an empty region
selector, and an empty selection being submittable. I checked hw292 live before
touching code. **One of the two is real, and it is on a different surface than
predicted.**

**REFUTED — `NewInstanceDialog` is not the empty selector.** Its region list is
populated from the live infrastructure topology, and the `>=2 regions` rule
(#3599) already blocks a multi-region mode with nothing picked. The live CR
proves the operator got a real list and used it:

```
$ kubectl get applications.apps.openova.io -A -o custom-columns=...
NS                  NAME         REGIONS                         PLACEMENT
hw292-omani-works   uat-ahs-pg   [me-east-215-a me-east-215-b]   map[mode:active-hot-standby regions:[me-east-215-a me-east-215-b]]
```

Two regions chosen, two regions stored. The empty region on that Organization's
CNPG Cluster came from the CHART consuming an unset `topology.primary.region`,
which #5641 already fixed. The three assertions recording this are kept as
tests so a real derivation regression here is caught.

**CONFIRMED — the empty selector, and the submittable empty selection, are on
`PlacementEditor`** (the Topology tab's "Edit placement"), and they are exactly
the shape the brief describes.

*(1) The selector.* Options render as
`[t.region, ...availableRegions.filter(...)].filter(Boolean)`. The seed is
`region: availableRegions[0] ?? ''`. When the infra topology query returns
nothing — it is `enabled: !!sovereignId`, it 401s without a session (I hit that
myself probing the endpoint in-pod), and it throws on any non-2xx — and the
Application has no targets yet, **both halves are falsy and the control renders
a `<select>` with ZERO options**: a blank box that reads identically to "still
loading".

*(2) The submission.* This is the load-bearing half. `validatePlacement`
(`shared/lib/placement.ts`) and the Go `ValidatePlacement` it explicitly claims
to mirror (`pkg/apis/blueprint/v1alpha1/placement_target.go:227`) both checked
role, standbyType and Primary count — and **neither ever read `Region`**. So
Apply was enabled on the blank selector and PUT `targets: [{region: '', ...}]`.
A blank region survived admission and the reconciler too.

That is the same shape still live on hw292, read-only this session:

```
Cluster hw292-omani-works/postgres   (bp-postgres 0.2.16, pre-#5641)
  label   openova.io/region = ''
  nodeAff values: [""]
  phase   Setting up primary        2d9h, READY column empty

CONTROL, same cluster, same key, working:
  cnpg/cnpg-pair-bp-cnpg-pair-primary   3/3   Cluster in healthy state
  shared-data/shared-pg{,-b,-c}         3/3   Cluster in healthy state
```

Both regions sampled (`1c56518035a83e03.yaml` and
`...-me-east-215-b-1.yaml`); nodes in region A carry
`openova.io/region=hw-me-east-215-a-rtz-prod`, region B
`...-b-rtz-prod`. Nothing carries the empty string, and nothing ever will.

**Fixing only (1) leaves the trap armed**, which is the brief's point: any
future case where the list is legitimately empty walks straight back into an
unschedulable workload under a green badge.

## Changes

- `pkg/apis/blueprint/v1alpha1/placement_target.go` — new stable reason
  `TargetMissingRegion`; `ValidatePlacement` rejects a declared target whose
  region is blank or whitespace-only, checked FIRST because it decides whether
  the target can run at all. An EMPTY target list stays a no-op, so every
  Application that has not adopted the #3969 target model is untouched.
- `shared/lib/placement.ts` — the FE mirror, same reason literal.
  `PlacementEditor` already renders `validation.message` and gates Apply on
  `validation !== null`, so the existing seam supplies both the disabled button
  and the legible reason with no new plumbing.
- `widgets/topology/PlacementEditor.tsx` — the zero-option case now renders
  `no regions reported` instead of an empty control.
- `AppDetail/InstancesSection.tsx` — the no-regions note promised "the server
  will place the instance in its default region" for EVERY mode. True for
  singleton; false for active-hot-standby, where there is no default second
  region and Create is simultaneously disabled. The operator got a reassurance
  and a dead button. Now mode-aware.
- `blueprint/internal/validate/placement_vocabulary_drift_test.go` — extends
  the existing cross-surface gate (it already reads FE files by path) so the
  two spellings cannot drift, and so deleting the check on either side fails
  CI even if the constant survives.

## Guard results — both directions, real output

**Pre-fix, `PlacementEditor.region-5639.test.tsx`** (4 fail / 3 pass — the 3
passing are the non-vacuity controls, which is the point):

```
 x PlacementEditor.region-5639.test.tsx (7 tests | 4 failed)
   x renders a legible empty-state instead of a <select> with zero options
   x disables Apply and names the reason when the seeded target has no region
   x no empty-region placement reaches the wire even if Apply is clicked
   x a Standby added with no region left to assign is caught too
 Tests  4 failed | 3 passed (7)
```

The third failure is the one that matters: `updateApplicationMock` **was
called** — the empty-region placement genuinely reached the wire, it was not
merely a button-state question.

**Pre-fix, Go**, with the reason constant added but no check, so the failure is
behavioural rather than a compile error:

```
--- FAIL: TestValidatePlacement_5639_EmptyRegionRejected
    ValidatePlacement accepted a target with no region — that renders
    openova.io/region In [""], which no node can satisfy (#5639);
    targets=[{Region: Cluster:c-a VCluster:mgmt Role:Primary StandbyType:}]
    ... (whitespace-only region, and the AHS standby case, same)
--- PASS: TestValidatePlacement_5639_RealRegionsStillAccepted
--- PASS: TestValidatePlacement_5639_NoTargetsIsStillANoOp
--- PASS: TestValidatePlacement_5639_ReasonIsDistinct
```

**Pre-fix, `InstancesSection.region-5639.test.tsx`** — 3 pass, 1 fails. The 3
passing ARE the refutation above, recorded rather than asserted from memory:

```
 x does NOT promise a server-side default for a multi-region mode
   AssertionError: expected 'No cluster regions reported for this ...'
   not to contain 'default region'
 Tests  1 failed | 3 passed (4)
```

**The negative control that makes the gate non-vacuous.** A fix that refused
every placement would satisfy every assertion above. So these must stay green
and do:

- `singleton on a SINGLE-region Sovereign is still applicable` — Apply enabled,
  and the wire carries `region: 'hw-me-east-215-a-rtz-prod'`, asserted on the
  VALUE, not on "a call happened" (an empty region also produces one call).
- `NEGATIVE CONTROL — singleton with no regions is still creatable` in the
  create dialog — submits with `placement: undefined`, so the server default
  still applies where a default genuinely exists.
- Go `platform-bootstrap-owned-host token is a region for this gate` — the
  bootstrap placement token is non-empty and must keep validating.

**Drift-gate vacuity, checked by breaking it.** Deleting the FE region check
(constant left in place):

```
--- FAIL: TestPlacementValidation_5639_MissingRegionReasonMatchesFE
    FE validatePlacement never reads t.region — the empty-region gate is missing
```

Restored, green.

**Post-fix gates, real output:**

| gate | result |
|---|---|
| `npx tsc -b --force` | clean, exit 0 |
| `npx vitest run` (full) | **215 files / 2037 tests passed** (was 213/2026 — this PR adds exactly 11) |
| `npm run build` | `built in 1.73s` |
| `npx eslint .` | **128 problems — identical to the pre-PR baseline**, zero net new |
| `go build ./...` (core/controllers) | clean |
| `go test ./...` (core/controllers) | all packages ok, incl. `application/admission` + `application/internal/controller`, the two `ValidatePlacement` call sites |
| `go test -count=1` on both touched packages | ok (uncached, after restoring the vacuity mutation) |

No existing Go fixture relied on a region-less target, so the blast radius of
the new invariant is zero.

## Notes

- No chart or blueprint changed, so the five-site lockstep does not apply here.
- No live cluster was mutated. hw292 was read-only throughout.
- `playwright-e2e.yml` only triggers on `products/catalyst/console/**`, never
  `bootstrap/ui/**`, so an e2e spec added here would not run in CI. Everything
  above is vitest and `go test` for that reason; no e2e was added.

## Separately flagged, deliberately NOT fixed here

`pages/sovereign/InstallPage.tsx:84` hard-codes `useState('hz-fsn-rtz-prod')`
for its region — a Hetzner literal, as free text, on a Huawei Sovereign, and it
always emits `regions: [region]` (exactly one) even when the placement mode is
active-hot-standby. Its own comment claims the region is "read from the
deployment's first region"; it is not read from anything. This is the same
near-miss-region class as the qa-fixtures `hz-fsn-rtz-prod` default #5658
found, and a near-miss region is exactly as unschedulable as an empty one. It
needs a live-derived picker rather than a validation tweak, so it belongs in
its own change rather than widening this one.

## For the next walker — the falsifiable assertion

Not closing #5639; merged is not delivered. Two live checks, both cheap:

1. Open an Application's **Topology tab, Edit placement** on a Sovereign whose
   infra topology is unavailable (or on an Application with no targets). The
   Region control must read `no regions reported` and **Apply must be
   disabled** with a reason naming the region. If Apply is clickable there, the
   gate has regressed.
2. Open the create dialog for **`bp-postgres`**, choose **`active-hot-standby`**:
   the region selector must list the Sovereign's regions, and Create must stay
   disabled until two are ticked.

hw292 still runs bp-postgres 0.2.16 and still shows `values: [""]`, so the
delivery leg of this issue remains open on a fresh prov regardless of this PR.

Refs #5639 #5641 #5658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
