### PR TITLE
fix(#5646): the failed-run progress recompute was unguarded at its call site

### DIFF
--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -1874,25 +1874,7 @@ func (h *Handler) failProvision(ctx context.Context, provisionID, tenantID strin
 		return
 	}
 
-	if stepIndex < len(p.Steps) && p.Steps[stepIndex].Status != "failed" {
-		p.Steps[stepIndex].Status = "failed"
-		// #5646 — same customer-facing field as failStep. Several callers wrap a
-		// raw error into this message (`vcluster not ready: %s`,
-		// `mirror kubeconfig to flux-system: %s`), so it carries the same
-		// runtime-object-name exposure and gets the same boundary.
-		p.Steps[stepIndex].Message = customerFacingMessage(message)
-		p.Steps[stepIndex].DoneAt = time.Now().UTC()
-	}
-
-	p.Status = "failed"
-	// #5646 — progress must never read 100 on a run that failed. A concurrent
-	// pod-truth reconcile (or an earlier step-completion roll-up) can have left
-	// Progress at 100 just before this failure lands; without recomputing it the
-	// customer sees a FULL progress bar sitting above "Provisioning didn't
-	// finish". Recompute from the steps that ACTUALLY completed — the failed /
-	// still-pending steps are excluded, so on a failed run this is always < 100.
-	// The invariant the funnel UI relies on: progress == 100 ⟺ status == completed.
-	p.Progress = completedStepProgress(p.Steps)
+	markProvisionFailed(p, stepIndex, message)
 	if err := h.Store.UpdateProvision(ctx, provisionID, p); err != nil {
 		slog.Error("failed to mark provision as failed", "error", err)
 	}
@@ -1979,4 +1961,39 @@ func buildProvisionSteps(depSlugs, apps []string, appNames map[string]string) []
 		store.ProvisionStep{Name: "Configuring TLS certificates", Status: "pending"},
 		store.ProvisionStep{Name: "Running health checks", Status: "pending"},
 	)
+}
+
+// markProvisionFailed applies the terminal failed state to p: paints the step
+// red with customer-safe copy, sets the run status, and recomputes progress.
+//
+// Extracted from failProvision for #5646. The progress recompute below was
+// previously inline and therefore unguarded — deleting the single line
+// `p.Progress = completedStepProgress(p.Steps)` left the whole package green,
+// because the only test on this behaviour exercised completedStepProgress (the
+// helper) and nothing asserted the failure path CALLS it. Same shape as #5767's
+// drain: the helper was tested, the wiring was not.
+//
+// Pure: mutates p, no store, no publish, no receiver — so a test can assert the
+// invariant directly instead of standing up a fake Mongo and event bus.
+//
+// The invariant the funnel UI relies on: progress == 100 ⟺ status == completed.
+func markProvisionFailed(p *store.Provision, stepIndex int, message string) {
+	if stepIndex < len(p.Steps) && p.Steps[stepIndex].Status != "failed" {
+		p.Steps[stepIndex].Status = "failed"
+		// #5646 — same customer-facing field as failStep. Several callers wrap a
+		// raw error into this message (`vcluster not ready: %s`,
+		// `mirror kubeconfig to flux-system: %s`), so it carries the same
+		// runtime-object-name exposure and gets the same boundary.
+		p.Steps[stepIndex].Message = customerFacingMessage(message)
+		p.Steps[stepIndex].DoneAt = time.Now().UTC()
+	}
+
+	p.Status = "failed"
+	// A concurrent pod-truth reconcile (or an earlier step-completion roll-up)
+	// can have left Progress at 100 just before this failure lands; without
+	// recomputing it the customer sees a FULL progress bar sitting above
+	// "Provisioning didn't finish". Recompute from the steps that ACTUALLY
+	// completed — the failed / still-pending steps are excluded, so on a failed
+	// run this is always < 100.
+	p.Progress = completedStepProgress(p.Steps)
 }

--- a/core/services/provisioning/handlers/provision_failed_progress_5646_test.go
+++ b/core/services/provisioning/handlers/provision_failed_progress_5646_test.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/provisioning/store"
+)
+
+// TestMarkProvisionFailed_ProgressNeverStaysHundred is the behavioural half.
+//
+// The live shape it reproduces: a concurrent pod-truth reconcile rolls Progress
+// to 100, then a step fails. Without the recompute the customer is shown a full
+// progress bar sitting directly above "Provisioning didn't finish" — the exact
+// contradiction #5646 was filed for.
+func TestMarkProvisionFailed_ProgressNeverStaysHundred(t *testing.T) {
+	p := &store.Provision{
+		Status:   "provisioning",
+		Progress: 100, // rolled to 100 by a concurrent reconcile before the failure
+		Steps: []store.ProvisionStep{
+			{Name: "Creating Organization", Status: "completed"},
+			{Name: "Committing manifests to Git", Status: "completed"},
+			{Name: "Provisioning vCluster", Status: "running"},
+			{Name: "Running health checks", Status: "pending"},
+		},
+	}
+
+	markProvisionFailed(p, 2, "vcluster not ready: tenant-uatco-kubeconfig missing")
+
+	if p.Status != "failed" {
+		t.Fatalf("status = %q, want failed", p.Status)
+	}
+	if p.Progress >= 100 {
+		t.Fatalf("progress = %d on a FAILED run — the funnel draws a full bar above "+
+			`"Provisioning didn't finish". The invariant is progress == 100 <=> status == completed`, p.Progress)
+	}
+	if p.Steps[2].Status != "failed" {
+		t.Fatalf("steps[2].status = %q, want failed", p.Steps[2].Status)
+	}
+	// The failed step's message is customer-visible; it must not carry the
+	// runtime object name (same boundary as TestFailedStepMessage_*).
+	if bannedProductTerm.MatchString(p.Steps[2].Message) {
+		t.Fatalf("banned term in customer-visible steps[2].message = %q", p.Steps[2].Message)
+	}
+	// Control: the diagnostic must survive the sanitisation, or operators lose
+	// the only signal they have.
+	if p.Steps[2].Message == "" {
+		t.Fatal("steps[2].message is empty — sanitising must not discard the diagnostic")
+	}
+}
+
+// TestMarkProvisionFailed_AllStepsCompleteStillNotHundred covers the boundary
+// the recompute exists for: every step reads "completed" but the run failed
+// anyway (a failure raised outside the step loop). Progress must still not be
+// 100, because the invariant is keyed on RUN status, not step tally.
+func TestMarkProvisionFailed_AllStepsCompleteStillNotHundred(t *testing.T) {
+	p := &store.Provision{
+		Status:   "provisioning",
+		Progress: 100,
+		Steps: []store.ProvisionStep{
+			{Name: "Creating Organization", Status: "completed"},
+			{Name: "Running health checks", Status: "completed"},
+		},
+	}
+
+	markProvisionFailed(p, 1, "post-flight verification failed")
+
+	if p.Status != "failed" {
+		t.Fatalf("status = %q, want failed", p.Status)
+	}
+	if p.Progress >= 100 {
+		t.Fatalf("progress = %d with status=failed — violates progress == 100 <=> completed", p.Progress)
+	}
+}
+
+// TestFailProvision_CallsMarkProvisionFailed is the wiring half, and it is the
+// one the package was missing.
+//
+// markProvisionFailed is pure, so every behavioural test above calls it
+// DIRECTLY. Deleting the call from failProvision therefore leaves them all
+// green while the shipped code stops recomputing progress entirely — which is
+// exactly the mutation that survived on this package before this file existed.
+//
+// Asserted against the parsed AST, so a mention in a comment cannot satisfy it.
+func TestFailProvision_CallsMarkProvisionFailed(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "consumer.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse consumer.go: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		d, ok := decl.(*ast.FuncDecl)
+		if ok && d.Name.Name == "failProvision" && d.Recv != nil {
+			fn = d
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("no (*Handler).failProvision in consumer.go")
+	}
+
+	var calls bool
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "markProvisionFailed" {
+			calls = true
+		}
+		return true
+	})
+
+	if !calls {
+		t.Fatal("failProvision does not call markProvisionFailed — the failed run keeps whatever " +
+			"Progress a concurrent reconcile last wrote, so the funnel can show 100% above " +
+			`"Provisioning didn't finish" (#5646)`)
+	}
+}


### PR DESCRIPTION
## What survived

While verifying #5646 for closure I injected its own defect into the failure path:

```diff
 consumer.go failProvision()
-	p.Progress = completedStepProgress(p.Steps)
```

Every test in the package stayed **green**. The run now reports `status: failed` while keeping whatever `Progress` a concurrent pod-truth reconcile last wrote — which is exactly the customer-visible contradiction the ticket describes: a full progress bar above "Provisioning didn't finish".

`TestCompletedStepProgress_NeverHundredOnFailedRun` exists and is a good test, but it exercises `completedStepProgress`, the pure helper. Nothing asserted the failure path *calls* it. Identical shape to the drain seam in #5767, found an hour earlier: helper tested, wiring not.

## Change

Extract `markProvisionFailed(p, stepIndex, message)` — the terminal state transition, pure, no store and no event bus — so the invariant is assertable without a fake Mongo.

| guard | asserts |
|---|---|
| `ProgressNeverStaysHundred` | `Progress=100` from a concurrent reconcile, then a step fails → `< 100`, step red, message sanitised, **diagnostic preserved** |
| `AllStepsCompleteStillNotHundred` | every step reads `completed` but the run failed anyway → still `< 100`; the invariant is keyed on RUN status, not step tally |
| `FailProvision_CallsMarkProvisionFailed` | AST assertion that `failProvision` actually calls it — the missing half |

The third follows the idiom established in #5775: parsed AST, not file text, so a mention in a comment cannot satisfy it.

## Verification

```
transition dropped from failProvision   RED   failProvision does not call markProvisionFailed
                                              <- this is the mutation that survived before
progress recompute dropped              RED   both behavioural tests
customerFacingMessage bypassed          RED   banned term in customer-visible steps[2].message
clean tree                              GREEN go test ./... — full module
```

Behaviour is byte-identical to `main`; this is an extraction plus guards. The sanitiser and diagnostic-preservation assertions are carried along because `markProvisionFailed` owns that boundary too, and a test that only checked the number would have let a raw `tenant-<slug>-kubeconfig` through.

Refs #5646 #960
