### PR TITLE
fix(application-controller): derive Application readiness from the BACKING resource, not the HelmRelease alone

### DIFF
--- a/core/controllers/application/deploy/rbac.yaml
+++ b/core/controllers/application/deploy/rbac.yaml
@@ -80,6 +80,19 @@ rules:
     resources: ["continuums"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
+  # #5955 — backing-resource readiness observation. A Flux HelmRelease
+  # reporting Ready=True only means Helm applied the manifests and the
+  # apiserver accepted them; anything that fails AFTER admission leaves the HR
+  # legitimately Ready over a dead workload. The readiness gate reads each
+  # backing object's own status.conditions[type=Ready]. #5513 shipped that read
+  # without the grant, so it 403'd on every Sovereign and the guard could not
+  # fail (measured on hw292: `auth can-i list clusters.postgresql.cnpg.io` ->
+  # no, while the HelmRelease control -> yes). READ-ONLY: Flux owns the writes.
+  # Mirrors products/catalyst/chart/templates/controllers/application-controller-clusterrole.yaml.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch"]
+
   # Events for audit trail on every reconcile error / status flip.
   - apiGroups: [""]
     resources: ["events"]

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -183,6 +183,25 @@ const (
 	// database that has zero pods and needs manual intervention.
 	ReasonBackingUnrecoverable = "BackingClusterUnrecoverable"
 
+	// ReasonBackingNotReady — #5955. Stamped on
+	// Application.status.conditions[type=Ready,status=False] when a downstream
+	// HelmRelease is Ready (manifests applied, apiserver accepted them) but a
+	// backing resource the chart installed REPORTS ITSELF not ready — e.g. a
+	// CNPG Cluster whose own status.conditions[type=Ready] is False over zero
+	// ready instances. A read verdict, not an inference.
+	ReasonBackingNotReady = "BackingNotReady"
+
+	// ReasonBackingUnverifiable — #5955. Stamped on
+	// Application.status.conditions[type=Ready,status=Unknown] when the
+	// controller COULD NOT OBSERVE a backing resource: the list was Forbidden
+	// / timed out / errored, or the object exists but has published no
+	// readiness signal at all. Distinct from ReasonBackingNotReady on purpose
+	// — "it says it is broken" and "I could not look" are different facts, and
+	// neither may be reported as Ready. The predecessor gate swallowed the
+	// second case as healthy, which is how an Application reported Ready over
+	// a database with zero ready instances on hw292.
+	ReasonBackingUnverifiable = "BackingReadinessUnverifiable"
+
 	// ReasonInvalidTopology — G117.6 (W2.C1, Refs #2745). Stamped on
 	// `Application.status.conditions[type=Ready,status=False]` when the
 	// resolved BCP topology (from Application.spec.topology override
@@ -1556,26 +1575,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 			app.GetNamespace(), app.GetName(), effectiveRegions)
 	}
 
-	// #5513 — a downstream HelmRelease Ready=True means "Helm applied the
-	// manifests", NOT "the workload came up". A CNPG-backed Application can
-	// carry a Ready HelmRelease while its backing CNPG Cluster sits in the
-	// terminal `unrecoverable` state (0 pods, ConsistentSystemID=False,
-	// "needs manual intervention"). Reporting the Application Ready over that
-	// is the fabricated DR posture #5513 walked live. Observe the backing
-	// CNPG Cluster CR(s) — matched by the chart-stamped
-	// app.kubernetes.io/instance label (= each per-cluster HR name) — and
-	// downgrade to Degraded when any is unrecoverable, so the reported Ready
-	// condition matches the workload reality. Read-only + failure-tolerant:
-	// a missing CNPG CRD (no Postgres in this Sovereign) or a transient list
-	// error NEVER fabricates a downgrade — the HR-derived phase stands.
+	// #5955 (generalises #5513) — a downstream HelmRelease Ready=True means
+	// "Helm applied the manifests and the apiserver ACCEPTED them", NOT "the
+	// workload came up". Anything that fails AFTER admission leaves the HR
+	// legitimately Ready over a dead workload, so readiness derived solely
+	// from HelmRelease readiness paints a green badge over nothing. Walked
+	// live on hw292: uat-ahs-pg reported "installed across 2 region(s);
+	// Ready=True from downstream HelmRelease(s)" while its backing CNPG
+	// Cluster carried status.conditions[Ready]=False with status.readyInstances
+	// absent entirely — on 2 of 2 per-Org Postgres clusters.
+	//
+	// observeBackingReadiness consults the BACKING RESOURCE'S OWN readiness
+	// signal (the standard status.conditions[type=Ready]) across a registry of
+	// backing kinds, and returns three states, never two:
+	//
+	//   backingReady        → nothing to do (also the answer when the
+	//                         Application has no backing of a registered kind,
+	//                         so the common case reaches Ready unchanged).
+	//   backingNotReady     → the backing was READ and says it is not ready →
+	//                         Degraded / Ready=False. A verdict.
+	//   backingUnobservable → the backing could not be read (Forbidden,
+	//                         timeout, API error) or published no readiness →
+	//                         Ready="Unknown". Explicitly unverifiable, NEVER
+	//                         a silent pass. #5513's gate collapsed this state
+	//                         into "healthy", which is why it could not fail
+	//                         on a Sovereign whose controller SA has no grant
+	//                         on the backing kind — the live hw292 shape.
 	if finalReady == "True" {
-		if cnpgNs, cnpgName, unrecoverable := r.backingCNPGUnrecoverable(ctx, app, perClusterStatus); unrecoverable {
+		switch v := r.observeBackingReadiness(ctx, app, perClusterStatus); v.state {
+		case backingNotReady:
 			finalPhase = PhaseDegraded
 			finalReady = "False"
-			finalReason = ReasonBackingUnrecoverable
+			finalReason = v.reason
 			finalMessage = fmt.Sprintf(
-				"Application %s/%s: backing CNPG cluster %s/%s is in an unrecoverable state and needs manual intervention; not reporting Ready",
-				app.GetNamespace(), app.GetName(), cnpgNs, cnpgName)
+				"Application %s/%s: %s; not reporting Ready",
+				app.GetNamespace(), app.GetName(), v.detail)
+		case backingUnobservable:
+			// Not Degraded — we have no evidence of failure, only an absence
+			// of evidence of health. Provisioning + Ready=Unknown is the
+			// honest pairing: the Application has not been shown to be up.
+			finalPhase = PhaseProvisioning
+			finalReady = "Unknown"
+			finalReason = ReasonBackingUnverifiable
+			finalMessage = fmt.Sprintf(
+				"Application %s/%s: backing-resource readiness could not be verified — %s; reporting Ready=Unknown rather than assuming healthy",
+				app.GetNamespace(), app.GetName(), v.detail)
 		}
 	}
 	su := statusUpdate{

--- a/core/controllers/application/internal/controller/application_controller_5513_test.go
+++ b/core/controllers/application/internal/controller/application_controller_5513_test.go
@@ -26,14 +26,43 @@ import (
 // makeCNPGCluster returns a CNPG Cluster CR (postgresql.cnpg.io/v1) carrying
 // the standard app.kubernetes.io/instance label (the Helm release name that
 // installed it) and the given status.phase.
+//
+// #5955 — the status is built to the FULL live shape, not phase-only. Every one
+// of the 11 CNPG Clusters dumped off hw292 publishes
+// status.conditions[type=Ready] alongside the phase, and the readiness gate
+// treats a CR that publishes NO readiness signal as unobservable (correctly —
+// see TestBackingReadiness_NoSignal_IsUnobservable). A phase-only fixture would
+// therefore have exercised the unobservable path while claiming to exercise the
+// healthy one. Ready mirrors CNPG's own coupling: True only in the healthy
+// phase.
 func makeCNPGCluster(namespace, name, instance, phase string) *unstructured.Unstructured {
+	ready := "False"
+	readyInstances := int64(0)
+	if phase == "Cluster in healthy state" {
+		ready = "True"
+		readyInstances = 1
+	}
+	return makeCNPGClusterWithStatus(namespace, name, instance, map[string]interface{}{
+		"phase":          phase,
+		"instances":      int64(1),
+		"readyInstances": readyInstances,
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "Ready", "status": ready},
+		},
+	})
+}
+
+// makeCNPGClusterWithStatus returns a CNPG Cluster CR with a verbatim status
+// map, so a test can reproduce an exact live status key set — including the
+// per-Org shape where status.readyInstances is ABSENT rather than zero.
+func makeCNPGClusterWithStatus(namespace, name, instance string, status map[string]interface{}) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
 	u.SetAPIVersion("postgresql.cnpg.io/v1")
 	u.SetKind("Cluster")
 	u.SetNamespace(namespace)
 	u.SetName(name)
 	u.SetLabels(map[string]string{InstanceLabel: instance})
-	u.Object["status"] = map[string]interface{}{"phase": phase}
+	u.Object["status"] = status
 	return u
 }
 
@@ -196,29 +225,31 @@ func TestReconcile_5513_ReadyHR_HealthyCNPG_StaysReady(t *testing.T) {
 	}
 }
 
-// TestCNPGClusterUnrecoverable_BothDirections — the phase classifier in
-// isolation. Terminal `unrecoverable` phrasings trip; transient/healthy phases
-// and an absent status do not.
-func TestCNPGClusterUnrecoverable_BothDirections(t *testing.T) {
-	cases := []struct {
-		phase string
-		want  bool
-	}{
-		{"Cluster is unrecoverable and needs manual intervention", true},
-		{"Cluster in unrecoverable state", true},
-		{"Cluster in healthy state", false},
-		{"Setting up primary", false},
-		{"Waiting for the instances to become active", false},
-		{"", false},
-	}
-	for _, c := range cases {
-		cr := makeCNPGCluster("mgmt", "postgres", "obs-mgmt-a", c.phase)
-		if got := cnpgClusterUnrecoverable(cr); got != c.want {
-			t.Errorf("cnpgClusterUnrecoverable(phase=%q) = %v, want %v", c.phase, got, c.want)
+// TestCNPGClusterUnrecoverable_KeepsItsOwnReason — the terminal `unrecoverable`
+// phase keeps the specific ReasonBackingUnrecoverable that #5513 shipped, even
+// though #5955 generalised the gate to every backing kind. Operator tooling and
+// the #5513 acceptance assert on that exact reason string.
+func TestCNPGClusterUnrecoverable_KeepsItsOwnReason(t *testing.T) {
+	for _, phase := range []string{
+		"Cluster is unrecoverable and needs manual intervention",
+		"Cluster in unrecoverable state",
+	} {
+		cr := makeCNPGCluster("mgmt", "postgres", "obs-mgmt-a", phase)
+		state, detail := cnpgClusterReadiness(cr)
+		if state != backingNotReady {
+			t.Errorf("cnpgClusterReadiness(phase=%q) state = %v, want backingNotReady", phase, state)
+		}
+		if got := backingNotReadyReason(detail); got != ReasonBackingUnrecoverable {
+			t.Errorf("reason for phase=%q = %q, want %q", phase, got, ReasonBackingUnrecoverable)
 		}
 	}
-	if cnpgClusterUnrecoverable(nil) {
-		t.Errorf("cnpgClusterUnrecoverable(nil) = true, want false")
+	// A healthy cluster is not swept up by the unrecoverable branch.
+	state, _ := cnpgClusterReadiness(makeCNPGCluster("mgmt", "postgres", "obs-mgmt-a", "Cluster in healthy state"))
+	if state != backingReady {
+		t.Errorf("healthy cluster state = %v, want backingReady", state)
+	}
+	if state, _ := cnpgClusterReadiness(nil); state != backingUnobservable {
+		t.Errorf("cnpgClusterReadiness(nil) state = %v, want backingUnobservable", state)
 	}
 }
 

--- a/core/controllers/application/internal/controller/application_controller_5955_test.go
+++ b/core/controllers/application/internal/controller/application_controller_5955_test.go
@@ -1,0 +1,418 @@
+// application_controller_5955_test.go — #5955, UAT row 238.
+//
+// An Application reported Ready=True over a database with ZERO ready instances,
+// on 2 of 2 per-Org Postgres clusters. The Application's own condition message
+// named the mechanism:
+//
+//	"Application hw292-omani-works/uat-ahs-pg installed across 2 region(s);
+//	 Ready=True from downstream HelmRelease(s)"
+//
+// Readiness was derived SOLELY from HelmRelease readiness. The HelmReleases were
+// legitimately True — Helm rendered valid YAML and the apiserver accepted the
+// Cluster CR. Nothing in the chain ever read the backing object's own readiness,
+// so any backing resource that fails AFTER admission produced a green badge over
+// a dead workload. Not Postgres-specific: that is the class.
+//
+// The live status key sets these fixtures reproduce (dumped read-only off hw292
+// region A on 2026-08-09; the key SET was dumped rather than guessed, so
+// `readyInstances` absent is reproduced as absent, not as 0):
+//
+//	control  shared-data/shared-pg          instances=3 readyInstances=3 Ready=True
+//	control  cnpg/cnpg-pair-primary         instances=3 readyInstances=3 Ready=True
+//	control  catalyst-system/openova-flow-pg instances=2 readyInstances=2 Ready=FALSE
+//	PER-ORG  hw292-omani-works/postgres     instances=1 readyInstances=ABSENT Ready=False
+//	PER-ORG  uatco/postgres                 instances=1 readyInstances=ABSENT Ready=False
+//
+// The openova-flow-pg control is why the gate keys on the Ready CONDITION and
+// not on the instance counts: readyInstances == instances there while the
+// cluster's own Ready condition is False, so a count-only gate would have
+// false-passed it.
+//
+// Asserted in all three directions, because the whole point of the fix is the
+// third one:
+//
+//  1. backing reports NOT-READY  → Application must NOT be Ready (Degraded).
+//  2. backing reports ready      → Application must still reach Ready (no
+//     over-rotation), and an Application with NO backing of a
+//     registered kind must still reach Ready normally.
+//  3. backing UNOBSERVABLE       → Application must report Ready=Unknown with
+//     reason BackingReadinessUnverifiable — never a
+//     silent pass. This is the state the predecessor
+//     gate (#5513) collapsed into "healthy", which is
+//     why it could not fail on hw292 at all: the
+//     controller SA has no grant on the backing kind,
+//     so every List returned Forbidden and every
+//     Forbidden was skipped.
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// hw292PerOrgCNPGStatus is the VERBATIM live status shape of the two defective
+// per-Org Postgres clusters: a Ready condition of False, a declared instance
+// count, and NO readyInstances key at all.
+func hw292PerOrgCNPGStatus() map[string]interface{} {
+	return map[string]interface{}{
+		"phase":     "Setting up primary",
+		"instances": int64(1),
+		// status.readyInstances deliberately ABSENT — hasKey=False live.
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "ConsistentSystemID", "status": "False"},
+			map[string]interface{}{"type": "Ready", "status": "False"},
+		},
+	}
+}
+
+// newAppOverCNPG builds the hw292 shape: an Application whose single fan-out
+// HelmRelease is Ready=True, over one backing CNPG Cluster.
+func newAppOverCNPG(t *testing.T, backing ...*unstructured.Unstructured) *Reconciler {
+	t.Helper()
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-postgres", "0.2.6", "mgmt",
+		[]string{"mgmt-A"},
+	)
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6",
+		"single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		nil,
+	)
+	hr := readyHR("obs-mgmt-a", "mgmt", "True")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	objs := append([]*unstructured.Unstructured{app, env, org, bp, hr}, backing...)
+	return newReconciler(t, fg, objs...)
+}
+
+// TestReconcile_5955_ReadyHR_BackingZeroReadyInstances_NotReady — THE failing-
+// pre-fix direction, reproducing UAT row 238 verbatim. The HelmRelease is
+// Ready=True (Helm applied the chart, the apiserver accepted the Cluster CR)
+// but the backing CNPG Cluster reports Ready=False with status.readyInstances
+// absent entirely. The Application must NOT report Ready.
+//
+// Before the fix the gate asked only "is status.phase unrecoverable?" — and
+// "Setting up primary" is not — so the Application settled on
+// phase=Ready / Ready=True over a database with zero ready instances.
+func TestReconcile_5955_ReadyHR_BackingZeroReadyInstances_NotReady(t *testing.T) {
+	cnpg := makeCNPGClusterWithStatus("mgmt", "postgres", "obs-mgmt-a", hw292PerOrgCNPGStatus())
+	r := newAppOverCNPG(t, cnpg)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if ready := readyConditionStatus(t, got); ready == "True" {
+		t.Fatalf("Ready condition = True over a backing CNPG with status.conditions[Ready]=False and "+
+			"status.readyInstances absent — the #5955 green badge over a dead database "+
+			"(phase=%q reason=%q msg=%q)", phase, reason, msg)
+	}
+	if phase == PhaseReady {
+		t.Fatalf("phase = Ready over a backing with zero ready instances (msg=%q)", msg)
+	}
+	if phase != PhaseDegraded {
+		t.Fatalf("phase = %q, want %q — the backing was READ and reports not-ready, which is a verdict, "+
+			"not an unobservable state", phase, PhaseDegraded)
+	}
+	if reason != ReasonBackingNotReady {
+		t.Errorf("reason = %q, want %q", reason, ReasonBackingNotReady)
+	}
+	// The message must name the object the operator has to go look at.
+	for _, want := range []string{"mgmt/postgres", "Ready"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestReconcile_5955_ReadyHR_HealthyBacking_StaysReady — control direction 1.
+// A backing that reports itself ready must not be swept up: the Application
+// still reaches Ready.
+func TestReconcile_5955_ReadyHR_HealthyBacking_StaysReady(t *testing.T) {
+	cnpg := makeCNPGClusterWithStatus("mgmt", "postgres", "obs-mgmt-a", map[string]interface{}{
+		"phase":          "Cluster in healthy state",
+		"instances":      int64(3),
+		"readyInstances": int64(3),
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "Ready", "status": "True"},
+			map[string]interface{}{"type": "ConsistentSystemID", "status": "True"},
+		},
+	})
+	r := newAppOverCNPG(t, cnpg)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if phase != PhaseReady {
+		t.Fatalf("phase = %q, want %q over a healthy backing (reason=%q msg=%q)", phase, PhaseReady, reason, msg)
+	}
+	if ready := readyConditionStatus(t, got); ready != "True" {
+		t.Fatalf("Ready condition = %q, want True over a healthy backing", ready)
+	}
+}
+
+// TestReconcile_5955_NoBackingResource_StaysReady — control direction 2, the
+// no-regression bar. The overwhelming majority of Applications install nothing
+// of a registered backing kind. Absence of a backing is NOT a failure to
+// observe one: those Applications must reach Ready exactly as before.
+func TestReconcile_5955_NoBackingResource_StaysReady(t *testing.T) {
+	r := newAppOverCNPG(t) // no backing objects at all
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if phase != PhaseReady {
+		t.Fatalf("phase = %q, want %q for an Application with no backing resource — "+
+			"an empty list must not read as unobservable (reason=%q msg=%q)", phase, PhaseReady, reason, msg)
+	}
+	if ready := readyConditionStatus(t, got); ready != "True" {
+		t.Fatalf("Ready condition = %q, want True for an Application with no backing resource", ready)
+	}
+}
+
+// TestReconcile_5955_BackingForbidden_IsUnverifiableNotReady — control
+// direction 3, and the heart of the fix. This is the LIVE hw292 shape: the
+// application-controller ServiceAccount has no grant on
+// postgresql.cnpg.io/clusters, so the List returns Forbidden.
+//
+//	kubectl auth can-i list clusters.postgresql.cnpg.io -n hw292-omani-works \
+//	  --as=system:serviceaccount:catalyst-system:catalyst-application-controller
+//	-> no          (control, same impersonation, helmreleases -> yes)
+//
+// The predecessor gate skipped that error and let the Application settle on
+// Ready=True — a missing permission silently rendered as a healthy database.
+// The Application must instead report Ready=Unknown: we have no evidence of
+// failure, only an absence of evidence of health.
+func TestReconcile_5955_BackingForbidden_IsUnverifiableNotReady(t *testing.T) {
+	cnpg := makeCNPGClusterWithStatus("mgmt", "postgres", "obs-mgmt-a", map[string]interface{}{
+		"phase":          "Cluster in healthy state",
+		"instances":      int64(3),
+		"readyInstances": int64(3),
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "Ready", "status": "True"},
+		},
+	})
+	r := newAppOverCNPG(t, cnpg)
+	// Even with a HEALTHY backing present, a Forbidden read must not pass:
+	// the controller did not see it. Sharing the healthy fixture with the
+	// control above makes the ONLY difference the observability of the read.
+	forbidCNPGList(t, r)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if ready := readyConditionStatus(t, got); ready == "True" {
+		t.Fatalf("Ready condition = True while the backing read was Forbidden — a missing RBAC grant "+
+			"must never render as a healthy workload (phase=%q reason=%q msg=%q)", phase, reason, msg)
+	} else if ready != "Unknown" {
+		t.Fatalf("Ready condition = %q, want Unknown for an unobservable backing", ready)
+	}
+	if phase == PhaseDegraded {
+		t.Fatalf("phase = Degraded for an UNOBSERVED backing — that fabricates a failure we did not measure (msg=%q)", msg)
+	}
+	if reason != ReasonBackingUnverifiable {
+		t.Errorf("reason = %q, want %q", reason, ReasonBackingUnverifiable)
+	}
+	if !strings.Contains(strings.ToLower(msg), "could not be verified") {
+		t.Errorf("message %q does not say the readiness could not be verified", msg)
+	}
+}
+
+// TestReconcile_5955_BackingKindAbsent_StaysReady — the counterpart of the
+// Forbidden case, and the reason "cannot observe" is not simply "any List
+// error". A Sovereign with no CNPG CRD installed serves NotFound for the
+// resource path; that is positive knowledge that there is no backing of that
+// kind, so every Application must keep reaching Ready. Without this branch the
+// fix would rotate every Application on a Postgres-free Sovereign to Unknown.
+func TestReconcile_5955_BackingKindAbsent_StaysReady(t *testing.T) {
+	r := newAppOverCNPG(t)
+	errCNPGList(t, r, apierrors.NewNotFound(
+		schema.GroupResource{Group: CNPGClusterGVR.Group, Resource: CNPGClusterGVR.Resource}, ""))
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if phase != PhaseReady {
+		t.Fatalf("phase = %q, want %q when the backing CRD is not served by this Sovereign "+
+			"(reason=%q msg=%q)", phase, PhaseReady, reason, msg)
+	}
+}
+
+// TestBackingKindAbsent_Classification — the read-error classifier in
+// isolation, both directions. Only "the kind is not served here" counts as
+// absent; every failure-to-observe must fall through to the unobservable path.
+func TestBackingKindAbsent_Classification(t *testing.T) {
+	gr := schema.GroupResource{Group: CNPGClusterGVR.Group, Resource: CNPGClusterGVR.Resource}
+	absent := []error{
+		apierrors.NewNotFound(gr, ""),
+		runtime.NewNotRegisteredErrForKind("test", schema.GroupVersionKind{
+			Group: CNPGClusterGVR.Group, Version: CNPGClusterGVR.Version, Kind: "ClusterList"}),
+	}
+	for _, err := range absent {
+		if !backingKindAbsent(err) {
+			t.Errorf("backingKindAbsent(%v) = false, want true", err)
+		}
+	}
+	unobservable := []error{
+		apierrors.NewForbidden(gr, "postgres", nil),
+		apierrors.NewUnauthorized("no token"),
+		apierrors.NewTimeoutError("too slow", 1),
+		apierrors.NewServiceUnavailable("apiserver down"),
+		apierrors.NewTooManyRequestsError("throttled"),
+		context.DeadlineExceeded,
+	}
+	for _, err := range unobservable {
+		if backingKindAbsent(err) {
+			t.Errorf("backingKindAbsent(%v) = true, want false — a failure to observe must never "+
+				"be classified as 'there is nothing to observe'", err)
+		}
+	}
+	if backingKindAbsent(nil) {
+		t.Errorf("backingKindAbsent(nil) = true, want false")
+	}
+}
+
+// TestBackingReadiness_NoSignal_IsUnobservable — a backing object that exists
+// but has published NO readiness at all (freshly admitted, controller has not
+// reconciled it yet) is unobservable, never ready. That window — "the apiserver
+// accepted it and nothing has confirmed it came up" — is exactly the one the
+// HelmRelease-only derivation reported as green.
+func TestBackingReadiness_NoSignal_IsUnobservable(t *testing.T) {
+	cases := []struct {
+		name   string
+		status map[string]interface{}
+	}{
+		{"empty status", map[string]interface{}{}},
+		{"phase only", map[string]interface{}{"phase": "Setting up primary"}},
+		{"instances but no readiness", map[string]interface{}{
+			"phase": "Setting up primary", "instances": int64(1)}},
+		{"Ready condition Unknown", map[string]interface{}{
+			"phase":      "Setting up primary",
+			"conditions": []interface{}{map[string]interface{}{"type": "Ready", "status": "Unknown"}},
+		}},
+	}
+	for _, c := range cases {
+		cr := makeCNPGClusterWithStatus("mgmt", "postgres", "obs-mgmt-a", c.status)
+		state, detail := cnpgClusterReadiness(cr)
+		if state != backingUnobservable {
+			t.Errorf("%s: state = %v, want backingUnobservable (detail=%q)", c.name, state, detail)
+		}
+	}
+}
+
+// TestBackingReadiness_ReadyConditionOutranksCounts — the openova-flow-pg
+// control, verbatim from hw292 region A: instances=2 AND readyInstances=2 while
+// status.conditions[Ready] is False (phase "Instance Status Extraction Error").
+// A gate keyed on the counts would call this healthy; the Ready condition is
+// the load-bearing signal and must win.
+func TestBackingReadiness_ReadyConditionOutranksCounts(t *testing.T) {
+	cr := makeCNPGClusterWithStatus("catalyst-system", "openova-flow-pg", "obs-mgmt-a", map[string]interface{}{
+		"phase":          "Instance Status Extraction Error: HTTP communication issue",
+		"instances":      int64(2),
+		"readyInstances": int64(2),
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "ConsistentSystemID", "status": "False"},
+			map[string]interface{}{"type": "Ready", "status": "False"},
+		},
+	})
+	state, detail := cnpgClusterReadiness(cr)
+	if state != backingNotReady {
+		t.Fatalf("state = %v, want backingNotReady — readyInstances==instances must not override a "+
+			"Ready condition of False (detail=%q)", state, detail)
+	}
+	if backingNotReadyReason(detail) != ReasonBackingNotReady {
+		t.Errorf("reason = %q, want %q", backingNotReadyReason(detail), ReasonBackingNotReady)
+	}
+}
+
+// TestObserveBackingReadiness_NotReadyOutranksUnobservable — rollup precedence.
+// An Application whose fan-out spans two namespaces, one unreadable and one
+// holding a backing that reports not-ready, must surface the VERDICT (the fact
+// we measured) rather than the unobservable state.
+func TestObserveBackingReadiness_NotReadyOutranksUnobservable(t *testing.T) {
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"}, nil)
+	cnpg := makeCNPGClusterWithStatus("mgmt", "postgres", "obs-mgmt-a", hw292PerOrgCNPGStatus())
+	fg := newFakeGitea()
+	r := newReconciler(t, fg, app, cnpg)
+	// Fail the read in the OTHER namespace only, leaving the not-ready backing
+	// in `mgmt` readable.
+	failListInNamespace(t, r, "acme", apierrors.NewForbidden(
+		schema.GroupResource{Group: CNPGClusterGVR.Group, Resource: CNPGClusterGVR.Resource}, "postgres", nil))
+
+	v := r.observeBackingReadiness(context.Background(), app, []map[string]interface{}{
+		{"hr": "obs-mgmt-a", "namespace": "mgmt"},
+	})
+	if v.state != backingNotReady {
+		t.Fatalf("state = %v, want backingNotReady (detail=%q)", v.state, v.detail)
+	}
+	if v.reason != ReasonBackingNotReady {
+		t.Errorf("reason = %q, want %q", v.reason, ReasonBackingNotReady)
+	}
+}
+
+// --- fake-client reactors -------------------------------------------------
+
+// fakeDyn exposes the reactor hook on the fake dynamic client the test
+// reconciler is built with.
+func fakeDyn(t *testing.T, r *Reconciler) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	f, ok := r.Dynamic.(*dynamicfake.FakeDynamicClient)
+	if !ok {
+		t.Fatalf("test dynamic client is %T, want *dynamicfake.FakeDynamicClient", r.Dynamic)
+	}
+	return f
+}
+
+// errCNPGList makes every CNPG Cluster list return err.
+func errCNPGList(t *testing.T, r *Reconciler, err error) {
+	t.Helper()
+	fakeDyn(t, r).PrependReactor("list", CNPGClusterGVR.Resource,
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, err
+		})
+}
+
+// forbidCNPGList makes every CNPG Cluster list return Forbidden — the live
+// hw292 RBAC shape.
+func forbidCNPGList(t *testing.T, r *Reconciler) {
+	t.Helper()
+	errCNPGList(t, r, apierrors.NewForbidden(
+		schema.GroupResource{Group: CNPGClusterGVR.Group, Resource: CNPGClusterGVR.Resource},
+		"postgres",
+		errNoGrant{},
+	))
+}
+
+// failListInNamespace makes CNPG Cluster lists fail in ONE namespace only.
+func failListInNamespace(t *testing.T, r *Reconciler, ns string, err error) {
+	t.Helper()
+	fakeDyn(t, r).PrependReactor("list", CNPGClusterGVR.Resource,
+		func(a k8stesting.Action) (bool, runtime.Object, error) {
+			if a.GetNamespace() == ns {
+				return true, nil, err
+			}
+			return false, nil, nil
+		})
+}
+
+type errNoGrant struct{}
+
+func (errNoGrant) Error() string {
+	return `clusters.postgresql.cnpg.io is forbidden: User "system:serviceaccount:catalyst-system:catalyst-application-controller" cannot list resource "clusters"`
+}

--- a/core/controllers/application/internal/controller/application_controller_backing_health.go
+++ b/core/controllers/application/internal/controller/application_controller_backing_health.go
@@ -1,25 +1,87 @@
-// application_controller_backing_health.go — #5513 backing-workload health.
+// application_controller_backing_health.go — backing-workload readiness.
 //
 // A downstream Flux HelmRelease reporting Ready=True means only that Helm
-// applied the chart's manifests — NOT that the workload the chart installs
-// actually came up. For a CNPG-backed Application the load-bearing workload is
-// the CNPG Cluster CR, and CNPG has a terminal `unrecoverable` phase ("Cluster
-// is unrecoverable and needs manual intervention") in which the database has
-// zero pods and cannot serve. Reporting the Application Ready over that state
-// is the fabricated DR posture walked live on hw291 (#5513).
+// applied the chart's manifests and the apiserver ACCEPTED them — NOT that the
+// workload the chart installs actually came up. Every resource that fails
+// AFTER admission (a database that never elects a primary, a StatefulSet whose
+// pods never pass their probes, an operator that rejects the spec at
+// reconcile-time) leaves the HelmRelease legitimately Ready while the thing the
+// User asked for is dead. Deriving Application readiness solely from
+// HelmRelease readiness therefore paints a green badge over a dead workload.
+// That is the defect class #5955 walked live on hw292:
 //
-// This file adds a read-only, failure-tolerant observation the reconcile status
-// rollup consults before it lets an Application settle on Ready=True. It never
-// writes and never fabricates a downgrade: a missing CNPG CRD (no Postgres in
-// this Sovereign) or a transient list error leaves the HR-derived phase intact.
+//	Application hw292-omani-works/uat-ahs-pg  → Ready=True
+//	  "installed across 2 region(s); Ready=True from downstream HelmRelease(s)"
+//	backing Cluster hw292-omani-works/postgres → status.conditions[Ready]=False
+//	  phase="Setting up primary", status.instances=1, status.readyInstances ABSENT
+//
+// ...on 2 of 2 per-Org Postgres clusters. The class is NOT Postgres-specific,
+// so the gate below is not a Postgres special-case: it observes a REGISTRY of
+// backing kinds (backingKinds) and consults each backing object's OWN readiness
+// signal — primarily the standard status.conditions[type=Ready], the same
+// contract the controller already trusts for HelmReleases.
+//
+// # The three-state contract (the load-bearing part)
+//
+// The predecessor of this gate (#5513) asked one narrow yes/no question — "is
+// the backing CNPG Cluster in the terminal `unrecoverable` phase?" — and
+// swallowed every read failure as a silent "no". On hw292 the
+// application-controller's ServiceAccount has NO grant on
+// postgresql.cnpg.io/clusters at all:
+//
+//	$ kubectl auth can-i list clusters.postgresql.cnpg.io -n hw292-omani-works \
+//	    --as=system:serviceaccount:catalyst-system:catalyst-application-controller
+//	no
+//	# control, same impersonation, kind the controller DOES observe:
+//	$ kubectl auth can-i list helmreleases.helm.toolkit.fluxcd.io -n hw292-omani-works \
+//	    --as=system:serviceaccount:catalyst-system:catalyst-application-controller
+//	yes
+//
+// so every List returned Forbidden, every Forbidden was skipped, and the guard
+// could not fail no matter how dead the database was. A guard that cannot
+// observe its subject and reports "healthy" is worse than no guard: it converts
+// a missing permission into a false green.
+//
+// This gate therefore returns THREE states, never two:
+//
+//	backingReady        — every observed backing publishes Ready=True.
+//	                      Also the answer when there is NO backing of a
+//	                      registered kind (the overwhelmingly common case:
+//	                      a web app, a queue, anything not in the registry) —
+//	                      absence of a backing is not a failure, so those
+//	                      Applications reach Ready exactly as before.
+//	backingNotReady     — a backing was READ and it says it is not ready.
+//	                      → Application Degraded, Ready=False. A verdict.
+//	backingUnobservable — the backing could not be read (Forbidden, timeout,
+//	                      API error) or it exists but has published no
+//	                      readiness at all.
+//	                      → Application Ready="Unknown", reason
+//	                      BackingReadinessUnverifiable. NEVER a silent pass.
+//
+// "Cannot observe" is deliberately NOT collapsed into either "healthy" or
+// "broken": claiming Degraded from an unread object would fabricate a failure,
+// and claiming Ready would reinstate the exact defect. Unknown is the honest
+// third answer and it is what the Ready condition's tri-state is for.
+//
+// The one read failure that is NOT unobservable is "this kind does not exist in
+// this Sovereign" (no CRD → NotFound / no-kind-match). That is positive
+// knowledge that there is no backing of that kind to observe, so it is skipped
+// — a Sovereign with no CNPG installed must not rotate every Application to
+// Unknown.
+//
+// The gate is READ-ONLY: it lists, it never writes.
 package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -34,43 +96,96 @@ var CNPGClusterGVR = schema.GroupVersionResource{
 }
 
 // InstanceLabel is the standard Helm/Kubernetes label a chart stamps on the
-// resources it renders, carrying the Helm release name. The bp-postgres /
-// cnpg-pair chart stamps it on each CNPG Cluster it creates, so it is the
-// stable link from an Application's per-cluster HelmRelease (whose name is the
-// release name) back to the CNPG Cluster CR that HelmRelease installed. Walked
-// live on hw291: the collapsed CNPG carried
-// `app.kubernetes.io/instance=uatwalk-ahs-07300830-rtz-a` (= the HR name).
+// resources it renders, carrying the Helm release name. Charts stamp it on the
+// backing objects they create, so it is the stable link from an Application's
+// per-cluster HelmRelease (whose name IS the release name) back to the objects
+// that HelmRelease installed. Walked live on hw292: the per-Org CNPG Cluster
+// `hw292-omani-works/postgres` carries
+// `app.kubernetes.io/instance=uat-ahs-pg-rtz-a` (= the HR name).
 const InstanceLabel = "app.kubernetes.io/instance"
 
-// backingCNPGUnrecoverable reports whether any CNPG Cluster CR backing this
-// Application is in CNPG's terminal `unrecoverable` phase. It returns the
-// namespace + name of the first such Cluster and true; ("", "", false) when
-// none is unrecoverable (including when there is no CNPG backing at all).
+// backingState is the three-state verdict for one backing object (and, rolled
+// up, for the whole Application). Ordered by precedence: a definite not-ready
+// verdict outranks an unobservable one, which outranks ready. Never reorder —
+// the rollup relies on the ordering.
+type backingState int
+
+const (
+	backingReady backingState = iota
+	backingUnobservable
+	backingNotReady
+)
+
+// backingVerdict is the rolled-up observation the status gate consults.
+type backingVerdict struct {
+	state backingState
+	// reason is the condition reason to stamp (empty when state is
+	// backingReady).
+	reason string
+	// detail is a human sentence naming the object and WHY, so the operator
+	// reading `kubectl describe application` learns which backing object to
+	// look at rather than just "something is wrong".
+	detail string
+}
+
+// backingKind describes one backing-resource kind the readiness gate observes,
+// and how to read readiness out of an instance of it. Adding a kind to the
+// registry is a data change here — the gate itself stays kind-agnostic.
+type backingKind struct {
+	// GVR is the resource to list.
+	GVR schema.GroupVersionResource
+	// Label is the human name used in operator-facing messages.
+	Label string
+	// Readiness classifies one object of this kind. It returns the state and
+	// a short detail phrase (no object name — the caller prefixes that).
+	// It must return backingUnobservable — never backingReady — when the
+	// object publishes no readiness signal it understands.
+	Readiness func(*unstructured.Unstructured) (backingState, string)
+}
+
+// backingKinds is the registry the gate walks. It is deliberately small: a kind
+// belongs here only when (a) an Application's HelmRelease can be Ready while
+// that kind is dead, and (b) the kind publishes a readiness signal we can read.
+var backingKinds = []backingKind{
+	{
+		GVR:       CNPGClusterGVR,
+		Label:     "CNPG Cluster",
+		Readiness: cnpgClusterReadiness,
+	},
+}
+
+// observeBackingReadiness rolls up the readiness of every backing object this
+// Application installed, across every registered kind.
 //
-// Discovery: the backing CNPG Cluster carries `app.kubernetes.io/instance` set
-// to the Helm release name of the HelmRelease that installed it — i.e. each
-// per-cluster HR name (the fan-out path) or the bare Application name (the
-// legacy single-HR host path). We search that label across the namespaces the
-// HRs were authored in, plus the Application's own namespace, so a CNPG routed
-// host-side (#4398) or landed in a vCluster host-ns is found either way.
+// Discovery: a backing object carries `app.kubernetes.io/instance` set to the
+// Helm release name of the HelmRelease that installed it — i.e. each per-cluster
+// HR name (the fan-out path) or the bare Application name (the legacy single-HR
+// host path). We search that label across the namespaces the HRs were authored
+// in, plus the Application's own namespace, so a backing routed host-side
+// (#4398) or landed in a vCluster host-ns is found either way.
 //
-// Read-only + failure-tolerant: a List error (CNPG CRD absent → the fake/real
-// dynamic client returns a no-kind error; or a transient API error) is skipped,
-// never surfaced as an unrecoverable verdict. The caller only downgrades on a
-// POSITIVE match, so a read failure can never manufacture a false Degraded.
-func (r *Reconciler) backingCNPGUnrecoverable(
+// Precedence: any definite not-ready wins; else any unobservable wins; else
+// ready. Read-only.
+func (r *Reconciler) observeBackingReadiness(
 	ctx context.Context,
 	app *unstructured.Unstructured,
 	perClusterStatus []map[string]interface{},
-) (namespace, name string, unrecoverable bool) {
+) backingVerdict {
 	if r == nil || r.Dynamic == nil || app == nil {
-		return "", "", false
+		// No client to observe with — that is an unobservable backing, not a
+		// healthy one. (In practice unreachable: the reconciler always has a
+		// client. Encoded anyway so the "no observation ⇒ not a pass" rule
+		// holds on every path.)
+		return backingVerdict{
+			state:  backingUnobservable,
+			reason: ReasonBackingUnverifiable,
+			detail: "no Kubernetes client available to observe backing resources",
+		}
 	}
 
 	// Build the (namespace, instance-label) work list from the materialised
 	// per-cluster HRs. Fall back to the bare Application identity when no
 	// fan-out ran (legacy single-HR host path).
-	type target struct{ ns, instance string }
 	nsSet := map[string]struct{}{app.GetNamespace(): {}}
 	var instances []string
 	for _, pcs := range perClusterStatus {
@@ -87,45 +202,217 @@ func (r *Reconciler) backingCNPGUnrecoverable(
 		instances = append(instances, app.GetName())
 	}
 
-	// De-dup (namespace × instance) probes.
-	seen := map[target]struct{}{}
-	for ns := range nsSet {
-		for _, inst := range instances {
-			t := target{ns: ns, instance: inst}
-			if _, ok := seen[t]; ok {
-				continue
-			}
-			seen[t] = struct{}{}
+	worst := backingVerdict{state: backingReady}
+	// promote keeps the highest-precedence verdict seen so far.
+	promote := func(v backingVerdict) {
+		if v.state > worst.state {
+			worst = v
+		}
+	}
 
-			list, err := r.Dynamic.Resource(CNPGClusterGVR).Namespace(t.ns).List(ctx, metav1.ListOptions{
-				LabelSelector: InstanceLabel + "=" + t.instance,
-			})
-			if err != nil {
-				// CNPG CRD absent or transient list error — never fabricate
-				// a downgrade on a read failure.
-				continue
-			}
-			for i := range list.Items {
-				if cnpgClusterUnrecoverable(&list.Items[i]) {
-					return t.ns, list.Items[i].GetName(), true
+	// De-dup (kind × namespace × instance) probes — the same HR name can
+	// appear under several namespaces in the work list.
+	type target struct {
+		gvr      schema.GroupVersionResource
+		ns       string
+		instance string
+	}
+	seen := map[target]struct{}{}
+	for _, bk := range backingKinds {
+		for ns := range nsSet {
+			for _, inst := range instances {
+				t := target{gvr: bk.GVR, ns: ns, instance: inst}
+				if _, ok := seen[t]; ok {
+					continue
+				}
+				seen[t] = struct{}{}
+
+				list, err := r.Dynamic.Resource(bk.GVR).Namespace(t.ns).List(ctx, metav1.ListOptions{
+					LabelSelector: InstanceLabel + "=" + t.instance,
+				})
+				if err != nil {
+					if backingKindAbsent(err) {
+						// Positive knowledge: this Sovereign has no such kind,
+						// so this Application has no backing of it. Not a
+						// failure, not an unobserved object — skip.
+						continue
+					}
+					// Forbidden / timeout / transient API error. We did NOT
+					// observe the backing; saying "ready" here is the #5955
+					// defect and saying "degraded" would fabricate a failure.
+					promote(backingVerdict{
+						state:  backingUnobservable,
+						reason: ReasonBackingUnverifiable,
+						detail: fmt.Sprintf("could not read %s objects in namespace %s (instance=%s): %v",
+							bk.Label, t.ns, t.instance, err),
+					})
+					continue
+				}
+				for i := range list.Items {
+					item := &list.Items[i]
+					state, why := bk.Readiness(item)
+					switch state {
+					case backingReady:
+						continue
+					case backingNotReady:
+						promote(backingVerdict{
+							state:  backingNotReady,
+							reason: backingNotReadyReason(why),
+							detail: fmt.Sprintf("backing %s %s/%s is not ready (%s)",
+								bk.Label, item.GetNamespace(), item.GetName(), why),
+						})
+					default:
+						promote(backingVerdict{
+							state:  backingUnobservable,
+							reason: ReasonBackingUnverifiable,
+							detail: fmt.Sprintf("backing %s %s/%s publishes no readiness signal (%s)",
+								bk.Label, item.GetNamespace(), item.GetName(), why),
+						})
+					}
 				}
 			}
 		}
 	}
-	return "", "", false
+	return worst
 }
 
-// cnpgClusterUnrecoverable reports whether a CNPG Cluster CR is in CNPG's
-// terminal `unrecoverable` phase. CNPG sets status.phase to a human string
-// (e.g. "Cluster in unrecoverable state" / "... unrecoverable and needs manual
-// intervention"); a case-insensitive substring match on "unrecoverable" is
-// robust across CNPG phrasings while staying specific to the terminal,
-// manual-intervention state (it does NOT trip on transient phases like
-// "Setting up primary" or "Cluster in healthy state").
-func cnpgClusterUnrecoverable(cr *unstructured.Unstructured) bool {
-	if cr == nil {
+// unrecoverableDetail is the marker a kind's Readiness func embeds in its
+// detail phrase to request the pre-existing, more specific
+// BackingClusterUnrecoverable reason (#5513) instead of the generic
+// BackingNotReady. Keeping that reason string stable matters: it is asserted by
+// the #5513 acceptance test and consumed by operator tooling.
+const unrecoverableDetail = "unrecoverable"
+
+func backingNotReadyReason(detail string) string {
+	if strings.Contains(strings.ToLower(detail), unrecoverableDetail) {
+		return ReasonBackingUnrecoverable
+	}
+	return ReasonBackingNotReady
+}
+
+// backingKindAbsent reports whether a List error means "this kind is not served
+// by this cluster" — a CRD that was never installed. That is positive knowledge
+// that there is nothing to observe, as opposed to a failure to observe
+// something that exists.
+//
+// The three shapes:
+//   - apierrors.IsNotFound — a real apiserver serving no such resource path
+//     ("the server could not find the requested resource").
+//   - meta.IsNoMatchError — the RESTMapper has no mapping for the GVR.
+//   - runtime.IsNotRegisteredError — the fake dynamic client used in tests has
+//     no list kind registered for the GVR.
+//
+// Everything else (Forbidden, Unauthorized, Timeout, ServiceUnavailable,
+// TooManyRequests, transport errors) is a failure to observe and must NOT land
+// here — that is precisely the class that made the #5513 guard inert on hw292.
+func backingKindAbsent(err error) bool {
+	if err == nil {
 		return false
 	}
+	return apierrors.IsNotFound(err) ||
+		meta.IsNoMatchError(err) ||
+		runtime.IsNotRegisteredError(err)
+}
+
+// cnpgClusterReadiness classifies one CNPG Cluster CR.
+//
+// Signal precedence, all field paths verified live on hw292 against 11 CNPG
+// Clusters (9 healthy controls + the 2 defective per-Org ones) rather than
+// guessed:
+//
+//  1. status.phase containing "unrecoverable" — CNPG's terminal,
+//     manual-intervention state. Kept as its own branch so the #5513 reason
+//     survives.
+//  2. status.conditions[type=Ready].status — the standard, kind-agnostic
+//     readiness contract. Live: "True" on all 9 healthy clusters, "False" on
+//     both defective per-Org clusters. This is the load-bearing signal.
+//  3. status.readyInstances vs status.instances — used only as a fallback when
+//     no Ready condition has been published yet, and as corroborating detail in
+//     the message. It is deliberately NOT the primary signal: the live control
+//     `catalyst-system/openova-flow-pg` reported instances=2 AND
+//     readyInstances=2 while its Ready condition was False (phase="Instance
+//     Status Extraction Error"), so gating on the counts alone would have
+//     false-passed a cluster the operator's own tooling calls broken.
+//
+// A Cluster with neither a Ready condition nor instance counts is
+// UNOBSERVABLE, not ready — a freshly-admitted CR that has published no status
+// is exactly the "failed after admission" window this gate exists to close.
+func cnpgClusterReadiness(cr *unstructured.Unstructured) (backingState, string) {
+	if cr == nil {
+		return backingUnobservable, "nil object"
+	}
+	status, hasStatus, _ := unstructured.NestedMap(cr.Object, "status")
+	if !hasStatus || len(status) == 0 {
+		return backingUnobservable, "no status published yet"
+	}
+
 	phase, _, _ := unstructured.NestedString(cr.Object, "status", "phase")
-	return strings.Contains(strings.ToLower(phase), "unrecoverable")
+	instances, hasInstances, _ := unstructured.NestedInt64(cr.Object, "status", "instances")
+	ready, hasReady, _ := unstructured.NestedInt64(cr.Object, "status", "readyInstances")
+
+	// Instance counts, rendered for the operator when we have them. Absent
+	// readyInstances is reported as absent, never as zero-and-therefore-fine.
+	counts := ""
+	switch {
+	case hasReady && hasInstances:
+		counts = fmt.Sprintf("%d/%d instances ready", ready, instances)
+	case hasInstances:
+		counts = fmt.Sprintf("status.readyInstances absent, %d instance(s) declared", instances)
+	}
+
+	detail := func(head string) string {
+		parts := []string{head}
+		if phase != "" {
+			parts = append(parts, "phase="+phase)
+		}
+		if counts != "" {
+			parts = append(parts, counts)
+		}
+		return strings.Join(parts, "; ")
+	}
+
+	// 1. CNPG's terminal state, kept specific.
+	if strings.Contains(strings.ToLower(phase), unrecoverableDetail) {
+		return backingNotReady, detail("cluster is unrecoverable and needs manual intervention")
+	}
+
+	// 2. The standard Ready condition.
+	switch cnpgReadyCondition(cr) {
+	case "True":
+		return backingReady, ""
+	case "False":
+		return backingNotReady, detail("status.conditions[type=Ready] is False")
+	case "Unknown":
+		return backingUnobservable, detail("status.conditions[type=Ready] is Unknown")
+	}
+
+	// 3. No Ready condition published. Fall back to the instance counts.
+	if hasInstances && hasReady {
+		if ready >= instances && instances > 0 {
+			return backingReady, ""
+		}
+		return backingNotReady, detail("no Ready condition published")
+	}
+	return backingUnobservable, detail("no Ready condition and no readyInstances published")
+}
+
+// cnpgReadyCondition returns the status of status.conditions[type=Ready], or ""
+// when no such condition exists.
+func cnpgReadyCondition(cr *unstructured.Unstructured) string {
+	conds, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	if err != nil || !found {
+		return ""
+	}
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := cm["type"].(string); t != "Ready" {
+			continue
+		}
+		s, _ := cm["status"].(string)
+		return s
+	}
+	return ""
 }

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1435,6 +1435,54 @@ type dependsOnDetail struct {
 // Application CR named `name` across every namespace on the Sovereign.
 //
 // qa-loop iter-11 Fix #45 Cluster-C.
+
+// backingVerdictReasons — #5955. The Ready-condition reasons the
+// application-controller stamps when it OBSERVED the backing resource a chart
+// installed and is reporting what it measured, rather than lagging behind Flux:
+//
+//	BackingNotReady               the backing was read and reports not-ready.
+//	BackingClusterUnrecoverable   the backing is in its terminal state (#5513).
+//	BackingReadinessUnverifiable  the backing could not be read at all, so
+//	                              readiness is explicitly unknown.
+//
+// A HelmRelease can be legitimately Ready under every one of these — Helm
+// applied the manifests and the apiserver accepted them; the workload died
+// afterwards. Promoting the response to Ready on the strength of that HR would
+// discard the only signal that measured the workload.
+var backingVerdictReasons = map[string]struct{}{
+	"BackingNotReady":              {},
+	"BackingClusterUnrecoverable":  {},
+	"BackingReadinessUnverifiable": {},
+}
+
+// applicationHoldsBackingVerdict reports whether the Application CR's Ready
+// condition carries a measured backing verdict, in which case the HR-Ready
+// overlay must not fire. Returns false for every other not-ready shape
+// (BootstrapAdopted, plain stale Provisioning, …) so the overlay keeps serving
+// the lag cases it was built for.
+func applicationHoldsBackingVerdict(obj *unstructured.Unstructured) bool {
+	if obj == nil {
+		return false
+	}
+	conds, ok, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !ok {
+		return false
+	}
+	for _, c := range conds {
+		cm, isMap := c.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		if t, _ := cm["type"].(string); t != "Ready" {
+			continue
+		}
+		reason, _ := cm["reason"].(string)
+		_, held := backingVerdictReasons[reason]
+		return held
+	}
+	return false
+}
+
 // applicationPrimaryRegion resolves an Application's primary region from its
 // CR status.
 //
@@ -1720,11 +1768,30 @@ func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 	// these apps and the operator saw FAILED/Provisioning (source:
 	// Application CR) while the HelmRelease was Ready. Fallback chain:
 	// spec.helmRelease.name → resp.ReleaseName.
+	//
+	// #5955 — the safety argument in (a) above is NO LONGER TRUE, and this is
+	// the whole reason the guard below exists. The controller no longer
+	// aggregates purely on HR-Ready: it also observes the BACKING resource the
+	// chart installed and deliberately holds the Application at
+	// Degraded / Ready=Unknown WHILE the HelmRelease is legitimately Ready,
+	// because a HelmRelease reporting Ready only means Helm applied the
+	// manifests and the apiserver accepted them. That is the controller's
+	// FINAL state, not a lag — so "racing it forward" would race it BACKWARD,
+	// past a measured verdict, and repaint the exact green badge over a dead
+	// database that #5955 fixed one layer down (Application
+	// hw292-omani-works/uat-ahs-pg, Ready=True over a CNPG Cluster whose own
+	// Ready condition was False with zero ready instances).
+	//
+	// The overlay therefore stays for the LAG shapes it was built for
+	// (#4889 spine/bootstrap adoption, C4-003 stale Provisioning) and is
+	// suppressed only when the CR's own Ready-condition reason says the
+	// controller MEASURED the workload and is reporting what it found.
 	hrLookupName := resp.ReleaseName
 	if hrn, ok, _ := unstructured.NestedString(obj.Object, "spec", "helmRelease", "name"); ok && hrn != "" {
 		hrLookupName = hrn
 	}
-	if isHRReady := h.helmReleaseReadyByName(r.Context(), depID, hrLookupName); isHRReady && resp.Phase != "Ready" {
+	if isHRReady := h.helmReleaseReadyByName(r.Context(), depID, hrLookupName); isHRReady &&
+		resp.Phase != "Ready" && !applicationHoldsBackingVerdict(obj) {
 		resp.HRReady = true
 		resp.PhaseFromCR = resp.Phase
 		resp.Phase = "Ready"

--- a/products/catalyst/bootstrap/api/internal/handler/applications_backing_verdict_5955_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_backing_verdict_5955_test.go
@@ -1,0 +1,109 @@
+// applications_backing_verdict_5955_test.go — #5955, the API layer.
+//
+// GET /…/apps/{id} carries an HR-Ready OVERLAY: when the Application CR's phase
+// is not Ready but the matching HelmRelease reports Ready=True, the response
+// phase is promoted to "Ready". It was built for LAG (#4889 spine/bootstrap
+// adoption, C4-003 stale Provisioning) on an argument the code states outright:
+// "the catalyst controller already aggregates on HR-Ready, so we're only racing
+// it forward, never against its final state".
+//
+// #5955 falsified that premise. The controller now observes the BACKING
+// resource a chart installed and deliberately holds the Application at
+// Degraded / Ready=Unknown WHILE the HelmRelease is legitimately Ready — a
+// HelmRelease reporting Ready only means Helm applied the manifests and the
+// apiserver accepted them. That is the controller's FINAL state, so an
+// unconditional overlay races it BACKWARD past a measured verdict and repaints
+// the same green badge over a dead database one layer up, where the operator
+// actually looks.
+//
+// Both directions asserted: the overlay must stay suppressed on a measured
+// backing verdict, and must still fire on every lag shape it was built for.
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func appWithReadyCondition(status, reason string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apps.openova.io/v1")
+	u.SetKind("Application")
+	u.SetNamespace("hw292-omani-works")
+	u.SetName("uat-ahs-pg")
+	u.Object["status"] = map[string]interface{}{
+		"phase": "Degraded",
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "Reconciling", "status": "False", "reason": "Idle"},
+			map[string]interface{}{"type": "Ready", "status": status, "reason": reason},
+		},
+	}
+	return u
+}
+
+// TestApplicationHoldsBackingVerdict_SuppressesOverlay — the failing-pre-fix
+// direction. Each of these reasons means the controller READ the workload (or
+// established it could not) and is reporting that. The HR-Ready overlay must
+// not overwrite it.
+func TestApplicationHoldsBackingVerdict_SuppressesOverlay(t *testing.T) {
+	cases := []struct {
+		reason string
+		status string
+	}{
+		{"BackingNotReady", "False"},
+		{"BackingClusterUnrecoverable", "False"},
+		{"BackingReadinessUnverifiable", "Unknown"},
+	}
+	for _, c := range cases {
+		obj := appWithReadyCondition(c.status, c.reason)
+		if !applicationHoldsBackingVerdict(obj) {
+			t.Errorf("applicationHoldsBackingVerdict(reason=%q) = false — the HR-Ready overlay would "+
+				"promote this Application to Ready over a workload the controller measured as not ready", c.reason)
+		}
+	}
+}
+
+// TestApplicationHoldsBackingVerdict_LeavesLagShapesAlone — the no-regression
+// direction. Every not-ready shape that is genuinely a LAG behind Flux must
+// keep letting the overlay through, or #4889 (spine/bootstrap apps rendering
+// FAILED while their adopted HelmRelease is Ready) comes straight back.
+func TestApplicationHoldsBackingVerdict_LeavesLagShapesAlone(t *testing.T) {
+	for _, reason := range []string{
+		"BootstrapAdopted", // #4889 — the live spine-* / harbor / shared-pg shape
+		"Reconciled",
+		"DownstreamHelmReleaseFailed",
+		"GiteaError",
+		"", // no reason recorded
+	} {
+		obj := appWithReadyCondition("False", reason)
+		if applicationHoldsBackingVerdict(obj) {
+			t.Errorf("applicationHoldsBackingVerdict(reason=%q) = true — suppressing the overlay here "+
+				"regresses the lag cases the overlay exists for", reason)
+		}
+	}
+}
+
+// TestApplicationHoldsBackingVerdict_MissingSignals — an Application with no
+// status, no conditions, or no Ready condition holds no verdict. Absence of a
+// verdict is not a verdict; the overlay's own behaviour governs those.
+func TestApplicationHoldsBackingVerdict_MissingSignals(t *testing.T) {
+	if applicationHoldsBackingVerdict(nil) {
+		t.Errorf("applicationHoldsBackingVerdict(nil) = true, want false")
+	}
+	bare := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if applicationHoldsBackingVerdict(bare) {
+		t.Errorf("applicationHoldsBackingVerdict(no status) = true, want false")
+	}
+	noReady := &unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"phase": "Provisioning",
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Reconciling", "status": "True", "reason": "Working"},
+			},
+		},
+	}}
+	if applicationHoldsBackingVerdict(noReady) {
+		t.Errorf("applicationHoldsBackingVerdict(no Ready condition) = true, want false")
+	}
+}

--- a/products/catalyst/chart/templates/controllers/application-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/application-controller-clusterrole.yaml
@@ -103,4 +103,34 @@ rules:
   - apiGroups: ["dr.openova.io"]
     resources: ["continuums"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # #5955 — the Application readiness gate observes the BACKING resources a
+  # chart installs, because a Flux HelmRelease reporting Ready=True only means
+  # Helm applied the manifests and the apiserver accepted them. Anything that
+  # fails AFTER admission leaves the HR legitimately Ready over a dead
+  # workload.
+  #
+  # #5513 shipped that observation for CNPG Clusters WITHOUT this grant, so on
+  # every Sovereign the List returned Forbidden, the code skipped the error,
+  # and the guard could not fail no matter how dead the database was. Measured
+  # on hw292 2026-08-09:
+  #
+  #   kubectl auth can-i list clusters.postgresql.cnpg.io -n hw292-omani-works \
+  #     --as=system:serviceaccount:catalyst-system:catalyst-application-controller
+  #   -> no
+  #   # control, same impersonation, kind the controller DOES observe:
+  #   kubectl auth can-i list helmreleases.helm.toolkit.fluxcd.io -n hw292-omani-works \
+  #     --as=system:serviceaccount:catalyst-system:catalyst-application-controller
+  #   -> yes
+  #
+  # Application hw292-omani-works/uat-ahs-pg was therefore Ready=True over a
+  # CNPG Cluster whose own status.conditions[Ready] was False with
+  # status.readyInstances absent — on 2 of 2 per-Org Postgres clusters.
+  #
+  # READ-ONLY on purpose: the controller observes backing health, it never
+  # mutates backing objects (Flux owns those writes). Without this grant the
+  # #5955 gate can only ever report Ready=Unknown / BackingReadinessUnverifiable
+  # — correct, but useless.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch"]
 {{- end }}


### PR DESCRIPTION
## The defect

An Application reported `Ready=True` over a database with **zero ready instances**, on 2 of 2 per-Org Postgres clusters. Its own condition message named the mechanism:

> `Application hw292-omani-works/uat-ahs-pg installed across 2 region(s); Ready=True from downstream HelmRelease(s)`

Readiness was derived **solely from HelmRelease readiness**. The HelmReleases were legitimately `True` — Helm rendered valid YAML and the apiserver accepted the `Cluster` CR. Nothing in the chain ever read the backing object's own readiness, so **any backing resource that fails AFTER admission produced a green badge over a dead workload**. That is a class, not a Postgres bug.

Live status key sets, dumped read-only off hw292 (the key SET was dumped, not guessed, so `readyInstances` absent is recorded as absent rather than as `0`):

```
control  shared-data/shared-pg           instances=3 readyInstances=3 Ready=True
control  cnpg/cnpg-pair-primary          instances=3 readyInstances=3 Ready=True
control  catalyst-system/openova-flow-pg instances=2 readyInstances=2 Ready=FALSE
PER-ORG  hw292-omani-works/postgres      instances=1 readyInstances=ABSENT Ready=False
PER-ORG  uatco/postgres                  instances=1 readyInstances=ABSENT Ready=False
```

## Two independent causes, both fixed

**1 — the gate asked the wrong question.** #5513 checked one narrow condition, "is `status.phase` `unrecoverable`?". The live clusters sat at `"Setting up primary"`, so the answer was no and the Application settled on Ready. `observeBackingReadiness` now consults the backing object's own `status.conditions[type=Ready]` — the same contract the controller already trusts for HelmReleases — over a registry of backing kinds (`backingKinds`), so adding a kind is a data change rather than a change at the gate.

**2 — the gate could not fail at all.** #5513 shipped that read with no RBAC grant for it, so on every Sovereign the `List` returned Forbidden and the code skipped the error. Measured read-only on hw292, with a control sharing the suspect property:

```
$ kubectl auth can-i list clusters.postgresql.cnpg.io -n hw292-omani-works \
    --as=system:serviceaccount:catalyst-system:catalyst-application-controller
no
$ kubectl auth can-i list helmreleases.helm.toolkit.fluxcd.io -n hw292-omani-works \
    --as=system:serviceaccount:catalyst-system:catalyst-application-controller
yes
```

Both ClusterRoles now grant `get/list/watch` on `postgresql.cnpg.io/clusters`, read-only — Flux owns the writes. Without the grant the corrected gate would be honest but useless: it could only ever answer "unverifiable".

## Three states, never two

This distinction is the substance of the change:

| state | meaning | Application reports |
|---|---|---|
| `backingReady` | every observed backing publishes `Ready=True` — **and** the answer when there is no backing of a registered kind | `Ready=True`, unchanged |
| `backingNotReady` | the backing was **read** and says it is not ready | `Degraded`, `Ready=False`, reason `BackingNotReady` |
| `backingUnobservable` | the backing could **not be read** (Forbidden / timeout / API error), or exists but published no readiness | `Ready=Unknown`, reason `BackingReadinessUnverifiable` |

Collapsing "I could not look" into "healthy" is what turned a missing permission into a false green. Collapsing it into "broken" would fabricate a failure nobody measured. `Unknown` is the honest third answer, and the CRD already admits it (`enum: ["True","False","Unknown"]`).

The one read error that is **not** unobservable is "this kind is not served here" (`NotFound` / no-kind-match) — positive knowledge that there is nothing to observe. Without that branch, every Application on a Postgres-free Sovereign would rotate to Unknown.

## Why the Ready condition and not the instance counts

The `catalyst-system/openova-flow-pg` control settled it: `readyInstances == instances == 2` while its own Ready condition was `False` (phase `"Instance Status Extraction Error"`). A gate keyed on the counts would have false-passed a cluster the operator's own tooling calls broken. The counts are corroborating detail in the operator-facing message and a fallback when no Ready condition has been published; the condition is the load-bearing signal.

## Proof the test can fail

Reverting **only** the gate to its pre-fix behaviour, with the tests unchanged, reproduces the live condition string verbatim:

```
--- FAIL: TestReconcile_5955_ReadyHR_BackingZeroReadyInstances_NotReady (0.00s)
    application_controller_5955_test.go:117: Ready condition = True over a backing CNPG with
    status.conditions[Ready]=False and status.readyInstances absent — the #5955 green badge over
    a dead database (phase="Ready" reason="Reconciled" msg="Application acme/obs installed across
    1 region(s); Ready=True from downstream HelmRelease(s)")
--- FAIL: TestReconcile_5955_BackingForbidden_IsUnverifiableNotReady (0.00s)
    application_controller_5955_test.go:219: Ready condition = True while the backing read was
    Forbidden — a missing RBAC grant must never render as a healthy workload (phase="Ready"
    reason="Reconciled" msg="Application acme/obs installed across 1 region(s); Ready=True from
    downstream HelmRelease(s)")
FAIL
```

The three no-regression controls (`HealthyBacking_StaysReady`, `NoBackingResource_StaysReady`, `BackingKindAbsent_StaysReady`) pass under **both** gates — correctly, since they are bars rather than defect detectors.

## Fixture correction

The #5513 fixtures were phase-only. Every live CNPG Cluster publishes a Ready condition alongside the phase, and the new gate treats an object publishing no readiness as unobservable — so a phase-only fixture would have exercised the unobservable path while claiming to exercise the healthy one. `makeCNPGCluster` now builds the full live shape; `makeCNPGClusterWithStatus` takes a verbatim status map for the exact per-Org shape.

## Verification

`go build ./... && go vet ./... && go test ./... && scripts/check-no-banned-words.sh`, chained, all green in `core/controllers/application`. Both ClusterRoles parse and carry the rule. No live-cluster writes were made — every live observation in this PR is `kubectl get` / `auth can-i`.

Refs #5955
Refs #5513
UAT row 238

---

## Second commit: the same defect one layer up, which would have hidden the first

`GET /…/apps/{id}` carries an **HR-Ready overlay** (`applications.go`): when the Application CR's phase is not Ready but the matching HelmRelease reports `Ready=True`, the response phase is promoted to `"Ready"`. It was built for lag shapes (#4889 spine/bootstrap adoption, C4-003 stale Provisioning) on an argument the code states outright:

> `(a) the catalyst controller already aggregates on HR-Ready, so we're only racing it forward, never against its final state`

The first commit falsifies that premise. The controller now deliberately holds an Application at Degraded / `Ready=Unknown` **while** the HelmRelease is legitimately Ready — that is its final state, not a lag. An unconditional overlay races it *backward* past a measured verdict and repaints the identical green badge on the console, where the operator actually looks. **The controller fix would have been invisible.**

The overlay is now suppressed only when the CR's own Ready-condition reason says the controller measured the workload (`BackingNotReady`, `BackingClusterUnrecoverable`, `BackingReadinessUnverifiable`). Every other not-ready shape still lets it through, so the lag cases it exists for are untouched — asserted against the live `BootstrapAdopted` shape that #4889 fixed (`spine-gitea`, `spine-harbor`, `harbor`, `shared-pg` all sit at `phase=Degraded reason=BootstrapAdopted` over Ready HelmReleases on hw292).

Removing the guard turns the suppression test red:

```
--- FAIL: TestApplicationHoldsBackingVerdict_SuppressesOverlay (0.00s)
    applicationHoldsBackingVerdict(reason="BackingNotReady") = false — the HR-Ready overlay
    would promote this Application to Ready over a workload the controller measured as not ready
    ... same for BackingClusterUnrecoverable and BackingReadinessUnverifiable
```

The neighbouring runtime-synth path (`applications_runtime_synth_5827.go`) was checked and left alone: it derives phase from actual Pod readiness for HR-only Applications with no CR, which is the correct pattern rather than another instance of this one.
