### PR TITLE
fix(org): per-Org console listeners land in EVERY region, and an unconverged region holds the Org back

### DIFF
--- a/core/controllers/organization/cmd/main.go
+++ b/core/controllers/organization/cmd/main.go
@@ -136,6 +136,18 @@ func main() {
 	// catalyst-system; the route + backendRefs share that namespace so they
 	// resolve without a ReferenceGrant. Defaults match the catalyst chart
 	// Service names/ports; env-overridable per Inviolable Principle #4.
+	// #5246 — per-Org console listeners span EVERY region. The secondary
+	// regions' kubeconfigs already exist in-cluster as the #5359 bridge Secret
+	// (`<regionKey>.yaml` per secondary CP); the Cilium ClusterMesh config
+	// Secret is the independent witness of how many other regions this
+	// Sovereign has, so "no kubeconfigs wired" can never silently read as "no
+	// secondary regions". Defaults match the shipping chart; per Inviolable
+	// Principle #4 all four are env-overridable.
+	secondaryKubeconfigSecret := envOr("CATALYST_SECONDARY_REGION_KUBECONFIG_SECRET", "cutover-secondary-kubeconfigs")
+	secondaryKubeconfigSecretNs := envOr("CATALYST_SECONDARY_REGION_KUBECONFIG_SECRET_NAMESPACE", "catalyst")
+	clusterMeshSecret := envOr("CATALYST_CLUSTERMESH_SECRET", "cilium-clustermesh")
+	clusterMeshSecretNs := envOr("CATALYST_CLUSTERMESH_SECRET_NAMESPACE", "kube-system")
+
 	consoleRouteNs := envOr("CATALYST_CONSOLE_ROUTE_NAMESPACE", "catalyst-system")
 	consoleAPISvc := envOr("CATALYST_CONSOLE_API_SERVICE", "catalyst-api")
 	consoleUISvc := envOr("CATALYST_CONSOLE_UI_SERVICE", "catalyst-ui")
@@ -287,6 +299,11 @@ func main() {
 		PoolPowerDNSSourceSecretNamespace: poolPowerDNSSourceSecretNS,
 		TenantConsoleLBIPv4:               tenantConsoleLBIPv4,
 		TenantPrimaryLBIPv4:               tenantPrimaryLBIPv4,
+
+		SecondaryRegionKubeconfigSecretName:      secondaryKubeconfigSecret,
+		SecondaryRegionKubeconfigSecretNamespace: secondaryKubeconfigSecretNs,
+		ClusterMeshSecretName:                    clusterMeshSecret,
+		ClusterMeshSecretNamespace:               clusterMeshSecretNs,
 	}
 	if err := r.SetupWithManager(mgr); err != nil {
 		log.Error(err, "setup reconciler")

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -367,6 +367,35 @@ type Reconciler struct {
 	// the record still resolves. Env: CATALYST_OTECH_INGRESS_IPV4 (the same key
 	// catalyst-api's tenant DNS provisioner reads).
 	TenantPrimaryLBIPv4 string
+
+	// #5246 — per-Org console listeners span EVERY region, not just the one
+	// this controller runs in. See tenant_console_tls_regions.go for the
+	// defect, the seam and the anti-vacuity witness.
+
+	// SecondaryRegionKubeconfigSecretName / …Namespace locate the #5359
+	// bridge Secret whose `<regionKey>.yaml` keys carry each secondary
+	// region's kubeconfig. Defaults: cutover-secondary-kubeconfigs /
+	// catalyst. Env: CATALYST_SECONDARY_REGION_KUBECONFIG_SECRET{,_NAMESPACE}.
+	SecondaryRegionKubeconfigSecretName      string
+	SecondaryRegionKubeconfigSecretNamespace string
+
+	// ClusterMeshSecretName / …Namespace locate the Cilium ClusterMesh config
+	// Secret used as the INDEPENDENT witness of how many other regions this
+	// Sovereign has — without it, "no kubeconfigs wired" would silently mean
+	// "no secondary regions" and the per-region check could never fail.
+	// Defaults: cilium-clustermesh / kube-system.
+	// Env: CATALYST_CLUSTERMESH_SECRET{,_NAMESPACE}.
+	ClusterMeshSecretName      string
+	ClusterMeshSecretNamespace string
+
+	// RegionClientBuilder builds a client from a secondary region's
+	// kubeconfig bytes. Nil in production (a real REST client is built);
+	// tests inject fakes so the fan-out is exercised without an apiserver.
+	RegionClientBuilder func(kubeconfig []byte) (client.Client, error)
+
+	// regionClients memoizes the per-region clients between reconciles,
+	// keyed on the bridge Secret's resourceVersion. Lazily allocated.
+	regionClients *regionClientCache
 }
 
 // httpDoer is the narrow HTTP seam the pool-DNS writer needs — *http.Client

--- a/core/controllers/organization/internal/controller/provisioning_postconditions.go
+++ b/core/controllers/organization/internal/controller/provisioning_postconditions.go
@@ -185,40 +185,65 @@ func (r *Reconciler) verifyProvisioned(ctx context.Context, org *orgapi.Organiza
 	if !ok {
 		return out
 	}
-	rb, err := r.consoleOrgListenersReadback(ctx, names)
 	gwNS, gwName := r.consoleGatewayNamespace(), r.consoleGatewayName()
-	switch {
-	case err != nil:
-		out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
-			"console Gateway %s/%s listeners for %q: %s",
-			gwNS, gwName, names.WildcardHost, err))
-	case rb.GatewayAbsent || len(rb.SpecMissing) > 0:
+
+	// 5 — #5246. The read-back runs PER REGION. The console ELB backend pool
+	// spans every region's nodes, so a listener pair that exists only where
+	// this controller happens to run leaves ~1/N of customer TLS connections
+	// answering with a reset. A single-region read-back is a guard that cannot
+	// fail on that defect: it verifies only the region we were always able to
+	// write. Regions the fan-out could not resolve a client for are folded in
+	// below with the same discipline — an UNWIRED region is a proven-absent
+	// artifact (no credential exists, so the listener can never land there),
+	// while an UNREACHABLE one is only a requeue (an apiserver blip must not
+	// red-flag every Organization on the Sovereign at once).
+	res := r.consoleRegionTargets(ctx)
+	for _, u := range res.Unwired {
 		out.Missing = append(out.Missing, fmt.Sprintf(
-			"console Gateway listeners %s/%s on %s/%s for hostname %q (without them every HTTPRoute on that host is Accepted=False NoMatchingListenerHostname — the Org is unreachable)",
-			names.HTTPSName, names.HTTPName, gwNS, gwName, names.WildcardHost))
-	default:
-		// 4 — the listener is in spec. That is NOT the same as serving. Both
-		// checks below close a way for the door to be dead while every status
-		// surface reads green (#5511).
-		if len(rb.PortDrift) > 0 {
-			out.Missing = append(out.Missing, fmt.Sprintf(
-				"console Gateway listeners on %s/%s bind the wrong port — %s (the console LoadBalancer forwards public 443/80 to the apex console-https/console-http ports and nothing else, so a per-Org listener on any other port receives no traffic and %q answers 000 while the workload behind it is healthy)",
-				gwNS, gwName, strings.Join(rb.PortDrift, ", "), names.WildcardHost))
-		}
+			"console Gateway listeners %s/%s in every region — %s (the console ELB pool forwards customer TLS to every region's nodes, so a region with no listener resets the handshake for %q on the share of connections it receives)",
+			names.HTTPSName, names.HTTPName, u, names.WildcardHost))
+	}
+	for _, u := range res.Unreachable {
+		out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
+			"console Gateway listeners for %q in every region — %s", names.WildcardHost, u))
+	}
+
+	for _, tgt := range res.Targets {
+		region := "region " + tgt.Region
+		rb, err := r.consoleOrgListenersReadback(ctx, tgt.Client, names)
 		switch {
-		case !rb.StatusObserved:
-			// The Gateway controller has not published ANY listener status
-			// yet. Absence of evidence, not evidence of absence — requeue.
-			// This is also the vacuity guard on the check below: without it,
-			// "our listener is in status" would pass trivially on an empty
-			// status and assert nothing at all.
+		case err != nil:
 			out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
-				"console Gateway %s/%s status.listeners is empty — the Gateway controller has not published listener status yet, so acceptance of %s/%s cannot be decided",
-				gwNS, gwName, names.HTTPSName, names.HTTPName))
-		case len(rb.StatusDropped) > 0:
+				"console Gateway %s/%s listeners for %q in %s: %s",
+				gwNS, gwName, names.WildcardHost, region, err))
+		case rb.GatewayAbsent || len(rb.SpecMissing) > 0:
 			out.Missing = append(out.Missing, fmt.Sprintf(
-				"console Gateway %s/%s ACCEPTED %d listeners into spec but published only %d in status — silently dropped: %s (a listener in spec and absent from status carries no condition and no event: from the operator's side it is indistinguishable from one that was never configured, yet every per-Org customer door depends on it)",
-				gwNS, gwName, rb.SpecCount, rb.StatusCount, strings.Join(rb.StatusDropped, ", ")))
+				"console Gateway listeners %s/%s on %s/%s in %s for hostname %q (without them every HTTPRoute on that host is Accepted=False NoMatchingListenerHostname — the Org is unreachable)",
+				names.HTTPSName, names.HTTPName, gwNS, gwName, region, names.WildcardHost))
+		default:
+			// 4 — the listener is in spec. That is NOT the same as serving. Both
+			// checks below close a way for the door to be dead while every status
+			// surface reads green (#5511).
+			if len(rb.PortDrift) > 0 {
+				out.Missing = append(out.Missing, fmt.Sprintf(
+					"console Gateway listeners on %s/%s in %s bind the wrong port — %s (the console LoadBalancer forwards public 443/80 to the apex console-https/console-http ports and nothing else, so a per-Org listener on any other port receives no traffic and %q answers 000 while the workload behind it is healthy)",
+					gwNS, gwName, region, strings.Join(rb.PortDrift, ", "), names.WildcardHost))
+			}
+			switch {
+			case !rb.StatusObserved:
+				// The Gateway controller has not published ANY listener status
+				// yet. Absence of evidence, not evidence of absence — requeue.
+				// This is also the vacuity guard on the check below: without it,
+				// "our listener is in status" would pass trivially on an empty
+				// status and assert nothing at all.
+				out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
+					"console Gateway %s/%s status.listeners is empty in %s — the Gateway controller has not published listener status yet, so acceptance of %s/%s cannot be decided",
+					gwNS, gwName, region, names.HTTPSName, names.HTTPName))
+			case len(rb.StatusDropped) > 0:
+				out.Missing = append(out.Missing, fmt.Sprintf(
+					"console Gateway %s/%s in %s ACCEPTED %d listeners into spec but published only %d in status — silently dropped: %s (a listener in spec and absent from status carries no condition and no event: from the operator's side it is indistinguishable from one that was never configured, yet every per-Org customer door depends on it)",
+					gwNS, gwName, region, rb.SpecCount, rb.StatusCount, strings.Join(rb.StatusDropped, ", ")))
+			}
 		}
 	}
 	return out
@@ -263,12 +288,15 @@ type consoleListenerReadback struct {
 // genuinely has no console edge, and saying so honestly is the entire point —
 // `ensureConsoleOrgListener` returning `(false, nil)` for that same case is
 // what let the gap pass as success in the first place.
-func (r *Reconciler) consoleOrgListenersReadback(ctx context.Context, names orgConsoleTLSNames) (consoleListenerReadback, error) {
+//
+// The target cluster is a PARAMETER (#5246): the caller probes every region
+// the console ELB pool forwards to, not just the one this controller runs in.
+func (r *Reconciler) consoleOrgListenersReadback(ctx context.Context, c client.Client, names orgConsoleTLSNames) (consoleListenerReadback, error) {
 	var out consoleListenerReadback
 
 	gw := unstructured.Unstructured{}
 	gw.SetGroupVersionKind(gatewayGVK)
-	if err := r.Get(ctx, client.ObjectKey{
+	if err := c.Get(ctx, client.ObjectKey{
 		Namespace: r.consoleGatewayNamespace(),
 		Name:      r.consoleGatewayName(),
 	}, &gw); err != nil {

--- a/core/controllers/organization/internal/controller/tenant_console_tls.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls.go
@@ -72,6 +72,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -339,11 +340,49 @@ func (r *Reconciler) reconcileTenantConsoleTLS(ctx context.Context, org *orgapi.
 	if err != nil {
 		return false, fmt.Errorf("org wildcard cert for %q: %w", names.WildcardHost, err)
 	}
-	listenerChanged, err := r.ensureConsoleOrgListener(ctx, names)
-	if err != nil {
-		return certChanged, fmt.Errorf("console listener for %q: %w", names.WildcardHost, err)
+
+	// #5246 — the listener pair goes into EVERY region the Sovereign serves.
+	// The organization-controller Deployment exists in region A only, so the
+	// manager's client can structurally only ever reach region A; the console
+	// ELB pool forwards customer TLS to every region's nodes. A region with no
+	// per-Org listener resets the handshake, which is the measured hw292
+	// 5/10-vs-10/10 split. See tenant_console_tls_regions.go.
+	res := r.consoleRegionTargets(ctx)
+	changed := certChanged
+	var errs []string
+	for _, tgt := range res.Targets {
+		if !tgt.Host {
+			// The Certificate is issued once, in the host region; the peer
+			// region gets the ISSUED Secret mirrored so its listener has
+			// material to terminate on (one LE issuance per Org, not N).
+			mirrored, mirrorErr := r.mirrorConsoleOrgCertSecret(ctx, tgt.Client, names)
+			if mirrorErr != nil {
+				errs = append(errs, fmt.Sprintf("region %q cert mirror: %s", tgt.Region, mirrorErr))
+			}
+			changed = changed || mirrored
+		}
+		listenerChanged, listenerErr := r.ensureConsoleOrgListener(ctx, tgt.Client, names)
+		if listenerErr != nil {
+			errs = append(errs, fmt.Sprintf("region %q listener: %s", tgt.Region, listenerErr))
+			continue
+		}
+		changed = changed || listenerChanged
 	}
-	return certChanged || listenerChanged, nil
+	// A region we could not even resolve a client for was never written and
+	// must never be silently absent from the outcome — that is the exact shape
+	// (#5246) in which a "wrote it everywhere" claim is made over a region set
+	// the same step already lost.
+	for _, u := range res.Unwired {
+		errs = append(errs, "unwired secondary region: "+u)
+	}
+	for _, u := range res.Unreachable {
+		errs = append(errs, "unreachable secondary region: "+u)
+	}
+	if len(errs) > 0 {
+		sort.Strings(errs)
+		return changed, fmt.Errorf("console listener for %q: %s", names.WildcardHost, strings.Join(errs, "; "))
+	}
+	return changed, nil
 }
 
 // reconcileOrgWildcardCert create-or-updates the per-Org cert-manager
@@ -425,7 +464,11 @@ func (r *Reconciler) reconcileOrgWildcardCert(ctx context.Context, org *orgapi.O
 // and the `*.<slug>.<parent>` hostname match the catalyst-api BSS-door
 // emitter byte-for-byte (#4241), so whichever door provisions a given Org,
 // the gateway edge converges on one consistent listener.
-func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgConsoleTLSNames) (bool, error) {
+//
+// #5246 — the target cluster is a PARAMETER, not r.Client. The console ELB
+// pool spans every region's nodes, so the pair must be appended to every
+// region's console Gateway; the caller fans this over consoleRegionTargets.
+func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, c client.Client, names orgConsoleTLSNames) (bool, error) {
 	gwNS := r.consoleGatewayNamespace()
 	gwName := r.consoleGatewayName()
 	httpsName := names.HTTPSName
@@ -435,7 +478,7 @@ func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgCons
 
 	gw := unstructured.Unstructured{}
 	gw.SetGroupVersionKind(gatewayGVK)
-	if err := r.Get(ctx, client.ObjectKey{Namespace: gwNS, Name: gwName}, &gw); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: gwNS, Name: gwName}, &gw); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Console Gateway not present yet (early bootstrap window).
 			// Skip quietly — a later reconcile re-runs once sovereign-tls
@@ -536,7 +579,7 @@ func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgCons
 	if err := unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners"); err != nil {
 		return false, fmt.Errorf("set Gateway %s/%s listeners: %w", gwNS, gwName, err)
 	}
-	if err := r.Update(ctx, &gw); err != nil {
+	if err := c.Update(ctx, &gw); err != nil {
 		// A conflict means another writer (or our own prior pass) touched
 		// the Gateway — surface it so the caller requeues and re-reads.
 		return false, fmt.Errorf("update Gateway %s/%s: %w", gwNS, gwName, err)
@@ -563,10 +606,40 @@ func (r *Reconciler) teardownTenantConsoleTLS(ctx context.Context, org *orgapi.O
 		return false, nil
 	}
 
-	listenerChanged, err := r.removeConsoleOrgListener(ctx, names)
-	if err != nil {
-		return false, fmt.Errorf("remove console listener for %q: %w", names.WildcardHost, err)
+	// #5246 — strip the pair in EVERY region the up-path may have written it
+	// into. A region-A-only teardown is what leaves a deleted Org's listeners
+	// on a peer region's Gateway forever: measured on hw292, region B's
+	// console Gateway still carried `console-https-r17probe` /
+	// `console-http-r17probe` days after that Org was deleted, while carrying
+	// nothing for either LIVE Org.
+	res := r.consoleRegionTargets(ctx)
+	listenerChanged := false
+	var errs []string
+	for _, tgt := range res.Targets {
+		removed, err := r.removeConsoleOrgListener(ctx, tgt.Client, names)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("region %q listener: %s", tgt.Region, err))
+			continue
+		}
+		listenerChanged = listenerChanged || removed
+		if tgt.Host {
+			continue
+		}
+		mirrorGone, err := r.deleteMirroredConsoleOrgCertSecret(ctx, tgt.Client, names)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("region %q mirrored TLS Secret: %s", tgt.Region, err))
+			continue
+		}
+		listenerChanged = listenerChanged || mirrorGone
 	}
+	for _, u := range res.Unreachable {
+		errs = append(errs, "unreachable secondary region: "+u)
+	}
+	if len(errs) > 0 {
+		sort.Strings(errs)
+		return listenerChanged, fmt.Errorf("remove console listener for %q: %s", names.WildcardHost, strings.Join(errs, "; "))
+	}
+
 	certChanged, err := r.deleteOrgWildcardCert(ctx, names)
 	if err != nil {
 		return listenerChanged, fmt.Errorf("delete org wildcard cert %q: %w", names.CertName, err)
@@ -631,13 +704,15 @@ func (r *Reconciler) deleteOrgWildcardTLSSecret(ctx context.Context, names orgCo
 // err): changed=true iff at least one listener was actually removed.
 // No-op when the Gateway is absent (already gone) or carries neither
 // listener (idempotent on a re-run).
-func (r *Reconciler) removeConsoleOrgListener(ctx context.Context, names orgConsoleTLSNames) (bool, error) {
+// The target cluster is a PARAMETER (#5246) so the caller can strip the pair
+// in every region the up-path fanned it into.
+func (r *Reconciler) removeConsoleOrgListener(ctx context.Context, c client.Client, names orgConsoleTLSNames) (bool, error) {
 	gwNS := r.consoleGatewayNamespace()
 	gwName := r.consoleGatewayName()
 
 	gw := unstructured.Unstructured{}
 	gw.SetGroupVersionKind(gatewayGVK)
-	if err := r.Get(ctx, client.ObjectKey{Namespace: gwNS, Name: gwName}, &gw); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: gwNS, Name: gwName}, &gw); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Gateway already gone — nothing to strip.
 			return false, nil
@@ -670,7 +745,7 @@ func (r *Reconciler) removeConsoleOrgListener(ctx context.Context, names orgCons
 	if err := unstructured.SetNestedSlice(gw.Object, kept, "spec", "listeners"); err != nil {
 		return false, fmt.Errorf("set Gateway %s/%s listeners: %w", gwNS, gwName, err)
 	}
-	if err := r.Update(ctx, &gw); err != nil {
+	if err := c.Update(ctx, &gw); err != nil {
 		// A conflict means another writer touched the Gateway concurrently —
 		// surface it so the caller requeues and re-reads.
 		return false, fmt.Errorf("update Gateway %s/%s: %w", gwNS, gwName, err)

--- a/core/controllers/organization/internal/controller/tenant_console_tls_5246_test.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_5246_test.go
@@ -1,0 +1,557 @@
+// tenant_console_tls_5246_test.go — #5246. The per-Org console listener pair
+// must exist in EVERY region the console ELB pool forwards to, and an Org whose
+// peer region never received it must not read as provisioned.
+//
+// THE DEFECT
+// ----------
+// The organization-controller Deployment exists in the region-A cluster only —
+// measured on hw292 dep 1c56518035a83e03, `catalyst-system` carries the four
+// Catalyst controllers in region A and nothing in region B. Every write in
+// tenant_console_tls.go went through the manager's client, which is bound to
+// the local apiserver, so `console-https-<slug>` / `console-http-<slug>` could
+// only ever land in region A. Not "usually" — structurally.
+//
+// The console EIP does not share that limitation: #5246 made the ELB backend
+// pool span every region's nodes so the EIP survives a region-kill, so customer
+// TLS arrives at whichever region the pool picks. Measured live on hw292 with
+// fresh-TCP sampling:
+//
+//	console.uatco.omani.homes   -> 200 on 5 of 10   (per-Org host)
+//	console.hw292.omani.works   -> 200 on 10 of 10  (apex control, same VIP,
+//	                                                 same ELB, same port)
+//
+// and, read straight off the two Gateways on 2026-08-10:
+//
+//	region A kube-system/cilium-gateway-console: …, console-https-uatco,
+//	                                             console-http-uatco
+//	region B kube-system/cilium-gateway-console: …, console-https-r17probe,
+//	                                             console-http-r17probe
+//
+// Region B carried the pair for `r17probe`, an Org DELETED days earlier, and
+// nothing for the live Org — one defect in both directions: the up-path never
+// reached region B, and the teardown never reached it either.
+//
+// WHAT IS ASSERTED HERE
+// ---------------------
+// Every assertion is on the VALUE in the peer region — the listener's hostname,
+// port and certificateRef — not on a key existing. Each carries a control that
+// answers the other way in the same fixture, so none of them can pass vacuously:
+//
+//  1. The pair lands in the secondary region, on THAT region's apex ports
+//     (a sibling Org's name is absent from the same Gateway — the control
+//     proving the presence assertion discriminates), and the issued TLS Secret
+//     is mirrored so the listener has material to terminate on.
+//  2. verifyProvisioned holds the Org back when the secondary region lacks the
+//     pair, naming the region; the same fixture with the pair present in both
+//     regions reports complete.
+//  3. A region the ClusterMesh witness proves exists but for which no
+//     kubeconfig is wired is reported as a MISSING artifact — the control being
+//     the single-region Sovereign (no mesh Secret), which stays clean.
+//  4. Teardown strips the pair in every region, leaving every other listener
+//     in both regions byte-for-byte intact.
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openova-io/openova/core/controllers/organization/internal/gitops"
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+)
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const (
+	// secondaryRegionKey mirrors the live hw292 bridge-Secret data key
+	// `me-east-215-b.yaml`.
+	secondaryRegionKey = "me-east-215-b"
+	// meshRemoteCluster mirrors the live hw292 region-A ClusterMesh config
+	// Secret, whose only non-certificate key names the remote cluster.
+	meshRemoteCluster = "hw292-me-east-b"
+)
+
+// regionGatewayListeners returns an apex console listener pair on the given
+// ports. Each region publishes its own apex pair, and the per-Org listeners
+// must ride the ports of the region they are written into (#5511) — so the two
+// regions in these tests deliberately run DIFFERENT apex ports.
+func regionGatewayListeners(httpsPort, httpPort int64) []any {
+	return []any{
+		map[string]any{
+			"name": consoleApexListenerHTTPSName, "hostname": "console.hw292.omani.works",
+			"port": httpsPort, "protocol": "HTTPS",
+		},
+		map[string]any{
+			"name": consoleApexListenerHTTPName, "hostname": "console.hw292.omani.works",
+			"port": httpPort, "protocol": "HTTP",
+		},
+	}
+}
+
+// newRegionScheme registers everything a region cluster's fake client must be
+// able to serve: core types (the mirrored TLS Secret) plus the Certificate and
+// Gateway GVKs the console-TLS path writes as Unstructured.
+func newRegionScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("add clientgo scheme: %v", err)
+	}
+	for _, gvk := range []schema.GroupVersionKind{certificateGVK, gatewayGVK} {
+		s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		s.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+	}
+	return s
+}
+
+// newRegionCluster builds a peer region's fake cluster carrying a console
+// Gateway with the given listeners, and a published status.listeners that
+// mirrors spec (the Gateway controller having admitted everything). Extra
+// spec-only listeners can be injected by the caller afterwards.
+func newRegionCluster(t *testing.T, listeners []any) client.Client {
+	t.Helper()
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	gw.SetName(consoleGatewayDefaultName)
+	gw.SetNamespace(consoleGatewayDefaultNamespace)
+	gw.Object["spec"] = map[string]any{"gatewayClassName": "cilium"}
+	if err := unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners"); err != nil {
+		t.Fatalf("seed region listeners: %v", err)
+	}
+	if err := unstructured.SetNestedSlice(gw.Object, statusFor(listeners), "status", "listeners"); err != nil {
+		t.Fatalf("seed region status listeners: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(newRegionScheme(t)).WithObjects(gw).Build()
+}
+
+// statusFor renders the status.listeners projection of a spec listener slice —
+// the Gateway controller having ADMITTED every listener it was given.
+func statusFor(listeners []any) []any {
+	out := make([]any, 0, len(listeners))
+	for _, l := range listeners {
+		m, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, map[string]any{"name": m["name"]})
+	}
+	return out
+}
+
+// multiRegionOrg is the live hw292 shape: a free-subdomain pool Org whose
+// console host is `console.uatco.omani.homes`.
+func multiRegionOrg() *orgapi.Organization {
+	org := sampleOrg()
+	org.Name = "uatco"
+	org.Spec.Slug = "uatco"
+	org.Spec.TenantPublic.Subdomain = "uatco"
+	org.Spec.TenantPublic.ParentDomain = "omani.homes"
+	return org
+}
+
+// multiRegionFixture wires a 2-region Sovereign: a host cluster carrying the
+// console Gateway, the ClusterMesh witness, the #5359 bridge Secret and the
+// ISSUED per-Org TLS Secret; plus one peer-region cluster reached through the
+// RegionClientBuilder seam.
+//
+// withMesh=false drops the ClusterMesh Secret — the single-region control.
+// withBridge=false drops the kubeconfig Secret — the "mesh says B exists but
+// nothing is wired to reach it" case.
+type multiRegionFixture struct {
+	r      *Reconciler
+	org    *orgapi.Organization
+	names  orgConsoleTLSNames
+	region client.Client
+}
+
+func newMultiRegionFixture(t *testing.T, withMesh, withBridge bool, regionListeners []any) multiRegionFixture {
+	t.Helper()
+	org := multiRegionOrg()
+	names, ok := orgConsoleTLSNamesForOrg(org)
+	if !ok {
+		t.Fatalf("fixture Org does not engage the console-TLS up-path")
+	}
+
+	// Host region: apex pair on 8443/8080 (the live hw292 ports).
+	r := consoleTLSReconciler(t, org, regionGatewayListeners(8443, 8080))
+	seedHostGatewayStatus(t, r)
+
+	// The plan-boundary artifacts verifyProvisioned also checks (#5395) —
+	// seeded so the region assertions below are the ONLY thing that can move
+	// the verdict.
+	lr := &corev1.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: gitops.BoundaryLimitRangeName, Namespace: org.Spec.Slug}}
+	if err := r.Create(context.Background(), lr); err != nil {
+		t.Fatalf("seed boundary LimitRange: %v", err)
+	}
+	if gitops.PlanRendersResourceQuota(org.Spec.PlanSlug) {
+		rq := &corev1.ResourceQuota{ObjectMeta: metav1.ObjectMeta{Name: gitops.BoundaryResourceQuotaName, Namespace: org.Spec.Slug}}
+		if err := r.Create(context.Background(), rq); err != nil {
+			t.Fatalf("seed boundary ResourceQuota: %v", err)
+		}
+	}
+
+	// The issued per-Org TLS Secret in the host region — what gets mirrored.
+	issued := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: names.CertName, Namespace: consoleTLSDefaultCertNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("CERT-BYTES"), "tls.key": []byte("KEY-BYTES")},
+	}
+	if err := r.Create(context.Background(), issued); err != nil {
+		t.Fatalf("seed issued TLS Secret: %v", err)
+	}
+
+	if withMesh {
+		mesh := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: consoleClusterMeshSecretDefaultName, Namespace: consoleClusterMeshSecretDefaultNamespace},
+			Data: map[string][]byte{
+				meshRemoteCluster:             []byte("endpoints: [https://10.218.1.5:2379]"),
+				meshRemoteCluster + "-ca.crt": []byte("CA"),
+				meshRemoteCluster + ".crt":    []byte("CRT"),
+				meshRemoteCluster + ".key":    []byte("KEY"),
+			},
+		}
+		if err := r.Create(context.Background(), mesh); err != nil {
+			t.Fatalf("seed ClusterMesh witness: %v", err)
+		}
+	}
+
+	// Peer region: apex pair on 9443/9080 — deliberately DIFFERENT from the
+	// host so the per-Org port must be derived from the region being written.
+	peer := newRegionCluster(t, regionListeners)
+
+	if withBridge {
+		bridge := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      consoleSecondaryKubeconfigSecretDefaultName,
+				Namespace: consoleSecondaryKubeconfigSecretDefaultNamespace,
+			},
+			Data: map[string][]byte{secondaryRegionKey + ".yaml": []byte("kubeconfig-for-" + secondaryRegionKey)},
+		}
+		if err := r.Create(context.Background(), bridge); err != nil {
+			t.Fatalf("seed secondary-region kubeconfig bridge: %v", err)
+		}
+	}
+
+	r.RegionClientBuilder = func(kubeconfig []byte) (client.Client, error) {
+		if string(kubeconfig) != "kubeconfig-for-"+secondaryRegionKey {
+			t.Fatalf("region client built from unexpected kubeconfig %q", string(kubeconfig))
+		}
+		return peer, nil
+	}
+
+	return multiRegionFixture{r: r, org: org, names: names, region: peer}
+}
+
+// seedHostGatewayStatus publishes status.listeners on the host Gateway so the
+// #5511 admission check is decidable (an empty status is Unverifiable, which
+// would otherwise mask the region assertions under test).
+func seedHostGatewayStatus(t *testing.T, r *Reconciler) {
+	t.Helper()
+	syncGatewayStatus(t, r.Client)
+}
+
+// syncGatewayStatus republishes a cluster's status.listeners from its current
+// spec.listeners — the Gateway controller having admitted everything.
+func syncGatewayStatus(t *testing.T, c client.Client) {
+	t.Helper()
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	key := client.ObjectKey{Namespace: consoleGatewayDefaultNamespace, Name: consoleGatewayDefaultName}
+	if err := c.Get(context.Background(), key, gw); err != nil {
+		t.Fatalf("read Gateway for status sync: %v", err)
+	}
+	spec, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		t.Fatalf("read spec.listeners for status sync: %v", err)
+	}
+	if err := unstructured.SetNestedSlice(gw.Object, statusFor(spec), "status", "listeners"); err != nil {
+		t.Fatalf("set status.listeners: %v", err)
+	}
+	if err := c.Update(context.Background(), gw); err != nil {
+		t.Fatalf("update Gateway status: %v", err)
+	}
+}
+
+// listenerIn returns the named listener from a cluster's console Gateway spec,
+// or nil when absent.
+func listenerIn(t *testing.T, c client.Client, name string) map[string]any {
+	t.Helper()
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	if err := c.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleGatewayDefaultNamespace, Name: consoleGatewayDefaultName,
+	}, gw); err != nil {
+		t.Fatalf("read console Gateway: %v", err)
+	}
+	listeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		t.Fatalf("read spec.listeners: %v", err)
+	}
+	for _, l := range listeners {
+		m, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		if n, _ := m["name"].(string); n == name {
+			return m
+		}
+	}
+	return nil
+}
+
+// listenerNamesIn returns every listener name on a cluster's console Gateway.
+func listenerNamesIn(t *testing.T, c client.Client) []string {
+	t.Helper()
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	if err := c.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleGatewayDefaultNamespace, Name: consoleGatewayDefaultName,
+	}, gw); err != nil {
+		t.Fatalf("read console Gateway: %v", err)
+	}
+	listeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		t.Fatalf("read spec.listeners: %v", err)
+	}
+	out := make([]string, 0, len(listeners))
+	for _, l := range listeners {
+		if m, ok := l.(map[string]any); ok {
+			if n, _ := m["name"].(string); n != "" {
+				out = append(out, n)
+			}
+		}
+	}
+	return out
+}
+
+// certRefName digs the terminating Secret name out of an HTTPS listener.
+func certRefName(t *testing.T, l map[string]any) string {
+	t.Helper()
+	refs, found, err := unstructured.NestedSlice(l, "tls", "certificateRefs")
+	if err != nil || !found || len(refs) == 0 {
+		t.Fatalf("listener %v carries no tls.certificateRefs (found=%v err=%v)", l["name"], found, err)
+	}
+	m, ok := refs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("certificateRefs[0] is not a map: %T", refs[0])
+	}
+	name, _ := m["name"].(string)
+	return name
+}
+
+// ── 1. the pair lands in the secondary region ────────────────────────────────
+
+func TestConsoleOrgListener_LandsInEverySecondaryRegion_5246(t *testing.T) {
+	// The peer region starts with its apex pair ONLY — the live hw292 region-B
+	// shape for a live Org.
+	f := newMultiRegionFixture(t, true, true, regionGatewayListeners(9443, 9080))
+
+	if _, err := f.r.reconcileTenantConsoleTLS(context.Background(), f.org); err != nil {
+		t.Fatalf("reconcileTenantConsoleTLS: %v", err)
+	}
+
+	// The defect, asserted on the VALUE in the peer region.
+	https := listenerIn(t, f.region, f.names.HTTPSName)
+	if https == nil {
+		t.Fatalf("secondary region %s carries NO %s listener — customer TLS arriving there resets (#5246). listeners=%v",
+			secondaryRegionKey, f.names.HTTPSName, listenerNamesIn(t, f.region))
+	}
+	if got, _ := https["hostname"].(string); got != f.names.WildcardHost {
+		t.Errorf("secondary region %s listener hostname = %q, want %q", secondaryRegionKey, got, f.names.WildcardHost)
+	}
+	// The port must come from the region being written, not from the host's
+	// apex pair — the two regions run different apex ports in this fixture.
+	if got, _ := listenerPort(https); got != 9443 {
+		t.Errorf("secondary region %s listener port = %d, want 9443 (that region's own apex console-https port; the console ELB forwards to nothing else)", secondaryRegionKey, got)
+	}
+	if got := certRefName(t, https); got != f.names.CertName {
+		t.Errorf("secondary region %s listener certificateRef = %q, want %q", secondaryRegionKey, got, f.names.CertName)
+	}
+	httpL := listenerIn(t, f.region, f.names.HTTPName)
+	if httpL == nil {
+		t.Fatalf("secondary region %s carries no %s listener", secondaryRegionKey, f.names.HTTPName)
+	}
+	if got, _ := listenerPort(httpL); got != 9080 {
+		t.Errorf("secondary region %s HTTP listener port = %d, want 9080", secondaryRegionKey, got)
+	}
+
+	// CONTROL — the same probe against a name that was never written must
+	// answer the other way. Without this, "listenerIn returned non-nil" could
+	// be satisfied by any lookup bug that returns the first listener.
+	if sibling := listenerIn(t, f.region, "console-https-neverprovisioned"); sibling != nil {
+		t.Fatalf("control failed: the presence probe reports a listener that was never written: %v", sibling)
+	}
+
+	// The host region keeps its own apex-derived ports — the fan-out must not
+	// have written the peer's ports into the host.
+	hostHTTPS := listenerIn(t, f.r.Client, f.names.HTTPSName)
+	if hostHTTPS == nil {
+		t.Fatalf("host region lost its %s listener", f.names.HTTPSName)
+	}
+	if got, _ := listenerPort(hostHTTPS); got != 8443 {
+		t.Errorf("host region listener port = %d, want 8443", got)
+	}
+
+	// The peer's listener needs material to terminate on: the issued Secret is
+	// mirrored, never a second Certificate (one Let's-Encrypt issuance per Org).
+	mirrored := &corev1.Secret{}
+	if err := f.region.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleTLSDefaultCertNamespace, Name: f.names.CertName,
+	}, mirrored); err != nil {
+		t.Fatalf("issued TLS Secret was not mirrored into region %s: %v", secondaryRegionKey, err)
+	}
+	if string(mirrored.Data["tls.crt"]) != "CERT-BYTES" {
+		t.Errorf("mirrored TLS Secret tls.crt = %q, want the host's issued bytes", string(mirrored.Data["tls.crt"]))
+	}
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(certificateGVK)
+	if err := f.region.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleTLSDefaultCertNamespace, Name: f.names.CertName,
+	}, cert); err == nil {
+		t.Errorf("a second cert-manager Certificate was created in region %s — both regions would solve the same DNS-01 challenge and burn two LE issuances for one SAN", secondaryRegionKey)
+	}
+
+	// Idempotence: a second pass changes nothing and still errors on nothing.
+	changed, err := f.r.reconcileTenantConsoleTLS(context.Background(), f.org)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if changed {
+		t.Errorf("second pass reported changed=true on a converged 2-region Sovereign — the fan-out is not idempotent")
+	}
+}
+
+// ── 2. an unconverged secondary region holds the Org back ────────────────────
+
+func TestVerifyProvisioned_SecondaryRegionMissingListenerIsNotProvisioned_5246(t *testing.T) {
+	// Peer region carries its apex pair only — the pair for this Org is absent.
+	f := newMultiRegionFixture(t, true, true, regionGatewayListeners(9443, 9080))
+	// Host region IS converged: write the pair there and publish status.
+	if _, err := f.r.ensureConsoleOrgListener(context.Background(), f.r.Client, f.names); err != nil {
+		t.Fatalf("seed host listener: %v", err)
+	}
+	syncGatewayStatus(t, f.r.Client)
+
+	got := f.r.verifyProvisioned(context.Background(), f.org)
+	if got.complete() {
+		t.Fatalf("Organization reported fully provisioned while region %s carries no %s listener — that is the hw292 shape: every status surface green, half the customer connections reset. missing=%v unverifiable=%v",
+			secondaryRegionKey, f.names.HTTPSName, got.Missing, got.Unverifiable)
+	}
+	msg := got.message()
+	if !strings.Contains(msg, secondaryRegionKey) {
+		t.Errorf("the NOT-provisioned message does not name the region that is missing the listener — an operator cannot act on it.\ngot: %s", msg)
+	}
+	if !strings.Contains(msg, f.names.HTTPSName) {
+		t.Errorf("the NOT-provisioned message does not name the listener.\ngot: %s", msg)
+	}
+
+	// CONTROL — converge the peer region and the SAME check must go green.
+	// Without this the assertion above could be satisfied by a verifier that
+	// never returns complete.
+	if _, err := f.r.ensureConsoleOrgListener(context.Background(), f.region, f.names); err != nil {
+		t.Fatalf("converge peer region: %v", err)
+	}
+	syncGatewayStatus(t, f.region)
+	got = f.r.verifyProvisioned(context.Background(), f.org)
+	if !got.complete() {
+		t.Fatalf("control failed: with the pair present in BOTH regions the Org still reads NOT provisioned. missing=%v unverifiable=%v",
+			got.Missing, got.Unverifiable)
+	}
+}
+
+// ── 3. a meshed region with no kubeconfig is a MISSING artifact ──────────────
+
+func TestConsoleRegionTargets_MeshedRegionWithNoKubeconfigIsUnwired_5246(t *testing.T) {
+	// Mesh declares a remote cluster; nothing is wired to reach it.
+	f := newMultiRegionFixture(t, true, false, regionGatewayListeners(9443, 9080))
+
+	res := f.r.consoleRegionTargets(context.Background())
+	if len(res.Targets) != 1 || !res.Targets[0].Host {
+		t.Fatalf("expected only the host target when no kubeconfig is wired, got %d targets", len(res.Targets))
+	}
+	if len(res.Unwired) == 0 {
+		t.Fatalf("a Sovereign whose ClusterMesh declares %q while zero kubeconfigs are wired reported NO shortfall — the region set would silently shrink to one and every downstream 'written in every region' claim would be made over it (#5246)", meshRemoteCluster)
+	}
+
+	// It must reach the operator as a MISSING artifact on the Org, not a log line.
+	if _, err := f.r.ensureConsoleOrgListener(context.Background(), f.r.Client, f.names); err != nil {
+		t.Fatalf("seed host listener: %v", err)
+	}
+	syncGatewayStatus(t, f.r.Client)
+	got := f.r.verifyProvisioned(context.Background(), f.org)
+	if got.complete() {
+		t.Fatalf("Org reads fully provisioned while a meshed region has no credential to receive its listener. missing=%v", got.Missing)
+	}
+
+	// CONTROL — a genuine SINGLE-region Sovereign has no ClusterMesh Secret,
+	// declares zero remotes, and must stay completely clean. Without this the
+	// shortfall check would red-flag every single-region install.
+	single := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	sres := single.r.consoleRegionTargets(context.Background())
+	if len(sres.Unwired) != 0 || len(sres.Unreachable) != 0 {
+		t.Fatalf("control failed: a single-region Sovereign reported unwired=%v unreachable=%v", sres.Unwired, sres.Unreachable)
+	}
+	if _, err := single.r.ensureConsoleOrgListener(context.Background(), single.r.Client, single.names); err != nil {
+		t.Fatalf("seed single-region listener: %v", err)
+	}
+	syncGatewayStatus(t, single.r.Client)
+	if sgot := single.r.verifyProvisioned(context.Background(), single.org); !sgot.complete() {
+		t.Fatalf("control failed: a converged single-region Sovereign reads NOT provisioned. missing=%v unverifiable=%v",
+			sgot.Missing, sgot.Unverifiable)
+	}
+}
+
+// ── 4. teardown strips the pair in every region ──────────────────────────────
+
+func TestTeardownConsoleTLS_StripsListenerInEveryRegion_5246(t *testing.T) {
+	f := newMultiRegionFixture(t, true, true, regionGatewayListeners(9443, 9080))
+	if _, err := f.r.reconcileTenantConsoleTLS(context.Background(), f.org); err != nil {
+		t.Fatalf("converge: %v", err)
+	}
+	if listenerIn(t, f.region, f.names.HTTPSName) == nil {
+		t.Fatalf("fixture precondition: peer region never received the pair")
+	}
+	// A sibling Org's pair on the SAME peer Gateway — teardown must not touch it.
+	siblingNames := orgConsoleTLSNamesFor("sibling", "omani.homes")
+	if _, err := f.r.ensureConsoleOrgListener(context.Background(), f.region, siblingNames); err != nil {
+		t.Fatalf("seed sibling listener: %v", err)
+	}
+
+	if _, err := f.r.teardownTenantConsoleTLS(context.Background(), f.org); err != nil {
+		t.Fatalf("teardownTenantConsoleTLS: %v", err)
+	}
+
+	for _, name := range []string{f.names.HTTPSName, f.names.HTTPName} {
+		if l := listenerIn(t, f.region, name); l != nil {
+			t.Errorf("peer region still carries %s after teardown — this is the live hw292 r17probe orphan: a DELETED Org's listeners surviving in region B while the live Org has none there", name)
+		}
+		if l := listenerIn(t, f.r.Client, name); l != nil {
+			t.Errorf("host region still carries %s after teardown", name)
+		}
+	}
+	// CONTROL — the sibling Org's pair and both apex listeners survive intact,
+	// proving the strip is name-scoped and not a wipe.
+	for _, name := range []string{siblingNames.HTTPSName, siblingNames.HTTPName, consoleApexListenerHTTPSName, consoleApexListenerHTTPName} {
+		if l := listenerIn(t, f.region, name); l == nil {
+			t.Errorf("teardown removed %s from the peer region — it must strip only this Org's pair. listeners=%v", name, listenerNamesIn(t, f.region))
+		}
+	}
+	// The mirrored TLS Secret goes with it — otherwise a future Org taking the
+	// same subdomain lands on a Secret of exactly the expected name holding the
+	// PREVIOUS Org's certificate (the R17 cross-Org identity leak).
+	mirrored := &corev1.Secret{}
+	if err := f.region.Get(context.Background(), client.ObjectKey{
+		Namespace: consoleTLSDefaultCertNamespace, Name: f.names.CertName,
+	}, mirrored); err == nil {
+		t.Errorf("mirrored TLS Secret survived teardown in region %s — a future Org on the same subdomain would inherit this Org's certificate", secondaryRegionKey)
+	}
+}

--- a/core/controllers/organization/internal/controller/tenant_console_tls_5511_test.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_5511_test.go
@@ -273,7 +273,7 @@ func TestEnsureConsoleOrgListener_5511_HealsDeadPortsInPlace(t *testing.T) {
 		t.Fatalf("fixture must start with the pair on the dead ports: %v (%d listeners)", before, count)
 	}
 
-	changed, err := r.ensureConsoleOrgListener(context.Background(), orgConsoleTLSNamesFor("acme", "omani.homes"))
+	changed, err := r.ensureConsoleOrgListener(context.Background(), r.Client, orgConsoleTLSNamesFor("acme", "omani.homes"))
 	if err != nil {
 		t.Fatalf("ensureConsoleOrgListener: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestEnsureConsoleOrgListener_5511_HealsDeadPortsInPlace(t *testing.T) {
 
 	// Idempotent once healed — otherwise the controller rewrites the Gateway on
 	// every pass and hot-loops against the apiserver.
-	changed, err = r.ensureConsoleOrgListener(context.Background(), orgConsoleTLSNamesFor("acme", "omani.homes"))
+	changed, err = r.ensureConsoleOrgListener(context.Background(), r.Client, orgConsoleTLSNamesFor("acme", "omani.homes"))
 	if err != nil {
 		t.Fatalf("ensureConsoleOrgListener pass 2: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestEnsureConsoleOrgListener_5511_ApexAbsentUsesCanonicalFallback(t *testin
 		},
 	})
 
-	if _, err := r.ensureConsoleOrgListener(context.Background(), orgConsoleTLSNamesFor("acme", "omani.homes")); err != nil {
+	if _, err := r.ensureConsoleOrgListener(context.Background(), r.Client, orgConsoleTLSNamesFor("acme", "omani.homes")); err != nil {
 		t.Fatalf("ensureConsoleOrgListener: %v", err)
 	}
 

--- a/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
@@ -1,0 +1,435 @@
+// tenant_console_tls_regions.go — #5246. The per-Org console listener pair is
+// written into EVERY region the Sovereign serves, not just the one this
+// controller happens to run in.
+//
+// THE DEFECT
+// ----------
+// A 2-region Sovereign is TWO separate k3s clusters joined by Cilium
+// ClusterMesh (see internal/clusterregistry's package doc). The
+// organization-controller Deployment exists in the region-A cluster only —
+// measured on hw292 dep 1c56518035a83e03, `catalyst-system` carries the four
+// Catalyst controllers in region A and NOTHING in region B. Every write in
+// tenant_console_tls.go goes through the manager's client, which is bound to
+// the local apiserver, so the per-Org `console-https-<slug>` /
+// `console-http-<slug>` listener pair could only ever land in region A. Not
+// "usually" — structurally.
+//
+// The public console EIP does not share that limitation. #5246 made both
+// front-door ELB backend pools span every region's nodes so the EIPs survive a
+// region-kill, so customer TLS for `console.<slug>.<parent>` arrives at
+// whichever region the pool picks. A region with no per-Org listener answers
+// the handshake with a reset. Measured on hw292 with fresh-TCP sampling:
+// `console.uatco.omani.homes` 5/10 HTTP 200 against a 10/10 control on
+// `console.hw292.omani.works` — same VIP, same ELB, same port. Region B's
+// `kube-system/cilium-gateway-console` carried listeners for `r17probe`, an Org
+// deleted days earlier, and nothing for either live Org.
+//
+// THE SEAM — no new credential contract
+// -------------------------------------
+// The secondary regions' kubeconfigs are ALREADY materialized in-cluster by
+// catalyst-api's #5359 bridge:
+//
+//	Secret <cutover-ns>/cutover-secondary-kubeconfigs
+//	  data: "<regionKey>.yaml" -> kubeconfig bytes   (one key per secondary)
+//
+// That is the same store ClusterMesh establish, the #5246 gateway-ELB member
+// reconciler and the #5261 stalled-HR force-reconcile already reach region-B
+// through. This file reads it and builds one controller-runtime client per
+// secondary region. The org-controller ClusterRole already grants
+// `secrets: get,list,watch` cluster-wide, so nothing new is granted.
+//
+// WHY IT CANNOT DEGRADE SILENTLY
+// ------------------------------
+// "No kubeconfig Secret" must not mean "no secondary regions" — that would be a
+// guard whose scope is decided by the same step that loses the region, exactly
+// the shape #5246 found in catalyst-api (a dropped region never entered
+// `targets`, so the admission read-back never looked at it and the emitter
+// logged "admitted in every region" over a one-region list).
+//
+// So the region set is cross-checked against an INDEPENDENT in-cluster witness:
+// the Cilium ClusterMesh config Secret `kube-system/cilium-clustermesh`, whose
+// non-certificate keys name every REMOTE cluster this region is meshed with
+// (hw292 region A: `hw292-me-east-b`). A Sovereign whose mesh declares N remote
+// clusters while the kubeconfig Secret resolves fewer reports the shortfall as
+// UNWIRED — verifyProvisioned turns that into a NOT-provisioned Organization
+// naming the count, never a green Org over an unwritten region. A single-region
+// Sovereign has no ClusterMesh Secret, declares zero remotes, and behaves
+// EXACTLY as before this file existed.
+//
+// Refs #5246 · #5511 (the port + admission twin) · #5359 (the kubeconfig
+// bridge) · #5930 (the catalyst-api twin of this fix).
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Console region fan-out defaults. All four are overridable through the
+// Reconciler's env-configured fields per Inviolable Principle #4.
+const (
+	// consoleSecondaryKubeconfigSecretDefaultName / …Namespace name the
+	// #5359 bridge Secret. The namespace default matches the cutover
+	// namespace the chart installs bp-self-sovereign-cutover into.
+	consoleSecondaryKubeconfigSecretDefaultName      = "cutover-secondary-kubeconfigs"
+	consoleSecondaryKubeconfigSecretDefaultNamespace = "catalyst"
+
+	// consoleClusterMeshSecretDefaultName / …Namespace name the Cilium
+	// ClusterMesh config Secret used as the independent witness of how many
+	// OTHER regions this Sovereign has.
+	consoleClusterMeshSecretDefaultName      = "cilium-clustermesh"
+	consoleClusterMeshSecretDefaultNamespace = "kube-system"
+
+	// consoleHostRegionKey labels the region this controller runs in. It is
+	// never derived from a kubeconfig — it IS the manager's own client.
+	consoleHostRegionKey = "local"
+
+	// consoleRegionClientTimeout bounds every call made through a secondary
+	// region's client. A wedged peer apiserver must degrade this Org's
+	// reconcile into a requeue, never hang the work queue.
+	consoleRegionClientTimeout = 20 * time.Second
+)
+
+// consoleRegionTarget is one cluster the per-Org console surface is written to.
+// The host region always leads the slice so the Certificate (which only ever
+// exists in the issuing region) is handled before any mirror.
+type consoleRegionTarget struct {
+	// Region is the region key — consoleHostRegionKey for the local cluster,
+	// otherwise the `<regionKey>` half of the bridge Secret's data key.
+	Region string
+	// Host reports whether this target is the cluster the controller runs in.
+	Host bool
+	// Client writes into that region's apiserver.
+	Client client.Client
+}
+
+// consoleRegionResolution is one pass of region discovery.
+type consoleRegionResolution struct {
+	// Targets — every region a write can actually be made to, host first.
+	Targets []consoleRegionTarget
+	// Unwired — regions the ClusterMesh witness proves exist but for which
+	// no kubeconfig is wired at all. STRUCTURAL: the listener can never be
+	// written there until an operator supplies the credential, so it is
+	// reported as a missing artifact, not as a transient.
+	Unwired []string
+	// Unreachable — regions whose kubeconfig IS wired but whose client could
+	// not be built or used this pass. TRANSIENT: an apiserver blip must not
+	// red-flag every Organization on the Sovereign, so it only requeues.
+	Unreachable []string
+}
+
+// regionClientCache memoizes the per-region clients between reconciles, keyed
+// on the bridge Secret's resourceVersion. Building a client runs discovery
+// against the remote apiserver; doing that per Org per 30s pass would put a
+// steady discovery load on the peer region for no new information.
+type regionClientCache struct {
+	mu              sync.Mutex
+	resourceVersion string
+	clients         map[string]client.Client
+}
+
+// regionCacheInitMu guards the lazy allocation of Reconciler.regionClients.
+// It is package-level rather than a Reconciler field so the Reconciler struct
+// stays copy-safe (`go vet` copylocks) for the literal construction in
+// cmd/main.go and the tests.
+var regionCacheInitMu sync.Mutex
+
+func (r *Reconciler) regionClientCache() *regionClientCache {
+	regionCacheInitMu.Lock()
+	defer regionCacheInitMu.Unlock()
+	if r.regionClients == nil {
+		r.regionClients = &regionClientCache{clients: map[string]client.Client{}}
+	}
+	return r.regionClients
+}
+
+func (r *Reconciler) secondaryKubeconfigSecretName() string {
+	if v := strings.TrimSpace(r.SecondaryRegionKubeconfigSecretName); v != "" {
+		return v
+	}
+	return consoleSecondaryKubeconfigSecretDefaultName
+}
+
+func (r *Reconciler) secondaryKubeconfigSecretNamespace() string {
+	if v := strings.TrimSpace(r.SecondaryRegionKubeconfigSecretNamespace); v != "" {
+		return v
+	}
+	return consoleSecondaryKubeconfigSecretDefaultNamespace
+}
+
+func (r *Reconciler) clusterMeshSecretName() string {
+	if v := strings.TrimSpace(r.ClusterMeshSecretName); v != "" {
+		return v
+	}
+	return consoleClusterMeshSecretDefaultName
+}
+
+func (r *Reconciler) clusterMeshSecretNamespace() string {
+	if v := strings.TrimSpace(r.ClusterMeshSecretNamespace); v != "" {
+		return v
+	}
+	return consoleClusterMeshSecretDefaultNamespace
+}
+
+// consoleRegionKeyFromSecretKey turns a bridge-Secret data key
+// (`me-east-215-b.yaml`) into its region key (`me-east-215-b`). Keys that are
+// not kubeconfig files are rejected by returning "".
+func consoleRegionKeyFromSecretKey(k string) string {
+	k = strings.TrimSpace(k)
+	switch {
+	case strings.HasSuffix(k, ".yaml"):
+		return strings.TrimSuffix(k, ".yaml")
+	case strings.HasSuffix(k, ".yml"):
+		return strings.TrimSuffix(k, ".yml")
+	}
+	return ""
+}
+
+// clusterMeshRemoteClusters extracts the REMOTE cluster names from a Cilium
+// ClusterMesh config Secret. The Secret carries, per remote cluster, one
+// `<name>` config key plus `<name>-ca.crt` / `<name>.crt` / `<name>.key`
+// material; only the config key names a cluster. The local cluster is never
+// present. Returns a sorted, de-duplicated slice.
+func clusterMeshRemoteClusters(sec *corev1.Secret) []string {
+	seen := map[string]bool{}
+	for k := range sec.Data {
+		k = strings.TrimSpace(k)
+		if k == "" || strings.HasSuffix(k, ".crt") || strings.HasSuffix(k, ".key") {
+			continue
+		}
+		seen[k] = true
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// newRegionClient builds a controller-runtime client from kubeconfig bytes.
+// The RegionClientBuilder seam lets tests inject fakes without a real
+// apiserver; production leaves it nil.
+func (r *Reconciler) newRegionClient(kubeconfig []byte) (client.Client, error) {
+	if r.RegionClientBuilder != nil {
+		return r.RegionClientBuilder(kubeconfig)
+	}
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("parse kubeconfig: %w", err)
+	}
+	cfg.Timeout = consoleRegionClientTimeout
+	c, err := client.New(cfg, client.Options{Scheme: r.Scheme()})
+	if err != nil {
+		return nil, fmt.Errorf("build client: %w", err)
+	}
+	return c, nil
+}
+
+// consoleRegionTargets resolves every region cluster the per-Org console
+// surface must be written to, plus the regions it could not reach and why.
+//
+// The host region always leads. Secondary regions come from the #5359 bridge
+// Secret; the ClusterMesh witness decides whether that set is COMPLETE. A
+// resolution that lost a region says so — it never returns a short list that a
+// downstream "verified in every region" check would then read as success.
+func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionResolution {
+	res := consoleRegionResolution{
+		Targets: []consoleRegionTarget{{Region: consoleHostRegionKey, Host: true, Client: r.Client}},
+	}
+
+	// The independent witness first: how many OTHER regions does this
+	// Sovereign's mesh declare? Absent Secret == single-region Sovereign.
+	meshRemotes := 0
+	mesh := &corev1.Secret{}
+	switch err := r.Get(ctx, client.ObjectKey{
+		Namespace: r.clusterMeshSecretNamespace(),
+		Name:      r.clusterMeshSecretName(),
+	}, mesh); {
+	case err == nil:
+		meshRemotes = len(clusterMeshRemoteClusters(mesh))
+	case apierrors.IsNotFound(err):
+		// Single-region Sovereign (or ClusterMesh not yet established).
+		// Zero expected secondaries; behaviour identical to pre-#5246.
+	default:
+		// Cannot decide completeness this pass. Report it as transient so
+		// the Org requeues rather than being declared complete on an
+		// unverified region set.
+		res.Unreachable = append(res.Unreachable, fmt.Sprintf(
+			"ClusterMesh witness %s/%s unreadable, so the expected region count is unknown: %s",
+			r.clusterMeshSecretNamespace(), r.clusterMeshSecretName(), err))
+	}
+
+	bridgeNS, bridgeName := r.secondaryKubeconfigSecretNamespace(), r.secondaryKubeconfigSecretName()
+	bridge := &corev1.Secret{}
+	err := r.Get(ctx, client.ObjectKey{Namespace: bridgeNS, Name: bridgeName}, bridge)
+	if err != nil && !apierrors.IsNotFound(err) {
+		res.Unreachable = append(res.Unreachable, fmt.Sprintf(
+			"secondary-region kubeconfig Secret %s/%s unreadable: %s", bridgeNS, bridgeName, err))
+		return res
+	}
+
+	regions := make([]string, 0, len(bridge.Data))
+	kubeconfigFor := make(map[string][]byte, len(bridge.Data))
+	if err == nil {
+		for k, v := range bridge.Data {
+			region := consoleRegionKeyFromSecretKey(k)
+			if region == "" || len(v) == 0 {
+				continue
+			}
+			regions = append(regions, region)
+			kubeconfigFor[region] = v
+		}
+	}
+	sort.Strings(regions)
+
+	// The shortfall check is the whole anti-vacuity point: a mesh that
+	// declares 1 remote cluster while 0 kubeconfigs are wired means every
+	// per-Org listener this controller writes reaches exactly half the
+	// regions the console ELB forwards to.
+	if meshRemotes > len(regions) {
+		res.Unwired = append(res.Unwired, fmt.Sprintf(
+			"%d of %d secondary region(s) have no kubeconfig in %s/%s (ClusterMesh declares %d remote cluster(s); wired region keys: %s)",
+			meshRemotes-len(regions), meshRemotes, bridgeNS, bridgeName, meshRemotes, describeRegionKeys(regions)))
+	}
+
+	cache := r.regionClientCache()
+	cache.mu.Lock()
+	if cache.resourceVersion != bridge.GetResourceVersion() {
+		cache.resourceVersion = bridge.GetResourceVersion()
+		cache.clients = map[string]client.Client{}
+	}
+	for _, region := range regions {
+		c, ok := cache.clients[region]
+		if !ok {
+			built, buildErr := r.newRegionClient(kubeconfigFor[region])
+			if buildErr != nil || built == nil {
+				res.Unreachable = append(res.Unreachable, fmt.Sprintf(
+					"region %q kubeconfig in %s/%s did not yield a client: %v", region, bridgeNS, bridgeName, buildErr))
+				continue
+			}
+			cache.clients[region] = built
+			c = built
+		}
+		res.Targets = append(res.Targets, consoleRegionTarget{Region: region, Client: c})
+	}
+	cache.mu.Unlock()
+
+	return res
+}
+
+// describeRegionKeys renders a region-key slice for an operator-facing message,
+// naming the empty case explicitly rather than rendering "[]".
+func describeRegionKeys(regions []string) string {
+	if len(regions) == 0 {
+		return "none"
+	}
+	return strings.Join(regions, ",")
+}
+
+// mirrorConsoleOrgCertSecret copies the ISSUED per-Org TLS Secret from the host
+// region into a secondary region, so that region's `console-https-<slug>`
+// listener has material to terminate on.
+//
+// A second cert-manager Certificate in the peer region is deliberately NOT
+// created: both would solve the same DNS-01 challenge on the same pool zone and
+// burn two Let's-Encrypt issuances per Org for one SAN. Mirroring the issued
+// Secret is what the catalyst-api twin does (#5511 mirrorOrgConsoleCertSecret)
+// and keeps the issuance count at one per Org.
+//
+// Returns (changed, err). "The host Secret is not issued yet" is an error, not
+// a silent skip: it is the state in which the peer region's listener is present
+// but ResolvedRefs=False, and the caller must keep requeueing until it clears.
+func (r *Reconciler) mirrorConsoleOrgCertSecret(ctx context.Context, dst client.Client, names orgConsoleTLSNames) (bool, error) {
+	ns := r.consoleTLSCertNamespace()
+
+	src := &corev1.Secret{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: names.CertName}, src); err != nil {
+		return false, fmt.Errorf("read host TLS Secret %s/%s to mirror: %w", ns, names.CertName, err)
+	}
+	if len(src.Data["tls.crt"]) == 0 || len(src.Data["tls.key"]) == 0 {
+		return false, fmt.Errorf("host TLS Secret %s/%s carries no issued keypair yet", ns, names.CertName)
+	}
+
+	desired := &corev1.Secret{}
+	desired.SetNamespace(ns)
+	desired.SetName(names.CertName)
+	desired.Type = src.Type
+	desired.Data = map[string][]byte{}
+	for k, v := range src.Data {
+		desired.Data[k] = v
+	}
+	desired.SetLabels(map[string]string{
+		"app.kubernetes.io/managed-by":      "catalyst",
+		"openova.io/managed-by":             "organization-controller",
+		"catalyst.openova.io/component":     "cilium-gateway-console",
+		"catalyst.openova.io/parent-zone":   names.ParentDomain,
+		"catalyst.openova.io/org-subdomain": names.Slug,
+		"catalyst.openova.io/mirrored-from": consoleHostRegionKey,
+	})
+
+	current := &corev1.Secret{}
+	switch err := dst.Get(ctx, client.ObjectKey{Namespace: ns, Name: names.CertName}, current); {
+	case apierrors.IsNotFound(err):
+		if createErr := dst.Create(ctx, desired); createErr != nil {
+			if apierrors.IsAlreadyExists(createErr) {
+				return true, nil
+			}
+			return false, fmt.Errorf("mirror TLS Secret %s/%s: %w", ns, names.CertName, createErr)
+		}
+		return true, nil
+	case err != nil:
+		return false, fmt.Errorf("read mirrored TLS Secret %s/%s: %w", ns, names.CertName, err)
+	}
+
+	if secretDataEqual(current.Data, desired.Data) {
+		return false, nil
+	}
+	current.Data = desired.Data
+	current.Type = desired.Type
+	current.SetLabels(desired.GetLabels())
+	if err := dst.Update(ctx, current); err != nil {
+		return false, fmt.Errorf("update mirrored TLS Secret %s/%s: %w", ns, names.CertName, err)
+	}
+	return true, nil
+}
+
+// deleteMirroredConsoleOrgCertSecret removes a mirrored per-Org TLS Secret from
+// a secondary region. Absent-as-success, matching every other teardown helper.
+func (r *Reconciler) deleteMirroredConsoleOrgCertSecret(ctx context.Context, dst client.Client, names orgConsoleTLSNames) (bool, error) {
+	ns := r.consoleTLSCertNamespace()
+	sec := &corev1.Secret{}
+	sec.SetNamespace(ns)
+	sec.SetName(names.CertName)
+	if err := dst.Delete(ctx, sec); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("delete mirrored Secret %s/%s: %w", ns, names.CertName, err)
+	}
+	return true, nil
+}
+
+// secretDataEqual compares two Secret data maps byte-for-byte.
+func secretDataEqual(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || string(av) != string(bv) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Refs #5246

## The defect — structural, not intermittent

The `organization-controller` Deployment exists in the **region-A cluster only**. Read off hw292 (dep `1c56518035a83e03`) 2026-08-10:

```
$ kubectl --kubeconfig hw292-a get deploy -A | grep catalyst-system
catalyst-system  catalyst-api                      .../catalyst-api:fad88bd
catalyst-system  catalyst-application-controller   .../application-controller:4abd412
catalyst-system  catalyst-environment-controller   .../environment-controller:8b7fc3b
catalyst-system  catalyst-organization-controller  .../organization-controller:8523ecf
catalyst-system  catalyst-useraccess-controller    .../useraccess-controller:8b7fc3b

$ kubectl --kubeconfig hw292-b get deploy -A | grep catalyst-system
(nothing)
```

Every write in `tenant_console_tls.go` went through the manager's client, bound to the local apiserver. The per-Org `console-https-<slug>` / `console-http-<slug>` pair could therefore only ever land in region A — not "usually", **structurally**.

The console EIP does not share that limitation. This issue's own ELB change made both front-door backend pools span every region's nodes so the EIPs survive a region-kill, so customer TLS for `console.<slug>.<parent>` arrives at whichever region the pool picks, and a region with no per-Org listener resets the handshake.

**The measurement** — the two console Gateways, read read-only on 2026-08-10:

```
region A  kube-system/cilium-gateway-console
  console-https           console.hw292.omani.works   8443
  console-http            console.hw292.omani.works   8080
  api-https / api-http / marketplace-https / marketplace-http ...
  console-https-uatco     *.uatco.omani.homes         8443
  console-http-uatco      *.uatco.omani.homes         8080

region B  kube-system/cilium-gateway-console
  console-https           console.hw292.omani.works   8443
  console-http            console.hw292.omani.works   8080
  api-https / api-http / marketplace-https / marketplace-http ...
  console-https-r17probe  *.r17probe.omani.homes      8443
  console-http-r17probe   *.r17probe.omani.homes      8080

$ kubectl --kubeconfig hw292-a get organizations
NAME                SUB      PARENT
hw292-omani-works   <none>   <none>
uatco               uatco    omani.homes
```

Region B carries the pair for `r17probe` — an Org **deleted days earlier** — and nothing for the one live Org. That is the same defect in both directions: the up-path never reached region B, and the teardown never reached it either. It matches the fresh-TCP sampling on the issue: `console.uatco.omani.homes` 5/10 HTTP 200 against a 10/10 control on `console.hw292.omani.works` — same VIP, same ELB, same port.

Region B also carries **zero** `org-wildcard-tls-*` Certificates or Secrets in `kube-system`, so even the listener it does have has nothing to terminate on.

This is the org-controller half of the split. The catalyst-api half was fixed in #5930; both doors write byte-identical resources by design (#4241), and correctness of the funnel door must not depend on a different service's reconcile loop.

## The mechanism

`consoleRegionTargets` (new, `tenant_console_tls_regions.go`) resolves the host region plus one controller-runtime client per secondary region. The kubeconfigs are **already materialized in-cluster** by catalyst-api's #5359 bridge:

```
Secret <cutover-ns>/cutover-secondary-kubeconfigs
  data: "<regionKey>.yaml" -> kubeconfig bytes   (one key per secondary)
```

Live on hw292 that Secret exists in ns `catalyst` with the single key `me-east-215-b.yaml`. No new credential contract is invented, and **no RBAC change** — the org-controller ClusterRole already grants `secrets: get,list,watch` cluster-wide. No chart is touched, so there is no version/pin lockstep to move (`check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` → *"No platform/products Chart.yaml files changed"*).

Three call sites now fan over that set:

- **Up-path** `reconcileTenantConsoleTLS` — appends the pair in every region. Each region's ports are derived from **that region's own** apex `console-https`/`console-http` pair (`consoleApexListenerPorts`), never from the host's, because the console ELB forwards to nothing else (#5511).
- **Cert** — the cert-manager `Certificate` stays a single host-region issuance; the **issued Secret is mirrored** to the peers (`mirrorConsoleOrgCertSecret`, the shape #5511's catalyst-api twin uses). Two Certificates would solve the same DNS-01 challenge on the same pool zone and burn two Let's-Encrypt issuances for one SAN.
- **Teardown** `teardownTenantConsoleTLS` — strips the pair and deletes the mirrored Secret in every region. Name-scoped, so sibling Orgs' and apex listeners are untouched. This is what kills the live `r17probe` orphan class, including its cross-Org identity-leak edge (a future Org taking that subdomain would land on a Secret of exactly the expected name holding the previous Org's certificate).
- **Verifier** `verifyProvisioned` (#5395) — reads the pair back **per region**. A single-region read-back is a guard that cannot fail on this defect: it verifies only the region we were always able to write.

Convergence is the existing loop — no manual step. A region that is behind holds `status.vcluster.phase` at `Provisioning` with `Ready=False ProvisioningIncomplete` naming the region, and the Ready-false path requeues at 30s until it clears.

## Why it cannot degrade silently

"No kubeconfig Secret" must not read as "no secondary regions" — that is precisely the shape #5930 found in catalyst-api: a dropped region never entered `targets`, so the admission read-back never looked at it and the emitter logged *"listener pair admitted in every region"* over a one-region list.

So the region set is cross-checked against an **independent in-cluster witness**: the Cilium ClusterMesh config Secret, whose non-certificate keys name every remote cluster this region is meshed with (hw292 region A: `hw292-me-east-b`). The two categories are then treated differently, deliberately:

- **Unwired** — the mesh proves the region exists and no kubeconfig is wired for it. Structural: the listener can never land there until a credential exists, so it is a **Missing** artifact and the Org is not provisioned.
- **Unreachable** — the kubeconfig is wired but the client could not be built or used this pass. Transient: reported **Unverifiable**, which only requeues, so one apiserver blip cannot red-flag every Organization on the Sovereign at once (`provisioning_postconditions.go`'s own evidence-of-absence doctrine).

A genuine single-region Sovereign has no ClusterMesh Secret, declares zero remotes, and behaves exactly as before this change.

## The test, and its failure output

`tenant_console_tls_5246_test.go` — four tests, every assertion on the **value** in the peer region (hostname, port, certificateRef), each with a control that answers the other way inside the same fixture:

1. the pair lands in the secondary region on **that region's** apex ports (the fixture deliberately runs the two regions on different apex ports, 8443/8080 vs 9443/9080) with the right hostname and certificateRef, the issued Secret is mirrored, no second Certificate is created, and a second pass is a no-op. Control: a name that was never written is still reported absent.
2. `verifyProvisioned` refuses Ready while the peer region lacks the pair, naming the region. Control: converge the peer and the same check goes green.
3. a meshed region with no kubeconfig becomes a Missing artifact. Control: a single-region Sovereign (no mesh Secret) stays completely clean.
4. teardown strips the pair in both regions and the mirrored Secret. Control: a sibling Org's pair and both apex listeners survive byte-for-byte.

**Proof the guard can fail.** With the fan-out disabled — `consoleRegionTargets` returning host-only, i.e. the exact pre-fix behaviour of a controller that can only reach its own region — all four fail:

```
=== RUN   TestConsoleOrgListener_LandsInEverySecondaryRegion_5246
    tenant_console_tls_5246_test.go:386: secondary region me-east-215-b carries NO console-https-uatco listener - customer TLS arriving there resets (#5246). listeners=[console-https console-http]
--- FAIL: TestConsoleOrgListener_LandsInEverySecondaryRegion_5246 (0.00s)
=== RUN   TestVerifyProvisioned_SecondaryRegionMissingListenerIsNotProvisioned_5246
    tenant_console_tls_5246_test.go:467: Organization reported fully provisioned while region me-east-215-b carries no console-https-uatco listener - that is the hw292 shape: every status surface green, half the customer connections reset. missing=[] unverifiable=[]
--- FAIL: TestVerifyProvisioned_SecondaryRegionMissingListenerIsNotProvisioned_5246 (0.00s)
=== RUN   TestConsoleRegionTargets_MeshedRegionWithNoKubeconfigIsUnwired_5246
    tenant_console_tls_5246_test.go:503: a Sovereign whose ClusterMesh declares "hw292-me-east-b" while zero kubeconfigs are wired reported NO shortfall - the region set would silently shrink to one and every downstream 'written in every region' claim would be made over it (#5246)
--- FAIL: TestConsoleRegionTargets_MeshedRegionWithNoKubeconfigIsUnwired_5246 (0.00s)
=== RUN   TestTeardownConsoleTLS_StripsListenerInEveryRegion_5246
    tenant_console_tls_5246_test.go:542: fixture precondition: peer region never received the pair
--- FAIL: TestTeardownConsoleTLS_StripsListenerInEveryRegion_5246 (0.00s)
FAIL
FAIL	github.com/openova-io/openova/core/controllers/organization/internal/controller	0.028s
```

With the fix restored, all four pass and the full module suite is green.

## Validation

- `go build ./...` + `go vet ./...` + `go test ./organization/... -count=1` → green, chained (`core/controllers`).
- `go test ./...` across `core/controllers` → no failures.
- `bash scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` → no chart changed, nothing to check.
- `bash scripts/check-no-banned-words.sh` → OK.
- Live hw292 reads above are read-only (`kubectl get`); **no cluster writes were made**, no NodePort is introduced or relied on anywhere in this diff.

## Not claimed

The fix is **not live-validated**. hw292 runs `organization-controller:8523ecf` (#5526-era) and `catalyst-api:fad88bd` (#5539-era), so neither this change nor #5930 is in a running image there — which is also why the live 5/10 split is still observable. The DoD gate is a fresh prov or an image roll, then fresh-TCP sampling of `console.<slug>.<pool>` against the apex control, with the two Gateways' listener sets as the artifact. UAT rows 87, 88, 90, 95 and R16 stay non-green until that walk lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
