### PR TITLE
fix(scripts): rename the UAT delivery classifier off a banned term (Refs #960)

### DIFF
--- a/docs/ledger/PATH-TO-100.md
+++ b/docs/ledger/PATH-TO-100.md
@@ -11,7 +11,7 @@ This is the single most decision-relevant fact in this file, and it was not
 visible until every failing row was classified at once rather than chased one at
 a time.
 
-`scripts/classify-uat-blockers.py --image fad88bd` — the catalyst-api actually
+`scripts/classify-uat-delivery-state.py --image fad88bd` — the catalyst-api actually
 running on hw292, **built 2026-08-02** — resolves each row's cited PRs to their
 merge commits and asks whether each is an ancestor of that artifact:
 

--- a/scripts/classify-uat-delivery-state.py
+++ b/scripts/classify-uat-delivery-state.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """Classify every non-green UAT row as DEPLOY-GATED or CODE-BLOCKED.
 
+NAME NOTE. This file was first landed as `classify-uat-blockers.py` and renamed
+within the hour. `.github/workflows/banned-words-validate.yaml` rejects
+`\bblocker[s]?\b` in any PR title or body, so the original name could never be
+mentioned in a PR that touched it — a self-inflicted trap on every future
+change. The verdict strings CODE-BLOCKED / DEPLOY-GATED are unaffected:
+"blocked" does not match the pattern, only "blocker(s)" does.
+
 WHY THIS EXISTS. "Why is UAT not at 100%?" has two very different answers, and
 they call for opposite next actions:
 
@@ -28,9 +35,9 @@ TWO TRAPS THIS ENCODES, both hit while deriving it by hand:
     over-counted the failures. (W3 is the example: status ✅, prose contains ❌.)
 
 USAGE
-    python3 scripts/classify-uat-blockers.py                  # auto-detect image
-    python3 scripts/classify-uat-blockers.py --image <sha>    # pin the artifact
-    python3 scripts/classify-uat-blockers.py --status ⚠️      # any status glyph
+    python3 scripts/classify-uat-delivery-state.py                  # auto-detect image
+    python3 scripts/classify-uat-delivery-state.py --image <sha>    # pin the artifact
+    python3 scripts/classify-uat-delivery-state.py --status ⚠️      # any status glyph
 
 The running artifact is NOT discoverable from the repo, so `--image` is how the
 walker supplies what it observed live (`kubectl get deploy … -o jsonpath` on the


### PR DESCRIPTION
I landed `scripts/classify-uat-delivery-state.py` an hour ago under a name containing a term that `.github/workflows/banned-words-validate.yaml` rejects — and it matched my own PR body, because the body named the file. PR #5792 shows that check red for exactly that reason.

Two things worth recording rather than quietly fixing:

1. **The name was a self-inflicted trap.** Every future PR touching this file would have to name it, and naming it fails the gate — a permanent tax on a file whose entire purpose is to be run and cited.
2. **#5792 merged with that check red.** The gate is advisory, not a merge barrier. Worth knowing before trusting a green square: this check cannot stop a merge, so it only works if someone reads it. I did not notice until after the squash landed.

The verdict strings `CODE-BLOCKED` / `DEPLOY-GATED` are unaffected — the pattern matches the noun form, not "blocked" — so the output vocabulary is unchanged and the classification is byte-identical:

```
DEPLOY-GATED  12  R17 W1 W2 35 37 57 86 90 92 115 219 234
CODE-BLOCKED   1  20
```

Re-ran after the rename to confirm. The reason is recorded in the file's own docstring so the next author doesn't rename it back.

Refs #960