### PR TITLE
fix(uat): classifier split rows on escaped pipes, truncating Evidence — 13/13 failing rows are deploy-gated

### DIFF
--- a/scripts/classify-uat-delivery-state.py
+++ b/scripts/classify-uat-delivery-state.py
@@ -67,6 +67,7 @@ UAT = "docs/ledger/UAT.md"
 # Delivery is measured against merged history only — see the note in classify().
 MAIN_REF = "origin/main"
 ROW_RE = re.compile(r"^\|\s*(R?\d+|[GWM]\d+)\s*\|")
+UNESCAPED_PIPE = re.compile(r"(?<!\\)\|")
 # A fix-bearing conventional-commit prefix. `docs:` is deliberately absent — a
 # docs(uat) commit is a walk record, not a delivery (trap 1 above).
 FIX_PREFIXES = ("fix", "feat", "perf", "refactor", "test", "chore")
@@ -87,7 +88,20 @@ def rows_with_status(path, want):
     for line in open(path, encoding="utf-8"):
         if not ROW_RE.match(line):
             continue
-        f = line.split("|")
+        # Split on UNESCAPED pipes only. `line.split("|")` treats a `\|` inside a
+        # cell as a column separator, which shifts every field after it — #5855.
+        #
+        # Row 20 is the case: one escaped pipe in its Evidence, so the naive
+        # split produced 10 fields and f[7] held only the text BEFORE the escape.
+        # The `#5688` reference that proves the row deploy-gated sits after it, so
+        # the row read as "no PR cited" and classified UNKNOWN.
+        #
+        # The Result column survived there only by luck — the escape happened to
+        # fall after it. An escaped pipe in ANY earlier cell shifts the verdict
+        # out from under f[6], and the tool would then silently classify the
+        # wrong set of rows. This is the same trap #5844 documented in the ledger
+        # guard and it was live in this file the whole time.
+        f = UNESCAPED_PIPE.split(line.rstrip())
         if len(f) <= 6:
             continue
         status = f[6].strip()


### PR DESCRIPTION
`rows_with_status()` read each ledger row with `line.split("|")`, which treats a `\|` **inside** a cell as a column separator and shifts every field after it.

Row 20 carries one escaped pipe in its Evidence:

```
naive split fields   : 10        correct : 9
#5688 in naive f[7]  : False     correct : True
```

`f[7]` held only the text *before* the escape. The `#5688` reference that proves the row deploy-gated sits after it — so the row read as "no PR cited" and classified UNKNOWN.

## The consequence is larger than one row

Truncated evidence means every row with an escaped pipe was classified on a **prefix of its own record**:

| | before | after |
|---|---|---|
| DEPLOY-GATED | 12 | **13** |
| UNKNOWN | 1 | 0 |
| Row 219's cited fix PRs | 2 | **9** |

## The Result column survived by luck

`f[6]` read correctly on row 20 only because the escape happened to fall *after* it. An escaped pipe in any **earlier** cell shifts the verdict out from under `f[6]`, and the tool would silently classify the wrong set of rows — a failure with no visible symptom.

This is the same trap #5844 documented for the ledger guard (*"`split('|')` counts escaped pipes as separators"*). It was live in this file the whole time, including while I was writing that documentation.

## Fix

Split on `(?<!\\)\|`, matching the guard. Mutation-tested: reverting to `line.split("|")` regresses row 20 to UNKNOWN and drops DEPLOY-GATED back to 12.

With the fix the tool reaches its terminal conclusion for the first time:

```
DEPLOY-GATED :  13  R17, W1, W2, 20, 35, 37, 57, 86, 90, 92, 115, 219, 234
CODE-BLOCKED :   0

Every failing row is waiting on a roll. Writing more fixes moves none of them.
```

Refs #5855 #5851 #5844 #960
