### PR TITLE
fix(bp-openbao): SSO landing re-validates a cached token before trusting it — UAT row 183

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -167,7 +167,12 @@ spec:
       #   region-local admin-token PushSecret can seed every region's vault —
       #   closes the region-B catalyst-newapi-admin-token SecretSyncedError
       #   (path never written in region-B; post-promote DR gap).
-      version: 1.2.64
+      # 1.2.65 — #5763 (UAT row 183 regression): SSO landing re-entry
+      #   re-validates a cached token (auth/token/lookup-self) before
+      #   trusting it into /ui/vault/secrets, instead of trusting a
+      #   client-side-only tokenExpirationEpoch that can't see a server-side
+      #   revoke — closes the "no login form but 403 on mounts" gap.
+      version: 1.2.65
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1335,7 +1335,9 @@ spec:
       #   mirror-advance force-push refuse-by-default + continuous
       #   source-host drift lint. Lockstep w/ slot-06a; also self-heals the
       #   pre-existing 1.4.1327/1.4.1325 version/appVersion drift.
-      version: 1.4.1328
+      # 1.4.1329 (#5459): catalog-seed bp-openbao pin 1.2.65 — SSO landing
+      #   re-validates a cached token before trusting it. Lockstep w/ slot-08.
+      version: 1.4.1329
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.64  # lockstep with chart/Chart.yaml (#5375: external-secrets-push policy so bp-newapi's region-local admin-token PushSecret can seed every region's vault)
+  version: 1.2.65  # lockstep with chart/Chart.yaml (#5459: SSO landing re-entry re-validates a cached token server-side before trusting it — UAT row 183 regression)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -239,7 +239,24 @@ name: bp-openbao
 #   broad `secret/data/*` ESO grant stays read-only. On already-provisioned
 #   envs the auth-bootstrap hook exits 0 (root token revoked after first run) —
 #   the grant lands on the next fresh prov per the release-train lifecycle.
-version: 1.2.64
+# 1.2.65 — #5459 (UAT row 183 regression): the SSO landing page's re-entry
+#   fast path ("already signed in? -> straight through") trusted a cached
+#   token's CLIENT-SIDE tokenExpirationEpoch alone, computed once at mint
+#   time from lease_duration. It has no way to learn a token was revoked
+#   SERVER-SIDE (explicit revoke, entity/alias churn, any other Vault-
+#   internal invalidation) before its programmed TTL elapsed — the landing
+#   page still shows no login form (session-authenticity "holds") but
+#   redirects straight into the authenticated UI with a dead token, which
+#   403s on its first real call, `sys/internal/ui/mounts` ("Not authorized"
+#   instead of Secrets Engines). Measured live hw292 2026-08-06T06:06Z,
+#   reproduced 3/3 loads, while the server-side ACL/OIDC-role/identity-group
+#   state was independently confirmed correct + converged in BOTH regions
+#   throughout the exact failure window (zero WARNs in the sso-configure
+#   reconciler log) — this was a client-trust bug, not a policy regression.
+#   The landing page now calls auth/token/lookup-self BEFORE trusting a
+#   cached token; a non-200 clears it and falls through to a fresh OIDC
+#   round-trip instead of dead-ending on a silent 403.
+version: 1.2.65
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/sso-landing.yaml
+++ b/platform/openbao/chart/templates/sso-landing.yaml
@@ -36,8 +36,13 @@ WHAT THIS PAGE DOES (gesture-free, popup-free, version-stable):
 
   Loop-safety: this page lives at /sso/landing — NOT a Vault UI route, NOT
   the OIDC callback. The bare-path HTTPRoute (/, /ui, /ui/) redirects HERE;
-  a re-entry that already holds a valid token short-circuits to
-  /ui/vault/secrets (idempotent). API clients use /v1/* — never touched.
+  a re-entry re-VALIDATES its cached token server-side (auth/token/lookup-
+  self) before short-circuiting to /ui/vault/secrets — a locally-future-dated
+  tokenExpirationEpoch is not proof the token is still good server-side
+  (#5459, UAT row 183: a revoked-but-not-yet-expired cached token used to
+  sail through this check and only 403 on the authenticated UI's first real
+  call). An invalid cached token is cleared and falls through to a fresh
+  OIDC round-trip. API clients use /v1/* — never touched.
 
   GATE — DO NOT re-add `.Values.gateway.enabled`/`.Values.gateway.host` here
   (#3374, the hw167 2026-06-19 zero-click regression): the landing
@@ -205,14 +210,56 @@ data:
             .catch(function () { fail("Network error starting sign-in."); });
         }
 
-        // Already signed in? (re-entry / idempotent) — straight through.
+        // Already signed in? (re-entry / idempotent) — VALIDATE before
+        // trusting it (#5459, UAT row 183 regression). The prior code
+        // short-circuited straight to POST_LOGIN whenever the CLIENT-SIDE
+        // tokenExpirationEpoch (computed once, at mint time, from the auth
+        // response's lease_duration) still looked future-dated. That never
+        // learns about a SERVER-SIDE revoke that happens before the token's
+        // programmed TTL elapses (an explicit `bao token revoke`, an entity/
+        // alias delete, or any other Vault-internal invalidation) — the
+        // landing page still shows no login form (session-authenticity
+        // "holds") but the dead token then 403s on the FIRST real API call
+        // the authenticated Ember UI makes, `sys/internal/ui/mounts`, which
+        // renders "Not authorized" instead of the Secrets Engines list.
+        // Measured live on hw292 2026-08-06T06:06Z: no token form + `GET
+        // /v1/sys/internal/ui/mounts` 403 `permission denied`, reproduced
+        // 3/3 loads, while auth/oidc/role/operator + the sso-operator-admin/
+        // -read policies + the external sovereign-admins/-ops group mapping
+        // were independently confirmed correct and converged in BOTH
+        // regions throughout the exact failure window (zero WARNs in the
+        // sso-configure reconciler log) — the server-side ACL/OIDC state was
+        // never wrong; only the CLIENT trusted a token it never re-checked.
+        // Fix: ask the server (`auth/token/lookup-self`, the same call the
+        // exchange() path already uses for the cosmetic display name) BEFORE
+        // trusting the cache. A 200 confirms the token is still good — enter
+        // as before. Anything else clears the stale entry and falls through
+        // to begin() (fresh OIDC round-trip), which self-heals the session
+        // exactly as a first-time visit would.
+        function enterIfStillValid(tokenData) {
+          fetch(ORIGIN + "/v1/auth/token/lookup-self", {
+            credentials: "omit",
+            headers: { "X-Vault-Token": tokenData.token, "Accept": "application/json" }
+          }).then(function (r) {
+            if (r.ok) {
+              window.location.replace(POST_LOGIN);
+            } else {
+              try { window.localStorage.removeItem("vault-token" + "☃" + "1"); } catch (e) {}
+              begin();
+            }
+          }).catch(function () {
+            try { window.localStorage.removeItem("vault-token" + "☃" + "1"); } catch (e) {}
+            begin();
+          });
+        }
+
         try {
           var DELIM = "☃";
           var existing = window.localStorage.getItem("vault-token" + DELIM + "1");
           if (existing) {
             var ex = JSON.parse(existing);
             if (ex && ex.token && ex.tokenExpirationEpoch && ex.tokenExpirationEpoch > Date.now() + 30000) {
-              window.location.replace(POST_LOGIN);
+              enterIfStillValid(ex);
               return;
             }
           }

--- a/platform/openbao/chart/tests/_sso_landing_stale_token_check.js
+++ b/platform/openbao/chart/tests/_sso_landing_stale_token_check.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Helper for sso-landing-stale-token-revalidate.sh (#5459, UAT row 183).
+//
+// Loads the ACTUAL landing-page <script> body extracted from a live `helm
+// template` render (never a hand-copied snippet — this is what would have
+// masked the regression) into a Node `vm` context with mocked
+// window/document/localStorage/fetch, seeds a CACHED token whose
+// CLIENT-SIDE tokenExpirationEpoch is far in the future (looks valid), and
+// observes two things the real browser would do: which URLs the script
+// fetch()es, and what it passes to window.location.replace().
+//
+// Usage: node _sso_landing_stale_token_check.js <path-to-extracted-js> <scenario>
+//   scenario = "revoked" -> mock GET .../auth/token/lookup-self => 403
+//   scenario = "valid"   -> mock GET .../auth/token/lookup-self => 200
+//
+// Prints one JSON line: {"fetchCalls":[...],"replaceCalls":[...]}
+
+'use strict';
+const fs = require('fs');
+const vm = require('vm');
+
+const jsPath = process.argv[2];
+const scenario = process.argv[3];
+if (!jsPath || !scenario) {
+  console.error('usage: node _sso_landing_stale_token_check.js <js-file> <revoked|valid>');
+  process.exit(2);
+}
+const src = fs.readFileSync(jsPath, 'utf8');
+
+function makeStorage(initial) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: function (k) { return map.has(k) ? map.get(k) : null; },
+    setItem: function (k, v) { map.set(k, String(v)); },
+    removeItem: function (k) { map.delete(k); },
+  };
+}
+
+const fetchCalls = [];
+const replaceCalls = [];
+
+// A token that LOOKS locally valid — ttl 24h, minted "now" — but whose
+// server-side fate is controlled by `scenario` below. This is the exact
+// shape persist() in the landing page writes.
+const cached = JSON.stringify({
+  token: 's.testcachedtoken00000',
+  policies: ['default', 'sso-operator-read'],
+  renewable: true,
+  entity_id: 'e-test-0000',
+  ttl: 86400,
+  tokenExpirationEpoch: Date.now() + 24 * 3600 * 1000,
+});
+
+const storage = makeStorage({ 'vault-token☃1': cached });
+
+function mockFetch(url) {
+  fetchCalls.push(String(url));
+  if (String(url).indexOf('/auth/token/lookup-self') !== -1) {
+    if (scenario === 'valid') {
+      return Promise.resolve({ ok: true, status: 200, json: function () { return Promise.resolve({ data: { display_name: 'oidc-test' } }); } });
+    }
+    return Promise.resolve({ ok: false, status: 403, json: function () { return Promise.resolve({ errors: ['permission denied'] }); } });
+  }
+  if (String(url).indexOf('/oidc/auth_url') !== -1) {
+    return Promise.resolve({ ok: true, status: 200, json: function () { return Promise.resolve({ data: { auth_url: 'https://kc.example.test/realms/sovereign/protocol/openid-connect/auth?x=1' } }); } });
+  }
+  return Promise.reject(new Error('unexpected fetch: ' + url));
+}
+
+function stubEl() {
+  return { style: {}, textContent: '', innerHTML: '' };
+}
+
+const ctx = {
+  console: console,
+  Date: Date,
+  JSON: JSON,
+  URLSearchParams: URLSearchParams,
+  Promise: Promise,
+  window: {
+    location: {
+      origin: 'https://bao.hw133.omani.works',
+      search: '',
+      replace: function (url) { replaceCalls.push(String(url)); },
+    },
+    localStorage: storage,
+  },
+  document: { getElementById: stubEl },
+  fetch: mockFetch,
+};
+vm.createContext(ctx);
+vm.runInContext(src, ctx, { filename: 'sso-landing.js' });
+
+// The re-entry path chains at least one `.then` (lookup-self) and, on the
+// invalid branch, a second round-trip (begin() -> auth_url). Flush the
+// microtask/macrotask queue before reporting.
+setTimeout(function () {
+  process.stdout.write(JSON.stringify({ fetchCalls: fetchCalls, replaceCalls: replaceCalls }) + '\n');
+}, 100);

--- a/platform/openbao/chart/tests/sso-landing-stale-token-revalidate.sh
+++ b/platform/openbao/chart/tests/sso-landing-stale-token-revalidate.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# bp-openbao — SSO landing MUST re-validate a cached token server-side before
+# trusting it (#5459, UAT row 183 regression, measured live hw292
+# 2026-08-06T06:06Z).
+#
+# WHY: the landing page's "already signed in? -> straight through" re-entry
+# fast path used to trust a CLIENT-SIDE tokenExpirationEpoch alone. That
+# value is computed once, at mint time, from the auth response's
+# lease_duration — it has no way to learn that the token was later revoked
+# server-side (explicit revoke, entity/alias churn, any other Vault-internal
+# invalidation) before its programmed TTL elapsed. The landing page still
+# shows no login form (session-authenticity "holds") but redirects straight
+# into the authenticated Ember UI with a dead token, which then 403s on its
+# first real call (`sys/internal/ui/mounts`) — "Not authorized" instead of
+# the Secrets Engines list. Independently confirmed on hw292: the server-side
+# ACL/OIDC-role/identity-group state was correct and converged in BOTH
+# regions throughout the exact failure window (zero WARNs in the
+# openbao-sso-configure reconciler log across 06:00-06:12Z) — the defect is
+# the CLIENT never re-checking a cache it blindly trusted.
+#
+# This guard extracts the ACTUAL landing-page <script> body from a live
+# `helm template` render (never a hand-copied snippet — a copy would mask
+# the exact regression this pins) and runs it in a Node vm with a mocked
+# fetch/localStorage/window, seeding a token that LOOKS locally valid (24h
+# future tokenExpirationEpoch) while a mocked `auth/token/lookup-self`
+# reports it dead server-side (403). It must NOT be a `must_contain`
+# string-grep — this proves BEHAVIOR: does the script actually ask the
+# server before deciding to enter, and does it correctly refuse to enter on
+# a 403 answer.
+#
+# Two scenarios + a vacuity control so the guard cannot pass on nothing:
+#   1. revoked -> lookup-self 403: the landing page MUST call lookup-self
+#      BEFORE any window.location.replace, and MUST NOT end up navigating to
+#      /ui/vault/secrets with the dead token (must fall through to a fresh
+#      OIDC round-trip instead).
+#   2. valid   -> lookup-self 200: the SAME code path MUST still complete
+#      normally and land on /ui/vault/secrets (proves the fix isn't just
+#      "never redirect" — a genuinely-valid cached token still short-circuits).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+test_dir="$(cd "$(dirname "$0")" && pwd)"
+helm="${HELM_BIN:-helm}"
+node_bin="${NODE_BIN:-node}"
+
+command -v "$node_bin" >/dev/null 2>&1 || { echo "SKIP: node not available"; exit 0; }
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+FQDN="hw133.omani.works"
+HOST="bao.${FQDN}"
+
+"$helm" template smoke "$chart_dir" \
+  --set gateway.enabled=true \
+  --set "gateway.host=${HOST}" \
+  --set "sso.sovereignFqdn=${FQDN}" \
+  > "$work/render.out"
+
+# Extract the landing page's inline <script> body. index.html is embedded
+# in the openbao-sso-landing ConfigMap as a literal-block; the <script> tag
+# is unique in the whole render.
+awk '/<script>/{f=1;next} /<\/script>/{f=0} f' "$work/render.out" > "$work/landing.js"
+
+if [ ! -s "$work/landing.js" ]; then
+  echo "FAIL: could not extract the landing page <script> body from the render"
+  exit 1
+fi
+"$node_bin" --check "$work/landing.js" || { echo "FAIL: extracted landing.js is not valid JavaScript"; exit 1; }
+
+run_scenario() {
+  # $1 = scenario name
+  "$node_bin" "$test_dir/_sso_landing_stale_token_check.js" "$work/landing.js" "$1"
+}
+
+echo "[bp-openbao] Case 7: cached-but-revoked token — re-entry must re-validate before entering"
+out_revoked="$(run_scenario revoked)"
+echo "  observed: $out_revoked"
+
+case "$out_revoked" in
+  *'"fetchCalls":[]'*)
+    echo "FAIL: re-entry never called the server at all (blind trust of the cached token — the exact #5459 regression)"
+    exit 1
+    ;;
+esac
+case "$out_revoked" in
+  *'lookup-self'*) : ;;
+  *)
+    echo "FAIL: re-entry did not call auth/token/lookup-self to validate the cached token"
+    exit 1
+    ;;
+esac
+# The dead token must NEVER be trusted into /ui/vault/secrets.
+case "$out_revoked" in
+  *'"replaceCalls":['*'/ui/vault/secrets'*)
+    echo "FAIL: landing page navigated to /ui/vault/secrets with a server-revoked cached token (regressed — will 403 on mounts, UAT row 183)"
+    exit 1
+    ;;
+esac
+# It MUST still recover — falling through to a fresh OIDC round-trip
+# (begin() -> auth_url), not just silently dead-ending.
+case "$out_revoked" in
+  *'realms/sovereign/protocol/openid-connect/auth'*) : ;;
+  *)
+    echo "FAIL: a revoked cached token did not fall through to a fresh OIDC login (begin()/auth_url never reached)"
+    exit 1
+    ;;
+esac
+echo "[bp-openbao] Case 7: PASS"
+
+echo "[bp-openbao] Case 8: vacuity control — a GENUINELY valid cached token must still short-circuit straight through"
+out_valid="$(run_scenario valid)"
+echo "  observed: $out_valid"
+case "$out_valid" in
+  *'lookup-self'*) : ;;
+  *) echo "FAIL: valid-token scenario never called lookup-self either (harness broken)"; exit 1 ;;
+esac
+case "$out_valid" in
+  *'"replaceCalls":['*'/ui/vault/secrets'*) : ;;
+  *)
+    echo "FAIL: a server-CONFIRMED-valid cached token failed to short-circuit into /ui/vault/secrets (guard would trivially pass by banning ALL redirects — that is not this fix)"
+    exit 1
+    ;;
+esac
+echo "[bp-openbao] Case 8: PASS"
+
+echo "[bp-openbao] All stale-token-revalidate cases PASS"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T07:15:06.330Z",
+  "generatedAt": "2026-08-06T09:35:07.466Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4960,7 +4960,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T07:02:35.350Z",
+  "generatedAt": "2026-08-06T07:15:06.330Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -3620,7 +3620,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.64",
+      "version": "1.2.65",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
@@ -4960,7 +4960,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.15",
+      "version": "0.1.14",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3755,7 +3755,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.64",
+    "version": "1.2.65",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3735,7 +3735,13 @@ name: bp-catalyst-platform
 #   documented contract (its own SIGPIPE on this file's size made a manual
 #   application necessary this time; arithmetic verified against
 #   scripts/check-chart-version-forward.sh before writing).
-version: 1.4.1328
+# 1.4.1329 — #5459: catalog-seed bp-openbao source.version + spec.version
+#   1.2.64 -> 1.2.65 (SSO landing re-validates a cached token before trusting
+#   it — UAT row 183). check-umbrella-republish-gate.py (#5734) requires this
+#   file's version to move in the SAME PR as any catalog-seed pin move, else
+#   the published bp-catalyst-platform OCI artifact never carries the pin.
+#   Serialized to 1.4.1329 because #5764 took 1.4.1328 on main first.
+version: 1.4.1329
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3885,7 +3891,7 @@ version: 1.4.1328
 #   unsatisfiable on kom4dc (me-east-215-*), which kept the production
 #   Continuum seed unfireable. Backwards-compatible (all-letter labels
 #   still match). Flux CreateReplace flows it to live Sovereigns.
-appVersion: 1.4.1328
+appVersion: 1.4.1329
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3471,7 +3471,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.64"
+  version: "1.2.65"
   visibility: unlisted
   card:
     title: "OpenBao"
@@ -3496,7 +3496,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openbao
-    version: "1.2.64"
+    version: "1.2.65"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## Summary
- Row 183 flipped `✅→⚠️` on hw292 2026-08-06T06:06Z: bare-URL SSO landing still lands signed-in (no token form) but `GET /v1/sys/internal/ui/mounts` 403s, so the Secrets Engines listing renders "Not authorized".
- Live-verified in BOTH hw292 regions that the OIDC role, `sso-operator-read`/`-admin` policies, and the `sovereign-admins`/`-ops` external group bindings are byte-identical and correctly converged (zero WARNs in the `openbao-sso-configure` reconciler log across the full 06:00–06:12Z failure window); a genuine fresh OIDC login succeeds. This ruled out a policy/role regression.
- Root cause: `platform/openbao/chart/templates/sso-landing.yaml`'s re-entry fast path ("already signed in? → straight through") trusted a cached token's CLIENT-SIDE `tokenExpirationEpoch` alone, with no server-side check — a token revoked server-side before its programmed TTL elapses sails through and 403s on the UI's first real API call. Introduced in `8a61b6844` (2026-06-14); latent until triggered on hw292.
- Fix: the re-entry path now calls `auth/token/lookup-self` before trusting the cache; a non-200 clears the stale entry and falls through to a fresh OIDC round-trip.
- Row 183 verdict is left at `⚠️` — this PR does not flip it; that only happens on a fresh live re-walk.

## Test plan
- [x] `platform/openbao/chart/tests/sso-landing-stale-token-revalidate.sh` — new guard, extracts the ACTUAL landing-page `<script>` from a live `helm template` render (not a hand-copied snippet) and runs it in a Node `vm` with mocked `fetch`/`localStorage`. RED on the pre-fix tree (`fetchCalls:[]`, straight `replace` to `/ui/vault/secrets` with a server-revoked token) — verified via `git stash` on the template file. GREEN post-fix, plus a vacuity control proving a genuinely-valid cached token still short-circuits normally.
- [x] Full `platform/openbao/chart/tests/*.sh` suite green (existing `sso-landing-render.sh` Cases 1–6 unaffected).
- [x] `helm lint` clean.
- [x] `scripts/check-bootstrap-kit-pin-sync.sh` — `bp-openbao: chart=1.2.65 pin=1.2.65` OK.
- [x] `scripts/check-catalog-seed-lockstep.sh` — PASS.
- [x] `tests/e2e/bootstrap-kit` go suite — PASS.
- [x] `blueprints.json` regenerated via `build-catalog.mjs`, diff confined to the `bp-openbao` version + `generatedAt`.
- [ ] Fresh live UAT re-walk of row 183 on hw292 (or next fresh prov) to confirm the flip and restamp the row — tracked on #5459.

Refs #960 #5459
