### PR TITLE
fix(auth): defer pin/issue realm write to pin/verify — no unauthenticated principal creation (Refs #5720)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -425,9 +425,9 @@ type pinIssueResponse struct {
 // HandlePinIssue handles POST /api/v1/auth/pin/issue.
 //
 //  1. Reads {"email"} from the body. Empty email → 400 email-required.
-//  2. Calls EnsureUser in the openova realm so the user record exists
-//     before they ever type the PIN.
-//  3. Per-email rate-limit check (60s) → 429 pin-rate-limited.
+//  2. Per-email rate-limit check (60s) → 429 pin-rate-limited.
+//  3. Verifies the openova-realm Keycloak client is CONFIGURED (a local
+//     env check — no Keycloak call, no realm write) → 503 when absent.
 //  4. Generates a 6-digit PIN with crypto/rand.
 //  5. Persists in pinStore with TTL + new requestId.
 //  6. Sends a plaintext email (no link). The PIN is the body. SMTP
@@ -436,6 +436,32 @@ type pinIssueResponse struct {
 //  7. Returns {ok, requestId, expiresInSec}. The UI uses requestId on
 //     /pin/verify so a stale browser tab cannot replay against a
 //     newer code.
+//
+// # This endpoint performs NO write to the identity store (#5720)
+//
+// Until 2026-08-06 step 2 called `kc.EnsureUser(email, "openova-users")`
+// BEFORE the PIN existed and before anything was verified. Because the
+// endpoint is unauthenticated, that made "type an address into the login
+// form" sufficient to mint a permanent, enabled, emailVerified realm
+// principal for an ARBITRARY address — the caller never had to read the
+// PIN, or even wait for it. The per-email 60s rate limiter did not
+// constrain it either: a caller who varies the address never repeats a
+// key. Found on hw292 (UAT row 41), where the sovereign realm held
+// `emrha.baysal@openova.io` — a transposition typo of the seeded owner
+// that became a permanent principal purely because somebody mistyped it
+// at the login form once.
+//
+// The realm write now lives in HandlePinVerify, gated on a correct PIN
+// (i.e. on proven control of the mailbox). Nothing at issue-time needed
+// the realm user: the pinStore is keyed on the email STRING, and
+// sendPinEmail takes an address, not a principal. The pinSessionAuthority
+// group lookup is the only realm read in the flow and it runs at verify.
+//
+// The `kc == nil` check in step 3 is retained deliberately: it is a local
+// env-configuration check (no network call, no write) that fails fast on
+// a Sovereign whose catalyst-openova-kc-credentials Secret never rendered
+// (the #901 / #3642 chain), rather than mailing a PIN that could never be
+// redeemed.
 func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 	if h.handoverSigner == nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
@@ -493,9 +519,15 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── 2. EnsureUser in openova realm ──────────────────────────────────────
-	kc := h.openovaKCClient()
-	if kc == nil {
+	// ── 2. Keycloak CONFIGURATION check (no call, no write) ─────────────────
+	//
+	// #5720: this used to be `kc.EnsureUser(email, "openova-users")` — an
+	// unauthenticated realm WRITE. It is now only the nil-check: does this
+	// deployment have openova-realm KC credentials at all? That is read
+	// from env/Secret locally; it contacts nothing and creates nothing.
+	// The actual EnsureUser now runs in HandlePinVerify, after the PIN has
+	// been proven.
+	if kc := h.openovaKCClient(); kc == nil {
 		// Rollback the reservation: this gate's failure isn't the
 		// operator's fault and a follow-up retry must not be punished by
 		// the 60s cooldown.
@@ -503,17 +535,6 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
 			"error":  "auth-unconfigured",
 			"detail": "CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set",
-		})
-		return
-	}
-	if _, err := kc.EnsureUser(r.Context(), email, "openova-users"); err != nil {
-		// Rollback so a Keycloak transient (502 from KC, etc) doesn't
-		// punish the operator for the next 60 seconds.
-		store.drop(email)
-		h.log.Error("pin/issue: EnsureUser failed", "email", email, "err", err)
-		writeJSON(w, http.StatusBadGateway, map[string]string{
-			"error":  "user-provisioning-failed",
-			"detail": "could not provision user record",
 		})
 		return
 	}
@@ -902,7 +923,50 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── On match: mint session JWT + set cookie ─────────────────────────────
+	// ── On match: provision the realm user (#5720) ──────────────────────────
+	//
+	// THIS is the point at which the caller has proven control of the
+	// mailbox — they read a 6-digit crypto/rand PIN that was delivered
+	// there and nowhere else. Only now may a permanent principal be
+	// written into the identity store.
+	//
+	// Before #5720 this ran in HandlePinIssue, so an unauthenticated POST
+	// with an arbitrary address was enough to create an enabled realm
+	// user. Everything upstream of this line (rate limit, PIN generation,
+	// pinStore, SMTP send) operates on the email STRING and never needed
+	// the principal to exist, so moving the write here costs nothing and
+	// removes the unauthenticated-write surface entirely.
+	//
+	// Ordering is load-bearing: EnsureUser MUST run BEFORE
+	// pinSessionAuthority below, because that resolves the session tier
+	// from live Keycloak group membership and would otherwise race a
+	// first-ever login. EnsureUser only joins `openova-users`; it never
+	// joins /sovereign-admins, so it cannot manufacture admin authority —
+	// a brand-new principal still resolves to viewer.
+	//
+	// Error taxonomy is deliberately identical to the pre-#5720 pin/issue
+	// contract (503 auth-unconfigured / 502 user-provisioning-failed), so
+	// a KC-down Sovereign fails the same way it always did; only the step
+	// at which it fails moved.
+	kcv := h.openovaKCClient()
+	if kcv == nil {
+		h.log.Error("pin/verify: openova KC client unconfigured; cannot provision user")
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "auth-unconfigured",
+			"detail": "CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set",
+		})
+		return
+	}
+	if _, err := kcv.EnsureUser(r.Context(), email, "openova-users"); err != nil {
+		h.log.Error("pin/verify: EnsureUser failed", "email", email, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "user-provisioning-failed",
+			"detail": "could not provision user record",
+		})
+		return
+	}
+
+	// ── Mint session JWT + set cookie ───────────────────────────────────────
 	//
 	// The PIN-derived JWT carries BOTH the legacy single-string `role`
 	// claim AND the Keycloak-shaped `tier` + `realm_access.roles` claims

--- a/products/catalyst/bootstrap/api/internal/handler/auth_pin_issue_no_unverified_realm_write_5720_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_pin_issue_no_unverified_realm_write_5720_test.go
@@ -1,0 +1,615 @@
+// auth_pin_issue_no_unverified_realm_write_5720_test.go — regression guard
+// for issue #5720.
+//
+// # The defect
+//
+// `POST /api/v1/auth/pin/issue` is UNAUTHENTICATED. Until 2026-08-06 it
+// called `kc.EnsureUser(email, "openova-users")` as step 2 — before the
+// PIN was generated, before it was mailed, and before anything was
+// verified. So typing any address into the console login form was
+// sufficient to write a permanent, enabled, emailVerified principal into
+// the Sovereign realm. The per-email 60s rate limiter did not constrain
+// it, because a caller who varies the address never repeats a key.
+//
+// Found on hw292 while re-walking UAT row 41, which asserts the sovereign
+// realm holds exactly the seeded owner principal. It held two: the owner
+// `emrah.baysal@openova.io` and `emrha.baysal@openova.io` — a
+// transposition typo that became a permanent realm user because somebody
+// mistyped it at the login form once, a day after the realm was seeded.
+//
+// # Why this file drives a fake Keycloak SERVER, not a fake client
+//
+// The assertion that matters is "no realm user exists after an unverified
+// issue call". A stub that records EnsureUser CALLS would assert on the
+// call, not on the effect, and would be satisfied by any refactor that
+// reaches Keycloak by another route. So these tests wire the REAL
+// *keycloak.Client (the production type, exercising its real
+// findUserByEmail / createUser / addUserToGroup HTTP sequence) against an
+// httptest server that keeps an actual realm-user table. The tests then
+// QUERY THAT TABLE. If a principal is created by any path, the table
+// shows it.
+//
+// # Vacuity
+//
+// Three of these tests fail RED on the pre-fix tree (they observe the
+// injected principal) and pass GREEN after. Two are CONTROLS that pass on
+// BOTH trees, so the suite cannot be satisfied by disabling the realm
+// write wholesale: TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720
+// requires that a real sign-in still provisions the principal and still
+// mints an admin session. A "fix" that stopped the injection by breaking
+// login turns that control red.
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
+)
+
+// ─── fake Keycloak realm (server-side state, queried by the assertions) ───────
+
+// fakeRealmUser is one principal in the fake realm's user table — the
+// same fields the live Keycloak Users list renders in the UAT row 41
+// walk.
+type fakeRealmUser struct {
+	ID            string
+	Email         string
+	Enabled       bool
+	EmailVerified bool
+	GroupPaths    []string
+}
+
+// fakeRealm is a minimal Keycloak Admin REST implementation covering the
+// exact endpoint set *keycloak.Client touches for EnsureUser +
+// UserGroupPaths. It holds real state so a test can ask "who exists in
+// this realm right now?" rather than "was a method called?".
+type fakeRealm struct {
+	mu     sync.Mutex
+	realm  string
+	users  map[string]*fakeRealmUser // keyed by lowercased email
+	groups map[string]string         // group name → id
+	nextID int
+
+	srv *httptest.Server
+}
+
+func newFakeRealm(t *testing.T, realm string) *fakeRealm {
+	t.Helper()
+	f := &fakeRealm{
+		realm:  realm,
+		users:  map[string]*fakeRealmUser{},
+		groups: map[string]string{},
+	}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.route))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// client returns the PRODUCTION Keycloak client pointed at this fake
+// realm. Everything the handler does goes through the real
+// EnsureUser/UserGroupPaths implementations and real HTTP.
+func (f *fakeRealm) client() *keycloak.Client {
+	return keycloak.NewWithHTTP(f.srv.URL, f.realm, "catalyst-api-server",
+		"not-a-real-secret", f.srv.Client())
+}
+
+// seedUser pre-creates a principal, as the realm import / handover seed
+// does for the Sovereign owner.
+func (f *fakeRealm) seedUser(email string, groupPaths ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	f.users[strings.ToLower(email)] = &fakeRealmUser{
+		ID:            fmt.Sprintf("seeded-%d", f.nextID),
+		Email:         email,
+		Enabled:       true,
+		EmailVerified: true,
+		GroupPaths:    append([]string{}, groupPaths...),
+	}
+}
+
+// emails returns the sorted set of principal emails currently in the
+// realm — this is the value the assertions read.
+func (f *fakeRealm) emails() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.users))
+	for _, u := range f.users {
+		out = append(out, u.Email)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (f *fakeRealm) user(email string) *fakeRealmUser {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.users[strings.ToLower(email)]
+}
+
+func (f *fakeRealm) route(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+
+	// Service-account token endpoint.
+	if strings.HasSuffix(p, "/protocol/openid-connect/token") {
+		writeJSONRaw(w, http.StatusOK, map[string]any{
+			"access_token": "fake-sa-token",
+			"expires_in":   300,
+		})
+		return
+	}
+
+	adminBase := "/admin/realms/" + f.realm
+	if !strings.HasPrefix(p, adminBase) {
+		http.NotFound(w, r)
+		return
+	}
+	rest := strings.TrimPrefix(p, adminBase)
+
+	switch {
+	// GET/POST /users
+	case rest == "/users" && r.Method == http.MethodGet:
+		f.handleFindUser(w, r)
+	case rest == "/users" && r.Method == http.MethodPost:
+		f.handleCreateUser(w, r)
+
+	// GET /users/{id}/groups   |   PUT /users/{id}/groups/{gid}
+	case strings.HasPrefix(rest, "/users/") && strings.HasSuffix(rest, "/groups") && r.Method == http.MethodGet:
+		f.handleUserGroups(w, strings.TrimSuffix(strings.TrimPrefix(rest, "/users/"), "/groups"))
+	case strings.HasPrefix(rest, "/users/") && strings.Contains(rest, "/groups/") && r.Method == http.MethodPut:
+		seg := strings.SplitN(strings.TrimPrefix(rest, "/users/"), "/groups/", 2)
+		f.handleJoinGroup(w, seg[0], seg[1])
+
+	// GET/POST /groups
+	case rest == "/groups" && r.Method == http.MethodGet:
+		f.handleFindGroup(w, r)
+	case rest == "/groups" && r.Method == http.MethodPost:
+		f.handleCreateGroup(w, r)
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (f *fakeRealm) handleFindUser(w http.ResponseWriter, r *http.Request) {
+	email := strings.ToLower(r.URL.Query().Get("email"))
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if u, ok := f.users[email]; ok {
+		writeJSONRaw(w, http.StatusOK, []map[string]any{{
+			"id": u.ID, "email": u.Email, "username": u.Email,
+			"enabled": u.Enabled, "emailVerified": u.EmailVerified,
+		}})
+		return
+	}
+	writeJSONRaw(w, http.StatusOK, []map[string]any{})
+}
+
+func (f *fakeRealm) handleCreateUser(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		Email         string `json:"email"`
+		Enabled       bool   `json:"enabled"`
+		EmailVerified bool   `json:"emailVerified"`
+	}
+	body, _ := io.ReadAll(r.Body)
+	_ = json.Unmarshal(body, &payload)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := strings.ToLower(payload.Email)
+	if _, exists := f.users[key]; exists {
+		w.WriteHeader(http.StatusConflict)
+		return
+	}
+	f.nextID++
+	id := fmt.Sprintf("user-%d", f.nextID)
+	f.users[key] = &fakeRealmUser{
+		ID:            id,
+		Email:         payload.Email,
+		Enabled:       payload.Enabled,
+		EmailVerified: payload.EmailVerified,
+	}
+	w.Header().Set("Location", f.srv.URL+"/admin/realms/"+f.realm+"/users/"+id)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (f *fakeRealm) handleUserGroups(w http.ResponseWriter, userID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := []map[string]any{}
+	for _, u := range f.users {
+		if u.ID != userID {
+			continue
+		}
+		for _, gp := range u.GroupPaths {
+			out = append(out, map[string]any{
+				"id": gp, "name": strings.TrimPrefix(gp, "/"), "path": gp,
+			})
+		}
+	}
+	writeJSONRaw(w, http.StatusOK, out)
+}
+
+func (f *fakeRealm) handleJoinGroup(w http.ResponseWriter, userID, groupID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	name := ""
+	for n, id := range f.groups {
+		if id == groupID {
+			name = n
+			break
+		}
+	}
+	for _, u := range f.users {
+		if u.ID != userID {
+			continue
+		}
+		path := "/" + name
+		for _, existing := range u.GroupPaths {
+			if existing == path {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+		u.GroupPaths = append(u.GroupPaths, path)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (f *fakeRealm) handleFindGroup(w http.ResponseWriter, r *http.Request) {
+	name, _ := url.QueryUnescape(r.URL.Query().Get("search"))
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if id, ok := f.groups[name]; ok {
+		writeJSONRaw(w, http.StatusOK, []map[string]any{{"id": id, "name": name, "path": "/" + name}})
+		return
+	}
+	writeJSONRaw(w, http.StatusOK, []map[string]any{})
+}
+
+func (f *fakeRealm) handleCreateGroup(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		Name string `json:"name"`
+	}
+	body, _ := io.ReadAll(r.Body)
+	_ = json.Unmarshal(body, &payload)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	id := fmt.Sprintf("group-%d", f.nextID)
+	f.groups[payload.Name] = id
+	w.Header().Set("Location", f.srv.URL+"/admin/realms/"+f.realm+"/groups/"+id)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func writeJSONRaw(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// ─── handler wired to the fake realm ─────────────────────────────────────────
+
+// newHandlerOnFakeRealm builds a Handler whose openova-realm client AND
+// sovereign-realm client are the production *keycloak.Client talking to
+// `realm`. Both are wired because pin/issue provisions via openovaKC
+// while pin/verify resolves authority via kc — a realm write by EITHER
+// path lands in the same observable table.
+func newHandlerOnFakeRealm(t *testing.T, realm *fakeRealm) *Handler {
+	t.Helper()
+	dir := t.TempDir()
+
+	privPEM, pubJWK, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+	keyPath := filepath.Join(dir, "handover.pem")
+	pubPath := filepath.Join(dir, "public.jwk")
+	if err := os.WriteFile(keyPath, privPEM, 0o600); err != nil {
+		t.Fatalf("write privPEM: %v", err)
+	}
+	if err := os.WriteFile(pubPath, pubJWK, 0o644); err != nil {
+		t.Fatalf("write pubJWK: %v", err)
+	}
+	signer, err := handoverjwt.LoadOrGenerate(keyPath, pubPath, "https://console.openova.io", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("LoadOrGenerate: %v", err)
+	}
+
+	kc := realm.client()
+	return &Handler{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverSigner: signer,
+		openovaKC:      kc,
+		kc:             kc,
+		pinStore:       newPinStoreNoSweeper(),
+	}
+}
+
+// postPinIssue drives the production HandlePinIssue exactly as the router
+// mounts it (cmd/api/main.go: r.Post("/api/v1/auth/pin/issue", h.HandlePinIssue)).
+func postPinIssue(t *testing.T, h *Handler, email string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/issue",
+		strings.NewReader(`{"email":`+pin5720JSONQuote(email)+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandlePinIssue(w, req)
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	return w.Code, body
+}
+
+func postPinVerify(t *testing.T, h *Handler, email, pin, requestID string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/verify",
+		strings.NewReader(`{"email":`+pin5720JSONQuote(email)+`,"pin":`+pin5720JSONQuote(pin)+
+			`,"requestId":`+pin5720JSONQuote(requestID)+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandlePinVerify(w, req)
+	return w.Result()
+}
+
+func pin5720JSONQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// ─── RED-on-pre-fix guards ───────────────────────────────────────────────────
+
+// TestPinIssue_NoRealmUserForUnverifiedEmail_5720 is the primary guard.
+//
+// One unauthenticated POST /pin/issue for an address nobody has verified
+// must leave the identity store untouched. The assertion reads the realm
+// user table — not the HTTP status, not a call counter — because the
+// defect's observable effect IS the principal.
+//
+// Pre-fix output (EnsureUser in HandlePinIssue):
+//
+//	realm users after unverified pin/issue: got [drive-by@t99.omani.works] want none
+func TestPinIssue_NoRealmUserForUnverifiedEmail_5720(t *testing.T) {
+	realm := newFakeRealm(t, "sovereign")
+	h := newHandlerOnFakeRealm(t, realm)
+	defer withSendPinEmail(noopSendPin)()
+
+	const victim = "drive-by@t99.omani.works"
+
+	code, body := postPinIssue(t, h, victim)
+	if code != http.StatusOK {
+		t.Fatalf("pin/issue status: got %d want 200 (body: %v)", code, body)
+	}
+
+	// THE assertion: query the realm.
+	if got := realm.emails(); len(got) != 0 {
+		t.Errorf("realm users after unverified pin/issue: got %v want none\n"+
+			"  #5720: pin/issue is unauthenticated — it must never write a principal.\n"+
+			"  The principal may only appear after a correct PIN proves mailbox control.",
+			got)
+	}
+}
+
+// TestPinIssue_UnauthenticatedFloodCreatesNoPrincipals_5720 models the
+// actual abuse: a caller who VARIES the address. The per-email 60s
+// rate limiter is keyed on the email, so it never fires here — which is
+// exactly why the pre-fix write was unbounded.
+//
+// Pre-fix this leaves 8 enabled principals in the realm.
+func TestPinIssue_UnauthenticatedFloodCreatesNoPrincipals_5720(t *testing.T) {
+	realm := newFakeRealm(t, "sovereign")
+	h := newHandlerOnFakeRealm(t, realm)
+	defer withSendPinEmail(noopSendPin)()
+
+	for i := 0; i < 8; i++ {
+		email := fmt.Sprintf("flood-%d@t99.omani.works", i)
+		if code, body := postPinIssue(t, h, email); code != http.StatusOK {
+			t.Fatalf("pin/issue[%d] status: got %d want 200 (body: %v)", i, code, body)
+		}
+	}
+
+	if got := realm.emails(); len(got) != 0 {
+		t.Errorf("realm users after 8 varied unverified pin/issue calls: got %d %v want 0\n"+
+			"  The 60s limiter is keyed per-email, so varying the address bypasses it entirely.",
+			len(got), got)
+	}
+}
+
+// TestPinVerify_WrongPINNeverCreatesPrincipal_5720 closes the other half:
+// a caller who issues AND answers, but answers wrong, has proven nothing
+// and must leave no trace. Runs the attempt budget to lockout.
+//
+// Pre-fix the principal was already written at issue-time, so it survives
+// every wrong answer.
+func TestPinVerify_WrongPINNeverCreatesPrincipal_5720(t *testing.T) {
+	realm := newFakeRealm(t, "sovereign")
+	h := newHandlerOnFakeRealm(t, realm)
+	defer withSendPinEmail(noopSendPin)()
+
+	const victim = "wrong-pin@t99.omani.works"
+	code, body := postPinIssue(t, h, victim)
+	if code != http.StatusOK {
+		t.Fatalf("pin/issue status: got %d want 200 (body: %v)", code, body)
+	}
+	requestID, _ := body["requestId"].(string)
+
+	for i := 0; i < pinMaxAttempts; i++ {
+		resp := postPinVerify(t, h, victim, "000000", requestID)
+		if resp.StatusCode == http.StatusOK {
+			t.Fatalf("attempt %d: wrong PIN unexpectedly accepted", i+1)
+		}
+	}
+
+	if got := realm.emails(); len(got) != 0 {
+		t.Errorf("realm users after issue + %d wrong PINs: got %v want none\n"+
+			"  A caller who never produced the PIN never proved mailbox control.",
+			pinMaxAttempts, got)
+	}
+}
+
+// ─── CONTROLS — must pass on BOTH the pre-fix and post-fix trees ─────────────
+
+// TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720 is the control that
+// makes the guards above un-cheatable. Deleting the EnsureUser call
+// outright, or gating login behind something stricter, turns this red.
+//
+// It asserts the FULL sign-in outcome for the seeded Sovereign owner:
+//
+//  1. pin/issue → 200 with a requestId
+//  2. pin/verify with the correct PIN → 200
+//  3. a catalyst_session cookie is set, HttpOnly + SameSite=Lax
+//  4. the session carries tier=admin + catalyst-admin, derived from the
+//     owner's live /sovereign-admins membership (NOT from a constant)
+//  5. the owner is provisioned into openova-users in the realm
+//
+// Passes on both trees: pre-fix the principal is created at issue,
+// post-fix at verify; either way it exists once sign-in completes.
+func TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720(t *testing.T) {
+	const owner = "emrah.baysal@t99.omani.works"
+	t.Setenv("OPERATOR_EMAIL", owner)
+
+	realm := newFakeRealm(t, "sovereign")
+	// The realm import / handover seeds the owner into /sovereign-admins.
+	realm.seedUser(owner, "/sovereign-admins")
+
+	h := newHandlerOnFakeRealm(t, realm)
+
+	// Capture the PIN off the send seam — the same seam production uses.
+	var issued string
+	defer withSendPinEmail(func(_, pin string) error {
+		issued = pin
+		return nil
+	})()
+
+	code, body := postPinIssue(t, h, owner)
+	if code != http.StatusOK {
+		t.Fatalf("owner pin/issue: got %d want 200 (body: %v)", code, body)
+	}
+	requestID, _ := body["requestId"].(string)
+	if requestID == "" {
+		t.Fatal("owner pin/issue: empty requestId")
+	}
+	if issued == "" {
+		t.Fatal("owner pin/issue: no PIN reached the send seam")
+	}
+
+	resp := postPinVerify(t, h, owner, issued, requestID)
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("owner pin/verify: got %d want 200 (body: %s)", resp.StatusCode, b)
+	}
+
+	cookie := findCookie(resp.Cookies(), "catalyst_session")
+	if cookie == nil || cookie.Value == "" {
+		t.Fatal("owner sign-in did not set catalyst_session — login is broken")
+	}
+	if !cookie.HttpOnly || cookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("catalyst_session hygiene: HttpOnly=%v SameSite=%v", cookie.HttpOnly, cookie.SameSite)
+	}
+
+	claims := decodeSessionClaims(t, cookie.Value)
+	if claims.Tier != pinSessionAdminTier {
+		t.Errorf("owner tier: got %q want %q (group-derived admin)", claims.Tier, pinSessionAdminTier)
+	}
+	if !claims.HasRealmRole("catalyst-admin") {
+		t.Errorf("owner realm roles: got %v want catalyst-admin", claims.RealmAccess.Roles)
+	}
+	if !policyModeCallerAuthorized(&claims) {
+		t.Error("owner session must pass the sovereign-admin gate")
+	}
+
+	// The principal exists and carries the openova-users membership the
+	// PIN flow is responsible for.
+	u := realm.user(owner)
+	if u == nil {
+		t.Fatalf("owner principal missing from realm after sign-in (have: %v)", realm.emails())
+	}
+	if !hasPath(u.GroupPaths, "/openova-users") {
+		t.Errorf("owner group paths: got %v want to include /openova-users", u.GroupPaths)
+	}
+	// And still no drive-by principals.
+	if got := realm.emails(); len(got) != 1 {
+		t.Errorf("realm users after one legitimate sign-in: got %v want exactly [%s]", got, owner)
+	}
+}
+
+// TestPinIssue_ResponseShapeIdenticalForKnownAndUnknownEmail_5720 pins the
+// enumeration-oracle half.
+//
+// HONEST SCOPE: this is a FORWARD-LOOKING invariant, not a reproduction of
+// #5720 — it passes on the pre-fix tree too, because pre-fix pin/issue
+// answered 200 for both cases (it created the missing principal rather
+// than reporting its absence). It is included because the natural
+// "cleanup" after moving EnsureUser is to add a `user not found → 404`
+// or `known → different code` shortcut to pin/issue, which would convert
+// this endpoint into an account-existence oracle for an unauthenticated
+// caller. This test makes that regression fail loudly.
+//
+// The assertion is on the caller-visible response: status + every field
+// except the deliberately-unpredictable requestId.
+func TestPinIssue_ResponseShapeIdenticalForKnownAndUnknownEmail_5720(t *testing.T) {
+	realm := newFakeRealm(t, "sovereign")
+	realm.seedUser("known@t99.omani.works", "/openova-users")
+	h := newHandlerOnFakeRealm(t, realm)
+	defer withSendPinEmail(noopSendPin)()
+
+	knownCode, knownBody := postPinIssue(t, h, "known@t99.omani.works")
+	unknownCode, unknownBody := postPinIssue(t, h, "never-seen@t99.omani.works")
+
+	if knownCode != unknownCode {
+		t.Errorf("status differs by account existence: known=%d unknown=%d — account-enumeration oracle",
+			knownCode, unknownCode)
+	}
+	delete(knownBody, "requestId")
+	delete(unknownBody, "requestId")
+	kj, _ := json.Marshal(knownBody)
+	uj, _ := json.Marshal(unknownBody)
+	if string(kj) != string(uj) {
+		t.Errorf("response body differs by account existence — account-enumeration oracle:\n  known:   %s\n  unknown: %s",
+			kj, uj)
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func decodeSessionClaims(t *testing.T, rawJWT string) auth.Claims {
+	t.Helper()
+	parts := strings.Split(rawJWT, ".")
+	if len(parts) != 3 {
+		t.Fatalf("session cookie: got %d JWT parts want 3", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode JWT payload: %v", err)
+	}
+	var claims auth.Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+	return claims
+}
+
+func hasPath(paths []string, want string) bool {
+	for _, p := range paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

`POST /api/v1/auth/pin/issue` is **unauthenticated**. Step 2 of the handler called

```go
if _, err := kc.EnsureUser(r.Context(), email, "openova-users"); err != nil {
```

**before** the PIN was generated, before it was mailed, and before anything was verified. So typing any address into the console login form was sufficient to write a permanent, `enabled`, `emailVerified` principal into the Sovereign realm — the caller never had to read the PIN, or even wait for it.

The per-email 60 s rate limiter (`store.tryReserve(email)`) does not constrain this at all: a caller who **varies** the address never repeats a key, so the write is unbounded.

Found on hw292 while re-walking UAT row 41, which asserts the sovereign realm holds exactly the seeded owner principal. It held two — the owner plus `emrha.baysal@openova.io`, a transposition typo that became a permanent realm user because somebody mistyped it at the login form once, a day after the realm was seeded.

CONFIRMED on `main` at `products/catalyst/bootstrap/api/internal/handler/auth.go:509` — the mechanism had not changed since the issue was filed.

### Why the stray landed in the `sovereign` realm

Worth recording, because the code reads as if it could not: `HandlePinIssue` provisions via `openovaKCClient()`, whose realm defaults to `openova`. On a **Sovereign** that default never applies — `CATALYST_OPENOVA_KC_REALM` is populated from the `catalyst-openova-kc-credentials` Secret, whose `kc-realm` key is mirrored from `keycloak/catalyst-kc-sa-credentials` (realm `sovereign`). So on a Sovereign `openovaKCClient()` and `keycloakClientFor()` resolve to the **same** realm, which is exactly why an unauthenticated `pin/issue` writes into the realm UAT row 41 inspects.

## Blast radius — measured, matches the issue

Re-derived from the code rather than restated. `keycloak.Client.EnsureUser` creates the user with `enabled: true`, `emailVerified: true`, `requiredActions: []`, and joins **only** `openova-users`. It never touches `/sovereign-admins`, and `pinSessionAuthority` derives admin authority exclusively from `/sovereign-admins` membership (or an exact `OPERATOR_EMAIL` match). An injected principal therefore resolves to `tier=viewer` with no credential set.

So this is an **unauthenticated write into the identity store**, not privilege escalation. Not inflated, not deflated.

## Fix

Defer the realm write to `HandlePinVerify`, gated on a correct PIN.

**Deferral was viable — nothing at issue-time needed the principal.** Checked each candidate dependency rather than assuming:

| Issue-time step | Needs the realm user? |
|---|---|
| `pinStore.tryReserve` / `put` | No — keyed on the email **string** |
| `generatePin` | No |
| `sendPinEmail` → SMTP | No — takes an address, not a principal |
| `pinSessionAuthority` (the only realm **read**) | Runs at **verify**, so it is downstream either way |
| `EnsureOwnerUserAccess` | Not on this path — only `auth_handover.go` calls it |

The one ordering constraint: `EnsureUser` must run **before** `pinSessionAuthority` in verify, since that resolves tier from live group membership. The fix places it there. `EnsureUser` only joins `openova-users`, so it cannot manufacture admin authority — a brand-new principal still resolves to `viewer`.

Two deliberate retentions, so the operator-visible contract does not move:

1. The `kc == nil` check **stays** in `pin/issue`. It is a local env/Secret check — no network call, no write — that still fails fast on a Sovereign whose `catalyst-openova-kc-credentials` never rendered (the #901 / #3642 chain), rather than mailing a PIN that could never be redeemed. `TestPinIssue_NoKCReturns503` is unchanged and still green.
2. The error taxonomy at verify is byte-identical to the old issue-time one (`503 auth-unconfigured` / `502 user-provisioning-failed`). A KC-down Sovereign fails the way it always did; only the step at which it fails moved.

## The enumeration-oracle half

After this change `pin/issue` **does not consult the realm at all**, so its response cannot vary by account existence. That closes the half the issue describes.

Two residual signals, stated honestly rather than papered over:

- **The 60 s cooldown (429).** It distinguishes "this address requested a code in the last 60 s" — *request recency*, not account existence. Pre-fix every address got a principal and post-fix none do, so it never discriminated known from unknown accounts. It is inherent to per-email rate limiting and removing it would break the "please wait 60 s" UX. **Left as-is, deliberately.**
- **`422 email-rejected` + `smtpCode` on an SMTP 5xx.** This is a real *mailbox*-existence oracle, but it enumerates the **mail relay**, not the Catalyst realm — the two sets differ (the stray `emrha.baysal@` has a realm principal and no mailbox). It is orthogonal to this defect, it is the contract `TestPinIssue_SMTP5xxReturns422` pins for #1742 / Cov-bench C6-010, and `LoginPage.tsx` renders its `detail` as the operator's only feedback on a mistyped address — i.e. the one signal that would have caught the very typo in this issue. Suppressing it here would trade a realm-write fix for a UX regression on the same flow. **Deliberately NOT changed**; noted below as follow-up.

A forward guard is included so the obvious post-refactor "cleanup" (adding a `user not found → 404` shortcut to `pin/issue`) cannot silently turn this endpoint into an account-existence oracle.

## Guard — both directions, verbatim

`auth_pin_issue_no_unverified_realm_write_5720_test.go` wires the **production** `*keycloak.Client` against an `httptest` server that keeps a real realm-user table, and asserts on **that table** — not on a status code, not on a call counter. A stub counting `EnsureUser` calls would assert on the call rather than the effect and would be satisfied by any refactor reaching Keycloak another way.

The exercised path is the one production mounts (`cmd/api/main.go:719 → h.HandlePinIssue`), through the real `findUserByEmail` / `createUser` / `addUserToGroup` HTTP sequence.

**Pre-fix tree (`auth.go` reverted to `origin/main`, guard file unchanged) — 3 RED, 2 controls GREEN:**

```
=== RUN   TestPinIssue_NoRealmUserForUnverifiedEmail_5720
    auth_pin_issue_no_unverified_realm_write_5720_test.go:402: realm users after unverified pin/issue: got [drive-by@t99.omani.works] want none
          #5720: pin/issue is unauthenticated — it must never write a principal.
          The principal may only appear after a correct PIN proves mailbox control.
--- FAIL: TestPinIssue_NoRealmUserForUnverifiedEmail_5720 (0.14s)
=== RUN   TestPinIssue_UnauthenticatedFloodCreatesNoPrincipals_5720
    auth_pin_issue_no_unverified_realm_write_5720_test.go:428: realm users after 8 varied unverified pin/issue calls: got 8 [flood-0@t99.omani.works flood-1@t99.omani.works flood-2@t99.omani.works flood-3@t99.omani.works flood-4@t99.omani.works flood-5@t99.omani.works flood-6@t99.omani.works flood-7@t99.omani.works] want 0
          The 60s limiter is keyed per-email, so varying the address bypasses it entirely.
--- FAIL: TestPinIssue_UnauthenticatedFloodCreatesNoPrincipals_5720 (0.05s)
=== RUN   TestPinVerify_WrongPINNeverCreatesPrincipal_5720
    auth_pin_issue_no_unverified_realm_write_5720_test.go:460: realm users after issue + 3 wrong PINs: got [wrong-pin@t99.omani.works] want none
          A caller who never produced the PIN never proved mailbox control.
--- FAIL: TestPinVerify_WrongPINNeverCreatesPrincipal_5720 (0.12s)
=== RUN   TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720
--- PASS: TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720 (0.08s)
=== RUN   TestPinIssue_ResponseShapeIdenticalForKnownAndUnknownEmail_5720
--- PASS: TestPinIssue_ResponseShapeIdenticalForKnownAndUnknownEmail_5720 (0.03s)
FAIL
```

**Post-fix tree — all 5 GREEN:**

```
=== RUN   TestPinIssue_NoRealmUserForUnverifiedEmail_5720
--- PASS: TestPinIssue_NoRealmUserForUnverifiedEmail_5720 (0.05s)
=== RUN   TestPinIssue_UnauthenticatedFloodCreatesNoPrincipals_5720
--- PASS: TestPinIssue_UnauthenticatedFloodCreatesNoPrincipals_5720 (0.10s)
=== RUN   TestPinVerify_WrongPINNeverCreatesPrincipal_5720
--- PASS: TestPinVerify_WrongPINNeverCreatesPrincipal_5720 (0.07s)
=== RUN   TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720
--- PASS: TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720 (0.07s)
=== RUN   TestPinIssue_ResponseShapeIdenticalForKnownAndUnknownEmail_5720
--- PASS: TestPinIssue_ResponseShapeIdenticalForKnownAndUnknownEmail_5720 (0.06s)
PASS
```

### The controls are what make the guards un-cheatable

`TestPinVerify_LegitimateOwnerSignsInEndToEnd_5720` passes on **both** trees and asserts the full sign-in outcome for the seeded owner: `pin/issue` 200 → correct PIN → `pin/verify` 200 → `catalyst_session` set `HttpOnly` + `SameSite=Lax` → `tier=admin` + `catalyst-admin` derived from live `/sovereign-admins` membership → `policyModeCallerAuthorized` true → the owner provisioned into `openova-users`. **Deleting the `EnsureUser` call outright, or otherwise stopping the injection by breaking login, turns this red.** That is the answer to "if the defect were present, could this check have gone red" run in the other direction.

`TestPinIssue_ResponseShapeIdenticalForKnownAndUnknownEmail_5720` also passes on both trees and is labelled in-file as a **forward-looking invariant, not a reproduction** — pre-fix `pin/issue` already answered 200 for both cases because it created the missing principal rather than reporting its absence. Calling it a #5720 repro would be exactly the "guard that tested a surface that cannot fail" pattern; it is included for the regression it *does* prevent.

### The check actually runs

`.github/workflows/test-bootstrap-api.yaml` triggers on `products/catalyst/bootstrap/api/**` (both `push` to main and `pull_request`) and runs `go test -race -count=1 ./...` — no `|| true`, no fail-open. The new file is under that path, so it is in scope on this PR.

## Not fixed here — deliberately

- **The live stray principal on hw292.** `emrha.baysal@openova.io` is still in the realm; this PR stops new ones, it does not clean up existing ones. Left in place on purpose — it is the live evidence for UAT row 41 and for this issue.
- **The SMTP `422` mailbox oracle** — reasoning above. Worth its own issue if we want it, since the right fix trades against typo feedback on the login form.
- **Unauthenticated SMTP amplification.** `pin/issue` still triggers one outbound mail per call to an arbitrary address; only the *realm* write is now gated. Pre-existing, unchanged by this PR, and a separate concern from #5720.
- **`gofmt` drift in `auth.go`.** The file was already non-`gofmt` on `origin/main` (verified by formatting the pristine blob), as are ~10 other files in the module. Not touched, to keep this diff to the defect. CI runs `go vet` + `go test`, not `gofmt`.

No chart change, so no #817 five-site lockstep applies — this is Go handler + test only.

Refs #5720
Refs #3374
