### PR TITLE
fix(cutover): pivot the loft chart source in EVERY region, not just the primary (Refs #5650)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1061,7 +1061,7 @@ spec:
       # index.yaml HelmRepository off charts.loft.sh into local Harbor +
       # suspends bp-vcluster-helmrepo so it holds; the step-08 fluxSourceHostLint
       # exception for charts.loft.sh is removed (empty allowHosts).
-      version: 0.1.171
+      version: 0.1.172
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.171
+  version: 0.1.172
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,49 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.172 (#5650) — THE LOFT CHART-SOURCE PIVOT NOW COVERS EVERY REGION. 0.1.168
+# shipped step-06 Phase-2c as a PRIMARY-ONLY block: every kubectl in it ran
+# against the Job's own in-cluster context. Bootstrap-kit slot 60 installs the
+# loft HelmRepository in EVERY region, so on a 2-region Sovereign the residual
+# charts.loft.sh tether is TWO objects, not the one #5650 originally named.
+#
+# Measured live on hw292 (dep 1c56518035a83e03, cutoverComplete=true since
+# 2026-08-03T08:12:04Z), sampled 2026-08-06 across 75 minutes — an interval
+# strictly longer than the actor's 15m period, because a single sample inside a
+# window proves nothing about a periodic actor. source-controller in BOTH
+# regions was still dialling the public internet ~63h after cutover:
+#
+#   region-a  23:36:44Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
+#   region-b  23:24:43Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
+#
+# Region-b's copy is not even referenced by a HelmRelease there and it still
+# reconciles — source-controller drives a HelmRepository on its own interval
+# regardless of consumers, so "nothing uses it" is not "it does not dial out".
+#
+# The consequence was worse than half a tether. Step-08's fluxSourceHostLint
+# runs PER REGION (#5359) over the same target list and its allowHosts went
+# EMPTY in 0.1.168, so a primary-only pivot makes the region-b lint fail and the
+# cutover can never reach cutoverComplete=true on the multi-region topology the
+# DoD requires. The pivot and the lint now build their region list identically.
+#
+# Phase-2c is restructured into loft_pivot_region(<region>,<kubeconfig>) called
+# for the primary and every mounted secondary. Sovereign-wide work (the Harbor
+# chart mirror, the durable Gitea slot suspend) still runs ONCE; only the live
+# patch is per-region, and each region now ends with a READ-BACK — `kubectl
+# patch` exiting 0 is not the object carrying the new URL. A region that cannot
+# be READ is fail-closed, not skipped (#5359: an unreadable region is not a
+# pivoted region).
+#
+# Phase-2c also moved OUT of podSpec.args into the step-06 ConfigMap's
+# phase2c.sh key, `.`-sourced from the step script (the step-03 run.sh pattern,
+# #5593). Step-06 rendered at 109254 B against the 110000 B MAX_ARG_STRLEN
+# early-warning budget — 746 bytes from the wall that killed step-03 live on
+# hw292 — and now renders at 98424 B with the secondary leg included.
+#
+# Guard: chart/tests/loft-pivot-regions.sh drives the REAL Phase-2c block out of
+# the render against a stub kubectl and asserts the per-region verdict in both
+# directions. On 0.1.171 it goes RED on 3 assertions (secondary never pivoted;
+# unreadable secondary passes; non-sticky patch passes) while its 4 controls
+# stay green on both trees, so it cannot be satisfied by disabling Phase-2c.
 # 0.1.171 (#5596) — THE SECONDARY-REGION PIVOT IS NOW PROVEN DURABLE, NOT MERELY
 # APPLIED. Step-06's #5359 secondary read-back was SINGLE-SHOT and fired within
 # seconds of the patch loop, so it measured the PATCH and never the PIVOT.
@@ -3370,7 +3414,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.171
+version: 0.1.172
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -81,6 +81,299 @@ data:
     {{- range .Values.helmRepositories.names }}
     {{ . }}
     {{- end }}
+  # #5593 — Phase 2c of the step script, mounted and exec (`.`-sourced) FROM
+  # FILE. Step-06 renders within a few hundred bytes of the 110000-byte inline
+  # arg budget, so this block MUST NOT move back into podSpec.args. Its
+  # extraction markers are also what chart/tests/loft-pivot-regions.sh drives.
+  phase2c.sh: |
+    # ---- Phase 2c (#5650): vcluster loft chart-source pivot ----
+    #
+    # The one Flux source the Phase-1/2 URL-pivot cannot reach. The
+    # bp-vcluster-helmrepo slot installs HelmRepository
+    # vcluster-system/loft at https://charts.loft.sh — a TRADITIONAL
+    # index.yaml source (spec.type default, NOT oci) in vcluster-system
+    # (NOT flux-system = HELMREPO_NAMESPACE). Phase-1 walks flux-system
+    # and matches only the openova-io OCI UPSTREAM_PREFIX, so it misses
+    # loft on both axes; post-cutover the org-controller's per-Org
+    # vcluster HelmReleases keep re-fetching charts.loft.sh on the HR's
+    # 15m interval — the residual tether #5650 found live on hw292,
+    # invisible to the timed step-08 hold (a 15m interval can straddle
+    # the 600s window). charts.loft.sh is an index.yaml repo no OpenOva
+    # registry mirrors, and the source default must stay upstream for
+    # non-Sovereign / pre-cutover installs, so the pivot is a RUNTIME
+    # cutover step (step-10 philosophy: keep chart defaults, rewrite
+    # POST-handover):
+    #   1. MIRROR — helm pull the upstream vcluster chart (egress still
+    #      open here) + helm push it OCI into local Harbor openova-io.
+    #   2. PIVOT  — patch the loft HR to type=oci +
+    #      url=oci://registry.<fqdn>/openova-io + secretRef=ghcr-pull
+    #      (Phase-0's registry.<fqdn> auth) + certSecretRef (Harbor CA),
+    #      replicating both secrets into vcluster-system where
+    #      source-controller reads them. Tenant HRs resolve chart=
+    #      vcluster version=0.33.* against the mirrored OCI tag unchanged.
+    #   3. DURABLE — suspend the bp-vcluster-helmrepo HelmRelease (live +
+    #      spec.suspend:true in the Gitea slot) so the 15m reconcile does
+    #      not re-render loft back to charts.loft.sh.
+    # FAIL-CLOSED: any sub-step that cannot complete leaves loft on
+    # charts.loft.sh and FATALs — step-08's fluxSourceHostLint (empty
+    # allowHosts) then fails the cutover on it rather than stamping a
+    # false cutoverComplete=true. See .Values.helmRepositories
+    # .vclusterLoftPivot and the fluxSourceHostLint HISTORY note.
+    #
+    # ── #5650 SECONDARY-REGION LEG (measured on hw292 2026-08-06) ──
+    #
+    # 0.1.168 shipped this pivot as a PRIMARY-ONLY block: every kubectl
+    # in it ran against the Job's own in-cluster context. But slot 60
+    # installs the loft HelmRepository in EVERY region, so on a 2-region
+    # Sovereign the tether is TWO objects, not one. Live on hw292 (dep
+    # 1c56518035a83e03), ~63h after cutoverComplete=true was stamped,
+    # source-controller in BOTH regions was still fetching it on the 15m
+    # interval — sampled across 75 minutes, i.e. an interval strictly
+    # longer than the actor's period, because a single sample inside a
+    # window proves nothing about a periodic actor:
+    #   region-a 23:36:44Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
+    #   region-b 23:24:43Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
+    # Region-b's copy is not even referenced by a HelmRelease there and
+    # it still reconciles: source-controller drives a HelmRepository on
+    # its own interval regardless of consumers, so "nothing uses it" is
+    # not "it does not dial out".
+    #
+    # And the consequence is worse than half a tether. Step-08's
+    # fluxSourceHostLint runs PER REGION (#5359) over the SAME target
+    # list, and its allowHosts is now EMPTY — so a primary-only pivot
+    # makes the region-b lint fail and the cutover can never reach
+    # cutoverComplete=true on the multi-region topology the DoD requires.
+    # The pivot must cover exactly the regions the lint measures; those
+    # two target lists are built the same way on purpose.
+    #
+    # SHARED vs PER-REGION. The Harbor mirror (one registry endpoint for
+    # the Sovereign) and the durable Gitea slot edit (one Gitea, which
+    # the secondaries also reconcile from after step-05) are
+    # SOVEREIGN-WIDE and run ONCE. Only the live patch — secret
+    # replication + HelmRepository patch + HelmRelease suspend + the
+    # read-back — is per-region.
+    #
+    # The `_lp_kubectl` shim is written on ONE line on purpose:
+    # chart/tests/loft-pivot-regions.sh extracts this function out of the
+    # RENDER with an awk range that terminates on the first bare `}`
+    # line, so a nested multi-line function definition would silently
+    # truncate the function under test (the #5646 drift shape).
+    loft_pivot_region() {
+      _lp_region="${1:-primary}"
+      _LP_KUBECONFIG="${2:-}"
+      _lp_kubectl() { if [ -n "${_LP_KUBECONFIG:-}" ]; then kubectl --kubeconfig="${_LP_KUBECONFIG}" "$@"; else kubectl "$@"; fi; }
+      _lp_kubectl create namespace "${VCL_LOFT_NAMESPACE}" >/dev/null 2>&1 || true
+      # 1. Pull auth. source-controller reads spec.secretRef from the
+      #    HR's OWN namespace, in the HR's OWN cluster — so the bytes
+      #    captured once from the primary must be applied into every
+      #    region, not just this Job's.
+      if [ ! -s "${LOFT_GHCR_SECRET_JSON}" ]; then
+        echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: no ${GHCR_PULL_SECRET_NAME} bytes were captured from the primary — the pivoted loft HR would 401 (#5650)" >&2
+        return 1
+      fi
+      if jq --arg ns "${VCL_LOFT_NAMESPACE}" '{apiVersion,kind,type,data,metadata:{name:.metadata.name,namespace:$ns}}' "${LOFT_GHCR_SECRET_JSON}" | _lp_kubectl apply -f - >/dev/null 2>&1; then
+        echo "[helmrepository-patches] Phase-2c [${_lp_region}]: replicated ${GHCR_PULL_SECRET_NAME} -> ${VCL_LOFT_NAMESPACE} (carries the registry.${SOVEREIGN_FQDN} auth Phase-0 added)"
+      else
+        echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: could not replicate ${GHCR_PULL_SECRET_NAME} into ${VCL_LOFT_NAMESPACE} — the pivoted loft HR would 401 (#5650)" >&2
+        return 1
+      fi
+      # 2. Harbor CA trust (optional — absent on a public-CA Harbor).
+      _lp_certref=""
+      if [ -n "${LOFT_TRUST_SECRET}" ] && [ -n "${LOFT_CA_B64}" ]; then
+        if printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: helmrepository-patches\ntype: Opaque\ndata:\n  ca.crt: %s\n' "${LOFT_TRUST_SECRET}" "${VCL_LOFT_NAMESPACE}" "${LOFT_CA_B64}" | _lp_kubectl apply -f - >/dev/null 2>&1; then
+          _lp_certref="${LOFT_TRUST_SECRET}"
+          echo "[helmrepository-patches] Phase-2c [${_lp_region}]: replicated Harbor CA trust ${LOFT_TRUST_SECRET} -> ${VCL_LOFT_NAMESPACE}"
+        else
+          echo "[helmrepository-patches] Phase-2c WARN [${_lp_region}]: could not apply trust CA into ${VCL_LOFT_NAMESPACE} — pivoting WITHOUT certSecretRef (needs a public-CA Harbor cert)"
+        fi
+      fi
+      # 3. LIVE-PATCH the loft HR in THIS region: index.yaml -> local OCI.
+      if [ -n "${_lp_certref}" ]; then
+        _lp_patch=$(printf '{"spec":{"type":"oci","url":"%s","secretRef":{"name":"%s"},"certSecretRef":{"name":"%s"}}}' "${LOFT_LOCAL_URL}" "${GHCR_PULL_SECRET_NAME}" "${_lp_certref}")
+      else
+        _lp_patch=$(printf '{"spec":{"type":"oci","url":"%s","secretRef":{"name":"%s"}}}' "${LOFT_LOCAL_URL}" "${GHCR_PULL_SECRET_NAME}")
+      fi
+      if _lp_kubectl patch helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" --type=merge --patch "${_lp_patch}" >/dev/null 2>&1; then
+        _lp_kubectl annotate --overwrite helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
+        echo "[helmrepository-patches] Phase-2c OK [${_lp_region}]: loft HR pivoted -> type=oci url=${LOFT_LOCAL_URL}"
+      else
+        echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: kubectl patch of loft HR failed (#5650)" >&2
+        return 1
+      fi
+      # 4. Suspend the bp-vcluster-helmrepo HelmRelease IN THIS REGION so
+      #    its next reconcile does not re-render loft back to
+      #    charts.loft.sh. Slot 60 lands in every region, so the reverting
+      #    actor exists in every region too.
+      if _lp_kubectl get helmrelease "${VCL_LOFT_RELEASE}" -n "${VCL_LOFT_RELEASE_NS}" >/dev/null 2>&1; then
+        if _lp_kubectl patch helmrelease "${VCL_LOFT_RELEASE}" -n "${VCL_LOFT_RELEASE_NS}" --type=merge --patch '{"spec":{"suspend":true}}' >/dev/null 2>&1; then
+          echo "[helmrepository-patches] Phase-2c OK [${_lp_region}]: suspended ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} (live) so the loft pivot is not reverted"
+        else
+          echo "[helmrepository-patches] Phase-2c WARN [${_lp_region}]: could not suspend ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} live — the durable Gitea edit below is the backstop"
+        fi
+      else
+        echo "[helmrepository-patches] Phase-2c [${_lp_region}]: HelmRelease ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} absent — nothing to suspend (loft HR may be operator-managed)"
+      fi
+      # 5. READ-BACK. `kubectl patch` exiting 0 is not the same as the
+      #    object carrying the new URL — an admission webhook or a
+      #    competing controller can revert it inside the same second, and
+      #    a Job that logged OK on an un-pivoted region is precisely the
+      #    single-region-sample failure this leg exists to end. Assert on
+      #    the DECLARATION we just wrote, in the region we wrote it to.
+      _lp_after=$(_lp_kubectl get helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" -o jsonpath='{.spec.url}' 2>/dev/null || echo "")
+      if [ "${_lp_after}" != "${LOFT_LOCAL_URL}" ]; then
+        echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: read-back shows spec.url='${_lp_after}', expected '${LOFT_LOCAL_URL}' — the pivot did not stick and this region would keep fetching ${VCL_LOFT_UPSTREAM_REPO} on its 15m interval (#5650)" >&2
+        return 1
+      fi
+      echo "[helmrepository-patches] Phase-2c [${_lp_region}]: read-back OK — spec.url=${_lp_after}"
+      return 0
+    }
+    if [ "${VCL_LOFT_PIVOT_ENABLED}" = "true" ]; then
+      LOFT_LOCAL_URL="oci://${harbor_endpoint}/${VCL_LOFT_LOCAL_PROJECT}"
+      LOFT_GHCR_SECRET_JSON="/tmp/.loft-ghcr-pull.json"
+      LOFT_TRUST_SECRET=""
+      LOFT_CA_B64=""
+      # ---- Target list: the SAME construction step-08's per-region
+      #      fluxSourceHostLint uses (primary + every mounted secondary
+      #      kubeconfig). If these two lists diverge, the lint measures a
+      #      region the pivot never touched — which IS this defect.
+      # SECONDARY_KUBECONFIG_DIR defaults to the Job's real mount and is
+      # overridable ONLY so chart/tests/loft-pivot-regions.sh can drive
+      # this block with a stub region set — the same seam WORK_DIR gives
+      # the step-08 lints. Nothing in the chart ever sets it.
+      loft_targets="primary="
+      for lt_kc in "${SECONDARY_KUBECONFIG_DIR:-/secondary-kubeconfigs}"/*.yaml; do
+        [ -e "${lt_kc}" ] || continue
+        loft_targets="${loft_targets} $(basename "${lt_kc}" .yaml)=${lt_kc}"
+      done
+      # ---- Classify every region: absent / already-oci / needs-pivot.
+      #      A region that cannot be READ is fail-closed: indistinguishable
+      #      from a pivoted one only in the log (#5359).
+      loft_need=""
+      for lt in ${loft_targets}; do
+        lt_region="${lt%%=*}"
+        lt_kc="${lt#*=}"
+        if [ -n "${lt_kc}" ]; then lt_ctx="--kubeconfig=${lt_kc}"; else lt_ctx=""; fi
+        if ! kubectl ${lt_ctx} get helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" -o json >/tmp/.loft-probe.json 2>/tmp/.loft-probe.err; then
+          if grep -qiE 'not found|no matches for kind|server doesn.t have a resource type|could not find the requested resource' /tmp/.loft-probe.err 2>/dev/null; then
+            echo "[helmrepository-patches] Phase-2c SKIP [${lt_region}]: HelmRepository ${VCL_LOFT_NAMESPACE}/${VCL_LOFT_HR_NAME} not present — bp-vcluster-helmrepo slot not installed in this region (#5650)"
+            continue
+          fi
+          echo "[helmrepository-patches] FATAL: Phase-2c cannot read ${VCL_LOFT_NAMESPACE}/${VCL_LOFT_HR_NAME} in region ${lt_region} ($(head -1 /tmp/.loft-probe.err 2>/dev/null)). An unreadable region is NOT a pivoted region — refusing to record success while it may still be on ${VCL_LOFT_UPSTREAM_REPO} (#5650 #5359)" >&2
+          exit 1
+        fi
+        lt_url=$(jq -r '.spec.url // ""' /tmp/.loft-probe.json 2>/dev/null)
+        lt_type=$(jq -r '.spec.type // ""' /tmp/.loft-probe.json 2>/dev/null)
+        if [ "${lt_type}" = "oci" ]; then
+          # Already OCI (idempotent re-run, or an operator overlay). The
+          # step-08 fluxSourceHostLint judges locality either way; leave it.
+          echo "[helmrepository-patches] Phase-2c SKIP [${lt_region}]: loft HR is already type=oci (${lt_url}) — idempotent re-run / operator overlay (#5650)"
+          continue
+        fi
+        echo "[helmrepository-patches] Phase-2c [${lt_region}]: loft HR on ${lt_url} — queued for pivot -> ${LOFT_LOCAL_URL}"
+        loft_need="${loft_need} ${lt_region}=${lt_kc}"
+      done
+      if [ -z "${loft_need}" ]; then
+        echo "[helmrepository-patches] Phase-2c: no region needs the loft pivot (absent or already local) — nothing to do (#5650)"
+      else
+        echo "[helmrepository-patches] Phase-2c: pivoting loft chart source -> ${LOFT_LOCAL_URL} in region(s):${loft_need} (#5650)"
+        # In-cluster Harbor serves an LE-staging (node-untrusted) cert on
+        # a fresh prov; the Job Pod has no node trust store. Mirror the
+        # same insecure-flag discipline Phase-3a uses (login vs pull take
+        # DIFFERENT flag spellings on helm v3.16.x).
+        case "${HELM_IN_CLUSTER_TLS_VERIFY:-false}" in
+          true|True|TRUE|1|yes) VCL_LFLAG=""; VCL_PFLAG="" ;;
+          *) VCL_LFLAG="--insecure"; VCL_PFLAG="--insecure-skip-tls-verify" ;;
+        esac
+        # 1. MIRROR (ONCE — one Harbor endpoint serves every region).
+        helm registry login "${harbor_endpoint}" ${VCL_LFLAG} \
+          -u "${HARBOR_USERNAME:-admin}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
+          && echo "[helmrepository-patches] Phase-2c: helm registry login ${harbor_endpoint} OK" \
+          || echo "[helmrepository-patches] Phase-2c WARN: helm registry login ${harbor_endpoint} non-zero (push may still succeed on a public-CA Harbor)"
+        rm -rf /tmp/loft-pull; mkdir -p /tmp/loft-pull
+        loft_pulled=0
+        vcl_att=0
+        while [ "${vcl_att}" -lt "${VCL_LOFT_PULL_ATTEMPTS:-3}" ]; do
+          vcl_att=$((vcl_att + 1))
+          if helm pull "${VCL_LOFT_CHART}" --repo "${VCL_LOFT_UPSTREAM_REPO}" \
+               --version "${VCL_LOFT_VERSION}" -d /tmp/loft-pull >/tmp/.loft-pull.log 2>&1; then
+            loft_pulled=1; break
+          fi
+          echo "[helmrepository-patches] Phase-2c: upstream pull ${VCL_LOFT_UPSTREAM_REPO} ${VCL_LOFT_CHART} ${VCL_LOFT_VERSION} attempt ${vcl_att}/${VCL_LOFT_PULL_ATTEMPTS:-3} failed; retrying in 5s"
+          sleep 5
+        done
+        if [ "${loft_pulled}" != "1" ]; then
+          echo "[helmrepository-patches] FATAL: Phase-2c could not pull the upstream vcluster chart from ${VCL_LOFT_UPSTREAM_REPO} (egress is still open at step-06 — a real upstream/DNS failure, not the deny hold). Leaving loft on the upstream URL; step-08 fluxSourceHostLint fails closed on it (#5650)." >&2
+          sed 's/^/    /' /tmp/.loft-pull.log 2>/dev/null | tail -6 >&2 || true
+          exit 1
+        fi
+        loft_tgz=$(ls /tmp/loft-pull/*.tgz 2>/dev/null | head -n1)
+        if [ -z "${loft_tgz}" ]; then
+          echo "[helmrepository-patches] FATAL: Phase-2c produced no chart tarball for ${VCL_LOFT_CHART} ${VCL_LOFT_VERSION} (#5650)" >&2
+          exit 1
+        fi
+        if ! helm push "${loft_tgz}" "${LOFT_LOCAL_URL}" ${VCL_PFLAG} >/tmp/.loft-push.log 2>&1; then
+          echo "[helmrepository-patches] FATAL: Phase-2c push ${loft_tgz##*/} -> ${LOFT_LOCAL_URL} failed — local Harbor cannot serve the pivoted loft source; leaving loft on the upstream URL (step-08 fails closed) (#5650)" >&2
+          sed 's/^/    /' /tmp/.loft-push.log 2>/dev/null | tail -6 >&2 || true
+          exit 1
+        fi
+        echo "[helmrepository-patches] Phase-2c OK: mirrored ${VCL_LOFT_CHART} ${VCL_LOFT_VERSION} -> ${LOFT_LOCAL_URL}/${VCL_LOFT_CHART}"
+        # 2. Capture the auth + trust material ONCE from the primary, then
+        #    replicate it into every region that needs the pivot.
+        gp_src_ns="${GHCR_PULL_SECRET_NAMESPACE}"
+        kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "${gp_src_ns}" >/dev/null 2>&1 || gp_src_ns="flux-system"
+        if ! kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "${gp_src_ns}" -o json >"${LOFT_GHCR_SECRET_JSON}" 2>/dev/null; then
+          echo "[helmrepository-patches] FATAL: Phase-2c could not read ${GHCR_PULL_SECRET_NAME} (tried ${GHCR_PULL_SECRET_NAMESPACE} + flux-system) — the pivoted loft HR would 401 (#5650)" >&2
+          exit 1
+        fi
+        if [ -n "${trust_secret}" ]; then
+          LOFT_CA_B64=$(kubectl get secret "${trust_secret}" -n "${HELMREPO_NAMESPACE}" -o json 2>/dev/null | jq -r '.data["ca.crt"] // empty')
+          [ -n "${LOFT_CA_B64}" ] && LOFT_TRUST_SECRET="${trust_secret}"
+        fi
+        # 3. PIVOT every queued region. One failing region FATALs the
+        #    step: a partially-pivoted Sovereign that reports success is
+        #    the exact shape of the defect (#5359 #5596 #5650).
+        loft_pivoted=0
+        for ln in ${loft_need}; do
+          ln_region="${ln%%=*}"
+          ln_kc="${ln#*=}"
+          if ! loft_pivot_region "${ln_region}" "${ln_kc}"; then
+            echo "[helmrepository-patches] FATAL: Phase-2c region ${ln_region} could not be pivoted off ${VCL_LOFT_UPSTREAM_REPO} — refusing to record success on a partially-pivoted Sovereign (#5650)" >&2
+            exit 1
+          fi
+          loft_pivoted=$((loft_pivoted + 1))
+        done
+        echo "[helmrepository-patches] Phase-2c OK: ${loft_pivoted} region(s) pivoted off ${VCL_LOFT_UPSTREAM_REPO} onto ${LOFT_LOCAL_URL} (#5650)"
+        # 4. DURABLE (ONCE): set spec.suspend=true on the slot file in the
+        #    Gitea clone so the bootstrap-kit reconcile keeps loft
+        #    suspended. One Gitea serves every region after step-05.
+        if [ -f "${VCL_LOFT_SLOT_FILE}" ]; then
+          vcl_yq=""
+          if command -v yq >/dev/null 2>&1; then
+            vcl_yq="yes"
+          else
+            apk add --no-cache yq >/dev/null 2>&1 || true
+            command -v yq >/dev/null 2>&1 && vcl_yq="yes"
+          fi
+          if [ -n "${vcl_yq}" ]; then
+            if yq -i '(select(.kind == "HelmRelease").spec.suspend) = true' "${VCL_LOFT_SLOT_FILE}" 2>/tmp/.loft-yq.log; then
+              edited=$((edited + 1))
+              echo "[helmrepository-patches] Phase-2c OK: durable spec.suspend=true written to ${VCL_LOFT_SLOT_FILE} (yq)"
+            else
+              echo "[helmrepository-patches] Phase-2c WARN: yq edit of ${VCL_LOFT_SLOT_FILE} failed — live suspend holds; durable revert-guard not written:" >&2
+              sed 's/^/    /' /tmp/.loft-yq.log 2>/dev/null | tail -4 >&2 || true
+            fi
+          else
+            echo "[helmrepository-patches] Phase-2c WARN: yq unavailable — durable suspend not written to ${VCL_LOFT_SLOT_FILE}; the live HelmRelease suspend holds the pivot for this cutover"
+          fi
+        else
+          echo "[helmrepository-patches] Phase-2c WARN: ${VCL_LOFT_SLOT_FILE} not present in the local mirror — durable suspend skipped; live suspend holds the pivot"
+        fi
+      fi
+    else
+      echo "[helmrepository-patches] Phase-2c SKIP: vclusterLoftPivot.enabled=false (#5650)"
+    fi
+    # ---- end Phase 2c (#5650) ----
+
   podSpec: |
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
@@ -343,6 +636,10 @@ data:
             readOnly: true
           - name: bootstrap-kit-pins
             mountPath: /pin-extractor
+            readOnly: true
+          # #5593 — Phase 2c of the step script, `.`-sourced from here.
+          - name: phase2c-script
+            mountPath: /phase2c
             readOnly: true
           - name: tmp
             mountPath: /tmp
@@ -1289,177 +1586,15 @@ data:
               echo "[helmrepository-patches] Phase-2.5 SKIP: ${catalyst_yaml} not present in local mirror"
             fi
 
-            # ---- Phase 2c (#5650): vcluster loft chart-source pivot ----
-            #
-            # The one Flux source the Phase-1/2 URL-pivot cannot reach. The
-            # bp-vcluster-helmrepo slot installs HelmRepository
-            # vcluster-system/loft at https://charts.loft.sh — a TRADITIONAL
-            # index.yaml source (spec.type default, NOT oci) in vcluster-system
-            # (NOT flux-system = HELMREPO_NAMESPACE). Phase-1 walks flux-system
-            # and matches only the openova-io OCI UPSTREAM_PREFIX, so it misses
-            # loft on both axes; post-cutover the org-controller's per-Org
-            # vcluster HelmReleases keep re-fetching charts.loft.sh on the HR's
-            # 15m interval — the residual tether #5650 found live on hw292,
-            # invisible to the timed step-08 hold (a 15m interval can straddle
-            # the 600s window). charts.loft.sh is an index.yaml repo no OpenOva
-            # registry mirrors, and the source default must stay upstream for
-            # non-Sovereign / pre-cutover installs, so the pivot is a RUNTIME
-            # cutover step (step-10 philosophy: keep chart defaults, rewrite
-            # POST-handover):
-            #   1. MIRROR — helm pull the upstream vcluster chart (egress still
-            #      open here) + helm push it OCI into local Harbor openova-io.
-            #   2. PIVOT  — patch the loft HR to type=oci +
-            #      url=oci://registry.<fqdn>/openova-io + secretRef=ghcr-pull
-            #      (Phase-0's registry.<fqdn> auth) + certSecretRef (Harbor CA),
-            #      replicating both secrets into vcluster-system where
-            #      source-controller reads them. Tenant HRs resolve chart=
-            #      vcluster version=0.33.* against the mirrored OCI tag unchanged.
-            #   3. DURABLE — suspend the bp-vcluster-helmrepo HelmRelease (live +
-            #      spec.suspend:true in the Gitea slot) so the 15m reconcile does
-            #      not re-render loft back to charts.loft.sh.
-            # FAIL-CLOSED: any sub-step that cannot complete leaves loft on
-            # charts.loft.sh and FATALs — step-08's fluxSourceHostLint (empty
-            # allowHosts) then fails the cutover on it rather than stamping a
-            # false cutoverComplete=true. See .Values.helmRepositories
-            # .vclusterLoftPivot and the fluxSourceHostLint HISTORY note.
-            if [ "${VCL_LOFT_PIVOT_ENABLED}" = "true" ]; then
-              loft_local_url="oci://${harbor_endpoint}/${VCL_LOFT_LOCAL_PROJECT}"
-              loft_already=0
-              loft_cur_url=$(kubectl get helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" -o jsonpath='{.spec.url}' 2>/dev/null || echo "")
-              loft_cur_type=$(kubectl get helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" -o jsonpath='{.spec.type}' 2>/dev/null || echo "")
-              if [ -z "${loft_cur_url}" ]; then
-                echo "[helmrepository-patches] Phase-2c SKIP: HelmRepository ${VCL_LOFT_NAMESPACE}/${VCL_LOFT_HR_NAME} not present — bp-vcluster-helmrepo slot not installed on this Sovereign (#5650)"
-              elif [ "${loft_cur_type}" = "oci" ]; then
-                # Already OCI (idempotent re-run, or an operator overlay). The
-                # step-08 fluxSourceHostLint judges locality either way; leave it.
-                echo "[helmrepository-patches] Phase-2c SKIP: loft HR is already type=oci (${loft_cur_url}) — idempotent re-run / operator overlay (#5650)"
-                loft_already=1
-              fi
-              if [ -n "${loft_cur_url}" ] && [ "${loft_already}" != "1" ]; then
-                echo "[helmrepository-patches] Phase-2c: pivoting loft chart source ${loft_cur_url} -> ${loft_local_url} (#5650)"
-                # In-cluster Harbor serves an LE-staging (node-untrusted) cert on
-                # a fresh prov; the Job Pod has no node trust store. Mirror the
-                # same insecure-flag discipline Phase-3a uses (login vs pull take
-                # DIFFERENT flag spellings on helm v3.16.x).
-                case "${HELM_IN_CLUSTER_TLS_VERIFY:-false}" in
-                  true|True|TRUE|1|yes) VCL_LFLAG=""; VCL_PFLAG="" ;;
-                  *) VCL_LFLAG="--insecure"; VCL_PFLAG="--insecure-skip-tls-verify" ;;
-                esac
-                # 1. MIRROR: helm pull the upstream index chart + push local OCI.
-                helm registry login "${harbor_endpoint}" ${VCL_LFLAG} \
-                  -u "${HARBOR_USERNAME:-admin}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
-                  && echo "[helmrepository-patches] Phase-2c: helm registry login ${harbor_endpoint} OK" \
-                  || echo "[helmrepository-patches] Phase-2c WARN: helm registry login ${harbor_endpoint} non-zero (push may still succeed on a public-CA Harbor)"
-                rm -rf /tmp/loft-pull; mkdir -p /tmp/loft-pull
-                loft_pulled=0
-                vcl_att=0
-                while [ "${vcl_att}" -lt "${VCL_LOFT_PULL_ATTEMPTS:-3}" ]; do
-                  vcl_att=$((vcl_att + 1))
-                  if helm pull "${VCL_LOFT_CHART}" --repo "${VCL_LOFT_UPSTREAM_REPO}" \
-                       --version "${VCL_LOFT_VERSION}" -d /tmp/loft-pull >/tmp/.loft-pull.log 2>&1; then
-                    loft_pulled=1; break
-                  fi
-                  echo "[helmrepository-patches] Phase-2c: upstream pull ${VCL_LOFT_UPSTREAM_REPO} ${VCL_LOFT_CHART} ${VCL_LOFT_VERSION} attempt ${vcl_att}/${VCL_LOFT_PULL_ATTEMPTS:-3} failed; retrying in 5s"
-                  sleep 5
-                done
-                if [ "${loft_pulled}" != "1" ]; then
-                  echo "[helmrepository-patches] FATAL: Phase-2c could not pull the upstream vcluster chart from ${VCL_LOFT_UPSTREAM_REPO} (egress is still open at step-06 — a real upstream/DNS failure, not the deny hold). Leaving loft on ${loft_cur_url}; step-08 fluxSourceHostLint fails closed on it (#5650)." >&2
-                  sed 's/^/    /' /tmp/.loft-pull.log 2>/dev/null | tail -6 >&2 || true
-                  exit 1
-                fi
-                loft_tgz=$(ls /tmp/loft-pull/*.tgz 2>/dev/null | head -n1)
-                if [ -z "${loft_tgz}" ]; then
-                  echo "[helmrepository-patches] FATAL: Phase-2c produced no chart tarball for ${VCL_LOFT_CHART} ${VCL_LOFT_VERSION} (#5650)" >&2
-                  exit 1
-                fi
-                if ! helm push "${loft_tgz}" "${loft_local_url}" ${VCL_PFLAG} >/tmp/.loft-push.log 2>&1; then
-                  echo "[helmrepository-patches] FATAL: Phase-2c push ${loft_tgz##*/} -> ${loft_local_url} failed — local Harbor cannot serve the pivoted loft source; leaving loft on ${loft_cur_url} (step-08 fails closed) (#5650)" >&2
-                  sed 's/^/    /' /tmp/.loft-push.log 2>/dev/null | tail -6 >&2 || true
-                  exit 1
-                fi
-                echo "[helmrepository-patches] Phase-2c OK: mirrored ${VCL_LOFT_CHART} ${VCL_LOFT_VERSION} -> ${loft_local_url}/${VCL_LOFT_CHART}"
-                # 2. Replicate pull auth + the Harbor CA trust into the loft HR
-                #    namespace — source-controller reads spec.secretRef and
-                #    spec.certSecretRef from the HR's OWN namespace, not flux-system.
-                kubectl create namespace "${VCL_LOFT_NAMESPACE}" >/dev/null 2>&1 || true
-                gp_src_ns="${GHCR_PULL_SECRET_NAMESPACE}"
-                kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "${gp_src_ns}" >/dev/null 2>&1 || gp_src_ns="flux-system"
-                if kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "${gp_src_ns}" -o json 2>/dev/null \
-                     | jq --arg ns "${VCL_LOFT_NAMESPACE}" '{apiVersion,kind,type,data,metadata:{name:.metadata.name,namespace:$ns}}' \
-                     | kubectl apply -f - >/dev/null 2>&1; then
-                  echo "[helmrepository-patches] Phase-2c: replicated ${GHCR_PULL_SECRET_NAME} -> ${VCL_LOFT_NAMESPACE} (carries the registry.${SOVEREIGN_FQDN} auth Phase-0 added)"
-                else
-                  echo "[helmrepository-patches] FATAL: Phase-2c could not replicate ${GHCR_PULL_SECRET_NAME} into ${VCL_LOFT_NAMESPACE} — the pivoted loft HR would 401 (#5650)" >&2
-                  exit 1
-                fi
-                loft_certref=""
-                if [ -n "${trust_secret}" ]; then
-                  loft_ca_b64=$(kubectl get secret "${trust_secret}" -n "${HELMREPO_NAMESPACE}" -o json 2>/dev/null | jq -r '.data["ca.crt"] // empty')
-                  if [ -n "${loft_ca_b64}" ]; then
-                    if printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: helmrepository-patches\ntype: Opaque\ndata:\n  ca.crt: %s\n' \
-                         "${trust_secret}" "${VCL_LOFT_NAMESPACE}" "${loft_ca_b64}" | kubectl apply -f - >/dev/null 2>&1; then
-                      loft_certref="${trust_secret}"
-                      echo "[helmrepository-patches] Phase-2c: replicated Harbor CA trust ${trust_secret} -> ${VCL_LOFT_NAMESPACE}"
-                    else
-                      echo "[helmrepository-patches] Phase-2c WARN: could not apply trust CA into ${VCL_LOFT_NAMESPACE} — pivoting WITHOUT certSecretRef (needs a public-CA Harbor cert)"
-                    fi
-                  fi
-                fi
-                # 3. LIVE-PATCH the loft HR: index.yaml -> local OCI.
-                if [ -n "${loft_certref}" ]; then
-                  loft_patch=$(printf '{"spec":{"type":"oci","url":"%s","secretRef":{"name":"%s"},"certSecretRef":{"name":"%s"}}}' "${loft_local_url}" "${GHCR_PULL_SECRET_NAME}" "${loft_certref}")
-                else
-                  loft_patch=$(printf '{"spec":{"type":"oci","url":"%s","secretRef":{"name":"%s"}}}' "${loft_local_url}" "${GHCR_PULL_SECRET_NAME}")
-                fi
-                if kubectl patch helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" \
-                     --type=merge --patch "${loft_patch}" >/dev/null 2>&1; then
-                  kubectl annotate --overwrite helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" \
-                    "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
-                  echo "[helmrepository-patches] Phase-2c OK: loft HR pivoted -> type=oci url=${loft_local_url}"
-                else
-                  echo "[helmrepository-patches] FATAL: Phase-2c kubectl patch of loft HR failed (#5650)" >&2
-                  exit 1
-                fi
-                # 4. Suspend the bp-vcluster-helmrepo HelmRelease (live) so its
-                #    next reconcile does not re-render loft back to charts.loft.sh.
-                if kubectl get helmrelease "${VCL_LOFT_RELEASE}" -n "${VCL_LOFT_RELEASE_NS}" >/dev/null 2>&1; then
-                  if kubectl patch helmrelease "${VCL_LOFT_RELEASE}" -n "${VCL_LOFT_RELEASE_NS}" \
-                       --type=merge --patch '{"spec":{"suspend":true}}' >/dev/null 2>&1; then
-                    echo "[helmrepository-patches] Phase-2c OK: suspended ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} (live) so the loft pivot is not reverted"
-                  else
-                    echo "[helmrepository-patches] Phase-2c WARN: could not suspend ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} live — the durable Gitea edit below is the backstop"
-                  fi
-                else
-                  echo "[helmrepository-patches] Phase-2c: HelmRelease ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} absent — nothing to suspend (loft HR may be operator-managed)"
-                fi
-                # 5. DURABLE: set spec.suspend=true on the slot file in the Gitea
-                #    clone so the bootstrap-kit reconcile keeps loft suspended.
-                if [ -f "${VCL_LOFT_SLOT_FILE}" ]; then
-                  vcl_yq=""
-                  if command -v yq >/dev/null 2>&1; then
-                    vcl_yq="yes"
-                  else
-                    apk add --no-cache yq >/dev/null 2>&1 || true
-                    command -v yq >/dev/null 2>&1 && vcl_yq="yes"
-                  fi
-                  if [ -n "${vcl_yq}" ]; then
-                    if yq -i '(select(.kind == "HelmRelease").spec.suspend) = true' "${VCL_LOFT_SLOT_FILE}" 2>/tmp/.loft-yq.log; then
-                      edited=$((edited + 1))
-                      echo "[helmrepository-patches] Phase-2c OK: durable spec.suspend=true written to ${VCL_LOFT_SLOT_FILE} (yq)"
-                    else
-                      echo "[helmrepository-patches] Phase-2c WARN: yq edit of ${VCL_LOFT_SLOT_FILE} failed — live suspend holds; durable revert-guard not written:" >&2
-                      sed 's/^/    /' /tmp/.loft-yq.log 2>/dev/null | tail -4 >&2 || true
-                    fi
-                  else
-                    echo "[helmrepository-patches] Phase-2c WARN: yq unavailable — durable suspend not written to ${VCL_LOFT_SLOT_FILE}; the live HelmRelease suspend holds the pivot for this cutover"
-                  fi
-                else
-                  echo "[helmrepository-patches] Phase-2c WARN: ${VCL_LOFT_SLOT_FILE} not present in the local mirror — durable suspend skipped; live suspend holds the pivot"
-                fi
-              fi
-            else
-              echo "[helmrepository-patches] Phase-2c SKIP: vclusterLoftPivot.enabled=false (#5650)"
-            fi
+            # Phase 2c (#5650) — the vcluster loft chart-source pivot, sourced
+            # FROM FILE rather than inlined. It is ~10 KiB of shell and step-06
+            # already renders within a few hundred bytes of the 110000-byte
+            # MAX_ARG_STRLEN early-warning budget (#5593): inlining it dies at
+            # exec with "argument list too long" before a single line runs. Same
+            # `.`-source discipline as step-03 run.sh / resolver.sh — it runs in
+            # THIS shell, so ${edited}, ${harbor_endpoint} and ${trust_secret}
+            # are visible to it and its `exit 1` FATALs the whole step.
+            . /phase2c/phase2c.sh
 
             # NOTE (Refs #3379 #3526): the two "nothing to push" paths below
             # must FALL THROUGH to Phase 3 (the readiness-gated strip), NOT
@@ -2385,6 +2520,13 @@ data:
           items:
             - key: extract-pins.sh
               path: extract-pins.sh
+      # #5593 — the same step-06 ConfigMap, exposing ONLY the phase2c.sh key.
+      - name: phase2c-script
+        configMap:
+          name: cutover-step-06-helmrepository-patches
+          items:
+            - key: phase2c.sh
+              path: phase2c.sh
       - name: tmp
         emptyDir: {}
       # #5359 — materialised by catalyst-api (cutover.go runCutover) from its

--- a/platform/self-sovereign-cutover/chart/tests/loft-pivot-regions.sh
+++ b/platform/self-sovereign-cutover/chart/tests/loft-pivot-regions.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# #5650 — behavioural test for step-06 Phase-2c: the vcluster loft chart-source
+# pivot must cover EVERY region, not just the primary.
+#
+# WHY THIS TEST EXISTS, and why it is not a grep.
+#
+# 0.1.168 shipped Phase-2c as a primary-only block: every kubectl in it ran
+# against the Job's own in-cluster context. Slot 60 installs the loft
+# HelmRepository in EVERY region, so on a 2-region Sovereign the tether is TWO
+# objects. Measured live on hw292 (dep 1c56518035a83e03), ~63h after
+# cutoverComplete=true, source-controller in BOTH regions was still fetching
+# https://charts.loft.sh on its 15m interval.
+#
+# The defect class #5650 is about is "a guard aimed at a moment that cannot
+# fail". A single-shot sample inside a window proves nothing about a periodic
+# actor, so this test does not observe traffic at all — it asserts on the
+# DECLARATION the pivot leaves behind, per region, which is not a race.
+#
+# HOW IT AVOIDS BEING THE SAME MISTAKE. It extracts the REAL Phase-2c block out
+# of the RENDERED Job (not a copy pasted here — #5646) and executes it against
+# stub kubectl/helm, then asserts the VERDICT and the recorded call log in both
+# directions. Every case below was run against the PRE-FIX tree first: cases 1,
+# 4 and 5 go RED there and green here; cases 2, 3 and 6 are CONTROLS that are
+# green on BOTH trees, so the suite cannot be satisfied by deleting, disabling
+# or blanket-suppressing Phase-2c — doing that turns the controls red.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw292.omani.works"
+HARBOR_HOST="registry.${FQDN}"
+LOCAL_URL="oci://${HARBOR_HOST}/openova-io"
+UPSTREAM="https://charts.loft.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+fail() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok   — $*"; }
+
+command -v jq >/dev/null 2>&1 || { echo "FAIL — jq is required (Phase-2c itself shells out to jq)."; exit 1; }
+
+# ── Extract the block under test straight from the render ──────────────────
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+# Extraction is plain awk over the render text — deliberately NO PyYAML, so the
+# suite has the same dependency surface as the Job it tests (sh + jq) and cannot
+# skip itself on a runner missing a python module.
+#
+# The two delimiters are stable across the pre-fix and post-fix trees on
+# purpose: this same extraction has to work on the tree that FAILS, or the
+# red-on-pre-fix claim is unverifiable. Leading indentation is stripped because
+# the block lives inside a YAML block scalar; sh does not care about it and
+# Phase-2c contains no heredoc whose body would be disturbed.
+# The end pattern accepts EITHER terminator on purpose. Post-fix, Phase-2c lives
+# in the ConfigMap's phase2c.sh key (moved out of the inline args for #5593) and
+# ends on its own marker; pre-fix it was inline and ran up to the "# NOTE (Refs
+# #3379 #3526)" comment. Matching both is what lets the identical suite run
+# against the tree it must go RED on.
+awk '/# ---- Phase 2c \(#5650\)/,/# ---- end Phase 2c \(#5650\)|# NOTE \(Refs #3379 #3526\)/' "${TMP}/render.yaml" \
+  | sed '$d' | sed 's/^ *//' >"${TMP}/phase2c.sh"
+if ! grep -q 'VCL_LOFT_PIVOT_ENABLED' "${TMP}/phase2c.sh"; then
+  echo "FAIL — Phase-2c did not extract from the render (marker comments changed?)."
+  exit 1
+fi
+# Truncation guard: the block must end on the `fi` that closes the
+# vclusterLoftPivot.enabled conditional. A short extraction would still `sh`
+# cleanly and could still exit 0 — the fail-open shape this suite exists to
+# eliminate.
+if ! tail -5 "${TMP}/phase2c.sh" | grep -q 'Phase-2c SKIP: vclusterLoftPivot.enabled=false'; then
+  echo "FAIL — Phase-2c extraction was truncated (missing the enabled=false else-branch tail)."
+  exit 1
+fi
+sh -n "${TMP}/phase2c.sh" || { echo "FAIL — extracted Phase-2c is not valid POSIX sh."; exit 1; }
+
+# ── Harness ────────────────────────────────────────────────────────────────
+# Stub kubectl keeps PER-CLUSTER state under ${STATE}/<cluster>/ where <cluster>
+# is the --kubeconfig basename or "primary". That is the whole point: a
+# primary-only implementation writes only ${STATE}/primary and the secondary
+# assertions below have nothing to read.
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/kubectl" <<'STUB'
+#!/usr/bin/env bash
+cluster="primary"
+args=()
+for a in "$@"; do
+  case "$a" in
+    --kubeconfig=*) kc="${a#--kubeconfig=}"; cluster="$(basename "${kc}" .yaml)" ;;
+    *) args+=("$a") ;;
+  esac
+done
+d="${STATE}/${cluster}"; mkdir -p "$d"
+printf '%s\n' "${args[*]}" >>"${d}/calls.log"
+printf '%s\n' "${cluster} ${args[*]}" >>"${STATE}/all-calls.log"
+# A cluster marked unreachable fails every verb with a transport error (NOT a
+# NotFound) — the fail-closed path.
+if [ -e "${STATE}/${cluster}.unreachable" ]; then
+  echo "Unable to connect to the server: dial tcp 10.0.0.1:6443: i/o timeout" >&2
+  exit 1
+fi
+verb="${args[0]:-}"
+case "${verb}" in
+  get)
+    kind="${args[1]:-}"; name="${args[2]:-}"
+    case "${kind}" in
+      helmrepository|helmrepositories)
+        if [ ! -e "${d}/loft.url" ]; then
+          echo "Error from server (NotFound): helmrepositories.source.toolkit.fluxcd.io \"${name}\" not found" >&2
+          exit 1
+        fi
+        url="$(cat "${d}/loft.url")"; typ="$(cat "${d}/loft.type" 2>/dev/null || echo "")"
+        if printf '%s\n' "${args[*]}" | grep -q 'jsonpath.*\.spec\.type'; then
+          printf '%s' "${typ}"
+        elif printf '%s\n' "${args[*]}" | grep -q 'jsonpath'; then
+          printf '%s' "${url}"
+        else
+          jq -n --arg u "${url}" --arg t "${typ}" \
+            '{apiVersion:"source.toolkit.fluxcd.io/v1beta2",kind:"HelmRepository",metadata:{name:"loft",namespace:"vcluster-system"},spec:({url:$u}+(if $t=="" then {} else {type:$t} end))}'
+        fi
+        ;;
+      helmrelease|helmreleases)
+        [ -e "${d}/hr.present" ] || { echo "Error from server (NotFound): helmreleases.helm.toolkit.fluxcd.io \"${name}\" not found" >&2; exit 1; }
+        echo '{}' ;;
+      secret|secrets)
+        case "${name}" in
+          cutover-harbor-ca) jq -n '{apiVersion:"v1",kind:"Secret",type:"Opaque",metadata:{name:"cutover-harbor-ca",namespace:"flux-system"},data:{"ca.crt":"Q0EK"}}' ;;
+          *)                 jq -n '{apiVersion:"v1",kind:"Secret",type:"kubernetes.io/dockerconfigjson",metadata:{name:"ghcr-pull",namespace:"flux-system"},data:{".dockerconfigjson":"e30K"}}' ;;
+        esac ;;
+      *) echo '{}' ;;
+    esac ;;
+  patch)
+    kind="${args[1]:-}"
+    if [ "${kind}" = "helmrepository" ] || [ "${kind}" = "helmrepositories" ]; then
+      # STICKY=0 simulates a patch that reports success but is reverted — the
+      # read-back must catch it.
+      if [ -e "${STATE}/${cluster}.nonsticky" ]; then exit 0; fi
+      newurl="$(printf '%s\n' "${args[*]}" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')"
+      [ -n "${newurl}" ] && printf '%s' "${newurl}" >"${d}/loft.url"
+      printf 'oci' >"${d}/loft.type"
+      printf '%s\n' "PIVOTED ${newurl}" >>"${d}/pivots.log"
+    else
+      printf 'SUSPENDED\n' >>"${d}/pivots.log"
+    fi
+    exit 0 ;;
+  apply) cat >/dev/null; printf 'APPLIED\n' >>"${d}/pivots.log"; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+cat >"${TMP}/bin/helm" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${STATE}/helm-calls.log"
+case "$1" in
+  pull) for a in "$@"; do [ "${prev:-}" = "-d" ] && { mkdir -p "$a"; : >"$a/vcluster-0.33.0.tgz"; }; prev="$a"; done ;;
+esac
+exit 0
+STUB
+chmod +x "${TMP}/bin/kubectl" "${TMP}/bin/helm"
+
+# run_case <label> <secondary-region-list> <primary-loft-url> <secondary-loft-url>
+#   *-loft-url = "" means the HelmRepository is absent in that region.
+# Extra per-case knobs come in via PRESET_* files created by the caller.
+run_case() {
+  local label="$1" secondaries="$2" purl="$3" surl="$4"
+  local case_dir="${TMP}/case-${label}"
+  rm -rf "${case_dir}"; mkdir -p "${case_dir}/state" "${case_dir}/kc"
+  if [ -n "${purl}" ]; then mkdir -p "${case_dir}/state/primary"; printf '%s' "${purl}" >"${case_dir}/state/primary/loft.url"; : >"${case_dir}/state/primary/hr.present"; printf '%s' "${PRESET_TYPE:-}" >"${case_dir}/state/primary/loft.type"; fi
+  for r in ${secondaries}; do
+    : >"${case_dir}/kc/${r}.yaml"
+    if [ -n "${surl}" ]; then mkdir -p "${case_dir}/state/${r}"; printf '%s' "${surl}" >"${case_dir}/state/${r}/loft.url"; : >"${case_dir}/state/${r}/hr.present"; printf '%s' "${PRESET_TYPE:-}" >"${case_dir}/state/${r}/loft.type"; fi
+  done
+  [ -n "${PRESET_UNREACHABLE:-}" ] && : >"${case_dir}/state/${PRESET_UNREACHABLE}.unreachable"
+  [ -n "${PRESET_NONSTICKY:-}" ] && : >"${case_dir}/state/${PRESET_NONSTICKY}.nonsticky"
+  CASE_DIR="${case_dir}"
+  (
+    export PATH="${TMP}/bin:${PATH}"
+    export STATE="${case_dir}/state"
+    export SECONDARY_KUBECONFIG_DIR="${case_dir}/kc"
+    export VCL_LOFT_PIVOT_ENABLED=true VCL_LOFT_HR_NAME=loft VCL_LOFT_NAMESPACE=vcluster-system
+    export VCL_LOFT_RELEASE=bp-vcluster-helmrepo VCL_LOFT_RELEASE_NS=flux-system
+    export VCL_LOFT_SLOT_FILE="${case_dir}/absent-slot.yaml"
+    export VCL_LOFT_UPSTREAM_REPO="${UPSTREAM}" VCL_LOFT_CHART=vcluster VCL_LOFT_VERSION='0.33.*'
+    export VCL_LOFT_LOCAL_PROJECT=openova-io VCL_LOFT_PULL_ATTEMPTS=1
+    export SOVEREIGN_FQDN="${FQDN}" HARBOR_USERNAME=admin HARBOR_PASSWORD=x
+    export GHCR_PULL_SECRET_NAME=ghcr-pull GHCR_PULL_SECRET_NAMESPACE=flux-system
+    export HELMREPO_NAMESPACE=flux-system
+    harbor_endpoint="${HARBOR_HOST}"
+    trust_secret="cutover-harbor-ca"
+    edited=0
+    # shellcheck disable=SC1090
+    . "${TMP}/phase2c.sh"
+  ) >"${case_dir}/out.log" 2>&1
+  echo "$?" >"${case_dir}/rc"
+}
+
+pivoted_to_local() { # <case> <cluster>
+  grep -q "PIVOTED ${LOCAL_URL}" "${TMP}/case-$1/state/$2/pivots.log" 2>/dev/null
+}
+targeted_with_kubeconfig() { # <case> <cluster>
+  grep -q "^$2 patch helmrepository" "${TMP}/case-$1/state/all-calls.log" 2>/dev/null
+}
+
+echo "── #5650 step-06 Phase-2c: the loft pivot must cover every region ──"
+
+# ── Case 1 (RED on the pre-fix tree): 2-region Sovereign ───────────────────
+# The whole finding. Both regions carry loft on charts.loft.sh; step-08's
+# fluxSourceHostLint measures BOTH with an empty allowHosts, so a pivot that
+# reaches only the primary does not merely leave half a tether — it makes the
+# cutover unable to complete on the multi-region topology the DoD requires.
+PRESET_TYPE="" PRESET_UNREACHABLE="" PRESET_NONSTICKY="" run_case two-region "me-east-215-b-1" "${UPSTREAM}" "${UPSTREAM}"
+rc=$(cat "${TMP}/case-two-region/rc")
+if [ "${rc}" != "0" ]; then
+  fail "2-region: Phase-2c exited ${rc}; expected 0. Output:"; sed 's/^/         /' "${TMP}/case-two-region/out.log" | tail -12
+else
+  pivoted_to_local two-region primary \
+    && pass "2-region: primary loft HR pivoted to ${LOCAL_URL}" \
+    || fail "2-region: primary loft HR was NOT pivoted to ${LOCAL_URL}"
+  if targeted_with_kubeconfig two-region me-east-215-b-1 && pivoted_to_local two-region me-east-215-b-1; then
+    pass "2-region: SECONDARY me-east-215-b-1 was targeted with --kubeconfig and pivoted to ${LOCAL_URL}"
+  else
+    fail "2-region: secondary me-east-215-b-1 was never pivoted — every kubectl in Phase-2c ran against the primary context, so region-b keeps fetching ${UPSTREAM} on its 15m interval and step-08's per-region fluxSourceHostLint fails closed on it (#5650)"
+  fi
+fi
+
+# ── Case 2 (CONTROL — green on BOTH trees): single-region Sovereign ────────
+# No secondary kubeconfigs mounted. The primary must still be pivoted. Deleting
+# or disabling Phase-2c to make case 1 "pass" turns this red.
+PRESET_TYPE="" PRESET_UNREACHABLE="" PRESET_NONSTICKY="" run_case single-region "" "${UPSTREAM}" ""
+rc=$(cat "${TMP}/case-single-region/rc")
+if [ "${rc}" = "0" ] && pivoted_to_local single-region primary; then
+  pass "CONTROL single-region: primary pivoted to ${LOCAL_URL}, exit 0"
+else
+  fail "CONTROL single-region: expected exit 0 with the primary pivoted; got rc=${rc}"
+fi
+
+# ── Case 3 (CONTROL — green on BOTH trees): slot 60 not installed ──────────
+# A Sovereign without bp-vcluster-helmrepo has nothing to pivot. This must be a
+# clean no-op, not a FATAL — otherwise the fail-closed cases below could be
+# satisfied by failing on everything.
+PRESET_TYPE="" PRESET_UNREACHABLE="" PRESET_NONSTICKY="" run_case loft-absent "me-east-215-b-1" "" ""
+rc=$(cat "${TMP}/case-loft-absent/rc")
+if [ "${rc}" = "0" ] && ! grep -q 'PIVOTED' "${TMP}/case-loft-absent/state"/*/pivots.log 2>/dev/null; then
+  pass "CONTROL loft-absent: clean no-op, exit 0, no patch issued"
+else
+  fail "CONTROL loft-absent: expected a clean no-op; got rc=${rc}"
+fi
+
+# ── Case 4 (RED on the pre-fix tree): secondary unreadable ─────────────────
+# An unreadable region is not a pivoted region. The pre-fix block never looks at
+# a secondary at all, so it exits 0 here — reporting success over a region it
+# never measured, which is the #5359 shape.
+PRESET_TYPE="" PRESET_UNREACHABLE="me-east-215-b-1" PRESET_NONSTICKY="" run_case secondary-unreadable "me-east-215-b-1" "${UPSTREAM}" "${UPSTREAM}"
+rc=$(cat "${TMP}/case-secondary-unreadable/rc")
+if [ "${rc}" != "0" ] && grep -q 'unreadable region is NOT a pivoted region' "${TMP}/case-secondary-unreadable/out.log"; then
+  pass "fail-closed: an unreadable secondary FATALs instead of recording success"
+else
+  fail "fail-closed: an unreadable secondary exited ${rc} — a region that could not be measured was treated as pivoted (#5359 #5650)"
+fi
+
+# ── Case 5 (RED on the pre-fix tree): patch reports success but reverts ────
+# kubectl patch exiting 0 is not the object carrying the new URL. Without the
+# read-back the Job logs OK over a region still on charts.loft.sh.
+PRESET_TYPE="" PRESET_UNREACHABLE="" PRESET_NONSTICKY="me-east-215-b-1" run_case patch-not-sticky "me-east-215-b-1" "${UPSTREAM}" "${UPSTREAM}"
+rc=$(cat "${TMP}/case-patch-not-sticky/rc")
+if [ "${rc}" != "0" ] && grep -q 'read-back shows' "${TMP}/case-patch-not-sticky/out.log"; then
+  pass "fail-closed: a non-sticky secondary patch is caught by the per-region read-back"
+else
+  fail "fail-closed: a secondary patch that silently reverted exited ${rc} — the pivot was asserted from the patch's exit code, not from the object (#5650)"
+fi
+
+# ── Case 6 (CONTROL — green on BOTH trees): already pivoted ───────────────
+# Idempotent re-run: loft is already type=oci on a Sovereign-local URL. Nothing
+# to do — no upstream pull, no patch, exit 0. This is the control that keeps the
+# fail-closed cases honest: a Phase-2c rewritten to FATAL on everything would
+# turn this red.
+PRESET_TYPE=oci PRESET_UNREACHABLE="" PRESET_NONSTICKY="" run_case already-oci "me-east-215-b-1" "${LOCAL_URL}" "${LOCAL_URL}"
+rc=$(cat "${TMP}/case-already-oci/rc")
+if [ "${rc}" = "0" ] && ! grep -q '^pull' "${TMP}/case-already-oci/state/helm-calls.log" 2>/dev/null; then
+  pass "CONTROL already-local: exit 0, no upstream pull, on a Sovereign whose loft source is already Sovereign-local"
+else
+  fail "CONTROL already-local: expected exit 0 with no upstream pull; got rc=${rc}"
+fi
+
+echo
+if [ "${FAILURES}" -eq 0 ]; then
+  echo "PASS — the loft chart-source pivot covers every region step-08 measures, and fails closed on any region it cannot prove (#5650)."
+  exit 0
+fi
+echo "FAIL — ${FAILURES} assertion(s) failed (#5650)."
+exit 1

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1127,6 +1127,25 @@ helmRepositories:
   # empty) then fails the cutover on it, loudly, rather than stamping a false
   # cutoverComplete=true. That is the property the #5652 lint exists to
   # enforce; this leg is what makes it pass honestly.
+  #
+  # ── PER-REGION as of 0.1.172 (#5650) ────────────────────────────────────
+  # 0.1.168 shipped this leg PRIMARY-ONLY — every kubectl in Phase-2c ran
+  # against the Job's own in-cluster context. Slot 60 installs the loft
+  # HelmRepository in EVERY region, so on a 2-region Sovereign the tether is
+  # TWO objects. Live on hw292 (dep 1c56518035a83e03), sampled 2026-08-06 over
+  # 75 minutes — deliberately longer than the actor's 15m period, because one
+  # sample inside a window cannot characterise a periodic actor:
+  #   region-a 23:36:44Z / region-b 23:24:43Z
+  #     "stored fetched index of size 3.893MB from 'https://charts.loft.sh'"
+  # both ~63h AFTER cutoverComplete=true. Region-b's copy is referenced by no
+  # HelmRelease and still reconciles — source-controller drives a
+  # HelmRepository on its own interval regardless of consumers.
+  # Phase-2c now runs loft_pivot_region() for the primary and every mounted
+  # secondary kubeconfig — the SAME target list step-08's per-region
+  # fluxSourceHostLint builds, so the pivot covers exactly what the lint
+  # measures. Sovereign-wide work (Harbor chart mirror, durable Gitea slot
+  # suspend) still runs once. Each region ends with a read-back, and a region
+  # that cannot be READ fails the step rather than being skipped (#5359).
   vclusterLoftPivot:
     # Default true — the residual tether is present on every fresh prov by
     # construction, so the keystone cc=true path needs the pivot. Set false
@@ -1136,10 +1155,12 @@ helmRepositories:
     enabled: true
     # The HelmRepository the bp-vcluster-helmrepo slot installs (matches the
     # org-controller CATALYST_VCLUSTER_HELMREPO_{NAME,NAMESPACE} defaults).
+    # Present in EVERY region, which is why the pivot loops the region set.
     helmRepositoryName: "loft"
     namespace: "vcluster-system"
     # The HelmRelease that reconciles the loft HR — suspended so it stops
-    # reverting the live pivot. Lives in flux-system (bootstrap-kit slot 60).
+    # reverting the live pivot. Lives in flux-system (bootstrap-kit slot 60)
+    # in EVERY region, so the suspend is issued per-region too.
     helmReleaseName: "bp-vcluster-helmrepo"
     helmReleaseNamespace: "flux-system"
     # The slot file in the local Gitea mirror where the durable suspend lands

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.171",
+      "version": "0.1.172",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.171",
+    "version": "0.1.172",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5101,7 +5101,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.171"
+  version: "0.1.172"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5118,7 +5118,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.171"
+    version: "0.1.172"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The loft chart-source pivot only ever covered the primary region

`#5650`'s instance fix (#5674, cutover 0.1.168) shipped step-06 Phase-2c as a **primary-only** block — every `kubectl` in it ran against the Job's own in-cluster context. Bootstrap-kit **slot 60 installs the loft HelmRepository in EVERY region**, so on a 2-region Sovereign the residual tether is **two objects, not the one the issue named**.

### CONFIRMED live, sampled longer than the actor's period

hw292, dep `1c56518035a83e03`, `cutoverComplete=true` since `2026-08-03T08:12:04Z` (all 11 steps `result=success`, `progressPercent=100`). Read-only, both regions looped.

A single sample inside a window proves nothing about a periodic actor, so this was sampled across **75 minutes** — strictly longer than the 15m interval. `source-controller`, ~63 hours after cutover:

    region-a  22:36:46Z  artifact up-to-date with remote revision: 'sha256:0812214739…'
    region-a  22:52:02Z  artifact up-to-date with remote revision: 'sha256:0812214739…'
    region-a  23:06:44Z  artifact up-to-date with remote revision: 'sha256:0812214739…'
    region-a  23:22:07Z  artifact up-to-date with remote revision: 'sha256:0812214739…'
    region-a  23:36:44Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
    region-a  23:51:48Z  artifact up-to-date with remote revision: 'sha256:e3514bbbc1…'

    region-b  22:38:47Z  artifact up-to-date with remote revision: 'sha256:0812214739…'
    region-b  22:54:08Z  artifact up-to-date with remote revision: 'sha256:0812214739…'
    region-b  23:08:58Z  artifact up-to-date with remote revision: 'sha256:0812214739…'
    region-b  23:24:43Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
    region-b  23:40:20Z  artifact up-to-date with remote revision: 'sha256:e3514bbbc1…'
    region-b  23:55:02Z  artifact up-to-date with remote revision: 'sha256:e3514bbbc1…'

Both regions, `spec.interval: 15m`, `suspend` unset, `Ready=True`. **Region-b's copy is referenced by no HelmRelease at all and still reconciles** — `source-controller` drives a HelmRepository on its own interval regardless of consumers, so "nothing uses it" is not "it does not dial out".

### Why this is worse than half a tether

Step-08's `fluxSourceHostLint` builds its target list as `primary` **plus every mounted secondary kubeconfig** (#5359) and its `allowHosts` went **empty** in 0.1.168. So a primary-only pivot does not merely leave region-b tethered — it makes the region-b lint **fail** and `cutoverComplete=true` **unreachable** on the multi-region topology the DoD requires. The pivot and the lint now build their region list identically, on purpose.

### The fix

- Phase-2c restructured into `loft_pivot_region(region, kubeconfig)`, called for the primary and every mounted secondary. Sovereign-wide work (the Harbor chart mirror, the durable Gitea slot suspend) still runs **once** — one registry endpoint, one Gitea.
- **Per-region read-back**: `kubectl patch` exiting 0 is not the object carrying the new URL.
- A region that cannot be **read** FATALs instead of being skipped (#5359 — an unreadable region is not a pivoted region).
- Phase-2c moved out of `podSpec.args` into the step-06 ConfigMap's `phase2c.sh` key, `.`-sourced from the step script (the step-03 `run.sh` pattern, #5593). Step-06 rendered at **109254 B** against the **110000 B** `MAX_ARG_STRLEN` early-warning budget — **746 bytes** from the wall that killed step-03 live on hw292 — and now renders at **98424 B** *with* the secondary leg included.

### The guard, in both directions

`platform/self-sovereign-cutover/chart/tests/loft-pivot-regions.sh` extracts the **real** Phase-2c block out of the render (not a pasted copy — #5646) and drives it against a stub `kubectl` that keeps **per-cluster** state. It asserts on the **declaration** the pivot leaves behind per region, not on observed traffic, so it is not a race.

**RED on the pre-fix tree** — `origin/main` `b871365d0`, cutover chart `0.1.171`, identical script:

    ── #5650 step-06 Phase-2c: the loft pivot must cover every region ──
      ok   — 2-region: primary loft HR pivoted to oci://registry.hw292.omani.works/openova-io
      FAIL — 2-region: secondary me-east-215-b-1 was never pivoted — every kubectl in Phase-2c ran against the primary context, so region-b keeps fetching https://charts.loft.sh on its 15m interval and step-08's per-region fluxSourceHostLint fails closed on it (#5650)
      ok   — CONTROL single-region: primary pivoted to oci://registry.hw292.omani.works/openova-io, exit 0
      ok   — CONTROL loft-absent: clean no-op, exit 0, no patch issued
      FAIL — fail-closed: an unreadable secondary exited 0 — a region that could not be measured was treated as pivoted (#5359 #5650)
      FAIL — fail-closed: a secondary patch that silently reverted exited 0 — the pivot was asserted from the patch's exit code, not from the object (#5650)
      ok   — CONTROL already-local: exit 0, no upstream pull, on a Sovereign whose loft source is already Sovereign-local

    FAIL — 3 assertion(s) failed (#5650).

**GREEN on this branch:**

    ── #5650 step-06 Phase-2c: the loft pivot must cover every region ──
      ok   — 2-region: primary loft HR pivoted to oci://registry.hw292.omani.works/openova-io
      ok   — 2-region: SECONDARY me-east-215-b-1 was targeted with --kubeconfig and pivoted to oci://registry.hw292.omani.works/openova-io
      ok   — CONTROL single-region: primary pivoted to oci://registry.hw292.omani.works/openova-io, exit 0
      ok   — CONTROL loft-absent: clean no-op, exit 0, no patch issued
      ok   — fail-closed: an unreadable secondary FATALs instead of recording success
      ok   — fail-closed: a non-sticky secondary patch is caught by the per-region read-back
      ok   — CONTROL already-local: exit 0, no upstream pull, on a Sovereign whose loft source is already Sovereign-local

    PASS — the loft chart-source pivot covers every region step-08 measures, and fails closed on any region it cannot prove (#5650).

**The controls are the point.** Cases 2, 3 and 6 (single-region, slot-60-absent, already-local) are green on **both** trees. Deleting, disabling or blanket-suppressing Phase-2c to make case 1 pass turns them red, so the suite cannot be satisfied by suppression. *"If the defect were present, could this check have gone red?"* — yes, on three independent assertions, demonstrated above rather than asserted.

The extraction is plain `awk` over the render text (no PyYAML) and its end-marker pattern deliberately accepts **both** the pre-fix and post-fix shapes, so the identical suite runs against the tree it must go red on.

### Full loft.sh actor enumeration — what I found and what I did NOT fix

Enumerated structurally by signature (not from the issue's list), then confirmed against the live object graph in **both** regions.

| # | Actor | Reaches loft.sh? | Disposition |
|---|---|---|---|
| 1 | `vcluster-system/loft` HelmRepository, **region-a** | **Yes**, 15m | Fixed by #5674, unchanged here |
| 2 | `vcluster-system/loft` HelmRepository, **region-b** | **Yes**, 15m — proven above | **Fixed by this PR** |
| 3 | `bp-mgmt-vcluster` / `bp-rtz-vcluster` / `bp-dmz-vcluster` `Chart.yaml dependencies[].repository` | **No at runtime** | **Not fixed, deliberately.** CI runs `helm dependency build` before `helm package`, so the loft subchart is vendored into the published OCI artifact; `helm-controller` renders the packaged chart and never resolves the dependency. Confirmed empirically: across both regions' full retained `source-controller` logs the ONLY external host ever fetched is `charts.loft.sh` **from the loft HelmRepository**, nothing from the umbrellas. |
| 4 | `.github/workflows/check-kyverno-proxy-images.yaml` `helm repo add loft` | Yes, on the **GitHub runner** | **Not fixed** — build-side CI, not a Sovereign tether, and it is what keeps the proxy-image guard honest. |
| 5 | `admin.loft.sh` license tether (vCluster CRD-sync) | **No** | **Not fixed — already avoided by design.** CRD-sync is the loft Free-tier feature that needs a permanent outbound tether; it is deliberately left off (`clusters/_template/bootstrap-kit/placement.yaml`, `bp-mgmt-vcluster/chart/Chart.yaml`). No `admin.loft.sh` hit in either region's `helm-controller` or `source-controller` logs. |
| 6 | vcluster control-plane **image** `harbor.openova.io/proxy-ghcr/loft-sh/vcluster-oss:0.33.4` (live in region-a) | Mothership host, not loft.sh | **Not this PR's leg** — step-10's leg, and `harbor.openova.io` is a `HOST_PROJECT_MAP` host that step-04's containerd `certs.d` redirect covers, so the pull resolves to the local registry. Step-08's `run_podspec_refhost_lint` already judges this class. |
| 7 | Flux `GitRepository` / `OCIRepository` on either region | No | Region-a: 5 GitRepositories, all `gitea-http.gitea.svc.cluster.local`. Region-b: 1, same. Zero OCIRepositories. |

**Structural sweep, both regions, full retained logs** — the only external host `source-controller` ever fetched:

    region-a:  2 × from 'https://charts.loft.sh'
    region-b:  3 × from 'https://charts.loft.sh'

Nothing else. That is the whole external Flux-source surface of a `cutoverComplete=true` Sovereign.

### Gates run

All 13 `chart/tests/*.sh` green (the CI gate auto-discovers the new script — no workflow edit needed), including `arg-strlen-guard.sh`, which **caught this change** before the ConfigMap move and is the reason step-06 now has 11 KB of headroom instead of 746 bytes. Plus `check-bootstrap-kit-pin-sync.sh`, `check-catalog-seed-lockstep.sh`, and `tests/e2e/bootstrap-kit` (Go) — the shell gates miss `blueprint.yaml` + catalog-seed, so the Go guard was run per #817.

#817 lockstep, all six sites at `0.1.172`: `chart/Chart.yaml`, `blueprint.yaml`, catalog-seed `spec.version` **and** `source.version`, `blueprints.json`, `catalog.generated.ts`, and the bootstrap-kit slot 06a pin.

### Not closed by this PR

Runtime closure is a fresh-prov walk on a **2-region** Sovereign: both regions' loft HR resolving to `oci://registry.<fqdn>/openova-io` under the deny-egress hold with empty `allowHosts`. PR merge is not that proof, and hw292 cannot show it — its local Gitea mirror is frozen (`mirrorResync.enabled: false`), which is why 0.1.168 never reached it either. A falsifiable live-walk assertion is posted on the issue.

Refs #5650 #5359 #5593 #5674 #5652

