### PR TITLE
fix(marketplace): hide payment chrome when credit covers the order (UAT row 85)

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -3,6 +3,7 @@
   import { readCart, clearCart } from '../lib/cart';
   import { formatOMR } from '../lib/currency';
   import { consoleHandoffHref, consoleLaunchHref } from '../lib/config';
+  import { creditCoversOrder, chargesCustomer } from '../lib/checkoutPaymentGate';
   import PinInput6 from './PinInput6.svelte';
 
   let cart = $state(readCart());
@@ -199,8 +200,14 @@
     ]).then(([ledger, voucher]) => { creditBaisa = ledger + voucher; });
   });
 
-  const creditCovers = $derived(creditBaisa >= totalCost && totalCost > 0);
+  const creditCovers = $derived(creditCoversOrder(totalCost, creditBaisa));
   const creditPartial = $derived(creditBaisa > 0 && creditBaisa < totalCost);
+  // UAT row 85: the payment-method picker + the Stripe redirect line render
+  // ONLY when the customer is actually charged. Gating them on `totalCost > 0`
+  // alone showed card chrome beside "Due now OMR 0.000" on a fully
+  // voucher-covered order. The voucher input below is deliberately NOT gated
+  // on this — it is additive credit, not a payment method.
+  const willCharge = $derived(chargesCustomer(totalCost, creditBaisa));
 
   // Handle return from Stripe checkout — redirect straight to console so the
   // user watches real-time provisioning on the Jobs page.
@@ -759,6 +766,11 @@
         <!-- Payment method picker -->
         {#if totalCost > 0}
           <div class="mb-6">
+            <!-- Payment chrome renders ONLY when the order actually charges the
+                 customer (UAT row 85). On a fully voucher-covered order the
+                 tiles + the Stripe redirect line contradicted "Due now OMR
+                 0.000" and the "Launch my Organization" button beside them. -->
+            {#if willCharge}
             <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">Payment method</div>
 
             <!-- Three brand tiles in one row — click a tile to select (radio-group behaviour, no separate dot) -->
@@ -808,8 +820,11 @@
             <p class="mt-3 text-xs text-[var(--color-text-dim)]">
               On <strong class="text-[var(--color-text)]">Purchase</strong>, you'll be redirected to Stripe's PCI-compliant checkout to complete payment securely.
             </p>
+            {/if}
 
-            <!-- Additive voucher — not a payment method, it applies credit against the total -->
+            <!-- Additive voucher — not a payment method, it applies credit
+                 against the total. Stays visible on a fully-covered order so a
+                 mistyped code can still be corrected or cleared. -->
             <div class="mt-4 rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--color-bg)] p-3">
               <label class="flex items-center gap-2 text-xs font-medium text-[var(--color-text-dim)]">
                 <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">

--- a/core/marketplace/src/lib/checkoutPaymentGate.test.ts
+++ b/core/marketplace/src/lib/checkoutPaymentGate.test.ts
@@ -1,0 +1,245 @@
+// UAT row 85 — a fully voucher-covered order must not show payment chrome.
+//
+// WHY THIS IS NOT "ASSERT THERE IS NO CARD FORM". There is no card form
+// anywhere in the funnel to begin with: `stripe.js`, `@stripe/`, `loadStripe`,
+// `cardnumber` and a payment `iframe` return ZERO hits across
+// `core/marketplace/src`. A test asserting their absence would pass on an
+// empty set, would have passed before this fix, and would therefore be
+// worthless. The control at the bottom of this file pins that fact so nobody
+// "strengthens" this suite back into that trap.
+//
+// What row 85 actually caught is the payment *chrome* one level up: the
+// Apple Pay / Mastercard / Visa picker and the line "you'll be redirected to
+// Stripe's PCI-compliant checkout", rendered beside `Due now OMR 0.000` and a
+// `Launch my Organization` button. They were gated on `totalCost > 0`, which
+// stays TRUE on a covered order because a voucher reduces `Due now`, not
+// `totalCost`.
+//
+// So the assertion below is made against the TEMPLATE'S OWN GUARD, resolved
+// through the component's `$derived` declarations and then EVALUATED for a
+// covered order. It is not a string match on the fixed text, and it fails
+// against the pre-fix `{#if totalCost > 0}` for the real reason: that
+// expression evaluates true when credit covers the order.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { chargesCustomer, creditCoversOrder } from './checkoutPaymentGate';
+
+// vitest runs with the package root as cwd (core/marketplace).
+const CHECKOUT = join(process.cwd(), 'src/components/CheckoutStep.svelte');
+const SOURCE = readFileSync(CHECKOUT, 'utf8');
+
+/** A priced order, in baisa — mirrors the funnel's unit. */
+const ORDER = 25_000;
+
+// ---------------------------------------------------------------------------
+// The predicates themselves.
+// ---------------------------------------------------------------------------
+
+describe('checkout payment gate — predicates', () => {
+  it('credit that meets or exceeds the order covers it', () => {
+    expect(creditCoversOrder(ORDER, ORDER)).toBe(true);
+    expect(creditCoversOrder(ORDER, ORDER + 1)).toBe(true);
+  });
+
+  it('a zero-cost order is not "covered by credit" — there is nothing to cover', () => {
+    expect(creditCoversOrder(0, 0)).toBe(false);
+    expect(creditCoversOrder(0, 5_000)).toBe(false);
+  });
+
+  it('does not charge when credit covers the order', () => {
+    expect(chargesCustomer(ORDER, ORDER)).toBe(false);
+    expect(chargesCustomer(ORDER, ORDER * 2)).toBe(false);
+  });
+
+  it('charges when there is no credit, or credit falls short', () => {
+    expect(chargesCustomer(ORDER, 0)).toBe(true);
+    expect(chargesCustomer(ORDER, ORDER - 1)).toBe(true);
+  });
+
+  it('a failed credit lookup (balance 0) keeps the paying path — never a free launch', () => {
+    // lib/api's getCreditBalance catch-path yields 0; that must fall through to
+    // the charged flow rather than silently presenting a covered order.
+    expect(chargesCustomer(ORDER, 0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Template block scanner — resolves which {#if} guards enclose a given piece
+// of markup, so the assertions land on the COMPONENT'S CALL SITE and not just
+// on the helper above (a helper-only test would pass with the template still
+// rendering the tiles).
+// ---------------------------------------------------------------------------
+
+const TEMPLATE = SOURCE.slice(SOURCE.indexOf('</script>'));
+
+const OPEN_BLOCK = /\{#(if|each|await|key|snippet)\b\s*([^]*?)\}\s*$/;
+const CLOSE_BLOCK = /\{\/(if|each|await|key|snippet)\}/;
+const ELSE_IF = /\{:else\s+if\s+([^]*?)\}\s*$/;
+const ELSE_PLAIN = /\{:else\}/;
+
+/**
+ * Returns the stack of enclosing `{#if}` guard expressions for the first line
+ * containing `needle`, outermost first. A `null` entry marks an `{:else}`
+ * branch, whose condition is not a plain expression.
+ */
+function guardsEnclosing(needle: string): (string | null)[] {
+  const lines = TEMPLATE.split('\n');
+  const stack: { kind: string; guard: string | null }[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.includes(needle)) {
+      return stack.filter((f) => f.kind === 'if').map((f) => f.guard);
+    }
+    const close = trimmed.match(CLOSE_BLOCK);
+    if (close) {
+      stack.pop();
+      continue;
+    }
+    const elseIf = trimmed.match(ELSE_IF);
+    if (elseIf && stack.length) {
+      stack[stack.length - 1].guard = elseIf[1].trim();
+      continue;
+    }
+    if (ELSE_PLAIN.test(trimmed) && stack.length) {
+      stack[stack.length - 1].guard = null;
+      continue;
+    }
+    const open = trimmed.match(OPEN_BLOCK);
+    if (open) {
+      stack.push({ kind: open[1], guard: open[1] === 'if' ? open[2].trim() : null });
+    }
+  }
+  throw new Error(`anchor not found in CheckoutStep.svelte template: ${needle}`);
+}
+
+/**
+ * The `{#if}` guard immediately wrapping `needle` — the one that decides
+ * whether that markup renders.
+ *
+ * Deliberately NOT "is some enclosing guard false": outer guards include an
+ * `{:else}` branch (`null`), and counting a `null` as false would let every
+ * assertion below pass without the payment gate existing at all.
+ */
+function innermostGuard(needle: string): string {
+  const guards = guardsEnclosing(needle);
+  const inner = guards[guards.length - 1];
+  if (inner == null) {
+    throw new Error(
+      `expected an {#if} guard directly around "${needle}", found ${
+        guards.length ? 'an {:else} branch' : 'no enclosing {#if} at all'
+      }`,
+    );
+  }
+  return inner;
+}
+
+/** `const NAME = $derived(EXPR);` declarations from the component's script. */
+function derivedBindings(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const m of SOURCE.matchAll(/const\s+(\w+)\s*=\s*\$derived\(([^]*?)\);/g)) {
+    out[m[1]] = m[2].trim();
+  }
+  return out;
+}
+
+/**
+ * Evaluates a template guard for a given (totalCost, creditBaisa), resolving a
+ * bare `$derived` identifier to its declared expression first. Throws when the
+ * guard references state this scenario does not model — which is itself a
+ * meaningful failure, since the payment gate must depend only on cost+credit.
+ */
+function evaluateGuard(guard: string, totalCost: number, creditBaisa: number): boolean {
+  const derived = derivedBindings();
+  const expr = Object.prototype.hasOwnProperty.call(derived, guard) ? derived[guard] : guard;
+  const fn = new Function(
+    'totalCost',
+    'creditBaisa',
+    'creditCoversOrder',
+    'chargesCustomer',
+    `"use strict"; return Boolean(${expr});`,
+  );
+  return fn(totalCost, creditBaisa, creditCoversOrder, chargesCustomer);
+}
+
+// ---------------------------------------------------------------------------
+// The call site.
+// ---------------------------------------------------------------------------
+
+const STRIPE_COPY = "you'll be redirected to Stripe's PCI-compliant checkout";
+const PAYMENT_HEADING = '>Payment method<';
+const TILES = ['aria-label="Apple Pay"', 'aria-label="Mastercard"', 'aria-label="Visa"'];
+const VOUCHER_INPUT = 'bind:value={promoCode}';
+
+describe('UAT row 85 — CheckoutStep hides payment chrome on a covered order', () => {
+  it('the template anchors exist (guard is not scanning an empty set)', () => {
+    // Without this, a renamed label would make every assertion below vacuous.
+    for (const anchor of [STRIPE_COPY, PAYMENT_HEADING, VOUCHER_INPUT, ...TILES]) {
+      expect(SOURCE, `missing anchor ${anchor}`).toContain(anchor);
+    }
+  });
+
+  const CHROME: [string, string][] = [
+    ['the Stripe redirect copy', STRIPE_COPY],
+    ['the "Payment method" heading', PAYMENT_HEADING],
+    ...TILES.map((t) => [`the ${t} tile`, t] as [string, string]),
+  ];
+
+  it.each(CHROME)('%s is not rendered when credit covers the order', (_label, anchor) => {
+    // Pre-fix the guard here is `totalCost > 0`, which is TRUE on a covered
+    // order (a voucher reduces `Due now`, not `totalCost`) — so the tiles and
+    // the redirect line rendered beside `Due now OMR 0.000`. This is the
+    // assertion that fails before the fix.
+    const guard = innermostGuard(anchor);
+    expect(
+      evaluateGuard(guard, ORDER, ORDER),
+      `guard \`${guard}\` still renders payment chrome when a voucher covers the order`,
+    ).toBe(false);
+  });
+
+  it.each(CHROME)('%s IS still rendered on an ordinary paid order', (_label, anchor) => {
+    // Counter-case: the fix must not hide payment chrome from a customer who
+    // really is about to be charged. Without this, gating on a constant
+    // `false` would satisfy the assertion above.
+    const guard = innermostGuard(anchor);
+    expect(
+      evaluateGuard(guard, ORDER, 0),
+      `guard \`${guard}\` hides payment chrome from a paying customer`,
+    ).toBe(true);
+  });
+
+  it('the voucher input survives a covered order so a wrong code can be cleared', () => {
+    // Regression pin: the blunt fix — gating the whole block on the new
+    // predicate — would strand a customer who mistyped a code, because the
+    // input would vanish the moment that code covered the total.
+    const guard = innermostGuard(VOUCHER_INPUT);
+    expect(
+      evaluateGuard(guard, ORDER, ORDER),
+      `guard \`${guard}\` hides the voucher input once credit covers the order`,
+    ).toBe(true);
+  });
+
+  it('payment chrome is gated strictly deeper than the voucher input', () => {
+    // Structural pin for the same regression: the chrome must live in a nested
+    // block INSIDE the voucher block's guard, never share it.
+    const voucher = guardsEnclosing(VOUCHER_INPUT);
+    const chrome = guardsEnclosing(STRIPE_COPY);
+    expect(chrome.length).toBeGreaterThan(voucher.length);
+    expect(chrome.slice(0, voucher.length)).toEqual(voucher);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Control — see the header comment.
+// ---------------------------------------------------------------------------
+
+describe('control — why the obvious test would have been worthless', () => {
+  it('the funnel has no card-collection surface at all, so asserting its absence proves nothing', () => {
+    for (const token of ['stripe.js', '@stripe/', 'loadStripe', 'cardnumber']) {
+      expect(SOURCE.toLowerCase()).not.toContain(token.toLowerCase());
+    }
+    // Documents the trap: this assertion held BEFORE the fix too, while the
+    // page was still showing the picker and the redirect line.
+  });
+});

--- a/core/marketplace/src/lib/checkoutPaymentGate.ts
+++ b/core/marketplace/src/lib/checkoutPaymentGate.ts
@@ -1,0 +1,51 @@
+// UAT row 85 — what the checkout page may show a customer whose voucher
+// already covers the whole order.
+//
+// The funnel has NO card form on any path: `stripe.js`, `@stripe/`,
+// `loadStripe`, a `cardnumber` field and a payment `iframe` are all absent
+// from `core/marketplace/src`. So "the checkout collects no card details" is
+// true by construction and asserting it proves nothing. The defect row 85
+// actually catches is one level up — the page still renders the payment
+// *chrome*: the Apple Pay / Mastercard / Visa picker and the line "you'll be
+// redirected to Stripe's PCI-compliant checkout", sitting directly beside
+// `Due now OMR 0.000` and a `Launch my Organization` button that goes nowhere
+// near Stripe. That is a contradiction the customer has to resolve, and it is
+// what made the row fail.
+//
+// These predicates are the single definition of "will this order actually
+// charge the customer", shared by the component's derived state and by the
+// test that pins the template's call site.
+
+/**
+ * `true` when available credit fully covers the order, so no payment
+ * instrument is involved at all.
+ *
+ * Both figures are in **baisa** (the billing API's unit) — never mix in an
+ * OMR-denominated value here.
+ *
+ * A zero-cost order is NOT "covered by credit": there is nothing to cover.
+ * That case is handled separately by the caller (the button already reads
+ * `totalCost === 0 || creditCovers`), and keeping it out of this predicate is
+ * what lets `chargesCustomer` stay a clean negation.
+ */
+export function creditCoversOrder(totalCost: number, creditBaisa: number): boolean {
+  return totalCost > 0 && creditBaisa >= totalCost;
+}
+
+/**
+ * `true` only when the customer will genuinely be charged — i.e. the order
+ * costs something AND credit does not cover it.
+ *
+ * This is the gate for the payment-method picker and the Stripe redirect copy.
+ * The pre-fix template gated them on `totalCost > 0` alone, which stays true
+ * for a fully-covered order (the voucher reduces `Due now`, not `totalCost`),
+ * so the card chrome rendered next to a zero balance.
+ *
+ * Deliberately NOT the gate for the voucher/promo-code input: a voucher is
+ * additive credit, not a payment method, and hiding its input the instant the
+ * code covers the total would strand a customer who mistyped a code with no
+ * way to clear it.
+ */
+export function chargesCustomer(totalCost: number, creditBaisa: number): boolean {
+  return totalCost > 0 && !creditCoversOrder(totalCost, creditBaisa);
+}


### PR DESCRIPTION
## UAT row 85 — a fully voucher-covered checkout still showed payment chrome

### Cause

`core/marketplace/src/components/CheckoutStep.svelte:760` (pre-fix):

```svelte
<!-- Payment method picker -->
{#if totalCost > 0}
```

That single guard wraps the Apple Pay / Mastercard / Visa tiles **and** the line
*"On **Purchase**, you'll be redirected to Stripe's PCI-compliant checkout to
complete payment securely."*

A voucher reduces **Due now**, not `totalCost` — the credit is subtracted for
display (`Math.max(0, totalCost - creditBaisa)`) while `totalCost` keeps its
original value. So on a fully-covered order the guard stays true and the page
renders card chrome directly beside:

```
Total (monthly)          OMR 9.000
Credit available        -OMR 86.000
Due now                  OMR 0.000
✓ Credit covers this order — no card charge needed.
[ Launch my Organization → ]
```

The component already knew the answer — `creditCovers` was derived two lines
above and used by the button — the payment block just never consulted it.

### Why the row was stamped ✅ with the bug on screen

The row-85 walk evidence in `docs/ledger/UAT.md` asserts *"ZERO Stripe elements on
the page (no `iframe[src*=stripe]`, no `cardnumber` input, no `[data-stripe]`)"*.

That assertion **cannot fail**. A grep for `stripe.js|@stripe/|loadStripe|cardnumber|iframe`
across `core/marketplace/src` returns **nothing** — the funnel has no card form on
any path; payment is a redirect handled server-side. The walk passed on an empty
set while the picker and the redirect copy were rendering.

### Fix

- New `core/marketplace/src/lib/checkoutPaymentGate.ts` — `creditCoversOrder()` and
  `chargesCustomer()`, the single definition of "will this order actually charge
  the customer".
- `CheckoutStep.svelte` derives `willCharge` from it and gates **only** the tiles,
  the "Payment method" heading and the Stripe redirect line on it. `creditCovers`
  now reuses the same predicate instead of re-deriving the comparison inline.
- The voucher/promo input stays **outside** the new gate deliberately. It is
  additive credit, not a payment method; gating the whole block would make the
  input vanish the instant a code covered the total, stranding a customer who
  mistyped one. A regression test pins this.

### Test — failing before, passing after

`core/marketplace/src/lib/checkoutPaymentGate.test.ts` does **not** assert "no card
form" (that would pass trivially, as above). It resolves the template's own
`{#if}` guard around each piece of payment chrome, substitutes the component's
`$derived` declaration, and **evaluates** it for a covered order.

**Before the fix** (`git checkout -- src/components/CheckoutStep.svelte`, test kept):

```
× the Stripe redirect copy is not rendered when credit covers the order
× the "Payment method" heading is not rendered when credit covers the order
× the aria-label="Apple Pay" tile is not rendered when credit covers the order
× the aria-label="Mastercard" tile is not rendered when credit covers the order
× the aria-label="Visa" tile is not rendered when credit covers the order
× payment chrome is gated strictly deeper than the voucher input

AssertionError: guard `totalCost > 0` still renders payment chrome when a
voucher covers the order: expected true to be false

 Test Files  1 failed (1)
      Tests  6 failed | 13 passed (19)
```

**After the fix** — full module suite, not just the new file:

```
 Test Files  7 passed (7)
      Tests  107 passed | 1 expected fail (108)
```

Guards that keep this test honest:

- **Counter-case**: each piece of chrome must still render for a paying customer
  (`creditBaisa = 0`) — a constant-`false` gate would fail this.
- **Vacuity control**: every template anchor must be found, and an `{:else}`
  branch is a hard error rather than a silently-false guard.
- **Documented trap**: a final control asserts the funnel has no card-collection
  surface at all, recording *why* the obvious test would have proved nothing.

### Other gates run

```
npm run build   → 11 page(s) built, [build] Complete!
postbuild       → [domain-hygiene] OK — 37 served file(s) scanned, zero banned domain literals (#3376)
```

Both were chained ahead of the commit (`npm test && npm run build && git commit && git push`).

### Not in scope

`docs/ledger/UAT.md` row 85 still carries its ✅ stamp from the hw292-2026-08-09
walk. Per the ledger rules the stamp flips on a re-walk against a deployed build,
not on PR merge — this PR does not touch it.

Refs #5926
Refs #3376
