### PR TITLE
test(api): pin that an Org-scoped session cannot reach deployment wipe (Refs #5401)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
@@ -91,6 +91,17 @@ func TestPathIsOrgSafe(t *testing.T) {
 		// mutation, launch-url) are NOT opened to Org sessions by this change.
 		"/catalyst/v1/apps/uid-1/endpoints",
 		"/catalyst/v1/apps/uid-1/launch-url",
+		// #5401 — the DESTRUCTIVE deployment routes, named explicitly.
+		//
+		// These are already denied transitively: the allowlist is prefix-based
+		// and nothing grants "/api/v1/deployments", so every path under it
+		// falls through to the 403. Naming them anyway is deliberate. #5401
+		// asked whether an org-admin can "destroy the Sovereign hosting every
+		// other Organization on it", and the answer should not depend on a
+		// reader reconstructing prefix arithmetic — the wipe path is the one
+		// route on this API whose successful call is unrecoverable.
+		"/api/v1/deployments/4635277cae4ffed9/wipe",
+		"/api/v1/deployments/4635277cae4ffed9/cloudinit-log",
 	}
 	for _, p := range unsafe {
 		if pathIsOrgSafe(p) {
@@ -103,6 +114,75 @@ func TestPathIsOrgSafe(t *testing.T) {
 func orgScopeGuardTestHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+// TestOrgScopeGuard_OrgScoped_CannotReachDeploymentWipe answers the question
+// #5401 left open, and answers it about the WIPE specifically.
+//
+// That issue observed the Sovereign operator panel rendering to an org-admin
+// and correctly refused to guess the severity, writing: "The walk observed the
+// page rendering; it did not establish whether the controls function for an
+// org-admin bearer or whether the backend rejects them. Those are very
+// different severities." The Decommission control is a link to a page that
+// POSTs /api/v1/deployments/{id}/wipe, so that route is where the severity is
+// actually decided.
+//
+// This asserts the middleware verdict rather than a status code alone. A 403
+// can be produced by a downstream handler that already ran and did work; what
+// matters for a destructive route is that the target is never ENTERED. So the
+// wrapped handler records whether it was invoked, and the assertion is that it
+// was not.
+//
+// The POST method is deliberate: pathIsOrgSafe is method-blind, and the guard
+// must not become method-sensitive in a way that lets a write through on a path
+// whose reads are denied.
+func TestOrgScopeGuard_OrgScoped_CannotReachDeploymentWipe(t *testing.T) {
+	h := &Handler{log: quietLog()}
+
+	reached := false
+	guard := h.OrgScopeGuard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/deployments/4635277cae4ffed9/wipe", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey,
+		&auth.Claims{Email: "customer@acme", Tier: orgScopedTier, Org: "acme"}))
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+
+	if reached {
+		t.Fatal("an Org-scoped session REACHED the wipe handler — this is the " +
+			"privilege-escalation path #5401 asked about, and it is unrecoverable when it succeeds")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("wipe must be 403'd for an Org-scoped session, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOrgScopeGuard_SovereignAdmin_ReachesDeploymentWipe is the control for the
+// test above. Without it, deleting the wipe route from the router — or breaking
+// the guard closed for everyone — would leave that test green while the
+// operator's own Decommission flow was dead.
+func TestOrgScopeGuard_SovereignAdmin_ReachesDeploymentWipe(t *testing.T) {
+	h := &Handler{log: quietLog()}
+
+	reached := false
+	guard := h.OrgScopeGuard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/deployments/4635277cae4ffed9/wipe", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey,
+		&auth.Claims{Email: "operator@openova.io", Tier: "admin"}))
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+
+	if !reached {
+		t.Fatalf("the Sovereign operator must still reach wipe — guard returned %d, "+
+			"so the deny above proves nothing", rec.Code)
+	}
 }
 
 func TestOrgScopeGuard_SovereignAdmin_Passthrough(t *testing.T) {


### PR DESCRIPTION
## The question this answers

#5401 is an open SECURITY issue that deliberately refused to guess its own severity:

> The walk observed the page rendering; it did not establish **whether the controls function** for an org-admin bearer or whether the backend rejects them. Those are very different severities. […] **Determining which is the first thing to do here.**

I determined it. The answer is **information-disclosure class, not privilege escalation** — and this PR pins the part of that answer that was holding only by implication.

## Evidence

| claim in #5401 | measured |
|---|---|
| org-admin can "read […] platform-wide credentials" | **No.** `TOKEN_MASK` is the hardcoded literal `'••••••••••••••••'` (SettingsPage.tsx:123). The real token value is never fetched or rendered — there is no credential in the DOM to disclose. |
| org-admin can "revoke" them | **No.** Both controls are `disabled`, `title="Token rotation API not yet wired"` / `"Cloud credential rotation API not yet wired"`. No endpoint exists behind them. |
| org-admin can "destroy the Sovereign" | **No.** Decommission POSTs `/api/v1/deployments/{id}/wipe`, which sits inside the `rg` group carrying `auth.RequireSession` + `h.OrgScopeGuard`. The guard is deny-by-default for Org-scoped sessions, and nothing in `orgSafePathPrefixes` grants `/api/v1/deployments`. |
| fictitious "Acme Financial" shipped as live defaults | **Already fixed** — `ORG_DEFAULTS` is now all-empty (`model.ts:339`), landed in `4abd41237`. |

Worth adding, because the issue reasoned from file placement: the **per-Org console has its own settings page** (`core/console/src/components/SettingsPage.svelte`, 212 lines), distinct from the sovereign `SettingsPage.tsx` the issue examined. Its only "Revoke" is *"Revoke every refresh token across all devices"* — ordinary self-service session logout. Its git history contains no #5401-related commit, only tenant→Organization renames, so it never carried the operator panel.

The guard is also **host-anchored** (#4110): a stale or forged sovereign-admin cookie landing on an Org console host is still confined, because the trust anchor is `X-Forwarded-Host`, which an Org-console browser cannot forge.

## What this PR changes

Nothing about the behaviour — it was already correct. What was missing is that wipe held **transitively**: denial came from prefix arithmetic (`/api/v1/deployments` is not allowlisted, so everything under it falls through) that a reader had to reconstruct. Wipe is the one route on this API whose successful call is unrecoverable, so it gets named.

- `.../wipe` and `.../cloudinit-log` added to the denied-path list by name.
- A middleware-level test driving an Org-scoped session over **POST** `.../wipe`, asserting the wrapped handler was **never entered** — a 403 alone is weaker, since it can be produced by a handler that already ran and did work.
- A **control** proving the Sovereign operator still reaches wipe, so breaking the guard closed for everyone cannot pass as a security win.

POST is deliberate: `pathIsOrgSafe` is method-blind and must stay that way.

## Mutation evidence

| mutation | result |
|---|---|
| allowlist `/api/v1/deployments` — the escalation #5401 feared | **4 tests failed** |
| guard becomes method-sensitive, POST passes through | **1 test failed** — *only the new one* |
| guard denies everyone, operator loses Decommission | **3 tests failed** (incl. the new control) |
| *revert* | **10 run, ok** |

The middle row is the gap this closes: the existing suite stayed **green** on a mutation that lets an Org-scoped POST through to wipe.

A first attempt at the third mutation is not counted — it failed to compile, and a build failure is not a test result.

## Scope

Test-only, `go vet` clean, 10 tests in this file (up from 8). No product code changed, so nothing here is deploy-gated.

Refs #5401
