### PR TITLE
fix(catalyst-ui): /k8s/stream fold collapsed both regions into one — key + attribute the snapshot by region

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.region-5571.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.region-5571.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * K8sListPage.region-5571.test.tsx — #5571 item (2): the Cloud list
+ * pages must SHOW which region each object came from.
+ *
+ * The server fans `/k8s/stream` out across every region and the SPA
+ * snapshot now keeps both regions' objects (see
+ * `useK8sCacheStream.region-split-5571.test.ts`). This file pins the
+ * last leg: the operator has to be able to SEE it. Without a region
+ * column, two rows with the identical namespace/name/age read as a
+ * duplicate-render bug rather than as "this policy exists in both
+ * regions", and a set that covers only one region is indistinguishable
+ * from a complete estate — which is the exact failure #5571 describes
+ * on the NetworkPolicies / CiliumNetworkPolicies pages.
+ *
+ * Snapshot keys here are built with the PRODUCTION `objectKey`
+ * function, never hand-written, so this fixture cannot drift away from
+ * the real key contract.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import type { K8sObject, K8sSnapshot } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { objectKey } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { regionLabel } from './k8sColumns'
+
+/** hw292's two real cluster-id conventions. */
+const REGION_A = 'sovereign-hw292.omani.works'
+const REGION_B = '1c56518035a83e03-me-east-215-b-1'
+
+const cloudState: {
+  k8sSnapshot: K8sSnapshot
+  k8sStatus: string
+  k8sRevision: number
+  deploymentId: string
+} = {
+  k8sSnapshot: new Map(),
+  k8sStatus: 'open',
+  k8sRevision: 1,
+  deploymentId: '1c56518035a83e03',
+}
+
+vi.mock('../CloudPage', () => ({ useCloud: () => cloudState }))
+
+afterEach(cleanup)
+
+/**
+ * Body rows carry `role="link"` (they are click-navigable), which
+ * OVERRIDES the implicit `row` role — so query the DOM directly rather
+ * than by role, or only the <thead> row is ever found.
+ */
+function bodyRows(table: HTMLElement): HTMLElement[] {
+  return [...table.querySelectorAll('tbody tr')] as HTMLElement[]
+}
+
+// Imported AFTER the mock so the page picks up the stubbed useCloud.
+const { K8sListPage } = await import('./K8sListPage')
+
+function np(ns: string, name: string, cluster: string): [string, K8sObject] {
+  const obj: K8sObject = {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: { namespace: ns, name, uid: `uid-${cluster}-${ns}-${name}` },
+    clusterId: cluster,
+  }
+  return [objectKey('networkpolicy', obj, cluster), obj]
+}
+
+const COLUMNS = [
+  { header: 'Namespace', extract: (o: K8sObject) => o.metadata?.namespace ?? '—' },
+  { header: 'Name', extract: (o: K8sObject) => o.metadata?.name ?? '—' },
+]
+
+function renderList(entries: Array<[string, K8sObject]>) {
+  cloudState.k8sSnapshot = new Map(entries)
+  cloudState.k8sRevision += 1
+  return render(
+    <K8sListPage
+      kind="networkpolicy"
+      title="Network Policies"
+      tagline="Namespaced ingress/egress rules"
+      columns={COLUMNS}
+    />,
+  )
+}
+
+describe('#5571 — Cloud list must attribute every row to its region', () => {
+  it('GUARD: the same policy in two regions renders TWO rows carrying DIFFERENT regions', () => {
+    renderList([
+      // Real hw292 collision — present in both regions.
+      np('gitea', 'gitea-default-deny', REGION_A),
+      np('gitea', 'gitea-default-deny', REGION_B),
+    ])
+
+    const table = screen.getByTestId('cloud-networkpolicy-table')
+    const rows = bodyRows(table)
+
+    expect(
+      rows.length,
+      '#5571: gitea/gitea-default-deny exists in BOTH hw292 regions — the list must show ' +
+        'both, not silently collapse them to one row.',
+    ).toBe(2)
+
+    // A "Region" header must exist…
+    expect(
+      within(table).getByText('Region'),
+      '#5571: no Region column — a one-region set is indistinguishable from the whole estate.',
+    ).toBeTruthy()
+
+    // …and the two rows must carry DIFFERENT, correctly-attributed
+    // regions. Asserting on the VALUE: a Region column that rendered
+    // the same label (or an empty one) for both rows would satisfy a
+    // header-only or non-empty-only check while still telling the
+    // operator nothing.
+    const regions = rows.map((r) => r.getAttribute('data-region'))
+    expect(regions.slice().sort()).toEqual([REGION_B, REGION_A].sort())
+
+    const cellText = rows.map((r) => [...r.querySelectorAll('td')].at(-1)?.textContent)
+    expect(cellText.slice().sort()).toEqual(
+      [regionLabel(REGION_A), regionLabel(REGION_B)].sort(),
+    )
+    expect(new Set(cellText).size, 'both rows rendered the SAME region label').toBe(2)
+  })
+
+  it('CONTROL: a single-region list still renders its rows and its region (passes pre- AND post-fix)', () => {
+    // Shares the harness, the mock and the render helper with the guard
+    // above but exercises no cross-region collision, so it holds on
+    // both trees — if the suite were disabled or the mock neutered to
+    // silence the guard, this would go red too.
+    renderList([
+      np('gitea', 'gitea-default-deny', REGION_A),
+      np('alloy', 'alloy-default-deny', REGION_A),
+    ])
+    const table = screen.getByTestId('cloud-networkpolicy-table')
+    const rows = bodyRows(table)
+    expect(rows.length).toBe(2)
+    expect(within(table).getByText('gitea-default-deny')).toBeTruthy()
+    expect(within(table).getByText('alloy-default-deny')).toBeTruthy()
+  })
+})
+
+describe('#5571 — regionLabel', () => {
+  it('renders both real cluster-id conventions, and never blanks a known region', () => {
+    // `<depID>-<region>` → the region.
+    expect(regionLabel('1c56518035a83e03-me-east-215-b-1')).toBe('me-east-215-b-1')
+    // chroot primary alias → "primary".
+    expect(regionLabel('sovereign-hw292.omani.works')).toBe('primary')
+    // Unrecognised id renders VERBATIM — never blank, because a blank
+    // region cell is the "partial set reads as complete" failure this
+    // column exists to prevent.
+    expect(regionLabel('some-unknown-shape')).toBe('some-unknown-shape')
+    // Only a genuinely absent region gets the em-dash.
+    expect(regionLabel('')).toBe('—')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tsx
@@ -18,6 +18,7 @@ import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { resourceDetailHref } from './resource.api'
 import { CLOUD_K8S_TONE_CSS } from './cloudListCss'
+import { REGION_COLUMN } from './k8sColumns'
 import type { K8sListPageProps } from './k8sColumns'
 
 // Re-export the column types + builders + tone classifiers (#4084) from
@@ -61,8 +62,10 @@ export function K8sListPage({
     const out: K8sObject[] = []
     if (!k8sSnapshot) return out
     for (const [key, obj] of k8sSnapshot.entries()) {
-      // Snapshot keys are `${kind}:${ns}/${name}` or `${kind}:${name}`
-      // for cluster-scoped. Filter to the requested kind only.
+      // Snapshot keys are `${kind}:${ns}/${name}@${cluster}` (or
+      // `${kind}:${name}@${cluster}` for cluster-scoped kinds) — the
+      // region suffix is a SUFFIX precisely so this prefix filter is
+      // unaffected by it (#5571).
       if (!key.startsWith(`${kind}:`)) continue
       out.push(obj as K8sObject)
     }
@@ -71,12 +74,27 @@ export function K8sListPage({
         const na = a.metadata?.namespace ?? ''
         const nb = b.metadata?.namespace ?? ''
         if (na !== nb) return na.localeCompare(nb)
-        return (a.metadata?.name ?? '').localeCompare(b.metadata?.name ?? '')
+        const nameA = a.metadata?.name ?? ''
+        const nameB = b.metadata?.name ?? ''
+        if (nameA !== nameB) return nameA.localeCompare(nameB)
+        // #5571: same ns/name in two regions — keep the ordering
+        // deterministic so the two rows never swap between renders.
+        return (a.clusterId ?? '').localeCompare(b.clusterId ?? '')
       })
     }
     return out
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [k8sSnapshot, k8sRevision, kind, sortByName])
+
+  // #5571: append a Region column whenever the stream is attributing
+  // objects to a cluster. Rendered even for a single region — an
+  // operator must be able to see WHICH region a set came from, since
+  // "only region-a is listed" and "the estate only has region-a" are
+  // otherwise indistinguishable on a security-posture page.
+  const effectiveColumns = useMemo(
+    () => (rows.some((r) => r.clusterId) ? [...columns, REGION_COLUMN] : columns),
+    [rows, columns],
+  )
 
   return (
     <div data-testid={`cloud-${kind}-list`}>
@@ -102,7 +120,7 @@ export function K8sListPage({
           <table className="w-full border-collapse text-sm" data-testid={`cloud-${kind}-table`}>
             <thead className="text-xs uppercase tracking-wide text-[var(--color-text-dim)]">
               <tr className="border-b border-[var(--color-border)]">
-                {columns.map((c) => (
+                {effectiveColumns.map((c) => (
                   <th key={c.header} className="px-3 py-2 text-left font-medium">
                     {c.header}
                   </th>
@@ -129,6 +147,7 @@ export function K8sListPage({
                       (href ? 'cursor-pointer hover:bg-[var(--color-bg-3)]' : '')
                     }
                     data-testid={`cloud-${kind}-row-${name || i}`}
+                    data-region={obj.clusterId ?? ''}
                     onClick={onRowClick}
                     onKeyDown={(e) => {
                       if (!href) return
@@ -140,7 +159,7 @@ export function K8sListPage({
                     role={href ? 'link' : undefined}
                     tabIndex={href ? 0 : undefined}
                   >
-                    {columns.map((c) => {
+                    {effectiveColumns.map((c) => {
                       const text = c.extract(obj)
                       const tone = c.tone?.(obj)
                       return (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/k8sColumns.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/k8sColumns.ts
@@ -45,6 +45,44 @@ export interface K8sListColumn {
   tone?: (obj: K8sObject) => CellTone | undefined
 }
 
+/**
+ * #5571: render a k8scache cluster id as an operator-readable region.
+ *
+ * Cluster ids arrive in two conventions:
+ *   - secondaries: `<deploymentID>-<region>`   e.g.
+ *     `1c56518035a83e03-me-east-215-b-1` → `me-east-215-b-1`
+ *   - the chroot's self-registered primary: `sovereign-<fqdn>` e.g.
+ *     `sovereign-t99.omani.works` → `primary`
+ *
+ * Anything unrecognised renders verbatim — never blank, because a
+ * blank region cell is exactly the "partial set reads as complete"
+ * failure this column exists to prevent.
+ */
+export function regionLabel(clusterId: string): string {
+  if (!clusterId) return '—'
+  if (clusterId.startsWith('sovereign-')) return 'primary'
+  // `<32-hex-ish depID>-<region>` — split on the FIRST dash only if the
+  // head looks like a deployment id (hex, ≥8 chars).
+  const dash = clusterId.indexOf('-')
+  if (dash > 0) {
+    const head = clusterId.slice(0, dash)
+    if (head.length >= 8 && /^[0-9a-f]+$/i.test(head)) {
+      return clusterId.slice(dash + 1)
+    }
+  }
+  return clusterId
+}
+
+/**
+ * #5571: the Region column. Injected by K8sListPage (not declared by
+ * each kind in kindsPages.tsx) so EVERY Cloud list page gains region
+ * attribution at once and no kind can be forgotten.
+ */
+export const REGION_COLUMN: K8sListColumn = {
+  header: 'Region',
+  extract: (obj) => regionLabel(obj.clusterId ?? ''),
+}
+
 export interface K8sListPageProps {
   /** Kind name as registered in the k8scache registry (e.g. "pod",
    *  "deployment", "service"). */

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
@@ -46,6 +46,7 @@
  */
 
 import type { K8sObject, K8sSnapshot } from './useK8sCacheStream'
+import { snapshotKey } from './useK8sCacheStream'
 import type { ArchNodeType, ArchStatus, GraphEdge, GraphNode } from './types'
 
 interface AdaptResult {
@@ -151,7 +152,14 @@ function resolveTopOwner(
     return { kind: 'DaemonSet', namespace: ns, name: ref.name }
   }
   if (ref.kind === 'ReplicaSet' && ref.name) {
-    const rs = snapshot.get(`replicaset:${ns}/${ref.name}`)
+    // #5571: resolve the owning ReplicaSet in the SAME region as the
+    // Pod. Snapshot keys are now cluster-suffixed, and on a 2-region
+    // Sovereign both regions run the same Deployment names — an
+    // unsuffixed lookup would either miss entirely or bind the Pod to
+    // the OTHER region's ReplicaSet.
+    const rs = snapshot.get(
+      snapshotKey('replicaset', ns, ref.name, pod.clusterId ?? ''),
+    )
     if (!rs) {
       return null
     }
@@ -596,7 +604,12 @@ export function k8sToGraph(snapshot: K8sSnapshot): AdaptResult {
     // hcloud-csi sets `volumeID` on the PV's csi block).
     const pvName = (pvc.spec?.['volumeName'] as string | undefined) ?? ''
     if (pvName) {
-      const pv = snapshot.get(`persistentvolume:${pvName}`)
+      // #5571: bind to the PV in the PVC's OWN region — a PV name can
+      // repeat across regions, and crossing the boundary here would
+      // attribute a region-a claim to a region-b disk.
+      const pv = snapshot.get(
+        snapshotKey('persistentvolume', '', pvName, pvc.clusterId ?? ''),
+      )
       const csi = pv?.spec?.['csi'] as { volumeAttributes?: Record<string, string>; volumeHandle?: string } | undefined
       const hcloudID = csi?.volumeAttributes?.['volumeID'] ?? csi?.volumeHandle ?? ''
       if (hcloudID) {

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.region-split-5571.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.region-split-5571.test.ts
@@ -1,0 +1,252 @@
+/**
+ * useK8sCacheStream.region-split-5571.test.ts — #5571 cross-region
+ * collapse guard.
+ *
+ * ## What this pins
+ *
+ * `/k8s/stream` fans out across every region of a Sovereign and tags
+ * each SSE frame with the region it came from (`cluster` on the event
+ * ENVELOPE — see catalyst-api `internal/handler/k8s.go`, and the
+ * server-side fan-out fix in PR #5687). The SPA then folds those
+ * frames into one snapshot Map.
+ *
+ * The fold is where the estate can still be silently truncated: if the
+ * snapshot key omits the region, the SAME `{ns}/{name}` in two regions
+ * collapses to ONE entry. A 2-region Sovereign runs the same charts in
+ * both regions, so that collision is the common case, not an edge —
+ * measured live on hw292 (dep 1c56518035a83e03, 2026-08-06):
+ *
+ *   NetworkPolicies        region-a 38 + region-b 26 = 64 real objects
+ *                          -> 21 share {ns}/{name} across regions
+ *   CiliumNetworkPolicies  region-a 57 + region-b 42 = 99 real objects
+ *                          -> 37 share {ns}/{name} across regions
+ *
+ * So a region-blind key drops 21 of 64 NetworkPolicies and 37 of 99
+ * CiliumNetworkPolicies on the Cloud security-posture pages, and — the
+ * sharper failure — a DELETE in one region erases the row for a policy
+ * that is still enforcing in the other. On a page whose job is to show
+ * network policy, absence reads as "no such policy". That is the
+ * #5571 symptom, one layer above the server fix.
+ *
+ * ## Why the assertions look the way they do
+ *
+ * Every assertion below scans snapshot VALUES by `{ns}/{name}` and
+ * checks the object CONTENT, never the key string. That is deliberate:
+ *   - it does not encode this implementation's key format, so the
+ *     guard stays valid for any correct fix, and
+ *   - a count or a key-presence check would pass on an EMPTY or
+ *     WRONG-REGION object; only comparing the two regions' distinct
+ *     spec values proves both objects genuinely survived the fold.
+ *
+ * The fixture uses two regions with DISTINGUISHABLE objects, because a
+ * single-region fixture structurally cannot detect a single-region bug.
+ *
+ * Object names are the real hw292 ones (`gitea/gitea-default-deny` is
+ * live in both regions; the two `cnpg-pair` policies are the real
+ * region-exclusive pair — `...allow-probe-to-replica` is region-B-only
+ * and is the same discriminator the original issue cited on hw291).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useK8sCacheStream, type K8sObject, type K8sSnapshot } from './useK8sCacheStream'
+
+/* ── hw292's two real cluster-id conventions ─────────────────────── */
+
+/** Chroot primary self-registers under a `sovereign-<fqdn>` alias. */
+const REGION_A = 'sovereign-hw292.omani.works'
+/** Secondaries keep `<deploymentID>-<region>` (LoadClustersFromDir). */
+const REGION_B = '1c56518035a83e03-me-east-215-b-1'
+
+/* ── EventSource shim (jsdom has none) ───────────────────────────── */
+
+interface FakeES {
+  url: string
+  onopen: ((e: Event) => void) | null
+  onmessage: ((e: MessageEvent) => void) | null
+  onerror: ((e: Event) => void) | null
+}
+
+let activeES: FakeES | null = null
+
+/** Registered via a helper rather than `activeES = this` so the class
+ *  does not alias `this` (@typescript-eslint/no-this-alias). */
+function register(es: FakeES) {
+  activeES = es
+}
+
+class FakeEventSource implements FakeES {
+  url: string
+  onopen: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    register(this)
+  }
+  close = () => {}
+}
+
+beforeEach(() => {
+  activeES = null
+  // @ts-expect-error — install fake on the global
+  globalThis.EventSource = FakeEventSource
+})
+
+afterEach(() => {
+  activeES = null
+  // @ts-expect-error — clean up
+  delete globalThis.EventSource
+})
+
+function send(frame: unknown) {
+  if (!activeES?.onmessage) throw new Error('no onmessage handler attached')
+  activeES.onmessage(new MessageEvent('message', { data: JSON.stringify(frame) }))
+}
+
+/**
+ * One `networkpolicy` delta, in the exact envelope shape catalyst-api
+ * emits (`{cluster, kind, type, object, at}`). `marker` goes into the
+ * object body so the two regions' copies are distinguishable by VALUE.
+ */
+function npFrame(
+  cluster: string,
+  ns: string,
+  name: string,
+  marker: string,
+  type: 'ADDED' | 'MODIFIED' | 'DELETED' = 'ADDED',
+) {
+  return {
+    cluster,
+    kind: 'networkpolicy',
+    type,
+    object: {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'NetworkPolicy',
+      metadata: { namespace: ns, name, uid: `uid-${cluster}-${ns}-${name}` },
+      spec: { podSelector: { matchLabels: { 'test.openova.io/region-marker': marker } } },
+    },
+    at: '2026-08-06T00:00:00Z',
+  }
+}
+
+/* ── Format-agnostic readers — scan VALUES, never keys ────────────── */
+
+function entriesFor(snapshot: K8sSnapshot, ns: string, name: string): K8sObject[] {
+  return [...snapshot.values()].filter(
+    (o) => o.metadata?.namespace === ns && o.metadata?.name === name,
+  )
+}
+
+function markerOf(obj: K8sObject): string {
+  const sel = obj.spec?.['podSelector'] as
+    | { matchLabels?: Record<string, string> }
+    | undefined
+  return sel?.matchLabels?.['test.openova.io/region-marker'] ?? ''
+}
+
+describe('#5571 — /k8s/stream fold must not collapse regions', () => {
+  it('GUARD: the same {ns}/{name} in two regions survives as TWO distinct objects', async () => {
+    const { result } = renderHook(() => useK8sCacheStream('1c56518035a83e03'))
+    await act(async () => {
+      activeES?.onopen?.(new Event('open'))
+      // Real hw292 collision: gitea/gitea-default-deny exists in BOTH.
+      send(npFrame(REGION_A, 'gitea', 'gitea-default-deny', 'from-region-a'))
+      send(npFrame(REGION_B, 'gitea', 'gitea-default-deny', 'from-region-b'))
+      // Real hw292 region-exclusive policies.
+      send(
+        npFrame(
+          REGION_A,
+          'cnpg',
+          'cnpg-pair-bp-cnpg-pair-allow-replication-to-primary',
+          'from-region-a',
+        ),
+      )
+      send(
+        npFrame(
+          REGION_B,
+          'cnpg',
+          'cnpg-pair-bp-cnpg-pair-allow-probe-to-replica',
+          'from-region-b',
+        ),
+      )
+    })
+
+    const snap = result.current.snapshot
+    const collided = entriesFor(snap, 'gitea', 'gitea-default-deny')
+
+    // Pre-fix this is 1: region-b's frame overwrote region-a's, because
+    // the key carried no region.
+    expect(
+      collided.length,
+      '#5571 REGRESSION: gitea/gitea-default-deny exists in BOTH hw292 regions but the ' +
+        `snapshot kept ${collided.length} — one region's NetworkPolicy was silently dropped ` +
+        'by the fold, so the Cloud page under-reports the estate.',
+    ).toBe(2)
+
+    // Assert on the VALUE, not the count: both regions' OWN bodies must
+    // be present. A count of 2 could otherwise be two copies of the
+    // same region's object.
+    expect(collided.map(markerOf).sort()).toEqual(['from-region-a', 'from-region-b'])
+
+    // …and each must be attributed to the region it actually came from.
+    expect(
+      collided.map((o) => o.clusterId).sort(),
+      '#5571: both copies survived but region attribution was lost — the operator still ' +
+        'cannot tell which region enforces which policy.',
+    ).toEqual([REGION_B, REGION_A].sort())
+
+    // Whole-estate count: 4 real objects across 2 regions (pre-fix: 3).
+    expect(snap.size).toBe(4)
+  })
+
+  it('GUARD: DELETE in one region must NOT erase the other region\'s policy', async () => {
+    const { result } = renderHook(() => useK8sCacheStream('1c56518035a83e03'))
+    await act(async () => {
+      activeES?.onopen?.(new Event('open'))
+      send(npFrame(REGION_A, 'gitea', 'gitea-default-deny', 'from-region-a'))
+      send(npFrame(REGION_B, 'gitea', 'gitea-default-deny', 'from-region-b'))
+    })
+    expect(entriesFor(result.current.snapshot, 'gitea', 'gitea-default-deny')).toHaveLength(2)
+
+    // region-b's copy is removed; region-a still enforces its own.
+    await act(async () => {
+      send(npFrame(REGION_B, 'gitea', 'gitea-default-deny', 'from-region-b', 'DELETED'))
+    })
+
+    const left = entriesFor(result.current.snapshot, 'gitea', 'gitea-default-deny')
+    expect(
+      left.length,
+      "#5571 REGRESSION: deleting region-b's NetworkPolicy also removed region-a's — the " +
+        'Cloud page now shows NO policy for a namespace that is still protected in region-a. ' +
+        'On a security-posture surface, that absence reads as "unprotected".',
+    ).toBe(1)
+    expect(markerOf(left[0]!), 'the surviving object must be REGION-A’s, not a stale region-b body').toBe(
+      'from-region-a',
+    )
+    expect(left[0]!.clusterId).toBe(REGION_A)
+  })
+
+  it('CONTROL: a single-region stream still folds normally (passes pre- AND post-fix)', async () => {
+    // This control shares the harness, the fixture helpers and the
+    // value-scanning assertions with the guards above, but exercises
+    // NO cross-region collision — so it passes on both the pre-fix and
+    // post-fix trees. If someone silences the guards by disabling this
+    // file, stubbing the hook, or neutering the EventSource shim, this
+    // control goes red too, which is what stops blanket suppression
+    // from looking like a pass.
+    const { result } = renderHook(() => useK8sCacheStream('1c56518035a83e03'))
+    await act(async () => {
+      activeES?.onopen?.(new Event('open'))
+      send(npFrame(REGION_A, 'gitea', 'gitea-default-deny', 'from-region-a'))
+      send(npFrame(REGION_A, 'alloy', 'alloy-default-deny', 'from-region-a'))
+    })
+
+    const snap = result.current.snapshot
+    expect(snap.size).toBe(2)
+    expect(entriesFor(snap, 'gitea', 'gitea-default-deny')).toHaveLength(1)
+    expect(entriesFor(snap, 'alloy', 'alloy-default-deny')).toHaveLength(1)
+    expect(markerOf(entriesFor(snap, 'alloy', 'alloy-default-deny')[0]!)).toBe('from-region-a')
+    expect(result.current.status).toBe('open')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.test.ts
@@ -99,7 +99,10 @@ describe('useK8sCacheStream', () => {
       })
     })
     expect(result.current.snapshot.size).toBe(1)
-    expect(result.current.snapshot.get('pod:default/p1')).toBeDefined()
+    // #5571: the key carries the region as an `@{cluster}` suffix.
+    expect(
+      result.current.snapshot.get('pod:default/p1@sovereign-omantel.biz'),
+    ).toBeDefined()
   })
 
   it('drops a frame whose object is missing entirely', async () => {
@@ -150,7 +153,7 @@ describe('useK8sCacheStream', () => {
         at: 'x',
       })
     })
-    const obj = result.current.snapshot.get('pod:default/p1') as
+    const obj = result.current.snapshot.get('pod:default/p1@alpha') as
       | { status?: { phase?: string } }
       | undefined
     expect(obj?.status?.phase).toBe('Running')
@@ -172,10 +175,14 @@ describe('useK8sCacheStream', () => {
     expect(result.current.snapshot.size).toBe(0)
   })
 
-  it('objectKey composes `kind:ns/name` and `kind:name` for cluster-scoped', () => {
+  it('objectKey composes `kind:ns/name@cluster` and `kind:name@cluster`', () => {
     expect(
-      objectKey('pod', { metadata: { namespace: 'default', name: 'p1' } }),
-    ).toBe('pod:default/p1')
-    expect(objectKey('node', { metadata: { name: 'n1' } })).toBe('node:n1')
+      objectKey('pod', { metadata: { namespace: 'default', name: 'p1' } }, 'r-a'),
+    ).toBe('pod:default/p1@r-a')
+    expect(objectKey('node', { metadata: { name: 'n1' } }, 'r-a')).toBe(
+      'node:n1@r-a',
+    )
+    // No region context → legacy unsuffixed form (mothership/tests).
+    expect(objectKey('node', { metadata: { name: 'n1' } }, '')).toBe('node:n1')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.ts
@@ -128,16 +128,41 @@ export interface K8sObject {
    */
   displayName?: string
   vclusterNamespace?: string
+  /**
+   * #5571: the k8scache cluster id (region) this object was observed
+   * in, stamped from the SSE event's `cluster` field as the delta is
+   * applied. The wire `object` never carries it — region identity
+   * lives on the ENVELOPE, so it has to be copied down onto the object
+   * or it is lost the moment the event is folded into the snapshot.
+   *
+   * Consumers that display estate-wide sets (the Cloud list pages)
+   * MUST surface this, otherwise one region's set is indistinguishable
+   * from the whole Sovereign's.
+   */
+  clusterId?: string
   [key: string]: unknown
 }
 
 /**
  * Snapshot is the in-memory mirror of every object the graph layer
- * cares about — keyed by composite id `{kind}:{namespace}/{name}` so a
- * Pod in two namespaces doesn't collide.
+ * cares about — keyed by composite id
+ * `{kind}:{namespace}/{name}@{cluster}` so a Pod in two namespaces
+ * doesn't collide, AND the SAME `{ns}/{name}` in two REGIONS doesn't
+ * collide either (#5571).
  *
  * Cluster-scoped kinds (Namespace, Node, PV, server.hcloud,
- * volume.hcloud) use `{kind}:{name}` (empty namespace).
+ * volume.hcloud) use `{kind}:{name}@{cluster}` (empty namespace).
+ *
+ * 🛑 The `@{cluster}` suffix is load-bearing (#5571). A 2-region
+ * Sovereign runs the SAME chart in both regions, so a large share of
+ * objects share `{ns}/{name}` across regions — measured on hw292:
+ * 21 of 64 NetworkPolicies and 37 of 99 CiliumNetworkPolicies. Keying
+ * without the cluster silently drops the loser of each collision and
+ * makes a DELETE in one region erase the row for the other, which the
+ * Cloud security-posture pages read as "policy absent". The suffix
+ * form (not a prefix) is deliberate: every existing key scan is
+ * `key.startsWith(`${kind}:`)` / `key.split(':', 1)[0]`, which keeps
+ * working unchanged.
  */
 export type K8sSnapshot = Map<string, K8sObject>
 
@@ -160,17 +185,43 @@ export interface UseK8sCacheStreamOptions {
 }
 
 /**
- * Compose the composite snapshot key for an event. Empty namespace
- * for cluster-scoped kinds so PV / Node / server.hcloud all key on
- * `{kind}:{name}` cleanly.
+ * Compose the composite snapshot key from raw coordinates. Empty
+ * namespace for cluster-scoped kinds so PV / Node / server.hcloud all
+ * key on `{kind}:{name}` cleanly.
+ *
+ * `cluster` is REQUIRED (#5571) — it is appended as a `@{cluster}`
+ * SUFFIX so `key.startsWith(`${kind}:`)` and `key.split(':', 1)[0]`
+ * scans elsewhere in the SPA keep working verbatim. It is required
+ * rather than defaulted so a new call site cannot silently
+ * re-introduce the cross-region collapse by forgetting it; pass `''`
+ * only where there is genuinely no region context.
  */
-export function objectKey(kind: string, obj: K8sObject): string {
-  const ns = obj.metadata?.namespace ?? ''
-  const name = obj.metadata?.name ?? ''
-  if (ns) {
-    return `${kind}:${ns}/${name}`
-  }
-  return `${kind}:${name}`
+export function snapshotKey(
+  kind: string,
+  ns: string,
+  name: string,
+  cluster: string,
+): string {
+  const base = ns ? `${kind}:${ns}/${name}` : `${kind}:${name}`
+  return cluster ? `${base}@${cluster}` : base
+}
+
+/**
+ * Compose the composite snapshot key for an event's object. See
+ * `snapshotKey` — `cluster` comes from the SSE event ENVELOPE
+ * (`payload.cluster`), never from the object itself.
+ */
+export function objectKey(
+  kind: string,
+  obj: K8sObject,
+  cluster: string,
+): string {
+  return snapshotKey(
+    kind,
+    obj.metadata?.namespace ?? '',
+    obj.metadata?.name ?? '',
+    cluster,
+  )
 }
 
 export function useK8sCacheStream(
@@ -260,11 +311,20 @@ export function useK8sCacheStream(
       if (!payload.object || !payload.object.metadata) {
         return
       }
-      const key = objectKey(payload.kind, payload.object)
+      // #5571: region identity lives on the event ENVELOPE, not on the
+      // object. Key by it so the two regions of a 2-region Sovereign
+      // cannot overwrite each other, and stamp it DOWN onto the stored
+      // object so consumers (Cloud list pages, owner-ref resolution)
+      // can still tell the regions apart after the fold.
+      const cluster = payload.cluster ?? ''
+      const key = objectKey(payload.kind, payload.object, cluster)
       if (payload.type === 'DELETED') {
         snapshotRef.current.delete(key)
       } else {
-        snapshotRef.current.set(key, payload.object)
+        snapshotRef.current.set(
+          key,
+          cluster ? { ...payload.object, clusterId: cluster } : payload.object,
+        )
       }
       setState((prev) => ({
         snapshot: snapshotRef.current,


### PR DESCRIPTION
## Summary

The **server-side** half of #5571 landed in PR #5687 — `deploymentScopedClusterIDs` no longer prefix-drops a chroot's alias-mismatched secondaries, so the `/k8s/stream` SSE fan-out now reaches every region and tags each frame with its `cluster`.

This is the **SPA half**. Even with a perfect fan-out, the browser folded the two regions straight back into one, so the reported symptom on the Cloud NetworkPolicies / CiliumNetworkPolicies pages survives the server fix.

`useK8sCacheStream` keyed its snapshot on `` `${kind}:${ns}/${name}` `` with **no region component**. Region identity lives on the event ENVELOPE (`cluster`), never on the object — so the moment a frame was folded into the Map, the region was discarded and the same `{ns}/{name}` from two regions overwrote each other.

## Confirmed against the live 2-region Sovereign

hw292, dep `1c56518035a83e03`, **both** kubeconfigs sampled independently (`/deps/kubeconfigs`-sourced region-a and region-b), 2026-08-06:

| kind | region-a | region-b | real estate | share `{ns}/{name}` across regions | max the UI could show |
|---|---|---|---|---|---|
| NetworkPolicy | 38 | 26 | **64** | 21 | **43** |
| CiliumNetworkPolicy | 57 | 42 | **99** | 37 | **62** |

Both regions run the same charts, so the collision is the common case, not an edge. Real colliding names include `gitea/gitea-default-deny`, `alloy/alloy-default-deny`, `dragonfly/dragonfly-redis`, `external-dns/bp-external-dns`. Real region-exclusive ones include `cnpg/cnpg-pair-bp-cnpg-pair-allow-probe-to-replica` (region-B only — the same discriminator the issue cited on hw291).

So the page could show at most **43 of 64** NetworkPolicies and **62 of 99** CiliumNetworkPolicies, with no region label to reveal the omission.

The sharper failure is **DELETE**: a policy removed in one region erased the row for the copy still enforcing in the other. On a page whose job is to show network policy, that absence reads as "no such policy" — the "absence must not read as compliance" concern in the issue.

## Changes

- **`useK8sCacheStream.ts`** — snapshot keys gain an `@{cluster}` **suffix** (suffix, not prefix, so every existing `` key.startsWith(`${kind}:`) `` / `key.split(':', 1)[0]` scan in the SPA keeps working verbatim), and the envelope's `cluster` is stamped down onto the stored object as `clusterId`. New `snapshotKey()` helper; `objectKey()` now takes the cluster as a **required** third argument so a new call site cannot silently re-introduce the collapse.
- **`k8sAdapter.ts`** — the two exact-key lookups (Pod → owning ReplicaSet, PVC → PV) now resolve within the referrer's **own** region. Without this they would either miss after the key change or bind a Pod to the *other* region's ReplicaSet.
- **`K8sListPage.tsx` / `k8sColumns.ts`** — issue item (2): a **Region column** (plus a `data-region` attribute), injected by the page rather than declared per-kind so every Cloud list page gains attribution at once and no kind can be forgotten. `regionLabel()` handles both real cluster-id conventions — `<depID>-<region>` and the chroot primary's `sovereign-<fqdn>` alias — and never blanks a known region. Collided rows get a deterministic `clusterId` sort tiebreaker.

## Falsifiability — both directions, verbatim

Guards **RED** on the pre-fix tree (fix reverted, tests kept):

```
 × GUARD: the same {ns}/{name} in two regions survives as TWO distinct objects
   AssertionError: #5571 REGRESSION: gitea/gitea-default-deny exists in BOTH hw292
   regions but the snapshot kept 1 — one region's NetworkPolicy was silently dropped
   by the fold, so the Cloud page under-reports the estate.: expected 1 to be 2

 × GUARD: DELETE in one region must NOT erase the other region's policy
   AssertionError: expected [ { …(4) } ] to have a length of 2 but got 1

 × GUARD: the same policy in two regions renders TWO rows carrying DIFFERENT regions
   TestingLibraryElementError: Unable to find an element with the text: Region

   Tests  2 failed | 1 passed   (hook file, pre-fix)
   Tests  1 failed | 2 passed   (list-page file, pre-fix)
```

**GREEN** after the fix:

```
 Test Files  3 passed (3)
      Tests  12 passed (12)
```

**Controls that pass on BOTH trees** (so the guards cannot be satisfied by blanket suppression): `CONTROL: a single-region stream still folds normally`, `CONTROL: a single-region list still renders its rows and its region`, and the `regionLabel` unit test. They share the harness, fixture helpers and assertion style with the guards, so disabling the file, stubbing the hook or neutering the EventSource shim turns them red too.

Note the list-page guard was falsified by reverting **only** `K8sListPage.tsx` and keeping the helpers — so it fails on *behaviour* (no Region column), not on an import error.

### Anti-trap notes

- **Assert on the VALUE, not the key or the count.** Every assertion scans snapshot **values** by `{ns}/{name}` and compares the two regions' *distinct object bodies*. Nothing asserts on the key string, so the guards do not encode this implementation's key format and stay valid for any correct fix. A count-only or key-presence check would pass on an empty or wrong-region object; `new Set(cellText).size === 2` specifically rejects a Region column that renders the same label for both rows.
- **Two distinct regions with distinguishable objects** — a single-region fixture structurally cannot detect a single-region bug.
- **The fixture does not hand-write the contract**: the list-page test builds its snapshot keys with the *production* `objectKey`, so it cannot drift from the real key contract.
- **The check runs**: the vitest gate is in `catalyst-build.yaml`, whose `paths:` filter `products/catalyst/bootstrap/**` covers every file changed here.

## Gates

- `vitest run` (full suite) — **222 files / 2073 tests pass**
- `tsc -b --noEmit` — clean
- `eslint` — clean on all changed files

## Scope — what I deliberately did NOT change

- **#5611 (Volumes claims 0) is NOT this root cause.** Its own evidence refutes the link: the PersistentVolumes chip reads **97**, i.e. the union across both regions, so the fan-out and the fold both work for PVs. `volumes`/`storageclasses` are simply uncollected kinds. Different defect, left alone.
- **Graph node identity.** `k8sToGraph` de-dupes nodes by `compositeId(kind, ns, name)`, so cross-region duplicates still collapse into one architecture-graph node. That is unchanged behaviour (and arguably right for a logical topology view) — no regression, and region-splitting the graph is a separate design question.
- **`src/lib/useK8sStream.ts`** carries the identical latent key bug but is imported by nothing except its own test. Left untouched rather than churn dead code.

Refs #5571 #5687 #5511 #5416
