### PR TITLE
fix(cutover): add mail.openova.io to the step-08 deny set — the 9th tether the proof certified as absent (#5921)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1066,7 +1066,7 @@ spec:
       # Sovereign (the git overwrite cannot preserve step-06's durable
       # HelmRepository-pivot commit); the reconciler also gains a CONTINUOUS
       # source-host drift lint (daytwoReconciler.sourceHostLint).
-      version: 0.1.176
+      version: 0.1.177
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1350,7 +1350,13 @@ spec:
       #   renders INSIDE this umbrella, so the entry only reaches a Sovereign
       #   once the umbrella republishes and this pin advances (#5734).
       #   Lockstep w/ products/catalyst/chart/Chart.yaml + slot-13d (0.1.6).
-      version: 1.4.1331
+      # 1.4.1332 (#5921, Refs #5919): the catalog-seed card + delivery pin for
+      #   bp-self-sovereign-cutover move 0.1.176 -> 0.1.177 (mail.openova.io
+      #   added to the step-08 deny set). The seed renders INSIDE this
+      #   umbrella, so the new pin only reaches a Sovereign once the umbrella
+      #   republishes and this pin advances (#5734). Lockstep w/
+      #   products/catalyst/chart/Chart.yaml + slot-06a (0.1.177).
+      version: 1.4.1332
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.176
+  version: 0.1.177
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3652,7 +3652,7 @@ name: bp-self-sovereign-cutover
 # pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
 # blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.176
+version: 0.1.177
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2087,6 +2087,21 @@ egressTest:
     # blocked by omission from the allow-list; this entry drives the active
     # call-home assertion that PROVES it is unreachable.
     - "console.openova.io"
+    # mail.openova.io (#5921): the NINTH tether, and the only one on the
+    # PURCHASE path. catalyst-system/marketplace-api sends every customer
+    # sign-in code through the mothership SMTP host, so on a post-cutover
+    # Sovereign a paying customer cannot complete checkout unless OUR mail
+    # server answers. ADR-0002 enumerates EIGHT tethers and outbound
+    # customer-auth SMTP is not among them, so no cutover step pivots it and
+    # nothing looked for it.
+    #
+    # It was absent from this list, which is exactly why the 600s hold passed
+    # with the tether fully live: this proof examines ONLY the hosts named
+    # here and infers sovereignty from their absence. Same shape as the 62
+    # ghcr.io HelmRepositories that survived the same hold (#5919). A host
+    # missing from this list is not merely untested — it is actively
+    # certified independent, which is worse.
+    - "mail.openova.io"
     # TBD-V24 MISS-3 (chart 0.1.37): xpkg.upbound.io is the Crossplane
     # Provider package upstream. Step 11 pivots every Provider's
     # spec.package literal off this host, so the deny-egress hold proof

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T14:31:16.253Z",
+  "generatedAt": "2026-08-10T10:48:53.140Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.176",
+      "version": "0.1.177",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.176",
+    "version": "0.1.177",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3757,7 +3757,14 @@ name: bp-catalyst-platform
 #   Blueprint CR list is the ONLY catalog leg that answers, and those CRs are
 #   whatever the LAST PUBLISHED umbrella rendered — hence this republish, per
 #   check-umbrella-republish-gate.py (#5734). Lockstep w/ slot-13 pin.
-version: 1.4.1331
+# 1.4.1332 (#5921, Refs #5919): the catalog-seed card + delivery pin for
+#   bp-self-sovereign-cutover move 0.1.176 -> 0.1.177 (mail.openova.io added
+#   to the step-08 deny set). A seed pin that moves without this file's
+#   version moving is never carried by the published OCI artifact, so the
+#   Sovereign would keep installing cutover 0.1.176 while the seed in git
+#   claimed 0.1.177 — check-umbrella-republish-gate.py (#5734). Lockstep w/
+#   slot-13 pin.
+version: 1.4.1332
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3912,7 +3919,7 @@ version: 1.4.1331
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1331
+appVersion: 1.4.1332
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.176"
+  version: "0.1.177"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.176"
+    version: "0.1.177"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The tether

`catalyst-system/marketplace-api` sends **every customer sign-in code** through `mail.openova.io`. On a post-cutover Sovereign with `cutoverComplete=true`, a paying customer cannot complete checkout unless **our** mail server answers.

ADR-0002 enumerates **eight** tethers. Outbound customer-auth SMTP is not among them, so no cutover step pivots it — and nothing looked for it.

## Why the proof missed it

Step-08 holds a deny-egress NetworkPolicy for 600s and calls the Sovereign independent if the cluster stays green. `mail.openova.io` was not in the deny set, so **the hold passed with the tether fully live** — the same shape as the 62 `ghcr.io` HelmRepositories that survived the same proof (#5919).

The distinction that matters: **a host missing from this list is not merely untested — it is actively certified independent.** The proof examines only the hosts it is told about and infers sovereignty from their absence.

## My first edit was inert, and the render caught it

I added the host to the template's `default (list ...)` fallback. It reads correctly — but `values.yaml` **sets `blockedDomains` explicitly**, so that default never fires. `helm template` showed `UPSTREAM_HOSTS` unchanged at five hosts. Reverted the template and fixed the site that actually governs.

## Render-verified

```
before: "github.com ghcr.io harbor.openova.io console.openova.io xpkg.upbound.io"
after:  "github.com ghcr.io harbor.openova.io console.openova.io mail.openova.io xpkg.upbound.io"
```

**Control:** `--set egressTest.blockedDomains[0]=only.example` renders `"only.example"` — proving the value is read from values rather than baked into the template.

## Scope — deliberately half the fix

This makes the tether **visible to the proof**. It does **not** pivot it. The Sovereign still needs its own outbound mail path, which is the larger half of #5921 and is not in this change.

A cutover run on 0.1.177 will now **FAIL step-08** while that remains true. That is the correct outcome: better a red proof than a green one asserting sovereignty that does not hold.

## Lockstep — five sites, and the three that were behind

The first push moved only sites 1 and 5 (chart `Chart.yaml` + the bootstrap-kit
pin), which is exactly the shape #5583 exists to catch: the shell pin-sync guard
passes on those two alone, and each of the remaining three fails in a *different*
guard, so nothing tells you the whole list at once.

| # | Site | Was | Now |
|---|---|---|---|
| 1 | `platform/self-sovereign-cutover/chart/Chart.yaml` | 0.1.176 | **0.1.177** |
| 2 | `platform/self-sovereign-cutover/blueprint.yaml` `spec.version` | 0.1.176 (behind) | **0.1.177** |
| 3 | catalog-seed card + delivery pin | 0.1.176 (delivery behind) | **0.1.177** |
| 4 | generated catalog (`blueprints.json` + `catalog.generated.ts`) | 0.1.176 (behind) | **0.1.177** |
| 5 | `clusters/_template/bootstrap-kit/06a-…` pin | 0.1.176 | **0.1.177** |

Site 4 was regenerated with `build-catalog.mjs` rather than hand-edited, and site
3 was written by `scripts/sync-catalog-seed-pin.py` (it reports a clean no-op on
re-run, which is the check that the two lines agree).

Umbrella republish `1.4.1331 → 1.4.1332` + slot-13 pin in lockstep — re-serialized
because #5843 took 1.4.1331 on main first. `appVersion` moves with `version`:
`check-chart-version-forward.sh` rejects the two diverging, which is the 215d6e4bf
shape from #5743.

## Gates, run locally on this tree

```
check-bootstrap-kit-pin-sync.sh                     PASS  67 chart→pin pairs
check-umbrella-republish-gate.py (#5734)            PASS  160 pins / 80 Blueprints @ 1.4.1332
check-catalog-seed-lockstep.sh                      PASS  68 checked, 0 fail
go test TestBootstrapKit_BlueprintVersionLockstepSweep|TestCatalogSeed   ok
check-release-lockstep-writer.py                    PASS  bump / noop / retry / umbrella
```

The last one is the guard that was red: its `umbrella` case runs the release
writer against this tree and then re-runs the bootstrap-kit Go guards on what it
pushed, so the `blueprint.yaml` drift surfaced there and in `manifest-validation`
from a single cause.

## Render, re-verified after the rebase

```
$ helm template cutover platform/self-sovereign-cutover/chart | grep -A1 UPSTREAM_HOSTS
          - name: UPSTREAM_HOSTS
            value: "github.com ghcr.io harbor.openova.io console.openova.io mail.openova.io xpkg.upbound.io"
```

**Control** — `--set egressTest.blockedDomains[0]=only.example` renders
`value: "only.example"`, so the list is read from `values.yaml` and not baked
into the template. That is the inert-`default` trap this PR's first edit hit.

## Housekeeping

Three files were swept into `414df7c2c` by accident and have been dropped:
`.uat-funnel2.mjs` and `ag.html` (scratch files at the repo root) and 550 lines of
unrelated `docs/ledger/uat-raw.csv` churn.

## The one remaining red

`ghcr-pin-existence` — `bp-self-sovereign-cutover:0.1.177` is this PR's own bump
and the chart publishes on merge. The job is declared
`continue-on-error: ${{ github.event_name != 'schedule' }}` in
`.github/workflows/check-catalog-seed-lockstep.yaml`, i.e. deliberately
non-blocking on `pull_request` for precisely this reason, and fail-loud on the
hourly cron once the publish race is over.

Refs #5921, #5919, #3678, #3379, #5583, #5734
