### PR TITLE
fix(console): the Status panel must render a bootstrap component's REAL status (UAT rows 67, 69)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.bootstrapStatus-5934.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.bootstrapStatus-5934.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * TopologyTab.bootstrapStatus-5934.test.tsx — #5934 (UAT rows 67, 69).
+ *
+ * THE DEFECT THESE GUARDS PIN. The app-detail Status panel printed the literal
+ * string "n/a — bootstrap component (HelmRelease, no Application CR)" for every
+ * bootstrap-kit component, on a page whose own header and Overview read STATUS
+ * Ready. One page contradicting itself, three inches apart.
+ *
+ * Two lines caused it, and only fixing BOTH moves the rows:
+ *   • the status poll was disabled outright when `isBootstrap`, so the console
+ *     never asked; and
+ *   • the Status panel branched on `isBootstrap` FIRST, hard-rendering the n/a
+ *     string regardless of what the API returned — so even an un-gated poll
+ *     would have been ignored.
+ *
+ * WHY THIS IS NOT DEPLOY-GATED. #5836 already landed the API half:
+ * HandleApplicationStatus now falls through to statusFromSynthesised (HR first,
+ * then runtime) instead of hard-404ing for a component with no Application CR.
+ * That fix is on main. But a rolled image changes nothing while the front end
+ * refuses to ask and refuses to listen — which is exactly why these rows were
+ * about to be mis-blamed on delivery.
+ *
+ * WHAT THE FALLBACK STILL MEANS. The n/a prose is kept, narrowed to its honest
+ * case: the endpoint was asked and genuinely had nothing (synthesis missed →
+ * 404). "We did not ask" and "there is no answer" must not render identically.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getApplicationPlacement = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+const getContinuumReplicationStatus = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+  getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
+}))
+
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+  }
+})
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+vi.mock('@/widgets/topology/PlacementEditor', () => ({
+  PlacementEditor: () => <div data-testid="stub-placement-editor" />,
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+/** The literal string the panel used to hard-render for every bootstrap component. */
+const NA_PROSE = /n\/a — bootstrap component/
+
+beforeEach(() => {
+  getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+  getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+  getContinuumReplicationStatus.mockRejectedValue(new Error('continuum replication-status: HTTP 404'))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('TopologyTab — bootstrap component status (#5934, UAT rows 67 + 69)', () => {
+  // THE ROW-67/69 GUARD. bp-grafana is a bootstrap-kit HelmRelease with no
+  // Application CR. Since #5836 its /status answers Ready (synthesised from the
+  // HR). The panel must show THAT, not the hardcoded abstention.
+  it('renders the REAL status the API returns for a bootstrap component, not the hardcoded n/a string', async () => {
+    getApplicationStatus.mockResolvedValue({
+      name: 'bp-grafana',
+      namespace: 'flux-system',
+      phase: 'Ready',
+      status: {},
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="test-sov" applicationName="bp-grafana" namespace="flux-system" isBootstrap />,
+      ),
+    )
+
+    // POSITIVE FIRST. TanStack mounts on a microtask, so asserting an element is
+    // ABSENT before proving the subject rendered passes for the wrong reason —
+    // the whole panel is empty at that instant. Wait for the real chip, then the
+    // negative assertions mean something.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-recon-status')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-recon-status').textContent).toContain('Reconciled')
+    expect(screen.queryByTestId('topology-tab-status-bootstrap')).toBeNull()
+    expect(screen.queryByText(NA_PROSE)).toBeNull()
+  })
+
+  // The poll gate itself. Kept separate from the render assertion above because
+  // they were two DIFFERENT lines: un-gating the poll without un-gating the
+  // render still prints n/a, and un-gating the render without the poll leaves
+  // the panel with nothing to render.
+  it('POLLS the status endpoint for a bootstrap component (#5836 made it answer)', async () => {
+    getApplicationStatus.mockResolvedValue({
+      name: 'bp-keycloak',
+      namespace: 'flux-system',
+      phase: 'Ready',
+      status: {},
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="test-sov" applicationName="bp-keycloak" namespace="flux-system" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(getApplicationStatus).toHaveBeenCalled()
+    })
+    expect(getApplicationStatus).toHaveBeenCalledWith('test-sov', 'bp-keycloak', 'flux-system')
+  })
+
+  // A Degraded component must read Degraded. A fix that pinned the chip to a
+  // constant "Reconciled" would satisfy the first guard and be a worse lie than
+  // the n/a string it replaced.
+  it('a Degraded bootstrap component reads Degraded, not a constant green chip', async () => {
+    getApplicationStatus.mockResolvedValue({
+      name: 'bp-grafana',
+      namespace: 'flux-system',
+      phase: 'Degraded',
+      status: { placementReason: 'HelmRelease not ready: upgrade retries exhausted' },
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="test-sov" applicationName="bp-grafana" namespace="flux-system" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-recon-status').textContent).toContain('Degraded')
+    })
+    expect(screen.getByTestId('topology-tab-recon-reason').textContent).toContain('upgrade retries exhausted')
+  })
+
+  // THE FALLBACK, narrowed to its honest case. When /status genuinely has
+  // nothing (synthesis missed both the HR and the runtime paths → 404), the
+  // panel abstains rather than inventing a status. This is the ONLY case the
+  // n/a prose may still appear in.
+  it('falls back to the n/a prose when the endpoint genuinely has no answer (404)', async () => {
+    getApplicationStatus.mockRejectedValue(new Error('application status: HTTP 404 application-not-found'))
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="test-sov" applicationName="bp-nothing" namespace="flux-system" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('topology-tab-recon-status')).toBeNull()
+  })
+
+  // #3656's original concern was a 404 LOOP, and it is still valid — it was the
+  // right worry answered with too blunt an instrument (never ask at all). Once
+  // the endpoint has said it has nothing, stop re-asking; while it answers, keep
+  // polling like any other app.
+  it('stops re-polling once the endpoint has answered 404 (the #3656 loop concern, kept)', async () => {
+    getApplicationStatus.mockRejectedValue(new Error('application status: HTTP 404 application-not-found'))
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="test-sov" applicationName="bp-nothing" namespace="flux-system" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+    })
+    const callsAfterFirstAnswer = getApplicationStatus.mock.calls.length
+    await new Promise((r) => setTimeout(r, 50))
+    expect(getApplicationStatus.mock.calls.length).toBe(callsAfterFirstAnswer)
+  })
+
+  // CONTROL — the non-bootstrap path already worked and must be undisturbed.
+  it('CONTROL: a non-bootstrap app still polls and still renders its recon chip', async () => {
+    getApplicationStatus.mockResolvedValue({
+      name: 'wordpress',
+      namespace: 'qa-omantel',
+      phase: 'Ready',
+      spec: { placement: 'single-region', regions: [] },
+      status: {},
+    })
+
+    render(withProviders(<TopologyTab sovereignId="test-sov" applicationName="wordpress" namespace="qa-omantel" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-recon-status').textContent).toContain('Reconciled')
+    })
+    expect(getApplicationStatus).toHaveBeenCalledWith('test-sov', 'wordpress', 'qa-omantel')
+    expect(screen.queryByTestId('topology-tab-status-bootstrap')).toBeNull()
+  })
+
+  // CONTROL — the pre-filled seam (initialApp) must not start a network poll.
+  it('CONTROL: initialApp still short-circuits the poll entirely', async () => {
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="test-sov"
+          applicationName="bp-grafana"
+          namespace="flux-system"
+          isBootstrap
+          initialApp={{ name: 'bp-grafana', namespace: 'flux-system', phase: 'Ready', status: {} }}
+        />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-recon-status')).toBeTruthy()
+    })
+    expect(getApplicationStatus).not.toHaveBeenCalled()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -215,9 +215,25 @@ describe('TopologyTab — #3969 { Placement, Status }', () => {
   })
 })
 
-describe('TopologyTab — bootstrap HelmRelease status poll (#3656)', () => {
-  it('does NOT poll the status endpoint for a bootstrap component (no 404 loop)', async () => {
+describe('TopologyTab — bootstrap HelmRelease status poll (#3656 → #5934)', () => {
+  // SUPERSEDED CONTRACT, rewritten rather than deleted. This case used to
+  // assert `getApplicationStatus` was NEVER called for a bootstrap component.
+  // That was correct while the endpoint 404'd forever, and it is wrong now:
+  // #5836 gave /applications/{name}/status the same synthesiser fallback its
+  // sibling detail endpoint has, so bp-alloy et al. DO have a status. Leaving
+  // the old assertion in place would have pinned the very defect rows 67/69
+  // measured — the console printing "n/a — bootstrap component" under a header
+  // reading Ready. The 404-LOOP concern #3656 actually cared about is retained
+  // and asserted in TopologyTab.bootstrapStatus-5934.test.tsx (the poll backs
+  // off the moment the endpoint answers with nothing).
+  it('#5934: DOES poll the status endpoint for a bootstrap component, and renders the answer', async () => {
     getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({
+      name: 'bp-alloy',
+      namespace: 'flux-system',
+      phase: 'Ready',
+      status: {},
+    })
 
     render(
       withProviders(
@@ -226,10 +242,10 @@ describe('TopologyTab — bootstrap HelmRelease status poll (#3656)', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+      expect(screen.getByTestId('topology-tab-recon-status')).toBeTruthy()
     })
-    expect(screen.queryByTestId('topology-tab-status-loading')).toBeNull()
-    expect(getApplicationStatus).not.toHaveBeenCalled()
+    expect(getApplicationStatus).toHaveBeenCalled()
+    expect(screen.queryByTestId('topology-tab-status-bootstrap')).toBeNull()
   })
 
   it('#4000: queries placement with EMPTY namespace for a bootstrap component (workload Pods run in their own ns, not the flux-system HR ns)', async () => {
@@ -656,8 +672,12 @@ describe('TopologyTab — #4886 bootstrap-HR DR off the live Continuum CR', () =
       expect(screen.getByTestId('topology-tab-dr-lag-value').textContent).toContain('0.0 s')
     })
     expect(screen.getByTestId('topology-tab-dr-source').textContent).toContain('live')
-    // The Status panel's honest "n/a — bootstrap component" note is unaffected.
-    expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+    // The Status panel is unaffected by the DR panel — it still renders. This
+    // used to anchor on the "n/a — bootstrap component" prose; #5934 made that
+    // string the FALLBACK rather than the fixed rendering for a bootstrap
+    // component, so anchoring on the panel itself is what this case actually
+    // means (DR does not displace Status).
+    expect(screen.getByTestId('topology-tab-status-panel')).toBeTruthy()
   })
 
   it('#5514: a DECLARED active-hot-standby with ZERO backing arms NOTHING — no lag, no follower card, switchover DISABLED', async () => {
@@ -1040,8 +1060,15 @@ describe('TopologyTab — #4886 bootstrap-HR DR off the live Continuum CR', () =
       ),
     )
 
+    // Anchor on the SUBJECT of this case — the replication-status answer this
+    // assertion is about — so the two negatives below cannot pass merely
+    // because nothing has rendered yet. (It previously anchored on the
+    // "n/a — bootstrap component" prose, which #5934 turned into a fallback.)
     await waitFor(() => {
-      expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+      expect(getContinuumReplicationStatus).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-placement-panel')).toBeTruthy()
     })
     expect(screen.queryByTestId('topology-tab-dr-panel')).toBeNull()
     expect(screen.queryByTestId('topology-tab-dr-switchover')).toBeNull()

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -64,11 +64,17 @@ export interface TopologyTabProps {
   /** Caller's tier — reserved (the editor server-side enforces the role). */
   callerTier?: string
   /**
-   * #3656 — true when this app is a bootstrap-kit HelmRelease with NO
-   * companion Application CR. The GET /applications/{name}/status endpoint
-   * 404s for these, so we MUST NOT poll it (calm n/a status instead of a
-   * 404 loop). Generic by construction — keys on "has Application CR", never
-   * a blueprint name.
+   * True when this app is a bootstrap-kit HelmRelease with NO companion
+   * Application CR. Generic by construction — keys on "has Application CR",
+   * never a blueprint name.
+   *
+   * #3656 → #5934: this flag no longer suppresses the status poll. It once
+   * did, because GET /applications/{name}/status 404'd for every such
+   * component; since #5836 that endpoint answers from the same synthesisers
+   * the sibling detail endpoint uses, so the flag now only selects the
+   * ABSTENTION COPY shown if the endpoint turns out to have nothing, plus the
+   * #4000 empty-namespace placement lookup. It must never again decide WHETHER
+   * to ask.
    */
   isBootstrap?: boolean
 }
@@ -136,17 +142,36 @@ export function TopologyTab({
   // panel's "Switch over…" button). Closed by default.
   const [showSwitchover, setShowSwitchover] = useState(false)
 
-  // #3656 — bootstrap-kit HelmReleases have no Application CR; the status
-  // endpoint 404s forever, so don't poll it for them.
+  // #3656 → #5934. #3656 disabled this poll for bootstrap-kit components
+  // because they have no Application CR and the endpoint 404'd forever. The
+  // 404-loop worry was right; "never ask" was too blunt an answer, and it
+  // outlived its cause: since #5836 GET /applications/{name}/status falls
+  // through to the same synthesisers the sibling detail endpoint uses (the
+  // HelmRelease first, then the live runtime), so bp-grafana and bp-keycloak
+  // DO have a status to report — the console simply never asked for it, and
+  // printed "n/a — bootstrap component" on a page whose own header read Ready
+  // (UAT rows 67, 69).
+  //
+  // So: ask for every component, and keep #3656's actual concern by backing
+  // off the moment the endpoint tells us it has nothing (retry:false + the
+  // error-aware interval below). One 404 per mount, never a loop.
+  const statusEnabled = !initialApp && !!sovereignId && !!applicationName
   const statusQ = useQuery({
     queryKey: ['application-status', sovereignId, applicationName, namespace, refreshTick],
     queryFn: () => getApplicationStatus(sovereignId, applicationName, namespace),
-    enabled: !initialApp && !isBootstrap && !!sovereignId && !!applicationName,
-    refetchInterval: isBootstrap ? false : 10_000,
+    enabled: statusEnabled,
+    refetchInterval: (query) => (query.state.status === 'error' ? false : 10_000),
     retry: false,
   })
 
   const app: ApplicationStatus | undefined = initialApp ?? statusQ.data
+
+  // Has the status question been ANSWERED yet? Distinct from "is there an
+  // answer": the Status panel below must not render its abstention prose while
+  // the request is still in flight, or every bootstrap component flashes
+  // "no status" before its real one arrives. A disabled query counts as
+  // settled — nothing is coming.
+  const statusSettled = !statusEnabled || statusQ.isSuccess || statusQ.isError
 
   // #3982 — the REAL placement, derived from where the component's
   // workloads actually run across BOTH region clusters. This is the
@@ -1042,15 +1067,20 @@ export function TopologyTab({
         data-testid="topology-tab-status-panel"
       >
         <h3 className="mb-2 text-sm font-semibold text-[var(--color-text-strong)]">Status</h3>
-        {isBootstrap ? (
-          <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-status-bootstrap">
-            n/a — bootstrap component (HelmRelease, no Application CR). Live rollout status is tracked via Flux.
-          </p>
-        ) : !app ? (
-          <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-status-loading">
-            Loading status…
-          </p>
-        ) : (
+        {/* #5934 — the ANSWER decides what renders here, never the component's
+            CLASS. This branch used to lead on `isBootstrap` and hard-render the
+            n/a prose regardless of what the API returned, so the real-status
+            branch was unreachable for the ~40 bootstrap-kit components on a
+            converged Sovereign — including when a caller had already handed us
+            a status via initialApp. That is what made rows 67 and 69 read
+            "n/a — bootstrap component" three inches under a header saying
+            STATUS Ready.
+
+            The abstention survives, narrowed to the one case that earns it: we
+            asked and the endpoint genuinely had nothing (both synthesisers
+            missed → 404). "We did not ask" and "there is no answer" must not
+            render identically. */}
+        {app ? (
           <div className="flex items-center gap-2 text-xs" data-testid="topology-tab-recon-status">
             <span
               className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 font-semibold ${
@@ -1069,6 +1099,14 @@ export function TopologyTab({
               </span>
             ) : null}
           </div>
+        ) : isBootstrap && statusSettled ? (
+          <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-status-bootstrap">
+            n/a — bootstrap component (HelmRelease, no Application CR). Live rollout status is tracked via Flux.
+          </p>
+        ) : (
+          <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-status-loading">
+            Loading status…
+          </p>
         )}
       </section>
     </div>


### PR DESCRIPTION
## Cause — two lines, both on `main`

`products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx`

- **:144** — `enabled: !initialApp && !isBootstrap && …` plus `refetchInterval: isBootstrap ? false : 10_000` **disabled the status poll outright** for a bootstrap component, so the console never asked.
- **:1045-1047** — the Status panel branched on `isBootstrap` **first** and hard-rendered

  ```
  n/a — bootstrap component (HelmRelease, no Application CR). Live rollout status is tracked via Flux.
  ```

  **regardless of what the API returned** — so the real-status branch was unreachable for the ~40 bootstrap-kit components on a converged Sovereign.

Rows 67 and 69 measured that string sitting three inches under a header reading **STATUS Ready**. One page contradicting itself.

## Why this is not deploy-gated

#5836 (Refs #5835) already landed the API half: `HandleApplicationStatus` falls through to `statusFromSynthesised` — HelmRelease first, then live runtime — instead of hard-404ing for a component with no Application CR. That fix is merged and on `main`.

**Rolling the image would not have moved either row.** The console never asks, and would discard the answer if it did. A fresh prov would have left 67 and 69 red and the ledger would have blamed delivery for a front-end defect.

#5835's own fix note called this out and deliberately scoped it out: *"NOT CLAIMED: the FE isBootstrap gate is NOT removed — that is a separate change."* This is that change.

## Fix

Ask for every component; let the **answer** decide what renders, never the component's **class**.

- `enabled` no longer consults `isBootstrap`.
- `refetchInterval: (query) => (query.state.status === 'error' ? false : 10_000)` — **#3656's actual concern is retained**. The 404-loop worry was right; "never ask at all" was too blunt an answer and it outlived its cause. With `retry: false` this is one 404 per mount, never a loop.
- The Status panel leads on `app`, falling back to the n/a prose only when `isBootstrap && statusSettled` — i.e. we asked and the endpoint genuinely had nothing (both synthesisers missed → 404). *"We did not ask"* and *"there is no answer"* must not render identically.
- `statusSettled` exists so the abstention never flashes while the request is in flight.

`isBootstrap` now selects only the abstention **copy** and the #4000 empty-namespace placement lookup; its prop doc is updated to say it must never again decide *whether* to ask.

## Test — failing then passing

New file `TopologyTab.bootstrapStatus-5934.test.tsx`, 7 cases.

**BEFORE the fix:**

```
× renders the REAL status the API returns for a bootstrap component, not the hardcoded n/a string
× POLLS the status endpoint for a bootstrap component (#5836 made it answer)
× a Degraded bootstrap component reads Degraded, not a constant green chip
× CONTROL: initialApp still short-circuits the poll entirely
  Tests  4 failed | 3 passed (7)
```

**AFTER the fix:**

```
  Tests  7 passed (7)
```

**The two lines are independently load-bearing, and that is mutation-verified.** Restoring only the `isBootstrap`-first render branch — with the poll left fully un-gated — turns 3 guards RED again:

```
× renders the REAL status the API returns for a bootstrap component, not the hardcoded n/a string
× a Degraded bootstrap component reads Degraded, not a constant green chip
× CONTROL: initialApp still short-circuits the poll entirely
  Tests  3 failed | 4 passed (7)
```

So un-gating the poll alone would still have printed `n/a`, and un-gating the render alone would have left the panel with nothing to render. Fixing either one would have moved a symptom.

Notes on guard shape:

- The **Degraded** case exists so a fix that pinned the chip to a constant green `Reconciled` cannot pass — that would be a worse lie than the string it replaced.
- The **fallback** case asserts the n/a prose still appears on a genuine 404, so the narrowing did not become a deletion.
- The **no-loop** case pins #3656's retained concern directly: call count does not grow after the endpoint has answered 404.
- Every negative assertion waits on a **positive** anchor first. TanStack mounts on a microtask, so a synchronous "element absent" check passes for the wrong reason against an empty body — the failure mode #5814's own fix note recorded.

**A finding the guards surfaced:** the `initialApp` control failed *before* the fix too. The hard-render discarded even a status handed straight in through the test/pre-fill seam, so the defect was never limited to the network path.

## Superseded cases rewritten, not deleted

Three cases in `TopologyTab.test.tsx` encoded the old contract:

- `does NOT poll the status endpoint for a bootstrap component` — asserted the exact defect. Rewritten to the corrected contract with a note recording why the #3656 assertion expired and where its surviving concern is now pinned.
- Two DR cases used the n/a prose as an incidental render anchor. Re-anchored on the subject each case is actually about (`topology-tab-status-panel`; the replication-status call + placement panel), so their negatives cannot pass merely because nothing has rendered.

## Gates

- `npm run typecheck` (`tsc -b --noEmit`) — clean
- `npx eslint` on all three touched files — clean
- `npx vitest run src/pages/sovereign/AppDetail/` — **12 files, 92 tests passed**
- `npx vitest run` (full sovereign-admin console suite) — **230 files, 2128 passed, 1 expected-fail**
- `scripts/check-no-banned-words.sh` — OK

Typecheck + AppDetail suite + banned-words chained ahead of the commit (`gate && gate && gate && add && commit && push`), never run on their own line.

Refs #5934, #5835, #3656
