### PR TITLE
fix(funnel): banned term still reaches the customer from a header label and a runtime K8s object name, plus a rendered-output guard for both

### DIFF
--- a/.github/workflows/test-marketplace-funnel.yaml
+++ b/.github/workflows/test-marketplace-funnel.yaml
@@ -1,0 +1,62 @@
+name: Test — Marketplace Funnel (vitest)
+
+# Runs the unit tests for core/marketplace — the CUSTOMER storefront + funnel
+# (signup, catalog, checkout, voucher redeem, the post-checkout `launching`
+# page).
+#
+# WHY THIS FILE EXISTS (#5646). Before it, `core/marketplace`'s vitest suite ran
+# in NO workflow at all. `marketplace-build.yaml` matches `core/marketplace/**`
+# but only builds and pushes the image, on push-to-main, with no `npm test` step
+# and no pull_request trigger. So `src/lib/redeemPreview.test.ts`,
+# `redeemOwnerGate.test.ts` and `rateLimitNotice.test.ts` — three suites covering
+# the voucher-redeem and rate-limit surfaces a paying customer hits — could go
+# red on main indefinitely without a single check turning red.
+#
+# That is the fail-open-gate class: a guard that cannot fail is not a guard. This
+# is the same gap #5439 closed for core/services/provisioning, applied to the
+# funnel. Adding the #5646 rendered-copy guard without this file would have
+# reproduced exactly that defect — a banned-term check nothing ever executes.
+
+on:
+  push:
+    paths:
+      - 'core/marketplace/**'
+      - '.github/workflows/test-marketplace-funnel.yaml'
+    branches: [main]
+  pull_request:
+    paths:
+      - 'core/marketplace/**'
+      - '.github/workflows/test-marketplace-funnel.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: vitest — funnel unit tests + customer-copy guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: core/marketplace
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: core/marketplace/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # No `|| true`, no `|| echo WARN`. vitest exits non-zero on any failing
+      # test and the default shell runs with `set -e`, so a red suite fails the
+      # job. Keep it that way — the WARN form is what made catalyst-build's
+      # vitest gate pass for two months while four source defects sat behind it.
+      - name: Run vitest
+        run: npm test

--- a/core/marketplace/src/components/Header.svelte
+++ b/core/marketplace/src/components/Header.svelte
@@ -229,7 +229,7 @@
               </div>
               <a href={portalHref()} class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] no-underline hover:bg-[var(--color-surface-hover)]" role="menuitem">
                 <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z"/></svg>
-                Console (my tenants)
+                Console (my Organizations)
               </a>
               <a href="/checkout" class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] no-underline hover:bg-[var(--color-surface-hover)]" role="menuitem">
                 <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"/></svg>

--- a/core/marketplace/src/lib/renderedCopy.test.ts
+++ b/core/marketplace/src/lib/renderedCopy.test.ts
@@ -1,0 +1,159 @@
+// #5646 — the banned term must never reach the customer's screen in the funnel.
+//
+// The issue was filed on "Creating tenant" in the provisioning timeline, which
+// is producer-side and guarded in Go
+// (core/services/provisioning/handlers/customer_facing_copy_5646_test.go). This
+// is the other half: the copy the funnel itself renders.
+//
+// WHY THIS IS NOT A GREP. `core/marketplace/src` contains ~30 legitimate uses of
+// the word as an identifier — the `/tenant/orgs` API path, the
+// `org-checkout-tenant` localStorage key, the `Tenant` TypeScript interface, the
+// `data-tenant` styling hook, code comments. A guard that flagged those would be
+// unusable and would be deleted. So the assertion is made on RENDERED TEXT
+// extracted by `renderedCopy.ts` — the words a customer reads — and the control
+// below pins that every one of those identifier uses stays unflagged.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import {
+  extractRenderedText,
+  extractSvelteRenderedText,
+  extractAstroRenderedText,
+} from './renderedCopy';
+
+// vitest runs with the package root as cwd (core/marketplace).
+const SRC = join(process.cwd(), 'src');
+
+/**
+ * docs/GLOSSARY.md §Banned-terms: "tenant" → "Organization".
+ *
+ * Case-insensitive and NOT word-anchored, so the spellings that would dodge a
+ * naive search are all covered: "Tenant", "TENANT", "tenants", "per-tenant",
+ * and the term embedded in a runtime object name (`tenant-uatco-kubeconfig`) —
+ * that last shape is how #5435 put the term on a console screen with no source
+ * string to grep for.
+ */
+const BANNED = /tenant/i;
+
+function walkFiles(dir: string, exts: string[], acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walkFiles(p, exts, acc);
+    else if (exts.some((e) => entry.endsWith(e))) acc.push(p);
+  }
+  return acc;
+}
+
+describe('#5646 — no banned product term in rendered funnel copy', () => {
+  const files = walkFiles(SRC, ['.svelte', '.astro']);
+
+  it('finds the funnel components (guard is not scanning an empty set)', () => {
+    // Without this, a bad glob would make every assertion below pass on nothing.
+    expect(files.length).toBeGreaterThan(15);
+  });
+
+  it.each(files.map((f) => [relative(SRC, f), f]))(
+    '%s renders no banned term',
+    (rel, abs) => {
+      const strings = extractRenderedText(readFileSync(abs, 'utf8'), abs);
+      const offenders = strings.filter((s) => BANNED.test(s.text));
+
+      expect(
+        offenders,
+        `${rel} renders the banned term "tenant" to a customer.\n` +
+          offenders.map((o) => `  [${o.kind}] ${o.text}`).join('\n') +
+          `\ndocs/GLOSSARY.md §Banned-terms: use "Organization".\n` +
+          `If this is an INTERNAL identifier (API path, storage key, type name, ` +
+          `comment, data-attribute) it should not be reaching rendered text at all.`,
+      ).toEqual([]);
+    },
+  );
+});
+
+describe('#5646 control — legitimate internal uses stay unflagged', () => {
+  // Every pattern below is real code from this tree. If the extractor ever
+  // starts returning these, the guard becomes noise and gets disabled — so this
+  // is as load-bearing as the assertion above, and it is green on BOTH the
+  // pre-fix and post-fix trees.
+  it('ignores script identifiers, comments, attribute expressions and data-attributes', () => {
+    const component = `
+<script lang="ts">
+  import { createTenant, getProvisionByTenant, type Tenant } from '../lib/api';
+  let tenantId = $state('');
+  const saved = localStorage.getItem('org-checkout-tenant');
+  const url = \`\${API_BASE}/provisioning/tenant/\${id}\`;
+</script>
+
+<!-- Logo (tenant-aware: rendered unconditionally; CSS hides the inactive one
+     based on html[data-tenant=...] set by the pre-hydration script) -->
+<div data-tenant={activeTenant} class="tenant-logo" id="tenant-root">
+  <a href="/tenant/orgs">Console (my Organizations)</a>
+  <span>{tenantId}</span>
+</div>
+`;
+    const rendered = extractSvelteRenderedText(component);
+    expect(rendered.filter((s) => BANNED.test(s.text))).toEqual([]);
+    // ...and it did not simply return nothing: the real copy is still there.
+    expect(rendered.map((s) => s.text)).toContain('Console (my Organizations)');
+  });
+
+  it('ignores an inline <script> in an Astro page (redeem.astro shape)', () => {
+    const page = `---
+import Layout from '../layouts/Layout.astro';
+const tenant = Astro.props.tenant;
+---
+<Layout title="Redeem">
+  <p>Redeem your voucher to create your Organization.</p>
+  <script>
+    var tenant = (window as any).__ORG_TENANT__;
+    var skipConsoleRedirect = !!(tenant && tenant.skipConsoleRedirect);
+  </script>
+</Layout>`;
+    const rendered = extractAstroRenderedText(page);
+    expect(rendered.filter((s) => BANNED.test(s.text))).toEqual([]);
+    expect(rendered.map((s) => s.text)).toContain(
+      'Redeem your voucher to create your Organization.',
+    );
+  });
+});
+
+describe('#5646 vacuity — the extractor can still go red', () => {
+  // An absence-assertion passes both when the term is absent AND when the
+  // extractor stopped working. These pin that it still SEES rendered copy, so a
+  // broken walker cannot turn the suite permanently green on nothing.
+  it('catches the banned term in Svelte rendered text, including inside blocks', () => {
+    const offending = `
+<script>let user = {};</script>
+{#if user}
+  <div>
+    <a href="/portal" aria-label="Open the tenant console">Console (my tenants)</a>
+  </div>
+{:else}
+  <p>Sign in to see your tenants</p>
+{/if}`;
+    const hits = extractSvelteRenderedText(offending).filter((s) => BANNED.test(s.text));
+    const texts = hits.map((h) => h.text);
+
+    expect(texts).toContain('Console (my tenants)');          // the string this PR removed
+    expect(texts).toContain('Open the tenant console');       // aria-label surface
+    expect(texts).toContain('Sign in to see your tenants');   // the {:else} branch
+  });
+
+  it('catches the banned term in Astro rendered text', () => {
+    const offending = `---
+const x = 1;
+---
+<p>Your tenant is being created</p>`;
+    const hits = extractAstroRenderedText(offending).filter((s) => BANNED.test(s.text));
+    expect(hits.map((h) => h.text)).toContain('Your tenant is being created');
+  });
+
+  it('catches a runtime-shaped object name if one is ever rendered (#5435 class)', () => {
+    const hits = extractSvelteRenderedText(
+      '<span>could not read tenant-uatco-kubeconfig</span>',
+    ).filter((s) => BANNED.test(s.text));
+    expect(hits.length).toBeGreaterThan(0);
+  });
+});

--- a/core/marketplace/src/lib/renderedCopy.ts
+++ b/core/marketplace/src/lib/renderedCopy.ts
@@ -1,0 +1,179 @@
+// renderedCopy.ts — extract the words a CUSTOMER actually reads from a funnel
+// component, as opposed to the identifiers a developer reads.
+//
+// #5646. The funnel is the storefront a paying customer walks after checkout,
+// and docs/GLOSSARY.md §Banned-terms governs every word on it ("tenant" →
+// "Organization"). Enforcing that with a plain grep is useless here, because the
+// SAME word is legitimate and unavoidable in this tree as an identifier:
+//
+//   localStorage.getItem('org-checkout-tenant')      ← internal storage key
+//   request<Tenant>('/tenant/orgs')                  ← API path + TS type
+//   html[data-tenant=...]                            ← styling hook
+//   <!-- Logo (tenant-aware: ...) -->                ← code comment
+//
+// A grep for the banned term flags all four, so a grep-shaped guard is one that
+// gets switched off within a week. What matters is narrower and checkable: the
+// term must not appear in RENDERED TEXT. So this module parses the component and
+// returns only the strings that reach the page — template text nodes plus the
+// handful of attributes screen readers and tooltips surface — and deliberately
+// drops <script>, <style>, comments, expression tags and every other attribute.
+//
+// That distinction is the whole guard. `Header.svelte` carried BOTH a rendered
+// "Console (my tenants)" and a comment mentioning `data-tenant`; only the first
+// is a defect, and only the first is returned here.
+
+/** A single customer-readable string, with enough context to report it. */
+export interface RenderedString {
+  /** The text as the customer reads it, whitespace-collapsed. */
+  text: string;
+  /** Where it came from — 'text' for a template text node, or the attribute name. */
+  kind: string;
+}
+
+/**
+ * Attributes whose literal value is presented to a user (visually, on hover, or
+ * through a screen reader). Everything else — class, href, data-*, id, bind:,
+ * on: — is an identifier surface and is intentionally NOT extracted.
+ */
+const USER_VISIBLE_ATTRS = new Set([
+  'alt',
+  'aria-label',
+  'aria-description',
+  'aria-placeholder',
+  'aria-roledescription',
+  'placeholder',
+  'title',
+  'label',
+]);
+
+const collapse = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+function push(out: RenderedString[], text: string, kind: string) {
+  const t = collapse(text);
+  if (t) out.push({ text: t, kind });
+}
+
+/**
+ * Extract rendered copy from a Svelte component using Svelte's own parser, so
+ * the notion of "this is markup, that is script" is the compiler's and not a
+ * regex approximation. Walks EVERY branch ({#if}/{#each}/{:else}), which an
+ * SSR-render-and-scan approach would not — a render only exercises the branch
+ * its props select, and the banned string may well sit in the other one.
+ */
+export function extractSvelteRenderedText(source: string): RenderedString[] {
+  // Imported lazily and synchronously via require-style interop so this module
+  // stays usable from a plain vitest run without a Svelte plugin.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { parse } = require('svelte/compiler');
+  const ast = parse(source, { modern: true });
+  const out: RenderedString[] = [];
+
+  // NB: ast.instance / ast.module are the <script> blocks and are never walked.
+  walkFragment(ast.fragment, out);
+  return out;
+}
+
+function walkFragment(fragment: any, out: RenderedString[]) {
+  if (!fragment || !Array.isArray(fragment.nodes)) return;
+  for (const node of fragment.nodes) walkNode(node, out);
+}
+
+function walkNode(node: any, out: RenderedString[]) {
+  if (!node || typeof node !== 'object') return;
+
+  switch (node.type) {
+    case 'Text':
+      push(out, node.data ?? node.raw ?? '', 'text');
+      return;
+
+    // Explicitly dropped: comments are developer copy, expression tags render a
+    // runtime VALUE (guarded on the producer side, in Go), and <style> is not copy.
+    case 'Comment':
+    case 'ExpressionTag':
+    case 'HtmlTag':
+      return;
+
+    case 'RegularElement':
+    case 'Component':
+    case 'SvelteElement':
+    case 'SvelteComponent':
+    case 'SlotElement':
+    case 'TitleElement': {
+      if (node.name === 'script' || node.name === 'style') return;
+      for (const attr of node.attributes ?? []) collectAttr(attr, out);
+      walkFragment(node.fragment, out);
+      return;
+    }
+
+    default: {
+      // Block constructs ({#if}/{#each}/{#await}/{#snippet}/{#key}) all hang
+      // their bodies off named fragment properties. Walking them generically
+      // means a new Svelte block type is covered the day it appears, rather
+      // than silently escaping the guard.
+      for (const key of ['fragment', 'body', 'consequent', 'alternate', 'pending', 'then', 'catch', 'fallback']) {
+        const child = node[key];
+        if (child && typeof child === 'object') {
+          if (Array.isArray(child.nodes)) walkFragment(child, out);
+          else walkNode(child, out);
+        }
+      }
+    }
+  }
+}
+
+function collectAttr(attr: any, out: RenderedString[]) {
+  if (!attr || attr.type !== 'Attribute') return;
+  if (!USER_VISIBLE_ATTRS.has(String(attr.name).toLowerCase())) return;
+
+  const v = attr.value;
+  if (v === true) return;
+  const parts = Array.isArray(v) ? v : [v];
+  for (const p of parts) {
+    // Only STATIC values. A {expression} attribute renders a runtime value.
+    if (p && p.type === 'Text') push(out, p.data ?? p.raw ?? '', `@${attr.name}`);
+  }
+}
+
+/**
+ * Extract rendered copy from an Astro page.
+ *
+ * Astro has no published synchronous parser in this package's dependency set,
+ * so this is a deliberately CONSERVATIVE markup scan: everything that is
+ * definitively not rendered copy is removed first (frontmatter, script, style,
+ * comments, expressions), and what survives between tags is treated as copy.
+ * Conservative in the safe direction — it may return slightly more than the
+ * customer sees, never less, so the guard cannot go quietly blind.
+ */
+export function extractAstroRenderedText(source: string): RenderedString[] {
+  let s = source;
+
+  // Frontmatter fence (--- ... ---) at the top of the file: TypeScript, not copy.
+  s = s.replace(/^\s*---[\s\S]*?\n---/, '');
+  // Inline <script>/<style> bodies — where `var tenant = ...` legitimately lives.
+  s = s.replace(/<script[\s\S]*?<\/script>/gi, '');
+  s = s.replace(/<style[\s\S]*?<\/style>/gi, '');
+  // HTML and JS comments.
+  s = s.replace(/<!--[\s\S]*?-->/g, '');
+  // {expressions} render runtime values, not literal copy.
+  s = s.replace(/\{[^{}]*\}/g, ' ');
+
+  const out: RenderedString[] = [];
+
+  // User-visible attributes, before tags are stripped.
+  const attrRE = new RegExp(`\\b(${[...USER_VISIBLE_ATTRS].join('|')})\\s*=\\s*"([^"]*)"`, 'gi');
+  for (const m of s.matchAll(attrRE)) push(out, m[2], `@${m[1].toLowerCase()}`);
+
+  // Then the text between tags. Tags become line breaks and each surviving line
+  // is one chunk, so a rendered phrase stays intact in the failure message
+  // instead of being reported as a bag of words.
+  for (const chunk of s.replace(/<[^>]*>/g, '\n').split('\n')) push(out, chunk, 'text');
+
+  return out;
+}
+
+/** Dispatch on file extension. */
+export function extractRenderedText(source: string, filename: string): RenderedString[] {
+  if (filename.endsWith('.svelte')) return extractSvelteRenderedText(source);
+  if (filename.endsWith('.astro')) return extractAstroRenderedText(source);
+  return [];
+}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -1867,9 +1867,16 @@ func (h *Handler) completeStepWithMessage(ctx context.Context, provisionID, tena
 // Used by sibling parallel workers so the UI sees which app broke.
 func (h *Handler) failStep(ctx context.Context, provisionID, tenantID string, idx int, name, message string) {
 	step := store.ProvisionStep{
-		Name:    name,
-		Status:  "failed",
-		Message: message,
+		Name:   name,
+		Status: "failed",
+		// #5646 — every caller here passes a RAW Go error (`err.Error()`), and
+		// this field is printed verbatim to a paying customer by
+		// ProvisioningTimeline.svelte. Those errors are assembled at runtime out
+		// of Kubernetes object names (`tenant-<slug>-kubeconfig`), so without
+		// this boundary the banned term reaches the funnel from an OBJECT NAME
+		// rather than from any string literal — the #5435 class, which no source
+		// grep can see. The unabridged error still goes to the log line below.
+		Message: customerFacingMessage(message),
 		DoneAt:  time.Now().UTC(),
 	}
 	if err := h.Store.UpdateStep(ctx, provisionID, idx, step); err != nil {
@@ -1889,7 +1896,11 @@ func (h *Handler) failProvision(ctx context.Context, provisionID, tenantID strin
 
 	if stepIndex < len(p.Steps) && p.Steps[stepIndex].Status != "failed" {
 		p.Steps[stepIndex].Status = "failed"
-		p.Steps[stepIndex].Message = message
+		// #5646 — same customer-facing field as failStep. Several callers wrap a
+		// raw error into this message (`vcluster not ready: %s`,
+		// `mirror kubeconfig to flux-system: %s`), so it carries the same
+		// runtime-object-name exposure and gets the same boundary.
+		p.Steps[stepIndex].Message = customerFacingMessage(message)
 		p.Steps[stepIndex].DoneAt = time.Now().UTC()
 	}
 

--- a/core/services/provisioning/handlers/customer_facing_copy.go
+++ b/core/services/provisioning/handlers/customer_facing_copy.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The customer-facing copy boundary for the funnel provisioning timeline.
+//
+// #5646. The `launching` page is the screen a PAYING CUSTOMER watches straight
+// after checkout. Everything on it comes from one JSON payload
+// (`GET /api/provisioning/tenant/<id>`), and the funnel renderers draw that
+// payload verbatim — `ProvisioningTimeline.svelte` prints `step.message` into
+// the page for any failed step with no filtering of its own. So whatever the
+// provisioning service writes into a step IS product copy, and
+// docs/GLOSSARY.md §Banned-terms governs it: "tenant" is banned, the
+// correction is "Organization".
+//
+// The step NAMES were the visible half of that bug and are already literal
+// strings under our control (consumer.go's step list). This file exists for
+// the half a source grep cannot see:
+//
+//	failStep(..., err.Error())
+//
+// writes a RAW Go error into the customer-visible `Message` field, and those
+// errors are built at runtime out of KUBERNETES OBJECT NAMES. The mirrored
+// vCluster kubeconfig Secret is named `tenant-<slug>-kubeconfig`, so a failed
+// mirror reaches the customer's screen as
+//
+//	update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/
+//	secrets/tenant-uatco-kubeconfig: status 500: ...
+//
+// — the banned term on a customer-facing screen, sourced from an object name,
+// invisible to any grep for a banned string literal. That is the #5435 class
+// (`deployment.apps/tenant` reaching the showback table the same way).
+//
+// The fix is at the PRESENTATION boundary, deliberately NOT at the identifier.
+// `tenant-<slug>-kubeconfig` is referenced by generated Flux Kustomizations and
+// per-Org HelmReleases (gitops.go, per_org_flux.go) on every Sovereign already
+// provisioned; renaming it is a separate change with a far larger blast radius.
+// The internal name stays exactly as it is — see vclusterKubeconfigSecretName —
+// and only the copy shown to the customer is rewritten. The unabridged error
+// is still logged by failStep for the sovereign-admin, so no diagnostic is lost.
+// ─────────────────────────────────────────────────────────────────────────────
+
+var (
+	// k8sAPIErrorRE matches the error k8sRequest emits on a >=400 response:
+	// `k8s <METHOD> <path>: status <code>`. The path carries the object name,
+	// which is exactly what must not reach the customer. The status code is
+	// genuinely useful, so it is kept.
+	k8sAPIErrorRE = regexp.MustCompile(`k8s [A-Z]+ /\S*?: status (\d+)`)
+
+	// k8sAPIPathRE catches any other bare API path that leaks through a
+	// differently-shaped wrapper.
+	k8sAPIPathRE = regexp.MustCompile(`/apis?/\S+`)
+
+	// internalObjectRE matches an internal Kubernetes object name built on the
+	// banned term — `tenant-<slug>-kubeconfig`, `tenant-<slug>-tls`,
+	// `tenant-<slug>-apps`, `catalyst-tenant-<slug>`. Matched BEFORE the bare
+	// word so the whole identifier is removed rather than half-rewritten into
+	// a name that does not exist.
+	internalObjectRE = regexp.MustCompile(`(?i)\b[a-z0-9-]*tenants?-[a-z0-9][a-z0-9.\-/]*`)
+
+	// bannedWordRE matches the banned term as a standalone English word, which
+	// is the form that reads as product copy.
+	bannedWordRE = regexp.MustCompile(`(?i)\btenants\b`)
+
+	bannedWordSingularRE = regexp.MustCompile(`(?i)\btenant\b`)
+
+	// tidy-up passes so a redacted message still reads like a sentence.
+	danglingSepRE = regexp.MustCompile(`\s*([:,])\s*([:,])`)
+	multiSpaceRE  = regexp.MustCompile(`[ \t]{2,}`)
+)
+
+// customerFacingMessage turns an internal error string into copy that is safe
+// to render on the funnel timeline: no Kubernetes plumbing, and no banned term.
+//
+// It is intentionally a pure string function so the guard can drive it with the
+// error strings the real code paths produce. Order matters — the widest,
+// most-specific redactions run first so that an identifier is removed whole
+// instead of being partially rewritten into something that does not exist.
+func customerFacingMessage(raw string) string {
+	if raw == "" {
+		return raw
+	}
+
+	out := k8sAPIErrorRE.ReplaceAllString(raw, "platform API returned status $1")
+	out = k8sAPIPathRE.ReplaceAllString(out, "an internal resource")
+	out = internalObjectRE.ReplaceAllString(out, "an internal resource")
+	out = bannedWordRE.ReplaceAllString(out, "Organizations")
+	out = bannedWordSingularRE.ReplaceAllString(out, "Organization")
+
+	out = danglingSepRE.ReplaceAllString(out, "$1")
+	out = multiSpaceRE.ReplaceAllString(out, " ")
+	out = strings.TrimSpace(out)
+	out = strings.TrimRight(out, ":, ")
+
+	return out
+}
+
+// vclusterKubeconfigSecretName is the name of the mirrored vCluster kubeconfig
+// Secret for an Organization.
+//
+// The `tenant-` prefix is an INTERNAL Kubernetes object name. It is referenced
+// by the generated apps-sync Kustomization (gitops.go) and by every per-Org
+// application HelmRelease already reconciling on every provisioned Sovereign,
+// so it deliberately does NOT change here — renaming it would strand those
+// references. It is centralised in one function so the customer-copy guard can
+// assert against the real name instead of a hand-written copy of it, and so the
+// mirror and its teardown can never drift apart.
+func vclusterKubeconfigSecretName(slug string) string {
+	return "tenant-" + slug + "-kubeconfig"
+}

--- a/core/services/provisioning/handlers/customer_facing_copy_5646_test.go
+++ b/core/services/provisioning/handlers/customer_facing_copy_5646_test.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/provisioning/store"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #5646 — the customer-facing vocabulary guard for the funnel timeline.
+//
+// WHAT THIS GUARD IS FOR, AND WHY IT IS NOT A GREP.
+//
+// The original defect was a string literal ("Creating tenant") and a grep would
+// have caught it. The half a grep CANNOT catch — and the half that was still
+// live on main when this guard was written — is the banned term arriving from a
+// runtime KUBERNETES OBJECT NAME. `failStep(..., err.Error())` writes a raw Go
+// error into the customer-visible `Message` field, those errors are built from
+// object names like `tenant-<slug>-kubeconfig`, and
+// ProvisioningTimeline.svelte:55 prints that field verbatim to a paying
+// customer. No source string ever contains the offending sentence; it is
+// assembled at runtime. Same class as #5435 (`deployment.apps/tenant`).
+//
+// So this guard asserts on the VALUE OF THE CUSTOMER-VISIBLE FIELD, and it
+// builds its inputs from the REAL production helpers (vclusterKubeconfigSecretName,
+// the real k8s error format, the real step-list builder) rather than from
+// hand-written strings — if someone renames the secret or reshapes the error,
+// the guard follows automatically instead of testing a stale copy.
+//
+// If the bug were present, could this go red? Yes — TestFailedStepMessage_*
+// below fails on a passthrough (pre-fix) customerFacingMessage; that red run is
+// pasted in the PR. And TestInternalIdentifiers_* is the CONTROL: it is green on
+// BOTH trees, and it fails if the "fix" is done by renaming the internal object
+// instead of the copy.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// bannedProductTerm is the docs/GLOSSARY.md §Banned-terms entry this guard
+// enforces on customer-facing copy: "tenant" → "Organization".
+//
+// Deliberately word-boundary anchored and case-insensitive so it also catches
+// the spellings that would evade a naive grep for the original sentence:
+// "Tenant", "TENANT", "tenants", "creating tenant", and the term embedded in a
+// hyphenated object name (`tenant-uatco-kubeconfig`) — the last one is the
+// whole point, since that is the spelling the runtime produces.
+var bannedProductTerm = regexp.MustCompile(`(?i)tenant`)
+
+// customerVisibleFields returns every string in a provisioning record that the
+// funnel renders to the customer. Kept in one place so a new rendered field is
+// added here rather than silently escaping the guard.
+//
+// Both fields are drawn by the funnel: LaunchingStep/ProvisioningTimeline print
+// `Name` for every step and `Message` for any failed step.
+func customerVisibleFields(steps []store.ProvisionStep) map[string]string {
+	out := map[string]string{}
+	for i, s := range steps {
+		out[fmt.Sprintf("steps[%d].name", i)] = s.Name
+		out[fmt.Sprintf("steps[%d].message", i)] = s.Message
+	}
+	return out
+}
+
+// realInternalErrors reproduces, using the production string formats and the
+// production object-name builder, the errors that actually reach failStep /
+// failProvision on a failed provision. Nothing here is invented copy: each entry
+// cites the code path that emits it.
+func realInternalErrors(slug string) []string {
+	secret := vclusterKubeconfigSecretName(slug)
+
+	// handlers.go:964 — the error k8sRequest returns on any >=400 response.
+	k8sErr := func(method, path string, code int) string {
+		return fmt.Sprintf("k8s %s %s: status %d: %s", method, path, code,
+			`{"kind":"Status","message":"internal error"}`)
+	}
+
+	return []string{
+		// mirrorVClusterKubeconfig PUT branch (handlers.go) wrapped by
+		// `update mirror secret (%s): %w`, reaching the customer through
+		// consumer.go's failStep on the "Provisioning vCluster" step.
+		fmt.Sprintf("update mirror secret (flux-system): %s",
+			k8sErr(http.MethodPut, "/api/v1/namespaces/flux-system/secrets/"+secret, 500)),
+
+		// mirrorVClusterKubeconfig POST branch, same customer field.
+		fmt.Sprintf("create mirror secret (%s): %s", slug,
+			k8sErr(http.MethodPost, "/api/v1/namespaces/"+slug+"/secrets", 403)),
+
+		// deleteVClusterKubeconfigMirror path, same object name.
+		k8sErr(http.MethodDelete, "/api/v1/namespaces/flux-system/secrets/"+secret, 409),
+
+		// consumer.go failProvision wrapper around the mirror error.
+		fmt.Sprintf("mirror kubeconfig to flux-system: read source secret %s/vc-vcluster: %s",
+			slug, k8sErr(http.MethodGet, "/api/v1/namespaces/"+slug+"/secrets/vc-vcluster", 404)),
+	}
+}
+
+// TestFailedStepMessage_NoBannedTermFromRuntimeObjectNames is the RED half.
+//
+// It pushes the errors the real code paths produce through the production
+// customer-copy boundary and asserts the customer-visible value is free of the
+// banned term. With customerFacingMessage reduced to a passthrough (which is
+// exactly what main did before this change) every case below fails.
+func TestFailedStepMessage_NoBannedTermFromRuntimeObjectNames(t *testing.T) {
+	const slug = "uatco" // the Org from the hw292 record that filed #5646
+
+	for _, raw := range realInternalErrors(slug) {
+		got := customerFacingMessage(raw)
+
+		if loc := bannedProductTerm.FindStringIndex(got); loc != nil {
+			t.Errorf(`banned term reached the customer-facing step message.
+  internal error : %s
+  rendered to customer: %s
+                        %s^-- %q
+  docs/GLOSSARY.md bans "tenant" on product surfaces; the correction is "Organization".
+  ProvisioningTimeline.svelte prints step.message verbatim, so this string IS product copy.`,
+				raw, got, strings.Repeat(" ", loc[0]), got[loc[0]:loc[1]])
+		}
+
+		if strings.TrimSpace(got) == "" {
+			t.Errorf("customer message for %q was redacted to nothing — the customer needs a reason, not a blank", raw)
+		}
+	}
+}
+
+// TestFailedStepMessage_KeepsTheDiagnostic checks the redaction stayed useful.
+// A guard that passes by blanking every message would be worse than the bug, so
+// the status code (the one genuinely actionable token) must survive.
+func TestFailedStepMessage_KeepsTheDiagnostic(t *testing.T) {
+	raw := fmt.Sprintf("update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/secrets/%s: status 500: boom",
+		vclusterKubeconfigSecretName("uatco"))
+
+	got := customerFacingMessage(raw)
+	if !strings.Contains(got, "500") {
+		t.Errorf("redaction dropped the status code — customer message %q is no longer diagnostic", got)
+	}
+	if !strings.Contains(got, "mirror secret") {
+		t.Errorf("redaction dropped the failing operation — customer message %q says nothing about what broke", got)
+	}
+}
+
+// TestProvisionStepNames_NoBannedTerm covers the literal half of the issue: the
+// step list the producer emits. It asserts on the names the funnel actually
+// draws, so a future edit that reintroduces "Creating tenant" is caught here
+// and not on a customer's screen.
+func TestProvisionStepNames_NoBannedTerm(t *testing.T) {
+	// The shipped step list (consumer.go startProvisioning) with the runtime-
+	// interpolated entries filled from the live hw292 catalog: dependency slugs
+	// come from the catalog verbatim, app names from the catalog display title.
+	emitted := []store.ProvisionStep{
+		{Name: "Creating Organization"},
+		{Name: "Committing manifests to Git"},
+		{Name: "Provisioning vCluster"},
+		{Name: fmt.Sprintf("Installing %s (dependency)", "mysql")},
+		{Name: fmt.Sprintf("Deploying %s", appDisplayName(map[string]string{"wp": "WordPress"}, "wp"))},
+		{Name: "Configuring TLS certificates"},
+		{Name: "Running health checks"},
+	}
+
+	for field, val := range customerVisibleFields(emitted) {
+		if bannedProductTerm.MatchString(val) {
+			t.Errorf("banned term in customer-visible %s = %q (docs/GLOSSARY.md: use \"Organization\")", field, val)
+		}
+	}
+}
+
+// TestInternalIdentifiers_AreNotRenamed is the CONTROL, and it must be GREEN ON
+// BOTH TREES — before and after the fix.
+//
+// The legitimate internal uses of the word must survive untouched: the mirrored
+// kubeconfig Secret is referenced by the generated apps-sync Kustomization and
+// by every per-Org application HelmRelease already reconciling on provisioned
+// Sovereigns. Fixing the customer's screen by renaming that object would strand
+// them. This control fails if anyone "fixes" the banned term at the identifier
+// layer instead of the copy layer — which is the wrong layer.
+func TestInternalIdentifiers_AreNotRenamed(t *testing.T) {
+	const slug = "uatco"
+
+	got := vclusterKubeconfigSecretName(slug)
+	if want := "tenant-" + slug + "-kubeconfig"; got != want {
+		t.Fatalf(`the INTERNAL vCluster kubeconfig Secret name changed: got %q, want %q.
+  This name is referenced by gitops.go's apps-sync Kustomization and by every
+  per-Org application HelmRelease on every already-provisioned Sovereign.
+  #5646 is a COPY defect: fix what the customer reads (customerFacingMessage),
+  never the object identity.`, got, want)
+	}
+
+	// And the copy boundary must not corrupt an internal identifier by rewriting
+	// it in place into a name that does not exist anywhere.
+	if strings.Contains(customerFacingMessage("k8s GET /api/v1/namespaces/flux-system/secrets/"+got+": status 404: x"),
+		"organization-"+slug+"-kubeconfig") {
+		t.Error("customerFacingMessage invented a renamed object name; it must redact the internal reference, not rewrite it into a fiction")
+	}
+}
+
+// TestBannedTermPattern_IsNotVacuous is the vacuity check. An absence-assertion
+// reports clean both when the term is absent AND when the matcher stopped
+// working. If bannedProductTerm is ever broken, every test above passes forever
+// on nothing — so prove it still matches the spellings that actually shipped,
+// and still ignores clean copy.
+func TestBannedTermPattern_IsNotVacuous(t *testing.T) {
+	mustMatch := []string{
+		"Creating tenant",                                 // the #5646 headline string
+		"Creating Tenant",                                 // case variant
+		"Console (my tenants)",                            // the funnel header string
+		"secrets/tenant-uatco-kubeconfig",                 // runtime object name (#5435 class)
+		"helmrelease tenant-f4179walk/vcluster not ready", // the 2026-06-24 live sighting
+	}
+	for _, s := range mustMatch {
+		if !bannedProductTerm.MatchString(s) {
+			t.Errorf("banned-term matcher no longer matches %q — every assertion in this file would pass on nothing", s)
+		}
+	}
+
+	mustNotMatch := []string{
+		"Creating Organization",
+		"Installing mysql (dependency)",
+		"platform API returned status 500",
+		"Provisioning vCluster",
+	}
+	for _, s := range mustNotMatch {
+		if bannedProductTerm.MatchString(s) {
+			t.Errorf("banned-term matcher is too broad: it flags clean copy %q and would fail every run", s)
+		}
+	}
+}

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -988,7 +988,7 @@ func (h *Handler) mirrorVClusterKubeconfig(ctx context.Context, tenantSlug strin
 	// Kustomization (generateAppsSyncKustomization) references.
 	srcNS := tenantSlug
 	srcName := "vc-vcluster"
-	dstName := "tenant-" + tenantSlug + "-kubeconfig"
+	dstName := vclusterKubeconfigSecretName(tenantSlug)
 
 	srcBody, err := h.k8sGet(fmt.Sprintf("/api/v1/namespaces/%s/secrets/%s", srcNS, srcName))
 	if err != nil {
@@ -1063,5 +1063,5 @@ func (h *Handler) mirrorVClusterKubeconfig(ctx context.Context, tenantSlug strin
 // tenant teardown. 404 is treated as success (already gone).
 func (h *Handler) deleteVClusterKubeconfigMirror(ctx context.Context, tenantSlug string) error {
 	return h.k8sDelete(fmt.Sprintf(
-		"/api/v1/namespaces/flux-system/secrets/tenant-%s-kubeconfig", tenantSlug))
+		"/api/v1/namespaces/flux-system/secrets/%s", vclusterKubeconfigSecretName(tenantSlug)))
 }


### PR DESCRIPTION
## Status of the filed defect: REFUTED on `main`, still true on the deployed build

#5646's headline string, "Creating tenant" in the funnel provisioning timeline, is **already fixed on `main`** — `c93634751` / PR #5673, merged 2026-08-05. `core/services/provisioning/handlers/consumer.go:1313` reads `Creating Organization`, and the repo-wide sweep for the literal returns only session-evidence documents.

Classification: **(b) fixed in `main`, undeployed.** hw292 runs the 2026-08-02 bundle, older than the fix. Re-confirmed live today, read-only:

```
$ curl -s https://marketplace.hw292.omani.works/api/provisioning/tenant/339cba9f-051a-4492-b447-b57301ae9e23
status= failed progress= 100
  completed  Creating tenant            <-- pre-#5673 build
  completed  Committing manifests to Git
  completed  Provisioning vCluster
  failed     Installing mysql (dependency)
  completed  Deploying WordPress
  completed  Configuring TLS certificates
  completed  Running health checks
```

So this PR does not re-fix that label. It ships what the three-way sweep found still live on `main`, plus the guard that would have caught both.

## Three-way sweep

**(a) Source strings.** `Creating tenant` is gone. But `core/marketplace/src/components/Header.svelte:232` renders **"Console (my tenants)"** in the account menu of every signed-in customer in the funnel. Rendered text, not an identifier, present on `main`. Fixed here.

**(b) Runtime Kubernetes object names — the leak a grep cannot see.** `failStep` / `failProvision` write a **raw Go error** into `ProvisionStep.Message`, and `ProvisioningTimeline.svelte:55` prints that field verbatim for any failed step:

```svelte
{#if step.status === 'failed' && step.message && step.message !== 'ok'}
  <span class="... text-[var(--color-danger)]">{step.message}</span>
```

Those errors are assembled at runtime from object names. `mirrorVClusterKubeconfig` mirrors a Secret named `tenant-<slug>-kubeconfig`, and `k8sRequest` formats failures as `k8s %s %s: status %d: %s` — **including the path**. A failed mirror therefore reaches a paying customer's screen as:

```
update mirror secret (flux-system): k8s PUT
/api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: ...
```

No string literal anywhere contains that sentence. Confirmed live on hw292, read-only — the object is real, in two namespaces:

```
$ kubectl get secret,configmap,deployment,statefulset,service,job,ingress,kustomization,helmrelease -A -o name | grep -i tenant
secret/openova-org-tenants-git-auth
secret/tenant-uatco-kubeconfig          <-- flux-system
secret/tenant-uatco-kubeconfig          <-- uatco
deployment.apps/tenant
service/tenant
kustomization.../catalyst-tenant-uatco-apps
... 20 live objects total
```

Same class as #5435, where `deployment.apps/tenant` reached the showback table the same way. Fixed here.

**(c) API-emitted step labels.** Two producers only: `consumer.go:1313` (clean since #5673) and `core/marketplace-api/handlers/handlers.go:156` ("Creating virtual cluster", clean). The two runtime-interpolated labels are `Installing %s (dependency)` (raw catalog dependency slug) and `Deploying %s` (catalog display title). Checked against the live hw292 catalog — all 35 apps: dependency slugs are `mysql`, `postgres`, `redis`; no app display name carries the term. Clean today, and now guarded, since both are catalog-driven and admin-editable.

## Which layer is fixed, and which is deliberately left

**Fixed — presentation only.** `customerFacingMessage()` drops the Kubernetes plumbing from the customer-visible message and rewrites the term. The status code and the failing operation survive, so it stays diagnostic:

```
BEFORE: update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: {"kind":"Status","message":"internal error"}
AFTER : update mirror secret (flux-system): platform API returned status 500: {"kind":"Status","message":"internal error"}

BEFORE: k8s DELETE /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 409: {...}
AFTER : platform API returned status 409: {...}
```

The unabridged error still goes to `slog.Error` for the sovereign-admin, so no diagnostic is lost.

**Deliberately NOT fixed — internal identity.** `tenant-<slug>-kubeconfig` is referenced by the generated apps-sync Kustomization (`gitops.go`) and by every per-Org application HelmRelease on already-provisioned Sovereigns; renaming it would strand them. Likewise `core/services/tenant/` (#5729), `deployment.apps/tenant`, `service/tenant`, the `/api/provisioning/tenant/<id>` route, and the `Tenant` TypeScript type. All are separate changes with much larger blast radius. The name is now centralised in `vclusterKubeconfigSecretName()` so the mirror and its teardown cannot drift, and so the guard asserts against the real name rather than a copy of it.

## The guard — both directions, real output

Two guards. Neither is a grep, because the defect in (b) has no source text to match, and because this tree has ~30 legitimate uses of the word as an identifier (`/tenant/orgs`, `org-checkout-tenant`, the `Tenant` type, `html[data-tenant]`, comments). A guard that flagged those would be switched off within a week.

### RED on the pre-fix tree

**Go** — `customerFacingMessage` reduced to a passthrough, which is exactly what `main` does:

```
=== RUN   TestFailedStepMessage_NoBannedTermFromRuntimeObjectNames
    customer_facing_copy_5646_test.go:112: banned term reached the customer-facing step message.
          internal error : update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: {"kind":"Status","message":"internal error"}
          rendered to customer: update mirror secret (flux-system): k8s PUT /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 500: {"kind":"Status","message":"internal error"}
                                                                                                                   ^-- "tenant"
          docs/GLOSSARY.md bans "tenant" on product surfaces; the correction is "Organization".
          ProvisioningTimeline.svelte prints step.message verbatim, so this string IS product copy.
    customer_facing_copy_5646_test.go:112: banned term reached the customer-facing step message.
          internal error : k8s DELETE /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 409: {"kind":"Status","message":"internal error"}
          rendered to customer: k8s DELETE /api/v1/namespaces/flux-system/secrets/tenant-uatco-kubeconfig: status 409: {"kind":"Status","message":"internal error"}
                                                                                  ^-- "tenant"
--- FAIL: TestFailedStepMessage_NoBannedTermFromRuntimeObjectNames (0.00s)
=== RUN   TestInternalIdentifiers_AreNotRenamed
--- PASS: TestInternalIdentifiers_AreNotRenamed (0.00s)          <-- CONTROL, green
=== RUN   TestBannedTermPattern_IsNotVacuous
--- PASS: TestBannedTermPattern_IsNotVacuous (0.00s)             <-- vacuity, green
FAIL
```

**vitest** — `Header.svelte` reverted to the string on `main`:

```
 ❯ src/lib/renderedCopy.test.ts (29 tests | 1 failed) 243ms
     × components/Header.svelte renders no banned term 16ms

AssertionError: components/Header.svelte renders the banned term "tenant" to a customer.
  [text] Console (my tenants)
docs/GLOSSARY.md §Banned-terms: use "Organization".
If this is an INTERNAL identifier (API path, storage key, type name, comment, data-attribute) it should not be reaching rendered text at all.

- Expected
+ Received
- []
+ [ { "kind": "text", "text": "Console (my tenants)" } ]

 Tests  1 failed | 28 passed (29)
```

Note what stayed green in that same run against the **real** `Header.svelte`: its `<!-- Logo (tenant-aware: ... html[data-tenant=...] ... ) -->` comment and its `data-tenant` attribute were not flagged. That is the control working on production code, not on a fixture.

### GREEN on the fixed tree

```
$ go test ./...   # core/services/provisioning
ok  github.com/openova-io/openova/core/services/provisioning/gitguard  0.014s
ok  github.com/openova-io/openova/core/services/provisioning/github    0.344s
ok  github.com/openova-io/openova/core/services/provisioning/gitops    0.012s
ok  github.com/openova-io/openova/core/services/provisioning/handlers  0.457s
ok  github.com/openova-io/openova/core/services/provisioning/store     0.003s

$ npm test   # core/marketplace
 Test Files  4 passed (4)
      Tests  76 passed (76)

$ npm run build
[build] 11 page(s) built in 1.63s
[domain-hygiene] OK — 37 served file(s) scanned, zero banned domain literals (#3376).
```

### Why these can go red, and why they cannot pass on nothing

- **Asserts on output, not source.** The Go guard asserts on the value of the customer-visible field, building its inputs from the production helpers (`vclusterKubeconfigSecretName`, the real `k8s %s %s: status %d` format) — rename the Secret or reshape the error and the guard follows instead of testing a stale copy. The vitest guard asserts on text extracted by Svelte's own parser, so "is this markup or script" is the compiler's judgement, not a regex approximation.
- **Every branch, not one render.** The AST walk covers `{#if}` / `{:else}` / `{#each}`; an SSR-render-and-scan only exercises the branch its props select, and the offending string may sit in the other one. Pinned by a vacuity test that puts the term in an `{:else}`.
- **Spellings that evade a naive search.** The matchers are case-insensitive and not word-anchored, so `Tenant`, `TENANT`, `tenants`, and the hyphenated runtime object name `tenant-uatco-kubeconfig` all trip. Pinned by `TestBannedTermPattern_IsNotVacuous` against five real spellings including the 2026-06-24 live sighting `helmrelease tenant-f4179walk/vcluster not ready`.
- **The controls are load-bearing.** `TestInternalIdentifiers_AreNotRenamed` fails if anyone "fixes" the term by renaming the Kubernetes object — the wrong layer. The vitest control pins that script identifiers, comments, `data-*` and API paths stay unflagged, and additionally that the extractor still returns the real copy (so it cannot pass by returning nothing). `finds the funnel components` fails if the glob ever scans an empty set.
- **A blanking redaction would fail too.** `TestFailedStepMessage_KeepsTheDiagnostic` requires the status code and the failing operation to survive, so the guard cannot be satisfied by emptying every message.

### The checks actually RUN

- Go: `.github/workflows/test-provisioning-service.yaml` already triggers on `pull_request` with `paths: core/services/provisioning/**`. The new test lands inside that path.
- vitest: **nothing ran `core/marketplace`'s suite at all.** `marketplace-build.yaml` matches `core/marketplace/**` but only builds and pushes the image, on push-to-main, with no test step and no `pull_request` trigger — so `redeemPreview.test.ts`, `redeemOwnerGate.test.ts` and `rateLimitNotice.test.ts` could go red on `main` indefinitely with nothing turning red. Same fail-open gap #5439 closed for `core/services/provisioning`. This PR adds `test-marketplace-funnel.yaml` (`pull_request` + `push`, `paths: core/marketplace/**`), with a plain `npm test` and no `|| true` — the `|| echo WARN` form is what let four source defects sit behind a green catalyst-build vitest gate for two months.

## Walk assertion for #5646 (stays OPEN)

Falsifiable, deploy-gated on a fresh prov carrying this branch:

> On the funnel `/launching` page after checkout, the first timeline step reads exactly **`Creating Organization`**, and `GET /api/provisioning/tenant/<id>` returns that same string in `steps[0].name`. If any step fails, the red text under it contains no occurrence of `tenant` in any case — in particular a failed kubeconfig mirror reads `... platform API returned status <code>` and never `.../secrets/tenant-<slug>-kubeconfig`. Signed in, the account menu reads **`Console (my Organizations)`**.

hw292 cannot serve this proof: it predates both #5673 and this branch.

Refs #5646 #5673 #5435 #5439 #5729
