### PR TITLE
fix(catalyst-api): graceful shutdown — drain HTTP, then join orphan PDM releases

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/drain.go
+++ b/products/catalyst/bootstrap/api/cmd/api/drain.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// defaultDrainBudget caps the HTTP drain.
+//
+// Kubernetes' default terminationGracePeriodSeconds is 30s. Overrunning it does
+// not buy a cleaner exit — the kubelet just SIGKILLs, which is the abrupt kill
+// this whole change exists to remove, only later. 25s leaves headroom for the
+// orphan-release join that follows the drain.
+const defaultDrainBudget = 25 * time.Second
+
+// httpDrainer is the http.Server surface drainOnSignal needs. Narrowed to one
+// method so a test can substitute a fake without standing up a real listener.
+type httpDrainer interface {
+	Shutdown(ctx context.Context) error
+}
+
+// orphanReleaseJoiner is the handler surface drainOnSignal needs.
+type orphanReleaseJoiner interface {
+	WaitOrphanReleases()
+}
+
+// drainOnSignal blocks until sigCh delivers, then shuts the HTTP server down
+// and joins the in-flight orphan-release goroutines — in that order (#5767).
+//
+// The order is the substance of this function, not an implementation detail.
+// Draining first and joining second is what makes the join terminate: past
+// Shutdown no new request can arrive, so no new orphan-release work can be
+// spawned. Joining first would race — a request landing mid-join spawns a
+// goroutine the join has already passed, and we would exit while it is still
+// writing to the store.
+//
+// Extracted from main() so the ordering is testable without delivering a real
+// signal to the test process.
+func drainOnSignal(
+	sigCh <-chan os.Signal,
+	srv httpDrainer,
+	joiner orphanReleaseJoiner,
+	budget time.Duration,
+	log *slog.Logger,
+) {
+	sig := <-sigCh
+	log.Info("shutdown signal received; draining", "signal", sig.String())
+
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		// Deliberately not fatal, and deliberately still followed by the
+		// join. A drain that overran its budget leaves in-flight requests
+		// cut, but an orphan-release goroutine killed mid-persistDeployment
+		// is the worse outcome (#489 subdomain lock), so we still wait for
+		// it rather than returning early on this error.
+		log.Warn("http drain did not finish inside the budget; continuing to the orphan-release join",
+			"err", err, "budget", budget.String())
+	}
+
+	joiner.WaitOrphanReleases()
+	log.Info("drain complete — orphan PDM releases joined, no persist left in flight")
+}

--- a/products/catalyst/bootstrap/api/cmd/api/drain_test.go
+++ b/products/catalyst/bootstrap/api/cmd/api/drain_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// recorder captures the call order across both collaborators. Order is the
+// contract drainOnSignal exists to enforce (#5767), so it is what we assert.
+type recorder struct {
+	mu    sync.Mutex
+	calls []string
+	// shutdownErr is returned by Shutdown; blockFor delays it so we can
+	// prove the join really waits for the drain rather than merely being
+	// written after it.
+	shutdownErr error
+	blockFor    time.Duration
+}
+
+func (r *recorder) Shutdown(ctx context.Context) error {
+	if r.blockFor > 0 {
+		select {
+		case <-time.After(r.blockFor):
+		case <-ctx.Done():
+			r.record("shutdown:ctx-expired")
+			return ctx.Err()
+		}
+	}
+	r.record("shutdown")
+	return r.shutdownErr
+}
+
+func (r *recorder) WaitOrphanReleases() { r.record("join") }
+
+func (r *recorder) record(s string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, s)
+}
+
+func (r *recorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+// TestDrainOnSignal_ShutsDownBeforeJoiningOrphanReleases pins the ordering.
+//
+// Joining before draining would race: a request landing mid-join spawns an
+// orphan-release goroutine the join has already passed, and the process exits
+// while that goroutine is still writing to the store — the #489 subdomain lock
+// this whole path exists to prevent.
+func TestDrainOnSignal_ShutsDownBeforeJoiningOrphanReleases(t *testing.T) {
+	rec := &recorder{}
+	sigCh := make(chan os.Signal, 1)
+	sigCh <- syscall.SIGTERM
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		drainOnSignal(sigCh, rec, rec, time.Second, quietLogger())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainOnSignal did not return after SIGTERM")
+	}
+
+	got := rec.snapshot()
+	want := []string{"shutdown", "join"}
+	if len(got) != len(want) {
+		t.Fatalf("call sequence = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("call sequence = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestDrainOnSignal_JoinsEvenWhenDrainOverrunsBudget is the case that matters
+// operationally: a stuck long-poll must not cost us the orphan-release join.
+// An overrunning drain leaves requests cut, which is survivable; a goroutine
+// killed mid-persistDeployment leaves a subdomain locked, which is not.
+func TestDrainOnSignal_JoinsEvenWhenDrainOverrunsBudget(t *testing.T) {
+	rec := &recorder{blockFor: time.Hour} // never finishes inside the budget
+	sigCh := make(chan os.Signal, 1)
+	sigCh <- syscall.SIGTERM
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		drainOnSignal(sigCh, rec, rec, 50*time.Millisecond, quietLogger())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainOnSignal hung when the drain overran its budget")
+	}
+
+	got := rec.snapshot()
+	if len(got) != 2 || got[0] != "shutdown:ctx-expired" || got[1] != "join" {
+		t.Fatalf("call sequence = %v, want [shutdown:ctx-expired join] — the join must survive a blown drain budget", got)
+	}
+}
+
+// TestDrainOnSignal_BlocksUntilSignalled proves the drain is signal-driven and
+// not fired at startup. Without this, a bug that ran the drain immediately
+// would still satisfy the ordering test above.
+func TestDrainOnSignal_BlocksUntilSignalled(t *testing.T) {
+	rec := &recorder{}
+	sigCh := make(chan os.Signal, 1)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		drainOnSignal(sigCh, rec, rec, time.Second, quietLogger())
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("drainOnSignal returned before any signal was delivered")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if calls := rec.snapshot(); len(calls) != 0 {
+		t.Fatalf("collaborators called before signal: %v", calls)
+	}
+
+	sigCh <- syscall.SIGINT
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainOnSignal did not return after SIGINT")
+	}
+}
+
+// TestDefaultDrainBudget_FitsKubernetesGracePeriod guards the constant against
+// drifting past the grace period it is sized for. Overrunning 30s converts a
+// clean exit back into the SIGKILL this change removes.
+func TestDefaultDrainBudget_FitsKubernetesGracePeriod(t *testing.T) {
+	const k8sDefaultGrace = 30 * time.Second
+	if defaultDrainBudget >= k8sDefaultGrace {
+		t.Fatalf("defaultDrainBudget=%s must stay under the default terminationGracePeriodSeconds (%s), "+
+			"leaving headroom for the orphan-release join", defaultDrainBudget, k8sDefaultGrace)
+	}
+}

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -2186,11 +2189,40 @@ func main() {
 			"addr", ln.Addr().String())
 	}
 
+	// #5767 — graceful shutdown. This was a bare http.ListenAndServe, so
+	// SIGTERM killed the process where it stood. That is not a cosmetic
+	// gap: restoreFromStore's orphan-release goroutine calls pdm.Release,
+	// THEN clears the dep's PDM pointers, THEN persists. Killed between the
+	// first and last step it leaves an on-disk record still claiming a
+	// reservation that no longer exists in PDM — the exact #489
+	// "every Pod restart permanently locks a subdomain" symptom that
+	// goroutine exists to prevent. A rolling restart is the most common
+	// event in this platform's life, so the fix for #489 was itself
+	// killable by the routine case.
+	//
+	// Order matters: Shutdown FIRST (stop accepting, drain in-flight
+	// requests), then join the orphan releases. Draining first would let a
+	// new request spawn work after we had already waited.
+	srv := &http.Server{Addr: ":" + port, Handler: r}
+	drained := make(chan struct{})
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		defer close(drained)
+		drainOnSignal(sigCh, srv, h, defaultDrainBudget, log)
+	}()
+
 	log.Info("catalyst api listening", "port", port)
-	if err := http.ListenAndServe(":"+port, r); err != nil {
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Error("server error", "err", err)
 		os.Exit(1)
 	}
+	// ErrServerClosed is the normal path out of a signalled shutdown, not a
+	// failure — wait for the drain goroutine before returning so the process
+	// does not exit while it is still joining.
+	<-drained
+	log.Info("catalyst api stopped cleanly")
 }
 
 func env(key, fallback string) string {

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -726,7 +726,7 @@ func (h *Handler) restoreFromStore() {
 	)
 }
 
-// waitOrphanReleases blocks until every releaseOrphanedReservation goroutine
+// WaitOrphanReleases blocks until every releaseOrphanedReservation goroutine
 // spawned by restoreFromStore has run to completion — including the trailing
 // persistDeployment write, not just the pdm.Release call.
 //
@@ -734,7 +734,13 @@ func (h *Handler) restoreFromStore() {
 // directory after the effect a caller would naturally poll for. Tests that
 // assert on the Release and then return would otherwise leave it writing into
 // an already-being-torn-down t.TempDir() (#5765).
-func (h *Handler) waitOrphanReleases() { h.orphanReleaseWG.Wait() }
+//
+// Exported for the SIGTERM drain in cmd/api (#5767): a Pod killed between
+// pdm.Release and persistDeployment leaves an on-disk record still claiming a
+// reservation that no longer exists in PDM — the exact #489 subdomain-lock
+// symptom this goroutine was written to prevent. Call it AFTER
+// http.Server.Shutdown returns, so no new work can arrive while draining.
+func (h *Handler) WaitOrphanReleases() { h.orphanReleaseWG.Wait() }
 
 // releaseOrphanedReservation calls pdm.Release for a deployment whose
 // status was rewritten to "failed" because the catalyst-api Pod died

--- a/products/catalyst/bootstrap/api/internal/handler/release_subdomain_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/release_subdomain_test.go
@@ -310,7 +310,7 @@ func TestRestoreFromStore_PodRestartOrphanReleasesPDMSlot(t *testing.T) {
 	// Still read through the mutex-protected snapshot accessor: a direct
 	// read of fpdm.releases races the goroutine's append (the race
 	// detector flagged that before the accessor existed).
-	h.waitOrphanReleases()
+	h.WaitOrphanReleases()
 	releases := fpdm.snapshotReleases()
 
 	if got := len(releases); got != 1 {
@@ -330,7 +330,7 @@ func TestRestoreFromStore_PodRestartOrphanReleasesPDMSlot(t *testing.T) {
 		t.Errorf("Status=%q, want failed (Pod-restart rewrite contract)", dep.Status)
 	}
 
-	// No wait needed for the success-path field clear: waitOrphanReleases
+	// No wait needed for the success-path field clear: WaitOrphanReleases
 	// above already joined the goroutine that clears the pointers and
 	// persists, so by here the clear has either happened or never will.
 	// Asserting directly turns a timing-dependent poll into a real


### PR DESCRIPTION
## What

catalyst-api had **no graceful shutdown**. `cmd/api/main.go` ran a bare
`http.ListenAndServe`; there was no `signal.Notify`, no `http.Server`, and no
`Shutdown` anywhere in the tree:

```
$ grep -rn 'Shutdown\|SIGTERM\|signal.Notify' cmd/api/*.go
cmd/api/main.go:2190:	if err := http.ListenAndServe(":"+port, r); err != nil {
$ grep -rn 'func (h \*Handler) \(Close\|Stop\|Shutdown\)' internal/handler/*.go
(no matches)
```

So every rolling restart, node drain and deploy-bot image roll killed the
process where it stood.

## Why it matters — this re-opens #489

`restoreFromStore`'s orphan-release goroutine does, in order:

1. `pdm.Release(...)` — frees the subdomain in pool-domain-manager
2. clears the dep's `pdmPoolDomain` / `pdmSubdomain` / `pdmReservationToken`
3. `persistDeployment(dep)` — writes that back to the store

Killed between (1) and (3), the on-disk record still claims a reservation that
no longer exists in PDM. That is exactly the *"every Pod restart during
provisioning permanently locks a subdomain"* symptom #489 exists to prevent — so
the fix for #489 was itself killable by the single most routine event in this
platform's life.

## Design — the ordering is the substance

`drainOnSignal` shuts the server down **first**, joins the orphan releases
**second**. Past `Shutdown` no request can arrive, so no new orphan-release work
can be spawned and the join is guaranteed to terminate. Joining first would
race: a request landing mid-join spawns a goroutine the join has already passed,
and we exit while it is still writing to the store.

A blown drain budget still falls through to the join — cut in-flight requests
are survivable, a goroutine killed mid-persist is the #489 lock.

`defaultDrainBudget = 25s`, inside the **live** catalyst-api
`terminationGracePeriodSeconds` (verified `30` on the mothership deployment, not
assumed from the chart default). Overrunning would convert a clean exit back
into a SIGKILL after a stall — strictly worse than what we started with.

Extracted into `cmd/api/drain.go` behind two one-method interfaces rather than
inlined in `main()`, so the ordering is testable without delivering a real
signal to the test process.

## Verification — every guard mutation-checked

| Guard | Injected defect | Result |
|---|---|---|
| ordering pinned | join before shutdown | **RED** `call sequence = [join shutdown], want [shutdown join]` |
| join survives blown budget | join before shutdown | **RED** `[join shutdown:ctx-expired]` |
| budget under grace period | `45 * time.Second` | **RED** `defaultDrainBudget=45s must stay under ... (30s)` |
| blocks until signalled | — | catches a drain that fires at startup; without it a drain-immediately bug would still pass the ordering test |

Green: `cmd/api` `-race` `ok 1.214s`; drain tests `-race -count=3` all pass;
`go build ./...` and `go vet` clean; `gofmt` clean on all touched files.

The third row is the one I'd flag to a reviewer — an ordering assertion alone is
satisfiable by code that never waits for the signal at all, so it needed its own
control.

## Scope

Deliberately does **not** touch the chart. The live grace period already
accommodates the budget, and a test now fails if the constant drifts past it, so
there is nothing to change there yet.

Refs #5767 #5766 #5765 #489
