### PR TITLE
fix(jobs): an unterminated run must not bury a failed one (UAT row 164)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
@@ -135,6 +135,68 @@ const (
 	ObsHealthFailing  = "failing"
 )
 
+// isTerminalRunStatus reports whether a run status carries a VERDICT — the
+// run reached a terminal state and its outcome is known. A pending or
+// still-running run has produced no verdict yet, which is the distinction
+// adoptRunHeadline turns on.
+func isTerminalRunStatus(status string) bool {
+	return status == ObsStatusSucceeded || status == ObsStatusFailed
+}
+
+// adoptRunHeadline resolves ONE run's outcome onto a collapsed leaf's headline
+// (Status / Message / ObservedAt). Every leaf that folds N runs into one row —
+// the cron leaf, the task leaf, and the Day-2 scanner row — shares it, so the
+// rules below cannot drift apart between the three.
+//
+// Two rules, and the second one is the #5926-class fix:
+//
+//  1. RECENCY — the most recent run wins. The apiserver returns collapsed runs
+//     in no guaranteed chronological order, so a stale Succeeded arriving after
+//     a fresh Failed must not overwrite the failure.
+//
+//  2. VERDICT — a run that has not TERMINATED carries no verdict, so it may
+//     never erase a terminal `failed` headline, and a real failure displaces a
+//     no-verdict headline whatever order the runs were listed in.
+//
+// Rule 1 alone was the defect behind UAT row 164. It compared an unterminated
+// run's startedAt against a terminated run's finishedAt — two different clocks —
+// so a newer in-flight run silently downgraded a real failure to "running".
+// Measured on hw292: Job syft-grype-bp-syft-grype-29763030 was
+// Failed/BackoffLimitExceeded (2026-08-03) while its successor
+// syft-grype-bp-syft-grype-29770230 sat two days stale with zero active pods and
+// no conditions at all. Both fold onto `task-syft-sbom`; the failed run was
+// recorded correctly as an Execution, but the LEAF read `installing`. Result:
+// 0 failed leaves out of 183 on a cluster that had a failed Job — precisely the
+// "invisible failing class" the §5a ingestion exists to kill (#3646).
+//
+// The failure therefore stands until a later run actually TERMINATES. A
+// subsequent Succeeded run clears it through rule 1 as normal, so the leaf is
+// not stuck red forever.
+func adoptRunHeadline(c *ReconcilerObservation, status, message string, runAt time.Time) {
+	set := func() {
+		c.Status = status
+		c.Message = message
+		if !runAt.IsZero() {
+			c.ObservedAt = runAt
+		}
+	}
+	switch {
+	case !isTerminalRunStatus(status) && c.Status == ObsStatusFailed:
+		// (2) An in-flight run never clears a recorded failure.
+		return
+	case status == ObsStatusFailed && !isTerminalRunStatus(c.Status):
+		// (2) A real failure always displaces a no-verdict headline, even when
+		// the apiserver listed the in-flight run first.
+		set()
+		return
+	}
+	// (1) Recency, comparing like with like. The first run always wins (the
+	// default ObservedAt is zero); later runs override only when not older.
+	if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
+		set()
+	}
+}
+
 // ReconcilerObservation is one observed reconciler object. The bridge
 // upserts exactly one leaf Job per observation, keyed by Kind+Name.
 type ReconcilerObservation struct {
@@ -321,23 +383,10 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 						FinishedAt: finished,
 						Message:    "run " + u.GetName() + ": " + status,
 					})
-					// The cron leaf's headline status reflects its MOST RECENT
-					// run, not list order (the apiserver returns owned Jobs in
-					// no guaranteed chronological order, so a stale Succeeded
-					// run arriving after a fresh Failed one must not overwrite
-					// the failure — that would re-introduce the silent-green
-					// the §5a ingestion exists to kill). Recency = the run's
-					// finish time, falling back to its start for an in-flight
-					// run. The first owned run always wins (default ObservedAt
-					// is zero); later runs override only when strictly newer.
-					runAt := firstNonZero(finished, started)
-					if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
-						c.Status = status
-						c.Message = "last run " + u.GetName() + ": " + status
-						if !runAt.IsZero() {
-							c.ObservedAt = runAt
-						}
-					}
+					// Headline = the most recent run, and never a no-verdict
+					// state over a recorded failure. See adoptRunHeadline.
+					adoptRunHeadline(c, status, "last run "+u.GetName()+": "+status,
+						firstNonZero(finished, started))
 				}
 				continue
 			}
@@ -381,18 +430,9 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 					FinishedAt: finished,
 					Message:    "run " + u.GetName() + ": " + status,
 				})
-				// Headline status reflects the MOST RECENT run (same recency
-				// rule as the cron leaf): a stale Succeeded run arriving after
-				// a fresh Failed one must not overwrite the failure. Recency =
-				// finish time, falling back to start for an in-flight run.
-				runAt := firstNonZero(finished, started)
-				if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
-					c.Status = status
-					c.Message = "last run " + u.GetName() + ": " + status
-					if !runAt.IsZero() {
-						c.ObservedAt = runAt
-					}
-				}
+				// Same headline resolution as the cron leaf. See adoptRunHeadline.
+				adoptRunHeadline(c, status, "last run "+u.GetName()+": "+status,
+					firstNonZero(finished, started))
 				continue
 			}
 			out = append(out, ReconcilerObservation{
@@ -668,12 +708,11 @@ func scannerIdentity(u *unstructured.Unstructured) (string, bool) {
 // foldScannerRun records ONE scanner run as an Execution on the single
 // identity-keyed scanner row (#3925), creating the row on first sight. This
 // is the collapse: N scan Jobs sharing an identity ⇒ 1 row + N Executions
-// (run-history), never N rows. The headline status is recency-resolved (the
-// MOST RECENT run wins — a stale Succeeded arriving after a fresh Failed must
-// not overwrite the failure), identical to the cron + task leaf recency rule,
-// so the row never flaps on re-ingest. The row is indexed by position in
-// `out` (never a cached pointer) for the same reallocation-safety reason
-// cronIdx/taskIdx are.
+// (run-history), never N rows. The headline is resolved by adoptRunHeadline —
+// the same rules the cron + task leaves use, so the row never flaps on
+// re-ingest and an unterminated run can never bury a failed one. The row is
+// indexed by position in `out` (never a cached pointer) for the same
+// reallocation-safety reason cronIdx/taskIdx are.
 func foldScannerRun(out *[]ReconcilerObservation, scannerIdx map[string]int, identity, ns string, u *unstructured.Unstructured, status string, started, finished time.Time) {
 	run := ReconcilerExecution{
 		Name:       u.GetName(),
@@ -686,15 +725,10 @@ func foldScannerRun(out *[]ReconcilerObservation, scannerIdx map[string]int, ide
 	if idx, ok := scannerIdx[identity]; ok {
 		c := &(*out)[idx]
 		c.Executions = append(c.Executions, run)
-		// Recency-resolve the headline so the collapsed row reflects the
-		// latest run, regardless of apiserver list order.
-		if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
-			c.Status = status
-			c.Message = "last scan run " + u.GetName() + ": " + status
-			if !runAt.IsZero() {
-				c.ObservedAt = runAt
-			}
-		}
+		// Resolve the headline so the collapsed row reflects the latest run
+		// regardless of apiserver list order, and never lets an unterminated
+		// run bury a failed one. See adoptRunHeadline.
+		adoptRunHeadline(c, status, "last scan run "+u.GetName()+": "+status, runAt)
 		return
 	}
 	*out = append(*out, ReconcilerObservation{

--- a/products/catalyst/bootstrap/api/internal/helmwatch/scanner_failed_leaf_5929_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/scanner_failed_leaf_5929_test.go
@@ -1,0 +1,291 @@
+// #5929 (UAT row 164) — a Job in a terminal Failed state must produce a leaf
+// that reads FAILED, not one that reads "running" because a later run has not
+// finished yet.
+//
+// Measured on hw292 (read-only kubectl): Job syft-grype-bp-syft-grype-29763030
+// was Failed/BackoffLimitExceeded on 2026-08-03, while its successor
+// ...-29770230 sat two days stale with zero active pods and no conditions at
+// all. Both collapse onto the single `task-syft-sbom` scanner row (#3925). The
+// failed run WAS recorded correctly as an Execution — but the leaf headline read
+// `installing`, so the canvas reported 0 failed leaves out of 183 on a cluster
+// that had a failed Job. That is the "invisible failing class" the §5a ingestion
+// exists to kill (#3646).
+//
+// WHERE THE DEFECT IS NOT. Per-Job extraction is sound: jobRunStatus returns
+// `failed` for the live object, and the rollup can already emit non-succeeded
+// group states. So a test that feeds ONE Failed Job through and asserts the leaf
+// is failed passes on the unfixed code and proves nothing. Every case below
+// therefore models the real shape — a terminal failure collapsed together with a
+// run that never terminated — and TestFailedScanRunSurvives_ControlSingleRun
+// pins the weaker test's vacuity so nobody "simplifies" this suite back into it.
+package helmwatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Live timings from the hw292 pair.
+var (
+	scanFailedAt = time.Date(2026, 8, 3, 20, 11, 32, 0, time.UTC)
+	scanNewerAt  = time.Date(2026, 8, 8, 18, 35, 41, 0, time.UTC)
+)
+
+// syftScannerCronJob builds the bp-syft-grype CronJob as it exists on hw292 —
+// named syft-grype-bp-syft-grype (NOT the bare release name), carrying the
+// blueprint label that isDay2ScannerCronJob keys off. Without that label it
+// would mint a separate cron leaf and the scanner row would never be seeded,
+// which would change what this test is measuring.
+func syftScannerCronJob() *unstructured.Unstructured {
+	u := makeCronJob(syftGrypeNamespace, "syft-grype-bp-syft-grype")
+	u.SetLabels(map[string]string{
+		"catalyst.openova.io/blueprint": "bp-syft-grype",
+		"app.kubernetes.io/instance":    syftGrypeCronName,
+	})
+	return u
+}
+
+// scanRun builds one spawned syft-grype run. condType "" models the live
+// ...-29770230 shape: started, no terminal condition, no active pods.
+func scanRun(name, condType string, at time.Time) *unstructured.Unstructured {
+	return makeBatchJob(syftGrypeNamespace, name, "syft-grype-bp-syft-grype",
+		condType, metav1.ConditionTrue, at)
+}
+
+// findLeaf returns the observation with the given name, or fails the test.
+func findLeaf(t *testing.T, obs []ReconcilerObservation, name string) ReconcilerObservation {
+	t.Helper()
+	for _, o := range obs {
+		if o.Name == name {
+			return o
+		}
+	}
+	names := make([]string, 0, len(obs))
+	for _, o := range obs {
+		names = append(names, o.Kind+"-"+o.Name)
+	}
+	t.Fatalf("no %q leaf in observations; got %v", name, names)
+	return ReconcilerObservation{}
+}
+
+// TestFailedScanRunIsNotBuriedByUnterminatedSuccessor is the row-164
+// reproduction: the exact hw292 pair, in the order the apiserver returned them.
+func TestFailedScanRunIsNotBuriedByUnterminatedSuccessor(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(
+		syftScannerCronJob(),
+		scanRun("syft-grype-bp-syft-grype-29763030", "Failed", scanFailedAt),
+		scanRun("syft-grype-bp-syft-grype-29770230", "", scanNewerAt),
+	))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+
+	leaf := findLeaf(t, obs, syftScanIdentity)
+	if leaf.Status != ObsStatusFailed {
+		t.Errorf("collapsed scanner leaf status = %q, want %q — a failed Job produced no failed leaf (0 failed out of 183 on hw292)",
+			leaf.Status, ObsStatusFailed)
+	}
+	if leaf.ObservedAt.IsZero() {
+		t.Error("collapsed scanner leaf has no ObservedAt — a terminated failure must carry its finish time")
+	}
+
+	// The terminated execution must itself be terminal: failed AND finished.
+	var failedRuns int
+	for _, e := range leaf.Executions {
+		if e.Name != "syft-grype-bp-syft-grype-29763030" {
+			continue
+		}
+		failedRuns++
+		if e.Status != ObsStatusFailed {
+			t.Errorf("execution %s status = %q, want %q", e.Name, e.Status, ObsStatusFailed)
+		}
+		if e.FinishedAt.IsZero() {
+			t.Errorf("execution %s has a zero FinishedAt — a Failed Job must terminate its execution", e.Name)
+		}
+	}
+	if failedRuns != 1 {
+		t.Errorf("expected the failed run to appear exactly once as an Execution, got %d", failedRuns)
+	}
+
+	// The collapse itself must still hold: ONE row for the scanner, not one per run.
+	var scannerRows int
+	for _, o := range obs {
+		if o.Name == syftScanIdentity {
+			scannerRows++
+		}
+	}
+	if scannerRows != 1 {
+		t.Errorf("scanner collapsed into %d rows, want exactly 1 (#3925)", scannerRows)
+	}
+}
+
+// TestFailedScanRunSurvivesEitherListOrder — the apiserver guarantees no
+// chronological order, so the verdict must not depend on which run is seen
+// first. Guarding only the failed-then-running direction would leave the
+// running-then-failed direction reading "running" through the recency rule.
+func TestFailedScanRunSurvivesEitherListOrder(t *testing.T) {
+	failed := scanRun("syft-grype-bp-syft-grype-29763030", "Failed", scanFailedAt)
+	running := scanRun("syft-grype-bp-syft-grype-29770230", "", scanNewerAt)
+
+	for _, tc := range []struct {
+		name string
+		objs []*unstructured.Unstructured
+	}{
+		{"failed run listed first", []*unstructured.Unstructured{failed, running}},
+		{"unterminated run listed first", []*unstructured.Unstructured{running, failed}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(
+				syftScannerCronJob(), tc.objs[0], tc.objs[1],
+			))
+			if err != nil {
+				t.Fatalf("ListReconcilerObservations: %v", err)
+			}
+			if got := findLeaf(t, obs, syftScanIdentity).Status; got != ObsStatusFailed {
+				t.Errorf("scanner leaf status = %q, want %q", got, ObsStatusFailed)
+			}
+		})
+	}
+}
+
+// TestSucceededRunClearsAnEarlierFailure — the counter-case. The fix must not
+// pin a leaf red forever: a run that actually TERMINATES successfully after the
+// failure resolves it. Without this, returning a constant "failed" would satisfy
+// every assertion above.
+func TestSucceededRunClearsAnEarlierFailure(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(
+		syftScannerCronJob(),
+		scanRun("syft-grype-bp-syft-grype-29763030", "Failed", scanFailedAt),
+		scanRun("syft-grype-bp-syft-grype-29770230", "Complete", scanNewerAt),
+	))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	if got := findLeaf(t, obs, syftScanIdentity).Status; got != ObsStatusSucceeded {
+		t.Errorf("scanner leaf status = %q, want %q — a later SUCCEEDED run must clear the failure", got, ObsStatusSucceeded)
+	}
+}
+
+// TestStaleSucceededRunStillCannotOverwriteAFailure — the pre-existing recency
+// contract must survive the change: an OLDER Succeeded run arriving after a
+// newer Failed one still must not overwrite the failure.
+func TestStaleSucceededRunStillCannotOverwriteAFailure(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(
+		syftScannerCronJob(),
+		scanRun("syft-grype-bp-syft-grype-29770230", "Failed", scanNewerAt),
+		scanRun("syft-grype-bp-syft-grype-29763030", "Complete", scanFailedAt),
+	))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	if got := findLeaf(t, obs, syftScanIdentity).Status; got != ObsStatusFailed {
+		t.Errorf("scanner leaf status = %q, want %q — a stale Succeeded run overwrote a newer failure", got, ObsStatusFailed)
+	}
+}
+
+// TestCronLeafFailureSurvivesUnterminatedSuccessor — the same defect lived in
+// the cron leaf's copy of the recency block, which is the ORIGINAL #3646
+// concern (a Failed openbao-snapshot-save hiding behind a green row). Fixing
+// only the scanner path would have left this one live.
+func TestCronLeafFailureSurvivesUnterminatedSuccessor(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(
+		makeCronJob("openbao", "openbao-snapshot-save"),
+		makeBatchJob("openbao", "openbao-snapshot-save-29763030", "openbao-snapshot-save",
+			"Failed", metav1.ConditionTrue, scanFailedAt),
+		makeBatchJob("openbao", "openbao-snapshot-save-29770230", "openbao-snapshot-save",
+			"", metav1.ConditionTrue, scanNewerAt),
+	))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	leaf := findLeaf(t, obs, "openbao-snapshot-save")
+	if leaf.Kind != ReconcilerKindCron {
+		t.Fatalf("leaf kind = %q, want %q", leaf.Kind, ReconcilerKindCron)
+	}
+	if leaf.Status != ObsStatusFailed {
+		t.Errorf("cron leaf status = %q, want %q — a failing snapshot CronJob is hiding behind an in-flight run",
+			leaf.Status, ObsStatusFailed)
+	}
+}
+
+// TestTaskLeafFailureSurvivesUnterminatedSuccessor — third copy of the same
+// block, on the standalone task leaf (#3916 collapse).
+func TestTaskLeafFailureSurvivesUnterminatedSuccessor(t *testing.T) {
+	// Run suffixes must carry a digit: isRunSuffix deliberately treats an
+	// all-letters 5-char tail as a real word, so "-abcde" would NOT collapse
+	// and the two runs would land on separate leaves.
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(
+		makeBatchJob("catalyst", "db-migrate-a1b2c", "", "Failed", metav1.ConditionTrue, scanFailedAt),
+		makeBatchJob("catalyst", "db-migrate-d3e4f", "", "", metav1.ConditionTrue, scanNewerAt),
+	))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	leaf := findLeaf(t, obs, "db-migrate")
+	if leaf.Status != ObsStatusFailed {
+		t.Errorf("task leaf status = %q, want %q", leaf.Status, ObsStatusFailed)
+	}
+}
+
+// TestFailedScanRunSurvives_ControlSingleRun documents WHY the cases above are
+// shaped the way they are. A lone Failed Job already produced a failed leaf on
+// the UNFIXED code — so this assertion passes either way and is worthless as a
+// regression guard. It is kept only to pin that fact.
+func TestFailedScanRunSurvives_ControlSingleRun(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(
+		syftScannerCronJob(),
+		scanRun("syft-grype-bp-syft-grype-29763030", "Failed", scanFailedAt),
+	))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	if got := findLeaf(t, obs, syftScanIdentity).Status; got != ObsStatusFailed {
+		t.Errorf("single failed run: leaf status = %q, want %q", got, ObsStatusFailed)
+	}
+	// If this ever becomes the ONLY case in this file, the row-164 defect can
+	// return undetected.
+}
+
+// TestAdoptRunHeadlineVerdictRule exercises the shared helper directly, so the
+// three call sites above are pinned by behaviour AND the rule itself is pinned
+// by table.
+func TestAdoptRunHeadlineVerdictRule(t *testing.T) {
+	older := scanFailedAt
+	newer := scanNewerAt
+
+	for _, tc := range []struct {
+		name       string
+		start      ReconcilerObservation
+		status     string
+		runAt      time.Time
+		wantStatus string
+	}{
+		{"in-flight run cannot clear a failure",
+			ReconcilerObservation{Status: ObsStatusFailed, ObservedAt: older},
+			ObsStatusRunning, newer, ObsStatusFailed},
+		{"failure displaces a pending seed",
+			ReconcilerObservation{Status: ObsStatusPending},
+			ObsStatusFailed, older, ObsStatusFailed},
+		{"failure displaces an in-flight headline even when older",
+			ReconcilerObservation{Status: ObsStatusRunning, ObservedAt: newer},
+			ObsStatusFailed, older, ObsStatusFailed},
+		{"newer success clears a failure",
+			ReconcilerObservation{Status: ObsStatusFailed, ObservedAt: older},
+			ObsStatusSucceeded, newer, ObsStatusSucceeded},
+		{"older success does not clear a failure",
+			ReconcilerObservation{Status: ObsStatusFailed, ObservedAt: newer},
+			ObsStatusSucceeded, older, ObsStatusFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.start
+			adoptRunHeadline(&c, tc.status, "msg", tc.runAt)
+			if c.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", c.Status, tc.wantStatus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## UAT row 164 — a terminal Failed Job produced no failed leaf (0 failed / 183)

Row 164 asserts *"the cutover group status reflects its real children (a group with
a failed child reads failed, not a fake Succeeded)"*. On hw292 the canvas reported
**0 failed leaves out of 183** while the cluster held a Job in a terminal `Failed`
state.

### Cause

`products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go` — the headline
resolution shared (by copy-paste) between `foldScannerRun` (was **line 683**), the
cron leaf path (was **line 334**) and the task leaf path (was **line 385**):

```go
runAt := firstNonZero(finished, started)
if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
    c.Status = status
    ...
}
```

This compares an **unterminated** run's `startedAt` against a **terminated** run's
`finishedAt` — two different clocks — so a run that has produced *no verdict at
all* overwrites a terminal `failed` headline.

**Measured live (read-only kubectl):**

```
syft-grype-bp-syft-grype-29763030  Failed / BackoffLimitExceeded   finished 2026-08-03T20:11:32Z
syft-grype-bp-syft-grype-29770230  no conditions, 0 active pods    started  2026-08-08T18:34:41Z
```

Both fold onto the single `task-syft-sbom` scanner row (#3925). Replaying that
exact pair through `ListReconcilerObservations`:

```
leaf kind=task name=syft-sbom status="installing" observedAt=2026-08-08 18:34:41
    exec ...-29763030 status="failed"     finished=2026-08-03 20:11:32
    exec ...-29770230 status="installing" finished=<zero>
```

### Where the defect is NOT — both alternatives were ruled out, not assumed

- **Per-Job extraction is sound.** `jobRunStatus` was probed against the live
  object's verbatim `status` and returns `failed` with a non-zero `finishedAt`.
  The `Failed` condition parses fine despite the extra `lastProbeTime` field.
- **The rollup is sound.** It already emits non-succeeded group states
  (`cutover` reads succeeded/14, `reconcilers` reads running), which localises the
  defect to ingestion rather than `store.go:580`.

The failed **execution** was recorded correctly all along; only the **leaf**
headline was wrong — which is exactly why the leaf count read zero.

### Fix

One `adoptRunHeadline` helper, replacing all three copies, with two rules:

1. **Recency** (unchanged) — the most recent run wins.
2. **Verdict** (new) — an unterminated run may never erase a `failed` headline,
   and a real failure displaces a no-verdict headline **regardless of list order**
   (the apiserver guarantees none). A later run that actually terminates still
   resolves the leaf, so nothing is pinned red forever.

All three sites were genuinely affected — including the Failed
`openbao-snapshot-save` CronJob case that motivated #3646 in the first place.
Fixing only the scanner path would have left the other two live.

### Test — failing before, passing after

`internal/helmwatch/scanner_failed_leaf_5929_test.go`.

**Before the fix** (`git checkout -- reconcilers.go`; the helper-direct table test
temporarily removed so the pre-fix ingestion compiles and is genuinely exercised):

```
collapsed scanner leaf status = "installing", want "failed" — a failed Job produced no failed leaf (0 failed out of 183 on hw292)
--- FAIL: TestFailedScanRunIsNotBuriedByUnterminatedSuccessor
    scanner leaf status = "installing", want "failed"     (failed run listed first)
    scanner leaf status = "installing", want "failed"     (unterminated run listed first)
--- FAIL: TestFailedScanRunSurvivesEitherListOrder
--- PASS: TestSucceededRunClearsAnEarlierFailure
--- PASS: TestStaleSucceededRunStillCannotOverwriteAFailure
    cron leaf status = "installing", want "failed" — a failing snapshot CronJob is hiding behind an in-flight run
--- FAIL: TestCronLeafFailureSurvivesUnterminatedSuccessor
    task leaf status = "installing", want "failed"
--- FAIL: TestTaskLeafFailureSurvivesUnterminatedSuccessor
--- PASS: TestFailedScanRunSurvives_ControlSingleRun
FAIL
```

**After the fix** — whole module, not just the touched package:

```
$ go build ./... && go vet ./... && go test ./...
(no FAIL lines; internal/helmwatch ok 20.3s)
```

Deliberate properties of this suite:

- **The naive test is proven worthless, not merely avoided.**
  `TestFailedScanRunSurvives_ControlSingleRun` feeds ONE Failed Job and asserts a
  failed leaf — and **passes on the unfixed code**. It is kept as a documented
  control so nobody "simplifies" the suite back into it.
- **Counter-cases that a lazy fix would break**: a later Succeeded run must clear
  the failure (a constant `failed` would fail this), and a *stale* Succeeded run
  must still not overwrite a newer failure (the pre-existing contract).
- **Both list orders** asserted, since guarding one direction leaves the other
  reading "running" through the recency rule.
- **Fixture fidelity**: the CronJob is built as it exists live —
  `syft-grype-bp-syft-grype`, not the bare release name — carrying the blueprint
  label `isDay2ScannerCronJob` keys off. Without it the scanner row is never
  seeded and the test would measure something else.

### Not in scope

`docs/ledger/UAT.md` row 164 still carries its ✅ stamp. The stamp flips on a
re-walk against a deployed build, not on PR merge — this PR does not touch it.

Refs #5929
Refs #3379
Refs #3646
Refs #3925
