### PR TITLE
fix(deploy-bot): make Chart.yaml version bump atomic and forward-only

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -710,25 +710,30 @@ jobs:
           grep -E "image: \".*catalyst-(api|ui):" "${API_KUST_TPL}" "${UI_KUST_TPL}"
           grep -A1 "CATALYST_BUILD_SHA" "${API_TPL}" | head -2
 
-          # Wave 5.48 (#2272) — bump bp-catalyst-platform Chart.yaml patch
-          # version so Blueprint Release re-publishes the OCI artifact
-          # pointing at the bumped image SHAs. Without this bump, Blueprint
-          # Release skips re-publish (it only triggers on chart-content
-          # changes per blueprint-release.yaml:617-639) → Flux on every
-          # Sovereign sees the same chart version → no roll → Wave 5.44/
-          # 5.47 stuck on hw01 for 25+ minutes after merge before being
-          # surfaced. Surfaced live on hw01 2026-05-24T05:48Z.
-          CHART_YAML="products/catalyst/chart/Chart.yaml"
-          CUR_VER=$(grep -E '^version: 1\.4\.[0-9]+$' "${CHART_YAML}" | head -1 | awk '{print $2}')
-          if [ -z "${CUR_VER}" ]; then
-            echo "::error title=Wave 5.48 chart-bump failed::Could not parse version: from ${CHART_YAML}"
-            exit 1
-          fi
-          CUR_PATCH="${CUR_VER##*.}"
-          NEXT_PATCH=$((CUR_PATCH + 1))
-          NEXT_VER="1.4.${NEXT_PATCH}"
-          sed -i -E "s|^version: 1\.4\.[0-9]+\$|version: ${NEXT_VER}|" "${CHART_YAML}"
-          echo "Chart.yaml version bump: ${CUR_VER} -> ${NEXT_VER}"
+          # Wave 5.48 (#2272) used to bump bp-catalyst-platform Chart.yaml's
+          # `version:` right here, in the same working-tree pass as the image
+          # SHA edits above, then let it ride to origin/main bundled inside
+          # the "Commit and push manifest updates" step's ONE commit below.
+          #
+          # #5743 (2026-08-06): that in-place sed computed NEXT_VER ONCE from
+          # whatever this job's checkout happened to show, never touched
+          # `appVersion:` at all, and rode the generic `deploy-bump` composite
+          # action's push-conflict recovery — a cherry-pick with `-X theirs`,
+          # correct for a last-writer-wins image tag but wrong for a monotonic
+          # counter. On a real race against services-build.yaml's own
+          # Chart.yaml bump, that recovery path blindly overwrote origin/main's
+          # ALREADY-HIGHER version with this job's stale pre-computed number:
+          # commit b76f3ca7b landed version=1.4.1324 as a direct child of
+          # a23de78d9 (version=1.4.1325) — the higher-numbered, earlier-
+          # published 1.4.1325 artifact turned out to carry FEWER fixes than
+          # the "regressed" 1.4.1324 that published four minutes later.
+          #
+          # The version/appVersion bump now happens in its OWN dedicated,
+          # atomic step below ("Atomically bump Chart.yaml version"), driven
+          # by scripts/bump-chart-version.sh + scripts/push-chart-version-
+          # bump.sh — the SAME two scripts services-build.yaml now calls for
+          # its half of this same field, so the two deploy-bots can never
+          # diverge on how "next version" is computed again.
 
           # contabo's catalyst-platform Kustomization at
           # ./products/catalyst/chart/templates reconciles every 10 min
@@ -884,8 +889,51 @@ jobs:
             products/catalyst/chart/templates/api-deployment-kustomize.yaml
             products/catalyst/chart/templates/ui-deployment.yaml
             products/catalyst/chart/templates/ui-deployment-kustomize.yaml
-            products/catalyst/chart/Chart.yaml
           commit-message: "deploy: update catalyst images to ${{ needs.build-ui.outputs.sha_short }} (+ #2851 controller sweep)"
+
+      # ──────────────────────────────────────────────────────────────
+      # ATOMIC CHART VERSION BUMP (Refs #5743)
+      # ──────────────────────────────────────────────────────────────
+      # Runs as its OWN commit, deliberately decoupled from the image/
+      # template bump above: that field is legitimately last-writer-wins
+      # (whichever build's image tag lands last is correct) and stays on
+      # the generic `deploy-bump` composite action. Chart.yaml's
+      # `version:`/`appVersion:` pair is a MONOTONIC COUNTER shared with
+      # services-build.yaml's own bump of the same file — a different
+      # conflict-resolution policy is required, so it gets its own retry
+      # loop via the shared, independently-tested scripts:
+      #
+      #   scripts/bump-chart-version.sh        — read-modify-write: always
+      #     re-reads origin/main's CURRENT version+appVersion (never a
+      #     value snapshotted earlier in this job) and derives
+      #     next = max(version, appVersion) + 1, so it can never regress
+      #     either field and self-heals any pre-existing drift.
+      #   scripts/check-chart-version-forward.sh — the hard guard, called
+      #     internally by bump-chart-version.sh before it writes anything:
+      #     fails loudly unless the new version strictly exceeds BOTH old
+      #     fields and new version == new appVersion.
+      #   scripts/push-chart-version-bump.sh   — commits + pushes with a
+      #     5-attempt retry that resets to fresh origin/main and re-calls
+      #     bump-chart-version.sh on every attempt, so a losing race just
+      #     means "compute a still-higher number and try again" — there is
+      #     no stale intent commit anywhere for a conflict policy to fall
+      #     back on. Proven under a real concurrent race in
+      #     scripts/tests/test-chart-version-forward.sh (T5).
+      - name: "Atomically bump products/catalyst/chart/Chart.yaml version"
+        id: bump_chart_version
+        run: |
+          set -euo pipefail
+          git config user.name  "hatiyildiz"
+          git config user.email "269457768+hatiyildiz@users.noreply.github.com"
+          NEXT="$(scripts/push-chart-version-bump.sh \
+            products/catalyst/chart/Chart.yaml \
+            "deploy(bp-catalyst-platform): bump chart version")"
+          if [ -n "${NEXT}" ]; then
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # Closes #712. The push above is made by GITHUB_TOKEN; per GitHub
       # Actions design, commits authored by GITHUB_TOKEN do NOT re-trigger
@@ -897,8 +945,13 @@ jobs:
       # SHA was superseded). Explicit workflow_dispatch reliably re-runs
       # blueprint-release on every deploy commit, picking up the new
       # values.yaml SHA tags.
+      #
+      # #5743: gated on the CHART VERSION bump's own push outcome, not the
+      # image/template commit's — publishing only makes sense once
+      # Chart.yaml's version actually moved (it is what blueprint-release
+      # reads to name the OCI artifact).
       - name: Trigger blueprint-release for the chart bump
-        if: steps.deploy_commit.outputs.pushed == 'true'
+        if: steps.bump_chart_version.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/check-chart-version-forward.yaml
+++ b/.github/workflows/check-chart-version-forward.yaml
@@ -1,0 +1,78 @@
+name: check-chart-version-forward
+
+# #5743 — assert a chart's `version:` can never move backward relative to
+# origin/main, and that `version == appVersion`, across a deploy-bot bump.
+#
+# WHY THIS EXISTS. Two independent deploy-bots (catalyst-build.yaml's Wave-
+# 5.48 step and services-build.yaml's own bump) raced to patch-bump
+# products/catalyst/chart/Chart.yaml `version:`, each computing "next" from a
+# value captured earlier in its own job rather than from origin/main at push
+# time. On a real push-conflict, catalyst-build.yaml's retry path (the shared
+# `deploy-bump` composite action's `-X theirs` cherry-pick — correct for a
+# last-writer-wins image tag, wrong for a monotonic counter) blindly
+# overwrote origin/main's ALREADY-HIGHER version with a stale, lower one:
+#
+#   04:06:32  a23de78d9  version=1.4.1325  appVersion=1.4.1325
+#   04:07:56  GHCR publishes 1.4.1325   (carries #5737's storage fix)
+#   04:08:28  b76f3ca7b  version=1.4.1324  appVersion=1.4.1325   <- BACKWARDS
+#   04:10:30  GHCR publishes 1.4.1324   (does NOT carry #5737's fix)
+#
+# The existing five-site lockstep guard (check-release-lockstep-writer.yaml)
+# does not catch this — it only asserts the five #817 sites agree WITH EACH
+# OTHER, never that the version moved forward relative to origin/main.
+# Self-consistent is not the same as correct (the #5741 distinction).
+#
+# scripts/bump-chart-version.sh + scripts/push-chart-version-bump.sh (now
+# called by BOTH deploy-bots) are the PREVENTIVE fix. This workflow is the
+# DETECTIVE backstop: it runs scripts/tests/test-chart-version-forward.sh,
+# which proves scripts/check-chart-version-forward.sh rejects the REAL
+# historical incident pair (not a synthetic `2.0.0 -> 1.0.0` fixture —
+# docs/PRINCIPLES.md A18: a guard proven only against synthetic input failed
+# to catch the very commit that motivated it) and that the fixed atomic
+# mechanism converges instead of repeating the incident under a real
+# concurrent push race against a bare repo.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/check-chart-version-forward.sh'
+      - 'scripts/bump-chart-version.sh'
+      - 'scripts/push-chart-version-bump.sh'
+      - 'scripts/tests/test-chart-version-forward.sh'
+      - '.github/workflows/catalyst-build.yaml'
+      - '.github/workflows/services-build.yaml'
+      - '.github/workflows/check-chart-version-forward.yaml'
+      - '.github/actions/deploy-bump/action.yaml'
+      - 'products/catalyst/chart/Chart.yaml'
+  pull_request:
+    paths:
+      - 'scripts/check-chart-version-forward.sh'
+      - 'scripts/bump-chart-version.sh'
+      - 'scripts/push-chart-version-bump.sh'
+      - 'scripts/tests/test-chart-version-forward.sh'
+      - '.github/workflows/catalyst-build.yaml'
+      - '.github/workflows/services-build.yaml'
+      - '.github/workflows/check-chart-version-forward.yaml'
+      - '.github/actions/deploy-bump/action.yaml'
+      - 'products/catalyst/chart/Chart.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    name: guard rejects the real #5743 incident, accepts a correct bump, converges under a real race
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history — the self-test extracts the ACTUAL Chart.yaml blob
+          # content from the real 215d6e4bf / a23de78d9 / b76f3ca7b commits
+          # (falling back to hardcoded values verified 2026-08-06 if a
+          # shallow clone or history rewrite ever makes them unreachable).
+          fetch-depth: 0
+
+      - name: Prove the guard goes RED for the real incident and GREEN once fixed
+        run: bash scripts/tests/test-chart-version-forward.sh

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -87,12 +87,11 @@ jobs:
       # The manual chart-version field in the PR becomes the floor; the
       # CI auto-bumps from there.
       # ──────────────────────────────────────────────────────────────
-      - name: Update deployment manifests + bump chart patch version
+      - name: Update deployment manifests
         id: rewrite
         run: |
           SHA=$(echo $GITHUB_SHA | head -c 7)
           DEPLOY_DIR="products/catalyst/chart/templates/org-services"
-          CHART_YAML="products/catalyst/chart/Chart.yaml"
           VALUES_YAML="products/catalyst/chart/values.yaml"
 
           # ──────────────────────────────────────────────────────────
@@ -155,23 +154,29 @@ jobs:
           sed -i "s|^  orgTag: \"[A-Za-z0-9_.-]*\"$|  orgTag: \"${SHA}\"|" "${VALUES_YAML}"
           echo "Bumped ${VALUES_YAML} images.orgTag to ${SHA}"
 
-          # Patch-bump Chart.yaml `version:` and `appVersion:` (kept in
-          # lockstep — the chart reflects the bundled appVersion via
-          # convention). Pure-bash semver patch increment to avoid
-          # depending on yq in this job.
-          current=$(awk '/^version:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')
-          if ! echo "$current" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error title=Unparseable chart version::Chart.yaml version='${current}' is not semver MAJOR.MINOR.PATCH; refusing to auto-bump."
-            exit 1
-          fi
-          major=$(echo "$current" | cut -d. -f1)
-          minor=$(echo "$current" | cut -d. -f2)
-          patch=$(echo "$current" | cut -d. -f3)
-          next="${major}.${minor}.$((patch + 1))"
-          sed -i "s|^version: .*$|version: ${next}|" "${CHART_YAML}"
-          sed -i "s|^appVersion: .*$|appVersion: ${next}|" "${CHART_YAML}"
-          echo "Bumped Chart.yaml ${current} -> ${next}"
-          echo "next_version=${next}" >> "$GITHUB_OUTPUT"
+          # #5743: Chart.yaml `version:`/`appVersion:` used to be patch-
+          # bumped right here (and again inside this step's own retry
+          # closure below) with hand-rolled arithmetic that read ONLY
+          # `version:`, never `appVersion:`, into lockstep. catalyst-
+          # build.yaml bumped the SAME file with a SEPARATE hand-rolled
+          # implementation that routed through the generic `deploy-bump`
+          # composite action's last-writer-wins `-X theirs` cherry-pick —
+          # correct for an image tag, wrong for a monotonic counter. The
+          # two independent implementations racing each other on one field
+          # produced the incident: commit b76f3ca7b (catalyst-build.yaml's
+          # bump) landed version=1.4.1324 as a direct child of a23de78d9
+          # (THIS workflow's bump, version=1.4.1325) — a lower, later-
+          # published version number that carried FEWER fixes than the
+          # higher, earlier-published one it clobbered.
+          #
+          # The bump now happens in its own dedicated step below
+          # ("Atomically bump Chart.yaml version"), via the SAME two
+          # shared scripts catalyst-build.yaml now calls
+          # (scripts/bump-chart-version.sh + scripts/push-chart-version-
+          # bump.sh) — one implementation, one guard
+          # (scripts/check-chart-version-forward.sh), so the two
+          # deploy-bots can never diverge on "what is the next version"
+          # again.
 
       - name: Commit and push manifest updates
         id: deploy_commit
@@ -180,17 +185,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           SHA=$(echo $GITHUB_SHA | head -c 7)
           DEPLOY_DIR="products/catalyst/chart/templates/org-services"
-          CHART_YAML="products/catalyst/chart/Chart.yaml"
           VALUES_YAML="products/catalyst/chart/values.yaml"
 
           # Idempotent reset-and-rewrite. Parallel/back-to-back CI runs
-          # both try to update the same `image:` lines AND the same
-          # version line — `git pull --rebase` would hit content
-          # conflicts. Idempotent reset-to-origin + re-apply is
-          # conflict-free by construction. On retry we re-read whatever
-          # version origin/main currently holds and bump from THAT, so
-          # two concurrent runs produce strictly increasing patch
-          # versions instead of clobbering each other.
+          # both try to update the same `image:` lines — `git pull
+          # --rebase` would hit content conflicts. Idempotent reset-to-
+          # origin + re-apply is conflict-free by construction.
           #
           # Issue #953: rewrite() must mirror the values.yaml orgTag
           # bump that the rewrite step does — otherwise a retry that
@@ -212,18 +212,6 @@ jobs:
               exit 1
             fi
             sed -i "s|^  orgTag: \"[A-Za-z0-9_.-]*\"$|  orgTag: \"${SHA}\"|" "${VALUES_YAML}"
-            current=$(awk '/^version:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')
-            if ! echo "$current" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "::error title=Unparseable chart version on retry::Chart.yaml version='${current}' is not semver."
-              exit 1
-            fi
-            major=$(echo "$current" | cut -d. -f1)
-            minor=$(echo "$current" | cut -d. -f2)
-            patch=$(echo "$current" | cut -d. -f3)
-            next="${major}.${minor}.$((patch + 1))"
-            sed -i "s|^version: .*$|version: ${next}|" "${CHART_YAML}"
-            sed -i "s|^appVersion: .*$|appVersion: ${next}|" "${CHART_YAML}"
-            echo "${next}"
           }
 
           git add products/
@@ -232,49 +220,76 @@ jobs:
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          NEXT="${{ steps.rewrite.outputs.next_version }}"
-          git commit -m "deploy: update org service images to ${SHA} + bump chart to ${NEXT}"
+          git commit -m "deploy: update org service images to ${SHA}"
 
           # TBD-V32 / openova-io/openova#2062 — race-safe push loop.
           # NOTE: this workflow deliberately does NOT use the shared
-          # `./.github/actions/deploy-bump` composite action. The rewrite
-          # closure above bumps the chart semver `patch` segment on every
-          # iteration so a rebased push lands at chart `vN.M.P+2` instead
-          # of `+1` — that re-bump only happens correctly inside this
-          # inline loop because the composite action treats files as
-          # opaque and would replay the SAME staged diff on every retry,
-          # which would lose to the parallel run that bumped the same
-          # patch number first. Bumping the max-attempts ceiling from 3
-          # to 5 matches the composite action default.
+          # `./.github/actions/deploy-bump` composite action — its
+          # `-X theirs` cherry-pick conflict policy is a deliberate
+          # last-writer-wins choice, correct for image tags but WRONG for
+          # the chart version counter this job used to also carry (#5743);
+          # now that Chart.yaml moved to its own step, plain reset-and-
+          # reapply is sufficient here again. Bumping the max-attempts
+          # ceiling from 3 to 5 matches the composite action default.
           for i in 1 2 3 4 5; do
             if git push; then
               echo "pushed=true" >> "$GITHUB_OUTPUT"
-              echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "push attempt $i failed — resetting to origin/main and re-applying rewrite"
             git fetch origin main
             git reset --hard origin/main
-            NEXT=$(rewrite)
+            rewrite
             git add products/
             if git diff --staged --quiet; then
               echo "no changes after re-fetch — another run already shipped this SHA"
               echo "pushed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            git commit -m "deploy: update org service images to ${SHA} + bump chart to ${NEXT}"
+            git commit -m "deploy: update org service images to ${SHA}"
             sleep $((i * 2))
           done
           echo "push failed after 5 attempts"
           exit 1
+
+      # ──────────────────────────────────────────────────────────────
+      # ATOMIC CHART VERSION BUMP (Refs #5743)
+      # ──────────────────────────────────────────────────────────────
+      # See the matching step in catalyst-build.yaml for the full
+      # rationale. Runs regardless of whether the image-tag commit above
+      # actually pushed anything (mirrors this workflow's previous
+      # unconditional per-run bump behaviour) — deriving from fresh
+      # origin/main on every attempt via scripts/bump-chart-version.sh
+      # means a no-op image-tag run still safely advances the chart
+      # version by exactly one step, in lockstep, never regressing either
+      # field.
+      - name: "Atomically bump products/catalyst/chart/Chart.yaml version"
+        id: bump_chart_version
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          NEXT="$(scripts/push-chart-version-bump.sh \
+            products/catalyst/chart/Chart.yaml \
+            "deploy(bp-catalyst-platform): bump chart version")"
+          if [ -n "${NEXT}" ]; then
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # GITHUB_TOKEN-authored pushes do NOT re-trigger workflows by
       # design, so a `push` path-trigger on blueprint-release.yaml is
       # not enough on its own — we must explicitly dispatch. Same
       # mechanism catalyst-build.yaml uses (PR #720) to publish the
       # bp-catalyst-platform OCI artifact for the bumped chart.
+      #
+      # #5743: gated on the CHART VERSION bump's own push outcome, not the
+      # image-tag commit's — publishing only makes sense once Chart.yaml's
+      # version actually moved.
       - name: Trigger blueprint-release for the chart bump
-        if: steps.deploy_commit.outputs.pushed == 'true'
+        if: steps.bump_chart_version.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -283,4 +298,4 @@ jobs:
             --ref main \
             -f blueprint=catalyst \
             -f tree=products
-          echo "blueprint-release dispatched for products/catalyst @ main (chart ${{ steps.deploy_commit.outputs.next_version }})"
+          echo "blueprint-release dispatched for products/catalyst @ main (chart ${{ steps.bump_chart_version.outputs.next_version }})"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,26 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# KNOWN-BAD, SUPERSEDED ARTIFACT — 1.4.1325 (Refs #5743). A push race between
+#   two independent deploy-bots (catalyst-build.yaml + services-build.yaml,
+#   see scripts/bump-chart-version.sh's header for the mechanism) put
+#   version=1.4.1325/appVersion=1.4.1325 on origin/main and GHCR at 04:07:56Z
+#   on 2026-08-06, four minutes before a racing bump clobbered `version:`
+#   BACKWARD to 1.4.1324 (appVersion stayed 1.4.1325 — the divergence itself
+#   is the tell). `helm pull` of both published artifacts proved 1.4.1325
+#   does NOT carry #5737's storage fix that 1.4.1324 does, despite being the
+#   numerically higher, earlier-published version.
+#   DISPOSITION: 1.4.1325 is left published but PERMANENTLY UNPINNED — never
+#   reference it from any bootstrap-kit slot, blueprint.yaml, or catalog-seed
+#   entry. It is NOT re-published with corrected content: chart artifacts are
+#   treated as immutable once pushed (cosign attestations + any consumer that
+#   already resolved its digest are bound to the ORIGINAL, bad bytes;
+#   overwriting the tag would silently break that binding). The remedy is
+#   forward-only — burn the number. The fixed atomic bump
+#   (scripts/bump-chart-version.sh) derives every future version from
+#   max(version, appVersion) + 1, so the very next legitimate bump after this
+#   fix lands moves past BOTH 1.4.1325 and the still-live 1.4.1327/1.4.1325
+#   drift this incident left on main, self-healing without a manual
+#   reconciliation commit.
 # 1.4.1322 — #5439: catalog-seed bp-self-sovereign-cutover pin 0.1.173 ->
 #   0.1.174. Step-07 gains Phase 3e, the IMAGE-registry half of the
 #   post-cutover re-tether #5527 closed for CHART bases: the org-controller,

--- a/scripts/bump-chart-version.sh
+++ b/scripts/bump-chart-version.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# bump-chart-version.sh — Refs #5743
+#
+# Atomically compute the NEXT `version:`/`appVersion:` pair for a Blueprint
+# Chart.yaml and write both fields into the LOCAL working copy, in lockstep.
+#
+# WHY THIS EXISTS
+# ----------------
+# Before this script, two separate deploy-bots (catalyst-build.yaml and
+# services-build.yaml) each hand-rolled their own patch-bump arithmetic
+# against products/catalyst/chart/Chart.yaml, computed ONCE from whatever
+# was in their own job's checkout — a value that can be, and on 2026-08-06
+# was, stale by the time the commit actually pushed. catalyst-build.yaml's
+# copy of the bump additionally only ever touched `version:`, never
+# `appVersion:`, so the two fields drifted on every run where only it fired
+# (main carries version=1.4.1327 / appVersion=1.4.1325 right now — three
+# catalyst-build.yaml runs after the incident, still unreconciled).
+#
+# This script is the single source of truth for "what is the next chart
+# version", called FRESH on every attempt (initial push AND every retry) by
+# both deploy-bots:
+#
+#   - It NEVER trusts the local working tree's current Chart.yaml. It always
+#     `git fetch`es and reads the BASELINE straight from `origin/main` via
+#     `git show`, so a stale checkout can never poison the computed number —
+#     the read half of the read-modify-write is pinned to the moment of the
+#     call, not the moment the job started.
+#   - next_version = bump_patch(max(baseline_version, baseline_appVersion)).
+#     Taking the MAX of both fields (not just `version:`) means the very
+#     first call after this fix lands SELF-HEALS the existing 1.4.1327 /
+#     1.4.1325 drift instead of perpetuating it, and a bump can never regress
+#     either field.
+#   - Before writing anything it calls check-chart-version-forward.sh as a
+#     self-check on its own arithmetic — belt-and-braces against a bug in
+#     this very script shipping the same class of defect it exists to kill.
+#   - Writes ONLY the two version fields; the caller is responsible for
+#     staging, committing, pushing, and — on push rejection — re-invoking
+#     this script after `git fetch && git reset --hard origin/main`. Because
+#     the read is always fresh, every retry naturally derives a number
+#     strictly above whatever landed on origin/main in the meantime; there is
+#     no stale value anywhere in this script for a conflict-resolution policy
+#     to fall back on.
+#
+# Usage:
+#   bump-chart-version.sh <path/to/Chart.yaml>
+#
+# Contract:
+#   - All diagnostics go to stderr.
+#   - The ONLY thing printed to stdout is the final next_version, so callers
+#     can do `NEXT=$(bump-chart-version.sh path/to/Chart.yaml)`.
+#
+# Exit 0: bumped; next_version on stdout.
+# Exit 1: any failure — missing file, unparseable baseline, guard rejection,
+#         or the post-write read-back not matching what was intended.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${SCRIPT_DIR}/check-chart-version-forward.sh"
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <path/to/Chart.yaml>" >&2
+  exit 1
+fi
+CHART_YAML="$1"
+
+if [ ! -f "${CHART_YAML}" ]; then
+  echo "::error title=bump-chart-version::${CHART_YAML} does not exist in the working tree." >&2
+  exit 1
+fi
+
+if [ ! -x "${GUARD}" ] && [ ! -r "${GUARD}" ]; then
+  echo "::error title=bump-chart-version::guard script not found at ${GUARD}." >&2
+  exit 1
+fi
+
+git fetch --quiet origin main
+
+BASELINE="$(git show "origin/main:${CHART_YAML}")"
+BASE_VERSION="$(printf '%s\n' "${BASELINE}" | awk '/^version:/{print $2; exit}' | tr -d '"')"
+BASE_APPVERSION="$(printf '%s\n' "${BASELINE}" | awk '/^appVersion:/{print $2; exit}' | tr -d '"')"
+
+if [ -z "${BASE_VERSION}" ]; then
+  echo "::error title=bump-chart-version::No '^version:' line in origin/main's ${CHART_YAML}." >&2
+  exit 1
+fi
+if [ -z "${BASE_APPVERSION}" ]; then
+  echo "::error title=bump-chart-version::No '^appVersion:' line in origin/main's ${CHART_YAML}." >&2
+  exit 1
+fi
+
+for v in "${BASE_VERSION}" "${BASE_APPVERSION}"; do
+  if ! [[ "${v}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "::error title=bump-chart-version::Unparseable baseline version '${v}' in origin/main's ${CHART_YAML}." >&2
+    exit 1
+  fi
+done
+
+# max(version, appVersion) — MAJOR.MINOR.PATCH compare, no external deps.
+semver_max() {
+  local a="$1" b="$2"
+  local a_maj a_min a_pat b_maj b_min b_pat
+  IFS='.' read -r a_maj a_min a_pat <<< "$a"
+  IFS='.' read -r b_maj b_min b_pat <<< "$b"
+  if [ "$a_maj" -gt "$b_maj" ]; then echo "$a"; return; fi
+  if [ "$a_maj" -lt "$b_maj" ]; then echo "$b"; return; fi
+  if [ "$a_min" -gt "$b_min" ]; then echo "$a"; return; fi
+  if [ "$a_min" -lt "$b_min" ]; then echo "$b"; return; fi
+  if [ "$a_pat" -ge "$b_pat" ]; then echo "$a"; return; fi
+  echo "$b"
+}
+
+BASE_MAX="$(semver_max "${BASE_VERSION}" "${BASE_APPVERSION}")"
+MAJOR="$(echo "${BASE_MAX}" | cut -d. -f1)"
+MINOR="$(echo "${BASE_MAX}" | cut -d. -f2)"
+PATCH="$(echo "${BASE_MAX}" | cut -d. -f3)"
+NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+# Self-check before touching the working tree — never trust this script's
+# own arithmetic silently.
+"${GUARD}" "${BASE_VERSION}" "${BASE_APPVERSION}" "${NEXT_VERSION}" "${NEXT_VERSION}" "${CHART_YAML}" >&2
+
+sed -i -E "s|^version: .*\$|version: ${NEXT_VERSION}|" "${CHART_YAML}"
+sed -i -E "s|^appVersion: .*\$|appVersion: ${NEXT_VERSION}|" "${CHART_YAML}"
+
+WROTE_VERSION="$(awk '/^version:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')"
+WROTE_APPVERSION="$(awk '/^appVersion:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')"
+if [ "${WROTE_VERSION}" != "${NEXT_VERSION}" ] || [ "${WROTE_APPVERSION}" != "${NEXT_VERSION}" ]; then
+  echo "::error title=bump-chart-version::sed failed to write ${NEXT_VERSION} into ${CHART_YAML} (got version=${WROTE_VERSION} appVersion=${WROTE_APPVERSION})." >&2
+  exit 1
+fi
+
+echo "bump-chart-version: origin/main's ${CHART_YAML} was version=${BASE_VERSION} appVersion=${BASE_APPVERSION} -> writing ${NEXT_VERSION}/${NEXT_VERSION} (Refs #5743)" >&2
+echo "${NEXT_VERSION}"

--- a/scripts/check-chart-version-forward.sh
+++ b/scripts/check-chart-version-forward.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# check-chart-version-forward.sh — Refs #5743
+#
+# WHY THIS EXISTS
+# ----------------
+# On 2026-08-06 two deploy-bots (catalyst-build.yaml's Wave-5.48 step and
+# services-build.yaml's own bump) raced to bump the SAME field —
+# products/catalyst/chart/Chart.yaml `version:` — with no shared lock and no
+# check that the number they were about to write was actually higher than
+# what was already on origin/main:
+#
+#   04:06:12  215d6e4bf  version=1.4.1324  appVersion=1.4.1323   <- inconsistent
+#   04:06:32  a23de78d9  version=1.4.1325  appVersion=1.4.1325
+#   04:07:56  GHCR publishes 1.4.1325
+#   04:08:28  b76f3ca7b  version=1.4.1324  appVersion=1.4.1325   <- BACKWARDS
+#   04:10:30  GHCR publishes 1.4.1324                            <- after 1325
+#
+# `helm pull` of both published charts proved 1.4.1324 (the numerically
+# LOWER, but chronologically LATER-published, version) carries #5737's
+# storage fix; 1.4.1325 does not. The existing five-site lockstep guard
+# (check-release-lockstep-writer.yaml / scripts/check-release-lockstep-
+# writer.py) does not catch this shape — it only asserts the five #817
+# sites agree WITH EACH OTHER, never that the number moved forward relative
+# to origin/main. Self-consistent is not the same as correct (the #5741
+# distinction).
+#
+# This script is that missing invariant, extracted into one small,
+# independently-testable assertion so both deploy-bots (and any future one)
+# can call the identical check before they ever write a byte:
+#
+#   1. new_version and new_appVersion must each parse as MAJOR.MINOR.PATCH.
+#   2. new_version MUST equal new_appVersion (the repo's lockstep convention,
+#      held through 1.4.1323, that 215d6e4bf broke).
+#   3. new_version MUST be strictly greater than BOTH old_version and
+#      old_appVersion (a version bump can never move backward relative to
+#      EITHER field already on origin/main — catches drift-recovery too).
+#
+# Usage:
+#   check-chart-version-forward.sh <old_version> <old_appVersion> \
+#                                   <new_version> <new_appVersion> [<label>]
+#
+# Exit 0: all three invariants hold. A one-line OK summary on stdout.
+# Exit 1: an invariant is violated. `::error::` + a plain-text explanation on
+#         stderr naming exactly which invariant failed and the two states.
+# Exit 2: usage error (wrong arg count).
+
+set -euo pipefail
+
+SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+# True (0) iff $1 is a STRICTLY greater MAJOR.MINOR.PATCH semver than $2.
+# Every internal comparison is inside an `if`, so a "false" leg never trips
+# `set -e` — the function always ends on an explicit `return`.
+semver_gt() {
+  local a="$1" b="$2"
+  local a_maj a_min a_pat b_maj b_min b_pat
+  IFS='.' read -r a_maj a_min a_pat <<< "$a"
+  IFS='.' read -r b_maj b_min b_pat <<< "$b"
+  if [ "$a_maj" -gt "$b_maj" ]; then return 0; fi
+  if [ "$a_maj" -lt "$b_maj" ]; then return 1; fi
+  if [ "$a_min" -gt "$b_min" ]; then return 0; fi
+  if [ "$a_min" -lt "$b_min" ]; then return 1; fi
+  if [ "$a_pat" -gt "$b_pat" ]; then return 0; fi
+  return 1
+}
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <old_version> <old_appVersion> <new_version> <new_appVersion> [<label>]" >&2
+  exit 2
+fi
+
+OLD_VERSION="$1"
+OLD_APPVERSION="$2"
+NEW_VERSION="$3"
+NEW_APPVERSION="$4"
+LABEL="${5:-chart}"
+
+fail() {
+  echo "::error title=Chart version regression (#5743)::${LABEL}: $1" >&2
+  echo "  old: version=${OLD_VERSION} appVersion=${OLD_APPVERSION}" >&2
+  echo "  new: version=${NEW_VERSION} appVersion=${NEW_APPVERSION}" >&2
+  exit 1
+}
+
+for v in "${OLD_VERSION}" "${OLD_APPVERSION}" "${NEW_VERSION}" "${NEW_APPVERSION}"; do
+  if ! [[ "${v}" =~ ${SEMVER_RE} ]]; then
+    fail "unparseable version '${v}' — expected MAJOR.MINOR.PATCH."
+  fi
+done
+
+if [ "${NEW_VERSION}" != "${NEW_APPVERSION}" ]; then
+  fail "version/appVersion diverged (version=${NEW_VERSION} appVersion=${NEW_APPVERSION}). The repo's lockstep convention, held through 1.4.1323, requires these to match — this is the 215d6e4bf shape."
+fi
+
+if ! semver_gt "${NEW_VERSION}" "${OLD_VERSION}"; then
+  fail "version did not move strictly forward relative to origin/main's version (${OLD_VERSION} -> ${NEW_VERSION}). This is the #5743 shape: a racing bump clobbered a higher, already-published version with a stale, lower one."
+fi
+
+if ! semver_gt "${NEW_VERSION}" "${OLD_APPVERSION}"; then
+  fail "version did not move strictly forward relative to origin/main's appVersion (${OLD_APPVERSION} -> ${NEW_VERSION})."
+fi
+
+echo "OK — ${LABEL}: ${OLD_VERSION}/${OLD_APPVERSION} -> ${NEW_VERSION}/${NEW_APPVERSION} (forward, consistent)"

--- a/scripts/push-chart-version-bump.sh
+++ b/scripts/push-chart-version-bump.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# push-chart-version-bump.sh — Refs #5743
+#
+# Commit + race-safe push a Chart.yaml version/appVersion bump computed by
+# bump-chart-version.sh (read-modify-write, atomic per docs/PRINCIPLES.md).
+#
+# Both catalyst-build.yaml and services-build.yaml call this SAME script for
+# their Chart.yaml version bump, instead of each hand-rolling their own
+# commit/push/retry loop against the same field — the divergence between
+# their two hand-rolled implementations (one of which routed through the
+# generic `deploy-bump` composite action's last-writer-wins `-X theirs`
+# cherry-pick conflict policy, wrong for a monotonic counter) is exactly what
+# produced the #5743 incident.
+#
+# Retry shape: on every attempt (including the first) the working tree is
+# reset to fresh origin/main and bump-chart-version.sh re-derives the next
+# number from THAT — never from a value computed earlier in the job. A push
+# rejection just means "try again from wherever origin/main is now"; there is
+# no stale intent commit anywhere in this script for a conflict-resolution
+# policy to fall back on, so there is nothing for a concurrent bump to race
+# against — every retry converges to a number strictly above whatever the
+# other bot already pushed.
+#
+# Usage:
+#   push-chart-version-bump.sh <path/to/Chart.yaml> [commit-message-prefix] [max-attempts]
+#
+# Requires: a working tree already checked out with an `origin` remote and
+# `git config user.name`/`user.email` already set by the caller.
+#
+# Env:
+#   SLEEP_SCALE   multiplier on the backoff sleep between retries (default 1;
+#                 tests set 0 so a simulated race runs in well under a
+#                 second instead of tens of seconds of real backoff).
+#
+# Output contract: the ONLY thing on stdout is the final pushed next_version
+# (or nothing, on the legitimate no-op path). All diagnostics — including
+# `pushed=true`/`pushed=false` — go to stderr.
+#
+# Exit 0: pushed (next_version on stdout) OR legitimate no-op (nothing on
+#         stdout, `pushed=false` on stderr — origin/main already carries this
+#         chart's intended state, e.g. a concurrent run's retry already
+#         converged it there).
+# Exit 1: every attempt failed to push.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUMP="${SCRIPT_DIR}/bump-chart-version.sh"
+
+CHART_YAML="${1:?Usage: $0 <path/to/Chart.yaml> [commit-message-prefix] [max-attempts]}"
+MSG_PREFIX="${2:-deploy(bp-catalyst-platform): bump chart version}"
+MAX_ATTEMPTS="${3:-5}"
+SLEEP_SCALE="${SLEEP_SCALE:-1}"
+
+git fetch --quiet origin main
+git reset --hard --quiet origin/main
+
+for i in $(seq 1 "${MAX_ATTEMPTS}"); do
+  NEXT="$("${BUMP}" "${CHART_YAML}")"
+  git add "${CHART_YAML}"
+  if git diff --staged --quiet; then
+    echo "push-chart-version-bump: no-op — ${CHART_YAML} already at target on origin/main." >&2
+    echo "pushed=false" >&2
+    exit 0
+  fi
+  git commit --quiet -m "${MSG_PREFIX} -> ${NEXT} (auto, Refs #5743)"
+  if git push origin HEAD:main; then
+    echo "push-chart-version-bump: pushed ${NEXT} (attempt ${i}/${MAX_ATTEMPTS})." >&2
+    echo "pushed=true" >&2
+    echo "${NEXT}"
+    exit 0
+  fi
+  echo "push-chart-version-bump: push attempt ${i}/${MAX_ATTEMPTS} failed — refetching origin/main and re-deriving next version." >&2
+  git fetch --quiet origin main
+  git reset --hard --quiet origin/main
+  SLEEP_S=$((i * 2 * SLEEP_SCALE))
+  if [ "${SLEEP_S}" -gt 0 ]; then
+    sleep "${SLEEP_S}"
+  fi
+done
+
+echo "::error title=push-chart-version-bump::${MAX_ATTEMPTS} attempts exhausted for ${CHART_YAML}." >&2
+echo "pushed=false" >&2
+exit 1

--- a/scripts/tests/test-chart-version-forward.sh
+++ b/scripts/tests/test-chart-version-forward.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# test-chart-version-forward.sh — non-vacuity proof for #5743
+#
+# Drives scripts/check-chart-version-forward.sh through the ACTUAL historical
+# incident data (not a synthetic `2.0.0 -> 1.0.0` fixture — docs/PRINCIPLES.md
+# A18: a guard proven only against synthetic input failed to catch the very
+# commit that motivated it), then drives scripts/bump-chart-version.sh +
+# scripts/push-chart-version-bump.sh through a REAL concurrent-push race
+# against a bare "origin" repo to prove the fixed mechanism converges instead
+# of repeating the incident.
+#
+#   T1  real regression: a23de78d9 (1.4.1325/1.4.1325) -> b76f3ca7b
+#       (1.4.1324/1.4.1325)                                          -> RED
+#   T2  real divergence-only shape: parent-of-215d6e4bf (1.4.1323/1.4.1323)
+#       -> 215d6e4bf (1.4.1324/1.4.1323)                             -> RED
+#   T3  consistent-but-backward (the #5741 "self-consistent is not correct"
+#       distinction — the existing five-site lockstep guard would NOT catch
+#       this shape, it only checks the five sites agree with each other)
+#                                                                     -> RED
+#   T4  the bump this fix WOULD have produced from the a23de78d9 baseline
+#       (1.4.1325/1.4.1325 -> 1.4.1326/1.4.1326)                     -> GREEN
+#   T5  end-to-end: two concurrent bots (mirroring catalyst-build.yaml and
+#       services-build.yaml) both call bump-chart-version.sh +
+#       push-chart-version-bump.sh against ONE shared bare origin at the
+#       same starting point, racing for real via backgrounded pushes ->
+#       origin's FINAL state must be forward, version==appVersion, and
+#       strictly higher than the pre-race baseline (no clobber either way)
+#
+# Usage: bash scripts/tests/test-chart-version-forward.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+GUARD="${REPO_ROOT}/scripts/check-chart-version-forward.sh"
+BUMP="${REPO_ROOT}/scripts/bump-chart-version.sh"
+PUSH="${REPO_ROOT}/scripts/push-chart-version-bump.sh"
+
+for f in "${GUARD}" "${BUMP}" "${PUSH}"; do
+  [ -x "${f}" ] || chmod +x "${f}"
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+FAILED=0
+fail() { echo "FAIL: $*" >&2; FAILED=1; }
+pass() { echo "PASS: $*"; }
+
+extract_field() {
+  # $1 = git ref/sha, $2 = field (version|appVersion)
+  git -C "${REPO_ROOT}" show "$1:products/catalyst/chart/Chart.yaml" 2>/dev/null \
+    | awk -v f="^${2}:" '$0 ~ f {print $2; exit}' | tr -d '"'
+}
+
+echo "=========================================================="
+echo "T1 — RED: the REAL #5743 incident (a23de78d9 -> b76f3ca7b)"
+echo "=========================================================="
+if git -C "${REPO_ROOT}" cat-file -e a23de78d9 2>/dev/null && git -C "${REPO_ROOT}" cat-file -e b76f3ca7b 2>/dev/null; then
+  OLD_V="$(extract_field a23de78d9 version)"
+  OLD_A="$(extract_field a23de78d9 appVersion)"
+  NEW_V="$(extract_field b76f3ca7b version)"
+  NEW_A="$(extract_field b76f3ca7b appVersion)"
+  echo "extracted from real git history: old=${OLD_V}/${OLD_A} new=${NEW_V}/${NEW_A}"
+  if [ "${OLD_V}" != "1.4.1325" ] || [ "${NEW_V}" != "1.4.1324" ]; then
+    fail "T1 setup — extracted values don't match the known incident shape (expected old version 1.4.1325, new version 1.4.1324); repo history may have changed. Falling back to hardcoded incident values."
+    OLD_V=1.4.1325 OLD_A=1.4.1325 NEW_V=1.4.1324 NEW_A=1.4.1325
+  fi
+else
+  echo "commits a23de78d9/b76f3ca7b not present in this checkout's history (shallow clone?) — using the hardcoded incident values verified 2026-08-06 by \`gh issue view 5743\`."
+  OLD_V=1.4.1325 OLD_A=1.4.1325 NEW_V=1.4.1324 NEW_A=1.4.1325
+fi
+echo "--- guard output (expect exit 1) ---"
+"${GUARD}" "${OLD_V}" "${OLD_A}" "${NEW_V}" "${NEW_A}" "bp-catalyst-platform"
+RC=$?
+echo "--- exit=${RC} ---"
+if [ "${RC}" -eq 0 ]; then
+  fail "T1 — guard PASSED on the real b76f3ca7b regression (version went backward 1.4.1325 -> 1.4.1324). It must fail."
+else
+  pass "T1 — guard correctly rejects the real incident commit pair."
+fi
+echo
+
+echo "=========================================================="
+echo "T2 — RED: the REAL divergence shape (215d6e4bf's own parent -> 215d6e4bf)"
+echo "=========================================================="
+if git -C "${REPO_ROOT}" cat-file -e 215d6e4bf 2>/dev/null; then
+  PARENT="$(git -C "${REPO_ROOT}" rev-parse 215d6e4bf^)"
+  OLD_V="$(extract_field "${PARENT}" version)"
+  OLD_A="$(extract_field "${PARENT}" appVersion)"
+  NEW_V="$(extract_field 215d6e4bf version)"
+  NEW_A="$(extract_field 215d6e4bf appVersion)"
+  echo "extracted from real git history: old=${OLD_V}/${OLD_A} new=${NEW_V}/${NEW_A}"
+else
+  echo "commit 215d6e4bf not present in this checkout's history — using the hardcoded values verified 2026-08-06."
+  OLD_V=1.4.1323 OLD_A=1.4.1323 NEW_V=1.4.1324 NEW_A=1.4.1323
+fi
+echo "--- guard output (expect exit 1) ---"
+"${GUARD}" "${OLD_V}" "${OLD_A}" "${NEW_V}" "${NEW_A}" "bp-catalyst-platform"
+RC=$?
+echo "--- exit=${RC} ---"
+if [ "${RC}" -eq 0 ]; then
+  fail "T2 — guard PASSED on the real 215d6e4bf version/appVersion divergence. It must fail."
+else
+  pass "T2 — guard correctly rejects the real 215d6e4bf divergence."
+fi
+echo
+
+echo "=========================================================="
+echo "T3 — RED: consistent-with-itself but backward (#5741 distinction)"
+echo "=========================================================="
+echo "--- guard output (expect exit 1) ---"
+"${GUARD}" 1.4.1325 1.4.1325 1.4.1200 1.4.1200 "bp-catalyst-platform"
+RC=$?
+echo "--- exit=${RC} ---"
+if [ "${RC}" -eq 0 ]; then
+  fail "T3 — guard PASSED on a version==appVersion pair that still moved backward. Self-consistency alone must not be enough (#5741 shape)."
+else
+  pass "T3 — guard correctly rejects a self-consistent-but-backward pair."
+fi
+echo
+
+echo "=========================================================="
+echo "T4 — GREEN: the corrected bump from the a23de78d9 baseline"
+echo "=========================================================="
+echo "--- guard output (expect exit 0) ---"
+"${GUARD}" 1.4.1325 1.4.1325 1.4.1326 1.4.1326 "bp-catalyst-platform"
+RC=$?
+echo "--- exit=${RC} ---"
+if [ "${RC}" -ne 0 ]; then
+  fail "T4 — guard REJECTED a correct forward, consistent bump."
+else
+  pass "T4 — guard accepts a correct forward, consistent bump."
+fi
+echo
+
+echo "=========================================================="
+echo "T5 — end-to-end: two concurrent bots racing bump-chart-version.sh"
+echo "     + push-chart-version-bump.sh against one shared bare origin"
+echo "=========================================================="
+
+UPSTREAM="${WORK}/upstream.git"
+git init -b main --bare "${UPSTREAM}" >/dev/null
+
+SEED="${WORK}/seed"
+git clone "${UPSTREAM}" "${SEED}" >/dev/null 2>&1
+mkdir -p "${SEED}/products/catalyst/chart"
+cat > "${SEED}/products/catalyst/chart/Chart.yaml" <<'YAML'
+apiVersion: v2
+name: bp-catalyst-platform
+version: 1.4.1325
+appVersion: 1.4.1325
+YAML
+( cd "${SEED}"
+  git config user.name  "seed"
+  git config user.email "seed@test.local"
+  git add products/catalyst/chart/Chart.yaml
+  git commit -m "seed: 1.4.1325/1.4.1325" >/dev/null
+  git push -u origin main >/dev/null 2>&1
+)
+
+# Two bots, each their own clone (mirrors two separate GitHub Actions runners
+# checking out the same repo independently) — bot A stands in for
+# catalyst-build.yaml, bot B for services-build.yaml. Both call the EXACT
+# same shared scripts this PR wires into both workflows.
+BOT_A="${WORK}/bot-a"
+BOT_B="${WORK}/bot-b"
+git clone "${UPSTREAM}" "${BOT_A}" >/dev/null 2>&1
+git clone "${UPSTREAM}" "${BOT_B}" >/dev/null 2>&1
+for d in "${BOT_A}" "${BOT_B}"; do
+  ( cd "${d}" && git config user.name "bot" && git config user.email "bot@test.local" )
+done
+
+run_bot() {
+  local dir="$1" label="$2" outfile="$3"
+  ( cd "${dir}" && SLEEP_SCALE=0 "${PUSH}" products/catalyst/chart/Chart.yaml "deploy(${label})" 10 ) \
+    > "${outfile}.stdout" 2> "${outfile}.stderr"
+  echo "$?" > "${outfile}.rc"
+}
+
+# Fire both concurrently — real backgrounded processes, real filesystem-level
+# git push races against the SAME bare "origin", not a simulated/serial
+# stand-in.
+run_bot "${BOT_A}" "catalyst-build" "${WORK}/bot-a-result" &
+PID_A=$!
+run_bot "${BOT_B}" "services-build" "${WORK}/bot-b-result" &
+PID_B=$!
+wait "${PID_A}"
+wait "${PID_B}"
+
+RC_A="$(cat "${WORK}/bot-a-result.rc")"
+RC_B="$(cat "${WORK}/bot-b-result.rc")"
+echo "--- bot A (catalyst-build stand-in) stderr ---"
+cat "${WORK}/bot-a-result.stderr"
+echo "--- bot B (services-build stand-in) stderr ---"
+cat "${WORK}/bot-b-result.stderr"
+echo "--- exit codes: A=${RC_A} B=${RC_B} ---"
+
+if [ "${RC_A}" -ne 0 ] || [ "${RC_B}" -ne 0 ]; then
+  fail "T5 — one of the two racing bots exhausted its retries and failed to push (RC_A=${RC_A} RC_B=${RC_B}); both must converge."
+fi
+
+CHECK="${WORK}/check"
+git clone "${UPSTREAM}" "${CHECK}" >/dev/null 2>&1
+FINAL_V="$(awk '/^version:/{print $2; exit}' "${CHECK}/products/catalyst/chart/Chart.yaml")"
+FINAL_A="$(awk '/^appVersion:/{print $2; exit}' "${CHECK}/products/catalyst/chart/Chart.yaml")"
+echo "final origin/main state: version=${FINAL_V} appVersion=${FINAL_A}"
+
+if [ "${FINAL_V}" != "${FINAL_A}" ]; then
+  fail "T5 — after the race, origin/main's version (${FINAL_V}) and appVersion (${FINAL_A}) diverged. The exact #5743 shape, reproduced end-to-end."
+else
+  pass "T5a — version/appVersion stayed in lockstep through the race."
+fi
+
+# The pre-race baseline was 1.4.1325. Two successful bumps (one per bot) must
+# land strictly above it — 1.4.1327 at minimum, never back down at 1.4.1325
+# or 1.4.1326-then-clobbered-to-1.4.1325 the way b76f3ca7b clobbered
+# a23de78d9's 1.4.1325 down to 1.4.1324.
+if ! "${GUARD}" 1.4.1325 1.4.1325 "${FINAL_V}" "${FINAL_A}" "post-race final state" >/dev/null 2>&1; then
+  fail "T5 — final origin/main state (${FINAL_V}/${FINAL_A}) did not move strictly forward from the pre-race baseline 1.4.1325/1.4.1325."
+else
+  pass "T5b — final origin/main state moved strictly forward from the pre-race baseline — no backward clobber, either bot's turn."
+fi
+
+git -C "${CHECK}" log --oneline -5
+echo
+
+if [ "${FAILED}" -ne 0 ]; then
+  echo "=========================================================="
+  echo "OVERALL: FAIL"
+  echo "=========================================================="
+  exit 1
+fi
+
+echo "=========================================================="
+echo "OVERALL: PASS — guard rejects the real incident (T1-T3), accepts a"
+echo "correct bump (T4), and the fixed atomic mechanism converges under a"
+echo "real concurrent race instead of repeating it (T5)."
+echo "=========================================================="


### PR DESCRIPTION
## Problem

Two independent deploy-bots — `catalyst-build.yaml`'s Wave-5.48 step and
`services-build.yaml`'s own bump — raced to patch-bump the same field,
`products/catalyst/chart/Chart.yaml` `version:`, each computing "next" from a
value snapshotted earlier in its own job rather than re-reading
`origin/main` at push time. `catalyst-build.yaml` additionally never touched
`appVersion:` at all. On a real push conflict, its retry path (the shared
`deploy-bump` composite action's `-X theirs` cherry-pick — correct for a
last-writer-wins image tag, wrong for a monotonic counter) blindly
overwrote `origin/main`'s already-higher version with a stale, lower one:

```
04:06:12  215d6e4bf  version=1.4.1324  appVersion=1.4.1323   <- inconsistent
04:06:32  a23de78d9  version=1.4.1325  appVersion=1.4.1325
04:07:56  GHCR publishes 1.4.1325
04:08:28  b76f3ca7b  version=1.4.1324  appVersion=1.4.1325   <- BACKWARDS
04:10:30  GHCR publishes 1.4.1324                            <- after 1325
```

`helm pull` of both published charts proved 1.4.1324 (numerically lower,
published later) carries a storage fix that 1.4.1325 (numerically higher,
published first) does not. `origin/main` right now still carries the
unreconciled drift this left behind: `version=1.4.1327`, `appVersion=1.4.1325`.

The existing five-site lockstep guard (`check-release-lockstep-writer.yaml`)
does not catch this shape — it only asserts the five #817 sites agree WITH
EACH OTHER, never that the version moved forward relative to `origin/main`.
Self-consistent is not the same as correct (#5741).

## Fix

- `scripts/bump-chart-version.sh` — always `git fetch`es and reads the
  baseline `version:`/`appVersion:` straight from `origin/main` (never the
  local working tree), derives `next = max(version, appVersion) + 1`, and
  self-checks its own arithmetic via the guard below before writing anything.
- `scripts/check-chart-version-forward.sh` — the hard guard: fails loudly
  unless the new version strictly exceeds BOTH prior fields and
  `new version == new appVersion`.
- `scripts/push-chart-version-bump.sh` — commits + pushes with a 5-attempt
  retry that re-derives fresh from `origin/main` on every attempt (including
  the first), so a losing race just computes a still-higher number and tries
  again. No stale intent commit anywhere for a conflict policy to fall back on.
- `catalyst-build.yaml` and `services-build.yaml` now both call these same
  two scripts for their Chart.yaml bump, in a dedicated commit decoupled from
  the (legitimately last-writer-wins) image-tag bumps, instead of maintaining
  two divergent hand-rolled implementations.

## Guard — RED before, GREEN after (real historical data, not synthetic)

`scripts/tests/test-chart-version-forward.sh` extracts the ACTUAL Chart.yaml
blob content from this repo's own git history at the incident commits and
feeds it straight to the guard — no synthetic `2.0.0 -> 1.0.0` fixture
(docs/PRINCIPLES.md A18: a guard proven only against synthetic input failed
to catch the very commit that motivated it). It also runs the fixed
mechanism through a REAL concurrent push race (two backgrounded processes
against one shared bare repo, not a serial simulation) and asserts the final
state converges instead of repeating the incident. Wired into CI via
`.github/workflows/check-chart-version-forward.yaml`.

Verbatim output, this session, before vs. after the fix existed:

```
T1 — RED: the REAL #5743 incident (a23de78d9 -> b76f3ca7b)
extracted from real git history: old=1.4.1325/1.4.1325 new=1.4.1324/1.4.1325
::error title=Chart version regression (#5743)::bp-catalyst-platform: version/appVersion diverged (version=1.4.1324 appVersion=1.4.1325)...
exit=1
PASS: T1 — guard correctly rejects the real incident commit pair.

T5 — end-to-end: two concurrent bots racing bump-chart-version.sh + push-chart-version-bump.sh
bot A: OK 1.4.1325/1.4.1325 -> 1.4.1326/1.4.1326 ... pushed 1.4.1326 (attempt 1/10)
bot B: push attempt 1/10 failed — refetching origin/main and re-deriving next version
bot B: OK 1.4.1326/1.4.1326 -> 1.4.1327/1.4.1327 ... pushed 1.4.1327 (attempt 2/10)
final origin/main state: version=1.4.1327 appVersion=1.4.1327
PASS: T5a — version/appVersion stayed in lockstep through the race.
PASS: T5b — final origin/main state moved strictly forward from the pre-race baseline.
OVERALL: PASS
```

All 5 sub-tests (T1-T5) pass; existing `.github/actions/deploy-bump`
self-tests (`test-basic.sh`, `test-clobber.sh`, `test-race.sh`) still pass
unmodified — the shared composite action itself is untouched, only its
`paths:` input in `catalyst-build.yaml` changed (Chart.yaml removed).

## Disposition of the already-published 1.4.1325

Documented directly in `Chart.yaml`: left published but **permanently
unpinned** — never referenced from any bootstrap-kit slot, blueprint.yaml, or
catalog-seed entry — and **not re-published** with corrected content. Chart
artifacts are treated as immutable once pushed (cosign attestations bind to
the original digest; any consumer that already resolved 1.4.1325's digest
would silently diverge if the tag's bytes changed underneath it). The remedy
is forward-only: the fixed bump's `max(version, appVersion) + 1` derivation
means the very next legitimate bump moves past both 1.4.1325 and the
still-live 1.4.1327/1.4.1325 drift, self-healing without a manual
reconciliation commit.

## Test plan

- [x] `bash scripts/tests/test-chart-version-forward.sh` — all 5 sub-tests
      pass (RED on real incident data, GREEN on corrected data, converges
      under a real concurrent race).
- [x] `bash .github/actions/deploy-bump/test-basic.sh` /
      `test-clobber.sh` / `test-race.sh` — unaffected, still pass.
- [x] `helm lint products/catalyst/chart` — passes.
- [x] YAML + `bash -n` + `shellcheck` on all new/changed workflow and script
      files.
- [ ] Live: next `catalyst-build.yaml` / `services-build.yaml` run on main
      converges `version == appVersion` moving strictly forward (operator
      walk, post-merge).

Refs #5743 #5323 #960

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
