### PR TITLE
test(catalog): lock the catalog-item cache key so the #5496 lost-update cannot silently return

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.nameKey.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.nameKey.test.ts
@@ -54,3 +54,49 @@ describe('CatalogDetail blueprint name key (#5449)', () => {
     expect(SRC).toMatch(/const\s+name\s*=\s*\(params\.blueprintName\s*\?\?\s*''\)\.replace\(\/\^bp-\/,\s*''\)/)
   })
 })
+
+/**
+ * #5496 — the SECOND half of the same drift, and the one with teeth.
+ *
+ * #5449 corrected the REGISTRATION site (`queryKey: ['catalog-item',
+ * qualifiedName]`) and left the INVALIDATION site on the bare `name`. A key
+ * that never matches makes `invalidateQueries` a silent no-op, so the 30s
+ * `staleTime` window holds the pre-save document. The next per-field save then
+ * computes its merge base from that stale cache and writes the *pre-edit*
+ * sibling values back — the first save is silently reverted, with no error and
+ * nothing in the UI to show a write was lost.
+ *
+ * The fix is live, but nothing locked it: with the invalidation key put back to
+ * the bare `name`, all 43 tests across the six CatalogDetail suites still
+ * passed. That is precisely the state #5449 shipped in — a half-applied fix
+ * under a green suite — so the guard below asserts the property for EVERY
+ * `catalog-item` key rather than for the one call site that happened to be
+ * wrong at the time.
+ */
+describe('CatalogDetail catalog-item cache key is uniform (#5496)', () => {
+  const keys = [...SRC.matchAll(/\['catalog-item',\s*([A-Za-z0-9_]+)\s*\]/g)].map((m) => m[1])
+
+  it('finds every catalog-item key site', () => {
+    // Vacuity guard: if the key shape is ever refactored, this test must fail
+    // loudly rather than silently assert over an empty list.
+    expect(keys.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('registers AND invalidates on the same qualified key', () => {
+    // A single bare `name` anywhere in this set re-opens the lost-update bug:
+    // the registered key and the invalidated key stop matching and the refetch
+    // becomes a no-op.
+    expect(keys).not.toContain('name')
+    expect(new Set(keys)).toEqual(new Set(['qualifiedName']))
+  })
+
+  it('keeps the documented refetch contract honest', () => {
+    // The comment above refetchCatalog states the refetch exists so "the next
+    // field's merge base picks up the saved sibling". If the key drifts, that
+    // sentence becomes false while still reading as reassuring in review.
+    const fn = SRC.match(/const refetchCatalog = \(\) => \{[\s\S]*?\n  \}/)
+    expect(fn, 'refetchCatalog not found').toBeTruthy()
+    expect((fn as RegExpMatchArray)[0]).toContain('qualifiedName')
+    expect((fn as RegExpMatchArray)[0]).not.toMatch(/\['catalog-item',\s*name\s*\]/)
+  })
+})


### PR DESCRIPTION
## The fix was live and completely unguarded

Walking #5496 I confirmed the fix is on `origin/main` — all three
`['catalog-item', …]` sites use `qualifiedName` (registration :172,
`refetchCatalog` :343, IaC path :661).

Then I put the invalidation key back to the bare `name` — the exact reported
defect — and ran everything:

```
Test Files  6 passed (6)
     Tests  43 passed (43)
```

**Green.** The lost-update bug was fully restored and the entire CatalogDetail
suite was happy.

## Why that matters more than a normal missing test

This is the state #5449 shipped in. #5449 introduced `qualifiedName` for exactly
this bare-vs-`bp-` drift, corrected the registration site, and missed the
invalidation site — and the suite was green then too. Nothing has changed since
that would stop the same half-application happening a third time.

The consequence is not cosmetic. A key that never matches makes
`invalidateQueries` a no-op; the 30s `staleTime` holds the pre-save document; the
next per-field save computes its merge base from that stale cache and writes the
**pre-edit** sibling values back. The first save is silently reverted — no error,
no warning. Five UAT rows (127/132/133/142/153) present as "the page doesn't
update after Save" and read as cosmetic in review. They are this bug.

## The guard

Asserts the property over **every** `['catalog-item', X]` site, not the one call
site that happened to be wrong:

```ts
const keys = [...SRC.matchAll(/\['catalog-item',\s*([A-Za-z0-9_]+)\s*\]/g)].map(m => m[1])
expect(keys).not.toContain('name')
expect(new Set(keys)).toEqual(new Set(['qualifiedName']))
```

Plus a **vacuity check** — if the key shape is ever refactored so the match set
empties, the test fails loudly rather than silently asserting over an empty list.
And a check that `refetchCatalog`'s body still honours its own documented
contract, since the comment there ("so the next field's merge base picks up the
saved sibling") becomes false while still reading as reassuring.

Source-text assertion follows this file's existing approach, and its stated
rationale still applies: a render test passes with the drift restored whenever a
fixture answers both spellings identically — which is how this survived twice.

## RED / GREEN

| Tree | Result |
|---|---|
| fixed | **46/46 pass** |
| invalidation key → bare `name` | **2 fail** — `expected [ 'qualifiedName', 'name', … ] to not include 'name'`, and the refetch-contract check |
| reverted | **46/46 pass** |

Test-only change; no production code touched.

Refs #5496 #5449
