### PR TITLE
fix(org-services): the workload named tenant is what put a banned term in the console (UAT row 121)

### DIFF
--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -189,7 +189,13 @@ data:
   # each other directly using these too.
   AUTH_URL: "http://auth.org-services.svc.cluster.local:8081"
   CATALOG_URL: "http://catalog.org-services.svc.cluster.local:8082"
-  TENANT_URL: "http://tenant.org-services.svc.cluster.local:8083"
+  # The env-var KEY stays TENANT_URL (every consumer's main.go reads that
+  # name; renaming it here without renaming them would silently fall back
+  # to each service's own hardcoded default). The VALUE moves to the
+  # canonical `organizations` Service — #5435 / UAT row 121. The old
+  # `tenant` Service is kept one release as an annotated alias, so a pod
+  # that has not rolled yet still resolves.
+  TENANT_URL: "http://organizations.org-services.svc.cluster.local:8083"
   PROVISIONING_URL: "http://provisioning.org-services.svc.cluster.local:8084"
   BILLING_URL: "http://billing.org-services.svc.cluster.local:8085"
   DOMAIN_URL: "http://domain.org-services.svc.cluster.local:8086"

--- a/products/catalyst/chart/templates/org-services/organization.yaml
+++ b/products/catalyst/chart/templates/org-services/organization.yaml
@@ -1,21 +1,41 @@
 {{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+# UAT row 121 / #5435 — the workload NAME is an operator-facing string.
+#
+# This Deployment was called `tenant`, and the sovereign console's
+# platform-overhead showback table keys its rows on the Deployment name
+# (applicationKey → ReplicaSet → Deployment, dashboard.go:681, feeding
+# GET /api/v1/org/consumption). So `tenant` — banned as an entity-noun by
+# docs/GLOSSARY.md — rendered verbatim at `/billing/orders` as a row
+# labelled `tenant` with `data-testid=showback-app-tenant`, on a Sovereign
+# whose console source contains the word nowhere. No source grep could see
+# it: the term arrived from a live Kubernetes object name.
+#
+# The rename is therefore the fix, not a cosmetic. `core/services/tenant/
+# handlers/routes.go` had already canonicalised the ROUTES to
+# `/organizations` and left the workload behind; this finishes that.
+#
+# The old `tenant` Service is KEPT below as an annotated one-release alias
+# on purpose: consumers read `TENANT_URL` from the `org-services-config`
+# ConfigMap, and a ConfigMap change does NOT roll a Deployment, so pods
+# that have not yet restarted still dial the old host. Removing the
+# Service in the same release would break them mid-upgrade.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tenant
+  name: organizations
   namespace: org-services
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: org-tenant
+      app: org-organizations
   template:
     metadata:
       labels:
         policy.cilium.io/enforced: "true"  # Wave 5.121 #2466
-        app: org-tenant
+        app: org-organizations
     spec:
-      serviceAccountName: tenant
+      serviceAccountName: organizations
       # TBD-D35a — must be true so the SandboxOrchestrator
       # (core/services/tenant/handlers/sandbox_consumer.go) can build an
       # in-cluster dynamic client and materialise Sandbox CRs in
@@ -30,7 +50,7 @@ spec:
       imagePullSecrets:
         - name: ghcr-pull
       containers:
-        - name: tenant
+        - name: organizations
           image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-tenant:{{ .Values.images.orgTag }}"
           imagePullPolicy: Always
           ports:
@@ -112,11 +132,34 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: tenant
+  name: organizations
   namespace: org-services
 spec:
   selector:
-    app: org-tenant
+    app: org-organizations
+  ports:
+    - port: 8083
+      targetPort: 8083
+---
+# One-release deprecation alias for the pre-#5435 `tenant` Service. Every
+# consumer (billing, domain, gateway, notification) resolves this host
+# from `org-services-config`'s TENANT_URL, and a ConfigMap edit does not
+# restart a Deployment, so a pod that has not rolled yet still dials
+# `tenant.org-services.svc`. Keeping the alias makes the rename a
+# non-event for them; it goes away one release after every consumer has
+# rolled onto the canonical name. It is a Service, not a workload, so it
+# never reaches the showback table — that keys on the Deployment (row 121).
+# naming-guard: alias
+apiVersion: v1
+kind: Service
+metadata:
+  name: tenant
+  namespace: org-services
+  annotations:
+    catalyst.openova.io/deprecated-alias-for: organizations
+spec:
+  selector:
+    app: org-organizations
   ports:
     - port: 8083
       targetPort: 8083

--- a/products/catalyst/chart/templates/org-services/serviceaccounts.yaml
+++ b/products/catalyst/chart/templates/org-services/serviceaccounts.yaml
@@ -39,7 +39,10 @@ metadata:
   namespace: org-services
 automountServiceAccountToken: false
 ---
-# tenant SA — TBD-D35a: tenant service hosts the SandboxOrchestrator
+# organizations SA (renamed from `tenant`, #5435 / UAT row 121 — the
+# workload identity is renamed in lockstep with the Deployment so a
+# `kubectl get sa -n org-services` read carries no banned entity-noun
+# either) — TBD-D35a: the service hosts the SandboxOrchestrator
 # (core/services/tenant/handlers/sandbox_consumer.go) which materialises
 # Sandbox.sandbox.openova.io CRs in `catalyst-system` on every
 # `tenant.sandbox_requested` event. The orchestrator builds an in-cluster
@@ -54,7 +57,7 @@ automountServiceAccountToken: false
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: tenant
+  name: organizations
   namespace: org-services
 automountServiceAccountToken: true
 ---
@@ -86,7 +89,7 @@ roleRef:
   name: tenant-sandbox-orchestrator
 subjects:
   - kind: ServiceAccount
-    name: tenant
+    name: organizations
     namespace: org-services
 ---
 apiVersion: v1

--- a/scripts/check-no-persona-machinery.sh
+++ b/scripts/check-no-persona-machinery.sh
@@ -41,6 +41,21 @@ declare -a MACHINERY=(
   'namespace:\s*sme\s*$'
   # Chart template directory named after the persona.
   'templates/sme-services'
+  # A Kubernetes object NAME (or a container name) that IS the persona
+  # word. #5435 / UAT row 121: the org-services Deployment was literally
+  # called `tenant`, and the sovereign console's platform-overhead
+  # showback table keys its rows on the Deployment name (applicationKey →
+  # ReplicaSet → Deployment, dashboard.go:681). So a banned entity-noun
+  # rendered at `/billing/orders` on a Sovereign whose console source
+  # contains the word NOWHERE — every prior banned-term sweep grepped the
+  # source and came back clean, because the string only exists at runtime
+  # as a Kubernetes object name. This pattern is the one shape a source
+  # grep could not otherwise see: an object whose whole name is the word.
+  # `name: tenant-sandbox-orchestrator` and `MONGODB_DB: "tenants"` are
+  # NOT matched — a compound name and a data value are not the defect.
+  # A deliberate compatibility Service keeps its old name behind the
+  # `naming-guard: alias` annotation, same as the route aliases.
+  '^\s*-?\s*name:\s*(tenant|tenants|sme|smes)\s*(#.*)?$'
 )
 
 # Patterns checked ONLY in Go files — exported Go identifiers naming
@@ -248,12 +263,56 @@ func reg(rg Router) {
 	rg.Post("/api/v1/sme/tenants", deprecatedAlias("/api/v1/organizations", h.Create))
 }
 EOF
+  # FIXTURE C (must FAIL): a Kubernetes workload whose NAME is the persona
+  # word — the #5435 / UAT row 121 shape. This is the fixture that would
+  # have caught the org-services `tenant` Deployment before it rendered a
+  # banned entity-noun into the sovereign console's showback table.
+  cat > "$tmp/products/x/bad_workload.yaml" <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tenant
+  namespace: org-services
+spec:
+  template:
+    spec:
+      containers:
+        - name: tenant
+EOF
+  # FIXTURE D (must PASS): the three shapes that look like C but are not
+  # the defect — an annotated one-release compatibility alias, a COMPOUND
+  # object name that merely contains the word, and a data VALUE.
+  cat > "$tmp/products/x/good_workload.yaml" <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-sandbox-orchestrator
+  namespace: catalyst-system
+---
+# naming-guard: alias
+apiVersion: v1
+kind: Service
+metadata:
+  name: tenant
+  namespace: org-services
+spec:
+  selector:
+    app: org-organizations
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: org-services-config
+data:
+  MONGODB_DB: "tenants"
+EOF
   git -C "$tmp" add -A >/dev/null 2>&1
 
-  local fail_ok=0 pass_ok=0
+  local fail_ok=0 pass_ok=0 name_fail_ok=0 name_pass_ok=0
 
   # Direction 1: the BAD file alone must trip the guard.
-  git -C "$tmp" rm -q --cached products/x/good_data.go >/dev/null 2>&1
+  git -C "$tmp" reset -q >/dev/null 2>&1
+  git -C "$tmp" add products/x/bad_route.go >/dev/null 2>&1
   if ROOT="$tmp" scan_tree "$tmp" >/dev/null 2>&1; then
     echo "SELF-TEST FAIL: a new /api/v1/sme/ route did NOT trip the guard"
   else
@@ -264,7 +323,6 @@ EOF
   # Direction 2: the GOOD file alone must PASS (Tier value + alias line).
   git -C "$tmp" reset -q >/dev/null 2>&1
   git -C "$tmp" add products/x/good_data.go >/dev/null 2>&1
-  git -C "$tmp" rm -q --cached products/x/bad_route.go >/dev/null 2>&1
   if ROOT="$tmp" scan_tree "$tmp" >/dev/null 2>&1; then
     echo "SELF-TEST OK: Tier \"sme\" data value + annotated alias PASS (data exemption)"
     pass_ok=1
@@ -272,8 +330,30 @@ EOF
     echo "SELF-TEST FAIL: a legitimate Tier \"sme\" value / alias was rejected"
   fi
 
-  if [ "$fail_ok" -eq 1 ] && [ "$pass_ok" -eq 1 ]; then
-    echo "SELF-TEST: BOTH directions proven."
+  # Direction 3 (#5435): a workload NAMED after the persona must trip it.
+  git -C "$tmp" reset -q >/dev/null 2>&1
+  git -C "$tmp" add products/x/bad_workload.yaml >/dev/null 2>&1
+  if ROOT="$tmp" scan_tree "$tmp" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: a Deployment named 'tenant' did NOT trip the guard"
+  else
+    echo "SELF-TEST OK: a Kubernetes object named 'tenant' is REJECTED (RED)"
+    name_fail_ok=1
+  fi
+
+  # Direction 4 (#5435): the near-misses must NOT trip it, or the guard is
+  # too broad to live with — a compound name, an annotated alias, a value.
+  git -C "$tmp" reset -q >/dev/null 2>&1
+  git -C "$tmp" add products/x/good_workload.yaml >/dev/null 2>&1
+  if ROOT="$tmp" scan_tree "$tmp" >/dev/null 2>&1; then
+    echo "SELF-TEST OK: compound name + annotated alias + data value PASS"
+    name_pass_ok=1
+  else
+    echo "SELF-TEST FAIL: a compound object name / alias / data value was rejected"
+  fi
+
+  if [ "$fail_ok" -eq 1 ] && [ "$pass_ok" -eq 1 ] &&
+     [ "$name_fail_ok" -eq 1 ] && [ "$name_pass_ok" -eq 1 ]; then
+    echo "SELF-TEST: BOTH directions proven, for routes AND object names."
     return 0
   fi
   return 1


### PR DESCRIPTION
## UAT row 121 — the banned term was a workload name, so no source grep could ever find it

Row 121's banned-term half has failed on every environment since hw290. The sovereign console renders a showback row literally labelled `tenant` at `/billing/orders`, with `data-testid=showback-app-tenant`, on a Sovereign whose console source contains the word **nowhere**.

**Cause.** The console keys each showback row on the workload NAME: `applicationKey` walks Pod → ReplicaSet → Deployment (`products/catalyst/bootstrap/api/internal/handler/dashboard.go:681`) and that value feeds `GET /api/v1/org/consumption`. One of the twelve org-services microservices was a Deployment literally named `tenant`. The term arrives at runtime from a Kubernetes object name — a source grep is structurally unable to see it, which is why several prior banned-term sweeps came back clean while the string was on screen.

`docs/GLOSSARY.md` bans `tenant` as an entity-noun. `core/services/tenant/handlers/routes.go` had already canonicalised the **routes** to `/organizations` and left the workload behind; this finishes that half.

### What changes

- Deployment / Service / ServiceAccount `tenant` → `organizations`; pod label `app: org-tenant` → `app: org-organizations`; the `tenant-sandbox-orchestrator` RoleBinding subject moves in lockstep.
- The old `tenant` Service is **kept one release as an annotated alias**. That is load-bearing, not caution: consumers read `TENANT_URL` from the `org-services-config` ConfigMap, and editing a ConfigMap does not roll a Deployment, so billing/domain/gateway/notification pods that have not restarted still dial `tenant.org-services.svc`. Removing the Service in the same release would break them mid-upgrade. A Service never reaches the showback table, so the alias does not re-open the defect.
- The ConfigMap **value** moves to the canonical host. The **key** stays `TENANT_URL` — every consumer's `main.go` reads that name, and renaming it here alone would silently fall through to each service's own hardcoded default.

### The guard, and proof it can fail

`scripts/check-no-persona-machinery.sh` already rejected persona-named routes, namespace declarations and chart template dirs. It had no pattern for the one shape that actually shipped: an object whose whole name **is** the banned word. It does now.

Run against the pre-change content of the two templates:

```
VIOLATION: .../org-services/organization.yaml:5      name: tenant
VIOLATION: .../org-services/organization.yaml:33     - name: tenant
VIOLATION: .../org-services/organization.yaml:115    name: tenant
VIOLATION: .../org-services/serviceaccounts.yaml:57  name: tenant
VIOLATION: .../org-services/serviceaccounts.yaml:89  name: tenant
PRE-FIX EXIT=1
```

On the fixed tree it exits 0, and `helm template` leaves exactly **one** `name: tenant` in the entire render — the annotated alias Service.

The self-test proves both directions on the new pattern, so it is neither vacuous nor too broad to live with:

```
SELF-TEST OK: a Kubernetes object named 'tenant' is REJECTED (RED)
SELF-TEST OK: compound name + annotated alias + data value PASS
```

Direction 4 is the one that matters for keeping the guard alive: `tenant-sandbox-orchestrator` (compound name), the annotated alias, and `MONGODB_DB: "tenants"` (a data value) all pass. A guard that failed on those would be switched off within a week.

### Delivery note

Umbrella template change with no catalog-seed pin move, so `check-umbrella-republish-gate.py` does not apply and the chart version is left to the deploy-bot — hand-picking a number here only risks a collision with a concurrent chart PR. Row 121 goes green on the walk after this reaches a Sovereign, not on merge.

Refs #5435 #3383
