### PR TITLE
fix(bp-postgres): the replica side must not name a role Secret it never renders

### DIFF
--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -88,7 +88,44 @@ spec:
       {{- $first := first .Values.databases }}
       database: {{ (default (dict) $first).name | default "app" | quote }}
       owner: {{ (default (dict) $first).owner | default "app" | quote }}
-      {{- if $first }}
+      {{- /*
+      #6016 SIDE GATE — this reference may only render where the Secret it
+      names is ALSO rendered. `secret.name` below resolves to
+      bp-postgres.roleSecretName, and role-secrets.yaml (which is the ONLY
+      producer of that object) is gated `not isReplicaSide`. Naming it on the
+      replica side therefore points CNPG at an object this chart deliberately
+      never creates there — and unlike managed.roles (a controller-level
+      reconcile that merely reports pending), bootstrap.initdb.secret is
+      POD-FATAL: CNPG projects it into the initdb Job as
+      `APP_USERNAME <- secretKeyRef{name: <roleSecret>, key: username}` with
+      `optional: false`, so the container cannot be configured at all.
+
+      Live proof (hw293, dep a0077ba47e3720e5, region me-east-215-b):
+      all three shared instances' initdb Pods sat in CreateContainerConfigError
+      for 139m — shared-pg-1-initdb, shared-pg-b-1-initdb, shared-pg-c-1-initdb
+      — on `APP_USERNAME: <set to the key 'username' in secret
+      'shared-pg-harbor'> Optional: false`, while region-B's shared-data held
+      ZERO basic-auth role Secrets (14 Secrets vs region-A's 36). The wedge
+      surfaced four hops downstream as keycloak-0 Init:0/1 and 8 non-Ready
+      HelmReleases (65-8=57), which is why it took three walkers to trace back
+      to a dangling name in this file.
+
+      The pre-flip window is what makes this reachable: renderReplicaHalf is
+      `activeHotStandby AND side=replica`, so BEFORE the crossRegion flip the
+      secondary still renders THIS singleton placeholder Cluster (deliberate,
+      #4460) — with `side` already stamped `secondary` from cloud-init. That
+      combination (side=secondary AND activeHotStandby=false) is precisely the
+      one the existing Case 4b fixture does not cover, because 4b sets
+      activeHotStandby=true and so skips this template entirely.
+
+      Dropping the reference on the replica side restores CNPG's own
+      auto-generated `<cluster>-app` credential for the THROWAWAY placeholder
+      (the pre-#5507 behaviour), which is discarded at the flip when
+      replica-cluster.yaml takes over. #5507's guarantee is untouched exactly
+      where it matters — primary and singleton, the sides that mint the role
+      Secret and hand it to real consumers.
+      */}}
+      {{- if and $first (not (include "bp-postgres.isReplicaSide" $)) }}
       {{- /*
       #5504: the initdb OWNER must be born holding the SAME Secret the
       managed.roles entry below declares for it.

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -368,6 +368,83 @@ if grep -qE '^kind: Secret$' "$TMP/preflip-replica-alias.yaml"; then
   fail "#5224: pre-flip side=replica minted a Secret (alias must match side=secondary)"
 fi
 
+# ── Case 4h: #6016 — the render must not REFERENCE a role Secret it does not MINT ─
+#
+# Case 4g above pins the MINT half of the #5224 side-gate ("the secondary
+# renders ZERO Secrets") and passes. The defect lived in the other half: a
+# DIFFERENT template referencing, by name, the object 4g just proved absent.
+# Asserting only the absence is the "guard tested a surface that cannot fail"
+# shape — 4g can never go red on a dangling reference, because it never looks
+# at references at all.
+#
+# THE CONTRADICTION (#6016, chart 0.2.18): cluster.yaml's
+# `bootstrap.initdb.secret.name` resolves to bp-postgres.roleSecretName, whose
+# ONLY producer is role-secrets.yaml — gated `not isReplicaSide`. On the
+# pre-flip secondary (side=secondary AND activeHotStandby=false, the window in
+# which renderReplicaHalf is still false so this template DOES render) the
+# reference was emitted and the Secret was not. CNPG projects that name into
+# the initdb Job as `APP_USERNAME <- secretKeyRef{key: username}` with
+# `optional: false`, so the Pod cannot be configured — a POD-FATAL dangle,
+# unlike managed.roles[].passwordSecret which is a controller-level reconcile
+# that merely reports pending (deliberate, documented in role-secrets.yaml).
+#
+# Live (hw293 dep a0077ba47e3720e5, region me-east-215-b): all three shared
+# instances' initdb Pods in CreateContainerConfigError for 139m, region-B
+# shared-data holding 14 Secrets to region-A's 36, surfacing four hops later as
+# keycloak-0 Init:0/1 and 8 non-Ready HelmReleases (65-8=57).
+#
+# The check is STRUCTURAL, not a token grep: it parses the rendered stream,
+# collects the Secret names the render DEFINES, collects the names it
+# REFERENCES from a pod-fatal position, and reports the difference.
+echo "[render] Case 4h: #6016 pre-flip SECONDARY → no pod-fatal reference to an unrendered role Secret"
+
+# Emits "<clusters> <initdb_refs> <dangling>"; names the dangling pairs on stderr.
+sharedpg_dangle_report() {
+  python3 - "$1" <<'PY'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if isinstance(d, dict)]
+defined = {d.get("metadata", {}).get("name")
+           for d in docs if d.get("kind") == "Secret"}
+clusters = [d for d in docs if d.get("kind") == "Cluster"]
+refs, dangling = 0, []
+for c in clusters:
+    spec = c.get("spec") or {}
+    initdb = ((spec.get("bootstrap") or {}).get("initdb") or {})
+    name = ((initdb.get("secret") or {}).get("name"))
+    if not name:
+        continue
+    refs += 1
+    if name not in defined:
+        dangling.append("%s -> %s" % (c.get("metadata", {}).get("name"), name))
+for d in dangling:
+    sys.stderr.write("  DANGLING bootstrap.initdb.secret: %s\n" % d)
+print(len(clusters), refs, len(dangling))
+PY
+}
+
+read -r pf_clusters pf_refs pf_dangling < <(sharedpg_dangle_report "$TMP/preflip-secondary.yaml") \
+  || fail "#6016: dangle report failed on the pre-flip secondary render"
+# Non-vacuity: the fixture must actually contain the placeholder Cluster. If the
+# render ever stops emitting one here, this case would pass on nothing.
+[ "${pf_clusters:-0}" -ge 1 ] \
+  || fail "#6016 VACUOUS: pre-flip secondary rendered ZERO Clusters — the fixture no longer exercises this template"
+[ "${pf_dangling:-0}" -eq 0 ] \
+  || fail "#6016: pre-flip SECONDARY references $pf_dangling role Secret(s) it never renders — CNPG projects these into the initdb Job with optional:false, so the Pod wedges in CreateContainerConfigError (hw293 region-B, 139m, 8 HelmReleases behind it)"
+
+# ── The vacuity CONTROL for the check above ───────────────────────────────
+# A dangle report that always returned 0 would satisfy the secondary assertion
+# no matter what the chart did. The pre-flip PRIMARY is the same code path with
+# the OPPOSITE expectation: it MUST both reference the role Secret (#5507 — the
+# initdb owner is born holding its managed-role credential) AND define it. So a
+# reference count of >= 1 here proves the extractor genuinely finds references,
+# and 0 dangling proves it distinguishes a satisfied one from a dangling one.
+read -r pp_clusters pp_refs pp_dangling < <(sharedpg_dangle_report "$TMP/preflip-primary.yaml") \
+  || fail "#6016: dangle report failed on the pre-flip primary render"
+[ "${pp_refs:-0}" -ge 1 ] \
+  || fail "#6016 CONTROL FAILED: the pre-flip PRIMARY carries NO bootstrap.initdb.secret reference — either #5507 regressed or the extractor is blind (in which case the secondary assertion above proves nothing)"
+[ "${pp_dangling:-0}" -eq 0 ] \
+  || fail "#5507/#6016: the pre-flip PRIMARY references a role Secret it does not mint — the side-gate has been over-applied to the minting side"
+
 # ── Case 4e: #4846 — crossRegionPeerClusters → identity-based CNP, NO ipBlock ─
 # The cross-region DR admission is an identity-based CiliumNetworkPolicy that
 # selects the peer cluster(s) by io.cilium.k8s.policy.cluster. A k8s-netpol

--- a/scripts/check-per-region-role-secrets.sh
+++ b/scripts/check-per-region-role-secrets.sh
@@ -92,6 +92,84 @@ B="$(short_sha 'pw-beta')"
 [ "$A" != "$B" ]                                          || { echo "SELF-TEST FAIL: hasher is degenerate — distinct inputs hashed alike" >&2; exit 2; }
 echo "OK — decision self-test passed (AGREE / MINT-ABSENT / DIVERGE / NOT-CONSUMED all distinguished)."
 
+# ─── Cross-region COVERAGE decision (#6016) ──────────────────────────────
+#
+# WHY THIS EXISTS: every check above is scoped to ONE region. The loop below
+# visits each context independently and asks "is what this region CONSUMES
+# backed by what this region MINTS". A region that mints nothing and consumes
+# nothing answers that question perfectly — so the sweep printed
+# "(no *-database-secret consumers found — nothing to check here)" followed by
+# "OK: every consumed role credential is backed by a minted one" and exited 0.
+#
+# Measured on hw293 (dep a0077ba47e3720e5) region me-east-215-b, which at that
+# moment held ZERO role Secrets, ZERO consumer hub Secrets, three CNPG initdb
+# Pods in CreateContainerConfigError and 8 non-Ready HelmReleases. The guard
+# called it clean. A per-region check that never compares regions cannot see a
+# per-region split — the absence is only meaningful RELATIVE to the peer.
+#
+# So: assert coverage across regions, do not assume it. Every name any region
+# holds must be held by every region. bp-postgres renders the role + hub
+# Secrets primary-side only (#5224 isReplicaSide) precisely because the
+# catalyst-api cross-mesh sync (#3629/#5230/#4158) is supposed to deliver
+# region-A's authoritative copies onward; "region B has none" is that delivery
+# not having happened, which is the fault this phase names.
+#
+# coverage_verdict <dir> <region>...
+#   reads  <dir>/<region>.names  (sorted, one Secret name per line)
+#   writes <dir>/missing         ("<region> <name>" per gap)
+#   echoes one of:
+#     NO-PEER   fewer than 2 regions — a split is not expressible here
+#     COVERED   every name held by ANY region is held by EVERY region
+#     SPLIT     some name is held by one region and missing from another
+coverage_verdict() {
+  local dir="$1"; shift
+  local regions=("$@")
+  : > "${dir}/missing"
+  if [ "${#regions[@]}" -lt 2 ]; then echo "NO-PEER"; return; fi
+  cat "${dir}"/*.names 2>/dev/null | sort -u > "${dir}/union"
+  local r n
+  for r in "${regions[@]}"; do
+    while read -r n; do
+      [ -n "${n}" ] && echo "${r} ${n}" >> "${dir}/missing"
+    done < <(comm -23 "${dir}/union" "${dir}/${r}.names")
+  done
+  if [ -s "${dir}/missing" ]; then echo "SPLIT"; else echo "COVERED"; fi
+}
+
+# ─── Phase 0b — coverage self-test (the negative FIRST) ──────────────────
+#
+# THE TRAP THIS PINS: a one-region fixture satisfies a "per-region coverage"
+# check identically to a correct two-region one, because with nothing to
+# compare against there is no gap to find. If NO-PEER and COVERED were the same
+# verdict, every assertion below would be provable with a single region and the
+# check would be decorative. They are deliberately DISTINCT tokens, and the
+# two-region-with-a-one-region-secret case is pinned RED before anything else.
+COV_T="$(mktemp -d)"
+trap 'rm -rf "${COV_T}"' EXIT
+
+printf 'shared-pg-harbor\nshared-pg-keycloak\n' | sort > "${COV_T}/a.names"
+printf 'shared-pg-harbor\nshared-pg-keycloak\n' | sort > "${COV_T}/b.names"
+[ "$(coverage_verdict "${COV_T}" a b)" = "COVERED" ] \
+  || { echo "SELF-TEST FAIL: two regions with identical coverage not COVERED" >&2; exit 2; }
+
+# THE REQUIRED NEGATIVE — two regions, the secret in only one. MUST go red.
+printf 'shared-pg-harbor\n' | sort > "${COV_T}/b.names"
+[ "$(coverage_verdict "${COV_T}" a b)" = "SPLIT" ] \
+  || { echo "SELF-TEST FAIL: a two-region deployment with a ONE-region secret was not SPLIT — this is the #6016 shape and the whole point of this phase" >&2; exit 2; }
+grep -q '^b shared-pg-keycloak$' "${COV_T}/missing" \
+  || { echo "SELF-TEST FAIL: SPLIT did not NAME the missing region/secret pair" >&2; exit 2; }
+
+# The hw293 shape specifically: the peer region holds NOTHING at all. The old
+# per-region loop reported this as clean.
+: > "${COV_T}/b.names"
+[ "$(coverage_verdict "${COV_T}" a b)" = "SPLIT" ] \
+  || { echo "SELF-TEST FAIL: a region holding ZERO secrets alongside a populated peer was not SPLIT — that is exactly the state the per-region loop called OK on hw293" >&2; exit 2; }
+
+# And the trap itself: ONE region can never manufacture a COVERED pass.
+[ "$(coverage_verdict "${COV_T}" a)" = "NO-PEER" ] \
+  || { echo "SELF-TEST FAIL: a single-region fixture produced a coverage verdict — one region must be inert, never 'clean'" >&2; exit 2; }
+echo "OK — coverage self-test passed (COVERED / SPLIT / NO-PEER distinguished; the one-region fixture cannot pass as covered)."
+
 if [ "${SELF_TEST_ONLY}" -eq 1 ]; then
   echo "OK: --self-test only; no cluster was contacted."
   exit 0
@@ -155,6 +233,67 @@ for ctx in "${CONTEXTS[@]}"; do
     esac
   done <<< "${consumers}"
 done
+
+# ─── Phase 2 — cross-region COVERAGE sweep (#6016) ───────────────────────
+#
+# Phase 1 asked each region about ITSELF. This asks the regions about EACH
+# OTHER, which is the only way a per-region split is visible. Runs even when a
+# region has no consumers at all — that is the case Phase 1 skips past, and the
+# case that wedged hw293.
+echo ""
+echo "== cross-region coverage =="
+
+COV_LIVE="$(mktemp -d)"
+trap 'rm -rf "${COV_T}" "${COV_LIVE}"' EXIT
+
+cov_regions=()
+cov_readable=1
+for ctx in "${CONTEXTS[@]}"; do
+  safe="$(printf '%s' "${ctx}" | tr -c 'A-Za-z0-9_.-' '_')"
+  # The tracked set = what bp-postgres renders primary-side and the cross-mesh
+  # sync is meant to carry onward: the per-owner role Secrets (basic-auth,
+  # MINUS `-superuser`, which CNPG mints locally per cluster and is legitimately
+  # region-local) plus the consumer hub Secrets. The CNPG-generated TLS material
+  # (`-replication` / `-ca` / `-server`) is likewise region-local and excluded.
+  if ! timeout 30 kubectl --context "${ctx}" -n "${MINT_NS}" get secret \
+        -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.type}{"\n"}{end}' \
+        2>/dev/null > "${COV_LIVE}/${safe}.raw"; then
+    echo "  WARN: could not read ${MINT_NS} secrets in ${ctx} — coverage NOT evaluated (reporting nothing rather than a false split)" >&2
+    cov_readable=0
+    break
+  fi
+  awk '$2=="kubernetes.io/basic-auth" && $1 !~ /-superuser$/ { print $1; next }
+       $1 ~ /-database-secret/ || $1 ~ /-database-env/       { print $1 }' \
+    "${COV_LIVE}/${safe}.raw" | sort -u > "${COV_LIVE}/${safe}.names"
+  printf '  %-28s holds %s tracked Secret(s)\n' "${ctx}" "$(wc -l < "${COV_LIVE}/${safe}.names")"
+  cov_regions+=("${safe}")
+done
+
+if [ "${cov_readable}" -eq 1 ]; then
+  cov_verdict="$(coverage_verdict "${COV_LIVE}" "${cov_regions[@]}")"
+  case "${cov_verdict}" in
+    NO-PEER)
+      echo "  skip  single region — a per-region split is not expressible with one context." ;;
+    COVERED)
+      echo "  OK    every tracked Secret is present in EVERY region." ;;
+    SPLIT)
+      EXIT=1
+      echo "  FAIL  per-region SPLIT — a Secret exists in one region and not another:" >&2
+      while IFS=' ' read -r r n; do
+        [ -z "${n}" ] && continue
+        printf '        MISSING in %-24s %s\n' "${r}" "${n}" >&2
+      done < "${COV_LIVE}/missing"
+      echo "" >&2
+      echo "        A consumer scheduled in the region that lacks the Secret cannot" >&2
+      echo "        start: CNPG projects the role Secret into its initdb Job with" >&2
+      echo "        optional:false (CreateContainerConfigError), and every workload" >&2
+      echo "        gated behind that instance stalls with it. On hw293 this" >&2
+      echo "        surfaced four hops downstream as keycloak-0 Init:0/1 and 8" >&2
+      echo "        non-Ready HelmReleases, which is why it took three walkers to" >&2
+      echo "        trace. Fix the PRODUCER (the primary-side render + the" >&2
+      echo "        cross-mesh hub-secret sync) — do NOT hand-copy the Secret." >&2 ;;
+  esac
+fi
 
 echo ""
 if [ "${EXIT}" -ne 0 ]; then


### PR DESCRIPTION
## Producer state: merged AND deployed AND still failing

Not a missing fix, not an unmerged one, not an undelivered one.

- `be5674530` (#5507, the commit that added `bootstrap.initdb.secret`) — `git merge-base --is-ancestor be5674530 origin/main` returns 0. It shipped as chart 0.2.15.
- Source HEAD is bp-postgres **0.2.18**. hw293 region-B's three `bp-postgres-shared*` HelmReleases report `lastAttemptedRevision` **0.2.18**. Deployed == source.
- The live Cluster in region B carries the reference: `spec.bootstrap.initdb.secret.name = shared-pg-harbor`, `managed.roles[] = harbor|gitea|keycloak -> shared-pg-{harbor,gitea,keycloak}`.

## Root cause

`role-secrets.yaml` is the **only** producer of `bp-postgres.roleSecretName`, gated `not isReplicaSide` since #5228/#5224 (deliberate — it prevents the hw273 divergent-password class). `cluster.yaml`'s `bootstrap.initdb.secret.name` resolves to the same helper and carried **no such gate**. Both templates are individually correct; jointly they are a dangling reference.

The window is reachable because `renderReplicaHalf` is `activeHotStandby AND side=replica`. Before the crossRegion flip the secondary still renders the singleton placeholder Cluster (#4460) with `side` already stamped `secondary` from cloud-init. CNPG projects the named Secret into the initdb Job as `APP_USERNAME <- secretKeyRef{key: username}` with `optional: false` — the container cannot be configured.

`managed.roles[].passwordSecret` dangles too, but that is a controller-level reconcile that reports pending, and `role-secrets.yaml` documents it as the deliberate trade. Only `initdb.secret` is pod-fatal, so only it is gated here.

### Measured on hw293 (dep `a0077ba47e3720e5`, region `me-east-215-b`), read-only

```
shared-pg-1-initdb-mdfjj     0/1  CreateContainerConfigError  139m
shared-pg-b-1-initdb-lkpqx   0/1  CreateContainerConfigError  139m
shared-pg-c-1-initdb-5fmkw   0/1  CreateContainerConfigError  139m
APP_USERNAME: <set to the key 'username' in secret 'shared-pg-harbor'> Optional: false
```

`shared-data` holds 36 Secrets in region A and 14 in region B. The 22-Secret difference is the entire primary-side-rendered set — 9 role-password Secrets and 13 consumer hub Secrets — not `shared-pg-harbor` alone. The 8 non-Ready HelmReleases (`bp-keycloak` plus 7 behind it) reconcile with 65-8=57.

## Scope note: this PR fixes one of two independent gaps

The second is **not** fixed here and is not a chart defect. Region A is still singleton (`instances: 1`, no `openova.io/cnpg-role` label), so its hub Secrets carry the region-local `-rw` host, not `-mesh-rw`. `syncSharedPGConsumerHubSecrets` has an explicit readiness gate on that marker and is therefore **correctly deferring** all 13 names. #5224 removed region-B's local mint from the first render onward, but the compensating cross-mesh delivery only unblocks at the crossRegion flip — leaving a coverage gap between first render and flip in which region B has neither its own mint nor a synced copy. That is a catalyst-api seam and a separate change.

This PR removes the chart-level self-contradiction and makes both gaps fail loudly instead of four hops downstream.

## The guard problem underneath

Two guards existed over this exact seam. Both passed.

**`postgres-render.sh` Case 4g** pins the *mint* half — "the pre-flip secondary renders ZERO Secrets" — and passes. It never inspects references, so it could not go red on a dangling one. Case 4b covers `side=secondary` only with `activeHotStandby=true`, which skips this template entirely. The untested combination was `side=secondary AND activeHotStandby=false`.

**New Case 4h** parses the rendered stream structurally rather than grepping tokens: names DEFINED as Secrets vs names REFERENCED from a pod-fatal position.

**`check-per-region-role-secrets.sh`** looped contexts independently, asking only whether a region's consumers were backed by its own mints. A region that mints nothing and consumes nothing answers that perfectly. Run against the real hw293 region-B it printed:

```
  (no *-database-secret consumers found — nothing to check here)
OK: every consumed role credential is backed by a minted one in the same region (#5499).
EXIT=0
```

on a region with zero role Secrets, zero hub Secrets, three wedged initdb Pods and 8 non-Ready HelmReleases. A per-region check that never compares regions cannot see a per-region split.

**New Phase 2** asserts cross-region coverage instead of assuming it.

## How the new assertions were shown to fail

Neither was written after the fix and assumed to work.

**Case 4h**, run against the pristine `origin/main` `cluster.yaml` with the new test in place:

```
[render] Case 4g: #5224 pre-flip SECONDARY ... → ZERO Secrets (no divergent mint)
[render] Case 4h: #6016 pre-flip SECONDARY → no pod-fatal reference to an unrendered role Secret
  DANGLING bootstrap.initdb.secret: shared-pg -> shared-pg-harbor
FAIL: #6016: pre-flip SECONDARY references 1 role Secret(s) it never renders ...
EXIT=1
```

Case 4g passes on the line immediately above the failure — direct evidence the old guard could not catch this. With the fix, all 31 cases green.

The trap this class hides behind is a check that reports 0 dangling because the extractor is blind. The pre-flip **primary** runs the same extractor with the opposite expectation — `>= 1` reference and 0 dangling (#5507 must still hold there) — so a degenerate report fails the control instead of silently satisfying the secondary assertion. A vacuity check also fails the case if the fixture ever stops rendering a Cluster.

**Phase 2**, against the live pair, exits **1** and names all 22:

```
  hw293-a   holds 22 tracked Secret(s)
  hw293-b   holds 0 tracked Secret(s)
  FAIL  per-region SPLIT — a Secret exists in one region and not another:
        MISSING in hw293-b   shared-pg-harbor
        MISSING in hw293-b   keycloak-database-secret
        ... (22 total)
```

Its decision function is self-tested before any cluster is contacted, negative first, including the trap named in the brief: **a one-region fixture returns `NO-PEER`, a token deliberately distinct from `COVERED`**, so a single region can never manufacture a clean pass; two regions with a one-region secret must return `SPLIT`; and a region holding *nothing* beside a populated peer must also return `SPLIT` — the hw293 state the old loop called OK.

A methodology note worth recording: the first attempt to run the guard across both regions merged the two kubeconfigs, whose cluster and user entries are both named `default`. The flatten silently collapsed them and both contexts resolved to region A's apiserver `212.72.24.43`, producing an identical, entirely false report for region B. Caught by checking `.clusters[].server` and a per-context secret count (36 vs 14) before trusting any verdict. Every live figure quoted here is from the corrected kubeconfig.

## Delivery

**No chart version bump.** `platform/postgres/chart/Chart.yaml` is untouched, as are the catalog seed and `clusters/_template/bootstrap-kit/*`. This fix therefore does **not** reach a cluster until bp-postgres is released; two peers are currently contending for chart versions, so that release is reported rather than taken here. `check-chart-version-forward` and `chart-version-claim` both trigger only on `Chart.yaml` paths, so neither is affected by this PR.

Everything against live clusters was read-only. The missing Secret was **not** hand-created on hw293 — that is the state this class produces, not a repair.

## UAT wording correction (flagged, not edited)

There is **no `UnknownHostException` and no JGroups fault** in this chain. The pod never reaches host resolution — it fails at container config, before any process starts. A UAT clause currently wording this as a DNS symptom should be corrected to name the missing role Secret, since as written it routes the next reader to the wrong layer. Not edited here per instruction.

Refs #6016 #5511
