### PR TITLE
fix(#5769): the #5646 step-name guard read a transcript, not the producer

### DIFF
--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -1309,27 +1309,7 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 	}
 	sort.Strings(depSlugs)
 
-	steps := []store.ProvisionStep{
-		{Name: "Creating Organization", Status: "pending"},
-		{Name: "Committing manifests to Git", Status: "pending"},
-		{Name: "Provisioning vCluster", Status: "pending"},
-	}
-	for _, dep := range depSlugs {
-		steps = append(steps, store.ProvisionStep{
-			Name:   fmt.Sprintf("Installing %s (dependency)", dep),
-			Status: "pending",
-		})
-	}
-	for _, appID := range apps {
-		steps = append(steps, store.ProvisionStep{
-			Name:   fmt.Sprintf("Deploying %s", appDisplayName(appNames, appID)),
-			Status: "pending",
-		})
-	}
-	steps = append(steps,
-		store.ProvisionStep{Name: "Configuring TLS certificates", Status: "pending"},
-		store.ProvisionStep{Name: "Running health checks", Status: "pending"},
-	)
+	steps := buildProvisionSteps(depSlugs, apps, appNames)
 
 	provision := &store.Provision{
 		TenantID:  tenantID,
@@ -1963,4 +1943,40 @@ func (h *Handler) publishEvent(_ context.Context, eventType, tenantID string, da
 	if err := h.Producer.Publish(pubCtx, topicProvisionEvents, event); err != nil {
 		slog.Error("failed to publish event", "type", eventType, "error", err)
 	}
+}
+
+// buildProvisionSteps returns the provisioning timeline exactly as the funnel
+// draws it, for the given dependency slugs and application ids.
+//
+// Extracted from startProvisioning for ONE reason (#5769): the #5646 guard
+// asserting no banned term reaches a customer's screen had no producer to call,
+// so it transcribed this list into the test file. A transcript cannot detect a
+// change to the thing it transcribes — putting "Creating tenant" back into the
+// producer left that guard green. The guard now calls this function, so the
+// names it checks are the names that ship.
+//
+// Pure: no receiver, no I/O, no clock. The caller resolves depSlugs/appNames
+// from the catalog first, which is the part that needs a cluster.
+func buildProvisionSteps(depSlugs, apps []string, appNames map[string]string) []store.ProvisionStep {
+	steps := []store.ProvisionStep{
+		{Name: "Creating Organization", Status: "pending"},
+		{Name: "Committing manifests to Git", Status: "pending"},
+		{Name: "Provisioning vCluster", Status: "pending"},
+	}
+	for _, dep := range depSlugs {
+		steps = append(steps, store.ProvisionStep{
+			Name:   fmt.Sprintf("Installing %s (dependency)", dep),
+			Status: "pending",
+		})
+	}
+	for _, appID := range apps {
+		steps = append(steps, store.ProvisionStep{
+			Name:   fmt.Sprintf("Deploying %s", appDisplayName(appNames, appID)),
+			Status: "pending",
+		})
+	}
+	return append(steps,
+		store.ProvisionStep{Name: "Configuring TLS certificates", Status: "pending"},
+		store.ProvisionStep{Name: "Running health checks", Status: "pending"},
+	)
 }

--- a/core/services/provisioning/handlers/customer_facing_copy_5646_test.go
+++ b/core/services/provisioning/handlers/customer_facing_copy_5646_test.go
@@ -145,17 +145,25 @@ func TestFailedStepMessage_KeepsTheDiagnostic(t *testing.T) {
 // draws, so a future edit that reintroduces "Creating tenant" is caught here
 // and not on a customer's screen.
 func TestProvisionStepNames_NoBannedTerm(t *testing.T) {
-	// The shipped step list (consumer.go startProvisioning) with the runtime-
-	// interpolated entries filled from the live hw292 catalog: dependency slugs
-	// come from the catalog verbatim, app names from the catalog display title.
-	emitted := []store.ProvisionStep{
-		{Name: "Creating Organization"},
-		{Name: "Committing manifests to Git"},
-		{Name: "Provisioning vCluster"},
-		{Name: fmt.Sprintf("Installing %s (dependency)", "mysql")},
-		{Name: fmt.Sprintf("Deploying %s", appDisplayName(map[string]string{"wp": "WordPress"}, "wp"))},
-		{Name: "Configuring TLS certificates"},
-		{Name: "Running health checks"},
+	// Read from the PRODUCER, never transcribed (#5769). This list used to be
+	// hand-copied into the test, which meant putting "Creating tenant" back into
+	// consumer.go left this guard green — the guard could not detect a change to
+	// the thing it was copying. buildProvisionSteps is the function
+	// startProvisioning itself calls; the runtime-interpolated entries are fed
+	// the same shapes the live hw292 catalog produces (dependency slugs verbatim,
+	// app names as catalog display titles).
+	emitted := buildProvisionSteps(
+		[]string{"mysql"},
+		[]string{"wp"},
+		map[string]string{"wp": "WordPress"},
+	)
+
+	// Vacuity check: a guard that iterates an empty list passes trivially. If
+	// the producer ever returns nothing, that is a defect in its own right and
+	// must not read as "no banned terms found".
+	if len(emitted) < 7 {
+		t.Fatalf("buildProvisionSteps returned %d steps, want >= 7 — "+
+			"a short or empty list makes the banned-term scan below vacuous", len(emitted))
 	}
 
 	for field, val := range customerVisibleFields(emitted) {


### PR DESCRIPTION
## The defect

`TestProvisionStepNames_NoBannedTerm` was written to stop `"Creating tenant"` reaching a customer's screen (#5646). It hand-copied the step list out of `startProvisioning` and scanned the copy:

```go
// The shipped step list (consumer.go startProvisioning) with the runtime-
// interpolated entries filled from the live hw292 catalog: ...
emitted := []store.ProvisionStep{
    {Name: "Creating Organization"},   // <- literal, written by the test
    ...
}
```

A transcript cannot detect a change to the thing it transcribes. Putting the banned string back into `consumer.go:1313` left the guard green.

The file's own header made the claim explicitly:

> it builds its inputs from the REAL production helpers (`vclusterKubeconfigSecretName`, the real k8s error format, **the real step-list builder**)

Two of the three were true. There was no step-list builder — the list was inline in `startProvisioning`, unreachable from a test.

## The change

Extract `buildProvisionSteps(depSlugs, apps, appNames)` from `startProvisioning`. Pure — no receiver, no I/O, no clock — so the guard calls the function that actually ships. The caller still resolves `depSlugs`/`appNames` from the catalog, which is the part that needs a cluster; only the assembly moves.

Also adds a vacuity check. A banned-term scan over an empty slice passes trivially, so a producer that returns nothing would have read as "no banned terms found" — the same failure mode one layer down.

## Verification

```
"Creating tenant" restored in the producer
  RED   customer_facing_copy_5646_test.go:171: banned term in customer-visible
        steps[0].name = "Creating tenant" (docs/GLOSSARY.md: use "Organization")

producer returns nil
  RED   vacuity check

clean tree
  GREEN  go test ./handlers/ — full package, not just the selected tests
```

`TestInternalIdentifiers_AreNotRenamed` — the control that must stay green on both trees, and that fails if anyone "fixes" the copy defect by renaming the internal `tenant-<slug>-kubeconfig` Secret — is untouched and still green.

Refs #5769 #5646 #960
