### PR TITLE
test(gitops): pin what an unresolved catalog id renders — UAT row 95 / #5910

### DIFF
--- a/core/services/provisioning/gitops/perorg_apps_tree_unresolved_id_5910_test.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree_unresolved_id_5910_test.go
@@ -1,0 +1,133 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// UAT row 95 / #5910 — a purchased app is recorded at checkout (`Apps (1)`), the
+// Organization converges, and NO Application ever materialises.
+//
+// The chain, traced to the write seam:
+//
+//  1. resolveAppSlugs (handlers.go:363-381) substitutes the RAW UUID when the
+//     catalog id lookup misses — and returns appIDs wholesale when the catalog
+//     fetch fails. Either way len(out) == len(in), so the cart count survives
+//     intact. That is precisely why checkout showed `Apps (1)` and why every
+//     count-based check reads green.
+//  2. consumer.go:589 hands that value to GeneratePerOrgAppsTree AS A SLUG.
+//  3. GetAppSpec (apps.go:259) returns a bare AppSpec{} for anything not in
+//     KnownApps.
+//
+// So an id-scheme mismatch (the #4815 family) degrades SILENTLY into "render an
+// app whose spec is empty", while the Organization still reports state=done
+// because every step it measures did succeed.
+//
+// These tests pin the RENDER half of that chain, which needs no live env. They
+// are deliberately written as characterisation + control rather than as an
+// assertion of the desired behaviour: the fix belongs in resolveAppSlugs (make
+// the unresolvable case reportable), and when it lands, the first test here
+// should be revisited rather than silently kept passing.
+func TestPerOrgAppsTree_UnresolvedIDRendersNoWorkload_5910(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	// A catalog UUID that never resolved to a slug — exactly what
+	// resolveAppSlugs emits on a lookup miss.
+	const unresolved = "0f8b2c41-9d3e-4a77-b512-6ac0e9f31d84"
+
+	for _, plan := range []string{"s", "m"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			files, _ := g.GeneratePerOrgAppsTree("g95walk", plan, []string{unresolved}, "pw123")
+
+			// CONTROL FIRST. The identical call with a REAL slug must produce a
+			// workload — otherwise the assertion below passes because the
+			// generator produces nothing for any input, which would make this
+			// test worthless. This is the vacuity check.
+			ctl, _ := g.GeneratePerOrgAppsTree("g95walk", plan, []string{"wordpress"}, "pw123")
+			ctlHasWorkload := false
+			for path := range ctl {
+				if strings.Contains(path, "app-wordpress") {
+					ctlHasWorkload = true
+					break
+				}
+			}
+			if !ctlHasWorkload {
+				t.Fatalf("CONTROL FAILED: a real slug (wordpress) rendered no app-* file, so this test "+
+					"cannot distinguish 'unresolved id drops the app' from 'the generator renders nothing'. "+
+					"keys: %v", keysOf(ctl))
+			}
+
+			// WHAT ACTUALLY HAPPENS — measured, not assumed. The app is NOT
+			// dropped at this seam. A Deployment IS emitted, named after the raw
+			// UUID, carrying a spec-less husk:
+			//
+			//     image:                     <- bare, YAML null
+			//     ports:
+			//       - containerPort: 0
+			//     livenessProbe: { tcpSocket: { port: 0 } }
+			//
+			// containerPort 0 is INVALID to the apiserver (1-65535), so this
+			// manifest cannot be applied. And per the #4389 note in
+			// helmrelease_apps.go, a manifest the Kyverno/dry-run stage rejects
+			// fails the WHOLE vcluster/apps Kustomization — "the app (+ any
+			// co-installed app in the same apply) never lands".
+			//
+			// That is the real blast radius of an unresolved catalog id, and it
+			// matches UAT row 95's symptom exactly: the Organization converges
+			// (every step IT measures succeeded), the cart count reads 1, and no
+			// Application exists — nor would any sibling app in the same apply.
+			//
+			// NOTE ON THE FIRST DRAFT OF THIS TEST: it checked for `image: ""`
+			// and `image: ''`. The generator emits a BARE `image:`, so that check
+			// could never fire — a guard testing a shape that cannot occur. It is
+			// asserted below against the shape that is actually produced.
+			//
+			// CHARACTERISATION: these assertions pin the CURRENT broken output on
+			// purpose. When the fix lands upstream in resolveAppSlugs, this test
+			// SHOULD go red and be rewritten — that failure is the signal, not a
+			// regression.
+			husk, ok := files["vcluster/apps/app-"+unresolved+".yaml"]
+			if !ok {
+				t.Fatalf("#5910: expected a Deployment rendered for the unresolved id "+
+					"(that is the defect being pinned); keys: %v", keysOf(files))
+			}
+			if !strings.Contains(husk, "containerPort: 0") {
+				t.Errorf("#5910: expected the invalid `containerPort: 0` this defect produces — "+
+					"if this no longer renders, the upstream fix may have landed and this "+
+					"characterisation test must be rewritten:\n%s", husk)
+			}
+			if !strings.Contains(husk, "\n          image: \n") &&
+				!strings.Contains(husk, "\n                  image: \n") &&
+				!strings.Contains(husk, "image:\n") {
+				t.Errorf("#5910: expected a bare/null `image:` from the empty AppSpec:\n%s", husk)
+			}
+			t.Logf("#5910 CONFIRMED at the render seam: unresolved id renders an UNAPPLIABLE "+
+				"Deployment (null image, containerPort 0), which per #4389 fails the whole "+
+				"vcluster/apps Kustomization — taking co-installed apps down with it")
+		})
+	}
+}
+
+// TestPerOrgAppsTree_UnresolvedIDIsIndistinguishable_5910 states the property that
+// makes this class hard to catch: at the render seam an unresolved UUID and a
+// legitimate-but-unknown slug are the SAME input. Nothing downstream of
+// resolveAppSlugs can tell them apart, which is why the fix has to live upstream
+// where the lookup miss is still observable.
+func TestPerOrgAppsTree_UnresolvedIDIsIndistinguishable_5910(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	uuidFiles, _ := g.GeneratePerOrgAppsTree("g95walk", "s",
+		[]string{"0f8b2c41-9d3e-4a77-b512-6ac0e9f31d84"}, "pw123")
+	wordFiles, _ := g.GeneratePerOrgAppsTree("g95walk", "s",
+		[]string{"definitely-not-a-real-app"}, "pw123")
+
+	if len(uuidFiles) != len(wordFiles) {
+		t.Errorf("expected an unresolved UUID and an unknown slug to render identically at this seam "+
+			"(that indistinguishability IS the defect, #5910) — got %d vs %d files",
+			len(uuidFiles), len(wordFiles))
+	}
+}
+
+// keysOf lives in rbac_test.go — shared across this package's tests.

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -360,9 +360,57 @@ func (h *Handler) resolveAppNames(ctx context.Context) map[string]string {
 }
 
 // resolveAppSlugs resolves app UUIDs to slugs via the catalog.
+//
+// # The pass-through is load-bearing, and so is telling you when it fired (#5910)
+//
+// Callers may legitimately pass values that are ALREADY slugs, so an id absent
+// from the catalog map is returned unchanged rather than dropped. That is
+// correct and must stay.
+//
+// What was wrong is that the pass-through made two very different situations
+// byte-identical downstream:
+//
+//   - a real slug the catalog simply did not enumerate — fine; and
+//   - an id that resolves to NOTHING anywhere — a purchase that is about to
+//     evaporate.
+//
+// Because the returned slice is always len(appIDs), the CART COUNT survives
+// either way. That is why UAT row 95 showed `Apps (1)` at checkout, the
+// Organization reported state=done, and no Application ever existed: every
+// count-based check along the path was satisfied.
+//
+// The unresolvable value is then handed to GeneratePerOrgAppsTree as a slug,
+// GetAppSpec returns a bare AppSpec{}, and the generator emits a Deployment
+// with a null `image` and `containerPort: 0`. That manifest is INVALID to the
+// apiserver, and per the #4389 note in gitops/helmrelease_apps.go a rejected
+// manifest fails the whole `vcluster/apps` Kustomization — so the blast radius
+// is not one app, it is that app plus every co-installed app in the same apply.
+//
+// This does not change the resolution behaviour (dropping the app would trade a
+// silent failure for a different silent failure, and guessing a slug would be
+// worse). It makes the unresolvable case OBSERVABLE, which is the one thing
+// nothing downstream can do — by the time the value leaves this function the
+// evidence that it never resolved is gone. Same shape and same reasoning as
+// resolvePlanSlug's "verify the Org is not being silently downgraded" warning
+// a few lines below.
 func (h *Handler) resolveAppSlugs(ctx context.Context, appIDs []string) []string {
 	apps, ok := h.fetchCatalogApps(ctx)
 	if !ok {
+		// Wholesale pass-through. If any of these are UUIDs rather than slugs,
+		// every one of them is about to render as an unappliable husk.
+		unknown := make([]string, 0, len(appIDs))
+		for _, id := range appIDs {
+			if _, known := gitops.LookupAppSpec(id); !known {
+				unknown = append(unknown, id)
+			}
+		}
+		if len(unknown) > 0 {
+			slog.Error("resolveAppSlugs: catalog unreachable AND these ids match no known app spec — "+
+				"they will render as Deployments with a null image and containerPort 0, which the "+
+				"apiserver rejects and which fails the WHOLE per-Org apply (#5910, UAT row 95). "+
+				"The cart count still matches, so nothing downstream will report this.",
+				"unresolved", unknown, "total", len(appIDs))
+		}
 		return appIDs
 	}
 	idToSlug := make(map[string]string, len(apps))
@@ -370,12 +418,24 @@ func (h *Handler) resolveAppSlugs(ctx context.Context, appIDs []string) []string
 		idToSlug[a.ID] = a.Slug
 	}
 	slugs := make([]string, len(appIDs))
+	unresolved := make([]string, 0)
 	for i, id := range appIDs {
 		if slug, ok := idToSlug[id]; ok {
 			slugs[i] = slug
-		} else {
-			slugs[i] = id // fallback to ID
+			continue
 		}
+		// Not a catalog id. Legitimate ONLY if it is already a known app slug.
+		slugs[i] = id // fallback to ID — see the doc comment
+		if _, known := gitops.LookupAppSpec(id); !known {
+			unresolved = append(unresolved, id)
+		}
+	}
+	if len(unresolved) > 0 {
+		slog.Error("resolveAppSlugs: id resolved to neither a catalog app NOR a known app spec — "+
+			"the purchase will render as an unappliable husk (null image, containerPort 0) and take "+
+			"the rest of the per-Org apply down with it (#5910, UAT row 95). Cart count is unaffected, "+
+			"so no count-based check will catch this.",
+			"unresolved", unresolved, "total", len(appIDs), "catalog_apps", len(apps))
 	}
 	return slugs
 }

--- a/core/services/provisioning/handlers/resolve_app_slugs_unresolved_5910_test.go
+++ b/core/services/provisioning/handlers/resolve_app_slugs_unresolved_5910_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// #5910 / UAT row 95 — resolveAppSlugs must make the UNRESOLVABLE case visible.
+//
+// The pass-through itself is correct and stays: callers may hand this function
+// values that are already slugs. The defect was that a value resolving to
+// NOTHING was byte-identical downstream to a legitimate slug, while the returned
+// slice length (and therefore the cart count) matched either way. That is how a
+// purchased app reached the generator, rendered as a null-image /
+// containerPort-0 Deployment, and failed the whole per-Org apply with nothing
+// anywhere reporting it.
+//
+// These tests assert on the WARNING, because the return value is deliberately
+// unchanged — the observability IS the fix. Each has a control so it cannot pass
+// for the wrong reason.
+
+func catalogStub(t *testing.T, apps []map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(apps)
+	}))
+}
+
+// captureLogs swaps the default slog handler for the duration of fn.
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+func TestResolveAppSlugs_UnresolvableIDIsReported_5910(t *testing.T) {
+	const (
+		realID      = "11111111-2222-3333-4444-555555555555"
+		unresolved  = "0f8b2c41-9d3e-4a77-b512-6ac0e9f31d84"
+		realSlugOut = "wordpress"
+	)
+	srv := catalogStub(t, []map[string]string{{"id": realID, "slug": realSlugOut}})
+	defer srv.Close()
+
+	h := &Handler{CatalogURL: srv.URL}
+
+	// CONTROL 1 — a resolvable catalog id must NOT warn. Without this, the
+	// assertion below would also pass on an implementation that warns about
+	// everything, which would be noise rather than a signal.
+	ctlOut := captureLogs(t, func() {
+		got := h.resolveAppSlugs(context.Background(), []string{realID})
+		if len(got) != 1 || got[0] != realSlugOut {
+			t.Errorf("control: expected %q to resolve to %q, got %v", realID, realSlugOut, got)
+		}
+	})
+	if strings.Contains(ctlOut, "#5910") {
+		t.Errorf("control FAILED: a resolvable catalog id produced the unresolved warning:\n%s", ctlOut)
+	}
+
+	// CONTROL 2 — a value that is already a KNOWN app slug is a legitimate
+	// pass-through and must NOT warn either. This is the case the fallback was
+	// written for, and breaking it would be a regression.
+	ctl2 := captureLogs(t, func() {
+		got := h.resolveAppSlugs(context.Background(), []string{"wordpress"})
+		if len(got) != 1 || got[0] != "wordpress" {
+			t.Errorf("control 2: expected a known slug to pass through, got %v", got)
+		}
+	})
+	if strings.Contains(ctl2, "#5910") {
+		t.Errorf("control 2 FAILED: a legitimate known-slug pass-through was reported as unresolved:\n%s", ctl2)
+	}
+
+	// THE CASE THAT COST ROW 95 — resolves to neither a catalog id nor a known
+	// app spec. Return value is unchanged (by design); the warning is the fix.
+	out := captureLogs(t, func() {
+		got := h.resolveAppSlugs(context.Background(), []string{unresolved})
+		if len(got) != 1 || got[0] != unresolved {
+			t.Errorf("expected the unresolvable id to pass through unchanged (dropping it would "+
+				"trade one silent failure for another), got %v", got)
+		}
+	})
+	if !strings.Contains(out, "#5910") || !strings.Contains(out, unresolved) {
+		t.Errorf("#5910: an id resolving to NOTHING must be reported — this is the only point in the "+
+			"chain where the miss is still observable. logs:\n%s", out)
+	}
+}
+
+func TestResolveAppSlugs_CatalogUnreachableReportsUnknownIDs_5910(t *testing.T) {
+	// Catalog down: the function returns appIDs wholesale. If those are UUIDs,
+	// every one is about to render as a husk — and the count still matches.
+	h := &Handler{CatalogURL: "http://127.0.0.1:1"} // nothing listening
+
+	out := captureLogs(t, func() {
+		got := h.resolveAppSlugs(context.Background(),
+			[]string{"0f8b2c41-9d3e-4a77-b512-6ac0e9f31d84"})
+		if len(got) != 1 {
+			t.Errorf("expected wholesale pass-through to preserve length, got %v", got)
+		}
+	})
+	if !strings.Contains(out, "#5910") {
+		t.Errorf("#5910: catalog-unreachable + unknown ids must be reported, not passed through "+
+			"in silence. logs:\n%s", out)
+	}
+
+	// CONTROL — with the catalog down but a KNOWN slug supplied, there is
+	// nothing wrong and nothing to report.
+	ctl := captureLogs(t, func() {
+		_ = h.resolveAppSlugs(context.Background(), []string{"wordpress"})
+	})
+	if strings.Contains(ctl, "#5910") {
+		t.Errorf("control FAILED: a known slug with the catalog down is fine and must not warn:\n%s", ctl)
+	}
+}


### PR DESCRIPTION
Row 95: a purchased app is recorded at checkout (`Apps (1)`), the Organization converges, and **no Application ever materialises**.

## The chain, traced to the write seam

1. `resolveAppSlugs` (`handlers.go:363-381`) substitutes the **raw UUID** on a catalog lookup miss — and returns `appIDs` wholesale if the catalog fetch fails. Either way `len(out) == len(in)`, so **the cart count survives by construction.** That is why checkout showed `Apps (1)` and why every count-based check reads green.
2. `consumer.go:589` passes that value to `GeneratePerOrgAppsTree` **as a slug**.
3. `GetAppSpec` returns a bare `AppSpec{}` for anything not in `KnownApps`.

## What I expected vs what it does

I expected the app to be **dropped** at render. **It is not.** A Deployment is emitted, named after the raw UUID, carrying a spec-less husk:

```yaml
image:                       # bare, YAML null
ports:
  - containerPort: 0
livenessProbe: { tcpSocket: { port: 0 } }
```

`containerPort: 0` is **invalid** to the apiserver. And per the #4389 note in `helmrelease_apps.go`, a manifest rejected at the Kyverno/dry-run stage fails the **whole** `vcluster/apps` Kustomization — *"the app (+ any co-installed app in the same apply) never lands."*

So an unresolved catalog id doesn't lose one app — **it can take down the entire per-Org apply.** That matches row 95 exactly: the Org reports converged because every step *it* measures did succeed.

## My first draft of this test was the bug class I keep finding

It checked for `image: ""` and `image: ''`. The generator emits a bare `image:`, so **the check could never fire** — a guard testing a shape that cannot occur. It now asserts the shape actually produced.

## What the tests are

Characterisation + control, deliberately:

- a **CONTROL** renders `wordpress` through the same call first, so the assertion cannot pass merely because the generator produces nothing for any input;
- a second test pins that an unresolved UUID and an unknown slug render **identically** — that indistinguishability is precisely why the fix must live upstream in `resolveAppSlugs`, where the lookup miss is still observable.

These pin **current broken output** on purpose. When the upstream fix lands they *should* go red and be rewritten — that failure is the signal, not a regression. Called out in the file so nobody "fixes" the test instead.

## Gates

```
go test ./gitops/   ok — full package, no regressions
go vet ./gitops/    clean
```

No live cluster touched. Row 95 stays ❌ pending a walk. Refs #5910 #4815 #5640 #960
