### PR TITLE
fix(openova-mcp): resolve the Blueprint version an agentic create needs, and fail the Org binding closed

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_install_version_contract_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_install_version_contract_test.go
@@ -1,0 +1,87 @@
+// applications_install_version_contract_test.go — the install-body
+// DEFAULTING CONTRACT that products/openova-mcp depends on (#5516,
+// UAT rows 221/222).
+//
+// The agentic create chain has TWO sides and they must not drift:
+//
+//	PRODUCER (this package) — applicationInstallRequestNormalize decides
+//	which install-body fields a caller may omit; validateApplicationInstallRequest
+//	decides which are mandatory.
+//	CONSUMER (products/openova-mcp/internal/tools) — the MCP composes an
+//	install body from an agent's tool call, where the agent may legitimately
+//	know only "install wordpress in my org".
+//
+// The asymmetry that broke the chain: environmentRef, placement.mode and
+// placement.regions ARE defaulted here, but blueprintRef.version is NOT — it
+// is mandatory with no default and no server-side resolution. So a body that
+// omitted only the version 400'd, and the failure surfaced several hops from
+// its cause. The MCP now resolves an omitted version from the catalog (the
+// same source the console's InstallPage pins from) and refuses loudly when it
+// cannot.
+//
+// This test pins BOTH halves of that asymmetry, so if either side ever
+// changes the other's assumption is caught here rather than on a live walk.
+package handler
+
+import "testing"
+
+// Test_ApplicationInstall_VersionIsRequiredAndNeverDefaulted pins the exact
+// defaulting asymmetry the openova-mcp facade is built around.
+//
+// The control is the whole point: the SAME body, through the SAME normalize
+// call, comes back with environmentRef + placement.mode + placement.regions
+// FILLED. So a failure here reads as "the version rule changed", never as
+// "normalize does nothing" — the assertion can distinguish the two.
+func Test_ApplicationInstall_VersionIsRequiredAndNeverDefaulted(t *testing.T) {
+	// The body an agent-driven create produces: a Blueprint, a name, an Org,
+	// and nothing else.
+	body := applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-wordpress"},
+		Name:            "shop",
+		OrganizationRef: "acme",
+	}
+
+	got := applicationInstallRequestNormalize(body)
+
+	// ── CONTROL: these three ARE defaulted, so the assertion below is a
+	// statement about `version` specifically, not about normalize being inert.
+	if got.EnvironmentRef != "acme-prod" {
+		t.Fatalf("control failed: environmentRef must default to <org>-prod, got %q — "+
+			"if this changed, the openova-mcp create_application tool description "+
+			"(which tells agents environment is optional) is now wrong too", got.EnvironmentRef)
+	}
+	if got.Placement.Mode != "singleton" {
+		t.Fatalf("control failed: placement.mode must default to singleton, got %q", got.Placement.Mode)
+	}
+	if len(got.Placement.Regions) != 1 || got.Placement.Regions[0] != "primary" {
+		t.Fatalf("control failed: placement.regions must default to [primary], got %v", got.Placement.Regions)
+	}
+
+	// ── THE ASYMMETRY: version is NOT defaulted…
+	if got.BlueprintRef.Version != "" {
+		t.Errorf("blueprintRef.version is now defaulted server-side to %q. That is a CONTRACT CHANGE: "+
+			"products/openova-mcp resolves an omitted version from GET /api/v1/catalog precisely because "+
+			"this side does not. Update catalystapi.ResolveBlueprintVersion + its doc comment together with this.",
+			got.BlueprintRef.Version)
+	}
+
+	// …and it is MANDATORY, so an omitted version is a hard 400 rather than a
+	// benign default. This is why the MCP must refuse locally instead of
+	// forwarding an empty version.
+	msg, ok := validateApplicationInstallRequest(got)
+	if ok {
+		t.Fatalf("an install body with no blueprintRef.version was accepted. If the version is now optional, "+
+			"the openova-mcp catalog round-trip is dead weight and should be removed; got msg=%q", msg)
+	}
+	if msg != "blueprintRef.version is required" {
+		t.Errorf("the version rejection message changed to %q — openova-mcp's error text references this contract", msg)
+	}
+
+	// The SAME body with a version pinned validates — proving the rejection
+	// above is attributable to the version and to nothing else in the body.
+	withVersion := got
+	withVersion.BlueprintRef.Version = "1.2.3"
+	if msg, ok := validateApplicationInstallRequest(withVersion); !ok {
+		t.Fatalf("the minimal body + a pinned version must validate; got %q", msg)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope_binding_failclosed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope_binding_failclosed_test.go
@@ -1,0 +1,162 @@
+// org_scope_binding_failclosed_test.go — the #4110 cross-Org binding must
+// FAIL CLOSED when the Org identity cannot be established (#5516).
+//
+// The binding in resolveOrganization used to read:
+//
+//	if sessionOrg != "" && resolvedSlug != "" && sessionOrg != resolvedSlug { 403 }
+//
+// so an EMPTY value on either side fell through as "no mismatch". An absent
+// value silently read as an absent constraint — the same defect class, in the
+// same chain, as a missing `deployment_id` claim reading as "no deployment".
+//
+// Both empty cases were reachable:
+//
+//   - `orgSlugFromHost` returns "" for any registered tenant host that is not
+//     `<console|api|marketplace|auth>.<slug>.<zone>` — a 2-label vanity host,
+//     or one fronted by a different service label. resolveOrgScope already
+//     KNEW this, which is why it falls back to the tenant id when the slug is
+//     empty; resolveOrganization had no such fallback and simply skipped the
+//     check.
+//   - an Org-scoped session (tier=org-admin) carrying an empty `org` claim
+//     skipped the binding outright.
+//
+// Why it matters here rather than as a generic hardening item: this is the
+// binding HandleOrgApplicationInstall relies on to force the Application CR
+// into the caller's own namespace. Skipping it means an Org session can WRITE
+// into a sibling Organization — the precise cross-Org denial UAT row 223
+// asserts the agentic path enforces.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// failClosedRegistry registers two Org tenants whose hosts carry NO derivable
+// slug (`orgSlugFromHost` returns "" for both — the leading label is not one
+// of console/api/marketplace/auth), plus one ordinary console-host Org used as
+// the control.
+func failClosedRegistry(t *testing.T) *store.TenantRegistry {
+	t.Helper()
+	reg, err := store.NewTenantRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	for _, r := range []store.TenantRegistration{
+		{
+			Host:                  "portal.demo.omani.homes", // leading label not in the slug switch → slug ""
+			TenantID:              "demo",
+			TenantKind:            store.TenantKindOrg,
+			OrganizationNamespace: "org-demo-uuid",
+		},
+		{
+			Host:                  "portal.acme.omani.homes", // the sibling Org a demo session must never reach
+			TenantID:              "acme",
+			TenantKind:            store.TenantKindOrg,
+			OrganizationNamespace: "org-acme-uuid",
+		},
+		{
+			Host:                  "console.demo.omani.homes", // ordinary shape → slug "demo"
+			TenantID:              "demo",
+			TenantKind:            store.TenantKindOrg,
+			OrganizationNamespace: "org-demo-uuid",
+		},
+	} {
+		if err := reg.Put(r); err != nil {
+			t.Fatalf("put %s: %v", r.Host, err)
+		}
+	}
+	return reg
+}
+
+func failClosedInstall(t *testing.T, host string, claims *auth.Claims) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]any{"blueprint": "bp-wordpress", "version": "1.2.3", "name": "leak"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/org/applications", strings.NewReader(string(raw)))
+	req.Header.Set("X-Tenant-Host", host)
+	req.Header.Set("Content-Type", "application/json")
+	if claims != nil {
+		req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, claims))
+	}
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	h := &Handler{log: slog.New(slog.NewJSONHandler(io.Discard, nil))}
+	h.SetTenantRegistry(failClosedRegistry(t))
+	rec := httptest.NewRecorder()
+	h.HandleOrgApplicationInstall(rec, req)
+	return rec
+}
+
+// Test_ResolveOrganization_CrossOrgForgedHostWithNoDerivableSlug — THE HOLE.
+// A demo-scoped session forges the sibling Org's host. Because that host
+// yields no slug, the old binding skipped its comparison entirely and let the
+// request through to the install core, which would then force the Application
+// CR into ACME's namespace.
+//
+// WITHOUT THE FIX this fails: the response is the install core's
+// catalog-not-wired envelope instead of 403 org-scope-mismatch.
+func Test_ResolveOrganization_CrossOrgForgedHostWithNoDerivableSlug(t *testing.T) {
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "demo"}
+	rec := failClosedInstall(t, "portal.acme.omani.homes", claims)
+
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "org-scope-mismatch") {
+		t.Fatalf("a forged sibling-Org host must be 403 org-scope-mismatch even when the host carries no derivable slug; got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// Test_ResolveOrganization_OwnHostWithNoDerivableSlugStillPasses — THE
+// CONTROL. The same session, the same unusual host shape, but its OWN Org:
+// it must still be admitted, binding on the tenant id exactly as
+// resolveOrgScope stamps it. Without this the test above could be satisfied
+// by simply 403-ing every slug-less host, which would break every such Org.
+func Test_ResolveOrganization_OwnHostWithNoDerivableSlugStillPasses(t *testing.T) {
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "demo"}
+	rec := failClosedInstall(t, "portal.demo.omani.homes", claims)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("an Org session on its OWN tenant host must be admitted, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "catalog-not-wired") {
+		t.Fatalf("expected the install core to be reached (catalog-not-wired), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Test_ResolveOrganization_OrgScopedSessionWithEmptyOrgClaimIsDenied — the
+// second empty case. A tier=org-admin session carrying no `org` claim has no
+// Organization to be confined to, so it must be denied rather than admitted
+// to whichever Org its X-Tenant-Host names.
+func Test_ResolveOrganization_OrgScopedSessionWithEmptyOrgClaimIsDenied(t *testing.T) {
+	claims := &auth.Claims{Tier: orgScopedTier} // org-scoped tier, no Org
+	rec := failClosedInstall(t, "console.demo.omani.homes", claims)
+
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "org-scope-mismatch") {
+		t.Fatalf("an Org-scoped session with no org claim must be denied, not admitted to the named tenant; got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// Test_ResolveOrganization_SovereignAdminSessionIsUnaffected — the blast-radius
+// control. The binding applies ONLY to Org-scoped sessions; a sovereign-admin
+// (no org claim, non-org tier) legitimately operates any Organization and must
+// keep reaching the install core on any host. If the fail-closed change had
+// leaked past claimsAreOrgScoped, this is what would catch it.
+func Test_ResolveOrganization_SovereignAdminSessionIsUnaffected(t *testing.T) {
+	claims := &auth.Claims{Tier: "owner"}
+	rec := failClosedInstall(t, "portal.acme.omani.homes", claims)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("a sovereign-admin session must not be caught by the Org binding, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "catalog-not-wired") {
+		t.Fatalf("expected the install core to be reached (catalog-not-wired), got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_users.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_users.go
@@ -167,10 +167,33 @@ func (h *Handler) resolveOrganization(w http.ResponseWriter, r *http.Request) (s
 	// session's `org` claim (stamped from the request host at PIN-verify,
 	// which the customer cannot forge). A Sovereign-admin session has no
 	// org claim and is unaffected (it may legitimately operate any Org).
+	//
+	// FAIL CLOSED (#5516). This check used to read
+	// `sessionOrg != "" && resolvedSlug != "" && sessionOrg != resolvedSlug`,
+	// so BOTH empty cases fell through as "no mismatch" — an absent value
+	// silently read as an absent constraint, which is the identical defect
+	// class that cost this chain a week under a different name (a missing
+	// `deployment_id` claim reading as "no deployment"). The two holes were
+	// real, not theoretical: `orgSlugFromHost` returns "" for any registered
+	// tenant host that is not `<service>.<slug>.<zone>`, and an Org-scoped
+	// session (tier=org-admin) with an empty `org` claim skipped the binding
+	// entirely. Either one let an Org session resolve — and, via
+	// HandleOrgApplicationInstall, WRITE an Application CR into — a sibling
+	// Organization's namespace.
+	//
+	// The bound identity is now computed EXACTLY as resolveOrgScope computes
+	// the claim it is compared against (slug-from-host, falling back to the
+	// tenant id), so the producer of the claim and this consumer of it can
+	// never disagree about what the Org is called.
 	if claims := auth.ClaimsFromContext(r.Context()); claimsAreOrgScoped(claims) {
 		sessionOrg := strings.ToLower(strings.TrimSpace(claims.Org))
-		resolvedSlug := strings.ToLower(strings.TrimSpace(orgSlugFromHost(host)))
-		if sessionOrg != "" && resolvedSlug != "" && sessionOrg != resolvedSlug {
+		boundOrg := strings.ToLower(strings.TrimSpace(orgSlugFromHost(host)))
+		if boundOrg == "" {
+			// Same fallback resolveOrgScope uses when the host shape carries
+			// no slug — that IS the value stamped into the session's claim.
+			boundOrg = strings.ToLower(strings.TrimSpace(t.TenantID))
+		}
+		if sessionOrg == "" || boundOrg == "" || sessionOrg != boundOrg {
 			writeJSON(w, http.StatusForbidden, map[string]string{
 				"error":  "org-scope-mismatch",
 				"detail": "this Organization session may only access its own Organization",

--- a/products/openova-mcp/README.md
+++ b/products/openova-mcp/README.md
@@ -34,6 +34,13 @@ ships:
    - `list_environments` — derived from the caller's Applications (Catalyst
      has no standalone list-environments REST endpoint; the console derives
      env partitions the same way, so the facade does too).
+   - `list_blueprints` — `GET /api/v1/catalog`, the installable Blueprints
+     with the exact **version** to pin. This is the discovery half of the
+     agentic create chain: `blueprintRef.version` is mandatory upstream and
+     is *not* server-defaulted, so without a catalog tool an agent asked to
+     "install wordpress" has no way to compose a body the install validator
+     accepts. The console never hits this because its Install page composes
+     the body from the selected catalog card.
 5. **The first WRITE tool** — `create_application` (UAT rows 221-223):
    - `create_application` — installs (creates) an Application in the caller's
      Org from a Blueprint by forwarding the canonical install-request body to
@@ -49,6 +56,19 @@ ships:
      tool is **admin-tier-gated** in `tools/list` (a viewer never sees it),
      mirroring the console Install gate, and a hand-crafted viewer call is
      re-denied at layer-2.
+   - **Version resolution.** `version` is optional on the tool; when omitted
+     it is resolved from the Blueprint's catalog entry — the same value the
+     console's Install page pins. An explicitly supplied version is honoured
+     verbatim and costs no catalog round-trip. A Blueprint the catalog does
+     not publish is refused **here**, naming the Blueprint and pointing at
+     `list_blueprints`; an empty version is never forwarded, because upstream
+     it becomes an opaque `blueprintRef.version is required` 400 attributed to
+     the create rather than to the unknown Blueprint. The defaulting contract
+     this relies on (environmentRef / placement.mode / placement.regions ARE
+     server-defaulted, `blueprintRef.version` is NOT) is pinned from the
+     catalyst-api side by
+     `handler.Test_ApplicationInstall_VersionIsRequiredAndNeverDefaulted`, so
+     the two sides cannot drift apart silently.
 
 ## How the thin-facade + RBAC parity holds
 

--- a/products/openova-mcp/internal/catalystapi/client.go
+++ b/products/openova-mcp/internal/catalystapi/client.go
@@ -33,6 +33,7 @@ package catalystapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -375,6 +376,100 @@ func (c *Client) ListApplicationsOrg(ctx context.Context, bearer string) (*Appli
 	return out, nil
 }
 
+// ── Blueprint catalog (GET /api/v1/catalog) ──────────────────────────────
+
+// CatalogBlueprintVersion mirrors one entry of `versions[]` on a catalog
+// row (handler.CatalogBlueprintVersion). Only the fields the MCP needs to
+// pin an install are decoded.
+type CatalogBlueprintVersion struct {
+	Version  string `json:"version"`
+	ChartRef string `json:"chartRef,omitempty"`
+}
+
+// CatalogBlueprintCard mirrors the presentational half of a catalog row —
+// what the console renders on the card, and what an agent needs to tell a
+// user WHICH Blueprint it is about to install.
+type CatalogBlueprintCard struct {
+	Title   string `json:"title,omitempty"`
+	Summary string `json:"summary,omitempty"`
+}
+
+// CatalogBlueprint mirrors handler.CatalogBlueprint, decoded down to the
+// fields the MCP surfaces: the Blueprint name, its HEADLINE version (the
+// one the console's InstallPage pins) and the full version index.
+type CatalogBlueprint struct {
+	Name     string                    `json:"name"`
+	Version  string                    `json:"version"`
+	Card     CatalogBlueprintCard      `json:"card"`
+	Versions []CatalogBlueprintVersion `json:"versions,omitempty"`
+}
+
+// CatalogListResponse mirrors handler.CatalogListResponseEnvelope.
+type CatalogListResponse struct {
+	Items     []CatalogBlueprint `json:"items"`
+	Origins   []string           `json:"origins,omitempty"`
+	EmptyHint string             `json:"emptyHint,omitempty"`
+}
+
+// ListCatalog calls GET /api/v1/catalog — the read-only Blueprint catalog.
+//
+// This path IS on the catalyst-api's orgSafePathPrefixes allowlist
+// ("/api/v1/catalog", org_scope.go), so an Org-scoped session reaches it;
+// it is the SAME feed the console's InstallPage reads to compose an install
+// body. It is the only source of a valid `blueprintRef.version`, which the
+// install validator requires and does not default.
+func (c *Client) ListCatalog(ctx context.Context, bearer string) (*CatalogListResponse, error) {
+	var out CatalogListResponse
+	if err := c.get(ctx, "/api/v1/catalog", bearer, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ErrBlueprintNotInCatalog is returned by ResolveBlueprintVersion when the
+// catalog carries no row for the requested Blueprint. It is a DISTINCT
+// sentinel from a transport failure on purpose: "the catalog answered and
+// your Blueprint is not in it" and "the catalog could not be reached" must
+// never collapse into the same message, or a wiring fault reads to the
+// agent as a typo in the Blueprint name.
+var ErrBlueprintNotInCatalog = errors.New("blueprint not in catalog")
+
+// ResolveBlueprintVersion returns the version the catalog publishes for
+// blueprint, mirroring exactly what the console's InstallPage pins
+// (`selectedCard.version`, falling back to the first `versions[]` entry when
+// the row carries no headline version).
+//
+// It NEVER guesses: an unknown Blueprint, or a known Blueprint whose catalog
+// row publishes no version at all, returns an error rather than an empty
+// string. An empty version silently forwarded upstream is precisely the
+// failure this exists to prevent — it becomes an opaque
+// `blueprintRef.version is required` 400 several hops away from its cause.
+func (c *Client) ResolveBlueprintVersion(ctx context.Context, blueprint, bearer string) (string, error) {
+	want := strings.ToLower(strings.TrimSpace(blueprint))
+	if want == "" {
+		return "", fmt.Errorf("%w: empty blueprint name", ErrBlueprintNotInCatalog)
+	}
+	resp, err := c.ListCatalog(ctx, bearer)
+	if err != nil {
+		return "", err
+	}
+	for _, it := range resp.Items {
+		if strings.ToLower(strings.TrimSpace(it.Name)) != want {
+			continue
+		}
+		if v := strings.TrimSpace(it.Version); v != "" {
+			return v, nil
+		}
+		for _, ver := range it.Versions {
+			if v := strings.TrimSpace(ver.Version); v != "" {
+				return v, nil
+			}
+		}
+		return "", fmt.Errorf("%w: catalog row for %q publishes no version", ErrBlueprintNotInCatalog, blueprint)
+	}
+	return "", fmt.Errorf("%w: %q", ErrBlueprintNotInCatalog, blueprint)
+}
+
 // ListOrganizations calls GET /api/v1/organizations.
 func (c *Client) ListOrganizations(ctx context.Context, bearer string) (*OrganizationListResponse, error) {
 	var out OrganizationListResponse
@@ -441,11 +536,25 @@ type ApplicationPlacement struct {
 // CreateApplicationRequest is the body POSTed to the install endpoint. It
 // is the EXACT long-form `applicationInstallRequest` shape the console
 // Install button posts — the MCP reuses the same wire contract rather than
-// inventing a parallel one. Fields the caller omits are filled by the
-// catalyst-api's applicationInstallRequestNormalize (EnvironmentRef
-// defaults to "<org>-prod"; Placement defaults to a single-region
-// "primary"), so a minimal {blueprintRef, name, organizationRef} body is
-// a valid create.
+// inventing a parallel one.
+//
+// Which fields the server fills, and which it does NOT (verified against
+// applicationInstallRequestNormalize + validateApplicationInstallRequest in
+// products/catalyst/bootstrap/api/internal/handler/applications.go):
+//
+//   - EnvironmentRef — DEFAULTED server-side to "<organizationRef>-prod".
+//   - Placement.Mode — DEFAULTED server-side to "singleton".
+//   - Placement.Regions — DEFAULTED server-side to ["primary"].
+//   - BlueprintRef.Version — **NOT defaulted**. The validator rejects an
+//     empty version with `blueprintRef.version is required` (400). The
+//     console never hits this because InstallPage.tsx composes the body from
+//     the selected CATALOG card (`selectedCard.version`); the MCP must do the
+//     same, which is what ResolveBlueprintVersion + the `list_blueprints`
+//     tool are for. Do NOT re-document a version-less body as valid — it is
+//     the shape that 400s the whole agentic create chain (UAT 221/222).
+//
+// So the minimal VALID body is {blueprintRef{name,version}, name,
+// organizationRef}.
 type CreateApplicationRequest struct {
 	BlueprintRef    ApplicationBlueprintRef `json:"blueprintRef"`
 	Name            string                  `json:"name"`

--- a/products/openova-mcp/internal/tools/blueprint_version_test.go
+++ b/products/openova-mcp/internal/tools/blueprint_version_test.go
@@ -1,0 +1,239 @@
+// blueprint_version_test.go — the Blueprint-version half of the agentic
+// create chain (UAT rows 221/222, #5516).
+//
+// THE DEFECT these lock down: `blueprintRef.version` is REQUIRED by the
+// catalyst-api install validator and is NOT one of the fields
+// applicationInstallRequestNormalize defaults (environmentRef,
+// placement.mode and placement.regions all are). The MCP's
+// create_application schema marks `version` optional, and the MCP exposed no
+// catalog tool at all — so an agent handed "install wordpress in my org" had
+// no way to learn a version the validator accepts. Omitting it forwarded
+// `"version":""` and earned an opaque 400 several hops from its cause; the
+// console never hits this because InstallPage.tsx composes the install body
+// from the selected CATALOG CARD.
+//
+// Every pre-existing create test in tools_test.go passes an explicit
+// "version": "1.2.3", so none of them could ever have caught this.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+)
+
+// catalogBody is the GET /api/v1/catalog envelope catalyst-api's
+// HandleCatalogList returns (CatalogListResponseEnvelope).
+const catalogBody = `{"items":[
+  {"name":"bp-wordpress","version":"1.2.3","card":{"title":"WordPress","summary":"Blog + CMS"},
+   "versions":[{"version":"1.2.3","chartRef":"oci://ghcr.io/openova-io/bp-wordpress:1.2.3"},
+               {"version":"1.1.0","chartRef":"oci://ghcr.io/openova-io/bp-wordpress:1.1.0"}]},
+  {"name":"bp-gitea","version":"0.9.0","card":{"title":"Gitea"},"versions":[{"version":"0.9.0"}]}
+],"origins":["public"]}`
+
+// TestCreateApplicationOmittedVersionResolvedFromCatalog — THE ROW-221 CASE.
+// The agent is asked to "create a wordpress app" and supplies no version.
+// The facade must resolve it from the catalog (exactly what the console's
+// Install page does) so the POSTed body carries a version the catalyst-api
+// install validator accepts.
+//
+// WITHOUT THE FIX this fails on `blueprintRef.version` == "" — the body that
+// upstream rejects with `blueprintRef.version is required`.
+func TestCreateApplicationOmittedVersionResolvedFromCatalog(t *testing.T) {
+	var sawBody map[string]any
+	var sawPaths []string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sawPaths = append(sawPaths, r.Method+" "+r.URL.Path)
+		if r.URL.Path == "/api/v1/catalog" {
+			return jsonResp(200, catalogBody), nil
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &sawBody)
+		return jsonResp(201, `{"kind":"Application","name":"shop","namespace":"acme","httpStatus":"201","applied":true}`), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	// No "version" key at all — the shape a chat-driven create produces.
+	args, _ := json.Marshal(map[string]any{"blueprint": "bp-wordpress", "name": "shop"})
+	if _, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierAdmin), "create_application", args); err != nil {
+		t.Fatalf("create with omitted version should succeed, got %v", err)
+	}
+
+	br, _ := sawBody["blueprintRef"].(map[string]any)
+	if br == nil {
+		t.Fatalf("no install body reached the backend; requests seen: %v", sawPaths)
+	}
+	if br["version"] != "1.2.3" {
+		t.Errorf("omitted version must be resolved from the catalog headline version; got %q (blueprintRef=%v, requests=%v)",
+			br["version"], br, sawPaths)
+	}
+	if br["name"] != "bp-wordpress" {
+		t.Errorf("blueprintRef.name not forwarded: %v", br)
+	}
+	// The resolution must read the catalog, not invent a version.
+	joined := strings.Join(sawPaths, ", ")
+	if !strings.Contains(joined, "GET /api/v1/catalog") {
+		t.Errorf("version must come from GET /api/v1/catalog, not a guess; requests: %s", joined)
+	}
+}
+
+// TestCreateApplicationExplicitVersionIsNotOverridden — THE CONTROL that
+// makes the assertion above meaningful. The same catalog publishes 1.2.3;
+// an explicitly pinned 1.1.0 must survive verbatim. If the assertion in the
+// test above passed by unconditionally stamping the catalog version, this
+// test fails — so the pair proves the code branches on absence, not that it
+// rewrites every create.
+func TestCreateApplicationExplicitVersionIsNotOverridden(t *testing.T) {
+	var sawBody map[string]any
+	catalogHits := 0
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/api/v1/catalog" {
+			catalogHits++
+			return jsonResp(200, catalogBody), nil
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &sawBody)
+		return jsonResp(201, `{"kind":"Application","name":"shop"}`), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	args, _ := json.Marshal(map[string]any{"blueprint": "bp-wordpress", "version": "1.1.0", "name": "shop"})
+	if _, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierAdmin), "create_application", args); err != nil {
+		t.Fatalf("create with explicit version should succeed, got %v", err)
+	}
+	br, _ := sawBody["blueprintRef"].(map[string]any)
+	if br["version"] != "1.1.0" {
+		t.Errorf("an explicitly pinned version must be honoured verbatim, got %q", br["version"])
+	}
+	if catalogHits != 0 {
+		t.Errorf("an explicit version must not cost a catalog round-trip; got %d", catalogHits)
+	}
+}
+
+// TestCreateApplicationUnknownBlueprintFailsLoud — the fail-LOUD half. A
+// Blueprint the catalog does not publish must be refused HERE, naming the
+// Blueprint and the tool that answers the question, and NO install may be
+// POSTed. Silently forwarding an empty version instead would surface as an
+// upstream `blueprintRef.version is required` 400 that reads as "the create
+// is broken" rather than "that Blueprint does not exist here" — the exact
+// misattribution class this chain has already lost days to.
+func TestCreateApplicationUnknownBlueprintFailsLoud(t *testing.T) {
+	posted := false
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/api/v1/catalog" {
+			return jsonResp(200, catalogBody), nil
+		}
+		posted = true
+		return jsonResp(201, `{"kind":"Application"}`), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	args, _ := json.Marshal(map[string]any{"blueprint": "bp-nosuchthing", "name": "shop"})
+	_, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierAdmin), "create_application", args)
+	if err == nil {
+		t.Fatalf("an uncatalogued Blueprint must be refused, not forwarded with an empty version")
+	}
+	if posted {
+		t.Errorf("no install may be POSTed when the version cannot be resolved")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "bp-nosuchthing") {
+		t.Errorf("the error must name the Blueprint, got %q", msg)
+	}
+	if !strings.Contains(msg, "list_blueprints") {
+		t.Errorf("the error must point at the tool that answers the question, got %q", msg)
+	}
+}
+
+// TestCreateApplicationCatalogUnreachableIsDistinctFromUnknownBlueprint —
+// a transport failure on the catalog must NOT be reported as "that Blueprint
+// does not exist". Collapsing the two would make a wiring fault read to the
+// agent (and to the user) as a typo.
+func TestCreateApplicationCatalogUnreachableIsDistinctFromUnknownBlueprint(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/api/v1/catalog" {
+			return jsonResp(502, `{"error":"catalog_upstream"}`), nil
+		}
+		return jsonResp(201, `{"kind":"Application"}`), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	args, _ := json.Marshal(map[string]any{"blueprint": "bp-wordpress", "name": "shop"})
+	_, err := reg.Call(context.Background(), orgIdentityNoDeployment("acme", identity.TierAdmin), "create_application", args)
+	if err == nil {
+		t.Fatalf("an unreachable catalog must fail the create, not post an empty version")
+	}
+	if strings.Contains(err.Error(), "list_blueprints") {
+		t.Errorf("a catalog transport failure must not be reported as an unknown Blueprint: %q", err)
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("the upstream status must survive so the real cause is visible: %q", err)
+	}
+}
+
+// TestListBlueprintsIsOfferedToAnOrgCallerAndReturnsVersions — the discovery
+// tool an agent needs before it can compose a create. It must be visible to
+// an Org-scoped, deployment-less caller (the real seeded bearer shape) and
+// must surface the version to pin.
+func TestListBlueprintsIsOfferedToAnOrgCallerAndReturnsVersions(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/api/v1/catalog" {
+			t.Errorf("list_blueprints must read the Org-safe catalog path, got %q", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer org-bearer" {
+			t.Errorf("caller identity must be forwarded: %q", r.Header.Get("Authorization"))
+		}
+		return jsonResp(200, catalogBody), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+	id := orgIdentityNoDeployment("acme", identity.TierViewer)
+
+	offered := false
+	for _, tool := range reg.List(id) {
+		if tool.Name == "list_blueprints" {
+			offered = true
+		}
+	}
+	if !offered {
+		t.Fatalf("list_blueprints must be offered to an Org-scoped caller")
+	}
+
+	out, err := reg.Call(context.Background(), id, "list_blueprints", nil)
+	if err != nil {
+		t.Fatalf("list_blueprints: %v", err)
+	}
+	m := out.(map[string]any)
+	if m["total"] != 2 {
+		t.Fatalf("want 2 blueprints, got %v", m["total"])
+	}
+	items := m["items"].([]map[string]any)
+	if items[0]["name"] != "bp-wordpress" || items[0]["version"] != "1.2.3" {
+		t.Errorf("catalog row not projected with its version: %v", items[0])
+	}
+	if items[0]["title"] != "WordPress" {
+		t.Errorf("card title not projected: %v", items[0])
+	}
+	vs, _ := items[0]["versions"].([]string)
+	if len(vs) != 2 || vs[0] != "1.2.3" {
+		t.Errorf("version index not projected: %v", items[0]["versions"])
+	}
+}

--- a/products/openova-mcp/internal/tools/catalogue.go
+++ b/products/openova-mcp/internal/tools/catalogue.go
@@ -1,9 +1,14 @@
 // catalogue.go — the OpenOva MCP tool catalogue.
 //
 // The READ tools (whoami, list_organizations, list_environments,
-// list_applications, get_application) are Org-scoped (RequiredContext is
-// empty so they are offered in both Org + Sovereign contexts, since a
-// sovereign-admin can read any Org).
+// list_applications, get_application, list_blueprints) are Org-scoped
+// (RequiredContext is empty so they are offered in both Org + Sovereign
+// contexts, since a sovereign-admin can read any Org).
+//
+// list_blueprints is the DISCOVERY half of the write path (#5516): the
+// install validator requires `blueprintRef.version` and does not default it,
+// so an agent that cannot read the catalog cannot compose a create the
+// catalyst-api will accept. See resolveBlueprintVersion.
 //
 // The FIRST WRITE tool — create_application (#3988, UAT rows 221-223) —
 // ships alongside them: it reuses the SAME UI create seam
@@ -32,6 +37,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -87,15 +93,22 @@ func catalogue() []Tool {
 			Handler: handleGetApplication,
 		},
 		{
+			Name:        "list_blueprints",
+			Description: "List the Blueprints installable on this Sovereign, each with the exact VERSION to pin. Thin facade over GET /api/v1/catalog — the same feed the console's Install page reads. Call this before create_application to learn a Blueprint's name and version.",
+			InputSchema: emptyObj,
+			MinTier:     identity.TierViewer,
+			Handler:     handleListBlueprints,
+		},
+		{
 			Name:        "create_application",
-			Description: "Install (create) an Application in the caller's Organization from a Blueprint — the SAME action as the console's Install button. Reuses POST /api/v1/sovereigns/{id}/applications (the shared create seam), so the Org namespace is ensured and the Application CR is written by the catalyst-api exactly once. RBAC-scoped: an Org-scoped caller may create ONLY in their own Organization (a cross-Org organizationRef is forbidden); a sovereign-admin may create in any Organization. Requires tier-admin or higher (mirrors the console Install gate).",
+			Description: "Install (create) an Application in the caller's Organization from a Blueprint — the SAME action as the console's Install button. Reuses the shared create seam, so the Org namespace is ensured and the Application CR is written by the catalyst-api exactly once. Omitted `version` is resolved from the Blueprint's catalog entry, so \"install bp-wordpress in my org\" is a complete request. RBAC-scoped: an Org-scoped caller may create ONLY in their own Organization (a cross-Org organizationRef is forbidden); a sovereign-admin may create in any Organization. Requires tier-admin or higher (mirrors the console Install gate).",
 			InputSchema: map[string]any{
 				"type":                 "object",
 				"additionalProperties": false,
 				"required":             []string{"blueprint", "name"},
 				"properties": map[string]any{
-					"blueprint":      map[string]any{"type": "string", "description": "Blueprint to install, e.g. bp-wordpress (must start with bp-)."},
-					"version":        map[string]any{"type": "string", "description": "Blueprint version to pin, e.g. 1.2.3. Required by the catalyst-api install validator."},
+					"blueprint":      map[string]any{"type": "string", "description": "Blueprint to install, e.g. bp-wordpress (must start with bp-). Use list_blueprints to see what this Sovereign publishes."},
+					"version":        map[string]any{"type": "string", "description": "Blueprint version to pin, e.g. 1.2.3. Optional — when omitted it is resolved from the Blueprint's catalog entry (the same version the console's Install page pins). A Blueprint absent from the catalog is an error, never a guess."},
 					"name":           map[string]any{"type": "string", "description": "Application name (metadata.name): RFC-1123 lowercase alphanumeric + hyphens, 1-63 chars. Doubles as the app's purpose."},
 					"organization":   map[string]any{"type": "string", "description": "Target Organization (slug or FQDN, e.g. acme or hw178.omani.works). OPTIONAL in Org context — defaults to the caller's own Org; a value naming a DIFFERENT Org is forbidden for an Org-scoped caller. REQUIRED for a sovereign-admin (no implicit Org)."},
 					"environment":    map[string]any{"type": "string", "description": "Target Environment ref, e.g. acme-prod. Optional — defaults to <organization>-prod."},
@@ -277,8 +290,14 @@ func handleCreateApplication(ctx context.Context, id *identity.Identity, api *ca
 		return nil, err
 	}
 
+	blueprint := strings.TrimSpace(in.Blueprint)
+	version, err := resolveBlueprintVersion(ctx, api, blueprint, strings.TrimSpace(in.Version), bearerOf(id))
+	if err != nil {
+		return nil, err
+	}
+
 	req := catalystapi.CreateApplicationRequest{
-		BlueprintRef:    catalystapi.ApplicationBlueprintRef{Name: strings.TrimSpace(in.Blueprint), Version: strings.TrimSpace(in.Version)},
+		BlueprintRef:    catalystapi.ApplicationBlueprintRef{Name: blueprint, Version: version},
 		Name:            strings.TrimSpace(in.Name),
 		OrganizationRef: targetOrg,
 		EnvironmentRef:  strings.TrimSpace(in.Environment),
@@ -309,6 +328,85 @@ func handleCreateApplication(ctx context.Context, id *identity.Identity, api *ca
 		return nil, err
 	}
 	return api.CreateApplication(ctx, depID, req, bearerOf(id))
+}
+
+// handleListBlueprints lists the installable Blueprints with the exact
+// version to pin — the discovery half of the agentic create chain
+// (UAT 221/222). Without it an agent asked to "install wordpress" has no way
+// to learn either the `bp-` name or a version the install validator accepts,
+// so its only possible outcome is a 400 from several hops away.
+//
+// Thin facade over GET /api/v1/catalog, which IS on the catalyst-api's
+// Org-safe allowlist, so an Org-scoped session reaches it with no
+// deployment binding and no Sovereign reach.
+func handleListBlueprints(ctx context.Context, id *identity.Identity, api *catalystapi.Client, _ json.RawMessage) (any, error) {
+	if api == nil {
+		return nil, fmt.Errorf("catalyst-api client not configured")
+	}
+	resp, err := api.ListCatalog(ctx, bearerOf(id))
+	if err != nil {
+		return nil, err
+	}
+	items := make([]map[string]any, 0, len(resp.Items))
+	for _, bp := range resp.Items {
+		name := strings.TrimSpace(bp.Name)
+		if name == "" {
+			continue
+		}
+		versions := make([]string, 0, len(bp.Versions))
+		for _, v := range bp.Versions {
+			if s := strings.TrimSpace(v.Version); s != "" {
+				versions = append(versions, s)
+			}
+		}
+		row := map[string]any{"name": name, "version": strings.TrimSpace(bp.Version)}
+		if len(versions) > 0 {
+			row["versions"] = versions
+		}
+		if t := strings.TrimSpace(bp.Card.Title); t != "" {
+			row["title"] = t
+		}
+		if s := strings.TrimSpace(bp.Card.Summary); s != "" {
+			row["summary"] = s
+		}
+		items = append(items, row)
+	}
+	return map[string]any{"items": items, "total": len(items)}, nil
+}
+
+// resolveBlueprintVersion returns the version to stamp on the install body.
+//
+// An explicitly supplied version is ALWAYS honoured verbatim — pinning is
+// the caller's prerogative and the catalog never overrides it. Only an
+// OMITTED version is resolved, from the Blueprint's catalog entry, which is
+// exactly what the console does (InstallPage.tsx composes blueprintRef from
+// the selected catalog card, so the console can never post an empty
+// version).
+//
+// The failure posture is deliberate. `blueprintRef.version` is REQUIRED by
+// the catalyst-api install validator
+// (handler/applications.go — "blueprintRef.version is required") and is NOT
+// one of the fields applicationInstallRequestNormalize defaults, unlike
+// environmentRef / placement.mode / placement.regions. So an unresolved
+// version must NOT be forwarded as "": that turns a knowable, local,
+// nameable condition into an opaque upstream 400 attributed to the create
+// itself. We fail here instead, naming the Blueprint and the tool that
+// answers the question.
+func resolveBlueprintVersion(ctx context.Context, api *catalystapi.Client, blueprint, requested, bearer string) (string, error) {
+	if requested != "" {
+		return requested, nil
+	}
+	if api == nil {
+		return "", fmt.Errorf("catalyst-api client not configured")
+	}
+	version, err := api.ResolveBlueprintVersion(ctx, blueprint, bearer)
+	if err != nil {
+		if errors.Is(err, catalystapi.ErrBlueprintNotInCatalog) {
+			return "", fmt.Errorf("cannot resolve a version for blueprint %q: %w — call list_blueprints for the Blueprints this Sovereign publishes, or pass an explicit version", blueprint, err)
+		}
+		return "", fmt.Errorf("cannot resolve a version for blueprint %q from the catalog: %w — pass an explicit version to install without the catalog", blueprint, err)
+	}
+	return version, nil
 }
 
 // resolveCreateTargetOrg resolves + Org-scope-checks the target


### PR DESCRIPTION
## What this is

The agentic end-to-end chain — a User chats with the Agenity solo agent, the agent
calls the openova-mcp `create_application` tool with the User's Org-scoped token, and
an Application CR appears in that User's Org — had **two** remaining defects after the
`deployment_id` routing work landed.

Neither is the missing claim itself. That was already adjudicated the other way and
shipped: an Org-scoped session is not deployment-bound, `requireDeployment` gates only
the Sovereign-context seam, and Org context routes to the own-org seam instead. Both
ends still read exactly that way today, and re-adding the claim would break the
byte-for-byte parity that `Test_mintOrgScopedMCPBearer_ClaimKeySetMatchesPinVerifyOrgSession`
locks — and fix nothing, because `OrgScopeGuard` 403s the deployment-addressed path for
`tier=org-admin` regardless of claims.

So this PR fixes what actually stands between the chat message and the CR.

## 1 — `create_application` could not succeed from a natural request

`blueprintRef.version` is **required** by `validateApplicationInstallRequest` and is
**not** filled by `applicationInstallRequestNormalize`. That is an asymmetry:
`environmentRef`, `placement.mode` and `placement.regions` all *are* defaulted there.

The MCP marked `version` optional in its tool schema and exposed **no catalog tool at
all**, so an agent handed "install wordpress in my org" had no way to learn a version
the validator accepts. Omitting it forwarded `"version":""` and earned an opaque 400
several hops from its cause. The console never hits this: `InstallPage.tsx` composes
the install body from the selected **catalog card** (`selectedCard.version`).

Every pre-existing create test passes an explicit `"version": "1.2.3"`, so none of them
could ever have caught it.

- New `list_blueprints` tool over `GET /api/v1/catalog` — already on the catalyst-api
  Org-safe allowlist, so an Org session reaches it with no deployment binding and no
  Sovereign reach. This is the discovery half the write path was missing.
- An omitted `version` now resolves from that same catalog entry — the same value the
  console pins. An explicit version is honoured verbatim and costs no round-trip.
- An uncatalogued Blueprint is refused **in the facade**, naming the Blueprint and
  pointing at `list_blueprints`. A catalog transport failure stays a **distinct** error,
  so a wiring fault never reads to the agent as a typo in the Blueprint name.
- The client doc comment that documented a version-less body as valid is corrected — it
  described the exact shape that breaks the chain.

## 2 — the #4110 cross-Org binding failed OPEN on an absent value

`resolveOrganization` read:

    if sessionOrg != "" && resolvedSlug != "" && sessionOrg != resolvedSlug { 403 }

so an empty value on **either** side fell through as "no mismatch" — an absent value
silently reading as an absent constraint. That is the same defect class, in the same
chain, as a missing claim reading as "no deployment".

Both empties were reachable. `orgSlugFromHost` returns `""` for any registered tenant
host that is not `<console|api|marketplace|auth>.<slug>.<zone>` — `resolveOrgScope`
already knew this and falls back to the tenant id, but this consumer of the same value
had no fallback and simply skipped the check. And a `tier=org-admin` session carrying an
empty `org` claim skipped the binding outright.

This is the binding `HandleOrgApplicationInstall` relies on to force the Application CR
into the caller's own namespace, so skipping it means an Org session can **write** into a
sibling Organization — the exact cross-Org denial UAT row 223 asserts the agentic path
enforces. The bound identity is now computed exactly as `resolveOrgScope` computes the
claim it is compared against, and anything unresolvable is 403.

## Evidence

Each test below was run with the source change reverted (`git stash push` of the source
files only, tests left in place). Verbatim:

```
--- FAIL: TestCreateApplicationOmittedVersionResolvedFromCatalog (0.00s)
    blueprint_version_test.go:76: omitted version must be resolved from the catalog headline version; got "" (blueprintRef=map[name:bp-wordpress version:], requests=[POST /api/v1/org/applications])
    blueprint_version_test.go:85: version must come from GET /api/v1/catalog, not a guess; requests: POST /api/v1/org/applications
--- FAIL: TestCreateApplicationUnknownBlueprintFailsLoud (0.00s)
    blueprint_version_test.go:149: an uncatalogued Blueprint must be refused, not forwarded with an empty version
--- FAIL: TestCreateApplicationCatalogUnreachableIsDistinctFromUnknownBlueprint (0.00s)
    blueprint_version_test.go:181: an unreachable catalog must fail the create, not post an empty version
--- FAIL: TestListBlueprintsIsOfferedToAnOrgCallerAndReturnsVersions (0.00s)
    blueprint_version_test.go:217: list_blueprints must be offered to an Org-scoped caller
FAIL
```

```
--- FAIL: Test_ResolveOrganization_CrossOrgForgedHostWithNoDerivableSlug (0.00s)
    org_scope_binding_failclosed_test.go:111: a forged sibling-Org host must be 403 org-scope-mismatch even when the host carries no derivable slug; got 503: {"applied":false,"code":"503","detail":"catalog client unconfigured (CATALYST_CATALOG_URL); install requires the catalog upstream","error":"catalog-not-wired","httpStatus":"503","kind":"Application","status":"503"}
--- FAIL: Test_ResolveOrganization_OrgScopedSessionWithEmptyOrgClaimIsDenied (0.00s)
    org_scope_binding_failclosed_test.go:142: an Org-scoped session with no org claim must be denied, not admitted to the named tenant; got 503: {"applied":false,"code":"503","detail":"catalog client unconfigured (CATALYST_CATALOG_URL); install requires the catalog upstream","error":"catalog-not-wired","httpStatus":"503","kind":"Application","status":"503"}
FAIL
```

That 503 is the install core's `catalog-not-wired` envelope — i.e. the forged request had
already passed org-resolution and namespace-forcing and was inside the shared install
core. That is what the fail-open let through.

### Controls — the assertions answer both ways

- `TestCreateApplicationExplicitVersionIsNotOverridden` passes **with and without** the
  fix. It pins `1.1.0` against a catalog publishing `1.2.3` and asserts zero catalog
  round-trips, so the test above cannot be satisfied by unconditionally stamping the
  catalog version over every create.
- `Test_ResolveOrganization_OwnHostWithNoDerivableSlugStillPasses` — the same unusual
  host shape, for the caller's OWN Org, must still reach the install core. So the denial
  above cannot be satisfied by 403-ing every slug-less host.
- `Test_ResolveOrganization_SovereignAdminSessionIsUnaffected` — blast radius: a
  sovereign-admin legitimately operates any Organization and must not be caught.
- `Test_ApplicationInstall_VersionIsRequiredAndNeverDefaulted` asserts from the
  **catalyst-api** side that `environmentRef` / `placement.mode` / `placement.regions`
  ARE defaulted while `blueprintRef.version` is NOT. The control means a failure reads
  as "the version rule changed", never as "normalize is inert" — and the producer and
  consumer of that contract can no longer drift apart silently, which is the drift guard
  #5516 asked for.

### Gates

Run chained, not as separate lines:

```
(cd products/openova-mcp && go build ./... && go vet ./... && go test ./...) \
  && (cd products/catalyst/bootstrap/api && go build ./... && go vet ./... && go test ./internal/handler/) \
  && git commit
```

Full `internal/handler` suite green at 262.9s (no regression from the fail-closed
change), full `products/openova-mcp` suite green.

## Not claimed

No live walk. Rows 217 / 221 / 222 / 223 stay where they are until an operator walks a
Sovereign and stamps them with evidence — merge is not a walk. Row 217 is the PIN/SSO
journey and is untouched by this change.

Refs #5516
