### PR TITLE
test(catalyst-api): guard that main() actually wires the graceful drain

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/drain_wiring_test.go
+++ b/products/catalyst/bootstrap/api/cmd/api/drain_wiring_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestMainWiresDrainOnSignal is the guard the other drain tests cannot be.
+//
+// drainOnSignal was extracted from main() precisely so its ordering could be
+// tested without delivering a real signal to the test process (#5767). That
+// extraction bought testability at the cost of a seam: every behavioural test
+// in drain_test.go calls drainOnSignal DIRECTLY, so deleting the one call site
+// in main() leaves all of them green while the shipped binary goes straight
+// back to the abrupt SIGTERM death the ticket was filed for.
+//
+// Asserted against the parsed AST rather than the file text, so a mention of
+// drainOnSignal in a comment or a string literal cannot satisfy it — the call
+// has to be a real CallExpr reachable from main's body.
+func TestMainWiresDrainOnSignal(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	var mainFn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Recv == nil && fn.Name.Name == "main" {
+			mainFn = fn
+			break
+		}
+	}
+	if mainFn == nil {
+		t.Fatal("no func main in main.go")
+	}
+
+	var (
+		callsDrain   bool
+		passesBudget bool
+		notifiesTerm bool
+	)
+	ast.Inspect(mainFn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			if fn.Name != "drainOnSignal" {
+				return true
+			}
+			callsDrain = true
+			// The budget must be the shared constant, not a literal that can
+			// drift past terminationGracePeriodSeconds without tripping
+			// TestDefaultDrainBudget_FitsKubernetesGracePeriod.
+			for _, arg := range call.Args {
+				if id, ok := arg.(*ast.Ident); ok && id.Name == "defaultDrainBudget" {
+					passesBudget = true
+				}
+			}
+		case *ast.SelectorExpr:
+			// signal.Notify(..., syscall.SIGTERM) — without SIGTERM the drain
+			// never fires under Kubernetes, which sends SIGTERM, not SIGINT.
+			if fn.Sel.Name != "Notify" {
+				return true
+			}
+			for _, arg := range call.Args {
+				if sel, ok := arg.(*ast.SelectorExpr); ok && sel.Sel.Name == "SIGTERM" {
+					notifiesTerm = true
+				}
+			}
+		}
+		return true
+	})
+
+	if !callsDrain {
+		t.Fatal("main() does not call drainOnSignal — the graceful shutdown is dead code and " +
+			"SIGTERM kills orphan-release mid-persistDeployment again (#5767, #489 subdomain lock)")
+	}
+	if !passesBudget {
+		t.Fatal("main() calls drainOnSignal without passing defaultDrainBudget — a literal budget " +
+			"escapes the grace-period guard in TestDefaultDrainBudget_FitsKubernetesGracePeriod")
+	}
+	if !notifiesTerm {
+		t.Fatal("main() does not register syscall.SIGTERM — Kubernetes sends SIGTERM on pod " +
+			"termination, so the drain would never run in the environment it exists for")
+	}
+}


### PR DESCRIPTION
## The seam

`drainOnSignal` was extracted from `main()` in #5768 so its ordering could be tested without delivering a real signal to the test process. Good change — but every test in `drain_test.go` calls `drainOnSignal` **directly**. Delete the one call site in `main()` and all four stay green while the shipped binary loses graceful shutdown entirely.

That is the same failure shape this session has been finding repeatedly, inverted: not "the guard tests a copy of the artifact" but "the guard tests the artifact and no one checks it is still plugged in".

## What this adds

An AST-level assertion over `main()` for three properties `drain_test.go` structurally cannot see:

| property | why it matters |
|---|---|
| `main()` calls `drainOnSignal` | otherwise the drain is dead code |
| it passes `defaultDrainBudget` | a literal escapes `TestDefaultDrainBudget_FitsKubernetesGracePeriod`, so the budget could drift past `terminationGracePeriodSeconds` unguarded |
| `signal.Notify` registers `SIGTERM` | Kubernetes sends SIGTERM on pod termination; SIGINT alone means the drain never runs in the one environment it exists for |

Parsed with `go/parser` and walked as AST, so `drainOnSignal` appearing in a comment or a string literal cannot satisfy it — the call has to be a real `CallExpr` reachable from `main`'s body.

## Verification

Mutation-proven, each direction independently:

```
call site deleted        RED   main() does not call drainOnSignal — the graceful
                               shutdown is dead code and SIGTERM kills
                               orphan-release mid-persistDeployment again
90*time.Second literal   RED   ...without passing defaultDrainBudget
SIGTERM dropped          RED   ...does not register syscall.SIGTERM
clean tree               GREEN
```

Note on method: the first pass of this proof used `-run 'Wiring'`, which selects nothing — the test is `TestMainWiresDrainOnSignal`, and Go reported `[no tests to run]` as `ok`. Two of the three mutations were re-run under `-run TestMainWiresDrainOnSignal` after the pattern was corrected. Recording it because `ok ... [no tests to run]` reads exactly like a pass.

Test-only; no production code touched.

Refs #5767 #960
