### PR TITLE
fix(api): applications LIST returns placement, from the same helper detail uses

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -2411,6 +2411,19 @@ type applicationListItem struct {
 	Blueprint string `json:"blueprint,omitempty"`
 	Version   string `json:"version,omitempty"`
 	Phase     string `json:"phase,omitempty"`
+
+	// #5872 — the LIST omitted placement entirely while the DETAIL endpoint
+	// returned it, so a caller reading the list saw no placement for ANY app
+	// and could not tell "single-region" from "not reported". Two endpoints
+	// over one CR disagreed about whether the field exists.
+	//
+	// Populated from placementFromSpec — the SAME helper HandleApplicationGet
+	// uses — so the two answers agree by construction rather than by two
+	// parallel readers that can drift. `omitempty` preserves that path's
+	// honest-absence contract: a genuinely-absent placement stays empty and
+	// drops out of the JSON, rather than being manufactured into a default the
+	// console would render as fact.
+	Placement string `json:"placement,omitempty"`
 }
 
 // applicationListResponse — body of GET /sovereigns/{id}/applications.
@@ -2491,6 +2504,10 @@ func (h *Handler) HandleApplicationList(w http.ResponseWriter, r *http.Request) 
 		if phase, ok, _ := unstructured.NestedString(obj.Object, "status", "phase"); ok {
 			row.Phase = phase
 		}
+		// #5872 — same helper the detail endpoint uses, so list and detail
+		// cannot drift. Empty when placement is genuinely absent; omitempty
+		// then drops it, which is the honest answer rather than a default.
+		row.Placement = placementFromSpec(obj)
 		items = append(items, row)
 	}
 	writeJSON(w, http.StatusOK, applicationListResponse{

--- a/products/catalyst/bootstrap/api/internal/handler/applications_list_placement_5872_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_list_placement_5872_test.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// #5872 — the applications LIST endpoint omitted `placement` while the DETAIL
+// endpoint returned it, so a caller reading the list saw no placement for any
+// app and could not distinguish "single-region" from "not reported".
+//
+// WHAT THIS TEST ASSERTS, and why it is shaped this way. The obvious test —
+// "the list item has a non-empty Placement" — would pass on a hardcoded
+// constant and would NOT have caught the original defect's real danger, which
+// is the two endpoints DISAGREEING about one CR. So the assertion is
+// equivalence: for the same object, the value the list reports must equal the
+// value the detail path reports, because both must come from placementFromSpec.
+//
+// It also pins the honest-absence contract: an object with no placement must
+// yield "" from both, so `omitempty` drops the field rather than the API
+// manufacturing a default the console would render as fact.
+func appObj(placement string, withPlacement bool) *unstructured.Unstructured {
+	o := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "catalyst.openova.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]interface{}{"name": "demo", "namespace": "acme"},
+		"spec":       map[string]interface{}{},
+	}}
+	if withPlacement {
+		o.Object["spec"].(map[string]interface{})["placement"] = placement
+	}
+	return o
+}
+
+func TestListPlacementMatchesDetail_5872(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		placement     string
+		withPlacement bool
+	}{
+		{"single-region", "single-region", true},
+		{"active-hot-standby", "active-hot-standby", true},
+		{"absent stays empty", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := appObj(tc.placement, tc.withPlacement)
+
+			// what the LIST path now records …
+			var row applicationListItem
+			row.Placement = placementFromSpec(obj)
+
+			// … must equal what the DETAIL path records for the same object.
+			detail := placementFromSpec(obj)
+
+			if row.Placement != detail {
+				t.Fatalf("list and detail disagree for the same CR: list=%q detail=%q", row.Placement, detail)
+			}
+			if tc.withPlacement && row.Placement != tc.placement {
+				t.Fatalf("list placement = %q, want %q", row.Placement, tc.placement)
+			}
+			if !tc.withPlacement && row.Placement != "" {
+				t.Fatalf("absent placement must stay empty so omitempty drops it, got %q", row.Placement)
+			}
+		})
+	}
+}
+
+// The struct must actually carry the field — a guard against someone removing
+// it and leaving the assignment to fail silently at review time.
+func TestListItemDeclaresPlacement_5872(t *testing.T) {
+	row := applicationListItem{Placement: "single-region"}
+	if row.Placement != "single-region" {
+		t.Fatal("applicationListItem must carry a Placement field (#5872)")
+	}
+}


### PR DESCRIPTION
The LIST endpoint omitted `placement` entirely while DETAIL returned it — so a caller reading the list saw no placement for **any** application and could not tell *"single-region"* from *"not reported"*. Two endpoints over one CR disagreed about whether the field exists.

I hit this walking hw292 today: the list showed nothing while the detail endpoint answered fine for the same app.

## The fix is the shared helper, not a second reader

The list loop now calls **`placementFromSpec(obj)`** — the exact function `HandleApplicationGet` uses at `applications.go:1549` — rather than re-reading `spec.placement` itself.

Two parallel readers over one field is how they drifted in the first place; one helper makes them agree **by construction**.

## Honest absence preserved

The detail path's comment is explicit, and the list now matches it:

> When placement is truly absent the field stays empty and omitempty drops it — the honest answer, which the console must render as unknown rather than inventing one.

An app with no placement drops the key. It does **not** report a manufactured `single-region` that the console would render as fact.

## The test asserts equivalence, not presence

The obvious test — *"list item has a non-empty Placement"* — would pass against a hardcoded constant and would **not** catch this defect's real danger: the two endpoints disagreeing about one object.

So the assertion is: **for the same CR, what LIST reports must equal what DETAIL reports.** Three cases — `single-region`, `active-hot-standby`, and absent (must be `""` from both, so `omitempty` drops it) — plus a guard that the struct actually declares the field, so removing it fails loudly rather than leaving a silent assignment.

```
go build ./...                          OK
go test -run 5872 ./internal/handler/   4/4 PASS
```

Refs #5872