### PR TITLE
ci: 8 Go modules and the sovereign-admin console had no PR-time test gate

### DIFF
--- a/.github/workflows/test-ungated-trees.yaml
+++ b/.github/workflows/test-ungated-trees.yaml
@@ -116,7 +116,18 @@ jobs:
           set -o pipefail
           go test -count=1 -v ./... 2>&1 | tee /tmp/out.txt
           n=$(grep -c '^--- PASS' /tmp/out.txt || true)
-          echo "::notice::${{ matrix.module }} ran ${n} test functions"
+          s=$(grep -c '^--- SKIP' /tmp/out.txt || true)
+          echo "::notice::${{ matrix.module }} ran ${n} test functions, skipped ${s}"
+          # Skips are reported, never hidden. core/pool-domain-manager declares
+          # 187 tests but executes 180: the 7 covering reserve / conflict /
+          # expiry / commit / token-mismatch / release / sweeper are Postgres
+          # integration tests gated on `PDM_TEST_DSN`, and because this module
+          # had no workflow at all they have never run anywhere. A gate that
+          # printed a clean "180 passed" would be the same lie in a new place.
+          # Wiring a Postgres service container for them is tracked on #5741.
+          if [ "${s:-0}" -gt 0 ]; then
+            grep '^--- SKIP' /tmp/out.txt | sed 's/^/::warning::skipped: /'
+          fi
           if [ "${n:-0}" -eq 0 ]; then
             echo "::error::${{ matrix.module }} reported zero executed tests — the suite vanished or stopped being discovered; go test exits 0 in that case, so this check is what catches it."
             exit 1

--- a/.github/workflows/test-ungated-trees.yaml
+++ b/.github/workflows/test-ungated-trees.yaml
@@ -1,0 +1,148 @@
+name: Test — trees with no PR-time gate (#5741)
+
+# WHY THIS EXISTS
+#
+# A repo-wide enumeration on 2026-08-06 (PRINCIPLES III.4, the #5010 shape)
+# found that large parts of the tree had unit suites which NO workflow ran at
+# PR time — 40 Go test files / 304 test funcs across 8 modules, plus the
+# sovereign-admin console's 222 vitest files / 1977 cases. A pull request
+# could change any of them and nothing red could appear.
+#
+# That is the limiting case of the defect class that dominated that session:
+# a guard that cannot go red. A test that never executes is a guard that can
+# never go red, and it is invisible precisely because the suite exists and
+# looks like coverage.
+#
+# Two independent instances triggered the sweep rather than a third being
+# waited for:
+#   - `core/services/**` had no PR-time Go gate  (#5733, provisioning only)
+#   - `core/marketplace`'s vitest ran in no workflow at all (#5646 / PR #5740)
+#
+# THE TRAP THIS FILE IS BUILT TO AVOID (#5515)
+#
+# Trigger breadth is NOT assertion breadth. All seven controller workflows
+# already *trigger* on `core/controllers/pkg/**`, but every one of them scoped
+# its `run:` to `./<x>/... ./internal/...` — so the canonical placement model's
+# only real coverage rode `build-sandbox-controller.yaml`, the build for a
+# product deleted 2026-06-30. Here the `paths:` list and the thing actually
+# executed are kept deliberately in lockstep, one module per matrix entry.
+#
+# NOT a duplicate of catalyst-build.yaml. That workflow does run the UI vitest
+# suite, fail-closed, with an empty KNOWN_RED allowlist — but it triggers on
+# `push: branches: [main]` only. Its own comment claims the gate makes a
+# regression "fail CI at PR time, not at operator-walk time"; the trigger block
+# contradicts the comment. This file is the PR-time half it describes.
+
+on:
+  pull_request:
+    paths:
+      - 'core/marketplace-api/**'
+      - 'core/pool-domain-manager/**'
+      - 'core/services/catalog/**'
+      - 'core/services/domain/**'
+      - 'core/services/gateway/**'
+      - 'core/services/metering-sidecar/**'
+      - 'core/services/notification/**'
+      - 'core/services/tenant/**'
+      - 'products/catalyst/bootstrap/ui/**'
+      - '.github/workflows/test-ungated-trees.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'core/marketplace-api/**'
+      - 'core/pool-domain-manager/**'
+      - 'core/services/catalog/**'
+      - 'core/services/domain/**'
+      - 'core/services/gateway/**'
+      - 'core/services/metering-sidecar/**'
+      - 'core/services/notification/**'
+      - 'core/services/tenant/**'
+      - 'products/catalyst/bootstrap/ui/**'
+      - '.github/workflows/test-ungated-trees.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-ungated-trees-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-modules:
+    name: go test — ${{ matrix.module }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # One entry per module that had NO PR-time gate. Each is its own Go
+        # module (there is no root go.mod in this repo), so each needs its own
+        # working-directory — a single `go test ./...` from the root would
+        # silently cover none of them.
+        module:
+          - core/marketplace-api
+          - core/pool-domain-manager
+          - core/services/catalog
+          - core/services/domain
+          - core/services/gateway
+          - core/services/metering-sidecar
+          - core/services/notification
+          - core/services/tenant
+    steps:
+      - uses: actions/checkout@v4
+
+      # `go-version-file`, not an explicit `go-version:` as most workflows in
+      # this repo use, because these eight modules do NOT agree: 1.22 for six
+      # of them, 1.23 for pool-domain-manager, 1.26.0 for services/tenant.
+      # Pinning one literal would build two of them under the wrong toolchain.
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache-dependency-path: ${{ matrix.module }}/go.sum
+
+      # `-count=1` defeats the test cache so a green here always means the
+      # suite actually ran on this SHA rather than replaying a cached result.
+      #
+      # The `--- PASS` assertion is this gate's own vacuity check, and it is
+      # not decoration. `go test ./...` exits 0 on a module with NO test files
+      # at all — it just prints `[no test files]`. Without the second check,
+      # a module whose suite is deleted, renamed out of `_test.go`, or moved
+      # behind a build tag would go on reporting green forever, which is the
+      # exact failure this whole workflow exists to end. A gate that cannot
+      # distinguish "everything passed" from "nothing ran" is not a gate.
+      - name: go test
+        working-directory: ${{ matrix.module }}
+        run: |
+          set -o pipefail
+          go test -count=1 -v ./... 2>&1 | tee /tmp/out.txt
+          n=$(grep -c '^--- PASS' /tmp/out.txt || true)
+          echo "::notice::${{ matrix.module }} ran ${n} test functions"
+          if [ "${n:-0}" -eq 0 ]; then
+            echo "::error::${{ matrix.module }} reported zero executed tests — the suite vanished or stopped being discovered; go test exits 0 in that case, so this check is what catches it."
+            exit 1
+          fi
+
+  bootstrap-ui-vitest:
+    name: vitest — sovereign-admin console
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: products/catalyst/bootstrap/ui/package-lock.json
+
+      - name: Install
+        working-directory: products/catalyst/bootstrap/ui
+        run: npm ci
+
+      # Plain `npm test` (= `vitest run`). No `|| true`, no `|| echo WARN` —
+      # the 2026-06-02 emergency unblock in catalyst-build.yaml used exactly
+      # that shape and swallowed every failure for two months, which is how
+      # SettingsPage.test.tsx stayed red since a7fb48245 with nobody noticing.
+      - name: vitest
+        working-directory: products/catalyst/bootstrap/ui
+        run: npm test

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -399,6 +399,34 @@ These are OpenOva-platform-specific anti-patterns — concrete PR / issue receip
 
 **Guard:** `scripts/check-netpol-egress-completeness.py` renders every policy-bearing chart and asserts, per selected endpoint, that the union of its egress rules allows 53/UDP + 53/TCP to cluster DNS. It asserts on parsed **values** — a hollow `egress: []`, a `port: 53` aimed at the workload's own namespace, and a UDP-only rule are all FAIL — and its Phase 0 proves the classifier still bites five known-broken shapes before any verdict is trusted.
 
+### A18 — The guard that cannot go red
+
+| | |
+|---|---|
+| **Receipt** | 2026-08-06, **thirteen instances in one session**, seven distinct shapes. Named ones: #5591 (scan-vs-enforce), #5389 (CRD documents-but-admits), #5600 (self-agreeing synthetic map), #5609 (test hand-feeds a prop production never passes), #5515 (the unit suite *asserted* the fail-open), #5611 (`StorageClassesPage.test.tsx` asserted the empty state), #5741 (40 Go test files + 1977 vitest cases run by no PR-time workflow at all) |
+| **Shape** | A check exists, is named for the defect, and passes — because it was never able to observe the defect. The suite reads as coverage, which is exactly why nobody re-examines it. |
+| **Why this is wrong** | This is the mechanism by which *"already fixed"* issues stay broken. Almost every defect found on 2026-08-06 was in something believed fixed, and it survived because the thing looking for it could not fail. It defeats §7 at the root: the evidence that a surface is verified is itself fabricated, so re-verification reproduces the same false green forever. |
+| **Right fix shape** | Make the guard fail on the pre-fix tree **before** trusting it green on the post-fix tree, and keep a vacuity control in the same run so "assert nothing" cannot pass. Fix at the seam that decides the outcome, not at the surface that displays it. |
+
+**The one question that catches all seven shapes:** *if the bug were present, could this check have gone red?* Ask it of the check, not of the code.
+
+**The seven shapes, each with the tell:**
+
+1. **Scanned but never enforced** — the job runs a detector and discards its exit code. Tell: no `exit 1` on the finding path (#5591).
+2. **The fixture is a photocopy of the contract** — the test's expected value is generated from the same source as the actual. Tell: a helper builds both sides (#5600).
+3. **"Was anything patched" standing in for "was THIS patched"** — an existence assertion where an identity assertion was meant (#5389).
+4. **The product reshaped so the assertion passes** — the inverse: `must_contain` tokens satisfied by fabricating the tokens. See also A8 (#5609, #5731).
+5. **No gate at all for a whole tree** — the suite is real, comprehensive, and run by nothing at PR time. Tell: `paths:` names the tree but `run:` does not, or no workflow names it at all (#5741).
+6. **A reachable gate argued out of mattering** — "that job can't see my diff" asserted from its *name* rather than its `paths:`. Tell: the job is `in_progress` on your branch while you explain why it is irrelevant.
+7. **The test PINS the fail-open as correct** — the worst one, because the fix turns CI red and *looks* like the regression. Tell: `want:` names the behaviour you are removing (#5515: `{name: "empty targets — singleton", want: PatternSingleton}`; #5611: an assertion on the "not in the current informer set" empty state).
+
+**Two corollaries that produced wrong conclusions on their own:**
+
+- **Trigger breadth is not assertion breadth.** All seven controller workflows *trigger* on `core/controllers/pkg/**`; every one scoped its `run:` to `./<x>/... ./internal/...`. The canonical placement model's only real coverage therefore rode `build-sandbox-controller.yaml` — the build for a product deleted 2026-06-30. A model whose sole gate belongs to a deleted product is one file deletion from having none. Read the `run:` line, not the `paths:` list.
+- **A comment asserting a property is not the property.** `catalyst-build.yaml`'s vitest step says it makes a regression *"fail CI at PR time, not at operator-walk time"*; its trigger block is `push: branches: [main]`. The gate is real and fail-closed — it just runs after the merge it was meant to block. Same for source comments: #5515's `DerivePattern` was commented "display only" while being persisted to `spec.placement.mode` (no CRD enum) and selecting the BcpTopology that arms the Continuum DR contract.
+
+**Guard:** `.github/workflows/test-ungated-trees.yaml` runs the nine previously ungated trees at PR time, and carries its own vacuity check — `go test ./...` **exits 0 on a module with no test files**, so the step asserts `--- PASS` count > 0 and fails explicitly otherwise. Verified both directions: a real module reports its executed count; an empty module exits 0 and trips the assertion.
+
 ---
 
 ## Cross-cutting flags that trigger a "stop and investigate" pass
@@ -554,6 +582,7 @@ Mapping (Anti-pattern → Principle it violates):
 | A15 (stable-state walk passed off as fresh-prov) | §7, Part IV rule 7 + [`DOD.md`](DOD.md) (operator-walked fresh-prov evidence) |
 | A16 (per-region secret on a shared VIP) | §2 (no workarounds), §7, Part III.4 (repo-wide enumeration on class recurrence) |
 | A17 (ingress-only policy in an egress-constrained namespace) | §2 (no workarounds), §7, Part III.4 (repo-wide enumeration on class recurrence) |
+| A18 (the guard that cannot go red) | §7 (verify before claiming done), §15 (real validators only), Part IV rule 1 (defensive shapes trigger investigation) |
 
 When you catch a new shape of failure in a PR review, add an A16+ entry here with the PR / issue number, the shape, why it's wrong, and the right fix shape. The catalog grows so the next session catches the same shape sooner.
 


### PR DESCRIPTION
## What

Adds a `pull_request` test gate for nine trees that had none.

## The gap

A PR could change any of these and nothing red could appear:

| Tree | test surface | named by a workflow? |
|---|---|---|
| `core/pool-domain-manager` | 16 files / **187** funcs | no — none, any trigger |
| `core/services/tenant` | 10 files / 50 funcs | no — none, any trigger |
| `core/services/notification` | 4 files / 23 funcs | no — none, any trigger |
| `core/services/catalog` | 4 files / 8 funcs | no — none, any trigger |
| `core/services/metering-sidecar` | 2 files / 14 funcs | no — none, any trigger |
| `core/services/domain` | 2 files / 11 funcs | no — none, any trigger |
| `core/services/gateway` | 1 file / 8 funcs | no — none, any trigger |
| `core/marketplace-api` | 1 file / 3 funcs | two, both push-only, zero test commands |
| `products/catalyst/bootstrap/ui` | 222 files / **1977** vitest cases | `catalyst-build.yaml`, **push-to-main only** |

`core/services/catalog` is where the #5716 `UpdateApp` empty-`tagline` persist lives. `core/pool-domain-manager` is the subdomain-pool reconciler behind the `.omani.*` tenant domains. `products/catalyst/bootstrap/ui` is the sovereign-admin console — per `CLAUDE.md`, where almost every operator-facing acceptance row lives.

## Why now

Two independent instances of the same shape landed hours apart from opposite directions — `core/services/**` had no PR-time Go gate (#5733), and `core/marketplace`'s vitest ran in no workflow at all (#5740). Two is a pattern, so I enumerated the repo instead of waiting for a third.

This is the limiting case of the defect class that dominated the session: **a guard that cannot go red**. A test that never executes can never go red, and it is invisible precisely because the suite exists and reads as coverage.

## What this is not

Not a duplicate of `catalyst-build.yaml`. That workflow genuinely runs the console vitest suite fail-closed with an empty `KNOWN_RED` allowlist. But it triggers on `push: branches: [main]`, while its own comment states the gate makes a regression *"fail CI at PR time, not at operator-walk time"*. The trigger block contradicts the comment. This is the PR-time half it describes; the push-time build is untouched.

## Current state — verified, not assumed

All nine trees **pass** today, run locally. No behaviour change here. The gap was that nothing would report it when that stopped being true.

## The gate's own vacuity check

`go test ./...` **exits 0 on a module with no test files** — it just prints `[no test files]`. So a suite that is deleted, renamed out of `_test.go`, or moved behind a build tag would report green forever. The step therefore asserts `--- PASS` count > 0 and fails with an explicit message otherwise.

Proven both directions locally:
- `core/services/gateway` → `8` executed test funcs, assertion passes
- a module with no tests → `go test` exits **0** with `[no test files]`, PASS count `0`, assertion fires

## Trap deliberately avoided (#5515)

Trigger breadth is not assertion breadth. All seven controller workflows already *trigger* on `core/controllers/pkg/**`, yet every one scoped its `run:` to `./<x>/... ./internal/...` — so the canonical placement model's only real coverage rode `build-sandbox-controller.yaml`, the build for a product deleted 2026-06-30. Here `paths:` and the executed command are kept in lockstep, one module per matrix entry.

`go-version-file` rather than a literal: the eight modules do not agree (1.22 ×6, 1.23 pool-domain-manager, 1.26.0 services/tenant).

Refs #5741 #960 #5515 #5646
