### PR TITLE
fix(funnel): the checkout sign-in dead end, and an app-readiness matcher that could never match

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -4,6 +4,7 @@
   import { formatOMR } from '../lib/currency';
   import { consoleHandoffHref, consoleLaunchHref } from '../lib/config';
   import { creditCoversOrder, chargesCustomer } from '../lib/checkoutPaymentGate';
+  import { codeExpiryNotice, needsFreshCode } from '../lib/checkoutSignIn';
   import PinInput6 from './PinInput6.svelte';
 
   let cart = $state(readCart());
@@ -36,6 +37,10 @@
   let code = $state('');
   let authError = $state('');
   let authLoading = $state(false);
+  // UAT row 84 — how long the server says this code is good for. Rendered
+  // instead of a hardcoded sentence, which had drifted to twice the real TTL.
+  // Null until the send call answers; codeExpiryNotice falls back then.
+  let codeExpiresInSec = $state<number | null>(null);
   let checkoutLoading = $state(false);
   let provision = $state<Provision | null>(null);
   let provisionError = $state('');
@@ -262,12 +267,36 @@
     authLoading = true;
     authError = '';
     try {
-      await sendMagicLink(email);
+      const res = await sendMagicLink(email);
+      // Render the expiry the server actually granted. An older server that
+      // does not report it leaves this null and the notice falls back.
+      codeExpiresInSec = typeof res?.expires_in_sec === 'number' ? res.expires_in_sec : null;
       authMode = 'verify';
     } catch (e: any) {
       authError = e.message || 'Failed to send code';
     }
     authLoading = false;
+  }
+
+  // UAT row 84 — the way OUT of the 6-digit screen.
+  //
+  // `authMode` used to go 'login' -> 'verify' and stop there: nothing in this
+  // component ever set it back. A customer whose code expired (or who mistyped
+  // their address, or who burned the 5-attempt cap) had no resend, no edit, no
+  // back — every further guess returned "invalid or expired code" and the only
+  // escape was reloading the page and losing the funnel state. That is the
+  // last screen before a purchase.
+  //
+  // Returning to the email stage rather than silently re-sending is deliberate:
+  // the most common reason a code never arrives is a typo in the address, and a
+  // blind resend would post a second code to the same wrong mailbox. The field
+  // is pre-filled, so for a genuine expiry it is one extra click.
+  function requestNewCode() {
+    authMode = 'login';
+    code = '';
+    pinResetCounter += 1;
+    authError = '';
+    codeExpiresInSec = null;
   }
 
   async function handleVerify() {
@@ -633,7 +662,26 @@
               {authLoading ? 'Verifying...' : 'Verify & Continue'}
             </button>
             <p class="mt-3 text-center text-xs text-[var(--color-text-dimmer)]">
-              Codes expire after 10 minutes — check your spam folder.
+              {codeExpiryNotice(codeExpiresInSec)}
+            </p>
+            <!-- The exit from this screen. Always present, because a code that
+                 never arrives looks identical to one that arrived late; when
+                 the server says the code is gone we lead with it instead of
+                 leaving the customer retyping something that cannot work. -->
+            <p class="mt-2 text-center text-xs">
+              {#if needsFreshCode(authError)}
+                <span class="text-[var(--color-text-dim)]">That code has expired.</span>
+              {:else}
+                <span class="text-[var(--color-text-dimmer)]">Didn't get it?</span>
+              {/if}
+              <button
+                type="button"
+                onclick={requestNewCode}
+                data-testid="checkout-request-new-code"
+                class="ml-1 font-semibold text-[var(--color-accent)] underline underline-offset-2 hover:text-[var(--color-accent-hover)]"
+              >
+                Send a new code
+              </button>
             </p>
           </form>
         {/if}

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -252,8 +252,11 @@ export const getAddons = async (): Promise<AddOn[]> => {
 };
 
 // Auth
+// `expires_in_sec` is the code's real TTL, reported so the sign-in page can
+// state it instead of hardcoding a number that drifts (UAT row 84). Optional:
+// a server predating the field simply omits it and the client falls back.
 export const sendMagicLink = (email: string) =>
-  request<{ message: string }>('/auth/magic-link', {
+  request<{ message: string; expires_in_sec?: number }>('/auth/magic-link', {
     method: 'POST',
     body: JSON.stringify({ email }),
   });

--- a/core/marketplace/src/lib/checkoutSignIn.test.ts
+++ b/core/marketplace/src/lib/checkoutSignIn.test.ts
@@ -1,0 +1,141 @@
+// UAT row 84 — the checkout sign-in step, in the halves that do not depend on
+// whether the mail was delivered.
+//
+// WHY THESE ASSERTIONS AND NOT "DOES SIGN-IN WORK". Row 84's headline failure
+// is that the sign-in mail is relayed through mail.openova.io (#5921) and can
+// go missing, which no unit test can reach. Underneath that were two defects
+// that bite even when the mail arrives perfectly, and those are pinned here:
+// the page advertised twice the expiry the server actually granted, and the
+// 6-digit screen had no way out. Both are checked against the component's OWN
+// call sites, resolved from source, so they fail against the pre-fix template
+// for the real reason rather than matching a fixed string.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { codeExpiryNotice, needsFreshCode, DEFAULT_CODE_TTL_SECONDS } from './checkoutSignIn';
+
+// vitest runs with the package root as cwd (core/marketplace).
+const CHECKOUT = join(process.cwd(), 'src/components/CheckoutStep.svelte');
+const SOURCE = readFileSync(CHECKOUT, 'utf8');
+
+// The Go handler that issues the code. Read as text on purpose — this suite's
+// job includes catching the two sides drifting apart, so it must not learn the
+// number from the same place the client does.
+const AUTH_HANDLER = join(process.cwd(), '../services/auth/handlers/handlers.go');
+const AUTH_SOURCE = readFileSync(AUTH_HANDLER, 'utf8');
+
+/**
+ * The verify-stage form only — the screen showing the 6 digit boxes.
+ *
+ * Sliced out rather than asserting against the whole component: the email
+ * stage legitimately has a submit button and the launch stage legitimately
+ * has navigation, and an assertion made against the whole file would pass on
+ * either of those while the verify screen stayed a dead end.
+ */
+function verifyStageMarkup(): string {
+  const ifLogin = SOURCE.indexOf("{#if authMode === 'login'}");
+  const elseAt = SOURCE.indexOf('{:else}', ifLogin);
+  const endAt = SOURCE.indexOf('{#if authError}', elseAt);
+  return SOURCE.slice(elseAt, endAt);
+}
+
+// ---------------------------------------------------------------------------
+// Controls — these prove the extraction above actually found the screen. If a
+// refactor moves the markup, these fail loudly instead of letting every
+// assertion below pass against an empty string.
+// ---------------------------------------------------------------------------
+
+describe('control — the verify stage is really being read', () => {
+  it('locates a non-empty verify-stage block', () => {
+    expect(verifyStageMarkup().length).toBeGreaterThan(200);
+  });
+
+  it('the block is the 6-digit screen and not some other branch', () => {
+    const markup = verifyStageMarkup();
+    expect(markup).toContain('PinInput6');
+    expect(markup).toContain('Verify & Continue');
+  });
+
+  it('the Go constant is really being parsed, not silently missed', () => {
+    expect(AUTH_SOURCE).toContain('magicCodeTTL');
+    expect(goMagicCodeTTLSeconds()).not.toBeNull();
+  });
+});
+
+/** Pulls `magicCodeTTL = N * time.Minute|Second` out of the Go source. */
+function goMagicCodeTTLSeconds(): number | null {
+  const m = AUTH_SOURCE.match(/magicCodeTTL\s*=\s*(\d+)\s*\*\s*time\.(Minute|Second)/);
+  if (!m) return null;
+  return m[2] === 'Minute' ? Number(m[1]) * 60 : Number(m[1]);
+}
+
+// ---------------------------------------------------------------------------
+// Defect 1 — the page promised 10 minutes, the server gave 5.
+// ---------------------------------------------------------------------------
+
+describe('code expiry — the page must state what the server actually grants', () => {
+  it('the client fallback equals the server TTL', () => {
+    expect(DEFAULT_CODE_TTL_SECONDS).toBe(goMagicCodeTTLSeconds());
+  });
+
+  it('renders the server-reported expiry, not a baked-in number', () => {
+    expect(codeExpiryNotice(600)).toBe('Codes expire after 10 minutes — check your spam folder.');
+    expect(codeExpiryNotice(300)).toBe('Codes expire after 5 minutes — check your spam folder.');
+    expect(codeExpiryNotice(60)).toBe('Codes expire after 1 minute — check your spam folder.');
+  });
+
+  it('never renders a zero or negative expiry', () => {
+    for (const bad of [0, -1, NaN, undefined, null]) {
+      expect(codeExpiryNotice(bad as number)).toBe(codeExpiryNotice(DEFAULT_CODE_TTL_SECONDS));
+    }
+  });
+
+  // THE CALL-SITE ASSERTION. Pre-fix the template carried the literal
+  // sentence, so the number was true only by coincidence and went stale the
+  // moment the TTL moved. It must come from the helper instead.
+  it('the verify screen derives its notice from the helper', () => {
+    const markup = verifyStageMarkup();
+    expect(markup).toContain('codeExpiryNotice');
+    expect(markup).not.toContain('Codes expire after 10 minutes');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 2 — an expired code was a dead end.
+// ---------------------------------------------------------------------------
+
+describe('expired code — the customer must be able to get a new one', () => {
+  it('recognises the server wordings that mean the code is gone', () => {
+    expect(needsFreshCode('invalid or expired code')).toBe(true);
+    expect(needsFreshCode('code invalidated after too many attempts')).toBe(true);
+  });
+
+  it('does NOT push a resend for a merely mistyped code', () => {
+    // The code is still live here; resending would throw away a working one.
+    expect(needsFreshCode('invalid code')).toBe(false);
+    expect(needsFreshCode('')).toBe(false);
+    expect(needsFreshCode(null)).toBe(false);
+  });
+
+  // THE STATE-MACHINE ASSERTION. `authMode` went 'login' -> 'verify' and was
+  // never set back anywhere in the component, so the 6-digit screen had no
+  // exit at all. This fails against the pre-fix source because the string
+  // `authMode = 'login'` does not occur in it even once.
+  it('some path returns the component to the email stage', () => {
+    expect(SOURCE).toMatch(/authMode\s*=\s*'login'/);
+  });
+
+  it('the verify screen itself offers that path', () => {
+    const markup = verifyStageMarkup();
+    expect(markup).toMatch(/requestNewCode|useDifferentEmail/);
+  });
+
+  it('the handler behind that control really resets the stage', () => {
+    // Guards against wiring the button to a no-op: the function the verify
+    // screen calls must be the one that assigns 'login'.
+    const handler = SOURCE.match(/function requestNewCode\([^)]*\)\s*\{[\s\S]*?\n  \}/);
+    expect(handler).not.toBeNull();
+    expect(handler![0]).toMatch(/authMode\s*=\s*'login'/);
+  });
+});

--- a/core/marketplace/src/lib/checkoutSignIn.ts
+++ b/core/marketplace/src/lib/checkoutSignIn.ts
@@ -1,0 +1,72 @@
+// UAT row 84 — the stranger's sign-in at checkout: enter email, get a code,
+// type it, end up signed in with the Org confirmed.
+//
+// Two things about that step were wrong in a way that had nothing to do with
+// whether the mail itself got delivered, and both bit at the last screen
+// before a purchase.
+//
+// 1. THE PAGE PROMISED TEN MINUTES AND THE SERVER GAVE FIVE. The notice under
+//    the 6-digit boxes read "Codes expire after 10 minutes" as a hardcoded
+//    sentence, while core/services/auth issued codes with a 5-minute TTL. A
+//    customer who took six minutes — ordinary when the sign-in mail is relayed
+//    off-Sovereign (#5921) and can queue — typed a code the page still showed
+//    as good and was told it was invalid. The server constant moved to 10 to
+//    match, and the send response now reports the expiry so this page can
+//    render the truth rather than a sentence nobody re-checks.
+//
+// 2. AN EXPIRED CODE WAS A DEAD END. `authMode` went 'login' -> 'verify' when
+//    the code was sent and was never set back, anywhere. There was no resend,
+//    no "wrong address?", no way back to the email field. Once the code
+//    expired — which, per (1), happened twice as fast as advertised — every
+//    further attempt returned "invalid or expired code", the 5-attempt cap
+//    then invalidated the code outright, and the only escape was reloading the
+//    page. The customer's own words for this is that the site is broken.
+//
+// These helpers are the shared definition of both, so the component and the
+// test that pins its call sites agree by construction.
+
+/**
+ * The code lifetime this page assumes when the server does not report one —
+ * an older `POST /auth/magic-link` that predates the `expires_in_sec` field.
+ *
+ * MUST equal `magicCodeTTL` in core/services/auth/handlers/handlers.go.
+ * `checkoutSignIn.test.ts` reads that constant out of the Go source and fails
+ * if these two drift, which is the whole reason the number is named here
+ * instead of being written into a sentence.
+ */
+export const DEFAULT_CODE_TTL_SECONDS = 600;
+
+/**
+ * The sentence shown under the 6-digit boxes.
+ *
+ * Derived from the server's reported expiry so it cannot go stale the next
+ * time the TTL moves. A non-positive or missing value falls back to
+ * `DEFAULT_CODE_TTL_SECONDS` rather than rendering "0 minutes".
+ */
+export function codeExpiryNotice(expiresInSec?: number | null): string {
+  const seconds =
+    typeof expiresInSec === 'number' && Number.isFinite(expiresInSec) && expiresInSec > 0
+      ? expiresInSec
+      : DEFAULT_CODE_TTL_SECONDS;
+  const minutes = Math.max(1, Math.round(seconds / 60));
+  const unit = minutes === 1 ? 'minute' : 'minutes';
+  return `Codes expire after ${minutes} ${unit} — check your spam folder.`;
+}
+
+/**
+ * `true` when the error the verify call came back with means the code is gone
+ * (expired, or burned by the attempt cap) rather than merely mistyped.
+ *
+ * The server's wording for these is "invalid or expired code" and "code
+ * invalidated after too many attempts" (core/services/auth/handlers/
+ * handlers.go). In both cases retyping cannot possibly work and the customer
+ * needs a fresh code — so the page leads with that instead of leaving them to
+ * guess. A plain "invalid code" (wrong digits, code still live) is NOT in this
+ * set: there the right move is to retype, and pushing a resend would throw
+ * away a code that still works.
+ */
+export function needsFreshCode(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return m.includes('expired') || m.includes('invalidated');
+}

--- a/core/services/auth/handlers/handlers.go
+++ b/core/services/auth/handlers/handlers.go
@@ -132,11 +132,31 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 // - Per-IP leaky bucket: at most `magicRateMax` verify attempts per
 //   `magicRateWindow` per source IP.
 const (
-	magicCodeTTL     = 5 * time.Minute
+	// magicCodeTTL — how long an issued 6-digit sign-in code stays valid.
+	//
+	// This MUST match what the funnel tells the customer ("Codes expire after
+	// 10 minutes", CheckoutStep.svelte) and what the console PIN path uses
+	// (`pinTTL`, products/catalyst/bootstrap/api/internal/handler/pinstore.go).
+	// It was 5 minutes behind a page that promised 10 — see
+	// magic_code_ttl_test.go for why the constant moved rather than the copy.
+	// Callers must never restate this as a literal; use magicCodeExpiresInSec.
+	magicCodeTTL     = 10 * time.Minute
 	magicMaxAttempts = 5
 	magicRateMax     = 10 // verify requests per IP per window
-	magicRateWindow  = 1 * time.Minute
+	// magicIssueRateMax — send/resend requests per IP per window. The sign-in
+	// page offers a "Send a new code" control (an expired code used to be a
+	// dead end), and every press composes an email to an address the caller
+	// chose, so this path needs its own ceiling. Set above what a real person
+	// clicks and far below anything useful for flooding a mailbox.
+	magicIssueRateMax = 5
+	magicRateWindow   = 1 * time.Minute
 )
+
+// magicCodeExpiresInSec is the code lifetime in whole seconds, as reported to
+// the client so the sign-in page can render the real expiry instead of a
+// hardcoded sentence. Returning it is what keeps the promise and the constant
+// from drifting apart again.
+func magicCodeExpiresInSec() int { return int(magicCodeTTL.Seconds()) }
 
 // SendMagicLink generates a 6-digit code, stores it in Valkey, and emails it.
 func (h *Handler) SendMagicLink(w http.ResponseWriter, r *http.Request) {
@@ -148,6 +168,14 @@ func (h *Handler) SendMagicLink(w http.ResponseWriter, r *http.Request) {
 	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
 	if req.Email == "" {
 		respond.Error(w, http.StatusBadRequest, "email is required")
+		return
+	}
+
+	// Cap issuance per source IP before composing any mail — see
+	// magicIssueRateMax. Counted in its own bucket so a resend never consumes
+	// the verify allowance the customer needs immediately afterwards.
+	if err := h.checkMagicRateLimit(r.Context(), "issue", clientIP(r), magicIssueRateMax); err != nil {
+		respond.Error(w, http.StatusTooManyRequests, "too many code requests, please try again in a minute")
 		return
 	}
 
@@ -180,7 +208,13 @@ func (h *Handler) SendMagicLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond.OK(w, map[string]string{"message": "check your email"})
+	// Report the real expiry so the page renders the truth. The client falls
+	// back to its own constant if this is absent (an older server), so the
+	// field is additive and safe for a rolling deploy.
+	respond.OK(w, map[string]any{
+		"message":        "check your email",
+		"expires_in_sec": magicCodeExpiresInSec(),
+	})
 }
 
 // VerifyMagicLink validates the code and issues tokens.
@@ -203,7 +237,7 @@ func (h *Handler) VerifyMagicLink(w http.ResponseWriter, r *http.Request) {
 	// 10^6 code space regardless of which email it targets. The gateway's
 	// per-IP rate limiter is bypassed when XFF is spoofable, so we enforce
 	// here as well; the direct TCP peer is the fallback.
-	if err := h.checkMagicRateLimit(ctx, ip); err != nil {
+	if err := h.checkMagicRateLimit(ctx, "verify", ip, magicRateMax); err != nil {
 		respond.Error(w, http.StatusTooManyRequests, "too many attempts, please try again later")
 		return
 	}
@@ -505,22 +539,25 @@ func (h *Handler) LogoutAll(w http.ResponseWriter, r *http.Request) {
 // increments, caller decides after N. If Valkey is unreachable we fail OPEN
 // (log + allow) — the alternative is to block legitimate traffic on a cache
 // blip, which is worse than the marginal brute-force risk.
-func (h *Handler) checkMagicRateLimit(ctx context.Context, ip string) error {
+// bucket names the leaky bucket ("verify" or "issue") so the two magic-code
+// paths are counted separately — a customer legitimately re-requesting a code
+// must not eat the allowance they need to then type it in.
+func (h *Handler) checkMagicRateLimit(ctx context.Context, bucket, ip string, max int) error {
 	if ip == "" {
 		return nil
 	}
-	key := "ratelimit:magic-verify:" + ip
+	key := "ratelimit:magic-" + bucket + ":" + ip
 	n, err := h.Valkey.Do(ctx, h.Valkey.B().Incr().Key(key).Build()).ToInt64()
 	if err != nil {
-		slog.Warn("magic rate-limit incr failed, failing open", "error", err)
+		slog.Warn("magic rate-limit incr failed, failing open", "bucket", bucket, "error", err)
 		return nil
 	}
 	if n == 1 {
 		h.Valkey.Do(ctx,
 			h.Valkey.B().Expire().Key(key).Seconds(int64(magicRateWindow.Seconds())).Build())
 	}
-	if n > int64(magicRateMax) {
-		return fmt.Errorf("rate limited: %d > %d", n, magicRateMax)
+	if n > int64(max) {
+		return fmt.Errorf("rate limited: %d > %d", n, max)
 	}
 	return nil
 }

--- a/core/services/auth/handlers/magic_code_ttl_test.go
+++ b/core/services/auth/handlers/magic_code_ttl_test.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+// UAT row 84 — "type the emailed sign-in code" at checkout.
+//
+// THE DEFECT THIS PINS. The marketplace checkout page tells the customer, in
+// so many words, "Codes expire after 10 minutes" (core/marketplace/src/
+// components/CheckoutStep.svelte, under the 6-digit entry). The code this
+// handler issues died after FIVE. A customer who read the page and took six
+// minutes to fetch the mail — entirely normal when the sign-in mail is relayed
+// off-Sovereign (#5921) and can queue — typed a code the page still presented
+// as valid and got "invalid or expired code" back, at the last step before
+// purchase. Nothing about that failure tells them to ask for a new one.
+//
+// WHY 10 IS THE CORRECT SIDE TO MOVE, not the copy. Three independent
+// surfaces already state 10 minutes and only this constant disagreed:
+//
+//   1. products/catalyst/bootstrap/api/internal/handler/pinstore.go — the
+//      console PIN path, `const pinTTL = 10 * time.Minute`. Same 6-digit
+//      credential, same purpose, same 5-attempt cap. It is the shipped
+//      reference implementation.
+//   2. Every customer-facing string: CheckoutStep.svelte, VerifyPinPage.tsx
+//      and PinSignInModal.tsx all say 10 minutes.
+//   3. The OAuth CSRF state token minted in THIS FILE (GoogleAuth, `Ex(10 *
+//      time.Minute)`) — so 10 minutes was already this service's own idea of
+//      a short-lived interactive credential.
+//
+// Moving the copy to 5 instead would have made the marketplace the only
+// sign-in surface in the platform with a different expiry, and would have made
+// the mail-relay latency problem worse rather than better.
+//
+// NOT A SECURITY LOOSENING. The brute-force budget is unchanged: a code is
+// still invalidated after `magicMaxAttempts` wrong guesses (5), and
+// `checkMagicRateLimit` still caps a source IP at `magicRateMax` verifies per
+// `magicRateWindow`. Doubling the window doubles the attempts an attacker may
+// make against one code only if they are willing to be locked out after 5 —
+// which is the same bound catalyst-api has shipped with at 10 minutes.
+
+func TestMagicCodeTTLMatchesTheCustomerFacingPromise(t *testing.T) {
+	// The number of minutes the funnel's checkout page promises the customer.
+	// Kept as a literal on purpose: this test's whole job is to fail when the
+	// server drifts away from what the page says, so it must not read the
+	// number from the same place the server does.
+	const promisedToCustomer = 10 * time.Minute
+
+	if magicCodeTTL != promisedToCustomer {
+		t.Errorf(
+			"magicCodeTTL = %v, but the checkout page tells the customer their code is good for %v.\n"+
+				"A customer who believes the page has %v to use a code the server killed at %v.\n"+
+				"Fix the constant, or fix every 'Codes expire after 10 minutes' string in the funnel and the console.",
+			magicCodeTTL, promisedToCustomer, promisedToCustomer, magicCodeTTL,
+		)
+	}
+}
+
+// TestMagicCodeTTLMatchesConsolePinTTL keeps the two sign-in paths from
+// drifting apart again. catalyst-api's pinstore.go is the reference; a
+// customer signing in at checkout and a sovereign-admin signing in at the
+// console are doing the same thing with the same kind of credential and must
+// get the same window.
+//
+// The reference value is restated here rather than imported because
+// catalyst-api is a separate Go module (products/catalyst/bootstrap/api) with
+// no dependency edge to this one — importing it to share a constant would
+// couple the marketplace auth service to the whole provisioning API.
+func TestMagicCodeTTLMatchesConsolePinTTL(t *testing.T) {
+	// products/catalyst/bootstrap/api/internal/handler/pinstore.go:31
+	const consolePinTTL = 10 * time.Minute
+
+	if magicCodeTTL != consolePinTTL {
+		t.Errorf(
+			"magicCodeTTL = %v but the console PIN path uses %v (pinstore.go). "+
+				"Two sign-in surfaces, one credential type, two expiry windows — pick one.",
+			magicCodeTTL, consolePinTTL,
+		)
+	}
+}
+
+// TestMagicCodeTTLIsReportedToTheClient pins the mechanism that stops this
+// drifting a third time: the send response carries the expiry, so the page can
+// render the truth instead of a hardcoded sentence that nobody re-checks when
+// the constant moves.
+//
+// This asserts on the VALUE the handler would put on the wire, not merely that
+// some field exists — a test for the field's presence would pass on a zero.
+func TestMagicCodeTTLIsReportedToTheClient(t *testing.T) {
+	got := magicCodeExpiresInSec()
+
+	if got == 0 {
+		t.Fatal("magicCodeExpiresInSec() = 0 — the client would render a '0 minutes' expiry notice")
+	}
+	if want := int(magicCodeTTL.Seconds()); got != want {
+		t.Errorf("magicCodeExpiresInSec() = %d, want %d (magicCodeTTL = %v)", got, want, magicCodeTTL)
+	}
+}

--- a/core/services/provisioning/handlers/app_pod_match_4297_test.go
+++ b/core/services/provisioning/handlers/app_pod_match_4297_test.go
@@ -4,10 +4,41 @@ import "testing"
 
 // #4297 — the provisioning workflow's app-readiness poll must match the right
 // pod-name shape per tier. Vcluster-tier (M+) app pods are synced up to the
-// host ns as `<appSlug>-...-x-apps-x-vcluster`; host-tier (free/S, no vcluster)
-// pods run natively in the host ns as `<appSlug>-...`. A host-tier wait that
-// looked for the syncer suffix would never match → 10-min timeout → false
-// provision failure. This locks the pure matcher.
+// host ns with a `-x-<inner-namespace>-x-vcluster` tail; host-tier (free/S, no
+// vcluster) pods run natively in the host ns as `<appSlug>-...`.
+//
+// WHY THESE FIXTURES ARE COPIED OFF A LIVE CLUSTER (UAT row 86).
+//
+// The previous version of this test invented every pod name it asserted on,
+// and every invented name used the inner namespace `apps`:
+//
+//	{"vcluster synced pod matches", "wordpress-7d9f-x-apps-x-vcluster", ...}
+//
+// `apps` has not been the inner namespace since #4290 made it the Org slug.
+// So the fixtures agreed with the matcher's hardcoded `-x-apps-x-vcluster`
+// literal, the suite went green, and the production matcher could not match a
+// single real pod. Measured read-only on hw292-a: pods cluster-wide carrying
+// `-x-apps-x-vcluster` = ZERO, while namespace `uatco` held
+// `mysql-5b9d89cbc6-hh6jt-x-uatco-x-vcluster` 1/1 Running and
+// `wordpress-678cbb45dc-lv6hw-x-uatco-x-vcluster` 1/1 Running.
+//
+// That is UAT row 86: `waitForVclusterApp` polled for ten minutes, matched
+// nothing, and failed the provision with "app mysql not ready in uatco after
+// 10m0s" — while mysql had been Ready within seconds and stayed up for days.
+// The customer's timeline showed a permanent red step for a healthy Org.
+//
+// The same hardcoded literal broke the HOST tier in the opposite direction:
+// the host branch is documented as rejecting a stray synced pod from a sibling
+// vcluster Org sharing the ns, but it only rejected pods whose inner namespace
+// was literally `apps` — so a real synced pod sailed through the check that
+// existed to stop it. One wrong constant, a false negative on one tier and a
+// false positive on the other.
+//
+// The names below are therefore VERBATIM live pod names, not constructed ones.
+// The identical trap was already caught and fixed in the sibling file — see
+// backing_services.go's `vclusterInnerPodName` and
+// backing_services_vcluster_suffix_5451_test.go, whose fixture discipline this
+// follows. `appPodNameMatches` was never migrated onto that helper.
 func TestAppPodNameMatches_TierAware(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -16,19 +47,30 @@ func TestAppPodNameMatches_TierAware(t *testing.T) {
 		isVcluster bool
 		want       bool
 	}{
-		// Vcluster tier — only the syncer-suffixed pod matches.
-		{"vcluster synced pod matches", "wordpress-7d9f-x-apps-x-vcluster", "wordpress", true, true},
-		{"vcluster native pod does NOT match", "wordpress-7d9f", "wordpress", true, false},
-		{"vcluster wrong app", "ghost-7d9f-x-apps-x-vcluster", "wordpress", true, false},
+		// ---- Vcluster tier, VERBATIM live names from hw292-a ns uatco ----
+		// These are the exact pods the row-86 provision was waiting for.
+		{"live mysql synced pod matches", "mysql-5b9d89cbc6-hh6jt-x-uatco-x-vcluster", "mysql", true, true},
+		{"live wordpress synced pod matches", "wordpress-678cbb45dc-lv6hw-x-uatco-x-vcluster", "wordpress", true, true},
+		// Cross-checks against the same live pair.
+		{"vcluster wrong app", "mysql-5b9d89cbc6-hh6jt-x-uatco-x-vcluster", "wordpress", true, false},
+		{"vcluster native pod does NOT match", "wordpress-678cbb45dc", "wordpress", true, false},
 
-		// Host tier — only the native-named pod matches; a stray synced pod from
-		// a sibling vcluster Org sharing the ns must NOT satisfy the wait.
+		// The inner namespace is the Org slug and varies per Org — the matcher
+		// must not care which one it is.
+		{"different org slug still matches", "ghost-abc123-x-walk-stranger-two-x-vcluster", "ghost", true, true},
+		{"legacy apps inner ns still matches", "wordpress-7d9f-x-apps-x-vcluster", "wordpress", true, true},
+
+		// ---- Host tier ----
 		{"host native pod matches", "wordpress-7d9f", "wordpress", false, true},
-		{"host rejects synced pod", "wordpress-7d9f-x-apps-x-vcluster", "wordpress", false, false},
 		{"host wrong app", "ghost-7d9f", "wordpress", false, false},
+		// The rejection this branch was written for, with a REAL inner ns. The
+		// old literal let this through.
+		{"host rejects synced pod from a sibling org", "wordpress-678cbb45dc-lv6hw-x-uatco-x-vcluster", "wordpress", false, false},
+		{"host rejects legacy-shaped synced pod", "wordpress-7d9f-x-apps-x-vcluster", "wordpress", false, false},
 
-		// Prefix discipline — a different app whose name starts similarly.
+		// ---- Prefix discipline ----
 		{"prefix boundary respected", "wordpress2-7d9f", "wordpress", false, false},
+		{"prefix boundary respected on synced pod", "wordpress2-7d9f-x-uatco-x-vcluster", "wordpress", true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -37,5 +79,27 @@ func TestAppPodNameMatches_TierAware(t *testing.T) {
 					tc.podName, tc.appSlug, tc.isVcluster, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestAppPodNameMatches_NoHardcodedInnerNamespace is the guard that would have
+// caught the original defect on the day it was written.
+//
+// It asserts the property that actually matters — the matcher works for an
+// arbitrary Org slug — rather than enumerating slugs, so it cannot be satisfied
+// by adding one more fixture to the table above.
+func TestAppPodNameMatches_NoHardcodedInnerNamespace(t *testing.T) {
+	// Every one of these is a plausible Org slug; `apps` is deliberately NOT
+	// among them, because that is the value the broken matcher was pinned to.
+	for _, innerNS := range []string{"uatco", "walk-stranger-two", "acme", "a", "org-with-many-dashes"} {
+		podName := "mysql-5b9d89cbc6-hh6jt-x-" + innerNS + "-x-vcluster"
+
+		if !appPodNameMatches(podName, "mysql", true) {
+			t.Errorf("vcluster tier: %q did not match slug %q — the matcher is tied to a specific inner namespace",
+				podName, "mysql")
+		}
+		if appPodNameMatches(podName, "mysql", false) {
+			t.Errorf("host tier: %q matched, but a synced pod must never satisfy a host-tier wait", podName)
+		}
 	}
 }

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -847,25 +847,37 @@ func (h *Handler) waitForHelmRelease(ctx context.Context, namespace, name string
 // matched; a host-tier wait that looked for the `-x-apps-x-vcluster` suffix
 // would never match and would always time out.
 // appPodNameMatches is the #4297 TIER-AWARE pod-name matcher. For the VCLUSTER
-// tier the app pod is synced up to the host ns with the
-// `<appSlug>-...-x-apps-x-vcluster` shape; for the HOST tier (no vcluster) the
-// pod runs natively in the host ns as `<appSlug>-...`. Extracted as a pure
-// function so the tier split is unit-testable without a live kube-API.
+// tier the app pod is synced up to the host ns as
+// `<appSlug>-...-x-<inner-namespace>-x-vcluster`; for the HOST tier (no
+// vcluster) the pod runs natively in the host ns as `<appSlug>-...`. Extracted
+// as a pure function so the tier split is unit-testable without a live
+// kube-API.
 //
-// The host-tier match is intentionally STRICT: it requires the slug-prefixed
-// name to NOT carry the vcluster syncer suffix, so a stray synced pod from a
-// sibling vcluster Org sharing the host ns can't satisfy a host-tier wait.
+// The host-tier match is intentionally STRICT: a synced pod from a sibling
+// vcluster Org sharing the host ns must NOT satisfy a host-tier wait.
+//
+// UAT row 86: this used to hardcode the inner namespace as `apps`
+// (`-x-apps-x-vcluster`). Since #4290 the inner namespace is the ORG SLUG, so
+// the literal matched nothing on any real cluster — measured on hw292-a, zero
+// pods cluster-wide carried it while `mysql-...-x-uatco-x-vcluster` was 1/1
+// Running. Every vcluster-tier dependency and app wait therefore ran its full
+// 10-minute budget and failed the provision for an Org that was already
+// healthy. The same literal defeated the host-tier rejection above, which only
+// excluded pods whose inner namespace happened to be `apps`.
+//
+// Delegating to vclusterInnerPodName (backing_services.go) is the point: that
+// helper already handles an arbitrary inner namespace and was written when
+// #5451 caught this exact defect in the sibling code path. There must be one
+// definition of "is this a synced pod", not two.
 func appPodNameMatches(podName, appSlug string, isVcluster bool) bool {
-	prefix := appSlug + "-"
-	if !strings.HasPrefix(podName, prefix) {
-		return false
-	}
-	const vclusterSuffix = "-x-apps-x-vcluster"
+	inner, synced := vclusterInnerPodName(podName)
 	if isVcluster {
-		return strings.HasSuffix(podName, vclusterSuffix)
+		// Vcluster tier — must be a synced pod, and the INNER name (the name
+		// the pod has inside the vcluster) is what carries the app slug.
+		return synced && strings.HasPrefix(inner, appSlug+"-")
 	}
-	// Host tier — native name, MUST NOT be a synced vcluster pod.
-	return !strings.HasSuffix(podName, vclusterSuffix)
+	// Host tier — native name only, never a synced pod from any Org.
+	return !synced && strings.HasPrefix(podName, appSlug+"-")
 }
 
 func (h *Handler) waitForVclusterApp(ctx context.Context, namespace, appSlug string, timeout time.Duration, isVcluster bool) error {


### PR DESCRIPTION
Three defects on the customer purchase path (UAT rows 84 and 86), each with a test that fails without the fix. None of them needed a working SMTP server to find.

## Row 84 — the sign-in code at checkout

**The page promised twice the expiry it granted.** The notice under the 6-digit boxes read `Codes expire after 10 minutes` as a hardcoded sentence; `core/services/auth` issued codes with `magicCodeTTL = 5 * time.Minute`. A customer who took six minutes typed a code the page still presented as valid and was told it was invalid — ordinary timing when the sign-in mail is relayed off-Sovereign (#5921) and can queue.

The **constant** moved rather than the copy, because 10 is what every other surface already states:

| Surface | Value |
|---|---|
| `products/catalyst/bootstrap/api/.../pinstore.go:31` `pinTTL` (console PIN — same 6-digit credential, same 5-attempt cap) | 10 min |
| `CheckoutStep.svelte`, `VerifyPinPage.tsx`, `PinSignInModal.tsx` | 10 min |
| OAuth CSRF state minted in **this same file** | 10 min |
| `magicCodeTTL` | **5 min** |

Not a security loosening: the brute-force budget is unchanged — 5 wrong guesses still invalidate the code, and the per-IP verify limiter is untouched. That is the bound catalyst-api has shipped at 10 minutes.

The send response now returns `expires_in_sec` and the page renders it, so the promise and the constant cannot drift apart again.

**An expired code was a dead end.** `authMode` went `'login' -> 'verify'` and was never set back *anywhere* in the component — no resend, no "wrong address?", no back. Once a code expired, every further attempt returned `invalid or expired code`, the 5-attempt cap then burned the code outright, and the only escape was reloading the page and losing funnel state. On the last screen before a purchase.

There is now a **Send a new code** control returning to the email stage. Returning there rather than silently re-sending is deliberate: the commonest reason a code never arrives is a typo in the address, and a blind resend posts a second code to the same wrong mailbox. When the server says the code is gone, the page leads with that instead of leaving the customer retyping something that cannot work.

That control composes mail to a caller-chosen address, so issuance is now rate-limited per source IP in **its own bucket**, separate from verify — a resend must not eat the verify allowance the customer needs immediately after.

## Row 86 — the timeline's permanent red step

`appPodNameMatches` hardcoded the vCluster inner namespace as `apps`. Since #4290 it is the **Org slug**. Measured read-only on hw292-a:

```
pods cluster-wide carrying "-x-apps-x-vcluster":  0

uatco  mysql-5b9d89cbc6-hh6jt-x-uatco-x-vcluster       1/1 Running
uatco  wordpress-678cbb45dc-lv6hw-x-uatco-x-vcluster   1/1 Running
```

So `waitForVclusterApp` polled its full ten minutes, matched nothing, and failed the provision with `app mysql not ready in uatco after 10m0s` — for a database Ready within seconds that stayed up for days. **The 10-minute budget was never the problem; the wait could not have succeeded at any budget.**

The same literal broke the host tier in the *opposite* direction: that branch exists to reject a stray synced pod from a sibling Org sharing the namespace, but it only rejected pods whose inner namespace was literally `apps`, so real synced pods sailed through the check written to stop them. One wrong constant — a false negative on one tier, a false positive on the other. The uninstall wait (`consumer.go:950`) shares the matcher and is repaired with it.

The fix delegates to `vclusterInnerPodName`, which already handles an arbitrary inner namespace — it was written when #5451 caught this exact defect in the sibling code path. `appPodNameMatches` was never migrated onto it. One definition of "is this a synced pod", not two.

### Why the suite stayed green

`app_pod_match_4297_test.go` invented every pod name it asserted on, and every invented name used `apps` — the fixtures transcribed the bug, so the guard passed on a matcher that could not match a single real pod. Fixtures are now verbatim live pod names, plus a property test that the matcher works for an *arbitrary* Org slug, which cannot be satisfied by adding one more name to the table.

## Verbatim failures without the fix

```
--- FAIL: TestMagicCodeTTLMatchesTheCustomerFacingPromise
    magicCodeTTL = 5m0s, but the checkout page tells the customer their
    code is good for 10m0s.
--- FAIL: TestMagicCodeTTLMatchesConsolePinTTL
    magicCodeTTL = 5m0s but the console PIN path uses 10m0s (pinstore.go).
```

```
× the verify screen derives its notice from the helper
    expected '{:else}...' to contain 'codeExpiryNotice'
× some path returns the component to the email stage
    expected '<script lang="ts">...' to match /authMode\s*=\s*'login'/
× the verify screen itself offers that path
× the handler behind that control really resets the stage
    expected null not to be null
```

```
--- FAIL: TestAppPodNameMatches_TierAware/live_mysql_synced_pod_matches
    appPodNameMatches("mysql-5b9d89cbc6-hh6jt-x-uatco-x-vcluster", "mysql",
      isVcluster=true) = false, want true
--- FAIL: TestAppPodNameMatches_TierAware/host_rejects_synced_pod_from_a_sibling_org
    appPodNameMatches("wordpress-678cbb45dc-lv6hw-x-uatco-x-vcluster",
      "wordpress", isVcluster=false) = true, want false
--- FAIL: TestAppPodNameMatches_NoHardcodedInnerNamespace
    vcluster tier: "mysql-...-x-uatco-x-vcluster" did not match slug "mysql"
      — the matcher is tied to a specific inner namespace
```

The client suite's 8 **control** assertions pass before and after — they prove the verify-stage markup was really extracted and the Go constant really parsed, so the 4 failures above are not an empty-string artifact.

## Verification

| Check | Result |
|---|---|
| `core/services/auth` `go build ./... && go vet ./... && go test ./...` | ok |
| `core/services/provisioning` `go build ./... && go vet ./... && go test ./...` | ok, all 5 packages |
| `core/marketplace` `vitest run` | 119 passed, 8 files |
| `npm run build` + `check-served-domain-hygiene` | clean, 37 files, zero banned domain literals |
| `check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` | `No platform/products Chart.yaml files changed` |
| `check-no-banned-words.sh` | OK |

**Render proof, not just source assertions** — the built bundle `dist/_astro/CheckoutStep.*.js` carries the derived expiry (`Codes expire after ${t} ${t===1?...}`) and `Send a new code`, and the literal `Codes expire after 10 minutes` appears **nowhere** in `dist/`.

No chart is touched, so the five lockstep sites do not move.

## What this does not do

Row 84's headline cause is untouched: the sign-in mail still leaves through `mail.openova.io`, the 9th sovereignty tether. That needs the relay work, not this.

Refs #5921 #3376
