### PR TITLE
fix(api): App-detail Dependencies is empty for bootstrap apps — reach the resolver that already works (Refs #5434)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1565,6 +1565,27 @@ func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// #5434 (UAT row 4) — bootstrap-synthesised CRs carry no spec.dependsOn,
+	// so the block above yields nothing and the App-detail Dependencies panel
+	// renders no producing instance at all.
+	//
+	// The inverter for this ALREADY EXISTS and is correct: dependsOnFromHRGraph
+	// reads the HelmRelease's Flux dependsOn graph and resolves each target's
+	// declared Context entry. It was simply unreachable from here — it runs
+	// only in synthesiseAppFromHelmRelease, which is gated on the Application
+	// CR being ABSENT. `spine-harbor` HAS a CR (spec: {bootstrap:true,
+	// helmRelease:{name:bp-harbor, namespace:flux-system}}), so it took this
+	// path, found no spec.dependsOn, and returned empty — while the working
+	// resolver sat one branch away.
+	//
+	// Deliberately NOT inverting the producer's parameters.databases[].consumer
+	// map, which was the other candidate fix. That would add a SECOND way to
+	// derive the same edge alongside a correct first one, and two derivations
+	// of one fact is exactly how these paths drifted apart. Reuse instead.
+	if len(resp.DependsOn) == 0 {
+		resp.DependsOn = h.dependsOnForBootstrapCR(r.Context(), depID, obj, resp.Blueprint)
+	}
+
 	// Family B (2026-05-17 t10 founder bug C4-003): HR-Ready overlay.
 	//
 	// Root cause: the catalyst-controller writes status.phase on the
@@ -1865,6 +1886,53 @@ func (h *Handler) synthesiseAppFromHelmRelease(ctx context.Context, depID, name 
 		return resp, true
 	}
 	return applicationDetailResponse{}, false
+}
+
+// dependsOnForBootstrapCR bridges an Application CR that has no
+// spec.dependsOn to the Flux graph its HelmRelease does have (#5434, UAT row 4).
+//
+// Bootstrap-synthesised CRs record only {bootstrap:true, helmRelease:{name,
+// namespace}} — the backing-service edges live on the HelmRelease, not on the
+// CR. dependsOnFromHRGraph already resolves exactly that, so this locates the
+// referenced HR and hands off. No new derivation rule is introduced.
+//
+// Every failure is a silent nil: no k8sCache, no helmRelease ref, an
+// unresolvable chroot cluster, a List error, or an HR that is simply not
+// present. The caller only reaches here when it has nothing to show anyway, so
+// a miss must leave the field empty (and `omitempty` drop it) rather than
+// manufacture an edge. Returning a fabricated dependency here would be worse
+// than the blank panel this fixes.
+func (h *Handler) dependsOnForBootstrapCR(ctx context.Context, depID string, obj *unstructured.Unstructured, blueprint string) []dependsOnDetail {
+	if h.k8sCache == nil {
+		return nil
+	}
+	hrName, _, _ := unstructured.NestedString(obj.Object, "spec", "helmRelease", "name")
+	if hrName == "" {
+		return nil
+	}
+	hrNS, _, _ := unstructured.NestedString(obj.Object, "spec", "helmRelease", "namespace")
+
+	clusterID := h.resolveChrootClusterID(depID)
+	if !h.k8sCacheHasCluster(clusterID) {
+		return nil
+	}
+	hrs, _, err := h.k8sCache.List(clusterID, "helmrelease", labels.Everything())
+	if err != nil {
+		return nil
+	}
+	for _, hr := range hrs {
+		if hr.GetName() != hrName {
+			continue
+		}
+		// The namespace is matched only when the CR states one. Bootstrap CRs
+		// generally do (flux-system), but an older CR that omits it must still
+		// resolve rather than silently miss on an empty-string compare.
+		if hrNS != "" && hr.GetNamespace() != hrNS {
+			continue
+		}
+		return h.dependsOnFromHRGraph(ctx, hrs, hr, blueprint)
+	}
+	return nil
 }
 
 // dependsOnFromHRGraph derives the consumer-side backing edges for an

--- a/products/catalyst/bootstrap/api/internal/handler/dependson_bootstrap_5434_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dependson_bootstrap_5434_test.go
@@ -1,0 +1,143 @@
+package handler
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// #5434 (UAT row 4) — the App-detail Dependencies panel renders nothing for a
+// bootstrap-synthesised Application.
+//
+// WHY THIS IS AN AST TEST AND NOT A BEHAVIOUR TEST. The defect was never that
+// the resolver was wrong. `dependsOnFromHRGraph` was correct the whole time —
+// it was simply never CALLED on this path, because it lives in
+// `synthesiseAppFromHelmRelease`, which only runs when the Application CR is
+// ABSENT. `spine-harbor` HAS a CR, so it took `HandleApplicationGet`, found no
+// `spec.dependsOn`, and returned empty while the working resolver sat one
+// branch away.
+//
+// That is the failure mode this repo keeps hitting: the helper is tested, the
+// CALL SITE is not, so deleting the single line that invokes it leaves every
+// test green. A behaviour test over `dependsOnForBootstrapCR` would have the
+// same hole — it would prove the helper works while saying nothing about
+// whether anything reaches it. So the assertion is on the wiring itself.
+//
+// The check is deliberately narrow: HandleApplicationGet must call
+// dependsOnForBootstrapCR, and that helper must delegate to
+// dependsOnFromHRGraph rather than growing a second derivation of the same
+// edge. Two ways to derive one fact is how these paths drifted apart to begin
+// with.
+
+func parseHandlerFile(t *testing.T, path string) (*token.FileSet, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return fset, f
+}
+
+// callsWithin reports the set of function names called inside funcName.
+func callsWithin(t *testing.T, f *ast.File, funcName string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		fd, ok := n.(*ast.FuncDecl)
+		if !ok || fd.Name == nil || fd.Name.Name != funcName {
+			return true
+		}
+		found = true
+		ast.Inspect(fd.Body, func(m ast.Node) bool {
+			call, ok := m.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			switch fn := call.Fun.(type) {
+			case *ast.SelectorExpr:
+				out[fn.Sel.Name] = true
+			case *ast.Ident:
+				out[fn.Name] = true
+			}
+			return true
+		})
+		return false
+	})
+	if !found {
+		t.Fatalf("function %s not found — this guard is asserting on nothing", funcName)
+	}
+	return out
+}
+
+func TestHandleApplicationGet_CallsBootstrapDependsOnFallback(t *testing.T) {
+	_, f := parseHandlerFile(t, "applications.go")
+
+	calls := callsWithin(t, f, "HandleApplicationGet")
+
+	// Vacuity: the extractor must actually see this function's calls. If the
+	// walk silently found nothing, every assertion below passes on an empty set.
+	if len(calls) < 5 {
+		t.Fatalf("only %d calls found inside HandleApplicationGet — the AST walk is broken", len(calls))
+	}
+
+	if !calls["dependsOnForBootstrapCR"] {
+		t.Fatal("HandleApplicationGet no longer calls dependsOnForBootstrapCR — " +
+			"a bootstrap-synthesised Application has no spec.dependsOn, so without this " +
+			"fallback the App-detail Dependencies panel renders empty again (#5434, UAT row 4). " +
+			"The resolver being correct does not help if nothing reaches it.")
+	}
+}
+
+func TestDependsOnForBootstrapCR_DelegatesToTheExistingResolver(t *testing.T) {
+	_, f := parseHandlerFile(t, "applications.go")
+
+	calls := callsWithin(t, f, "dependsOnForBootstrapCR")
+
+	if !calls["dependsOnFromHRGraph"] {
+		t.Fatal("dependsOnForBootstrapCR no longer delegates to dependsOnFromHRGraph — " +
+			"if it has grown its own edge derivation, there are now TWO ways to compute the " +
+			"same dependency and they will drift, which is exactly how the CR path and the " +
+			"HR path diverged in #5434.")
+	}
+
+	// It must read the HR reference off the CR; without that it cannot find
+	// which HelmRelease to resolve and would silently return nil forever.
+	if !calls["NestedString"] {
+		t.Fatal("dependsOnForBootstrapCR no longer reads spec.helmRelease off the CR — " +
+			"it cannot locate the HelmRelease whose Flux graph carries the edges.")
+	}
+}
+
+// TestDependsOnForBootstrapCR_FailsSilentlyWithoutCache pins the safety
+// property: every miss must yield nil, never a fabricated edge. The caller only
+// reaches this helper when it has nothing to show, so inventing a dependency
+// would be worse than the blank panel being fixed.
+func TestDependsOnForBootstrapCR_FailsSilentlyWithoutCache(t *testing.T) {
+	h := &Handler{} // no k8sCache
+	if got := h.dependsOnForBootstrapCR(nil, "dep-1", nil, "bp-harbor"); got != nil {
+		t.Fatalf("expected nil with no k8sCache, got %v — a miss must never manufacture an edge", got)
+	}
+}
+
+// Guard the comment that carries the reasoning. The "why not invert the
+// producer map" decision is the part a future author is most likely to undo,
+// because inverting looks like the obvious fix and the issue itself proposed it.
+func TestDependsOnFallback_RecordsWhyNotProducerInversion(t *testing.T) {
+	_, f := parseHandlerFile(t, "applications.go")
+	var text strings.Builder
+	for _, cg := range f.Comments {
+		text.WriteString(cg.Text())
+	}
+	body := text.String()
+	if !strings.Contains(body, "#5434") {
+		t.Fatal("the #5434 reasoning comment is gone from applications.go")
+	}
+	if !strings.Contains(body, "parameters.databases") {
+		t.Fatal("the note explaining why the producer map is NOT inverted has been removed — " +
+			"without it the next author re-adds a second derivation of the same edge")
+	}
+}


### PR DESCRIPTION
UAT row 4 fails because the App-detail Dependencies panel never names the producing instance. The issue diagnosed this as *"the backend never inverts the producer's `parameters.databases[].consumer` map"*. **That isn't what's wrong.**

## The inverter already exists — it was just unreachable

`dependsOnFromHRGraph` reads the HelmRelease's Flux `dependsOn` graph and resolves each target's declared Context entry. It's correct. It runs only inside `synthesiseAppFromHelmRelease`, which is gated on the Application CR being **absent**:

| path | trigger | resolves how |
|---|---|---|
| CR path (`HandleApplicationGet`) | a CR exists | `spec.dependsOn` on the **CR** → empty for bootstrap CRs |
| HR path | no CR | `dependsOnFromHRGraph` → the **HelmRelease's** Flux graph ✅ |

`spine-harbor` **has** a CR (`{bootstrap:true, helmRelease:{name:bp-harbor, namespace:flux-system}}`), so it takes the CR path, finds nothing, and returns empty — while the working resolver sits one branch away.

## The fix is a fallback, not a new derivation

When the CR carries no `spec.dependsOn` but does carry `spec.helmRelease`, resolve that HR from the chroot k8sCache and hand off to `dependsOnFromHRGraph` — the same chroot cluster resolution `synthesiseAppFromHelmRelease` already uses.

**Deliberately not inverting the producer map**, which the issue proposed. That adds a *second* way to derive the same edge beside a correct first one, and two derivations of one fact is precisely how these paths drifted apart into this bug. The reasoning is in the code **and guarded**, because inverting looks like the obvious fix and the ticket recommends it.

Every miss returns `nil` — no cache, no HR ref, unresolvable cluster, List error, HR absent. The caller only arrives here with nothing to show, so a fabricated edge would be worse than the blank panel.

## The guard asserts on the WIRING

Deliberate. The defect was never a wrong resolver — it was a resolver **nothing called**. That's the shape where the helper is tested, the call site isn't, and deleting one line leaves everything green. A behaviour test over the helper would have the identical hole.

| mutation | result |
|---|---|
| delete the call site (helper intact, uninvoked) | `CallsBootstrapDependsOnFallback` **RED** |
| helper stops delegating, invents an edge | `DelegatesToTheExistingResolver` **RED** |
| strip the why-not-producer-inversion rationale | `RecordsWhyNotProducerInversion` **RED** |
| *revert* | **4 run, ok** |

Plus a vacuity check that the AST walk actually sees the function's calls, and a nil-safety test.

`gofmt` + `go vet` clean. Deploy-gated on hw292 like every fix merged today — the running catalyst-api was built 2026-08-02.

Refs #5434 #3370 #960
