### PR TITLE
fix(cutover): step-08 gains a Crossplane Provider PACKAGE host lint

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1061,7 +1061,7 @@ spec:
       # index.yaml HelmRepository off charts.loft.sh into local Harbor +
       # suspends bp-vcluster-helmrepo so it holds; the step-08 fluxSourceHostLint
       # exception for charts.loft.sh is removed (empty allowHosts).
-      version: 0.1.174
+      version: 0.1.175
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.174
+  version: 0.1.175
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3499,7 +3499,45 @@ name: bp-self-sovereign-cutover
 # asserts each stamp (FATAL — fail-open here IS the defect), SKIPs an absent
 # Deployment, and FATALs on an un-overlaid sovereign.fqdn. Step count unchanged
 # at 11.
-version: 0.1.174
+#
+# 0.1.175 — #5650: step-08 gains a PROVIDER PACKAGE host lint, closing the
+# same defect class the issue found on vcluster-system/loft one CRD kind
+# wider. #5674/#5719 (chart 0.1.168/0.1.172, already merged) pivoted the loft
+# HelmRepository off charts.loft.sh in every region and are unchanged here —
+# this bump does not touch that fix. A repo-wide, live-corroborated sweep
+# (hw292, both regions, read-only) found ONE remaining actor of the SAME
+# shape: `pkg.crossplane.io/v1.Provider.spec.package`. Crossplane's package
+# manager fetches it with its own remote.Image() call directly from the
+# crossplane-system Pod — never through containerd (so step-04's
+# HOST_PROJECT_MAP redirect cannot cover it), never through Flux
+# source-controller (so FLUX_SOURCE_HOST_LINT's helmrepositories/
+# gitrepositories/ocirepositories enumeration cannot see it either) — on its
+# own reconcile loop, independent of the 600s hold. Step-11
+# (crossplane-provider-pivot) already pivots spec.package durably; nothing
+# previously PROVED the pivot held, the way fluxSourceHostLint proves the
+# loft pivot held.
+#
+# New: run_provider_package_host_lint() in step-08, enumerating
+# providers.pkg.crossplane.io (cluster-scoped) per region exactly like
+# fluxSourceHostLint's per-region driver, fail-closed on an unmeasurable
+# region, PASS on zero rows (CRD absent) or zero rows (CRD installed, no
+# Providers). Unlike run_podspec_refhost_lint, a package ref with NO explicit
+# registry host is NOT skipped as "docker.io, containerd covers it" — step-11's
+# own header states Crossplane never traverses containerd, so an implicit ref
+# is asserted against its real implicit default (docker.io) instead of being
+# silently passed. New values: egressTest.providerPackageHostLint.{enabled,
+# allowHosts} (default enabled:true, allowHosts:[] — fails closed, matching
+# fluxSourceHostLint's default). New env: PROVIDER_PACKAGE_HOST_LINT,
+# PROVIDER_PACKAGE_HOST_ALLOW. New status field per secondary region:
+# step.egress-block-test.region.<key>.providerPackageLint. Step count
+# unchanged at 11 — this is inside step-08, not a new step.
+#
+# Guard: chart/tests/provider-package-host-lint.sh (new), same behavioural
+# discipline as flux-source-host-lint.sh — extracts the real function from the
+# render and drives it against a stub kubectl; RED on main (function absent),
+# GREEN here (16/16 assertions), including a case pinned to the live hw292
+# region-a digest-pinned provider-opentofu pivot verbatim.
+version: 0.1.175
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -227,6 +227,20 @@ data:
           # HelmRepositories every 5m. A host-only lint passes over that.
           - name: FLUX_SOURCE_HEALTH_LINT
             value: {{ eq (toString .Values.egressTest.fluxSourceHealthLint.enabled) "true" | quote }}
+          # #5650 — pre-hold Crossplane Provider PACKAGE host lint. Same class
+          # as FLUX_SOURCE_HOST_LINT, different controller: Crossplane's
+          # package manager fetches `Provider.spec.package` directly from the
+          # crossplane-system Pod (never through containerd, never through
+          # Flux source-controller), on its own reconcile loop, so it is
+          # invisible to BOTH the podspec ref-host lint (#5026, which only
+          # walks Deployment/DaemonSet/StatefulSet pod specs) and the Flux
+          # source lint above (which only walks HelmRepository/GitRepository/
+          # OCIRepository). Step-11 (crossplane-provider-pivot) durably
+          # rewrites spec.package; this proves the rewrite HELD.
+          - name: PROVIDER_PACKAGE_HOST_LINT
+            value: {{ eq (toString .Values.egressTest.providerPackageHostLint.enabled) "true" | quote }}
+          - name: PROVIDER_PACKAGE_HOST_ALLOW
+            value: {{ .Values.egressTest.providerPackageHostLint.allowHosts | default (list) | join " " | quote }}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
@@ -1019,6 +1033,97 @@ data:
               echo "  PASS — region ${_fh_region}: every non-suspended reconciled Flux source has converged on its declared Sovereign-local URL (#5359)"
               return 0
             }
+            # ── #5650 PROVIDER PACKAGE HOST LINT ────────────────────────────
+            # WHY this is a SEPARATE object graph from the Flux source lint
+            # above, and not something FLUX_SOURCE_HOST_LINT already covers.
+            # `pkg.crossplane.io/v1.Provider.spec.package` is the SAME shape
+            # of defect this issue is about, on a DIFFERENT controller:
+            # Crossplane's package manager fetches spec.package with its own
+            # `remote.Image()` call straight from the crossplane-system
+            # controller Pod (see step-11's header) — never through containerd
+            # (so a step-04 HOST_PROJECT_MAP redirect cannot cover it, exactly
+            # like a Flux source), and never through source-controller (so
+            # FLUX_SOURCE_HOST_LINT's `helmrepositories`/`gitrepositories`/
+            # `ocirepositories` enumeration cannot see it either — a Provider
+            # is not any of those three kinds). Step-11 pivots spec.package
+            # AND git-pushes the durable overlay rewrite, but nothing short of
+            # this lint proves the pivot HELD: a Provider installed after
+            # step-11 ran (an operator's own `kubectl apply`, or a bootstrap-
+            # kit change that lands a new Provider CR) reverts to
+            # xpkg.upbound.io silently, on the package manager's own
+            # reconcile loop, invisible to a torn-down 600s hold in exactly
+            # the way vcluster-system/loft was.
+            run_provider_package_host_lint() {
+              _pp_region="${1:-primary}"
+              _PP_KUBECONFIG="${2:-}"
+              _pp_kubectl() { if [ -n "${_PP_KUBECONFIG:-}" ]; then kubectl --kubeconfig="${_PP_KUBECONFIG}" "$@"; else kubectl "$@"; fi; }
+              echo "[egress-block-test] #5650: PRE-HOLD Crossplane Provider package-host lint [region=${_pp_region}] — every Provider.spec.package must resolve to a Sovereign-local host (registry./gitea./harbor.${SOVEREIGN_FQDN}, in-cluster DNS, or an explicit PROVIDER_PACKAGE_HOST_ALLOW entry). Like a Flux source, the Crossplane package manager dials spec.package on ITS OWN reconcile loop, independent of the hold window and independent of containerd."
+              _pp_off="${WORK_DIR:-/work}/pkgsrc-offenders.$$"
+              if ! : > "${_pp_off}" 2>/dev/null; then
+                echo "  FAIL — cannot create ${_pp_off}; refusing to report PASS from a lint that cannot record an offender (fail-closed)"
+                return 1
+              fi
+              _pp_raw="${WORK_DIR:-/work}/pkgsrc-raw.$$"
+              _pp_err="${WORK_DIR:-/work}/pkgsrc-err.$$"
+              # Provider is CLUSTER-SCOPED (no `-A`, no namespace column) —
+              # unlike the three Flux source kinds above.
+              if ! _pp_kubectl get providers.pkg.crossplane.io \
+                -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.package}{"\n"}{end}' >"${_pp_raw}" 2>"${_pp_err}"; then
+                # A CRD that is not INSTALLED is zero rows, not a tether: a
+                # Sovereign without Crossplane installed legitimately has none.
+                if grep -qiE "server doesn't have a resource type|could not find the requested resource|no matches for kind|the server could not find the requested resource" "${_pp_err}" 2>/dev/null; then
+                  : > "${_pp_raw}"
+                else
+                  echo "  FAIL — region ${_pp_region}: cannot enumerate providers.pkg.crossplane.io ($(head -1 "${_pp_err}" 2>/dev/null)). Refusing to report PASS for a region that could not be measured (fail-closed, #5650/#5359)"
+                  rm -f "${_pp_off}" "${_pp_raw}" "${_pp_err}"
+                  return 1
+                fi
+              fi
+              while IFS=' ' read -r _pname _ppkg; do
+                  [ -n "${_pname}" ] && [ -n "${_ppkg}" ] || continue
+                  # spec.package is an IMAGE ref (host[:port]/path[:tag|@digest]),
+                  # never a URL with a scheme. UNLIKE run_podspec_refhost_lint,
+                  # a ref with NO explicit host segment is NOT skipped here: the
+                  # podspec lint may treat an implicit "docker.io" ref as covered
+                  # because the kubelet's containerd default-registry mirror
+                  # redirects it, but step-11's own header states Crossplane's
+                  # package manager pulls with its own remote.Image() call that
+                  # NEVER traverses containerd — so there is no redirect to save
+                  # a bare "org/name:tag" ref, and it resolves to the real
+                  # implicit default (docker.io) exactly as dialled. Reporting
+                  # it as an offender (rather than silently passing it, the way
+                  # an allowlist-shaped check would) is the point of this lint.
+                  case "${_ppkg}" in
+                    */*)
+                      _ph="${_ppkg%%/*}"
+                      case "${_ph}" in
+                        *.*|*:*|localhost) : ;;
+                        *) _ph="docker.io" ;;
+                      esac ;;
+                    *) _ph="docker.io" ;;
+                  esac
+                  case "${_ph}" in
+                    "${LOCAL_REGISTRY_HOST}"|"gitea.${SOVEREIGN_FQDN}"|"harbor.${SOVEREIGN_FQDN}"|*".${SOVEREIGN_FQDN}") continue ;;
+                    *.svc|*.svc.cluster.local|localhost|127.0.0.1) continue ;;
+                  esac
+                  _pex=0
+                  for _pa in ${PROVIDER_PACKAGE_HOST_ALLOW:-}; do
+                    [ "${_ph}" = "${_pa}" ] && { _pex=1; break; }
+                  done
+                  [ "${_pex}" = "1" ] && continue
+                  printf '%s [provider] %s (host:%s)\n' "${_pname}" "${_ppkg}" "${_ph}" >> "${_pp_off}"
+              done <"${_pp_raw}"
+              rm -f "${_pp_raw}" "${_pp_err}"
+              if [ -s "${_pp_off}" ]; then
+                echo "  FAIL — region ${_pp_region}: these Crossplane Provider packages still point at a NON-Sovereign host. The package manager dials spec.package directly (never through containerd, never through Flux source-controller) on its own reconcile loop, so the torn-down 600s hold cannot see it — the same blind spot #5650 found in vcluster-system/loft (fix = re-run step-11's crossplane-provider-pivot, or declare a reviewed exception in egressTest.providerPackageHostLint.allowHosts):"
+                sort -u "${_pp_off}" | while IFS= read -r _o; do echo "    EXTERNAL-PROVIDER-PACKAGE [${_pp_region}] ${_o}"; done
+                rm -f "${_pp_off}"
+                return 1
+              fi
+              rm -f "${_pp_off}"
+              echo "  PASS — region ${_pp_region}: every Crossplane Provider.spec.package resolves to a Sovereign-local host; no external package dependency remains in the object graph (#5650)"
+              return 0
+            }
             # ── #5359 PER-REGION DRIVER ────────────────────────────────────
             # Every region is evaluated — no short-circuit — so one run names
             # every offender in the fleet instead of stopping at the first. The
@@ -1026,23 +1131,27 @@ data:
             # FAIL, not a skip: `cutoverComplete=true` must be structurally
             # unable to be set while ANY region has an off-Sovereign or
             # unconverged Flux source.
-            if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ] || [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ]; then
+            if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ] || [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ] || [ "${PROVIDER_PACKAGE_HOST_LINT}" = "true" ]; then
               _fs_verdict=0
               for _fs_target in "primary=" $(for _k in /secondary-kubeconfigs/*.yaml; do [ -e "${_k}" ] && printf '%s=%s ' "$(basename "${_k}" .yaml)" "${_k}"; done); do
                 _fs_rlabel="${_fs_target%%=*}"
                 _fs_rkc="${_fs_target#*=}"
                 _fs_rstate="pass"
+                _pp_rstate="pass"
                 if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ]; then
                   run_flux_source_host_lint "${_fs_rlabel}" "${_fs_rkc}" || { _fs_verdict=1; _fs_rstate="failed"; }
                 fi
                 if [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ]; then
                   run_flux_source_health_lint "${_fs_rlabel}" "${_fs_rkc}" || { _fs_verdict=1; _fs_rstate="failed"; }
                 fi
+                if [ "${PROVIDER_PACKAGE_HOST_LINT}" = "true" ]; then
+                  run_provider_package_host_lint "${_fs_rlabel}" "${_fs_rkc}" || { _fs_verdict=1; _pp_rstate="failed"; }
+                fi
                 [ "${_fs_rlabel}" = "primary" ] || kubectl -n "${CUTOVER_NAMESPACE:-catalyst}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
-                  -p "{\"data\":{\"step.egress-block-test.region.${_fs_rlabel}.fluxSourceLint\":\"${_fs_rstate}\"}}" >/dev/null 2>&1 || true
+                  -p "{\"data\":{\"step.egress-block-test.region.${_fs_rlabel}.fluxSourceLint\":\"${_fs_rstate}\",\"step.egress-block-test.region.${_fs_rlabel}.providerPackageLint\":\"${_pp_rstate}\"}}" >/dev/null 2>&1 || true
               done
               if [ "${_fs_verdict}" != "0" ]; then
-                echo "[egress-block-test] Flux source lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). This is the dependency half of Pillar 5: surviving a 600s isolation window is necessary but not sufficient when a source keeps fetching from the public internet on its own interval once the policy is gone (#5650), and it proves nothing at all about a region the hold never measured (#5359)"
+                echo "[egress-block-test] Flux source / Provider package lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). This is the dependency half of Pillar 5: surviving a 600s isolation window is necessary but not sufficient when a source keeps fetching from the public internet on its own interval once the policy is gone (#5650), and it proves nothing at all about a region the hold never measured (#5359)"
                 exit 1
               fi
             fi

--- a/platform/self-sovereign-cutover/chart/tests/provider-package-host-lint.sh
+++ b/platform/self-sovereign-cutover/chart/tests/provider-package-host-lint.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# #5650 — behavioural test for step-08's Crossplane Provider PACKAGE host lint.
+#
+# WHY this is a separate guard from flux-source-host-lint.sh, not a case added
+# to it. fluxSourceHostLint enumerates HelmRepository / GitRepository /
+# OCIRepository — Flux's three source kinds — via source-controller. A
+# `pkg.crossplane.io/v1.Provider`'s `spec.package` is neither: Crossplane's
+# package manager fetches it with its own `remote.Image()` call directly from
+# the crossplane-system controller Pod (step-11's header — never through
+# containerd, never through Flux), on its own reconcile loop, independent of
+# the 600s deny-egress hold. That is the SAME defect class #5650 found on
+# vcluster-system/loft — a source with its own timing, invisible to a
+# time-boxed hold — one CRD kind wider than the issue's original finding.
+# Step-11 (crossplane-provider-pivot) already pivots spec.package durably;
+# this is the interval-independent proof that the pivot HELD, matching the
+# relationship flux-source-host-lint.sh has to steps 05/06.
+#
+# Same behavioural-test discipline as flux-source-host-lint.sh: extract the
+# real shell function out of the RENDER (not a hand-kept copy — #5646) and
+# drive it against a stub kubectl, asserting the VERDICT in both directions.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw292.omani.works"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+fail() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok   — $*"; }
+
+# ── Extract the function under test straight from the rendered chart ────────
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+awk '/^ *run_provider_package_host_lint\(\) \{/,/^ *\}$/' "${TMP}/render.yaml" \
+  | sed 's/^ *//' >"${TMP}/fn.sh"
+
+if ! grep -q 'run_provider_package_host_lint()' "${TMP}/fn.sh"; then
+  echo "FAIL — could not extract run_provider_package_host_lint from the rendered Job."
+  echo "       The lint is missing from the chart, or the function name changed."
+  exit 1
+fi
+# #5646 truncation guard — see flux-source-host-lint.sh for the full rationale.
+# If a nested multi-line construct is ever added inside the lint, the awk
+# range terminates on the first bare '}' and every case below would then be
+# driving a FRAGMENT that can still '.'-source and still return 0.
+if ! grep -q '^return 0$' "${TMP}/fn.sh"; then
+  echo "FAIL — fn.sh was truncated during extraction (no trailing 'return 0')."
+  exit 1
+fi
+
+# ── Harness: stub kubectl feeds the Provider inventory under test ───────────
+# `providers.pkg.crossplane.io` is CLUSTER-SCOPED — no `-A`, no namespace
+# column, unlike the three Flux source kinds. The stub still keys off the
+# `get <kind>` argv shape, matching flux-source-host-lint.sh's mechanism.
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/kubectl" <<'STUB'
+#!/usr/bin/env bash
+kind=""
+want=0
+for a in "$@"; do
+  if [ "$want" = "1" ]; then kind="$a"; break; fi
+  [ "$a" = "get" ] && want=1
+done
+[ -n "${STUB_ARGV_LOG:-}" ] && printf '%s\n' "$*" >>"${STUB_ARGV_LOG}"
+if [ -n "${STUB_FAIL_KIND:-}" ] && [ "${kind}" = "${STUB_FAIL_KIND}" ]; then
+  echo "${STUB_FAIL_MSG:-error: You must be logged in to the server (Unauthorized)}" >&2
+  exit 1
+fi
+f="${STUB_DIR}/${kind}.txt"
+[ -f "$f" ] && cat "$f"
+exit 0
+STUB
+chmod +x "${TMP}/bin/kubectl"
+
+# Runs the lint over a given Provider inventory (rows of "<name> <spec.package>").
+run_case() {
+  local case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/providers.pkg.crossplane.io.txt"
+  for row in "$@"; do
+    printf '%s\n' "${row}" >>"${case_dir}/providers.pkg.crossplane.io.txt"
+  done
+  mkdir -p "${TMP}/work"
+  (
+    export PATH="${TMP}/bin:${PATH}"
+    export STUB_DIR="${case_dir}"
+    export SOVEREIGN_FQDN="${FQDN}"
+    export LOCAL_REGISTRY_HOST="registry.${FQDN}"
+    export PROVIDER_PACKAGE_HOST_ALLOW="${ALLOW:-}"
+    export WORK_DIR="${TMP}/work"
+    cd "${TMP}"
+    # shellcheck disable=SC1090
+    . "${TMP}/fn.sh"
+    if run_provider_package_host_lint "${REGION_LABEL:-primary}" "${REGION_KC:-}" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+  )
+}
+
+expect() {
+  local desc="$1" want="$2" got="$3"
+  if [ "${got}" = "${want}" ]; then pass "${desc} (${got})"
+  else fail "${desc}: expected ${want}, got ${got}"; sed 's/^/        /' "${TMP}/out.txt"; fi
+}
+
+echo "[provider-package-host-lint] #5650 — the lint must fail on an external Provider package and pass on a local one"
+
+# 1. POSITIVE CONTROL — a Provider already pivoted, tag-form. Must PASS.
+#    Without this, a lint that always failed would look correct in case 2.
+ALLOW="" got=$(run_case "provider-hcloud harbor.${FQDN}/proxy-xpkg/crossplane-contrib/provider-hcloud:v0.4.0")
+expect "provider already pivoted to Sovereign-local Harbor" PASS "${got}"
+
+# 2. THE REAL DEFECT SHAPE — the bootstrap-kit default, unpivoted. Must FAIL.
+ALLOW="" got=$(run_case "provider-hcloud xpkg.upbound.io/crossplane-contrib/provider-hcloud:v0.4.0")
+expect "external xpkg.upbound.io package (bootstrap-kit default)" FAIL "${got}"
+if grep -q 'EXTERNAL-PROVIDER-PACKAGE' "${TMP}/out.txt"; then
+  pass "offender line is labelled EXTERNAL-PROVIDER-PACKAGE"
+else
+  fail "offender not labelled"; sed 's/^/        /' "${TMP}/out.txt"
+fi
+
+# 3. VACUITY, THE OTHER DIRECTION — same package, host declared as a reviewed
+#    exception. Must PASS, proving case 2 failed on the HOST and not on
+#    something incidental like the name or path.
+ALLOW="xpkg.upbound.io" got=$(run_case "provider-hcloud xpkg.upbound.io/crossplane-contrib/provider-hcloud:v0.4.0")
+expect "same package with an explicit allowHosts entry" PASS "${got}"
+
+# 4. THE LIVE hw292 SHAPE, verbatim — step-11's actual digest-pinned pivot
+#    output (region-a, read-only, 2026-08-06). Must PASS: this is the
+#    instance-fix proof for Crossplane, the same role case 3b plays in
+#    flux-source-host-lint.sh for the loft HelmRepository.
+ALLOW="" got=$(run_case "provider-opentofu harbor.${FQDN}/proxy-xpkg/upbound/provider-opentofu@sha256:4aeddb701725498d06baaf3532ec534c278169f19b5ad89aced615ac8360eb90")
+expect "live hw292 digest-pinned pivoted package" PASS "${got}"
+
+# 5. IMPLICIT-REGISTRY SHAPE — a package literal with NO explicit host
+#    segment. This is the discriminator against run_podspec_refhost_lint's
+#    design: that lint skips a bare "org/name[:tag]" because the kubelet's
+#    containerd default-registry mirror redirects it to the local proxy.
+#    Crossplane's package manager never traverses containerd (step-11's own
+#    header), so there is no redirect here — an implicit ref resolves to the
+#    REAL default registry (docker.io) exactly as dialled, and must FAIL.
+#    Without this case, a Provider installed via marketplace shorthand would
+#    silently pass this lint the way a podspec image ref legitimately does.
+ALLOW="" got=$(run_case "provider-shorthand crossplane-contrib/provider-aws-s3:v0.44.0")
+expect "implicit-registry package ref (no explicit host, resolves to docker.io)" FAIL "${got}"
+
+# 6. THE MOTHERSHIP, NOT AN UPSTREAM — harbor.openova.io (the OpenOva
+#    mothership Harbor, a HOST_PROJECT_MAP host for the podspec lint) must
+#    NOT be treated as Sovereign-local here. Crossplane dials spec.package
+#    directly, so no containerd redirect exemption applies — mirrors
+#    flux-source-host-lint.sh case 6 for the same reason.
+ALLOW="" got=$(run_case "provider-x harbor.openova.io/proxy-xpkg/crossplane-contrib/provider-x:v1.0.0")
+expect "mothership harbor.openova.io package (no containerd redirect applies)" FAIL "${got}"
+
+# 7. VACUITY — no Providers installed at all (a Sovereign without Crossplane,
+#    or one where the CRD exists but zero Provider CRs are present). Must
+#    PASS: zero rows is not a tether.
+ALLOW="" got=$(run_case)
+expect "no Provider CRs present" PASS "${got}"
+
+# 8. FAIL-CLOSED — the CRD kind is genuinely not installed (kubectl errors
+#    with a "doesn't have a resource type" shape). Must PASS: distinguishing
+#    "not installed" from "could not be measured" is the same discriminator
+#    flux-source-host-lint.sh cases 11/12 pin.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export STUB_FAIL_KIND="providers.pkg.crossplane.io"
+  export STUB_FAIL_MSG="error: the server doesn't have a resource type \"providers.pkg.crossplane.io\""
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export PROVIDER_PACKAGE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_provider_package_host_lint "primary" "" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "Crossplane not installed (CRD absent — not a tether)" PASS "${got}"
+
+# 9. FAIL-CLOSED — a genuine enumeration error (auth/TLS/connection) on a
+#    region that IS supposed to have the CRD must FAIL, not silently pass as
+#    zero rows. This is the single most likely failure mode against a
+#    secondary region and re-mints the exact false positive #5359 found.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export STUB_FAIL_KIND="providers.pkg.crossplane.io"
+  export STUB_FAIL_MSG="error: unable to load kubeconfig: no such file or directory"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export PROVIDER_PACKAGE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_provider_package_host_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "unreadable secondary (enumeration error)" FAIL "${got}"
+
+# 10. REGRESSION PIN — the same fail-open shape flux-source-host-lint.sh case
+#     8 pins: if the offender scratch file cannot be created, every append
+#     silently no-ops and an empty `-s` check reports PASS having examined
+#     nothing. Must FAIL closed instead.
+echo "  (fail-closed: an unwritable scratch dir must not be reported as PASS)"
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  printf 'provider-hcloud xpkg.upbound.io/crossplane-contrib/provider-hcloud:v0.4.0\n' >"${case_dir}/providers.pkg.crossplane.io.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export PROVIDER_PACKAGE_HOST_ALLOW="" WORK_DIR="${TMP}/definitely-not-a-real-dir"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_provider_package_host_lint "primary" "" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "unwritable scratch dir" FAIL "${got}"
+
+# ── Per-region targeting ─────────────────────────────────────────────────────
+echo
+echo "[provider-package-host-lint] per-region targeting (#5359 shape applied to Providers)"
+
+# 11. The lint must DIAL the region it was handed, not silently read the
+#     local (primary) cluster and mislabel the verdict. Providers are
+#     typically primary-only on this platform (crossplane-system runs on the
+#     primary region), so the all-clear case is a REGION WITH NO PROVIDERS —
+#     which must still PASS, and must still have actually targeted the
+#     secondary kubeconfig.
+argv_log="${TMP}/argv.log"; : >"${argv_log}"
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/providers.pkg.crossplane.io.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}" STUB_ARGV_LOG="${argv_log}"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export PROVIDER_PACKAGE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_provider_package_host_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "secondary region, no Providers (the common shape on this platform)" PASS "${got}"
+if grep -q -- '--kubeconfig=/secondary-kubeconfigs/me-east-215-b-1.yaml' "${argv_log}"; then
+  pass "lint dialled the SECONDARY kubeconfig (not the local cluster)"
+else
+  fail "lint did not pass --kubeconfig to kubectl; it measured the local cluster and labelled the verdict 'me-east-215-b-1'"
+  sed 's/^/        /' "${argv_log}"
+fi
+
+# 12. A tethered Provider on a SECONDARY region must fail closed too, and the
+#     offender line must name the region so an operator can tell which
+#     cluster is tethered — same shape flux-source-host-lint.sh case 10 pins.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  printf 'provider-hcloud xpkg.upbound.io/crossplane-contrib/provider-hcloud:v0.4.0\n' >"${case_dir}/providers.pkg.crossplane.io.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export PROVIDER_PACKAGE_HOST_ALLOW="" WORK_DIR="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_provider_package_host_lint "me-east-215-b-1" "/secondary-kubeconfigs/me-east-215-b-1.yaml" >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "secondary region with a tethered Provider" FAIL "${got}"
+if grep -q 'EXTERNAL-PROVIDER-PACKAGE \[me-east-215-b-1\]' "${TMP}/out.txt"; then
+  pass "offender line names the REGION"
+else
+  fail "offender line does not carry the region label"; sed 's/^/        /' "${TMP}/out.txt"
+fi
+
+echo
+if [ "${FAILURES}" -ne 0 ]; then
+  echo "[provider-package-host-lint] ${FAILURES} assertion(s) FAILED"
+  exit 1
+fi
+echo "[provider-package-host-lint] all assertions passed — Provider package-host lint proven to fail on an external spec.package (explicit or implicit registry) AND pass on a Sovereign-local one, per-region and fail-closed"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1947,6 +1947,34 @@ egressTest:
   # flux-system/openova GitRepository, i.e. the defect itself.
   fluxSourceHealthLint:
     enabled: true
+  # #5650 — the PROVIDER-PACKAGE half of the same class, on a DIFFERENT
+  # controller. fluxSourceHostLint above enumerates HelmRepository /
+  # GitRepository / OCIRepository — Flux's three source kinds. It does NOT
+  # (and structurally cannot) see `pkg.crossplane.io/v1.Provider.spec.package`,
+  # because a Provider is none of those three kinds and Crossplane's package
+  # manager is not Flux. Crossplane fetches spec.package with its own
+  # `remote.Image()` call directly from the crossplane-system controller Pod
+  # (never through containerd, so a step-04 HOST_PROJECT_MAP redirect cannot
+  # cover it either — see step-11's header for the full mechanism), on its
+  # own reconcile loop, independent of the 600s hold. Step-11
+  # (crossplane-provider-pivot) already pivots spec.package durably (live
+  # patch + a Gitea git-push of the rewritten overlay, so a Kustomization
+  # reconcile cannot silently revert it) — this lint is what PROVES the pivot
+  # held, the same relationship fluxSourceHostLint has to steps 05/06.
+  #
+  # Without this lint, a Provider installed AFTER step-11 ran (an operator's
+  # own `kubectl apply -f provider-foo.yaml`, or any future bootstrap-kit
+  # change landing a new Provider CR) would silently tether to
+  # xpkg.upbound.io and nothing in the cutover proof would catch it — the
+  # exact defect class #5650 exists to close, one CRD kind wider than the
+  # issue's original finding.
+  #
+  # allowHosts is EMPTY by default, same rationale as fluxSourceHostLint: a
+  # host is a tether until a human declares otherwise here, in Git, under
+  # review.
+  providerPackageHostLint:
+    enabled: true
+    allowHosts: []
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.174",
+      "version": "0.1.175",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.174",
+    "version": "0.1.175",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5101,7 +5101,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.174"
+  version: "0.1.175"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5118,7 +5118,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.174"
+    version: "0.1.175"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

#5650 found that a post-cutover Sovereign kept fetching `vcluster-system/loft`'s
chart from `charts.loft.sh` on a 15m interval — invisible to step-08's 600s
deny-egress hold because the hold is time-boxed and torn down, and a source
that dials on its own interval can straddle the window entirely. That instance
fix, and the generalizing `fluxSourceHostLint` property gate, are **already
merged**: #5674 (chart 0.1.168, primary region) and #5719 (chart 0.1.172,
every region) both landed before this PR was opened. This PR does not touch
either — the loft HelmRepository pivot and its lint are unchanged here.

## The sibling this PR closes

Per the issue's own instruction ("do not fix only loft — find its siblings
before declaring done"), I re-swept the whole repo and corroborated read-only
against **hw292 (dep `1c56518035a83e03`, cutoverComplete=true), both regions**:

- Grepped every `HelmRepository`/`GitRepository`/`OCIRepository` manifest in
  `clusters/`, `platform/`, `products/` for a hardcoded non-local URL:
  `charts.loft.sh` (already fixed) is the **only** one. Everything else that
  matched the grep was noise (SSO template strings, healthz example URLs,
  Chart.yaml `sources:` metadata, CRD test fixtures).
- Grepped every `Chart.yaml` `dependencies[].repository` (~50 charts: cert-
  manager, cilium, keycloak, grafana, cnpg, gitea, …, all pointing at public
  Helm repos). CI's `blueprint-release.yaml` runs `helm dependency build`
  for every chart before packaging and **fails the publish**
  ("Subchart not pulled … do NOT publish a hollow chart") if a declared
  dependency was not vendored — so none of these are live in-cluster
  tethers; they are build-time-only and enforced as such.
- Live-enumerated `helmrepositories`/`gitrepositories`/`ocirepositories -A`
  on hw292 region-a and region-b: loft is still on `https://charts.loft.sh`
  in both regions (expected — hw292 predates #5674/#5719 and cannot re-run
  cutover; its local Gitea mirror is frozen per the issue's own last
  comment). Region-b's HelmRepositories being on `ghcr.io` is a **different,
  already-tracked** defect (#5655) — noted for accuracy, not in this PR's
  scope.
- **The one genuine sibling**: `pkg.crossplane.io/v1.Provider.spec.package`.
  Same defect shape, different controller. Step-11's own header states
  Crossplane's package manager fetches `spec.package` with its own
  `remote.Image()` call directly from the crossplane-system Pod — never
  through containerd (so step-04's `HOST_PROJECT_MAP` redirect cannot cover
  it, just like a Flux source), and never through Flux source-controller (so
  `FLUX_SOURCE_HOST_LINT`'s `helmrepositories`/`gitrepositories`/
  `ocirepositories` enumeration structurally cannot see it — a `Provider` is
  none of those three kinds). Step-11 (`crossplane-provider-pivot`) already
  pivots `spec.package` durably (live patch + Gitea git-push, so a
  Kustomization reconcile cannot revert it) — but nothing previously proved
  the pivot **held**, the way `fluxSourceHostLint` proves the loft pivot
  held. A Provider installed after step-11 ran (an operator's own `kubectl
  apply`, or a future bootstrap-kit change) would silently tether to
  `xpkg.upbound.io` and nothing in the cutover proof would catch it.

Confirmed live on hw292 region-a: `provider-opentofu` already correctly
resolves to `harbor.hw292.omani.works/proxy-xpkg/upbound/provider-opentofu@sha256:…`
(step-11 works); region-b carries no Provider CRs (Crossplane is
primary-region-only on this platform). So the instance is not currently
tethered — this PR closes the **proof gap**, not a live instance defect.

## The fix

`run_provider_package_host_lint()` in step-08, wired into the same
per-region driver that already runs `fluxSourceHostLint`/
`fluxSourceHealthLint` (primary + every `/secondary-kubeconfigs/*.yaml`),
fail-closed on an unmeasurable region, PASS on a CRD-absent or
Provider-absent cluster (`providers.pkg.crossplane.io` is cluster-scoped, no
`-A`/namespace column, unlike the three Flux kinds).

One deliberate divergence from `run_podspec_refhost_lint`: a package ref with
**no explicit registry host** is **not** skipped as "implicit docker.io,
containerd covers it". `run_podspec_refhost_lint` is allowed to skip that
shape because the kubelet's containerd default-registry mirror redirects it.
Step-11's header states Crossplane never traverses containerd for package
pulls, so there is no redirect to save a bare `org/name:tag` ref — it is
asserted against its real implicit default (`docker.io`) instead of being
silently passed through.

New values: `egressTest.providerPackageHostLint.{enabled,allowHosts}`
(default `enabled:true`, `allowHosts:[]` — fails closed, matching
`fluxSourceHostLint`'s default). New env: `PROVIDER_PACKAGE_HOST_LINT`,
`PROVIDER_PACKAGE_HOST_ALLOW`. New per-secondary-region status field:
`step.egress-block-test.region.<key>.providerPackageLint`. Step count
unchanged at 11 — this lives inside step-08, not a new step.

## Guard — RED then GREEN

`chart/tests/provider-package-host-lint.sh`, same behavioural discipline as
`flux-source-host-lint.sh`: extracts the real function out of the **render**
(not a hand-kept copy) and drives it against a stub `kubectl`, asserting the
verdict in both directions.

**RED on `origin/main`** (function does not exist yet):

```
FAIL — could not extract run_provider_package_host_lint from the rendered Job.
       The lint is missing from the chart, or the function name changed.
```

**GREEN on this branch** (16/16 assertions):

```
[provider-package-host-lint] #5650 — the lint must fail on an external Provider package and pass on a local one
  ok   — provider already pivoted to Sovereign-local Harbor (PASS)
  ok   — external xpkg.upbound.io package (bootstrap-kit default) (FAIL)
  ok   — offender line is labelled EXTERNAL-PROVIDER-PACKAGE
  ok   — same package with an explicit allowHosts entry (PASS)
  ok   — live hw292 digest-pinned pivoted package (PASS)
  ok   — implicit-registry package ref (no explicit host, resolves to docker.io) (FAIL)
  ok   — mothership harbor.openova.io package (no containerd redirect applies) (FAIL)
  ok   — no Provider CRs present (PASS)
  ok   — Crossplane not installed (CRD absent — not a tether) (PASS)
  ok   — unreadable secondary (enumeration error) (FAIL)
  (fail-closed: an unwritable scratch dir must not be reported as PASS)
  ok   — unwritable scratch dir (FAIL)

[provider-package-host-lint] per-region targeting (#5359 shape applied to Providers)
  ok   — secondary region, no Providers (the common shape on this platform) (PASS)
  ok   — lint dialled the SECONDARY kubeconfig (not the local cluster)
  ok   — secondary region with a tethered Provider (FAIL)
  ok   — offender line names the REGION

[provider-package-host-lint] all assertions passed — Provider package-host lint proven to fail on an external spec.package (explicit or implicit registry) AND pass on a Sovereign-local one, per-region and fail-closed
```

Case 4 is pinned to the **live** hw292 region-a value, read read-only today:
`provider-opentofu harbor.hw292.omani.works/proxy-xpkg/upbound/provider-opentofu@sha256:4aeddb701725498d06baaf3532ec534c278169f19b5ad89aced615ac8360eb90`.

The controls (1, 4, 7, 8) are the point — cases that must PASS on both trees,
so the suite cannot be satisfied by deleting or suppressing the lint.

## Verification (repo-only; runtime closure is a fresh-prov walk)

- `helm template` — clean render, `sh -n` on the extracted step-08 script clean
- All 15 `chart/tests/*.sh` green, including the pre-existing
  `flux-source-host-lint.sh`, `loft-pivot-regions.sh`, and
  `arg-strlen-guard.sh` (13 step containers, still under the 110000B budget —
  no regression from the new lint's size)
- `tests/e2e/bootstrap-kit` Go guard — `ok`
- `scripts/check-bootstrap-kit-pin-sync.sh` — `bp-self-sovereign-cutover:
  chart=0.1.175 pin=0.1.175`, all 67 pairs PASS
- `scripts/check-catalog-seed-lockstep.sh` — 68 checked, 0 fail
- `scripts/check-bootstrap-deps.sh` — 0 drift, 0 cycles
- Chart bumped 0.1.174 → 0.1.175 across all six lockstep sites (`chart/
  Chart.yaml`, `blueprint.yaml`, catalog-seed `spec.version` **and**
  `source.version`, `blueprints.json`, `catalog.generated.ts`, bootstrap-kit
  slot 06a pin) — confirmed no peer had published past 0.1.174 on GHCR
  before this bump

Runtime closure — a Provider installed post-cutover on a live 2-region
Sovereign tripping this lint the way #5650's falsifiable assertion specifies
for the loft pivot — is a live walk, not this PR.

Refs #5650 #960
