### PR TITLE
fix(§854): LB nodePort:0 guard counted presence, not ports — 4 of 5 could go unguarded

### DIFF
--- a/scripts/check-lb-nodeport0.py
+++ b/scripts/check-lb-nodeport0.py
@@ -112,11 +112,59 @@ def lb_capable(text: str, chart_dir: pathlib.Path) -> bool:
     return False
 
 
-def guarded(text: str) -> bool:
-    """True if the template carries BOTH §854 LB guard tokens."""
-    has_alloc = "allocateLoadBalancerNodePorts: false" in text
-    has_np0 = re.search(r"(?m)^\s*nodePort:\s*0\s*$", text) is not None
-    return has_alloc and has_np0
+# A port entry in a Service `ports:` list. Helm templates write these as
+# `- port: 25` / `- name: smtp`, one list item per exposed port.
+_PORT_ITEM_RE = re.compile(r"(?m)^\s*-\s+(?:name|port|targetPort)\s*:")
+_NP0_RE = re.compile(r"(?m)^\s*nodePort:\s*0\s*$")
+
+
+def port_items(text: str) -> int:
+    """Count `ports:` list entries. Deliberately counts the FIRST key of each
+    list item only, so a 3-key port block still counts as one port."""
+    n = 0
+    in_ports = False
+    ports_indent = -1
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if re.match(r"^ports\s*:", stripped):
+            in_ports, ports_indent = True, indent
+            continue
+        if in_ports:
+            # a key at or left of `ports:` indentation ends the block
+            if indent <= ports_indent and not stripped.startswith("-"):
+                in_ports = False
+                continue
+            if stripped.startswith("- "):
+                n += 1
+    return n
+
+
+def guarded(text: str) -> tuple[bool, str]:
+    """True if the template carries the §854 LB guards on EVERY port.
+
+    #5690 follow-up: this previously asked only whether `nodePort: 0` appeared
+    ANYWHERE in the file — a boolean presence check. A Service exposing five
+    ports with the sentinel on ONE of them therefore passed, which is the very
+    shape #5690 reported (bp-stalwart-sovereign mail, 5 unguarded ports).
+    Removing four of five sentinels left this check green.
+
+    `allocateLoadBalancerNodePorts: false` alone is not sufficient (#5348): it
+    stops NEW allocations, but an apply that merely OMITS `nodePort` leaves an
+    existing allocation in place. The per-port `nodePort: 0` is the sentinel the
+    apiserver actually clears, so it must be present once per port.
+    """
+    if "allocateLoadBalancerNodePorts: false" not in text:
+        return False, "missing `allocateLoadBalancerNodePorts: false`"
+    ports = port_items(text)
+    np0 = len(_NP0_RE.findall(text))
+    if np0 == 0:
+        return False, "no `nodePort: 0` on any port"
+    if ports and np0 < ports:
+        return False, f"{np0} `nodePort: 0` for {ports} port(s) — {ports - np0} port(s) unguarded"
+    return True, ""
 
 
 def scan():
@@ -134,8 +182,9 @@ def scan():
         if not lb_capable(text, chart_dir):
             continue
         lb.append(f)
-        if not guarded(text):
-            unguarded.append(f)
+        ok, why = guarded(text)
+        if not ok:
+            unguarded.append((f, why))
     return lb, unguarded
 
 
@@ -154,8 +203,8 @@ def main() -> int:
 
     if unguarded:
         print("FAIL: LoadBalancer Service template(s) omit the §854 nodePort:0 guard", file=sys.stderr)
-        for f in unguarded:
-            print(f"  - {rel(f)}", file=sys.stderr)
+        for f, why in unguarded:
+            print(f"  - {rel(f)}: {why}", file=sys.stderr)
         print(
             "\nA LoadBalancer Service without `allocateLoadBalancerNodePorts: false`\n"
             "+ explicit `nodePort: 0` auto-allocates a NodePort per port on apply\n"
@@ -184,10 +233,35 @@ def self_test() -> int:
     tmp = pathlib.Path(os.environ.get("ROOT", "."))  # chart_dir unused for literals
     if not lb_capable(guarded_tpl, tmp):
         fails.append("literal LoadBalancer not detected as LB-capable")
-    if not guarded(guarded_tpl):
+    if not guarded(guarded_tpl)[0]:
         fails.append("guarded template not recognised as guarded")
-    if guarded(unguarded_tpl):
+    if guarded(unguarded_tpl)[0]:
         fails.append("DISCRIMINATION: unguarded LB template passed as guarded")
+
+    # #5690 follow-up — the discrimination case the ORIGINAL guard missed:
+    # a multi-port LB with the sentinel on SOME ports. The old boolean
+    # presence check passed this; it is the exact partial shape of #5690.
+    partial_tpl = (
+        "kind: Service\nspec:\n  type: LoadBalancer\n"
+        "  allocateLoadBalancerNodePorts: false\n  ports:\n"
+        "    - name: a\n      port: 25\n      nodePort: 0\n"
+        "    - name: b\n      port: 587\n"
+        "    - name: c\n      port: 993\n"
+    )
+    ok_partial, why_partial = guarded(partial_tpl)
+    if ok_partial:
+        fails.append("DISCRIMINATION: 1-of-3 guarded ports passed as fully guarded (#5690 partial shape)")
+    elif "unguarded" not in why_partial:
+        fails.append(f"partial-guard reason unhelpful: {why_partial!r}")
+
+    # And the inverse must stay green: a fully-guarded multi-port LB.
+    full_tpl = partial_tpl.replace(
+        "    - name: b\n      port: 587\n", "    - name: b\n      port: 587\n      nodePort: 0\n"
+    ).replace(
+        "    - name: c\n      port: 993\n", "    - name: c\n      port: 993\n      nodePort: 0\n"
+    )
+    if not guarded(full_tpl)[0]:
+        fails.append("fully-guarded 3-port LB wrongly flagged unguarded")
     if not lb_capable(unguarded_tpl, tmp):
         fails.append("unguarded literal LB not detected as LB-capable")
     if lb_capable(clusterip_tpl, tmp):


### PR DESCRIPTION
## The guard written for #5690 could not catch #5690's partial shape

Walking #5690 I confirmed the reported fix is on `main` —
`platform/stalwart-sovereign/chart/templates/service-mail.yaml` carries
`allocateLoadBalancerNodePorts: false` plus `nodePort: 0` on all five mail ports
(smtp/submission/submissions/imap/imaps).

Then I tested the guard that was added alongside it (#5693/#5694) by deleting
**one** of those five sentinels:

```
$ python3 scripts/check-lb-nodeport0.py
OK: all 4 LoadBalancer Service template(s) carry the §854 nodePort:0 guard.
     ✓ platform/stalwart-sovereign/chart/templates/service-mail.yaml
$ echo $?
0
```

Green, with a tick next to the file that now auto-allocates a NodePort on apply.
Deleting **four** of five also passed.

## Cause

```python
has_np0 = re.search(r"(?m)^\s*nodePort:\s*0\s*$", text) is not None
```

A boolean presence test — "does `nodePort: 0` appear anywhere in this file" — not
"does every port carry it". #5690 was reported as *five* unguarded ports; the
guard is satisfied by one.

## Fix

Count `ports:` list items, require one sentinel per port, and say what is short:

```
- platform/stalwart-sovereign/chart/templates/service-mail.yaml:
    4 `nodePort: 0` for 5 port(s) — 1 port(s) unguarded
```

`allocateLoadBalancerNodePorts: false` is still required and still not sufficient
alone (#5348): it stops NEW allocations, but an apply that merely OMITS
`nodePort` leaves an existing allocation in place. The per-port `nodePort: 0` is
the sentinel the apiserver clears.

## Self-test

Added the discrimination case the original lacked — a **1-of-3 guarded**
multi-port LB must FAIL — and its inverse, a fully-guarded 3-port LB must PASS.
Without the inverse, "reject everything" would satisfy the new rule.

The existing vacuity floor and the guarded/unguarded/ClusterIP discrimination
cases are untouched.

## RED / GREEN, against the real template

| State | Result |
|---|---|
| unmodified `main` | exit **0**, 4 templates ✓ |
| drop 1 of 5 sentinels | exit **1** — `4 for 5 port(s) — 1 unguarded` |
| drop 4 of 5 sentinels | exit **1** — `1 for 5 port(s) — 4 unguarded` |
| restored | exit **0** |
| `--self-test` | **PASS** (4 LB services; discrimination OK) |

Script-only change; no chart templates touched. All four current LB templates
remain compliant.

Refs #5690 #5348 #5693
