### PR TITLE
test(catalyst-api): pin the per-Org console listener by rendered name+hostname in EVERY region (Refs #5635)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile_5635_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile_5635_test.go
@@ -19,8 +19,11 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
+	"sort"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
 )
@@ -114,18 +118,77 @@ func orgCRWithSource(slug, parentDomain, source string) *unstructured.Unstructur
 	}}
 }
 
+// consoleListenersAppliedTo returns the Gateway listeners ONE region's client
+// actually received, as rendered listener NAME -> rendered hostname VALUE,
+// read out of the SSA apply payloads themselves.
+//
+// Why the payload and not dyn.Actions() presence: the defect this file guards
+// is per-Org — on hw292 region-b carried `console-https-r17probe` while
+// `console-https-uatco` was absent, so ~50% of fresh TCP connections to
+// console.uatco.omani.homes were reset at the TLS handshake. A check that only
+// asks "was the console Gateway patched in this region" answers YES on that
+// exact cluster state, because ANOTHER Org's patch satisfies it. Reading the
+// applied listeners by name+hostname is what makes the assertion able to go red
+// on the live defect.
+func consoleListenersAppliedTo(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]string {
+	t.Helper()
+	applied := map[string]string{}
+	for _, a := range dyn.Actions() {
+		if a.GetResource() != consoleGatewayGVR || a.GetVerb() != "patch" {
+			continue
+		}
+		pa, ok := a.(k8stesting.PatchAction)
+		if !ok || pa.GetName() != consoleGatewayName {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(pa.GetPatch(), &obj); err != nil {
+			t.Fatalf("unmarshal console Gateway apply payload: %v", err)
+		}
+		listeners, found, err := unstructured.NestedSlice(obj, "spec", "listeners")
+		if err != nil || !found {
+			continue
+		}
+		for _, l := range listeners {
+			lm, ok := l.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, _ := lm["name"].(string)
+			hostname, _ := lm["hostname"].(string)
+			if name != "" {
+				applied[name] = hostname
+			}
+		}
+	}
+	return applied
+}
+
+// orgWildcardForConsoleHost derives the per-Org wildcard a console host must be
+// served by: console.<slug>.<parent> -> *.<slug>.<parent>. Pure string work,
+// deliberately NOT a call into resolveOrgConsoleTLSNames — a guard that asks the
+// production resolver what to expect agrees with the emitter by construction and
+// cannot catch the emitter rendering the wrong hostname.
+func orgWildcardForConsoleHost(consoleHost string) string {
+	_, zone, found := strings.Cut(consoleHost, ".")
+	if !found {
+		return ""
+	}
+	return "*." + zone
+}
+
 // consoleSurfacePresent reports whether a region cluster carries BOTH halves of
-// an Org's console gateway surface: a Gateway listener SSA patch was issued for
-// this Org's listener pair, and an HTTPRoute in catalyst-system serves the Org's
-// console host (under EITHER producer's name — the gateway edge does not care
-// which name serves the host, only that one does).
+// an Org's console gateway surface: a Gateway listener SSA patch was issued
+// carrying THIS Org's wildcard hostname, and an HTTPRoute in catalyst-system
+// serves the Org's console host (under EITHER producer's name — the gateway edge
+// does not care which name serves the host, only that one does).
 func consoleSurfacePresent(t *testing.T, dyn *dynamicfake.FakeDynamicClient, consoleHost string) (listener bool, route string) {
 	t.Helper()
-	for _, a := range dyn.Actions() {
-		if a.GetResource() == consoleGatewayGVR && a.GetVerb() == "patch" {
-			if pa, ok := a.(interface{ GetName() string }); ok && pa.GetName() == consoleGatewayName {
-				listener = true
-			}
+	wildcard := orgWildcardForConsoleHost(consoleHost)
+	for _, hostname := range consoleListenersAppliedTo(t, dyn) {
+		if hostname == wildcard {
+			listener = true
+			break
 		}
 	}
 	list, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
@@ -297,6 +360,92 @@ func TestReconcileOrgConsoleTLSFromOrgCRs_BackfillsMissingSecondaryRegion(t *tes
 	if len(serving) != 1 || serving[0] != orgCtrlRoute {
 		t.Errorf("host region routes for %s = %v, want exactly [%s] (adopted, not duplicated)", host, serving, orgCtrlRoute)
 	}
+}
+
+// TestReconcileOrgConsoleTLSFromOrgCRs_EveryRegionCarriesEveryOrgsListenerPair
+// — #5635 lock 3: the LISTENER level, pinned by rendered value, in every region.
+//
+// This is hw292's live state on 2026-08-06, read off both regions'
+// kube-system/cilium-gateway-console:
+//
+//	region-a  console-https-uatco     *.uatco.omani.homes      <- present
+//	          console-http-uatco      *.uatco.omani.homes
+//	region-b  console-https-r17probe  *.r17probe.omani.homes   <- a DIFFERENT Org
+//	          console-http-r17probe   *.r17probe.omani.homes
+//	region-b  (no listener for *.uatco.omani.homes)
+//
+// The shared console EIP 212.72.24.85 round-robins both regions' hostNetwork
+// cilium-envoy, so a fresh TCP connection landing on region-b finds NO listener
+// matching SNI console.uatco.omani.homes and is reset during the TLS handshake
+// — measured 8/16 that day, failures all curl rc=35, against a same-EIP
+// console.hw292.omani.works control at 10/10.
+//
+// WHY THIS TEST EXISTS SEPARATELY from the two locks above. Region-b in that
+// capture HAS per-Org listeners and HAS been patched — just for the wrong Org.
+// Any assertion phrased as "a per-Org listener exists in this region", "the
+// console Gateway was patched here", or a COUNT of listeners is satisfied by
+// that exact broken state. Only pinning the rendered name AND hostname, per Org,
+// per region, can go red on it. Both are asserted against literals rather than
+// against resolveOrgConsoleTLSNames, so an emitter that renders a wrong-but-
+// self-consistent hostname is still caught.
+func TestReconcileOrgConsoleTLSFromOrgCRs_EveryRegionCarriesEveryOrgsListenerPair(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+
+	hostDyn := fakeDynForOrgConsoleReconcile(t,
+		funnelOrgCR("uatco", "omani.homes"), // the funnel door — hw292's failing Org
+		bssOrgCR("r17probe", "omani.homes"), // the BSS door — hw292's working Org
+	)
+	secDyn := fakeDynForOrgConsoleReconcile(t)
+	hostCore := k8sfake.NewSimpleClientset(
+		issuedOrgWildcardSecret("org-wildcard-tls-uatco-omani-homes"),
+		issuedOrgWildcardSecret("org-wildcard-tls-r17probe-omani-homes"),
+	)
+	secCore := k8sfake.NewSimpleClientset()
+
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	// listener NAME -> the hostname it MUST carry. Literals on purpose.
+	wantListeners := map[string]string{
+		"console-https-uatco":    "*.uatco.omani.homes",
+		"console-http-uatco":     "*.uatco.omani.homes",
+		"console-https-r17probe": "*.r17probe.omani.homes",
+		"console-http-r17probe":  "*.r17probe.omani.homes",
+	}
+
+	for _, region := range []struct {
+		name string
+		dyn  *dynamicfake.FakeDynamicClient
+	}{
+		{"region-a-host", hostDyn},
+		{"region-b-secondary", secDyn},
+	} {
+		applied := consoleListenersAppliedTo(t, region.dyn)
+		for _, name := range sortedKeys(wantListeners) {
+			want := wantListeners[name]
+			got, ok := applied[name]
+			if !ok {
+				t.Errorf("#5635 [%s]: listener %q (%s) was NEVER applied to this region — "+
+					"every fresh TCP connection for that host landing here is reset at the TLS "+
+					"handshake; region carries %v",
+					region.name, name, want, sortedKeys(applied))
+				continue
+			}
+			if got != want {
+				t.Errorf("#5635 [%s]: listener %q hostname = %q, want %q",
+					region.name, name, got, want)
+			}
+		}
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // TestOrgConsoleTLSRecordFromOrgCR_SkipCases — the CR→record derivation must


### PR DESCRIPTION
## Verdict first: the live failure is **#5635 undeployed**, not a gap in `main`. What IS a gap is the guard.

Dispatched to root-cause `console.uatco.omani.homes` failing ~50% of fresh connections on hw292. The symptom reproduces exactly. The production fix for it is already on `main`. The **test that is supposed to hold that fix in place cannot fail on the live defect**, and that is what this PR closes.

Test-only. `org_console_tls.go` is byte-identical to `origin/main` (`git diff --quiet origin/main -- …/org_console_tls.go` passes).

## 1. Reproduction — 16 fresh TCP connections

Separate `curl --no-keepalive` invocations; per #5459 a browser loop or a keepalive curl pins one backend over HTTP/2 and reports 100% against a round-robin.

```
s5  rc=0  200 verify=0      s4  rc=35  OpenSSL SSL_connect: Connection reset by peer
s6  rc=0  200 verify=0      s8  rc=35  OpenSSL SSL_connect: Connection reset by peer
s7  rc=0  200 verify=0      s9  rc=35  OpenSSL SSL_connect: Connection reset by peer
s10 rc=0  200 verify=0      s11 rc=35  OpenSSL SSL_connect: Connection reset by peer
s13 rc=0  200 verify=0      s12 rc=35  OpenSSL SSL_connect: Connection reset by peer
s14 rc=0  200 verify=0      s16 rc=35  OpenSSL SSL_connect: Connection reset by peer
SUMMARY console.uatco.omani.homes   ok=8  of 16

SUMMARY console.hw292.omani.works   ok=12 of 12   (control, SAME EIP 212.72.24.85)
```

Successes carry `ssl_verify_result=0`. Failures are `rc=35` — TLS handshake, before any HTTP status exists, so envoy matched **no listener for that SNI**.

## 2. Per-region inventory — both regions sampled, because the defect IS the split

`kube-system/cilium-gateway-console`, looped over both kubeconfigs:

| | region-a | region-b |
|---|---|---|
| `console-https-uatco` / `console-http-uatco` (`*.uatco.omani.homes`) | **present** | **absent** |
| `console-https-r17probe` / `console-http-r17probe` (`*.r17probe.omani.homes`) | absent | **present** — the Org is deleted |
| apex `console/api/marketplace` listeners | present | present |

Region-b is not empty and not unpatched. It carries a per-Org listener pair — for the **wrong Org**.

## 3. (a) or (b): it is **(b)**, proven by ancestry, not by hope

hw292 runs `catalyst-api:fad88bd` (2026-08-02). Every fix in this family lands after it:

```
e5fc89203  2026-08-04  #5647  console surface reconciled from Org CRs, every region   -> NOT in fad88bd
407c00e74  2026-08-05  #5672  reap deleted-Org console surface in every region        -> NOT in fad88bd
de754137a  2026-08-06  #5713  per-Org APP hosts from every region (ClusterMesh stubs) -> NOT in fad88bd
10ab5c70b  2026-08-06  #5723  reap on BOTH producers' parent-label vocabularies       -> NOT in fad88bd
```

**#5713 does not cover this.** It is the APP half (`wordpress.<slug>.<parent>`, HTTPRoute + Service mesh stubs). The console **listener** half is #5647.

And `main`'s fix would reach this Org: the loop is wired (`main.go:1099`), it keys on the Organization CR — `uatco`'s CR carries `openova.io/source: tenant-created-event` and `tenantPublic.parentDomain: omani.homes`, which `orgConsoleTLSRecordFromOrgCR` accepts — and the fan-out seam resolves region-b on this cluster, confirmed from catalyst-api's own log:

```
k8scache: informer synced  cluster=1c56518035a83e03
k8scache: informer synced  cluster=1c56518035a83e03-me-east-215-b-1
```

That is exactly the `<primaryID>-<regionKey>` prefix relation `orgConsoleTLSSecondaryRegions` requires. The live control for the same claim: `r17probe` came through the BSS door, ran the multi-region emitter, and **did** reach region-b.

## 4. The real gap — a guard that cannot go red on its own defect

`consoleSurfacePresent` derived its listener verdict from *"was there a patch action on the Gateway named `cilium-gateway-console`"*. It never read which listener, or its hostname. **Another Org's patch satisfies it.**

Control, run rather than argued. Same mutation both times — skip **only** `ensureOrgConsoleListener` for one Org on the secondary, leaving cert mirror and HTTPRoute fanning out normally, which is hw292's region-b exactly:

**`origin/main`'s guard, listener-only mutation:**
```
=== RUN   TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths
--- PASS: TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths (0.11s)
```
Green. Two Orgs, region-b's door shut, guard says fine. The single-Org backfill test does fail — only because there is no second Org's patch to mask it, which is precisely the blindness: **it disappears on any region serving ≥2 Orgs, i.e. every real Sovereign.**

**This PR's guard, same mutation:**
```
=== RUN   TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths
    [marketplace-funnel/region-b-secondary] no Gateway listener apply for console.uatco.omani.homes
--- FAIL: TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths (0.11s)
=== RUN   TestReconcileOrgConsoleTLSFromOrgCRs_EveryRegionCarriesEveryOrgsListenerPair
    #5635 [region-b-secondary]: listener "console-http-uatco" (*.uatco.omani.homes) was NEVER
      applied to this region — every fresh TCP connection for that host landing here is reset
      at the TLS handshake; region carries [console-http-r17probe console-https-r17probe]
    #5635 [region-b-secondary]: listener "console-https-uatco" (*.uatco.omani.homes) was NEVER
      applied to this region — …; region carries [console-http-r17probe console-https-r17probe]
--- FAIL: TestReconcileOrgConsoleTLSFromOrgCRs_EveryRegionCarriesEveryOrgsListenerPair (0.11s)
FAIL
```

`region carries [console-http-r17probe console-https-r17probe]` is the live hw292 region-b state, emitted by the test.

**Unmutated `origin/main` — all green, so the assertion is not simply always-red:**
```
--- PASS: TestReconcileOrgConsoleTLSFromOrgCRs_BothCreationPaths (0.11s)
--- PASS: TestReconcileOrgConsoleTLSFromOrgCRs_BackfillsMissingSecondaryRegion (0.05s)
--- PASS: TestReconcileOrgConsoleTLSFromOrgCRs_EveryRegionCarriesEveryOrgsListenerPair (0.11s)
ok    …/internal/handler   0.285s
```

Full package: `ok …/internal/handler 256.565s`.

## 5. What the guard asserts

Two distinct regions (a single-region fixture cannot detect a single-region bug), and for **every** Org × **every** region, the listener pair pinned by rendered **name and hostname**:

```
console-https-uatco    -> *.uatco.omani.homes
console-http-uatco     -> *.uatco.omani.homes
console-https-r17probe -> *.r17probe.omani.homes
console-http-r17probe  -> *.r17probe.omani.homes
```

Read out of the SSA apply payloads, compared against **literals** — deliberately not against `resolveOrgConsoleTLSNames`, since a guard that asks the production resolver what to expect agrees with the emitter by construction and cannot catch a wrong-but-self-consistent hostname. Not a count, not a key.

## 6. The two sub-findings — different defects, and one is a red herring

**`PROGRAMMED=False` is NOT the cause.** Both gateways read `Programmed=False` in both regions, `reason: AddressNotAssigned`, `status.addresses` empty. But the apex `console-https` listener reads `Programmed=False` too and its host is **12/12**. `cilium-envoy` is `hostNetwork: true`, so the datapath is DIRECT (hostPort, §854) and no address is ever assigned to the Gateway object — envoy still programs every `Accepted`+`ResolvedRefs` listener. Cosmetic here, and it is why `waitOrgConsoleListenersAdmitted` correctly polls for listener **presence** rather than `Programmed`.

**The orphaned `r17probe` listener is a separate defect** — teardown-reap, not fan-out. Its Org CR is gone from region-a while its listener survives in region-b (`console-https-r17probe` now sits `Accepted=False`, `ResolvedRefs=False`, its cert secret reaped). That is the #5364/#5649/#5672/#5723 family, all merged, all post-`fad88bd`.

## 7. Falsifiable live assertion — #5635 stays OPEN

Merged is not delivered. This needs a catalyst-api roll carrying `main`. Both regions sampled:

1. `kubectl -n kube-system get gateway cilium-gateway-console -o json` lists `console-https-<slug>` with hostname `*.<slug>.<parent>` in **both** regions, for **every** live Org.
2. No listener whose slug has no Organization CR survives in **either** region.
3. 20 separate `curl --no-keepalive` to `https://console.<slug>.<parent>/` return **20/20** non-`35` exits (today 8/16), with a same-EIP `console.hw292.omani.works` control.

Read-only against both clusters throughout — `kubectl get` and `curl` only.

Refs #5635 #5647 #5713 #5723 #5359 #960
