### PR TITLE
fix(catalyst-api): stamp domain/keycloak parameters for a per-Org stalwart-mail install

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
@@ -145,6 +145,16 @@ func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug, orgConsole
 		stampOpenovaMCPOrgParameters(out, sovereignFQDN, orgSlug, orgConsoleHost)
 	}
 
+	// #5752 — bp-stalwart-tenant (catalog slug stalwart-mail) never had a
+	// case here, so a funnel install landed with parameters:{} — no
+	// domain.primary (the chart's certificate.yaml Certificate, and
+	// therefore the StatefulSet's non-optional stalwart-tls Secret mount,
+	// never renders without it) and no keycloak.realmURL (the Blueprint's
+	// OWN configSchema requires it). See stampStalwartTenantParameters.
+	if isStalwartTenantBlueprint(blueprint) {
+		stampStalwartTenantParameters(out, sovereignFQDN, orgConsoleHost)
+	}
+
 	// bp-postgres: seed `topology.mode` when the caller supplied NOTHING at all.
 	// Preserved verbatim from the #4283 shape — a caller that DID supply values
 	// keeps them, and we do not start declaring a mode where we previously
@@ -713,6 +723,106 @@ func isOpenovaMCPBlueprint(blueprint string) bool {
 	b := strings.TrimSpace(strings.ToLower(blueprint))
 	b = strings.TrimPrefix(b, "bp-")
 	return b == "openova-mcp"
+}
+
+// isStalwartTenantBlueprint reports whether the blueprint id refers to
+// bp-stalwart-tenant (with or without the `bp-` prefix). Catalog slug is
+// `stalwart-mail`; the Blueprint/chart name is `bp-stalwart-tenant` — this
+// checks the latter, matching the value both install doors actually pass
+// (Application.spec.blueprintRef.name / seed.Blueprint).
+func isStalwartTenantBlueprint(blueprint string) bool {
+	b := strings.TrimSpace(strings.ToLower(blueprint))
+	b = strings.TrimPrefix(b, "bp-")
+	return b == "stalwart-tenant"
+}
+
+// stalwartTenantSharedRealm is the realm name of the shared Sovereign
+// Keycloak realm every per-Org app in this codebase falls back to when
+// per-Org realms are disabled (CATALYST_PER_ORG_REALM_ENABLED=false, the
+// Sovereign default) — see auth.go's broker-login URL builder
+// (`https://auth.<sov-fqdn>/realms/sovereign/broker/...`) and the
+// openbao_sso_init_test.go / openbao/client_test.go fixtures, which already
+// exercise this exact issuer shape.
+const stalwartTenantSharedRealm = "sovereign"
+
+// stampStalwartTenantParameters populates the two parameter groups
+// bp-stalwart-tenant needs to actually converge on this Application-CR
+// install door — #5752, live-diagnosed on hw292 funnel Org `uatco`
+// (2026-08-06).
+//
+// THE BUG IT FIXES. `uatco-mail`'s Application CR installed through this
+// door with `spec.parameters: {}`. The chart's
+// `bp-stalwart-tenant.tenantDomain` helper reads `domain.primary` (or the
+// legacy/forward-looking aliases) and resolves to "" when none are set;
+// `templates/certificate.yaml` gates the WHOLE cert-manager Certificate for
+// `mail.<tenant-domain>` on that value being non-empty (smoke-render-safe by
+// design — CI's default-values render must stay valid). With an empty
+// domain the Certificate is never created, cert-manager never materialises
+// the `stalwart-tls` Secret, and the StatefulSet's non-optional `tls`
+// Secret volume mount blocks the Pod at ContainerCreating FOREVER — live
+// kubelet Events on hw292: `MountVolume.SetUp failed for volume "tls":
+// secret "stalwart-tls" not found`, repeated x1737 over 2d10h. Separately,
+// the chart's OWN configSchema (platform/stalwart-tenant/blueprint.yaml)
+// declares `required: [keycloak]` + `keycloak.required: [realmURL]` — an
+// empty parameters map does not even satisfy the Blueprint's own contract.
+//
+// THE FIX mirrors the proven stampAgenity*/stampOpenovaMCP* shape:
+//   - domain.primary + ingress.webmail.host — derived from orgConsoleHost
+//     the SAME way stampAgenityGateHost derives agenity.<slug>.<pool>
+//     (console.<slug>.<pool> → <slug>.<pool>): domain.primary = <slug>.
+//     <pool>, ingress.webmail.host = mail.<slug>.<pool>.
+//   - keycloak.realmURL — falls back to the shared Sovereign realm
+//     (stalwartTenantSharedRealm) every other per-Org app in this Sovereign
+//     already authenticates against under the default
+//     CATALYST_PER_ORG_REALM_ENABLED=false posture, rather than a per-Org
+//     realm host that is NXDOMAIN by default.
+//
+// Deference (same as every stampAgenity*/stampOpenovaMCP* sibling): every
+// field is set only when the caller did not already pin a non-empty value;
+// nothing here is forced onto an explicit install request. No-op on the
+// domain/ingress side when orgConsoleHost is empty or has no dotted zone
+// (mothership / Catalyst-Zero / registry-miss — fail-closed, matches the
+// chart's existing smoke-render-safe behaviour); no-op on the keycloak side
+// when sovereignFQDN is empty (same mothership case).
+func stampStalwartTenantParameters(params map[string]interface{}, sovereignFQDN, orgConsoleHost string) {
+	host := strings.ToLower(strings.TrimSpace(orgConsoleHost))
+	if host != "" {
+		// console.<slug>.<pool> -> <slug>.<pool>; require a dotted host so a
+		// bare label can't produce a zone-less domain (mirrors
+		// stampAgenityGateHost's guard).
+		if parts := strings.SplitN(host, ".", 2); len(parts) == 2 && parts[1] != "" {
+			orgZone := parts[1]
+
+			domain, _ := params["domain"].(map[string]interface{})
+			if domain == nil {
+				domain = map[string]interface{}{}
+			}
+			setIfAbsentString(domain, "primary", orgZone)
+			params["domain"] = domain
+
+			ingress, _ := params["ingress"].(map[string]interface{})
+			if ingress == nil {
+				ingress = map[string]interface{}{}
+			}
+			webmail, _ := ingress["webmail"].(map[string]interface{})
+			if webmail == nil {
+				webmail = map[string]interface{}{}
+			}
+			setIfAbsentString(webmail, "host", "mail."+orgZone)
+			ingress["webmail"] = webmail
+			params["ingress"] = ingress
+		}
+	}
+
+	fqdn := strings.TrimSpace(sovereignFQDN)
+	if fqdn != "" {
+		keycloak, _ := params["keycloak"].(map[string]interface{})
+		if keycloak == nil {
+			keycloak = map[string]interface{}{}
+		}
+		setIfAbsentString(keycloak, "realmURL", "https://auth."+fqdn+"/realms/"+stalwartTenantSharedRealm)
+		params["keycloak"] = keycloak
+	}
 }
 
 // postgresConfigSchemaMode folds the canonical placement topology onto the

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_stalwart_5752_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_stalwart_5752_test.go
@@ -1,0 +1,206 @@
+// Tests for #5752 — bp-stalwart-tenant's per-Org install door emitted
+// spec.parameters: {} (no domain, no keycloak.realmURL), so the chart's
+// certificate.yaml Certificate never rendered, cert-manager never
+// materialised the stalwart-tls Secret, and the StatefulSet's non-optional
+// tls Secret mount left the Pod stuck ContainerCreating forever. Live
+// evidence: hw292 funnel Org `uatco`, 2026-08-06 (kubelet Event
+// "MountVolume.SetUp failed for volume \"tls\": secret \"stalwart-tls\" not
+// found", x1737 over 2d10h; Application.spec.parameters == {}).
+//
+// THE GUARD: TestNewApplicationCRFromSeed_StalwartTenantNoValues_ParametersValidateConfigSchema
+// is the money test — it round-trips the SAME producer the live install
+// door uses (newApplicationCRFromSeed) through validate.Parameters against
+// the REAL bp-stalwart-tenant configSchema (required: [keycloak],
+// keycloak.required: [realmURL] — mirrored from
+// platform/stalwart-tenant/blueprint.yaml). Before the #5752 fix,
+// defaultedParameters had no bp-stalwart-tenant case, so the produced
+// parameters stayed {} and this assertion FAILED
+// ("keycloak: keycloak is required" / similar). After the fix it PASSES.
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/core/controllers/pkg/validate"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
+)
+
+// bpStalwartTenantConfigSchema mirrors platform/stalwart-tenant/blueprint.yaml
+// spec.configSchema — specifically the two `required` clauses that make an
+// empty parameters map invalid: the top-level `required: [keycloak]` and
+// the nested `keycloak.required: [realmURL]`.
+func bpStalwartTenantConfigSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":     "object",
+		"required": []interface{}{"keycloak"},
+		"properties": map[string]interface{}{
+			"domain": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"primary": map[string]interface{}{"type": "string"},
+					"mode":    map[string]interface{}{"type": "string", "enum": []interface{}{"free-subdomain", "byo"}, "default": "free-subdomain"},
+				},
+			},
+			"keycloak": map[string]interface{}{
+				"type":     "object",
+				"required": []interface{}{"realmURL"},
+				"properties": map[string]interface{}{
+					"realmURL":         map[string]interface{}{"type": "string"},
+					"clientID":         map[string]interface{}{"type": "string", "default": "stalwart"},
+					"clientSecretName": map[string]interface{}{"type": "string", "default": "stalwart-oidc"},
+				},
+			},
+		},
+	}
+}
+
+// ── defaultedParameters unit table ──────────────────────────────────────
+
+func TestDefaultedParameters_StalwartTenantNoValues_StampsDomainIngressKeycloak(t *testing.T) {
+	got := defaultedParameters("bp-stalwart-tenant", "singleton", "hw292.omani.works", "uatco", "console.uatco.omani.homes", nil)
+
+	domain, ok := got["domain"].(map[string]interface{})
+	if !ok || domain["primary"] != "uatco.omani.homes" {
+		t.Fatalf("domain.primary = %#v, want uatco.omani.homes", got["domain"])
+	}
+	ingress, ok := got["ingress"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("ingress block missing: %#v", got)
+	}
+	webmail, ok := ingress["webmail"].(map[string]interface{})
+	if !ok || webmail["host"] != "mail.uatco.omani.homes" {
+		t.Fatalf("ingress.webmail.host = %#v, want mail.uatco.omani.homes", ingress["webmail"])
+	}
+	keycloak, ok := got["keycloak"].(map[string]interface{})
+	if !ok || keycloak["realmURL"] != "https://auth.hw292.omani.works/realms/sovereign" {
+		t.Fatalf("keycloak.realmURL = %#v, want https://auth.hw292.omani.works/realms/sovereign", got["keycloak"])
+	}
+}
+
+func TestDefaultedParameters_StalwartTenantExplicitValuesWin(t *testing.T) {
+	explicit := map[string]interface{}{
+		"domain":   map[string]interface{}{"primary": "pinned.example"},
+		"keycloak": map[string]interface{}{"realmURL": "https://auth.pinned.example/realms/org-pinned"},
+	}
+	got := defaultedParameters("bp-stalwart-tenant", "singleton", "hw292.omani.works", "uatco", "console.uatco.omani.homes", explicit)
+
+	domain := got["domain"].(map[string]interface{})
+	if domain["primary"] != "pinned.example" {
+		t.Fatalf("a caller-pinned domain.primary must NOT be overwritten, got %#v", domain["primary"])
+	}
+	keycloak := got["keycloak"].(map[string]interface{})
+	if keycloak["realmURL"] != "https://auth.pinned.example/realms/org-pinned" {
+		t.Fatalf("a caller-pinned keycloak.realmURL must NOT be overwritten, got %#v", keycloak["realmURL"])
+	}
+	// ingress.webmail.host was NOT explicitly pinned, so the stamp still
+	// lands alongside the preserved explicit values.
+	ingress := got["ingress"].(map[string]interface{})
+	webmail := ingress["webmail"].(map[string]interface{})
+	if webmail["host"] != "mail.uatco.omani.homes" {
+		t.Fatalf("ingress.webmail.host must still be stamped when not explicitly pinned, got %#v", webmail["host"])
+	}
+}
+
+func TestDefaultedParameters_StalwartTenantEmptyOrgConsoleHost_NoDomainStamp(t *testing.T) {
+	// Mothership / Catalyst-Zero / registry-miss: empty orgConsoleHost ⇒ no
+	// domain/ingress stamp (fail-closed, chart's existing behaviour holds).
+	// keycloak.realmURL still stamps since sovereignFQDN is independently
+	// non-empty.
+	got := defaultedParameters("bp-stalwart-tenant", "singleton", "hw292.omani.works", "uatco", "", nil)
+	if _, ok := got["domain"]; ok {
+		t.Fatalf("empty orgConsoleHost must NOT stamp domain, got %#v", got["domain"])
+	}
+	if _, ok := got["ingress"]; ok {
+		t.Fatalf("empty orgConsoleHost must NOT stamp ingress, got %#v", got["ingress"])
+	}
+	keycloak, ok := got["keycloak"].(map[string]interface{})
+	if !ok || keycloak["realmURL"] != "https://auth.hw292.omani.works/realms/sovereign" {
+		t.Fatalf("keycloak.realmURL must still stamp off sovereignFQDN alone, got %#v", got["keycloak"])
+	}
+}
+
+func TestDefaultedParameters_StalwartTenantEmptyFQDN_NoKeycloakStamp(t *testing.T) {
+	// Mothership / Catalyst-Zero: empty sovereignFQDN ⇒ no keycloak stamp.
+	got := defaultedParameters("bp-stalwart-tenant", "singleton", "", "uatco", "console.uatco.omani.homes", nil)
+	if _, ok := got["keycloak"]; ok {
+		t.Fatalf("empty sovereignFQDN must NOT stamp keycloak.realmURL, got %#v", got["keycloak"])
+	}
+	// domain/ingress still stamp since orgConsoleHost is independently non-empty.
+	domain, ok := got["domain"].(map[string]interface{})
+	if !ok || domain["primary"] != "uatco.omani.homes" {
+		t.Fatalf("domain.primary must still stamp off orgConsoleHost alone, got %#v", got["domain"])
+	}
+}
+
+func TestDefaultedParameters_NonStalwartTenant_NoStamp(t *testing.T) {
+	got := defaultedParameters("bp-agenity", "singleton", "hw292.omani.works", "uatco", "console.uatco.omani.homes", nil)
+	if _, ok := got["keycloak"]; ok {
+		t.Fatalf("non-stalwart-tenant Blueprint must NOT get keycloak.realmURL stamp, got %#v", got["keycloak"])
+	}
+	if domain, ok := got["domain"]; ok {
+		t.Fatalf("non-stalwart-tenant Blueprint must NOT get domain stamp, got %#v", domain)
+	}
+}
+
+// ── The money test: proves the LIVE install door's output now satisfies the
+//    Blueprint's own configSchema, using the SAME producer + SAME validator
+//    the application-controller runs. This is the #5752 red→green guard. ──
+
+func TestNewApplicationCRFromSeed_StalwartTenantNoValues_ParametersValidateConfigSchema(t *testing.T) {
+	seed := instances.ApplicationSeed{
+		Name:           "uatco-mail",
+		Namespace:      "uatco",
+		Blueprint:      "bp-stalwart-tenant",
+		Topology:       "singleton",
+		SovereignFQDN:  "hw292.omani.works",
+		OrgConsoleHost: "console.uatco.omani.homes",
+		// Values intentionally empty — this is the exact live shape:
+		// a funnel install through POST /catalyst/v1/apps/instances
+		// supplies no explicit values.
+	}
+	obj := newApplicationCRFromSeed(seed)
+
+	params, found, err := unstructured.NestedMap(obj.Object, "spec", "parameters")
+	if err != nil {
+		t.Fatalf("read spec.parameters: %v", err)
+	}
+	if !found || params == nil {
+		t.Fatalf("spec.parameters absent/nil — must be a non-null object")
+	}
+
+	rep, vErr := validate.Parameters(bpStalwartTenantConfigSchema(), params)
+	if vErr != nil {
+		t.Fatalf("validate.Parameters internal error: %v", vErr)
+	}
+	if !rep.Valid {
+		t.Fatalf("produced spec.parameters does NOT satisfy bp-stalwart-tenant configSchema (this is the live #5752 bug — an empty parameters map fails 'required: keycloak'): %v\nparams=%#v", rep.Errors, params)
+	}
+
+	domain, _ := params["domain"].(map[string]interface{})
+	if domain == nil || domain["primary"] != "uatco.omani.homes" {
+		t.Fatalf("spec.parameters.domain.primary = %#v, want uatco.omani.homes (required for templates/certificate.yaml to render the stalwart-tls Certificate)", params["domain"])
+	}
+}
+
+func TestNewApplicationUnstructured_StalwartTenant_StampsDomainAndKeycloak(t *testing.T) {
+	req := applicationInstallRequest{
+		BlueprintRef: applicationBlueprintRef{Name: "bp-stalwart-tenant", Version: "0.1.15"},
+	}
+	obj := newApplicationUnstructured(req, "hw292.omani.works", "console.uatco.omani.homes")
+	params, found, err := unstructured.NestedMap(obj.Object, "spec", "parameters")
+	if err != nil {
+		t.Fatalf("read spec.parameters: %v", err)
+	}
+	if !found || params == nil {
+		t.Fatalf("spec.parameters absent/nil")
+	}
+	rep, vErr := validate.Parameters(bpStalwartTenantConfigSchema(), params)
+	if vErr != nil {
+		t.Fatalf("validate.Parameters internal error: %v", vErr)
+	}
+	if !rep.Valid {
+		t.Fatalf("installApplicationCore door output does NOT satisfy configSchema: %v\nparams=%#v", rep.Errors, params)
+	}
+}


### PR DESCRIPTION
## Summary

- Live-diagnosed on hw292 (funnel Org `uatco`): `Application.spec.parameters` for the `bp-stalwart-tenant` install is `{}` — completely empty.
- The two Application-CR creation doors in `products/catalyst/bootstrap/api/internal/handler/` both funnel through `application_parameters.go`'s `defaultedParameters()`, which has hardcoded per-blueprint-slug branches (`isAgenityBlueprint`, `isOpenovaMCPBlueprint`, `isPostgresBlueprint`) — each stamping the values that Blueprint's chart actually needs. There was **no `bp-stalwart-tenant` branch**, so a funnel install (no explicit values supplied) emits `spec.parameters: {}`.
- Consequence: the chart's `templates/certificate.yaml` Certificate (which materialises the `stalwart-tls` Secret the StatefulSet's tls volume mount depends on) is gated on `domain.primary` resolving; with it empty the Certificate never renders and the Pod sits `ContainerCreating` forever. The Blueprint's own configSchema also declares `required: [keycloak]` / `keycloak.required: [realmURL]`, so an empty parameters map doesn't even satisfy its own contract.
- This is a **separate, more proximate** defect from #5615 (already-merged §854 nodePort fix) — even a clean, nodePort-clean install would still get stuck without this fix, because the Certificate would still never render.
- Filed as #5752 with full live evidence + root-cause citations.

## Fix

Adds `isStalwartTenantBlueprint` + `stampStalwartTenantParameters`, mirroring the proven `stampAgenity*`/`stampOpenovaMCP*` shape:

- `domain.primary` + `ingress.webmail.host` — derived from `orgConsoleHost` the same way `stampAgenityGateHost` derives `agenity.<slug>.<pool>` (`console.<slug>.<pool>` → `<slug>.<pool>`).
- `keycloak.realmURL` — falls back to the shared Sovereign realm (`https://auth.<sovereignFQDN>/realms/sovereign`) every other per-Org app in this codebase already authenticates against under the default `CATALYST_PER_ORG_REALM_ENABLED=false` posture (see `auth.go`'s broker-login URL builder + `openbao_sso_init_test.go` for the identical, already-proven issuer shape in this same package).
- Every field defers to an explicit caller-supplied value — nothing is forced onto an install request that already pinned it, matching the existing deference convention.

## Guard — red before, green after

`application_parameters_stalwart_5752_test.go`'s money test round-trips the SAME producer the live install door uses (`newApplicationCRFromSeed`) through `validate.Parameters` against a fixture mirroring the real `bp-stalwart-tenant` configSchema.

Red (pre-fix tree — temporarily reverted `application_parameters.go`, kept the test):
```
=== RUN   TestNewApplicationCRFromSeed_StalwartTenantNoValues_ParametersValidateConfigSchema
    application_parameters_stalwart_5752_test.go:178: produced spec.parameters does NOT satisfy bp-stalwart-tenant configSchema
        (this is the live #5752 bug -- an empty parameters map fails 'required: keycloak'): [#: missing properties: 'keycloak']
        params=map[string]interface {}{}
--- FAIL: TestNewApplicationCRFromSeed_StalwartTenantNoValues_ParametersValidateConfigSchema (0.00s)
FAIL
```

Green (post-fix, plus the 6 sibling unit-table cases — deference, fail-closed on empty `sovereignFQDN`/`orgConsoleHost`, non-stalwart Blueprints unaffected):
```
=== RUN   TestDefaultedParameters_StalwartTenantNoValues_StampsDomainIngressKeycloak
--- PASS: TestDefaultedParameters_StalwartTenantNoValues_StampsDomainIngressKeycloak (0.00s)
=== RUN   TestDefaultedParameters_StalwartTenantExplicitValuesWin
--- PASS: TestDefaultedParameters_StalwartTenantExplicitValuesWin (0.00s)
=== RUN   TestDefaultedParameters_StalwartTenantEmptyOrgConsoleHost_NoDomainStamp
--- PASS: TestDefaultedParameters_StalwartTenantEmptyOrgConsoleHost_NoDomainStamp (0.00s)
=== RUN   TestDefaultedParameters_StalwartTenantEmptyFQDN_NoKeycloakStamp
--- PASS: TestDefaultedParameters_StalwartTenantEmptyFQDN_NoKeycloakStamp (0.00s)
=== RUN   TestDefaultedParameters_NonStalwartTenant_NoStamp
--- PASS: TestDefaultedParameters_NonStalwartTenant_NoStamp (0.00s)
=== RUN   TestNewApplicationCRFromSeed_StalwartTenantNoValues_ParametersValidateConfigSchema
--- PASS: TestNewApplicationCRFromSeed_StalwartTenantNoValues_ParametersValidateConfigSchema (0.00s)
=== RUN   TestNewApplicationUnstructured_StalwartTenant_StampsDomainAndKeycloak
--- PASS: TestNewApplicationUnstructured_StalwartTenant_StampsDomainAndKeycloak (0.00s)
PASS
```

Full module regression: `go build ./...` clean; `go test ./...` across all 30 packages in `products/catalyst/bootstrap/api` — all green, no new failures.

## Scope note

This PR is control-plane only (`products/catalyst/bootstrap/api`, its own Go module). The chart-level `platform/stalwart-tenant/` fix for the SAME live symptom (a distinct volumeClaimTemplate immutable-label defect blocking future `helm upgrade`s) ships separately in #5754, to keep each PR's guard and blast radius scoped to one surface.

## Nodeport discipline

This PR touches zero Kubernetes Service/networking manifests or fields — pure Go parameter-stamping logic. No NodePort of any kind is created, targeted, or relied upon.

Refs #5752 #5615 #960
