### PR TITLE
fix(catalog): seed bp-openova-mcp so the per-Org MCP is installable, and gate the source→seed direction

### DIFF
--- a/.github/workflows/check-catalog-seed-lockstep.yaml
+++ b/.github/workflows/check-catalog-seed-lockstep.yaml
@@ -14,7 +14,14 @@ name: catalog-seed lockstep guard
 # delivery pin resolves to a real published tag on ghcr.io — the one seed
 # property no in-repo guard can see. See the script header for why.
 #
-# Refs G117 #2744, #5559.
+# The third job (`source-coverage`, #5843) runs the OPPOSITE direction. Both
+# jobs above — and every other seed guard in the repo — iterate the SEED and
+# look outward, so a Blueprint that ships a chart with NO seed entry is not
+# failing any of them, it is invisible to all of them. bp-openova-mcp sat in
+# that blind spot for six chart releases and was uninstallable the whole time.
+# See scripts/check-catalog-seed-source-coverage.py.
+#
+# Refs G117 #2744, #5559, #5843.
 
 on:
   push:
@@ -22,17 +29,29 @@ on:
     paths:
       - 'products/catalyst/chart/templates/catalog-seed/blueprints.yaml'
       - 'platform/**/blueprint.yaml'
+      - 'products/**/blueprint.yaml'
+      - 'platform/*/chart/Chart.yaml'
+      - 'products/*/chart/Chart.yaml'
       - 'scripts/check-catalog-seed-lockstep.sh'
+      - 'scripts/check-catalog-seed-source-coverage.py'
       - 'scripts/expected-unpublished-catalog-seed-pins.yaml'
+      - 'scripts/expected-unseeded-blueprints.yaml'
       - 'scripts/lib/parse-catalog-seed-pins.awk'
+      - 'scripts/sync-catalog-seed-pin.py'
       - '.github/workflows/check-catalog-seed-lockstep.yaml'
   pull_request:
     paths:
       - 'products/catalyst/chart/templates/catalog-seed/blueprints.yaml'
       - 'platform/**/blueprint.yaml'
+      - 'products/**/blueprint.yaml'
+      - 'platform/*/chart/Chart.yaml'
+      - 'products/*/chart/Chart.yaml'
       - 'scripts/check-catalog-seed-lockstep.sh'
+      - 'scripts/check-catalog-seed-source-coverage.py'
       - 'scripts/expected-unpublished-catalog-seed-pins.yaml'
+      - 'scripts/expected-unseeded-blueprints.yaml'
       - 'scripts/lib/parse-catalog-seed-pins.awk'
+      - 'scripts/sync-catalog-seed-pin.py'
       - '.github/workflows/check-catalog-seed-lockstep.yaml'
   workflow_dispatch:
   # #5559 — publish-lag safety net, same cadence rationale as the #4409 cron on
@@ -96,3 +115,25 @@ jobs:
           # package-listing call picks up the `packages: read` scope above.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/check-catalog-seed-lockstep.sh --check-ghcr
+
+  source-coverage:
+    # #5843 — the SOURCE→SEED direction. Every charted Blueprint under
+    # platform/ + products/ must be carried by the catalog seed, or declared
+    # in scripts/expected-unseeded-blueprints.yaml with a reason.
+    #
+    # Blocking on every event including `schedule`: unlike the GHCR phase there
+    # is no publish race to tolerate here — both sides of this comparison are
+    # files in this very commit.
+    name: source→seed coverage (#5843)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+      - name: Prove the guard can fail before trusting that it passed
+        run: python3 scripts/check-catalog-seed-source-coverage.py --self-test
+      - name: Assert every charted Blueprint is seeded or declared
+        run: python3 scripts/check-catalog-seed-source-coverage.py

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1343,7 +1343,14 @@ spec:
       #   land (every such token 403s incl. sys/internal/ui/mounts, and the UI
       #   reads "Not authorized" on a session that authenticated fine).
       #   Lockstep w/ slot-08 + platform/openbao/blueprint.yaml.
-      version: 1.4.1330
+      # 1.4.1331 (#5843, Refs #3988 / UAT rows 212-213): the catalog-seed gains
+      #   its first bp-openova-mcp entry (0.1.6). Without it no Blueprint CR
+      #   named bp-openova-mcp exists on any Sovereign, so the per-Org install
+      #   door cannot resolve the blueprint it is built to stamp. The seed
+      #   renders INSIDE this umbrella, so the entry only reaches a Sovereign
+      #   once the umbrella republishes and this pin advances (#5734).
+      #   Lockstep w/ products/catalyst/chart/Chart.yaml + slot-13d (0.1.6).
+      version: 1.4.1331
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3749,7 +3749,15 @@ name: bp-catalyst-platform
 #   file's version to move in the SAME PR as any catalog-seed pin move, else
 #   the published bp-catalyst-platform OCI artifact never carries the pin.
 #   Serialized to 1.4.1329 because #5764 took 1.4.1328 on main first.
-version: 1.4.1330
+# 1.4.1331 (#5843, Refs #3988 / UAT rows 212-213): the catalog-seed gains a
+#   bp-openova-mcp entry (0.1.6) — it had NONE, so no Blueprint CR named
+#   bp-openova-mcp has ever existed on any Sovereign and the per-Org install
+#   door (application_parameters.go stampOpenovaMCPOrgParameters) could not
+#   resolve its own blueprint. On a pre-cutover Sovereign the in-cluster
+#   Blueprint CR list is the ONLY catalog leg that answers, and those CRs are
+#   whatever the LAST PUBLISHED umbrella rendered — hence this republish, per
+#   check-umbrella-republish-gate.py (#5734). Lockstep w/ slot-13 pin.
+version: 1.4.1331
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3899,7 +3907,12 @@ version: 1.4.1330
 #   unsatisfiable on kom4dc (me-east-215-*), which kept the production
 #   Continuum seed unfireable. Backwards-compatible (all-letter labels
 #   still match). Flux CreateReplace flows it to live Sovereigns.
-appVersion: 1.4.1329
+# 1.4.1331 (#5843): moved WITH `version:` above. scripts/bump-chart-version.sh
+# writes next = max(version, appVersion) + 1 into BOTH fields, and
+# scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
+# main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
+# it in the same commit, exactly as the documented self-heal contract does.
+appVersion: 1.4.1331
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6091,4 +6091,114 @@ spec:
     silentLogin: true
   multiInstance:
     enabled: false
+---
+# bp-openova-mcp (#5843, Refs #3988 / UAT rows 212-213) — the per-Org MCP
+# instance's ONLY install door.
+#
+# Why this entry has to exist, stated as the mechanism rather than as a
+# convention: `POST /applications` resolves a requested blueprint through
+# chainedCatalogClient, whose LAST leg is the in-cluster Blueprint CR LIST
+# (catalog_client_cluster_fallback.go). On a pre-cutover Sovereign the two
+# earlier legs — the gitea `catalog` / `catalog-sovereign` Orgs — are EMPTY
+# (they are populated by bp-self-sovereign-cutover step 1, dormant until
+# post-handover), so that fallback is the ONLY leg that ever answers. The CRs
+# it lists are exactly what THIS template renders. bp-openova-mcp was absent
+# from it, so no Blueprint CR named bp-openova-mcp has ever existed on any
+# Sovereign (measured on hw292: 80 CRs labelled managed-by=catalog-seed, zero
+# matching *mcp*), and the per-Org install door could not resolve its own
+# blueprint — while the door itself is BUILT and on by default:
+# products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+# stampOpenovaMCPOrgParameters (:144 dispatch, :515-521 body) stamps
+# mode="organization", the per-Org httpRoute.hostnames and the RS256 pubkey
+# Secret ref, wired at applications.go:1196 + endpoint_handler.go:2387.
+# That is the whole of UAT rows 212/213's "undelivered surface": not a missing
+# chart, not a missing door — a missing catalog row.
+#
+# The sovereign-mode instance is UNAFFECTED by this entry: it installs from
+# bootstrap-kit slot 13d (clusters/_template/bootstrap-kit/13d-bp-openova-mcp.yaml)
+# and reconcileBootstrapOwned never reads the Blueprint CR's version.
+#
+# visibility: unlisted — VERBATIM from products/openova-mcp/blueprint.yaml:53.
+# This is infrastructure: the per-Org instance installs through the
+# Application-CR door, never as a marketplace card. The USER-facing Pillar-4
+# card is bp-agenity (above), which CONSUMES this MCP.
+#
+# Lockstep with products/openova-mcp/chart/Chart.yaml 0.1.6 + the published
+# chart ghcr.io/openova-io/bp-openova-mcp:0.1.6 + products/openova-mcp/
+# blueprint.yaml spec.version 0.1.6 + bootstrap-kit slot 13d pin 0.1.6. The
+# earlier Chart.yaml notes read "not in catalog-seed, matching the 0.1.3/0.1.4
+# precedent" — that precedent WAS the defect, and it was invisible because
+# scripts/check-catalog-seed-lockstep.sh iterates seed→source, so a blueprint
+# with no seed entry is structurally unreachable by it. The opposite direction
+# is now enforced by scripts/check-catalog-seed-source-coverage.py.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-openova-mcp
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: ai-runtime
+    catalyst.openova.io/section: pts-4-7-agentic-workspace
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  # 0.1.6 — lockstep with products/openova-mcp/chart/Chart.yaml (appVersion
+  # 0.2.5). 0.1.5 (#5206) added the per-Org install door + made an Org-scoped
+  # caller reaching a Sovereign-pinned instance a clear identity error instead
+  # of a silent context relabel; 0.1.4 (#5175) added the fail-closed
+  # whoami-delegated verify so post-handover SESSION tokens are accepted;
+  # 0.1.3 (#5167) made verify=rs256 parse the JWK mirror a Sovereign actually
+  # seeds. All three are why a per-Org instance is worth installing at all.
+  version: "0.1.6"
+  visibility: unlisted
+  card:
+    title: "OpenOva MCP"
+    category: ai-runtime
+    family: agent-runtime
+    summary: "The RBAC-scoped OpenOva MCP server — exposes Applications, Environments and Organizations as MCP tools whose surface is exactly what the calling User can do in the console."
+    description: "A thin facade over the live catalyst-api: every data tool forwards the caller's own bearer, so the platform's authz is the final word and the server holds no privileged token. mode=organization pins the instance to a single Organization's scope and tool subset."
+    icon: openova-mcp.svg
+    license: "MIT"
+    tags: [mcp, agent, rbac, thin-facade, pillar-4]
+    docs: "https://github.com/openova-io/openova"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-openova-mcp
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-openova-mcp
+    version: 0.1.6
+  topology:
+    supported:
+      - singleton
+    defaults:
+      # A stateless per-context facade — region-pinned singleton; both BCP
+      # defaults resolve to the single in-region instance. VERBATIM from
+      # products/openova-mcp/blueprint.yaml.
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          # tier MUST be '' (host-native): a per-Org install lands in the
+          # Org's own namespace on the HOST. #4325 de-vclustered mgmt/rtz/dmz
+          # into native host namespaces, so a non-empty tier resolves through
+          # VClusterPlacements to the removed `rtz` namespace → Degraded
+          # `namespaces "rtz" not found` (the bp-agenity 0.5.10 lesson above).
+          # `rtz-A` is the region designator, NOT a vCluster.
+          tier: ''
+          clusters: [rtz-A]
+          roles:
+            rtz-A: singleton
+  # No endpoints[] and no sso block — the MCP is an agent-facing JSON-RPC API,
+  # not a browser UI, so there is nothing for the console's Launch button to
+  # open. Matches products/openova-mcp/blueprint.yaml, which declares neither.
+  multiInstance:
+    enabled: false
 {{- end }}

--- a/scripts/check-catalog-seed-source-coverage.py
+++ b/scripts/check-catalog-seed-source-coverage.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""check-catalog-seed-source-coverage.py — the SOURCE→SEED direction (issue #5843).
+
+What this closes
+────────────────
+Every existing catalog-seed guard walks the seed and looks OUTWARD:
+
+  * scripts/check-catalog-seed-lockstep.sh  — for each Blueprint IN THE SEED,
+    compare its fields against platform/<x>/blueprint.yaml (:108 `for bp_name in
+    $bp_names`, sourced from the RENDERED seed);
+  * TestCatalogSeed_DeliveryPinsNotBehindComponentCharts (#4415) — for each
+    `source:` block IN THE SEED, compare source.version against the component
+    Chart.yaml;
+  * TestCatalogSeed_DisplayVersionNotBehindDeliveryPin (#4432) — same, spec.version;
+  * check-catalog-seed-lockstep.sh --check-ghcr (#5559) — for each delivery pin
+    IN THE SEED, assert the tag exists on GHCR;
+  * check-umbrella-republish-gate.py (#5734) — for each pin IN THE SEED, assert
+    the umbrella republished after it moved.
+
+Every one of them iterates the seed. A Blueprint that ships a chart and has NO
+seed entry at all is therefore not "failing" any of them — it is INVISIBLE to
+all of them, structurally. There is no assertion anywhere in the repo that the
+seed COVERS the source tree.
+
+That blind spot is not hypothetical. bp-openova-mcp shipped a published chart
+(ghcr.io/openova-io/bp-openova-mcp, six releases 0.1.0…0.1.6), a blueprint.yaml,
+a bootstrap-kit slot (13d) and a purpose-built per-Org install door in
+catalyst-api (application_parameters.go stampOpenovaMCPOrgParameters) — with
+ZERO seed entry, for six releases, every gate green. The consequence was total:
+on a pre-cutover Sovereign the gitea `catalog` / `catalog-sovereign` Orgs are
+empty (they are populated by bp-self-sovereign-cutover step 1, dormant until
+post-handover), so chainedCatalogClient's in-cluster Blueprint CR leg is the
+ONLY leg that ever answers, and those CRs are exactly what the seed renders. No
+seed entry ⇒ no Blueprint CR ⇒ `POST /applications` cannot resolve the blueprint
+⇒ the per-Org MCP is uninstallable. Measured on hw292: 80 Blueprint CRs labelled
+managed-by=catalog-seed, zero named *mcp*. UAT rows 212/213 sat ❌ on it.
+
+What this asserts
+─────────────────
+For every `platform/<x>/` and `products/<x>/` directory that ships BOTH a
+`blueprint.yaml` AND a `chart/Chart.yaml` (i.e. it is a real, deliverable
+Blueprint in this monorepo), the catalog seed must carry an entry for it —
+matched on the chart name, or on the Blueprint's own metadata.name.
+
+Anything genuinely excluded is declared, with a reason, in
+`scripts/expected-unseeded-blueprints.yaml`. That register is held to three
+self-retiring invariants so it cannot rot into a silencer:
+
+  1. A declared chart that IS seeded  → FAIL (stale row; delete it). The
+     register retires itself the moment the gap is closed.
+  2. A declared chart with no matching source directory → FAIL (dead row).
+  3. Every row must carry a non-empty `reason` and the `source` path it lives
+     at → FAIL otherwise. "Excluded" must always name WHY and WHERE.
+
+Vacuity guards (a negative assertion that runs zero times is not a gate):
+  * zero charted blueprints discovered            → exit 2 (the walker broke)
+  * zero seed entries parsed                      → exit 2 (the parser broke)
+  * zero discovered blueprints resolved as seeded → exit 2 (the match broke —
+    the tree has dozens of seeded charts, so "none matched" is a parser fault,
+    never dozens of simultaneous defects; same shape as the #5559 control probe)
+
+The seed parser is IMPORTED from scripts/sync-catalog-seed-pin.py rather than
+re-implemented, so there is no second copy of the catalog-seed shape to drift
+away from the thing this guards (same rationale as check-umbrella-republish-
+gate.py and check-release-lockstep-writer.py).
+
+Exit codes:
+  0 — every charted Blueprint is either seeded or declared in the register
+  1 — at least one charted Blueprint is neither, or a register invariant broke
+  2 — usage / parse / tooling error, or a vacuity guard tripped
+
+Usage:
+  scripts/check-catalog-seed-source-coverage.py
+  scripts/check-catalog-seed-source-coverage.py --register <path>
+  scripts/check-catalog-seed-source-coverage.py --self-test
+
+Refs #5843 #3988
+"""
+
+import argparse
+import importlib.util
+import os
+import re
+import sys
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SEED_PATH = os.path.join(
+    "products", "catalyst", "chart", "templates", "catalog-seed", "blueprints.yaml"
+)
+REGISTER_PATH = os.path.join("scripts", "expected-unseeded-blueprints.yaml")
+SOURCE_TREES = ("platform", "products")
+
+# Top-level `name:` of a Helm Chart.yaml (column 0 — the chart's own name, not
+# a dependency's, which is indented).
+_RE_CHART_NAME = re.compile(r'^name:\s*"?([A-Za-z0-9][A-Za-z0-9._-]*)"?\s*$')
+# metadata.name of a blueprint.yaml (2-space, the only 2-space `name:` key).
+_RE_BP_NAME = re.compile(r'^  name:\s*"?([A-Za-z0-9][A-Za-z0-9._-]*)"?\s*$')
+
+
+def _load_seed_parser():
+    """Import scripts/sync-catalog-seed-pin.py (hyphenated filename, not a normal
+    import target) so this guard shares the writer's own catalog-seed parser."""
+    path = os.path.join(REPO_ROOT, "scripts", "sync-catalog-seed-pin.py")
+    spec = importlib.util.spec_from_file_location("sync_catalog_seed_pin", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _first_match(path, regex):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                m = regex.match(line.rstrip("\n"))
+                if m:
+                    return m.group(1)
+    except OSError:
+        return None
+    return None
+
+
+def discover_charted_blueprints(root):
+    """Every <tree>/<dir> that ships BOTH blueprint.yaml and chart/Chart.yaml.
+
+    Returns a list of dicts: {source, dir, chart, blueprint_name}."""
+    found = []
+    for tree in SOURCE_TREES:
+        base = os.path.join(root, tree)
+        if not os.path.isdir(base):
+            continue
+        for name in sorted(os.listdir(base)):
+            bp = os.path.join(base, name, "blueprint.yaml")
+            chart = os.path.join(base, name, "chart", "Chart.yaml")
+            if not (os.path.isfile(bp) and os.path.isfile(chart)):
+                continue
+            found.append({
+                "source": "%s/%s" % (tree, name),
+                "dir": name,
+                "chart": _first_match(chart, _RE_CHART_NAME),
+                "blueprint_name": _first_match(bp, _RE_BP_NAME),
+            })
+    return found
+
+
+def seed_identifiers(root, seed_path):
+    """Every identifier the catalog seed makes a Blueprint addressable by:
+    metadata.name, manifests.chart and source.chart."""
+    parser = _load_seed_parser()
+    with open(os.path.join(root, seed_path), encoding="utf-8") as fh:
+        lines = fh.read().split("\n")
+    entries = parser._parse_entries(lines)
+    idents = set()
+    for e in entries:
+        for key in ("name", "manifests_chart", "source_chart"):
+            if e.get(key):
+                idents.add(e[key])
+    return entries, idents
+
+
+def load_register(path):
+    """Parse the declared-exclusion register. Returns (rows, error-string)."""
+    if not os.path.isfile(path):
+        return [], "register not found at %s" % path
+    with open(path, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh) or {}
+    if not isinstance(doc, dict) or "unseeded" not in doc:
+        return [], "register %s has no top-level `unseeded:` key" % path
+    rows = doc.get("unseeded") or []
+    if not isinstance(rows, list):
+        return [], "register %s: `unseeded:` must be a list" % path
+    return rows, None
+
+
+def run(root=REPO_ROOT, seed_path=SEED_PATH, register_path=REGISTER_PATH,
+        out=sys.stdout, err=sys.stderr):
+    register_abs = register_path if os.path.isabs(register_path) else os.path.join(root, register_path)
+
+    blueprints = discover_charted_blueprints(root)
+    if not blueprints:
+        print("ERROR: discovered ZERO directories shipping both blueprint.yaml and "
+              "chart/Chart.yaml under %s — the walker is broken; refusing a vacuous PASS."
+              % "/ ".join(SOURCE_TREES), file=err)
+        return 2
+
+    try:
+        entries, idents = seed_identifiers(root, seed_path)
+    except OSError as exc:
+        print("ERROR: cannot read the catalog seed at %s: %s" % (seed_path, exc), file=err)
+        return 2
+    if not entries:
+        print("ERROR: parsed ZERO Blueprint entries out of %s (expected dozens) — the "
+              "seed parser is broken; refusing a vacuous PASS." % seed_path, file=err)
+        return 2
+
+    rows, reg_err = load_register(register_abs)
+    if reg_err:
+        print("ERROR: %s" % reg_err, file=err)
+        return 2
+
+    declared = {}
+    fail = 0
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict) or not row.get("chart"):
+            print("  FAIL register row %d: every row needs a `chart:` key." % (i + 1), file=out)
+            fail += 1
+            continue
+        chart = row["chart"]
+        # ── Invariant 3: an exclusion must always say WHY and WHERE.
+        if not str(row.get("reason") or "").strip():
+            print("  FAIL register '%s': rows must carry a non-empty `reason:`. An "
+                  "undeclared reason is how a register becomes a silencer." % chart, file=out)
+            fail += 1
+            continue
+        if not str(row.get("source") or "").strip():
+            print("  FAIL register '%s': rows must carry the `source:` directory the "
+                  "chart lives at (e.g. platform/<x>)." % chart, file=out)
+            fail += 1
+            continue
+        declared[chart] = row
+
+    by_chart = {b["chart"]: b for b in blueprints if b["chart"]}
+
+    # ── Invariant 1 + 2 on the register, before the coverage sweep.
+    for chart, row in sorted(declared.items()):
+        if chart in idents:
+            print("  FAIL register '%s': the catalog seed DOES carry this chart now — "
+                  "delete the row from %s (stale exclusion)." % (chart, register_path), file=out)
+            fail += 1
+            continue
+        if chart not in by_chart:
+            print("  FAIL register '%s': no directory under %s ships both a blueprint.yaml "
+                  "and a chart/Chart.yaml for it — delete the dead row from %s."
+                  % (chart, "/".join(SOURCE_TREES), register_path), file=out)
+            fail += 1
+            continue
+        if by_chart[chart]["source"] != row["source"]:
+            print("  FAIL register '%s': declares source '%s' but the chart lives at '%s'."
+                  % (chart, row["source"], by_chart[chart]["source"]), file=out)
+            fail += 1
+
+    seeded = 0
+    waived = 0
+    missing = []
+    for b in blueprints:
+        keys = {b["chart"], b["blueprint_name"], "bp-" + b["dir"], b["dir"]}
+        keys.discard(None)
+        if keys & idents:
+            seeded += 1
+            continue
+        if b["chart"] in declared:
+            waived += 1
+            continue
+        missing.append(b)
+
+    # ── Vacuity / control probe. The tree carries dozens of seeded charts; if
+    # NONE resolved, the identifier match is broken, not the catalog. Exit 2
+    # (tooling) rather than 1 (defect) so the diagnosis is not inverted.
+    if seeded == 0:
+        print("ERROR: %d charted Blueprint(s) were examined and NOT ONE resolved against a "
+              "catalog-seed identifier. That is a parser/match failure, not %d simultaneous "
+              "defects." % (len(blueprints), len(blueprints)), file=err)
+        return 2
+
+    print("── catalog-seed SOURCE→SEED coverage (#5843) ──", file=out)
+    print("charted Blueprints: %d   seeded: %d   declared-unseeded: %d   undeclared gaps: %d"
+          % (len(blueprints), seeded, waived, len(missing)), file=out)
+
+    if missing:
+        print(file=out)
+        print("FAIL: %d Blueprint(s) ship a chart but have NO catalog-seed entry and are not "
+              "declared in %s:" % (len(missing), register_path), file=out)
+        for b in missing:
+            print("  %-44s chart %-32s Blueprint %s"
+                  % (b["source"], b["chart"], b["blueprint_name"]), file=out)
+        print(file=out)
+        print("For each of the above, no Blueprint CR is ever rendered into a Sovereign. On a", file=out)
+        print("pre-cutover Sovereign the in-cluster CR list is the ONLY catalog leg that answers", file=out)
+        print("(the gitea catalog Orgs are empty until bp-self-sovereign-cutover step 1 runs), so", file=out)
+        print("`POST /applications` cannot resolve the blueprint: it is uninstallable.", file=out)
+        print(file=out)
+        print("Fix, in order of preference:", file=out)
+        print("  1. Add the entry to %s" % seed_path, file=out)
+        print("     (card spec.version + source.chart/source.version), then move the other", file=out)
+        print("     lockstep sites: the component chart/Chart.yaml, its blueprint.yaml, the", file=out)
+        print("     bootstrap-kit slot pin, and REPUBLISH the umbrella", file=out)
+        print("     products/catalyst/chart/Chart.yaml — without that last one the published", file=out)
+        print("     artifact never carries the new entry (#5734).", file=out)
+        print("  2. If it is deliberately excluded, declare it in %s" % register_path, file=out)
+        print("     with a `reason:` and its `source:` path.", file=out)
+        fail += len(missing)
+
+    if fail:
+        print(file=out)
+        print("FAIL: %d finding(s). Silencing this gate by deleting a blueprint.yaml or a "
+              "chart is NOT a fix — it hides the gap while leaving the catalog as broken."
+              % fail, file=out)
+        return 1
+
+    print("PASS: every charted Blueprint under %s is either carried by the catalog seed or "
+          "declared in %s." % ("/".join(SOURCE_TREES), register_path), file=out)
+    return 0
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Self-test — prove this guard's machinery CAN go both RED and GREEN, on a
+# synthetic tree. Without this a "PASS" is indistinguishable from a guard that
+# cannot fail (the dominant defect class in this repo's guard history).
+# ────────────────────────────────────────────────────────────────────────────
+_SEED_FIXTURE_HEAD = """{{- if .Values.catalogSeed.enabled }}
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-seeded-fixture
+spec:
+  version: "1.0.0"
+  visibility: unlisted
+  manifests:
+    chart: bp-seeded-fixture
+  source:
+    kind: HelmRepository
+    chart: bp-seeded-fixture
+    version: 1.0.0
+"""
+
+
+def _self_test():
+    import shutil
+    import tempfile
+
+    tmp = tempfile.mkdtemp(prefix="seed-coverage-selftest-")
+    rc_final = 0
+    try:
+        seed_rel = SEED_PATH
+        seed_abs = os.path.join(tmp, seed_rel)
+        os.makedirs(os.path.dirname(seed_abs), exist_ok=True)
+        with open(seed_abs, "w", encoding="utf-8") as fh:
+            fh.write(_SEED_FIXTURE_HEAD)
+
+        def make_bp(tree, name, chart_name):
+            d = os.path.join(tmp, tree, name)
+            os.makedirs(os.path.join(d, "chart"), exist_ok=True)
+            with open(os.path.join(d, "blueprint.yaml"), "w", encoding="utf-8") as fh:
+                fh.write("apiVersion: catalyst.openova.io/v1alpha1\nkind: Blueprint\n"
+                         "metadata:\n  name: %s\nspec:\n  version: 1.0.0\n" % chart_name)
+            with open(os.path.join(d, "chart", "Chart.yaml"), "w", encoding="utf-8") as fh:
+                fh.write("apiVersion: v2\nname: %s\nversion: 1.0.0\n" % chart_name)
+
+        make_bp("platform", "seeded-fixture", "bp-seeded-fixture")
+        make_bp("products", "unseeded-fixture", "bp-unseeded-fixture")
+
+        reg_abs = os.path.join(tmp, REGISTER_PATH)
+        os.makedirs(os.path.dirname(reg_abs), exist_ok=True)
+
+        def write_register(body):
+            with open(reg_abs, "w", encoding="utf-8") as fh:
+                fh.write(body)
+
+        # ── RED: a charted Blueprint with no seed entry and no declaration.
+        write_register("unseeded: []\n")
+        rc = run(root=tmp, out=sys.stdout, err=sys.stderr)
+        if rc != 1:
+            print("SELF-TEST FAIL: an undeclared unseeded Blueprint must exit 1 (got %d)" % rc,
+                  file=sys.stderr)
+            rc_final = 2
+
+        # ── GREEN: same tree, gap declared with a reason + source.
+        write_register(
+            "unseeded:\n"
+            "  - chart: bp-unseeded-fixture\n"
+            "    source: products/unseeded-fixture\n"
+            "    reason: self-test fixture\n"
+        )
+        rc = run(root=tmp, out=sys.stdout, err=sys.stderr)
+        if rc != 0:
+            print("SELF-TEST FAIL: a declared exclusion must exit 0 (got %d)" % rc,
+                  file=sys.stderr)
+            rc_final = 2
+
+        # ── RED: invariant 1 — a declared chart that IS seeded is a stale row.
+        write_register(
+            "unseeded:\n"
+            "  - chart: bp-seeded-fixture\n"
+            "    source: platform/seeded-fixture\n"
+            "    reason: stale row fixture\n"
+            "  - chart: bp-unseeded-fixture\n"
+            "    source: products/unseeded-fixture\n"
+            "    reason: self-test fixture\n"
+        )
+        rc = run(root=tmp, out=sys.stdout, err=sys.stderr)
+        if rc != 1:
+            print("SELF-TEST FAIL: a stale (now-seeded) register row must exit 1 (got %d)" % rc,
+                  file=sys.stderr)
+            rc_final = 2
+
+        # ── RED: invariant 2 — a declared chart with no source directory.
+        write_register(
+            "unseeded:\n"
+            "  - chart: bp-ghost-fixture\n"
+            "    source: platform/ghost-fixture\n"
+            "    reason: dead row fixture\n"
+            "  - chart: bp-unseeded-fixture\n"
+            "    source: products/unseeded-fixture\n"
+            "    reason: self-test fixture\n"
+        )
+        rc = run(root=tmp, out=sys.stdout, err=sys.stderr)
+        if rc != 1:
+            print("SELF-TEST FAIL: a dead register row must exit 1 (got %d)" % rc,
+                  file=sys.stderr)
+            rc_final = 2
+
+        # ── RED: invariant 3 — a row with no reason.
+        write_register(
+            "unseeded:\n"
+            "  - chart: bp-unseeded-fixture\n"
+            "    source: products/unseeded-fixture\n"
+        )
+        rc = run(root=tmp, out=sys.stdout, err=sys.stderr)
+        if rc != 1:
+            print("SELF-TEST FAIL: a reason-less register row must exit 1 (got %d)" % rc,
+                  file=sys.stderr)
+            rc_final = 2
+
+        if rc_final == 0:
+            print("SELF-TEST PASS: the guard goes RED on an undeclared gap, on a stale row, "
+                  "on a dead row and on a reason-less row, and GREEN on a declared one.")
+        return rc_final
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--register", default=REGISTER_PATH,
+                    help="path to the declared-exclusion register")
+    ap.add_argument("--self-test", action="store_true",
+                    help="prove the guard can go both RED and GREEN on a synthetic tree")
+    args = ap.parse_args(argv)
+    if args.self_test:
+        return _self_test()
+    return run(register_path=args.register)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/expected-unseeded-blueprints.yaml
+++ b/scripts/expected-unseeded-blueprints.yaml
@@ -1,0 +1,172 @@
+# scripts/expected-unseeded-blueprints.yaml
+#
+# The declared-exclusion register for scripts/check-catalog-seed-source-coverage.py
+# (issue #5843). Every `platform/<x>/` and `products/<x>/` directory that ships
+# BOTH a blueprint.yaml AND a chart/Chart.yaml must appear in the catalog seed
+# (products/catalyst/chart/templates/catalog-seed/blueprints.yaml) — or be
+# declared here, with a reason.
+#
+# Why the register exists at all
+# ──────────────────────────────
+# Every other catalog-seed guard iterates the SEED and looks outward, so a
+# Blueprint with no seed entry is invisible to all of them rather than failing
+# any of them. bp-openova-mcp lived in that blind spot for six chart releases
+# with a published chart, a bootstrap-kit slot and a purpose-built per-Org
+# install door in catalyst-api — and was uninstallable the whole time, because
+# on a pre-cutover Sovereign the in-cluster Blueprint CR list is the only
+# catalog leg that answers and the seed is what renders those CRs. The coverage
+# guard asserts the opposite direction; this file is where a genuine exclusion
+# is stated OUT LOUD instead of being a silence.
+#
+# Invariants the guard holds this file to (they make it self-retiring — it
+# cannot rot into a blanket silencer):
+#   1. A declared chart that IS seeded            → FAIL, delete the row.
+#   2. A declared chart with no source directory  → FAIL, delete the dead row.
+#   3. A row with no `reason:` or no `source:`    → FAIL.
+#
+# Adding a row is NOT the preferred fix for a new Blueprint. Seeding it is.
+# A row here is a statement that the chart is intentionally absent from the
+# catalog, and it should name what installs it instead.
+#
+# Fields:
+#   chart   — the `name:` in <source>/chart/Chart.yaml (what the seed would
+#             reference as source.chart)
+#   source  — the directory the chart lives at, e.g. platform/oidc-gate
+#   reason  — WHY it is not seeded, and what installs it instead
+#
+# Refs #5843 #3988.
+
+unseeded:
+  # ── Group A — bootstrap-kit-owned. These install from their OWN kit slot
+  # (clusters/_template/bootstrap-kit/<NN>-<name>.yaml), which Flux reconciles
+  # directly. core/controllers/application's reconcileBootstrapOwned is
+  # status-only for them and never reads a Blueprint CR's version, so the
+  # absence of a seed entry does not affect what runs. They are infrastructure,
+  # not catalog items.
+  - chart: bp-catalyst-edge-routes
+    source: platform/catalyst-edge-routes
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 13e
+      (13e-bp-catalyst-secondary-edge-routes.yaml). Secondary-region edge
+      routing for the Catalyst control plane; never installed from the catalog.
+
+  - chart: bp-dragonfly
+    source: platform/dragonfly
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 06 (06-bp-dragonfly.yaml). The
+      node-level image-distribution layer the cutover's registry pivot depends
+      on; never installed from the catalog.
+
+  - chart: bp-hcloud-csi
+    source: platform/hcloud-csi
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 55a (55a-bp-hcloud-csi.yaml).
+      Provider storage driver, selected by the deployment's cloud provider at
+      provision time; never installed from the catalog.
+
+  - chart: bp-huawei-evs-csi
+    source: platform/huawei-evs-csi
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 55b (55b-bp-huawei-evs-csi.yaml).
+      Provider storage driver, selected by the deployment's cloud provider at
+      provision time; never installed from the catalog.
+
+  - chart: bp-network-policies
+    source: platform/network-policies
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 26 (26-network-policies.yaml).
+      Cluster-wide default-deny posture; an Organization must not be able to
+      install or re-install it from the catalog.
+
+  - chart: bp-oidc-gate
+    source: platform/oidc-gate
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 13c (13c-bp-oidc-gate.yaml), and
+      per-Org as a companion rendered by the bp-agenity chart rather than as a
+      standalone catalog item.
+
+  - chart: bp-plane-isolation
+    source: platform/plane-isolation
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 26b (26b-bp-plane-isolation.yaml).
+      Cross-plane isolation policy; same reasoning as bp-network-policies.
+
+  - chart: bp-sovereign-tls-vars
+    source: platform/sovereign-tls-vars
+    reason: >-
+      Bootstrap-kit-owned — installs from slot 12a
+      (12a-bp-sovereign-tls-vars.yaml). Carries the Sovereign's own TLS/domain
+      substitution vars for the GitOps loop; not a catalog item.
+
+  # ── Group B — no bootstrap-kit slot AND no seed entry. These are NOT
+  # "deliberately excluded" in the same sense as Group A: nothing installs them
+  # today through either door. They are recorded here so the set is ENUMERATED
+  # rather than invisible, which is the whole point of this register — the
+  # bp-openova-mcp defect was exactly this shape and went unseen for six
+  # releases. Closing each one is its own call (some may want a seed entry,
+  # some may want retiring); the guard will retire the row automatically the
+  # moment one gets seeded.
+  - chart: bp-anthropic-adapter
+    source: platform/anthropic-adapter
+    reason: >-
+      No kit slot and no seed entry — not installable from either door today.
+      Enumerated here, not silenced; needs an owner call on seed-or-retire.
+
+  - chart: bp-cert-manager-dynadot-webhook
+    source: platform/cert-manager-dynadot-webhook
+    reason: >-
+      No kit slot and no seed entry. The DNS-01 solver webhook is wired by
+      cert-manager's own issuer config on the provisioning path rather than as
+      a catalog install; recorded so the absence is visible.
+
+  - chart: bp-cilium-policies
+    source: platform/cilium-policies
+    reason: >-
+      No kit slot and no seed entry. Cilium network policy bundle — cluster
+      posture, never an Organization-installable catalog item; recorded so the
+      absence is visible.
+
+  - chart: bp-knative
+    source: platform/knative
+    reason: >-
+      No kit slot and no seed entry — not installable from either door today.
+      Enumerated here, not silenced; needs an owner call on seed-or-retire.
+
+  - chart: bp-librechat
+    source: platform/librechat
+    reason: >-
+      No kit slot and no seed entry — not installable from either door today.
+      Enumerated here, not silenced; needs an owner call on seed-or-retire.
+
+  - chart: bp-netbird
+    source: platform/netbird
+    reason: >-
+      No kit slot and no seed entry — not installable from either door today.
+      Enumerated here, not silenced; needs an owner call on seed-or-retire.
+
+  - chart: bp-qa-app
+    source: platform/qa-app
+    reason: >-
+      QA fixture Blueprint, default-OFF on production Sovereigns
+      (qaTestEnabled). Deliberately kept out of the production catalog seed so
+      a customer-reachable Sovereign never carries a test fixture card.
+
+  - chart: sandbox
+    source: platform/sandbox
+    reason: >-
+      LEGACY — the Sandbox concept was removed on 2026-06-30 and superseded by
+      products/agenity + products/openova-mcp. Deliberately unseeded; the
+      directory is retained for history only.
+
+  - chart: bp-spire
+    source: platform/spire
+    reason: >-
+      No kit slot and no seed entry — not installable from either door today.
+      Enumerated here, not silenced; needs an owner call on seed-or-retire.
+
+  - chart: bp-stalwart-sovereign
+    source: platform/stalwart-sovereign
+    reason: >-
+      No kit slot and no seed entry. The per-Organization mail Blueprint that
+      IS seeded is bp-stalwart-tenant; this Sovereign-scoped sibling has no
+      install door today. Enumerated here, not silenced.


### PR DESCRIPTION
## What was actually wrong

The per-Org MCP is **built and wired on by default**. What was missing was a
single catalog-seed entry, so the Blueprint CR never materialised and
`POST /applications` could not resolve it.

Measured, not inferred:

- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` contained
  **0** occurrences of `bp-openova-mcp`. Control: `bp-agenity` appears **6**
  times in the same file, so the search itself was sound.
- Live hw292: **80** Blueprint CRs, all labelled
  `catalyst.openova.io/managed-by: catalog-seed`, **none** named `*mcp*`.
- Everything downstream of the catalog already existed:
  `application_parameters.go:144` dispatches `stampOpenovaMCPOrgParameters`
  when the blueprint matches, and `:515-521` stamps `mode: "organization"`,
  the per-Org `httpRoute.hostnames` and `auth.rs256PubkeySecret`. Call sites
  wired at `applications.go:1196` and `endpoint_handler.go:2387`.
- Chart `bp-openova-mcp:0.1.6` **is published** on GHCR (six releases,
  0.1.0…0.1.6) and renders both modes — `products/openova-mcp/chart/tests/
  render-modes.sh:67` asserts `OPENOVA_MCP_CONTEXT: "organization"`.
- `products/openova-mcp/blueprint.yaml:53` declares `visibility: unlisted` —
  it installs through the Application-CR door, not as a marketplace card.

Why the catalog row is load-bearing rather than cosmetic: on a **pre-cutover**
Sovereign the gitea `catalog` / `catalog-sovereign` Orgs are empty (they are
populated by `bp-self-sovereign-cutover` step 1, dormant until post-handover),
so `chainedCatalogClient`'s last leg — the in-cluster Blueprint CR LIST in
`catalog_client_cluster_fallback.go` — is the **only** leg that ever answers.
The CRs it lists are exactly what this template renders. No seed entry ⇒ no
Blueprint CR ⇒ the per-Org MCP is uninstallable, which is precisely what UAT
rows 212/213 record as "an undelivered surface".

## Render proof (not a reading of the diff)

```
helm template products/catalyst/chart --show-only templates/catalog-seed/blueprints.yaml
```

|                                   | before | after |
|---|---:|---:|
| `kind: Blueprint` documents       | **80** | **81** |
| `metadata.name: bp-openova-mcp`   | **0**  | **1**  |

The rendered CR:

```yaml
name: bp-openova-mcp
version: "0.1.6"
visibility: unlisted
chart: bp-openova-mcp
srcVersion: 0.1.6
```

## The guard hole this also closes

Every catalog-seed guard in the repo walks the **seed** and looks outward:
`check-catalog-seed-lockstep.sh:108` (`for bp_name in $bp_names`, sourced from
the rendered seed), the #4415 / #4432 Go guards, the #5559 GHCR existence gate,
the #5734 umbrella-republish gate. A blueprint that ships a chart with **no
seed entry** is therefore not failing any of them — it is *invisible* to all of
them, structurally. That is how six chart releases shipped with a published
chart, a bootstrap-kit slot and a purpose-built install door, and no way to
install it, with every gate green.

New: `scripts/check-catalog-seed-source-coverage.py` walks the opposite
direction. Every `platform/<x>/` and `products/<x>/` shipping **both** a
`blueprint.yaml` **and** a `chart/Chart.yaml` must be carried by the seed, or
declared in `scripts/expected-unseeded-blueprints.yaml` with a `reason:` and a
`source:` path. The register is held to three **self-retiring** invariants so
it cannot rot into a silencer:

1. a declared chart that **is** seeded → FAIL (stale row, delete it);
2. a declared chart with no source directory → FAIL (dead row);
3. a row with no `reason:` / no `source:` → FAIL.

Plus three vacuity guards (zero blueprints discovered, zero seed entries
parsed, or zero discovered blueprints resolving as seeded all exit 2 — a
tooling fault, never dozens of simultaneous defects), and the seed parser is
**imported** from `scripts/sync-catalog-seed-pin.py` so there is no second copy
of the catalog-seed shape to drift away from the thing it guards.

### It can fail — shown, not asserted

Run against `main`'s tree (this PR's seed entry reverted, everything else
intact), verbatim:

```
── catalog-seed SOURCE→SEED coverage (#5843) ──
charted Blueprints: 89   seeded: 70   declared-unseeded: 18   undeclared gaps: 1

FAIL: 1 Blueprint(s) ship a chart but have NO catalog-seed entry and are not declared in scripts/expected-unseeded-blueprints.yaml:
  products/openova-mcp                         chart bp-openova-mcp                   Blueprint bp-openova-mcp

For each of the above, no Blueprint CR is ever rendered into a Sovereign. On a
pre-cutover Sovereign the in-cluster CR list is the ONLY catalog leg that answers
(the gitea catalog Orgs are empty until bp-self-sovereign-cutover step 1 runs), so
`POST /applications` cannot resolve the blueprint: it is uninstallable.
...
FAIL: 1 finding(s). Silencing this gate by deleting a blueprint.yaml or a chart is NOT a fix — it hides the gap while leaving the catalog as broken.
EXIT=1
```

`--self-test` additionally proves the machinery goes RED on an undeclared gap,
on a stale row, on a dead row and on a reason-less row, and GREEN on a declared
one, using a synthetic tree — it runs as its own CI step **before** the real
sweep, so a green sweep is never mistaken for a guard that cannot fail.

The register enumerates the **18 pre-existing** charted Blueprints with no seed
entry, in two honest groups: 8 that install from their own bootstrap-kit slot
(edge-routes, dragonfly, both CSIs, network-policies, oidc-gate,
plane-isolation, sovereign-tls-vars) and 10 with no kit slot and no seed entry
at all. The second group is recorded so the set is *enumerated* rather than
invisible; each one's disposition is a separate call, and the register retires
its own row automatically the moment one gets seeded.

## Lockstep — all five sites

| # | Site | State |
|---|---|---|
| 1 | `products/openova-mcp/chart/Chart.yaml` | already `0.1.6` |
| 2 | `products/openova-mcp/blueprint.yaml` `spec.version` | already `0.1.6` |
| 3 | catalog-seed **card** `spec.version` | **added** `"0.1.6"` |
| 3 | catalog-seed **delivery** `source.version` | **added** `0.1.6` |
| 4 | generated catalog (`blueprints.json` + `catalog.generated.ts`) | already carries `bp-openova-mcp 0.1.6` — it generates from `blueprint.yaml`, and `build-catalog.mjs` re-run produces **no diff** |
| 5 | bootstrap-kit slot 13d pin | already `0.1.6` |
| 5 | **umbrella republish** `products/catalyst/chart/Chart.yaml` + slot-13 pin | **1.4.1330 → 1.4.1331** |

The umbrella republish is the one without which the entry never reaches a
Sovereign (#5734): the published `bp-catalyst-platform` OCI artifact is what
renders these CRs. `appVersion` moves with `version`, healing a pre-existing
`1.4.1330`/`1.4.1329` split exactly as `scripts/bump-chart-version.sh`'s
documented `max(version, appVersion) + 1` self-heal contract does — without
that, `check-chart-version-forward.sh` (#5743) rejects the pair.

## Gates run locally, all green

| Gate | Result |
|---|---|
| `check-catalog-seed-source-coverage.py --self-test` | PASS (RED×4, GREEN×1) |
| `check-catalog-seed-source-coverage.py` | PASS — 89 charted, 71 seeded, 18 declared, 0 gaps |
| `check-catalog-seed-lockstep.sh` | PASS — checked 68, fail 0 |
| `check-catalog-seed-lockstep.sh --check-ghcr` | PASS — 75 pins resolved incl. `bp-openova-mcp:0.1.6` |
| `check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` | PASS — `bp-catalyst-platform` chart=1.4.1331 pin=1.4.1331 |
| `check-release-lockstep-writer.py` | PASS — `bump` / `noop` / `retry` / `umbrella`, 4/4 |
| `check-umbrella-republish-gate.py --ref HEAD` | PASS — 160 pins across 80 Blueprints (was 158/79) |
| `check-chart-version-forward.sh 1.4.1330 1.4.1329 1.4.1331 1.4.1331` | OK — forward, consistent |
| `check-dr-pairs-declare-promotion.sh` | PASS |
| `audit-placement-conformance.py rendered` | PASS — 67 slots, 0 in vClusters |
| `go test ./tests/e2e/bootstrap-kit` | ok |
| `build-catalog.mjs` re-run | no drift |
| `check-no-banned-words.sh --commit-messages` | OK |

## What this does NOT claim

UAT rows **212** and **213** stay ❌. They flip only on a live walk: a per-Org
`bp-openova-mcp` instance actually deployed and routed for an Organization,
then the clause re-asserted against it. What this change removes is the reason
that walk could not start — the row 212 disposition names it exactly: *"the
catalog ENTRY exists in-image; the SEEDER/RENDER is the gap — zero of 80
Blueprint CRs are named `*mcp*`, against `bp-agenity` present and installed as
the control."* Also note the seed row is only one of the two doors row 212
names; the per-Org GitOps renderer emitting an instance automatically is
tracked separately on #5843.

Refs #5843 #3687 #3988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
