### PR TITLE
fix(funnel): the per-Org bp-newapi HelmRelease could not install, and once it could it installed empty (#5987)

### DIFF
--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -393,6 +393,31 @@ spec:
 // default) + PATCHes the DSN via its own post-install hook, so disableWait:true
 // lets the release reach hook execution (the #4246 deadlock fix). Tier-aware
 // kubeConfig like the other HR apps (vcluster tier installs INTO the vcluster).
+//
+// #5987 — THE VALUES BLOCK WAS NOT SPEAKING THE CHART'S LANGUAGE. Three of the
+// four keys below are corrections; each was proven by `helm template` against
+// platform/newapi/chart (identical chart, command and --api-versions across
+// every run, only the values file differing):
+//
+//   - No `catalystIntegration` at all → the chart defaults it ON with an empty
+//     `externalSecret.remoteRef.key`, and templates/external-secret.yaml makes
+//     that combination an explicit `{{- fail }}`. Render exited 1. This became
+//     urgent when #5969 added `openclaw ⇒ newapi` to impliedHelmReleaseApps:
+//     the broken HR stopped being opt-in and now reaches EVERY openclaw Org.
+//   - A top-level `oidc.issuerURL` → not a bp-newapi value (the chart reads
+//     `auth.adminUI.keycloak.*`). Helm drops unknown values silently, so
+//     deployment.yaml's $kcConfigured gate never held: fixing only the `fail`
+//     produced a release with NO Deployment.
+//   - A top-level `httpRoute:` → not a bp-newapi value either (the chart reads
+//     `ingress.httpRoute.*`, and `host:` is a scalar, not `hostnames:`), so no
+//     HTTPRoute rendered and `api.<slug>.<parent>` — the exact host
+//     generateOpenClawHR stamps into openclaw's llm.baseURL — was served by
+//     nothing. That is UAT row 225's dangling-host shape.
+//
+// bp-openclaw's values.yaml DOES define top-level `oidc`/`llm`/`keycloak`/
+// `newapi`/`tenant`/`httpRoute`, so generateOpenClawHR does not share this
+// gap — verified by rendering its funnel values against platform/openclaw/chart
+// (exit 0, Deployment + HTTPRoute on openclaw.<slug>.<parent>).
 func generateNewAPIHR(opt helmReleaseAppOpts) string {
 	host := fmt.Sprintf("api.%s.%s", opt.slug, opt.parentDomain)
 	primaryDomain := fmt.Sprintf("%s.%s", opt.slug, opt.parentDomain)
@@ -400,11 +425,12 @@ func generateNewAPIHR(opt helmReleaseAppOpts) string {
 	if keycloakRealm == "" {
 		keycloakRealm = fmt.Sprintf("https://keycloak.%s.%s/realms/org-%s", opt.slug, opt.parentDomain, opt.slug)
 	}
-	return fmt.Sprintf(`# bp-newapi (#4739) — per-Org NewAPI LLM gateway rendered by the generic funnel
-# generator. openclaw's llm.baseURL (api.<slug>.<parent>/v1) routes here. Mirrors
-# the BSS-door orgTenantBPNewAPI (#945) but DROPS the dependsOn: bp-keycloak the
-# generic funnel never renders (a dependsOn on a never-rendered HR wedges the
-# release forever — the same divergence as bp-openclaw). Chart owns its CNPG.
+	return fmt.Sprintf(`# bp-newapi (#4739, #5987) — per-Org NewAPI LLM gateway rendered by the generic
+# funnel generator. openclaw's llm.baseURL (api.<slug>.<parent>/v1) routes here.
+# Mirrors the BSS-door orgTenantBPNewAPI (#945) but DROPS the dependsOn:
+# bp-keycloak the generic funnel never renders (a dependsOn on a never-rendered
+# HR wedges the release forever — the same divergence as bp-openclaw). Chart
+# owns its CNPG.
 %s
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -450,17 +476,71 @@ spec:
     # own per-Org CNPG Cluster + syncs the canonical DSN via its post-install
     # hook. Do NOT set database.existingSecret (deployment.yaml auto-resolves
     # bp-newapi-newapi-db-dsn).
-    oidc:
-      issuerURL: %s
-    ingress:
+    #
+    # ── Ops-staff admin UI OIDC (#5987) ──────────────────────────────────
+    # The chart key is auth.adminUI.keycloak.* — NOT a top-level oidc.issuerURL
+    # (that key does not exist in bp-newapi's values.yaml, so Helm dropped it
+    # and deployment.yaml's $kcConfigured gate — mode==keycloak AND issuer AND
+    # existingSecret — left the release with no Deployment at all).
+    # existingSecret is materialised BY THE CHART
+    # (templates/keycloak-client-secret.yaml: lookup-or-randAlphaNum, policy
+    # keep), so naming it here is self-provisioning, not a dangling reference.
+    # ssoBridgeSync stays OFF, exactly as the BSS door does it (#4169): a
+    # per-Org AppRegistration for clientId newapi-admin PUT-overwrites the
+    # Sovereign-level newapi-admin client's redirectUris, breaking SSO on
+    # newapi.<sovereign-fqdn>.
+    auth:
+      adminUI:
+        mode: keycloak
+        keycloak:
+          issuer: %s
+          clientId: newapi-admin
+          callbackPath: /oauth/callback
+          existingSecret: newapi-oidc-client-secret
+          ssoBridgeSync:
+            enabled: false
+      customerAPI:
+        keyIssuer: catalyst
+    # Valkey OFF (#3858 root cause #3, same as the BSS door): the chart default
+    # valkey.url is the host-placed valkey synced from the rtz vCluster, which a
+    # per-Org install (vcluster tier especially) cannot reach. NewAPI treats
+    # REDIS_CONN_STRING as required once set and CrashLoops on the Redis ping;
+    # with valkey off it falls back to an in-process cache and Postgres still
+    # holds every piece of durable state.
+    valkey:
       enabled: false
-    httpRoute:
-      enabled: true
-      hostnames:
-        - %s
-      parentRef:
-        name: cilium-gateway-console
-        namespace: kube-system
+    # ── catalystIntegration OFF — deliberate, do NOT copy the BSS door here ──
+    # #5987/#4477/#5375. This block exists to hand catalyst-api a bearer for the
+    # SOVEREIGN's NewAPI (unified-rbac POSTs to newapi.newapi.svc), and it is
+    # singular by construction: catalyst-api's seedNewapiAdminToken seam writes
+    # ONE cluster-shared OpenBao path, the external-secrets-push policy grants
+    # create/update on exactly that one key, and the rendered Secret carries
+    # reflector annotations that auto-mirror it into catalyst-system, where the
+    # Sovereign's own copy already lives.
+    #
+    # Enabling it on a per-Org install would therefore be actively destructive,
+    # not merely redundant: the chart's companion PushSecret (default enabled,
+    # updatePolicy Replace) would overwrite that shared path with THIS Org's own
+    # random token-signing-key ADMIN_SECRET, 401-ing per-user key issuance for
+    # the whole Sovereign, while two ExternalSecrets fought over one mirrored
+    # Secret name in catalyst-system. Nothing inside the per-Org release
+    # consumes the Secret, so off is both safe and complete.
+    catalystIntegration:
+      enabled: false
+    ingress:
+      # The traefik Ingress the BSS door renders is inert on a Sovereign; public
+      # exposure rides the dedicated console Gateway, same as bp-openclaw.
+      enabled: false
+      # #5987 — the chart key is ingress.httpRoute.* with a SCALAR host; a
+      # top-level httpRoute: block with hostnames: [] is not a bp-newapi value
+      # and rendered no route, leaving openclaw's llm.baseURL pointing at a
+      # hostname this Org served from nowhere (UAT row 225).
+      httpRoute:
+        enabled: true
+        host: %s
+        parentRef:
+          name: cilium-gateway-console
+          namespace: kube-system
 `, helmRepoBlock("bp-newapi"), opt.slug, opt.slug, opt.kubeConfigBlock(),
 		primaryDomain, keycloakRealm, host)
 }

--- a/core/services/provisioning/gitops/newapi_hr_installable_5987_test.go
+++ b/core/services/provisioning/gitops/newapi_hr_installable_5987_test.go
@@ -1,0 +1,353 @@
+package gitops
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #5987 — the funnel-rendered bp-newapi HelmRelease could not install, and
+// once it could, it installed EMPTY.
+//
+// TWO defects, both in generateNewAPIHR's `values:` block, both proven by
+// `helm template` against platform/newapi/chart (chart, command and
+// --api-versions held identical across every run; only the values file
+// changed):
+//
+//  1. RENDER-BLOCKING. The block passed no `catalystIntegration` at all.
+//     bp-newapi's values.yaml defaults `catalystIntegration.enabled: true` +
+//     `externalSecret.enabled: true` with `remoteRef.key: ""`, and
+//     templates/external-secret.yaml turns that combination into an explicit
+//     `{{- fail }}`. Rendering the funnel values exited 1 with
+//     "catalystIntegration.externalSecret.remoteRef.key is empty".
+//     Live impact: #5969 added `openclaw ⇒ newapi` to impliedHelmReleaseApps,
+//     so EVERY openclaw Org — not just an Org that bought newapi — renders
+//     this HR.
+//
+//  2. SILENTLY-EMPTY. The block stamped a TOP-LEVEL `oidc.issuerURL` and a
+//     TOP-LEVEL `httpRoute:` — neither key exists in bp-newapi's values.yaml
+//     (the chart reads `auth.adminUI.keycloak.*` and `ingress.httpRoute.*`).
+//     Helm drops unknown values silently, so deployment.yaml's $kcConfigured
+//     gate (mode==keycloak AND issuer AND existingSecret) was never met and
+//     httproute.yaml's `.Values.ingress.httpRoute.enabled` gate was never
+//     true. Fixing (1) alone produced a release with NO Deployment and NO
+//     HTTPRoute — i.e. `api.<slug>.<parent>`, the exact host
+//     generateOpenClawHR stamps into openclaw's llm.baseURL, still served
+//     nothing. That is UAT row 225's dangling-host shape, unfixed.
+//
+// These tests pin the CHART-SIDE contract, not the wording of the template:
+// each assertion below restates a gate that lives in platform/newapi/chart
+// and names it.
+
+// ─────────────────────────────────────────────────────────────────────────
+// yamlScalar — a deliberately small, indentation-aware lookup for a dotted
+// path through a 2-space-indented YAML mapping. It exists so these tests
+// assert on the VALUE at a chart-recognised PATH instead of grepping for a
+// substring: `grep "issuer:"` passes just as happily on a top-level `oidc:`
+// block the chart never reads, which is precisely the defect (2) above.
+//
+// TestYAMLScalar_SelfCheck below is its vacuity guard — it proves the lookup
+// can miss, and that it refuses to skip a level.
+// ─────────────────────────────────────────────────────────────────────────
+func yamlScalar(block, path string) (string, bool) {
+	segs := strings.Split(path, ".")
+	lines := strings.Split(block, "\n")
+	depth, idx := 0, 0
+	for si, seg := range segs {
+		found := false
+		for ; idx < len(lines); idx++ {
+			raw := lines[idx]
+			trimmed := strings.TrimLeft(raw, " ")
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			ind := len(raw) - len(trimmed)
+			if ind < depth {
+				// Left the parent mapping without finding the key.
+				return "", false
+			}
+			if ind > depth {
+				// Belongs to a sibling's sub-tree.
+				continue
+			}
+			if !strings.HasPrefix(trimmed, seg+":") {
+				continue
+			}
+			rest := strings.TrimSpace(strings.TrimPrefix(trimmed, seg+":"))
+			if si == len(segs)-1 {
+				return rest, true
+			}
+			idx++
+			depth += 2
+			found = true
+			break
+		}
+		if !found {
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// hrValuesBlock returns the HelmRelease document's `spec.values:` mapping,
+// dedented to column 0 so yamlScalar paths read like chart values paths.
+func hrValuesBlock(t *testing.T, doc string) string {
+	t.Helper()
+	var hr string
+	for _, d := range strings.Split(doc, "\n---\n") {
+		if strings.Contains(d, "kind: HelmRelease") {
+			hr = d
+			break
+		}
+	}
+	if hr == "" {
+		t.Fatalf("no HelmRelease document in:\n%s", doc)
+	}
+	var out []string
+	grabbing := false
+	for _, l := range strings.Split(hr, "\n") {
+		if l == "  values:" {
+			grabbing = true
+			continue
+		}
+		if !grabbing {
+			continue
+		}
+		if strings.TrimSpace(l) == "" {
+			out = append(out, "")
+			continue
+		}
+		if !strings.HasPrefix(l, "    ") {
+			break
+		}
+		out = append(out, l[4:])
+	}
+	if len(out) == 0 {
+		t.Fatalf("HelmRelease carries no spec.values block:\n%s", hr)
+	}
+	return strings.Join(out, "\n")
+}
+
+// newapiValuesFaults applies the three bp-newapi chart gates the funnel HR
+// must satisfy, and returns one line per violated gate. Empty result == the
+// chart renders a NewAPI that actually exists.
+//
+// Every gate below is a literal condition in platform/newapi/chart:
+//
+//   - templates/external-secret.yaml:42 + templates/admin-token-pushsecret.yaml:71
+//     `{{- fail }}` when catalystIntegration is on and remoteRef.key is empty.
+//   - templates/deployment.yaml:35,81 $kcConfigured — no Deployment without
+//     auth.adminUI.keycloak.issuer AND .existingSecret.
+//   - templates/httproute.yaml:32 — no HTTPRoute without
+//     ingress.httpRoute.enabled.
+func newapiValuesFaults(values string) []string {
+	var faults []string
+
+	ciEnabled, ciSet := yamlScalar(values, "catalystIntegration.enabled")
+	remoteKey, _ := yamlScalar(values, "catalystIntegration.externalSecret.remoteRef.key")
+	// The chart DEFAULTS catalystIntegration.enabled + externalSecret.enabled
+	// to true, so "unset" is the failing case, not the safe one.
+	if !ciSet || ciEnabled != "false" {
+		if strings.TrimSpace(remoteKey) == "" {
+			faults = append(faults, "catalystIntegration is left at its enabled-by-default state with an empty externalSecret.remoteRef.key — external-secret.yaml:42 `fail`s the render")
+		}
+	}
+
+	issuer, _ := yamlScalar(values, "auth.adminUI.keycloak.issuer")
+	if strings.TrimSpace(issuer) == "" {
+		faults = append(faults, "auth.adminUI.keycloak.issuer is empty — deployment.yaml's $kcConfigured gate is unmet and the release renders NO Deployment")
+	}
+	kcSecret, _ := yamlScalar(values, "auth.adminUI.keycloak.existingSecret")
+	if strings.TrimSpace(kcSecret) == "" {
+		faults = append(faults, "auth.adminUI.keycloak.existingSecret is empty — deployment.yaml's $kcConfigured gate is unmet and the release renders NO Deployment")
+	}
+
+	route, _ := yamlScalar(values, "ingress.httpRoute.enabled")
+	if strings.TrimSpace(route) != "true" {
+		faults = append(faults, "ingress.httpRoute.enabled is not true — httproute.yaml renders nothing and api.<slug>.<parent> is served by no route")
+	}
+
+	return faults
+}
+
+// TestYAMLScalar_SelfCheck is the vacuity guard for the two helpers above.
+// Without it, a lookup that silently returned ("", false) for EVERY path
+// would make newapiValuesFaults report faults forever (or, with the
+// polarity flipped, never) regardless of the code under test.
+func TestYAMLScalar_SelfCheck(t *testing.T) {
+	fixture := strings.Join([]string{
+		"sovereignFQDN: acme.omani.homes",
+		"auth:",
+		"  adminUI:",
+		"    # a comment that must be skipped",
+		"    mode: keycloak",
+		"    keycloak:",
+		"      issuer: https://kc.example/realms/org-acme",
+		"      existingSecret: newapi-oidc-client-secret",
+		"ingress:",
+		"  enabled: false",
+		"  httpRoute:",
+		"    enabled: true",
+	}, "\n")
+
+	hits := map[string]string{
+		"sovereignFQDN":                        "acme.omani.homes",
+		"auth.adminUI.mode":                    "keycloak",
+		"auth.adminUI.keycloak.issuer":         "https://kc.example/realms/org-acme",
+		"ingress.enabled":                      "false",
+		"ingress.httpRoute.enabled":            "true",
+		"auth.adminUI.keycloak.existingSecret": "newapi-oidc-client-secret",
+	}
+	for path, want := range hits {
+		got, ok := yamlScalar(fixture, path)
+		if !ok || got != want {
+			t.Errorf("yamlScalar(%q) = (%q, %v), want (%q, true)", path, got, ok, want)
+		}
+	}
+
+	// It must MISS what is absent, and it must not skip a level — a lookup
+	// that flattened the tree would find `mode` under `auth.mode` and would
+	// therefore have found the old top-level `oidc.issuerURL` acceptable.
+	for _, path := range []string{
+		"catalystIntegration.enabled",
+		"auth.mode",
+		"auth.adminUI.keycloak.nonexistent",
+		"httpRoute.enabled", // the WRONG (top-level) key the defect used
+	} {
+		if got, ok := yamlScalar(fixture, path); ok {
+			t.Errorf("yamlScalar(%q) = (%q, true), want a miss", path, got)
+		}
+	}
+}
+
+// TestNewAPIValuesFaults_FlagsThePreFixBlock is the second half of the
+// vacuity guard, and the one that matters most: it feeds newapiValuesFaults
+// the EXACT values block generateNewAPIHR emitted before #5987 and asserts
+// all three chart gates are reported. A fixture that omitted the fields the
+// bug keys on would let the checker pass on data that could never exercise
+// the defect — this pins that it cannot.
+func TestNewAPIValuesFaults_FlagsThePreFixBlock(t *testing.T) {
+	preFix := strings.Join([]string{
+		"sovereignFQDN: acme.omani.homes",
+		"oidc:",
+		"  issuerURL: https://keycloak.acme.omani.homes/realms/org-acme",
+		"ingress:",
+		"  enabled: false",
+		"httpRoute:",
+		"  enabled: true",
+		"  hostnames:",
+		"    - api.acme.omani.homes",
+		"  parentRef:",
+		"    name: cilium-gateway-console",
+		"    namespace: kube-system",
+	}, "\n")
+
+	faults := newapiValuesFaults(preFix)
+	if len(faults) != 4 {
+		t.Fatalf("pre-#5987 values must trip all four chart gates (render fail, issuer, existingSecret, httpRoute); got %d:\n%s",
+			len(faults), strings.Join(faults, "\n"))
+	}
+	joined := strings.Join(faults, "\n")
+	for _, want := range []string{"external-secret.yaml:42", "$kcConfigured", "httproute.yaml"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("fault report must name the chart gate %q; got:\n%s", want, joined)
+		}
+	}
+}
+
+// TestFunnelNewAPIHR_SatisfiesChartValuesContract_5987 is the regression
+// proof. It runs the REAL generator across both boundary tiers and the
+// shared-realm/per-Org-realm split, and asserts the rendered HR trips none
+// of the chart gates.
+func TestFunnelNewAPIHR_SatisfiesChartValuesContract_5987(t *testing.T) {
+	cases := []struct {
+		name string
+		opt  helmReleaseAppOpts
+	}{
+		{"host-tier", helmReleaseAppOpts{slug: "acme", parentDomain: "omani.homes"}},
+		{"vcluster-tier", helmReleaseAppOpts{slug: "acme", parentDomain: "omani.homes", kubeSecret: "tenant-acme-kubeconfig"}},
+		{"shared-realm", helmReleaseAppOpts{slug: "acme", parentDomain: "omani.homes", sharedRealmIssuer: "https://auth.t99.omani.works/realms/sovereign"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values := hrValuesBlock(t, generateNewAPIHR(tc.opt))
+			if faults := newapiValuesFaults(values); len(faults) > 0 {
+				t.Fatalf("funnel bp-newapi HR violates the bp-newapi chart values contract (#5987):\n  - %s\n\nrendered values:\n%s",
+					strings.Join(faults, "\n  - "), values)
+			}
+
+			// The route must carry the host openclaw is pointed at, and it
+			// must ride the console Gateway (a Sovereign runs no traefik for
+			// per-Org apps — the same stance generateOpenClawHR takes).
+			wantHost := fmt.Sprintf("api.%s.%s", tc.opt.slug, tc.opt.parentDomain)
+			if got, _ := yamlScalar(values, "ingress.httpRoute.host"); got != wantHost {
+				t.Errorf("ingress.httpRoute.host = %q, want %q", got, wantHost)
+			}
+			if got, _ := yamlScalar(values, "ingress.httpRoute.parentRef.name"); got != "cilium-gateway-console" {
+				t.Errorf("ingress.httpRoute.parentRef.name = %q, want cilium-gateway-console", got)
+			}
+			if got, _ := yamlScalar(values, "ingress.enabled"); got != "false" {
+				t.Errorf("ingress.enabled = %q, want false (the traefik Ingress is inert on a Cilium-Gateway Sovereign)", got)
+			}
+		})
+	}
+}
+
+// TestFunnelNewAPIHR_NeverClobbersTheSovereignAdminToken_5987 pins the
+// reason the funnel HR turns catalystIntegration OFF rather than copying the
+// BSS door's block verbatim.
+//
+// bp-newapi's catalystIntegration ships a PushSecret
+// (templates/admin-token-pushsecret.yaml, default enabled, updatePolicy
+// Replace) that writes THIS release's own random token-signing-key
+// ADMIN_SECRET to the OpenBao path in externalSecret.remoteRef.key. That path
+// is cluster-shared and singular: catalyst-api's seedNewapiAdminToken seam
+// writes `catalyst/newapi/admin-token`
+// (products/catalyst/bootstrap/api/internal/handler/sovereign_newapi_admin_token_seed.go),
+// the OpenBao `external-secrets-push` policy grants create/update on exactly
+// that one key, and catalyst-api's unified-rbac consumes the resulting bearer
+// against the SOVEREIGN's newapi (`newapi.newapi.svc`). A per-Org install
+// pointed at that path would overwrite the Sovereign-wide bearer with an Org-
+// local secret and 401 the whole Sovereign's per-user key issuance, and its
+// target Secret carries reflector auto-mirror annotations into
+// catalyst-system, where the Sovereign's own copy already lives.
+//
+// Nothing in the per-Org release consumes the Secret, so the correct funnel
+// value is `enabled: false` — and this test fails if a future edit turns it
+// back on without also proving a per-Org, per-Org-writable path exists.
+func TestFunnelNewAPIHR_NeverClobbersTheSovereignAdminToken_5987(t *testing.T) {
+	values := hrValuesBlock(t, generateNewAPIHR(helmReleaseAppOpts{slug: "acme", parentDomain: "omani.homes"}))
+
+	got, ok := yamlScalar(values, "catalystIntegration.enabled")
+	if !ok || got != "false" {
+		t.Fatalf("catalystIntegration.enabled = %q (set=%v), want false — see this test's doc comment", got, ok)
+	}
+	if strings.Contains(values, "catalyst/newapi/admin-token") {
+		t.Errorf("the funnel HR must NOT name the cluster-shared admin-token path; the chart's PushSecret would overwrite the Sovereign-wide bearer with this Org's own")
+	}
+}
+
+// TestFunnelNewAPIHR_ServesOpenClawLLMBaseURL_5987 pins the coupling that
+// motivated impliedHelmReleaseApps (openclaw ⇒ newapi, #5969): openclaw's
+// llm.baseURL is generated, not configured, so if the two templates ever
+// disagree on the host the implication delivers a gateway nobody can reach.
+func TestFunnelNewAPIHR_ServesOpenClawLLMBaseURL_5987(t *testing.T) {
+	opt := helmReleaseAppOpts{slug: "acme", parentDomain: "omani.homes"}
+
+	newapiValues := hrValuesBlock(t, generateNewAPIHR(opt))
+	routeHost, ok := yamlScalar(newapiValues, "ingress.httpRoute.host")
+	if !ok {
+		t.Fatalf("bp-newapi HR carries no ingress.httpRoute.host:\n%s", newapiValues)
+	}
+
+	openclawValues := hrValuesBlock(t, generateOpenClawHR(opt))
+	llmBase, ok := yamlScalar(openclawValues, "llm.baseURL")
+	if !ok {
+		t.Fatalf("bp-openclaw HR carries no llm.baseURL:\n%s", openclawValues)
+	}
+
+	if want := "https://" + routeHost + "/v1"; llmBase != want {
+		t.Errorf("openclaw llm.baseURL = %q but bp-newapi's HTTPRoute serves %q (want llm.baseURL == %q) — the implied-app closure would install a gateway openclaw cannot reach",
+			llmBase, routeHost, want)
+	}
+}


### PR DESCRIPTION
## What was wrong

`core/services/provisioning/gitops/helmrelease_apps.go` → `generateNewAPIHR` emitted a `values:` block whose keys the `bp-newapi` chart does not define. Three separate faults, found while confirming #5987:

1. **Render-blocking.** No `catalystIntegration` at all. `platform/newapi/chart/values.yaml` defaults `catalystIntegration.enabled: true` + `externalSecret.enabled: true` with `remoteRef.key: ""`, and `templates/external-secret.yaml:42` turns that into an explicit `{{- fail }}`.
2. **Silently empty (a).** A top-level `oidc.issuerURL` — not a bp-newapi value; the chart reads `auth.adminUI.keycloak.*`. Helm drops unknown values silently, so `deployment.yaml`'s `$kcConfigured` gate (mode==keycloak AND issuer AND existingSecret) never held.
3. **Silently empty (b).** A top-level `httpRoute:` — not a bp-newapi value either; the chart reads `ingress.httpRoute.*` and takes a scalar `host:`, not `hostnames:`.

Urgency: `70f6b07aa` (#5969) added `openclaw ⇒ newapi` to `impliedHelmReleaseApps`, so the broken HR stopped being opt-in and now renders for **every** openclaw Org.

## Render evidence, with its control

`helm template` against `platform/newapi/chart` (chart copied once into a scratch dir with the `common` dependency vendored, then held byte-identical across every run). **Chart, command and `--api-versions` were identical for all five runs — only the `--values` file changed:**

```
helm template newapi <chart> -n acme --values <FILE> \
  --api-versions external-secrets.io/v1beta1 \
  --api-versions external-secrets.io/v1alpha1 \
  --api-versions gateway.networking.k8s.io/v1 \
  --api-versions postgresql.cnpg.io/v1 \
  --api-versions cilium.io/v2
```

| values | exit | rendered |
|---|---|---|
| funnel, **unfixed** | **1** — `execution error at (bp-newapi/templates/external-secret.yaml:42:4): catalystIntegration.externalSecret.remoteRef.key is empty` | nothing |
| funnel + BSS door's `catalystIntegration` (control) | 0 | 1609 lines |
| funnel + canonical shared path `catalyst/newapi/admin-token` (control) | 0 | 1609 lines, ExternalSecret `remoteRef.key` **non-empty** — and a PushSecret (see below) |
| full BSS-door values (control for "what working looks like") | 0 | 2052 lines, **Deployment present** |
| funnel + only `catalystIntegration.enabled: false` | 0 | 1378 lines — **but NO Deployment, NO HTTPRoute** |
| funnel, **fixed** (this PR, values taken from the real generator) | 0 | 1807 lines — Deployment + HTTPRoute |

The fifth row is the point: fixing the `fail` alone yields a release that installs and contains no NewAPI. Diffing `# Source:` lines between rows 3 and 5 shows exactly three templates drop out — `external-secret.yaml`, `admin-token-pushsecret.yaml`, and the external-secrets webhook-readiness hook that mirrors their gate — with the app itself unchanged, i.e. it was never rendering.

After the fix, the same command renders: `Deployment/newapi-bp-newapi`, `HTTPRoute/newapi-bp-newapi-public` with `hostnames: [api.acme.omani.homes]` and `parentRefs: [cilium-gateway-console/kube-system]`, `Secret/newapi-oidc-client-secret` (chart-materialised), `Secret/newapi-bp-newapi-app-creds`, `Cluster/newapi-bp-newapi-newapi-pg`, and **no** PushSecret or `catalyst-newapi-admin-token` ExternalSecret.

## Why `catalystIntegration` is OFF rather than copied from the BSS door

Copying it would have been destructive, not merely redundant. The integration is singular by construction:

- catalyst-api's `seedNewapiAdminToken` seam writes **one cluster-shared** OpenBao path (`sovereign_newapi_admin_token_seed.go`), and its own doc comment records that the historical per-tenant `sovereign/<fqdn>/…` shape 403s — catalyst-api's role is scoped to `secret/{data,metadata}/catalyst/*`. The BSS door still passes that historical per-tenant path, so its own ExternalSecret cannot sync (noted below as follow-up).
- `platform/openbao/chart/templates/auth-bootstrap-job.yaml` grants ESO create/update on **exactly that one key** — a per-Org path is unwritable by design.
- The chart's companion PushSecret (`admin-token-pushsecret.yaml`, default enabled, `updatePolicy: Replace`) sources `ADMIN_SECRET` from **this release's own** random `newapi-bp-newapi-token-signing-key`. Rendered per-Org against the shared path, it would overwrite the Sovereign-wide bearer and 401 unified-rbac's per-user key issuance for the whole Sovereign. Confirmed in the row-3 render: `PushSecret/catalyst-newapi-admin-token-push` → `remoteKey: "catalyst/newapi/admin-token"`, selector `newapi-bp-newapi-token-signing-key`.
- The target Secret also carries reflector auto-mirror annotations into `catalyst-system`, where the Sovereign's own copy already lives — two sources, one destination.
- Nothing inside the per-Org release consumes the Secret; catalyst-api's consumer targets `newapi.newapi.svc`.

So `enabled: false` is both the safe and the complete answer for the funnel path, and the reasoning is written at the edit site so a future reader does not "restore parity" by turning it back on.

## `generateOpenClawHR` — checked, does not share the gap

`platform/openclaw/chart/values.yaml` **does** define top-level `oidc` / `llm` / `keycloak` / `newapi` / `tenant` / `httpRoute`, and its placeholder `fail`s are gated behind `assertNoPlaceholders` (default `false`). Rendering its funnel values against `platform/openclaw/chart` exits 0 with a Deployment and an HTTPRoute on `openclaw.<slug>.<parent>`. Left untouched; a new test pins that its `llm.baseURL` stays equal to the host bp-newapi's HTTPRoute serves, since that coupling is what the implied-app closure rests on.

## The regression test, and proof it can fail

`core/services/provisioning/gitops/newapi_hr_installable_5987_test.go` asserts the three chart gates **by path lookup**, not substring grep — `grep "issuer:"` passes just as happily on the top-level `oidc` block the chart never reads, which is the defect itself. Each fault message names the chart file and line it restates.

Two vacuity guards, because a fixture that omits the field the bug keys on is the recurring trap here:

- `TestYAMLScalar_SelfCheck` — the lookup must hit known paths, must **miss** absent ones, and must refuse to skip a level (it must not find `auth.mode`, nor accept the old top-level `httpRoute.enabled`).
- `TestNewAPIValuesFaults_FlagsThePreFixBlock` — feeds the checker the **exact pre-fix values block** and requires all four faults to be reported.

Proven red before the fix: all three `_5987` tests failed against the unfixed generator across host tier, vcluster tier and shared-realm, each reporting four faults; the two guards passed at the same time. Green after. Full `core/services/provisioning` suite passes.

## Constraints honoured

No chart version bumped. `products/catalyst/chart/Chart.yaml`, the catalog seed and `clusters/_template/bootstrap-kit/*` untouched — the fix is entirely in the generator, so no umbrella-version claimant enters the queue. No secret value appears anywhere; only path and key names. No UAT row stamped — no environment exists to walk.

## Follow-up worth its own issue (not fixed here)

The BSS door's `orgTenantBPNewAPI` passes `remoteRef.key: sovereign/<OTECHFQDN>/newapi/<TenantID>/admin-token`. That path is unwritable by catalyst-api (403, per the seam's own comment) and outside the ESO push policy's single-key grant, so every BSS-door Org's `catalyst-newapi-admin-token` ExternalSecret sits in `SecretSyncedError` and its PushSecret cannot write. It renders, so it never tripped a gate — a latent read-path defect in the other door.

Refs #5987 #4477 #5375 #5969
