### PR TITLE
fix(cloud): storage counts read every region + wire the storageclass GVR (#5611)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -1077,48 +1077,142 @@ func loadPeerings(ctx context.Context, in LoaderInput, rs provisioner.RegionSpec
 // on every Sovereign, not just the hcloud mothership. Buckets stay []
 // until an object-storage source is wired (honest empty, not a false
 // count — the Buckets page renders the "not collected" empty-state).
+//
+// #5611 second defect (region fold): both collectors read ONLY
+// in.DynamicClient — the PRIMARY region's cluster — while buildTopology
+// beside them already fans out per region. On the 2-region hw292 that
+// makes the Volumes chip report region-a's 57 PVs while the
+// PersistentVolumes chip (k8scache SSE, which fans out across every
+// registered cluster) reports the true union of 105. Same object kind,
+// two different numbers on the same chip row. storageSources resolves
+// EVERY live cluster of this Sovereign so the storage counts carry the
+// same union semantics the PV chip already has.
 func buildStorage(ctx context.Context, in LoaderInput) StorageData {
+	srcs := storageSources(in)
 	return StorageData{
-		PVCs:    loadPVCs(ctx, in),
+		PVCs:    loadPVCs(ctx, srcs),
 		Buckets: []Bucket{},
-		Volumes: loadVolumes(ctx, in),
+		Volumes: loadVolumes(ctx, srcs),
 	}
 }
 
-func loadPVCs(ctx context.Context, in LoaderInput) (out []PVC) {
+// storageSource — one live cluster the storage collectors read from,
+// plus the region key that cluster belongs to. The region key is the
+// AUTHORITATIVE region attribution for every object read through it:
+// on hw292 both regions' EVS PVs carry the SAME CSI topology zone
+// (`topology.evs.csi.huaweicloud.com/zone = me-east-215a`, verified
+// live 2026-08-06 on both kubeconfigs), so the in-object topology term
+// cannot separate the regions and only the source cluster can.
+type storageSource struct {
+	// clusterID — dedupe key so a cluster resolved twice (e.g. two
+	// declared regions collapsing onto one client via the #5274
+	// token-overlap fallback) is read once.
+	clusterID string
+	// region — declared CloudRegion this client serves. Empty on the
+	// legacy single-client path, where callers fall back to the
+	// object's own topology term.
+	region string
+	dc     dynamic.Interface
+}
+
+// storageSources enumerates every live cluster whose storage belongs to
+// THIS Sovereign. The branch structure deliberately mirrors
+// buildTopology's: the chroot "every registered cluster" fan-out fires
+// only when no regions are declared, because on the mothership the
+// k8sCache holds clusters for EVERY deployment — iterating it there
+// would union other Sovereigns' volumes into this one's Cloud page (a
+// far worse number than the region-a-only undercount it replaces).
+func storageSources(in LoaderInput) []storageSource {
+	seen := map[string]bool{}
+	out := []storageSource{}
+	add := func(id, region string, dc dynamic.Interface) {
+		if dc == nil || seen[id] {
+			return
+		}
+		seen[id] = true
+		out = append(out, storageSource{clusterID: id, region: region, dc: dc})
+	}
+
+	switch {
+	case len(in.Regions) > 0:
+		// Declared-regions path (mothership). Regions[0] is the primary
+		// and IS in.DynamicClient — perRegionDynamicClient returns nil
+		// for it by contract, so it is added once, here.
+		primaryRegion := strings.TrimSpace(in.Region)
+		if primaryRegion == "" {
+			primaryRegion = strings.TrimSpace(in.Regions[0].CloudRegion)
+		}
+		add(in.DeploymentID, primaryRegion, in.DynamicClient)
+		for _, rs := range in.Regions {
+			if dc := perRegionDynamicClient(in, rs); dc != nil {
+				add("region:"+rs.CloudRegion, strings.TrimSpace(rs.CloudRegion), dc)
+			}
+		}
+	case in.K8sCache != nil && len(in.K8sCache.Clusters()) > 0:
+		// Chroot post-cutover path (G14): the on-Sovereign k8sCache
+		// holds only this Sovereign's own clusters.
+		for _, cid := range in.K8sCache.Clusters() {
+			region := ""
+			if strings.HasPrefix(cid, in.DeploymentID+"-") {
+				region = trimMaterialisationIndex(strings.TrimPrefix(cid, in.DeploymentID+"-"))
+			} else if cid == in.DeploymentID {
+				region = strings.TrimSpace(in.Region)
+			}
+			add(cid, region, clientForCluster(in, cid))
+		}
+	default:
+		// Legacy single-client path (tests, pre-multi-region payloads).
+		add(in.DeploymentID, strings.TrimSpace(in.Region), in.DynamicClient)
+	}
+	return out
+}
+
+func loadPVCs(ctx context.Context, srcs []storageSource) (out []PVC) {
 	out = []PVC{}
 	defer func() {
 		if r := recover(); r != nil {
 			out = []PVC{}
 		}
 	}()
-	if in.DynamicClient == nil {
-		return out
-	}
 	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
 		Resource: "persistentvolumeclaims",
 	}
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	list, err := in.DynamicClient.Resource(gvr).Namespace("").List(cctx, metav1.ListOptions{})
-	if err != nil || list == nil {
-		return out
-	}
-	for _, item := range list.Items {
-		spec, _, _ := nestedMap(item.Object, "spec")
-		status, _, _ := nestedMap(item.Object, "status")
-		capacity := stringField(stringMapField(status, "capacity"), "storage")
-		out = append(out, PVC{
-			ID:           string(item.GetUID()),
-			Name:         item.GetName(),
-			Namespace:    item.GetNamespace(),
-			Capacity:     capacity,
-			Used:         "",
-			StorageClass: stringField(spec, "storageClassName"),
-			Status:       stringField(status, "phase"),
-		})
+	seen := map[string]bool{}
+	for _, src := range srcs {
+		if src.dc == nil {
+			continue
+		}
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		list, err := src.dc.Resource(gvr).Namespace("").List(cctx, metav1.ListOptions{})
+		cancel()
+		if err != nil || list == nil {
+			continue
+		}
+		for _, item := range list.Items {
+			// UID dedupe: belt-and-braces against a cluster reachable
+			// through two source keys. Objects without a UID (fake
+			// clients in unit tests) are never deduped away.
+			if uid := string(item.GetUID()); uid != "" {
+				if seen[uid] {
+					continue
+				}
+				seen[uid] = true
+			}
+			spec, _, _ := nestedMap(item.Object, "spec")
+			status, _, _ := nestedMap(item.Object, "status")
+			capacity := stringField(stringMapField(status, "capacity"), "storage")
+			out = append(out, PVC{
+				ID:           string(item.GetUID()),
+				Name:         item.GetName(),
+				Namespace:    item.GetNamespace(),
+				Capacity:     capacity,
+				Used:         "",
+				StorageClass: stringField(spec, "storageClassName"),
+				Status:       stringField(status, "phase"),
+			})
+		}
 	}
 	return out
 }
@@ -1129,38 +1223,60 @@ func loadPVCs(ctx context.Context, in LoaderInput) (out []PVC) {
 // Huawei via evs.csi.huaweicloud.com), so PVs are the provider-agnostic
 // source that is populated on every Sovereign — unlike the hcloud-only
 // Crossplane `volume.hcloud` XRC, which returns nothing on a Huawei
-// Sovereign and produced the false "Volumes 0". Mirrors loadPVCs: reads
-// the same in.DynamicClient (the region this loader is scoped to), so
-// the count matches that region's live PVs and never fabricates a row.
-func loadVolumes(ctx context.Context, in LoaderInput) (out []Volume) {
+// Sovereign and produced the false "Volumes 0". Mirrors loadPVCs.
+//
+// Reads EVERY source in srcs (one per live region — see storageSources)
+// so the count is the union across regions, matching the semantics the
+// PersistentVolumes chip already has via the k8scache SSE fan-out. A
+// single-source srcs is exactly the previous single-region behaviour.
+func loadVolumes(ctx context.Context, srcs []storageSource) (out []Volume) {
 	out = []Volume{}
 	defer func() {
 		if r := recover(); r != nil {
 			out = []Volume{}
 		}
 	}()
-	if in.DynamicClient == nil {
-		return out
-	}
 	// PVs are cluster-scoped — list without a namespace.
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	list, err := in.DynamicClient.Resource(gvr).List(cctx, metav1.ListOptions{})
-	if err != nil || list == nil {
-		return out
-	}
-	for _, item := range list.Items {
-		spec, _, _ := nestedMap(item.Object, "spec")
-		status, _, _ := nestedMap(item.Object, "status")
-		out = append(out, Volume{
-			ID:         item.GetName(),
-			Name:       item.GetName(),
-			Capacity:   stringField(stringMapField(spec, "capacity"), "storage"),
-			Region:     pvRegion(spec),
-			AttachedTo: pvClaimRef(spec),
-			Status:     pvPhaseToTopologyStatus(stringField(status, "phase")),
-		})
+	seen := map[string]bool{}
+	for _, src := range srcs {
+		if src.dc == nil {
+			continue
+		}
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		list, err := src.dc.Resource(gvr).List(cctx, metav1.ListOptions{})
+		cancel()
+		if err != nil || list == nil {
+			continue
+		}
+		for _, item := range list.Items {
+			if uid := string(item.GetUID()); uid != "" {
+				if seen[uid] {
+					continue
+				}
+				seen[uid] = true
+			}
+			spec, _, _ := nestedMap(item.Object, "spec")
+			status, _, _ := nestedMap(item.Object, "status")
+			// Region attribution: the SOURCE cluster wins over the PV's
+			// own CSI topology term. On hw292 every PV in BOTH regions
+			// reports zone "me-east-215a", so the in-object term folds
+			// the two regions into one filter value; the cluster the PV
+			// was read from is the honest answer. Fall back to the
+			// topology term only when the source carries no region key.
+			region := src.region
+			if region == "" {
+				region = pvRegion(spec)
+			}
+			out = append(out, Volume{
+				ID:         item.GetName(),
+				Name:       item.GetName(),
+				Capacity:   stringField(stringMapField(spec, "capacity"), "storage"),
+				Region:     region,
+				AttachedTo: pvClaimRef(spec),
+				Status:     pvPhaseToTopologyStatus(stringField(status, "phase")),
+			})
+		}
 	}
 	return out
 }

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_storage_regions_5611_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_storage_regions_5611_test.go
@@ -1,0 +1,211 @@
+// topology_loader_storage_regions_5611_test.go — #5611, second defect.
+//
+// PR #5685 removed the hardcoded `Volumes: []Volume{}` so the cloud
+// Volumes page stopped claiming a false zero. It did NOT fix where the
+// number comes from: buildStorage read ONLY in.DynamicClient — the
+// PRIMARY region's cluster — while buildTopology right beside it already
+// fans out per region. On the 2-region hw292 that leaves the Volumes
+// chip reporting region-a's 57 PVs while the PersistentVolumes chip
+// (k8scache SSE, which fans out across every registered cluster) reports
+// the true union of 105. Same underlying object kind, two different
+// numbers on the same chip row — a zero replaced by a different wrong
+// number.
+//
+// Live hw292 numbers these fixtures are scaled down from (both
+// kubeconfigs sampled 2026-08-06):
+//
+//	region-a (1c56518035a83e03)                    57 PVs / 58 PVCs
+//	region-b (1c56518035a83e03-me-east-215-b-1)    48 PVs / 48 PVCs
+//	union                                         105 PVs / 106 PVCs
+//
+// Region attribution is asserted too, and it is not cosmetic: on hw292
+// every PV in BOTH regions carries the SAME CSI topology zone
+// (`topology.evs.csi.huaweicloud.com/zone = me-east-215a`), so the
+// in-object term folds the regions together and only the source cluster
+// can tell them apart. A union that mislabels every row as one region is
+// still a console that misinforms.
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+const (
+	depID5611     = "1c56518035a83e03"
+	regionA5611   = "me-east-215-a"
+	regionB5611   = "me-east-215-b"
+	clusterB5611  = depID5611 + "-me-east-215-b-1"
+	csiZoneShared = "me-east-215a" // identical in BOTH regions on hw292
+)
+
+// storageClient builds a fake dynamic client carrying cluster-scoped PVs
+// and namespaced PVCs, every object carrying the shared CSI zone so the
+// fixture reproduces hw292's region-indistinguishable topology terms.
+func storageClient(t *testing.T, pvNames, pvcNames []string, uidPrefix string) dynamic.Interface {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "persistentvolumes"}:      "PersistentVolumeList",
+		{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}: "PersistentVolumeClaimList",
+	}
+	objs := []runtime.Object{}
+	for _, n := range pvNames {
+		objs = append(objs, &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: n, UID: types.UID(uidPrefix + n)},
+			Spec: corev1.PersistentVolumeSpec{
+				Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("50Gi")},
+				NodeAffinity: &corev1.VolumeNodeAffinity{
+					Required: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+							MatchExpressions: []corev1.NodeSelectorRequirement{{
+								Key:      "topology.evs.csi.huaweicloud.com/zone",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{csiZoneShared},
+							}},
+						}},
+					},
+				},
+			},
+			Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeBound},
+		})
+	}
+	for _, n := range pvcNames {
+		objs = append(objs, &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "openova-system", UID: types.UID(uidPrefix + n)},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+		})
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
+}
+
+// twoRegionInput mirrors hw292's declared shape: Regions[0] is the
+// primary (served by in.DynamicClient), Regions[1] is a secondary whose
+// kubeconfig is registered in the k8sCache under "<depID>-<region>-1".
+func twoRegionInput(t *testing.T) LoaderInput {
+	t.Helper()
+	primary := storageClient(t, []string{"pv-a-1", "pv-a-2", "pv-a-3"}, []string{"pvc-a-1", "pvc-a-2", "pvc-a-3"}, "uid-a-")
+	secondary := storageClient(t, []string{"pv-b-1", "pv-b-2"}, []string{"pvc-b-1", "pvc-b-2"}, "uid-b-")
+	return LoaderInput{
+		DeploymentID:  depID5611,
+		Region:        regionA5611,
+		DynamicClient: primary,
+		Regions: []provisioner.RegionSpec{
+			{CloudRegion: regionA5611, Provider: "huawei"},
+			{CloudRegion: regionB5611, Provider: "huawei"},
+		},
+		K8sCache: &fakeK8sCache{
+			clients: map[string]dynamic.Interface{depID5611: primary, clusterB5611: secondary},
+		},
+	}
+}
+
+// TestBuildStorage_UnionsBothRegions_5611 is the decisive guard. On the
+// pre-fix tree buildStorage reads only in.DynamicClient, so Volumes is 3
+// (region-a only) and this fails at "got 3, want 5".
+func TestBuildStorage_UnionsBothRegions_5611(t *testing.T) {
+	storage := buildStorage(context.Background(), twoRegionInput(t))
+
+	if got := len(storage.Volumes); got != 5 {
+		t.Fatalf("Volumes = %d, want 5 (3 region-a + 2 region-b) — the Cloud Volumes chip reports one region while the PersistentVolumes chip reports the union (#5611)", got)
+	}
+	if got := len(storage.PVCs); got != 5 {
+		t.Fatalf("PVCs = %d, want 5 (3 region-a + 2 region-b) — same single-region fold (#5611)", got)
+	}
+
+	// Both regions actually present, by name — a union that silently
+	// read the primary twice would also total 5 without the fix.
+	names := map[string]bool{}
+	for _, v := range storage.Volumes {
+		names[v.Name] = true
+	}
+	for _, want := range []string{"pv-a-1", "pv-a-2", "pv-a-3", "pv-b-1", "pv-b-2"} {
+		if !names[want] {
+			t.Errorf("volume %q missing from the union; got %v", want, names)
+		}
+	}
+}
+
+// TestBuildStorage_RegionAttribution_5611 — every row must carry the
+// region of the CLUSTER it was read from, not the CSI topology term the
+// two regions share. Pre-fix (and with a naive union) all five rows read
+// "me-east-215a", collapsing the Volumes page's region filter to a
+// single useless option.
+func TestBuildStorage_RegionAttribution_5611(t *testing.T) {
+	storage := buildStorage(context.Background(), twoRegionInput(t))
+
+	perRegion := map[string]int{}
+	for _, v := range storage.Volumes {
+		perRegion[v.Region]++
+	}
+	if perRegion[regionA5611] != 3 {
+		t.Errorf("region %s = %d volumes, want 3 (got the whole map %v)", regionA5611, perRegion[regionA5611], perRegion)
+	}
+	if perRegion[regionB5611] != 2 {
+		t.Errorf("region %s = %d volumes, want 2 (got the whole map %v)", regionB5611, perRegion[regionB5611], perRegion)
+	}
+	if perRegion[csiZoneShared] != 0 {
+		t.Errorf("%d volumes fell back to the shared CSI zone %q — the source cluster must win, or both regions read as one", perRegion[csiZoneShared], csiZoneShared)
+	}
+}
+
+// TestBuildStorage_NoDoubleCount_5611 is the CONTROL: a SINGLE-region
+// Sovereign must report exactly its own objects. Green on the pre-fix
+// tree too — it is what rules out a "fix" that counts everything twice.
+func TestBuildStorage_NoDoubleCount_5611(t *testing.T) {
+	primary := storageClient(t, []string{"pv-a-1", "pv-a-2", "pv-a-3"}, []string{"pvc-a-1"}, "uid-a-")
+	in := LoaderInput{
+		DeploymentID:  depID5611,
+		Region:        regionA5611,
+		DynamicClient: primary,
+		Regions:       []provisioner.RegionSpec{{CloudRegion: regionA5611, Provider: "huawei"}},
+		K8sCache: &fakeK8sCache{
+			clients: map[string]dynamic.Interface{depID5611: primary},
+		},
+	}
+	storage := buildStorage(context.Background(), in)
+	if got := len(storage.Volumes); got != 3 {
+		t.Fatalf("single-region Volumes = %d, want exactly 3 — the fan-out must not read the same cluster twice", got)
+	}
+	if got := len(storage.PVCs); got != 1 {
+		t.Fatalf("single-region PVCs = %d, want exactly 1", got)
+	}
+}
+
+// TestStorageSources_MothershipDoesNotUnionOtherSovereigns_5611 — the
+// guard on the fan-out's blast radius. On the MOTHERSHIP the k8sCache
+// holds clusters for EVERY deployment, so a fan-out that iterated
+// Clusters() unconditionally would union other Sovereigns' volumes into
+// this one's Cloud page: a far worse number than the undercount it
+// replaces. With Regions declared, only this deployment's clusters may
+// be read.
+func TestStorageSources_MothershipDoesNotUnionOtherSovereigns_5611(t *testing.T) {
+	in := twoRegionInput(t)
+	cache := in.K8sCache.(*fakeK8sCache)
+	// A DIFFERENT Sovereign's cluster, registered in the same cache.
+	other := storageClient(t, []string{"pv-other-1", "pv-other-2"}, nil, "uid-other-")
+	cache.clients["deadbeefdeadbeef"] = other
+
+	storage := buildStorage(context.Background(), in)
+
+	if got := len(storage.Volumes); got != 5 {
+		t.Fatalf("Volumes = %d, want 5 — another Sovereign's volumes leaked into this deployment's Cloud page", got)
+	}
+	for _, v := range storage.Volumes {
+		if v.Name == "pv-other-1" || v.Name == "pv-other-2" {
+			t.Fatalf("volume %q belongs to a different deployment and must never appear here", v.Name)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -104,6 +104,21 @@ var DefaultKinds = []Kind{
 	// bridge (PV.csi.volumeAttributes carries the hcloud volume id).
 	{Name: "persistentvolume", GVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, Namespaced: false},
 
+	// Storage (storage.k8s.io/v1). Cluster-scoped.
+	//
+	// #5611 — the cloud list's "Storage Classes" chip rendered the
+	// not-collected marker "—" and its page rendered a stub reading
+	// "the storage.k8s.io/StorageClass GVR is not yet in the
+	// catalyst-api k8scache registry", while every Sovereign serves 2
+	// of them (evs-ssd default + seaweedfs-storage, both regions of
+	// hw292, verified live 2026-08-06). The GVR is core Kubernetes and
+	// served on every cluster, so this is NOT Optional — no discovery
+	// probe needed. Read verbs for storage.k8s.io/storageclasses are
+	// ALREADY on the catalyst-api-cutover-driver ClusterRole
+	// (chart/templates/clusterrole-cutover-driver.yaml §5), so the
+	// chroot in-cluster fallback needs no RBAC change.
+	{Name: "storageclass", GVR: schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"}, Namespaced: false},
+
 	// Workloads (apps/v1).
 	{Name: "deployment", GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, Namespaced: true},
 	{Name: "statefulset", GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}, Namespaced: true},
@@ -463,6 +478,9 @@ var kindShortAliases = map[string]string{
 	"pvcs":   "persistentvolumeclaim", // pluralised short form (matrix usage)
 	"pv":     "persistentvolume",
 	"pvs":    "persistentvolume",
+	// #5611 — kubectl's own short form for StorageClass.
+	"sc":     "storageclass",
+	"scs":    "storageclass",
 	"deploy": "deployment",
 	"sts":    "statefulset",
 	"ds":     "daemonset",

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -60,12 +60,11 @@ import { CloudKindChips } from './cloud-list/CloudKindChips'
 import {
   CLOUD_PAGE_K8S_KINDS,
   DEFAULT_KIND,
-  KIND_IDS,
-  KIND_TO_REGISTRY,
   isValidKind,
   readPersistedKind,
   type CloudListKind,
 } from './cloud-list/kinds'
+import { deriveKindCounts } from './cloud-list/kindCounts'
 import { useK8sCacheStream } from '@/widgets/architecture-graph/useK8sCacheStream'
 import { CloudLensProvider } from '@/widgets/architecture-graph/useCloudLens'
 import type { LensId } from '@/widgets/architecture-graph/presets'
@@ -424,59 +423,13 @@ export function CloudPage({
   // K8s-backed kind (incl. the reconcilers) is overridden from the live
   // SSE snapshot once initialState arrives. `null` = data unavailable
   // (renders "—"); 0 = genuinely empty.
-  const kindCounts = useMemo<Record<CloudListKind, number | null>>(() => {
-    const c = {} as Record<CloudListKind, number | null>
-    for (const id of KIND_IDS) {
-      // K8s-backed kinds start at null (until the stream connects);
-      // topology-projected kinds start at 0 (the snapshot is sync).
-      c[id] = id in KIND_TO_REGISTRY ? null : 0
-    }
-    if (data) {
-      let clusters = 0
-      let vclusters = 0
-      let nodePools = 0
-      let workerNodes = 0
-      let lb = 0
-      for (const region of data.topology.regions ?? []) {
-        for (const cluster of region.clusters ?? []) {
-          clusters += 1
-          vclusters += cluster.vclusters?.length ?? 0
-          nodePools += cluster.nodePools?.length ?? 0
-          workerNodes += cluster.nodes?.length ?? 0
-          lb += cluster.loadBalancers?.length ?? 0
-        }
-      }
-      c['clusters'] = clusters
-      c['vclusters'] = vclusters
-      c['node-pools'] = nodePools
-      c['worker-nodes'] = workerNodes
-      c['load-balancers'] = lb
-      c['pvcs'] = data.storage?.pvcs?.length ?? 0
-      c['buckets'] = data.storage?.buckets?.length ?? 0
-      c['volumes'] = data.storage?.volumes?.length ?? 0
-    }
-    // Override every K8s-backed count from the live snapshot. Counts
-    // stay null until the SSE connection delivers initialState=1.
-    if (k8sStream.snapshot.size > 0) {
-      const liveCounts: Partial<Record<CloudListKind, number>> = {}
-      for (const key of k8sStream.snapshot.keys()) {
-        const kind = key.split(':', 1)[0]
-        for (const [chipId, registryKind] of Object.entries(KIND_TO_REGISTRY)) {
-          if (registryKind === kind) {
-            const id = chipId as CloudListKind
-            liveCounts[id] = (liveCounts[id] ?? 0) + 1
-          }
-        }
-      }
-      // Always set to 0 (not null) for K8s-backed kinds once the stream
-      // has any data — initialState=1 has arrived, so a 0-count kind is
-      // genuinely empty, not unconnected.
-      for (const chipId of Object.keys(KIND_TO_REGISTRY) as CloudListKind[]) {
-        c[chipId] = liveCounts[chipId] ?? 0
-      }
-    }
-    return c
-  }, [data, k8sStream.snapshot, k8sStream.revision])
+  // Body extracted to cloud-list/kindCounts.ts (#5611) so the guard can
+  // assert on the VALUE this produces without hand-feeding the chips a
+  // `counts` prop production never generates.
+  const kindCounts = useMemo<Record<CloudListKind, number | null>>(
+    () => deriveKindCounts(data, k8sStream.snapshot),
+    [data, k8sStream.snapshot, k8sStream.revision],
+  )
 
   const setKind = useCallback(
     (next: CloudListKind) => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindCounts.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindCounts.ts
@@ -1,0 +1,79 @@
+/**
+ * kindCounts.ts — the per-kind count map behind the Cloud list chip
+ * badges.
+ *
+ * Extracted verbatim out of CloudPage's `kindCounts` useMemo (#5611) so
+ * the derivation is testable as PRODUCTION code. A guard that renders
+ * CloudKindChips with a hand-built `counts` prop proves nothing about
+ * what the operator sees — it asserts on a value production never
+ * produced. CloudPage now calls this function, so a test that calls it
+ * exercises the same path.
+ *
+ * Semantics (unchanged):
+ *   • `null`  → data unavailable; the chip renders the "—" marker.
+ *   • `0`     → genuinely empty (stream connected, nothing of this kind).
+ *   • Topology-projected kinds seed from the topology snapshot.
+ *   • Every kind in KIND_TO_REGISTRY is overridden from the live SSE
+ *     snapshot once initialState has arrived.
+ */
+
+import type { K8sSnapshot } from '@/widgets/architecture-graph/useK8sCacheStream'
+import type { HierarchicalInfrastructure } from '@/lib/infrastructure.types'
+import { KIND_IDS, KIND_TO_REGISTRY, type CloudListKind } from './kinds'
+
+export function deriveKindCounts(
+  data: HierarchicalInfrastructure | undefined | null,
+  snapshot: K8sSnapshot | null | undefined,
+): Record<CloudListKind, number | null> {
+  const c = {} as Record<CloudListKind, number | null>
+  for (const id of KIND_IDS) {
+    // K8s-backed kinds start at null (until the stream connects);
+    // topology-projected kinds start at 0 (the snapshot is sync).
+    c[id] = id in KIND_TO_REGISTRY ? null : 0
+  }
+  if (data) {
+    let clusters = 0
+    let vclusters = 0
+    let nodePools = 0
+    let workerNodes = 0
+    let lb = 0
+    for (const region of data.topology.regions ?? []) {
+      for (const cluster of region.clusters ?? []) {
+        clusters += 1
+        vclusters += cluster.vclusters?.length ?? 0
+        nodePools += cluster.nodePools?.length ?? 0
+        workerNodes += cluster.nodes?.length ?? 0
+        lb += cluster.loadBalancers?.length ?? 0
+      }
+    }
+    c['clusters'] = clusters
+    c['vclusters'] = vclusters
+    c['node-pools'] = nodePools
+    c['worker-nodes'] = workerNodes
+    c['load-balancers'] = lb
+    c['pvcs'] = data.storage?.pvcs?.length ?? 0
+    c['buckets'] = data.storage?.buckets?.length ?? 0
+    c['volumes'] = data.storage?.volumes?.length ?? 0
+  }
+  // Override every K8s-backed count from the live snapshot. Counts stay
+  // null until the SSE connection delivers initialState=1.
+  if (snapshot && snapshot.size > 0) {
+    const liveCounts: Partial<Record<CloudListKind, number>> = {}
+    for (const key of snapshot.keys()) {
+      const kind = key.split(':', 1)[0]
+      for (const [chipId, registryKind] of Object.entries(KIND_TO_REGISTRY)) {
+        if (registryKind === kind) {
+          const id = chipId as CloudListKind
+          liveCounts[id] = (liveCounts[id] ?? 0) + 1
+        }
+      }
+    }
+    // Always set to 0 (not null) for K8s-backed kinds once the stream
+    // has any data — initialState=1 has arrived, so a 0-count kind is
+    // genuinely empty, not unconnected.
+    for (const chipId of Object.keys(KIND_TO_REGISTRY) as CloudListKind[]) {
+      c[chipId] = liveCounts[chipId] ?? 0
+    }
+  }
+  return c
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
@@ -150,6 +150,11 @@ export const KIND_TO_REGISTRY: Partial<Record<CloudListKind, string>> = {
   namespaces: 'namespace',
   nodes: 'node',
   persistentvolumes: 'persistentvolume',
+  // #5611 — storage.k8s.io/StorageClass. Adding the mapping here is what
+  // auto-subscribes the CloudPage SSE (CLOUD_PAGE_K8S_KINDS is derived
+  // from this map) AND makes the chip count tally live objects instead
+  // of the not-collected "—".
+  'storage-classes': 'storageclass',
   endpointslices: 'endpointslice',
   // Wave-2 Family-E (#1583, C11-005/C11-006): Kyverno PolicyReport CRDs.
   policyreports: 'policyreport',
@@ -359,7 +364,10 @@ export const KINDS: readonly CloudKindEntry[] = [
   { id: 'secrets', label: 'Secrets', tagline: 'Sensitive bundles (values redacted)', hasData: true, Component: SecretsListPage, icon: ICON_SECRET, category: 'config', primary: false },
   { id: 'volumes', label: 'Volumes', tagline: 'Cloud block volumes', hasData: true, Component: VolumesPage, icon: ICON_VOLUME, category: 'storage', primary: false },
   { id: 'persistentvolumes', label: 'PersistentVolumes', tagline: 'Cluster-scoped backing volumes', hasData: true, Component: PersistentVolumesListPage, icon: ICON_PV, category: 'storage', primary: false },
-  { id: 'storage-classes', label: 'Storage Classes', tagline: 'Provisioner + reclaim policy presets', hasData: false, Component: StorageClassesListPage, icon: ICON_STORAGE_CLASS, category: 'storage', primary: false },
+  // #5611 — hasData flipped false→true: the `storageclass` GVR is now in
+  // the catalyst-api k8scache registry, so the chip shows the real count
+  // instead of the not-collected marker "—".
+  { id: 'storage-classes', label: 'Storage Classes', tagline: 'Provisioner + reclaim policy presets', hasData: true, Component: StorageClassesListPage, icon: ICON_STORAGE_CLASS, category: 'storage', primary: false },
 
   // Wave-2 Family-E (C11-005/C11-006): Kyverno PolicyReport surfaces.
   // Both render in the `+ More` popover (the Compliance dashboard is the

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
@@ -600,20 +600,63 @@ export function CiliumClusterwideNetworkPoliciesListPage() {
   )
 }
 
+/**
+ * StorageClass columns (#5611).
+ *
+ * StorageClass carries `provisioner` / `reclaimPolicy` /
+ * `volumeBindingMode` / `allowVolumeExpansion` at the TOP level of the
+ * object — not under `spec` — so `colSpec` does not apply and each
+ * column extracts directly.
+ */
+function colTop(key: string, header: string) {
+  return {
+    header,
+    extract: (o: K8sObject) => {
+      const v = o[key]
+      return v == null ? '—' : String(v)
+    },
+  }
+}
+
+/** The `storageclass.kubernetes.io/is-default-class` annotation is what
+ *  `kubectl get sc` renders as the "(default)" name suffix. */
+const SC_DEFAULT_ANNOTATION = 'storageclass.kubernetes.io/is-default-class'
+const COL_SC_DEFAULT = {
+  header: 'Default',
+  extract: (o: K8sObject) =>
+    o.metadata?.annotations?.[SC_DEFAULT_ANNOTATION] === 'true' ? 'yes' : '—',
+  tone: (o: K8sObject): CellTone | undefined =>
+    o.metadata?.annotations?.[SC_DEFAULT_ANNOTATION] === 'true' ? 'ok' : undefined,
+}
+
+/**
+ * StorageClassesListPage — #5611.
+ *
+ * Was a stub reading "the storage.k8s.io/StorageClass GVR is not yet in
+ * the catalyst-api k8scache registry", with `hasData: false` in kinds.ts
+ * so the chip rendered the not-collected marker "—" on a Sovereign
+ * serving 2 classes per region. The GVR is now registered
+ * (api/internal/k8scache/kinds.go `storageclass`), so this renders live
+ * objects like every other wired kind — including the #5571 Region
+ * column, which matters here because BOTH regions serve a class named
+ * `evs-ssd` and they must not read as one.
+ */
 export function StorageClassesListPage() {
   return (
-    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6 text-sm text-[var(--color-text-dim)]">
-      <h2 className="mb-1 text-lg font-semibold text-[var(--color-text-strong)]">Storage Classes</h2>
-      <p>
-        The <code className="font-mono">storage.k8s.io/StorageClass</code> GVR is not yet in the
-        catalyst-api k8scache registry. Tracking work to add it lives in
-        {' '}
-        <a href="https://github.com/openova-io/openova/issues/321" className="underline">
-          issue #321
-        </a>
-        .
-      </p>
-    </div>
+    <K8sListPage
+      kind="storageclass"
+      title="Storage Classes"
+      tagline="Provisioner + reclaim policy presets backing every PVC."
+      columns={[
+        COL_NAME,
+        colTop('provisioner', 'Provisioner'),
+        colTop('reclaimPolicy', 'Reclaim Policy'),
+        colTop('volumeBindingMode', 'Binding Mode'),
+        colTop('allowVolumeExpansion', 'Expandable'),
+        COL_SC_DEFAULT,
+        COL_AGE,
+      ]}
+    />
   )
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/storageChips.5611.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/storageChips.5611.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * storageChips.5611.test.tsx — #5611.
+ *
+ * The issue: `/cloud?view=list&kind=volumes` reported **`Volumes 0`**
+ * and rendered "No volumes yet" on hw292, a Sovereign carrying 50+ EVS
+ * block volumes; the sibling **`Storage Classes —`** chip rendered the
+ * not-collected marker while `kubectl get storageclass` returned 2 per
+ * region. Meanwhile the **PersistentVolumes** chip on the SAME row read
+ * the correct union across both regions — so the data was always
+ * reachable and only the storage collectors were wrong.
+ *
+ * What these guards assert, and why in this shape:
+ *
+ *  1. **On the VALUE, never the key.** A test asserting the chip
+ *     "renders" or that `counts['storage-classes']` is *defined* passes
+ *     on the pre-fix tree — `—` is rendered and `null` is defined. Zero
+ *     is a value. Every assertion below pins a NUMBER.
+ *
+ *  2. **Through production code.** The counts come from
+ *     `deriveKindCounts`, the function CloudPage itself calls. Handing
+ *     `CloudKindChips` a literal `counts` object would assert on a value
+ *     production never produces.
+ *
+ *  3. **Two regions.** The snapshot is built with the production
+ *     `objectKey`, whose `@cluster` suffix (#5571) is what keeps both
+ *     regions' copies of the identically-named `evs-ssd` StorageClass
+ *     distinct. A single-region fixture would pass at half the count.
+ *
+ *  4. **Control.** PersistentVolumes — a kind that already collected
+ *     correctly — must still read its own real number, and must not
+ *     move. That is what rules out a "fix" that double-counts.
+ *
+ * Live hw292 numbers this fixture is scaled down from (both kubeconfigs
+ * sampled 2026-08-06): region-a 57 PVs / 58 PVCs / 2 SCs, region-b 48
+ * PVs / 48 PVCs / 2 SCs.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup, render, screen, fireEvent } from '@testing-library/react'
+import type { K8sObject, K8sSnapshot } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { objectKey } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { deriveKindCounts } from './kindCounts'
+import { CloudKindChips } from './CloudKindChips'
+import { KINDS } from './kinds'
+
+afterEach(cleanup)
+
+/** hw292's two real cluster ids. */
+const REGION_A = '1c56518035a83e03'
+const REGION_B = '1c56518035a83e03-me-east-215-b-1'
+
+function obj(
+  kind: string,
+  registryKind: string,
+  name: string,
+  cluster: string,
+): [string, K8sObject] {
+  const o: K8sObject = {
+    kind,
+    metadata: { name, uid: `uid-${cluster}-${name}` },
+    clusterId: cluster,
+  }
+  return [objectKey(registryKind, o, cluster), o]
+}
+
+/**
+ * A two-region snapshot in hw292's real shape: BOTH regions serve a
+ * StorageClass named `evs-ssd` and one named `seaweedfs-storage` — the
+ * names collide exactly, which is why the region-suffixed key matters.
+ */
+function twoRegionSnapshot(): K8sSnapshot {
+  const entries: Array<[string, K8sObject]> = []
+  for (const region of [REGION_A, REGION_B]) {
+    entries.push(obj('StorageClass', 'storageclass', 'evs-ssd', region))
+    entries.push(obj('StorageClass', 'storageclass', 'seaweedfs-storage', region))
+  }
+  // Control kind: PersistentVolumes, 3 in region-a + 2 in region-b.
+  for (const name of ['pv-a-1', 'pv-a-2', 'pv-a-3']) {
+    entries.push(obj('PersistentVolume', 'persistentvolume', name, REGION_A))
+  }
+  for (const name of ['pv-b-1', 'pv-b-2']) {
+    entries.push(obj('PersistentVolume', 'persistentvolume', name, REGION_B))
+  }
+  return new Map(entries)
+}
+
+/** Read a chip's rendered count text out of the `+ More` popover. */
+function overflowChipCount(kindId: string): string {
+  fireEvent.click(screen.getByTestId('cloud-kind-chip-more'))
+  const item = screen.getByTestId(`cloud-kind-chip-more-item-${kindId}`)
+  const badge = item.querySelector('.cloud-kind-chip-count')
+  return badge?.textContent ?? ''
+}
+
+describe('#5611 — storage kinds must report their real count, not a false zero or "—"', () => {
+  it('GUARD: Storage Classes counts BOTH regions (4), not "—" and not one region (2)', () => {
+    const counts = deriveKindCounts(undefined, twoRegionSnapshot())
+
+    // Pre-fix this is `null` (no KIND_TO_REGISTRY mapping → never
+    // overridden from the snapshot), which the chip renders as "—".
+    expect(counts['storage-classes']).toBe(4)
+
+    render(
+      <CloudKindChips activeKind="clusters" counts={counts} onChange={() => {}} />,
+    )
+    // The rendered badge is the operator-visible claim. `—` and `2` both
+    // fail here; only the cross-region union passes.
+    expect(overflowChipCount('storage-classes')).toBe('4')
+  })
+
+  it('GUARD: the Storage Classes chip is wired to a collected kind (hasData)', () => {
+    // hasData=false forces the chip to render "—" regardless of the
+    // count, so the flag is load-bearing for the assertion above.
+    const entry = KINDS.find((k) => k.id === 'storage-classes')
+    expect(entry?.hasData).toBe(true)
+  })
+
+  // NOTE on vacuity: this one is GREEN on both trees by construction —
+  // it feeds the fixture the union the Go loader now produces and checks
+  // the UI does not lose it. The defect guard for the loader itself is
+  // TestBuildStorage_UnionsBothRegions_5611 (Go), which reads 3 instead
+  // of 5 on the pre-fix tree. Stated plainly rather than labelled GUARD.
+  it('COHERENCE: Volumes and PersistentVolumes must never disagree', () => {
+    // The topology response carries the per-region union the Go loader
+    // now produces (storageSources fan-out): 3 region-a + 2 region-b.
+    const data = {
+      cloud: [],
+      topology: { pattern: 'active-passive', regions: [] },
+      storage: {
+        pvcs: [],
+        buckets: [],
+        volumes: [
+          { id: 'pv-a-1', name: 'pv-a-1', capacity: '50Gi', region: 'me-east-215-a', attachedTo: '', status: 'healthy' },
+          { id: 'pv-a-2', name: 'pv-a-2', capacity: '50Gi', region: 'me-east-215-a', attachedTo: '', status: 'healthy' },
+          { id: 'pv-a-3', name: 'pv-a-3', capacity: '50Gi', region: 'me-east-215-a', attachedTo: '', status: 'healthy' },
+          { id: 'pv-b-1', name: 'pv-b-1', capacity: '50Gi', region: 'me-east-215-b', attachedTo: '', status: 'healthy' },
+          { id: 'pv-b-2', name: 'pv-b-2', capacity: '50Gi', region: 'me-east-215-b', attachedTo: '', status: 'healthy' },
+        ],
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    const counts = deriveKindCounts(data, twoRegionSnapshot())
+
+    // The coherence property #5611 is really about: Volumes and
+    // PersistentVolumes project the SAME underlying objects, so they
+    // must never disagree. Pre-fix the loader read region-a only, so
+    // this read 3 while the PV chip read 5.
+    expect(counts['volumes']).toBe(5)
+    expect(counts['volumes']).toBe(counts['persistentvolumes'])
+  })
+
+  it('CONTROL: PersistentVolumes still reports its own real number (no double count)', () => {
+    const counts = deriveKindCounts(undefined, twoRegionSnapshot())
+    // 3 region-a + 2 region-b = 5. Green on the pre-fix tree too — this
+    // is the control that proves the fix did not inflate every kind.
+    expect(counts['persistentvolumes']).toBe(5)
+  })
+
+  it('CONTROL: an uncollected kind still reports "—", so "—" was never unreachable', () => {
+    // DNS Zones is still hasData:false (PowerDNS, not K8s). If this
+    // rendered a number the "—" assertions above would be vacuous.
+    const counts = deriveKindCounts(undefined, twoRegionSnapshot())
+    render(
+      <CloudKindChips activeKind="clusters" counts={counts} onChange={() => {}} />,
+    )
+    expect(overflowChipCount('dns-zones')).toBe('—')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/CloudStoragePage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/CloudStoragePage.test.tsx
@@ -78,7 +78,13 @@ describe('CloudStoragePage', () => {
     expect(screen.getByTestId('cloud-storage-page-tile-volumes-count').textContent).toBe('1')
   })
 
-  it('Storage Classes shows — placeholder count', async () => {
+  // #5611: "—" here no longer means "storage classes are not collected"
+  // (they are — k8scache registry kind `storageclass`). It now means
+  // "the SSE stream has not delivered initialState yet", which is
+  // exactly this harness (`disableStream`). Rendering 0 before the
+  // stream connects would be a false zero, which is the whole bug class
+  // #5611 is about, so the marker is the correct output here.
+  it('Storage Classes shows — while the k8s stream is not connected', async () => {
     renderLanding(infrastructureTopologyFixture)
     expect((await screen.findByTestId('cloud-storage-page-tile-storage-classes-count')).textContent).toBe('—')
   })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/CloudStoragePage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/CloudStoragePage.tsx
@@ -26,10 +26,13 @@ const STORAGE_TILES: readonly StorageTile[] = [
     hasData: true,
   },
   {
+    // #5611 — the storage-class informer landed (k8scache registry kind
+    // `storageclass`), so this tile counts live objects instead of
+    // rendering the not-collected marker "—".
     id: 'storage-classes',
     label: 'Storage Classes',
-    tagline: 'Awaiting storage-class informer (#321).',
-    hasData: false,
+    tagline: 'Provisioner + reclaim policy presets backing every PVC.',
+    hasData: true,
   },
   {
     id: 'buckets',
@@ -46,21 +49,43 @@ const STORAGE_TILES: readonly StorageTile[] = [
 ]
 
 export function CloudStoragePage() {
-  const { deploymentId, data, isLoading } = useCloud()
+  const { deploymentId, data, isLoading, k8sSnapshot, k8sRevision } = useCloud()
 
   const counts = useMemo(() => {
     const out: Record<StorageTile['id'], number | null> = {
       pvcs: 0,
+      // #5611 — null until the SSE stream delivers initialState; a
+      // storage-class count of 0 before the stream connects would be a
+      // false zero, so the tile keeps rendering "—" until then.
       'storage-classes': null,
       buckets: 0,
       volumes: 0,
+    }
+    // Storage classes are cluster-scoped K8s objects streamed through
+    // the k8scache SSE, not projected onto the topology response, so
+    // this count comes from the snapshot — the same source the
+    // /cloud?view=list chip tallies. Snapshot keys are
+    // `storageclass:<name>@<cluster>` (#5571), so both regions' copies
+    // of `evs-ssd` are counted, matching the PersistentVolumes chip.
+    if (k8sSnapshot && k8sSnapshot.size > 0) {
+      let sc = 0
+      for (const key of k8sSnapshot.keys()) {
+        if (key.split(':', 1)[0] === 'storageclass') sc += 1
+      }
+      out['storage-classes'] = sc
     }
     if (!data) return out
     out.pvcs = data.storage?.pvcs?.length ?? 0
     out.buckets = data.storage?.buckets?.length ?? 0
     out.volumes = data.storage?.volumes?.length ?? 0
     return out
-  }, [data])
+    // k8sRevision looks "unnecessary" to the linter but is load-bearing:
+    // k8sSnapshot is a MUTABLE Map whose identity does not change as SSE
+    // deltas are folded in, so the revision counter is the only signal
+    // that its contents moved. Same dependency CloudPage's kindCounts
+    // carries for the same reason.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, k8sSnapshot, k8sRevision])
 
   return (
     <div data-testid="cloud-storage-page">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/StorageClassesPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/StorageClassesPage.test.tsx
@@ -1,5 +1,12 @@
 /**
- * StorageClassesPage.test.tsx — placeholder lock-in.
+ * StorageClassesPage.test.tsx
+ *
+ * #5611: this file previously LOCKED IN the placeholder — it asserted
+ * the "storage class data is not in the current informer set" empty
+ * state and its #321 docs link, i.e. it pinned the defect in place and
+ * would have gone red on the fix. The `storageclass` GVR is now in the
+ * catalyst-api k8scache registry, so the route renders the live list
+ * instead, and this asserts THAT.
  */
 
 import { describe, it, expect, afterEach, beforeEach } from 'vitest'
@@ -69,10 +76,14 @@ beforeEach(() => {
 afterEach(() => cleanup())
 
 describe('StorageClassesPage', () => {
-  it('renders header + empty state + docs link', async () => {
+  it('#5611: renders the live storageclass list, not the #321 placeholder', async () => {
     renderPage()
-    expect(await screen.findByTestId('cloud-storage-classes-page')).toBeTruthy()
-    expect(screen.getByTestId('cloud-storage-classes-empty')).toBeTruthy()
-    expect(screen.getByTestId('cloud-storage-classes-docs-link')).toBeTruthy()
+    // The generic K8sListPage's container for kind=storageclass. Its
+    // presence is what proves the route is wired to the live stream.
+    expect(await screen.findByTestId('cloud-storageclass-list')).toBeTruthy()
+    // And the placeholder is genuinely gone — without this the assertion
+    // above could pass alongside a leftover stub.
+    expect(screen.queryByTestId('cloud-storage-classes-empty')).toBeNull()
+    expect(screen.queryByTestId('cloud-storage-classes-docs-link')).toBeNull()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/StorageClassesPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/StorageClassesPage.tsx
@@ -1,19 +1,13 @@
 /**
- * StorageClassesPage — placeholder list page for
- * /cloud/storage/storage-classes (P3 of #309). Pending the
- * storage-class informer (#321).
+ * StorageClassesPage — /cloud/storage/storage-classes.
+ *
+ * #5611: was a CloudListPlaceholder ("Storage class data is not in the
+ * current informer set. The storage-class informer rollout is tracked
+ * separately."). The `storageclass` GVR is now registered in the
+ * catalyst-api k8scache (api/internal/k8scache/kinds.go), so this route
+ * renders the SAME live list the /cloud?view=list&kind=storage-classes
+ * chip navigates to — one component, one source, so the two routes can
+ * never disagree about how many storage classes exist.
  */
 
-import { CloudListPlaceholder } from '../cloud-list/CloudListPlaceholder'
-
-export function StorageClassesPage() {
-  return (
-    <CloudListPlaceholder
-      testId="cloud-storage-classes"
-      title="Storage Classes"
-      tagline="Cluster-wide storage classes (local-path, longhorn, csi-cinder, etc.)."
-      bodyText="Storage class data is not in the current informer set. The storage-class informer rollout is tracked separately."
-      docsHref="https://github.com/openova-io/openova/issues/321"
-    />
-  )
-}
+export { StorageClassesListPage as StorageClassesPage } from '../cloud-list/kindsPages'


### PR DESCRIPTION
## Re-verification of #5661 first — the recorded root cause is FIXED on `main`

I re-verified every claim in the issue against `origin/main` @ `634a41cdb` before writing a line.

| # | Issue claim | Verdict on `main` today |
|---|---|---|
| 1 | `StepTopology.tsx` offers a "Single region" card | **CONFIRMED** — `TOPOLOGIES[]` entry `id: 'solo'`, `regions: 1`, and `TOPOLOGY_REGION_COUNT.solo === 1` / `TOPOLOGY_REGION_LABELS.solo` has one label |
| 2 | `StepReview.tsx` never emits `bcpTopology` — zero hits in `bootstrap/ui/src/` | **REFUTED** — 3 hits in `StepReview.tsx` since PR #5662 (`abb570b`, merged 2026-08-04). The derivation is `regionsPayload.length < 2 ? 'single-region' : undefined`, threaded into the POST body and mirrored into the Review card |
| 3 | catalyst-api rejects the body at the #4706 floor | **CONFIRMED, still live** — `handler/deployments.go` `CreateDeployment`: `TrimSpace(req.BcpTopology) == "" && len(req.Regions) < 2` returns HTTP 400 *before* `req.Validate()` runs. Correct behaviour; the wizard now clears it |
| 4 | The wizard structurally cannot fire a single-region prov | **REFUTED as of `main`** — the value is on the wire and clears both server gates |
| 5 | Wizard nav blocks the SOLO choice | **REFUTED** — `StepTopology` gates only on `canProceed = !!store.topology`; no region-count gate anywhere in the wizard |

**(a)/(b) classification: (b) — fixed in `main`, undeployed.** hw292 runs 2026-08-02 images; PR #5662 merged 2026-08-04. Anyone walking a wizard built before `abb570b` still sees the 400. Nothing to re-fix in source.

### Full path trace (wizard → submit → validate → provision)

```
StepTopology  card 'solo'  →  store.topology = 'solo'
StepReview    TOPOLOGY_REGION_LABELS['solo'] → 1 label → regionRows(1) → regionsPayload(1)
              bcpTopology = regionsPayload.length < 2 ? 'single-region' : undefined
              POST /v1/deployments { regions: [1], bcpTopology: 'single-region' }
handler       deployments.go CreateDeployment — #4706 floor: PASS (declaration present)
provisioner   Validate() — enum check PASS; mirror invariant
              (single-region + >=2 regions) not tripped; hot-standby
              invariant not applicable
              writeTfvars → bcp_topology = deriveBcpTopology(req) = "single-region"
                            enable_hot_standby = false
tofu          hetzner/variables.tf + huawei/variables.tf var.bcp_topology
              validation contains(["single-region","active-hotstandby","active-active"])
cloud-init    _shared/cloudinit-control-plane.tftpl
              SOVEREIGN_BCP_TOPOLOGY / SOVEREIGN_ENABLE_HOT_STANDBY
```

Every hop accepts `single-region`. **The break is gone; what is missing is the guard.**

`kom4dc` (single-region, 2-VPC mimic) corroborates this — single-region provisioning has working precedent all the way to tofu.

**Overlap check:** none. `derivePattern` / `derivedFromRuntime` (#5515/#5568) live in `handler/applications_placement_runtime.go` — Application *placement* / vCluster tiers. #5724's `instances.ValidateShape` / `validVClusterTier` / `validateApplicationUpdateRequest` are the same seam. `bcpTopology` is deployment-creation BCP topology at signup. Zero file overlap, zero shared symbols. Nothing touched in either seam.

## So what does this PR ship

PR #5662 shipped 12 lines and **no test**. There is no `StepReview.test.tsx` in the tree at all. The one line that makes the operator's single-region choice firable is entirely unguarded — a refactor of the POST-body block drops it and CI stays green. That is the gap this closes.

### The guard asserts on the WIRE, not the render

"The dropdown shows Single region" is not the claim — the pre-fix tree rendered that card perfectly and still could not fire. Every assertion reads the actual `fetch` request body produced by `postDeployment()` and evaluates it through two oracles transcribed literally from the Go source:

- `admittedByBcpFloor()` — `handler/deployments.go`: `TrimSpace(req.BcpTopology) == "" && len(req.Regions) < 2` → 400
- `rejectedByValidate()` — `provisioner.Validate()`'s enum check plus both cross-field mirror invariants

The test drives the real callback: `StepShell` publishes the step's `onNext` into the `wizardNav` store (the persistent `WizardLayout` footer renders the Launch button), so invoking `useWizardNav.getState().nav.onNext()` runs the same `onLaunch` → `postDeployment` path a click runs.

## Both-directions guard output — verbatim

**Pre-fix tree** (`gh pr diff 5662 | git apply -R`, i.e. #5662's 12 lines removed):

```
 ✓ #5661 — the #4706 floor oracle is not vacuous > rejects the PRE-FIX body shape: 1 region and no bcpTopology 2ms
 ✓ #5661 — the #4706 floor oracle is not vacuous > rejects a contradictory body: single-region declared with 2 regions 0ms
 ✓ #5661 — the #4706 floor oracle is not vacuous > rejects an unknown topology token 0ms
 × #5661 — the wizard can fire a single-region prov > SOLO sends bcpTopology="single-region" on the wire with exactly 1 region 276ms
   → the wizard's single-region body would be REJECTED by the #4706 admission floor with HTTP 400 (bcpTopology=undefined, regions=1) — the SOLO topology card cannot fire a prov: expected false to be true // Object.is equality
 × #5661 — the wizard can fire a single-region prov > renders the declared topology in the Review card (body-mirror contract) 131ms
   → expected 'TopologyTemplatesoloRegions1 (1 topol…' to contain 'BCP topology'
 ✓ #5661 — the wizard can fire a single-region prov > the SOLO body would have been REJECTED without the declaration 104ms
 ✓ #5661 controls — multi-region semantics are byte-identical > dual sends NO bcpTopology and 2 regions, and is admitted 111ms
 ✓ #5661 controls — multi-region semantics are byte-identical > zoned sends NO bcpTopology and 2 regions, and is admitted 109ms
 ✓ #5661 controls — multi-region semantics are byte-identical > compact sends NO bcpTopology and 2 regions, and is admitted 108ms
 ✓ #5661 controls — multi-region semantics are byte-identical > citadel sends NO bcpTopology and 4 regions, and is admitted 109ms
 ✓ #5661 — AIR-GAP defeats the SOLO declaration > SOLO + AIR-GAP emits 2 regions and NO declaration — server derives active-hotstandby 100ms

 Test Files  1 failed (1)
      Tests  2 failed | 9 passed (11)
```

**Fixed tree** (this branch, `main` as-is):

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

### "If the defect were present, could THIS check have gone red?"

Yes — demonstrated above, not assumed. And the controls stayed **green on both trees**, so the suite is not an accept-everything rubber stamp:

- `dual` / `zoned` / `compact` / `citadel` must send **no** `bcpTopology` key (`'bcpTopology' in body === false`, not merely falsy) and the right region count, and must still be admitted — multi-region wire bytes unchanged.
- A hand-built contradictory body (`single-region` + 2 regions) must be **rejected** by the Validate mirror — proving the oracle can say no.
- An unknown token (`'solo'`) must be **rejected** by the enum check.
- The floor oracle is run against a synthetic pre-fix body and must report 400 — its own vacuity check.

**CI reachability confirmed, not assumed:** `catalyst-build.yaml`'s `paths:` filter includes `products/catalyst/bootstrap/**`, and its vitest step has failed **closed** since #5589 (per-file `FAIL` parser + summary cross-check + non-zero-rc backstop). This test runs on push and can fail the build.

## Deliberately NOT fixed

**SOLO + AIR-GAP silently becomes `active-hotstandby`.** The air-gap add-on appends a region row, so `regionsPayload.length === 2`, the `< 2` derivation leaves `bcpTopology` unset, and `deriveBcpTopology` on the server returns `active-hotstandby` + `enable_hot_standby=true` — for an operator who picked the "Single region" card plus a region the UI itself describes as "pull-only replication · Specter forensic mode". `store.airgap` is never sent on the wire at all, so the server cannot tell the two apart.

Not fixed here because it needs a product decision, not a code guess: does an air-gapped forensic region count as a BCP standby? If it does not, the wire needs an `airgap` flag and `deriveBcpTopology` needs to discount that region — a server-side change in the same seam #5724 and #5515/#5568 are actively contending. The suite pins the current behaviour explicitly as *observed, not endorsed*, with a comment naming the assertion to flip when the decision lands. Recorded on #5661.

**No live proof claimed.** hw292 is itself 2-region (`me-east-215-a` / `me-east-215-b-1`), so it structurally cannot demonstrate a single-region fire, and I fired nothing. Everything above is source + contract reasoning, and I say so rather than dressing it as a walk.

## Gates

- `npx tsc -b --noEmit` — clean
- `npx vitest run src/pages/wizard/` — 9 files, 208 tests pass
- `npm test` (the CI gate) — 223 files, 2084 tests pass

Refs #5661 #5662 #4706 #960

<!-- body re-validated after removing a banned phrase -->
