### PR TITLE
fix(marketplace): give the storefront a readable session signal — UAT rows 3 + 91

### DIFF
--- a/core/marketplace/src/layouts/Layout.astro
+++ b/core/marketplace/src/layouts/Layout.astro
@@ -87,7 +87,19 @@ const { title, step = 0 } = Astro.props;
         if (qs.get('order_id')) return;
         if (qs.get('new') === '1') return;
         var token = localStorage.getItem('org-token');
-        if (!token) return;
+        if (!token) {
+          // #5940 (UAT rows 3 + 91): a customer who authenticated on the
+          // CONSOLE origin has no marketplace-origin `org-token`, so every
+          // line below this used to be unreachable for them — measured on
+          // hw292 2026-08-10 as `redirectCount 0` with an empty
+          // `document.cookie`. catalyst_session is HttpOnly and always will
+          // be; the readable companion `catalyst_session_hint` is what makes
+          // this branch possible. Spec + parity guard:
+          // src/lib/returningVisitor.ts + src/lib/layoutReturningVisitor.test.ts.
+          var hinted = hintedConsoleTarget();
+          if (hinted) window.location.replace(hinted);
+          return;
+        }
         var CACHE_KEY = 'org-has-workspace-v1';
         var TTL_MS = 60 * 1000;
         var cached = null;
@@ -146,6 +158,63 @@ const { title, step = 0 } = Astro.props;
           })
           .catch(function () {});
       } catch (e) {}
+      // #5940 — read the NON-HttpOnly `catalyst_session_hint` cookie and
+      // return the console URL for its owner, or '' when there is no usable
+      // hint. Mirrors src/lib/sessionHint.ts + src/lib/returningVisitor.ts,
+      // which are the tested spec; this copy exists only because an
+      // `is:inline` script cannot import (it must run before the bundle so a
+      // returning customer never sees the storefront flash).
+      //
+      // The hint carries a version and, at most, an Org slug. It is a
+      // ROUTING signal and never a credential: the console it points at
+      // still authenticates the visitor against the HttpOnly session. The
+      // slug is spliced into a hostname, so it is accepted only as a legal
+      // DNS label — that check is the security boundary here.
+      //
+      // There is deliberately NO mothership fallback. Row 91's forbidden
+      // half — that a returning customer is never sent to the mothership
+      // console — passes today and must keep passing, so an unrecognised
+      // host returns '' rather than a guess. (This comment is served
+      // VERBATIM in every franchised bundle, so it must not name the
+      // mothership apex either; check-served-domain-hygiene.mjs enforces
+      // that on the build output and caught an earlier draft of it.)
+      function hintedConsoleTarget() {
+        try {
+          var tenant = window.__ORG_TENANT__;
+          if (tenant && tenant.skipConsoleRedirect) return '';
+          var raw = '';
+          var parts = (document.cookie || '').split(';');
+          for (var i = 0; i < parts.length; i++) {
+            var eq = parts[i].indexOf('=');
+            if (eq < 0) continue;
+            if (parts[i].slice(0, eq).trim() !== 'catalyst_session_hint') continue;
+            raw = decodeURIComponent(parts[i].slice(eq + 1).trim());
+            break;
+          }
+          if (!raw || raw.length > 128) return '';
+          if (raw.split('.').length >= 3) return ''; // JWT-shaped: refuse
+          var params = new URLSearchParams(raw);
+          if (params.get('v') !== '1') return '';
+          var org = (params.get('org') || '').trim().toLowerCase();
+          if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(org)) org = '';
+
+          var stamped = '';
+          try { stamped = (localStorage.getItem('org-active-console-host') || '').trim().toLowerCase(); } catch (_) {}
+          if (stamped.indexOf('console.') === 0) {
+            if (!org || stamped.indexOf('console.' + org + '.') === 0) {
+              return 'https://' + stamped + '/dashboard';
+            }
+          }
+          var host = (window.location.hostname || '').toLowerCase();
+          if (host.indexOf('marketplace.') === 0) {
+            var sovFqdn = host.slice('marketplace.'.length);
+            if (sovFqdn) {
+              return 'https://console.' + (org ? org + '.' : '') + sovFqdn + '/dashboard';
+            }
+          }
+          return '';
+        } catch (e) { return ''; }
+      }
       function redirect(slug) {
         var token = localStorage.getItem('org-token') || '';
         var refresh = localStorage.getItem('org-refresh-token') || '';

--- a/core/marketplace/src/lib/layoutReturningVisitor.test.ts
+++ b/core/marketplace/src/lib/layoutReturningVisitor.test.ts
@@ -1,0 +1,253 @@
+// layoutReturningVisitor.test.ts — #5940 (UAT row 91).
+//
+// WHY THIS FILE EXISTS, and why `returningVisitor.test.ts` is not enough.
+//
+// The redirect that row 91 walks is an `is:inline` script in
+// `src/layouts/Layout.astro`. It has to be inline — it runs before the Svelte
+// bundle so a returning customer never sees the storefront flash — which
+// means it cannot `import` the module that holds the tested logic. That is
+// the classic setup for a fix that is green in unit tests and absent from the
+// shipped page.
+//
+// So this file does not test a reconstruction. It EXTRACTS the real
+// `<script is:inline>` blocks from Layout.astro on disk, runs them against a
+// fake window/document/localStorage, and asserts on the URL the script passes
+// to `location.replace`. Deleting `hintedConsoleTarget` from the page, or
+// changing where it points, fails here.
+//
+// The last describe block then re-runs the same matrix through
+// `resolveReturningVisitor` and requires the two to agree, so the inline copy
+// cannot drift from its spec without a red test.
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { resolveReturningVisitor } from './returningVisitor';
+
+const LAYOUT = join(__dirname, '..', 'layouts', 'Layout.astro');
+const layoutSrc = readFileSync(LAYOUT, 'utf8');
+
+/** Every `<script is:inline>` body in the layout, in document order. */
+function inlineScripts(src: string): string[] {
+  const out: string[] = [];
+  for (const m of src.matchAll(/<script is:inline>([\s\S]*?)<\/script>/g)) out.push(m[1]);
+  return out;
+}
+
+const scripts = inlineScripts(layoutSrc);
+
+interface RunOptions {
+  host: string;
+  cookie: string;
+  localStorage?: Record<string, string>;
+  brands?: Record<string, unknown>;
+  pathname?: string;
+  search?: string;
+}
+
+interface RunResult {
+  /** The URL passed to location.replace, or '' when none was. */
+  replaced: string;
+  replaceCalls: number;
+}
+
+/**
+ * Execute the layout's real inline scripts against a synthetic browser.
+ *
+ * Only the surfaces the scripts touch are provided. Anything they reach for
+ * that is missing throws, which is itself informative — a script that started
+ * depending on something new would fail loudly here rather than silently.
+ */
+function runLayoutScripts(opts: RunOptions): RunResult {
+  const store = new Map<string, string>(Object.entries(opts.localStorage || {}));
+  let replaced = '';
+  let replaceCalls = 0;
+
+  const fakeWindow: Record<string, unknown> = {
+    __ORG_BRANDS__: opts.brands,
+    location: {
+      hostname: opts.host,
+      pathname: opts.pathname ?? '/',
+      search: opts.search ?? '',
+      replace(url: string) {
+        replaceCalls += 1;
+        replaced = url;
+      },
+    },
+    matchMedia: () => ({ matches: false }),
+    URLSearchParams,
+  };
+
+  const fakeDocument = {
+    cookie: opts.cookie,
+    title: 'Redeem voucher — OpenOva',
+    documentElement: {
+      dataset: {} as Record<string, string>,
+      setAttribute() {},
+    },
+  };
+
+  const fakeLocalStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+  };
+  const fakeSessionStorage = {
+    getItem: () => null,
+    setItem: () => {},
+  };
+
+  const body = scripts.join('\n;\n');
+  // `fetch` is provided but never expected to fire on the paths under test —
+  // the cookie-hint branch returns before the probe. Returning a rejected
+  // promise would mask a wrong branch; throwing surfaces it.
+  const fn = new Function(
+    'window',
+    'document',
+    'localStorage',
+    'sessionStorage',
+    'URLSearchParams',
+    'fetch',
+    body,
+  );
+  fn(
+    fakeWindow,
+    fakeDocument,
+    fakeLocalStorage,
+    fakeSessionStorage,
+    URLSearchParams,
+    () => {
+      throw new Error('the inline script issued a network probe on a path that should not need one');
+    },
+  );
+
+  return { replaced, replaceCalls };
+}
+
+const SOV_MARKETPLACE = 'marketplace.t92.omani.works';
+const HINT = (org: string) => `catalyst_session_hint=${encodeURIComponent(org ? `org=${org}&v=1` : 'v=1')}`;
+
+describe('Layout.astro inline redirect — the SHIPPED script (#5940, row 91)', () => {
+  // Vacuity guard. If the extractor stopped matching, every assertion below
+  // would run against an empty program and pass.
+  it('CONTROL: the extractor found the inline scripts', () => {
+    expect(scripts.length).toBeGreaterThanOrEqual(2);
+    expect(layoutSrc).toContain('hintedConsoleTarget');
+  });
+
+  it('sends an Org-scoped cookie-borne customer to their OWN Org console', () => {
+    const out = runLayoutScripts({ host: SOV_MARKETPLACE, cookie: HINT('uatco') });
+    expect(out.replaceCalls).toBe(1);
+    expect(out.replaced).toBe('https://console.uatco.t92.omani.works/dashboard');
+  });
+
+  it('sends a Sovereign-admin cookie-borne visitor to the Sovereign console', () => {
+    const out = runLayoutScripts({ host: SOV_MARKETPLACE, cookie: HINT('') });
+    expect(out.replaced).toBe('https://console.t92.omani.works/dashboard');
+  });
+
+  it('honours the stamped server-authoritative console host (pool TLD)', () => {
+    const out = runLayoutScripts({
+      host: SOV_MARKETPLACE,
+      cookie: HINT('uatco'),
+      localStorage: { 'org-active-console-host': 'console.uatco.omani.homes' },
+    });
+    expect(out.replaced).toBe('https://console.uatco.omani.homes/dashboard');
+  });
+
+  // ── CONTROLS ───────────────────────────────────────────────────────────
+  it('CONTROL: a signed-OUT visitor is NOT redirected — the storefront renders', () => {
+    // This is the measured pre-fix state for everyone (document.cookie
+    // empty). It must remain the behaviour for anyone without a session.
+    const out = runLayoutScripts({ host: SOV_MARKETPLACE, cookie: '' });
+    expect(out.replaceCalls).toBe(0);
+    expect(out.replaced).toBe('');
+  });
+
+  it('CONTROL: a cart-only cookie jar does not count as a session', () => {
+    const out = runLayoutScripts({
+      host: SOV_MARKETPLACE,
+      cookie: 'org-theme=dark; some-analytics=1',
+      localStorage: { 'org-cart': '[]', 'org-pending-voucher': 'ABC123' },
+    });
+    expect(out.replaceCalls).toBe(0);
+  });
+
+  it('CONTROL: a demo/partner opt-out tenant is not bounced', () => {
+    const out = runLayoutScripts({
+      host: SOV_MARKETPLACE,
+      cookie: HINT('uatco'),
+      brands: { [SOV_MARKETPLACE]: { id: 'demo', brand: 'Demo', skipConsoleRedirect: true } },
+    });
+    expect(out.replaceCalls).toBe(0);
+  });
+
+  it('CONTROL: a JWT-shaped hint value is refused, not parsed', () => {
+    const out = runLayoutScripts({
+      host: SOV_MARKETPLACE,
+      cookie: 'catalyst_session_hint=eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhIn0.c2ln',
+    });
+    expect(out.replaceCalls).toBe(0);
+  });
+
+  it('CONTROL: a slug that is not a DNS label cannot steer the host', () => {
+    // Degrades to the Sovereign console — the bad slug is dropped, never
+    // spliced into the address.
+    const out = runLayoutScripts({
+      host: SOV_MARKETPLACE,
+      cookie: `catalyst_session_hint=${encodeURIComponent('org=acme:8080&v=1')}`,
+    });
+    expect(out.replaced).toBe('https://console.t92.omani.works/dashboard');
+    expect(out.replaced).not.toContain('8080');
+  });
+
+  it('CONTROL: a fully-qualified host smuggled into the slug is refused outright', () => {
+    // The off-Sovereign redirect this whole check exists to prevent.
+    const out = runLayoutScripts({
+      host: SOV_MARKETPLACE,
+      cookie: `catalyst_session_hint=${encodeURIComponent('org=evil.example.test&v=1')}`,
+    });
+    expect(out.replaceCalls).toBe(0);
+    expect(out.replaced).not.toContain('evil.example.test');
+  });
+
+  it('does not fire on the exempt paths (/launching, /auth/callback, ?order_id, ?new=1)', () => {
+    for (const [pathname, search] of [
+      ['/launching', ''],
+      ['/auth/callback', ''],
+      ['/checkout', '?order_id=ord_1'],
+      ['/plans', '?new=1'],
+    ] as const) {
+      const out = runLayoutScripts({ host: SOV_MARKETPLACE, cookie: HINT('uatco'), pathname, search });
+      expect(out.replaceCalls, `${pathname}${search} must stay put`).toBe(0);
+    }
+  });
+});
+
+describe('inline script and returningVisitor.ts agree (drift guard)', () => {
+  const cases = [
+    { org: 'uatco', stamped: '' },
+    { org: '', stamped: '' },
+    { org: 'uatco', stamped: 'console.uatco.omani.homes' },
+    { org: 'uatco', stamped: 'console.otherorg.omani.homes' },
+    { org: 'acme-corp', stamped: '' },
+  ];
+
+  for (const c of cases) {
+    it(`org=${c.org || '(none)'} stamped=${c.stamped || '(none)'}`, () => {
+      const inline = runLayoutScripts({
+        host: SOV_MARKETPLACE,
+        cookie: HINT(c.org),
+        localStorage: c.stamped ? { 'org-active-console-host': c.stamped } : {},
+      });
+      const module = resolveReturningVisitor({
+        host: SOV_MARKETPLACE,
+        skipConsoleRedirect: false,
+        hint: { org: c.org },
+        stampedConsoleHost: c.stamped,
+      });
+      expect(module.redirect).toBe(true);
+      expect(inline.replaced).toBe(module.redirect ? module.url : '');
+    });
+  }
+});

--- a/core/marketplace/src/lib/redeemDestination.test.ts
+++ b/core/marketplace/src/lib/redeemDestination.test.ts
@@ -13,6 +13,8 @@
 // is written down here as executable, citable fact.
 
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
   ownerProbeIsAuthenticable,
@@ -102,39 +104,124 @@ describe('resolveRedeemDestination — which page the visitor lands on', () => {
     expect(out.reason).toBe('no-live-org');
   });
 
-  // ── THE #5421 GAP ────────────────────────────────────────────────────
-  // `it.fails` PASSES while the assertion inside fails, and goes RED the
-  // moment the assertion starts succeeding. So this is a live tripwire,
-  // not a disabled test: it records the exact acceptance criterion for
-  // #5421 and forces whoever closes the gap to promote it to `it()`.
+  // ── THE #5421 GAP, CLOSED BY #5940 ───────────────────────────────────
+  // This was an `it.fails` tripwire whose comment said it would go RED the
+  // moment the assertion started succeeding, and that whoever closed the
+  // gap must promote it to `it()`. That is what #5940 does — so it is
+  // promoted here, and it asserts the DESTINATION URL rather than merely
+  // that a bounce occurred.
   //
-  // Persona: an owner authenticated on the CONSOLE origin via the
-  // passwordless-PIN flow. The `catalyst_session` cookie is scoped
-  // `.<sov>` path `/`, so the browser DOES attach it to the same-origin
-  // `/api/tenant/orgs` probe — but the Organization mesh never reads it.
-  it.fails(
-    'OPEN #5421: an owner carrying ONLY the console session cookie is handed to the console',
-    async () => {
-      const out = await resolveRedeemDestination({
-        skipConsoleRedirect: false,
-        token: '', // no marketplace-origin token — the owner authed on console.<sov>
-        fetchOrgs: orgMesh({ token: '', consoleSessionCookie: true }),
-      });
-      expect(out.destination).toBe('console');
-    },
-  );
+  // Persona: an owner authenticated on the CONSOLE origin. There is still
+  // no marketplace-origin token and the Organization mesh still cannot
+  // authenticate the probe — nothing about that changed. What changed is
+  // that catalyst-api now sets a readable `catalyst_session_hint` next to
+  // the HttpOnly session, so the page never has to reach the probe.
+  it('an owner carrying ONLY the console session is handed to the console (#5940)', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: false,
+      token: '', // no marketplace-origin token — the owner authed on console.<sov>
+      fetchOrgs: orgMesh({ token: '', consoleSessionCookie: true }),
+      hint: { org: 'uatco' },
+      host: 'marketplace.t92.omani.works',
+    });
+    expect(out.destination).toBe('console');
+    expect(out.reason).toBe('owner-session-hint');
+    // The row asserts the owner reaches /dashboard. Asserting only
+    // `destination === 'console'` would pass on a bounce to anywhere.
+    expect(out.url).toBe('https://console.uatco.t92.omani.works/dashboard');
+  });
 
-  // The characterisation of the same persona TODAY. This is what the
-  // walk sees: the owner is funnelled, and the reason is NOT "anonymous"
-  // — the probe simply could not be authenticated.
-  it('records the current (defective) cookie-only-owner outcome as probe-unauthenticated', async () => {
+  it('a Sovereign-admin session (no Org slug) reaches the Sovereign console', async () => {
+    // The exact hw292 2026-08-10 persona: tier `owner`, no Org scope.
     const out = await resolveRedeemDestination({
       skipConsoleRedirect: false,
       token: '',
       fetchOrgs: orgMesh({ token: '', consoleSessionCookie: true }),
+      hint: { org: '' },
+      host: 'marketplace.t92.omani.works',
+    });
+    expect(out.url).toBe('https://console.t92.omani.works/dashboard');
+  });
+
+  it('the hint path never emits a token-bearing URL', () => {
+    // A hint-borne visitor already holds the session cookie for the target
+    // console, so there is nothing to hand off. Threading the (empty)
+    // marketplace token through /launching would produce a handover with
+    // no token to redeem.
+    return resolveRedeemDestination({
+      skipConsoleRedirect: false,
+      token: '',
+      fetchOrgs: orgMesh({ token: '', consoleSessionCookie: true }),
+      hint: { org: 'uatco' },
+      host: 'marketplace.t92.omani.works',
+    }).then((out) => {
+      expect(typeof out.url).toBe('string');
+      expect(out.url ?? '').not.toContain('token=');
+      expect(out.url ?? '').not.toContain('/launching');
+    });
+  });
+
+  // ── CONTROL 5: the check answers the other way ───────────────────────
+  // Without a hint the SAME persona must still be funnelled, and for the
+  // same recorded reason. This is what proves the assertions above are
+  // driven by the hint and not by a gate that now always says 'console'.
+  it('CONTROL: with NO hint, the cookie-only visitor is still funnelled as probe-unauthenticated', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: false,
+      token: '',
+      fetchOrgs: orgMesh({ token: '', consoleSessionCookie: true }),
+      hint: null,
+      host: 'marketplace.t92.omani.works',
     });
     expect(out.destination).toBe('funnel');
     expect(out.reason).toBe('probe-unauthenticated');
+    expect(out.url).toBeUndefined();
+  });
+
+  it('CONTROL: an opt-out Organization is not bounced even WITH a hint', async () => {
+    const out = await resolveRedeemDestination({
+      skipConsoleRedirect: true,
+      token: '',
+      fetchOrgs: orgMesh({ token: '' }),
+      hint: { org: 'uatco' },
+      host: 'marketplace.t92.omani.works',
+    });
+    expect(out.destination).toBe('funnel');
+    expect(out.reason).toBe('opt-out');
+  });
+});
+
+// ── PAGE WIRING ────────────────────────────────────────────────────────
+//
+// The module above can be perfect while `redeem.astro` never passes it a
+// hint — the shape that let #5686 ship green. These assertions read the
+// REAL page source, so deleting the wiring fails here.
+
+describe('redeem.astro actually consumes the hint (#5940)', () => {
+  const pageSrc = readFileSync(
+    join(__dirname, '..', 'pages', 'redeem.astro'),
+    'utf8',
+  );
+
+  it('imports the hint reader and passes it into the resolver', () => {
+    expect(pageSrc).toContain('currentSessionHint');
+    expect(pageSrc).toMatch(/hint:\s*currentSessionHint\(\)/);
+  });
+
+  it('passes the host and the stamped console host, which the destination needs', () => {
+    expect(pageSrc).toMatch(/host:\s*window\.location\.hostname/);
+    expect(pageSrc).toContain('org-active-console-host');
+  });
+
+  it('navigates to the resolved URL rather than re-deriving one', () => {
+    expect(pageSrc).toMatch(/window\.location\.replace\(outcome\.url\)/);
+  });
+
+  // CONTROL — proves these greps can report absence. If this ever passes as
+  // present, the matcher is over-matching and the assertions above are
+  // vacuous.
+  it('CONTROL: a token that is NOT in the page is reported absent', () => {
+    expect(pageSrc).not.toContain('currentSessionHint_RENAMED');
   });
 });
 

--- a/core/marketplace/src/lib/redeemDestination.ts
+++ b/core/marketplace/src/lib/redeemDestination.ts
@@ -43,12 +43,33 @@
 //
 // That is why the outcome did not move: the gate says "ask the server",
 // and the server says 401, and 401 lands in the same `runFunnel()` branch
-// the old token short-circuit used. #5421 is therefore still OPEN, and the
-// remaining work is a cross-service decision (teach the Organization mesh
-// to accept the console session, or narrow the row's contract to the
-// marketplace-origin persona) — not another client-side edit.
+// the old token short-circuit used.
+//
+// ── How #5940 closes it ──────────────────────────────────────────────
+//
+// Not by teaching the Organization mesh to read a cookie, and not by
+// weakening `catalyst_session`. catalyst-api now sets a second,
+// NON-HttpOnly cookie next to every session carrying a version and, at
+// most, an Org slug (`products/catalyst/bootstrap/api/internal/handler/
+// session_hint.go`). The redeem page reads THAT — synchronously, before
+// any probe — and hands the owner to their console.
+//
+// The probe below is unchanged and still runs for everyone else, so the
+// marketplace-origin (`org-token`) owner keeps the path they had. The
+// hint only adds an answer where the probe had none:
+//
+//   hint present            -> console       (the #5940 persona)
+//   no hint, token present  -> probe, as before
+//   no hint, no token       -> funnel        (anonymous — unchanged)
+//
+// `ownerProbeIsAuthenticable` stays exactly as it was, and still returns
+// false for a cookie-only visitor. That fact did not change and is not
+// being papered over: the fix routes AROUND the probe rather than
+// pretending the probe can now authenticate.
 
 import { redeemOwnerGate } from './redeemOwnerGate';
+import type { SessionHint } from './sessionHint';
+import { resolveReturningVisitor } from './returningVisitor';
 
 /** Where the redeem page sends the visitor. */
 export type RedeemDestination = 'funnel' | 'console';
@@ -62,6 +83,13 @@ export type RedeemDestination = 'funnel' | 'console';
 export type RedeemReason =
   /** Demo/partner Organization that opts out of the console hand-off. */
   | 'opt-out'
+  /**
+   * #5940: the readable `catalyst_session_hint` cookie identified a
+   * signed-in visitor before any probe was needed. This is the persona
+   * UAT row 3 walks — authed on the console origin, no marketplace-origin
+   * token, previously shown the "Sign up to redeem" stranger form.
+   */
+  | 'owner-session-hint'
   /** Server confirmed >=1 live Organization — the owner path. */
   | 'owner'
   /** Server answered, but the visitor owns no live Organization yet. */
@@ -88,6 +116,15 @@ export interface RedeemOutcome {
   reason: RedeemReason;
   /** Set only when destination === 'console'. */
   org?: RedeemOrgSummary;
+  /**
+   * The exact address to navigate to. Set only on the hint path, where
+   * the visitor already holds a `catalyst_session` cookie for the target
+   * console and therefore needs NO token hand-off — the browser presents
+   * the session on the navigation itself. The probe path keeps using
+   * `consoleLaunchHref`, which threads the marketplace-origin token
+   * through the readiness interstitial.
+   */
+  url?: string;
 }
 
 /**
@@ -125,6 +162,15 @@ export interface RedeemDestinationDeps {
    * `.status` on an HTTP error, mirroring `request()` in `./api.ts`.
    */
   fetchOrgs: () => Promise<RedeemOrgSummary[] | null | undefined>;
+  /**
+   * #5940 — the parsed `catalyst_session_hint` cookie, or null when the
+   * visitor has none. Null keeps the pre-#5940 behaviour exactly.
+   */
+  hint?: SessionHint | null;
+  /** `window.location.hostname`, used to compose the console host. */
+  host?: string;
+  /** `localStorage['org-active-console-host']` (#4176), when stamped. */
+  stampedConsoleHost?: string;
 }
 
 /**
@@ -141,6 +187,28 @@ export async function resolveRedeemDestination(
     }) === 'funnel'
   ) {
     return { destination: 'funnel', reason: 'opt-out' };
+  }
+
+  // #5940 — the readable signal, checked BEFORE the probe. This is the
+  // whole fix for UAT row 3: the owner measured on hw292 had a live
+  // session and no marketplace-origin token, so every path below this
+  // ended at the funnel for them no matter what it returned.
+  //
+  // `resolveReturningVisitor` owns the host derivation so the redeem page
+  // and the Layout redirect cannot disagree about where "the console" is.
+  const hinted = resolveReturningVisitor({
+    host: deps.host || '',
+    skipConsoleRedirect: deps.skipConsoleRedirect,
+    hint: deps.hint ?? null,
+    stampedConsoleHost: deps.stampedConsoleHost,
+  });
+  if (hinted.redirect) {
+    return {
+      destination: 'console',
+      reason: 'owner-session-hint',
+      url: hinted.url,
+      org: deps.hint?.org ? { slug: deps.hint.org } : undefined,
+    };
   }
 
   let orgs: RedeemOrgSummary[] | null | undefined;

--- a/core/marketplace/src/lib/returningVisitor.test.ts
+++ b/core/marketplace/src/lib/returningVisitor.test.ts
@@ -1,0 +1,140 @@
+// returningVisitor.test.ts — #5940 (UAT row 91, and the shared destination
+// used by row 3).
+//
+// Every assertion here is on the DESTINATION URL, not on "a redirect
+// happened". Row 91 has two halves and only a URL can tell them apart:
+//
+//   positive  — the customer reaches THEIR OWN Org console;
+//   forbidden — never `console.openova.io` / the mothership.
+//
+// A test that asserted `decision.redirect === true` would pass just as
+// happily on a bounce to the mothership, which is the exact failure the row
+// forbids. So the mothership case is asserted explicitly, and the module has
+// no mothership branch to reach.
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveReturningVisitor } from './returningVisitor';
+
+const SOV_MARKETPLACE = 'marketplace.t92.omani.works';
+
+describe('resolveReturningVisitor — where a cookie-borne visitor lands', () => {
+  // ── THE #5940 / row 91 CASE ────────────────────────────────────────────
+  it('sends an Org-scoped session to that Org OWN console', () => {
+    const out = resolveReturningVisitor({
+      host: SOV_MARKETPLACE,
+      skipConsoleRedirect: false,
+      hint: { org: 'uatco' },
+    });
+    expect(out).toEqual({
+      redirect: true,
+      reason: 'session-hint',
+      url: 'https://console.uatco.t92.omani.works/dashboard',
+    });
+  });
+
+  it('sends a Sovereign-admin session (no slug) to the Sovereign console', () => {
+    // The persona measured on hw292 2026-08-10: tier `owner`, no Org scope.
+    const out = resolveReturningVisitor({
+      host: SOV_MARKETPLACE,
+      skipConsoleRedirect: false,
+      hint: { org: '' },
+    });
+    expect(out).toEqual({
+      redirect: true,
+      reason: 'session-hint',
+      url: 'https://console.t92.omani.works/dashboard',
+    });
+  });
+
+  it('prefers the server-authoritative stamped console host (pool TLD, #4176)', () => {
+    // An Org provisioned on a POOL parent domain does not live under the
+    // marketplace's domain, so re-deriving from the host would land on a
+    // dead apex-wildcard address.
+    const out = resolveReturningVisitor({
+      host: SOV_MARKETPLACE,
+      skipConsoleRedirect: false,
+      hint: { org: 'uatco' },
+      stampedConsoleHost: 'console.uatco.omani.homes',
+    });
+    expect(out).toMatchObject({ url: 'https://console.uatco.omani.homes/dashboard' });
+  });
+
+  it('ignores a stamp that names a DIFFERENT Org', () => {
+    // A stale stamp from a previously-active Org must never misroute the
+    // Org this session is actually scoped to.
+    const out = resolveReturningVisitor({
+      host: SOV_MARKETPLACE,
+      skipConsoleRedirect: false,
+      hint: { org: 'uatco' },
+      stampedConsoleHost: 'console.otherorg.omani.homes',
+    });
+    expect(out).toMatchObject({ url: 'https://console.uatco.t92.omani.works/dashboard' });
+  });
+
+  // ── CONTROLS: the check must answer BOTH ways ──────────────────────────
+  it('CONTROL: a visitor with NO hint is not redirected at all', () => {
+    // The signed-out storefront visitor. If this ever redirects, the fix has
+    // made the marketplace unusable for new customers.
+    expect(
+      resolveReturningVisitor({ host: SOV_MARKETPLACE, skipConsoleRedirect: false, hint: null }),
+    ).toEqual({ redirect: false, reason: 'no-session-hint' });
+  });
+
+  it('CONTROL: a demo/partner opt-out Organization is never bounced', () => {
+    expect(
+      resolveReturningVisitor({
+        host: SOV_MARKETPLACE,
+        skipConsoleRedirect: true,
+        hint: { org: 'uatco' },
+      }),
+    ).toEqual({ redirect: false, reason: 'opt-out' });
+  });
+
+  // ── ROW 91's FORBIDDEN HALF ────────────────────────────────────────────
+  it('never produces a mothership destination, even with a valid hint', () => {
+    // Hosts that are not `marketplace.<sov>`: dev, preview, a bare apex.
+    for (const host of ['localhost', 'preview.example.test', 'omani.works', '']) {
+      const out = resolveReturningVisitor({ host, skipConsoleRedirect: false, hint: { org: 'uatco' } });
+      expect(out, `host ${host} must not yield a fallback destination`).toEqual({
+        redirect: false,
+        reason: 'unknown-console-host',
+      });
+    }
+  });
+
+  it('no reachable input yields a mothership URL', () => {
+    // Belt and braces on the row's forbidden clause: sweep the matrix and
+    // assert the apex never appears in ANY produced destination.
+    const forbidden = ['openova', 'io'].join('.');
+    for (const host of [SOV_MARKETPLACE, 'marketplace.omani.homes', 'localhost']) {
+      for (const org of ['', 'uatco', 'acme-corp']) {
+        for (const stamped of ['', 'console.uatco.omani.homes', 'console.acme-corp.omani.rest']) {
+          const out = resolveReturningVisitor({
+            host,
+            skipConsoleRedirect: false,
+            hint: { org },
+            stampedConsoleHost: stamped,
+          });
+          if (out.redirect) {
+            expect(out.url, `${host}/${org}/${stamped} produced a mothership URL`).not.toContain(forbidden);
+            expect(out.url).toMatch(/^https:\/\/console\./);
+            expect(out.url.endsWith('/dashboard')).toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  // CONTROL for the sweep above: it must actually have produced redirects,
+  // or "no mothership URL was seen" is true of an empty set.
+  it('CONTROL: the sweep produced at least one redirect', () => {
+    const out = resolveReturningVisitor({
+      host: SOV_MARKETPLACE,
+      skipConsoleRedirect: false,
+      hint: { org: 'uatco' },
+      stampedConsoleHost: '',
+    });
+    expect(out.redirect).toBe(true);
+  });
+});

--- a/core/marketplace/src/lib/returningVisitor.ts
+++ b/core/marketplace/src/lib/returningVisitor.ts
@@ -1,0 +1,125 @@
+// returningVisitor — where a cookie-borne returning customer is sent
+// from ANY marketplace page (#5940, UAT rows 3 + 91).
+//
+// ── What was measured, and what it means ─────────────────────────────
+//
+// UAT row 91 on hw292 2026-08-10: `redirectCount 0` from the marketplace
+// root, `document.cookie` empty, localStorage holding only `org-cart` /
+// `org-pending-voucher` — cart state, not a session. The returning-user
+// redirect in `Layout.astro` bails on its very first line for this
+// visitor: `var token = localStorage.getItem('org-token'); if (!token)
+// return;`. A customer who authenticated on the CONSOLE origin has no
+// marketplace-origin token, so the redirect could never fire for them.
+//
+// This module computes the destination for exactly that visitor, from
+// the readable hint cookie (`./sessionHint`). It is the SPEC for the
+// inline `hintedConsoleTarget()` in `../layouts/Layout.astro`; that
+// script has to be `is:inline` (it runs before the bundle so a returning
+// customer never sees the storefront flash), so it cannot import this.
+// `layoutReturningVisitor.test.ts` executes the REAL inline script and
+// asserts it agrees with this module on every case, which is what keeps
+// the two from drifting.
+//
+// ── The destination, and the thing it must never be ──────────────────
+//
+// Row 91 has two halves. The positive half — "sends the customer to
+// their own Org console" — is what this adds. The forbidden half —
+// "never to `console.openova.io` / the mothership" — already passes and
+// must KEEP passing, so this module has no mothership branch at all: an
+// unrecognised host yields NO redirect rather than a fallback. That is
+// asserted directly in the tests, not left to inspection.
+
+import type { SessionHint } from './sessionHint';
+
+/** Where the console lands a signed-in visitor. */
+const CONSOLE_LANDING_PATH = '/dashboard';
+
+export type ReturningVisitorReason =
+  /** Demo/partner Organization that opts out of the console hand-off. */
+  | 'opt-out'
+  /** No readable hint — anonymous, or signed out. Render the storefront. */
+  | 'no-session-hint'
+  /**
+   * A hint exists, but this host yields no console host we trust (dev
+   * `localhost`, a preview host, an unrecognised shape). Deliberately NOT
+   * a mothership fallback — see the module doc.
+   */
+  | 'unknown-console-host'
+  /** The hint identified a console; `url` carries where to send them. */
+  | 'session-hint';
+
+export type ReturningVisitorDecision =
+  | { redirect: false; reason: Exclude<ReturningVisitorReason, 'session-hint'> }
+  | { redirect: true; reason: 'session-hint'; url: string };
+
+export interface ReturningVisitorInput {
+  /** `window.location.hostname`, e.g. `marketplace.t92.omani.works`. */
+  host: string;
+  /** `__ORG_TENANT__.skipConsoleRedirect` — the demo/partner opt-out. */
+  skipConsoleRedirect: boolean;
+  /** Parsed `catalyst_session_hint`, or null when the visitor has none. */
+  hint: SessionHint | null;
+  /**
+   * `localStorage['org-active-console-host']` — the SERVER-authoritative
+   * console host stamped at signup (#4176). It is the only source that
+   * knows an Org's chosen POOL parent domain, which is frequently NOT the
+   * marketplace's own domain, so it wins over any derivation.
+   */
+  stampedConsoleHost?: string;
+}
+
+/**
+ * Resolve where a hint-bearing visitor should be sent.
+ *
+ * Precedence mirrors `deriveConsoleURL` in `./config.ts`:
+ *   1. opt-out tenants never bounce, whatever the session says;
+ *   2. no hint → no redirect (the pre-#5940 behaviour, unchanged);
+ *   3. the stamped server-authoritative console host, when it names this
+ *      Org (a stamp for a DIFFERENT Org must never misroute this one);
+ *   4. `marketplace.<sov>` → `console.<slug>.<sov>`, or `console.<sov>`
+ *      for a Sovereign-admin session that carries no slug;
+ *   5. anything else → no redirect. Never a mothership fallback.
+ */
+export function resolveReturningVisitor(
+  input: ReturningVisitorInput,
+): ReturningVisitorDecision {
+  if (input.skipConsoleRedirect) return { redirect: false, reason: 'opt-out' };
+  if (!input.hint) return { redirect: false, reason: 'no-session-hint' };
+
+  const host = (input.host || '').toLowerCase().trim();
+  const org = (input.hint.org || '').toLowerCase().trim();
+  const stamped = (input.stampedConsoleHost || '').toLowerCase().trim();
+
+  if (stamped.startsWith('console.')) {
+    // Trust the stamp only when it names THIS Org, or when the session
+    // carries no Org at all (a Sovereign-admin session has no slug to
+    // contradict it).
+    if (!org || stamped.startsWith(`console.${org}.`)) {
+      return { redirect: true, reason: 'session-hint', url: consoleURL(stamped) };
+    }
+  }
+
+  if (host.startsWith('marketplace.')) {
+    const sovFqdn = host.slice('marketplace.'.length);
+    if (sovFqdn) {
+      return {
+        redirect: true,
+        reason: 'session-hint',
+        url: consoleURL(org ? `console.${org}.${sovFqdn}` : `console.${sovFqdn}`),
+      };
+    }
+  }
+
+  return { redirect: false, reason: 'unknown-console-host' };
+}
+
+/**
+ * The console URL for a console HOST. Exported so the redeem page and
+ * the Layout redirect compose the identical address — UAT row 3 asserts
+ * the owner lands on `/dashboard`, and two call sites picking two
+ * landing paths would make that row pass on one page and fail on the
+ * other.
+ */
+export function consoleURL(consoleHost: string): string {
+  return `https://${consoleHost}${CONSOLE_LANDING_PATH}`;
+}

--- a/core/marketplace/src/lib/sessionHint.test.ts
+++ b/core/marketplace/src/lib/sessionHint.test.ts
@@ -1,0 +1,114 @@
+// sessionHint.test.ts — #5940 (UAT rows 3 + 91).
+//
+// The hint is the ONLY thing standing between a signed-in customer and the
+// stranger signup form, so two properties matter and both are asserted with
+// a control that proves the check answers the other way too:
+//
+//   - a real hint is READ (otherwise the fix is inert);
+//   - a hint that is absent, stale-versioned, over-long or credential-shaped
+//     is REFUSED (otherwise a signed-out visitor gets bounced, which is a
+//     worse outcome than the bug).
+//
+// The slug matters more than it looks: the caller splices it into a HOSTNAME.
+// A value containing a dot, a slash or a colon could point a customer off the
+// Sovereign entirely, so those cases are pinned individually rather than
+// covered by one "invalid input" case.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  SESSION_HINT_COOKIE,
+  parseSessionHintValue,
+  readSessionHint,
+} from './sessionHint';
+
+describe('parseSessionHintValue', () => {
+  it('reads a Sovereign-admin hint (no Org slug)', () => {
+    expect(parseSessionHintValue('v=1')).toEqual({ org: '' });
+  });
+
+  it('reads an Org-scoped hint and returns the slug', () => {
+    // Row 91 needs the slug: without it the marketplace can only reach the
+    // Sovereign console, not the customer's OWN Org console.
+    expect(parseSessionHintValue('org=acme&v=1')).toEqual({ org: 'acme' });
+    expect(parseSessionHintValue('v=1&org=acme-corp')).toEqual({ org: 'acme-corp' });
+  });
+
+  // ── refusals ───────────────────────────────────────────────────────────
+  it('refuses an absent or empty value', () => {
+    expect(parseSessionHintValue(undefined)).toBeNull();
+    expect(parseSessionHintValue(null)).toBeNull();
+    expect(parseSessionHintValue('')).toBeNull();
+    expect(parseSessionHintValue('   ')).toBeNull();
+  });
+
+  it('refuses an unknown payload version', () => {
+    // A future server that changes the shape must not have this reader
+    // guessing at it.
+    expect(parseSessionHintValue('v=2&org=acme')).toBeNull();
+    expect(parseSessionHintValue('org=acme')).toBeNull();
+  });
+
+  it('refuses a JWT-shaped value — the hint is never a token', () => {
+    expect(parseSessionHintValue('eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhIn0.c2ln')).toBeNull();
+    // Even carrying the right version, a dotted 3-segment value is refused:
+    // the server never emits one, so it is a smuggling attempt or a bug.
+    expect(parseSessionHintValue('v=1&x=a.b.c')).toBeNull();
+  });
+
+  it('refuses an over-long value', () => {
+    expect(parseSessionHintValue('v=1&org=' + 'a'.repeat(200))).toBeNull();
+  });
+
+  it('drops a slug that is not a legal DNS label, keeping the session signal', () => {
+    // These would otherwise be spliced into a hostname. Degrading to
+    // {org:''} sends the visitor to the Sovereign console — never off-host.
+    for (const bad of [
+      'acme/evil',              // a slash would inject a path
+      'acme:8080',              // a colon would inject a port
+      '-acme',                  // illegal leading hyphen
+      'acme-',                  // illegal trailing hyphen
+      'ACME_CORP',              // underscore is not a DNS label char
+      'ácme',                   // non-ASCII
+    ]) {
+      expect(
+        parseSessionHintValue(`v=1&org=${encodeURIComponent(bad)}`),
+        `slug ${bad} must not survive into a hostname`,
+      ).toEqual({ org: '' });
+    }
+  });
+
+  it('refuses the WHOLE hint when a dotted host is smuggled into the slug', () => {
+    // A slug carrying a fully-qualified host trips the earlier
+    // JWT-shape/dot refusal, so the hint is rejected outright rather than
+    // degraded. Stricter than the case above, and asserted separately so the
+    // two layers cannot be confused for one.
+    expect(parseSessionHintValue(`v=1&org=${encodeURIComponent('evil.example.test')}`)).toBeNull();
+  });
+});
+
+describe('readSessionHint — cookie-string parsing', () => {
+  it('finds the hint among other cookies', () => {
+    expect(readSessionHint(`org-theme=dark; ${SESSION_HINT_COOKIE}=org=acme%26v=1; other=x`))
+      .toEqual({ org: 'acme' });
+  });
+
+  it('returns null when no cookies are present at all', () => {
+    // THE MEASURED STATE on the marketplace origin before this fix:
+    // document.cookie was empty, which is why redirectCount was 0.
+    expect(readSessionHint('')).toBeNull();
+    expect(readSessionHint(undefined)).toBeNull();
+  });
+
+  // CONTROL — the two cookie names share a prefix. A substring match would
+  // read `catalyst_session` (HttpOnly, hence never present) and quietly
+  // return null for every real visitor.
+  it('CONTROL: does not mistake catalyst_session for the hint', () => {
+    expect(readSessionHint('catalyst_session=v=1')).toBeNull();
+    expect(readSessionHint('catalyst_session_hint_extra=v=1')).toBeNull();
+  });
+
+  it('CONTROL: an unrelated cookie jar yields no hint', () => {
+    expect(readSessionHint('org-cart=%5B%5D; org-pending-voucher=ABC123')).toBeNull();
+  });
+});

--- a/core/marketplace/src/lib/sessionHint.ts
+++ b/core/marketplace/src/lib/sessionHint.ts
@@ -1,0 +1,118 @@
+// sessionHint — the marketplace's readable "a session exists" signal
+// (#5940, UAT rows 3 + 91).
+//
+// ── The fact this module exists to work around ───────────────────────
+//
+// `catalyst_session` is HttpOnly, and it must stay that way. The
+// marketplace is a STATIC build on a SEPARATE host with client-side
+// auth, so its JS cannot see that cookie: `document.cookie` reads EMPTY
+// even on the console's own origin. Measured on hw292 2026-08-10 — an
+// owner whose session was live (whoami 200, tier `owner`, seconds later)
+// opened their own voucher-redeem link and got the "Sign up to redeem"
+// stranger form, `redirectCount` 0. The marketplace root did nothing at
+// all for the same visitor.
+//
+// catalyst-api now sets a second, NON-HttpOnly cookie next to every
+// session (`products/catalyst/bootstrap/api/internal/handler/
+// session_hint.go`). This module reads it.
+//
+// ── What a hint is, and what it is emphatically NOT ──────────────────
+//
+// It is a ROUTING signal, never a credential. Everything it can do is
+// send the browser to a console — and that console then authenticates
+// the visitor against the HttpOnly session exactly as it always did. A
+// forged hint therefore buys an attacker one thing: a sign-in page.
+//
+// So this parser is deliberately paranoid in ONE direction only: it
+// refuses to believe anything it cannot use safely. The `org` value is
+// spliced into a hostname by the caller, so it is accepted only when it
+// is a legal DNS label — a dot, a slash or a colon in that position
+// could redirect a visitor off-Sovereign, which is the one outcome that
+// would actually matter.
+
+/** The cookie catalyst-api sets alongside every `catalyst_session`. */
+export const SESSION_HINT_COOKIE = 'catalyst_session_hint';
+
+/** The only payload version this reader understands. */
+const SUPPORTED_VERSION = '1';
+
+/**
+ * A whole hint cannot be longer than this. The real value is ~15 bytes
+ * (`org=<slug>&v=1`); anything approaching a token's length is something
+ * this reader should refuse rather than try to interpret.
+ */
+const MAX_HINT_LENGTH = 128;
+
+/** A legal lowercase DNS label — the only shape an Org slug can take. */
+const DNS_LABEL = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export interface SessionHint {
+  /**
+   * The Organization the session is scoped to, or '' for a
+   * Sovereign-admin session (which is scoped to the Sovereign itself and
+   * has no Org slug to carry).
+   */
+  org: string;
+}
+
+/**
+ * Parse a raw hint cookie VALUE.
+ *
+ * Returns null — meaning "treat this visitor as signed out" — when the
+ * value is absent, over-long, of an unknown version, or shaped like a
+ * credential. Returning null is always safe: the caller then renders the
+ * public funnel, which is the behaviour that shipped before this fix.
+ */
+export function parseSessionHintValue(raw: string | null | undefined): SessionHint | null {
+  if (!raw) return null;
+  const value = raw.trim();
+  if (!value || value.length > MAX_HINT_LENGTH) return null;
+
+  // A dotted 3-segment value is JWT-shaped. The server never emits one,
+  // so seeing one means either a bug or something being smuggled through
+  // this channel — refuse either way rather than parse around it.
+  if (value.split('.').length >= 3) return null;
+
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(value);
+  } catch {
+    return null;
+  }
+
+  if (params.get('v') !== SUPPORTED_VERSION) return null;
+
+  const org = (params.get('org') || '').trim().toLowerCase();
+  // An unusable slug degrades to a session-exists-only hint — never to a
+  // rejected hint, and never to a slug we splice into a host unchecked.
+  return { org: DNS_LABEL.test(org) ? org : '' };
+}
+
+/**
+ * Read the hint out of a `document.cookie` string.
+ *
+ * Cookie parsing is done by hand rather than with a regex over the whole
+ * string because `catalyst_session_hint` and `catalyst_session` share a
+ * prefix: a substring match would happily read the wrong cookie, and the
+ * wrong cookie here is the HttpOnly one that will never be present.
+ */
+export function readSessionHint(cookieString: string | null | undefined): SessionHint | null {
+  if (!cookieString) return null;
+  for (const part of cookieString.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    if (part.slice(0, eq).trim() !== SESSION_HINT_COOKIE) continue;
+    return parseSessionHintValue(decodeURIComponent(part.slice(eq + 1).trim()));
+  }
+  return null;
+}
+
+/** Browser-side convenience. Safe in SSR (returns null, no `document`). */
+export function currentSessionHint(): SessionHint | null {
+  if (typeof document === 'undefined') return null;
+  try {
+    return readSessionHint(document.cookie);
+  } catch {
+    return null;
+  }
+}

--- a/core/marketplace/src/pages/redeem.astro
+++ b/core/marketplace/src/pages/redeem.astro
@@ -151,6 +151,12 @@ import Layout from '../layouts/Layout.astro';
     // 'consult-server' still funnels a cookie-borne owner, because the
     // Organization mesh cannot authenticate that probe (see the module doc).
     import { resolveRedeemDestination } from '../lib/redeemDestination';
+    // #5940 (UAT row 3): the readable signal that makes the owner bounce
+    // possible at all. `catalyst_session` is HttpOnly and stays that way, so
+    // this page reads the non-HttpOnly `catalyst_session_hint` companion
+    // catalyst-api sets alongside it. No token, no claims — see
+    // ../lib/sessionHint.ts.
+    import { currentSessionHint } from '../lib/sessionHint';
     // #5634 (UAT row 92): the response-to-panel decision lives in a plain module
     // so it can be unit-tested; this page keeps only the DOM writes that need the
     // response body.
@@ -277,25 +283,44 @@ import Layout from '../layouts/Layout.astro';
       var loadingCopy = document.querySelector('#redeem-loading p');
       if (loadingCopy) loadingCopy.textContent = 'One moment…';
 
+      var stampedConsoleHost = '';
+      try { stampedConsoleHost = localStorage.getItem('org-active-console-host') || ''; } catch (_) {}
+
       // #5421 — the gate + the server consult + the pick, in one tested unit.
+      // #5940 — plus the readable hint, which is checked BEFORE the probe.
       const outcome = await resolveRedeemDestination({
         skipConsoleRedirect: skipConsoleRedirect,
         token: token,
         activeOrgId: activeId,
         fetchOrgs: getMyOrgs,
+        hint: currentSessionHint(),
+        host: window.location.hostname,
+        stampedConsoleHost: stampedConsoleHost,
       });
 
       if (outcome.destination === 'funnel') {
         // Every non-owner path lands here: the demo/partner opt-out, a visitor
-        // with no live Organization, and — until #5421 closes — a cookie-borne
-        // owner whose probe the Organization mesh could not authenticate
-        // (`reason === 'probe-unauthenticated'`). Funnelling rather than
-        // trapping is deliberate: nobody is ever stuck on a dead shim.
+        // with no live Organization, and a visitor whose probe the Organization
+        // mesh could not authenticate AND who carried no session hint
+        // (`reason === 'probe-unauthenticated'` — a genuinely anonymous
+        // visitor, now that #5940 gives a signed-in one a readable signal).
+        // Funnelling rather than trapping is deliberate: nobody is ever stuck
+        // on a dead shim.
         runFunnel();
         return;
       }
 
-      // OWNER — hand off to the console dashboard.
+      // #5940 — the hint path already carries the exact destination, and the
+      // visitor already holds a `catalyst_session` cookie for that console, so
+      // there is nothing to hand off: navigate straight there. Threading the
+      // (empty) marketplace-origin token through /launching would produce a
+      // handover with no token to redeem.
+      if (outcome.url) {
+        window.location.replace(outcome.url);
+        return;
+      }
+
+      // OWNER via the server probe — hand off to the console dashboard.
       const pick = outcome.org;
       const slug = (pick && pick.slug) ? String(pick.slug) : '';
       // #4176 — stamp the SERVER-AUTHORITATIVE console host so the derivation

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -1167,6 +1167,13 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
+	// #5940 (UAT rows 3 + 91): the readable companion. The marketplace is a
+	// static build on a sibling host and cannot see the HttpOnly session
+	// above, so an authed owner opening a voucher-redeem link was shown the
+	// stranger signup form. This carries "a session exists" + the Org slug
+	// and nothing else — see session_hint.go. Emitted AFTER the Del above so
+	// the replay defence does not drop it.
+	setSessionHintCookie(w, orgClaim, cookieDomain, cookieMaxAge, secure)
 
 	h.log.Info("pin/verify: session established",
 		"email", email,
@@ -1291,6 +1298,10 @@ func (h *Handler) HandleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	w.Header().Add("Set-Cookie", buildClearSessionCookie(auth.SessionCookieName, cookieDomain, secure))
 	w.Header().Add("Set-Cookie", buildClearSessionCookie("catalyst_refresh", cookieDomain, secure))
+	// #5940: the hint must die with the session. A hint that outlives
+	// sign-out bounces a signed-OUT visitor to a console that immediately
+	// asks them to sign in, with no way back to the storefront.
+	w.Header().Add("Set-Cookie", buildClearSessionHintCookie(cookieDomain, secure, "Max-Age=-1"))
 
 	// Build the Keycloak end_session_endpoint URL. Returns "" when KC
 	// is not wired (CATALYST_KC_ADDR unset, e.g. CI / contabo bring-up).
@@ -1678,6 +1689,12 @@ func (h *Handler) HandleAuthSessionLogout(w http.ResponseWriter, r *http.Request
 		}
 		w.Header().Add("Set-Cookie", b.String())
 	}
+	// #5940: clear the readable hint on this logout path too. Missing it
+	// here would leave a signed-out visitor bouncing from the storefront to
+	// a console that only asks them to sign in again. Non-HttpOnly (it must
+	// match the attribute the cookie was set with) and Max-Age=-1 as on the
+	// DELETE path.
+	w.Header().Add("Set-Cookie", buildClearSessionHintCookie(domain, secure, "Max-Age=0"))
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = io.WriteString(w, `{"ok":true,"loggedOut":true}`+"\n")

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -565,6 +565,12 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
+	// #5940 (UAT rows 3 + 91): the readable "a session exists" companion.
+	// This is the SOVEREIGN-ADMIN handover, so the session is not Org-scoped
+	// and the hint carries no slug — the marketplace then derives the
+	// Sovereign's own console. This is the exact persona measured on hw292
+	// 2026-08-10 (owner session live, redeem page showed the stranger form).
+	setSessionHintCookie(w, "", cookieDomain, cookieMaxAge, secure)
 
 	h.log.Info("auth_handover: operator session established",
 		"email", claims.Email,

--- a/products/catalyst/bootstrap/api/internal/handler/auth_logout_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_logout_test.go
@@ -52,9 +52,15 @@ func TestHandleAuthLogout_ClearCookieWireShape(t *testing.T) {
 		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
 	}
 
+	// #5940: three lines now — catalyst_session, catalyst_refresh, and the
+	// non-HttpOnly catalyst_session_hint, which must be cleared on the same
+	// response or a signed-out visitor keeps getting bounced to a console
+	// that only asks them to sign in again. The hint's own attribute
+	// contract (notably: NOT HttpOnly) is asserted in session_hint_test.go;
+	// this test keeps owning the two HttpOnly lines.
 	cookies := w.Result().Header.Values("Set-Cookie")
-	if len(cookies) != 2 {
-		t.Fatalf("Set-Cookie count: got %d want 2 — %v", len(cookies), cookies)
+	if len(cookies) != 3 {
+		t.Fatalf("Set-Cookie count: got %d want 3 — %v", len(cookies), cookies)
 	}
 
 	// Build a per-cookie checklist so any missing attribute on either
@@ -162,9 +168,11 @@ func TestHandleAuthSessionLogout_PostWireShape(t *testing.T) {
 		t.Errorf("body missing ok:true — got %q", w.Body.String())
 	}
 
+	// #5940: three lines — the two HttpOnly cookies below plus the
+	// non-HttpOnly catalyst_session_hint (asserted in session_hint_test.go).
 	cookies := w.Result().Header.Values("Set-Cookie")
-	if len(cookies) != 2 {
-		t.Fatalf("Set-Cookie count: got %d want 2 — %v", len(cookies), cookies)
+	if len(cookies) != 3 {
+		t.Fatalf("Set-Cookie count: got %d want 3 — %v", len(cookies), cookies)
 	}
 
 	var sessionLine, refreshLine string

--- a/products/catalyst/bootstrap/api/internal/handler/auth_test_session.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_test_session.go
@@ -251,6 +251,12 @@ func (h *Handler) HandleAuthTestSession(w http.ResponseWriter, r *http.Request) 
 		SameSite: http.SameSiteLaxMode,
 	})
 
+	// #5940: the readable hint rides with EVERY session mint, this one
+	// included. A QA-executor session that carried no hint would make an
+	// acceptance walk of UAT rows 3 / 91 measure a browser state no real
+	// customer is ever in, and report a false failure.
+	setSessionHintCookie(w, "", cookieDomain, cookieMaxAge, secure)
+
 	h.log.Info("auth/test-session: minted",
 		"tier", tier,
 		"role", role,

--- a/products/catalyst/bootstrap/api/internal/handler/org_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_handover.go
@@ -221,6 +221,11 @@ func (h *Handler) AuthOrgHandover(w http.ResponseWriter, r *http.Request) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
+	// #5940 (UAT rows 3 + 91): the readable "a session exists" companion,
+	// carrying this Org's slug so the marketplace can bounce a returning
+	// customer to THEIR console rather than a generic one. No token, no
+	// claims — see session_hint.go. Emitted after the Del above.
+	setSessionHintCookie(w, scope.Org, cookieDomain, cookieMaxAge, secure)
 
 	h.log.Info("auth_org_handover: org session established",
 		"email", email, "org", scope.Org, "host", scope.Host)

--- a/products/catalyst/bootstrap/api/internal/handler/session_hint.go
+++ b/products/catalyst/bootstrap/api/internal/handler/session_hint.go
@@ -1,0 +1,171 @@
+// session_hint.go — the readable "a session exists" signal (#5940,
+// UAT rows 3 + 91).
+//
+// ── The problem this exists to solve ─────────────────────────────────
+//
+// `catalyst_session` is HttpOnly by design and must stay that way. The
+// marketplace (`core/marketplace/`) is a STATIC build on a SEPARATE host
+// whose auth is deliberately client-side, so its JavaScript cannot read
+// that cookie — `document.cookie` is empty even on the console's own
+// origin. Measured on hw292 2026-08-10: an owner holding a live console
+// session (`GET /api/v1/whoami` -> 200, tier `owner`, seconds later)
+// opened their own voucher-redeem URL and was shown the "Sign up to
+// redeem" stranger form; `redirectCount` was 0. The marketplace root
+// behaved the same way — no returning-user redirect at all.
+//
+// Neither surface has a bug in its own logic. They have no readable
+// signal, so the bounce cannot happen BY CONSTRUCTION.
+//
+// ── What this adds ───────────────────────────────────────────────────
+//
+// A second cookie, `catalyst_session_hint`, set alongside every
+// `catalyst_session` and cleared alongside it. It is NOT HttpOnly, so a
+// static page on a sibling host can read it, and it carries no secret:
+//
+//	v=1                (a session was minted by this Sovereign)
+//	org=<slug>         (optional; the Organization the session is scoped
+//	                    to — absent for a Sovereign-admin session)
+//
+// That is the whole value. No token, no JWT, no email, no jti, no
+// expiry-bearing claim. It is a hint, never a credential: nothing on the
+// server ever reads it back, so forging it grants a visitor exactly one
+// thing — a redirect to a console that will then ask them to sign in.
+// Authority stays entirely with the HttpOnly `catalyst_session`.
+//
+// ── Scope, stated honestly ───────────────────────────────────────────
+//
+// The hint is scoped to `sessionCookieDomain(r)` — EXACTLY the domain
+// the real session cookie already spans. It therefore reaches every host
+// the session itself reaches and not one host more:
+//
+//	console.<sov>            -> Domain=.<sov>        -> marketplace.<sov> READS IT
+//	console.<slug>.<sov>     -> Domain=.<sov>        -> marketplace.<sov> READS IT
+//	console.<slug>.<pool>    -> Domain=.<slug>.<pool>-> marketplace.<sov> does NOT
+//
+// The third row is a browser rule (a host cannot set a cookie for an
+// unrelated registrable domain), not an omission. That persona signed up
+// ON the marketplace origin and therefore holds the marketplace-origin
+// `org-token`, which is the path that already works for it. The hint is
+// strictly additive: it can only add a redirect where there was none.
+
+package handler
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SessionHintCookieName is the NON-HttpOnly companion to
+// auth.SessionCookieName. Readable by client-side JS on any host inside
+// the session cookie's domain, so a static sibling app (the marketplace)
+// can tell that a session exists without ever seeing the session itself.
+const SessionHintCookieName = "catalyst_session_hint"
+
+// sessionHintVersion is stamped as `v=` so the reader can reject a value
+// shape it does not understand instead of guessing at it.
+const sessionHintVersion = "1"
+
+// maxSessionHintOrgLen bounds the only variable-length field. A DNS label
+// is 63 octets; an Org slug becomes one (`console.<slug>.<zone>`), so
+// anything longer could not be a slug this Sovereign issued.
+const maxSessionHintOrgLen = 63
+
+// sanitizeHintOrg returns the Org slug if — and only if — it is a
+// lowercase DNS label. Anything else yields "" and the hint is emitted
+// without an `org` key.
+//
+// This is a whitelist rather than an escape: the value lands in a cookie
+// that client-side JS splices into a hostname, so the set of acceptable
+// characters is exactly the set legal in a DNS label. A rejected slug
+// degrades to a session-exists-only hint, never to a malformed host.
+func sanitizeHintOrg(org string) string {
+	s := strings.ToLower(strings.TrimSpace(org))
+	if s == "" || len(s) > maxSessionHintOrgLen {
+		return ""
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9':
+		case c == '-' && i != 0 && i != len(s)-1:
+		default:
+			return ""
+		}
+	}
+	return s
+}
+
+// buildSessionHintValue renders the hint payload.
+//
+// The output is a sorted, URL-encoded key/value list — `v=1` alone for a
+// Sovereign-admin session, `org=<slug>&v=1` for an Org-scoped one. Every
+// key is enumerated here; there is no pass-through of caller data, so a
+// new claim cannot leak into the hint by accident.
+func buildSessionHintValue(org string) string {
+	vals := url.Values{}
+	vals.Set("v", sessionHintVersion)
+	if slug := sanitizeHintOrg(org); slug != "" {
+		vals.Set("org", slug)
+	}
+	return vals.Encode()
+}
+
+// setSessionHintCookie emits the hint next to a freshly minted session.
+//
+// Attributes mirror the session cookie (Path, Domain, Max-Age, Secure,
+// SameSite) so the two live and die together in the browser's jar. The
+// ONE deliberate difference is HttpOnly:false — that difference is the
+// entire point, and it is safe only because the value is not a
+// credential.
+//
+// Call this AFTER the session cookie's own http.SetCookie: HandlePinVerify
+// and HandleOrgHandover both call w.Header().Del("Set-Cookie") immediately
+// before minting the session (the TBD-F7/#1730 replay defence), which
+// would otherwise drop the hint too.
+func setSessionHintCookie(w http.ResponseWriter, org, domain string, maxAge int, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     SessionHintCookieName,
+		Value:    buildSessionHintValue(org),
+		Path:     "/",
+		Domain:   domain,
+		MaxAge:   maxAge,
+		HttpOnly: false, // the point of this cookie — see the file header
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// buildClearSessionHintCookie returns the Set-Cookie header value that
+// deletes the hint.
+//
+// Sign-out MUST clear this. A stale hint would bounce a signed-OUT
+// visitor to a console that immediately asks them to sign in — an
+// infinite door with no way back to the storefront, which is a worse
+// customer outcome than the bug being fixed here.
+//
+// HttpOnly is deliberately absent — a clear-cookie must mirror the
+// attributes the cookie was set with, and this one was set readable.
+// SameSite stays Lax for the same reason.
+//
+// `maxAgeToken` is the literal Max-Age the caller's sibling cookies use on
+// that response: the DELETE path contracts on `Max-Age=-1`, the SPA POST
+// path on `Max-Age=0`. Both are non-positive and therefore identical to a
+// browser (RFC 6265bis), so this is a wire-consistency choice — every
+// Set-Cookie on one response reads the same way to anyone auditing it.
+func buildClearSessionHintCookie(domain string, secure bool, maxAgeToken string) string {
+	var b strings.Builder
+	b.WriteString(SessionHintCookieName)
+	b.WriteString("=; Path=/")
+	if domain != "" {
+		b.WriteString("; Domain=")
+		b.WriteString(domain)
+	}
+	if secure {
+		b.WriteString("; Secure")
+	}
+	b.WriteString("; SameSite=Lax; ")
+	b.WriteString(maxAgeToken)
+	return b.String()
+}

--- a/products/catalyst/bootstrap/api/internal/handler/session_hint_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/session_hint_test.go
@@ -1,0 +1,283 @@
+// session_hint_test.go — #5940 (UAT rows 3 + 91).
+//
+// WHAT THESE ASSERT, and why each one can fail.
+//
+// The fix's whole value is that a static sibling app can READ a signal the
+// HttpOnly session cookie cannot give it. Two properties therefore carry the
+// entire contract, and both are asserted here against the real handlers:
+//
+//	1. The hint is emitted, alongside the session, with HttpOnly=false and the
+//	   SAME Domain/Path/Max-Age/Secure as the session. Wrong Domain and the
+//	   browser drops it; HttpOnly=true and the marketplace still cannot read it
+//	   — either way the fix is inert while every other test stays green.
+//	2. The hint is NOT a credential. The session JWT must not appear in it,
+//	   and the value must stay inside the enumerated `v` / `org` shape.
+//
+// Every assertion below has a CONTROL that fails if the check is vacuous —
+// e.g. the "no token in the hint" test also asserts the token IS in the
+// session cookie, so a harness that minted no token at all cannot pass it.
+
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// ─── the value shape ──────────────────────────────────────────────────────
+
+func TestBuildSessionHintValue_ShapeAndSanitisation(t *testing.T) {
+	cases := []struct {
+		name string
+		org  string
+		want string
+	}{
+		{name: "sovereign-admin session carries no org", org: "", want: "v=1"},
+		{name: "org-scoped session carries the slug", org: "acme", want: "org=acme&v=1"},
+		{name: "slug is lowercased", org: "ACME", want: "org=acme&v=1"},
+		{name: "surrounding whitespace trimmed", org: "  acme  ", want: "org=acme&v=1"},
+		{name: "internal hyphen kept (legal DNS label)", org: "acme-corp", want: "org=acme-corp&v=1"},
+		// Rejections. Each of these would otherwise be spliced into a hostname
+		// by the marketplace, so the whitelist is the security boundary.
+		{name: "dot rejected — would widen the host", org: "acme.evil", want: "v=1"},
+		{name: "slash rejected", org: "acme/evil", want: "v=1"},
+		{name: "leading hyphen rejected (illegal DNS label)", org: "-acme", want: "v=1"},
+		{name: "trailing hyphen rejected", org: "acme-", want: "v=1"},
+		{name: "over-long slug rejected", org: strings.Repeat("a", 64), want: "v=1"},
+		{name: "ampersand rejected — would forge a second key", org: "a&v=9", want: "v=1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildSessionHintValue(tc.org); got != tc.want {
+				t.Errorf("buildSessionHintValue(%q) = %q, want %q", tc.org, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildSessionHintValue_OnlyEnumeratedKeys is the leak guard: the hint
+// must never grow a key that was not deliberately added. Parsing the output
+// and comparing the key set (rather than the whole string) means a future
+// `vals.Set("email", ...)` fails here even if the rest of the shape holds.
+func TestBuildSessionHintValue_OnlyEnumeratedKeys(t *testing.T) {
+	for _, org := range []string{"", "acme"} {
+		parsed, err := url.ParseQuery(buildSessionHintValue(org))
+		if err != nil {
+			t.Fatalf("hint value is not parseable: %v", err)
+		}
+		for k := range parsed {
+			if k != "v" && k != "org" {
+				t.Errorf("hint carries unexpected key %q — the hint must never carry anything but a version and a slug", k)
+			}
+		}
+		if parsed.Get("v") != "1" {
+			t.Errorf("hint version: got %q want %q", parsed.Get("v"), "1")
+		}
+	}
+}
+
+// ─── PIN verify: the hint rides with the session ──────────────────────────
+
+// TestPinVerify_EmitsReadableSessionHint is the headline guard for #5940.
+// Without the fix there is no catalyst_session_hint on the response at all,
+// which is precisely why the marketplace had no readable signal.
+func TestPinVerify_EmitsReadableSessionHint(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "")
+
+	h := testPinSetup(t)
+	h.pinStore.put("ops@omantel.biz", "123456", "req-1")
+
+	req := httptest.NewRequest(http.MethodPost,
+		"http://console.omantel.biz/api/v1/auth/pin/verify",
+		strings.NewReader(`{"email":"ops@omantel.biz","pin":"123456","requestId":"req-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Host", "console.omantel.biz")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandlePinVerify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	session := findCookie(w.Result().Cookies(), "catalyst_session")
+	if session == nil {
+		t.Fatal("control failed: catalyst_session was not set, so this test proves nothing about the hint")
+	}
+	hint := findCookie(w.Result().Cookies(), SessionHintCookieName)
+	if hint == nil {
+		t.Fatalf("%s not set — the marketplace has no readable signal that a session exists, which IS the #5940 defect (UAT rows 3 + 91)", SessionHintCookieName)
+	}
+
+	// (1) readable by client-side JS. This single attribute is the fix.
+	if hint.HttpOnly {
+		t.Errorf("%s must NOT be HttpOnly — a static sibling app cannot read an HttpOnly cookie, so the redirect stays impossible", SessionHintCookieName)
+	}
+	// CONTROL for (1): the real session must stay HttpOnly. A fix that made
+	// the session itself readable would satisfy the line above and would be a
+	// straight security regression.
+	if !session.HttpOnly {
+		t.Error("catalyst_session must remain HttpOnly — the hint exists so the session never has to be readable")
+	}
+
+	// (2) the hint must reach the same hosts as the session, no more, no less.
+	if hint.Domain != session.Domain {
+		t.Errorf("hint Domain %q != session Domain %q — a mismatched Domain either drops the cookie or widens it beyond the session", hint.Domain, session.Domain)
+	}
+	if hint.Domain != "omantel.biz" {
+		t.Errorf("hint Domain: got %q want %q (marketplace.omantel.biz must be able to read it)", hint.Domain, "omantel.biz")
+	}
+	if hint.Path != session.Path {
+		t.Errorf("hint Path %q != session Path %q", hint.Path, session.Path)
+	}
+	if hint.MaxAge != session.MaxAge {
+		t.Errorf("hint MaxAge %d != session MaxAge %d — a hint that outlives the session bounces a signed-out visitor forever", hint.MaxAge, session.MaxAge)
+	}
+	if hint.Secure != session.Secure {
+		t.Errorf("hint Secure %v != session Secure %v", hint.Secure, session.Secure)
+	}
+
+	// (3) the hint is not a credential.
+	if hint.Value != "v=1" {
+		t.Errorf("hint value: got %q want %q (Sovereign-admin session — no Org slug)", hint.Value, "v=1")
+	}
+	assertHintCarriesNoToken(t, hint.Value, session.Value)
+}
+
+// TestPinVerify_HintCarriesOrgSlugForOrgScopedSession covers the customer
+// persona of UAT row 91: the marketplace must send the visitor to THEIR OWN
+// Org console, which it can only do if it knows the slug.
+func TestPinVerify_HintCarriesOrgSlugForOrgScopedSession(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "")
+
+	h := testPinSetup(t)
+	// An Org console host registered as tenant_kind=org is what makes
+	// HandlePinVerify mint an Org-SCOPED session (resolveOrgScope), which is
+	// the only session shape that has a slug to hand the marketplace.
+	h.tenantRegistry = orgRegistry(t, "console.acme.omantel.biz", "acme")
+	h.pinStore.put("owner@acme.test", "123456", "req-1")
+
+	req := httptest.NewRequest(http.MethodPost,
+		"http://console.acme.omantel.biz/api/v1/auth/pin/verify",
+		strings.NewReader(`{"email":"owner@acme.test","pin":"123456","requestId":"req-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Host", "console.acme.omantel.biz")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandlePinVerify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+	hint := findCookie(w.Result().Cookies(), SessionHintCookieName)
+	if hint == nil {
+		t.Fatalf("%s not set", SessionHintCookieName)
+	}
+	parsed, err := url.ParseQuery(hint.Value)
+	if err != nil {
+		t.Fatalf("hint value %q is not parseable: %v", hint.Value, err)
+	}
+	if got := parsed.Get("org"); got != "acme" {
+		t.Errorf("hint org: got %q want %q — without the slug the marketplace can only reach the Sovereign console, not the customer's own Org console (UAT row 91)", got, "acme")
+	}
+}
+
+// ─── logout: the hint dies with the session ───────────────────────────────
+
+// TestHandleAuthLogout_ClearsSessionHint. A hint that survives sign-out is
+// worse than the bug being fixed: the storefront would bounce a signed-OUT
+// visitor into a console that immediately demands a sign-in.
+func TestHandleAuthLogout_ClearsSessionHint(t *testing.T) {
+	t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "console.example.test")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/auth/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandleAuthLogout(w, req)
+
+	line := findSetCookieLine(w.Result().Header.Values("Set-Cookie"), SessionHintCookieName+"=;")
+	if line == "" {
+		t.Fatalf("DELETE /auth/session does not clear %s — cookies=%v", SessionHintCookieName, w.Result().Header.Values("Set-Cookie"))
+	}
+	for _, want := range []string{"Max-Age=-1", "Path=/", "Domain=console.example.test", "Secure", "SameSite=Lax"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("hint clear-cookie missing %q in %q", want, line)
+		}
+	}
+	// The clear MUST mirror the set: a HttpOnly clear does not delete a
+	// non-HttpOnly cookie's twin in every browser, and it would also be an
+	// attribute the set never carried.
+	if strings.Contains(line, "HttpOnly") {
+		t.Errorf("hint clear-cookie must not be HttpOnly (the cookie was set without it) — got %q", line)
+	}
+}
+
+// TestHandleAuthSessionLogout_ClearsSessionHint covers the SPA POST path.
+// The DELETE path passing is not evidence for this one — they are two
+// separate builders with two separate attribute sets.
+func TestHandleAuthSessionLogout_ClearsSessionHint(t *testing.T) {
+	t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "console.example.test")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandleAuthSessionLogout(w, req)
+
+	line := findSetCookieLine(w.Result().Header.Values("Set-Cookie"), SessionHintCookieName+"=;")
+	if line == "" {
+		t.Fatalf("POST /auth/session does not clear %s — cookies=%v", SessionHintCookieName, w.Result().Header.Values("Set-Cookie"))
+	}
+	if strings.Contains(line, "HttpOnly") {
+		t.Errorf("hint clear-cookie must not be HttpOnly — got %q", line)
+	}
+	if !strings.Contains(line, "Domain=console.example.test") {
+		t.Errorf("hint clear-cookie missing Domain — got %q", line)
+	}
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+// assertHintCarriesNoToken proves the hint is not a credential in transit.
+//
+// The CONTROL is the second half: the session JWT's own segments must be
+// found in the SESSION cookie. Without that, a harness that minted an empty
+// token would make the "not in the hint" assertion trivially true.
+func assertHintCarriesNoToken(t *testing.T, hintValue, sessionValue string) {
+	t.Helper()
+	segments := strings.Split(sessionValue, ".")
+	if len(segments) != 3 {
+		t.Fatalf("control failed: session cookie %q is not a 3-segment JWT, so 'the token is absent from the hint' proves nothing", sessionValue)
+	}
+	for i, seg := range segments {
+		if seg == "" {
+			t.Fatalf("control failed: session JWT segment %d is empty", i)
+		}
+		if strings.Contains(hintValue, seg) {
+			t.Errorf("hint value %q contains JWT segment %d — the hint must carry NO token material", hintValue, i)
+		}
+	}
+	// A hint that merely looks like a JWT would also be wrong: the reader
+	// treats it as an opaque key/value list, so a dotted 3-segment value is a
+	// sign something credential-shaped leaked in.
+	if strings.Count(hintValue, ".") >= 2 {
+		t.Errorf("hint value %q is JWT-shaped — the hint is a key/value list, never a token", hintValue)
+	}
+}
+
+func findSetCookieLine(lines []string, prefix string) string {
+	for _, l := range lines {
+		if strings.HasPrefix(l, prefix) {
+			return l
+		}
+	}
+	return ""
+}

--- a/products/catalyst/bootstrap/api/internal/handler/session_hint_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/session_hint_test.go
@@ -189,6 +189,42 @@ func TestPinVerify_HintCarriesOrgSlugForOrgScopedSession(t *testing.T) {
 	}
 }
 
+// ─── the QA test-session mint ─────────────────────────────────────────────
+
+// TestAuthTestSession_EmitsReadableSessionHint. The acceptance walk for rows
+// 3 and 91 gets its session from this endpoint. If it minted a session with
+// no hint, the walk would measure a browser state no real customer is ever
+// in — and report a false failure against a working fix.
+func TestAuthTestSession_EmitsReadableSessionHint(t *testing.T) {
+	t.Setenv(testSessionEnvVar, "true")
+	t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", ".omantel.biz")
+
+	h := testPinSetup(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-session?tier=owner", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandleAuthTestSession(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+	session := findCookie(w.Result().Cookies(), "catalyst_session")
+	if session == nil {
+		t.Fatal("control failed: catalyst_session was not set, so this test proves nothing about the hint")
+	}
+	hint := findCookie(w.Result().Cookies(), SessionHintCookieName)
+	if hint == nil {
+		t.Fatalf("%s not set — a walk driven by this endpoint would see no session signal on the marketplace", SessionHintCookieName)
+	}
+	if hint.HttpOnly {
+		t.Errorf("%s must NOT be HttpOnly", SessionHintCookieName)
+	}
+	if hint.Domain != session.Domain {
+		t.Errorf("hint Domain %q != session Domain %q", hint.Domain, session.Domain)
+	}
+	assertHintCarriesNoToken(t, hint.Value, session.Value)
+}
+
 // ─── logout: the hint dies with the session ───────────────────────────────
 
 // TestHandleAuthLogout_ClearsSessionHint. A hint that survives sign-out is


### PR DESCRIPTION
Refs #5940, #3687, #4546, #5421 — UAT rows 3 and 91, one cause.

## The one fact both rows fail on

`catalyst_session` is HttpOnly and must stay that way. The marketplace is a **static build on a separate host** whose auth is deliberately client-side, so its JavaScript has never had a way to tell that a visitor is signed in — `document.cookie` reads **empty even on the console's own origin**.

Measured on hw292 2026-08-10:

| row | symptom | measurement |
|---|---|---|
| 3 | an authed owner opening their own voucher-redeem link gets the "Sign up to redeem" **stranger form** | `redirectCount 0`, owner identity absent from the page, while `whoami` on the console returned `200` / tier `owner` seconds later |
| 91 | the marketplace root performs **no returning-user redirect at all** | `redirectCount 0`, `document.cookie` empty, localStorage holding only `org-pending-voucher` / `org-cart` — cart state, not a session |

Neither page has a bug in its own logic. `Layout.astro` bails on its first line — `var token = localStorage.getItem('org-token'); if (!token) return;` — and a customer who authenticated on the **console** origin legitimately has no marketplace-origin token. The bounce could not happen **by construction**.

## Design chosen: the hint cookie (option 1), and why

`catalyst-api` now sets **`catalyst_session_hint`** next to every session and clears it next to every sign-out. It is **not** HttpOnly and carries a version plus, at most, an Org slug:

```
v=1                 # a Sovereign-admin session
org=uatco&v=1       # an Org-scoped session
```

No token. No JWT. No email, no `jti`, no expiry-bearing claim. `buildSessionHintValue` enumerates every key it emits — there is no pass-through of caller data, so a future claim cannot leak in by accident, and a test asserts the key set rather than the string so it fails if one appears.

**It is a routing signal, never a credential.** Nothing on the server ever reads it back. Everything a forged hint can do is send a browser to a console — which then authenticates the visitor against the untouched HttpOnly session. A forged hint therefore buys exactly one thing: a sign-in page.

Option 2 (a `whoami` from the marketplace origin with CORS credentials) was rejected on three counts, in order of weight:

1. **It needs a new authenticated cross-origin surface.** The marketplace's own `/api/` does not reach catalyst-api at all — `marketplace-routes.yaml` routes it to the Organization mesh, and both hops there (`core/services/gateway/proxy.go`, `core/services/shared/middleware/jwt.go`) read `Authorization: Bearer` only and require HS256. Neither reads a cookie. So option 2 means a **new** cross-origin call to `api.<sov>`, not a re-use of an existing one.
2. **`Access-Control-Allow-Credentials` cannot pair with `*`.** Every Sovereign would need a runtime-maintained per-Org origin allow-list — a new mutable security surface, to replace a cookie that carries no secret.
3. **It costs a round trip before paint**, on every marketplace page load, to answer a question a synchronous `document.cookie` read answers.

### The boundary, stated rather than glossed

The hint is scoped to `sessionCookieDomain(r)` — **exactly** the domain the session cookie already spans, so it reaches every host the session reaches and not one host more:

| console host | cookie Domain | can `marketplace.<sov>` read it? |
|---|---|---|
| `console.<sov>` | `.<sov>` | yes |
| `console.<slug>.<sov>` | `.<sov>` | yes |
| `console.<slug>.<pool>` | `.<slug>.<pool>` | **no** |

The third row is a browser rule — a host cannot set a cookie for an unrelated registrable domain — not an omission. That persona signed up **on the marketplace origin** and therefore holds the marketplace-origin `org-token`, which is the path that already works for it. The hint is strictly additive: it can only add a redirect where there was none. Row 3's and row 91's measured persona (sovereign-owner on `console.<sov>`, storefront on `marketplace.<sov>`) is in the first row of that table.

Note also what did **not** change: `ownerProbeIsAuthenticable` still returns `false` for a cookie-only visitor, because the Organization mesh still cannot authenticate that probe. The fix routes **around** the probe rather than pretending the probe can now authenticate.

## Changes

**Server — the signal**

- `products/catalyst/bootstrap/api/internal/handler/session_hint.go` — new. `SessionHintCookieName`, `sanitizeHintOrg` (DNS-label whitelist), `buildSessionHintValue`, `setSessionHintCookie` (`HttpOnly:false`, everything else mirroring the session), `buildClearSessionHintCookie`.
- `auth.go:1176` — `HandlePinVerify` emits the hint (after the `w.Header().Del("Set-Cookie")` replay defence, which would otherwise drop it).
- `auth.go:1304` — `HandleAuthLogout` clears it. `auth.go:1697` — `HandleAuthSessionLogout` (the SPA POST path) clears it too.
- `org_handover.go:220` — Org-scoped handover emits it **with the slug**, which is what lets row 91 reach the customer's own console rather than a generic one.
- `auth_handover.go:568` — sovereign-admin handover emits it with no slug.
- `auth_test_session.go:258` — the env-gated QA test-session mint emits it too. This is the endpoint the acceptance walk for these two rows will get its session from; minting there without a hint would put the walking browser in a state no real customer is ever in, and produce a false failure against a working fix. (Verified it can fail: disabling that one line gives `session_hint_test.go:217: catalyst_session_hint not set — a walk driven by this endpoint would see no session signal on the marketplace`.)

Sign-out clearing is not tidiness: a hint that outlives the session bounces a **signed-out** visitor into a console that immediately demands a sign-in, with no way back to the storefront — a worse outcome than the bug being fixed.

**Marketplace — the readers**

- `core/marketplace/src/lib/sessionHint.ts` — new. Parses the cookie; refuses an absent, over-long, wrong-version or JWT-shaped value, and drops a slug that is not a legal DNS label. The slug is spliced into a **hostname**, so that whitelist is the security boundary here.
- `core/marketplace/src/lib/returningVisitor.ts` — new. `resolveReturningVisitor` computes the destination **URL**. Precedence mirrors `deriveConsoleURL`: opt-out, then no-hint, then the stamped server-authoritative host (#4176, and only when it names *this* Org), then `marketplace.<sov>` → `console.<slug>.<sov>`. There is **no mothership branch at all** — an unrecognised host yields no redirect rather than a guess.
- `core/marketplace/src/layouts/Layout.astro:314` — the `if (!token)` bail now consults `hintedConsoleTarget()` before returning. `Layout.astro:374` adds that function.
- `core/marketplace/src/lib/redeemDestination.ts:146` — the hint is checked **before** the probe; a hit returns `reason: 'owner-session-hint'` plus the exact `url`.
- `core/marketplace/src/pages/redeem.astro:281` — passes the hint, host and stamped console host in, and navigates to `outcome.url`. A hint-borne visitor already holds the session cookie for that console, so there is nothing to hand off; threading the (empty) marketplace token through `/launching` would produce a handover with no token to redeem.

## Tests — and the verbatim output proving each can fail

Captured by reverting **only** the wiring (`Layout.astro`, `redeem.astro`, `redeemDestination.ts`, the three handlers) to `origin/main` while keeping the new modules and every test in place.

Assertions are on the **destination URL**, not on "a redirect happened" — a test asserting `redirect === true` would pass just as happily on a bounce to the mothership, which is the outcome row 91 forbids.

**Server:**

```
--- FAIL: TestPinVerify_EmitsReadableSessionHint (0.11s)
    session_hint_test.go:115: catalyst_session_hint not set — the marketplace has no readable signal that a session exists, which IS the #5940 defect (UAT rows 3 + 91)
--- FAIL: TestPinVerify_HintCarriesOrgSlugForOrgScopedSession (0.07s)
    session_hint_test.go:181: catalyst_session_hint not set
--- FAIL: TestHandleAuthLogout_ClearsSessionHint (0.00s)
    session_hint_test.go:208: DELETE /auth/session does not clear catalyst_session_hint — cookies=[catalyst_session=; Path=/; Domain=console.example.test; Secure; HttpOnly; SameSite=Lax; Max-Age=-1 catalyst_refresh=; ...]
--- FAIL: TestHandleAuthSessionLogout_ClearsSessionHint (0.00s)
    session_hint_test.go:237: POST /auth/session does not clear catalyst_session_hint — cookies=[catalyst_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Strict; ...]
--- FAIL: TestHandleAuthLogout_ClearCookieWireShape (0.00s)
    auth_logout_test.go:63: Set-Cookie count: got 2 want 3 — [...]
```

**Row 3 — the redeem page:**

```
 FAIL  src/lib/redeemDestination.test.ts > an owner carrying ONLY the console session is handed to the console (#5940)
AssertionError: expected 'funnel' to be 'console' // Object.is equality
Expected: "console"
Received: "funnel"

 FAIL  src/lib/redeemDestination.test.ts > a Sovereign-admin session (no Org slug) reaches the Sovereign console
AssertionError: expected undefined to be 'https://console.t92.omani.works/dashb…'
- Expected:  "https://console.t92.omani.works/dashboard"
+ Received:  undefined
```

**Row 91 — the marketplace root.** This suite does not test a reconstruction: it **extracts the real `<script is:inline>` blocks from `Layout.astro` on disk** and executes them against a synthetic window, then asserts on the URL passed to `location.replace`. The inline script cannot `import` (it must run before the bundle so a returning customer never sees the storefront flash), which is the classic setup for a fix that is green in unit tests and absent from the shipped page.

```
 FAIL  src/lib/layoutReturningVisitor.test.ts > sends an Org-scoped cookie-borne customer to their OWN Org console
AssertionError: expected +0 to be 1 // Object.is equality
- Expected:  1
+ Received:  0

 FAIL  src/lib/layoutReturningVisitor.test.ts > inline script and returningVisitor.ts agree (drift guard) > org=uatco stamped=(none)
AssertionError: expected '' to be 'https://console.uatco.t92.omani.works…'
- https://console.uatco.t92.omani.works/dashboard

 FAIL  src/lib/layoutReturningVisitor.test.ts > CONTROL: the extractor found the inline scripts
AssertionError: expected '---\nimport Header from …' to contain 'hintedConsoleTarget'
```

`expected +0 to be 1` is `redirectCount 0` — literally the number the live walk recorded.

**Controls — the checks answer both ways.** Every one of these is a real test in the suite, not a claim:

- a **signed-out** visitor is not redirected at all (`replaceCalls === 0`) and still reaches the redeem form — asserted against the shipped inline script and against the redeem resolver;
- a cart-only cookie jar (`org-cart`, `org-pending-voucher`) does not count as a session;
- **with no hint**, the same cookie-only persona is still funnelled with `reason === 'probe-unauthenticated'` and `url === undefined` — this is what proves the positive assertions are driven by the hint rather than by a gate that now always says "console";
- a demo/partner opt-out Organization is never bounced, hint or not;
- a JWT-shaped hint value is refused; a slug carrying a fully-qualified host is refused outright; a slug with a colon degrades to the Sovereign console and cannot steer the address;
- `catalyst_session` is asserted to remain HttpOnly, so a "fix" that made the session itself readable fails;
- the no-token-in-the-hint test asserts the session JWT's segments **are** present in the session cookie first, so a harness minting an empty token cannot pass it vacuously;
- the mothership sweep runs the full host × slug × stamp matrix and asserts no produced URL contains the mothership apex — with a companion test proving the sweep produced at least one redirect, so it is not vacuously true of an empty set;
- the `redeem.astro` wiring greps carry a control asserting a token that is **not** in the page reports absent, so the matcher cannot be over-matching.

The `it.fails` tripwire in `redeemDestination.test.ts` — whose comment said it would go red the moment the assertion started succeeding and that whoever closed the gap must promote it — is promoted to `it()`.

## Gates

Chained before commit, not run separately:

```
Test Files  10 passed (10)
     Tests  152 passed (152)
[domain-hygiene] OK — 42 served file(s) scanned, zero banned domain literals (#3376)
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  256.299s   (full suite)
```

`check-served-domain-hygiene.mjs` earned its keep here: an earlier draft of the inline comment named the mothership console host, and because that comment is served **verbatim** in every franchised bundle the guard failed the build across 11 pages. Reworded, then green.

## Not claimed

No UAT row is stamped by this PR. Rows 3 and 91 need a browser walk on a live Sovereign with a signed-in session, and the evidence has to be a screenshot plus the destination URL — not a passing test suite. The ledger stays untouched until that walk lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAeT2QkmeqeDDEmN69YMrq
