### PR TITLE
fix(cutover): pivot the per-Org IMAGE registry host — three generators wrote the mothership Harbor back after cutoverComplete=true (Refs #5439)

### DIFF
--- a/.github/workflows/test-provisioning-service.yaml
+++ b/.github/workflows/test-provisioning-service.yaml
@@ -1,0 +1,55 @@
+name: Test — Provisioning Service (Go)
+
+# Runs the Go tests for core/services/provisioning — the per-Org GitOps tree
+# generator.
+#
+# WHY THIS FILE EXISTS (#5439). Before it, `core/services/**` had NO Go test
+# gate at all: services-build.yaml matches `core/services/**` but only builds
+# and pushes images, on push-to-main, with no `go test` step and no
+# pull_request trigger. Every unit test under core/services/provisioning/
+# — including the #5527 cutover-aware catalog-base tests and the #5439
+# cutover-aware image-registry tests — could go red on main indefinitely
+# without a single check turning red. That is the fail-open-gate class: a
+# guard that cannot fail is not a guard.
+#
+# Scoped to the provisioning module because it is its own Go module
+# (core/services/provisioning/go.mod); sibling services under core/services/
+# still need their own gates and are deliberately NOT claimed here.
+
+on:
+  push:
+    paths:
+      - 'core/services/provisioning/**'
+      - '.github/workflows/test-provisioning-service.yaml'
+    branches: [main]
+  pull_request:
+    paths:
+      - 'core/services/provisioning/**'
+      - '.github/workflows/test-provisioning-service.yaml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core/services/provisioning
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: core/services/provisioning/go.sum
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Vet
+        run: go vet ./...
+
+      # No `|| true`, no `|| echo WARN` — a red test must fail the job.
+      - name: Run unit tests
+        run: go test -race -count=1 ./...

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1061,7 +1061,7 @@ spec:
       # index.yaml HelmRepository off charts.loft.sh into local Harbor +
       # suspends bp-vcluster-helmrepo so it holds; the step-08 fluxSourceHostLint
       # exception for charts.loft.sh is removed (empty allowHosts).
-      version: 0.1.173
+      version: 0.1.174
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1322,12 +1322,16 @@ spec:
       #   create-side reconcile; deleted Orgs converge to fully-deleted in
       #   every region.
       #   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
-      # 1.4.1321 (#5439): catalog-seed cutover pin 0.1.174 — step-07 Phase 3e
+      # 1.4.1322 (#5439): catalog-seed cutover pin 0.1.174 — step-07 Phase 3e
       #   pivots the per-Org IMAGE registry host off the mothership Harbor.
-      #   Lockstep w/ slot-06a.
+      #   (re-serialized past main 1.4.1321 at rebase — the deploy-bot took
+      #   1.4.1321 for the c85b41e image sweep while this branch was rebasing;
+      #   same version + different content is the #5323 hollow-pin shape, which
+      #   every lockstep gate passes through because each tree is internally
+      #   consistent.) Lockstep w/ slot-06a.
       # 1.4.1320 (#5467): catalog-seed cutover pin 0.1.173 — step-09 no longer
       #   prints the tail of the minted Gitea token. Lockstep w/ slot-06a.
-      version: 1.4.1321
+      version: 1.4.1322
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1322,6 +1322,9 @@ spec:
       #   create-side reconcile; deleted Orgs converge to fully-deleted in
       #   every region.
       #   (re-serialized past main 1.4.1290 to 1.4.1291 at rebase — #5364 #5649.)
+      # 1.4.1321 (#5439): catalog-seed cutover pin 0.1.174 — step-07 Phase 3e
+      #   pivots the per-Org IMAGE registry host off the mothership Harbor.
+      #   Lockstep w/ slot-06a.
       # 1.4.1320 (#5467): catalog-seed cutover pin 0.1.173 — step-09 no longer
       #   prints the tail of the minted Gitea token. Lockstep w/ slot-06a.
       version: 1.4.1321

--- a/core/controllers/organization/internal/gitops/cutover_aware_vcluster_5439.go
+++ b/core/controllers/organization/internal/gitops/cutover_aware_vcluster_5439.go
@@ -1,0 +1,145 @@
+package gitops
+
+// Cutover-aware vCluster/app IMAGE registry host (#5439) — the field #5527
+// did not cover.
+//
+// THE DEFECT (hw292 live, 2026-08-06, cutoverComplete=true since
+// 2026-08-03T08:12:04Z): PR #5529 (#5527) made the OCI *chart* base this
+// module's siblings emit cutover-aware, but the per-Org vCluster manifest's
+// IMAGE registry host stayed a compile-time literal — `harbor.openova.io`,
+// the MOTHERSHIP Harbor. Render() writes `vcluster/vcluster.yaml` into the
+// per-Org Gitea tree on EVERY Organization reconcile, so a Sovereign that has
+// genuinely passed its cutover (including the step-08 deny-egress proof) has
+// the mothership host written back into a Flux-owned source by the next org
+// mutation. Verified on the live object, not by reading the template:
+//
+//	kubectl -n uatco get helmrelease vcluster -o json | jq -r '.spec.values'
+//	  "coredns":{"deployment":{"image":"harbor.openova.io/proxy-dockerhub/coredns/coredns:1.11.3"}}
+//	  "image":{"registry":"harbor.openova.io"
+//	  "statefulSet":{"image":{"registry":"harbor.openova.io"
+//
+// This is the SAME class as #5439's named defect (a control-plane writer
+// re-asserting a mothership reference after cutoverComplete), one field over.
+// The invariant (#5527, restated): no Flux-owned object may be pivoted only at
+// the object layer — the pivot must land in whatever source Flux asserts from.
+//
+// WHY THE CHART DEFAULT CANNOT FIX IT: products/catalyst/chart/templates/
+// controllers/organization-controller-deployment.yaml ALWAYS stamps
+// CATALYST_VCLUSTER_IMAGE_REGISTRY (`| default "harbor.openova.io"`), so the
+// Go-side zero-value default is dead code and the configured value is the
+// mothership literal on every Sovereign from birth. For the same reason a
+// cutover `kubectl set env` on THAT var is not durable: it IS present in the
+// chart manifest, so the next Flux-driven helm upgrade reverts it (unlike
+// #5527's CATALYST_LOCAL_REGISTRY_URL, which is absent from every chart
+// manifest and therefore survives a 3-way strategic merge). The durable seam
+// has to be here, in the generator.
+//
+// THE SEAM: cutover step-07 Phase 3e (added with this fix) stamps
+// CATALYST_LOCAL_IMAGE_REGISTRY_HOST=harbor.<sovereign-fqdn> onto the
+// organization-controller, provisioning and catalyst-api Deployments. That
+// var appears in NO chart manifest, so it survives restarts and helm/Flux
+// 3-way merges; `kubectl set env` rolls the Deployment, so the regenerating
+// process always carries the fact. The value is byte-identical to the host
+// step-10 (vcluster-registry-pivot) already pivots the three platform
+// vClusters to — `target_host="harbor.${SOVEREIGN_FQDN}"` — so the generated
+// source and the pivoted objects agree and Flux has nothing to drift-correct.
+//
+// Why NOT the neighbouring candidates:
+//
+//   - SovereignFQDN / HostCluster alone: set from BIRTH on every Sovereign, so
+//     branching on it would point a PRE-cutover Sovereign's vClusters at a
+//     local Harbor whose proxy-cache projects do not exist yet (step-02) and
+//     which holds no mirrored images (step-03) — every per-Org vCluster would
+//     ImagePullBackOff during the whole pre-cutover life of the Sovereign.
+//   - The #3667 durable seal (cutoverComplete=true): flips only AFTER step-08's
+//     deny-egress hold passes, while the generated source must already be local
+//     DURING the hold. Same reasoning #5527 recorded.
+//   - Rewriting CATALYST_VCLUSTER_IMAGE_REGISTRY in the bootstrap-kit overlay:
+//     the overlay is rendered once at prov time from a pre-cutover context; it
+//     has no knowledge of when (or whether) the operator fires the cutover.
+//
+// Refs #5439 #5527 #4885.
+
+import (
+	"os"
+	"strings"
+)
+
+// mothershipHarborHost is the bootstrap (pre-cutover) image-registry host
+// every generator in this program ships as its default — the OpenOva
+// mothership Harbor. Its presence in a post-cutover render IS the defect.
+const mothershipHarborHost = "harbor.openova.io"
+
+// resolveVClusterImageRegistry is the pure resolution core (unit-tested
+// directly, no env):
+//
+//   - configured non-empty AND not the mothership literal → an operator (or a
+//     future cutover step) has named an explicit host; it wins outright
+//     (Inviolable Principle #4).
+//   - localImageRegistryHost non-empty → the step-07 Phase 3e stamp, the exact
+//     final host; normalised (scheme + trailing slash stripped) and returned.
+//   - else a pivot fact (localRegistryURL — step-07 Phase 3d's chart OCI base
+//     — or the step-07 Phase 3b issuer pair) AND a resolvable FQDN →
+//     harbor.<fqdn>, matching step-10's target_host exactly.
+//   - a pivot fact WITHOUT an FQDN is an inconsistent state this generator
+//     cannot mint a registry host from — fail safe to the configured host
+//     rather than emit one that resolves nowhere.
+//   - no fact → the configured host, unchanged. Pre-cutover output is
+//     byte-identical to the historical render, so Flux sees zero drift.
+func resolveVClusterImageRegistry(configured, localImageRegistryHost, localRegistryURL, pinIssuer, handoverIssuer string, fqdnCandidates ...string) string {
+	cfg := strings.TrimSpace(configured)
+	if cfg == "" {
+		cfg = mothershipHarborHost
+	}
+	if cfg != mothershipHarborHost {
+		return cfg
+	}
+	if h := normalizeRegistryHost(localImageRegistryHost); h != "" {
+		return h
+	}
+	if strings.TrimSpace(localRegistryURL) == "" &&
+		strings.TrimSpace(pinIssuer) == "" &&
+		strings.TrimSpace(handoverIssuer) == "" {
+		return cfg
+	}
+	for _, c := range fqdnCandidates {
+		if f := strings.TrimSpace(c); f != "" {
+			return "harbor." + f
+		}
+	}
+	return cfg
+}
+
+// normalizeRegistryHost strips any URL scheme and trailing slashes/paths so a
+// stamp supplied as `https://harbor.<fqdn>/` resolves to the bare host an
+// image reference needs.
+func normalizeRegistryHost(v string) string {
+	s := strings.TrimSpace(v)
+	if s == "" {
+		return ""
+	}
+	for _, scheme := range []string{"https://", "http://", "oci://"} {
+		s = strings.TrimPrefix(s, scheme)
+	}
+	s = strings.TrimSuffix(s, "/")
+	if s == "" {
+		return ""
+	}
+	return s
+}
+
+// vclusterImageRegistryFor reads the process env and resolves the image
+// registry host the rendered per-Org manifests declare. Called at render time
+// (per reconcile), so the value tracks the Deployment's CURRENT env — the pod
+// rolls when step-07 Phase 3e stamps it, and every subsequent regeneration
+// emits the local host.
+func vclusterImageRegistryFor(configured string, fqdnCandidates ...string) string {
+	return resolveVClusterImageRegistry(
+		configured,
+		os.Getenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST"),
+		os.Getenv("CATALYST_LOCAL_REGISTRY_URL"),
+		os.Getenv("CATALYST_PIN_ISSUER"),
+		os.Getenv("CATALYST_HANDOVER_JWT_ISSUER"),
+		fqdnCandidates...,
+	)
+}

--- a/core/controllers/organization/internal/gitops/cutover_aware_vcluster_5439_test.go
+++ b/core/controllers/organization/internal/gitops/cutover_aware_vcluster_5439_test.go
@@ -1,0 +1,233 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #5439 — post-cutover re-tether guard for the per-Org vCluster IMAGE registry.
+//
+// Read the "if the defect were present, could THIS check have gone red?" test
+// before touching these. The pair is deliberate:
+//
+//   - TestRender_VClusterImageRegistry_PostCutover_NoMothershipHost is the RED
+//     guard. On the pre-fix tree Render() emits `harbor.openova.io` even with
+//     every step-07 pivot fact set, so it FAILS. It cannot be satisfied by
+//     deleting the mothership literal from the templates, because…
+//   - TestRender_VClusterImageRegistry_PreCutover_ByteIdenticalToHistorical is
+//     the CONTROL. It passes on BOTH the pre-fix and post-fix trees and
+//     REQUIRES the mothership literal to still be rendered when no pivot fact
+//     is present. A blanket suppression that satisfies the first assertion
+//     breaks this one.
+// ---------------------------------------------------------------------------
+
+// pivotFactEnv sets the step-07 stamps a cut-over Sovereign's
+// organization-controller carries. t.Setenv restores on cleanup, so these
+// tests must not be t.Parallel().
+func pivotFactEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST", "harbor.hw292.omani.works")
+	t.Setenv("CATALYST_LOCAL_REGISTRY_URL", "oci://registry.hw292.omani.works/openova-io")
+	t.Setenv("CATALYST_PIN_ISSUER", "https://console.hw292.omani.works")
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "https://console.hw292.omani.works")
+}
+
+// noPivotFactEnv clears every fact so the process looks like a pre-cutover
+// Sovereign / the mothership. Explicit rather than implicit: `go test` inherits
+// the developer's environment, and a stray CATALYST_PIN_ISSUER would otherwise
+// turn the control green for the wrong reason.
+func noPivotFactEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST", "")
+	t.Setenv("CATALYST_LOCAL_REGISTRY_URL", "")
+	t.Setenv("CATALYST_PIN_ISSUER", "")
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "")
+}
+
+// liveShapedInputs mirrors the Inputs the organization-controller built for the
+// live hw292 Organization `uatco` whose rendered HelmRelease carried
+// `image.registry: harbor.openova.io` three times AFTER cutoverComplete=true.
+// VClusterImageRegistry is the mothership literal because the chart ALWAYS
+// stamps CATALYST_VCLUSTER_IMAGE_REGISTRY with it — that is the live input, not
+// a contrived one.
+func liveShapedInputs() Inputs {
+	return Inputs{
+		Slug:                  "uatco",
+		DisplayName:           "UAT Co",
+		Tier:                  "org",
+		PlanSlug:              "m",
+		SovereignFQDN:         "hw292.omani.works",
+		HostCluster:           "hw292.omani.works",
+		VClusterChartVersion:  "0.33.*",
+		VClusterImageRegistry: "harbor.openova.io",
+	}
+}
+
+// TestRender_VClusterImageRegistry_PostCutover_NoMothershipHost is the RED
+// guard: with the cutover pivot facts present, NOTHING the generator writes
+// into the Flux-owned per-Org tree may name the mothership.
+func TestRender_VClusterImageRegistry_PostCutover_NoMothershipHost(t *testing.T) {
+	pivotFactEnv(t)
+	out, err := Render(liveShapedInputs())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for path, body := range out {
+		if strings.Contains(string(body), mothershipHarborHost) {
+			t.Errorf("#5439 re-tether: %s names the mothership host %q on a cut-over Sovereign — "+
+				"the next Organization reconcile writes it back into the Flux source and undoes the step-06/step-10 pivot\n%s",
+				path, mothershipHarborHost, body)
+		}
+	}
+	vcl := string(out["vcluster/vcluster.yaml"])
+	if vcl == "" {
+		t.Fatal("vcluster/vcluster.yaml not rendered — the guard would pass vacuously")
+	}
+	// Positive half: the local host must actually land, and it must be the
+	// SAME host step-10 pivots the platform vClusters to (target_host=
+	// harbor.${SOVEREIGN_FQDN}), or the generated source and the pivoted
+	// objects disagree and Flux drift-corrects forever.
+	if !strings.Contains(vcl, "registry: harbor.hw292.omani.works") {
+		t.Errorf("expected the Sovereign-local host 'harbor.hw292.omani.works' in vcluster.yaml\n%s", vcl)
+	}
+	if !strings.Contains(vcl, "harbor.hw292.omani.works/proxy-dockerhub/coredns/coredns:") {
+		t.Errorf("coredns image not pivoted — this exact key held harbor.openova.io live on hw292\n%s", vcl)
+	}
+	if !strings.Contains(vcl, "repository: proxy-ghcr/loft-sh/kubernetes") {
+		t.Errorf("k8s-distro proxy path lost during the pivot\n%s", vcl)
+	}
+}
+
+// TestRender_VClusterImageRegistry_PreCutover_ByteIdenticalToHistorical is the
+// CONTROL. It passes on the pre-fix tree AND the post-fix tree. Its job is to
+// make the RED guard unsatisfiable by suppression: a pre-cutover Sovereign
+// MUST still render the mothership Harbor, because its own Harbor has no
+// proxy-cache projects (step-02) and no mirrored images (step-03) yet — every
+// per-Org vCluster would ImagePullBackOff.
+func TestRender_VClusterImageRegistry_PreCutover_ByteIdenticalToHistorical(t *testing.T) {
+	noPivotFactEnv(t)
+	out, err := Render(liveShapedInputs())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	vcl := string(out["vcluster/vcluster.yaml"])
+	if vcl == "" {
+		t.Fatal("vcluster/vcluster.yaml not rendered")
+	}
+	for _, want := range []string{
+		"registry: harbor.openova.io",
+		"image: harbor.openova.io/proxy-dockerhub/coredns/coredns:1.11.3",
+		"repository: proxy-ghcr/loft-sh/kubernetes",
+		"repository: proxy-ghcr/loft-sh/vcluster-oss",
+	} {
+		if !strings.Contains(vcl, want) {
+			t.Errorf("pre-cutover render lost %q — a pre-cutover Sovereign pulls vCluster images "+
+				"through the MOTHERSHIP Harbor; pointing it at its own empty Harbor is an ImagePullBackOff, not a fix\n%s",
+				want, vcl)
+		}
+	}
+}
+
+// TestRender_VClusterImageRegistry_ExplicitOverrideWinsBothPhases proves the
+// Principle #4 escape hatch survives the fix in both phases: an operator (or a
+// future cutover step) naming an explicit non-mothership host is authoritative
+// and never second-guessed by the derivation.
+func TestRender_VClusterImageRegistry_ExplicitOverrideWinsBothPhases(t *testing.T) {
+	for _, phase := range []struct {
+		name string
+		set  func(*testing.T)
+	}{
+		{"pre-cutover", noPivotFactEnv},
+		{"post-cutover", pivotFactEnv},
+	} {
+		t.Run(phase.name, func(t *testing.T) {
+			phase.set(t)
+			in := liveShapedInputs()
+			in.VClusterImageRegistry = "registry.internal.example"
+			out, err := Render(in)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			vcl := string(out["vcluster/vcluster.yaml"])
+			if !strings.Contains(vcl, "registry: registry.internal.example") {
+				t.Errorf("explicit override lost in %s\n%s", phase.name, vcl)
+			}
+			if strings.Contains(vcl, mothershipHarborHost) {
+				t.Errorf("explicit override leaked the mothership host in %s\n%s", phase.name, vcl)
+			}
+		})
+	}
+}
+
+// TestResolveVClusterImageRegistry is the pure-core table. It pins the whole
+// decision map, not just the happy path — an action-flip that silently
+// re-ordered the precedence would go red here.
+func TestResolveVClusterImageRegistry(t *testing.T) {
+	t.Parallel()
+	const fqdn = "hw292.omani.works"
+	cases := []struct {
+		name                                                      string
+		configured, localHost, localURL, pinIss, handIss, wantOut string
+		fqdns                                                     []string
+	}{
+		{
+			name:       "no fact — mothership literal unchanged",
+			configured: mothershipHarborHost, wantOut: mothershipHarborHost,
+			fqdns: []string{fqdn},
+		},
+		{
+			name:       "no fact — empty configured falls back to the historical default",
+			configured: "", wantOut: mothershipHarborHost, fqdns: []string{fqdn},
+		},
+		{
+			name:       "explicit non-mothership host wins over every fact",
+			configured: "registry.internal.example", localHost: "harbor." + fqdn,
+			localURL: "oci://registry." + fqdn + "/openova-io", pinIss: "https://console." + fqdn,
+			wantOut: "registry.internal.example", fqdns: []string{fqdn},
+		},
+		{
+			name:       "step-07 Phase 3e stamp is authoritative",
+			configured: mothershipHarborHost, localHost: "harbor." + fqdn,
+			wantOut: "harbor." + fqdn, fqdns: []string{"ignored.example"},
+		},
+		{
+			name:       "step-07 Phase 3e stamp normalised (scheme + trailing slash)",
+			configured: mothershipHarborHost, localHost: "https://harbor." + fqdn + "/",
+			wantOut: "harbor." + fqdn, fqdns: []string{fqdn},
+		},
+		{
+			name:       "Phase 3d chart-OCI fact derives harbor.<fqdn>",
+			configured: mothershipHarborHost, localURL: "oci://registry." + fqdn + "/openova-io",
+			wantOut: "harbor." + fqdn, fqdns: []string{fqdn},
+		},
+		{
+			name:       "Phase 3b issuer fact derives harbor.<fqdn>",
+			configured: mothershipHarborHost, pinIss: "https://console." + fqdn,
+			wantOut: "harbor." + fqdn, fqdns: []string{fqdn},
+		},
+		{
+			name:       "handover issuer alone is enough",
+			configured: mothershipHarborHost, handIss: "https://console." + fqdn,
+			wantOut: "harbor." + fqdn, fqdns: []string{fqdn},
+		},
+		{
+			name:       "second FQDN candidate used when the first is empty",
+			configured: mothershipHarborHost, pinIss: "https://console." + fqdn,
+			wantOut: "harbor." + fqdn, fqdns: []string{"", fqdn},
+		},
+		{
+			name:       "fact without any FQDN fails safe to the configured host",
+			configured: mothershipHarborHost, pinIss: "https://console." + fqdn,
+			wantOut: mothershipHarborHost, fqdns: []string{"", ""},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := resolveVClusterImageRegistry(c.configured, c.localHost, c.localURL, c.pinIss, c.handIss, c.fqdns...)
+			if got != c.wantOut {
+				t.Errorf("resolveVClusterImageRegistry = %q, want %q", got, c.wantOut)
+			}
+		})
+	}
+}

--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -986,12 +986,16 @@ func Render(in Inputs) (map[string][]byte, error) {
 	if in.VClusterHelmRepoNamespace == "" {
 		in.VClusterHelmRepoNamespace = "vcluster-system"
 	}
-	if in.VClusterImageRegistry == "" {
-		// Bootstrap default — the Sovereign-local Harbor. Matches the
-		// `global.registryMirror` default in bp-dmz/mgmt/rtz-vcluster.
-		// Cutover Step-04 flips it to harbor.<sovereign-fqdn> per ADR-0002.
-		in.VClusterImageRegistry = "harbor.openova.io"
-	}
+	// #5439: cutover-aware image-registry host. The chart ALWAYS stamps
+	// CATALYST_VCLUSTER_IMAGE_REGISTRY, so the zero-value branch below is
+	// only reached by direct callers/tests — the live value arriving here is
+	// the mothership literal on every Sovereign from birth. Post-cutover that
+	// literal, re-rendered into vcluster/vcluster.yaml on every reconcile,
+	// re-tethers a cut-over Sovereign (see cutover_aware_vcluster_5439.go).
+	// Pre-cutover (no pivot fact) the resolver returns the input unchanged, so
+	// the rendered bytes stay identical and Flux sees zero drift.
+	in.VClusterImageRegistry = vclusterImageRegistryFor(
+		in.VClusterImageRegistry, in.SovereignFQDN, in.HostCluster)
 	if in.Tier == "" {
 		in.Tier = "org"
 	}

--- a/core/services/provisioning/gitops/cutover_aware_vcluster_5439.go
+++ b/core/services/provisioning/gitops/cutover_aware_vcluster_5439.go
@@ -1,0 +1,105 @@
+package gitops
+
+// Cutover-aware vCluster/app IMAGE registry host (#5439) — the provisioning
+// half. Companion to cutover_aware_5527.go, which made the OCI *chart* base
+// cutover-aware but left the IMAGE registry host a compile-time literal.
+//
+// THE DEFECT: every image this module proxies — the per-Org CNPG/MySQL/Valkey
+// datastore images and every catalog app image routed through proxyImage() —
+// is re-tagged through `defaultVClusterRegistryMirror` = harbor.openova.io,
+// the MOTHERSHIP Harbor. The trees are regenerated on EVERY org mutation, so
+// post-cutover the mothership host is written back into a source Flux asserts
+// from. Same class as #5439's named defect, one field over. Live on hw292
+// (cutoverComplete=true): deploy/provisioning carried
+// VCLUSTER_IMAGE_REGISTRY=harbor.openova.io.
+//
+// THE SEAM is the same one cutover_aware_5527.go documents, extended by
+// step-07 Phase 3e: CATALYST_LOCAL_IMAGE_REGISTRY_HOST=harbor.<sovereign-fqdn>,
+// the exact host step-10 (vcluster-registry-pivot) pivots the three platform
+// vClusters to (`target_host="harbor.${SOVEREIGN_FQDN}"`). It appears in NO
+// chart manifest, so `kubectl set env` survives restarts and helm/Flux 3-way
+// merges — unlike VCLUSTER_IMAGE_REGISTRY itself, which products/catalyst/
+// chart/templates/org-services/provisioning.yaml ALWAYS stamps and a helm
+// upgrade therefore reverts.
+//
+// Refs #5439 #5527 #4885.
+
+import (
+	"os"
+	"strings"
+)
+
+// mothershipHarborHost is the bootstrap (pre-cutover) image-registry host this
+// module ships as its default — the OpenOva mothership Harbor. Its presence in
+// a post-cutover render IS the defect.
+const mothershipHarborHost = defaultVClusterRegistryMirror
+
+// resolveVClusterImageRegistry is the pure resolution core (unit-tested
+// directly, no env). Precedence, highest first:
+//
+//   - configured non-empty AND not the mothership literal → an operator (or a
+//     future cutover step) named an explicit host; it wins outright
+//     (Inviolable Principle #4).
+//   - localImageRegistryHost → the step-07 Phase 3e stamp, the exact final
+//     host; normalised (scheme + trailing slash stripped).
+//   - a pivot fact (localRegistryURL — Phase 3d's chart OCI base — or the
+//     Phase 3b issuer pair) AND a resolvable FQDN → harbor.<fqdn>.
+//   - a fact WITHOUT an FQDN → fail safe to the configured host rather than
+//     emit one that resolves nowhere.
+//   - no fact → the configured host, unchanged: pre-cutover output stays
+//     byte-identical to the historical render and Flux sees zero drift.
+func resolveVClusterImageRegistry(configured, localImageRegistryHost, localRegistryURL, pinIssuer, handoverIssuer string, fqdnCandidates ...string) string {
+	cfg := strings.TrimSpace(configured)
+	if cfg == "" {
+		cfg = mothershipHarborHost
+	}
+	if cfg != mothershipHarborHost {
+		return cfg
+	}
+	if h := normalizeRegistryHost(localImageRegistryHost); h != "" {
+		return h
+	}
+	if strings.TrimSpace(localRegistryURL) == "" &&
+		strings.TrimSpace(pinIssuer) == "" &&
+		strings.TrimSpace(handoverIssuer) == "" {
+		return cfg
+	}
+	for _, c := range fqdnCandidates {
+		if f := strings.TrimSpace(c); f != "" {
+			return "harbor." + f
+		}
+	}
+	return cfg
+}
+
+// normalizeRegistryHost strips any URL scheme and trailing slash so a stamp
+// supplied as `https://harbor.<fqdn>/` resolves to the bare host an image
+// reference needs.
+func normalizeRegistryHost(v string) string {
+	s := strings.TrimSpace(v)
+	if s == "" {
+		return ""
+	}
+	for _, scheme := range []string{"https://", "http://", "oci://"} {
+		s = strings.TrimPrefix(s, scheme)
+	}
+	s = strings.TrimSuffix(s, "/")
+	return s
+}
+
+// vclusterImageRegistryFor reads the process env and resolves the image
+// registry host the emitted manifests declare. Called at render time (per
+// mutation), so the value tracks the Deployment's CURRENT env — the pod rolls
+// when step-07 Phase 3e stamps it, and every subsequent regeneration emits the
+// local host.
+func vclusterImageRegistryFor(configured string) string {
+	return resolveVClusterImageRegistry(
+		configured,
+		os.Getenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST"),
+		os.Getenv("CATALYST_LOCAL_REGISTRY_URL"),
+		os.Getenv("CATALYST_PIN_ISSUER"),
+		os.Getenv("CATALYST_HANDOVER_JWT_ISSUER"),
+		os.Getenv("SOVEREIGN_FQDN"),
+		os.Getenv("CATALYST_OTECH_FQDN"),
+	)
+}

--- a/core/services/provisioning/gitops/cutover_aware_vcluster_5439_test.go
+++ b/core/services/provisioning/gitops/cutover_aware_vcluster_5439_test.go
@@ -1,0 +1,157 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #5439 — post-cutover re-tether guard for the provisioning generator's IMAGE
+// registry host. Same deliberate pair as the org-controller's:
+//
+//   - the PostCutover test is the RED guard (fails on the pre-fix tree),
+//   - the PreCutover test is the CONTROL: it passes on BOTH trees and REQUIRES
+//     the mothership literal to still be emitted when no pivot fact is present,
+//     so the red guard cannot be satisfied by deleting the literal.
+// ---------------------------------------------------------------------------
+
+func provPivotFactEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST", "harbor.hw292.omani.works")
+	t.Setenv("CATALYST_LOCAL_REGISTRY_URL", "oci://registry.hw292.omani.works/openova-io")
+	t.Setenv("CATALYST_PIN_ISSUER", "")
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "")
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+}
+
+func provNoPivotFactEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST", "")
+	t.Setenv("CATALYST_LOCAL_REGISTRY_URL", "")
+	t.Setenv("CATALYST_PIN_ISSUER", "")
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "")
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+}
+
+// liveShapedGenerator mirrors the live hw292 wiring: main.go reads
+// VCLUSTER_IMAGE_REGISTRY, which the chart ALWAYS stamps with the mothership
+// literal, and hands it to the generator.
+func liveShapedGenerator() *ManifestGenerator {
+	g := NewManifestGenerator("clusters/hw292.omani.works/org-tenants")
+	g.RegistryMirror = mothershipHarborHost
+	return g
+}
+
+// TestRegistryMirror_PostCutover_NoMothershipHost is the RED guard: every image
+// this generator emits — datastores and catalog apps alike — must be re-tagged
+// through the Sovereign-local Harbor once the cutover facts are present.
+func TestRegistryMirror_PostCutover_NoMothershipHost(t *testing.T) {
+	provPivotFactEnv(t)
+	g := liveShapedGenerator()
+	if got := g.registryMirror(); got != "harbor.hw292.omani.works" {
+		t.Fatalf("#5439 re-tether: registryMirror() = %q on a cut-over Sovereign, want %q — "+
+			"every datastore + catalog-app image the next org mutation writes into the Flux "+
+			"source would name the mothership Harbor", got, "harbor.hw292.omani.works")
+	}
+	// The rendered artefacts, not just the accessor: an assertion on the
+	// accessor alone would go green if a caller stopped using it.
+	for name, body := range map[string]string{
+		"db-postgres.yaml": generatePostgres("uatco-apps", "pw", []string{"wordpress"}, nil, g.registryMirror()),
+		"db-mysql.yaml":    generateMySQL("uatco-apps", "pw", []string{"wordpress"}, nil, g.registryMirror()),
+		"db-redis.yaml":    generateRedis("uatco-apps", g.registryMirror()),
+	} {
+		if strings.Contains(body, mothershipHarborHost) {
+			t.Errorf("#5439 re-tether: %s names the mothership host %q post-cutover\n%s",
+				name, mothershipHarborHost, body)
+		}
+		if !strings.Contains(body, "harbor.hw292.omani.works/proxy-") {
+			t.Errorf("%s did not route through the Sovereign-local Harbor proxy\n%s", name, body)
+		}
+	}
+}
+
+// TestRegistryMirror_PreCutover_ByteIdenticalToHistorical is the CONTROL —
+// green on BOTH trees. A pre-cutover Sovereign's own Harbor has no proxy-cache
+// projects (step-02) and no mirrored images (step-03), so it MUST keep pulling
+// through the mothership.
+func TestRegistryMirror_PreCutover_ByteIdenticalToHistorical(t *testing.T) {
+	provNoPivotFactEnv(t)
+	g := liveShapedGenerator()
+	if got := g.registryMirror(); got != mothershipHarborHost {
+		t.Fatalf("pre-cutover registryMirror() = %q, want %q — pointing a pre-cutover Sovereign "+
+			"at its own empty Harbor is an ImagePullBackOff, not a fix", got, mothershipHarborHost)
+	}
+	body := generateRedis("uatco-apps", g.registryMirror())
+	if !strings.Contains(body, mothershipHarborHost+"/proxy-dockerhub/valkey/valkey:8-alpine") {
+		t.Errorf("pre-cutover render lost the historical mothership proxy path\n%s", body)
+	}
+	// Unset generator (direct callers / Catalyst-Zero) keeps the historical
+	// bootstrap default.
+	empty := NewManifestGenerator("x")
+	if got := empty.registryMirror(); got != defaultVClusterRegistryMirror {
+		t.Errorf("unset RegistryMirror = %q, want the historical default %q", got, defaultVClusterRegistryMirror)
+	}
+}
+
+// TestRegistryMirror_ExplicitOverrideWinsBothPhases pins the Principle #4
+// escape hatch in both phases.
+func TestRegistryMirror_ExplicitOverrideWinsBothPhases(t *testing.T) {
+	for _, phase := range []struct {
+		name string
+		set  func(*testing.T)
+	}{
+		{"pre-cutover", provNoPivotFactEnv},
+		{"post-cutover", provPivotFactEnv},
+	} {
+		t.Run(phase.name, func(t *testing.T) {
+			phase.set(t)
+			g := NewManifestGenerator("x")
+			g.RegistryMirror = "registry.internal.example"
+			if got := g.registryMirror(); got != "registry.internal.example" {
+				t.Errorf("explicit override lost in %s: got %q", phase.name, got)
+			}
+		})
+	}
+}
+
+// TestResolveVClusterImageRegistry_Provisioning pins the whole decision map of
+// the pure core (an action-flip that re-ordered precedence goes red here).
+func TestResolveVClusterImageRegistry_Provisioning(t *testing.T) {
+	t.Parallel()
+	const fqdn = "hw292.omani.works"
+	cases := []struct {
+		name                                             string
+		configured, localHost, localURL, pinIss, handIss string
+		fqdns                                            []string
+		want                                             string
+	}{
+		{name: "no fact", configured: mothershipHarborHost, fqdns: []string{fqdn}, want: mothershipHarborHost},
+		{name: "empty configured, no fact", configured: "", fqdns: []string{fqdn}, want: mothershipHarborHost},
+		{name: "explicit host beats every fact", configured: "registry.internal.example",
+			localHost: "harbor." + fqdn, localURL: "oci://registry." + fqdn + "/openova-io",
+			pinIss: "https://console." + fqdn, fqdns: []string{fqdn}, want: "registry.internal.example"},
+		{name: "Phase 3e stamp authoritative", configured: mothershipHarborHost,
+			localHost: "harbor." + fqdn, fqdns: []string{"ignored.example"}, want: "harbor." + fqdn},
+		{name: "Phase 3e stamp normalised", configured: mothershipHarborHost,
+			localHost: "https://harbor." + fqdn + "/", fqdns: []string{fqdn}, want: "harbor." + fqdn},
+		{name: "Phase 3d chart-OCI fact derives", configured: mothershipHarborHost,
+			localURL: "oci://registry." + fqdn + "/openova-io", fqdns: []string{fqdn}, want: "harbor." + fqdn},
+		{name: "Phase 3b issuer fact derives", configured: mothershipHarborHost,
+			pinIss: "https://console." + fqdn, fqdns: []string{fqdn}, want: "harbor." + fqdn},
+		{name: "handover issuer alone", configured: mothershipHarborHost,
+			handIss: "https://console." + fqdn, fqdns: []string{fqdn}, want: "harbor." + fqdn},
+		{name: "second FQDN candidate", configured: mothershipHarborHost,
+			pinIss: "https://console." + fqdn, fqdns: []string{"", fqdn}, want: "harbor." + fqdn},
+		{name: "fact without FQDN fails safe", configured: mothershipHarborHost,
+			pinIss: "https://console." + fqdn, fqdns: []string{"", ""}, want: mothershipHarborHost},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolveVClusterImageRegistry(c.configured, c.localHost, c.localURL, c.pinIss, c.handIss, c.fqdns...); got != c.want {
+				t.Errorf("resolveVClusterImageRegistry = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -396,13 +396,17 @@ func NewManifestGenerator(basePath string) *ManifestGenerator {
 	return &ManifestGenerator{BasePath: basePath}
 }
 
-// registryMirror returns the configured Harbor proxy host, falling back
-// to the bootstrap default when unset.
+// registryMirror returns the Harbor proxy host every emitted image is re-tagged
+// through, falling back to the bootstrap default when unset.
+//
+// #5439: the result is cutover-aware. The chart ALWAYS stamps
+// VCLUSTER_IMAGE_REGISTRY, so on every Sovereign the configured value is the
+// mothership literal from birth; re-emitting it after cutover writes the
+// mothership back into a Flux-owned source on the next org mutation. With no
+// pivot fact present the resolver returns the input unchanged, so pre-cutover
+// output stays byte-identical. See cutover_aware_vcluster_5439.go.
 func (g *ManifestGenerator) registryMirror() string {
-	if g.RegistryMirror == "" {
-		return defaultVClusterRegistryMirror
-	}
-	return g.RegistryMirror
+	return vclusterImageRegistryFor(g.RegistryMirror)
 }
 
 func (g *ManifestGenerator) TenantDir(slug string) string {

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.173
+  version: 0.1.174
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3446,7 +3446,60 @@ name: bp-self-sovereign-cutover
 # copyAttempts,skopeoStaticURL,maxRefsPerCycle}. No RBAC change (the runner
 # ClusterRole already grants deployments/statefulsets/daemonsets/jobs/cronjobs
 # get+list+watch). Step count unchanged at 11.
-version: 0.1.173
+#
+# 0.1.174 — #5439: step-07 gains Phase 3e, the IMAGE-registry half of the
+# post-cutover re-tether #5527 closed for CHART bases.
+#
+# THE DEFECT, live on hw292 (dep 1c56518035a83e03, cutoverComplete=true since
+# 2026-08-03T08:12:04Z), read off the live object rather than the template:
+#
+#   kubectl -n uatco get helmrelease vcluster -o json | jq -r '.spec.values'
+#     "coredns":{"deployment":{"image":"harbor.openova.io/proxy-dockerhub/coredns/coredns:1.11.3"}}
+#     "image":{"registry":"harbor.openova.io"
+#     "statefulSet":{"image":{"registry":"harbor.openova.io"
+#   kubectl -n catalyst-system get deploy catalyst-organization-controller ...
+#     CATALYST_VCLUSTER_IMAGE_REGISTRY=harbor.openova.io
+#   kubectl -n org-services get deploy provisioning ...
+#     VCLUSTER_IMAGE_REGISTRY=harbor.openova.io
+#
+# Three control-plane generators render the per-Org tree — the org-controller
+# (vcluster/vcluster.yaml), org-services/provisioning (the datastore + catalog
+# app images) and catalyst-api (the legacy org-tenants overlay). All three took
+# the image-registry host from a chart-stamped env whose value is the MOTHERSHIP
+# Harbor on every Sovereign from birth, and NO cutover step ever pivoted it:
+# step-04 rewrites node containerd certs.d, step-07 Phases 1-2/4 rewrite chart
+# values and pod specs, step-10 pivots the three PLATFORM vClusters — none of
+# them touch the generator. So every Organization signup/teardown wrote the
+# mothership host back into a source Flux asserts from, hours or days after the
+# cutover (including its deny-egress proof) had reported success. Exactly the
+# #5439 shape, one field over from #5527's.
+#
+# WHY NOT `kubectl set env CATALYST_VCLUSTER_IMAGE_REGISTRY`: that var IS
+# templated by products/catalyst/chart/templates/{controllers/organization-
+# controller-deployment,org-services/provisioning}.yaml, so the next
+# Flux-driven helm upgrade reverts a set-env on it within minutes. Phase 3e
+# therefore stamps a NEW var — CATALYST_LOCAL_IMAGE_REGISTRY_HOST — that
+# appears in no chart manifest and so survives the 3-way strategic merge, the
+# same durability argument Phase 3d stakes on CATALYST_LOCAL_REGISTRY_URL. The
+# generators resolve it (core/controllers/organization/internal/gitops/
+# cutover_aware_vcluster_5439.go and its two siblings); with no pivot fact
+# present they return the configured value UNCHANGED, so a pre-cutover
+# Sovereign still pulls through the mothership proxy-cache and the rendered
+# bytes are byte-identical (a pre-cutover Sovereign's own Harbor has no
+# proxy-cache projects until step-02 and no mirrored images until step-03 —
+# flipping it early is an ImagePullBackOff, not a fix).
+#
+# The stamped value is harbor.<sovereign.fqdn> — byte-identical to step-10's
+# `target_host`, so the generated source and the objects step-10 pivots agree
+# and Flux has nothing to drift-correct. Contract Case 78 EXECUTES both
+# derivations from their own rendered templates and asserts they match, so a
+# re-worded one cannot silently diverge.
+#
+# New values: orgController.{deploymentName,namespace}. Phase 3e read-back
+# asserts each stamp (FATAL — fail-open here IS the defect), SKIPs an absent
+# Deployment, and FATALs on an un-overlaid sovereign.fqdn. Step count unchanged
+# at 11.
+version: 0.1.174
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -119,6 +119,19 @@ data:
             value: {{ .Values.orgProvisioning.deploymentName | quote }}
           - name: ORG_PROVISIONING_NAMESPACE
             value: {{ .Values.orgProvisioning.namespace | quote }}
+          # #5439 Phase 3e: the Sovereign FQDN the local IMAGE registry host is
+          # derived from — harbor.<fqdn>, byte-identical to step-10's
+          # `target_host="harbor.${SOVEREIGN_FQDN}"`.
+          - name: SOVEREIGN_FQDN
+            value: {{ .Values.sovereign.fqdn | quote }}
+          # #5439 Phase 3e: the org-controller Deployment — the generator that
+          # writes per-Org `vcluster/vcluster.yaml`. It is the writer that still
+          # held harbor.openova.io in HelmRelease uatco/vcluster on hw292 AFTER
+          # cutoverComplete=true, because no cutover step ever stamped it.
+          - name: ORG_CONTROLLER_DEPLOYMENT
+            value: {{ .Values.orgController.deploymentName | quote }}
+          - name: ORG_CONTROLLER_NAMESPACE
+            value: {{ .Values.orgController.namespace | quote }}
           # G62 (#2613): Gitea persistence inputs — durable source-of-truth
           # edit so Flux Kustomization doesn't revert the HR patch.
           - name: GITEA_INTERNAL_URL
@@ -967,6 +980,68 @@ data:
             else
               echo "[catalyst-api-env-patch] #5527 Phase 3d SKIP: deploy/${ORG_PROVISIONING_DEPLOYMENT} not found in ${ORG_PROVISIONING_NAMESPACE} (no marketplace tier — no per-Org generator to pivot)"
             fi
+
+            # ---- Phase 3e (#5439): pivot the per-Org IMAGE registry host ----
+            # Phase 3d pivots the CHART base the per-Org generators emit. The
+            # IMAGE registry host they emit is a SECOND field and was never
+            # pivoted by any step: the three generators (org-controller,
+            # provisioning, catalyst-api) all default to `harbor.openova.io`
+            # — the MOTHERSHIP Harbor — and the bp-catalyst-platform chart
+            # ALWAYS stamps that literal onto the first two Deployments, so it
+            # is the live value on every Sovereign from birth.
+            #
+            # Live on hw292, cutoverComplete=true since 2026-08-03T08:12:04Z:
+            #   kubectl -n uatco get hr vcluster -o json | jq -r .spec.values
+            #     "image":{"registry":"harbor.openova.io"
+            #     "statefulSet":{"image":{"registry":"harbor.openova.io"
+            #     "coredns":{...:"harbor.openova.io/proxy-dockerhub/coredns/..."}
+            # Every Organization reconcile re-wrote that into the Flux-owned
+            # per-Org tree AFTER the cutover had reported success — the #5439
+            # re-tether, one field over from the #5527 one.
+            #
+            # WHY A NEW ENV NAME rather than `kubectl set env
+            # CATALYST_VCLUSTER_IMAGE_REGISTRY`: that var IS templated by
+            # products/catalyst/chart/templates/{controllers/organization-
+            # controller-deployment,org-services/provisioning}.yaml, so the
+            # next Flux-driven helm upgrade reverts a set-env on it within
+            # minutes. CATALYST_LOCAL_IMAGE_REGISTRY_HOST appears in NO chart
+            # manifest, so a strategic-merge preserves it — the same durability
+            # argument Phase 3d stakes on CATALYST_LOCAL_REGISTRY_URL.
+            #
+            # The value is byte-identical to step-10's target_host
+            # (harbor.${SOVEREIGN_FQDN}), so the generated source and the
+            # objects step-10 pivots agree and Flux has nothing to
+            # drift-correct. Deployment-absent is a SKIP; present-but-unstamped
+            # is FATAL (fail-open here IS the defect).
+            if [ -z "${SOVEREIGN_FQDN}" ] || [ "${SOVEREIGN_FQDN}" = "example.local" ]; then
+              echo "[catalyst-api-env-patch] #5439 FATAL Phase 3e: sovereign.fqdn not overlaid (got '${SOVEREIGN_FQDN}') — cannot derive the local image-registry host" >&2
+              exit 1
+            fi
+            LOCAL_IMAGE_HOST="harbor.${SOVEREIGN_FQDN}"
+            for _tgt in \
+              "${ORG_CONTROLLER_DEPLOYMENT}:${ORG_CONTROLLER_NAMESPACE}" \
+              "${ORG_PROVISIONING_DEPLOYMENT}:${ORG_PROVISIONING_NAMESPACE}" \
+              "${DEPLOYMENT_NAME}:${DEPLOYMENT_NAMESPACE}"; do
+              _d="${_tgt%%:*}"
+              _n="${_tgt##*:}"
+              if ! kubectl get deploy "${_d}" -n "${_n}" >/dev/null 2>&1; then
+                echo "[catalyst-api-env-patch] #5439 Phase 3e SKIP: deploy/${_d} not found in ${_n}"
+                continue
+              fi
+              echo "[catalyst-api-env-patch] #5439 Phase 3e: CATALYST_LOCAL_IMAGE_REGISTRY_HOST=${LOCAL_IMAGE_HOST} -> deploy/${_d} -n ${_n}"
+              kubectl set env "deploy/${_d}" -n "${_n}" \
+                "CATALYST_LOCAL_IMAGE_REGISTRY_HOST=${LOCAL_IMAGE_HOST}"
+              # Read-back assert — live template value, not intention.
+              _live=$(kubectl get deploy "${_d}" -n "${_n}" \
+                -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='CATALYST_LOCAL_IMAGE_REGISTRY_HOST')].value}" 2>/dev/null || echo "")
+              if [ "${_live}" != "${LOCAL_IMAGE_HOST}" ]; then
+                echo "[catalyst-api-env-patch] #5439 FATAL Phase 3e: deploy/${_d} CATALYST_LOCAL_IMAGE_REGISTRY_HOST='${_live}' (want '${LOCAL_IMAGE_HOST}') — the next Organization mutation would write the mothership Harbor back into the per-Org Flux source; Pillar 5 independence not met" >&2
+                exit 1
+              fi
+              echo "[catalyst-api-env-patch] #5439 Phase 3e OK: deploy/${_d} CATALYST_LOCAL_IMAGE_REGISTRY_HOST=${_live}"
+              kubectl rollout status "deploy/${_d}" -n "${_n}" --timeout=180s \
+                || echo "[catalyst-api-env-patch] #5439 WARN Phase 3e: deploy/${_d} rollout slow (best-effort — the fact is in the pod template; step-08's roll-set covers the live roll)"
+            done
 
             # ---- Phase 4 (#4973 #4975 #4961): comprehensive pod-spec image sweep ----
             # The HR global.imageRegistry pivots above (Phases 1-2 + the additionalHRs

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -4442,4 +4442,97 @@ fi
 grep -q 'env settled WITH 2 named operator override' "$TMP/c77/out.txt" || { echo "FAIL: cascade pass does not announce both overrides (#5391)" >&2; exit 1; }
 echo "  PASS (#5391: gate executed in 7 directions — stuck+no-override blocks with TERMINAL diagnosis and remedy, valid named override passes AND records <ns>/<name>=<reason> durably, empty-reason/healthy/mid-roll overrides all fail-closed, unrecordable override refused, clean pass clears the record, hw290 DependencyNotReady cascade overridable; extracted gate ${c77_lines} lines)"
 
+# ── Case 78 (#5439): step-07 Phase 3e — the per-Org IMAGE registry host ──────
+# LIVE hw292 2026-08-06 (dep 1c56518035a83e03, cutoverComplete=true since
+# 2026-08-03T08:12:04Z):
+#   kubectl -n uatco get helmrelease vcluster -o json | jq -r '.spec.values'
+#     "coredns":{"deployment":{"image":"harbor.openova.io/proxy-dockerhub/coredns/coredns:1.11.3"}}
+#     "image":{"registry":"harbor.openova.io"
+#     "statefulSet":{"image":{"registry":"harbor.openova.io"
+#   kubectl -n catalyst-system get deploy catalyst-organization-controller -o jsonpath=...
+#     CATALYST_VCLUSTER_IMAGE_REGISTRY=harbor.openova.io
+# #5527/Phase 3d pivoted the CHART base the per-Org generators emit; the IMAGE
+# registry host is a SECOND field and no step pivoted it, so every Organization
+# reconcile wrote the MOTHERSHIP Harbor back into the Flux-owned per-Org tree
+# after the cutover had reported success. Phase 3e stamps the local host on all
+# three generator Deployments.
+echo "[cutover-contract] Case 78: step-07 Phase 3e stamps CATALYST_LOCAL_IMAGE_REGISTRY_HOST on all three per-Org generators (#5439)"
+awk '/name: cutover-step-07-catalyst-api-env-patch/{c=1} /name: cutover-step-08-egress-block-test/{c=0} c' "$TMP/render.yaml" > "$TMP/s07e.yaml"
+if [ ! -s "$TMP/s07e.yaml" ]; then
+  echo "FAIL: cannot extract the step-07 ConfigMap from the render (#5439 vacuity check)" >&2
+  exit 1
+fi
+# (a) the org-controller target is values-driven and present. This is THE writer
+#     that was missing: it renders vcluster/vcluster.yaml on every Organization
+#     reconcile and no cutover step had ever named it.
+if ! grep -qF 'ORG_CONTROLLER_DEPLOYMENT' "$TMP/s07e.yaml" \
+   || ! grep -qF 'value: "catalyst-organization-controller"' "$TMP/s07e.yaml" \
+   || ! grep -qF 'value: "catalyst-system"' "$TMP/s07e.yaml"; then
+  echo "FAIL: step-07 lacks the ORG_CONTROLLER_DEPLOYMENT/NAMESPACE inputs — Phase 3e cannot reach the generator that wrote harbor.openova.io into HelmRelease uatco/vcluster on hw292 (#5439)" >&2
+  exit 1
+fi
+# (b) all THREE generator Deployments must be in the stamp loop. Naming only the
+#     provisioning one (the #5527 target) leaves the live re-tether writer out.
+for _t in '${ORG_CONTROLLER_DEPLOYMENT}:${ORG_CONTROLLER_NAMESPACE}' \
+          '${ORG_PROVISIONING_DEPLOYMENT}:${ORG_PROVISIONING_NAMESPACE}' \
+          '${DEPLOYMENT_NAME}:${DEPLOYMENT_NAMESPACE}'; do
+  if ! grep -qF "$_t" "$TMP/s07e.yaml"; then
+    echo "FAIL: step-07 Phase 3e does not stamp ${_t} — that generator keeps emitting the mothership Harbor into the Flux source after cutover (#5439)" >&2
+    exit 1
+  fi
+done
+# (c) the stamp itself + the read-back FATAL + the Deployment-absent SKIP.
+if ! grep -qF '"CATALYST_LOCAL_IMAGE_REGISTRY_HOST=${LOCAL_IMAGE_HOST}"' "$TMP/s07e.yaml"; then
+  echo "FAIL: step-07 never stamps CATALYST_LOCAL_IMAGE_REGISTRY_HOST — the generators have no readable pivot fact for the image host (#5439)" >&2
+  exit 1
+fi
+if ! grep -qF 'would write the mothership Harbor back into the per-Org Flux source' "$TMP/s07e.yaml"; then
+  echo "FAIL: step-07 Phase 3e has no read-back FATAL — a failed stamp on an existing Deployment fails open into the exact #5439 defect" >&2
+  exit 1
+fi
+if ! grep -qF 'Phase 3e SKIP' "$TMP/s07e.yaml"; then
+  echo "FAIL: step-07 Phase 3e has no explicit Deployment-absent SKIP (#5439)" >&2
+  exit 1
+fi
+# (d) the unconfigured-overlay guard: sovereign.fqdn left at the chart default
+#     must FATAL rather than stamp `harbor.example.local`.
+if ! grep -qF 'sovereign.fqdn not overlaid' "$TMP/s07e.yaml"; then
+  echo "FAIL: step-07 Phase 3e has no example-default guard — an unconfigured overlay would stamp harbor.example.local (#5439)" >&2
+  exit 1
+fi
+# (e) EXECUTE the rendered derivation, and pin it to step-10's. The two must
+#     agree exactly: step-10 pivots the LIVE platform-vCluster objects while
+#     Phase 3e pivots the GENERATED per-Org source. If they disagree, Flux
+#     drift-corrects one against the other forever. Extract BOTH from their own
+#     rendered templates rather than restating either here.
+d78=$(grep -F 'LOCAL_IMAGE_HOST="harbor.${SOVEREIGN_FQDN}"' "$TMP/s07e.yaml" | head -1 | sed 's/^ *//')
+if [ -z "$d78" ]; then
+  echo "FAIL: cannot extract the LOCAL_IMAGE_HOST derivation from the step-07 render (#5439 vacuity check)" >&2
+  exit 1
+fi
+awk '/name: cutover-step-10-vcluster-registry-pivot/{c=1} /name: cutover-step-11-crossplane-provider-pivot/{c=0} c' "$TMP/render.yaml" > "$TMP/s10e.yaml"
+d78b=$(grep -F 'target_host="harbor.${SOVEREIGN_FQDN}"' "$TMP/s10e.yaml" | head -1 | sed 's/^ *//')
+if [ -z "$d78b" ]; then
+  echo "FAIL: cannot extract step-10's target_host derivation — the cross-step consistency check would pass vacuously (#5439)" >&2
+  exit 1
+fi
+got78=$(SOVEREIGN_FQDN="t90.omani.works" sh -c "$d78; printf '%s' \"\$LOCAL_IMAGE_HOST\"")
+got78b=$(SOVEREIGN_FQDN="t90.omani.works" sh -c "$d78b; printf '%s' \"\$target_host\"")
+if [ "$got78" != "harbor.t90.omani.works" ]; then
+  echo "FAIL: Phase 3e derivation maps t90.omani.works -> '$got78', want harbor.t90.omani.works (#5439)" >&2
+  exit 1
+fi
+if [ "$got78" != "$got78b" ]; then
+  echo "FAIL: Phase 3e stamps '$got78' but step-10 pivots the live vCluster objects to '$got78b' — the generated source and the pivoted objects disagree and Flux drift-corrects forever (#5439)" >&2
+  exit 1
+fi
+# (f) CONTROL — green on the pre-fix tree too: Phase 3d's chart-base stamp must
+#     still be intact. #5439 is additive; if this fix removed or renamed the
+#     #5527 seam it would trade one re-tether for another.
+if ! grep -qF '"CATALYST_LOCAL_REGISTRY_URL=${LOCAL_OCI_BASE}"' "$TMP/s07e.yaml"; then
+  echo "FAIL: the #5527 Phase 3d chart-base stamp was lost while adding Phase 3e (#5439 control)" >&2
+  exit 1
+fi
+echo "  PASS (#5439: Phase 3e present with a values-driven org-controller target, stamps all three generator Deployments, executed derivation equals step-10's target_host exactly, read-back FATAL + absent-Deployment SKIP + unconfigured-overlay guard, #5527 Phase 3d intact)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1302,6 +1302,22 @@ orgProvisioning:
   deploymentName: "provisioning"
   namespace: "org-services"
 
+# #5439 — step-07 Phase 3e: the organization-controller Deployment. It renders
+# the per-Org `vcluster/vcluster.yaml` (core/controllers/organization/internal/
+# gitops/manifests.go) on EVERY Organization reconcile, and the IMAGE registry
+# host it declares was never pivoted by any cutover step — the chart always
+# stamps CATALYST_VCLUSTER_IMAGE_REGISTRY=harbor.openova.io (the MOTHERSHIP
+# Harbor) and no step overrode it. Live on hw292 with cutoverComplete=true,
+# HelmRelease uatco/vcluster still carried `image.registry: harbor.openova.io`
+# in three places. Phase 3e stamps CATALYST_LOCAL_IMAGE_REGISTRY_HOST=
+# harbor.<sovereign.fqdn> — byte-identical to step-10's target_host — onto this
+# Deployment, the provisioning Deployment and catalyst-api. The var is absent
+# from every chart manifest, so it survives the helm/Flux 3-way merge that
+# would revert a set-env on CATALYST_VCLUSTER_IMAGE_REGISTRY itself.
+orgController:
+  deploymentName: "catalyst-organization-controller"
+  namespace: "catalyst-system"
+
 # #4885 (Refs #3379 #4563): step-07 image-registry pivot — the CURATED set of
 # ADDITIONAL openova-io HelmReleases whose chart HONOURS global.imageRegistry
 # and must be pivoted to the local Harbor at cutover.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T02:38:58.363Z",
+  "generatedAt": "2026-08-06T02:58:50.306Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.173",
+      "version": "0.1.174",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_aware_vcluster_5439.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_aware_vcluster_5439.go
@@ -1,0 +1,100 @@
+package handler
+
+// Cutover-aware vCluster/app IMAGE registry host (#5439) — the catalyst-api
+// org-tenants leg. Companion to organization_gitops.go's
+// orgTenantSharedHelmRepositoriesYAML (#5527), which made the OCI *chart* base
+// cutover-aware but left the IMAGE registry host a compile-time literal.
+//
+// THE DEFECT: orgTenantTemplateData.VClusterImageRegistry is read from
+// CATALYST_VCLUSTER_IMAGE_REGISTRY with the mothership Harbor
+// (harbor.openova.io) as the default — and the chart ALWAYS stamps that env
+// with exactly that literal, so the value is the mothership on every Sovereign
+// from birth. WriteTenantOverlay regenerates the overlay on every Org
+// signup/teardown, so post-cutover the mothership host is written back into a
+// source Flux asserts from — the same re-tether #5439 names, one field over.
+//
+// THE SEAM: cutover step-07 Phase 3e stamps
+// CATALYST_LOCAL_IMAGE_REGISTRY_HOST=harbor.<sovereign-fqdn> — the exact host
+// step-10 pivots the platform vClusters to (`target_host=
+// harbor.${SOVEREIGN_FQDN}`). It appears in NO chart manifest, so it survives
+// restarts and helm/Flux 3-way merges; CATALYST_VCLUSTER_IMAGE_REGISTRY does
+// NOT (products/catalyst/chart/templates/controllers/
+// organization-controller-deployment.yaml templates it), so a `kubectl set env`
+// on that var is reverted by the next Flux-driven helm upgrade. The stamp also
+// repairs a residual #5527 hole observed live on hw292: catalyst-api carries
+// the step-07 issuer fact but BOTH SOVEREIGN_FQDN and CATALYST_OTECH_FQDN are
+// empty, so a derivation with no explicit stamp fails safe to the mothership.
+//
+// Refs #5439 #5527 #4885.
+
+import (
+	"os"
+	"strings"
+)
+
+// mothershipVClusterImageRegistry is the bootstrap (pre-cutover) image-registry
+// host this leg ships as its default — the OpenOva mothership Harbor.
+const mothershipVClusterImageRegistry = "harbor.openova.io"
+
+// resolveVClusterImageRegistry is the pure resolution core (unit-tested
+// directly, no env). Precedence, highest first:
+//
+//   - configured non-empty AND not the mothership literal → explicit operator
+//     host, wins outright (Inviolable Principle #4).
+//   - localImageRegistryHost → the step-07 Phase 3e stamp, normalised.
+//   - a pivot fact (localRegistryURL / the issuer pair) AND a resolvable FQDN
+//     → harbor.<fqdn>.
+//   - a fact WITHOUT an FQDN → fail safe to the configured host.
+//   - no fact → the configured host, unchanged (byte-identical pre-cutover).
+func resolveVClusterImageRegistry(configured, localImageRegistryHost, localRegistryURL, pinIssuer, handoverIssuer string, fqdnCandidates ...string) string {
+	cfg := strings.TrimSpace(configured)
+	if cfg == "" {
+		cfg = mothershipVClusterImageRegistry
+	}
+	if cfg != mothershipVClusterImageRegistry {
+		return cfg
+	}
+	if h := normalizeVClusterRegistryHost(localImageRegistryHost); h != "" {
+		return h
+	}
+	if strings.TrimSpace(localRegistryURL) == "" &&
+		strings.TrimSpace(pinIssuer) == "" &&
+		strings.TrimSpace(handoverIssuer) == "" {
+		return cfg
+	}
+	for _, c := range fqdnCandidates {
+		if f := strings.TrimSpace(c); f != "" {
+			return "harbor." + f
+		}
+	}
+	return cfg
+}
+
+// normalizeVClusterRegistryHost strips any URL scheme and trailing slash so a
+// stamp supplied as `https://harbor.<fqdn>/` resolves to the bare host an image
+// reference needs.
+func normalizeVClusterRegistryHost(v string) string {
+	s := strings.TrimSpace(v)
+	if s == "" {
+		return ""
+	}
+	for _, scheme := range []string{"https://", "http://", "oci://"} {
+		s = strings.TrimPrefix(s, scheme)
+	}
+	return strings.TrimSuffix(s, "/")
+}
+
+// vclusterImageRegistryFor reads the process env and resolves the image
+// registry host the rendered org-tenant overlay declares. Called at render
+// time (per Org mutation), so the value tracks the Deployment's CURRENT env.
+func vclusterImageRegistryFor(configured string) string {
+	return resolveVClusterImageRegistry(
+		configured,
+		os.Getenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST"),
+		os.Getenv("CATALYST_LOCAL_REGISTRY_URL"),
+		os.Getenv("CATALYST_PIN_ISSUER"),
+		os.Getenv("CATALYST_HANDOVER_JWT_ISSUER"),
+		os.Getenv("SOVEREIGN_FQDN"),
+		os.Getenv("CATALYST_OTECH_FQDN"),
+	)
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_aware_vcluster_5439_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_aware_vcluster_5439_test.go
@@ -1,0 +1,125 @@
+package handler
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// #5439 — post-cutover re-tether guard for the catalyst-api org-tenants leg's
+// IMAGE registry host. Same deliberate pair as the other two generators:
+// a RED guard that fails on the pre-fix tree, and a CONTROL that is green on
+// BOTH trees and REQUIRES the mothership literal pre-cutover, so the red guard
+// cannot be satisfied by deleting the literal.
+// ---------------------------------------------------------------------------
+
+func apiPivotFactEnv(t *testing.T) {
+	t.Helper()
+	// Live hw292 shape: the step-07 issuer fact IS present but both FQDN envs
+	// are EMPTY — which is why the Phase 3e stamp, not a derivation, is the
+	// load-bearing seam for this process.
+	t.Setenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST", "harbor.hw292.omani.works")
+	t.Setenv("CATALYST_LOCAL_REGISTRY_URL", "")
+	t.Setenv("CATALYST_PIN_ISSUER", "https://console.hw292.omani.works")
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "https://console.hw292.omani.works")
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+}
+
+func apiNoPivotFactEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CATALYST_LOCAL_IMAGE_REGISTRY_HOST", "")
+	t.Setenv("CATALYST_LOCAL_REGISTRY_URL", "")
+	t.Setenv("CATALYST_PIN_ISSUER", "")
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "")
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+}
+
+// TestVClusterImageRegistry_PostCutover_NoMothershipHost is the RED guard.
+func TestVClusterImageRegistry_PostCutover_NoMothershipHost(t *testing.T) {
+	apiPivotFactEnv(t)
+	t.Setenv("CATALYST_VCLUSTER_IMAGE_REGISTRY", mothershipVClusterImageRegistry)
+	got := vclusterImageRegistryFor(mothershipVClusterImageRegistry)
+	if got == mothershipVClusterImageRegistry {
+		t.Fatalf("#5439 re-tether: org-tenant overlay would declare the mothership host %q "+
+			"on a cut-over Sovereign — the next Org signup/teardown writes it back into the Flux source",
+			mothershipVClusterImageRegistry)
+	}
+	if got != "harbor.hw292.omani.works" {
+		t.Fatalf("vclusterImageRegistryFor = %q, want %q (the SAME host step-10 pivots the "+
+			"platform vClusters to; a different host makes the source and the pivoted objects disagree)",
+			got, "harbor.hw292.omani.works")
+	}
+}
+
+// TestVClusterImageRegistry_PreCutover_ByteIdenticalToHistorical is the
+// CONTROL — green on BOTH trees. A pre-cutover Sovereign's own Harbor holds no
+// mirrored images yet, so it MUST keep pulling through the mothership.
+func TestVClusterImageRegistry_PreCutover_ByteIdenticalToHistorical(t *testing.T) {
+	apiNoPivotFactEnv(t)
+	if got := vclusterImageRegistryFor(mothershipVClusterImageRegistry); got != mothershipVClusterImageRegistry {
+		t.Fatalf("pre-cutover resolve = %q, want the historical %q — pointing a pre-cutover "+
+			"Sovereign at its own empty Harbor is an ImagePullBackOff, not a fix",
+			got, mothershipVClusterImageRegistry)
+	}
+	if got := vclusterImageRegistryFor(""); got != mothershipVClusterImageRegistry {
+		t.Fatalf("unset configured value = %q, want the historical default %q",
+			got, mothershipVClusterImageRegistry)
+	}
+}
+
+// TestVClusterImageRegistry_ExplicitOverrideWinsBothPhases pins the Principle
+// #4 escape hatch in both phases.
+func TestVClusterImageRegistry_ExplicitOverrideWinsBothPhases(t *testing.T) {
+	for _, phase := range []struct {
+		name string
+		set  func(*testing.T)
+	}{
+		{"pre-cutover", apiNoPivotFactEnv},
+		{"post-cutover", apiPivotFactEnv},
+	} {
+		t.Run(phase.name, func(t *testing.T) {
+			phase.set(t)
+			if got := vclusterImageRegistryFor("registry.internal.example"); got != "registry.internal.example" {
+				t.Errorf("explicit override lost in %s: got %q", phase.name, got)
+			}
+		})
+	}
+}
+
+// TestResolveVClusterImageRegistry_API pins the whole decision map of the pure
+// core.
+func TestResolveVClusterImageRegistry_API(t *testing.T) {
+	t.Parallel()
+	const fqdn = "hw292.omani.works"
+	const mothership = mothershipVClusterImageRegistry
+	cases := []struct {
+		name                                             string
+		configured, localHost, localURL, pinIss, handIss string
+		fqdns                                            []string
+		want                                             string
+	}{
+		{name: "no fact", configured: mothership, fqdns: []string{fqdn}, want: mothership},
+		{name: "empty configured, no fact", configured: "", fqdns: []string{fqdn}, want: mothership},
+		{name: "explicit host beats every fact", configured: "registry.internal.example",
+			localHost: "harbor." + fqdn, pinIss: "https://console." + fqdn,
+			fqdns: []string{fqdn}, want: "registry.internal.example"},
+		{name: "Phase 3e stamp authoritative", configured: mothership,
+			localHost: "harbor." + fqdn, fqdns: []string{"ignored.example"}, want: "harbor." + fqdn},
+		{name: "Phase 3e stamp normalised", configured: mothership,
+			localHost: "https://harbor." + fqdn + "/", fqdns: nil, want: "harbor." + fqdn},
+		{name: "Phase 3d chart-OCI fact derives", configured: mothership,
+			localURL: "oci://registry." + fqdn + "/openova-io", fqdns: []string{fqdn}, want: "harbor." + fqdn},
+		{name: "Phase 3b issuer fact derives", configured: mothership,
+			pinIss: "https://console." + fqdn, fqdns: []string{fqdn}, want: "harbor." + fqdn},
+		{name: "handover issuer alone", configured: mothership,
+			handIss: "https://console." + fqdn, fqdns: []string{fqdn}, want: "harbor." + fqdn},
+		{name: "live hw292 shape: issuer fact but NO fqdn fails safe", configured: mothership,
+			pinIss: "https://console." + fqdn, fqdns: []string{"", ""}, want: mothership},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolveVClusterImageRegistry(c.configured, c.localHost, c.localURL, c.pinIss, c.handIss, c.fqdns...); got != c.want {
+				t.Errorf("resolveVClusterImageRegistry = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -850,7 +850,14 @@ func renderOrganizationOverlay(rec store.OrganizationProvisionRecord, versions O
 	// harbor.<sovereign-fqdn> post-handover (ADR-0002). Read here so the
 	// WordPress HelmRelease's `global.imageRegistry` is never hardcoded
 	// (Inviolable Principle #4).
-	imageRegistry := strings.TrimSpace(envOr("CATALYST_VCLUSTER_IMAGE_REGISTRY", "harbor.openova.io"))
+	// #5439: cutover-aware. The chart ALWAYS stamps this env with the
+	// mothership literal, so re-emitting it after cutover writes the
+	// mothership Harbor back into the Flux-owned overlay on the next Org
+	// signup/teardown. With no pivot fact present the resolver returns the
+	// input unchanged — pre-cutover bytes are identical, zero Flux drift.
+	// See cutover_aware_vcluster_5439.go.
+	imageRegistry := vclusterImageRegistryFor(
+		strings.TrimSpace(envOr("CATALYST_VCLUSTER_IMAGE_REGISTRY", mothershipVClusterImageRegistry)))
 
 	data := orgTenantTemplateData{
 		TenantID:              rec.OrganizationID,

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.173",
+    "version": "0.1.174",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-# 1.4.1321 — #5439: catalog-seed bp-self-sovereign-cutover pin 0.1.173 ->
+# 1.4.1322 — #5439: catalog-seed bp-self-sovereign-cutover pin 0.1.173 ->
 #   0.1.174. Step-07 gains Phase 3e, the IMAGE-registry half of the
 #   post-cutover re-tether #5527 closed for CHART bases: the org-controller,
 #   org-services/provisioning and catalyst-api all emitted the MOTHERSHIP
@@ -3704,7 +3704,7 @@ name: bp-catalyst-platform
 # 1.4.1295 — #5467: bp-self-sovereign-cutover 0.1.168 -> 0.1.169 (harbor-prewarm
 #   GHCR-PAT log-leak fix). Bootstrap-kit slot-06a + catalog-seed pins lockstep.
 #   (re-serialized past main 1.4.1294 at rebase.)
-version: 1.4.1321
+version: 1.4.1322
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,17 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1321 — #5439: catalog-seed bp-self-sovereign-cutover pin 0.1.173 ->
+#   0.1.174. Step-07 gains Phase 3e, the IMAGE-registry half of the
+#   post-cutover re-tether #5527 closed for CHART bases: the org-controller,
+#   org-services/provisioning and catalyst-api all emitted the MOTHERSHIP
+#   Harbor (harbor.openova.io) as the per-Org vCluster/app image registry, and
+#   no cutover step ever pivoted it — live on hw292 with cutoverComplete=true,
+#   HelmRelease uatco/vcluster still carried image.registry: harbor.openova.io
+#   in three places three days after the cutover reported success. Phase 3e
+#   stamps CATALYST_LOCAL_IMAGE_REGISTRY_HOST=harbor.<fqdn> (a chart-ABSENT
+#   var, so it survives the helm 3-way merge that reverts a set-env on the
+#   chart-templated CATALYST_VCLUSTER_IMAGE_REGISTRY). Seed-pin bump only on
+#   this side; lockstep w/ slot-06a (pin-sync gate).
 # 1.4.1320 — #5467: catalog-seed bp-self-sovereign-cutover pin 0.1.172 ->
 #   0.1.173. Step-09 gitea-token-mint stopped emitting the LAST 5 chars of
 #   the freshly minted Gitea API token via ${new_token##???...???} — the same

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5101,7 +5101,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.173"
+  version: "0.1.174"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5118,7 +5118,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.173"
+    version: "0.1.174"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What #5439 asked, and what is actually true on `main`

**REFUTED — the named defect is fixed.** `orgTenantSharedHelmRepositoriesYAML()` no longer hardcodes `oci://ghcr.io/openova-io`; #5527 / PR #5529 (commit `3d6b321c1`) routes it through `orgTenantHelmRepositoryURL()` in both the catalyst-api leg (`products/catalyst/bootstrap/api/internal/handler/organization_gitops.go:584`) and the per-Org leg (`core/services/provisioning/gitops/cutover_aware_5527.go`), with step-07 Phase 3d stamping the fact. Verified in source on `origin/main` at `db176798d`, not by search.

**CONFIRMED — the defect CLASS is still live, one field over.** #5527 pivoted the OCI **chart** base. The **image registry host** on the very same generated objects was never pivoted by any cutover step.

## Live evidence — hw292, dep `1c56518035a83e03`, `cutoverComplete=true` since 2026-08-03T08:12:04Z

Read off the live object, both regions sampled (`for R in a b` over `/deps/kubeconfigs/1c56518035a83e03{,-me-east-215-b-1}.yaml`):

```
$ kubectl -n uatco get helmrelease vcluster -o json | jq -r '.spec.values'
  "coredns":{"deployment":{"image":"harbor.openova.io/proxy-dockerhub/coredns/coredns:1.11.3"}}
  "image":{"registry":"harbor.openova.io"
  "statefulSet":{"image":{"registry":"harbor.openova.io"

$ kubectl -n catalyst-system get deploy catalyst-organization-controller -o jsonpath=...
  CATALYST_VCLUSTER_IMAGE_REGISTRY=harbor.openova.io

$ kubectl -n org-services get deploy provisioning -o jsonpath=...
  VCLUSTER_IMAGE_REGISTRY=harbor.openova.io
```

`harbor.openova.io` is the **mothership** Harbor. The writer is the organization-controller — the `uatco` HelmRelease is owned by Kustomization `catalyst-tenant-uatco-vcluster`, whose tree carries `vcluster/vcluster.yaml`, rendered by `core/controllers/organization/internal/gitops/manifests.go:1029` on **every** Organization reconcile. Three days after `cutoverComplete=true`, the control plane is still writing the mothership into a source Flux asserts from.

Classification: **(a) broken in `main` today.** Nothing on `main` resolves it — the version deployed on hw292 (`bp-self-sovereign-cutover 0.1.159`) and `main` (`0.1.172`) behave identically here.

## Why the chart default could not fix it, and why `kubectl set env` on the existing var could not either

`products/catalyst/chart/templates/{controllers/organization-controller-deployment,org-services/provisioning}.yaml` **always** stamp `CATALYST_VCLUSTER_IMAGE_REGISTRY` / `VCLUSTER_IMAGE_REGISTRY` (`| default "harbor.openova.io"`). So:

- the Go-side zero-value default is dead code — the live value is the mothership literal from birth;
- a cutover `kubectl set env` on **that** var is reverted by the next Flux-driven helm upgrade, because it *is* present in the chart manifest. #5527's durability argument ("a 3-way strategic merge preserves env entries absent from both chart manifests") holds for `CATALYST_LOCAL_REGISTRY_URL` and does **not** hold here.

The durable seam therefore has to be in the generator, keyed off a chart-absent fact.

## The fix

1. **Three generators** resolve the host through a cutover-aware pure core (`cutover_aware_vcluster_5439.go`, one per Go module — the same duplication shape #5527 used):
   - `core/controllers/organization/internal/gitops/` (the live writer)
   - `core/services/provisioning/gitops/` (datastore + catalog-app images)
   - `products/catalyst/bootstrap/api/internal/handler/` (legacy org-tenants leg)

   Precedence: an explicit non-mothership host wins outright (Principle #4) → the step-07 Phase 3e stamp → a pivot fact plus a resolvable FQDN → `harbor.<fqdn>` → **no fact returns the configured value unchanged**. Pre-cutover output is byte-identical, so Flux sees zero drift and a pre-cutover Sovereign keeps pulling through the mothership proxy-cache (its own Harbor has no proxy projects until step-02 and no images until step-03 — flipping early is an ImagePullBackOff, not a fix).

2. **Step-07 Phase 3e** stamps `CATALYST_LOCAL_IMAGE_REGISTRY_HOST=harbor.<sovereign.fqdn>` on all three Deployments, with a read-back FATAL per target, an absent-Deployment SKIP, and a FATAL on an un-overlaid `sovereign.fqdn`. The value is byte-identical to step-10's `target_host`, so the generated source and the objects step-10 pivots agree.

3. New chart values `orgController.{deploymentName,namespace}`. Chart `0.1.173 → 0.1.174` (re-bumped after #5730 took 0.1.173), five lockstep sites plus the umbrella `bp-catalyst-platform 1.4.1322` (re-serialized twice past the deploy-bot); `check-bootstrap-kit-pin-sync.sh` and `check-catalog-seed-lockstep.sh` both green.

## The guard — red on the pre-fix tree, with a control that is green on BOTH

The red guard asserts nothing the generator writes names the mothership once the facts are present. The control asserts the mothership **is** still rendered when no fact is present — so the red guard cannot be satisfied by deleting the literal or blanket-suppressing it.

**org-controller, pre-fix tree** (`vclusterImageRegistryFor` call reverted to the old `if == "" { "harbor.openova.io" }`):

```
=== RUN   TestRender_VClusterImageRegistry_PostCutover_NoMothershipHost
--- FAIL: TestRender_VClusterImageRegistry_PostCutover_NoMothershipHost (0.00s)
=== RUN   TestRender_VClusterImageRegistry_PreCutover_ByteIdenticalToHistorical
--- PASS: TestRender_VClusterImageRegistry_PreCutover_ByteIdenticalToHistorical (0.00s)
=== RUN   TestRender_VClusterImageRegistry_ExplicitOverrideWinsBothPhases
--- PASS: TestRender_VClusterImageRegistry_ExplicitOverrideWinsBothPhases (0.00s)
FAIL	github.com/openova-io/openova/core/controllers/organization/internal/gitops	0.006s
```

with the failure body:

```
cutover_aware_vcluster_5439_test.go:78: #5439 re-tether: vcluster/vcluster.yaml names the
  mothership host "harbor.openova.io" on a cut-over Sovereign — the next Organization reconcile
  writes it back into the Flux source and undoes the step-06/step-10 pivot
```

**provisioning, pre-fix tree:**

```
=== RUN   TestRegistryMirror_PostCutover_NoMothershipHost
--- FAIL: TestRegistryMirror_PostCutover_NoMothershipHost (0.00s)
    cutover_aware_vcluster_5439_test.go:54: #5439 re-tether: registryMirror() = "harbor.openova.io"
      on a cut-over Sovereign, want "harbor.hw292.omani.works" — every datastore + catalog-app image
      the next org mutation writes into the Flux source would name the mothership Harbor
=== RUN   TestRegistryMirror_PreCutover_ByteIdenticalToHistorical
--- PASS: TestRegistryMirror_PreCutover_ByteIdenticalToHistorical (0.00s)
=== RUN   TestRegistryMirror_ExplicitOverrideWinsBothPhases
--- PASS: TestRegistryMirror_ExplicitOverrideWinsBothPhases (0.00s)
FAIL	github.com/openova-io/openova/core/services/provisioning/gitops	0.004s
```

**chart contract, pre-fix tree** (chart template + values reverted, test kept):

```
[cutover-contract] Case 78: step-07 Phase 3e stamps CATALYST_LOCAL_IMAGE_REGISTRY_HOST on all three per-Org generators (#5439)
FAIL: step-07 lacks the ORG_CONTROLLER_DEPLOYMENT/NAMESPACE inputs — Phase 3e cannot reach the
generator that wrote harbor.openova.io into HelmRelease uatco/vcluster on hw292 (#5439)
```

**post-fix, all green:**

```
ok  github.com/openova-io/openova/core/controllers/organization/internal/gitops  0.010s
ok  github.com/openova-io/openova/core/services/provisioning/gitops              0.011s
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler 65.070s
[cutover-contract] Case 78 ... PASS
[cutover-contract] All gates green.
```

Case 78 does not grep for a re-worded string: it EXECUTES the rendered Phase 3e derivation and step-10's `target_host` derivation, each extracted from its own rendered template, and fails if they disagree. It also carries a vacuity check on both extractions and a control asserting #5527's Phase 3d stamp is still intact.

## Does the check RUN?

- org-controller — `build-organization-controller.yaml` runs `go test -race ./organization/...` on `pull_request`. Yes.
- catalyst-api — `test-bootstrap-api.yaml` runs `go test -race ./...` on `pull_request`. Yes.
- provisioning — **no.** `core/services/**` had **no Go test gate at all**: `services-build.yaml` matches the path but only builds and pushes images, on push-to-main, with no `go test` step and no `pull_request` trigger. Every unit test under `core/services/provisioning/` — including #5527's — could have been red on `main` indefinitely with nothing turning red. This PR adds `.github/workflows/test-provisioning-service.yaml` (vet + `go test -race`, no `|| true`).
- chart contract — `blueprint-release.yaml` executes every `platform/*/chart/tests/*.sh`.

## Enumerated but NOT fixed here

Found by asking structurally "what writes a HelmRepository/OCIRepository URL or an image host into a Flux-owned source", not from the issue's list.

| Writer / surface | State | Why not in this PR |
|---|---|---|
| `catalyst-api` `SOVEREIGN_FQDN` and `CATALYST_OTECH_FQDN` both **empty** live on hw292 | #5527's derivation in that process fails safe to ghcr — the fix is inert there | Phase 3e's explicit stamp closes it for the image host. The chart-base leg still needs `CATALYST_LOCAL_REGISTRY_URL` on catalyst-api, which step-07 stamps only on the provisioning Deployment. The leg is dormant while `TENANT_GITOPS_PER_ORG=true` (live value), so it is a latent, not active, tether — reported on #5439 rather than widening this diff |
| `CATALYST_POOL_POWERDNS_API_URL=https://pdns.openova.io` on the org-controller | mothership DNS control plane, re-asserted on every Org reconcile | Deliberate for the shared `omani.*` pool; a customer Sovereign uses its own pool. Needs a product decision, not a code fix |
| Region-B: **65/65** `flux-system` HelmRepositories on `oci://ghcr.io/openova-io` while region A is fully on `registry.hw292.omani.works` | live now, on `cutoverComplete=true`, with `step.helmrepository-patches.region.me-east-215-b-1.result=success` recorded 2026-08-03T07:41:13Z | Already tracked as **#5596** / #5359. Fresh corroboration posted there rather than re-filed |
| `vcluster-system/loft` → `https://charts.loft.sh` in **both** regions | live | **#5650**, PR #5719 tonight |
| Pod image strings still naming `harbor.openova.io/proxy-*` cluster-wide | live | By design post-step-04: containerd `certs.d` rewrites the host at the node. Not a source-of-truth write, so out of this class |

## Constraints

No NodePorts touched. No secret, token or key in any diff, commit or comment. `Refs`, never `Closes` — #5439 stays open with a falsifiable live-walk assertion.

Refs #5439 #5527 #4885

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq