### PR TITLE
fix(application-controller): stop crediting readiness to regions that were never delivered

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1698,7 +1698,33 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	// status.targets[].armed; the runtime lease-held state stays on the
 	// Continuum CR (continuum-controller-owned) and only the fresh-multi-region
 	// walk proves which region currently holds it.
-	readyByRegion := readbackByRegion(plan, finalPhase)
+	//
+	// #5137 — the readiness input is CAPPED by what was actually delivered.
+	// The observation work-list above is built from the MATERIALISED
+	// deliveries (perClusterStatus → fanoutHRRefs); the fan-out below runs
+	// over the DECLARED plan. When the topology fan-out collapses to fewer
+	// clusters than the plan declares regions (the #5513 condition, live on
+	// hw292/uat-ahs-pg: ONE HelmRelease `uat-ahs-pg-rtz-a`, TWO declared
+	// regions), the aggregate PhaseReady earned by the deliveries that DO
+	// exist was stamped onto every declared region — so me-east-215-b, which
+	// holds no namespace, no HelmRelease and no workload, published
+	// `status.targets[].ready: true` + `standbyType: Hot` while
+	// `status.regions[]` for the SAME region published `replicas: 0,
+	// ready: 0`, and the ONE recon value read `Reconciled`. One object, two
+	// contradictory facts, with the Topology tab wired to the optimistic
+	// half. The credit is capped at the number of deliveries observed Ready,
+	// read from perClusterStatus — the same source #5513 already made
+	// authoritative for the region count a few lines above.
+	readyDeliveries := len(plan.Regions)
+	if fanoutOwnsInstall {
+		readyDeliveries = 0
+		for _, pcs := range perClusterStatus {
+			if s, _ := pcs["status"].(string); s == PhaseReady {
+				readyDeliveries++
+			}
+		}
+	}
+	readyByRegion := readbackByRegion(plan, finalPhase, readyDeliveries)
 	observed := observedTargetsFromPlan(plan, effectiveTargets, readyByRegion, continuumRef != "")
 	su.PlacementRecon, su.PlacementReason, su.ObservedTargets = reconStatusBlock(observed)
 
@@ -1714,15 +1740,41 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 // observeRegionHelmReleases collapses the per-region HRs to a single
 // worst-of phase; we fan that back out across the plan's regions so the
 // ObservedTarget rollup is consistent with the Application phase the rest
-// of the status already reports. PhaseReady ⇒ every region ready;
-// PhaseDegraded/PhaseFailed ⇒ every region degraded; otherwise ⇒ none
-// ready yet (Reconciling), never degraded.
-func readbackByRegion(plan placement.Plan, phase string) map[string]regionReadback {
+// of the status already reports. PhaseDegraded/PhaseFailed ⇒ every region
+// degraded; anything but Ready/Degraded/Failed ⇒ none ready yet
+// (Reconciling), never degraded.
+//
+// #5137 — PhaseReady is NOT fanned out unconditionally. `readyDeliveries`
+// is how many deliveries the reconcile actually observed reporting
+// Ready=True; at most that many regions may be credited, in plan order
+// (placement.Resolve puts the Primary at index 0, then the standbys). A
+// declared region beyond that count was never observed by ANY HelmRelease
+// GET this pass — no evidence exists for it, so it reports Reconciling.
+//
+// This is the asymmetry the defect demands: `ready` is the OBSERVED half of
+// a status whose region/role/standbyType identity is DECLARED intent, so
+// over-claiming readiness fabricates a hot standby that does not exist
+// (hw292/uat-ahs-pg published `ready: true` for a region with no
+// namespace). Over-claiming DEGRADED is at worst noisy — it never invents a
+// working replica — so the degraded fan-out is deliberately left alone.
+//
+// Not in scope: the legacy single-HR host path aims every planned region at
+// the same bare `<app>` HR, so its per-region evidence is nominal rather
+// than real. Its caller passes len(plan.Regions) — a non-binding cap that
+// keeps that path byte-identical to before.
+func readbackByRegion(plan placement.Plan, phase string, readyDeliveries int) map[string]regionReadback {
 	out := make(map[string]regionReadback, len(plan.Regions))
+	credited := 0
 	for _, rp := range plan.Regions {
 		switch phase {
 		case PhaseReady:
+			if credited >= readyDeliveries {
+				// No delivery left to attribute to this region.
+				out[rp.Name] = regionReadback{}
+				continue
+			}
 			out[rp.Name] = regionReadback{ready: true}
+			credited++
 		case PhaseDegraded, PhaseFailed:
 			out[rp.Name] = regionReadback{degraded: true}
 		default:

--- a/core/controllers/application/internal/controller/placement_readback_5137_test.go
+++ b/core/controllers/application/internal/controller/placement_readback_5137_test.go
@@ -1,0 +1,191 @@
+package controller
+
+// placement_readback_5137_test.go — #5137 / UAT row 60: ONE Application
+// object must never publish two contradictory facts about the same region.
+//
+// Measured live on hw292 2026-08-10, Application `uat-ahs-pg`
+// (namespace hw292-omani-works, bp-postgres 0.2.16, phase Ready, 6d5h old):
+//
+//	status.regions[1] = {name: me-east-215-b, role: standby, replicas: 0, ready: 0}
+//	status.targets[1] = {region: me-east-215-b, role: Standby, standbyType: Hot, ready: true}
+//	status.placementRecon = "Reconciled"   (placementReason: "")
+//	status.perCluster      = [{cluster: rtz-A, hr: uat-ahs-pg-rtz-a, role: singleton, status: Ready}]
+//
+// One materialised HelmRelease, TWO declared regions. Region B had no
+// namespace at all on the region-B apiserver, no HelmRelease, no CNPG
+// replica and no Continuum — yet the per-app Topology tab, which renders
+// status.targets and status.placementRecon, painted a live armed Hot
+// standby over it.
+//
+// The identity half of a target (region / role / standbyType) is DECLARED
+// intent, resolved from spec.placement.targets[] or derived from the
+// placement plan. `ready` is the only OBSERVED field on the row — and
+// readbackByRegion was fanning ONE aggregate phase across every DECLARED
+// plan region, so a region that no HelmRelease GET ever touched inherited
+// the readiness another region earned. That is intent wearing an
+// observation's name.
+//
+// These tests pin the invariant: the number of regions credited Ready can
+// never exceed the number of deliveries actually observed Ready.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// hw292Row60Plan is the live active-hot-standby plan behind UAT row 60:
+// primary me-east-215-a + Hot standby me-east-215-b.
+func hw292Row60Plan() placement.Plan {
+	return placement.Plan{
+		PrimaryRegion: "me-east-215-a",
+		Regions: []placement.RegionPlan{
+			{Name: "me-east-215-a", Role: placement.RolePrimary, Standby: false},
+			{Name: "me-east-215-b", Role: placement.RoleStandby, Standby: true},
+		},
+	}
+}
+
+// TestReadbackByRegion_UndeliveredStandbyIsNeverReady reproduces the exact
+// hw292 contradiction: the plan declares TWO regions, the fan-out
+// materialised ONE HelmRelease, that HelmRelease is Ready — so the rolled-up
+// Application phase is Ready. The undelivered standby region must NOT
+// inherit it.
+//
+// Pre-fix this whole test fails: readbackByRegion stamped ready:true on
+// every plan region, so targets[1].ready was true, the recon value was
+// "Reconciled" and the reason was empty.
+func TestReadbackByRegion_UndeliveredStandbyIsNeverReady(t *testing.T) {
+	plan := hw292Row60Plan()
+
+	// ONE delivery observed Ready (uat-ahs-pg-rtz-a); the plan declares two
+	// regions. This is the live hw292 shape.
+	const observedReadyDeliveries = 1
+
+	readback := readbackByRegion(plan, PhaseReady, observedReadyDeliveries)
+
+	if !readback["me-east-215-a"].ready {
+		t.Errorf("primary me-east-215-a has a Ready delivery and must stay ready; got %+v",
+			readback["me-east-215-a"])
+	}
+	if readback["me-east-215-b"].ready {
+		t.Errorf("me-east-215-b has NO delivery (no namespace, no HelmRelease on the live cluster) "+
+			"and must never report ready; got %+v", readback["me-east-215-b"])
+	}
+	if readback["me-east-215-b"].degraded {
+		t.Errorf("an unobserved region is Reconciling, not Degraded; got %+v", readback["me-east-215-b"])
+	}
+
+	// The full surface the Topology tab reads: status.targets[] + the ONE
+	// recon value + its reason.
+	targets := placementTargetsFromPlan(plan)
+	obs := observedTargetsFromPlan(plan, targets, readback, false)
+	status, reason, rows := reconStatusBlock(obs)
+
+	if len(rows) != 2 {
+		t.Fatalf("status.targets rows = %d, want 2", len(rows))
+	}
+	primaryRow := rows[0].(map[string]interface{})
+	standbyRow := rows[1].(map[string]interface{})
+
+	// The identity half stays DECLARED — the fix must not erase the
+	// standby's Hot type, only stop claiming it is up.
+	if standbyRow["standbyType"] != string(bpv1alpha1.StandbyHot) {
+		t.Errorf("standby row must keep its declared standbyType Hot; got %+v", standbyRow)
+	}
+	if primaryRow["ready"] != true {
+		t.Errorf("primary row must report ready:true (its delivery IS Ready); got %+v", primaryRow)
+	}
+	if standbyRow["ready"] != false {
+		t.Errorf("status.targets for me-east-215-b reports ready:%v while status.regions for the SAME "+
+			"region reports replicas:0 ready:0 — one object, two contradictory facts (#5137). Row: %+v",
+			standbyRow["ready"], standbyRow)
+	}
+
+	if status != string(bpv1alpha1.ReconStatusReconciling) {
+		t.Errorf("placementRecon = %q, want %q: a placement with an undelivered region is not reconciled",
+			status, bpv1alpha1.ReconStatusReconciling)
+	}
+	if !strings.Contains(reason, "me-east-215-b") {
+		t.Errorf("placementReason = %q, want it to NAME the region that has not converged", reason)
+	}
+}
+
+// TestReadbackByRegion_FullyDeliveredPairStaysReady is the positive control
+// that keeps the test above from passing for the trivial reason. A REAL
+// 2-region pair — two deliveries, both Ready — must still report both
+// regions ready and the placement Reconciled. Without this control, a fix
+// that simply never reports ready would look green.
+func TestReadbackByRegion_FullyDeliveredPairStaysReady(t *testing.T) {
+	plan := hw292Row60Plan()
+
+	readback := readbackByRegion(plan, PhaseReady, 2)
+	if !readback["me-east-215-a"].ready || !readback["me-east-215-b"].ready {
+		t.Fatalf("a genuinely delivered 2-region pair must report both regions ready; got %+v", readback)
+	}
+
+	obs := observedTargetsFromPlan(plan, placementTargetsFromPlan(plan), readback, true)
+	status, reason, rows := reconStatusBlock(obs)
+	if status != string(bpv1alpha1.ReconStatusReconciled) {
+		t.Errorf("placementRecon = %q (reason %q), want Reconciled for a fully delivered pair", status, reason)
+	}
+	// §13 arming still rides on the Hot standby when a Continuum exists.
+	if rows[1].(map[string]interface{})["armed"] != true {
+		t.Errorf("a delivered Hot standby with a DR contract must stay armed; got %+v", rows[1])
+	}
+}
+
+// TestReadbackByRegion_NeverCreditsMoreRegionsThanDeliveries pins the
+// invariant itself across the shapes the fan-out can produce, so a future
+// edit cannot re-introduce the any-region-implies-all-regions fallacy.
+func TestReadbackByRegion_NeverCreditsMoreRegionsThanDeliveries(t *testing.T) {
+	threeRegion := placement.Plan{
+		PrimaryRegion: "me-east-215-a",
+		Regions: []placement.RegionPlan{
+			{Name: "me-east-215-a", Role: placement.RolePrimary},
+			{Name: "me-east-215-b", Role: placement.RoleStandby, Standby: true},
+			{Name: "me-east-215-c", Role: placement.RoleStandby, Standby: true},
+		},
+	}
+
+	cases := []struct {
+		name             string
+		plan             placement.Plan
+		phase            string
+		readyDeliveries  int
+		wantReadyRegions int
+	}{
+		{"hw292 row60: 1 delivery, 2 declared regions", hw292Row60Plan(), PhaseReady, 1, 1},
+		{"zero deliveries observed Ready", hw292Row60Plan(), PhaseReady, 0, 0},
+		{"3 declared, 1 delivered", threeRegion, PhaseReady, 1, 1},
+		{"3 declared, 2 delivered", threeRegion, PhaseReady, 2, 2},
+		{"3 declared, 3 delivered", threeRegion, PhaseReady, 3, 3},
+		// A cap wider than the plan can never manufacture extra regions.
+		{"cap exceeds plan", hw292Row60Plan(), PhaseReady, 9, 2},
+		// Non-Ready phases are unchanged by the cap.
+		{"provisioning credits nothing", hw292Row60Plan(), PhaseProvisioning, 2, 0},
+		{"degraded credits nothing", hw292Row60Plan(), PhaseDegraded, 2, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			readback := readbackByRegion(tc.plan, tc.phase, tc.readyDeliveries)
+			got := 0
+			for _, rb := range readback {
+				if rb.ready {
+					got++
+				}
+			}
+			if got != tc.wantReadyRegions {
+				t.Errorf("regions credited ready = %d, want %d (deliveries observed Ready = %d, "+
+					"declared regions = %d)", got, tc.wantReadyRegions, tc.readyDeliveries, len(tc.plan.Regions))
+			}
+			if got > tc.readyDeliveries && tc.phase == PhaseReady {
+				t.Errorf("credited %d regions from %d deliveries — readiness must never be fabricated",
+					got, tc.readyDeliveries)
+			}
+		})
+	}
+}

--- a/core/controllers/application/internal/controller/placement_recon_test.go
+++ b/core/controllers/application/internal/controller/placement_recon_test.go
@@ -208,7 +208,7 @@ func TestObservedTargetsFromPlan_PrefersDesiredRoles(t *testing.T) {
 		{Region: "region-a", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
 		{Region: "region-b", Cluster: "mgmt-B", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
 	}
-	ready := readbackByRegion(plan, PhaseReady)
+	ready := readbackByRegion(plan, PhaseReady, len(plan.Regions))
 	obs := observedTargetsFromPlan(plan, targets, ready, false)
 	if len(obs) != 2 {
 		t.Fatalf("observed len = %d, want 2", len(obs))
@@ -244,7 +244,7 @@ func TestObservedTargetsFromPlan_ArmsHotStandbyWhenDRContract(t *testing.T) {
 		{Region: "region-b", Cluster: "mgmt-B", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
 		{Region: "region-c", Cluster: "mgmt-C", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyCold},
 	}
-	obs := observedTargetsFromPlan(plan, targets, readbackByRegion(plan, PhaseReady), true)
+	obs := observedTargetsFromPlan(plan, targets, readbackByRegion(plan, PhaseReady, len(plan.Regions)), true)
 	if obs[0].Armed {
 		t.Errorf("Primary must never be Armed, got %+v", obs[0])
 	}
@@ -276,7 +276,7 @@ func TestObservedTargetsFromPlan_LegacyPlanWithoutTargets(t *testing.T) {
 		},
 	}
 	// No desired targets ⇒ map the legacy plan roles.
-	obs := observedTargetsFromPlan(plan, nil, readbackByRegion(plan, PhaseProvisioning), false)
+	obs := observedTargetsFromPlan(plan, nil, readbackByRegion(plan, PhaseProvisioning, len(plan.Regions)), false)
 	if obs[0].Role != bpv1alpha1.DataRolePrimary || obs[1].Role != bpv1alpha1.DataRoleStandby {
 		t.Errorf("legacy plan roles = %q/%q, want Primary/Standby", obs[0].Role, obs[1].Role)
 	}


### PR DESCRIPTION
## The defect — measured live, hw292, 2026-08-10

UAT row 60's Application `uat-ahs-pg` (ns `hw292-omani-works`, bp-postgres 0.2.16, phase `Ready`, 6d5h old) publishes **two contradictory facts about the same region in one object**:

```
status.regions[1]     = {name: me-east-215-b, role: standby, replicas: 0, ready: 0}
status.targets[1]     = {region: me-east-215-b, role: Standby, standbyType: Hot, ready: true}
status.placementRecon = "Reconciled"   (placementReason: "")
status.perCluster     = [{cluster: rtz-A, hr: uat-ahs-pg-rtz-a, role: singleton, status: Ready}]
```

Corroborating live state, read-only:

- `kubectl -n hw292-omani-works get hr` (region A) returns **exactly one** HelmRelease: `uat-ahs-pg-rtz-a  True  Helm install succeeded`. There is no second HR.
- `kubectl get ns hw292-omani-works` on the **region-B** apiserver: `Error from server (NotFound)`. The standby region does not have the namespace at all.
- `status.continuumRef` is `null` — no DR contract backs the pair.
- Note `perCluster[0].role` is literally **`singleton`**: the fan-out itself knows there is no standby, while `status.targets` asserts `Standby / Hot / ready:true`.

`TopologyTab` renders `status.targets` and `status.placementRecon`, so the DR surface paints a live Hot standby over a region that holds nothing.

## Cause — `core/controllers/application/internal/controller/application_controller.go:1720` (`readbackByRegion`)

```go
case PhaseReady:
    out[rp.Name] = regionReadback{ready: true}   // for EVERY rp in plan.Regions
```

The observation work-list is built from the **materialised** deliveries — `perClusterStatus` → `fanoutHRRefs` → `observeRegionHelmReleases` (line 1491). The readiness fan-out runs over the **declared** `plan.Regions`. When the topology fan-out collapses to fewer clusters than the plan declares regions, `observeRegionHelmReleases` sees only the HRs that exist, all of them Ready, so it returns `PhaseReady` — and `readbackByRegion` stamps that verdict onto regions **no HelmRelease GET ever touched**. `DeriveReconStatus` then sees all-ready and emits `Reconciled` with an empty reason.

This is the same class #5513 already caught 170 lines earlier for the region *count* (`effectiveRegions = len(perClusterStatus)` when the fan-out owns the install, line 1530). `readbackByRegion` was the leftover half.

## Intent vs observed — the finding

**Yes: `targets[]` is declared intent wearing an observation's name.**

- The **identity** half of a target (`region` / `role` / `standbyType`) is declared: `effectivePlacementTargets` (`placement_recon.go:258`) returns `spec.placement.targets[]` verbatim, or derives them from the placement plan via `placementTargetsFromPlan` (`placement_recon.go:274`), which hard-codes `StandbyHot` for any standby region. Nothing observes anything.
- `armed` is explicitly declared — the code comment at `placement_recon.go:196` says so: *"the DESIRED-STATE arming signal"*.
- `ready` is the **only** observed field on the row, and it was being supplied by a fanned-out aggregate rather than a per-region observation.

So the bug is precisely that the UI reads intent and calls it readiness — and the controller handed it a field labelled `ready` that never was.

## The fix — derive `targets[].ready` from observed state (producer side)

`readbackByRegion` takes the number of deliveries actually observed `Ready=True` and credits **at most that many** regions, in plan order (`placement.Resolve` puts the Primary at index 0). The count is read from `perClusterStatus`, the same source #5513 made authoritative in this function. On the legacy single-HR host path the caller passes `len(plan.Regions)` — a non-binding cap, so that path is byte-identical to before.

The degraded fan-out is **deliberately left alone**. Over-claiming *ready* fabricates a replica that does not exist; over-claiming *degraded* is at worst noisy. The asymmetry is the point.

Effect on the live object: `targets[1].ready` → `false`, `placementRecon` → `Reconciling`, `placementReason` → `me-east-215-b Standby·Hot is reconciling`. The declared `standbyType: Hot` is preserved — the fix stops claiming the standby is *up*, it does not erase what was *asked for*.

### Why not the alternative (point TopologyTab at `status.regions`)

Rejected on three counts, all from the code:

1. **`status.regions[].replicas` is itself declared, not observed.** `replicasFor` (`application_controller.go:3840`) returns `0` for any standby — by design, per the #3375 DoD-2 standby scale-down in `render/fanout.go:212` (`_openova_standby: true`). And `mergeRegionReadiness` (`application_controller.go:1896`) sets `ready = replicas`. So a **genuine, healthy** Hot standby also reads `replicas: 0, ready: 0`. Rendering that half would trade today's false positive for a permanent false negative on every real DR pair — it would break row 60's own assertion.
2. **`status.targets` / `placementRecon` is the #3969 §7.4 contract** — *"the ONE recon value… a mismatch is NEVER rendered as a second contradictory value"* (`recon_status.go:3`). Every consumer reads it: `DeriveReconStatus`, catalyst-api, fleet rollups. A UI-only change leaves the CR itself publishing `Reconciled` over a region with no namespace.
3. There are **four** front-end trees. Fixing one renderer repairs one screen; fixing the producer repairs the resource.

**Known bound, stated honestly:** the cap is a count, not a per-region attribution — the fan-out HR carries `catalyst.openova.io/cluster` but no region label (`render/fanout.go:224`), so two deliveries in the *same* region would still credit two regions. That shape does not occur in the measured case (1 cluster, 2 regions) and closing it needs a region label on the fan-out HR; this change is strictly tighter than the unconditional fan-out it replaces.

## Test — fails before, passes after

`core/controllers/application/internal/controller/placement_readback_5137_test.go` reconstructs the exact live state: 2 declared regions, 1 delivery observed Ready.

**BEFORE** (only the `case PhaseReady` body reverted to the pre-fix unconditional fan-out; the test file and signature unchanged):

```
--- FAIL: TestReadbackByRegion_UndeliveredStandbyIsNeverReady (0.00s)
    placement_readback_5137_test.go:74: me-east-215-b has NO delivery (no namespace, no HelmRelease on the live cluster) and must never report ready; got {ready:true degraded:false}
    placement_readback_5137_test.go:102: status.targets for me-east-215-b reports ready:true while status.regions for the SAME region reports replicas:0 ready:0 — one object, two contradictory facts (#5137). Row: map[ready:true region:me-east-215-b role:Standby standbyType:Hot]
    placement_readback_5137_test.go:108: placementRecon = "Reconciled", want "Reconciling": a placement with an undelivered region is not reconciled
    placement_readback_5137_test.go:112: placementReason = "", want it to NAME the region that has not converged
--- FAIL: TestReadbackByRegion_NeverCreditsMoreRegionsThanDeliveries/hw292_row60:_1_delivery,_2_declared_regions
    placement_readback_5137_test.go:182: regions credited ready = 2, want 1 (deliveries observed Ready = 1, declared regions = 2)
    placement_readback_5137_test.go:186: credited 2 regions from 1 deliveries — readiness must never be fabricated
--- FAIL: .../zero_deliveries_observed_Ready      regions credited ready = 2, want 0
--- FAIL: .../3_declared,_1_delivered             regions credited ready = 3, want 1
--- FAIL: .../3_declared,_2_delivered             regions credited ready = 3, want 2
FAIL	github.com/openova-io/openova/core/controllers/application/internal/controller	0.009s
```

**AFTER:**

```
--- PASS: TestReadbackByRegion_UndeliveredStandbyIsNeverReady (0.00s)
--- PASS: TestReadbackByRegion_FullyDeliveredPairStaysReady (0.00s)
--- PASS: TestReadbackByRegion_NeverCreditsMoreRegionsThanDeliveries (0.00s)
    --- PASS: .../hw292_row60:_1_delivery,_2_declared_regions
    --- PASS: .../zero_deliveries_observed_Ready
    --- PASS: .../3_declared,_1_delivered
    --- PASS: .../3_declared,_2_delivered
    --- PASS: .../3_declared,_3_delivered
    --- PASS: .../cap_exceeds_plan
    --- PASS: .../provisioning_credits_nothing
    --- PASS: .../degraded_credits_nothing
ok  	github.com/openova-io/openova/core/controllers/application/internal/controller	0.011s
```

`TestReadbackByRegion_FullyDeliveredPairStaysReady` is the **positive control** — it passes in *both* runs. A genuine 2-region pair (2 deliveries, both Ready) still reports both regions ready, `Reconciled`, and keeps the Hot standby `armed`. Without it, a fix that simply never reported ready would look green.

Full gate, chained: `go build ./... && go vet ./application/... && go test ./... -count=1` → `EXIT=0` on `core/controllers`.

Refs #3986 #5137
