### PR TITLE
docs(path-to-100): #5894 is deploy-gated behind #5640, not needs-design

### DIFF
--- a/docs/ledger/PATH-TO-100.md
+++ b/docs/ledger/PATH-TO-100.md
@@ -81,9 +81,22 @@ table separates the two by pairing every UNKNOWN with a live walk.
 These are new code, not pending deployments. Each was found on hw292 as it runs
 today, and each is recorded with the measurement that produced it.
 
+> **One of them was not, and the correction is the point.** #5894 sat in this table
+> — and, before that, parked as *needs-design* on the issue — on the strength of a
+> real measurement and a **wrong causal story**: I had concluded the org-controller
+> holds a single `client.Client` and structurally cannot reach region B. It does not
+> build that surface at all; catalyst-api does, and #5511 gave it a per-region seam
+> back on 2026-07-30, *inside* the running image. Following it to ground turned a
+> "needs a topology decision" into "a merged fix (#5645) that has never executed",
+> which is a **completely different kind of work** — nobody has to design anything.
+> A correct measurement with an unverified mechanism attached is still a wrong row,
+> and it points the next reader at the wrong file. The generalisable check: before
+> filing a defect as new code, name the component that actually writes the surface
+> and `git log --grep` it — a fix may already exist and be sitting one deploy away.
+
 | issue | what breaks | how it was found |
 |---|---|---|
-| **#5894** | per-Org consoles reset the TLS handshake **~50%** of the time, on both Orgs and both pool TLDs | 12 probes per host across 6 hosts: 4 sovereign-domain hosts **0/48 resets**, 2 pool-TLD hosts **exactly 50%** — isolates it to the pool-TLD cert/listener, one region serving it and one not |
+| ~~**#5894**~~ **moved out of this table — it IS deploy-gated (2026-08-08)** | per-Org consoles reset the TLS handshake **~50%** of the time, on both Orgs and both pool TLDs | 12 probes per host across 6 hosts: 4 sovereign-domain hosts **0/48 resets**, 2 pool-TLD hosts **exactly 50%** — isolates it to the pool-TLD cert/listener, one region serving it and one not. **Then followed to ground:** region B *has* `cilium-gateway-console` but **zero per-Org listeners**, while region A has both (`uatco`, `walk-stranger-two`) — so #5511's fan-out reached the Gateway and stopped. Neither guard in `orgConsoleTLSTargets` closes on identity (`SOVEREIGN_FQDN=hw292.omani.works`, both regions configured, `isChroot()` true). The truncation is a **catalyst-api OOMKill**: `restarts=125, exit=137, limits=4Gi, requests=96Mi, in-flight 1900Mi`. `orgConsoleTLSTargets` returns the host region as `targets[0]` and appends secondaries after, so a kill during the long per-region admission poll (`org_console_tls.go:266,437`) completes region A and dies before region B — exactly the observed asymmetry. `api-deployment.yaml:1814-1846` already recorded this from **#5642** four days earlier: the leak is `Factory.AddCluster` rebuilding all 42 informers on byte-identical kubeconfigs, ~62 Mi/min, **fixed in #5645 (MERGED) but never executed** because no published image reaches a `cutoverComplete=true` Sovereign — **#5640** |
 | **#5895** | first visit to a per-Org console renders a **blank page**; a reload recovers | cold browser stops at the `prompt=none` silent-auth URL with `body_len=0`, unchanged after 25s |
 | **#5882** | OpenBao SSO session lands with no token prompt but its policy **cannot list mounts** — Secrets pane renders `403 permission denied` | authenticated shell renders, content pane errors |
 | **#5883** | a **mistyped email** at the PIN form persists a Keycloak realm user (`emrha.` alongside `emrah.`) | counting the Users list — a presence check matches both strings and reports green |


### PR DESCRIPTION
Corrects a row I got wrong, and the correction changes what kind of work it is.

## What I had

#5894 measured a real split: 12 probes across 6 hosts, 4 sovereign-domain hosts
**0/48 resets**, 2 pool-TLD hosts **exactly 50%**. That measurement stands.

Attached to it was a causal story I never verified — that the org-controller holds
a single `client.Client` and structurally cannot reach region B — so I parked the
issue **needs-design**, pending a topology ownership decision.

## What is true

The org-controller does not build that surface. `catalyst-api` does, in
`org_console_tls.go`, and **#5511** ("fan per-Org console gateway surface out to
every region") gave it a per-region client seam on 2026-07-30 — merged *before* the
running image (`fad88bd`, 2026-08-02), so it is already deployed.

Followed to ground on hw292, read-only:

| region | gateway present | per-Org listeners |
|---|---|---|
| A | `cilium-gateway-console` | `uatco`, `walk-stranger-two` |
| B | `cilium-gateway-console` | **none** |

The Gateway object *was* fanned out. Only the listeners are missing, and both guards
in `orgConsoleTLSTargets` pass: `SOVEREIGN_FQDN=hw292.omani.works`, `isChroot()`
true, both regions in `CATALYST_CONFIGURED_REGIONS`. The fan-out is entitled to run.

It is being cut short by an OOM:

```
restarts=125   lastState=OOMKilled exit=137
limits=4Gi     requests=96Mi     in-flight 1900Mi
```

The host region is `targets[0]`; secondaries are appended after it. A kill during
the long per-region admission poll (`org_console_tls.go:266,437`) completes region A
and dies before region B — precisely the asymmetry the probes measured.

## And that was already known

`api-deployment.yaml:1814-1846` carries this from **#5642**, four days earlier and
measured better than mine: the leak is `Factory.AddCluster` rebuilding all 42
informers on byte-identical kubeconfigs, ~62 Mi/min. **Fixed in #5645 (MERGED),
never executed** — no published image reaches a `cutoverComplete=true` Sovereign
(**#5640**). My 125 restarts are the same defect three days further along.

So #5894 needs no design and no new code. It is deploy-gated behind #5640, like the
other twelve.

## What I deliberately did not do

I was about to raise `requests.memory` off today's readings. That same comment
forbids it, correctly: the only valid value is the post-fix steady-state floor, and
that binary has never executed anywhere — setting it from leaking numbers would bake
the leak into the chart permanently, "the same error as raising the limit, one field
over." **Chart untouched.**

## Guards

```
ok — 286 rows: no cell-spill, no phantom 8th column, all Result cells populated
ok — 286 data rows, 187 green (65.4%)
```

All live access read-only. Refs #5894 #5640 #5645 #5642 #5511
