### PR TITLE
fix(catalyst-api): org-teardown reap keys on BOTH producers' parent-label vocabularies + a producer->reaper round-trip guard

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap.go
@@ -73,7 +73,12 @@
 //     (the chart's apex pair `console-https`/`console-http` never matches);
 //     Certificate/Secret name prefix `org-wildcard-tls-` (the Sovereign's
 //     per-zone wildcards are `sovereign-wildcard-tls-*`) + a label- or
-//     cert-manager-annotation-derived org zone; Namespace with an org
+//     cert-manager-annotation-derived org zone, where the label derivation
+//     (orgZoneFromProducerLabels) accepts BOTH producers' parent-label
+//     vocabularies — catalyst-api's `pool-parent` and the org-controller's
+//     `parent-zone` — through ONE shared helper, so the Certificate and
+//     Secret scans cannot drift onto different identity rules (#5649);
+//     Namespace with an org
 //     identity label (`openova.io/organization` / `catalyst.openova.io/org`
 //     / `kustomize.toolkit.fluxcd.io/name=org-tenants`) and NOT in the
 //     protected-namespace denylist. Anything that cannot be positively
@@ -136,6 +141,11 @@ const (
 	orgConsoleListenerHTTPSPrefix = consoleApexListenerHTTPSName + "-"
 	orgConsoleListenerHTTPPrefix  = consoleApexListenerHTTPName + "-"
 	consoleHostLabelPrefix        = "console."
+	// orgTenantsKustomizationName — the Flux Kustomization that renders the
+	// funnel-materialized per-Org tenant namespaces (clusters/<sov-fqdn>/
+	// org-tenants). Only namespaces carrying THIS value are name-keyed
+	// candidates; see orgNamespaceReapIdentity.
+	orgTenantsKustomizationName = "org-tenants"
 )
 
 // orgConsoleReapProtectedNamespaces — hard denylist (safety model #4). A
@@ -255,6 +265,79 @@ func orgZoneSlugParent(zone, sovereignFQDN string) (slug string, ok bool) {
 		return "", false
 	}
 	return slug, true
+}
+
+// orgZoneFromProducerLabels derives an artifact's org zone `<slug>.<parent>`
+// from the identity labels the producers stamp, accepting BOTH producers'
+// parent-label vocabularies:
+//
+//   - catalyst-api  — `catalyst.openova.io/pool-parent`
+//     (org_console_tls.go orgConsoleTLSLabels)
+//   - org-controller — `catalyst.openova.io/parent-zone`
+//     (core/controllers/organization/.../tenant_console_tls.go:363 and
+//     tenant_route.go:149)
+//
+// Returns "" when no positive identity can be derived, so every caller falls
+// through to its own secondary source (Certificate → spec.commonName,
+// Secret → the `cert-manager.io/common-name` annotation) and, failing that,
+// leaves the object alone (safety model #4).
+//
+// SHARED ON PURPOSE. Before this helper the Certificate scan read both label
+// spellings while the Secret scan read only `pool-parent`. That asymmetry was
+// invisible to every test in the package because the fixtures hand-write the
+// label set they expect: flipping catalyst-api's own emitter from
+// `pool-parent` to `parent-zone` left the WHOLE internal/handler suite green
+// (256s, `ok`) while making the #5511 mirrored TLS Secret in every secondary
+// region permanently unreapable — the mirror carries no cert-manager
+// annotation, so there is no fallback behind the label. One helper means the
+// two scans cannot drift apart again by construction. Refs #5649 #5364.
+func orgZoneFromProducerLabels(labels map[string]string) string {
+	sub := strings.TrimSpace(labels["catalyst.openova.io/org-subdomain"])
+	if sub == "" {
+		return ""
+	}
+	parent := strings.TrimSpace(labels["catalyst.openova.io/pool-parent"])
+	if parent == "" {
+		parent = strings.TrimSpace(labels["catalyst.openova.io/parent-zone"])
+	}
+	if parent == "" {
+		return "" // slug without a parent zone — the caller's fallback decides
+	}
+	return sub + "." + parent
+}
+
+// orgNamespaceReapIdentity is the pure candidate test scanOrgNamespaces
+// applies to one Namespace: returns the org identity the namespace is keyed
+// on, or ok=false when it is not a positively-identified org boundary
+// namespace. Exposed as a standalone predicate so the producer→reaper
+// round-trip guard can feed it the Namespace an emitter ACTUALLY wrote
+// instead of re-stating the rule in a fixture (Refs #5649).
+func orgNamespaceReapIdentity(name string, labels map[string]string) (string, bool) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" || orgConsoleReapProtectedNamespaces[name] || strings.HasPrefix(name, "kube-") {
+		return "", false
+	}
+	identity := labels["openova.io/organization"]
+	if identity == "" {
+		identity = labels["catalyst.openova.io/org"]
+	}
+	if identity == "" {
+		// Third shape: the funnel-materialized tenant ns, identified ONLY by
+		// the org-tenants Kustomization that renders it — identity is the ns
+		// name itself. The label VALUE is pinned (not merely the key) because
+		// the scan's List selector pins it: a namespace rendered by any OTHER
+		// Kustomization (`catalyst-tenant-<slug>-vcluster`, the live shape on
+		// hw292) must NOT become a name-keyed candidate.
+		if labels["kustomize.toolkit.fluxcd.io/name"] != orgTenantsKustomizationName {
+			return "", false
+		}
+		identity = name
+	}
+	identity = strings.ToLower(strings.TrimSpace(identity))
+	if identity == "" || !orgSlugRE.MatchString(identity) {
+		return "", false
+	}
+	return identity, true
 }
 
 // reapCandidateOldEnough applies the age grace (safety model #2). A zero
@@ -388,18 +471,7 @@ func (h *Handler) scanOrgConsoleCertificates(ctx context.Context, sc *orgConsole
 		if !reapCandidateOldEnough(c.GetCreationTimestamp()) {
 			continue
 		}
-		zone := strings.TrimSpace(c.GetLabels()["catalyst.openova.io/org-subdomain"])
-		if zone != "" {
-			parent := strings.TrimSpace(c.GetLabels()["catalyst.openova.io/pool-parent"])
-			if parent == "" {
-				parent = strings.TrimSpace(c.GetLabels()["catalyst.openova.io/parent-zone"])
-			}
-			if parent == "" {
-				zone = "" // label slug without a parent zone — fall through to commonName
-			} else {
-				zone = zone + "." + parent
-			}
-		}
+		zone := orgZoneFromProducerLabels(c.GetLabels())
 		if zone == "" {
 			zone = nestedString(c.Object, "spec", "commonName")
 		}
@@ -429,12 +501,7 @@ func (h *Handler) scanOrgConsoleSecrets(ctx context.Context, sc *orgConsoleReapS
 		if !reapCandidateOldEnough(s.CreationTimestamp) {
 			continue
 		}
-		zone := ""
-		if sub := strings.TrimSpace(s.Labels["catalyst.openova.io/org-subdomain"]); sub != "" {
-			if parent := strings.TrimSpace(s.Labels["catalyst.openova.io/pool-parent"]); parent != "" {
-				zone = sub + "." + parent
-			}
-		}
+		zone := orgZoneFromProducerLabels(s.Labels)
 		if zone == "" {
 			zone = strings.TrimSpace(s.Annotations["cert-manager.io/common-name"])
 		}
@@ -454,25 +521,19 @@ func (h *Handler) scanOrgConsoleSecrets(ctx context.Context, sc *orgConsoleReapS
 // every tenant HelmRelease inside it (#5364).
 func (h *Handler) scanOrgNamespaces(ctx context.Context, sc *orgConsoleReapScan) {
 	seen := map[string]bool{}
-	addNS := func(name, identity string, ts metav1.Time) {
+	addNS := func(name string, labels map[string]string, ts metav1.Time) {
+		identity, ok := orgNamespaceReapIdentity(name, labels)
+		if !ok || seen[strings.ToLower(strings.TrimSpace(name))] || !reapCandidateOldEnough(ts) {
+			return
+		}
 		name = strings.ToLower(strings.TrimSpace(name))
-		identity = strings.ToLower(strings.TrimSpace(identity))
-		if name == "" || identity == "" || seen[name] {
-			return
-		}
-		if orgConsoleReapProtectedNamespaces[name] || strings.HasPrefix(name, "kube-") {
-			return
-		}
-		if !orgSlugRE.MatchString(identity) || !reapCandidateOldEnough(ts) {
-			return
-		}
 		seen[name] = true
 		sc.namespaces[identity] = append(sc.namespaces[identity], name)
 	}
 	for _, selector := range []string{
 		"openova.io/organization",
 		"catalyst.openova.io/org",
-		"kustomize.toolkit.fluxcd.io/name=org-tenants",
+		"kustomize.toolkit.fluxcd.io/name=" + orgTenantsKustomizationName,
 	} {
 		list, err := sc.target.core.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: selector})
 		if err != nil {
@@ -482,14 +543,7 @@ func (h *Handler) scanOrgNamespaces(ctx context.Context, sc *orgConsoleReapScan)
 		}
 		for i := range list.Items {
 			ns := &list.Items[i]
-			identity := ns.Labels["openova.io/organization"]
-			if identity == "" {
-				identity = ns.Labels["catalyst.openova.io/org"]
-			}
-			if identity == "" {
-				identity = ns.Name
-			}
-			addNS(ns.Name, identity, ns.CreationTimestamp)
+			addNS(ns.Name, ns.Labels, ns.CreationTimestamp)
 		}
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap_roundtrip_5649_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap_roundtrip_5649_test.go
@@ -1,0 +1,461 @@
+// org_console_tls_reap_roundtrip_5649_test.go — #5649, the producer→reaper
+// ROUND-TRIP guard.
+//
+// WHY THIS EXISTS, on top of the #5364 fixture test next door.
+//
+// TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped seeds
+// its orphans from HAND-WRITTEN fixtures — `catalystAPIConsoleRoute`,
+// `seedOrgWildcardCert`, `mirroredOrgSecret` and friends restate each
+// producer's name+label contract in the test file. That makes the test a COPY
+// of the contract, and a copy cannot notice when the original moves. Measured,
+// not assumed: flipping catalyst-api's own emitter label
+// `catalyst.openova.io/pool-parent` → `catalyst.openova.io/parent-zone` in
+// orgConsoleTLSLabels (a plausible consolidation onto the org-controller's
+// vocabulary — it stamps `parent-zone` at tenant_console_tls.go:363) left the
+// ENTIRE internal/handler package green:
+//
+//	ok  github.com/.../internal/handler  256.073s
+//
+// while in production it made the #5511 mirrored per-Org TLS Secret in EVERY
+// secondary region permanently unreapable — the mirror carries no
+// `cert-manager.io/common-name` annotation, so there is no fallback behind the
+// label the scan reads. Green suite, live leak, in exactly the class #5649 was
+// filed for. (That specific hole is closed in this PR by
+// orgZoneFromProducerLabels; this test is what makes the NEXT one visible.)
+//
+// WHAT THIS TEST DOES DIFFERENTLY. It writes nothing by hand. It runs the real
+// reconcile pass so catalyst-api's OWN emitters produce the per-Org console
+// surface in both regions, derives the expected names from the producer's own
+// resolver (resolveOrgConsoleTLSNames — production code, not a restatement),
+// deletes ONE Organization CR, runs the pass again, and asserts that
+// everything the emitters wrote for the deleted Org is gone in EVERY region
+// while everything they wrote for the LIVE Org is untouched. If a producer
+// changes a name shape, a label, or a region fan-out and the reaper does not
+// follow, this test goes red by construction.
+//
+// SCOPE, stated rather than implied. The fake dynamic client and the fake
+// typed clientset are SEPARATE object stores, so a Namespace the app-surface
+// emitter creates through the dynamic client is not visible to the typed
+// client the namespace scan lists through. That is a harness artifact, not a
+// production property (one apiserver backs both). Rather than paper over it
+// with a hand-seeded duplicate, this test asserts the namespace contract at
+// its real seam: the Namespace object ensureOrgBoundaryNamespaceForApps
+// actually wrote is fed to orgNamespaceReapIdentity — the exact predicate
+// scanOrgNamespaces applies — and must yield the Org's identity. Likewise the
+// cert-manager-issued host Secret is injected by hand because cert-manager is
+// an EXTERNAL producer; its shape is pinned to what hw292 carries live
+// (labels: only `controller.cert-manager.io/fao`; annotations include
+// `cert-manager.io/common-name: <slug>.<parent>`), and the object under test
+// is the MIRROR catalyst-api derives from it.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// certManagerIssuedSecret — the EXTERNAL producer's shape, pinned to the live
+// hw292 object `kube-system/org-wildcard-tls-<slug>-omani-homes`: cert-manager
+// copies none of the Certificate's labels onto the backing Secret, so the
+// `cert-manager.io/common-name` annotation is the only org identity on it.
+func certManagerIssuedSecret(certName, orgZone string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      certName,
+			Namespace: consoleCertNamespace,
+			Labels:    map[string]string{"controller.cert-manager.io/fao": "true"},
+			Annotations: map[string]string{
+				"cert-manager.io/certificate-name": certName,
+				"cert-manager.io/common-name":      orgZone,
+				"cert-manager.io/alt-names":        "*." + orgZone + "," + orgZone,
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{"tls.crt": []byte("issued"), "tls.key": []byte("key")},
+	}
+}
+
+// producerNames resolves one Org's artifact names through the PRODUCER's own
+// resolver, from the same Organization CR the reconcile pass reads. Every
+// expectation in this test comes from here — never from a string literal — so
+// a producer-side rename moves the expectation with it and the assertion then
+// measures only whether the REAPER followed.
+func producerNames(t *testing.T, slug, parent, sovereignFQDN string) orgConsoleTLSNames {
+	t.Helper()
+	rec, ok := orgConsoleTLSRecordFromOrgCR(funnelOrgCR(slug, parent), sovereignFQDN)
+	if !ok {
+		t.Fatalf("producer refused to derive a console surface for %s.%s", slug, parent)
+	}
+	names, ok := resolveOrgConsoleTLSNames(rec)
+	if !ok {
+		t.Fatalf("resolveOrgConsoleTLSNames refused %s.%s", slug, parent)
+	}
+	return names
+}
+
+// routeNamesInRegion lists the console HTTPRoute names a region actually
+// holds, so the test can assert on OBSERVED state rather than on a guess.
+func routeNamesInRegion(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]bool {
+	t.Helper()
+	list, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list console routes: %v", err)
+	}
+	out := map[string]bool{}
+	for i := range list.Items {
+		out[list.Items[i].GetName()] = true
+	}
+	return out
+}
+
+// applySSAListeners is the harness bridge for the ONE thing a fake apiserver
+// cannot do. ensureOrgConsoleListener adds the per-Org listener pair with a
+// server-side-apply Patch (org_console_tls.go:791), and `dynamicfake` records
+// ApplyPatchType patches without performing the name-keyed list merge a real
+// apiserver performs — so on a fake the Gateway object never grows the pair.
+// The #5635 tests work around this by asserting on the ACTION log; the reap,
+// however, scans and strips OBJECT state, so the round trip needs the merged
+// object.
+//
+// This performs exactly that merge, and it takes the listener definitions from
+// the producer's OWN recorded patch bytes — nothing here is retyped from the
+// emitter. A producer-side rename of the listener name or hostname therefore
+// still flows through to the assertions unchanged.
+func applySSAListeners(t *testing.T, dyn *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+	ctx := context.Background()
+	gw, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Get(ctx, consoleGatewayName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get console gateway: %v", err)
+	}
+	listeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		t.Fatalf("read gateway listeners: %v", err)
+	}
+	byName := map[string]bool{}
+	for _, l := range listeners {
+		if lm, ok := l.(map[string]any); ok {
+			if n, ok := lm["name"].(string); ok {
+				byName[n] = true
+			}
+		}
+	}
+	merged := false
+	for _, a := range dyn.Actions() {
+		pa, ok := a.(k8stesting.PatchAction)
+		if !ok || pa.GetPatchType() != types.ApplyPatchType ||
+			pa.GetResource() != consoleGatewayGVR || pa.GetName() != consoleGatewayName {
+			continue
+		}
+		var applied map[string]any
+		if err := json.Unmarshal(pa.GetPatch(), &applied); err != nil {
+			t.Fatalf("decode recorded SSA patch: %v", err)
+		}
+		patched, _, err := unstructured.NestedSlice(applied, "spec", "listeners")
+		if err != nil {
+			t.Fatalf("read listeners out of the recorded SSA patch: %v", err)
+		}
+		for _, l := range patched {
+			lm, ok := l.(map[string]any)
+			if !ok {
+				continue
+			}
+			n, _ := lm["name"].(string)
+			if n == "" || byName[n] {
+				continue
+			}
+			byName[n] = true
+			listeners = append(listeners, lm)
+			merged = true
+		}
+	}
+	if !merged {
+		return
+	}
+	if err := unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners"); err != nil {
+		t.Fatalf("set merged gateway listeners: %v", err)
+	}
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Update(ctx, gw, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("write merged gateway: %v", err)
+	}
+}
+
+// TestOrgConsoleTeardown_ProducerRoundTrip_EveryEmittedArtifactIsReaped —
+// emit with the real producers, delete the Org, reap, and assert the round
+// trip closes in every region.
+//
+// Direction 1 (reaped): every artifact catalyst-api's emitters wrote for
+// `ghostco` is gone in BOTH regions after the CR is deleted.
+// Direction 2 (never reaped): every artifact the SAME emitters wrote for the
+// still-live `liveco` survives the same pass, in both regions.
+func TestOrgConsoleTeardown_ProducerRoundTrip_EveryEmittedArtifactIsReaped(t *testing.T) {
+	const (
+		sovereignFQDN = "hw292.omani.works"
+		parent        = "omani.homes"
+		liveSlug      = "liveco"
+		ghostSlug     = "ghostco"
+	)
+	t.Setenv("SOVEREIGN_FQDN", sovereignFQDN) // chroot gate for the region fan-out
+	ctx := context.Background()
+
+	liveNames := producerNames(t, liveSlug, parent, sovereignFQDN)
+	ghostNames := producerNames(t, ghostSlug, parent, sovereignFQDN)
+
+	hostDyn := fakeDynForOrgConsoleReconcile(t,
+		funnelOrgCR(liveSlug, parent), bssOrgCR(ghostSlug, parent))
+	secDyn := fakeDynForOrgConsoleReconcile(t) // secondaries carry no Organization CRD (live hw292)
+	hostCore := k8sfake.NewSimpleClientset()
+	secCore := k8sfake.NewSimpleClientset()
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+
+	// ── PASS 1: the real emitters produce the surface in both regions. ──
+	h.reconcileOrgConsoleTLSOnce(ctx)
+
+	// cert-manager (external) issues the backing Secrets for the Certificates
+	// pass 1 created, so pass 2's mirror has something to copy.
+	for _, n := range []orgConsoleTLSNames{liveNames, ghostNames} {
+		if !certExists(t, hostDyn, n.CertName) {
+			t.Fatalf("producer did not create Certificate %s in the host region — fixture cannot proceed", n.CertName)
+		}
+		if _, err := hostCore.CoreV1().Secrets(consoleCertNamespace).
+			Create(ctx, certManagerIssuedSecret(n.CertName, n.OrgZone), metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed cert-manager-issued Secret %s: %v", n.CertName, err)
+		}
+	}
+
+	// ── PASS 2: the mirror emitter copies the issued Secrets to secondaries. ──
+	h.reconcileOrgConsoleTLSOnce(ctx)
+
+	// Materialize the SSA listener merge a real apiserver would have done, from
+	// the producer's own recorded patch bytes (see applySSAListeners).
+	applySSAListeners(t, hostDyn)
+	applySSAListeners(t, secDyn)
+
+	// The app-surface emitter's Namespace contract, asserted at its real seam
+	// (see the file header on why this is a predicate check, not a store check).
+	if err := ensureOrgBoundaryNamespaceForApps(ctx, secDyn, ghostNames,
+		mustOrgRecord(t, ghostSlug, parent, sovereignFQDN)); err != nil {
+		t.Fatalf("app-surface emitter could not create the secondary boundary Namespace: %v", err)
+	}
+	producedNS, err := secDyn.Resource(namespacesGVR()).Get(ctx, ghostNames.Slug, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("read back the Namespace the app-surface emitter wrote: %v", err)
+	}
+	if identity, ok := orgNamespaceReapIdentity(producedNS.GetName(), producedNS.GetLabels()); !ok {
+		t.Errorf("the Namespace ensureOrgBoundaryNamespaceForApps writes into a secondary region is NOT a reap candidate — "+
+			"labels %v fail orgNamespaceReapIdentity, so a deleted Org's boundary namespace (and every mirrored app route + "+
+			"ClusterMesh stub inside it) leaks in that region forever (#5649 #5635)", producedNS.GetLabels())
+	} else if identity != ghostNames.Slug {
+		t.Errorf("app-surface Namespace resolves to reap identity %q, want the Org slug %q — the reaper would key it to the wrong Org",
+			identity, ghostNames.Slug)
+	}
+
+	// ── VACUITY: the producers really did write everything, in both regions. ──
+	type artifact struct {
+		what    string
+		present bool
+	}
+	preState := func(n orgConsoleTLSNames) []artifact {
+		hostRoutes, secRoutes := routeNamesInRegion(t, hostDyn), routeNamesInRegion(t, secDyn)
+		hostListeners, secListeners := gatewayListenerNames(t, hostDyn), gatewayListenerNames(t, secDyn)
+		return []artifact{
+			{fmt.Sprintf("host route %s", n.RouteName), hostRoutes[n.RouteName]},
+			{fmt.Sprintf("secondary route %s", n.RouteName), secRoutes[n.RouteName]},
+			{fmt.Sprintf("host listener %s", n.HTTPSName), hostListeners[n.HTTPSName]},
+			{fmt.Sprintf("host listener %s", n.HTTPName), hostListeners[n.HTTPName]},
+			{fmt.Sprintf("secondary listener %s", n.HTTPSName), secListeners[n.HTTPSName]},
+			{fmt.Sprintf("secondary listener %s", n.HTTPName), secListeners[n.HTTPName]},
+			{fmt.Sprintf("host Certificate %s", n.CertName), certExists(t, hostDyn, n.CertName)},
+			{fmt.Sprintf("host issued Secret %s", n.CertName), secretExists(t, hostCore, n.CertName)},
+			{fmt.Sprintf("secondary mirrored Secret %s", n.CertName), secretExists(t, secCore, n.CertName)},
+		}
+	}
+	for _, n := range []orgConsoleTLSNames{liveNames, ghostNames} {
+		for _, a := range preState(n) {
+			if !a.present {
+				t.Fatalf("vacuity: the producers never wrote %s — a later 'reaped' assertion would pass on nothing", a.what)
+			}
+		}
+	}
+
+	// ── Delete the Organization CR. Nothing else. ──
+	if err := hostDyn.Resource(organizationGVR()).
+		Delete(ctx, ghostSlug, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete Organization CR %s: %v", ghostSlug, err)
+	}
+
+	// ── PASS 3: the reap. ──
+	h.reconcileOrgConsoleTLSOnce(ctx)
+
+	// Direction 1 — every producer-emitted ghostco artifact is gone, per region.
+	var leaked []string
+	for _, a := range preState(ghostNames) {
+		if a.present {
+			leaked = append(leaked, a.what)
+		}
+	}
+	if len(leaked) > 0 {
+		sort.Strings(leaked)
+		for _, l := range leaked {
+			t.Errorf("deleted Org %s: the producers wrote it and the reaper left it behind — %s (#5649)", ghostSlug, l)
+		}
+	}
+
+	// Direction 2 — the SURVIVOR is untouched. A deletion path is only correct
+	// if the live Org's identical surface comes through the same pass intact.
+	for _, a := range preState(liveNames) {
+		if !a.present {
+			t.Errorf("live Org %s lost %s in the same pass that reaped %s — over-eager reaper (#5649)",
+				liveSlug, a.what, ghostSlug)
+		}
+	}
+	// And the Sovereign's own apex listeners, which parse like a per-Org pair.
+	for region, dyn := range map[string]*dynamicfake.FakeDynamicClient{"host": hostDyn, "secondary": secDyn} {
+		names := gatewayListenerNames(t, dyn)
+		if !names[consoleApexListenerHTTPSName] || !names[consoleApexListenerHTTPName] {
+			t.Errorf("[%s] the Sovereign's apex listener pair was stripped by the reap pass", region)
+		}
+	}
+}
+
+// mustOrgRecord builds the provisioning record the emitters consume from the
+// Organization CR, via the production derivation.
+func mustOrgRecord(t *testing.T, slug, parent, sovereignFQDN string) store.OrganizationProvisionRecord {
+	t.Helper()
+	rec, ok := orgConsoleTLSRecordFromOrgCR(funnelOrgCR(slug, parent), sovereignFQDN)
+	if !ok {
+		t.Fatalf("orgConsoleTLSRecordFromOrgCR refused %s.%s", slug, parent)
+	}
+	return rec
+}
+
+// TestOrgZoneFromProducerLabels_BothProducerVocabularies — the unit half of
+// the same contract: the reap's label-derived identity must accept BOTH
+// producers' parent-label spellings, because the mirrored TLS Secret has no
+// annotation fallback behind it.
+//
+// catalyst-api stamps `catalyst.openova.io/pool-parent`
+// (org_console_tls.go orgConsoleTLSLabels); the org-controller stamps
+// `catalyst.openova.io/parent-zone` (tenant_console_tls.go:363,
+// tenant_route.go:149). Before this PR the Certificate scan read both and the
+// Secret scan read only the first.
+func TestOrgZoneFromProducerLabels_BothProducerVocabularies(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name: "catalyst-api vocabulary (pool-parent)",
+			labels: map[string]string{
+				"catalyst.openova.io/org-subdomain": "uatco",
+				"catalyst.openova.io/pool-parent":   "omani.homes",
+			},
+			want: "uatco.omani.homes",
+		},
+		{
+			name: "org-controller vocabulary (parent-zone) — the live hw292 Certificate shape",
+			labels: map[string]string{
+				"catalyst.openova.io/org-subdomain": "uatco",
+				"catalyst.openova.io/parent-zone":   "omani.homes",
+			},
+			want: "uatco.omani.homes",
+		},
+		{
+			name:   "no identity at all — must stay underivable so nothing is reaped",
+			labels: map[string]string{"controller.cert-manager.io/fao": "true"},
+			want:   "",
+		},
+		{
+			name:   "slug without any parent — underivable, caller falls through",
+			labels: map[string]string{"catalyst.openova.io/org-subdomain": "uatco"},
+			want:   "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orgZoneFromProducerLabels(tc.labels); got != tc.want {
+				t.Errorf("orgZoneFromProducerLabels() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOrgNamespaceReapIdentity_OnlyPositivelyIdentifiedOrgNamespaces — the
+// never-reap half of the namespace predicate. The `org-tenants` branch keys on
+// the namespace NAME, so its label VALUE must be pinned: hw292's live org
+// namespaces carry `kustomize.toolkit.fluxcd.io/name:
+// catalyst-tenant-<slug>-vcluster`, and a key-only match would make any
+// Flux-rendered namespace a name-keyed reap candidate.
+func TestOrgNamespaceReapIdentity_OnlyPositivelyIdentifiedOrgNamespaces(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		nsName string
+		labels map[string]string
+		wantID string
+		wantOK bool
+	}{
+		{
+			name:   "org-controller boundary ns",
+			nsName: "uatco",
+			labels: map[string]string{"openova.io/organization": "uatco"},
+			wantID: "uatco", wantOK: true,
+		},
+		{
+			name:   "catalyst-api ensureOrgNamespace ns",
+			nsName: "uatco",
+			labels: map[string]string{"catalyst.openova.io/org": "uatco"},
+			wantID: "uatco", wantOK: true,
+		},
+		{
+			name:   "funnel-materialized ns via the org-tenants Kustomization",
+			nsName: "uatco",
+			labels: map[string]string{"kustomize.toolkit.fluxcd.io/name": "org-tenants"},
+			wantID: "uatco", wantOK: true,
+		},
+		{
+			name:   "some OTHER Kustomization's namespace — the live hw292 label value",
+			nsName: "shared-pg",
+			labels: map[string]string{"kustomize.toolkit.fluxcd.io/name": "catalyst-tenant-uatco-vcluster"},
+			wantOK: false,
+		},
+		{
+			name:   "protected system namespace even when mislabelled",
+			nsName: "flux-system",
+			labels: map[string]string{"openova.io/organization": "flux-system"},
+			wantOK: false,
+		},
+		{
+			name:   "unlabelled namespace",
+			nsName: "monitoring-extra",
+			labels: map[string]string{},
+			wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := orgNamespaceReapIdentity(tc.nsName, tc.labels)
+			if ok != tc.wantOK {
+				t.Fatalf("orgNamespaceReapIdentity(%q) ok = %v, want %v", tc.nsName, ok, tc.wantOK)
+			}
+			if ok && id != tc.wantID {
+				t.Errorf("orgNamespaceReapIdentity(%q) = %q, want %q", tc.nsName, id, tc.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What #5672 left, and the part of it that no test could see

PR #5672 closed the one-producer / one-region teardown gap this issue named. Verifying it produced two findings.

### Finding 1 — the shipped guard cannot see producer drift (the reason this PR exists)

`TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped` seeds its orphans from **hand-written fixtures** — `catalystAPIConsoleRoute`, `seedOrgWildcardCert`, `mirroredOrgSecret` restate each producer's name+label contract inside the test file. That makes the test a **copy** of the contract, and a copy cannot notice when the original moves.

Measured, not argued. I flipped catalyst-api's own emitter label in `orgConsoleTLSLabels` from `catalyst.openova.io/pool-parent` to `catalyst.openova.io/parent-zone` (a plausible consolidation onto the org-controller's vocabulary) and ran the whole package:

```
drift injected: producer label pool-parent -> parent-zone
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	256.073s
```

Green suite. In production that same flip makes the #5511 mirrored per-Org TLS Secret in **every secondary region** permanently unreapable.

### Finding 2 — the asymmetry that drift exposes is live in the merged code today

`scanOrgConsoleCertificates` read **both** parent-label spellings. `scanOrgConsoleSecrets` read only `pool-parent`.

The org-controller stamps `parent-zone`, not `pool-parent` — `core/controllers/organization/internal/controller/tenant_console_tls.go:363` and `tenant_route.go:149`. Confirmed on the live hw292 Certificate:

```
$ kubectl -n kube-system get certificate org-wildcard-tls-uatco-omani-homes -o jsonpath='{.metadata.labels}'
{"catalyst.openova.io/org-subdomain":"uatco","catalyst.openova.io/parent-zone":"omani.homes",
 "openova.io/managed-by":"organization-controller", ...}
```

A Secret in that vocabulary has **no** `cert-manager.io/common-name` annotation behind it (the mirror is written by `mirrorOrgConsoleCertSecret`, not by cert-manager), so there is no fallback — the object is simply never a candidate.

## The change

**Source.** One shared `orgZoneFromProducerLabels` used by both scans, so the Certificate and Secret identity rules cannot drift apart again by construction. `orgNamespaceReapIdentity` extracted as the pure namespace predicate, and it now pins the `kustomize.toolkit.fluxcd.io/name` **value** to `org-tenants` rather than matching the key alone — hw292's live org namespaces carry `catalyst-tenant-<slug>-vcluster`, and a key-only match would have made any Flux-rendered namespace a name-keyed reap candidate. That is strictly fewer deletes, never more.

**Guard.** `TestOrgConsoleTeardown_ProducerRoundTrip_EveryEmittedArtifactIsReaped` writes nothing by hand. It runs the real reconcile pass so catalyst-api's own emitters produce the surface in both regions, derives every expectation from the producer's own resolver (`resolveOrgConsoleTLSNames`), deletes **one** Organization CR, runs the pass again, and asserts the round trip closes in every region — with the live Org's identical surface and the Sovereign's apex listeners asserted intact in the same pass.

Scope is stated in the file header rather than implied: the fake dynamic client and the fake typed clientset are separate object stores, so the namespace class is asserted at its real seam (the object `ensureOrgBoundaryNamespaceForApps` actually wrote is fed to `orgNamespaceReapIdentity`, the exact predicate the scan applies), and the SSA listener merge a real apiserver performs is materialized from the producer's **own recorded patch bytes**.

## Both directions, measured

### 1. Reap disabled (the pre-#5672 tree) — round-trip RED, 9 producer-emitted classes, both regions

```
--- FAIL: TestOrgConsoleTeardown_ProducerRoundTrip_EveryEmittedArtifactIsReaped (0.27s)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — host Certificate org-wildcard-tls-ghostco-omani-homes (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — host issued Secret org-wildcard-tls-ghostco-omani-homes (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — host listener console-http-ghostco (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — host listener console-https-ghostco (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — host route catalyst-ui-ghostco-omani-homes (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — secondary listener console-http-ghostco (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — secondary listener console-https-ghostco (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — secondary mirrored Secret org-wildcard-tls-ghostco-omani-homes (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — secondary route catalyst-ui-ghostco-omani-homes (#5649)
```

### 2. Producer renames its console route shape — round-trip RED, shipped fixture test GREEN

Injected `catalyst-ui-` -> `catalyst-console-` in `resolveOrgConsoleTLSNames`, everything else at HEAD of this branch:

```
PROBE 2 drift: producer console route name catalyst-ui-* -> catalyst-console-*
--- FAIL: TestOrgConsoleTeardown_ProducerRoundTrip_EveryEmittedArtifactIsReaped (0.27s)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — host route catalyst-console-ghostco-omani-homes (#5649)
    deleted Org ghostco: the producers wrote it and the reaper left it behind — secondary route catalyst-console-ghostco-omani-homes (#5649)
```

`TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped` does not appear — it passed, because it asserts on the literal name it wrote itself. That gap is exactly what this guard is for.

### 3. The as-merged #5672 Secret scan + the label drift — round-trip RED on the secondary mirror, shipped tests GREEN

```
PROBE 3: reap Secret scan reverted to the as-merged #5672 form + producer label drift pool-parent -> parent-zone
=== RUN   TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped
--- PASS: TestOrgConsoleTeardown_OrphanedOrg_BothProducersBothRegions_AllReaped (0.06s)
=== RUN   TestOrgConsoleTeardown_AlreadyClean_NoOpNoDeletes
--- PASS: TestOrgConsoleTeardown_AlreadyClean_NoOpNoDeletes (0.05s)
=== RUN   TestOrgConsoleTeardown_ProducerRoundTrip_EveryEmittedArtifactIsReaped
    deleted Org ghostco: the producers wrote it and the reaper left it behind — secondary mirrored Secret org-wildcard-tls-ghostco-omani-homes (#5649)
--- FAIL: TestOrgConsoleTeardown_ProducerRoundTrip_EveryEmittedArtifactIsReaped (0.27s)
```

### 4. Clean tree with this fix — green, under CI's exact invocation

```
$ go test -race -count=1 ./internal/handler/
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	263.758s
```

### Control that passes on BOTH trees

`TestOrgConsoleTeardown_AlreadyClean_NoOpNoDeletes` — asserts **zero delete verbs** on all four fake clients for a fully-served live Org. It is green in probes 1, 2, 3 and 4, so none of the reds above can be satisfied by blanket suppression: a reaper that deleted more would fail it, a reaper that deleted nothing fails the round trip.

### The check runs

`.github/workflows/test-bootstrap-api.yaml` filters on `products/catalyst/bootstrap/api/**`, which both changed files match, and the step is `go test -race -count=1 ./...` with no `|| true`.

## Live state, for the record

hw292 (dep `1c56518035a83e03`) still carries the R17 residue in both regions. That is expected and is not evidence about this PR: the deployed image is `catalyst-api:fad88bd`, which predates #5672's merge commit `407c00e7` entirely (`git merge-base --is-ancestor 407c00e74 fad88bd` -> false). The falsifiable live assertion is on the issue.

No chart change — #5672 already granted every delete verb on `catalyst-api-cutover-driver` — so no #817 five-site lockstep applies.

Refs #5649 #5364 #5635 #5511 #960
