### PR TITLE
fix(self-sovereign-cutover): refuse Day-2 mirror-advance force-push on a cutover Sovereign

### DIFF
--- a/.github/workflows/check-sovereign-daytwo-bootstrap-refuse.yaml
+++ b/.github/workflows/check-sovereign-daytwo-bootstrap-refuse.yaml
@@ -1,0 +1,56 @@
+name: check-sovereign-daytwo-bootstrap-refuse
+
+# #5759 — assert scripts/sovereign-daytwo-bootstrap.sh REFUSES on a
+# cutoverComplete=true Sovereign instead of re-stamping the force-push that
+# reverts a completed cutover.
+#
+# WHY THIS EXISTS. Running `scripts/sovereign-daytwo-bootstrap.sh --apply` on
+# hw292 (dep 1c56518035a83e03, 2-region, cutoverComplete=true) on 2026-08-06
+# re-stamped step-01 (gitea-mirror), which force-pushed upstream
+# openova/openova onto this Sovereign's local Gitea mirror
+# (`git push --force ... refs/heads/*:refs/heads/*`) and silently discarded
+# step-06's durable HelmRepository-pivot commit. 62 of 69 region-a
+# HelmRepositories reverted to oci://ghcr.io/openova-io; step-06 had already
+# stripped the ghcr-pull credential (severance working as designed), so Flux
+# was left authenticating to a registry it deliberately no longer holds
+# credentials for. 44 of 72 HelmReleases went not-Ready, unrecoverable
+# in-cluster — the only remedy would be re-tethering the Sovereign, exactly
+# what cutover exists to prevent.
+#
+# This workflow runs scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh,
+# which proves the fix against the REAL historical script blob (via
+# `git show origin/main:...`, not a synthetic fixture — docs/PRINCIPLES.md
+# A18) and two vacuity controls: a genuinely pre-cutover Sovereign
+# (cutoverComplete=false) must still be a clean no-op, and an
+# unreadable/absent cutoverComplete must ALSO refuse (fail-closed).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/sovereign-daytwo-bootstrap.sh'
+      - 'scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh'
+      - '.github/workflows/check-sovereign-daytwo-bootstrap-refuse.yaml'
+  pull_request:
+    paths:
+      - 'scripts/sovereign-daytwo-bootstrap.sh'
+      - 'scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh'
+      - '.github/workflows/check-sovereign-daytwo-bootstrap-refuse.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    name: script refuses on cutoverComplete=true, exits clean on cutoverComplete=false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history — the self-test reads the REAL pre-#5759 script blob
+          # via `git show origin/main:scripts/sovereign-daytwo-bootstrap.sh`.
+          fetch-depth: 0
+
+      - name: Prove the script refuses for the real #5759 incident shape
+        run: bash scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1061,7 +1061,12 @@ spec:
       # index.yaml HelmRepository off charts.loft.sh into local Harbor +
       # suspends bp-vcluster-helmrepo so it holds; the step-08 fluxSourceHostLint
       # exception for charts.loft.sh is removed (empty allowHosts).
-      version: 0.1.175
+      # 0.1.176 (#5759): sovereign-daytwo-bootstrap.sh + the Day-2 reconciler's
+      # CATALOG leg both REFUSE their force-push on a cutoverComplete=true
+      # Sovereign (the git overwrite cannot preserve step-06's durable
+      # HelmRepository-pivot commit); the reconciler also gains a CONTINUOUS
+      # source-host drift lint (daytwoReconciler.sourceHostLint).
+      version: 0.1.176
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1331,7 +1331,11 @@ spec:
       #   consistent.) Lockstep w/ slot-06a.
       # 1.4.1320 (#5467): catalog-seed cutover pin 0.1.173 — step-09 no longer
       #   prints the tail of the minted Gitea token. Lockstep w/ slot-06a.
-      version: 1.4.1327
+      # 1.4.1328 (#5759): catalog-seed cutover pin 0.1.176 — Day-2
+      #   mirror-advance force-push refuse-by-default + continuous
+      #   source-host drift lint. Lockstep w/ slot-06a; also self-heals the
+      #   pre-existing 1.4.1327/1.4.1325 version/appVersion drift.
+      version: 1.4.1328
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.175
+  version: 0.1.176
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3537,7 +3537,122 @@ name: bp-self-sovereign-cutover
 # render and drives it against a stub kubectl; RED on main (function absent),
 # GREEN here (16/16 assertions), including a case pinned to the live hw292
 # region-a digest-pinned provider-opentofu pivot verbatim.
-version: 0.1.175
+#
+# 0.1.176 (#5759, Refs #5640 #960) — the Day-2 delivery path stops being able
+# to REVERT a completed cutover.
+#
+# THE LIVE FAILURE. hw292 (dep 1c56518035a83e03, cutoverComplete=true since
+# 2026-08-03T08:12:04Z) ran `scripts/sovereign-daytwo-bootstrap.sh --apply` on
+# 2026-08-06, which re-stamps this chart's OWN step-01 (gitea-mirror) Job from
+# the PodSpec ConfigMap already on the cluster. Step-01's push is
+# `git push --force <local-gitea> refs/heads/*:refs/heads/* refs/tags/*:
+# refs/tags/*` against a FRESH bare clone of the public upstream repo — a raw
+# ref overwrite, not a merge. Step-06 (helmrepository-patches) had already
+# committed a durable "cutover: pivot N HelmRepository URLs to local Harbor"
+# commit onto that SAME local branch; that commit exists ONLY in this
+# Sovereign's Gitea and is never reachable from a fresh upstream clone, so the
+# force-push did not mask it, it DISCARDED it:
+#
+#   HelmRepository census, region-a: 62 -> oci://ghcr.io/openova-io (UPSTREAM)
+#                                      7 -> local registry
+#   HelmChart 'flux-system/flux-system-bp-cilium' not ready: failed to
+#     configure login options: no auth config for 'ghcr.io' in the
+#     docker-registry Secret 'ghcr-pull'
+#   44 of 72 HelmReleases not Ready.
+#
+# Step-06 had ALREADY stripped the ghcr-pull credential as part of cutover
+# severance (working exactly as designed — mirrorResync.enabled: false is the
+# documented MASTER SEVERANCE SWITCH), so the Sovereign was left
+# authenticating to a registry it deliberately no longer holds credentials
+# for, with NO in-cluster remedy: the only fix would be restoring the
+# stripped credential, i.e. re-tethering — exactly what cutover exists to
+# prevent. The environment could not self-heal and was lost.
+#
+# THE SAME DEFECT IN THE CHART ITSELF, more urgent than the script: this
+# release's own Day-2 reconciler (12-daytwo-harbor-pin-reconciler.yaml,
+# `daytwoReconciler.enabled: true` BY DEFAULT since #5640/0.1.170) runs the
+# IDENTICAL force-push, against the IDENTICAL local Gitea repo and branch, in
+# its CATALOG leg (`reconcile_catalog_once`) whenever an operator's one-shot
+# request names CATALOG post-cutover (the DOCUMENTED, in-band, RECOMMENDED
+# successor to the standalone script), or every cycle in
+# `daytwoReconciler.mode: warm`. That is a LIVE LATENT failure on every
+# cutover Sovereign already running >= 0.1.170, not a one-off script misuse.
+#
+# WHAT CHANGES.
+#
+# 1. REFUSE-BY-DEFAULT, both call sites. `reconcile_catalog_once()` now reads
+#    the cutover-status ConfigMap's cutoverComplete once per cycle
+#    (CUTOVER_COMPLETE, computed in reconcile_once()) and refuses its
+#    force-push outright unless it reads the LITERAL string 'false' — 'true',
+#    empty and unreadable are all treated as unsafe, fail-closed. There is no
+#    override knob: the mechanism cannot GUARANTEE the re-render preserves
+#    the pivot (a raw ref overwrite structurally cannot), so a flag would only
+#    move the same silent revert one step further from the operator's eyes.
+#    Blocked attempts are audited distinctly (`CATALOG blocked`, not
+#    `failed`) and counted in REQ_FAILED; CATALOG_STATUS stays OUT of
+#    publish_health() exactly as before (an event, not a durable state).
+#    scripts/sovereign-daytwo-bootstrap.sh gets the identical treatment and is
+#    reduced to a pure refusal (its Job-stamping path is now unreachable
+#    dead weight and has been removed) — see the script's own header for the
+#    full incident writeup.
+#
+# 2. A CONTINUOUS post-advance property assertion, `daytwoReconciler.
+#    sourceHostLint` (default true): `run_daytwo_source_host_lint()` runs
+#    EVERY reconcile cycle once cutoverComplete=true and asserts zero
+#    HelmRepository/GitRepository/OCIRepository resolve to a non-Sovereign
+#    host — the SAME host-classification shape and allowHosts list as
+#    step-08's egressTest.fluxSourceHostLint (single-source discipline, not a
+#    forked exception list), reused rather than re-derived. The difference
+#    from step-08's copy is WHEN it runs: that one fires ONCE, inside the
+#    600s deny-egress hold, torn down with it at the ORIGINAL cutover. This
+#    reconciler is a standing Deployment (#5157 — a CronJob's scheduler dies
+#    with its region on a region-kill), so its copy keeps watching for the
+#    Sovereign's ENTIRE post-cutover life — interval-independent — and
+#    catches a revert from ANY cause: this reconciler's own (now-refused)
+#    CATALOG leg, a sovereign-admin re-stamping an unfixed step-01 ConfigMap
+#    by hand via the script (chart-embedded fixes only protect a Sovereign
+#    already upgraded past 0.1.176), or a cause nobody has written yet.
+#    UNLIKE catalog leg status, a drift folds INTO publish_health() (0/1
+#    READY) — "the registry contract is silently broken" is a durable STATE,
+#    not a one-off event, and stays true every cycle until fixed. Gated the
+#    OPPOSITE way from item 1's refuse (requires the LITERAL 'true', not
+#    "not false") so an unmeasurable cutover state cannot manufacture a false
+#    drift report on a Sovereign that might still be mid-cutover.
+#
+# 3. VERDICT ON THE SIBLING (#5759 item 3), stated with evidence rather than
+#    assumed: `daytwoReconciler`'s CATALOG leg SHARES the defect — same
+#    refspec (`refs/heads/*:refs/heads/* refs/tags/*:refs/tags/*`), same
+#    target branch, same local Gitea repo, same force overwrite semantics —
+#    and is fixed the same way in this release (item 1 above). It is NOT a
+#    standing tether in the default posture (`mode: request`, no CATALOG
+#    scope open, dials nothing every 300s cycle); it fires only on an
+#    explicit operator request or in `mode: warm`.
+#
+# GUARDS. chart/tests/daytwo-catalog-leg.sh grows two scenarios (C8: an
+# explicit CATALOG request on a cutoverComplete=true Sovereign is BLOCKED,
+# not synced, zero egress, audited distinctly; C9: the identical request on
+# cutoverComplete=false is UNCHANGED from the pre-fix C2 shape — the guard is
+# a real condition, not an always-block) plus two vacuity inversions (the
+# refuse condition neutered reproduces the pre-fix sync-through exactly).
+# New chart/tests/daytwo-source-host-lint.sh (14 assertions) proves the drift
+# lint fails on a post-cutover drift and passes on a local source (the base
+# shape shared with step-08's lint), AND — the property unique to this file —
+# stays silent on the BYTE-IDENTICAL offending row pre-cutover / with an
+# unmeasurable cutover status, flipping only on cutoverComplete=true; RED
+# against the pre-0.1.176 chart (function does not exist), GREEN here.
+# scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh drives the REAL
+# pre-#5759 script blob via `git show origin/main:...` (not a synthetic
+# fixture — docs/PRINCIPLES.md A18) against an identical stub kubectl: RED —
+# the historical script stamps the Job; GREEN — the fixed script refuses;
+# plus the same two vacuity controls. No RBAC change (helmrepositories/
+# gitrepositories/ocirepositories get/list/watch was already granted
+# cluster-wide for step-08's use). Step count unchanged at 11 — this bump
+# touches the Day-2 reconciler and an out-of-chart operator script, not a
+# cutover step. New values: daytwoReconciler.sourceHostLint.{enabled}. Slot-06a
+# pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
+# blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
+# (Inviolable Principle #13).
+version: 0.1.176
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
@@ -267,6 +267,24 @@ spec:
               value: {{ .Values.daytwoReconciler.request.auditMaxLines | quote }}
             - name: RELEASE_NAMESPACE
               value: {{ .Release.Namespace | quote }}
+            # #5759 — cutoverComplete read every cycle (never cached): gates
+            # the catalog leg's refuse-by-default AND the source-host drift
+            # lint below. Same ConfigMap + key step-08's egress-block-test Job
+            # and scripts/sovereign-daytwo-bootstrap.sh already read.
+            - name: STATUS_CONFIGMAP
+              value: {{ .Values.status.configMapName | quote }}
+            # #5759 — the source-host drift lint's Sovereign-local allowlist.
+            # SOVEREIGN_FQDN + the host-classification shape are byte-identical
+            # to step-08's egressTest.fluxSourceHostLint (08-egress-block-test-
+            # job.yaml, run_flux_source_host_lint) — single-source discipline:
+            # one allowlist, declared once, consumed by both the one-shot
+            # cutover proof and this standing post-cutover watcher.
+            - name: SOVEREIGN_FQDN
+              value: {{ .Values.sovereign.fqdn | quote }}
+            - name: SOURCE_HOST_LINT_ENABLED
+              value: {{ eq (toString .Values.daytwoReconciler.sourceHostLint.enabled) "true" | quote }}
+            - name: SOURCE_HOST_LINT_ALLOW
+              value: {{ .Values.egressTest.fluxSourceHostLint.allowHosts | default (list) | join " " | quote }}
             # Per-leg switches. Both default true; an operator debugging one
             # half can silence the other without losing the loop.
             - name: CHART_LEG_ENABLED
@@ -347,6 +365,10 @@ spec:
               : "${IMAGE_SCAN_MAX:=400}"
               : "${REQUEST_MAX_REFS:=50}"
               : "${AUDIT_MAX_LINES:=500}"
+              : "${STATUS_CONFIGMAP:=self-sovereign-cutover-status}"
+              : "${SOVEREIGN_FQDN:=}"
+              : "${SOURCE_HOST_LINT_ENABLED:=true}"
+              : "${SOURCE_HOST_LINT_ALLOW:=}"
               WORK=/tmp/daytwo-work
               mkdir -p "${WORK}"
               # #5640 FAIL-CLOSED readiness surface. The reconciler is READY iff
@@ -978,6 +1000,41 @@ spec:
                         return 0 ;;
                 esac
 
+                # #5759 — REFUSE-BY-DEFAULT. Measured live on hw292 (dep
+                # 1c56518035a83e03, cutoverComplete=true) 2026-08-06: this exact
+                # push reverted 62 of 69 region-a HelmRepositories from the
+                # local Harbor back to oci://ghcr.io/openova-io, with the
+                # ghcr-pull credential already stripped by step-06 (severance
+                # working as designed) — 44/72 HelmReleases went not-Ready and
+                # the Sovereign could not self-heal in-cluster (the only
+                # in-cluster remedy would be restoring the stripped upstream
+                # credential, i.e. re-tethering — exactly what cutover exists
+                # to prevent). Root cause, read off the push two lines below:
+                # `git push --force` against a bare clone of UPSTREAM, using
+                # the same explicit-refspec shape template 01 (gitea-mirror)
+                # uses, is a raw ref overwrite, not a merge.
+                # Step-06's durable "cutover: pivot N HelmRepository URLs to
+                # local Harbor" commit lives ONLY on this Sovereign's local
+                # `${UPSTREAM_BRANCH}` and is never reachable from a fresh
+                # upstream clone, so the force-push does not mask that commit,
+                # it DISCARDS it. There is today no merge-preserving
+                # alternative shipped, so this leg cannot guarantee the
+                # re-render preserves the cutover pivot — the exact guarantee
+                # #5759 requires before it may run. Refuse rather than revert
+                # silently. Gated on the LITERAL string 'false' (not merely
+                # "not true"): an unreadable/empty status ConfigMap is treated
+                # as cutover-complete for this check, fail-closed, the same
+                # posture step-08's per-region lint takes on an unmeasurable
+                # region (#5359) — "could not confirm this is safe" is never
+                # "safe".
+                if [ "${CUTOVER_COMPLETE:-}" != "false" ]; then
+                  CATALOG_STATUS="blocked-post-cutover"
+                  echo "[daytwo] catalog leg: REFUSING (#5759) — cutoverComplete='${CUTOVER_COMPLETE:-unreadable}' (expected the literal 'false' to proceed). Force-pushing ${UPSTREAM_REPO_URL} onto this Sovereign's local Gitea mirror would overwrite ${UPSTREAM_BRANCH} wholesale and silently discard step-06's durable HelmRepository-pivot commit, re-tethering every chart Flux re-renders to ghcr.io with no credential left to reach it (step-06 already stripped ghcr-pull auth by design). The mirror is UNCHANGED and the Sovereign keeps running on its current pins. No override exists for this refusal — a real fix needs a merge-preserving mirror mechanism, not a flag."
+                  daytwo_audit "CATALOG\tblocked\t${_cat_id}\t${_cat_by}\t${UPSTREAM_REPO_URL}\tcutoverComplete=${CUTOVER_COMPLETE:-unreadable}"
+                  REQ_FAILED=$((REQ_FAILED+1))
+                  return 1
+                fi
+
                 if [ -z "${UPSTREAM_REPO_URL}" ]; then
                   echo "[daytwo] catalog leg: upstream repo URL is empty — refusing to sync"
                   CATALOG_STATUS="no-upstream"
@@ -1157,6 +1214,92 @@ spec:
                   || echo "[daytwo] WARN: could not update ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} (logs still carry the manifest)"
               }
 
+              # ── #5759 CONTINUOUS SOURCE-HOST DRIFT LINT ──────────────────────
+              # Same host-classification shape as step-08's egressTest.
+              # fluxSourceHostLint (08-egress-block-test-job.yaml,
+              # run_flux_source_host_lint) — reused, not forked (single-source
+              # discipline: one allowlist, egressTest.fluxSourceHostLint.
+              # allowHosts, feeds both). The difference is WHEN it runs. That
+              # lint fires ONCE, inside the 600s deny-egress hold, at the
+              # ORIGINAL cutover, and is torn down with the hold — proving
+              # nothing about a re-render minutes, days or months later. This
+              # reconciler is a standing Deployment (#5157: a CronJob's
+              # scheduler dies with its region on a region-kill, so this is a
+              # Deployment on purpose), so its own copy keeps watching for the
+              # Sovereign's entire post-cutover life — INTERVAL-INDEPENDENT,
+              # per #5759 item 2 — and catches a revert from ANY cause: this
+              # reconciler's own (now-refused) CATALOG leg, a sovereign-admin
+              # re-stamping an unfixed step-01 PodSpec ConfigMap by hand via
+              # scripts/sovereign-daytwo-bootstrap.sh (chart-embedded fixes
+              # only protect a Sovereign already upgraded past this release),
+              # or a cause nobody has written yet. Measured live on hw292 (dep
+              # 1c56518035a83e03) 2026-08-06: 69/69 local HelmRepositories fell
+              # to 7/69 (62 reverted to ghcr.io) with nothing standing watch.
+              run_daytwo_source_host_lint() {
+                DRIFT_STATUS="skipped"; DRIFT_COUNT=0
+                [ "${SOURCE_HOST_LINT_ENABLED}" = "true" ] || return 0
+                # Pre-cutover, external hosts are the NORMAL, correct state
+                # (nothing has been pivoted yet) — only assert once this
+                # Sovereign claims cutoverComplete=true. Fail-closed the other
+                # way from the catalog-leg refuse above: an unreadable status
+                # here must NOT manufacture a false drift report on a Sovereign
+                # that may still be mid-cutover, so this leg requires the
+                # LITERAL 'true' rather than "not 'false'".
+                if [ "${CUTOVER_COMPLETE:-}" != "true" ]; then
+                  DRIFT_STATUS="not-cutover"
+                  return 0
+                fi
+                _dh_off="${WORK}/source-host-offenders.$$"
+                if ! : > "${_dh_off}" 2>/dev/null; then
+                  echo "[daytwo] source-host lint: cannot create ${_dh_off}; refusing to report clean from a lint that cannot record an offender (fail-closed)"
+                  DRIFT_STATUS="scratch-unwritable"; DRIFT_COUNT=1
+                  return 1
+                fi
+                _dh_raw="${WORK}/source-host-raw.$$"
+                _dh_err="${WORK}/source-host-err.$$"
+                for _dk in helmrepositories gitrepositories ocirepositories; do
+                  if ! kubectl get "${_dk}" -A \
+                    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.url}{" "}{.spec.suspend}{"\n"}{end}' >"${_dh_raw}" 2>"${_dh_err}"; then
+                    if grep -qiE "server doesn't have a resource type|could not find the requested resource|no matches for kind|the server could not find the requested resource" "${_dh_err}" 2>/dev/null; then
+                      : > "${_dh_raw}"
+                    else
+                      echo "[daytwo] source-host lint: FAIL — cannot enumerate ${_dk} ($(head -1 "${_dh_err}" 2>/dev/null)). Refusing to report clean for a cycle that could not measure (fail-closed, #5759/#5359 shape)"
+                      rm -f "${_dh_off}" "${_dh_raw}" "${_dh_err}"
+                      DRIFT_STATUS="unmeasurable"; DRIFT_COUNT=1
+                      return 1
+                    fi
+                  fi
+                  while IFS=' ' read -r _dns _dname _durl _dsusp; do
+                    [ -n "${_dns}" ] && [ -n "${_durl}" ] || continue
+                    _dh="${_durl#*://}"; _dh="${_dh%%/*}"; _dh="${_dh%%:*}"
+                    [ -n "${_dh}" ] || continue
+                    case "${_dh}" in
+                      "${LOCAL_REGISTRY_HOST}"|"gitea.${SOVEREIGN_FQDN}"|"harbor.${SOVEREIGN_FQDN}"|*".${SOVEREIGN_FQDN}") continue ;;
+                      *.svc|*.svc.cluster.local|localhost|127.0.0.1) continue ;;
+                    esac
+                    _dex=0
+                    for _da in ${SOURCE_HOST_LINT_ALLOW:-}; do
+                      [ "${_dh}" = "${_da}" ] && { _dex=1; break; }
+                    done
+                    [ "${_dex}" = "1" ] && continue
+                    [ "${_dsusp}" = "true" ] && continue
+                    printf '%s/%s [%s] %s (host:%s)\n' "${_dns}" "${_dname}" "${_dk}" "${_durl}" "${_dh}" >> "${_dh_off}"
+                  done <"${_dh_raw}"
+                done
+                rm -f "${_dh_raw}" "${_dh_err}"
+                if [ -s "${_dh_off}" ]; then
+                  DRIFT_COUNT=$(sort -u "${_dh_off}" | wc -l | tr -d ' ')
+                  echo "[daytwo] source-host lint: FAIL — ${DRIFT_COUNT} Flux source object(s) resolve to a non-Sovereign host on a cutoverComplete=true Sovereign (#5759 shape — a mirror advance overwrote the durable pivot, or it was never applied). Fix = re-run step-06's HelmRepository pivot against the CURRENT local Gitea main, or declare a reviewed exception in egressTest.fluxSourceHostLint.allowHosts:"
+                  sort -u "${_dh_off}" | while IFS= read -r _o; do echo "    EXTERNAL-SOURCE-DRIFT ${_o}"; done
+                  rm -f "${_dh_off}"
+                  DRIFT_STATUS="drifted"
+                  return 1
+                fi
+                rm -f "${_dh_off}"
+                DRIFT_STATUS="ok"
+                return 0
+              }
+
               # #5640 FAIL-CLOSED readiness verdict. Written from the MEASURED
               # cycle outcome, never from a knob: READY requires every enabled
               # leg to have completed (status=ok) AND zero missing artifacts. A
@@ -1184,6 +1327,17 @@ spec:
                 if [ "$((CHART_MISS + IMAGE_MISS))" -gt 0 ]; then
                   _ph_reason="${_ph_reason:+${_ph_reason},}unpullable-pins=$((CHART_MISS + IMAGE_MISS))"
                 fi
+                # #5759 — UNLIKE CATALOG_STATUS above, source-host drift IS a
+                # readiness input: it is a durable STATE ("this cluster's Flux
+                # sources have reverted to a registry we deliberately no longer
+                # hold credentials for"), not a one-off event, and it stays
+                # true every cycle until a human fixes it. That is exactly the
+                # shape publish_health() exists to surface.
+                if [ "${DRIFT_STATUS:-}" = "drifted" ]; then
+                  _ph_reason="${_ph_reason:+${_ph_reason},}source-host-drift=${DRIFT_COUNT}"
+                elif [ "${DRIFT_STATUS:-}" = "unmeasurable" ] || [ "${DRIFT_STATUS:-}" = "scratch-unwritable" ]; then
+                  _ph_reason="${_ph_reason:+${_ph_reason},}source-host-lint-${DRIFT_STATUS}"
+                fi
                 if [ -n "${_ph_reason}" ]; then
                   echo "NOTREADY ${_ph_reason}" > "${HEALTH_FILE}"
                   echo "[daytwo] readiness: NOT-READY (${_ph_reason}) — this Deployment now reports 0/1 READY. On a post-cutover Sovereign that is the visible form of 'this cluster holds a pin its registry cannot serve' (#5640)"
@@ -1200,6 +1354,12 @@ spec:
                 IMAGE_REFS=0; IMAGE_PRESENT=0; IMAGE_WARMED=0; IMAGE_MISS=0
                 CATALOG_SYNCED=0
                 REQ_DELIVERED=0; REQ_FAILED=0
+                # #5759 — read fresh every cycle (never cached across cycles):
+                # gates the catalog leg's refuse-by-default AND the
+                # source-host drift lint below. Same ConfigMap+key
+                # scripts/sovereign-daytwo-bootstrap.sh and step-08 read.
+                CUTOVER_COMPLETE=$(kubectl -n "${RELEASE_NAMESPACE}" get configmap "${STATUS_CONFIGMAP}" \
+                  -o jsonpath='{.data.cutoverComplete}' 2>/dev/null || true)
                 daytwo_load_request
                 # Leg 0 FIRST — see reconcile_catalog_once's header. A catalog
                 # sync that landed AFTER the chart leg would move the pins and
@@ -1215,11 +1375,16 @@ spec:
                 if [ "${IMAGE_LEG_ENABLED}" = "true" ]; then
                   reconcile_images_once || _rc=1
                 fi
+                # #5759 — runs every cycle regardless of which legs are
+                # enabled: it watches the CLUSTER's Flux sources, not this
+                # reconciler's own actions, so it must not go blind just
+                # because an operator silenced CHART_LEG_ENABLED/etc.
+                run_daytwo_source_host_lint || _rc=1
                 daytwo_consume_request
                 daytwo_audit_flush
                 publish_manifest
                 publish_health
-                echo "[daytwo] cycle complete: catalog(${CATALOG_STATUS}) synced=${CATALOG_SYNCED} | charts(${CHART_STATUS}) missing=${CHART_MISS} | images(${IMAGE_STATUS}) missing=${IMAGE_MISS} (manifest -> ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM})"
+                echo "[daytwo] cycle complete: catalog(${CATALOG_STATUS}) synced=${CATALOG_SYNCED} | charts(${CHART_STATUS}) missing=${CHART_MISS} | images(${IMAGE_STATUS}) missing=${IMAGE_MISS} | sourceHostLint(${DRIFT_STATUS}) drift=${DRIFT_COUNT} (manifest -> ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM})"
                 return "${_rc}"
               }
 

--- a/platform/self-sovereign-cutover/chart/tests/daytwo-catalog-leg.sh
+++ b/platform/self-sovereign-cutover/chart/tests/daytwo-catalog-leg.sh
@@ -138,6 +138,7 @@ printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/nslookup"; chmod +x "$TMP/bin
 printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/sleep"; chmod +x "$TMP/bin/sleep"
 
 STUB_REQUEST_JSON=""; STUB_CONSUMED_ID=""; STUB_CLONE_RC=0; STUB_PUSH_RC=0; STUB_REV="aaaa1111"
+STUB_CUTOVER_COMPLETE="false"   # #5759 — see run_leg's export of CUTOVER_COMPLETE
 
 request_cm() {
   jq -n --arg id "$1" --arg scope "$2" \
@@ -153,6 +154,12 @@ run_leg() {   # run_leg [script-path] -> $TMP/out.txt, $TMP/egress.log
     echo 'set +e'
     while IFS= read -r line; do printf 'export %q\n' "$line"; done < "$TMP/env.txt"
     echo 'export HARBOR_USERNAME=admin HARBOR_PASSWORD=stub GHCR_DOCKERCONFIG='
+    # #5759 — reconcile_once() reads CUTOVER_COMPLETE once per cycle (a live
+    # kubectl get, not a rendered env var) and reconcile_catalog_once() reads
+    # it as a plain variable. Default false so C1-C7 above keep testing what
+    # they always tested (an UNBLOCKED leg); C8 below overrides it to prove
+    # the #5759 refusal.
+    printf 'export CUTOVER_COMPLETE=%q\n' "${STUB_CUTOVER_COMPLETE:-false}"
     cat "$script"
     # Same order reconcile_once runs them in the cluster.
     echo 'daytwo_load_request'
@@ -272,6 +279,29 @@ grep -qE '^\S+\s+CATALOG\s+failed\s+' "$TMP/out.txt" || fail "C7: a failed sync 
 STUB_CLONE_RC=0
 pass "C7: unreachable upstream => mirror untouched, failure audited, Sovereign keeps running on its current pins."
 
+echo "[daytwo-catalog-leg] C8 (#5759): REFUSE-BY-DEFAULT — an explicit CATALOG request on a cutoverComplete=true Sovereign must be BLOCKED, not synced"
+# This is the hw292 (dep 1c56518035a83e03) shape one layer over: C2 already
+# proves an explicit CATALOG request syncs the mirror. C8 proves that same
+# request is REFUSED once this Sovereign claims cutoverComplete=true — the
+# force-push below would otherwise discard step-06's durable HelmRepository-
+# pivot commit exactly as it did live on 2026-08-06.
+request_cm "2026-08-06-catalog-refresh" "CATALOG"; STUB_CONSUMED_ID=""
+STUB_CUTOVER_COMPLETE="true"; run_leg; STUB_CUTOVER_COMPLETE="false"
+grep -q 'RESULT status=blocked-post-cutover synced=0' "$TMP/out.txt" \
+  || { cat "$TMP/out.txt"; fail "C8: expected status=blocked-post-cutover synced=0"; }
+assert_no_egress "C8"
+grep -qi '#5759' "$TMP/out.txt" || fail "C8: the refusal message does not cite #5759"
+grep -qE '^\S+\s+CATALOG\s+blocked\s+' "$TMP/out.txt" \
+  || { sed -n '/---AUDIT---/,$p' "$TMP/out.txt"; fail "C8: a blocked sync must still be audited (distinct from 'failed')"; }
+pass "C8: an explicit CATALOG request is REFUSED outright on a cutoverComplete=true Sovereign — zero egress, audited as blocked, mirror untouched."
+
+echo "[daytwo-catalog-leg] C9 (#5759 control): the SAME request on a cutoverComplete=false Sovereign is UNCHANGED (C2's original behaviour) — the #5759 guard is a real condition, not an always-block"
+request_cm "2026-08-06-catalog-refresh" "CATALOG"; STUB_CONSUMED_ID=""
+STUB_CUTOVER_COMPLETE="false"; run_leg
+grep -q 'RESULT status=ok synced=1 delivered=1' "$TMP/out.txt" \
+  || { cat "$TMP/out.txt"; fail "C9: cutoverComplete=false must reproduce C2's result verbatim — got a different status, meaning #5759's guard fires even pre-cutover (an always-block), which would make C8's PASS meaningless"; }
+pass "C9: cutoverComplete=false leaves the CATALOG leg exactly as C2 proved it — #5759's refusal is conditional, not vacuous."
+
 # ── SECOND DIRECTION ──────────────────────────────────────────────────────────
 # Each mutation reproduces a real defective shape; the paired assertion must
 # stop holding. These are what make the greens above meaningful.
@@ -294,6 +324,20 @@ expect_fail_on_mutant "C1/C3/C4 explicit-opt-in guard (catalog_in_scope removed 
 expect_fail_on_mutant "C2 upstream-target guard (leg no longer reads UPSTREAM_REPO_URL)" \
   's#git clone --bare --quiet "\$\{UPSTREAM_REPO_URL\}"#git clone --bare --quiet ""#' \
   'git clone --bare --quiet "\$\{UPSTREAM_REPO_URL\}"'
+expect_fail_on_mutant "C8 #5759 refuse-by-default guard (condition neutered so it can never trigger)" \
+  's#!= "false" \]; then#!= "true" ]; then#' \
+  '!= "false" \]; then'
+# …and the POSITIVE direction for C8: with the guard neutered, an explicit
+# CATALOG request on a cutoverComplete=true Sovereign must go back to
+# reproducing C2's shape (synced=1) — proving C8's PASS is really the guard
+# acting, not some other change in behaviour.
+sed -E 's#!= "false" \]; then#!= "true" ]; then#' "$TMP/script.sh" > "$TMP/mutant-noguard.sh"
+grep -q 'reconcile_catalog_once()' "$TMP/mutant-noguard.sh" || fail "C8 vacuity: mutant script lost reconcile_catalog_once()"
+request_cm "2026-08-06-catalog-refresh" "CATALOG"; STUB_CONSUMED_ID=""
+STUB_CUTOVER_COMPLETE="true"; run_leg "$TMP/mutant-noguard.sh"; STUB_CUTOVER_COMPLETE="false"
+grep -q 'RESULT status=ok synced=1 delivered=1' "$TMP/out.txt" \
+  || { cat "$TMP/out.txt"; fail "VACUITY: with the #5759 guard neutered, a cutoverComplete=true Sovereign no longer reproduces the pre-fix sync-through shape — C8's PASS may not be testing the guard"; }
+pass "vacuity(C8): with the guard neutered, the pre-#5759 behaviour (sync-through on cutoverComplete=true) comes back exactly — C8's PASS is the guard, not an accident."
 
 # C5's ordering assertion gets its own inverted run: swap the two calls and
 # confirm the comparison flips. A line-number comparison that cannot flip would
@@ -308,4 +352,4 @@ m_chart=$(grep -n 'reconcile_charts_once ||' "$TMP/mutant-order.sh" | head -1 | 
   || fail "VACUITY: the C5 ordering check does not flip when the legs are swapped — it is not actually testing order"
 pass "vacuity(C5 ordering): swapping the legs makes the check fail, so its PASS is meaningful"
 
-echo "[daytwo-catalog-leg] ALL PASS — 7 scenarios + 4 vacuity inversions"
+echo "[daytwo-catalog-leg] ALL PASS — 9 scenarios + 6 vacuity inversions"

--- a/platform/self-sovereign-cutover/chart/tests/daytwo-source-host-lint.sh
+++ b/platform/self-sovereign-cutover/chart/tests/daytwo-source-host-lint.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# #5759 — behavioural test for the Day-2 reconciler's CONTINUOUS source-host
+# drift lint (run_daytwo_source_host_lint, 12-daytwo-harbor-pin-reconciler.yaml).
+#
+# WHY a behavioural test and not a render grep, and why a NEW file rather than
+# extending flux-source-host-lint.sh. The host-classification shape is
+# deliberately byte-similar to step-08's run_flux_source_host_lint (same
+# lesson: assert on the VALUE not the KEY, per
+# reference_assert_on_the_value_not_the_key_and_sample_every_role.md), but the
+# GATING is different and is the actual point of this lint, so it needs its
+# own cases:
+#   - step-08's lint runs ONCE, inside the torn-down 600s deny-egress hold, at
+#     the ORIGINAL cutover.
+#   - this lint runs every ~300s cycle of a STANDING Deployment for the
+#     Sovereign's entire post-cutover life (#5157: a Deployment, not a
+#     CronJob, survives a region-kill) — interval-independent, per #5759 item
+#     2 — and it must NOT fire pre-cutover, when an external host is the
+#     NORMAL, correct state. A test that only proved "fails on tether, passes
+#     on local" would miss the one property that makes this lint safe to run
+#     continuously: cases 9-11 below.
+#
+# Extracted straight from the rendered chart (not a hand-kept copy — #5646:
+# a copy can silently drift from the shipped source and keep passing after
+# the real thing changed).
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw292.omani.works"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+fail() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok   — $*"; }
+
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" --set daytwoReconciler.enabled=true \
+  --show-only templates/12-daytwo-harbor-pin-reconciler.yaml >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+awk '/^ *run_daytwo_source_host_lint\(\) \{/,/^ *\}$/' "${TMP}/render.yaml" \
+  | sed 's/^ *//' >"${TMP}/fn.sh"
+
+if ! grep -q 'run_daytwo_source_host_lint()' "${TMP}/fn.sh"; then
+  echo "FAIL — could not extract run_daytwo_source_host_lint from the rendered Deployment."
+  echo "       The lint is missing from the chart, or the function name changed."
+  exit 1
+fi
+# The awk range terminates on the first bare '}' line — pin the tail
+# explicitly so a nested multi-line construct silently truncating the
+# extraction is a test failure, not a fragment quietly passing.
+grep -q '^return 0$' "${TMP}/fn.sh" \
+  || { echo "FAIL — fn.sh was truncated during extraction (no trailing 'return 0')."; exit 1; }
+# Vacuity on the extraction itself (#5652 shape): too short to be the real
+# body would make every case below pass on nothing.
+fn_lines=$(wc -l <"${TMP}/fn.sh")
+[ "${fn_lines}" -ge 30 ] || { echo "FAIL — extracted function is only ${fn_lines} lines — looks truncated"; exit 1; }
+
+# ── Harness: stub kubectl feeds the source inventory under test ────────────
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/kubectl" <<'STUB'
+#!/usr/bin/env bash
+kind=""
+want=0
+for a in "$@"; do
+  if [ "$want" = "1" ]; then kind="$a"; break; fi
+  [ "$a" = "get" ] && want=1
+done
+if [ -n "${STUB_FAIL_KIND:-}" ] && [ "${kind}" = "${STUB_FAIL_KIND}" ]; then
+  echo "${STUB_FAIL_MSG:-error: You must be logged in to the server (Unauthorized)}" >&2
+  exit 1
+fi
+f="${STUB_DIR}/${kind}.txt"
+[ -f "$f" ] && cat "$f"
+exit 0
+STUB
+chmod +x "${TMP}/bin/kubectl"
+
+# run_case <desc> <cutoverComplete> <enabled> <allow> <kind|row> ...
+run_case() {
+  local desc="$1" cc="$2" enabled="$3" allow="$4"; shift 4
+  local case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/helmrepositories.txt"
+  : >"${case_dir}/gitrepositories.txt"
+  : >"${case_dir}/ocirepositories.txt"
+  for spec in "$@"; do
+    local kind="${spec%%|*}" row="${spec#*|}"
+    printf '%s\n' "${row}" >>"${case_dir}/${kind}.txt"
+  done
+  mkdir -p "${TMP}/work"; : >"${TMP}/drift-status.txt"
+  (
+    export PATH="${TMP}/bin:${PATH}"
+    export STUB_DIR="${case_dir}"
+    export SOVEREIGN_FQDN="${FQDN}"
+    export LOCAL_REGISTRY_HOST="registry.${FQDN}"
+    export SOURCE_HOST_LINT_ALLOW="${allow}"
+    export SOURCE_HOST_LINT_ENABLED="${enabled}"
+    export CUTOVER_COMPLETE="${cc}"
+    export WORK="${TMP}/work"
+    cd "${TMP}"
+    # shellcheck disable=SC1090
+    . "${TMP}/fn.sh"
+    rc=0
+    run_daytwo_source_host_lint >"${TMP}/out.txt" 2>&1 || rc=1
+    printf 'DRIFT_STATUS=%s DRIFT_COUNT=%s\n' "${DRIFT_STATUS:-}" "${DRIFT_COUNT:-}" >"${TMP}/drift-status.txt"
+    exit "${rc}"
+  )
+  if [ $? -eq 0 ]; then echo PASS; else echo FAIL; fi
+}
+
+expect() {
+  local desc="$1" want="$2" got="$3"
+  if [ "${got}" = "${want}" ]; then pass "${desc} (${got})"
+  else fail "${desc}: expected ${want}, got ${got}"; sed 's/^/        /' "${TMP}/out.txt" 2>/dev/null; fi
+}
+
+echo "[daytwo-source-host-lint] #5759 — base shape: fail on a drifted source, pass on a local one (cutoverComplete=true)"
+
+# 1. POSITIVE CONTROL — all local, post-cutover. Must PASS.
+got=$(run_case "all-local" "true" "true" "" \
+  "helmrepositories|flux-system bp-cilium oci://registry.${FQDN}/openova-io " \
+  "helmrepositories|flux-system bp-agenity oci://registry.${FQDN}/openova-io " \
+  "gitrepositories|flux-system catalog https://gitea.${FQDN}/catalog/openova ")
+expect "all-local sources, cutoverComplete=true" PASS "${got}"
+
+# 2. THE #5759 SHAPE — hw292 post-force-push: 62 HelmRepositories reverted to
+#    ghcr.io. Must FAIL.
+got=$(run_case "reverted-to-ghcr" "true" "true" "" \
+  "helmrepositories|flux-system bp-cilium oci://registry.${FQDN}/openova-io " \
+  "helmrepositories|flux-system bp-keycloak oci://ghcr.io/openova-io ")
+expect "HelmRepository reverted to ghcr.io post-cutover (the #5759 shape)" FAIL "${got}"
+grep -q 'DRIFT_STATUS=drifted DRIFT_COUNT=1' "${TMP}/drift-status.txt" \
+  && pass "DRIFT_STATUS/DRIFT_COUNT feed publish_health() a countable reason" \
+  || fail "drift status/count not set correctly: $(cat "${TMP}/drift-status.txt")"
+
+# 3. VACUITY — same inventory, reviewed exception declared. Must PASS,
+#    proving case 2 failed on the HOST.
+got=$(run_case "allowed-exception" "true" "true" "ghcr.io" \
+  "helmrepositories|flux-system bp-cilium oci://registry.${FQDN}/openova-io " \
+  "helmrepositories|flux-system bp-keycloak oci://ghcr.io/openova-io ")
+expect "same drift with an explicit SOURCE_HOST_LINT_ALLOW entry" PASS "${got}"
+
+# 4. A suspended source cannot reconcile — reported, must not fail.
+got=$(run_case "suspended" "true" "true" "" \
+  "helmrepositories|flux-system bp-keycloak oci://ghcr.io/openova-io true")
+expect "suspended external source" PASS "${got}"
+
+# 5. Other kinds covered too.
+got=$(run_case "git-tether" "true" "true" "" \
+  "gitrepositories|flux-system upstream https://github.com/openova-io/openova ")
+expect "external GitRepository" FAIL "${got}"
+got=$(run_case "oci-tether" "true" "true" "" \
+  "ocirepositories|flux-system up oci://ghcr.io/openova-io/bp-x ")
+expect "external OCIRepository" FAIL "${got}"
+
+# 6. Mothership harbor.openova.io must still fail (no containerd redirect
+#    applies to a source object).
+got=$(run_case "mothership-harbor" "true" "true" "" \
+  "helmrepositories|flux-system bp-x oci://harbor.openova.io/openova-io ")
+expect "mothership harbor.openova.io source" FAIL "${got}"
+
+# 7. Port/path-bearing local URL must parse to the bare host and PASS.
+got=$(run_case "port-parse" "true" "true" "" \
+  "helmrepositories|flux-system bp-x oci://registry.${FQDN}:5000/openova-io/deep/path ")
+expect "local host with port and path" PASS "${got}"
+
+# 8. FAIL-CLOSED — an unwritable scratch dir must not report PASS.
+echo "  (fail-closed: an unwritable scratch dir must not be reported as PASS)"
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/helmrepositories.txt"; : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export SOURCE_HOST_LINT_ALLOW="" SOURCE_HOST_LINT_ENABLED="true" CUTOVER_COMPLETE="true"
+  export WORK="${TMP}/definitely-not-a-real-dir/nested/deeper"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_daytwo_source_host_lint >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "unwritable scratch dir" FAIL "${got}"
+
+# 9. FAIL-CLOSED — an unmeasurable enumeration (auth/connection error, not a
+#    missing CRD) must not report PASS.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  : >"${case_dir}/helmrepositories.txt"; : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export STUB_FAIL_KIND="helmrepositories" STUB_FAIL_MSG="error: Unauthorized"
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export SOURCE_HOST_LINT_ALLOW="" SOURCE_HOST_LINT_ENABLED="true" CUTOVER_COMPLETE="true"
+  export WORK="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_daytwo_source_host_lint >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "unmeasurable enumeration (auth error)" FAIL "${got}"
+
+# 10. VACUITY the other way — a kind that is merely NOT INSTALLED is zero
+#     rows, not a tether, and must PASS.
+got=$(
+  case_dir="${TMP}/case"; rm -rf "${case_dir}"; mkdir -p "${case_dir}"
+  printf 'flux-system bp-cilium oci://registry.%s/openova-io \n' "${FQDN}" >"${case_dir}/helmrepositories.txt"
+  : >"${case_dir}/gitrepositories.txt"; : >"${case_dir}/ocirepositories.txt"
+  export PATH="${TMP}/bin:${PATH}" STUB_DIR="${case_dir}"
+  export STUB_FAIL_KIND="ocirepositories" STUB_FAIL_MSG="error: the server doesn't have a resource type \"ocirepositories\""
+  export SOVEREIGN_FQDN="${FQDN}" LOCAL_REGISTRY_HOST="registry.${FQDN}"
+  export SOURCE_HOST_LINT_ALLOW="" SOURCE_HOST_LINT_ENABLED="true" CUTOVER_COMPLETE="true"
+  export WORK="${TMP}/work"
+  cd "${TMP}"; . "${TMP}/fn.sh"
+  if run_daytwo_source_host_lint >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+)
+expect "uninstalled source kind (not a tether)" PASS "${got}"
+
+echo
+echo "[daytwo-source-host-lint] #5759 — the property this lint exists to add: cutoverComplete gating"
+
+# 11. THE DISCRIMINATOR. Pre-cutover, an external host is the NORMAL state
+#     (nothing has been pivoted yet) — the SAME offending row that FAILED in
+#     case 2 must PASS here purely because cutoverComplete != 'true'. Without
+#     this case, enabling this lint by default would false-positive every
+#     Sovereign for its entire pre-cutover life.
+got=$(run_case "pre-cutover-external-is-normal" "false" "true" "" \
+  "helmrepositories|flux-system bp-cilium oci://ghcr.io/openova-io ")
+expect "external host, cutoverComplete=false (pre-cutover — normal, must not fire)" PASS "${got}"
+grep -q 'DRIFT_STATUS=not-cutover' "${TMP}/drift-status.txt" \
+  && pass "DRIFT_STATUS=not-cutover names WHY it did not assert (not merely 'lucky pass')" \
+  || fail "expected DRIFT_STATUS=not-cutover, got: $(cat "${TMP}/drift-status.txt")"
+
+# 12. FAIL-CLOSED THE OTHER WAY — an unreadable/empty cutoverComplete must
+#     also stay silent (this lint's fail-closed direction is the OPPOSITE of
+#     the catalog leg's refuse-by-default: an unmeasurable cutover state must
+#     not manufacture a false drift report on a Sovereign that might still be
+#     mid-cutover). Same offending row as case 2/11.
+got=$(run_case "unreadable-status-cm" "" "true" "" \
+  "helmrepositories|flux-system bp-cilium oci://ghcr.io/openova-io ")
+expect "external host, cutoverComplete unreadable (must not fire — see #5759 asymmetry note)" PASS "${got}"
+
+# 13. THE SAME OFFENDING ROW, cutoverComplete=true — must now FAIL. This is
+#     the case that proves 11/12 are not simply "the lint never fires": one
+#     flag flips the verdict on byte-identical input.
+got=$(run_case "same-row-post-cutover" "true" "true" "" \
+  "helmrepositories|flux-system bp-cilium oci://ghcr.io/openova-io ")
+expect "the SAME external row, cutoverComplete=true (must now fire)" FAIL "${got}"
+
+# 14. OPERATOR OPT-OUT — SOURCE_HOST_LINT_ENABLED=false must skip regardless
+#     of cutover state or offenders present.
+got=$(run_case "operator-disabled" "true" "false" "" \
+  "helmrepositories|flux-system bp-cilium oci://ghcr.io/openova-io ")
+expect "SOURCE_HOST_LINT_ENABLED=false (operator opt-out)" PASS "${got}"
+grep -q 'DRIFT_STATUS=skipped' "${TMP}/drift-status.txt" \
+  && pass "DRIFT_STATUS=skipped distinguishes an opt-out from a clean measurement" \
+  || fail "expected DRIFT_STATUS=skipped, got: $(cat "${TMP}/drift-status.txt")"
+
+echo
+if [ "${FAILURES}" -ne 0 ]; then
+  echo "[daytwo-source-host-lint] ${FAILURES} assertion(s) FAILED"
+  exit 1
+fi
+echo "[daytwo-source-host-lint] all assertions passed — lint proven to fail on a post-cutover drift AND pass on a local source, AND (the property unique to this file) to stay silent on the identical drift pre-cutover / unmeasurable-status, flipping only on cutoverComplete=true"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2317,6 +2317,40 @@ daytwoReconciler:
     # `upstream.repoURL` (the same value step-01 uses), so an operator who
     # mirrors the catalog into their OWN forge points that at it and this leg
     # follows without further configuration.
+    #
+    # #5759 — REFUSE-BY-DEFAULT, NOT GATED BY THIS SWITCH. Even with catalog.
+    # enabled=true, reconcile_catalog_once() now refuses its force-push
+    # outright once this Sovereign's cutoverComplete=true (no override knob —
+    # see the template's #5759 comment for why). Measured live on hw292 (dep
+    # 1c56518035a83e03) 2026-08-06: an identical force-push, fired via
+    # scripts/sovereign-daytwo-bootstrap.sh rather than this leg, discarded
+    # step-06's durable HelmRepository-pivot commit and reverted 62/69
+    # region-a HelmRepositories to ghcr.io with no credential left to reach
+    # it. This leg shares the exact mechanism (same refspec, same target
+    # branch, same local Gitea repo) whenever an operator's request names
+    # CATALOG post-cutover, or in mode=warm every cycle — so it is refused the
+    # same way, unconditionally, until a merge-preserving mirror mechanism
+    # ships. Setting this false silences the leg entirely (no refusal message
+    # either); leaving it true keeps the loud, audited refusal visible.
+    enabled: true
+  # #5759 — CONTINUOUS post-advance property assertion, run every cycle once
+  # this Sovereign is cutoverComplete=true: zero HelmRepository / GitRepository
+  # / OCIRepository may resolve to a non-Sovereign host. Same host-
+  # classification shape + allowlist as step-08's egressTest.fluxSourceHostLint
+  # (reused via that SAME allowHosts list — single-source discipline, not a
+  # second exception list to keep in sync), but INTERVAL-INDEPENDENT: step-08's
+  # lint runs ONCE, inside the torn-down 600s deny-egress hold, at the
+  # ORIGINAL cutover. This reconciler is a standing Deployment (#5157 — a
+  # CronJob's scheduler dies with its region on a region-kill), so its own
+  # copy keeps watching for the Sovereign's entire post-cutover life, catching
+  # a revert from ANY cause: this reconciler's own (now-refused) CATALOG leg,
+  # a sovereign-admin re-stamping an unfixed step-01 ConfigMap by hand via
+  # scripts/sovereign-daytwo-bootstrap.sh (chart-embedded fixes only protect a
+  # Sovereign already upgraded past this release), or a cause nobody has
+  # written yet. A drift folds into this Deployment's readiness (0/1 READY),
+  # unlike catalog.enabled's leg status, because "the registry contract is
+  # silently broken" is a durable STATE, not a one-off event.
+  sourceHostLint:
     enabled: true
   # #5265 leg — the frozen bootstrap-kit CHART pins.
   charts:

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.175",
+      "version": "0.1.176",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.175",
+    "version": "0.1.176",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3725,7 +3725,17 @@ name: bp-catalyst-platform
 # 1.4.1295 — #5467: bp-self-sovereign-cutover 0.1.168 -> 0.1.169 (harbor-prewarm
 #   GHCR-PAT log-leak fix). Bootstrap-kit slot-06a + catalog-seed pins lockstep.
 #   (re-serialized past main 1.4.1294 at rebase.)
-version: 1.4.1327
+# 1.4.1328 — #5759: catalog-seed bp-self-sovereign-cutover source.version +
+#   spec.version 0.1.175 -> 0.1.176 (Day-2 mirror-advance force-push
+#   refuse-by-default + continuous source-host drift lint). version/
+#   appVersion were 1.4.1327/1.4.1325 (drifted; check-umbrella-republish-
+#   gate.py #5734 requires this file's version to move whenever a
+#   catalog-seed pin moves in the same PR) — max(version, appVersion)+1
+#   self-heals the drift in the same bump, per scripts/bump-chart-version.sh's
+#   documented contract (its own SIGPIPE on this file's size made a manual
+#   application necessary this time; arithmetic verified against
+#   scripts/check-chart-version-forward.sh before writing).
+version: 1.4.1328
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3875,7 +3885,7 @@ version: 1.4.1327
 #   unsatisfiable on kom4dc (me-east-215-*), which kept the production
 #   Continuum seed unfireable. Backwards-compatible (all-letter labels
 #   still match). Flux CreateReplace flows it to live Sovereigns.
-appVersion: 1.4.1325
+appVersion: 1.4.1328
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5101,7 +5101,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.175"
+  version: "0.1.176"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5118,7 +5118,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.175"
+    version: "0.1.176"
   topology:
     supported:
       - singleton

--- a/scripts/sovereign-daytwo-bootstrap.sh
+++ b/scripts/sovereign-daytwo-bootstrap.sh
@@ -1,72 +1,83 @@
 #!/usr/bin/env bash
-# sovereign-daytwo-bootstrap.sh — the ONE-TIME operator action that gives an
-# ALREADY-CUT-OVER Sovereign its first post-cutover delivery (Refs #5640).
+# sovereign-daytwo-bootstrap.sh — #5759: RETIRED TO A REFUSAL.
 #
-# WHY THIS EXISTS — the bootstrapping trap, stated plainly
-# ───────────────────────────────────────────────────────
-# The in-band fix for #5640 is the Day-2 reconciler's CATALOG leg, which ships
-# INSIDE `bp-self-sovereign-cutover`. The version of that chart a Sovereign runs
-# is decided by the bootstrap-kit pin in its LOCAL GITEA MIRROR. Post-cutover
-# that mirror is frozen (`mirrorResync.enabled: false`, the deliberate
-# Principle-14 severance). So on a Sovereign cut over BEFORE the catalog leg
-# existed, the remedy cannot pass through the gap it remedies: the new chart is
-# published, and the Sovereign has no path to learn that it exists.
+# This script used to re-stamp an ALREADY-CUT-OVER Sovereign's OWN step-01
+# (gitea-mirror) + step-03 (harbor-prewarm) Jobs, to deliver
+# bp-self-sovereign-cutover's Day-2 catalog leg (#5640) to a Sovereign cut
+# over before that leg existed. It no longer stamps anything. It detects
+# cutoverComplete and REFUSES, loudly, with the evidence below — a refusal
+# beats a silent revert.
 #
-# Measured on hw292 (dep 1c56518035a83e03, cutoverComplete=true, 2026-08-06):
-# local Gitea bootstrap-kit slot 06a pinned bp-self-sovereign-cutover 0.1.159
-# while upstream main had reached 0.1.169.
+# WHY IT IS RETIRED, not merely "be careful"
+# ───────────────────────────────────────────
+# Its step-01 re-stamp forced:
 #
-# There is no way to close that loop from the repo side, and pretending
-# otherwise would mean shipping a background auto-pull from ghcr — precisely the
-# Principle-11 violation the design refuses. The honest answer is that the FIRST
-# delivery is operator-initiated. This script is that one action, and it is the
-# LAST one: once the Sovereign is on a chart carrying the catalog leg, every
-# subsequent delivery is the in-band, audited, one-shot `CATALOG` request and
-# this script is never needed again.
+#   git push --force <local-gitea> 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*'
 #
-# WHAT IT DOES — and what it deliberately does not
-# ────────────────────────────────────────────────
-# It uses ONLY resources already present on the Sovereign: it re-stamps the
-# cutover's OWN step-01 (gitea-mirror) and step-03 (harbor-prewarm) Jobs from
-# the `cutover-step-*` PodSpec ConfigMaps the chart installed. It writes no new
-# manifests, patches nothing, and introduces no new credential path. Step-01
-# re-syncs the local Gitea mirror (moving the bootstrap-kit pins); step-03
-# warms the newly-pinned charts + images into the local Harbor. Flux then rolls
-# the cutover HelmRelease onto the new chart, which brings the catalog leg with
-# it.
+# — a raw ref overwrite of the local Gitea mirror's branch from a FRESH clone
+# of upstream, not a merge. Once a Sovereign is cutoverComplete=true, step-06
+# (helmrepository-patches) has ALREADY committed a durable "cutover: pivot N
+# HelmRepository URLs to local Harbor" commit onto that SAME branch — a
+# commit that exists ONLY in this Sovereign's local Gitea and is never
+# reachable from a fresh clone of the public upstream repo. The force-push
+# above does not mask that commit, it DISCARDS it, and Flux's next reconcile
+# re-renders every pivoted HelmRepository back onto ghcr.io.
 #
-# It does NOT repoint any Flux source, and it does NOT re-enable the banned
-# resync CronJob. After it finishes, the Sovereign still reconciles EXCLUSIVELY
-# from its local Gitea + local Harbor.
+# Measured live on hw292 (dep 1c56518035a83e03, cutoverComplete=true since
+# 2026-08-03T08:12:04Z): running this script --apply on 2026-08-06 reverted 62
+# of 69 region-a HelmRepositories from the local Harbor back to
+# oci://ghcr.io/openova-io. Step-06 had ALREADY stripped the ghcr-pull
+# credential from flux-system as part of cutover severance (working exactly
+# as designed — mirrorResync.enabled: false is the documented MASTER
+# SEVERANCE SWITCH), so Flux was left authenticating to a registry it
+# deliberately no longer holds credentials for:
 #
-# Step-01's push uses explicit refspecs and never prunes, so the sovereign-local
-# refs step-06/07 pushed (HelmRepository pivots, catalyst-api env) survive.
+#   HelmChart 'flux-system/flux-system-bp-cilium' is not ready: unknown build
+#   error: failed to configure login options: no auth config for 'ghcr.io' in
+#   the docker-registry Secret 'ghcr-pull'
 #
-# NOTE ON CREDENTIALS. Step-06 strips the cutover's own ghcr auth by design, so
-# step-03 may not be able to pull PRIVATE openova-io packages here. That is the
-# intended shape — delivery is scoped to a credential the operator owns. If
-# step-03 reports auth failures, supply an upstream credential the same way the
-# in-band path does (daytwoReconciler.warm.credentialSecret) and re-run.
+# 44 of 72 HelmReleases went not-Ready. There is NO in-cluster remedy: the
+# only fix would be restoring the stripped upstream credential, i.e.
+# re-tethering the Sovereign — exactly what cutover exists to prevent. Full
+# chain: https://github.com/openova-io/openova/issues/5759
 #
-# Usage:
+# `12-daytwo-harbor-pin-reconciler.yaml`'s CATALOG leg (bp-self-sovereign-
+# cutover >= 0.1.170) shares the IDENTICAL force-push against the IDENTICAL
+# branch of the IDENTICAL local Gitea repo whenever an operator's request
+# names CATALOG post-cutover (or every cycle in mode=warm), so it is refused
+# the same way now — see that template's own #5759 comment. There is
+# therefore no safer in-band alternative to point an operator toward today.
+#
+# THE PATH FORWARD. A safe re-mirror needs to PRESERVE the local-only pivot
+# commit while still advancing to new upstream content — a merge, not an
+# overwrite. That mechanism does not exist yet (tracked in #5759). Until it
+# ships, a Sovereign that cut over before bp-self-sovereign-cutover 0.1.170
+# (and therefore has no Day-2 catalog leg) stays on its cutover-time chart
+# pins; that is not silent breakage, it is the deliberate Principle-14 freeze.
+#
+# Usage (unchanged, for any runbook/cron already invoking it):
 #   scripts/sovereign-daytwo-bootstrap.sh --kubeconfig <path> [--namespace catalyst] [--apply]
 #
-# DRY-RUN BY DEFAULT. Without --apply it only measures and prints the plan.
+# It ALWAYS refuses once cutoverComplete is 'true', empty or unreadable
+# (fail-closed — a Sovereign old enough to need this script is far more
+# likely mid/post-cutover than pre-cutover). On a genuinely pre-cutover
+# Sovereign (cutoverComplete=false) it exits 0 immediately: this script was
+# never for that case either — the normal delivery chain is already intact.
+# There is no override flag. --apply is accepted only so an existing
+# invocation does not hard-error on an unrecognised argument; it changes
+# nothing below.
 set -euo pipefail
 
 KUBECONFIG_PATH=""
 NS="catalyst"
 APPLY=0
-# The first chart version whose Day-2 reconciler carries the CATALOG leg. At or
-# above this, the in-band one-shot request replaces this script entirely.
-CATALOG_LEG_MIN_VERSION="0.1.170"
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --kubeconfig) KUBECONFIG_PATH="$2"; shift 2 ;;
     --namespace|-n) NS="$2"; shift 2 ;;
     --apply) APPLY=1; shift ;;
-    -h|--help) sed -n '1,55p' "$0"; exit 0 ;;
+    -h|--help) sed -n '1,64p' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -75,109 +86,50 @@ done
 export KUBECONFIG="${KUBECONFIG_PATH}"
 
 k() { kubectl --request-timeout=60s "$@"; }
-die() { echo "ERROR: $*" >&2; exit 1; }
 
-echo "== #5640 Day-2 bootstrap =="
+echo "== #5759 / #5640 Day-2 bootstrap (retired to a refusal — see file header) =="
 echo "-- cluster: $(k config current-context 2>/dev/null || echo unknown), namespace: ${NS}"
+[ "${APPLY}" = "1" ] && echo "-- note: --apply no longer changes this script's behaviour (#5759)"
 
-# 1. This is a POST-cutover remedy. On a pre-cutover Sovereign the normal
-#    delivery chain is intact and this script is both unnecessary and wrong.
 cc=$(k -n "${NS}" get cm self-sovereign-cutover-status -o jsonpath='{.data.cutoverComplete}' 2>/dev/null || true)
-[ "${cc}" = "true" ] \
-  || die "cutoverComplete is '${cc:-absent}', not 'true'. This Sovereign is not cut over, so its delivery chain is not severed and this bootstrap does not apply."
-echo "-- cutoverComplete=true"
+echo "-- cutoverComplete=${cc:-unreadable}"
 
-# 2. Installed chart version. If the catalog leg is already present, the in-band
-#    path exists and using this script instead would be a needless out-of-band
-#    action.
-ver=$(k -n flux-system get hr bp-self-sovereign-cutover -o jsonpath='{.spec.chart.spec.version}' 2>/dev/null || true)
-[ -n "${ver}" ] || die "could not read the bp-self-sovereign-cutover HelmRelease version in flux-system"
-echo "-- installed cutover chart: ${ver} (catalog leg lands in ${CATALOG_LEG_MIN_VERSION})"
-
-# catalog leg present iff CATALOG_LEG_MIN_VERSION <= ver, i.e. MIN sorts first.
-oldest=$(printf '%s\n%s\n' "${ver}" "${CATALOG_LEG_MIN_VERSION}" | sort -V | head -1)
-if [ "${oldest}" = "${CATALOG_LEG_MIN_VERSION}" ]; then
+if [ "${cc}" = "false" ]; then
   cat <<EOF
 
-This Sovereign already runs ${ver}, which carries the Day-2 catalog leg.
-No out-of-band action is needed — use the in-band, audited, one-shot request:
-
-  kubectl -n ${NS} create configmap self-sovereign-cutover-daytwo-request \\
-    --from-literal=requestId=\$(date -u +%Y-%m-%d)-catalog-refresh \\
-    --from-literal=requestedBy=<you@example.com> \\
-    --from-literal=scope=CATALOG
-
-The reconciler consumes that requestId once, syncs the mirror, delivers the
-newly-pinned charts and images in the SAME window, and closes.
+This Sovereign has not cut over (cutoverComplete=false). This script exists
+ONLY to serve an ALREADY-CUT-OVER Sovereign, and that case is now permanently
+refused (#5759) — so there is nothing safe for it to do here either. The
+normal delivery chain (step-01/03 as part of the ORIGINAL cutover, still
+ahead of this Sovereign) already applies. No action taken.
 EOF
   exit 0
 fi
 
-# 3. The step PodSpec ConfigMaps must be present — they are what we re-stamp.
-for cm in cutover-step-01-gitea-mirror cutover-step-03-harbor-prewarm; do
-  k -n "${NS}" get cm "${cm}" >/dev/null 2>&1 || die "ConfigMap ${NS}/${cm} is absent — cannot re-stamp the step without the chart's own PodSpec"
-done
-echo "-- step-01 + step-03 PodSpec ConfigMaps present"
+# #5759 — REFUSE-BY-DEFAULT. cc is 'true', empty or unreadable: all three
+# treated the same, fail-closed.
+cat >&2 <<EOF
 
-mirror_rev() { k -n flux-system get gitrepo openova -o jsonpath='{.status.artifact.revision}' 2>/dev/null || true; }
-echo "-- local Gitea mirror revision (before): $(mirror_rev)"
+ERROR: refusing to run (#5759).
 
-if [ "${APPLY}" != "1" ]; then
-  cat <<EOF
+cutoverComplete='${cc:-unreadable}' — expected the literal 'false' to
+proceed, which this script no longer permits doing anything useful with
+anyway (see the file header). Re-stamping step-01 here would force-push
+upstream openova/openova onto this Sovereign's local Gitea mirror with:
 
-DRY RUN — nothing was changed. Re-run with --apply to execute:
+  git push --force <local> 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*'
 
-  1. stamp Job cutover-daytwo-bootstrap-01 from ${NS}/cutover-step-01-gitea-mirror
-     (re-syncs the local Gitea mirror; moves the frozen bootstrap-kit pins)
-  2. stamp Job cutover-daytwo-bootstrap-03 from ${NS}/cutover-step-03-harbor-prewarm
-     (warms the newly-pinned charts + images into the local Harbor)
+That discards step-06's durable HelmRepository-pivot commit and re-tethers
+every chart Flux re-renders to ghcr.io with no credential left to reach it
+(step-06 already stripped ghcr-pull auth by design). Measured live on hw292
+(dep 1c56518035a83e03) 2026-08-06: this exact --apply reverted 62 of 69
+region-a HelmRepositories and left 44 of 72 HelmReleases not-Ready,
+unrecoverable in-cluster (the only in-cluster remedy would be restoring the
+stripped credential, i.e. re-tethering — exactly what cutover exists to
+prevent).
 
-Flux then rolls bp-self-sovereign-cutover ${ver} -> the newly-pinned version,
-which carries the catalog leg. From that point delivery is in-band and this
-script is never needed again.
+There is no override flag for this refusal and none is coming until a
+merge-preserving mirror mechanism ships (tracked in #5759). The Sovereign is
+UNCHANGED; nothing else ran.
 EOF
-  exit 0
-fi
-
-stamp() {   # stamp <job-name> <podspec-cm> <deadline-seconds>
-  local job="$1" cm="$2" deadline="$3" spec
-  spec=$(k -n "${NS}" get cm "${cm}" -o jsonpath='{.data.podSpec}')
-  [ -n "${spec}" ] || die "${cm} carries no podSpec"
-  k -n "${NS}" delete job "${job}" --ignore-not-found >/dev/null 2>&1 || true
-  {
-    echo "apiVersion: batch/v1"
-    echo "kind: Job"
-    echo "metadata:"
-    echo "  name: ${job}"
-    echo "  labels:"
-    echo "    app.kubernetes.io/managed-by: sovereign-daytwo-bootstrap"
-    echo "    catalyst.openova.io/issue: \"5640\""
-    echo "spec:"
-    echo "  backoffLimit: 1"
-    echo "  template:"
-    echo "    spec:"
-    printf '%s\n' "${spec}" | sed 's/^/      /'
-  } | k -n "${NS}" apply -f - >/dev/null
-  echo "-- stamped Job ${NS}/${job}; waiting up to ${deadline}s"
-  if ! k -n "${NS}" wait --for=condition=complete "job/${job}" --timeout="${deadline}s" 2>/dev/null; then
-    echo "!! ${job} did not report complete. Last 40 log lines:" >&2
-    k -n "${NS}" logs "job/${job}" --tail=40 2>&1 | sed 's/^/   /' >&2
-    die "${job} failed — the Sovereign is UNCHANGED and still running on its current pins"
-  fi
-  echo "-- ${job} complete"
-}
-
-stamp cutover-daytwo-bootstrap-01 cutover-step-01-gitea-mirror 1200
-echo "-- local Gitea mirror revision (after): $(mirror_rev)"
-stamp cutover-daytwo-bootstrap-03 cutover-step-03-harbor-prewarm 5400
-
-cat <<EOF
-
-Done. Flux will now move bp-self-sovereign-cutover off ${ver} onto the newly
-mirrored pin. Watch it with:
-
-  kubectl -n flux-system get hr bp-self-sovereign-cutover -w
-
-Once it reports the new version, the Day-2 reconciler's catalog leg is present
-and every future delivery is the in-band one-shot request (scope=CATALOG).
-EOF
+exit 1

--- a/scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh
+++ b/scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# test-sovereign-daytwo-bootstrap-refuse.sh — #5759 non-vacuity proof.
+#
+# Drives scripts/sovereign-daytwo-bootstrap.sh through a stub kubectl in TWO
+# forms:
+#   RED   the REAL pre-#5759 blob, read via `git show origin/main:...` — not
+#         retyped, not a synthetic fixture (docs/PRINCIPLES.md A18: a guard
+#         proven only against synthetic input can pass while missing the
+#         actual incident shape). This is the literal script that reverted
+#         62/69 region-a HelmRepositories on hw292 (dep 1c56518035a83e03) on
+#         2026-08-06.
+#   GREEN the FIXED script in the working tree.
+#
+# Both are run against an IDENTICAL stub kubectl reporting
+# cutoverComplete=true. The assertion is that they DISAGREE: the historical
+# script proceeds to stamp Job cutover-daytwo-bootstrap-01 (the force-push
+# leg); the fixed script refuses before stamping anything.
+#
+# Two controls close the vacuity gaps an "always fail" fix would hide behind:
+#   - cutoverComplete=false must still exit 0 cleanly (proves the fix is a
+#     real condition, not an unconditional failure that happens to also
+#     "pass" the RED/GREEN comparison above).
+#   - An unreadable/absent cutoverComplete must ALSO refuse (fail-closed).
+#
+# Usage: bash scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh
+#   Requires `origin` to have `main` fetched (git fetch origin main) so the
+#   RED fixture can be read; CI checkouts always satisfy this.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+CURRENT="${REPO_ROOT}/scripts/sovereign-daytwo-bootstrap.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok — $*"; }
+
+[ -f "${CURRENT}" ] || fail "working-tree script not found at ${CURRENT}"
+chmod +x "${CURRENT}" 2>/dev/null || true
+
+# ── RED fixture: the REAL pre-#5759 blob, from git ─────────────────────────
+cd "${REPO_ROOT}"
+PRE_FIX_REF="${PRE_FIX_REF:-origin/main}"
+if ! git cat-file -e "${PRE_FIX_REF}:scripts/sovereign-daytwo-bootstrap.sh" 2>/dev/null; then
+  git fetch origin main --quiet 2>/dev/null || true
+fi
+git cat-file -e "${PRE_FIX_REF}:scripts/sovereign-daytwo-bootstrap.sh" 2>/dev/null \
+  || fail "cannot read ${PRE_FIX_REF}:scripts/sovereign-daytwo-bootstrap.sh — fetch origin/main first"
+git show "${PRE_FIX_REF}:scripts/sovereign-daytwo-bootstrap.sh" > "${TMP}/pre-fix.sh"
+chmod +x "${TMP}/pre-fix.sh"
+grep -q "cutoverComplete is" "${TMP}/pre-fix.sh" \
+  || fail "the ${PRE_FIX_REF} blob does not look like the pre-#5759 script (its REQUIRE-cutoverComplete=true die message is absent) — point PRE_FIX_REF at a commit before this fix"
+grep -qi "REFUSING (#5759)" "${TMP}/pre-fix.sh" \
+  && fail "VACUITY: ${PRE_FIX_REF} already carries the #5759 refusal — re-point PRE_FIX_REF at the commit immediately before this PR to get a genuine pre-fix fixture"
+
+# ── Stub kubectl — answers every call BOTH script shapes make ──────────────
+mkdir -p "${TMP}/bin"
+cat > "${TMP}/bin/kubectl" <<'KSTUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"config current-context"*) echo "stub-context"; exit 0 ;;
+  *"get cm self-sovereign-cutover-status"*) printf '%s' "${STUB_CC:-}"; exit "${STUB_CC_RC:-0}" ;;
+  *"get hr bp-self-sovereign-cutover"*) printf '%s' "${STUB_CHART_VER:-0.1.159}"; exit 0 ;;
+  *"get cm cutover-step-01-gitea-mirror"*) printf 'STUB_PODSPEC_01'; exit 0 ;;
+  *"get cm cutover-step-03-harbor-prewarm"*) printf 'STUB_PODSPEC_03'; exit 0 ;;
+  *"get gitrepo openova"*) printf 'aaaa1111'; exit 0 ;;
+  *"delete job"*) exit 0 ;;
+  *"apply -f -"*) echo "JOB_STAMPED $(date +%s)" >> "${STUB_ACTION_LOG}"; cat >/dev/null; exit 0 ;;
+  *"wait --for=condition=complete"*) exit 0 ;;
+  *) exit 0 ;;
+esac
+KSTUB
+chmod +x "${TMP}/bin/kubectl"
+touch "${TMP}/kubeconfig"
+
+run_script() {   # run_script <script-path>  -> sets RC, OUT; logs to $TMP/action.log
+  local script="$1"
+  STUB_ACTION_LOG="${TMP}/action.log"; : > "${STUB_ACTION_LOG}"
+  OUT=$(STUB_CC="${STUB_CC:-}" STUB_CC_RC="${STUB_CC_RC:-0}" STUB_CHART_VER="${STUB_CHART_VER:-0.1.159}" \
+    STUB_ACTION_LOG="${STUB_ACTION_LOG}" PATH="${TMP}/bin:${PATH}" \
+    bash "${script}" --kubeconfig "${TMP}/kubeconfig" --apply 2>&1)
+  RC=$?
+}
+
+echo "[5759-refuse] RED: the REAL pre-fix script (${PRE_FIX_REF}) on a cutoverComplete=true Sovereign"
+STUB_CC="true"; run_script "${TMP}/pre-fix.sh"
+echo "${OUT}" | sed 's/^/    /'
+echo "    exit=${RC}"
+grep -q "JOB_STAMPED" "${TMP}/action.log" \
+  || fail "RED did not reproduce: the pre-fix script did not attempt to stamp a Job on cutoverComplete=true — either the stub is wrong or ${PRE_FIX_REF} is not the pre-#5759 blob"
+pass "RED confirmed — the pre-#5759 script stamps cutover-daytwo-bootstrap-01 on a cutoverComplete=true Sovereign, reproducing the exact hw292 defect shape (62/69 HelmRepositories reverted, #5759)"
+
+echo "[5759-refuse] GREEN: the FIXED script (working tree) on the SAME cutoverComplete=true Sovereign"
+STUB_CC="true"; run_script "${CURRENT}"
+echo "${OUT}" | sed 's/^/    /'
+echo "    exit=${RC}"
+[ "${RC}" = "1" ] || fail "GREEN: expected exit 1 (refuse), got ${RC}"
+grep -qi "#5759" <<<"${OUT}" || fail "GREEN: refusal message does not cite #5759"
+grep -qi "REFUS" <<<"${OUT}" || fail "GREEN: no explicit refusal language in the output"
+grep -q "JOB_STAMPED" "${TMP}/action.log" \
+  && fail "GREEN: the fixed script stamped a Job anyway — the refusal did not actually stop the mutating path"
+pass "GREEN confirmed — the fixed script refuses (exit 1), cites #5759, and never reaches the Job-stamping path"
+
+echo "[5759-refuse] CONTROL 1 (vacuity): cutoverComplete=false must still be a clean no-op"
+STUB_CC="false"; run_script "${CURRENT}"
+echo "${OUT}" | sed 's/^/    /'
+echo "    exit=${RC}"
+[ "${RC}" = "0" ] \
+  || fail "CONTROL 1: a genuinely pre-cutover Sovereign (cutoverComplete=false) must exit 0, got ${RC} — an 'always fail' fix would also pass the GREEN assertion above, which is exactly what this control exists to catch"
+grep -q "JOB_STAMPED" "${TMP}/action.log" \
+  && fail "CONTROL 1: stamped a Job on a pre-cutover Sovereign — that was never in scope for this script either"
+pass "CONTROL 1 confirmed — cutoverComplete=false exits 0 cleanly; the refusal is a real condition, not a vacuous always-fail"
+
+echo "[5759-refuse] CONTROL 2 (fail-closed): an unreadable/absent cutoverComplete must ALSO refuse"
+STUB_CC=""; STUB_CC_RC=1; run_script "${CURRENT}"
+STUB_CC_RC=0
+echo "${OUT}" | sed 's/^/    /'
+echo "    exit=${RC}"
+[ "${RC}" = "1" ] || fail "CONTROL 2: an unreadable status ConfigMap must refuse (exit 1), got ${RC} — 'could not confirm this is safe' must never default to proceeding"
+pass "CONTROL 2 confirmed — an unreadable cutoverComplete refuses rather than defaulting to safe"
+
+echo "[5759-refuse] ALL PASS — RED (real pre-fix blob stamps a Job) -> GREEN (fixed script refuses) -> 2 controls"


### PR DESCRIPTION
## What

`scripts/sovereign-daytwo-bootstrap.sh --apply` reverted a completed cutover
live on hw292 (dep `1c56518035a83e03`, cutoverComplete=true) on 2026-08-06,
reverting 62/69 region-a HelmRepositories to `ghcr.io` with no credential
left to reach it (step-06 had already stripped `ghcr-pull`), leaving 44/72
HelmReleases not-Ready with no in-cluster remedy.

**Root cause**: both `sovereign-daytwo-bootstrap.sh` (step-01 re-stamp) and
the Day-2 reconciler's CATALOG leg (`reconcile_catalog_once`,
`12-daytwo-harbor-pin-reconciler.yaml`) do:

```
git push --force <local-gitea> 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*'
```

against a fresh bare clone of the public upstream repo. Once
`cutoverComplete=true`, step-06 has already committed a durable
`cutover: pivot N HelmRepository URLs to local Harbor` commit onto that same
branch, reachable ONLY in the Sovereign's local Gitea. The force-push
overwrites the branch wholesale — it does not mask that commit, it discards
it.

## Fix — the smallest correct set

1. **Refuse-by-default**: both call sites now refuse the force-push once
   `cutoverComplete` reads anything other than the literal `'false'` — fail-
   closed (unreadable/empty/`'true'` all refuse). No override flag: a raw ref
   overwrite structurally cannot guarantee preserving the pivot, so a flag
   would just move the same silent revert one step further from the
   operator's eyes. `sovereign-daytwo-bootstrap.sh`'s Job-stamping path is
   now unreachable and has been removed — the script only detects and
   refuses.

2. **Post-advance property assertion**: the Day-2 reconciler gains
   `daytwoReconciler.sourceHostLint` (default on) — every ~300s cycle, once
   `cutoverComplete=true`, it asserts zero HelmRepository / GitRepository /
   OCIRepository resolve to a non-Sovereign host, reusing step-08's
   `egressTest.fluxSourceHostLint` host-classification shape + allowlist
   (single-source discipline, not a forked exception list) per the pattern
   in `run_provider_package_host_lint` (08-egress-block-test-job.yaml).
   Unlike step-08's one-shot lint (torn down with the 600s deny-egress hold
   at the ORIGINAL cutover), this is interval-independent: a standing
   Deployment watching for the Sovereign's entire post-cutover life, so it
   catches a revert from ANY cause. A drift folds into this Deployment's
   readiness (0/1 READY).

3. **Verdict on the sibling — `daytwoReconciler` SHARES the defect.**
   `reconcile_catalog_once()` runs the *identical* force-push against the
   *identical* branch of the *identical* local Gitea repo whenever an
   operator's one-shot request names `CATALOG` post-cutover (the documented,
   in-band, RECOMMENDED successor to the standalone script!) — or every
   cycle in `mode: warm`. It is **not** a standing tether in the default
   posture (`mode: request`, no open CATALOG scope → zero egress every
   cycle), so it does not misfire unprompted, but the moment an operator (or
   an agent, as happened) uses the documented in-band path, it reverts the
   cutover exactly like the script did. This is now fixed the same way as
   item 1.

## Guards — RED before, GREEN after

**`scripts/tests/test-sovereign-daytwo-bootstrap-refuse.sh`** — drives the
REAL pre-fix script blob via `git show origin/main:...` (not a synthetic
fixture — docs/PRINCIPLES.md A18) against a stub kubectl:

```
[5759-refuse] RED: the REAL pre-fix script (origin/main) on a cutoverComplete=true Sovereign
    -- stamped Job catalyst/cutover-daytwo-bootstrap-01; waiting up to 1200s
    -- stamped Job catalyst/cutover-daytwo-bootstrap-03; waiting up to 5400s
    exit=0
  ok — RED confirmed — the pre-#5759 script stamps cutover-daytwo-bootstrap-01
       on a cutoverComplete=true Sovereign, reproducing the hw292 defect shape

[5759-refuse] GREEN: the FIXED script (working tree) on the SAME Sovereign
    ERROR: refusing to run (#5759).
    exit=1
  ok — GREEN confirmed — the fixed script refuses (exit 1), cites #5759,
       and never reaches the Job-stamping path

[5759-refuse] CONTROL 1 (vacuity): cutoverComplete=false stays a clean no-op — exit=0
[5759-refuse] CONTROL 2 (fail-closed): unreadable cutoverComplete ALSO refuses — exit=1
[5759-refuse] ALL PASS — RED -> GREEN -> 2 controls
```

**`chart/tests/daytwo-catalog-leg.sh`** (extended, C8/C9 + 2 vacuity
inversions) — run against the pre-fix chart (`git show origin/main:...`):

```
[daytwo-catalog-leg] C8 (#5759): REFUSE-BY-DEFAULT — an explicit CATALOG request on a cutoverComplete=true Sovereign must be BLOCKED, not synced
FAIL: C8: expected status=blocked-post-cutover synced=0
```

— against the fix: `ALL PASS — 9 scenarios + 6 vacuity inversions`.

**`chart/tests/daytwo-source-host-lint.sh`** (new, 14 cases) — against the
pre-fix chart:

```
FAIL — could not extract run_daytwo_source_host_lint from the rendered Deployment.
       The lint is missing from the chart, or the function name changed.
```

— against the fix: `all assertions passed — lint proven to fail on a
post-cutover drift AND pass on a local source, AND ... to stay silent on the
identical drift pre-cutover / unmeasurable-status, flipping only on
cutoverComplete=true`.

Every assertion is a vacuity-checked pair (case + inverted mutant), per
`docs/PRINCIPLES.md` A18.

## Version / lockstep

`bp-self-sovereign-cutover` 0.1.175 → 0.1.176 (0.1.175 was the currently-
published tag on `ghcr.io` at the time this branch was cut — verified via
`gh api orgs/openova-io/packages/container/bp-self-sovereign-cutover/versions`
before choosing the next number, no collision). All five lockstep sites move
together: `Chart.yaml`, `blueprint.yaml`, bootstrap-kit slot 06a pin, catalog
seed `source.version` + `spec.version`, and the generated API/UI catalog
(regenerated via `products/catalyst/bootstrap/ui/scripts/build-catalog.mjs`
— byte-identical to the hand version-bump, confirming no other drift).
`scripts/check-bootstrap-kit-pin-sync.sh` and
`scripts/check-catalog-seed-lockstep.sh` both pass.

## Verified

- `helm lint` / `helm template` clean.
- All 15 `platform/self-sovereign-cutover/chart/tests/*.sh` green.
- `go build ./...` clean in `products/catalyst/bootstrap/api`;
  `blueprints.json` re-validated as JSON post-bump.
- No NodePort references introduced (grep-clean on every touched file).
- Source-side only — no cluster access, no UAT verdict touched, nothing
  fired/wiped.

## Not in scope (follow-up)

A genuinely safe re-mirror mechanism that PRESERVES the local-only pivot
commit while still advancing to new upstream content (a merge, not an
overwrite) is real future work, tracked in #5759. Until it ships, a
Sovereign that cut over before `bp-self-sovereign-cutover` 0.1.170 (no Day-2
catalog leg) stays frozen on its cutover-time chart pins — the deliberate
Principle-14 posture, not silent breakage.

Refs #5759 #5640 #960
