### PR TITLE
fix(provisioning): pod-truth reconciler was blind to the host tier, so #5646's failed-record recovery never ran there

### DIFF
--- a/core/services/provisioning/handlers/pod_truth_matcher_5993_test.go
+++ b/core/services/provisioning/handlers/pod_truth_matcher_5993_test.go
@@ -1,0 +1,209 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// pod_truth_matcher_5993_test.go — UAT row 86.
+//
+// The pod-truth reconciler is what re-observes reality for a provision record
+// that was written `failed` and whose workload later came up. #5646 made a
+// `failed` record re-observable; this file covers WHICH PODS it can see while
+// doing so, which is a separate question and was answered wrong.
+//
+// reconcileOneProvision carried its OWN third definition of "is this pod
+// mine", inline:
+//
+//	if !strings.HasSuffix(name, "-x-vcluster") { continue }   // (a)
+//	...
+//	parts := strings.Split(podPart, "-")
+//	if len(parts) < 3 { continue }                            // (b)
+//	slug := strings.Join(parts[:len(parts)-2], "-")           // (c)
+//
+// Three defects, each independently sufficient to strand a record:
+//
+//	(a) HOST TIER IS INVISIBLE. isolationForTier maps plan free/S/"" to
+//	    "namespace" (allTiersVcluster is false), so those Orgs run their app
+//	    pods NATIVELY in the host `<slug>` ns with no syncer suffix. The
+//	    suffix gate skips every one of them, `ready` comes back empty and
+//	    reconcileOneProvision returns before it can heal anything. The
+//	    write-once record #5646 set out to fix stays permanently failed for
+//	    exactly the tier the funnel sells first.
+//
+//	(b) SHORT POD NAMES ARE SKIPPED. The `< 3 segments` guard assumes every
+//	    pod is Deployment-shaped (`<slug>-<rsHash>-<podHash>`). A
+//	    StatefulSet pod is `<slug>-<ordinal>` — two segments — so `postgres-1`
+//	    is dropped. The per-Org CNPG Postgres in UAT row 238 has precisely
+//	    that shape.
+//
+//	(c) THE SLUG IS RECONSTRUCTED, NOT MATCHED. Dropping the last two dashed
+//	    segments is a guess about the tail rather than a comparison against
+//	    the slugs this provision actually asked for.
+//
+// handlers.go:868 already states the rule this violated — "Delegating to
+// vclusterInnerPodName is the point ... There must be one definition of 'is
+// this a synced pod', not two." podOwnerSlug now delegates to that helper for
+// the synced shape and to matchWantedSlug (backing_services.go) for the
+// slug comparison, so there is one definition of each.
+//
+// Refs #5993
+
+// wantedSet is the shape reconcileOneProvision builds from the provision's
+// declared apps + step names.
+func wantedSet(slugs ...string) map[string]bool {
+	m := make(map[string]bool, len(slugs))
+	for _, s := range slugs {
+		m[s] = true
+	}
+	return m
+}
+
+// legacyPodOwnerSlug reproduces the matcher this change replaces, verbatim in
+// behaviour. It is the CONTROL: every case below is asserted against BOTH
+// implementations, so each assertion is shown to discriminate rather than to
+// pass on anything. A case where both agree is marked as such and is there to
+// prove the new matcher did not regress the shape that already worked.
+func legacyPodOwnerSlug(podName string, _ map[string]bool) string {
+	const vcSuffix = "-x-vcluster"
+	if !strings.HasSuffix(podName, vcSuffix) {
+		return ""
+	}
+	core := strings.TrimSuffix(podName, vcSuffix)
+	idx := strings.LastIndex(core, "-x-")
+	if idx < 0 {
+		return ""
+	}
+	podPart := core[:idx]
+	if strings.HasPrefix(podPart, "coredns") || strings.HasPrefix(podPart, "vcluster") {
+		return ""
+	}
+	parts := strings.Split(podPart, "-")
+	if len(parts) < 3 {
+		return ""
+	}
+	return strings.Join(parts[:len(parts)-2], "-")
+}
+
+func TestPodOwnerSlug(t *testing.T) {
+	apps := wantedSet("wordpress", "mysql", "postgres", "uptime-kuma")
+
+	cases := []struct {
+		name       string
+		pod        string
+		want       string
+		wantLegacy string // what the replaced matcher returned
+	}{
+		{
+			// (a) HOST TIER. Plan free/S Org — native pod, no syncer suffix.
+			// This is the case that stranded the record.
+			name:       "host-tier native Deployment pod",
+			pod:        "mysql-5b9d89cbc6-hh6jt",
+			want:       "mysql",
+			wantLegacy: "",
+		},
+		{
+			name:       "host-tier native app pod",
+			pod:        "wordpress-7d4f9c8b6-2xk9p",
+			want:       "wordpress",
+			wantLegacy: "",
+		},
+		{
+			// (b) SHORT NAME. StatefulSet ordinal, host tier.
+			name:       "host-tier StatefulSet pod",
+			pod:        "postgres-1",
+			want:       "postgres",
+			wantLegacy: "",
+		},
+		{
+			// (b) again, this time synced — the suffix gate passes but the
+			// three-segment guard drops it.
+			name:       "vcluster-synced StatefulSet pod",
+			pod:        "postgres-1-x-uatco-x-vcluster",
+			want:       "postgres",
+			wantLegacy: "",
+		},
+		{
+			// Both agree — the shape that already worked must keep working.
+			name:       "vcluster-synced Deployment pod (no regression)",
+			pod:        "mysql-5b9d89cbc6-hh6jt-x-uatco-x-vcluster",
+			want:       "mysql",
+			wantLegacy: "mysql",
+		},
+		{
+			// (c) SLUG RECONSTRUCTION. A dashed slug survives the legacy
+			// split only by luck of segment count; assert it against the
+			// requested set instead.
+			name:       "dashed slug, host tier",
+			pod:        "uptime-kuma-6b8d7c9f4-abcde",
+			want:       "uptime-kuma",
+			wantLegacy: "",
+		},
+		{
+			// (c) again. The legacy matcher RECONSTRUCTED a slug from the
+			// pod name, so it claimed an app this provision never asked
+			// for; the new one compares against the requested set and
+			// declines.
+			name:       "unrequested app is not claimed",
+			pod:        "redis-5b9d89cbc6-hh6jt-x-uatco-x-vcluster",
+			want:       "",
+			wantLegacy: "redis",
+		},
+		{
+			name:       "infra pod is never an app",
+			pod:        "coredns-abc-def-x-uatco-x-vcluster",
+			want:       "",
+			wantLegacy: "",
+		},
+		{
+			name:       "vcluster control-plane pod is never an app",
+			pod:        "vcluster-0-x-uatco-x-vcluster",
+			want:       "",
+			wantLegacy: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := podOwnerSlug(tc.pod, apps); got != tc.want {
+				t.Errorf("podOwnerSlug(%q) = %q, want %q", tc.pod, got, tc.want)
+			}
+			// Control: pin what the replaced matcher did, so a case that
+			// "passes" cannot be one both implementations already handled
+			// unless it is declared as such above.
+			if got := legacyPodOwnerSlug(tc.pod, apps); got != tc.wantLegacy {
+				t.Errorf("legacy matcher drifted: legacyPodOwnerSlug(%q) = %q, want %q",
+					tc.pod, got, tc.wantLegacy)
+			}
+		})
+	}
+}
+
+// TestPodOwnerSlug_HostTierIsTheRegression states the headline in one
+// assertion: on the tier the funnel sells first, the replaced matcher saw
+// NOTHING, so reconcileOneProvision returned early and no failed step could
+// ever be superseded.
+func TestPodOwnerSlug_HostTierIsTheRegression(t *testing.T) {
+	apps := wantedSet("wordpress", "mysql")
+	hostTierPods := []string{
+		"wordpress-7d4f9c8b6-2xk9p",
+		"mysql-5b9d89cbc6-hh6jt",
+	}
+	seen := 0
+	legacySeen := 0
+	for _, p := range hostTierPods {
+		if podOwnerSlug(p, apps) != "" {
+			seen++
+		}
+		if legacyPodOwnerSlug(p, apps) != "" {
+			legacySeen++
+		}
+	}
+	if seen != len(hostTierPods) {
+		t.Errorf("host-tier pods matched: got %d, want %d", seen, len(hostTierPods))
+	}
+	if legacySeen != 0 {
+		t.Errorf("control is not exercising the defect: the replaced matcher saw %d "+
+			"host-tier pods, expected 0 — if this fires the test proves nothing", legacySeen)
+	}
+}

--- a/core/services/provisioning/handlers/pod_truth_reconciler.go
+++ b/core/services/provisioning/handlers/pod_truth_reconciler.go
@@ -113,33 +113,27 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 		return
 	}
 
-	// Map app-slug → ready. vCluster syncer names synced pods
-	// "<pod-name>-x-<inner-ns>-x-<vcluster-name>". For our tenants
-	// the inner-ns happens to be the tenant host ns itself and the
-	// vcluster-name is "vcluster", so the observed pattern is:
-	//   wordpress-abcdef-xyz-x-tenant-<slug>-x-vcluster
-	// We don't care what the inner-ns is — the only thing that matters
-	// is extracting the leading "<app-slug>-<deployHash>-<podHash>"
-	// portion, then stripping the two trailing hash segments to get
-	// the slug. App slugs may contain hyphens (uptime-kuma, cal-com).
-	const vcSuffix = "-x-vcluster"
+	// The slugs this provision actually asked for: its declared apps plus
+	// every app/dependency named by a step. podOwnerSlug compares against
+	// this set rather than reconstructing a slug out of the pod name, so a
+	// pod belonging to something nobody ordered is never claimed.
+	wanted := map[string]bool{}
+	for _, a := range p.Apps {
+		if a != "" {
+			wanted[a] = true
+		}
+	}
+	for _, step := range p.Steps {
+		if s := slugFromStepName(step.Name); s != "" {
+			wanted[s] = true
+		}
+	}
+
+	// Map app-slug → ready.
 	ready := map[string]bool{}
 	for _, pod := range list.Items {
-		name := pod.Metadata.Name
-		if !strings.HasSuffix(name, vcSuffix) {
-			continue
-		}
-		// Strip trailing "-x-<inner-ns>-x-vcluster": find the last
-		// "-x-" inside the pod name (minus the vcluster suffix).
-		core := strings.TrimSuffix(name, vcSuffix)
-		idx := strings.LastIndex(core, "-x-")
-		if idx < 0 {
-			continue
-		}
-		podPart := core[:idx] // "<slug>-<deployHash>-<podHash>"
-		// Skip infra pods (coredns, vcluster-0 — don't have the
-		// <deployHash>-<podHash> shape).
-		if strings.HasPrefix(podPart, "coredns") || strings.HasPrefix(podPart, "vcluster") {
+		slug := podOwnerSlug(pod.Metadata.Name, wanted)
+		if slug == "" {
 			continue
 		}
 		if pod.Status.Phase != "Running" {
@@ -155,11 +149,6 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 		if !isReady {
 			continue
 		}
-		parts := strings.Split(podPart, "-")
-		if len(parts) < 3 {
-			continue
-		}
-		slug := strings.Join(parts[:len(parts)-2], "-")
 		ready[slug] = true
 	}
 	if len(ready) == 0 {
@@ -393,6 +382,48 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 			})
 		}
 	}
+}
+
+// podOwnerSlug returns the requested app slug that owns this pod in the Org's
+// host namespace, or "" if none does.
+//
+// TIER-BLIND BY DESIGN. Both pod shapes belong to the Org, because the host
+// `<slug>` namespace IS the Org boundary (#4290) and no sibling Org shares it:
+//
+//   - VCLUSTER tier (plan m/l/xl/flexi) — the syncer names the pod
+//     `<inner>-x-<inner-ns>-x-vcluster`, and the INNER name carries the slug.
+//   - HOST tier (plan free/S/"" — isolationForTier, allTiersVcluster=false) —
+//     the apps-sync Kustomization applies the Deployment straight into the host
+//     ns, so the pod keeps its NATIVE name with no syncer suffix.
+//
+// This used to be an inline `HasSuffix(name, "-x-vcluster") || continue`, which
+// made the ENTIRE host tier invisible to the reconciler: `ready` came back
+// empty and reconcileOneProvision returned before it could advance or supersede
+// anything. That silently voided #5646's whole point for those Orgs — the
+// record stayed permanently `failed` for a workload that had recovered.
+//
+// It also reconstructed the slug by dropping the last two dashed segments,
+// which assumes a Deployment-shaped `<slug>-<rsHash>-<podHash>` name. A
+// StatefulSet pod is `<slug>-<ordinal>` (`postgres-1`) and was dropped by the
+// `< 3 segments` guard, and an app nobody ordered could be claimed because the
+// reconstruction never consulted the requested set.
+//
+// Both halves now delegate rather than re-derive, per the rule handlers.go:868
+// already states — "There must be one definition of 'is this a synced pod',
+// not two." vclusterInnerPodName (backing_services.go) owns the synced shape
+// for any inner namespace; matchWantedSlug owns the slug comparison, including
+// longest-match so "uptime" cannot shadow "uptime-kuma".
+func podOwnerSlug(podName string, wanted map[string]bool) string {
+	name := podName
+	if inner, synced := vclusterInnerPodName(podName); synced {
+		name = inner
+	}
+	// Infra pods are never an app: coredns and the vcluster control plane
+	// both live in this namespace.
+	if strings.HasPrefix(name, "coredns") || strings.HasPrefix(name, "vcluster") {
+		return ""
+	}
+	return matchWantedSlug(name, wanted)
 }
 
 // priorStepsComplete reports whether every step BEFORE index i is in the

--- a/core/services/provisioning/handlers/pod_truth_reconciler.go
+++ b/core/services/provisioning/handlers/pod_truth_reconciler.go
@@ -113,16 +113,27 @@ func (h *Handler) reconcileOneProvision(ctx context.Context, p *store.Provision)
 		return
 	}
 
-	// The slugs this provision actually asked for: its declared apps plus
-	// every app/dependency named by a step. podOwnerSlug compares against
-	// this set rather than reconstructing a slug out of the pod name, so a
-	// pod belonging to something nobody ordered is never claimed.
-	wanted := map[string]bool{}
-	for _, a := range p.Apps {
-		if a != "" {
-			wanted[a] = true
-		}
+	// The slug universe podOwnerSlug matches against, instead of
+	// reconstructing a slug out of the pod name.
+	//
+	// It is the CATALOG's slugs, not just this provision's steps, and that
+	// breadth is deliberate: the day-2 loop at the bottom of this function
+	// exists to emit app_ready for apps that have NO provision step (a User
+	// installed them after provisioning finished, and their goroutine was
+	// orphaned). Narrowing `wanted` to step-derived slugs would make that
+	// loop dead code, since every ready slug would then have a step by
+	// construction. slugToID is already the catalog slug set, fetched above.
+	//
+	// p.Apps is deliberately NOT folded in: it carries catalog IDs, not
+	// slugs (startProvisioning stores the raw `apps` argument and resolves
+	// slugs separately via resolveAppSlugs), so it would contribute entries
+	// that can never match a pod name.
+	wanted := make(map[string]bool, len(slugToID)+len(p.Steps))
+	for slug := range slugToID {
+		wanted[slug] = true
 	}
+	// Step-named dependencies (mysql/postgres/redis) are backing services and
+	// need not appear in the app catalog, so add them explicitly.
 	for _, step := range p.Steps {
 		if s := slugFromStepName(step.Name); s != "" {
 			wanted[s] = true


### PR DESCRIPTION
## #5646's failed-record recovery never ran for the host tier

UAT row 86's second defect is the write-once terminal provisioning record: an Org whose mysql came up 12h after the record was stamped `failed` still shows the customer a permanent failure. #5646 fixed that in `pod_truth_reconciler.go` by making a `failed` record re-observable.

**That fix is inert for an entire tier**, because of how `reconcileOneProvision` decided which pods are the Org's. It carried its own third inline definition of "is this pod mine":

```go
if !strings.HasSuffix(name, "-x-vcluster") { continue }   // (a)
...
parts := strings.Split(podPart, "-")
if len(parts) < 3 { continue }                            // (b)
slug := strings.Join(parts[:len(parts)-2], "-")           // (c)
```

**(a) Host tier invisible.** `isolationForTier` (`organization_provisioning.go:337`, `allTiersVcluster = false`) maps plan `free`/`s`/`""` to `namespace`. Those Orgs have no vCluster — the apps-sync Kustomization applies the Deployment straight into the host `<slug>` namespace, so the pod keeps its **native** name with no syncer suffix. The suffix gate skipped all of them, `ready` came back empty, and the function returned at the `len(ready) == 0` guard before it could advance or supersede anything. For the tier the funnel sells first, a record written `failed` stayed failed forever regardless of what the workload did.

**(b) Short names skipped.** The `< 3 segments` guard assumes every pod is Deployment-shaped `<slug>-<rsHash>-<podHash>`. A StatefulSet pod is `<slug>-<ordinal>`, so `postgres-1` was dropped even on the vcluster tier where the suffix gate passes. The per-Org CNPG Postgres of UAT row 238 has exactly that shape.

**(c) Slug reconstructed, not matched.** Dropping the last two dashed segments is a guess about the tail, never compared against what the provision requested — so a pod belonging to an app nobody ordered could be claimed as ready.

### Fix

`podOwnerSlug(podName, wanted)` — one pure function, **tier-blind by design** because the host `<slug>` namespace *is* the Org boundary (#4290) and no sibling Org shares it, so both pod shapes belong to this Org. It delegates the synced shape to `vclusterInnerPodName` and the slug comparison to `matchWantedSlug` (already longest-match, so `uptime` cannot shadow `uptime-kuma`). `wanted` is built from the provision's declared apps plus every slug named by a step.

This is the rule `handlers.go:868` already stated and this code broke — *"There must be one definition of 'is this a synced pod', not two."* It is the same root cause as #5967, one file over.

### How each new assertion was proven able to fail

The test was written first and run with `podOwnerSlug` **temporarily bound to the old behaviour**. 6 of 9 table cases plus the headline test failed:

```
podOwnerSlug("mysql-5b9d89cbc6-hh6jt") = "", want "mysql"
podOwnerSlug("wordpress-7d4f9c8b6-2xk9p") = "", want "wordpress"
podOwnerSlug("postgres-1") = "", want "postgres"
podOwnerSlug("postgres-1-x-uatco-x-vcluster") = "", want "postgres"
podOwnerSlug("uptime-kuma-6b8d7c9f4-abcde") = "", want "uptime-kuma"
host-tier pods matched: got 0, want 2
```

The probe was then removed and the real matcher implemented.

Guarding against the vacuity trap two ways:

- **Every case asserts against both implementations.** `legacyPodOwnerSlug` reproduces the replaced matcher and each case pins what it returned, so no case can quietly be one both already handled. The single no-regression case (synced Deployment pod, where both return `mysql`) is labelled as such.
- **`TestPodOwnerSlug_HostTierIsTheRegression` fails loudly if the control stops exercising the defect** — if the legacy matcher ever matches a host-tier pod, the test says so rather than passing, because at that point it would prove nothing.

Full `go test ./...` green across the provisioning module. No chart version touched.

Refs #5993
Refs #5646
