### PR TITLE
fix(catalyst-api): customer Application CRs must carry spec.organizationRef (UAT rows 15, 25(i))

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/application_organizationref_5933_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_organizationref_5933_test.go
@@ -1,0 +1,152 @@
+/*
+application_organizationref_5933_test.go — #5933 (UAT rows 15, 25(i)).
+
+THE DEFECT THESE GUARDS PIN. #5814 gave the sovereign /apps grid an Org
+attribution chip by reading `spec.organizationRef` off each Application CR
+(sovereign.go). That reader is deliberately VERBATIM — it never synthesises the
+Org from the namespace or from the CR-name prefix, because both guesses are
+wrong for a spine CR (`spine-openbao` lives in `flux-system` and belongs to the
+Sovereign self-org). A verbatim reader is only ever as good as its producer,
+and the customer-app producer did not write the field at all: the spec map in
+newApplicationUnstructured carried environmentRef / blueprintRef / placement /
+regions / parameters and nothing about ownership.
+
+The live control on hw292 is what makes this unambiguous — the spine producer
+(renderSpineApplicationCR) writes organizationRef and its CRs carry
+`hw292-omani-works`, while every customer CR in Org `uatco` carries an empty
+one. The field, the CRD's preserve-unknown-fields spec, the reader and the chip
+all worked; ONE producer omitted it.
+
+WHY THESE GUARDS ARE SHAPED LIKE THIS. The load-bearing assertion is the
+POSITIVE one on the customer path — the #5814 wire-shape guards all still pass
+with the producer broken, because an empty `Org` marshals away under omitempty
+and reads exactly like "this Application declares no Org". Nothing downstream
+can tell an omitted field from an unowned Application, so only the producer can
+be held to it. The spine case is carried alongside as a CONTROL: it already
+worked, and a guard that only watches the path being changed cannot notice the
+change breaking its sibling.
+*/
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// customerInstallRequest — a realistic customer install body, matching the
+// hw292 control (Org `uatco` launching bp-agenity through the funnel).
+func customerInstallRequest() applicationInstallRequest {
+	return applicationInstallRequest{
+		Name:            "uatco-agenity",
+		OrganizationRef: "uatco",
+		EnvironmentRef:  "uatco-prod",
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-agenity", Version: "0.3.1"},
+		Placement: applicationPlacement{
+			Mode:    "single-region",
+			Regions: []string{"me-east-215"},
+		},
+	}
+}
+
+// THE ROW-15 GUARD. A customer-launched Application CR must carry
+// spec.organizationRef, verbatim. Before the fix this fails with
+// `spec.organizationRef absent` — the reader at sovereign.go:866 has nothing
+// to read and the Org chip can never render for a customer app.
+func TestNewApplicationUnstructured_StampsOrganizationRef(t *testing.T) {
+	obj := newApplicationUnstructured(customerInstallRequest(), "hw292.omani.works", "console.uatco.omani.homes")
+
+	org, found, err := unstructured.NestedString(obj.Object, "spec", "organizationRef")
+	if err != nil {
+		t.Fatalf("spec.organizationRef is not a string: %v", err)
+	}
+	if !found {
+		t.Fatal("spec.organizationRef ABSENT on a customer-launched Application CR — " +
+			"#5814's Org-attribution reader (sovereign.go, `spec.organizationRef`) is verbatim-only, " +
+			"so with no producer it returns empty forever and no customer app can appear under its Org " +
+			"(UAT rows 15, 25(i)). Live control on hw292: spine-harbor carries hw292-omani-works, " +
+			"uatco-agenity carries nothing.")
+	}
+	if org != "uatco" {
+		t.Fatalf("spec.organizationRef = %q, want %q — the Org identity must be VERBATIM, "+
+			"the same value stamped on the catalyst.openova.io/organization label. Never the slugged "+
+			"namespace and never the CR-name prefix: both are wrong for a spine CR, which is exactly "+
+			"why the reader refuses to synthesise and depends on this producer.", org, "uatco")
+	}
+}
+
+// The Org identity on the CR must be the SAME string in both places it lands.
+// Deriving one from the other's slugged form is the failure mode the reader's
+// doc comment forbids, and a chip that disagrees with the label is worse than
+// no chip.
+func TestNewApplicationUnstructured_OrganizationRefMatchesTheOrganizationLabel(t *testing.T) {
+	// A dotted FQDN Org ref — the case where the CR's namespace (slugged) and
+	// the Org identity (verbatim) genuinely diverge, so a producer that reached
+	// for the namespace instead of the request field is caught here rather than
+	// passing by coincidence on an already-DNS-safe slug.
+	req := customerInstallRequest()
+	req.OrganizationRef = "hw292.omani.works"
+	req.EnvironmentRef = "hw292-omani-works-prod"
+
+	obj := newApplicationUnstructured(req, "hw292.omani.works", "")
+
+	org, _, _ := unstructured.NestedString(obj.Object, "spec", "organizationRef")
+	label := obj.GetLabels()["catalyst.openova.io/organization"]
+	if org != label {
+		t.Fatalf("spec.organizationRef = %q but catalyst.openova.io/organization label = %q — "+
+			"one Application must not carry two spellings of its own Org.", org, label)
+	}
+	if org != "hw292.omani.works" {
+		t.Fatalf("spec.organizationRef = %q, want the verbatim request value %q "+
+			"(the CR namespace is the SLUGGED form %q — reading the namespace back out is the "+
+			"synthesis the #5814 reader exists to avoid)",
+			org, "hw292.omani.works", obj.GetNamespace())
+	}
+}
+
+// FAIL-CLOSED. An install request with no Org ref must not stamp an EMPTY
+// organizationRef: an absent field is the honest rendering of "attribution
+// unknown", whereas `organizationRef: ""` asserts an Org whose name is the
+// empty string. validateApplicationInstallRequest already rejects an empty ref
+// on both HTTP seams, so this only governs direct/legacy callers of the
+// builder — but it is the difference between the reader seeing "no answer" and
+// seeing "the answer is nothing".
+func TestNewApplicationUnstructured_OmitsOrganizationRefWhenUnset(t *testing.T) {
+	req := customerInstallRequest()
+	req.OrganizationRef = ""
+
+	obj := newApplicationUnstructured(req, "", "")
+
+	if _, found, _ := unstructured.NestedString(obj.Object, "spec", "organizationRef"); found {
+		t.Fatal("spec.organizationRef stamped as an empty string when the request carried no Org — " +
+			"omit the field instead, so an unattributed Application is distinguishable from one " +
+			"claiming an empty-named Org.")
+	}
+}
+
+// CONTROL — the spine/bootstrap producer already wrote organizationRef and is
+// the reason the field is known to work end-to-end (hw292: spine-harbor reads
+// hw292-omani-works). It is a DIFFERENT function on a DIFFERENT path, so this
+// guard exists to prove the customer-path change did not disturb what already
+// worked. Both producers are asserted through the same accessor the reader
+// uses, so a rename on one side cannot pass here while breaking the grid.
+func TestSpineApplicationCR_StillStampsOrganizationRef_Control(t *testing.T) {
+	sc := spineComponent{
+		Chart:            "harbor",
+		HRName:           "bp-harbor",
+		BlueprintName:    "bp-harbor",
+		BlueprintVersion: "1.2.25",
+	}
+	owner := map[string]string{
+		"catalyst.openova.io/organization": "hw292-omani-works",
+		"catalyst.openova.io/environment":  "hw292-omani-works-cp",
+	}
+	cr := renderSpineApplicationCR(sc, "hw292-omani-works-cp", "hw292-omani-works", []string{"me-east-215"}, owner, "")
+
+	org, found, _ := unstructured.NestedString(cr.Object, "spec", "organizationRef")
+	if !found || org != "hw292-omani-works" {
+		t.Fatalf("spine spec.organizationRef = %q (found=%v), want hw292-omani-works — "+
+			"the customer-path fix must not disturb the producer that already worked; "+
+			"this is the live control the whole diagnosis rests on.", org, found)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1151,6 +1151,38 @@ func newApplicationUnstructured(req applicationInstallRequest, sovereignFQDN, or
 		"placement": placementValue,
 		"regions":   regions,
 	}
+	// #5933 (UAT rows 15, 25(i)) — stamp the OWNING Organization on the CR.
+	//
+	// This was the one field the customer-app producer never wrote. The
+	// Org identity reached the CR only as the `catalyst.openova.io/
+	// organization` label and as the slugged metadata.namespace, so
+	// spec.organizationRef — which the spine producer has always written
+	// (post_handover_spine_apps.go renderSpineApplicationCR) — was absent
+	// on every Application a customer ever launched.
+	//
+	// WHY THAT MATTERED. #5814 gave the sovereign /apps grid its Org
+	// attribution chip by reading exactly this field, VERBATIM: it never
+	// synthesises the Org from the namespace or the CR-name prefix,
+	// because both guesses are wrong for a spine CR (spine-openbao sits in
+	// flux-system and belongs to the Sovereign self-org). A verbatim
+	// reader over a field no producer writes returns empty forever, and an
+	// absent chip is indistinguishable from an unowned Application — so
+	// nothing downstream could detect the gap. Measured on hw292:
+	// spine-harbor carried `hw292-omani-works` while uatco-agenity,
+	// uatco-mail and uatco-openclaw carried nothing.
+	//
+	// VERBATIM, matching the label above — never the slugged namespace.
+	// The two must agree, or one Application carries two spellings of its
+	// own Org. Omitted when unset so an unattributed CR stays legible as
+	// "attribution unknown" rather than claiming an empty-named Org; both
+	// HTTP install seams already reject an empty ref in
+	// validateApplicationInstallRequest.
+	//
+	// The CRD preserves it (spec carries x-kubernetes-preserve-unknown-
+	// fields), which is how the spine CRs have been storing it all along.
+	if orgRef := strings.TrimSpace(req.OrganizationRef); orgRef != "" {
+		spec["organizationRef"] = orgRef
+	}
 	// #4283 / #4282 Root-B — ALWAYS stamp a non-null spec.parameters
 	// OBJECT. Caller-supplied parameters are used verbatim; otherwise we
 	// emit at least `{}` (plus a configSchema-valid topology.mode for


### PR DESCRIPTION
## Cause

`products/catalyst/bootstrap/api/internal/handler/applications.go:1136-1152` — `newApplicationUnstructured` builds the Application `spec` map with `environmentRef` / `blueprintRef` / `placement` / `regions` / `parameters` and **never writes `organizationRef`**. The Org identity reached the CR only as the `catalyst.openova.io/organization` label and as the slugged `metadata.namespace`.

Both HTTP install seams route through this one builder — the sovereign install (`applications.go:542`) and the own-org install (`org_applications.go` → `installApplicationCore`) — so every customer app on every Sovereign is affected.

## Why the reader could not compensate

#5814 gave the sovereign `/apps` grid its Org-attribution chip by reading exactly `spec.organizationRef` at `sovereign.go:866`, **verbatim**. That is deliberate: it never synthesises the Org from the namespace or the CR-name prefix, because both guesses are wrong for a spine CR (`spine-openbao` sits in `flux-system` and belongs to the Sovereign self-org). A verbatim reader over a field no producer writes returns empty forever — and an absent chip is indistinguishable from an unowned Application, so no wire-shape test downstream could notice.

The sibling **preview** endpoint (`applications_preview.go:221`) has always emitted `organizationRef`, so the preview showed a CR shape the real create then did not produce.

## Live control — hw292, dep `1c56518035a83e03`, read-only

```
$ kubectl get applications.apps.openova.io -A -o jsonpath=...
catalyst   spine-gitea      orgRef=hw292-omani-works
catalyst   spine-harbor     orgRef=hw292-omani-works
catalyst   spine-keycloak   orgRef=hw292-omani-works
catalyst   spine-openbao    orgRef=hw292-omani-works
uatco      uatco-agenity    orgRef=
uatco      uatco-mail       orgRef=
uatco      uatco-openclaw   orgRef=
```

The spine producer (`post_handover_spine_apps.go:516` `renderSpineApplicationCR`) writes the field and its CRs carry it. The field, the CRD's `x-kubernetes-preserve-unknown-fields` spec, the reader and the chip all work. **One producer omitted it.**

## Fix

Stamp `spec.organizationRef` verbatim from `req.OrganizationRef`, matching the label above it and the spine producer. Omitted when unset, so an unattributed CR stays legible as "attribution unknown" rather than claiming an Org whose name is the empty string — both HTTP seams already reject an empty ref in `validateApplicationInstallRequest`, so this only governs direct callers of the builder.

## Test — failing then passing

New file `application_organizationref_5933_test.go`. Four guards; the **positive assertion on the customer path is the load-bearing one**, because the #5814 wire-shape guards all still pass with the producer broken (an empty `Org` marshals away under `omitempty` and reads exactly like "declares no Org").

**BEFORE the fix:**

```
=== RUN   TestNewApplicationUnstructured_StampsOrganizationRef
    spec.organizationRef ABSENT on a customer-launched Application CR — #5814's
    Org-attribution reader (sovereign.go, `spec.organizationRef`) is verbatim-only,
    so with no producer it returns empty forever and no customer app can appear
    under its Org (UAT rows 15, 25(i)). Live control on hw292: spine-harbor carries
    hw292-omani-works, uatco-agenity carries nothing.
--- FAIL: TestNewApplicationUnstructured_StampsOrganizationRef (0.00s)
=== RUN   TestNewApplicationUnstructured_OrganizationRefMatchesTheOrganizationLabel
    spec.organizationRef = "" but catalyst.openova.io/organization label =
    "hw292.omani.works" — one Application must not carry two spellings of its own Org.
--- FAIL: TestNewApplicationUnstructured_OrganizationRefMatchesTheOrganizationLabel (0.00s)
=== RUN   TestNewApplicationUnstructured_OmitsOrganizationRefWhenUnset
--- PASS
=== RUN   TestSpineApplicationCR_StillStampsOrganizationRef_Control
--- PASS
FAIL
```

**AFTER the fix:**

```
--- PASS: TestNewApplicationUnstructured_StampsOrganizationRef (0.00s)
--- PASS: TestNewApplicationUnstructured_OrganizationRefMatchesTheOrganizationLabel (0.00s)
--- PASS: TestNewApplicationUnstructured_OmitsOrganizationRefWhenUnset (0.00s)
--- PASS: TestSpineApplicationCR_StillStampsOrganizationRef_Control (0.00s)
PASS
```

The fail-closed guard passes pre-fix (vacuously — nothing is written at all), so it was **mutation-verified separately**: changing the stamp to unconditional `spec["organizationRef"] = strings.TrimSpace(req.OrganizationRef)` turns it RED with `stamped as an empty string when the request carried no Org`.

The **spine control** is the case that already worked. It asserts `spine-harbor` carries `hw292-omani-works` through the same accessor the reader uses, so the customer-path change cannot silently disturb the producer this whole diagnosis rests on, and a rename on one side cannot pass here while breaking the grid.

Two other guards deliberately use a **dotted FQDN Org ref**, the one case where the CR namespace (slugged) and the Org identity (verbatim) genuinely diverge — a producer that reached for the namespace instead of the request field is caught there rather than passing by coincidence on an already-DNS-safe slug.

## Why this matters

Rows 15 and 25(i) were classified **deploy-gated**. They are not. #5814 (the reader) and #5833 are merged and waiting on a roll, but rolling the image would not have moved these rows one inch — the producer wall is on `main` and no amount of delivery clears it. **A fresh prov would have left both rows red and the ledger would have blamed delivery for a source defect.**

## Gates

- `go test ./internal/handler/` — **ok, 258.308s** (full handler suite, not the targeted subset)
- `go vet ./...` — clean
- `scripts/check-no-banned-words.sh` — OK

All three chained ahead of the commit (`gate && gate && gate && add && commit && push`), never run on their own line.

Refs #5933, #5814, #5833
