### PR TITLE
fix(auth-gate): the cached session marker must be able to go stale

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
@@ -9,6 +9,9 @@ import {
   sameSovereignHostFamily,
   CANONICAL_SOVEREIGN_SUBDOMAINS,
   PUBLIC_PATH_PREFIXES,
+  markAuthed,
+  clearAuthed,
+  AUTH_MARKER_MAX_AGE_MS,
 } from './auth-gate'
 
 describe('canonicalisePath', () => {
@@ -141,9 +144,58 @@ describe('hasCatalystSession', () => {
     expect(hasCatalystSession()).toBe(true)
   })
 
-  it('returns true when catalyst:authed marker is set (new cookie flow)', () => {
-    sessionStorage.setItem('catalyst:authed', '1')
+  it('returns true when a FRESH catalyst:authed marker is set (new cookie flow)', () => {
+    markAuthed()
     expect(hasCatalystSession()).toBe(true)
+  })
+
+  // #5887 / UAT row 29 — the marker must be able to go stale.
+  //
+  // These are the cases that made rootBeforeLoad's `if (hasCatalystSession())
+  // return` skip the /whoami probe (and the silent-SSO leg) forever once a
+  // marker existed, PIN-walling an operator who still held a live realm
+  // session. Each asserts the gate now declines to short-circuit, which is
+  // what lets the probe run and the #5460 revocation fire.
+  it('returns false once the marker is older than the max age', () => {
+    const t0 = 1_000_000_000_000
+    markAuthed(t0)
+    expect(hasCatalystSession(t0 + AUTH_MARKER_MAX_AGE_MS - 1)).toBe(true)
+    expect(hasCatalystSession(t0 + AUTH_MARKER_MAX_AGE_MS)).toBe(false)
+    expect(hasCatalystSession(t0 + AUTH_MARKER_MAX_AGE_MS + 60_000)).toBe(false)
+  })
+
+  it('treats a marker with NO timestamp as stale (the pre-fix shape)', () => {
+    // Exactly what a pre-fix build left behind, and what a hand-set value
+    // looks like. "I cannot tell how old this is" must confirm, not trust.
+    sessionStorage.setItem('catalyst:authed', '1')
+    expect(hasCatalystSession()).toBe(false)
+  })
+
+  it('treats a non-numeric or future timestamp as stale', () => {
+    const t0 = 1_000_000_000_000
+    sessionStorage.setItem('catalyst:authed', '1')
+    sessionStorage.setItem('catalyst:authed-at', 'not-a-number')
+    expect(hasCatalystSession(t0)).toBe(false)
+    // A future stamp would otherwise grant an unbounded lease — the same
+    // bug reintroduced through the clock.
+    sessionStorage.setItem('catalyst:authed-at', String(t0 + 60_000))
+    expect(hasCatalystSession(t0)).toBe(false)
+  })
+
+  it('clearAuthed removes BOTH the marker and its stamp', () => {
+    markAuthed()
+    clearAuthed()
+    expect(sessionStorage.getItem('catalyst:authed')).toBeNull()
+    expect(sessionStorage.getItem('catalyst:authed-at')).toBeNull()
+  })
+
+  // Vacuity control: without it, every assertion above is satisfied by a
+  // hasCatalystSession() that simply always returns false.
+  it('still short-circuits for a genuinely fresh session (guard is not always-false)', () => {
+    const t0 = 1_000_000_000_000
+    markAuthed(t0)
+    expect(hasCatalystSession(t0)).toBe(true)
+    expect(hasCatalystSession(t0 + 1_000)).toBe(true)
   })
 
   it('returns false when catalyst:authed has a different value', () => {

--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
@@ -232,12 +232,81 @@ export function sanitizeNextParam(
  * after sessionStorage cleared, or pasting a deep-link URL into a fresh
  * window all leave the cookie intact while losing the JS-side marker.
  */
-export function hasCatalystSession(): boolean {
+export const AUTH_MARKER_KEY = 'catalyst:authed'
+export const AUTH_MARKER_AT_KEY = 'catalyst:authed-at'
+
+/**
+ * How long the cached marker may be trusted without re-confirming against
+ * the authority. #5887 / UAT row 29.
+ *
+ * The marker exists to skip a /whoami on every in-session navigation, and a
+ * 5-minute window keeps that benefit almost entirely: a burst of navigation
+ * costs one probe, not one per route. What it buys is a BOUND on how long a
+ * dead session can masquerade as a live one.
+ */
+export const AUTH_MARKER_MAX_AGE_MS = 5 * 60 * 1000
+
+/**
+ * Record a confirmed session. Writes the marker AND its timestamp together,
+ * so no call site can produce a marker that is exempt from ageing — the
+ * failure this whole mechanism exists to prevent.
+ */
+export function markAuthed(now: number = Date.now()): void {
+  try {
+    sessionStorage.setItem(AUTH_MARKER_KEY, '1')
+    sessionStorage.setItem(AUTH_MARKER_AT_KEY, String(now))
+  } catch {
+    /* private browsing may throw */
+  }
+}
+
+/** Clear the cached session marker and its timestamp. */
+export function clearAuthed(): void {
+  try {
+    sessionStorage.removeItem(AUTH_MARKER_KEY)
+    sessionStorage.removeItem(AUTH_MARKER_AT_KEY)
+  } catch {
+    /* private browsing may throw */
+  }
+}
+
+export function hasCatalystSession(now: number = Date.now()): boolean {
   if (typeof window === 'undefined' || typeof sessionStorage === 'undefined') return true
   try {
     const ssKeys = Object.keys(sessionStorage)
     if (ssKeys.some((k) => k.startsWith('oidc:'))) return true
-    if (sessionStorage.getItem('catalyst:authed') === '1') return true
+    if (sessionStorage.getItem(AUTH_MARKER_KEY) !== '1') return false
+
+    // #5887 / UAT row 29 — THE MARKER MUST BE ABLE TO GO STALE.
+    //
+    // Before this, the marker was trusted forever. That made the #5460
+    // revocation below UNREACHABLE from the one gate that needed it:
+    // rootBeforeLoad reads `if (hasCatalystSession()) return` BEFORE it
+    // calls probeWhoamiAndCacheMarker, so a marker left over from an
+    // expired session skipped the probe that would have cleared it — and
+    // skipped the #3374 Layer-B silent-SSO leg with it. The operator hit
+    // the 6-digit PIN wall while holding a perfectly good Keycloak realm
+    // session, and every surface reading the marker rendered authenticated
+    // chrome over a dead session. The marker was self-perpetuating at the
+    // only site that could clear it.
+    //
+    // Ageing it out is deliberately FAIL-SAFE. The worst case is one extra
+    // /whoami: a 200 re-stamps and the operator never notices, a 401
+    // revokes and hands off to the silent leg, and a 5xx/network error
+    // returns null which rootBeforeLoad already treats as fail-open. No
+    // path here can lock out an operator who has a live session.
+    //
+    // A marker with NO timestamp is treated as stale rather than fresh —
+    // that is the pre-fix shape (or a hand-set value), and the safe reading
+    // of "I cannot tell how old this is" is to confirm it once.
+    const stamp = sessionStorage.getItem(AUTH_MARKER_AT_KEY)
+    if (stamp === null) return false
+    const at = Number(stamp)
+    if (!Number.isFinite(at)) return false
+    // A stamp from the future is corrupt, not fresh — do not let it grant
+    // an unbounded lease (the exact bug, reintroduced through the clock).
+    if (at > now) return false
+    return now - at < AUTH_MARKER_MAX_AGE_MS
   } catch {
     /* private browsing may throw */
   }
@@ -279,11 +348,9 @@ export async function probeWhoamiAndCacheMarker(
       headers: { Accept: 'application/json' },
     })
     if (res.status === 200) {
-      try {
-        sessionStorage.setItem('catalyst:authed', '1')
-      } catch {
-        /* private browsing may throw */
-      }
+      // markAuthed (not a bare setItem) so the freshness stamp is written
+      // with the marker — #5887. A marker without a stamp reads as stale.
+      markAuthed()
       return true
     }
     if (res.status === 401) {
@@ -295,11 +362,9 @@ export async function probeWhoamiAndCacheMarker(
       // lands on the PIN wall even with a live Keycloak session, and
       // every surface consulting the marker renders authenticated chrome
       // against a dead session (hw290 row-29 walk, 2026-07-29).
-      try {
-        sessionStorage.removeItem('catalyst:authed')
-      } catch {
-        /* private browsing may throw */
-      }
+      // clearAuthed drops the stamp too, so a later markAuthed cannot be
+      // mistaken for the revoked session's age (#5887).
+      clearAuthed()
       return false
     }
     return null

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
@@ -61,6 +61,7 @@ import {
 } from '@/shared/lib/oidc'
 import type { TokenSet } from '@/shared/lib/oidc'
 import { RequiredActionsModal } from '@/components/RequiredActionsModal'
+import { markAuthed } from '../auth-gate'
 
 /**
  * Build the basepath-aware URL prefix so the redirect target works both
@@ -198,7 +199,7 @@ export function SovereignConsoleLayout() {
         const cookieClaims = await probeSessionCookie()
         if (cookieClaims) {
           // Mark the rootRoute auth gate (#1090 cluster A2) as satisfied.
-          try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private browsing */ }
+          markAuthed()
           setAuthState({ status: 'cookie-authenticated', claims: cookieClaims })
           return
         }
@@ -225,7 +226,7 @@ export function SovereignConsoleLayout() {
       // server-issued session.
       const cookieClaims = await probeSessionCookie()
       if (cookieClaims) {
-        try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private browsing */ }
+        markAuthed()
         setAuthState({ status: 'cookie-authenticated', claims: cookieClaims })
         return
       }

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -191,6 +191,7 @@ import {
   sanitizeNextParam,
 } from './auth-gate'
 import { LENSES, type LensId } from '@/widgets/architecture-graph/presets'
+import { markAuthed } from './auth-gate'
 
 // isValidLensId — closed-set guard for the cloud route's `lens` query
 // param (#3996 follow-up: the reconciliation deep-link carries
@@ -543,7 +544,7 @@ const authHandoverRoute = createRoute({
     // the rootRoute auth gate (#1090 cluster A2) as satisfied so the
     // next navigation to /dashboard isn't bounced to /login.
     if (typeof window !== 'undefined') {
-      try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private */ }
+      markAuthed()
     }
     throw redirect({ to: '/dashboard' as never, replace: true })
   },

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -19,7 +19,7 @@ import { AuthShell } from '@/app/layouts/AuthLayout'
 import { Button } from '@/shared/ui/button'
 import { PinInput6 } from '@/components/PinInput6'
 import { API_BASE, isCatalystZeroURL } from '@/shared/config/urls'
-import { sanitizeNextParam } from '@/app/auth-gate'
+import { markAuthed, sanitizeNextParam } from '@/app/auth-gate'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 type State = 'idle' | 'verifying' | 'error'
@@ -98,7 +98,7 @@ export function VerifyPinPage() {
         // HttpOnly + invisible to JS, so the gate's hasCatalystSession()
         // check would otherwise fail and bounce the operator right back
         // to /login (regression on omantel 2026-05-09).
-        try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private browsing */ }
+        markAuthed()
         // G113 Step 6 — hard-navigate to the KC identity-broker URL
         // when catalyst-api signalled one. The broker flow does an
         // OIDC roundtrip back to catalyst-api (using the catalyst_session


### PR DESCRIPTION
UAT row 29 — the last ❌ row that genuinely needed code written.

## The bug

An operator holding a live Keycloak realm session got PIN-walled once their catalyst session expired, and every surface reading the marker rendered authenticated chrome over a dead session.

The two halves of the existing design never met:

```
router.tsx     if (hasCatalystSession()) return             ← exits here
router.tsx     await probeWhoamiAndCacheMarker(API_BASE)    ← never reached
auth-gate.ts   if (res.status === 401) removeItem(...)      ← #5460, unreachable
```

**#5460 is correct** — a 401 revokes the marker. But `rootBeforeLoad` short-circuits *before* the probe that would produce that 401, and `hasCatalystSession()` trusted the marker forever. So a marker left over from an expired session skipped the probe that would have cleared it, and skipped the #3374 Layer-B silent-SSO leg with it. **The marker was self-perpetuating at the only site that could clear it.** The #5460 comment predicts this exact state; the fix landed in the callee rather than the caller's ordering, so the predicted state stayed reachable.

## What changes

Each marker write carries a written-at stamp; `hasCatalystSession()` declines to short-circuit once it exceeds `AUTH_MARKER_MAX_AGE_MS` (5 min).

- **Missing, non-numeric, and future stamps all read as stale.** "I cannot tell how old this is" must confirm, not trust — and a future stamp would otherwise grant an unbounded lease, which is the same bug reintroduced through the clock.
- **All four production write sites** go through `markAuthed()` instead of a bare `setItem`, so no call site can mint a marker exempt from ageing: `VerifyPinPage`, `SovereignConsoleLayout` (×2), `router.tsx`. `clearAuthed()` drops both keys together.

## Why this is safe to land without a live env

It is fail-safe in the only direction it can move. Worst case is **one extra `/whoami` per 5 minutes** of navigation:

| probe result | outcome |
|---|---|
| 200 | re-stamps, operator never notices |
| 401 | revokes, hands off to the silent-SSO leg |
| 5xx / network | returns `null` → `rootBeforeLoad` already fails open |

No path can lock out an operator holding a live session. The fast path the marker exists for is preserved — a burst of navigation costs one probe, not one per route.

## Gates

```
auth-gate suite   62 passed
full UI suite     229 files, 2121 passed, 1 expected fail
                  (the #5899 tripwire for #5895 — still correctly red)
tsc -b --noEmit   clean
```

The new tests carry a **vacuity control**: without it, every staleness assertion would be satisfied by a `hasCatalystSession()` that simply always returns `false`.

## Scope of the claim

Source-correct, **not walked**. Row 29 stays ❌ until a live walk — this is deploy-gated behind #5640 with the other thirteen. I am not stamping the ledger off a green unit suite.

Refs #5887 #5460 #3374 #5640 #960
