### PR TITLE
ci: auto-close guard read neither commit messages nor the past-tense keywords

### DIFF
--- a/.github/workflows/pr-body-validate.yaml
+++ b/.github/workflows/pr-body-validate.yaml
@@ -68,7 +68,7 @@ jobs:
           # Detect GitHub auto-close keywords with a whitespace/start
           # boundary, followed by whitespace and a #NNN reference.
           # Mirrors GH's documented closing-keyword grammar.
-          PATTERN='(^|[[:space:]])(Closes|Fixes|Resolves|Close|Fix|Resolve)[[:space:]]+#[0-9]+'
+          PATTERN='(^|[[:space:]])(Closes|Closed|Close|Fixes|Fixed|Fix|Resolves|Resolved|Resolve)[[:space:]]+#[0-9]+'
 
           if printf '%s' "${PR_BODY:-}" | grep -iqE "${PATTERN}"; then
             echo ""
@@ -103,3 +103,80 @@ jobs:
           fi
 
           echo "OK — PR body does not use Closes/Fixes/Resolves keywords."
+
+  no-auto-close-keywords-commits:
+    name: Reject Closes/Fixes/Resolves in commit messages on this PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      # WHY THIS JOB EXISTS (#5744)
+      #
+      # The job above inspects `github.event.pull_request.body` and nothing
+      # else. But on a SQUASH merge — this repo's merge mode — GitHub composes
+      # the squash commit message from the BRANCH COMMIT MESSAGES, and it is
+      # that text GitHub parses for closing keywords. So a PR body that
+      # correctly says `Refs #N` still auto-closes #N if any commit on the
+      # branch says `fixed #N`.
+      #
+      # Not hypothetical: PR #5738's commit body line 3 read
+      #   "PR #5662 fixed #5661 with 12 lines in StepReview.tsx"
+      # — prose ABOUT an earlier PR, not an instruction — and #5661 closed on
+      # merge. The body gate passed correctly the whole time. It reads as full
+      # coverage of "this PR cannot auto-close an issue" and is half of it.
+      #
+      # That is `docs/PRINCIPLES.md` A18 shape 5: the check that cannot go red
+      # for the path the defect actually takes.
+      - name: Checkout (full history for commit range)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Inspect commit messages for auto-close keywords
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -u
+
+          echo "PR #${PR_NUMBER}"
+          echo "Range: ${BASE_SHA}..${HEAD_SHA}"
+
+          # Same grammar as the PR-body job above — keep the two in step.
+          PATTERN='(^|[[:space:]])(Closes|Closed|Close|Fixes|Fixed|Fix|Resolves|Resolved|Resolve)[[:space:]]+#[0-9]+'
+
+          # %B = full message (subject + body). A conventional-commit subject
+          # like `fix(scope): ...` cannot match: the pattern requires
+          # whitespace before the keyword and `#NNN` after it.
+          HITS=$(git log --format='%H%n%B%n--' "${BASE_SHA}..${HEAD_SHA}" \
+                 | grep -inE "${PATTERN}" || true)
+
+          if [ -n "${HITS}" ]; then
+            echo ""
+            echo "Detected auto-close keyword in a commit message on this branch:"
+            printf '%s\n' "${HITS}"
+            echo ""
+            if printf '%s' "${PR_LABELS}" | tr ',' '\n' | grep -qx "ci-gate-exception"; then
+              echo "Label 'ci-gate-exception' is present — guard ALLOWS this PR."
+              exit 0
+            fi
+
+            echo "::error::A commit message uses an auto-close keyword (Closes/Fixes/Resolves) but the PR lacks the 'ci-gate-exception' label."
+            echo ""
+            echo "On squash merge GitHub parses the COMMIT text, not just the PR"
+            echo "body — so this closes the issue on merge even when the PR body"
+            echo "correctly says 'Refs #N'. Auto-close bypasses the operator-walk"
+            echo "DoD: issues close only after the walk-with-screenshot lands."
+            echo ""
+            echo "How to fix:"
+            echo "  1. Reword the commit(s): 'fixed #N' -> 'Refs #N', or when"
+            echo "     referring to earlier work, name it without the keyword —"
+            echo "     'PR #5662 addressed #5661' rather than 'fixed #5661'."
+            echo "     git commit --amend, or git rebase -i for older commits."
+            echo "  2. OR add 'ci-gate-exception' if this PR genuinely has no"
+            echo "     operator-visible surface."
+            exit 1
+          fi
+
+          echo "OK — no commit message on this branch uses Closes/Fixes/Resolves."


### PR DESCRIPTION
Closes the two holes that let issue **5661 auto-close itself** on the merge of PR #5738, even though that PR's body correctly used `Refs`. Either hole alone was sufficient.

## Hole 1 — the gate never reads commit messages

`no-auto-close-keywords` inspects `github.event.pull_request.body` and nothing else. On a **squash merge**, GitHub composes the squash commit message from the **branch commit messages**, and that is the text it parses for closing keywords.

PR #5738's commit body line 3:

```
PR #5662 fixed #<ref> with 12 lines in StepReview.tsx and shipped no test.
```

Prose *about an earlier PR*. It closed the issue. The body gate passed correctly the whole time — it reads as full coverage of "this PR cannot auto-close an issue" and is half of it.

## Hole 2 — the pattern was missing a third of GitHub's keywords

```diff
-PATTERN='(^|[[:space:]])(Closes|Fixes|Resolves|Close|Fix|Resolve)[[:space:]]+#[0-9]+'
+PATTERN='(^|[[:space:]])(Closes|Closed|Close|Fixes|Fixed|Fix|Resolves|Resolved|Resolve)[[:space:]]+#[0-9]+'
```

GitHub honours **nine**: `close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved`. The gate covered six — `closed`, **`fixed`**, `resolved` were never matched. A PR body saying `fixed #5661` verbatim would have sailed through too.

## How hole 2 was found — worth reading

My first draft of the commit-message job **copied the existing six-keyword pattern**. Run against the actual commit that caused the incident, it produced **no match**. A synthetic `Fixes #123` fixture would have passed and I would have shipped a guard blind to the exact case that motivated it.

That is `docs/PRINCIPLES.md` **A18** — the guard that cannot go red — applied to the guard being written to enforce A18. The only thing that caught it was insisting the positive control be the **real** failing input.

## Proof, both directions, on real repo commits

| input | before | after |
|---|---|---|
| `ab3a5d619` — the commit behind this incident | no match | **match, line 4** |
| all 9 GitHub closing keywords | 6/9 | **9/9** |
| `5036a66a5` `d7edf36c5` `e58941fd1` `ca4562a2d` `79acd510c` `155a462e5` (real merges) | 0 hits | **0 hits** |
| `fix(cloud): counts (#5611)` · `Refs #5741` · `a fix for #12 landed` · `prefix #3` | 0 | **0** |

Conventional-commit subjects cannot false-positive: the grammar requires whitespace before the keyword and `#NNN` immediately after, so `fix(scope):` and `prefix #3` are both safe.

The new job reuses the existing `ci-gate-exception` escape hatch and the same `BASE_SHA..HEAD_SHA` range convention already used by `banned-words-commit-messages`.

Refs #5744 #5661 #960



## The guard fired on its own PR

The first push of this branch went **red on both jobs** — a PR documenting a closing-keyword incident necessarily quotes one. I redacted the refs rather than take `ci-gate-exception`, so this PR is itself proof the gate bites rather than a claim that it does.
