### PR TITLE
fix(dr): make the DR panel report what it measures — UAT rows 62/63/71 + #5945

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -77,6 +77,18 @@ type continuumReplicationStatus struct {
 	//         verified from live cluster state; reported as unknown, NOT as
 	//         a fabricated healthy.
 	StandbyAvailable *bool                   `json:"standbyAvailable,omitempty"`
+	// Phase / LeaseHolder / LeaseExpiresAt are the CONTINUUM'S OWN reconciled
+	// status, relayed verbatim so the DR panel can render the live Continuum
+	// state instead of a static badge (UAT row 62). The controller writes all
+	// three (continuum_controller.go patchStatus: status.phase,
+	// status.leaseHolder, status.leaseExpiresAt) and this endpoint already READ
+	// leaseHolder — it just consumed it internally (to correct CurrentPrimary)
+	// and then dropped it, so the console had no way to show WHO holds the
+	// witness lease or whether the Continuum reconciled Healthy. Omitted when
+	// the CR does not report them — never defaulted to a green-looking value.
+	Phase             string                  `json:"phase,omitempty"`
+	LeaseHolder       string                  `json:"leaseHolder,omitempty"`
+	LeaseExpiresAt    string                  `json:"leaseExpiresAt,omitempty"`
 	Replicas          []continuumReplicaInfo  `json:"replicas"`
 	HealthGates       []continuumHealthGate   `json:"healthGates"`
 	ObservedAt        string                  `json:"observedAt"`
@@ -403,6 +415,44 @@ func (h *Handler) augmentReplicationStandbyStatus(
 		}
 	}
 	if !determined {
+		// PER-REGION SPLIT (#5511 class), measured on hw292 2026-08-10: this
+		// handler's dynamic client is scoped to the REGION-A cluster, and the
+		// replica half of a 2-region pair is a cnpg Cluster in REGION B. So for
+		// dr-shared-pg — spec.cnpgPair={shared-pg, shared-data}, a genuinely
+		// healthy pair — the region-A list returns only the
+		// `openova.io/cnpg-role=primary` half, no replica is resolvable, and
+		// this branch reported "unverifiable" PERMANENTLY. Since #5508 the
+		// console turns that Warn into "the lag is not a measurement" and prints
+		// "—", which is the clause UAT rows 62 and 71 fail on.
+		//
+		// The continuum-controller does NOT have that blind spot: it probes the
+		// standby directly (pgprobe, #4901/#5311) and publishes the verdict as
+		// `status.standbyAvailable`. When our own cross-check cannot see the
+		// replica, that probe is the best positive evidence available, so relay
+		// it — and SAY SO in the message, because it is a weaker provenance than
+		// reading the replica half ourselves.
+		//
+		// This does NOT reopen #4901 (a stored-green CR masking an outage): the
+		// probe is what GOES FALSE during an outage, and it is only consulted
+		// here when the live cross-check found nothing to contradict it. A CR
+		// that omits the key still reports unverifiable — never a fabricated Pass.
+		if crStandby, found, _ := unstructured.NestedBool(cr.Object, "status", "standbyAvailable"); found {
+			resp.StandbyAvailable = &crStandby
+			if crStandby {
+				upsertHealthGate(resp, continuumHealthGate{
+					Name: "standby-available", Status: "Pass", Severity: "info",
+					Message: "standby leg reported available by the Continuum controller's standby probe (the replica half is not visible from this region's cluster)",
+				})
+				return
+			}
+			resp.ReplicaPromotable = false
+			resp.StreamingState = "interrupted"
+			upsertHealthGate(resp, continuumHealthGate{
+				Name: "standby-available", Status: "Fail", Severity: "critical",
+				Message: "the Continuum controller's standby probe reports the required hot-standby is unreachable; replication has no standby leg and RPO=0 durability is at risk",
+			})
+			return
+		}
 		upsertHealthGate(resp, continuumHealthGate{
 			Name: "standby-available", Status: "Warn", Severity: "warning",
 			Message: "standby leg not verifiable from live cluster state (no cnpg pair resolvable); reporting unknown, not healthy",
@@ -1087,8 +1137,14 @@ func enrichReplicationStatus(cr *unstructured.Unstructured) continuumReplication
 	// hardcoded all-Pass wall (the prior shape reported "streaming-replication
 	// Pass" during a proven standby outage).
 	leaseHolder, _, _ := unstructured.NestedString(cr.Object, "status", "leaseHolder")
+	// Row 62 — relay the Continuum's OWN reconciled status so the DR panel can
+	// render live state (phase + who holds the witness lease + when it expires)
+	// rather than a static badge. Read-only passthrough; empty when unreported.
+	out.Phase = phase
+	out.LeaseHolder = leaseHolder
+	out.LeaseExpiresAt, _, _ = unstructured.NestedString(cr.Object, "status", "leaseExpiresAt")
 	out.HealthGates = []continuumHealthGate{
-		replicationHealthGate(replHealthy, replHealthyFound, phase),
+		replicationHealthGate(replHealthy, replHealthyFound, standbyAvailable, standbyAvailableFound, phase),
 		walLagHealthGate(cr.Object, out.WALLagSeconds),
 		leaseWitnessHealthGate(leaseHolder),
 	}
@@ -1110,11 +1166,30 @@ func enrichReplicationStatus(cr *unstructured.Unstructured) continuumReplication
 }
 
 // replicationHealthGate derives the streaming-replication gate from the
-// observed status. Tri-state honest: Pass only on a positive
-// replicationHealthy=true reading; Fail on an explicit false or a
-// Degraded/FailedOver phase; Warn (unverified) when the CR reports neither —
-// NEVER a default Pass. #4923.
-func replicationHealthGate(healthy, found bool, phase string) continuumHealthGate {
+// observed status. Tri-state honest: Pass only on POSITIVE evidence; Fail on an
+// explicit negative or a Degraded/FailedOver phase; Warn (unverified) when the
+// CR reports neither — NEVER a default Pass. #4923.
+//
+// UAT row 71 — THE GATE COULD NEVER PASS. `status.replicationHealthy` has ZERO
+// producers: grep across core/controllers/continuum and core/pkg/apis returns
+// nothing, and all 8 live Continuums on hw292 omit it. So `found` was false on
+// every real CR and this gate returned Warn "unverified" unconditionally,
+// forever, on a fully healthy pair. Downstream that is not cosmetic: since
+// #5508 the console treats a streaming-replication Warn as "the lag reading is
+// not a measurement" and renders the replication lag as "—", which is exactly
+// the clause row 71 fails on ("a live replication-lag number").
+//
+// The fix is the one #5601 already applied to ReplicaPromotable in this same
+// file and did not carry across to the gate: consume the key the controller
+// ACTUALLY writes. `status.standbyAvailable` is the continuum-controller's own
+// standby-probe verdict (patchStatus line ~1396; the #4901/#5311 probe), so a
+// true reading alongside a reconciled-ready phase IS positive evidence that
+// replication is streaming, and a false reading is a verified fault. A CR
+// carrying neither key still yields Warn — never a Pass without evidence.
+// Degraded/FailedOver are already short-circuited to Fail below, so the only
+// phase that can carry the standby-probe evidence to a Pass is Healthy.
+func replicationHealthGate(healthy, found, standbyAvailable, standbyFound bool, phase string) continuumHealthGate {
+	phaseReady := phase == "Healthy"
 	switch {
 	case found && healthy:
 		return continuumHealthGate{Name: "streaming-replication", Status: "Pass", Severity: "info"}
@@ -1124,6 +1199,12 @@ func replicationHealthGate(healthy, found bool, phase string) continuumHealthGat
 	case phase == "Degraded" || phase == "FailedOver":
 		return continuumHealthGate{Name: "streaming-replication", Status: "Fail", Severity: "critical",
 			Message: fmt.Sprintf("Continuum phase is %s", phase)}
+	case standbyFound && !standbyAvailable:
+		return continuumHealthGate{Name: "streaming-replication", Status: "Fail", Severity: "critical",
+			Message: "the Continuum's standby probe reports no standby leg; replication is not streaming"}
+	case standbyFound && standbyAvailable && phaseReady:
+		return continuumHealthGate{Name: "streaming-replication", Status: "Pass", Severity: "info",
+			Message: fmt.Sprintf("standby probe reports the standby leg available; Continuum phase is %s", phase)}
 	default:
 		return continuumHealthGate{Name: "streaming-replication", Status: "Warn", Severity: "warning",
 			Message: "replication health not reported by the Continuum CR; unverified"}

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_row62_71_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_row62_71_test.go
@@ -1,0 +1,276 @@
+// continuum_dr_extras_row62_71_test.go — UAT rows 62 + 71 regression locks.
+//
+// Both rows fail on the SAME rendered symptom (the DR panel cannot show a live
+// replication-lag number, and shows no Continuum phase / lease holder) and both
+// bottom out in this handler, not in the console:
+//
+//   1. THE STREAMING GATE COULD NEVER PASS. replicationHealthGate keyed on
+//      `status.replicationHealthy`, a spelling with ZERO producers (grep over
+//      core/controllers/continuum + core/pkg/apis returns nothing; all 8 live
+//      Continuums on hw292 omit it). So every real CR got Warn "unverified" —
+//      a gate that structurally cannot pass — and since #5508 the console reads
+//      that Warn as "the lag is not a measurement" and prints "—".
+//
+//   2. THE STANDBY LEG WAS PERMANENTLY "UNVERIFIABLE" ON A 2-REGION SOVEREIGN.
+//      This handler's dynamic client is scoped to the REGION-A cluster; the
+//      replica half of a pair is a cnpg Cluster in REGION B. Measured on hw292
+//      2026-08-10: `kubectl -n shared-data get clusters.postgresql.cnpg.io`
+//      returns ONLY `openova.io/cnpg-role=primary` halves, so
+//      cnpgPairStandbyForContinuum finds no replica and findCNPGPairForApp
+//      requires both halves — leaving the standby-available gate on Warn
+//      forever, and `standbyAvailable` omitted, which makes the console's
+//      #4923/#4901 red "Standby absent" banner UNREACHABLE.
+//
+//   3. PHASE + LEASE HOLDER WERE READ AND THEN DROPPED. enrichReplicationStatus
+//      already reads status.leaseHolder (to correct CurrentPrimary) but never
+//      put it, or status.phase, on the wire — so row 62's "live Continuum
+//      status (Ready / lease holder / standby)" clause had no data to render.
+//
+// Every assertion below is on the VALUE, and each fix carries a CONTROL that
+// must move the other way, so none of these gates can pass vacuously.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// fetchReplicationStatusRaw decodes the response into a generic map so the
+// assertions pin the WIRE KEY NAMES the console consumes, not just Go struct
+// fields (a wrong json tag would sail through a typed decode).
+func fetchReplicationStatusRaw(t *testing.T, h *Handler, depID, name, ns string) map[string]interface{} {
+	t.Helper()
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+depID+"/continuum/"+name+"/replication-status?namespace="+ns, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+// gateByName lives in continuum_dr_extras_4923_test.go — reused here.
+
+// setCnpgPairRef stamps spec.cnpgPair so cnpgPairStandbyForContinuum is the
+// path exercised (the live dr-shared-pg shape).
+func setCnpgPairRef(cr *unstructured.Unstructured, name, ns string) {
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"name":      name,
+		"namespace": ns,
+	}, "spec", "cnpgPair")
+}
+
+// ── Row 71: the streaming-replication gate must be able to PASS ──────────
+
+// The hw292 dr-shared-pg shape with BOTH cnpg halves visible: phase=Healthy,
+// standbyAvailable=true, lag 0. The streaming-replication gate must read Pass.
+// Before the fix it read Warn "replication health not reported ... unverified"
+// because the only key consulted (status.replicationHealthy) has no producer.
+func TestReplicationStatus_Row71_StreamingGatePassesOnControllerStandbyProbe(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	setContinuumControllerStatus(cr, "Healthy", true, 0)
+	primary, replica := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row71-streaming-pass")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+	g := gateByName(t, resp, "streaming-replication")
+	if g.Status != "Pass" {
+		t.Fatalf("streaming-replication gate: got %q (%q), want Pass — the gate keyed on a status field with no producer, so it could never pass on a live CR", g.Status, g.Message)
+	}
+}
+
+// CONTROL for the above: the gate must still FAIL on a negative standby probe
+// and still WARN when the CR reports neither key. Without these the Pass above
+// would prove only that the gate was hardwired open.
+func TestReplicationStatus_Row71_StreamingGateControls(t *testing.T) {
+	t.Run("standby probe false -> Fail", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		cr := newContinuumUnstructured(
+			"dr-shared-pg", "shared-data", "shared-pg",
+			"me-east-215-a", []string{"me-east-215-b"})
+		setContinuumControllerStatus(cr, "Healthy", false, 0)
+		primary, replica := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+		factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+		h.dynamicFactory = factory
+		dep := installUserAccessDeployment(t, h, "dep-row71-streaming-fail")
+
+		resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+		if g := gateByName(t, resp, "streaming-replication"); g.Status != "Fail" {
+			t.Fatalf("streaming-replication gate on a false standby probe: got %q want Fail", g.Status)
+		}
+	})
+
+	t.Run("no evidence at all -> Warn, never Pass", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		cr := newContinuumUnstructured(
+			"dr-spine-openbao", "catalyst", "spine-openbao",
+			"me-east-215-a", nil)
+		// Deliberately NO standbyAvailable / replicationHealthy — the raft
+		// spine shape. phase stays the fixture's Healthy.
+		factory, _ := fakeContinuumDynamicFactory(cr)
+		h.dynamicFactory = factory
+		dep := installUserAccessDeployment(t, h, "dep-row71-streaming-warn")
+
+		resp := fetchReplicationStatus(t, h, dep.ID, "dr-spine-openbao", "catalyst")
+		if g := gateByName(t, resp, "streaming-replication"); g.Status != "Warn" {
+			t.Fatalf("streaming-replication gate with no evidence: got %q want Warn (a Pass here would be a fabricated health claim)", g.Status)
+		}
+	})
+}
+
+// ── Row 62: the per-region split must not report "unverifiable" ──────────
+
+// The live hw292 shape: dr-shared-pg carries spec.cnpgPair and the controller's
+// standby probe says the leg is available, but ONLY the primary half is visible
+// from this region's cluster (the replica Cluster CR lives in region B). The
+// endpoint must relay the probe verdict instead of reporting unknown.
+func TestReplicationStatus_Row62_PerRegionSplitRelaysStandbyProbe(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	setContinuumControllerStatus(cr, "Healthy", true, 0)
+	setCnpgPairRef(cr, "shared-pg", "shared-data")
+	// ONLY the primary half — the region-B replica is invisible from here.
+	primary, _ := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row62-split-available")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+	if resp.StandbyAvailable == nil {
+		t.Fatalf("standbyAvailable omitted: the replica half is not visible from region A, so the endpoint reported unknown and the console's tri-state read has nothing to consume")
+	}
+	if !*resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got false want true (the controller's probe says the leg is available)")
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Pass" {
+		t.Fatalf("standby-available gate: got %q (%q), want Pass", g.Status, g.Message)
+	}
+}
+
+// CONTROL — the same region-split, probe says the standby is GONE. This is the
+// path that makes the console's red "Standby absent" banner reachable at all:
+// standbyAvailable must be an explicit false (not omitted), the gate must Fail,
+// the stream must read interrupted and the replica must not be promotable.
+func TestReplicationStatus_Row62_PerRegionSplitSurfacesAbsentStandby(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	setContinuumControllerStatus(cr, "Healthy", false, 0)
+	setCnpgPairRef(cr, "shared-pg", "shared-data")
+	primary, _ := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row62-split-absent")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+	if resp.StandbyAvailable == nil || *resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want an explicit false — a lost standby that reports 'unknown' leaves the red banner unreachable", resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Fail" {
+		t.Fatalf("standby-available gate: got %q want Fail", g.Status)
+	}
+	if resp.StreamingState != "interrupted" {
+		t.Fatalf("streamingState: got %q want interrupted", resp.StreamingState)
+	}
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true, want false — nothing to promote when the standby leg is gone")
+	}
+}
+
+// CONTROL — honest unknown SURVIVES. A Continuum with no cnpg pair and no
+// standby probe (the dr-spine-openbao raft shape) must still report unknown,
+// never a relayed Pass. This is what stops the fix above from becoming a
+// blanket green.
+func TestReplicationStatus_Row62_NoProbeStaysUnknown(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-spine-openbao", "catalyst", "spine-openbao",
+		"me-east-215-a", nil)
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row62-unknown")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-spine-openbao", "catalyst")
+	if resp.StandbyAvailable != nil {
+		t.Fatalf("standbyAvailable: got %v want omitted (no probe, no pair — unknown is the honest answer)", *resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Warn" {
+		t.Fatalf("standby-available gate: got %q want Warn", g.Status)
+	}
+}
+
+// ── Row 62: phase + lease holder must reach the wire ─────────────────────
+
+// Row 62's clause is "shows the live Continuum status (Ready / lease holder /
+// standby) from the live API, not a static badge". The handler read leaseHolder
+// and dropped it; the console therefore had nothing to render. Assert on the
+// WIRE KEYS and on their VALUES.
+func TestReplicationStatus_Row62_EmitsPhaseAndLeaseHolder(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"hw-me-east-215-a-rtz-prod", []string{"hw-me-east-215-b-rtz-prod"})
+	setContinuumControllerStatus(cr, "Healthy", true, 0)
+	_ = unstructured.SetNestedField(cr.Object, "hw-me-east-215-a-rtz-prod", "status", "leaseHolder")
+	_ = unstructured.SetNestedField(cr.Object, "2026-08-10T05:54:58Z", "status", "leaseExpiresAt")
+	primary, replica := newCNPGPairFixture("shared-pg", "shared-data",
+		"hw-me-east-215-a-rtz-prod", "hw-me-east-215-b-rtz-prod")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row62-phase-lease")
+
+	raw := fetchReplicationStatusRaw(t, h, dep.ID, "dr-shared-pg", "shared-data")
+	for key, want := range map[string]string{
+		"phase":          "Healthy",
+		"leaseHolder":    "hw-me-east-215-a-rtz-prod",
+		"leaseExpiresAt": "2026-08-10T05:54:58Z",
+	} {
+		got, ok := raw[key]
+		if !ok {
+			t.Fatalf("wire key %q absent — the console cannot render the live Continuum status it does not receive", key)
+		}
+		if got != want {
+			t.Fatalf("wire key %q: got %v want %q", key, got, want)
+		}
+	}
+}
+
+// CONTROL — a CR that reports no lease holder must NOT get a fabricated one.
+// `omitempty` means the key is simply absent, which is what lets the console
+// distinguish "no lease observed" from a lease it can name.
+func TestReplicationStatus_Row62_NoLeaseHolderIsOmittedNotInvented(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	// Blank the fixture's leaseHolder — the CR observes none.
+	_ = unstructured.SetNestedField(cr.Object, "", "status", "leaseHolder")
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row62-no-lease")
+
+	raw := fetchReplicationStatusRaw(t, h, dep.ID, "dr-shared-pg", "shared-data")
+	if v, ok := raw["leaseHolder"]; ok {
+		t.Fatalf("leaseHolder present as %v on a CR that reports none — that is an invented lease", v)
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -257,6 +257,18 @@ export interface ContinuumReplicationStatus {
    * undefined — unverifiable (no cnpg pair resolvable) — unknown, not green.
    */
   standbyAvailable?: boolean
+  /**
+   * The Continuum CR's OWN reconciled status, relayed by the endpoint (UAT
+   * row 62). `phase` is the controller's reconciled verdict (Healthy /
+   * Degraded / FailedOver / …), `leaseHolder` is the region currently holding
+   * the DNS-witness lease and `leaseExpiresAt` its rolling expiry — the three
+   * facts that make the DR panel a live reading rather than a static badge.
+   * All three are `omitempty` server-side: absent means the CR does not report
+   * it, and the panel must render nothing rather than invent a value.
+   */
+  phase?: string
+  leaseHolder?: string
+  leaseExpiresAt?: string
   healthGates?: ContinuumHealthGate[]
   replicas?: ContinuumReplicaInfo[]
   observedAt?: string

--- a/products/catalyst/bootstrap/ui/src/pages/orphaned-page-components.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/orphaned-page-components.test.ts
@@ -123,7 +123,7 @@ const isTestFile = (p: string) => /\.(test|spec)\.[tj]sx?$/.test(p)
  * through unnoticed, while a false positive means someone chases a component
  * that is perfectly fine.
  */
-function referencesComponent(src: string, name: string): boolean {
+function componentMatchers(name: string): RegExp[] {
   const n = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   return [
     new RegExp(`\\b(?:import|export)\\b[^\\n;]*\\b${n}\\b`),  // import/export specifier
@@ -131,7 +131,33 @@ function referencesComponent(src: string, name: string): boolean {
     new RegExp(`<\\s*${n}[\\s/>]`),                                // JSX usage
     new RegExp(`\\b${n}\\s*\\(`),                                // call
     new RegExp(`[:=]\\s*${n}\\b`),                                 // type / assignment position
-  ].some((re) => re.test(src))
+  ]
+}
+
+/**
+ * referencesComponent — the SAME five shapes, with the compiled matchers passed
+ * in and a literal-substring pre-filter in front.
+ *
+ * WHY THIS SHAPE. The pair space is |pages| x |sources| — 176 x 373 = ~65,600
+ * today — and the previous form rebuilt all five RegExp objects on every single
+ * pair (~328,000 constructions) before testing them against whole file texts.
+ * That put the walk at ~3.2s locally against vitest's 5s per-test timeout, and
+ * it went red on a loaded CI runner: twice on this PR, and identically on main
+ * (run 31335661070, 2026-08-09) BEFORE this PR existed. The file's own comment
+ * above already names the failure mode — "a guard that goes red because it is
+ * slow is indistinguishable, from CI's side, from one that found something" —
+ * so this is that same lesson applied one level further in.
+ *
+ * SEMANTICS ARE UNCHANGED, and the pre-filter is sound rather than a heuristic:
+ * all five patterns embed `name` literally, so a file that does not contain the
+ * raw substring cannot match any of them. `includes` therefore only skips pairs
+ * every regex would have rejected. Nothing is loosened — a component that is
+ * genuinely orphaned still reports as one, which the KNOWN_ORPHANS assertions
+ * below verify in both directions.
+ */
+function referencesComponent(src: string, name: string, matchers: RegExp[]): boolean {
+  if (!src.includes(name)) return false
+  return matchers.some((re) => re.test(src))
 }
 
 describe('#5831 — page components must be reachable from something other than their own test', () => {
@@ -146,8 +172,14 @@ describe('#5831 — page components must be reachable from something other than 
     text: readFileSync(file, 'utf8'),
   }))
 
-  const referencedElsewhere = (page: string, name: string): string[] =>
-    sources.filter((s) => s.file !== page && referencesComponent(s.text, name)).map((s) => s.file)
+  // Compile each component's five matchers ONCE per name, not once per
+  // (page, source) pair — see referencesComponent for why that mattered.
+  const referencedElsewhere = (page: string, name: string): string[] => {
+    const matchers = componentMatchers(name)
+    return sources
+      .filter((s) => s.file !== page && referencesComponent(s.text, name, matchers))
+      .map((s) => s.file)
+  }
 
   // Vacuity control FIRST. Every assertion below is "X is referenced by some
   // file in this set". If the walk returned nothing, every component would look

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr-honesty.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr-honesty.test.tsx
@@ -1,0 +1,406 @@
+/**
+ * TopologyTab.dr-honesty.test.tsx — UAT rows 62 + 63 + 71 regression locks.
+ *
+ * Row 62 ("the Topology DR section shows the live Continuum status (Ready /
+ * lease holder / standby) from the live API, not a static badge") failed on
+ * three separate legs, each measured on hw292:
+ *
+ *   62a — the standby card's health line was
+ *         `drStatus?.streamingState || 'hot replica (follows WAL)'` against a
+ *         backend that returns `streamingState: ""` for every CR-derived
+ *         reading. So it printed a green claim UNCONDITIONALLY, including over
+ *         a standby the same payload had just declared unverifiable. A static
+ *         badge, in a row whose clause forbids one.
+ *   62b — no phase and no lease holder rendered anywhere.
+ *   62c — `standbyAbsent` keyed ONLY on `standbyAvailable === false`, a field
+ *         the backend omits whenever the leg is undetermined, while it always
+ *         publishes a `standby-available` health gate. A payload whose own gate
+ *         read Fail rendered NO red banner.
+ *
+ * Row 63 ("...the control DISABLED...") could not be verified because NO
+ * switchover element rendered on an unbacked app at all — absent is not
+ * disabled.
+ *
+ * Row 71 is the backend half (the streaming gate could never Pass); its lock
+ * lives in continuum_dr_extras_row62_71_test.go. What is asserted HERE is the
+ * consumer contract that made that backend Warn visible: a live reading with
+ * passing gates must render a NUMBER, not "—".
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getApplicationPlacement = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+const getContinuumReplicationStatus = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+  getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
+}))
+
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+  }
+})
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+vi.mock('@/widgets/topology/PlacementEditor', () => ({
+  PlacementEditor: () => <div data-testid="stub-placement-editor" />,
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+/** An Application declaring active-hot-standby across two regions. */
+const AHS_APP = {
+  name: 'shared-pg',
+  namespace: 'shared-data',
+  spec: {
+    placement: {
+      targets: [
+        { region: 'hw-me-east-215-a-rtz-prod', cluster: 'hw-me-east-215-a-rtz-prod', role: 'Primary' },
+        {
+          region: 'hw-me-east-215-b-rtz-prod',
+          cluster: 'hw-me-east-215-b-rtz-prod',
+          role: 'Standby',
+          standbyType: 'Hot',
+        },
+      ],
+    },
+  },
+  status: { placementRecon: 'Reconciled' },
+}
+
+function renderTab() {
+  return render(
+    withProviders(
+      <TopologyTab
+        sovereignId="dep-hw292"
+        applicationName="shared-pg"
+        namespace="shared-data"
+        initialApp={AHS_APP as never}
+      />,
+    ),
+  )
+}
+
+beforeEach(() => {
+  getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+  getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('row 62c — the standby-absent banner must be reachable from the gate', () => {
+  it('renders the red Standby absent banner on a standby-available gate that reads Fail', async () => {
+    // The payload shape the backend emits when the controller's standby probe
+    // reports the leg is GONE but the tri-state bool did not survive to this
+    // consumer's read. The gate IS the verdict; it must arm the banner.
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0,
+      streamingState: '',
+      source: 'live',
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [
+        {
+          name: 'standby-available',
+          status: 'Fail',
+          severity: 'critical',
+          message: 'required hot-standby is unreachable',
+        },
+      ],
+    })
+
+    renderTab()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-standby-absent')).toBeTruthy()
+    })
+    // ...and the lag must NOT print a zero next to it.
+    expect(screen.getByTestId('topology-tab-dr-lag-value').textContent).toContain('—')
+  })
+
+  it('CONTROL — a standby-available gate that PASSES renders no absent banner', async () => {
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0,
+      streamingState: 'streaming',
+      source: 'live',
+      standbyAvailable: true,
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [
+        { name: 'standby-available', status: 'Pass', severity: 'info' },
+        { name: 'streaming-replication', status: 'Pass', severity: 'info' },
+        { name: 'wal-lag-under-rpo', status: 'Pass', severity: 'info' },
+      ],
+    })
+
+    renderTab()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-regions')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('topology-tab-dr-standby-absent')).toBeNull()
+  })
+})
+
+describe('row 62a — the standby health line is never a hardcoded green claim', () => {
+  it('does not print "hot replica (follows WAL)" when the API reports no streaming state and the gate is unverified', async () => {
+    // The EXACT hw292 payload: source live, streamingState "", standby leg
+    // reported unverifiable. The old code printed the green claim anyway.
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0,
+      streamingState: '',
+      source: 'live',
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [
+        {
+          name: 'standby-available',
+          status: 'Warn',
+          severity: 'warning',
+          message: 'standby leg not verifiable from live cluster state',
+        },
+      ],
+    })
+
+    renderTab()
+
+    const line = await screen.findByTestId(
+      'topology-tab-dr-standby-hw-me-east-215-b-rtz-prod-health',
+    )
+    expect(line.textContent).not.toContain('hot replica')
+    expect(line.textContent).toContain('not verified')
+  })
+
+  it('CONTROL — a real streaming state from the API is rendered verbatim', async () => {
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0,
+      streamingState: 'streaming',
+      source: 'live',
+      standbyAvailable: true,
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [{ name: 'standby-available', status: 'Pass', severity: 'info' }],
+    })
+
+    renderTab()
+
+    const line = await screen.findByTestId(
+      'topology-tab-dr-standby-hw-me-east-215-b-rtz-prod-health',
+    )
+    expect(line.textContent).toContain('streaming')
+  })
+})
+
+describe('row 62b — the live Continuum status (phase + lease holder) renders', () => {
+  it('renders the reconciled phase and the witness-lease holder from the API', async () => {
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0,
+      streamingState: 'streaming',
+      source: 'live',
+      standbyAvailable: true,
+      phase: 'Healthy',
+      leaseHolder: 'hw-me-east-215-a-rtz-prod',
+      leaseExpiresAt: '2026-08-10T05:54:58Z',
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [{ name: 'standby-available', status: 'Pass', severity: 'info' }],
+    })
+
+    renderTab()
+
+    expect((await screen.findByTestId('topology-tab-dr-phase')).textContent).toContain('Healthy')
+    expect(screen.getByTestId('topology-tab-dr-lease-holder').textContent).toBe(
+      'hw-me-east-215-a-rtz-prod',
+    )
+    expect(screen.getByTestId('topology-tab-dr-lease-expires').textContent).toContain(
+      '2026-08-10T05:54:58Z',
+    )
+  })
+
+  it('CONTROL — an API that reports no phase/lease renders no status strip (never an invented Healthy)', async () => {
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0,
+      streamingState: 'streaming',
+      source: 'live',
+      standbyAvailable: true,
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [{ name: 'standby-available', status: 'Pass', severity: 'info' }],
+    })
+
+    renderTab()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-regions')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('topology-tab-dr-continuum-status')).toBeNull()
+  })
+})
+
+describe('row 71 — a fully-verified live reading renders a lag NUMBER', () => {
+  it('prints the numeric lag when every health gate passes', async () => {
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0.2,
+      streamingState: 'streaming',
+      syncState: 'sync',
+      source: 'live',
+      standbyAvailable: true,
+      phase: 'Healthy',
+      leaseHolder: 'hw-me-east-215-a-rtz-prod',
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [
+        { name: 'streaming-replication', status: 'Pass', severity: 'info' },
+        { name: 'wal-lag-under-rpo', status: 'Pass', severity: 'info' },
+        { name: 'standby-available', status: 'Pass', severity: 'info' },
+      ],
+    })
+
+    renderTab()
+
+    const lag = await screen.findByTestId('topology-tab-dr-lag-value')
+    expect(lag.textContent).toContain('0.2 s')
+  })
+
+  it('CONTROL — the SAME lag renders "—" while the gates say unverified', async () => {
+    // This is what hw292 actually served before the backend fix: a real 0.2s
+    // reading behind a streaming-replication gate that could never Pass.
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0.2,
+      streamingState: '',
+      source: 'live',
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [
+        {
+          name: 'streaming-replication',
+          status: 'Warn',
+          severity: 'warning',
+          message: 'replication health not reported by the Continuum CR; unverified',
+        },
+      ],
+    })
+
+    renderTab()
+
+    const lag = await screen.findByTestId('topology-tab-dr-lag-value')
+    expect(lag.textContent).toContain('—')
+  })
+})
+
+describe('row 63 — an active-hot-standby app with NO Continuum backing', () => {
+  const UNBACKED = {
+    continuum: 'dr-uat-ahs-pg',
+    namespace: 'hw292-omani-works',
+    primaryRegion: 'hw-me-east-215-a-rtz-prod',
+    currentPrimary: 'hw-me-east-215-a-rtz-prod',
+    walLagSeconds: 0,
+    replicaPromotable: false,
+    streamingState: '',
+    syncState: '',
+    source: 'pending',
+    replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+    healthGates: [{ name: 'live-status', status: 'Warn', severity: 'info' }],
+  }
+
+  it('renders the switchover control DISABLED with "Switchover unavailable" copy', async () => {
+    getContinuumReplicationStatus.mockResolvedValue(UNBACKED)
+
+    renderTab()
+
+    const btn = (await screen.findByTestId(
+      'topology-tab-dr-switchover-open',
+    )) as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(screen.getByTestId('topology-tab-dr-switchover-reason').textContent).toContain(
+      'Switchover unavailable',
+    )
+  })
+
+  it('and still synthesizes NO lag, standby or target-region values', async () => {
+    getContinuumReplicationStatus.mockResolvedValue(UNBACKED)
+
+    renderTab()
+
+    // Wait for the SETTLED no-backing state (the reason line only renders once
+    // the poll resolves), not merely for the panel to mount.
+    await screen.findByTestId('topology-tab-dr-switchover-reason')
+    expect(screen.getByTestId('topology-tab-dr-none')).toBeTruthy()
+    // No numeric lag row, no standby card, no armed target region.
+    expect(screen.queryByTestId('topology-tab-dr-lag-value')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-regions')).toBeNull()
+    expect(screen.getByTestId('topology-tab-dr-switchover-reason').textContent).not.toContain(
+      'promote standby',
+    )
+  })
+
+  it('CONTROL — a BACKED app arms the same control, so "disabled" above is chosen by the backing, not printed unconditionally', async () => {
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'hw-me-east-215-a-rtz-prod',
+      currentPrimary: 'hw-me-east-215-a-rtz-prod',
+      walLagSeconds: 0,
+      replicaPromotable: true,
+      streamingState: 'streaming',
+      source: 'live',
+      standbyAvailable: true,
+      replicas: [{ region: 'hw-me-east-215-b-rtz-prod', role: 'replica' }],
+      healthGates: [{ name: 'standby-available', status: 'Pass', severity: 'info' }],
+    })
+
+    renderTab()
+
+    const btn = (await screen.findByTestId(
+      'topology-tab-dr-switchover-open',
+    )) as HTMLButtonElement
+    expect(btn.disabled).toBe(false)
+    expect(screen.getByTestId('topology-tab-dr-switchover-reason').textContent).toContain(
+      'promote standby',
+    )
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -745,9 +745,28 @@ describe('TopologyTab — #4886 bootstrap-HR DR off the live Continuum CR', () =
     expect(screen.queryByTestId('topology-tab-dr-standby')).toBeNull()
     expect(screen.queryByTestId('topology-tab-dr-standby-me-east-215-b')).toBeNull()
     expect(document.body.textContent).not.toContain('hot replica (follows WAL)')
-    // 3. NO switchover control armed against a region with no namespace.
-    expect(screen.queryByTestId('topology-tab-dr-switchover-open')).toBeNull()
+    // 3. NO switchover control ARMED against a region with no namespace.
+    //
+    // UAT row 63 tightened this clause. #5514 asserted the control was ABSENT,
+    // which was the cheapest way to guarantee it could not arm — but "absent"
+    // and "disabled" are different statements to an operator, and the row's
+    // own wording is "'Switchover unavailable' copy, the control DISABLED".
+    // The 2026-08-10 walk could not verify that sub-clause at all because no
+    // switchover element existed on the page to inspect. So the control now
+    // RENDERS here, permanently disabled, with honest copy — which is strictly
+    // stronger than absence: it still cannot arm (it has no onClick and no
+    // target region), and it now also tells the operator why.
+    const unbackedSwitchover = screen.getByTestId(
+      'topology-tab-dr-switchover-open',
+    ) as HTMLButtonElement
+    expect(unbackedSwitchover.disabled).toBe(true)
+    expect(screen.getByTestId('topology-tab-dr-switchover-reason').textContent).toContain(
+      'Switchover unavailable',
+    )
+    // The dialog is what "armed" would mean, and it must still be unreachable.
     expect(screen.queryByTestId('continuum-switchover-dialog')).toBeNull()
+    // No target region is named anywhere — the phantom must not be printed.
+    expect(document.body.textContent).not.toContain('promote standby')
   })
 
   it('#5514: an explicit replicaPromotable:false on a LIVE reading DISABLES the switchover (the verdict is consulted)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -42,6 +42,7 @@ import {
   type Capability,
   type PlacementTarget,
   type ReconStatus,
+  HOST_VCLUSTER,
   PATTERN_NOT_REPORTED,
   derivePattern,
   describePattern,
@@ -304,7 +305,19 @@ export function TopologyTab({
           return {
             region: cluster,
             cluster,
-            vcluster: 'mgmt',
+            // #5945 — this used to stamp `vcluster: 'mgmt'` on EVERY
+            // per-cluster-derived target. #4325 deleted bp-mgmt-vcluster (and
+            // the dmz/rtz siblings), so no post-#4325 Sovereign has an `mgmt`
+            // namespace — the 45-namespace census on hw292 shows zero, and the
+            // only vClusters are per-Org. The value was pure fabrication:
+            // `status.perCluster` reports a CLUSTER, never a vCluster.
+            // It was also load-bearing downstream, which is how #5945 was
+            // measured: these targets seed the PlacementEditor, whose
+            // `optionsForTarget` re-admits whatever the current target names —
+            // so the fabricated 'mgmt' both PRESELECTED a retired vCluster and
+            // put it back in the select that #5616 had already narrowed to
+            // ['host']. Report no vCluster instead; `host` is the renderer's
+            // honest default and the one tier the controller can always resolve.
             role: isPrimary ? ('Primary' as const) : ('Standby' as const),
             ...(isPrimary ? {} : { standbyType: 'Hot' as const }),
           } as PlacementTarget
@@ -524,7 +537,36 @@ export function TopologyTab({
   // unreachable (region-kill / outage) and MUST render as a fault — never as
   // a calm "hot replica (follows WAL)" card. undefined = unverifiable
   // (unknown), which renders the normal card without a false health claim.
-  const standbyAbsent = drStatus?.standbyAvailable === false
+  //
+  // UAT row 62 — READ WHAT THE BACKEND ACTUALLY EMITS. The tri-state bool is
+  // `omitempty`, so it is ABSENT from the payload whenever the standby leg is
+  // undetermined, and it is not the only place the verdict is published: the
+  // same backend upserts a `standby-available` health gate on EVERY branch
+  // (Pass / Warn / Fail). Keying the red banner on the bool alone meant a
+  // response whose own gate said Fail rendered no banner at all. A Fail gate is
+  // a VERIFIED fault by construction (the backend never emits Fail without
+  // positive evidence of a lost leg), so it must arm the banner too.
+  const standbyGate = useMemo(
+    () => healthGates.find((g) => g.name === 'standby-available'),
+    [healthGates],
+  )
+  const standbyGateStatus = (standbyGate?.status ?? '').toLowerCase()
+  const standbyAbsent = drStatus?.standbyAvailable === false || standbyGateStatus === 'fail'
+
+  // The standby card's health line. Row 62's clause is "not a static badge",
+  // and this line was `drStatus?.streamingState || 'hot replica (follows WAL)'`
+  // against a backend that returns `streamingState: ""` for every
+  // Continuum-CR-derived reading — so in practice it was a HARDCODED green
+  // claim, printed unchanged over a standby the API had just declared
+  // unverifiable. Derive it from the evidence instead, and never assert
+  // "follows WAL" without a reading that says so.
+  const standbyHealthLine = useMemo(() => {
+    if (standbyAbsent) return 'standby unreachable — replication interrupted'
+    if (drStatus?.streamingState) return drStatus.streamingState
+    if (standbyGateStatus === 'pass') return 'standby leg verified reachable'
+    if (standbyGateStatus === 'warn') return 'standby state not verified'
+    return 'standby state not reported'
+  }, [standbyAbsent, drStatus, standbyGateStatus])
 
   // The switchover target — the standby region we would promote. Prefer the
   // placement Standby target, fall back to the live continuum standby region.
@@ -625,6 +667,35 @@ export function TopologyTab({
     return Array.from(set).filter(Boolean).sort()
   }, [targets, infraQ.data])
 
+  // #5945 — the vCluster options the placement editor may offer, derived from
+  // the OBSERVED topology instead of a hardcoded tier vocabulary. Each live
+  // vCluster is identified by its HOST NAMESPACE (`VClusterSpec.namespace`,
+  // the real placement identity per #5616 — the per-Org vCluster is *named*
+  // "vcluster" but *runs* in the Org namespace, so the display name is not
+  // addressable). `host` is always offered: it is the one tier the
+  // application-controller resolves without a dedicated namespace.
+  //
+  // Before this, TopologyTab passed NO vCluster list at all, so the editor fell
+  // back to ['host'] and the only other entry it ever showed was whatever the
+  // current target named — which the perCluster projection above hardcoded to
+  // the #4325-deleted `mgmt`. Net effect measured on hw292: the select offered
+  // retired tiers, preselected one of them, and the per-Org vClusters that DO
+  // exist were not offered at all.
+  const availableVClusters = useMemo(() => {
+    const set = new Set<string>([HOST_VCLUSTER])
+    for (const r of infraQ.data?.topology?.regions ?? []) {
+      const clusters = (r as unknown as { clusters?: Array<{ vclusters?: Array<{ namespace?: string }> }> })
+        .clusters ?? []
+      for (const c of clusters) {
+        for (const vc of c.vclusters ?? []) {
+          const ns = (vc.namespace ?? '').trim()
+          if (ns) set.add(ns)
+        }
+      }
+    }
+    return Array.from(set)
+  }, [infraQ.data])
+
   const availableClusters = useMemo(() => {
     const set = new Set<string>(targets.map((t) => t.cluster))
     for (const r of infraQ.data?.topology?.regions ?? []) {
@@ -708,7 +779,10 @@ export function TopologyTab({
                       data-testid={`topology-tab-target-card-${i}`}
                     >
                       <div className="font-mono text-[11px] text-[var(--color-text-dim)]">
-                        {t.region} · {t.cluster} · {t.vcluster ?? 'mgmt'}
+                        {/* #5945 — the fallback was `mgmt`, a vCluster #4325
+                            deleted, so a target that named no vCluster was
+                            DISPLAYED as living in one that cannot exist. */}
+                        {t.region} · {t.cluster} · {t.vcluster || HOST_VCLUSTER}
                       </div>
                       <div
                         className={`mt-1 text-xs font-semibold ${
@@ -775,6 +849,7 @@ export function TopologyTab({
             capability={capability}
             availableRegions={availableRegions}
             availableClusters={availableClusters}
+            availableVClusters={availableVClusters}
             ownedDependencies={ownedDeps}
             disableNetwork={disableNetwork}
             onCancel={() => setEditing(false)}
@@ -846,9 +921,93 @@ export function TopologyTab({
                   stay unavailable until a real replica reports.
                 </p>
               ) : null}
+              {/* UAT row 63 — the switchover control must render DISABLED here,
+                  not vanish. The clause is "renders an honest no-backing DR
+                  section: 'Switchover unavailable' copy, the control DISABLED,
+                  and NO synthesized lag / standby / target-region values", and
+                  the 2026-08-10 walk could not verify the middle clause because
+                  NO switchover element existed on the page at all — an absent
+                  control and a disabled one are not the same statement, and only
+                  the second one tells the operator that switchover is a thing
+                  this app has and cannot currently do.
+                  It is rendered inside the !drBacked branch precisely so it can
+                  never arm: there is no `onClick`, no target region and no
+                  numeric value anywhere in it — the row's third clause holds by
+                  construction. */}
+              {!drQ.isLoading ? (
+                <div
+                  className="mt-3 flex items-center gap-2"
+                  data-testid="topology-tab-dr-switchover"
+                >
+                  <button
+                    type="button"
+                    className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled
+                    data-testid="topology-tab-dr-switchover-open"
+                  >
+                    Switch over…
+                  </button>
+                  <span
+                    className="text-[10px] text-[var(--color-text-dim)]"
+                    data-testid="topology-tab-dr-switchover-reason"
+                  >
+                    Switchover unavailable — no live Continuum backs this
+                    placement, so there is no standby to promote.
+                  </span>
+                </div>
+              ) : null}
             </div>
           ) : (
             <>
+              {/* UAT row 62 — the LIVE Continuum status: reconciled phase +
+                  which region holds the witness lease + when that lease
+                  expires. The clause is "the live Continuum status (Ready /
+                  lease holder / standby) from the live API, not a static
+                  badge"; the panel previously rendered none of it, because the
+                  replication-status endpoint read `status.leaseHolder`
+                  internally and never put it (or `status.phase`) on the wire.
+                  Each cell renders ONLY when the API reports it — an absent
+                  phase prints nothing rather than a green-looking default. */}
+              {drStatus?.phase || drStatus?.leaseHolder ? (
+                <div
+                  className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs"
+                  data-testid="topology-tab-dr-continuum-status"
+                >
+                  {drStatus?.phase ? (
+                    <span
+                      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-semibold ${
+                        drStatus.phase === 'Healthy'
+                          ? 'bg-green-500/10 text-green-400'
+                          : drStatus.phase === 'Degraded' || drStatus.phase === 'Failed'
+                            ? 'bg-red-500/10 text-red-400'
+                            : 'bg-yellow-500/10 text-yellow-400'
+                      }`}
+                      data-testid="topology-tab-dr-phase"
+                      title="The Continuum CR's reconciled phase, read live off the DR API."
+                    >
+                      ● {drStatus.phase}
+                    </span>
+                  ) : null}
+                  {drStatus?.leaseHolder ? (
+                    <span className="text-[var(--color-text-dim)]">
+                      lease held by{' '}
+                      <span
+                        className="font-mono text-[var(--color-text)]"
+                        data-testid="topology-tab-dr-lease-holder"
+                      >
+                        {drStatus.leaseHolder}
+                      </span>
+                      {drStatus?.leaseExpiresAt ? (
+                        <span data-testid="topology-tab-dr-lease-expires">
+                          {' '}
+                          · renews {drStatus.leaseExpiresAt}
+                        </span>
+                      ) : null}
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
+
               <div
                 className="flex flex-wrap items-stretch gap-2"
                 data-testid="topology-tab-dr-regions"
@@ -888,12 +1047,9 @@ export function TopologyTab({
                       </div>
                       <div
                         className={`text-[10px] ${standbyAbsent ? 'text-red-400' : 'text-[var(--color-text-dim)]'}`}
+                        data-testid={`topology-tab-dr-standby-${region}-health`}
                       >
-                        {standbyAbsent
-                          ? 'standby unreachable — replication interrupted'
-                          : drStatus?.streamingState
-                            ? drStatus.streamingState
-                            : 'hot replica (follows WAL)'}
+                        {standbyHealthLine}
                       </div>
                     </div>
                   ))
@@ -920,10 +1076,9 @@ export function TopologyTab({
                     </div>
                     <div
                       className={`text-[10px] ${standbyAbsent ? 'text-red-400' : 'text-[var(--color-text-dim)]'}`}
+                      data-testid="topology-tab-dr-standby-health"
                     >
-                      {standbyAbsent
-                        ? 'standby unreachable — replication interrupted'
-                        : drStatus?.streamingState || 'hot replica (follows WAL)'}
+                      {standbyHealthLine}
                     </div>
                   </div>
                 )}
@@ -1029,7 +1184,10 @@ export function TopologyTab({
                 >
                   Switch over…
                 </button>
-                <span className="text-[10px] text-[var(--color-text-dim)]">
+                <span
+                  className="text-[10px] text-[var(--color-text-dim)]"
+                  data-testid="topology-tab-dr-switchover-reason"
+                >
                   {switchoverArmed
                     ? `promote standby ${switchoverTarget} — runs an RPO/health preflight before you confirm`
                     : switchoverBlockedReason}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.vcluster-vocabulary-5945.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.vcluster-vocabulary-5945.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * TopologyTab.vcluster-vocabulary-5945.test.tsx — #5945 regression lock.
+ *
+ * MEASURED (hw292, 2026-08-10, `/app/uatco-agenity` → Topology → Edit
+ * placement): the vCluster select offered `host | mgmt | dmz | rtz` with
+ * **mgmt preselected**. #4325 deleted bp-mgmt-vcluster / bp-dmz-vcluster /
+ * bp-rtz-vcluster, so no post-#4325 Sovereign has any of those namespaces —
+ * the 45-namespace census shows zero, and the only vClusters are per-Org.
+ * Choosing one writes a placement targeting a vCluster that cannot exist, and
+ * the per-Org vClusters that DO exist were not offered at all.
+ *
+ * THE MECHANISM, which is why the fix is here and not in the editor. #5616
+ * already narrowed PlacementEditor's own default to ['host']. But:
+ *   1. TopologyTab's `status.perCluster` projection hardcoded `vcluster:
+ *      'mgmt'` on every derived target — `perCluster` reports a CLUSTER and
+ *      carries no vCluster at all, so that value was invented; and
+ *   2. the editor deliberately re-admits whatever the current target names
+ *      (so an existing placement is never silently rewritten), which turned
+ *      the invented 'mgmt' back into a selectable option AND the select's
+ *      current value; and
+ *   3. TopologyTab passed no `availableVClusters`, so the real per-Org
+ *      vClusters in the live topology were never offered.
+ *
+ * Same dead-vocabulary class as #5932/#5937 (the dashboard treemap grouping on
+ * a label only the deleted charts ever wrote). This file renders the REAL
+ * PlacementEditor — a stub could not see the select at all.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getApplicationPlacement = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+const getContinuumReplicationStatus = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+  getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
+  updateApplication: vi.fn(),
+}))
+
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+  }
+})
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+/**
+ * The live hw292 topology: ONE per-Org vCluster, named "vcluster" but running
+ * in the Org's own host namespace (`uatco`). No mgmt/dmz/rtz namespace exists.
+ */
+const LIVE_TOPOLOGY = {
+  topology: {
+    regions: [
+      {
+        id: 'r-a',
+        name: 'hw-me-east-215-a-rtz-prod',
+        clusters: [
+          {
+            id: 'c-a',
+            name: 'hw-me-east-215-a-rtz-prod',
+            vclusters: [{ id: 'vc-1', name: 'vcluster', namespace: 'uatco' }],
+          },
+        ],
+      },
+    ],
+  },
+}
+
+/**
+ * An Application whose ONLY placement signal is `status.perCluster` — the
+ * projection that used to stamp the invented `mgmt`. This is the shape
+ * #5945 was measured on.
+ */
+const PER_CLUSTER_APP = {
+  name: 'uatco-agenity',
+  namespace: 'uatco',
+  spec: {},
+  status: {
+    placementRecon: 'Reconciled',
+    perCluster: [{ cluster: 'hw-me-east-215-a-rtz-prod', role: 'primary' }],
+  },
+}
+
+async function openEditor() {
+  render(
+    withProviders(
+      <TopologyTab
+        sovereignId="dep-hw292"
+        applicationName="uatco-agenity"
+        namespace="uatco"
+        initialApp={PER_CLUSTER_APP as never}
+      />,
+    ),
+  )
+  const edit = await screen.findByTestId('topology-tab-edit-placement')
+  fireEvent.click(edit)
+  return (await screen.findByTestId('placement-editor-target-0-vcluster')) as HTMLSelectElement
+}
+
+function optionValues(select: HTMLSelectElement): string[] {
+  return Array.from(select.querySelectorAll('option')).map((o) => o.value)
+}
+
+beforeEach(() => {
+  getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+  getHierarchicalInfrastructure.mockResolvedValue(LIVE_TOPOLOGY)
+  getContinuumReplicationStatus.mockRejectedValue(new Error('HTTP 404'))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('#5945 — the placement editor offers only vClusters that exist', () => {
+  it('does not offer any of the #4325-deleted tiers', async () => {
+    const select = await openEditor()
+    const values = optionValues(select)
+    for (const dead of ['mgmt', 'dmz', 'rtz']) {
+      expect(values).not.toContain(dead)
+    }
+  })
+
+  it('does not PRESELECT a retired vCluster', async () => {
+    const select = await openEditor()
+    expect(select.value).not.toBe('mgmt')
+    expect(select.value).toBe('host')
+  })
+
+  it('offers the OBSERVED per-Org vCluster by its host namespace, plus host', async () => {
+    const select = await openEditor()
+    const values = optionValues(select)
+    // `uatco` is the host namespace of the live vCluster — the real placement
+    // identity (#5616). The display name ("vcluster") is not addressable.
+    expect(values).toContain('uatco')
+    expect(values).toContain('host')
+    expect(values).not.toContain('vcluster')
+  })
+
+  it('CONTROL — the projected target carries no invented vCluster, and the card says host', async () => {
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-hw292"
+          applicationName="uatco-agenity"
+          namespace="uatco"
+          initialApp={PER_CLUSTER_APP as never}
+        />,
+      ),
+    )
+    const card = await screen.findByTestId('topology-tab-target-card-0')
+    expect(card.textContent).not.toContain('mgmt')
+    expect(card.textContent).toContain('host')
+  })
+
+  it('CONTROL — an Application that GENUINELY declares a legacy vCluster keeps it selectable', async () => {
+    // #5616's invariant must survive: the editor may never silently rewrite a
+    // placement an operator really committed. This is what makes the three
+    // assertions above a statement about INVENTED values, not a blanket ban.
+    const declared = {
+      name: 'legacy-app',
+      namespace: 'uatco',
+      spec: {
+        placement: {
+          targets: [
+            {
+              region: 'hw-me-east-215-a-rtz-prod',
+              cluster: 'hw-me-east-215-a-rtz-prod',
+              vcluster: 'mgmt',
+              role: 'Primary',
+            },
+          ],
+        },
+      },
+      status: { placementRecon: 'Reconciled' },
+    }
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-hw292"
+          applicationName="legacy-app"
+          namespace="uatco"
+          initialApp={declared as never}
+        />,
+      ),
+    )
+    fireEvent.click(await screen.findByTestId('topology-tab-edit-placement'))
+    const select = (await screen.findByTestId(
+      'placement-editor-target-0-vcluster',
+    )) as HTMLSelectElement
+    expect(select.value).toBe('mgmt')
+    expect(optionValues(select)).toContain('mgmt')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/lib/placement.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/placement.ts
@@ -28,6 +28,19 @@ export type Pattern = 'singleton' | 'active-passive' | 'active-hot-standby' | 'a
  * The token for "no pattern could be derived" (#5515). NOT a pattern — the
  * explicit absence of one.
  */
+/**
+ * HOST_VCLUSTER — the one vCluster tier that is always addressable.
+ *
+ * #5616 established it as the safe default (the application-controller
+ * normalises `host` to the Organization's own namespace, so it never resolves
+ * to a namespace that does not exist). #5945 showed it needs a SHARED home:
+ * the editor owned the constant while the Topology tab hardcoded `'mgmt'` —
+ * a tier #4325 deleted — as its own display fallback and target seed, so the
+ * two surfaces disagreed about what "no vCluster specified" means. Placement
+ * vocabulary lives here; both consumers now read the same word.
+ */
+export const HOST_VCLUSTER = 'host'
+
 export const PATTERN_NOT_REPORTED = 'not-reported'
 
 /**

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/PlacementEditor.tsx
@@ -29,6 +29,7 @@ import {
   type OwnedDependencyOverride,
   type PlacementTarget,
   type StandbyType,
+  HOST_VCLUSTER,
   PATTERN_NOT_REPORTED,
   canAddPrimary,
   derivePattern,
@@ -94,8 +95,7 @@ export interface PlacementEditorProps {
 // Organization's own namespace), so it is the only safe fallback. Real
 // tiers arrive through `availableVClusters`, which the Sovereign
 // supplies from its live topology.
-const DEFAULT_VCLUSTERS = ['host']
-const HOST_VCLUSTER = 'host'
+const DEFAULT_VCLUSTERS = [HOST_VCLUSTER]
 
 export function PlacementEditor({
   sovereignId,


### PR DESCRIPTION
## What this fixes

Four DR/topology honesty defects on the **sovereign-admin** console
(`products/catalyst/bootstrap/ui/src/pages/sovereign/`). Three of the four
bottom out in **catalyst-api**, not in the console — the console cannot render
a fact the API declines to send, and cannot trust a gate the API cannot pass.

A fifth row (48) was investigated and is **refuted, not fixed** — evidence at
the end.

---

## Row 71 + Row 62 — the streaming-replication gate could never Pass

`replicationHealthGate` keyed on `status.replicationHealthy`. That spelling has
**zero producers**:

```
$ grep -rn "replicationHealthy\|ReplicationHealthy" core/controllers/continuum/ core/pkg/apis/ | grep -v _test
(no output)
```

and all 8 live Continuums on hw292 omit it:

```
shared-data / dr-shared-pg
   phase= Healthy  leaseHolder= hw-me-east-215-a-rtz-prod
   standbyAvailable= True  replicationLagSeconds= 0  replicationHealthy= None
```

So `found` was false on every real CR and the gate returned
`Warn "replication health not reported by the Continuum CR; unverified"`
**unconditionally, forever**, on a fully healthy pair. That is not cosmetic:
since #5508 the console treats a `streaming-replication` Warn as *"the lag
reading is not a measurement"* and renders the lag as `—`. Row 71's clause is
"a live replication-lag number", so the gate that could never pass was the
thing failing the row.

The fix is the correction #5601 already made to `ReplicaPromotable` **in this
same file** and did not carry across to the gate: consume the key the
controller actually writes (`status.standbyAvailable`, the #4901/#5311 probe
verdict) alongside `phase`. A CR carrying neither key still yields `Warn` —
never a Pass without evidence.

`products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go:1130-1170`

## Row 62 — the standby leg was permanently "unverifiable" on a 2-region Sovereign

`augmentReplicationStandbyStatus` cross-checks the standby by listing the
replica-role cnpg Cluster. But **this handler's dynamic client is scoped to the
region-A cluster, and the replica half lives in region B.** Measured
read-only on hw292:

```
$ kubectl -n shared-data get clusters.postgresql.cnpg.io --show-labels
NAME          READY  STATUS                    LABELS
shared-pg     3      Cluster in healthy state  ...,openova.io/cnpg-role=primary,...
shared-pg-b   3      Cluster in healthy state  ...,openova.io/cnpg-role=primary,...
shared-pg-c   3      Cluster in healthy state  ...,openova.io/cnpg-role=primary,...
```

Only primary halves. So `cnpgPairStandbyForContinuum` finds no replica,
`findCNPGPairForApp` requires **both** halves, and the code fell to the
"unverifiable" branch **permanently** — `standbyAvailable` omitted, gate Warn.
That is what makes the walk's finding true in effect: *the #4923/#4901 red
"Standby absent" banner is UNREACHABLE*, because its only trigger was a field
the backend never sends on this topology.

This is the per-region SPLIT class (#5511/#5394/#5416).

The continuum-controller does **not** have that blind spot — it probes the
standby directly and publishes `status.standbyAvailable`. When our own
cross-check cannot see the replica, relay that probe, and name the weaker
provenance in the gate message. **#4901 is not reopened**: the probe is the
thing that goes *false* during an outage, it is only consulted when the live
cross-check found nothing to contradict, and a CR that omits the key still
reports unknown.

`continuum_dr_extras.go:405-448`

## Row 62 — phase + lease holder reach the wire, and the standby line stops lying

Two more legs the walk named:

- `enrichReplicationStatus` **already read** `status.leaseHolder` (to correct
  `CurrentPrimary`) and then dropped it, and never read `status.phase` onto the
  response at all. The row's clause is "the live Continuum status (**Ready /
  lease holder** / standby) from the live API, not a static badge" — there was
  no data to render. Now emitted as `phase` / `leaseHolder` / `leaseExpiresAt`,
  all `omitempty`. `continuum_dr_extras.go:71-88, 1089-1096`
- The standby card's health line was
  `drStatus?.streamingState || 'hot replica (follows WAL)'` against a backend
  that returns `streamingState: ""` for **every** CR-derived reading. In
  practice a **hardcoded green claim**, printed unchanged over a standby the
  same payload had just called unverifiable — a static badge in a row whose
  clause forbids one. Now derived from the evidence.
  `TopologyTab.tsx:527-560`

Also: `standbyAbsent` now fires on a `standby-available` gate reading `Fail`,
not only on the `omitempty` bool. **Read what the backend actually emits.**

## Row 63 — the switchover control renders DISABLED, not absent

The 2026-08-10 walk could not verify the "control **disabled**" sub-clause
because **no switchover element existed on the page at all** — the `!drBacked`
branch rendered the honest copy and nothing else. Absence and disabled are
different statements to a sovereign-admin, and only the second one says
"switchover is a thing this app has, and cannot currently do".

The control now renders permanently disabled with
`Switchover unavailable — no live Continuum backs this placement, so there is
no standby to promote.` It is inside the `!drBacked` branch precisely so it
**cannot** arm: no `onClick`, no target region, no numeric value anywhere in
it, so row 63's third clause ("NO synthesized lag / standby / target-region
values") holds by construction. `TopologyTab.tsx:857-895`

#5514's assertion that the control is *absent* is tightened to *disabled* —
strictly stronger, and it keeps #5514's real intent (nothing armed, no dialog
reachable, no phantom region printed).

## #5945 — the placement editor offers only vClusters that exist

#5616 already narrowed `PlacementEditor`'s own default to `['host']`, so the
dead vocabulary was arriving from **its caller**:

1. `TopologyTab`'s `status.perCluster` projection hardcoded `vcluster: 'mgmt'`
   on every derived target. `perCluster` reports a **cluster** and carries no
   vCluster at all — the value was invented.
2. The editor deliberately re-admits whatever the current target names (so an
   operator's real placement is never silently rewritten), which turned that
   invented `mgmt` back into **both** a selectable option and the select's
   preselected value — reproducing #5945's measurement exactly.
3. `TopologyTab` passed no `availableVClusters`, so the per-Org vClusters that
   **do** exist were never offered.

Options now come from the **observed** topology, keyed by each vCluster's host
namespace (`VClusterSpec.namespace`, the real placement identity per #5616),
plus `host`. Same dead-vocabulary class as #5932/#5937.
`TopologyTab.tsx:305-320, 700-728, 793-797`

`HOST_VCLUSTER` moved to `shared/lib/placement.ts` — the two surfaces disagreed
about what "no vCluster specified" means, which is how the drift started.

---

## Row 48 — REFUTED, with evidence. Not a UI defect.

The brief asked whether the `active-passive` gating is wrong if a blueprint
supports it. **It is not wrong.** `disabled` derives *solely* from that
Blueprint's own `spec.topology.supported`
(`InstancesSection.tsx:591/836-840`), and the render is **already** asserted at
the DOM level in `InstancesSection.topology-gate.test.tsx` (6/6 pass on this
branch):

- `renders active-passive ENABLED (the option is not greyed out)`
- `the operator can actually SELECT active-passive and the value sticks`
- `a create request POSTs topology=active-passive end-to-end`
- `renders active-passive DISABLED with the not-supported reason` (control)
- `at least one operator-VISIBLE (listed) Blueprint declares active-passive`
  (non-vacuity guard on the shipped catalog)

The gate is also non-vacuous in the field. Census over all 99 `blueprint.yaml`
in the monorepo (98 declare `topology.supported`):

| | count |
|---|---|
| declare `active-passive` | **24** — catalyst-edge-routes, debezium, ferretdb, flink, k8s-ws-proxy, langfuse, loki, matrix, milvus, mimir, nats-jetstream, neo4j, newapi, oidc-gate, openbao, openmeter, opensearch, sso-bridge, stalwart-tenant, strimzi, tempo, temporal, valkey, wordpress-tenant |
| do not | **74** |

Both directions are well populated, so `disabled` tracks a real property rather
than being a blanket. (This corrects the UAT row's own figure of "five
installable blueprints DO declare it" — the row undercounted; the fixture the
existing test drives, `bp-ferretdb`, is in the list above.)

The UAT row's 2026-08-10 note already concludes *"API + SOURCE HALVES PROVEN …
One screenshot closes it."* The residual is a **walk artifact**, not code. No
change shipped for row 48.

---

## Proof each guard can fail

### Go — source reverted, tests kept

```
--- FAIL: TestReplicationStatus_Row71_StreamingGatePassesOnControllerStandbyProbe (0.00s)
    continuum_dr_extras_row62_71_test.go:95: streaming-replication gate: got "Warn" ("replication health not reported by the Continuum CR; unverified"), want Pass — the gate keyed on a status field with no producer, so it could never pass on a live CR
--- FAIL: TestReplicationStatus_Row71_StreamingGateControls (0.00s)
    --- FAIL: TestReplicationStatus_Row71_StreamingGateControls/standby_probe_false_->_Fail (0.00s)
        continuum_dr_extras_row62_71_test.go:116: streaming-replication gate on a false standby probe: got "Warn" want Fail
--- FAIL: TestReplicationStatus_Row62_PerRegionSplitRelaysStandbyProbe (0.00s)
    continuum_dr_extras_row62_71_test.go:159: standbyAvailable omitted: the replica half is not visible from region A, so the endpoint reported unknown and the console's tri-state read has nothing to consume
--- FAIL: TestReplicationStatus_Row62_PerRegionSplitSurfacesAbsentStandby (0.00s)
    continuum_dr_extras_row62_71_test.go:187: standbyAvailable: got <nil> want an explicit false — a lost standby that reports 'unknown' leaves the red banner unreachable
--- FAIL: TestReplicationStatus_Row62_EmitsPhaseAndLeaseHolder (0.00s)
    continuum_dr_extras_row62_71_test.go:250: wire key "phase" absent — the console cannot render the live Continuum status it does not receive
FAIL
```

Two tests **pass in both states, by design** — they pin behaviour that must not
change: `Row62_NoProbeStaysUnknown` (no probe, no pair → still unknown, never a
relayed Pass) and `Row62_NoLeaseHolderIsOmittedNotInvented` (a CR reporting no
lease must not get a fabricated one), plus the `no evidence at all -> Warn`
sub-control.

### Frontend — `TopologyTab.tsx` reverted, tests kept

`11 failed | 5 passed (16)`

```
× does not offer any of the #4325-deleted tiers
    AssertionError: expected [ 'host', 'mgmt' ] to not include 'mgmt'
× does not PRESELECT a retired vCluster
    AssertionError: expected 'mgmt' not to be 'mgmt' // Object.is equality
× offers the OBSERVED per-Org vCluster by its host namespace, plus host
    AssertionError: expected [ 'host', 'mgmt' ] to include 'uatco'
× CONTROL — the projected target carries no invented vCluster, and the card says host
    AssertionError: expected 'hw-me-east-215-a-rtz-prod · hw-me-eas…' not to contain 'mgmt'
× renders the red Standby absent banner on a standby-available gate that reads Fail
    Unable to find an element by: [data-testid="topology-tab-dr-standby-absent"]
× does not print "hot replica (follows WAL)" when the API reports no streaming state and the gate is unverified
    Unable to find an element by: [data-testid="topology-tab-dr-standby-hw-me-east-215-b-rtz-prod-health"]
× CONTROL — a real streaming state from the API is rendered verbatim
    Unable to find an element by: [data-testid="topology-tab-dr-standby-hw-me-east-215-b-rtz-prod-health"]
× renders the reconciled phase and the witness-lease holder from the API
    Unable to find an element by: [data-testid="topology-tab-dr-phase"]
× renders the switchover control DISABLED with "Switchover unavailable" copy
    Unable to find an element by: [data-testid="topology-tab-dr-switchover-open"]
× and still synthesizes NO lag, standby or target-region values
    Unable to find an element by: [data-testid="topology-tab-dr-switchover-reason"]
× CONTROL — a BACKED app arms the same control, so "disabled" above is chosen by the backing, not printed unconditionally
    Unable to find an element by: [data-testid="topology-tab-dr-switchover-reason"]
```

The 3 `mgmt` assertions reproduce #5945's own measurement verbatim — the select
offering a retired tier, preselecting it, and not offering the per-Org vCluster
that actually exists.

The 5 that pass without the fix are the **controls that must not move**: a
`Pass` gate renders no absent banner; an API reporting no phase renders no
status strip (never an invented `Healthy`); a fully-gated live reading prints
its numeric lag while the same lag behind a `Warn` prints `—`; and an
Application that **genuinely declares** a legacy vCluster keeps it selectable
(#5616's invariant — this is what makes the three `mgmt` assertions a statement
about *invented* values, not a blanket ban).

### Both directions shown reachable

Honest-copy path **and** real-data path each have an explicit control:
`row 63` asserts disabled-on-unbacked **and** armed-on-backed in the same
describe; `row 62a` asserts "not verified" on an empty `streamingState`
**and** verbatim `streaming` when the API sends one.

## Gates (chained, not newline-separated)

```
npx tsc -b && npx vitest run   →  232 files / 2144 passed, 1 expected fail
npx tsc -b && npm run build     →  clean
go build ./... && go vet ./internal/handler/ && go test ./...  →  28 ok, 0 fail
npx eslint <changed files>      →  clean
scripts/check-no-banned-words.sh → OK
```

Live verification was **read-only** throughout
(`kubectl --kubeconfig=/tmp/hw292-a.yaml get …`). No cluster writes, no
NodePorts, no secrets.

Refs #3375 #4923 #5945

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
