### PR TITLE
fix(marketplace): test the redeem OUTCOME, not the gate decision — #5686 left the cookie-borne owner on the funnel (Refs #5421)

### DIFF
--- a/.github/workflows/test-marketplace-funnel.yaml
+++ b/.github/workflows/test-marketplace-funnel.yaml
@@ -60,3 +60,10 @@ jobs:
       # vitest gate pass for two months while four source defects sat behind it.
       - name: Run vitest
         run: npm test
+
+      # #5421 — build the site too. The redeem page imports the helpers these
+      # tests cover, and a type error there fails `astro build` while vitest
+      # stays green. Without this step the only thing that catches it is the
+      # image build in marketplace-build.yaml, which runs AFTER merge.
+      - name: astro build
+        run: npm run build

--- a/core/marketplace/src/lib/redeemDestination.test.ts
+++ b/core/marketplace/src/lib/redeemDestination.test.ts
@@ -1,0 +1,155 @@
+// redeemDestination.test.ts — #5421 (UAT row 3).
+//
+// The existing `redeemOwnerGate.test.ts` asserts the gate's DECISION
+// string ('consult-server'). That decision is now correct, and the tests
+// pass — but the visitor's OUTCOME never changed, because the server the
+// gate defers to cannot authenticate the probe. These tests assert the
+// outcome instead: which page each persona actually lands on.
+//
+// The fake mesh below is not a convenience stub — it encodes the verified
+// wire contract of the two services that actually receive the probe (see
+// `orgMesh`). Hand-waving that contract (e.g. "the cookie authenticates
+// the request") is exactly the assumption that let #5686 ship green, so it
+// is written down here as executable, citable fact.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ownerProbeIsAuthenticable,
+  resolveRedeemDestination,
+  type RedeemOrgSummary,
+} from './redeemDestination';
+
+const LIVE_ORG: RedeemOrgSummary = {
+  id: 'org-1',
+  slug: 'acme',
+  status: 'active',
+  console_host: 'console.acme.t01.omani.works',
+};
+
+/**
+ * The Organization mesh as it actually behaves on `marketplace.<sov>/api/`.
+ *
+ * Verified on `main`, not assumed:
+ *   core/services/gateway/proxy.go            validateJWT reads only
+ *     `Authorization: Bearer` and rejects when it is absent.
+ *   core/services/shared/middleware/jwt.go    JWTAuth does the same, and
+ *     additionally rejects any non-HMAC signing method.
+ * Neither consults a cookie, so `catalyst_session` is accepted by the
+ * browser onto the request and then discarded by the server.
+ *
+ * Live confirmation (read-only, hw292):
+ *   GET https://marketplace.hw292.omani.works/api/tenant/orgs  -> HTTP 401
+ */
+function orgMesh(session: { token: string; consoleSessionCookie?: boolean }) {
+  return async (): Promise<RedeemOrgSummary[]> => {
+    if (!ownerProbeIsAuthenticable({
+      token: session.token,
+      hasConsoleSessionCookie: session.consoleSessionCookie,
+    })) {
+      throw Object.assign(new Error('unauthorized'), { status: 401 });
+    }
+    return [LIVE_ORG];
+  };
+}
+
+describe('resolveRedeemDestination — which page the visitor lands on', () => {
+  // ── CONTROL 1 ────────────────────────────────────────────────────────
+  // An anonymous visitor must still reach the redeem funnel. Without this,
+  // a naive "always hand off to the console" would satisfy the #5421 case.
+  it('CONTROL: an anonymous visitor reaches the redeem funnel', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: false,
+      token: '',
+      fetchOrgs: orgMesh({ token: '' }),
+    });
+    expect(out.destination).toBe('funnel');
+  });
+
+  // ── CONTROL 2 ────────────────────────────────────────────────────────
+  // The persona that already worked (signed up through the funnel, so the
+  // marketplace origin holds an org-token) must keep working.
+  it('CONTROL: a marketplace-origin (localStorage) owner is handed to the console', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: false,
+      token: 'hs256-org-token',
+      fetchOrgs: orgMesh({ token: 'hs256-org-token' }),
+    });
+    expect(out.destination).toBe('console');
+    expect(out.reason).toBe('owner');
+    expect(out.org?.slug).toBe('acme');
+  });
+
+  // ── CONTROL 3 ────────────────────────────────────────────────────────
+  it('CONTROL: a demo/partner opt-out Organization stays on the marketplace', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: true,
+      token: 'hs256-org-token',
+      fetchOrgs: orgMesh({ token: 'hs256-org-token' }),
+    });
+    expect(out.destination).toBe('funnel');
+    expect(out.reason).toBe('opt-out');
+  });
+
+  // ── CONTROL 4 ────────────────────────────────────────────────────────
+  it('CONTROL: a signed-in visitor with no live Organization still reaches the funnel', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: false,
+      token: 'hs256-org-token',
+      fetchOrgs: async () => [{ id: 'o', slug: 's', status: 'deleted' }],
+    });
+    expect(out.destination).toBe('funnel');
+    expect(out.reason).toBe('no-live-org');
+  });
+
+  // ── THE #5421 GAP ────────────────────────────────────────────────────
+  // `it.fails` PASSES while the assertion inside fails, and goes RED the
+  // moment the assertion starts succeeding. So this is a live tripwire,
+  // not a disabled test: it records the exact acceptance criterion for
+  // #5421 and forces whoever closes the gap to promote it to `it()`.
+  //
+  // Persona: an owner authenticated on the CONSOLE origin via the
+  // passwordless-PIN flow. The `catalyst_session` cookie is scoped
+  // `.<sov>` path `/`, so the browser DOES attach it to the same-origin
+  // `/api/tenant/orgs` probe — but the Organization mesh never reads it.
+  it.fails(
+    'OPEN #5421: an owner carrying ONLY the console session cookie is handed to the console',
+    async () => {
+      const out = await resolveRedeemDestination({
+        skipConsoleRedirect: false,
+        token: '', // no marketplace-origin token — the owner authed on console.<sov>
+        fetchOrgs: orgMesh({ token: '', consoleSessionCookie: true }),
+      });
+      expect(out.destination).toBe('console');
+    },
+  );
+
+  // The characterisation of the same persona TODAY. This is what the
+  // walk sees: the owner is funnelled, and the reason is NOT "anonymous"
+  // — the probe simply could not be authenticated.
+  it('records the current (defective) cookie-only-owner outcome as probe-unauthenticated', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: false,
+      token: '',
+      fetchOrgs: orgMesh({ token: '', consoleSessionCookie: true }),
+    });
+    expect(out.destination).toBe('funnel');
+    expect(out.reason).toBe('probe-unauthenticated');
+  });
+});
+
+describe('ownerProbeIsAuthenticable — the fact #5686 assumed away', () => {
+  it('a console session cookie does NOT make the probe authenticable', () => {
+    // The whole of #5686 rests on the opposite of this assertion. Neither
+    // the Organization gateway nor the tenant middleware reads a cookie,
+    // so presenting one changes nothing about whether the probe is
+    // accepted. Flipping this to `true` requires a real server change.
+    expect(
+      ownerProbeIsAuthenticable({ token: '', hasConsoleSessionCookie: true }),
+    ).toBe(false);
+  });
+
+  it('a marketplace-origin org-token does', () => {
+    expect(ownerProbeIsAuthenticable({ token: 'hs256', hasConsoleSessionCookie: false })).toBe(true);
+  });
+});

--- a/core/marketplace/src/lib/redeemDestination.ts
+++ b/core/marketplace/src/lib/redeemDestination.ts
@@ -1,0 +1,168 @@
+// redeemDestination — the END-TO-END ownership decision for the voucher
+// redeem page (#5421, UAT row 3).
+//
+// ── Why this module exists (and why redeemOwnerGate was not enough) ──
+//
+// `redeemOwnerGate` decides only the FIRST hop: "should the page ask the
+// server at all?". PR #5686 fixed that hop so a cookie-borne owner no
+// longer short-circuits to the funnel on a missing localStorage token —
+// the gate now returns 'consult-server'.
+//
+// But 'consult-server' is a DECISION, not an OUTCOME. What the visitor
+// actually sees is decided one hop later, by whether the server can
+// answer. Testing the gate alone cannot see that, which is how #5686
+// shipped green while the reported symptom survived untouched.
+//
+// This module models the WHOLE pipeline — gate, then server consult, then
+// the owner hand-off — so a test can assert the thing the UAT row asserts:
+// *which page does this persona land on*.
+//
+// ── The wire contract the probe actually meets ───────────────────────
+//
+// The redeem page runs on `marketplace.<sov>` and probes `/api/tenant/orgs`
+// as a same-origin relative URL (`core/marketplace/src/lib/config.ts` —
+// `API_BASE = ${BASE}api`). On a Sovereign, `marketplace.<sov>` `/api/`
+// is routed by `products/catalyst/chart/templates/org-services/
+// marketplace-routes.yaml` to the Organization mesh gateway
+// (`org-services/gateway:8080`) — NOT to catalyst-api.
+//
+// Both hops on that path authenticate on the `Authorization: Bearer`
+// header ONLY, and both require HS256:
+//
+//   core/services/gateway/proxy.go            validateJWT — reads
+//     `r.Header.Get("Authorization")`, rejects a missing/!Bearer header.
+//   core/services/shared/middleware/jwt.go    JWTAuth — same, plus
+//     `if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok { … }`.
+//
+// Neither reads a cookie. `catalyst_session` is an RS256 cookie minted by
+// catalyst-api for the CONSOLE origin; the browser does attach it to the
+// same-origin probe (it is scoped `.<sov>` path `/`), but the receiving
+// services discard it. So for a cookie-only owner the probe carries no
+// credential either service accepts, and 401s — see REDEEM_OWNER_PROBE_
+// AUTHENTICATOR below.
+//
+// That is why the outcome did not move: the gate says "ask the server",
+// and the server says 401, and 401 lands in the same `runFunnel()` branch
+// the old token short-circuit used. #5421 is therefore still OPEN, and the
+// remaining work is a cross-service decision (teach the Organization mesh
+// to accept the console session, or narrow the row's contract to the
+// marketplace-origin persona) — not another client-side edit.
+
+import { redeemOwnerGate } from './redeemOwnerGate';
+
+/** Where the redeem page sends the visitor. */
+export type RedeemDestination = 'funnel' | 'console';
+
+/**
+ * WHY the visitor landed there. The reason is the part that makes the
+ * #5421 gap observable: a cookie-borne owner and a genuinely anonymous
+ * visitor both end on the funnel today, and without this discriminator
+ * the two are indistinguishable in code, in tests, and in a walk.
+ */
+export type RedeemReason =
+  /** Demo/partner Organization that opts out of the console hand-off. */
+  | 'opt-out'
+  /** Server confirmed >=1 live Organization — the owner path. */
+  | 'owner'
+  /** Server answered, but the visitor owns no live Organization yet. */
+  | 'no-live-org'
+  /**
+   * The ownership probe could not be authenticated by the Organization
+   * mesh. Today this covers BOTH a genuinely anonymous visitor AND the
+   * #5421 cookie-borne owner, because the probe carries no credential
+   * that mesh accepts either way.
+   */
+  | 'probe-unauthenticated'
+  /** The probe reached the server but failed for some other reason. */
+  | 'probe-error';
+
+export interface RedeemOrgSummary {
+  id?: string;
+  slug?: string;
+  status?: string;
+  console_host?: string;
+}
+
+export interface RedeemOutcome {
+  destination: RedeemDestination;
+  reason: RedeemReason;
+  /** Set only when destination === 'console'. */
+  org?: RedeemOrgSummary;
+}
+
+/**
+ * The credential the ownership probe presents to the Organization mesh.
+ *
+ * This is deliberately a NAMED, exported contract rather than an inline
+ * `if (token)`, because it is the precise fact PR #5686 assumed away. The
+ * probe is authenticable **iff** it can set an `Authorization: Bearer`
+ * header — i.e. iff a marketplace-origin `org-token` exists. A
+ * `catalyst_session` cookie, however valid, contributes nothing here:
+ * neither `core/services/gateway/proxy.go` nor
+ * `core/services/shared/middleware/jwt.go` reads cookies.
+ *
+ * Keep this in lockstep with `request()` in `./api.ts`, which sets the
+ * header only when `localStorage['org-token']` is non-empty.
+ */
+export function ownerProbeIsAuthenticable(input: {
+  /** marketplace-origin localStorage `org-token`. */
+  token: string;
+  /** `catalyst_session` cookie presence — accepted, and deliberately IGNORED. */
+  hasConsoleSessionCookie?: boolean;
+}): boolean {
+  return !!input.token;
+}
+
+export interface RedeemDestinationDeps {
+  /** Demo/partner opt-out (`__ORG_TENANT__.skipConsoleRedirect`). */
+  skipConsoleRedirect: boolean;
+  /** marketplace-origin localStorage `org-token` ('' for a cookie-only owner). */
+  token: string;
+  /** The active-Organization id previously stamped by the funnel, if any. */
+  activeOrgId?: string;
+  /**
+   * Issues the `/api/tenant/orgs` probe. Rejects with an error carrying
+   * `.status` on an HTTP error, mirroring `request()` in `./api.ts`.
+   */
+  fetchOrgs: () => Promise<RedeemOrgSummary[] | null | undefined>;
+}
+
+/**
+ * Resolve where the redeem page should send this visitor, mirroring the
+ * decision `init()` in `../pages/redeem.astro` performs.
+ */
+export async function resolveRedeemDestination(
+  deps: RedeemDestinationDeps,
+): Promise<RedeemOutcome> {
+  if (
+    redeemOwnerGate({
+      token: deps.token,
+      skipConsoleRedirect: deps.skipConsoleRedirect,
+    }) === 'funnel'
+  ) {
+    return { destination: 'funnel', reason: 'opt-out' };
+  }
+
+  let orgs: RedeemOrgSummary[] | null | undefined;
+  try {
+    orgs = await deps.fetchOrgs();
+  } catch (e) {
+    const status = (e as { status?: number } | null)?.status;
+    // 401/403 mean the mesh did not accept the probe's credentials. For a
+    // cookie-borne owner that is not "anonymous" — it is #5421.
+    const reason: RedeemReason =
+      status === 401 || status === 403 ? 'probe-unauthenticated' : 'probe-error';
+    return { destination: 'funnel', reason };
+  }
+
+  const live = Array.isArray(orgs)
+    ? orgs.filter((o) => o && o.status !== 'deleted')
+    : [];
+  if (live.length === 0) {
+    return { destination: 'funnel', reason: 'no-live-org' };
+  }
+
+  const pick =
+    (deps.activeOrgId && live.find((o) => o.id === deps.activeOrgId)) || live[0];
+  return { destination: 'console', reason: 'owner', org: pick };
+}

--- a/core/marketplace/src/lib/redeemOwnerGate.test.ts
+++ b/core/marketplace/src/lib/redeemOwnerGate.test.ts
@@ -1,11 +1,19 @@
 // redeemOwnerGate.test.ts — #5421 (UAT row 3).
 //
-// The decisive assertion is the cookie-only owner: token ABSENT + not
-// opted out must still consult the server. Against the pre-fix gate
-// (`funnel when !token || skip`) this case returned 'funnel' — the exact
-// bug that showed an authed owner the anonymous signup funnel. Both the
-// opt-out and the token-present paths are asserted too, so a gate that
-// unconditionally returns 'consult-server' would not pass either.
+// SCOPE — read this before citing these tests as evidence for #5421.
+//
+// They assert the gate's DECISION only: "should the page ask the server?".
+// They do NOT show that a cookie-borne owner is recognised. That outcome is
+// decided one hop later, by whether the Organization mesh can authenticate
+// the probe — and it cannot, so such an owner is still funnelled. See
+// `redeemDestination.test.ts`, which asserts the OUTCOME and carries the
+// `it.fails` tripwire for the still-open #5421 gap.
+//
+// The cookie-only case below returns 'funnel' against the pre-#5686 gate
+// (`funnel when !token || skip`) and 'consult-server' now, so it does record
+// a real change — just not one the visitor can see. Both the opt-out and the
+// token-present paths are asserted too, so a gate that unconditionally
+// returns 'consult-server' would not pass either.
 
 import { describe, expect, it } from 'vitest';
 

--- a/core/marketplace/src/pages/redeem.astro
+++ b/core/marketplace/src/pages/redeem.astro
@@ -145,10 +145,12 @@ import Layout from '../layouts/Layout.astro';
     // imports resolve. No new session mechanism is introduced.
     import { getMyOrgs, setActiveOrgConsoleHost } from '../lib/api';
     import { consoleLaunchHref } from '../lib/config';
-    // #5421 (UAT row 3): the owner pre-check gate lives in a plain module so it
-    // can be unit-tested. Ownership must NOT be gated on the marketplace-origin
-    // localStorage token — a cookie-borne owner has none there.
-    import { redeemOwnerGate } from '../lib/redeemOwnerGate';
+    // #5421 (UAT row 3): the WHOLE ownership decision — gate, server consult,
+    // and the REASON a visitor was funnelled — lives in a plain module so it can
+    // be unit-tested end-to-end. Testing only the gate hid the fact that
+    // 'consult-server' still funnels a cookie-borne owner, because the
+    // Organization mesh cannot authenticate that probe (see the module doc).
+    import { resolveRedeemDestination } from '../lib/redeemDestination';
     // #5634 (UAT row 92): the response-to-panel decision lives in a plain module
     // so it can be unit-tested; this page keeps only the DOM writes that need the
     // response body.
@@ -265,46 +267,36 @@ import Layout from '../layouts/Layout.astro';
 
       var token = '';
       try { token = localStorage.getItem('org-token') || ''; } catch (_) {}
-      // Gate on the opt-out only — NEVER on token presence (#5421). A cookie-borne
-      // owner has no marketplace-origin token; bailing on `!token` is exactly the
-      // bug that showed authed owners the anonymous funnel.
-      if (redeemOwnerGate({ token: token, skipConsoleRedirect: skipConsoleRedirect }) === 'funnel') {
-        runFunnel();
-        return;
-      }
+      var activeId = '';
+      try { activeId = localStorage.getItem('org-active-org') || ''; } catch (_) {}
 
-      // Consult the server: show a neutral shim (never the funnel) while we
-      // confirm ownership from the cookie-borne session, suppressing any funnel
-      // flash for an owner. A genuinely anonymous visitor 401s below and falls
-      // through to the funnel.
+      // Show a neutral shim (never the funnel) while the decision resolves, so
+      // an owner never sees a funnel flash. Cheap for the opt-out path, which
+      // resolves synchronously below.
       show('redeem-loading');
       var loadingCopy = document.querySelector('#redeem-loading p');
       if (loadingCopy) loadingCopy.textContent = 'One moment…';
 
-      let orgs;
-      try {
-        orgs = await getMyOrgs();
-      } catch (_) {
-        // Token present but ownership unconfirmable (expired session, API down):
-        // fall through to the public funnel rather than trapping the visitor.
+      // #5421 — the gate + the server consult + the pick, in one tested unit.
+      const outcome = await resolveRedeemDestination({
+        skipConsoleRedirect: skipConsoleRedirect,
+        token: token,
+        activeOrgId: activeId,
+        fetchOrgs: getMyOrgs,
+      });
+
+      if (outcome.destination === 'funnel') {
+        // Every non-owner path lands here: the demo/partner opt-out, a visitor
+        // with no live Organization, and — until #5421 closes — a cookie-borne
+        // owner whose probe the Organization mesh could not authenticate
+        // (`reason === 'probe-unauthenticated'`). Funnelling rather than
+        // trapping is deliberate: nobody is ever stuck on a dead shim.
         runFunnel();
         return;
       }
 
-      const live = Array.isArray(orgs)
-        ? orgs.filter((o) => o && o.status !== 'deleted')
-        : [];
-      if (live.length === 0) {
-        // Signed in but not yet an owner (mid-signup returning visitor).
-        runFunnel();
-        return;
-      }
-
-      // OWNER — hand off to the console dashboard. Prefer the active org, else
-      // the first live one, mirroring Layout.astro's pick + CheckoutStep.
-      let activeId = '';
-      try { activeId = localStorage.getItem('org-active-org') || ''; } catch (_) {}
-      const pick = (activeId && live.find((o) => o.id === activeId)) || live[0];
+      // OWNER — hand off to the console dashboard.
+      const pick = outcome.org;
       const slug = (pick && pick.slug) ? String(pick.slug) : '';
       // #4176 — stamp the SERVER-AUTHORITATIVE console host so the derivation
       // lands on the Org's chosen POOL TLD (console.<slug>.<pool-apex>) instead


### PR DESCRIPTION
## Status of the filed defect: REFUTED on `main`, still true on the deployed build

#5646's headline string, "Creating tenant" in the funnel provisioning timeline, is **already fixed on `main`** — `c93634751` / PR #5673, merged 2026-08-05. `core/services/provisioning/handlers/consumer.go:1313` reads `Creating Organization`, and the repo-wide sweep for the literal returns only session-evidence documents.

Classification: **(b) fixed in `main`, undeployed.** hw292 runs the 2026-08-02 bundle, older than the fix. Re-confirmed live today, read-only:

```
$ curl -s https://marketplace.hw292.omani.works/api/provisioning/tenant/339cba9f-051a-4492-b447-b57301ae9e23
status= failed progress= 100
  completed  Creating tenant            <-- pre-#5673 build
  completed  Committing manifests to Git
  completed  Provisioning vCluster
  failed     Installing mysql (dependency)
  completed  Deploying WordPress
  completed  Configuring TLS certificates
  completed  Running health checks
```

So this PR does not re-fix that label. It ships what the three-way sweep found still live on `main`, plus the guard that would have caught both.

## Three-way sweep

**(a) Source strings.** `Creating tenant` is gone. But `core/marketplace/src/components/Header.svelte:232` renders **"Console (my tenants)"** in the account menu of every signed-in customer in the funnel. Rendered text, not an identifier, present on `main`. Fixed here.

**(b) Runtime Kubernetes object names — the leak a grep cannot see.** `failStep` / `failProvision` write a **raw Go error** into `ProvisionStep.Message`, and `ProvisioningTimeline.svelte:55` prints that field verbatim for any failed step:

```svelte
{#if step.status === 'failed' && step.message && step.message !== 'ok'}
  <span class="... text-[var(--color-danger)]">{step.message}</span>
```

Those errors are assembled at runtime from object names. `mirrorVClusterKubeconfig` mirrors a Secret named `tenant-<slug>-kubeconfig`, and `k8sRequest` formats failures as `k8s %s %s: status %d: %s` — **including the path**. A failed mirror therefore reaches a paying customer's screen as:

```
update mirror secret (flux-system): k8s PUT
/api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: ...
```

No string literal anywhere contains that sentence. Confirmed live on hw292, read-only — the object is real, in two namespaces:

```
$ kubectl get secret,configmap,deployment,statefulset,service,job,ingress,kustomization,helmrelease -A -o name | grep -i tenant
secret/openova-org-tenants-git-auth
secret/tenant-uatco-kubeconfig          <-- flux-system
secret/tenant-uatco-kubeconfig          <-- uatco
deployment.apps/tenant
service/tenant
kustomization.../catalyst-tenant-uatco-apps
... 20 live objects total
```

Same class as #5435, where `deployment.apps/tenant` reached the showback table the same way. Fixed here.

**(c) API-emitted step labels.** Two producers only: `consumer.go:1313` (clean since #5673) and `core/marketplace-api/handlers/handlers.go:156` ("Creating virtual cluster", clean). The two runtime-interpolated labels are `Installing %s (dependency)` (raw catalog dependency slug) and `Deploying %s` (catalog display title). Checked against the live hw292 catalog — all 35 apps: dependency slugs are `mysql`, `postgres`, `redis`; no app display name carries the term. Clean today, and now guarded, since both are catalog-driven and admin-editable.

## Which layer is fixed, and which is deliberately left

**Fixed — presentation only.** `customerFacingMessage()` drops the Kubernetes plumbing from the customer-visible message and rewrites the term. The status code and the failing operation survive, so it stays diagnostic:

```
BEFORE: update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: {"kind":"Status","message":"internal error"}
AFTER : update mirror secret (flux-system): platform API returned status 500: {"kind":"Status","message":"internal error"}

BEFORE: k8s DELETE /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 409: {...}
AFTER : platform API returned status 409: {...}
```

The unabridged error still goes to `slog.Error` for the sovereign-admin, so no diagnostic is lost.

**Deliberately NOT fixed — internal identity.** `tenant-<slug>-kubeconfig` is referenced by the generated apps-sync Kustomization (`gitops.go`) and by every per-Org application HelmRelease on already-provisioned Sovereigns; renaming it would strand them. Likewise `core/services/tenant/` (#5729), `deployment.apps/tenant`, `service/tenant`, the `/api/provisioning/tenant/<id>` route, and the `Tenant` TypeScript type. All are separate changes with much larger blast radius. The name is now centralised in `vclusterKubeconfigSecretName()` so the mirror and its teardown cannot drift, and so the guard asserts against the real name rather than a copy of it.

## The guard — both directions, real output

Two guards. Neither is a grep, because the defect in (b) has no source text to match, and because this tree has ~30 legitimate uses of the word as an identifier (`/tenant/orgs`, `org-checkout-tenant`, the `Tenant` type, `html[data-tenant]`, comments). A guard that flagged those would be switched off within a week.

### RED on the pre-fix tree

**Go** — `customerFacingMessage` reduced to a passthrough, which is exactly what `main` does:

```
=== RUN   TestFailedStepMessage_NoBannedTermFromRuntimeObjectNames
    customer_facing_copy_5646_test.go:112: banned term reached the customer-facing step message.
          internal error : update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: {"kind":"Status","message":"internal error"}
          rendered to customer: update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: {"kind":"Status","message":"internal error"}
                                                                                                                   ^-- "tenant"
          docs/GLOSSARY.md bans "tenant" on product surfaces; the correction is "Organization".
          ProvisioningTimeline.svelte prints step.message verbatim, so this string IS product copy.
    customer_facing_copy_5646_test.go:112: banned term reached the customer-facing step message.
          internal error : k8s DELETE /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 409: {"kind":"Status","message":"internal error"}
          rendered to customer: k8s DELETE /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 409: {"kind":"Status","message":"internal error"}
                                                                                  ^-- "tenant"
--- FAIL: TestFailedStepMessage_NoBannedTermFromRuntimeObjectNames (0.00s)
=== RUN   TestInternalIdentifiers_AreNotRenamed
--- PASS: TestInternalIdentifiers_AreNotRenamed (0.00s)          <-- CONTROL, green
=== RUN   TestBannedTermPattern_IsNotVacuous
--- PASS: TestBannedTermPattern_IsNotVacuous (0.00s)             <-- vacuity, green
FAIL
```

**vitest** — `Header.svelte` reverted to the string on `main`:

```
 ❯ src/lib/renderedCopy.test.ts (29 tests | 1 failed) 243ms
     × components/Header.svelte renders no banned term 16ms

AssertionError: components/Header.svelte renders the banned term "tenant" to a customer.
  [text] Console (my tenants)
docs/GLOSSARY.md §Banned-terms: use "Organization".
If this is an INTERNAL identifier (API path, storage key, type name, comment, data-attribute) it should not be reaching rendered text at all.

- Expected
+ Received
- []
+ [ { "kind": "text", "text": "Console (my tenants)" } ]

 Tests  1 failed | 28 passed (29)
```

Note what stayed green in that same run against the **real** `Header.svelte`: its `<!-- Logo (tenant-aware: ... html[data-tenant=...] ... ) -->` comment and its `data-tenant` attribute were not flagged. That is the control working on production code, not on a fixture.

### GREEN on the fixed tree

```
$ go test ./...   # core/services/provisioning
ok  github.com/openova-io/openova/core/services/provisioning/gitguard  0.014s
ok  github.com/openova-io/openova/core/services/provisioning/github    0.344s
ok  github.com/openova-io/openova/core/services/provisioning/gitops    0.012s
ok  github.com/openova-io/openova/core/services/provisioning/handlers  0.457s
ok  github.com/openova-io/openova/core/services/provisioning/store     0.003s

$ npm test   # core/marketplace
 Test Files  4 passed (4)
      Tests  76 passed (76)

$ npm run build
[build] 11 page(s) built in 1.63s
[domain-hygiene] OK — 37 served file(s) scanned, zero banned domain literals (#3376).
```

### Why these can go red, and why they cannot pass on nothing

- **Asserts on output, not source.** The Go guard asserts on the value of the customer-visible field, building its inputs from the production helpers (`vclusterKubeconfigSecretName`, the real `k8s %s %s: status %d` format) — rename the Secret or reshape the error and the guard follows instead of testing a stale copy. The vitest guard asserts on text extracted by Svelte's own parser, so "is this markup or script" is the compiler's judgement, not a regex approximation.
- **Every branch, not one render.** The AST walk covers `{#if}` / `{:else}` / `{#each}`; an SSR-render-and-scan only exercises the branch its props select, and the offending string may sit in the other one. Pinned by a vacuity test that puts the term in an `{:else}`.
- **Spellings that evade a naive search.** The matchers are case-insensitive and not word-anchored, so `Tenant`, `TENANT`, `tenants`, and the hyphenated runtime object name `tenant-uatco-kubeconfig` all trip. Pinned by `TestBannedTermPattern_IsNotVacuous` against five real spellings including the 2026-06-24 live sighting `helmrelease tenant-f4179walk/vcluster not ready`.
- **The controls are load-bearing.** `TestInternalIdentifiers_AreNotRenamed` fails if anyone "fixes" the term by renaming the Kubernetes object — the wrong layer. The vitest control pins that script identifiers, comments, `data-*` and API paths stay unflagged, and additionally that the extractor still returns the real copy (so it cannot pass by returning nothing). `finds the funnel components` fails if the glob ever scans an empty set.
- **A blanking redaction would fail too.** `TestFailedStepMessage_KeepsTheDiagnostic` requires the status code and the failing operation to survive, so the guard cannot be satisfied by emptying every message.

### The checks actually RUN

- Go: `.github/workflows/test-provisioning-service.yaml` already triggers on `pull_request` with `paths: core/services/provisioning/**`. The new test lands inside that path.
- vitest: **nothing ran `core/marketplace`'s suite at all.** `marketplace-build.yaml` matches `core/marketplace/**` but only builds and pushes the image, on push-to-main, with no test step and no `pull_request` trigger — so `redeemPreview.test.ts`, `redeemOwnerGate.test.ts` and `rateLimitNotice.test.ts` could go red on `main` indefinitely with nothing turning red. Same fail-open gap #5439 closed for `core/services/provisioning`. This PR adds `test-marketplace-funnel.yaml` (`pull_request` + `push`, `paths: core/marketplace/**`), with a plain `npm test` and no `|| true` — the `|| echo WARN` form is what let four source defects sit behind a green catalyst-build vitest gate for two months.

## Walk assertion for #5646 (stays OPEN)

Falsifiable, deploy-gated on a fresh prov carrying this branch:

> On the funnel `/launching` page after checkout, the first timeline step reads exactly **`Creating Organization`**, and `GET /api/provisioning/tenant/<id>` returns that same string in `steps[0].name`. If any step fails, the red text under it contains no occurrence of `tenant` in any case — in particular a failed kubeconfig mirror reads `... platform API returned status <code>` and never `.../secrets/tenant-<slug>-kubeconfig`. Signed in, the account menu reads **`Console (my Organizations)`**.

hw292 cannot serve this proof: it predates both #5673 and this branch.

Refs #5646 #5673 #5435 #5439 #5729
It also **had never run at the time it merged**. No workflow executed `core/marketplace`'s vitest suite: `marketplace-build.yaml` only builds the image, `catalyst-build.yaml`'s vitest gate runs `products/catalyst/bootstrap/ui` (a different tree), and `playwright-e2e.yml` filters on `products/catalyst/console/**`. All 47 marketplace tests were dead weight.

**Correction, same night:** a peer landed `test-marketplace-funnel.yaml` in #5740 while this work was in flight, which now runs the suite on every PR touching `core/marketplace/**`. So the hole is already closed on `main`. This PR therefore no longer adds its own duplicate workflow — it adds the one step that one lacks, a pre-merge `astro build`, since a type error in the redeem page fails the build while vitest stays green.
