### PR TITLE
fix(stalwart-tenant): stop baking chart version into the immutable volumeClaimTemplate labels

### DIFF
--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -58,7 +58,18 @@ spec:
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
   # 0.1.14 (#5615): §854 — allocateLoadBalancerNodePorts:false + nodePort: 0
   # on the SMTP/IMAP LoadBalancer Services so the Kyverno guard admits them.
-  version: 0.1.14
+  # 0.1.15 (2026-08-06, live hw292 funnel Org uatco): the StatefulSet's
+  # volumeClaimTemplates[].metadata.labels rendered via the FULL labels
+  # helper, which embeds the chart version (helm.sh/chart) + appVersion
+  # (app.kubernetes.io/version). volumeClaimTemplates is IMMUTABLE
+  # post-create, so EVERY chart bump — including the 0.1.14 fix above —
+  # permanently blocked `helm upgrade` for any Org whose StatefulSet
+  # already exists ("Forbidden: updates to statefulset spec ... forbidden"),
+  # matching memory reference_stalwart_tenant_no_inplace_upgrade_and_
+  # splan_bundle_sizing.md's "cannot be upgraded in place" finding. Switched
+  # the PVC template to a new stableLabels helper carrying only
+  # version-independent labels. Refs #5615 #960.
+  version: 0.1.15
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -188,7 +188,33 @@ name: bp-stalwart-tenant
 #   entry (#5348 — false alone only stops NEW allocations; an apply that OMITS
 #   nodePort never clears an existing one); (c) template `fail` on
 #   type=NodePort so an overlay can never opt back in. Refs #5615 #5348 #5088.
-version: 0.1.14
+#
+# 0.1.15 (2026-08-06): re-diagnosed hw292 funnel Org uatco after 0.1.14 —
+#   uatco-mail-rtz-a's StatefulSet pod was STILL stuck ContainerCreating
+#   (`MountVolume.SetUp failed for volume "tls" : secret "stalwart-tls" not
+#   found`), release still pinned at 0.1.13 (chart-delivery gap, #5640, not a
+#   chart defect). But the LIVE StatefulSet had already been created by the
+#   failed 0.1.13 install, and templates/deployment.yaml's
+#   volumeClaimTemplates[].metadata.labels rendered via the FULL
+#   `bp-stalwart-tenant.labels` helper — which bakes in
+#   `helm.sh/chart: bp-stalwart-tenant-<Chart.Version>` +
+#   `app.kubernetes.io/version: <Chart.AppVersion>`. `spec.
+#   volumeClaimTemplates` is IMMUTABLE post-create (only 'replicas',
+#   'ordinals', 'template', 'updateStrategy',
+#   'persistentVolumeClaimRetentionPolicy', 'minReadySeconds' may change), so
+#   EVERY chart bump — including 0.1.14 above — changes that label and
+#   permanently blocks `helm upgrade` for any Org whose StatefulSet already
+#   exists ("Forbidden: updates to statefulset spec ... forbidden"). This is
+#   the mechanical cause of memory
+#   reference_stalwart_tenant_no_inplace_upgrade_and_splan_bundle_sizing.md's
+#   "CANNOT be upgraded in place" finding. Fix: new `stableLabels` helper
+#   (name/instance/managed-by/blueprint only, no version-bearing keys) used
+#   ONLY on the volumeClaimTemplate metadata; every other resource keeps the
+#   full `.labels` helper unchanged. Guard:
+#   tests/volumeclaimtemplate-stable-labels.sh renders the chart at two
+#   different versions and asserts the volumeClaimTemplates block is
+#   byte-identical. Refs #5615 #960.
+version: 0.1.15
 appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/templates/_helpers.tpl
+++ b/platform/stalwart-tenant/chart/templates/_helpers.tpl
@@ -37,6 +37,30 @@ catalyst.openova.io/blueprint: bp-stalwart-tenant
 {{- end }}
 
 {{/*
+STABLE labels for objects Kubernetes treats as IMMUTABLE post-create
+(currently: the StatefulSet's volumeClaimTemplates[].metadata). Live
+root-cause (hw292 funnel Org `uatco`, 2026-08-06): the full
+`bp-stalwart-tenant.labels` helper embeds `helm.sh/chart: <name>-<Chart.
+Version>` + `app.kubernetes.io/version: <Chart.AppVersion>` — both churn
+on every chart release. `spec.volumeClaimTemplates` only allows patches
+to 'replicas', 'ordinals', 'template', 'updateStrategy',
+'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' — ANY other
+diff (including a label-only one) makes `kubectl`/Helm's patch fail with
+`Forbidden: updates to statefulset spec ... forbidden`. Using the FULL
+labels helper there meant every future chart bump (e.g. the #5615 §854
+nodeport fix, 0.1.13 -> 0.1.14) would permanently block `helm upgrade`
+for any Org whose StatefulSet already exists — the mechanical reason
+this chart "has no in-place upgrade path". This helper carries only the
+labels that do NOT change across a chart version bump.
+*/}}
+{{- define "bp-stalwart-tenant.stableLabels" -}}
+app.kubernetes.io/name: {{ include "bp-stalwart-tenant.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-stalwart-tenant
+{{- end }}
+
+{{/*
 Selector labels.
 */}}
 {{- define "bp-stalwart-tenant.selectorLabels" -}}

--- a/platform/stalwart-tenant/chart/templates/deployment.yaml
+++ b/platform/stalwart-tenant/chart/templates/deployment.yaml
@@ -141,10 +141,19 @@ spec:
             # ContainerCreating until the cert exists is the correct
             # convergence behaviour and matches bp-stalwart-sovereign.
   volumeClaimTemplates:
+    # #5615-followup (2026-08-06, live hw292 funnel Org uatco): use the
+    # STABLE label subset here, never the full bp-stalwart-tenant.labels
+    # helper. volumeClaimTemplates[].metadata is immutable post-create on
+    # a StatefulSet — a version-bearing label (helm.sh/chart,
+    # app.kubernetes.io/version) here means EVERY future chart bump
+    # permanently blocks `helm upgrade` for any Org whose StatefulSet
+    # already exists ("Forbidden: updates to statefulset spec ...
+    # forbidden"). See templates/_helpers.tpl stableLabels + the
+    # volumeclaimtemplate-stable-labels.sh guard.
     - metadata:
         name: data
         labels:
-          {{- include "bp-stalwart-tenant.labels" . | nindent 10 }}
+          {{- include "bp-stalwart-tenant.stableLabels" . | nindent 10 }}
       spec:
         accessModes:
           {{- toYaml .Values.persistence.spool.accessModes | nindent 10 }}

--- a/platform/stalwart-tenant/chart/tests/volumeclaimtemplate-stable-labels.sh
+++ b/platform/stalwart-tenant/chart/tests/volumeclaimtemplate-stable-labels.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# bp-stalwart-tenant — volumeClaimTemplate label-churn guard.
+#
+# ROOT CAUSE (live evidence, hw292 funnel Org `uatco`, 2026-08-06):
+#
+# The StatefulSet's `volumeClaimTemplates[0].metadata.labels` renders via
+# the FULL `bp-stalwart-tenant.labels` helper (templates/_helpers.tpl),
+# which embeds `helm.sh/chart: bp-stalwart-tenant-<Chart.Version>` and
+# `app.kubernetes.io/version: <Chart.AppVersion>`.
+#
+# `spec.volumeClaimTemplates` is IMMUTABLE post-create on a StatefulSet —
+# the Kubernetes API only allows patches to 'replicas', 'ordinals',
+# 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and
+# 'minReadySeconds'. Baking the CHART VERSION into that immutable block
+# means EVERY future chart bump (e.g. the unrelated #5615 §854 nodeport
+# fix, 0.1.13 -> 0.1.14) changes the label value on the next `helm
+# upgrade`, and the apiserver rejects the patch with:
+#   "cannot patch ... with kind StatefulSet: ... Forbidden: updates to
+#    statefulset spec for fields other than 'replicas', 'ordinals',
+#    'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy'
+#    and 'minReadySeconds' are forbidden"
+#
+# This is the mechanical reason bp-stalwart-tenant "has NO in-place
+# upgrade path" (memory
+# reference_stalwart_tenant_no_inplace_upgrade_and_splan_bundle_sizing.md)
+# — and it means a per-Org Stalwart release that already has a
+# StatefulSet on disk (even one materialised by a FAILED install, as on
+# uatco/hw292: HelmRelease uatco-mail-rtz-a stayed pinned at
+# bp-stalwart-tenant@0.1.13 with a live StatefulSet pod stuck
+# ContainerCreating on the missing stalwart-tls secret) can NEVER
+# reconcile forward to a fixed chart version — the upgrade always fails
+# on this same immutable-field rejection, independent of whatever the
+# chart bump actually fixes.
+#
+# THE GUARD: render the chart twice — once at its current Chart.yaml
+# version, once at a synthetic "next" version/appVersion — and assert
+# the StatefulSet's volumeClaimTemplates block is BYTE-IDENTICAL across
+# the two renders. If it isn't, ANY future chart version bump is
+# guaranteed to break `helm upgrade` for every Org whose StatefulSet
+# already exists.
+#
+# Refs #5615 #960
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "[stalwart-tenant/volumeclaimtemplate-stable-labels] SKIP — yq not installed."
+  exit 0
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+render_a="${workdir}/render-current.yaml"
+render_b="${workdir}/render-bumped.yaml"
+bumped_chart="${workdir}/bumped-chart"
+
+# Render A: chart as-is (whatever Chart.Version/AppVersion main currently
+# pins). default values — the StatefulSet renders unconditionally
+# (stalwart.enabled defaults true; only Certificate/Ingress gate on an
+# empty tenant domain), so no values file is required.
+helm template smoke "${chart_dir}" --namespace smoke > "${render_a}"
+
+# Render B: a byte-copy of the chart with ONLY Chart.yaml's version +
+# appVersion bumped, simulating the next release. rsync/cp -a would also
+# copy charts/*.tgz (Chart.lock deps) — copy the whole tree so the
+# dependency resolves identically.
+cp -a "${chart_dir}" "${bumped_chart}"
+sed -i \
+  -e 's/^version: .*/version: 9.9.9-guard-probe/' \
+  -e 's/^appVersion: .*/appVersion: "9.9.9-guard-probe"/' \
+  "${bumped_chart}/Chart.yaml"
+helm template smoke "${bumped_chart}" --namespace smoke > "${render_b}"
+
+vct_a="${workdir}/vct-a.yaml"
+vct_b="${workdir}/vct-b.yaml"
+yq eval 'select(.kind == "StatefulSet") | .spec.volumeClaimTemplates' "${render_a}" > "${vct_a}"
+yq eval 'select(.kind == "StatefulSet") | .spec.volumeClaimTemplates' "${render_b}" > "${vct_b}"
+
+if [ ! -s "${vct_a}" ] || [ "$(cat "${vct_a}")" = "null" ]; then
+  echo "::error title=Stalwart volumeClaimTemplate guard::StatefulSet or its volumeClaimTemplates did not render — chart shape changed, update this guard."
+  exit 1
+fi
+
+if ! diff -u "${vct_a}" "${vct_b}" > "${workdir}/diff.txt"; then
+  echo "::error title=Stalwart volumeClaimTemplate immutable-label churn::volumeClaimTemplates[].metadata differs across a chart version bump — this WILL break every future 'helm upgrade' with 'Forbidden: updates to statefulset spec ... forbidden' for any Org whose StatefulSet already exists (e.g. hw292 funnel Org uatco, stuck on bp-stalwart-tenant@0.1.13)."
+  cat "${workdir}/diff.txt"
+  echo "[stalwart-tenant/volumeclaimtemplate-stable-labels] FAIL"
+  exit 1
+fi
+
+echo "[stalwart-tenant/volumeclaimtemplate-stable-labels] volumeClaimTemplates identical across a chart version bump — StatefulSet upgrades will not hit the immutable-field rejection."
+echo "[stalwart-tenant/volumeclaimtemplate-stable-labels] PASS"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T02:58:50.306Z",
+  "generatedAt": "2026-08-06T07:02:35.350Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4960,7 +4960,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5095,7 +5095,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2764,7 +2764,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.14"
+  version: "0.1.15"
   visibility: listed
   card:
     title: "Stalwart (per-Organization)"
@@ -2805,7 +2805,7 @@ is event-driven (ADR-0003 §3).
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-stalwart-tenant
-    version: "0.1.14"
+    version: "0.1.15"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## Summary

- Live-diagnosed the funnel Org `uatco`'s stuck-forever `bp-stalwart-tenant` Pod on hw292 (2-region, cutoverComplete=true). It is `ContainerCreating` for 2d14h+; kubelet Events repeat `MountVolume.SetUp failed for volume "tls" : secret "stalwart-tls" not found`, x1737 over 2d10h.
- The immediate proximate cause matches #5615 (chart still pinned at `bp-stalwart-tenant@0.1.13` on this Sovereign — a chart-delivery gap tracked separately). But the FAILED 0.1.13 install already materialised the StatefulSet before Helm hit the denied Services, and `templates/deployment.yaml`'s `volumeClaimTemplates[].metadata.labels` rendered the full `bp-stalwart-tenant.labels` helper — which bakes `helm.sh/chart: bp-stalwart-tenant-<Chart.Version>` + `app.kubernetes.io/version: <Chart.AppVersion>` into an **immutable** field.
- `spec.volumeClaimTemplates` only allows patches to `replicas`/`ordinals`/`template`/`updateStrategy`/`persistentVolumeClaimRetentionPolicy`/`minReadySeconds`. Baking the chart version there means **every** future chart bump — including the already-merged 0.1.14 §854 fix — permanently blocks `helm upgrade` for any Org whose StatefulSet already exists (`Forbidden: updates to statefulset spec ... forbidden`). This is the mechanical root cause behind memory `reference_stalwart_tenant_no_inplace_upgrade_and_splan_bundle_sizing.md`'s "cannot be upgraded in place" finding.
- Fix: new `stableLabels` helper (name/instance/managed-by/blueprint only — no version-bearing keys), used ONLY on the volumeClaimTemplate metadata. Every other resource keeps the existing full labels helper unchanged.
- Bumped the five lockstep sites 0.1.14 -> 0.1.15 (Chart.yaml, blueprint.yaml `spec.version`, catalog-seed `spec.version` + `source.version`, regenerated `blueprints.json` + `catalog.generated.ts`). No bootstrap-kit pin exists for this per-Org chart (confirmed via `check-bootstrap-kit-pin-sync.sh`'s skip list, matching PR #5625's own finding). 0.1.14 is the latest published `ghcr.io/openova-io/bp-stalwart-tenant` tag (verified via `gh api`); 0.1.15 publishes on merge.
- Region check: `uatco` has no `region-b` namespace/resources on hw292 at all (`placement: singleton`, `regions: [primary]`) — confirmed NOT an instance of the per-region-split defect class (#5394/#5406/#5414/#5416/#5511/#5591/#5599/#5602/#5611).
- **A separate, more proximate defect also blocks uatco's mail today**: the Application CR's `spec.parameters` is `{}` because the control-plane install door never populates `domain`/`keycloak` for `bp-stalwart-tenant`. That is a distinct surface (Go control-plane, not this chart) — filed as #5752 and fixed in a separate PR so this PR stays chart-scoped.

## Live evidence

```
$ kubectl -n uatco describe pod uatco-mail-rtz-a-bp-stalwart-tenant-0
...
Events:
  Type     Reason       Age                      From     Message
  ----     ------       ----                     ----     -------
  Warning  FailedMount  119s (x1737 over 2d10h)  kubelet  MountVolume.SetUp failed for volume "tls" : secret "stalwart-tls" not found

$ kubectl -n uatco get helmrelease uatco-mail-rtz-a -o jsonpath='{.spec.chart.spec.version}'
0.1.13
```

## Guard — red before, green after

`platform/stalwart-tenant/chart/tests/volumeclaimtemplate-stable-labels.sh` renders the chart at its current `Chart.yaml` version and again at a synthetic bumped version, then asserts the StatefulSet's `volumeClaimTemplates` block is byte-identical.

Red (pre-fix tree):
```
::error title=Stalwart volumeClaimTemplate immutable-label churn::volumeClaimTemplates[].metadata differs across a chart version bump ...
--- vct-a.yaml
+++ vct-b.yaml
@@ -1,10 +1,10 @@
 - metadata:
     name: data
     labels:
-      helm.sh/chart: bp-stalwart-tenant-0.1.14
+      helm.sh/chart: bp-stalwart-tenant-9.9.9-guard-probe
       app.kubernetes.io/name: bp-stalwart-tenant
       app.kubernetes.io/instance: smoke
-      app.kubernetes.io/version: "0.15.5"
+      app.kubernetes.io/version: "9.9.9-guard-probe"
       app.kubernetes.io/managed-by: Helm
       catalyst.openova.io/blueprint: bp-stalwart-tenant
   spec:
[stalwart-tenant/volumeclaimtemplate-stable-labels] FAIL
```

Green (post-fix):
```
[stalwart-tenant/volumeclaimtemplate-stable-labels] volumeClaimTemplates identical across a chart version bump — StatefulSet upgrades will not hit the immutable-field rejection.
[stalwart-tenant/volumeclaimtemplate-stable-labels] PASS
```

## Other gates run

- `helm lint platform/stalwart-tenant/chart` — 0 failed.
- Existing chart tests (`expression-syntax.sh`, `oidc-render.sh`) — both PASS, unaffected.
- `scripts/check-catalog-seed-lockstep.sh` — PASS (68 checked, 0 fail).
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASS (67 pairs; `bp-stalwart-tenant` correctly in the 30-chart "not in bootstrap kit" skip set).
- `scripts/check-live-nodeports.sh` against hw292 region-a and region-b — 0 live node ports in owned namespaces on either region (region-b's `forbid-nodeport-service=Audit` posture is the pre-existing, separately-tracked #5591 gap, not introduced or masked by this PR).
- `scripts/check-no-nodeports.sh` (full repo source scan) — run; result pasted in a follow-up comment once the (long-running) sweep completes.

## Nodeport discipline

This PR does not touch any Service/nodePort field — the §854 nodePort fix already merged in #5625 (chart 0.1.14). No NodePort of any kind is created, targeted, or relied upon by this change.

Refs #5615 #960
