### PR TITLE
fix(placement): the Go derivePattern still fails open into singleton, and derivedFromRuntime has no consumer

### DIFF
--- a/.github/workflows/build-application-controller.yaml
+++ b/.github/workflows/build-application-controller.yaml
@@ -90,7 +90,17 @@ jobs:
 
       - name: Run unit tests
         working-directory: core/controllers
-        run: go test -count=1 -race ./application/... ./internal/...
+        # #5515 — `./pkg/...` added. The paths filter above already TRIGGERS
+        # this workflow on `core/controllers/pkg/**`, but the test pattern
+        # excluded that tree, so the canonical placement model
+        # (pkg/apis/blueprint/v1alpha1 — DerivePattern + ValidatePlacement, the
+        # functions this controller's own fan-out calls) had its unit suite run
+        # by exactly ONE workflow in the repo: build-sandbox-controller.yaml,
+        # the build for the LEGACY Sandbox controller removed 2026-06-30. A
+        # model whose only CI coverage rides a deleted product is one file
+        # deletion away from having none. Trigger and assertion now cover the
+        # same tree.
+        run: go test -count=1 -race ./application/... ./internal/... ./pkg/...
 
       # On pull_request runs we stop here — image push requires
       # `packages: write` which only main-branch authors hold.

--- a/core/controllers/application/internal/controller/placement_fanout.go
+++ b/core/controllers/application/internal/controller/placement_fanout.go
@@ -250,6 +250,19 @@ func blueprintReplicationFor(choice bpv1alpha1.BcpTopology, bpTopo *bpv1alpha1.T
 // BcpTopology enum, used ONLY for the HR `LabelTopology` value +
 // observability rollups. It does not gate the render (the per-target roles
 // do). The mapping is the obvious 1:1 between the two vocabularies.
+//
+// #5515 — `PatternNotReported` has NO honest BcpTopology counterpart (the
+// enum carries no "unknown" member), and the `default:` arm below would map
+// it onto `singleton` — re-introducing, one layer down, exactly the fail-open
+// DerivePattern just closed. It cannot arrive here: this function is only
+// reached from placementVariantFromTargets, which the application-controller
+// calls at step §8c AFTER step 5.1 has run ValidatePlacement over the same
+// target list and markFailed'd on `NoPrimary` — and a no-Primary list is the
+// only input that derives `not-reported`. That ordering is the actual guard,
+// so it is pinned by an executable test
+// (TestPatternNotReported_5515_UnreachableInFanout) rather than left to a
+// comment. The explicit case below exists so the fall-through can never
+// silently absorb it if that ordering is ever changed.
 func patternToBcpTopology(p bpv1alpha1.Pattern) bpv1alpha1.BcpTopology {
 	switch p {
 	case bpv1alpha1.PatternActiveActive:
@@ -258,7 +271,12 @@ func patternToBcpTopology(p bpv1alpha1.Pattern) bpv1alpha1.BcpTopology {
 		return bpv1alpha1.BcpActiveHotStandby
 	case bpv1alpha1.PatternActivePassive:
 		return bpv1alpha1.BcpActivePassive
+	case bpv1alpha1.PatternSingleton:
+		return bpv1alpha1.BcpSingleton
 	default:
+		// Includes PatternNotReported — unreachable per the ValidatePlacement
+		// ordering above; kept as the conservative label rather than a
+		// fabricated DR posture.
 		return bpv1alpha1.BcpSingleton
 	}
 }

--- a/core/controllers/application/internal/controller/placement_notreported_5515_test.go
+++ b/core/controllers/application/internal/controller/placement_notreported_5515_test.go
@@ -1,0 +1,128 @@
+// placement_notreported_5515_test.go — #5515.
+//
+// `bpv1alpha1.DerivePattern` no longer fails open into `singleton` for a
+// target list with no Primary; it returns `PatternNotReported`. This file
+// pins the two consequences of that inside the application-controller's
+// fan-out, both of which are load-bearing and neither of which the model
+// test can see:
+//
+//  1. `patternToBcpTopology` has no honest counterpart for the new token —
+//     BcpTopology carries no "unknown" member — so the safety of the mapping
+//     rests ENTIRELY on `not-reported` never reaching it. That is an
+//     ORDERING claim about the reconcile loop, so it is pinned as one.
+//
+//  2. The four real patterns must still map to their real BcpTopology, or
+//     "map everything to singleton" would satisfy (1) trivially.
+package controller
+
+import (
+	"testing"
+
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// TestPatternNotReported_5515_UnreachableInFanout pins the ordering the
+// fan-out's safety depends on: application_controller.go runs
+// ValidatePlacement at step 5.1 (and markFailed's on its error) BEFORE
+// placementVariantFromTargets at §8c. `not-reported` is derived only from a
+// no-Primary target list, and ValidatePlacement rejects exactly that list as
+// `NoPrimary` whenever any target is declared — so no reconcile can carry an
+// un-derivable pattern into patternToBcpTopology, where it would be mapped
+// onto `singleton` and re-open #5515 one layer down.
+//
+// The empty list is the other half: it derives `not-reported` and
+// ValidatePlacement legitimately accepts it (nothing was declared), so the
+// fan-out is instead gated by `fanoutFromTargets := len(...) > 0`, which is
+// asserted here too.
+func TestPatternNotReported_5515_UnreachableInFanout(t *testing.T) {
+	std := bpv1alpha1.CapabilityPrimaryStandby
+
+	// Every non-empty target list that derives `not-reported` must be
+	// rejected by the step-5.1 gate.
+	noPrimaryLists := map[string][]bpv1alpha1.PlacementTarget{
+		"standby only (Hot)": {
+			{Region: "region-b", Cluster: "mgmt-B", VCluster: "mgmt",
+				Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+		},
+		"standby only (Cold)": {
+			{Region: "region-b", Cluster: "mgmt-B", VCluster: "mgmt",
+				Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyCold},
+		},
+		"unrecognised roles": {
+			{Region: "region-a", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1alpha1.DataRole("")},
+		},
+	}
+	for name, targets := range noPrimaryLists {
+		t.Run("gated/"+name, func(t *testing.T) {
+			if got := bpv1alpha1.DerivePattern(targets, std); got != bpv1alpha1.PatternNotReported {
+				t.Fatalf("precondition: DerivePattern = %q, want %q", got, bpv1alpha1.PatternNotReported)
+			}
+			if err := bpv1alpha1.ValidatePlacement(bpv1alpha1.Placement{Targets: targets}, std); err == nil {
+				t.Fatalf("#5515: this list derives `not-reported` but ValidatePlacement ACCEPTS it, "+
+					"so it reaches patternToBcpTopology, which maps it onto %q — the fail-open "+
+					"is back one layer down", bpv1alpha1.BcpSingleton)
+			}
+		})
+	}
+
+	// The empty list derives `not-reported` and is legitimately valid; the
+	// fan-out's own len>0 guard is what keeps it out.
+	t.Run("gated/empty list is valid but never fans out", func(t *testing.T) {
+		var empty []bpv1alpha1.PlacementTarget
+		if got := bpv1alpha1.DerivePattern(empty, std); got != bpv1alpha1.PatternNotReported {
+			t.Fatalf("precondition: DerivePattern = %q, want %q", got, bpv1alpha1.PatternNotReported)
+		}
+		if err := bpv1alpha1.ValidatePlacement(bpv1alpha1.Placement{Targets: empty}, std); err != nil {
+			t.Fatalf("an empty placement declares nothing and must stay valid, got %v", err)
+		}
+		if len(empty) > 0 {
+			t.Fatalf("the fan-out guard `len(spec.PlacementTargets) > 0` must exclude the empty list")
+		}
+	})
+
+	// Control — the four real patterns still map to their real topology, so
+	// a patternToBcpTopology that returned `singleton` for everything (which
+	// would make the assertions above vacuous) fails here.
+	for pattern, want := range map[bpv1alpha1.Pattern]bpv1alpha1.BcpTopology{
+		bpv1alpha1.PatternSingleton:        bpv1alpha1.BcpSingleton,
+		bpv1alpha1.PatternActivePassive:    bpv1alpha1.BcpActivePassive,
+		bpv1alpha1.PatternActiveHotStandby: bpv1alpha1.BcpActiveHotStandby,
+		bpv1alpha1.PatternActiveActive:     bpv1alpha1.BcpActiveActive,
+	} {
+		if got := patternToBcpTopology(pattern); got != want {
+			t.Errorf("patternToBcpTopology(%q) = %q, want %q", pattern, got, want)
+		}
+	}
+}
+
+// TestSynthesizeSwitchover_5515_NotReportedNeverArms — the fan-out arms the
+// per-app Continuum lease-witness off the DERIVED pattern. Pre-fix, a
+// Standby-only target list derived `active-hot-standby` (the `standbys == 0`
+// arm was skipped), i.e. a DR contract with no primary to fail over FROM.
+// Post-fix it derives `not-reported` → BcpSingleton → no Switchover. Pinned
+// with the DR-capable control beside it so "never arm anything" fails.
+func TestSynthesizeSwitchover_5515_NotReportedNeverArms(t *testing.T) {
+	standbyOnly := []bpv1alpha1.PlacementTarget{
+		{Region: "region-b", Cluster: "mgmt-B", VCluster: "mgmt",
+			Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+	}
+	choice := patternToBcpTopology(bpv1alpha1.DerivePattern(standbyOnly, bpv1alpha1.CapabilityPrimaryStandby))
+	if sw, _ := synthesizeSwitchover(standbyOnly, choice, nil); sw != nil {
+		t.Errorf("a Standby-only placement has no primary to fail over from; it must not arm a "+
+			"switchover (choice=%q)", choice)
+	}
+
+	// Control — a genuine Primary + Hot Standby still arms.
+	drCapable := []bpv1alpha1.PlacementTarget{
+		{Region: "region-a", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+		{Region: "region-b", Cluster: "mgmt-B", VCluster: "mgmt",
+			Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+	}
+	drChoice := patternToBcpTopology(bpv1alpha1.DerivePattern(drCapable, bpv1alpha1.CapabilityPrimaryStandby))
+	if drChoice != bpv1alpha1.BcpActiveHotStandby {
+		t.Fatalf("control: derived choice = %q, want %q", drChoice, bpv1alpha1.BcpActiveHotStandby)
+	}
+	if sw, _ := synthesizeSwitchover(drCapable, drChoice, nil); sw == nil {
+		t.Errorf("VACUITY: a genuine Primary + Hot Standby placement must still arm a switchover")
+	}
+}

--- a/core/controllers/blueprint/internal/validate/placement_vocabulary_drift_test.go
+++ b/core/controllers/blueprint/internal/validate/placement_vocabulary_drift_test.go
@@ -164,6 +164,78 @@ func TestPlacementValidation_5639_MissingRegionReasonMatchesFE(t *testing.T) {
 	}
 }
 
+// #5515 — the placement DERIVATION must agree across the two surfaces as
+// strictly as the mode vocabulary does.
+//
+// This is the drift the existing gates above could not see. The frontend
+// `derivePattern` (shared/lib/placement.ts) took the no-Primary guard in
+// PR #5519 on 2026-07-30; the Go `DerivePattern` — which the FE module's own
+// header names as the source it mirrors — kept failing open into `singleton`
+// for another six days, and its unit suite ASSERTED the fail-open
+// (`{"empty targets — singleton", want: PatternSingleton}`). Nothing in CI
+// could go red, because every gate compared VOCABULARY (which token strings
+// exist) and none compared BEHAVIOUR (what each side returns for the same
+// input).
+//
+// So this pins behaviour, both directions, on both sides:
+//
+//	no Primary  -> not-reported   (never a confident pattern name)
+//	one Primary -> singleton      (a genuine singleton still reports one)
+//
+// It reads the FE file with a STRICT reader rather than the package's
+// mustReadRepoFile, which t.Skipf's when the file cannot be read — a drift
+// gate that silently skips on a moved path is the same fail-open one layer
+// up.
+func TestPlacementDerivation_5515_NoPrimaryGuardMatchesFE(t *testing.T) {
+	root := findRepoRoot(t)
+	fePath := filepath.Join(root, "products", "catalyst", "bootstrap", "ui", "src", "shared", "lib", "placement.ts")
+	raw, err := os.ReadFile(fePath)
+	if err != nil {
+		t.Fatalf("could not read the FE placement module at %s (%v) — the drift gate must "+
+			"FAIL, not skip, when the surface it pins has moved", fePath, err)
+	}
+	fe := string(raw)
+
+	// (a) The FE carries the token AND the guard that returns it. A surviving
+	//     constant with a deleted check is the #5639 shape.
+	if !strings.Contains(fe, "PATTERN_NOT_REPORTED") {
+		t.Errorf("FE placement.ts exports no PATTERN_NOT_REPORTED token")
+	}
+	if !strings.Contains(fe, "primaries === 0") {
+		t.Errorf("FE derivePattern has no `primaries === 0` guard — the empty/no-Primary " +
+			"target list falls through to `singleton` again (#5515)")
+	}
+
+	// (b) The FE token spelling and the Go token must be the same string, or
+	//     the two surfaces render different words for the same state.
+	if !strings.Contains(fe, "'"+string(bpv1alpha1.PatternNotReported)+"'") {
+		t.Errorf("FE placement.ts does not carry the Go token %q — the two derivations have drifted",
+			bpv1alpha1.PatternNotReported)
+	}
+
+	// (c) The Go behaviour itself, both directions — so this file fails if the
+	//     guard is removed even when every token above survives.
+	noPrimary := []bpv1alpha1.PlacementTarget{
+		{Region: "region-b", Cluster: "mgmt-B", VCluster: "mgmt",
+			Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+	}
+	if got := bpv1alpha1.DerivePattern(noPrimary, bpv1alpha1.CapabilityPrimaryStandby); got != bpv1alpha1.PatternNotReported {
+		t.Errorf("Go DerivePattern returned %q for a target list with no Primary, want %q (#5515)",
+			got, bpv1alpha1.PatternNotReported)
+	}
+	if got := bpv1alpha1.DerivePattern(nil, bpv1alpha1.CapabilityPrimaryStandby); got == bpv1alpha1.PatternSingleton {
+		t.Errorf("Go DerivePattern fails open: an EMPTY target list returned the confident %q", got)
+	}
+	// Control — a real singleton must still report `singleton`, else "always
+	// return not-reported" would satisfy the two assertions above.
+	onePrimary := []bpv1alpha1.PlacementTarget{
+		{Region: "region-a", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+	}
+	if got := bpv1alpha1.DerivePattern(onePrimary, bpv1alpha1.CapabilityPrimaryStandby); got != bpv1alpha1.PatternSingleton {
+		t.Errorf("VACUITY: a genuine one-Primary placement derived %q, want %q", got, bpv1alpha1.PatternSingleton)
+	}
+}
+
 // ── helpers ──────────────────────────────────────────────────────────
 
 func mustReadRepoFile(t *testing.T, root string, parts ...string) string {

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go
@@ -113,6 +113,15 @@ const (
 	PatternActiveHotStandby Pattern = "active-hot-standby"
 	// PatternActiveActive — ≥2 Primary (requires multi-primary).
 	PatternActiveActive Pattern = "active-active"
+
+	// PatternNotReported — NOT a pattern. The explicit absence of one
+	// (#5515). Emitted when the target list carries no Primary, so no
+	// pattern can be derived from it.
+	//
+	// Mirrors the frontend token `PATTERN_NOT_REPORTED` in
+	// products/catalyst/bootstrap/ui/src/shared/lib/placement.ts; the two
+	// sides are pinned together by the placement-vocabulary drift gate.
+	PatternNotReported Pattern = "not-reported"
 )
 
 // PlacementTarget — one desired target in an Application's Placement
@@ -171,10 +180,36 @@ type Placement struct {
 //	pattern(targets, capability):
 //	  primaries = [t for t in targets if t.role == Primary]
 //	  standbys  = [t for t in targets if t.role == Standby]
+//	  if len(primaries) == 0:             -> "not-reported"   (#5515)
 //	  if len(primaries) >= 2:             -> "active-active"
 //	  if len(standbys)  == 0:             -> "singleton"
 //	  if any(s.standbyType == Hot for s): -> "active-hot-standby"
 //	  else:                               -> "active-passive"
+//
+// #5515 — the no-Primary guard MUST come first and MUST NOT fall through to
+// `singleton`. Every one of the four patterns asserts a live Primary; with
+// zero Primary targets there is no pattern, only missing data. Pre-fix this
+// function returned a CONFIDENT `singleton` for three separate inputs that
+// carry no derivable placement at all:
+//
+//   - `nil` / `[]` — no placement data. `singleton` is the one pattern that
+//     means "no cross-region failover, and that is fine", so defaulting to
+//     it turned every data-collection failure into a deliberate, healthy
+//     single-region choice.
+//   - a list whose roles are all unrecognised (neither Primary nor Standby)
+//     — same counters, same false `singleton`.
+//   - a Standby-only list — pre-fix this skipped the `standbys == 0` arm and
+//     asserted `active-hot-standby` / `active-passive`: an "active-*"
+//     pattern with no active. ValidatePlacement already rejects that list as
+//     `NoPrimary`; the derived label must not contradict its own gate.
+//
+// The frontend mirror (products/catalyst/bootstrap/ui/src/shared/lib/
+// placement.ts) took this guard in PR #5519; this Go function is the source
+// the mirror declares itself a mirror OF, and it kept failing open — which
+// matters more here, because unlike the FE label this value is folded onto
+// the stored `spec.placement.mode` (applications_update.go) and selects the
+// BcpTopology that drives the fan-out + Continuum arming
+// (placement_fanout.go).
 //
 // The capability argument is accepted for symmetry with ValidatePlacement
 // (callers pass both) — the derivation itself reads only the targets, so
@@ -196,6 +231,9 @@ func DerivePattern(targets []PlacementTarget, _ PlacementCapability) Pattern {
 		}
 	}
 	switch {
+	// #5515 — no Primary ⇒ no pattern. Never fail open into `singleton`.
+	case primaries == 0:
+		return PatternNotReported
 	case primaries >= 2:
 		return PatternActiveActive
 	case standbys == 0:

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/placement_target_test.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/placement_target_test.go
@@ -60,10 +60,14 @@ func TestDerivePattern(t *testing.T) {
 			want: PatternActiveHotStandby,
 		},
 		{
-			name:    "empty targets — singleton",
+			// #5515 — this case previously read `want: PatternSingleton`.
+			// The suite ASSERTED the fail-open: "no placement data at all"
+			// was pinned as identical to "one Primary, in one region,
+			// deliberately, with no cross-region failover wanted".
+			name:    "empty targets — not-reported, NEVER singleton",
 			targets: nil,
 			cap:     CapabilityPrimaryStandby,
-			want:    PatternSingleton,
+			want:    PatternNotReported,
 		},
 	}
 	for _, tc := range cases {
@@ -72,6 +76,172 @@ func TestDerivePattern(t *testing.T) {
 				t.Errorf("DerivePattern = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestDerivePattern_5515_NeverFailsOpen is the #5515 regression gate on the
+// GO source of truth (the frontend mirror took the same guard in PR #5519 —
+// this function is the one it declares itself a mirror OF, and it kept
+// failing open for another six days).
+//
+// It asserts on the RETURNED VALUE in both directions, because either
+// direction alone is vacuous here:
+//
+//   - the negative block alone would pass against a DerivePattern hard-wired
+//     to `return PatternNotReported`;
+//   - the positive block alone is what the pre-fix suite had, and it stayed
+//     green for the entire life of the defect.
+func TestDerivePattern_5515_NeverFailsOpen(t *testing.T) {
+	// ── Negative: nothing derivable ⇒ not-reported, and specifically NOT a
+	//    confident pattern name. ────────────────────────────────────────
+	notDerivable := []struct {
+		name    string
+		targets []PlacementTarget
+	}{
+		{
+			name:    "nil target list — the /placement endpoint reported nothing",
+			targets: nil,
+		},
+		{
+			name:    "empty target list",
+			targets: []PlacementTarget{},
+		},
+		{
+			name: "roles all unrecognised — same counters as empty",
+			targets: []PlacementTarget{
+				{Region: "region-a", Cluster: "mgmt-A", VCluster: "mgmt", Role: DataRole("")},
+				{Region: "region-b", Cluster: "mgmt-B", VCluster: "mgmt", Role: DataRole("Whatever")},
+			},
+		},
+		{
+			name: "Standby-only, Hot — an active-* pattern with no active",
+			targets: []PlacementTarget{
+				p("region-b", "mgmt-B", DataRoleStandby, StandbyHot),
+			},
+		},
+		{
+			name: "Standby-only, Cold",
+			targets: []PlacementTarget{
+				p("region-b", "mgmt-B", DataRoleStandby, StandbyCold),
+			},
+		},
+		{
+			name: "two Standbys, no Primary",
+			targets: []PlacementTarget{
+				p("region-b", "mgmt-B", DataRoleStandby, StandbyHot),
+				p("region-c", "mgmt-C", DataRoleStandby, StandbyCold),
+			},
+		},
+	}
+	for _, tc := range notDerivable {
+		t.Run("not-derivable/"+tc.name, func(t *testing.T) {
+			got := DerivePattern(tc.targets, CapabilityPrimaryStandby)
+			if got == PatternSingleton {
+				t.Fatalf("#5515 FAIL-OPEN: DerivePattern returned the confident %q for a "+
+					"target list with no Primary. `singleton` means \"one Primary, one "+
+					"region, no cross-region failover, and that is fine\" — asserting it "+
+					"here turns missing data into a healthy DR verdict.", got)
+			}
+			if got != PatternNotReported {
+				t.Fatalf("DerivePattern = %q, want %q (no Primary ⇒ no pattern)", got, PatternNotReported)
+			}
+		})
+	}
+
+	// ── Control: a genuine placement still derives its real pattern. Without
+	//    these, "always return not-reported" would pass the block above. ──
+	derivable := []struct {
+		name    string
+		targets []PlacementTarget
+		cap     PlacementCapability
+		want    Pattern
+	}{
+		{
+			name:    "genuine singleton — exactly one Primary, no standby",
+			targets: []PlacementTarget{p("region-a", "mgmt-A", DataRolePrimary, "")},
+			cap:     CapabilityPrimaryStandby,
+			want:    PatternSingleton,
+		},
+		{
+			name: "genuine active-hot-standby",
+			targets: []PlacementTarget{
+				p("region-a", "mgmt-A", DataRolePrimary, ""),
+				p("region-b", "mgmt-B", DataRoleStandby, StandbyHot),
+			},
+			cap:  CapabilityPrimaryStandby,
+			want: PatternActiveHotStandby,
+		},
+		{
+			name: "genuine active-passive",
+			targets: []PlacementTarget{
+				p("region-a", "mgmt-A", DataRolePrimary, ""),
+				p("region-b", "mgmt-B", DataRoleStandby, StandbyCold),
+			},
+			cap:  CapabilityPrimaryStandby,
+			want: PatternActivePassive,
+		},
+		{
+			name: "genuine active-active",
+			targets: []PlacementTarget{
+				p("region-a", "mgmt-A", DataRolePrimary, ""),
+				p("region-b", "mgmt-B", DataRolePrimary, ""),
+			},
+			cap:  CapabilityMultiPrimary,
+			want: PatternActiveActive,
+		},
+		{
+			name: "one Primary alongside an unrecognised role still derives singleton",
+			targets: []PlacementTarget{
+				p("region-a", "mgmt-A", DataRolePrimary, ""),
+				{Region: "region-b", Cluster: "mgmt-B", VCluster: "mgmt", Role: DataRole("")},
+			},
+			cap:  CapabilityPrimaryStandby,
+			want: PatternSingleton,
+		},
+	}
+	for _, tc := range derivable {
+		t.Run("derivable/"+tc.name, func(t *testing.T) {
+			got := DerivePattern(tc.targets, tc.cap)
+			if got == PatternNotReported {
+				t.Fatalf("VACUITY: DerivePattern returned %q for a genuinely derivable "+
+					"placement — a guard that always reports \"not reported\" is as "+
+					"useless as one that always reports `singleton`", got)
+			}
+			if got != tc.want {
+				t.Fatalf("DerivePattern = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// ── The token itself must not collide with a real pattern name, or the
+	//    two blocks above could never disagree. ───────────────────────────
+	for _, real := range []Pattern{PatternSingleton, PatternActivePassive, PatternActiveHotStandby, PatternActiveActive} {
+		if PatternNotReported == real {
+			t.Fatalf("PatternNotReported collides with the real pattern %q", real)
+		}
+	}
+}
+
+// TestDerivePattern_5515_AgreesWithValidatePlacement pins the two halves of
+// the model against each other: every target list ValidatePlacement rejects
+// as `NoPrimary` is exactly the set DerivePattern cannot derive. Before the
+// fix they contradicted — the gate said "invalid, no Primary" while the label
+// said "singleton", and a caller that trusted the label never saw the gate.
+func TestDerivePattern_5515_AgreesWithValidatePlacement(t *testing.T) {
+	noPrimary := Placement{Targets: []PlacementTarget{
+		p("region-b", "mgmt-B", DataRoleStandby, StandbyHot),
+	}}
+	err := ValidatePlacement(noPrimary, CapabilityPrimaryStandby)
+	if err == nil {
+		t.Fatalf("ValidatePlacement must reject a Standby-only placement")
+	}
+	var pe *PlacementError
+	if !errors.As(err, &pe) || pe.Reason != "NoPrimary" {
+		t.Fatalf("ValidatePlacement reason = %v, want NoPrimary", err)
+	}
+	if got := DerivePattern(noPrimary.Targets, CapabilityPrimaryStandby); got != PatternNotReported {
+		t.Fatalf("the gate rejects this placement as NoPrimary but the label calls it %q — "+
+			"the two halves of the model disagree (#5515)", got)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -133,10 +133,22 @@ func applicationUpdateRequestNormalize(b applicationUpdateRequest) applicationUp
 	// Regions Primary-first (regions[0] == primary, per placement_projection).
 	// Only fires when Mode is empty, so an explicit {mode,regions} caller (or
 	// a body that sets both) is byte-unchanged.
+	//
+	// #5515 — the fold is skipped when the pattern is NOT DERIVABLE (a target
+	// list with no Primary). This value is not a display label here: it is
+	// PERSISTED onto spec.placement.mode of the Application CR, and the CRD
+	// puts no enum on that field, so whatever lands here is what every
+	// downstream reader believes. Pre-fix DerivePattern returned a confident
+	// `singleton` for a no-Primary list, so an invalid placement was stored as
+	// a deliberate single-region posture. Leaving Mode empty makes the request
+	// fail CLOSED on the existing "placement.mode is required when placement
+	// is set" 400, which names the problem instead of persisting a fiction.
 	if b.Placement != nil && len(b.Placement.Targets) > 0 && strings.TrimSpace(b.Placement.Mode) == "" {
-		b.Placement.Mode = string(bpv1.DerivePattern(b.Placement.Targets, ""))
-		if len(b.Placement.Regions) == 0 {
-			b.Placement.Regions = regionsFromPlacementTargets(b.Placement.Targets)
+		if pattern := bpv1.DerivePattern(b.Placement.Targets, ""); pattern != bpv1.PatternNotReported {
+			b.Placement.Mode = string(pattern)
+			if len(b.Placement.Regions) == 0 {
+				b.Placement.Regions = regionsFromPlacementTargets(b.Placement.Targets)
+			}
 		}
 	}
 	return b

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_5515_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_5515_test.go
@@ -1,0 +1,133 @@
+// applications_update_placement_5515_test.go — #5515.
+//
+// The targets→mode fold in applicationUpdateRequestNormalize is the one
+// DerivePattern call site whose output is PERSISTED: it becomes
+// `spec.placement.mode` on the Application CR, and the CRD puts no enum on
+// that field, so whatever the fold writes is what every downstream reader
+// (the DR projection, the Topology tab, the showback rollups) believes.
+//
+// Pre-fix, DerivePattern returned a confident `singleton` for a target list
+// with no Primary, so PUTting such a list stored a deliberate single-region
+// DR posture for a placement the model's own gate rejects as `NoPrimary`.
+// The fold now skips a non-derivable pattern, leaving Mode empty so the
+// request fails CLOSED on the existing "placement.mode is required when
+// placement is set" 400 — which names the problem instead of persisting one.
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+func TestApplicationUpdateNormalize_5515_NoPrimaryNeverPersistsSingleton(t *testing.T) {
+	noPrimary := []struct {
+		name    string
+		targets []bpv1.PlacementTarget
+	}{
+		{
+			name: "standby only (Hot)",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-b", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+			},
+		},
+		{
+			name: "standby only (Cold)",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-b", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyCold},
+			},
+		},
+		{
+			name: "unrecognised role",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Role: bpv1.DataRole("")},
+			},
+		},
+	}
+	for _, tc := range noPrimary {
+		t.Run("no-primary/"+tc.name, func(t *testing.T) {
+			got := applicationUpdateRequestNormalize(applicationUpdateRequest{
+				Placement: &applicationPlacement{Targets: tc.targets},
+			})
+			if got.Placement == nil {
+				t.Fatalf("placement dropped")
+			}
+			if got.Placement.Mode == "singleton" {
+				t.Fatalf("#5515: a placement with NO Primary target was folded onto the stored "+
+					"mode %q — the CR now records a deliberate single-region posture for a "+
+					"placement ValidatePlacement rejects as NoPrimary", got.Placement.Mode)
+			}
+			if got.Placement.Mode != "" {
+				t.Fatalf("mode = %q, want empty so the request fails closed on the "+
+					"\"placement.mode is required\" 400", got.Placement.Mode)
+			}
+			// Fails CLOSED, with an actionable message — not silently accepted.
+			msg, ok := validateApplicationUpdateRequest(got)
+			if ok {
+				t.Fatalf("a non-derivable placement must not validate")
+			}
+			if !strings.Contains(msg, "placement.mode is required") {
+				t.Errorf("rejection message = %q, want the actionable placement.mode text", msg)
+			}
+		})
+	}
+
+	// ── Control: every derivable placement still folds exactly as before.
+	//    Without this block, a fold that never wrote a mode would pass. ──
+	derivable := []struct {
+		name     string
+		targets  []bpv1.PlacementTarget
+		wantMode string
+	}{
+		{
+			name:     "genuine singleton still folds to singleton",
+			targets:  []bpv1.PlacementTarget{{Region: "me-east-215-a", Role: bpv1.DataRolePrimary}},
+			wantMode: "singleton",
+		},
+		{
+			name: "genuine active-hot-standby",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+			},
+			wantMode: "active-hot-standby",
+		},
+		{
+			name: "genuine active-passive",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyCold},
+			},
+			wantMode: "active-passive",
+		},
+		{
+			name: "genuine active-active",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Role: bpv1.DataRolePrimary},
+			},
+			wantMode: "active-active",
+		},
+	}
+	for _, tc := range derivable {
+		t.Run("derivable/"+tc.name, func(t *testing.T) {
+			got := applicationUpdateRequestNormalize(applicationUpdateRequest{
+				Placement: &applicationPlacement{Targets: tc.targets},
+			})
+			if got.Placement == nil {
+				t.Fatalf("placement dropped")
+			}
+			if got.Placement.Mode != tc.wantMode {
+				t.Fatalf("VACUITY CHECK: mode = %q, want %q — the fold must still fire for "+
+					"every derivable placement", got.Placement.Mode, tc.wantMode)
+			}
+			if len(got.Placement.Regions) == 0 {
+				t.Errorf("regions fold must still fire for a derivable placement")
+			}
+			if msg, ok := validateApplicationUpdateRequest(got); !ok {
+				t.Errorf("validation failed after targets fold: %s", msg)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -1047,3 +1047,155 @@ describe('TopologyTab — #4886 bootstrap-HR DR off the live Continuum CR', () =
     expect(screen.queryByTestId('topology-tab-dr-switchover')).toBeNull()
   })
 })
+
+describe('TopologyTab — #5568 derivedFromRuntime is consumed, not discarded', () => {
+  /**
+   * #5568 found `derivedFromRuntime` hardcoded `true` on every return path of
+   * GET /applications/{name}/placement — a provenance flag that could not
+   * fail. PR #5683 fixed the server half. The client half was still missing:
+   * a repo-wide grep for the field found ONE production reference (the type
+   * declaration in catalog.api.ts) and a pile of test mocks. Nothing read it.
+   *
+   * That mattered because the fallback chain below the runtime rung is keyed
+   * on EMPTINESS, not provenance: whenever the runtime reports no targets the
+   * panel silently projects `spec.placement` / `status.perCluster` and renders
+   * the result through the same Pattern chip. So a DECLARED two-region pair
+   * and an OBSERVED two-region pair were pixel-identical — the #5513 shape,
+   * and the #5731 class: a surface reporting a state it did not observe.
+   *
+   * Both directions are asserted. The declared cases alone would pass against
+   * a component that always printed "declared"; the runtime control alone is
+   * what the pre-fix tree already satisfied.
+   */
+  beforeEach(() => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+  })
+
+  it('runtime-observed targets are labelled runtime-observed (control — must not always say declared)', async () => {
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'dep-x', vcluster: 'mgmt', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'dep-x-b', vcluster: 'mgmt', role: 'Primary' },
+      ],
+      derivedFromRuntime: true,
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="dep-x" applicationName="grafana" namespace="mgmt" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-placement-source')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-placement-source').textContent).toBe('runtime-observed')
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('active-active')
+  })
+
+  it('the no-data-plane response (derivedFromRuntime:false) must NOT render its spec projection as observed', async () => {
+    // The #5568 sharp end: k8sCache==nil returns 200 + targets:[] +
+    // derivedFromRuntime:false. No runtime was consulted. The panel still
+    // renders SOMETHING (the declared spec) — it must say so.
+    getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: false })
+    getApplicationStatus.mockResolvedValue({
+      name: 'shared-pg',
+      namespace: 'shared-data',
+      spec: {
+        placement: {
+          targets: [
+            { region: 'me-east-215-a', cluster: 'c-a', vcluster: 'host', role: 'Primary' },
+            { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+          ],
+        },
+      },
+      status: {},
+    })
+
+    render(
+      withProviders(<TopologyTab sovereignId="dep-y" applicationName="shared-pg" namespace="shared-data" />),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-placement-source')).toBeTruthy()
+    })
+    // The pattern still renders — the operator keeps their declared view.
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('active-hot-standby')
+    // But it is NOT presented as an observation.
+    const source = screen.getByTestId('topology-tab-placement-source').textContent ?? ''
+    expect(source).not.toBe('runtime-observed')
+    expect(source).toContain('declared')
+  })
+
+  it('a runtime that returned targets but admitted derivedFromRuntime:false is still not an observation', async () => {
+    // Provenance beats non-emptiness: a populated list from a response that
+    // says no runtime was consulted is a projection, whatever its length.
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'c-a', vcluster: 'host', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: false,
+    })
+
+    render(
+      withProviders(<TopologyTab sovereignId="dep-y" applicationName="shared-pg" namespace="shared-data" />),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-placement-source')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-placement-source').textContent).not.toBe('runtime-observed')
+  })
+
+  it('a runtime observation that found NOTHING must not let the declared spec pose as observed', async () => {
+    // derivedFromRuntime:true + targets:[] — the runtime WAS read and genuinely
+    // holds nothing. The chain falls back to the declared spec (so the operator
+    // still sees their intent), but that intent is not an observation.
+    getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+    getApplicationStatus.mockResolvedValue({
+      name: 'uatwalk-ahs',
+      namespace: 'uatcorp',
+      spec: {
+        placement: {
+          targets: [
+            { region: 'me-east-215-a', cluster: 'c-a', vcluster: 'host', role: 'Primary' },
+            { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+          ],
+        },
+      },
+      status: {},
+    })
+
+    render(
+      withProviders(<TopologyTab sovereignId="dep-y" applicationName="uatwalk-ahs" namespace="uatcorp" />),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-placement-source')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-placement-source').textContent).not.toBe('runtime-observed')
+  })
+
+  it('an un-derivable pattern prints no provenance chip at all (nothing to attribute)', async () => {
+    getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: false })
+    getApplicationStatus.mockResolvedValue({
+      name: 'cilium',
+      namespace: 'kube-system',
+      spec: {},
+      status: {},
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="dep-z" applicationName="cilium" namespace="kube-system" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-placement-empty')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('not reported')
+    expect(screen.queryByTestId('topology-tab-placement-source')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -96,6 +96,31 @@ interface RegionStatus {
   lastTransitionTime?: string
 }
 
+/**
+ * PlacementSource — where the rendered target list came from (#5568).
+ *
+ *   runtime  — the /placement endpoint reported `derivedFromRuntime: true`
+ *              AND returned targets: a genuine live observation.
+ *   declared — the targets came from `spec.placement` / `status.perCluster` /
+ *              the legacy mode+regions projection, or from a /placement
+ *              response that admitted no runtime was consulted. Desired
+ *              state, not observed state.
+ *   none     — no targets from any source; the pattern is `not reported`.
+ *
+ * The distinction is the whole point of the endpoint's `derivedFromRuntime`
+ * field, which #5568 found hardcoded `true` server-side. That half is fixed;
+ * this type is the consumer that makes the flag mean something — without it
+ * a declared 2-region pair and an observed 2-region pair render identically.
+ */
+type PlacementSource = 'runtime' | 'declared' | 'none'
+
+/** The chip copy per provenance. Never prints a source it cannot back. */
+const PLACEMENT_SOURCE_LABEL: Record<PlacementSource, string> = {
+  runtime: 'runtime-observed',
+  declared: 'declared · not observed',
+  none: 'no source',
+}
+
 export function TopologyTab({
   sovereignId,
   applicationName,
@@ -156,6 +181,24 @@ export function TopologyTab({
     return Array.isArray(t) ? (t as PlacementTarget[]) : []
   }, [placementQ.data])
 
+  // #5568 — `derivedFromRuntime` is the endpoint's PROVENANCE flag: true only
+  // when the live k8s cache was actually queried. Until now NOTHING in the
+  // frontend read it (grep: one type declaration in catalog.api.ts and a pile
+  // of test mocks, zero production consumers), so the field asserted a
+  // discrimination the UI never made — the same "carries zero information"
+  // defect the server-side hardcode had, moved one hop downstream.
+  //
+  // It is load-bearing because the fallback chain below is keyed on
+  // EMPTINESS, not on provenance: whenever the runtime reports no targets the
+  // panel silently projects `spec.placement` / `status.perCluster` instead and
+  // renders the result identically. So a DECLARED intention and an OBSERVED
+  // fact reach the same Pattern chip with nothing to tell them apart — which
+  // is how a 2-region pair renders over a 1-region runtime (#5513).
+  //
+  // Null response = the endpoint was unreachable (getApplicationPlacement
+  // returns null on !res.ok), which is not a runtime observation either.
+  const runtimeWasConsulted = placementQ.data?.derivedFromRuntime === true
+
   // Pull the Blueprint card for placementCapability (gates >1 Primary).
   const blueprintRef = app?.spec?.blueprintRef
   const blueprintQ = useQuery({
@@ -188,12 +231,24 @@ export function TopologyTab({
   //      explicitly chose in the editor (used pre-rollout / when the data
   //      plane is unavailable).
   //   3. legacy status.targets / mode+regions projection.
-  const targets: PlacementTarget[] = useMemo(() => {
-    if (runtimeTargets.length > 0) return runtimeTargets
+  //
+  // #5568 — the resolver now also reports WHICH rung it landed on, because the
+  // rung is the provenance: rung 1 is observed, rungs 2 and 3 are declared.
+  // The panel renders that distinction instead of presenting all three the
+  // same way.
+  const resolved: { targets: PlacementTarget[]; source: PlacementSource } = useMemo(() => {
+    // Rung 1 is only an OBSERVATION when the endpoint says a runtime was
+    // actually consulted (#5568). If it reports derivedFromRuntime:false the
+    // targets did not come from live state, so they are not treated as such.
+    if (runtimeTargets.length > 0 && runtimeWasConsulted) {
+      return { targets: runtimeTargets, source: 'runtime' as const }
+    }
+    const declared = (t: PlacementTarget[]) => ({ targets: t, source: 'declared' as const })
+    if (runtimeTargets.length > 0) return declared(runtimeTargets)
     const specPlacement = app?.spec?.placement
     if (specPlacement && typeof specPlacement === 'object') {
       const t = (specPlacement as Record<string, unknown>).targets
-      if (Array.isArray(t) && t.length > 0) return t as PlacementTarget[]
+      if (Array.isArray(t) && t.length > 0) return declared(t as PlacementTarget[])
     }
     // Legacy fallback: project from status.targets (recon rollup), else
     // from the legacy mode + regions.
@@ -230,11 +285,11 @@ export function TopologyTab({
           } as PlacementTarget
         })
         .filter((t): t is PlacementTarget => t !== null)
-      if (effective.length > 0) return effective
+      if (effective.length > 0) return declared(effective)
     }
     const statusTargets = status.targets
     if (Array.isArray(statusTargets) && statusTargets.length > 0) {
-      return statusTargets as PlacementTarget[]
+      return declared(statusTargets as PlacementTarget[])
     }
     const statusRegions = (status.regions ?? []) as RegionStatus[]
     // status.placement is an OBJECT on a real (#3373/#3969) controller; only
@@ -246,8 +301,15 @@ export function TopologyTab({
           ? status.placement
           : ''
     const regions = Array.isArray(app?.spec?.regions) ? app!.spec!.regions! : statusRegions.map((r) => r.name)
-    return targetsFromLegacy({ mode, regions, statusRegions })
-  }, [app, runtimeTargets])
+    const legacy = targetsFromLegacy({ mode, regions, statusRegions })
+    // Nothing anywhere — an empty list is neither observed nor declared, and
+    // derivePattern renders it as `not reported` (#5515). Labelling it
+    // "declared" would assert a desired state that was never written.
+    return legacy.length > 0 ? declared(legacy) : { targets: legacy, source: 'none' as const }
+  }, [app, runtimeTargets, runtimeWasConsulted])
+
+  const targets: PlacementTarget[] = resolved.targets
+  const placementSource: PlacementSource = resolved.source
 
   const pattern = useMemo(() => derivePattern(targets), [targets])
 
@@ -574,6 +636,31 @@ export function TopologyTab({
             >
               {patternLabel(pattern)}
             </span>
+            {/* #5568 — the PROVENANCE of the targets this pattern was derived
+                from. `derivedFromRuntime` exists to make exactly this
+                distinction and had no consumer, so a declared 2-region pair
+                and an observed one rendered identically. Only the runtime rung
+                is allowed to read as observed. */}
+            {pattern !== PATTERN_NOT_REPORTED && (
+              <>
+                {' · '}
+                <span
+                  className={
+                    placementSource === 'runtime'
+                      ? 'text-[var(--color-text-dim)]'
+                      : 'font-semibold text-yellow-400'
+                  }
+                  data-testid="topology-tab-placement-source"
+                  title={
+                    placementSource === 'runtime'
+                      ? 'Derived from live runtime state observed in the region clusters.'
+                      : 'Projected from the DECLARED placement (spec/status). No live runtime observation backs this — it is desired state, not observed state.'
+                  }
+                >
+                  {PLACEMENT_SOURCE_LABEL[placementSource]}
+                </span>
+              </>
+            )}
           </span>
         </div>
 


### PR DESCRIPTION
## What this is

Both issues were reported CLOSED-on-main in their own comment threads. Verified at
function level rather than by commit-message matching, and **each turned out to be
half-fixed**: the half that was easy to see was fixed, the half that carries the
consequence was not.

| Claim | Verdict on `main` @ 7fbcdee1a | Class |
|---|---|---|
| #5515 — `derivePattern` fails open, empty list ⇒ `singleton` — **frontend** | **REFUTED (fixed)** — `placement.ts:108` `if (primaries === 0) return PATTERN_NOT_REPORTED`, landed PR #5519 | — |
| #5515 — same defect in the **Go source the frontend mirrors** | **CONFIRMED, live on `main` today** | (a) |
| #5568 — `derivedFromRuntime` hardcoded `true` — **server** | **REFUTED (fixed)** — `applications_placement_runtime.go:97` returns `false` on `k8sCache == nil`, landed PR #5683 | — |
| #5568 — the flag "implies a discrimination the type never makes" — **console** | **CONFIRMED, live on `main` today** | (a) |
| #5513 — `active-hot-standby` renders a 2-region pair over a singleton | **Separate root cause**, one shared mechanism — see below | — |

## #5515 — the Go mirror kept failing open for six days after the mirror was fixed

`products/catalyst/bootstrap/ui/src/shared/lib/placement.ts` opens with

> Mirrors the Go single source (v1alpha1/placement_target.go).

The mirror took the no-Primary guard on 2026-07-30. The source did not. On `main`
today, `core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go:184`:

```
	switch {
	case primaries >= 2:
		return PatternActiveActive
	case standbys == 0:
		return PatternSingleton     // fires when targets is EMPTY
```

and its unit suite **asserted the fail-open** rather than catching it:

```
		{
			name:    "empty targets — singleton",
			targets: nil,
			want:    PatternSingleton,
		},
```

**This one matters more than the frontend one it mirrors**, because despite the
"display only" doc comment it is not a label — it is persisted and it selects
behaviour:

- `products/catalyst/bootstrap/api/internal/handler/applications_update.go:137` —
  `b.Placement.Mode = string(bpv1.DerivePattern(...))`. That value is written to
  `spec.placement.mode` on the Application CR, and `application.yaml` puts **no enum**
  on the field, so whatever lands there is what every downstream reader believes.
- `core/controllers/application/internal/controller/placement_fanout.go:146` —
  `patternToBcpTopology(DerivePattern(targets, capability))` picks the BcpTopology
  that drives the fan-out and the Continuum lease-witness arming.

Two distinct fabrications, both reachable:

1. **no Primary ⇒ `singleton`** — an invalid placement stored as a deliberate
   single-region DR posture.
2. **Standby-only ⇒ `active-hot-standby` / `active-passive`** — the `standbys == 0`
   arm is skipped, so the label asserts an "active-\*" pattern *with no active*. The
   model's own `ValidatePlacement` rejects that list as `NoPrimary` on the same input.
   The gate and the label contradicted each other, and only the label is what the
   fan-out consumes.

### Fix

`PatternNotReported = "not-reported"` (same token string as the FE) + a first-position
`primaries == 0` guard. Consumers handled so the fail-open cannot reappear one layer
down:

- `applications_update.go` skips the fold when the pattern is not derivable, so the
  request fails **closed** on the existing `placement.mode is required when placement
  is set` 400 — an actionable rejection instead of a persisted fiction.
- `patternToBcpTopology`'s bare `default:` (which would have absorbed the new token
  into `singleton`) is now explicit. It is unreachable because
  `application_controller.go:768` runs `ValidatePlacement` and `markFailed`s before
  the §8c fan-out at :868 — that **ordering** is what makes it safe, so it is pinned
  by a test rather than left to a comment.

## #5568 — the server tells the truth now and the console throws it away

PR #5683 fixed the emission. The consumer was never written. Repo-wide grep for
`derivedFromRuntime` on `main` returns **one production reference** — the type
declaration at `catalog.api.ts:558` — plus test mocks. Nothing reads it.

So the field's stated purpose is still unmet in both directions the issue named:

> `DerivedFromRuntime` should be `false` … **so the FE's fallback actually engages**.
> If the flag is genuinely always-true by construction … it should not be a field at
> all — its presence implies a discrimination the type never makes.

`TopologyTab.tsx` keys its fallback on **emptiness**, not provenance
(`if (runtimeTargets.length > 0) return runtimeTargets`), and then renders whatever it
resolved through one `Pattern:` chip. A declared `spec.placement` projection and a live
runtime observation are pixel-identical. The two cases that go wrong:

- `derivedFromRuntime:false` (no data plane) — the FE does **not** fall back "because
  the endpoint is unavailable"; it gets a 200, sees an empty list, and projects the
  declared spec, presenting it as the Topology tab's runtime view.
- `derivedFromRuntime:true` + `targets:[]` — the runtime genuinely observed nothing,
  and the declared spec silently takes its place.

### Fix

The resolver reports which rung it landed on, and the panel renders it:
`runtime-observed` (dim) vs `declared · not observed` (yellow), `data-testid=
topology-tab-placement-source`. No chip at all when the pattern is `not reported` —
nothing to attribute.

## Are #5515 / #5568 / #5513 one root cause?

**No — three causes, one shared mechanism, and they are worth keeping distinct.**

- #5515 (Go) and #5568 (console) are **independent defects on the same value's
  journey**: one fabricates the topology, the other erases the provenance that would
  have exposed the fabrication. Fixed here, together, because a reader of the Topology
  tab needs both.
- **#5513 is a separate root cause** — its collapse trigger is an empty
  `openova.io/region` label on the CNPG object, and its `status.perCluster` /
  "installed across N regions" divergence is controller-side. Not touched here.
  But it and #5515-Go **meet at one line**: `placement_fanout.go:146` deriving
  `singleton` is a second, independent path to the exact collapse #5513 describes
  ("the fan-out resolves to `role=singleton`, so no second-region HelmRelease is
  emitted and no Continuum CR is created"). And its render half — "the Topology tab
  renders **declared** `spec.placement` while the per-cluster table renders
  **effective** `status.perCluster`" — is precisely what the #5568 provenance chip now
  makes visible. So this PR narrows #5513 without closing it. No third ticket filed.

## Guard output — RED on the pre-fix tree, both directions

Method: revert only the guard line, keep the tests.

**Go model — `case primaries == 0` removed:**

```
--- FAIL: TestDerivePattern (0.00s)
    --- FAIL: TestDerivePattern/empty_targets_—_not-reported,_NEVER_singleton (0.00s)
        placement_target_test.go:76: DerivePattern = "singleton", want "not-reported"
--- FAIL: TestDerivePattern_5515_NeverFailsOpen (0.00s)
    --- FAIL: .../not-derivable/nil_target_list_—_the_/placement_endpoint_reported_nothing
        #5515 FAIL-OPEN: DerivePattern returned the confident "singleton" for a target list
        with no Primary. `singleton` means "one Primary, one region, no cross-region
        failover, and that is fine" — asserting it here turns missing data into a healthy
        DR verdict.
    --- FAIL: .../not-derivable/empty_target_list                       (same)
    --- FAIL: .../not-derivable/roles_all_unrecognised                  (same)
    --- FAIL: .../not-derivable/Standby-only,_Hot_—_an_active-*_pattern_with_no_active
        DerivePattern = "active-hot-standby", want "not-reported" (no Primary ⇒ no pattern)
    --- FAIL: .../not-derivable/Standby-only,_Cold
        DerivePattern = "active-passive", want "not-reported"
    --- FAIL: .../not-derivable/two_Standbys,_no_Primary
        DerivePattern = "active-hot-standby", want "not-reported"
--- FAIL: TestDerivePattern_5515_AgreesWithValidatePlacement (0.00s)
        the gate rejects this placement as NoPrimary but the label calls it
        "active-hot-standby" — the two halves of the model disagree (#5515)
FAIL
```

**API fold, true pre-fix state (model + fold both reverted) — the persisted value:**

```
--- FAIL: TestApplicationUpdateNormalize_5515_NoPrimaryNeverPersistsSingleton
    --- FAIL: .../no-primary/unrecognised_role
        #5515: a placement with NO Primary target was folded onto the stored mode
        "singleton" — the CR now records a deliberate single-region posture for a
        placement ValidatePlacement rejects as NoPrimary
    --- FAIL: .../no-primary/standby_only_(Hot)
        mode = "active-hot-standby", want empty so the request fails closed
    --- FAIL: .../no-primary/standby_only_(Cold)
        mode = "active-passive", want empty so the request fails closed
FAIL
```

**Cross-surface drift gate:**

```
--- FAIL: TestPlacementDerivation_5515_NoPrimaryGuardMatchesFE (0.00s)
    Go DerivePattern returned "active-hot-standby" for a target list with no Primary,
      want "not-reported" (#5515)
    Go DerivePattern fails open: an EMPTY target list returned the confident "singleton"
FAIL
```

**Fan-out ordering gate:**

```
--- FAIL: TestPatternNotReported_5515_UnreachableInFanout (0.00s)
    --- FAIL: .../gated/standby_only_(Hot)      precondition: DerivePattern = "active-hot-standby"
    --- FAIL: .../gated/standby_only_(Cold)     precondition: DerivePattern = "active-passive"
    --- FAIL: .../gated/unrecognised_roles      precondition: DerivePattern = "singleton"
    --- FAIL: .../gated/empty_list...           precondition: DerivePattern = "singleton"
FAIL
```

**Console, `TopologyTab.tsx` restored to `origin/main` (no consumer exists):**

```
 × runtime-observed targets are labelled runtime-observed (control)
 × the no-data-plane response (derivedFromRuntime:false) must NOT render its spec projection as observed
 × a runtime that returned targets but admitted derivedFromRuntime:false is still not an observation
 × a runtime observation that found NOTHING must not let the declared spec pose as observed
TestingLibraryElementError: Unable to find an element by: [data-testid="topology-tab-placement-source"]
      Tests  4 failed | 1 passed | 27 skipped (32)
```

### Vacuity checks — the assertions key on the FLAG, not on the chip existing

Two mutants, each caught by exactly the test written for it:

```
MUTANT A — runtimeWasConsulted = true   (chip present, flag ignored — the naive fix)
 × a runtime that returned targets but admitted derivedFromRuntime:false is still not an observation
   AssertionError: expected 'runtime-observed' not to be 'runtime-observed'
      Tests  1 failed | 4 passed

MUTANT B — runtimeWasConsulted = false  (always "declared" — the paranoid non-fix)
 × runtime-observed targets are labelled runtime-observed (control — must not always say declared)
   AssertionError: expected 'declared · not observed' to be 'runtime-observed'
      Tests  1 failed | 4 passed
```

Go controls are in-suite: every derivable placement must still derive its real pattern
(`VACUITY: DerivePattern returned "not-reported" for a genuinely derivable placement`),
every derivable fold must still write its mode, and the four real patterns must still
map to their real BcpTopology.

## Green, post-fix

```
core/controllers            go test ./...                    all ok
catalyst-api                go test ./...                    all ok
bootstrap/ui                vitest run    222 files | 2078 tests passed
bootstrap/ui                tsc -b --noEmit                  exit 0
scripts/check-controller-workflow-uniformity.sh              OK: all 7 controller workflows
scripts/check-no-banned-words.sh                             OK
```

## The workflow that was not running the model's tests

Checking that CI would actually run these guards turned up a gap worth its own line.
Every `build-*-controller.yaml` lists `core/controllers/pkg/**` in its paths filter
(TBD-A69 #2006 made that uniform) — but the test *commands* are scoped
`./application/...`, `./blueprint/...`, `./<x>/... ./internal/...`. None includes
`./pkg/...`.

So `pkg/apis/blueprint/v1alpha1` — the canonical placement model, `DerivePattern` and
`ValidatePlacement` — had its unit suite run in CI by **exactly one workflow**:
`build-sandbox-controller.yaml`, the build for the **legacy Sandbox controller removed
2026-06-30**. Trigger without assertion on six workflows; the seventh belongs to a
deleted product. `./pkg/...` added to `build-application-controller.yaml` (the
controller whose fan-out calls the function), which already triggers on that tree.
Uniformity guard still passes.

## Live state — hw292, read-only, both regions looped

- `catalyst-api` / `catalyst-ui` on dep `1c56518035a83e03` run `fad88bd` (2026-08-02).
  `git merge-base --is-ancestor a5216c662 fad88bd` → **NO**: the #5568 server fix is
  **(b) fixed in `main`, undeployed** there. `796e587b2` (the #5515 *frontend* fix)
  **is** an ancestor, so hw292 already renders `not reported` rather than a fabricated
  `singleton`.
- `application-controller` runs `4abd412` (2026-08-02) — carries the Go fail-open,
  which is **(a) still on `main`** regardless of vintage.
- Every live Application on hw292 has `spec.placement.targets` **absent** —
  `spine-gitea` / `spine-harbor` / `spine-keycloak` `placement=active-hot-standby`,
  `harbor` / `guacamole` / `newapi` `placement=singleton`, `uat-ahs-pg`
  `{"mode":"active-hot-standby","regions":[…a,…b]}`. So `derivePattern([])` is the
  live input for every one of them, exactly the #5515 precondition recorded on the
  issue 2026-07-31. Region-b holds no `applications` resource type; the loop is in the
  evidence so the single-region-sample trap is closed.

## Deliberately NOT fixed

- **`BcpTopology` gets no `unknown` member.** It would ripple into the CRD enums and
  the placement-vocabulary drift gate for a value that is unreachable by the
  ValidatePlacement ordering. Pinned by test instead.
- **#5513's controller half** — the empty `openova.io/region` label, `status.perCluster`
  vs "installed across N region(s)", the `Switch over…` gate, `spec.organizationRef`.
  Different root cause; left open.
- **The declared-vs-runtime divergence itself** (#3969 line: Overview renders
  `spec.placement`, Topology renders `derivePattern(runtime)`). This PR makes the
  divergence *visible and labelled*; it does not unify the two sources.
- **`mustReadRepoFile` / `findRepoRoot` `t.Skipf` on a missing path** — a drift gate
  that silently skips when its target moves. Shared by many tests in that package, so
  it is not rewritten here; the new drift test uses its own strict reader that
  `Fatalf`s instead, and says so in a comment.
- **No chart touched**, so no #817 five-site lockstep and no contention with the
  in-flight cutover-chart bump.

Refs #5515 #5568 #5513 #3969 #5731
