### PR TITLE
fix(catalyst-api): a Sovereign must not report placement from a cache narrower than it declares

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -70,9 +70,33 @@ import (
 // `derivedFromRuntime: true` there falsely asserts the empty list was
 // runtime-observed, when the branch is taken precisely because it was not —
 // the exact fabrication UAT row 55 leans on this flag to rule out.
+//
+// #6015 — `true` additionally requires that the runtime we consulted COVERS
+// the deployment. A cache holding fewer of this deployment's region clusters
+// than the deployment DECLARES cannot answer "where does this component run":
+// every region it is blind to reads as absent, and the collapse is invisible
+// because the same fan-out that lost the region also decides what "observed"
+// means. Measured on hw293 (dep a0077ba47e3720e5): the chroot's k8scache held
+// only its self-registered region-a cluster because its secondary kubeconfig
+// was never delivered, and `bp-alloy` — 6 pods in region A and 6 in region B,
+// counted on each region's own apiserver — came back as ONE region-A Primary
+// under `derivedFromRuntime: true`. RegionsDeclared / RegionsObserved carry the
+// shortfall to the FE so it can keep its spec/status fallback instead of
+// rendering a fabricated singleton.
 type runtimePlacementResponse struct {
 	Targets            []bpv1.PlacementTarget `json:"targets"`
 	DerivedFromRuntime bool                   `json:"derivedFromRuntime"`
+
+	// RegionsDeclared — how many regions this Sovereign was provisioned with
+	// (deployment record's Regions[], else the chart-baked
+	// CATALYST_CONFIGURED_REGIONS the chroot always carries). 0 = unknown.
+	RegionsDeclared int `json:"regionsDeclared,omitempty"`
+	// RegionsObserved — how many of THIS deployment's region clusters the fan
+	// out actually listed successfully.
+	RegionsObserved int `json:"regionsObserved,omitempty"`
+	// UnobservedClusters — this deployment's registered cluster ids whose List
+	// failed (unregistered in the cache, or apiserver unreachable).
+	UnobservedClusters []string `json:"unobservedClusters,omitempty"`
 }
 
 // HandleApplicationPlacement — GET
@@ -109,7 +133,12 @@ func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Requ
 
 	clusterRegion := h.clusterRegionMap(urlID)
 
-	targets := h.derivePlacementTargets(name, ns, primaryID, clusterRegion)
+	// #6015 — who this deployment IS, and how many regions it declares. Both
+	// are needed to tell an honest "the component runs in one region" from a
+	// "the cache can only see one region" that looks identical downstream.
+	depID, fqdn, declaredRegions := h.placementDeploymentIdentity(urlID)
+
+	targets, cov := h.derivePlacementTargets(name, ns, primaryID, clusterRegion, depID, fqdn)
 
 	// #4551 — Standby discovery for cross-region CNPG-backed components.
 	//
@@ -131,7 +160,112 @@ func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Requ
 	// pair exists, the runtime targets are returned unchanged.
 	targets = h.augmentWithCNPGStandby(r, urlID, name, ns, targets)
 
-	writeJSON(w, http.StatusOK, runtimePlacementResponse{Targets: targets, DerivedFromRuntime: true})
+	// #6015 — the coverage gate. `derivedFromRuntime` may only claim a genuine
+	// runtime observation when (a) at least one of this deployment's clusters
+	// was actually listed, AND (b) the clusters we listed are not fewer than
+	// the regions the deployment declares. Both halves are load-bearing:
+	//
+	//   (a) closes the #5568 sibling the k8sCache==nil check cannot see — an
+	//       UNREGISTERED cluster id. derivePlacementTargets swallows that
+	//       List error with `continue`, so the mother could answer
+	//       `derivedFromRuntime: true` while its own cache said the cluster is
+	//       not registered (exactly what QuarantineDeployment leaves behind).
+	//   (b) closes the false-singleton: declared 2, observed 1.
+	//
+	// declaredRegions == 0 means we genuinely cannot tell (no record, no
+	// chart-baked env), so (b) is skipped rather than inventing a failure —
+	// the surface-not-gate discipline. It never DOWNGRADES a full observation.
+	derived := len(cov.observed) > 0 && (declaredRegions == 0 || len(cov.observed) >= declaredRegions)
+	if !derived {
+		h.log.Error("placement: runtime coverage is NARROWER than the deployment declares — refusing to assert derivedFromRuntime, every unobserved region would read as absent and collapse this component to a false singleton (#6015)",
+			"id", urlID,
+			"deploymentID", depID,
+			"component", name,
+			"regionsDeclared", declaredRegions,
+			"regionsObserved", len(cov.observed),
+			"observedClusters", strings.Join(cov.observed, ","),
+			"unobservedClusters", strings.Join(cov.unobserved, ","),
+		)
+	}
+
+	writeJSON(w, http.StatusOK, runtimePlacementResponse{
+		Targets:            targets,
+		DerivedFromRuntime: derived,
+		RegionsDeclared:    declaredRegions,
+		RegionsObserved:    len(cov.observed),
+		UnobservedClusters: cov.unobserved,
+	})
+}
+
+// placementRuntimeCoverage records which of THIS deployment's region clusters
+// the placement fan-out could actually read (#6015). `observed` are the ones
+// whose Pod List succeeded; `unobserved` are the ones registered for this
+// deployment whose List failed — unregistered id, quarantined reflectors, or an
+// unreachable apiserver. Clusters belonging to OTHER deployments (the mother's
+// cache holds every managed Sovereign, #3987) are counted in neither: they say
+// nothing about this deployment's coverage.
+type placementRuntimeCoverage struct {
+	observed   []string
+	unobserved []string
+}
+
+// clusterOwnedByDeployment reports whether a k8scache cluster id belongs to the
+// deployment being asked about. The id shapes are the ones the registration
+// paths mint: the deployment id itself (mother-side primary + the chroot's
+// CATALYST_SELF_DEPLOYMENT_ID self-registration), `<depID>-<regionKey>` for a
+// secondary posted to /api/v1/sovereign/secondary-kubeconfig, and
+// `sovereign-<fqdn>` for the FQDN-derived chroot fallback.
+func clusterOwnedByDeployment(cid, primaryID, depID, fqdn string) bool {
+	if cid == "" {
+		return false
+	}
+	if cid == primaryID {
+		return true
+	}
+	if depID != "" && (cid == depID || strings.HasPrefix(cid, depID+"-")) {
+		return true
+	}
+	if fqdn != "" && cid == "sovereign-"+fqdn {
+		return true
+	}
+	return false
+}
+
+// placementDeploymentIdentity resolves the deployment behind a placement URL id
+// and how many regions it DECLARES (#6015).
+//
+// The declared count is the MAX of the record's own region list and the
+// chart-baked CATALYST_CONFIGURED_REGIONS, never just the record's. On a chroot
+// whose mother-side record was never imported — the hw293 state, where handover
+// never fired — chrootEnsureDeployment synthesizes a record that can carry a
+// single region; taking that as "declared" would hand the coverage gate a
+// denominator derived from the same blindness it is meant to detect, i.e. a
+// guard that cannot fail. The `sovereign-fqdn` ConfigMap key `configuredRegions`
+// is written by the IaC at provision time and is independent of both the
+// k8scache and the deployment store — verified live on hw293:
+// `configuredRegions=hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod` while
+// the cache held one cluster.
+func (h *Handler) placementDeploymentIdentity(urlID string) (depID, fqdn string, declaredRegions int) {
+	envRegions := len(regionsFromEnv())
+	var dep *Deployment
+	if val, ok := h.deployments.Load(urlID); ok {
+		dep = val.(*Deployment)
+	} else {
+		dep = h.chrootEnsureDeployment(urlID)
+	}
+	if dep == nil {
+		return "", "", envRegions
+	}
+	dep.mu.Lock()
+	depID = dep.ID
+	fqdn = strings.TrimSpace(dep.Request.SovereignFQDN)
+	recRegions := len(configuredRegionsForDeployment(dep))
+	dep.mu.Unlock()
+	declaredRegions = recRegions
+	if envRegions > declaredRegions {
+		declaredRegions = envRegions
+	}
+	return depID, fqdn, declaredRegions
 }
 
 // augmentWithCNPGStandby appends a Standby·Hot target for the region-b
@@ -402,7 +536,13 @@ type placementOccupancy struct {
 // cluster, list its Pods + Namespaces + Nodes, keep the Pods that belong to
 // `name`, and collapse them into one PlacementTarget per (region × cluster
 // × vcluster) the component actually occupies, with an HONEST role.
-func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegion map[string]string) []bpv1.PlacementTarget {
+// #6015: it additionally REPORTS which of this deployment's clusters it could
+// read. The `continue` on a List error below is still the right rendering
+// behaviour (show N-1 regions rather than nothing), but silently degrading the
+// DATA while the caller keeps asserting `derivedFromRuntime: true` is what
+// turned a blind cache into a fabricated singleton. The coverage report is how
+// the caller can tell the two apart.
+func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegion map[string]string, depID, fqdn string) ([]bpv1.PlacementTarget, placementRuntimeCoverage) {
 	// Fan out across primary + every secondary region cluster.
 	clusterIDs := []string{primaryID}
 	seen := map[string]struct{}{primaryID: {}}
@@ -414,15 +554,25 @@ func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegi
 		clusterIDs = append(clusterIDs, cid)
 	}
 
+	cov := placementRuntimeCoverage{}
 	// key = region|cluster|vcluster → occupancy.
 	occ := map[string]*placementOccupancy{}
 	for _, cid := range clusterIDs {
+		owned := clusterOwnedByDeployment(cid, primaryID, depID, fqdn)
 		pods, _, err := h.k8sCache.List(cid, "pod", labels.Everything())
 		if err != nil {
 			// A secondary that can't be listed degrades silently — render
 			// N-1 regions rather than nothing. The primary's pods are the
 			// floor; a missing primary just yields no targets (honest).
+			// #6015 — but RECORD it, so the caller cannot claim the resulting
+			// target list is a complete runtime observation.
+			if owned {
+				cov.unobserved = append(cov.unobserved, cid)
+			}
 			continue
+		}
+		if owned {
+			cov.observed = append(cov.observed, cid)
 		}
 		nsList, _, _ := h.k8sCache.List(cid, "namespace", labels.Everything())
 		nodes, _, _ := h.k8sCache.List(cid, "node", labels.Everything())
@@ -454,7 +604,7 @@ func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegi
 	}
 
 	if len(occ) == 0 {
-		return []bpv1.PlacementTarget{}
+		return []bpv1.PlacementTarget{}, cov
 	}
 
 	// Collapse occupancies → targets with honest roles.
@@ -513,7 +663,7 @@ func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegi
 		}
 		return a.VCluster < b.VCluster
 	})
-	return targets
+	return targets, cov
 }
 
 // componentNameCandidates returns the identity strings a Pod may carry for

--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
@@ -13,6 +13,7 @@
 package handler
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"net/http"
@@ -464,6 +465,21 @@ func containsStr(xs []string, s string) bool {
 // zero-touch even when the handover-window export missed. No file-wait here:
 // we forward only what is already on disk and let the next pass pick up any
 // region whose kubeconfig lands later.
+// secondaryKubeconfigForwardClient builds the HTTP client the level-triggered
+// re-forward POSTs through. A package var so a test can drive the REAL
+// reforwardSecondaryKubeconfigsToChild / runSecondaryKubeconfigDelivery against
+// an httptest server. A test that re-implements the production loop locally
+// cannot fail on a defect in the production loop — this seam is what lets the
+// #6015 assertions bind to the shipped code path.
+var secondaryKubeconfigForwardClient = func() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // chroot cert may rotate; same rationale as exportDeploymentToChild
+		},
+	}
+}
+
 func (h *Handler) reforwardSecondaryKubeconfigsToChild(dep *Deployment) {
 	if dep == nil {
 		return
@@ -484,12 +500,7 @@ func (h *Handler) reforwardSecondaryKubeconfigsToChild(dep *Deployment) {
 		return
 	}
 	url := "https://api." + fqdn + "/api/v1/sovereign/secondary-kubeconfig"
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // chroot cert may rotate; same rationale as exportDeploymentToChild
-		},
-	}
+	client := secondaryKubeconfigForwardClient()
 	for _, regionKey := range keys {
 		path := filepath.Join(dir, depID+"-"+regionKey+".yaml")
 		raw, err := os.ReadFile(path)
@@ -509,5 +520,113 @@ func (h *Handler) reforwardSecondaryKubeconfigsToChild(dep *Deployment) {
 		}
 		body, _ := json.Marshal(payload)
 		h.postSecondaryKubeconfigWithRetry(client, url, body, depID, regionKey)
+	}
+}
+
+// secondaryKubeconfigDeliveryIntervalDefault — cadence of the #6015
+// level-triggered delivery loop. Matches clusterMeshSteadyStateIntervalDefault
+// so the two level-triggered reconcilers converge on the same rhythm.
+const secondaryKubeconfigDeliveryIntervalDefault = 5 * time.Minute
+
+// secondaryKubeconfigDeliveryStopped reports whether a deployment status means
+// the Sovereign is GONE (or going) and there is nothing left to deliver to.
+// Every other status — including "failed" — keeps the loop running: a failed
+// Phase-1 outcome describes a HelmRelease census, NOT the reachability of the
+// regions' apiservers, and the chroot still needs its peer's kubeconfig to see
+// region B at all.
+func secondaryKubeconfigDeliveryStopped(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "wiping", "wiped", "aborted":
+		return true
+	}
+	return false
+}
+
+// runSecondaryKubeconfigDelivery is the level-triggered home of the durable
+// secondary-kubeconfig delivery (#6015). It re-forwards every on-disk secondary
+// kubeconfig to the chroot on an interval for as long as the Sovereign exists.
+//
+// 🛑 Why this is NOT inside runClusterMeshSteadyStateHeal any more —
+// the hw293 (dep a0077ba47e3720e5) root cause, measured live:
+//
+//	reforwardSecondaryKubeconfigsToChild had exactly ONE caller,
+//	runClusterMeshSteadyStateHeal, which runAutoEstablishClusterMesh reaches
+//	ONLY after `err == nil && meshConverged && cnpgPairConverged`, and which
+//	markPhase1Done spawns ONLY under `outcome == OutcomeReady && finalStatus
+//	== "ready"`. The one-shot exportSecondaryKubeconfigsToChild sits behind
+//	the same fireHandover gate. So BOTH producers of the chroot's
+//	`/var/lib/catalyst/kubeconfigs` were gated on the deployment reaching
+//	status=ready.
+//
+//	On hw293 exactly ONE HelmRelease out of 65 failed in the primary region:
+//	`self-sovereign-cutover` — the chart that installs DORMANT at
+//	bootstrap-kit slot 06a and is operator-gated by design. That flipped
+//	Phase-1 to `finalStatus=failed`, which (a) skipped fireHandover, (b)
+//	skipped runAutoEstablishClusterMesh, and (c) quarantined both of the
+//	deployment's clusters out of the mother's own k8scache. The chroot's
+//	kubeconfigs dir therefore stayed EMPTY FOREVER while region B's apiserver
+//	was healthy the whole time — the Sovereign simply held no credential for
+//	it. Downstream: the placement resolver fanned out over the single
+//	self-registered region-a cluster and reported a false `singleton` with
+//	`derivedFromRuntime: true`, and orgConsoleTLSPoolRegions read an empty
+//	pool so the #5246 "unreached" list stayed empty and the per-Org listener
+//	guard could not fail.
+//
+// Delivery is a DATA-PLANE concern. Coupling it to a HelmRelease census, to
+// ClusterMesh convergence, or to the CNPG-pair flip means any one of those
+// unrelated conditions can permanently blind the Sovereign to its own peer
+// region. This loop owns delivery on its own terms and stops only when the
+// Sovereign is being torn down.
+//
+// Idempotent + self-deduplicating: the chroot handler overwrites the file and
+// AddCluster on a duplicate ID is a no-op, and secondaryKubeconfigDeliveryActive
+// makes a second concurrent trigger a cheap no-op. Each pass forwards only what
+// is already on the mother's disk (no file-wait) — a region whose kubeconfig
+// lands later is picked up by the next pass.
+func (h *Handler) runSecondaryKubeconfigDelivery(dep *Deployment) {
+	if dep == nil {
+		return
+	}
+	dep.mu.Lock()
+	depID := strings.TrimSpace(dep.ID)
+	fqdn := strings.TrimSpace(dep.Request.SovereignFQDN)
+	regionCount := len(dep.Request.Regions)
+	dep.mu.Unlock()
+	// A single-region Sovereign has no peer kubeconfig to deliver, and without
+	// an FQDN there is no chroot endpoint to POST to.
+	if depID == "" || fqdn == "" || regionCount < 2 {
+		return
+	}
+	if _, loaded := h.secondaryKubeconfigDeliveryActive.LoadOrStore(depID, struct{}{}); loaded {
+		return
+	}
+	defer h.secondaryKubeconfigDeliveryActive.Delete(depID)
+
+	interval := h.secondaryKubeconfigDeliveryInterval
+	if interval <= 0 {
+		interval = secondaryKubeconfigDeliveryIntervalDefault
+	}
+	h.log.Info("secondary-kubeconfig-delivery: level-triggered loop started — delivery is independent of the Phase-1 outcome, ClusterMesh convergence and the cnpg-pair flip (#6015)",
+		"id", depID,
+		"fqdn", fqdn,
+		"declaredRegions", regionCount,
+		"interval", interval.String(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for {
+		dep.mu.Lock()
+		status := dep.Status
+		dep.mu.Unlock()
+		if secondaryKubeconfigDeliveryStopped(status) {
+			h.log.Info("secondary-kubeconfig-delivery: loop stopped — the Sovereign is being torn down",
+				"id", depID, "status", status)
+			return
+		}
+		h.reforwardSecondaryKubeconfigsToChild(dep)
+		if err := sleepCtx(ctx, interval); err != nil {
+			return
+		}
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -679,6 +679,14 @@ func (h *Handler) restoreFromStore() {
 			meshRetries++
 			go h.retryStartupClusterMeshReconcile(dep)
 		}
+		// #6015 — secondary-kubeconfig delivery resumes on EVERY restore of a
+		// multi-region deployment, independent of the three mesh branches
+		// above. Those branches all decline a deployment whose Phase-1
+		// concluded `failed`, which is precisely the hw293 state that left the
+		// chroot's kubeconfigs dir empty forever. The loop self-guards on
+		// region count, FQDN and a torn-down status, and de-duplicates against
+		// the markPhase1Done trigger.
+		go h.runSecondaryKubeconfigDelivery(dep)
 		// #3319 (founder, 2026-06-12) — converged-late handover. MUST be
 		// an INDEPENDENT hook, not the else-arm above: #3317 made the
 		// mesh branch accept failed+TIMEOUT records too, so as an

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -66,6 +66,21 @@ type Handler struct {
 	// runs. map[string]struct{}.
 	clusterMeshLoopActive sync.Map
 
+	// secondaryKubeconfigDeliveryActive guards against double-starting the
+	// #6015 secondary-kubeconfig delivery loop for the same deployment.
+	// runSecondaryKubeconfigDelivery LoadOrStores the dep ID on entry and
+	// Deletes it on return, exactly like clusterMeshLoopActive above, so the
+	// Phase-1 terminate trigger and the startup-restore trigger cannot run two
+	// competing loops against the same chroot. map[string]struct{}.
+	secondaryKubeconfigDeliveryActive sync.Map
+
+	// secondaryKubeconfigDeliveryInterval (#6015) — cadence of the
+	// level-triggered secondary-kubeconfig delivery loop. Zero falls back to
+	// secondaryKubeconfigDeliveryIntervalDefault. Tests inject a sub-second
+	// value so a pass is observable in milliseconds; production leaves it at
+	// zero.
+	secondaryKubeconfigDeliveryInterval time.Duration
+
 	// orphanReleaseWG tracks the releaseOrphanedReservation goroutines that
 	// restoreFromStore fires (#489). Those goroutines outlive the call that
 	// spawned them: after pdm.Release returns they clear the dep's PDM

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
@@ -590,6 +590,47 @@ func (h *Handler) provisionOrgConsoleTLS(ctx context.Context, rec store.Organiza
 			"unreached_pool_regions", strings.Join(unreachedPoolRegions, ","),
 		)
 	}
+	// #6015 — a pool SHORTER than the declared region set is a FAILURE, not a
+	// satisfied precondition.
+	//
+	// The #5246 accounting above can only report regions the pool NAMED. Both
+	// the pool and the target list are derived from the same on-disk
+	// `<depID>-<regionKey>.yaml` set, so when a region is missing from that set
+	// it is missing from the pool, missing from `unreached`, and missing from
+	// the read-back loop below — which then emits `listener pair admitted in
+	// every region` over the regions we chose to write. The guard's own scope
+	// was decided by the step that lost the region, so it cannot fail on this
+	// defect.
+	//
+	// 🛑 The comparison is `declared > written`, NOT `pool is empty`. Measured
+	// on hw293 (dep a0077ba47e3720e5) the chroot's kubeconfigs dir is NOT
+	// empty — it holds exactly one file, `a0077ba47e3720e5.yaml`, the REGION-A
+	// config; only the `-me-east-215-b-1.yaml` secondary is absent. A presence
+	// check would find the directory populated and pass while region A's
+	// console Gateway declared 10 listeners against region B's 6 and per-Org
+	// hosts TLS-reset ~6 of 12 fresh connections. It must also fire on a
+	// short-but-non-empty pool (3 declared, 1 delivered).
+	//
+	// CATALYST_CONFIGURED_REGIONS is the independent declaration: written into
+	// the `sovereign-fqdn` ConfigMap by the IaC at provision time, it does not
+	// come from the kubeconfig set or from h.k8sCache, so it can contradict
+	// them. `targets` always carries the host region, so this compares the
+	// declaration against host + every pool region we could actually write.
+	// Chroot-only — on the mother isChroot() is false and per-Org listeners are
+	// never fanned out here at all.
+	if isChroot() {
+		if declared := len(regionsFromEnv()); declared > len(targets) {
+			admitted = false
+			h.log.Error("org-console-tls: this Sovereign DECLARES more regions than carry a per-Org console listener — the undelivered region(s) hold no `console-https-<slug>` listener, so every customer connection the shared console EIP round-robins onto them resets at the TLS handshake (#6015)",
+				"org_tenant_id", rec.OrganizationID,
+				"console_host", names.ConsoleHost,
+				"regions_declared", declared,
+				"regions_written", len(targets),
+				"regions", strings.Join(regions, ","),
+				"remedy", "the mother must deliver `<depID>-<regionKey>.yaml` to this Sovereign's CATALYST_K8SCACHE_KUBECONFIGS_DIR (POST /api/v1/sovereign/secondary-kubeconfig)",
+			)
+		}
+	}
 	for _, tgt := range targets {
 		if err := waitOrgConsoleListenersAdmitted(ctx, tgt.dyn, names, admitDeadline); err != nil {
 			admitted = false

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1458,6 +1458,23 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		h.k8sCache.QuarantineDeployment(dep.ID)
 	}
 
+	// #6015 — start the durable secondary-kubeconfig delivery loop for EVERY
+	// multi-region deployment, whatever Phase-1 concluded. This deliberately
+	// sits OUTSIDE the `finalStatus == "ready"` branch below.
+	//
+	// Before this line, both producers of the chroot's
+	// `/var/lib/catalyst/kubeconfigs` hung off that branch: the one-shot export
+	// inside fireHandover, and the level-triggered re-forward buried in
+	// runClusterMeshSteadyStateHeal (itself only reachable after full mesh +
+	// cnpg-pair convergence). On hw293 a single failed HelmRelease — the
+	// DORMANT-by-design `self-sovereign-cutover` chart — latched
+	// finalStatus=failed, so neither producer ever ran and the Sovereign never
+	// received region B's kubeconfig even though region B's apiserver was
+	// healthy throughout. A HelmRelease census is not a statement about
+	// apiserver reachability, and it must not decide whether a Sovereign is
+	// allowed to see its own peer region.
+	h.spawnPostHandoverHook(func() { h.runSecondaryKubeconfigDelivery(dep) })
+
 	// Issues #764 + #768 — auto-fire the handover JWT mint immediately
 	// after Phase-1 reaches OutcomeReady. Until this landed, the
 	// operator was stranded on the wizard's provision page after a

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
@@ -1,0 +1,614 @@
+// secondary_kubeconfig_coverage_6015_test.go — #6015.
+//
+// Three defects, one shape: a Sovereign whose catalyst-api holds FEWER region
+// kubeconfigs than the deployment declares answers exactly like a correct
+// single-region one, and every guard downstream is scoped by the same step that
+// lost the region.
+//
+// Measured live on hw293 (dep a0077ba47e3720e5, 2026-08-10):
+//
+//   - Phase-1 terminated `finalStatus=failed` on ONE HelmRelease out of 65 —
+//     `self-sovereign-cutover`, the chart that installs DORMANT at slot 06a.
+//     That gate skipped fireHandover AND runAutoEstablishClusterMesh, and both
+//     producers of the chroot's kubeconfigs dir hang off those two.
+//   - 🛑 The dir is NOT empty. It holds exactly ONE file,
+//     `a0077ba47e3720e5.yaml` — the REGION-A config. Only the
+//     `-me-east-215-b-1.yaml` secondary is missing, and region B's apiserver
+//     answered 6 nodes to a direct query throughout: a missing CREDENTIAL, not
+//     a reachability problem. Every assertion here is therefore about COVERAGE
+//     (the kubeconfig/cluster set vs the DECLARED region set), never about
+//     presence — a `dir is non-empty` / `pool == 0` check reads the region-A
+//     file, passes, and leaves the defect live.
+//   - `…/applications/bp-alloy/placement` returned ONE region-A Primary under
+//     `derivedFromRuntime: true` while alloy ran 6 pods in A and 6 in B;
+//     `cilium` (14/14) returned `targets: []` under the same flag.
+//   - `orgConsoleTLSPoolRegions` excludes the primary by design, so that
+//     one-file dir yields a SHORT pool → empty `unreached` → `listener pair
+//     admitted in every region` over regions="host".
+//
+// Every assertion below is written to be RED against the pre-#6015 code:
+//   - Coverage_*: pre-fix HandleApplicationPlacement hardcoded `true`.
+//   - ShortRegionPool_*: pre-fix a short pool produced no `unreached` entries,
+//     so the success line was emitted.
+//   - Delivery_*: pre-fix reforwardSecondaryKubeconfigsToChild had exactly one
+//     caller, gated behind mesh+cnpg convergence behind status=ready.
+//
+// Each negative case is paired with a CONTROL that shares its fixture shape and
+// must stay GREEN, so a red negative proves the defect and not the harness.
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// ---------------------------------------------------------------------------
+// Guard A — derivedFromRuntime must not be assertable from a narrow cache.
+// ---------------------------------------------------------------------------
+
+// THE NEGATIVE CASE, built first. A deployment that DECLARES two regions whose
+// cache holds only region A must NOT claim its answer was runtime-derived: the
+// one target it can see is indistinguishable from an honest singleton, and the
+// FE has no other signal to fall back on.
+//
+// This is the exact hw293 `bp-alloy` shape — 6 pods in each region, one region
+// visible.
+func TestPlacementCoverage_TwoDeclaredOneCached_NotDerived_6015(t *testing.T) {
+	depID := "a0077ba47e3720e5"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+
+	h := newSingleClusterPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{
+			placementFixturePod("alloy", "alloy-aaa", "alloy", regionA, ""),
+		})
+
+	resp := callPlacement(t, h, depID, "bp-alloy")
+
+	if resp.DerivedFromRuntime {
+		t.Fatalf("#6015: derivedFromRuntime must be FALSE when the cache covers %d of %d declared regions — "+
+			"the lone region-A target reads identically to an honest singleton (targets=%+v)",
+			resp.RegionsObserved, resp.RegionsDeclared, resp.Targets)
+	}
+	if resp.RegionsDeclared != 2 {
+		t.Fatalf("#6015: regionsDeclared = %d, want 2 (the deployment record declares two regions)", resp.RegionsDeclared)
+	}
+	if resp.RegionsObserved != 1 {
+		t.Fatalf("#6015: regionsObserved = %d, want 1 (only the region-A cluster is registered)", resp.RegionsObserved)
+	}
+}
+
+// THE CONTROL for the test above — the SAME component, the SAME two-region
+// deployment, but with BOTH region clusters in the cache. It must stay GREEN.
+//
+// Without this control the negative case is worthless: a coverage check that
+// returns false for every fixture passes the negative test while breaking the
+// product. This pins that the gate fires on the SHORTFALL, not on the fixture.
+func TestPlacementCoverage_TwoDeclaredTwoCached_Derived_6015(t *testing.T) {
+	depID := "a0077ba47e3720e5"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{placementFixturePod("alloy", "alloy-aaa", "alloy", regionA, "")},
+		[]*unstructured.Unstructured{placementFixturePod("alloy", "alloy-bbb", "alloy", regionB, "")},
+	)
+
+	resp := callPlacement(t, h, depID, "bp-alloy")
+
+	if !resp.DerivedFromRuntime {
+		t.Fatalf("control: derivedFromRuntime must stay TRUE on full coverage (declared=%d observed=%d unobserved=%v)",
+			resp.RegionsDeclared, resp.RegionsObserved, resp.UnobservedClusters)
+	}
+	if len(resp.Targets) != 2 {
+		t.Fatalf("control: got %d targets want 2 — alloy runs in BOTH regions (%+v)", len(resp.Targets), resp.Targets)
+	}
+	if resp.RegionsObserved != 2 || resp.RegionsDeclared != 2 {
+		t.Fatalf("control: declared/observed = %d/%d, want 2/2", resp.RegionsDeclared, resp.RegionsObserved)
+	}
+}
+
+// The #5568 sibling the `k8sCache == nil` check structurally cannot see: the
+// cache is PRESENT but the deployment's cluster is NOT REGISTERED in it. The
+// List error is swallowed by `continue`, so pre-#6015 the handler answered
+// `derivedFromRuntime: true` while its own cache said the cluster is unknown —
+// exactly what QuarantineDeployment leaves behind on the mother (hw293:
+// "deployment quarantined (terminal failure) … clustersRemoved: 2").
+func TestPlacementCoverage_UnregisteredCluster_NotDerived_6015(t *testing.T) {
+	depID := "a0077ba47e3720e5"
+
+	// A live cache that holds SOMEBODY ELSE's clusters, so h.k8sCache != nil
+	// and the #5568 early return does not fire, but nothing of this deployment.
+	h := newPlacementHandler(t, "some-other-dep", "eu-central-1", "eu-west-1",
+		[]*unstructured.Unstructured{placementFixturePod("apps", "x-aaa", "x", "eu-central-1", "")},
+		[]*unstructured.Unstructured{},
+	)
+	h.deployments.Store(depID, &Deployment{
+		ID: depID,
+		Request: provisioner.Request{
+			SovereignFQDN: "hw293.omantel.biz",
+			Regions: []provisioner.RegionSpec{
+				{CloudRegion: "me-east-215-a"},
+				{CloudRegion: "me-east-215-b"},
+			},
+		},
+	})
+
+	resp := callPlacement(t, h, depID, "bp-alloy")
+
+	if resp.DerivedFromRuntime {
+		t.Fatalf("#6015/#5568: derivedFromRuntime must be FALSE when NONE of the deployment's clusters could be listed "+
+			"(observed=%d unobserved=%v) — the empty answer is a cache miss, not a runtime observation",
+			resp.RegionsObserved, resp.UnobservedClusters)
+	}
+	if resp.RegionsObserved != 0 {
+		t.Fatalf("#6015: regionsObserved = %d, want 0 — no cluster of this deployment is registered", resp.RegionsObserved)
+	}
+}
+
+// A genuinely SINGLE-region Sovereign must keep claiming a runtime derivation:
+// declared 1, observed 1 is full coverage. Without this the fix would trade a
+// false `true` for a false `false` on every single-region prov.
+func TestPlacementCoverage_SingleRegionDeployment_StillDerived_6015(t *testing.T) {
+	depID := "dep-single-region"
+	regionA := "me-east-215-a"
+
+	h := newSingleClusterPlacementHandler(t, depID, regionA, "",
+		[]*unstructured.Unstructured{placementFixturePod("apps", "solo-xyz", "solo", regionA, "")})
+
+	resp := callPlacement(t, h, depID, "solo")
+
+	if !resp.DerivedFromRuntime {
+		t.Fatalf("single-region: derivedFromRuntime must stay TRUE (declared=%d observed=%d) — 1 of 1 is FULL coverage",
+			resp.RegionsDeclared, resp.RegionsObserved)
+	}
+	if len(resp.Targets) != 1 {
+		t.Fatalf("single-region: got %d targets want 1 (%+v)", len(resp.Targets), resp.Targets)
+	}
+}
+
+// THE DENOMINATOR. hw293's Sovereign never received the mother's record —
+// handover never fired — so on the chroot the record is whatever
+// chrootEnsureDeployment could synthesize, and that can carry ONE region while
+// the Sovereign was provisioned with two. Taking the record as "declared" hands
+// the coverage gate a denominator produced by the same blindness it exists to
+// detect: declared 1, observed 1, gate satisfied, false singleton preserved.
+//
+// The declared count must therefore be the MAX of the record and the chart-
+// baked CATALYST_CONFIGURED_REGIONS — an INDEPENDENT declaration the IaC writes
+// into the `sovereign-fqdn` ConfigMap at provision time, verified live on hw293
+// as `hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod` while the cache held
+// ONE cluster and the record knew nothing.
+//
+// Falsifiable two ways: it is RED if the denominator comes from the record
+// alone, AND red if the coverage comparison is dropped.
+func TestPlacementCoverage_DeclaredCountIgnoresAnUndercountingRecord_6015(t *testing.T) {
+	depID := "a0077ba47e3720e5"
+	regionA := "me-east-215-a"
+
+	t.Setenv("SOVEREIGN_FQDN", "hw293.omantel.biz")
+	t.Setenv("CATALYST_CONFIGURED_REGIONS", "hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod")
+
+	// regionB == "" → the stored record declares exactly ONE region, the
+	// undercount a chroot-synthesized record produces.
+	h := newSingleClusterPlacementHandler(t, depID, regionA, "",
+		[]*unstructured.Unstructured{placementFixturePod("alloy", "alloy-aaa", "alloy", regionA, "")})
+
+	// Premise check: the record really does undercount. Without this the test
+	// could pass for the wrong reason.
+	val, _ := h.deployments.Load(depID)
+	if got := len(val.(*Deployment).Request.Regions); got != 1 {
+		t.Fatalf("test premise broken: record declares %d regions, want 1", got)
+	}
+
+	resp := callPlacement(t, h, depID, "bp-alloy")
+
+	if resp.RegionsDeclared != 2 {
+		t.Fatalf("#6015: regionsDeclared = %d, want 2 from CATALYST_CONFIGURED_REGIONS — "+
+			"a denominator taken from the undercounting record makes this gate unable to fail", resp.RegionsDeclared)
+	}
+	if resp.DerivedFromRuntime {
+		t.Fatalf("#6015: derivedFromRuntime must be FALSE — the chart declares 2 regions, the cache covers 1")
+	}
+}
+
+// newSingleClusterPlacementHandler mirrors newPlacementHandler but registers
+// ONLY the primary region's cluster while the deployment record still declares
+// two regions when regionB is non-empty. This is the hw293 cache shape.
+func newSingleClusterPlacementHandler(t *testing.T, depID, regionA, regionB string, podsA []*unstructured.Unstructured) *Handler {
+	t.Helper()
+
+	r := k8scache.NewRegistry()
+	_ = r.Add(k8scache.Kind{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true})
+	_ = r.Add(k8scache.Kind{Name: "namespace", GVR: schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}, Namespaced: false})
+	_ = r.Add(k8scache.Kind{Name: "node", GVR: schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, Namespaced: false})
+
+	dynA, coreA := dashFixtureClients(toRuntimeObjs(podsA)...)
+
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger:   quietHandlerLogger(),
+		Registry: r,
+		Clusters: []k8scache.ClusterRef{{ID: depID, DynamicClient: dynA, CoreClient: coreA}},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(f.Stop)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _, _ := f.List(depID, "pod", labels.Everything())
+		if len(got) >= len(podsA) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	h := NewWithPDM(quietHandlerLogger(), &fakePDM{})
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+
+	regions := []provisioner.RegionSpec{{CloudRegion: regionA}}
+	if regionB != "" {
+		regions = append(regions, provisioner.RegionSpec{CloudRegion: regionB})
+	}
+	h.deployments.Store(depID, &Deployment{
+		ID:      depID,
+		Request: provisioner.Request{SovereignFQDN: "hw293.omantel.biz", Regions: regions},
+	})
+	return h
+}
+
+// ---------------------------------------------------------------------------
+// Guard B — an EMPTY region pool is a FAILURE, not a satisfied precondition.
+// ---------------------------------------------------------------------------
+
+// The #5246 `unreached` accounting can only report regions the POOL named, and
+// the pool is derived from the same on-disk `<depID>-<regionKey>.yaml` set the
+// targets are. When that set is SHORT the pool is short, `unreached` is empty,
+// and the emitter logs "listener pair admitted in every region" over a target
+// list that never contained the missing region — a guard whose scope is decided
+// by the step that lost the region cannot fail on this defect.
+//
+// 🛑 The gate must be `declared > written`, NOT `pool == 0`. Measured on hw293,
+// the Sovereign's kubeconfigs dir is NOT empty: it holds exactly one file,
+// `a0077ba47e3720e5.yaml` — the REGION-A config. The secondary is what is
+// missing. `seedELBPoolKubeconfigs` reproduces that faithfully (it always
+// writes `<depID>.yaml`), and `onDiskSecondaryKubeconfigKeys` excludes the
+// primary, so a NON-EMPTY directory still yields a pool that is short. A
+// presence check would read the file, find the directory populated, and pass
+// while the defect is live. The `pool spans 3, one delivered` case below pins
+// that the gate fires on a short-but-NON-EMPTY pool too.
+//
+// The DECLARED region count comes from CATALYST_CONFIGURED_REGIONS, written
+// into the `sovereign-fqdn` ConfigMap by the IaC at provision time. It does not
+// read the kubeconfig set or h.k8sCache, so it can contradict them — which is
+// the only reason the shortfall is detectable at all.
+//
+// Drives the REAL provisionOrgConsoleTLS. Each control changes exactly one
+// variable, so a missing success line in a negative case can only be caused by
+// the undelivered region.
+func TestProvisionOrgConsoleTLS_ShortRegionPoolIsNotReady_6015(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		configuredRegion string
+		delivered        []string
+		wantSuccessLine  bool
+	}{
+		{
+			name:             "control: the chart declares ONE region, the host target covers it",
+			configuredRegion: "hw-me-east-215-a-rtz-prod",
+			wantSuccessLine:  true,
+		},
+		{
+			name:             "control: two declared, the secondary IS delivered — full coverage",
+			configuredRegion: "hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod",
+			delivered:        []string{"me-east-215-b-1"},
+			wantSuccessLine:  true,
+		},
+		{
+			name:             "hw293: two declared, dir holds ONLY the region-A primary, secondary never delivered",
+			configuredRegion: "hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod",
+			wantSuccessLine:  false,
+		},
+		{
+			name:             "short but NON-EMPTY pool: three declared, one secondary delivered",
+			configuredRegion: "hw-a-rtz-prod,hw-b-rtz-prod,hw-c-rtz-prod",
+			delivered:        []string{"me-east-215-b-1"},
+			wantSuccessLine:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SOVEREIGN_FQDN", "hw293.omantel.biz")
+			t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "dep292")
+			t.Setenv("CATALYST_CONFIGURED_REGIONS", tc.configuredRegion)
+			// Always writes `dep292.yaml` (the region-A primary), plus any
+			// delivered secondaries — the real on-disk shape, never an empty dir.
+			seedELBPoolKubeconfigs(t, "dep292", tc.delivered...)
+
+			// Every region in the target list ADMITS the pair, so the #5511
+			// read-back is satisfied throughout and cannot be the reason a
+			// success line goes missing. The ONLY variable across the cases is
+			// how many regions the chart declares vs how many were delivered.
+			hostDyn := fakeDynForConsoleTLSWithApexPorts(t, 8443, 8080)
+			admitPerOrgListenersOnGet(hostDyn, "console-https-uatco", "console-http-uatco")
+			hostCore := k8sfake.NewSimpleClientset(issuedOrgWildcardSecret("org-wildcard-tls-uatco-omani-homes"))
+
+			stubs := map[string]struct {
+				dyn  dynamic.Interface
+				core kubernetes.Interface
+			}{}
+			for _, region := range tc.delivered {
+				regionDyn := fakeDynForConsoleTLSWithApexPorts(t, 8443, 8080)
+				admitPerOrgListenersOnGet(regionDyn, "console-https-uatco", "console-http-uatco")
+				stubs["dep292-"+region+".yaml"] = struct {
+					dyn  dynamic.Interface
+					core kubernetes.Interface
+				}{dyn: regionDyn, core: k8sfake.NewSimpleClientset()}
+			}
+			stubPoolRegionClients(t, stubs)
+
+			h, logs := newPoolRegionHandler(t, "dep292", hostDyn, hostCore)
+			h.provisionOrgConsoleTLS(context.Background(), uatcoRecord())
+
+			out := logs.String()
+			gotSuccess := strings.Contains(out, "listener pair admitted in every region")
+			if gotSuccess != tc.wantSuccessLine {
+				t.Fatalf("#6015: success line present = %t, want %t — a pool SHORTER than the declared region set is an "+
+					"undelivered kubeconfig, not a satisfied precondition (a `pool == 0` check would pass here: the "+
+					"kubeconfigs dir holds the region-A primary); logs:\n%s",
+					gotSuccess, tc.wantSuccessLine, out)
+			}
+			if !tc.wantSuccessLine && !strings.Contains(out, "DECLARES more regions") {
+				t.Fatalf("#6015: the shortfall is not named anywhere an operator can grep for it; logs:\n%s", out)
+			}
+		})
+	}
+}
+
+// THE TRAP, pinned explicitly: on hw293 the kubeconfigs DIRECTORY is populated
+// (one file, the region-A primary) while the region POOL is empty, because
+// onDiskSecondaryKubeconfigKeys excludes the primary by design. Any guard
+// phrased over the directory — "the dir is non-empty", "a kubeconfig exists" —
+// reads the region-A file and passes while region B has no credential at all.
+// This is why the gate above compares against the DECLARED region set.
+func TestOrgConsoleTLSPool_PopulatedDirCanStillYieldAnEmptyPool_6015(t *testing.T) {
+	depID := "a0077ba47e3720e5"
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	// The hw293 dir, verified live: region-A primary present, secondary absent.
+	mustWrite(t, filepath.Join(dir, depID+".yaml"), "apiVersion: v1\nkind: Config\n")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("test premise broken: want exactly 1 file on disk, got %d (err=%v)", len(entries), err)
+	}
+	if pool := orgConsoleTLSPoolRegions(depID); len(pool) != 0 {
+		t.Fatalf("pool must be EMPTY with no SECONDARY kubeconfig on disk (the primary is excluded by design), got %v", pool)
+	}
+
+	// After delivery the same enumeration must surface the region.
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"), "apiVersion: v1\nkind: Config\n")
+	pool := orgConsoleTLSPoolRegions(depID)
+	if len(pool) != 1 {
+		t.Fatalf("pool must hold the delivered secondary region, got %v", pool)
+	}
+	if _, ok := pool["me-east-215-b-1"]; !ok {
+		t.Fatalf("pool key = %v, want me-east-215-b-1", pool)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The population seam — delivery must not be gated on the Phase-1 outcome.
+// ---------------------------------------------------------------------------
+
+// THE NEGATIVE CASE. A deployment whose Phase-1 concluded `failed` still has a
+// live secondary region whose kubeconfig sits on the mother's disk. Pre-#6015
+// nothing ever forwarded it: exportSecondaryKubeconfigsToChild is inside
+// fireHandover (`finalStatus == "ready"`), and the only caller of
+// reforwardSecondaryKubeconfigsToChild was runClusterMeshSteadyStateHeal, which
+// runAutoEstablishClusterMesh reaches only after full mesh + cnpg-pair
+// convergence — itself spawned only on the same ready branch.
+//
+// A failed HelmRelease census says NOTHING about whether region B's apiserver
+// answers. On hw293 the single failure was `self-sovereign-cutover`, a chart
+// that is DORMANT by design.
+func TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015(t *testing.T) {
+	depID := "a0077ba47e3720e5"
+	fqdn := "hw293.omantel.biz"
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	chroot := &fakeChrootServer{}
+	srv := httptest.NewServer(chroot.handler())
+	defer srv.Close()
+	withChrootForwardClient(t, srv)
+
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"),
+		"apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://212.72.24.6:6443\n  name: c\n")
+
+	h := newExportTestHandler(t)
+	h.secondaryKubeconfigDeliveryInterval = 5 * time.Millisecond
+	dep := makeDep(depID, fqdn, []string{"me-east-215-a", "me-east-215-b"})
+
+	// The hw293 state: Phase-1 concluded failed on one dormant chart.
+	dep.mu.Lock()
+	dep.Status = "failed"
+	dep.mu.Unlock()
+
+	go h.runSecondaryKubeconfigDelivery(dep)
+	t.Cleanup(func() {
+		dep.mu.Lock()
+		dep.Status = "wiped" // ends the loop
+		dep.mu.Unlock()
+	})
+
+	if !waitForRegionPost(chroot, "me-east-215-b-1", 3*time.Second) {
+		t.Fatalf("#6015: the Sovereign never received region-b's kubeconfig for a status=failed deployment — "+
+			"delivery is still gated behind the Phase-1 outcome; regionsPosted=%v", chroot.regionsPosted())
+	}
+}
+
+// THE WIRING. The loop above is only worth anything if something STARTS it on
+// the path hw293 actually took: Phase-1 concluding FAILED. Pre-#6015 the only
+// spawn sites were inside `if outcome == OutcomeReady && finalStatus ==
+// "ready"`, so this drives the REAL markPhase1Done with a failed outcome and
+// asserts the Sovereign still gets its peer's kubeconfig.
+//
+// Without this test the hook could be deleted from phase1_watch.go and every
+// other #6015 assertion would stay green — a guard that cannot fail on the
+// delivered defect.
+//
+// CONTROL: the identical fixture with a SINGLE region must deliver NOTHING, so
+// a green negative cannot be produced by a loop that simply POSTs always.
+func TestMarkPhase1Done_FailedOutcomeStillStartsDelivery_6015(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		regions    []string
+		wantPosted bool
+	}{
+		{name: "control: single-region Sovereign has no peer to deliver to", regions: []string{"me-east-215-a"}, wantPosted: false},
+		{name: "hw293: two regions, Phase-1 concluded FAILED on one dormant chart", regions: []string{"me-east-215-a", "me-east-215-b"}, wantPosted: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			depID := "a0077ba47e3720e5"
+			dir := t.TempDir()
+			t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+			chroot := &fakeChrootServer{}
+			srv := httptest.NewServer(chroot.handler())
+			defer srv.Close()
+			withChrootForwardClient(t, srv)
+
+			// Region B's kubeconfig IS on the mother's disk — the hw293 state.
+			mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"),
+				"apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://212.72.24.6:6443\n  name: c\n")
+
+			h := NewWithPDM(silentLogger(), &fakePDM{})
+			h.secondaryKubeconfigDeliveryInterval = 5 * time.Millisecond
+			dep := makeDep(depID, "hw293.omantel.biz", tc.regions)
+			dep.mu.Lock()
+			dep.Status = "phase1-watching"
+			dep.Result = &provisioner.Result{SovereignFQDN: "hw293.omantel.biz"}
+			dep.mu.Unlock()
+			h.deployments.Store(depID, dep)
+
+			// The hw293 census: 64 of 65 installed, `self-sovereign-cutover`
+			// (dormant at slot 06a by design) failed → OutcomeFailed.
+			h.markPhase1Done(dep, map[string]string{
+				"cilium":                 helmwatch.StateInstalled,
+				"catalyst-platform":      helmwatch.StateInstalled,
+				"self-sovereign-cutover": helmwatch.StateFailed,
+			}, helmwatch.OutcomeFailed)
+
+			dep.mu.Lock()
+			status := dep.Status
+			dep.mu.Unlock()
+			if status != "failed" {
+				t.Fatalf("precondition: markPhase1Done did not latch Status=failed (got %q) — the test would not exercise the gate it targets", status)
+			}
+			t.Cleanup(func() {
+				dep.mu.Lock()
+				dep.Status = "wiped"
+				dep.mu.Unlock()
+			})
+
+			got := waitForRegionPost(chroot, "me-east-215-b-1", 3*time.Second)
+			if got != tc.wantPosted {
+				t.Fatalf("#6015: region-b kubeconfig delivered = %t, want %t — a failed HelmRelease census must not decide "+
+					"whether a Sovereign may see its own peer region; regionsPosted=%v", got, tc.wantPosted, chroot.regionsPosted())
+			}
+		})
+	}
+}
+
+// CONTROL: the loop must STOP once the Sovereign is being torn down, or a wiped
+// deployment would keep POSTing at a dead endpoint forever. Also pins that
+// `failed` is NOT a stop reason — the whole point of the fix.
+func TestSecondaryKubeconfigDelivery_StopsOnlyOnTeardown_6015(t *testing.T) {
+	for _, st := range []string{"wiping", "wiped", "aborted"} {
+		if !secondaryKubeconfigDeliveryStopped(st) {
+			t.Errorf("#6015: status %q must STOP the delivery loop", st)
+		}
+	}
+	for _, st := range []string{"failed", "ready", "provisioning", "phase1-watching", ""} {
+		if secondaryKubeconfigDeliveryStopped(st) {
+			t.Errorf("#6015: status %q must NOT stop the delivery loop — it says nothing about apiserver reachability", st)
+		}
+	}
+}
+
+// CONTROL: a SINGLE-region deployment has no peer kubeconfig to deliver, so the
+// loop must decline rather than spin. Pins that the new loop is not a fire-hose.
+func TestSecondaryKubeconfigDelivery_DeclinesSingleRegion_6015(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	chroot := &fakeChrootServer{}
+	srv := httptest.NewServer(chroot.handler())
+	defer srv.Close()
+	withChrootForwardClient(t, srv)
+
+	depID := "dep-single"
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"), "apiVersion: v1\nkind: Config\n")
+
+	h := newExportTestHandler(t)
+	h.secondaryKubeconfigDeliveryInterval = 5 * time.Millisecond
+	dep := makeDep(depID, "t99.omani.works", []string{"me-east-215-a"})
+
+	done := make(chan struct{})
+	go func() { h.runSecondaryKubeconfigDelivery(dep); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("#6015: the delivery loop must RETURN immediately for a single-region deployment, not spin")
+	}
+	if n := len(chroot.regionsPosted()); n != 0 {
+		t.Fatalf("#6015: single-region deployment posted %d kubeconfig(s), want 0", n)
+	}
+}
+
+// withChrootForwardClient routes the production forward client at the httptest
+// server for the duration of the test, so the assertions bind to the REAL
+// reforwardSecondaryKubeconfigsToChild rather than to a local re-implementation
+// of it (a test that re-implements the production loop cannot fail on a defect
+// in the production loop).
+func withChrootForwardClient(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	prev := secondaryKubeconfigForwardClient
+	secondaryKubeconfigForwardClient = func() *http.Client {
+		return &http.Client{Timeout: 5 * time.Second, Transport: newRoundTripperToServer(srv)}
+	}
+	t.Cleanup(func() { secondaryKubeconfigForwardClient = prev })
+}
+
+func waitForRegionPost(chroot *fakeChrootServer, region string, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		for _, r := range chroot.regionsPosted() {
+			if r == region {
+				return true
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
Refs #6015 #5930 #5568

## The measurement, corrected

hw293 (dep `a0077ba47e3720e5`) holds **one** kubeconfig in its catalyst-api's `CATALYST_K8SCACHE_KUBECONFIGS_DIR` — `a0077ba47e3720e5.yaml`, the **region-A** config. The directory is **not empty**; the `-me-east-215-b-1.yaml` secondary is what is absent, and region B's apiserver answers 6 nodes to a direct query. A missing **credential**, not reachability.

That distinction drives every assertion here: a check phrased as "the directory is non-empty" or "the pool is empty" reads the region-A file, finds it, and **passes while the defect is live**. All three gates below compare **coverage against the declared region set**.

## The population seam: merged, deployed, and still failing

Both producers are in the running image and neither can run:

| producer | gate |
|---|---|
| `exportSecondaryKubeconfigsToChild` | inside `fireHandover`, reached only under `outcome == OutcomeReady && finalStatus == "ready"` |
| `reforwardSecondaryKubeconfigsToChild` (the durable one) | one caller, `runClusterMeshSteadyStateHeal`, reached only after `err == nil && meshConverged && cnpgPairConverged` — spawned from the same ready branch |

hw293's Phase-1 latched `failed` on **one HelmRelease out of 65**: `self-sovereign-cutover`, the chart that installs **dormant** at bootstrap-kit slot 06a and is operator-gated by design.

```
"phase 1 watch terminated" finalStatus=failed failedCount=1
  regions="me-east-215-a=64/65(primary) me-east-215-b-1=57/65(DEGRADED)"
"k8scache: deployment quarantined (terminal failure)" clustersRemoved=2
POST /api/v1/deployments/a0077ba47e3720e5/mint-handover-token -> 409
```

`componentStates` on the mother's own record: 67 entries, exactly one not `installed` — `self-sovereign-cutover: failed`.

So handover never fired, the mesh loop never spawned, both clusters were quarantined out of the mother's cache, and the Sovereign never received a credential for a healthy region. **A HelmRelease census is not a statement about apiserver reachability, and it must not decide whether a Sovereign may see its own peer region.**

Delivery moves to `runSecondaryKubeconfigDelivery` — level-triggered, spawned from the Phase-1 terminate path for every multi-region deployment **whatever Phase-1 concluded**, re-armed on startup restore, stopping only on `wiping`/`wiped`/`aborted`.

## The two gates that could not fail

**Placement** returned `derivedFromRuntime: true` from a one-cluster fan-out. It now requires the clusters actually listed to be no fewer than the regions declared, and at least one listed at all — which also closes the **#5568 sibling** the `k8sCache == nil` check structurally cannot see: an *unregistered* cluster whose `List` error is swallowed by `continue`, exactly what `QuarantineDeployment` leaves behind.

The denominator is `max(record, CATALYST_CONFIGURED_REGIONS)`. A chroot-synthesized record can undercount, and a denominator drawn from the same blindness makes the gate unable to fail. The chart-baked value is independent of both the kubeconfig set and the cache — verified live on hw293: `configuredRegions=hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod` while the cache held one cluster.

**`provisionOrgConsoleTLS`** logged `listener pair admitted in every region` with `regions="host"`. #5930's `unreached` list can only name regions the **pool** named, and pool and targets both derive from the same on-disk set — so a region missing there is missing from `unreached` and from the read-back too. It now compares declared against written. `declared > written`, **not** `pool == 0`: the gate must also fire on a short-but-non-empty pool (3 declared, 1 delivered), which is a covered case.

## Falsifiability

Every assertion shown RED under a mutation restoring the pre-fix behaviour, each paired with a control on the same fixture that stayed GREEN:

| mutation | result |
|---|---|
| `derived := true` | 3 coverage negatives RED, 2 controls GREEN |
| denominator from the record alone | undercounting-record test RED, 4 others GREEN |
| drop the declared-vs-written check | 2 pool negatives RED, 2 controls GREEN |
| presence-shaped (`pool == 0`) check | both pool negatives RED, 2 controls GREEN |
| `failed` added to the stop set | delivery-on-failed RED, single-region control GREEN |
| hook removed from phase1 terminate | wiring test RED, single-region control GREEN |

`secondaryKubeconfigForwardClient` is a package var so the delivery tests drive the **shipped** reforward path through an httptest server rather than re-implementing the loop — a test that re-implements the production loop cannot fail on a defect in it.

`go build ./...`, `go vet ./internal/handler/`, and the full `internal/handler` suite (272s) are green on this branch.

## Not in this change

- No chart version bump; no catalog seed or bootstrap-kit edits.
- No live-cluster writes — diagnosis was read-only (`kubectl logs`/`get`/`exec cat` against the mother, `kubectl get` against hw293 region A).
- The `self-sovereign-cutover` HelmRelease failure itself is a separate defect. This change stops it from blinding the Sovereign to region B; it does not fix why the dormant chart's HR reports failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
