### PR TITLE
fix(wizard): stop offering components that resolve to no Blueprint, and make the guard able to say so (UAT row W5)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -419,7 +419,13 @@ export const TOPOLOGY_REGION_LABELS: Record<TopologyTemplate, string[]> = {
 /** Base defaults: all M + all R in required blocks; optional blocks empty */
 export const DEFAULT_COMPONENT_GROUPS: Record<string, string[]> = {
   pilot:    ['flux', 'crossplane', 'gitea', 'opentofu', 'vcluster'],
-  spine:    ['cilium', 'coraza', 'powerdns', 'external-dns', 'envoy', 'frpc', 'netbird'],
+  // UAT row W5 / #5575: `envoy` and `frpc` dropped. This table is a SECOND
+  // component catalog — it seeds INITIAL_WIZARD_STATE.componentGroups — and
+  // nothing validated it against componentGroups.ts, so removing the cards
+  // alone would still have left both ids pre-selected on every fresh wizard
+  // run. componentGroups.catalog-integrity.5575.test.ts now cross-checks
+  // this table too.
+  spine:    ['cilium', 'coraza', 'powerdns', 'external-dns', 'netbird'],
   surge:    ['vpa', 'keda', 'reloader', 'continuum'],
   silo:     ['seaweedfs', 'velero', 'harbor'],
   guardian: ['kyverno', 'openbao', 'external-secrets', 'cert-manager', 'falco', 'trivy', 'syft-grype', 'sigstore', 'keycloak'],
@@ -467,10 +473,12 @@ export function getProfileDefaults(
     defaults.insights = [...defaults.insights, 'openmeter']
   }
 
-  // strongSwan IPsec: compliance-heavy or financial
-  if (isFinancial || isHealthcare || hasAuditComp) {
-    defaults.spine = [...defaults.spine, 'strongswan']
-  }
+  // The strongSwan IPsec profile rule is REMOVED, not re-pointed — UAT row
+  // W5 / #5575. `strongswan` resolved to no Blueprint, so for a financial /
+  // healthcare / audit-bound org this rule silently pre-selected an IPsec
+  // gateway that could never be installed: the profile most likely to
+  // actually need site-to-site VPN was the one handed a card that deploys
+  // nothing. Re-add the rule when a bp-strongswan exists.
 
   return defaults
 }

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepComponents.test.tsx
@@ -152,8 +152,28 @@ const MANDATORY = ALL_COMPONENTS.filter((c) => c.tier === 'mandatory')
 /* ── Catalog sanity ───────────────────────────────────────────────── */
 
 describe('component catalog', () => {
-  it('renders 60+ components from componentGroups.ts', () => {
-    expect(ALL_COMPONENTS.length).toBeGreaterThanOrEqual(60)
+  /**
+   * UAT row W5 / #5575 — this used to read
+   * `expect(ALL_COMPONENTS.length).toBeGreaterThanOrEqual(60)`.
+   *
+   * 60 was chosen when the catalog held 64 entries, six of which resolved
+   * to no Blueprint at all. So the number encoded the phantoms: removing an
+   * uninstallable card made the suite RED, and keeping one made it green.
+   * A floor that rewards padding is worse than no floor — it is an argument
+   * against ever cleaning the catalog up.
+   *
+   * What actually matters is the invariant, not the magnitude: every entry
+   * in ALL_COMPONENTS is a member of exactly one PRODUCTS family and every
+   * PRODUCTS member has a ComponentDef — the "counts are self-consistent"
+   * half of row W5. The floor is kept only as a truncation smoke test (a
+   * bad merge that empties a family), set well below the real size so it
+   * can never again be the thing that blocks a removal.
+   */
+  it('catalog size is self-consistent with the PRODUCTS families', () => {
+    const memberIds = PRODUCTS.flatMap((p) => p.components)
+    expect(new Set(memberIds).size).toBe(memberIds.length) // no id in two families
+    expect([...ALL_COMPONENTS.map((c) => c.id)].sort()).toEqual([...memberIds].sort())
+    expect(ALL_COMPONENTS.length).toBeGreaterThanOrEqual(40) // truncation smoke test
   })
 
   it('every component has a tier', () => {
@@ -1108,8 +1128,12 @@ describe('store: addProduct cascade', () => {
     useWizardStore.getState().addProduct('cortex')
     const sel = useWizardStore.getState().selectedComponents
     for (const id of [
+      // 'superset' left this list with its catalog card (UAT row W5 /
+      // #5575). A not.toContain on an id that no longer exists can never
+      // fail, so keeping it would have turned a real exclusion assertion
+      // into decoration.
       'strimzi', 'debezium', 'flink', 'temporal',
-      'clickhouse', 'iceberg', 'superset',
+      'clickhouse', 'iceberg',
     ]) {
       expect(sel).not.toContain(id)
     }
@@ -1226,8 +1250,12 @@ describe('addComponent → product family cascade (CORTEX)', () => {
     useWizardStore.getState().addComponent('specter')
     const sel = useWizardStore.getState().selectedComponents
     for (const id of [
+      // 'superset' left this list with its catalog card (UAT row W5 /
+      // #5575). A not.toContain on an id that no longer exists can never
+      // fail, so keeping it would have turned a real exclusion assertion
+      // into decoration.
       'strimzi', 'debezium', 'flink', 'temporal',
-      'clickhouse', 'iceberg', 'superset',
+      'clickhouse', 'iceberg',
     ]) {
       expect(sel).not.toContain(id)
     }

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentFootprints.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentFootprints.ts
@@ -86,10 +86,11 @@ export const COMPONENT_FOOTPRINTS: Record<string, ComponentFootprint> = {
   coraza:         { ramMb: 256,  cpuMilli: 100 },
   powerdns:       { ramMb: 512,  cpuMilli: 200 }, // pdns-auth + cnpg-pg side
   'external-dns': { ramMb: 64,   cpuMilli: 50  },
-  envoy:          { ramMb: 256,  cpuMilli: 200 },
-  frpc:           { ramMb: 64,   cpuMilli: 50  },
+  // envoy / frpc / strongswan removed with their catalog cards — UAT row
+  // W5 / #5575, no Blueprint source resolved for any of the three. Leaving
+  // the footprints behind would keep inflating the sizing estimate for
+  // workloads that can never be installed.
   netbird:        { ramMb: 256,  cpuMilli: 100 },
-  strongswan:     { ramMb: 128,  cpuMilli: 50  },
 
   /* ── SURGE — Scaling & Resilience ─────────────────────────────── */
   vpa:            { ramMb: 512,  cpuMilli: 150 }, // recommender + updater + admission-controller
@@ -135,7 +136,7 @@ export const COMPONENT_FOOTPRINTS: Record<string, ComponentFootprint> = {
   clickhouse:     { ramMb: 1024, cpuMilli: 500 },
   ferretdb:       { ramMb: 256,  cpuMilli: 100 },
   iceberg:        { ramMb: 256,  cpuMilli: 100 },
-  superset:       { ramMb: 768,  cpuMilli: 300 },
+  // superset removed with its catalog card — UAT row W5 / #5575.
 
   /* ── CORTEX — AI & Machine Learning ───────────────────────────── */
   kserve:         { ramMb: 384,  cpuMilli: 200 },
@@ -153,7 +154,7 @@ export const COMPONENT_FOOTPRINTS: Record<string, ComponentFootprint> = {
   livekit:        { ramMb: 768,  cpuMilli: 300 },
   stunner:        { ramMb: 256,  cpuMilli: 100 },
   matrix:         { ramMb: 1024, cpuMilli: 400 },
-  ntfy:           { ramMb: 128,  cpuMilli: 50  },
+  // ntfy removed with its catalog card — UAT row W5 / #5575.
 }
 
 /** Empty-footprint sentinel used for components missing from the catalog. */

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.catalog-integrity.5575.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.catalog-integrity.5575.test.ts
@@ -25,6 +25,7 @@ import { resolve, join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 
 import { ALL_COMPONENTS } from './componentGroups'
+import { DEFAULT_COMPONENT_GROUPS, getProfileDefaults } from '../../../entities/deployment/model'
 
 // ── locate the monorepo root (contains platform/ + products/ + clusters/) ────
 function repoRoot(): string {
@@ -46,17 +47,33 @@ function repoRoot(): string {
 
 const ROOT = repoRoot()
 
-// The 6 components #5575 found to resolve to no Blueprint. Tracked here as
-// EXPLICIT debt (Refs #5575) so they are visible, not hidden — the disposition
-// (remove vs. mark coming-soon vs. build the blueprint) is a product decision;
-// this list keeps the fail-closed gate green until then and blocks any NEW one.
-const KNOWN_UNBUILT: ReadonlySet<string> = new Set([
-  'envoy', // tier: mandatory, but the real envoy ships inside bp-cilium (cilium-envoy)
-  'frpc',
-  'strongswan',
-  'superset',
-  'ntfy',
-  'specter', // componentGroups.ts already comments "there is no bp-specter HelmRelease"
+// Tracked, non-mandatory debt: an offered component whose Blueprint is not
+// built YET. The map value is the reason, so the list can be argued with
+// rather than grown by reflex.
+//
+// UAT row W5 promoted this row to a determinate FAIL on 2026-08-10 with a
+// precise complaint about this very list: it held SIX ids, one of them
+// (`envoy`) at `tier: 'mandatory'`, and the first test below is written as
+// `unresolved === [...KNOWN_UNBUILT]`. A debt list that can absorb a
+// MANDATORY entry makes that test unable to fail for the case that matters
+// most — the operator cannot deselect a mandatory card, so every single
+// deployment emitted an id nothing could install, and the suite stayed
+// green. Five of the six are now REMOVED from the catalog outright
+// (componentGroups.ts carries the reasoning per family). `specter` stays
+// because it is not a phantom third-party card: it is an OpenOva product
+// with copy in the marketplace, an entry in the deployment store and a
+// documented `familyRequires: ['cortex']` cascade. Deleting it would be a
+// product decision; declaring it as bounded, non-mandatory debt is not.
+//
+// The bound is enforced, not merely written down — see the mandatory-tier
+// test below. That is the rule this row was actually failing on.
+const KNOWN_UNBUILT: ReadonlyMap<string, string> = new Map([
+  [
+    'specter',
+    'OpenOva AIOps component; componentGroups.ts already records "there is ' +
+      'no bp-specter HelmRelease". Optional tier, so an operator can decline ' +
+      'it. Refs #5575.',
+  ],
 ])
 
 // dependsOn targets that are legitimate infra edges but not selectable
@@ -112,10 +129,30 @@ describe('#5575 wizard component catalog integrity (fail-closed)', () => {
 
   it('every offered component resolves to a Blueprint, except tracked KNOWN_UNBUILT debt', () => {
     const unresolved = ids.filter(id => !resolvesToBlueprint(id)).sort()
-    const expected = [...KNOWN_UNBUILT].sort()
+    const expected = [...KNOWN_UNBUILT.keys()].sort()
     // Bidirectional: no NEW phantom (unresolved ⊆ KNOWN_UNBUILT) AND no stale
     // debt entry (KNOWN_UNBUILT ⊆ unresolved — a built one must leave the list).
     expect(unresolved).toEqual(expected)
+  })
+
+  it('no MANDATORY component may be tracked as unbuilt debt (UAT row W5)', () => {
+    // The rule the row was failing on, now enforced rather than described.
+    // `mandatory` means the operator cannot deselect the card, so a mandatory
+    // id with no Blueprint behind it is emitted by EVERY deployment this
+    // wizard produces. There is no tier of debt that makes that acceptable,
+    // and allowing it is what let the suite stay green while `envoy` shipped
+    // as an uninstallable mandatory card.
+    const byId = new Map(ALL_COMPONENTS.map(c => [c.id, c]))
+    const mandatoryDebt = [...KNOWN_UNBUILT.keys()]
+      .filter(id => byId.get(id)?.tier === 'mandatory')
+      .sort()
+    expect(mandatoryDebt).toEqual([])
+  })
+
+  it('every debt entry states a reason (the list is argued with, not grown)', () => {
+    for (const [id, reason] of KNOWN_UNBUILT) {
+      expect(reason.trim().length, `${id} carries no reason`).toBeGreaterThan(20)
+    }
   })
 
   it('every component dependency references a real component or tracked infra dep', () => {
@@ -129,12 +166,54 @@ describe('#5575 wizard component catalog integrity (fail-closed)', () => {
     expect([...dangling].sort()).toEqual([])
   })
 
-  it('the debt allowlist is non-empty and every entry is a real offered component (no typos)', () => {
-    // Vacuity: if the resolver silently broke and marked everything resolved,
-    // the first test would demand an EMPTY KNOWN_UNBUILT — this guards the other
-    // direction (the allowlist must reference ids that actually exist).
-    expect(KNOWN_UNBUILT.size).toBeGreaterThan(0)
+  it('every debt entry is a real offered component (no typos)', () => {
     const idSet = new Set(ids)
-    for (const id of KNOWN_UNBUILT) expect(idSet.has(id)).toBe(true)
+    for (const id of KNOWN_UNBUILT.keys()) expect(idSet.has(id)).toBe(true)
+  })
+
+  it('the DEFAULT/profile selection tables only name real components', () => {
+    // The second catalog. `DEFAULT_COMPONENT_GROUPS` (entities/deployment/
+    // model.ts) seeds INITIAL_WIZARD_STATE.componentGroups, and
+    // getProfileDefaults() adds to it per industry/compliance — neither was
+    // ever cross-checked against componentGroups.ts. That is how `envoy`,
+    // `frpc` and `strongswan` stayed PRE-SELECTED on a fresh wizard run
+    // even though they resolved to no Blueprint: removing their cards would
+    // not have removed them from the default selection. An id here that has
+    // no ComponentDef is invisible in the UI and still shipped in the
+    // payload, which is strictly worse than a visible phantom card.
+    const idSet = new Set(ids)
+    const profiles: Array<[string, string[], string]> = [
+      ['finance', ['PCI DSS'], '50,000'],
+      ['healthcare', ['HIPAA'], '500'],
+      ['software', ['SOC 2'], '100,000'],
+      ['retail', [], '200'],
+      ['', [], ''],
+    ]
+    const seen = new Set<string>()
+    for (const list of Object.values(DEFAULT_COMPONENT_GROUPS)) for (const id of list) seen.add(id)
+    for (const [ind, comp, size] of profiles) {
+      for (const list of Object.values(getProfileDefaults(ind, comp, size))) {
+        for (const id of list) seen.add(id)
+      }
+    }
+    const unknown = [...seen].filter(id => !idSet.has(id)).sort()
+    expect(unknown).toEqual([])
+    // Vacuity: the sweep must actually have collected ids.
+    expect(seen.size).toBeGreaterThan(20)
+  })
+
+  it('the resolver discriminates — it is not answering "yes" to everything', () => {
+    // The vacuity guard, and it had to be rewritten. It used to be
+    // `KNOWN_UNBUILT.size > 0`: a proxy that only works while debt exists,
+    // and therefore an argument FOR keeping phantoms in the catalog. It also
+    // never tested the resolver at all — a resolver that returned `true`
+    // unconditionally would still have passed it.
+    //
+    // This asks the resolver directly, both ways: a control id that certainly
+    // has Blueprint sources must resolve, and an id that certainly has none
+    // must not. If either direction breaks, the whole file is measuring
+    // nothing, and it says so here rather than reporting a clean catalog.
+    expect(resolvesToBlueprint('keycloak')).toBe(true)
+    expect(resolvesToBlueprint('definitely-not-a-blueprint-xyzzy')).toBe(false)
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.ts
@@ -214,10 +214,19 @@ export const GROUPS: GroupDef[] = [
       // square card tile — render the letter-mark fallback instead (#173).
       { id: 'powerdns',     name: 'PowerDNS',     desc: 'Authoritative DNS with DNSSEC signing and geographic failover', tier: 'mandatory',   dependencies: ['cnpg'], logoUrl: null },
       { id: 'external-dns', name: 'External DNS', desc: 'Reconciles Service, Ingress, Gateway into authoritative DNS',   tier: 'mandatory',   dependencies: ['powerdns'], logoUrl: basePath('component-logos/external-dns.png') },
-      { id: 'envoy',        name: 'Envoy',        desc: 'Programmable L7 proxy for routing, TLS, and gRPC',              tier: 'mandatory',   dependencies: [] },
-      { id: 'frpc',         name: 'frpc',         desc: 'Reverse tunnel client for Sovereigns behind NAT or firewalls',   tier: 'recommended', dependencies: [] },
+      // UAT row W5 / #5575 — `envoy`, `frpc` and `strongswan` were removed
+      // from this family. None of the three resolved to ANY Blueprint
+      // source: no platform/<id>, no products/<id>, no bootstrap-kit slot,
+      // no bp-<id> reference anywhere in the monorepo. Selecting them
+      // deployed nothing, silently.
+      //
+      // `envoy` was the sharp one: `tier: 'mandatory'`, so the operator
+      // could not deselect it and EVERY deployment emitted a component id
+      // that nothing could install. Envoy does ship on every Sovereign —
+      // as `cilium-envoy`, inside bp-cilium, which is already a mandatory
+      // card here. A second card for the proxy Cilium embeds was never a
+      // separate installable unit, only a duplicate of one.
       { id: 'netbird',      name: 'NetBird',      desc: 'Identity-bound mesh VPN over WireGuard for operators and sites', tier: 'mandatory',   dependencies: [], logoUrl: basePath('component-logos/netbird.png') },
-      { id: 'strongswan',   name: 'strongSwan',   desc: 'Standards-compliant IPsec gateway for partner site-to-site links', tier: 'optional', dependencies: [], logoUrl: basePath('component-logos/strongswan.png') },
     ],
   },
   {
@@ -329,7 +338,9 @@ export const GROUPS: GroupDef[] = [
       { id: 'clickhouse', name: 'ClickHouse',     desc: 'Columnar analytics database for sub-second OLAP queries',      tier: 'optional',    dependencies: [] },
       { id: 'ferretdb',   name: 'FerretDB',       desc: 'MongoDB wire protocol on PostgreSQL-backed storage',           tier: 'optional',    dependencies: ['cnpg'], logoUrl: basePath('component-logos/ferretdb.png') },
       { id: 'iceberg',    name: 'Iceberg',        desc: 'ACID lakehouse format with time travel over object storage',   tier: 'optional',    dependencies: ['seaweedfs'] },
-      { id: 'superset',   name: 'Superset',       desc: 'BI dashboards and SQL Lab for analytical exploration',         tier: 'optional',    dependencies: ['cnpg'] },
+      // `superset` removed — UAT row W5 / #5575: no Blueprint source of any
+      // kind resolved for it, so the card offered a BI stack that could not
+      // be installed.
     ],
   },
   {
@@ -390,7 +401,7 @@ export const GROUPS: GroupDef[] = [
       { id: 'livekit',  name: 'LiveKit',  desc: 'WebRTC SFU for Organization video and audio with encryption', tier: 'recommended', dependencies: [] },
       { id: 'stunner',  name: 'STUNner',  desc: 'Kubernetes-native TURN and STUN gateway for WebRTC media',  tier: 'recommended', dependencies: [] },
       { id: 'matrix',   name: 'Matrix',   desc: 'Federated end-to-end encrypted messaging with protocol bridges', tier: 'optional', dependencies: ['cnpg'] },
-      { id: 'ntfy',     name: 'Ntfy',     desc: 'Topic-based push notifications over HTTP with mobile subscribers', tier: 'optional', dependencies: [] },
+      // `ntfy` removed — UAT row W5 / #5575: no Blueprint source resolved.
     ],
   },
 ]
@@ -422,7 +433,7 @@ export const PRODUCTS: Product[] = [
     subtitle: 'Networking & Service Mesh',
     description: 'CNI, service mesh, load balancing, WAF, and encrypted VPN connectivity',
     tier: 'mandatory',
-    components: ['cilium', 'coraza', 'powerdns', 'external-dns', 'envoy', 'frpc', 'netbird', 'strongswan'],
+    components: ['cilium', 'coraza', 'powerdns', 'external-dns', 'netbird'],
     cascadeOnMemberSelection: false,
     familyDependencies: [],
   },
@@ -477,7 +488,7 @@ export const PRODUCTS: Product[] = [
     subtitle: 'Data & Integration',
     description: 'Event streaming, CDC, workflow orchestration, and analytics databases',
     tier: 'recommended',
-    components: ['cnpg', 'postgres', 'valkey', 'strimzi', 'debezium', 'flink', 'temporal', 'clickhouse', 'ferretdb', 'iceberg', 'superset'],
+    components: ['cnpg', 'postgres', 'valkey', 'strimzi', 'debezium', 'flink', 'temporal', 'clickhouse', 'ferretdb', 'iceberg'],
     // FABRIC is à-la-carte — Strimzi, Temporal, ClickHouse, Superset are
     // independent stacks operators pick individually. Selecting one
     // doesn't imply the others.
@@ -515,7 +526,7 @@ export const PRODUCTS: Product[] = [
     subtitle: 'Communication',
     description: 'Self-hosted email, WebRTC video conferencing, federated messaging, and push notifications',
     tier: 'optional',
-    components: ['stalwart', 'livekit', 'stunner', 'matrix', 'ntfy'],
+    components: ['stalwart', 'livekit', 'stunner', 'matrix'],
     // RELAY is à-la-carte — Stalwart (mail) and LiveKit (video) are
     // distinct workloads with their own decision criteria.
     cascadeOnMemberSelection: false,


### PR DESCRIPTION
## UAT row W5 — the wizard offered components with no Blueprint, and the test that exists to catch that could not

Row W5 asserts every component id in the deployment wizard resolves to a real Blueprint. **Six of 64 did not** — `envoy`, `frpc`, `strongswan`, `superset`, `ntfy`, `specter` — while `componentGroups.catalog-integrity.5575.test.ts` stayed green, because a `KNOWN_UNBUILT` allowlist absorbed all six and the test is written as `unresolved === [...KNOWN_UNBUILT]`.

One of the six, `envoy`, was `tier: 'mandatory'`. An operator **cannot deselect a mandatory card**, so every deployment this wizard produced emitted a component id that nothing could install, and no test could report it. A debt list that can absorb a mandatory entry is not a debt list — it is an exemption from the assertion.

### Removed from the catalog

`envoy`, `frpc`, `strongswan`, `superset`, `ntfy`. None resolves to a `platform/` dir, a `products/` dir, a bootstrap-kit slot, or a `bp-<id>` reference anywhere in the monorepo.

`envoy` is the one that looks arguable and is not: envoy **does** run on every Sovereign, as `cilium-envoy` inside bp-cilium — which is already a mandatory card in the same SPINE family. The second card was a duplicate of one, not a second installable unit.

`specter` **stays**, as the single tracked debt entry with a written reason. It is not a phantom third-party card: it is an OpenOva product with marketplace copy, a deployment-store entry, and a documented `familyRequires: ['cortex']` cascade. Removing it is a product decision; bounding it is not — and the bound is now enforced.

### The second catalog — the part that would have made a card-only fix useless

`entities/deployment/model.ts` carries its **own** component list, `DEFAULT_COMPONENT_GROUPS`, which seeds `INITIAL_WIZARD_STATE.componentGroups`, plus `getProfileDefaults()` rules layered on top. Nothing cross-checked it against `componentGroups.ts`.

`envoy` and `frpc` were pre-selected there, and a financial / healthcare / audit-bound profile additionally pre-selected `strongswan` — so **the profile most likely to actually need an IPsec gateway was the one handed a card that deploys nothing**. Deleting the cards alone would have left all three silently pre-selected and shipped in the payload with no card, name or logo anywhere in the UI, which is strictly worse than a visible phantom. Both tables are cleaned, and the integrity test now sweeps `DEFAULT_COMPONENT_GROUPS` plus five profile shapes.

### Three guard repairs, each proven able to fail

| repair | probe | result |
|---|---|---|
| mandatory-tier debt is forbidden | re-add `envoy` as mandatory + to `KNOWN_UNBUILT` | `AssertionError: expected [ 'envoy' ] to deeply equal []` |
| second catalog is cross-checked | put `envoy` back in `DEFAULT_COMPONENT_GROUPS.spine` only | `AssertionError: expected [ 'envoy' ] to deeply equal []` |
| resolver vacuity | direct two-way probe (`keycloak` → true, synthetic id → false) | replaces `KNOWN_UNBUILT.size > 0` |

The old vacuity guard deserves calling out: `expect(KNOWN_UNBUILT.size).toBeGreaterThan(0)` is an argument **for** keeping phantoms in the catalog, and it never touched the resolver at all — a resolver hardcoded to return `true` would have passed it.

Same shape in `StepComponents.test.tsx`: `expect(ALL_COMPONENTS.length).toBeGreaterThanOrEqual(60)`. 60 was picked when the catalog held 64 including the six phantoms, so removing an uninstallable card turned the suite RED and keeping one kept it green. Replaced with the invariant that actually matters — `ALL_COMPONENTS` equals the union of `PRODUCTS` family membership with no id in two families, which is row W5's "counts are self-consistent" half — plus a truncation floor set far below the real size so it can never again block a removal.

Two `not.toContain('superset')` exclusions were also removed rather than left behind: an exclusion assertion about an id that no longer exists cannot fail.

### Verification

- `npx vitest run` — 232 files, 2148 passed, 1 expected fail (pre-existing), 0 failed.
- `npx tsc --noEmit` — clean.

Row W5 clause 1 (counts self-consistent) and clause 2 (every id resolves) now both hold against `main`, with `specter` declared as the one bounded, non-mandatory exception rather than hidden inside a green test.

Refs #5575 #3969
