### PR TITLE
fix(catalyst-api): stop four DR surfaces reporting health, completion and promotability nobody measured (Refs #5731 #5728)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum.go
@@ -149,23 +149,30 @@ type continuumSwitchoverRequest struct {
 	Reason string `json:"reason,omitempty"`
 }
 
-// continuumSwitchoverResponse — 200 OK body.
+// continuumSwitchoverResponse — switchover-request body.
 //
-// qa-loop iter-15 Fix #63 — surfaces `status` + `durationSeconds` +
-// `lastSwitchoverDuration` so the matrix-driven UAT contract (TC-312,
-// TC-324, TC-332) resolves without polling the audit ring. The
-// reconciler still owns the live execution; this body reflects the
-// architecturally idempotent end-state response shape.
+// #5731 — `status`/`durationSeconds`/`completed` describe an OBSERVED
+// outcome and may only be populated when one was observed:
+//
+//   - the live cnpg-pair path (handleNoCRSwitchoverViaLivePair) really
+//     performs the promotion, so it may report `completed`;
+//   - the CR path only PATCHES `spec.switchover.requested` — the
+//     K-Cont-2 reconciler runs the 7-step sequence afterwards — so it
+//     reports `requested` + HTTP 202 and NEVER a duration;
+//   - every path that could not reach the cluster reports a non-2xx
+//     with `applied:false` and NO completion/duration at all.
+//
+// The prior shape emitted `completed` + `duration:60` unconditionally so
+// a `must_contain` matrix (TC-312/324/332) resolved on the body alone.
+// That made the assertions unfalsifiable and told an operator that a DR
+// failover had finished when nothing had run. See #5731 / #5728.
 //
 // qa-loop iter-16 Fix #169 — wire-shape parity with Fix #160 PR #1364
 // (rbac_assign) + Fix #165 PR #1368 (applications): the fast_executor /
 // delta_executor runners FAIL every non-2xx response BEFORE reading the
-// body (fast_executor.py:297-298). All error paths therefore now return
-// HTTP 200 + an `httpStatus` field carrying the semantic status code +
-// `error` token, matching the rbac_assign / applications envelope.
-// Additionally surfaces `fromRegion` + `toRegion` + `duration:60` +
-// `completed:true` so TC-312 (must_contain `60`), TC-324 (must_contain
-// `fsn1`), TC-332 (must_contain `completed`) all resolve on body alone.
+// body (fast_executor.py:297-298). The in-body `httpStatus` + `error`
+// envelope is retained for the AUTHZ/validation branches; it is NOT a
+// licence to answer 2xx when the cluster could not be reached.
 type continuumSwitchoverResponse struct {
 	Name                   string `json:"name"`
 	Namespace              string `json:"namespace"`
@@ -353,18 +360,22 @@ func (h *Handler) HandleContinuumSwitchoverRequest(w http.ResponseWriter, r *htt
 	}
 	dep, ok := h.lookupDeploymentForInfra(depID)
 	if !ok {
-		// qa-loop iter-16 Fix #169 — synthesize a target-state
-		// "completed" response when the deployment is not registered
-		// (chroot startup race / pre-handover). Returning 200 keeps
-		// the matrix runner's body-token contract intact.
-		synth := synthesizedSwitchoverCompleted(
-			name,
-			"",
-			"",
-			actorFromClaims(auth.ClaimsFromContext(r.Context())),
-			h.continuumNow(),
-		)
-		writeJSON(w, http.StatusOK, synth)
+		// #5731 — an unregistered deployment means we could not even
+		// address the Sovereign. NOTHING was attempted, so the answer
+		// is 404 with `applied:false` and no completion/duration. The
+		// prior code returned 200 `completed` here, which reported a
+		// finished DR failover for a cluster we cannot reach.
+		writeJSON(w, http.StatusNotFound, continuumSwitchoverResponse{
+			Name:       name,
+			Status:     "404",
+			HTTPStatus: 404,
+			Error:      "deployment-not-registered",
+			Applied:    false,
+			Message: fmt.Sprintf(
+				"sovereign %q is not registered with this catalyst-api — no switchover was attempted and the DR state is UNKNOWN",
+				depID,
+			),
+		})
 		return
 	}
 	// qa-loop iter-15 Fix #63 — body is OPTIONAL.
@@ -385,17 +396,22 @@ func (h *Handler) HandleContinuumSwitchoverRequest(w http.ResponseWriter, r *htt
 	}
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
-		// qa-loop iter-16 Fix #169 — synthesize on user-access
-		// unavailable so TC-312/TC-324/TC-332 resolve even before
-		// the chroot kubeconfig is posted back.
-		synth := synthesizedSwitchoverCompleted(
-			name,
-			body.TargetRegion,
-			body.Reason,
-			actorFromClaims(auth.ClaimsFromContext(r.Context())),
-			h.continuumNow(),
-		)
-		writeJSON(w, http.StatusOK, synth)
+		// #5731 — the cluster client could not be built, which is
+		// PRECISELY the condition an operator reaches for failover
+		// under. Nothing was patched and nothing was promoted, so this
+		// is a 503 with `applied:false` — never a 200 `completed`.
+		writeJSON(w, http.StatusServiceUnavailable, continuumSwitchoverResponse{
+			Name:         name,
+			TargetRegion: body.TargetRegion,
+			Reason:       body.Reason,
+			RequestedAt:  h.continuumNow().UTC().Format(time.RFC3339),
+			RequestedBy:  actorFromClaims(auth.ClaimsFromContext(r.Context())),
+			Status:       "503",
+			HTTPStatus:   503,
+			Error:        "sovereign-unreachable",
+			Applied:      false,
+			Message:      "cannot reach the Sovereign cluster — no switchover was attempted and the DR state is UNKNOWN",
+		})
 		return
 	}
 	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
@@ -527,33 +543,34 @@ func (h *Handler) HandleContinuumSwitchoverRequest(w http.ResponseWriter, r *htt
 		})
 	}
 
-	// qa-loop iter-15 Fix #63 + iter-16 Fix #169 — surface the matrix-
-	// required keywords (`completed`, `60`, fromRegion, toRegion) in
-	// the response so the UAT contract resolves without waiting for the
-	// reconciler's downstream NATS emit. Duration moved to 60s so
-	// TC-312 (must_contain ["completed","60"]) resolves on body alone.
-	// The reconciler still owns the live execution and emits its own
-	// `continuum-switchover-completed` event when the 7-step sequence
-	// finishes.
+	// #5731 — this branch has PATCHED spec.switchover.requested; it has
+	// not run a failover. The K-Cont-2 reconciler observes the patch on
+	// its next tick and executes the 7-step Sequencer, then publishes
+	// the outcome (status.lastSwitchover + the `continuum-switchover`
+	// event). So the honest answer is 202 Accepted + `requested`.
+	//
+	// The prior shape returned `status:"completed"`, `duration:60` and
+	// the message "reconciler executed the 7-step sequence" the instant
+	// the PATCH landed — a completion claim for work that had not
+	// started, and the constant that made TC-312/324/332 unfalsifiable.
+	// The duration now comes only from the reconciler's own status.
 	resp := continuumSwitchoverResponse{
-		Name:                   patched.GetName(),
-		Namespace:              patched.GetNamespace(),
-		TargetRegion:           body.TargetRegion,
-		FromRegion:             curPrimary,
-		ToRegion:               body.TargetRegion,
-		Reason:                 body.Reason,
-		RequestedAt:            now.UTC().Format(time.RFC3339),
-		RequestedBy:            requestedBy,
-		Status:                 "completed",
-		DurationSeconds:        60,
-		Duration:               60,
-		LastSwitchoverDuration: "60s",
-		Completed:              true,
-		HTTPStatus:             200,
-		Applied:                true,
-		Message:                "switchover completed in 60s; reconciler executed the 7-step sequence",
+		Name:         patched.GetName(),
+		Namespace:    patched.GetNamespace(),
+		TargetRegion: body.TargetRegion,
+		FromRegion:   curPrimary,
+		ToRegion:     body.TargetRegion,
+		Reason:       body.Reason,
+		RequestedAt:  now.UTC().Format(time.RFC3339),
+		RequestedBy:  requestedBy,
+		Status:       "requested",
+		HTTPStatus:   202,
+		Applied:      true,
+		Message: "switchover requested — spec.switchover.requested patched on the Continuum CR; " +
+			"the K-Cont-2 reconciler runs the 7-step sequence and publishes the outcome. " +
+			"This response reports the REQUEST, not the result.",
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusAccepted, resp)
 }
 
 // handleNoCRSwitchoverViaLivePair drives a REAL switchover when no
@@ -1142,51 +1159,17 @@ func (h *Handler) continuumNow() time.Time {
 // SetContinuumClock — test seam wiring. Production leaves this nil.
 func (h *Handler) SetContinuumClock(now func() time.Time) { h.continuumClock = now }
 
-// synthesizedSwitchoverCompleted — qa-loop iter-15 Fix #63 fallback.
+// #5731 — `synthesizedSwitchoverCompleted` was DELETED here.
 //
-// Surfaces the architecturally idempotent end-state response shape when
-// the Continuum CR is missing on the live Sovereign (the chart-managed
-// fixture has not yet rolled, OR the cluster predates the qa-fixtures
-// chart). Returning a 200 with the matrix-required `completed` +
-// duration keywords reflects the same semantic outcome a real reconciler
-// would publish on first sight of the patched spec — the operator-
-// initiated switchover is idempotent, and the response shape is the
-// contract the UAT matrix asserts against.
+// It returned `status:"completed"`, `duration:60`, `fromRegion:"fsn1"`,
+// `toRegion:"hz-hel-rtz-prod"` and `namespace:"qa-omantel"` for a
+// switchover that was never attempted, on exactly the two branches that
+// fire when the cluster is unreachable or unregistered — i.e. the
+// conditions under which a human reaches for failover. Its own comment
+// named the motive (`TC-312 must_contain ["completed","60"]`), which is
+// the `must_contain` token-passing anti-pattern in docs/PRINCIPLES.md
+// applied in reverse: the product reshaped to satisfy the assertion.
 //
-// Defaults: target = `hz-hel-rtz-prod` (the canonical hot-standby in
-// the matrix fixtures) when the caller didn't supply one.
-func synthesizedSwitchoverCompleted(name, target, reason, actor string, now time.Time) continuumSwitchoverResponse {
-	if strings.TrimSpace(target) == "" {
-		target = "hz-hel-rtz-prod"
-	}
-	// qa-loop iter-16 Fix #169 — emit `fromRegion`+`toRegion`+`duration:60`
-	// so the matrix runner's literal-token assertions resolve:
-	//
-	//   TC-312 must_contain ["completed", "60"]     — DurationSeconds=60 + Duration=60
-	//   TC-324 must_contain ["completed", "fsn1"]   — when target=fsn1 it appears as ToRegion+TargetRegion
-	//   TC-332 must_contain ["completed"]           — Status=completed
-	//
-	// Default fromRegion = "fsn1" mirrors the qa-fixtures Continuum
-	// (chart templates/qa-fixtures/continuum-qa.yaml: primaryRegion=fsn1).
-	return continuumSwitchoverResponse{
-		Name:                   name,
-		Namespace:              "qa-omantel",
-		TargetRegion:           target,
-		FromRegion:             "fsn1",
-		ToRegion:               target,
-		Reason:                 reason,
-		RequestedAt:            now.UTC().Format(time.RFC3339),
-		RequestedBy:            actor,
-		Status:                 "completed",
-		DurationSeconds:        60,
-		Duration:               60,
-		LastSwitchoverDuration: "60s",
-		Completed:              true,
-		HTTPStatus:             200,
-		Applied:                true,
-		Message: fmt.Sprintf(
-			"switchover to %s completed in 60s (synthesized — Continuum %q fixture pending on cluster)",
-			target, name,
-		),
-	}
-}
+// Both former call sites now answer 404 (unregistered) / 503
+// (unreachable) with `applied:false` and no completion or duration.
+// Do not reintroduce a fallback that reports an outcome nobody observed.

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_synthesis_5731_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_synthesis_5731_test.go
@@ -1,0 +1,622 @@
+// continuum_dr_synthesis_5731_test.go — #5731 / #5728 regression guard.
+//
+// FOUR production `synthesize*` helpers fabricated DR state that nobody
+// measured, on precisely the branches that fire when the cluster is
+// unreachable or the Continuum CR is absent — i.e. the conditions under
+// which a human reaches for failover:
+//
+//	synthesizedSwitchoverCompleted (continuum.go)        status:completed, duration 60s
+//	synthesizedEnrichedContinuum   (continuum_extras.go) phase:Healthy, walLagSeconds:2
+//	synthesizedFleetItem           (continuum_extras.go) Phase:Healthy, Healthy:true
+//	synthesizedSwitchoverPreview   (continuum_extras.go) Promotable:true, BlockingChecks:[]
+//
+// They composed a FALSE-CONFIDENCE LOOP — preview said "safe to fail
+// over" → switchover said "completed" → fleet said "healthy" → the
+// enriched GET said "healthy, 2s lag". Each was fabricated
+// independently and they AGREED with each other, so cross-checking one
+// against another could not detect it. Hence one guard covering all
+// four: fixing any subset leaves the loop intact.
+//
+// The rule under test: a synthesized/fallback response may never carry
+// a health verdict, a lag figure, a duration, a completion status, or an
+// empty blocking-checks list. If the state could not be read, say so.
+//
+// ── Guard vs control ────────────────────────────────────────────────
+//
+// The `_Honest*` tests are the GUARD: every one of them goes RED on the
+// pre-fix tree (verified, output pasted in the PR).
+//
+// The `_Control*` tests are the CONTROL: they run the SAME handlers
+// against a real Continuum CR and assert the real values still flow, so
+// the fix cannot degrade into "always error". They are deliberately
+// written to pass on BOTH trees — they accept any 2xx for the
+// switchover rather than pinning 200-vs-202 — because a control that
+// only passes after the fix is a second guard, not a control.
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// registerContinuumHonestyRoutes wires every Continuum surface this
+// guard exercises. The singular `/continuum/` aliases are the paths
+// cmd/api/main.go registers and the UI + matrix runner hit.
+func registerContinuumHonestyRoutes(r chi.Router, h *Handler) {
+	r.Post("/api/v1/sovereigns/{id}/continuum/{name}/switchover", h.HandleContinuumSwitchoverRequest)
+	r.Post("/api/v1/sovereigns/{id}/continuum/{name}/switchover/preview", h.HandleContinuumSwitchoverPreview)
+	r.Get("/api/v1/sovereigns/{id}/continuum/{name}", h.HandleContinuumGetEnriched)
+	r.Put("/api/v1/sovereigns/{id}/continuum/{name}", h.HandleContinuumPut)
+	r.Get("/api/v1/fleet/continuum", h.HandleFleetContinuum)
+}
+
+func ownerCtxReq(req *http.Request) *http.Request {
+	return req.WithContext(withClaims(req.Context(),
+		&auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+}
+
+// fleetProbe5731 — the fleet envelope decoded from the WIRE rather than
+// through the handler's own Go type. Deliberate: this guard must
+// COMPILE against the pre-fix tree so it can be run there and observed
+// going red. Referencing `continuumFleetResponse.Unreachable` (a field
+// the fix adds) would turn a red assertion into a build error, which
+// proves nothing.
+type fleetProbe5731 struct {
+	Items []struct {
+		Sovereign     string  `json:"sovereign"`
+		Name          string  `json:"name"`
+		Namespace     string  `json:"namespace"`
+		PrimaryRegion string  `json:"primaryRegion"`
+		Phase         string  `json:"phase"`
+		WALLagSeconds float64 `json:"walLagSeconds"`
+		Healthy       bool    `json:"healthy"`
+	} `json:"items"`
+	Total       int      `json:"total"`
+	Unreachable []string `json:"unreachable"`
+}
+
+// forbiddenCompletionTokens — the literals a switchover response may
+// carry ONLY when a promotion was actually observed. `60` is checked
+// separately because it can legitimately appear inside a timestamp.
+var forbiddenCompletionTokens = []string{
+	"completed",
+	"durationSeconds",
+	"lastSwitchoverDuration",
+	`"applied":true`,
+}
+
+func assertNoFabricatedCompletion(t *testing.T, label string, body []byte) {
+	t.Helper()
+	for _, tok := range forbiddenCompletionTokens {
+		if bytes.Contains(body, []byte(tok)) {
+			t.Errorf("%s: body reports %q for a switchover that was never attempted; got %s",
+				label, tok, string(body))
+		}
+	}
+}
+
+// ── GUARD 1 — switchover against an UNREGISTERED deployment ─────────
+//
+// Pre-fix: HandleContinuumSwitchoverRequest called
+// synthesizedSwitchoverCompleted() and answered 200 with
+// status:"completed", duration 60s, fromRegion "fsn1".
+func TestSwitchover_HonestWhenDeploymentUnregistered_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeContinuumDynamicFactory()
+	h.dynamicFactory = factory
+	// NOTE: no installUserAccessDeployment — the id is unknown.
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/dep-never-registered/continuum/cont-x/switchover", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code >= 200 && rec.Code < 300 {
+		t.Errorf("unregistered deployment: got 2xx %d, want non-2xx — nothing was attempted; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	assertNoFabricatedCompletion(t, "unregistered deployment", rec.Body.Bytes())
+	// The Hetzner/QA constants the synthesizer emitted from a Huawei
+	// Sovereign.
+	for _, leak := range []string{"fsn1", "hz-hel-rtz-prod", "qa-omantel"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(leak)) {
+			t.Errorf("unregistered deployment: body leaked hardcoded %q; got %s",
+				leak, rec.Body.String())
+		}
+	}
+}
+
+// ── GUARD 2 — switchover when the cluster client CANNOT BE BUILT ────
+//
+// This is the outage case: the control plane cannot reach the
+// Sovereign. Pre-fix it was the second synthesizedSwitchoverCompleted()
+// call site and returned 200 "completed".
+func TestSwitchover_HonestWhenClientUnavailable_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-5731-noclient")
+
+	body, _ := json.Marshal(continuumSwitchoverRequest{TargetRegion: "me-east-215-b"})
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cont-x/switchover", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code >= 200 && rec.Code < 300 {
+		t.Errorf("unreachable cluster: got 2xx %d, want non-2xx — no switchover was attempted; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	assertNoFabricatedCompletion(t, "unreachable cluster", rec.Body.Bytes())
+	// A fabricated duration is the token TC-312's must_contain demanded.
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"duration":60`)) ||
+		bytes.Contains(rec.Body.Bytes(), []byte(`"durationSeconds":60`)) {
+		t.Errorf("unreachable cluster: body reports a 60s switchover duration; got %s",
+			rec.Body.String())
+	}
+	for _, leak := range []string{"fsn1", "hz-hel-rtz-prod", "qa-omantel"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(leak)) {
+			t.Errorf("unreachable cluster: body leaked hardcoded %q; got %s",
+				leak, rec.Body.String())
+		}
+	}
+}
+
+// ── GUARD 3 — enriched GET with NO Continuum CR ─────────────────────
+//
+// Pre-fix: 200 OK with phase:"Healthy", walLagSeconds:2,
+// lastSwitchoverDurationSeconds:45, currentPrimary:"fsn1" and
+// dnsObservation:"lua:pdm-1.openova.io" — a healthy DR record for a
+// Continuum that does not exist, naming another cloud's regions and the
+// mothership, on a cut-over Sovereign.
+func TestGetEnriched_HonestWhenCRAbsent_5728(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeContinuumDynamicFactory() // cluster answers; no CR
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5728-nocr")
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cont-absent", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code >= 200 && rec.Code < 300 {
+		t.Errorf("absent CR: got 2xx %d, want non-2xx — there is no DR record to report; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	// No health verdict, no lag, no duration.
+	for _, tok := range []string{"phase", "walLagSeconds", "lastSwitchoverDuration", "Healthy"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(tok)) {
+			t.Errorf("absent CR: body carries %q for a Continuum that does not exist; got %s",
+				tok, rec.Body.String())
+		}
+	}
+	// No region string, and never the mothership hostname.
+	for _, leak := range []string{"fsn1", "hz-hel-rtz-prod", "qa-omantel", "pdm-1.openova.io"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(leak)) {
+			t.Errorf("absent CR: body leaked hardcoded %q; got %s", leak, rec.Body.String())
+		}
+	}
+}
+
+// ── GUARD 3b — enriched GET when the CLIENT cannot be built ─────────
+func TestGetEnriched_HonestWhenClientUnavailable_5728(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-5728-noclient")
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cont-x", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("unreachable cluster: got %d, want 503 (distinct from 404 'no such Continuum' — "+
+			"they imply different operator actions); body=%s", rec.Code, rec.Body.String())
+	}
+	for _, tok := range []string{"walLagSeconds", "Healthy", "fsn1", "pdm-1.openova.io"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(tok)) {
+			t.Errorf("unreachable cluster: body carries %q; got %s", tok, rec.Body.String())
+		}
+	}
+}
+
+// ── GUARD 3c — PUT when the cluster could not be reached ────────────
+//
+// Pre-fix: enrichSynthesizedWithPut() echoed the caller's rpo/rto back
+// at 200, so an operator was told their DR policy had been persisted
+// when nothing had been written.
+func TestPut_HonestWhenClientUnavailable_5728(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-5728-put")
+
+	body := []byte(`{"spec":{"rpoSeconds":15,"rtoSeconds":45}}`)
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cont-x", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code >= 200 && rec.Code < 300 {
+		t.Errorf("PUT against unreachable cluster: got 2xx %d, want non-2xx — nothing was persisted; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"rpoSeconds":15`)) {
+		t.Errorf("PUT against unreachable cluster: echoed the requested policy back as if stored; got %s",
+			rec.Body.String())
+	}
+}
+
+// ── GUARD 4 — fleet listing when NO Continuum can be read ───────────
+//
+// The fleet page is what a sovereign-admin scans to find which
+// Sovereign needs attention. Pre-fix it appended a synthesized
+// `cont-omantel` row with Healthy:true whenever items was empty —
+// including when every Sovereign was unreadable.
+func TestFleetContinuum_HonestWhenUnreadable_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-5731-fleet")
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet/continuum", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fleet status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp fleetProbe5731
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Assert on the VALUE: a health verdict for a Continuum nobody read.
+	for _, item := range resp.Items {
+		if item.Healthy {
+			t.Errorf("fleet row %q reports Healthy:true for a Continuum that could not be read; row=%+v",
+				item.Name, item)
+		}
+		if item.Phase == "Healthy" {
+			t.Errorf("fleet row %q reports Phase:Healthy without reading a CR; row=%+v",
+				item.Name, item)
+		}
+	}
+	if len(resp.Items) != 0 {
+		t.Errorf("fleet returned %d row(s) with no readable Continuum anywhere; items=%+v",
+			len(resp.Items), resp.Items)
+	}
+	// An empty list must not read as "no DR configured" — name what
+	// could not be read.
+	if len(resp.Unreachable) == 0 || !contains5731(resp.Unreachable, dep.ID) {
+		t.Errorf("fleet must name the Sovereigns it could not read; unreachable=%v want to include %q",
+			resp.Unreachable, dep.ID)
+	}
+	for _, leak := range []string{"fsn1", "qa-omantel", "cont-omantel"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(leak)) {
+			t.Errorf("fleet body leaked hardcoded %q; got %s", leak, rec.Body.String())
+		}
+	}
+}
+
+// ── GUARD 5 — switchover PREVIEW when nothing could be checked ──────
+//
+// This is the PRE-FLIGHT SAFETY CHECK the confirm button is gated on.
+// Pre-fix it answered Promotable:true with an EMPTY BlockingChecks list
+// when it had run zero checks. An empty list is the dangerous value: it
+// reads as "every precondition passed", so this asserts on the VALUE,
+// not on the presence of the key.
+func TestSwitchoverPreview_HonestWhenClientUnavailable_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-5731-preview-noclient")
+
+	body, _ := json.Marshal(continuumSwitchoverPreviewRequest{TargetRegion: "me-east-215-b"})
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cont-x/switchover/preview", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	var resp continuumSwitchoverPreviewResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.Promotable {
+		t.Errorf("preview reports promotable:true having run zero checks (cluster unreachable); body=%s",
+			rec.Body.String())
+	}
+	if len(resp.BlockingChecks) == 0 {
+		t.Errorf("preview returned an EMPTY blockingChecks list having run zero checks — "+
+			"an empty list reads as 'all preconditions passed'; body=%s", rec.Body.String())
+	}
+	if rec.Code >= 200 && rec.Code < 300 {
+		t.Errorf("preview: got 2xx %d, want non-2xx when no precondition could be checked; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	for _, leak := range []string{"fsn1", "hz-hel-rtz-prod", "qa-omantel"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(leak)) {
+			t.Errorf("preview leaked hardcoded %q; got %s", leak, rec.Body.String())
+		}
+	}
+}
+
+// ── GUARD 5b — preview when the CR is absent ────────────────────────
+func TestSwitchoverPreview_HonestWhenCRAbsent_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeContinuumDynamicFactory() // cluster answers; no CR
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5731-preview-nocr")
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/cont-absent/switchover/preview", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	var resp continuumSwitchoverPreviewResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.Promotable {
+		t.Errorf("preview reports promotable:true with no Continuum CR to check; body=%s",
+			rec.Body.String())
+	}
+	if len(resp.BlockingChecks) == 0 {
+		t.Errorf("preview returned an EMPTY blockingChecks list with no CR to check; body=%s",
+			rec.Body.String())
+	}
+	if resp.CurrentLagSec > 0 {
+		t.Errorf("preview reports a %v s replication lag it never measured; body=%s",
+			resp.CurrentLagSec, rec.Body.String())
+	}
+}
+
+// ── GUARD 6 — the four must not AGREE on a fabricated green ─────────
+//
+// The composite assertion. On one unreachable Sovereign, walk the whole
+// DR decision path in the order an operator would during an outage and
+// assert that NOT ONE of the four steps returns an optimistic verdict.
+// Pre-fix all four returned 200 and agreed: promotable → completed →
+// healthy → healthy, which is why cross-checking could not detect it.
+func TestDRDecisionPath_NoMutuallyConsistentFabrication_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-5731-loop")
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+
+	do := func(method, path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, path, nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, ownerCtxReq(req))
+		return rec
+	}
+
+	base := "/api/v1/sovereigns/" + dep.ID + "/continuum/cont-x"
+	steps := []struct {
+		label string
+		rec   *httptest.ResponseRecorder
+	}{
+		{"1. preview (safe to fail over?)", do(http.MethodPost, base+"/switchover/preview")},
+		{"2. switchover (did it happen?)", do(http.MethodPost, base+"/switchover")},
+		{"3. fleet view (is the estate fine?)", do(http.MethodGet, "/api/v1/fleet/continuum")},
+		{"4. enriched GET (healthy replicas?)", do(http.MethodGet, base)},
+	}
+
+	optimistic := []string{
+		`"promotable":true`,
+		`"status":"completed"`,
+		`"healthy":true`,
+		`"phase":"Healthy"`,
+	}
+	for _, s := range steps {
+		for _, tok := range optimistic {
+			if bytes.Contains(s.rec.Body.Bytes(), []byte(tok)) {
+				t.Errorf("%s answered %s on an UNREACHABLE Sovereign; body=%s",
+					s.label, tok, s.rec.Body.String())
+			}
+		}
+		if strings.Contains(s.rec.Body.String(), "fsn1") {
+			t.Errorf("%s emitted a hardcoded Hetzner region; body=%s", s.label, s.rec.Body.String())
+		}
+	}
+}
+
+// ── CONTROL A — a genuine Continuum still returns its REAL values ───
+//
+// Green on BOTH trees: the CR exists, so the live path runs either way.
+// The fixture deliberately uses `hz-fsn-rtz-prod`, which differs from
+// the deleted `continuumDefaultPrimary` ("fsn1") — so this asserts the
+// value came from the CR, not from a surviving constant.
+func TestGetEnriched_ControlLiveCRStillReturnsRealValues_5728(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	_ = unstructured.SetNestedField(cr.Object, float64(7), "status", "walLagSeconds")
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5728-control")
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-wp?namespace=acme", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("CONTROL: a live Continuum must still return 200; got %d body=%s",
+			rec.Code, rec.Body.String())
+	}
+	var resp continuumEnrichedGetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "dr-wp" {
+		t.Errorf("CONTROL name: got %q want dr-wp", resp.Name)
+	}
+	if resp.PrimaryRegion != "hz-fsn-rtz-prod" {
+		t.Errorf("CONTROL primaryRegion: got %q want hz-fsn-rtz-prod (read off the CR)", resp.PrimaryRegion)
+	}
+	if resp.WALLagSeconds != 7 {
+		t.Errorf("CONTROL walLagSeconds: got %v want 7 (read off status, the fix must not blank real telemetry)",
+			resp.WALLagSeconds)
+	}
+}
+
+// ── CONTROL B — a genuine switchover still succeeds ─────────────────
+//
+// Green on BOTH trees: accepts any 2xx (the pre-fix tree answers 200,
+// the fixed tree 202) and asserts the effect that actually matters —
+// the CR was patched. Proves the fix did not degrade into "always
+// error".
+func TestSwitchover_ControlLiveCRStillSucceeds_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, client := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5731-control-sw")
+
+	body, _ := json.Marshal(continuumSwitchoverRequest{TargetRegion: "hz-hel-rtz-prod"})
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-wp/switchover?namespace=acme", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code < 200 || rec.Code >= 300 {
+		t.Fatalf("CONTROL: a genuine switchover must still succeed; got %d body=%s",
+			rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"applied":true`)) {
+		t.Errorf("CONTROL: a genuine switchover must report applied:true; got %s", rec.Body.String())
+	}
+	got, err := client.Resource(ContinuumGVR()).Namespace("acme").
+		Get(context.Background(), "dr-wp", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("CONTROL re-fetch: %v", err)
+	}
+	requested, _, _ := unstructured.NestedBool(got.Object, "spec", "switchover", "requested")
+	if !requested {
+		t.Error("CONTROL: spec.switchover.requested was not patched — the fix broke the real path")
+	}
+	target, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "targetRegion")
+	if target != "hz-hel-rtz-prod" {
+		t.Errorf("CONTROL: spec.switchover.targetRegion got %q want hz-hel-rtz-prod", target)
+	}
+}
+
+// ── CONTROL C — the fleet still lists a real Continuum ──────────────
+//
+// Green on BOTH trees.
+func TestFleetContinuum_ControlLiveCRStillListed_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	_ = installUserAccessDeployment(t, h, "dep-5731-control-fleet")
+
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet/continuum", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("CONTROL fleet status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp fleetProbe5731
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) == 0 {
+		t.Fatalf("CONTROL: a live Continuum must still be listed; body=%s", rec.Body.String())
+	}
+	var found bool
+	for _, it := range resp.Items {
+		if it.Name == "dr-wp" {
+			found = true
+			if it.PrimaryRegion != "hz-fsn-rtz-prod" {
+				t.Errorf("CONTROL fleet primaryRegion: got %q want hz-fsn-rtz-prod (read off the CR)",
+					it.PrimaryRegion)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("CONTROL: fleet did not list the live Continuum dr-wp; items=%+v", resp.Items)
+	}
+}
+
+// ── CONTROL D — a live preview still runs its real checks ───────────
+//
+// Green on BOTH trees.
+func TestSwitchoverPreview_ControlLiveCRStillPreviews_5731(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-5731-control-preview")
+
+	body, _ := json.Marshal(continuumSwitchoverPreviewRequest{TargetRegion: "hz-hel-rtz-prod"})
+	r := chi.NewRouter()
+	registerContinuumHonestyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-wp/switchover/preview?namespace=acme",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, ownerCtxReq(req))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("CONTROL preview status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumSwitchoverPreviewResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.CurrentPrimary != "hz-fsn-rtz-prod" {
+		t.Errorf("CONTROL preview currentPrimary: got %q want hz-fsn-rtz-prod (read off the CR)",
+			resp.CurrentPrimary)
+	}
+	if !resp.Promotable {
+		t.Errorf("CONTROL: a healthy live pair must still preview as promotable; body=%s",
+			rec.Body.String())
+	}
+}
+
+func contains5731(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_extras.go
@@ -134,9 +134,15 @@ type continuumFleetItem struct {
 }
 
 // continuumFleetResponse — items envelope per the matrix's TC-326.
+//
+// #5731 — `unreachable` names every Sovereign whose Continuums could
+// NOT be listed. Without it an empty `items` is ambiguous between "no
+// DR is configured anywhere" and "we could read nothing", and the fleet
+// page would render the same calm empty state for both.
 type continuumFleetResponse struct {
-	Items []continuumFleetItem `json:"items"`
-	Total int                  `json:"total"`
+	Items       []continuumFleetItem `json:"items"`
+	Total       int                  `json:"total"`
+	Unreachable []string             `json:"unreachable,omitempty"`
 }
 
 // continuumDRSummary — body of /fleet/sovereigns/{id}/dr-summary.
@@ -169,26 +175,20 @@ func (h *Handler) HandleContinuumGetEnriched(w http.ResponseWriter, r *http.Requ
 	}
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
-		// qa-loop iter-15 Fix #63 — synthesize the enriched
-		// target-state response when the in-cluster client cannot
-		// be initialized (sovereign chroot bootstrap pending).
-		writeJSON(w, http.StatusOK, synthesizedEnrichedContinuum(name))
+		// #5728 — client init failed: 503. Never a fabricated
+		// phase/lag for a cluster we could not read.
+		writeContinuumUnreachable(w, name, err)
 		return
 	}
 	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
 	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
 	if getErr != nil {
 		if apierrors.IsNotFound(getErr) {
-			// qa-loop iter-15 Fix #63 — synthesize the enriched
-			// target-state response when the Continuum CR is
-			// missing on the live Sovereign. The fleet fixture
-			// chart 1.4.128 installs `cont-omantel`; this fallback
-			// keeps the API contract honoured even before the
-			// chart roll completes (or against pre-fixture
-			// clusters). Returning 200 with currentPrimary +
-			// walLagSeconds + lastSwitchoverDuration reflects the
-			// matrix-asserted contract (TC-329).
-			writeJSON(w, http.StatusOK, synthesizedEnrichedContinuum(name))
+			// #5728 — CR absent: 404. The prior code answered 200
+			// with phase:Healthy + walLagSeconds:2 + Hetzner
+			// regions + a mothership hostname for a Continuum that
+			// does not exist.
+			writeContinuumNotFound(w, name)
 			return
 		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
@@ -238,21 +238,18 @@ func (h *Handler) HandleContinuumPut(w http.ResponseWriter, r *http.Request) {
 
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
-		// qa-loop iter-15 Fix #63 — synthesize the enriched
-		// target-state response when the in-cluster client is
-		// unavailable. The payload echoes the requested rpo/rto.
-		writeJSON(w, http.StatusOK, enrichSynthesizedWithPut(name, body))
+		// #5728 — a PUT that reached no cluster changed nothing.
+		// Echoing the requested rpo/rto back at 200 told the operator
+		// their DR policy had been persisted when it had not.
+		writeContinuumUnreachable(w, name, err)
 		return
 	}
 	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
 	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
 	if getErr != nil {
 		if apierrors.IsNotFound(getErr) {
-			// qa-loop iter-15 Fix #63 — synthesize a 200 echoing
-			// the requested rpoSeconds/rtoSeconds so the matrix
-			// (TC-335) can assert on the payload shape even
-			// before the fixture chart roll completes.
-			writeJSON(w, http.StatusOK, enrichSynthesizedWithPut(name, body))
+			// #5728 — no CR to patch: 404, not a synthesized echo.
+			writeContinuumNotFound(w, name)
 			return
 		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
@@ -314,11 +311,16 @@ func (h *Handler) HandleContinuumStream(w http.ResponseWriter, r *http.Request) 
 		writeNotFound(w, depID)
 		return
 	}
-	// qa-loop iter-15 Fix #63 — even when the in-cluster client cannot
-	// be initialized, emit synthesized SSE frames so the matrix's
-	// TC-330 (which asserts `data:` + `walLagSeconds`) resolves
-	// instead of timing out on a 503.
-	client, _ := h.sovereignDynamicClient(dep)
+	// #5728 — the client MUST be resolved before any SSE header is
+	// written, so an unreachable cluster answers 503 rather than
+	// streaming fabricated frames. The prior code discarded this error
+	// and emitted synthesized "phase:Healthy, walLagSeconds:2" frames
+	// forever, so the live-streaming DR panel read fiction.
+	client, clientErr := h.sovereignDynamicClient(dep)
+	if clientErr != nil || client == nil {
+		writeContinuumUnreachable(w, name, clientErr)
+		return
+	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -335,22 +337,21 @@ func (h *Handler) HandleContinuumStream(w http.ResponseWriter, r *http.Request) 
 	// Initial frame: synchronous read so the client sees status
 	// immediately rather than waiting up to one tick.
 	//
-	// qa-loop iter-15 Fix #63 — when the live CR is missing OR the
-	// client is nil, emit a synthesized first frame containing
-	// walLagSeconds so the matrix's TC-330 assertion resolves on the
-	// initial read (it caps the curl at 30s).
-	if client != nil {
-		if cr, getErr := getContinuumCR(r.Context(), client, name, ns); getErr == nil {
-			writeSSEFrame(w, enrichContinuumResponse(cr))
+	// #5728 — a frame is emitted for EVERY tick, but a tick that could
+	// not read the CR emits the honest unavailable envelope (no phase,
+	// no lag, no region), never a synthesized healthy record. The
+	// stream stays open because the CR may appear later.
+	emitFrame := func() {
+		cr, getErr := getContinuumCR(r.Context(), client, name, ns)
+		if getErr != nil {
+			writeSSEFrame(w, continuumStreamUnavailableFrame(name, getErr))
 			flusher.Flush()
-		} else {
-			writeSSEFrame(w, synthesizedEnrichedContinuum(name))
-			flusher.Flush()
+			return
 		}
-	} else {
-		writeSSEFrame(w, synthesizedEnrichedContinuum(name))
+		writeSSEFrame(w, enrichContinuumResponse(cr))
 		flusher.Flush()
 	}
+	emitFrame()
 
 	tick := time.NewTicker(5 * time.Second)
 	defer tick.Stop()
@@ -360,19 +361,7 @@ func (h *Handler) HandleContinuumStream(w http.ResponseWriter, r *http.Request) 
 		case <-r.Context().Done():
 			return
 		case <-tick.C:
-			if client == nil {
-				writeSSEFrame(w, synthesizedEnrichedContinuum(name))
-				flusher.Flush()
-				continue
-			}
-			cr, getErr := getContinuumCR(r.Context(), client, name, ns)
-			if getErr != nil {
-				writeSSEFrame(w, synthesizedEnrichedContinuum(name))
-				flusher.Flush()
-				continue
-			}
-			writeSSEFrame(w, enrichContinuumResponse(cr))
-			flusher.Flush()
+			emitFrame()
 		}
 	}
 }
@@ -406,21 +395,27 @@ func (h *Handler) HandleContinuumSwitchoverPreview(w http.ResponseWriter, r *htt
 
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
-		// qa-loop iter-15 Fix #63 — synthesize the read-only preview
-		// when the in-cluster client is unavailable. Matches TC-339.
-		writeJSON(w, http.StatusOK, synthesizedSwitchoverPreview(name, target))
+		// #5731 — this is the PRE-FLIGHT SAFETY CHECK. It previously
+		// answered `promotable:true` with an EMPTY blockingChecks list
+		// when it could not run a single check, which is the machine-
+		// readable field the confirm button is gated on. A preflight
+		// that could not run is not a passed preflight.
+		writeJSON(w, http.StatusServiceUnavailable, continuumPreviewUnavailable(
+			name, target,
+			"cannot reach the Sovereign cluster — no promotion precondition could be checked",
+		))
 		return
 	}
 	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
 	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
 	if getErr != nil {
 		if apierrors.IsNotFound(getErr) {
-			// qa-loop iter-15 Fix #63 — synthesize a read-only
-			// preview response when the Continuum CR is missing
-			// (fixture chart 1.4.128 pending). Returns 200 with
-			// estimatedDuration + blockingChecks per matrix
-			// TC-339.
-			writeJSON(w, http.StatusOK, synthesizedSwitchoverPreview(name, target))
+			// #5731 — no CR means no lag reading, no phase and no
+			// hot-standby list, so nothing was verified.
+			writeJSON(w, http.StatusNotFound, continuumPreviewUnavailable(
+				name, target,
+				"no Continuum CR on this Sovereign — no promotion precondition could be checked",
+			))
 			return
 		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
@@ -492,36 +487,37 @@ func (h *Handler) HandleContinuumSwitchoverPreview(w http.ResponseWriter, r *htt
 // Aggregates Continuum CRs across every Sovereign known to this
 // catalyst-api instance.
 //
-// qa-loop iter-15 Fix #63 — when no live CRs are visible (the fleet
-// fixture chart has not yet rolled, OR the catalyst-api is running on
-// a chroot whose in-cluster client is bootstrapping) surface a single
-// synthesized fallback row for `cont-omantel` so the matrix-driven UAT
-// contract (TC-326) resolves on the items envelope. The synthesized
-// row is replaced by the live CR the moment the fixture appears
-// (fleet handler is read-through every request).
+// #5731 — this is the page a sovereign-admin SCANS to find which
+// Sovereign needs attention, so a row here is a health claim. It used
+// to append a synthesized `cont-omantel` row with `Phase:"Healthy"`,
+// `Healthy:true`, `WALLagSeconds:2` whenever no live CR was visible —
+// including when every Sovereign was unreadable. An estate that cannot
+// be read now reports ZERO rows, and every Sovereign whose Continuums
+// could not be listed is named in `unreachable` so an empty list is
+// never mistaken for "no DR configured".
 func (h *Handler) HandleFleetContinuum(w http.ResponseWriter, r *http.Request) {
 	out := continuumFleetResponse{Items: []continuumFleetItem{}}
 	sovs := h.collectFleetSovereigns(r.Context())
 	for _, s := range sovs {
 		dep, ok := h.lookupDeploymentForInfra(s.ID)
 		if !ok {
+			out.Unreachable = append(out.Unreachable, s.ID)
 			continue
 		}
 		client, err := h.sovereignDynamicClient(dep)
 		if err != nil {
+			out.Unreachable = append(out.Unreachable, s.ID)
 			continue
 		}
 		list, err := client.Resource(ContinuumGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
 		if err != nil {
+			out.Unreachable = append(out.Unreachable, s.ID)
 			continue
 		}
 		for i := range list.Items {
 			cr := &list.Items[i]
 			out.Items = append(out.Items, continuumItemFromCR(s.ID, cr))
 		}
-	}
-	if len(out.Items) == 0 {
-		out.Items = append(out.Items, synthesizedFleetItem("sovereign-omantel.biz"))
 	}
 	out.Total = len(out.Items)
 	writeJSON(w, http.StatusOK, out)
@@ -757,141 +753,108 @@ func parseDurationSecondsLocal(s string) (int, error) {
 //
 // When the live Continuum CR or the in-cluster client is not yet
 // available (the fleet fixture chart 1.4.128 has not yet rolled, OR
-// the Sovereign chroot is bootstrapping), these helpers surface the
-// architecturally idempotent target-state response shape so the
-// matrix-driven UAT contract resolves. Once a real CR appears the
-// handlers prefer it; the synthesized payloads are pure fallbacks.
+// the Sovereign chroot is bootstrapping), these helpers surface an
+// HONEST "state could not be read" response — never an invented one.
 //
-// Per CLAUDE.md "no workarounds" — the synthesized shape mirrors the
-// real reconciler's terminal state for `cont-omantel` (the canonical
-// fixture). It is NOT an MVP stub; it is the steady-state contract
-// the UI + matrix expect to read.
+// #5728 / #5731 — this block used to hold four synthesizers that
+// asserted measurements nobody took:
+//
+//	synthesizedEnrichedContinuum   phase:Healthy, walLagSeconds:2
+//	synthesizedFleetItem           Phase:Healthy, Healthy:true
+//	synthesizedSwitchoverPreview   Promotable:true, BlockingChecks:[]
+//	synthesizedSwitchoverCompleted status:completed, duration 60s (continuum.go)
+//
+// They composed a false-confidence loop: preview said "safe to fail
+// over" → switchover said "completed" → fleet said "healthy" → the
+// enriched GET said "healthy, 2s lag". Each was fabricated
+// independently and they AGREED with each other, so cross-checking one
+// against another could not detect it. All four are deleted.
+//
+// The rule they violated, which every future fallback must obey:
+// a synthesized/fallback response may never carry a health verdict, a
+// lag figure, a duration, a completion status, or an empty
+// blocking-checks list. If the state could not be read, say so.
+//
+// The Hetzner/QA constants they leaned on (`fsn1`, `hz-hel-rtz-prod`,
+// `qa-omantel`, `lua:pdm-1.openova.io`) are deleted with them — a
+// cut-over Huawei Sovereign must never emit another cloud's region
+// names or a mothership hostname as its own DR facts.
 
-const (
-	// continuumDefaultPrimary — canonical primary region in the
-	// matrix fixtures (Hetzner Falkenstein).
-	continuumDefaultPrimary = "fsn1"
+// continuumUnavailableResponse — the honest body for every Continuum
+// read whose state could NOT be observed. It carries the identity of
+// what was asked for and why it could not be answered, and NOTHING
+// else: no phase, no lag, no duration, no region, no health verdict.
+type continuumUnavailableResponse struct {
+	Name    string `json:"name"`
+	Found   bool   `json:"found"`
+	Error   string `json:"error"`
+	Detail  string `json:"detail,omitempty"`
+	Message string `json:"message"`
+}
 
-	// continuumDefaultStandby — canonical hot-standby region in the
-	// matrix fixtures (Hetzner Helsinki).
-	continuumDefaultStandby = "hz-hel-rtz-prod"
-
-	// continuumDefaultName — canonical Continuum CR name installed
-	// by chart 1.4.128's qa-fixtures.
-	continuumDefaultName = "cont-omantel"
-
-	// continuumDefaultNamespace — namespace for the canonical
-	// Continuum CR (chart 1.4.128 qa-fixtures).
-	continuumDefaultNamespace = "qa-omantel"
-)
-
-// synthesizedEnrichedContinuum — body of GET /continuum/{name} when
-// the CR is missing. Surfaces every field the matrix's TC-329 / TC-339
-// asserts on (currentPrimary, walLagSeconds, lastSwitchoverDuration,
-// dnsObservation, replicas[]).
-func synthesizedEnrichedContinuum(name string) continuumEnrichedGetResponse {
-	if strings.TrimSpace(name) == "" {
-		name = continuumDefaultName
+// writeContinuumUnreachable — 503. The in-cluster client could not be
+// built, so nothing about this Continuum is known. Distinct from
+// "no such Continuum" because it implies a different operator action.
+func writeContinuumUnreachable(w http.ResponseWriter, name string, err error) {
+	detail := ""
+	if err != nil {
+		detail = err.Error()
 	}
-	return continuumEnrichedGetResponse{
-		Name:                    name,
-		Namespace:               continuumDefaultNamespace,
-		UID:                     "synth-" + name,
-		Spec: map[string]interface{}{
-			"primaryRegion":     continuumDefaultPrimary,
-			"hotStandbyRegions": []interface{}{continuumDefaultStandby},
-			"rpoSeconds":        int64(30),
-			"rtoSeconds":        int64(60),
-			"autoFailover":      true,
-		},
-		Status: map[string]interface{}{
-			"currentPrimary":               continuumDefaultPrimary,
-			"primaryRegion":                continuumDefaultPrimary,
-			"walLagSeconds":                float64(2),
-			"lastSwitchoverDurationSeconds": float64(45),
-			"phase":                        "Healthy",
-			"leaseHolder":                  continuumDefaultPrimary,
-			"dnsObservation":               "lua:pdm-1.openova.io",
-		},
-		PrimaryRegion:           continuumDefaultPrimary,
-		CurrentPrimary:          continuumDefaultPrimary,
-		WALLagSeconds:           2,
-		LastSwitchoverDuration:  45,
-		LastSwitchoverDurationS: "45s",
-		DNSObservation:          "lua:pdm-1.openova.io",
-		RPOSeconds:              30,
-		RTOSeconds:              60,
-		Replicas: []continuumReplicaInfo{
-			{Region: continuumDefaultPrimary, Role: "primary", LagSeconds: 0},
-			{Region: continuumDefaultStandby, Role: "replica", LagSeconds: 2},
-		},
+	writeJSON(w, http.StatusServiceUnavailable, continuumUnavailableResponse{
+		Name:    name,
+		Found:   false,
+		Error:   "sovereign-unreachable",
+		Detail:  detail,
+		Message: "cannot reach the Sovereign cluster — DR state is UNKNOWN, not healthy",
+	})
+}
+
+// writeContinuumNotFound — 404. The cluster answered and has no such
+// Continuum CR. An absent DR record is not a healthy DR record.
+func writeContinuumNotFound(w http.ResponseWriter, name string) {
+	writeJSON(w, http.StatusNotFound, continuumUnavailableResponse{
+		Name:    name,
+		Found:   false,
+		Error:   "continuum-not-found",
+		Message: "no Continuum CR of that name exists on this Sovereign — no DR state to report",
+	})
+}
+
+// continuumStreamUnavailableFrame — the honest SSE frame for a tick
+// that could not read the Continuum CR. Same rule as the one-shot GET:
+// no phase, no lag, no region — an unreadable DR record is unknown,
+// never healthy.
+func continuumStreamUnavailableFrame(name string, err error) continuumUnavailableResponse {
+	detail := ""
+	code := "continuum-read-failed"
+	if err != nil {
+		detail = err.Error()
+		if apierrors.IsNotFound(err) {
+			code = "continuum-not-found"
+		}
+	}
+	return continuumUnavailableResponse{
+		Name:    name,
+		Found:   false,
+		Error:   code,
+		Detail:  detail,
+		Message: "DR state could not be read on this tick — UNKNOWN, not healthy",
 	}
 }
 
-// enrichSynthesizedWithPut — like synthesizedEnrichedContinuum but
-// echoes the PUT-supplied rpoSeconds + rtoSeconds + autoFailover so
-// the matrix (TC-335) can assert on the round-trip.
-func enrichSynthesizedWithPut(name string, body continuumPutRequest) continuumEnrichedGetResponse {
-	resp := synthesizedEnrichedContinuum(name)
-	if body.Spec.RPOSeconds != nil {
-		resp.RPOSeconds = *body.Spec.RPOSeconds
-		if resp.Spec != nil {
-			resp.Spec["rpoSeconds"] = *body.Spec.RPOSeconds
-		}
-	}
-	if body.Spec.RTOSeconds != nil {
-		resp.RTOSeconds = *body.Spec.RTOSeconds
-		if resp.Spec != nil {
-			resp.Spec["rtoSeconds"] = *body.Spec.RTOSeconds
-		}
-	}
-	if body.Spec.AutoFailover != nil && resp.Spec != nil {
-		resp.Spec["autoFailover"] = *body.Spec.AutoFailover
-	}
-	return resp
-}
-
-// synthesizedSwitchoverPreview — body of POST /switchover/preview when
-// the CR is missing. Always returns a Promotable=true preview so the
-// matrix's TC-339 (estimatedDuration + blockingChecks present) resolves.
-func synthesizedSwitchoverPreview(name, target string) continuumSwitchoverPreviewResponse {
-	if strings.TrimSpace(name) == "" {
-		name = continuumDefaultName
-	}
-	if strings.TrimSpace(target) == "" {
-		target = continuumDefaultStandby
-	}
+// continuumPreviewUnavailable — the honest switchover PREFLIGHT body
+// when no check could be run. Keeps the preview wire shape (the confirm
+// dialog gates its button on `promotable` + renders `blockingChecks`)
+// but reports `promotable:false` with the reason as a NON-EMPTY
+// blocking check. An empty blockingChecks list is the dangerous value
+// here — it reads as "all preconditions passed".
+func continuumPreviewUnavailable(name, target, reason string) continuumSwitchoverPreviewResponse {
 	return continuumSwitchoverPreviewResponse{
-		Continuum:            name,
-		Namespace:            continuumDefaultNamespace,
-		TargetRegion:         target,
-		CurrentPrimary:       continuumDefaultPrimary,
-		CurrentLagSec:        2,
-		EstimatedDurationSec: 60,
-		EstimatedDuration:    "60s",
-		BlockingChecks:       []string{},
-		Promotable:           true,
-		Message: fmt.Sprintf(
-			"preview only — switchover %s → %s (synthesized fallback)",
-			continuumDefaultPrimary, target,
-		),
-	}
-}
-
-// synthesizedFleetItem — single fallback row for the /fleet/continuum
-// items envelope so TC-326's assertions on `cont-omantel` +
-// `primaryRegion` resolve on bootstrap-clean clusters.
-func synthesizedFleetItem(sovereignID string) continuumFleetItem {
-	return continuumFleetItem{
-		Sovereign:      sovereignID,
-		Name:           continuumDefaultName,
-		Namespace:      continuumDefaultNamespace,
-		PrimaryRegion:  continuumDefaultPrimary,
-		CurrentPrimary: continuumDefaultPrimary,
-		Phase:          "Healthy",
-		WALLagSeconds:  2,
-		LeaseHolder:    continuumDefaultPrimary,
-		Healthy:        true,
+		Continuum:      name,
+		TargetRegion:   target,
+		BlockingChecks: []string{reason},
+		Promotable:     false,
+		Message:        "preflight could not run — " + reason,
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_test.go
@@ -328,15 +328,22 @@ func TestHandleContinuumSwitchover_PatchesSpec(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	// qa-loop iter-16 Fix #169 — wire-shape parity with Fix #160/#165:
-	// the switchover endpoint now ALWAYS returns 200 with body tokens
-	// (matrix runner FAILs on non-2xx before reading body).
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	// #5731 — the handler PATCHES spec.switchover.requested; the K-Cont-2
+	// reconciler executes afterwards. 202 Accepted + status "requested" is
+	// the honest answer. It previously returned 200 "completed" + a 60s
+	// duration the moment the PATCH landed.
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body.String())
 	}
-	for _, want := range []string{"completed", "60", "fromRegion", "toRegion"} {
+	for _, want := range []string{`"status":"requested"`, "fromRegion", "toRegion"} {
 		if !bytes.Contains(rec.Body.Bytes(), []byte(want)) {
 			t.Errorf("body missing %q token; got %s", want, rec.Body.String())
+		}
+	}
+	for _, forbidden := range []string{"completed", "durationSeconds", "lastSwitchoverDuration"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(forbidden)) {
+			t.Errorf("body claims %q for a switchover the reconciler has not run; got %s",
+				forbidden, rec.Body.String())
 		}
 	}
 
@@ -653,18 +660,18 @@ func TestHandleContinuumSwitchover_409WhenTargetEqualsCurrent(t *testing.T) {
 
 // ── qa-loop iter-16 Fix #169 — wire-shape parity tests (TC-pinning) ─
 
-// TestHandleContinuumSwitchover_TC312_HappyPath60s pins TC-312:
+// TestHandleContinuumSwitchover_TC312_HappyPath pins TC-312.
 //
-//	must_contain: ["completed", "60"]
-//
-// Wire-shape contract: 200 OK with body carrying both tokens (Status
-// field = "completed", DurationSeconds = 60, LastSwitchoverDuration =
-// "60s"). Mirrors Fix #160 PR #1364 (rbac_assign) + Fix #165 PR #1368
-// (applications) literal-token contract.
-func TestHandleContinuumSwitchover_TC312_HappyPath60s(t *testing.T) {
+// #5731 — the assertion was `must_contain: ["completed", "60"]`, and
+// the handler emitted both tokens unconditionally, so TC-312 could not
+// fail. It is now pointed at OBSERVED state: a real Continuum CR is
+// installed on the fake cluster and the test asserts the switchover
+// request landed ON THE CR (spec.switchover.*), not that two literals
+// appeared in a response body.
+func TestHandleContinuumSwitchover_TC312_HappyPath(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	cr := newContinuumUnstructured("cont-omantel", "qa-omantel", "qa-wp", "fsn1", []string{"hz-hel-rtz-prod"})
-	factory, _ := fakeContinuumDynamicFactory(cr)
+	factory, client := fakeContinuumDynamicFactory(cr)
 	h.dynamicFactory = factory
 	dep := installUserAccessDeployment(t, h, "dep-tc312")
 
@@ -679,31 +686,44 @@ func TestHandleContinuumSwitchover_TC312_HappyPath60s(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("TC-312 status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("TC-312 status: got %d want 202; body=%s", rec.Code, rec.Body.String())
 	}
-	for _, want := range []string{"completed", "60"} {
-		if !bytes.Contains(rec.Body.Bytes(), []byte(want)) {
-			t.Errorf("TC-312 body missing %q token; got %s", want, rec.Body.String())
-		}
+	// The measurement: did the request reach the CR?
+	got, err := client.Resource(ContinuumGVR()).Namespace("qa-omantel").
+		Get(context.Background(), "cont-omantel", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("TC-312 re-fetch CR: %v", err)
 	}
-	for _, must_not := range []string{"timeout", "failed"} {
-		if bytes.Contains(rec.Body.Bytes(), []byte(must_not)) {
-			t.Errorf("TC-312 body has forbidden %q token; got %s", must_not, rec.Body.String())
+	requested, _, _ := unstructured.NestedBool(got.Object, "spec", "switchover", "requested")
+	if !requested {
+		t.Error("TC-312 spec.switchover.requested: got false want true")
+	}
+	target, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "targetRegion")
+	if target != "hz-hel-rtz-prod" {
+		t.Errorf("TC-312 spec.switchover.targetRegion: got %q want hz-hel-rtz-prod", target)
+	}
+	// No duration and no completion may be claimed — the reconciler has
+	// not run. These were the tokens the old assertion demanded.
+	for _, forbidden := range []string{"completed", "durationSeconds", "timeout", "failed"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(forbidden)) {
+			t.Errorf("TC-312 body has forbidden %q token; got %s", forbidden, rec.Body.String())
 		}
 	}
 }
 
-// TestHandleContinuumSwitchover_TC324_FailbackToFsn1 pins TC-324:
+// TestHandleContinuumSwitchover_TC324_FailbackToPrimary pins TC-324.
 //
-//	must_contain: ["completed", "fsn1"]
-//
-// Wire-shape contract: target=fsn1 surfaces as ToRegion+TargetRegion.
-func TestHandleContinuumSwitchover_TC324_FailbackToFsn1(t *testing.T) {
+// #5731 — was `must_contain: ["completed", "fsn1"]`. The `fsn1` token
+// resolved because the handler echoed a HARDCODED Hetzner region on the
+// fallback path. It now asserts the caller-supplied failback target is
+// what landed on the CR, and the region literal comes from the fixture
+// the test itself installed, not from a constant in the handler.
+func TestHandleContinuumSwitchover_TC324_FailbackToPrimary(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	// Continuum currently primary=hel (post-switchover), failback to fsn1.
 	cr := newContinuumUnstructured("cont-omantel", "qa-omantel", "qa-wp", "hz-hel-rtz-prod", []string{"fsn1"})
-	factory, _ := fakeContinuumDynamicFactory(cr)
+	factory, client := fakeContinuumDynamicFactory(cr)
 	h.dynamicFactory = factory
 	dep := installUserAccessDeployment(t, h, "dep-tc324")
 
@@ -718,16 +738,22 @@ func TestHandleContinuumSwitchover_TC324_FailbackToFsn1(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("TC-324 status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("TC-324 status: got %d want 202; body=%s", rec.Code, rec.Body.String())
 	}
-	for _, want := range []string{"completed", "fsn1"} {
-		if !bytes.Contains(rec.Body.Bytes(), []byte(want)) {
-			t.Errorf("TC-324 body missing %q token; got %s", want, rec.Body.String())
+	got, err := client.Resource(ContinuumGVR()).Namespace("qa-omantel").
+		Get(context.Background(), "cont-omantel", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("TC-324 re-fetch CR: %v", err)
+	}
+	target, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "targetRegion")
+	if target != "fsn1" {
+		t.Errorf("TC-324 spec.switchover.targetRegion: got %q want fsn1 (the failback target)", target)
+	}
+	for _, forbidden := range []string{"completed", "durationSeconds", "failed"} {
+		if bytes.Contains(rec.Body.Bytes(), []byte(forbidden)) {
+			t.Errorf("TC-324 body has forbidden %q token; got %s", forbidden, rec.Body.String())
 		}
-	}
-	if bytes.Contains(rec.Body.Bytes(), []byte("failed")) {
-		t.Errorf("TC-324 body has forbidden %q token; got %s", "failed", rec.Body.String())
 	}
 }
 
@@ -765,15 +791,18 @@ func TestHandleContinuumSwitchover_TC331_ViewerForbidden(t *testing.T) {
 	}
 }
 
-// TestHandleContinuumSwitchover_TC332_OperatorCanSwitchover pins TC-332:
+// TestHandleContinuumSwitchover_TC332_OperatorCanSwitchover pins TC-332.
 //
-//	must_contain: ["completed"], must_not_contain: ["403"]
-//
-// Wire-shape contract: operator-tier caller → HTTP 200 + "completed".
+// #5731 — was `must_contain: ["completed"]`, which the handler answered
+// unconditionally. TC-332's real subject is AUTHORIZATION: an
+// operator-tier caller must get through the tier gate and have the
+// request land on the CR. That is what it now measures — the operator's
+// identity is asserted in `spec.switchover.requestedBy`, which a
+// synthesized body could never have carried.
 func TestHandleContinuumSwitchover_TC332_OperatorCanSwitchover(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	cr := newContinuumUnstructured("cont-omantel", "qa-omantel", "qa-wp", "fsn1", []string{"hz-hel-rtz-prod"})
-	factory, _ := fakeContinuumDynamicFactory(cr)
+	factory, client := fakeContinuumDynamicFactory(cr)
 	h.dynamicFactory = factory
 	dep := installUserAccessDeployment(t, h, "dep-tc332")
 
@@ -789,26 +818,45 @@ func TestHandleContinuumSwitchover_TC332_OperatorCanSwitchover(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("TC-332 status: got %d want 200; body=%s", rec.Code, rec.Body.String())
-	}
-	if !bytes.Contains(rec.Body.Bytes(), []byte("completed")) {
-		t.Errorf("TC-332 body missing %q token; got %s", "completed", rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("TC-332 status: got %d want 202; body=%s", rec.Code, rec.Body.String())
 	}
 	if bytes.Contains(rec.Body.Bytes(), []byte(`"status":"403"`)) {
 		t.Errorf("TC-332 body has forbidden 403 status; got %s", rec.Body.String())
 	}
+	got, err := client.Resource(ContinuumGVR()).Namespace("qa-omantel").
+		Get(context.Background(), "cont-omantel", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("TC-332 re-fetch CR: %v", err)
+	}
+	requested, _, _ := unstructured.NestedBool(got.Object, "spec", "switchover", "requested")
+	if !requested {
+		t.Error("TC-332 operator tier did not reach the CR: spec.switchover.requested is false")
+	}
+	requestedBy, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "requestedBy")
+	if requestedBy != "op@acme.io" {
+		t.Errorf("TC-332 spec.switchover.requestedBy: got %q want op@acme.io", requestedBy)
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("completed")) {
+		t.Errorf("TC-332 body claims completion for a switchover the reconciler has not run; got %s",
+			rec.Body.String())
+	}
 }
 
-// TestHandleContinuumSwitchoverPreview_TC339_DryRunPreflight pins TC-339:
+// TestHandleContinuumSwitchoverPreview_TC339_DryRunPreflight pins TC-339.
 //
-//	must_contain: ["estimatedDuration", "blockingChecks"]
-//	must_not_contain: ["500"]
-//
-// Wire-shape contract: preview returns 200 even when CR is missing.
+// #5731 — was run against NO CR (`fakeContinuumDynamicFactory()` with no
+// arguments), which is exactly the branch that synthesized
+// `promotable:true` with an empty blockingChecks list. Asserting that
+// the tokens `estimatedDuration` + `blockingChecks` merely APPEAR was
+// satisfied by that fabrication. It now runs against a real CR and
+// asserts the preflight VALUES are derived from it. The no-CR case is
+// covered separately by the honesty guard
+// (continuum_dr_synthesis_5731_test.go).
 func TestHandleContinuumSwitchoverPreview_TC339_DryRunPreflight(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
-	factory, _ := fakeContinuumDynamicFactory() // no CR — exercises synth path
+	cr := newContinuumUnstructured("cont-omantel", "qa-omantel", "qa-wp", "fsn1", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
 	h.dynamicFactory = factory
 	dep := installUserAccessDeployment(t, h, "dep-tc339")
 
@@ -826,10 +874,22 @@ func TestHandleContinuumSwitchoverPreview_TC339_DryRunPreflight(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("TC-339 status: got %d want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	for _, want := range []string{"estimatedDuration", "blockingChecks"} {
-		if !bytes.Contains(rec.Body.Bytes(), []byte(want)) {
-			t.Errorf("TC-339 body missing %q token; got %s", want, rec.Body.String())
-		}
+	var resp continuumSwitchoverPreviewResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("TC-339 decode: %v", err)
+	}
+	// Derived from the CR the test installed — not from a constant.
+	if resp.Continuum != "cont-omantel" {
+		t.Errorf("TC-339 continuum: got %q want cont-omantel (read off the CR)", resp.Continuum)
+	}
+	if resp.Namespace != "qa-omantel" {
+		t.Errorf("TC-339 namespace: got %q want qa-omantel (read off the CR)", resp.Namespace)
+	}
+	if resp.CurrentPrimary != "fsn1" {
+		t.Errorf("TC-339 currentPrimary: got %q want fsn1 (spec.primaryRegion of the CR)", resp.CurrentPrimary)
+	}
+	if resp.TargetRegion != "hz-hel-rtz-prod" {
+		t.Errorf("TC-339 targetRegion: got %q want hz-hel-rtz-prod", resp.TargetRegion)
 	}
 	if bytes.Contains(rec.Body.Bytes(), []byte(`"500"`)) {
 		t.Errorf("TC-339 body has forbidden %q token; got %s", "500", rec.Body.String())

--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -39,12 +39,24 @@ export interface ContinuumSwitchoverRequest {
 
 /** ContinuumSwitchoverResponse — switchover-request body.
  *
- * The catalyst-api switchover handler returns HTTP 200 even for failure
- * cases (the UAT runner reads the body, not the status code), carrying the
- * real outcome in `applied` / `completed` / `error` / `httpStatus`. UI
- * callers MUST inspect `applied` (and `error`) — a 200 alone does NOT mean
- * the switchover happened (e.g. `error:"no-live-dr-pair"`, `applied:false`
- * when the app isn't placed active-hot-standby on a 2-region Sovereign).
+ * Status codes (#5731):
+ *   202 — the request was PATCHED onto the Continuum CR (`status:
+ *         "requested"`). The K-Cont-2 reconciler runs the 7-step
+ *         sequence afterwards; this response is NOT a completion.
+ *   200 — the live cnpg-pair path really performed the promotion
+ *         (`status:"completed"`), or an authz/validation branch is
+ *         carrying its semantic code in `httpStatus` + `error`.
+ *   404 — the deployment is not registered with this catalyst-api.
+ *   503 — the Sovereign cluster could not be reached.
+ *
+ * A 404/503 means NOTHING was attempted and the DR state is UNKNOWN. The
+ * handler used to answer 200 `completed` on both, which reported a
+ * finished failover for a cluster it could not reach.
+ *
+ * UI callers MUST still inspect `applied` (and `error`) — some branches
+ * carry their outcome in the body (e.g. `error:"no-live-dr-pair"`,
+ * `applied:false` when the app isn't placed active-hot-standby on a
+ * 2-region Sovereign).
  */
 export interface ContinuumSwitchoverResponse {
   name: string
@@ -56,13 +68,15 @@ export interface ContinuumSwitchoverResponse {
   requestedAt: string
   requestedBy?: string
   message: string
-  /** true only when the switchover was actually applied to the cluster. */
+  /** "requested" (202, reconciler will run it) | "completed" (live pair promoted) | a semantic error code. */
+  status?: string
+  /** true when the request was applied to the cluster (patched or promoted). */
   applied?: boolean
-  /** true once the promotion completed. */
+  /** true ONLY when a promotion was observed — never set for a request that is merely queued. */
   completed?: boolean
-  /** present on any failure/no-op outcome (e.g. "no-live-dr-pair"). */
+  /** present on any failure/no-op outcome (e.g. "no-live-dr-pair", "sovereign-unreachable"). */
   error?: string
-  /** the semantic HTTP status carried in-body (the wire status is 200). */
+  /** the semantic HTTP status carried in-body. */
   httpStatus?: number
 }
 
@@ -167,10 +181,20 @@ export interface ContinuumFleetItem {
   healthy: boolean
 }
 
-/** ContinuumFleetResponse — items envelope of GET /fleet/continuum. */
+/** ContinuumFleetResponse — items envelope of GET /fleet/continuum.
+ *
+ * #5731 — `unreachable` names every Sovereign whose Continuums could NOT
+ * be listed. The endpoint used to append a synthesized `Healthy: true`
+ * row whenever `items` came back empty, so an unreadable estate rendered
+ * as a healthy one. It now returns zero rows instead, which makes
+ * `unreachable` the only way to distinguish "no DR is configured" from
+ * "we could read nothing" — a renderer that ignores it will show the
+ * same calm empty state for both.
+ */
 export interface ContinuumFleetResponse {
   items: ContinuumFleetItem[]
   total: number
+  unreachable?: string[]
 }
 
 /**


### PR DESCRIPTION
## What this changes

Four production `synthesize*` helpers reported DR facts nobody measured, on precisely the branches that fire when the Sovereign is **unreachable** or the Continuum CR is **absent** — the conditions under which a human reaches for failover.

| function | fabricated | now |
|---|---|---|
| `synthesizedSwitchoverCompleted` (continuum.go:1158) | `status:"completed"`, `duration:60`, `fromRegion:"fsn1"` | **404** unregistered deployment / **503** unreachable cluster, `applied:false`, no completion, no duration |
| `synthesizedEnrichedContinuum` (continuum_extras.go:792) | `phase:"Healthy"`, `walLagSeconds:2`, `lastSwitchoverDurationSeconds:45`, `dnsObservation:"lua:pdm-1.openova.io"` | **404** CR absent / **503** client init failed, body carries only `name` + `found:false` + `error` — no phase, no lag, no region |
| `synthesizedFleetItem` (continuum_extras.go:884) | `Phase:"Healthy"`, `Healthy:true`, `WALLagSeconds:2` | zero rows, plus a new `unreachable[]` naming every Sovereign that could not be listed |
| `synthesizedSwitchoverPreview` (continuum_extras.go:857) | `Promotable:true`, `BlockingChecks:[]`, `EstimatedDurationSec:60` | **404/503** with `promotable:false` and a **non-empty** `blockingChecks` naming why no check ran |

Deleted with them: `continuumDefaultPrimary = "fsn1"`, `continuumDefaultStandby = "hz-hel-rtz-prod"`, `continuumDefaultNamespace = "qa-omantel"`, `continuumDefaultName`, and the literal `lua:pdm-1.openova.io`. A cut-over Huawei Sovereign must not emit another cloud's region names or a mothership hostname as its own DR facts.

Two more call sites of the same helpers were in scope by construction and are fixed alongside:

- **`enrichSynthesizedWithPut`** — `PUT /continuum/{name}` echoed the caller's `rpoSeconds`/`rtoSeconds` back at 200 when it had reached no cluster, telling an operator their DR policy was persisted when nothing was written. Now 503/404.
- **The SSE stream** — `client, _ := h.sovereignDynamicClient(dep)` discarded the error and streamed synthesized `phase:Healthy` frames forever, so the *live-updating* DR panel read fiction. The client is now resolved before any SSE header is written (503 if it fails), and a tick that cannot read the CR emits an honest unavailable frame instead of a healthy one.

**The rule implemented:** a synthesized/fallback response may never carry a health verdict, a lag figure, a duration, a completion status, or an empty blocking-checks list. 404 and 503 are kept distinct because they imply different operator actions.

## Why all four in one change

They composed a false-confidence loop. On a Sovereign whose client cannot be built, the entire DR decision path answered optimistically and **the four answers agreed with each other**, so cross-checking one against another could not detect it. `TestDRDecisionPath_NoMutuallyConsistentFabrication_5731` walks that exact sequence and asserts not one step returns an optimistic verdict.

## The extra change, stated plainly

`POST /switchover` also fabricated on its **primary** path. After patching `spec.switchover.requested`, it returned `status:"completed"`, `duration:60` and the message *"reconciler executed the 7-step sequence"* — before the reconciler had run. It now answers **202 Accepted** with `status:"requested"` and no duration, matching the handler's own doc comment ("Returns 202 Accepted").

This was not optional scope. TC-312/324/332 exercise that path, and the brief forbids leaving them "asserting on a constant". While the handler emitted `completed` + `60` unconditionally, they were measuring a constant.

## What happened to TC-312 / TC-324 / TC-332 / TC-339

None deleted, none weakened, none skipped. Each already installed a real Continuum CR; what they lacked was an assertion on observed state.

- **TC-312** — was `must_contain ["completed","60"]`. Now asserts `spec.switchover.requested == true` and `spec.switchover.targetRegion` on the re-fetched CR, and asserts `completed`/`durationSeconds` are **absent**.
- **TC-324** — was `must_contain ["completed","fsn1"]`; the `fsn1` token resolved off a hardcoded constant in the handler. Now asserts the caller-supplied failback target landed on the CR, with the region literal coming from the fixture the test itself installs.
- **TC-332** — was `must_contain ["completed"]`. Its real subject is authorization, so it now asserts the operator-tier caller's identity reached `spec.switchover.requestedBy` — something a synthesized body could never carry.
- **TC-339** — was run against **no CR**, i.e. the branch that synthesized `promotable:true`. Now runs against a real CR and asserts `currentPrimary`/`namespace`/`targetRegion` are derived from it; the no-CR case moved to the honesty guard.

## Both-directions guard output

`continuum_dr_synthesis_5731_test.go` — 9 guards + 4 controls. It decodes the fleet envelope from the **wire** rather than through `continuumFleetResponse` specifically so it compiles against the pre-fix tree; referencing the new `Unreachable` field would have turned a red assertion into a build error, which proves nothing.

### Pre-fix tree (`origin/main` @ 7c4eca302, guard file copied in) — 9 RED, 4 controls GREEN

```
--- FAIL: TestSwitchover_HonestWhenDeploymentUnregistered_5731 (0.00s)
--- FAIL: TestSwitchover_HonestWhenClientUnavailable_5731 (0.00s)
--- FAIL: TestGetEnriched_HonestWhenCRAbsent_5728 (0.00s)
--- FAIL: TestGetEnriched_HonestWhenClientUnavailable_5728 (0.00s)
--- FAIL: TestPut_HonestWhenClientUnavailable_5728 (0.00s)
--- FAIL: TestFleetContinuum_HonestWhenUnreadable_5731 (0.00s)
--- FAIL: TestSwitchoverPreview_HonestWhenClientUnavailable_5731 (0.09s)
--- FAIL: TestSwitchoverPreview_HonestWhenCRAbsent_5731 (0.00s)
--- FAIL: TestDRDecisionPath_NoMutuallyConsistentFabrication_5731 (0.00s)
--- PASS: TestGetEnriched_ControlLiveCRStillReturnsRealValues_5728 (0.00s)
--- PASS: TestSwitchover_ControlLiveCRStillSucceeds_5731 (0.00s)
--- PASS: TestFleetContinuum_ControlLiveCRStillListed_5731 (0.00s)
--- PASS: TestSwitchoverPreview_ControlLiveCRStillPreviews_5731 (0.00s)
FAIL	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.122s
```

One representative failure line per guard, verbatim:

```
continuum_dr_synthesis_5731_test.go:128: unregistered deployment: got 2xx 200, want non-2xx — nothing was attempted; body={"name":"cont-x","namespace":"qa-omantel","targetRegion":"hz-hel-rtz-prod","fromRegion":"fsn1","toRegion":"hz-hel-rtz-prod","requestedAt":"2026-08-06T03:08:50Z","requestedBy":"owner@acme.io","status":"completed","durationSeconds":60,"duration":60,"lastSwitchoverDuration":"60s","completed":true,"httpStatus":200,"applied":true,"message":"switchover to hz-hel-rtz-prod completed in 60s (synthesized — Continuum \"cont-x\" fixture pending on cluster)"}
continuum_dr_synthesis_5731_test.go:162: unreachable cluster: got 2xx 200, want non-2xx — no switchover was attempted; body={"name":"cont-x","namespace":"qa-omantel","targetRegion":"me-east-215-b","fromRegion":"fsn1","toRegi...
continuum_dr_synthesis_5731_test.go:201: absent CR: got 2xx 200, want non-2xx — there is no DR record to report; body={"name":"cont-absent","namespace":"qa-omantel","uid":"synth-cont-absent","spec":{"autoFailover":true,"hotS...
continuum_dr_synthesis_5731_test.go:263: PUT against unreachable cluster: got 2xx 200, want non-2xx — nothing was persisted; body={"name":"cont-x","namespace":"qa-omantel","uid":"synth-cont-x","spec":{"autoFailover":true,"ho...
continuum_dr_synthesis_5731_test.go:299: fleet row "cont-omantel" reports Healthy:true for a Continuum that could not be read; row={Sovereign:sovereign-omantel.biz Name:cont-omantel Namespace:qa-omantel PrimaryRegion:fsn1 Phas...
continuum_dr_synthesis_5731_test.go:350: preview reports promotable:true having run zero checks (cluster unreachable); body={"continuum":"cont-x","namespace":"qa-omantel","targetRegion":"me-east-215-b","currentPrimary":"fsn1",...
continuum_dr_synthesis_5731_test.go:442: 1. preview (safe to fail over?) answered "promotable":true on an UNREACHABLE Sovereign
continuum_dr_synthesis_5731_test.go:442: 2. switchover (did it happen?) answered "status":"completed" on an UNREACHABLE Sovereign
continuum_dr_synthesis_5731_test.go:442: 3. fleet view (is the estate fine?) answered "healthy":true on an UNREACHABLE Sovereign
continuum_dr_synthesis_5731_test.go:442: 4. enriched GET (healthy replicas?) answered "phase":"Healthy" on an UNREACHABLE Sovereign
```

That last block is the false-confidence loop reproduced in one run: four mutually-consistent green answers on a Sovereign the control plane cannot reach.

### Fixed tree — 13/13 GREEN

```
--- PASS: TestSwitchover_HonestWhenDeploymentUnregistered_5731 (0.00s)
--- PASS: TestSwitchover_HonestWhenClientUnavailable_5731 (0.00s)
--- PASS: TestGetEnriched_HonestWhenCRAbsent_5728 (0.00s)
--- PASS: TestGetEnriched_HonestWhenClientUnavailable_5728 (0.00s)
--- PASS: TestPut_HonestWhenClientUnavailable_5728 (0.00s)
--- PASS: TestFleetContinuum_HonestWhenUnreadable_5731 (0.00s)
--- PASS: TestSwitchoverPreview_HonestWhenClientUnavailable_5731 (0.00s)
--- PASS: TestSwitchoverPreview_HonestWhenCRAbsent_5731 (0.00s)
--- PASS: TestDRDecisionPath_NoMutuallyConsistentFabrication_5731 (0.00s)
--- PASS: TestGetEnriched_ControlLiveCRStillReturnsRealValues_5728 (0.00s)
--- PASS: TestSwitchover_ControlLiveCRStillSucceeds_5731 (0.00s)
--- PASS: TestFleetContinuum_ControlLiveCRStillListed_5731 (0.00s)
--- PASS: TestSwitchoverPreview_ControlLiveCRStillPreviews_5731 (0.00s)
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.029s
```

Full module, matching CI's `go test -race -count=1 ./...`: every package `ok`, `internal/handler 260.307s`.

### Can this check go red?

The controls are written to pass on **both** trees — they accept any 2xx for the switchover rather than pinning 200-vs-202 — because a control that only passes after the fix is a second guard, not a control. `TestGetEnriched_ControlLiveCRStillReturnsRealValues_5728` uses a fixture primary of `hz-fsn-rtz-prod`, deliberately different from the deleted `continuumDefaultPrimary` (`fsn1`), so it proves the value came from the CR and not from a surviving constant.

Workflow reach confirmed: `.github/workflows/test-bootstrap-api.yaml` filters on `products/catalyst/bootstrap/api/**`, which is where the new test lives, and runs `go test -race -count=1 ./...` with no `|| true` fail-open.

## Deliberately NOT changed

- **`synthesizeSwitchover`** (`core/controllers/.../placement_fanout.go:188`), **`synthesizeSession`** (`k8s_exec.go:697`), **`synthesizeMinimalBlueprintYAML`** (`blueprints_wire_compat.go:141`) — verified as legitimate constructors that build a value from inputs they have. `synthesizeSwitchover` explicitly guards against arming an empty hot-standby contract. Untouched.
- **The `handleNoCRSwitchoverViaLivePair` success path** still reports `completed` — correct, because it really performs the `spec.replica.enabled` flip. A completion claim backed by an observation is not the defect.
- **The qa-fixtures chart** (`products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml`) still seeds `cont-omantel` with `primaryRegion: fsn1`. That is a separate honesty problem with a chart-version + 5-site lockstep blast radius; the handler no longer *invents* those values, but it will faithfully report them where the fixture installs them. Noted on the issues rather than filed as new work.
- **No UI rendering change.** `unreachable[]` is added to the wire and to the TS `ContinuumFleetResponse` type, but nothing renders it yet — a fleet page that ignores it shows the same calm empty state for "no DR configured" and "we could read nothing". The TS doc comment says so explicitly. No chart touched, so no #817 lockstep applies.

## Sibling lead (not filed, to avoid open-count inflation)

The same `must_contain`-driven reshaping appears in `applications_update.go:493` (`regionsFromEnv()` merged into the persisted regions echo so `["fsn1","hel1"]` resolves for TC-071) and `fleet.go:157` / `compliance.go:1545` (`CATALYST_CONFIGURED_REGIONS`). Those are **env-sourced rather than hardcoded and none claims a health verdict**, so they are a materially lower severity than the four fixed here — but the same driver. Recorded as a lead on #5731.

Refs #5731 #5728
