### PR TITLE
fix(api): /version must say whether buildTime is a link time or a process start (Refs #5821)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/version.go
+++ b/products/catalyst/bootstrap/api/internal/handler/version.go
@@ -115,6 +115,28 @@ type VersionResponse struct {
 	// Go — runtime version (debug aid; e.g. "go1.26.0"). Useful when
 	// chasing a regression that correlates with a Go upgrade.
 	Go string `json:"go"`
+
+	// BuildTimeSource — where BuildTime actually came from: "ldflag",
+	// "env", or "process-start" (#5821).
+	//
+	// WHY THIS FIELD EXISTS. BuildTime silently falls back to the process
+	// start time when neither the ldflag nor CATALYST_BUILD_TIME is set. The
+	// key is still named `buildTime`, so the response is indistinguishable
+	// from a genuinely fresh build — and the whole point of this endpoint is
+	// answering "what version is live right now".
+	//
+	// Measured on hw292 2026-08-07: /version returned
+	// buildTime 2026-08-07T12:39:41Z on a binary whose SHA (fad88bd) was built
+	// five days earlier. Read at face value that says every fix merged that
+	// morning was already live. It was not — the pod had merely restarted.
+	// The UAT ledger's entire deploy-gated-vs-code-blocked split turns on
+	// exactly this question, so a field that can be off by days without
+	// saying so is worse than one that is absent.
+	//
+	// Reported rather than suppressed: process start is genuinely useful (it
+	// dates the current pod, which is how you spot a restart loop). The defect
+	// was never the fallback — it was the fallback being unlabelled.
+	BuildTimeSource string `json:"buildTimeSource"`
 }
 
 // HandleVersion — GET /api/v1/version
@@ -123,18 +145,26 @@ type VersionResponse struct {
 // JSON. No auth gate (probe-friendly).
 func (h *Handler) HandleVersion(w http.ResponseWriter, r *http.Request) {
 	sha := envOrTrim("CATALYST_BUILD_SHA", buildSHA)
-	bt := envOrTrim("CATALYST_BUILD_TIME", buildTime)
+
+	// Resolve BuildTime and record WHICH source won, so a caller can tell a
+	// real link timestamp from the process-start fallback (#5821).
+	bt := strings.TrimSpace(os.Getenv("CATALYST_BUILD_TIME"))
+	btSource := "env"
 	if bt == "" {
-		bt = processStartTime
+		bt, btSource = strings.TrimSpace(buildTime), "ldflag"
+	}
+	if bt == "" {
+		bt, btSource = processStartTime, "process-start"
 	}
 	resp := VersionResponse{
-		Service:      "catalyst-api",
-		SHA:          sha,
-		GitSha:       sha,
-		Version:      envOrTrim("CATALYST_BUILD_VERSION", buildVersion),
-		ChartVersion: envOrTrim("CATALYST_CHART_VERSION", chartVersion),
-		BuildTime:    bt,
-		Go:           runtime.Version(),
+		Service:         "catalyst-api",
+		SHA:             sha,
+		GitSha:          sha,
+		Version:         envOrTrim("CATALYST_BUILD_VERSION", buildVersion),
+		ChartVersion:    envOrTrim("CATALYST_CHART_VERSION", chartVersion),
+		BuildTime:       bt,
+		BuildTimeSource: btSource,
+		Go:              runtime.Version(),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/version_buildtime_source_5821_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/version_buildtime_source_5821_test.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #5821 — /version must say WHERE buildTime came from.
+//
+// buildTime falls back to the process start time when neither the ldflag nor
+// CATALYST_BUILD_TIME is set, and the key stays named `buildTime`. The response
+// is then indistinguishable from a genuinely fresh build.
+//
+// Measured on hw292 2026-08-07: /version returned buildTime 2026-08-07T12:39:41Z
+// on a binary whose SHA (fad88bd) was built five days earlier. Read at face
+// value that says every fix merged that morning was already live. It was not —
+// the pod had merely restarted. The UAT ledger's whole
+// deploy-gated-vs-code-blocked split turns on that question, so a field that can
+// be off by days without saying so is worse than one that is absent.
+//
+// The fallback itself is NOT the defect and is not removed: process start dates
+// the current pod, which is how a restart loop gets spotted. The defect was the
+// fallback being unlabelled.
+
+func decodeVersion(t *testing.T) VersionResponse {
+	t.Helper()
+	h := &Handler{}
+	rec := httptest.NewRecorder()
+	h.HandleVersion(rec, httptest.NewRequest(http.MethodGet, "/api/v1/version", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/version returned %d, want 200", rec.Code)
+	}
+	var got VersionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode /version: %v (body %s)", err, rec.Body.String())
+	}
+	return got
+}
+
+func TestVersion_BuildTimeSourceNamesTheFallback(t *testing.T) {
+	// No env, and the ldflag is empty in a test binary → the fallback path.
+	got := decodeVersion(t)
+
+	if got.BuildTime == "" {
+		t.Fatal("buildTime is empty — the endpoint must always return a parseable timestamp")
+	}
+	if got.BuildTimeSource != "process-start" {
+		t.Fatalf("buildTimeSource = %q, want %q — with no ldflag and no env the timestamp "+
+			"is the process start, and a caller that cannot tell will read a restarted pod "+
+			"as a freshly built one (#5821)", got.BuildTimeSource, "process-start")
+	}
+	// The fallback VALUE is still the process start, not something invented.
+	if got.BuildTime != processStartTime {
+		t.Fatalf("buildTime = %q, want the process start %q — the fallback must report the "+
+			"real start, not a synthesised timestamp", got.BuildTime, processStartTime)
+	}
+}
+
+func TestVersion_BuildTimeSourceNamesTheEnvOverride(t *testing.T) {
+	t.Setenv("CATALYST_BUILD_TIME", "2026-08-02T04:00:00Z")
+
+	got := decodeVersion(t)
+	if got.BuildTime != "2026-08-02T04:00:00Z" {
+		t.Fatalf("buildTime = %q, want the env value", got.BuildTime)
+	}
+	if got.BuildTimeSource != "env" {
+		t.Fatalf("buildTimeSource = %q, want %q", got.BuildTimeSource, "env")
+	}
+}
+
+// Whitespace-only env must NOT count as a real value. This is the shape that
+// makes the field lie most convincingly: the chart templates the env var, the
+// value renders empty with a trailing newline, and an un-trimmed check reports
+// source="env" for a timestamp that is blank or whitespace.
+func TestVersion_BlankEnvFallsThroughAndSaysSo(t *testing.T) {
+	t.Setenv("CATALYST_BUILD_TIME", "   ")
+
+	got := decodeVersion(t)
+	if got.BuildTimeSource != "process-start" {
+		t.Fatalf("buildTimeSource = %q with a whitespace-only CATALYST_BUILD_TIME, want %q — "+
+			"a blank env value must fall through, not be reported as a real build timestamp",
+			got.BuildTimeSource, "process-start")
+	}
+	if got.BuildTime != processStartTime {
+		t.Fatalf("buildTime = %q, want the process start %q", got.BuildTime, processStartTime)
+	}
+}
+
+// The key must be present on the wire under its exact name. Callers (the UAT
+// classifier, monitoring) read `buildTimeSource` verbatim; no omitempty, and
+// never absent — an absent key is exactly the ambiguity this fixes.
+func TestVersion_BuildTimeSourceKeyIsAlwaysOnTheWire(t *testing.T) {
+	h := &Handler{}
+	rec := httptest.NewRecorder()
+	h.HandleVersion(rec, httptest.NewRequest(http.MethodGet, "/api/v1/version", nil))
+
+	var m map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	v, present := m["buildTimeSource"]
+	if !present {
+		t.Fatalf(`/version carries no "buildTimeSource" key — a reader is back to guessing `+
+			`whether buildTime is a link time or a restart time: %s`, rec.Body.String())
+	}
+	if s, _ := v.(string); s == "" {
+		t.Fatalf(`"buildTimeSource" is empty — omitempty was added, or the resolution left it `+
+			`unset; either way the key conveys nothing: %s`, rec.Body.String())
+	}
+
+	// Control: the pre-existing contract keys are untouched. version_test.go
+	// owns that contract, but asserting it here too means a careless edit to
+	// this response struct cannot pass on THIS file alone.
+	for _, k := range []string{"service", "sha", "gitSha", "version", "buildTime", "go"} {
+		if _, ok := m[k]; !ok {
+			t.Fatalf("/version lost the pre-existing key %q — removing keys is a contract break", k)
+		}
+	}
+}

--- a/scripts/classify-uat-delivery-state.py
+++ b/scripts/classify-uat-delivery-state.py
@@ -26,6 +26,17 @@ W1/W2 and rows 35/115 individually before the pattern became visible.
 
 TWO TRAPS THIS ENCODES, both hit while deriving it by hand:
 
+ 0. DO NOT read the running artifact off `GET /api/v1/version`'s `buildTime`.
+    That field silently falls back to the PROCESS START time when the build-time
+    ldflag and CATALYST_BUILD_TIME are both unset, and it keeps the same key
+    name either way. Measured on hw292 2026-08-07: buildTime said
+    2026-08-07T12:39:41Z for sha fad88bd, a binary built five days earlier —
+    i.e. it reported a pod restart as a fresh build, which would have flipped
+    every DEPLOY-GATED row to a false CODE-BLOCKED. `buildTimeSource` (#5821)
+    now names the branch, so `"process-start"` is readable as "this is not a
+    build timestamp". This tool takes `--image <commit-ish>` and dates it from
+    GIT for exactly this reason, and refuses (exit 2) to guess.
+
  1. A cited PR is often a `docs(uat)` WALK RECORD, not a fix. #5615 and #5617
     are the walks that recorded rows 219/234 failing. Counting them as fixes
     turns a code-blocked row into a false deploy-gate, so commit SUBJECT is


### PR DESCRIPTION
Full write-up in #5821.

## Measured, live, today

```
$ curl -s https://console.hw292.omani.works/api/v1/version
{"sha":"fad88bd", ..., "version":"0.0.0", "buildTime":"2026-08-07T12:39:41Z"}
```

`fad88bd` was built **2026-08-02**. `buildTime` says **today**.

`HandleVersion` falls back to `processStartTime` when neither `CATALYST_BUILD_TIME` nor the `buildTime` ldflag is set — and keeps the key named `buildTime`. On hw292 the ldflag is unset (note `version: "0.0.0"`, the compiled-in default), so what the endpoint reports is **when the pod last started**. The fallback is intentional and documented in the source; what was missing is any way for a *caller* to tell which branch produced the value.

## Why it matters more than it looks

This endpoint exists to answer "what version is live right now" — it is the one unauthenticated probe for that. Read at face value, the response above says every fix merged this morning is already deployed. **None of them are.**

The UAT ledger's whole **DEPLOY-GATED vs CODE-BLOCKED** split turns on exactly that question. A field that can be off by five days without saying so is worse than one that is absent: absence prompts a check, a confident wrong answer does not.

It also hid the opposite signal. A `buildTime` that advances while `sha` stays fixed is a **restart loop** — which is #5642 on this very host. That information was on the wire and unreadable.

## Fix

Adds `buildTimeSource: "env" | "ldflag" | "process-start"`.

**The fallback is not removed, deliberately.** Process start genuinely dates the current pod, which is how a restart loop gets spotted. The defect was never the fallback — it was the fallback being *unlabelled*. Reporting it honestly keeps the diagnostic and removes the ambiguity.

The env read is also trimmed before it counts as a real value. That is the shape that lies most convincingly: the chart templates the variable, the value renders empty or with a trailing newline, and an un-trimmed check reports `source: "env"` for a blank timestamp.

## Guards — 4, mutation-verified

| Mutation | Goes RED |
|---|---|
| drop the field from the response (back to the ambiguous shape) | all 4 |
| label the fallback `"env"` regardless (a confident lie) | 2 |
| un-trim the env read (whitespace counts as real) | 1 |

The wire-key test also re-asserts the six pre-existing keys as a control — `version_test.go` owns that contract, but duplicating it here means a careless edit to the response struct cannot pass on this file alone.

## Also

Records the trap as **trap 0** in `scripts/classify-uat-delivery-state.py`. That tool already refuses to guess the running artifact and dates `--image` from git — had it read `buildTime` instead, it would have flipped all 12 DEPLOY-GATED rows to a false CODE-BLOCKED and sent the next session writing fixes for code that was already correct.

## Gates

`go vet` clean · full handler suite green (255s).

Refs #5821 #5642 #960
