### PR TITLE
fix(5921): pivot customer sign-in mail off the mothership — a relay scope the Sovereign owns, and a cutover gate that refuses to certify without it

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,14 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.179
+      # 0.1.180 (#5921): step-08 gains the PRE-HOLD outbound customer-auth
+      # SMTP relay lint — the NINTH tether, and the only one on the purchase
+      # path. marketplace-api dials smtp-host from sovereign-smtp-credentials
+      # to send every customer sign-in code; ADR-0002 lists eight tethers and
+      # this is not among them. A declaration lint, because SMTP is dialled on
+      # a customer action and a 600s hold with no signup in it never sees the
+      # dial. Step count unchanged at 11.
+      version: 0.1.180
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,13 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1422
+      # 1.4.1414 (#5921): catalog-seed bp-self-sovereign-cutover pin 0.1.179 ->
+      #   0.1.180 (step-08 gains the pre-hold outbound customer-auth SMTP relay
+      #   lint — the NINTH tether, and the only one on the purchase path). The
+      #   seed renders INSIDE this umbrella, so the new pin only reaches a
+      #   Sovereign once the umbrella republishes and this pin advances (#5734).
+      #   Lockstep w/ products/catalyst/chart/Chart.yaml + slot-06a (0.1.180).
+      version: 1.4.1423
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.179
+  version: 0.1.180
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,36 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.180 (#5921) — THE NINTH TETHER: customer sign-in mail. Step-08 gains a
+# PRE-HOLD outbound customer-auth SMTP relay lint. catalyst-system/marketplace-api
+# reads smtp-host from catalyst-system/sovereign-smtp-credentials by secretKeyRef
+# and dials it to send every customer sign-in code; on hw292 that host was
+# mail.openova.io with cutoverComplete=true, so a Sovereign certified independent
+# still could not sell anything unless OUR mail server answered. ADR-0002
+# enumerates EIGHT tethers and outbound customer-auth SMTP is not among them, so
+# no step pivots it. This is a DECLARATION lint, not another deny-set entry:
+# #5951 already named the host in blockedDomains, but SMTP is dialled on a
+# CUSTOMER ACTION rather than a reconcile interval, so a 600s hold containing no
+# signup produces no connection to block and the runtime proof passes over a live
+# tether — the #5650 timing-independence argument with a human, rather than an
+# interval, as the trigger. Reading the configured host is the only measurement
+# that does not depend on someone buying something inside the window. Proven in
+# BOTH directions by chart/tests/smtp-relay-host-lint.sh, which extracts the real
+# function from the RENDER (#5646) and drives 17 cases through a stub kubectl:
+# RED on mail.openova.io (the live hw292 finding), GREEN on mail.<fqdn> / the
+# apex / in-cluster / loopback / an allowHosts exception, fail-CLOSED on an
+# unreadable Secret, and a deliberate PASS carve-out for an ABSENT Secret (no
+# Secret == SMTP_HOST empty == nothing dialled == a funnel gap, not a tether).
+# Scoped to the PRIMARY region on purpose — sovereign-smtp-credentials is a
+# single-region control-plane object, so polling a secondary would fail-closed on
+# every multi-region Sovereign (the #5505 shape). Comments follow #6004's block-
+# comment discipline so the Helm release Secret does not regrow. Step count
+# UNCHANGED at 11 — this is a new lint inside step-08, not a twelfth step. New
+# values: egressTest.smtpRelayHostLint.{enabled,allowHosts,secretNamespace,
+# secretName}, enabled by DEFAULT and expected to go RED on today's Sovereigns,
+# the same call #5951 made. No RBAC change (secrets get was already granted).
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version +
+# the API blueprints.json + the generated UI catalog move to 0.1.180 in lockstep
+# (Inviolable Principle #13).
 # 0.1.179 (#6004) — THIS CHART COULD NO LONGER BE INSTALLED ON ANY SOVEREIGN.
 # Helm stores a release as base64(gzip(json(release))) in Secret
 # sh.helm.release.v1.<release>.v<n>, and Kubernetes caps a Secret's data at
@@ -3705,7 +3736,7 @@ name: bp-self-sovereign-cutover
 # pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
 # blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.179
+version: 0.1.180
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -273,6 +273,31 @@ data:
             value: {{ eq (toString .Values.egressTest.providerPackageHostLint.enabled) "true" | quote }}
           - name: PROVIDER_PACKAGE_HOST_ALLOW
             value: {{ .Values.egressTest.providerPackageHostLint.allowHosts | default (list) | join " " | quote }}
+          {{- /*
+           #5921 — pre-hold outbound customer-auth SMTP relay host lint. The
+           NINTH tether, and the only one on the PURCHASE path.
+           catalyst-system/marketplace-api reads smtp-host out of
+           catalyst-system/sovereign-smtp-credentials and dials it to send
+           every customer sign-in code. On hw292 that host is mail.openova.io
+           with cutoverComplete=true: no customer can finish a purchase unless
+           the OpenOva mothership's mail server answers.
+
+           Why the hold cannot see this even with mail.openova.io in the deny
+           set: SMTP is dialled ON A CUSTOMER ACTION, not on a reconcile
+           timer. A 600s window with no signup in it produces no connection
+           to block, so the runtime proof passes over a live tether — the
+           timing-independence argument #5650 made for Flux sources applies
+           with more force here, because the trigger is a human rather than
+           an interval. This lint reads the DECLARATION instead.
+          */}}
+          - name: SMTP_RELAY_HOST_LINT
+            value: {{ eq (toString .Values.egressTest.smtpRelayHostLint.enabled) "true" | quote }}
+          - name: SMTP_RELAY_HOST_ALLOW
+            value: {{ .Values.egressTest.smtpRelayHostLint.allowHosts | default (list) | join " " | quote }}
+          - name: SMTP_RELAY_SECRET_NAMESPACE
+            value: {{ .Values.egressTest.smtpRelayHostLint.secretNamespace | quote }}
+          - name: SMTP_RELAY_SECRET_NAME
+            value: {{ .Values.egressTest.smtpRelayHostLint.secretName | quote }}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
@@ -1232,6 +1257,113 @@ data:
               echo "  PASS — region ${_pp_region}: every Crossplane Provider.spec.package resolves to a Sovereign-local host; no external package dependency remains in the object graph (#5650)"
               return 0
             }
+            {{- /*
+             ── #5921 OUTBOUND CUSTOMER-AUTH SMTP RELAY HOST LINT ──────────
+             The ninth tether. catalyst-system/marketplace-api takes SMTP_HOST
+             from catalyst-system/sovereign-smtp-credentials via secretKeyRef
+             and dials it to deliver every customer sign-in code. ADR-0002
+             enumerates EIGHT tethers; outbound customer-auth SMTP is not among
+             them, so no cutover step pivots it and, until #5951, nothing even
+             named the host in the deny set.
+
+             WHY A DECLARATION LINT AND NOT THE HOLD. Adding mail.openova.io to
+             blockedDomains (#5951) makes the host unreachable during the
+             window; it does not make the dependency visible, because SMTP is
+             dialled on a CUSTOMER ACTION rather than on a reconcile interval.
+             A 600s hold containing no signup produces no connection to block
+             and the runtime proof passes with the tether fully live. That is
+             the #5650 timing argument with a human, rather than an interval,
+             as the trigger — strictly worse, because the interval at least
+             guarantees an eventual dial. Reading the configured host is the
+             only measurement that does not depend on someone buying something
+             inside the window.
+
+             The function is extracted from the RENDER by
+             chart/tests/smtp-relay-host-lint.sh (the #5646 drift reason), so
+             the `_sr_` scratch names and the trailing `return 0` are load-
+             bearing and any nested helper stays on ONE line.
+            */}}
+            run_smtp_relay_host_lint() {
+              _sr_ns="${SMTP_RELAY_SECRET_NAMESPACE:-catalyst-system}"
+              _sr_name="${SMTP_RELAY_SECRET_NAME:-sovereign-smtp-credentials}"
+              echo "[egress-block-test] #5921: PRE-HOLD outbound customer-auth SMTP relay lint — ${_sr_ns}/${_sr_name} smtp-host is what marketplace-api dials to send every customer sign-in code; it must be a Sovereign-local relay (*.${SOVEREIGN_FQDN}, in-cluster DNS, or an explicit SMTP_RELAY_HOST_ALLOW entry)."
+              _sr_err="${WORK_DIR:-/work}/smtprelay-err.$$"
+              if ! : > "${_sr_err}" 2>/dev/null; then
+                echo "  FAIL — cannot create ${_sr_err}; refusing to report PASS from a lint that cannot record its own measurement (fail-closed)"
+                return 1
+              fi
+              {{- /*
+               FAIL-CLOSED ENUMERATION, with ONE deliberate exception. A Secret
+               that does not exist means marketplace-api renders SMTP_HOST
+               empty and sends nothing at all (core/marketplace-api/main.go
+               defaultSMTPHost is ""), which is a broken funnel but NOT a
+               tether — the same treatment the Flux lint gives an uninstalled
+               CRD. Every OTHER error (RBAC drift, unreachable API, expired
+               cert) means the relay could not be measured, and a verdict
+               rendered over an unmeasured surface is the #5633 fail-open shape.
+               The discriminator is the EXIT CODE, not whether stderr happens
+               to be non-empty: kubectl writes deprecation and auth-plugin
+               warnings to stderr on entirely successful calls, so a
+               stderr-is-non-empty test would read a warning as an
+               unmeasurable relay and fail every Sovereign that emits one.
+              */}}
+              if ! _sr_b64="$(kubectl -n "${_sr_ns}" get secret "${_sr_name}" -o jsonpath='{.data.smtp-host}' 2>"${_sr_err}")"; then
+                if grep -qiE 'not found|notfound' "${_sr_err}" 2>/dev/null; then
+                  echo "  PASS — ${_sr_ns}/${_sr_name} does not exist; marketplace-api renders SMTP_HOST empty and dials nothing. No outbound mail tether (NOTE: customer sign-in mail is also disabled — a funnel gap, tracked separately from sovereignty)."
+                  rm -f "${_sr_err}"
+                  return 0
+                fi
+                echo "  FAIL — cannot read ${_sr_ns}/${_sr_name} ($(head -1 "${_sr_err}" 2>/dev/null)). Refusing to report PASS for a relay that could not be measured (fail-closed, #5921)"
+                rm -f "${_sr_err}"
+                return 1
+              fi
+              rm -f "${_sr_err}"
+              if [ -z "${_sr_b64}" ]; then
+                echo "  PASS — ${_sr_ns}/${_sr_name} carries no smtp-host key; marketplace-api renders SMTP_HOST empty and dials nothing. No outbound mail tether (NOTE: customer sign-in mail is also disabled)."
+                return 0
+              fi
+              _sr_host="$(printf '%s' "${_sr_b64}" | base64 -d 2>/dev/null)"
+              if [ -z "${_sr_host}" ]; then
+                echo "  FAIL — smtp-host in ${_sr_ns}/${_sr_name} did not base64-decode to anything. The relay is unmeasurable, not absent (fail-closed)."
+                return 1
+              fi
+              {{- /*
+               Bare host: drop any scheme and any :port. An IPv6 literal keeps
+               its brackets, so only strip a trailing :port when what follows
+               the last colon has no closing bracket in it.
+              */}}
+              _sr_h="${_sr_host#*://}"; _sr_h="${_sr_h%%/*}"
+              case "${_sr_h}" in
+                \[*\]:*) _sr_h="${_sr_h%:*}" ;;
+                \[*\]) : ;;
+                *:*) _sr_h="${_sr_h%:*}" ;;
+              esac
+              case "${_sr_h}" in
+                "${SOVEREIGN_FQDN}"|*".${SOVEREIGN_FQDN}") echo "  PASS — smtp-host ${_sr_host} is a Sovereign-local relay; customer sign-in mail leaves this Sovereign under its own name (#5921)"; return 0 ;;
+                *.svc|*.svc.cluster.local|localhost|127.0.0.1) echo "  PASS — smtp-host ${_sr_host} is an in-cluster relay; customer sign-in mail never leaves the Sovereign (#5921)"; return 0 ;;
+              esac
+              for _sr_a in ${SMTP_RELAY_HOST_ALLOW:-}; do
+                if [ "${_sr_h}" = "${_sr_a}" ]; then
+                  echo "  PASS — smtp-host ${_sr_host} is a reviewed exception declared in egressTest.smtpRelayHostLint.allowHosts (a third-party relay the operator has chosen and owns)"
+                  return 0
+                fi
+              done
+              echo "  FAIL — smtp-host ${_sr_host} (host:${_sr_h}) is NOT a Sovereign-local relay. Every customer sign-in code this Sovereign sends transits a machine somebody else operates, so the purchase path stops working the moment that operator does. This is the NINTH tether and ADR-0002 does not list it, which is why no step pivots it. Fix = point ${_sr_ns}/${_sr_name} at a Sovereign-local submission relay (catalyst-api seeds this at provision time; CATALYST_SOVEREIGN_SMTP_RELAY_MODE=sovereign-local makes it mail.${SOVEREIGN_FQDN}), or declare a reviewed third-party relay in egressTest.smtpRelayHostLint.allowHosts."
+              return 1
+            }
+            if [ "${SMTP_RELAY_HOST_LINT:-false}" = "true" ]; then
+              {{- /*
+               Scoped to the PRIMARY only, on purpose: marketplace-api and the
+               sovereign-smtp-credentials Secret are single-region control-plane
+               objects, so asking a secondary for them would fail-closed on
+               every multi-region Sovereign and wedge the flow this guard
+               protects (the #5505 shape).
+              */}}
+              if ! run_smtp_relay_host_lint; then
+                echo "[egress-block-test] Outbound customer-auth SMTP relay lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). A Sovereign that cannot send its own sign-in codes cannot complete a purchase without us, whatever the other eight tethers say (#5921)"
+                exit 1
+              fi
+            fi
             {{- /*
              ── #5359 PER-REGION DRIVER ────────────────────────────────────
              Every region is evaluated — no short-circuit — so one run names

--- a/platform/self-sovereign-cutover/chart/tests/smtp-relay-host-lint.sh
+++ b/platform/self-sovereign-cutover/chart/tests/smtp-relay-host-lint.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# #5921 — behavioural test for step-08's outbound customer-auth SMTP relay lint.
+#
+# THE DEFECT. catalyst-system/marketplace-api takes SMTP_HOST from
+# catalyst-system/sovereign-smtp-credentials by secretKeyRef and dials it to
+# deliver every customer sign-in code. On hw292 that host is mail.openova.io
+# with cutoverComplete=true: a Sovereign certified independent cannot complete
+# a purchase unless the OpenOva mothership's mail server answers. ADR-0002
+# enumerates EIGHT tethers and outbound customer-auth SMTP is not among them,
+# so no cutover step pivots it.
+#
+# WHY A BEHAVIOURAL TEST AND NOT A RENDER GREP. The lint exists to catch a
+# defect that a "does the key exist" assertion cannot see (#5639/#5641), and it
+# would be the fourth pre-hold lint in this Job whose only observed state is
+# PASS. So this suite extracts the real shell function out of the RENDER and
+# drives it against a stub kubectl, asserting the VERDICT in both directions.
+# A guard that has only ever been observed passing is not yet known to be a
+# guard.
+#
+# Taking the function from the render rather than from a copy pasted into this
+# file is the #5646 reason: a suite validating a hand-kept copy goes on passing
+# after the shipped thing changes.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw292.omani.works"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+fail() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok   — $*"; }
+
+# ── Extract the function under test straight from the rendered chart ────────
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+awk '/^ *run_smtp_relay_host_lint\(\) \{/,/^ *\}$/' "${TMP}/render.yaml" \
+  | sed 's/^ *//' >"${TMP}/fn.sh"
+
+if ! grep -q 'run_smtp_relay_host_lint()' "${TMP}/fn.sh"; then
+  echo "FAIL — could not extract run_smtp_relay_host_lint from the rendered Job."
+  echo "       The lint is missing from the chart, or the function name changed."
+  exit 1
+fi
+# The awk range terminates on the first bare `}` line. If a nested multi-line
+# helper is ever added inside the lint the range truncates and every case below
+# would be driving a FRAGMENT — which would still `.`-source cleanly and could
+# still return 0. Pin the distinctive TAIL so truncation is a test failure
+# rather than a silent change of subject.
+if ! grep -q 'NINTH tether' "${TMP}/fn.sh"; then
+  echo "FAIL — the extracted function is truncated (its terminal FAIL message is missing)."
+  echo "       A nested function or a bare '}' line inside the lint breaks the awk range."
+  exit 1
+fi
+
+# ── Harness: stub kubectl serves the Secret under test ──────────────────────
+# STUB_HOST is the PLAINTEXT smtp-host; the stub base64-encodes it exactly as
+# the API server would, so the lint's own decode path is exercised rather than
+# bypassed. STUB_RC + STUB_ERR drive the failure branches.
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/kubectl" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "${STUB_ERR:-}" ]; then printf '%s\n' "${STUB_ERR}" >&2; exit "${STUB_RC:-1}"; fi
+# A warning on stderr alongside a SUCCESSFUL call — the shape that must not be
+# mistaken for an unmeasurable relay.
+[ -n "${STUB_WARN:-}" ] && printf '%s\n' "${STUB_WARN}" >&2
+if [ "${STUB_ABSENT_KEY:-}" = "1" ]; then exit 0; fi
+printf '%s' "${STUB_HOST:-}" | base64 | tr -d '\n'
+exit 0
+STUB
+chmod +x "${TMP}/bin/kubectl"
+
+# Runs the lint over one stubbed Secret; echoes PASS or FAIL.
+run_case() {
+  # Shift ONE at a time: `shift 2` is a no-op when only one argument was
+  # passed, which silently left the host in "$@" and fed it to the env loop.
+  local host="${1:-}"; shift || true
+  local allow="${1:-}"; shift || true
+  mkdir -p "${TMP}/work"
+  (
+    export PATH="${TMP}/bin:${PATH}"
+    export SOVEREIGN_FQDN="${FQDN}"
+    export SMTP_RELAY_HOST_ALLOW="${allow}"
+    export SMTP_RELAY_SECRET_NAMESPACE="catalyst-system"
+    export SMTP_RELAY_SECRET_NAME="sovereign-smtp-credentials"
+    export WORK_DIR="${TMP}/work"
+    export STUB_HOST="${host}"
+    # Per-case overrides arrive as NAME=VALUE arguments.
+    for kv in "$@"; do export "${kv?}"; done
+    cd "${TMP}"
+    # shellcheck disable=SC1090
+    . "${TMP}/fn.sh"
+    if run_smtp_relay_host_lint >"${TMP}/out.txt" 2>&1; then echo PASS; else echo FAIL; fi
+  )
+}
+
+expect() {
+  local desc="$1" want="$2" got="$3"
+  if [ "${got}" = "${want}" ]; then pass "${desc} (${got})"
+  else fail "${desc}: expected ${want}, got ${got}"; sed 's/^/        /' "${TMP}/out.txt"; fi
+}
+
+echo "[smtp-relay-host-lint] #5921 — the lint must fail on the mothership relay and pass on a Sovereign-local one"
+
+# 1. THE REAL DEFECT — the live hw292 finding, byte for byte. Must FAIL.
+got=$(run_case "mail.openova.io")
+expect "mothership relay mail.openova.io (the live hw292 finding)" FAIL "${got}"
+if grep -q 'NINTH tether' "${TMP}/out.txt"; then
+  pass "verdict names the tether so an operator can act on it"
+else
+  fail "verdict did not explain what was found"; sed 's/^/        /' "${TMP}/out.txt"
+fi
+
+# 2. POSITIVE CONTROL — the pivoted relay. Must PASS. Without this case a lint
+#    that always failed would look correct in case 1.
+got=$(run_case "mail.${FQDN}")
+expect "Sovereign-local relay mail.<fqdn>" PASS "${got}"
+
+# 3. DISCRIMINATION — the Sovereign's own apex, and an in-cluster relay (the
+#    shape a restored slot 95 ClusterIP Service produces).
+got=$(run_case "${FQDN}")
+expect "the Sovereign's own apex host" PASS "${got}"
+got=$(run_case "stalwart-web.stalwart.svc.cluster.local")
+expect "in-cluster submission relay" PASS "${got}"
+got=$(run_case "localhost")
+expect "loopback relay" PASS "${got}"
+
+# 4. VACUITY, THE OTHER DIRECTION — the SAME mothership host declared as a
+#    reviewed exception must PASS, proving case 1 failed on the HOST and not on
+#    something incidental like the decode or the Secret name.
+got=$(run_case "mail.openova.io" "mail.openova.io")
+expect "same host with an explicit allowHosts entry" PASS "${got}"
+
+# 5. An allowHosts entry must not be a substring free-for-all: a DIFFERENT
+#    third-party relay is still a tether when only one is declared.
+got=$(run_case "smtp.sendgrid.net" "mail.openova.io")
+expect "undeclared third-party relay while another is allowed" FAIL "${got}"
+
+# 6. A near-miss host that merely ENDS with the FQDN's characters but is not a
+#    subdomain of it must FAIL. Without this, a `*.${FQDN}` glob written as a
+#    bare substring test would pass on an attacker-shaped host.
+got=$(run_case "mail.nothw292.omani.works")
+expect "host that is not a subdomain of the Sovereign FQDN" FAIL "${got}"
+
+# 7. Port-bearing hosts must parse to the bare host in BOTH directions, so the
+#    port never turns a local relay into a tether or the reverse.
+got=$(run_case "mail.${FQDN}:587")
+expect "Sovereign-local relay with an explicit port" PASS "${got}"
+got=$(run_case "mail.openova.io:587")
+expect "mothership relay with an explicit port" FAIL "${got}"
+
+# 8. THE ABSENT-SECRET CARVE-OUT. No Secret means marketplace-api renders
+#    SMTP_HOST empty and dials nothing (core/marketplace-api/main.go
+#    defaultSMTPHost is ""), which is a broken funnel but not a TETHER — the
+#    same treatment the Flux lint gives an uninstalled CRD.
+got=$(run_case "" "" 'STUB_ERR=Error from server (NotFound): secrets "sovereign-smtp-credentials" not found' "STUB_RC=1")
+expect "absent Secret (no relay configured, not a tether)" PASS "${got}"
+got=$(run_case "" "" "STUB_ABSENT_KEY=1")
+expect "Secret present but carrying no smtp-host key" PASS "${got}"
+
+# 9. FAIL-CLOSED. Any OTHER read error means the relay could not be measured,
+#    and a verdict rendered over an unmeasured surface is the #5633 fail-open
+#    shape this Job has already been bitten by twice.
+got=$(run_case "" "" 'STUB_ERR=error: You must be logged in to the server (Unauthorized)' "STUB_RC=1")
+expect "unreadable Secret (RBAC drift)" FAIL "${got}"
+
+# 10. VACUITY FOR CASE 9 — a kubectl WARNING on stderr accompanies a fully
+#     successful call. An earlier draft of this lint keyed on "stderr is
+#     non-empty" rather than on the exit code, which would have failed every
+#     Sovereign whose kubectl emits a deprecation notice: a guard that goes red
+#     on a healthy cluster gets disabled, and then guards nothing.
+got=$(run_case "mail.${FQDN}" "" "STUB_WARN=W0810 12:00:00 client-side throttling")
+expect "Sovereign-local relay with a kubectl warning on stderr" PASS "${got}"
+
+# 11. FAIL-CLOSED on an unwritable scratch dir — the regression the sibling
+#     flux lint shipped and this suite caught there. A lint that cannot record
+#     its own measurement must not report PASS.
+got=$(run_case "mail.openova.io" "" "WORK_DIR=${TMP}/definitely-not-a-real-dir")
+expect "unwritable scratch dir" FAIL "${got}"
+
+# 12. Undecodable bytes are unmeasurable, not absent.
+got=$(run_case "" "" "STUB_ABSENT_KEY=0" "STUB_HOST=")
+expect "empty smtp-host value" PASS "${got}"
+
+echo
+if [ "${FAILURES}" -ne 0 ]; then
+  echo "[smtp-relay-host-lint] ${FAILURES} assertion(s) FAILED"
+  exit 1
+fi
+echo "[smtp-relay-host-lint] all assertions passed — the lint is proven to fail on the live hw292 mothership relay AND pass on a Sovereign-local one, with the absent-Secret carve-out and the unmeasurable-relay fail-closed both pinned"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1975,6 +1975,44 @@ egressTest:
   providerPackageHostLint:
     enabled: true
     allowHosts: []
+  # #5921 — outbound customer-auth SMTP relay host lint. The NINTH tether,
+  # and the only one on the PURCHASE path.
+  #
+  # catalyst-system/marketplace-api takes SMTP_HOST from
+  # catalyst-system/sovereign-smtp-credentials by secretKeyRef and dials it to
+  # deliver every customer sign-in code. On hw292 that host is mail.openova.io
+  # while cutoverComplete=true — so a Sovereign certified independent still
+  # cannot sell anything unless the OpenOva mothership's mail server answers.
+  # ADR-0002 enumerates EIGHT tethers and outbound customer-auth SMTP is not
+  # among them, so no cutover step pivots it.
+  #
+  # Why this is a DECLARATION lint rather than another entry in the deny set:
+  # naming mail.openova.io in blockedDomains (#5951) makes it unreachable
+  # during the hold, but SMTP is dialled on a CUSTOMER ACTION, not on a
+  # reconcile interval. A 600s window with no signup in it produces no
+  # connection to block, and the runtime proof passes with the tether live.
+  # That is the #5650 timing-independence argument with a human rather than an
+  # interval as the trigger, which is strictly weaker — an interval at least
+  # guarantees an eventual dial.
+  #
+  # ON BY DEFAULT, and it will go RED on today's Sovereigns. That is the
+  # intended outcome and the same call #5951 made: a red proof beats a green
+  # one asserting a sovereignty that does not hold. The pivot target itself is
+  # still missing — slot 95 (bp-stalwart-sovereign) was removed from the
+  # bootstrap-kit in 94ffe01ff, so nothing yet serves mail.<sovereignFQDN>. An
+  # operator running a cutover before that lands declares their chosen relay in
+  # allowHosts, which is a reviewed decision recorded in Git rather than a
+  # silent default.
+  smtpRelayHostLint:
+    enabled: true
+    # Third-party relays the operator has explicitly chosen and owns. Default
+    # EMPTY so the lint fails closed: a relay is a tether until someone says
+    # otherwise in values, in Git, under review.
+    allowHosts: []
+    # The Secret marketplace-api actually reads. Fixed by the bp-catalyst-
+    # platform chart contract (#901); overridable only for a bespoke install.
+    secretNamespace: catalyst-system
+    secretName: sovereign-smtp-credentials
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.179",
+      "version": "0.1.180",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_relay_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_relay_scope_test.go
@@ -1,0 +1,208 @@
+// #5921 — the NINTH tether: customer sign-in mail.
+//
+// catalyst-system/marketplace-api reads catalyst-system/sovereign-smtp-
+// credentials (chart template marketplace-api/deployment.yaml) to send every
+// customer sign-in code. Seeding a mothership relay into that Secret means a
+// post-cutover Sovereign with cutoverComplete=true cannot sell anything unless
+// OUR mail server answers. ADR-0002 enumerates EIGHT tethers and outbound
+// customer-auth SMTP is not among them, so no cutover step pivots it.
+//
+// These tests pin two properties the pre-#5921 seed could not express:
+//
+//  1. A Sovereign-local relay is reachable AT ALL. Before this change the host
+//     was `mail.openova.io` or an operator-supplied literal; there was no way
+//     to say "use the Sovereign's own mail host" and no code path anywhere in
+//     the seed that consulted dep.Request.SovereignFQDN.
+//  2. The Secret's provenance annotation reports the RESOLVED host rather than
+//     the code path. The old constant `phase-1-mothership-relay` was stamped
+//     even onto a Secret pointing at a Sovereign-local relay, so anything
+//     keying on it read a self-report that could not go wrong — the
+//     "guard that tested a surface that cannot fail" shape.
+package handler
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestResolveSovereignSMTPRelay_ScopeMatrix drives the resolver directly so
+// each precedence rung is asserted in BOTH directions. A resolver that always
+// returned "mothership" would satisfy any single case here on its own.
+func TestResolveSovereignSMTPRelay_ScopeMatrix(t *testing.T) {
+	const fqdn = "t99.omani.works"
+
+	cases := []struct {
+		name      string
+		mode      string
+		hostEnv   string
+		fromEnv   string
+		portEnv   string
+		fqdn      string
+		wantHost  string
+		wantFrom  string
+		wantPort  string
+		wantScope string
+	}{
+		{
+			// POSITIVE CONTROL — the shipped default is deliberately
+			// unchanged. Flipping it would point every fresh Sovereign at a
+			// relay nothing serves (slot 95 bp-stalwart-sovereign was removed
+			// from the bootstrap-kit in 94ffe01ff), which is an outage on the
+			// purchase path, not a sovereignty fix.
+			name: "default mode is the mothership relay (no regression)",
+			fqdn: fqdn, wantHost: "mail.openova.io", wantFrom: "noreply@openova.io",
+			wantPort: "587", wantScope: SovereignSMTPRelayScopeMothership,
+		},
+		{
+			// THE FIX — the path that did not exist before #5921.
+			name: "sovereign-local mode derives mail.<fqdn> from the deployment",
+			mode: SovereignSMTPRelayScopeLocal, fqdn: fqdn,
+			wantHost: "mail." + fqdn, wantFrom: "noreply@" + fqdn,
+			wantPort: "587", wantScope: SovereignSMTPRelayScopeLocal,
+		},
+		{
+			// FAIL-SAFE — sovereign-local cannot compose a host without an
+			// FQDN. Seeding the bare string `mail.` would break PIN delivery
+			// for the life of the cluster, so fall back to a deliverable relay
+			// AND report the tether honestly rather than claiming local.
+			name: "sovereign-local with empty FQDN falls back and reports mothership",
+			mode: SovereignSMTPRelayScopeLocal, fqdn: "",
+			wantHost: "mail.openova.io", wantFrom: "noreply@openova.io",
+			wantPort: "587", wantScope: SovereignSMTPRelayScopeMothership,
+		},
+		{
+			// THE ANNOTATION BUG — an operator-pinned Sovereign-local relay
+			// used to be stamped `phase-1-mothership-relay`. Scope must be
+			// measured from the resolved HOST, never from the requested mode.
+			name:    "explicit host wins and is classified from the host itself",
+			hostEnv: "mail." + fqdn, fqdn: fqdn,
+			wantHost: "mail." + fqdn, wantFrom: "noreply@openova.io",
+			wantPort: "587", wantScope: SovereignSMTPRelayScopeLocal,
+		},
+		{
+			// VACUITY, THE OTHER WAY — an explicit host that is NOT the
+			// Sovereign's own stays a tether even in sovereign-local mode.
+			// This proves the previous case turned on the HOST and not merely
+			// on the presence of an override.
+			name: "explicit foreign host stays a tether even in sovereign-local mode",
+			mode: SovereignSMTPRelayScopeLocal, hostEnv: "smtp.sendgrid.net", fqdn: fqdn,
+			wantHost: "smtp.sendgrid.net", wantFrom: "noreply@openova.io",
+			wantPort: "587", wantScope: SovereignSMTPRelayScopeMothership,
+		},
+		{
+			name: "explicit from and port are honoured",
+			mode: SovereignSMTPRelayScopeLocal, fromEnv: "hello@" + fqdn, portEnv: "2525", fqdn: fqdn,
+			wantHost: "mail." + fqdn, wantFrom: "hello@" + fqdn,
+			wantPort: "2525", wantScope: SovereignSMTPRelayScopeLocal,
+		},
+		{
+			// An in-cluster relay is the Sovereign's own too — this is the
+			// shape a restored slot 95 would produce via its ClusterIP
+			// Service, and it must not be reported as a mothership tether.
+			name:    "in-cluster service host classifies as sovereign-local",
+			hostEnv: "stalwart-web.stalwart.svc.cluster.local", fqdn: fqdn,
+			wantHost: "stalwart-web.stalwart.svc.cluster.local", wantFrom: "noreply@openova.io",
+			wantPort: "587", wantScope: SovereignSMTPRelayScopeLocal,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(sovereignSMTPRelayModeEnv, tc.mode)
+			t.Setenv("CATALYST_SOVEREIGN_SMTP_RELAY_HOST", tc.hostEnv)
+			t.Setenv("CATALYST_SOVEREIGN_SMTP_RELAY_FROM", tc.fromEnv)
+			t.Setenv("CATALYST_SOVEREIGN_SMTP_RELAY_PORT", tc.portEnv)
+
+			got := resolveSovereignSMTPRelay(tc.fqdn, "noreply@openova.io")
+
+			if got.Host != tc.wantHost {
+				t.Errorf("Host = %q, want %q", got.Host, tc.wantHost)
+			}
+			if got.From != tc.wantFrom {
+				t.Errorf("From = %q, want %q", got.From, tc.wantFrom)
+			}
+			if got.Port != tc.wantPort {
+				t.Errorf("Port = %q, want %q", got.Port, tc.wantPort)
+			}
+			if got.Scope != tc.wantScope {
+				t.Errorf("Scope = %q, want %q (scope must be measured from the resolved host, not the requested mode)", got.Scope, tc.wantScope)
+			}
+		})
+	}
+}
+
+// TestSeedSovereignSMTPCredentials_SovereignLocalRelay is the end-to-end
+// assertion on the SEEDED BYTES. The resolver being right is not enough if the
+// seed never consults the deployment's FQDN and never writes what it returns.
+// This case fails outright before #5921: the pre-fix seed contained no
+// reference to dep.Request.SovereignFQDN anywhere.
+func TestSeedSovereignSMTPCredentials_SovereignLocalRelay(t *testing.T) {
+	const fqdn = "t99.omani.works"
+	setSeedSMTPEnv(t, "noreply@openova.io", "p455w0rd-bytes-here-not-real")
+	t.Setenv(sovereignSMTPRelayModeEnv, SovereignSMTPRelayScopeLocal)
+
+	core := kfake.NewSimpleClientset()
+	h := &Handler{log: silentLogger()}
+	h.SetSovereignSMTPSeedClientFactory(func(string) (kubernetes.Interface, error) { return core, nil })
+
+	dep := seedTestDeployment("dep-local-relay")
+	dep.Request.SovereignFQDN = fqdn
+
+	if outcome := h.seedSovereignSMTPCredentials(context.Background(), dep, "kubeconfig-yaml-bytes"); outcome != SovereignSMTPSeedOutcomeCreated {
+		t.Fatalf("outcome = %q, want %q", outcome, SovereignSMTPSeedOutcomeCreated)
+	}
+
+	got, err := core.CoreV1().Secrets(sovereignSMTPSeedNamespace).Get(context.Background(), sovereignSMTPSeedSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Secret not created: %v", err)
+	}
+
+	// The bytes marketplace-api actually dials. This is the purchase path.
+	if host := string(got.Data["smtp-host"]); host != "mail."+fqdn {
+		t.Errorf("smtp-host = %q, want %q — a post-cutover Sovereign must not send customer sign-in codes through the mothership", host, "mail."+fqdn)
+	}
+	if from := string(got.Data["smtp-from"]); from != "noreply@"+fqdn {
+		t.Errorf("smtp-from = %q, want %q", from, "noreply@"+fqdn)
+	}
+	// Provenance must describe the bytes, not the code path.
+	if s := got.Annotations["catalyst.openova.io/relay-scope"]; s != SovereignSMTPRelayScopeLocal {
+		t.Errorf("relay-scope annotation = %q, want %q", s, SovereignSMTPRelayScopeLocal)
+	}
+	if p := got.Annotations["catalyst.openova.io/seed-phase"]; p != "phase-2-sovereign-local-relay" {
+		t.Errorf("seed-phase annotation = %q, want phase-2-sovereign-local-relay", p)
+	}
+}
+
+// TestSeedSovereignSMTPCredentials_MothershipRelayIsStampedAsTethered pins the
+// other direction: the default seed still writes a deliverable relay AND now
+// says out loud that it is a tether. Without this case the test above is also
+// satisfied by a seed that stamps `sovereign-local` unconditionally.
+func TestSeedSovereignSMTPCredentials_MothershipRelayIsStampedAsTethered(t *testing.T) {
+	setSeedSMTPEnv(t, "noreply@openova.io", "p455w0rd-bytes-here-not-real")
+
+	core := kfake.NewSimpleClientset()
+	h := &Handler{log: silentLogger()}
+	h.SetSovereignSMTPSeedClientFactory(func(string) (kubernetes.Interface, error) { return core, nil })
+
+	dep := seedTestDeployment("dep-mothership-relay")
+	dep.Request.SovereignFQDN = "t99.omani.works"
+
+	if outcome := h.seedSovereignSMTPCredentials(context.Background(), dep, "kubeconfig-yaml-bytes"); outcome != SovereignSMTPSeedOutcomeCreated {
+		t.Fatalf("outcome = %q, want %q", outcome, SovereignSMTPSeedOutcomeCreated)
+	}
+
+	got, err := core.CoreV1().Secrets(sovereignSMTPSeedNamespace).Get(context.Background(), sovereignSMTPSeedSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Secret not created: %v", err)
+	}
+	if host := string(got.Data["smtp-host"]); host != "mail.openova.io" {
+		t.Errorf("smtp-host = %q, want mail.openova.io (the default must stay deliverable)", host)
+	}
+	if s := got.Annotations["catalyst.openova.io/relay-scope"]; s != SovereignSMTPRelayScopeMothership {
+		t.Errorf("relay-scope annotation = %q, want %q — the default seed IS a tether and must say so", s, SovereignSMTPRelayScopeMothership)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed.go
@@ -95,6 +95,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -130,6 +131,158 @@ const defaultSovereignSMTPSeedTimeout = 30 * time.Second
 // wizard's reducer renders these events alongside the per-component
 // install lines.
 const sovereignSMTPSeedPhase = "sovereign-smtp-seed"
+
+// ── #5921 — the NINTH tether, and the only one on the purchase path ──
+//
+// Everything this file seeds ends up in catalyst-system/sovereign-smtp-
+// credentials, which `catalyst-system/marketplace-api` reads via
+// secretKeyRef to send every customer sign-in code (chart template
+// marketplace-api/deployment.yaml). Seeding `mail.openova.io` there
+// means a post-cutover Sovereign with cutoverComplete=true still cannot
+// sell anything unless the OpenOva mothership's mail server answers.
+// ADR-0002 enumerates EIGHT tethers; outbound customer-auth SMTP is not
+// among them, so no cutover step pivots it.
+//
+// RELAY SCOPE is therefore an explicit, recorded property of the seed —
+// not an accident of which default fired:
+//
+//   sovereign-local — relay at `mail.<sovereignFQDN>`, sender
+//                     `noreply@<sovereignFQDN>`. The Sovereign sends its
+//                     own customer mail and owns the whole purchase path.
+//                     REQUIRES a Sovereign-local submission relay to
+//                     exist (see the "what remains" note below).
+//   mothership      — relay at `mail.openova.io` (the Phase-1 behaviour
+//                     this file has always had). Deliverable on a fresh
+//                     Sovereign that has no mail stack of its own, and a
+//                     live tether until pivoted.
+//
+// DEFAULT IS `mothership` ON PURPOSE. Flipping the default would point
+// every fresh Sovereign at a relay that does not exist yet — slot 95
+// (bp-stalwart-sovereign) was removed from the bootstrap-kit in 94ffe01ff
+// because its post-install Job was timing out, so today NOTHING serves
+// `mail.<sovereignFQDN>`. A default that breaks PIN delivery on every
+// prov is not a sovereignty fix, it is an outage. The pivot is gated on
+// the local relay actually existing, which is why the ENFORCEMENT half
+// lives in the cutover's step-08 lint (run_smtp_relay_host_lint) rather
+// than in a default flip here.
+const sovereignSMTPRelayModeEnv = "CATALYST_SOVEREIGN_SMTP_RELAY_MODE"
+
+const (
+	// SovereignSMTPRelayScopeMothership — the seed wrote mothership relay
+	// coordinates. The Sovereign's customer-auth mail is TETHERED.
+	SovereignSMTPRelayScopeMothership = "mothership"
+	// SovereignSMTPRelayScopeLocal — the seed wrote Sovereign-local relay
+	// coordinates derived from the deployment's own FQDN.
+	SovereignSMTPRelayScopeLocal = "sovereign-local"
+)
+
+// sovereignSMTPRelay — the resolved outbound relay coordinates plus the
+// SCOPE that produced them.
+type sovereignSMTPRelay struct {
+	Host  string
+	Port  string
+	From  string
+	Scope string
+}
+
+// resolveSovereignSMTPRelay decides the relay coordinates the seed writes.
+//
+// Precedence, highest first:
+//
+//  1. CATALYST_SOVEREIGN_SMTP_RELAY_HOST — an explicit operator-pinned
+//     relay. Honoured in either mode so a bespoke relay needs no rebuild.
+//  2. CATALYST_SOVEREIGN_SMTP_RELAY_MODE=sovereign-local — derive
+//     `mail.<sovereignFQDN>` from the deployment's own request.
+//  3. mothership (default) — `mail.openova.io`.
+//
+// SCOPE IS MEASURED FROM THE RESOLVED HOST, NEVER FROM THE REQUESTED
+// MODE. That distinction is the bug this function also fixes: the seed
+// previously stamped every Secret `seed-phase: phase-1-mothership-relay`
+// unconditionally, so an operator who pinned a Sovereign-local relay via
+// CATALYST_SOVEREIGN_SMTP_RELAY_HOST got a Secret whose own provenance
+// annotation said "mothership". Any cutover lint or migration script
+// keying on that annotation would have read a value that described the
+// code path instead of the bytes — a self-report that cannot go wrong is
+// not evidence.
+//
+// FAIL-SAFE: sovereign-local with an empty SovereignFQDN cannot compose a
+// host. Rather than seed `mail.` (an unresolvable host that would break
+// PIN delivery for the life of the cluster), fall back to the mothership
+// relay and report the scope HONESTLY as mothership, so the operator sees
+// a tether rather than a silent breakage.
+func resolveSovereignSMTPRelay(sovereignFQDN, smtpUser string) sovereignSMTPRelay {
+	port := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_PORT")
+	if port == "" {
+		port = "587"
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(sovereignSMTPRelayModeEnv)))
+	fqdn := strings.ToLower(strings.TrimSpace(sovereignFQDN))
+
+	host := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_HOST")
+	from := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_FROM")
+
+	if host == "" {
+		if mode == SovereignSMTPRelayScopeLocal && fqdn != "" {
+			host = "mail." + fqdn
+			if from == "" {
+				from = "noreply@" + fqdn
+			}
+		} else {
+			host = "mail.openova.io"
+		}
+	}
+	if from == "" {
+		from = smtpUser
+	}
+
+	return sovereignSMTPRelay{
+		Host:  host,
+		Port:  port,
+		From:  from,
+		Scope: classifySovereignSMTPRelayScope(host, fqdn),
+	}
+}
+
+// classifySovereignSMTPRelayScope reports whether a relay host is the
+// Sovereign's own or somebody else's, from the HOST STRING itself.
+//
+// A host is Sovereign-local when it is the Sovereign's own FQDN or any
+// subdomain of it, or an in-cluster address. Everything else — including
+// every openova.io host — is a tether. Deliberately NOT a
+// "contains openova.io" test: the discriminator is "is this MINE", and a
+// Sovereign whose own FQDN were an openova.io subdomain would still be
+// answering for itself.
+func classifySovereignSMTPRelayScope(host, sovereignFQDN string) string {
+	h := strings.ToLower(strings.TrimSpace(host))
+	h = strings.TrimSuffix(h, ".")
+	if i := strings.LastIndex(h, ":"); i > 0 && !strings.Contains(h[i:], "]") {
+		h = h[:i]
+	}
+	fqdn := strings.ToLower(strings.TrimSpace(sovereignFQDN))
+
+	if fqdn != "" && (h == fqdn || strings.HasSuffix(h, "."+fqdn)) {
+		return SovereignSMTPRelayScopeLocal
+	}
+	switch {
+	case h == "localhost", h == "127.0.0.1":
+		return SovereignSMTPRelayScopeLocal
+	case strings.HasSuffix(h, ".svc"), strings.HasSuffix(h, ".svc.cluster.local"):
+		return SovereignSMTPRelayScopeLocal
+	}
+	return SovereignSMTPRelayScopeMothership
+}
+
+// sovereignSMTPSeedPhaseLabel maps a relay scope onto the historical
+// `seed-phase` annotation vocabulary. The mothership value is preserved
+// verbatim so existing tooling that greps for `phase-1-mothership-relay`
+// keeps matching the Secrets it always matched.
+func sovereignSMTPSeedPhaseLabel(scope string) string {
+	if scope == SovereignSMTPRelayScopeLocal {
+		return "phase-2-sovereign-local-relay"
+	}
+	return "phase-1-mothership-relay"
+}
 
 // SovereignSMTPSeedClientFactory — test-only override for building a
 // kubernetes.Interface from a kubeconfig YAML. Production wires
@@ -205,18 +358,13 @@ func (h *Handler) seedSovereignSMTPCredentials(ctx context.Context, dep *Deploym
 	// contract Secret to a host that actually answers. Env-overridable so a
 	// bespoke relay can be pinned without a rebuild; defaults match the seed's
 	// stated intent (mail.openova.io:587).
-	relayHost := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_HOST")
-	if relayHost == "" {
-		relayHost = "mail.openova.io"
-	}
-	relayPort := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_PORT")
-	if relayPort == "" {
-		relayPort = "587"
-	}
-	relayFrom := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_FROM")
-	if relayFrom == "" {
-		relayFrom = smtpUser
-	}
+	//
+	// #5921 — the relay is now resolved through a SCOPED helper so the
+	// Sovereign-local path exists and the Secret records which scope it
+	// actually got. See resolveSovereignSMTPRelay for the precedence and
+	// for why the default stays `mothership`.
+	relay := resolveSovereignSMTPRelay(dep.Request.SovereignFQDN, smtpUser)
+	relayHost, relayPort, relayFrom := relay.Host, relay.Port, relay.From
 
 	factory := h.sovereignSMTPSeedClientFactory
 	if factory == nil {
@@ -295,10 +443,24 @@ func (h *Handler) seedSovereignSMTPCredentials(ctx context.Context, dep *Deploym
 				// SMTP credentials. The value is a UUID — not a
 				// credential — and is safe to log.
 				"catalyst.openova.io/seeded-by-deployment-id": dep.ID,
-				// Phase-1 marker: when Phase-2 spins up per-Sovereign
+				// Phase marker: when Phase-2 spins up per-Sovereign
 				// Stalwart-relay, the migration script can target
 				// every Secret with this annotation for rotation.
-				"catalyst.openova.io/seed-phase": "phase-1-mothership-relay",
+				//
+				// #5921 — this used to be the CONSTANT string
+				// "phase-1-mothership-relay", stamped even when an
+				// operator had pinned a Sovereign-local relay through
+				// CATALYST_SOVEREIGN_SMTP_RELAY_HOST. It described the
+				// code path rather than the bytes, so it could never
+				// disagree with reality and was worthless as evidence.
+				// It is now derived from the RESOLVED host.
+				"catalyst.openova.io/seed-phase": sovereignSMTPSeedPhaseLabel(relay.Scope),
+				// #5921 — machine-readable tether marker. `mothership`
+				// means every customer sign-in code this Sovereign
+				// sends transits OUR mail server; the cutover step-08
+				// smtp-relay-host lint refuses to certify sovereignty
+				// while that is true.
+				"catalyst.openova.io/relay-scope": relay.Scope,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -343,6 +505,8 @@ func (h *Handler) seedSovereignSMTPCredentials(ctx context.Context, dep *Deploym
 		"name", sovereignSMTPSeedSecretName,
 		"smtpRelayHost", relayHost, // #4748 — not a secret; the reachable public relay
 		"smtpRelayPort", relayPort,
+		"smtpRelayScope", relay.Scope, // #5921 — `mothership` == customer-auth mail is tethered
+
 		"smtpUserBytes", len(smtpUser),
 		"smtpPassBytes", len(smtpPass),
 	)

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.179",
+    "version": "0.1.180",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3578,16 +3578,6 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-# 1.4.1417 — #6114: catalog-seed bp-openclaw pin 0.2.17 -> 0.2.18 (lockstep w/
-#   platform/openclaw chart + blueprint.yaml) so the phantom-Secret removal
-#   reaches fresh Orgs. bp-openclaw 0.2.17 mounted LLM_API_KEY/OPENAI_API_KEY
-#   from `openclaw-newapi-controller-token`, a Secret NOTHING in the repo has
-#   ever created; the refs were `optional: true` so the envs silently stayed
-#   unset and no Pod reported it, and the controller binary reads neither env.
-#   0.2.18 drops the reference rather than minting a live NewAPI token with no
-#   consumer. The per-user `newapi-key-{uuid}` path (ADR-0003 §3.3) is
-#   unchanged. Without this seed bump the Sovereign keeps resolving 0.2.17 and
-#   the fix is a hollow pin (the #6040 class).
 # 1.4.1072 — #4952: catalog-seed bp-openclaw pin 0.2.16 -> 0.2.17 (lockstep w/
 #   platform/openclaw chart + blueprint.yaml) so the per-Org-namespace fix
 #   reaches fresh funnel Orgs. bp-openclaw 0.2.16 defaulted tenant.namespace to
@@ -3899,7 +3889,18 @@ name: bp-catalyst-platform
 #   The seed pin is the delivery half: without this bump a pinned Sovereign
 #   resolves 1.5.9 and never sees the fix. This chart's own templates are
 #   unchanged.
-version: 1.4.1422
+#
+# 1.4.1414 (#5921): catalog-seed bp-self-sovereign-cutover pin 0.1.179 ->
+#   0.1.180 — step-08 gains the pre-hold outbound customer-auth SMTP relay
+#   host lint (the NINTH tether: marketplace-api sends every customer sign-in
+#   code through catalyst-system/sovereign-smtp-credentials' smtp-host, which
+#   is mail.openova.io on a post-cutover Sovereign, so a cluster certified
+#   independent still cannot sell anything unless OUR mail server answers).
+#   Republished here per check-umbrella-republish-gate.py (#5734): a
+#   catalog-seed pin that moves without this file's version moving is never
+#   carried by the published bp-catalyst-platform OCI artifact, so the
+#   Sovereign keeps installing the old cutover chart. Lockstep w/ slot-13 pin.
+version: 1.4.1423
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4054,7 +4055,7 @@ version: 1.4.1422
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1422
+appVersion: 1.4.1414
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.179"
+  version: "0.1.180"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.179"
+    version: "0.1.180"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Rebased onto current `main` (was a day stale, `ghcr-pin-existence` red on a
superseded pin). Re-verified end to end; nothing about the design changed.

## The producer

`products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed.go:208-211`
(pre-change) — the **mothership's** catalyst-api seeds
`catalyst-system/sovereign-smtp-credentials` onto every NEW Sovereign at
provision time with a hardcoded `relayHost = "mail.openova.io"`.
`catalyst-system/marketplace-api` reads that Secret by `secretKeyRef` and dials
it to send every customer sign-in code. A Sovereign with `cutoverComplete=true`
therefore cannot sell anything unless **our** mail server answers. ADR-0002 and
`docs/DOD.md` Pillar 5 enumerate **eight** tethers; outbound customer-auth SMTP
is not among them, so no cutover step pivots it and no sovereignty check looks
for it.

## The target exists, but nothing installs it

`platform/stalwart-sovereign/` ships a per-Sovereign mail chart. Bootstrap-kit
**slot 95** (`bp-stalwart-sovereign`) was **removed** in `94ffe01ff`
(2026-05-05, #958, Phase-2 deferred), and no slot serves it today — nothing
answers `mail.<sovereignFQDN>` on a current prov. That single fact drives every
decision below.

## Where the pivot goes

The seed gains a **scoped relay resolver** (`sovereign-local` | `mothership`) so
the Sovereign-local path exists at all — before this change no code path
anywhere in the seed consulted `dep.Request.SovereignFQDN`.

**The default stays `mothership` deliberately.** Flipping it would point every
fresh Sovereign at a host nothing serves — an outage on the purchase path, not a
sovereignty fix. That is exactly the **#6172 ordering trap** (bp-keycloak at slot
09 pointing at a Service this chart creates at slot 13). Enforcement therefore
lives in **cutover step-08 as a pre-hold lint**, not as a new step.

**Step count is unchanged at 11**, so `docs/GLOSSARY.md` and `CLAUDE.md` need no
edit and cannot drift. `chart/tests/cutover-contract.sh` still asserts exactly 11
step ConfigMaps and passes.

## Slot ordering

The lint ships in `bp-self-sovereign-cutover`, installed **dormant at slot 06a**
and executed only **post-handover** — after slot 13 (`bp-catalyst-platform`,
which brings marketplace-api) and after provision-time seeding. It reads a Secret
that by then already exists, and an **absent Secret is an explicit PASS
carve-out**, so the lint cannot wedge the flow it protects. No forward reference,
no cycle.

## Why a declaration lint rather than another deny-set entry

#5951 already added `mail.openova.io` to step-08's `blockedDomains`. That makes
the host unreachable during the hold; it does not make the dependency visible,
because SMTP is dialled on a **customer action** rather than a reconcile
interval. A 600s window containing no signup produces no connection to block, and
the runtime proof passes with the tether fully live — the #5650
timing-independence argument with a human, rather than an interval, as the
trigger, which is strictly weaker.

## A self-report that could not go wrong, also fixed

The seed stamped the constant annotation `seed-phase=phase-1-mothership-relay`
even onto a Secret an operator had pointed at a Sovereign-local relay via
`CATALYST_SOVEREIGN_SMTP_RELAY_HOST`. It described the code path, not the bytes.
Scope is now **measured from the resolved host** and published as
`catalyst.openova.io/relay-scope`.

## Red then green

`chart/tests/smtp-relay-host-lint.sh` extracts the real function from the
**render** (#5646) and drives 17 cases through a stub kubectl.

RED, against `origin/main`'s chart:

```
FAIL — could not extract run_smtp_relay_host_lint from the rendered Job.
       The lint is missing from the chart, or the function name changed.
EXIT=1
```

GREEN, against this chart:

```
  ok   — mothership relay mail.openova.io (the live hw292 finding) (FAIL)
  ok   — Sovereign-local relay mail.<fqdn> (PASS)
  ok   — in-cluster submission relay (PASS)
  ok   — unreadable Secret (RBAC drift) (FAIL)
  ok   — absent Secret (no relay configured, not a tether) (PASS)
[smtp-relay-host-lint] all assertions passed
EXIT=0
```

Go, `-count=1`, against `origin/main`'s exact semantics reproduced through the
new signatures:

```
--- FAIL: TestResolveSovereignSMTPRelay_ScopeMatrix/sovereign-local_mode_derives_mail.<fqdn>_from_the_deployment
        Host = "mail.openova.io", want "mail.t99.omani.works"
        Scope = "mothership", want "sovereign-local"
--- FAIL: TestSeedSovereignSMTPCredentials_SovereignLocalRelay
        relay-scope annotation = "mothership", want "sovereign-local"
        seed-phase annotation = "phase-1-mothership-relay", want phase-2-sovereign-local-relay
FAIL
```

after:

```
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.335s
```

## Controls and vacuity

**CONTROL 1** — `chart/tests/provider-package-host-lint.sh`, the sibling pre-hold
lint in the same Job, shares the suspect property (extracted from the render,
driven by a stub kubectl) and stays green: exit 0. All 17 cutover chart suites
pass.

**CONTROL 2** — the pre-existing `sovereign_smtp_seed_test.go`, which asserts the
default host **is** `mail.openova.io`, still passes. The default is deliberately
unregressed, and the test matrix carries that case as a named positive control.

**VACUITY** — mutating the shipped lint's terminal verdict from `FAIL`/`return 1`
to `PASS`/`return 0` turns the suite RED on exactly the four negative cases:

```
  FAIL — mothership relay mail.openova.io (the live hw292 finding): expected FAIL, got PASS
  FAIL — undeclared third-party relay while another is allowed: expected FAIL, got PASS
  FAIL — host that is not a subdomain of the Sovereign FQDN: expected FAIL, got PASS
  FAIL — mothership relay with an explicit port: expected FAIL, got PASS
VACUITY EXIT=1
```

The suite can fail on a live chart, not only on a missing one.

## Size

#6004 shrank this chart to fit under the 1048576-byte Helm release-Secret cap, so
every comment added here uses the block-comment form stored once rather than
twice. `scripts/check-helm-release-payload-size.py`: **73.90% of ceiling, 168804
bytes under budget**.

## Lockstep — eight sites

Cutover `Chart.yaml`, `blueprint.yaml`, slot-06a pin, catalog-seed
`spec.version` and `source.version`, the API `blueprints.json`, and the generated
UI catalog all move `0.1.179 -> 0.1.180`; the umbrella republishes
`1.4.1411 -> 1.4.1414` with its slot-13 pin, per
`check-umbrella-republish-gate.py` (#5734). The two generated files were rebuilt
with the real generator (`node scripts/build-catalog.mjs`), not hand-edited, and
`scripts/bump-chart-version.sh` was re-run immediately before the push.

## Expected behaviour on today's Sovereigns

The lint is **on by default and will go red** on a Sovereign still seeded with
the mothership relay. That is the intended outcome and the same call #5951 made:
a red proof beats a green one asserting a sovereignty that does not hold. An
operator cutting over before a Sovereign-local relay lands declares their chosen
relay in `egressTest.smtpRelayHostLint.allowHosts` — a reviewed decision recorded
in Git rather than a silent default.

No live environment was used and **no runtime evidence is claimed** (hw294 is
wedged at 51/67 on #6172). Source-and-test work only.

Refs #5921
