### PR TITLE
fix(console): guard the catalog per-field save against silently blanking stored values (Refs #5610)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.blank-guard-5610.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.blank-guard-5610.test.ts
@@ -1,0 +1,196 @@
+/**
+ * commerce.api.blank-guard-5610.test.ts — #5610 seatbelt: a per-field catalog
+ * Save must not silently replace a NON-EMPTY stored value with an empty one.
+ *
+ * Why this guard lives at the API seam and not only in the editor
+ * ──────────────────────────────────────────────────────────────
+ * #5610 facet A was the summary inline editor opening BLANK over a non-empty
+ * summary — one Save away from writing "" over it. The pre-fill itself is
+ * fixed (CatalogDetail.tsx `summaryDraft`), but a guard built on the editor's
+ * own idea of "the current value" would be reading the exact prop that was
+ * wrong, so it would be blind in precisely the case it exists for. This guard
+ * compares the patch against the STORED ROW that saveCatalogEdit already
+ * fetches for its merge base — an independent source that holds even if the
+ * pre-fill regresses.
+ *
+ * The wipe is REAL, not theoretical. `Store.UpdateApp` `$set`s every column
+ * (core/services/catalog/store/store.go:301), so an empty tagline zeroes the
+ * stored one. The catalyst-api read path happens to MASK it on the page the
+ * operator wiped it from — `overlayCatalogEdits` overlays only a non-empty
+ * tagline (catalog_overlay.go:112) and the git leg uses `setIfNonEmpty`
+ * (catalog_edit_blueprint_yaml.go:75) — but the raw store column is what the
+ * Organization console (core/console/src/lib/api.ts:239) and the customer
+ * storefront (core/marketplace/src/lib/api.ts:164) render.
+ *
+ * The guard is a CONFIRMATION, never a ban — deliberate clearing must stay
+ * possible (store.go:307 calls out clearing a theme-icon override by name).
+ * Both directions are pinned below.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { saveCatalogEdit } from './commerce.api'
+
+interface Call {
+  url: string
+  method: string
+  body: Record<string, unknown> | null
+}
+
+const calls: Call[] = []
+const storeRows: { value: Array<Record<string, unknown>> } = { value: [] }
+
+/** A stored row whose card fields are all NON-EMPTY — every one of them is
+ *  something an empty save would destroy. */
+const STORED_ROW = {
+  id: 'b6ac3a3b-0000-4000-8000-000000000000',
+  slug: 'alloy',
+  name: 'Alloy',
+  tagline: 'Unified node agent for logs, metrics, and traces',
+  icon_light: '/component-logos/alloy.svg',
+  icon_dark: '/component-logos/alloy-dark.svg',
+  supported_topologies: ['singleton'],
+  published: true,
+}
+
+const IAC_SEED = {
+  name: 'Alloy',
+  tagline: 'Unified node agent for logs, metrics, and traces',
+  supported_topologies: ['singleton'],
+  icon_light: '',
+  icon_dark: '',
+}
+
+function jsonRes(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as unknown as Response)
+}
+
+beforeEach(() => {
+  calls.length = 0
+  storeRows.value = [{ ...STORED_ROW }]
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+    let body: Record<string, unknown> | null = null
+    if (typeof init?.body === 'string') body = JSON.parse(init.body) as Record<string, unknown>
+    calls.push({ url, method, body })
+    if (url.includes('/org/commerce/apps') && method === 'GET') return jsonRes(storeRows.value)
+    return jsonRes({ stored: true, committed: true, store: body })
+  }) as typeof fetch
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/** Every write (PUT/POST) the save issued — the list GET is not a write. */
+function writes(): Call[] {
+  return calls.filter((c) => c.method === 'PUT' || c.method === 'POST')
+}
+
+describe('saveCatalogEdit — blank-write seatbelt (#5610)', () => {
+  it('REFUSES a summary save that would blank a non-empty stored tagline — nothing reaches the wire', async () => {
+    const verdict = await saveCatalogEdit('bp-alloy', { tagline: '' }, IAC_SEED)
+
+    // The refusal is reported…
+    expect(verdict.blanked).toEqual([
+      { key: 'tagline', current: 'Unified node agent for logs, metrics, and traces' },
+    ])
+    expect(verdict.stored).toBe(false)
+    // …and — the whole point — NO write was issued. A refusal that still PUT
+    // would be theater.
+    expect(writes()).toHaveLength(0)
+    // Non-vacuity: the guard ran against a row it actually fetched.
+    expect(calls.filter((c) => c.method === 'GET')).toHaveLength(1)
+  })
+
+  it('whitespace-only is blank too — "   " does not sneak the wipe past the guard', async () => {
+    const verdict = await saveCatalogEdit('bp-alloy', { tagline: '   ' }, IAC_SEED)
+    expect(verdict.blanked?.[0].key).toBe('tagline')
+    expect(writes()).toHaveLength(0)
+  })
+
+  it('holds even when the caller believes the current value is empty (the pre-fill-regression case)', async () => {
+    // Simulates exactly the #5610 facet-A shape: the page thinks the summary
+    // is "" (a blank editor), so its create-seed carries "" too, and the patch
+    // is an innocent-looking empty tagline. The stored row still has the text.
+    // A guard keyed on the caller's own view would wave this through.
+    const verdict = await saveCatalogEdit('bp-alloy', { tagline: '' }, { ...IAC_SEED, tagline: '' })
+    expect(verdict.blanked?.[0].current).toBe('Unified node agent for logs, metrics, and traces')
+    expect(writes()).toHaveLength(0)
+  })
+
+  it('reports EVERY column a multi-key patch would blank (the icon pair)', async () => {
+    const verdict = await saveCatalogEdit('bp-alloy', { icon_light: '', icon_dark: '' }, IAC_SEED)
+    expect(verdict.blanked?.map((f) => f.key)).toEqual(['icon_light', 'icon_dark'])
+    expect(writes()).toHaveLength(0)
+  })
+
+  it('clearing the whole topology set is guarded as well', async () => {
+    const verdict = await saveCatalogEdit('bp-alloy', { supported_topologies: [] }, IAC_SEED)
+    expect(verdict.blanked).toEqual([{ key: 'supported_topologies', current: 'singleton' }])
+    expect(writes()).toHaveLength(0)
+  })
+
+  /* ── The other direction: the guard must not break real editing ──────── */
+
+  it('NEGATIVE CASE — a confirmed clear still writes the empty value through', async () => {
+    // store.go:307 documents clearing a theme-icon override as a supported
+    // operation. The seatbelt costs a confirmation, it does not remove the
+    // capability — if this fails, the "fix" is a blanket block.
+    const verdict = await saveCatalogEdit(
+      'bp-alloy',
+      { icon_light: '' },
+      IAC_SEED,
+      { allowBlank: ['icon_light'] },
+    )
+    expect(verdict.blanked).toBeUndefined()
+    expect(verdict.stored).toBe(true)
+    const put = writes()
+    expect(put).toHaveLength(1)
+    expect(put[0].method).toBe('PUT')
+    // The empty value genuinely reached the store…
+    expect(put[0].body!.icon_light).toBe('')
+    // …and #5510 still holds: the untouched siblings kept their stored values.
+    expect(put[0].body!.tagline).toBe('Unified node agent for logs, metrics, and traces')
+    expect(put[0].body!.name).toBe('Alloy')
+  })
+
+  it('NEGATIVE CASE — confirming ONE column does not license blanking another', async () => {
+    const verdict = await saveCatalogEdit(
+      'bp-alloy',
+      { icon_light: '', icon_dark: '' },
+      IAC_SEED,
+      { allowBlank: ['icon_light'] },
+    )
+    expect(verdict.blanked?.map((f) => f.key)).toEqual(['icon_dark'])
+    expect(writes()).toHaveLength(0)
+  })
+
+  it('an ordinary non-empty edit is untouched by the guard — single call, still writes', async () => {
+    const verdict = await saveCatalogEdit('bp-alloy', { tagline: 'Edited by the walk' }, IAC_SEED)
+    expect(verdict.blanked).toBeUndefined()
+    expect(writes()).toHaveLength(1)
+    expect(writes()[0].body!.tagline).toBe('Edited by the walk')
+  })
+
+  it('clearing a column that is ALREADY empty is not a wipe — no confirmation demanded', async () => {
+    storeRows.value = [{ ...STORED_ROW, icon_dark: '' }]
+    const verdict = await saveCatalogEdit('bp-alloy', { icon_dark: '' }, IAC_SEED)
+    expect(verdict.blanked).toBeUndefined()
+    expect(writes()).toHaveLength(1)
+  })
+
+  it('the CREATE path (no stored row) is never guarded — there is nothing to lose', async () => {
+    storeRows.value = []
+    const verdict = await saveCatalogEdit('bp-alloy', { tagline: '' }, IAC_SEED)
+    expect(verdict.blanked).toBeUndefined()
+    const post = writes()
+    expect(post).toHaveLength(1)
+    expect(post[0].method).toBe('POST')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.partial-patch-5510.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.partial-patch-5510.test.ts
@@ -169,7 +169,16 @@ describe('saveCatalogEdit — partial patch, stored row is the merge base (#5510
   it('an explicitly CLEARED field is written as empty (undefined ≠ empty string)', async () => {
     storeRows.value = [{ ...NAMEPROOF_ROW }]
 
-    await saveCatalogEdit('bp-alloy', { icon_light: '' }, IAC_SEED)
+    // #5610 — clearing a NON-EMPTY stored value now needs the operator's
+    // explicit confirmation, carried as `allowBlank`. The #5510 contract this
+    // test exists for is unchanged and still asserted below: present-but-empty
+    // is a real edit that reaches the store, and it must not drag siblings
+    // with it. What changed is that the intent must be stated, so a blank
+    // editor can no longer wipe a value by accident (see
+    // `commerce.api.blank-guard-5610.test.ts` for the refusal side).
+    await saveCatalogEdit('bp-alloy', { icon_light: '' }, IAC_SEED, {
+      allowBlank: ['icon_light'],
+    })
 
     const sent = mutation().body!
     // Present-but-empty means "the operator cleared it" — it must reach the

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
@@ -214,6 +214,86 @@ function toStoreColumns(patch: CatalogEntryPatch): Partial<CommerceApp> {
   return columns
 }
 
+/* ── #5610 — the blank-write seatbelt ──────────────────────────────────
+ *
+ * A per-field save that carries `""` for a column the store currently holds
+ * NON-EMPTY is a data-destroying write. `Store.UpdateApp` `$set`s every
+ * column unconditionally (core/services/catalog/store/store.go:301
+ * `{Key: "tagline", Value: app.Tagline}`), so an empty tagline zeroes the
+ * stored one. The catalyst-api read path masks that on the sovereign-admin
+ * catalog page — `overlayCatalogEdits` only overlays a NON-empty tagline
+ * (catalog_overlay.go:112) and the git leg uses `setIfNonEmpty`
+ * (catalog_edit_blueprint_yaml.go:75) — but the raw store column is what the
+ * Organization console and the customer storefront render
+ * (core/console/src/lib/api.ts:239, core/marketplace/src/lib/api.ts:164),
+ * so the loss is real and user-visible; it is simply invisible from the page
+ * the operator wiped it on.
+ *
+ * This guard is deliberately placed HERE and not only in the editor. The
+ * editor's own notion of "the current value" is the very prop that #5610
+ * facet A got wrong — a guard built on it would be blind in exactly the case
+ * it exists for. The authoritative stored row is fetched on the save path
+ * anyway (`listApps()` for the merge base), so comparing against it costs
+ * nothing and holds even if the editor's pre-fill regresses again.
+ *
+ * It is a CONFIRMATION gate, not a ban: clearing a field is legitimate (the
+ * store comments at store.go:307 call out clearing a theme-icon override
+ * explicitly). The caller re-issues the save with the field named in
+ * `allowBlank` once a human has confirmed.
+ *
+ * The refusal is reported on the RETURN verdict (`blanked`) rather than
+ * thrown: the editor reads it across a module boundary that component tests
+ * replace with `vi.mock`, where a thrown class identity would not survive.
+ * Ignoring it fails CLOSED — `stored:false` and nothing reached the wire.
+ */
+
+/** Why a `blanked` verdict carries `stored:false` — shown if a caller
+ *  surfaces `reason` without handling `blanked` explicitly. */
+export const BLANKED_REASON = 'clearing a non-empty stored value needs confirmation'
+
+/** One column an edit would clear, with the value that would be lost. */
+export interface BlankedField {
+  key: keyof CatalogEntryEdit
+  /** The value currently stored — so the UI can name what is at stake. */
+  current: string
+}
+
+/** The columns `patch` would clear on `stored`. Empty when the patch clears
+ *  nothing, clears something already empty, or touches no clearable key. */
+function blankedFields(patch: CatalogEntryPatch, stored: CommerceApp): BlankedField[] {
+  const out: BlankedField[] = []
+  const trimmed = (v: unknown) => (typeof v === 'string' ? v.trim() : '')
+  const check = (key: keyof CatalogEntryEdit, next: string | undefined, cur: unknown) => {
+    if (next === undefined) return // untouched key — nothing to lose
+    if (trimmed(next) !== '') return // still carries a value
+    const before = trimmed(cur)
+    if (before === '') return // already empty — clearing loses nothing
+    out.push({ key, current: before })
+  }
+  check('name', patch.name, stored.name)
+  check('tagline', patch.tagline, stored.tagline)
+  check('icon_light', patch.icon_light, stored.icon_light)
+  check('icon_dark', patch.icon_dark, stored.icon_dark)
+  if (
+    patch.supported_topologies !== undefined &&
+    patch.supported_topologies.length === 0 &&
+    (stored.supported_topologies?.length ?? 0) > 0
+  ) {
+    out.push({
+      key: 'supported_topologies',
+      current: (stored.supported_topologies ?? []).join(', '),
+    })
+  }
+  return out
+}
+
+/** Options for {@link saveCatalogEdit}. */
+export interface SaveCatalogEditOptions {
+  /** Columns the operator has EXPLICITLY confirmed clearing (#5610). A
+   *  column not named here is refused rather than blanked. */
+  allowBlank?: readonly string[]
+}
+
 /**
  * CatalogSaveVerdict — the #3668/#5113 dual-write verdict for one catalog
  * card-save. The catalyst-api `apps` create/update proxy wraps the upstream
@@ -231,6 +311,13 @@ export interface CatalogSaveVerdict {
   stored: boolean
   committed: boolean | null
   reason?: string
+  /**
+   * #5610 — present ONLY when the save was REFUSED before reaching the wire
+   * because it would have cleared these non-empty stored columns. Nothing
+   * was written (`stored:false`); re-issue with `allowBlank` naming the keys
+   * once a human has confirmed the clear.
+   */
+  blanked?: BlankedField[]
 }
 
 /** parseCatalogEditEnvelope — fold a commerce `apps` write response body
@@ -288,15 +375,22 @@ export function parseCatalogEditEnvelope(body: unknown, slug: string): CatalogSa
  * surfaces "Saved to IaC ✓" vs "Saved to store — IaC commit failed: …"
  * instead of closing silently.
  *
+ * #5610 — a patch key that would CLEAR a non-empty stored column returns a
+ * `blanked` verdict WITHOUT writing, unless the column is named in
+ * `opts.allowBlank` (the operator confirmed the clear). See the seatbelt
+ * commentary above `BlankedField`.
+ *
  * @param slug       catalog entry id (`bp-`-prefixed or bare).
  * @param patch      ONLY the fields this save edits (#5510).
  * @param createSeed values to seed a brand-new store row with, used ONLY
  *                  when no row exists yet. Never applied over a stored value.
+ * @param opts       #5610 blank-write confirmation.
  */
 export async function saveCatalogEdit(
   slug: string,
   patch: CatalogEntryPatch,
   createSeed: CatalogEntryPatch = {},
+  opts: SaveCatalogEditOptions = {},
 ): Promise<CatalogSaveVerdict> {
   const bare = slug.replace(/^bp-/, '')
   const columns = toStoreColumns(patch)
@@ -304,6 +398,16 @@ export async function saveCatalogEdit(
   const existing = apps.find((a) => (a.slug ?? '').replace(/^bp-/, '') === bare)
 
   if (existing && existing.id) {
+    // #5610 — refuse a write that would clear a non-empty stored column
+    // before it reaches the wire. Checked against `existing` (the
+    // authoritative row we already fetched for the merge base), never
+    // against anything the editor believes the current value to be.
+    const confirmed = opts.allowBlank ?? []
+    const blanked = blankedFields(patch, existing).filter((f) => !confirmed.includes(f.key))
+    if (blanked.length > 0) {
+      return { slug: bare, stored: false, committed: false, blanked, reason: BLANKED_REASON }
+    }
+
     // Overlay the edited keys onto the full runtime row: the untouched
     // columns keep their STORED values through the full-$set UpdateApp.
     const merged: CommerceApp = { ...existing, ...columns }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.iac-baseline-5610.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.iac-baseline-5610.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * CatalogDetail.iac-baseline-5610.test.tsx — #5610 facet B lock-in.
+ *
+ * Reported: after a SUCCESSFUL "Commit IaC", the catalog Edit-IaC editor still
+ * shows "• unsaved changes" right next to its own "Committed to IaC ✓"
+ * message, and "Commit IaC" stays enabled inviting a redundant re-commit of
+ * identical bytes. It only clears on a full page reload.
+ *
+ * Mechanism: YamlEditor's dirty state is `yaml.trim() !== initial.trim()`
+ * (YamlEditor.tsx:213) and `initial` is a `useMemo` over the `seedYaml` prop
+ * (:185). CatalogDetail owns that prop (`committedIac`). If the just-committed
+ * bytes are not fed back as the new seed, the baseline stays at the PRE-commit
+ * file forever and `dirty` can never go false.
+ *
+ * The fix landed in CatalogDetail (`setCommittedIac(yaml)` in `onCommit`) with
+ * no test, so this file pins both halves of the chain — deliberately, because
+ * either half alone is token-passing:
+ *
+ *   PART 1 (here) — CatalogDetail re-baselines: after a successful commit the
+ *            props it hands YamlEditor carry the just-committed YAML as
+ *            `seedYaml`, and after a FAILED one they do not.
+ *   PART 2 (widgets/cloud-list/YamlEditor.baseline-5610.test.tsx) — that seed
+ *            is genuinely what clears the pill, asserted against the REAL
+ *            widget. Separate file because the two halves need opposite mock
+ *            states for the same module.
+ *
+ * Part 1 without part 2 would assert a prop nobody proved matters; part 2
+ * without part 1 would assert a widget nobody proved is wired that way.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { YamlEditorProps } from '@/widgets/cloud-list/YamlEditor'
+
+const adminHolder = { value: true }
+vi.mock('@/shared/lib/useCatalogAdmin', () => ({
+  useCatalogAdmin: () => adminHolder.value,
+}))
+
+/** Records every props object CatalogDetail hands the editor, and drives the
+ *  REAL `onCommit` with a chosen buffer — the same path "Commit IaC" takes. */
+const yamlEditorRenders: YamlEditorProps[] = []
+const committedBuffer = { value: '' }
+vi.mock('@/widgets/cloud-list/YamlEditor', () => ({
+  YamlEditor: (props: YamlEditorProps) => {
+    yamlEditorRenders.push(props)
+    return (
+      <div data-testid="mock-yaml-editor">
+        <pre data-testid="mock-yaml-editor-seed">{props.seedYaml ?? '(no seedYaml)'}</pre>
+        <button
+          type="button"
+          data-testid="mock-yaml-editor-commit"
+          onClick={() => {
+            // The real YamlEditor catches a throwing onCommit into its
+            // `applyError` panel; mirror that so a failed-commit case does not
+            // surface as an unhandled rejection.
+            void props.onCommit?.(committedBuffer.value)?.catch(() => {})
+          }}
+        >
+          Commit
+        </button>
+      </div>
+    )
+  },
+}))
+
+import { CatalogDetail } from './CatalogDetail'
+
+const CATALOG = {
+  name: 'alloy',
+  version: '1.0.2',
+  card: { title: 'Alloy', summary: 'Unified node agent' },
+  origin: 'upstream',
+  source: 'gitea',
+  raw: { metadata: { name: 'bp-alloy' }, spec: { version: '1.0.2' } },
+}
+
+/** The file as committed BEFORE this edit. */
+const COMMITTED_YAML = [
+  'apiVersion: catalyst.openova.io/v1',
+  'kind: Blueprint',
+  'metadata:',
+  '  name: bp-alloy',
+  'spec:',
+  '  version: 1.0.2',
+  '',
+].join('\n')
+
+/** The operator's one-line edit (the issue's exact 1.0.2 → 1.0.3 walk). */
+const EDITED_YAML = COMMITTED_YAML.replace('version: 1.0.2', 'version: 1.0.3')
+
+function jsonRes(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response)
+}
+
+function installFetch() {
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+    if (url.includes('/iac')) {
+      if (method === 'PUT') {
+        return jsonRes({
+          slug: 'alloy',
+          path: 'catalog-sovereign/bp-alloy/blueprint.yaml',
+          committed: true,
+        })
+      }
+      return jsonRes({
+        blueprintYaml: COMMITTED_YAML,
+        path: 'catalog-sovereign/bp-alloy/blueprint.yaml',
+      })
+    }
+    if (url.includes('/instances')) return jsonRes({ items: [] })
+    if (url.includes('/catalog/')) return jsonRes(CATALOG)
+    return jsonRes({})
+  }) as typeof fetch
+}
+
+function renderCatalog() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const catalogRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/catalog/$blueprintName',
+    component: CatalogDetail,
+  })
+  const tree = rootRoute.addChildren([catalogRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/catalog/alloy'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  adminHolder.value = true
+  yamlEditorRenders.length = 0
+  committedBuffer.value = EDITED_YAML
+  installFetch()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('#5610 facet B — PART 1: CatalogDetail re-baselines the editor on a successful commit', () => {
+  it('feeds the just-committed YAML back as seedYaml', async () => {
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('catalog-detail-edit-iac'))
+    // Non-vacuity: the editor first opens on the PRE-edit committed file.
+    await waitFor(() =>
+      expect(screen.getByTestId('mock-yaml-editor-seed').textContent).toContain('version: 1.0.2'),
+    )
+
+    fireEvent.click(screen.getByTestId('mock-yaml-editor-commit'))
+
+    // The baseline moved to the bytes that were just committed.
+    await waitFor(() =>
+      expect(screen.getByTestId('mock-yaml-editor-seed').textContent).toContain('version: 1.0.3'),
+    )
+    expect(yamlEditorRenders[yamlEditorRenders.length - 1].seedYaml).toBe(EDITED_YAML)
+  })
+
+  it('does NOT re-baseline when the commit did not land', async () => {
+    // A failed commit must leave the operator's edit flagged as unsaved —
+    // re-baselining on failure would be the #5113-facet-D fabricated-green
+    // defect in a new place.
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = (init?.method ?? 'GET').toUpperCase()
+      if (url.includes('/iac') && method === 'PUT') {
+        return jsonRes({ slug: 'alloy', committed: false, reason: 'gitea unreachable' })
+      }
+      if (url.includes('/iac')) return jsonRes({ blueprintYaml: COMMITTED_YAML })
+      if (url.includes('/instances')) return jsonRes({ items: [] })
+      if (url.includes('/catalog/')) return jsonRes(CATALOG)
+      return jsonRes({})
+    }) as typeof fetch
+
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('catalog-detail-edit-iac'))
+    await waitFor(() =>
+      expect(screen.getByTestId('mock-yaml-editor-seed').textContent).toContain('version: 1.0.2'),
+    )
+    fireEvent.click(screen.getByTestId('mock-yaml-editor-commit'))
+
+    await waitFor(() => expect(yamlEditorRenders.length).toBeGreaterThan(1))
+    expect(yamlEditorRenders[yamlEditorRenders.length - 1].seedYaml).toBe(COMMITTED_YAML)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.blank-guard-5610.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.blank-guard-5610.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * CatalogInlineField.blank-guard-5610.test.tsx — #5610 facet A, the editor half.
+ *
+ * The reported defect: the summary inline editor opened EMPTY over a non-empty
+ * summary. An empty box is one careless Save away from destroying the stored
+ * value — and that save really does land (see
+ * `commerce.api.blank-guard-5610.test.ts`, which pins the wire behaviour).
+ *
+ * Two independent properties are pinned here, deliberately not one:
+ *
+ *   1. PRE-FILL + RE-SYNC — the editor opens on the current value, and the
+ *      draft tracks that value when it arrives or changes AFTER mount. The
+ *      original bug is the classic stale-initial-state trap: `useState(prop)`
+ *      captures the first value forever. Pinning only "opens pre-filled on a
+ *      value that was already there at mount" would miss the async case
+ *      entirely.
+ *
+ *   2. THE SEATBELT — a save that would blank a non-empty stored value is
+ *      refused and confirmed, not silently performed. This must hold
+ *      INDEPENDENTLY of (1): if the pre-fill regresses, the seatbelt is the
+ *      only thing between a blank box and data loss.
+ *
+ * And the direction that keeps the fix honest: deliberately clearing a field
+ * must remain possible. A guard that satisfies (2) by making clearing
+ * impossible has broken the feature, not fixed it.
+ *
+ * These exercise CatalogInlineField directly (not through CatalogDetail) so
+ * the editor's own contract is what is asserted, with the commerce seam
+ * mocked at the module boundary.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import type { BlankedField, CatalogSaveVerdict } from '@/lib/commerce.api'
+
+/** The mocked commerce seam. Default: an ordinary durable save. */
+const saveSpy = vi.fn(
+  (
+    slug: string,
+    patch: Record<string, unknown>,
+    seed: Record<string, unknown> | undefined,
+    opts: { allowBlank?: readonly string[] } | undefined,
+  ): Promise<CatalogSaveVerdict> => {
+    void slug
+    void patch
+    void seed
+    void opts
+    return Promise.resolve({ slug: 'wordpress', stored: true, committed: true })
+  },
+)
+vi.mock('@/lib/commerce.api', () => ({
+  saveCatalogEdit: (
+    slug: string,
+    patch: Record<string, unknown>,
+    seed: Record<string, unknown> | undefined,
+    opts: { allowBlank?: readonly string[] } | undefined,
+  ) => saveSpy(slug, patch, seed, opts),
+}))
+
+import { CatalogInlineField } from './CatalogInlineField'
+
+const SEED = {
+  name: 'WordPress',
+  tagline: 'Website and blog platform',
+  supported_topologies: ['singleton'],
+  icon_light: '',
+  icon_dark: '',
+}
+
+/**
+ * Renders the summary field with an EXTERNALLY controllable current value, so
+ * a test can make the value arrive after mount the way an async catalog fetch
+ * does. `onValue` hands the setter back to the test.
+ */
+function renderSummaryField(initialValue: string, onValue: (set: (v: string) => void) => void) {
+  function Harness() {
+    const [value, setValue] = useState(initialValue)
+    onValue(setValue)
+    return (
+      <CatalogInlineField<string>
+        blueprintId="bp-wordpress"
+        fieldKey="summary"
+        label="Summary"
+        createSeed={SEED}
+        editable
+        initialDraft={value}
+        renderDisplay={() => <span data-testid="summary-display">{value}</span>}
+        renderEditor={(draft, setDraft) => (
+          <textarea
+            data-testid="cif-summary-input"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+        )}
+        toPatch={(draft) => ({ tagline: draft.trim() })}
+        onSaved={() => {}}
+      />
+    )
+  }
+  return render(<Harness />)
+}
+
+/** Make the next save answer with a blank-write refusal for `fields`. */
+function refuseOnce(fields: BlankedField[]) {
+  saveSpy.mockImplementationOnce((_s, _p, _seed, opts) => {
+    const confirmed = opts?.allowBlank ?? []
+    const still = fields.filter((f) => !confirmed.includes(f.key))
+    if (still.length > 0) {
+      return Promise.resolve({
+        slug: 'wordpress',
+        stored: false,
+        committed: false,
+        blanked: still,
+      })
+    }
+    return Promise.resolve({ slug: 'wordpress', stored: true, committed: true })
+  })
+}
+
+beforeEach(() => {
+  saveSpy.mockReset()
+  saveSpy.mockImplementation(() =>
+    Promise.resolve({ slug: 'wordpress', stored: true, committed: true }),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('#5610 — the inline editor opens on the CURRENT value (facet A)', () => {
+  it('opens PRE-FILLED with the value present at mount', () => {
+    renderSummaryField('Website and blog platform', () => {})
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    const input = screen.getByTestId('cif-summary-input') as HTMLTextAreaElement
+    expect(input.value).toBe('Website and blog platform')
+  })
+
+  it('a LATE-ARRIVING value re-syncs into the editor (the stale-initial-state trap)', () => {
+    // Mount with nothing — the shape of a detail page whose catalog fetch has
+    // not resolved yet. `useState(initialDraft)` captures "" for the lifetime
+    // of the component, so the ONLY thing that gets a later value in front of
+    // the operator is `open()` re-seeding from the current prop. This holds on
+    // the pre-fix tree too; it is pinned because it is an easily-dropped habit
+    // of one function and dropping it lands straight back on a blank editor
+    // over non-empty content.
+    let setValue: (v: string) => void = () => {}
+    renderSummaryField('', (s) => {
+      setValue = s
+    })
+    // Non-vacuity: it really is empty before the value lands.
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    expect((screen.getByTestId('cif-summary-input') as HTMLTextAreaElement).value).toBe('')
+    fireEvent.click(screen.getByTestId('cif-summary-cancel'))
+
+    // The value arrives after mount …
+    act(() => setValue('Website and blog platform'))
+
+    // … and the editor now opens on it.
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    expect((screen.getByTestId('cif-summary-input') as HTMLTextAreaElement).value).toBe(
+      'Website and blog platform',
+    )
+  })
+
+  it('a value arriving while the operator is TYPING never clobbers the draft', async () => {
+    // The re-sync must not become a different data-loss bug.
+    let setValue: (v: string) => void = () => {}
+    renderSummaryField('Old summary', (s) => {
+      setValue = s
+    })
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    const input = screen.getByTestId('cif-summary-input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'Half-typed replacement' } })
+    setValue('A background refetch landed')
+    await waitFor(() =>
+      expect((screen.getByTestId('cif-summary-input') as HTMLTextAreaElement).value).toBe(
+        'Half-typed replacement',
+      ),
+    )
+  })
+})
+
+describe('#5610 — the blank-write seatbelt (independent of the pre-fill)', () => {
+  it('a save that would blank a non-empty stored summary asks first — and says what is at stake', async () => {
+    refuseOnce([{ key: 'tagline', current: 'Website and blog platform' }])
+    renderSummaryField('Website and blog platform', () => {})
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    fireEvent.change(screen.getByTestId('cif-summary-input'), { target: { value: '' } })
+    fireEvent.click(screen.getByTestId('cif-summary-save'))
+
+    // The confirmation is raised…
+    await screen.findByTestId('cif-summary-blank-confirm')
+    expect(screen.getByTestId('cif-summary-blank-current').textContent).toBe(
+      'Website and blog platform',
+    )
+    // …the editor stayed open on the operator's draft…
+    expect(screen.getByTestId('cif-summary-input')).toBeTruthy()
+    // …and no durable-save toast was fabricated.
+    expect(screen.queryByTestId('cif-summary-save-verdict')).toBeNull()
+    // The first attempt went out WITHOUT a blanket allowBlank — the refusal is
+    // the API's to make, not something the editor opted out of.
+    expect(saveSpy).toHaveBeenCalledTimes(1)
+    expect(saveSpy.mock.calls[0][3]).toEqual({ allowBlank: [] })
+  })
+
+  it('backing out of the confirmation leaves the value alone — no second save', async () => {
+    refuseOnce([{ key: 'tagline', current: 'Website and blog platform' }])
+    renderSummaryField('Website and blog platform', () => {})
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    fireEvent.change(screen.getByTestId('cif-summary-input'), { target: { value: '' } })
+    fireEvent.click(screen.getByTestId('cif-summary-save'))
+    await screen.findByTestId('cif-summary-blank-confirm')
+
+    fireEvent.click(screen.getByTestId('cif-summary-blank-keep'))
+    await waitFor(() => expect(screen.queryByTestId('cif-summary-blank-confirm')).toBeNull())
+    expect(saveSpy).toHaveBeenCalledTimes(1) // still just the refused attempt
+  })
+
+  it('the seatbelt holds even when the editor opened BLANK (pre-fill regression)', async () => {
+    // The exact #5610 shape: the editor believes the current value is empty,
+    // so it cannot know a save is destructive. The refusal comes from the
+    // stored row, so the operator is still asked.
+    refuseOnce([{ key: 'tagline', current: 'Website and blog platform' }])
+    renderSummaryField('', () => {})
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    expect((screen.getByTestId('cif-summary-input') as HTMLTextAreaElement).value).toBe('')
+    fireEvent.click(screen.getByTestId('cif-summary-save'))
+    await screen.findByTestId('cif-summary-blank-confirm')
+    expect(screen.getByTestId('cif-summary-blank-current').textContent).toBe(
+      'Website and blog platform',
+    )
+  })
+
+  /* ── The direction that keeps the fix honest ─────────────────────────── */
+
+  it('NEGATIVE CASE — a deliberate clear still goes through on confirmation', async () => {
+    // If this fails, the seatbelt is a blanket block and clearing a field the
+    // product says is clearable has been broken.
+    refuseOnce([{ key: 'tagline', current: 'Website and blog platform' }])
+    renderSummaryField('Website and blog platform', () => {})
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    fireEvent.change(screen.getByTestId('cif-summary-input'), { target: { value: '' } })
+    fireEvent.click(screen.getByTestId('cif-summary-save'))
+    await screen.findByTestId('cif-summary-blank-confirm')
+
+    fireEvent.click(screen.getByTestId('cif-summary-blank-confirm-clear'))
+
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(2))
+    // The confirmed retry carries the explicit opt-in for THAT column…
+    expect(saveSpy.mock.calls[1][3]).toEqual({ allowBlank: ['tagline'] })
+    // …the empty value is genuinely what is being written…
+    expect(saveSpy.mock.calls[1][1]).toEqual({ tagline: '' })
+    // …and the editor closes with a real verdict, as any successful save does.
+    await waitFor(() => expect(screen.queryByTestId('cif-summary-input')).toBeNull())
+    expect((await screen.findByTestId('cif-summary-save-verdict')).getAttribute('data-tone')).toBe(
+      'ok',
+    )
+  })
+
+  it('NEGATIVE CASE — an ordinary non-empty edit saves on ONE click, no confirmation', async () => {
+    renderSummaryField('Website and blog platform', () => {})
+    fireEvent.click(screen.getByTestId('cif-summary-edit'))
+    fireEvent.change(screen.getByTestId('cif-summary-input'), {
+      target: { value: 'Website, blog and store platform' },
+    })
+    fireEvent.click(screen.getByTestId('cif-summary-save'))
+
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1))
+    expect(screen.queryByTestId('cif-summary-blank-confirm')).toBeNull()
+    expect(saveSpy.mock.calls[0][1]).toEqual({ tagline: 'Website, blog and store platform' })
+    await waitFor(() => expect(screen.queryByTestId('cif-summary-input')).toBeNull())
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogInlineField.tsx
@@ -33,7 +33,12 @@
  */
 
 import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { saveCatalogEdit, type CatalogEntryEdit, type CatalogEntryPatch } from '@/lib/commerce.api'
+import {
+  saveCatalogEdit,
+  type BlankedField,
+  type CatalogEntryEdit,
+  type CatalogEntryPatch,
+} from '@/lib/commerce.api'
 
 /** How long the save-verdict toast stays visible (#5113 facet-a). */
 export const TOAST_MS = 6_000
@@ -101,6 +106,11 @@ export function CatalogInlineField<T>({
   //   committed:null  → amber  "Saved to store — no IaC verdict reported"
   // Auto-dismisses after TOAST_MS; never blocks the next edit.
   const [notice, setNotice] = useState<SaveNotice | null>(null)
+  // #5610 — the blank-write confirmation. Non-null while a save has been
+  // REFUSED by saveCatalogEdit because it would clear these non-empty stored
+  // columns; the operator either confirms (re-save with allowBlank) or backs
+  // out. Nothing has reached the wire while this is set.
+  const [pendingBlank, setPendingBlank] = useState<BlankedField[] | null>(null)
   const editorRef = useRef<HTMLDivElement>(null)
   const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -117,16 +127,31 @@ export function CatalogInlineField<T>({
     noticeTimerRef.current = setTimeout(() => setNotice(null), TOAST_MS)
   }
 
-  // Re-seed the draft from the latest current value each time the editor opens,
-  // so re-opening after an external refetch starts from the live value.
+  // Re-seed the draft from the latest current value each time the editor opens.
+  //
+  // #5610 — this, not `useState(initialDraft)`, is what makes a LATE-ARRIVING
+  // value reach the editor. The `useState` initializer captures the value at
+  // MOUNT and never sees another (the stale-initial-state trap); the editor is
+  // only ever populated through this function, which reads the CURRENT
+  // render's prop, so a value that lands after mount is picked up on the next
+  // open. `CatalogInlineField.blank-guard-5610.test.tsx` pins that, because
+  // the property is a habit of this function rather than something the type
+  // system enforces — dropping the re-seed here is a silent regression to a
+  // blank editor over non-empty content.
+  //
+  // A value arriving while the editor is OPEN is deliberately NOT adopted:
+  // overwriting a half-typed draft from a background refetch would be a second
+  // data-loss bug wearing the first one's clothes.
   const open = () => {
     setDraft(initialDraft)
     setError(null)
+    setPendingBlank(null)
     setEditing(true)
   }
   const cancel = () => {
     setEditing(false)
     setError(null)
+    setPendingBlank(null)
   }
 
   // Autofocus the first focusable control when the editor opens.
@@ -138,7 +163,15 @@ export function CatalogInlineField<T>({
     node?.focus()
   }, [editing])
 
-  const save = async () => {
+  /**
+   * Commit this field.
+   *
+   * @param allowBlank #5610 — store columns whose clearing the operator has
+   *   just CONFIRMED. Empty on the first attempt: saveCatalogEdit then refuses
+   *   (and writes nothing) if the save would blank a non-empty stored value,
+   *   and we raise the confirmation instead of reporting a save.
+   */
+  const save = async (allowBlank: readonly string[] = []) => {
     setSaving(true)
     setError(null)
     // #5510 — send ONLY this field's keys. saveCatalogEdit overlays them onto
@@ -148,9 +181,20 @@ export function CatalogInlineField<T>({
     // silently reverted untouched fields.
     const patch: CatalogEntryPatch = toPatch(draft)
     try {
-      const verdict = await saveCatalogEdit(blueprintId, patch, createSeed)
+      const verdict = await saveCatalogEdit(blueprintId, patch, createSeed, { allowBlank })
+      // #5610 — REFUSED, not saved: the edit would have cleared a non-empty
+      // stored value. Keep the editor open on the operator's draft and ask.
+      // This is the seatbelt for a pre-fill regression: it compares the patch
+      // against the STORED row, not against whatever the editor believes the
+      // current value to be.
+      if (verdict.blanked?.length) {
+        setPendingBlank(verdict.blanked)
+        setSaving(false)
+        return
+      }
       setSaving(false)
       setEditing(false)
+      setPendingBlank(null)
       // Row 132 — surface the dual-write verdict instead of closing
       // silently. committed:false/null NEVER reads as a durable green.
       if (verdict.committed === true) {
@@ -244,6 +288,44 @@ export function CatalogInlineField<T>({
           {error}
         </p>
       ) : null}
+      {/* #5610 — the blank-write confirmation. Reached only when the save was
+          already REFUSED (nothing on the wire), so the destructive path costs
+          a second, deliberate click and names the value at stake. */}
+      {pendingBlank ? (
+        <div
+          className="cif-blank-confirm"
+          role="alert"
+          data-testid={`cif-${fieldKey}-blank-confirm`}
+        >
+          <p className="cif-blank-text">
+            This clears {label}. The stored value{' '}
+            <strong data-testid={`cif-${fieldKey}-blank-current`}>
+              {pendingBlank.map((f) => f.current).join(' · ')}
+            </strong>{' '}
+            will be removed.
+          </p>
+          <div className="cif-actions">
+            <button
+              type="button"
+              className="cif-btn cif-btn-ghost"
+              onClick={() => setPendingBlank(null)}
+              disabled={saving}
+              data-testid={`cif-${fieldKey}-blank-keep`}
+            >
+              Keep it
+            </button>
+            <button
+              type="button"
+              className="cif-btn cif-btn-danger"
+              onClick={() => void save(pendingBlank.map((f) => f.key))}
+              disabled={saving}
+              data-testid={`cif-${fieldKey}-blank-confirm-clear`}
+            >
+              Clear it
+            </button>
+          </div>
+        </div>
+      ) : null}
       <div className="cif-actions">
         <button
           type="button"
@@ -306,6 +388,18 @@ const CATALOG_INLINE_FIELD_CSS = `
 .cif-topo-summary { font-size: 0.85rem; color: var(--color-text); font-weight: 400; }
 
 .cif-error { margin: 0; color: var(--color-danger); font-size: 0.78rem; }
+
+/* #5610 — the blank-write confirmation strip. */
+.cif-blank-confirm {
+  display: flex; flex-direction: column; gap: 0.4rem;
+  border: 1px solid var(--color-danger, #dc2626); border-radius: 8px;
+  padding: 0.5rem 0.65rem;
+  background: color-mix(in srgb, var(--color-danger, #dc2626) 10%, transparent);
+}
+.cif-blank-text { margin: 0; font-size: 0.78rem; color: var(--color-text); font-weight: 400; }
+.cif-blank-text strong { font-weight: 600; }
+.cif-btn-danger { background: var(--color-danger, #dc2626); color: #fff; }
+.cif-btn-danger:hover:not(:disabled) { filter: brightness(0.92); }
 
 /* #5113 facet-a — the per-field save-verdict toast (UAT row 132). */
 .cif-toast {

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.baseline-5610.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.baseline-5610.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * YamlEditor.baseline-5610.test.tsx — #5610 facet B, PART 2.
+ *
+ * PART 1 (`pages/sovereign/CatalogDetail.iac-baseline-5610.test.tsx`) pins that
+ * CatalogDetail feeds the just-committed YAML back as `seedYaml` after a
+ * successful "Commit IaC". On its own that asserts a prop nobody proved
+ * matters. This file closes the chain against the REAL widget: the seed is
+ * exactly what the "• unsaved changes" pill and the Commit button read.
+ *
+ * The reported symptom was the pill still reading "• unsaved changes" beside
+ * the editor's own "Committed to IaC ✓", with Commit still enabled and
+ * inviting a redundant re-commit of identical bytes — clearing only on a full
+ * page reload.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import type { EditorView } from '@codemirror/view'
+
+import { YamlEditor } from './YamlEditor'
+
+const COMMITTED_YAML = [
+  'apiVersion: catalyst.openova.io/v1',
+  'kind: Blueprint',
+  'metadata:',
+  '  name: bp-alloy',
+  'spec:',
+  '  version: 1.0.2',
+  '',
+].join('\n')
+
+/** The issue's exact walk: one line, 1.0.2 → 1.0.3. */
+const EDITED_YAML = COMMITTED_YAML.replace('version: 1.0.2', 'version: 1.0.3')
+
+beforeEach(() => {
+  global.fetch = vi.fn()
+})
+afterEach(() => cleanup())
+
+describe('#5610 facet B — the seed IS the dirty baseline', () => {
+  it('pill goes dirty on an edit and clears once the seed catches up to the buffer', async () => {
+    let view: EditorView | null = null
+    const props = {
+      deploymentId: 'dep',
+      kind: 'Blueprint',
+      ns: undefined,
+      name: 'bp-alloy',
+      obj: null,
+      commitLabel: 'Commit IaC',
+      onCommit: async () => 'Committed to IaC ✓',
+      onCreateEditor: (v: EditorView) => {
+        view = v
+      },
+    }
+    const { rerender } = render(<YamlEditor {...props} seedYaml={COMMITTED_YAML} />)
+
+    // Untouched: clean, and Commit disabled (nothing to send).
+    expect(screen.getByText('• no unsaved edits')).toBeTruthy()
+    expect((screen.getByTestId('yaml-editor-apply') as HTMLButtonElement).disabled).toBe(true)
+
+    // The operator edits one line — dirty, Commit enabled. (Non-vacuity: the
+    // clean assertion below cannot pass by the pill never having lit up.)
+    await waitFor(() => expect(view).not.toBeNull())
+    view!.dispatch({ changes: { from: 0, to: view!.state.doc.length, insert: EDITED_YAML } })
+    await waitFor(() => expect(screen.getByText('• unsaved changes')).toBeTruthy())
+    expect((screen.getByTestId('yaml-editor-apply') as HTMLButtonElement).disabled).toBe(false)
+
+    // The commit lands and the owner re-baselines the seed to those bytes
+    // (PART 1). THAT is what clears the pill and disables the button.
+    rerender(<YamlEditor {...props} seedYaml={EDITED_YAML} />)
+    await waitFor(() => expect(screen.getByText('• no unsaved edits')).toBeTruthy())
+    expect((screen.getByTestId('yaml-editor-apply') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('a STALE seed keeps the pill lit — the exact reported symptom', async () => {
+    // The pre-fix shape: the buffer holds the committed bytes, but the seed
+    // was never moved off the pre-commit file. `dirty` can never go false.
+    let view: EditorView | null = null
+    render(
+      <YamlEditor
+        deploymentId="dep"
+        kind="Blueprint"
+        ns={undefined}
+        name="bp-alloy"
+        obj={null}
+        commitLabel="Commit IaC"
+        seedYaml={COMMITTED_YAML}
+        onCommit={async () => 'Committed to IaC ✓'}
+        onCreateEditor={(v) => {
+          view = v
+        }}
+      />,
+    )
+    await waitFor(() => expect(view).not.toBeNull())
+    view!.dispatch({ changes: { from: 0, to: view!.state.doc.length, insert: EDITED_YAML } })
+
+    // No re-baseline → still "unsaved changes", and Commit still enabled,
+    // inviting the redundant re-commit the issue calls out.
+    await waitFor(() => expect(screen.getByText('• unsaved changes')).toBeTruthy())
+    expect((screen.getByTestId('yaml-editor-apply') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('whitespace-only drift does not read as unsaved (the baseline is trimmed)', async () => {
+    let view: EditorView | null = null
+    const props = {
+      deploymentId: 'dep',
+      kind: 'Blueprint',
+      ns: undefined,
+      name: 'bp-alloy',
+      obj: null,
+      commitLabel: 'Commit IaC',
+      onCommit: async () => 'ok',
+      onCreateEditor: (v: EditorView) => {
+        view = v
+      },
+    }
+    render(<YamlEditor {...props} seedYaml={COMMITTED_YAML} />)
+    await waitFor(() => expect(view).not.toBeNull())
+    view!.dispatch({
+      changes: { from: 0, to: view!.state.doc.length, insert: `${COMMITTED_YAML}\n\n` },
+    })
+    await waitFor(() => expect(screen.getByText('• no unsaved edits')).toBeTruthy())
+  })
+})


### PR DESCRIPTION
## What this is

#5610 facet A reported the catalog **summary inline editor opening EMPTY** over a non-empty summary — a data-loss hazard, since an operator who clicks the pencil, sees a blank box and Saves destroys the stored summary with no warning and no undo.

The pre-fill itself already landed (#5682), and the facet-B baseline landed in #5684. This PR adds the part neither shipped: **a seatbelt that is independent of the pre-fill**, plus the guard coverage both fixes went in without.

## Verified vs refuted

| Claim in #5610 | Verdict |
|---|---|
| Facet A — summary editor opens empty | **Confirmed as the original defect**; already fixed on `main` by #5682 (`summaryDraft` widened to `tagline \|\| summary \|\| description`, matching what the hero renders) |
| Facet B — YamlEditor keeps "unsaved changes" after a successful commit | **Confirmed**; already fixed on `main` by #5684 (`setCommittedIac(yaml)`), but shipped with **no test** |
| `dirty` never re-seeds (`YamlEditor.tsx:213`) | **Confirmed as the mechanism.** `dirty = yaml.trim() !== initial.trim()` and `initial` is a `useMemo` over the `seedYaml` prop, which CatalogDetail owns |

## Does an empty save actually persist? Yes

Traced end to end, and proven by driving `origin/main`'s own code:

```
PUT issued: true
PUT url   : /api/v1/org/commerce/apps/row-1
PUT tagline value on the wire = ""
```

- `commerce.api.ts` `toStoreColumns` carries a present-but-empty value (`if (patch.tagline !== undefined)`), so `""` reaches the wire.
- `Store.UpdateApp` `$set`s every column unconditionally — `core/services/catalog/store/store.go:301` `{Key: "tagline", Value: app.Tagline}` — so the stored tagline is zeroed.

**Why it looked harmless.** The catalyst-api read path masks it *on the page the operator wiped it from*: `overlayCatalogEdits` overlays only a **non-empty** tagline (`catalog_overlay.go:112`) and the git leg uses `setIfNonEmpty` (`catalog_edit_blueprint_yaml.go:75`), so the sovereign-admin catalog page falls back to the IaC value and looks unchanged. But the **raw store column** is what the Organization console (`core/console/src/lib/api.ts:239` → `AppDetail.svelte:288`) and the **customer storefront** (`core/marketplace/src/lib/api.ts:164` → `AppDetail.svelte:147`) render. The loss is real and user-visible — just not from where it was caused.

## The fix

The guard sits at the **API seam**, deliberately not in the editor: an editor-side check would compare against the very prop facet A got wrong, so it would be blind in exactly the case it exists for. `saveCatalogEdit` already fetches the authoritative stored row for its #5510 merge base, so it now compares the patch against that row and returns a `blanked` verdict **without writing** when a save would clear a non-empty column. Ignoring the verdict fails **closed**. The editor turns it into a two-step confirmation that names the value at stake.

A **confirmation, never a ban** — clearing stays possible via an explicit `allowBlank`, which is what `store.go:307` documents for theme-icon overrides. Confirming one column does not license blanking another, and the create path is unguarded since nothing is at stake.

No null-guard was added anywhere; nothing hides the empty state.

## Guards — vacuity-checked in BOTH directions

Every guard was run against the pre-fix component, not just asserted to fail.

| Guard | On `origin/main` | After |
|---|---|---|
| `commerce.api.blank-guard-5610.test.ts` | **6 failed / 4 passed** | 10 passed |
| `CatalogInlineField.blank-guard-5610.test.tsx` | **4 failed / 4 passed** | 8 passed |
| `CatalogDetail.iac-baseline-5610.test.tsx` (facet B, part 1) | **1 failed / 1 passed** with `setCommittedIac(yaml)` removed | 2 passed |
| `YamlEditor.baseline-5610.test.tsx` (facet B, part 2) | mechanism proof — passes both ways by design | 3 passed |

The tests that pass on `main` are the **must-still-work** direction, on purpose: an ordinary non-empty edit still saves on one click; a deliberate clear still writes `""` through on confirmation; clearing an already-empty column demands nothing; the create path is untouched. Without those a blanket block would satisfy the guard by breaking the feature.

Facet B is pinned in two halves because either alone is token-passing: part 1 asserts CatalogDetail re-baselines the seed, part 2 proves against the **real** widget that the seed is what clears the pill and disables the redundant re-commit.

`origin/main` failure output, verbatim:

```
× REFUSES a summary save that would blank a non-empty stored tagline — nothing reaches the wire
× whitespace-only is blank too — "   " does not sneak the wipe past the guard
× holds even when the caller believes the current value is empty (the pre-fill-regression case)
× reports EVERY column a multi-key patch would blank (the icon pair)
× clearing the whole topology set is guarded as well
× NEGATIVE CASE — confirming ONE column does not license blanking another
 Tests  6 failed | 4 passed (10)
```

## Gates — real output

- `npx tsc -b --noEmit` → exit **0**
- `npx vitest run` → **217 files / 2049 tests passed** (baseline before this change: 213 / 2026)
- `npm run build` → `✓ built in 1.93s`
- `npx eslint <7 touched files>` → exit **0**. Repo-wide eslint is **112 errors / 63 files on this branch and on `origin/main` alike** — byte-identical, all pre-existing, none from this change.

One `AppsPage.handover.test.tsx` failure appeared in an intermediate full-suite run and was a load-related flake in a file this diff does not touch; it passes in isolation and in the final full run.

## Note on an existing test

`commerce.api.partial-patch-5510.test.ts` encoded the old "an empty value always writes" contract. Its intent is unchanged and still asserted — a cleared field reaches the store, and it does not drag siblings with it — but the call now states that intent via `allowBlank`. The refusal side is covered comprehensively in the new file.

## Not closing this issue

Merged is not delivered. Falsifiable assertion for the next walker:

> On the sovereign-admin console, open **Catalog → a Blueprint with a non-empty summary → the `cif-summary-edit` pencil**. The `cif-summary-input` textarea must contain that summary text, not the placeholder. Then clear it and Save: a `cif-summary-blank-confirm` strip must appear naming the stored value, and nothing may be written until **Clear it** is clicked. An ordinary non-empty edit must still save on a single click.

Refs #5610
