### PR TITLE
fix(catalyst-api): per-Org console listeners span every region the ELB pool does (Refs #5246)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh.go
@@ -142,7 +142,7 @@ func (h *Handler) reconcileOrgAppSurfaceAcrossRegions(ctx context.Context, deps 
 		return
 	}
 
-	targets := h.orgConsoleTLSTargets(deps)
+	targets, _ := h.orgConsoleTLSTargets(deps)
 	if len(targets) < 2 {
 		// Single-region Sovereign (or a mothership, where orgConsoleTLSTargets
 		// deliberately refuses to fan out). Nothing to mirror and nothing to

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
@@ -99,6 +99,8 @@ package handler
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -112,6 +114,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
@@ -331,40 +334,177 @@ func orgConsoleTLSSecondaryRegions(clusterIDs []string) map[string]string {
 	return out
 }
 
+// orgConsoleTLSSelfDeploymentID resolves THIS chroot's deployment id — the
+// `<depID>` prefix of every `<depID>-<regionKey>.yaml` secondary kubeconfig on
+// the catalyst-api-deployments PVC, and therefore the key that turns the
+// on-disk kubeconfig set into a region set.
+//
+// Env first (CATALYST_SELF_DEPLOYMENT_ID — the orchestrator-stamped var
+// k8scache.buildChrootClusterRef reads for exactly the same purpose). Falls
+// back to deriving it from the k8sCache cluster set: on a chroot that set is
+// one primary plus its `<primary>-<region>` secondaries, so the primary is the
+// single id that is not another id's hyphen-suffixed child. Returns "" when
+// the set is ambiguous (two unrelated ids — a mothership cache), which makes
+// every caller degrade to the pre-#5246 k8sCache-only behaviour rather than
+// guess a prefix and read another deployment's kubeconfigs.
+func orgConsoleTLSSelfDeploymentID(clusterIDs []string) string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID")); v != "" {
+		return v
+	}
+	roots := make([]string, 0, 1)
+	for _, id := range clusterIDs {
+		child := false
+		for _, p := range clusterIDs {
+			if p != id && strings.HasPrefix(id, p+"-") {
+				child = true
+				break
+			}
+		}
+		if !child {
+			roots = append(roots, id)
+		}
+	}
+	if len(roots) != 1 {
+		return ""
+	}
+	return roots[0]
+}
+
+// orgConsoleTLSPoolRegions returns `regionKey -> kubeconfig path` for every
+// secondary region that is IN THE CONSOLE ELB BACKEND POOL.
+//
+// 🛑 #5246 — this MUST stay the same enumeration the pool writer uses. The
+// console ELB's member set is built by discoverSecondaryNodeInternalIPs
+// (post_handover_gateway_elb.go:264-269) from the on-disk
+// `<depID>-<regionKey>.yaml` files, whose own godoc calls that set "the
+// authoritative source of which secondary regions exist". Deriving the
+// LISTENER region set from a different source is what produced the defect:
+// PR #5246 spanned the pool across every region (so the shared console EIP
+// round-robins onto region-b's cilium-envoy) while the listener writer stayed
+// on h.k8sCache.Clusters() — a set that DROPS a region whose AddCluster failed
+// (k8scache.NewFactory logs "skipping cluster" and continues) or that has not
+// yet been re-registered after a restart. A region in the pool with no per-Org
+// listener resets the TLS handshake, which is the measured 5/10 on
+// console.<slug>.<parent> against a 10/10 apex control on the same VIP.
+func orgConsoleTLSPoolRegions(depID string) map[string]string {
+	if strings.TrimSpace(depID) == "" {
+		return nil
+	}
+	dir := secondaryKubeconfigsDir()
+	keys := onDiskSecondaryKubeconfigKeys(dir, depID)
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(keys))
+	for _, k := range keys {
+		out[k] = filepath.Join(dir, depID+"-"+k+".yaml")
+	}
+	return out
+}
+
+// orgConsoleTLSClientsFromKubeconfig builds the dynamic + core clients for one
+// secondary region straight off its on-disk kubeconfig — the fallback the
+// #5246 fix needs when a pool region is absent from h.k8sCache. A package var
+// so tests inject fakes without a live apiserver.
+var orgConsoleTLSClientsFromKubeconfig = func(path string) (dynamic.Interface, kubernetes.Interface, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	restCfg.Timeout = 20 * time.Second
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	core, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return dyn, core, nil
+}
+
 // orgConsoleTLSTargets resolves every region cluster the per-Org console
-// gateway surface must be written to. The host region always leads; secondary
-// regions are appended ONLY on a chroot (SOVEREIGN_FQDN set) — on the
-// mothership h.k8sCache holds EVERY managed Sovereign's clusters (#3987) and
-// a blind fan-out would write per-Org listeners onto alien deployments.
-// This is the same per-region client seam the D20 jobs fan-out
-// (chrootSeedSecondaryRegions) and the /cloud page use — no new plumbing.
-func (h *Handler) orgConsoleTLSTargets(deps *sovereignDeps) []orgConsoleTLSTarget {
-	targets := []orgConsoleTLSTarget{{region: orgConsoleTLSHostRegion, dyn: deps.dyn, core: deps.core}}
-	if h.k8sCache == nil || !isChroot() {
-		return targets
+// gateway surface must be written to, plus the region keys it could NOT reach.
+// The host region always leads; secondary regions are appended ONLY on a
+// chroot (SOVEREIGN_FQDN set) — on the mothership h.k8sCache holds EVERY
+// managed Sovereign's clusters (#3987) and a blind fan-out would write per-Org
+// listeners onto alien deployments.
+//
+// #5246 — the region set is the CONSOLE ELB POOL's region set, not
+// h.k8sCache's. h.k8sCache is tried first (it is warm, informer-backed, and
+// the same seam the D20 jobs fan-out and the /cloud page use); every pool
+// region it does not cover is then reached directly through its on-disk
+// kubeconfig. A pool region that neither path can build a client for is
+// returned in `unreached` so the caller reports NOT-ready instead of logging
+// "admitted in every region" over a target list that silently lost a region.
+func (h *Handler) orgConsoleTLSTargets(deps *sovereignDeps) (targets []orgConsoleTLSTarget, unreached []string) {
+	targets = []orgConsoleTLSTarget{{region: orgConsoleTLSHostRegion, dyn: deps.dyn, core: deps.core}}
+	if !isChroot() {
+		return targets, nil
 	}
-	secondaries := orgConsoleTLSSecondaryRegions(h.k8sCache.Clusters())
-	cids := make([]string, 0, len(secondaries))
-	for cid := range secondaries {
-		cids = append(cids, cid)
+
+	covered := map[string]bool{}
+	var clusterIDs []string
+	if h.k8sCache != nil {
+		clusterIDs = h.k8sCache.Clusters()
+		secondaries := orgConsoleTLSSecondaryRegions(clusterIDs)
+		cids := make([]string, 0, len(secondaries))
+		for cid := range secondaries {
+			cids = append(cids, cid)
+		}
+		sort.Strings(cids)
+		for _, cid := range cids {
+			region := secondaries[cid]
+			dyn, err := h.k8sCache.DynamicClientFor(cid)
+			if err != nil || dyn == nil {
+				h.log.Warn("org-console-tls: secondary region dynamic client unavailable in k8sCache — falling back to its on-disk kubeconfig (#5246)",
+					"clusterID", cid, "region", region, "err", err)
+				continue
+			}
+			covered[region] = true
+			targets = append(targets, orgConsoleTLSTarget{
+				region:    region,
+				clusterID: cid,
+				dyn:       dyn,
+				core:      h.k8sCache.CoreClient(cid),
+			})
+		}
 	}
-	sort.Strings(cids)
-	for _, cid := range cids {
-		region := secondaries[cid]
-		dyn, err := h.k8sCache.DynamicClientFor(cid)
-		if err != nil || dyn == nil {
-			h.log.Warn("org-console-tls: secondary region dynamic client unavailable — its per-Org gateway surface is NOT written this pass; the next reconcile retries (#5511)",
-				"clusterID", cid, "region", region, "err", err)
+
+	// #5246 — close the gap between the pool's region set and the listener
+	// writer's. Anything the ELB forwards to must carry the listener.
+	depID := orgConsoleTLSSelfDeploymentID(clusterIDs)
+	pool := orgConsoleTLSPoolRegions(depID)
+	regions := make([]string, 0, len(pool))
+	for region := range pool {
+		regions = append(regions, region)
+	}
+	sort.Strings(regions)
+	for _, region := range regions {
+		if covered[region] {
 			continue
 		}
+		dyn, core, err := orgConsoleTLSClientsFromKubeconfig(pool[region])
+		if err != nil || dyn == nil {
+			unreached = append(unreached, region)
+			h.log.Error("org-console-tls: region is in the console ELB backend pool but NO client could be built for it — its per-Org listeners cannot be written and ~1/N of customer connections will TLS-reset there (#5246)",
+				"region", region, "kubeconfig", pool[region], "err", err)
+			continue
+		}
+		h.log.Info("org-console-tls: pool region absent from k8sCache — writing its per-Org gateway surface through its on-disk kubeconfig (#5246)",
+			"region", region, "deploymentID", depID)
 		targets = append(targets, orgConsoleTLSTarget{
 			region:    region,
-			clusterID: cid,
+			clusterID: depID + "-" + region,
 			dyn:       dyn,
-			core:      h.k8sCache.CoreClient(cid),
+			core:      core,
 		})
 	}
-	return targets
+	return targets, unreached
 }
 
 // provisionOrgConsoleTLS is the best-effort, non-gating finalisation step that
@@ -404,7 +544,7 @@ func (h *Handler) provisionOrgConsoleTLS(ctx context.Context, rec store.Organiza
 		return
 	}
 
-	targets := h.orgConsoleTLSTargets(deps)
+	targets, unreachedPoolRegions := h.orgConsoleTLSTargets(deps)
 	regions := make([]string, 0, len(targets))
 	for _, tgt := range targets {
 		regions = append(regions, tgt.region)
@@ -438,6 +578,18 @@ func (h *Handler) provisionOrgConsoleTLS(ctx context.Context, rec store.Organiza
 	// PRESENT in status.listeners; one deadline bounds the whole pass.
 	admitDeadline := time.Now().Add(orgConsoleListenerAdmitBudget)
 	admitted := true
+	// #5246 — a region the console ELB pool forwards to but which produced no
+	// target was never written and is therefore never read back either. Left
+	// unaccounted it turns the loop below into a guard that cannot fail: it
+	// verifies only the regions we chose to write. Count it as NOT admitted.
+	if len(unreachedPoolRegions) > 0 {
+		admitted = false
+		h.log.Error("org-console-tls: console ELB pool spans regions this Sovereign cannot write listeners into — those regions TLS-reset every per-Org console connection they receive (#5246)",
+			"org_tenant_id", rec.OrganizationID,
+			"console_host", names.ConsoleHost,
+			"unreached_pool_regions", strings.Join(unreachedPoolRegions, ","),
+		)
+	}
 	for _, tgt := range targets {
 		if err := waitOrgConsoleListenersAdmitted(ctx, tgt.dyn, names, admitDeadline); err != nil {
 			admitted = false

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_pool_regions_5246_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_pool_regions_5246_test.go
@@ -1,0 +1,391 @@
+// org_console_tls_pool_regions_5246_test.go — #5246, the region-set-divergence
+// lock.
+//
+// THE DEFECT THESE TESTS GO RED ON. PR #5246 (merge 6f62061a6, 2026-07-19)
+// replaced `local.primary_lb_node_ips` with `local.gateway_lb_members` so the
+// gateway AND console ELB backend pools span EVERY region's nodes — correct,
+// and required for region-kill EIP failover (#5244). The pool's region set is
+// enumerated by discoverSecondaryNodeInternalIPs (post_handover_gateway_elb.go)
+// from the on-disk `<depID>-<regionKey>.yaml` kubeconfigs, whose own godoc
+// calls that "the authoritative source of which secondary regions exist".
+//
+// The per-Org LISTENER writer was left on a DIFFERENT region set:
+// h.k8sCache.Clusters(). That set is lossy by construction —
+// k8scache.NewFactory logs `k8scache: skipping cluster` and CONTINUES when a
+// cluster's AddCluster fails (factory.go:550-556), and a restarted chroot
+// re-registers its secondaries asynchronously (hw292 logs the secondary being
+// added 5m06s after boot, as a "runtime add"). Every region in the pool but
+// absent from the cache receives customer traffic on the shared console EIP
+// and has no `console-https-<slug>` listener to answer with, so the connection
+// is reset at the TLS handshake.
+//
+// Measured on hw292 (dep 1c56518035a83e03) 2026-08-09, region A vs region B
+// `kube-system/cilium-gateway-console` spec.listeners:
+//
+//	region A: console-https-uatco *.uatco.omani.homes, console-https-walk-stranger-two …
+//	region B: console-https-r17probe *.r17probe.omani.homes   <- a DELETED Org, and nothing else
+//
+// Both regions' nodes are in the console ELB pool, so fresh-TCP samples of
+// https://console.uatco.omani.homes measure 5/10 HTTP 200 against a 10/10
+// control on https://console.hw292.omani.works — same VIP, same ELB, same
+// port. (Fresh TCP per sample: a browser or an HTTP/2 loop pins one backend
+// and structurally cannot sample a round-robin.)
+//
+// WHAT MAKES THESE TESTS ABLE TO FAIL. Both drive the real emitter with a
+// k8sCache that carries ONLY the primary — the lossy state — while the on-disk
+// kubeconfig set (the ELB pool's own source) names a secondary region. On the
+// unfixed tree orgConsoleTLSTargets consults only the cache, returns the host
+// target alone, and provisionOrgConsoleTLS then reports "listener pair
+// admitted in every region" over a one-region list: the region that actually
+// drops customer traffic is neither written nor read back, so the existing
+// admission guard passes on the exact live cluster state that is broken.
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// seedELBPoolKubeconfigs writes the on-disk kubeconfig set that DEFINES the
+// console ELB backend pool's region span — `<depID>.yaml` for the primary plus
+// one `<depID>-<regionKey>.yaml` per secondary — and points
+// secondaryKubeconfigsDir() at it. Contents are irrelevant: the pool writer
+// and this fix both key off the FILENAMES (onDiskSecondaryKubeconfigKeys), and
+// the client builder is stubbed per-test.
+func seedELBPoolKubeconfigs(t *testing.T, depID string, secondaryRegions ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+			t.Fatalf("seed kubeconfig %s: %v", name, err)
+		}
+	}
+	write(depID + ".yaml")
+	for _, r := range secondaryRegions {
+		write(depID + "-" + r + ".yaml")
+	}
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	return dir
+}
+
+// stubPoolRegionClients makes the on-disk-kubeconfig fallback hand back the
+// given fakes, keyed by the kubeconfig file's basename. A path with no entry
+// returns an error — that is the "region in the pool, no client obtainable"
+// case, which must be reported, never silently dropped.
+func stubPoolRegionClients(t *testing.T, byFile map[string]struct {
+	dyn  dynamic.Interface
+	core kubernetes.Interface
+},
+) {
+	t.Helper()
+	prev := orgConsoleTLSClientsFromKubeconfig
+	orgConsoleTLSClientsFromKubeconfig = func(path string) (dynamic.Interface, kubernetes.Interface, error) {
+		c, ok := byFile[filepath.Base(path)]
+		if !ok {
+			return nil, nil, errors.New("dial tcp: connect: connection refused")
+		}
+		return c.dyn, c.core, nil
+	}
+	t.Cleanup(func() { orgConsoleTLSClientsFromKubeconfig = prev })
+}
+
+// admitPerOrgListenersOnGet makes every GET of the console Gateway on this
+// fake answer with the apex listener pair in spec AND the named per-Org
+// listeners in status.listeners — i.e. a region whose cilium-operator DID
+// admit the pair. It is what lets the "not ready" assertion below be about the
+// unreached ELB-pool region and nothing else: with the host region admitting,
+// the #5511 read-back is satisfied for every target, so the success line fires
+// on the unfixed tree and cannot fire on the fixed one.
+func admitPerOrgListenersOnGet(dyn *dynamicfake.FakeDynamicClient, perOrgListenerNames ...string) {
+	statusListeners := []any{
+		map[string]any{"name": "console-https"},
+		map[string]any{"name": "console-http"},
+	}
+	for _, n := range perOrgListenerNames {
+		statusListeners = append(statusListeners, map[string]any{"name": n})
+	}
+	dyn.PrependReactor("get", consoleGatewayGVR.Resource, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ga, ok := action.(k8stesting.GetAction)
+		if !ok || ga.GetName() != consoleGatewayName {
+			return false, nil, nil
+		}
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "Gateway",
+			"metadata": map[string]any{
+				"name": consoleGatewayName, "namespace": consoleGatewayNamespace, "generation": int64(2),
+			},
+			"spec": map[string]any{"listeners": []any{
+				map[string]any{"name": "console-https", "port": int64(8443), "protocol": "HTTPS"},
+				map[string]any{"name": "console-http", "port": int64(8080), "protocol": "HTTP"},
+			}},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{"type": "Accepted", "status": "True", "observedGeneration": int64(2)}},
+				"listeners":  statusListeners,
+			},
+		}}, nil
+	})
+}
+
+// newPoolRegionHandler wires a chroot Handler whose host region is hostDyn and
+// whose k8sCache carries ONLY the primary cluster — the lossy-cache state the
+// live defect ran in. Logs are captured so the "every region" success claim
+// can be asserted against.
+func newPoolRegionHandler(t *testing.T, depID string, hostDyn *dynamicfake.FakeDynamicClient, hostCore *k8sfake.Clientset) (*Handler, *bytes.Buffer) {
+	t.Helper()
+	shrinkAdmitBudget(t)
+	var logs bytes.Buffer
+	h := &Handler{log: slog.New(slog.NewTextHandler(&logs, nil))}
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: hostCore, dyn: hostDyn}, nil
+	})
+	h.SetOrganizationDeps(OrganizationDeps{OTECHFQDN: "hw292.omani.works"})
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clusters: []k8scache.ClusterRef{{ID: depID, DynamicClient: hostDyn, CoreClient: hostCore}},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+	return h, &logs
+}
+
+func uatcoRecord() store.OrganizationProvisionRecord {
+	return store.OrganizationProvisionRecord{
+		OrganizationID: "tid-uatco",
+		Subdomain:      "uatco",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		OTECHFQDN:      "hw292.omani.works",
+		CompanyName:    "UAT Co",
+	}
+}
+
+// listenerHostnamesAppliedTo returns listener NAME -> rendered hostname for
+// every Gateway SSA payload one region's client received. Asserting on the
+// rendered name+hostname (not merely "the Gateway was patched") is what makes
+// this able to go red on hw292: region B WAS patched there — for a different,
+// deleted Org.
+func listenerHostnamesAppliedTo(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, a := range dyn.Actions() {
+		if a.GetResource() != consoleGatewayGVR || a.GetVerb() != "patch" {
+			continue
+		}
+		pa, ok := a.(k8stesting.PatchAction)
+		if !ok || pa.GetName() != consoleGatewayName {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(pa.GetPatch(), &obj); err != nil {
+			t.Fatalf("unmarshal Gateway apply payload: %v", err)
+		}
+		listeners, found, err := unstructured.NestedSlice(obj, "spec", "listeners")
+		if err != nil || !found {
+			continue
+		}
+		for _, l := range listeners {
+			lm, ok := l.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name, _ := lm["name"].(string); name != "" {
+				hostname, _ := lm["hostname"].(string)
+				out[name] = hostname
+			}
+		}
+	}
+	return out
+}
+
+// TestProvisionOrgConsoleTLS_WritesEveryRegionInTheELBPool — #5246 lock 1.
+//
+// The console ELB pool spans region `me-east-215-b-1` (its kubeconfig is on
+// disk, which is exactly how discoverSecondaryNodeInternalIPs put that
+// region's nodes into the pool). h.k8sCache carries only the primary. The
+// per-Org listener pair MUST still be written into that region, because the
+// shared console EIP already round-robins customer TLS onto its cilium-envoy.
+//
+// UNFIXED TREE: orgConsoleTLSTargets reads h.k8sCache.Clusters() only, yields
+// the host target alone, and region B receives no apply at all.
+func TestProvisionOrgConsoleTLS_WritesEveryRegionInTheELBPool(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "dep292")
+	seedELBPoolKubeconfigs(t, "dep292", "me-east-215-b-1")
+
+	hostDyn := fakeDynForConsoleTLSWithApexPorts(t, 8443, 8080)
+	hostCore := k8sfake.NewSimpleClientset(issuedOrgWildcardSecret("org-wildcard-tls-uatco-omani-homes"))
+	regionBDyn := fakeDynForConsoleTLSWithApexPorts(t, 8443, 8080)
+	regionBCore := k8sfake.NewSimpleClientset()
+
+	stubPoolRegionClients(t, map[string]struct {
+		dyn  dynamic.Interface
+		core kubernetes.Interface
+	}{
+		"dep292-me-east-215-b-1.yaml": {dyn: regionBDyn, core: regionBCore},
+	})
+
+	h, _ := newPoolRegionHandler(t, "dep292", hostDyn, hostCore)
+	h.provisionOrgConsoleTLS(context.Background(), uatcoRecord())
+
+	for region, dyn := range map[string]*dynamicfake.FakeDynamicClient{
+		"region-a-host": hostDyn, "region-b-elb-pool": regionBDyn,
+	} {
+		applied := listenerHostnamesAppliedTo(t, dyn)
+		if got := applied["console-https-uatco"]; got != "*.uatco.omani.homes" {
+			t.Errorf("[%s] console-https-uatco hostname = %q, want %q — this region is in the console ELB pool, so every connection it receives for console.uatco.omani.homes resets at the TLS handshake",
+				region, got, "*.uatco.omani.homes")
+		}
+		if got := applied["console-http-uatco"]; got != "*.uatco.omani.homes" {
+			t.Errorf("[%s] console-http-uatco hostname = %q, want %q", region, got, "*.uatco.omani.homes")
+		}
+	}
+
+	// The listener's certificateRef must resolve in that region too — a
+	// listener pointing at a Secret that is not there closes the door just as
+	// completely (the per-region secret-split class #5394/#5406/#5414/#5416).
+	if _, err := regionBCore.CoreV1().Secrets(consoleCertNamespace).
+		Get(context.Background(), "org-wildcard-tls-uatco-omani-homes", metav1.GetOptions{}); err != nil {
+		t.Errorf("cert secret not mirrored into the ELB-pool region: %v", err)
+	}
+}
+
+// TestProvisionOrgConsoleTLS_UnreachablePoolRegionIsNotReportedReady —
+// #5246 lock 2, the vacuity lock.
+//
+// A region is in the console ELB pool and NO client can be built for it. The
+// pass must report NOT-ready and name the region. The pre-fix code path is
+// worse than merely incomplete: it drops such a region from the target list
+// before the #5511 admission read-back, so the read-back — the guard that is
+// supposed to catch a closed door — iterates only over regions we chose to
+// write and passes. A guard whose scope is decided by the same step that lost
+// the region cannot fail on this defect.
+// The single-region CONTROL is what makes the negative assertion mean
+// something: same fixture, same admitting host Gateway, one variable changed —
+// whether the ELB pool spans a second region. The control must still log the
+// success line, so "no success line" in the pool case can only be caused by
+// the unreached region and not by some unrelated failure in the fixture.
+func TestProvisionOrgConsoleTLS_UnreachablePoolRegionIsNotReportedReady(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		poolSecondaries []string
+		wantSuccessLine bool
+		wantRegionNamed string
+	}{
+		{name: "control: console ELB pool is single-region", poolSecondaries: nil, wantSuccessLine: true},
+		{name: "pool spans a region no client can be built for", poolSecondaries: []string{"me-east-215-b-1"}, wantSuccessLine: false, wantRegionNamed: "me-east-215-b-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SOVEREIGN_FQDN", "hw292.omani.works")
+			t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "dep292")
+			seedELBPoolKubeconfigs(t, "dep292", tc.poolSecondaries...)
+
+			// The host Gateway ADMITS the pair (status.listeners carries both
+			// names), so the #5511 read-back is satisfied for every region in
+			// the target list. The ONLY remaining variable is the pool span.
+			hostDyn := fakeDynForConsoleTLSWithApexPorts(t, 8443, 8080)
+			admitPerOrgListenersOnGet(hostDyn, "console-https-uatco", "console-http-uatco")
+			hostCore := k8sfake.NewSimpleClientset(issuedOrgWildcardSecret("org-wildcard-tls-uatco-omani-homes"))
+
+			// No entry for any secondary kubeconfig => the builder errors,
+			// mimicking an unreachable / unparseable secondary kubeconfig.
+			stubPoolRegionClients(t, map[string]struct {
+				dyn  dynamic.Interface
+				core kubernetes.Interface
+			}{})
+
+			h, logs := newPoolRegionHandler(t, "dep292", hostDyn, hostCore)
+			h.provisionOrgConsoleTLS(context.Background(), uatcoRecord())
+
+			out := logs.String()
+			gotSuccess := strings.Contains(out, "listener pair admitted in every region")
+			if gotSuccess != tc.wantSuccessLine {
+				t.Errorf("success line present = %t, want %t — the emitter must never claim EVERY region over a target list that silently lost one; logs:\n%s",
+					gotSuccess, tc.wantSuccessLine, out)
+			}
+			if tc.wantRegionNamed != "" && !strings.Contains(out, tc.wantRegionNamed) {
+				t.Errorf("the unreached ELB-pool region %q is not named anywhere in the output — an operator cannot act on it; logs:\n%s",
+					tc.wantRegionNamed, out)
+			}
+		})
+	}
+}
+
+// TestOrgConsoleTLSSelfDeploymentID_DerivesPrimaryWithoutEnv pins the fallback
+// used when CATALYST_SELF_DEPLOYMENT_ID is unstamped: on a chroot the cache
+// holds one primary plus its `<primary>-<region>` children, so the primary is
+// the single id that is no other id's child. An ambiguous set (a mothership
+// cache holding sibling deployments) must yield "" so the on-disk fallback
+// never reads another deployment's kubeconfigs.
+func TestOrgConsoleTLSSelfDeploymentID_DerivesPrimaryWithoutEnv(t *testing.T) {
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "")
+	for _, tc := range []struct {
+		name string
+		ids  []string
+		want string
+	}{
+		{"primary only", []string{"1c56518035a83e03"}, "1c56518035a83e03"},
+		{"primary + secondary", []string{"1c56518035a83e03", "1c56518035a83e03-me-east-215-b-1"}, "1c56518035a83e03"},
+		{"sibling deployments (mothership)", []string{"depA", "depB"}, ""},
+		{"empty", nil, ""},
+	} {
+		if got := orgConsoleTLSSelfDeploymentID(tc.ids); got != tc.want {
+			t.Errorf("%s: orgConsoleTLSSelfDeploymentID(%v) = %q, want %q", tc.name, tc.ids, got, tc.want)
+		}
+	}
+}
+
+// TestOrgConsoleTLSPoolRegions_MatchesTheELBPoolEnumeration pins the fix's
+// central claim: the listener writer's region set is read from the SAME files
+// the console ELB pool writer reads. `.nodeip` sidecars and the primary's own
+// `<depID>.yaml` are not regions; another deployment's kubeconfigs are not
+// ours.
+func TestOrgConsoleTLSPoolRegions_MatchesTheELBPoolEnumeration(t *testing.T) {
+	dir := seedELBPoolKubeconfigs(t, "dep292", "me-east-215-b-1", "eu-west-101-c-1")
+	if err := os.WriteFile(filepath.Join(dir, "dep292-me-east-215-b-1.nodeip"), []byte("10.218.1.5"), 0o600); err != nil {
+		t.Fatalf("seed nodeip sidecar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "otherdep-ap-southeast-3.yaml"), []byte("apiVersion: v1\n"), 0o600); err != nil {
+		t.Fatalf("seed alien kubeconfig: %v", err)
+	}
+
+	got := orgConsoleTLSPoolRegions("dep292")
+	want := map[string]string{
+		"me-east-215-b-1": filepath.Join(dir, "dep292-me-east-215-b-1.yaml"),
+		"eu-west-101-c-1": filepath.Join(dir, "dep292-eu-west-101-c-1.yaml"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("pool regions = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("pool region %q = %q, want %q", k, got[k], v)
+		}
+	}
+	if r := orgConsoleTLSPoolRegions(""); r != nil {
+		t.Errorf("blank deployment id must yield no regions, got %v", r)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reap.go
@@ -198,8 +198,11 @@ func (h *Handler) reapOrgConsoleTLSOrphans(ctx context.Context, deps *sovereignD
 		return
 	}
 
-	// 1. Scan every region FIRST.
-	targets := h.orgConsoleTLSTargets(deps)
+	// 1. Scan every region FIRST. A pool region with no client (#5246) is
+	// simply not scanned and therefore not reaped from — the reap is
+	// per-region and absent-as-success, so an unreachable region leaves its
+	// orphans for the next pass rather than blocking the reachable ones.
+	targets, _ := h.orgConsoleTLSTargets(deps)
 	scans := make([]*orgConsoleReapScan, 0, len(targets))
 	for _, tgt := range targets {
 		scans = append(scans, h.scanOrgConsoleArtifacts(ctx, tgt, sovereignFQDN))


### PR DESCRIPTION
Refs #5246

## The cause — one file:line

`products/catalyst/bootstrap/api/internal/handler/org_console_tls.go:341` —
`orgConsoleTLSTargets` derived the per-Org **listener** region set from
`h.k8sCache.Clusters()`, while the console **ELB backend pool** derives its
region set from a completely different source.

PR #5246 (merge `6f62061a6`, 2026-07-19) was correct: it replaced
`local.primary_lb_node_ips` with `local.gateway_lb_members` so both public ELB
pools span every region's nodes, which is what makes the EIPs survive a
region-kill (#5244). The pool's region set is enumerated by
`discoverSecondaryNodeInternalIPs`
(`post_handover_gateway_elb.go:264-269`) from the on-disk
`<depID>-<regionKey>.yaml` secondary kubeconfigs — whose own godoc calls that
set *"the authoritative source of which secondary regions exist"*.

The listener writer was never moved onto that set. `h.k8sCache.Clusters()` is
**lossy by construction**:

- `k8scache.NewFactory` logs `k8scache: skipping cluster` and **continues**
  when a cluster's `AddCluster` fails (`internal/k8scache/factory.go:550-556`);
- a restarted chroot re-registers secondaries asynchronously — hw292's own log
  shows the secondary arriving as a *"runtime add"* 5m06s after boot.

A region that is in the pool but missing from that cache receives customer TLS
on the shared console EIP and has no `console-https-<slug>` listener to answer
with, so the connection is reset at the handshake.

Worse, the loss was **silent**. The dropped region never entered `targets`, so
the #5511 admission read-back — the guard meant to catch a closed door — never
looked at it, and `provisionOrgConsoleTLS` logged
`listener pair admitted in every region` over a one-region list. A guard whose
scope is decided by the same step that lost the region cannot fail on this
defect.

## Live symptom (hw292, dep `1c56518035a83e03`, 2026-08-09/10)

`kube-system/cilium-gateway-console` `spec.listeners`, read-only:

| | region A | region B |
|---|---|---|
| apex | `console-https`, `api-https`, `marketplace-https` | same |
| per-Org | `console-https-uatco` `*.uatco.omani.homes`, `console-https-walk-stranger-two` `*.walk-stranger-two.omani.rest` | `console-https-r17probe` `*.r17probe.omani.homes` — a **deleted** Org, and nothing else |

Both regions' nodes are in the console ELB pool. Fresh-TCP sampling (separate
`curl --no-keepalive --http1.1` invocations — a browser or an HTTP/2 loop pins
one backend and structurally cannot sample a round-robin):

```
console.uatco.omani.homes     000 200 000 000 200 200 200 000 000 200   -> 5/10
console.hw292.omani.works     200 200 200 200 200 200 200 200 200 200   -> 10/10   (control: same VIP, same ELB, same port)
```

Region-B `catalyst-system` HTTPRoutes tell the same story: only
`catalyst-ui-r17probe-omani-homes` exists there; both live Orgs' console and
app routes are region-A-only.

## The fix

Derive the listener writer's region set from **the console ELB pool's own
source**, and never report ready over a set that lost a region.

`orgConsoleTLSTargets` now returns `(targets, unreached)`:

1. `h.k8sCache` is still tried first — it is warm, informer-backed, and the
   same seam the D20 jobs fan-out and `/cloud` use. Nothing about the healthy
   path changes.
2. Every region in `orgConsoleTLSPoolRegions(depID)` — i.e. every
   `<depID>-<regionKey>.yaml` on the deployments PVC, byte-identical to the
   enumeration the pool writer performs — that the cache did not cover is
   reached **directly through its on-disk kubeconfig**.
3. A pool region neither path can build a client for is returned in
   `unreached`. `provisionOrgConsoleTLS` counts that as **not admitted**, names
   the region, and never emits the "admitted in every region" line.

`orgConsoleTLSSelfDeploymentID` resolves the `<depID>` prefix from
`CATALYST_SELF_DEPLOYMENT_ID` (the same var `k8scache.buildChrootClusterRef`
reads) and falls back to deriving it from the cache set. An ambiguous set —
a mothership cache holding sibling deployments — yields `""`, so the on-disk
path is skipped entirely rather than guessing a prefix and reading another
deployment's kubeconfigs. The whole block stays behind the existing
`isChroot()` gate, so #3987 (mothership must never fan out onto alien
deployments) is unchanged, and a single-region Sovereign finds no secondary
files and behaves exactly as before.

### Why not the other option

The alternative in scope was *scope the ELB pool down to the regions that have
listeners*. Rejected from the code: the pool spanning all regions **is** the
region-kill failover mechanism. `#5246`'s own root-cause dump shows both pools
holding only `10.208.1.x` region-a members, the TCP health monitors correctly
draining them on the kill, the pools going empty, and both EIPs black-holing
for the whole outage while region-b's `cilium-envoy` was serving `node:443`.
Narrowing the pool would trade a per-Org TLS reset for total loss of the
gateway + console EIPs on a region-kill — it would re-open #5244 in exchange
for #5246.
The pool is right; the listener set was the thing that had to follow it.

No NodePort anywhere: this changes which apiserver receives an SSA patch, not a
single port. `scripts/check-no-nodeports.sh` passes on the diff.

## The test — failing, then passing

`org_console_tls_pool_regions_5246_test.go`. Both behavioural tests drive the
real emitter with a k8sCache holding **only the primary** (the lossy state)
while the on-disk kubeconfig set — the ELB pool's own source — names a
secondary region.

**BEFORE** (`orgConsoleTLSTargets` returning early with the k8sCache-only set,
i.e. the shipped-today body):

```
--- FAIL: TestProvisionOrgConsoleTLS_WritesEveryRegionInTheELBPool (0.05s)
    org_console_tls_pool_regions_5246_test.go:259: [region-b-elb-pool] console-https-uatco hostname = "", want "*.uatco.omani.homes" — this region is in the console ELB pool, so every connection it receives for console.uatco.omani.homes resets at the TLS handshake
    org_console_tls_pool_regions_5246_test.go:263: [region-b-elb-pool] console-http-uatco hostname = "", want "*.uatco.omani.homes"
    org_console_tls_pool_regions_5246_test.go:272: cert secret not mirrored into the ELB-pool region: secrets "org-wildcard-tls-uatco-omani-homes" not found
--- FAIL: TestProvisionOrgConsoleTLS_UnreachablePoolRegionIsNotReportedReady (0.00s)
    org_console_tls_pool_regions_5246_test.go:326: success line present = true, want false — the emitter must never claim EVERY region over a target list that silently lost one; logs:
        ... msg="org-console-tls: ensured per-Org console TLS trio — listener pair admitted in every region" console_host=console.uatco.omani.homes regions=host
    org_console_tls_pool_regions_5246_test.go:330: the unreached ELB-pool region "me-east-215-b-1" is not named anywhere in the output — an operator cannot act on it
    --- PASS: .../control:_console_ELB_pool_is_single-region (0.00s)
    --- FAIL: .../pool_spans_a_region_no_client_can_be_built_for (0.00s)
FAIL
```

Note `regions=host` in the captured log next to the words *"admitted in every
region"* — that is the defect stated in the emitter's own voice.

**AFTER**:

```
--- PASS: TestProvisionOrgConsoleTLS_WritesEveryRegionInTheELBPool (0.05s)
--- PASS: TestProvisionOrgConsoleTLS_UnreachablePoolRegionIsNotReportedReady (0.00s)
    --- PASS: .../control:_console_ELB_pool_is_single-region (0.00s)
    --- PASS: .../pool_spans_a_region_no_client_can_be_built_for (0.00s)
--- PASS: TestOrgConsoleTLSSelfDeploymentID_DerivesPrimaryWithoutEnv (0.00s)
--- PASS: TestOrgConsoleTLSPoolRegions_MatchesTheELBPoolEnumeration (0.00s)
ok  	.../internal/handler	0.129s
```

Anti-vacuity properties, deliberate:

- The listener assertion is on the **rendered name + hostname** of the SSA
  payload each region received, not on "was the Gateway patched in this
  region". The weaker check answers YES on the exact hw292 state, because
  `r17probe`'s patch satisfies it.
- The not-ready test is a two-case table whose **control** (pool is
  single-region, everything else identical, host Gateway admitting) must still
  log the success line — and it does, on both trees. That is what makes "no
  success line" in the pool case attributable to the unreached region and not
  to some unrelated fixture failure.
- `TestOrgConsoleTLSPoolRegions_MatchesTheELBPoolEnumeration` pins the fix's
  central claim — same files as the pool writer — and excludes `.nodeip`
  sidecars, the primary's own `<depID>.yaml`, and another deployment's
  kubeconfigs.

## Gates run

- `go build ./...` — green.
- `go vet ./...` — green.
- `go test ./... -count=1` across `products/catalyst/bootstrap/api` — **all
  packages ok**, including the 256s handler suite.
- `bash scripts/check-no-nodeports.sh` — **exit 0**, all phases: Phase 0 vacuity
  self-test OK (pattern matches 4/4 banned forms, rejects 2/2 allowed), Phase 1
  static source scan OK, Phase 1b IaC port-literal scan OK, Phase 2 rendered
  charts OK. The CI job `Reject NodePorts (sources + rendered charts)` also
  passed on this branch. This diff touches four `.go` files and no chart, YAML,
  or IaC — it changes which apiserver receives an SSA patch, not a port.

## Not claimed

This is a source fix, not a live proof. hw292 currently runs
`catalyst-api:fad88bd`, which predates even #5635 (`main.go` in that commit has
no `ReconcileOrgConsoleTLSFromOrgCRs` call), so the 5/10 above is the
pre-#5635 **and** pre-this-PR shape. The DoD gate is a walk on an env carrying
this image: re-read both regions' `cilium-gateway-console` listener sets and
re-run the fresh-TCP sample on a funnel Org's console host, evidence onto the
UAT rows (R17, 86, 87, 88, 90, 91, 94, 217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
