### PR TITLE
fix(dashboard): group the vCluster treemap layer on a runtime signal, not a label #4325 deleted

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/dashboard.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard.go
@@ -391,6 +391,53 @@ type podRow struct {
 // HandleTreemap. Used as a region fallback when Pods/Nodes lack the
 // `openova.io/region`/`topology.kubernetes.io/region` label — common
 // on HCS where Huawei CCM doesn't stamp the topology label.
+// vclustersFromRuntime returns namespace -> vCluster name for every
+// namespace that is OBSERVED to host a vCluster, keyed off the syncer's
+// own `vcluster.loft.sh/managed-by` label on the pods it mirrors into
+// the host namespace.
+//
+// #5932: the pre-existing join key was `catalyst.openova.io/vcluster-role`,
+// which only ever existed because bp-{mgmt,dmz,rtz}-vcluster stamped it.
+// #4325 deleted all three of those charts, and the per-Org vClusters that
+// replaced them (written by the org-controller) stamp nothing equivalent.
+// So the label matched zero namespaces on every post-#4325 Sovereign, every
+// pod fell through to the "host" bucket, and the vCluster treemap layer
+// rendered a single block — the data was present the whole time, only the
+// key was dead. A grouping key that silently matches nothing degrades to
+// one bucket instead of failing, which is why this went unnoticed.
+//
+// Keying on the syncer label instead means the answer is derived from what
+// is actually running (#3969: placement is read from runtime, never from a
+// declared field). It also holds for a vCluster created by any chart, since
+// the label is written by vCluster itself rather than by our templates.
+//
+// The BLOCK NAME is the host namespace's `openova.io/organization` label,
+// not the managed-by value: every per-Org vCluster is installed under the
+// same release name (`vcluster`), so naming blocks after it would collapse
+// all Organizations into one cell — the very bug being fixed. Namespaces
+// with no synced pod are absent from the map and keep bucketing to "host",
+// which is correct for a namespace-isolated Organization.
+func vclustersFromRuntime(pods []*unstructured.Unstructured, nsByName map[string]*unstructured.Unstructured) map[string]string {
+	out := map[string]string{}
+	for _, p := range pods {
+		if _, synced := p.GetLabels()["vcluster.loft.sh/managed-by"]; !synced {
+			continue
+		}
+		ns := p.GetNamespace()
+		if _, done := out[ns]; done {
+			continue
+		}
+		name := ns
+		if n, ok := nsByName[ns]; ok {
+			if org := n.GetLabels()["openova.io/organization"]; org != "" {
+				name = org
+			}
+		}
+		out[ns] = name
+	}
+	return out
+}
+
 func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets []*unstructured.Unstructured, clusterID string, clusterCloudRegion string) []podRow {
 	pvcByKey := map[string]*unstructured.Unstructured{}
 	for _, p := range pvcs {
@@ -409,6 +456,7 @@ func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets []*unst
 	for _, ns := range namespaces {
 		nsByName[ns.GetName()] = ns
 	}
+	vclusterByNS := vclustersFromRuntime(pods, nsByName)
 	// Node-label join keys: `openova.io/region` (canonical OpenOva) or
 	// `topology.kubernetes.io/region` (K8s standard, set by hcloud-ccm
 	// on every Hetzner node). Pods inherit via spec.nodeName.
@@ -444,6 +492,13 @@ func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets []*unst
 		vcluster := stringLabel(p, "catalyst.openova.io/vcluster-role", "")
 		if vcluster == "" {
 			vcluster = nsLabels["catalyst.openova.io/vcluster-role"]
+		}
+		// #5932: neither label exists on a per-Org vCluster, so without
+		// this fallback EVERY pod bucketed to "host" and the vCluster
+		// layer rendered one undifferentiated block. See
+		// vclustersFromRuntime for why the runtime signal is the join key.
+		if vcluster == "" {
+			vcluster = vclusterByNS[p.GetNamespace()]
 		}
 		// Derive region: pod-level label wins, then Namespace label,
 		// then the pod's host Node's region labels. Empty falls back

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
@@ -1224,3 +1224,103 @@ func TestDashboardTreemap_ApplicationNamedAfterDeploymentNotReplicaSet(t *testin
 		t.Errorf("coredns cpu_request: got %v want 50m", bySize["coredns"])
 	}
 }
+
+/* ── #5932 per-Org vCluster grouping ─────────────────────────────── */
+
+// mkOrgNamespace is a host Namespace for an Organization: it carries the
+// `openova.io/organization` join key but deliberately NOT
+// `catalyst.openova.io/vcluster-role`, because no post-#4325 Sovereign
+// stamps that label anywhere. Measured on hw292 2026-08-10: the label
+// matched 0 of 45 namespaces.
+func mkOrgNamespace(name, org string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":            name,
+			"resourceVersion": "1",
+			"labels":          map[string]any{"openova.io/organization": org},
+		},
+	}}
+}
+
+// mkSyncedPod is a pod mirrored into the host namespace by the vCluster
+// syncer. The managed-by VALUE is the vCluster's Helm release name, which
+// is `vcluster` for every per-Org install — identical across Organizations
+// on purpose, since keying blocks on it is the collapse this test forbids.
+func mkSyncedPod(ns, name, app string) *unstructured.Unstructured {
+	p := mkDashPod(dashFixturePod{
+		Namespace: ns, Name: name, Application: app, Family: "",
+		CPURequest: "100m", Ready: true,
+	})
+	p.Object["metadata"].(map[string]any)["labels"].(map[string]any)["vcluster.loft.sh/managed-by"] = "vcluster"
+	return p
+}
+
+// TestVclustersFromRuntime_PerOrgBlocksDoNotCollapse pins #5932.
+//
+// Before the fix the only join key was `catalyst.openova.io/vcluster-role`,
+// which #4325 stopped producing. Every pod then fell through to the "host"
+// bucket and LAYER1=vCluster rendered ONE block, so the layer silently
+// degraded instead of failing. Each sub-case below fails on the pre-fix
+// code, which is what makes this a check rather than a description.
+func TestVclustersFromRuntime_PerOrgBlocksDoNotCollapse(t *testing.T) {
+	namespaces := []*unstructured.Unstructured{
+		mkOrgNamespace("uatco", "uatco"),
+		mkOrgNamespace("walk-stranger-two", "walk-stranger-two"),
+		mkDashNamespace("catalyst", "", ""), // host: no Org label, no synced pod
+	}
+	pods := []*unstructured.Unstructured{
+		mkSyncedPod("uatco", "coredns-0", "coredns"),
+		mkSyncedPod("walk-stranger-two", "coredns-0", "coredns"),
+		mkDashPod(dashFixturePod{Namespace: "catalyst", Name: "api-0",
+			Application: "catalyst-api", CPURequest: "100m", Ready: true}),
+	}
+
+	// The pre-fix key must be absent from every fixture, otherwise this
+	// test could pass on the old code and prove nothing.
+	for _, ns := range namespaces {
+		if _, bad := ns.GetLabels()["catalyst.openova.io/vcluster-role"]; bad {
+			t.Fatalf("fixture %s carries the retired label; the test would not exercise the fix", ns.GetName())
+		}
+	}
+
+	rows := buildPodRows(pods, nil, nil, namespaces, nil, nil, "cid", "")
+	got := map[string]string{}
+	for _, r := range rows {
+		id, _ := dimensionKey(r, "vcluster")
+		got[r.namespace] = id
+	}
+
+	if got["uatco"] != "uatco" {
+		t.Errorf("uatco pod must bucket under its own Organization's vCluster; got %q", got["uatco"])
+	}
+	if got["walk-stranger-two"] != "walk-stranger-two" {
+		t.Errorf("walk-stranger-two pod must bucket under its own vCluster; got %q", got["walk-stranger-two"])
+	}
+	// The collapse guard: both vClusters share managed-by="vcluster", so a
+	// fix that named blocks after that value would put them in one bucket.
+	if got["uatco"] == got["walk-stranger-two"] {
+		t.Errorf("two distinct per-Org vClusters collapsed into one block %q", got["uatco"])
+	}
+	// Negative control: a namespace with no synced pod is NOT a vCluster.
+	// Without this, a helper that returned every namespace would pass above.
+	if got["catalyst"] != "host" {
+		t.Errorf("host namespace must stay in the host bucket; got %q", got["catalyst"])
+	}
+}
+
+// TestVclustersFromRuntime_LegacyLabelStillWins keeps the pre-#4325 path
+// working: an env that DOES carry `vcluster-role` must group by it, so
+// this fix adds a fallback rather than replacing the existing behaviour.
+func TestVclustersFromRuntime_LegacyLabelStillWins(t *testing.T) {
+	namespaces := []*unstructured.Unstructured{mkDashNamespace("mgmt-ns", "mgmt", "")}
+	pods := []*unstructured.Unstructured{mkDashPodOnNode("mgmt-ns", "p-0", "grafana", "")}
+	rows := buildPodRows(pods, nil, nil, namespaces, nil, nil, "cid", "")
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row; got %d", len(rows))
+	}
+	if id, _ := dimensionKey(rows[0], "vcluster"); id != "mgmt" {
+		t.Errorf("legacy vcluster-role label must still win; got %q", id)
+	}
+}


### PR DESCRIPTION
## What

`dimensionKey(row, "vcluster")` bucketed on `catalyst.openova.io/vcluster-role`. That label was only ever written by `bp-mgmt-vcluster` / `bp-dmz-vcluster` / `bp-rtz-vcluster`. **#4325 deleted all three charts**, and the per-Org vClusters that replaced them (written by the org-controller) stamp nothing equivalent.

So on every post-#4325 Sovereign the key matched nothing, every pod fell through to the `host` bucket, and `LAYER1=vCluster` rendered one undifferentiated block.

## Why it went unnoticed

A grouping key that matches nothing **degrades to a single bucket instead of erroring**. The render stayed green, the data was there the whole time, only the key was dead. This is the same shape as the retired-clause problem the UAT slot itself had — the row that should have caught it was frozen against the same dead migration.

## Measured, not assumed (hw292, 2026-08-10)

| Signal | Result |
|---|---|
| namespaces carrying `catalyst.openova.io/vcluster-role` | **0 of 45** |
| namespaces observed hosting a vCluster | **2** (`uatco`, `walk-stranger-two`) |
| `vcluster.loft.sh/managed-by` in host ns `catalyst`/`harbor`/`keycloak` | **absent** |
| `vcluster.loft.sh/managed-by` in `hw292-omani-works` (namespace-isolated Org) | **absent** |

The last two rows are the negative control: the new key is not simply true everywhere.

## The fix

Fall back to `vcluster.loft.sh/managed-by`, which the vCluster syncer writes onto the pods it mirrors into the host namespace. That makes the grouping a **runtime observation** (#3969 — placement is read from what is running, never from a declared field) and works for a vCluster created by any chart, not just ours.

The block **name** comes from the host namespace's `openova.io/organization`, deliberately **not** from the managed-by value: every per-Org vCluster installs under the same release name `vcluster`, so naming blocks after it would collapse all Organizations into one cell — the same bug wearing a different key. `TestVclustersFromRuntime_PerOrgBlocksDoNotCollapse` asserts that non-collapse explicitly.

## Verified able to fail

With the fallback disabled, both Organizations bucket to `"host"` and the collapse assertion trips:

```
uatco pod must bucket under its own Organization's vCluster; got "host"
walk-stranger-two pod must bucket under its own vCluster; got "host"
two distinct per-Org vClusters collapsed into one block "host"
```

That reproduces the live symptom, so the test is a check rather than a description. The fixtures also assert the retired label is absent from themselves, otherwise the test could pass on the old code and prove nothing.

## Compatibility

The legacy path is kept and covered — `TestVclustersFromRuntime_LegacyLabelStillWins` shows an env still carrying `vcluster-role` groups by it. This adds a fallback, it does not replace behaviour.

## Gates

- `go build ./...` clean
- `go vet ./internal/handler/` clean
- full `internal/handler` suite green (257s), not a targeted subset

## UAT

Closes the source half of rows **102** and **103** (row 103's evidence records that fixing 102 closes it with no separate work — the isolation itself already measures sound, only the rendering was broken). Both are deploy-gated behind a catalyst-api roll.

Refs #5932, #4325, #3969
