### PR TITLE
test(stalwart-params): unchecked assertion panicked the binary and abandoned 6 sibling tests

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_stalwart_5752_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_stalwart_5752_test.go
@@ -86,18 +86,35 @@ func TestDefaultedParameters_StalwartTenantExplicitValuesWin(t *testing.T) {
 	}
 	got := defaultedParameters("bp-stalwart-tenant", "singleton", "hw292.omani.works", "uatco", "console.uatco.omani.homes", explicit)
 
-	domain := got["domain"].(map[string]interface{})
+	// Checked assertions, matching this file's first test. An unchecked
+	// `.(map[string]interface{})` here panics the whole test BINARY the moment
+	// the stamper regresses to a no-op, and Go abandons every test that had not
+	// yet run — the six siblings below reported nothing at all. A regression
+	// must fail this test, not silence the suite.
+	domain, ok := got["domain"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("domain must be a map, got %#v — the stamper dropped it entirely", got["domain"])
+	}
 	if domain["primary"] != "pinned.example" {
 		t.Fatalf("a caller-pinned domain.primary must NOT be overwritten, got %#v", domain["primary"])
 	}
-	keycloak := got["keycloak"].(map[string]interface{})
+	keycloak, ok := got["keycloak"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("keycloak must be a map, got %#v — the stamper dropped it entirely", got["keycloak"])
+	}
 	if keycloak["realmURL"] != "https://auth.pinned.example/realms/org-pinned" {
 		t.Fatalf("a caller-pinned keycloak.realmURL must NOT be overwritten, got %#v", keycloak["realmURL"])
 	}
 	// ingress.webmail.host was NOT explicitly pinned, so the stamp still
 	// lands alongside the preserved explicit values.
-	ingress := got["ingress"].(map[string]interface{})
-	webmail := ingress["webmail"].(map[string]interface{})
+	ingress, ok := got["ingress"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("ingress must be stamped even when domain/keycloak are pinned, got %#v", got["ingress"])
+	}
+	webmail, ok := ingress["webmail"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("ingress.webmail must be a map, got %#v", ingress["webmail"])
+	}
 	if webmail["host"] != "mail.uatco.omani.homes" {
 		t.Fatalf("ingress.webmail.host must still be stamped when not explicitly pinned, got %#v", webmail["host"])
 	}


### PR DESCRIPTION
## What

One unchecked type assertion in `application_parameters_stalwart_5752_test.go` panics the test **binary** when the #5752 stamper regresses, so Go abandons every test that had not yet run.

## How it was found

Verifying #5752 by injecting its original defect — `stampStalwartTenantParameters` returns immediately, the pre-fix state where a funnel install landed with `parameters: {}`. The suite went red, which is the right direction, but only **2 of 8** tests reported:

```
=== RUN   TestDefaultedParameters_StalwartTenantNoValues_StampsDomainIngressKeycloak
--- FAIL
=== RUN   TestDefaultedParameters_StalwartTenantExplicitValuesWin
--- FAIL
panic: interface conversion: interface {} is nil, not map[string]interface {}
    application_parameters_stalwart_5752_test.go:99
FAIL
```

The remaining six never executed. A red suite hid the fact that most of its coverage was never evaluated — and a *partially* regressed stamper that happens to trip line 99 first would silence the same six.

## The inconsistency

The file's own first test already does this correctly:

```go
domain, ok := got["domain"].(map[string]interface{})   // line 64 — checked
...
domain := got["domain"].(map[string]interface{})       // line 89 — bare
```

This change brings the second test in line with the first: four checked assertions, each with a `t.Fatalf` naming what the stamper dropped.

## What it recovers

| | before | after |
|---|---|---|
| tests reporting under the pre-#5752 mutation | 2 of 8 | **8 of 8** |
| FAIL | 2 | 6 |
| PASS (genuine negative controls) | 0 | 2 |

The six that were silent include `TestNewApplicationCRFromSeed_StalwartTenantNoValues_ParametersValidateConfigSchema` — the test asserting the emitted parameters satisfy the Blueprint's own configSchema (`required: [keycloak]`), which is the assertion sitting closest to the live `ContainerCreating` wedge #5752 was filed for. It fails correctly once allowed to run.

The two still passing are real controls, not survivors: `NonStalwartTenant_NoStamp` asserts *absence* of a stamp, and `RenderOrganizationOverlay_StalwartEmitsKeycloakOIDC` exercises the overlay renderer rather than the stamper.

## Verification

```
clean tree                exit=0   ok
pre-#5752 mutation        exit=1   6 FAIL / 2 PASS, all 8 reported, no panic
revert                    exit=0   ok, git status clean
gofmt                     clean
```

Test-only; no production code touched.

Refs #5752 #960
