### PR TITLE
test(wizard): guard the single-region topology WIRE contract — #5662's fix shipped untested

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.bcp-topology-wire.5661.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.bcp-topology-wire.5661.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * StepReview.bcp-topology-wire.5661.test.tsx — the wire contract for the
+ * operator's TOPOLOGY choice.
+ *
+ * ── What this guards (issue #5661) ──────────────────────────────────
+ * StepTopology offers a SOLO ("Single region") card. The catalyst-api's
+ * #4706 admission floor (handler/deployments.go CreateDeployment) rejects
+ * any POST body whose `bcpTopology` is empty AND whose `regions` array
+ * has fewer than 2 entries — HTTP 400, BEFORE Request.Validate() ever
+ * runs. So a wizard that renders the SOLO card but omits `bcpTopology`
+ * from the body can NEVER fire a single-region prov: the operator's
+ * choice is structurally unreachable. That was #5661; PR #5662 fixed it
+ * with 12 lines in StepReview and NO test.
+ *
+ * ── Why the assertion is on the WIRE, not on the render ─────────────
+ * "The dropdown shows Single region" is not the claim under test — the
+ * pre-fix tree rendered that card perfectly and still could not fire.
+ * The claim is "a single-region choice produces a body the #4706 floor
+ * ACCEPTS". So every assertion below reads the actual `fetch` request
+ * body that `postDeployment()` sends, and evaluates it through
+ * `admittedByBcpFloor()` — a literal transcription of the Go floor
+ * condition at handler/deployments.go:
+ *
+ *     strings.TrimSpace(req.BcpTopology) == "" && len(req.Regions) < 2
+ *         → HTTP 400
+ *
+ * plus `rejectedByValidate()`, the mirror invariant from
+ * provisioner.Validate() that rejects an explicit single-region
+ * declaration carrying >=2 regions. A body must clear BOTH to fire.
+ *
+ * ── Controls (so "accept everything" cannot pass) ───────────────────
+ *   • DUAL (2 regions) must still send NO bcpTopology and still be
+ *     admitted — the server's multi-region default semantics unchanged.
+ *   • A hand-built contradictory body (single-region + 2 regions) must
+ *     be REJECTED by the Validate mirror — proving the oracle can say no.
+ *   • The floor oracle itself is exercised on a synthetic pre-fix body
+ *     (1 region, no bcpTopology) and must report 400 — proving the oracle
+ *     can go red at all.
+ *
+ * Refs #5661 #5662 #4706 #960
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { StepReview } from './StepReview'
+import { useWizardStore } from '@/entities/deployment/store'
+import { useWizardNav } from '@/shared/lib/wizardNav'
+import {
+  INITIAL_WIZARD_STATE,
+  TOPOLOGY_REGION_COUNT,
+  TOPOLOGY_REGION_LABELS,
+} from '@/entities/deployment/model'
+import type { TopologyTemplate } from '@/entities/deployment/model'
+
+/* ── Test doubles for StepReview's non-wire dependencies ──────────── */
+
+const navigateSpy = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ navigate: navigateSpy }),
+}))
+
+vi.mock('@/shared/lib/useSession', () => ({
+  useSession: () => ({
+    signedIn: true,
+    email: 'operator@example.test',
+    sub: 'sub-1',
+    tier: 'owner',
+    roles: [],
+    loading: false,
+    refetch: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}))
+
+vi.mock('@/widgets/auth/PinSignInModal', () => ({
+  PinSignInModal: () => null,
+}))
+
+/* ── The server-side contract, transcribed ────────────────────────── */
+
+interface WireBody {
+  bcpTopology?: string
+  regions?: unknown[]
+}
+
+/**
+ * #4706 admission floor, verbatim from
+ * products/catalyst/bootstrap/api/internal/handler/deployments.go:
+ *
+ *   if strings.TrimSpace(req.BcpTopology) == "" && len(req.Regions) < 2 {
+ *       http.Error(w, "...", http.StatusBadRequest); return
+ *   }
+ */
+function admittedByBcpFloor(body: WireBody): boolean {
+  const declared = (body.bcpTopology ?? '').trim()
+  const regionCount = body.regions?.length ?? 0
+  return !(declared === '' && regionCount < 2)
+}
+
+/**
+ * The mirror invariant from provisioner.Validate(): an EXPLICIT
+ * single-region declaration carrying >=2 regions is contradictory and is
+ * rejected. Returns a reason string when the body would be rejected.
+ */
+function rejectedByValidate(body: WireBody): string | null {
+  const declared = (body.bcpTopology ?? '').trim().toLowerCase()
+  const regionCount = body.regions?.length ?? 0
+  if (declared !== '' && !['single-region', 'active-hotstandby', 'active-active'].includes(declared)) {
+    return `bcpTopology ${declared} is not one of the three valid values`
+  }
+  if (declared === 'single-region' && regionCount >= 2) {
+    return `bcpTopology=single-region contradicts len(regions)=${regionCount}`
+  }
+  if ((declared === 'active-hotstandby' || declared === 'active-active') && regionCount < 2) {
+    return `bcpTopology=${declared} requires len(regions)>=2 (got ${regionCount})`
+  }
+  return null
+}
+
+/* ── Harness ──────────────────────────────────────────────────────── */
+
+const FQDN_POOL = 'omani-works'
+const FQDN_SUB = 'sovtest'
+
+/** Seed the wizard store as if the operator completed every prior step. */
+function seedStore(topology: TopologyTemplate, airgap = false) {
+  const regionCount = TOPOLOGY_REGION_LABELS[topology].length + (airgap ? 1 : 0)
+  useWizardStore.setState({
+    ...INITIAL_WIZARD_STATE,
+    orgName: 'Acme Sovereign',
+    orgEmail: 'operator@example.test',
+    topology,
+    airgap,
+    sovereignDomainMode: 'pool',
+    sovereignPoolDomain: FQDN_POOL,
+    sovereignSubdomain: FQDN_SUB,
+    regionProviders: Array.from({ length: regionCount }, () => 'hetzner'),
+    regionCloudRegions: Array.from({ length: regionCount }, () => 'fsn1'),
+    regionControlPlaneSizes: Array.from({ length: regionCount }, () => 'cpx41'),
+    regionWorkerSizes: Array.from({ length: regionCount }, () => 'cpx41'),
+    regionWorkerCounts: Array.from({ length: regionCount }, () => 2),
+    hetznerToken: 'x'.repeat(64),
+    hetznerProjectId: 'proj_abc',
+    sshPublicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBdkRf2yAJ7E7g1zFJKj7xZl9Q3WkF0K3ZQp5Y7qXmHZ op@example.test',
+  })
+}
+
+/**
+ * Render StepReview, fire the Launch action, and return the parsed POST
+ * body that reached `fetch`. StepShell publishes the step's onNext into
+ * the wizardNav store (the persistent WizardLayout footer is what renders
+ * the Launch button), so invoking `useWizardNav.getState().onNext()` runs
+ * the SAME `onLaunch` → `postDeployment` path a real click runs.
+ */
+async function launchAndCaptureBody(): Promise<WireBody> {
+  const fetchSpy = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ id: 'dep-test-0001' }),
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+
+  render(<StepReview />)
+
+  await waitFor(() => {
+    expect(useWizardNav.getState().nav.onNext).toBeTypeOf('function')
+  })
+  await (useWizardNav.getState().nav.onNext!() as unknown as Promise<void>)
+
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+
+  const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+  expect(url).toContain('/v1/deployments')
+  expect(init.method).toBe('POST')
+  return JSON.parse(init.body as string) as WireBody
+}
+
+beforeEach(() => {
+  navigateSpy.mockReset()
+  useWizardNav.setState({ nav: {} })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+/* ── The oracle can go red (vacuity check) ────────────────────────── */
+
+describe('#5661 — the #4706 floor oracle is not vacuous', () => {
+  it('rejects the PRE-FIX body shape: 1 region and no bcpTopology', () => {
+    const preFix: WireBody = { regions: [{ provider: 'hetzner' }] }
+    expect(admittedByBcpFloor(preFix)).toBe(false)
+  })
+
+  it('rejects a contradictory body: single-region declared with 2 regions', () => {
+    const contradictory: WireBody = {
+      bcpTopology: 'single-region',
+      regions: [{ provider: 'hetzner' }, { provider: 'hetzner' }],
+    }
+    expect(admittedByBcpFloor(contradictory)).toBe(true)
+    expect(rejectedByValidate(contradictory)).toMatch(/contradicts len\(regions\)=2/)
+  })
+
+  it('rejects an unknown topology token', () => {
+    expect(rejectedByValidate({ bcpTopology: 'solo', regions: [{}] })).toMatch(/not one of/)
+  })
+})
+
+/* ── The claim under test ─────────────────────────────────────────── */
+
+describe('#5661 — the wizard can fire a single-region prov', () => {
+  it('SOLO sends bcpTopology="single-region" on the wire with exactly 1 region', async () => {
+    seedStore('solo')
+    const body = await launchAndCaptureBody()
+
+    expect(body.regions).toHaveLength(1)
+
+    // The floor assertion comes FIRST so the RED message on a regressed
+    // tree names the actual operator-visible failure, not a field diff.
+    expect(
+      admittedByBcpFloor(body),
+      `the wizard's single-region body would be REJECTED by the #4706 admission floor ` +
+        `with HTTP 400 (bcpTopology=${JSON.stringify(body.bcpTopology)}, ` +
+        `regions=${body.regions?.length}) — the SOLO topology card cannot fire a prov`,
+    ).toBe(true)
+
+    // The VALUE, not the presence of the card.
+    expect(body.bcpTopology).toBe('single-region')
+    expect(rejectedByValidate(body)).toBeNull()
+  })
+
+  it('renders the declared topology in the Review card (body-mirror contract)', async () => {
+    seedStore('solo')
+    render(<StepReview />)
+    const topologySection = await screen.findByTestId('review-section-topology')
+    expect(topologySection.textContent).toContain('BCP topology')
+    expect(topologySection.textContent).toContain('single-region')
+  })
+
+  it('the SOLO body would have been REJECTED without the declaration', async () => {
+    seedStore('solo')
+    const body = await launchAndCaptureBody()
+
+    // Strip the field the fix threads: the same body is a 400. This is
+    // what makes the assertion above load-bearing rather than decorative.
+    const stripped: WireBody = { ...body, bcpTopology: undefined }
+    expect(admittedByBcpFloor(stripped)).toBe(false)
+  })
+})
+
+/* ── Controls: multi-region must be unchanged ─────────────────────── */
+
+describe('#5661 controls — multi-region semantics are byte-identical', () => {
+  it.each<[TopologyTemplate, number]>([
+    ['dual', 2],
+    ['zoned', 2],
+    ['compact', 2],
+    ['citadel', 4],
+  ])('%s sends NO bcpTopology and %i regions, and is admitted', async (topology, want) => {
+    expect(TOPOLOGY_REGION_COUNT[topology]).toBe(want)
+    seedStore(topology)
+    const body = await launchAndCaptureBody()
+
+    expect(body.regions).toHaveLength(want)
+    // undefined is dropped by JSON.stringify — the key must be ABSENT,
+    // not present-and-empty (present-and-empty would still trip the
+    // floor's TrimSpace()=="" branch on a hypothetical 1-region body,
+    // and would change the server's derive-vs-explicit path).
+    expect('bcpTopology' in body).toBe(false)
+
+    expect(admittedByBcpFloor(body)).toBe(true)
+    expect(rejectedByValidate(body)).toBeNull()
+  })
+})
+
+/* ── The AIR-GAP interaction (documented, deliberately unfixed) ────── */
+
+describe('#5661 — AIR-GAP defeats the SOLO declaration', () => {
+  it('SOLO + AIR-GAP emits 2 regions and NO declaration — server derives active-hotstandby', async () => {
+    seedStore('solo', true)
+    const body = await launchAndCaptureBody()
+
+    // The air-gap add-on appends a region row, so regionsPayload.length
+    // is 2 and StepReview's `< 2` derivation leaves bcpTopology unset.
+    // The body is still ADMITTED (2 regions clears the floor), but the
+    // effective topology the server derives is "active-hotstandby" — a
+    // synchronous zero-tx-loss standby — for an operator who picked the
+    // "Single region" card plus a pull-only forensic region.
+    //
+    // Asserted as the CURRENT behaviour, not endorsed: whether an
+    // air-gap region should count as a BCP standby is a product
+    // decision, tracked on #5661. If that decision lands, this
+    // expectation is the one to flip.
+    expect(body.regions).toHaveLength(2)
+    expect('bcpTopology' in body).toBe(false)
+    expect(admittedByBcpFloor(body)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Re-verification of #5661 first — the recorded root cause is FIXED on `main`

I re-verified every claim in the issue against `origin/main` @ `634a41cdb` before writing a line.

| # | Issue claim | Verdict on `main` today |
|---|---|---|
| 1 | `StepTopology.tsx` offers a "Single region" card | **CONFIRMED** — `TOPOLOGIES[]` entry `id: 'solo'`, `regions: 1`, and `TOPOLOGY_REGION_COUNT.solo === 1` / `TOPOLOGY_REGION_LABELS.solo` has one label |
| 2 | `StepReview.tsx` never emits `bcpTopology` — zero hits in `bootstrap/ui/src/` | **REFUTED** — 3 hits in `StepReview.tsx` since PR #5662 (`abb570b`, merged 2026-08-04). The derivation is `regionsPayload.length < 2 ? 'single-region' : undefined`, threaded into the POST body and mirrored into the Review card |
| 3 | catalyst-api rejects the body at the #4706 floor | **CONFIRMED, still live** — `handler/deployments.go` `CreateDeployment`: `TrimSpace(req.BcpTopology) == "" && len(req.Regions) < 2` returns HTTP 400 *before* `req.Validate()` runs. Correct behaviour; the wizard now clears it |
| 4 | The wizard structurally cannot fire a single-region prov | **REFUTED as of `main`** — the value is on the wire and clears both server gates |
| 5 | Wizard nav blocks the SOLO choice | **REFUTED** — `StepTopology` gates only on `canProceed = !!store.topology`; no region-count gate anywhere in the wizard |

**(a)/(b) classification: (b) — fixed in `main`, undeployed.** hw292 runs 2026-08-02 images; PR #5662 merged 2026-08-04. Anyone walking a wizard built before `abb570b` still sees the 400. Nothing to re-fix in source.

### Full path trace (wizard → submit → validate → provision)

```
StepTopology  card 'solo'  →  store.topology = 'solo'
StepReview    TOPOLOGY_REGION_LABELS['solo'] → 1 label → regionRows(1) → regionsPayload(1)
              bcpTopology = regionsPayload.length < 2 ? 'single-region' : undefined
              POST /v1/deployments { regions: [1], bcpTopology: 'single-region' }
handler       deployments.go CreateDeployment — #4706 floor: PASS (declaration present)
provisioner   Validate() — enum check PASS; mirror invariant
              (single-region + >=2 regions) not tripped; hot-standby
              invariant not applicable
              writeTfvars → bcp_topology = deriveBcpTopology(req) = "single-region"
                            enable_hot_standby = false
tofu          hetzner/variables.tf + huawei/variables.tf var.bcp_topology
              validation contains(["single-region","active-hotstandby","active-active"])
cloud-init    _shared/cloudinit-control-plane.tftpl
              SOVEREIGN_BCP_TOPOLOGY / SOVEREIGN_ENABLE_HOT_STANDBY
```

Every hop accepts `single-region`. **The break is gone; what is missing is the guard.**

`kom4dc` (single-region, 2-VPC mimic) corroborates this — single-region provisioning has working precedent all the way to tofu.

**Overlap check:** none. `derivePattern` / `derivedFromRuntime` (#5515/#5568) live in `handler/applications_placement_runtime.go` — Application *placement* / vCluster tiers. #5724's `instances.ValidateShape` / `validVClusterTier` / `validateApplicationUpdateRequest` are the same seam. `bcpTopology` is deployment-creation BCP topology at signup. Zero file overlap, zero shared symbols. Nothing touched in either seam.

## So what does this PR ship

PR #5662 shipped 12 lines and **no test**. There is no `StepReview.test.tsx` in the tree at all. The one line that makes the operator's single-region choice firable is entirely unguarded — a refactor of the POST-body block drops it and CI stays green. That is the gap this closes.

### The guard asserts on the WIRE, not the render

"The dropdown shows Single region" is not the claim — the pre-fix tree rendered that card perfectly and still could not fire. Every assertion reads the actual `fetch` request body produced by `postDeployment()` and evaluates it through two oracles transcribed literally from the Go source:

- `admittedByBcpFloor()` — `handler/deployments.go`: `TrimSpace(req.BcpTopology) == "" && len(req.Regions) < 2` → 400
- `rejectedByValidate()` — `provisioner.Validate()`'s enum check plus both cross-field mirror invariants

The test drives the real callback: `StepShell` publishes the step's `onNext` into the `wizardNav` store (the persistent `WizardLayout` footer renders the Launch button), so invoking `useWizardNav.getState().nav.onNext()` runs the same `onLaunch` → `postDeployment` path a click runs.

## Both-directions guard output — verbatim

**Pre-fix tree** (`gh pr diff 5662 | git apply -R`, i.e. #5662's 12 lines removed):

```
 ✓ #5661 — the #4706 floor oracle is not vacuous > rejects the PRE-FIX body shape: 1 region and no bcpTopology 2ms
 ✓ #5661 — the #4706 floor oracle is not vacuous > rejects a contradictory body: single-region declared with 2 regions 0ms
 ✓ #5661 — the #4706 floor oracle is not vacuous > rejects an unknown topology token 0ms
 × #5661 — the wizard can fire a single-region prov > SOLO sends bcpTopology="single-region" on the wire with exactly 1 region 276ms
   → the wizard's single-region body would be REJECTED by the #4706 admission floor with HTTP 400 (bcpTopology=undefined, regions=1) — the SOLO topology card cannot fire a prov: expected false to be true // Object.is equality
 × #5661 — the wizard can fire a single-region prov > renders the declared topology in the Review card (body-mirror contract) 131ms
   → expected 'TopologyTemplatesoloRegions1 (1 topol…' to contain 'BCP topology'
 ✓ #5661 — the wizard can fire a single-region prov > the SOLO body would have been REJECTED without the declaration 104ms
 ✓ #5661 controls — multi-region semantics are byte-identical > dual sends NO bcpTopology and 2 regions, and is admitted 111ms
 ✓ #5661 controls — multi-region semantics are byte-identical > zoned sends NO bcpTopology and 2 regions, and is admitted 109ms
 ✓ #5661 controls — multi-region semantics are byte-identical > compact sends NO bcpTopology and 2 regions, and is admitted 108ms
 ✓ #5661 controls — multi-region semantics are byte-identical > citadel sends NO bcpTopology and 4 regions, and is admitted 109ms
 ✓ #5661 — AIR-GAP defeats the SOLO declaration > SOLO + AIR-GAP emits 2 regions and NO declaration — server derives active-hotstandby 100ms

 Test Files  1 failed (1)
      Tests  2 failed | 9 passed (11)
```

**Fixed tree** (this branch, `main` as-is):

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

### "If the defect were present, could THIS check have gone red?"

Yes — demonstrated above, not assumed. And the controls stayed **green on both trees**, so the suite is not an accept-everything rubber stamp:

- `dual` / `zoned` / `compact` / `citadel` must send **no** `bcpTopology` key (`'bcpTopology' in body === false`, not merely falsy) and the right region count, and must still be admitted — multi-region wire bytes unchanged.
- A hand-built contradictory body (`single-region` + 2 regions) must be **rejected** by the Validate mirror — proving the oracle can say no.
- An unknown token (`'solo'`) must be **rejected** by the enum check.
- The floor oracle is run against a synthetic pre-fix body and must report 400 — its own vacuity check.

### CI reachability — checked, and stated precisely

I checked the trigger, not just the `paths:` filter, because "my test is in a watched directory" is not the same claim as "my test can turn a check red".

- `catalyst-build.yaml`'s `paths:` filter **does** include `products/catalyst/bootstrap/**`, and its vitest step has failed **closed** since #5589 (per-file `FAIL` parser + summary cross-check + non-zero-rc backstop). Verified by reading the workflow, not by inference.
- But its trigger is `on: push: branches: [main]` + `workflow_dispatch` — **there is no `pull_request` trigger**. Grepping every workflow for one that runs `vitest`/`npm test` on `pull_request` returns exactly one hit, and it is `cloudflare-worker-leases-build.yaml` — a different tree.

**So, honestly: this guard fires on push-to-`main`, where it fails the catalyst-ui build before the image is published. It does NOT gate this PR.** The 20 green checks above are lint/naming/NodePort/render guards; none of them ran my test. That is a real gate on the deploy path and it is the gate that exists today, but calling it a PR gate would be exactly the "the check could not have gone red" mistake this PR is written to prevent.

The absence of a PR-level vitest gate for the catalyst UI is a pre-existing repo-wide CI gap, not something introduced here. Adding `pull_request` to `catalyst-build.yaml` is not the right fix — that workflow builds and pushes images to GHCR, so it would need splitting into a test job and a publish job first. Next action, as a follow-up PR rather than a rider on this one: split `catalyst-build.yaml` into a `test` job (`pull_request` + `push`) and a `publish` job (`push` only), so UI unit tests gate the merge instead of the deploy. Held back here because that workflow is contended tonight and carries its own blast radius.

## Deliberately NOT fixed

**SOLO + AIR-GAP silently becomes `active-hotstandby`.** The air-gap add-on appends a region row, so `regionsPayload.length === 2`, the `< 2` derivation leaves `bcpTopology` unset, and `deriveBcpTopology` on the server returns `active-hotstandby` + `enable_hot_standby=true` — for an operator who picked the "Single region" card plus a region the UI itself describes as "pull-only replication · Specter forensic mode". `store.airgap` is never sent on the wire at all, so the server cannot tell the two apart.

Not fixed here because it needs a product decision, not a code guess: does an air-gapped forensic region count as a BCP standby? If it does not, the wire needs an `airgap` flag and `deriveBcpTopology` needs to discount that region — a server-side change in the same seam #5724 and #5515/#5568 are actively contending. The suite pins the current behaviour explicitly as *observed, not endorsed*, with a comment naming the assertion to flip when the decision lands. Recorded on #5661.

**No live proof claimed.** hw292 is itself 2-region (`me-east-215-a` / `me-east-215-b-1`), so it structurally cannot demonstrate a single-region fire, and I fired nothing. Everything above is source + contract reasoning, and I say so rather than dressing it as a walk.

## Gates

- `npx tsc -b --noEmit` — clean
- `npx vitest run src/pages/wizard/` — 9 files, 208 tests pass
- `npm test` (the CI gate) — 223 files, 2084 tests pass

Refs #5661 #5662 #4706 #960

<!-- body re-validated after removing a banned phrase -->

