### PR TITLE
fix(catalyst-api): join the orphan-release goroutine instead of racing its TempDir cleanup

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -616,7 +616,16 @@ func (h *Handler) restoreFromStore() {
 			if dep.Status == "failed" && rec.PDMReservationToken != "" &&
 				rec.PDMPoolDomain != "" && rec.PDMSubdomain != "" &&
 				dep.AdoptedAt == nil && h.pdm != nil {
-				go h.releaseOrphanedReservation(dep.ID, rec.PDMPoolDomain, rec.PDMSubdomain)
+				// Tracked on orphanReleaseWG so callers can join the
+				// goroutine's FULL body — including the trailing
+				// persistDeployment write (#5765). Add before the `go`,
+				// never inside it, or Wait can return before the
+				// goroutine has even been scheduled.
+				h.orphanReleaseWG.Add(1)
+				go func(id, pool, sub string) {
+					defer h.orphanReleaseWG.Done()
+					h.releaseOrphanedReservation(id, pool, sub)
+				}(dep.ID, rec.PDMPoolDomain, rec.PDMSubdomain)
 			}
 		}
 
@@ -716,6 +725,16 @@ func (h *Handler) restoreFromStore() {
 		"dir", h.store.Dir(),
 	)
 }
+
+// waitOrphanReleases blocks until every releaseOrphanedReservation goroutine
+// spawned by restoreFromStore has run to completion — including the trailing
+// persistDeployment write, not just the pdm.Release call.
+//
+// Exists because that goroutine has observable side effects on the store
+// directory after the effect a caller would naturally poll for. Tests that
+// assert on the Release and then return would otherwise leave it writing into
+// an already-being-torn-down t.TempDir() (#5765).
+func (h *Handler) waitOrphanReleases() { h.orphanReleaseWG.Wait() }
 
 // releaseOrphanedReservation calls pdm.Release for a deployment whose
 // status was rewritten to "failed" because the catalyst-api Pod died

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -66,6 +66,20 @@ type Handler struct {
 	// runs. map[string]struct{}.
 	clusterMeshLoopActive sync.Map
 
+	// orphanReleaseWG tracks the releaseOrphanedReservation goroutines that
+	// restoreFromStore fires (#489). Those goroutines outlive the call that
+	// spawned them: after pdm.Release returns they clear the dep's PDM
+	// pointers and call persistDeployment, i.e. they WRITE to the store
+	// directory. Without a join point nothing can observe when that write
+	// has landed — which is #5765: the test asserted on the recorded
+	// Release call, returned, and t.TempDir()'s RemoveAll then raced the
+	// still-pending persist ("directory not empty").
+	//
+	// Waiting on the release alone is not sufficient and never was; the
+	// observable side effect the caller cares about is the persist. Use
+	// waitOrphanReleases to join.
+	orphanReleaseWG sync.WaitGroup
+
 	// pdm — pool-domain-manager client. Required in production; tests can
 	// inject a fake via NewWithPDM. The default URL points at the in-cluster
 	// service FQDN so a stock Catalyst-Zero deployment "just works" without

--- a/products/catalyst/bootstrap/api/internal/handler/release_subdomain_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/release_subdomain_test.go
@@ -295,19 +295,23 @@ func TestRestoreFromStore_PodRestartOrphanReleasesPDMSlot(t *testing.T) {
 	// fires releaseOrphanedReservation as a goroutine.
 	h := NewWithStore(silentLogger(), fpdm, st)
 
-	// Wait briefly for the async release to fire — capped at 2s. Use
-	// the mutex-protected snapshot accessor; a direct read of
-	// fpdm.releases here races the goroutine's append (race detector
-	// flagged it on first CI run before the accessor was added).
-	deadline := time.Now().Add(2 * time.Second)
-	var releases []releaseCall
-	for time.Now().Before(deadline) {
-		releases = fpdm.snapshotReleases()
-		if len(releases) > 0 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	// Join the async release goroutine rather than racing a timer (#5765).
+	//
+	// The previous version polled for up to 2s and broke the loop the
+	// instant the Release call was RECORDED. That is the wrong event: the
+	// goroutine continues past pdm.Release to clear the dep's PDM pointers
+	// and call persistDeployment — a WRITE into this test's t.TempDir().
+	// The test then returned and TempDir's RemoveAll raced that write,
+	// failing the whole package with "unlinkat ...: directory not empty"
+	// on loaded CI runners while passing locally. Waiting on the WaitGroup
+	// covers the goroutine's full body, so there is no timer to lose and
+	// nothing still writing when cleanup runs.
+	//
+	// Still read through the mutex-protected snapshot accessor: a direct
+	// read of fpdm.releases races the goroutine's append (the race
+	// detector flagged that before the accessor existed).
+	h.waitOrphanReleases()
+	releases := fpdm.snapshotReleases()
 
 	if got := len(releases); got != 1 {
 		t.Fatalf("expected 1 orphan PDM Release; got %d (%+v)", got, releases)
@@ -326,18 +330,12 @@ func TestRestoreFromStore_PodRestartOrphanReleasesPDMSlot(t *testing.T) {
 		t.Errorf("Status=%q, want failed (Pod-restart rewrite contract)", dep.Status)
 	}
 
-	// Wait for the success-path field clear (the goroutine clears the
-	// pointers + persists after a successful release).
-	deadline = time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		dep.mu.Lock()
-		cleared := dep.pdmPoolDomain == "" && dep.pdmSubdomain == ""
-		dep.mu.Unlock()
-		if cleared {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	// No wait needed for the success-path field clear: waitOrphanReleases
+	// above already joined the goroutine that clears the pointers and
+	// persists, so by here the clear has either happened or never will.
+	// Asserting directly turns a timing-dependent poll into a real
+	// assertion — if the clear regresses, this fails deterministically
+	// instead of flaking under load (#5765).
 	dep.mu.Lock()
 	defer dep.mu.Unlock()
 	if dep.pdmPoolDomain != "" || dep.pdmSubdomain != "" {


### PR DESCRIPTION
## What

`TestRestoreFromStore_PodRestartOrphanReleasesPDMSlot` reddens the `test` gate on
PRs that change nothing in its tree. It did exactly that on #5764, which touches
**zero** `.go` files. Fixes the goroutine lifetime behind it.

## Root cause — a goroutine lifetime, not a slow assertion

The failure is stamped `(0.00s)`, which rules out the 2-second poll loop timing
out (my own first analysis on #5765 blamed that; the timestamp refuted it):

```
--- FAIL: TestRestoreFromStore_PodRestartOrphanReleasesPDMSlot (0.00s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat
      /tmp/TestRestoreFromStore_...001: directory not empty
```

`restoreFromStore` fires `releaseOrphanedReservation` as a bare `go` (#489). That
goroutine calls `pdm.Release` and then **keeps going** — it clears the dep's PDM
pointers and calls `persistDeployment`, a WRITE into the store directory, which
in this test is `t.TempDir()`.

The test polled only until the Release was **recorded**, then asserted and
returned. `t.TempDir()`'s deferred `RemoveAll` then walked the directory while
the persist was still landing. Whether that races is pure scheduling — hence
green locally, red on a loaded runner.

## Fix

- `Handler.orphanReleaseWG`; `restoreFromStore` does `Add(1)` **before** the `go`
  (never inside it, or `Wait` can return before the goroutine is scheduled), and
  the closure defers `Done`.
- `waitOrphanReleases()` joins the goroutine's **full body**, including the
  trailing persist — not just the `Release` a caller would naturally poll for.
- The test joins instead of polling. **Both** of its 2-second timer loops are
  deleted; the second one waited for the pointer-clear that the join now
  guarantees. The test is deterministic: no timer to lose, nothing still writing
  at cleanup.

## Verification — vacuity-checked, not assumed

| Control | Result |
|---|---|
| `-race -count=10`, fixed | `ok ... 1.179s` |
| Sibling `TestReleaseSubdomain*`, `-race -count=2` | `ok ... 1.090s` |
| **Mutation: `releaseOrphanedReservation` stubbed to return immediately** | **`FAIL: expected 1 orphan PDM Release; got 0`** |
| CI re-run of the original failure, identical bytes | `test: success` (flake confirmed) |
| Full package on clean `origin/main`, CI's exact scope | `ok ... 256.556s` — *longer* than CI's failing 178s run, so duration is not the variable |

The mutation row is the one that matters: the test still catches the #489
regression it exists for. It is faster, not weaker — the old version spent ~2s
per run polling.

## Why this is worth a PR rather than a retry

This is the mirror image of the defect class this session has been hunting. A
guard that *cannot* go red hides real bugs; a guard that goes red when nothing
is wrong trains everyone to wave red away as "probably the flaky one" — which is
how a genuine failure eventually gets merged. Both destroy the signal.

Also worth noting for follow-up: nothing in production joins these goroutines
either. `waitOrphanReleases` now gives a shutdown path something to call if we
want catalyst-api to stop cleanly rather than exiting mid-persist. Not wired up
here — flagged in #5765 rather than scope-crept into this PR.

Refs #5765 #5764 #489
