### PR TITLE
ci(lockstep): run the release writer and assert all five sites converge (Refs #5583)

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -830,6 +830,16 @@ jobs:
       # on every deploy-bot bump (issue #5583) and cascades that red into every
       # open PR. Writing them here makes one bump = one atomically-green commit.
       #
+      # 🛑 THE FIVE SITES ARE GUARDED. `scripts/check-release-lockstep-writer.py`
+      # (workflow: check-release-lockstep-writer.yaml) EXECUTES the steps below —
+      # `chart`, `bump_pin`, `bump_blueprint`, `sync_seed` and the commit+push
+      # step — against a scratch clone with a local bare `origin`, then asserts on
+      # the commit that actually lands. Deleting a step, narrowing an `if:`,
+      # dropping a path from `git add`, or letting the push-retry re-apply only
+      # some sites all turn that gate RED. If you add a SIXTH site, add its step
+      # id to WRITER_STEP_IDS in that script — otherwise the new step is not run
+      # by the guard and the convergence assertions will fail closed.
+      #
       # Node is pinned to the same '22' the #5520 gate
       # (.github/workflows/check-catalog-generated-drift.yaml) uses;
       # build-catalog.mjs has ZERO npm dependencies (node builtins only), so no

--- a/.github/workflows/check-release-lockstep-writer.yaml
+++ b/.github/workflows/check-release-lockstep-writer.yaml
@@ -1,0 +1,75 @@
+name: check — release writer moves all five lockstep sites (#5583)
+
+# A chart bump is only complete when FIVE sites move together: Chart.yaml,
+# blueprint.yaml spec.version, the catalog-seed card spec.version AND delivery
+# source.version, the committed generated catalog (blueprints.json +
+# catalog.generated.ts), and the bootstrap-kit slot pin. The deploy-bot writes
+# site 1; `.github/workflows/blueprint-release.yaml` writes sites 2..5 after the
+# chart publishes.
+#
+# Before #5678 that writer covered only sites 2 and 5, so every deploy-bot bump
+# left seed + generated-catalog drift on main. That drift is not silent: it
+# reddens the `pull_request` legs of check-catalog-seed-lockstep,
+# check-catalog-generated-drift (#5520) and the bootstrap-kit Go guards on EVERY
+# open PR, through no fault of theirs (#5583). Two hand-fix commits in one hour
+# on 2026-08-02/03 (c6e79239f, 90c69ae46) were the treadmill this replaces.
+#
+# The gates that go red are all downstream of the writer, and none of them can
+# see the writer itself — they only see the state it left behind, after the fact,
+# on someone else's PR. This gate is the missing upstream one: it runs the
+# writer's own steps against a scratch clone with a local bare `origin` and
+# asserts on the commit that actually lands. It therefore fails for every way the
+# writer can regress — a deleted step, an `if:` that stops firing, a `git add`
+# that forgets a file, a retry path that drops a site — and not merely for a
+# deleted grep token.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/blueprint-release.yaml'
+      - '.github/workflows/check-release-lockstep-writer.yaml'
+      - 'scripts/check-release-lockstep-writer.py'
+      - 'scripts/sync-catalog-seed-pin.py'
+      - 'products/catalyst/bootstrap/ui/scripts/build-catalog.mjs'
+      - 'products/catalyst/chart/templates/catalog-seed/blueprints.yaml'
+      - 'clusters/_template/bootstrap-kit/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/blueprint-release.yaml'
+      - '.github/workflows/check-release-lockstep-writer.yaml'
+      - 'scripts/check-release-lockstep-writer.py'
+      - 'scripts/sync-catalog-seed-pin.py'
+      - 'products/catalyst/bootstrap/ui/scripts/build-catalog.mjs'
+  workflow_dispatch:
+
+jobs:
+  writer:
+    name: run the release writer and assert all five sites converge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # node 22 = the pin the #5520 drift gate uses; build-catalog.mjs has zero
+      # npm dependencies, so no `npm ci` is needed.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      # The harness runs the repo's own bootstrap-kit Go lockstep guards against
+      # the tree the writer pushed — they are the guards that actually redden, so
+      # asserting on them is the point. Without Go on PATH the harness FAILS
+      # rather than silently reporting on less than it claims.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: false
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Run the release lockstep writer guard
+        run: python3 scripts/check-release-lockstep-writer.py --scratch-dir "${RUNNER_TEMP}"
+
+      - name: Self-test the catalog-seed sync helper
+        run: python3 scripts/sync-catalog-seed-pin.py --self-test

--- a/scripts/check-release-lockstep-writer.py
+++ b/scripts/check-release-lockstep-writer.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+"""check-release-lockstep-writer.py — prove the release writer moves ALL FIVE
+lockstep sites, by RUNNING it (issue #5583).
+
+Why this exists
+───────────────
+A chart bump is only complete when five sites move together:
+
+  1. platform|products/<x>/chart/Chart.yaml            `version:`        (deploy-bot)
+  2. platform|products/<x>/blueprint.yaml              `spec.version`    (release writer)
+  3. products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+                                  card `spec.version` AND `source.version`
+  4. the committed generated catalog
+       products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+       products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+  5. clusters/_template/bootstrap-kit/<NN>-<chart>.yaml `version:`       (the kit pin)
+
+Sites 2..5 are written by `.github/workflows/blueprint-release.yaml` after it
+publishes the chart. Before #5678 that writer covered only sites 2 and 5, so
+every deploy-bot bump left main carrying seed + generated-catalog drift, which
+then reddened the `pull_request` legs of check-catalog-seed-lockstep,
+check-catalog-generated-drift (#5520) and the bootstrap-kit Go guards on every
+open PR — through no fault of theirs (#5583).
+
+What this guard does that a grep cannot
+───────────────────────────────────────
+It does not read the workflow for the presence of a step name or a command
+string. It EXTRACTS the workflow's own `run:` bodies, EXECUTES them against a
+scratch clone of the repo with a local bare `origin`, and then asserts on the
+commit that actually landed on that origin's `main`. So it goes red for every
+way the writer can regress — a deleted step, a step whose `if:` never fires, a
+`git add` that forgets a file, a retry path that drops a site — not only for a
+deleted grep token.
+
+Because the step bodies are taken from the workflow, this guard cannot drift
+away from the thing it guards: there is no second copy of the bump logic here.
+
+Cases
+─────
+  bump      POSITIVE. Simulate a deploy-bot Chart.yaml-only patch bump of a
+            chart proven IN SCOPE of every site (in the bootstrap kit, in the
+            catalog seed with a STATIC version, and carrying a blueprint.yaml).
+            The writer must converge all five sites in what it pushes.
+            → RED before #5678, GREEN after.
+
+  umbrella  CONTROL, must be GREEN on both trees. Same harness, same mechanism,
+            run against bp-catalyst-platform: it IS in the kit and IS in the
+            seed (so it is in scope — the in-scope precondition is asserted, not
+            assumed), but its seed card renders `{{ .Chart.Version }}` and it has
+            no blueprint.yaml, so sites 2/3/4 are legitimate no-ops. A guard that
+            demanded a literal rewrite here would be wrong; this control fails if
+            someone "fixes" the guard by blanket-asserting every site always moves.
+
+  noop      CONTROL, must be GREEN on both trees. Run the writer with NO chart
+            bump at all. Nothing may drift and nothing may be pushed backwards.
+            This is the vacuity check: it proves the harness can go green, so a
+            red `bump` case is signal and not a harness that always fails.
+
+Usage
+─────
+  scripts/check-release-lockstep-writer.py              # all cases
+  scripts/check-release-lockstep-writer.py --case bump  # one case
+  scripts/check-release-lockstep-writer.py --keep       # keep the scratch tree
+
+Each case materialises ~40 MB of scratch (a tracked-file copy of the repo, a bare
+origin, and a clone of what got pushed). On a dev box `/tmp` lives on the small
+root filesystem and is routinely full — pass `--scratch-dir` (or set
+LOCKSTEP_GUARD_SCRATCH) to somewhere on the big volume. CI runners are fine.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOW = os.path.join(REPO_ROOT, ".github", "workflows", "blueprint-release.yaml")
+
+SEED_REL = "products/catalyst/chart/templates/catalog-seed/blueprints.yaml"
+JSON_REL = "products/catalyst/bootstrap/api/internal/catalog/blueprints.json"
+TS_REL = "products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts"
+KIT_REL = "clusters/_template/bootstrap-kit"
+UI_REL = "products/catalyst/bootstrap/ui"
+
+# The steps of the `build` job that are pure local file edits — the release
+# WRITER. Everything else in that job talks to GHCR / cosign / helm and is out
+# of scope here. Ids that do not exist in the workflow are skipped with a
+# notice: that is what makes this guard runnable against a PRE-fix tree (where
+# `sync_seed` does not exist yet) instead of erroring out on a missing key.
+# Fails CLOSED: a future sixth site added in a step whose id is not listed here
+# will not run, and the convergence assertions below go red until it is added.
+WRITER_STEP_IDS = ["chart", "bump_pin", "bump_blueprint", "sync_seed"]
+
+# The commit step carries no `id:`, so it is located structurally — the one step
+# in the build job whose script pushes to main.
+COMMIT_STEP_MARKER = "git push origin HEAD:main"
+
+_RE_EXPR = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
+_RE_KIT_VERSION = re.compile(r"^      version:\s*\"?([^\"\s]+)\"?\s*$", re.M)
+_RE_BP_VERSION = re.compile(r"^  version:\s*\"?([^\"\s]+)\"?\s*$", re.M)
+_RE_SEMVER = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+GREEN = "\033[32m" if sys.stdout.isatty() else ""
+RED = "\033[31m" if sys.stdout.isatty() else ""
+RESET = "\033[0m" if sys.stdout.isatty() else ""
+
+
+class Failure(Exception):
+    pass
+
+
+def sh(cmd, cwd, env=None, check=True, capture=True):
+    r = subprocess.run(
+        cmd, cwd=cwd, env=env, shell=isinstance(cmd, str),
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+        text=True,
+    )
+    if check and r.returncode != 0:
+        out = (r.stdout or "").strip()
+        raise Failure("command failed (%d): %s\n%s" % (r.returncode, cmd, out))
+    return r
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub-Actions expression evaluation — only the subset the build job uses:
+# `matrix.<k>`, `steps.<id>.outputs.<k>`, string literals, == != && || ( ).
+# ─────────────────────────────────────────────────────────────────────────────
+def _lookup(ref, ctx):
+    parts = ref.split(".")
+    if parts[0] == "matrix" and len(parts) == 2:
+        return ctx["matrix"].get(parts[1], "")
+    if parts[0] == "steps" and len(parts) == 4 and parts[2] == "outputs":
+        return ctx["steps"].get(parts[1], {}).get(parts[3], "")
+    if parts[0] == "github" and len(parts) == 2:
+        return ctx.get("github", {}).get(parts[1], "")
+    raise Failure("unsupported workflow expression reference: %r" % ref)
+
+
+def resolve(text, ctx):
+    """Substitute every ${{ … }} in `text` with its value."""
+    if not isinstance(text, str):
+        return text
+    return _RE_EXPR.sub(lambda m: str(_lookup(m.group(1), ctx)), text)
+
+
+_SAFE_IF = re.compile(r"^[A-Za-z0-9_'\"()!=. \t<>&|-]*$")
+
+
+def eval_if(cond, ctx):
+    if cond is None:
+        return True
+    expr = resolve(str(cond), ctx)
+    # Context refs that were NOT wrapped in ${{ }} (the `if:` shorthand).
+    expr = re.sub(
+        r"steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)",
+        lambda m: "'%s'" % ctx["steps"].get(m.group(1), {}).get(m.group(2), ""),
+        expr,
+    )
+    expr = re.sub(r"matrix\.([A-Za-z0-9_-]+)",
+                  lambda m: "'%s'" % ctx["matrix"].get(m.group(1), ""), expr)
+    if not _SAFE_IF.match(expr):
+        raise Failure("refusing to evaluate unrecognised `if:` expression: %r" % cond)
+    py = expr.replace("&&", " and ").replace("||", " or ")
+    try:
+        return bool(eval(py, {"__builtins__": {}}, {}))  # noqa: S307 - charset-gated
+    except Exception as exc:
+        raise Failure("cannot evaluate `if: %s` (as %r): %s" % (cond, py, exc))
+
+
+def load_build_steps():
+    with open(WORKFLOW) as fh:
+        wf = yaml.safe_load(fh)
+    job = wf["jobs"]["build"]
+    return wf.get("env", {}) or {}, job.get("env", {}) or {}, job["steps"]
+
+
+def find_commit_step(steps):
+    hits = [s for s in steps if COMMIT_STEP_MARKER in (s.get("run") or "")]
+    if len(hits) != 1:
+        raise Failure(
+            "expected exactly ONE step in the build job that pushes to main "
+            "(marker %r); found %d. The release writer's shape changed — update "
+            "this guard rather than deleting it." % (COMMIT_STEP_MARKER, len(hits))
+        )
+    return hits[0]
+
+
+def run_step(step, work, ctx, wf_env, job_env, label):
+    step_id = step.get("id")
+    if not eval_if(step.get("if"), ctx):
+        print("    - skip  %-14s (if: false)" % (step_id or label))
+        return
+    env = dict(os.environ)
+    env.update({k: str(resolve(v, ctx)) for k, v in (wf_env or {}).items()})
+    env.update({k: str(resolve(v, ctx)) for k, v in (job_env or {}).items()})
+    env.update({k: str(resolve(v, ctx)) for k, v in (step.get("env") or {}).items()})
+
+    fd, out_path = tempfile.mkstemp(prefix="gh-output-")
+    os.close(fd)
+    env["GITHUB_OUTPUT"] = out_path
+    env["GITHUB_STEP_SUMMARY"] = out_path + ".summary"
+
+    script = resolve(step["run"], ctx)
+    r = subprocess.run(["bash", "-c", script], cwd=work, env=env,
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    body = (r.stdout or "").strip()
+    for line in body.splitlines():
+        print("        | " + line)
+    if r.returncode != 0:
+        raise Failure("workflow step %r exited %d" % (step_id or label, r.returncode))
+
+    outs = {}
+    with open(out_path) as fh:
+        for line in fh:
+            if "=" in line:
+                k, v = line.rstrip("\n").split("=", 1)
+                outs[k] = v
+    os.unlink(out_path)
+    if step_id:
+        ctx["steps"].setdefault(step_id, {}).update(outs)
+    print("    - ran   %-14s outputs=%s" % (step_id or label, outs or "{}"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scratch repo
+# ─────────────────────────────────────────────────────────────────────────────
+def build_scratch(root):
+    work = os.path.join(root, "work")
+    remote = os.path.join(root, "remote.git")
+    os.makedirs(work)
+    # Copy the TRACKED working tree (in CI that is exactly the checked-out ref;
+    # locally it also carries uncommitted edits, which is what we want to test).
+    sh("git ls-files -z | tar --null -T - -cf - | tar -xf - -C %s" % work, cwd=REPO_ROOT)
+    sh("git init -q -b main", cwd=work)
+    sh('git config user.email "guard@openova.io" && git config user.name "lockstep-guard"', cwd=work)
+    sh("git add -A && git commit -q -m baseline", cwd=work)
+    sh("git init -q --bare -b main %s" % remote, cwd=root)
+    sh("git remote add origin %s" % remote, cwd=work)
+    sh("git push -q origin main", cwd=work)
+    sh("git branch -q --set-upstream-to=origin/main main", cwd=work)
+    return work, remote
+
+
+def clone_pushed(root, remote):
+    pushed = os.path.join(root, "pushed")
+    sh("git clone -q --branch main %s %s" % (remote, pushed), cwd=root)
+    if not os.path.isdir(os.path.join(pushed, "platform")):
+        raise Failure("the clone of origin/main is empty — nothing was pushed")
+    return pushed
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Site readers
+# ─────────────────────────────────────────────────────────────────────────────
+def read_chart(tree, path):
+    txt = open(os.path.join(tree, path, "chart", "Chart.yaml")).read()
+    name = re.search(r"^name:\s*\"?([^\"\s]+)", txt, re.M).group(1)
+    ver = re.search(r"^version:\s*\"?([^\"\s]+)", txt, re.M).group(1)
+    return name, ver
+
+
+def bump_patch(v):
+    m = _RE_SEMVER.match(v)
+    if not m:
+        raise Failure("chart version %r is not MAJOR.MINOR.PATCH — pick another case chart" % v)
+    return "%s.%s.%d" % (m.group(1), m.group(2), int(m.group(3)) + 1)
+
+
+def blueprint_path(tree, path):
+    for c in (os.path.join(tree, path, "blueprint.yaml"),
+              os.path.join(tree, path, "chart", "blueprint.yaml")):
+        if os.path.isfile(c):
+            return c
+    return None
+
+
+def read_blueprint_version(tree, path):
+    f = blueprint_path(tree, path)
+    if f is None:
+        return None
+    m = _RE_BP_VERSION.search(open(f).read())
+    return m.group(1) if m else None
+
+
+def kit_slots(tree, chart):
+    kit = os.path.join(tree, KIT_REL)
+    out = []
+    for name in sorted(os.listdir(kit)):
+        if not name.endswith(".yaml"):
+            continue
+        txt = open(os.path.join(kit, name)).read()
+        if re.search(r"^      chart: %s$" % re.escape(chart), txt, re.M):
+            m = _RE_KIT_VERSION.search(txt)
+            out.append((name, m.group(1) if m else None))
+    return out
+
+
+def seed_entries(tree, chart):
+    """Return [(name, spec_raw, source_raw)] for every seed entry delivering `chart`.
+
+    Deliberately an INDEPENDENT reader, not an import of the writer's own parser
+    in scripts/sync-catalog-seed-pin.py: a guard that reuses the subject's parser
+    inherits the subject's blind spots, and it must also be runnable against a
+    tree where that helper does not exist yet. The seed is a Helm template, so a
+    YAML unmarshal is impossible; the fields read here are static YAML at a fixed
+    2-/4-space shape, the same shape the Go guards key on.
+    """
+    lines = open(os.path.join(tree, SEED_REL)).read().split("\n")
+    out, cur = [], None
+    in_manifests = in_source = False
+
+    def flush():
+        if cur is not None:
+            out.append(cur)
+
+    for ln in lines:
+        if re.match(r"^kind:\s*Blueprint\s*$", ln):
+            flush()
+            cur = {"name": None, "chart": None, "spec": None, "source": None}
+            in_manifests = in_source = False
+            continue
+        if cur is None:
+            continue
+        if re.match(r"^  manifests:\s*$", ln):
+            in_manifests, in_source = True, False
+            continue
+        if re.match(r"^  source:\s*$", ln):
+            in_source, in_manifests = True, False
+            continue
+        if (in_manifests or in_source) and ln.strip() and not ln.startswith("    "):
+            in_manifests = in_source = False
+        if cur["name"] is None:
+            m = re.match(r"^  name:\s*\"?(bp-[A-Za-z0-9._-]+)\"?\s*$", ln)
+            if m:
+                cur["name"] = m.group(1)
+        if in_manifests:
+            m = re.match(r"^    chart:\s*\"?([A-Za-z0-9][A-Za-z0-9._-]*)\"?\s*$", ln)
+            if m and cur["chart"] is None:
+                cur["chart"] = m.group(1)
+            continue
+        if in_source:
+            m = re.match(r"^    version:\s*(.*?)\s*$", ln)
+            if m and cur["source"] is None:
+                cur["source"] = m.group(1)
+            continue
+        if cur["spec"] is None:
+            m = re.match(r"^  version:\s*(.*?)\s*$", ln)
+            if m:
+                cur["spec"] = m.group(1)
+    flush()
+    return [(e["name"], e["spec"], e["source"]) for e in out if e["chart"] == chart]
+
+
+def is_static(raw):
+    return raw is not None and re.match(r"^\"?\d", raw) is not None
+
+
+def bare(raw):
+    return None if raw is None else raw.strip().strip('"').strip("'")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertions on the tree that actually landed on origin/main
+# ─────────────────────────────────────────────────────────────────────────────
+def assert_sites(pushed, path, chart, want, expect, problems):
+    """expect: dict of site -> 'literal' | 'templated' | 'absent'."""
+    _, chart_ver = read_chart(pushed, path)
+    if chart_ver != want:
+        problems.append("site 1 Chart.yaml: %s != %s" % (chart_ver, want))
+
+    bp = read_blueprint_version(pushed, path)
+    if expect["blueprint"] == "absent":
+        if bp is not None:
+            problems.append("site 2 blueprint.yaml unexpectedly present (%s)" % bp)
+    elif bp != want:
+        problems.append("site 2 %s spec.version: %s != %s"
+                        % (os.path.relpath(blueprint_path(pushed, path), pushed), bp, want))
+
+    entries = seed_entries(pushed, chart)
+    if expect["seed"] == "absent":
+        if entries:
+            problems.append("site 3 catalog-seed unexpectedly has %d entr(y|ies) for %s"
+                            % (len(entries), chart))
+    else:
+        if not entries:
+            problems.append("site 3 catalog-seed has NO entry for %s — the case chart is "
+                            "OUT OF SCOPE of the seed writer, so this case proves nothing"
+                            % chart)
+        for (name, sraw, vraw) in entries:
+            for label, raw in (("spec.version", sraw), ("source.version", vraw)):
+                if expect["seed"] == "templated":
+                    if is_static(raw):
+                        problems.append("site 3 %s %s: expected a Helm-templated value, "
+                                        "found the literal %s (the writer rewrote a "
+                                        "template into a pin)" % (name, label, raw))
+                    continue
+                if not is_static(raw):
+                    problems.append("site 3 %s %s: %s is not a static version" % (name, label, raw))
+                elif bare(raw) != want:
+                    problems.append("site 3 %s %s: %s != %s" % (name, label, bare(raw), want))
+
+    slots = kit_slots(pushed, chart)
+    if expect["kit"] == "absent":
+        if slots:
+            problems.append("site 5 bootstrap-kit unexpectedly pins %s (%s)" % (chart, slots))
+    else:
+        if not slots:
+            problems.append("site 5 no bootstrap-kit slot pins %s — the case chart is OUT OF "
+                            "SCOPE of the pin writer, so this case proves nothing" % chart)
+        for (f, v) in slots:
+            if v != want:
+                problems.append("site 5 %s/%s: %s != %s" % (KIT_REL, f, v, want))
+
+
+def assert_generated_in_sync(pushed, problems):
+    """Site 4 — the #5520 gate, run against what landed on main."""
+    r = sh("node scripts/build-catalog.mjs", cwd=os.path.join(pushed, UI_REL), check=False)
+    if r.returncode != 0:
+        problems.append("site 4 build-catalog.mjs failed:\n%s" % r.stdout)
+        return
+    d = sh("git diff --stat -- %s %s" % (JSON_REL, TS_REL), cwd=pushed)
+    if d.stdout.strip():
+        problems.append("site 4 committed generated catalog is STALE on the pushed main "
+                        "(#5520 gate would be red on every open PR):\n%s" % d.stdout.strip())
+
+
+def assert_repo_gates(pushed, problems, skip_slow):
+    """Run the repo's OWN lockstep gates against the pushed tree."""
+    go = shutil.which("go")
+    if go:
+        r = sh("go test -count=1 -run "
+               "'TestBootstrapKit_BlueprintVersionLockstepSweep|"
+               "TestCatalogSeed_DeliveryPinsNotBehindComponentCharts|"
+               "TestCatalogSeed_DisplayVersionNotBehindDeliveryPin' ./...",
+               cwd=os.path.join(pushed, "tests", "e2e", "bootstrap-kit"), check=False)
+        if r.returncode != 0:
+            problems.append("bootstrap-kit Go lockstep guards RED on the pushed main:\n%s"
+                            % r.stdout.strip()[:4000])
+    else:
+        problems.append("`go` not on PATH — the Go lockstep guards could not be run, so this "
+                        "guard would be reporting on less than it claims. Install Go.")
+
+    r = sh("bash scripts/check-bootstrap-kit-pin-sync.sh", cwd=pushed, check=False)
+    if r.returncode != 0:
+        problems.append("check-bootstrap-kit-pin-sync.sh RED on the pushed main:\n%s"
+                        % r.stdout.strip()[-3000:])
+
+    if not skip_slow:
+        r = sh("bash scripts/check-catalog-seed-lockstep.sh", cwd=pushed, check=False)
+        if r.returncode != 0:
+            problems.append("check-catalog-seed-lockstep.sh RED on the pushed main:\n%s"
+                            % r.stdout.strip()[-3000:])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cases
+# ─────────────────────────────────────────────────────────────────────────────
+CASES = {
+    # name: (matrix path, bump?, expected shape of each site, in-scope preconditions)
+    "bump": dict(
+        path="platform/keycloak", do_bump=True,
+        expect=dict(blueprint="literal", seed="literal", kit="literal"),
+        why="a chart in the kit AND in the seed with STATIC version lines — every "
+            "site is in scope, so a writer that drops one MUST be caught here",
+    ),
+    "retry": dict(
+        path="platform/keycloak", do_bump=True, conflict=True,
+        expect=dict(blueprint="literal", seed="literal", kit="literal"),
+        why="POSITIVE — same bump, but a rival commit lands on main between the "
+            "writer's edits and its push, forcing the retry loop's `git reset "
+            "--hard origin/main`. That reset wipes the working-tree edits, so a "
+            "retry that re-applies only some sites re-opens #5583 on exactly the "
+            "concurrency the matrix fan-out makes routine",
+    ),
+    "umbrella": dict(
+        path="products/catalyst", do_bump=True,
+        expect=dict(blueprint="absent", seed="templated", kit="literal"),
+        why="CONTROL — in the kit and in the seed (in scope), but the seed card is "
+            "`{{ .Chart.Version }}` and there is no blueprint.yaml, so sites 2/3/4 "
+            "are legitimate no-ops; must stay green on a pre-fix tree too",
+    ),
+    "noop": dict(
+        path="platform/keycloak", do_bump=False,
+        expect=dict(blueprint="literal", seed="literal", kit="literal"),
+        why="CONTROL / vacuity check — no bump at all; nothing may drift, so a red "
+            "`bump` case cannot be a harness that is simply always red",
+    ),
+}
+
+
+def precheck_in_scope(case, name):
+    """Assert the case chart is genuinely SEEN by the mechanism before we conclude
+    anything from it (#5389: a drift injected into a blueprint the guard never
+    compares 'proves' a working guard worthless)."""
+    path = case["path"]
+    chart, ver = read_chart(REPO_ROOT, path)
+    facts = []
+    slots = kit_slots(REPO_ROOT, chart)
+    entries = seed_entries(REPO_ROOT, chart)
+    bp = blueprint_path(REPO_ROOT, path)
+    facts.append("bootstrap-kit slots: %s" % ([f for f, _ in slots] or "none"))
+    facts.append("catalog-seed entries: %s" % ([n for n, _, _ in entries] or "none"))
+    facts.append("blueprint.yaml: %s" % (os.path.relpath(bp, REPO_ROOT) if bp else "none"))
+    print("    in-scope facts for %s (%s @ %s):" % (name, chart, ver))
+    for f in facts:
+        print("      · " + f)
+
+    if case["expect"]["kit"] == "literal" and not slots:
+        raise Failure("case %r expects a kit pin but no slot pins %s" % (name, chart))
+    if case["expect"]["seed"] in ("literal", "templated") and not entries:
+        raise Failure("case %r expects a seed entry but %s is absent from the catalog-seed — "
+                      "the case chart is OUT OF SCOPE and would prove nothing" % (name, chart))
+    if case["expect"]["seed"] == "literal":
+        for (n, sraw, vraw) in entries:
+            if not (is_static(sraw) and is_static(vraw)):
+                raise Failure("case %r needs STATIC seed version lines; %s has %r / %r"
+                              % (name, n, sraw, vraw))
+    if case["expect"]["blueprint"] == "literal" and bp is None:
+        raise Failure("case %r expects a blueprint.yaml at %s but none exists" % (name, path))
+    return chart, ver
+
+
+MIN_FREE_MB = 300
+
+
+def scratch_base(explicit):
+    base = (explicit or os.environ.get("LOCKSTEP_GUARD_SCRATCH")
+            or os.environ.get("RUNNER_TEMP") or tempfile.gettempdir())
+    os.makedirs(base, exist_ok=True)
+    st = os.statvfs(base)
+    free_mb = st.f_bavail * st.f_frsize // (1024 * 1024)
+    if free_mb < MIN_FREE_MB:
+        raise Failure(
+            "scratch dir %s has only %d MB free (need ~%d MB per case). On this box "
+            "/tmp is on the small root filesystem — re-run with --scratch-dir on the "
+            "big volume, or set LOCKSTEP_GUARD_SCRATCH." % (base, free_mb, MIN_FREE_MB))
+    # Every temp file this harness makes (incl. the per-step $GITHUB_OUTPUT) goes
+    # here, not to a possibly-full /tmp.
+    tempfile.tempdir = base
+    return base
+
+
+def run_case(name, case, keep, skip_slow, base):
+    print("\n%s─── case %s ───%s  %s" % (GREEN, name, RESET, case["why"]))
+    chart, cur = precheck_in_scope(case, name)
+    want = bump_patch(cur) if case["do_bump"] else cur
+
+    root = tempfile.mkdtemp(prefix="lockstep-writer-%s-" % name, dir=base)
+    try:
+        work, remote = build_scratch(root)
+
+        if case["do_bump"]:
+            # Simulate the deploy-bot: it writes site 1 and NOTHING else, then
+            # pushes to main and dispatches Blueprint Release.
+            cy = os.path.join(work, case["path"], "chart", "Chart.yaml")
+            txt = open(cy).read()
+            new = re.sub(r"^version:\s*.*$", "version: %s" % want, txt, count=1, flags=re.M)
+            if new == txt:
+                raise Failure("could not rewrite Chart.yaml version in %s" % cy)
+            open(cy, "w").write(new)
+            sh('git add -A && git commit -q -m "deploy: bump %s to %s (simulated bot)"'
+               % (chart, want), cwd=work)
+            sh("git push -q origin main", cwd=work)
+            print("    bot commit pushed: %s %s -> %s (Chart.yaml ONLY)" % (chart, cur, want))
+        else:
+            print("    no bot commit — writer runs against an already-lockstep main")
+
+        wf_env, job_env, steps = load_build_steps()
+        by_id = {s.get("id"): s for s in steps if s.get("id")}
+        ctx = {"matrix": {"path": case["path"]}, "steps": {}, "github": {}}
+
+        print("    running the release writer's own steps:")
+        for sid in WRITER_STEP_IDS:
+            if sid not in by_id:
+                print("    - absent %-13s (not declared in this workflow)" % sid)
+                continue
+            run_step(by_id[sid], work, ctx, wf_env, job_env, sid)
+
+        if case.get("conflict"):
+            rival = os.path.join(root, "rival")
+            sh("git clone -q --branch main %s %s" % (remote, rival), cwd=root)
+            sh('git config user.email "rival@openova.io" && git config user.name "rival"', cwd=rival)
+            with open(os.path.join(rival, "README.md"), "a") as fh:
+                fh.write("\n<!-- rival commit injected by the lockstep writer guard -->\n")
+            sh('git add -A && git commit -q -m "rival: concurrent push"', cwd=rival)
+            sh("git push -q origin main", cwd=rival)
+            print("    rival commit pushed to origin/main — the writer's push must now retry")
+
+        run_step(find_commit_step(steps), work, ctx, wf_env, job_env, "commit+push")
+
+        pushed = clone_pushed(root, remote)
+        problems = []
+        assert_sites(pushed, case["path"], chart, want, case["expect"], problems)
+        assert_generated_in_sync(pushed, problems)
+        assert_repo_gates(pushed, problems, skip_slow)
+
+        head = sh("git log -1 --format=%s", cwd=pushed).stdout.strip()
+        files = sh("git show --name-only --format= HEAD", cwd=pushed).stdout.strip()
+        print("    landed on origin/main: %s" % head)
+        shown = files.splitlines()
+        for f in shown[:20]:
+            print("      + " + f)
+        if len(shown) > 20:
+            print("      + … %d more" % (len(shown) - 20))
+
+        if problems:
+            print("%s  FAIL case %s — the release writer did not converge all five sites%s"
+                  % (RED, name, RESET))
+            for p in problems:
+                print("    ✗ " + p)
+            return False
+        print("%s  PASS case %s — all five lockstep sites converged at %s on origin/main%s"
+              % (GREEN, name, want, RESET))
+        return True
+    finally:
+        if keep:
+            print("    scratch kept at %s" % root)
+        else:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--case", choices=sorted(CASES), action="append",
+                    help="run only these case(s); default = all")
+    ap.add_argument("--keep", action="store_true", help="keep the scratch tree for inspection")
+    ap.add_argument("--skip-slow", action="store_true",
+                    help="skip check-catalog-seed-lockstep.sh (~14s per case)")
+    ap.add_argument("--scratch-dir", default=None,
+                    help="where to materialise the scratch repos (default $LOCKSTEP_GUARD_SCRATCH, "
+                         "$RUNNER_TEMP, then the system temp dir)")
+    args = ap.parse_args(argv)
+
+    names = args.case or sorted(CASES)
+    print("release lockstep writer guard (#5583) — workflow: %s"
+          % os.path.relpath(WORKFLOW, REPO_ROOT))
+    try:
+        base = scratch_base(args.scratch_dir)
+    except Failure as exc:
+        print("%sFAIL — %s%s" % (RED, exc, RESET))
+        return 1
+    ok = True
+    for n in names:
+        try:
+            ok = run_case(n, CASES[n], args.keep, args.skip_slow, base) and ok
+        except Failure as exc:
+            print("%s  FAIL case %s — harness error%s\n    ✗ %s" % (RED, n, RESET, exc))
+            ok = False
+
+    print()
+    if ok:
+        print("PASS: the release writer moves all five lockstep sites in the commit it pushes.")
+        return 0
+    print("FAIL: the release writer leaves at least one lockstep site behind (#5583). "
+          "Every deploy-bot chart bump will land drift on main and redden every open PR.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

A gate on the **release writer itself**, not on the state it leaves behind.

A chart bump is complete only when five sites move together:

| # | site | written by |
|---|---|---|
| 1 | `platform\|products/<x>/chart/Chart.yaml` `version` | the deploy-bot |
| 2 | `platform\|products/<x>/blueprint.yaml` `spec.version` | `blueprint-release.yaml` step `bump_blueprint` |
| 3 | catalog-seed card `spec.version` **and** delivery `source.version` | step `sync_seed` (#5678) |
| 4 | `blueprints.json` + `catalog.generated.ts` | step `sync_seed` (#5678) |
| 5 | `clusters/_template/bootstrap-kit/<NN>-<chart>.yaml` `version` | step `bump_pin` |

Before #5678 the writer covered only 2 and 5, so every deploy-bot bump landed seed +
generated-catalog drift on `main`, which reddened `check-catalog-seed-lockstep`,
`check-catalog-generated-drift` (#5520) and the bootstrap-kit Go guards on **every open
PR** through no fault of theirs — issue #5583, hand-fixed twice in one hour on 2026-08-02/03.

**Every gate that goes red for this is downstream of the writer and cannot see the writer at
all.** It only sees the state left behind, after the fact, on someone else's PR. That is why
#5678 could close the hole and nothing would notice if it reopened. This PR is the missing
upstream gate.

## What the guard does — and what it deliberately does not do

`scripts/check-release-lockstep-writer.py` does **not** grep the workflow for a step name or a
command string. It:

1. materialises a scratch copy of the tracked tree with a local **bare** `origin`;
2. simulates the deploy-bot — rewrites **only** `Chart.yaml` and pushes;
3. **extracts the `run:` bodies of the release writer's own steps** (`chart`, `bump_pin`,
   `bump_blueprint`, `sync_seed`, and the commit+push step, located structurally by its push
   to main), evaluates their `if:` and `env:` the way Actions would, and **executes them**;
4. clones what actually landed on that origin's `main` and asserts on it: all five sites at the
   new version, `build-catalog.mjs` re-run clean (the #5520 gate), the three bootstrap-kit Go
   lockstep guards green, `check-bootstrap-kit-pin-sync.sh` green, `check-catalog-seed-lockstep.sh`
   green.

Because the step bodies come from the workflow, there is no second copy of the bump logic here
to drift out of sync. The guard goes red for a deleted step, an `if:` that stops firing, a
`git add` that forgets a path, or a retry that re-applies only some sites — not merely for a
deleted grep token.

## Cases

| case | kind | what it is |
|---|---|---|
| `bump` | POSITIVE | `bp-keycloak` — proven in scope of **every** site before the case runs |
| `retry` | POSITIVE | same bump, but a rival commit lands on main between the writer's edits and its push, forcing the retry loop's `git reset --hard origin/main` |
| `umbrella` | CONTROL, green both trees | `bp-catalyst-platform` — **is** in the kit and **is** in the seed, but its card renders a Helm template and it has no `blueprint.yaml`, so sites 2/3/4 are legitimate no-ops |
| `noop` | CONTROL, green both trees | no bump at all — the vacuity check |

**On the in-scope trap.** A control drawn from a blueprint the mechanism never looks at proves
nothing (the #5389 shape: a drift injected into `platform/neo4j` left the lockstep guard green
because `bp-neo4j` is absent from the seed). So `precheck_in_scope()` asserts and prints the
facts before drawing any conclusion from a case, and refuses to run a case whose chart is not
seen by the site it claims to exercise:

    in-scope facts for bump (bp-keycloak @ 1.5.7):
      · bootstrap-kit slots: ['09-keycloak.yaml']
      · catalog-seed entries: ['bp-keycloak']
      · blueprint.yaml: platform/keycloak/blueprint.yaml

    in-scope facts for umbrella (bp-catalyst-platform @ 1.4.1314):
      · bootstrap-kit slots: ['13-bp-catalyst-platform.yaml']
      · catalog-seed entries: ['bp-catalyst-platform']
      · blueprint.yaml: none

`bp-catalyst-platform` is the control precisely because it **is** in scope of the same mechanism —
it just legitimately has nothing to rewrite. A "fix" that made the guard assert every site always
moves would turn this control red.

The seed reader in the guard is an **independent** implementation, not an import of
`sync-catalog-seed-pin.py`'s parser: a guard that reuses the subject's parser inherits the
subject's blind spots, and it must also run against a tree where that helper does not exist yet.

## Both directions — verbatim

Run against **`d7e03c975`** (the parent of the #5678 merge — the tree that actually shipped the
bug) and against **`main`**.

### PRE-FIX, case `bump` → RED

    - ran   bump_pin       outputs={'bumped': 'true', 'pin_file': 'clusters/_template/bootstrap-kit/09-keycloak.yaml', 'prev_version': '1.5.7'}
    - ran   bump_blueprint outputs={'bumped': 'true', 'bp_file': 'platform/keycloak/blueprint.yaml', 'prev_version': '1.5.7'}
    - absent sync_seed     (not declared in this workflow)
    - ran   commit+push    outputs={}
    landed on origin/main: deploy(bp-keycloak): bump bootstrap-kit pin 1.5.7 -> 1.5.8 (auto, Refs TBD-A6)
      + clusters/_template/bootstrap-kit/09-keycloak.yaml
      + platform/keycloak/blueprint.yaml
      FAIL case bump — the release writer did not converge all five sites
        ✗ site 3 bp-keycloak spec.version: 1.5.7 != 1.5.8
        ✗ site 3 bp-keycloak source.version: 1.5.7 != 1.5.8
        ✗ site 4 committed generated catalog is STALE on the pushed main (#5520 gate would be red on every open PR):
    products/catalyst/bootstrap/api/internal/catalog/blueprints.json      | 4 ++--
     .../catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts   | 2 +-
     2 files changed, 3 insertions(+), 3 deletions(-)
        ✗ bootstrap-kit Go lockstep guards RED on the pushed main:
    --- FAIL: TestCatalogSeed_DeliveryPinsNotBehindComponentCharts (0.03s)
        main_test.go:1499: CATALOG-SEED DRIFT (#4415 / #4864):
              chart "bp-keycloak" delivery pin is BEHIND its component chart:
                catalog-seed source.version = "1.5.7"  (blueprints.yaml line 605)
                component chart/Chart.yaml   = "1.5.8"
    --- FAIL: TestCatalogSeed_DisplayVersionNotBehindDeliveryPin (0.03s)
        main_test.go:1652: CATALOG-SEED DISPLAY DRIFT (#4432 / R21):
              Blueprint "bp-keycloak" card spec.version is BEHIND its component chart:
                catalog-seed spec.version   = "1.5.7"  (blueprints.yaml line 582)
                component chart/Chart.yaml  = "1.5.8"
    FAIL	github.com/openova-io/openova/tests/e2e/bootstrap-kit	0.116s

    FAIL: the release writer leaves at least one lockstep site behind (#5583). Every deploy-bot chart bump will land drift on main and redden every open PR.

`case retry` fails identically on the pre-fix tree.

### PRE-FIX, controls → GREEN (the same run, same tree)

      PASS case umbrella — all five lockstep sites converged at 1.4.1291 on origin/main
      PASS case noop — all five lockstep sites converged at 1.5.7 on origin/main
    PASS: the release writer moves all five lockstep sites in the commit it pushes.

This is what makes the red above signal: on the identical tree, two cases go green. The guard is
not simply always red, and it cannot be satisfied by blanket suppression — suppressing site 3/4
assertions would turn `umbrella` red (it asserts the template is *not* rewritten into a literal).

### POST-FIX (`main`), all four cases → GREEN

      PASS case bump — all five lockstep sites converged at 1.5.8 on origin/main
      PASS case noop — all five lockstep sites converged at 1.5.7 on origin/main
      PASS case retry — all five lockstep sites converged at 1.5.8 on origin/main
      PASS case umbrella — all five lockstep sites converged at 1.4.1315 on origin/main
    PASS: the release writer moves all five lockstep sites in the commit it pushes.

The `bump` case's landed commit on main:

    landed on origin/main: deploy(bp-keycloak): bump bootstrap-kit pin 1.5.7 -> 1.5.8 (auto, Refs TBD-A6)
      + clusters/_template/bootstrap-kit/09-keycloak.yaml
      + platform/keycloak/blueprint.yaml
      + products/catalyst/bootstrap/api/internal/catalog/blueprints.json
      + products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
      + products/catalyst/chart/templates/catalog-seed/blueprints.yaml

## Findings from building it (no code change needed)

- The **retry path is genuinely correct.** `case retry` forces the real conflict → `git reset --hard
  origin/main` → re-apply, and the pushed commit still carries all five files:
  `deploy(bp-keycloak): lockstep pin+blueprint.yaml+catalog-seed -> 1.5.8 (… retry 1)` / 5 files changed.
- **All eight bot workflows that write a `Chart.yaml` version on main dispatch `blueprint-release`
  explicitly** (`gh workflow run blueprint-release.yaml`) — `build-bp-guacamole`, `build-bp-newapi`,
  `build-bp-newapi-sandbox-bridge`, `build-bp-wordpress-tenant-pg`, `build-k8s-ws-proxy`,
  `openclaw-controller`, `catalyst-build`, `services-build`. They push with `GITHUB_TOKEN`, which does
  not re-trigger workflows, so the explicit dispatch is load-bearing. No writer is orphaned.
- The catalog-seed has **no entry whose `manifests.chart` differs from its `source.chart`** (80 entries
  checked), so the helper's match-on-`manifests.chart` cannot miss a delivery pin today.

## Deliberately not fixed

- **No sixth site added, no change to the writer.** #5678's writer converges correctly under all four
  cases; adding behaviour here would be speculative.
- The guard's `WRITER_STEP_IDS` allow-list is explicit rather than "run every `run:` step" — the other
  steps in that job publish to GHCR and sign with cosign. It **fails closed**: a future sixth site in a
  new step id that is not listed will not be run, and the convergence assertions go red. A comment block
  in `blueprint-release.yaml` says exactly this at the point of edit.
- The guard is not wired into `manifest-validation`; it is its own workflow, path-scoped to the writer
  and its inputs, so it does not add time to unrelated PRs.

Refs #5583 #5678 #5520 #4432
