### PR TITLE
fix(scripts): delivery classifier missed fixes that reference an ISSUE — under-reported deploy-gated rows by 8 (Refs #960)

### DIFF
--- a/scripts/classify-uat-delivery-state.py
+++ b/scripts/classify-uat-delivery-state.py
@@ -53,6 +53,8 @@ import sys
 from collections import OrderedDict
 
 UAT = "docs/ledger/UAT.md"
+# Delivery is measured against merged history only — see the note in classify().
+MAIN_REF = "origin/main"
 ROW_RE = re.compile(r"^\|\s*(R?\d+|[GWM]\d+)\s*\|")
 # A fix-bearing conventional-commit prefix. `docs:` is deliberately absent — a
 # docs(uat) commit is a walk record, not a delivery (trap 1 above).
@@ -104,8 +106,14 @@ def classify(evidence, image):
         #
         # So: enumerate EVERY commit mentioning the issue anywhere in its
         # message, keep the fix-type subjects, and take the newest of those.
+        # Scope to MAIN, not --all. `--all` walks every ref including stale
+        # pre-squash feature branches, and those commits are not ancestors of
+        # anything — so a lingering branch fakes a deploy-gate. Caught by this
+        # script's own control: pinning --image to main must yield ZERO
+        # deploy-gated rows, and with --all it yielded one (row 37, resolving
+        # to the unmerged twin of a squashed commit). "Merged" means on main.
         lines = [l for l in sh(
-            f"git log --all --grep='#{pr}' --format='%H\t%s'").split("\n") if l.strip()]
+            f"git log {MAIN_REF} --grep='#{pr}' --format='%H\t%s'").split("\n") if l.strip()]
         fixes, docs_seen = [], False
         for line in lines:
             h, _, subject = line.partition("\t")

--- a/scripts/classify-uat-delivery-state.py
+++ b/scripts/classify-uat-delivery-state.py
@@ -90,18 +90,34 @@ def classify(evidence, image):
     prs = sorted(set(re.findall(r"#(\d{4,5})", evidence)), key=int)
     pending, delivered, docs, unmerged = [], [], [], []
     for pr in prs:
-        sha = sh(f"git log --oneline --all --grep='(#{pr})' -1 --format=%H")
-        if not sha:
-            unmerged.append(pr)
+        # Resolve the DELIVERING commit, which is harder than it looks and was
+        # wrong in this script's first version.
+        #
+        #   `--grep='(#N)'` matches only the squash-merge subject form. A row
+        #   citing an ISSUE number misses its fix entirely, because the fix
+        #   says `Refs #N` in the BODY. That misread #5513 as code-blocked when
+        #   both halves of its fix were merged AND mutation-guarded.
+        #
+        #   Plain `--grep='#N' -1` is worse: it returns the most RECENT mention,
+        #   which is nearly always a docs(uat) walk record — the commit that
+        #   recorded the failure, not the one that fixed it.
+        #
+        # So: enumerate EVERY commit mentioning the issue anywhere in its
+        # message, keep the fix-type subjects, and take the newest of those.
+        lines = [l for l in sh(
+            f"git log --all --grep='#{pr}' --format='%H\t%s'").split("\n") if l.strip()]
+        fixes, docs_seen = [], False
+        for line in lines:
+            h, _, subject = line.partition("\t")
+            kind = subject.split("(")[0].split(":")[0].strip()
+            if kind in FIX_PREFIXES:
+                fixes.append(h)
+            elif kind in DOCS_PREFIXES:
+                docs_seen = True
+        if not fixes:
+            (docs if docs_seen else unmerged).append(pr)
             continue
-        subject = sh(f"git log -1 --format=%s {sha}")
-        kind = subject.split("(")[0].split(":")[0].strip()
-        if kind in DOCS_PREFIXES:
-            docs.append(pr)
-            continue
-        if kind not in FIX_PREFIXES:
-            docs.append(pr)
-            continue
+        sha = fixes[0]  # git log is newest-first
         in_image = subprocess.run(
             f"git merge-base --is-ancestor {sha} {image}", shell=True
         ).returncode == 0


### PR DESCRIPTION
I shipped this classifier 90 minutes ago with a resolver that used `git log --grep='(#N)'` — matching only the squash-merge **subject** form. A UAT row citing an **issue** number (most of them) never matched, because the fix says `Refs #N` in the **body**. Those rows were reported CODE-BLOCKED while their fix was merged.

**Caught on row 59 / #5513**, which the classifier called "cited but unmerged". Both halves of that fix are merged *and* mutation-guarded — verified by injecting the defects, not by reading:

| half | mutation | result |
|---|---|---|
| client | force `drBacked = true` (ignore the `source === 'live'` honesty flag) | **2 of 32 red**, incl. the `#5514` zero-backing test |
| backend | delete the `fanoutOwnsInstall` override (restore the fabricated region count) | **1 of 4 red** |

**The naive repair is worse than the bug.** Plain `--grep='#N' -1` returns the most *recent* commit mentioning the issue — nearly always a `docs(uat)` walk record, i.e. the commit that **recorded** the failure. That would convert every code-blocked row into a false deploy-gate. So the resolver now enumerates every commit mentioning the issue, keeps fix-type subjects, and takes the newest of those; the docs-vs-fix classification already in the script is what makes it safe.

**Measured impact — the ⚠️ tier doubles:**

| tier | before | after |
|---|---|---|
| ❌ | 12 gated / 1 blocked | unchanged |
| ⚠️ | 8 gated / 32 blocked | **16 gated / 24 blocked** |

Newly recognised as deploy-gated: G9, 18, 41, 48, 59, 121, 233, 241. So **28 rows** across both tiers wait on a roll, not 20 — and the genuine remaining code work is the 24 ⚠️ rows plus row 20, not the ❌ set.

Guards still fire: no image → exit 2; `--image` = main → all rows flip to CODE-BLOCKED.

Refs #960