### PR TITLE
fix(guard): execute-and-detect guard for credential prefixes in logs — catches the step-09 Gitea-token tail the #5467 fix missed (Refs #5467)

### DIFF
--- a/.github/workflows/check-no-credential-prefix-logging.yaml
+++ b/.github/workflows/check-no-credential-prefix-logging.yaml
@@ -1,0 +1,75 @@
+name: check — no credential prefix in logs (#5467)
+
+# Permanent guard against the #5467 class: a log line that emits part of a
+# credential's value.
+#
+# #5467 was the step-03 cutover Job printing `pat=${ghcr_pat:0:8}` — 8
+# characters of the GHCR PAT into pod logs on every cutover, on every
+# Sovereign. Fixed in bp-self-sovereign-cutover 0.1.169. Three steps later in
+# the same chart, step-09 was printing the LAST 5 characters of the freshly
+# minted Gitea API token via `${new_token##???…???}` — the same disclosure in
+# a spelling no grep for the step-03 idiom would ever match. That one survived
+# the fix and was found by this guard.
+#
+# scripts/check-no-credential-prefix-logging.sh therefore does not grep. It
+# binds each credential-carrying variable in an output statement to a
+# sentinel, EXECUTES the statement, and fails on a PARTIAL run of sentinel
+# bytes in the emitted output — truncation by any mechanism, including ones
+# nobody has invented yet. See the script header for the full rationale.
+#
+# Two jobs, deliberately:
+#   * self-test — the vacuity check. Proves the detector goes RED on a
+#     known-bad fixture and stays GREEN on a known-good one. A scanner that
+#     cannot fail is not a guard, and this job is what stops this one from
+#     quietly decaying into one.
+#   * scan — the repo-wide check.
+#
+# The self-test runs FIRST and the scan depends on it, so a green scan can
+# never be reported off a broken detector.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'clusters/**'
+      - 'core/**'
+      - 'infra/**'
+      - '.github/workflows/**'
+      - 'scripts/**'
+      - 'tools/**'
+  pull_request:
+    paths:
+      - 'platform/**'
+      - 'products/**'
+      - 'clusters/**'
+      - 'core/**'
+      - 'infra/**'
+      - '.github/workflows/**'
+      - 'scripts/**'
+      - 'tools/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  self-test:
+    name: Vacuity check (detector must go red on the bad fixture)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prove the detector can fail
+        run: bash scripts/check-no-credential-prefix-logging.sh --self-test
+
+  scan:
+    name: Reject credential prefixes in log lines
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: self-test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run credential-prefix logging guard
+        run: bash scripts/check-no-credential-prefix-logging.sh

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1061,7 +1061,7 @@ spec:
       # index.yaml HelmRepository off charts.loft.sh into local Harbor +
       # suspends bp-vcluster-helmrepo so it holds; the step-08 fluxSourceHostLint
       # exception for charts.loft.sh is removed (empty allowHosts).
-      version: 0.1.172
+      version: 0.1.173
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1322,7 +1322,9 @@ spec:
       #   create-side reconcile; deleted Orgs converge to fully-deleted in
       #   every region.
       #   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
-      version: 1.4.1319
+      # 1.4.1320 (#5467): catalog-seed cutover pin 0.1.173 — step-09 no longer
+      #   prints the tail of the minted Gitea token. Lockstep w/ slot-06a.
+      version: 1.4.1320
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/keycloak/chart/tests/admin-password-stable.sh
+++ b/platform/keycloak/chart/tests/admin-password-stable.sh
@@ -42,7 +42,11 @@ if [ -z "$PW" ] || [ "$PW" = "null" ]; then
   echo "FAIL 1: keycloak-admin Secret missing or empty admin-password"
   exit 1
 fi
-echo "PASS 1: keycloak-admin Secret renders admin-password (${PW:0:6}...)"
+# #5467 — length only, never a prefix. The rendered admin-password is a
+# deterministic function of the chart values, so a prefix printed here is a
+# prefix of the real Sovereign admin password for anyone who renders with the
+# real sovereignFQDN — and CI logs on a public repo are world-readable.
+echo "PASS 1: keycloak-admin Secret renders admin-password (len=${#PW})"
 
 # Test 2: resource-policy: keep so the password persists across uninstall
 KEEP="$(echo "$OUT" | yq 'select(.kind=="Secret" and .metadata.name=="keycloak-admin") | .metadata.annotations["helm.sh/resource-policy"]')"

--- a/platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh
+++ b/platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh
@@ -32,7 +32,10 @@ if [ -z "$GRAFANA_EMPTY" ] || [ "$GRAFANA_EMPTY" = "null" ]; then
   echo "FAIL 1: empty salt did not produce a derived secret"
   exit 1
 fi
-echo "PASS 1: empty-salt grafana secret = ${GRAFANA_EMPTY:0:8}..."
+# #5467 — length only. Tests 2 and 3 below compare the secrets in FULL, so the
+# prefix printed here was never load-bearing; it just put 8 characters of a
+# derived client secret into the log.
+echo "PASS 1: empty-salt grafana secret derived (len=${#GRAFANA_EMPTY})"
 
 # Test 2: Non-empty salt → different secret than empty
 GRAFANA_SALTED=$(extract_secret "rotation-2026-06-02" '.clients[] | select(.clientId=="grafana") | .secret')
@@ -40,7 +43,7 @@ if [ "$GRAFANA_SALTED" = "$GRAFANA_EMPTY" ]; then
   echo "FAIL 2: salt change did not rotate the derived secret"
   exit 1
 fi
-echo "PASS 2: salted grafana secret = ${GRAFANA_SALTED:0:8}... (differs from empty)"
+echo "PASS 2: salted grafana secret (len=${#GRAFANA_SALTED}) differs from empty-salt"
 
 # Test 3: Same salt value renders identically (idempotent)
 GRAFANA_SALTED_AGAIN=$(extract_secret "rotation-2026-06-02" '.clients[] | select(.clientId=="grafana") | .secret')

--- a/platform/keycloak/chart/tests/g117-w2c4-per-org-realm.sh
+++ b/platform/keycloak/chart/tests/g117-w2c4-per-org-realm.sh
@@ -217,7 +217,10 @@ if [ "$secret_a" = "$secret_b" ]; then
   echo "FAIL: broker secrets are identical across Orgs (cross-Org isolation violation)" >&2
   exit 1
 fi
-echo "  PASS (acme secret=${secret_a:0:8}…  beta-org secret=${secret_b:0:8}…  distinct)"
+# #5467 — the assertion above already compared the two secrets in FULL; the
+# echo only has to report the verdict. Printing 8 characters of each adds no
+# diagnostic and discloses two derived broker secrets into public CI logs.
+echo "  PASS (acme len=${#secret_a}  beta-org len=${#secret_b}  distinct)"
 
 echo "[g117-w2c4-per-org-realm] Case 11: broker secret is deterministic across renders (idempotent)"
 out_re=$(helm template smoke "$CHART_DIR" \

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.172
+  version: 0.1.173
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,37 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.173 (#5467) — STEP-09 STOPS PRINTING THE TAIL OF THE MINTED GITEA TOKEN.
+# #5467 was filed and fixed against step-03, which printed `pat=${ghcr_pat:0:8}`
+# — the first 8 characters of the GHCR PAT. The fix landed in 0.1.169. What the
+# issue did not have is the SECOND instance, three steps later in the same
+# chart:
+#
+#   09-gitea-token-mint-job.yaml:271
+#   echo "[gitea-token-mint] minted token: ...${new_token##???…???}"
+#
+# `##` with 35 literal `?` glob-strips the first 35 characters and emits the
+# LAST 5 of a freshly minted Gitea API token — the credential the host GitOps
+# loop authenticates with for the remainder of the Sovereign's life. Same
+# disclosure class as step-03, different spelling: no `:0:N`, no `cut -c`, no
+# `%.8s`. Every grep-shaped sweep for the step-03 idiom walks straight past it,
+# which is why it survived the 0.1.169 fix. The surrounding code is otherwise
+# careful to a fault — `# Extract the sha1 field WITHOUT printing it` sits 8
+# lines above, and the error paths sed-redact the token — and this one line was
+# quietly contradicting all of it on every cutover.
+#
+# Now: `minted token: set (len=${#new_token})`. That is the entire diagnostic
+# the line ever carried (did mint return a plausible sha1, or junk) at zero
+# bytes of disclosure — matching the step-03 branch and the mothership branch.
+#
+# Found by the new scripts/check-no-credential-prefix-logging.sh, which does not
+# grep. It binds every credential-carrying variable in an output statement to a
+# sentinel, EXECUTES the statement, and fails on a PARTIAL run of sentinel bytes
+# in the emitted output. Truncation by any mechanism — invented or not yet
+# invented — lands in the same net; full interpolation (a Secret NAME, a
+# `printf '%s:%s'` feeding skopeo --src-creds) does not, so the 531 legitimate
+# credential-named statements in this repo stay quiet. Step count unchanged
+# at 11; no values, RBAC or step-boundary change.
+#
 # 0.1.172 (#5650) — THE LOFT CHART-SOURCE PIVOT NOW COVERS EVERY REGION. 0.1.168
 # shipped step-06 Phase-2c as a PRIMARY-ONLY block: every kubectl in it ran
 # against the Job's own in-cluster context. Bootstrap-kit slot 60 installs the
@@ -3414,7 +3446,7 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.172
+version: 0.1.173
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
@@ -268,7 +268,18 @@ data:
               printf '%s\n' "${mint_response}" | sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" >&2
               exit 1
             fi
-            echo "[gitea-token-mint] minted token: ...${new_token##???????????????????????????????????}" 2>/dev/null || echo "[gitea-token-mint] minted token: <redacted>"
+            # #5467 — do NOT print any fragment of the minted token. The old
+            # `${new_token##???…???}` glob-stripped the first 35 characters and
+            # emitted the LAST 5 of a live Gitea API token — the credential the
+            # host GitOps loop authenticates with for the rest of the
+            # Sovereign's life. It is the same disclosure class as the step-03
+            # GHCR-PAT prefix, in a different spelling: no `:0:N`, no `cut -c`,
+            # so no grep for the step-03 idiom would ever have found it. The
+            # comment 8 lines up already says "WITHOUT printing it"; this line
+            # was quietly contradicting it on every cutover.
+            # Length + set/unset is the whole diagnostic: it distinguishes
+            # "mint returned a plausible sha1" from "mint returned junk".
+            echo "[gitea-token-mint] minted token: set (len=${#new_token})"
 
             # ── 4. Validate the token against Gitea ──────────────────────
             # GET /api/v1/user with `Authorization: token <X>` returns

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T02:21:30.813Z",
+  "generatedAt": "2026-08-06T02:38:58.363Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.172",
+      "version": "0.1.173",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.172",
+    "version": "0.1.173",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1320 — #5467: catalog-seed bp-self-sovereign-cutover pin 0.1.172 ->
+#   0.1.173. Step-09 gitea-token-mint stopped emitting the LAST 5 chars of
+#   the freshly minted Gitea API token via ${new_token##???...???} — the same
+#   disclosure class as the step-03 GHCR-PAT prefix (#5467, fixed in 0.1.169)
+#   in a spelling no grep for that idiom would ever match. Seed-pin bump only
+#   on this side; lockstep w/ slot-06a (pin-sync gate).
 # 1.4.1312 — #5635 (APP half): grant catalyst-api `namespaces: create` +
 #   `services: create` so reconcileOrgAppSurfaceAcrossRegions can make a
 #   SECONDARY region serve the per-Org purchased-app hosts instead of
@@ -3686,7 +3692,7 @@ name: bp-catalyst-platform
 # 1.4.1295 — #5467: bp-self-sovereign-cutover 0.1.168 -> 0.1.169 (harbor-prewarm
 #   GHCR-PAT log-leak fix). Bootstrap-kit slot-06a + catalog-seed pins lockstep.
 #   (re-serialized past main 1.4.1294 at rebase.)
-version: 1.4.1319
+version: 1.4.1320
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5101,7 +5101,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.172"
+  version: "0.1.173"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5118,7 +5118,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.172"
+    version: "0.1.173"
   topology:
     supported:
       - singleton

--- a/scripts/check-no-credential-prefix-logging.sh
+++ b/scripts/check-no-credential-prefix-logging.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# check — no credential PREFIX reaches a log line (#5467).
+#
+# ─────────────────────────────────────────────────────────────────────
+# The defect class
+# ─────────────────────────────────────────────────────────────────────
+# #5467: the step-03 harbor-prewarm cutover Job printed the first 8
+# characters of the GHCR PAT into its pod logs on every cutover, on
+# every Sovereign:
+#
+#     echo "... pat=${ghcr_pat:0:8}... (len=${#ghcr_pat})"
+#
+# Four of those 8 characters were real secret material (the `ghp_` type
+# tag is the other four), alongside positive confirmation of the token
+# TYPE, its exact LENGTH, and the owning ACCOUNT. Pod logs are not a
+# secret store: operators read them, log aggregators ship them, support
+# bundles capture them, and a failed cutover gets its logs pasted into
+# an issue. The identical mothership branch 14 lines below already did
+# it correctly — user + length, no prefix.
+#
+# The platform rule this enforces: **secret VALUES are never printed;
+# lengths and hashes only.** A truncated secret is still a secret.
+#
+# ─────────────────────────────────────────────────────────────────────
+# Why this guard evaluates instead of greps
+# ─────────────────────────────────────────────────────────────────────
+# A grep for `${ghcr_pat:0:8}` is worthless: it passes the moment the
+# line is rewritten to `$(printf '%s' "$pat" | cut -c1-8)`, or
+# `${pat::8}`, or `${pat:0:4}${pat:4:4}`, or awk substr. It asserts on
+# the KEY (the spelling of one expression) and not on the VALUE (what
+# actually lands in the log).
+#
+# So this guard runs each candidate output statement for real. Every
+# credential-named variable in the statement is bound to a 40-character
+# SENTINEL, the statement is executed in an isolated bash, and the
+# emitted bytes are inspected for sentinel material:
+#
+#   * ZERO sentinel bytes emitted  → PASS. `(len=${#pat})` prints "40";
+#     `user=${user}` prints a non-credential value. Both are the
+#     diagnostics an operator actually needs — "was a credential
+#     present, was it the right length, for which account" — and none
+#     of them costs a byte of the secret.
+#
+#   * a PARTIAL run of sentinel bytes (>=4 chars, but not the whole
+#     sentinel) → FAIL. This is exactly and only the #5467 shape. You
+#     cannot emit part of a variable's value by accident: something in
+#     the statement truncated it. The detector does not care HOW —
+#     :0:N, ::N, cut -c, head -c, awk substr, a sed character class, or
+#     an expression nobody has invented yet all land in the same net.
+#
+#   * the FULL sentinel emitted → NOT failed here, deliberately. Full
+#     interpolation is overwhelmingly a *name* being logged
+#     (`TLS_SECRET`, `SOURCE_SECRET`, `PAT_SOURCE_KEY` — Kubernetes
+#     object names, not values) or a value-producing `printf '%s:%s'`
+#     feeding skopeo --src-creds, which is not a log line at all. There
+#     are 139 such statements in this repo and flagging them would make
+#     this guard noise nobody reads. Partial-run detection is immune to
+#     that entire false-positive population by construction: a name
+#     variable interpolated whole emits the WHOLE sentinel, never a
+#     fragment of it.
+#
+# Statements that cannot be safely executed (they contain a command
+# substitution, so running them would run arbitrary commands) are not
+# executed. They fall back to a static truncation-idiom check against
+# the credential variable, and are counted in the report so the
+# unevaluated population stays visible rather than silently passing.
+#
+# ─────────────────────────────────────────────────────────────────────
+# Waivers
+# ─────────────────────────────────────────────────────────────────────
+# A genuine false positive takes an inline `# credlog-ok: <reason>` on
+# the offending line. Waivers are reported in the summary — an
+# unreviewed waiver pile is the next version of this bug.
+#
+# Self-test: `--self-test` runs the detector over scripts/tests/
+# fixtures that ship a known-BAD and a known-GOOD line and asserts the
+# detector goes red on one and green on the other. This is the
+# vacuity check: a scanner that cannot go red is not a guard.
+#
+# Refs #5467
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+MODE="scan"
+case "${1:-}" in
+  --self-test) MODE="self-test" ;;
+  "") ;;
+  *) echo "usage: $0 [--self-test]" >&2; exit 2 ;;
+esac
+
+export CREDLOG_MODE="${MODE}"
+export CREDLOG_ROOT="${REPO_ROOT}"
+
+python3 - <<'PY'
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.environ["CREDLOG_ROOT"]
+MODE = os.environ["CREDLOG_MODE"]
+
+# 40 chars, uppercase-only, no digits (so `${#var}` -> "40" can never be
+# mistaken for sentinel material) and no common English trigrams (so a
+# 4-char window cannot collide with ordinary log prose).
+SENTINEL = "ZQXJVKWFYHBGMPTZQXJVKWFYHBGMPTZQXJVKWFYH"
+WINDOW = 4
+
+# Credential-VALUE-shaped variable names. Deliberately broad on the stem
+# and narrow on the suffix: `TLS_SECRET` is in scope for evaluation, and
+# is then cleared by the partial-run rule rather than by a name
+# allowlist that would rot.
+CRED_STEM = re.compile(
+    r"(?:^|_)(pat|token|secret|password|passwd|pwd|pw|apikey|credential|"
+    r"creds?|privkey|jwt|bearer|sessionkey)(?:$|_)",
+    re.I,
+)
+# Also catch camelCase / lowercase joined spellings (ghcr_pat, moth_pat,
+# clientSecret, apiKey, rootToken, adminPassword).
+CRED_CAMEL = re.compile(
+    r"(pat|token|secret|password|passwd|apikey|credential|privkey|jwt|bearer)",
+    re.I,
+)
+
+VAR_RE = re.compile(
+    r"\$\{#?([A-Za-z_][A-Za-z0-9_]*)[^}]*\}|\$([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+# Truncation idioms, for the statically-checked (unevaluable) population.
+TRUNC_STATIC = re.compile(
+    r":\s*-?\d+\s*:\s*-?\d+\}"          # ${v:0:8}
+    r"|::\s*-?\d+\}"                     # ${v::8}
+    r"|\bcut\s+-c"                       # | cut -c1-8
+    r"|\bhead\s+-c"                       # | head -c8
+    r"|\bsubstr\s*\("                     # awk substr(v,1,8)
+    r"|%\.\d+s"                           # printf '%.8s'
+    r"|\.slice\s*\(\s*0"                  # js .slice(0,8)
+    r"|\[\s*:\s*\d+\s*\]",                # py v[:8]
+)
+
+WAIVER = re.compile(r"#\s*credlog-ok\b")
+
+SKIP_DIRS = {
+    ".git", "node_modules", ".claude", "vendor", "dist", "build",
+    ".venv", "__pycache__", "graphify-out", "artifacts",
+}
+
+SCAN_YAML_UNDER = ("platform/", "products/", "clusters/", "core/",
+                   "infra/", ".github/")
+
+# The self-test fixtures are scanned explicitly by --self-test (which walks
+# them directly). They must NOT be part of the repo-wide scan: the bad
+# fixture is deliberately, permanently defective.
+FIXTURE_PREFIX = os.path.join("scripts", "tests", "credlog-fixtures")
+
+
+def in_scope(rel: str) -> bool:
+    if rel.startswith(FIXTURE_PREFIX):
+        return False
+    if rel.endswith(".sh"):
+        return True
+    if rel.endswith((".yaml", ".yml", ".tpl", ".tftpl")):
+        return rel.startswith(SCAN_YAML_UNDER)
+    return False
+
+
+def collect_files(root: str):
+    out = []
+    for base, dirs, names in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for n in names:
+            rel = os.path.relpath(os.path.join(base, n), root)
+            if in_scope(rel):
+                out.append(rel)
+    return sorted(out)
+
+
+def is_cred(name: str) -> bool:
+    return bool(CRED_STEM.search(name) or CRED_CAMEL.search(name))
+
+
+ASSIGN_RE = re.compile(
+    r"^\s*(?:export\s+|local\s+|readonly\s+|declare\s+-\S+\s+)?"
+    r"([A-Za-z_][A-Za-z0-9_]*)=(.+)$"
+)
+
+
+def cred_vars_by_assignment(lines):
+    """A variable's NAME is not the only evidence that it holds a secret.
+
+    `GRAFANA_EMPTY=$(extract_secret ... .secret)` holds a Keycloak client
+    secret under a name no name-regex will ever guess. So take the
+    assignment line as evidence too: if the right-hand side mentions a
+    credential, the variable is treated as credential-carrying for the rest
+    of the file.
+
+    Widening the CANDIDATE set is nearly free here — the partial-run rule,
+    not the name filter, is what actually decides pass/fail. Broad
+    selection, sharp verdict."""
+    out = set()
+    for line in lines:
+        if line.lstrip().startswith("#"):
+            continue
+        m = ASSIGN_RE.match(line)
+        if not m:
+            continue
+        name, rhs = m.group(1), m.group(2)
+        if CRED_CAMEL.search(rhs):
+            out.add(name)
+    return out
+
+
+def split_statement(line: str, start: int) -> str:
+    """Take the echo/printf statement beginning at `start`, stopping at the
+    first UNQUOTED shell separator or redirection. Quote-aware so a `;` or
+    `|` inside the message text does not truncate the statement."""
+    i = start
+    n = len(line)
+    sq = dq = False
+    while i < n:
+        c = line[i]
+        if c == "\\" and not sq:
+            i += 2
+            continue
+        if c == "'" and not dq:
+            sq = not sq
+        elif c == '"' and not sq:
+            dq = not dq
+        elif not sq and not dq:
+            if c in ";|&":
+                break
+            if c in "<>":
+                break
+        i += 1
+    return line[start:i].rstrip()
+
+
+CMD_START = re.compile(r"(?:^|[;&|(]|\bthen\b|\bdo\b|\belse\b|\{)\s*(echo|printf)(?=\s|$)")
+
+
+def statements(line: str):
+    for m in CMD_START.finditer(line):
+        yield m.start(1), split_statement(line, m.start(1))
+
+
+def evaluate(stmt: str, cred_var: str, other_vars):
+    """Bind cred_var to SENTINEL, everything else to a benign value, run the
+    statement, return emitted bytes. None if it could not be executed."""
+    assigns = ["%s=%s" % (cred_var, SENTINEL)]
+    for v in other_vars:
+        if v == cred_var:
+            continue
+        assigns.append("%s=benign" % v)
+    script = "\n".join(assigns) + "\n" + stmt + "\n"
+    try:
+        p = subprocess.run(
+            ["bash", "--norc", "--noprofile", "-c", script],
+            capture_output=True, text=True, timeout=10,
+            env={"PATH": "/usr/bin:/bin", "LC_ALL": "C"},
+        )
+    except Exception:
+        return None
+    if p.returncode != 0 and not p.stdout and not p.stderr:
+        return None
+    return (p.stdout or "") + (p.stderr or "")
+
+
+def sentinel_bytes(out: str):
+    """(full_hit, partial_hit) — partial means a >=WINDOW-char run of the
+    sentinel appears but the whole sentinel does not."""
+    if SENTINEL in out:
+        return True, False
+    for i in range(0, len(SENTINEL) - WINDOW + 1):
+        if SENTINEL[i:i + WINDOW] in out:
+            return False, True
+    return False, False
+
+
+def scan(root: str):
+    failures, waivers, unevaluated, checked = [], [], [], 0
+    for rel in collect_files(root):
+        path = os.path.join(root, rel)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                lines = fh.read().splitlines()
+        except OSError:
+            continue
+        by_assign = cred_vars_by_assignment(lines)
+        for lineno, line in enumerate(lines, 1):
+            stripped = line.lstrip()
+            # A shell/YAML comment cannot emit anything. The #5467
+            # postmortem comments quote the defective expression verbatim
+            # and must not re-trip the guard that documents them.
+            if stripped.startswith("#"):
+                continue
+            for _, stmt in statements(line):
+                names = set()
+                for m in VAR_RE.finditer(stmt):
+                    names.add(m.group(1) or m.group(2))
+                creds = sorted(n for n in names
+                               if is_cred(n) or n in by_assign)
+                if not creds:
+                    continue
+                if WAIVER.search(line):
+                    waivers.append((rel, lineno, creds, line.strip()))
+                    continue
+                checked += 1
+                unsafe = "$(" in stmt or "`" in stmt
+                for cv in creds:
+                    if unsafe:
+                        if TRUNC_STATIC.search(stmt):
+                            failures.append(
+                                (rel, lineno, cv, "static: truncation idiom "
+                                 "applied to a credential inside a command "
+                                 "substitution", stmt))
+                        else:
+                            unevaluated.append((rel, lineno, cv, stmt))
+                        continue
+                    out = evaluate(stmt, cv, names)
+                    if out is None:
+                        unevaluated.append((rel, lineno, cv, stmt))
+                        continue
+                    full, partial = sentinel_bytes(out)
+                    if partial:
+                        leaked = "".join(
+                            ch for ch in out if ch in set(SENTINEL))
+                        failures.append(
+                            (rel, lineno, cv,
+                             "emitted %d chars of the credential value"
+                             % len(leaked), stmt))
+    return failures, waivers, unevaluated, checked
+
+
+def report(failures, waivers, unevaluated, checked, root_label):
+    print("=== #5467 credential-prefix logging guard (%s) ===" % root_label)
+    print("output statements interpolating a credential-named variable: %d"
+          % checked)
+    print("statically-checked (command substitution, not executed):    %d"
+          % len(unevaluated))
+    print("waived (# credlog-ok):                                      %d"
+          % len(waivers))
+    for rel, lineno, creds, text in waivers:
+        print("  WAIVED %s:%d  vars=%s" % (rel, lineno, ",".join(creds)))
+        print("         %s" % text[:160])
+    if failures:
+        print("")
+        print("FAIL: %d statement(s) emit part of a credential value into a "
+              "log line." % len(failures))
+        for rel, lineno, cv, why, stmt in failures:
+            print("")
+            print("  %s:%d" % (rel, lineno))
+            print("    variable : %s" % cv)
+            print("    verdict  : %s" % why)
+            print("    statement: %s" % stmt[:200])
+        print("")
+        print("Secret VALUES are never printed — lengths and hashes only.")
+        print("Print `(len=${#var})` and the non-secret account/user instead;")
+        print("that preserves every bit of the diagnostic (was a credential")
+        print("present, is it the right length, whose is it) at zero cost.")
+        return 1
+    print("")
+    print("PASS: no statement emits a fragment of a credential value.")
+    return 0
+
+
+def self_test():
+    """Vacuity check. The detector must go RED on a known-bad fixture and
+    GREEN on a known-good one. A guard that cannot fail is not a guard."""
+    fixtures = os.path.join(ROOT, "scripts", "tests", "credlog-fixtures")
+    bad = os.path.join(fixtures, "bad")
+    good = os.path.join(fixtures, "good")
+    ok = True
+
+    print("=== self-test: detector must go RED on the bad fixture ===")
+    f, w, u, c = scan(bad)
+    rc = report(f, w, u, c, "fixture/bad")
+    if rc == 0:
+        print("SELF-TEST FAIL: the bad fixture did NOT trip the detector — "
+              "this guard is vacuous.")
+        ok = False
+    else:
+        print("self-test: bad fixture tripped %d finding(s) — detector is "
+              "live." % len(f))
+
+    print("")
+    print("=== self-test: detector must stay GREEN on the good fixture ===")
+    f2, w2, u2, c2 = scan(good)
+    rc2 = report(f2, w2, u2, c2, "fixture/good")
+    if rc2 != 0:
+        print("SELF-TEST FAIL: the good fixture tripped the detector — "
+              "length-only logging must never be flagged.")
+        ok = False
+    else:
+        print("self-test: good fixture stayed green over %d credential "
+              "statement(s) — the control holds." % c2)
+
+    if c2 == 0:
+        print("SELF-TEST FAIL: the good fixture exercised ZERO credential "
+              "statements — the control proves nothing.")
+        ok = False
+
+    print("")
+    if not ok:
+        print("SELF-TEST: FAILED")
+        return 1
+    print("SELF-TEST: PASSED (red on bad, green on good)")
+    return 0
+
+
+if MODE == "self-test":
+    sys.exit(self_test())
+
+sys.exit(report(*scan(ROOT), root_label="repo"))
+PY

--- a/scripts/tests/credlog-fixtures/bad/known-bad.sh
+++ b/scripts/tests/credlog-fixtures/bad/known-bad.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# FIXTURE — known-BAD credential-prefix logging. NOT executed by anything;
+# it exists so scripts/check-no-credential-prefix-logging.sh --self-test can
+# prove the detector goes RED. Every value below is obviously fake.
+#
+# This file must NEVER be "fixed". If a cleanup pass makes these lines safe,
+# the guard silently becomes vacuous and #5467 walks straight back in.
+set -euo pipefail
+
+ghcr_pat="FAKE-NOT-A-TOKEN-fixture-value-only-0000"
+ghcr_user="fake-bot"
+api_token="fake-token-value-for-fixture-only"
+admin_password="fake-password-for-fixture-only"
+client_secret="fake-client-secret-for-fixture-only"
+
+# 1. The literal #5467 shape — bash substring prefix.
+echo "[fixture] ghcr.io auth extracted: user=${ghcr_user} pat=${ghcr_pat:0:8}... (len=${#ghcr_pat})"
+
+# 2. The same disclosure with the offset omitted — a rewrite that any
+#    grep-for-":0:8" guard would sail straight past.
+echo "[fixture] token head=${api_token::6}"
+
+# 3. Suffix disclosure. Equally a secret; equally caught, because the
+#    detector looks at emitted BYTES, not at the spelling of the operator.
+echo "[fixture] password tail=${admin_password: -5}"
+
+# 4. Split across two truncations so no single expression looks like a
+#    prefix — still emits 8 real characters.
+echo "[fixture] secret=${client_secret:0:4}${client_secret:4:4}"
+
+# 5. printf precision, a form with no colon in it at all.
+printf '[fixture] pat=%.8s\n' "${ghcr_pat}"

--- a/scripts/tests/credlog-fixtures/good/known-good.sh
+++ b/scripts/tests/credlog-fixtures/good/known-good.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# FIXTURE — known-GOOD credential logging: the CONTROL.
+#
+# Every line here interpolates a credential-named variable and every line is
+# legitimate. The guard must stay GREEN over all of them, on the pre-fix tree
+# and the post-fix tree alike. If a future tightening of the detector starts
+# flagging these, the detector has become noise and will be ignored — which is
+# how #5467 survived in the first place.
+#
+# All values are obviously fake.
+set -euo pipefail
+
+ghcr_pat="FAKE-NOT-A-TOKEN-fixture-value-only-0000"
+ghcr_user="fake-bot"
+admin_password="fake-password-for-fixture-only"
+
+# The canonical safe shape — the fix #5467 landed. Length + account only.
+# An operator debugging a pull failure learns everything they need: a
+# credential WAS extracted, it is the right length, and it belongs to this
+# account. Zero bytes of it are disclosed.
+echo "[fixture] ghcr.io auth extracted: user=${ghcr_user} (len=${#ghcr_pat})"
+
+# Set/unset verdict without touching the value.
+if [ -n "${admin_password}" ]; then
+  echo "[fixture] admin password: set (len=${#admin_password})"
+else
+  echo "[fixture] admin password: UNSET"
+fi
+
+# Kubernetes object NAMES that merely happen to match the credential
+# name-stem. These are not values and interpolate whole; the partial-run
+# rule must let them through untouched.
+TLS_SECRET="my-webhook-tls"
+SOURCE_SECRET="harbor-database"
+PAT_SOURCE_KEY="token"
+echo "[fixture] waiting for secret ${TLS_SECRET}"
+echo "[fixture] synced from ${SOURCE_SECRET} key ${PAT_SOURCE_KEY}"
+
+# A hash is not a prefix: it is a one-way digest, discloses no secret
+# material, and is the sanctioned way to compare two credentials across
+# logs. Emitting it whole must not be flagged.
+pat_sha="$(printf '%s' "${ghcr_pat}" | sha256sum | cut -d' ' -f1)"
+echo "[fixture] pat sha256=${pat_sha}"


### PR DESCRIPTION
## Status of #5467 itself: REFUTED as an open defect on `main`

The line the issue names is already fixed. PR #5680 (sha `3cb067bb6`, 2026-08-05, bp-self-sovereign-cutover 0.1.169) landed it, and `main` today reads:

    platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml:422
    echo "[harbor-prewarm] ghcr.io auth extracted: user=${ghcr_user} (len=${#ghcr_pat})"

Classification per the dispatch: **(b) fixed in `main`, undeployed.** hw292 runs 2026-08-02 images, older than 0.1.169, so a cutover there would still show the old line.

What was *not* fixed is the **class**. Nothing prevented the next instance, and there already was a next one, three steps later in the same chart.

## Measured exposure of the original defect

| | |
|---|---|
| Characters emitted | 8 of a 40-char GHCR PAT. 4 are the `ghp_` type tag, so **4 characters of real secret material**, plus positive confirmation of token type, exact length, and owning account |
| Line | `03-harbor-prewarm-job.yaml:581` (pre-fix numbering), now `:422` |
| Level | plain `echo` to stdout — the pod's normal log stream, no debug flag, every cutover, every Sovereign |
| Customer-readable after handover? | **Yes, and not only via kubectl.** `GET /api/v1/sovereigns/{id}/k8s/logs/{ns}/{pod}/{container}` streams arbitrary pod logs, and `viewerTierAllowsLogs()` in `products/catalyst/bootstrap/api/internal/handler/k8s_logs.go:260` returns `true` for any authenticated session. So the fragment was readable from the Sovereign console by any signed-in user for as long as the Job pod was retained |

Proportionate reading: our own pre-live infra, nothing that halts a walk, not an incident. Worth removing, worth guarding, and the same idiom did in fact exist elsewhere — which is the actual finding here.

## The guard: `scripts/check-no-credential-prefix-logging.sh`

A grep for `${ghcr_pat:0:8}` is worthless. It passes the moment the line becomes `$(printf '%s' "$pat" | cut -c1-8)`, or `${pat::8}`, or `${pat:0:4}${pat:4:4}`. It asserts on the spelling of one expression, not on what lands in the log. **The step-09 instance below is the proof: it contains no `:0:N`, no `cut -c`, no `%.8s`, and every grep-shaped sweep for the step-03 idiom walks straight past it.**

So this guard executes. For each output statement that interpolates a credential-carrying variable, it binds that variable to a 40-character sentinel, runs the statement in an isolated bash, and inspects the emitted bytes:

- **zero sentinel bytes** → pass. `(len=${#pat})` prints `40`; `user=${user}` prints a non-secret. That is the whole diagnostic an operator needs — was a credential present, is it the right length, whose is it — at zero disclosure.
- **a PARTIAL run of sentinel bytes** → **FAIL**. You cannot emit part of a value by accident; something truncated it. The detector does not care how.
- **the FULL sentinel** → pass, deliberately. That population is Secret *names* (`TLS_SECRET`, `SOURCE_SECRET`, `PAT_SOURCE_KEY`) and `printf '%s:%s'` feeding `skopeo --src-creds`, which is not a log line at all. There are 531 such statements in this repo; flagging them would make the guard noise nobody reads, and partial-run detection is immune to that entire class by construction — a name interpolated whole emits the *whole* sentinel, never a fragment.

Candidate selection is broad, the verdict is sharp. A variable counts as credential-carrying if its **name** matches *or* its **assignment line** mentions a credential — `GRAFANA_EMPTY=$(extract_secret ... .secret)` holds a Keycloak client secret under a name no name-regex would ever guess, and that widening is what caught two of the findings below. Widening the candidate set is nearly free because the partial-run rule, not the name filter, decides pass/fail.

Statements containing a command substitution are not executed (running them would run arbitrary commands). They fall back to a static truncation-idiom check and are **counted in the report** rather than silently passing — currently 40, all manually reviewed as benign (object names, `[ -z "$vtok" ] && echo yes` set/unset verdicts, HR readback values).

## Guard evidence — both directions

### 1. It fails RED on the pre-fix tree

Source fixes reverted, guard kept, verbatim:

```
=== #5467 credential-prefix logging guard (repo) ===
output statements interpolating a credential-named variable: 531
statically-checked (command substitution, not executed):    40
waived (# credlog-ok):                                      0

FAIL: 6 statement(s) emit part of a credential value into a log line.

  platform/keycloak/chart/tests/admin-password-stable.sh:45
    variable : PW
    verdict  : emitted 7 chars of the credential value
    statement: echo "PASS 1: keycloak-admin Secret renders admin-password (${PW:0:6}...)"

  platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh:35
    variable : GRAFANA_EMPTY
    verdict  : emitted 9 chars of the credential value
    statement: echo "PASS 1: empty-salt grafana secret = ${GRAFANA_EMPTY:0:8}..."

  platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh:43
    variable : GRAFANA_SALTED
    verdict  : emitted 9 chars of the credential value
    statement: echo "PASS 2: salted grafana secret = ${GRAFANA_SALTED:0:8}... (differs from empty)"

  platform/keycloak/chart/tests/g117-w2c4-per-org-realm.sh:220
    variable : secret_a
    verdict  : emitted 9 chars of the credential value
    statement: echo "  PASS (acme secret=${secret_a:0:8}…  beta-org secret=${secret_b:0:8}…  distinct)"

  platform/keycloak/chart/tests/g117-w2c4-per-org-realm.sh:220
    variable : secret_b
    verdict  : emitted 9 chars of the credential value
    statement: echo "  PASS (acme secret=${secret_a:0:8}…  beta-org secret=${secret_b:0:8}…  distinct)"

  platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml:271
    variable : new_token
    verdict  : emitted 5 chars of the credential value
    statement: echo "[gitea-token-mint] minted token: ...${new_token##???????????????????????????????????}" 2

Secret VALUES are never printed — lengths and hashes only.
GUARD EXIT CODE = 1
```

### 2. It catches the ORIGINAL #5467 line

The decisive regression check — re-introduce the exact pre-#5680 statement and re-run:

```
re-introduced the ORIGINAL #5467 line
  platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml:422
    variable : ghcr_pat
    verdict  : emitted 8 chars of the credential value
    statement: echo "[harbor-prewarm] ghcr.io auth extracted: user=${ghcr_user} pat=${ghcr_pat:0:8}... (len=${#ghcr_pat})"
EXIT=1
```

Reverted immediately; `03-harbor-prewarm-job.yaml` is unmodified in this PR.

### 3. It passes on the post-fix tree

```
=== #5467 credential-prefix logging guard (repo) ===
output statements interpolating a credential-named variable: 531
statically-checked (command substitution, not executed):    40
waived (# credlog-ok):                                      0

PASS: no statement emits a fragment of a credential value.
```

### 4. Vacuity check — the CONTROL, passing on BOTH trees

`--self-test` is a separate CI job that the scan job `needs:`, so a green scan can never be reported off a broken detector. The bad fixture carries five *different* truncation spellings; the good fixture carries six legitimate credential statements the guard must never flag.

```
=== self-test: detector must go RED on the bad fixture ===
FAIL: 5 statement(s) emit part of a credential value into a log line.
  known-bad.sh:17  ghcr_pat        emitted 8 chars   ${ghcr_pat:0:8}
  known-bad.sh:21  api_token       emitted 6 chars   ${api_token::6}
  known-bad.sh:25  admin_password  emitted 5 chars   ${admin_password: -5}
  known-bad.sh:29  client_secret   emitted 8 chars   ${client_secret:0:4}${client_secret:4:4}
  known-bad.sh:32  ghcr_pat        emitted 8 chars   printf '[fixture] pat=%.8s\n'
self-test: bad fixture tripped 5 finding(s) — detector is live.

=== self-test: detector must stay GREEN on the good fixture ===
PASS: no statement emits a fragment of a credential value.
self-test: good fixture stayed green over 6 credential statement(s) — the control holds.

SELF-TEST: PASSED (red on bad, green on good)
```

The good fixture is the control that passes on both trees: it contains `(len=${#ghcr_pat})`, a set/unset verdict, three Secret-name interpolations, and a full sha256 — none of which are ever flagged, before or after the fix.

Three of the four occurrences of `${VAR:0:N}` that a naive grep *would* find are in the bad-fixture population; two of the five real findings (`GRAFANA_EMPTY`, `GRAFANA_SALTED`) are invisible to a name-based filter, and the sixth (`new_token`) is invisible to an idiom-based one.

**Confirm the check RUNS**: the workflow `paths:` filter covers `platform/**`, `products/**`, `clusters/**`, `core/**`, `infra/**`, `scripts/**`, `tools/**`, `.github/workflows/**` — every tree the scan reads. The files changed in this PR match it.

## Full sweep list

Every truncation idiom in the repo, and its disposition. Sweep covered `${VAR:0:N}`, `${VAR::N}`, `${VAR: -N}`, `##`/`%%` glob-strips, `cut -c`, `head -c`, `printf %.Ns`, `awk substr`, `.slice(0,N)`, `[:N]` across `platform/`, `products/`, `core/`, `scripts/`, `tools/`, `clusters/`, `infra/`, `.github/`.

**Fixed (5) — genuine credential material:**

| Location | Emitted | Verdict |
|---|---|---|
| `self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml:271` | last **5** chars of a live minted Gitea API token | **Production.** Found only by the executing guard |
| `keycloak/chart/tests/admin-password-stable.sh:45` | 6 chars of the rendered Keycloak admin password | Public CI logs |
| `keycloak/chart/tests/g117-5b-secret-rotation-salt.sh:35` | 8 chars of the derived grafana client secret | Public CI logs |
| `keycloak/chart/tests/g117-5b-secret-rotation-salt.sh:43` | 8 chars of the salted grafana client secret | Public CI logs |
| `keycloak/chart/tests/g117-w2c4-per-org-realm.sh:220` | 8 chars each of **two** per-Org broker secrets | Public CI logs |

Every one of those test assertions already compared the values in **full**, so the prefix was never load-bearing — it was decoration that cost secret material. All four suites re-run green with `len=` reporting:

```
PASS 1: keycloak-admin Secret renders admin-password (len=32)
PASS 1: empty-salt grafana secret derived (len=64)
PASS 2: salted grafana secret (len=64) differs from empty-salt
  PASS (acme len=64  beta-org len=64  distinct)
```

**Left alone (deliberately, with reason):**

| Location | Why it stays |
|---|---|
| `products/axon/scripts/e2e-test.sh:30,42` — `${body:0:200}` | HTTP response body, not a credential. Truncation is the point (log volume) |
| `.github/workflows/*` — `$GITHUB_SHA \| head -c 7` (28 sites) | Git SHA. Not secret |
| `scripts/check-no-*.sh` — `${trimmed:0:1}` | YAML comment-char test on parsed lines |
| `products/catalyst/**` — `id[:8]`, `uid.slice(0,8)`, `dep[:8]` (~25 sites) | Deployment/UID short-forms for object names and UI labels. Not secret |
| `openova-flow/server/internal/store/pgstore.go:103` — `sha256[:8]` | Truncated **hash**, not a truncated secret |
| `self-sovereign-cutover/**` and `catalyst/**` `sed -E "s,${PAT}+,REDACTED,g"` | These *consume* the credential to redact it out of error bodies — the opposite of the defect. The guard passes them because they emit zero sentinel bytes |
| 40 command-substitution statements | Reviewed individually; all object names, set/unset verdicts, or HR readback values |

The `${ghcr_pat:0:8}` strings remaining in `Chart.yaml:141` and `03-harbor-prewarm-job.yaml:416` are inside the postmortem **comments** that document the fix. The guard skips comment lines, so the documentation of the defect cannot re-trip the guard that documents it.

## Lockstep + budget

bp-self-sovereign-cutover **0.1.172 → 0.1.173** across four sites: `chart/Chart.yaml`, `blueprint.yaml`, `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`, `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (both `spec.version` and `source.version`).

The keycloak changes are `chart/tests/` only — no rendered-output change, so no bp-keycloak version bump, matching the precedent of `c18191116` (34 chart-test scripts across many charts, no Chart.yaml bumps).

```
scripts/check-bootstrap-kit-pin-sync.sh    PASS: all bootstrap-kit pins are in sync (67 pairs)
scripts/check-catalog-seed-lockstep.sh     PASS: checked 68, fail 0
go test ./tests/e2e/bootstrap-kit/...      ok  0.590s
helm lint platform/self-sovereign-cutover  1 chart linted, 0 failed
```

**MAX_ARG_STRLEN**: I added explanatory comment lines to the step-09 script, which count toward the arg budget.

```
arg-strlen-guard: PASS — 13 step containers, every inline arg/env under 110000 B

step-09  baseline 11423 B  ->  now 12028 B   (+605 B)   margin 97972 B
step-06  98424 B unchanged — still the tightest at 11576 B margin
step-08  94901 B unchanged
```

Step-09 is nowhere near the wall; the tightest step is untouched.

Cutover chart suites re-run: `arg-strlen-guard.sh`, `step06-pivot-readback.sh` (13 passed / 0 failed), `flux-source-host-lint.sh`, `single-platform-copy.sh` — all pass.

## CI note — `ghcr-pin-existence` is red, and is expected to be

`bp-self-sovereign-cutover:0.1.173` does not exist on `ghcr.io/openova-io` yet: `blueprint-release.yaml` publishes the tag on push to `main`, so any PR that bumps a chart pin necessarily fails this gate until it merges. Same on the merged #5680, verified rather than assumed:

    gh api repos/openova-io/openova/commits/3cb067bb6/check-runs
    ghcr-pin-existence -> failure

Not a candidate for `scripts/expected-unpublished-catalog-seed-pins.yaml` — that register is for charts with no source to publish, and its invariant 3 makes an entry go red the moment the chart *is* published, so registering an in-flight bump would rot immediately.

Every other gate is green, including `run the release writer and assert all five sites converge`.

## Not claimed

No runtime proof. Both fixed lines are deploy-gated: proving step-09 emits `set (len=40)` with no token tail needs a cutover on a Sovereign carrying 0.1.173. That rides the next fresh-prov cutover, and #5467 stays **open** with a falsifiable assertion posted as a comment.

No NodePorts were created or relied on. No real secret, token, or token prefix appears in this PR, its commits, the fixtures, or the guard — fixture values are `FAKE-NOT-A-TOKEN-fixture-value-only-0000` and similar, deliberately not GitHub-token-shaped so push protection has nothing to match.

Refs #5467
