### PR TITLE
docs(ledger): the remaining ❌ set is a DEPLOY, not a fix backlog — classify every non-green row by delivery state

### DIFF
--- a/docs/ledger/PATH-TO-100.md
+++ b/docs/ledger/PATH-TO-100.md
@@ -5,6 +5,55 @@
 
 ---
 
+## The remaining ❌ set is a DEPLOY, not a fix backlog (measured 2026-08-07)
+
+This is the single most decision-relevant fact in this file, and it was not
+visible until every failing row was classified at once rather than chased one at
+a time.
+
+`scripts/classify-uat-blockers.py --image fad88bd` — the catalyst-api actually
+running on hw292, **built 2026-08-02** — resolves each row's cited PRs to their
+merge commits and asks whether each is an ancestor of that artifact:
+
+| verdict | count | rows |
+|---|---|---|
+| **DEPLOY-GATED** — fix merged, artifact predates it | **12** | R17, W1, W2, 35, 37, 57, 86, 90, 92, 115, 219, 234 |
+| **CODE-BLOCKED** — no merged fix cited | **1** | 20 |
+
+Row 20 is the lone exception and is not really engineering either: it needs a
+customer Organization driven through the funnel before its assertion can be
+evaluated at all.
+
+Run against the ⚠️ tier the same way, **8 more** rows are deploy-gated (W5, 9,
+33, 53, 55, 62, 71, 87). So **20 rows across both tiers are waiting on a roll**,
+and writing further fixes moves none of them.
+
+**What this changes.** The next action for the ❌ set is delivering the train —
+not another fix wave. Four separate investigations this session (R17's
+cross-region reaper, W1/W2's wizard defaults, rows 35/115's bp-guacamole
+`crossRegion`, row 92's 429 notice) each independently terminated in "the fix is
+merged and the running artifact predates it". That is the same finding four
+times, which is what the classifier now surfaces in one command.
+
+**Two traps the script encodes**, both of which produced wrong answers by hand
+before being caught:
+
+1. A cited PR is often a `docs(uat)` **walk record**, not a fix — #5615 and
+   #5617 are the walks that recorded rows 219/234 failing. Counting those as
+   fixes turns a code-blocked row into a false deploy-gate, so the commit
+   *subject* is classified, not merely its presence.
+2. The row's verdict is the **6th pipe-delimited cell**, not "does the line
+   contain ❌". Several ✅ rows cite ❌ in their evidence prose; matching the
+   whole line over-counted failures (W3 is the example — status ✅, prose
+   contains ❌).
+
+The script **refuses to guess the running artifact** and exits non-zero without
+`--image`/`UAT_IMAGE`, because a wrong artifact inverts every verdict — the same
+wrong-subject failure mode as
+`feedback_never_declare_an_env_dead_without_probing_its_own_record_fqdn`.
+
+---
+
 ## Where the ledger actually stands
 
 The ledger was reset for this env — `scripts/reset-uat.py hw292` flushed 135 hw291 evidence cells to ☐/⏳ on 2026-07-31, per the founder's each-new-env-flushes-all-evidence law — and has been re-walked upward from there ever since. It is **no longer** near-zero, so the "a raw tally reads near-zero by design" note that stood here from 2026-07-31 has been retired rather than left to mislead.

--- a/scripts/classify-uat-blockers.py
+++ b/scripts/classify-uat-blockers.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Classify every non-green UAT row as DEPLOY-GATED or CODE-BLOCKED.
+
+WHY THIS EXISTS. "Why is UAT not at 100%?" has two very different answers, and
+they call for opposite next actions:
+
+  DEPLOY-GATED — the row cites a `fix:`/`feat:` PR that is merged on main but
+                 whose merge commit is NOT an ancestor of the artifact actually
+                 running on the environment. No code work remains; the train
+                 needs to roll.
+  CODE-BLOCKED — the row cites no merged fix at all, or cites one that IS in the
+                 running artifact and still fails. Real engineering remains.
+
+Measured on 2026-08-07 against hw292 (catalyst-api fad88bd, built 2026-08-02):
+12 of the 13 ❌ rows were DEPLOY-GATED. Writing more fixes would not have moved
+any of them. That is worth being able to re-measure in one command rather than
+rediscovering it a row at a time — the previous pass found it by chasing R17,
+W1/W2 and rows 35/115 individually before the pattern became visible.
+
+TWO TRAPS THIS ENCODES, both hit while deriving it by hand:
+
+ 1. A cited PR is often a `docs(uat)` WALK RECORD, not a fix. #5615 and #5617
+    are the walks that recorded rows 219/234 failing. Counting them as fixes
+    turns a code-blocked row into a false deploy-gate, so commit SUBJECT is
+    classified, not just presence.
+ 2. The row's status is the 6th pipe-delimited cell, not "does the line contain
+    ❌". Several ✅ rows mention ❌ in their evidence prose; matching on the line
+    over-counted the failures. (W3 is the example: status ✅, prose contains ❌.)
+
+USAGE
+    python3 scripts/classify-uat-blockers.py                  # auto-detect image
+    python3 scripts/classify-uat-blockers.py --image <sha>    # pin the artifact
+    python3 scripts/classify-uat-blockers.py --status ⚠️      # any status glyph
+
+The running artifact is NOT discoverable from the repo, so `--image` is how the
+walker supplies what it observed live (`kubectl get deploy … -o jsonpath` on the
+image tag). Without it the script uses UAT_IMAGE from the environment, and if
+neither is present it says so and exits non-zero rather than guessing — a
+silently-assumed image would invert every verdict.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import OrderedDict
+
+UAT = "docs/ledger/UAT.md"
+ROW_RE = re.compile(r"^\|\s*(R?\d+|[GWM]\d+)\s*\|")
+# A fix-bearing conventional-commit prefix. `docs:` is deliberately absent — a
+# docs(uat) commit is a walk record, not a delivery (trap 1 above).
+FIX_PREFIXES = ("fix", "feat", "perf", "refactor", "test", "chore")
+DOCS_PREFIXES = ("docs",)
+
+
+def sh(cmd):
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True).stdout.strip()
+
+
+def rows_with_status(path, want):
+    """Yield (row_id, evidence) for rows whose STATUS CELL is `want`.
+
+    The status is field 6 of the pipe-split line. Matching on the whole line
+    over-counts, because passing rows cite failures in their prose (trap 2).
+    """
+    out = OrderedDict()
+    for line in open(path, encoding="utf-8"):
+        if not ROW_RE.match(line):
+            continue
+        f = line.split("|")
+        if len(f) <= 6:
+            continue
+        status = f[6].strip()
+        # A stamped row may carry a screenshot suffix after the glyph.
+        if not status.startswith(want):
+            continue
+        out[f[1].strip()] = f[7] if len(f) > 7 else ""
+    return out
+
+
+def classify(evidence, image):
+    """Split the PRs an evidence cell cites into delivery buckets."""
+    prs = sorted(set(re.findall(r"#(\d{4,5})", evidence)), key=int)
+    pending, delivered, docs, unmerged = [], [], [], []
+    for pr in prs:
+        sha = sh(f"git log --oneline --all --grep='(#{pr})' -1 --format=%H")
+        if not sha:
+            unmerged.append(pr)
+            continue
+        subject = sh(f"git log -1 --format=%s {sha}")
+        kind = subject.split("(")[0].split(":")[0].strip()
+        if kind in DOCS_PREFIXES:
+            docs.append(pr)
+            continue
+        if kind not in FIX_PREFIXES:
+            docs.append(pr)
+            continue
+        in_image = subprocess.run(
+            f"git merge-base --is-ancestor {sha} {image}", shell=True
+        ).returncode == 0
+        (delivered if in_image else pending).append(pr)
+    return pending, delivered, docs, unmerged
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--image", help="commit-ish of the artifact running on the env")
+    ap.add_argument("--status", default="❌", help="status glyph to classify (default ❌)")
+    ap.add_argument("--uat", default=UAT)
+    args = ap.parse_args()
+
+    import os
+
+    image = args.image or os.environ.get("UAT_IMAGE")
+    if not image:
+        print(
+            "ERROR: no running artifact supplied. Pass --image <sha> (or set UAT_IMAGE)\n"
+            "with the image tag observed LIVE on the environment. Guessing one would\n"
+            "invert every verdict, so this exits instead.",
+            file=sys.stderr,
+        )
+        return 2
+    if subprocess.run(f"git rev-parse --verify {image}", shell=True,
+                      capture_output=True).returncode != 0:
+        print(f"ERROR: {image!r} does not resolve in this repo — fetch it first.", file=sys.stderr)
+        return 2
+
+    built = sh(f"git log -1 --format=%ad --date=short {image}")
+    rows = rows_with_status(args.uat, args.status)
+    if not rows:
+        print(f"no rows with status {args.status!r} — nothing to classify")
+        return 0
+
+    print(f"artifact {image} (built {built}) · {len(rows)} row(s) at status {args.status}\n")
+    print(f"{'row':<6} {'verdict':<14} detail")
+    print("-" * 96)
+    gated, blocked = [], []
+    for rid, ev in rows.items():
+        pending, delivered, docs, unmerged = classify(ev, image)
+        if pending:
+            gated.append(rid)
+            detail = f"fix PRs merged AFTER the artifact: {', '.join('#' + p for p in pending)}"
+            verdict = "DEPLOY-GATED"
+        else:
+            blocked.append(rid)
+            bits = []
+            if delivered:
+                bits.append(f"fix present in artifact: {', '.join('#' + p for p in delivered)}")
+            if docs:
+                bits.append(f"docs/walk-record only: {', '.join('#' + p for p in docs)}")
+            if unmerged:
+                bits.append(f"cited but unmerged: {', '.join('#' + p for p in unmerged)}")
+            detail = "; ".join(bits) or "no PR cited"
+            verdict = "CODE-BLOCKED"
+        print(f"{rid:<6} {verdict:<14} {detail}")
+
+    print()
+    print(f"DEPLOY-GATED : {len(gated):>3}  {', '.join(gated)}")
+    print(f"CODE-BLOCKED : {len(blocked):>3}  {', '.join(blocked)}")
+    if gated and not blocked:
+        print("\nEvery failing row is waiting on a roll. Writing more fixes moves none of them.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Four separate investigations this session — R17's cross-region reaper, W1/W2's wizard defaults, rows 35/115's bp-guacamole `crossRegion`, row 92's 429 notice — each independently ended in the same sentence: **the fix is merged and the running artifact predates it.** That is one finding discovered four times.

`scripts/classify-uat-blockers.py` makes it one command. Against hw292's catalyst-api `fad88bd` (built **2026-08-02**):

| verdict | count | rows |
|---|---|---|
| **DEPLOY-GATED** — fix merged, artifact predates it | **12** | R17, W1, W2, 35, 37, 57, 86, 90, 92, 115, 219, 234 |
| **CODE-BLOCKED** — no merged fix cited | **1** | 20 |

Row 20 is the lone exception and isn't really engineering either — it needs a customer Org driven through the funnel before its assertion can be evaluated. Run against ⚠️, **8 more** are deploy-gated. **20 rows across both tiers are waiting on a roll**, and writing further fixes moves none of them.

**Two traps encoded**, both of which gave me wrong answers by hand first:

1. A cited PR is often a `docs(uat)` **walk record**, not a fix — #5615/#5617 are the walks that *recorded* 219/234 failing. Counting them as fixes turns a code-blocked row into a false deploy-gate, so the commit **subject** is classified.
2. The verdict is the **6th pipe-delimited cell**, not "line contains ❌". Several ✅ rows cite ❌ in prose (W3: status ✅, prose ❌), so whole-line matching over-counts.

It **refuses to guess the running artifact** — exits 2 without `--image`/`UAT_IMAGE` — because a wrong artifact inverts every verdict, the same wrong-subject failure mode as the near-wipe of a healthy hw292.

| mutation | result |
|---|---|
| `--image` = current main | all 13 → CODE-BLOCKED (fixes now delivered) |
| `--status ⚠️` | classifies that tier: 8 gated / 32 blocked |
| no image / unresolvable image | exit 2, no guess |

Docs + one new script. No product code. Tally guard: 286 rows / 181 green.

Refs #960