### PR TITLE
fix(dr): every CNPG DR pair must declare a promotion mechanism (Refs #5623)

### DIFF
--- a/.github/workflows/check-dr-pairs-declare-promotion.yaml
+++ b/.github/workflows/check-dr-pairs-declare-promotion.yaml
@@ -1,0 +1,64 @@
+name: check — every DR pair declares a promotion mechanism (#5623)
+
+# Permanent guard that every CNPG standby half in the catalog has something
+# that will actually promote it when its source region dies.
+#
+# On the hw292 G12 region-kill (2026-08-03) bp-cnpg-pair's region-B dr-promoter
+# promoted at T0+2m16s with RPO=0. The three bp-postgres shared-pg pairs — which
+# render the IDENTICAL standby shape — stayed `pg_is_in_recovery() = t` for the
+# entire outage, because only bp-cnpg-pair shipped a promoter. keycloak is a
+# shared-pg consumer, so the auth path could not recover in region-B even in
+# principle. Nothing in the source distinguished the pair that promotes from the
+# three that could not: all four rendered valid YAML and all four reported Ready.
+#
+# bp-cnpg-pair's own render test asserted its promoter was present, and passed,
+# for every one of the months bp-postgres had none. A property proven in ONE
+# place and assumed fleet-wide is what this gate exists to stop, so Phase 1
+# ENUMERATES the catalog by structural signature (bootstrap.pg_basebackup) and
+# fails on any unregistered standby half — a new DR pair cannot be added without
+# stating what promotes it.
+#
+# Path filters are deliberately the whole of platform/ and products/: the gate's
+# value is catching a standby half in a chart nobody thought to list. Narrowing
+# these to today's known DR charts would reproduce the original defect.
+#
+# Per docs/PRINCIPLES.md #4a this workflow renders templates locally — it does
+# not deploy anything, call cloud APIs, or touch a live cluster.
+#
+# Refs #5623 #5178 #5220 #5133 #5157 #5125 #5639
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'scripts/check-dr-pairs-declare-promotion.sh'
+      - '.github/workflows/check-dr-pairs-declare-promotion.yaml'
+  pull_request:
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'scripts/check-dr-pairs-declare-promotion.sh'
+      - '.github/workflows/check-dr-pairs-declare-promotion.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dr-pairs-declare-promotion:
+    name: Every DR pair declares a promotion mechanism
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Run DR-pair promotion-mechanism gate
+        run: bash scripts/check-dr-pairs-declare-promotion.sh

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1193,6 +1193,42 @@ The deterministic failover test for two independent CNPG clusters:
    cluster drift" REVERTS the patch mid-outage and silently re-demotes the
    survivor (hw256 G12, T0+2m07s). (The `Continuum` CR orchestration path is the
    automated equivalent — PR #2072/#2074.)
+3b. **SAMPLE EVERY PAIR, NOT JUST `bp-cnpg-pair` (#5623).** A 2-region Sovereign
+   runs FOUR CNPG DR pairs, and until 2026-08-04 only one of them could promote.
+   On hw292 (2026-08-03) `bp-cnpg-pair` promoted at T0+2m16s with RPO=0 while
+   `shared-pg-replica`, `shared-pg-b-replica` and `shared-pg-c-replica` each
+   stayed `pg_is_in_recovery() = t` for the WHOLE outage — keycloak is a
+   shared-pg consumer, so the auth path could not recover in region-B even in
+   principle, behind a gateway that answered a correct-looking 503. A walk that
+   samples only the cnpg-pair line reports Pillar 3 GREEN on a Sovereign whose
+   platform databases are all read-only. **The falsifiable per-pair assertion:**
+
+   | Pair (region-B object) | Chart | Mechanism | Must promote within | Observe |
+   |---|---|---|---|---|
+   | `cnpg/cnpg-pair-bp-cnpg-pair-replica` | bp-cnpg-pair ≥0.2.14 | `dr-promoter` | ~2–4 min, zero touch | `dr-auto-promoted-at` on the region-B HR |
+   | `shared-data/shared-pg-replica` | bp-postgres ≥0.2.18 | `dr-promoter` | ~2–4 min, zero touch | `dr-auto-promoted-at` on `bp-postgres-shared` |
+   | `shared-data/shared-pg-b-replica` | bp-postgres ≥0.2.18 | `dr-promoter` | ~2–4 min, zero touch | `dr-auto-promoted-at` on `bp-postgres-shared-b` |
+   | `shared-data/shared-pg-c-replica` | bp-postgres ≥0.2.18 | `dr-promoter` | ~2–4 min, zero touch | `dr-auto-promoted-at` on `bp-postgres-shared-c` |
+   | per-Org `wordpress-db-replica` | bp-wordpress-tenant | **`manual`** | never automatically | `catalyst.openova.io/dr-promotion-mechanism` on the standby Cluster CR |
+
+   The count is the assertion. Region-B must hold **four** `*-dr-promoter`
+   Deployments during the outage, not one:
+   ```bash
+   KUBECONFIG=<region-b> kubectl get deploy -A -o name | grep dr-promoter   # want 4
+   KUBECONFIG=<region-b> kubectl get cluster.postgresql.cnpg.io -A \
+     -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,PRIMARY:.status.currentPrimary
+   # then, per standby, the ground truth — a promoted standby answers `f`:
+   #   psql -tAc 'select pg_is_in_recovery()'
+   ```
+   Sample **both** regions and sample **repeatedly** through the outage window: a
+   single post-recovery sample cannot distinguish "promoted at T0+2m" from "never
+   promoted and region-A came back". `bp-wordpress-tenant` is the known
+   exception, declared not inferred — its standby carries
+   `catalyst.openova.io/dr-promotion-mechanism: manual` precisely so a walker
+   reads the gap off the live object instead of discovering it by killing a
+   region. Making that pair automatic is tracked on #5623; the catalog-wide
+   source gate is `scripts/check-dr-pairs-declare-promotion.sh`.
+
 4. Verify the write made it across — zero-tx-loss (RPO=0)
 5. Reverse: `scripts/region-kill-drill.sh recover --arm` os-starts region-a.
    **AUTOMATIC (bp-cnpg-pair ≥ 0.2.18, #5245)** — the failback now converges

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: organization-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.22
+  version: 0.4.23
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -311,7 +311,41 @@ name: bp-wordpress-tenant
 #   Also hardened the step-0 pg4wp `curl` with `--max-time 120` (mirrors the
 #   step-4 OIDC-plugin vendor) so a black-holed GitHub egress can only FAIL
 #   FAST (→ OnFailure retry) instead of hanging the hook indefinitely.
-version: 0.4.22
+# 0.4.23 (#5623): the active-hot-standby pair must DECLARE what promotes its
+#   standby, and the render FAILS CLOSED when it does not.
+#   FOUND — hw292 G12 region-kill (2026-08-03): bp-cnpg-pair's region-B
+#   dr-promoter promoted at T0+2m16s (RPO=0) while the three bp-postgres
+#   shared-pg standbys, which render the identical shape, stayed
+#   `pg_is_in_recovery()=t` for the whole outage because only bp-cnpg-pair
+#   shipped a promoter. bp-postgres 0.2.18 ported it. THIS chart renders the
+#   same cross-region standby (`replica.enabled: true` + pg_basebackup +
+#   externalClusters, templates/cnpg-cluster.yaml) and ships NEITHER a promoter
+#   NOR a `kind: Continuum` CR — and the mechanism its own template comment
+#   names, "Continuum K-Cont-2", is a region-A-ONLY Deployment (verified live
+#   2026-08-06 on hw292: region-B carries neither continuum-controller nor the
+#   Continuum CRD) that orchestrates a PLANNED switchover. It dies with the
+#   region it would fail away from — the #5137 root cause. `replica.enabled` is
+#   additionally hard-coded here with no `topology.promoted` HR-value seam, so
+#   even a hand-patch of the live Cluster CR is reverted by flux
+#   drift-correction mid-outage (#5125-D1). Net: a customer ticking the HA box
+#   got a standby nothing would ever promote, silently.
+#   NOT FIXED BY FABRICATING A PROMOTER — a promoter that fires without a real
+#   quorum/lease signal is the #5178 false-promote flap (hw266 TL2→TL25). The
+#   proven bp-cnpg-pair actor latches durability by suspending a NAMED
+#   HelmRelease, and this chart's HR is minted per-Application by the
+#   application-controller, so there is no stable HR name at render time. That
+#   seam is real design work, tracked on #5623.
+#   SHIPPED — `pg.activeHotStandby.promotion.mechanism`, REQUIRED whenever the
+#   pair renders. `manual` (operator-run promotion, RUNBOOKS §6.1) is the only
+#   mechanism this chart can honour today; `dr-promoter` and `continuum` fail
+#   closed naming exactly what is missing, so declaring an undelivered failover
+#   is impossible. The declared value is stamped on the STANDBY Cluster CR as
+#   `catalyst.openova.io/dr-promotion-mechanism`, so an operator can answer "who
+#   promotes this?" from the live object during an outage instead of from a
+#   values file. Singleton installs render byte-identical (no annotation, no
+#   declaration required). Catalog-wide enforcement:
+#   scripts/check-dr-pairs-declare-promotion.sh.
+version: 0.4.23
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/_helpers.tpl
+++ b/platform/wordpress-tenant/chart/templates/_helpers.tpl
@@ -235,6 +235,65 @@ failure-isolation gain). Triggered only when enabled=true.
 {{- end -}}
 
 {{/*
+#5623 — EVERY rendered DR pair MUST DECLARE ITS PROMOTION MECHANISM.
+
+THE DEFECT THIS EXISTS TO PREVENT
+---------------------------------
+On the hw292 G12 region-kill (2026-08-03) `bp-cnpg-pair`'s region-B dr-promoter
+auto-promoted at T0+2m16s while the three `bp-postgres` shared-pg standbys stayed
+`pg_is_in_recovery()=t` for the WHOLE outage — they rendered the identical
+split-side standby shape but shipped no region-local promoter, so nothing in the
+surviving region ever acted on them. bp-postgres 0.2.18 ported the promoter.
+
+THIS chart renders the SAME standby shape (`replica.enabled: true` +
+`bootstrap.pg_basebackup` + `externalClusters[]`, below) and ships NEITHER a
+promoter NOR a `kind: Continuum` CR. The mechanism its own template comment names
+— "Continuum K-Cont-2" — is a REGION-A-ONLY Deployment: on hw292 region-B carries
+no continuum-controller and not even the Continuum CRD (verified live 2026-08-06,
+both regions sampled). So a region-A kill leaves this pair's standby read-only
+with no actor anywhere that can promote it, and NOTHING in the render says so.
+`replica.enabled: true` is additionally hard-coded here (no `topology.promoted`
+HR-value seam like bp-postgres/bp-cnpg-pair), so even a hand-patch of the live
+Cluster CR is reverted by flux drift-correction mid-outage (#5125-D1).
+
+WHY A REQUIRED DECLARATION AND NOT A PORTED PROMOTER
+----------------------------------------------------
+A promoter that promotes without a real quorum/lease signal causes the #5178
+false-promote flap and split-brain. Porting the proven bp-cnpg-pair actor here
+needs a design decision this chart cannot make on its own: the actor's durability
+latch patches a NAMED HelmRelease, and this chart's HR is minted per-Application
+by the application-controller, so there is no stable HR name at render time. That
+seam is real work, tracked on #5623 — it is NOT something to fabricate inline.
+
+What IS shippable and correct today: refuse to render an "HA" pair that silently
+cannot fail over. The operator must state the mechanism out loud, and the value
+they state is stamped onto the standby Cluster CR so it is visible on the LIVE
+object (`kubectl get cluster -o jsonpath=...dr-promotion-mechanism`), not only in
+a values file. `manual` is the only mechanism this chart can actually deliver
+today; `dr-promoter` and `continuum` fail closed naming exactly what is missing,
+so the day one of them ships the declaration becomes true rather than aspirational.
+*/}}
+{{- define "bp-wordpress-tenant.drPromotionMechanism" -}}
+{{- dig "activeHotStandby" "promotion" "mechanism" "" .Values.pg | toString | trim -}}
+{{- end -}}
+
+{{- define "bp-wordpress-tenant.validateActiveHotStandbyPromotion" -}}
+{{- $m := include "bp-wordpress-tenant.drPromotionMechanism" . -}}
+{{- if eq $m "" -}}
+{{- fail "pg.activeHotStandby.promotion.mechanism is REQUIRED when the active-hot-standby pair renders (#5623): this chart renders a cross-region CNPG standby, and an undeclared pair is one that silently never promotes on a region kill. Set it to \"manual\" (operator-run promotion per RUNBOOKS §6.1 — the only mechanism this chart delivers today) or ship an automatic one first." -}}
+{{- end -}}
+{{- if eq $m "dr-promoter" -}}
+{{- fail "pg.activeHotStandby.promotion.mechanism=\"dr-promoter\" is NOT DELIVERABLE by bp-wordpress-tenant (#5623): this chart ships no dr-promoter Deployment and no `topology.promoted` HelmRelease-value promote seam, so declaring it would assert a failover that cannot happen. Port the bp-cnpg-pair/bp-postgres actor (and a stable per-Application HR name for its suspend latch) before declaring this." -}}
+{{- end -}}
+{{- if eq $m "continuum" -}}
+{{- fail "pg.activeHotStandby.promotion.mechanism=\"continuum\" is NOT DELIVERABLE by bp-wordpress-tenant (#5623): this chart renders no `kind: Continuum` CR, and continuum-controller is a region-A-only Deployment that dies with region-A (the #5137 root cause — region-B carries neither the controller nor the Continuum CRD). Continuum orchestrates a PLANNED switchover; it is not an unplanned-region-kill actor." -}}
+{{- end -}}
+{{- if ne $m "manual" -}}
+{{- fail (printf "pg.activeHotStandby.promotion.mechanism=%q is not a recognised mechanism (#5623). Valid: manual | dr-promoter | continuum." $m) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 wp-cli image reference, with optional `global.imageRegistry` rewrite for
 Sovereign Harbor proxy-cache. Mirrors `wordpressImage` so both runtime
 and CLI images route through the same proxy. Returns

--- a/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
+++ b/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
@@ -52,6 +52,9 @@ bp-wordpress-tenant in EVERY region for HA mode.
 {{- $haEnabled := eq (include "bp-wordpress-tenant.dbMode" .) "active-hot-standby" -}}
 {{- if $haEnabled }}
 {{- include "bp-wordpress-tenant.validateActiveHotStandbyRegions" . }}
+{{- /* #5623 — a DR pair that declares no promotion mechanism is one that
+       silently never promotes on a region kill. Fail closed. */ -}}
+{{- include "bp-wordpress-tenant.validateActiveHotStandbyPromotion" . }}
 {{- end }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
@@ -272,6 +275,14 @@ metadata:
     catalyst.openova.io/blueprint: bp-wordpress-tenant
     catalyst.openova.io/cnpg-pair-role: replica
     catalyst.openova.io/cnpg-pair-name: {{ .Values.database.cnpgClusterName | quote }}
+    # #5623 — WHAT WILL PROMOTE THIS STANDBY, stamped on the live object.
+    # An operator inspecting a running pair must be able to answer "who promotes
+    # this on a region-A kill?" from the cluster itself, not from a values file
+    # in a git repo. `manual` means NOTHING region-local will act: promotion is
+    # the sovereign-admin's RUNBOOKS §6.1 action and the RTO is however long
+    # that takes. bp-cnpg-pair / bp-postgres stamp their pairs by shipping an
+    # actual dr-promoter Deployment alongside; this chart ships none.
+    catalyst.openova.io/dr-promotion-mechanism: {{ include "bp-wordpress-tenant.drPromotionMechanism" . | quote }}
 spec:
   instances: {{ .Values.database.cluster.instances }}
   imageName: {{ .Values.database.cluster.imageName | default "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql" }}:{{ .Values.database.cluster.pgVersion }}

--- a/platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh
+++ b/platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh
@@ -110,6 +110,7 @@ echo "  PASS"
 echo "[d31-render] Case 2: enabled render emits primary + replica with right shape"
 helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
   --set "pg.activeHotStandby.enabled=true" \
+  --set "pg.activeHotStandby.promotion.mechanism=manual" \
   --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
   --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
   --set "database.cluster.instances=3" \
@@ -327,6 +328,7 @@ echo "  PASS"
 echo "[d31-render] Case 3: enabled with empty primaryRegion triggers fail-fast"
 if helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
      --set "pg.activeHotStandby.enabled=true" \
+     --set "pg.activeHotStandby.promotion.mechanism=manual" \
      --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
      > "$TMP/noprimary.yaml" 2> "$TMP/noprimary.err"; then
   echo "FAIL: render succeeded with empty pg.activeHotStandby.primaryRegion — should have failed fast." >&2
@@ -343,6 +345,7 @@ echo "  PASS"
 echo "[d31-render] Case 4: same primary/replica region triggers fail-fast"
 if helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
      --set "pg.activeHotStandby.enabled=true" \
+     --set "pg.activeHotStandby.promotion.mechanism=manual" \
      --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
      --set "pg.activeHotStandby.replicaRegion=hz-fsn-rtz-prod" \
      > "$TMP/sameregion.yaml" 2> "$TMP/sameregion.err"; then
@@ -360,6 +363,7 @@ echo "  PASS"
 echo "[d31-render] Case 5: clusterMesh.enabled=false omits managed.services.additional on primary"
 helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
   --set "pg.activeHotStandby.enabled=true" \
+  --set "pg.activeHotStandby.promotion.mechanism=manual" \
   --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
   --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
   --set "pg.activeHotStandby.clusterMesh.enabled=false" \
@@ -413,6 +417,7 @@ echo "  PASS"
 echo "[d31-render] Case 6: replication.mode=async omits synchronous_* parameters"
 helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
   --set "pg.activeHotStandby.enabled=true" \
+  --set "pg.activeHotStandby.promotion.mechanism=manual" \
   --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
   --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
   --set "pg.activeHotStandby.replication.mode=async" \
@@ -424,6 +429,93 @@ helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
 if grep -q "synchronous_commit\|synchronous_standby_names" "$TMP/async.yaml"; then
   echo "FAIL: replication.mode=async leaked synchronous_* parameters into the manifest." >&2
   grep -nE "synchronous_(commit|standby_names)" "$TMP/async.yaml" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 7: #5623 — the pair MUST declare what promotes its standby ──
+# hw292 G12 region-kill (2026-08-03): bp-cnpg-pair's region-B dr-promoter
+# promoted at T0+2m16s (RPO=0); every DR pair that shipped no region-local
+# promoter stayed pg_is_in_recovery()=t for the WHOLE outage. This chart is in
+# the second group — it renders a cross-region standby but ships no promoter and
+# no Continuum CR, and continuum-controller is region-A-only (it dies with the
+# region it would fail away from, #5137). So an UNDECLARED pair here is an "HA"
+# database whose standby nothing promotes, and before 0.4.23 it rendered
+# silently. Chart 0.4.23 fails closed instead.
+echo "[d31-render] Case 7a: enabled with NO promotion mechanism triggers fail-fast"
+if helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+     --set "pg.activeHotStandby.enabled=true" \
+     --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
+     --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
+     > "$TMP/nopromo.yaml" 2> "$TMP/nopromo.err"; then
+  echo "FAIL: render succeeded with no pg.activeHotStandby.promotion.mechanism — a DR pair that declares no promotion mechanism is one that silently never promotes (#5623)." >&2
+  exit 1
+fi
+if ! grep -q "pg.activeHotStandby.promotion.mechanism is REQUIRED" "$TMP/nopromo.err"; then
+  echo "FAIL: expected the #5623 fail-fast naming pg.activeHotStandby.promotion.mechanism:" >&2
+  cat "$TMP/nopromo.err" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# A mechanism this chart does NOT ship must fail closed. Declaring an
+# undelivered failover is worse than declaring none: it reads as a guarantee in
+# every audit that follows.
+for bogus in dr-promoter continuum nonsense; do
+  echo "[d31-render] Case 7b: mechanism=$bogus fails closed"
+  if helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+       --set "pg.activeHotStandby.enabled=true" \
+       --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
+       --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
+       --set "pg.activeHotStandby.promotion.mechanism=$bogus" \
+       > /dev/null 2> "$TMP/bogus-$bogus.err"; then
+    echo "FAIL: chart accepted mechanism=$bogus, which it does not ship (#5623)." >&2
+    exit 1
+  fi
+  echo "  PASS"
+done
+
+# Case 7c: the declared mechanism is stamped on the STANDBY Cluster CR, so an
+# operator can answer "who promotes this?" from the LIVE object during an
+# outage instead of from a values file in git. Asserted on the VALUE — a key
+# with an empty value is exactly how #5639 survived two months.
+echo "[d31-render] Case 7c: declared mechanism is stamped on the replica Cluster CR"
+helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+  --set "pg.activeHotStandby.enabled=true" \
+  --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
+  --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
+  --set "pg.activeHotStandby.promotion.mechanism=manual" \
+  > "$TMP/promo.yaml" 2> "$TMP/promo.err" || {
+  echo "FAIL: mechanism=manual render errored:" >&2
+  cat "$TMP/promo.err" >&2
+  exit 1
+}
+stamped="$(python3 - "$TMP/promo.yaml" <<'PYEOF'
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if d and d.get('kind') == 'Cluster':
+        ann = (d.get('metadata') or {}).get('annotations') or {}
+        if ann.get('catalyst.openova.io/cnpg-pair-role') == 'replica':
+            print(ann.get('catalyst.openova.io/dr-promotion-mechanism', ''))
+PYEOF
+)"
+if [ "$stamped" != "manual" ]; then
+  echo "FAIL: replica Cluster CR dr-promotion-mechanism annotation = '${stamped:-<absent>}', want 'manual' (#5623)." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# Case 7d: a SINGLETON install must stay byte-identical — no DR pair means no
+# declaration is required and none must leak into the render.
+echo "[d31-render] Case 7d: singleton render carries no promotion declaration"
+helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+  > "$TMP/singleton-promo.yaml" 2> "$TMP/singleton-promo.err" || {
+  echo "FAIL: singleton render errored — the #5623 declaration must not affect non-DR installs:" >&2
+  cat "$TMP/singleton-promo.err" >&2
+  exit 1
+}
+if grep -q "dr-promotion-mechanism" "$TMP/singleton-promo.yaml"; then
+  echo "FAIL: singleton render leaked the DR promotion annotation (#5623)." >&2
   exit 1
 fi
 echo "  PASS"

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -267,6 +267,33 @@ pg:
     # HA checkbox. With enabled=true both MUST be set AND differ.
     primaryRegion: ""
     replicaRegion: ""
+    # ── #5623 REQUIRED promotion declaration ───────────────────────────
+    # WHO PROMOTES THE STANDBY WHEN THE PRIMARY REGION DIES?
+    #
+    # On the hw292 G12 region-kill (2026-08-03) the pairs that shipped a
+    # region-local dr-promoter promoted in ~2 minutes; the pairs that shipped
+    # none stayed read-only for the entire outage — and nothing in their render
+    # distinguished the two. This chart is in the second group: it renders a
+    # cross-region standby (`replica.enabled: true` + pg_basebackup, see
+    # templates/cnpg-cluster.yaml) but ships NO dr-promoter and NO Continuum CR,
+    # and continuum-controller is region-A-only (dies with region-A; region-B
+    # carries neither the controller nor the Continuum CRD — verified live
+    # 2026-08-06 on hw292, both regions sampled).
+    #
+    # So the mechanism must be STATED, not assumed. Empty ⇒ the render FAILS.
+    #   manual       — the ONLY value this chart can honour today. Promotion is
+    #                  the sovereign-admin's RUNBOOKS §6.1 action; RTO = human
+    #                  response time, NOT the ~2min a promoter delivers.
+    #   dr-promoter  — fails closed: this chart ships no promoter and no
+    #                  `topology.promoted` HR-value promote seam.
+    #   continuum    — fails closed: no Continuum CR is rendered, and Continuum
+    #                  orchestrates a PLANNED switchover from region A only.
+    #
+    # The declared value is stamped on the standby Cluster CR as
+    # `catalyst.openova.io/dr-promotion-mechanism` so it is answerable from the
+    # live object. Making this automatic is tracked on #5623.
+    promotion:
+      mechanism: ""
     # WAL streaming + promotability threshold — mirrors bp-cnpg-pair
     # walStreaming defaults. Continuum K-Cont-2 reads these back from
     # the Cluster CR status before initiating cross-cluster switchover.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T22:02:23.260Z",
+  "generatedAt": "2026-08-05T23:28:53.809Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -5767,7 +5767,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/api/internal/handler/organization_active_hot_standby_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_active_hot_standby_test.go
@@ -201,3 +201,55 @@ func TestRenderOrganizationOverlay_HotStandby_Degenerate_FallsBackToSingle(t *te
 		})
 	}
 }
+
+// #5623 — the emitted HA block MUST declare what promotes the standby.
+//
+// On the hw292 G12 region-kill (2026-08-03) bp-cnpg-pair's region-B dr-promoter
+// promoted at T0+2m16s with RPO=0, while every DR pair that shipped no
+// region-local promoter stayed pg_is_in_recovery()=t for the entire outage.
+// bp-wordpress-tenant is in the second group: it renders a cross-region standby
+// but ships no promoter, and the per-Application Continuum CR this same writer
+// emits is reconciled by continuum-controller — a SINGLE region-A Deployment
+// that dies with the region it would fail away from (#5137; verified live on
+// hw292 2026-08-06, region-B carries neither the controller nor the Continuum
+// CRD) whose spec.autoFailover defaults to false.
+//
+// bp-wordpress-tenant 0.4.23+ therefore REFUSES to render an active-hot-standby
+// pair with no declared mechanism. This test is the lock on the writer side: if
+// the declaration is ever dropped from the template, every tenant WordPress
+// install on a multi-region Sovereign fails its Helm render instead of silently
+// shipping a standby nothing promotes. Asserting the VALUE, not the key — a key
+// with an empty value is exactly how #5639 survived two months.
+func TestRenderOrganizationOverlay_HotStandby_On_DeclaresPromotionMechanism(t *testing.T) {
+	t.Setenv("SOVEREIGN_ENABLE_HOT_STANDBY", "true")
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "hz-hel-rtz-prod")
+	files, err := renderOrganizationOverlay(d31TestRec(), OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	wp := files["bp-wordpress-tenant.yaml"]
+	if !strings.Contains(wp, "promotion:") {
+		t.Fatalf("#5623: HA overlay carries no pg.activeHotStandby.promotion block — "+
+			"bp-wordpress-tenant 0.4.23+ fails the render without it:\n%s", wp)
+	}
+	if !strings.Contains(wp, "mechanism: manual") {
+		t.Fatalf("#5623: HA overlay does not declare mechanism: manual. Only declare a "+
+			"mechanism this chart actually ships — \"dr-promoter\" and \"continuum\" fail "+
+			"closed in the chart precisely so an undelivered failover cannot be asserted:\n%s", wp)
+	}
+}
+
+// #5623 companion — a NON-HA overlay must not carry the declaration at all.
+// Single-region tenants render no DR pair, so a promotion mechanism there would
+// be a claim about a standby that does not exist.
+func TestRenderOrganizationOverlay_HotStandby_Off_NoPromotionMechanism(t *testing.T) {
+	t.Setenv("SOVEREIGN_ENABLE_HOT_STANDBY", "false")
+	files, err := renderOrganizationOverlay(d31TestRec(), OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if wp := files["bp-wordpress-tenant.yaml"]; strings.Contains(wp, "mechanism:") {
+		t.Fatalf("#5623: non-HA overlay leaked a promotion mechanism declaration:\n%s", wp)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1654,6 +1654,32 @@ spec:
         enabled: true
         primaryRegion: {{ .PrimaryRegion }}
         replicaRegion: {{ .ReplicaRegion }}
+        # #5623 — WHAT PROMOTES THIS STANDBY ON A REGION KILL. Required by
+        # bp-wordpress-tenant 0.4.23+: the chart refuses to render an
+        # active-hot-standby pair that has not stated its promotion mechanism,
+        # because an undeclared pair is one that silently never promotes (hw292
+        # G12: the pairs without a region-local promoter stayed
+        # pg_is_in_recovery()=t for the entire outage while bp-cnpg-pair's
+        # promoted in 2m16s).
+        #
+        # "manual" is the CORRECT value for this path today, and it is not a
+        # placeholder. The orgTenantContinuum CR rendered below is reconciled by
+        # continuum-controller, which is a SINGLE region-A Deployment — it dies
+        # with the region it would fail away from (the #5137 root cause;
+        # verified live on hw292 2026-08-06, region-B carries neither the
+        # controller nor the Continuum CRD) — and its spec.autoFailover defaults
+        # to false. So nothing promotes this standby automatically on an
+        # unplanned region-A loss; the sovereign-admin does, per RUNBOOKS §6.1.
+        # Declaring "continuum" here would assert a failover that cannot happen,
+        # which is why the chart fails closed on that value.
+        #
+        # Making this automatic means porting the proven bp-cnpg-pair /
+        # bp-postgres dr-promoter onto this chart, which needs a stable
+        # per-Application HelmRelease name for the actor's #5218 suspend latch.
+        # Tracked on #5623 — do NOT flip this to "dr-promoter" before that
+        # actor actually renders.
+        promotion:
+          mechanism: manual
 {{- end }}
 `
 

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5902,7 +5902,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.4.22",
+    "version": "0.4.23",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-postgres",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -62,7 +62,20 @@ spec:
   # hook pod fits the 4-CPU `plan-quota` headroom and actually schedules; the
   # 0.4.21 hook was rejected `exceeded quota: plan-quota` → never created → HR
   # timeout → no external HTTPRoute → host 404.
-  version: "0.4.22"
+  # #5623: →0.4.23 — the active-hot-standby pair must DECLARE what promotes its
+  # standby, and the render FAILS CLOSED without it. On hw292's G12 region-kill
+  # the DR pairs with no region-local promoter stayed read-only for the whole
+  # outage while bp-cnpg-pair's promoted in 2m16s; this chart renders the same
+  # standby shape with no promoter and no Continuum CR, and continuum-controller
+  # is region-A-only (dies with the region it would fail away from, #5137). New
+  # `pg.activeHotStandby.promotion.mechanism` — "manual" is the only value this
+  # chart can honour; "dr-promoter"/"continuum" fail closed so an undelivered
+  # failover cannot be asserted. The value is stamped on the standby Cluster CR
+  # as catalyst.openova.io/dr-promotion-mechanism. Singleton installs are
+  # byte-identical. Enforced catalog-wide by
+  # scripts/check-dr-pairs-declare-promotion.sh. Lockstep with
+  # platform/wordpress-tenant/blueprint.yaml + the bare-slug alias entry below.
+  version: "0.4.23"
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
@@ -91,7 +104,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.22"
+    version: "0.4.23"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/wordpress-tenant/blueprint.yaml. Uses {{.AppName}} so
   # multi-instance tenants get distinct hostnames per Application.
@@ -204,7 +217,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.4.22"
+  version: "0.4.23"
   visibility: listed
   card:
     title: "WordPress"
@@ -226,7 +239,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.22"
+    version: "0.4.23"
   # Lockstep with the bp-wordpress-tenant entry above + platform/wordpress-tenant/
   # blueprint.yaml. Same chart bytes; this is the bare-slug entrypoint only.
   topology:

--- a/scripts/check-dr-pairs-declare-promotion.sh
+++ b/scripts/check-dr-pairs-declare-promotion.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# #5623 CLASS GATE — every CNPG DR pair in this catalog must DECLARE, and
+# actually RENDER, the mechanism that promotes its standby on a region kill.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# THE DEFECT THIS EXISTS TO PREVENT
+# ---------------------------------
+# hw292 G12 region-kill, 2026-08-03, T0 = 20:01:27Z, hard os-stop of all four
+# region-A ECS. `bp-cnpg-pair`'s region-B dr-promoter did exactly what it was
+# built to do: primary loss at 20:01:45Z, 120s hold, PROMOTING at 20:03:43Z,
+# RPO=0, post-kill write accepted, zero operator action.
+#
+# The three `bp-postgres` shared-pg pairs did nothing. They render the IDENTICAL
+# split-side standby shape — same `replica.enabled: true`, same
+# `bootstrap.pg_basebackup`, same WAL stream over the same ClusterMesh `-mesh`
+# Service — but shipped no region-local promoter, so `shared-pg-replica`,
+# `shared-pg-b-replica` and `shared-pg-c-replica` each stayed
+# `pg_is_in_recovery() = t` for the WHOLE outage. keycloak is a shared-pg
+# consumer, so the auth path could not recover in region-B even in principle.
+#
+# Enumerating region-B Deployments during the outage returned exactly ONE DR
+# actor for FOUR pairs. Nothing in the source distinguished the pair that
+# promotes from the three that cannot: all four rendered valid YAML, all four
+# reported Ready, and the difference only became observable by killing a region.
+#
+# WHY A CATALOG-WIDE GATE AND NOT A PER-CHART TEST
+# ------------------------------------------------
+# bp-cnpg-pair's own render test asserted its promoter was present, and passed,
+# for every one of the months bp-postgres had none. A property proven in ONE
+# place and assumed fleet-wide is the exact shape of #5591 and of this issue.
+# So the gate ENUMERATES the catalog: any template that renders a CNPG standby
+# half is in scope, whether or not its author thought about failover.
+#
+# WHY THE ASSERTIONS LOOK LIKE THIS
+# ---------------------------------
+#   1. NEVER assert on a KEY. `grep -q dr-promoter` passes on a comment, and
+#      `grep -q 'name: PRIMARY_LIVENESS_ENABLED'` passes on an EMPTY value —
+#      that is #5639, where a guard read the key and missed a broken value for
+#      two months. Every positive case below pins the rendered VALUE.
+#   2. NEVER accept a promoter that would promote unsafely. #5178: a promoter
+#      that fires without a positive proof the primary region is gone
+#      false-promoted a healthy replica and ran the region-B timeline away
+#      (hw266, TL2→TL25). #5220: one that fires before it has ever observed
+#      steady-state streaming cements a convergence-time transient. So
+#      "declares dr-promoter" is only satisfied by a promoter that carries the
+#      positive-liveness gate AND the steady-state arm gate AND drives the
+#      HelmRelease desired state rather than patching a live Cluster CR
+#      (#5125-D1: a live patch is reverted by flux drift-correction mid-outage).
+#   3. Every dr-promoter case has a NEGATIVE twin that must NOT render the
+#      promoter (async replication — no synchronous data fence, so automatic
+#      promotion could fork committed data). A guard observed only passing is
+#      not yet known to be a guard, and a blanket "everything renders" cannot
+#      satisfy this gate.
+#
+# WHAT IT CHECKS
+# --------------
+#   Phase 1 (registry)  — enumerate every chart template in the repo that emits
+#                         a CNPG `bootstrap.pg_basebackup` stanza (the
+#                         structural signature of a standby half: a Cluster CR
+#                         that seeds itself from another Cluster). Each must be
+#                         registered below with its promotion mechanism. A NEW
+#                         unregistered one FAILS, so adding a DR pair forces the
+#                         author to state what promotes it. A registered file
+#                         that no longer emits one also FAILS, so the registry
+#                         cannot rot. A registered chart with no Phase-2 case
+#                         FAILS, so registering cannot become a rubber stamp.
+#   Phase 2 (behavior)  — render each registered chart and prove the declared
+#                         mechanism is the one it actually ships, both
+#                         directions. See each case for its specific claim.
+#
+# Usage: bash scripts/check-dr-pairs-declare-promotion.sh
+# Refs #5623 #5178 #5220 #5133 #5157 #5125 #5639
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+A="hz-fsn-rtz-prod"
+B="hz-hel-rtz-prod"
+
+fails=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() {
+  printf '  FAIL  %s\n' "$1"
+  fails=$((fails + 1))
+}
+
+# Chart deps must be vendored before `helm template` (bp-wordpress-tenant pulls
+# `common`). Same pattern the per-chart tests use.
+ensure_deps() {
+  local dir="$1"
+  if [ -f "$dir/Chart.yaml" ] && grep -q '^dependencies:' "$dir/Chart.yaml" 2>/dev/null; then
+    if [ ! -d "$dir/charts" ] || [ -z "$(ls -A "$dir/charts" 2>/dev/null)" ]; then
+      (cd "$dir" && helm dependency build >/dev/null 2>&1)
+    fi
+  fi
+}
+
+# env_value <file> <ENV_NAME> — the rendered VALUE of a container env var.
+# Reads the `value:` line that FOLLOWS `- name: <ENV_NAME>`, so an empty or
+# missing value is distinguishable from a present key (#5639).
+env_value() {
+  grep -A1 -E "^[[:space:]]*-[[:space:]]*name:[[:space:]]*$2[[:space:]]*$" "$1" \
+    | grep -E "^[[:space:]]*value:" | head -1 \
+    | sed -E 's/^[[:space:]]*value:[[:space:]]*//; s/^"//; s/"$//'
+}
+
+# promoter_deployments <file> — names of rendered Deployments whose name marks
+# them a DR promoter. Parsed as YAML, not grepped, so a comment mentioning
+# "dr-promoter" can never satisfy the assertion.
+promoter_deployments() {
+  python3 - "$1" <<'PYEOF'
+import sys, yaml
+try:
+    docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+except Exception as e:
+    print(f"__PARSE_ERROR__ {e}")
+    sys.exit(0)
+for d in docs:
+    if d.get('kind') == 'Deployment':
+        n = (d.get('metadata') or {}).get('name', '')
+        if 'dr-promoter' in n:
+            print(n)
+PYEOF
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# REGISTRY — every chart template that renders a CNPG standby half, and the
+# mechanism that promotes that standby when its source region dies.
+#
+# Format: <template path>|<chart dir>|<mechanism>
+#
+# Mechanisms:
+#   dr-promoter — a region-local Deployment in the SURVIVING region that
+#                 promotes automatically. The only mechanism that works on an
+#                 UNPLANNED region kill, because it is the only one that does
+#                 not depend on anything in the region that died.
+#   manual      — nothing region-local acts; promotion is the sovereign-admin's
+#                 RUNBOOKS §6.1 action. Honest, and the RTO is human response
+#                 time. Must be DECLARED by the chart so the gap is visible on
+#                 the live object, never inferred from an absent promoter.
+#
+# `continuum` is deliberately NOT an accepted mechanism for an unplanned kill:
+# continuum-controller is a single region-A Deployment (verified live on hw292
+# 2026-08-06, both regions sampled — region-B carries neither the controller nor
+# the Continuum CRD), and its Sequencer orchestrates a PLANNED switchover. It
+# dies with the region it is supposed to fail away from. That is the #5137 root
+# cause and precisely why bp-cnpg-pair grew its own promoter.
+# ─────────────────────────────────────────────────────────────────────────────
+REGISTRY="
+platform/cnpg-pair/chart/templates/replica-cluster.yaml|platform/cnpg-pair/chart|dr-promoter
+platform/cnpg-pair/chart/templates/primary-cluster.yaml|platform/cnpg-pair/chart|dr-promoter
+platform/postgres/chart/templates/replica-cluster.yaml|platform/postgres/chart|dr-promoter
+platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml|platform/wordpress-tenant/chart|manual
+"
+
+echo "══ Phase 1 — registry completeness ══"
+
+# Structural signature of a standby half: the CNPG `pg_basebackup` bootstrap
+# stanza. A Cluster CR that seeds itself from ANOTHER Cluster is one half of a
+# pair, and the other half is somewhere it can be lost.
+mapfile -t FOUND < <(
+  grep -rlE '^[[:space:]]*pg_basebackup:' --include='*.yaml' --include='*.tpl' \
+    platform products 2>/dev/null | sort
+)
+
+registered_paths="$(echo "$REGISTRY" | awk -F'|' 'NF{print $1}' | sort)"
+
+if [ "${#FOUND[@]}" -eq 0 ]; then
+  fail "detector matched ZERO templates — the pg_basebackup signature changed and
+        this gate is now vacuous. Fix the detector before trusting a green run."
+fi
+
+for f in "${FOUND[@]}"; do
+  if echo "$registered_paths" | grep -qxF "$f"; then
+    continue
+  fi
+  fail "UNREGISTERED DR pair: $f
+        This template renders a CNPG standby half (bootstrap.pg_basebackup).
+        Something must promote that standby when its source region dies, or the
+        database is read-only for the whole outage (#5623, hw292 G12). Add it to
+        REGISTRY in this script with its mechanism and add a Phase-2 case that
+        PROVES the mechanism renders."
+done
+
+for line in $REGISTRY; do
+  [ -z "$line" ] && continue
+  path="${line%%|*}"
+  if [ ! -f "$path" ]; then
+    fail "REGISTERED path does not exist: $path (registry rot — remove or fix it)"
+  elif ! grep -qE '^[[:space:]]*pg_basebackup:' "$path"; then
+    fail "REGISTERED path no longer renders a standby half: $path
+        It is registered as a DR pair but emits no bootstrap.pg_basebackup. If
+        the pair was removed, drop the registry line; if the shape changed, the
+        Phase-1 detector needs updating — do not leave a stale rubber stamp."
+  fi
+done
+
+# Every registered CHART must have a Phase-2 case. Registering without proving
+# is the rubber stamp this gate exists to prevent.
+registered_charts="$(echo "$REGISTRY" | awk -F'|' 'NF{print $2}' | sort -u)"
+CASED_CHARTS="platform/cnpg-pair/chart platform/postgres/chart platform/wordpress-tenant/chart"
+for c in $registered_charts; do
+  case " $CASED_CHARTS " in
+    *" $c "*) ;;
+    *) fail "REGISTERED chart has no Phase-2 behavior case: $c
+        A registry entry with nothing rendering it is a claim, not a proof. Add
+        a case below and list the chart in CASED_CHARTS." ;;
+  esac
+done
+
+[ "$fails" -eq 0 ] && pass "registry covers every standby-half renderer (${#FOUND[@]} template(s)), and every registered chart has a behavior case"
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo
+echo "══ Phase 2 — behavior ══"
+
+# assert_promoter_case <label> <render file> — the dr-promoter contract.
+# A promoter only counts if it is SAFE: #5178 positive-liveness gate, #5220
+# steady-state arm gate, #5125-D1 HelmRelease desired-state seam.
+assert_promoter_case() {
+  local label="$1" f="$2"
+  local deploys
+  deploys="$(promoter_deployments "$f")"
+  case "$deploys" in
+    __PARSE_ERROR__*) fail "$label: render did not parse as YAML — $deploys"; return ;;
+  esac
+  if [ -z "$deploys" ]; then
+    fail "$label: NO dr-promoter Deployment in the standby-side render.
+        This is the #5623 defect exactly: a standby that nothing region-local
+        will ever promote. Region-B held one DR actor for four pairs on hw292."
+    return
+  fi
+  pass "$label: renders a dr-promoter Deployment ($(echo "$deploys" | tr '\n' ' '))"
+
+  # #5178 — POSITIVE proof region-A is gone, not merely unreachable-from-
+  # replication. Asserted on the VALUE: the key renders either way (#5639).
+  local live; live="$(env_value "$f" PRIMARY_LIVENESS_ENABLED)"
+  if [ "$live" = "true" ]; then
+    pass "$label: #5178 positive region-A liveness gate ARMED (PRIMARY_LIVENESS_ENABLED=true)"
+  else
+    fail "$label: #5178 liveness gate not armed — PRIMARY_LIVENESS_ENABLED=${live:-<empty/absent>}, want \"true\".
+        With peer ClusterMesh names wired the promoter MUST positively probe the
+        primary before promoting; without it a link flap reads as a region death
+        and the promoter false-promotes (hw266 TL2→TL25, hw273)."
+  fi
+
+  # #5220 — ineligible to promote until continuous streaming has been OBSERVED.
+  local arm; arm="$(env_value "$f" STEADY_STATE_ARM_SECONDS)"
+  if [ -n "$arm" ] && [ "$arm" -gt 0 ] 2>/dev/null; then
+    pass "$label: #5220 steady-state arm gate set (STEADY_STATE_ARM_SECONDS=$arm)"
+  else
+    fail "$label: #5220 arm gate missing/zero — STEADY_STATE_ARM_SECONDS=${arm:-<empty/absent>}, want a positive integer.
+        A never-converged pair must never be promotable, else a convergence-time
+        transient is cemented by the suspend latch (hw273)."
+  fi
+
+  # #5125-D1 — the promote must ride the HelmRelease DESIRED state. A live
+  # Cluster-CR patch is reverted by flux drift-correction mid-outage (hw256).
+  local hr; hr="$(env_value "$f" HR_NAME)"
+  if [ -n "$hr" ]; then
+    pass "$label: #5125-D1 HelmRelease desired-state promote seam wired (HR_NAME=$hr)"
+  else
+    fail "$label: no HR_NAME — the promoter has no HelmRelease desired-state seam.
+        Promoting by patching the live Cluster CR is reverted by flux drift
+        correction mid-outage (#5125-D1, hw256 G12)."
+  fi
+}
+
+# assert_no_promoter <label> <render file> <why>
+assert_no_promoter() {
+  local label="$1" f="$2" why="$3"
+  local deploys; deploys="$(promoter_deployments "$f")"
+  if [ -z "$deploys" ]; then
+    pass "$label: no promoter rendered ($why)"
+  else
+    fail "$label: promoter rendered where it MUST NOT be ($why) — got: $(echo "$deploys" | tr '\n' ' ')"
+  fi
+}
+
+# ── bp-cnpg-pair — mechanism: dr-promoter ────────────────────────────────────
+# The reference implementation, green on hw292. This case is the VACUITY
+# CONTROL: it passes on the pre-#5675 tree AND on today's tree, so a blanket
+# failure (bad helm, bad detector, empty renders) cannot satisfy this gate.
+ensure_deps platform/cnpg-pair/chart
+if helm template dr platform/cnpg-pair/chart \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region="$A" \
+  --set cnpgPair.replica.region="$B" \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={peer-mesh}' \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/cnpg-pair-replica.yaml" 2>"$TMP/cnpg-pair-replica.err"; then
+  assert_promoter_case "bp-cnpg-pair side=replica" "$TMP/cnpg-pair-replica.yaml"
+else
+  fail "bp-cnpg-pair side=replica render errored: $(tail -2 "$TMP/cnpg-pair-replica.err")"
+fi
+
+# Negative twin — async has NO synchronous data fence, so an automatic promote
+# could fork committed data. The promoter must NOT render.
+if helm template dr platform/cnpg-pair/chart \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region="$A" \
+  --set cnpgPair.replica.region="$B" \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.replication.mode=async \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={peer-mesh}' \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/cnpg-pair-async.yaml" 2>/dev/null; then
+  assert_no_promoter "bp-cnpg-pair side=replica replication=async" "$TMP/cnpg-pair-async.yaml" \
+    "async has no synchronous fence — automatic promotion could fork committed data"
+else
+  fail "bp-cnpg-pair async render errored (expected a successful render with no promoter)"
+fi
+
+# ── bp-postgres — mechanism: dr-promoter (the three shared-pg pairs) ──────────
+# This case FAILS on the pre-#5675 tree (bp-postgres ≤0.2.17 shipped no
+# promoter) and PASSES from 0.2.18. It is the #5623 regression lock.
+ensure_deps platform/postgres/chart
+cat > "$TMP/pg-replica.values.yaml" <<YAML
+enabled: true
+instance: { name: shared-pg, namespace: shared-data }
+topology:
+  mode: active-hot-standby
+  side: replica
+  instances: 3
+  primary: { region: $A }
+  replica: { region: $B }
+  networkPolicy:
+    crossRegionPeerClusters: [peer-mesh]
+databases:
+  - name: keycloak
+    owner: keycloak
+    reflect: { secretName: keycloak-database-secret, namespaces: [keycloak] }
+YAML
+if helm template shared-pg platform/postgres/chart -f "$TMP/pg-replica.values.yaml" \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 \
+  > "$TMP/pg-replica.yaml" 2>"$TMP/pg-replica.err"; then
+  assert_promoter_case "bp-postgres side=replica (shared-pg)" "$TMP/pg-replica.yaml"
+else
+  fail "bp-postgres side=replica render errored: $(tail -2 "$TMP/pg-replica.err")"
+fi
+
+# Negative twin — async, same reasoning as bp-cnpg-pair.
+if helm template shared-pg platform/postgres/chart -f "$TMP/pg-replica.values.yaml" \
+  --set topology.replication.mode=async \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 \
+  > "$TMP/pg-async.yaml" 2>/dev/null; then
+  assert_no_promoter "bp-postgres side=replica replication=async" "$TMP/pg-async.yaml" \
+    "async has no synchronous fence — automatic promotion could fork committed data"
+else
+  fail "bp-postgres async render errored (expected a successful render with no promoter)"
+fi
+
+# ── bp-wordpress-tenant — mechanism: manual ──────────────────────────────────
+# This chart renders a cross-region standby but ships no promoter and no
+# Continuum CR. `manual` is honest; SILENCE is not. The gate therefore requires
+# the declaration to be (a) mandatory and (b) visible on the standby object.
+ensure_deps platform/wordpress-tenant/chart
+WP_BASE=(
+  --set smeDomain=t99.omani.works
+  --set keycloak.realmURL=https://kc.example/realms/x
+  --set keycloak.clientSecretName=wp-oidc
+  --set adminUser.email=admin@example.org
+  --set database.mode=active-hot-standby
+  --set pg.activeHotStandby.primaryRegion="$A"
+  --set pg.activeHotStandby.replicaRegion="$B"
+)
+
+# Negative FIRST — an undeclared pair must FAIL CLOSED. Before #5623 this
+# rendered happily and shipped a standby nothing would ever promote.
+if helm template wp platform/wordpress-tenant/chart "${WP_BASE[@]}" \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/wp-undeclared.yaml" 2>"$TMP/wp-undeclared.err"; then
+  fail "bp-wordpress-tenant: active-hot-standby rendered with NO promotion mechanism declared.
+        This is the #5623 defect on the customer-facing Blueprint: a paying
+        Organization gets an \"HA\" database whose standby nothing promotes, and
+        the render says nothing about it. The chart must fail closed."
+elif grep -q 'pg.activeHotStandby.promotion.mechanism' "$TMP/wp-undeclared.err"; then
+  pass "bp-wordpress-tenant: undeclared active-hot-standby FAILS CLOSED naming pg.activeHotStandby.promotion.mechanism"
+else
+  fail "bp-wordpress-tenant: undeclared render failed, but not with the promotion-mechanism error —
+        got: $(tail -2 "$TMP/wp-undeclared.err")"
+fi
+
+# Positive — the declaration renders, and is stamped on the STANDBY object so an
+# operator can answer "who promotes this?" from the live cluster, not from git.
+if helm template wp platform/wordpress-tenant/chart "${WP_BASE[@]}" \
+  --set pg.activeHotStandby.promotion.mechanism=manual \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/wp-manual.yaml" 2>"$TMP/wp-manual.err"; then
+  stamped="$(python3 - "$TMP/wp-manual.yaml" <<'PYEOF'
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if d and d.get('kind') == 'Cluster':
+        ann = (d.get('metadata') or {}).get('annotations') or {}
+        if ann.get('catalyst.openova.io/cnpg-pair-role') == 'replica':
+            print(ann.get('catalyst.openova.io/dr-promotion-mechanism', ''))
+PYEOF
+)"
+  if [ "$stamped" = "manual" ]; then
+    pass "bp-wordpress-tenant: standby Cluster CR stamped catalyst.openova.io/dr-promotion-mechanism=manual"
+  else
+    fail "bp-wordpress-tenant: standby not stamped with the declared mechanism — got '${stamped:-<absent>}', want 'manual'.
+        The declaration must be answerable from the live object; a values-file-only
+        claim is invisible to the operator during an outage."
+  fi
+  # A `manual` declaration that shipped a promoter would be a stale lie in the
+  # other direction — the registry would be describing a chart that no longer
+  # matches it.
+  assert_no_promoter "bp-wordpress-tenant mechanism=manual" "$TMP/wp-manual.yaml" \
+    "declared mechanism is manual — a promoter here would contradict the registry"
+else
+  fail "bp-wordpress-tenant mechanism=manual render errored: $(tail -2 "$TMP/wp-manual.err")"
+fi
+
+# A mechanism this chart cannot deliver must fail closed rather than assert a
+# failover that will not happen.
+for bogus in dr-promoter continuum; do
+  if helm template wp platform/wordpress-tenant/chart "${WP_BASE[@]}" \
+    --set pg.activeHotStandby.promotion.mechanism="$bogus" \
+    --api-versions postgresql.cnpg.io/v1 > /dev/null 2>"$TMP/wp-$bogus.err"; then
+    fail "bp-wordpress-tenant: accepted mechanism=$bogus, which it does not ship.
+        Declaring an undelivered mechanism is worse than declaring none — it
+        reads as a failover guarantee in every audit that follows."
+  else
+    pass "bp-wordpress-tenant: mechanism=$bogus fails closed (chart ships no such actor)"
+  fi
+done
+
+# ── singleton non-regression — the gate must not penalise non-DR installs ────
+if helm template wp platform/wordpress-tenant/chart \
+  --set smeDomain=t99.omani.works \
+  --set keycloak.realmURL=https://kc.example/realms/x \
+  --set keycloak.clientSecretName=wp-oidc \
+  --set adminUser.email=admin@example.org \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/wp-singleton.yaml" 2>/dev/null; then
+  if grep -q 'dr-promotion-mechanism' "$TMP/wp-singleton.yaml"; then
+    fail "bp-wordpress-tenant singleton leaked the DR promotion annotation (single-region installs must be byte-identical)"
+  else
+    pass "bp-wordpress-tenant singleton renders unchanged (no DR pair, no declaration required)"
+  fi
+else
+  fail "bp-wordpress-tenant singleton render errored — the #5623 declaration must not affect non-DR installs"
+fi
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "══ $fails failure(s) — a DR pair in this catalog cannot promote its standby ══"
+  exit 1
+fi
+echo "══ OK — every DR pair declares a promotion mechanism and renders it ══"

--- a/scripts/check-region-selector-fail-closed.sh
+++ b/scripts/check-region-selector-fail-closed.sh
@@ -256,14 +256,22 @@ if [ ! -f platform/wordpress-tenant/chart/charts/common-0.1.3.tgz ]; then
   fi
 fi
 if [ -d platform/wordpress-tenant/chart/charts ]; then
+  # #5623 — chart 0.4.23 additionally REQUIRES a declared promotion mechanism
+  # whenever the active-hot-standby pair renders (an undeclared DR pair is one
+  # that silently never promotes on a region kill). Supply it on BOTH legs so
+  # this gate keeps testing the REGION selector: without it the positive leg
+  # fails for the promotion reason and the negative leg passes for the promotion
+  # reason, which would make the region assertion vacuous in both directions.
   run_case "bp-wordpress-tenant" platform/wordpress-tenant/chart "$A" \
     --api-versions postgresql.cnpg.io/v1 \
     --set pg.activeHotStandby.enabled=true \
+    --set pg.activeHotStandby.promotion.mechanism=manual \
     --set pg.activeHotStandby.primaryRegion="$A" \
     --set pg.activeHotStandby.replicaRegion="$B" \
     --NEG-- \
     --api-versions postgresql.cnpg.io/v1 \
-    --set pg.activeHotStandby.enabled=true
+    --set pg.activeHotStandby.enabled=true \
+    --set pg.activeHotStandby.promotion.mechanism=manual
 fi
 
 # bp-catalyst-platform qa-fixtures — the sibling this sweep found still pinning


### PR DESCRIPTION
## #5623 was fixed in one place. This closes the class.

PR #5675 ported the proven `bp-cnpg-pair` dr-promoter onto `bp-postgres`, which closed the three shared-pg pairs. Nothing stopped the same defect from existing elsewhere in the catalog — and it did.

### Confirmed from code + live state

| Claim | Verdict | Evidence |
|---|---|---|
| Only `bp-cnpg-pair` ships a dr-promoter | **REFUTED as of today** | `platform/postgres/chart/templates/dr-promoter.yaml` exists — PR #5675 (`d2ee38f13`), bp-postgres 0.2.18 |
| hw292 region-B held exactly one DR actor | **CONFIRMED, still true live** | region-B `shared-data` has **zero** Deployments; `cnpg` holds only `cnpg-pair-bp-cnpg-pair-dr-promoter 1/1`. Region-B HRs still pin bp-postgres **0.2.16** — the 0.2.18 fix has not rolled to this env |
| Four DR pairs exist | **CONFIRMED** | region-A: `shared-pg`, `shared-pg-b`, `shared-pg-c`, `cnpg-pair-…-primary`. region-B: the three `*-replica` + `cnpg-pair-…-replica`. Both regions sampled |
| Continuum could be the mechanism | **REFUTED** | region-B has no `continuum-controller` Deployment **and not even the Continuum CRD** (`error: the server doesn't have a resource type "continuum"`). It is region-A-only and dies with the region it would fail away from — the #5137 root cause |
| A **fourth** chart has the same defect, unfixed | **FOUND** | `bp-wordpress-tenant` — see below |

### The residual: `bp-wordpress-tenant`

Enumerating the catalog by structural signature (`bootstrap.pg_basebackup`) returns **4 templates across 3 charts**, not 2. The third is `platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml`: it renders the identical cross-region standby (`replica.enabled: true` + `pg_basebackup` + `externalClusters`) and ships **neither a dr-promoter nor a Continuum CR**. The mechanism its own template comment names — "Continuum K-Cont-2" — is the region-A-only controller refuted above. `replica.enabled` is additionally hard-coded with no `topology.promoted` HR-value seam, so even a hand-patch of the live Cluster CR is reverted by flux drift-correction mid-outage (#5125-D1).

**This path is customer-facing.** `blueprint.yaml` exposes `database.mode: active-hot-standby` — its own description says *"the marketplace voucher → org wizard (D29) writes this field directly"* — the catalog tags WordPress `ha` + `cnpg-pair`, and catalyst-api's `organization_gitops` writer injects `pg.activeHotStandby` into every tenant HelmRelease on a multi-region Sovereign. A paying Organization ticking the HA box got a standby nothing would ever promote, silently. A UAT walker had already recorded the live shape on hw291 (`docs/sessions/2026-07-30/evidence/…`) without it being read as this class.

### Mechanism chosen, and what was deliberately NOT done

**Region-local `dr-promoter` Deployment** is the only mechanism that works on an unplanned kill, because it is the only one with no dependency on the region that died. Continuum is a *planned-switchover* orchestrator, single-region, `autoFailover` default false.

**I did not port a promoter onto `bp-wordpress-tenant`.** Per #5178 a promoter that fires without a real quorum/lease signal false-promotes and runs the timeline away (hw266, TL2→TL25). The proven actor latches durability by suspending a **named** HelmRelease, and this chart's HR is minted per-Application by the application-controller — there is no stable HR name at render time. That seam is a real design decision, not something to fabricate inline. Tracked on #5623.

What is shippable and correct today: **a DR pair that cannot state what promotes it does not render.**

- `pg.activeHotStandby.promotion.mechanism`, **required** whenever the pair renders. `manual` (operator-run, RUNBOOKS §6.1) is the only mechanism this chart delivers; `dr-promoter` and `continuum` **fail closed** naming exactly what is missing, so an undelivered failover cannot be asserted.
- The declared value is stamped on the **standby** Cluster CR as `catalyst.openova.io/dr-promotion-mechanism`, so an operator answers *"who promotes this?"* from the live object during an outage rather than from a values file in git.
- Singleton installs render byte-identical (no annotation, no declaration required).
- `organization_gitops.go` emits `mechanism: manual` on the HA path — without it the new fail-closed render would wedge every tenant WordPress install on a multi-region Sovereign — plus two writer regression tests.

### The guard, vacuity-checked both directions with real output

`scripts/check-dr-pairs-declare-promotion.sh` (+ CI workflow). Modelled on `check-region-selector-fail-closed.sh`:

- **Phase 1** enumerates every template emitting `bootstrap.pg_basebackup`. Unregistered → FAIL (a new DR pair cannot be added without stating what promotes it). Registered-but-no-longer-a-pair → FAIL. Registered-with-no-behavior-case → FAIL, so registering cannot become a rubber stamp. Detector-matches-zero → FAIL, so the gate cannot go vacuous silently.
- **Phase 2** proves the declared mechanism is the one actually shipped. A `dr-promoter` only counts if it carries the **#5178** positive-liveness gate, the **#5220** steady-state arm gate and the **#5125-D1** HelmRelease promote seam — each asserted on the rendered **VALUE**, never the key (a key with an empty value is how #5639 survived two months). Each has an **async negative twin** that must NOT render a promoter (async has no synchronous fence, so automatic promotion could fork committed data).

Run against three trees:

| Tree | Result |
|---|---|
| pre-PR#5675 (`d2ee38f13^`) | **5 FAIL** — `bp-postgres side=replica (shared-pg): NO dr-promoter Deployment in the standby-side render.` + the wordpress cases |
| `origin/main` (post-#5675, pre-this-PR) | **4 FAIL** — wordpress only; bp-postgres and bp-cnpg-pair PASS |
| this branch | **0 FAIL** |

The **bp-cnpg-pair block PASSES on all three trees** — the control that makes a blanket failure (bad helm, broken detector, empty renders) unable to satisfy the gate.

### Guards run

`check-dr-pairs-declare-promotion` OK · `check-region-selector-fail-closed` OK (its wordpress leg now supplies the mechanism on **both** legs — without that its region assertion would have gone vacuous in both directions) · `check-catalog-seed-lockstep` 68 checked / 0 fail · `check-bootstrap-kit-pin-sync` 67 pairs PASS (bp-wordpress-tenant is not a kit slot → 4 lockstep sites, not 5) · `helm lint` clean · all 4 wordpress chart render gates green (12 cases) · `go vet` + full `internal/handler` suite green (256s).

Lockstep at 0.4.23: `Chart.yaml` · `blueprint.yaml` `spec.version` · catalog-seed `spec.version` + `source.version` × 2 entries (canonical + bare-slug alias) · regenerated `blueprints.json` + `catalog.generated.ts` via `build-catalog.mjs`.

`ghcr-pin-existence` will fail structurally on the 0.4.23 bump until the chart publishes — expected, not chased.

### Also

`docs/RUNBOOKS.md` §6.1 gains the per-pair region-kill assertion the next walker needs: which pairs must promote, within what RTO, and how to observe it — including that **region-B must hold four `*-dr-promoter` Deployments during the outage, not one.** A walk that samples only the cnpg-pair line reports Pillar 3 green on a Sovereign whose platform databases are all read-only. That is precisely how this survived.

### Scope

Repo-only. No live cluster mutated, no region-kill performed; all live evidence above is read-only `kubectl get`. **#5623 stays open** — merged is not delivered. Runtime proof is owed on the next 2-region G12 walk: the three shared-pg standbys promoting on a real region-A kill (bp-postgres ≥0.2.18 has never been region-killed), and this pair's `manual` RTO measured rather than assumed.

Refs #5623 #5178 #5220 #5133 #5157 #5125 #5137 #5639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
