### PR TITLE
docs(uat): generate the WBS partition from UAT.md instead of transcribing it

### DIFF
--- a/.github/workflows/check-uat-partition-derived.yaml
+++ b/.github/workflows/check-uat-partition-derived.yaml
@@ -1,0 +1,59 @@
+# check-uat-partition-derived.yaml — WBS-TO-100.md §1 must agree with UAT.md
+# about which failing rows need an engineer.
+#
+# §1 sorts every ❌ row into DEPLOY-GATED / BUILD / ENV-STATE / WALKABLE NOW.
+# Those four classes route to four different people, so a row in the wrong one
+# gets neither the fix nor the walk. The list was kept by hand and drifted three
+# separate ways inside one day (2026-08-10): it partitioned 78 rows against a
+# 76-❌ ledger, it still listed eleven rows as BUILD hours after they were
+# re-tagged DEPLOY-GATED in UAT.md, and it carried two rows as ❌ after they had
+# stopped being ❌.
+#
+# The drift is guaranteed rather than careless: UAT.md is rewritten by every walk
+# and by a cron, so any hand-transcribed copy is stale by construction. Hence a
+# guard rather than a correction.
+name: check-uat-partition-derived
+
+on:
+  pull_request:
+    paths:
+      - "docs/ledger/UAT.md"
+      - "docs/ledger/WBS-TO-100.md"
+      - "scripts/uat-partition.py"
+      - ".github/workflows/check-uat-partition-derived.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/ledger/UAT.md"
+      - "docs/ledger/WBS-TO-100.md"
+      - "scripts/uat-partition.py"
+      - ".github/workflows/check-uat-partition-derived.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  partition-derived:
+    name: WBS §1 partition is derived from UAT.md
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # Runs FIRST. The real check asserts "the two agree", which is what a
+      # parser that read NOTHING also reports. The self-test proves the
+      # derivation picks the LAST label, treats an untagged ❌ row as walkable,
+      # excludes green rows, goes red on a row left in the wrong bucket, rejects
+      # prose smuggled into an id run instead of mis-parsing it, and refuses to
+      # call an unreadable ledger "agreement".
+      - name: Self-test the derivation and the comparison
+        run: python3 scripts/uat-partition.py --self-test
+
+      - name: WBS §1 must match the derivation
+        run: python3 scripts/uat-partition.py --check

--- a/docs/ledger/WBS-TO-100.md
+++ b/docs/ledger/WBS-TO-100.md
@@ -5,63 +5,82 @@
 > happen in, what depends on what, and where the critical path actually runs.
 > Built 2026-08-09 from live hw292 measurement, not from the prior narrative.
 
-## 0. The arithmetic, stated once  (re-counted 2026-08-10 by `scripts/uat-tally.py`)
+## 0. The arithmetic, stated once  (snapshot at `87c994af2`; re-run `scripts/uat-tally.py`)
 
 | tier | rows |
 |---|---|
-| ✅ PASS | 192 |
-| ❌ FAIL | 76 |
-| ☐ NOT RUN | 18 |
+| ✅ PASS | 206 |
+| ❌ FAIL | 77 |
+| ☐ NOT RUN | 3 |
 | **total** | **286** |
 
-**STONE = 192/286 = 67.1%.**
+**STONE = 206/286 = 72.0%** *at that commit.*
 
-This table previously read `208 ✅ / 78 ❌` with the line *"the ledger is binary …
-no partials, no parked, no unwalked"*. Both halves went stale the same day: the
-retire-and-replace swaps reset a clause's verdict to ☐ (a NEW clause inheriting
-the old one's ✅ would be fabrication), and the SSO-chain merge flipped its rows
-back to unverified by design. So there IS a third tier again, and it is 18 rows
-wide. It is stated here rather than folded into ❌ because the two demand
-different work — a ☐ row needs a walk, a ❌ row needs a fix, a deploy or a
-different env — and because a section that silently disagrees with
-`scripts/uat-tally.py` is the thing this file exists to prevent.
+**Treat every number in this section as a snapshot, not a fact.** It moved twice
+within one hour on 2026-08-10 while this file was being edited, because walks and
+a cron write UAT.md continuously. `scripts/uat-tally.py` is the count; this table
+is a reading of it.
+
+The table previously read `208 ✅ / 78 ❌` under the line *"the ledger is binary …
+no partials, no parked, no unwalked"*. That claim is not durable either: a
+retire-and-replace swap resets the replaced clause to ☐ (a NEW clause inheriting
+the old one's ✅ would be fabrication), and an SSO-chain merge flips its rows back
+to unverified by design — so the third tier reappears whenever either happens,
+and it was 18 rows wide a few hours before this snapshot. It is shown separately
+rather than folded into ❌ because the two demand different work: a ☐ row needs a
+walk, a ❌ row needs a fix, a deploy or a different env.
 
 The earlier `189/250 = 75.6%` figure excluded 36 ⛔ rows from the denominator.
 That was flattering and wrong: a row you cannot answer is not a row you may
 drop. Excluding failures raises the score by removing the evidence against it,
 which is the floating-denominator behaviour the frozen 286 exists to prevent.
 
-## 1. The 76 ❌, partitioned by what actually unblocks them  (re-derived 2026-08-10)
+## 1. The ❌ set, partitioned by what actually unblocks them
 
-**These lists are now DERIVED from UAT.md, not transcribed into it.** Each row's
-bucket is the LAST partition label in its own Evidence cell. The previous version
-was transcribed by hand and had drifted three separate ways within a day: it
-partitioned 78 rows when the ledger held 76 ❌, it still listed 87 88 90 95 R16 62
-63 71 100 103 106 as BUILD after those rows had been re-tagged DEPLOY-GATED in
-UAT.md, and it carried 115 and 165 as ❌ after they had stopped being ❌. Two
-documents disagreeing about which rows need an engineer is worse than either one
-being wrong alone, because the reader cannot tell which to believe.
+**These lists are GENERATED, not transcribed.** `python3 scripts/uat-partition.py
+--write` derives them from UAT.md — a row's bucket is the LAST partition label in
+its own Evidence cell, and a ❌ row with no label is WALKABLE NOW because nothing
+has recorded a reason it cannot be walked. `--check` fails CI when this section
+and UAT.md disagree, so the two can no longer drift apart silently.
+
+They already had. The hand-kept version drifted three separate ways inside one
+day: it partitioned 78 rows against a 76-❌ ledger, it still listed 87 88 90 95
+R16 62 63 71 100 103 106 as BUILD hours after those rows were re-tagged
+DEPLOY-GATED in UAT.md, and it carried 115 and 165 as ❌ after they had stopped
+being ❌. Two ledger files disagreeing about which rows need an engineer is worse
+than either being wrong alone, because the reader cannot tell which to believe —
+and the drift was guaranteed rather than careless, since UAT.md is rewritten by
+every walk and by a cron.
 
 | bucket | rows | what it needs |
 |---|--:|---|
 | **DEPLOY-GATED** | 41 | the fix is merged and not running here; closes on a roll/prov |
-| **BUILD** (`NEEDS-CODE`) | 22 | no fix exists yet |
+| **BUILD** | 22 | no fix exists yet (`NEEDS-CODE` in UAT.md) |
 | **ENV-STATE** | 7 | needs a different environment shape entirely |
-| **WALKABLE NOW** | 6 | a walk on THIS env can change the verdict |
-| **total** | **76** | |
+| **WALKABLE NOW** | 7 | a walk on THIS env can change the verdict |
+| **total** | **77** | |
 
 - **DEPLOY-GATED (41)** — 4 7 15 25 33 37 55 57 59 62 63 67 69 71 75 87 88 90 92 94 95 100 103 106 176 183 188 212 213 216 218 219 221 222 228 234 238 W1 W2 R16 R22
-- **BUILD (22)** — 3 19 38 84 85 86 96 98 102 121 164 177 184 192 195 225 233 G2 G7 G8 G9 W5
+- **BUILD (22)** — 3 19 38 84 85 86 96 98 102 121 164 177 184 192 195 225 233 G2 W5 G7 G8 G9
 - **ENV-STATE (7)** — 29 41 60 123 178 241 R17
-- **WALKABLE NOW (6)** — 48 (one screenshot of the create `<select>` on a Blueprint that declares active-passive), 91 (a signed-in customer session), 217 (IMAP plus a browser; the recorded listener cause was refuted live), 220 (a chat round-trip), 223 (the MCP read legs, whose only stated cause was refuted against the deployed build by digest), 242 (one authenticated POST of a 1-region body with bcpTopology omitted, requiring 4xx)
+- **WALKABLE NOW (7)** — 35 48 91 217 220 223 242
+
+What each WALKABLE NOW row needs, since "walk it" is not an instruction:
+
+- **48** — one screenshot of the create `<select>` on a Blueprint that declares `active-passive`
+- **91** — a signed-in customer session
+- **217** — IMAP plus a browser; the recorded listener cause was refuted on live objects
+- **220** — a chat round-trip (currently fails on the revoked credential, #5956)
+- **223** — the MCP read legs, whose only stated cause was refuted against the deployed build by digest
+- **242** — one authenticated POST of a 1-region body with `bcpTopology` omitted, requiring 4xx
 
 **THE NUMBER THAT MATTERS: re-walking still cannot move most of this ledger.** 70
-of the 76 wait on a deploy, an environment, or code that does not exist. Six would
-answer differently if walked today — twice the previous count, and the increase is
-not progress: 48, 217 and 223 were sitting in BUILD carrying the sentence *"no fix
-exists yet"* while their own evidence cells said the opposite three sentences
-earlier. Nobody was going to walk them, and nobody was going to fix them either,
-because each class routes the row to a different person.
+of the 77 wait on a deploy, an environment, or code that does not exist. Seven
+would answer differently if walked today — more than double the previous count,
+and the increase is not progress: 48, 217 and 223 were sitting in BUILD carrying
+the sentence *"no fix exists yet"* while their own evidence cells said the
+opposite a few sentences earlier. Nobody was going to walk them, and nobody was
+going to fix them either, because each class routes the row to a different person.
 
 This is worth stating plainly because "walk the failing rows" is the intuitive next
 move and it is the wrong one for 41 of them. The ledger moves when a fix REACHES a
@@ -97,16 +116,22 @@ makes it visible to the egress proof; pivoting the SMTP path itself is still ope
 
 ## 3. Sequencing — why the prov is fired ONCE, and last
 
-Firing a fresh prov converts A+B (31 rows) but `reset-uat.py` flushes all 208 banked
-greens, because UAT evidence is per-env by law. So:
+Firing a fresh prov converts the DEPLOY-GATED bucket in one move, but
+`reset-uat.py` flushes every banked green, because UAT evidence is per-env by law.
+So:
 
 ```
-real work to 100%  =  78 non-green  +  208 re-walks
+real work to 100%  =  <non-green>  +  <banked greens re-walked>
+                   =  80           +  206                        (at 87c994af2)
 ```
 
-Any plan quoting "78 rows left" and omitting the re-walk is wrong by a factor of
-three. That is why the prov is a **once** decision: every premature fire pays the
-208-row re-walk again. Land D first, then fire.
+The shape is what matters and it does not move: the re-walk term is roughly
+**three times** the non-green term, so any plan quoting only "N rows left" is
+wrong by about a factor of three. Both terms are read from
+`scripts/uat-tally.py`, not from this page — the figures above were 78 + 208 a
+few hours earlier and will be different again by the time the prov is fired. That
+is why the prov is a **once** decision: every premature fire pays the whole
+re-walk again. Land D first, then fire.
 
 ## WP-0 — #5919: cutover step-06 reverts its own pivot  ⟵ CRITICAL PATH HEAD
 

--- a/scripts/uat-partition.py
+++ b/scripts/uat-partition.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Derive the FAIL-row partition from UAT.md, and hold WBS-TO-100.md §1 to it.
+
+WHY. `WBS-TO-100.md` §1 says which failing rows need an ENGINEER, which need a
+ROLL, which need a different ENV, and which just need a WALK. Those four classes
+route to four different people, so a row in the wrong one gets neither the fix
+nor the walk. The list was kept by hand, and inside a single day (2026-08-10) it
+had drifted three separate ways at once:
+
+  * it partitioned 78 rows while the ledger held 76 ❌;
+  * it still listed 87 88 90 95 R16 62 63 71 100 103 106 as BUILD ("no fix
+    exists yet") hours after those rows were re-tagged DEPLOY-GATED in UAT.md;
+  * it carried 115 and 165 as ❌ after they had stopped being ❌.
+
+Two ledger files disagreeing about which rows need an engineer is worse than
+either being wrong alone, because the reader cannot tell which to believe. And
+the drift is guaranteed, not accidental: UAT.md is edited by every walk and by a
+cron, so ANY hand-transcribed copy of it is stale by construction.
+
+THE SOURCE OF TRUTH is each row's own Evidence cell: a row's bucket is the LAST
+partition label written into it (`PARTITION …: X`, or the `RE-TAGGED …: X -> Y`
+that supersedes it). A ❌ row carrying NO label is WALKABLE NOW — nothing has
+recorded a reason it cannot be walked, which is exactly how 91/220/242 were
+being read already.
+
+    uat-partition.py               # print the derivation
+    uat-partition.py --check       # fail if WBS-TO-100.md §1 disagrees
+    uat-partition.py --write       # rewrite WBS-TO-100.md §1 from UAT.md
+    uat-partition.py --self-test   # prove --check goes red AND green
+"""
+import argparse
+import collections
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+UAT = ROOT / "docs" / "ledger" / "UAT.md"
+WBS = ROOT / "docs" / "ledger" / "WBS-TO-100.md"
+
+ROW_ID = re.compile(r"^\|\s*(R?\d+|[GWM]\d+)\s*\|")
+CELL = re.compile(r"(?<!\\)\|")
+LABEL = re.compile(
+    r"(?:PARTITION\s+\d{4}-\d{2}-\d{2}:|RE-TAGGED\s+\d{4}-\d{2}-\d{2}:\s*[A-Z][A-Z\- ]*[A-Z]\s*->)"
+    r"\s*([A-Z][A-Z\- ]*[A-Z])"
+)
+
+# The ledger writes NEEDS-CODE; the WBS calls the same class BUILD. One name has
+# to win at the seam or the comparison is decided by spelling.
+CANON = {"NEEDS-CODE": "BUILD", "UNTAGGED": "WALKABLE NOW"}
+ORDER = ["DEPLOY-GATED", "BUILD", "ENV-STATE", "WALKABLE NOW"]
+
+BULLET = re.compile(r"^- \*\*(?P<bucket>[A-Z][A-Z\- ]*[A-Z])\s*\((?P<n>\d+)\)\*\*\s+—\s+(?P<ids>.*)$")
+BARE_ID = re.compile(r"^(R?\d+|[GWM]\d+)$")
+
+
+def sort_key(rid):
+    """Numerics first in numeric order, then the lettered families."""
+    m = re.match(r"^(\d+)$", rid)
+    if m:
+        return (0, int(m.group(1)), "")
+    m = re.match(r"^([RGWM])(\d+)$", rid)
+    if m:
+        return (1, int(m.group(2)), m.group(1))
+    return (2, 0, rid)
+
+
+def derive(text):
+    """{bucket: [row_id]} over every ❌ row."""
+    buckets = collections.defaultdict(list)
+    for line in text.split("\n"):
+        m = ROW_ID.match(line)
+        if not m:
+            continue
+        cells = [c.strip() for c in CELL.split(line.strip()) if c.strip() != ""]
+        if len(cells) < 6 or not cells[5].startswith("❌"):
+            continue
+        labels = [x.strip() for x in LABEL.findall(line)]
+        bucket = labels[-1] if labels else "UNTAGGED"
+        buckets[CANON.get(bucket, bucket)].append(m.group(1))
+    for v in buckets.values():
+        v.sort(key=sort_key)
+    return dict(buckets)
+
+
+def parse_wbs(text):
+    """{bucket: [row_id]} as WBS §1 currently claims. Prose in an id run is an error."""
+    claimed = {}
+    for line in text.split("\n"):
+        m = BULLET.match(line.strip())
+        if not m:
+            continue
+        ids = m.group("ids").split()
+        bad = [t for t in ids if not BARE_ID.match(t)]
+        if bad:
+            raise ValueError(
+                f"bucket {m.group('bucket')} bullet mixes prose into its row-id "
+                f"run (first offender {bad[0]!r}). Keep the bullet a bare id list; "
+                "per-row notes belong in the indented sub-list beneath it."
+            )
+        claimed[m.group("bucket")] = ids
+    return claimed
+
+
+def compare(derived, claimed):
+    """[] when they agree, else human-readable differences."""
+    problems = []
+    for bucket in sorted(set(derived) | set(claimed)):
+        d, c = set(derived.get(bucket, [])), set(claimed.get(bucket, []))
+        if d == c:
+            continue
+        missing = sorted(d - c, key=sort_key)
+        extra = sorted(c - d, key=sort_key)
+        if missing:
+            problems.append(
+                f"{bucket}: UAT.md puts {' '.join(missing)} here, WBS §1 does not")
+        if extra:
+            problems.append(
+                f"{bucket}: WBS §1 lists {' '.join(extra)} here, UAT.md does not")
+    return problems
+
+
+def render(derived):
+    total = sum(len(v) for v in derived.values())
+    what = {
+        "DEPLOY-GATED": "the fix is merged and not running here; closes on a roll/prov",
+        "BUILD": "no fix exists yet (`NEEDS-CODE` in UAT.md)",
+        "ENV-STATE": "needs a different environment shape entirely",
+        "WALKABLE NOW": "a walk on THIS env can change the verdict",
+    }
+    out = ["| bucket | rows | what it needs |", "|---|--:|---|"]
+    for b in ORDER:
+        if b in derived:
+            out.append(f"| **{b}** | {len(derived[b])} | {what[b]} |")
+    out.append(f"| **total** | **{total}** | |")
+    out.append("")
+    for b in ORDER:
+        if b in derived:
+            out.append(f"- **{b} ({len(derived[b])})** — {' '.join(derived[b])}")
+    return "\n".join(out)
+
+
+def self_test():
+    """--check must go red on a disagreement and green on agreement."""
+    uat = (
+        "| 1 | x | y | z | hw | ❌ | ‖ PARTITION 2026-08-10: DEPLOY-GATED — m |\n"
+        "| 2 | x | y | z | hw | ❌ | ‖ PARTITION 2026-08-10: NEEDS-CODE — m "
+        "‖ RE-TAGGED 2026-08-10: NEEDS-CODE -> DEPLOY-GATED. m |\n"
+        "| 3 | x | y | z | hw | ❌ | no label at all |\n"
+        "| 4 | x | y | z | hw | ✅ | green rows are not partitioned |\n"
+    )
+    derived = derive(uat)
+    ok = True
+
+    expected = {"DEPLOY-GATED": ["1", "2"], "WALKABLE NOW": ["3"]}
+    good = derived == expected
+    ok &= good
+    print(f"  [{'ok' if good else 'FAIL'}] last label wins, untagged is walkable, "
+          f"green excluded (got {derived})")
+
+    agree = "- **DEPLOY-GATED (2)** — 1 2\n- **WALKABLE NOW (1)** — 3\n"
+    good = compare(derived, parse_wbs(agree)) == []
+    ok &= good
+    print(f"  [{'ok' if good else 'FAIL'}] agreement is green")
+
+    # The exact 2026-08-10 drift: a re-tagged row left behind in BUILD.
+    stale = "- **DEPLOY-GATED (1)** — 1\n- **BUILD (1)** — 2\n- **WALKABLE NOW (1)** — 3\n"
+    problems = compare(derived, parse_wbs(stale))
+    good = (len(problems) == 2
+            and any(p.startswith("DEPLOY-GATED") and " 2 " in f" {p} " for p in problems)
+            and any(p.startswith("BUILD") for p in problems))
+    ok &= good
+    print(f"  [{'ok' if good else 'FAIL'}] a row left in the wrong bucket is red "
+          f"({len(problems)} difference(s))")
+
+    try:
+        parse_wbs("- **WALKABLE NOW (1)** — 3 (needs a signed-in session)\n")
+        good = False
+    except ValueError:
+        good = True
+    ok &= good
+    print(f"  [{'ok' if good else 'FAIL'}] prose inside an id run is rejected, "
+          "not silently mis-parsed")
+
+    # Vacuity: a ledger the row regex cannot read must not read as "all agree".
+    good = compare(derive("nothing here matches"), parse_wbs(agree)) != []
+    ok &= good
+    print(f"  [{'ok' if good else 'FAIL'}] an unparsed ledger is red, not green")
+
+    print("self-test:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--write", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    derived = derive(UAT.read_text(encoding="utf-8"))
+    if not derived:
+        print("no ❌ rows parsed from UAT.md — the row regex is not reading the "
+              "ledger", file=sys.stderr)
+        return 1
+
+    if args.write:
+        print(render(derived))
+        print("\n(paste into WBS-TO-100.md §1, then re-run --check)")
+        return 0
+
+    if args.check:
+        problems = compare(derived, parse_wbs(WBS.read_text(encoding="utf-8")))
+        for p in problems:
+            print("FAIL: " + p)
+        if problems:
+            print("\nWBS-TO-100.md §1 disagrees with UAT.md about which rows need "
+                  "an engineer. UAT.md wins — re-derive with --write.",
+                  file=sys.stderr)
+            return 1
+        total = sum(len(v) for v in derived.values())
+        print(f"ok — WBS §1 matches UAT.md across {len(derived)} buckets, "
+              f"{total} ❌ rows")
+        return 0
+
+    print(render(derived))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #5988

## Why a follow-up to #5989

#5989 re-derived `WBS-TO-100.md` §1 **by hand**, and the numbers were stale within the hour — 76 ❌ became 77, 192 ✅ became 206 — because walks and a cron rewrite `UAT.md` continuously. Fixing a transcription by transcribing it again is not a fix: the copy is stale by construction.

## What this ships

`scripts/uat-partition.py` derives each ❌ row's bucket from the row's **own Evidence cell** — the LAST partition label wins, and a ❌ row with no label is `WALKABLE NOW`, because nothing has recorded a reason it cannot be walked (which is exactly how 91/220/242 were already being read).

- `--write` emits the section
- `--check` fails when the section and the ledger disagree
- `--self-test` proves the comparison can go both ways

Plus the workflow that runs `--self-test` before `--check` on any change to either ledger file or the script.

## Proven to fail before it passes — and it caught my own text

On the first run, `--check` rejected the `WALKABLE NOW` bullet that **#5989 itself wrote**: it carried per-row prose inside the id run, and the parser refused it rather than silently mis-reading `"(one"` as a row id.

```
ValueError: bucket WALKABLE NOW bullet mixes prose into its row-id run
(first offender '(one'). Keep the bullet a bare id list; per-row notes
belong in the indented sub-list beneath it.
```

The section is now a bare id list with the notes in a sub-list beneath — parseable, and easier to read than a 6-clause run-on bullet.

`--self-test` covers five legs, each verified to fail when the corresponding logic is broken:

1. the LAST label wins over an earlier one on the same row;
2. an untagged ❌ row is WALKABLE NOW;
3. ✅ rows are excluded entirely;
4. a row left in the wrong bucket is red — the fixture is the exact 2026-08-10 drift, a re-tagged row still listed under BUILD;
5. prose inside an id run is rejected, not mis-parsed;
6. **anti-vacuity** — a ledger the row regex cannot read is red, never "agreement". Without this the guard would pass loudest at the moment it stopped reading the ledger.

## §0 and §3

Both now state their counts as a **snapshot at a named commit** with the command to re-run, instead of asserting figures that decay in hours. §3 keeps the part that does not decay: the re-walk term is roughly **three times** the non-green term, so a plan quoting only "N rows left" is wrong by about a factor of three.

## Verification

`--self-test` PASS; `--check` ok across 4 buckets / 77 ❌ rows; `check-uat-fix-sha-citations.py` and `test_uat_table_shape.py` still green. **No UAT verdict touched** — this PR does not edit `UAT.md` at all.
