### PR TITLE
fix(api,ui): #5616 refuse a placement vCluster tier this Sovereign cannot resolve (3 open doors + the component #5622 missed)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -75,6 +75,7 @@ import (
 	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 	"github.com/openova-io/openova/core/controllers/pkg/validate"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
 )
 
 // SSE timing knobs — keep responsive without hammering the apiserver.
@@ -155,14 +156,18 @@ type applicationPlacement struct {
 }
 
 // validVClusterTier — accepted spec.placement.vcluster values
-// (#3373). Mirrors bpv1alpha1.IsKnownVCluster; kept as a tiny local
-// set so the wire validation stays dependency-free.
+// (#3373). Delegates to the instances package so this door shares ONE
+// vocabulary AND one availability fact with POST /apps/instances.
+//
+// #5616 — it used to hold its own `{"", host, mgmt, dmz, rtz}` tuple.
+// Two independent copies of a vocabulary is how a fix lands on one door
+// and misses the other: PR #5622 removed the dead tiers from a single
+// front-end dropdown while BOTH API validators kept accepting them, so
+// a direct call, a Git edit or the MCP `create_application` tool still
+// produced a 201 followed by a permanently Degraded Application
+// (`namespaces "rtz" not found`). Availability is now enforced here too.
 func validVClusterTier(v string) bool {
-	switch v {
-	case "", "host", "mgmt", "dmz", "rtz":
-		return true
-	}
-	return false
+	return instances.IsKnownVClusterTier(v) && instances.VClusterTierAvailable(v)
 }
 
 // applicationInstallRequest is the body of POST
@@ -943,8 +948,31 @@ func validateApplicationInstallRequest(req applicationInstallRequest) (string, b
 		}
 	}
 	// #3373 — instance placement WHERE fields.
-	if !validVClusterTier(req.Placement.VCluster) {
-		return "placement.vcluster must be one of host, mgmt, dmz, rtz", false
+	// #5616 — separate "not a tier at all" from "a real tier this
+	// Sovereign does not install": the second one needs a remedy in the
+	// message, because the operator did nothing wrong.
+	if !instances.IsKnownVClusterTier(req.Placement.VCluster) {
+		return "placement.vcluster must be one of " + instances.KnownVClusterTiersCSV(), false
+	}
+	if !instances.VClusterTierAvailable(req.Placement.VCluster) {
+		return instances.UnavailableTierMessage(req.Placement.VCluster), false
+	}
+	// #5616 — the #3969 desired-state form carries the tier PER TARGET
+	// (`placement.targets[].vcluster`), and nothing validated it. That is
+	// the door the shipped PlacementEditor walks through: a freshly added
+	// target defaults to `mgmt` with no operator interaction at all
+	// (widgets/topology/PlacementEditor.tsx DEFAULT_VCLUSTERS[1]), so an
+	// untouched Apply used to commit a tier that resolves to a namespace
+	// no Sovereign creates.
+	for i, t := range req.Placement.Targets {
+		if !instances.IsKnownVClusterTier(t.VCluster) {
+			return fmt.Sprintf("placement.targets[%d].vcluster must be one of %s",
+				i, instances.KnownVClusterTiersCSV()), false
+		}
+		if !instances.VClusterTierAvailable(t.VCluster) {
+			return fmt.Sprintf("placement.targets[%d]: %s", i,
+				instances.UnavailableTierMessage(t.VCluster)), false
+		}
 	}
 	for i, c := range req.Placement.Clusters {
 		if strings.TrimSpace(c) == "" {

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -42,6 +42,7 @@ import (
 	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 	"github.com/openova-io/openova/core/controllers/pkg/validate"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
 )
 
 // previewDefaultRegion — placeholder region stamped on a topology
@@ -885,6 +886,29 @@ func validateApplicationUpdateRequest(req applicationUpdateRequest) (string, boo
 		for i, reg := range req.Placement.Regions {
 			if strings.TrimSpace(reg) == "" {
 				return fmt.Sprintf("placement.regions[%d] is empty", i), false
+			}
+		}
+		// #5616 — the placement TIER was never validated on this door at
+		// all, on either the flat field or the #3969 per-target form. It
+		// is the door the shipped Topology-tab PlacementEditor uses, and
+		// an untouched new target defaults to `mgmt` — a tier whose host
+		// namespace no Sovereign creates, so Apply committed a placement
+		// that could only ever reconcile to `namespaces "mgmt" not
+		// found`. Refuse it here, with the remedy in the message.
+		if !instances.IsKnownVClusterTier(req.Placement.VCluster) {
+			return "placement.vcluster must be one of " + instances.KnownVClusterTiersCSV(), false
+		}
+		if !instances.VClusterTierAvailable(req.Placement.VCluster) {
+			return instances.UnavailableTierMessage(req.Placement.VCluster), false
+		}
+		for i, t := range req.Placement.Targets {
+			if !instances.IsKnownVClusterTier(t.VCluster) {
+				return fmt.Sprintf("placement.targets[%d].vcluster must be one of %s",
+					i, instances.KnownVClusterTiersCSV()), false
+			}
+			if !instances.VClusterTierAvailable(t.VCluster) {
+				return fmt.Sprintf("placement.targets[%d]: %s", i,
+					instances.UnavailableTierMessage(t.VCluster)), false
 			}
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_4950_owndeps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_4950_owndeps_test.go
@@ -27,6 +27,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
 )
 
 // realConsolePlacementPUT is the EXACT body shape the Sovereign console
@@ -35,6 +37,14 @@ import (
 // the LOCKED capitalised vocabulary ("Primary"/"Standby"), matching
 // core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go and the FE
 // placement.ts DataRole type.
+//
+// #5616 — this body was RECORDED from the console before the placement
+// editor stopped defaulting fresh targets to the `mgmt` tier. It is kept
+// verbatim because it is the wire-compat fixture for #4950 (targets[] +
+// ownedDependencies must decode), but `vcluster: "mgmt"` is only a legal
+// placement on a Sovereign that actually installs the mgmt vCluster — so
+// the tests below declare it installed rather than quietly weakening the
+// availability gate.
 const realConsolePlacementPUT = `{"placement":{` +
 	`"targets":[` +
 	`{"region":"me-east-215-a","cluster":"mgmt-A","vcluster":"mgmt","role":"Primary"},` +
@@ -49,6 +59,10 @@ const realConsolePlacementPUT = `{"placement":{` +
 // NOT dropped-to-empty-mode which 400'd. This guards BOTH fix arms (the struct
 // field so Path-A succeeds, and the fallback carrying targets).
 func TestDecodeApplicationUpdateBody_4950_OwnedDependenciesKeepsTargets(t *testing.T) {
+	// #5616 — the recorded body places on `mgmt`; validate it as a
+	// Sovereign that installs that tier would.
+	instances.SetAvailableVClusterTiers("mgmt")
+	t.Cleanup(func() { instances.SetAvailableVClusterTiers("") })
 	body, err := decodeApplicationUpdateBody([]byte(realConsolePlacementPUT))
 	if err != nil {
 		t.Fatalf("decode failed: %v", err)
@@ -81,6 +95,9 @@ func TestDecodeApplicationUpdateBody_4950_OwnedDependenciesKeepsTargets(t *testi
 // active-hot-standby pattern across both regions — the operator-visible
 // Edit-placement→Apply outcome from the hw235 walk (app `shared-pg`).
 func TestHandleApplicationUpdate_4950_ConsolePlacementApply_Returns200(t *testing.T) {
+	// #5616 — see the fixture note: the recorded body places on `mgmt`.
+	instances.SetAvailableVClusterTiers("mgmt")
+	t.Cleanup(func() { instances.SetAvailableVClusterTiers("") })
 	// Seed the app as a singleton in region-a so the Apply is a non-destructive
 	// scale-up (singleton → active-hot-standby, +1 region) that needs no ?force.
 	cr := makeAppCR("acme", "shared-pg", "1.2.3", "singleton", []string{"me-east-215-a"})

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/giteapr"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/precheck"
 )
 
@@ -635,6 +636,13 @@ func TestCreateInstance_HappyPath(t *testing.T) {
 // post-create Topology tab reflects it. Asserts the OBJECT form of
 // spec.placement + spec.regions land verbatim.
 func TestCreateInstance_PlacementStampedOnCR(t *testing.T) {
+	// #5616 — the subject here is "the chosen placement is stamped
+	// verbatim", not tier availability. `rtz` is only choosable on a
+	// Sovereign that installs the rtz vCluster, so declare it installed;
+	// the availability gate itself is pinned in
+	// internal/instances/placement_availability_5616_test.go.
+	instances.SetAvailableVClusterTiers("rtz")
+	t.Cleanup(func() { instances.SetAvailableVClusterTiers("") })
 	h, _, dyn := newTestHandlerWithEndpoint(t)
 	h.SetCatalogClient(fakeBlueprintInCatalog("wordpress",
 		[]map[string]interface{}{}, true, []string{"singleton", "active-hot-standby"}))

--- a/products/catalyst/bootstrap/api/internal/instances/create.go
+++ b/products/catalyst/bootstrap/api/internal/instances/create.go
@@ -32,12 +32,132 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/openova-io/openova/core/controllers/application/admission"
 	appv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/application/v1alpha1"
 )
+
+// ── #5616 — a placement TIER is only real when the Sovereign installs it ──
+//
+// `placement.vcluster` carries a TIER KEY, not a namespace. The
+// application-controller turns that key into a HOST NAMESPACE through its
+// VClusterPlacements map (`VCLUSTER_PLACEMENT_<TIER>_NS`, defaulting to
+// the tier name) and addresses the per-cluster HelmRelease there. So the
+// key is usable only when a vCluster for that tier actually exists.
+//
+// Until now this validator accepted {host, mgmt, dmz, rtz}
+// UNCONDITIONALLY, while `clusters/_template/bootstrap-kit/` installs NO
+// mgmt / dmz / rtz vCluster and creates no such namespace (verified on
+// hw292 2026-08-04: 53 namespaces, none of mgmt/dmz/rtz). Three of the
+// four accepted values therefore resolved to a namespace that exists on
+// no Sovereign: the API answered 201 and the Application then sat
+// Degraded forever behind a raw Kubernetes error —
+// `upsert per-cluster HelmRelease rtz/uatco-agenity-rtz-a: namespaces
+// "rtz" not found` (#5616). PR #5622 stopped OFFERING those options in
+// ONE of the four front-end trees; every other door into this endpoint
+// (direct API call, Git edit, the MCP `create_application` tool, the
+// catalyst-console tree) still walked straight into the same wall,
+// because the CONTRACT never changed.
+//
+// The accepted set is now DERIVED from what the Sovereign installs
+// rather than hardcoded: "host" (namespace-independent — the controller
+// normalises it to the Organization's own namespace) plus whatever
+// CATALYST_PLACEMENT_VCLUSTER_TIERS names. Default = host only, which
+// matches every Sovereign this repo can provision today. An operator who
+// installs the mgmt vCluster sets CATALYST_PLACEMENT_VCLUSTER_TIERS=mgmt
+// and the tier is selectable again — one knob, no code change, and the
+// knob is the SAME fact the controller's VCLUSTER_PLACEMENT_MGMT_NS
+// already encodes.
+
+// TierEnvVar is the env var an operator sets to declare which non-host
+// vCluster tiers this Sovereign actually installs (comma-separated).
+const TierEnvVar = "CATALYST_PLACEMENT_VCLUSTER_TIERS"
+
+// knownVClusterTiers is the whole `placement.vcluster` VOCABULARY —
+// the values the CRD + the application-controller can parse at all.
+// Mirrors bpv1alpha1.IsKnownVCluster. A value outside this set is a
+// malformed request (400 placement-vcluster-invalid); a value inside it
+// but not installed here is a well-formed request this Sovereign cannot
+// honour (400 placement-vcluster-unavailable).
+var knownVClusterTiers = []string{"host", "mgmt", "dmz", "rtz"}
+
+// availableNonHostTiers holds the non-host tiers this Sovereign can
+// actually place into. Package-level so the handler stays untouched and
+// tests can drive it explicitly; seeded once from the environment.
+var availableNonHostTiers = parseAvailableTiers(os.Getenv(TierEnvVar))
+
+// parseAvailableTiers turns the comma-separated env value into the set
+// of non-host tiers to accept. Unknown or empty entries are dropped —
+// an operator typo must never widen the accepted set. "host" is always
+// accepted and is not stored here.
+func parseAvailableTiers(csv string) map[string]bool {
+	out := map[string]bool{}
+	for _, raw := range strings.Split(csv, ",") {
+		t := strings.ToLower(strings.TrimSpace(raw))
+		if t == "" || t == "host" {
+			continue
+		}
+		for _, known := range knownVClusterTiers {
+			if t == known {
+				out[t] = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+// SetAvailableVClusterTiers re-reads the available-tier set from a
+// comma-separated list. Exported so tests — and any future explicit
+// wiring from the handler's config — can set it without touching the
+// process environment.
+func SetAvailableVClusterTiers(csv string) { availableNonHostTiers = parseAvailableTiers(csv) }
+
+// IsKnownVClusterTier reports whether v is in the vocabulary at all.
+// The empty string ("inherit the Blueprint default") is always known.
+// Exported so every door into the Application-create/update API shares
+// ONE vocabulary instead of re-declaring the tuple (#5616).
+func IsKnownVClusterTier(v string) bool {
+	if v == "" {
+		return true
+	}
+	for _, known := range knownVClusterTiers {
+		if v == known {
+			return true
+		}
+	}
+	return false
+}
+
+// VClusterTierAvailable reports whether this Sovereign can actually
+// place an Application into tier v. "" (inherit) and "host" always can;
+// every other tier needs its vCluster to be installed and declared.
+// Exported so the sovereign-scoped install + placement-update handlers
+// enforce the SAME availability fact as create-instance (#5616).
+func VClusterTierAvailable(v string) bool {
+	if v == "" || v == "host" {
+		return true
+	}
+	return availableNonHostTiers[v]
+}
+
+// KnownVClusterTiersCSV renders the vocabulary for an error message.
+func KnownVClusterTiersCSV() string { return strings.Join(knownVClusterTiers, ", ") }
+
+// UnavailableTierMessage is the ONE operator-facing explanation for a
+// well-formed tier this Sovereign cannot honour. Shared by every door
+// into the Application API so the remedy never diverges (#5616).
+func UnavailableTierMessage(tier string) string {
+	return fmt.Sprintf(
+		"placement.vcluster %q is not available on this Sovereign: no vCluster is installed for that tier, "+
+			"so the Application would be addressed into a namespace that does not exist. "+
+			"Leave placement.vcluster blank to inherit the Blueprint default, or choose %q. "+
+			"(A sovereign-admin who has installed the tier's vCluster enables it with %s.)",
+		tier, "host", TierEnvVar)
+}
 
 // CreateInstanceRequest mirrors the OpenAPI schema
 // `components/schemas/CreateInstanceRequest`. Unexported in the
@@ -124,11 +244,19 @@ func (r CreateInstanceRequest) ValidateShape() *ShapeError {
 	}
 	// #3373 — instance placement WHERE fields.
 	if r.Placement != nil {
-		switch r.Placement.VCluster {
-		case "", "host", "mgmt", "dmz", "rtz":
-		default:
+		if !IsKnownVClusterTier(r.Placement.VCluster) {
 			return &ShapeError{Code: "placement-vcluster-invalid",
-				Message: fmt.Sprintf("placement.vcluster %q not in {host, mgmt, dmz, rtz}", r.Placement.VCluster)}
+				Message: fmt.Sprintf("placement.vcluster %q not in {%s}",
+					r.Placement.VCluster, KnownVClusterTiersCSV())}
+		}
+		// #5616 — well-formed, but is it REAL here? A tier with no
+		// vCluster installed resolves to a host namespace that does not
+		// exist, and the Application would land Degraded on a raw
+		// Kubernetes error minutes after a 201. Refuse it at the point
+		// of choice instead, for every client of this endpoint.
+		if !VClusterTierAvailable(r.Placement.VCluster) {
+			return &ShapeError{Code: "placement-vcluster-unavailable",
+				Message: UnavailableTierMessage(r.Placement.VCluster)}
 		}
 		for i, c := range r.Placement.Clusters {
 			if strings.TrimSpace(c) == "" {

--- a/products/catalyst/bootstrap/api/internal/instances/placement_availability_5616_test.go
+++ b/products/catalyst/bootstrap/api/internal/instances/placement_availability_5616_test.go
@@ -1,0 +1,221 @@
+// #5616 — the create-instance contract must refuse a placement tier
+// this Sovereign cannot resolve.
+//
+// WHAT WENT WRONG (hw292, funnel Organization `uatco`, 2026-08-04):
+//
+//	POST /catalyst/v1/apps/instances {"placement":{"vcluster":"rtz"}} → 201
+//	Application uatco/uatco-agenity  phase=Degraded
+//	  Ready=False reason=GiteaError
+//	  upsert per-cluster HelmRelease rtz/uatco-agenity-rtz-a:
+//	    namespaces "rtz" not found
+//
+// `placement.vcluster` is a TIER KEY that the application-controller maps
+// to a HOST NAMESPACE (VClusterPlacements, default namespace == tier
+// name). `clusters/_template/bootstrap-kit/` installs no mgmt / dmz / rtz
+// vCluster, so three of the four values this endpoint accepted resolved
+// to a namespace that exists on no Sovereign — a 201 followed by a
+// permanently broken install, with a raw Kubernetes error as the only
+// explanation the operator ever sees.
+//
+// WHY A FRONT-END FIX IS NOT ENOUGH: PR #5622 stopped OFFERING the dead
+// options in products/catalyst/bootstrap/ui. The other doors into this
+// same endpoint — a direct API call, a Git edit of the Application CR,
+// the MCP `create_application` tool, the products/catalyst/console tree —
+// never consulted that dropdown. The contract is the only place that
+// covers all of them.
+//
+// HOW THESE TESTS FAIL IF THE DEFECT COMES BACK: TestGuard_… asserts on
+// the ShapeError the production validator returns for an uninstalled
+// tier. Before the fix ValidateShape returned nil for "rtz" and the guard
+// goes red on `want placement-vcluster-unavailable, got <nil>`. The
+// controls below stay green on BOTH trees, so a green run is not the
+// gate being switched off.
+
+package instances
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// defaultSovereign resets the available-tier set to what every Sovereign
+// this repo provisions actually has: host only. Mirrors an unset
+// CATALYST_PLACEMENT_VCLUSTER_TIERS.
+func defaultSovereign(t *testing.T) {
+	t.Helper()
+	SetAvailableVClusterTiers("")
+	t.Cleanup(func() { SetAvailableVClusterTiers("") })
+}
+
+// ── THE GUARD — red on the pre-fix tree ──────────────────────────────
+//
+// Pre-fix output (origin/main @ 0b6174597):
+//
+//	--- FAIL: TestGuard_UninstalledTierIsRefused_5616/rtz
+//	    want ShapeError code "placement-vcluster-unavailable", got <nil>
+//	    (accepted → 201, then Degraded: namespaces "rtz" not found)
+func TestGuard_UninstalledTierIsRefused_5616(t *testing.T) {
+	for _, tier := range []string{"mgmt", "dmz", "rtz"} {
+		t.Run(tier, func(t *testing.T) {
+			defaultSovereign(t)
+			r := validReq()
+			r.Placement = &InstancePlacementRequest{VCluster: tier}
+			err := r.ValidateShape()
+			if err == nil {
+				t.Fatalf("vcluster %q was ACCEPTED on a Sovereign that installs no %s vCluster — "+
+					"this is #5616: the create answers 201 and the Application then Degrades on "+
+					"`namespaces %q not found`", tier, tier, tier)
+			}
+			if err.Code != "placement-vcluster-unavailable" {
+				t.Fatalf("want ShapeError code %q, got %q (%s)",
+					"placement-vcluster-unavailable", err.Code, err.Message)
+			}
+			// The message must tell the operator what to do instead —
+			// the whole complaint in #5616 was a Kubernetes-internal
+			// error with no remedy in it.
+			if !strings.Contains(err.Message, "host") {
+				t.Errorf("refusal message must name the working alternative, got: %s", err.Message)
+			}
+		})
+	}
+}
+
+// TestGuard_UninstalledTierRefusedThroughBuild_5616 exercises the path
+// PRODUCTION takes: HandleCreateInstance calls ValidateShape and then
+// Build, and Build re-validates before minting a seed. A tier the
+// Sovereign lacks must never reach an ApplicationSeed — that seed is
+// what becomes the Application CR.
+func TestGuard_UninstalledTierRefusedThroughBuild_5616(t *testing.T) {
+	defaultSovereign(t)
+	r := validReq()
+	r.Placement = &InstancePlacementRequest{VCluster: "rtz"}
+	seed, err := r.Build("singleton")
+	if err == nil {
+		t.Fatalf("Build minted a seed for an uninstalled tier: %+v", seed.Placement)
+	}
+	var se *ShapeError
+	if !asShapeError(err, &se) || se.Code != "placement-vcluster-unavailable" {
+		t.Fatalf("want placement-vcluster-unavailable from Build, got %v", err)
+	}
+}
+
+// TestGuard_RefusalIsWireSerialisable_5616 pins the VALUE that reaches
+// the client, not merely the Go struct: HandleCreateInstance writes
+// {"code":…,"message":…} with HTTP 400, and clients branch on `code`.
+func TestGuard_RefusalIsWireSerialisable_5616(t *testing.T) {
+	defaultSovereign(t)
+	r := validReq()
+	r.Placement = &InstancePlacementRequest{VCluster: "mgmt"}
+	err := r.ValidateShape()
+	if err == nil {
+		t.Fatal("mgmt accepted on a host-only Sovereign — #5616 regression")
+	}
+	body, merr := json.Marshal(map[string]string{"code": err.Code, "message": err.Message})
+	if merr != nil {
+		t.Fatalf("marshal: %v", merr)
+	}
+	var got map[string]string
+	if uerr := json.Unmarshal(body, &got); uerr != nil {
+		t.Fatalf("unmarshal: %v", uerr)
+	}
+	if got["code"] != "placement-vcluster-unavailable" {
+		t.Fatalf("wire code = %q, want placement-vcluster-unavailable (body=%s)", got["code"], body)
+	}
+}
+
+// ── CONTROLS — green on BOTH the pre-fix and post-fix trees ──────────
+
+// Control 1. The two placements that always work must keep working.
+// If the new gate were a blanket reject, this goes red — which is
+// exactly the failure mode a "refuse the tier" fix invites.
+func TestControl_BlankAndHostAlwaysAccepted_5616(t *testing.T) {
+	for _, tier := range []string{"", "host"} {
+		defaultSovereign(t)
+		r := validReq()
+		r.Placement = &InstancePlacementRequest{VCluster: tier}
+		if err := r.ValidateShape(); err != nil {
+			t.Errorf("vcluster %q must always validate (blank = inherit the Blueprint "+
+				"default, host = the Organization's own namespace), got %v", tier, err)
+		}
+	}
+}
+
+// Control 2. A value outside the VOCABULARY is still the pre-existing
+// malformed-request error, not the new availability error. Proves the
+// #5616 gate was added ALONGSIDE the shape check rather than replacing
+// it — a swap would silently downgrade a typo to "unavailable".
+func TestControl_UnknownTierStillShapeInvalid_5616(t *testing.T) {
+	defaultSovereign(t)
+	r := validReq()
+	r.Placement = &InstancePlacementRequest{VCluster: "warp-zone"}
+	err := r.ValidateShape()
+	if err == nil || err.Code != "placement-vcluster-invalid" {
+		t.Fatalf("want placement-vcluster-invalid for a value outside the vocabulary, got %v", err)
+	}
+}
+
+// Control 3. Placement omitted entirely — the silent-accept default flow
+// the overwhelming majority of installs take, and the one the hw292
+// control Applications (uatco-openclaw, uatco-mail) actually used.
+func TestControl_NilPlacementUnaffected_5616(t *testing.T) {
+	defaultSovereign(t)
+	r := validReq()
+	if err := r.ValidateShape(); err != nil {
+		t.Fatalf("nil placement must stay valid, got %v", err)
+	}
+}
+
+// ── VACUITY CHECK — the gate must be able to say YES ─────────────────
+//
+// A guard that refuses everything would pass every test above. This
+// drives the knob an operator turns after installing the tier's vCluster
+// and asserts the SAME request now succeeds — and that a sibling tier
+// they did NOT install stays refused, so the knob is per-tier and not a
+// master off-switch.
+func TestVacuity_InstalledTierAcceptedSiblingStillRefused_5616(t *testing.T) {
+	SetAvailableVClusterTiers("mgmt")
+	t.Cleanup(func() { SetAvailableVClusterTiers("") })
+
+	ok := validReq()
+	ok.Placement = &InstancePlacementRequest{VCluster: "mgmt"}
+	if err := ok.ValidateShape(); err != nil {
+		t.Fatalf("mgmt must be accepted once the operator declares it installed, got %v", err)
+	}
+
+	nope := validReq()
+	nope.Placement = &InstancePlacementRequest{VCluster: "dmz"}
+	err := nope.ValidateShape()
+	if err == nil || err.Code != "placement-vcluster-unavailable" {
+		t.Fatalf("declaring mgmt must NOT also enable dmz, got %v", err)
+	}
+}
+
+// TestVacuity_TierListParsingIgnoresJunk_5616 — an operator typo must
+// never widen the accepted set. `parseAvailableTiers` keeps only values
+// that are in the vocabulary.
+func TestVacuity_TierListParsingIgnoresJunk_5616(t *testing.T) {
+	SetAvailableVClusterTiers(" RTZ , warp-zone ,, host ")
+	t.Cleanup(func() { SetAvailableVClusterTiers("") })
+
+	good := validReq()
+	good.Placement = &InstancePlacementRequest{VCluster: "rtz"}
+	if err := good.ValidateShape(); err != nil {
+		t.Errorf("rtz declared (case/space-insensitively) must be accepted, got %v", err)
+	}
+	bad := validReq()
+	bad.Placement = &InstancePlacementRequest{VCluster: "warp-zone"}
+	if err := bad.ValidateShape(); err == nil || err.Code != "placement-vcluster-invalid" {
+		t.Errorf("a junk entry in %s must not become an accepted tier, got %v", TierEnvVar, err)
+	}
+}
+
+// asShapeError is a tiny errors.As stand-in kept local so the guard has
+// no dependency beyond the package under test.
+func asShapeError(err error, out **ShapeError) bool {
+	se, ok := err.(*ShapeError)
+	if ok {
+		*out = se
+	}
+	return ok
+}

--- a/products/catalyst/bootstrap/api/internal/instances/placement_test.go
+++ b/products/catalyst/bootstrap/api/internal/instances/placement_test.go
@@ -18,13 +18,25 @@ func TestValidateShape_PlacementNil_OK(t *testing.T) {
 	}
 }
 
+// #5616 — this used to assert that ALL FOUR tiers validate
+// unconditionally. That assertion was the defect written down as a test:
+// mgmt/dmz/rtz resolve to host namespaces no Sovereign creates, so
+// accepting them produced a 201 followed by a permanently Degraded
+// Application. The contract is now "vocabulary AND availability"; the
+// availability half is covered in placement_availability_5616_test.go.
 func TestValidateShape_PlacementValidTiers(t *testing.T) {
 	for _, tier := range []string{"", "host", "mgmt", "dmz", "rtz"} {
-		r := validReq()
-		r.Placement = &InstancePlacementRequest{VCluster: tier}
-		if err := r.ValidateShape(); err != nil {
-			t.Errorf("vcluster %q must validate, got %v", tier, err)
-		}
+		t.Run(tier, func(t *testing.T) {
+			// Every tier in the VOCABULARY is well-formed; the only way
+			// one may be refused is the availability gate.
+			SetAvailableVClusterTiers("mgmt,dmz,rtz")
+			t.Cleanup(func() { SetAvailableVClusterTiers("") })
+			r := validReq()
+			r.Placement = &InstancePlacementRequest{VCluster: tier}
+			if err := r.ValidateShape(); err != nil {
+				t.Errorf("vcluster %q must validate when the tier is installed, got %v", tier, err)
+			}
+		})
 	}
 }
 
@@ -38,8 +50,11 @@ func TestValidateShape_PlacementUnknownTierRejected(t *testing.T) {
 }
 
 func TestValidateShape_PlacementEmptyClusterEntryRejected(t *testing.T) {
+	// #5616 — pin the tier to one that is always available so this test
+	// keeps exercising the CLUSTERS check rather than tripping the new
+	// availability gate first.
 	r := validReq()
-	r.Placement = &InstancePlacementRequest{VCluster: "rtz", Clusters: []string{"mgmt-A", " "}}
+	r.Placement = &InstancePlacementRequest{VCluster: "host", Clusters: []string{"mgmt-A", " "}}
 	err := r.ValidateShape()
 	if err == nil || err.Code != "placement-clusters-invalid" {
 		t.Fatalf("want placement-clusters-invalid, got %v", err)
@@ -47,6 +62,11 @@ func TestValidateShape_PlacementEmptyClusterEntryRejected(t *testing.T) {
 }
 
 func TestBuild_PlacementPassesThroughToSeed(t *testing.T) {
+	// #5616 — an INSTALLED rtz tier must still pass straight through to
+	// the seed. This is the vacuity check on the availability gate: it
+	// refuses tiers the Sovereign lacks, never tiers it has.
+	SetAvailableVClusterTiers("rtz")
+	t.Cleanup(func() { SetAvailableVClusterTiers("") })
 	r := validReq()
 	r.Placement = &InstancePlacementRequest{
 		VCluster: "rtz",

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
@@ -80,7 +80,22 @@ export interface PlacementEditorProps {
   disableNetwork?: boolean
 }
 
-const DEFAULT_VCLUSTERS = ['host', 'mgmt', 'dmz', 'rtz']
+// #5616 — the placement TIER is only real when the Sovereign installs a
+// vCluster for it. `clusters/_template/bootstrap-kit/` installs no mgmt /
+// dmz / rtz vCluster, and the application-controller resolves each tier
+// key to a SAME-NAMED host namespace, so those three keys address the
+// per-cluster HelmRelease into a namespace that does not exist and the
+// install Degrades on `namespaces "mgmt" not found` (hw292 2026-08-04).
+//
+// This editor used to offer all four unconditionally AND default a fresh
+// target to index [1] — `mgmt` — so an operator who never touched the
+// vCluster control still committed a dead tier on Apply. `host` is the
+// one namespace-independent target (the controller normalises it to the
+// Organization's own namespace), so it is the only safe fallback. Real
+// tiers arrive through `availableVClusters`, which the Sovereign
+// supplies from its live topology.
+const DEFAULT_VCLUSTERS = ['host']
+const HOST_VCLUSTER = 'host'
 
 export function PlacementEditor({
   sovereignId,
@@ -108,7 +123,7 @@ export function PlacementEditor({
       {
         region: availableRegions[0] ?? '',
         cluster: availableClusters[0] ?? '',
-        vcluster: (availableVClusters ?? DEFAULT_VCLUSTERS)[1] ?? 'mgmt',
+        vcluster: (availableVClusters ?? DEFAULT_VCLUSTERS)[0] ?? HOST_VCLUSTER,
         role: 'Primary' as DataRole,
       },
     ]
@@ -119,6 +134,11 @@ export function PlacementEditor({
   const [info, setInfo] = useState<string | null>(null)
 
   const vclusters = availableVClusters ?? DEFAULT_VCLUSTERS
+
+  // #5616 — the selectable tiers for one target: the Sovereign's real
+  // placement targets plus whatever this target is currently set to.
+  const optionsForTarget = (current?: string): string[] =>
+    current && !vclusters.includes(current) ? [...vclusters, current] : vclusters
   const pattern = useMemo(() => derivePattern(targets), [targets])
   const validation = useMemo(() => validatePlacement(targets, capability), [targets, capability])
 
@@ -159,7 +179,7 @@ export function PlacementEditor({
       const cluster = availableClusters.find((c) => !usedClusters.has(c)) ?? availableClusters[1] ?? availableClusters[0] ?? ''
       return [
         ...prev,
-        { region, cluster, vcluster: prev[0]?.vcluster ?? 'mgmt', role: 'Standby' as DataRole, standbyType: 'Hot' as StandbyType },
+        { region, cluster, vcluster: prev[0]?.vcluster ?? HOST_VCLUSTER, role: 'Standby' as DataRole, standbyType: 'Hot' as StandbyType },
       ]
     })
   }
@@ -283,11 +303,16 @@ export function PlacementEditor({
                   <span className="text-[var(--color-text-dim)]">vCluster</span>
                   <select
                     className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-1.5 py-1 font-mono"
-                    value={t.vcluster ?? 'mgmt'}
+                    value={t.vcluster ?? HOST_VCLUSTER}
                     onChange={(e) => setTarget(i, { vcluster: e.target.value })}
                     data-testid={`placement-editor-target-${i}-vcluster`}
                   >
-                    {vclusters.map((v) => (
+                    {/* #5616 — offer the REAL targets, but never hide the
+                        tier this Application already carries: an existing
+                        `mgmt` placement must stay visible (and re-selectable)
+                        even on a Sovereign that offers only `host`, or the
+                        editor would silently rewrite it on the next Apply. */}
+                    {optionsForTarget(t.vcluster).map((v) => (
                       <option key={v} value={v}>
                         {v}
                       </option>

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.vcluster-5616.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.vcluster-5616.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * PlacementEditor.vcluster-5616.test.tsx — #5616 guard, BOTH directions.
+ *
+ * THE DEFECT THIS PINS. `placement.vcluster` carries a TIER KEY. The
+ * application-controller resolves that key to a HOST NAMESPACE through
+ * its VClusterPlacements map (namespace == tier name by default) and
+ * addresses the per-cluster HelmRelease there. `clusters/_template/
+ * bootstrap-kit/` installs NO mgmt / dmz / rtz vCluster and creates no
+ * such namespace — verified live on hw292 2026-08-04: 53 namespaces,
+ * none of mgmt/dmz/rtz. So those three keys can only ever produce
+ *
+ *     Application uatco/uatco-agenity  phase=Degraded
+ *       upsert per-cluster HelmRelease rtz/uatco-agenity-rtz-a:
+ *         namespaces "rtz" not found
+ *
+ * PR #5622 fixed the CREATE dialog (AppDetail/InstancesSection.tsx). It
+ * did not touch THIS component, which is a different door in the SAME
+ * shipped tree — and a worse one: the create dialog at least required
+ * the operator to pick a dead option, whereas this editor SEEDED a fresh
+ * target with `DEFAULT_VCLUSTERS[1]` — literally `'mgmt'` — so an
+ * operator who never opened the vCluster control still committed a dead
+ * tier the moment they pressed Apply.
+ *
+ * WHAT THE GUARD ASSERTS. Not button state, not the option list alone:
+ * the VALUE that reaches the wire. `updateApplication` is mocked and the
+ * PUT body is read back, because "the dropdown looked right" is exactly
+ * the evidence that let #5616 ship in the first place.
+ *
+ * THE CONTROLS ARE LOAD-BEARING. A "fix" that hardcoded every target to
+ * `host` would satisfy the first assertion. So:
+ *   - an operator-chosen tier must still reach the wire unchanged, and
+ *   - an Application ALREADY placed on `mgmt` must keep `mgmt` visible
+ *     and selected, or the editor would silently rewrite a real
+ *     placement on the next Apply.
+ *
+ * Confirmed RED against the pre-fix tree — real output in the PR body.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+
+import { PlacementEditor } from './PlacementEditor'
+
+const updateApplicationMock = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve({}),
+)
+vi.mock('@/lib/catalog.api', () => ({
+  updateApplication: (...args: unknown[]) => updateApplicationMock(...args),
+}))
+
+/** The body PlacementEditor PUTs — third positional arg of updateApplication. */
+type AppliedBody = {
+  placement: { targets: Array<{ region: string; cluster: string; vcluster?: string }> }
+}
+const appliedBody = (call = 0): AppliedBody =>
+  updateApplicationMock.mock.calls[call][2] as AppliedBody
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const REGION = 'hw-me-east-215-a-rtz-prod'
+
+function renderEditor(overrides: Partial<React.ComponentProps<typeof PlacementEditor>> = {}) {
+  return render(
+    <PlacementEditor
+      sovereignId="s"
+      applicationName="agenity"
+      initialTargets={[]}
+      capability="primary+standby"
+      availableRegions={[REGION]}
+      availableClusters={[REGION]}
+      {...overrides}
+    />,
+  )
+}
+
+const tierSelect = (i = 0) =>
+  screen.getByTestId(`placement-editor-target-${i}-vcluster`) as HTMLSelectElement
+const optionValues = (sel: HTMLSelectElement) =>
+  Array.from(sel.querySelectorAll('option')).map((o) => o.value)
+
+describe('#5616 — an untouched placement must not default to a dead tier', () => {
+  it('seeds a fresh target on host, not mgmt', () => {
+    renderEditor()
+    // Pre-fix: DEFAULT_VCLUSTERS[1] === 'mgmt'.
+    expect(tierSelect().value).toBe('host')
+  })
+
+  it('the tier that reaches the wire on an untouched Apply is host', async () => {
+    renderEditor()
+    fireEvent.click(screen.getByTestId('placement-editor-apply'))
+    await waitFor(() => expect(updateApplicationMock).toHaveBeenCalledTimes(1))
+    // THE assertion: pre-fix this was `"mgmt"`, and the controller then
+    // addressed the HelmRelease into a namespace that does not exist.
+    expect(appliedBody().placement.targets[0].vcluster).toBe('host')
+  })
+
+  it('a Standby added after the Primary inherits host, not mgmt', async () => {
+    renderEditor({ availableRegions: [REGION, 'hw-me-east-215-b-rtz-prod'] })
+    fireEvent.click(screen.getByTestId('placement-editor-add-target'))
+    fireEvent.click(screen.getByTestId('placement-editor-apply'))
+    await waitFor(() => expect(updateApplicationMock).toHaveBeenCalledTimes(1))
+    for (const t of appliedBody().placement.targets) {
+      expect(t.vcluster).toBe('host')
+    }
+  })
+
+  it('does not offer a fabricated tier the Sovereign never installed', () => {
+    renderEditor()
+    // Pre-fix the fallback list was ['host','mgmt','dmz','rtz'] — four
+    // options, three of which could only ever Degrade.
+    const values = optionValues(tierSelect())
+    expect(values).toContain('host')
+    expect(values).not.toContain('dmz')
+    expect(values).not.toContain('rtz')
+  })
+})
+
+describe('#5616 controls — the gate must not flatten real placements', () => {
+  it('CONTROL: a tier the Sovereign DOES report is offered and reaches the wire', async () => {
+    // A fix that hardcoded `host` everywhere would pass every assertion
+    // above. This is the direction that catches it.
+    renderEditor({ availableVClusters: ['host', 'mgmt'] })
+    fireEvent.change(tierSelect(), { target: { value: 'mgmt' } })
+    fireEvent.click(screen.getByTestId('placement-editor-apply'))
+    await waitFor(() => expect(updateApplicationMock).toHaveBeenCalledTimes(1))
+    expect(appliedBody().placement.targets[0].vcluster).toBe('mgmt')
+  })
+
+  it('CONTROL: an Application already placed on mgmt keeps mgmt selected and selectable', () => {
+    renderEditor({
+      initialTargets: [{ region: REGION, cluster: 'c-a', vcluster: 'mgmt', role: 'Primary' }],
+    })
+    // The editor must never hide a placement the Application actually has —
+    // shrinking the option list would silently rewrite it on the next Apply.
+    expect(tierSelect().value).toBe('mgmt')
+    expect(optionValues(tierSelect())).toContain('mgmt')
+  })
+
+  it('CONTROL: an existing placement round-trips unchanged through Apply', async () => {
+    renderEditor({
+      initialTargets: [{ region: REGION, cluster: 'c-a', vcluster: 'mgmt', role: 'Primary' }],
+    })
+    fireEvent.click(screen.getByTestId('placement-editor-apply'))
+    await waitFor(() => expect(updateApplicationMock).toHaveBeenCalledTimes(1))
+    expect(appliedBody().placement.targets[0].vcluster).toBe('mgmt')
+  })
+})


### PR DESCRIPTION
## What #5616 actually is, and why it was still live

`placement.vcluster` carries a **tier key**, not a namespace. The application-controller turns that key into a **host namespace** through its `VClusterPlacements` map (`VCLUSTER_PLACEMENT_<TIER>_NS`, defaulting to the tier name) and addresses the per-cluster HelmRelease there. `clusters/_template/bootstrap-kit/` installs **no** mgmt / dmz / rtz vCluster and creates no such namespace, and `VCLUSTER_PLACEMENT_*_NS` is set nowhere in the repo. So three of the four tier keys the API accepted could only ever produce the reported failure:

```
Application uatco/uatco-agenity  phase=Degraded
  upsert per-cluster HelmRelease rtz/uatco-agenity-rtz-a: namespaces "rtz" not found
```

Re-verified live on hw292 today, read-only:

```
$ kubectl get ns | grep -Ew "mgmt|dmz|rtz|host"   ->  (no matches)
$ kubectl get ns --no-headers | wc -l             ->  53
```

**CONFIRMED — the premise still holds, and #5622 closed one door of four.** PR #5622 removed the dead options from `AppDetail/InstancesSection.tsx`. It did not change the **contract**, and it did not touch the other producers. Three doors were still open on `main`:

| Door | State before this PR |
|---|---|
| `instances.ValidateShape` — `POST /catalyst/v1/apps/instances` | hardcoded `{"", host, mgmt, dmz, rtz}`, all accepted → **201 then Degraded** |
| `handler.validVClusterTier` — `POST /api/v1/sovereigns/{id}/applications` | a **second, independent copy** of the same tuple |
| `validateApplicationUpdateRequest` — `PUT …/applications/{name}` | never validated the tier **at all**, on either the flat field or `placement.targets[]` |

Those doors are what a direct API call, a Git edit, and the MCP `create_application` tool use — none of them consult a dropdown.

## The one #5622 missed in its own tree

`products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx` — the Topology-tab placement editor, **same shipped tree, different component** — seeded every fresh target from `DEFAULT_VCLUSTERS[1]`, which is literally `'mgmt'`:

```
const DEFAULT_VCLUSTERS = ['host', 'mgmt', 'dmz', 'rtz']
vcluster: (availableVClusters ?? DEFAULT_VCLUSTERS)[1] ?? 'mgmt',
```

No call site passes `availableVClusters`, so the fallback is always what runs. This is worse than the reported bug: #5616 needed the operator to *pick* a dead option, whereas here an operator who never opened the vCluster control still committed a dead tier the moment they pressed Apply — into the update door that validated nothing.

## The fix

- **One vocabulary, one availability fact.** `instances` now owns `IsKnownVClusterTier` / `VClusterTierAvailable`; both handler doors delegate instead of keeping their own copy. Two copies of a vocabulary is how a fix lands on one door and misses the other.
- **Accepted set derived, not hardcoded.** `host` (namespace-independent — the controller normalises it to the Organization's own namespace) plus whatever `CATALYST_PLACEMENT_VCLUSTER_TIERS` names. Default = host only, which matches every Sovereign this repo can provision today. A sovereign-admin who installs the mgmt vCluster sets `CATALYST_PLACEMENT_VCLUSTER_TIERS=mgmt` — one knob, no code change, the same fact `VCLUSTER_PLACEMENT_MGMT_NS` already encodes. No chart change: the default is already correct.
- **A distinct, actionable 400.** `placement-vcluster-unavailable` (a real tier this Sovereign lacks) stays separate from `placement-vcluster-invalid` (not a tier at all), and the message names the remedy — the whole complaint in #5616 was a Kubernetes-internal error with no remedy in it. `placement.targets[]` is validated per entry.
- **PlacementEditor defaults to `host`**, and offers only real targets — while still showing the tier an Application already carries, so an existing `mgmt` placement is never silently rewritten on the next Apply.

Deliberately **not** attempted: making mgmt/dmz/rtz *work*. That needs bootstrap-kit slots that install those vClusters, which do not exist. This PR takes the issue's second sanctioned resolution — do not offer, and do not accept, what cannot resolve — and applies it at the contract layer so it holds for every client.

## Guard — RED on the pre-fix tree, GREEN after, controls green on BOTH

### Go — `internal/instances/placement_availability_5616_test.go`

Run against **untouched `origin/main`** (materialised with `git archive`; only the guard file plus a 6-line shim supplying `TierEnvVar` / a no-op `SetAvailableVClusterTiers` were added, so every failure below is **behavioural**, not a missing symbol):

```
--- FAIL: TestGuard_UninstalledTierIsRefused_5616/mgmt
    vcluster "mgmt" was ACCEPTED on a Sovereign that installs no mgmt vCluster — this is
    #5616: the create answers 201 and the Application then Degrades on `namespaces "mgmt" not found`
--- FAIL: TestGuard_UninstalledTierIsRefused_5616/dmz
--- FAIL: TestGuard_UninstalledTierIsRefused_5616/rtz
--- FAIL: TestGuard_UninstalledTierRefusedThroughBuild_5616
    Build minted a seed for an uninstalled tier: &{VCluster:rtz Regions:[] Clusters:[]}
--- FAIL: TestGuard_RefusalIsWireSerialisable_5616
    mgmt accepted on a host-only Sovereign — #5616 regression
--- FAIL: TestVacuity_InstalledTierAcceptedSiblingStillRefused_5616
    declaring mgmt must NOT also enable dmz, got <nil>
--- PASS: TestControl_BlankAndHostAlwaysAccepted_5616
--- PASS: TestControl_UnknownTierStillShapeInvalid_5616
--- PASS: TestControl_NilPlacementUnaffected_5616
--- PASS: TestVacuity_TierListParsingIgnoresJunk_5616
FAIL
```

Post-fix: `ok  …/internal/instances` — all 10 pass.

### Front-end — `widgets/topology/PlacementEditor.vcluster-5616.test.tsx`

Run with the **pre-fix `PlacementEditor.tsx` from `origin/main`** restored under the new spec. It mocks `updateApplication` and reads the PUT body back, so it asserts the **value that reaches the wire**, not button state or option markup:

```
FAIL  #5616 > seeds a fresh target on host, not mgmt
  expected 'mgmt' to be 'host'
FAIL  #5616 > the tier that reaches the wire on an untouched Apply is host
  AssertionError: expected 'mgmt' to be 'host'   (appliedBody().placement.targets[0].vcluster)
FAIL  #5616 > a Standby added after the Primary inherits host, not mgmt
  expected 'mgmt' to be 'host'
FAIL  #5616 > does not offer a fabricated tier the Sovereign never installed
  expected [ 'host', 'mgmt', 'dmz', 'rtz' ] to not include 'dmz'
 ✓ CONTROL: a tier the Sovereign DOES report is offered and reaches the wire
 ✓ CONTROL: an Application already placed on mgmt keeps mgmt selected and selectable
 ✓ CONTROL: an existing placement round-trips unchanged through Apply

 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

Post-fix: `Test Files 1 passed (1) · Tests 7 passed (7)`.

**Could this have gone red if the defect were present?** Yes — it did, in both languages, on the real pre-fix code. **Could a lazy fix pass it?** No: hardcoding `host` everywhere fails the two "operator-chosen / existing tier survives" controls, and a blanket reject fails `TestVacuity_InstalledTierAcceptedSiblingStillRefused_5616`. **Does it run?** The Go tests are in the api module's normal `go test ./...`; the vitest spec is under `products/catalyst/bootstrap/ui/src`, which the UI vitest job collects (219 → 220 files below). It is deliberately **not** a Playwright spec — `playwright-smoke.yaml` / `playwright-e2e.yml` filter on `products/catalyst/console/**`, never `bootstrap/ui/**`, so a spec added there would never have executed.

## Gates

| Gate | Baseline (`origin/main`) | This branch |
|---|---|---|
| `tsc --noEmit` (bootstrap/ui) | — | exit 0 |
| vitest (bootstrap/ui, full) | 219 files / **2060 passed**, 0 failed | 220 files / **2067 passed**, 0 failed |
| `npm run build` (bootstrap/ui) | — | exit 0 |
| eslint `src` (bootstrap/ui) | **126 problems (111 errors, 15 warnings)** | **126 problems (111 errors, 15 warnings)** — delta **0** |
| `go test ./internal/handler/ ./internal/instances/` | `ok handler 254.985s` · `ok instances` | `ok handler 254.276s` · `ok instances` — **0 regressions** |
| `go build ./...` (bootstrap/api) | — | OK |
| `go vet` (handler + instances) | — | clean |
| `gofmt -l` on changed files | — | clean |
| `scripts/check-no-banned-words.sh` | — | OK |

Three existing tests used a tier as an incidental sample value and now declare it installed rather than weakening the gate — `TestCreateInstance_PlacementStampedOnCR` (`rtz`), and the two #4950 tests whose fixture is a **recording of the console body from before this fix** (`vcluster: "mgmt"`). The fixture is kept verbatim, since decoding it is the point of #4950.

## Walk that closes this

Console → `/catalog/bp-agenity` → **+ New instance**: the vCluster control offers only `Default (server picks)` + `host`. App detail → Topology → Edit placement: a fresh target shows `host`, not `mgmt`. And, from any client:

```
POST /catalyst/v1/apps/instances {"…","placement":{"vcluster":"rtz"}}
  → 400 {"code":"placement-vcluster-unavailable", …}     (was: 201, then Degraded)
```

Refs #5616 #5622 #3373 #3969 #960